### PR TITLE
Simple sharing in functions Set.remove and Set.filter

### DIFF
--- a/stdlib/set.ml
+++ b/stdlib/set.ml
@@ -223,10 +223,18 @@ module Make(Ord: OrderedType) =
 
     let rec remove x = function
         Empty -> Empty
-      | Node(l, v, r, _) ->
+      | (Node(l, v, r, _) as t) ->
           let c = Ord.compare x v in
-          if c = 0 then merge l r else
-          if c < 0 then bal (remove x l) v r else bal l v (remove x r)
+          if c = 0 then merge l r
+          else
+            if c < 0 then
+              let ll = remove x l in
+              if l == ll then t
+              else bal ll v r
+            else
+              let rr = remove x r in
+              if r == rr then t
+              else bal l v rr
 
     let rec union s1 s2 =
       match (s1, s2) with

--- a/stdlib/set.ml
+++ b/stdlib/set.ml
@@ -332,12 +332,14 @@ module Make(Ord: OrderedType) =
 
     let rec filter p = function
         Empty -> Empty
-      | Node(l, v, r, _) ->
+      | (Node(l, v, r, _)) as t ->
           (* call [p] in the expected left-to-right order *)
           let l' = filter p l in
           let pv = p v in
           let r' = filter p r in
-          if pv then join l' v r' else concat l' r'
+          if pv then
+            if l==l' && r==r' then t else join l' v r'
+          else concat l' r'
 
     let rec partition p = function
         Empty -> (Empty, Empty)

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -127,7 +127,9 @@ module type S =
 
     val filter: (elt -> bool) -> t -> t
     (** [filter p s] returns the set of all elements in [s]
-       that satisfy predicate [p]. *)
+       that satisfy predicate [p]. If [p] satisfies every element in [s],
+       [s] is returned unchanged (the result of the function is then
+       physically equal to [s]). *)
 
     val partition: (elt -> bool) -> t -> t * t
     (** [partition p s] returns a pair of sets [(s1, s2)], where

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -84,7 +84,8 @@ module type S =
 
     val remove: elt -> t -> t
     (** [remove x s] returns a set containing all elements of [s],
-       except [x]. If [x] was not in [s], [s] is returned unchanged. *)
+       except [x]. If [x] was not in [s], [s] is returned unchanged
+       (the result of the function is then physically equal to [s]). *)
 
     val union: t -> t -> t
     (** Set union. *)

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -77,7 +77,8 @@ module type S =
     val add: elt -> t -> t
     (** [add x s] returns a set containing all elements of [s],
        plus [x]. If [x] was already in [s], [s] is returned unchanged
-       (the result of the function is then physically equal to [s]). *)
+       (the result of the function is then physically equal to [s]).
+       @before 4.03 Physical equality was not ensured. *)
 
     val singleton: elt -> t
     (** [singleton x] returns the one-element set containing only [x]. *)
@@ -85,7 +86,8 @@ module type S =
     val remove: elt -> t -> t
     (** [remove x s] returns a set containing all elements of [s],
        except [x]. If [x] was not in [s], [s] is returned unchanged
-       (the result of the function is then physically equal to [s]). *)
+       (the result of the function is then physically equal to [s]).
+       @before 4.03 Physical equality was not ensured. *)
 
     val union: t -> t -> t
     (** Set union. *)
@@ -129,7 +131,8 @@ module type S =
     (** [filter p s] returns the set of all elements in [s]
        that satisfy predicate [p]. If [p] satisfies every element in [s],
        [s] is returned unchanged (the result of the function is then
-       physically equal to [s]). *)
+       physically equal to [s]).
+       @before 4.03 Physical equality was not ensured.*)
 
     val partition: (elt -> bool) -> t -> t * t
     (** [partition p s] returns a pair of sets [(s1, s2)], where

--- a/testsuite/tests/lib-set/testset.ml
+++ b/testsuite/tests/lib-set/testset.ml
@@ -145,3 +145,18 @@ let () =
 
   assert (!s2 == !s1);
   assert(a2 -. a1 = a1 -. a0)
+
+let () =
+  (* check that removing an element from a set that is not present in this set
+     (1) doesn't allocate and (2) return the original set *)
+  let s1 = ref S.empty in
+  for i = 1 to 10 do s1 := S.add i !s1 done;
+  let s2 = ref !s1 in
+
+  let a0 = Gc.allocated_bytes () in
+  let a1 = Gc.allocated_bytes () in
+  for i = 11 to 30 do s2 := S.remove i !s2 done;
+  let a2 = Gc.allocated_bytes () in
+
+  assert (!s2 == !s1);
+  assert(a2 -. a1 = a1 -. a0)

--- a/testsuite/tests/lib-set/testset.ml
+++ b/testsuite/tests/lib-set/testset.ml
@@ -160,3 +160,11 @@ let () =
 
   assert (!s2 == !s1);
   assert(a2 -. a1 = a1 -. a0)
+
+let () =
+  (* check that filtering a set where all elements are satisfied by
+     the given predicate return the original set *)
+  let s1 = ref S.empty in
+  for i = 1 to 10 do s1 := S.add i !s1 done;
+  let s2 = S.filter (fun e -> e >= 0) !s1 in
+  assert (s2 == !s1)


### PR DESCRIPTION
Modify functions Set.remove and Set.filter so that:
- Set.remove returns the given set if the element to be removed is not is the set
- Set.filter returns the given set if the given predicate satisfies all the elements of the set
