### PR TITLE
Local open in patterns

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,10 @@ OCaml 4.04.0:
 
 ### Language features:
 
+- GPR#187: Local opening of modules in a pattern.
+  Syntax: "M.(p)", "M.[p]","M.[| p |]", "M.{p}"
+  (Florian Angeletti)
+
 - GPR#301: local exception declarations "let exception ... in"
   (Alain Frisch)
 

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -385,30 +385,36 @@ is not inferred, and must be given explicitly.
 \ikwd{let\@\texttt{let}}
 \ikwd{open\@\texttt{open}}
 
-(Introduced in OCaml 3.12)
+(Introduced in OCaml 3.12, extended to patterns in 4.03)
 
 \begin{syntax}
 expr:
        ...
      | "let" "open" module-path "in" expr
      | module-path '.(' expr ')'
+;
+pattern:
+       ...
+     | module-path '.(' pattern ')'
 \end{syntax}
 
 The expressions
 @"let" "open" module-path "in" expr@
 and
-@module-path'.('expr')'@ are strictly equivalent. They
-locally open the module referred to by the module path @module-path@ in
-the scope of the expression @expr@.
+@module-path'.('expr')'@ are strictly equivalent. On the pattern side,
+only the pattern @module-path'.('pattern')'@ is available. These
+constructions locally open the module referred to by the module path
+@module-path@ in the respective scope of the expression @expr@ or
+pattern @pattern@.
 
-Restricting opening to the scope of a single expression instead of a
-whole structure allows one to benefit from shorter syntax to refer to
-components of the opened module, without polluting the global
-scope. Also, this can make the code easier to read (the open statement is
-closer to where it is used) and to refactor (because the code
-fragment is more self-contained).
+Restricting opening to the scope of a single expression or pattern
+instead of a whole structure allows one to benefit from shorter syntax
+to refer to components of the opened module, without polluting the
+global scope. Also, this can make the code easier to read (the open
+statement is closer to where it is used) and to refactor (because the
+code fragment is more self-contained).
 
-\paragraph{Local opens for delimited expressions} (Introduced in OCaml 4.02)
+\paragraph{Local opens for delimited expressions or patterns} (Introduced in OCaml 4.02)
 
 \begin{syntax}
 expr:
@@ -417,9 +423,20 @@ expr:
      | module-path '.[|' expr '|]'
      | module-path '.{' expr '}'
      | module-path '.{<' expr '>}'
+;
+pattern:
+       ...
+     | module-path '.[' pattern ']'
+     | module-path '.[|' pattern '|]'
+     | module-path '.{' pattern '}'
 \end{syntax}
 
-When the body of a local open expression is delimited by @'[' ']'@,  @'[|' '|]'@,  @'{' '}'@, or @'{<' '>}'@, the parentheses can be omitted.  For example, @module-path'.['expr']'@ is equivalent to @module-path'.(['expr'])'@, and @module-path'.[|' expr '|]'@ is equivalent to @module-path'.([|' expr '|])'@.
+When the body of a local open expression or pattern is delimited by
+@'[' ']'@,  @'[|' '|]'@,  or @'{' '}'@, the parentheses can be omitted.
+For expression, parentheses can also be omitted for @'{<' '>}'@.
+For example, @module-path'.['expr']'@ is equivalent to
+@module-path'.(['expr'])'@, and @module-path'.[|' pattern '|]'@ is
+equivalent to @module-path'.([|' pattern '|])'@.
 
 \section{Record and object notations}
 

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -87,6 +87,7 @@ module Pat = struct
   let type_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_type a)
   let lazy_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_lazy a)
   let unpack ?loc ?attrs a = mk ?loc ?attrs (Ppat_unpack a)
+  let open_ ?loc ?attrs a b = mk ?loc ?attrs (Ppat_open (a, b))
   let exception_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_exception a)
   let extension ?loc ?attrs a = mk ?loc ?attrs (Ppat_extension a)
 end

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -97,6 +97,7 @@ module Pat:
     val type_: ?loc:loc -> ?attrs:attrs -> lid -> pattern
     val lazy_: ?loc:loc -> ?attrs:attrs -> pattern -> pattern
     val unpack: ?loc:loc -> ?attrs:attrs -> str -> pattern
+    val open_: ?loc:loc -> ?attrs:attrs  -> lid -> pattern -> pattern
     val exception_: ?loc:loc -> ?attrs:attrs -> pattern -> pattern
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> pattern
   end

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -398,6 +398,9 @@ module P = struct
     | Ppat_unpack s -> iter_loc sub s
     | Ppat_exception p -> sub.pat sub p
     | Ppat_extension x -> sub.extension sub x
+    | Ppat_open (lid, p) ->
+        iter_loc sub lid; sub.pat sub p
+
 end
 
 module CE = struct

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -414,6 +414,7 @@ module P = struct
     | Ppat_type s -> type_ ~loc ~attrs (map_loc sub s)
     | Ppat_lazy p -> lazy_ ~loc ~attrs (sub.pat sub p)
     | Ppat_unpack s -> unpack ~loc ~attrs (map_loc sub s)
+    | Ppat_open (lid,p) -> open_ ~loc ~attrs (map_loc sub lid) (sub.pat sub p)
     | Ppat_exception p -> exception_ ~loc ~attrs (sub.pat sub p)
     | Ppat_extension x -> extension ~loc ~attrs (sub.extension sub x)
 end

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -200,6 +200,7 @@ let rec add_pattern bv pat =
   | Ppat_type li -> add bv li
   | Ppat_lazy p -> add_pattern bv p
   | Ppat_unpack id -> pattern_bv := StringMap.add id.txt bound !pattern_bv
+  | Ppat_open ( m, p) -> let bv = open_module bv m.txt in add_pattern bv p
   | Ppat_exception p -> add_pattern bv p
   | Ppat_extension e -> handle_extension e
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1751,6 +1751,12 @@ pattern:
       { expecting 3 "pattern" }
   | EXCEPTION ext_attributes pattern %prec prec_constr_appl
       { mkpat_attrs (Ppat_exception $3) $2}
