### PR TITLE
Allow static allocation of mutable values

### DIFF
--- a/asmcomp/clambda.ml
+++ b/asmcomp/clambda.ml
@@ -24,6 +24,7 @@ type ustructured_constant =
   | Uconst_int64 of int64
   | Uconst_nativeint of nativeint
   | Uconst_block of int * uconstant list
+  | Uconst_mutable_block of int * uconstant list
   | Uconst_float_array of float list
   | Uconst_string of string
 
@@ -133,6 +134,9 @@ let rank_structured_constant = function
   | Uconst_block _ -> 4
   | Uconst_float_array _ -> 5
   | Uconst_string _ -> 6
+  | Uconst_mutable_block _ ->
+      (* mutable blocks cannot be shared *)
+      assert false
 
 let compare_structured_constants c1 c2 =
   match c1, c2 with

--- a/asmcomp/clambda.mli
+++ b/asmcomp/clambda.mli
@@ -24,6 +24,7 @@ type ustructured_constant =
   | Uconst_int64 of int64
   | Uconst_nativeint of nativeint
   | Uconst_block of int * uconstant list
+  | Uconst_mutable_block of int * uconstant list
   | Uconst_float_array of float list
   | Uconst_string of string
 

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2278,7 +2278,8 @@ let rec emit_structured_constant symb cst cont =
   | Uconst_nativeint n ->
       emit_block boxedintnat_header symb
         (emit_boxed_nativeint_constant n cont)
-  | Uconst_block (tag, csts) ->
+  | Uconst_block (tag, csts)
+  | Uconst_mutable_block (tag, csts) ->
       let cont = List.fold_right emit_constant csts cont in
       emit_block (block_header tag (List.length csts)) symb cont
   | Uconst_float_array fields ->

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2370,6 +2370,17 @@ let emit_all_constants cont =
   constant_closures := [];
   !c
 
+(* Build the table of mutable structured constants *)
+
+let emit_mutable_globals_table ~glob ~symbols cont =
+  let table_symbol = Compilenv.make_symbol (Some "mutable_globals") in
+  Cdata(Cglobal_symbol table_symbol ::
+        Cdefine_symbol table_symbol ::
+        Csymbol_address glob ::
+        List.map (fun s -> Csymbol_address s) symbols @
+        [Cint 0n])
+  :: cont
+
 (* Translate a compilation unit *)
 
 let compunit size ulam =
@@ -2381,6 +2392,7 @@ let compunit size ulam =
                        fun_dbg  = Debuginfo.none }] in
   let c2 = transl_all_functions StringSet.empty c1 in
   let c3 = emit_all_constants c2 in
