### PR TITLE
Add compatibility macro

### DIFF
--- a/byterun/caml/compatibility.h
+++ b/byterun/caml/compatibility.h
@@ -16,6 +16,10 @@
 #ifndef CAML_COMPATIBILITY_H
 #define CAML_COMPATIBILITY_H
 
+/* internal global variables renamed between 4.02.1 and 4.03.0 */
+#define caml_stat_top_heap_size caml_stat_top_heap_wsz
+#define caml_stat_heap_size caml_stat_heap_wsz
+
 #ifndef CAML_NAME_SPACE
 
 /*


### PR DESCRIPTION
Core_kernel uses `caml_stat_heap_size` which was renamed to `caml_stat_heap_wsz`.
I did'nt look into the other recent renamings of that kind. I will propose others if needed.