+  | mod_longident DOT LPAREN pattern RPAREN
+    { mkpat @@ Ppat_open (mkrhs $1 1, $4)}
+  | mod_longident DOT LPAREN pattern error
+    {unclosed "(" 3 ")" 5  }
+  | mod_longident DOT LPAREN error
+    { expecting 4 "pattern" }
   | pattern attribute
       { Pat.attr $1 $2 }
   | pattern_gen { $1 }
@@ -1806,20 +1812,19 @@ simple_pattern_not_ident:
       { mkpat(Ppat_variant($1, None)) }
   | SHARP type_longident
       { mkpat(Ppat_type (mkrhs $2 2)) }
-  | LBRACE lbl_pattern_list RBRACE
-      { let (fields, closed) = $2 in mkpat(Ppat_record(fields, closed)) }
-  | LBRACE lbl_pattern_list error
-      { unclosed "{" 1 "}" 3 }
-  | LBRACKET pattern_semi_list opt_semi RBRACKET
-      { reloc_pat (mktailpat (rhs_loc 4) (List.rev $2)) }
-  | LBRACKET pattern_semi_list opt_semi error
-      { unclosed "[" 1 "]" 4 }
-  | LBRACKETBAR pattern_semi_list opt_semi BARRBRACKET
-      { mkpat(Ppat_array(List.rev $2)) }
-  | LBRACKETBAR BARRBRACKET
-      { mkpat(Ppat_array []) }
-  | LBRACKETBAR pattern_semi_list opt_semi error
-      { unclosed "[|" 1 "|]" 4 }
+  | simple_delimited_pattern
+      { $1 }
+  | mod_longident DOT simple_delimited_pattern
+      { mkpat @@ Ppat_open(mkrhs $1 1, $3) }
+  | mod_longident DOT LPAREN RPAREN
+      { mkpat @@ Ppat_open( mkrhs $1 1, mkpat @@
+                 Ppat_construct ( mkrhs (Lident "()") 4, None) ) }
+  | mod_longident DOT LPAREN pattern RPAREN
+      { mkpat @@ Ppat_open (mkrhs $1 1, $4)}
+  | mod_longident DOT LPAREN pattern error
+      {unclosed "(" 3 ")" 5  }
+  | mod_longident DOT LPAREN error
+      { expecting 4 "pattern" }
   | LPAREN pattern RPAREN
       { reloc_pat $2 }
   | LPAREN pattern error
@@ -1842,6 +1847,25 @@ simple_pattern_not_ident:
   | extension
       { mkpat(Ppat_extension $1) }
 ;
+simple_delimited_pattern:
+  | LBRACE lbl_pattern_list RBRACE
+    { let (fields, closed) = $2 in mkpat(Ppat_record(fields, closed)) }
+  | LBRACE lbl_pattern_list error
+    { unclosed "{" 1 "}" 3 }
+  | LBRACE lbl_pattern_list error
+    { unclosed "{" 1 "}" 3 }
+  | LBRACKET pattern_semi_list opt_semi RBRACKET
+    { reloc_pat (mktailpat (rhs_loc 4) (List.rev $2)) }
+  | LBRACKET RBRACKET
+    { mkpat @@ Ppat_construct ( mkrhs (Lident "[]") 1, None) }
+  | LBRACKET pattern_semi_list opt_semi error
+    { unclosed "[" 1 "]" 4 }
+  | LBRACKETBAR pattern_semi_list opt_semi BARRBRACKET
+    { mkpat(Ppat_array(List.rev $2)) }
+  | LBRACKETBAR BARRBRACKET
+    { mkpat(Ppat_array []) }
+  | LBRACKETBAR pattern_semi_list opt_semi error
+    { unclosed "[|" 1 "|]" 4 }
 
 pattern_comma_list:
     pattern_comma_list COMMA pattern            { $3 :: $1 }

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -220,6 +220,7 @@ and pattern_desc =
         (* exception P *)
   | Ppat_extension of extension
         (* [%id] *)
+  | Ppat_open of Longident.t loc * pattern
 
 (* Value expressions *)
 

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -238,6 +238,9 @@ and pattern i ppf x =
   | Ppat_exception p ->
       line i ppf "Ppat_exception\n";
       pattern i ppf p
+  | Ppat_open (m,p) ->
+      line i ppf "Ppat_open \"%a\"\n" fmt_longident_loc m;
+      pattern i ppf p
   | Ppat_extension (s, arg) ->
       line i ppf "Ppat_extension \"%s\"\n" s.txt;
       payload i ppf arg

