### PR TITLE
Inline signatures in .ml files

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -611,6 +611,25 @@ The precedences must be listed from low to high.
 
 implementation:
     structure EOF                        { extra_str 1 $1 }
+  | inline_sig structure EOF
+      {
+       let str = Mod.structure ~loc:(rhs_loc 2) (extra_str 2 $2) in
+       let loc = symbol_rloc () in
+       let i = Incl.mk (Mod.constraint_ ~loc str $1) ~loc ~attrs:[] in
+       [ Str.include_ ~loc i ]
+      }
+;
+inline_sig:
+  SIG signature END
+     {
+       Mty.signature ~loc:(symbol_rloc ()) (extra_sig 2 $2)
+     }
+| SIG signature error
+      { unclosed "sig" 1 "end" 3 }
+| inline_sig attribute
+     {
+       Mty.attr $1 $2
+     }
 ;
 interface:
     signature EOF                        { extra_sig 1 $1 }


### PR DESCRIPTION
It is sometimes convenient to specify the external interface of a compilation unit directly in the .ml file.  In particular, for "plugin" modules which are supposed to be dynlinked independently, the external interface is empty, and it can be inconvenient having to specify an empty .mli file.  Benefits of having an explicit external interface even in such cases are clear:  enable unused-stuff warnings to be triggered; prevent accidental use of internal components by other modules.

One of the recommendations of the LaFoSec study (about the security aspects of OCaml) is precisely to allowing defining the interface of a module directly in the .ml file.  This pull request implements this recommendation by allowing an initial `sig ... end` declaration at the top of implementation files.  This is currently done purely as syntactic sugar, mapping this to:

``` ocaml
   include (struct ... end : sig ... end)
```

If one agrees on the benefit of the proposal and on the syntax, one could discuss whether we should represent the new form explicitly in the Parsetree and/or compile the construction specifically (to avoid creating the included structure).

FWIW, this extension has been in use at LexiFi for several years (precisely to restrict the interface of plugins, which is often empty or very small).
