### PR TITLE
Actually use simplified lambda

### DIFF
--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -136,7 +136,7 @@ let load_lambda ppf (size, lam) =
     else Filename.temp_file ("caml" ^ !phrase_name) ext_dll
   in
   let fn = Filename.chop_extension dll in
-  Asmgen.compile_implementation ~toplevel:need_symbol fn ppf (size, lam);
+  Asmgen.compile_implementation ~toplevel:need_symbol fn ppf (size, slam);
   Asmlink.call_linker_shared [fn ^ ext_obj] dll;
   Sys.remove (fn ^ ext_obj);
 


### PR DESCRIPTION
This change prevents assertions triggered in closure.ml:1023
(and why simplify if not use the simplified version)

Signed-off-by: Christoph Höger christoph.hoeger@tu-berlin.de
