### PR TITLE
Infix constructors

### DIFF
--- a/ocamldoc/odoc_ocamlhtml.mll
+++ b/ocamldoc/odoc_ocamlhtml.mll
@@ -251,8 +251,10 @@ let lowercase = ['a'-'z' '\223'-'\246' '\248'-'\255' '_']
 let uppercase = ['A'-'Z' '\192'-'\214' '\216'-'\222']
 let identchar =
   ['A'-'Z' 'a'-'z' '_' '\192'-'\214' '\216'-'\246' '\248'-'\255' '\'' '0'-'9']
+let constructorchar =
+  ['$' '%' '&' '*' '+' '-' '.' '/' ':' '<' '=' '>' '@' '^' '|']
 let symbolchar =
-  ['!' '$' '%' '&' '*' '+' '-' '.' '/' ':' '<' '=' '>' '?' '@' '^' '|' '~']
+  constructorchar | ['!' '?' '~']
 let decimal_literal = ['0'-'9']+
 let hex_literal = '0' ['x' 'X'] ['0'-'9' 'A'-'F' 'a'-'f']+
 let oct_literal = '0' ['o' 'O'] ['0'-'7']+
@@ -366,7 +368,6 @@ rule token = parse
   | "."  { print (Lexing.lexeme lexbuf) ; token lexbuf }
   | ".." { print (Lexing.lexeme lexbuf) ; token lexbuf }
   | ":"  { print (Lexing.lexeme lexbuf) ; token lexbuf }
-  | "::" { print (Lexing.lexeme lexbuf) ; token lexbuf }
   | ":=" { print (Lexing.lexeme lexbuf) ; token lexbuf }
   | ":>" { print (Lexing.lexeme lexbuf) ; token lexbuf }
   | ";"  { print (Lexing.lexeme lexbuf) ; token lexbuf }
@@ -406,6 +407,22 @@ rule token = parse
   | "**" symbolchar *
             { print (Lexing.lexeme lexbuf) ; token lexbuf }
   | ['*' '/' '%'] symbolchar *
+            { print (Lexing.lexeme lexbuf) ; token lexbuf }
+
+  | ':' ['|' '&' '$'] constructorchar *
+  (* := and :> are invalid operators since  COLONEQUAL and COLONGREATER already exist.
+     :< is invalid because [ x:<foo:bar> ] is valid. *)
+  | ':' ['=' '>' '<'] constructorchar +
+            { print (Lexing.lexeme lexbuf) ; token lexbuf }
+  | ':' ['@' '^'] constructorchar *
+            { print (Lexing.lexeme lexbuf) ; token lexbuf }
+  | "::" constructorchar *
+            { print (Lexing.lexeme lexbuf) ; token lexbuf }
+  | ':' ['+' '-'] constructorchar *
+            { print (Lexing.lexeme lexbuf) ; token lexbuf }
+  | ':' "**" constructorchar *
+            { print (Lexing.lexeme lexbuf) ; token lexbuf }
+  | ':' ['*' '/' '%'] constructorchar *
             { print (Lexing.lexeme lexbuf) ; token lexbuf }
   | eof { () }
   | _

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -484,8 +484,23 @@ rule token = parse
   | '%'     { PERCENT }
   | ['*' '/' '%'] symbolchar *
             { INFIXOP3(Lexing.lexeme lexbuf) }
+
+  | ':' ['|' '&' '$'] constructorchar *
+  (* := and :> are invalid operators since  COLONEQUAL and COLONGREATER already exist.
+     :< is invalid because [ x:<foo:bar> ] is valid. *)
+  | ':' ['=' '>' '<'] constructorchar +
+            { INFIXCONSTRUCTOR0(Lexing.lexeme lexbuf) }
+  | ':' ['@' '^'] constructorchar *
+            { INFIXCONSTRUCTOR1(Lexing.lexeme lexbuf) }
   | "::" constructorchar *
