### PR TITLE
Fix constructor names in Typedast printing.

### DIFF
--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -150,25 +150,25 @@ let rec core_type i ppf x =
   attributes i ppf x.ctyp_attributes;
   let i = i+1 in
   match x.ctyp_desc with
-  | Ttyp_any -> line i ppf "Ptyp_any\n";
-  | Ttyp_var (s) -> line i ppf "Ptyp_var %s\n" s;
+  | Ttyp_any -> line i ppf "Ttyp_any\n";
+  | Ttyp_var (s) -> line i ppf "Ttyp_var %s\n" s;
   | Ttyp_arrow (l, ct1, ct2) ->
-      line i ppf "Ptyp_arrow\n";
+      line i ppf "Ttyp_arrow\n";
       string i ppf l;
       core_type i ppf ct1;
       core_type i ppf ct2;
   | Ttyp_tuple l ->
-      line i ppf "Ptyp_tuple\n";
+      line i ppf "Ttyp_tuple\n";
       list i core_type ppf l;
   | Ttyp_constr (li, _, l) ->
-      line i ppf "Ptyp_constr %a\n" fmt_path li;
+      line i ppf "Ttyp_constr %a\n" fmt_path li;
       list i core_type ppf l;
   | Ttyp_variant (l, closed, low) ->
-      line i ppf "Ptyp_variant closed=%a\n" fmt_closed_flag closed;
+      line i ppf "Ttyp_variant closed=%a\n" fmt_closed_flag closed;
       list i label_x_bool_x_core_type_list ppf l;
       option i (fun i -> list i string) ppf low
   | Ttyp_object (l, c) ->
-      line i ppf "Ptyp_object %a\n" fmt_closed_flag c;
+      line i ppf "Ttyp_object %a\n" fmt_closed_flag c;
       let i = i + 1 in
       List.iter
         (fun (s, attrs, t) ->
@@ -178,17 +178,17 @@ let rec core_type i ppf x =
         )
         l
   | Ttyp_class (li, _, l) ->
-      line i ppf "Ptyp_class %a\n" fmt_path li;
+      line i ppf "Ttyp_class %a\n" fmt_path li;
       list i core_type ppf l;
   | Ttyp_alias (ct, s) ->
-      line i ppf "Ptyp_alias \"%s\"\n" s;
+      line i ppf "Ttyp_alias \"%s\"\n" s;
       core_type i ppf ct;
   | Ttyp_poly (sl, ct) ->
-      line i ppf "Ptyp_poly%a\n"
+      line i ppf "Ttyp_poly%a\n"
         (fun ppf -> List.iter (fun x -> fprintf ppf " '%s" x)) sl;
       core_type i ppf ct;
   | Ttyp_package { pack_path = s; pack_fields = l } ->
-      line i ppf "Ptyp_package %a\n" fmt_path s;
+      line i ppf "Ttyp_package %a\n" fmt_path s;
       list i package_with ppf l;
 
 and package_with i ppf (s, t) =
@@ -215,55 +215,55 @@ and pattern i ppf x =
         pattern i ppf { x with pat_extra = rem }
     | [] ->
   match x.pat_desc with
-  | Tpat_any -> line i ppf "Ppat_any\n";
-  | Tpat_var (s,_) -> line i ppf "Ppat_var \"%a\"\n" fmt_ident s;
+  | Tpat_any -> line i ppf "Tpat_any\n";
+  | Tpat_var (s,_) -> line i ppf "Tpat_var \"%a\"\n" fmt_ident s;
   | Tpat_alias (p, s,_) ->
-      line i ppf "Ppat_alias \"%a\"\n" fmt_ident s;
+      line i ppf "Tpat_alias \"%a\"\n" fmt_ident s;
       pattern i ppf p;
-  | Tpat_constant (c) -> line i ppf "Ppat_constant %a\n" fmt_constant c;
+  | Tpat_constant (c) -> line i ppf "Tpat_constant %a\n" fmt_constant c;
   | Tpat_tuple (l) ->
-      line i ppf "Ppat_tuple\n";
+      line i ppf "Tpat_tuple\n";
       list i pattern ppf l;
   | Tpat_construct (li, _, po) ->
