### PR TITLE
Warnings for pr 210

### DIFF
--- a/byterun/caml/io.h
+++ b/byterun/caml/io.h
@@ -92,6 +92,11 @@ CAMLextern int caml_really_getblock (struct channel *, char *, intnat);
 
 #define Channel(v) (*((struct channel **) (Data_custom_val(v))))
 
+/* Runtime warnings */
+
+CAMLextern value caml_ml_enable_runtime_warnings(value);
+CAMLprim value caml_ml_runtime_warnings_enabled(value);
+
 /* The locking machinery */
 
 CAMLextern void (*caml_channel_mutex_free) (struct channel *);

--- a/byterun/startup_aux.c
+++ b/byterun/startup_aux.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include "caml/backtrace.h"
 #include "caml/memory.h"
+#include "caml/io.h"
 #include "caml/startup_aux.h"
 
 


### PR DESCRIPTION
There's a clang warning since #210 was merged: 

```
gcc -DCAML_NAME_SPACE -O  -Wall -D_FILE_OFFSET_BITS=64 -D_REENTRANT    -c -o startup_aux.o startup_aux.c
startup_aux.c:86:9: warning: implicit declaration of function 'caml_ml_enable_runtime_warnings' is invalid in C99 [-Wimplicit-function-declaration]
        caml_ml_enable_runtime_warnings(Val_bool (p)); break;
        ^
1 warning generated.
```

I'm not quite sure if `<caml/io.h>` is the right place for the runtime-warnings functionality to be exposed from though, despite the fact that this is where the first fd-leak warning was introduced...
