### PR TITLE
add a `if let` construct to the language

### DIFF
--- a/testsuite/tests/exotic-syntax/Makefile
+++ b/testsuite/tests/exotic-syntax/Makefile
@@ -13,5 +13,5 @@
 BASEDIR=../..
 MAIN_MODULE=exotic
 
-include $(BASEDIR)/makefiles/Makefile.one
+include $(BASEDIR)/makefiles/Makefile.several
 include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/exotic-syntax/iflet.ml
+++ b/testsuite/tests/exotic-syntax/iflet.ml
@@ -1,0 +1,13 @@
+
+let ok() = print_endline "ok";;
+let fail() = print_endline "fail";;
+
+let assert_ b = if b then ok() else fail();;
+
+if let Some x = None then fail() else ok();;
+
+if let Some x = Some 42 then assert_ (x=42) else fail ();;
+
+if let [1;2;y] = [1;2;3] then assert_ (y=3) else fail ();;
+
+if let [x] = [1] and [y] = [2] then assert_ (x=1 && y=2) ;;

--- a/testsuite/tests/exotic-syntax/iflet.ml
+++ b/testsuite/tests/exotic-syntax/iflet.ml
@@ -11,3 +11,15 @@ if let Some x = Some 42 then assert_ (x=42) else fail ();;
 if let [1;2;y] = [1;2;3] then assert_ (y=3) else fail ();;
 
 if let [x] = [1] and [y] = [2] then assert_ (x=1 && y=2) ;;
+
+type foo =
+  | A of int
+  | B of int * string
+  | C
+;;
+
+let f foo =
+  if let A x | B (x, _) = foo then ok ();;
+
+f (A 42);;
+f (B (0, "foo"));;

--- a/testsuite/tests/exotic-syntax/iflet.reference
+++ b/testsuite/tests/exotic-syntax/iflet.reference
@@ -1,0 +1,4 @@
+ok
+ok
+ok
+ok

--- a/testsuite/tests/exotic-syntax/iflet.reference
+++ b/testsuite/tests/exotic-syntax/iflet.reference
@@ -2,3 +2,5 @@ ok
 ok
 ok
 ok
+ok
+ok


### PR DESCRIPTION
Similar to the existing construct in swift and rust ([RFC for rust](https://github.com/rust-lang/rfcs/pull/160)). If this construct is approved, I might implement `while let` ([RFC for rust](https://github.com/rust-lang/rfcs/pull/214)).

An expression `if let Some x = e then a else b` becomes `match e with Some x -> a | _ -> b`.
