### PR TITLE
Remove duplicate productions

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1852,9 +1852,9 @@ sig_exception_declaration:
 generalized_constructor_arguments:
     /*empty*/                     { (Pcstr_tuple [],None) }
   | OF constructor_arguments      { ($2,None) }
-  | COLON constructor_arguments MINUSGREATER simple_core_type_no_attr
+  | COLON constructor_arguments MINUSGREATER simple_core_type
                                   { ($2,Some $4) }
-  | COLON simple_core_type_no_attr
+  | COLON simple_core_type
                                   { (Pcstr_tuple [],Some $2) }
 ;
 
@@ -2029,13 +2029,6 @@ simple_core_type:
       { match $2 with [sty] -> sty | _ -> raise Parse_error }
 ;
 
-simple_core_type_no_attr:
-    simple_core_type2  %prec below_SHARP
-      { $1 }
-  | LPAREN core_type_comma_list RPAREN %prec below_SHARP
-      { match $2 with [sty] -> sty | _ -> raise Parse_error }
-;
-
 simple_core_type2:
     QUOTE ident
       { mktyp(Ptyp_var $2) }
@@ -2123,9 +2116,9 @@ simple_core_type_or_tuple:
       { mktyp(Ptyp_tuple($1 :: List.rev $3)) }
 ;
 simple_core_type_or_tuple_no_attr:
-    simple_core_type_no_attr
+    simple_core_type
       { $1 }
-  | simple_core_type_no_attr STAR core_type_list_no_attr
+  | simple_core_type STAR core_type_list_no_attr
       { mktyp(Ptyp_tuple($1 :: List.rev $3)) }
 ;
 core_type_comma_list:
@@ -2137,8 +2130,8 @@ core_type_list:
   | core_type_list STAR simple_core_type        { $3 :: $1 }
 ;
 core_type_list_no_attr:
-    simple_core_type_no_attr                     { [$1] }
-  | core_type_list STAR simple_core_type_no_attr { $3 :: $1 }
+    simple_core_type                     { [$1] }
+  | core_type_list STAR simple_core_type { $3 :: $1 }
 ;
 meth_list:
     field SEMI meth_list                     { let (f, c) = $3 in ($1 :: f, c) }

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1859,7 +1859,7 @@ generalized_constructor_arguments:
 ;
 
 constructor_arguments:
-  | core_type_list_no_attr { Pcstr_tuple (List.rev $1) }
+  | core_type_list                   { Pcstr_tuple (List.rev $1) }
   | LBRACE label_declarations RBRACE { Pcstr_record $2 }
 ;
 label_declarations:
@@ -2120,12 +2120,8 @@ core_type_comma_list:
   | core_type_comma_list COMMA core_type        { $3 :: $1 }
 ;
 core_type_list:
-    simple_core_type %prec below_LBRACKETAT  { [$1] }
+    simple_core_type                            { [$1] }
   | core_type_list STAR simple_core_type        { $3 :: $1 }
-;
-core_type_list_no_attr:
-    simple_core_type                     { [$1] }
-  | core_type_list STAR simple_core_type { $3 :: $1 }
 ;
 meth_list:
     field SEMI meth_list                     { let (f, c) = $3 in ($1 :: f, c) }

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1079,14 +1079,14 @@ method_:
 class_type:
     class_signature
       { $1 }
-  | QUESTION LIDENT COLON simple_core_type_or_tuple_no_attr MINUSGREATER
+  | QUESTION LIDENT COLON simple_core_type_or_tuple MINUSGREATER
     class_type
       { mkcty(Pcty_arrow(Optional $2 , $4, $6)) }
-  | OPTLABEL simple_core_type_or_tuple_no_attr MINUSGREATER class_type
+  | OPTLABEL simple_core_type_or_tuple MINUSGREATER class_type
       { mkcty(Pcty_arrow(Optional $1, $2, $4)) }
-  | LIDENT COLON simple_core_type_or_tuple_no_attr MINUSGREATER class_type
+  | LIDENT COLON simple_core_type_or_tuple MINUSGREATER class_type
       { mkcty(Pcty_arrow(Labelled $1, $3, $5)) }
-  | simple_core_type_or_tuple_no_attr MINUSGREATER class_type
+  | simple_core_type_or_tuple MINUSGREATER class_type
       { mkcty(Pcty_arrow(Nolabel, $1, $3)) }
  ;
 class_signature:
@@ -2111,14 +2111,8 @@ name_tag_list:
   | name_tag_list name_tag                      { $2 :: $1 }
 ;
 simple_core_type_or_tuple:
-    simple_core_type %prec below_LBRACKETAT  { $1 }
+    simple_core_type { $1 }
   | simple_core_type STAR core_type_list
-      { mktyp(Ptyp_tuple($1 :: List.rev $3)) }
-;
-simple_core_type_or_tuple_no_attr:
-    simple_core_type
-      { $1 }
-  | simple_core_type STAR core_type_list_no_attr
       { mktyp(Ptyp_tuple($1 :: List.rev $3)) }
 ;
 core_type_comma_list:


### PR DESCRIPTION
This pull request does nothing.  It's just a minor code simplification. 

There are a few identical productions in the grammar, apparently left over after various changes to the attribute attachment strategy.  For example, the rules for [`simple_core_type_no_attr`](https://github.com/ocaml/ocaml/blob/5b7552b652de8c42fd6a675f3ba5fc40c7a3ffcd/parsing/parser.mly#L2032-L2037) and [`simple_core_type`](https://github.com/ocaml/ocaml/blob/5b7552b652de8c42fd6a675f3ba5fc40c7a3ffcd/parsing/parser.mly#L2025-L2030) are literally identical apart from their names:

``` ocaml
  simple_core_type_no_attr:
    simple_core_type2  %prec below_SHARP
      { $1 }
  | LPAREN core_type_comma_list RPAREN %prec below_SHARP
      { match $2 with [sty] -> sty | _ -> raise Parse_error }
```

``` ocaml
  simple_core_type:
    simple_core_type2  %prec below_SHARP
      { $1 }
  | LPAREN core_type_comma_list RPAREN %prec below_SHARP
      { match $2 with [sty] -> sty | _ -> raise Parse_error }
```

Similarly, `simple_core_type_or_tuple` and `core_type_list` have duplicate `_no_attr` versions which are identical except for unused `%prec` annotations.  Having identical productions around makes the grammar harder to modify, so this PR removes them.
