### PR TITLE
RFC: tail recursion modulo constructors

### DIFF
--- a/driver/main.ml
+++ b/driver/main.ml
@@ -111,6 +111,7 @@ module Options = Main_args.Make_bytecomp_options (struct
   let _no_strict_formats = unset strict_formats
   let _thread = set use_threads
   let _vmthread = fun () -> fatal vmthread_removed_message
+  let _trmc = set force_trmc
   let _unboxed_types = set unboxed_types
   let _no_unboxed_types = unset unboxed_types
   let _unsafe = set unsafe

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -545,6 +545,10 @@ let mk_no_unboxed_types f =
   " unannotated unboxable types will not be unboxed (default)"
 ;;
 
+let mk_trmc f =
+  "-force-trmc", Arg.Unit f, " Rewrite all possible trmc calls"
+;;
+
 let mk_unsafe f =
   "-unsafe", Arg.Unit f,
   " Do not compile bounds checking on array and string access"
@@ -897,6 +901,7 @@ module type Common_options = sig
   val _no_strict_sequence : unit -> unit
   val _strict_formats : unit -> unit
   val _no_strict_formats : unit -> unit
+  val _trmc : unit -> unit
   val _unboxed_types : unit -> unit
   val _no_unboxed_types : unit -> unit
   val _unsafe : unit -> unit
@@ -1178,6 +1183,7 @@ struct
     mk_strict_formats F._strict_formats;
     mk_no_strict_formats F._no_strict_formats;
     mk_thread F._thread;
+    mk_trmc F._trmc;
     mk_unboxed_types F._unboxed_types;
     mk_no_unboxed_types F._no_unboxed_types;
     mk_unsafe F._unsafe;
@@ -1371,6 +1377,7 @@ struct
     mk_strict_formats F._strict_formats;
     mk_no_strict_formats F._no_strict_formats;
     mk_thread F._thread;
+    mk_trmc F._trmc;
     mk_unbox_closures F._unbox_closures;
     mk_unbox_closures_factor F._unbox_closures_factor;
     mk_inline_max_unroll F._inline_max_unroll;
@@ -1562,6 +1569,7 @@ struct
     mk_strict_formats F._strict_formats;
     mk_no_strict_formats F._no_strict_formats;
     mk_thread F._thread;
+    mk_trmc F._trmc;
     mk_unboxed_types F._unboxed_types;
     mk_no_unboxed_types F._no_unboxed_types;
     mk_unsafe_string F._unsafe_string;

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -41,6 +41,7 @@ module type Common_options = sig
   val _no_strict_sequence : unit -> unit
   val _strict_formats : unit -> unit
   val _no_strict_formats : unit -> unit
+  val _trmc : unit -> unit
   val _unboxed_types : unit -> unit
   val _no_unboxed_types : unit -> unit
   val _unsafe : unit -> unit

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -196,6 +196,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _shared () = shared := true; dlcode := true
   let _S = set keep_asm_file
   let _thread = set use_threads
+  let _trmc = set force_trmc
   let _unbox_closures = set unbox_closures
   let _unbox_closures_factor f = unbox_closures_factor := f
   let _unboxed_types = set unboxed_types

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -269,6 +269,7 @@ type function_attribute = {
   local: local_attribute;
   is_a_functor: bool;
   stub: bool;
+  trmc_candidate: bool;
 }
 
 type lambda =
@@ -346,6 +347,7 @@ let default_function_attribute = {
   local = Default_local;
   is_a_functor = false;
   stub = false;
+  trmc_candidate = false;
 }
 
 let default_stub_attribute =

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -250,6 +250,7 @@ type function_attribute = {
   local: local_attribute;
   is_a_functor: bool;
   stub: bool;
+  trmc_candidate: bool;
 }
 
 type lambda =

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -445,27 +445,29 @@ let name_of_primitive = function
   | Pint_as_pointer -> "Pint_as_pointer"
   | Popaque -> "Popaque"
 
-let function_attribute ppf { inline; specialise; local; is_a_functor; stub } =
-  if is_a_functor then
+let function_attribute ppf t =
+  if t.is_a_functor then
     fprintf ppf "is_a_functor@ ";
-  if stub then
+  if t.stub then
     fprintf ppf "stub@ ";
-  begin match inline with
+  begin match t.inline with
   | Default_inline -> ()
   | Always_inline -> fprintf ppf "always_inline@ "
   | Never_inline -> fprintf ppf "never_inline@ "
   | Unroll i -> fprintf ppf "unroll(%i)@ " i
   end;
-  begin match specialise with
+  begin match t.specialise with
   | Default_specialise -> ()
   | Always_specialise -> fprintf ppf "always_specialise@ "
   | Never_specialise -> fprintf ppf "never_specialise@ "
   end;
-  begin match local with
+  begin match t.local with
   | Default_local -> ()
   | Always_local -> fprintf ppf "always_local@ "
   | Never_local -> fprintf ppf "never_local@ "
-  end
+  end;
+  if t.trmc_candidate then
+    fprintf ppf "trmc@ "
 
 let apply_tailcall_attribute ppf tailcall =
   if tailcall then

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -444,6 +444,7 @@ let rec compile_functor mexp coercion root_path loc =
       local = Default_local;
       is_a_functor = true;
       stub = false;
+      trmc_candidate = false;
     };
     loc;
     body;

