### PR TITLE
fix for ocamlbuild on cygwin cannot find ocamlfind

### DIFF
--- a/ocamlbuild/command.ml
+++ b/ocamlbuild/command.ml
@@ -125,7 +125,7 @@ let virtual_solver virtual_command =
 
 (* On Windows, we need to also check for the ".exe" version of the file. *)
 let file_or_exe_exists file =
-  sys_file_exists file || (Sys.os_type = "Win32" && sys_file_exists (file ^ ".exe"))
+  sys_file_exists file || ((Sys.os_type = "Win32" || Sys.os_type = "Cygwin") && sys_file_exists (file ^ ".exe"))
 
 let search_in_path cmd =
   (* Try to find [cmd] in path [path]. *)

--- a/ocamlbuild/command.ml
+++ b/ocamlbuild/command.ml
@@ -125,7 +125,7 @@ let virtual_solver virtual_command =
 
 (* On Windows, we need to also check for the ".exe" version of the file. *)
 let file_or_exe_exists file =
-  sys_file_exists file || ((Sys.os_type = "Win32" || Sys.os_type = "Cygwin") && sys_file_exists (file ^ ".exe"))
+  sys_file_exists file || ((Sys.win32 || Sys.cygwin) && sys_file_exists (file ^ ".exe"))
 
 let search_in_path cmd =
   (* Try to find [cmd] in path [path]. *)


### PR DESCRIPTION
ocamlbuild should append .exe extension to filename when looking for
executables on os_type 'Cygwin' (same as os_type 'Win32')
