### PR TITLE
Array functions

### DIFF
--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -87,6 +87,19 @@ let map f a =
     r
   end
 
+let map2 f a b =
+  let la = length a in
+  let lb = length b in
+  if la <> lb then raise (Invalid_argument "arrays must have the same length") else begin
+    if la = 0 then [||] else begin
+      let r = create la (f (unsafe_get a 0) (unsafe_get b 0)) in
+      for i = 1 to la - 1 do
+        unsafe_set r i (f (unsafe_get a i) (unsafe_get b i))
+      done;
+      r
+    end
+  end
+
 let iteri f a =
   for i = 0 to length a - 1 do f i (unsafe_get a i) done
 

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -78,7 +78,7 @@ let iter f a =
   for i = 0 to length a - 1 do f(unsafe_get a i) done
 
 let iter2 f a b =
-  if length a <> length b then raise (Invalid_argument "arrays must have the same length")
+  if length a <> length b then invalid_arg "Array.iter2: arrays must have the same length"
   else
     for i = 0 to length a - 1 do f (unsafe_get a i) (unsafe_get b i) done
 
@@ -95,7 +95,7 @@ let map f a =
 let map2 f a b =
   let la = length a in
   let lb = length b in
-  if la <> lb then raise (Invalid_argument "arrays must have the same length") else begin
+  if la <> lb then invalid_arg "Array.map2: arrays must have the same length" else begin
     if la = 0 then [||] else begin
       let r = create la (f (unsafe_get a 0) (unsafe_get b 0)) in
       for i = 1 to la - 1 do

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -77,7 +77,7 @@ let blit a1 ofs1 a2 ofs2 len =
 let iter f a =
   for i = 0 to length a - 1 do f(unsafe_get a i) done
 
-let iter f a b =
+let iter2 f a b =
   if length a <> length b then raise (Invalid_argument "arrays must have the same length")
   else
     for i = 0 to length a - 1 do f (unsafe_get a i) (unsafe_get b i) done

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -77,6 +77,11 @@ let blit a1 ofs1 a2 ofs2 len =
 let iter f a =
   for i = 0 to length a - 1 do f(unsafe_get a i) done
 
+let iter f a b =
+  if length a <> length b then raise (Invalid_argument "arrays must have the same length")
+  else
+    for i = 0 to length a - 1 do f (unsafe_get a i) (unsafe_get b i) done
+
 let map f a =
   let l = length a in
   if l = 0 then [||] else begin

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -132,6 +132,12 @@ val map : ('a -> 'b) -> 'a array -> 'b array
    and builds an array with the results returned by [f]:
    [[| f a.(0); f a.(1); ...; f a.(Array.length a - 1) |]]. *)
 