-            { INFIXCONSTRUCTOR(Lexing.lexeme lexbuf) }
+            { INFIXCONSTRUCTOR1BIS(Lexing.lexeme lexbuf) }
+  | ':' ['+' '-'] constructorchar *
+            { INFIXCONSTRUCTOR2(Lexing.lexeme lexbuf) }
+  | ':' "**" constructorchar *
+            { INFIXCONSTRUCTOR4(Lexing.lexeme lexbuf) }
+  | ':' ['*' '/' '%'] constructorchar *
+            { INFIXCONSTRUCTOR3(Lexing.lexeme lexbuf) }
+
   | eof { EOF }
   | _
       { raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -268,8 +268,10 @@ let lowercase_latin1 = ['a'-'z' '\223'-'\246' '\248'-'\255' '_']
 let uppercase_latin1 = ['A'-'Z' '\192'-'\214' '\216'-'\222']
 let identchar_latin1 =
   ['A'-'Z' 'a'-'z' '_' '\192'-'\214' '\216'-'\246' '\248'-'\255' '\'' '0'-'9']
+let constructorchar =
+  ['$' '%' '&' '*' '+' '-' '.' '/' ':' '<' '=' '>' '@' '^' '|']
 let symbolchar =
-  ['!' '$' '%' '&' '*' '+' '-' '.' '/' ':' '<' '=' '>' '?' '@' '^' '|' '~']
+  constructorchar | ['!' '?' '~']
 let decimal_literal =
   ['0'-'9'] ['0'-'9' '_']*
 let hex_literal =
@@ -433,7 +435,6 @@ rule token = parse
   | "."  { DOT }
   | ".." { DOTDOT }
   | ":"  { COLON }
-  | "::" { COLONCOLON }
   | ":=" { COLONEQUAL }
   | ":>" { COLONGREATER }
   | ";"  { SEMI }
@@ -483,6 +484,8 @@ rule token = parse
   | '%'     { PERCENT }
   | ['*' '/' '%'] symbolchar *
             { INFIXOP3(Lexing.lexeme lexbuf) }
+  | "::" constructorchar *
+            { INFIXCONSTRUCTOR(Lexing.lexeme lexbuf) }
   | eof { EOF }
   | _
       { raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1133,8 +1133,6 @@ expr:
       { mkexp_constructor $2 (rhs_loc 2) (ghexp(Pexp_tuple[$1;$3])) (symbol_rloc()) }
   | expr INFIXCONSTRUCTOR4 expr
       { mkexp_constructor $2 (rhs_loc 2) (ghexp(Pexp_tuple[$1;$3])) (symbol_rloc()) }
-  | LPAREN infix_construct RPAREN LPAREN expr COMMA expr RPAREN
-      { mkexp_constructor $2 (rhs_loc 2) (ghexp(Pexp_tuple[$5;$7])) (symbol_rloc()) }
   | expr INFIXOP0 expr
       { mkinfix $1 $2 $3 }
   | expr INFIXOP1 expr
@@ -2007,10 +2005,12 @@ operator:
 ;
 constr_ident:
     UIDENT                                      { $1 }
-/*  | LBRACKET RBRACKET                           { "[]" } */
+  | constr_ident_no_uident                      { $1 }
+
+constr_ident_no_uident:
+    LBRACKET RBRACKET                           { "[]" }
   | LPAREN RPAREN                               { "()" }
-  | infix_construct                             { $1 }
-/*  | LPAREN infix_construct RPAREN               { $1 } */
+  | LPAREN infix_construct RPAREN               { $2 }
   | FALSE                                       { "false" }
   | TRUE                                        { "true" }
 ;
@@ -2029,10 +2029,8 @@ val_longident:
 ;
 constr_longident:
     mod_longident       %prec below_DOT         { $1 }
-  | LBRACKET RBRACKET                           { Lident "[]" }
-  | LPAREN RPAREN                               { Lident "()" }
-  | FALSE                                       { Lident "false" }
-  | TRUE                                        { Lident "true" }
+  | constr_ident_no_uident                      { Lident $1 }
+  | mod_longident DOT constr_ident_no_uident    { Ldot($1, $3) }
 ;
 label_longident:
     LIDENT                                      { Lident $1 }

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -106,11 +106,11 @@ let mkuplus name arg =
   | _ ->
       mkexp(Pexp_apply(mkoperator ("~" ^ name) 1, ["", arg]))
 
-let mkexp_cons consloc args loc =
-  Exp.mk ~loc (Pexp_construct(mkloc (Lident "::") consloc, Some args))
+let mkexp_constructor constructor constructorloc args loc =
+  Exp.mk ~loc (Pexp_construct(mkloc (Lident constructor) constructorloc, Some args))
 
-let mkpat_cons consloc args loc =
-  Pat.mk ~loc (Ppat_construct(mkloc (Lident "::") consloc, Some args))
+let mkpat_constructor constructor constructorloc args loc =
+  Pat.mk ~loc (Ppat_construct(mkloc (Lident constructor) constructorloc, Some args))
 
 let rec mktailexp nilloc = function
     [] ->
@@ -124,7 +124,7 @@ let rec mktailexp nilloc = function
                loc_ghost = true}
       in
       let arg = Exp.mk ~loc (Pexp_tuple [e1; exp_el]) in
-      mkexp_cons {loc with loc_ghost = true} arg loc
+      mkexp_constructor "::" {loc with loc_ghost = true} arg loc
 
 let rec mktailpat nilloc = function
     [] ->
@@ -138,7 +138,7 @@ let rec mktailpat nilloc = function
                loc_ghost = true}
       in
       let arg = Pat.mk ~loc (Ppat_tuple [p1; pat_pl]) in
