### PR TITLE
Stricter documentation rules

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -438,6 +438,16 @@ rule token = parse
   | ":>" { COLONGREATER }
   | ";"  { SEMI }
   | ";;" { SEMISEMI }
+  | ";@" { reset_string_buffer();
+           is_in_string := true;
+           let start_loc = Location.curr lexbuf in
+           let string_start = lexbuf.lex_start_p in
+           let end_loc = alcomment lexbuf in
+           is_in_string := false;
+           lexbuf.lex_start_p <- string_start;
+           let loc = { start_loc with
+                       Location.loc_end = end_loc.Location.loc_end } in
+           ALCOMMENT (get_stored_string(), loc) }
   | "<"  { LESS }
   | "<-" { LESSMINUS }
   | "="  { EQUAL }
@@ -619,6 +629,16 @@ and string = parse
   | _
       { store_string_char(Lexing.lexeme_char lexbuf 0);
         string lexbuf }
+
+and alcomment = parse
+  | ' '* newline
+      { let loc = Location.curr lexbuf in
+        update_loc lexbuf None 1 false 0;
+        loc }
+  | eof { Location.curr lexbuf }
+  | _
+      { store_string_char (Lexing.lexeme_char lexbuf 0);
+        alcomment lexbuf }
 
 and quoted_string delim = parse
   | newline

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -157,6 +157,9 @@ let unclosed opening_name opening_num closing_name closing_num =
   raise(Syntaxerr.Error(Syntaxerr.Unclosed(rhs_loc opening_num, opening_name,
                                            rhs_loc closing_num, closing_name)))
 
+let undocumented pos =
+    raise Syntaxerr.(Error(Undocumented (rhs_loc pos)))
+
 let expecting pos nonterm =
     raise Syntaxerr.(Error(Expecting(rhs_loc pos, nonterm)))
 
@@ -417,6 +420,7 @@ let mkctf_attrs d attrs =
 %token WHILE
 %token WITH
 %token <string * Location.t> COMMENT
+%token <string * Location.t> ALCOMMENT
 
 %token EOL
 
@@ -522,7 +526,7 @@ top_structure:
 ;
 top_structure_tail:
     /* empty */                          { [] }
-  | structure_item top_structure_tail    { $1 :: $2 }
+  | documented_structure_item top_structure_tail    { $1 @ $2 }
 ;
 use_file:
     use_file_tail                        { $1 }
@@ -534,9 +538,9 @@ use_file_tail:
   | SEMISEMI EOF                              { [] }
   | SEMISEMI seq_expr post_item_attributes use_file_tail
                                               { Ptop_def[mkstrexp $2 $3] :: $4 }
-  | SEMISEMI structure_item use_file_tail     { Ptop_def[$2] :: $3 }
+  | SEMISEMI documented_structure_item use_file_tail     { Ptop_def $2 :: $3 }
   | SEMISEMI toplevel_directive use_file_tail { $2 :: $3 }
-  | structure_item use_file_tail              { Ptop_def[$1] :: $2 }
+  | documented_structure_item use_file_tail              { Ptop_def $1 :: $2 }
   | toplevel_directive use_file_tail          { $1 :: $2 }
 ;
 parse_core_type:
@@ -625,8 +629,26 @@ structure:
 structure_tail:
     /* empty */          { [] }
   | SEMISEMI structure   { $2 }
-  | structure_item structure_tail { $1 :: $2 }
+  | documented_structure_item structure_tail { $1 @ $2 }
 ;
+alcomment:
+    ALCOMMENT
+    { let comment, loc = $1 in
+      let exp = Exp.mk ~loc (Pexp_constant (Const_string (comment, None))) in
+      let loc = rhs_loc 1 in
+      let str = Str.mk ~loc (Pstr_eval (exp, [])) in
+      let payload = PStr [str] in
+      Str.mk ~loc (Pstr_attribute (mkloc "doc" loc, payload)),
+      Sig.mk ~loc (Psig_attribute (mkloc "doc" loc, payload))
+    }
+;
+documented_structure_item:
+  | structure_item
+    { undocumented 1 }
+  | alcomment structure_item
+    { [fst $1; $2] }
+;
+
 structure_item:
     LET ext_attributes rec_flag let_bindings
       {
@@ -728,7 +750,13 @@ module_type:
 signature:
     /* empty */          { [] }
   | SEMISEMI signature   { $2 }
-  | signature_item signature { $1 :: $2 }
+  | documented_signature_item signature { $1 @ $2 }
+;
+documented_signature_item:
+  | signature_item
+    { undocumented 1 }
+  | alcomment signature_item
+    { [snd $1; $2] }
 ;
 signature_item:
     VAL val_ident COLON core_type post_item_attributes

--- a/parsing/syntaxerr.ml
+++ b/parsing/syntaxerr.ml
@@ -14,6 +14,7 @@
 
 type error =
     Unclosed of Location.t * string * Location.t * string
+  | Undocumented of Location.t
   | Expecting of Location.t * string
   | Not_expecting of Location.t * string
   | Applicative_path of Location.t
@@ -36,7 +37,8 @@ let prepare_error = function
                            the highlighted '%s' might be unmatched"
              closing opening)
         "Error: Syntax error: '%s' expected" closing
-
+  | Undocumented loc ->
+      Location.errorf ~loc "Error: Documentation error: no documentation, add a ';@' line."
   | Expecting (loc, nonterm) ->
       Location.errorf ~loc "Error: Syntax error: %s expected." nonterm
   | Not_expecting (loc, nonterm) ->
@@ -68,6 +70,7 @@ let report_error ppf err =
 
 let location_of_error = function
   | Unclosed(l,_,_,_)
+  | Undocumented l
   | Applicative_path l
   | Variable_in_scope(l,_)
   | Other l

--- a/parsing/syntaxerr.mli
+++ b/parsing/syntaxerr.mli
@@ -16,6 +16,7 @@ open Format
 
 type error =
     Unclosed of Location.t * string * Location.t * string
+  | Undocumented of Location.t
   | Expecting of Location.t * string
   | Not_expecting of Location.t * string
   | Applicative_path of Location.t


### PR DESCRIPTION
It is rarely an habit of the OCaml programmer to document code. OCamldoc syntax can be confusing and documentation often ends up dispersed between comments.

Luckily, this patch provides a small and reasonable solution for both problems:
- by introducing a new token, ";@" which turns the rest of the line into a documentation string
- by making mandatory that every structure and signature item is preceded by a documentation.

Absence of documentation becoming a syntax error, documentation coverage should increase quickly.

``` ocaml
$ ./ocaml
        OCaml version 4.03.0+dev6-2015-01-20
# let rec fib n = if n <= 1 then 1 else fib (n - 1) + fib (n - 2);;
Error: Documentation error: no documentation, add a ';@' line.
# ;@ The swiss army knife of patient people counting rabbits
  let rec fib n = if n <= 1 then 1 else fib (n - 1) + fib (n - 2);;
val fib : int -> int = <fun>
```

I am considering `;@@` and `;@@@` variants to make the scope of the documented item more specific, but I'll wait for community feedback before engaging on such work.

Beware: the compiler can't yet bootstrap when this patch is applied.
If chamelle n°5 is still being developed, I'll happily port the patch to this new language.
