### PR TITLE
Update manpage wrt camlp4 split

### DIFF
--- a/man/ocaml.m
+++ b/man/ocaml.m
@@ -81,9 +81,9 @@ If the given directory starts with
 .BR + ,
 it is taken relative to the
 standard library directory. For instance,
-.B \-I\ +camlp4
+.B \-I\ +compiler-libs
 adds the subdirectory
-.B camlp4
+.B compiler-libs
 of the standard library to the search path.
 .IP
 Directories can also be added to the search path once the toplevel

--- a/man/ocamlc.m
+++ b/man/ocamlc.m
@@ -350,9 +350,9 @@ If the given directory starts with
 .BR + ,
 it is taken relative to the
 standard library directory. For instance,
-.B \-I\ +camlp4
+.B \-I\ +compiler-libs
 adds the subdirectory
-.B camlp4
+.B compiler-libs
 of the standard library to the search path.
 .TP
 .BI \-impl \ filename
@@ -744,7 +744,7 @@ have type
 \ \ Non-returning statement.
 
 22
-\ \ Camlp4 warning.
+\ \ Preprocessor warning.
 
 23
 \ \ Useless record

--- a/man/ocamlopt.m
+++ b/man/ocamlopt.m
@@ -260,9 +260,9 @@ If the given directory starts with
 .BR + ,
 it is taken relative to the
 standard library directory. For instance,
-.B \-I\ +camlp4
+.B \-I\ +compiler-libs
 adds the subdirectory
-.B camlp4
+.B compiler-libs
 of the standard library to the search path.
 .TP
 .BI \-impl \ filename


### PR DESCRIPTION
Also, I've notice 2 reference to "camlp4" in `[opt]toploop.ml`, is it still appropriate ?
