### PR TITLE
Specialize primitives even when eta-expanding

### DIFF
--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -40,6 +40,12 @@ let rec struct_const ppf = function
         List.iter (fun f -> fprintf ppf "@ %s" f) fl in
       fprintf ppf "@[<1>[|@[%s%a@]|]@]" f1 floats fl
 
+let array_kind = function
+  | Pgenarray -> "gen"
+  | Paddrarray -> "addr"
+  | Pintarray -> "int"
+  | Pfloatarray -> "float"
+
 let boxed_integer_name = function
   | Pnativeint -> "nativeint"
   | Pint32 -> "int32"
@@ -158,12 +164,12 @@ let primitive ppf = function
   | Pstringsetu -> fprintf ppf "string.unsafe_set"
   | Pstringrefs -> fprintf ppf "string.get"
   | Pstringsets -> fprintf ppf "string.set"
-  | Parraylength _ -> fprintf ppf "array.length"
-  | Pmakearray _ -> fprintf ppf "makearray "
-  | Parrayrefu _ -> fprintf ppf "array.unsafe_get"
-  | Parraysetu _ -> fprintf ppf "array.unsafe_set"
-  | Parrayrefs _ -> fprintf ppf "array.get"
-  | Parraysets _ -> fprintf ppf "array.set"
+  | Parraylength k -> fprintf ppf "array.length[%s]" (array_kind k)
+  | Pmakearray k -> fprintf ppf "makearray[%s]" (array_kind k)
+  | Parrayrefu k -> fprintf ppf "array.unsafe_get[%s]" (array_kind k)
+  | Parraysetu k -> fprintf ppf "array.unsafe_set[%s]" (array_kind k)
+  | Parrayrefs k -> fprintf ppf "array.get[%s]" (array_kind k)
+  | Parraysets k -> fprintf ppf "array.set[%s]" (array_kind k)
   | Pctconst c ->
      let const_name = match c with
        | Big_endian -> "big_endian"

--- a/bytecomp/translcore.mli
+++ b/bytecomp/translcore.mli
@@ -21,7 +21,8 @@ val transl_exp: expression -> lambda
 val transl_apply: lambda -> (label * expression option * optional) list
                   -> Location.t -> lambda
 val transl_let: rec_flag -> value_binding list -> lambda -> lambda
-val transl_primitive: Location.t -> Primitive.description -> lambda
+val transl_primitive: Location.t -> Primitive.description -> Env.t
+                      -> Types.type_expr -> lambda
 
 val check_recursive_lambda: Ident.t list -> lambda -> bool
 

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -97,7 +97,7 @@ let rec apply_coercion strict restr arg =
             (Lapply(Lvar id, [apply_coercion Alias cc_arg (Lvar param)],
                     Location.none))))
   | Tcoerce_primitive {pc_desc; pc_type; pc_env} ->
-      transl_primitive Location.none pc_desc
+      transl_primitive Location.none pc_desc pc_env pc_type
   | Tcoerce_alias (path, cc) ->
       name_lambda strict arg
         (fun id -> apply_coercion Alias cc (transl_normal_path path))
@@ -385,7 +385,8 @@ and transl_structure fields cc rootpath = function
                   (fun (pos, cc) ->
                     match cc with
                       Tcoerce_primitive p ->
-                        transl_primitive Location.none p.pc_desc
+                        transl_primitive Location.none
+                          p.pc_desc p.pc_env p.pc_type
                     | _ -> apply_coercion Strict cc (get_field pos))
                   pos_cc_list))
           and id_pos_list =
@@ -704,7 +705,8 @@ let transl_store_structure glob map prims str =
   and store_primitive (pos, prim) cont =
     Lsequence(Lprim(Psetfield(pos, false),
                     [Lprim(Pgetglobal glob, []);
-                     transl_primitive Location.none prim.pc_desc]),
+                     transl_primitive Location.none
+                       prim.pc_desc prim.pc_env prim.pc_type]),
               cont)
 
   in List.fold_right store_primitive prims

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -96,8 +96,8 @@ let rec apply_coercion strict restr arg =
           apply_coercion Strict cc_res
             (Lapply(Lvar id, [apply_coercion Alias cc_arg (Lvar param)],
                     Location.none))))
-  | Tcoerce_primitive p ->
-      transl_primitive Location.none p
+  | Tcoerce_primitive {pc_desc; pc_type; pc_env} ->
+      transl_primitive Location.none pc_desc
   | Tcoerce_alias (path, cc) ->
       name_lambda strict arg
         (fun id -> apply_coercion Alias cc (transl_normal_path path))
@@ -121,7 +121,7 @@ and wrap_id_pos_list id_pos_list get_field lam =
       (lam, Ident.empty) id_pos_list
   in
   if s == Ident.empty then lam else subst_lambda s lam
-  
+
 
 (* Compose two coercions
    apply_coercion c1 (apply_coercion c2 e) behaves like
@@ -384,7 +384,8 @@ and transl_structure fields cc rootpath = function
                 List.map
                   (fun (pos, cc) ->
                     match cc with
-                      Tcoerce_primitive p -> transl_primitive Location.none p
+                      Tcoerce_primitive p ->
+                        transl_primitive Location.none p.pc_desc
                     | _ -> apply_coercion Strict cc (get_field pos))
                   pos_cc_list))
           and id_pos_list =
@@ -703,7 +704,7 @@ let transl_store_structure glob map prims str =
   and store_primitive (pos, prim) cont =
     Lsequence(Lprim(Psetfield(pos, false),
                     [Lprim(Pgetglobal glob, []);
-                     transl_primitive Location.none prim]),
+                     transl_primitive Location.none prim.pc_desc]),
               cont)
 
   in List.fold_right store_primitive prims

--- a/bytecomp/typeopt.ml
+++ b/bytecomp/typeopt.ml
@@ -20,18 +20,26 @@ open Lambda
 let scrape env ty =
   (Ctype.repr (Ctype.expand_head_opt env (Ctype.correct_levels ty))).desc
 
-let has_base_type exp base_ty_path =
-  match scrape exp.exp_env exp.exp_type with
+let is_function_type env ty =
+  match scrape env ty with
+  | Tarrow (_, lhs, rhs, _) -> Some (lhs, rhs)
+  | _ -> None
+
+let is_base_type env ty base_ty_path =
+  match scrape env ty with
   | Tconstr(p, _, _) -> Path.same p base_ty_path
   | _ -> false
 
-let maybe_pointer exp =
-  match scrape exp.exp_env exp.exp_type with
+let has_base_type exp base_ty_path =
+  is_base_type exp.exp_env exp.exp_type base_ty_path
+
+let maybe_pointer_type env typ =
+  match scrape env typ with
   | Tconstr(p, args, abbrev) ->
       not (Path.same p Predef.path_int) &&
       not (Path.same p Predef.path_char) &&
       begin try
-        match Env.find_type p exp.exp_env with
+        match Env.find_type p env with
         | {type_kind = Type_variant []} -> true (* type exn *)
         | {type_kind = Type_variant cstrs} ->
             List.exists (fun c -> c.Types.cd_args <> Cstr_tuple []) cstrs
@@ -42,6 +50,8 @@ let maybe_pointer exp =
            Maybe we should emit a warning. *)
       end
   | _ -> true
+
+let maybe_pointer exp = maybe_pointer_type exp.exp_env exp.exp_type
 
 let array_element_kind env ty =
   match scrape env ty with
@@ -78,7 +88,7 @@ let array_element_kind env ty =
   | _ ->
       Paddrarray
 
-let array_kind_gen ty env =
+let array_type_kind env ty =
   match scrape env ty with
   | Tconstr(p, [elt_ty], _) | Tpoly({desc = Tconstr(p, [elt_ty], _)}, _)
     when Path.same p Predef.path_array ->
@@ -87,9 +97,9 @@ let array_kind_gen ty env =
       (* This can happen with e.g. Obj.field *)
       Pgenarray
 
-let array_kind exp = array_kind_gen exp.exp_type exp.exp_env
+let array_kind exp = array_type_kind exp.exp_env exp.exp_type
 
-let array_pattern_kind pat = array_kind_gen pat.pat_type pat.pat_env
+let array_pattern_kind pat = array_type_kind pat.pat_env pat.pat_type
 
 let bigarray_decode_type env ty tbl dfl =
   match scrape env ty with
@@ -117,11 +127,11 @@ let layout_table =
   ["c_layout", Pbigarray_c_layout;
    "fortran_layout", Pbigarray_fortran_layout]
 
-let bigarray_kind_and_layout exp =
-  match scrape exp.exp_env exp.exp_type with
+let bigarray_type_kind_and_layout env typ =
+  match scrape env typ with
   | Tconstr(p, [caml_type; elt_type; layout_type], abbrev) ->
