### PR TITLE
Race condition when building ocamlbuild with massive parallelism

### DIFF
--- a/ocamlbuild/Makefile
+++ b/ocamlbuild/Makefile
@@ -125,8 +125,10 @@ ocamlbuildlib.cmxa: ocamlbuild_pack.cmx $(EXTRA_CMX)
 
 # The packs
 
-ocamlbuild_pack.cmo ocamlbuild_pack.cmi: $(PACK_CMO)
+ocamlbuild_pack.cmo: $(PACK_CMO)
 	$(OCAMLC) -pack $(PACK_CMO) -o ocamlbuild_pack.cmo
+
+ocamlbuild_pack.cmi: ocamlbuild_pack.cmo
 
 ocamlbuild_pack.cmx: $(PACK_CMX)
 	$(OCAMLOPT) -pack $(PACK_CMX) -o ocamlbuild_pack.cmx


### PR DESCRIPTION
`ocamlbuild/Makefile` had a race condition which might make the build fail occasionally.

On test machine with 16 cores, `make -j` failed once every three build.
After patch, I got 12 consecutive successful builds.
