### PR TITLE
Short functor type syntax

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -823,8 +823,13 @@ module_type:
       { unclosed "sig" 1 "end" 3 }
   | FUNCTOR functor_args MINUSGREATER module_type
       %prec below_WITH
-      { List.fold_left (fun acc (n, t) -> mkmty(Pmty_functor(n, t, acc)))
-                       $4 $2 }
+      { List.fold_left
+          (fun acc (n, t) ->
+           mkmty(Pmty_functor(n, t, acc)))
+        $4 $2 }
+  | module_type MINUSGREATER module_type
+      %prec below_WITH
+      { mkmty(Pmty_functor(mknoloc "_", Some $1, $3)) }
   | module_type WITH with_constraints
       { mkmty(Pmty_with($1, List.rev $3)) }
   | MODULE TYPE OF module_expr %prec below_LBRACKETAT
@@ -2009,7 +2014,7 @@ core_type:
       { Typ.attr $1 $2 }
 ;
 core_type_no_attr:
-    core_type2
+    core_type2 %prec MINUSGREATER
       { $1 }
   | core_type2 AS QUOTE ident
       { mktyp(Ptyp_alias($1, $4)) }

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -915,8 +915,12 @@ class printer  ()= object(self:'self)
     | Pmty_functor (_, None, mt2) ->
         pp f "@[<hov2>functor () ->@ %a@]" self#module_type mt2
     | Pmty_functor (s, Some mt1, mt2) ->
-        pp f "@[<hov2>functor@ (%s@ :@ %a)@ ->@ %a@]" s.txt
-          self#module_type mt1  self#module_type mt2
+        if s.txt = "_" then
+          pp f "@[<hov2>%a@ ->@ %a@]"
+             self#module_type mt1  self#module_type mt2
+        else
+          pp f "@[<hov2>functor@ (%s@ :@ %a)@ ->@ %a@]" s.txt
+             self#module_type mt1  self#module_type mt2
     | Pmty_with (mt, l) ->
         let with_constraint f = function
           | Pwith_type (li, ({ptype_params= ls ;_} as td)) ->

--- a/testsuite/tests/typing-modules/generative.ml.reference
+++ b/testsuite/tests/typing-modules/generative.ml.reference
@@ -39,6 +39,6 @@ Error: Signature mismatch:
          functor (X : sig  end) -> sig  end
 #     module X : functor (X : sig  end) (Y : sig  end) (Z : sig  end) -> sig  end
 #   module Y : functor (X : sig  end) (Y : sig  end) (Z : sig  end) -> sig  end
-# module Z : functor (_ : sig  end) (_ : sig  end) (_ : sig  end) -> sig  end
+# module Z : sig  end -> sig  end -> sig  end -> sig  end
 #   module GZ : functor (X : sig  end) () (Z : sig  end) -> sig  end
 # 

--- a/testsuite/tests/typing-signatures/els.ml.reference
+++ b/testsuite/tests/typing-signatures/els.ml.reference
@@ -91,5 +91,5 @@
         USERCODE(TV).F
   end
 #   module type X = functor (X : CORE) -> BARECODE
-# module type X = functor (_ : CORE) -> BARECODE
+# module type X = CORE -> BARECODE
 # 


### PR DESCRIPTION
Add support for simple functor types of the form:

```
S -> T
```

equivalent to:

```
functor (_ : S) -> T
```

The `S` and `T` can be any module type expressions. 

While not actually ambiguous there is a potential shift-reduce conflict related to with constraints:

```
S with type t = int -> float
```

vs

```
S with type t = int -> T
```

This is resolved in favour of the first one (shift), meaning that the second type must be written:

```
(S with type t = int) -> T
```