-      (bigarray_decode_type exp.exp_env elt_type kind_table Pbigarray_unknown,
-       bigarray_decode_type exp.exp_env layout_type layout_table
+      (bigarray_decode_type env elt_type kind_table Pbigarray_unknown,
+       bigarray_decode_type env layout_type layout_table
                             Pbigarray_unknown_layout)
   | _ ->
       (Pbigarray_unknown, Pbigarray_unknown_layout)

--- a/bytecomp/typeopt.mli
+++ b/bytecomp/typeopt.mli
@@ -12,9 +12,16 @@
 
 (* Auxiliaries for type-based optimizations, e.g. array kinds *)
 
+val is_function_type :
+      Env.t -> Types.type_expr -> (Types.type_expr * Types.type_expr) option
+val is_base_type : Env.t -> Types.type_expr -> Path.t -> bool
 val has_base_type : Typedtree.expression -> Path.t -> bool
+
+val maybe_pointer_type : Env.t -> Types.type_expr -> bool
 val maybe_pointer : Typedtree.expression -> bool
+
+val array_type_kind : Env.t -> Types.type_expr -> Lambda.array_kind
 val array_kind : Typedtree.expression -> Lambda.array_kind
 val array_pattern_kind : Typedtree.pattern -> Lambda.array_kind
-val bigarray_kind_and_layout :
-      Typedtree.expression -> Lambda.bigarray_kind * Lambda.bigarray_layout
+val bigarray_type_kind_and_layout :
+      Env.t -> Types.type_expr -> Lambda.bigarray_kind * Lambda.bigarray_layout

--- a/testsuite/tests/translprim/Makefile
+++ b/testsuite/tests/translprim/Makefile
@@ -1,0 +1,4 @@
+BASEDIR=../..
+TOPFLAGS+=-dlambda
+include $(BASEDIR)/makefiles/Makefile.toplevel
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/translprim/array_spec.ml
+++ b/testsuite/tests/translprim/array_spec.ml
@@ -1,0 +1,62 @@
+external len : 'a array -> int = "%array_length"
+external safe_get : 'a array -> int -> 'a = "%array_safe_get"
+external unsafe_get : 'a array -> int -> 'a = "%array_unsafe_get"
+external safe_set : 'a array -> int -> 'a -> unit = "%array_safe_set"
+external unsafe_set : 'a array -> int -> 'a -> unit = "%array_unsafe_set"
+
+(* Specialization in application *)
+
+let int_a = [|1;2;3|];;
+let float_a = [|1.;2.;3.|];;
+let addr_a = [|"a";"b";"c"|];;
+
+len int_a;;
+len float_a;;
+len addr_a;;
+(fun a -> len a);;
+
+safe_get int_a 0;;
+safe_get float_a 0;;
+safe_get addr_a 0;;
+(fun a -> safe_get a 0);;
+
+unsafe_get int_a 0;;
+unsafe_get float_a 0;;
+unsafe_get addr_a 0;;
+(fun a -> unsafe_get a 0);;
+
+safe_set int_a 0 1;;
+safe_set float_a 0 1.;;
+safe_set addr_a 0 "a";;
+(fun a x -> safe_set a 0 x);;
+
+unsafe_set int_a 0 1;;
+unsafe_set float_a 0 1.;;
+unsafe_set addr_a 0 "a";;
+(fun a x -> unsafe_set a 0 x);;
+
+(* Specialization during eta-expansion *)
+
+let eta_gen_len : 'a array -> _ = len;;
+let eta_gen_safe_get : 'a array -> int -> 'a = safe_get;;
+let eta_gen_unsafe_get : 'a array -> int -> 'a = unsafe_get;;
+let eta_gen_safe_set : 'a array -> int -> 'a -> unit = safe_set;;
+let eta_gen_unsafe_set : 'a array -> int -> 'a -> unit = unsafe_set;;
+
+let eta_int_len : int array -> _ = len;;
+let eta_int_safe_get : int array -> int -> int = safe_get;;
+let eta_int_unsafe_get : int array -> int -> int = unsafe_get;;
+let eta_int_safe_set : int array -> int -> int -> unit = safe_set;;
+let eta_int_unsafe_set : int array -> int -> int -> unit = unsafe_set;;
+
+let eta_float_len : float array -> _ = len;;
+let eta_float_safe_get : float array -> int -> float = safe_get;;
+let eta_float_unsafe_get : float array -> int -> float = unsafe_get;;
+let eta_float_safe_set : float array -> int -> float -> unit = safe_set;;
+let eta_float_unsafe_set : float array -> int -> float -> unit = unsafe_set;;
+
+let eta_addr_len : string array -> _ = len;;
+let eta_addr_safe_get : string array -> int -> string = safe_get;;
+let eta_addr_unsafe_get : string array -> int -> string = unsafe_get;;
+let eta_addr_safe_set : string array -> int -> string -> unit = safe_set;;
+let eta_addr_unsafe_set : string array -> int -> string -> unit = unsafe_set;;

--- a/testsuite/tests/translprim/array_spec.ml.reference
+++ b/testsuite/tests/translprim/array_spec.ml.reference
@@ -1,0 +1,194 @@
+
+#                 (seq 0a 0a 0a 0a 0a
+  (let (int_a/1211 = (makearray[int] 1 2 3))
+    (apply (field 1 (global Toploop!)) "int_a" int_a/1211)))
+external len : 'a array -> int = "%array_length"
+external safe_get : 'a array -> int -> 'a = "%array_safe_get"
+external unsafe_get : 'a array -> int -> 'a = "%array_unsafe_get"
+external safe_set : 'a array -> int -> 'a -> unit = "%array_safe_set"
+external unsafe_set : 'a array -> int -> 'a -> unit = "%array_unsafe_set"
+val int_a : int array = [|1; 2; 3|]
+# (let (float_a/1212 = (makearray[float] 1. 2. 3.))
+  (apply (field 1 (global Toploop!)) "float_a" float_a/1212))
+val float_a : float array = [|1.; 2.; 3.|]
+# (let (addr_a/1213 = (makearray[addr] "a" "b" "c"))
+  (apply (field 1 (global Toploop!)) "addr_a" addr_a/1213))
+val addr_a : string array = [|"a"; "b"; "c"|]
+#   (let (int_a/1211 = (apply (field 0 (global Toploop!)) "int_a"))
+  (array.length[int] int_a/1211))
+- : int = 3
+# (let (float_a/1212 = (apply (field 0 (global Toploop!)) "float_a"))
+  (array.length[float] float_a/1212))
+- : int = 3
+# (let (addr_a/1213 = (apply (field 0 (global Toploop!)) "addr_a"))
+  (array.length[addr] addr_a/1213))
+- : int = 3
+# (function a/1214 (array.length[gen] a/1214))
+- : 'a array -> int = <fun>
+#   (let (int_a/1211 = (apply (field 0 (global Toploop!)) "int_a"))
+  (array.get[int] int_a/1211 0))
+- : int = 1
+# (let (float_a/1212 = (apply (field 0 (global Toploop!)) "float_a"))
+  (array.get[float] float_a/1212 0))
+- : float = 1.
+# (let (addr_a/1213 = (apply (field 0 (global Toploop!)) "addr_a"))
+  (array.get[addr] addr_a/1213 0))
+- : string = "a"
+# (function a/1215 (array.get[gen] a/1215 0))
+- : 'a array -> 'a = <fun>
+#   (let (int_a/1211 = (apply (field 0 (global Toploop!)) "int_a"))
+  (array.unsafe_get[int] int_a/1211 0))
+- : int = 1
+# (let (float_a/1212 = (apply (field 0 (global Toploop!)) "float_a"))
+  (array.unsafe_get[float] float_a/1212 0))
+- : float = 1.
+# (let (addr_a/1213 = (apply (field 0 (global Toploop!)) "addr_a"))
+  (array.unsafe_get[addr] addr_a/1213 0))
+- : string = "a"
+# (function a/1216 (array.unsafe_get[gen] a/1216 0))
+- : 'a array -> 'a = <fun>
+#   (let (int_a/1211 = (apply (field 0 (global Toploop!)) "int_a"))
+  (array.set[int] int_a/1211 0 1))
+- : unit = ()
+# (let (float_a/1212 = (apply (field 0 (global Toploop!)) "float_a"))
+  (array.set[float] float_a/1212 0 1.))
+- : unit = ()
+# (let (addr_a/1213 = (apply (field 0 (global Toploop!)) "addr_a"))
+  (array.set[addr] addr_a/1213 0 "a"))
+- : unit = ()
+# (function a/1217 x/1218 (array.set[gen] a/1217 0 x/1218))
+- : 'a array -> 'a -> unit = <fun>
+#   (let (int_a/1211 = (apply (field 0 (global Toploop!)) "int_a"))
+  (array.unsafe_set[int] int_a/1211 0 1))
+- : unit = ()
+# (let (float_a/1212 = (apply (field 0 (global Toploop!)) "float_a"))
+  (array.unsafe_set[float] float_a/1212 0 1.))
+- : unit = ()
+# (let (addr_a/1213 = (apply (field 0 (global Toploop!)) "addr_a"))
+  (array.unsafe_set[addr] addr_a/1213 0 "a"))
+- : unit = ()
+# (function a/1219 x/1220 (array.unsafe_set[gen] a/1219 0 x/1220))
+- : 'a array -> 'a -> unit = <fun>
+#       (let (eta_gen_len/1221 = (function prim/1222 (array.length[gen] prim/1222)))
+  (apply (field 1 (global Toploop!)) "eta_gen_len" eta_gen_len/1221))
+val eta_gen_len : 'a array -> int = <fun>
+# (let
+  (eta_gen_safe_get/1223 =
+     (function prim/1225 prim/1224 (array.get[gen] prim/1225 prim/1224)))
+  (apply (field 1 (global Toploop!)) "eta_gen_safe_get"
+    eta_gen_safe_get/1223))
+val eta_gen_safe_get : 'a array -> int -> 'a = <fun>
+# (let
+  (eta_gen_unsafe_get/1226 =
+     (function prim/1228 prim/1227
+       (array.unsafe_get[gen] prim/1228 prim/1227)))
+  (apply (field 1 (global Toploop!)) "eta_gen_unsafe_get"
+    eta_gen_unsafe_get/1226))
+val eta_gen_unsafe_get : 'a array -> int -> 'a = <fun>
+# (let
+  (eta_gen_safe_set/1229 =
+     (function prim/1232 prim/1231 prim/1230
+       (array.set[gen] prim/1232 prim/1231 prim/1230)))
+  (apply (field 1 (global Toploop!)) "eta_gen_safe_set"
+    eta_gen_safe_set/1229))
+val eta_gen_safe_set : 'a array -> int -> 'a -> unit = <fun>
+# (let
+  (eta_gen_unsafe_set/1233 =
+     (function prim/1236 prim/1235 prim/1234
+       (array.unsafe_set[gen] prim/1236 prim/1235 prim/1234)))
+  (apply (field 1 (global Toploop!)) "eta_gen_unsafe_set"
+    eta_gen_unsafe_set/1233))
+val eta_gen_unsafe_set : 'a array -> int -> 'a -> unit = <fun>
+#   (let (eta_int_len/1237 = (function prim/1238 (array.length[int] prim/1238)))
+  (apply (field 1 (global Toploop!)) "eta_int_len" eta_int_len/1237))
+val eta_int_len : int array -> int = <fun>
+# (let
+  (eta_int_safe_get/1239 =
+     (function prim/1241 prim/1240 (array.get[int] prim/1241 prim/1240)))
+  (apply (field 1 (global Toploop!)) "eta_int_safe_get"
+    eta_int_safe_get/1239))
+val eta_int_safe_get : int array -> int -> int = <fun>
+# (let
+  (eta_int_unsafe_get/1242 =
+     (function prim/1244 prim/1243
+       (array.unsafe_get[int] prim/1244 prim/1243)))
+  (apply (field 1 (global Toploop!)) "eta_int_unsafe_get"
+    eta_int_unsafe_get/1242))
+val eta_int_unsafe_get : int array -> int -> int = <fun>
+# (let
+  (eta_int_safe_set/1245 =
+     (function prim/1248 prim/1247 prim/1246
+       (array.set[int] prim/1248 prim/1247 prim/1246)))
+  (apply (field 1 (global Toploop!)) "eta_int_safe_set"
+    eta_int_safe_set/1245))
+val eta_int_safe_set : int array -> int -> int -> unit = <fun>
+# (let
+  (eta_int_unsafe_set/1249 =
+     (function prim/1252 prim/1251 prim/1250
+       (array.unsafe_set[int] prim/1252 prim/1251 prim/1250)))
+  (apply (field 1 (global Toploop!)) "eta_int_unsafe_set"
+    eta_int_unsafe_set/1249))
+val eta_int_unsafe_set : int array -> int -> int -> unit = <fun>
+#   (let
+  (eta_float_len/1253 = (function prim/1254 (array.length[float] prim/1254)))
+  (apply (field 1 (global Toploop!)) "eta_float_len" eta_float_len/1253))
+val eta_float_len : float array -> int = <fun>
+# (let
+  (eta_float_safe_get/1255 =
+     (function prim/1257 prim/1256 (array.get[float] prim/1257 prim/1256)))
+  (apply (field 1 (global Toploop!)) "eta_float_safe_get"
+    eta_float_safe_get/1255))
+val eta_float_safe_get : float array -> int -> float = <fun>
+# (let
+  (eta_float_unsafe_get/1258 =
+     (function prim/1260 prim/1259
+       (array.unsafe_get[float] prim/1260 prim/1259)))
+  (apply (field 1 (global Toploop!)) "eta_float_unsafe_get"
+    eta_float_unsafe_get/1258))
+val eta_float_unsafe_get : float array -> int -> float = <fun>
+# (let
+  (eta_float_safe_set/1261 =
+     (function prim/1264 prim/1263 prim/1262
+       (array.set[float] prim/1264 prim/1263 prim/1262)))
+  (apply (field 1 (global Toploop!)) "eta_float_safe_set"
+    eta_float_safe_set/1261))
+val eta_float_safe_set : float array -> int -> float -> unit = <fun>
+# (let
+  (eta_float_unsafe_set/1265 =
+     (function prim/1268 prim/1267 prim/1266
+       (array.unsafe_set[float] prim/1268 prim/1267 prim/1266)))
+  (apply (field 1 (global Toploop!)) "eta_float_unsafe_set"
+    eta_float_unsafe_set/1265))
+val eta_float_unsafe_set : float array -> int -> float -> unit = <fun>
+#   (let
+  (eta_addr_len/1269 = (function prim/1270 (array.length[addr] prim/1270)))
+  (apply (field 1 (global Toploop!)) "eta_addr_len" eta_addr_len/1269))
+val eta_addr_len : string array -> int = <fun>
+# (let
+  (eta_addr_safe_get/1271 =
+     (function prim/1273 prim/1272 (array.get[addr] prim/1273 prim/1272)))
+  (apply (field 1 (global Toploop!)) "eta_addr_safe_get"
+    eta_addr_safe_get/1271))
+val eta_addr_safe_get : string array -> int -> string = <fun>
+# (let
+  (eta_addr_unsafe_get/1274 =
+     (function prim/1276 prim/1275
+       (array.unsafe_get[addr] prim/1276 prim/1275)))
+  (apply (field 1 (global Toploop!)) "eta_addr_unsafe_get"
+    eta_addr_unsafe_get/1274))
+val eta_addr_unsafe_get : string array -> int -> string = <fun>
+# (let
+  (eta_addr_safe_set/1277 =
+     (function prim/1280 prim/1279 prim/1278
+       (array.set[addr] prim/1280 prim/1279 prim/1278)))
+  (apply (field 1 (global Toploop!)) "eta_addr_safe_set"
+    eta_addr_safe_set/1277))
+val eta_addr_safe_set : string array -> int -> string -> unit = <fun>
+# (let
+  (eta_addr_unsafe_set/1281 =
+     (function prim/1284 prim/1283 prim/1282
+       (array.unsafe_set[addr] prim/1284 prim/1283 prim/1282)))
+  (apply (field 1 (global Toploop!)) "eta_addr_unsafe_set"
+    eta_addr_unsafe_set/1281))
+val eta_addr_unsafe_set : string array -> int -> string -> unit = <fun>
+# 

