### PR TITLE
Refactor backtrace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@
 /asmrun/alloc.c
 /asmrun/array.c
 /asmrun/compare.c
+/asmrun/backtrace.c
 /asmrun/ints.c
 /asmrun/floats.c
 /asmrun/str.c

--- a/asmrun/Makefile
+++ b/asmrun/Makefile
@@ -26,8 +26,8 @@ COBJS=startup_aux.o startup.o \
   misc.o freelist.o major_gc.o minor_gc.o memory.o alloc.o compare.o ints.o \
   floats.o str.o array.o io.o extern.o intern.o hash.o sys.o parsing.o \
   gc_ctrl.o terminfo.o md5.o obj.o lexing.o printexc.o callback.o weak.o \
-  compact.o finalise.o custom.o $(UNIX_OR_WIN32).o backtrace.o natdynlink.o\
-  debugger.o meta.o dynlink.o
+  compact.o finalise.o custom.o $(UNIX_OR_WIN32).o backtrace_prim.o backtrace.o \
+  natdynlink.o debugger.o meta.o dynlink.o
 
 ASMOBJS=$(ARCH).o
 
@@ -127,6 +127,8 @@ main.c: ../byterun/main.c
 	ln -s ../byterun/main.c main.c
 startup_aux.c: ../byterun/startup_aux.c
 	ln -s ../byterun/startup_aux.c startup_aux.c
+backtrace.c: ../byterun/backtrace.c
+	ln -s ../byterun/backtrace.c backtrace.c
 misc.c: ../byterun/misc.c
 	ln -s ../byterun/misc.c misc.c
 freelist.c: ../byterun/freelist.c

--- a/asmrun/backtrace_prim.c
+++ b/asmrun/backtrace_prim.c
@@ -33,14 +33,14 @@
    In particular, we do not need to use [caml_modify] when setting
    an array element with such a value.
 */
-value caml_raw_backtrace_slot_of_code(code_t pc)
+value caml_val_raw_backtrace_slot(backtrace_slot pc)
 {
   return Val_long((uintnat)pc>>1);
 }
 
-code_t caml_raw_backtrace_slot_code(value v)
+backtrace_slot caml_raw_backtrace_slot_val(value v)
 {
-  return ((code_t)(Long_val(v)<<1));
+  return ((backtrace_slot)(Long_val(v)<<1));
 }
 
 /* returns the next frame descriptor (or NULL if none is available),
@@ -99,7 +99,7 @@ void caml_stash_backtrace(value exn, uintnat pc, char * sp, char * trapsp)
   }
   if (caml_backtrace_buffer == NULL) {
     Assert(caml_backtrace_pos == 0);
-    caml_backtrace_buffer = malloc(BACKTRACE_BUFFER_SIZE * sizeof(code_t));
+    caml_backtrace_buffer = malloc(BACKTRACE_BUFFER_SIZE * sizeof(backtrace_slot));
     if (caml_backtrace_buffer == NULL) return;
   }
 
@@ -109,7 +109,7 @@ void caml_stash_backtrace(value exn, uintnat pc, char * sp, char * trapsp)
     if (descr == NULL) return;
     /* store its descriptor in the backtrace buffer */
     if (caml_backtrace_pos >= BACKTRACE_BUFFER_SIZE) return;
-    caml_backtrace_buffer[caml_backtrace_pos++] = (code_t) descr;
+    caml_backtrace_buffer[caml_backtrace_pos++] = (backtrace_slot) descr;
 
     /* Stop when we reach the current exception handler */
 #ifndef Stack_grows_upwards
@@ -170,7 +170,7 @@ CAMLprim value caml_get_current_callstack(value max_frames_value) {
     for (trace_pos = 0; trace_pos < trace_size; trace_pos++) {
       frame_descr * descr = caml_next_frame_descriptor(&pc, &sp);
       Assert(descr != NULL);
-      Field(trace, trace_pos) = caml_raw_backtrace_slot_of_code((code_t) descr);
+      Field(trace, trace_pos) = caml_val_raw_backtrace_slot((backtrace_slot) descr);
     }
   }
 
