### PR TITLE
PR#4518: change location format for reporting errors in ocamldoc

### DIFF
--- a/Changes
+++ b/Changes
@@ -102,7 +102,7 @@ Compilers:
 - GPR#270: Make [transl_exception_constructor] generate [Immutable] blocks
   (Mark Shinwell)
 - GPR#275: native-code generator for IBM z System running Linux.
-  In memoriam Gene Amdahl, 1922-2015. 
+  In memoriam Gene Amdahl, 1922-2015.
   (Bill O'Farrell, Tristan Amini, Xavier Leroy)
 - GPR#282: relax short-paths safety check in presence of module aliases, take
   penalty into account while building the printing map.
@@ -319,6 +319,8 @@ Bug fixes:
   (Marc Lasson, review by Alain Frisch)
 
 Features wishes:
+- PR#4518, GPR#29: change location format for reporting errors in ocamldoc
+  (Sergei Lebedev)
 - PR#4714: List.cons
 - PR#5418 (comments) : generate dependencies with $(CC) instead of gcc
 - PR#6167: OCAMLPARAM support for disabling PIC generation ("pic=0")

--- a/ocamldoc/odoc_messages.ml
+++ b/ocamldoc/odoc_messages.ml
@@ -233,6 +233,9 @@ let help = " Display this list of options"
 
 let warning = "Warning"
 
+let error_location file l c =
+  Printf.sprintf "File \"%s\", line %d, character %d:\n" file l c
+
 let bad_magic_number =
   "Bad magic number for this ocamldoc dump!\n"^
   "This dump was not created by this version of OCamldoc."
@@ -244,10 +247,7 @@ let errors_occured n = (string_of_int n)^" error(s) encountered"
 let parse_error = "Parse error"
 let text_parse_error l c s =
   let lines = Str.split (Str.regexp_string "\n") s in
-  "Syntax error in text:\n"^s^"\n"^
-  "line "^(string_of_int l)^", character "^(string_of_int c)^":\n"^
-  (List.nth lines l)^"\n"^
-  (String.make c ' ')^"^"
+  (List.nth lines l) ^ "\n" ^ (String.make c ' ') ^ "^"
 
 let file_not_found_in_paths paths name =
   Printf.sprintf "No file %s found in the load paths: \n%s"


### PR DESCRIPTION
As [requested](http://caml.inria.fr/mantis/view.php?id=4518) by @dbuenzli, I've changed ocamldoc location format to:

```
File "src/xmlm.mli", line 3, character 39:
```

However, there's a couple of issues worth discussing:
1. Warnings currently don't have any location information, e.g. the following results in "Warning: Element `some_error` not found".
   
   ``` ocaml
   (** {b Raises {!some_error} on input errors}. *)
   ```
2. Parse errors might be reported twice. For instance, if we remove the closing bracket in the example above
   
   ``` ocaml
   (** {b Raises {!some_error} on input errors. *)
   ```
   
   we'll see
   
   ```
   File "./test.mli", line 0, character 40:
   {b Raises {!some_error} on input errors.
                                           ^
   File "./test.mli", line 0, character 40:
   {b Raises {!some_error} on input errors.
                                           ^
   2 error(s) encountered
   ```
   
   This happens because the module is processed in two steps:
   - First ocamldoc tries to [extract](https://github.com/ocaml/ocaml/blob/trunk/ocamldoc/odoc_comments.mli#L45) the first special comment in the module, returning its `length` for further analysis.
   - Then ocamldoc parses all of the remaining special comments, using `length`, obtained in the previous step, as a starting position for parsing.
   
   So, if the first step fails with a parse error, `length` [is assumed](https://github.com/ocaml/ocaml/blob/trunk/ocamldoc/odoc_comments.ml#L42) to be `0`. Thus, the second step starts with the beginning of the file and yields the same parse error. 