--- a/testsuite/tests/pattern_open/Makefile
+++ b/testsuite/tests/pattern_open/Makefile
@@ -1,0 +1,3 @@
+BASEDIR=../..
+include $(BASEDIR)/makefiles/Makefile.toplevel
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/pattern_open/pattern_open.ml
+++ b/testsuite/tests/pattern_open/pattern_open.ml
@@ -1,0 +1,144 @@
+let pp fmt = Printf.printf fmt
+
+type 'a box = B of 'a
+(* Basic tests *)
+module M = struct
+	type c = C
+	type t = {x : c box }
+end
+;;
+module N = struct
+  type d = D
+  let d = D
+  type t = {x: d box}
+end
+open N
+;;
+let f M.{ x=B C } y  = M.C,y
+;;
+let g M.(x) M.(w) = x * w
+;;
+let g = function
+  | M.[] -> []
+  | M.[C] -> M.[C]
+  | _ -> []
+;;
+let h = function
+  | M.[||] -> None
+  | M.[| C |] -> Some M.C
+  | _ -> None
+;;
+let f2 = function
+  | M.( B (B C) ) -> M.C
+;;
+
+;;
+(* () constructor *)
+let M.() = ()
+;;
+(* Pattern open separation*)
+module L = struct
+  type _ c = C : unit c
+  type t = { t : unit c }
+  type r = { r : unit c }
+  let x ()= pp "Wrong value L.x\n"
+end
+;;
+module K = struct
+  type _ c = C : unit c
+  type t = { t : unit c }
+  type r = { r : unit c }
+  let x ()= pp "Right value K.x\n"
+end
+;;
+let () =
+  let test =
+  let open K in
+  function
+  | L.{t}, ({r=C} : K.r)  -> x ()
+  in
+  test (L.{t=C}, K.{r=C})
+;;
+module Exterior = struct
+module Gadt = struct
+module Boolean = struct
+  type t = { b : bool }
+  type wrong = false | true
+  let print () = pp "Wrong function: Exterior.Gadt.Boolean.print\n"
+end
+
+type _ t =
+  | Bool : Boolean.t -> bool t
+  | Int : int -> int t
+  | Eq : 'a t * 'a t -> bool t
+
+let print () = pp "Wrong function: Exterior.Gadt.print\n"
+end
+let print () = pp "Wrong function: Exterior.print\n"
+end
+;;
+let rec eval: type t. t Exterior.Gadt.t -> t = function
+  | Exterior.( Gadt.( Eq (a,b) ) ) -> (eval a) = (eval b)
+  | Exterior.( Gadt.( Bool Boolean.{b} ) ) -> b
+  | Exterior.Gadt.( Int n ) -> n
+let () =
+  let print () = pp "Right function print\n" in
+  let choose (type a):a Exterior.Gadt.t * a Exterior.Gadt.t -> a -> a = fun (a,b) c ->
+  match a, b, c with
+  | Exterior.( Gadt.( Bool Boolean.{b} ), Gadt.Bool _ , _ ) -> print(); true
+  | Exterior.(Gadt.Bool Gadt.Boolean.{b}), _ , true -> print(); true
+  | Exterior.(Gadt.Bool Gadt.Boolean.{b}), _ , false -> print(); b
+  | Exterior.Gadt.( Int n, Int k, 0 ) -> print(); 0
+  | Exterior.( Gadt.(Int n, Gadt.Int k, l) ) -> print(); k+n+l
+  | Exterior.Gadt.( Eq (a,b) ), _,  true -> print(); true
+  | Exterior.(Gadt.( Eq (a,b), _ ,  false )) -> print(); eval a = eval b in
+  let _ = choose Exterior.Gadt.(Bool Boolean.{b=true}, Bool Boolean.{b=false}) false in
+  print ()
+;;
+(* existential type *)
+module Existential = struct
+type printable = E : 'a * ('a -> unit) -> printable
+end
+
+let rec print: Existential.printable -> unit  = function
+  | Existential.( E(x, print) ) -> print x
+;;
+(* Test that constructors and variables introduced in scope inside M.(..) are not
+propagated outside of M.(..) *)
+module S = struct
+type 'a t = Sep : unit t
+type ex = Ex: 'a * 'a -> ex
+let s = Sep
+end
+;;
+let test_separation = function
+  | S.(Sep), (S.(Sep,Sep), Sep) -> ()
+;;
+let test_separation_2 = function
+  | S.(Ex(a,b)), Ex(c,d) -> ()
+;;
+let test_separation_3 = function
+  | S.(Sep) -> s
+;;
+
+(* Testing interaction of local open in pattern and backtracking *)
+module PR6437 = struct
+  module Ctx = struct
+  type ('a, 'b) t =
+    | Nil : (unit, unit) t
+    | Cons : ('a, 'b) t -> ('a * unit, 'b * unit) t
+  end
+
+  module Var = struct
+  type 'a t =
+    | O : ('a * unit) t
+    | S : 'a t -> ('a * unit) t
+  end
+end
+
+let rec f : type g1 g2. (g1, g2) PR6437.Ctx.t * g1 PR6437.Var.t
+  -> g2 PR6437.Var.t = function
+    | PR6437.( Ctx.(Cons g), Var.(O) ) -> PR6437.Var.O
+    | PR6437.( Ctx.(Cons g), Var.(S n) ) -> PR6437.Var.S (f (g, n))
+    | _ -> .
+;;

--- a/testsuite/tests/pattern_open/pattern_open.ml.reference
+++ b/testsuite/tests/pattern_open/pattern_open.ml.reference
@@ -1,0 +1,81 @@
+
+#                 val pp : ('a, out_channel, unit) format -> 'a = <fun>
+type 'a box = B of 'a
+module M : sig type c = C type t = { x : c box; } end
+#             module N : sig type d = D val d : d type t = { x : d box; } end
+#   val f : M.t -> 'a -> M.c * 'a = <fun>
+#   val g : int -> int -> int = <fun>
+#         val g : M.c list -> M.c list = <fun>
+#         val h : M.c array -> M.c option = <fun>
+#     val f2 : M.c box box -> M.c = <fun>
+#   #     #               module L :
+  sig
+    type _ c = C : unit c
+    type t = { t : unit c; }
+    type r = { r : unit c; }
+    val x : unit -> unit
+  end
+#             module K :
+  sig
+    type _ c = C : unit c
+    type t = { t : unit c; }
+    type r = { r : unit c; }
+    val x : unit -> unit
+  end
+#               Right value K.x
+#                                   module Exterior :
+  sig
+    module Gadt :
+      sig
+        module Boolean :
+          sig
+            type t = { b : bool; }
+            type wrong = false | true
+            val print : unit -> unit
+          end
+        type _ t =
+            Bool : Boolean.t -> bool t
+          | Int : int -> int t
+          | Eq : 'a t * 'a t -> bool t
+        val print : unit -> unit
+      end
+    val print : unit -> unit
+  end
+#                                   Right function print
+Right function print
+val eval : 't Exterior.Gadt.t -> 't = <fun>
+#               module Existential :
+  sig type printable = E : 'a * ('a -> unit) -> printable end
+val print : Existential.printable -> unit = <fun>
+# *             module S :
+  sig
+    type 'a t = Sep : unit t
+    type ex = Ex : 'a * 'a -> ex
+    val s : unit t
+  end
+#     Characters 58-61:
+    | S.(Sep), (S.(Sep,Sep), Sep) -> ()
+                             ^^^
+Error: Unbound constructor Sep
+#     Characters 50-52:
+    | S.(Ex(a,b)), Ex(c,d) -> ()
+                   ^^
+Error: Unbound constructor Ex
+#     Characters 48-49:
+    | S.(Sep) -> s
+                 ^
+Error: Unbound value s
+#                                           module PR6437 :
+  sig
+    module Ctx :
+      sig
+        type ('a, 'b) t =
+            Nil : (unit, unit) t
+          | Cons : ('a, 'b) t -> ('a * unit, 'b * unit) t
+      end
+    module Var :
+      sig type 'a t = O : ('a * unit) t | S : 'a t -> ('a * unit) t end
+  end
+val f : ('g1, 'g2) PR6437.Ctx.t * 'g1 PR6437.Var.t -> 'g2 PR6437.Var.t =
+  <fun>
+# 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -121,7 +121,7 @@ val generic_instance: Env.t -> type_expr -> type_expr
 val instance_list: Env.t -> type_expr list -> type_expr list
         (* Take an instance of a list of type schemes *)
 val instance_constructor:
