### PR TITLE
Marshaling: beyond 4 Gb

### DIFF
--- a/byterun/caml/intext.h
+++ b/byterun/caml/intext.h
@@ -27,7 +27,25 @@
 
 /* Magic number */
 
-#define Intext_magic_number 0x8495A6BE
+#define Intext_magic_number_small 0x8495A6BE
+#define Intext_magic_number_big 0x8495A6BF
+
+/* Header format for the "small" model: 20 bytes
+       0   "small" magic number
+       4   length of marshaled data, in bytes
+       8   number of shared blocks
+      12   size in words when read on a 32-bit platform
+      16   size in words when read on a 64-bit platform
+   The 4 numbers are 32 bits each, in big endian.
+
+   Header format for the "big" model: 32 bytes
+       0   "big" magic number
+       4   four reserved bytes, currently set to 0
+       8   length of marshaled data, in bytes
+      16   number of shared blocks
+      24   size in words when read on a 64-bit platform
+   The 3 numbers are 64 bits each, in big endian.
+*/
 
 /* Codes for the compact format */
 
@@ -41,16 +59,20 @@
 #define CODE_SHARED8 0x4
 #define CODE_SHARED16 0x5
 #define CODE_SHARED32 0x6
+#define CODE_SHARED64 0x14
 #define CODE_BLOCK32 0x8
 #define CODE_BLOCK64 0x13
 #define CODE_STRING8 0x9
 #define CODE_STRING32 0xA
+#define CODE_STRING64 0x15
 #define CODE_DOUBLE_BIG 0xB
 #define CODE_DOUBLE_LITTLE 0xC
 #define CODE_DOUBLE_ARRAY8_BIG 0xD
 #define CODE_DOUBLE_ARRAY8_LITTLE 0xE
 #define CODE_DOUBLE_ARRAY32_BIG 0xF
 #define CODE_DOUBLE_ARRAY32_LITTLE 0x7
+#define CODE_DOUBLE_ARRAY64_BIG 0x16
+#define CODE_DOUBLE_ARRAY64_LITTLE 0x17
 #define CODE_CODEPOINTER 0x10
 #define CODE_INFIXPOINTER 0x11
 #define CODE_CUSTOM 0x12
@@ -59,10 +81,12 @@
 #define CODE_DOUBLE_NATIVE CODE_DOUBLE_BIG
 #define CODE_DOUBLE_ARRAY8_NATIVE CODE_DOUBLE_ARRAY8_BIG
 #define CODE_DOUBLE_ARRAY32_NATIVE CODE_DOUBLE_ARRAY32_BIG
+#define CODE_DOUBLE_ARRAY64_NATIVE CODE_DOUBLE_ARRAY64_BIG
 #else
 #define CODE_DOUBLE_NATIVE CODE_DOUBLE_LITTLE
 #define CODE_DOUBLE_ARRAY8_NATIVE CODE_DOUBLE_ARRAY8_LITTLE
 #define CODE_DOUBLE_ARRAY32_NATIVE CODE_DOUBLE_ARRAY32_LITTLE
+#define CODE_DOUBLE_ARRAY64_NATIVE CODE_DOUBLE_ARRAY64_LITTLE
 #endif
 
 /* Size-ing data structures for extern.  Chosen so that

--- a/byterun/extern.c
+++ b/byterun/extern.c
@@ -440,7 +440,7 @@ static void extern_rec(value v)
       } else if (d < 0x10000) {
         writecode16(CODE_SHARED16, d);
 #ifdef ARCH_SIXTYFOUR
-      } else if (d >= (uintnat)1 >> 32) {
+      } else if (d >= (uintnat)1 << 32) {
         writecode64(CODE_SHARED64, d);
 #endif
       } else {

--- a/byterun/extern.c
+++ b/byterun/extern.c
@@ -715,19 +715,15 @@ CAMLexport intnat caml_output_value_to_block(value v, value flags,
   extern_ptr = extern_userprovided_output;
   extern_limit = buf + len;
   data_len = extern_value(v, flags, header, &header_len);
-  if (header_len == 20) {
-    /* Good guess! */
-    memcpy(buf, header, 20);
-    return 20 + data_len;
-  } else {
-    /* Need to shift the output to make room for big header. 
+  if (header_len != 20) {
+    /* Bad guess!  Need to shift the output to make room for big header. 
        Make sure there is room. */
     if (header_len + data_len > len)
       caml_failwith("Marshal.to_buffer: buffer overflow");
     memmove(buf + header_len, buf + 20, data_len);
-    memcpy(buf, header, header_len);
-    return header_len + data_len;
   }
