### PR TITLE
Allow static exception through trywith

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -575,8 +575,15 @@ let emit_instr fallthrough i =
         end
     | Llabel lbl ->
         `{emit_Llabel fallthrough lbl}:\n`
-    | Lbranch lbl ->
-        `	jmp	{emit_label lbl}\n`
+    | Lbranch (lbl,frame_offsets) ->
+        `	jmp	{emit_label lbl}\n`;
+        if frame_offsets <> 0
+        then begin
+          assert(frame_offsets > 0);
+          let n = frame_offsets * 16 in
+          cfi_adjust_cfa_offset n;
+          stack_offset := !stack_offset + n
+        end
     | Lcondbranch(tst, lbl) ->
         begin match tst with
           Itruetest ->

--- a/asmcomp/amd64/emit_nt.mlp
+++ b/asmcomp/amd64/emit_nt.mlp
@@ -565,8 +565,14 @@ let emit_instr fallthrough i =
         `	ret\n`
     | Llabel lbl ->
         `{emit_Llabel fallthrough lbl}:\n`
-    | Lbranch lbl ->
-        `	jmp	{emit_label lbl}\n`
+    | Lbranch (lbl,frame_offsets) ->
+        `	jmp	{emit_label lbl}\n`;
+        if frame_offsets <> 0
+        then begin
+          assert(frame_offsets > 0);
+          let n = frame_offsets * 16 in
+          stack_offset := !stack_offset - 16
+        end
     | Lcondbranch(tst, lbl) ->
         begin match tst with
           Itruetest ->

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -679,8 +679,16 @@ let emit_instr i =
         end
     | Llabel lbl ->
         `{emit_label lbl}:\n`; 0
-    | Lbranch lbl ->
-        `	b	{emit_label lbl}\n`; 1
+    | Lbranch (lbl,frame_offsets) ->
+        `	b	{emit_label lbl}\n`;
+        if frame_offsets <> 0
+        then begin
+          assert(frame_offsets > 0);
+          let n = frame_offsets * 8 in
+          cfi_adjust_cfa_offset n;
+          stack_offset := !stack_offset + n
+        end;
+        1
     | Lcondbranch(tst, lbl) ->
         begin match tst with
           Itruetest ->

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -520,8 +520,15 @@ let emit_instr i =
         output_epilogue (fun () -> `	ret\n`)
     | Llabel lbl ->
         `{emit_label lbl}:\n`
-    | Lbranch lbl ->
-        `	b	{emit_label lbl}\n`
+    | Lbranch (lbl,frame_offsets) ->
+        `	b	{emit_label lbl}\n`;
+        if frame_offsets <> 0
+        then begin
+          assert(frame_offsets > 0);
+          let n = frame_offsets * 16 in
+          cfi_adjust_cfa_offset n;
+          stack_offset := !stack_offset + n
+        end
     | Lcondbranch(tst, lbl) ->
         begin match tst with
         | Itruetest ->

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -749,8 +749,15 @@ let emit_instr fallthrough i =
         end
     | Llabel lbl ->
         `{emit_Llabel fallthrough lbl}:\n`
-    | Lbranch lbl ->
-        `	jmp	{emit_label lbl}\n`
+    | Lbranch (lbl,frame_offsets) ->
+        `	jmp	{emit_label lbl}\n`;
+        if frame_offsets <> 0
+        then begin
+          assert(frame_offsets > 0);
+          let n = frame_offsets * trap_frame_size in
+          cfi_adjust_cfa_offset n;
+          stack_offset := !stack_offset + n
+        end
     | Lcondbranch(tst, lbl) ->
         begin match tst with
           Itruetest ->

--- a/asmcomp/i386/emit_nt.mlp
+++ b/asmcomp/i386/emit_nt.mlp
@@ -678,8 +678,14 @@ let emit_instr i =
         `	ret\n`
     | Llabel lbl ->
         `{emit_label lbl}:\n`
