### PR TITLE
[RFC] add program for returning a hash of an ocaml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2486,6 +2486,7 @@
 /tools/dumpobj
 /tools/dumpapprox
 /tools/objinfo
+/tools/ocamlmd5sum
 /tools/cvt_emit
 /tools/cvt_emit.bak
 /tools/cvt_emit.ml

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -17,13 +17,24 @@ type t =
  {mutable buffer : bytes;
   mutable position : int;
   mutable length : int;
-  initial_buffer : bytes}
+  mutable initial_buffer : bytes}
 
 let create n =
  let n = if n < 1 then 1 else n in
  let n = if n > Sys.max_string_length then Sys.max_string_length else n in
  let s = Bytes.create n in
  {buffer = s; position = 0; length = n; initial_buffer = s}
+
+let recreate b n =
+  let res = b.buffer, b.position in
+  let n = if n < 1 then 1 else n in
+  let n = if n > Sys.max_string_length then Sys.max_string_length else n in
+  let s = Bytes.create n in
+  b.buffer <- s;
+  b.position <- 0;
+  b.length <- n;
+  b.initial_buffer <- s;
+  res
 
 let contents b = Bytes.sub_string b.buffer 0 b.position
 let to_bytes b = Bytes.sub b.buffer 0 b.position

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -78,6 +78,12 @@ val reset : t -> unit
    For long-lived buffers that may have grown a lot, [reset] allows
    faster reclamation of the space used by the buffer. *)
 
+val recreate: t -> int -> bytes * int
+(** Empty the buffer, replace the initial internal byte sequence with a
+    new one of the given size and return the internal byte sequence with
+    the length of the content.
+*)
+
 val add_char : t -> char -> unit
 (** [add_char b c] appends the character [c] at the end of the buffer [b]. *)
 

--- a/tools/.depend
+++ b/tools/.depend
@@ -45,6 +45,12 @@ objinfo.cmo : ../asmcomp/printclambda.cmi ../utils/misc.cmi \
 objinfo.cmx : ../asmcomp/printclambda.cmx ../utils/misc.cmx \
     ../utils/config.cmx ../asmcomp/cmx_format.cmi ../bytecomp/cmo_format.cmi \
     ../typing/cmi_format.cmx ../bytecomp/bytesections.cmx
+ocamlmd5sum.cmo : ../utils/misc.cmi ../utils/config.cmi
+	../asmcomp/cmx_format.cmi ../bytecomp/cmo_format.cmi	\
+	../typing/cmi_format.cmi ../bytecomp/bytesections.cmi
+ocamlmd5sum.cmx : ../utils/misc.cmx ../utils/config.cmx		\
+	../asmcomp/cmx_format.cmi ../bytecomp/cmo_format.cmi	\
+	../typing/cmi_format.cmx ../bytecomp/bytesections.cmx
 ocaml299to3.cmo :
 ocaml299to3.cmx :
 ocamlcp.cmo : ../driver/main_args.cmi

--- a/tools/Makefile.shared
+++ b/tools/Makefile.shared
@@ -22,7 +22,7 @@ COMPFLAGS= -strict-sequence -w +27+32..39 -warn-error A -safe-string $(INCLUDES)
 LINKFLAGS=$(INCLUDES)
 
 all: ocamldep ocamlprof ocamlcp ocamloptp ocamlmktop ocamlmklib dumpobj \
-     objinfo read_cmt
+     objinfo read_cmt ocamlmd5sum
 
 all: tast_iter.cmo
 
@@ -30,7 +30,7 @@ all: tast_iter.cmo
 
 .PHONY: all
 
-opt.opt: ocamldep.opt read_cmt.opt
+opt.opt: ocamldep.opt read_cmt.opt ocamlmd5sum.opt
 .PHONY: opt.opt
 
 # The dependency generator
@@ -285,8 +285,10 @@ OBJINFO=../compilerlibs/ocamlcommon.cma \
         ../asmcomp/printclambda.cmo \
         objinfo.cmo
 
+
 objinfo: objinfo_helper$(EXE) $(OBJINFO)
 	$(CAMLC) -o objinfo $(OBJINFO)
