### PR TITLE
Add optional perms argument to Filename.open_temp_file.

### DIFF
--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -230,13 +230,13 @@ let temp_file ?(temp_dir = !current_temp_dir_name) prefix suffix =
       if counter >= 1000 then raise e else try_name (counter + 1)
   in try_name 0
 
-let open_temp_file ?(mode = [Open_text]) ?(temp_dir = !current_temp_dir_name)
-                   prefix suffix =
+let open_temp_file ?(mode = [Open_text]) ?(perms = 0o600)
+                   ?(temp_dir = !current_temp_dir_name) prefix suffix =
   let rec try_name counter =
     let name = temp_file_name temp_dir prefix suffix in
     try
       (name,
-       open_out_gen (Open_wronly::Open_creat::Open_excl::mode) 0o600 name)
+       open_out_gen (Open_wronly::Open_creat::Open_excl::mode) perms name)
     with Sys_error _ as e ->
       if counter >= 1000 then raise e else try_name (counter + 1)
   in try_name 0

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -87,8 +87,8 @@ val temp_file : ?temp_dir: string -> string -> string -> string
 *)
 
 val open_temp_file :
-      ?mode: open_flag list -> ?temp_dir: string -> string -> string ->
-      string * out_channel
+      ?mode: open_flag list -> ?perms: int -> ?temp_dir: string -> string -> 
+      string -> string * out_channel
 (** Same as {!Filename.temp_file}, but returns both the name of a fresh
    temporary file, and an output channel opened (atomically) on
    this file.  This function is more secure than [temp_file]: there
@@ -96,8 +96,12 @@ val open_temp_file :
    by a symbolic link) before the program opens it.  The optional argument
    [mode] is a list of additional flags to control the opening of the file.
    It can contain one or several of [Open_append], [Open_binary],
-   and [Open_text].  The default is [[Open_text]] (open in text mode).
-   Raise [Sys_error] if the file could not be opened.
+   and [Open_text].  The default is [[Open_text]] (open in text mode). The
+   file is created with permissions [perms] (defaults to readable and 
+   writable only by the file owner). 
+
+   @raise Sys_error if the file could not be opened.
+   @before 4.03.0 no ?perms optional argument
    @before 3.11.2 no ?temp_dir optional argument
 *)
 


### PR DESCRIPTION
You sometimes want to be able to specify the permissions of the temporary file. See for example this issue https://github.com/ocsigen/js_of_ocaml/issues/182
