### PR TITLE
Making gc.h and some part of memory.h public

### DIFF
--- a/byterun/Makefile.common
+++ b/byterun/Makefile.common
@@ -33,9 +33,9 @@ PRIMS=\
   dynlink.c backtrace.c
 
 PUBLIC_INCLUDES=\
-  alloc.h callback.h config.h custom.h fail.h hash.h intext.h \
-  memory.h misc.h mlvalues.h printexc.h signals.h compatibility.h \
-  version.h
+  alloc.h callback.h config.h custom.h fail.h gc.h hash.h intext.h \
+  memory.h misc.h mlvalues.h page_table.h printexc.h signals.h \
+  compatibility.h version.h
 
 
 all:: ocamlrun$(EXE) ld.conf libcamlrun.$(A) all-$(RUNTIMED)

--- a/byterun/caml/memory.h
+++ b/byterun/caml/memory.h
@@ -52,43 +52,7 @@ color_t caml_allocation_color (void *hp);
 
 /* <private> */
 
-#define Not_in_heap 0
-#define In_heap 1
-#define In_young 2
-#define In_static_data 4
-#define In_code_area 8
-
-#ifdef ARCH_SIXTYFOUR
-
-/* 64 bits: Represent page table as a sparse hash table */
-int caml_page_table_lookup(void * addr);
-#define Classify_addr(a) (caml_page_table_lookup((void *)(a)))
-
-#else
-
-/* 32 bits: Represent page table as a 2-level array */
-#define Pagetable2_log 11
-#define Pagetable2_size (1 << Pagetable2_log)
-#define Pagetable1_log (Page_log + Pagetable2_log)
-#define Pagetable1_size (1 << (32 - Pagetable1_log))
-CAMLextern unsigned char * caml_page_table[Pagetable1_size];
-
-#define Pagetable_index1(a) (((uintnat)(a)) >> Pagetable1_log)
-#define Pagetable_index2(a) \
-  ((((uintnat)(a)) >> Page_log) & (Pagetable2_size - 1))
-#define Classify_addr(a) \
-  caml_page_table[Pagetable_index1(a)][Pagetable_index2(a)]
-
-#endif
-
-#define Is_in_value_area(a) \
-  (Classify_addr(a) & (In_heap | In_young | In_static_data))
-#define Is_in_heap(a) (Classify_addr(a) & In_heap)
-#define Is_in_heap_or_young(a) (Classify_addr(a) & (In_heap | In_young))
-
-int caml_page_table_add(int kind, void * start, void * end);
-int caml_page_table_remove(int kind, void * start, void * end);
-int caml_page_table_initialize(mlsize_t bytesize);
+#include "page_table.h"
 
 #ifdef DEBUG
 #define DEBUG_clear(result, wosize) do{ \

--- a/byterun/caml/page_table.h
+++ b/byterun/caml/page_table.h
@@ -43,13 +43,18 @@ CAMLextern unsigned char * caml_page_table[Pagetable1_size];
 
 #endif
 
+int caml_page_table_add(int kind, void * start, void * end);
+int caml_page_table_remove(int kind, void * start, void * end);
+int caml_page_table_initialize(mlsize_t bytesize);
+
+/* External code should only use the following four macros.
+
+   The code above may change in the future in incompatible ways. */
+
 #define Is_in_value_area(a) \
   (Classify_addr(a) & (In_heap | In_young | In_static_data))
 #define Is_in_heap(a) (Classify_addr(a) & In_heap)
 #define Is_in_heap_or_young(a) (Classify_addr(a) & (In_heap | In_young))
-
-int caml_page_table_add(int kind, void * start, void * end);
-int caml_page_table_remove(int kind, void * start, void * end);
-int caml_page_table_initialize(mlsize_t bytesize);
+#define Is_in_static_data(a) (Classify_addr(a) & In_static_data)
 
 #endif

--- a/byterun/caml/page_table.h
+++ b/byterun/caml/page_table.h
@@ -1,0 +1,42 @@
+#ifndef CAML_PAGETABLE_H
+#define CAML_PAGETABLE_H
+
+#define Not_in_heap 0
+#define In_heap 1
+#define In_young 2
+#define In_static_data 4
+#define In_code_area 8
+
+#ifdef ARCH_SIXTYFOUR
+
+/* 64 bits: Represent page table as a sparse hash table */
+int caml_page_table_lookup(void * addr);
+#define Classify_addr(a) (caml_page_table_lookup((void *)(a)))
+
+#else
+
+/* 32 bits: Represent page table as a 2-level array */
+#define Pagetable2_log 11
+#define Pagetable2_size (1 << Pagetable2_log)
+#define Pagetable1_log (Page_log + Pagetable2_log)
+#define Pagetable1_size (1 << (32 - Pagetable1_log))
+CAMLextern unsigned char * caml_page_table[Pagetable1_size];
+
+#define Pagetable_index1(a) (((uintnat)(a)) >> Pagetable1_log)
+#define Pagetable_index2(a) \
+  ((((uintnat)(a)) >> Page_log) & (Pagetable2_size - 1))
+#define Classify_addr(a) \
+  caml_page_table[Pagetable_index1(a)][Pagetable_index2(a)]
+
+#endif
+
+#define Is_in_value_area(a) \
+  (Classify_addr(a) & (In_heap | In_young | In_static_data))
+#define Is_in_heap(a) (Classify_addr(a) & In_heap)
+#define Is_in_heap_or_young(a) (Classify_addr(a) & (In_heap | In_young))
+
+int caml_page_table_add(int kind, void * start, void * end);
+int caml_page_table_remove(int kind, void * start, void * end);
+int caml_page_table_initialize(mlsize_t bytesize);
+
+#endif

--- a/byterun/caml/page_table.h
+++ b/byterun/caml/page_table.h
@@ -1,3 +1,16 @@
+/***********************************************************************/
+/*                                                                     */
+/*                                OCaml                                */
+/*                                                                     */
+/*             Damien Doligez, projet Para, INRIA Rocquencourt         */
+/*                                                                     */
+/*  Copyright 1996 Institut National de Recherche en Informatique et   */
+/*  en Automatique.  All rights reserved.  This file is distributed    */
+/*  under the terms of the GNU Library General Public License, with    */
+/*  the special exception on linking described in file ../LICENSE.     */
+/*                                                                     */
+/***********************************************************************/
+
 #ifndef CAML_PAGETABLE_H
 #define CAML_PAGETABLE_H
 


### PR DESCRIPTION
With -no-naked-pointer if one wants to point to things outside the caml heap, one need (among other things) to add a valid header to such out-of-heap values.
Cf. the recent discussion on subject on the caml list: https://sympa.inria.fr/sympa/arc/caml-list/2015-05/msg00089.html

However the `Make_header` (and color related) macros defined in gc.h are not available for public use, which leads people to write (horrible) things like:

```
#include <caml/../../../src/byterun/gc.h>
```

Things which will break when switching to 4.02.2 since gc.h (among others) was moved in byterun/caml/.

This patch proposes to make gc.h public, allowing people to write `#include <caml/gc.h>`.

Additionally, some page table checks defined in memory.h are pretty useful (to check if a value is in the heap, is constant, etc.) but are also private even though memory.h is public.
This patch also makes these checks public by exporting them from a new header file: page_table.h so as not to pollute the namespace of people already including (the public part of) memory.h.
