### PR TITLE
FreeBSD 10 uses clang by default, with gcc not available by default

### DIFF
--- a/configure
+++ b/configure
@@ -924,6 +924,13 @@ case "$arch,$system" in
                     *gcc*) aspp="${TOOLPREF}gcc -c";;
                               *) aspp="${TOOLPREF}as -P";;
                   esac;;
+  *,freebsd)      if ./searchpath clang; then
+                    as="clang -c"
+                    aspp="clang -c"
+                  else
+                    as="${TOOLPREF}as"
+                    aspp="${TOOLPREF}gcc -c"
+                  fi ;;
   amd64,*|arm,*|arm64,*|i386,*|power,bsd*|sparc,*)
                   as="${TOOLPREF}as"
                   aspp="${TOOLPREF}gcc -c";;


### PR DESCRIPTION
This fixes the configure script to use clang by default if available
on FreeBSD.  It shouldnt affect previous versions, but may cause a
build failure if a buggy clang is installed from ports on something
earlier than FreeBSD 10.
