### PR TITLE
PR6712: Ignore (-traverse) common VCS directories in ocamlbuild

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,6 +36,10 @@ Toplevel and debugger:
 - PR#5958: generalized polymorphic #install_printer
   (Pierre Chambart and Grégoire Henry)
 
+OCamlbuild:
+- PR#6712: Ignore common VCS directories
+  (Peter Zotov)
+
 Bug fixes:
 - PR#6648: show_module should indicate its elision
 - PR#6650: Cty_constr not handled correctly by Subst

--- a/ocamlbuild/main.ml
+++ b/ocamlbuild/main.ml
@@ -92,6 +92,7 @@ let proceed () =
      <**/*.cmi>: ocaml, byte, native\n\
      <**/*.cmx>: ocaml, native\n\
      <**/*.mly>: infer\n\
+     <**/.svn>|\".bzr\"|\".hg\"|\".git\"|\"_darcs\": -traverse\n\
     ";
 
   List.iter


### PR DESCRIPTION
See http://caml.inria.fr/mantis/view.php?id=6712
