### PR TITLE
[RFC] add caml_modify_field and caml_initialize_field

### DIFF
--- a/byterun/alloc.c
+++ b/byterun/alloc.c
@@ -117,11 +117,8 @@ CAMLexport value caml_alloc_array(value (*funct)(char const *),
   } else {
     result = caml_alloc (nbr, 0);
     for (n = 0; n < nbr; n++) {
-      /* The two statements below must be separate because of evaluation
-         order (don't take the address &Field(result, n) before
-         calling funct, which may cause a GC and move result). */
       v = funct(arr[n]);
-      caml_modify(&Field(result, n), v);
+      caml_modify_field(result, n, v);
     }
     CAMLreturn (result);
   }
@@ -185,7 +182,7 @@ CAMLprim value caml_update_dummy(value dummy, value newval)
     }
   }else{
     for (i = 0; i < size; i++){
-      caml_modify (&Field(dummy, i), Field(newval, i));
+      caml_modify_field(dummy, i, Field(newval, i));
     }
   }
   return Val_unit;

--- a/byterun/backtrace.c
+++ b/byterun/backtrace.c
@@ -493,7 +493,7 @@ CAMLprim value caml_get_exception_backtrace(value unit)
               /* caml_convert_raw_backtrace_slot will not fail with
                caml_failwith as we checked (events != NULL) already */
               slot = caml_convert_raw_backtrace_slot(raw_slot);
-              caml_modify(&Field(arr, i), slot);
+              caml_modify_field(arr, i, slot);
           }
       }
       res = caml_alloc_small(1, 0); Field(res, 0) = arr; /* Some */

--- a/byterun/interp.c
+++ b/byterun/interp.c
@@ -532,7 +532,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
         /* caml_alloc_shr and caml_initialize never trigger a GC,
            so no need to Setup_for_gc */
         accu = caml_alloc_shr(1 + nvars, Closure_tag);
-        for (i = 0; i < nvars; i++) caml_initialize(&Field(accu, i + 1), sp[i]);
+        for (i = 0; i < nvars; i++) caml_initialize_field(accu, i + 1, sp[i]);
       }
       /* The code pointer is not in the heap, so no need to go through
          caml_initialize. */
@@ -558,8 +558,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
         /* caml_alloc_shr and caml_initialize never trigger a GC,
            so no need to Setup_for_gc */
         accu = caml_alloc_shr(blksize, Closure_tag);
-        p = &Field(accu, nfuncs * 2 - 1);
-        for (i = 0; i < nvars; i++, p++) caml_initialize(p, sp[i]);
+        for (i = 0; i < nvars; i++, p++)
+          caml_initialize_field(accu, nfuncs * 2 - 1, sp[i]);
       }
       sp += nvars;
       /* The code pointers and infix headers are not in the heap,
@@ -620,7 +620,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
     }
 
     Instruct(SETGLOBAL):
-      caml_modify(&Field(caml_global_data, *pc), accu);
+      caml_modify_field(caml_global_data, *pc, accu);
       accu = Val_unit;
       pc++;
       Next;
@@ -650,8 +650,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
         for (i = 1; i < wosize; i++) Field(block, i) = *sp++;
       } else {
         block = caml_alloc_shr(wosize, tag);
-        caml_initialize(&Field(block, 0), accu);
-        for (i = 1; i < wosize; i++) caml_initialize(&Field(block, i), *sp++);
+        caml_initialize_field(block, 0, accu);
+        for (i = 1; i < wosize; i++) caml_initialize_field(block, i, *sp++);
       }
       accu = block;
       Next;
@@ -724,23 +724,23 @@ value caml_interprete(code_t prog, asize_t prog_size)
     }
 
     Instruct(SETFIELD0):
-      caml_modify(&Field(accu, 0), *sp++);
+      caml_modify_field(accu, 0, *sp++);
       accu = Val_unit;
       Next;
     Instruct(SETFIELD1):
-      caml_modify(&Field(accu, 1), *sp++);
+      caml_modify_field(accu, 1, *sp++);
       accu = Val_unit;
       Next;
     Instruct(SETFIELD2):
-      caml_modify(&Field(accu, 2), *sp++);
+      caml_modify_field(accu, 2, *sp++);
       accu = Val_unit;
       Next;
     Instruct(SETFIELD3):
-      caml_modify(&Field(accu, 3), *sp++);
+      caml_modify_field(accu, 3, *sp++);
       accu = Val_unit;
       Next;
     Instruct(SETFIELD):
-      caml_modify(&Field(accu, *pc), *sp++);
+      caml_modify_field(accu, *pc, *sp++);
       accu = Val_unit;
       pc++;
       Next;
@@ -764,7 +764,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       sp += 1;
       Next;
     Instruct(SETVECTITEM):
-      caml_modify(&Field(accu, Long_val(sp[0])), sp[1]);
+      caml_modify_field(accu, Long_val(sp[0]), sp[1]);
       accu = Val_unit;
       sp += 2;
       Next;

--- a/byterun/memory.h
+++ b/byterun/memory.h
@@ -38,7 +38,9 @@ CAMLextern void caml_adjust_gc_speed (mlsize_t, mlsize_t);
 CAMLextern void caml_alloc_dependent_memory (mlsize_t);
 CAMLextern void caml_free_dependent_memory (mlsize_t);
 CAMLextern void caml_modify (value *, value);
+CAMLextern void caml_modify_field (value, intnat, value);
 CAMLextern void caml_initialize (value *, value);
+CAMLextern void caml_initialize_field (value, intnat, value);
 CAMLextern value caml_check_urgent_gc (value);
 CAMLextern void * caml_stat_alloc (asize_t);              /* Size in bytes. */
 CAMLextern void caml_stat_free (void *);
