### PR TITLE
PR6692: Support for UTF-8 identifiers

### DIFF
--- a/tools/ocamldep.ml
+++ b/tools/ocamldep.ml
@@ -193,7 +193,7 @@ let print_raw_dependencies source_file deps =
   Depend.StringSet.iter
     (fun dep ->
       if (String.length dep > 0)
-          && (match dep.[0] with 'A'..'Z' -> true | _ -> false) then begin
+          && (match dep.[0] with 'A'..'Z' | '\128'..'\255' -> true | _ -> false) then begin
             print_char ' ';
             print_string dep
           end)


### PR DESCRIPTION
This depends on https://github.com/ocaml/ocaml/pull/124 and includes it here as a way to offer a test environment via OPAM.

See http://caml.inria.fr/mantis/view.php?id=6692. I will shortly explain the specifics of this PR.
