### PR TITLE
Unnecessary boxing in "let"

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -1150,7 +1150,7 @@ type unboxed_number_kind =
   | Boxed_float
   | Boxed_integer of boxed_integer
 
-let is_unboxed_number = function
+let rec is_unboxed_number = function
     Uconst(Uconst_ref(_, Uconst_float _)) ->
       Boxed_float
   | Uprim(p, _, _) ->
@@ -1192,6 +1192,8 @@ let is_unboxed_number = function
         | Pbbswap bi -> Boxed_integer bi
         | _ -> No_unboxing
       end
+  | Ulet(_, _, body) -> is_unboxed_number body
+  | Usequence(_, e2) -> is_unboxed_number e2
   | _ -> No_unboxing
 
 let subst_boxed_number unbox_fn boxed_id unboxed_id box_chunk box_offset exp =


### PR DESCRIPTION
A `let` expression is always boxed, regardless of whether it's necessary or not, like in the following example:

``` ocaml
let y =
  let z = x +. x in
  z +. z
```

This change should fix that.  OCaml test suite passes.  Here's an example OCaml code with its machine translation without and with the change.

``` ocaml
let () =
  let x = 0.5 in
  let w =
    let y =
      let z = x +. x in
      z +. z
    in
    y +. y
  in
  let _u = w +. w in ()
```

``` asm
camlTest__entry:
    .cfi_startproc
    subq    $8, %rsp
    .cfi_adjust_cfa_offset  8
.L100:
    movsd   .L101(%rip), %xmm0
    movsd   .L101(%rip), %xmm1
    addsd   %xmm0, %xmm1
    movq    $1277, %rbx
    call    caml_alloc3@PLT
.L102:
    leaq    8(%r15), %rax
    movq    %rbx, -8(%rax)
    addsd   %xmm1, %xmm1
    movsd   %xmm1, (%rax)
    movq    $1277, %rbx
    leaq    16(%rax), %rdi
    movq    %rbx, -8(%rdi)
    movsd   (%rax), %xmm0
    addsd   (%rax), %xmm0
    movsd   %xmm0, (%rdi)
    movsd   (%rdi), %xmm0
    addsd   (%rdi), %xmm0
    movq    $1, %rax
    movq    $1, %rax
    addq    $8, %rsp
    .cfi_adjust_cfa_offset  -8
    ret
```

``` asm
camlTest__entry:
    .cfi_startproc
.L100:
    movsd   .L101(%rip), %xmm0
    movsd   .L101(%rip), %xmm1
    addsd   %xmm0, %xmm1
    addsd   %xmm1, %xmm1
    addsd   %xmm1, %xmm1
    addsd   %xmm1, %xmm1
    movq    $1, %rax
    movq    $1, %rax
    ret
```