-        ?in_pattern:Env.t ref * int ->
+        ?in_pattern:Env.mut * int ->
         constructor_description -> type_expr list * type_expr
         (* Same, for a constructor *)
 val instance_parameterized_type:
@@ -164,7 +164,7 @@ val enforce_constraints: Env.t -> type_expr -> unit
 
 val unify: Env.t -> type_expr -> type_expr -> unit
         (* Unify the two types given. Raise [Unify] if not possible. *)
-val unify_gadt: newtype_level:int -> Env.t ref -> type_expr -> type_expr -> unit
+val unify_gadt: newtype_level:int -> Env.mut -> type_expr -> type_expr -> unit
         (* Unify the two types given and update the environment with the
            local constraints. Raise [Unify] if not possible. *)
 val unify_var: Env.t -> type_expr -> type_expr -> unit

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -158,6 +158,8 @@ module EnvTbl =
 
     let fold_name f = Ident.fold_name (fun k (d,_) -> f k d)
     let keys tbl = Ident.fold_all (fun k _ accu -> k::accu) tbl []
+    let merge tbl1 tbl2=
+      Ident.fold_all Ident.add tbl2 tbl1
   end
 
 type type_descriptions =
@@ -255,6 +257,54 @@ let empty = {
   flags = 0;
   functor_args = Ident.empty;
  }
+
+(* partially mutable environment for typing pattern *)
+type mut = {
+  local: t; (* original environment + new identifiers introduced in pattern open *)
+  shared: t ref; (* share type equalities introduced by typing GADTs in pattern *)
+}
+
+let rec concat_summary new_sum old =
+  match new_sum with
+  | Env_empty -> old
+  | Env_value (summary,b,c) -> Env_value( concat_summary summary old, b, c)
+  | Env_type (summary,b,c) -> Env_type( concat_summary summary old, b, c)
+  | Env_extension (summary,b,c) -> Env_extension( concat_summary summary old, b, c)
+  | Env_module (summary,b,c) -> Env_module( concat_summary summary old, b, c)
+  | Env_modtype (summary,b,c) -> Env_modtype( concat_summary summary old, b, c)
+  | Env_class (summary,b,c) -> Env_class( concat_summary summary old, b, c)
+  | Env_cltype (summary,b,c) -> Env_cltype( concat_summary summary old, b, c)
+  | Env_open (summary,b) -> Env_open( concat_summary summary old, b)
+  | Env_functor_arg (summary,b) -> Env_functor_arg( concat_summary summary old, b)
+
+(* merge back together the shared and local part of the environment *)
+let freeze {shared;local} =
+  let shared = !shared in
+  if shared == empty then local else
+ let merge f = EnvTbl.merge (f local) (f shared) in
+  {
+    values = merge (fun x -> x.values);
+    types = merge (fun x -> x.types);
+    constrs = merge (fun x -> x.constrs);
+    labels = merge (fun x -> x.labels);
+    modules = merge (fun x -> x.modules);
+    modtypes = merge (fun x -> x.modtypes);
+    components = merge (fun x -> x.components);
+    classes = merge (fun x -> x.classes);
+    cltypes = merge (fun x -> x.cltypes);
+    functor_args = merge (fun x -> x.functor_args);
+    summary = concat_summary shared.summary local.summary;
+    local_constraints = local.local_constraints || shared.local_constraints;
+    gadt_instances = shared.gadt_instances @ local.gadt_instances;
+    flags = local.flags lor shared.flags;
+  }
+(* create a new partially mutable environment with an empty shared part*)
+let thaw (env:t) = { local = env ; shared = ref empty}
+
+let local m_env = m_env.local
+let shared m_env = !(m_env.shared)
+let local_update m_env local = { m_env with local }
+let shared_update mut env = mut.shared := env
 
 let in_signature b env =
   let flags =

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -36,6 +36,30 @@ val initial_safe_string: t
 val initial_unsafe_string: t
 val diff: t -> t -> Ident.t list
 
+type mut
+(* Partially mutable environment used in typing patterns and cases.
+   Such environment is split in a local and shared parts.
+   The local part is immutable and used to track new identifiers introduced
+   locally by pattern open.
+   The shared part is mutable and used to propagate type equalities
+   introduced by GADTs.
+ *)
+
+(* Thaw creates a new mutable environment, whose local part is the original
+   env and with an empty shared part.*)
+val thaw : t -> mut
+
+(* Freeze merge back together the shared and local parts of the mutable
+   environment to recreate an Env.t.
+   It is guaranteed that: x == freeze (thaw x) *)
+val freeze : mut -> t
+
+(* For manipulating partially mutable environment *)
+val shared: mut -> t
+val local: mut -> t
+val local_update: mut -> t -> mut
+val shared_update: mut ->  t -> unit
+
 type type_descriptions =
     constructor_description list * label_description list
 

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -160,6 +160,8 @@ let rec pretty_val ppf v =
             fprintf ppf "@[(%a : _)@]" pretty_val { v with pat_extra = rem }
           | Tpat_type _ ->
             fprintf ppf "@[(# %a)@]" pretty_val { v with pat_extra = rem }
+          | Tpat_open _ ->
+              fprintf ppf "@[(# %a)@]" pretty_val { v with pat_extra = rem }
         end
     | [] ->
   match v.pat_desc with

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -214,6 +214,10 @@ and pattern i ppf x =
         line i ppf "Tpat_type %a\n" fmt_path id;
         attributes i ppf attrs;
         pattern i ppf { x with pat_extra = rem }
+    | (Tpat_open (id,_,_), _, attrs)::rem ->
+        line i ppf "Tpat_open \"%a\"\n" fmt_path id;
+        attributes i ppf attrs;
+        pattern i ppf { x with pat_extra = rem }
     | [] ->
   match x.pat_desc with
   | Tpat_any -> line i ppf "Tpat_any\n";

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -186,6 +186,7 @@ let pat sub x =
   let extra = function
     | Tpat_type _
     | Tpat_unpack as d -> d
