### PR TITLE
Backward compatibility for Noreturn and CAMLunused macro

### DIFF
--- a/asmrun/fail.c
+++ b/asmrun/fail.c
@@ -47,7 +47,7 @@ extern caml_generated_constant
 
 /* Exception raising */
 
-Noreturn extern void caml_raise_exception (value bucket);
+CAMLnoreturn extern void caml_raise_exception (value bucket);
 
 char * caml_exception_pointer = NULL;
 

--- a/asmrun/fail.c
+++ b/asmrun/fail.c
@@ -47,7 +47,7 @@ extern caml_generated_constant
 
 /* Exception raising */
 
-CAMLnoreturn extern void caml_raise_exception (value bucket);
+CAMLno_return extern void caml_raise_exception (value bucket);
 
 char * caml_exception_pointer = NULL;
 

--- a/asmrun/fail.c
+++ b/asmrun/fail.c
@@ -47,7 +47,7 @@ extern caml_generated_constant
 
 /* Exception raising */
 
-CAMLno_return extern void caml_raise_exception (value bucket);
+CAMLnoreturn_start extern void caml_raise_exception (value bucket);
 
 char * caml_exception_pointer = NULL;
 

--- a/byterun/caml/fail.h
+++ b/byterun/caml/fail.h
@@ -60,21 +60,21 @@ int caml_is_special_exception(value exn);
 extern "C" {
 #endif
 
-Noreturn CAMLextern void caml_raise (value bucket);
-Noreturn CAMLextern void caml_raise_constant (value tag);
-Noreturn CAMLextern void caml_raise_with_arg (value tag, value arg);
-Noreturn CAMLextern void caml_raise_with_args (value tag, int nargs, value arg[]);
-Noreturn CAMLextern void caml_raise_with_string (value tag, char const * msg);
-Noreturn CAMLextern void caml_failwith (char const *);
-Noreturn CAMLextern void caml_invalid_argument (char const *);
-Noreturn CAMLextern void caml_raise_out_of_memory (void);
-Noreturn CAMLextern void caml_raise_stack_overflow (void);
-Noreturn CAMLextern void caml_raise_sys_error (value);
-Noreturn CAMLextern void caml_raise_end_of_file (void);
-Noreturn CAMLextern void caml_raise_zero_divide (void);
-Noreturn CAMLextern void caml_raise_not_found (void);
-Noreturn CAMLextern void caml_array_bound_error (void);
-Noreturn CAMLextern void caml_raise_sys_blocked_io (void);
+CAMLnoreturn CAMLextern void caml_raise (value bucket);
+CAMLnoreturn CAMLextern void caml_raise_constant (value tag);
+CAMLnoreturn CAMLextern void caml_raise_with_arg (value tag, value arg);
+CAMLnoreturn CAMLextern void caml_raise_with_args (value tag, int nargs, value arg[]);
+CAMLnoreturn CAMLextern void caml_raise_with_string (value tag, char const * msg);
+CAMLnoreturn CAMLextern void caml_failwith (char const *);
+CAMLnoreturn CAMLextern void caml_invalid_argument (char const *);
+CAMLnoreturn CAMLextern void caml_raise_out_of_memory (void);
+CAMLnoreturn CAMLextern void caml_raise_stack_overflow (void);
+CAMLnoreturn CAMLextern void caml_raise_sys_error (value);
+CAMLnoreturn CAMLextern void caml_raise_end_of_file (void);
+CAMLnoreturn CAMLextern void caml_raise_zero_divide (void);
+CAMLnoreturn CAMLextern void caml_raise_not_found (void);
+CAMLnoreturn CAMLextern void caml_array_bound_error (void);
+CAMLnoreturn CAMLextern void caml_raise_sys_blocked_io (void);
 
 #ifdef __cplusplus
 }

