### PR TITLE
(PR6497) Emit and parse [@@@ocaml.ppx.context] attribute

### DIFF
--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -22,6 +22,7 @@ open Compenv
 (* Keep in sync with the copy in optcompile.ml *)
 
 let interface ppf sourcefile outputprefix =
+  Ast_mapper.tool_name := "ocamlc";
   Compmisc.init_path false;
   let modulename = module_of_filename ppf sourcefile outputprefix in
   Env.set_unit_name modulename;
@@ -54,6 +55,7 @@ let print_if ppf flag printer arg =
 let (++) x f = f x
 
 let implementation ppf sourcefile outputprefix =
+  Ast_mapper.tool_name := "ocamlc";
   Compmisc.init_path false;
   let modulename = module_of_filename ppf sourcefile outputprefix in
   Env.set_unit_name modulename;

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -85,6 +85,7 @@ module Options = Main_args.Make_bytecomp_options (struct
   let _custom = set custom_runtime
   let _dllib s = dllibs := Misc.rev_split_words s @ !dllibs
   let _dllpath s = dllpaths := !dllpaths @ [s]
+  let _for_pack s = for_package := Some s
   let _g = set debug
   let _i () = print_types := true; compile_only := true
   let _I s = include_dirs := s :: !include_dirs

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -73,9 +73,10 @@ let mk_dtypes f =
   "-dtypes", Arg.Unit f, " (deprecated) same as -annot"
 ;;
 
-let mk_for_pack_byt () =
-  "-for-pack", Arg.String ignore,
-  "<ident>  Ignored (for compatibility with ocamlopt)"
+let mk_for_pack_byt f =
+  "-for-pack", Arg.String f,
+  "<ident>  Generate code that can later be `packed' with\n\
+  \     ocamlc -pack -o <ident>.cmo"
 ;;
 
 let mk_for_pack_opt f =
@@ -493,6 +494,7 @@ module type Compiler_options =  sig
   val _cclib : string -> unit
   val _ccopt : string -> unit
   val _config : unit -> unit
+  val _for_pack : string -> unit
   val _g : unit -> unit
   val _i : unit -> unit
   val _impl : string -> unit
@@ -571,7 +573,6 @@ module type Optcomp_options = sig
   include Common_options
   include Compiler_options
   include Optcommon_options
-  val _for_pack : string -> unit
   val _no_float_const_prop : unit -> unit
   val _nodynlink : unit -> unit
   val _p : unit -> unit
@@ -612,7 +613,7 @@ struct
     mk_dllib F._dllib;
     mk_dllpath F._dllpath;
     mk_dtypes F._annot;
-    mk_for_pack_byt ();
+    mk_for_pack_byt F._for_pack;
     mk_g_byt F._g;
     mk_i F._i;
     mk_I F._I;

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -52,6 +52,7 @@ module type Compiler_options =  sig
   val _cclib : string -> unit
   val _ccopt : string -> unit
   val _config : unit -> unit
+  val _for_pack : string -> unit
   val _g : unit -> unit
   val _i : unit -> unit
   val _impl : string -> unit
@@ -130,7 +131,6 @@ module type Optcomp_options = sig
   include Common_options
   include Compiler_options
   include Optcommon_options
-  val _for_pack : string -> unit
   val _no_float_const_prop : unit -> unit
   val _nodynlink : unit -> unit
   val _p : unit -> unit

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -23,6 +23,7 @@ open Compenv
 (* Keep in sync with the copy in compile.ml *)
 
 let interface ppf sourcefile outputprefix =
+  Ast_mapper.tool_name := "ocamlopt";
   Compmisc.init_path false;
   let modulename = module_of_filename ppf sourcefile outputprefix in
   Env.set_unit_name modulename;
@@ -56,6 +57,7 @@ let (++) x f = f x
 let (+++) (x, y) f = (x, f y)
 
 let implementation ppf sourcefile outputprefix =
+  Ast_mapper.tool_name := "ocamlopt";
   Compmisc.init_path true;
   let modulename = module_of_filename ppf sourcefile outputprefix in
   Env.set_unit_name modulename;

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -45,6 +45,7 @@ let initial_env () =
 
 (** Optionally preprocess a source file *)
 let preprocess sourcefile =
+  Ast_mapper.tool_name := "ocamldoc";
   try
     Pparse.preprocess sourcefile
   with Pparse.Error err ->

--- a/parsing/ast_mapper.mli
+++ b/parsing/ast_mapper.mli
@@ -72,6 +72,10 @@ val default_mapper: mapper
 
 (** {2 Apply mappers to compilation units} *)
 
+val tool_name: string ref
+(** The name of the tool invoking the preprocessor:
+    ["ocamlc"], ["ocamlopt"], ["ocamldoc"], ... *)
+
 val apply: source:string -> target:string -> mapper -> unit
 (** Apply a mapper (parametrized by the unit name) to a dumped
     parsetree found in the [source] file and put the result in the

--- a/tools/Makefile.shared
+++ b/tools/Makefile.shared
@@ -39,7 +39,7 @@ CAMLDEP_OBJ=depend.cmo ocamldep.cmo
 CAMLDEP_IMPORTS=misc.cmo config.cmo clflags.cmo terminfo.cmo \
   warnings.cmo location.cmo longident.cmo \
   syntaxerr.cmo ast_helper.cmo parser.cmo lexer.cmo parse.cmo \
-  ccomp.cmo pparse.cmo compenv.cmo
+  ccomp.cmo ast_mapper.cmo pparse.cmo compenv.cmo
 
 ocamldep: depend.cmi $(CAMLDEP_OBJ)
 	$(CAMLC) $(LINKFLAGS) -compat-32 -o ocamldep $(CAMLDEP_IMPORTS) $(CAMLDEP_OBJ)

--- a/tools/ocamlcp.ml
+++ b/tools/ocamlcp.ml
@@ -54,6 +54,7 @@ module Options = Main_args.Make_bytecomp_options (struct
   let _dllib = option_with_arg "-dllib"
   let _dllpath = option_with_arg "-dllpath"
   let _dtypes = option "-dtypes"
+  let _for_pack = option_with_arg "-for-pack"
   let _g = option "-g"
   let _i = option "-i"
   let _I s = option_with_arg "-I" s

--- a/tools/ocamldep.ml
+++ b/tools/ocamldep.ml
@@ -18,7 +18,6 @@ let ppf = Format.err_formatter
 
 type file_kind = ML | MLI;;
 
-let include_dirs = ref []
 let load_path = ref ([] : (string * string array) list)
 let ml_synonyms = ref [".ml"]
 let mli_synonyms = ref [".mli"]
@@ -214,6 +213,7 @@ let report_err exn =
         | None -> raise x
 
 let read_parse_and_extract parse_function extract_function magic source_file =
+  Ast_mapper.tool_name := "ocamldep";
   Depend.free_structure_names := Depend.StringSet.empty;
   try
     let input_file = Pparse.preprocess source_file in
@@ -295,7 +295,7 @@ let file_dependencies_as kind source_file =
   load_path := [];
   List.iter add_to_load_path (
       (!Compenv.last_include_dirs @
-       !include_dirs @
+       !Clflags.include_dirs @
        !Compenv.first_include_dirs
       ));
   Location.input_name := source_file;
@@ -411,7 +411,7 @@ let _ =
         " Show absolute filenames in error messages";
      "-all", Arg.Set all_dependencies,
         " Generate dependencies on all files";
-     "-I", Arg.String (fun s -> include_dirs := s :: !include_dirs),
+     "-I", Arg.String (fun s -> Clflags.include_dirs := s :: !Clflags.include_dirs),
         "<dir>  Add <dir> to the list of include directories";
      "-impl", Arg.String (file_dependencies_as ML),
         "<f>  Process <f> as a .ml file";

--- a/toplevel/opttopmain.ml
+++ b/toplevel/opttopmain.ml
@@ -115,6 +115,7 @@ module Options = Main_args.Make_opttop_options (struct
 end);;
 
 let main () =
+  Ast_mapper.tool_name := "ocamlnat";
   Arg.parse Options.list file_argument usage;
   if not (prepare Format.err_formatter) then exit 2;
   Opttoploop.loop Format.std_formatter

--- a/toplevel/topmain.ml
+++ b/toplevel/topmain.ml
@@ -102,6 +102,7 @@ end);;
 
 let main () =
   let ppf = Format.err_formatter in
+  Ast_mapper.tool_name := "ocaml";
   Compenv.readenv ppf Before_args;
   Arg.parse Options.list file_argument usage;
   Compenv.readenv ppf Before_link;


### PR DESCRIPTION
This attribute serves to provide context to the ppx preprocessors,
specifically:
- tool name (ocamlc, ocamlopt, ...)
- -I, -g, -open, -for-pack options