+    | Tpat_open (path,loc,env) ->  Tpat_open (path, loc, sub.env sub env)
     | Tpat_constraint ct -> Tpat_constraint (sub.typ sub ct)
   in
   let pat_env = sub.env sub x.pat_env in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1375,6 +1375,13 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
       unify_pat_types loc frozen_env ty expected_ty;
       k { p with pat_extra =
         (Tpat_type (path, lid), loc, sp.ppat_attributes) :: p.pat_extra }
+  | Ppat_open (lid,p) ->
+      let path, new_env = !type_open Asttypes.Fresh (Env.local env) sp.ppat_loc lid in
+      let env = Env.local_update env new_env in
+      type_pat ~env p expected_ty ( fun p ->
+        k { p with pat_extra =( Tpat_open (path,lid,new_env),
+                            loc, sp.ppat_attributes) :: p.pat_extra }
+      )
   | Ppat_exception _ ->
       raise (Error (loc, Env.freeze env, Exception_pattern_below_toplevel))
   | Ppat_extension ext ->
@@ -1824,6 +1831,7 @@ let iter_ppat f p =
   | Ppat_variant (_, arg) | Ppat_construct (_, arg) -> may f arg
   | Ppat_tuple lst ->  List.iter f lst
   | Ppat_exception p | Ppat_alias (p,_)
+  | Ppat_open (_,p)
   | Ppat_constraint (p,_) | Ppat_lazy p -> f p
   | Ppat_record (args, _flag) -> List.iter (fun (_,p) -> f p) args
 
@@ -1836,18 +1844,21 @@ let contains_polymorphic_variant p =
   try loop p; false with Exit -> true
 
 let contains_gadt env p =
-  let rec loop p =
+  let rec loop env p =
     match p.ppat_desc with
-      Ppat_construct (lid, _) ->
+      | Ppat_construct (lid, _) ->
         begin try
           let cstrs = Env.lookup_all_constructors lid.txt env in
           List.iter (fun (cstr,_) -> if cstr.cstr_generalized then raise Exit)
             cstrs
         with Not_found -> ()
-        end; iter_ppat loop p
-    | _ -> iter_ppat loop p
+        end; iter_ppat (loop env) p
+      | Ppat_open (lid,sub_p) ->
+        let _, new_env = !type_open Asttypes.Fresh env p.ppat_loc lid in
+        loop new_env sub_p
+    | _ -> iter_ppat (loop env) p
   in
-  try loop p; false with Exit -> true
+  try loop env p; false with Exit -> true
 
 let check_absent_variant env =
   iter_pattern

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -381,11 +381,11 @@ let unify_pat_types_gadt loc env ty ty' =
     unify_gadt ~newtype_level env ty ty'
   with
     Unify trace ->
-      raise(Error(loc, !env, Pattern_type_clash(trace)))
+      raise(Error(loc, (Env.freeze env), Pattern_type_clash(trace)))
   | Tags(l1,l2) ->
-      raise(Typetexp.Error(loc, !env, Typetexp.Variant_tags (l1, l2)))
+      raise(Typetexp.Error(loc, (Env.freeze env), Typetexp.Variant_tags (l1, l2)))
   | Unification_recursive_abbrev trace ->
-      raise(Error(loc, !env, Recursive_local_constraint trace))
+      raise(Error(loc, (Env.freeze env), Recursive_local_constraint trace))
 
 
 (* Creating new conjunctive types is not allowed when typing patterns *)
@@ -955,11 +955,11 @@ type state =
 let save_state env =
   { snapshot = Btype.snapshot ();
     levels = Ctype.save_levels ();
-    env = !env; }
+    env = Env.shared env; }
 let set_state s env =
   Btype.backtrack s.snapshot;
   Ctype.set_levels s.levels;
-  env := s.env
+  Env.shared_update env s.env
 
 (* type_pat does not generate local constraints inside or patterns *)
 type type_pat_mode =
@@ -985,15 +985,16 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
   let rp k x : pattern = if constrs = None then k (rp x) else k x in
   match sp.ppat_desc with
     Ppat_any ->
+      let frozen_env = Env.freeze env in
       let k' d = rp k {
         pat_desc = d;
         pat_loc = loc; pat_extra=[];
         pat_type = expected_ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env }
+        pat_env = frozen_env }
       in
       if explode > 0 then
-        let (sp, constrs, labels) = Parmatch.ppat_of_type !env expected_ty in
+        let (sp, constrs, labels) = Parmatch.ppat_of_type frozen_env expected_ty in
         if sp.ppat_desc = Parsetree.Ppat_any then k' Tpat_any else
         if mode = Inside_or then raise Need_backtrack else
         let explode =
@@ -1012,7 +1013,7 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
         pat_loc = loc; pat_extra=[];
         pat_type = expected_ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env }
+        pat_env = Env.freeze env }
   | Ppat_unpack name ->
       assert (constrs = None);
       let id = enter_variable loc name expected_ty ~is_module:true in
@@ -1022,14 +1023,15 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
         pat_extra=[Tpat_unpack, loc, sp.ppat_attributes];
         pat_type = expected_ty;
         pat_attributes = [];
-        pat_env = !env }
+        pat_env = Env.freeze env }
   | Ppat_constraint({ppat_desc=Ppat_var name; ppat_loc=lloc},
                     ({ptyp_desc=Ptyp_poly _} as sty)) ->
       (* explicitly polymorphic type *)
       assert (constrs = None);
-      let cty, force = Typetexp.transl_simple_type_delayed !env sty in
+      let env = Env.freeze env in
+      let cty, force = Typetexp.transl_simple_type_delayed env sty in
       let ty = cty.ctyp_type in
-      unify_pat_types lloc !env ty expected_ty;
+      unify_pat_types lloc env ty expected_ty;
       pattern_force := force :: !pattern_force;
       begin match ty.desc with
       | Tpoly (body, tyl) ->
@@ -1044,15 +1046,16 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
             pat_extra = [Tpat_constraint cty, loc, sp.ppat_attributes];
             pat_type = ty;
             pat_attributes = [];