+  let c4 = emit_mutable_globals_table ~glob ~symbols:[] c3 in
   let space =
     (* These words will be registered as roots and as such must contain
        valid values, in case we are in no-naked-pointers mode.  Likewise
@@ -2392,7 +2404,7 @@ let compunit size ulam =
   in
   Cdata ([Cint(black_block_header 0 size);
          Cglobal_symbol glob;
-         Cdefine_symbol glob] @ space) :: c3
+         Cdefine_symbol glob] @ space) :: c4
 
 (*
 CAMLprim value caml_cache_public_method (value meths, value tag, value *cache)
@@ -2723,7 +2735,7 @@ let cint_zero = Cint 0n
 
 let global_table namelist =
   let mksym name =
-    Csymbol_address (Compilenv.make_symbol ~unitname:name None)
+    Csymbol_address (Compilenv.make_symbol ~unitname:name (Some "mutable_globals"))
   in
   Cdata(Cglobal_symbol "caml_globals" ::
         Cdefine_symbol "caml_globals" ::

--- a/asmcomp/compilenv.mli
+++ b/asmcomp/compilenv.mli
@@ -56,11 +56,20 @@ val new_const_symbol : unit -> string
 val new_const_label : unit -> int
 
 val new_structured_constant:
+  ?mutability:Asttypes.mutable_flag ->
   Clambda.ustructured_constant ->
   shared:bool -> (* can be shared with another structually equal constant *)
   string
+
+type structured_constant = {
+  label : string;
+  exported : bool;
+  mutability : Asttypes.mutable_flag;
+  value : Clambda.ustructured_constant;
+}
+
 val structured_constants:
-  unit -> (string * bool * Clambda.ustructured_constant) list
+  unit -> structured_constant list
 val add_exported_constant: string -> unit
 
 type structured_constants

--- a/asmcomp/printclambda.ml
+++ b/asmcomp/printclambda.ml
@@ -24,6 +24,10 @@ let rec structured_constant ppf = function
       fprintf ppf "block(%i" tag;
       List.iter (fun u -> fprintf ppf ",%a" uconstant u) l;
       fprintf ppf ")"
+  | Uconst_mutable_block (tag, l) ->
+      fprintf ppf "block_mutable(%i" tag;
+      List.iter (fun u -> fprintf ppf ",%a" uconstant u) l;
+      fprintf ppf ")"
   | Uconst_float_array [] ->
       fprintf ppf "floatarray()"
   | Uconst_float_array (f1 :: fl) ->

--- a/asmrun/natdynlink.c
+++ b/asmrun/natdynlink.c
@@ -90,7 +90,7 @@ CAMLprim value caml_natdynlink_run(void *handle, value symbol) {
   sym = optsym("__frametable");
   if (NULL != sym) caml_register_frametable(sym);
 
-  sym = optsym("");
+  sym = optsym("__mutable_globals");
   if (NULL != sym) caml_register_dyn_global(sym);
 
   sym = optsym("__data_begin");

--- a/asmrun/roots.c
+++ b/asmrun/roots.c
@@ -132,6 +132,7 @@ value * caml_gc_regs;
 intnat caml_globals_inited = 0;
 static intnat caml_globals_scanned = 0;
 static link * caml_dyn_globals = NULL;
+static link * caml_dyn_globals_scanned = NULL;
 
 void caml_register_dyn_global(void *v) {
   caml_dyn_globals = cons((void*) v,caml_dyn_globals);
@@ -170,11 +171,13 @@ void caml_oldify_local_roots (void)
 
   /* Dynamic global roots */
   iter_list(caml_dyn_globals, lnk) {
+    if (caml_dyn_globals_scanned == lnk) break;
     glob = (value) lnk->data;
     for (j = 0; j < Wosize_val(glob); j++){
       Oldify (&Field (glob, j));
     }
   }
+  caml_dyn_globals_scanned = caml_dyn_globals;
 
   /* The stack and local roots */
   if (caml_frame_descriptors == NULL) caml_init_frame_descriptors();

--- a/asmrun/roots.c
+++ b/asmrun/roots.c
@@ -153,7 +153,7 @@ void caml_oldify_local_roots (void)
 #else
   unsigned short * p;
 #endif
-  value glob;
+  value * glob;
   value * root;
   struct caml__roots_block *lr;
   link *lnk;
@@ -162,9 +162,10 @@ void caml_oldify_local_roots (void)
   for (i = caml_globals_scanned;
        i <= caml_globals_inited && caml_globals[i] != 0;
        i++) {
-    glob = caml_globals[i];
-    for (j = 0; j < Wosize_val(glob); j++){
-      Oldify (&Field (glob, j));
+    for(glob = caml_globals[i]; *glob != 0; glob++) {
+      for (j = 0; j < Wosize_val(*glob); j++){
+        Oldify (&Field (*glob, j));
+      }
     }
   }
   caml_globals_scanned = caml_globals_inited;
@@ -172,9 +173,10 @@ void caml_oldify_local_roots (void)
   /* Dynamic global roots */
   iter_list(caml_dyn_globals, lnk) {
     if (caml_dyn_globals_scanned == lnk) break;
-    glob = (value) lnk->data;
-    for (j = 0; j < Wosize_val(glob); j++){
-      Oldify (&Field (glob, j));
+    for(glob = (value *) lnk->data; *glob != 0; glob++) {
+      for (j = 0; j < Wosize_val(*glob); j++){
+        Oldify (&Field (*glob, j));
+      }
     }
   }
   caml_dyn_globals_scanned = caml_dyn_globals;
@@ -256,21 +258,23 @@ void caml_darken_all_roots (void)
 void caml_do_roots (scanning_action f)
 {
   int i, j;
-  value glob;
+  value * glob;
   link *lnk;
 
   /* The global roots */
   for (i = 0; caml_globals[i] != 0; i++) {
-    glob = caml_globals[i];
-    for (j = 0; j < Wosize_val(glob); j++)
-      f (Field (glob, j), &Field (glob, j));
+    for(glob = caml_globals[i]; *glob != 0; glob++) {
+      for (j = 0; j < Wosize_val(*glob); j++)
+        f (Field (*glob, j), &Field (*glob, j));
+    }
   }
 
   /* Dynamic global roots */
   iter_list(caml_dyn_globals, lnk) {
-    glob = (value) lnk->data;
-    for (j = 0; j < Wosize_val(glob); j++){
-      f (Field (glob, j), &Field (glob, j));
+    for(glob = (value *) lnk->data; *glob != 0; glob++) {
+      for (j = 0; j < Wosize_val(*glob); j++){
+        f (Field (*glob, j), &Field (*glob, j));
+      }
     }
   }
 

--- a/asmrun/stack.h
+++ b/asmrun/stack.h
@@ -99,7 +99,7 @@ extern char * caml_bottom_of_stack;
 extern uintnat caml_last_return_address;
 extern value * caml_gc_regs;
 extern char * caml_exception_pointer;
-extern value caml_globals[];
+extern value * caml_globals[];
 extern intnat caml_globals_inited;
 extern intnat * caml_frametable[];
 

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -58,10 +58,12 @@ let transl_extension_constructor env path ext =
   in
   match ext.ext_kind with
     Text_decl(args, ret) ->
-      Lprim(prim_set_oo_id,
-            [Lprim(Pmakeblock(Obj.object_tag, Mutable),
-                   [Lconst(Const_base(Const_string (name,None)));
-                    Lconst(Const_base(Const_int 0))])])
+      let id = Ident.create "set_oo_id" in
+      Llet(Strict, id,
+           Lprim(Pmakeblock(Obj.object_tag, Mutable),
+                 [Lconst(Const_base(Const_string (name,None)));
+                  Lconst(Const_base(Const_int 0))]),
+           Lsequence(Lprim(prim_set_oo_id, [Lvar id]), Lvar id))
   | Text_rebind(path, lid) ->
       transl_path ~loc:ext.ext_loc env path
 

--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -47,7 +47,7 @@ parsecmm.mli parsecmm.ml: parsecmm.mly
 lexcmm.ml: lexcmm.mll
 	@$(OCAMLLEX) -q lexcmm.mll
 
-MLCASES=optargs staticalloc
+MLCASES=optargs staticalloc staticalloc_mutable
 
 CASES=fib tak quicksort quicksort2 soli \
       arith checkbound tagged-fib tagged-integr tagged-quicksort tagged-tak

--- a/testsuite/tests/asmcomp/staticalloc_mutable.ml
+++ b/testsuite/tests/asmcomp/staticalloc_mutable.ml
@@ -18,6 +18,8 @@ type stuff = {
   mutable stuff : stuff option;
 }
 
+exception Stuff of stuff
+
 let () =
   let x0 = Gc.allocated_bytes () in
   let x1 = Gc.allocated_bytes () in
@@ -31,6 +33,7 @@ let () =
   let p1 = (v, v) in
   let g () = (snd p1, fst p1) in
   assert (g () == p1);
+  try raise (Stuff v) with Stuff _ -> ();
   let x2 = Gc.allocated_bytes () in
   assert(x1 -. x0 = x2 -. x1)
      (* check that we did not allocated anything between x1 and x2 *)

--- a/testsuite/tests/asmcomp/staticalloc_mutable.ml
+++ b/testsuite/tests/asmcomp/staticalloc_mutable.ml
@@ -1,0 +1,36 @@
+(***********************************************************************)
+(*                                                                     *)
+(*                                OCaml                                *)
+(*                                                                     *)
+(*                       Pierre Chambart, OCamlPro                     *)
+(*                                                                     *)
+(*  Copyright 2015 Institut National de Recherche en Informatique et   *)
+(*  en Automatique.  All rights reserved.  This file is distributed    *)
+(*  under the terms of the Q Public License version 1.0.               *)
+(*                                                                     *)
+(***********************************************************************)
+
+(* Check the effectiveness of static allocation of toplevel mutable values. *)
+
+type stuff = {
+  mutable v : int;
+  mutable l : int list;
+  mutable stuff : stuff option;
+}
+
+let () =
+  let x0 = Gc.allocated_bytes () in
+  let x1 = Gc.allocated_bytes () in
+  let v = { v = 3; l = [1;2;3]; stuff = None } in
+  let v' = { v = 3; l = [1;2;3]; stuff = None } in
+  assert(v != v');
+  let v2 = { v = 12; l = []; stuff = Some v } in
+  v.v <- 4;
+  v.l <- [4;5];
+  v.stuff <- Some v2;
+  let p1 = (v, v) in
+  let g () = (snd p1, fst p1) in
+  assert (g () == p1);
+  let x2 = Gc.allocated_bytes () in
+  assert(x1 -. x0 = x2 -. x1)
+     (* check that we did not allocated anything between x1 and x2 *)

--- a/testsuite/tests/basic-more/mutable_sharing.ml
+++ b/testsuite/tests/basic-more/mutable_sharing.ml
@@ -1,0 +1,65 @@
+
+let r1 = ref 0
+let r2 = ref r1
+
+let () =
+  incr r1;
+  assert(! !r2 = 1)
+
+let () =
+  for i = 0 to 5 do
+    let r = ref 0 in
+    incr r;
+    assert(!r = 1);
+    r2 := r
+  done
+
+let () =
+  let i = ref 0 in
+  while !i < 5  do
+    let r = ref 0 in
+    incr r;
+    assert(!r = 1);
+    r2 := r;
+    incr i;
+  done
+
+let rec rec_test n =
+  if n > 0 then begin
+    let r = ref 0 in
+    incr r;
+    assert(!r = 1);
+    r2 := r;
+    rec_test (n-1)
+  end
+
+let f () =
+  let r = ref 0 in
+  incr r;
+  assert(!r = 1);
+  r2 := r
+
+let g () =
+  for i = 0 to 5 do
+    let r = ref 0 in
+    incr r;
+    assert(!r = 1);
+    r2 := r
+  done
+
+let h () =
+  let i = ref 0 in
+  while !i < 5  do
+    let r = ref 0 in
+    incr r;
+    assert(!r = 1);
+    r2 := r;
+    incr i;
+  done
+
+
+let () =
+  rec_test 3; rec_test 3;
+  f (); f (); f ();
+  g (); g (); g ();
+  h (); h (); h ()

--- a/testsuite/tests/basic-more/mutable_sharing.reference
+++ b/testsuite/tests/basic-more/mutable_sharing.reference
@@ -1,0 +1,2 @@
+
+All tests succeeded.


### PR DESCRIPTION
This patch modifies the runtime to allow multiple roots per compilation unit and turns some mutable allocations into structured constants. Those are recorded as roots for the GC.
The makeblock that can be statically allocated are those that are evaluated at most once. This allows some code to be allocation free (see the test https://github.com/ocaml/ocaml/blob/de65bc6e6e2e7a51a5d5b626a08f14f0d5fc16b1/testsuite/tests/asmcomp/staticalloc_mutable.ml).
In particular it allows user defined exception to behave exactly as compiler defined ones.

Note: https://github.com/ocaml/ocaml/pull/177 is included in this patch suite to avoid a increasing the cost of minor collections.
