### PR TITLE
backslash (\) synonym for fun

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -473,6 +473,7 @@ rule token = parse
   | "+=" { PLUSEQ }
   | "-"  { MINUS }
   | "-." { MINUSDOT }
+  | "\\" { BACKSLASH }
 
   | "!" symbolchar +
             { PREFIXOP(Lexing.lexeme lexbuf) }

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -483,6 +483,7 @@ let class_of_let_bindings lbs body =
 %token RPAREN
 %token SEMI
 %token SEMISEMI
+%token BACKSLASH
 %token SHARP
 %token <string> SHARPOP
 %token SIG
@@ -655,6 +656,12 @@ functor_args:
       { $2 :: $1 }
   | functor_arg
       { [ $1 ] }
+;
+
+fun_:
+    FUN { "fun" }
+  | BACKSLASH { "fun" }
+
 ;
 
 module_expr:
@@ -924,7 +931,7 @@ class_fun_def:
 class_expr:
     class_simple_expr
       { $1 }
-  | FUN class_fun_def
+  | fun_ class_fun_def
       { $2 }
   | class_simple_expr simple_labeled_expr_list
       { mkclass(Pcl_apply($1, List.rev $2)) }
@@ -1197,10 +1204,10 @@ expr:
       { mkexp_attrs (Pexp_open($3, mkrhs $5 5, $7)) $4 }
   | FUNCTION ext_attributes opt_bar match_cases
       { mkexp_attrs (Pexp_function(List.rev $4)) $2 }
-  | FUN ext_attributes labeled_simple_pattern fun_def
+  | fun_ ext_attributes labeled_simple_pattern fun_def
       { let (l,o,p) = $3 in
         mkexp_attrs (Pexp_fun(l, o, p, $4)) $2 }
-  | FUN ext_attributes LPAREN TYPE LIDENT RPAREN fun_def
+  | fun_ ext_attributes LPAREN TYPE LIDENT RPAREN fun_def
       { mkexp_attrs (Pexp_newtype($5, $7)) $2 }
   | MATCH ext_attributes seq_expr WITH opt_bar match_cases
       { mkexp_attrs (Pexp_match($3, List.rev $6)) $2 }
@@ -2303,7 +2310,7 @@ single_attr_id:
   | EXTERNAL { "external" }
   | FALSE { "false" }
   | FOR { "for" }
-  | FUN { "fun" }
+  | fun_ { "fun" }
   | FUNCTION { "function" }
   | FUNCTOR { "functor" }
   | IF { "if" }


### PR DESCRIPTION
(Side note: this is my first pull request with a non-comment change.)

One of the downsides of spinning up a lambda in OCaml is that the syntax is _relatively_ heavy. 'fun ' may not seem like much, but it adds up quickly, and dissuades you sometimes from opening up a lambda when you really should. I really like haskell's '\' notation for lambdas, and we use the same notation in our own research language at my lab. I thought there was some fundamental limitation preventing the usage of backslash in OCaml, but peeking into the parser/lexer, I couldn't find any.

This pull request adopts \ as a synonym for fun. This means that

```
let foo = fun x -> x + 1
```

becomes

```
let foo = \x -> x + 1
```

which seems a lot cleaner to me.

The one thing that doesn't work well is that 

```
let foo = \
x -> x + 1
```

won't parse, because \ followed by newline is for some reason reserved by the lexer. If someone could enlighten me regarding this, I'd be very grateful. I don't think this is a big deal though, since nobody expects to write foo as above. It just means that automated tools producing ocaml code should use 'fun' rather than '\'.
