### PR TITLE
Ocamlbuild: make log printing code tail-recursive

### DIFF
--- a/ocamlbuild/ocamlbuild_executor.ml
+++ b/ocamlbuild/ocamlbuild_executor.ml
@@ -63,18 +63,15 @@ let output_lines prefix oc buffer =
     output_char oc '\n'
   in
   let rec loop i =
-    if i = m then
-      ()
+    if i < m then
+      let j =
+        try String.index_from u i '\n'
+        with Not_found -> m
+      in
+      output_line i j;
+      loop (j + 1)
     else
-      begin
-        try
-          let j = String.index_from u i '\n' in
-          output_line i j;
-          loop (j + 1)
-        with
-        | Not_found ->
-            output_line i m
-      end
+      ()
   in
   loop 0
 ;;


### PR DESCRIPTION
When executing a command, ocamlbuild keeps the complete output in memory before writing to a log file.
The writing code is not tail-recursive, outputing too many lines can cause ocamlbuild to fail with "Exception Stack Overflow" message.

The proposed patch fix this (the output is still kept in memory).
