### PR TITLE
PR6695: Do not treat paths as encoded in ISO-8859-1

### DIFF
--- a/Changes
+++ b/Changes
@@ -24,6 +24,9 @@ Standard library:
 - PR#6585: fix memory leak in win32unix/createprocess.c
 - expose Sys.{int_size,max_wosize} for improved js_of_ocaml portability
   (Hugo Heuzard)
+- PR#6694, PR#6695: deprecate functions using ISO-8859-1 character set
+  in Char, Bytes, String and provide alternatives using US-ASCII.
+  (Peter Zotov)
 
 Type system:
 * PR#6465: allow incremental weakening of module aliases (Jacques Garrigue).

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -38,7 +38,7 @@ type pack_member =
 
 let read_member_info pack_path file = (
   let name =
-    String.capitalize(Filename.basename(chop_extensions file)) in
+    String.capitalize_ascii(Filename.basename(chop_extensions file)) in
   let kind =
     if Filename.check_suffix file ".cmx" then begin
       let (info, crc) = Compilenv.read_unit_info file in
@@ -171,7 +171,7 @@ let package_files ppf initial_env files targetcmx =
   let prefix = chop_extensions targetcmx in
   let targetcmi = prefix ^ ".cmi" in
   let targetobj = chop_extension_if_any targetcmx ^ Config.ext_obj in
-  let targetname = String.capitalize(Filename.basename prefix) in
+  let targetname = String.capitalize_ascii(Filename.basename prefix) in
   (* Set the name of the current "input" *)
   Location.input_name := targetcmx;
   (* Set the name of the current compunit *)

--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -96,7 +96,7 @@ type pack_member =
 
 let read_member_info file = (
   let name =
-    String.capitalize(Filename.basename(chop_extensions file)) in
+    String.capitalize_ascii(Filename.basename(chop_extensions file)) in
   let kind =
     if Filename.check_suffix file ".cmo" then begin
     let ic = open_in_bin file in
@@ -261,7 +261,7 @@ let package_files ppf initial_env files targetfile =
         files in
     let prefix = chop_extensions targetfile in
     let targetcmi = prefix ^ ".cmi" in
-    let targetname = String.capitalize(Filename.basename prefix) in
+    let targetname = String.capitalize_ascii(Filename.basename prefix) in
     try
       let coercion =
         Typemod.package_units initial_env files targetcmi targetname in

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -542,7 +542,7 @@ let lam_of_loc kind loc =
   | Loc_MODULE ->
     let filename = Filename.basename file in
     let module_name =
-      try String.capitalize (Filename.chop_extension filename)
+      try String.capitalize_ascii (Filename.chop_extension filename)
       with Invalid_argument _ -> "//"^filename^"//"
     in Lconst (Const_immstring module_name)
   | Loc_LOC ->

--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -150,9 +150,9 @@ let convert_module mdle =
   match mdle with
   | Some m ->
       (* Strip .ml extension if any, and capitalize *)
-      String.capitalize(if Filename.check_suffix m ".ml"
-                        then Filename.chop_suffix m ".ml"
-                        else m)
+      String.capitalize_ascii(if Filename.check_suffix m ".ml"
+                              then Filename.chop_suffix m ".ml"
+                              else m)
   | None ->
       try
         (get_current_event ()).ev_module
@@ -270,7 +270,7 @@ let instr_dir ppf lexbuf =
       let new_directory' = List.rev new_directory in
       match new_directory' with
       | mdl :: for_keyw :: tl
-        when (String.lowercase for_keyw) = "for" && (List.length tl) > 0 ->
+        when (String.lowercase_ascii for_keyw) = "for" && (List.length tl) > 0 ->
           List.iter (function x -> add_path_for mdl (expand_path x)) tl
       | _ ->
           List.iter (function x -> add_path (expand_path x)) new_directory'

--- a/debugger/loadprinter.ml
+++ b/debugger/loadprinter.ml
@@ -70,7 +70,7 @@ let rec loadfiles ppf name =
     true
   with
   | Dynlink.Error (Dynlink.Unavailable_unit unit) ->
-      loadfiles ppf (String.uncapitalize unit ^ ".cmo")
+      loadfiles ppf (String.uncapitalize_ascii unit ^ ".cmo")
         &&
       loadfiles ppf name
   | Not_found ->

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -85,7 +85,7 @@ let module_of_filename ppf inputfile outputprefix =
       String.sub basename 0 pos
     with Not_found -> basename
   in
-  let name = String.capitalize name in
+  let name = String.capitalize_ascii name in
   check_unit_name ppf inputfile name;
   name
 ;;

--- a/ocamlbuild/display.ml
+++ b/ocamlbuild/display.ml
@@ -297,10 +297,10 @@ let update_tagline_from_tags ds =
         done
     | (tag, c) :: rest ->
         if Tags.mem tag tags then
-          Bytes.set tagline i (Char.uppercase c)
+          Bytes.set tagline i (Char.uppercase_ascii c)
         else
           if Tags.mem tag ds.ds_seen_tags then
-            Bytes.set tagline i (Char.lowercase c)
+            Bytes.set tagline i (Char.lowercase_ascii c)
           else
             Bytes.set tagline i '-';
         loop (i + 1) rest

--- a/ocamlbuild/loc.ml
+++ b/ocamlbuild/loc.ml
@@ -20,7 +20,7 @@ let print_loc ppf (source, start, end_) =
     if one_or_two then fprintf ppf " %d" start_num
     else fprintf ppf "s %d-%d" start_num end_num in
   fprintf ppf "%s %S, line%a, character%a:@."
-    (String.capitalize source)
+    (String.capitalize_ascii source)
     (file start)
     (print (line start = line end_))
       (line start, line end_)

--- a/ocamlbuild/ocaml_specific.ml
+++ b/ocamlbuild/ocaml_specific.ml
@@ -720,17 +720,17 @@ flag ["ocaml"; "ocamllex"; "quiet"] (A"-q");;
 
 let ocaml_warn_flag c =
   flag ~deprecated:true
-    ["ocaml"; "compile"; sprintf "warn_%c" (Char.uppercase c)]
-    (S[A"-w"; A (sprintf "%c" (Char.uppercase c))]);
+    ["ocaml"; "compile"; sprintf "warn_%c" (Char.uppercase_ascii c)]
+    (S[A"-w"; A (sprintf "%c" (Char.uppercase_ascii c))]);
   flag ~deprecated:true
-    ["ocaml"; "compile"; sprintf "warn_error_%c" (Char.uppercase c)]
-    (S[A"-warn-error"; A (sprintf "%c" (Char.uppercase c))]);
+    ["ocaml"; "compile"; sprintf "warn_error_%c" (Char.uppercase_ascii c)]
+    (S[A"-warn-error"; A (sprintf "%c" (Char.uppercase_ascii c))]);
   flag ~deprecated:true
-    ["ocaml"; "compile"; sprintf "warn_%c" (Char.lowercase c)]
-    (S[A"-w"; A (sprintf "%c" (Char.lowercase c))]);
+    ["ocaml"; "compile"; sprintf "warn_%c" (Char.lowercase_ascii c)]
+    (S[A"-w"; A (sprintf "%c" (Char.lowercase_ascii c))]);
   flag ~deprecated:true
-    ["ocaml"; "compile"; sprintf "warn_error_%c" (Char.lowercase c)]
-    (S[A"-warn-error"; A (sprintf "%c" (Char.lowercase c))]);;
+    ["ocaml"; "compile"; sprintf "warn_error_%c" (Char.lowercase_ascii c)]
+    (S[A"-warn-error"; A (sprintf "%c" (Char.lowercase_ascii c))]);;
 
 List.iter ocaml_warn_flag ['A'; 'C'; 'D'; 'E'; 'F'; 'K'; 'L'; 'M'; 'P'; 'R'; 'S'; 'U'; 'V'; 'X'; 'Y'; 'Z'];;
 

--- a/ocamlbuild/ocaml_utils.ml
+++ b/ocamlbuild/ocaml_utils.ml
@@ -40,14 +40,14 @@ let pflag_and_dep tags ptag cmd_spec =
     (fun param ->
        flag_and_dep (Param_tags.make ptag param :: tags) (cmd_spec param))
 
-let module_name_of_filename f = String.capitalize (Pathname.remove_extensions f)
+let module_name_of_filename f = String.capitalize_ascii (Pathname.remove_extensions f)
 let module_name_of_pathname x =
   module_name_of_filename (Pathname.to_string (Pathname.basename x))
 
 let ignore_stdlib x =
   if !Options.nostdlib then false
   else
-    let x' = !*stdlib_dir/((String.uncapitalize x)-.-"cmi") in
+    let x' = !*stdlib_dir/((String.uncapitalize_ascii x)-.-"cmi") in
     Pathname.exists x'
 
 let non_dependencies = ref []
@@ -69,8 +69,8 @@ let expand_module =
   memo3 (fun include_dirs module_name exts ->
     let dirname = Pathname.dirname module_name in
     let basename = Pathname.basename module_name in
-    let module_name_cap = dirname/(String.capitalize basename) in
-    let module_name_uncap = dirname/(String.uncapitalize basename) in
+    let module_name_cap = dirname/(String.capitalize_ascii basename) in
+    let module_name_uncap = dirname/(String.uncapitalize_ascii basename) in
     List.fold_right begin fun include_dir ->
       List.fold_right begin fun ext acc ->
         include_dir/(module_name_uncap-.-ext) ::

--- a/ocamlbuild/options.ml
+++ b/ocamlbuild/options.ml
@@ -77,7 +77,7 @@ let mk_virtual_solvers =
   List.iter begin fun cmd ->
     let solver () =
       A (find_tool cmd)
-    in Command.setup_virtual_command_solver (String.uppercase cmd) solver
+    in Command.setup_virtual_command_solver (String.uppercase_ascii cmd) solver
   end
 
 let () =
@@ -353,7 +353,7 @@ let init () =
   dir_reorder my_include_dirs include_dirs;
   dir_reorder my_exclude_dirs exclude_dirs;
 
-  ignore_list := List.map String.capitalize !ignore_list
+  ignore_list := List.map String.capitalize_ascii !ignore_list
 ;;
 
 (* The current heuristic: we know we are in an ocamlbuild project if

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -62,7 +62,7 @@ let tool_name = "ocamldoc"
 let process_implementation_file ppf sourcefile =
   init_path ();
   let prefixname = Filename.chop_extension sourcefile in
-  let modulename = String.capitalize(Filename.basename prefixname) in
+  let modulename = String.capitalize_ascii(Filename.basename prefixname) in
   Env.set_unit_name modulename;
   let inputfile = preprocess sourcefile in
   let env = initial_env () in
@@ -95,7 +95,7 @@ let process_implementation_file ppf sourcefile =
 let process_interface_file ppf sourcefile =
   init_path ();
   let prefixname = Filename.chop_extension sourcefile in
-  let modulename = String.capitalize(Filename.basename prefixname) in
+  let modulename = String.capitalize_ascii(Filename.basename prefixname) in
   Env.set_unit_name modulename;
   let inputfile = preprocess sourcefile in
   let ast =
@@ -205,7 +205,7 @@ let process_file ppf sourcefile =
             try Filename.chop_extension file
             with _ -> file
           in
-          String.capitalize (Filename.basename s)
+          String.capitalize_ascii (Filename.basename s)
         in
         let txt =
           try Odoc_text.Texter.text_of_string (Odoc_misc.input_file_as_string file)

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -1899,7 +1899,7 @@ module Analyser =
        in
        prepare_file complete_source_file input_file;
        (* We create the t_module for this file. *)
-       let mod_name = String.capitalize (Filename.basename (Filename.chop_extension source_file)) in
+       let mod_name = String.capitalize_ascii (Filename.basename (Filename.chop_extension source_file)) in
        let (len,info_opt) = My_ir.first_special !file_name !file in
 
        (* we must complete the included modules *)

--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -307,7 +307,7 @@ class virtual text =
     method html_of_custom_text b s t = ()
 
     method html_of_Target b ~target ~code =
-      if String.lowercase target = "html" then bs b code else ()
+      if String.lowercase_ascii target = "html" then bs b code else ()
 
     method html_of_Raw b s = bs b (self#escape s)
 
@@ -2312,7 +2312,7 @@ class html =
             [] -> ()
           | e :: _ ->
               let s =
-                match (Char.uppercase (Name.simple (name e)).[0]) with
+                match (Char.uppercase_ascii (Name.simple (name e)).[0]) with
                   'A'..'Z' as c -> String.make 1 c
                 | _ -> ""
               in

--- a/ocamldoc/odoc_latex.ml
+++ b/ocamldoc/odoc_latex.ml
@@ -293,7 +293,7 @@ class text =
     method latex_of_custom_text fmt s t = ()
 
     method latex_of_Target fmt ~target ~code =
-      if String.lowercase target = "latex" then
+      if String.lowercase_ascii target = "latex" then
         self#latex_of_Latex fmt code
       else
         ()

--- a/ocamldoc/odoc_man.ml
+++ b/ocamldoc/odoc_man.ml
@@ -340,7 +340,7 @@ class man =
     method man_of_custom_text b s t = ()
 
     method man_of_Target b ~target ~code =
-      if String.lowercase target = "man" then bs b code else ()
+      if String.lowercase_ascii target = "man" then bs b code else ()
 
     (** Print groff string to display code. *)
     method man_of_code b s = self#man_of_text b [ Code s ]

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -454,7 +454,7 @@ let create_index_lists elements string_of_ele =
         match s with
           "" -> f current acc0 acc1 (acc2 @ [ele]) q
         | _ ->
-            let first = Char.uppercase s.[0] in
+            let first = Char.uppercase_ascii s.[0] in
             match first with
               'A' .. 'Z' ->
                 if current = first then

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -1520,7 +1520,7 @@ module Analyser =
       in
       prepare_file complete_source_file input_file;
       (* We create the t_module for this file. *)
-      let mod_name = String.capitalize
+      let mod_name = String.capitalize_ascii
           (Filename.basename (try Filename.chop_extension source_file with _ -> source_file))
       in
       let (len,info_opt) = My_ir.first_special !file_name !file in

--- a/ocamldoc/odoc_texi.ml
+++ b/ocamldoc/odoc_texi.ml
@@ -311,7 +311,7 @@ class text =
     method texi_of_custom_text s t = ""
 
     method texi_of_Target ~target ~code =
-      if String.lowercase target = "texi" then code else ""
+      if String.lowercase_ascii target = "texi" then code else ""
 
     method texi_of_Verbatim s = s
     method texi_of_Raw s = self#escape s

--- a/otherlibs/dynlink/extract_crc.ml
+++ b/otherlibs/dynlink/extract_crc.ml
@@ -20,7 +20,7 @@ let print_crc unit =
   try
     let crc = Dynlink.digest_interface unit (!load_path @ ["."]) in
     if !first then first := false else print_string ";\n";
-    print_string "  \""; print_string (String.capitalize unit);
+    print_string "  \""; print_string (String.capitalize_ascii unit);
     print_string "\",\n    \"";
     for i = 0 to String.length crc - 1 do
       Printf.printf "\\%03d" (Char.code crc.[i])

--- a/otherlibs/str/str.ml
+++ b/otherlibs/str/str.ml
@@ -11,6 +11,10 @@
 (*                                                                     *)
 (***********************************************************************)
 
+(* In this module, [@ocaml.warnerror "-3"] is used in several places
+   that use deprecated functions to preserve legacy behavior.
+   It overrides -w @3 given on the command line. *)
+
 (** String utilities *)
 
 let string_before s n = String.sub s 0 n
@@ -88,9 +92,9 @@ module Charset =
       r
 
     let fold_case s =
-      let r = make_empty() in
-      iter (fun c -> add r (Char.lowercase c); add r (Char.uppercase c)) s;
-      r
+      (let r = make_empty() in
+       iter (fun c -> add r (Char.lowercase c); add r (Char.uppercase c)) s;
+       r)[@ocaml.warnerror "-3"]
 
   end
 
@@ -211,9 +215,9 @@ let charclass_of_regexp fold_case re =
 (* The case fold table: maps characters to their lowercase equivalent *)
 
 let fold_case_table =
-  let t = Bytes.create 256 in
-  for i = 0 to 255 do Bytes.set t i (Char.lowercase(Char.chr i)) done;
-  Bytes.to_string t
+  (let t = Bytes.create 256 in
+   for i = 0 to 255 do Bytes.set t i (Char.lowercase(Char.chr i)) done;
+   Bytes.to_string t)[@ocaml.warnerror "-3"]
 
 module StringMap =
   Map.Make(struct type t = string let compare (x:t) y = compare x y end)
@@ -269,7 +273,7 @@ let compile fold_case re =
   let rec emit_code = function
     Char c ->
       if fold_case then
-        emit_instr op_CHARNORM (Char.code (Char.lowercase c))
+        emit_instr op_CHARNORM (Char.code (Char.lowercase c))[@ocaml.warnerror "-3"]
       else
         emit_instr op_CHAR (Char.code c)
   | String s ->
@@ -277,7 +281,7 @@ let compile fold_case re =
         0 -> ()
       | 1 ->
         if fold_case then
-          emit_instr op_CHARNORM (Char.code (Char.lowercase s.[0]))
+          emit_instr op_CHARNORM (Char.code (Char.lowercase s.[0]))[@ocaml.warnerror "-3"]
         else
           emit_instr op_CHAR (Char.code s.[0])
       | _ ->
@@ -290,7 +294,7 @@ let compile fold_case re =
           emit_code (String (string_after s (i+1)))
         with Not_found ->
           if fold_case then
-            emit_instr op_STRINGNORM (cpool_index (String.lowercase s))
+            emit_instr op_STRINGNORM (cpool_index (String.lowercase s))[@ocaml.warnerror "-3"]
           else
             emit_instr op_STRING (cpool_index s)
       end

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -206,6 +206,9 @@ let mapi f s =
 let uppercase s = map Char.uppercase s
 let lowercase s = map Char.lowercase s
 
+let uppercase_ascii s = map Char.uppercase_ascii s
+let lowercase_ascii s = map Char.lowercase_ascii s
+
 let apply1 f s =
   if length s = 0 then s else begin
     let r = copy s in
@@ -215,6 +218,9 @@ let apply1 f s =
 
 let capitalize s = apply1 Char.uppercase s
 let uncapitalize s = apply1 Char.lowercase s
+
+let capitalize_ascii s = apply1 Char.uppercase_ascii s
+let uncapitalize_ascii s = apply1 Char.lowercase_ascii s
 
 let rec index_rec s lim i c =
   if i >= lim then raise Not_found else

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -203,9 +203,6 @@ let mapi f s =
     r
   end
 
-let uppercase s = map Char.uppercase s
-let lowercase s = map Char.lowercase s
-
 let uppercase_ascii s = map Char.uppercase_ascii s
 let lowercase_ascii s = map Char.lowercase_ascii s
 
@@ -215,9 +212,6 @@ let apply1 f s =
     unsafe_set r 0 (f(unsafe_get s 0));
     r
   end
-
-let capitalize s = apply1 Char.uppercase s
-let uncapitalize s = apply1 Char.lowercase s
 
 let capitalize_ascii s = apply1 Char.uppercase_ascii s
 let uncapitalize_ascii s = apply1 Char.lowercase_ascii s
@@ -266,3 +260,11 @@ let rcontains_from s i c =
 type t = bytes
 
 let compare (x: t) (y: t) = Pervasives.compare x y
+
+(* Deprecated functions implemented via other deprecated functions *)
+[@@@ocaml.warning "-3"]
+let uppercase s = map Char.uppercase s
+let lowercase s = map Char.lowercase s
+
+let capitalize s = apply1 Char.uppercase s
+let uncapitalize s = apply1 Char.lowercase s

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -229,22 +229,46 @@ val rcontains_from : bytes -> int -> char -> bool
     position in [s]. *)
 
 val uppercase : bytes -> bytes
+  [@@ocaml.deprecated "Use Bytes.uppercase_ascii instead."]
 (** Return a copy of the argument, with all lowercase letters
-    translated to uppercase, including accented letters of the ISO
-    Latin-1 (8859-1) character set. *)
+   translated to uppercase, including accented letters of the ISO
+   Latin-1 (8859-1) character set.
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val lowercase : bytes -> bytes
+  [@@ocaml.deprecated "Use Bytes.lowercase_ascii instead."]
 (** Return a copy of the argument, with all uppercase letters
-    translated to lowercase, including accented letters of the ISO
-    Latin-1 (8859-1) character set. *)
+   translated to lowercase, including accented letters of the ISO
+   Latin-1 (8859-1) character set.
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val capitalize : bytes -> bytes
-(** Return a copy of the argument, with the first byte set to
-    uppercase. *)
+  [@@ocaml.deprecated "Use Bytes.capitalize_ascii instead."]
+(** Return a copy of the argument, with the first character set to uppercase,
+   using the ISO Latin-1 (8859-1) character set..
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val uncapitalize : bytes -> bytes
-(** Return a copy of the argument, with the first byte set to
-    lowercase. *)
+  [@@ocaml.deprecated "Use Bytes.uncapitalize_ascii instead."]
+(** Return a copy of the argument, with the first character set to lowercase,
+   using the ISO Latin-1 (8859-1) character set..
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
+
+val uppercase_ascii : bytes -> bytes
+(** Return a copy of the argument, with all lowercase letters
+   translated to uppercase, using the US-ASCII character set. *)
+
+val lowercase_ascii : bytes -> bytes
+(** Return a copy of the argument, with all uppercase letters
+   translated to lowercase, using the US-ASCII character set. *)
+
+val capitalize_ascii : bytes -> bytes
+(** Return a copy of the argument, with the first character set to uppercase,
+   using the US-ASCII character set. *)
+
+val uncapitalize_ascii : bytes -> bytes
+(** Return a copy of the argument, with the first character set to lowercase,
+   using the US-ASCII character set. *)
 
 type t = bytes
 (** An alias for the type of byte sequences. *)
@@ -386,11 +410,6 @@ let s = Bytes.of_string "hello"
 *)
 
 (**/**)
-
-val lowercase_ascii : bytes -> bytes
-val uppercase_ascii : bytes -> bytes
-val capitalize_ascii : bytes -> bytes
-val uncapitalize_ascii : bytes -> bytes
 
 (* The following is for system use only. Do not call directly. *)
 

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -387,6 +387,11 @@ let s = Bytes.of_string "hello"
 
 (**/**)
 
+val lowercase_ascii : bytes -> bytes
+val uppercase_ascii : bytes -> bytes
+val capitalize_ascii : bytes -> bytes
+val uncapitalize_ascii : bytes -> bytes
+
 (* The following is for system use only. Do not call directly. *)
 
 external unsafe_get : bytes -> int -> char = "%string_unsafe_get"

--- a/stdlib/char.ml
+++ b/stdlib/char.ml
@@ -62,6 +62,16 @@ let uppercase c =
   then unsafe_chr(code c - 32)
   else c
 
+let lowercase_ascii c =
+  if (c >= 'A' && c <= 'Z')
+  then unsafe_chr(code c + 32)
+  else c
+
+let uppercase_ascii c =
+  if (c >= 'a' && c <= 'z')
+  then unsafe_chr(code c - 32)
+  else c
+
 type t = char
 
 let compare c1 c2 = code c1 - code c2

--- a/stdlib/char.mli
+++ b/stdlib/char.mli
@@ -27,10 +27,24 @@ val escaped : char -> string
    of OCaml. *)
 
 val lowercase : char -> char
-(** Convert the given character to its equivalent lowercase character. *)
+  [@@ocaml.deprecated "Use Char.lowercase_ascii instead."]
+(** Convert the given character to its equivalent lowercase character,
+   using the ISO Latin-1 (8859-1) character set.
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val uppercase : char -> char
-(** Convert the given character to its equivalent uppercase character. *)
+  [@@ocaml.deprecated "Use Char.uppercase_ascii instead."]
+(** Convert the given character to its equivalent uppercase character,
+   using the ISO Latin-1 (8859-1) character set.
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
+
+val lowercase_ascii : char -> char
+(** Convert the given character to its equivalent lowercase character,
+   using the US-ASCII character set. *)
+
+val uppercase_ascii : char -> char
+(** Convert the given character to its equivalent uppercase character,
+   using the US-ASCII character set. *)
 
 type t = char
 (** An alias for the type of characters. *)
@@ -42,9 +56,6 @@ val compare: t -> t -> int
     {!Set.Make} and {!Map.Make}. *)
 
 (**/**)
-
-val lowercase_ascii : char -> char
-val uppercase_ascii : char -> char
 
 (* The following is for system use only. Do not call directly. *)
 

--- a/stdlib/char.mli
+++ b/stdlib/char.mli
@@ -43,6 +43,9 @@ val compare: t -> t -> int
 
 (**/**)
 
+val lowercase_ascii : char -> char
+val uppercase_ascii : char -> char
+
 (* The following is for system use only. Do not call directly. *)
 
 external unsafe_chr : int -> char = "%identity"

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -107,7 +107,7 @@ module Win32 = struct
    String.length name >= String.length suff &&
    (let s = String.sub name (String.length name - String.length suff)
                             (String.length suff) in
-    String.lowercase s = String.lowercase suff)
+    String.lowercase_ascii s = String.lowercase_ascii suff)
   let temp_dir_name =
     try Sys.getenv "TEMP" with Not_found -> "."
   let quote s =

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -121,6 +121,15 @@ let capitalize s =
 let uncapitalize s =
   B.uncapitalize (bos s) |> bts
 
+let uppercase_ascii s =
+  B.uppercase_ascii (bos s) |> bts
+let lowercase_ascii s =
+  B.lowercase_ascii (bos s) |> bts
+let capitalize_ascii s =
+  B.capitalize_ascii (bos s) |> bts
+let uncapitalize_ascii s =
+  B.uncapitalize_ascii (bos s) |> bts
+
 type t = string
 
 let compare (x: t) (y: t) = Pervasives.compare x y

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -112,14 +112,6 @@ let contains_from s i c =
   B.contains_from (bos s) i c
 let rcontains_from s i c =
   B.rcontains_from (bos s) i c
-let uppercase s =
-  B.uppercase (bos s) |> bts
-let lowercase s =
-  B.lowercase (bos s) |> bts
-let capitalize s =
-  B.capitalize (bos s) |> bts
-let uncapitalize s =
-  B.uncapitalize (bos s) |> bts
 
 let uppercase_ascii s =
   B.uppercase_ascii (bos s) |> bts
@@ -133,3 +125,14 @@ let uncapitalize_ascii s =
 type t = string
 
 let compare (x: t) (y: t) = Pervasives.compare x y
+
+(* Deprecated functions implemented via other deprecated functions *)
+[@@@ocaml.warning "-3"]
+let uppercase s =
+  B.uppercase (bos s) |> bts
+let lowercase s =
+  B.lowercase (bos s) |> bts
+let capitalize s =
+  B.capitalize (bos s) |> bts
+let uncapitalize s =
+  B.uncapitalize (bos s) |> bts

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -215,20 +215,46 @@ val rcontains_from : string -> int -> char -> bool
    position in [s]. *)
 
 val uppercase : string -> string
+  [@@ocaml.deprecated "Use String.uppercase_ascii instead."]
 (** Return a copy of the argument, with all lowercase letters
    translated to uppercase, including accented letters of the ISO
-   Latin-1 (8859-1) character set. *)
+   Latin-1 (8859-1) character set.
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val lowercase : string -> string
+  [@@ocaml.deprecated "Use String.lowercase_ascii instead."]
 (** Return a copy of the argument, with all uppercase letters
    translated to lowercase, including accented letters of the ISO
-   Latin-1 (8859-1) character set. *)
+   Latin-1 (8859-1) character set.
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val capitalize : string -> string
-(** Return a copy of the argument, with the first character set to uppercase. *)
+  [@@ocaml.deprecated "Use String.capitalize_ascii instead."]
+(** Return a copy of the argument, with the first character set to uppercase,
+   using the ISO Latin-1 (8859-1) character set..
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val uncapitalize : string -> string
-(** Return a copy of the argument, with the first character set to lowercase. *)
+  [@@ocaml.deprecated "Use String.uncapitalize_ascii instead."]
+(** Return a copy of the argument, with the first character set to lowercase,
+   using the ISO Latin-1 (8859-1) character set..
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
+
+val uppercase_ascii : string -> string
+(** Return a copy of the argument, with all lowercase letters
+   translated to uppercase, using the US-ASCII character set. *)
+
+val lowercase_ascii : string -> string
+(** Return a copy of the argument, with all uppercase letters
+   translated to lowercase, using the US-ASCII character set. *)
+
+val capitalize_ascii : string -> string
+(** Return a copy of the argument, with the first character set to uppercase,
+   using the US-ASCII character set. *)
+
+val uncapitalize_ascii : string -> string
+(** Return a copy of the argument, with the first character set to lowercase,
+   using the US-ASCII character set. *)
 
 type t = string
 (** An alias for the type of strings. *)
@@ -240,11 +266,6 @@ val compare: t -> t -> int
     {!Set.Make} and {!Map.Make}. *)
 
 (**/**)
-
-val lowercase_ascii : string -> string
-val uppercase_ascii : string -> string
-val capitalize_ascii : string -> string
-val uncapitalize_ascii : string -> string
 
 (* The following is for system use only. Do not call directly. *)
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -241,6 +241,11 @@ val compare: t -> t -> int
 
 (**/**)
 
+val lowercase_ascii : string -> string
+val uppercase_ascii : string -> string
+val capitalize_ascii : string -> string
+val uncapitalize_ascii : string -> string
+
 (* The following is for system use only. Do not call directly. *)
 
 external unsafe_get : string -> int -> char = "%string_unsafe_get"

--- a/tools/ocamldep.ml
+++ b/tools/ocamldep.ml
@@ -78,7 +78,7 @@ let add_to_synonym_list synonyms suffix =
 
 (* Find file 'name' (capitalized) in search path *)
 let find_file name =
-  let uname = String.uncapitalize name in
+  let uname = String.uncapitalize_ascii name in
   let rec find_in_array a pos =
     if pos >= Array.length a then None else begin
       let s = a.(pos) in
@@ -331,7 +331,7 @@ let sort_files_by_dependencies files =
 (* Init Hashtbl with all defined modules *)
   let files = List.map (fun (file, file_kind, deps) ->
     let modname =
-      String.capitalize (Filename.chop_extension (Filename.basename file))
+      String.capitalize_ascii (Filename.chop_extension (Filename.basename file))
     in
     let key = (modname, file_kind) in
     let new_deps = ref [] in

--- a/toplevel/expunge.ml
+++ b/toplevel/expunge.ml
@@ -44,7 +44,7 @@ let main () =
   let input_name = Sys.argv.(1) in
   let output_name = Sys.argv.(2) in
   for i = (if negate then 4 else 3) to Array.length Sys.argv - 1 do
-    to_keep := StringSet.add (String.capitalize Sys.argv.(i)) !to_keep
+    to_keep := StringSet.add (String.capitalize_ascii Sys.argv.(i)) !to_keep
   done;
   let ic = open_in_bin input_name in
   Bytesections.read_toc ic;

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -116,7 +116,7 @@ let input_name = Location.input_name
 
 let parse_mod_use_file name lb =
   let modname =
-    String.capitalize (Filename.chop_extension (Filename.basename name))
+    String.capitalize_ascii (Filename.chop_extension (Filename.basename name))
   in
   let items =
     List.concat

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1623,7 +1623,7 @@ let package_units initial_env objfiles cmifile modulename =
     List.map
       (fun f ->
          let pref = chop_extensions f in
-         let modname = String.capitalize(Filename.basename pref) in
+         let modname = String.capitalize_ascii(Filename.basename pref) in
          let sg = Env.read_signature modname (pref ^ ".cmi") in
          if Filename.check_suffix f ".cmi" &&
             not(Mtype.no_code_needed_sig Env.initial_safe_string sg)

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -104,7 +104,7 @@ let find_in_path_rel path name =
   in try_dir path
 
 let find_in_path_uncap path name =
-  let uname = String.uncapitalize name in
+  let uname = String.uncapitalize_ascii name in
   let rec try_dir = function
     [] -> raise Not_found
   | dir::rem ->

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -206,7 +206,7 @@ let parse_opt error active flags s =
     if i >= String.length s then () else
     match s.[i] with
     | 'A' .. 'Z' ->
-       List.iter set (letter (Char.lowercase s.[i]));
+       List.iter set (letter (Char.lowercase_ascii s.[i]));
        loop (i+1)
     | 'a' .. 'z' ->
        List.iter clear (letter s.[i]);
@@ -223,7 +223,7 @@ let parse_opt error active flags s =
         for n = n1 to min n2 last_warning_number do myset n done;
         loop i
     | 'A' .. 'Z' ->
-       List.iter myset (letter (Char.lowercase s.[i]));
+       List.iter myset (letter (Char.lowercase_ascii s.[i]));
        loop (i+1)
     | 'a' .. 'z' ->
        List.iter myset (letter s.[i]);
@@ -489,10 +489,10 @@ let help_warnings () =
     match letter c with
     | [] -> ()
     | [n] ->
-        Printf.printf "  %c Synonym for warning %i.\n" (Char.uppercase c) n
+        Printf.printf "  %c Synonym for warning %i.\n" (Char.uppercase_ascii c) n
     | l ->
         Printf.printf "  %c Set of warnings %s.\n"
-          (Char.uppercase c)
+          (Char.uppercase_ascii c)
           (String.concat ", " (List.map string_of_int l))
   done;
   exit 0


### PR DESCRIPTION
See http://caml.inria.fr/mantis/view.php?id=6695.