--- a/testsuite/tests/translprim/comparison_table.ml
+++ b/testsuite/tests/translprim/comparison_table.ml
@@ -1,0 +1,193 @@
+external cmp : 'a -> 'a -> int = "%compare";;
+external eq : 'a -> 'a -> bool = "%equal";;
+external ne : 'a -> 'a -> bool = "%notequal";;
+external lt : 'a -> 'a -> bool = "%lessthan";;
+external gt : 'a -> 'a -> bool = "%greaterthan";;
+external le : 'a -> 'a -> bool = "%lessequal";;
+external ge : 'a -> 'a -> bool = "%greaterequal";;
+
+(* Check specialization in explicit application *)
+
+let gen_cmp x y = cmp x y;;
+let int_cmp (x : int) y = cmp x y;;
+let float_cmp (x : float) y = cmp x y;;
+let string_cmp (x : string) y = cmp x y;;
+let int32_cmp (x : int32) y = cmp x y;;
+let int64_cmp (x : int64) y = cmp x y;;
+let nativeint_cmp (x : nativeint) y = cmp x y;;
+
+let gen_eq x y = eq x y;;
+let int_eq (x : int) y = eq x y;;
+let float_eq (x : float) y = eq x y;;
+let string_eq (x : string) y = eq x y;;
+let int32_eq (x : int32) y = eq x y;;
+let int64_eq (x : int64) y = eq x y;;
+let nativeint_eq (x : nativeint) y = eq x y;;
+
+let gen_ne x y = ne x y;;
+let int_ne (x : int) y = ne x y;;
+let float_ne (x : float) y = ne x y;;
+let string_ne (x : string) y = ne x y;;
+let int32_ne (x : int32) y = ne x y;;
+let int64_ne (x : int64) y = ne x y;;
+let nativeint_ne (x : nativeint) y = ne x y;;
+
+let gen_lt x y = lt x y;;
+let int_lt (x : int) y = lt x y;;
+let float_lt (x : float) y = lt x y;;
+let string_lt (x : string) y = lt x y;;
+let int32_lt (x : int32) y = lt x y;;
+let int64_lt (x : int64) y = lt x y;;
+let nativeint_lt (x : nativeint) y = lt x y;;
+
+let gen_gt x y = gt x y;;
+let int_gt (x : int) y = gt x y;;
+let float_gt (x : float) y = gt x y;;
+let string_gt (x : string) y = gt x y;;
+let int32_gt (x : int32) y = gt x y;;
+let int64_gt (x : int64) y = gt x y;;
+let nativeint_gt (x : nativeint) y = gt x y;;
+
+let gen_le x y = le x y;;
+let int_le (x : int) y = le x y;;
+let float_le (x : float) y = le x y;;
+let string_le (x : string) y = le x y;;
+let int32_le (x : int32) y = le x y;;
+let int64_le (x : int64) y = le x y;;
+let nativeint_le (x : nativeint) y = le x y;;
+
+let gen_ge x y = ge x y;;
+let int_ge (x : int) y = ge x y;;
+let float_ge (x : float) y = ge x y;;
+let string_ge (x : string) y = ge x y;;
+let int32_ge (x : int32) y = ge x y;;
+let int64_ge (x : int64) y = ge x y;;
+let nativeint_ge (x : nativeint) y = ge x y;;
+
+(* Check specialization in eta-expansion *)
+
+let eta_gen_cmp : 'a -> _ = cmp;;
+let eta_int_cmp : int -> _ = cmp;;
+let eta_float_cmp : float -> _ = cmp;;
+let eta_string_cmp : string -> _ = cmp;;
+let eta_int32_cmp : int32 -> _ = cmp;;
+let eta_int64_cmp : int64 -> _ = cmp;;
+let eta_nativeint_cmp : nativeint -> _ = cmp;;
+
+let eta_gen_eq : 'a -> _ = eq;;
+let eta_int_eq : int -> _ = eq;;
+let eta_float_eq : float -> _ = eq;;
+let eta_string_eq : string -> _ = eq;;
+let eta_int32_eq : int32 -> _ = eq;;
+let eta_int64_eq : int64 -> _ = eq;;
+let eta_nativeint_eq : nativeint -> _ = eq;;
+
+let eta_gen_ne : 'a -> _ = ne;;
+let eta_int_ne : int -> _ = ne;;
+let eta_float_ne : float -> _ = ne;;
+let eta_string_ne : string -> _ = ne;;
+let eta_int32_ne : int32 -> _ = ne;;
+let eta_int64_ne : int64 -> _ = ne;;
+let eta_nativeint_ne : nativeint -> _ = ne;;
+
+let eta_gen_lt : 'a -> _ = lt;;
+let eta_int_lt : int -> _ = lt;;
+let eta_float_lt : float -> _ = lt;;
+let eta_string_lt : string -> _ = lt;;
+let eta_int32_lt : int32 -> _ = lt;;
+let eta_int64_lt : int64 -> _ = lt;;
+let eta_nativeint_lt : nativeint -> _ = lt;;
+
+let eta_gen_gt : 'a -> _ = gt;;
+let eta_int_gt : int -> _ = gt;;
+let eta_float_gt : float -> _ = gt;;
+let eta_string_gt : string -> _ = gt;;
+let eta_int32_gt : int32 -> _ = gt;;
+let eta_int64_gt : int64 -> _ = gt;;
+let eta_nativeint_gt : nativeint -> _ = gt;;
+
+let eta_gen_le : 'a -> _ = le;;
+let eta_int_le : int -> _ = le;;
+let eta_float_le : float -> _ = le;;
+let eta_string_le : string -> _ = le;;
+let eta_int32_le : int32 -> _ = le;;
+let eta_int64_le : int64 -> _ = le;;
+let eta_nativeint_le : nativeint -> _ = le;;
+
+let eta_gen_ge : 'a -> _ = ge;;
+let eta_int_ge : int -> _ = ge;;
+let eta_float_ge : float -> _ = ge;;
+let eta_string_ge : string -> _ = ge;;
+let eta_int32_ge : int32 -> _ = ge;;
+let eta_int64_ge : int64 -> _ = ge;;
+let eta_nativeint_ge : nativeint -> _ = ge;;
+
+(* Check results of computations *)
+
+let int_vec = [(1,1);(1,2);(2,1)];;
+let float_vec = [(1.,1.);(1.,2.);(2.,1.)];;
+let string_vec = [("1","1");("1","2");("2","1")];;
+let int32_vec = [(1l,1l);(1l,2l);(2l,1l)];;
+let int64_vec = [(1L,1L);(1L,2L);(2L,1L)];;
+let nativeint_vec = [(1n,1n);(1n,2n);(2n,1n)];;
+
+let test_vec cmp eq ne lt gt le ge vec =
+  let uncurry f (x,y) = f x y in
+  let map f l = List.map (uncurry f) l in
+  (map gen_cmp vec, map cmp vec),
+  (map (fun gen spec -> map gen vec, map spec vec)
+     [gen_eq,eq; gen_ne,ne; gen_lt,lt; gen_gt,gt; gen_le,le; gen_ge,ge])
+;;
+
+test_vec
+  int_cmp int_eq int_ne int_lt int_gt int_le int_ge
+  int_vec;;
+test_vec
+  float_cmp float_eq float_ne float_lt float_gt float_le float_ge
+  float_vec;;
+test_vec
+  string_cmp string_eq string_ne string_lt string_gt string_le string_ge
+  string_vec;;
+test_vec
+  int32_cmp int32_eq int32_ne int32_lt int32_gt int32_le int32_ge
+  int32_vec;;
+test_vec
+  int64_cmp int64_eq int64_ne int64_lt int64_gt int64_le int64_ge
+  int64_vec;;
+test_vec
+  nativeint_cmp nativeint_eq nativeint_ne
+  nativeint_lt nativeint_gt nativeint_le nativeint_ge
+  nativeint_vec;;
+
+let eta_test_vec cmp eq ne lt gt le ge vec =
+  let uncurry f (x,y) = f x y in
+  let map f l = List.map (uncurry f) l in
+  (map eta_gen_cmp vec, map cmp vec),
+  (map (fun gen spec -> map gen vec, map spec vec)
+     [eta_gen_eq,eq; eta_gen_ne,ne; eta_gen_lt,lt;
+      eta_gen_gt,gt; eta_gen_le,le; eta_gen_ge,ge])
+;;
+
+eta_test_vec
+  eta_int_cmp eta_int_eq eta_int_ne eta_int_lt eta_int_gt eta_int_le eta_int_ge
+  int_vec;;
+eta_test_vec
+  eta_float_cmp eta_float_eq eta_float_ne eta_float_lt eta_float_gt
+  eta_float_le eta_float_ge
+  float_vec;;
+eta_test_vec
+  eta_string_cmp eta_string_eq eta_string_ne eta_string_lt eta_string_gt
+  eta_string_le eta_string_ge
+  string_vec;;
+eta_test_vec
+  eta_int32_cmp eta_int32_eq eta_int32_ne eta_int32_lt eta_int32_gt
+  eta_int32_le eta_int32_ge
+  int32_vec;;
+eta_test_vec
+  eta_int64_cmp eta_int64_eq eta_int64_ne eta_int64_lt eta_int64_gt
+  eta_int64_le eta_int64_ge
+  int64_vec;;
+eta_test_vec
+  eta_nativeint_cmp eta_nativeint_eq eta_nativeint_ne
+  eta_nativeint_lt eta_nativeint_gt eta_nativeint_le eta_nativeint_ge
+  nativeint_vec;;

