### PR TITLE
Turn Lapply case of Lambda.lambda into a record

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -453,7 +453,7 @@ let rec comp_expr env exp sz cont =
       end
   | Lconst cst ->
       Kconst cst :: cont
-  | Lapply(func, args, info) ->
+  | Lapply{ap_func = func; ap_args = args} ->
       let nargs = List.length args in
       if is_tailcall cont then begin
         comp_args env args sz
@@ -577,7 +577,11 @@ let rec comp_expr env exp sz cont =
       comp_expr env arg sz (add_const_unit cont)
   | Lprim(Pdirapply loc, [func;arg])
   | Lprim(Prevapply loc, [arg;func]) ->
-      let exp = Lapply(func, [arg], mk_apply_info loc) in
+      let exp = Lapply{ap_should_be_tailcall=false;
+                       ap_loc=loc;
+                       ap_func=func;
+                       ap_args=[arg];
+                       ap_inlined=Default_inline} in
       comp_expr env exp sz cont
   | Lprim(Pnot, [arg]) ->
       let newcont =
@@ -820,7 +824,7 @@ let rec comp_expr env exp sz cont =
       | Lev_after ty ->
           let info =
             match lam with
-              Lapply(_, args, _)      -> Event_return (List.length args)
+              Lapply{ap_args = args}  -> Event_return (List.length args)
             | Lsend(_, _, _, args, _) -> Event_return (List.length args + 1)
             | _                       -> Event_other
           in

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -166,24 +166,6 @@ type inline_attribute =
   | Never_inline (* [@inline never] *)
   | Default_inline (* no [@inline] attribute *)
 
-type apply_info = {
-  apply_loc : Location.t;
-  apply_should_be_tailcall : bool; (* true if [@tailcall] was specified *)
-  apply_inlined : inline_attribute; (* specified with [@inlined] attribute *)
-}
-
-val no_apply_info : apply_info
-(** Default [apply_info]: no location, no tailcall *)
-
-val mk_apply_info : ?tailcall:bool -> ?inlined_attribute:inline_attribute ->
-  Location.t -> apply_info
-(** Build apply_info
-    @param tailcall if true, the application should be in tail position;
-    default false
-    @param inlined_attribute specify wether the function should be inlined
-    or not
-*)
-
 type function_kind = Curried | Tupled
 
 type let_kind = Strict | Alias | StrictOpt | Variable
@@ -208,7 +190,7 @@ type function_attribute = {
 type lambda =
     Lvar of Ident.t
   | Lconst of structured_constant
-  | Lapply of lambda * lambda list * apply_info
+  | Lapply of lambda_apply
   | Lfunction of lfunction
   | Llet of let_kind * Ident.t * lambda * lambda
   | Lletrec of (Ident.t * lambda) list * lambda
@@ -234,6 +216,13 @@ and lfunction =
     params: Ident.t list;
     body: lambda;
     attr: function_attribute; } (* specified with [@inline] attribute *)
+
+and lambda_apply =
+  { ap_func : lambda;
+    ap_args : lambda list;
+    ap_loc : Location.t;
+    ap_should_be_tailcall : bool;       (* true if [@tailcall] was specified *)
+    ap_inlined : inline_attribute }     (* specified with the [@inline] attribute *)
 
 and lambda_switch =
   { sw_numconsts: int;                  (* Number of integer cases *)

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1517,7 +1517,11 @@ let inline_lazy_force_cond arg loc =
                 (* ... if (tag == Obj.lazy_tag) then Lazy.force varg else ... *)
                 Lprim(Pintcomp Ceq,
                       [Lvar tag; Lconst(Const_base(Const_int Obj.lazy_tag))]),
-                Lapply(force_fun, [varg], mk_apply_info loc),
+                Lapply{ap_should_be_tailcall=false;
+                       ap_loc=loc;
+                       ap_func=force_fun;
+                       ap_args=[varg];
+                       ap_inlined=Default_inline},
                 (* ... arg *)
                   varg))))
 
@@ -1535,7 +1539,11 @@ let inline_lazy_force_switch arg loc =
                sw_blocks =
                  [ (Obj.forward_tag, Lprim(Pfield 0, [varg]));
                    (Obj.lazy_tag,
-                    Lapply(force_fun, [varg], mk_apply_info loc)) ];
+                    Lapply{ap_should_be_tailcall=false;
+                           ap_loc=loc;
+                           ap_func=force_fun;
+                           ap_args=[varg];
+                           ap_inlined=Default_inline}) ];
                sw_failaction = Some varg } ))))
 
 let inline_lazy_force arg loc =

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -266,12 +266,12 @@ let rec lam ppf = function
       Ident.print ppf id
   | Lconst cst ->
       struct_const ppf cst
-  | Lapply(lfun, largs, info) ->
+  | Lapply ap ->
       let lams ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
-      fprintf ppf "@[<2>(apply@ %a%a%a%a)@]" lam lfun lams largs
-        apply_tailcall_attribute info.apply_should_be_tailcall
-        apply_inlined_attribute info.apply_inlined
+      fprintf ppf "@[<2>(apply@ %a%a%a%a)@]" lam ap.ap_func lams ap.ap_args
+        apply_tailcall_attribute ap.ap_should_be_tailcall
+        apply_inlined_attribute ap.ap_inlined
   | Lfunction{kind; params; body; attr} ->
       let pr_params ppf params =
         match kind with

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -729,11 +729,11 @@ and transl_exp0 e =
           let should_be_tailcall, funct =
             Translattribute.get_tailcall_attribute funct
           in
