### PR TITLE
Simplif.emit_tail_infos: recurse on function body in an application

### DIFF
--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -530,6 +530,7 @@ let rec emit_tail_infos is_tail lambda =
       && not is_tail
       && Warnings.is_active Warnings.Expect_tailcall
         then Location.prerr_warning loc Warnings.Expect_tailcall;
+      emit_tail_infos false func;
       list_emit_tail_infos false l;
       if !Clflags.annotations then
         Stypes.record (Stypes.An_call (loc, call_kind l));


### PR DESCRIPTION
This caused some emit_tail_infos warnings and annotations to be missed.

Because of compile-time beta-reductions, the bug tries to hide. To test:

``` ocaml
(* missed if bytecode optimizations are enabled *)
let rec fact = function
  | 1 -> 1
  | n -> n * (fun () -> (fact [@tailcall]) (n-1)) ()
;;

(* always missed *)
let rec fact = function
  | 1 -> 1
  | n -> n * (fun () -> let n = (fact [@tailcall]) (n-1) in fun () -> n) () ()
;;
```
