### PR TITLE
fix -dsource error

### DIFF
--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1202,7 +1202,7 @@ class printer  ()= object(self:'self)
     | Pstr_recmodule decls -> (* 3.07 *)
         let aux f = function
           | ({pmb_expr={pmod_desc=Pmod_constraint (expr, typ)}} as pmb) ->
-              pp f "@[<hov2>and@ %s:%a@ =@ %a@]%a" pmb.pmb_name.txt
+              pp f "@[<hov2>@ and@ %s:%a@ =@ %a@]%a" pmb.pmb_name.txt
               self#module_type typ
               self#module_expr expr
               self#item_attributes pmb.pmb_attributes


### PR DESCRIPTION
when printing recursive module
the old version  would print
struct
endand A = ...

this tiny PR fixes such problem
