### PR TITLE
First draft of the OCAMLLIB patch

### DIFF
--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -501,7 +501,8 @@ let build_custom_runtime prim_name exec_name =
   let runtime_lib = "-lcamlrun" ^ !Clflags.runtime_variant in
   Ccomp.call_linker Ccomp.Exe exec_name
     ([prim_name] @ List.rev !Clflags.ccobjs @ [runtime_lib])
-    (Clflags.std_include_flag "-I" ^ " " ^ Config.bytecomp_c_libraries)
+    (String.concat " " (Clflags.std_include_flag "-I")
+     ^ " " ^ Config.bytecomp_c_libraries)
 
 let append_bytecode_and_cleanup bytecode_name exec_name prim_name =
   let oc = open_out_gen [Open_wronly; Open_append; Open_binary] 0 exec_name in

--- a/bytecomp/dll.ml
+++ b/bytecomp/dll.ml
@@ -114,17 +114,19 @@ let synchronize_primitive num symb =
 
 let ld_conf_contents () =
   let path = ref [] in
-  begin try
-    let ic = open_in (Filename.concat Config.standard_library "ld.conf") in
-    begin try
-      while true do
-        path := input_line ic :: !path
-      done
-    with End_of_file -> ()
-    end;
-    close_in ic
-  with Sys_error _ -> ()
-  end;
+  let read alt =
+    try
+      let ic = open_in (Filename.concat alt "ld.conf") in
+      begin try
+        while true do
+          path := input_line ic :: !path
+        done
+      with End_of_file -> ()
+      end;
+      close_in ic
+    with Sys_error _ -> ()
+  in
+  List.iter read Config.standard_library;
   List.rev !path
 
 (* Split the CAML_LD_LIBRARY_PATH environment variable and return

--- a/debugger/loadprinter.ml
+++ b/debugger/loadprinter.ml
@@ -97,7 +97,7 @@ let rec eval_path = function
   libray, so we load it beforehand as it cannot be found in the search path. *)
 let () =
   let compiler_libs =
-    Filename.concat Config.standard_library "compiler-libs" in
+    Misc.expand_directory Config.standard_library "+compiler-lib" in
   let topdirs =
     Filename.concat compiler_libs "topdirs.cmi" in
   ignore (Env.read_signature "Topdirs" topdirs)

--- a/debugger/parameters.ml
+++ b/debugger/parameters.ml
@@ -23,7 +23,7 @@ let socket_name = ref ""
 let arguments = ref ""
 
 let default_load_path =
-  ref [ Filename.current_dir_name; Config.standard_library ]
+  ref ( Filename.current_dir_name :: Config.standard_library )
 
 let add_path dir =
   load_path := dir :: except dir !load_path;

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -23,14 +23,15 @@ let print_version_and_library compiler =
   Printf.printf "The OCaml %s, version " compiler;
   print_string Config.version; print_newline();
   print_string "Standard library directory: ";
-  print_string Config.standard_library; print_newline();
+  print_string (String.concat ":" Config.standard_library); print_newline();
   exit 0
 
 let print_version_string () =
   print_string Config.version; print_newline(); exit 0
 
 let print_standard_library () =
-  print_string Config.standard_library; print_newline(); exit 0
+  print_string (String.concat ":" Config.standard_library); print_newline();
+  exit 0
 
 let fatal err =
   prerr_endline err;

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -28,7 +28,7 @@ open Typedtree
    then the standard library directory. *)
 let init_path () =
   load_path :=
-    "" :: List.rev (Config.standard_library :: !Clflags.include_dirs);
+    "" :: List.rev (Config.standard_library @ !Clflags.include_dirs);
   Env.reset_cache ()
 
 (** Return the initial environment in which compilation proceeds. *)

--- a/ocamldoc/odoc_config.ml
+++ b/ocamldoc/odoc_config.ml
@@ -11,7 +11,7 @@
 (***********************************************************************)
 
 let custom_generators_path =
-  Filename.concat Config.standard_library
-    (Filename.concat "ocamldoc" "custom")
+  let ocamldoc = Misc.expand_directory Config.standard_library "+ocamldoc" in
+  Filename.concat ocamldoc "custom"
 
 let print_warnings = ref true

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -190,8 +190,10 @@ let dump_byte ic =
 
 let read_dyn_header filename ic =
   let tempfile = Filename.temp_file "objinfo" ".out" in
-  let helper = Filename.concat Config.standard_library "objinfo_helper" in
   try
