### PR TITLE
Introduce Asttypes.arrow_flag to encode labelled arguments

### DIFF
--- a/bytecomp/translcore.mli
+++ b/bytecomp/translcore.mli
@@ -18,7 +18,7 @@ open Typedtree
 open Lambda
 
 val transl_exp: expression -> lambda
-val transl_apply: lambda -> (label * expression option * optional) list
+val transl_apply: lambda -> (arrow_flag * expression option * optional) list
                   -> Location.t -> lambda
 val transl_let: rec_flag -> value_binding list -> lambda -> lambda
 val transl_primitive: Location.t -> Primitive.description -> lambda

--- a/ocamldoc/odoc_info.mli
+++ b/ocamldoc/odoc_info.mli
@@ -713,7 +713,7 @@ val is_optional : Asttypes.arrow_flag -> bool
 
 (** Return the label name for the given label,
    i.e. removes the beginning '?' if present.*)
-val label_name : Asttypes.arrow_flag -> string
+val label_name : Asttypes.arrow_flag -> string option
 
 (** Return the given name where the module name or
    part of it was removed, according to the list of modules

--- a/ocamldoc/odoc_info.mli
+++ b/ocamldoc/odoc_info.mli
@@ -709,11 +709,11 @@ val create_index_lists : 'a list -> ('a -> string) -> 'a list list
 val remove_option : Types.type_expr -> Types.type_expr
 
 (** Return [true] if the given label is optional.*)
-val is_optional : string -> bool
+val is_optional : Asttypes.arrow_flag -> bool
 
 (** Return the label name for the given label,
    i.e. removes the beginning '?' if present.*)
