### PR TITLE
Warning doesn't say which labels were omitted

### DIFF
--- a/testsuite/tests/warnings/w06.ml
+++ b/testsuite/tests/warnings/w06.ml
@@ -1,0 +1,6 @@
+let foo ~bar = () (* one label *)
+
+let bar ~foo ~baz = () (* two labels *)
+
+let _ = foo 2
+let _ = bar 4 2

--- a/testsuite/tests/warnings/w06.reference
+++ b/testsuite/tests/warnings/w06.reference
@@ -1,0 +1,4 @@
+File "w06.ml", line 5, characters 8-11:
+Warning 6: label bar was omitted in the application of this function.
+File "w06.ml", line 6, characters 8-11:
+Warning 6: labels foo, baz were omitted in the application of this function.

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1004,7 +1004,11 @@ and class_expr cl_num val_env met_env scl =
         List.for_all (fun (l,_) -> l = Nolabel) sargs &&
         List.exists (fun l -> l <> Nolabel) labels &&
         begin
-          Location.prerr_warning cl.cl_loc Warnings.Labels_omitted;
+          Location.prerr_warning
+	    cl.cl_loc
+	    (Warnings.Labels_omitted
+	       (List.map Printtyp.string_of_label
+			 (List.filter ((<>) Nolabel) labels)));
           true
         end
       in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3273,7 +3273,11 @@ and type_application env funct sargs =
       List.length labels = List.length sargs &&
       List.for_all (fun (l,_) -> l = Nolabel) sargs &&
       List.exists (fun l -> l <> Nolabel) labels &&
-      (Location.prerr_warning funct.exp_loc Warnings.Labels_omitted;
+      (Location.prerr_warning
+	 funct.exp_loc
+	 (Warnings.Labels_omitted
+	    (List.map Printtyp.string_of_label
+		      (List.filter ((<>) Nolabel) labels)));
        true)
     end
   in

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -23,7 +23,7 @@ type t =
   | Deprecated of string                    (*  3 *)
   | Fragile_match of string                 (*  4 *)
   | Partial_application                     (*  5 *)
-  | Labels_omitted                          (*  6 *)
+  | Labels_omitted of string list           (*  6 *)
   | Method_override of string list          (*  7 *)
   | Partial_match of string                 (*  8 *)
   | Non_closed_record_pattern of string     (*  9 *)
@@ -82,7 +82,7 @@ let number = function
   | Deprecated _ -> 3
   | Fragile_match _ -> 4
   | Partial_application -> 5
-  | Labels_omitted -> 6
+  | Labels_omitted _ -> 6
   | Method_override _ -> 7
   | Partial_match _ -> 8
   | Non_closed_record_pattern _ -> 9
@@ -260,8 +260,13 @@ let message = function
   | Partial_application ->
       "this function application is partial,\n\
        maybe some arguments are missing."
-  | Labels_omitted ->
-      "labels were omitted in the application of this function."
+  | Labels_omitted [] -> assert false
+  | Labels_omitted [l] ->
+     "label " ^ l ^ " was omitted in the application of this function."
+  | Labels_omitted (l :: ls) ->
+     "labels " ^
+       List.fold_left (fun a b -> a ^ ", " ^ b) l ls ^
+       " were omitted in the application of this function." 
   | Method_override [lab] ->
       "the method " ^ lab ^ " is overridden."
   | Method_override (cname :: slist) ->

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -263,9 +263,8 @@ let message = function
   | Labels_omitted [] -> assert false
   | Labels_omitted [l] ->
      "label " ^ l ^ " was omitted in the application of this function."
-  | Labels_omitted (l :: ls) ->
-     "labels " ^
-       List.fold_left (fun a b -> a ^ ", " ^ b) l ls ^
+  | Labels_omitted ls ->
+     "labels " ^ String.concat ", " ls ^
        " were omitted in the application of this function." 
   | Method_override [lab] ->
       "the method " ^ lab ^ " is overridden."

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -18,7 +18,7 @@ type t =
   | Deprecated of string                    (*  3 *)
   | Fragile_match of string                 (*  4 *)
   | Partial_application                     (*  5 *)
-  | Labels_omitted                          (*  6 *)
+  | Labels_omitted of string list           (*  6 *)
   | Method_override of string list          (*  7 *)
   | Partial_match of string                 (*  8 *)
   | Non_closed_record_pattern of string     (*  9 *)


### PR DESCRIPTION
A modest proposal to http://caml.inria.fr/mantis/view.php?id=6876.

``` ocaml
(* -w +6 *)
let foo ~bar = ()
(* Warning 6: label bar was omitted in the application of this function. *)
let bar ~foo ~baz = ()
(* Warning 6: labels foo, baz were omitted in the application of this function. *)
```

Maybe warning 6 should also give label's type ?