@@ -179,7 +179,7 @@ CAMLprim value caml_get_current_callstack(value max_frames_value) {
 
 /* Extract location information for the given frame descriptor */
 
-void caml_extract_location_info(code_t slot, /*out*/ struct caml_loc_info * li)
+void caml_extract_location_info(backtrace_slot slot, /*out*/ struct caml_loc_info * li)
 {
   uintnat infoptr;
   uint32_t info1, info2;
@@ -217,12 +217,12 @@ void caml_extract_location_info(code_t slot, /*out*/ struct caml_loc_info * li)
   li->loc_endchr = ((info2 & 0xF) << 6) | (info1 >> 26);
 }
 
-CAMLprim value caml_add_debug_info(code_t start, value size, value events)
+CAMLprim value caml_add_debug_info(backtrace_slot start, value size, value events)
 {
   return Val_unit;
 }
 
-CAMLprim value caml_remove_debug_info(code_t start)
+CAMLprim value caml_remove_debug_info(backtrace_slot start)
 {
   return Val_unit;
 }

--- a/asmrun/backtrace_prim.c
+++ b/asmrun/backtrace_prim.c
@@ -19,52 +19,28 @@
 
 #include "caml/alloc.h"
 #include "caml/backtrace.h"
+#include "caml/backtrace_prim.h"
 #include "caml/memory.h"
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
 #include "stack.h"
-
-int caml_backtrace_active = 0;
-int caml_backtrace_pos = 0;
-code_t * caml_backtrace_buffer = NULL;
-value caml_backtrace_last_exn = Val_unit;
-#define BACKTRACE_BUFFER_SIZE 1024
 
 /* In order to prevent the GC from walking through the debug information
    (which have no headers), we transform frame_descr pointers into
    31/63 bits ocaml integers by shifting them by 1 to the right. We do
    not lose information as descr pointers are aligned.
 
-   In particular, we do not need to use [caml_initialize] when setting
+   In particular, we do not need to use [caml_modify] when setting
    an array element with such a value.
 */
-#define Val_Descrptr(descr) Val_long((uintnat)descr>>1)
-#define Descrptr_Val(v) ((frame_descr *) (Long_val(v)<<1))
-
-/* Start or stop the backtrace machinery */
-
-CAMLprim value caml_record_backtrace(value vflag)
+value caml_raw_backtrace_slot_of_code(code_t pc)
 {
-  int flag = Int_val(vflag);
-
-  if (flag != caml_backtrace_active) {
-    caml_backtrace_active = flag;
-    caml_backtrace_pos = 0;
-    if (flag) {
-      caml_backtrace_last_exn = Val_unit;
-      caml_register_global_root(&caml_backtrace_last_exn);
-    } else {
-      caml_remove_global_root(&caml_backtrace_last_exn);
-    }
-  }
-  return Val_unit;
+  return Val_long((uintnat)pc>>1);
 }
 
-/* Return the status of the backtrace machinery */
-
-CAMLprim value caml_backtrace_status(value vunit)
+code_t caml_raw_backtrace_slot_code(value v)
 {
-  return Val_bool(caml_backtrace_active);
+  return ((code_t)(Long_val(v)<<1));
 }
 
 /* returns the next frame descriptor (or NULL if none is available),
@@ -194,7 +170,7 @@ CAMLprim value caml_get_current_callstack(value max_frames_value) {
     for (trace_pos = 0; trace_pos < trace_size; trace_pos++) {
       frame_descr * descr = caml_next_frame_descriptor(&pc, &sp);
       Assert(descr != NULL);
-      Field(trace, trace_pos) = Val_Descrptr(descr);
+      Field(trace, trace_pos) = caml_raw_backtrace_slot_of_code((code_t) descr);
     }
   }
 
@@ -203,11 +179,11 @@ CAMLprim value caml_get_current_callstack(value max_frames_value) {
 
 /* Extract location information for the given frame descriptor */
 
-CAMLexport void extract_location_info(frame_descr * d,
-                                  /*out*/ struct caml_loc_info * li)
+void caml_extract_location_info(code_t slot, /*out*/ struct caml_loc_info * li)
 {
   uintnat infoptr;
   uint32_t info1, info2;
+  frame_descr * d = (frame_descr *)slot;
 
   /* If no debugging information available, print nothing.
      When everything is compiled with -g, this corresponds to
@@ -241,121 +217,6 @@ CAMLexport void extract_location_info(frame_descr * d,
   li->loc_endchr = ((info2 & 0xF) << 6) | (info1 >> 26);
 }
 
-/* Print location information -- same behavior as in Printexc
-
-   note that the test for compiler-inserted raises is slightly redundant:
-     (!li->loc_valid && li->loc_is_raise)
-   extract_location_info above guarantees that when li->loc_valid is
-   0, then li->loc_is_raise is always 1, so the latter test is
-   useless. We kept it to keep code identical to the byterun/
-   implementation. */
-
-static void print_location(struct caml_loc_info * li, int index)
-{
-  char * info;
-
-  /* Ignore compiler-inserted raise */
-  if (!li->loc_valid && li->loc_is_raise) return;
-
-  if (li->loc_is_raise) {
-    /* Initial raise if index == 0, re-raise otherwise */
-    if (index == 0)
-      info = "Raised at";
-    else
-      info = "Re-raised at";
-  } else {
-    if (index == 0)
-      info = "Raised by primitive operation at";
-    else
-      info = "Called from";
-  }
-  if (! li->loc_valid) {
-    fprintf(stderr, "%s unknown location\n", info);
-  } else {
-    fprintf (stderr, "%s file \"%s\", line %d, characters %d-%d\n",
-             info, li->loc_filename, li->loc_lnum,
-             li->loc_startchr, li->loc_endchr);
-  }
-}
-
-/* Print a backtrace */
-
-void caml_print_exception_backtrace(void)
-{
-  int i;
-  struct caml_loc_info li;
-
-  for (i = 0; i < caml_backtrace_pos; i++) {
-    extract_location_info((frame_descr *) (caml_backtrace_buffer[i]), &li);
-    print_location(&li, i);
-  }
-}
-
-/* Convert the raw backtrace to a data structure usable from OCaml */
-
-CAMLprim value caml_convert_raw_backtrace_slot(value backtrace_slot) {
-  CAMLparam1(backtrace_slot);
-  CAMLlocal2(p, fname);
-  struct caml_loc_info li;
-
-  extract_location_info(Descrptr_Val(backtrace_slot), &li);
-
-  if (li.loc_valid) {
-    fname = caml_copy_string(li.loc_filename);
-    p = caml_alloc_small(5, 0);
-    Field(p, 0) = Val_bool(li.loc_is_raise);
-    Field(p, 1) = fname;
-    Field(p, 2) = Val_int(li.loc_lnum);
-    Field(p, 3) = Val_int(li.loc_startchr);
-    Field(p, 4) = Val_int(li.loc_endchr);
-  } else {
-    p = caml_alloc_small(1, 1);
-    Field(p, 0) = Val_bool(li.loc_is_raise);
-  }
-
-  CAMLreturn(p);
-}
-
-/* Get a copy of the latest backtrace */
-
-CAMLprim value caml_get_exception_raw_backtrace(value unit)
-{
-  CAMLparam0();
-  CAMLlocal1(res);
-  const int tag = 0;
-
-  /* Beware: the allocations below may cause finalizers to be run, and another
-     backtrace---possibly of a different length---to be stashed (for example
-     if the finalizer raises then catches an exception).  We choose to ignore
-     any such finalizer backtraces and return the original one. */
-
-  if (caml_backtrace_buffer == NULL || caml_backtrace_pos == 0) {
-    res = caml_alloc(0, tag);
-  }
-  else {
-    code_t saved_caml_backtrace_buffer[BACKTRACE_BUFFER_SIZE];
-    int saved_caml_backtrace_pos;
-    intnat i;
-
-    saved_caml_backtrace_pos = caml_backtrace_pos;
-
-    if (saved_caml_backtrace_pos > BACKTRACE_BUFFER_SIZE) {
-      saved_caml_backtrace_pos = BACKTRACE_BUFFER_SIZE;
-    }
-
-    memcpy(saved_caml_backtrace_buffer, caml_backtrace_buffer,
-           saved_caml_backtrace_pos * sizeof(code_t));
-
-    res = caml_alloc(saved_caml_backtrace_pos, tag);
-    for (i = 0; i < saved_caml_backtrace_pos; i++) {
-      /* [Val_Descrptr] always returns an immediate. */
-      Field(res, i) = Val_Descrptr(saved_caml_backtrace_buffer[i]);
-    }
-  }
-
-  CAMLreturn(res);
-}
-
 CAMLprim value caml_add_debug_info(code_t start, value size, value events)
 {
   return Val_unit;
@@ -366,29 +227,7 @@ CAMLprim value caml_remove_debug_info(code_t start)
   return Val_unit;
 }
 
-/* the function below is deprecated: we previously returned directly
-   the OCaml-usable representation, instead of the raw backtrace as an
-   abstract type, but this has a large performance overhead if you
-   store a lot of backtraces and print only some of them.
-
-   It is not used by the Printexc library anymore, or anywhere else in
-   the compiler, but we have kept it in case some user still depends
-   on it as an external.
-*/
-
-CAMLprim value caml_get_exception_backtrace(value unit)
+int caml_debug_info_available(void)
 {
-  CAMLparam0();
-  CAMLlocal3(arr, res, backtrace);
-  intnat i;
-
-  backtrace = caml_get_exception_raw_backtrace(Val_unit);
-
-  arr = caml_alloc(Wosize_val(backtrace), 0);
-  for (i = 0; i < Wosize_val(backtrace); i++) {
-    Store_field(arr, i, caml_convert_raw_backtrace_slot(Field(backtrace, i)));
-  }
-
-  res = caml_alloc_small(1, 0); Field(res, 0) = arr; /* Some */
-  CAMLreturn(res);
+  return 1;
 }

--- a/asmrun/backtrace_prim.c
+++ b/asmrun/backtrace_prim.c
@@ -28,11 +28,7 @@
 /* In order to prevent the GC from walking through the debug information
    (which have no headers), we transform frame_descr pointers into
    31/63 bits ocaml integers by shifting them by 1 to the right. We do
-   not lose information as descr pointers are aligned.
-
-   In particular, we do not need to use [caml_modify] when setting
-   an array element with such a value.
-*/
+   not lose information as descr pointers are aligned.  */
 value caml_val_raw_backtrace_slot(backtrace_slot pc)
 {
   return Val_long((uintnat)pc>>1);
@@ -43,9 +39,8 @@ backtrace_slot caml_raw_backtrace_slot_val(value v)
   return ((backtrace_slot)(Long_val(v)<<1));
 }
 
-/* returns the next frame descriptor (or NULL if none is available),
+/* Returns the next frame descriptor (or NULL if none is available),
    and updates *pc and *sp to point to the following one.  */
-
 frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp)
 {
   frame_descr * d;
@@ -90,7 +85,6 @@ frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp)
    preserved the global, statically bounded buffer of the old
    implementation -- before the more flexible
    [caml_get_current_callstack] was implemented. */
-
 void caml_stash_backtrace(value exn, uintnat pc, char * sp, char * trapsp)
 {
   if (exn != caml_backtrace_last_exn) {
@@ -126,8 +120,8 @@ void caml_stash_backtrace(value exn, uintnat pc, char * sp, char * trapsp)
    (hopefully less often). Instead of using a bounded buffer as
    [caml_stash_backtrace], we first traverse the stack to compute the
    right size, then allocate space for the trace. */
-
-CAMLprim value caml_get_current_callstack(value max_frames_value) {
+CAMLprim value caml_get_current_callstack(value max_frames_value)
+{
   CAMLparam1(max_frames_value);
   CAMLlocal1(trace);
 
@@ -170,7 +164,7 @@ CAMLprim value caml_get_current_callstack(value max_frames_value) {
     for (trace_pos = 0; trace_pos < trace_size; trace_pos++) {
       frame_descr * descr = caml_next_frame_descriptor(&pc, &sp);
       Assert(descr != NULL);
-      Field(trace, trace_pos) = caml_val_raw_backtrace_slot((backtrace_slot) descr);
+      Store_field(trace, trace_pos, caml_val_raw_backtrace_slot((backtrace_slot) descr));
     }
   }
 
@@ -178,7 +172,6 @@ CAMLprim value caml_get_current_callstack(value max_frames_value) {
 }
 
 /* Extract location information for the given frame descriptor */
-
 void caml_extract_location_info(backtrace_slot slot, /*out*/ struct caml_loc_info * li)
 {
   uintnat infoptr;

--- a/asmrun/stack.h
+++ b/asmrun/stack.h
@@ -78,15 +78,6 @@ typedef struct {
   unsigned short live_ofs[1];
 } frame_descr;
 
-struct caml_loc_info {
-  int loc_valid;
-  int loc_is_raise;
-  char * loc_filename;
-  int loc_lnum;
-  int loc_startchr;
-  int loc_endchr;
-};
-
 /* Hash table of frame descriptors */
 
 extern frame_descr ** caml_frame_descriptors;
@@ -99,10 +90,6 @@ extern void caml_init_frame_descriptors(void);
 extern void caml_register_frametable(intnat *);
 extern void caml_unregister_frametable(intnat *);
 extern void caml_register_dyn_global(void *);
-
-CAMLextern void extract_location_info(frame_descr * d,
-                                      /*out*/ struct caml_loc_info * li);
-
 
 extern uintnat caml_stack_usage (void);
 extern uintnat (*caml_stack_usage_hook)(void);

--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -117,6 +117,7 @@ void caml_main(char **argv)
                 caml_init_max_percent_free);
   init_static();
   caml_init_signals();
+  caml_init_backtrace();
   caml_debugger_init (); /* force debugger.o stub to be linked */
   exe_name = argv[0];
   if (exe_name == NULL) exe_name = "";

--- a/byterun/Makefile.common
+++ b/byterun/Makefile.common
@@ -20,7 +20,7 @@ CC=$(BYTECC)
 COMMONOBJS=\
   interp.o misc.o stacks.o fix_code.o startup_aux.o startup.o \
   freelist.o major_gc.o minor_gc.o memory.o alloc.o roots.o globroots.o \
-  fail.o signals.o signals_byt.o printexc.o backtrace.o \
+  fail.o signals.o signals_byt.o printexc.o backtrace_prim.o backtrace.o \
   compare.o ints.o floats.o str.o array.o io.o extern.o intern.o \
   hash.o sys.o meta.o parsing.o gc_ctrl.o terminfo.o md5.o obj.o \
   lexing.o callback.o debugger.o weak.o compact.o finalise.o custom.o \
@@ -30,7 +30,7 @@ PRIMS=\
   alloc.c array.c compare.c extern.c floats.c gc_ctrl.c hash.c \
   intern.c interp.c ints.c io.c lexing.c md5.c meta.c obj.c parsing.c \
   signals.c str.c sys.c terminfo.c callback.c weak.c finalise.c stacks.c \
-  dynlink.c backtrace.c
+  dynlink.c backtrace_prim.c backtrace.c
 
 PUBLIC_INCLUDES=\
   address_class.h alloc.h callback.h config.h custom.h fail.h gc.h \

--- a/byterun/backtrace.c
+++ b/byterun/backtrace.c
@@ -143,7 +143,7 @@ CAMLprim value caml_get_exception_raw_backtrace(value unit)
 
     res = caml_alloc(saved_caml_backtrace_pos, 0);
     for (i = 0; i < saved_caml_backtrace_pos; i++) {
-      Store_field(res, i, caml_val_raw_backtrace_slot(saved_caml_backtrace_buffer[i]));
+      Field(res, i) = caml_val_raw_backtrace_slot(saved_caml_backtrace_buffer[i]);
     }
   }
 

--- a/byterun/backtrace.c
+++ b/byterun/backtrace.c
@@ -37,7 +37,6 @@ void caml_init_backtrace(void)
 }
 
 /* Start or stop the backtrace machinery */
-
 CAMLprim value caml_record_backtrace(value vflag)
 {
   int flag = Int_val(vflag);
@@ -54,7 +53,6 @@ CAMLprim value caml_record_backtrace(value vflag)
 }
 
 /* Return the status of the backtrace machinery */
-
 CAMLprim value caml_backtrace_status(value vunit)
 {
   return Val_bool(caml_backtrace_active);
@@ -68,7 +66,6 @@ CAMLprim value caml_backtrace_status(value vunit)
    0, then li->loc_is_raise is always 1, so the latter test is
    useless. We kept it to keep code identical to the byterun/
    implementation. */
-
 static void print_location(struct caml_loc_info * li, int index)
 {
   char * info;
@@ -98,7 +95,6 @@ static void print_location(struct caml_loc_info * li, int index)
 }
 
 /* Print a backtrace */
-
 CAMLexport void caml_print_exception_backtrace(void)
 {
   int i;
@@ -116,7 +112,6 @@ CAMLexport void caml_print_exception_backtrace(void)
 }
 
 /* Get a copy of the latest backtrace */
-
 CAMLprim value caml_get_exception_raw_backtrace(value unit)
 {
   CAMLparam0();
@@ -156,7 +151,6 @@ CAMLprim value caml_get_exception_raw_backtrace(value unit)
 }
 
 /* Convert the raw backtrace to a data structure usable from OCaml */
-
 CAMLprim value caml_convert_raw_backtrace_slot(value backtrace_slot)
 {
   CAMLparam1(backtrace_slot);
@@ -191,9 +185,7 @@ CAMLprim value caml_convert_raw_backtrace_slot(value backtrace_slot)
 
    It is not used by the Printexc library anymore, or anywhere else in
    the compiler, but we have kept it in case some user still depends
-   on it as an external.
-*/
-
+   on it as an external.  */
 CAMLprim value caml_get_exception_backtrace(value unit)
 {
   CAMLparam0();

--- a/byterun/backtrace.c
+++ b/byterun/backtrace.c
@@ -31,6 +31,11 @@ CAMLexport int caml_backtrace_pos = 0;
 CAMLexport backtrace_slot * caml_backtrace_buffer = NULL;
 CAMLexport value caml_backtrace_last_exn = Val_unit;
 
+void caml_init_backtrace(void)
+{
+  caml_register_global_root(&caml_backtrace_last_exn);
+}
+
 /* Start or stop the backtrace machinery */
 
 CAMLprim value caml_record_backtrace(value vflag)
@@ -40,12 +45,7 @@ CAMLprim value caml_record_backtrace(value vflag)
   if (flag != caml_backtrace_active) {
     caml_backtrace_active = flag;
     caml_backtrace_pos = 0;
-    if (flag) {
-      caml_backtrace_last_exn = Val_unit;
-      caml_register_global_root(&caml_backtrace_last_exn);
-    } else {
-      caml_remove_global_root(&caml_backtrace_last_exn);
-    }
+    caml_backtrace_last_exn = Val_unit;
     /* Note: lazy initialization of caml_backtrace_buffer in
        caml_stash_backtrace to simplify the interface with the thread
        libraries */

--- a/byterun/backtrace_prim.c
+++ b/byterun/backtrace_prim.c
@@ -140,8 +140,8 @@ struct ev_info *process_debug_events(code_t code_start, value events_heap, mlsiz
         if(events[j].ev_filename == NULL)
           caml_fatal_error ("caml_add_debug_info: out of memory");
         memcpy(events[j].ev_filename,
-               String_val(Field(ev_start, POS_FNAME)),
-               fnsz);
+            String_val(Field(ev_start, POS_FNAME)),
+            fnsz);
       }
 
       events[j].ev_lnum = Int_val(Field(ev_start, POS_LNUM));
@@ -318,7 +318,7 @@ CAMLprim value caml_get_current_callstack(value max_frames_value)
     for (trace_pos = 0; trace_pos < trace_size; trace_pos++) {
       code_t p = caml_next_frame_pointer(&sp, &trsp);
       Assert(p != NULL);
-      Field(trace, trace_pos) = caml_val_raw_backtrace_slot(p);
+      Store_field(trace, trace_pos, caml_val_raw_backtrace_slot(p));
     }
   }
 
@@ -412,18 +412,18 @@ static struct ev_info *event_for_location(code_t pc)
 
   low = 0;
   high = di->num_events;
-  while(low+1 < high) {
+  while (low+1 < high) {
     uintnat m = (low+high)/2;
     if(pc < di->events[m].ev_pc) high = m;
     else low = m;
   }
-  if(di->events[low].ev_pc == pc)
+  if (di->events[low].ev_pc == pc)
     return &di->events[low];
   /* ocamlc sometimes moves an event past a following PUSH instruction;
      allow mismatch by 1 instruction. */
-  if(di->events[low].ev_pc == pc + 1)
+  if (di->events[low].ev_pc == pc + 1)
     return &di->events[low];
-  if(low+1 < di->num_events && di->events[low+1].ev_pc == pc + 1)
+  if (low+1 < di->num_events && di->events[low+1].ev_pc == pc + 1)
     return &di->events[low+1];
 
   return NULL;
@@ -435,7 +435,8 @@ void caml_extract_location_info(backtrace_slot slot, /*out*/ struct caml_loc_inf
 {
   code_t pc = slot;
   struct ev_info *event = event_for_location(pc);
-  li->loc_is_raise = caml_is_instruction(*pc, RAISE) ||
+  li->loc_is_raise =
+    caml_is_instruction(*pc, RAISE) ||
     caml_is_instruction(*pc, RERAISE);
   if (event == NULL) {
     li->loc_valid = 0;

--- a/byterun/backtrace_prim.c
+++ b/byterun/backtrace_prim.c
@@ -250,14 +250,14 @@ void caml_stash_backtrace(value exn, code_t pc, value * sp, int reraise)
    In particular, we do not need to use [caml_modify] when setting
    an array element with such a value.
 */
-value caml_raw_backtrace_slot_of_code(code_t pc)
+value caml_val_raw_backtrace_slot(backtrace_slot pc)
 {
   return Val_long ((uintnat)pc >> 1);
 }
 
-code_t caml_raw_backtrace_slot_code(value v)
+backtrace_slot caml_raw_backtrace_slot_val(value v)
 {
-  return ((code_t)(Long_val(v) << 1));
+  return ((backtrace_slot)(Long_val(v) << 1));
 }
 
 /* returns the next frame pointer (or NULL if none is available);
@@ -318,7 +318,7 @@ CAMLprim value caml_get_current_callstack(value max_frames_value)
     for (trace_pos = 0; trace_pos < trace_size; trace_pos++) {
       code_t p = caml_next_frame_pointer(&sp, &trsp);
       Assert(p != NULL);
-      Field(trace, trace_pos) = caml_raw_backtrace_slot_of_code(p);
+      Field(trace, trace_pos) = caml_val_raw_backtrace_slot(p);
     }
   }
 
@@ -431,8 +431,9 @@ static struct ev_info *event_for_location(code_t pc)
 
 /* Extract location information for the given PC */
 
-void caml_extract_location_info(code_t pc, /*out*/ struct caml_loc_info * li)
+void caml_extract_location_info(backtrace_slot slot, /*out*/ struct caml_loc_info * li)
 {
+  code_t pc = slot;
   struct ev_info *event = event_for_location(pc);
   li->loc_is_raise = caml_is_instruction(*pc, RAISE) ||
     caml_is_instruction(*pc, RERAISE);

--- a/byterun/backtrace_prim.c
+++ b/byterun/backtrace_prim.c
@@ -383,7 +383,7 @@ void read_main_debug_info(struct debug_info *di)
   CAMLreturn0;
 }
 
-CAMLexport void caml_init_debug_info()
+CAMLexport void caml_init_debug_info(void)
 {
   caml_ext_table_init(&caml_debug_info, 1);
   caml_add_debug_info(caml_start_code, Val_long(caml_code_size), Val_unit);

--- a/byterun/backtrace_prim.c
+++ b/byterun/backtrace_prim.c
@@ -1,0 +1,448 @@
+/***********************************************************************/
+/*                                                                     */
+/*                                OCaml                                */
+/*                                                                     */
+/*            Xavier Leroy, projet Cristal, INRIA Rocquencourt         */
+/*                                                                     */
+/*  Copyright 2000 Institut National de Recherche en Informatique et   */
+/*  en Automatique.  All rights reserved.  This file is distributed    */
+/*  under the terms of the GNU Library General Public License, with    */
+/*  the special exception on linking described in file ../LICENSE.     */
+/*                                                                     */
+/***********************************************************************/
+
+/* Stack backtrace for uncaught exceptions */
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "caml/config.h"
+#ifdef HAS_UNISTD
+#include <unistd.h>
+#endif
+
+#include "caml/mlvalues.h"
+#include "caml/alloc.h"
+#include "caml/custom.h"
+#include "caml/io.h"
+#include "caml/instruct.h"
+#include "caml/intext.h"
+#include "caml/exec.h"
+#include "caml/fix_code.h"
+#include "caml/memory.h"
+#include "caml/startup.h"
+#include "caml/stacks.h"
+#include "caml/sys.h"
+#include "caml/backtrace.h"
+#include "caml/fail.h"
+#include "caml/backtrace_prim.h"
+
+/* The table of debug information fragments */
+struct ext_table caml_debug_info;
+
+CAMLexport char * caml_cds_file = NULL;
+
+/* Location of fields in the Instruct.debug_event record */
+enum {
+  EV_POS = 0,
+  EV_MODULE = 1,
+  EV_LOC = 2,
+  EV_KIND = 3
+};
+
+/* Location of fields in the Location.t record. */
+enum {
+  LOC_START = 0,
+  LOC_END = 1,
+  LOC_GHOST = 2
+};
+
+/* Location of fields in the Lexing.position record. */
+enum {
+  POS_FNAME = 0,
+  POS_LNUM = 1,
+  POS_BOL = 2,
+  POS_CNUM = 3
+};
+
+/* Runtime representation of the debug information, optimized
+   for quick lookup */
+struct ev_info {
+  code_t ev_pc;
+  char *ev_filename;
+  int ev_lnum;
+  int ev_startchr;
+  int ev_endchr;
+};
+
+struct debug_info {
+  code_t start;
+  code_t end;
+  mlsize_t num_events;
+  struct ev_info *events;
+  int already_read;
+};
+
+static struct debug_info *find_debug_info(code_t pc)
+{
+  int i;
+  for (i = 0; i < caml_debug_info.size; i++) {
+    struct debug_info *di = caml_debug_info.contents[i];
+    if (pc >= di->start && pc < di->end)
+      return di;
+  }
+  return NULL;
+}
+
+static int cmp_ev_info(const void *a, const void *b)
+{
+  code_t pc_a = ((const struct ev_info*)a)->ev_pc;
+  code_t pc_b = ((const struct ev_info*)b)->ev_pc;
+  if (pc_a > pc_b) return 1;
+  if (pc_a < pc_b) return -1;
+  return 0;
+}
+
+struct ev_info *process_debug_events(code_t code_start, value events_heap, mlsize_t *num_events)
+{
+  CAMLparam1(events_heap);
+  CAMLlocal3(l, ev, ev_start);
+  mlsize_t i, j;
+  struct ev_info *events;
+
+  /* Compute the size of the required event buffer. */
+  *num_events = 0;
+  for (i = 0; i < caml_array_length(events_heap); i++)
+    for (l = Field(events_heap, i); l != Val_int(0); l = Field(l, 1))
+      (*num_events)++;
+
+  if (*num_events == 0)
+      CAMLreturnT(struct ev_info *, NULL);
+
+  events = malloc(*num_events * sizeof(struct ev_info));
+  if(events == NULL)
+    caml_fatal_error ("caml_add_debug_info: out of memory");
+
+  j = 0;
+  for (i = 0; i < caml_array_length(events_heap); i++) {
+    for (l = Field(events_heap, i); l != Val_int(0); l = Field(l, 1)) {
+      ev = Field(l, 0);
+
+      events[j].ev_pc = (code_t)((char*)code_start + Long_val(Field(ev, EV_POS)));
+
+      ev_start = Field(Field(ev, EV_LOC), LOC_START);
+
+      {
+        uintnat fnsz = caml_string_length(Field(ev_start, POS_FNAME)) + 1;
+        events[j].ev_filename = (char*)malloc(fnsz);
+        if(events[j].ev_filename == NULL)
+          caml_fatal_error ("caml_add_debug_info: out of memory");
+        memcpy(events[j].ev_filename,
+               String_val(Field(ev_start, POS_FNAME)),
+               fnsz);
+      }
+
+      events[j].ev_lnum = Int_val(Field(ev_start, POS_LNUM));
+      events[j].ev_startchr =
+        Int_val(Field(ev_start, POS_CNUM))
+        - Int_val(Field(ev_start, POS_BOL));
+      events[j].ev_endchr =
+        Int_val(Field(Field(Field(ev, EV_LOC), LOC_END), POS_CNUM))
+        - Int_val(Field(ev_start, POS_BOL));
+
+      j++;
+    }
+  }
+
+  Assert(j == *num_events);
+
+  qsort(events, *num_events, sizeof(struct ev_info), cmp_ev_info);
+
+  CAMLreturnT(struct ev_info *, events);
+}
+
+/* Processes a (Instruct.debug_event list array) into a form suitable
+   for quick lookup and registers it for the (code_start,code_size) pc range. */
+CAMLprim value caml_add_debug_info(code_t code_start, value code_size, value events_heap)
+{
+  CAMLparam1(events_heap);
+  struct debug_info *debug_info;
+
+  /* build the OCaml-side debug_info value */
+  debug_info = caml_stat_alloc(sizeof(struct debug_info));
+
+  debug_info->start = code_start;
+  debug_info->end = (code_t)((char*) code_start + Long_val(code_size));
+  if (events_heap == Val_unit) {
+    debug_info->events = NULL;
+    debug_info->num_events = 0;
+    debug_info->already_read = 0;
+  } else {
+    debug_info->events =
+      process_debug_events(code_start, events_heap, &debug_info->num_events);
+    debug_info->already_read = 1;
+  }
+
+  caml_ext_table_add(&caml_debug_info, debug_info);
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value caml_remove_debug_info(code_t start)
+{
+  CAMLparam0();
+  CAMLlocal2(dis, prev);
+
+  int i;
+  for (i = 0; i < caml_debug_info.size; i++) {
+    struct debug_info *di = caml_debug_info.contents[i];
+    if (di->start == start) {
+      /* note that caml_ext_table_remove calls caml_stat_free on the
+         removed resource, bracketing the caml_stat_alloc call in
+         caml_add_debug_info. */
+      caml_ext_table_remove(&caml_debug_info, di);
+      break;
+    }
+  }
+
+  CAMLreturn(Val_unit);
+}
+
+/* Store the return addresses contained in the given stack fragment
+   into the backtrace array */
+
+void caml_stash_backtrace(value exn, code_t pc, value * sp, int reraise)
+{
+  if (pc != NULL) pc = pc - 1;
+  if (exn != caml_backtrace_last_exn || !reraise) {
+    caml_backtrace_pos = 0;
+    caml_backtrace_last_exn = exn;
+  }
+
+  if (caml_backtrace_buffer == NULL) {
+    Assert(caml_backtrace_pos == 0);
+    caml_backtrace_buffer = malloc(BACKTRACE_BUFFER_SIZE * sizeof(code_t));
+    if (caml_backtrace_buffer == NULL) return;
+  }
+
+  if (caml_backtrace_pos >= BACKTRACE_BUFFER_SIZE) return;
+  /* testing the code region is needed: PR#1554 */
+  if (find_debug_info(pc) != NULL)
+    caml_backtrace_buffer[caml_backtrace_pos++] = pc;
+
+  /* Traverse the stack and put all values pointing into bytecode
+     into the backtrace buffer. */
+  for (/*nothing*/; sp < caml_trapsp; sp++) {
+    code_t p = (code_t) *sp;
+    if (caml_backtrace_pos >= BACKTRACE_BUFFER_SIZE) break;
+    if (find_debug_info(p) != NULL)
+      caml_backtrace_buffer[caml_backtrace_pos++] = p;
+  }
+}
+
+/* In order to prevent the GC from walking through the debug
+   information (which have no headers), we transform code pointers to
+   31/63 bits ocaml integers by shifting them by 1 to the right. We do
+   not lose information as code pointers are aligned.
+
+   In particular, we do not need to use [caml_modify] when setting
+   an array element with such a value.
+*/
+value caml_raw_backtrace_slot_of_code(code_t pc)
+{
+  return Val_long ((uintnat)pc >> 1);
+}
+
+code_t caml_raw_backtrace_slot_code(value v)
+{
+  return ((code_t)(Long_val(v) << 1));
+}
+
+/* returns the next frame pointer (or NULL if none is available);
+   updates *sp to point to the following one, and *trsp to the next
+   trap frame, which we will skip when we reach it  */
+
+code_t caml_next_frame_pointer(value ** sp, value ** trsp)
+{
+  while (*sp < caml_stack_high) {
+    code_t *p = (code_t*) (*sp)++;
+    if(&Trap_pc(*trsp) == p) {
+      *trsp = Trap_link(*trsp);
+      continue;
+    }
+
+    if (find_debug_info(*p) != NULL)
+      return *p;
+  }
+  return NULL;
+}
+
+/* Stores upto [max_frames_value] frames of the current call stack to
+   return to the user. This is used not in an exception-raising
+   context, but only when the user requests to save the trace
+   (hopefully less often). Instead of using a bounded buffer as
+   [caml_stash_backtrace], we first traverse the stack to compute the
+   right size, then allocate space for the trace. */
+
+CAMLprim value caml_get_current_callstack(value max_frames_value)
+{
+  CAMLparam1(max_frames_value);
+  CAMLlocal1(trace);
+
+  /* we use `intnat` here because, were it only `int`, passing `max_int`
+     from the OCaml side would overflow on 64bits machines. */
+  intnat max_frames = Long_val(max_frames_value);
+  intnat trace_size;
+
+  /* first compute the size of the trace */
+  {
+    value * sp = caml_extern_sp;
+    value * trsp = caml_trapsp;
+
+    for (trace_size = 0; trace_size < max_frames; trace_size++) {
+      code_t p = caml_next_frame_pointer(&sp, &trsp);
+      if (p == NULL) break;
+    }
+  }
+
+  trace = caml_alloc(trace_size, 0);
+
+  /* then collect the trace */
+  {
+    value * sp = caml_extern_sp;
+    value * trsp = caml_trapsp;
+    uintnat trace_pos;
+
+    for (trace_pos = 0; trace_pos < trace_size; trace_pos++) {
+      code_t p = caml_next_frame_pointer(&sp, &trsp);
+      Assert(p != NULL);
+      Field(trace, trace_pos) = caml_raw_backtrace_slot_of_code(p);
+    }
+  }
+
+  CAMLreturn(trace);
+}
+
+/* Read the debugging info contained in the current bytecode executable. */
+
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
+void read_main_debug_info(struct debug_info *di)
+{
+  CAMLparam0();
+  CAMLlocal3(events, evl, l);
+  char *exec_name;
+  int fd, num_events, orig, i;
+  struct channel *chan;
+  struct exec_trailer trail;
+
+  Assert(di->already_read == 0);
+  di->already_read = 1;
+
+  if (caml_cds_file != NULL) {
+    exec_name = caml_cds_file;
+  } else {
+    exec_name = caml_exe_name;
+  }
+
+  fd = caml_attempt_open(&exec_name, &trail, 1);
+  if (fd < 0){
+    caml_fatal_error ("executable program file not found");
+    CAMLreturn0;
+  }
+
+  caml_read_section_descriptors(fd, &trail);
+  if (caml_seek_optional_section(fd, &trail, "DBUG") != -1) {
+    chan = caml_open_descriptor_in(fd);
+
+    num_events = caml_getword(chan);
+    events = caml_alloc(num_events, 0);
+
+    for (i = 0; i < num_events; i++) {
+      orig = caml_getword(chan);
+      evl = caml_input_val(chan);
+      caml_input_val(chan); /* Skip the list of absolute directory names */
+      /* Relocate events in event list */
+      for (l = evl; l != Val_int(0); l = Field(l, 1)) {
+        value ev = Field(l, 0);
+        Field(ev, EV_POS) = Val_long(Long_val(Field(ev, EV_POS)) + orig);
+      }
+      /* Record event list */
+      Store_field(events, i, evl);
+    }
+
+    caml_close_channel(chan);
+
+    di->events = process_debug_events(caml_start_code, events, &di->num_events);
+  }
+
+  CAMLreturn0;
+}
+
+CAMLexport void caml_init_debug_info()
+{
+  caml_ext_table_init(&caml_debug_info, 1);
+  caml_add_debug_info(caml_start_code, Val_long(caml_code_size), Val_unit);
+}
+
+int caml_debug_info_available(void)
+{
+  return (caml_debug_info.size != 0);
+}
+
+/* Search the event index for the given PC.  Return -1 if not found. */
+
+static struct ev_info *event_for_location(code_t pc)
+{
+  uintnat low, high;
+  struct debug_info *di = find_debug_info(pc);
+
+  if (di == NULL)
+    return NULL;
+
+  if (!di->already_read)
+    read_main_debug_info(di);
+
+  if (di->num_events == 0)
+    return NULL;
+
+  low = 0;
+  high = di->num_events;
+  while(low+1 < high) {
+    uintnat m = (low+high)/2;
+    if(pc < di->events[m].ev_pc) high = m;
+    else low = m;
+  }
+  if(di->events[low].ev_pc == pc)
+    return &di->events[low];
+  /* ocamlc sometimes moves an event past a following PUSH instruction;
+     allow mismatch by 1 instruction. */
+  if(di->events[low].ev_pc == pc + 1)
+    return &di->events[low];
+  if(low+1 < di->num_events && di->events[low+1].ev_pc == pc + 1)
+    return &di->events[low+1];
+
+  return NULL;
+}
+
+/* Extract location information for the given PC */
+
+void caml_extract_location_info(code_t pc, /*out*/ struct caml_loc_info * li)
+{
+  struct ev_info *event = event_for_location(pc);
+  li->loc_is_raise = caml_is_instruction(*pc, RAISE) ||
+    caml_is_instruction(*pc, RERAISE);
+  if (event == NULL) {
+    li->loc_valid = 0;
+    return;
+  }
+  li->loc_valid = 1;
+  li->loc_filename = event->ev_filename;
+  li->loc_lnum = event->ev_lnum;
+  li->loc_startchr = event->ev_startchr;
+  li->loc_endchr = event->ev_endchr;
+}

--- a/byterun/caml/backtrace.h
+++ b/byterun/caml/backtrace.h
@@ -17,38 +17,50 @@
 #include "mlvalues.h"
 #include "exec.h"
 
-/* Non zero iff backtraces are recorded.
- * This value shouldn't be set directly, one should use instead
- * [caml_record_backtrace] instead.
+/* Runtime support for backtrace generation.
  *
  * It has two kind of users:
- * - high-level functions reading it to determine whether a backtrace might be
- *   available;
- * - low-level runtime routines, to determine whether a backtrace should be generated
- *   when using "raise".
- */
-CAMLextern int caml_backtrace_active;
-
-/* Backtrace generation is split in multiple steps.
+ * - high-level API to capture and decode backtraces;
+ * - low-level runtime routines, to introspect machine state and determine
+ *   whether a backtrace should be generated when using "raise".
+ *
+ * Backtrace generation is split in multiple steps.
  * The lowest-level one, done by [backtrace_prim.c] just fills the
  * [caml_backtrace_buffer] variable each time a frame is unwinded.
  * At that point, we don't know whether the backtrace will be useful or not so
  * this code should be as fast as possible.
  *
- * If the backtrace happens to be useful, later passes will read [caml_backtrace_buffer]
- * and turn it into a [raw_backtrace] and then a [backtrace].
+ * If the backtrace happens to be useful, later passes will read
+ * [caml_backtrace_buffer] and turn it into a [raw_backtrace] and then a
+ * [backtrace].
  * This is done in [backtrace.c] and [stdlib/printexc.ml].
  *
- * The following type, [backtrace_slot] represents values stored in the
- * lowest-level buffer.
+ * Content of buffers
+ * ------------------
+ *
+ * [caml_backtrace_buffer] (really cheap)
+ *   Backend and process image dependent, abstracted by C-type backtrace_slot.
+ * [raw_backtrace] (cheap)
+ *   OCaml values of abstract type [Printexc.raw_backtrace_slot],
+ *   still backend and process image dependent (unsafe to marshal).
+ * [backtrace] (more expensive)
+ *   OCaml values of algebraic data-type [Printexc.backtrace_slot]
+ */
+
+/* Non zero iff backtraces are recorded.
+ * One should use to change this variable [caml_record_backtrace].
+ */
+CAMLextern int caml_backtrace_active;
+
+/* The [backtrace_slot] type represents values stored in the [caml_backtrace_buffer].
  * In bytecode, it is the same as a [code_t], in native code it as a [frame_descr *].
  * The difference doesn't matter for code outside [backtrace_prim.c], so it is
- * just exposed has a [backtrace_slot].
+ * just exposed as a [backtrace_slot].
  */
 typedef void * backtrace_slot;
 
 /* The [caml_backtrace_buffer] and [caml_backtrace_last_exn]
- * variables are valid only if caml_backtrace_active is non-null.
+ * variables are valid only if [caml_backtrace_active != 0].
  *
  * They are part of the state specific to each thread, and threading libraries
  * are responsible for copying them on context switch.
@@ -60,13 +72,13 @@ typedef void * backtrace_slot;
  * [caml_backtrace_pos] is always zero if [!caml_backtrace_active].
  *
  * Its maximum size is determined by [BACKTRACE_BUFFER_SIZE] from
- * [backtrace_prim.h] but this shouldn't affect users.
+ * [backtrace_prim.h], but this shouldn't affect users.
  */
 CAMLextern backtrace_slot * caml_backtrace_buffer;
 CAMLextern int caml_backtrace_pos;
 
 /* [caml_backtrace_last_exn] stores the last exception value that was raised,
- * iff [caml_backtrace_active].
+ * iff [caml_backtrace_active != 0].
  * It is tested for equality to determine whether a raise is a re-raise of the
  * same exception.
  *
@@ -81,26 +93,32 @@ CAMLextern value caml_backtrace_last_exn;
 
 /* [caml_record_backtrace] toggle backtrace recording on and off.
  * This function can be called at runtime by user-code, or during
- * initialization if backtrace were requested.
- * It is then called before initializating the GC, so it shouldn't allocate
- * memory.
+ * initialization if backtraces were requested.
+ *
+ * It might be called before GC initialization, so it shouldn't do OCaml
+ * allocation.
  */
 CAMLprim value caml_record_backtrace(value vflag);
 
+
 #ifndef NATIVE_CODE
+
 /* Path to the file containing debug information, if any, or NULL. */
 CAMLextern char * caml_cds_file;
+
 /* Primitive called _only_ by runtime to record unwinded frames to backtrace.
  * A similar primitive exists for native code, but with a different prototype. */
 extern void caml_stash_backtrace(value exn, code_t pc, value * sp, int reraise);
+
 #endif
+
 
 /* Default (C-level) printer for backtraces.
  * It is called if an exception causes a termination of the program or of a thread.
  *
  * [Printexc] provide a higher-level printer mimicking its output but making
- * use of registered custom exception printers, which replaces this printer
- * when program terminates and [Printexc] was initialized.
+ * use of registered exception printers, and is used when possible in place of
+ * this function after [Printexc] initialization.
  */
 CAMLextern void caml_print_exception_backtrace(void);
 

--- a/byterun/caml/backtrace.h
+++ b/byterun/caml/backtrace.h
@@ -17,17 +17,93 @@
 #include "mlvalues.h"
 #include "exec.h"
 
+/* Non zero iff backtraces are recorded.
+ * This value shouldn't be set directly, one should use instead
+ * [caml_record_backtrace] instead.
+ *
+ * It has two kind of users:
+ * - high-level functions reading it to determine whether a backtrace might be
+ *   available;
+ * - low-level runtime routines, to determine whether a backtrace should be generated
+ *   when using "raise".
+ */
 CAMLextern int caml_backtrace_active;
-CAMLextern int caml_backtrace_pos;
-CAMLextern code_t * caml_backtrace_buffer;
-CAMLextern value caml_backtrace_last_exn;
-CAMLextern char * caml_cds_file;
 
+/* Backtrace generation is split in multiple steps.
+ * The lowest-level one, done by [backtrace_prim.c] just fills the
+ * [caml_backtrace_buffer] variable each time a frame is unwinded.
+ * At that point, we don't know whether the backtrace will be useful or not so
+ * this code should be as fast as possible.
+ *
+ * If the backtrace happens to be useful, later passes will read [caml_backtrace_buffer]
+ * and turn it into a [raw_backtrace] and then a [backtrace].
+ * This is done in [backtrace.c] and [stdlib/printexc.ml].
+ *
+ * The following type, [backtrace_slot] represents values stored in the
+ * lowest-level buffer.
+ * In bytecode, it is the same as a [code_t], in native code it as a [frame_descr *].
+ * The difference doesn't matter for code outside [backtrace_prim.c], so it is
+ * just exposed has a [backtrace_slot].
+ */
+typedef void * backtrace_slot;
+
+/* The [caml_backtrace_buffer] and [caml_backtrace_last_exn]
+ * variables are valid only if caml_backtrace_active is non-null.
+ *
+ * They are part of the state specific to each thread, and threading libraries
+ * are responsible for copying them on context switch.
+ * See [otherlibs/systhreads/st_stubs.c] and [otherlibs/threads/scheduler.c].
+ */
+
+/* [caml_backtrace_buffer] is filled by runtime when unwinding stack.
+ * It is an array ranging from [0] to [caml_backtrace_pos - 1].
+ * [caml_backtrace_pos] is always zero if [!caml_backtrace_active].
+ *
+ * Its maximum size is determined by [BACKTRACE_BUFFER_SIZE] from
+ * [backtrace_prim.h] but this shouldn't affect users.
+ */
+CAMLextern backtrace_slot * caml_backtrace_buffer;
+CAMLextern int caml_backtrace_pos;
+
+/* [caml_backtrace_last_exn] stores the last exception value that was raised,
+ * iff [caml_backtrace_active].
+ * It is tested for equality to determine whether a raise is a re-raise of the
+ * same exception.
+ *
+ * FIXME: this shouldn't matter anymore. Since OCaml 4.02, non-parameterized
+ * exceptions are constant, so physical equality is no longer appropriate.
+ * raise and re-raise are distinguished by:
+ * - passing reraise = 1 to [caml_stash_backtrace] (see below) in the bytecode
+ *   interpreter;
+ * - directly resetting [caml_backtrace_pos] to 0 in native runtimes for raise.
+ */
+CAMLextern value caml_backtrace_last_exn;
+
+/* [caml_record_backtrace] toggle backtrace recording on and off.
+ * This function can be called at runtime by user-code, or during
+ * initialization if backtrace were requested.
+ * It is then called before initializating the GC, so it shouldn't allocate
+ * memory.
+ */
 CAMLprim value caml_record_backtrace(value vflag);
+
 #ifndef NATIVE_CODE
+/* Path to the file containing debug information, if any, or NULL. */
+CAMLextern char * caml_cds_file;
+/* Primitive called _only_ by runtime to record unwinded frames to backtrace.
+ * A similar primitive exists for native code, but with a different prototype. */
 extern void caml_stash_backtrace(value exn, code_t pc, value * sp, int reraise);
 #endif
+
+/* Default (C-level) printer for backtraces.
+ * It is called if an exception causes a termination of the program or of a thread.
+ *
+ * [Printexc] provide a higher-level printer mimicking its output but making
+ * use of registered custom exception printers, which replaces this printer
+ * when program terminates and [Printexc] was initialized.
+ */
 CAMLextern void caml_print_exception_backtrace(void);
+
 CAMLexport void caml_init_debug_info();
 
 #endif /* CAML_BACKTRACE_H */

--- a/byterun/caml/backtrace.h
+++ b/byterun/caml/backtrace.h
@@ -104,6 +104,7 @@ extern void caml_stash_backtrace(value exn, code_t pc, value * sp, int reraise);
  */
 CAMLextern void caml_print_exception_backtrace(void);
 
-CAMLexport void caml_init_debug_info();
+void caml_init_backtrace(void);
+CAMLexport void caml_init_debug_info(void);
 
 #endif /* CAML_BACKTRACE_H */

--- a/byterun/caml/backtrace_prim.h
+++ b/byterun/caml/backtrace_prim.h
@@ -14,6 +14,19 @@
 #ifndef CAML_BACKTRACE_PRIM_H
 #define CAML_BACKTRACE_PRIM_H
 
+#include "backtrace.h"
+
+/* Backtrace generation is split in the two files [backtrace.c] and [backtrace_prim.c].
+ *
+ * [backtrace_prim.c] contains all backend-specific code, and has two different
+ * implementations in [byterun/backtrace_prim.c] and [asmrun/backtrace_prim.c].
+ *
+ * [backtrace.c] has a unique implementation, and rely on [backtrace_prim.c] interface
+ * to expose a uniform higher level API.
+ *
+ * This file, [backtrace_prim.h] documents the interface expected by [backtrace.c].
+ */
+
 /* Extract location information for the given raw_backtrace_slot */
 
 struct caml_loc_info {
@@ -25,12 +38,16 @@ struct caml_loc_info {
   int loc_endchr;
 };
 
+/* Check availability of debug information before extracting a trace.
+ * Relevant for bytecode, always true for native code. */
 int caml_debug_info_available(void);
-void caml_extract_location_info(code_t pc, /*out*/ struct caml_loc_info * li);
 
-/* Accessing raw_backtrace_slot values */
-value caml_raw_backtrace_slot_of_code(code_t pc);
-code_t caml_raw_backtrace_slot_code(value slot);
+/* Extract locations from backtrace_slot */
+void caml_extract_location_info(backtrace_slot pc, /*out*/ struct caml_loc_info * li);
+
+/* Expose a [backtrace_slot] as an OCaml value. */
+value caml_val_raw_backtrace_slot(backtrace_slot pc);
+backtrace_slot caml_raw_backtrace_slot_val(value slot);
 
 #define BACKTRACE_BUFFER_SIZE 1024
 

--- a/byterun/caml/backtrace_prim.h
+++ b/byterun/caml/backtrace_prim.h
@@ -1,0 +1,37 @@
+/***********************************************************************/
+/*                                                                     */
+/*                                OCaml                                */
+/*                                                                     */
+/*            Xavier Leroy, projet Cristal, INRIA Rocquencourt         */
+/*                                                                     */
+/*  Copyright 2001 Institut National de Recherche en Informatique et   */
+/*  en Automatique.  All rights reserved.  This file is distributed    */
+/*  under the terms of the GNU Library General Public License, with    */
+/*  the special exception on linking described in file ../LICENSE.     */
+/*                                                                     */
+/***********************************************************************/
+
+#ifndef CAML_BACKTRACE_PRIM_H
+#define CAML_BACKTRACE_PRIM_H
+
+/* Extract location information for the given raw_backtrace_slot */
+
+struct caml_loc_info {
+  int loc_valid;
+  int loc_is_raise;
+  char * loc_filename;
+  int loc_lnum;
+  int loc_startchr;
+  int loc_endchr;
+};
+
+int caml_debug_info_available(void);
+void caml_extract_location_info(code_t pc, /*out*/ struct caml_loc_info * li);
+
+/* Accessing raw_backtrace_slot values */
+value caml_raw_backtrace_slot_of_code(code_t pc);
+code_t caml_raw_backtrace_slot_code(value slot);
+
+#define BACKTRACE_BUFFER_SIZE 1024
+
+#endif /* CAML_BACKTRACE_PRIM_H */

--- a/byterun/caml/backtrace_prim.h
+++ b/byterun/caml/backtrace_prim.h
@@ -16,15 +16,13 @@
 
 #include "backtrace.h"
 
-/* Backtrace generation is split in the two files [backtrace.c] and [backtrace_prim.c].
+/* Backtrace generation is split in [backtrace.c] and [backtrace_prim.c].
  *
  * [backtrace_prim.c] contains all backend-specific code, and has two different
  * implementations in [byterun/backtrace_prim.c] and [asmrun/backtrace_prim.c].
  *
- * [backtrace.c] has a unique implementation, and rely on [backtrace_prim.c] interface
- * to expose a uniform higher level API.
- *
- * This file, [backtrace_prim.h] documents the interface expected by [backtrace.c].
+ * [backtrace.c] has a unique implementation, and expose a uniform higher level API
+ * above [backtrace_prim.c].
  */
 
 /* Extract location information for the given raw_backtrace_slot */
@@ -45,10 +43,20 @@ int caml_debug_info_available(void);
 /* Extract locations from backtrace_slot */
 void caml_extract_location_info(backtrace_slot pc, /*out*/ struct caml_loc_info * li);
 
-/* Expose a [backtrace_slot] as an OCaml value. */
+/* Expose a [backtrace_slot] as a OCaml value of type [raw_backtrace_slot]. */
 value caml_val_raw_backtrace_slot(backtrace_slot pc);
 backtrace_slot caml_raw_backtrace_slot_val(value slot);
 
 #define BACKTRACE_BUFFER_SIZE 1024
+
+/* Besides decoding backtrace info, [backtrace_prim] has two other responsibilities:
+ *
+ * It defines the [caml_stash_backtrace] function, which is called to quickly
+ * fill the backtrace buffer by walking the stack when an exception is raised.
+ *
+ * It also defines the [caml_get_current_callstack] OCaml primitive, which also
+ * walks the stack but directly turns it into a [raw_backtrace] and is called
+ * explicitly.
+ */
 
 #endif /* CAML_BACKTRACE_PRIM_H */

--- a/byterun/caml/backtrace_prim.h
+++ b/byterun/caml/backtrace_prim.h
@@ -43,7 +43,10 @@ int caml_debug_info_available(void);
 /* Extract locations from backtrace_slot */
 void caml_extract_location_info(backtrace_slot pc, /*out*/ struct caml_loc_info * li);
 
-/* Expose a [backtrace_slot] as a OCaml value of type [raw_backtrace_slot]. */
+/* Expose a [backtrace_slot] as a OCaml value of type [raw_backtrace_slot].
+ * The value returned should be an immediate and not an OCaml block, so that it
+ * is safe to store using direct assignment and [Field], and not [Store_field] /
+ * [caml_modify].  */
 value caml_val_raw_backtrace_slot(backtrace_slot pc);
 backtrace_slot caml_raw_backtrace_slot_val(value slot);
 

--- a/byterun/startup.c
+++ b/byterun/startup.c
@@ -328,6 +328,7 @@ CAMLexport void caml_main(char **argv)
                 caml_init_max_percent_free);
   caml_init_stack (caml_init_max_stack_wsz);
   caml_init_atom_table();
+  caml_init_backtrace();
   /* Initialize the interpreter */
   caml_interprete(NULL, 0);
   /* Initialize the debugger, if needed */
@@ -411,6 +412,7 @@ CAMLexport void caml_startup_code(
                 caml_init_max_percent_free);
   caml_init_stack (caml_init_max_stack_wsz);
   caml_init_atom_table();
+  caml_init_backtrace();
   /* Initialize the interpreter */
   caml_interprete(NULL, 0);
   /* Initialize the debugger, if needed */

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -80,7 +80,7 @@ struct caml_thread_struct {
   struct longjmp_buffer * external_raise; /* Saved external_raise */
 #endif
   int backtrace_pos;            /* Saved backtrace_pos */
-  code_t * backtrace_buffer;    /* Saved backtrace_buffer */
+  backtrace_slot * backtrace_buffer;    /* Saved backtrace_buffer */
   value backtrace_last_exn;     /* Saved backtrace_last_exn (root) */
 };
 

--- a/otherlibs/threads/scheduler.c
+++ b/otherlibs/threads/scheduler.c
@@ -80,7 +80,7 @@ struct caml_thread_struct {
   value * sp;
   value * trapsp;
   value backtrace_pos;          /* The backtrace info for this thread */
-  code_t * backtrace_buffer;
+  backtrace_slot * backtrace_buffer;
   value backtrace_last_exn;
   value status;                 /* RUNNABLE, KILLED. etc (see below) */
   value fd;     /* File descriptor on which we're doing read or write */


### PR DESCRIPTION
This PR refactors backtrace infrastructure.

The main motivation is to prepare ground for other (not ready) changes:
- clarifying the notions of `caml_backtrace_buffer`-slots, `raw_backtrace`-slots and `backtrace`-slots, which will help streamlining https://github.com/ocaml/ocaml/pull/199 into the existing Printexc interface
- https://github.com/def-lkb/ocaml/tree/virtual-frame-table which implements backtraces robust against inlining,
- https://github.com/def-lkb/ocaml/tree/many-exceptions-backtrace which allows to reraise a different exception, and display all different exceptions raised in a backtrace.
# backtrace_prim

The main change is that `backtrace.c` is split in `backtrace_prim.c` and `backtrace.c` files.
`backtrace.c` is shared between native and bytecode backends.
`backtrace_prim.c` is implemented in `asmrun/backtrace_prim.c` and `byterun/backtrace_prim.c`.

`backtrace_prim` is responsible for:
- walking the stacks
- decoding debug information
- abstracting the C-level notion type of backtrace slots (which differs between backends)

`backtrace` implements the high-level API, generation of OCaml values for slot and backtraces, printing, initialization, etc.

`backtrace.h` and `backtrace_prim.h` attempt to document this architecture.
# Other changes

When filling a raw_backtrace, `Store_field` is used instead of `Field(_) = _`.
This might be slightly slower, but no longer makes the assumption that a raw_backtrace_slot is always an immediate value, and/or that raw_backtrace_slot generation will never allocate.

Updated `otherlibs/threads` and `otherlibs/systhreads` to use `caml_` prefixed C-symbols, rather than relying on `caml/compatibility.h` to get names correct. This is part of the cleanup because threading libraries are responsible for updating backtrace state on context switch.
