### PR TITLE
Allow custom warning printers / catchers.

### DIFF
--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -72,6 +72,22 @@ let status = ref Terminfo.Uninitialised
 
 let num_loc_lines = ref 0 (* number of lines already printed after input *)
 
+let print_updating_num_loc_lines ppf f arg =
+  let open Format in
+  let out_functions = pp_get_formatter_out_functions ppf () in
+  let out_string str start len =
+    let rec count i c =
+      if i = start + len then c
+      else if String.get str i = '\n' then count (succ i) (succ c)
+      else count (succ i) c in
+    num_loc_lines := !num_loc_lines + count start 0 ;
+    out_functions.out_string str start len in
+  pp_set_formatter_out_functions ppf
+    { out_functions with out_string } ;
+  f ppf arg ;
+  pp_print_flush ppf ();
+  pp_set_formatter_out_functions ppf out_functions
+
 (* Highlight the locations using standout mode. *)
 
 let highlight_terminfo ppf num_lines lb locs =
@@ -261,17 +277,17 @@ let print_error ppf loc =
 
 let print_error_cur_file ppf = print_error ppf (in_file !input_name);;
 
-let print_warning loc ppf w =
+let default_warning_printer loc ppf w =
   if Warnings.is_active w then begin
-    let printw ppf w =
-      let n = Warnings.print ppf w in
-      num_loc_lines := !num_loc_lines + n
-    in
     print ppf loc;
-    fprintf ppf "Warning %a@." printw w;
-    pp_print_flush ppf ();
-    incr num_loc_lines;
+    fprintf ppf "Warning %a@." Warnings.print w
   end
+;;
+
+let warning_printer = ref default_warning_printer ;;
+
+let print_warning loc ppf w =
+  print_updating_num_loc_lines ppf (!warning_printer loc) w
 ;;
 
 let prerr_warning loc w = print_warning loc err_formatter w;;
@@ -317,7 +333,7 @@ let error_of_exn exn =
   in
   loop !error_of_exn
 
-let rec report_error ppf ({loc; msg; sub; if_highlight} as err) =
+let rec default_error_reporter ppf ({loc; msg; sub; if_highlight} as err) =
   let highlighted =
     if if_highlight <> "" then
       let rec collect_locs locs {loc; sub; if_highlight; _} =
@@ -333,9 +349,15 @@ let rec report_error ppf ({loc; msg; sub; if_highlight} as err) =
   else begin
     print ppf loc;
     Format.pp_print_string ppf msg;
-    List.iter (fun err -> Format.fprintf ppf "@\n@[<2>%a@]" report_error err)
+    List.iter (fun err -> Format.fprintf ppf "@\n@[<2>%a@]" default_error_reporter err)
               sub
   end
+
+let error_reporter = ref default_error_reporter
+
+let report_error ppf err =
+  print_updating_num_loc_lines ppf !error_reporter err
+;;
 
 let error_of_printer loc print x =
   let buf = Buffer.create 64 in

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -56,6 +56,11 @@ val prerr_warning: t -> Warnings.t -> unit
 val echo_eof: unit -> unit
 val reset: unit -> unit
 
+val warning_printer : (t -> formatter -> Warnings.t -> unit) ref
+(** Hook for intercepting warnings. *)
+val default_warning_printer : t -> formatter -> Warnings.t -> unit
+(** Original warning printer for use in hooks. *)
+
 val highlight_locations: formatter -> t list -> bool
 
 type 'a loc = {
@@ -114,6 +119,11 @@ val register_error_of_exn: (exn -> error option) -> unit
      being located as well). *)
 
 val report_error: formatter -> error -> unit
+
+val error_reporter : (formatter -> error -> unit) ref
+(** Hook for intercepting error reports. *)
+val default_error_reporter : formatter -> error -> unit
+(** Original error reporter for use in hooks. *)
 
 val report_exception: formatter -> exn -> unit
   (* Reraise the exception if it is unknown. *)

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -395,19 +395,9 @@ let nerrors = ref 0;;
 let print ppf w =
   let msg = message w in
   let num = number w in
-  let newlines = ref 0 in
-  for i = 0 to String.length msg - 1 do
-    if msg.[i] = '\n' then incr newlines;
-  done;
-  let out_functions = Format.pp_get_formatter_out_functions ppf () in
-  let countnewline x = incr newlines; out_functions.Format.out_newline x in
-  Format.pp_set_formatter_out_functions ppf
-         {out_functions with Format.out_newline = countnewline};
   Format.fprintf ppf "%d: %s" num msg;
   Format.pp_print_flush ppf ();
-  Format.pp_set_formatter_out_functions ppf out_functions;
-  if (!current).error.(num) then incr nerrors;
-  !newlines
+  if (!current).error.(num) then incr nerrors
 ;;
 
 exception Errors of int;;

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -73,9 +73,7 @@ val is_error : t -> bool;;
 val defaults_w : string;;
 val defaults_warn_error : string;;
 
-val print : formatter -> t -> int;;
-  (* returns the number of newlines in the printed string *)
-
+val print : formatter -> t -> unit;;
 
 exception Errors of int;;
 


### PR DESCRIPTION
When writing alternative toplevels (such as tryocaml), one can catch errors to display them in a custom way, but doing so for warnings is not possible, except by parsing the output. This patch adds a hook for doing so.

I tried to make this patch minimal, but for the current error underlining to continue working with custom warning printers, I had to move some formatter patching code (that counts the '\n' present in Warning messages) from Warnings to Location.

I also added a hook for displaying errors, for consistency.
