### PR TITLE
Add a safe_string tag to ocamlbuild

### DIFF
--- a/ocamlbuild/ocaml_specific.ml
+++ b/ocamlbuild/ocaml_specific.ml
@@ -665,6 +665,8 @@ flag ["ocaml"; "link"; "byte"; "output_obj"] (A"-output-obj");;
 flag ["ocaml"; "dtypes"; "compile"] (A "-dtypes");;
 flag ["ocaml"; "annot"; "compile"] (A "-annot");;
 flag ["ocaml"; "bin_annot"; "compile"] (A "-bin-annot");;
+flag ["ocaml"; "safe_string"; "compile"] (A "-safe-string");;
+flag ["ocaml"; "safe_string"; "infer_interface"] (A "-safe-string");;
 flag ["ocaml"; "short_paths"; "compile"] (A "-short-paths");;
 flag ["ocaml"; "short_paths"; "infer_interface"] (A "-short-paths");;
 flag ["ocaml"; "rectypes"; "compile"] (A "-rectypes");;


### PR DESCRIPTION
It kicks in for interface inference and compiler invocations.
safe_string does also alter the output of inferred types if
short_paths is used (since "bytes" is shorter than "string"),
but this requires a change to the ocamldoc driver and isn't
addressed in this PR.

Closes #6495
