### PR TITLE
Keep general types of Printf.{ifprintf,ikfprintf}

### DIFF
--- a/stdlib/printf.mli
+++ b/stdlib/printf.mli
@@ -127,7 +127,7 @@ val bprintf : Buffer.t -> ('a, Buffer.t, unit) format -> 'a
    append the formatted arguments to the given extensible buffer
    (see module {!Buffer}). *)
 
-val ifprintf : 'a -> ('b, 'a, 'c, unit) format4 -> 'b
+val ifprintf : 'b -> ('a, 'b, 'c, unit) format4 -> 'a
 (** Same as {!Printf.fprintf}, but does not print anything.
     Useful to ignore some material when conditionally printing.
     @since 3.10.0
@@ -135,27 +135,28 @@ val ifprintf : 'a -> ('b, 'a, 'c, unit) format4 -> 'b
 
 (** Formatted output functions with continuations. *)
 
-val kfprintf : (out_channel -> 'a) -> out_channel ->
-              ('b, out_channel, unit, 'a) format4 -> 'b;;
+val kfprintf : (out_channel -> 'b) -> out_channel ->
+              ('a, out_channel, unit, 'b) format4 -> 'a;;
 (** Same as [fprintf], but instead of returning immediately,
    passes the out channel to its first argument at the end of printing.
    @since 3.09.0
 *)
 
-val ikfprintf : ('a -> 'b) -> 'a -> ('c, 'a, 'd, 'b) format4 -> 'c;;
+val ikfprintf : ('b -> 'd) -> 'b -> ('a, 'b, 'c, 'd) format4 -> 'a;;
+
 (** Same as [kfprintf] above, but does not print anything.
    Useful to ignore some material when conditionally printing.
    @since 4.0
 *)
 
-val ksprintf : (string -> 'a) -> ('b, unit, string, 'a) format4 -> 'b;;
+val ksprintf : (string -> 'b) -> ('a, unit, string, 'b) format4 -> 'a;;
 (** Same as [sprintf] above, but instead of returning the string,
    passes it to the first argument.
    @since 3.09.0
 *)
 
-val kbprintf : (Buffer.t -> 'a) -> Buffer.t ->
-              ('b, Buffer.t, unit, 'a) format4 -> 'b;;
+val kbprintf : (Buffer.t -> 'b) -> Buffer.t ->
+              ('a, Buffer.t, unit, 'b) format4 -> 'a;;
 (** Same as [bprintf], but instead of returning immediately,
    passes the buffer to its first argument at the end of printing.
    @since 3.10.0
@@ -163,5 +164,5 @@ val kbprintf : (Buffer.t -> 'a) -> Buffer.t ->
 
 (** Deprecated *)
 
-val kprintf : (string -> 'a) -> ('b, unit, string, 'a) format4 -> 'b
+val kprintf : (string -> 'b) -> ('a, unit, string, 'b) format4 -> 'a
 (** A deprecated synonym for [ksprintf]. *)

--- a/stdlib/printf.mli
+++ b/stdlib/printf.mli
@@ -127,7 +127,7 @@ val bprintf : Buffer.t -> ('a, Buffer.t, unit) format -> 'a
    append the formatted arguments to the given extensible buffer
    (see module {!Buffer}). *)
 
-val ifprintf : 'a -> ('b, 'a, unit) format -> 'b
+val ifprintf : 'a -> ('b, 'a, 'c, unit) format4 -> 'b
 (** Same as {!Printf.fprintf}, but does not print anything.
     Useful to ignore some material when conditionally printing.
     @since 3.10.0
@@ -142,9 +142,7 @@ val kfprintf : (out_channel -> 'a) -> out_channel ->
    @since 3.09.0
 *)
 
-val ikfprintf : (out_channel -> 'a) -> out_channel ->
-              ('b, out_channel, unit, 'a) format4 -> 'b
-;;
+val ikfprintf : ('a -> 'b) -> 'a -> ('c, 'a, 'd, 'b) format4 -> 'c;;
 (** Same as [kfprintf] above, but does not print anything.
    Useful to ignore some material when conditionally printing.
    @since 4.0


### PR DESCRIPTION
For PR#6904 http://caml.inria.fr/mantis/view.php?id=6904
