### PR TITLE
fix "compatibility macros for runtime constants that recently changed names"

### DIFF
--- a/byterun/caml/compatibility.h
+++ b/byterun/caml/compatibility.h
@@ -17,8 +17,8 @@
 #define CAML_COMPATIBILITY_H
 
 /* internal global variables renamed between 4.02.1 and 4.03.0 */
-#define caml_stat_top_heap_size caml_stat_top_heap_wsz
-#define caml_stat_heap_size caml_stat_heap_wsz
+#define caml_stat_top_heap_size Bsize_wsize(caml_stat_top_heap_wsz)
+#define caml_stat_heap_size Bsize_wsize(caml_stat_heap_wsz)
 
 #ifndef CAML_NAME_SPACE
 


### PR DESCRIPTION
cf: https://github.com/ocaml/ocaml/commit/d5b3d2f7e4695561a5fa335d9ca4059b6c077517