+
 
 install::
 	cp objinfo $(INSTALL_BINDIR)/ocamlobjinfo$(EXE)
@@ -294,6 +296,30 @@ install::
 
 clean::
 	rm -f objinfo objinfo_helper$(EXE)
+
+# Display a hash on compiled files
+
+OCAMLMD5SUM=../compilerlibs/ocamlcommon.cma \
+            ../compilerlibs/ocamlbytecomp.cma \
+            ocamlmd5sum.cmo
+
+OCAMLMD5SUMX=../compilerlibs/ocamlcommon.cmxa \
+             ../compilerlibs/ocamlbytecomp.cmxa \
+             ocamlmd5sum.cmx
+
+ocamlmd5sum: $(OCAMLMD5SUM)
+	$(CAMLC) $(LINKFLAGS) -o ocamlmd5sum $(OCAMLMD5SUM)
+
+ocamlmd5sum.opt: $(OCAMLMD5SUMX)
+	$(CAMLOPT) $(LINKFLAGS) -o ocamlmd5sum.opt $(OCAMLMD5SUMX)
+
+install::
+	cp ocamlmd5sum $(INSTALL_BINDIR)/ocamlmd5sum$(EXE)
+	if test -f ocamldep.opt; \
+	  then cp ocamldep.opt $(INSTALL_BINDIR)/ocamldep.opt$(EXE); else :; fi
+
+clean::
+	rm -f ocamlmd5sum
 
 # Scan object files for required primitives
 

