### PR TITLE
Add punning for object copying expressions.

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1408,7 +1408,7 @@ field_expr:
     label EQUAL expr
       { (mkrhs $1 1, $3) }
   | label
-      { (mkrhs $1 1, mkexp (Pexp_ident (mkrhs (Lident $1) 1))) }
+      { (mkrhs $1 1, exp_of_label (Lident $1) 1) }
 ;
 expr_semi_list:
     expr                                        { [$1] }

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1401,9 +1401,8 @@ lbl_expr:
       { (mkrhs $1 1, exp_of_label $1 1) }
 ;
 field_expr_list:
-    field_expr { [$1] }
+    field_expr opt_semi { [$1] }
   | field_expr SEMI field_expr_list { $1 :: $3 }
-  | field_expr SEMI { [$1] }
 ;
 field_expr:
     label EQUAL expr

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1264,15 +1264,15 @@ simple_expr:
       { mkexp(Pexp_apply(mkoperator "!" 1, ["",$2])) }
   | NEW ext_attributes class_longident
       { mkexp_attrs (Pexp_new(mkrhs $3 3)) $2 }
-  | LBRACELESS field_expr_list opt_semi GREATERRBRACE
-      { mkexp (Pexp_override(List.rev $2)) }
-  | LBRACELESS field_expr_list opt_semi error
+  | LBRACELESS field_expr_list GREATERRBRACE
+      { mkexp (Pexp_override $2) }
+  | LBRACELESS field_expr_list error
       { unclosed "{<" 1 ">}" 4 }
   | LBRACELESS GREATERRBRACE
       { mkexp (Pexp_override [])}
-  | mod_longident DOT LBRACELESS field_expr_list opt_semi GREATERRBRACE
-      { mkexp(Pexp_open(Fresh, mkrhs $1 1, mkexp (Pexp_override(List.rev $4))))}
-  | mod_longident DOT LBRACELESS field_expr_list opt_semi error
+  | mod_longident DOT LBRACELESS field_expr_list GREATERRBRACE
+      { mkexp(Pexp_open(Fresh, mkrhs $1 1, mkexp (Pexp_override $4)))}
+  | mod_longident DOT LBRACELESS field_expr_list error
       { unclosed "{<" 3 ">}" 6 }
   | simple_expr SHARP label
       { mkexp(Pexp_send($1, $3)) }
@@ -1401,10 +1401,15 @@ lbl_expr:
       { (mkrhs $1 1, exp_of_label $1 1) }
 ;
 field_expr_list:
+    field_expr { [$1] }
+  | field_expr SEMI field_expr_list { $1 :: $3 }
+  | field_expr SEMI { [$1] }
+;
+field_expr:
     label EQUAL expr
-      { [mkrhs $1 1,$3] }
-  | field_expr_list SEMI label EQUAL expr
-      { (mkrhs $3 3, $5) :: $1 }
+      { (mkrhs $1 1, $3) }
+  | label
+      { (mkrhs $1 1, mkexp (Pexp_ident (mkrhs (Lident $1) 1))) }
 ;
 expr_semi_list:
     expr                                        { [$1] }


### PR DESCRIPTION
This little patch extends the "punning" pattern in the OCaml syntax to object override expressions.  The punning pattern conflates label names and variable names in various contexts; for example, you can define functions with labeled arguments either by binding variables for each argument or by punning, borrowing the label name as a variable:

``` ocaml
let f ~a:x ~b:y = x + y
let f  ~a  ~b   = a + b
```

Similarly, you can pass labeled arguments either explicitly or by punning:

``` ocaml
let x = 3 and y = 4 in f ~a:x ~b:y
let a = 3 and b = 4 in f  ~a  ~b
```

The same thing applies to record labels, both in patterns and expressions:

``` ocaml
let conj { re = r ; im = i } = { re = r; im = -.i }
let conj { re; im } = { re; im = -.im }
```

This patch extends the pattern to object override expressions, which make copies of objects, changing the values of some fields.  With the patch applied you can either use the existing syntax or the more concise version with punning:

``` ocaml
object val a = 3 val b = 4 method m x y = {< a = x; b = y >} end
object val a = 3 val b = 4 method m a b = {< a; b >} end
```