-            pat_env = !env
+            pat_env = env
           }
       | _ -> assert false
       end
   | Ppat_alias(sq, name) ->
       assert (constrs = None);
       type_pat sq expected_ty (fun q ->
+        let frozen_env = Env.freeze env in
         begin_def ();
-        let ty_var = build_as_type !env q in
+        let ty_var = build_as_type frozen_env q in
         end_def ();
         generalize ty_var;
         let id = enter_variable ~is_as_variable:true loc name ty_var in
@@ -1061,16 +1064,17 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
           pat_loc = loc; pat_extra=[];
           pat_type = q.pat_type;
           pat_attributes = sp.ppat_attributes;
-          pat_env = !env })
+          pat_env = frozen_env })
   | Ppat_constant cst ->
-      let cst = constant_or_raise !env loc cst in
-      unify_pat_types loc !env (type_constant cst) expected_ty;
+      let frozen_env = Env.freeze env in
+      let cst = constant_or_raise frozen_env loc cst in
+      unify_pat_types loc frozen_env (type_constant cst) expected_ty;
       rp k {
         pat_desc = Tpat_constant cst;
         pat_loc = loc; pat_extra=[];
         pat_type = expected_ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env }
+        pat_env = frozen_env }
   | Ppat_interval (Pconst_char c1, Pconst_char c2) ->
       let open Ast_helper.Pat in
       let gloc = {loc with Location.loc_ghost=true} in
@@ -1086,23 +1090,26 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
       type_pat ~explode:0 p expected_ty k
         (* TODO: record 'extra' to remember about interval *)
   | Ppat_interval _ ->
-      raise (Error (loc, !env, Invalid_interval))
+      raise (Error (loc, (Env.freeze env), Invalid_interval))
   | Ppat_tuple spl ->
       assert (List.length spl >= 2);
       let spl_ann = List.map (fun p -> (p,newvar ())) spl in
       let ty = newty (Ttuple(List.map snd spl_ann)) in
-      unify_pat_types loc !env ty expected_ty;
+      let env = Env.freeze env in
+      unify_pat_types loc env ty expected_ty;
       map_fold_cont (fun (p,t) -> type_pat p t) spl_ann (fun pl ->
         rp k {
         pat_desc = Tpat_tuple pl;
         pat_loc = loc; pat_extra=[];
         pat_type = expected_ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env })
+        pat_env = env }
+      )
   | Ppat_construct(lid, sarg) ->
+      let frozen_env = Env.freeze env in
       let opath =
         try
-          let (p0, p, _) = extract_concrete_variant !env expected_ty in
+          let (p0, p, _) = extract_concrete_variant frozen_env expected_ty in
             Some (p0, p, true)
         with Not_found -> None
       in
@@ -1110,28 +1117,28 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
         match lid.txt, constrs with
           Longident.Lident s, Some constrs when Hashtbl.mem constrs s ->
             [Hashtbl.find constrs s, (fun () -> ())]
-        | _ ->  Typetexp.find_all_constructors !env lid.loc lid.txt
+        | _ ->  Typetexp.find_all_constructors frozen_env lid.loc lid.txt
       in
       let check_lk tpath constr =
         if constr.cstr_generalized then
