### PR TITLE
Give hints to ocamldep

### DIFF
--- a/tools/depend.mli
+++ b/tools/depend.mli
@@ -16,11 +16,7 @@ module StringSet : Set.S with type elt = string
 
 val free_structure_names : StringSet.t ref
 
-val open_module :
-  StringSet.t ->
-  ?attributes:(string Location.loc * Parsetree.payload) list ->
-  Longident.t ->
-  StringSet.t
+val open_module : StringSet.t -> Longident.t -> StringSet.t
 
 val add_use_file : StringSet.t -> Parsetree.toplevel_phrase list -> unit
 

--- a/tools/depend.mli
+++ b/tools/depend.mli
@@ -16,7 +16,11 @@ module StringSet : Set.S with type elt = string
 
 val free_structure_names : StringSet.t ref
 
-val open_module : StringSet.t -> Longident.t -> unit
+val open_module :
+  StringSet.t ->
+  ?attributes:(string Location.loc * Parsetree.payload) list ->
+  Longident.t ->
+  StringSet.t
 
 val add_use_file : StringSet.t -> Parsetree.toplevel_phrase list -> unit
 

--- a/tools/ocamldep.ml
+++ b/tools/ocamldep.ml
@@ -227,9 +227,9 @@ let read_parse_and_extract parse_function extract_function magic source_file =
 		    input_file parse_function magic
       in
       let bound_vars = Depend.StringSet.empty in
-      List.iter (fun modname ->
+      let bound_vars = List.fold_left (fun bound_vars modname ->
 	Depend.open_module bound_vars (Longident.Lident modname)
-      ) !Clflags.open_modules;
+      ) bound_vars !Clflags.open_modules in
       extract_function bound_vars ast;
       Pparse.remove_preprocessed input_file;
       !Depend.free_structure_names


### PR DESCRIPTION
ie. prevents `A` to be considered as a dependency in the following mli  

```
open My_module_containing_A
[@@ocamldep.hint include A]
(* Tell ocamldep that the module [My_module_containing_A] provides a module [A] *) 

val x : A.t
```
