### PR TITLE
arm64: Align code and data to 8 bytes.

### DIFF
--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -644,7 +644,7 @@ let fundecl fundecl =
   call_gc_sites := [];
   bound_error_sites := [];
   `	.text\n`;
-  `	.align	2\n`;
+  `	.align	3\n`;
   `	.globl	{emit_symbol fundecl.fun_name}\n`;
   `	.type	{emit_symbol fundecl.fun_name}, %function\n`;
   `{emit_symbol fundecl.fun_name}:\n`;
@@ -685,6 +685,7 @@ let emit_item = function
 
 let data l =
   `	.data\n`;
+  `	.align 3\n`;
   List.iter emit_item l
 
 (* Beginning / end of an assembly file *)


### PR DESCRIPTION
Insufficient alignment seems to be the cause of relocation errors when
linking large native code OCaml programs:

 (.text+0xc): relocation truncated to fit: R_AARCH64_LDST64_ABS_LO12_NC against symbol `camlOdoc_type' defined in .data section in odoc_type.o
../stdlib/stdlib.a(listLabels.o): In function`camlListLabels__entry':
(.text+0x10): relocation truncated to fit: R_AARCH64_LDST64_ABS_LO12_NC against symbol `camlListLabels' defined in .data section in ../stdlib/stdlib.a(listLabels.o)

PR#6283 http://caml.inria.fr/mantis/view.php?id=6283
