### PR TITLE
Do not emit [add $0, %rsp] and [sub $0, %rsp].

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -394,12 +394,16 @@ let emit_float_test cmp neg i lbl =
 let output_epilogue f =
   if frame_required() then begin
     let n = frame_size() - 8 - (if fp then 8 else 0) in
-    I.add (int n) rsp;
-    cfi_adjust_cfa_offset (-n);
+    if n <> 0
+    then begin
+      I.add (int n) rsp;
+      cfi_adjust_cfa_offset (-n);
+    end;
     if fp then I.pop rbp;
     f ();
     (* reset CFA back cause function body may continue *)
-    cfi_adjust_cfa_offset n
+    if n <> 0
+    then cfi_adjust_cfa_offset n
   end
   else
     f ()
@@ -510,8 +514,10 @@ let emit_instr fallthrough i =
   | Lop(Istackoffset n) ->
       if n < 0
       then I.add (int (-n)) rsp
-      else I.sub (int n) rsp;
-      cfi_adjust_cfa_offset n;
+      else if n > 0
+      then I.sub (int n) rsp;
+      if n <> 0
+      then cfi_adjust_cfa_offset n;
       stack_offset := !stack_offset + n
   | Lop(Iload(chunk, addr)) ->
       let dest = res i 0 in
@@ -817,8 +823,11 @@ let fundecl fundecl =
   if !Clflags.gprofile then emit_profile();
   if frame_required() then begin
     let n = frame_size() - 8 - (if fp then 8 else 0) in
-    I.sub (int n) rsp;
-    cfi_adjust_cfa_offset n;
+    if n <> 0
+    then begin
+      I.sub (int n) rsp;
+      cfi_adjust_cfa_offset n;
+    end;
   end;
   def_label !tailrec_entry_point;
   emit_all true fundecl.fun_body;


### PR DESCRIPTION
ocamlopt will emit useless instructions (specifically the ones in
the title) if there are no local variables on the stack.

This is silly.