--- a/ocamldoc/odoc_args.ml
+++ b/ocamldoc/odoc_args.ml
@@ -228,6 +228,7 @@ module Options = Main_args.Make_ocamldoc_options(struct
   let _no_strict_formats = unset Clflags.strict_formats
   let _thread = set Clflags.use_threads
   let _vmthread = ignore
+  let _trmc = set Clflags.force_trmc
   let _unboxed_types = set Clflags.unboxed_types
   let _no_unboxed_types = unset Clflags.unboxed_types
   let _unsafe () = assert false

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -373,6 +373,7 @@ module Options = Main_args.Make_bytetop_options (struct
   let _no_strict_sequence = clear strict_sequence
   let _strict_formats = set strict_formats
   let _no_strict_formats = clear strict_formats
+  let _trmc = set force_trmc
   let _unboxed_types = set unboxed_types
   let _no_unboxed_types = clear unboxed_types
   let _unsafe = set unsafe

--- a/tools/ocamlcp.ml
+++ b/tools/ocamlcp.ml
@@ -95,6 +95,7 @@ module Options = Main_args.Make_bytecomp_options (struct
   let _no_strict_sequence = ignore
   let _strict_formats = ignore
   let _no_strict_formats = ignore
+  let _trmc = ignore
   let _thread = ignore
   let _vmthread = ignore
   let _unboxed_types = ignore

--- a/tools/ocamloptp.ml
+++ b/tools/ocamloptp.ml
@@ -118,6 +118,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _strict_formats = ignore
   let _no_strict_formats = ignore
   let _shared = ignore
+  let _trmc = ignore
   let _thread = ignore
   let _unbox_closures = ignore
   let _unbox_closures_factor = ignore
@@ -135,7 +136,6 @@ module Options = Main_args.Make_optcomp_options (struct
   let _color = ignore
   let _error_style = ignore
   let _where = ignore
-
   let _linscan = ignore
   let _nopervasives = ignore
   let _match_context_rows = ignore

--- a/toplevel/topmain.ml
+++ b/toplevel/topmain.ml
@@ -130,6 +130,7 @@ module Options = Main_args.Make_bytetop_options (struct
   let _no_strict_sequence = clear strict_sequence
   let _strict_formats = set strict_formats
   let _no_strict_formats = clear strict_formats
+  let _trmc = set force_trmc
   let _unboxed_types = set unboxed_types
   let _no_unboxed_types = clear unboxed_types
   let _unsafe = set unsafe

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -135,6 +135,7 @@ let debug_runavail = ref false          (* -drunavail *)
 
 let native_code = ref false             (* set to true under ocamlopt *)
 
+let force_trmc = ref false              (* -trmc *)
 let force_slash = ref false             (* for ocamldep *)
 let clambda_checks = ref false          (* -clambda-checks *)
 

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -186,6 +186,7 @@ val dlcode : bool ref
 val pic_code : bool ref
 val runtime_variant : string ref
 val with_runtime : bool ref
+val force_trmc : bool ref
 val force_slash : bool ref
 val keep_docs : bool ref
 val keep_locs : bool ref

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -93,6 +93,9 @@ type t =
   | Unsafe_without_parsing                  (* 64 *)
   | Redefining_unit of string               (* 65 *)
   | Unused_open_bang of string              (* 66 *)
+  | Invalid_trmc_attribute                  (* 67 *)
+  | Unused_trmc_attribute                   (* 68 *)
+  | Potential_trmc_call                     (* 69 *)
 ;;
 
 type alert = {kind:string; message:string; def:loc; use:loc}


### PR DESCRIPTION
This pull request introduces tail-recursion modulo constructor, which allows to write
a version `List.map` that is both tail-recursive and natural.
## Using TRMC

Getting the benefits of TRMC is opt-in.  Since it turns stack allocation into mutation and heap-allocation, it might have an impact on the program profile.

However, because of the nature of TRMC mutations, they almost never cross heaps and stay in the fast-path (I don't have recent benchmarks yet, but the performance cost, if any is negligible).
### Attributes

A few syntaxes have been tried, the two most satisfying ones are:
- annotating bindings

``` ocaml
let rec map f = function
 | [] -> []
 | x :: xs ->
   let y = f x in
   y :: map f xs
 [@@trmc]
```
- annotating patterns

``` ocaml
let rec map[@trmc] f = function
 | [] -> []
 | x :: xs ->
   let y = f x in
   y :: map f xs
```

The first one applies only to global bindings (item attributes are not yet allowed on local-let). 
The second one required updating the parser, as attributes were not allowed on the identifier of function binding, and proved quite tricky. It is the one implemented in current revision.

Finally, the `-force-trmc` flags enable automatic rewriting of calls to trmc style.
## TRMC cases

TRMC applies to all tail-positions consisting of value constructors, possibly nested, applied to the result of a recursive call to a "trmc candidate", that is a recursive function being defined which have the `[@trmc]` attribute specified above.

Examples:
- `y :: map f xs` from above,
- `y :: z :: map f xs` would qualify also
- in case of ambiguity, for instance when mapping both subtrees of a tree,
  e.g. `Node (l,r) -> Node (tree_map f l, tree_map f r)`, one of the call will
  be rewritten in TRMC style but which one is not specified.

In the last case, use an explicit let-binding to enforce the order. TRMC rewritting won't cross let-bindings, so

``` ocaml
let l = tree_map f l in
let r = tree_map f r in
Node (l, r)
```

will disable TRMC.

``` ocaml
let l = tree_map f l in
Node (l, tree_map f r)
```

will force TRMC on the right subtree.

Also, you shouldn't rely on the evaluation order in the expression in tail-position, as trmc rewritting might change the ordering (trmc call evaluated last).  But since afaik evaluation order of arguments is not strongly specified in OCaml, it should already be the case.
## Warnings

Three new warnings are introduced:
- 51, `[@trmc]` attribute on a function which doesn't satisfy trmc requirements
- 52, `[@trmc]` attribute on a function which is never applied in trmc position
- 53, a call has been detected to be in trmc-position, the function could benefit of `[@trmc]` attribute (useful to detect trmc opportunities in existing code base).

However, in the last case, making this a warning is not satisfying, as plenty of codes with `-warn-error A` will break.
## Cons

There are a few cases where observable behavior will change or break.

When using delim-cc or hansei.  Since the continuation captures the stack and not the heap, and trmc move values to the heap and out of the stack really early, one will be able to observe values getting mutated.  TRMC shouldn't be used in such cases.

It is unclear how TRMC will behave with multicore GCs and alternative runtimes (like js_of_ocaml, although it is more likely to be fine).  The mutations introduced will touch values which are not expected to be mutated.
As far as OCaml semantics and the classic OCaml runtime are concerned, this is fine since these values are not observable.  But different runtimes might have different expectations.

`let rec l = 1 :: l in map succ l` might prove to be a bit memory hungry instead of failing quickly.