--- a/byterun/caml/fail.h
+++ b/byterun/caml/fail.h
@@ -60,21 +60,21 @@ int caml_is_special_exception(value exn);
 extern "C" {
 #endif
 
-CAMLnoreturn CAMLextern void caml_raise (value bucket);
-CAMLnoreturn CAMLextern void caml_raise_constant (value tag);
-CAMLnoreturn CAMLextern void caml_raise_with_arg (value tag, value arg);
-CAMLnoreturn CAMLextern void caml_raise_with_args (value tag, int nargs, value arg[]);
-CAMLnoreturn CAMLextern void caml_raise_with_string (value tag, char const * msg);
-CAMLnoreturn CAMLextern void caml_failwith (char const *);
-CAMLnoreturn CAMLextern void caml_invalid_argument (char const *);
-CAMLnoreturn CAMLextern void caml_raise_out_of_memory (void);
-CAMLnoreturn CAMLextern void caml_raise_stack_overflow (void);
-CAMLnoreturn CAMLextern void caml_raise_sys_error (value);
-CAMLnoreturn CAMLextern void caml_raise_end_of_file (void);
-CAMLnoreturn CAMLextern void caml_raise_zero_divide (void);
-CAMLnoreturn CAMLextern void caml_raise_not_found (void);
-CAMLnoreturn CAMLextern void caml_array_bound_error (void);
-CAMLnoreturn CAMLextern void caml_raise_sys_blocked_io (void);
+CAMLno_return CAMLextern void caml_raise (value bucket);
+CAMLno_return CAMLextern void caml_raise_constant (value tag);
+CAMLno_return CAMLextern void caml_raise_with_arg (value tag, value arg);
+CAMLno_return CAMLextern void caml_raise_with_args (value tag, int nargs, value arg[]);
+CAMLno_return CAMLextern void caml_raise_with_string (value tag, char const * msg);
+CAMLno_return CAMLextern void caml_failwith (char const *);
+CAMLno_return CAMLextern void caml_invalid_argument (char const *);
+CAMLno_return CAMLextern void caml_raise_out_of_memory (void);
+CAMLno_return CAMLextern void caml_raise_stack_overflow (void);
+CAMLno_return CAMLextern void caml_raise_sys_error (value);
+CAMLno_return CAMLextern void caml_raise_end_of_file (void);
+CAMLno_return CAMLextern void caml_raise_zero_divide (void);
+CAMLno_return CAMLextern void caml_raise_not_found (void);
+CAMLno_return CAMLextern void caml_array_bound_error (void);
+CAMLno_return CAMLextern void caml_raise_sys_blocked_io (void);
 
 #ifdef __cplusplus
 }

--- a/byterun/caml/fail.h
+++ b/byterun/caml/fail.h
@@ -60,21 +60,21 @@ int caml_is_special_exception(value exn);
 extern "C" {
 #endif
 
-CAMLno_return CAMLextern void caml_raise (value bucket);
-CAMLno_return CAMLextern void caml_raise_constant (value tag);
-CAMLno_return CAMLextern void caml_raise_with_arg (value tag, value arg);
-CAMLno_return CAMLextern void caml_raise_with_args (value tag, int nargs, value arg[]);
-CAMLno_return CAMLextern void caml_raise_with_string (value tag, char const * msg);
-CAMLno_return CAMLextern void caml_failwith (char const *);
-CAMLno_return CAMLextern void caml_invalid_argument (char const *);
-CAMLno_return CAMLextern void caml_raise_out_of_memory (void);
-CAMLno_return CAMLextern void caml_raise_stack_overflow (void);
-CAMLno_return CAMLextern void caml_raise_sys_error (value);
-CAMLno_return CAMLextern void caml_raise_end_of_file (void);
-CAMLno_return CAMLextern void caml_raise_zero_divide (void);
-CAMLno_return CAMLextern void caml_raise_not_found (void);
-CAMLno_return CAMLextern void caml_array_bound_error (void);
-CAMLno_return CAMLextern void caml_raise_sys_blocked_io (void);
+CAMLnoreturn_start CAMLextern void caml_raise (value bucket);
+CAMLnoreturn_start CAMLextern void caml_raise_constant (value tag);
+CAMLnoreturn_start CAMLextern void caml_raise_with_arg (value tag, value arg);
+CAMLnoreturn_start CAMLextern void caml_raise_with_args (value tag, int nargs, value arg[]);
+CAMLnoreturn_start CAMLextern void caml_raise_with_string (value tag, char const * msg);
+CAMLnoreturn_start CAMLextern void caml_failwith (char const *);
+CAMLnoreturn_start CAMLextern void caml_invalid_argument (char const *);
+CAMLnoreturn_start CAMLextern void caml_raise_out_of_memory (void);
+CAMLnoreturn_start CAMLextern void caml_raise_stack_overflow (void);
+CAMLnoreturn_start CAMLextern void caml_raise_sys_error (value);
+CAMLnoreturn_start CAMLextern void caml_raise_end_of_file (void);
+CAMLnoreturn_start CAMLextern void caml_raise_zero_divide (void);
+CAMLnoreturn_start CAMLextern void caml_raise_not_found (void);
+CAMLnoreturn_start CAMLextern void caml_array_bound_error (void);
+CAMLnoreturn_start CAMLextern void caml_raise_sys_blocked_io (void);
 
 #ifdef __cplusplus
 }

