### PR TITLE
Add nocmx option to generate empty cmx files

### DIFF
--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -1291,6 +1291,8 @@ let intro size lam =
   global_approx := Array.init size (fun i -> Value_global_field (id, i));
   Compilenv.set_global_approx(Value_tuple !global_approx);
   let (ulam, approx) = close Tbl.empty Tbl.empty lam in
-  collect_exported_structured_constants (Value_tuple !global_approx);
+  if !Clflags.opaque
+  then Compilenv.set_global_approx(Value_unknown)
+  else collect_exported_structured_constants (Value_tuple !global_approx);
   global_approx := [||];
   ulam

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -446,6 +446,12 @@ let mk_dstartup f =
   "-dstartup", Arg.Unit f, " (undocumented)"
 ;;
 
+let mk_opaque f =
+  "-opaque", Arg.Unit f,
+  " Does not generate cross-module optimization information\n\
+  \     (reduces necessary recompilation on module change)"
+;;
+
 let mk__ f =
   "-", Arg.String f,
   "<file>  Treat <file> as a file name (even if it starts with `-')"
@@ -515,7 +521,6 @@ module type Compiler_options =  sig
   val _v : unit -> unit
   val _verbose : unit -> unit
   val _where : unit -> unit
-
   val _nopervasives : unit -> unit
 end
 ;;
@@ -578,6 +583,7 @@ module type Optcomp_options = sig
   val _pp : string -> unit
   val _S : unit -> unit
   val _shared : unit -> unit
+  val _opaque :  unit -> unit
 end;;
 
 module type Opttop_options = sig
@@ -794,6 +800,7 @@ struct
     mk_dscheduling F._dscheduling;
     mk_dlinear F._dlinear;
     mk_dstartup F._dstartup;
+    mk_opaque F._opaque;
   ]
 end;;
 

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -137,6 +137,7 @@ module type Optcomp_options = sig
   val _pp : string -> unit
   val _S : unit -> unit
   val _shared : unit -> unit
+  val _opaque :  unit -> unit
 end;;
 
 module type Opttop_options = sig

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -149,6 +149,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _dscheduling = set dump_scheduling
   let _dlinear = set dump_linear
   let _dstartup = set keep_startup_file
+  let _opaque = set opaque
 
   let anonymous = anonymous
 end);;

--- a/tools/ocamloptp.ml
+++ b/tools/ocamloptp.ml
@@ -120,6 +120,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _dscheduling = option "-dscheduling"
   let _dlinear = option "-dlinear"
   let _dstartup = option "-dstartup"
+  let _opaque = option "-opaque"
 
   let anonymous = process_file
 end);;

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -71,6 +71,7 @@ and dump_instr = ref false              (* -dinstr *)
 
 let keep_asm_file = ref false           (* -S *)
 let optimize_for_speed = ref true       (* -compact *)
+and opaque = ref false                  (* -opaque *)
 
 and dump_cmm = ref false                (* -dcmm *)
 let dump_selection = ref false          (* -dsel *)
@@ -86,7 +87,6 @@ let dump_scheduling = ref false         (* -dscheduling *)
 let dump_linear = ref false             (* -dlinear *)
 let keep_startup_file = ref false       (* -dstartup *)
 let dump_combine = ref false            (* -dcombine *)
-
 let native_code = ref false             (* set to true under ocamlopt *)
 let inline_threshold = ref 10
 let force_slash = ref false             (* for ocamldep *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -92,3 +92,4 @@ val runtime_variant : string ref
 val force_slash : bool ref
 val keep_locs : bool ref
 val unsafe_string : bool ref
+val opaque : bool ref


### PR DESCRIPTION
The intent of this option is to enable semi-separate _native_ compilation. Currently, when a module changes, all the modules that depend on it need to be recompiled. Activating `-nocmx` disables cross-module optimization, but should let us change a module without having to recompile all the others (although to be honest this still have to be verified).

This would be of practical value for development cycles of project that have (compile;test) loops: currently compilation is much slower in native code than in bytecode, but tests can be sensibly faster in native code. `-nocmx` could bring the best of both worlds, with fast compiles and rather-fast tests.