+    let helper =
+      Misc.expand_directory Config.standard_library "+objinfo_helper"
+    in
     try_finally
       (fun () ->
         let rc = Sys.command (sprintf "%s %s > %s"

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -453,7 +453,8 @@ let set_paths () =
   (* Add whatever -I options have been specified on the command line,
      but keep the directories that user code linked in with ocamlmktop
      may have added to load_path. *)
-  load_path := !load_path @ [Filename.concat Config.standard_library "camlp4"];
+  load_path := !load_path @
+               [Misc.expand_directory Config.standard_library "+camlp4"];
   load_path := "" :: (List.rev !Clflags.include_dirs @ !load_path);
   Dll.add_path !load_path
 

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -60,7 +60,7 @@ let compile_file name =
             else Config.bytecomp_c_compiler)
        (String.concat " " (List.rev !Clflags.all_ccopts))
        (quote_prefixed "-I" (List.rev !Clflags.include_dirs))
-       (Clflags.std_include_flag "-I")
+       (String.concat " " (Clflags.std_include_flag "-I"))
        (Filename.quote name))
 
 let create_archive archive file_list =

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -94,12 +94,13 @@ let force_slash = ref false             (* for ocamldep *)
 let dont_write_files = ref false        (* set to true under ocamldoc *)
 
 let std_include_flag prefix =
-  if !no_std_include then ""
-  else (prefix ^ (Filename.quote Config.standard_library))
+  if !no_std_include then []
+  else List.map (fun path -> (prefix ^ Filename.quote path))
+      Config.standard_library
 ;;
 
 let std_include_dir () =
-  if !no_std_include then [] else [Config.standard_library]
+  if !no_std_include then [] else Config.standard_library
 ;;
 
 let shared = ref false (* -shared *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -84,7 +84,7 @@ val dump_combine : bool ref
 val native_code : bool ref
 val inline_threshold : int ref
 val dont_write_files : bool ref
-val std_include_flag : string -> string
+val std_include_flag : string -> string list
 val std_include_dir : unit -> string list
 val shared : bool ref
 val dlcode : bool ref

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -15,8 +15,8 @@
 val version: string
         (* The current version number of the system *)
 
-val standard_library: string
-        (* The directory containing the standard libraries *)
+val standard_library: string list
+        (* The directories containing the standard libraries *)
 val standard_runtime: string
         (* The full path to the standard bytecode interpreter ocamlrun *)
 val ccomp_type: string

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -27,12 +27,12 @@ let standard_library_default = "%%LIBDIR%%"
 
 let standard_library =
   try
-    Sys.getenv "OCAMLLIB"
+    Misc.split (Sys.getenv "OCAMLLIB") ':'
   with Not_found ->
   try
-    Sys.getenv "CAMLLIB"
+    Misc.split (Sys.getenv "CAMLLIB") ':'
   with Not_found ->
-    standard_library_default
+    [standard_library_default]
 
 let standard_runtime = "%%BYTERUN%%"
 let ccomp_type = "%%CCOMPTYPE%%"
@@ -101,7 +101,7 @@ let print_config oc =
   let p_bool name valu = Printf.fprintf oc "%s: %B\n" name valu in
   p "version" version;
   p "standard_library_default" standard_library_default;
-  p "standard_library" standard_library;
+  p "standard_library" (String.concat ":" standard_library);
   p "standard_runtime" standard_runtime;
   p "ccomp_type" ccomp_type;
   p "bytecomp_c_compiler" bytecomp_c_compiler;

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -108,11 +108,19 @@ let remove_file filename =
 (* Expand a -I option: if it starts with +, make it relative to the standard
    library directory *)
 
-let expand_directory alt s =
+let expand_directory_aux alt s =
   if String.length s > 0 && s.[0] = '+'
   then Filename.concat alt
                        (String.sub s 1 (String.length s - 1))
   else s
+
+let expand_directory alts s =
+  let dirs = List.map (fun alt -> expand_directory_aux alt s) alts in
+  try List.find (fun dir -> Sys.file_exists dir) dirs
+  with Not_found ->
+    match alts with
+    | main :: _ -> expand_directory_aux main s
+    | _ -> failwith (Printf.sprintf "Cannot resolve %s." s)
 
 (* Hashtable functions *)
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -48,8 +48,8 @@ val find_in_path_uncap: string list -> string -> string
            to match. *)
 val remove_file: string -> unit
         (* Delete the given file if it exists. Never raise an error. *)
-val expand_directory: string -> string -> string
-        (* [expand_directory alt file] eventually expands a [+] at the
+val expand_directory: string list -> string -> string
+        (* [expand_directory alts file] eventually expands a [+] at the
            beginning of file into [alt] (an alternate root directory) *)
 
 val create_hashtable: int -> ('a * 'b) list -> ('a, 'b) Hashtbl.t


### PR DESCRIPTION
Surely not good enough to inclusion, but at least there's something to discuss.

Need to fix:
- [ ] decide if we want to return a proper/prettier error in `Misc.expand_directory` when +name` cannot be resolved. This patch tries to keep the same behaviour as before.
- [ ] fix `asmrun/dynlink.c`
- [ ] fix `byterun/dynlink.c`
- [ ] fix `stdlib/caml/dynlink.c`
- [ ] fix `./ocamlbuild/ocamlbuild_where.ml`
- [ ] check that the debugger still works ok