-          raise (Error (lid.loc, !env,
+          raise (Error (lid.loc, frozen_env,
                         Unqualified_gadt_pattern (tpath, constr.cstr_name)))
       in
       let constr =
         wrap_disambiguate "This variant pattern is expected to have" expected_ty
-          (Constructor.disambiguate lid !env opath ~check_lk) candidates
+          (Constructor.disambiguate lid frozen_env opath ~check_lk) candidates
       in
       if constr.cstr_generalized && constrs <> None && mode = Inside_or
       then raise Need_backtrack;
-      Env.mark_constructor Env.Pattern !env (Longident.last lid.txt) constr;
+      Env.mark_constructor Env.Pattern frozen_env (Longident.last lid.txt) constr;
       Builtin_attributes.check_deprecated loc constr.cstr_attributes
         constr.cstr_name;
       if no_existentials && constr.cstr_existentials <> [] then
-        raise (Error (loc, !env, Unexpected_existential));
+        raise (Error (loc, frozen_env, Unexpected_existential));
       (* if constructor is gadt, we must verify that the expected type has the
          correct head *)
       if constr.cstr_generalized then
-        unify_head_only loc !env expected_ty constr;
+        unify_head_only loc frozen_env expected_ty constr;
       let sargs =
         match sarg with
           None -> []
@@ -1154,14 +1161,14 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
       | _ -> ()
       end;
       if List.length sargs <> constr.cstr_arity then
-        raise(Error(loc, !env, Constructor_arity_mismatch(lid.txt,
+        raise(Error(loc, frozen_env, Constructor_arity_mismatch(lid.txt,
                                      constr.cstr_arity, List.length sargs)));
       let (ty_args, ty_res) =
         instance_constructor ~in_pattern:(env, get_newtype_level ()) constr
       in
       (* PR#7214: do not use gadt unification for toplevel lets *)
       if not constr.cstr_generalized || mode = Inside_or || no_existentials
-      then unify_pat_types loc !env ty_res expected_ty
+      then unify_pat_types loc (Env.freeze env) ty_res expected_ty
       else unify_pat_types_gadt loc env ty_res expected_ty;
 
       let rec check_non_escaping p =
@@ -1172,7 +1179,7 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
         | Ppat_alias (p, _) ->
             check_non_escaping p
         | Ppat_constraint _ ->
-            raise (Error (p.ppat_loc, !env, Inlined_record_escape))
+            raise (Error (p.ppat_loc, frozen_env, Inlined_record_escape))
         | _ ->
             ()
       in
@@ -1185,8 +1192,9 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
           pat_loc = loc; pat_extra=[];
           pat_type = expected_ty;
           pat_attributes = sp.ppat_attributes;
-          pat_env = !env })
+          pat_env = frozen_env })
   | Ppat_variant(l, sarg) ->
+      let env = Env.freeze env in
       let arg_type = match sarg with None -> [] | Some _ -> [newvar()] in
       let row = { row_fields =
                     [l, Reither(sarg = None, arg_type, true, ref None)];
@@ -1195,14 +1203,14 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
                   row_more = newvar ();
                   row_fixed = false;
                   row_name = None } in
-      unify_pat_types loc !env (newty (Tvariant row)) expected_ty;
+      unify_pat_types loc env (newty (Tvariant row)) expected_ty;
       let k arg =
         rp k {
         pat_desc = Tpat_variant(l, arg, ref {row with row_more = newvar()});
         pat_loc = loc; pat_extra=[];
         pat_type =  expected_ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env }
+        pat_env = env }
       in begin
         (* PR#6235: propagate type information *)
         match sarg, arg_type with
@@ -1211,9 +1219,10 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
       end
   | Ppat_record(lid_sp_list, closed) ->
       assert (lid_sp_list <> []);
+      let env = Env.freeze env in
       let opath, record_ty =
         try
-          let (p0, p,_) = extract_concrete_record !env expected_ty in
+          let (p0, p,_) = extract_concrete_record env expected_ty in
           Some (p0, p, true), expected_ty
         with Not_found -> None, newvar ()
       in
@@ -1222,9 +1231,9 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
         let (vars, ty_arg, ty_res) = instance_label false label in
         if vars = [] then end_def ();
         begin try
-          unify_pat_types loc !env ty_res record_ty
+          unify_pat_types loc env ty_res record_ty
         with Unify trace ->
-          raise(Error(label_lid.loc, !env,
+          raise(Error(label_lid.loc, env,
                       Label_mismatch(label_lid.txt, trace)))
         end;
         type_pat sarg ty_arg (fun arg ->
@@ -1233,37 +1242,38 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
             generalize ty_arg;
             List.iter generalize vars;
             let instantiated tv =
-              let tv = expand_head !env tv in
+              let tv = expand_head env tv in
               not (is_Tvar tv) || tv.level <> generic_level in
             if List.exists instantiated vars then
               raise
-                (Error(label_lid.loc, !env, Polymorphic_label label_lid.txt))
+                (Error(label_lid.loc, env, Polymorphic_label label_lid.txt))
           end;
           k (label_lid, label, arg))
       in
       let k' k lbl_pat_list =
         check_recordpat_labels loc lbl_pat_list closed;
-        unify_pat_types loc !env record_ty expected_ty;
+        unify_pat_types loc env record_ty expected_ty;
         rp k {
         pat_desc = Tpat_record (lbl_pat_list, closed);
         pat_loc = loc; pat_extra=[];
         pat_type = expected_ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env }
+        pat_env = env }
       in
       if constrs = None then
         k (wrap_disambiguate "This record pattern is expected to have"
              expected_ty
-             (type_label_a_list ?labels loc false !env type_label_pat opath
+             (type_label_a_list ?labels loc false env type_label_pat opath
                 lid_sp_list)
              (k' (fun x -> x)))
       else
-        type_label_a_list ?labels loc false !env type_label_pat opath
+        type_label_a_list ?labels loc false env type_label_pat opath
           lid_sp_list (k' k)
   | Ppat_array spl ->
+      let env = Env.freeze env in
       let ty_elt = newvar() in
       unify_pat_types
-        loc !env (instance_def (Predef.type_array ty_elt)) expected_ty;
+        loc env (instance_def (Predef.type_array ty_elt)) expected_ty;
       let spl_ann = List.map (fun p -> (p,newvar())) spl in
       map_fold_cont (fun (p,_) -> type_pat p ty_elt) spl_ann (fun pl ->
         rp k {
@@ -1271,7 +1281,7 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
         pat_loc = loc; pat_extra=[];
         pat_type = expected_ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env })
+        pat_env = env })
   | Ppat_or(sp1, sp2) ->
       let state = save_state env in
       begin match
@@ -1293,15 +1303,16 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
           None, None -> raise Need_backtrack
         | Some p, None | None, Some p -> p (* no variables in this case *)
         | Some p1, Some p2 ->
+        let env= Env.freeze env in
         let alpha_env =
-          enter_orpat_variables loc !env p1_variables p2_variables in
+          enter_orpat_variables loc env p1_variables p2_variables in
         pattern_variables := p1_variables;
         module_variables := p1_module_variables;
         { pat_desc = Tpat_or(p1, alpha_pat alpha_env p2, None);
           pat_loc = loc; pat_extra=[];
           pat_type = expected_ty;
           pat_attributes = sp.ppat_attributes;
-          pat_env = !env }
+          pat_env = env }
       with
         p -> rp k p
       | exception Need_backtrack when mode <> Inside_or ->
@@ -1314,8 +1325,9 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
             type_pat ~mode sp2 expected_ty k
       end
   | Ppat_lazy sp1 ->
+      let env = Env.freeze env in
       let nv = newvar () in
-      unify_pat_types loc !env (instance_def (Predef.type_lazy_t nv))
+      unify_pat_types loc env (instance_def (Predef.type_lazy_t nv))
         expected_ty;
       type_pat sp1 nv (fun p1 ->
         rp k {
@@ -1323,21 +1335,22 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
         pat_loc = loc; pat_extra=[];
         pat_type = expected_ty;
         pat_attributes = sp.ppat_attributes;
-        pat_env = !env })
+        pat_env = env } )
   | Ppat_constraint(sp, sty) ->
       (* Separate when not already separated by !principal *)
+      let env = Env.freeze env in
       let separate = true in
       if separate then begin_def();
-      let cty, force = Typetexp.transl_simple_type_delayed !env sty in
+      let cty, force = Typetexp.transl_simple_type_delayed env sty in
       let ty = cty.ctyp_type in
       let ty, expected_ty' =
         if separate then begin
           end_def();
           generalize_structure ty;
-          instance !env ty, instance !env ty
+          instance env ty, instance env ty
         end else ty, ty
       in
-      unify_pat_types loc !env ty expected_ty;
+      unify_pat_types loc env ty expected_ty;
       type_pat sp expected_ty' (fun p ->
         (*Format.printf "%a@.%a@."
           Printtyp.raw_type_expr ty
@@ -1357,12 +1370,13 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
                   pat_extra = extra :: p.pat_extra}
         in k p)
   | Ppat_type lid ->
-      let (path, p,ty) = build_or_pat !env loc lid.txt in
-      unify_pat_types loc !env ty expected_ty;
+      let frozen_env = Env.freeze env in
+      let (path, p,ty) = build_or_pat frozen_env loc lid.txt in
+      unify_pat_types loc frozen_env ty expected_ty;
       k { p with pat_extra =
         (Tpat_type (path, lid), loc, sp.ppat_attributes) :: p.pat_extra }
   | Ppat_exception _ ->
-      raise (Error (loc, !env, Exception_pattern_below_toplevel))
+      raise (Error (loc, Env.freeze env, Exception_pattern_below_toplevel))
   | Ppat_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
@@ -1373,7 +1387,7 @@ let type_pat ?(allow_existentials=false) ?constrs ?labels ?(mode=Normal)
     let r =
       type_pat ~no_existentials:(not allow_existentials) ~constrs ~labels
         ~mode ~explode ~env sp expected_ty (fun x -> x) in
-    iter_pattern (fun p -> p.pat_env <- !env) r;
+    iter_pattern (fun p -> p.pat_env <- Env.freeze env) r;
     newtype_level := None;
     r
   with e ->
@@ -1384,7 +1398,7 @@ let type_pat ?(allow_existentials=false) ?constrs ?labels ?(mode=Normal)
 (* this function is passed to Partial.parmatch
    to type check gadt nonexhaustiveness *)
 let partial_pred ~lev ?mode ?explode env expected_ty constrs labels p =
-  let env = ref env in
+  let env = Env.thaw env in
   let state = save_state env in
   try
     reset_pattern None true;
@@ -1431,25 +1445,25 @@ let add_pattern_variables ?check ?check_as env =
 
 let type_pattern ~lev env spat scope expected_ty =
   reset_pattern scope true;
-  let new_env = ref env in
+  let new_env = Env.thaw env in
   let pat = type_pat ~allow_existentials:true ~lev new_env spat expected_ty in
   let new_env, unpacks =
-    add_pattern_variables !new_env
+    add_pattern_variables (Env.freeze new_env)
       ~check:(fun s -> Warnings.Unused_var_strict s)
       ~check_as:(fun s -> Warnings.Unused_var s) in
   (pat, new_env, get_ref pattern_force, unpacks)
 
 let type_pattern_list env spatl scope expected_tys allow =
   reset_pattern scope allow;
-  let new_env = ref env in
+  let new_env = Env.thaw env in
   let patl = List.map2 (type_pat new_env) spatl expected_tys in
-  let new_env, unpacks = add_pattern_variables !new_env in
+  let new_env, unpacks = add_pattern_variables (Env.freeze new_env) in
   (patl, new_env, get_ref pattern_force, unpacks)
 
 let type_class_arg_pattern cl_num val_env met_env l spat =
   reset_pattern None false;
   let nv = newvar () in
-  let pat = type_pat (ref val_env) spat nv in
+  let pat = type_pat (Env.thaw val_env) spat nv in
   if has_variants pat then begin
     Parmatch.pressure_variants val_env [pat];
     iter_pattern finalize_variant pat
@@ -1483,7 +1497,7 @@ let type_self_pattern cl_num privty val_env met_env par_env spat =
   in
   reset_pattern None false;
   let nv = newvar() in
-  let pat = type_pat (ref val_env) spat nv in
+  let pat = type_pat (Env.thaw val_env) spat nv in
   List.iter (fun f -> f()) (get_ref pattern_force);
   let meths = ref Meths.empty in
   let vars = ref Vars.empty in

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -38,6 +38,7 @@ type pattern =
 and pat_extra =
   | Tpat_constraint of core_type
   | Tpat_type of Path.t * Longident.t loc
+  | Tpat_open of Path.t * Longident.t loc * Env.t
   | Tpat_unpack
 
 and pattern_desc =

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -56,6 +56,7 @@ and pat_extra =
                            where [disjunction] is a [Tpat_or _] representing the
                            branches of [tconst].
          *)
