### PR TITLE
Reveal the type of Unix.inet_addr as private string plus some new conven...

### DIFF
--- a/otherlibs/threads/unix.ml
+++ b/otherlibs/threads/unix.ml
@@ -511,6 +511,13 @@ external getgrgid : int -> group_entry = "unix_getgrgid"
 
 type inet_addr = string
 
+let ipv4_addr_of_bytes buf off = Bytes.(sub buf off 4 |> to_string)
+let ipv6_addr_of_bytes buf off = Bytes.(sub buf off 16 |> to_string)
+let inet_addr_of_string_raw str =
+  match String.length str with
+    4 | 16 -> str
+  | _ -> invalid_arg "inet_addr_of_string_raw"
+
 external inet_addr_of_string : string -> inet_addr
                                     = "unix_inet_addr_of_string"
 external string_of_inet_addr : inet_addr -> string

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -481,6 +481,13 @@ type inet_addr = string
 
 let is_inet6_addr s = String.length s = 16
 
+let ipv4_addr_of_bytes buf off = Bytes.(sub buf off 4 |> to_string)
+let ipv6_addr_of_bytes buf off = Bytes.(sub buf off 16 |> to_string)
+let inet_addr_of_string_raw str =
+  match String.length str with
+    4 | 16 -> str
+  | _ -> invalid_arg "inet_addr_of_string_raw"
+
 external inet_addr_of_string : string -> inet_addr
                                     = "unix_inet_addr_of_string"
 external string_of_inet_addr : inet_addr -> string

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -909,8 +909,30 @@ val getgrgid : int -> group_entry
 (** {6 Internet addresses} *)
 
 
-type inet_addr
-(** The abstract type of Internet addresses. *)
+type inet_addr = private string
+(** The type of Internet addresses, a string of length 4 or 16
+    depending of the IP version of the address. *)
+
+val ipv4_addr_of_bytes : bytes -> int -> inet_addr
+(** [ipv4_addr_of_bytes buf off] returns the IPv4 address extracted
+    from [buf] at offset [off].
+
+    Raise [Invalid_argument] if [off] and [off+4] do not designate a
+    valid range of [buf].
+*)
+
+val ipv6_addr_of_bytes : bytes -> int -> inet_addr
+(** [ipv6_addr_of_bytes buf off] returns the IPv6 address extracted
+    from [buf] at offset [off].
+
+    Raise [Invalid_argument] if [off] and [off+16] do not designate a
+    valid range of [buf]. *)
+
+val inet_addr_of_string_raw : string -> inet_addr
+(** [inet_addr_of_string_raw addr] returns the IP address extracted
+    from [addr].
+
+    Raise [Invalid_argument] if [addr] has not length 4 or 16. *)
 
 val inet_addr_of_string : string -> inet_addr
 (** Conversion from the printable representation of an Internet

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -486,6 +486,13 @@ type inet_addr = string
 
 let is_inet6_addr s = String.length s = 16
 
+let ipv4_addr_of_bytes buf off = Bytes.(sub buf off 4 |> to_string)
+let ipv6_addr_of_bytes buf off = Bytes.(sub buf off 16 |> to_string)
+let inet_addr_of_string_raw str =
+  match String.length str with
+    4 | 16 -> str
+  | _ -> invalid_arg "inet_addr_of_string_raw"
+
 external inet_addr_of_string : string -> inet_addr
                                     = "unix_inet_addr_of_string"
 external string_of_inet_addr : inet_addr -> string


### PR DESCRIPTION
...ience functions.

Added functions ipv4_addr_of_bytes, ipv6_addr_of_bytes and
inet_addr_of_string_raw to extract IP addresses from bytes and
raw_strings.
