### PR TITLE
ocamlbuild: use ocamlfind to discover camlp4 path

### DIFF
--- a/Changes
+++ b/Changes
@@ -226,6 +226,8 @@ OCamlbuild:
 - Changed OCamlbuild's license to LGPLv2 with static linking exception.
 - GPR#219: speedup target-already-built builds
   (ygrek)
+- PR#6605, GPR#117: use ocamlfind, if available, to discover camlp4 path
+  (Vincent Laporte)
 
 Bug fixes:
 - PR#3612: memory leak in bigarray read from file

--- a/ocamlbuild/ocaml_specific.ml
+++ b/ocamlbuild/ocaml_specific.ml
@@ -698,15 +698,25 @@ ocaml_lib ~extern:true ~tag_name:"use_toplevel" "toplevellib";;
 ocaml_lib ~extern:true ~dir:"+ocamldoc" "ocamldoc";;
 ocaml_lib ~extern:true ~dir:"+ocamlbuild" ~tag_name:"use_ocamlbuild" "ocamlbuildlib";;
 
-ocaml_lib ~extern:true ~dir:"+camlp4" ~tag_name:"use_camlp4" "camlp4lib";;
-ocaml_lib ~extern:true ~dir:"+camlp4" ~tag_name:"use_old_camlp4" "camlp4";;
-ocaml_lib ~extern:true ~dir:"+camlp4" ~tag_name:"use_camlp4_full" "camlp4fulllib";;
+let camlp4dir =
+  Findlib.(
+    try
+      if sys_command "sh -c 'ocamlfind list >/dev/null' 2>/dev/null" != 0
+      then raise (Findlib_error Cannot_run_ocamlfind);
+      (query "camlp4").location
+    with Findlib_error _ ->
+      "+camlp4"
+  );;
+
+ocaml_lib ~extern:true ~dir:camlp4dir ~tag_name:"use_camlp4" "camlp4lib";;
+ocaml_lib ~extern:true ~dir:camlp4dir ~tag_name:"use_old_camlp4" "camlp4";;
+ocaml_lib ~extern:true ~dir:camlp4dir ~tag_name:"use_camlp4_full" "camlp4fulllib";;
 flag ["ocaml"; "compile"; "use_camlp4_full"]
-     (S[A"-I"; A"+camlp4/Camlp4Parsers";
-        A"-I"; A"+camlp4/Camlp4Printers";
-        A"-I"; A"+camlp4/Camlp4Filters"]);;
-flag ["ocaml"; "use_camlp4_bin"; "link"; "byte"] (A"+camlp4/Camlp4Bin.cmo");;
-flag ["ocaml"; "use_camlp4_bin"; "link"; "native"] (A"+camlp4/Camlp4Bin.cmx");;
+     (S[A"-I"; A(camlp4dir^"/Camlp4Parsers");
+        A"-I"; A(camlp4dir^"/Camlp4Printers");
+        A"-I"; A(camlp4dir^"/Camlp4Filters")]);;
+flag ["ocaml"; "use_camlp4_bin"; "link"; "byte"] (A(camlp4dir^"/Camlp4Bin.cmo"));;
+flag ["ocaml"; "use_camlp4_bin"; "link"; "native"] (A(camlp4dir^"/Camlp4Bin.cmx"));;
 
 flag ["ocaml"; "debug"; "compile"; "byte"] (A "-g");;
 flag ["ocaml"; "debug"; "link"; "byte"; "program"] (A "-g");;


### PR DESCRIPTION
Fixes [issue 6605](http://caml.inria.fr/mantis/view.php?id=6605).

The idea is to use `ocamlfind` to discover where camlp4 is actually installed. And so even if the `-use-ocamlfind` option is not given, for compatibility reasons.

In case the call to `ocamlfind` fails, the default value of `+camlp4` is used. So a working install of camlp4 without ocamlfind is still possible.

The query to `ocamlfind` is done lazily, only when a rule requires camlp4.
