### PR TITLE
Added comments to parsetree.mli

### DIFF
--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -17,12 +17,15 @@ open Asttypes
 (** {2 Extension points} *)
 
 type attribute = string loc * payload
-      (* [@id ARG]
+       (* Metadata containers passed around within the AST.
+        * The compiler ignores unknown attributes.
+         [@id ARG]
          [@@id ARG]
        *)
 
 and extension = string loc * payload
-      (* [%id ARG]
+      (* Sub-language placeholder -- rejected by the typechecker.
+         [%id ARG]
          [%%id ARG]
        *)
 
@@ -111,10 +114,13 @@ and package_type = Longident.t loc * (Longident.t loc * core_type) list
 
 and row_field =
   | Rtag of label * bool * core_type list
-        (* [`A]                   ( true,  [] )
+        (* true: contains a constant (i.e. empty) constructor
+           [`A]                   ( true,  [] )
            [`A of T]              ( false, [T] )
            [`A of T1 & .. & Tn]   ( false, [T1;...Tn] )
            [`A of & T1 & .. & Tn] ( true,  [T1;...Tn] )
+           '&' occurs when several types are used for the same constructor 
+             (see 4.2 in the manual)
          *)
   | Rinherit of core_type
         (* [ T ] *)
@@ -682,7 +688,8 @@ and structure_item_desc =
   | Pstr_modtype of module_type_declaration
         (* module type S = MT *)
   | Pstr_open of override_flag * Longident.t loc * attributes
-        (* open X *)
+        (* open! X - true (silence 'used identifier shadowing' warning)
+           open  X - false *)
   | Pstr_class of class_declaration list
         (* class c1 = ... and ... and cn = ... *)
   | Pstr_class_type of class_type_declaration list
@@ -719,6 +726,7 @@ and module_binding =
 type toplevel_phrase =
   | Ptop_def of structure
   | Ptop_dir of string * directive_argument
+     (* #use, #load ... *)
 
 and directive_argument =
   | Pdir_none

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -17,16 +17,18 @@ open Asttypes
 (** {2 Extension points} *)
 
 type attribute = string loc * payload
-       (* Metadata containers passed around within the AST.
-        * The compiler ignores unknown attributes.
-         [@id ARG]
-         [@@id ARG]
+       (* [@id ARG]
+          [@@id ARG]
+
+          Metadata containers passed around within the AST.
+          The compiler ignores unknown attributes.
        *)
 
 and extension = string loc * payload
-      (* Sub-language placeholder -- rejected by the typechecker.
-         [%id ARG]
+      (* [%id ARG]
          [%%id ARG]
+
+         Sub-language placeholder -- rejected by the typechecker.
        *)
 
 and attributes = attribute list
@@ -114,11 +116,13 @@ and package_type = Longident.t loc * (Longident.t loc * core_type) list
 
 and row_field =
   | Rtag of label * bool * core_type list
-        (* true: contains a constant (i.e. empty) constructor
-           [`A]                   ( true,  [] )
+        (* [`A]                   ( true,  [] )
            [`A of T]              ( false, [T] )
            [`A of T1 & .. & Tn]   ( false, [T1;...Tn] )
            [`A of & T1 & .. & Tn] ( true,  [T1;...Tn] )
+
+           The 2nd field is true if the tag contains a 
+             constant (empty) constructor.
            '&' occurs when several types are used for the same constructor 
              (see 4.2 in the manual)
          *)
@@ -688,8 +692,11 @@ and structure_item_desc =
   | Pstr_modtype of module_type_declaration
         (* module type S = MT *)
   | Pstr_open of override_flag * Longident.t loc * attributes
-        (* open! X - true (silence 'used identifier shadowing' warning)
-           open  X - false *)
+        (* open! X - true 
+           open  X - false 
+
+           override_flag silences the 'used identifier shadowing' warning
+           *)
   | Pstr_class of class_declaration list
         (* class c1 = ... and ... and cn = ... *)
   | Pstr_class_type of class_type_declaration list

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -29,7 +29,7 @@ and extension = string loc * payload
          [%%id ARG]
 
          Sub-language placeholder -- rejected by the typechecker.
-       *)
+      *)
 
 and attributes = attribute list
 
@@ -121,11 +121,11 @@ and row_field =
            [`A of T1 & .. & Tn]   ( false, [T1;...Tn] )
            [`A of & T1 & .. & Tn] ( true,  [T1;...Tn] )
 
-           The 2nd field is true if the tag contains a 
-             constant (empty) constructor.
-           '&' occurs when several types are used for the same constructor 
-             (see 4.2 in the manual)
-         *)
+          - The 2nd field is true if the tag contains a
+            constant (empty) constructor.
+          - '&' occurs when several types are used for the same constructor
+            (see 4.2 in the manual)
+        *)
   | Rinherit of core_type
         (* [ T ] *)
 
@@ -692,8 +692,8 @@ and structure_item_desc =
   | Pstr_modtype of module_type_declaration
         (* module type S = MT *)
   | Pstr_open of override_flag * Longident.t loc * attributes
-        (* open! X - true 
-           open  X - false 
+        (* open! X - true
+           open  X - false
 
            override_flag silences the 'used identifier shadowing' warning
            *)


### PR DESCRIPTION
Specifically, I documented some more obscure features that weren't obvious from reading the existing comments.
Discussion of these comments can be found on the mailing list at https://sympa.inria.fr/sympa/arc/caml-list/2014-04/msg00022.html