-val label_name : string -> string
+val label_name : Asttypes.arrow_flag -> string
 
 (** Return the given name where the module name or
    part of it was removed, according to the list of modules

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -471,6 +471,10 @@ let create_index_lists elements string_of_ele =
 
 let is_optional = Btype.is_optional
 let label_name = Btype.label_name
+let label_prefix = function
+  | Asttypes.Simple -> ""
+  | Asttypes.Optional s -> "?" ^ s ^ ":"
+  | Asttypes.Labelled s -> s ^ ":"
 
 let remove_option typ =
   let rec iter t =

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -471,6 +471,11 @@ let create_index_lists elements string_of_ele =
 
 let is_optional = Btype.is_optional
 let label_name = Btype.label_name
+
+let label_name' label = match label_name label with
+  | None -> ""
+  | Some s -> s
+
 let label_prefix = function
   | Asttypes.Simple -> ""
   | Asttypes.Optional s -> "?" ^ s ^ ":"

--- a/ocamldoc/odoc_misc.mli
+++ b/ocamldoc/odoc_misc.mli
@@ -111,7 +111,8 @@ val is_optional : Asttypes.arrow_flag -> bool
 
 (** Return the label name for the given label,
    i.e. removes the beginning '?' if present.*)
-val label_name : Asttypes.arrow_flag -> string
+val label_name : Asttypes.arrow_flag -> string option
+val label_name' : Asttypes.arrow_flag -> string
 
 (** Return the string to print when label is prefixing a type
    i.e. appends ':' if label is non-empty .*)

--- a/ocamldoc/odoc_misc.mli
+++ b/ocamldoc/odoc_misc.mli
@@ -107,8 +107,12 @@ val search_string_backward : pat: string -> s: string -> int
 val remove_option : Types.type_expr -> Types.type_expr
 
 (** Return [true] if the given label is optional.*)
-val is_optional : string -> bool
+val is_optional : Asttypes.arrow_flag -> bool
 
 (** Return the label name for the given label,
    i.e. removes the beginning '?' if present.*)
-val label_name : string -> string
+val label_name : Asttypes.arrow_flag -> string
+
+(** Return the string to print when label is prefixing a type
+   i.e. appends ':' if label is non-empty .*)
+val label_prefix : Asttypes.arrow_flag -> string

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -222,7 +222,7 @@ module Analyser =
           let f {Types.cd_id=constructor_name;cd_args=type_expr_list;cd_res=ret_type} =
             let constructor_name = Ident.name constructor_name in
             let comment_opt =
-              try List.assoc constructor_name name_comment_list 
+              try List.assoc constructor_name name_comment_list
               with Not_found -> None
             in
             {
@@ -1262,7 +1262,7 @@ module Analyser =
             (
              let new_param = Simple_name
                  {
-                   sn_name = Btype.label_name label ;
+                   sn_name = Odoc_misc.label_name' label ;
                    sn_type = Odoc_env.subst_type env type_expr ;
                    sn_text = None ; (* will be updated when the class will be created *)
                  }

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -128,11 +128,7 @@ let string_of_class_params c =
       Types.Cty_arrow (label, t, ctype) ->
         let parent = is_arrow_type t in
         Printf.bprintf b "%s%s%s%s -> "
-          (
-           match label with
-             "" -> ""
-           | s -> s^":"
-          )
+          (Odoc_misc.label_prefix label)
           (if parent then "(" else "")
           (Odoc_print.string_of_type_expr
              (if Odoc_misc.is_optional label then

--- a/ocamldoc/odoc_value.ml
+++ b/ocamldoc/odoc_value.ml
@@ -95,26 +95,18 @@ let parameter_list_from_arrows typ =
    so there is nothing to merge. With this dummy list we can merge the
    parameter names from the .ml and the type from the .mli file. *)
 let dummy_parameter_list typ =
-  let normal_name s =
-    match s with
-      "" -> s
-    | _ ->
-        match s.[0] with
-          '?' -> String.sub s 1 ((String.length s) - 1)
-        | _ -> s
-  in
   Printtyp.mark_loops typ;
   let liste_param = parameter_list_from_arrows typ in
   let rec iter (label, t) =
     match t.Types.desc with
     | Types.Ttuple l ->
-        if label = "" then
+        if label = Asttypes.Simple then
           Odoc_parameter.Tuple
-            (List.map (fun t2 -> iter ("", t2)) l, t)
+            (List.map (fun t2 -> iter (Asttypes.Simple, t2)) l, t)
         else
           (* if there is a label, then we don't want to decompose the tuple *)
           Odoc_parameter.Simple_name
-            { Odoc_parameter.sn_name = normal_name label ;
+            { Odoc_parameter.sn_name = Odoc_misc.label_name label ;
               Odoc_parameter.sn_type = t ;
               Odoc_parameter.sn_text = None }
     | Types.Tlink t2
@@ -123,7 +115,7 @@ let dummy_parameter_list typ =
 
     | _ ->
         Odoc_parameter.Simple_name
-          { Odoc_parameter.sn_name = normal_name label ;
+          { Odoc_parameter.sn_name = Odoc_misc.label_name label ;
              Odoc_parameter.sn_type = t ;
             Odoc_parameter.sn_text = None }
   in

--- a/ocamldoc/odoc_value.ml
+++ b/ocamldoc/odoc_value.ml
@@ -100,23 +100,24 @@ let dummy_parameter_list typ =
   let rec iter (label, t) =
     match t.Types.desc with
     | Types.Ttuple l ->
-        if label = Asttypes.Simple then
-          Odoc_parameter.Tuple
-            (List.map (fun t2 -> iter (Asttypes.Simple, t2)) l, t)
-        else
-          (* if there is a label, then we don't want to decompose the tuple *)
-          Odoc_parameter.Simple_name
-            { Odoc_parameter.sn_name = Odoc_misc.label_name label ;
-              Odoc_parameter.sn_type = t ;
-              Odoc_parameter.sn_text = None }
+        begin match Odoc_misc.label_name label with
+        | None -> Odoc_parameter.Tuple
+                    (List.map (fun t2 -> iter (Asttypes.Simple, t2)) l, t)
+        | Some name ->
+            (* if there is a label, then we don't want to decompose the tuple *)
+            Odoc_parameter.Simple_name
+              { Odoc_parameter.sn_name = name;
+                Odoc_parameter.sn_type = t;
+                Odoc_parameter.sn_text = None }
+        end
     | Types.Tlink t2
     | Types.Tsubst t2 ->
         (iter (label, t2))
 
     | _ ->
         Odoc_parameter.Simple_name
-          { Odoc_parameter.sn_name = Odoc_misc.label_name label ;
-             Odoc_parameter.sn_type = t ;
+          { Odoc_parameter.sn_name = Odoc_misc.label_name' label;
+            Odoc_parameter.sn_type = t ;
             Odoc_parameter.sn_text = None }
   in
   List.map iter liste_param

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -390,8 +390,8 @@ module Convenience = struct
   let record ?over l =
     Exp.record (List.map (fun (s, e) -> (lid s, e)) l) over
   let func l = Exp.function_ (List.map (fun (p, e) -> Exp.case p e) l)
-  let lam ?(label = "") ?default pat exp = Exp.fun_ label default pat exp
-  let app f l = Exp.apply f (List.map (fun a -> "", a) l)
+  let lam ?(label = Simple) ?default pat exp = Exp.fun_ label default pat exp
+  let app f l = Exp.apply f (List.map (fun a -> Simple, a) l)
   let evar s = Exp.ident (lid s)
   let let_in ?(recursive = false) b body =
     Exp.let_ (if recursive then Recursive else Nonrecursive) b body

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -38,7 +38,7 @@ module Typ :
 
     val any: ?loc:loc -> ?attrs:attrs -> unit -> core_type
     val var: ?loc:loc -> ?attrs:attrs -> string -> core_type
-    val arrow: ?loc:loc -> ?attrs:attrs -> label -> core_type -> core_type -> core_type
+    val arrow: ?loc:loc -> ?attrs:attrs -> arrow_flag -> core_type -> core_type -> core_type
     val tuple: ?loc:loc -> ?attrs:attrs -> core_type list -> core_type
     val constr: ?loc:loc -> ?attrs:attrs -> lid -> core_type list -> core_type
     val object_: ?loc:loc -> ?attrs:attrs -> (string * core_type) list -> closed_flag -> core_type
@@ -85,9 +85,9 @@ module Exp:
     val ident: ?loc:loc -> ?attrs:attrs -> lid -> expression
     val constant: ?loc:loc -> ?attrs:attrs -> constant -> expression
     val let_: ?loc:loc -> ?attrs:attrs -> rec_flag -> value_binding list -> expression -> expression
-    val fun_: ?loc:loc -> ?attrs:attrs -> label -> expression option -> pattern -> expression -> expression
+    val fun_: ?loc:loc -> ?attrs:attrs -> arrow_flag -> expression option -> pattern -> expression -> expression
     val function_: ?loc:loc -> ?attrs:attrs -> case list -> expression
-    val apply: ?loc:loc -> ?attrs:attrs -> expression -> (label * expression) list -> expression
+    val apply: ?loc:loc -> ?attrs:attrs -> expression -> (arrow_flag * expression) list -> expression
     val match_: ?loc:loc -> ?attrs:attrs -> expression -> case list -> expression
     val try_: ?loc:loc -> ?attrs:attrs -> expression -> case list -> expression
     val tuple: ?loc:loc -> ?attrs:attrs -> expression list -> expression
@@ -246,7 +246,7 @@ module Cty:
 
     val constr: ?loc:loc -> ?attrs:attrs -> lid -> core_type list -> class_type
     val signature: ?loc:loc -> ?attrs:attrs -> class_signature -> class_type
-    val arrow: ?loc:loc -> ?attrs:attrs -> label -> core_type -> class_type -> class_type
+    val arrow: ?loc:loc -> ?attrs:attrs -> arrow_flag -> core_type -> class_type -> class_type
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> class_type
   end
 
@@ -271,8 +271,8 @@ module Cl:
 
     val constr: ?loc:loc -> ?attrs:attrs -> lid -> core_type list -> class_expr
     val structure: ?loc:loc -> ?attrs:attrs -> class_structure -> class_expr
-    val fun_: ?loc:loc -> ?attrs:attrs -> label -> expression option -> pattern -> class_expr -> class_expr
-    val apply: ?loc:loc -> ?attrs:attrs -> class_expr -> (label * expression) list -> class_expr
+    val fun_: ?loc:loc -> ?attrs:attrs -> arrow_flag -> expression option -> pattern -> class_expr -> class_expr
+    val apply: ?loc:loc -> ?attrs:attrs -> class_expr -> (arrow_flag * expression) list -> class_expr
     val let_: ?loc:loc -> ?attrs:attrs -> rec_flag -> value_binding list -> class_expr -> class_expr
     val constraint_: ?loc:loc -> ?attrs:attrs -> class_expr -> class_type -> class_expr
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> class_expr
@@ -340,7 +340,7 @@ module Convenience :
     val unit: unit -> expression
 
     val func: (pattern * expression) list -> expression
-    val lam: ?label:string -> ?default:expression -> pattern -> expression -> expression
+    val lam: ?label:arrow_flag -> ?default:expression -> pattern -> expression -> expression
     val app: expression -> expression list -> expression
 
     val str: string -> expression

--- a/parsing/asttypes.mli
+++ b/parsing/asttypes.mli
@@ -42,8 +42,12 @@ type 'a loc = 'a Location.loc = {
   loc : Location.t;
 }
 
-
 type variance =
   | Covariant
   | Contravariant
   | Invariant
+
+type arrow_flag =
+  | Simple             (*        T -> ... *)
+  | Labelled of string (*  label:T -> ... *)
+  | Optional of string (* ?label:T -> ... *)

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -72,7 +72,7 @@ let ghunit () =
   ghexp (Pexp_construct (mknoloc (Lident "()"), None))
 
 let mkinfix arg1 name arg2 =
-  mkexp(Pexp_apply(mkoperator name 2, ["", arg1; "", arg2]))
+  mkexp(Pexp_apply(mkoperator name 2, [Simple, arg1; Simple, arg2]))
 
 let neg_float_string f =
   if String.length f > 0 && f.[0] = '-'
@@ -92,7 +92,7 @@ let mkuminus name arg =
   | ("-" | "-."), Pexp_constant(Const_float f) ->
       mkexp(Pexp_constant(Const_float(neg_float_string f)))
   | _ ->
-      mkexp(Pexp_apply(mkoperator ("~" ^ name) 1, ["", arg]))
+      mkexp(Pexp_apply(mkoperator ("~" ^ name) 1, [Simple, arg]))
 
 let mkuplus name arg =
   let desc = arg.pexp_desc in
@@ -103,7 +103,7 @@ let mkuplus name arg =
   | "+", Pexp_constant(Const_nativeint _)
   | ("+" | "+."), Pexp_constant(Const_float _) -> mkexp desc
   | _ ->
-      mkexp(Pexp_apply(mkoperator ("~" ^ name) 1, ["", arg]))
+      mkexp(Pexp_apply(mkoperator ("~" ^ name) 1, [Simple, arg]))
 
 let mkexp_cons consloc args loc =
   Exp.mk ~loc (Pexp_construct(mkloc (Lident "::") consloc, Some args))
@@ -176,34 +176,34 @@ let bigarray_get arr arg =
   match bigarray_untuplify arg with
     [c1] ->
       mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Array1" get)),
-                       ["", arr; "", c1]))
+                       [Simple, arr; Simple, c1]))
   | [c1;c2] ->
       mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Array2" get)),
-                       ["", arr; "", c1; "", c2]))
+                       [Simple, arr; Simple, c1; Simple, c2]))
   | [c1;c2;c3] ->
       mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Array3" get)),
-                       ["", arr; "", c1; "", c2; "", c3]))
+                       [Simple, arr; Simple, c1; Simple, c2; Simple, c3]))
   | coords ->
       mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Genarray" "get")),
