### PR TITLE
PR5197: arg: Allow flags such as --flag=arg as well as --flag arg.

### DIFF
--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -134,56 +134,62 @@ let parse_argv_dynamic ?(current=current) argv speclist anonfun errmsg =
         try assoc3 s !speclist
         with Not_found -> stop (Unknown s)
       in
+      let no_arg () = () in
+      let get_arg () =
+        if !current + 1 < l then argv.(!current + 1)
+        else stop (Missing s)
+      in
       begin try
         let rec treat_action = function
-        | Unit f -> f ();
-        | Bool f when !current + 1 < l ->
-            let arg = argv.(!current + 1) in
+        | Unit f -> no_arg (); f ();
+        | Bool f ->
+            let arg = get_arg () in
             begin try f (bool_of_string arg)
             with Invalid_argument "bool_of_string" ->
                    raise (Stop (Wrong (s, arg, "a boolean")))
             end;
             incr current;
-        | Set r -> r := true;
-        | Clear r -> r := false;
-        | String f when !current + 1 < l ->
-            f argv.(!current + 1);
+        | Set r -> no_arg (); r := true;
+        | Clear r -> no_arg (); r := false;
+        | String f ->
+            let arg = get_arg () in
+            f arg;
             incr current;
-        | Symbol (symb, f) when !current + 1 < l ->
-            let arg = argv.(!current + 1) in
+        | Symbol (symb, f) ->
+            let arg = get_arg () in
             if List.mem arg symb then begin
-              f argv.(!current + 1);
+              f arg;
               incr current;
             end else begin
               raise (Stop (Wrong (s, arg, "one of: "
                                           ^ (make_symlist "" " " "" symb))))
             end
-        | Set_string r when !current + 1 < l ->
-            r := argv.(!current + 1);
+        | Set_string r ->
+            r := get_arg ();
             incr current;
-        | Int f when !current + 1 < l ->
-            let arg = argv.(!current + 1) in
+        | Int f ->
+            let arg = get_arg () in
             begin try f (int_of_string arg)
             with Failure "int_of_string" ->
                    raise (Stop (Wrong (s, arg, "an integer")))
             end;
             incr current;
-        | Set_int r when !current + 1 < l ->
-            let arg = argv.(!current + 1) in
+        | Set_int r ->
+            let arg = get_arg () in
             begin try r := (int_of_string arg)
             with Failure "int_of_string" ->
                    raise (Stop (Wrong (s, arg, "an integer")))
             end;
             incr current;
-        | Float f when !current + 1 < l ->
-            let arg = argv.(!current + 1) in
+        | Float f ->
+            let arg = get_arg () in
             begin try f (float_of_string arg);
             with Failure "float_of_string" ->
                    raise (Stop (Wrong (s, arg, "a float")))
             end;
             incr current;
-        | Set_float r when !current + 1 < l ->
-            let arg = argv.(!current + 1) in
+        | Set_float r ->
+            let arg = get_arg () in
             begin try r := (float_of_string arg);
             with Failure "float_of_string" ->
                    raise (Stop (Wrong (s, arg, "a float")))
@@ -196,7 +202,6 @@ let parse_argv_dynamic ?(current=current) argv speclist anonfun errmsg =
               f argv.(!current + 1);
               incr current;
             done;
-        | _ -> raise (Stop (Missing s))
         in
         treat_action action
       with Bad m -> stop (Message m);

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -25,7 +25,8 @@
     [Unit], [Set] and [Clear] keywords take no argument. A [Rest]
     keyword takes the remaining of the command line as arguments.
     Every other keyword takes the following word on the command line
-    as argument.
+    as argument.  For compatibility with GNU getopt_long, [keyword=arg]
+    is also allowed.
     Arguments not preceded by a keyword are called anonymous arguments.
 
    Examples ([cmd] is assumed to be the command name):


### PR DESCRIPTION
Allow flags to be followed directly by their argument, separated by an '=' sign.  This is consistent with what GNU getopt_long and many other command line parsing libraries allow.

Fix for the following issue:
http://caml.inria.fr/mantis/view.php?id=5197
