### PR TITLE
ocamlfind lookup fix

### DIFF
--- a/ocamlbuild/options.ml
+++ b/ocamlbuild/options.ml
@@ -286,8 +286,7 @@ let init () =
 
   if !use_ocamlfind then begin
     ocamlfind_cmd := A "ocamlfind";
-    let cmd = Command.string_of_command_spec !ocamlfind_cmd in
-    begin try ignore(Command.search_in_path cmd)
+    begin try ignore(Command.search_in_path "ocamlfind")
     with Not_found -> failwith "ocamlfind not found on path, but -no-ocamlfind not used" end;
     (* TODO: warning message when using an option such as -ocamlc *)
     (* Note that plugins can still modify these variables After_options.


### PR DESCRIPTION
Command.string_of_command_spec possibly quotes the result (unlikely on *nix, but always on Windows). If the output is quoted, Command.search_in_path will of course fail.