--- a/byterun/caml/memory.h
+++ b/byterun/caml/memory.h
@@ -152,6 +152,11 @@ CAMLextern struct caml__roots_block *caml_local_roots;  /* defined in roots.c */
   CAMLparam0 (); \
   CAMLxparamN (x, (size))
 
+#if defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 7))
+  #define CAMLunused __attribute__ ((unused))
+#elif
+  #define CAMLunused
+#endif
 
 #if defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 7))
   #define CAMLunused_start __attribute__ ((unused))

--- a/byterun/caml/memory.h
+++ b/byterun/caml/memory.h
@@ -154,7 +154,7 @@ CAMLextern struct caml__roots_block *caml_local_roots;  /* defined in roots.c */
 
 #if defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 7))
   #define CAMLunused __attribute__ ((unused))
-#elif
+#else
   #define CAMLunused
 #endif
 

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -40,11 +40,11 @@ typedef char * addr;
 
 #ifdef __GNUC__
   /* Works only in GCC 2.5 and later */
-  #define CAMLnoreturn __attribute__ ((noreturn))
+  #define CAMLno_return __attribute__ ((noreturn))
 #elif _MSC_VER >= 1500
-  #define CAMLnoreturn __declspec(noreturn)
+  #define CAMLno_return __declspec(noreturn)
 #else
-  #define CAMLnoreturn
+  #define CAMLno_return
 #endif
 
 #ifdef __GNUC__
