### PR TITLE
Add a [CAMLdrop] macro which is the dual of [CAMLparam0]

### DIFF
--- a/byterun/caml/memory.h
+++ b/byterun/caml/memory.h
@@ -154,7 +154,9 @@ CAMLextern struct caml__roots_block *caml_local_roots;  /* defined in roots.c */
    Your function may raise an exception or return a [value] with the
    [CAMLreturn] macro.  Its argument is simply the [value] returned by
    your function.  Do NOT directly return a [value] with the [return]
-   keyword.  If your function returns void, use [CAMLreturn0].
+   keyword.  If your function returns void, use [CAMLreturn0]. The
+   [CAMLdrop] macro is the dual of [CAMLparam0]: it cleans up the
+   local roots.
 
    All the identifiers beginning with "caml__" are reserved by OCaml.
    Do not use them for anything (local or global variables, struct or
@@ -309,6 +311,9 @@ CAMLextern struct caml__roots_block *caml_local_roots;  /* defined in roots.c */
 
 #define CAMLnoreturn ((void) caml__frame)
 
+#define CAMLdrop do{ \
+    caml_local_roots = caml__frame; \
+  } while(0)
 
 /* convenience macro */
 #define Store_field(block, offset, val) do{ \


### PR DESCRIPTION
When writing C stubs, it is currently not possible to reset the value
of [caml_local_roots] to the [caml__frame] value without terminating
the execution of the function (e.g. using [CAMLreturn0]). The
workaround is to use explicitly the line

```
caml_local_roots = caml__frame;
```

in the C stubs.

The proposed macro [CAMLdrop] solve the issue of having to use these
variables explicitly.