--- a/tools/ocamlmd5sum.ml
+++ b/tools/ocamlmd5sum.ml
@@ -1,0 +1,127 @@
+(***********************************************************************)
+(*                                                                     *)
+(*                                OCaml                                *)
+(*                                                                     *)
+(*            Xavier Leroy, projet Cristal, INRIA Rocquencourt         *)
+(*        Mehdi Dogguy, PPS laboratory, University Paris Diderot       *)
+(*                                                                     *)
+(*  Copyright 1996 Institut National de Recherche en Informatique et   *)
+(*  en Automatique.   Modifications Copyright 2010 Mehdi Dogguy,       *)
+(*  used and distributed as part of OCaml by permission from           *)
+(*  the author.   This file is distributed under the terms of the      *)
+(*  Q Public License version 1.0.                                      *)
+(*                                                                     *)
+(***********************************************************************)
+
+
+open Printf
+open Misc
+open Config
+
+open Cmi_format
+open Cmx_format
+
+(** copied from objinfo *)
+let read_dyn_header filename ic =
+  let tempfile = Filename.temp_file "objinfo" ".out" in
+  let helper = Filename.concat Config.standard_library "objinfo_helper" in
+  try
+    try_finally
+      (fun () ->
+        let rc = Sys.command (sprintf "%s %s > %s"
+                                (Filename.quote helper)
+                                (Filename.quote filename)
+                                tempfile) in
+        if rc <> 0 then failwith "cannot read";
+        let tc = open_in tempfile in
+        try_finally
+          (fun () ->
+            let ofs = Scanf.fscanf tc "%Ld" (fun x -> x) in
+            LargeFile.seek_in ic ofs;
+            Some(input_value ic : dynheader))
+          (fun () -> close_in tc))
+      (fun () -> remove_file tempfile)
+  with Failure _ | Sys_error _ -> None
+
+let md5sum_aux filename =
+  let ic = open_in_bin filename in
+  let len_magic_number = String.length cmo_magic_number in
+  let magic_number = really_input_string ic len_magic_number in
+  let default () = Digest.file filename in
+  let crc =
+    if magic_number = cmo_magic_number then begin
+      (** cmo doesn't have digest stored, default *)
+      default ()
+    end else if magic_number = cma_magic_number then begin
+      (** cma doesn't have digest stored, default *)
+      default ()
+    end else if magic_number = cmi_magic_number then begin
+      (** cmi digest use the digest of the signature, of
+          all the dependencies and the flags *)
+      let crcs,flags = Cmi_format.input_crcs_flags ic in
+      let todigest =
+        Buffer.create (List.length crcs * 16 + List.length flags) in
+      List.iter (function
+          | (_,Some crc) -> Buffer.add_string todigest crc
+          | (name,_)     -> Buffer.add_string todigest name
+        ) crcs;
+      List.iter (function Rectypes -> Buffer.add_char todigest 'R') flags;
+      let todigest, len = Buffer.recreate todigest 1 in
+      Digest.subbytes todigest 0 len
+    end else if magic_number = cmx_magic_number then begin
+      (** the crc of the unit is at the end of the file *)
+      let pos = in_channel_length ic - 16 in
+      seek_in ic pos;
+      Digest.input ic
+    end else if magic_number = cmxa_magic_number then begin
+      (** There is no crc easily available in a cmxa without reading the
+          whole library_infos, ie file. So we just compute directly
+          the digest of the file. *)
+      default ()
+    end else begin
+      let pos_trailer = in_channel_length ic - len_magic_number in
+      let _ = seek_in ic pos_trailer in
+      let magic_number = really_input_string ic len_magic_number in
+      if magic_number = Config.exec_magic_number then begin
+        (** bytecode *)
+        default ()
+      end else if Filename.check_suffix filename ".cmxs" then begin
+        flush stdout;
+        match read_dyn_header filename ic with
+        | None ->
+            (** can't read the header, digest of the whole file *)
+            default ()
+        | Some header ->
+            if header.dynu_magic = Config.cmxs_magic_number then
+              let units = header.dynu_units in
+              let todigest = Buffer.create (List.length units * 16) in
+              List.iter
+                (fun unit -> Buffer.add_string todigest unit.dynu_crc) units;
+              let todigest, len = Buffer.recreate todigest 1 in
+              Digest.subbytes todigest 0 len
+            else begin
+              (** wrong magic number *)
+              default ()
+            end;
+      end else begin
+        (** not an ocaml object file *)
+        default ()
+      end
+    end
+  in
+  close_in ic;
+  crc
+
+let md5sum filename =
+  let digest = md5sum_aux filename in
+  Printf.printf "%s\n%!" (Digest.to_hex digest)
+
+let arg_list = []
+let arg_usage =
+   Printf.sprintf "%s [OPTIONS] FILES : give information on files" Sys.argv.(0)
+
+let main() =
+  Arg.parse arg_list md5sum arg_usage;
+  exit 0
+
+let _ = main ()

--- a/typing/cmi_format.ml
+++ b/typing/cmi_format.ml
@@ -37,6 +37,18 @@ let input_cmi ic =
       cmi_flags = flags;
     }
 
+let input_crcs_flags ic =
+  (** skip name and signature *)
+  let header = Bytes.create Marshal.header_size in
+  really_input ic header 0 Marshal.header_size;
+  let size = Marshal.data_size header 0 in
+  seek_in ic (pos_in ic + size);
+  (** read the other fields *)
+  let crcs = input_value ic in
+  let flags = input_value ic in
+  crcs, flags
+
+
 let read_cmi filename =
   let ic = open_in_bin filename in
   try

--- a/typing/cmi_format.mli
+++ b/typing/cmi_format.mli
@@ -28,7 +28,13 @@ val input_cmi : in_channel -> cmi_infos
 (* read a cmi from a filename, checking the magic *)
 val read_cmi : string -> cmi_infos
 
-(* Error report *)
+(* read the crcs and flags informations (the magic is supposed to have
+   already been read) *)
+val input_crcs_flags:
+  in_channel -> ((string * Digest.t option) list * pers_flags list)
+
+
+  (* Error report *)
 
 type error =
     Not_an_interface of string


### PR DESCRIPTION
One way to solve [mantis 4991](http://caml.inria.fr/mantis/view.php?id=4991) (cmi partially written) is to create the output file at a temporary location (using -o), then move them to the real one, if it is different than the one already there.

This request for comment propose to add a new tool ocamlmd5sum, for computing a checksum of the .cmx, cmi, ... by reusing when possible the checksum already present in them.

Unfortunately it is not really faster than the venerable md5sum, but I don't understand why. I will also try to provide new ocamlbuild rules that use the method (temporary file) in order to show the advantage.