-      line i ppf "Ppat_construct %a\n" fmt_longident li;
+      line i ppf "Tpat_construct %a\n" fmt_longident li;
       list i pattern ppf po;
   | Tpat_variant (l, po, _) ->
-      line i ppf "Ppat_variant \"%s\"\n" l;
+      line i ppf "Tpat_variant \"%s\"\n" l;
       option i pattern ppf po;
   | Tpat_record (l, c) ->
-      line i ppf "Ppat_record\n";
+      line i ppf "Tpat_record\n";
       list i longident_x_pattern ppf l;
   | Tpat_array (l) ->
-      line i ppf "Ppat_array\n";
+      line i ppf "Tpat_array\n";
       list i pattern ppf l;
   | Tpat_or (p1, p2, _) ->
-      line i ppf "Ppat_or\n";
+      line i ppf "Tpat_or\n";
       pattern i ppf p1;
       pattern i ppf p2;
   | Tpat_lazy p ->
-      line i ppf "Ppat_lazy\n";
+      line i ppf "Tpat_lazy\n";
       pattern i ppf p;
 
 and expression_extra i ppf x attrs =
   match x with
   | Texp_constraint ct ->
-      line i ppf "Pexp_constraint\n";
+      line i ppf "Texp_constraint\n";
       attributes i ppf attrs;
       core_type i ppf ct;
   | Texp_coerce (cto1, cto2) ->
-      line i ppf "Pexp_constraint\n";
+      line i ppf "Texp_coerce\n";
       attributes i ppf attrs;
       option i core_type ppf cto1;
       core_type i ppf cto2;
   | Texp_open (ovf, m, _, _) ->
-      line i ppf "Pexp_open %a \"%a\"\n" fmt_override_flag ovf fmt_path m;
+      line i ppf "Texp_open %a \"%a\"\n" fmt_override_flag ovf fmt_path m;
       attributes i ppf attrs;
   | Texp_poly cto ->
-      line i ppf "Pexp_poly\n";
+      line i ppf "Texp_poly\n";
       attributes i ppf attrs;
       option i core_type ppf cto;
   | Texp_newtype s ->
-      line i ppf "Pexp_newtype \"%s\"\n" s;
+      line i ppf "Texp_newtype \"%s\"\n" s;
       attributes i ppf attrs;
 
 and expression i ppf x =
@@ -274,103 +274,103 @@ and expression i ppf x =
       (i+1) x.exp_extra
   in
   match x.exp_desc with
-  | Texp_ident (li,_,_) -> line i ppf "Pexp_ident %a\n" fmt_path li;
-  | Texp_instvar (_, li,_) -> line i ppf "Pexp_instvar %a\n" fmt_path li;
-  | Texp_constant (c) -> line i ppf "Pexp_constant %a\n" fmt_constant c;
+  | Texp_ident (li,_,_) -> line i ppf "Texp_ident %a\n" fmt_path li;
+  | Texp_instvar (_, li,_) -> line i ppf "Texp_instvar %a\n" fmt_path li;
+  | Texp_constant (c) -> line i ppf "Texp_constant %a\n" fmt_constant c;
   | Texp_let (rf, l, e) ->
-      line i ppf "Pexp_let %a\n" fmt_rec_flag rf;
+      line i ppf "Texp_let %a\n" fmt_rec_flag rf;
       list i value_binding ppf l;
       expression i ppf e;
   | Texp_function (p, l, _partial) ->
-      line i ppf "Pexp_function \"%s\"\n" p;
+      line i ppf "Texp_function \"%s\"\n" p;
 (*      option i expression ppf eo; *)
       list i case ppf l;
   | Texp_apply (e, l) ->
-      line i ppf "Pexp_apply\n";
+      line i ppf "Texp_apply\n";
       expression i ppf e;
       list i label_x_expression ppf l;
   | Texp_match (e, l1, l2, partial) ->
-      line i ppf "Pexp_match\n";
+      line i ppf "Texp_match\n";
       expression i ppf e;
       list i case ppf l1;
       list i case ppf l2;
   | Texp_try (e, l) ->
-      line i ppf "Pexp_try\n";
+      line i ppf "Texp_try\n";
       expression i ppf e;
       list i case ppf l;
   | Texp_tuple (l) ->
