### PR TITLE
Fix TZ issue in gettimeofday under Windows

### DIFF
--- a/otherlibs/win32unix/gettimeofday.c
+++ b/otherlibs/win32unix/gettimeofday.c
@@ -17,35 +17,20 @@
 
 #include "unixsupport.h"
 
-#ifdef HAS_MKTIME
 static double initial_time = 0; /* 0 means uninitialized */
-#else
-static time_t initial_time = 0; /* 0 means uninitialized */
-#endif
+static const uint64_t epoch_ft = 116444736000000000llu;
 static DWORD initial_tickcount;
 
 CAMLprim value unix_gettimeofday(value unit)
 {
   DWORD tickcount = GetTickCount();
-  SYSTEMTIME st;
+  uint64_t ft;
   struct tm tm;
   if (initial_time == 0 || tickcount < initial_tickcount) {
     initial_tickcount = tickcount;
-#ifdef HAS_MKTIME
-    GetLocalTime(&st);
-    tm.tm_sec = st.wSecond;
-    tm.tm_min = st.wMinute;
-    tm.tm_hour = st.wHour;
-    tm.tm_mday = st.wDay;
-    tm.tm_mon = st.wMonth - 1;
-    tm.tm_year = st.wYear - 1900;
-    tm.tm_wday = 0;
-    tm.tm_yday = 0;
-    tm.tm_isdst = -1;
-    initial_time = ((double) mktime(&tm) + (double) st.wMilliseconds * 1e-3);
-#else
-    initial_time = time(NULL);
-#endif
+    GetSystemTimeAsFileTime((FILETIME*)&ft);
+    ft -= epoch_ft; /* shift to Epoch-relative time */
+    initial_time = ft * 1e-7; /* ft is in 100ns */
     return copy_double((double) initial_time);
   } else {
     return copy_double((double) initial_time +

--- a/otherlibs/win32unix/gettimeofday.c
+++ b/otherlibs/win32unix/gettimeofday.c
@@ -18,6 +18,7 @@
 #include "unixsupport.h"
 
 static double initial_time = 0; /* 0 means uninitialized */
+/* Windows' epoch as a Unix timestamp in hundreds of ns */
 static const uint64_t epoch_ft = 116444736000000000llu;
 static DWORD initial_tickcount;
 


### PR DESCRIPTION
Fix issue 6671 that I reported in the official (still?) bug tracker. My comment about it:

When running some experiments with timing functions on Windows, I ran into a problem that occurred only in Cygwin's Bash: gettimeofday provided non-UTC timestamps. After some code inspection, here and there, I found the culprit: the TZ environment variable affects gettimeofday and it shouldn't.

Unix.gettimeofday under Windows (mingw and msvc) uses C's `mktime` to convert a Windows-specific local time (provided by `GetLocalTime`) to a Unix timestamp. However `mktime` (here Microsoft's one in msvcrt) is sensible to the TZ environment variable. All would be well if `GetLocalTime` would also take TZ into account. But obviously it does not. Consequently, a wrong time offset appears if TZ is set and is not the current local time zone of Windows.

Why does it appears inside a Cygwin shell? TZ as some legitimate uses in Cygwin. And Cygwin defines by default TZ to the current time zone of the system (Europe/Paris for me). In this particular case, it should be good, no? obviously not! Microsoft and Cygwin do not have the same understanding of what is a good TZ value.

Regards
Mickaël
