### PR TITLE
Location: rename error.loc label to location

### DIFF
--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -619,7 +619,7 @@ let default_mapper =
       );
   }
 
-let rec extension_of_error {loc; msg; if_highlight; sub} =
+let rec extension_of_error {location = loc; msg; if_highlight; sub} =
   { loc; txt = "ocaml.error" },
   PStr ([Str.eval (Exp.constant (Const_string (msg, None)));
          Str.eval (Exp.constant (Const_string (if_highlight, None)))] @

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -291,17 +291,17 @@ let mknoloc txt = mkloc txt none
 
 type error =
   {
-    loc: t;
+    location: t;
     msg: string;
     sub: error list;
     if_highlight: string; (* alternative message if locations are highlighted *)
   }
 
 let errorf ?(loc = none) ?(sub = []) ?(if_highlight = "") =
-  Printf.ksprintf (fun msg -> {loc; msg; sub; if_highlight})
+  Printf.ksprintf (fun msg -> {location = loc; msg; sub; if_highlight})
 
 let error ?(loc = none) ?(sub = []) ?(if_highlight = "") msg =
-  {loc; msg; sub; if_highlight}
+  {location = loc; msg; sub; if_highlight}
 
 let error_of_exn : (exn -> error option) list ref = ref []
 
@@ -317,11 +317,11 @@ let error_of_exn exn =
   in
   loop !error_of_exn
 
-let rec report_error ppf ({loc; msg; sub; if_highlight} as err) =
+let rec report_error ppf ({location; msg; sub; if_highlight} as err) =
   let highlighted =
     if if_highlight <> "" then
-      let rec collect_locs locs {loc; sub; if_highlight; _} =
-        List.fold_left collect_locs (loc :: locs) sub
+      let rec collect_locs locs {location; sub; if_highlight; _} =
+        List.fold_left collect_locs (location :: locs) sub
       in
       let locs = collect_locs [] err in
       highlight_locations ppf locs
@@ -331,7 +331,7 @@ let rec report_error ppf ({loc; msg; sub; if_highlight} as err) =
   if highlighted then
     Format.pp_print_string ppf if_highlight
   else begin
-    print ppf loc;
+    print ppf location;
     Format.pp_print_string ppf msg;
     List.iter (fun err -> Format.fprintf ppf "@\n@[<2>%a@]" report_error err)
               sub
@@ -384,4 +384,5 @@ let () =
     )
 
 let raise_errorf ?(loc = none) ?(sub = []) ?(if_highlight = "") =
-  Printf.ksprintf (fun msg -> raise (Error ({loc; msg; sub; if_highlight})))
+  Printf.ksprintf
+    (fun msg -> raise (Error ({location = loc; msg; sub; if_highlight})))

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -83,7 +83,7 @@ val absname: bool ref
 
 type error =
   {
-    loc: t;
+    location: t;
     msg: string;
     sub: error list;
     if_highlight: string; (* alternative message if locations are highlighted *)


### PR DESCRIPTION
This prevents ambiguity with `t.loc`.

4.02 (the exception_registration branch) introduced another record with a `loc` field in `Location`.
This works because of constructor disambiguation, I am not sure relying on this feature was desired.

Renaming the field helps sharing code in merlin, since it may be compiled with <4.02.
