### PR TITLE
Short syntax for overriding local open

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,6 +23,8 @@ Language features:
 - GPR#88: allow field punning in object copying expressions:
     {< x; y; >} is sugar for {< x = x; y = y; >}
   (Jeremy Yallop)
+- GPR#218: Add the syntax "M.!( ... )" that opens a module locally but doesn't trigger shadowing warnings.
+  (Gabriel Radanne and 'Octachron')
 
 Compilers:
 - PR#6501: harden the native-code generator against certain uses of "%identity"

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -456,6 +456,7 @@ rule token = parse
   | ","  { COMMA }
   | "->" { MINUSGREATER }
   | "."  { DOT }
+  | ".!"  { DOTBANG }
   | ".." { DOTDOT }
   | ":"  { COLON }
   | "::" { COLONCOLON }

--- a/testsuite/tests/warnings/w44_45.ml
+++ b/testsuite/tests/warnings/w44_45.ml
@@ -1,0 +1,78 @@
+
+  (* auxiliary type *)
+  type 'a box = { x : ' a}
+
+  (* Identifiers to be shadowed *)
+  let value = 1
+  type t = Constructor
+  class c = object end
+  module Module = struct end
+  type record = { test_label : unit; other_label : unit }
+  module type module_type = sig end
+
+(* Shadowing module *)
+module Shadower = struct
+  let value = 2
+  type t = Constructor
+  type record = { test_label : unit; other_label_shadower : unit }
+  let r = { test_label = (); other_label_shadower = () }
+  class c = object end
+  module Module = struct end
+  module type module_type = sig end
+end;;
+
+(* First, test shadowing with global open *)
+module Global = struct
+  open Shadower (* Trigger warnings 44 and 45 *)
+  let value = value
+  let record = { test_label = (); other_label_shadower = () }
+  let constructor: Shadower.t  = Constructor
+  let o = new c
+  module Module = Module
+  module type  module_type = module_type
+end;;
+
+module Global_with_override = struct
+  open! Shadower (* explicit override : do not trigger warnings 44 and 45 *)
+  let value = value
+  let record = { test_label = (); other_label_shadower = () }
+  let constructor: Shadower.t  = Constructor
+  let o = new c
+  module Module = Module
+  module type  module_type = module_type
+end;;
+
+(* Then, test shadowing with local open *)
+let local =
+  let open Shadower in
+  let module Module : module_type = Module in
+  value, { test_label = (); other_label_shadower = () } , (Constructor: Shadower.t) , new c
+
+let local_with_override =
+  let open! Shadower in
+  value, { test_label = (); other_label_shadower = () } , (Constructor: Shadower.t) , new c, ( module Module : module_type )
+
+
+module S = Shadower (* Shadower is too long to type here *)
+(* Last, test shadowing with delimited local open *)
+let local_delimited_parens =
+  S.( value, { test_label = (); other_label_shadower = () } , (Constructor: Shadower.t) , new c, ( module Module : module_type ) )
+and list =
+  S.[value], S.[{ test_label = (); other_label_shadower = () }], S.[(Constructor: Shadower.t)], S.[new c], S.[( module Module : module_type )]
+and array =
+  S.[|value|], S.[|{ test_label = (); other_label_shadower = () }|], S.[|(Constructor: Shadower.t)|], S.[|new c|],  S.[|( module Module : module_type )|]
+and record =
+  S.{ x =value }, S.{ x = { test_label = (); other_label_shadower = () } }, S.{ x = (Constructor: Shadower.t) }, S.{ x = new c }, S.{ x = ( module Module : module_type ) }
+and objects =
+  object val x = value method m = S.{< x = value >} end, object val x = S.r method m = S.{< x = { test_label = (); other_label_shadower = () } >} end, object val x = S.Constructor method m = S.{< x = (Constructor: Shadower.t) >} end, object val x = new S.c  method m = S.{< x = new c >} end, object val x = ( module S.Module : S.module_type ) method m = S.{< x = ( module Module : module_type ) >} end
+
+let local_delimited_parens_with_override =
+  S.!( value, { test_label = (); other_label_shadower = () } , (Constructor: Shadower.t) , new c, ( module Module : module_type ) )
+and list_override =
+  S.![value], S.![{ test_label = (); other_label_shadower = () }], S.![(Constructor: Shadower.t)], S.![new c], S.![( module Module : module_type )]
+and array_override =
+  S.![|value|], S.![|{ test_label = (); other_label_shadower = () }|], S.![|(Constructor: Shadower.t)|], S.![|new c|],  S.![|( module Module : module_type )|]
+and record_override =
+  S.!{ x =value }, S.!{ x = { test_label = (); other_label_shadower = () } }, S.!{ x = (Constructor: Shadower.t) }, S.!{ x = new c }, S.!{ x = ( module Module : module_type ) }
+and objects_override =
+  object val x = value method m = S.!{< x = value >} end, object val x = S.r method m = S.!{< x = { test_label = (); other_label_shadower = () } >} end, object val x = S.Constructor method m = S.!{< x = (Constructor: Shadower.t) >} end, object val x = new S.c  method m = S.!{< x = new c >} end, object val x = ( module S.Module : S.module_type ) method m = S.!{< x = ( module Module : module_type ) >} end

