### PR TITLE
Don't check recursive use of non-recursive types

### DIFF
--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -1,0 +1,18 @@
+module Unused : sig
+end = struct
+  type unused = int
+end
+;;
+
+module Unused_nonrec : sig
+end = struct
+  type nonrec used = int
+  type nonrec unused = used
+end
+;;
+
+module Unused_rec : sig
+end = struct
+  type unused = A of unused
+end
+;;

--- a/testsuite/tests/typing-warnings/unused_types.ml.reference
+++ b/testsuite/tests/typing-warnings/unused_types.ml.reference
@@ -1,0 +1,21 @@
+
+#         Characters 40-52:
+    type unused = int
+         ^^^^^^^^^^^^
+Warning 34: unused type unused.
+module Unused : sig  end
+#             Characters 80-93:
+    type nonrec unused = used
+                ^^^^^^^^^^^^^
+Warning 34: unused type unused.
+module Unused_nonrec : sig  end
+#           Characters 45-65:
+    type unused = A of unused
+         ^^^^^^^^^^^^^^^^^^^^
+Warning 34: unused type unused.
+Characters 45-65:
+    type unused = A of unused
+         ^^^^^^^^^^^^^^^^^^^^
+Warning 37: unused constructor A.
+module Unused_rec : sig  end
+# 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1022,24 +1022,26 @@ let transl_type_decl env rec_flag sdecl_list =
   let current_slot = ref None in
   let warn_unused = Warnings.is_active (Warnings.Unused_type_declaration "") in
   let id_slots id =
-    if not warn_unused then id, None
-    else
-      (* See typecore.ml for a description of the algorithm used
-         to detect unused declarations in a set of recursive definitions. *)
-      let slot = ref [] in
-      let td = Env.find_type (Path.Pident id) temp_env in
-      let name = Ident.name id in
-      Env.set_type_used_callback
-        name td
-        (fun old_callback ->
-          match !current_slot with
-          | Some slot -> slot := (name, td) :: !slot
-          | None ->
-              List.iter (fun (name, d) -> Env.mark_type_used env name d)
-                (get_ref slot);
-              old_callback ()
-        );
-      id, Some slot
+    match rec_flag with
+    | Asttypes.Recursive when warn_unused ->
+        (* See typecore.ml for a description of the algorithm used
+             to detect unused declarations in a set of recursive definitions. *)
+        let slot = ref [] in
+        let td = Env.find_type (Path.Pident id) temp_env in
+        let name = Ident.name id in
+        Env.set_type_used_callback
+          name td
+          (fun old_callback ->
+             match !current_slot with
+             | Some slot -> slot := (name, td) :: !slot
+             | None ->
+                 List.iter (fun (name, d) -> Env.mark_type_used env name d)
+                   (get_ref slot);
+                 old_callback ()
+          );
+        id, Some slot
+    | Asttypes.Recursive | Asttypes.Nonrecursive ->
+        id, None
   in
   let transl_declaration name_sdecl (id, slot) =
     current_slot := slot; transl_declaration temp_env name_sdecl id in


### PR DESCRIPTION
Typechecking of `nonrec` types was still looking for uses in the temporary environment.
This made the compiler fail with "exception Not_found" when warning 34 was enabled.