-      line i ppf "Pexp_tuple\n";
+      line i ppf "Texp_tuple\n";
       list i expression ppf l;
   | Texp_construct (li, _, eo) ->
-      line i ppf "Pexp_construct %a\n" fmt_longident li;
+      line i ppf "Texp_construct %a\n" fmt_longident li;
       list i expression ppf eo;
   | Texp_variant (l, eo) ->
-      line i ppf "Pexp_variant \"%s\"\n" l;
+      line i ppf "Texp_variant \"%s\"\n" l;
       option i expression ppf eo;
   | Texp_record (l, eo) ->
-      line i ppf "Pexp_record\n";
+      line i ppf "Texp_record\n";
       list i longident_x_expression ppf l;
       option i expression ppf eo;
   | Texp_field (e, li, _) ->
-      line i ppf "Pexp_field\n";
+      line i ppf "Texp_field\n";
       expression i ppf e;
       longident i ppf li;
   | Texp_setfield (e1, li, _, e2) ->
-      line i ppf "Pexp_setfield\n";
+      line i ppf "Texp_setfield\n";
       expression i ppf e1;
       longident i ppf li;
       expression i ppf e2;
   | Texp_array (l) ->
-      line i ppf "Pexp_array\n";
+      line i ppf "Texp_array\n";
       list i expression ppf l;
   | Texp_ifthenelse (e1, e2, eo) ->
-      line i ppf "Pexp_ifthenelse\n";
+      line i ppf "Texp_ifthenelse\n";
       expression i ppf e1;
       expression i ppf e2;
       option i expression ppf eo;
   | Texp_sequence (e1, e2) ->
-      line i ppf "Pexp_sequence\n";
+      line i ppf "Texp_sequence\n";
       expression i ppf e1;
       expression i ppf e2;
   | Texp_while (e1, e2) ->
-      line i ppf "Pexp_while\n";
+      line i ppf "Texp_while\n";
       expression i ppf e1;
       expression i ppf e2;
   | Texp_for (s, _, e1, e2, df, e3) ->
-      line i ppf "Pexp_for \"%a\" %a\n" fmt_ident s fmt_direction_flag df;
+      line i ppf "Texp_for \"%a\" %a\n" fmt_ident s fmt_direction_flag df;
       expression i ppf e1;
       expression i ppf e2;
       expression i ppf e3;
   | Texp_send (e, Tmeth_name s, eo) ->
-      line i ppf "Pexp_send \"%s\"\n" s;
+      line i ppf "Texp_send \"%s\"\n" s;
       expression i ppf e;
       option i expression ppf eo
   | Texp_send (e, Tmeth_val s, eo) ->
-      line i ppf "Pexp_send \"%a\"\n" fmt_ident s;
+      line i ppf "Texp_send \"%a\"\n" fmt_ident s;
       expression i ppf e;
       option i expression ppf eo
-  | Texp_new (li, _, _) -> line i ppf "Pexp_new %a\n" fmt_path li;
+  | Texp_new (li, _, _) -> line i ppf "Texp_new %a\n" fmt_path li;
   | Texp_setinstvar (_, s, _, e) ->
-      line i ppf "Pexp_setinstvar \"%a\"\n" fmt_path s;
+      line i ppf "Texp_setinstvar \"%a\"\n" fmt_path s;
       expression i ppf e;
   | Texp_override (_, l) ->
-      line i ppf "Pexp_override\n";
+      line i ppf "Texp_override\n";
       list i string_x_expression ppf l;
   | Texp_letmodule (s, _, me, e) ->
-      line i ppf "Pexp_letmodule \"%a\"\n" fmt_ident s;
+      line i ppf "Texp_letmodule \"%a\"\n" fmt_ident s;
       module_expr i ppf me;
       expression i ppf e;
   | Texp_assert (e) ->
-      line i ppf "Pexp_assert";
+      line i ppf "Texp_assert";
       expression i ppf e;
   | Texp_lazy (e) ->
-      line i ppf "Pexp_lazy";
+      line i ppf "Texp_lazy";
       expression i ppf e;
   | Texp_object (s, _) ->
-      line i ppf "Pexp_object";
+      line i ppf "Texp_object";
       class_structure i ppf s
   | Texp_pack me ->
-      line i ppf "Pexp_pack";
+      line i ppf "Texp_pack";
       module_expr i ppf me
 
 and value_description i ppf x =
