### PR TITLE
fix getsockopt behaviour for boolean socket options

### DIFF
--- a/otherlibs/unix/sockopt.c
+++ b/otherlibs/unix/sockopt.c
@@ -194,6 +194,7 @@ unix_getsockopt_aux(char * name,
 
   switch (ty) {
   case TYPE_BOOL:
+    return Val_bool(optval.i);
   case TYPE_INT:
     return Val_int(optval.i);
   case TYPE_LINGER:


### PR DESCRIPTION
Original report was in PR#1282, which reported that non-0/1 return
values from boolean getsockopt were being handled with Val_int
instead of Val_bool (which truncates them down to 0 or 1).

This regressed in #4484 which was a major refactoring of the code
that went back to using Val_int for the bool case.

This fixes it. Original bug in 2002, regression 2008, fix in 2015!

Debugged with @andrewray
