### PR TITLE
Emitaux: also emit column location

### DIFF
--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -216,29 +216,32 @@ let emit_debug_info_gen dbg file_emitter loc_emitter =
     (!Clflags.debug || Config.with_frame_pointers)
      && dbg.Debuginfo.dinfo_line > 0 (* PR#6243 *)
   then begin
-    let line = dbg.Debuginfo.dinfo_line in
-    let file_name = dbg.Debuginfo.dinfo_file in
+    let { Debuginfo.
+          dinfo_line = line;
+          dinfo_char_start = col;
+          dinfo_file = file_name;
+        } = dbg in
     let file_num =
       try List.assoc file_name !file_pos_nums
       with Not_found ->
         let file_num = !file_pos_num_cnt in
         incr file_pos_num_cnt;
-        file_emitter file_num file_name;
+        file_emitter ~file_num ~file_name;
         file_pos_nums := (file_name,file_num) :: !file_pos_nums;
         file_num in
-    loc_emitter file_num line;
+    loc_emitter ~file_num ~line ~col;
   end
 
 let emit_debug_info dbg =
-  emit_debug_info_gen dbg (fun file_num file_name ->
-    emit_string "\t.file\t";
-    emit_int file_num; emit_char '\t';
-    emit_string_literal file_name; emit_char '\n';
-  )
-    (fun file_num line ->
-      emit_string "\t.loc\t";
+  emit_debug_info_gen dbg (fun ~file_num ~file_name ->
+      emit_string "\t.file\t";
       emit_int file_num; emit_char '\t';
-      emit_int line; emit_char '\n')
+      emit_string_literal file_name; emit_char '\n';
+    )
+    (fun ~file_num ~line ~col:_ ->
+       emit_string "\t.loc\t";
+       emit_int file_num; emit_char '\t';
+       emit_int line; emit_char '\n')
 
 let reset () =
   reset_debug_info ();

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -32,8 +32,8 @@ val reset_debug_info: unit -> unit
 val emit_debug_info: Debuginfo.t -> unit
 val emit_debug_info_gen :
   Debuginfo.t ->
-  (int -> string -> unit) ->
-  (int -> int -> unit) -> unit
+  (file_num:int -> file_name:string -> unit) ->
+  (file_num:int -> line:int -> col:int -> unit) -> unit
 
 type frame_descr =
   { fd_lbl: int;                        (* Return address *)

--- a/asmcomp/x86_ast.mli
+++ b/asmcomp/x86_ast.mli
@@ -205,9 +205,9 @@ type asm_line =
   | Cfi_adjust_cfa_offset of int
   | Cfi_endproc
   | Cfi_startproc
-  | File of int * string (* file_num * filename *)
+  | File of int * string (* (file_num, file_name) *)
   | Indirect_symbol of string
-  | Loc of int * int (* file_num x line *)
+  | Loc of int * int * int (* (file_num, line, col) *)
   | Private_extern of string
   | Set of string * constant
   | Size of string * constant

--- a/asmcomp/x86_dsl.ml
+++ b/asmcomp/x86_dsl.ml
@@ -83,11 +83,11 @@ module D = struct
   let comment s = directive (Comment s)
   let data () = section [ ".data" ] None []
   let extrn s ptr = directive (External (s, ptr))
-  let file num filename = directive (File (num, filename))
+  let file ~file_num ~file_name = directive (File (file_num, file_name))
   let global s = directive (Global s)
   let indirect_symbol s = directive (Indirect_symbol s)
   let label ?(typ = NONE) s = directive (NewLabel (s, typ))
-  let loc num loc = directive (Loc (num, loc))
+  let loc ~file_num ~line ~col = directive (Loc (file_num, line, col))
   let long cst = directive (Long cst)
   let mode386 () = directive Mode386
   let model name = directive (Model name)

--- a/asmcomp/x86_dsl.mli
+++ b/asmcomp/x86_dsl.mli
@@ -73,11 +73,11 @@ module D : sig
   val comment: string -> unit
   val data: unit -> unit
   val extrn: string -> data_type -> unit
-  val file: int -> string -> unit
+  val file: file_num:int -> file_name:string -> unit
   val global: string -> unit
   val indirect_symbol: string -> unit
   val label: ?typ:data_type -> string -> unit
-  val loc: int -> int -> unit
+  val loc: file_num:int -> line:int -> col:int -> unit
   val long: constant -> unit
   val mode386: unit -> unit
   val model: string -> unit

--- a/asmcomp/x86_gas.ml
+++ b/asmcomp/x86_gas.ml
@@ -279,7 +279,7 @@ let print_line b = function
       bprintf b "\t.file\t%d\t\"%s\""
         file_num (X86_proc.string_of_string_literal file_name)
   | Indirect_symbol s -> bprintf b "\t.indirect_symbol %s" s
-  | Loc (file_num, line) -> bprintf b "\t.loc\t%d\t%d" file_num line
+  | Loc (file_num, line, col) -> bprintf b "\t.loc\t%d\t%d\t%d" file_num line col
   | Private_extern s -> bprintf b "\t.private_extern %s" s
   | Set (arg1, arg2) -> bprintf b "\t.set %s, %a" arg1 cst arg2
   | Size (s, c) -> bprintf b "\t.size %s,%a" s cst c


### PR DESCRIPTION
GNU AS supports taking the column as an optional third argument in `.loc` directives.
This branch transmits the column to location emitter, and generate the directive on X86 GAS (although it should be supported on other platforms, the generic `Emitaux.emit_debug_info` could be updated too).

This result in a minor improvement of DWARF debugging information.
