### PR TITLE
Clear caml_backtrace_last_exn before registering as root

### DIFF
--- a/asmrun/backtrace.c
+++ b/asmrun/backtrace.c
@@ -51,6 +51,7 @@ CAMLprim value caml_record_backtrace(value vflag)
     caml_backtrace_active = flag;
     caml_backtrace_pos = 0;
     if (flag) {
+      caml_backtrace_last_exn = Val_unit;
       caml_register_global_root(&caml_backtrace_last_exn);
     } else {
       caml_remove_global_root(&caml_backtrace_last_exn);

--- a/byterun/backtrace.c
+++ b/byterun/backtrace.c
@@ -73,6 +73,7 @@ CAMLprim value caml_record_backtrace(value vflag)
     caml_backtrace_active = flag;
     caml_backtrace_pos = 0;
     if (flag) {
+      caml_backtrace_last_exn = Val_unit;
       caml_register_global_root(&caml_backtrace_last_exn);
     } else {
       caml_remove_global_root(&caml_backtrace_last_exn);


### PR DESCRIPTION
Switching on backtrace recording registers `caml_backtrace_last_exn` as a global root, switching it off removes it.
But the value is never cleared, so that an arbitrary pointer to the ocaml heap can end up there and corrupts the GC.

Testcase (tested with 4.02.1 and 4.02.2):

``` ocaml
(* $ ocamlopt -g fail.ml
   $ ./a.out 
   Segmentation fault
*)
let test arg =
  Gc.minor ();
  Printexc.record_backtrace true;
  begin try raise (Invalid_argument (Bytes.copy "lalala"))
  with _ -> ()
  end; (* caml_backtrace_last_exn is now pointing to the exception *)
  Printexc.record_backtrace false; (* no longer a root *)
  Gc.minor (); (* minor heap clean, but caml_backtrace_last_exn still pointing to value *)
  ignore [arg; arg; arg]; (* allocate random stuff *)
  Printexc.record_backtrace true; (* again a root, pointing somewhere in minor heap *)
  Gc.minor () (* hopefully fails *)

let () = while true do test (); done
```