@@ -398,15 +398,15 @@ and type_declaration i ppf x =
 and type_kind i ppf x =
   match x with
   | Ttype_abstract ->
-      line i ppf "Ptype_abstract\n"
+      line i ppf "Ttype_abstract\n"
   | Ttype_variant l ->
-      line i ppf "Ptype_variant\n";
+      line i ppf "Ttype_variant\n";
       list (i+1) constructor_decl ppf l;
   | Ttype_record l ->
-      line i ppf "Ptype_record\n";
+      line i ppf "Ttype_record\n";
       list (i+1) label_decl ppf l;
   | Ttype_open ->
-      line i ppf "Ptype_open\n"
+      line i ppf "Ttype_open\n"
 
 and type_extension i ppf x =
   line i ppf "type_extension\n";
@@ -430,11 +430,11 @@ and extension_constructor i ppf x =
 and extension_constructor_kind i ppf x =
   match x with
       Text_decl(a, r) ->
-        line i ppf "Pext_decl\n";
+        line i ppf "Text_decl\n";
         constructor_arguments (i+1) ppf a;
         option (i+1) core_type ppf r;
     | Text_rebind(p, _) ->
-        line i ppf "Pext_rebind\n";
+        line i ppf "Text_rebind\n";
         line (i+1) ppf "%a\n" fmt_path p;
 
 and class_type i ppf x =
@@ -443,13 +443,13 @@ and class_type i ppf x =
   let i = i+1 in
   match x.cltyp_desc with
   | Tcty_constr (li, _, l) ->
-      line i ppf "Pcty_constr %a\n" fmt_path li;
+      line i ppf "Tcty_constr %a\n" fmt_path li;
       list i core_type ppf l;
   | Tcty_signature (cs) ->
-      line i ppf "Pcty_signature\n";
+      line i ppf "Tcty_signature\n";
       class_signature i ppf cs;
   | Tcty_arrow (l, co, cl) ->
-      line i ppf "Pcty_arrow \"%s\"\n" l;
+      line i ppf "Tcty_arrow \"%s\"\n" l;
       core_type i ppf co;
       class_type i ppf cl;
 
@@ -464,21 +464,21 @@ and class_type_field i ppf x =
   attributes i ppf x.ctf_attributes;
   match x.ctf_desc with
   | Tctf_inherit (ct) ->
-      line i ppf "Pctf_inherit\n";
+      line i ppf "Tctf_inherit\n";
       class_type i ppf ct;
   | Tctf_val (s, mf, vf, ct) ->
-      line i ppf "Pctf_val \"%s\" %a %a\n" s fmt_mutable_flag mf
+      line i ppf "Tctf_val \"%s\" %a %a\n" s fmt_mutable_flag mf
            fmt_virtual_flag vf;
       core_type (i+1) ppf ct;
   | Tctf_method (s, pf, vf, ct) ->
-      line i ppf "Pctf_method \"%s\" %a %a\n" s fmt_private_flag pf fmt_virtual_flag vf;
+      line i ppf "Tctf_method \"%s\" %a %a\n" s fmt_private_flag pf fmt_virtual_flag vf;
       core_type (i+1) ppf ct;
   | Tctf_constraint (ct1, ct2) ->
-      line i ppf "Pctf_constraint\n";
+      line i ppf "Tctf_constraint\n";
       core_type (i+1) ppf ct1;
       core_type (i+1) ppf ct2;
   | Tctf_attribute (s, arg) ->
-      line i ppf "Pctf_attribute \"%s\"\n" s.txt;
+      line i ppf "Tctf_attribute \"%s\"\n" s.txt;
       Printast.payload i ppf arg
 
 and class_description i ppf x =
@@ -508,27 +508,27 @@ and class_expr i ppf x =
   let i = i+1 in
   match x.cl_desc with
   | Tcl_ident (li, _, l) ->
-      line i ppf "Pcl_constr %a\n" fmt_path li;
+      line i ppf "Tcl_ident %a\n" fmt_path li;
       list i core_type ppf l;
   | Tcl_structure (cs) ->
-      line i ppf "Pcl_structure\n";
+      line i ppf "Tcl_structure\n";
       class_structure i ppf cs;
   | Tcl_fun (l, p, _, ce, _) ->