-    | Lbranch lbl ->
-        `	jmp	{emit_label lbl}\n`
+    | Lbranch (lbl,frame_offsets) ->
+        `	jmp	{emit_label lbl}\n`;
+        if frame_offsets <> 0
+        then begin
+          assert(frame_offsets > 0);
+          let n = frame_offsets * 8 in
+          stack_offset := !stack_offset + n
+        end
     | Lcondbranch(tst, lbl) ->
         begin match tst with
           Itruetest ->

--- a/asmcomp/linearize.mli
+++ b/asmcomp/linearize.mli
@@ -15,6 +15,8 @@
 type label = int
 val new_label: unit -> label
 
+type frame_offsets = int
+
 type instruction =
   { mutable desc: instruction_desc;
     mutable next: instruction;
@@ -29,7 +31,7 @@ and instruction_desc =
   | Lreloadretaddr
   | Lreturn
   | Llabel of label
-  | Lbranch of label
+  | Lbranch of label * frame_offsets
   | Lcondbranch of Mach.test * label
   | Lcondbranch3 of label option * label option * label option
   | Lswitch of label array

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -348,7 +348,7 @@ let instr_size = function
   | Lreloadretaddr -> 2
   | Lreturn -> 2
   | Llabel lbl -> 0
-  | Lbranch lbl -> 1
+  | Lbranch (lbl,_) -> 1
   | Lcondbranch(tst, lbl) -> 2
   | Lcondbranch3(lbl0, lbl1, lbl2) ->
       1 + (if lbl0 = None then 0 else 1)
@@ -397,7 +397,7 @@ let fixup_branches codesize map code =
     | Lcondbranch(test, lbl) when branch_overflows map pc lbl ->
         let lbl2 = new_label() in
         let cont =
-          instr_cons (Lbranch lbl) [||] [||]
+          instr_cons (Lbranch (lbl,0)) [||] [||]
             (instr_cons (Llabel lbl2) [||] [||] instr.next) in
         instr.desc <- Lcondbranch(invert_test test, lbl2);
         instr.next <- cont;
@@ -659,8 +659,15 @@ let rec emit_instr i dslot =
         `	blr\n`
     | Llabel lbl ->
         `{emit_label lbl}:\n`
-    | Lbranch lbl ->
-        `	b	{emit_label lbl}\n`
+    | Lbranch (lbl,frame_offsets) ->
+        `	b	{emit_label lbl}\n`;
+        if frame_offsets <> 0
+        then begin
+          assert(frame_offsets > 0);
+          let n = frame_offsets * 16 in
+          cfi_adjust_cfa_offset n;
+          stack_offset := !stack_offset + n
+        end
     | Lcondbranch(tst, lbl) ->
         begin match tst with
           Itruetest ->

--- a/asmcomp/printlinear.ml
+++ b/asmcomp/printlinear.ml
@@ -36,8 +36,10 @@ let instr ppf i =
       fprintf ppf "return %a" regs i.arg
   | Llabel lbl ->
       fprintf ppf "%a:" label lbl
-  | Lbranch lbl ->
-      fprintf ppf "goto %a" label lbl
+  | Lbranch (lbl, frame_offsets) ->
+      if frame_offsets = 0
+      then fprintf ppf "goto %a" label lbl
+      else fprintf ppf "goto %a offset %i" label lbl frame_offsets
   | Lcondbranch(tst, lbl) ->
       fprintf ppf "if %a goto %a" (test tst) i.arg label lbl
   | Lcondbranch3(lbl0, lbl1, lbl2) ->

--- a/asmcomp/sparc/emit.mlp
+++ b/asmcomp/sparc/emit.mlp
@@ -515,9 +515,15 @@ let rec emit_instr i dslot =
           `	add	%sp, {emit_int n}, %sp\n`
     | Llabel lbl ->
         `{emit_label lbl}:\n`
-    | Lbranch lbl ->
+    | Lbranch (lbl,frame_offsets) ->
         `	b	{emit_label lbl}\n`;
-        fill_delay_slot dslot
+        fill_delay_slot dslot;
+        if frame_offsets <> 0
+        then begin
+          assert(frame_offsets > 0);
+          let n = frame_offsets * 8 in
+          stack_offset := !stack_offset + n
+        end
     | Lcondbranch(tst, lbl) ->
         begin match tst with
           Itruetest ->

--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -50,7 +50,8 @@ lexcmm.ml: lexcmm.mll
 MLCASES=optargs staticalloc
 
 CASES=fib tak quicksort quicksort2 soli \
-      arith checkbound tagged-fib tagged-integr tagged-quicksort tagged-tak
+      arith checkbound tagged-fib tagged-integr tagged-quicksort tagged-tak \
+      test-exit-trywith
 ARGS_fib=-DINT_INT -DFUN=fib main.c
 ARGS_tak=-DUNIT_INT -DFUN=takmain main.c
 ARGS_quicksort=-DSORT -DFUN=quicksort main.c
@@ -63,6 +64,7 @@ ARGS_tagged-fib=-DINT_INT -DFUN=fib main.c
 ARGS_tagged-integr=-DINT_FLOAT -DFUN=test main.c
 ARGS_tagged-quicksort=-DSORT -DFUN=quicksort main.c
 ARGS_tagged-tak=-DUNIT_INT -DFUN=takmain main.c
+ARGS_test-exit-trywith=-DINT_INT -DFUN=exit_trywith main.c
 
 tests: $(CASES:=.o)
 	@for c in $(CASES); do \

--- a/testsuite/tests/asmcomp/parsecmm.mly
+++ b/testsuite/tests/asmcomp/parsecmm.mly
@@ -197,6 +197,9 @@ expr:
           | _ -> Cifthenelse($3, $4, (Cexit(0,[]))) in
         Ccatch(0, [], Cloop body, Ctuple []) }
   | LPAREN CATCH sequence WITH sequence RPAREN { Ccatch(0, [], $3, $5) }