-                       ["", arr; "", ghexp(Pexp_array coords)]))
+                       [Simple, arr; Simple, ghexp(Pexp_array coords)]))
 
 let bigarray_set arr arg newval =
   let set = if !Clflags.fast then "unsafe_set" else "set" in
   match bigarray_untuplify arg with
     [c1] ->
       mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Array1" set)),
-                       ["", arr; "", c1; "", newval]))
+                       [Simple, arr; Simple, c1; Simple, newval]))
   | [c1;c2] ->
       mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Array2" set)),
-                       ["", arr; "", c1; "", c2; "", newval]))
+                       [Simple, arr; Simple, c1; Simple, c2; Simple, newval]))
   | [c1;c2;c3] ->
       mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Array3" set)),
-                       ["", arr; "", c1; "", c2; "", c3; "", newval]))
+                       [Simple, arr; Simple, c1; Simple, c2; Simple, c3; Simple, newval]))
   | coords ->
       mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Genarray" "set")),
-                       ["", arr;
-                        "", ghexp(Pexp_array coords);
-                        "", newval]))
+                       [Simple, arr;
+                        Simple, ghexp(Pexp_array coords);
+                        Simple, newval]))
 
 let lapply p1 p2 =
   if !Clflags.applicative_functors
@@ -919,13 +919,13 @@ class_type:
     class_signature
       { $1 }
   | QUESTION LIDENT COLON simple_core_type_or_tuple_no_attr MINUSGREATER class_type
-      { mkcty(Pcty_arrow("?" ^ $2 , mkoption $4, $6)) }
+      { mkcty(Pcty_arrow(Optional $2 , mkoption $4, $6)) }
   | OPTLABEL simple_core_type_or_tuple_no_attr MINUSGREATER class_type
-      { mkcty(Pcty_arrow("?" ^ $1, mkoption $2, $4)) }
+      { mkcty(Pcty_arrow(Optional $1, mkoption $2, $4)) }
   | LIDENT COLON simple_core_type_or_tuple_no_attr MINUSGREATER class_type
-      { mkcty(Pcty_arrow($1, $3, $5)) }
+      { mkcty(Pcty_arrow(Labelled $1, $3, $5)) }
   | simple_core_type_or_tuple_no_attr MINUSGREATER class_type
-      { mkcty(Pcty_arrow("", $1, $3)) }
+      { mkcty(Pcty_arrow(Simple, $1, $3)) }
   | class_type attribute
       { Cty.attr $1 $2 }
   | extension
@@ -1015,21 +1015,21 @@ seq_expr:
 ;
 labeled_simple_pattern:
     QUESTION LPAREN label_let_pattern opt_default RPAREN
-      { ("?" ^ fst $3, $4, snd $3) }
+      { (Optional (fst $3), $4, snd $3) }
   | QUESTION label_var
-      { ("?" ^ fst $2, None, snd $2) }
+      { (Optional (fst $2), None, snd $2) }
   | OPTLABEL LPAREN let_pattern opt_default RPAREN
-      { ("?" ^ $1, $4, $3) }
+      { (Optional $1, $4, $3) }
   | OPTLABEL pattern_var
-      { ("?" ^ $1, None, $2) }
+      { (Optional $1, None, $2) }
   | TILDE LPAREN label_let_pattern RPAREN
-      { (fst $3, None, snd $3) }
+      { (Labelled (fst $3), None, snd $3) }
   | TILDE label_var
-      { (fst $2, None, snd $2) }
+      { (Labelled (fst $2), None, snd $2) }
   | LABEL simple_pattern
-      { ($1, None, $2) }
+      { (Labelled $1, None, $2) }
   | simple_pattern
-      { ("", None, $1) }
+      { (Simple, None, $1) }
 ;
 pattern_var:
     LIDENT            { mkpat(Ppat_var (mkrhs $1 1)) }
@@ -1142,10 +1142,10 @@ expr:
       { mkexp(Pexp_setfield($1, mkrhs $3 3, $5)) }
   | simple_expr DOT LPAREN seq_expr RPAREN LESSMINUS expr
       { mkexp(Pexp_apply(ghexp(Pexp_ident(array_function "Array" "set")),
-                         ["",$1; "",$4; "",$7])) }
+                         [Simple,$1; Simple,$4; Simple,$7])) }
   | simple_expr DOT LBRACKET seq_expr RBRACKET LESSMINUS expr
       { mkexp(Pexp_apply(ghexp(Pexp_ident(array_function "String" "set")),
-                         ["",$1; "",$4; "",$7])) }
+                         [Simple,$1; Simple,$4; Simple,$7])) }
   | simple_expr DOT LBRACE expr RBRACE LESSMINUS expr
       { bigarray_set $1 $4 $7 }
   | label LESSMINUS expr
@@ -1191,12 +1191,12 @@ simple_expr:
       { unclosed "(" 3 ")" 5 }
   | simple_expr DOT LPAREN seq_expr RPAREN
       { mkexp(Pexp_apply(ghexp(Pexp_ident(array_function "Array" "get")),
-                         ["",$1; "",$4])) }
+                         [Simple,$1; Simple,$4])) }
   | simple_expr DOT LPAREN seq_expr error
       { unclosed "(" 3 ")" 5 }
   | simple_expr DOT LBRACKET seq_expr RBRACKET
       { mkexp(Pexp_apply(ghexp(Pexp_ident(array_function "String" "get")),
-                         ["",$1; "",$4])) }
+                         [Simple,$1; Simple,$4])) }
   | simple_expr DOT LBRACKET seq_expr error
       { unclosed "[" 3 "]" 5 }
   | simple_expr DOT LBRACE expr RBRACE
@@ -1233,9 +1233,9 @@ simple_expr:
   | mod_longident DOT LBRACKET expr_semi_list opt_semi error
       { unclosed "[" 3 "]" 6 }
   | PREFIXOP simple_expr
-      { mkexp(Pexp_apply(mkoperator $1 1, ["",$2])) }
+      { mkexp(Pexp_apply(mkoperator $1 1, [Simple,$2])) }
   | BANG simple_expr
-      { mkexp(Pexp_apply(mkoperator "!" 1, ["",$2])) }
+      { mkexp(Pexp_apply(mkoperator "!" 1, [Simple,$2])) }
   | NEW ext_attributes class_longident
       { mkexp_attrs (Pexp_new(mkrhs $3 3)) $2 }
   | LBRACELESS field_expr_list opt_semi GREATERRBRACE
@@ -1274,19 +1274,19 @@ simple_labeled_expr_list:
 ;
 labeled_simple_expr:
     simple_expr %prec below_SHARP
-      { ("", $1) }
+      { (Simple, $1) }
   | label_expr
       { $1 }
 ;
 label_expr:
     LABEL simple_expr %prec below_SHARP
-      { ($1, $2) }
+      { (Labelled $1, $2) }
   | TILDE label_ident
-      { $2 }
+      { (Labelled (fst $2), snd $2) }
   | QUESTION label_ident
-      { ("?" ^ fst $2, snd $2) }
+      { (Optional (fst $2), snd $2) }
   | OPTLABEL simple_expr %prec below_SHARP
-      { ("?" ^ $1, $2) }
+      { (Optional $1, $2) }
 ;
 label_ident:
     LIDENT   { ($1, mkexp(Pexp_ident(mkrhs (Lident $1) 1))) }
@@ -1676,13 +1676,13 @@ core_type2:
     simple_core_type_or_tuple
       { $1 }
   | QUESTION LIDENT COLON core_type2 MINUSGREATER core_type2
-      { mktyp(Ptyp_arrow("?" ^ $2 , mkoption $4, $6)) }
+      { mktyp(Ptyp_arrow(Optional $2 , mkoption $4, $6)) }
   | OPTLABEL core_type2 MINUSGREATER core_type2