-      line i ppf "Pcl_fun\n";
+      line i ppf "Tcl_fun\n";
       label i ppf l;
       pattern i ppf p;
       class_expr i ppf ce
   | Tcl_apply (ce, l) ->
-      line i ppf "Pcl_apply\n";
+      line i ppf "Tcl_apply\n";
       class_expr i ppf ce;
       list i label_x_expression ppf l;
   | Tcl_let (rf, l1, l2, ce) ->
-      line i ppf "Pcl_let %a\n" fmt_rec_flag rf;
+      line i ppf "Tcl_let %a\n" fmt_rec_flag rf;
       list i value_binding ppf l1;
       list i ident_x_loc_x_expression_def ppf l2;
       class_expr i ppf ce;
   | Tcl_constraint (ce, Some ct, _, _, _) ->
-      line i ppf "Pcl_constraint\n";
+      line i ppf "Tcl_constraint\n";
       class_expr i ppf ce;
       class_type i ppf ct
   | Tcl_constraint (ce, None, _, _, _) -> class_expr i ppf ce
@@ -544,24 +544,24 @@ and class_field i ppf x =
   attributes i ppf x.cf_attributes;
   match x.cf_desc with
   | Tcf_inherit (ovf, ce, so, _, _) ->
-      line i ppf "Pcf_inherit %a\n" fmt_override_flag ovf;
+      line i ppf "Tcf_inherit %a\n" fmt_override_flag ovf;
       class_expr (i+1) ppf ce;
       option (i+1) string ppf so;
   | Tcf_val (s, mf, _, k, _) ->
-      line i ppf "Pcf_val \"%s\" %a\n" s.txt fmt_mutable_flag mf;
+      line i ppf "Tcf_val \"%s\" %a\n" s.txt fmt_mutable_flag mf;
       class_field_kind (i+1) ppf k
   | Tcf_method (s, pf, k) ->
-      line i ppf "Pcf_method \"%s\" %a\n" s.txt fmt_private_flag pf;
+      line i ppf "Tcf_method \"%s\" %a\n" s.txt fmt_private_flag pf;
       class_field_kind (i+1) ppf k
   | Tcf_constraint (ct1, ct2) ->
-      line i ppf "Pcf_constraint\n";
+      line i ppf "Tcf_constraint\n";
       core_type (i+1) ppf ct1;
       core_type (i+1) ppf ct2;
   | Tcf_initializer (e) ->
-      line i ppf "Pcf_initializer\n";
+      line i ppf "Tcf_initializer\n";
       expression (i+1) ppf e;
   | Tcf_attribute (s, arg) ->
-      line i ppf "Pcf_attribute \"%s\"\n" s.txt;
+      line i ppf "Tcf_attribute \"%s\"\n" s.txt;
       Printast.payload i ppf arg
 
 and class_field_kind i ppf = function
@@ -587,21 +587,21 @@ and module_type i ppf x =
   attributes i ppf x.mty_attributes;
   let i = i+1 in
   match x.mty_desc with
-  | Tmty_ident (li,_) -> line i ppf "Pmty_ident %a\n" fmt_path li;
-  | Tmty_alias (li,_) -> line i ppf "Pmty_alias %a\n" fmt_path li;
+  | Tmty_ident (li,_) -> line i ppf "Tmty_ident %a\n" fmt_path li;
+  | Tmty_alias (li,_) -> line i ppf "Tmty_alias %a\n" fmt_path li;
   | Tmty_signature (s) ->
-      line i ppf "Pmty_signature\n";
+      line i ppf "Tmty_signature\n";
       signature i ppf s;
   | Tmty_functor (s, _, mt1, mt2) ->
-      line i ppf "Pmty_functor \"%a\"\n" fmt_ident s;
+      line i ppf "Tmty_functor \"%a\"\n" fmt_ident s;
       Misc.may (module_type i ppf) mt1;
       module_type i ppf mt2;
   | Tmty_with (mt, l) ->
-      line i ppf "Pmty_with\n";
+      line i ppf "Tmty_with\n";
       module_type i ppf mt;
       list i longident_x_with_constraint ppf l;
   | Tmty_typeof m ->