--- a/testsuite/tests/translprim/comparison_table.ml.reference
+++ b/testsuite/tests/translprim/comparison_table.ml.reference
@@ -1,0 +1,807 @@
+
+# 0a
+external cmp : 'a -> 'a -> int = "%compare"
+# 0a
+external eq : 'a -> 'a -> bool = "%equal"
+# 0a
+external ne : 'a -> 'a -> bool = "%notequal"
+# 0a
+external lt : 'a -> 'a -> bool = "%lessthan"
+# 0a
+external gt : 'a -> 'a -> bool = "%greaterthan"
+# 0a
+external le : 'a -> 'a -> bool = "%lessequal"
+# 0a
+external ge : 'a -> 'a -> bool = "%greaterequal"
+#       (let (gen_cmp/1213 = (function x/1214 y/1215 (caml_compare x/1214 y/1215)))
+  (apply (field 1 (global Toploop!)) "gen_cmp" gen_cmp/1213))
+val gen_cmp : 'a -> 'a -> int = <fun>
+# (let
+  (int_cmp/1216 = (function x/1217 y/1218 (caml_int_compare x/1217 y/1218)))
+  (apply (field 1 (global Toploop!)) "int_cmp" int_cmp/1216))
+val int_cmp : int -> int -> int = <fun>
+# (let
+  (float_cmp/1219 =
+     (function x/1220 y/1221 (caml_float_compare x/1220 y/1221)))
+  (apply (field 1 (global Toploop!)) "float_cmp" float_cmp/1219))
+val float_cmp : float -> float -> int = <fun>
+# (let
+  (string_cmp/1222 =
+     (function x/1223 y/1224 (caml_string_compare x/1223 y/1224)))
+  (apply (field 1 (global Toploop!)) "string_cmp" string_cmp/1222))
+val string_cmp : string -> string -> int = <fun>
+# (let
+  (int32_cmp/1225 =
+     (function x/1226 y/1227 (caml_int32_compare x/1226 y/1227)))
+  (apply (field 1 (global Toploop!)) "int32_cmp" int32_cmp/1225))
+val int32_cmp : int32 -> int32 -> int = <fun>
+# (let
+  (int64_cmp/1228 =
+     (function x/1229 y/1230 (caml_int64_compare x/1229 y/1230)))
+  (apply (field 1 (global Toploop!)) "int64_cmp" int64_cmp/1228))
+val int64_cmp : int64 -> int64 -> int = <fun>
+# (let
+  (nativeint_cmp/1231 =
+     (function x/1232 y/1233 (caml_nativeint_compare x/1232 y/1233)))
+  (apply (field 1 (global Toploop!)) "nativeint_cmp" nativeint_cmp/1231))
+val nativeint_cmp : nativeint -> nativeint -> int = <fun>
+#   (let (gen_eq/1234 = (function x/1235 y/1236 (caml_equal x/1235 y/1236)))
+  (apply (field 1 (global Toploop!)) "gen_eq" gen_eq/1234))
+val gen_eq : 'a -> 'a -> bool = <fun>
+# (let (int_eq/1237 = (function x/1238 y/1239 (== x/1238 y/1239)))
+  (apply (field 1 (global Toploop!)) "int_eq" int_eq/1237))
+val int_eq : int -> int -> bool = <fun>
+# (let (float_eq/1240 = (function x/1241 y/1242 (==. x/1241 y/1242)))
+  (apply (field 1 (global Toploop!)) "float_eq" float_eq/1240))
+val float_eq : float -> float -> bool = <fun>
+# (let
+  (string_eq/1243 =
+     (function x/1244 y/1245 (caml_string_equal x/1244 y/1245)))
+  (apply (field 1 (global Toploop!)) "string_eq" string_eq/1243))
+val string_eq : string -> string -> bool = <fun>
+# (let (int32_eq/1246 = (function x/1247 y/1248 (Int32.== x/1247 y/1248)))
+  (apply (field 1 (global Toploop!)) "int32_eq" int32_eq/1246))
+val int32_eq : int32 -> int32 -> bool = <fun>
+# (let (int64_eq/1249 = (function x/1250 y/1251 (Int64.== x/1250 y/1251)))
+  (apply (field 1 (global Toploop!)) "int64_eq" int64_eq/1249))
+val int64_eq : int64 -> int64 -> bool = <fun>
+# (let
+  (nativeint_eq/1252 = (function x/1253 y/1254 (Nativeint.== x/1253 y/1254)))
+  (apply (field 1 (global Toploop!)) "nativeint_eq" nativeint_eq/1252))
+val nativeint_eq : nativeint -> nativeint -> bool = <fun>
+#   (let (gen_ne/1255 = (function x/1256 y/1257 (caml_notequal x/1256 y/1257)))
+  (apply (field 1 (global Toploop!)) "gen_ne" gen_ne/1255))
+val gen_ne : 'a -> 'a -> bool = <fun>
+# (let (int_ne/1258 = (function x/1259 y/1260 (!= x/1259 y/1260)))
+  (apply (field 1 (global Toploop!)) "int_ne" int_ne/1258))
+val int_ne : int -> int -> bool = <fun>
+# (let (float_ne/1261 = (function x/1262 y/1263 (!=. x/1262 y/1263)))
+  (apply (field 1 (global Toploop!)) "float_ne" float_ne/1261))
+val float_ne : float -> float -> bool = <fun>
+# (let
+  (string_ne/1264 =
+     (function x/1265 y/1266 (caml_string_notequal x/1265 y/1266)))
+  (apply (field 1 (global Toploop!)) "string_ne" string_ne/1264))
+val string_ne : string -> string -> bool = <fun>
+# (let (int32_ne/1267 = (function x/1268 y/1269 (Int32.!= x/1268 y/1269)))
+  (apply (field 1 (global Toploop!)) "int32_ne" int32_ne/1267))
+val int32_ne : int32 -> int32 -> bool = <fun>
+# (let (int64_ne/1270 = (function x/1271 y/1272 (Int64.!= x/1271 y/1272)))
+  (apply (field 1 (global Toploop!)) "int64_ne" int64_ne/1270))
+val int64_ne : int64 -> int64 -> bool = <fun>
+# (let
+  (nativeint_ne/1273 = (function x/1274 y/1275 (Nativeint.!= x/1274 y/1275)))
+  (apply (field 1 (global Toploop!)) "nativeint_ne" nativeint_ne/1273))
+val nativeint_ne : nativeint -> nativeint -> bool = <fun>
+#   (let (gen_lt/1276 = (function x/1277 y/1278 (caml_lessthan x/1277 y/1278)))
+  (apply (field 1 (global Toploop!)) "gen_lt" gen_lt/1276))
+val gen_lt : 'a -> 'a -> bool = <fun>
+# (let (int_lt/1279 = (function x/1280 y/1281 (< x/1280 y/1281)))
+  (apply (field 1 (global Toploop!)) "int_lt" int_lt/1279))
+val int_lt : int -> int -> bool = <fun>
+# (let (float_lt/1282 = (function x/1283 y/1284 (<. x/1283 y/1284)))
+  (apply (field 1 (global Toploop!)) "float_lt" float_lt/1282))
+val float_lt : float -> float -> bool = <fun>
+# (let
+  (string_lt/1285 =
+     (function x/1286 y/1287 (caml_string_lessthan x/1286 y/1287)))
+  (apply (field 1 (global Toploop!)) "string_lt" string_lt/1285))
+val string_lt : string -> string -> bool = <fun>
+# (let (int32_lt/1288 = (function x/1289 y/1290 (Int32.< x/1289 y/1290)))
+  (apply (field 1 (global Toploop!)) "int32_lt" int32_lt/1288))
+val int32_lt : int32 -> int32 -> bool = <fun>
+# (let (int64_lt/1291 = (function x/1292 y/1293 (Int64.< x/1292 y/1293)))
+  (apply (field 1 (global Toploop!)) "int64_lt" int64_lt/1291))
+val int64_lt : int64 -> int64 -> bool = <fun>
+# (let
+  (nativeint_lt/1294 = (function x/1295 y/1296 (Nativeint.< x/1295 y/1296)))
+  (apply (field 1 (global Toploop!)) "nativeint_lt" nativeint_lt/1294))
+val nativeint_lt : nativeint -> nativeint -> bool = <fun>
+#   (let
+  (gen_gt/1297 = (function x/1298 y/1299 (caml_greaterthan x/1298 y/1299)))
+  (apply (field 1 (global Toploop!)) "gen_gt" gen_gt/1297))
+val gen_gt : 'a -> 'a -> bool = <fun>
+# (let (int_gt/1300 = (function x/1301 y/1302 (> x/1301 y/1302)))
+  (apply (field 1 (global Toploop!)) "int_gt" int_gt/1300))
+val int_gt : int -> int -> bool = <fun>
+# (let (float_gt/1303 = (function x/1304 y/1305 (>. x/1304 y/1305)))
+  (apply (field 1 (global Toploop!)) "float_gt" float_gt/1303))
+val float_gt : float -> float -> bool = <fun>
+# (let
+  (string_gt/1306 =
+     (function x/1307 y/1308 (caml_string_greaterthan x/1307 y/1308)))
+  (apply (field 1 (global Toploop!)) "string_gt" string_gt/1306))
+val string_gt : string -> string -> bool = <fun>
+# (let (int32_gt/1309 = (function x/1310 y/1311 (Int32.> x/1310 y/1311)))
+  (apply (field 1 (global Toploop!)) "int32_gt" int32_gt/1309))
+val int32_gt : int32 -> int32 -> bool = <fun>
+# (let (int64_gt/1312 = (function x/1313 y/1314 (Int64.> x/1313 y/1314)))
+  (apply (field 1 (global Toploop!)) "int64_gt" int64_gt/1312))
+val int64_gt : int64 -> int64 -> bool = <fun>
+# (let
+  (nativeint_gt/1315 = (function x/1316 y/1317 (Nativeint.> x/1316 y/1317)))
+  (apply (field 1 (global Toploop!)) "nativeint_gt" nativeint_gt/1315))
+val nativeint_gt : nativeint -> nativeint -> bool = <fun>
+#   (let (gen_le/1318 = (function x/1319 y/1320 (caml_lessequal x/1319 y/1320)))
+  (apply (field 1 (global Toploop!)) "gen_le" gen_le/1318))
+val gen_le : 'a -> 'a -> bool = <fun>
+# (let (int_le/1321 = (function x/1322 y/1323 (<= x/1322 y/1323)))
+  (apply (field 1 (global Toploop!)) "int_le" int_le/1321))
+val int_le : int -> int -> bool = <fun>
+# (let (float_le/1324 = (function x/1325 y/1326 (<=. x/1325 y/1326)))
+  (apply (field 1 (global Toploop!)) "float_le" float_le/1324))
+val float_le : float -> float -> bool = <fun>
+# (let
+  (string_le/1327 =
+     (function x/1328 y/1329 (caml_string_lessequal x/1328 y/1329)))
+  (apply (field 1 (global Toploop!)) "string_le" string_le/1327))
+val string_le : string -> string -> bool = <fun>
+# (let (int32_le/1330 = (function x/1331 y/1332 (Int32.<= x/1331 y/1332)))
+  (apply (field 1 (global Toploop!)) "int32_le" int32_le/1330))
+val int32_le : int32 -> int32 -> bool = <fun>
+# (let (int64_le/1333 = (function x/1334 y/1335 (Int64.<= x/1334 y/1335)))
+  (apply (field 1 (global Toploop!)) "int64_le" int64_le/1333))
+val int64_le : int64 -> int64 -> bool = <fun>
+# (let
+  (nativeint_le/1336 = (function x/1337 y/1338 (Nativeint.<= x/1337 y/1338)))
+  (apply (field 1 (global Toploop!)) "nativeint_le" nativeint_le/1336))
+val nativeint_le : nativeint -> nativeint -> bool = <fun>
+#   (let
+  (gen_ge/1339 = (function x/1340 y/1341 (caml_greaterequal x/1340 y/1341)))
+  (apply (field 1 (global Toploop!)) "gen_ge" gen_ge/1339))
+val gen_ge : 'a -> 'a -> bool = <fun>
+# (let (int_ge/1342 = (function x/1343 y/1344 (>= x/1343 y/1344)))
+  (apply (field 1 (global Toploop!)) "int_ge" int_ge/1342))
+val int_ge : int -> int -> bool = <fun>
+# (let (float_ge/1345 = (function x/1346 y/1347 (>=. x/1346 y/1347)))
+  (apply (field 1 (global Toploop!)) "float_ge" float_ge/1345))
+val float_ge : float -> float -> bool = <fun>
+# (let
+  (string_ge/1348 =
+     (function x/1349 y/1350 (caml_string_greaterequal x/1349 y/1350)))
+  (apply (field 1 (global Toploop!)) "string_ge" string_ge/1348))
+val string_ge : string -> string -> bool = <fun>
+# (let (int32_ge/1351 = (function x/1352 y/1353 (Int32.>= x/1352 y/1353)))
+  (apply (field 1 (global Toploop!)) "int32_ge" int32_ge/1351))
+val int32_ge : int32 -> int32 -> bool = <fun>
+# (let (int64_ge/1354 = (function x/1355 y/1356 (Int64.>= x/1355 y/1356)))
+  (apply (field 1 (global Toploop!)) "int64_ge" int64_ge/1354))
+val int64_ge : int64 -> int64 -> bool = <fun>
+# (let
+  (nativeint_ge/1357 = (function x/1358 y/1359 (Nativeint.>= x/1358 y/1359)))
+  (apply (field 1 (global Toploop!)) "nativeint_ge" nativeint_ge/1357))
+val nativeint_ge : nativeint -> nativeint -> bool = <fun>
+#       (let
+  (eta_gen_cmp/1360 =
+     (function prim/1362 prim/1361 (caml_compare prim/1362 prim/1361)))
+  (apply (field 1 (global Toploop!)) "eta_gen_cmp" eta_gen_cmp/1360))
+val eta_gen_cmp : 'a -> 'a -> int = <fun>
+# (let
+  (eta_int_cmp/1363 =
+     (function prim/1365 prim/1364 (caml_int_compare prim/1365 prim/1364)))
+  (apply (field 1 (global Toploop!)) "eta_int_cmp" eta_int_cmp/1363))
+val eta_int_cmp : int -> int -> int = <fun>
+# (let
+  (eta_float_cmp/1366 =
+     (function prim/1368 prim/1367 (caml_float_compare prim/1368 prim/1367)))
+  (apply (field 1 (global Toploop!)) "eta_float_cmp" eta_float_cmp/1366))
+val eta_float_cmp : float -> float -> int = <fun>
+# (let
+  (eta_string_cmp/1369 =
+     (function prim/1371 prim/1370 (caml_string_compare prim/1371 prim/1370)))
+  (apply (field 1 (global Toploop!)) "eta_string_cmp" eta_string_cmp/1369))
+val eta_string_cmp : string -> string -> int = <fun>
+# (let
+  (eta_int32_cmp/1372 =
+     (function prim/1374 prim/1373 (caml_int32_compare prim/1374 prim/1373)))
+  (apply (field 1 (global Toploop!)) "eta_int32_cmp" eta_int32_cmp/1372))
+val eta_int32_cmp : int32 -> int32 -> int = <fun>
+# (let
+  (eta_int64_cmp/1375 =
+     (function prim/1377 prim/1376 (caml_int64_compare prim/1377 prim/1376)))
+  (apply (field 1 (global Toploop!)) "eta_int64_cmp" eta_int64_cmp/1375))
+val eta_int64_cmp : int64 -> int64 -> int = <fun>
+# (let
+  (eta_nativeint_cmp/1378 =
+     (function prim/1380 prim/1379
+       (caml_nativeint_compare prim/1380 prim/1379)))
+  (apply (field 1 (global Toploop!)) "eta_nativeint_cmp"
+    eta_nativeint_cmp/1378))
+val eta_nativeint_cmp : nativeint -> nativeint -> int = <fun>
+#   (let
+  (eta_gen_eq/1381 =
+     (function prim/1383 prim/1382 (caml_equal prim/1383 prim/1382)))
+  (apply (field 1 (global Toploop!)) "eta_gen_eq" eta_gen_eq/1381))
+val eta_gen_eq : 'a -> 'a -> bool = <fun>
+# (let
+  (eta_int_eq/1384 = (function prim/1386 prim/1385 (== prim/1386 prim/1385)))
+  (apply (field 1 (global Toploop!)) "eta_int_eq" eta_int_eq/1384))
+val eta_int_eq : int -> int -> bool = <fun>
+# (let
+  (eta_float_eq/1387 =
+     (function prim/1389 prim/1388 (==. prim/1389 prim/1388)))
+  (apply (field 1 (global Toploop!)) "eta_float_eq" eta_float_eq/1387))
+val eta_float_eq : float -> float -> bool = <fun>
+# (let
+  (eta_string_eq/1390 =
+     (function prim/1392 prim/1391 (caml_string_equal prim/1392 prim/1391)))
+  (apply (field 1 (global Toploop!)) "eta_string_eq" eta_string_eq/1390))
+val eta_string_eq : string -> string -> bool = <fun>
+# (let
+  (eta_int32_eq/1393 =
+     (function prim/1395 prim/1394 (Int32.== prim/1395 prim/1394)))
+  (apply (field 1 (global Toploop!)) "eta_int32_eq" eta_int32_eq/1393))
+val eta_int32_eq : int32 -> int32 -> bool = <fun>
+# (let
+  (eta_int64_eq/1396 =
+     (function prim/1398 prim/1397 (Int64.== prim/1398 prim/1397)))
+  (apply (field 1 (global Toploop!)) "eta_int64_eq" eta_int64_eq/1396))
+val eta_int64_eq : int64 -> int64 -> bool = <fun>
+# (let
+  (eta_nativeint_eq/1399 =
+     (function prim/1401 prim/1400 (Nativeint.== prim/1401 prim/1400)))
+  (apply (field 1 (global Toploop!)) "eta_nativeint_eq"
+    eta_nativeint_eq/1399))
+val eta_nativeint_eq : nativeint -> nativeint -> bool = <fun>
+#   (let
+  (eta_gen_ne/1402 =
+     (function prim/1404 prim/1403 (caml_notequal prim/1404 prim/1403)))
+  (apply (field 1 (global Toploop!)) "eta_gen_ne" eta_gen_ne/1402))
+val eta_gen_ne : 'a -> 'a -> bool = <fun>
+# (let
+  (eta_int_ne/1405 = (function prim/1407 prim/1406 (!= prim/1407 prim/1406)))
+  (apply (field 1 (global Toploop!)) "eta_int_ne" eta_int_ne/1405))
+val eta_int_ne : int -> int -> bool = <fun>
+# (let
+  (eta_float_ne/1408 =
+     (function prim/1410 prim/1409 (!=. prim/1410 prim/1409)))
+  (apply (field 1 (global Toploop!)) "eta_float_ne" eta_float_ne/1408))
+val eta_float_ne : float -> float -> bool = <fun>
+# (let
+  (eta_string_ne/1411 =
+     (function prim/1413 prim/1412
+       (caml_string_notequal prim/1413 prim/1412)))
+  (apply (field 1 (global Toploop!)) "eta_string_ne" eta_string_ne/1411))
+val eta_string_ne : string -> string -> bool = <fun>
+# (let
+  (eta_int32_ne/1414 =
+     (function prim/1416 prim/1415 (Int32.!= prim/1416 prim/1415)))
+  (apply (field 1 (global Toploop!)) "eta_int32_ne" eta_int32_ne/1414))
+val eta_int32_ne : int32 -> int32 -> bool = <fun>
+# (let
+  (eta_int64_ne/1417 =
+     (function prim/1419 prim/1418 (Int64.!= prim/1419 prim/1418)))
+  (apply (field 1 (global Toploop!)) "eta_int64_ne" eta_int64_ne/1417))
+val eta_int64_ne : int64 -> int64 -> bool = <fun>
+# (let
+  (eta_nativeint_ne/1420 =
+     (function prim/1422 prim/1421 (Nativeint.!= prim/1422 prim/1421)))
+  (apply (field 1 (global Toploop!)) "eta_nativeint_ne"
+    eta_nativeint_ne/1420))
+val eta_nativeint_ne : nativeint -> nativeint -> bool = <fun>
+#   (let
+  (eta_gen_lt/1423 =
+     (function prim/1425 prim/1424 (caml_lessthan prim/1425 prim/1424)))
+  (apply (field 1 (global Toploop!)) "eta_gen_lt" eta_gen_lt/1423))
+val eta_gen_lt : 'a -> 'a -> bool = <fun>
+# (let
+  (eta_int_lt/1426 = (function prim/1428 prim/1427 (< prim/1428 prim/1427)))
+  (apply (field 1 (global Toploop!)) "eta_int_lt" eta_int_lt/1426))
+val eta_int_lt : int -> int -> bool = <fun>
+# (let
+  (eta_float_lt/1429 =
+     (function prim/1431 prim/1430 (<. prim/1431 prim/1430)))
+  (apply (field 1 (global Toploop!)) "eta_float_lt" eta_float_lt/1429))
+val eta_float_lt : float -> float -> bool = <fun>
+# (let
+  (eta_string_lt/1432 =
+     (function prim/1434 prim/1433
+       (caml_string_lessthan prim/1434 prim/1433)))
+  (apply (field 1 (global Toploop!)) "eta_string_lt" eta_string_lt/1432))
+val eta_string_lt : string -> string -> bool = <fun>
+# (let
+  (eta_int32_lt/1435 =
+     (function prim/1437 prim/1436 (Int32.< prim/1437 prim/1436)))
+  (apply (field 1 (global Toploop!)) "eta_int32_lt" eta_int32_lt/1435))
+val eta_int32_lt : int32 -> int32 -> bool = <fun>
+# (let
+  (eta_int64_lt/1438 =
+     (function prim/1440 prim/1439 (Int64.< prim/1440 prim/1439)))
+  (apply (field 1 (global Toploop!)) "eta_int64_lt" eta_int64_lt/1438))
+val eta_int64_lt : int64 -> int64 -> bool = <fun>
+# (let
+  (eta_nativeint_lt/1441 =
+     (function prim/1443 prim/1442 (Nativeint.< prim/1443 prim/1442)))
+  (apply (field 1 (global Toploop!)) "eta_nativeint_lt"
+    eta_nativeint_lt/1441))
+val eta_nativeint_lt : nativeint -> nativeint -> bool = <fun>
+#   (let
+  (eta_gen_gt/1444 =
+     (function prim/1446 prim/1445 (caml_greaterthan prim/1446 prim/1445)))
+  (apply (field 1 (global Toploop!)) "eta_gen_gt" eta_gen_gt/1444))
+val eta_gen_gt : 'a -> 'a -> bool = <fun>
+# (let
+  (eta_int_gt/1447 = (function prim/1449 prim/1448 (> prim/1449 prim/1448)))
+  (apply (field 1 (global Toploop!)) "eta_int_gt" eta_int_gt/1447))
+val eta_int_gt : int -> int -> bool = <fun>
+# (let
+  (eta_float_gt/1450 =
+     (function prim/1452 prim/1451 (>. prim/1452 prim/1451)))
+  (apply (field 1 (global Toploop!)) "eta_float_gt" eta_float_gt/1450))
+val eta_float_gt : float -> float -> bool = <fun>
+# (let
+  (eta_string_gt/1453 =
+     (function prim/1455 prim/1454
+       (caml_string_greaterthan prim/1455 prim/1454)))
+  (apply (field 1 (global Toploop!)) "eta_string_gt" eta_string_gt/1453))
+val eta_string_gt : string -> string -> bool = <fun>
+# (let
+  (eta_int32_gt/1456 =
+     (function prim/1458 prim/1457 (Int32.> prim/1458 prim/1457)))
+  (apply (field 1 (global Toploop!)) "eta_int32_gt" eta_int32_gt/1456))
+val eta_int32_gt : int32 -> int32 -> bool = <fun>
+# (let
+  (eta_int64_gt/1459 =
+     (function prim/1461 prim/1460 (Int64.> prim/1461 prim/1460)))
+  (apply (field 1 (global Toploop!)) "eta_int64_gt" eta_int64_gt/1459))
+val eta_int64_gt : int64 -> int64 -> bool = <fun>
+# (let
+  (eta_nativeint_gt/1462 =
+     (function prim/1464 prim/1463 (Nativeint.> prim/1464 prim/1463)))
+  (apply (field 1 (global Toploop!)) "eta_nativeint_gt"
+    eta_nativeint_gt/1462))
+val eta_nativeint_gt : nativeint -> nativeint -> bool = <fun>
+#   (let
+  (eta_gen_le/1465 =
+     (function prim/1467 prim/1466 (caml_lessequal prim/1467 prim/1466)))
+  (apply (field 1 (global Toploop!)) "eta_gen_le" eta_gen_le/1465))
+val eta_gen_le : 'a -> 'a -> bool = <fun>
+# (let
+  (eta_int_le/1468 = (function prim/1470 prim/1469 (<= prim/1470 prim/1469)))
+  (apply (field 1 (global Toploop!)) "eta_int_le" eta_int_le/1468))
+val eta_int_le : int -> int -> bool = <fun>
+# (let
+  (eta_float_le/1471 =
+     (function prim/1473 prim/1472 (<=. prim/1473 prim/1472)))
+  (apply (field 1 (global Toploop!)) "eta_float_le" eta_float_le/1471))
+val eta_float_le : float -> float -> bool = <fun>
+# (let
+  (eta_string_le/1474 =
+     (function prim/1476 prim/1475
+       (caml_string_lessequal prim/1476 prim/1475)))
+  (apply (field 1 (global Toploop!)) "eta_string_le" eta_string_le/1474))
+val eta_string_le : string -> string -> bool = <fun>
+# (let
+  (eta_int32_le/1477 =
+     (function prim/1479 prim/1478 (Int32.<= prim/1479 prim/1478)))
+  (apply (field 1 (global Toploop!)) "eta_int32_le" eta_int32_le/1477))
+val eta_int32_le : int32 -> int32 -> bool = <fun>
+# (let
+  (eta_int64_le/1480 =
+     (function prim/1482 prim/1481 (Int64.<= prim/1482 prim/1481)))
+  (apply (field 1 (global Toploop!)) "eta_int64_le" eta_int64_le/1480))
+val eta_int64_le : int64 -> int64 -> bool = <fun>
+# (let
+  (eta_nativeint_le/1483 =
+     (function prim/1485 prim/1484 (Nativeint.<= prim/1485 prim/1484)))
+  (apply (field 1 (global Toploop!)) "eta_nativeint_le"
+    eta_nativeint_le/1483))
+val eta_nativeint_le : nativeint -> nativeint -> bool = <fun>
+#   (let
+  (eta_gen_ge/1486 =
+     (function prim/1488 prim/1487 (caml_greaterequal prim/1488 prim/1487)))
+  (apply (field 1 (global Toploop!)) "eta_gen_ge" eta_gen_ge/1486))
+val eta_gen_ge : 'a -> 'a -> bool = <fun>
+# (let
+  (eta_int_ge/1489 = (function prim/1491 prim/1490 (>= prim/1491 prim/1490)))
+  (apply (field 1 (global Toploop!)) "eta_int_ge" eta_int_ge/1489))
+val eta_int_ge : int -> int -> bool = <fun>
+# (let
+  (eta_float_ge/1492 =
+     (function prim/1494 prim/1493 (>=. prim/1494 prim/1493)))
+  (apply (field 1 (global Toploop!)) "eta_float_ge" eta_float_ge/1492))
+val eta_float_ge : float -> float -> bool = <fun>
+# (let
+  (eta_string_ge/1495 =
+     (function prim/1497 prim/1496
+       (caml_string_greaterequal prim/1497 prim/1496)))
+  (apply (field 1 (global Toploop!)) "eta_string_ge" eta_string_ge/1495))
+val eta_string_ge : string -> string -> bool = <fun>
+# (let
+  (eta_int32_ge/1498 =
+     (function prim/1500 prim/1499 (Int32.>= prim/1500 prim/1499)))
+  (apply (field 1 (global Toploop!)) "eta_int32_ge" eta_int32_ge/1498))
+val eta_int32_ge : int32 -> int32 -> bool = <fun>
+# (let
+  (eta_int64_ge/1501 =
+     (function prim/1503 prim/1502 (Int64.>= prim/1503 prim/1502)))
+  (apply (field 1 (global Toploop!)) "eta_int64_ge" eta_int64_ge/1501))
+val eta_int64_ge : int64 -> int64 -> bool = <fun>
+# (let
+  (eta_nativeint_ge/1504 =
+     (function prim/1506 prim/1505 (Nativeint.>= prim/1506 prim/1505)))
+  (apply (field 1 (global Toploop!)) "eta_nativeint_ge"
+    eta_nativeint_ge/1504))
+val eta_nativeint_ge : nativeint -> nativeint -> bool = <fun>
+#       (let (int_vec/1507 = [0: [0: 1 1] [0: [0: 1 2] [0: [0: 2 1] 0a]]])
+  (apply (field 1 (global Toploop!)) "int_vec" int_vec/1507))
+val int_vec : (int * int) list = [(1, 1); (1, 2); (2, 1)]
+# (let (float_vec/1508 = [0: [0: 1. 1.] [0: [0: 1. 2.] [0: [0: 2. 1.] 0a]]])
+  (apply (field 1 (global Toploop!)) "float_vec" float_vec/1508))
+val float_vec : (float * float) list = [(1., 1.); (1., 2.); (2., 1.)]
+# (let
+  (string_vec/1509 = [0: [0: "1" "1"] [0: [0: "1" "2"] [0: [0: "2" "1"] 0a]]])
+  (apply (field 1 (global Toploop!)) "string_vec" string_vec/1509))
+val string_vec : (string * string) list =
+  [("1", "1"); ("1", "2"); ("2", "1")]
+# (let (int32_vec/1510 = [0: [0: 1l 1l] [0: [0: 1l 2l] [0: [0: 2l 1l] 0a]]])
+  (apply (field 1 (global Toploop!)) "int32_vec" int32_vec/1510))
+val int32_vec : (int32 * int32) list = [(1l, 1l); (1l, 2l); (2l, 1l)]
+# (let (int64_vec/1511 = [0: [0: 1L 1L] [0: [0: 1L 2L] [0: [0: 2L 1L] 0a]]])
+  (apply (field 1 (global Toploop!)) "int64_vec" int64_vec/1511))
+val int64_vec : (int64 * int64) list = [(1L, 1L); (1L, 2L); (2L, 1L)]
+# (let
+  (nativeint_vec/1512 = [0: [0: 1n 1n] [0: [0: 1n 2n] [0: [0: 2n 1n] 0a]]])
+  (apply (field 1 (global Toploop!)) "nativeint_vec" nativeint_vec/1512))
+val nativeint_vec : (nativeint * nativeint) list =
+  [(1n, 1n); (1n, 2n); (2n, 1n)]
+#               (let
+  (gen_ge/1339 = (apply (field 0 (global Toploop!)) "gen_ge")
+   gen_le/1318 = (apply (field 0 (global Toploop!)) "gen_le")
+   gen_gt/1297 = (apply (field 0 (global Toploop!)) "gen_gt")
+   gen_lt/1276 = (apply (field 0 (global Toploop!)) "gen_lt")
+   gen_ne/1255 = (apply (field 0 (global Toploop!)) "gen_ne")
+   gen_eq/1234 = (apply (field 0 (global Toploop!)) "gen_eq")
+   gen_cmp/1213 = (apply (field 0 (global Toploop!)) "gen_cmp")
+   test_vec/1513 =
+     (function cmp/1514 eq/1515 ne/1516 lt/1517 gt/1518 le/1519 ge/1520
+       vec/1521
+       (let
+         (uncurry/1522 =
+            (function f/1523 param/1575
+              (apply f/1523 (field 0 param/1575) (field 1 param/1575)))
+          map/1526 =
+            (function f/1527 l/1528
+              (apply (field 11 (global List!)) (apply uncurry/1522 f/1527)
+                l/1528)))
+         (makeblock 0
+           (makeblock 0 (apply map/1526 gen_cmp/1213 vec/1521)
+             (apply map/1526 cmp/1514 vec/1521))
+           (apply map/1526
+             (function gen/1529 spec/1530
+               (makeblock 0 (apply map/1526 gen/1529 vec/1521)
+                 (apply map/1526 spec/1530 vec/1521)))
+             (makeblock 0 (makeblock 0 gen_eq/1234 eq/1515)
+               (makeblock 0 (makeblock 0 gen_ne/1255 ne/1516)
+                 (makeblock 0 (makeblock 0 gen_lt/1276 lt/1517)
+                   (makeblock 0 (makeblock 0 gen_gt/1297 gt/1518)
+                     (makeblock 0 (makeblock 0 gen_le/1318 le/1519)
+                       (makeblock 0 (makeblock 0 gen_ge/1339 ge/1520) 0a)))))))))))
+  (apply (field 1 (global Toploop!)) "test_vec" test_vec/1513))
+val test_vec :
+  ('a -> 'a -> 'b) ->
+  ('a -> 'a -> 'c) ->
+  ('a -> 'a -> 'c) ->
+  ('a -> 'a -> 'c) ->
+  ('a -> 'a -> 'c) ->
+  ('a -> 'a -> 'c) ->
+  ('a -> 'a -> 'c) ->
+  ('a * 'a) list -> (int list * 'b list) * (bool list * 'c list) list = <fun>
+#       (let
+  (test_vec/1513 = (apply (field 0 (global Toploop!)) "test_vec")
+   int_vec/1507 = (apply (field 0 (global Toploop!)) "int_vec")
+   int_ge/1342 = (apply (field 0 (global Toploop!)) "int_ge")
+   int_le/1321 = (apply (field 0 (global Toploop!)) "int_le")
+   int_gt/1300 = (apply (field 0 (global Toploop!)) "int_gt")
+   int_lt/1279 = (apply (field 0 (global Toploop!)) "int_lt")
+   int_ne/1258 = (apply (field 0 (global Toploop!)) "int_ne")
+   int_eq/1237 = (apply (field 0 (global Toploop!)) "int_eq")
+   int_cmp/1216 = (apply (field 0 (global Toploop!)) "int_cmp"))
+  (apply test_vec/1513 int_cmp/1216 int_eq/1237 int_ne/1258 int_lt/1279
+    int_gt/1300 int_le/1321 int_ge/1342 int_vec/1507))
+- : (int list * int list) * (bool list * bool list) list =
+(([0; -1; 1], [0; -1; 1]),
+ [([true; false; false], [true; false; false]);
+  ([false; true; true], [false; true; true]);
+  ([false; true; false], [false; true; false]);
+  ([false; false; true], [false; false; true]);
+  ([true; true; false], [true; true; false]);
+  ([true; false; true], [true; false; true])])
+#     (let
+  (test_vec/1513 = (apply (field 0 (global Toploop!)) "test_vec")
+   float_vec/1508 = (apply (field 0 (global Toploop!)) "float_vec")
+   float_ge/1345 = (apply (field 0 (global Toploop!)) "float_ge")
+   float_le/1324 = (apply (field 0 (global Toploop!)) "float_le")
+   float_gt/1303 = (apply (field 0 (global Toploop!)) "float_gt")
+   float_lt/1282 = (apply (field 0 (global Toploop!)) "float_lt")
+   float_ne/1261 = (apply (field 0 (global Toploop!)) "float_ne")
+   float_eq/1240 = (apply (field 0 (global Toploop!)) "float_eq")
+   float_cmp/1219 = (apply (field 0 (global Toploop!)) "float_cmp"))
+  (apply test_vec/1513 float_cmp/1219 float_eq/1240 float_ne/1261
+    float_lt/1282 float_gt/1303 float_le/1324 float_ge/1345 float_vec/1508))
+- : (int list * int list) * (bool list * bool list) list =
+(([0; -1; 1], [0; -1; 1]),
+ [([true; false; false], [true; false; false]);
+  ([false; true; true], [false; true; true]);
+  ([false; true; false], [false; true; false]);
+  ([false; false; true], [false; false; true]);
+  ([true; true; false], [true; true; false]);
+  ([true; false; true], [true; false; true])])
+#     (let
+  (test_vec/1513 = (apply (field 0 (global Toploop!)) "test_vec")
+   string_vec/1509 = (apply (field 0 (global Toploop!)) "string_vec")
+   string_ge/1348 = (apply (field 0 (global Toploop!)) "string_ge")
+   string_le/1327 = (apply (field 0 (global Toploop!)) "string_le")
+   string_gt/1306 = (apply (field 0 (global Toploop!)) "string_gt")
+   string_lt/1285 = (apply (field 0 (global Toploop!)) "string_lt")
+   string_ne/1264 = (apply (field 0 (global Toploop!)) "string_ne")
+   string_eq/1243 = (apply (field 0 (global Toploop!)) "string_eq")
+   string_cmp/1222 = (apply (field 0 (global Toploop!)) "string_cmp"))
+  (apply test_vec/1513 string_cmp/1222 string_eq/1243 string_ne/1264
+    string_lt/1285 string_gt/1306 string_le/1327 string_ge/1348
+    string_vec/1509))
+- : (int list * int list) * (bool list * bool list) list =
+(([0; -1; 1], [0; -1; 1]),
+ [([true; false; false], [true; false; false]);
+  ([false; true; true], [false; true; true]);
+  ([false; true; false], [false; true; false]);
+  ([false; false; true], [false; false; true]);
+  ([true; true; false], [true; true; false]);
+  ([true; false; true], [true; false; true])])
+#     (let
+  (test_vec/1513 = (apply (field 0 (global Toploop!)) "test_vec")
+   int32_vec/1510 = (apply (field 0 (global Toploop!)) "int32_vec")
+   int32_ge/1351 = (apply (field 0 (global Toploop!)) "int32_ge")
+   int32_le/1330 = (apply (field 0 (global Toploop!)) "int32_le")
+   int32_gt/1309 = (apply (field 0 (global Toploop!)) "int32_gt")
+   int32_lt/1288 = (apply (field 0 (global Toploop!)) "int32_lt")
+   int32_ne/1267 = (apply (field 0 (global Toploop!)) "int32_ne")
+   int32_eq/1246 = (apply (field 0 (global Toploop!)) "int32_eq")
+   int32_cmp/1225 = (apply (field 0 (global Toploop!)) "int32_cmp"))
+  (apply test_vec/1513 int32_cmp/1225 int32_eq/1246 int32_ne/1267
+    int32_lt/1288 int32_gt/1309 int32_le/1330 int32_ge/1351 int32_vec/1510))
+- : (int list * int list) * (bool list * bool list) list =
+(([0; -1; 1], [0; -1; 1]),
+ [([true; false; false], [true; false; false]);
+  ([false; true; true], [false; true; true]);
+  ([false; true; false], [false; true; false]);
+  ([false; false; true], [false; false; true]);
+  ([true; true; false], [true; true; false]);
+  ([true; false; true], [true; false; true])])
+#     (let
+  (test_vec/1513 = (apply (field 0 (global Toploop!)) "test_vec")
+   int64_vec/1511 = (apply (field 0 (global Toploop!)) "int64_vec")
+   int64_ge/1354 = (apply (field 0 (global Toploop!)) "int64_ge")
+   int64_le/1333 = (apply (field 0 (global Toploop!)) "int64_le")
+   int64_gt/1312 = (apply (field 0 (global Toploop!)) "int64_gt")
+   int64_lt/1291 = (apply (field 0 (global Toploop!)) "int64_lt")
+   int64_ne/1270 = (apply (field 0 (global Toploop!)) "int64_ne")
+   int64_eq/1249 = (apply (field 0 (global Toploop!)) "int64_eq")
+   int64_cmp/1228 = (apply (field 0 (global Toploop!)) "int64_cmp"))
+  (apply test_vec/1513 int64_cmp/1228 int64_eq/1249 int64_ne/1270
+    int64_lt/1291 int64_gt/1312 int64_le/1333 int64_ge/1354 int64_vec/1511))
+- : (int list * int list) * (bool list * bool list) list =
+(([0; -1; 1], [0; -1; 1]),
+ [([true; false; false], [true; false; false]);
+  ([false; true; true], [false; true; true]);
+  ([false; true; false], [false; true; false]);
+  ([false; false; true], [false; false; true]);
+  ([true; true; false], [true; true; false]);
+  ([true; false; true], [true; false; true])])
+#       (let
+  (test_vec/1513 = (apply (field 0 (global Toploop!)) "test_vec")
+   nativeint_vec/1512 = (apply (field 0 (global Toploop!)) "nativeint_vec")
+   nativeint_ge/1357 = (apply (field 0 (global Toploop!)) "nativeint_ge")
+   nativeint_le/1336 = (apply (field 0 (global Toploop!)) "nativeint_le")
+   nativeint_gt/1315 = (apply (field 0 (global Toploop!)) "nativeint_gt")
+   nativeint_lt/1294 = (apply (field 0 (global Toploop!)) "nativeint_lt")
+   nativeint_ne/1273 = (apply (field 0 (global Toploop!)) "nativeint_ne")
+   nativeint_eq/1252 = (apply (field 0 (global Toploop!)) "nativeint_eq")
+   nativeint_cmp/1231 = (apply (field 0 (global Toploop!)) "nativeint_cmp"))
+  (apply test_vec/1513 nativeint_cmp/1231 nativeint_eq/1252 nativeint_ne/1273
+    nativeint_lt/1294 nativeint_gt/1315 nativeint_le/1336 nativeint_ge/1357
+    nativeint_vec/1512))
+- : (int list * int list) * (bool list * bool list) list =
+(([0; -1; 1], [0; -1; 1]),
+ [([true; false; false], [true; false; false]);
+  ([false; true; true], [false; true; true]);
+  ([false; true; false], [false; true; false]);
+  ([false; false; true], [false; false; true]);
+  ([true; true; false], [true; true; false]);
+  ([true; false; true], [true; false; true])])
+#                 (let
+  (eta_gen_ge/1486 = (apply (field 0 (global Toploop!)) "eta_gen_ge")
+   eta_gen_le/1465 = (apply (field 0 (global Toploop!)) "eta_gen_le")
+   eta_gen_gt/1444 = (apply (field 0 (global Toploop!)) "eta_gen_gt")
+   eta_gen_lt/1423 = (apply (field 0 (global Toploop!)) "eta_gen_lt")
+   eta_gen_ne/1402 = (apply (field 0 (global Toploop!)) "eta_gen_ne")
+   eta_gen_eq/1381 = (apply (field 0 (global Toploop!)) "eta_gen_eq")
+   eta_gen_cmp/1360 = (apply (field 0 (global Toploop!)) "eta_gen_cmp")
+   eta_test_vec/1576 =
+     (function cmp/1577 eq/1578 ne/1579 lt/1580 gt/1581 le/1582 ge/1583
+       vec/1584
+       (let
+         (uncurry/1585 =
+            (function f/1586 param/1594
+              (apply f/1586 (field 0 param/1594) (field 1 param/1594)))
+          map/1589 =
+            (function f/1590 l/1591
+              (apply (field 11 (global List!)) (apply uncurry/1585 f/1590)
+                l/1591)))
+         (makeblock 0
+           (makeblock 0 (apply map/1589 eta_gen_cmp/1360 vec/1584)
+             (apply map/1589 cmp/1577 vec/1584))
+           (apply map/1589
+             (function gen/1592 spec/1593
+               (makeblock 0 (apply map/1589 gen/1592 vec/1584)
+                 (apply map/1589 spec/1593 vec/1584)))
+             (makeblock 0 (makeblock 0 eta_gen_eq/1381 eq/1578)
+               (makeblock 0 (makeblock 0 eta_gen_ne/1402 ne/1579)
+                 (makeblock 0 (makeblock 0 eta_gen_lt/1423 lt/1580)
+                   (makeblock 0 (makeblock 0 eta_gen_gt/1444 gt/1581)
+                     (makeblock 0 (makeblock 0 eta_gen_le/1465 le/1582)
+                       (makeblock 0 (makeblock 0 eta_gen_ge/1486 ge/1583) 0a)))))))))))
+  (apply (field 1 (global Toploop!)) "eta_test_vec" eta_test_vec/1576))
+val eta_test_vec :
+  ('a -> 'a -> 'b) ->
+  ('a -> 'a -> 'c) ->
+  ('a -> 'a -> 'c) ->
+  ('a -> 'a -> 'c) ->
+  ('a -> 'a -> 'c) ->
+  ('a -> 'a -> 'c) ->
+  ('a -> 'a -> 'c) ->
+  ('a * 'a) list -> (int list * 'b list) * (bool list * 'c list) list = <fun>
+#       (let
+  (eta_test_vec/1576 = (apply (field 0 (global Toploop!)) "eta_test_vec")
+   int_vec/1507 = (apply (field 0 (global Toploop!)) "int_vec")
+   eta_int_ge/1489 = (apply (field 0 (global Toploop!)) "eta_int_ge")
+   eta_int_le/1468 = (apply (field 0 (global Toploop!)) "eta_int_le")
+   eta_int_gt/1447 = (apply (field 0 (global Toploop!)) "eta_int_gt")
+   eta_int_lt/1426 = (apply (field 0 (global Toploop!)) "eta_int_lt")
+   eta_int_ne/1405 = (apply (field 0 (global Toploop!)) "eta_int_ne")
+   eta_int_eq/1384 = (apply (field 0 (global Toploop!)) "eta_int_eq")
+   eta_int_cmp/1363 = (apply (field 0 (global Toploop!)) "eta_int_cmp"))
+  (apply eta_test_vec/1576 eta_int_cmp/1363 eta_int_eq/1384 eta_int_ne/1405
+    eta_int_lt/1426 eta_int_gt/1447 eta_int_le/1468 eta_int_ge/1489
+    int_vec/1507))
+- : (int list * int list) * (bool list * bool list) list =
+(([0; -1; 1], [0; -1; 1]),
+ [([true; false; false], [true; false; false]);
+  ([false; true; true], [false; true; true]);
+  ([false; true; false], [false; true; false]);
+  ([false; false; true], [false; false; true]);
+  ([true; true; false], [true; true; false]);
+  ([true; false; true], [true; false; true])])
+#       (let
+  (eta_test_vec/1576 = (apply (field 0 (global Toploop!)) "eta_test_vec")
+   float_vec/1508 = (apply (field 0 (global Toploop!)) "float_vec")
+   eta_float_ge/1492 = (apply (field 0 (global Toploop!)) "eta_float_ge")
+   eta_float_le/1471 = (apply (field 0 (global Toploop!)) "eta_float_le")
+   eta_float_gt/1450 = (apply (field 0 (global Toploop!)) "eta_float_gt")
+   eta_float_lt/1429 = (apply (field 0 (global Toploop!)) "eta_float_lt")
+   eta_float_ne/1408 = (apply (field 0 (global Toploop!)) "eta_float_ne")
+   eta_float_eq/1387 = (apply (field 0 (global Toploop!)) "eta_float_eq")
+   eta_float_cmp/1366 = (apply (field 0 (global Toploop!)) "eta_float_cmp"))
+  (apply eta_test_vec/1576 eta_float_cmp/1366 eta_float_eq/1387
+    eta_float_ne/1408 eta_float_lt/1429 eta_float_gt/1450 eta_float_le/1471
+    eta_float_ge/1492 float_vec/1508))
+- : (int list * int list) * (bool list * bool list) list =
+(([0; -1; 1], [0; -1; 1]),
+ [([true; false; false], [true; false; false]);
+  ([false; true; true], [false; true; true]);
+  ([false; true; false], [false; true; false]);
+  ([false; false; true], [false; false; true]);
+  ([true; true; false], [true; true; false]);
+  ([true; false; true], [true; false; true])])
+#       (let
+  (eta_test_vec/1576 = (apply (field 0 (global Toploop!)) "eta_test_vec")
+   string_vec/1509 = (apply (field 0 (global Toploop!)) "string_vec")
+   eta_string_ge/1495 = (apply (field 0 (global Toploop!)) "eta_string_ge")
+   eta_string_le/1474 = (apply (field 0 (global Toploop!)) "eta_string_le")
+   eta_string_gt/1453 = (apply (field 0 (global Toploop!)) "eta_string_gt")
+   eta_string_lt/1432 = (apply (field 0 (global Toploop!)) "eta_string_lt")
+   eta_string_ne/1411 = (apply (field 0 (global Toploop!)) "eta_string_ne")
+   eta_string_eq/1390 = (apply (field 0 (global Toploop!)) "eta_string_eq")
+   eta_string_cmp/1369 = (apply (field 0 (global Toploop!)) "eta_string_cmp"))
+  (apply eta_test_vec/1576 eta_string_cmp/1369 eta_string_eq/1390
+    eta_string_ne/1411 eta_string_lt/1432 eta_string_gt/1453
+    eta_string_le/1474 eta_string_ge/1495 string_vec/1509))
+- : (int list * int list) * (bool list * bool list) list =
+(([0; -1; 1], [0; -1; 1]),
+ [([true; false; false], [true; false; false]);
+  ([false; true; true], [false; true; true]);
+  ([false; true; false], [false; true; false]);
+  ([false; false; true], [false; false; true]);
+  ([true; true; false], [true; true; false]);
+  ([true; false; true], [true; false; true])])
+#       (let
+  (eta_test_vec/1576 = (apply (field 0 (global Toploop!)) "eta_test_vec")
+   int32_vec/1510 = (apply (field 0 (global Toploop!)) "int32_vec")
+   eta_int32_ge/1498 = (apply (field 0 (global Toploop!)) "eta_int32_ge")
+   eta_int32_le/1477 = (apply (field 0 (global Toploop!)) "eta_int32_le")
+   eta_int32_gt/1456 = (apply (field 0 (global Toploop!)) "eta_int32_gt")
+   eta_int32_lt/1435 = (apply (field 0 (global Toploop!)) "eta_int32_lt")
+   eta_int32_ne/1414 = (apply (field 0 (global Toploop!)) "eta_int32_ne")
+   eta_int32_eq/1393 = (apply (field 0 (global Toploop!)) "eta_int32_eq")
+   eta_int32_cmp/1372 = (apply (field 0 (global Toploop!)) "eta_int32_cmp"))
+  (apply eta_test_vec/1576 eta_int32_cmp/1372 eta_int32_eq/1393
+    eta_int32_ne/1414 eta_int32_lt/1435 eta_int32_gt/1456 eta_int32_le/1477
+    eta_int32_ge/1498 int32_vec/1510))
+- : (int list * int list) * (bool list * bool list) list =
+(([0; -1; 1], [0; -1; 1]),
+ [([true; false; false], [true; false; false]);
+  ([false; true; true], [false; true; true]);
+  ([false; true; false], [false; true; false]);
+  ([false; false; true], [false; false; true]);
+  ([true; true; false], [true; true; false]);
+  ([true; false; true], [true; false; true])])
+#       (let
+  (eta_test_vec/1576 = (apply (field 0 (global Toploop!)) "eta_test_vec")
+   int64_vec/1511 = (apply (field 0 (global Toploop!)) "int64_vec")
+   eta_int64_ge/1501 = (apply (field 0 (global Toploop!)) "eta_int64_ge")
+   eta_int64_le/1480 = (apply (field 0 (global Toploop!)) "eta_int64_le")
+   eta_int64_gt/1459 = (apply (field 0 (global Toploop!)) "eta_int64_gt")
+   eta_int64_lt/1438 = (apply (field 0 (global Toploop!)) "eta_int64_lt")
+   eta_int64_ne/1417 = (apply (field 0 (global Toploop!)) "eta_int64_ne")
+   eta_int64_eq/1396 = (apply (field 0 (global Toploop!)) "eta_int64_eq")
+   eta_int64_cmp/1375 = (apply (field 0 (global Toploop!)) "eta_int64_cmp"))
+  (apply eta_test_vec/1576 eta_int64_cmp/1375 eta_int64_eq/1396
+    eta_int64_ne/1417 eta_int64_lt/1438 eta_int64_gt/1459 eta_int64_le/1480
+    eta_int64_ge/1501 int64_vec/1511))
+- : (int list * int list) * (bool list * bool list) list =
+(([0; -1; 1], [0; -1; 1]),
+ [([true; false; false], [true; false; false]);
+  ([false; true; true], [false; true; true]);
+  ([false; true; false], [false; true; false]);
+  ([false; false; true], [false; false; true]);
+  ([true; true; false], [true; true; false]);
+  ([true; false; true], [true; false; true])])
+#       (let
+  (eta_test_vec/1576 = (apply (field 0 (global Toploop!)) "eta_test_vec")
+   nativeint_vec/1512 = (apply (field 0 (global Toploop!)) "nativeint_vec")
+   eta_nativeint_ge/1504 =
+     (apply (field 0 (global Toploop!)) "eta_nativeint_ge")
+   eta_nativeint_le/1483 =
+     (apply (field 0 (global Toploop!)) "eta_nativeint_le")
+   eta_nativeint_gt/1462 =
+     (apply (field 0 (global Toploop!)) "eta_nativeint_gt")
+   eta_nativeint_lt/1441 =
+     (apply (field 0 (global Toploop!)) "eta_nativeint_lt")
+   eta_nativeint_ne/1420 =
+     (apply (field 0 (global Toploop!)) "eta_nativeint_ne")
+   eta_nativeint_eq/1399 =
+     (apply (field 0 (global Toploop!)) "eta_nativeint_eq")
+   eta_nativeint_cmp/1378 =
+     (apply (field 0 (global Toploop!)) "eta_nativeint_cmp"))
+  (apply eta_test_vec/1576 eta_nativeint_cmp/1378 eta_nativeint_eq/1399
+    eta_nativeint_ne/1420 eta_nativeint_lt/1441 eta_nativeint_gt/1462
+    eta_nativeint_le/1483 eta_nativeint_ge/1504 nativeint_vec/1512))
+- : (int list * int list) * (bool list * bool list) list =
+(([0; -1; 1], [0; -1; 1]),
+ [([true; false; false], [true; false; false]);
+  ([false; true; true], [false; true; true]);
+  ([false; true; false], [false; true; false]);
+  ([false; false; true], [false; false; true]);
+  ([true; true; false], [true; true; false]);
+  ([true; false; true], [true; false; true])])
+# 

--- a/testsuite/tests/translprim/module_coercion.ml
+++ b/testsuite/tests/translprim/module_coercion.ml
@@ -1,0 +1,37 @@
+module M = struct
+  external len : 'a array -> int = "%array_length"
+  external safe_get : 'a array -> int -> 'a = "%array_safe_get"
+  external unsafe_get : 'a array -> int -> 'a = "%array_unsafe_get"
+  external safe_set : 'a array -> int -> 'a -> unit = "%array_safe_set"
+  external unsafe_set : 'a array -> int -> 'a -> unit = "%array_unsafe_set"
+  external cmp : 'a -> 'a -> int = "%compare";;
+  external eq : 'a -> 'a -> bool = "%equal";;
+  external ne : 'a -> 'a -> bool = "%notequal";;
+  external lt : 'a -> 'a -> bool = "%lessthan";;
+  external gt : 'a -> 'a -> bool = "%greaterthan";;
+  external le : 'a -> 'a -> bool = "%lessequal";;
+  external ge : 'a -> 'a -> bool = "%greaterequal";;
+end;;
+
+module type T = sig
+  type t
+  val len : t array -> int
+  val safe_get : t array -> int -> t
+  val unsafe_get : t array -> int -> t
+  val safe_set : t array -> int -> t -> unit
+  val unsafe_set : t array -> int -> t -> unit
+  val cmp : t -> t -> int
+  val eq : t -> t -> bool
+  val ne : t -> t -> bool
+  val lt : t -> t -> bool
+  val gt : t -> t -> bool
+  val le : t -> t -> bool
+  val ge : t -> t -> bool
+end;;
+
+module M_int : T with type t := int = M;;
+module M_float : T with type t := float = M;;
+module M_string : T with type t := string = M;;
+module M_int32 : T with type t := int32 = M;;
+module M_int64 : T with type t := int64 = M;;
+module M_nativeint : T with type t := nativeint = M;;

--- a/testsuite/tests/translprim/module_coercion.ml.reference
+++ b/testsuite/tests/translprim/module_coercion.ml.reference
@@ -1,0 +1,225 @@
+
+#                           (apply (field 1 (global Toploop!)) "M/1218" (makeblock 0))
+module M :
+  sig
+    external len : 'a array -> int = "%array_length"
+    external safe_get : 'a array -> int -> 'a = "%array_safe_get"
+    external unsafe_get : 'a array -> int -> 'a = "%array_unsafe_get"
+    external safe_set : 'a array -> int -> 'a -> unit = "%array_safe_set"
+    external unsafe_set : 'a array -> int -> 'a -> unit = "%array_unsafe_set"
+    external cmp : 'a -> 'a -> int = "%compare"
+    external eq : 'a -> 'a -> bool = "%equal"
+    external ne : 'a -> 'a -> bool = "%notequal"
+    external lt : 'a -> 'a -> bool = "%lessthan"
+    external gt : 'a -> 'a -> bool = "%greaterthan"
+    external le : 'a -> 'a -> bool = "%lessequal"
+    external ge : 'a -> 'a -> bool = "%greaterequal"
+  end
+#                               0a
+module type T =
+  sig
+    type t
+    val len : t array -> int
+    val safe_get : t array -> int -> t
+    val unsafe_get : t array -> int -> t
+    val safe_set : t array -> int -> t -> unit
+    val unsafe_set : t array -> int -> t -> unit
+    val cmp : t -> t -> int
+    val eq : t -> t -> bool
+    val ne : t -> t -> bool
+    val lt : t -> t -> bool
+    val gt : t -> t -> bool
+    val le : t -> t -> bool
+    val ge : t -> t -> bool
+  end
+#   (apply (field 1 (global Toploop!)) "M_int/1270"
+  (makeblock 0 (function prim/1272 (array.length[int] prim/1272))
+    (function prim/1274 prim/1273 (array.get[int] prim/1274 prim/1273))
+    (function prim/1276 prim/1275
+      (array.unsafe_get[int] prim/1276 prim/1275))
+    (function prim/1279 prim/1278 prim/1277
+      (array.set[int] prim/1279 prim/1278 prim/1277))
+    (function prim/1282 prim/1281 prim/1280
+      (array.unsafe_set[int] prim/1282 prim/1281 prim/1280))
+    (function prim/1284 prim/1283 (caml_int_compare prim/1284 prim/1283))
+    (function prim/1286 prim/1285 (== prim/1286 prim/1285))
+    (function prim/1288 prim/1287 (!= prim/1288 prim/1287))
+    (function prim/1290 prim/1289 (< prim/1290 prim/1289))
+    (function prim/1292 prim/1291 (> prim/1292 prim/1291))
+    (function prim/1294 prim/1293 (<= prim/1294 prim/1293))
+    (function prim/1296 prim/1295 (>= prim/1296 prim/1295))))
+module M_int :
+  sig
+    val len : int array -> int
+    val safe_get : int array -> int -> int
+    val unsafe_get : int array -> int -> int
+    val safe_set : int array -> int -> int -> unit
+    val unsafe_set : int array -> int -> int -> unit
+    val cmp : int -> int -> int
+    val eq : int -> int -> bool
+    val ne : int -> int -> bool
+    val lt : int -> int -> bool
+    val gt : int -> int -> bool
+    val le : int -> int -> bool
+    val ge : int -> int -> bool
+  end
+# (apply (field 1 (global Toploop!)) "M_float/1321"
+  (makeblock 0 (function prim/1323 (array.length[float] prim/1323))
+    (function prim/1325 prim/1324 (array.get[float] prim/1325 prim/1324))
+    (function prim/1327 prim/1326
+      (array.unsafe_get[float] prim/1327 prim/1326))
+    (function prim/1330 prim/1329 prim/1328
+      (array.set[float] prim/1330 prim/1329 prim/1328))
+    (function prim/1333 prim/1332 prim/1331
+      (array.unsafe_set[float] prim/1333 prim/1332 prim/1331))
+    (function prim/1335 prim/1334 (caml_float_compare prim/1335 prim/1334))
+    (function prim/1337 prim/1336 (==. prim/1337 prim/1336))
+    (function prim/1339 prim/1338 (!=. prim/1339 prim/1338))
+    (function prim/1341 prim/1340 (<. prim/1341 prim/1340))
+    (function prim/1343 prim/1342 (>. prim/1343 prim/1342))
+    (function prim/1345 prim/1344 (<=. prim/1345 prim/1344))
+    (function prim/1347 prim/1346 (>=. prim/1347 prim/1346))))
+module M_float :
+  sig
+    val len : float array -> int
+    val safe_get : float array -> int -> float
+    val unsafe_get : float array -> int -> float
+    val safe_set : float array -> int -> float -> unit
+    val unsafe_set : float array -> int -> float -> unit
+    val cmp : float -> float -> int
+    val eq : float -> float -> bool
+    val ne : float -> float -> bool
+    val lt : float -> float -> bool
+    val gt : float -> float -> bool
+    val le : float -> float -> bool
+    val ge : float -> float -> bool
+  end
+# (apply (field 1 (global Toploop!)) "M_string/1372"
+  (makeblock 0 (function prim/1374 (array.length[addr] prim/1374))
+    (function prim/1376 prim/1375 (array.get[addr] prim/1376 prim/1375))
+    (function prim/1378 prim/1377
+      (array.unsafe_get[addr] prim/1378 prim/1377))
+    (function prim/1381 prim/1380 prim/1379
+      (array.set[addr] prim/1381 prim/1380 prim/1379))
+    (function prim/1384 prim/1383 prim/1382
+      (array.unsafe_set[addr] prim/1384 prim/1383 prim/1382))
+    (function prim/1386 prim/1385 (caml_string_compare prim/1386 prim/1385))
+    (function prim/1388 prim/1387 (caml_string_equal prim/1388 prim/1387))
+    (function prim/1390 prim/1389 (caml_string_notequal prim/1390 prim/1389))
+    (function prim/1392 prim/1391 (caml_string_lessthan prim/1392 prim/1391))
+    (function prim/1394 prim/1393
+      (caml_string_greaterthan prim/1394 prim/1393))
+    (function prim/1396 prim/1395
+      (caml_string_lessequal prim/1396 prim/1395))
+    (function prim/1398 prim/1397
+      (caml_string_greaterequal prim/1398 prim/1397))))
+module M_string :
+  sig
+    val len : string array -> int
+    val safe_get : string array -> int -> string
+    val unsafe_get : string array -> int -> string
+    val safe_set : string array -> int -> string -> unit
+    val unsafe_set : string array -> int -> string -> unit
+    val cmp : string -> string -> int
+    val eq : string -> string -> bool
+    val ne : string -> string -> bool
+    val lt : string -> string -> bool
+    val gt : string -> string -> bool
+    val le : string -> string -> bool
+    val ge : string -> string -> bool
+  end
+# (apply (field 1 (global Toploop!)) "M_int32/1423"
+  (makeblock 0 (function prim/1425 (array.length[addr] prim/1425))
+    (function prim/1427 prim/1426 (array.get[addr] prim/1427 prim/1426))
+    (function prim/1429 prim/1428
+      (array.unsafe_get[addr] prim/1429 prim/1428))
+    (function prim/1432 prim/1431 prim/1430
+      (array.set[addr] prim/1432 prim/1431 prim/1430))
+    (function prim/1435 prim/1434 prim/1433
+      (array.unsafe_set[addr] prim/1435 prim/1434 prim/1433))
+    (function prim/1437 prim/1436 (caml_int32_compare prim/1437 prim/1436))
+    (function prim/1439 prim/1438 (Int32.== prim/1439 prim/1438))
+    (function prim/1441 prim/1440 (Int32.!= prim/1441 prim/1440))
+    (function prim/1443 prim/1442 (Int32.< prim/1443 prim/1442))
+    (function prim/1445 prim/1444 (Int32.> prim/1445 prim/1444))
+    (function prim/1447 prim/1446 (Int32.<= prim/1447 prim/1446))
+    (function prim/1449 prim/1448 (Int32.>= prim/1449 prim/1448))))
+module M_int32 :
+  sig
+    val len : int32 array -> int
+    val safe_get : int32 array -> int -> int32
+    val unsafe_get : int32 array -> int -> int32
+    val safe_set : int32 array -> int -> int32 -> unit
+    val unsafe_set : int32 array -> int -> int32 -> unit
+    val cmp : int32 -> int32 -> int
+    val eq : int32 -> int32 -> bool
+    val ne : int32 -> int32 -> bool
+    val lt : int32 -> int32 -> bool
+    val gt : int32 -> int32 -> bool
+    val le : int32 -> int32 -> bool
+    val ge : int32 -> int32 -> bool
+  end
+# (apply (field 1 (global Toploop!)) "M_int64/1474"
+  (makeblock 0 (function prim/1476 (array.length[addr] prim/1476))
+    (function prim/1478 prim/1477 (array.get[addr] prim/1478 prim/1477))
+    (function prim/1480 prim/1479
+      (array.unsafe_get[addr] prim/1480 prim/1479))
+    (function prim/1483 prim/1482 prim/1481
+      (array.set[addr] prim/1483 prim/1482 prim/1481))
+    (function prim/1486 prim/1485 prim/1484
+      (array.unsafe_set[addr] prim/1486 prim/1485 prim/1484))
+    (function prim/1488 prim/1487 (caml_int64_compare prim/1488 prim/1487))
+    (function prim/1490 prim/1489 (Int64.== prim/1490 prim/1489))
+    (function prim/1492 prim/1491 (Int64.!= prim/1492 prim/1491))
+    (function prim/1494 prim/1493 (Int64.< prim/1494 prim/1493))
+    (function prim/1496 prim/1495 (Int64.> prim/1496 prim/1495))
+    (function prim/1498 prim/1497 (Int64.<= prim/1498 prim/1497))
+    (function prim/1500 prim/1499 (Int64.>= prim/1500 prim/1499))))
+module M_int64 :
+  sig
+    val len : int64 array -> int
+    val safe_get : int64 array -> int -> int64
+    val unsafe_get : int64 array -> int -> int64
+    val safe_set : int64 array -> int -> int64 -> unit
+    val unsafe_set : int64 array -> int -> int64 -> unit
+    val cmp : int64 -> int64 -> int
+    val eq : int64 -> int64 -> bool
+    val ne : int64 -> int64 -> bool
+    val lt : int64 -> int64 -> bool
+    val gt : int64 -> int64 -> bool
+    val le : int64 -> int64 -> bool
+    val ge : int64 -> int64 -> bool
+  end
+# (apply (field 1 (global Toploop!)) "M_nativeint/1525"
+  (makeblock 0 (function prim/1527 (array.length[addr] prim/1527))
+    (function prim/1529 prim/1528 (array.get[addr] prim/1529 prim/1528))
+    (function prim/1531 prim/1530
+      (array.unsafe_get[addr] prim/1531 prim/1530))
+    (function prim/1534 prim/1533 prim/1532
+      (array.set[addr] prim/1534 prim/1533 prim/1532))
+    (function prim/1537 prim/1536 prim/1535
+      (array.unsafe_set[addr] prim/1537 prim/1536 prim/1535))
+    (function prim/1539 prim/1538
+      (caml_nativeint_compare prim/1539 prim/1538))
+    (function prim/1541 prim/1540 (Nativeint.== prim/1541 prim/1540))
+    (function prim/1543 prim/1542 (Nativeint.!= prim/1543 prim/1542))
+    (function prim/1545 prim/1544 (Nativeint.< prim/1545 prim/1544))
+    (function prim/1547 prim/1546 (Nativeint.> prim/1547 prim/1546))
+    (function prim/1549 prim/1548 (Nativeint.<= prim/1549 prim/1548))
+    (function prim/1551 prim/1550 (Nativeint.>= prim/1551 prim/1550))))
+module M_nativeint :
+  sig
+    val len : nativeint array -> int
+    val safe_get : nativeint array -> int -> nativeint
+    val unsafe_get : nativeint array -> int -> nativeint
+    val safe_set : nativeint array -> int -> nativeint -> unit
+    val unsafe_set : nativeint array -> int -> nativeint -> unit
+    val cmp : nativeint -> nativeint -> int
+    val eq : nativeint -> nativeint -> bool
+    val ne : nativeint -> nativeint -> bool
+    val lt : nativeint -> nativeint -> bool
+    val gt : nativeint -> nativeint -> bool
+    val le : nativeint -> nativeint -> bool
+    val ge : nativeint -> nativeint -> bool
+  end
+# 

