### PR TITLE
Fix 0006945: strings containing 0 are truncated

### DIFF
--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -225,6 +225,7 @@ CAMLextern value caml_hash_variant(char const * tag);
 #define String_tag 252
 #define String_val(x) ((char *) Bp_val(x))
 CAMLextern mlsize_t caml_string_length (value);   /* size in bytes */
+CAMLextern int caml_string_is_c_safe (value); /* non-zero iff string contains no 0 */
 
 /* Floating-point numbers. */
 #define Double_tag 253

--- a/byterun/str.c
+++ b/byterun/str.c
@@ -31,6 +31,22 @@ CAMLexport mlsize_t caml_string_length(value s)
   return temp - Byte (s, temp);
 }
 
+CAMLexport int caml_string_is_c_safe (value s)
+{
+  mlsize_t len;
+  char *p;
+  int i;
+
+  len = caml_string_length(s);
+  p = String_val(s);
+
+  for (i=0; i<len; ++i) {
+    if (p[i] == '\0')
+      return 0;
+  }
+  return 1;
+}
+
 /* returns a value that represents a number of bytes (chars) */
 CAMLprim value caml_ml_string_length(value s)
 {

--- a/byterun/str.c
+++ b/byterun/str.c
@@ -34,17 +34,12 @@ CAMLexport mlsize_t caml_string_length(value s)
 CAMLexport int caml_string_is_c_safe (value s)
 {
   mlsize_t len;
-  char *p;
-  int i;
+  size_t len2;
 
   len = caml_string_length(s);
-  p = String_val(s);
+  len2 = strlen(String_val(s));
 
-  for (i=0; i<len; ++i) {
-    if (p[i] == '\0')
-      return 0;
-  }
-  return 1;
+  return (len == len2);
 }
 
 /* returns a value that represents a number of bytes (chars) */

--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -92,6 +92,15 @@ CAMLexport void caml_sys_io_error(value arg)
   }
 }
 
+/* check that the string is a proper path */
+static inline void caml_sys_check_path(value name)
+{
+  if (! caml_string_is_c_safe(name)) {
+    errno = ENOENT;
+    caml_sys_error(name);
+  }
+}
+
 CAMLprim value caml_sys_exit(value retcode)
 {
   if ((caml_verb_gc & 0x400) != 0) {
@@ -137,6 +146,7 @@ CAMLprim value caml_sys_open(value path, value vflags, value vperm)
   int fd, flags, perm;
   char * p;
 
+  caml_sys_check_path(path);
   p = caml_strdup(String_val(path));
   flags = caml_convert_flag_list(vflags, sys_open_flags);
   perm = Int_val(vperm);
@@ -172,11 +182,7 @@ CAMLprim value caml_sys_file_exists(value name)
   char * p;
   int ret;
 
-  if (! caml_string_is_c_safe(name)) {
-    errno = ENOENT;
-    caml_sys_error(name);
-  }
-
+  caml_sys_check_path(name);
   p = caml_strdup(String_val(name));
   caml_enter_blocking_section();
 #ifdef _WIN32
@@ -201,6 +207,7 @@ CAMLprim value caml_sys_is_directory(value name)
   char * p;
   int ret;
 
+  caml_sys_check_path(name);
   p = caml_strdup(String_val(name));
   caml_enter_blocking_section();
 #ifdef _WIN32
@@ -224,6 +231,7 @@ CAMLprim value caml_sys_remove(value name)
   CAMLparam1(name);
   char * p;
   int ret;
+  caml_sys_check_path(name);
   p = caml_strdup(String_val(name));
   caml_enter_blocking_section();
   ret = unlink(p);
@@ -255,6 +263,7 @@ CAMLprim value caml_sys_chdir(value dirname)
   CAMLparam1(dirname);
   char * p;
   int ret;
+  caml_sys_check_path(dirname);
   p = caml_strdup(String_val(dirname));
   caml_enter_blocking_section();
   ret = chdir(p);
@@ -278,6 +287,8 @@ CAMLprim value caml_sys_getcwd(value unit)
 CAMLprim value caml_sys_getenv(value var)
 {
   char * res;
+
+  // FIXME is there a need to check for null bytes here?
 
   res = getenv(String_val(var));
   if (res == 0) caml_raise_not_found();
@@ -475,6 +486,7 @@ CAMLprim value caml_sys_read_directory(value path)
   char * p;
   int ret;
 
+  caml_sys_check_path(path);
   caml_ext_table_init(&tbl, 50);
   p = caml_strdup(String_val(path));
   caml_enter_blocking_section();

--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -172,6 +172,11 @@ CAMLprim value caml_sys_file_exists(value name)
   char * p;
   int ret;
 
+  if (! caml_string_is_c_safe(name)) {
+    errno = ENOENT;
+    caml_sys_error(name);
+  }
+
   p = caml_strdup(String_val(name));
   caml_enter_blocking_section();
 #ifdef _WIN32

--- a/otherlibs/unix/stat.c
+++ b/otherlibs/unix/stat.c
@@ -97,6 +97,8 @@ CAMLprim value unix_lstat(value path)
   int ret;
   struct stat buf;
   char * p;
+  if (! caml_string_is_c_safe(path))
+    unix_error(ENOENT, "lstat", path);
   p = caml_strdup(String_val(path));
   caml_enter_blocking_section();
 #ifdef HAS_SYMLINK
@@ -131,6 +133,8 @@ CAMLprim value unix_stat_64(value path)
   int ret;
   struct stat buf;
   char * p;
+  if (! caml_string_is_c_safe(path))
+    unix_error(ENOENT, "unix_stat_64", path);
   p = caml_strdup(String_val(path));
   caml_enter_blocking_section();
   ret = stat(p, &buf);
@@ -146,6 +150,8 @@ CAMLprim value unix_lstat_64(value path)
   int ret;
   struct stat buf;
   char * p;
+  if (! caml_string_is_c_safe(path))
+    unix_error(ENOENT, "unix_lstat_64", path);
   p = caml_strdup(String_val(path));
   caml_enter_blocking_section();
 #ifdef HAS_SYMLINK

--- a/otherlibs/unix/stat.c
+++ b/otherlibs/unix/stat.c
@@ -77,6 +77,9 @@ CAMLprim value unix_stat(value path)
   int ret;
   struct stat buf;
   char * p;
+
+  if (! caml_string_is_c_safe(path))
+    unix_error(ENOENT, "stat", path);
   p = caml_strdup(String_val(path));
   caml_enter_blocking_section();
   ret = stat(p, &buf);


### PR DESCRIPTION
I added checks in many primitive operations to fix http://caml.inria.fr/mantis/view.php?id=6945
I don't know the performance overhead, but it does fix the test case. Maybe the check can be made faster.

On the other hand, it looks to me like many calls to `strdup` are unecessary, since the strings are given to system calls as `const char*` and free()'d just after.