-      line i ppf "Pmty_typeof\n";
+      line i ppf "Tmty_typeof\n";
       module_expr i ppf m;
 
 and signature i ppf x = list i signature_item ppf x.sig_items
@@ -611,45 +611,45 @@ and signature_item i ppf x =
   let i = i+1 in
   match x.sig_desc with
   | Tsig_value vd ->
-      line i ppf "Psig_value\n";
+      line i ppf "Tsig_value\n";
       value_description i ppf vd;
   | Tsig_type l ->
-      line i ppf "Psig_type\n";
+      line i ppf "Tsig_type\n";
       list i type_declaration ppf l;
   | Tsig_typext e ->
-      line i ppf "Psig_typext\n";
+      line i ppf "Tsig_typext\n";
       type_extension i ppf e;
   | Tsig_exception ext ->
-      line i ppf "Psig_exception\n";
+      line i ppf "Tsig_exception\n";
       extension_constructor i ppf ext
   | Tsig_module md ->
-      line i ppf "Psig_module \"%a\"\n" fmt_ident md.md_id;
+      line i ppf "Tsig_module \"%a\"\n" fmt_ident md.md_id;
       attributes i ppf md.md_attributes;
       module_type i ppf md.md_type
   | Tsig_recmodule decls ->
-      line i ppf "Psig_recmodule\n";
+      line i ppf "Tsig_recmodule\n";
       list i module_declaration ppf decls;
   | Tsig_modtype x ->
-      line i ppf "Psig_modtype \"%a\"\n" fmt_ident x.mtd_id;
+      line i ppf "Tsig_modtype \"%a\"\n" fmt_ident x.mtd_id;
       attributes i ppf x.mtd_attributes;
       modtype_declaration i ppf x.mtd_type
   | Tsig_open od ->
-      line i ppf "Psig_open %a %a\n"
+      line i ppf "Tsig_open %a %a\n"
            fmt_override_flag od.open_override
            fmt_path od.open_path;
       attributes i ppf od.open_attributes
   | Tsig_include incl ->
-      line i ppf "Psig_include\n";
+      line i ppf "Tsig_include\n";
       attributes i ppf incl.incl_attributes;
       module_type i ppf incl.incl_mod
   | Tsig_class (l) ->
-      line i ppf "Psig_class\n";
+      line i ppf "Tsig_class\n";
       list i class_description ppf l;
   | Tsig_class_type (l) ->
-      line i ppf "Psig_class_type\n";
+      line i ppf "Tsig_class_type\n";
       list i class_type_declaration ppf l;
   | Tsig_attribute (s, arg) ->
-      line i ppf "Psig_attribute \"%s\"\n" s.txt;
+      line i ppf "Tsig_attribute \"%s\"\n" s.txt;
       Printast.payload i ppf arg
 
 and module_declaration i ppf md =
@@ -669,38 +669,38 @@ and modtype_declaration i ppf = function
 and with_constraint i ppf x =
   match x with
   | Twith_type (td) ->
-      line i ppf "Pwith_type\n";
+      line i ppf "Twith_type\n";
       type_declaration (i+1) ppf td;
   | Twith_typesubst (td) ->
-      line i ppf "Pwith_typesubst\n";
+      line i ppf "Twith_typesubst\n";
       type_declaration (i+1) ppf td;
-  | Twith_module (li,_) -> line i ppf "Pwith_module %a\n" fmt_path li;
-  | Twith_modsubst (li,_) -> line i ppf "Pwith_modsubst %a\n" fmt_path li;
+  | Twith_module (li,_) -> line i ppf "Twith_module %a\n" fmt_path li;
+  | Twith_modsubst (li,_) -> line i ppf "Twith_modsubst %a\n" fmt_path li;
 
 and module_expr i ppf x =
   line i ppf "module_expr %a\n" fmt_location x.mod_loc;
   attributes i ppf x.mod_attributes;
   let i = i+1 in
   match x.mod_desc with
-  | Tmod_ident (li,_) -> line i ppf "Pmod_ident %a\n" fmt_path li;
+  | Tmod_ident (li,_) -> line i ppf "Tmod_ident %a\n" fmt_path li;
   | Tmod_structure (s) ->
-      line i ppf "Pmod_structure\n";
+      line i ppf "Tmod_structure\n";
       structure i ppf s;
   | Tmod_functor (s, _, mt, me) ->