-          let inlined_attribute, funct =
+          let inlined, funct =
             Translattribute.get_inlined_attribute funct
           in
           let e = { e with exp_desc = Texp_apply(funct, oargs) } in
-          event_after e (transl_apply ~should_be_tailcall ~inlined_attribute
+          event_after e (transl_apply ~should_be_tailcall ~inlined
                            f args' e.exp_loc)
       in
       let wrap0 f =
@@ -785,11 +785,11 @@ and transl_exp0 e =
       let should_be_tailcall, funct =
         Translattribute.get_tailcall_attribute funct
       in
-      let inlined_attribute, funct =
+      let inlined, funct =
         Translattribute.get_inlined_attribute funct
       in
       let e = { e with exp_desc = Texp_apply(funct, oargs) } in
-      event_after e (transl_apply ~should_be_tailcall ~inlined_attribute
+      event_after e (transl_apply ~should_be_tailcall ~inlined
                        (transl_exp funct) oargs e.exp_loc)
   | Texp_match(arg, pat_expr_list, exn_pat_expr_list, partial) ->
     transl_match e arg pat_expr_list exn_pat_expr_list partial
@@ -907,8 +907,11 @@ and transl_exp0 e =
       in
       event_after e lam
   | Texp_new (cl, {Location.loc=loc}, _) ->
-      Lapply(Lprim(Pfield 0, [transl_path ~loc e.exp_env cl]),
-             [lambda_unit], no_apply_info)
+      Lapply{ap_should_be_tailcall=false;
+             ap_loc=loc;
+             ap_func=Lprim(Pfield 0, [transl_path ~loc e.exp_env cl]);
+             ap_args=[lambda_unit];
+             ap_inlined=Default_inline}
   | Texp_instvar(path_self, path, _) ->
       Lprim(Parrayrefu Paddrarray,
             [transl_normal_path path_self; transl_normal_path path])
@@ -917,8 +920,11 @@ and transl_exp0 e =
   | Texp_override(path_self, modifs) ->
       let cpy = Ident.create "copy" in
       Llet(Strict, cpy,
-           Lapply(Translobj.oo_prim "copy", [transl_normal_path path_self],
-                  no_apply_info),
+           Lapply{ap_should_be_tailcall=false;
+                  ap_loc=Location.none;
+                  ap_func=Translobj.oo_prim "copy";
+                  ap_args=[transl_normal_path path_self];
+                  ap_inlined=Default_inline},
            List.fold_right
              (fun (path, _, expr) rem ->
                 Lsequence(transl_setinstvar (Lvar cpy) path expr, rem))
@@ -1039,18 +1045,21 @@ and transl_tupled_cases patl_expr_list =
   List.map (fun (patl, guard, expr) -> (patl, transl_guard guard expr))
     patl_expr_list
 
-and transl_apply ?(should_be_tailcall=false) ?inlined_attribute lam sargs loc =
+and transl_apply ?(should_be_tailcall=false) ?(inlined = Default_inline) lam sargs loc =
   let lapply funct args =
     match funct with
       Lsend(k, lmet, lobj, largs, loc) ->
         Lsend(k, lmet, lobj, largs @ args, loc)
     | Levent(Lsend(k, lmet, lobj, largs, loc), _) ->
         Lsend(k, lmet, lobj, largs @ args, loc)
-    | Lapply(lexp, largs, info) ->
-        Lapply(lexp, largs @ args, {info with apply_loc=loc})
+    | Lapply ap ->
+        Lapply {ap with ap_args = ap.ap_args @ args; ap_loc = loc}
     | lexp ->
-        Lapply(lexp, args, mk_apply_info ~tailcall:should_be_tailcall
-                 ?inlined_attribute loc)
+        Lapply {ap_should_be_tailcall=should_be_tailcall;
+                ap_loc=loc;
+                ap_func=lexp;
+                ap_args=args;
+                ap_inlined=inlined}
   in
   let rec build_apply lam args = function
       (None, optional) :: l ->
@@ -1090,7 +1099,7 @@ and transl_apply ?(should_be_tailcall=false) ?inlined_attribute lam sargs loc =
     | [] ->
         lapply lam (List.rev_map fst args)
   in
-  build_apply lam [] (List.map (fun (l, x,o) -> may_map transl_exp x, o) sargs)
+  (build_apply lam [] (List.map (fun (l, x,o) -> may_map transl_exp x, o) sargs) : Lambda.lambda)
 
 and transl_function loc untuplify_fn repr partial cases =
   match cases with

--- a/bytecomp/translcore.mli
+++ b/bytecomp/translcore.mli
@@ -19,7 +19,7 @@ open Lambda
 
 val transl_exp: expression -> lambda
 val transl_apply: ?should_be_tailcall:bool
-                  -> ?inlined_attribute:inline_attribute
+                  -> ?inlined:inline_attribute
                   -> lambda -> (arg_label * expression option * optional) list
                   -> Location.t -> lambda
 val transl_let: rec_flag -> value_binding list -> lambda -> lambda


### PR DESCRIPTION
This is a follow-up to #111, making the arguments of the `Lapply` case of `Lambda.lambda` into a record, in analogy to the change in #133, which treats the case of `Lfunction`.
