### PR TITLE
Make `ocaml{c,opt} -c -i foo.ml' generate only foo.cmi

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -16,7 +16,9 @@ let output_prefix name =
   let oname =
     match !output_name with
     | None -> name
-    | Some n -> if !compile_only then (output_name := None; n) else name in
+    | Some n ->
+        if !compile_only || !print_types
+        then (output_name := None; n) else name in
   Misc.chop_extension_if_any oname
 
 let print_version_and_library compiler =

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -86,7 +86,7 @@ module Options = Main_args.Make_bytecomp_options (struct
   let _dllib s = dllibs := Misc.rev_split_words s @ !dllibs
   let _dllpath s = dllpaths := !dllpaths @ [s]
   let _g = set debug
-  let _i () = print_types := true; compile_only := true
+  let _i = set print_types
   let _I s = include_dirs := s :: !include_dirs
   let _impl = impl
   let _intf = intf
@@ -167,7 +167,7 @@ let main () =
         revd (extracted_output);
       Warnings.check_fatal ();
     end
-    else if not !compile_only && !objfiles <> [] then begin
+    else if not !print_types && not !compile_only && !objfiles <> [] then begin
       let target =
         if !output_c_object then
           let s = extract_output !output_name in

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -84,7 +84,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _config () = show_config ()
   let _for_pack s = for_package := Some s
   let _g = set debug
-  let _i () = print_types := true; compile_only := true
+  let _i = set print_types
   let _I dir = include_dirs := dir :: !include_dirs
   let _impl = impl
   let _inline n = inline_threshold := n * 8
@@ -187,7 +187,7 @@ let main () =
       Asmlink.link_shared ppf (get_objfiles ()) target;
       Warnings.check_fatal ();
     end
-    else if not !compile_only && !objfiles <> [] then begin
+    else if not !print_types && not !compile_only && !objfiles <> [] then begin
       let target =
         if !output_c_object then
           let s = extract_output !output_name in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1564,7 +1564,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
   let (str, sg, finalenv) =
     type_structure initial_env ast (Location.in_file sourcefile) in
   let simple_sg = simplify_signature sg in
-  if !Clflags.print_types then begin
+  if !Clflags.print_types && not !Clflags.compile_only then begin
     Printtyp.wrap_printing_env initial_env
       (fun () -> fprintf std_formatter "%a@." Printtyp.signature simple_sg);
     (str, Tcoerce_none)   (* result is ignored by Compile.implementation *)


### PR DESCRIPTION
This should improve the life of build system makers quite a lot (and help to parallelize the build of projects as well).