+  | Tpat_open of Path.t * Longident.t loc * Env.t
   | Tpat_unpack
         (** (module P)     { pat_desc  = Tpat_var "P"
                            ; pat_extra = (Tpat_unpack, _, _) :: ... }

--- a/typing/typedtreeIter.ml
+++ b/typing/typedtreeIter.ml
@@ -224,6 +224,7 @@ module MakeIterator(Iter : IteratorArgument) : sig
       List.iter (fun (cstr, _, _attrs) -> match cstr with
               | Tpat_type _ -> ()
               | Tpat_unpack -> ()
+              | Tpat_open _ -> ()
               | Tpat_constraint ct -> iter_core_type ct) pat.pat_extra;
       begin
         match pat.pat_desc with

--- a/typing/typedtreeMap.ml
+++ b/typing/typedtreeMap.ml
@@ -259,7 +259,7 @@ module MakeMap(Map : MapArgument) = struct
     match pat_extra with
       | Tpat_constraint ct, loc, attrs ->
           (Tpat_constraint (map_core_type  ct), loc, attrs)
-      | (Tpat_type _ | Tpat_unpack), _, _ -> pat_extra
+      | (Tpat_type _ | Tpat_unpack | Tpat_open _ ), _, _ -> pat_extra
 
   and map_expression exp =
     let exp = Map.enter_expression exp in


### PR DESCRIPTION
This pull request adds support for local open inside patterns. Four new constructions mirroring the local open constructions for expressions are added
- `M.(pattern)`
- `M.[pattern_list]` ⟺ `M.([pattern_list])`
- `M.{labeled_pattern_list}` ⟺ `M.({labeled_pattern_list})`
- `M.[| .. |]` ⟺ `M.( [| .. |] )`

At the typing phase, the construction `M.(pattern)` brings all identifiers defined within M inside the scope and then proceed with the typing of `pattern`. All others expression are desugared to the `M.(..)` construction during parsing.

One the main advantages of these constructions would be to deconstruct record with the same
syntax used to construct them

``` Ocaml
let f M.{x} = M.{x}
```

Other uses of these local pattern might be quite unfrequent but the similarity with the local open for expression should help users to discover or remember this feature when the need arises. Since there is no analogous to `let open M in ...` on the pattern side, local open in pattern and expression are not completely symmetric. However, `let open M in ..` constructions in the pattern side would look quite foreign to me. 

Questionable implementation details:
- Currently, the local pattern open use the `type_open` function like the local expression pattern. However, this implies that values defined inside `M` are also brought to the scope. Does this warrant a specialised `type_open_for_pattern` function?
- This pull request does not provide support for `M.()` and `M.[]` whose semantics seem quite ambiguous to me.