--- a/testsuite/tests/warnings/w44_45.reference
+++ b/testsuite/tests/warnings/w44_45.reference
@@ -1,0 +1,84 @@
+File "w44_45.ml", line 26, characters 2-15:
+Warning 44: this open statement shadows the value identifier value (which is later used)
+File "w44_45.ml", line 26, characters 2-15:
+Warning 45: this open statement shadows the label test_label (which is later used)
+File "w44_45.ml", line 26, characters 2-15:
+Warning 45: this open statement shadows the constructor Constructor (which is later used)
+File "w44_45.ml", line 26, characters 2-15:
+Warning 44: this open statement shadows the class identifier c (which is later used)
+File "w44_45.ml", line 26, characters 2-15:
+Warning 44: this open statement shadows the module identifier Module (which is later used)
+File "w44_45.ml", line 26, characters 2-15:
+Warning 44: this open statement shadows the module type identifier module_type (which is later used)
+File "w44_45.ml", line 47, characters 2-160:
+Warning 44: this open statement shadows the module identifier Module (which is later used)
+File "w44_45.ml", line 47, characters 2-160:
+Warning 44: this open statement shadows the module type identifier module_type (which is later used)
+File "w44_45.ml", line 47, characters 2-160:
+Warning 44: this open statement shadows the value identifier value (which is later used)
+File "w44_45.ml", line 47, characters 2-160:
+Warning 45: this open statement shadows the label test_label (which is later used)
+File "w44_45.ml", line 47, characters 2-160:
+Warning 45: this open statement shadows the constructor Constructor (which is later used)
+File "w44_45.ml", line 47, characters 2-160:
+Warning 44: this open statement shadows the class identifier c (which is later used)
+File "w44_45.ml", line 59, characters 2-130:
+Warning 44: this open statement shadows the value identifier value (which is later used)
+File "w44_45.ml", line 59, characters 2-130:
+Warning 45: this open statement shadows the label test_label (which is later used)
+File "w44_45.ml", line 59, characters 2-130:
+Warning 45: this open statement shadows the constructor Constructor (which is later used)
+File "w44_45.ml", line 59, characters 2-130:
+Warning 44: this open statement shadows the class identifier c (which is later used)
+File "w44_45.ml", line 59, characters 2-130:
+Warning 44: this open statement shadows the module type identifier module_type (which is later used)
+File "w44_45.ml", line 59, characters 2-130:
+Warning 44: this open statement shadows the module identifier Module (which is later used)
+File "w44_45.ml", line 61, characters 2-11:
+Warning 44: this open statement shadows the value identifier value (which is later used)
+File "w44_45.ml", line 61, characters 13-63:
+Warning 45: this open statement shadows the label test_label (which is later used)
+File "w44_45.ml", line 61, characters 65-94:
+Warning 45: this open statement shadows the constructor Constructor (which is later used)
+File "w44_45.ml", line 61, characters 96-105:
+Warning 44: this open statement shadows the class identifier c (which is later used)
+File "w44_45.ml", line 61, characters 107-142:
+Warning 44: this open statement shadows the module type identifier module_type (which is later used)
+File "w44_45.ml", line 61, characters 107-142:
+Warning 44: this open statement shadows the module identifier Module (which is later used)
+File "w44_45.ml", line 63, characters 2-13:
+Warning 44: this open statement shadows the value identifier value (which is later used)
+File "w44_45.ml", line 63, characters 15-67:
+Warning 45: this open statement shadows the label test_label (which is later used)
+File "w44_45.ml", line 63, characters 69-100:
+Warning 45: this open statement shadows the constructor Constructor (which is later used)
+File "w44_45.ml", line 63, characters 102-113:
+Warning 44: this open statement shadows the class identifier c (which is later used)
+File "w44_45.ml", line 63, characters 116-153:
+Warning 44: this open statement shadows the module type identifier module_type (which is later used)
+File "w44_45.ml", line 63, characters 116-153:
+Warning 44: this open statement shadows the module identifier Module (which is later used)
+File "w44_45.ml", line 65, characters 2-16:
+Warning 44: this open statement shadows the value identifier value (which is later used)
+File "w44_45.ml", line 65, characters 18-74:
+Warning 45: this open statement shadows the label test_label (which is later used)
+File "w44_45.ml", line 65, characters 76-111:
+Warning 45: this open statement shadows the constructor Constructor (which is later used)
+File "w44_45.ml", line 65, characters 113-128:
+Warning 44: this open statement shadows the class identifier c (which is later used)
+File "w44_45.ml", line 65, characters 130-171:
+Warning 44: this open statement shadows the module type identifier module_type (which is later used)
+File "w44_45.ml", line 65, characters 130-171:
+Warning 44: this open statement shadows the module identifier Module (which is later used)
+File "w44_45.ml", line 67, characters 34-51:
+Warning 44: this open statement shadows the value identifier value (which is later used)
+File "w44_45.ml", line 67, characters 87-145:
+Warning 45: this open statement shadows the label test_label (which is later used)
+File "w44_45.ml", line 67, characters 191-228:
+Warning 45: this open statement shadows the constructor Constructor (which is later used)
+File "w44_45.ml", line 67, characters 269-286:
+Warning 44: this open statement shadows the class identifier c (which is later used)
+File "w44_45.ml", line 67, characters 354-397:
+Warning 44: this open statement shadows the module type identifier module_type (which is later used)
+File "w44_45.ml", line 67, characters 354-397:
+Warning 44: this open statement shadows the module identifier Module (which is later used)


### PR DESCRIPTION
This proposal adds the syntax `M.!( ... )` which opens a module locally but silent the shadowing warnings. It is similar to both the shortcut local open syntax `M.( ... )` and the shadowing local open syntax `let open! M in ...`

The proposal is motivated by two points:
- The shadowing warnings do help to catch various bugs.
- Local open is very useful to implement EDSL-like functionalities, by shadowing existing operators in a limited scope.

Half of this proposal, and in particular the tests, were done by @Octachron, big thanks to him!
