### PR TITLE
Warn user when a type variable in a type constraint has been instantiated.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,6 +473,10 @@ beforedepend:: utils/config.ml
 parsing/parser.mli parsing/parser.ml: parsing/parser.mly
 	$(CAMLYACC) $(YACCFLAGS) parsing/parser.mly
 
+parsing/parser.cmo: COMPFLAGS:=-w -50..51 ${COMPFLAGS}
+parsing/parser.p.cmo: COMPFLAGS:=-w -50..51 ${COMPFLAGS}
+parsing/parser.cmx: COMPFLAGS:=-w -50..51 ${COMPFLAGS}
+
 partialclean::
 	rm -f parsing/parser.mli parsing/parser.ml parsing/parser.output
 

--- a/debugger/Makefile.shared
+++ b/debugger/Makefile.shared
@@ -113,6 +113,9 @@ beforedepend:: lexer.ml
 
 parser.ml parser.mli: parser.mly
 	$(CAMLYACC) parser.mly
+parser.cmo: COMPFLAGS:=-w -50..51 ${COMPFLAGS}
+parser.p.cmo: COMPFLAGS:=-w -50..51 ${COMPFLAGS}
+parser.cmx: COMPFLAGS:=-w -50..51 ${COMPFLAGS}
 clean::
 	rm -f parser.ml parser.mli
 beforedepend:: parser.ml parser.mli

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -39,6 +39,9 @@ clean::
 parser.ml parser.mli: parser.mly
 	$(CAMLYACC) $(YACCFLAGS) parser.mly
 
+parser.cmo: COMPFLAGS:=-w -50..51 ${COMPFLAGS}
+parser.cmx: COMPFLAGS:=-w -50..51 ${COMPFLAGS}
+
 clean::
 	rm -f parser.ml parser.mli parser.output
 

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -193,8 +193,14 @@ dot: $(EXECMOFILES)
 odoc_text_parser.ml: odoc_text_parser.mly
 odoc_text_parser.mli: odoc_text_parser.mly
 
+odoc_text_parser.cmo: COMPFLAGS:=-w -50..51 ${COMPFLAGS}
+odoc_text_parser.cmx: COMPFLAGS:=-w -50..51 ${COMPFLAGS}
+
 odoc_parser.ml:	odoc_parser.mly
 odoc_parser.mli:odoc_parser.mly
+
+odoc_parser.cmo: COMPFLAGS:=-w -50..51 ${COMPFLAGS}
+odoc_parser.cmx: COMPFLAGS:=-w -50..51 ${COMPFLAGS}
 
 odoc_text_lexer.ml: odoc_text_lexer.mll
 

--- a/typing/typedtreeIter.ml
+++ b/typing/typedtreeIter.ml
@@ -91,6 +91,7 @@ module MakeIterator(Iter : IteratorArgument) : sig
     val iter_module_type : module_type -> unit
     val iter_pattern : pattern -> unit
     val iter_class_expr : class_expr -> unit
+    val iter_class_type : class_type -> unit
 
   end = struct
 
@@ -249,7 +250,7 @@ module MakeIterator(Iter : IteratorArgument) : sig
         exp.exp_extra;
       begin
         match exp.exp_desc with
-          Texp_ident (path, _, _) -> ()
+        | Texp_ident (path, _, _) -> ()
         | Texp_constant cst -> ()
         | Texp_let (rec_flag, list, exp) ->
             iter_bindings rec_flag list;

--- a/typing/typedtreeIter.mli
+++ b/typing/typedtreeIter.mli
@@ -87,6 +87,7 @@ module MakeIterator :
     val iter_module_type : module_type -> unit
     val iter_pattern : pattern -> unit
     val iter_class_expr : class_expr -> unit
-           end
+    val iter_class_type : class_type -> unit
+  end
 
 module DefaultIteratorArgument : IteratorArgument

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -67,6 +67,8 @@ type t =
   | Attribute_payload of string * string    (* 47 *)
   | Eliminated_optional_arguments of string list (* 48 *)
   | No_cmi_file of string                   (* 49 *)
+  | Unified_var of string * string          (* 50 *)
+  | Instantiated_var of string * string     (* 51 *)
 ;;
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
@@ -125,9 +127,11 @@ let number = function
   | Attribute_payload _ -> 47
   | Eliminated_optional_arguments _ -> 48
   | No_cmi_file _ -> 49
+  | Unified_var _ -> 50
+  | Instantiated_var _ -> 51
 ;;
 
-let last_warning_number = 49
+let last_warning_number = 51
 (* Must be the max number returned by the [number] function. *)
 
 let letter = function
@@ -373,6 +377,10 @@ let message = function
         (String.concat ", " sl)
   | No_cmi_file s ->
       "no cmi file was found in path for module " ^ s
+  | Unified_var (name, name') ->
+      Printf.sprintf "The explicit type variable '%s has been unified with another explicit type variable: '%s." name name'
+  | Instantiated_var (name, ty) ->
+      Printf.sprintf "The explicit type variable '%s has been instantied into:\n%s" name ty
 ;;
 
 let nerrors = ref 0;;
@@ -468,6 +476,8 @@ let descriptions =
    47, "Illegal attribute payload.";
    48, "Implicit elimination of optional arguments.";
    49, "Absent cmi file when looking up module alias.";
+   50, "Unified variable in type constraint";
+   51, "Instantiated variable in type constraint";
   ]
 ;;
 

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -62,6 +62,8 @@ type t =
   | Attribute_payload of string * string    (* 47 *)
   | Eliminated_optional_arguments of string list (* 48 *)
   | No_cmi_file of string                   (* 49 *)
+  | Unified_var of string * string          (* 50 *)
+  | Instantiated_var of string * string     (* 51 *)
 ;;
 
 val parse_options : bool -> string -> unit;;


### PR DESCRIPTION
It seems to be a common misunderstanding amongst beginners that type variables in type constraint are unification variables and that they should be explicitly quantified when desired.

This small patch adds a warning when such non-quantified variable has been instantiated by the type checker. The verification is made /a posteriori/ by looking for type constraints in the typed tree. 

I'm not sure this warning is really a desired feature, but it is probably worth discussion. For instance, ocamlyacc-generated files use such variables on purpose.
