### PR TITLE
Parse -.x**2. (unary -.) as -.(x**2.).  Fix PR#3414

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -479,7 +479,7 @@ rule token = parse
   | ['+' '-'] symbolchar *
             { INFIXOP2(Lexing.lexeme lexbuf) }
   | "**" symbolchar *
-            { INFIXOP4(Lexing.lexeme lexbuf) }
+            { EXPONENTIATION(Lexing.lexeme lexbuf) }
   | '%'     { PERCENT }
   | ['*' '/' '%'] symbolchar *
             { INFIXOP3(Lexing.lexeme lexbuf) }


### PR DESCRIPTION
This is what is expected mathematically.  Note that -2.**2. is parsed
as (-2.)**2. because -2. is considered to be a constant.  However
-.2.**2.  is parsed as -.(2.**2.).