@@ -86,14 +86,14 @@ extern caml_timing_hook caml_finalise_begin_hook, caml_finalise_end_hook;
 #ifdef DEBUG
 #define CAMLassert(x) \
   ((x) ? (void) 0 : caml_failed_assert ( #x , __FILE__, __LINE__))
-CAMLnoreturn CAMLextern int caml_failed_assert (char *, char *, int);
+CAMLno_return CAMLextern int caml_failed_assert (char *, char *, int);
 #else
 #define CAMLassert(x) ((void) 0)
 #endif
 
-CAMLnoreturn CAMLextern void caml_fatal_error (char *msg);
-CAMLnoreturn CAMLextern void caml_fatal_error_arg (char *fmt, char *arg);
-CAMLnoreturn CAMLextern void caml_fatal_error_arg2 (char *fmt1, char *arg1,
+CAMLno_return CAMLextern void caml_fatal_error (char *msg);
+CAMLno_return CAMLextern void caml_fatal_error_arg (char *fmt, char *arg);
+CAMLno_return CAMLextern void caml_fatal_error_arg2 (char *fmt1, char *arg1,
                                        char *fmt2, char *arg2);
 
 /* Safe string operations */

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -40,12 +40,21 @@ typedef char * addr;
 
 #ifdef __GNUC__
   /* Works only in GCC 2.5 and later */
-  #define Noreturn __attribute__ ((noreturn))
+  #define CAMLnoreturn __attribute__ ((noreturn))
 #elif _MSC_VER >= 1500
-  #define Noreturn __declspec(noreturn)
+  #define CAMLnoreturn __declspec(noreturn)
 #else
+  #define CAMLnoreturn
+#endif
+
+#ifdef __GNUC__
+  /* Works only in GCC 2.5 and later */
+  #define Noreturn __attribute__ ((noreturn))
+#elif 
   #define Noreturn
 #endif
+
+
 
 /* Export control (to mark primitives and to handle Windows DLL) */
 
@@ -77,14 +86,14 @@ extern caml_timing_hook caml_finalise_begin_hook, caml_finalise_end_hook;
 #ifdef DEBUG
 #define CAMLassert(x) \
   ((x) ? (void) 0 : caml_failed_assert ( #x , __FILE__, __LINE__))
-Noreturn CAMLextern int caml_failed_assert (char *, char *, int);
+CAMLnoreturn CAMLextern int caml_failed_assert (char *, char *, int);
 #else
 #define CAMLassert(x) ((void) 0)
 #endif
 
-Noreturn CAMLextern void caml_fatal_error (char *msg);
-Noreturn CAMLextern void caml_fatal_error_arg (char *fmt, char *arg);
-Noreturn CAMLextern void caml_fatal_error_arg2 (char *fmt1, char *arg1,
+CAMLnoreturn CAMLextern void caml_fatal_error (char *msg);
+CAMLnoreturn CAMLextern void caml_fatal_error_arg (char *fmt, char *arg);
+CAMLnoreturn CAMLextern void caml_fatal_error_arg2 (char *fmt1, char *arg1,
                                        char *fmt2, char *arg2);
 
 /* Safe string operations */

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -50,7 +50,7 @@ typedef char * addr;
 #ifdef __GNUC__
   /* Works only in GCC 2.5 and later */
   #define Noreturn __attribute__ ((noreturn))
-#elif 
+#else
   #define Noreturn
 #endif
 

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -40,17 +40,16 @@ typedef char * addr;
 
 #ifdef __GNUC__
   /* Works only in GCC 2.5 and later */
-  #define CAMLno_return __attribute__ ((noreturn))
-#elif _MSC_VER >= 1500
-  #define CAMLno_return __declspec(noreturn)
-#else
-  #define CAMLno_return
-#endif
-
-#ifdef __GNUC__
-  /* Works only in GCC 2.5 and later */
   #define Noreturn __attribute__ ((noreturn))
+  #define CAMLnoreturn_end __attribute__ ((noreturn))
+  #define CAMLnoreturn_start __attribute__ ((noreturn))
+#elif _MSC_VER >= 1500
+  #define CAMLnoreturn_start __declspec(noreturn)
+  #define CAMLnoreturn_end
+  #define Noreturn
 #else
+  #define CAMLnoreturn_start
+  #define CAMLnoreturn_end
   #define Noreturn
 #endif
 
@@ -86,14 +85,14 @@ extern caml_timing_hook caml_finalise_begin_hook, caml_finalise_end_hook;
 #ifdef DEBUG
 #define CAMLassert(x) \
   ((x) ? (void) 0 : caml_failed_assert ( #x , __FILE__, __LINE__))
-CAMLno_return CAMLextern int caml_failed_assert (char *, char *, int);
+CAMLnoreturn_start CAMLextern int caml_failed_assert (char *, char *, int);
 #else
 #define CAMLassert(x) ((void) 0)
 #endif
 
-CAMLno_return CAMLextern void caml_fatal_error (char *msg);
-CAMLno_return CAMLextern void caml_fatal_error_arg (char *fmt, char *arg);
-CAMLno_return CAMLextern void caml_fatal_error_arg2 (char *fmt1, char *arg1,
+CAMLnoreturn_start CAMLextern void caml_fatal_error (char *msg);
+CAMLnoreturn_start CAMLextern void caml_fatal_error_arg (char *fmt, char *arg);
+CAMLnoreturn_start CAMLextern void caml_fatal_error_arg2 (char *fmt1, char *arg1,
                                        char *fmt2, char *arg2);
 
 /* Safe string operations */

--- a/byterun/caml/printexc.h
+++ b/byterun/caml/printexc.h
@@ -24,7 +24,7 @@ extern "C" {
 
 
 CAMLextern char * caml_format_exception (value);
-Noreturn void caml_fatal_uncaught_exception (value);
+CAMLnoreturn void caml_fatal_uncaught_exception (value);
 
 #ifdef __cplusplus
 }

--- a/byterun/caml/printexc.h
+++ b/byterun/caml/printexc.h
@@ -24,7 +24,7 @@ extern "C" {
 
 
 CAMLextern char * caml_format_exception (value);
-CAMLno_return void caml_fatal_uncaught_exception (value);
+CAMLnoreturn_start void caml_fatal_uncaught_exception (value);
 
 #ifdef __cplusplus
 }

--- a/byterun/caml/printexc.h
+++ b/byterun/caml/printexc.h
@@ -24,7 +24,7 @@ extern "C" {
 
 
 CAMLextern char * caml_format_exception (value);
-CAMLnoreturn void caml_fatal_uncaught_exception (value);
+CAMLno_return void caml_fatal_uncaught_exception (value);
 
 #ifdef __cplusplus
 }

--- a/byterun/extern.c
+++ b/byterun/extern.c
@@ -75,10 +75,10 @@ static struct extern_item * extern_stack_limit = extern_stack_init
 
 /* Forward declarations */
 
-CAMLno_return static void extern_out_of_memory(void);
-CAMLno_return static void extern_invalid_argument(char *msg);
-CAMLno_return static void extern_failwith(char *msg);
-CAMLno_return static void extern_stack_overflow(void);
+CAMLnoreturn_start static void extern_out_of_memory(void);
+CAMLnoreturn_start static void extern_invalid_argument(char *msg);
+CAMLnoreturn_start static void extern_failwith(char *msg);
+CAMLnoreturn_start static void extern_stack_overflow(void);
 static struct code_fragment * extern_find_code(char *addr);
 static void extern_replay_trail(void);
 static void free_extern_output(void);

--- a/byterun/extern.c
+++ b/byterun/extern.c
@@ -75,10 +75,10 @@ static struct extern_item * extern_stack_limit = extern_stack_init
 
 /* Forward declarations */
 
-Noreturn static void extern_out_of_memory(void);
-Noreturn static void extern_invalid_argument(char *msg);
-Noreturn static void extern_failwith(char *msg);
-Noreturn static void extern_stack_overflow(void);
+CAMLnoreturn static void extern_out_of_memory(void);
+CAMLnoreturn static void extern_invalid_argument(char *msg);
+CAMLnoreturn static void extern_failwith(char *msg);
+CAMLnoreturn static void extern_stack_overflow(void);
 static struct code_fragment * extern_find_code(char *addr);
 static void extern_replay_trail(void);
 static void free_extern_output(void);

--- a/byterun/extern.c
+++ b/byterun/extern.c
@@ -75,10 +75,10 @@ static struct extern_item * extern_stack_limit = extern_stack_init
 
 /* Forward declarations */
 
-CAMLnoreturn static void extern_out_of_memory(void);
-CAMLnoreturn static void extern_invalid_argument(char *msg);
-CAMLnoreturn static void extern_failwith(char *msg);
-CAMLnoreturn static void extern_stack_overflow(void);
+CAMLno_return static void extern_out_of_memory(void);
+CAMLno_return static void extern_invalid_argument(char *msg);
+CAMLno_return static void extern_failwith(char *msg);
+CAMLno_return static void extern_stack_overflow(void);
 static struct code_fragment * extern_find_code(char *addr);
 static void extern_replay_trail(void);
 static void free_extern_output(void);

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -66,7 +66,7 @@ static value intern_block;
 
 static char * intern_resolve_code_pointer(unsigned char digest[16],
                                           asize_t offset);
-CAMLnoreturn static void intern_bad_code_pointer(unsigned char digest[16]);
+CAMLno_return static void intern_bad_code_pointer(unsigned char digest[16]);
 
 static void intern_free_stack(void);
 

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -66,7 +66,7 @@ static value intern_block;
 
 static char * intern_resolve_code_pointer(unsigned char digest[16],
                                           asize_t offset);
-CAMLno_return static void intern_bad_code_pointer(unsigned char digest[16]);
+CAMLnoreturn_start static void intern_bad_code_pointer(unsigned char digest[16]);
 
 static void intern_free_stack(void);
 

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -66,7 +66,7 @@ static value intern_block;
 
 static char * intern_resolve_code_pointer(unsigned char digest[16],
                                           asize_t offset);
-Noreturn static void intern_bad_code_pointer(unsigned char digest[16]);
+CAMLnoreturn static void intern_bad_code_pointer(unsigned char digest[16]);
 
 static void intern_free_stack(void);
 

--- a/otherlibs/graph/libgraph.h
+++ b/otherlibs/graph/libgraph.h
@@ -74,7 +74,7 @@ extern int caml_gr_bits_per_pixel;
 #endif
 #endif
 
-CAMLno_return extern void caml_gr_fail(char *fmt, char *arg);
+CAMLnoreturn_start extern void caml_gr_fail(char *fmt, char *arg);
 extern void caml_gr_check_open(void);
 extern unsigned long caml_gr_pixel_rgb(int rgb);
 extern int caml_gr_rgb_pixel(long unsigned int pixel);

--- a/otherlibs/graph/libgraph.h
+++ b/otherlibs/graph/libgraph.h
@@ -74,7 +74,7 @@ extern int caml_gr_bits_per_pixel;
 #endif
 #endif
 
-Noreturn extern void caml_gr_fail(char *fmt, char *arg);
+CAMLnoreturn extern void caml_gr_fail(char *fmt, char *arg);
 extern void caml_gr_check_open(void);
 extern unsigned long caml_gr_pixel_rgb(int rgb);
 extern int caml_gr_rgb_pixel(long unsigned int pixel);

--- a/otherlibs/graph/libgraph.h
+++ b/otherlibs/graph/libgraph.h
@@ -74,7 +74,7 @@ extern int caml_gr_bits_per_pixel;
 #endif
 #endif
 
-CAMLnoreturn extern void caml_gr_fail(char *fmt, char *arg);
+CAMLno_return extern void caml_gr_fail(char *fmt, char *arg);
 extern void caml_gr_check_open(void);
 extern unsigned long caml_gr_pixel_rgb(int rgb);
 extern int caml_gr_rgb_pixel(long unsigned int pixel);

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -26,8 +26,8 @@ extern "C" {
 
 extern value unix_error_of_code (int errcode);
 extern int code_of_unix_error (value error);
-CAMLnoreturn extern void unix_error (int errcode, char * cmdname, value arg);
-CAMLnoreturn extern void uerror (char * cmdname, value arg);
+CAMLno_return extern void unix_error (int errcode, char * cmdname, value arg);
+CAMLno_return extern void uerror (char * cmdname, value arg);
 
 #define UNIX_BUFFER_SIZE 65536
 

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -26,8 +26,8 @@ extern "C" {
 
 extern value unix_error_of_code (int errcode);
 extern int code_of_unix_error (value error);
-Noreturn extern void unix_error (int errcode, char * cmdname, value arg);
-Noreturn extern void uerror (char * cmdname, value arg);
+CAMLnoreturn extern void unix_error (int errcode, char * cmdname, value arg);
+CAMLnoreturn extern void uerror (char * cmdname, value arg);
 
 #define UNIX_BUFFER_SIZE 65536
 

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -26,8 +26,8 @@ extern "C" {
 
 extern value unix_error_of_code (int errcode);
 extern int code_of_unix_error (value error);
-CAMLno_return extern void unix_error (int errcode, char * cmdname, value arg);
-CAMLno_return extern void uerror (char * cmdname, value arg);
+CAMLnoreturn_start extern void unix_error (int errcode, char * cmdname, value arg);
+CAMLnoreturn_start extern void uerror (char * cmdname, value arg);
 
 #define UNIX_BUFFER_SIZE 65536
 


### PR DESCRIPTION
As outlined in PR #165 the new macro definitions for `Noreturn` and `CAMLunused` will lead to problems with third party stubs. Therefor the old macros are reintroduced and the new definitions are now available through the `CAMLnoreturn` and the `CAMLunused_start` and `CAMLunused_end` macro.