+  | LPAREN CATCH sequence WITH LPAREN identlist RPAREN sequence RPAREN
+    { Ccatch(0, $6, $3, $8) }
+  | LPAREN EXIT exprlist RPAREN { Cexit(0,$3) }
   | EXIT        { Cexit(0,[]) }
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
                 { unbind_ident $5; Ctrywith($3, $5, $6) }
@@ -212,6 +215,10 @@ expr:
       { Cop(Cstore Word, [access_array $3 $4 Arch.size_int; $5]) }
   | LPAREN FLOATASET expr expr expr RPAREN
       { Cop(Cstore Double_u, [access_array $3 $4 Arch.size_float; $5]) }
+;
+identlist:
+    identlist bind_ident        { $2 :: $1 }
+  | /**/                        { [] }
 ;
 exprlist:
     exprlist expr               { $2 :: $1 }

--- a/testsuite/tests/asmcomp/test-exit-trywith.cmm
+++ b/testsuite/tests/asmcomp/test-exit-trywith.cmm
@@ -1,0 +1,13 @@
+(function "exit_trywith" (b:int)
+  (+ 33
+  (catch
+    (try
+      (if (<= b 0)
+          (exit 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 b)
+          (raise b))
+     with var (+ var 456))
+   with (a b c d e f g h i j k l m n o p q r s t)
+    (+ a (+ b (+ c (+ d (+ e (+ f (+ g
+    (+ h (+ i (+ j (+ k (+ l (+ m
+    (+ n (+ o (+ p (+ q (+ r (+ s (+ t 123))))))))))))))))))))
+   )))


### PR DESCRIPTION
Currently, it is not possible in Cmm to have an expression like:

```
  (catch
    (try
       exit
     with var 1)
   with 2)
```

because the exception trap in not removed when branching from `exit` to its handler.
This patch adds the required Lpoptrap before branching and reset the stack offset after. @xavierleroy is it correct to do it that way ?

This kind of pattern is never generated by the current compiler, but could appear later when optimising out allocations of temporary block inside a try/with.

The provided example `testsuite/tests/asmcomp/test-exit-trywith.cmm` is tested on amd64/linux, ocamlopt has been compiled for every architecture/OS.
