### PR TITLE
Optimize reallocation of caml_frame_descriptors.

### DIFF
--- a/asmrun/backtrace.c
+++ b/asmrun/backtrace.c
@@ -72,16 +72,14 @@ CAMLprim value caml_backtrace_status(value vunit)
 frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp)
 {
   frame_descr * d;
-  frame_table_elt e;
   uintnat h;
 
   while (1) {
     h = Hash_retaddr(*pc);
     while (1) {
-      e = caml_frame_descriptors[h];
-      d = e.frame_descr;
+      d = caml_frame_descriptors[h];
       if (d == 0) return NULL; /* can happen if some code compiled without -g */
-      if (e.retaddr == *pc) break;
+      if (d->retaddr == *pc) break;
       h = (h+1) & caml_frame_descriptors_mask;
     }
     /* Skip to next frame */

--- a/asmrun/backtrace.c
+++ b/asmrun/backtrace.c
@@ -74,8 +74,6 @@ frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp)
   frame_descr * d;
   uintnat h;
 
-  if (caml_frame_descriptors == NULL) caml_init_frame_descriptors();
-
   while (1) {
     h = Hash_retaddr(*pc);
     while (1) {

--- a/asmrun/backtrace.c
+++ b/asmrun/backtrace.c
@@ -72,14 +72,16 @@ CAMLprim value caml_backtrace_status(value vunit)
 frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp)
 {
   frame_descr * d;
+  frame_table_elt e;
   uintnat h;
 
   while (1) {
     h = Hash_retaddr(*pc);
     while (1) {
-      d = caml_frame_descriptors[h];
+      e = caml_frame_descriptors[h];
+      d = e.frame_descr;
       if (d == 0) return NULL; /* can happen if some code compiled without -g */
-      if (d->retaddr == *pc) break;
+      if (e.retaddr == *pc) break;
       h = (h+1) & caml_frame_descriptors_mask;
     }
     /* Skip to next frame */

--- a/asmrun/roots.c
+++ b/asmrun/roots.c
@@ -57,7 +57,7 @@ static link *cons(void *data, link *tl) {
 static link *frametables = NULL;
 static intnat num_descr = 0;
 
-static int count_desciptors(link *list) {
+static int count_descriptors(link *list) {
   intnat num_descr = 0;
   link *lnk;
   iter_list(list,lnk) {
@@ -115,7 +115,7 @@ static void init_frame_descriptors(link *new_frametables)
   Assert(new_frametables);
 
   tail = frametables_list_tail(new_frametables);
-  increase = count_desciptors(new_frametables);
+  increase = count_descriptors(new_frametables);
   tblsize = caml_frame_descriptors_mask + 1;
 
   /* Reallocate the caml_frame_descriptor table if it is too small */
@@ -127,7 +127,7 @@ static void init_frame_descriptors(link *new_frametables)
 
     /* [num_descr] can be less than [num_descr + increase] if frame
        tables where unregistered */
-    num_descr = count_desciptors(new_frametables);
+    num_descr = count_descriptors(new_frametables);
 
     tblsize = 4;
     while (tblsize < 2 * num_descr) tblsize *= 2;

--- a/asmrun/stack.h
+++ b/asmrun/stack.h
@@ -78,9 +78,14 @@ typedef struct {
   unsigned short live_ofs[1];
 } frame_descr;
 
+typedef struct {
+  frame_descr *frame_descr;
+  uintnat retaddr;
+} frame_table_elt;
+
 /* Hash table of frame descriptors */
 
-extern frame_descr ** caml_frame_descriptors;
+extern frame_table_elt * caml_frame_descriptors;
 extern int caml_frame_descriptors_mask;
 
 #define Hash_retaddr(addr) \
@@ -88,6 +93,7 @@ extern int caml_frame_descriptors_mask;
 
 extern void caml_init_frame_descriptors(void);
 extern void caml_register_frametable(intnat *);
+extern void caml_unregister_frametable(intnat *);
 extern void caml_register_dyn_global(void *);
 
 extern uintnat caml_stack_usage (void);

--- a/asmrun/stack.h
+++ b/asmrun/stack.h
@@ -78,14 +78,9 @@ typedef struct {
   unsigned short live_ofs[1];
 } frame_descr;
 
-typedef struct {
-  frame_descr *frame_descr;
-  uintnat retaddr;
-} frame_table_elt;
-
 /* Hash table of frame descriptors */
 
-extern frame_table_elt * caml_frame_descriptors;
+extern frame_descr ** caml_frame_descriptors;
 extern int caml_frame_descriptors_mask;
 
 #define Hash_retaddr(addr) \

--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -162,6 +162,7 @@ void caml_main(char **argv)
   value res;
   char tos;
 
+  caml_init_frame_descriptors();
   caml_init_ieee_floats();
 #ifdef _MSC_VER
   caml_install_invalid_parameter_handler();


### PR DESCRIPTION
It now only reallocate and reinitialise the whole table only when it
is too small. This avoids quadratic behavior when loading a lot of
module with dynlink.

This in problematic on frama-c when inlining increase the code size. The frame table
initialisation took ~0.5 second. This is quite noticeable on real examples where the
whole frama-c analysis is ~1.5s long.
