### PR TITLE
#6539: don't divide caml_major_heap_increment by eight

### DIFF
--- a/byterun/gc_ctrl.c
+++ b/byterun/gc_ctrl.c
@@ -321,7 +321,7 @@ CAMLprim value caml_gc_get(value v)
 
   res = caml_alloc_tuple (7);
   Store_field (res, 0, Val_long (Wsize_bsize (caml_minor_heap_size)));  /* s */
-  Store_field (res, 1,Val_long(Wsize_bsize(caml_major_heap_increment)));/* i */
+  Store_field (res, 1, Val_long (caml_major_heap_increment));           /* i */
   Store_field (res, 2, Val_long (caml_percent_free));                   /* o */
   Store_field (res, 3, Val_long (caml_verb_gc));                        /* v */
   Store_field (res, 4, Val_long (caml_percent_max));                    /* O */


### PR DESCRIPTION
Major heap increment is now stored in words or percent:

``` c
extern uintnat caml_major_heap_increment; /* percent or words; see major_gc.c */
```

However, in caml_gc_get, the major heap increment is still divided by 8:

``` c
Store_field (res, 1,Val_long(Wsize_bsize(caml_major_heap_increment)));/* i */
```

This leads to this behaviour:

``` ocaml
let print x = print_int x; print_newline ()

let control = Gc.get ()
let () = print control.Gc.major_heap_increment

let () = Gc.set control
let () = print (Gc.get ()).Gc.major_heap_increment

let () = Gc.set { control with major_heap_increment = 40960 }
let () = print (Gc.get ()).Gc.major_heap_increment
```

Output:

```
$ ./temp
1
0
5120
```
