### PR TITLE
Add String.{cut,rcut}.

### DIFF
--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -113,6 +113,24 @@ val concat : string -> string list -> string
 (** [String.concat sep sl] concatenates the list of strings [sl],
    inserting the separator string [sep] between each. *)
 
+val cut : string -> string -> (string * string) option
+(** [String.cut sep s] is either the pair [Some (l,r)] of the two
+    (possibly empty) substrings of [s] that are delimited by the first
+    match of the non empty separator string [sep] or [None] if [sep]
+    can't be matched in [s]. Matching starts from the beginning of [s].
+
+    The invariant [l ^ sep ^ r = s] holds. 
+
+    @raise Invalid_argument if [sep] is the empty string. 
+    @since 4.01.1 *)
+
+val rcut : string -> string -> (string * string) option
+(** [String.rcut sep s] is like {!cut} but the matching is done backwards
+    starting from the end of [s].
+
+    @raise Invalid_argument if [sep] is the empty string. 
+    @since 4.01.1 *)
+
 val iter : (char -> unit) -> string -> unit
 (** [String.iter f s] applies function [f] in turn to all
    the characters of [s].  It is equivalent to

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -77,6 +77,24 @@ val concat : sep:string -> string list -> string
 (** [String.concat sep sl] concatenates the list of strings [sl],
    inserting the separator string [sep] between each. *)
 
+val cut : sep:string -> string -> (string * string) option
+(** [String.cut sep s] is either the pair [Some (l,r)] of the two
+    (possibly empty) substrings of [s] that are delimited by the first
+    match of the non empty separator string [sep] or [None] if [sep]
+    can't be matched in [s]. Matching starts from the beginning of [s].
+
+    The invariant [l ^ sep ^ r = s] holds. 
+
+    @raise Invalid_argument if [sep] is the empty string. 
+    @since 4.01.1 *)
+
+val rcut : sep:string -> string -> (string * string) option
+(** [String.rcut sep s] is like {!cut} but the matching is done backwards
+    starting from the end of [s].
+
+    @raise Invalid_argument if [sep] is the empty string. 
+    @since 4.01.1 *)
+
 val iter : f:(char -> unit) -> string -> unit
 (** [String.iter f s] applies function [f] in turn to all
    the characters of [s].  It is equivalent to


### PR DESCRIPTION
As a follow up to pull request https://github.com/ocaml/ocaml/pull/10. This pull request adds `String.{cut,rcut}` which cuts a string in two at a given non empty separator `sep` starting either from the beginning of the string or from the end. The signature for `StringLabels` is :

```
val cut : ~sep:string -> string -> (string * string) option
val rcut : ~sep:string -> string -> (string * string) option
```

These functions have the following invariants. First for any non empty `sep` and `s` such that `sep` is in `s` we have:

```
assert (String.{cut,rcut} sep s = Some (l,r))
assert (l ^ sep ^ r = s)
```

Then for any `s` such that `sep` doesn't occur in `s`: 

```
assert (String.{rcut,cut} sep s = None)
```

Here is the result of `String.{cut,rcut}` on a few edge cases.

```
  (* String.cut *) 
  assert (try ignore (String.cut "" ""); false with Invalid_argument _ -> true);
  assert (try ignore (String.cut "" "123"); false with Invalid_argument _ -> true);
  assert (String.cut "," "" = None);
  assert (String.cut "," "," = Some ("", ""));
  assert (String.cut "," ",," = Some ("", ","));
  assert (String.cut "," ",,," = Some ("", ",,"));
  assert (String.cut "," "123" = None); 
  assert (String.cut "," ",123" = Some ("", "123"));
  assert (String.cut "," "123," = Some ("123", "")); 
  assert (String.cut "," "1,2,3" = Some ("1", "2,3")); 
  assert (String.cut "," " 1,2,3" = Some (" 1", "2,3")); 
  assert (String.cut "<>" "" = None); 
  assert (String.cut "<>" "<>" = Some ("", ""));
  assert (String.cut "<>" "<><>" = Some ("", "<>"));
  assert (String.cut "<>" "<><><>" = Some ("", "<><>"));
  assert (String.rcut "<>" "1" = None);
  assert (String.cut "<>" "123" = None);
  assert (String.cut "<>" "<>123" = Some ("", "123"));
  assert (String.cut "<>" "123<>" = Some ("123", ""));
  assert (String.cut "<>" "1<>2<>3" = Some ("1", "2<>3"));
  assert (String.cut "<>" " 1<>2<>3" = Some (" 1", "2<>3"));
  assert (String.cut "<>" ">>><>>>><>>>><>>>>" = 
          Some (">>>", ">>><>>>><>>>>"));
  assert (String.cut "<->" "<->>->" = Some ("", ">->"));
  assert (String.rcut "<->" "<-" = None);
  assert (String.cut "aa" "aa" = Some ("", "")); 
  assert (String.cut "aa" "aaa" = Some ("", "a"));
  assert (String.cut "aa" "aaaa" = Some ("", "aa"));
  assert (String.cut "aa" "aaaaa" = Some ("", "aaa";));
  assert (String.cut "aa" "aaaaaa" = Some ("", "aaaa"));
  (* String.rcut *) 
  assert (try ignore (String.rcut "" ""); false with Invalid_argument _ -> true);
  assert (try ignore (String.rcut "" "123"); false with Invalid_argument _ -> true);
  assert (String.rcut "," "" = None);
  assert (String.rcut "," "," = Some ("", ""));
  assert (String.rcut "," ",," = Some (",", ""));
  assert (String.rcut "," ",,," = Some (",,", ""));
  assert (String.rcut "," "123" = None); 
  assert (String.rcut "," ",123" = Some ("", "123"));
  assert (String.rcut "," "123," = Some ("123", "")); 
  assert (String.rcut "," "1,2,3" = Some ("1,2", "3")); 
  assert (String.rcut "," "1,2,3 " = Some ("1,2", "3 ")); 
  assert (String.rcut "<>" "" = None); 
  assert (String.rcut "<>" "<>" = Some ("", ""));
  assert (String.rcut "<>" "<><>" = Some ("<>", ""));
  assert (String.rcut "<>" "<><><>" = Some ("<><>", ""));
  assert (String.rcut "<>" "1" = None);
  assert (String.rcut "<>" "123" = None);
  assert (String.rcut "<>" "<>123" = Some ("", "123"));
  assert (String.rcut "<>" "123<>" = Some ("123", ""));
  assert (String.rcut "<>" "1<>2<>3" = Some ("1<>2", "3"));
  assert (String.rcut "<>" "1<>2<>3 " = Some ("1<>2", "3 "));
  assert (String.rcut "<>" ">>><>>>><>>>><>>>>" = 
          Some (">>><>>>><>>>>", ">>>"));
  assert (String.rcut "<->" "<->>->" = Some ("", ">->"));
  assert (String.rcut "<->" "<-" = None);
  assert (String.rcut "aa" "aa" = Some ("", "")); 
  assert (String.rcut "aa" "aaa" = Some ("a", ""));
  assert (String.rcut "aa" "aaaa" = Some ("aa", ""));
  assert (String.rcut "aa" "aaaaa" = Some ("aaa", "";));
  assert (String.rcut "aa" "aaaaaa" = Some ("aaaa", ""));
```
