### PR TITLE
parser.mly: minor mistake in position of a symbol

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1157,7 +1157,7 @@ expr:
   | OBJECT ext_attributes class_structure END
       { mkexp_attrs (Pexp_object $3) $2 }
   | OBJECT ext_attributes class_structure error
-      { unclosed "object" 1 "end" 3 }
+      { unclosed "object" 1 "end" 4 }
   | expr attribute
       { Exp.attr $1 $2 }
 ;


### PR DESCRIPTION
This is not even a bug, just a behavior that differs from the rest of the code: usually in error productions, reported messages refers to the position of the error token. This is not the case here.
