### PR TITLE
Native code configuration on FreeBSD10

### DIFF
--- a/configure
+++ b/configure
@@ -889,10 +889,7 @@ case "$arch,$system" in
                     *) aspp="${TOOLPREF}as -P";;
                   esac;;
   *,freebsd)      as="${TOOLPREF}as"
-                  case "$cc" in
-                    *gcc*) aspp="${TOOLPREF}gcc -c";; # freebsd<10 or gcc
-                    *) aspp="${TOOLPREF}cc -c";;      # freebsd10 and clang
-                  esac;;
+                  aspp="${TOOLPREF}cc -c";;
   amd64,*|arm,*|arm64,*|i386,*|power,bsd*|sparc,*)
                   as="${TOOLPREF}as"
                   aspp="${TOOLPREF}gcc -c";;

--- a/configure
+++ b/configure
@@ -886,7 +886,12 @@ case "$arch,$system" in
   sparc,solaris)  as="${TOOLPREF}as"
                   case "$cc" in
                     *gcc*) aspp="${TOOLPREF}gcc -c";;
-                              *) aspp="${TOOLPREF}as -P";;
+                    *) aspp="${TOOLPREF}as -P";;
+                  esac;;
+  *,freebsd)      as="${TOOLPREF}as"
+                  case "$cc" in
+                    *gcc*) aspp="${TOOLPREF}gcc -c";; # freebsd<10 or gcc
+                    *) aspp="${TOOLPREF}cc -c";;      # freebsd10 and clang
                   esac;;
   amd64,*|arm,*|arm64,*|i386,*|power,bsd*|sparc,*)
                   as="${TOOLPREF}as"


### PR DESCRIPTION
Use 'as=as', 'aspp=cc -c'.  If 'cc=gcc' then use previous defaults.  

Tested on x86_64 versions of FreeBSD10 and FreeBSD9.2.