-      { mktyp(Ptyp_arrow("?" ^ $1 , mkoption $2, $4)) }
+      { mktyp(Ptyp_arrow(Optional $1 , mkoption $2, $4)) }
   | LIDENT COLON core_type2 MINUSGREATER core_type2
-      { mktyp(Ptyp_arrow($1, $3, $5)) }
+      { mktyp(Ptyp_arrow(Labelled $1, $3, $5)) }
   | core_type2 MINUSGREATER core_type2
-      { mktyp(Ptyp_arrow("", $1, $3)) }
+      { mktyp(Ptyp_arrow(Simple, $1, $3)) }
 ;
 
 simple_core_type:

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -49,7 +49,7 @@ and core_type_desc =
         (*  _ *)
   | Ptyp_var of string
         (* 'a *)
-  | Ptyp_arrow of label * core_type * core_type
+  | Ptyp_arrow of arrow_flag * core_type * core_type
         (* T1 -> T2       (label = "")
            ~l:T1 -> T2    (label = "l")
            ?l:T1 -> T2    (label = "?l")
@@ -196,7 +196,7 @@ and expression_desc =
          *)
   | Pexp_function of case list
         (* function P1 -> E1 | ... | Pn -> En *)
-  | Pexp_fun of label * expression option * pattern * expression
+  | Pexp_fun of arrow_flag * expression option * pattern * expression
         (* fun P -> E1                          (lab = "", None)
            fun ~l:P -> E1                       (lab = "l", None)
            fun ?l:P -> E1                       (lab = "?l", None)
@@ -207,7 +207,7 @@ and expression_desc =
            - "fun P1 P2 .. Pn -> E1" is represented as nested Pexp_fun.
            - "let f P = E" is represented using Pexp_fun.
          *)
-  | Pexp_apply of expression * (label * expression) list
+  | Pexp_apply of expression * (arrow_flag * expression) list
         (* E0 ~l1:E1 ... ~ln:En
            li can be empty (non labeled argument) or start with '?'
            (optional argument).
@@ -389,7 +389,7 @@ and class_type_desc =
            ['a1, ..., 'an] c *)
   | Pcty_signature of class_signature
         (* object ... end *)
-  | Pcty_arrow of label * core_type * class_type
+  | Pcty_arrow of arrow_flag * core_type * class_type
         (* T -> CT       (label = "")
            ~l:T -> CT    (label = "l")
            ?l:T -> CT    (label = "?l")
@@ -463,13 +463,13 @@ and class_expr_desc =
            ['a1, ..., 'an] c *)
   | Pcl_structure of class_structure
         (* object ... end *)
-  | Pcl_fun of label * expression option * pattern * class_expr
+  | Pcl_fun of arrow_flag * expression option * pattern * class_expr
         (* fun P -> CE                          (lab = "", None)
            fun ~l:P -> CE                       (lab = "l", None)
            fun ?l:P -> CE                       (lab = "?l", None)
            fun ?l:(P = E0) -> CE                (lab = "?l", Some E0)
          *)
-  | Pcl_apply of class_expr * (label * expression) list
+  | Pcl_apply of class_expr * (arrow_flag * expression) list
         (* CE ~l1:E1 ... ~ln:En
            li can be empty (non labeled argument) or start with '?'
            (optional argument).

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1198,22 +1198,20 @@ class printer  ()= object(self:'self)
         self#pattern pc_lhs (self#option self#expression ~first:"@;when@;") pc_guard self#under_pipe#expression pc_rhs in
     self#list aux f l ~sep:""
   method label_x_expression_param f (l,e) =
-    let simple_name = match e.pexp_desc with
-      | Pexp_ident {txt=Lident l;_} -> Some l
-      | _ -> None
+    let print_label c s =
+      let simple_name = match e.pexp_desc with
+        | Pexp_ident {txt=Lident l;_} -> Some l
+        | _ -> None
+      in
+      if Some s = simple_name then
+        pp f "%c%s" c s
+      else
+        pp f "%c%s:%a" c s self#simple_expr e
     in
     match l with
     | Simple -> self#expression2 f e ; (* level 2*)
-    | Optional s ->
-        if Some s = simple_name then
-          pp f "?%s" s
-        else
-          pp f "?%s:%a" s self#simple_expr e
-    | Labelled s ->
-        if Some s = simple_name then
-          pp f "~%s" s
-        else
-          pp f "~%s:%a" s self#simple_expr e
+    | Optional s -> print_label '?' s
+    | Labelled s -> print_label '~' s
 
   method directive_argument f x =
     (match x with

--- a/parsing/pprintast.mli
+++ b/parsing/pprintast.mli
@@ -50,10 +50,10 @@ class printer :
     method expression2 : Format.formatter -> Parsetree.expression -> unit
     method label_exp :
       Format.formatter ->
-      Asttypes.label * Parsetree.expression option * Parsetree.pattern ->
+      Asttypes.arrow_flag * Parsetree.expression option * Parsetree.pattern ->
       unit
     method label_x_expression_param :
-      Format.formatter -> Asttypes.label * Parsetree.expression -> unit
+      Format.formatter -> Asttypes.arrow_flag * Parsetree.expression -> unit
     method list :
       ?sep:space_formatter ->
       ?first:space_formatter ->
@@ -106,8 +106,8 @@ class printer :
       Format.formatter -> string Asttypes.loc option * Asttypes.variance -> unit
     method type_var_option :
       Format.formatter -> string Asttypes.loc option -> unit
-    method type_with_label :
-      Format.formatter -> Asttypes.label * Parsetree.core_type -> unit
+    method type_in_arrow :
+      Format.formatter -> Asttypes.arrow_flag * Parsetree.core_type -> unit
     method tyvar : Format.formatter -> string -> unit
     method under_pipe : 'b
     method under_semi : 'b

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -125,11 +125,17 @@ let option i f ppf x =
       f (i+1) ppf x;
 ;;
 
+let arrow_flag f = function
+  | Simple -> ()
+  | Optional s -> fprintf f "?%s" s
+  | Labelled s -> fprintf f "%s" s
+;;
+
 let longident_loc i ppf li = line i ppf "%a\n" fmt_longident_loc li;;
 let string i ppf s = line i ppf "\"%s\"\n" s;;
 let string_loc i ppf s = line i ppf "%a\n" fmt_string_loc s;;
 let bool i ppf x = line i ppf "%s\n" (string_of_bool x);;
-let label i ppf x = line i ppf "label=\"%s\"\n" x;;
+let label i ppf x = line i ppf "label=\"%a\"\n" arrow_flag x;;
 
 let rec core_type i ppf x =
   line i ppf "core_type %a\n" fmt_location x.ptyp_loc;
@@ -139,8 +145,7 @@ let rec core_type i ppf x =
   | Ptyp_any -> line i ppf "Ptyp_any\n";
   | Ptyp_var (s) -> line i ppf "Ptyp_var %s\n" s;
   | Ptyp_arrow (l, ct1, ct2) ->
-      line i ppf "Ptyp_arrow\n";
-      string i ppf l;
+      line i ppf "Ptyp_arrow \"%a\"\n" arrow_flag l;
       core_type i ppf ct1;
       core_type i ppf ct2;
   | Ptyp_tuple l ->
@@ -245,7 +250,7 @@ and expression i ppf x =
       line i ppf "Pexp_function\n";
       list i case ppf l;
   | Pexp_fun (l, eo, p, e) ->
-      line i ppf "Pexp_fun \"%s\"\n" l;
+      line i ppf "Pexp_fun \"%a\"\n" arrow_flag l;
       option i expression ppf eo;
       pattern i ppf p;
       expression i ppf e;
@@ -424,7 +429,7 @@ and class_type i ppf x =
       line i ppf "Pcty_signature\n";
       class_signature i ppf cs;
   | Pcty_arrow (l, co, cl) ->
-      line i ppf "Pcty_arrow \"%s\"\n" l;
+      line i ppf "Pcty_arrow \"%a\"\n" arrow_flag l;
       core_type i ppf co;
       class_type i ppf cl;
   | Pcty_extension (s, arg) ->
@@ -813,7 +818,7 @@ and longident_x_expression i ppf (li, e) =
   expression (i+1) ppf e;
 
 and label_x_expression i ppf (l,e) =
-  line i ppf "<label> \"%s\"\n" l;
+  line i ppf "<label> \"%a\"\n" arrow_flag l;
   expression (i+1) ppf e;
 
 and label_x_bool_x_core_type_list i ppf x =

--- a/tools/untypeast.ml
+++ b/tools/untypeast.ml
@@ -235,7 +235,7 @@ and untype_expression exp =
           untype_expression exp)
     | Texp_function (label, [{c_lhs=p; c_guard=None; c_rhs=e}], _) ->
         Pexp_fun (label, None, untype_pattern p, untype_expression e)
-    | Texp_function ("", cases, _) ->
+    | Texp_function (Simple, cases, _) ->
         Pexp_function (untype_cases cases)
     | Texp_function _ ->
         assert false

--- a/toplevel/trace.ml
+++ b/toplevel/trace.ml
@@ -12,6 +12,7 @@
 
 (* The "trace" facility *)
 
+open Asttypes
 open Format
 open Misc
 open Longident
@@ -52,7 +53,10 @@ let set_code_pointer cls ptr = Obj.set_field cls 0 ptr
 let invoke_traced_function codeptr env arg =
   Meta.invoke_traced_function codeptr env arg
 
-let print_label ppf l = if l <> "" then fprintf ppf "%s:" l
+let print_label ppf = function
+  | Simple -> ()
+  | Optional s -> fprintf ppf "?%s:" s
+  | Labelled s -> fprintf ppf "%s:" s
 
 (* If a function returns a functional value, wrap it into a trace code *)
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -12,6 +12,7 @@
 
 (* Basic operations on core types *)
 
+open Asttypes
 open Misc
 open Types
 
@@ -540,12 +541,22 @@ let check_memorized_abbrevs () =
                   (*  Utilities for labels          *)
                   (**********************************)
 
-let is_optional l =
-  String.length l > 0 && l.[0] = '?'
+let is_simple = function
+  | Simple -> true
+  | _ -> false
 
-let label_name l =
-  if is_optional l then String.sub l 1 (String.length l - 1)
-                   else l
+let is_optional = function
+  | Optional _ -> true
+  | _ -> false
+
+let label_name = function
+  | Simple -> ""
+  | Optional s | Labelled s -> s
+
+let label_raw = function
+  | Simple -> ""
+  | Optional s -> "?" ^ s
+  | Labelled s -> s
 
 let rec extract_label_aux hd l = function
     [] -> raise Not_found

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -550,21 +550,23 @@ let is_optional = function
   | _ -> false
 
 let label_name = function
-  | Simple -> ""
-  | Optional s | Labelled s -> s
+  | Simple -> None
+  | Optional s | Labelled s -> Some s
 
 let label_raw = function
   | Simple -> ""
   | Optional s -> "?" ^ s
   | Labelled s -> s
 
-let rec extract_label_aux hd l = function
+let rec extract_arg_aux hd l = function
     [] -> raise Not_found
   | (l',t as p) :: ls ->
-      if label_name l' = l then (l', t, List.rev hd, ls)
-      else extract_label_aux (p::hd) l ls
+      if label_name l' = l then
+        (l', t, List.rev hd, ls)
+      else
+        extract_arg_aux (p::hd) l ls
 
-let extract_label l ls = extract_label_aux [] l ls
+let extract_arg l ls = extract_arg_aux [] (label_name l) ls
 
 
                   (**********************************)

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -157,11 +157,14 @@ val forget_abbrev:
 
 (**** Utilities for labels ****)
 
-val is_optional : label -> bool
-val label_name : label -> label
+val is_simple : arrow_flag -> bool
+val is_optional : arrow_flag -> bool
+val label_name : arrow_flag -> label
+val label_raw : arrow_flag -> label
+
 val extract_label :
-    label -> (label * 'a) list ->
-    label * 'a * (label * 'a) list * (label * 'a) list
+    label -> (arrow_flag * 'a) list ->
+    arrow_flag * 'a * (arrow_flag * 'a) list * (arrow_flag * 'a) list
     (* actual label, value, before list, after list *)
 
 (**** Utilities for backtracking ****)

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -159,11 +159,11 @@ val forget_abbrev:
 
 val is_simple : arrow_flag -> bool
 val is_optional : arrow_flag -> bool
-val label_name : arrow_flag -> label
+val label_name : arrow_flag -> label option
 val label_raw : arrow_flag -> label
 
-val extract_label :
-    label -> (arrow_flag * 'a) list ->
+val extract_arg :
+    arrow_flag -> (arrow_flag * 'a) list ->
     arrow_flag * 'a * (arrow_flag * 'a) list * (arrow_flag * 'a) list
     (* actual label, value, before list, after list *)
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2240,7 +2240,7 @@ let unify_package env unify_list lv1 p1 n1 tl1 lv2 p2 n2 tl2 =
   let ntl2 = complete_type_list env n1 lv2 (Mty_ident p2) n2 tl2
   and ntl1 = complete_type_list env n2 lv2 (Mty_ident p1) n1 tl1 in
   unify_list (List.map snd ntl1) (List.map snd ntl2);
-  if eq_package_path env p1 p2 
+  if eq_package_path env p1 p2
   || !package_subtype env p1 n1 tl1 p2 n2 tl2
   && !package_subtype env p2 n2 tl2 p1 n1 tl1 then () else raise Not_found
 
@@ -2776,7 +2776,7 @@ let filter_arrow env t l =
       link_type t t';
       (t1, t2)
   | Tarrow(l', t1, t2, _)
-    when l = l' || !Clflags.classic && l = "" && not (is_optional l') ->
+    when l = l' || !Clflags.classic && is_simple l && not (is_optional l') ->
       (t1, t2)
   | _ ->
       raise (Unify [])
@@ -3584,7 +3584,7 @@ let match_class_declarations env patt_params patt_type subj_params subj_type =
         (* Use moregeneral for class parameters, need to recheck everything to
            keeps relationships (PR#4824) *)
         let clty_params =
-          List.fold_right (fun ty cty -> Cty_arrow ("*",ty,cty)) in
+          List.fold_right (fun ty cty -> Cty_arrow (Labelled "*",ty,cty)) in
         match_class_types ~trace:false env
           (clty_params patt_params patt_type)
           (clty_params subj_params subj_type)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -161,7 +161,7 @@ val unify_gadt: newtype_level:int -> Env.t ref -> type_expr -> type_expr -> unit
 val unify_var: Env.t -> type_expr -> type_expr -> unit
         (* Same as [unify], but allow free univars when first type
            is a variable. *)
-val filter_arrow: Env.t -> type_expr -> label -> type_expr * type_expr
+val filter_arrow: Env.t -> type_expr -> arrow_flag -> type_expr * type_expr
         (* A special case of unification (with l:'a -> 'b). *)
 val filter_method: Env.t -> string -> private_flag -> type_expr -> type_expr
         (* A special case of unification (with {m : 'a; 'b}). *)

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -136,6 +136,11 @@ let string_loc i ppf s = line i ppf "\"%s\"\n" s.txt;;
 let bool i ppf x = line i ppf "%s\n" (string_of_bool x);;
 let label i ppf x = line i ppf "label=\"%s\"\n" x;;
 
+let arrow_flag f = function
+  | Simple -> fprintf f ""
+  | Optional s -> fprintf f "?%s" s
+  | Labelled s -> fprintf f "%s" s
+
 let attributes i ppf l =
   let i = i + 1 in
   List.iter
@@ -153,8 +158,7 @@ let rec core_type i ppf x =
   | Ttyp_any -> line i ppf "Ptyp_any\n";
   | Ttyp_var (s) -> line i ppf "Ptyp_var %s\n" s;
   | Ttyp_arrow (l, ct1, ct2) ->
-      line i ppf "Ptyp_arrow\n";
-      string i ppf l;
+      line i ppf "Ptyp_arrow \"%a\"\n" arrow_flag l;
       core_type i ppf ct1;
       core_type i ppf ct2;
   | Ttyp_tuple l ->
@@ -281,7 +285,7 @@ and expression i ppf x =
       list i value_binding ppf l;
       expression i ppf e;
   | Texp_function (p, l, _partial) ->
-      line i ppf "Pexp_function \"%s\"\n" p;
+      line i ppf "Pexp_function \"%a\"\n" arrow_flag p;
 (*      option i expression ppf eo; *)
       list i case ppf l;
   | Texp_apply (e, l) ->
@@ -421,7 +425,7 @@ and class_type i ppf x =
       line i ppf "Pcty_signature\n";
       class_signature i ppf cs;
   | Tcty_arrow (l, co, cl) ->
-      line i ppf "Pcty_arrow \"%s\"\n" l;
+      line i ppf "Pcty_arrow \"%a\"\n" arrow_flag l;
       core_type i ppf co;
       class_type i ppf cl;
 
@@ -789,7 +793,7 @@ and longident_x_expression i ppf (li, _, e) =
   expression (i+1) ppf e;
 
 and label_x_expression i ppf (l, e, _) =
-  line i ppf "<label> \"%s\"\n" l;
+  line i ppf "<label> \"%a\"\n" arrow_flag l;
   (match e with None -> () | Some e -> expression (i+1) ppf e)
 
 and ident_x_loc_x_expression_def i ppf (l,_, e) =

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -983,8 +983,7 @@ and class_expr cl_num val_env met_env scl =
         match ty_fun, ty_fun0 with
         | Cty_arrow (l, ty, ty_fun), Cty_arrow (_, ty0, ty_fun0)
           when sargs <> [] || more_sargs <> [] ->
-            let name = Btype.label_name l
-            and optional =
+            let optional =
               if Btype.is_optional l then Optional else Required in
             let sargs, more_sargs, arg =
               if ignore_labels && not (Btype.is_optional l) then begin
@@ -1003,11 +1002,11 @@ and class_expr cl_num val_env met_env scl =
                 let (l', sarg0, sargs, more_sargs) =
                   try
                     let (l', sarg0, sargs1, sargs2) =
-                      Btype.extract_label name sargs
+                      Btype.extract_arg l sargs
                     in (l', sarg0, sargs1 @ sargs2, more_sargs)
                   with Not_found ->
                     let (l', sarg0, sargs1, sargs2) =
-                      Btype.extract_label name more_sargs
+                      Btype.extract_arg l more_sargs
                     in (l', sarg0, sargs @ sargs1, sargs2)
                 in
                 if optional = Required && Btype.is_optional l' then

--- a/typing/typeclass.mli
+++ b/typing/typeclass.mli
@@ -81,7 +81,7 @@ type error =
   | Field_type_mismatch of string * string * (type_expr * type_expr) list
   | Structure_expected of class_type
   | Cannot_apply of class_type
-  | Apply_wrong_label of label
+  | Apply_wrong_label of arrow_flag
   | Pattern_type_clash of type_expr
   | Repeated_parameter
   | Unbound_class_2 of Longident.t

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3121,8 +3121,7 @@ and type_application env funct sargs =
             Location.prerr_warning loc w
           end
         in
-        let name = label_name l
-        and optional = if is_optional l then Optional else Required in
+        let optional = if is_optional l then Optional else Required in
         let sargs, more_sargs, arg =
           if ignore_labels && not (is_optional l) then begin
             (* In classic mode, omitted = [] *)
@@ -3142,14 +3141,14 @@ and type_application env funct sargs =
           end else try
             let (l', sarg0, sargs, more_sargs) =
               try
-                let (l', sarg0, sargs1, sargs2) = extract_label name sargs in
+                let (l', sarg0, sargs1, sargs2) = extract_arg l sargs in
                 if sargs1 <> [] then
                   may_warn sarg0.pexp_loc
                     (Warnings.Not_principal "commuting this argument");
                 (l', sarg0, sargs1 @ sargs2, more_sargs)
               with Not_found ->
                 let (l', sarg0, sargs1, sargs2) =
-                  extract_label name more_sargs in
+                  extract_arg l more_sargs in
                 if sargs1 <> [] || sargs <> [] then
                   may_warn sarg0.pexp_loc
                     (Warnings.Not_principal "commuting this argument");

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -30,7 +30,7 @@ type error =
   | Orpat_vars of Ident.t
   | Expr_type_clash of (type_expr * type_expr) list
   | Apply_non_function of type_expr
-  | Apply_wrong_label of label * type_expr
+  | Apply_wrong_label of arrow_flag * type_expr
   | Label_multiply_defined of string
   | Label_missing of Ident.t list
   | Label_not_mutable of Longident.t
@@ -52,7 +52,7 @@ type error =
   | Coercion_failure of
       type_expr * type_expr * (type_expr * type_expr) list * bool
   | Too_many_arguments of bool * type_expr
-  | Abstract_wrong_label of label * type_expr
+  | Abstract_wrong_label of arrow_flag * type_expr
   | Scoping_let_module of string * type_expr
   | Masked_instance_variable of Longident.t
   | Not_a_variant_type of Longident.t
@@ -1461,7 +1461,7 @@ external format_to_string :
 
 let type_format loc fmt =
 
-  let ty_arrow gty ty = newty (Tarrow ("", instance_def gty, ty, Cok)) in
+  let ty_arrow gty ty = newty (Tarrow (Simple, instance_def gty, ty, Cok)) in
 
   let bad_conversion fmt i c =
     raise (Error (loc, Env.empty, Bad_conversion (fmt, i, c))) in
@@ -1657,7 +1657,8 @@ let type_format loc fmt =
 let rec approx_type env sty =
   match sty.ptyp_desc with
     Ptyp_arrow (p, _, sty) ->
-      let ty1 = if is_optional p then type_option (newvar ()) else newvar () in
+      let ty1 = newvar () in
+      let ty1 = if is_optional p then type_option ty1 else ty1 in
       newty (Tarrow (p, ty1, approx_type env sty, Cok))
   | Ptyp_tuple args ->
       newty (Ttuple (List.map (approx_type env) args))
@@ -1681,7 +1682,7 @@ let rec type_approx env sexp =
   | Pexp_fun (p,_,_, e) ->
        newty (Tarrow(p, newvar (), type_approx env e, Cok))
   | Pexp_function ({pc_rhs=e}::_) ->
-       newty (Tarrow("", newvar (), type_approx env e, Cok))
+       newty (Tarrow(Simple, newvar (), type_approx env e, Cok))
   | Pexp_match (_, {pc_rhs=e}::_) -> type_approx env e
   | Pexp_try (e, _) -> type_approx env e
   | Pexp_tuple l -> newty (Ttuple(List.map (type_approx env) l))
@@ -2046,7 +2047,7 @@ and type_expect_ ?in_function env sexp ty_expected =
         l [{pc_lhs=spat; pc_guard=None; pc_rhs=sexp}]
   | Pexp_function caselist ->
       type_function ?in_function
-        loc sexp.pexp_attributes env ty_expected "" caselist
+        loc sexp.pexp_attributes env ty_expected Simple caselist
   | Pexp_apply(sfunct, sargs) ->
       begin_def (); (* one more level for non-returning functions *)
       if !Clflags.principal then begin_def ();
@@ -2495,7 +2496,7 @@ and type_expect_ ?in_function env sexp ty_expected =
                     filter_self_method env met Private meths privty
                   in
                   let method_type = newvar () in
-                  let (obj_ty, res_ty) = filter_arrow env method_type "" in
+                  let (obj_ty, res_ty) = filter_arrow env method_type Simple in
                   unify env obj_ty desc.val_type;
                   unify env res_ty (instance env typ);
                   let exp =
@@ -2509,7 +2510,7 @@ and type_expect_ ?in_function env sexp ty_expected =
                                 exp_type = method_type;
                                 exp_attributes = []; (* check *)
                                 exp_env = env},
-                          ["",
+                          [Simple,
                             Some {exp_desc = Texp_ident(path, lid, desc);
                                   exp_loc = obj.exp_loc; exp_extra = [];
                                   exp_type = desc.val_type;
@@ -2949,7 +2950,7 @@ and type_argument env sarg ty_expected' ty_expected =
   (* ty_expected' may be generic *)
   let no_labels ty =
     let ls, tvar = list_labels env ty in
-    not tvar && List.for_all ((=) "") ls
+    not tvar && List.for_all is_simple ls
   in
   let rec is_inferred sexp =
     match sexp.pexp_desc with
@@ -2958,7 +2959,7 @@ and type_argument env sarg ty_expected' ty_expected =
     | _ -> false
   in
   match expand_head env ty_expected' with
-    {desc = Tarrow("",ty_arg,ty_res,_); level = lv} when is_inferred sarg ->
+    {desc = Tarrow(Simple,ty_arg,ty_res,_); level = lv} when is_inferred sarg ->
       (* apply optional arguments when expected type is "" *)
       (* we must be very careful about not breaking the semantics *)
       if !Clflags.principal then begin_def ();
@@ -2972,7 +2973,7 @@ and type_argument env sarg ty_expected' ty_expected =
         | Tarrow (l,ty_arg,ty_fun,_) when is_optional l ->
             let ty = option_none (instance env ty_arg) sarg.pexp_loc in
             make_args ((l, Some ty, Optional) :: args) ty_fun
-        | Tarrow (l,_,ty_res',_) when l = "" || !Clflags.classic ->
+        | Tarrow (l,_,ty_res',_) when is_simple l || !Clflags.classic ->
             args, ty_fun, no_labels ty_res'
         | Tvar _ ->  args, ty_fun, false
         |  _ -> [], texp.exp_type, false
@@ -3008,10 +3009,10 @@ and type_argument env sarg ty_expected' ty_expected =
           {texp with exp_type = ty_res; exp_desc =
            Texp_apply
              (texp,
-              List.rev args @ ["", Some eta_var, Required])}
+              List.rev args @ [Simple, Some eta_var, Required])}
         in
         { texp with exp_type = ty_fun; exp_desc =
-          Texp_function("", [case eta_pat e], Total) }
+          Texp_function(Simple, [case eta_pat e], Total) }
       in
       if warn then Location.prerr_warning texp.exp_loc
           (Warnings.Without_principality "eliminated optional argument");
@@ -3042,7 +3043,7 @@ and type_application env funct sargs =
   let ignored = ref [] in
   let rec type_unknown_args
       (args :
-      (Asttypes.label * (unit -> Typedtree.expression) option *
+      (Asttypes.arrow_flag * (unit -> Typedtree.expression) option *
          Typedtree.optional) list)
     omitted ty_fun = function
       [] ->
@@ -3068,7 +3069,7 @@ and type_application env funct sargs =
               unify env ty_fun (newty (Tarrow(l1,t1,t2,Clink(ref Cunknown))));
               (t1, t2)
           | Tarrow (l,t1,t2,_) when l = l1
-            || !Clflags.classic && l1 = "" && not (is_optional l) ->
+            || !Clflags.classic && is_simple l1 && not (is_optional l) ->
               (t1, t2)
           | td ->
               let ty_fun =
@@ -3101,8 +3102,8 @@ and type_application env funct sargs =
       not tvar &&
       let labels = List.filter (fun l -> not (is_optional l)) ls in
       List.length labels = List.length sargs &&
-      List.for_all (fun (l,_) -> l = "") sargs &&
-      List.exists (fun l -> l <> "") labels &&
+      List.for_all (fun (l,_) -> is_simple l) sargs &&
+      List.exists (fun l -> not (is_simple l)) labels &&
       (Location.prerr_warning funct.exp_loc Warnings.Labels_omitted;
        true)
     end
@@ -3130,7 +3131,7 @@ and type_application env funct sargs =
                 raise(Error(sarg0.pexp_loc, env,
                             Apply_wrong_label(l', ty_old)))
             | _, (l', sarg0) :: more_sargs ->
-                if l <> l' && l' <> "" then
+                if l <> l' && not (is_simple l') then
                   raise(Error(sarg0.pexp_loc, env,
                               Apply_wrong_label(l', ty_fun')))
                 else
@@ -3156,7 +3157,7 @@ and type_application env funct sargs =
             in
             if optional = Required && is_optional l' then
               Location.prerr_warning sarg0.pexp_loc
-                (Warnings.Nonoptional_label l);
+                (Warnings.Nonoptional_label (Btype.label_raw l));
             sargs, more_sargs,
             if optional = Required || is_optional l' then
               Some (fun () -> type_argument env sarg0 ty ty0)
@@ -3170,7 +3171,7 @@ and type_application env funct sargs =
           with Not_found ->
             sargs, more_sargs,
             if optional = Optional &&
-              (List.mem_assoc "" sargs || List.mem_assoc "" more_sargs)
+              (List.mem_assoc Simple sargs || List.mem_assoc Simple more_sargs)
             then begin
               may_warn funct.exp_loc
                 (Warnings.Without_principality "eliminated optional argument");
@@ -3199,8 +3200,8 @@ and type_application env funct sargs =
   match funct.exp_desc, sargs with
     (* Special case for ignore: avoid discarding warning *)
     Texp_ident (_, _, {val_kind=Val_prim{Primitive.prim_name="%ignore"}}),
-    ["", sarg] ->
-      let ty_arg, ty_res = filter_arrow env (instance env funct.exp_type) "" in
+    [Simple, sarg] ->
+      let ty_arg, ty_res = filter_arrow env (instance env funct.exp_type) Simple in
       let exp = type_expect env sarg ty_arg in
       begin match (expand_head env exp.exp_type).desc with
       | Tarrow _ ->
@@ -3209,7 +3210,7 @@ and type_application env funct sargs =
           add_delayed_check (fun () -> check_application_result env false exp)
       | _ -> ()
       end;
-      (["", Some exp, Required], ty_res)
+      ([Simple, Some exp, Required], ty_res)
   | _ ->
       let ty = funct.exp_type in
       if ignore_labels then
@@ -3707,9 +3708,9 @@ let report_error env ppf = function
       end
   | Apply_wrong_label (l, ty) ->
       let print_label ppf = function
-        | "" -> fprintf ppf "without label"
-        | l ->
-            fprintf ppf "with label %s%s" (if is_optional l then "" else "~") l
+        | Simple -> fprintf ppf "without label"
+        | Optional s -> fprintf ppf "with label ?%s" s
+        | Labelled s -> fprintf ppf "with label ~%s" s
       in
       reset_and_mark_loops ty;
       fprintf ppf
@@ -3801,8 +3802,10 @@ let report_error env ppf = function
       end
   | Abstract_wrong_label (l, ty) ->
       let label_mark = function
-        | "" -> "but its first argument is not labelled"
-        |  l -> sprintf "but its first argument is labelled ~%s" l in
+        | Simple -> "but its first argument is not labelled"
+        | Labelled s | Optional s ->
+            sprintf "but its first argument is labelled ~%s" s
+      in
       reset_and_mark_loops ty;
       fprintf ppf "@[<v>@[<2>This function should have type@ %a@]@,%s@]"
       type_expr ty (label_mark l)

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -31,7 +31,7 @@ val type_let:
 val type_expression:
         Env.t -> Parsetree.expression -> Typedtree.expression
 val type_class_arg_pattern:
-        string -> Env.t -> Env.t -> label -> Parsetree.pattern ->
+        string -> Env.t -> Env.t -> arrow_flag -> Parsetree.pattern ->
         Typedtree.pattern * (Ident.t * string loc * Ident.t * type_expr) list *
         Env.t * Env.t
 val type_self_pattern:
@@ -72,7 +72,7 @@ type error =
   | Orpat_vars of Ident.t
   | Expr_type_clash of (type_expr * type_expr) list
   | Apply_non_function of type_expr
-  | Apply_wrong_label of label * type_expr
+  | Apply_wrong_label of arrow_flag * type_expr
   | Label_multiply_defined of string
   | Label_missing of Ident.t list
   | Label_not_mutable of Longident.t
@@ -94,7 +94,7 @@ type error =
   | Coercion_failure of
       type_expr * type_expr * (type_expr * type_expr) list * bool
   | Too_many_arguments of bool * type_expr
-  | Abstract_wrong_label of label * type_expr
+  | Abstract_wrong_label of arrow_flag * type_expr
   | Scoping_let_module of string * type_expr
   | Masked_instance_variable of Longident.t
   | Not_a_variant_type of Longident.t

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -74,8 +74,8 @@ and expression_desc =
     Texp_ident of Path.t * Longident.t loc * Types.value_description
   | Texp_constant of constant
   | Texp_let of rec_flag * value_binding list * expression
-  | Texp_function of label * case list * partial
-  | Texp_apply of expression * (label * expression option * optional) list
+  | Texp_function of arrow_flag * case list * partial
+  | Texp_apply of expression * (arrow_flag * expression option * optional) list
   | Texp_match of expression * case list * partial
   | Texp_try of expression * case list
   | Texp_tuple of expression list
@@ -131,10 +131,9 @@ and class_expr =
 and class_expr_desc =
     Tcl_ident of Path.t * Longident.t loc * core_type list
   | Tcl_structure of class_structure
-  | Tcl_fun of
-      label * pattern * (Ident.t * string loc * expression) list * class_expr *
-        partial
-  | Tcl_apply of class_expr * (label * expression option * optional) list
+  | Tcl_fun of arrow_flag * pattern * (Ident.t * string loc * expression) list
+               * class_expr * partial
+  | Tcl_apply of class_expr * (arrow_flag * expression option * optional) list
   | Tcl_let of rec_flag * value_binding list *
                   (Ident.t * string loc * expression) list * class_expr
   | Tcl_constraint of
@@ -322,7 +321,7 @@ and core_type =
 and core_type_desc =
     Ttyp_any
   | Ttyp_var of string
-  | Ttyp_arrow of label * core_type * core_type
+  | Ttyp_arrow of arrow_flag * core_type * core_type
   | Ttyp_tuple of core_type list
   | Ttyp_constr of Path.t * Longident.t loc * core_type list
   | Ttyp_object of (string * core_type) list * closed_flag
@@ -403,7 +402,7 @@ and class_type =
 and class_type_desc =
     Tcty_constr of Path.t * Longident.t loc * core_type list
   | Tcty_signature of class_signature
-  | Tcty_arrow of label * core_type * class_type
+  | Tcty_arrow of arrow_flag * core_type * class_type
 
 and class_signature = {
     csig_self : core_type;

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -73,8 +73,8 @@ and expression_desc =
     Texp_ident of Path.t * Longident.t loc * Types.value_description
   | Texp_constant of constant
   | Texp_let of rec_flag * value_binding list * expression
-  | Texp_function of label * case list * partial
-  | Texp_apply of expression * (label * expression option * optional) list
+  | Texp_function of arrow_flag * case list * partial
+  | Texp_apply of expression * (arrow_flag * expression option * optional) list
   | Texp_match of expression * case list * partial
   | Texp_try of expression * case list
   | Texp_tuple of expression list
@@ -130,10 +130,9 @@ and class_expr =
 and class_expr_desc =
     Tcl_ident of Path.t * Longident.t loc * core_type list
   | Tcl_structure of class_structure
-  | Tcl_fun of
-      label * pattern * (Ident.t * string loc * expression) list * class_expr *
-        partial
-  | Tcl_apply of class_expr * (label * expression option * optional) list
+  | Tcl_fun of arrow_flag * pattern * (Ident.t * string loc * expression) list
+               * class_expr * partial
+  | Tcl_apply of class_expr * (arrow_flag * expression option * optional) list
   | Tcl_let of rec_flag * value_binding list *
                   (Ident.t * string loc * expression) list * class_expr
   | Tcl_constraint of
@@ -320,7 +319,7 @@ and core_type =
 and core_type_desc =
     Ttyp_any
   | Ttyp_var of string
-  | Ttyp_arrow of label * core_type * core_type
+  | Ttyp_arrow of arrow_flag * core_type * core_type
   | Ttyp_tuple of core_type list
   | Ttyp_constr of Path.t * Longident.t loc * core_type list
   | Ttyp_object of (string * core_type) list * closed_flag
@@ -402,7 +401,7 @@ and class_type =
 and class_type_desc =
     Tcty_constr of Path.t * Longident.t loc * core_type list
   | Tcty_signature of class_signature
-  | Tcty_arrow of label * core_type * class_type
+  | Tcty_arrow of arrow_flag * core_type * class_type
 
 and class_signature = {
     csig_self : core_type;

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -23,7 +23,7 @@ type type_expr =
 
 and type_desc =
     Tvar of string option
-  | Tarrow of label * type_expr * type_expr * commutable
+  | Tarrow of arrow_flag * type_expr * type_expr * commutable
   | Ttuple of type_expr list
   | Tconstr of Path.t * type_expr list * abbrev_memo ref
   | Tobject of type_expr * (Path.t * type_expr list) option ref
@@ -231,7 +231,7 @@ module Concr = Set.Make(OrderedString)
 type class_type =
     Cty_constr of Path.t * type_expr list * class_type
   | Cty_signature of class_signature
-  | Cty_arrow of label * type_expr * class_type
+  | Cty_arrow of arrow_flag * type_expr * class_type
 
 and class_signature =
   { csig_self: type_expr;

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -23,7 +23,7 @@ type type_expr =
 
 and type_desc =
     Tvar of string option
-  | Tarrow of label * type_expr * type_expr * commutable
+  | Tarrow of arrow_flag * type_expr * type_expr * commutable
   | Ttuple of type_expr list
   | Tconstr of Path.t * type_expr list * abbrev_memo ref
   | Tobject of type_expr * (Path.t * type_expr list) option ref
@@ -218,7 +218,7 @@ module Concr : Set.S with type elt = string
 type class_type =
     Cty_constr of Path.t * type_expr list * class_type
   | Cty_signature of class_signature
-  | Cty_arrow of label * type_expr * class_type
+  | Cty_arrow of arrow_flag * type_expr * class_type
 
 and class_signature =
   { csig_self: type_expr;


### PR DESCRIPTION
This commit introduce the type `arrow_flag` in place of `string` to represent labelled arguments.

Previously, labelled arguments where encoded as a string tagging the left hand-side of an arrow type:
"" is the absence of label, "?ident" for optional arguments, "ident" for labelled arguments.

The `arrow_flag` variant now brings more structure to function arguments.
The purpose is two fold: offers a proper encoding of labels rather than relying on string processing, and ease further extensions of arrow lhs.
