### PR TITLE
Fix docstrings saying when Invalid_argument is raised for list functions.

### DIFF
--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -112,14 +112,14 @@ val fold_right : ('a -> 'b -> 'b) -> 'a list -> 'b -> 'b
 val iter2 : ('a -> 'b -> unit) -> 'a list -> 'b list -> unit
 (** [List.iter2 f [a1; ...; an] [b1; ...; bn]] calls in turn
    [f a1 b1; ...; f an bn].
-   Raise [Invalid_argument] if the two lists have
-   different lengths. *)
+   Raise [Invalid_argument] if the two lists are determined
+   to have different lengths. *)
 
 val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [List.map2 f [a1; ...; an] [b1; ...; bn]] is
    [[f a1 b1; ...; f an bn]].
-   Raise [Invalid_argument] if the two lists have
-   different lengths.  Not tail-recursive. *)
+   Raise [Invalid_argument] if the two lists are determined
+   to have different lengths.  Not tail-recursive. *)
 
 val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [List.rev_map2 f l1 l2] gives the same result as
@@ -129,14 +129,14 @@ val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 val fold_left2 : ('a -> 'b -> 'c -> 'a) -> 'a -> 'b list -> 'c list -> 'a
 (** [List.fold_left2 f a [b1; ...; bn] [c1; ...; cn]] is
    [f (... (f (f a b1 c1) b2 c2) ...) bn cn].
-   Raise [Invalid_argument] if the two lists have
-   different lengths. *)
+   Raise [Invalid_argument] if the two lists are determined
+   to have different lengths. *)
 
 val fold_right2 : ('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> 'c -> 'c
 (** [List.fold_right2 f [a1; ...; an] [b1; ...; bn] c] is
    [f a1 b1 (f a2 b2 (... (f an bn c) ...))].
-   Raise [Invalid_argument] if the two lists have
-   different lengths.  Not tail-recursive. *)
+   Raise [Invalid_argument] if the two lists are determined
+   to have different lengths.  Not tail-recursive. *)
 
 
 (** {6 List scanning} *)
@@ -154,13 +154,13 @@ val exists : ('a -> bool) -> 'a list -> bool
 
 val for_all2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!List.for_all}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two lists have
-   different lengths. *)
+   Raise [Invalid_argument] if the two lists are determined
+   to have different lengths. *)
 
 val exists2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!List.exists}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two lists have
-   different lengths. *)
+   Raise [Invalid_argument] if the two lists are determined
+   to have different lengths. *)
 
 val mem : 'a -> 'a list -> bool
 (** [mem a l] is true if and only if [a] is equal

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -112,14 +112,14 @@ val fold_right : f:('a -> 'b -> 'b) -> 'a list -> init:'b -> 'b
 val iter2 : f:('a -> 'b -> unit) -> 'a list -> 'b list -> unit
 (** [List.iter2 f [a1; ...; an] [b1; ...; bn]] calls in turn
    [f a1 b1; ...; f an bn].
-   Raise [Invalid_argument] if the two lists have
-   different lengths. *)
+   Raise [Invalid_argument] if the two lists are determined
+   to have different lengths. *)
 
 val map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [List.map2 f [a1; ...; an] [b1; ...; bn]] is
    [[f a1 b1; ...; f an bn]].
-   Raise [Invalid_argument] if the two lists have
-   different lengths.  Not tail-recursive. *)
+   Raise [Invalid_argument] if the two lists are determined
+   to have different lengths.  Not tail-recursive. *)
 
 val rev_map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [List.rev_map2 f l1 l2] gives the same result as
@@ -130,15 +130,15 @@ val fold_left2 :
   f:('a -> 'b -> 'c -> 'a) -> init:'a -> 'b list -> 'c list -> 'a
 (** [List.fold_left2 f a [b1; ...; bn] [c1; ...; cn]] is
    [f (... (f (f a b1 c1) b2 c2) ...) bn cn].
-   Raise [Invalid_argument] if the two lists have
-   different lengths. *)
+   Raise [Invalid_argument] if the two lists are determined
+   to have different lengths. *)
 
 val fold_right2 :
   f:('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> init:'c -> 'c
 (** [List.fold_right2 f [a1; ...; an] [b1; ...; bn] c] is
    [f a1 b1 (f a2 b2 (... (f an bn c) ...))].
-   Raise [Invalid_argument] if the two lists have
-   different lengths.  Not tail-recursive. *)
+   Raise [Invalid_argument] if the two lists are determined
+   to have different lengths.  Not tail-recursive. *)
 
 
 (** {6 List scanning} *)
@@ -156,13 +156,13 @@ val exists : f:('a -> bool) -> 'a list -> bool
 
 val for_all2 : f:('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!ListLabels.for_all}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two lists have
-   different lengths. *)
+   Raise [Invalid_argument] if the two lists are determined
+   to have different lengths. *)
 
 val exists2 : f:('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!ListLabels.exists}, but for a two-argument predicate.
-   Raise [Invalid_argument] if the two lists have
-   different lengths. *)
+   Raise [Invalid_argument] if the two lists are determined
+   to have different lengths. *)
 
 val mem : 'a -> set:'a list -> bool
 (** [mem a l] is true if and only if [a] is equal


### PR DESCRIPTION
I've been migrating some list-processing code to use [Core_kernel](https://github.com/janestreet/core_kernel) instead of the [standard library](https://github.com/ocaml/ocaml/tree/trunk/stdlib) and noticed that the documentation strings for the two libraries have somehow become interchanged.  The standard library documentation for `List.exists2` [says](https://github.com/ocaml/ocaml/blob/68fe1eb/stdlib/list.mli#L160-L163):

>  Same as `List.exists`, but for a two-argument predicate. Raise `Invalid_argument` if the two lists have different lengths.

In fact, `List.exists2` does not always raise `Invalid_argument` if the two lists have different lengths:

``` ocaml
# List.exists2 (>) [1; 2] [3; 1; 0];;
- : bool = true
```

On the other hand, the documentation for `Core.Std.List.exists2_exn` [says](https://github.com/janestreet/core_kernel/blob/c1dcec751/lib/core_list.mli#L73-L76):

> Same as `List.exists`, but for a two-argument predicate. Raise `Invalid_argument` if the end of one list is reached before the end of the other.

In fact, `Core.Std.List.exists2_exn` can fail even if the predicate is satisfied (which should mean that the ends of the lists are not reached):

``` ocaml
# Core_kernel.Std.List.exists2_exn ~f:(>) [1; 2] [3; 1; 0];; 
Exception: Invalid_argument "length mismatch in exists2_exn: 2 <> 3 ".
```

This changeset rectifies the situation for various functions in the standard library.  (See janestreet/core_kernel#16 for the corresponding `core_kernel` issue.