-      mkpat_cons {loc with loc_ghost = true} arg loc
+      mkpat_constructor "::" {loc with loc_ghost = true} arg loc
 
 let mkstrexp e attrs =
   { pstr_desc = Pstr_eval (e, attrs); pstr_loc = e.pexp_loc }
@@ -307,7 +307,6 @@ let mkctf_attrs d attrs =
 %token <char> CHAR
 %token CLASS
 %token COLON
-%token COLONCOLON
 %token COLONEQUAL
 %token COLONGREATER
 %token COMMA
@@ -340,6 +339,7 @@ let mkctf_attrs d attrs =
 %token <string> INFIXOP2
 %token <string> INFIXOP3
 %token <string> INFIXOP4
+%token <string> INFIXCONSTRUCTOR
 %token INHERIT
 %token INITIALIZER
 %token <int> INT
@@ -461,13 +461,13 @@ The precedences must be listed from low to high.
 %nonassoc below_LBRACKETAT
 %nonassoc LBRACKETAT
 %nonassoc LBRACKETATAT
-%right    COLONCOLON                    /* expr (e :: e :: e) */
+%right    INFIXCONSTRUCTOR                    /* expr (e OP e OP e) with OP a constructor */
 %left     INFIXOP2 PLUS PLUSDOT MINUS MINUSDOT PLUSEQ /* expr (e OP e OP e) */
 %left     PERCENT INFIXOP3 STAR                 /* expr (e OP e OP e) */
 %right    INFIXOP4                      /* expr (e OP e OP e) */
 %nonassoc prec_unary_minus prec_unary_plus /* unary - */
 %nonassoc prec_constant_constructor     /* cf. simple_expr (C versus C x) */
-%nonassoc prec_constr_appl              /* above AS BAR COLONCOLON COMMA */
+%nonassoc prec_constr_appl              /* above AS BAR INFIXCONSTRUCTOR COMMA */
 %nonassoc below_SHARP
 %nonassoc SHARP                         /* simple_expr/toplevel_directive */
 %nonassoc below_DOT
@@ -1116,10 +1116,10 @@ expr:
   | FOR ext_attributes pattern EQUAL seq_expr direction_flag seq_expr DO
     seq_expr DONE
       { mkexp_attrs(Pexp_for($3, $5, $7, $6, $9)) $2 }
-  | expr COLONCOLON expr
-      { mkexp_cons (rhs_loc 2) (ghexp(Pexp_tuple[$1;$3])) (symbol_rloc()) }
-  | LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr RPAREN
-      { mkexp_cons (rhs_loc 2) (ghexp(Pexp_tuple[$5;$7])) (symbol_rloc()) }
+  | expr INFIXCONSTRUCTOR expr
+      { mkexp_constructor $2 (rhs_loc 2) (ghexp(Pexp_tuple[$1;$3])) (symbol_rloc()) }
+  | LPAREN INFIXCONSTRUCTOR RPAREN LPAREN expr COMMA expr RPAREN
+      { mkexp_constructor $2 (rhs_loc 2) (ghexp(Pexp_tuple[$5;$7])) (symbol_rloc()) }
   | expr INFIXOP0 expr
       { mkinfix $1 $2 $3 }
   | expr INFIXOP1 expr
