### PR TITLE
added result type

### DIFF
--- a/otherlibs/threads/pervasives.ml
+++ b/otherlibs/threads/pervasives.ml
@@ -210,6 +210,10 @@ external ( := ) : 'a ref -> 'a -> unit = "%setfield0"
 external incr : int ref -> unit = "%incr"
 external decr : int ref -> unit = "%decr"
 
+(* Result type *)
+
+type ('a,'b) result = Ok of 'a | Error of 'b
+
 (* String conversion functions *)
 
 external format_int : string -> int -> string = "caml_format_int"

--- a/stdlib/pervasives.ml
+++ b/stdlib/pervasives.ml
@@ -206,6 +206,10 @@ external ( := ) : 'a ref -> 'a -> unit = "%setfield0"
 external incr : int ref -> unit = "%incr"
 external decr : int ref -> unit = "%decr"
 
+(* Result type *)
+
+type ('a,'b) result = Ok of 'a | Error of 'b
+
 (* String conversion functions *)
 
 external format_int : string -> int -> string = "caml_format_int"

--- a/stdlib/pervasives.mli
+++ b/stdlib/pervasives.mli
@@ -966,6 +966,9 @@ external decr : int ref -> unit = "%decr"
 (** Decrement the integer contained in the given reference.
    Equivalent to [fun r -> r := pred !r]. *)
 
+(** {6 Result type} *)
+
+type ('a,'b) result = Ok of 'a | Error of 'b
 
 (** {6 Operations on format strings} *)
 


### PR DESCRIPTION
This PR adds a new result type, with the following signature:

```
type ('a,'b) result = Ok of 'a | Error of 'b
```

to Pervasives.  This is very similar to a type that shows up in many
existing libraries, and should hopefully allow us to converge on one
definition that can be shared.  Here are some other known use-cases in
prominent released libraries.
- Daniel Bunzli's libraries, as separated out in his
  [Result](http://erratique.ch/repos/result/tree/src/result.mli) library
- Containers' [CCError](https://github.com/c-cube/ocaml-containers/blob/master/src/core/CCError.mli) type
- Mondet's [pvem](https://bitbucket.org/smondet/pvem) library
- Batteries' [batResult](https://github.com/ocaml-batteries-team/batteries-included/blob/master/src/batResult.mli) type
- Core's [Result](https://github.com/janestreet/core_kernel/blob/master/lib/result.mli) type

The first three of these use the polymorphic variant type,

```
[`Ok of 'a | `Error of 'b]
```

Batteries uses an ordinary variant with this layout:

```
type ('a,'b) t = Ok of 'a | Bad of 'b
```

Core_kernel uses an ordinary variant with this layout:

```
type ('a,'b) t = Ok of 'a | Error of 'b
```

After some discussion (notably including Daniel Bunzli), it seems like
the ordinary variant approach is better from a perspective of the less
error prone typing discipline of ordinary variants.  In particular,
OCaml correctly detects that the following code is broken:

```
type ('a,'b) result =
| Ok of 'a
| Error of 'b

module Z : sig
  val f : ('a list,'b) result -> int
end = struct
  let f = function
    | Ok [] -> 0
    | Ok (_::_) -> 1
    | (OK | Error _) -> 2
end
```

But lets the same code done with polymorphic variants compile without
issues.

```
type ('a,'b) presult =
 [ `Ok of 'a
 | `Error of 'b ]

module Z : sig
  val f : ('a list,'b) presult -> int
end = struct
  let f = function
    | `Ok [] -> 0
    | `Ok (_::_) -> 1
    | (`OK | `Error _) -> 2
end
```

The hope is that by putting one of these in the stdlib, we can have
better interoperability between libraries on what seems to be a quite
basic type, without having to use the more complex and error prone
polymorphic variant solution.  Bunzli among others have expressed some
concern with needing to pull in a separate package for such a basic
type, which is what motivates moving it to the stdlib.
