### PR TITLE
Support lazy local let-bindings.

### DIFF
--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -83,7 +83,7 @@ module Exp = struct
 
   let ident ?loc ?attrs a = mk ?loc ?attrs (Pexp_ident a)
   let constant ?loc ?attrs a = mk ?loc ?attrs (Pexp_constant a)
-  let let_ ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_let (a, b, c))
+  let let_ ?loc ?attrs a b c d = mk ?loc ?attrs (Pexp_let (a, b, c, d))
   let fun_ ?loc ?attrs a b c d = mk ?loc ?attrs (Pexp_fun (a, b, c, d))
   let function_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_function a)
   let apply ?loc ?attrs a b = mk ?loc ?attrs (Pexp_apply (a, b))

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -91,7 +91,7 @@ module Exp:
 
     val ident: ?loc:loc -> ?attrs:attrs -> lid -> expression
     val constant: ?loc:loc -> ?attrs:attrs -> constant -> expression
-    val let_: ?loc:loc -> ?attrs:attrs -> rec_flag -> value_binding list
+    val let_: ?loc:loc -> ?attrs:attrs -> rec_flag -> bool -> value_binding list
               -> expression -> expression
     val fun_: ?loc:loc -> ?attrs:attrs -> arg_label -> expression option -> pattern
               -> expression -> expression

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -315,8 +315,8 @@ module E = struct
     match desc with
     | Pexp_ident x -> ident ~loc ~attrs (map_loc sub x)
     | Pexp_constant x -> constant ~loc ~attrs x
-    | Pexp_let (r, vbs, e) ->
-        let_ ~loc ~attrs r (List.map (sub.value_binding sub) vbs)
+    | Pexp_let (r, l, vbs, e) ->
+        let_ ~loc ~attrs r l (List.map (sub.value_binding sub) vbs)
           (sub.expr sub e)
     | Pexp_fun (lab, def, p, e) ->
         fun_ ~loc ~attrs lab (map_opt (sub.expr sub) def) (sub.pat sub p)

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -352,7 +352,7 @@ let val_of_let_bindings lbs =
       | None -> str
       | Some id -> ghstr (Pstr_extension((id, PStr [str]), []))
 
-let expr_of_let_bindings lbs body =
+let expr_of_let_bindings lzy lbs body =
   let bindings =
     List.map
       (fun lb ->
@@ -361,7 +361,7 @@ let expr_of_let_bindings lbs body =
          Vb.mk ~loc:lb.lb_loc lb.lb_pattern lb.lb_expression)
       lbs.lbs_bindings
   in
-    mkexp_attrs (Pexp_let(lbs.lbs_rec, List.rev bindings, body))
+    mkexp_attrs (Pexp_let(lbs.lbs_rec, lzy, List.rev bindings, body))
       (lbs.lbs_extension, lbs.lbs_attributes)
 
 let class_of_let_bindings lbs body =
@@ -1190,7 +1190,9 @@ expr:
   | simple_expr simple_labeled_expr_list
       { mkexp(Pexp_apply($1, List.rev $2)) }
   | let_bindings IN seq_expr
-      { expr_of_let_bindings $1 $3 }
+      { expr_of_let_bindings false $1 $3 }
+  | LAZY let_bindings IN seq_expr
+      { expr_of_let_bindings true $2 $4 }
   | LET MODULE ext_attributes UIDENT module_binding_body IN seq_expr
       { mkexp_attrs (Pexp_letmodule(mkrhs $4 4, $5, $7)) $3 }
   | LET OPEN override_flag ext_attributes mod_longident IN seq_expr

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -213,9 +213,11 @@ and expression_desc =
          *)
   | Pexp_constant of constant
         (* 1, 'a', "true", 1.0, 1l, 1L, 1n *)