+  memcpy(buf, header, header_len);
+  return header_len + data_len;
 }
 
 CAMLprim value caml_output_value_to_buffer(value buf, value ofs, value len,

--- a/byterun/extern.c
+++ b/byterun/extern.c
@@ -302,26 +302,47 @@ static void extern_stack_overflow(void)
   caml_raise_out_of_memory();
 }
 
+/* Conversion to big-endian */
+
+static inline void store16(char * dst, int n)
+{
+  dst[0] = n >> 8;  dst[1] = n;
+}
+
+static inline void store32(char * dst, intnat n)
+{
+  dst[0] = n >> 24;  dst[1] = n >> 16;  dst[2] = n >> 8;  dst[3] = n;
+}
+
+static inline void store64(char * dst, int64_t n)
+{
+  dst[0] = n >> 56;  dst[1] = n >> 48;  dst[2] = n >> 40;  dst[3] = n >> 32;
+  dst[4] = n >> 24;  dst[5] = n >> 16;  dst[6] = n >> 8;   dst[7] = n;
+}
+
 /* Write characters, integers, and blocks in the output buffer */
 
-#define Write(c) \
-  if (extern_ptr >= extern_limit) grow_extern_output(1); \
-  *extern_ptr++ = (c)
+static inline void write(int c)
+{
+  if (extern_ptr >= extern_limit) grow_extern_output(1);
+  *extern_ptr++ = c;
+}
 
-static void writeblock(char *data, intnat len)
+static void writeblock(char * data, intnat len)
 {
   if (extern_ptr + len > extern_limit) grow_extern_output(len);
-  memmove(extern_ptr, data, len);
+  memcpy(extern_ptr, data, len);
   extern_ptr += len;
 }
 
