### PR TITLE
Make [Thread.id] and [Thread.self] [noalloc].

### DIFF
--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -22,8 +22,8 @@ external thread_uncaught_exception : exn -> unit =
             "caml_thread_uncaught_exception"
 
 external yield : unit -> unit = "caml_thread_yield"
-external self : unit -> t = "caml_thread_self"
-external id : t -> int = "caml_thread_id"
+external self : unit -> t = "caml_thread_self" "noalloc"
+external id : t -> int = "caml_thread_id" "noalloc"
 external join : t -> unit = "caml_thread_join"
 external exit : unit -> unit = "caml_thread_exit"
 

--- a/otherlibs/threads/thread.ml
+++ b/otherlibs/threads/thread.ml
@@ -64,11 +64,10 @@ external thread_join : t -> unit = "thread_join"
 external thread_delay : float -> unit = "thread_delay"
 external thread_wait_pid : int -> resumption_status = "thread_wait_pid"
 external thread_wakeup : t -> unit = "thread_wakeup"
-external thread_self : unit -> t = "thread_self"
+external thread_self : unit -> t = "thread_self" "noalloc"
 external thread_kill : t -> unit = "thread_kill"
 external thread_uncaught_exception : exn -> unit = "thread_uncaught_exception"
-
-external id : t -> int = "thread_id"
+external thread_id : t -> int = "thread_id" "noalloc"
 
 (* In sleep() below, we rely on the fact that signals are detected
    only at function applications and beginning of loops,
@@ -82,6 +81,7 @@ let wakeup pid = thread_wakeup pid
 let self () = thread_self()
 let kill pid = thread_kill pid
 let exit () = thread_kill(thread_self())
+let id t = thread_id t
 
 let select_aux arg = thread_select arg
 

--- a/otherlibs/threads/thread.mli
+++ b/otherlibs/threads/thread.mli
@@ -35,7 +35,7 @@ val create : ('a -> 'b) -> 'a -> t
 val self : unit -> t
 (** Return the thread currently executing. *)
 
-external id : t -> int = "thread_id"
+val id : t -> int
 (** Return the identifier of the given thread. A thread identifier
    is an integer that identifies uniquely the thread.
    It can be used to build data structures indexed by threads. *)


### PR DESCRIPTION
These functions are called every tick of the Async scheduler, and
are the only remaining calls to [caml_c_call] every cycle. It would
be nice to remove them, especially since these functions don't
allocate.
