### PR TITLE
ocamlbuild speedup

### DIFF
--- a/ocamlbuild/display.ml
+++ b/ocamlbuild/display.ml
@@ -376,8 +376,9 @@ let event di ?(pretend=false) command target tags =
 ;;
 (* ***)
 (*** dprintf *)
-let dprintf ?(log_level=1) di fmt =
+let dprintf ?(raw=false) ?(log_level=1) di fmt =
   if log_level > di.di_log_level then Discard_printf.discard_printf fmt else
+  let fmt = if raw then fmt else "@[<2>"^^fmt^^"@]@." in
   match di.di_display_line with
   | Classic -> Format.fprintf di.di_formatter fmt
   | Sophisticated _ ->

--- a/ocamlbuild/display.ml
+++ b/ocamlbuild/display.ml
@@ -376,6 +376,7 @@ let event di ?(pretend=false) command target tags =
 ;;
 (* ***)
 (*** dprintf *)
+let is_logging di log_level = log_level <= di.di_log_level
 let dprintf ?(raw=false) ?(log_level=1) di fmt =
   if log_level > di.di_log_level then Discard_printf.discard_printf fmt else
   let fmt = if raw then fmt else "@[<2>"^^fmt^^"@]@." in

--- a/ocamlbuild/display.mli
+++ b/ocamlbuild/display.mli
@@ -31,4 +31,5 @@ val finish : ?how:[`Success|`Error|`Quiet] -> display -> unit
 val event : display -> ?pretend:bool -> string -> string -> Tags.t -> unit
 val display : display -> (out_channel -> unit) -> unit
 val update : display -> unit
+val is_logging : display -> int -> bool
 val dprintf : ?raw:bool -> ?log_level:int -> display -> ('a, Format.formatter, unit) format -> 'a

--- a/ocamlbuild/display.mli
+++ b/ocamlbuild/display.mli
@@ -31,4 +31,4 @@ val finish : ?how:[`Success|`Error|`Quiet] -> display -> unit
 val event : display -> ?pretend:bool -> string -> string -> Tags.t -> unit
 val display : display -> (out_channel -> unit) -> unit
 val update : display -> unit
