### PR TITLE
Small fixes related to `int_of_string`

### DIFF
--- a/byterun/ints.c
+++ b/byterun/ints.c
@@ -30,7 +30,8 @@ static char * parse_sign_and_base(char * p,
   if (*p == '-') {
     *sign = -1;
     p++;
-  }
+  } else if (*p == '+')
+    p++;
   *base = 10; *signedness = 1;
   if (*p == '0') {
     switch (p[1]) {

--- a/byterun/ints.c
+++ b/byterun/ints.c
@@ -26,6 +26,8 @@ static char * parse_sign_and_base(char * p,
                                   /*out*/ int * signedness,
                                   /*out*/ int * sign)
 {
+  while (*p == ' ')
+    p++;
   *sign = 1;
   if (*p == '-') {
     *sign = -1;

--- a/byterun/ints.c
+++ b/byterun/ints.c
@@ -26,8 +26,6 @@ static char * parse_sign_and_base(char * p,
                                   /*out*/ int * signedness,
                                   /*out*/ int * sign)
 {
-  while (*p == ' ')
-    p++;
   *sign = 1;
   if (*p == '-') {
     *sign = -1;

--- a/testsuite/tests/lib-num/test_big_ints.ml
+++ b/testsuite/tests/lib-num/test_big_ints.ml
@@ -382,7 +382,7 @@ failwith_test 5 big_int_of_string "sdjdkfighdgf"
 test 6
 eq_big_int (big_int_of_string "123", big_int_of_int 123);;
 test 7
-eq_big_int (big_int_of_string "3456", big_int_of_int 3456);;
+eq_big_int (big_int_of_string "+3456", big_int_of_int 3456);;
 
 test 9
 eq_big_int (big_int_of_string "-3456", big_int_of_int (-3456));;

--- a/testsuite/tests/tool-ocaml/t240-c_call1.ml
+++ b/testsuite/tests/tool-ocaml/t240-c_call1.ml
@@ -1,5 +1,7 @@
 open Lib;;
 if Pervasives.int_of_string "123" <> 123 then raise Not_found;;
+(** test for fix of bug 6649: http://caml.inria.fr/mantis/view.php?id=6649 *)
+if Pervasives.int_of_string "+123" <> 123 then raise Not_found;;
 
 (**
        0 CONSTINT 42

--- a/testsuite/tests/tool-ocaml/t240-c_call1.ml
+++ b/testsuite/tests/tool-ocaml/t240-c_call1.ml
@@ -3,8 +3,6 @@ if Pervasives.int_of_string "123" <> 123 then raise Not_found;;
 (** test for fix of bug 6649: http://caml.inria.fr/mantis/view.php?id=6649 *)
 if Pervasives.int_of_string "+123" <> 123 then raise Not_found;;
 
-if Pervasives.int_of_string " 123" <> 123 then raise Not_found;;
-
 (**
        0 CONSTINT 42
        2 PUSHACC0 

--- a/testsuite/tests/tool-ocaml/t240-c_call1.ml
+++ b/testsuite/tests/tool-ocaml/t240-c_call1.ml
@@ -3,6 +3,8 @@ if Pervasives.int_of_string "123" <> 123 then raise Not_found;;
 (** test for fix of bug 6649: http://caml.inria.fr/mantis/view.php?id=6649 *)
 if Pervasives.int_of_string "+123" <> 123 then raise Not_found;;
 
+if Pervasives.int_of_string " 123" <> 123 then raise Not_found;;
+
 (**
        0 CONSTINT 42
        2 PUSHACC0 

--- a/testsuite/tests/tool-ocaml/t240-c_call1.ml
+++ b/testsuite/tests/tool-ocaml/t240-c_call1.ml
@@ -3,6 +3,10 @@ if Pervasives.int_of_string "123" <> 123 then raise Not_found;;
 (** test for fix of bug 6649: http://caml.inria.fr/mantis/view.php?id=6649 *)
 if Pervasives.int_of_string "+123" <> 123 then raise Not_found;;
 
+if Int32.of_string "+123" <> Int32.of_int 123 then raise Not_found;;
+if Int64.of_string "+123" <> Int64.of_int 123 then raise Not_found;;
+if Nativeint.of_string "+123" <> Nativeint.of_int 123 then raise Not_found;;
+
 (**
        0 CONSTINT 42
        2 PUSHACC0 


### PR DESCRIPTION
This pull request includes two patches to fix [bug #6649](http://caml.inria.fr/mantis/view.php?id=6649) and allow `int_of_string` to parse strings with some leading whitespace.

It is worth noting that the second fix (whitespace) was accomplished by modifying the function `parse_sign_and_base` in `byterun/ints.c`, as I assume that raw performance is the main priority in implementing these system functions. It may, however, by slightly prettier to change the definition of `int_of_string` found in `stdlib/pervasives.ml` from

```
external int_of_string : string -> int = "caml_int_of_string"
```

to something like

```
external int_of_string_extern : string -> int = "caml_int_of_string"

let int_of_string (s : string) =
  String.trim s
  |> int_of_string_extern
```