+static inline void writeblock_float8(double * data, intnat ndoubles)
+{
 #if ARCH_FLOAT_ENDIANNESS == 0x01234567 || ARCH_FLOAT_ENDIANNESS == 0x76543210
-#define writeblock_float8(data,ndoubles) \
-  writeblock((char *)(data), (ndoubles) * 8)
+  writeblock((char *) data, ndoubles * 8);
 #else
-#define writeblock_float8(data,ndoubles) \
-  caml_serialize_block_float_8((data), (ndoubles))
+  caml_serialize_block_float_8(data, ndoubles);
 #endif
+}
 
 static void writecode8(int code, intnat val)
 {
@@ -335,39 +356,25 @@ static void writecode16(int code, intnat val)
 {
   if (extern_ptr + 3 > extern_limit) grow_extern_output(3);
   extern_ptr[0] = code;
-  extern_ptr[1] = val >> 8;
-  extern_ptr[2] = val;
+  store16(extern_ptr + 1, val);
   extern_ptr += 3;
-}
-
-static void write32(intnat val)
-{
-  if (extern_ptr + 4 > extern_limit) grow_extern_output(4);
-  extern_ptr[0] = val >> 24;
-  extern_ptr[1] = val >> 16;
-  extern_ptr[2] = val >> 8;
-  extern_ptr[3] = val;
-  extern_ptr += 4;
 }
 
 static void writecode32(int code, intnat val)
 {
   if (extern_ptr + 5 > extern_limit) grow_extern_output(5);
   extern_ptr[0] = code;
-  extern_ptr[1] = val >> 24;
-  extern_ptr[2] = val >> 16;
-  extern_ptr[3] = val >> 8;
-  extern_ptr[4] = val;
+  store32(extern_ptr + 1, val);
   extern_ptr += 5;
 }
 
 #ifdef ARCH_SIXTYFOUR
 static void writecode64(int code, intnat val)
 {
-  int i;
   if (extern_ptr + 9 > extern_limit) grow_extern_output(9);
-  *extern_ptr ++ = code;
-  for (i = 64 - 8; i >= 0; i -= 8) *extern_ptr++ = val >> i;
+  extern_ptr[0] = code;
+  store64(extern_ptr + 1, val);
+  extern_ptr += 9;
 }
 #endif
 
@@ -383,7 +390,7 @@ static void extern_rec(value v)
   if (Is_long(v)) {
     intnat n = Long_val(v);
     if (n >= 0 && n < 0x40) {
-      Write(PREFIX_SMALL_INT + n);
+      write(PREFIX_SMALL_INT + n);
     } else if (n >= -(1 << 7) && n < (1 << 7)) {
       writecode8(CODE_INT8, n);
     } else if (n >= -(1 << 15) && n < (1 << 15)) {
@@ -419,7 +426,7 @@ static void extern_rec(value v)
        in the externed block, and they are automatically shared. */
     if (sz == 0) {
       if (tag < 16) {
-        Write(PREFIX_SMALL_BLOCK + tag);
+        write(PREFIX_SMALL_BLOCK + tag);
       } else {
         writecode32(CODE_BLOCK32, hd);
       }
@@ -432,6 +439,10 @@ static void extern_rec(value v)
         writecode8(CODE_SHARED8, d);
       } else if (d < 0x10000) {
         writecode16(CODE_SHARED16, d);
+#ifdef ARCH_SIXTYFOUR
+      } else if (d >= (uintnat)1 >> 32) {
+        writecode64(CODE_SHARED64, d);
+#endif
       } else {
         writecode32(CODE_SHARED32, d);
       }
@@ -443,7 +454,7 @@ static void extern_rec(value v)
     case String_tag: {
       mlsize_t len = caml_string_length(v);
       if (len < 0x20) {
-        Write(PREFIX_SMALL_STRING + len);
+        write(PREFIX_SMALL_STRING + len);
       } else if (len < 0x100) {
         writecode8(CODE_STRING8, len);
       } else {
@@ -451,8 +462,13 @@ static void extern_rec(value v)
         if (len > 0xFFFFFB && (extern_flags & COMPAT_32))
           extern_failwith("output_value: string cannot be read back on "
                           "32-bit platform");
-#endif
+        if (len < (uintnat)1 << 32)
+          writecode32(CODE_STRING32, len);
+        else
+          writecode64(CODE_STRING64, len);
+#else
         writecode32(CODE_STRING32, len);
+#endif
       }
       writeblock(String_val(v), len);
       size_32 += 1 + (len + 4) / 4;
@@ -463,7 +479,7 @@ static void extern_rec(value v)
     case Double_tag: {
       if (sizeof(double) != 8)
         extern_invalid_argument("output_value: non-standard floats");
-      Write(CODE_DOUBLE_NATIVE);
+      write(CODE_DOUBLE_NATIVE);
       writeblock_float8((double *) v, 1);
       size_32 += 1 + 2;
       size_64 += 1 + 1;
@@ -482,8 +498,13 @@ static void extern_rec(value v)
         if (nfloats > 0x1FFFFF && (extern_flags & COMPAT_32))
           extern_failwith("output_value: float array cannot be read back on "
                           "32-bit platform");
-#endif
+        if (nfloats < (uintnat) 1 << 32)
+          writecode32(CODE_DOUBLE_ARRAY32_NATIVE, nfloats);
+        else
+          writecode64(CODE_DOUBLE_ARRAY64_NATIVE, nfloats);
+#else
         writecode32(CODE_DOUBLE_ARRAY32_NATIVE, nfloats);
+#endif
       }
       writeblock_float8((double *) v, nfloats);
       size_32 += 1 + nfloats * 2;
@@ -506,7 +527,7 @@ static void extern_rec(value v)
         = Custom_ops_val(v)->serialize;
       if (serialize == NULL)
         extern_invalid_argument("output_value: abstract value (Custom)");
-      Write(CODE_CUSTOM);
+      write(CODE_CUSTOM);
       writeblock(ident, strlen(ident) + 1);
       Custom_ops_val(v)->serialize(v, &sz_32, &sz_64);
       size_32 += 2 + ((sz_32 + 3) >> 2);  /* header + ops + data */
@@ -517,19 +538,19 @@ static void extern_rec(value v)
     default: {
       value field0;
       if (tag < 16 && sz < 8) {
-        Write(PREFIX_SMALL_BLOCK + tag + (sz << 4));
-#ifdef ARCH_SIXTYFOUR
-      } else if (hd >= ((uintnat)1 << 32)) {
-        /* Is this case useful?  The overflow check in extern_value will fail.*/
-        writecode64(CODE_BLOCK64, Whitehd_hd (hd));
-#endif
+        write(PREFIX_SMALL_BLOCK + tag + (sz << 4));
       } else {
 #ifdef ARCH_SIXTYFOUR
         if (sz > 0x3FFFFF && (extern_flags & COMPAT_32))
           extern_failwith("output_value: array cannot be read back on "
                           "32-bit platform");
-#endif
+        if (hd < (uintnat)1 << 32)
+          writecode32(CODE_BLOCK32, Whitehd_hd (hd));
+        else
+          writecode64(CODE_BLOCK64, Whitehd_hd (hd));
+#else
         writecode32(CODE_BLOCK32, Whitehd_hd (hd));
+#endif
       }
       size_32 += 1 + sz;
       size_64 += 1 + sz;
@@ -571,7 +592,9 @@ static void extern_rec(value v)
 
 static int extern_flag_values[] = { NO_SHARING, CLOSURES, COMPAT_32 };
 
-static intnat extern_value(value v, value flags)
+static intnat extern_value(value v, value flags,
+                           /*out*/ char header[32],
+                           /*out*/ int * header_len)
 {
   intnat res_len;
   /* Parse flag list */
@@ -581,53 +604,58 @@ static intnat extern_value(value v, value flags)
   obj_counter = 0;
   size_32 = 0;
   size_64 = 0;
-  /* Write magic number */
-  write32(Intext_magic_number);
-  /* Set aside space for the sizes */
-  extern_ptr += 4*4;
   /* Marshal the object */
   extern_rec(v);
   /* Record end of output */
   close_extern_output();
   /* Undo the modifications done on externed blocks */
   extern_replay_trail();
-  /* Write the sizes */
+  /* Write the header */
   res_len = extern_output_length();
 #ifdef ARCH_SIXTYFOUR
   if (res_len >= ((intnat)1 << 32) ||
       size_32 >= ((intnat)1 << 32) || size_64 >= ((intnat)1 << 32)) {
-    /* The object is so big its size cannot be written in the header.
-       Besides, some of the array lengths or string lengths or shared offsets
-       it contains may have overflowed the 32 bits used to write them. */
-    free_extern_output();
-    caml_failwith("output_value: object too big");
+    /* The object is too big for the small header format.
+       Fail if we are in compat32 mode, or use big header. */
+    if (extern_flags & COMPAT_32) {
+      free_extern_output();
+      caml_failwith("output_value: object too big to be read back on "
+                    "32-bit platform");
+    }
+    store32(header, Intext_magic_number_big);
+    store32(header + 4, 0);
+    store64(header + 8, res_len);
+    store64(header + 16, obj_counter);
+    store64(header + 24, size_64);
+    *header_len = 32;
+    return res_len;
   }
 #endif
-  if (extern_userprovided_output != NULL)
-    extern_ptr = extern_userprovided_output + 4;
-  else {
-    extern_ptr = extern_output_first->data + 4;
-    extern_limit = extern_output_first->data + SIZE_EXTERN_OUTPUT_BLOCK;
-  }
-  write32(res_len - 5*4);
-  write32(obj_counter);
-  write32(size_32);
-  write32(size_64);
+  /* Use the small header format */
+  store32(header, Intext_magic_number_small);
+  store32(header + 4, res_len);
+  store32(header + 8, obj_counter);
+  store32(header + 12, size_32);
+  store32(header + 16, size_64);
+  *header_len = 20;
   return res_len;
 }
 
 void caml_output_val(struct channel *chan, value v, value flags)
 {
+  char header[32];
+  int header_len;
   struct output_block * blk, * nextblk;
 
   if (! caml_channel_binary_mode(chan))
     caml_failwith("output_value: not a binary channel");
   init_extern_output();
-  extern_value(v, flags);
+  extern_value(v, flags, header, &header_len);
   /* During [caml_really_putblock], concurrent [caml_output_val] operations
      can take place (via signal handlers or context switching in systhreads),
      and [extern_output_first] may change. So, save it in a local variable. */
   blk = extern_output_first;
+  caml_really_putblock(chan, header, header_len);
   while (blk != NULL) {
     caml_really_putblock(chan, blk->data, blk->end - blk->data);
     nextblk = blk->next;
@@ -649,20 +677,24 @@ CAMLprim value caml_output_value(value vchan, value v, value flags)
 
 CAMLprim value caml_output_value_to_string(value v, value flags)
 {
-  intnat len, ofs;
+  char header[32];
+  int header_len;
+  intnat data_len, ofs;
   value res;
   struct output_block * blk, * nextblk;
 
   init_extern_output();
-  len = extern_value(v, flags);
+  data_len = extern_value(v, flags, header, &header_len);
   /* PR#4030: it is prudent to save extern_output_first before allocating
      the result, as in caml_output_val */
   blk = extern_output_first;
-  res = caml_alloc_string(len);
+  res = caml_alloc_string(header_len + data_len);
   ofs = 0;
+  memcpy(&Byte(res, ofs), header, header_len);
+  ofs += header_len;
   while (blk != NULL) {
     int n = blk->end - blk->data;
-    memmove(&Byte(res, ofs), blk->data, n);
+    memcpy(&Byte(res, ofs), blk->data, n);
     ofs += n;
     nextblk = blk->next;
     free(blk);
@@ -671,48 +703,66 @@ CAMLprim value caml_output_value_to_string(value v, value flags)
   return res;
 }
 
+CAMLexport intnat caml_output_value_to_block(value v, value flags,
+                                             char * buf, intnat len)
+{
+  char header[32];
+  int header_len;
+  intnat data_len;
+  /* At this point we don't know the size of the header.  
+     Guess that it is small, and fix up later if not. */
+  extern_userprovided_output = buf + 20;
+  extern_ptr = extern_userprovided_output;
+  extern_limit = buf + len;
+  data_len = extern_value(v, flags, header, &header_len);
+  if (header_len == 20) {
+    /* Good guess! */
+    memcpy(buf, header, 20);
+    return 20 + data_len;
+  } else {
+    /* Need to shift the output to make room for big header. 
+       Make sure there is room. */
+    if (header_len + data_len > len)
+      caml_failwith("Marshal.to_buffer: buffer overflow");
+    memmove(buf + header_len, buf + 20, data_len);
+    memcpy(buf, header, header_len);
+    return header_len + data_len;
+  }
+}
+
 CAMLprim value caml_output_value_to_buffer(value buf, value ofs, value len,
                                            value v, value flags)
 {
-  intnat len_res;
-  extern_userprovided_output = &Byte(buf, Long_val(ofs));
-  extern_ptr = extern_userprovided_output;
-  extern_limit = extern_userprovided_output + Long_val(len);
-  len_res = extern_value(v, flags);
-  return Val_long(len_res);
+  intnat l =
+    caml_output_value_to_block(v, flags,
+                               &Byte(buf, Long_val(ofs)), Long_val(len));
+  return Val_long(l);
 }
 
 CAMLexport void caml_output_value_to_malloc(value v, value flags,
                                             /*out*/ char ** buf,
                                             /*out*/ intnat * len)
-{
-  intnat len_res;
+{ 
+  char header[32];
+  int header_len;
+  intnat data_len;
   char * res;
   struct output_block * blk;
 
   init_extern_output();
-  len_res = extern_value(v, flags);
-  res = malloc(len_res);
+  data_len = extern_value(v, flags, header, &header_len);
+  res = malloc(header_len + data_len);
   if (res == NULL) extern_out_of_memory();
   *buf = res;
-  *len = len_res;
+  *len = header_len + data_len;
+  memcpy(res, header, header_len);
+  res += header_len;
   for (blk = extern_output_first; blk != NULL; blk = blk->next) {
     int n = blk->end - blk->data;
-    memmove(res, blk->data, n);
+    memcpy(res, blk->data, n);
     res += n;
   }
   free_extern_output();
-}
-
-CAMLexport intnat caml_output_value_to_block(value v, value flags,
-                                             char * buf, intnat len)
-{
-  intnat len_res;
-  extern_userprovided_output = buf;
-  extern_ptr = extern_userprovided_output;
-  extern_limit = extern_userprovided_output + len;
-  len_res = extern_value(v, flags);
-  return len_res;
 }
 
 /* Functions for writing user-defined marshallers */
@@ -727,24 +777,22 @@ CAMLexport void caml_serialize_int_1(int i)
 CAMLexport void caml_serialize_int_2(int i)
 {
   if (extern_ptr + 2 > extern_limit) grow_extern_output(2);
-  extern_ptr[0] = i >> 8;
-  extern_ptr[1] = i;
+  store16(extern_ptr, i);
   extern_ptr += 2;
 }
 
 CAMLexport void caml_serialize_int_4(int32_t i)
 {
   if (extern_ptr + 4 > extern_limit) grow_extern_output(4);
-  extern_ptr[0] = i >> 24;
-  extern_ptr[1] = i >> 16;
-  extern_ptr[2] = i >> 8;
-  extern_ptr[3] = i;
+  store32(extern_ptr, i);
   extern_ptr += 4;
 }
 
 CAMLexport void caml_serialize_int_8(int64_t i)
 {
-  caml_serialize_block_8(&i, 1);
+  if (extern_ptr + 8 > extern_limit) grow_extern_output(8);
+  store64(extern_ptr, i);
+  extern_ptr += 8;
 }
 
 CAMLexport void caml_serialize_float_4(float f)
@@ -760,7 +808,7 @@ CAMLexport void caml_serialize_float_8(double f)
 CAMLexport void caml_serialize_block_1(void * data, intnat len)
 {
   if (extern_ptr + len > extern_limit) grow_extern_output(len);
-  memmove(extern_ptr, data, len);
+  memcpy(extern_ptr, data, len);
   extern_ptr += len;
 }
 
@@ -776,7 +824,7 @@ CAMLexport void caml_serialize_block_2(void * data, intnat len)
     extern_ptr = q;
   }
 #else
-  memmove(extern_ptr, data, len * 2);
+  memcpy(extern_ptr, data, len * 2);
   extern_ptr += len * 2;
 #endif
 }
@@ -793,7 +841,7 @@ CAMLexport void caml_serialize_block_4(void * data, intnat len)
     extern_ptr = q;
   }
 #else
-  memmove(extern_ptr, data, len * 4);
+  memcpy(extern_ptr, data, len * 4);
   extern_ptr += len * 4;
 #endif
 }
@@ -810,7 +858,7 @@ CAMLexport void caml_serialize_block_8(void * data, intnat len)
     extern_ptr = q;
   }
 #else
-  memmove(extern_ptr, data, len * 8);
+  memcpy(extern_ptr, data, len * 8);
   extern_ptr += len * 8;
 #endif
 }
@@ -819,7 +867,7 @@ CAMLexport void caml_serialize_block_float_8(void * data, intnat len)
 {
   if (extern_ptr + 8 * len > extern_limit) grow_extern_output(8 * len);
 #if ARCH_FLOAT_ENDIANNESS == 0x01234567
-  memmove(extern_ptr, data, len * 8);
+  memcpy(extern_ptr, data, len * 8);
   extern_ptr += len * 8;
 #elif ARCH_FLOAT_ENDIANNESS == 0x76543210
   {

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -96,7 +96,7 @@ static inline int16_t read16s(void)
 static inline uint32_t read32u(void)
 {
   uint32_t res =
-    (intern_src[0] << 24) + (intern_src[1] << 16)
+    ((uint32_t)(intern_src[0]) << 24) + (intern_src[1] << 16)
     + (intern_src[2] << 8) + intern_src[3];
   intern_src += 4;
   return res;
@@ -105,7 +105,7 @@ static inline uint32_t read32u(void)
 static inline int32_t read32s(void)
 {
   int32_t res =
-    (intern_src[0] << 24) + (intern_src[1] << 16)
+    ((uint32_t)(intern_src[0]) << 24) + (intern_src[1] << 16)
     + (intern_src[2] << 8) + intern_src[3];
   intern_src += 4;
   return res;


### PR DESCRIPTION
Following up on http://caml.inria.fr/mantis/view.php?id=6910, here is a proposal to enable marshaling (output_value, input_value, etc) to process really large data structures.  Currently, the data format used for marshaling limits the size of marshaled data to 4 Gb, owing to the use of 32-bit integers in the data header.  

This pull request introduces an alternate format for the headers of marshaled data, where all sizes are represented as 64 bit integers, thus lifting this limitation.

output_value et al use the alternate, "big" format only if:
- the size of marshaled data would not fit the old, "small" format (which implies we are on a 64-bit platform, obviously);
- the Compat_32 flag is not selected (such "big" marshaled data cannot be read back on a 32-bit platform, obviously).  If Compat_32 is selected, marshaling fails.

In all other cases, we keep using the old, "small" format, for compatibility with 32-bit readers, with older versions of OCaml, and also for compactness (the "small" header is smaller than the "big" header).

input_value et al handle both header formats on 64-bit hosts, and fail cleanly on the big header format on 32-bit hosts.

This PR is a straightforward implementation of this approach.  There is some code refactoring so that the generation and parsing of headers is not duplicated.    In parallel, there are a few independent improvements to the marshaling code:
- replace ugly macros with inline functions (now that we are allowed to use them);
- use memcpy() instead of memmove() when we know the source and destination blocks are disjoint.

I have a simple test that is not included in the PR, however, because it needs about 64 Gb of RAM (yes, you need that much space to exercise the new "big" format) and takes 10+ minutes to run (yes, you need that much time to generate, process and check that much data).  So, this test is not appropriate for inclusion in the test suite.

The most questionable thing about this PR is its practical utility...  As the figures above suggest, one needs a big machine, big data, and big computations to hit the size limitations of the current, "small" header format.  At best, this work is future-proofing.