-  | Pexp_let of rec_flag * value_binding list * expression
-        (* let P1 = E1 and ... and Pn = EN in E       (flag = Nonrecursive)
-           let rec P1 = E1 and ... and Pn = EN in E   (flag = Recursive)
+  | Pexp_let of rec_flag * bool * value_binding list * expression
+        (* let P1 = E1 and ... and Pn = EN in E       (Nonrecursive, false)
+           let rec P1 = E1 and ... and Pn = EN in E   (Recursive, false)
+           lazy let  ... in E                         (Nonrecursive, true)
+           lazy let rec ... in E                      (Recursive, true)
          *)
   | Pexp_function of case list
         (* function P1 -> E1 | ... | Pn -> En *)

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -531,10 +531,11 @@ class printer  ()= object(self:'self)
     | Pexp_try (e, l) ->
         pp f "@[<0>@[<hv2>try@ %a@]@ @[<0>with%a@]@]" (* "try@;@[<2>%a@]@\nwith@\n%a"*)
           self#reset#expression e  self#case_list l
-    | Pexp_let (rf, l, e) ->
+    | Pexp_let (rf, lf, l, e) ->
         (* pp f "@[<2>let %a%a in@;<1 -2>%a@]" (\*no identation here, a new line*\) *)
         (*   self#rec_flag rf *)
-        pp f "@[<2>%a in@;<1 -2>%a@]"
+        pp f "@[<2>%s%a in@;<1 -2>%a@]"
+          (if lf then "lazy " else "")
           self#reset#bindings (rf,l)
           self#expression e
     | Pexp_apply (e, l) ->

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -247,8 +247,8 @@ and expression i ppf x =
   match x.pexp_desc with
   | Pexp_ident (li) -> line i ppf "Pexp_ident %a\n" fmt_longident_loc li;
   | Pexp_constant (c) -> line i ppf "Pexp_constant %a\n" fmt_constant c;
-  | Pexp_let (rf, l, e) ->
-      line i ppf "Pexp_let %a\n" fmt_rec_flag rf;
+  | Pexp_let (rf, lf, l, e) ->
+      line i ppf "Pexp_let %a%s\n" fmt_rec_flag rf (if lf then " lazy" else "");
       list i value_binding ppf l;
       expression i ppf e;
   | Pexp_function l ->

--- a/tools/depend.ml
+++ b/tools/depend.ml
@@ -154,7 +154,7 @@ let rec add_expr bv exp =
   match exp.pexp_desc with
     Pexp_ident l -> add bv l
   | Pexp_constant _ -> ()
-  | Pexp_let(rf, pel, e) ->
+  | Pexp_let(rf, _lf, pel, e) ->
       let bv = add_bindings rf bv pel in add_expr bv e
   | Pexp_fun (_, opte, p, e) ->
       add_opt add_expr bv opte; add_expr (add_pattern bv p) e

--- a/tools/ocamlprof.ml
+++ b/tools/ocamlprof.ml
@@ -176,7 +176,7 @@ and rw_exp iflag sexp =
     Pexp_ident _lid -> ()
   | Pexp_constant _cst -> ()
 
-  | Pexp_let(_, spat_sexp_list, sbody) ->
+  | Pexp_let(_rf, _lf, spat_sexp_list, sbody) ->
     rewrite_patexp_list iflag spat_sexp_list;
     rewrite_exp iflag sbody
 

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -113,6 +113,7 @@ type error =
   | No_value_clauses
   | Exception_pattern_below_toplevel
   | Inlined_record_escape
+  | Lazy_let_complex_pattern
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -92,6 +92,7 @@ type value_description =
 
 and value_kind =
     Val_reg                             (* Regular value *)
+  | Val_lazy                            (* Lazy value *)
   | Val_prim of Primitive.description   (* Primitive *)
   | Val_ivar of mutable_flag * string   (* Instance variable (mutable ?) *)
   | Val_self of (Ident.t * type_expr) Meths.t ref *

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -90,6 +90,7 @@ type value_description =
 
 and value_kind =
     Val_reg                             (* Regular value *)
+  | Val_lazy                            (* Lazy value *)
   | Val_prim of Primitive.description   (* Primitive *)
   | Val_ivar of mutable_flag * string   (* Instance variable (mutable ?) *)
   | Val_self of (Ident.t * type_expr) Meths.t ref *

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -347,7 +347,7 @@ let expression sub exp =
       Texp_ident (_path, lid, _) -> Pexp_ident (map_loc sub lid)
     | Texp_constant cst -> Pexp_constant cst
     | Texp_let (rec_flag, list, exp) ->
-        Pexp_let (rec_flag,
+        Pexp_let (rec_flag, false,
           List.map (sub.value_binding sub) list,
           sub.expr sub exp)
 


### PR DESCRIPTION
This is a proposal to add lazy local let-bindings to OCaml.  We have been using this extension at LexiFi for years and are quite happy with it.  See:

 http://www.lexifi.com/blog/ocaml-extensions-lexifi-semi-implicit-laziness

One could argue that introducing implicit elimination of laziness hampers program readability, but this specific proposal keeps an explicit "lazy" keyword on the introduction site, and is restricted to local bindings, so the elimination remains quite "close" to the introduction.

Concretely, this PR adds support for a new form a local let-binding:

``` ocaml
lazy let x = e in body
```

(multiple and/or recursive bindings are allowed as well, but only simple variable patterns are allowed -- at least for now).

which behaves as:

``` ocaml
let x = lazy e' in body'
```

where occurrences of `x` in `body` are replaced by `Lazy.force x` in `body'` (and also to produce `e'` from `e` in case of a `let rec`).

A typical use case is to relax restrictions on recursive let bindings, for instance in the definition of GUI components where callback are attached on upon creation:

``` ocaml
  lazy let rec b = button "Run" ~onclick:(fun () -> b # disable; ...) in
  hbox [ label "..."; b ]
```

Without lazy bindings, one could write

``` ocaml
  let rec b = lazy (button "Run" ~onclick:(fun () -> (Lazy.force b) # disable; ...)) in
  hbox [ label "..."; Lazy.force b ]
```

but this is so heavy that this would discourage using this style of API in favor of a less functional approach (with callbacks attached as side-effects).

The implementation is quite light:  a new kind of value `Val_lazy` is used in place of `Val_reg` for local identifiers bound with a `lazy let`; the bound expression are type-checked by inserting a `lazy` on top of them; when a value identifier `x` refers to a lazy value, it is type-checked again as `Lazy.force x`, with an updated environment where `x` has kind `Val_reg`.  Consequently, the resulting Typedtree is the same as would be obtained by the manual expansion (explicit `lazy` and `Lazy.force`, no `Val_reg` in Texp_ident nodes), and the code generator is untouched.