@@ -1444,13 +1444,13 @@ pattern:
       { mkpat(Ppat_construct(mkrhs $1 1, Some $2)) }
   | name_tag pattern %prec prec_constr_appl
       { mkpat(Ppat_variant($1, Some $2)) }
-  | pattern COLONCOLON pattern
-      { mkpat_cons (rhs_loc 2) (ghpat(Ppat_tuple[$1;$3])) (symbol_rloc()) }
-  | pattern COLONCOLON error
+  | pattern INFIXCONSTRUCTOR pattern
+      { mkpat_constructor $2 (rhs_loc 2) (ghpat(Ppat_tuple[$1;$3])) (symbol_rloc()) }
+  | pattern INFIXCONSTRUCTOR error
       { expecting 3 "pattern" }
-  | LPAREN COLONCOLON RPAREN LPAREN pattern COMMA pattern RPAREN
-      { mkpat_cons (rhs_loc 2) (ghpat(Ppat_tuple[$5;$7])) (symbol_rloc()) }
-  | LPAREN COLONCOLON RPAREN LPAREN pattern COMMA pattern error
+  | LPAREN INFIXCONSTRUCTOR RPAREN LPAREN pattern COMMA pattern RPAREN
+      { mkpat_constructor $2 (rhs_loc 2) (ghpat(Ppat_tuple[$5;$7])) (symbol_rloc()) }
+  | LPAREN INFIXCONSTRUCTOR RPAREN LPAREN pattern COMMA pattern error
       { unclosed "(" 4 ")" 8 }
   | pattern BAR pattern
       { mkpat(Ppat_or($1, $3)) }
@@ -1984,8 +1984,8 @@ constr_ident:
     UIDENT                                      { $1 }
 /*  | LBRACKET RBRACKET                           { "[]" } */
   | LPAREN RPAREN                               { "()" }
-  | COLONCOLON                                  { "::" }
-/*  | LPAREN COLONCOLON RPAREN                    { "::" } */
+  | INFIXCONSTRUCTOR                            { $1 }
+/*  | LPAREN INFIXCONSTRUCTOR RPAREN              { $1 } */
   | FALSE                                       { "false" }
   | TRUE                                        { "true" }
 ;

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -24,7 +24,7 @@ open Parsetree
 
 let prefix_symbols  = [ '!'; '?'; '~' ] ;;
 let infix_symbols = [ '='; '<'; '>'; '@'; '^'; '|'; '&'; '+'; '-'; '*'; '/';
-                      '$'; '%' ]
+                      '$'; '%' ; ':']
 let operator_chars = [ '!'; '$'; '%'; '&'; '*'; '+'; '-'; '.'; '/';
                        ':'; '<'; '='; '>'; '?'; '@'; '^'; '|'; '~' ]
 let numeric_chars  = [ '0'; '1'; '2'; '3'; '4'; '5'; '6'; '7'; '8'; '9' ]
