### PR TITLE
Add -linkall flag to ocamlcommon archives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,7 @@ clean:: partialclean
 # Shared parts of the system
 
 compilerlibs/ocamlcommon.cma: $(COMMON)
-	$(CAMLC) -a -o $@ $(COMMON)
+	$(CAMLC) -a -linkall -o $@ $(COMMON)
 partialclean::
 	rm -f compilerlibs/ocamlcommon.cma
 
@@ -494,7 +494,7 @@ beforedepend:: parsing/lexer.ml
 # Shared parts of the system compiled with the native-code compiler
 
 compilerlibs/ocamlcommon.cmxa: $(COMMON:.cmo=.cmx)
-	$(CAMLOPT) -a -o $@ $(COMMON:.cmo=.cmx)
+	$(CAMLOPT) -a -linkall -o $@ $(COMMON:.cmo=.cmx)
 partialclean::
 	rm -f compilerlibs/ocamlcommon.cmxa compilerlibs/ocamlcommon.a
 


### PR DESCRIPTION
This patch add the "-linkall" flag when creating the ocamlcommon.cma and ocamlcommon.cmxa archives.

Modules in "typing/" subdirectory rely on side-effects during initialization to setup forward references.
It would be unsafe for a module to not be linked, thus it seems preferable to enforce linking of  all modules.
