### PR TITLE
Missing POSIX signals in Sys

### DIFF
--- a/byterun/signals.c
+++ b/byterun/signals.c
@@ -238,11 +238,33 @@ void caml_urge_major_slice (void)
 #ifndef SIGPROF
 #define SIGPROF -1
 #endif
+#ifndef SIGBUS
+#define SIGBUS -1
+#endif
+#ifndef SIGPOLL
+#define SIGPOLL -1
+#endif
+#ifndef SIGSYS
+#define SIGSYS -1
+#endif
+#ifndef SIGTRAP
+#define SIGTRAP -1
+#endif
+#ifndef SIGURG
+#define SIGURG -1
+#endif
+#ifndef SIGXCPU
+#define SIGXCPU -1
+#endif
+#ifndef SIGXFSZ
+#define SIGXFSZ -1
+#endif
 
 static int posix_signals[] = {
   SIGABRT, SIGALRM, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGKILL, SIGPIPE,
   SIGQUIT, SIGSEGV, SIGTERM, SIGUSR1, SIGUSR2, SIGCHLD, SIGCONT,
-  SIGSTOP, SIGTSTP, SIGTTIN, SIGTTOU, SIGVTALRM, SIGPROF
+  SIGSTOP, SIGTSTP, SIGTTIN, SIGTTOU, SIGVTALRM, SIGPROF, SIGBUS,
+  SIGPOLL, SIGSYS, SIGTRAP, SIGURG, SIGXCPU, SIGXFSZ
 };
 
 CAMLexport int caml_convert_signal_number(int signo)

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -211,25 +211,32 @@ val sigprof : int
 (** Profiling interrupt *)
 
 val sigbus : int
-(** Bus error *)
+(** Bus error
+    @since 4.03 *)
 
 val sigpoll : int
-(** Pollable event *)
+(** Pollable event
+    @since 4.03 *)
 
 val sigsys : int
-(** Bad argument to routine *)
+(** Bad argument to routine
+    @since 4.03 *)
 
 val sigtrap : int
-(** Trace/breakpoint trap *)
+(** Trace/breakpoint trap
+    @since 4.03 *)
 
 val sigurg : int
-(** Urgent condition on socket *)
+(** Urgent condition on socket
+    @since 4.03 *)
 
 val sigxcpu : int
-(** Timeout in cpu time *)
+(** Timeout in cpu time
+    @since 4.03 *)
 
 val sigxfsz : int
-(** File size limit exceeded *)
+(** File size limit exceeded
+    @since 4.03 *)
 
 
 exception Break

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -210,6 +210,27 @@ val sigvtalrm : int
 val sigprof : int
 (** Profiling interrupt *)
 
+val sigbus : int
+(** Bus error *)
+
+val sigpoll : int
+(** Pollable event *)
+
+val sigsys : int
+(** Bad argument to routine *)
+
+val sigtrap : int
+(** Trace/breakpoint trap *)
+
+val sigurg : int
+(** Urgent condition on socket *)
+
+val sigxcpu : int
+(** Timeout in cpu time *)
+
+val sigxfsz : int
+(** File size limit exceeded *)
+
 
 exception Break
 (** Exception raised on interactive interrupt if {!Sys.catch_break}

--- a/stdlib/sys.mlp
+++ b/stdlib/sys.mlp
@@ -82,6 +82,13 @@ let sigttin = -18
 let sigttou = -19
 let sigvtalrm = -20
 let sigprof = -21
+let sigbus = -22
+let sigpoll = -23
+let sigsys = -24
+let sigtrap = -25
+let sigurg = -26
+let sigxcpu = -27
+let sigxfsz = -28
 
 exception Break
 


### PR DESCRIPTION
There seems to be signals defined in the POSIX standard, but not made available by the Sys module.
More precisely from what I read on the man page about signals, Sys exposes all signal from the POSIX.1-1990 standard, but only two from the POSIX.1-2001 standard (`SIGVTALRM` and `SIGPROF`).
Looking at the history, it seems to be because the code for signals was written in 1995/1996.

This pull request adds the missing signals.
