### PR TITLE
[RFC] document the unsafe conversions Bytes.unsafe_{to,of}_string

### DIFF
--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -258,48 +258,37 @@ val compare: t -> t -> int
 
 (** {6 Unsafe conversions (Advanced)}
 
-    The conversions below are unsafe versions of [unsafe_to_string]
-    and [unsafe_of_string] that may not copy the internal data when
+    The conversions below are unsafe versions of [to_string]
+    and [of_string] that may not copy the internal data when
     converting from [bytes] to [string] and conversely. They are
     unsafe, in the sense that using them may break the invariant, if
     you never use the deprecated [String] functions, strings are
     immutable.
 
     They are used internally inside the standard library to implement
-    the basic building blocks; they SHOULD NOT be used outside, except
+    the basic building blocks; they should not be used outside, except
     by expert library authors. Note that [to_string] and [of_string]
     are quite fast, and that using unsafe functions indiscriminately
     will bring you more bugs than performance improvements.
-
-    Note that this interface DOES NOT assume that [bytes] and [string]
-    share the same representation; if [string]'s implementation
-    becomes ropes-based in the future, [unsafe_to_string] will still
-    make sense. On the contrary, using [Obj.magic] would break memory
-    safety; never use it (or unsafe externals) to convert between
-    [bytes] and [string].
 *)
 
 val unsafe_to_string : bytes -> string
 (**
-   Unsafely converts a byte sequence to a string.
+   Unsafely convert a byte sequence into a string.
 
    To reason about the use of [unsafe_to_string], it is convenient to
-   consider an "ownership" discipline (in the sense of Mezzo
-   [1]). A piece of code that manipulates some data "owns" it; there
-   are two disjoint ownership mode:
-
-   - Unique ownership: the data may be accessed and mutated
-
+   consider an "ownership" discipline. A piece of code that
+   manipulates some data "owns" it; there are two disjoint ownership
+   mode:
+   - Unique ownership: the data may be accessed and mutated}
    - Shared ownership: the data has several owner, that may only
-     access it, not mutate it.
+   access it, not mutate it.
 
    Unique ownership is linear: passing the data to another piece of
    code means giving up ownership (we cannot write the
    data again). A unique owner may decide to make the data shared
    (giving up mutation rights on it), but shared data may never become
    uniquely-owned again.
-
-   [1] http://gallium.inria.fr/~fpottier/biblio/pottier_abstracts.html#pottier-protzenko-13
 
    [unsafe_to_string s] is only safe to use if the caller is the
    unique owner of the byte sequence [s]; the caller gives up
@@ -312,9 +301,9 @@ val unsafe_to_string : bytes -> string
    that is never changed after initialization is performed.
 
    {[ let string_init len f : string =
-        let s = Bytes.create len in
-        for i = 0 to len - 1 do Bytes.set s i (f i) done;
-        Bytes.unsafe_to_string s
+   let s = Bytes.create len in
+   for i = 0 to len - 1 do Bytes.set s i (f i) done;
+   Bytes.unsafe_to_string s
    ]}
 
    This function is safe because the byte sequence [s] will never
@@ -334,7 +323,7 @@ val unsafe_to_string : bytes -> string
    that we can mutate the sequence again after the call ended.
 
    {[ let bytes_length (s : bytes) =
-        String.length (Bytes.unsafe_to_string s)
+   String.length (Bytes.unsafe_to_string s)
    ]}
 
    In this use-case, we do not promise that [s] will never be mutated
@@ -349,48 +338,53 @@ val unsafe_to_string : bytes -> string
    The caller may not mutate [s] while the string is borrowed (it has
    temporarily given up ownership). This affects concurrent programs,
    but also higher-order functions: if [String.length] returned
-   a future to be called later, [s] should not be mutated until this
-   future is fully consumed and returns ownership.
+   a closure to be called later, [s] should not be mutated until this
+   closure is fully applied and returns ownership.
 *)
 
 val unsafe_of_string : string -> bytes
 
