### PR TITLE
Added dylib as an extension for ocamlmklib

### DIFF
--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -53,8 +53,6 @@ let print_if ppf flag printer arg =
   if !flag then fprintf ppf "%a@." printer arg;
   arg
 
-let (++) x f = f x
-
 let implementation ppf sourcefile outputprefix =
   Compmisc.init_path false;
   let modulename = module_of_filename ppf sourcefile outputprefix in
@@ -63,12 +61,12 @@ let implementation ppf sourcefile outputprefix =
   if !Clflags.print_types then begin
     let comp ast =
       ast
-      ++ print_if ppf Clflags.dump_parsetree Printast.implementation
-      ++ print_if ppf Clflags.dump_source Pprintast.structure
-      ++ Typemod.type_implementation sourcefile outputprefix modulename env
-      ++ print_if ppf Clflags.dump_typedtree
+      |> print_if ppf Clflags.dump_parsetree Printast.implementation
+      |> print_if ppf Clflags.dump_source Pprintast.structure
+      |> Typemod.type_implementation sourcefile outputprefix modulename env
+      |> print_if ppf Clflags.dump_typedtree
           Printtyped.implementation_with_coercion
-      ++ (fun _ -> ());
+      |> (fun _ -> ());
       Warnings.check_fatal ();
       Stypes.dump (Some (outputprefix ^ ".annot"))
     in
@@ -81,18 +79,18 @@ let implementation ppf sourcefile outputprefix =
     let oc = open_out_bin objfile in
     let comp ast =
       ast
-      ++ print_if ppf Clflags.dump_parsetree Printast.implementation
-      ++ print_if ppf Clflags.dump_source Pprintast.structure
-      ++ Typemod.type_implementation sourcefile outputprefix modulename env
-      ++ print_if ppf Clflags.dump_typedtree
+      |> print_if ppf Clflags.dump_parsetree Printast.implementation
+      |> print_if ppf Clflags.dump_source Pprintast.structure
+      |> Typemod.type_implementation sourcefile outputprefix modulename env
+      |> print_if ppf Clflags.dump_typedtree
                   Printtyped.implementation_with_coercion
-      ++ Translmod.transl_implementation modulename
-      ++ print_if ppf Clflags.dump_rawlambda Printlambda.lambda
-      ++ Simplif.simplify_lambda
-      ++ print_if ppf Clflags.dump_lambda Printlambda.lambda
-      ++ Bytegen.compile_implementation modulename
-      ++ print_if ppf Clflags.dump_instr Printinstr.instrlist
-      ++ Emitcode.to_file oc modulename objfile;
+      |> Translmod.transl_implementation modulename
+      |> print_if ppf Clflags.dump_rawlambda Printlambda.lambda
+      |> Simplif.simplify_lambda
+      |> print_if ppf Clflags.dump_lambda Printlambda.lambda
+      |> Bytegen.compile_implementation modulename
+      |> print_if ppf Clflags.dump_instr Printinstr.instrlist
+      |> Emitcode.to_file oc modulename objfile;
       Warnings.check_fatal ();
       close_out oc;
       Stypes.dump (Some (outputprefix ^ ".annot"))

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -20,7 +20,7 @@ let compiler_path name =
 
 let bytecode_objs = ref []  (* .cmo,.cma,.ml,.mli files to pass to ocamlc *)
 and native_objs = ref []    (* .cmx,.cmxa,.ml,.mli files to pass to ocamlopt *)
-and c_objs = ref []         (* .o, .a, .obj, .lib, .dll files to pass
+and c_objs = ref []         (* .o, .a, .obj, .lib, .dll, .dylib files to pass
                                to mksharedlib and ar *)
 and caml_libs = ref []      (* -cclib to pass to ocamlc, ocamlopt *)
 and caml_opts = ref []      (* -ccopt to pass to ocamlc, ocamlopt *)
@@ -75,7 +75,7 @@ let parse_arguments argv =
     else if ends_with s ".ml" || ends_with s ".mli" then
      (bytecode_objs := s :: !bytecode_objs;
       native_objs := s :: !native_objs)
-    else if List.exists (ends_with s) [".o"; ".a"; ".obj"; ".lib"; ".dll"] then
+    else if List.exists (ends_with s) [".o"; ".a"; ".obj"; ".lib"; ".dll"; ".dylib"] then
       c_objs := s :: !c_objs
     else if s = "-cclib" then
       caml_libs := next_arg () :: "-cclib" :: !caml_libs
@@ -153,7 +153,7 @@ let parse_arguments argv =
 
 let usage = "\
 Usage: ocamlmklib [options] <.cmo|.cma|.cmx|.cmxa|.ml|.mli|.o|.a|.obj|.lib|\
-                             .dll files>\
+                             .dll|.dylib files>\
 \nOptions are:\
 \n  -cclib <lib>   C library passed to ocamlc -a or ocamlopt -a only\
 \n  -ccopt <opt>   C option passed to ocamlc -a or ocamlopt -a only\


### PR DESCRIPTION
I was using ocamlmklib on OS X and found this oversight, ie the lack of dylib as a valid option to ocamlmklib. 