-      line i ppf "Pmod_functor \"%a\"\n" fmt_ident s;
+      line i ppf "Tmod_functor \"%a\"\n" fmt_ident s;
       Misc.may (module_type i ppf) mt;
       module_expr i ppf me;
   | Tmod_apply (me1, me2, _) ->
-      line i ppf "Pmod_apply\n";
+      line i ppf "Tmod_apply\n";
       module_expr i ppf me1;
       module_expr i ppf me2;
   | Tmod_constraint (me, _, Tmodtype_explicit mt, _) ->
-      line i ppf "Pmod_constraint\n";
+      line i ppf "Tmod_constraint\n";
       module_expr i ppf me;
       module_type i ppf mt;
   | Tmod_constraint (me, _, Tmodtype_implicit, _) -> module_expr i ppf me
   | Tmod_unpack (e, _) ->
-      line i ppf "Pmod_unpack\n";
+      line i ppf "Tmod_unpack\n";
       expression i ppf e;
 
 and structure i ppf x = list i structure_item ppf x.str_items
@@ -710,51 +710,51 @@ and structure_item i ppf x =
   let i = i+1 in
   match x.str_desc with
   | Tstr_eval (e, attrs) ->
-      line i ppf "Pstr_eval\n";
+      line i ppf "Tstr_eval\n";
       attributes i ppf attrs;
       expression i ppf e;
   | Tstr_value (rf, l) ->
-      line i ppf "Pstr_value %a\n" fmt_rec_flag rf;
+      line i ppf "Tstr_value %a\n" fmt_rec_flag rf;
       list i value_binding ppf l;
   | Tstr_primitive vd ->
-      line i ppf "Pstr_primitive\n";
+      line i ppf "Tstr_primitive\n";
       value_description i ppf vd;
   | Tstr_type l ->
-      line i ppf "Pstr_type\n";
+      line i ppf "Tstr_type\n";
       list i type_declaration ppf l;
   | Tstr_typext te ->
-      line i ppf "Pstr_typext\n";
+      line i ppf "Tstr_typext\n";
       type_extension i ppf te
   | Tstr_exception ext ->
-      line i ppf "Pstr_exception\n";
+      line i ppf "Tstr_exception\n";
       extension_constructor i ppf ext;
   | Tstr_module x ->
-      line i ppf "Pstr_module\n";
+      line i ppf "Tstr_module\n";
       module_binding i ppf x
   | Tstr_recmodule bindings ->
-      line i ppf "Pstr_recmodule\n";
+      line i ppf "Tstr_recmodule\n";
       list i module_binding ppf bindings
   | Tstr_modtype x ->
-      line i ppf "Pstr_modtype \"%a\"\n" fmt_ident x.mtd_id;
+      line i ppf "Tstr_modtype \"%a\"\n" fmt_ident x.mtd_id;
       attributes i ppf x.mtd_attributes;
       modtype_declaration i ppf x.mtd_type
   | Tstr_open od ->
-      line i ppf "Pstr_open %a %a\n"
+      line i ppf "Tstr_open %a %a\n"
            fmt_override_flag od.open_override
            fmt_path od.open_path;
       attributes i ppf od.open_attributes
   | Tstr_class (l) ->
-      line i ppf "Pstr_class\n";
+      line i ppf "Tstr_class\n";
       list i class_declaration ppf (List.map (fun (cl, _,_) -> cl) l);
   | Tstr_class_type (l) ->
-      line i ppf "Pstr_class_type\n";
+      line i ppf "Tstr_class_type\n";
       list i class_type_declaration ppf (List.map (fun (_, _, cl) -> cl) l);
   | Tstr_include incl ->
-      line i ppf "Pstr_include";
+      line i ppf "Tstr_include";
       attributes i ppf incl.incl_attributes;
       module_expr i ppf incl.incl_mod;
   | Tstr_attribute (s, arg) ->
-      line i ppf "Pstr_attribute \"%s\"\n" s.txt;
+      line i ppf "Tstr_attribute \"%s\"\n" s.txt;
       Printast.payload i ppf arg
 
 and string_x_module_type i ppf (s, _, mty) =


### PR DESCRIPTION
Simply correct all the strings. Most of it is s/P/T/.
