### PR TITLE
Cmm arithmetic optimisations

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -133,7 +133,7 @@ let rec mul_int c1 c2 =
   | (c, Cconst_int(-1)) | (Cconst_int(-1), c) ->
       sub_int (Cconst_int 0) c
   | (c, Cconst_int n) | (Cconst_int n, c) when n = 1 lsl Misc.log2 n->
-      Cop(Clsl, [c; Cconst_int(Misc.log2 n)])
+      lsl_int c (Cconst_int (Misc.log2 n))
   | (Cop(Caddi, [c; Cconst_int n]), Cconst_int k) |
     (Cconst_int k, Cop(Caddi, [c; Cconst_int n]))
     when no_overflow_mul n k ->
@@ -196,8 +196,8 @@ let untag_int = function
 
 let mul_int_tagged c1 c2 =
   match (c1, c2) with
-  | (Cconst_int n1, c2) -> mul_int (untag_int c1) (decr_int c2)
-  | (_, _) -> mul_int (decr_int c1) (untag_int c2)
+  | (Cconst_int n1, c2) -> incr_int (mul_int (untag_int c1) (decr_int c2))
+  | (_, _) -> incr_int (mul_int (decr_int c1) (untag_int c2))
 
 (* Turning integer divisions into multiply-high then shift.
    The [division_parameters] function is used in module Emit for
@@ -1594,7 +1594,7 @@ and transl_prim_2 p arg1 arg2 dbg =
   | Psubint ->
       incr_int(sub_int (transl arg1) (transl arg2))
   | Pmulint ->
-      incr_int(mul_int_tagged (transl arg1) (transl arg2))
+      mul_int_tagged (transl arg1) (transl arg2)
   | Pdivint ->
       tag_int(div_int (untag_int(transl arg1)) (untag_int(transl arg2)) dbg)
   | Pmodint ->

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -78,7 +78,7 @@ let int_const n =
 let rec add_const c n =
   if n = 0 then c
   else match c with
-    Cconst_int x when no_overflow_add x n -> Cconst_int (x + n)
+  | Cconst_int x when no_overflow_add x n -> Cconst_int (x + n)
   | Cop(Caddi, ([Cconst_int x; c] | [c; Cconst_int x])) when no_overflow_add n x ->
       let d = n + x in
       if d == 0 then c else Cop(Caddi, [c; Cconst_int d])
@@ -93,7 +93,7 @@ let decr_int c = add_const c (-1)
 
 let rec add_int c1 c2 =
   match (c1, c2) with
-    (Cconst_int n, c) | (c, Cconst_int n) ->
+  | (Cconst_int n, c) | (c, Cconst_int n) ->
       add_const c n
   | (Cop(Caddi, [c1; Cconst_int n1]), c2) -> 
       add_const (add_int c1 c2) n1
@@ -104,7 +104,7 @@ let rec add_int c1 c2 =
 
 let rec sub_int c1 c2 =
   match (c1, c2) with
-    (c1, Cconst_int n2) when n2 <> min_int ->
+  | (c1, Cconst_int n2) when n2 <> min_int ->
       add_const c1 (-n2)
   | (c1, Cop(Caddi, [c2; Cconst_int n2])) when n2 <> min_int ->
       add_const (sub_int c1 c2) (-n2)
@@ -115,7 +115,7 @@ let rec sub_int c1 c2 =
 
 let rec lsl_int c1 c2 =
   match (c1, c2) with
-    (Cop(Clsl, [c; Cconst_int n1]), Cconst_int n2)
+  | (Cop(Clsl, [c; Cconst_int n1]), Cconst_int n2)
     when n1 > 0 && n2 > 0 && n1 + n2 < size_int * 8 ->
       Cop(Clsl, [c; Cconst_int (n1 + n2)])
   | (Cop(Caddi, [c1; Cconst_int n1]), Cconst_int n2) 
@@ -126,7 +126,7 @@ let rec lsl_int c1 c2 =
 
 let rec mul_int c1 c2 =
   match (c1, c2) with
-    (c, Cconst_int 0) | (Cconst_int 0, c) ->
+  | (c, Cconst_int 0) | (Cconst_int 0, c) ->
       Cconst_int 0
   | (c, Cconst_int 1) | (Cconst_int 1, c) ->
       c

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -172,7 +172,12 @@ let no_overflow_sub a b = (a lxor (lnot b)) lor (b lxor (a-b)) < 0
 
 let no_overflow_mul a b = b <> 0 && (a * b) / b = a
 
-let no_overflow_lsl a k = min_int asr k <= a && a <= max_int asr k
+let bitsize =
+  if 1 lsl 30 < 0 && 1 lsl 31 == 0 then 32      (* 32-bit *)
+  else if 1 lsl 62 < 0 && 1 lsl 63 == 0 then 64 (* 64-bit *)
+  else failwith "unknown platform bit width"
+
+let no_overflow_lsl a k = 0 <= k && k < bitsize && min_int asr k <= a && a <= max_int asr k
 
 (* String operations *)
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -170,7 +170,9 @@ let no_overflow_add a b = (a lxor b) lor (a lxor (lnot (a+b))) < 0
 
 let no_overflow_sub a b = (a lxor (lnot b)) lor (b lxor (a-b)) < 0
 
-let no_overflow_lsl a = min_int asr 1 <= a && a <= max_int asr 1
+let no_overflow_mul a b = b <> 0 && (a * b) / b = a
+
+let no_overflow_lsl a k = min_int asr k <= a && a <= max_int asr k
 
 (* String operations *)
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -172,12 +172,7 @@ let no_overflow_sub a b = (a lxor (lnot b)) lor (b lxor (a-b)) < 0
 
 let no_overflow_mul a b = b <> 0 && (a * b) / b = a
 
-let bitsize =
-  if 1 lsl 30 < 0 && 1 lsl 31 == 0 then 32      (* 32-bit *)
-  else if 1 lsl 62 < 0 && 1 lsl 63 == 0 then 64 (* 64-bit *)
-  else failwith "unknown platform bit width"
-
-let no_overflow_lsl a k = 0 <= k && k < bitsize && min_int asr k <= a && a <= max_int asr k
+let no_overflow_lsl a k = 0 <= k && k < Sys.word_size && min_int asr k <= a && a <= max_int asr k
 
 (* String operations *)
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -83,9 +83,12 @@ val no_overflow_add: int -> int -> bool
 val no_overflow_sub: int -> int -> bool
         (* [no_overflow_add n1 n2] returns [true] if the computation of
            [n1 - n2] does not overflow. *)
-val no_overflow_lsl: int -> bool
-        (* [no_overflow_add n] returns [true] if the computation of
-           [n lsl 1] does not overflow. *)
+val no_overflow_mul: int -> int -> bool
+        (* [no_overflow_mul n1 n2] returns [true] if the computation of
+           [n1 * n2] does not overflow. *)
+val no_overflow_lsl: int -> int -> bool
+        (* [no_overflow_lsl n k] returns [true] if the computation of
+           [n lsl k] does not overflow. *)
 
 val chop_extension_if_any: string -> string
         (* Like Filename.chop_extension but returns the initial file


### PR DESCRIPTION
Some optimisations on Cmm expressions involving tagging or constants. Here's a (best-case) example:

```
let int_of_digits a b c = 
  100 * (Char.code a - Char.code '0') + 
   10 * (Char.code b - Char.code '0') +
    1 * (Char.code c - Char.code '0')
```

Trunk compiles this to:

```
 (+
   (+ (+ (* 200 (>>s (+ a/1020 -96) 1)) (* 20 (>>s (+ b/1021 -96) 1)))
     (* 2 (>>s (+ c/1022 -96) 1)))
   1)
```

This branch compiles this to:

```
(+ (+ (+ ( * a/1020 100) ( * b/1021 10)) c/1022) -10766)
```

Floating all of the constant operations, tags, etc. out of arithmetic means they can be merged into one addition.