@@ -117,9 +119,21 @@ int caml_page_table_initialize(mlsize_t bytesize);
   DEBUG_clear ((result), (wosize));                                         \
 }while(0)
 
-/* Deprecated alias for [caml_modify] */
+/* Deprecated alias for [caml_modify], [caml_modify_field] */
 
 #define Modify(fp,val) caml_modify((fp), (val))
+
+/* GS: can we turn this into
+     caml_modify_field((block), (offset), (val)),
+   or is it important to preserve the hardcoded evaluation order to
+   keep code not using CAMLlocal* properly working (if computing some
+   values calls a GC and moves the other around)? */
+#define Store_field(block, offset, val) do{ \
+  mlsize_t caml__temp_offset = (offset); \
+  value caml__temp_val = (val); \
+  caml_modify_field((block), caml__temp_offset, caml__temp_val); \
+}while(0)
+
 
 /* </private> */
 
@@ -310,12 +324,6 @@ CAMLextern struct caml__roots_block *caml_local_roots;  /* defined in roots.c */
 #define CAMLnoreturn ((void) caml__frame)
 
 
-/* convenience macro */
-#define Store_field(block, offset, val) do{ \
-  mlsize_t caml__temp_offset = (offset); \
-  value caml__temp_val = (val); \
-  caml_modify (&Field ((block), caml__temp_offset), caml__temp_val); \
-}while(0)
 
 /*
    NOTE: [Begin_roots] and [End_roots] are superseded by [CAMLparam]*,

--- a/byterun/meta.c
+++ b/byterun/meta.c
@@ -84,7 +84,7 @@ CAMLprim value caml_realloc_global(value size)
                      requested_size);
     new_global_data = caml_alloc_shr(requested_size, 0);
     for (i = 0; i < actual_size; i++)
-      caml_initialize(&Field(new_global_data, i), Field(caml_global_data, i));
+        caml_initialize_field(new_global_data, i, Field(caml_global_data, i));
     for (i = actual_size; i < requested_size; i++){
       Field (new_global_data, i) = Val_long (0);
     }

--- a/byterun/obj.c
+++ b/byterun/obj.c
@@ -114,7 +114,7 @@ CAMLprim value caml_obj_dup(value arg)
     for (i = 0; i < sz; i++) Field(res, i) = Field(arg, i);
   } else {
     res = caml_alloc_shr(sz, tg);
-    for (i = 0; i < sz; i++) caml_initialize(&Field(res, i), Field(arg, i));
+    for (i = 0; i < sz; i++) caml_initialize_field(res, i, Field(arg, i));
   }
   CAMLreturn (res);
 }
@@ -148,7 +148,7 @@ CAMLprim value caml_obj_truncate (value v, value newsize)
      can darken them as appropriate. */
   if (tag < No_scan_tag) {
     for (i = new_wosize; i < wosize; i++){
-      caml_modify(&Field(v, i), Val_unit);
+      caml_modify_field(v, i, Val_unit);
 #ifdef DEBUG
       Field (v, i) = Debug_free_truncate;
 #endif

--- a/byterun/parsing.c
+++ b/byterun/parsing.c
@@ -238,7 +238,7 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
     RESTORE;
   push:
     Field(env->s_stack, sp) = Val_int(state);
-    caml_modify(&Field(env->v_stack, sp), env->lval);
+    caml_modify_field(env->v_stack, sp, env->lval);
     Store_field (env->symb_start_stack, sp, env->symb_start);
     Store_field (env->symb_end_stack, sp, env->symb_end);
     goto loop;
@@ -274,7 +274,7 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
   case SEMANTIC_ACTION_COMPUTED:
     RESTORE;
     Field(env->s_stack, sp) = Val_int(state);
-    caml_modify(&Field(env->v_stack, sp), arg);
+    caml_modify_field(env->v_stack, sp, arg);
     asp = Int_val(env->asp);
     Store_field (env->symb_end_stack, sp, Field(env->symb_end_stack, asp));
     if (sp > asp) {

--- a/byterun/signals.c
+++ b/byterun/signals.c
@@ -303,7 +303,7 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
       caml_signal_handlers = caml_alloc(NSIG, 0);
       caml_register_global_root(&caml_signal_handlers);
     }
-    caml_modify(&Field(caml_signal_handlers, sig), Field(action, 0));
+    caml_modify_field(caml_signal_handlers, sig, Field(action, 0));
   }
   caml_process_pending_signals();
   CAMLreturn (res);

--- a/byterun/weak.c
+++ b/byterun/weak.c
@@ -130,7 +130,7 @@ CAMLprim value caml_weak_get_copy (value ar, value n)
         if (caml_gc_phase == Phase_mark && Is_block (f) && Is_in_heap (f)){
           caml_darken (f, NULL);
         }
-        Modify (&Field (elt, i), f);
+        caml_modify_field(elt, i, f);
       }
     }else{
       memmove (Bp_val (elt), Bp_val (v), Bosize_val (v));


### PR DESCRIPTION
Stephen Dolan reported that he had to do a related change as part of his Multicore-OCaml work, and it seems applicable independently of it.

This patch does not remove all uses of `Field(...)` as a lvalue, or all `&Field(..)` constructs, but only those that fit into the following patterns:

```
caml_modify(&Field(v, idx), w) => caml_modify_field(v, idx, w)
caml_initialize(&Field(v, idx, w) => caml_initialize_field(v, idx, w)
```

This is an exploratory patch from someone that doesn't know the runtime very well. I had some questions when working on the code, which are marked with
`/* GS: ... */` comments.

All feedback and comments are welcome.