--- a/testsuite/tests/translprim/ref_spec.ml
+++ b/testsuite/tests/translprim/ref_spec.ml
@@ -1,0 +1,39 @@
+type 'a custom_rec = { x : unit; mutable y : 'a }
+type float_rec = { w : float; mutable z : float }
+
+type cst = A | B
+type gen = C | D of string
+
+let int_ref = ref 1;;
+let var_ref = ref `A;;
+let vargen_ref = ref `A;;
+let cst_ref = ref A;;
+let gen_ref = ref C;;
+let flt_ref = ref 0.;;
+
+int_ref := 2;;
+var_ref := `B;;
+vargen_ref := `B 0;;
+vargen_ref := `C;;
+cst_ref := B;;
+gen_ref := D "foo";;
+gen_ref := C;;
+flt_ref := 1.;;
+
+let int_rec = { x = (); y = 1 };;
+let var_rec = { x = (); y = `A };;
+let vargen_rec = { x = (); y = `A };;
+let cst_rec = { x = (); y = A };;
+let gen_rec = { x = (); y = C };;
+let flt_rec = { x = (); y = 0. };;
+let flt_rec' = { w = 0.; z = 0. };;
+
+int_rec.y <- 2;;
+var_rec.y <- `B;;
+vargen_rec.y <- `B 0;;
+vargen_rec.y <- `C;;
+cst_rec.y <- B;;
+gen_rec.y <- D "foo";;
+gen_rec.y <- C;;
+flt_rec.y <- 1.;;
+flt_rec'.z <- 1.;;

--- a/testsuite/tests/translprim/ref_spec.ml.reference
+++ b/testsuite/tests/translprim/ref_spec.ml.reference
@@ -1,0 +1,97 @@
+
+#             (seq 0a 0a 0a 0a
+  (let (int_ref/1218 = (makemutable 0 1))
+    (apply (field 1 (global Toploop!)) "int_ref" int_ref/1218)))
+type 'a custom_rec = { x : unit; mutable y : 'a; }
+type float_rec = { w : float; mutable z : float; }
+type cst = A | B
+type gen = C | D of string
+val int_ref : int ref = {contents = 1}
+# (let (var_ref/1219 = (makemutable 0 65a))
+  (apply (field 1 (global Toploop!)) "var_ref" var_ref/1219))
+val var_ref : _[> `A ] ref = {contents = `A}
+# (let (vargen_ref/1220 = (makemutable 0 65a))
+  (apply (field 1 (global Toploop!)) "vargen_ref" vargen_ref/1220))
+val vargen_ref : _[> `A ] ref = {contents = `A}
+# (let (cst_ref/1221 = (makemutable 0 0a))
+  (apply (field 1 (global Toploop!)) "cst_ref" cst_ref/1221))
+val cst_ref : cst ref = {contents = A}
+# (let (gen_ref/1222 = (makemutable 0 0a))
+  (apply (field 1 (global Toploop!)) "gen_ref" gen_ref/1222))
+val gen_ref : gen ref = {contents = C}
+# (let (flt_ref/1223 = (makemutable 0 0.))
+  (apply (field 1 (global Toploop!)) "flt_ref" flt_ref/1223))
+val flt_ref : float ref = {contents = 0.}
+#   (let (int_ref/1218 = (apply (field 0 (global Toploop!)) "int_ref"))
+  (setfield_imm 0 int_ref/1218 2))
+- : unit = ()
+# (let (var_ref/1219 = (apply (field 0 (global Toploop!)) "var_ref"))
+  (setfield_ptr 0 var_ref/1219 66a))
+- : unit = ()
+# (let (vargen_ref/1220 = (apply (field 0 (global Toploop!)) "vargen_ref"))
+  (setfield_ptr 0 vargen_ref/1220 [0: 66 0]))
+- : unit = ()
+# (let (vargen_ref/1220 = (apply (field 0 (global Toploop!)) "vargen_ref"))
+  (setfield_ptr 0 vargen_ref/1220 67a))
+- : unit = ()
+# (let (cst_ref/1221 = (apply (field 0 (global Toploop!)) "cst_ref"))
+  (setfield_imm 0 cst_ref/1221 1a))
+- : unit = ()
+# (let (gen_ref/1222 = (apply (field 0 (global Toploop!)) "gen_ref"))
+  (setfield_ptr 0 gen_ref/1222 [0: "foo"]))
+- : unit = ()
+# (let (gen_ref/1222 = (apply (field 0 (global Toploop!)) "gen_ref"))
+  (setfield_ptr 0 gen_ref/1222 0a))
+- : unit = ()
+# (let (flt_ref/1223 = (apply (field 0 (global Toploop!)) "flt_ref"))
+  (setfield_ptr 0 flt_ref/1223 1.))
+- : unit = ()
+#   (let (int_rec/1224 = (makemutable 0 0a 1))
+  (apply (field 1 (global Toploop!)) "int_rec" int_rec/1224))
+val int_rec : int custom_rec = {x = (); y = 1}
+# (let (var_rec/1226 = (makemutable 0 0a 65a))
+  (apply (field 1 (global Toploop!)) "var_rec" var_rec/1226))
+val var_rec : _[> `A ] custom_rec = {x = (); y = `A}
+# (let (vargen_rec/1228 = (makemutable 0 0a 65a))
+  (apply (field 1 (global Toploop!)) "vargen_rec" vargen_rec/1228))
+val vargen_rec : _[> `A ] custom_rec = {x = (); y = `A}
+# (let (cst_rec/1230 = (makemutable 0 0a 0a))
+  (apply (field 1 (global Toploop!)) "cst_rec" cst_rec/1230))
+val cst_rec : cst custom_rec = {x = (); y = A}
+# (let (gen_rec/1232 = (makemutable 0 0a 0a))
+  (apply (field 1 (global Toploop!)) "gen_rec" gen_rec/1232))
+val gen_rec : gen custom_rec = {x = (); y = C}
+# (let (flt_rec/1234 = (makemutable 0 0a 0.))
+  (apply (field 1 (global Toploop!)) "flt_rec" flt_rec/1234))
+val flt_rec : float custom_rec = {x = (); y = 0.}
+# (let (flt_rec'/1236 = (makearray[float] 0. 0.))
+  (apply (field 1 (global Toploop!)) "flt_rec'" flt_rec'/1236))
+val flt_rec' : float_rec = {w = 0.; z = 0.}
+#   (let (int_rec/1224 = (apply (field 0 (global Toploop!)) "int_rec"))
+  (setfield_imm 1 int_rec/1224 2))
+- : unit = ()
+# (let (var_rec/1226 = (apply (field 0 (global Toploop!)) "var_rec"))
+  (setfield_ptr 1 var_rec/1226 66a))
+- : unit = ()
+# (let (vargen_rec/1228 = (apply (field 0 (global Toploop!)) "vargen_rec"))
+  (setfield_ptr 1 vargen_rec/1228 [0: 66 0]))
+- : unit = ()
+# (let (vargen_rec/1228 = (apply (field 0 (global Toploop!)) "vargen_rec"))
+  (setfield_ptr 1 vargen_rec/1228 67a))
+- : unit = ()
+# (let (cst_rec/1230 = (apply (field 0 (global Toploop!)) "cst_rec"))
+  (setfield_imm 1 cst_rec/1230 1a))
+- : unit = ()
+# (let (gen_rec/1232 = (apply (field 0 (global Toploop!)) "gen_rec"))
+  (setfield_ptr 1 gen_rec/1232 [0: "foo"]))
+- : unit = ()
+# (let (gen_rec/1232 = (apply (field 0 (global Toploop!)) "gen_rec"))
+  (setfield_ptr 1 gen_rec/1232 0a))
+- : unit = ()
+# (let (flt_rec/1234 = (apply (field 0 (global Toploop!)) "flt_rec"))
+  (setfield_ptr 1 flt_rec/1234 1.))
+- : unit = ()
+# (let (flt_rec'/1236 = (apply (field 0 (global Toploop!)) "flt_rec'"))
+  (setfloatfield 1 flt_rec'/1236 1.))
+- : unit = ()
+# 

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -26,7 +26,9 @@ let value_descriptions env vd1 vd2 =
     match (vd1.val_kind, vd2.val_kind) with
         (Val_prim p1, Val_prim p2) ->
           if p1 = p2 then Tcoerce_none else raise Dont_match
-      | (Val_prim p, _) -> Tcoerce_primitive p
+      | (Val_prim p, _) ->
+          let pc = {pc_desc = p; pc_type = vd2.val_type; pc_env = env } in
+          Tcoerce_primitive pc
       | (_, Val_prim p) -> raise Dont_match
       | (_, _) -> Tcoerce_none
   end else

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -179,8 +179,9 @@ let rec print_coercion ppf c =
       pr "@[<2>functor@ (%a)@ (%a)@]"
         print_coercion inp
         print_coercion out
-  | Tcoerce_primitive pd ->
-      pr "prim %s" pd.Primitive.prim_name
+  | Tcoerce_primitive {pc_desc; pc_env = _; pc_type}  ->
+      pr "prim %s@ (%a)" pc_desc.Primitive.prim_name
+        Printtyp.raw_type_expr pc_type
   | Tcoerce_alias (p, c) ->
       pr "@[<2>alias %a@ (%a)@]"
         Printtyp.path p

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -244,7 +244,7 @@ and module_coercion =
   | Tcoerce_structure of (int * module_coercion) list *
                          (Ident.t * int * module_coercion) list
   | Tcoerce_functor of module_coercion * module_coercion
-  | Tcoerce_primitive of Primitive.description
+  | Tcoerce_primitive of primitive_coercion
   | Tcoerce_alias of Path.t * module_coercion
 
 and module_type =
@@ -262,6 +262,14 @@ and module_type_desc =
   | Tmty_with of module_type * (Path.t * Longident.t loc * with_constraint) list
   | Tmty_typeof of module_expr
   | Tmty_alias of Path.t * Longident.t loc
+
+(* Keep primitive type information for type-based lambda-code specialization *)
+and primitive_coercion =
+  {
+    pc_desc: Primitive.description;
+    pc_type: type_expr;
+    pc_env: Env.t;
+  }
 
 and signature = {
   sig_items : signature_item list;

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -243,7 +243,7 @@ and module_coercion =
   | Tcoerce_structure of (int * module_coercion) list *
                          (Ident.t * int * module_coercion) list
   | Tcoerce_functor of module_coercion * module_coercion
-  | Tcoerce_primitive of Primitive.description
+  | Tcoerce_primitive of primitive_coercion
   | Tcoerce_alias of Path.t * module_coercion
 
 and module_type =
@@ -261,6 +261,13 @@ and module_type_desc =
   | Tmty_with of module_type * (Path.t * Longident.t loc * with_constraint) list
   | Tmty_typeof of module_expr
   | Tmty_alias of Path.t * Longident.t loc
+
+and primitive_coercion =
+  {
+    pc_desc: Primitive.description;
+    pc_type: type_expr;
+    pc_env: Env.t;
+  }
 
 and signature = {
   sig_items : signature_item list;


### PR DESCRIPTION
As pointed out in [PR 6494](http://caml.inria.fr/mantis/view.php?id=6494), primitives are not always specialized even though type information are available.

This request changes code generation to always specialize when enough is known about types.