-val dprintf : ?log_level:int -> display -> ('a, Format.formatter, unit) format -> 'a
+val dprintf : ?raw:bool -> ?log_level:int -> display -> ('a, Format.formatter, unit) format -> 'a

--- a/ocamlbuild/log.ml
+++ b/ocamlbuild/log.ml
@@ -39,9 +39,8 @@ let init log_file =
   in
   internal_display := Some (Display.create ~mode ?log_file ~log_level:!level ())
 
-let raw_dprintf log_level = Display.dprintf ~log_level !-internal_display
-
-let dprintf log_level fmt = raw_dprintf log_level ("@[<2>"^^fmt^^"@]@.")
+let raw_dprintf log_level = Display.dprintf ~raw:true ~log_level !-internal_display
+let dprintf log_level fmt = Display.dprintf ~log_level !-internal_display fmt
 let eprintf fmt = dprintf (-1) fmt
 
 let update () = Display.update !-internal_display

--- a/ocamlbuild/log.ml
+++ b/ocamlbuild/log.ml
@@ -41,6 +41,7 @@ let init log_file =
 
 let raw_dprintf log_level = Display.dprintf ~raw:true ~log_level !-internal_display
 let dprintf log_level fmt = Display.dprintf ~log_level !-internal_display fmt
+let is_logging log_level = Display.is_logging !-internal_display log_level
 let eprintf fmt = dprintf (-1) fmt
 
 let update () = Display.update !-internal_display

--- a/ocamlbuild/resource.ml
+++ b/ocamlbuild/resource.ml
@@ -112,6 +112,8 @@ module Cache = struct
     fprintf f "@[<2>{ @[<2>built =@ %a@];@ @[<2>changed =@ %a@];@ @[<2>dependencies =@ %a@]@ }@]"
       print_build_status e.built print_knowledge e.changed Resources.print e.dependencies
 
+  module Hashtbl = Hashtbl.Make(struct type t = Pathname.t let hash = Hashtbl.hash let equal (x:string) y = x = y end)
+
   let cache = Hashtbl.create 103
 
   let get r =

--- a/ocamlbuild/signatures.mli
+++ b/ocamlbuild/signatures.mli
@@ -312,6 +312,9 @@ module type LOG = sig
       ["@\[<2>"] and ["@\]@."]. *)
   val dprintf : int -> ('a, Format.formatter, unit) format -> 'a
 
+  (** @return whether logging at this level will print anything *)
+  val is_logging : int -> bool
+
   (** Equivalent to calling [dprintf] with a level [< 0]. *)
   val eprintf : ('a, Format.formatter, unit) format -> 'a
 

--- a/ocamlbuild/solver.ml
+++ b/ocamlbuild/solver.ml
@@ -40,15 +40,16 @@ let rec self depth on_the_go_orig target =
   let rules = Rule.get_rules () in
   let on_the_go = target :: on_the_go_orig in
 
-  dprintf 4 "==%a> %a" pp_repeat (depth, "==") Resource.print target;
+  (* skip allocating fmt on a hot path *)
+  if is_logging 4 then dprintf 4 "==%a> %a" pp_repeat (depth, "==") Resource.print target;
   if List.mem target on_the_go_orig then raise (Circular(target, on_the_go_orig));
   match Resource.Cache.resource_state target with
   | Resource.Cache.Bbuilt ->
-      (dprintf 5 "%a already built" Resource.print target)
+      (if is_logging 5 then dprintf 5 "%a already built" Resource.print target)
   | Resource.Cache.Bcannot_be_built ->
-      (dprintf 5 "%a already failed" Resource.print target; failed target (Leaf target))
+      (if is_logging 5 then dprintf 5 "%a already failed" Resource.print target; failed target (Leaf target))
   | Resource.Cache.Bsuspension(s) ->
-      (dprintf 5 "%a was suspended -> resuming" Resource.print target;
+      (if is_logging 5 then dprintf 5 "%a was suspended -> resuming" Resource.print target;
        Resource.Cache.resume_suspension s)
   | Resource.Cache.Bnot_built_yet ->
     if not (Pathname.is_relative target) && Pathname.exists target then
@@ -110,9 +111,10 @@ and self_firsts depth on_the_go rss =
     end results ([], []) in
   let count = List.length cmds in
   let job_debug = if !Command.jobs = 1 then 10 else 5 in
-  if count > 1 then dprintf job_debug ">>> PARALLEL: %d" count;
+  (* skip allocating fmt on a hot path *)
+  if is_logging job_debug && count > 1 then dprintf job_debug ">>> PARALLEL: %d" count;
   let opt_exn = Command.execute_many cmds in
-  if count > 1 then dprintf job_debug "<<< PARALLEL";
+  if is_logging job_debug && count > 1 then dprintf job_debug "<<< PARALLEL";
   begin match opt_exn with
   | Some(res, exn) ->
       List.iter2 (fun res thunk -> if res then thunk ()) res thunks;


### PR DESCRIPTION
See http://caml.inria.fr/mantis/view.php?id=4934 and http://caml.inria.fr/mantis/view.php?id=5756

Timings:
Building already built coq 8.4 with current trunk takes 51s here.
First commit brings it down to 46s, second - 34s, all three - 30s.
All in all 40% speedup with minimal changes.

Explanation:
1. Specializing `Hashtbl` is usual elimination of generic `compare`.
2. `Log.dprintf` wraps log format even if there will be no printing done - this is too expensive and is fixed globally.
3. Still the recursive procedure in `Solver.self` generates too much garbage in `Format.ifprintf` when discarding printing, this is solved with `if loglevel <= X then dprintf X` for selected hot path (5 calls total).