+val map2 : ('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
+(** [Array.map f a b] applies function [f] to all the elements of [a]
+   and [b], and builds an array with the results returned by [f]:
+   [[| f a.(0) b.(0); f a.(1) b.(1); ...; f a.(Array.length a - 1) b.(Array.length b - 1)|]].
+   Raise [Invalid_argument] if the arrays are not the same size. *)
+
 val iteri : (int -> 'a -> unit) -> 'a array -> unit
 (** Same as {!Array.iter}, but the
    function is applied to the index of the element as first argument,

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -127,13 +127,18 @@ val iter : ('a -> unit) -> 'a array -> unit
    the elements of [a].  It is equivalent to
    [f a.(0); f a.(1); ...; f a.(Array.length a - 1); ()]. *)
 
+val iter2 : ('a -> 'b -> 'c) -> 'a array -> 'b array -> unit
+(** [Array.iter2 f a b] applies function [f] to all the elements of [a]
+   and [b].
+   Raise [Invalid_argument] if the arrays are not the same size. *)
+
 val map : ('a -> 'b) -> 'a array -> 'b array
 (** [Array.map f a] applies function [f] to all the elements of [a],
    and builds an array with the results returned by [f]:
    [[| f a.(0); f a.(1); ...; f a.(Array.length a - 1) |]]. *)
 
 val map2 : ('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
-(** [Array.map f a b] applies function [f] to all the elements of [a]
+(** [Array.map2 f a b] applies function [f] to all the elements of [a]
    and [b], and builds an array with the results returned by [f]:
    [[| f a.(0) b.(0); f a.(1) b.(1); ...; f a.(Array.length a - 1) b.(Array.length b - 1)|]].
    Raise [Invalid_argument] if the arrays are not the same size. *)

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -127,7 +127,7 @@ val iter : ('a -> unit) -> 'a array -> unit
    the elements of [a].  It is equivalent to
    [f a.(0); f a.(1); ...; f a.(Array.length a - 1); ()]. *)
 
-val iter2 : ('a -> 'b -> 'c) -> 'a array -> 'b array -> unit
+val iter2 : ('a -> 'b -> unit) -> 'a array -> 'b array -> unit
 (** [Array.iter2 f a b] applies function [f] to all the elements of [a]
    and [b].
    Raise [Invalid_argument] if the arrays are not the same size. *)

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -122,31 +122,31 @@ val of_list : 'a list -> 'a array
 (** [Array.of_list l] returns a fresh array containing the elements
    of [l]. *)
 
+external create_float: int -> float array = "caml_make_float_vect"
+(** [Array.create_float n] returns a fresh float array of length [n],
+    with uninitialized data.
+    @since 4.03 *)
+
+val make_float: int -> float array
+  [@@ocaml.deprecated "Use Array.create_float instead."]
+(** @deprecated [Array.make_float] is an alias for {!Array.create_float}. *)
+
+(** {6 Iterators} *)
+
 val iter : ('a -> unit) -> 'a array -> unit
 (** [Array.iter f a] applies function [f] in turn to all
    the elements of [a].  It is equivalent to
    [f a.(0); f a.(1); ...; f a.(Array.length a - 1); ()]. *)
 
-val iter2 : ('a -> 'b -> unit) -> 'a array -> 'b array -> unit
-(** [Array.iter2 f a b] applies function [f] to all the elements of [a]
-   and [b].
-   Raise [Invalid_argument] if the arrays are not the same size. *)
+val iteri : (int -> 'a -> unit) -> 'a array -> unit
+(** Same as {!Array.iter}, but the
+   function is applied to the index of the element as first argument,
+   and the element itself as second argument. *)
 
 val map : ('a -> 'b) -> 'a array -> 'b array
 (** [Array.map f a] applies function [f] to all the elements of [a],
    and builds an array with the results returned by [f]:
    [[| f a.(0); f a.(1); ...; f a.(Array.length a - 1) |]]. *)
-
-val map2 : ('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
-(** [Array.map2 f a b] applies function [f] to all the elements of [a]
-   and [b], and builds an array with the results returned by [f]:
-   [[| f a.(0) b.(0); f a.(1) b.(1); ...; f a.(Array.length a - 1) b.(Array.length b - 1)|]].
-   Raise [Invalid_argument] if the arrays are not the same size. *)
-
-val iteri : (int -> 'a -> unit) -> 'a array -> unit
-(** Same as {!Array.iter}, but the
-   function is applied to the index of the element as first argument,
-   and the element itself as second argument. *)
 
 val mapi : (int -> 'a -> 'b) -> 'a array -> 'b array
 (** Same as {!Array.map}, but the
@@ -163,14 +163,18 @@ val fold_right : ('b -> 'a -> 'a) -> 'b array -> 'a -> 'a
    [f a.(0) (f a.(1) ( ... (f a.(n-1) x) ...))],
    where [n] is the length of the array [a]. *)
 
-external create_float: int -> float array = "caml_make_float_vect"
-(** [Array.create_float n] returns a fresh float array of length [n],
-    with uninitialized data.
-    @since 4.03 *)
+(** {6 Iterators on two arrays} *)
 
-val make_float: int -> float array
-  [@@ocaml.deprecated "Use Array.create_float instead."]
-(** @deprecated [Array.make_float] is an alias for {!Array.create_float}. *)
+val iter2 : ('a -> 'b -> unit) -> 'a array -> 'b array -> unit
+(** [Array.iter2 f a b] applies function [f] to all the elements of [a]
+   and [b].
+   Raise [Invalid_argument] if the arrays are not the same size. *)
+
+val map2 : ('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
+(** [Array.map2 f a b] applies function [f] to all the elements of [a]
+   and [b], and builds an array with the results returned by [f]:
+   [[| f a.(0) b.(0); f a.(1) b.(1); ...; f a.(Array.length a - 1) b.(Array.length b - 1)|]].
+   Raise [Invalid_argument] if the arrays are not the same size. *)
 
 (** {6 Sorting} *)
 

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -140,7 +140,7 @@ val iter : ('a -> unit) -> 'a array -> unit
 
 val iteri : (int -> 'a -> unit) -> 'a array -> unit
 (** Same as {!Array.iter}, but the
-   function is applied to the index of the element as first argument,
+   function is applied with the index of the element as first argument,
    and the element itself as second argument. *)
 
 val map : ('a -> 'b) -> 'a array -> 'b array


### PR DESCRIPTION
This PR adds functions `Array.map2` and `Array.iter2` to the standard library. The new functions mirror their counterparts in the `List` module of the standard library.