-(**
-   On paper, the same ownership discipline that makes
-   [unsafe_to_string] correct applies to [unsafe_of_string]: you may
-   use it if you are the owner of the [string] value, and are
-   giving ownership to a [bytes]-expecting program.
+(** Unsafely convert a shared string to a byte sequence that should
+    not be mutated.
 
-   In practice, this function is extremely difficult to use correctly,
-   because it is hard to reason about ownership of [string] values. We
-   advise you to avoid [unsafe_of_string].
+    On paper, the same ownership discipline that makes
+    [unsafe_to_string] correct applies to [unsafe_of_string]: you may
+    use it if you are the owner of the [string] value, and you will
+    own the return [bytes] accordingly.
 
-   For example, string literals are shared, so you never uniquely own
-   them.
+    In practice, this function is extremely difficult to use correctly,
+    because it is hard to reason about ownership of [string] values. We
+    advise you to avoid [unsafe_of_string].
 
-   {[
-   let incorrect = Bytes.unsafe_of_string "hello"
-   let s = Bytes.of_string "hello"
-   ]}
+    For example, string literals are shared, so you never uniquely own
+    them.
 
-   The [incorrect] version is unsafe, because the string literal
-   ["hello"] could be shared with other parts of the program, and
-   mutating [incorrect] is a bug. You must always use the second
-   version, which performs a copy and is thus correct.
+    {[
+    let incorrect = Bytes.unsafe_of_string "hello"
+    let s = Bytes.of_string "hello"
+    ]}
 
-   Calling [unsafe_of_string] on strings that are not string literals,
-   but are (partly) built from string literals, is also unsafe: in
-   a ropes-based implementation of string, ["foo" ^ s] would be a tree
-   whose left leaf is the shared string ["foo"]; similarly, the unique
-   ownership of [String.concat sep string_list] requires unique
-   ownership of [sep] and all the strings in [string_list].
+    The first declaration is incorrect, because the string literal
+    ["hello"] could be shared with other parts of the program, and
+    mutating [incorrect] is a bug. You must always use the second
+    version, which performs a copy and is thus correct.
 
-   The only case we have reasonable confidence is safe is if the
-   produced [bytes] is never mutated: it is not uniquely owned, but
-   shared, by the caller, and used as an immutable byte sequence. This
-   is possibly useful for incremental migration of low-level program
-   that manipulate immutable byte sequences, and previously used the
-   [string] type for this purpose.
+    Calling [unsafe_of_string] on strings that are not string
+    literals, but are (partly) built from string literals, is also
+    incorrect. For example, mutating [unsafe_of_string ("foo" ^ s)]
+    could mutate the shared string ["foo"] -- assuming a rope-like
+    representation of string. More generally, functions operating on
+    strings will assume shared ownership, they do not preserve unique
+    ownership. It is thus incorrect to assume unique ownership of the
+    result of [unsafe_of_string].
+
+    The only case we have reasonable confidence is safe is if the
+    produced [bytes] is never mutated: it is not uniquely owned, but
+    shared, and must be used as an immutable byte sequence. This is
+    possibly useful for incremental migration of low-level program
+    that manipulate immutable sequences of bytes -- for example
+    {!Marshal.from_bytes} -- and previously used the [string] type for
+    this purpose.
 *)
 
 (**/**)

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -258,18 +258,12 @@ val compare: t -> t -> int
 
 (** {6 Unsafe conversions (Advanced)}
 
-    The conversions below are unsafe versions of [to_string]
-    and [of_string] that may not copy the internal data when
-    converting from [bytes] to [string] and conversely. They are
-    unsafe, in the sense that using them may break the invariant, if
-    you never use the deprecated [String] functions, strings are
-    immutable.
-
-    They are used internally inside the standard library to implement
-    the basic building blocks; they should not be used outside, except
-    by expert library authors. Note that [to_string] and [of_string]
-    are quite fast, and that using unsafe functions indiscriminately
-    will bring you more bugs than performance improvements.
+    This section describes unsafe, low-level conversion functions
+    between [bytes] and [string]. They do not copy the internal data;
+    used improperly, they can break the immutability invariant on
+    strings provided the `-safe-string` option. They are available for
+    expert library authors, but for most purposes you should use the
+    always-correct [to_string] and [of_string] instead.
 *)
 
 val unsafe_to_string : bytes -> string


### PR DESCRIPTION
The attached patch contains a tentative documentation of the two new functions [Bytes.unsafe_of_string] and [Bytes.unsafe_to_string] that are intended for use when migrating code to support the new `-safe-string` option.

It is only a preliminary patch; in particular, it does not contain much OCamldoc formatting (I will add those laters). I would be interested in feedback on the content. The objectives of documenting these functions are the following:
1. we do not want beginners to use them (there is no need to, given the existing `Bytes.of_string` and `Bytes.to_string` which are correct and fast enough for most purposes)
2. we do not want experts to use them wrongly or, worse, wrongly use `Obj.magic` or `"%identity"` instead.

Not documenting at all is a very good way to reach goal (1), but does pretty badly on (2). Do you feel the proposed documentation is effective? How should it be improved?

Finally, be aware that documenting unsafe functions is still a controversial topic among OCaml maintainers. I'd like to get as good a proposal as possible, but it is possible that maintainers decide to keep those undocumented in any case. Invest your time wisely.
