### PR TITLE
Hashtbl doc example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -723,6 +723,12 @@ ocamldoc: ocamlc ocamlyacc ocamllex otherlibraries
 ocamldoc.opt: ocamlc.opt ocamlyacc ocamllex
 	cd ocamldoc && $(MAKE) opt.opt
 
+# Documentation
+
+html_doc: ocamldoc
+	make -C ocamldoc html_doc
+	@echo "documentation is in ./ocamldoc/stdlib_html/"
+
 partialclean::
 	cd ocamldoc && $(MAKE) clean
 

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -181,6 +181,7 @@ $(OCAMLDOC_LIBCMXA): $(LIBCMXFILES)
 	$(OCAMLOPT) -a -o $@ $(LINKFLAGS)	$(OCAMLSRCDIR)/tools/depend.cmx $(LIBCMXFILES)
 
 manpages: stdlib_man/Pervasives.3o
+html_doc: stdlib_html/Pervasives.html
 
 dot: $(EXECMOFILES)
 	$(OCAMLDOC_RUN) -dot -dot-reduce -o ocamldoc.dot $(INCLUDES) \
@@ -305,6 +306,13 @@ stdlib_man/Pervasives.3o: $(STDLIB_MLIS)
 	$(OCAMLDOC_RUN) -man -d stdlib_man $(INCLUDES) \
 	-t "OCaml library" -man-mini \
 	$(STDLIB_MLIS)
+
+stdlib_html/Pervasives.html: $(STDLIB_MLIS)
+	$(MKDIR) stdlib_html
+	$(OCAMLDOC_RUN) -d stdlib_html -html $(INCLUDES) \
+	-t "OCaml library" \
+	$(STDLIB_MLIS)
+
 
 autotest_stdlib: dummy
 	$(MKDIR) $@

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -187,6 +187,27 @@ val stats : ('a, 'b) t -> statistics
 
 (** {6 Functorial interface} *)
 
+(** The functorial interface allows to use specific comparison
+    and hash functions, either for performance/security concerns,
+    or because keys are not hashable/comparable with the polymorphic builtins.
+
+    For instance, one might want to specialize a table for integer keys:
+    {[
+      module IntHash =
+        struct
+          type t = int
+          let equal i j = i=j
+          let hash i = i land max_int
+        end
+
+      module IntHashtbl = Hashtbl.Make(IntHash)
+
+      let h = IntHashtbl.create 17 in
+      IntHashtbl.add h 12 "hello";;  (* works *)
+
+      let h' = IntHashtbl.create 17 in
+      IntHashtbl.add h false "world";; (* won't typecheck *)
+    ]} *)
 
 module type HashedType =
   sig


### PR DESCRIPTION
Some beginner on #ocaml had trouble understanding what `Hashtbl.Make` was, why it was useful, and how to use it, so here is an example in the documentation.

I also added a Makefile target to build the documentation of the stdlib in html.