@@ -353,11 +353,15 @@ class printer  ()= object(self:'self)
     else match x.ppat_desc with
     | Ppat_variant (l, Some p) ->  pp f "@[<2>`%s@;%a@]" l self#simple_pattern p
     | Ppat_construct (({txt=Lident("()"|"[]");_}), _) -> self#simple_pattern f x
-    | Ppat_construct (({txt;_} as li), po) -> (* FIXME The third field always false *)
-        if txt = Lident "::" then
+    | Ppat_construct (({txt=Lident s;_} as li), po) -> (* FIXME The third field always false *)
+        if s = "::" then
           pp f "%a" pattern_list_helper x
         else
           (match po with
+          | Some ({ppat_desc = Ppat_tuple([pat1; pat2]);_}) when s.[0] = ':' ->
+              pp f "(%a) %a (%a)"  self#simple_pattern  pat1 self#longident_loc li self#simple_pattern pat2
+          | Some x when s.[0] = ':' ->
+              pp f "(%a)@;%a"  self#longident_loc li self#simple_pattern x
           |Some x ->
               pp f "%a@;%a"  self#longident_loc li self#simple_pattern x
           | None -> pp f "%a@;"self#longident_loc li )
@@ -567,10 +571,17 @@ class printer  ()= object(self:'self)
                (*reset here only because [function,match,try,sequence] are lower priority*)
             end (e,l))
 
-    | Pexp_construct (li, Some eo)
+    | Pexp_construct ({txt= Lident s ;_} as li, Some eo)
       when not (is_simple_construct (view_expr x))-> (* Not efficient FIXME*)
         (match view_expr x with
         | `cons ls -> self#list self#simple_expr f ls ~sep:"@;::@;"
+        | `normal when s.[0] = ':' ->
+            begin match eo with
+              | ({pexp_desc= Pexp_tuple([e1;e2]);_}) ->
+                  pp f "@[<2>%a@;%s@;%a@]" self#simple_expr e1  s  self#simple_expr e2
+              | _ ->
+                  pp f "@[<2>(%a)@;%a@]" self#longident_loc li  self#simple_expr eo
+            end
         | `normal ->
             pp f "@[<2>%a@;%a@]" self#longident_loc li
               self#simple_expr  eo
@@ -1310,7 +1321,7 @@ class printer  ()= object(self:'self)
   method constructor_declaration f (name, args, res, attrs) =
     match res with
     | None ->
-        pp f "%s%a%a" name
+        pp f "%a%a%a" protect_ident name
           self#attributes attrs
           (fun f -> function
              | Pcstr_tuple [] -> ()
@@ -1319,7 +1330,7 @@ class printer  ()= object(self:'self)
              | Pcstr_record l -> pp f "@;of@;%a" (self#record_declaration) l
           ) args
     | Some r ->
-        pp f "%s%a:@;%a" name
+        pp f "%a%a:@;%a" protect_ident name
           self#attributes attrs
           (fun f -> function
              | Pcstr_tuple [] -> self#core_type1 f r

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -19,19 +19,11 @@ let cautious f ppf arg =
   try f ppf arg with
     Ellipsis -> fprintf ppf "..."
 
-let rec print_ident ppf =
-  function
-    Oide_ident s -> pp_print_string ppf s
-  | Oide_dot (id, s) ->
-      print_ident ppf id; pp_print_char ppf '.'; pp_print_string ppf s
-  | Oide_apply (id1, id2) ->
-      fprintf ppf "%a(%a)" print_ident id1 print_ident id2
-
 let parenthesized_ident name =
   (List.mem name ["or"; "mod"; "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr"])
   ||
   (match name.[0] with
-      'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' ->
+      'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' | '(' | '[' ->
         false
     | _ -> true)
 
@@ -40,6 +32,15 @@ let value_ident ppf name =
     fprintf ppf "( %s )" name
   else
     pp_print_string ppf name
+
+let rec print_ident ppf =
+  function
+    Oide_ident s -> value_ident ppf s
+  | Oide_dot (id, s) ->
+      print_ident ppf id; pp_print_char ppf '.'; value_ident ppf s
+  | Oide_apply (id1, id2) ->
+      fprintf ppf "%a(%a)" print_ident id1 print_ident id2
+
 
 (* Values *)
 
@@ -504,15 +505,15 @@ and print_out_constr ppf (name, tyl,ret_type_opt) =
       | [] ->
           pp_print_string ppf name
       | _ ->
-          fprintf ppf "@[<2>%s of@ %a@]" name
+          fprintf ppf "@[<2>%a of@ %a@]" value_ident name
             (print_typlist print_simple_out_type " *") tyl
       end
   | Some ret_type ->
       begin match tyl with
       | [] ->
-          fprintf ppf "@[<2>%s :@ %a@]" name print_simple_out_type  ret_type
+          fprintf ppf "@[<2>%a :@ %a@]" value_ident name print_simple_out_type  ret_type
       | _ ->
-          fprintf ppf "@[<2>%s :@ %a -> %a@]" name
+          fprintf ppf "@[<2>%a :@ %a -> %a@]" value_ident name
             (print_typlist print_simple_out_type " *")
             tyl print_simple_out_type ret_type
       end


### PR DESCRIPTION
It was previously possible to overwrite the constructor `::`. This patch allows infix constructors like this : 

``` ocaml
# type arit = ( :+ ) of arit * arit | ( :* ) of arit * arit | Int of int;;
type arit = ( :+ ) of arit * arit | ( :* ) of arit * arit | Int of int

(* priorities and associativities are as expected *)
# let affine x a b =  Int a  :+  Int b :* x ;;
val affine : arit -> int -> int -> arit = <fun>

(** The various printers have been adapted *)
# affine (Int 1) 3 2 ;;
- : arit = ( :+ ) (Int 3, ( :* ) (Int 2, Int 1))

(** It works in patterns with the right priorities too *)
# let factorize = function 
    | a :* x :+ b :* y when a = b -> a :* (x :+ y) 
    | arit -> arit
  in factorize ((Int 3 :* Int 4) :+ (Int 3 :* Int 5)) ;;
- : arit = ( :* ) (Int 3, ( :+ ) (Int 4, Int 5))
```

The design is based on the one used by infix operators: 
- An infix constructor must start by `:`, analogous to the fact that a constructor must start by a capital letter.
- Priorities and associativities are the same as operators, as specified by [this table](http://caml.inria.fr/pub/docs/manual-ocaml/expr.html) but with regards to the **second** character. `:+` will behave as `+`,  and so will the very pretty `:+<>`. 
- Infix constructors starting by a `::` (`::@` for example) will have the same priority and associativity as `::`, which is unchanged.
- the prefix characters `!`, `?` and `~` can't be used inside an infix operators for the sake of retro-compatibility. The construction `a::!r` was parsed `a :: !r` and this proposal keep this behavior.

There are three exceptions to the above rules: `:>`, `:=` and `:<` **can't** be used as infix constructors (but they **can** be prefix, `:><:` is a valid infix constructor). The reason for the first two are obvious, the last one is forbidden because of the following piece of code: `x:<foo:bar>`.

To allow easier usage of the infix constructors and for consistency, I modified the parser so that 
- An infix constructor must be declared surrounded by parenthesis, as an operator.
- An infix operator can be used as a normal constructor, surrounded by parenthesis : `(:+) (Int 3, Int 4)`.
- Every constructor can be prefixed by a module to address the constructor from this module. : `M.Cons` (like before), `M.(:+)`, `M.[]`, `M.()`, `M.true` and `M.false`. All of them are rebindable (yes, including the last four. It was already the case before except for `[]`, and I changed it for consistency).

Implementation notes: 
- https://github.com/Drup/ocaml/commit/e34dc324e9a858ba0d09dc4b916feaf485b0b66d implements a simpler proposal, with only infix constructors of the form `::...`.
- https://github.com/Drup/ocaml/commit/1ba59cf2c085d5ef317c531ea9d1b908f4727c0c implements the infix constructor of the form `:..` with various priorities and associativities.
- https://github.com/Drup/ocaml/commit/c0cf9af1a226542901fc93326a26f33cc3ffcdf3 modifies the parser to allow the simplification explained in the previous paragraph.
- https://github.com/Drup/ocaml/commit/1ba59cf2c085d5ef317c531ea9d1b908f4727c0c fixes the pretty printers. I tried to be thorough, but it's quite possible I missed some. I also tried to make my modifications as simple as possible (no priority guessing to reduce the amount of parenthesis, for example). I was tempted to share some code between the various printers, but the build system disagreed with me on that, and I didn't dare to argue with him.
- https://github.com/Drup/ocaml/commit/52d52fe41f7362dbef1100b563c374ce8927a0f1 fixes a lexer in ocamldoc/ ... I'm not actually sure what it's for (rendering of code between [] in ocamldoc comments, maybe ?), but I preferred to keep it in sync with the main lexer nevertheless. 

The compiler bootstrap and the testsuite passes.

TODO:
- Check that I didn't miss any corner cases (opam and CI, I believe in you!)
- Maybe make the toplevel printer nicer, so that `(:+) (Int 3, Int 4)` is printed `Int 3 :+ Int4` ... but I'm not actually sure it's a good idea, since I don't know how to print `M.(:+) (Int 3, Int 4)`, `M.(Int 3 :+ Int4)` might not be correct.
- Add tests ? I couldn't find infix associativities and priorities tests, where are they ?

Another example, from [this](http://cedeela.fr/batch-operations-on-collections.html) : 

``` ocaml
type (_, _) op =
    Id : ('a, 'a) op
  | ( ::@ ) : ('a, 'b) base_op * ('b, 'c) op -> ('a, 'c) op
... 
let rec _optimize_head
: type a b. (a,b) op -> (a,b) op optim_result
= fun op -> match op with
 | Map f ::@ Map g ::@ cont -> ...
...
```
