### PR TITLE
change the behavior of Buffer.add_channel on channels not containing enough elements

### DIFF
--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -101,12 +101,20 @@ let add_bytes b s = add_string b (Bytes.unsafe_to_string s)
 let add_buffer b bs =
   add_subbytes b bs.buffer 0 bs.position
 
+(* read up to [len] bytes from [ic] into [b]. *)
+let rec add_channel_rec b ic len =
+  if len > 0 then (
+    let n = input ic b.buffer b.position len in
+    b.position <- b.position + n;
+    if n = 0 then raise End_of_file
+    else add_channel_rec b ic (len-n)   (* n <= len *)
+  )
+
 let add_channel b ic len =
   if len < 0 || len > Sys.max_string_length then   (* PR#5004 *)
     invalid_arg "Buffer.add_channel";
   if b.position + len > b.length then resize b len;
-  really_input ic b.buffer b.position len;
-  b.position <- b.position + len
+  add_channel_rec b ic len
 
 let output_buffer oc b =
   output oc b.buffer 0 b.position

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -116,10 +116,11 @@ val add_buffer : t -> t -> unit
    at the end of buffer [b1].  [b2] is not modified. *)
 
 val add_channel : t -> in_channel -> int -> unit
-(** [add_channel b ic n] reads exactly [n] character from the
+(** [add_channel b ic n] reads at most [n] characters from the
    input channel [ic] and stores them at the end of buffer [b].
    Raise [End_of_file] if the channel contains fewer than [n]
-   characters. *)
+   characters. In this case the characters are still added to
+   the buffer, so as to avoid loss of data. *)
 
 val output_buffer : out_channel -> t -> unit
 (** [output_buffer oc b] writes the current contents of buffer [b]


### PR DESCRIPTION
See [mantis issue](http://caml.inria.fr/mantis/view.php?id=6719).
