### PR TITLE
OCamlbuild: Fix the check of ocamlfind

### DIFF
--- a/ocamlbuild/main.ml
+++ b/ocamlbuild/main.ml
@@ -254,7 +254,7 @@ let proceed () =
             link (Pathname.dirname cmd); acc
         | _ ->
             if !Options.program_to_execute then
-              eprintf "Warning: Won't execute %s whose extension is neither .byte nor .native" cmd;
+              Log.eprintf "Warning: Won't execute %s whose extension is neither .byte nor .native" cmd;
             acc
       end targets [] in
 

--- a/ocamlbuild/main.ml
+++ b/ocamlbuild/main.ml
@@ -66,16 +66,42 @@ let proceed () =
   Options.init ();
   if !Options.must_clean then clean ();
   Hooks.call_hook Hooks.After_options;
-  let options_wd = Sys.getcwd () in
+
   let first_run_for_plugin =
     (* If we are in the first run before launching the plugin, we
        should skip the user-visible operations (hygiene) that may need
        information from the plugin to run as the user expects it.
-       
+
        Note that we don't need to disable the [Hooks] call as they are
        no-ops anyway, before any plugin has registered hooks. *)
     Plugin.we_need_a_plugin () && not !Options.just_plugin in
 
+  if !Options.use_ocamlfind then begin
+    let ocamlfind_cmd = A "ocamlfind" in
+    let ocamlfind arg = S[ocamlfind_cmd; arg] in
+    let cmd = Command.string_of_command_spec ocamlfind_cmd in
+    let has_ocamlfind =
+      try ignore(Command.search_in_path cmd); true
+      with Not_found ->
+        if first_run_for_plugin then
+          Log.eprintf
+            "Warning: ocamlfind not found on path, but -no-ocamlfind not \
+             used. Defaulting to -no-ocamlfind.";
+        false
+    in
+    (* TODO: warning message when using an option such as -ocamlc *)
+    if has_ocamlfind then begin
+      Options.ocamlc := ocamlfind & A"ocamlc";
+      Options.ocamlopt := ocamlfind & A"ocamlopt";
+      Options.ocamldep := ocamlfind & A"ocamldep";
+      Options.ocamldoc := ocamlfind & A"ocamldoc";
+      Options.ocamlmktop := ocamlfind & A"ocamlmktop";
+    end else begin
+      Options.use_ocamlfind := false;
+    end;
+  end;
+
+  let options_wd = Sys.getcwd () in
   let target_dirs = List.union [] (List.map Pathname.dirname !Options.targets) in
 
   Configuration.parse_string

--- a/ocamlbuild/options.ml
+++ b/ocamlbuild/options.ml
@@ -92,8 +92,6 @@ let ocamllex = ref (V"OCAMLLEX")
 let ocamlmklib = ref (V"OCAMLMKLIB")
 let ocamlmktop = ref (V"OCAMLMKTOP")
 let ocamlrun = ref N
-let ocamlfind_cmd = ref (V"OCAMLFIND")
-let ocamlfind arg = S[!ocamlfind_cmd; arg]
 let program_to_execute = ref false
 let must_clean = ref false
 let show_documentation = ref false
@@ -283,21 +281,6 @@ let init () =
       let log = if !Log.level > 0 then Some log else None in
       Log.init log
   in
-
-  if !use_ocamlfind then begin
-    ocamlfind_cmd := A "ocamlfind";
-    let cmd = Command.string_of_command_spec !ocamlfind_cmd in
-    begin try ignore(Command.search_in_path cmd)
-    with Not_found -> failwith "ocamlfind not found on path, but -no-ocamlfind not used" end;
-    (* TODO: warning message when using an option such as -ocamlc *)
-    (* Note that plugins can still modify these variables After_options.
-       This design decision can easily be changed. *)
-    ocamlc := ocamlfind & A"ocamlc";
-    ocamlopt := ocamlfind & A"ocamlopt";
-    ocamldep := ocamlfind & A"ocamldep";
-    ocamldoc := ocamlfind & A"ocamldoc";
-    ocamlmktop := ocamlfind & A"ocamlmktop";
-  end;
 
   let reorder x y = x := !x @ (List.concat (List.rev !y)) in
   reorder targets targets_internal;


### PR DESCRIPTION
As noticed in the following issues, ocamlbuild checks if ocamlfind is present too early (as it should be done after the After_options hook).
https://github.com/ocaml/opam-repository/pull/1641
https://github.com/ocaml/camlp4/issues/14

However, it appeared to be a difficult problem because of plugin tags. So a warning still appears if ocamlfind has been disabled in the plugin since ocamlfind is used to build the plugin itself.

I've also added a little patch that fixes a shadowing bug (maybe I should have done another PR for that).
