### PR TITLE
Fix a typo in close_functions.

### DIFF
--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -783,7 +783,7 @@ and close_functions fenv cenv fun_defs =
       build_closure_env env_param (fv_pos - env_pos) fv in
     let cenv_body =
       List.fold_right2
-        (fun (id, params, arity, body) pos env ->
+        (fun (id, params, body, fundesc) pos env ->
           Tbl.add id (Uoffset(Uvar env_param, pos - env_pos)) env)
         uncurried_defs clos_offsets cenv_fv in
     let (ubody, approx) = close fenv_rec cenv_body body in


### PR DESCRIPTION
The change fixes what is pretty obviously a typo in `close_functions`: the `uncurried_functions`  list is a list of `(id, params, body, fundesc)` tuples, rather than a list of `(id, params, arity, body)` tuples, as can be seen from the form that creates it as well as from several places it's used.

The typo isn't a bug since the variables `arity` and `body` are never actually referenced in the body of the function, but it does (negatively) affect readability. 
