### PR TITLE
Native code support for armv6 on FreeBSD10

### DIFF
--- a/asmcomp/arm/arch.ml
+++ b/asmcomp/arm/arch.ml
@@ -21,7 +21,8 @@ type fpu = Soft | VFPv2 | VFPv3_D16 | VFPv3
 
 let abi =
   match Config.system with
-    "linux_eabi"   -> EABI
+    "linux_eabi" 
+  | "freebsd" -> EABI
   | "linux_eabihf" -> EABI_HF
   | _ -> assert false
 

--- a/asmrun/arm.S
+++ b/asmrun/arm.S
@@ -44,6 +44,15 @@
         cmp     \reg, #0
         beq     \lbl
         .endm
+#elif defined(SYS_freebsd)
+        .arch   armv6
+        .arm
+
+    /* Compatibility macros */
+        .macro  cbz reg, lbl
+        cmp     \reg, #0
+        beq     \lbl
+        .endm
 #endif
 
 trap_ptr        .req    r8

--- a/configure
+++ b/configure
@@ -765,6 +765,7 @@ if test $with_sharedlibs = "yes"; then
     x86_64-*-netbsd*)             natdynlink=true;;
     i386-*-gnu0.3)                natdynlink=true;;
     arm*-*-linux*)                natdynlink=true;;
+    arm*-*-freebsd*)              natdynlink=true;;
     aarch64-*-linux*)             natdynlink=true;;
   esac
 fi

--- a/configure
+++ b/configure
@@ -815,6 +815,7 @@ case "$target" in
   armv7*-*-linux-gnueabi)       arch=arm; model=armv7; system=linux_eabi;;
   armv6t2*-*-linux-gnueabi)     arch=arm; model=armv6t2; system=linux_eabi;;
   armv6*-*-linux-gnueabi)       arch=arm; model=armv6; system=linux_eabi;;
+  armv6*-*-freebsd*)            arch=arm; model=armv6; system=freebsd;;
   armv5te*-*-linux-gnueabi)     arch=arm; model=armv5te; system=linux_eabi;;
   armv5*-*-linux-gnueabi)       arch=arm; model=armv5; system=linux_eabi;;
   arm*-*-linux-gnueabi)         arch=arm; system=linux_eabi;;
@@ -888,6 +889,8 @@ case "$arch,$system" in
                     *gcc*) aspp="${TOOLPREF}gcc -c";;
                               *) aspp="${TOOLPREF}as -P";;
                   esac;;
+  arm,freebsd)    as="${TOOLPREF}cc -c"
+                  aspp="${TOOLPREF}cc -c";;
   amd64,*|arm,*|arm64,*|i386,*|power,bsd*|sparc,*)
                   as="${TOOLPREF}as"
                   aspp="${TOOLPREF}gcc -c";;


### PR DESCRIPTION
- configure accepts armv6/freebsd for native code compilation
- 'as' and 'aspp' map to 'cc -c'
- new section in arm.S to configure SYS_freebsd for armv6+softfp
- arch/arm.ml maps Sys.config="freebsd" to EABI

Tested on FreeBSD RELEASE/10 on Raspberry PI.
