### PR TITLE
Shadow warnings: 44 refined into 52,53 for alphanumeric identifiers and symbolic operators

### DIFF
--- a/man/ocamlc.m
+++ b/man/ocamlc.m
@@ -900,7 +900,7 @@ mentioned here corresponds to the empty set.
 
 .IP
 The default setting is
-.BR \-w\ +a\-4\-6\-7\-9\-27\-29\-32..39\-41\-42\-44\-45\-48\-50 .
+.BR \-w\ +a\-4\-6\-7\-9\-27\-29\-32..39\-41\-42\-44\-45\-48\-50\-52\-53 .
 Note that warnings
 .BR 5 \ and \ 10
 are not always triggered, depending on the internals of the type checker.

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -25,6 +25,7 @@ open Parsetree
 let fixity_of_string s = match Misc.fixity s with
     | `Infix -> `Infix s
     | `Prefix -> `Prefix s
+    | `Indexing -> `Infix s
     | `Normal -> `Normal
 
 let view_fixity_of_exp = function
@@ -34,7 +35,7 @@ let view_fixity_of_exp = function
 (* which identifiers are in fact operators needing parentheses *)
 let needs_parens txt =
   match Misc.fixity txt with
-    | `Infix | `Prefix -> true
+    | `Infix | `Prefix | `Indexing -> true
     | `Normal -> false
 
 (* some infixes need spaces around parens to avoid clashes with comment

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -22,39 +22,20 @@ open Location
 open Longident
 open Parsetree
 
-let prefix_symbols  = [ '!'; '?'; '~' ] ;;
-let infix_symbols = [ '='; '<'; '>'; '@'; '^'; '|'; '&'; '+'; '-'; '*'; '/';
-                      '$'; '%' ]
-let operator_chars = [ '!'; '$'; '%'; '&'; '*'; '+'; '-'; '.'; '/';
-                       ':'; '<'; '='; '>'; '?'; '@'; '^'; '|'; '~' ]
-let numeric_chars  = [ '0'; '1'; '2'; '3'; '4'; '5'; '6'; '7'; '8'; '9' ]
-
-(* type fixity = Infix| Prefix  *)
-
-let special_infix_strings =
-  ["asr"; "land"; "lor"; "lsl"; "lsr"; "lxor"; "mod"; "or"; ":="; "!=" ]
-
-(* determines if the string is an infix string.
-   checks backwards, first allowing a renaming postfix ("_102") which
-   may have resulted from Pexp -> Texp -> Pexp translation, then checking
-   if all the characters in the beginning of the string are valid infix
-   characters. *)
-let fixity_of_string  = function
-  | s when List.mem s special_infix_strings -> `Infix s
-  | s when List.mem s.[0] infix_symbols -> `Infix s
-  | s when List.mem s.[0] prefix_symbols -> `Prefix s
-  | _ -> `Normal
+let fixity_of_string s = match Misc.fixity s with
+    | `Infix -> `Infix s
+    | `Prefix -> `Prefix s
+    | `Normal -> `Normal
 
 let view_fixity_of_exp = function
   | {pexp_desc = Pexp_ident {txt=Lident l;_};_} -> fixity_of_string l
   | _ -> `Normal  ;;
 
-let is_infix  = function  | `Infix _ -> true | _  -> false
-
 (* which identifiers are in fact operators needing parentheses *)
 let needs_parens txt =
-  is_infix (fixity_of_string txt)
-  || List.mem txt.[0] prefix_symbols
+  match Misc.fixity txt with
+    | `Infix | `Prefix -> true
+    | `Normal -> false
 
 (* some infixes need spaces around parens to avoid clashes with comment
    syntax *)

--- a/testsuite/tests/warnings/w44.ml
+++ b/testsuite/tests/warnings/w44.ml
@@ -1,0 +1,133 @@
+let ignore _ = ()
+
+module Pervasives = struct
+  (* the evil shadower *)
+  let compare x y = (x, y)
+  let (<=) x y = (x, y)
+  let (mod) x y = (x, y)
+  let (.()) x y = (x, y)
+  let x = ()
+end
+
+[@@@ocaml.warning "+A"]
+
+(* this should not warn: shadowed identifier is not used *)
+let _ = fun compare ->
+  ignore compare;
+  let open Pervasives in
+  x
+
+let _ = fun (<=) ->
+  ignore (<=);
+  let open Pervasives in
+  x
+
+let _ = fun (mod) ->
+  ignore (mod);
+  let open Pervasives in
+  x
+
+let _ = fun (.()) ->
+  ignore (.());
+  let open Pervasives in
+  x
+
+(* this should raise 44 (the old warning) *)
+let _ = fun compare ->
+  ignore compare;
+  let open Pervasives in
+  compare
+
+(* this should raise 44 (the old warning) *)
+let _ = fun (<=) ->
+  ignore (<=);
+  let open Pervasives in
+  (<=)
+
+let _ = fun (mod) ->
+  ignore (mod);
+  let open Pervasives in
+  (mod)
+
+let _ = fun (mod) a b ->
+  ignore (mod);
+  let open Pervasives in
+  a mod b
+
+let _ = fun (.()) ->
+  ignore (.());
+  let open Pervasives in
+  (.())
+
+let _ = fun (.()) a b ->
+  ignore (.());
+  let open Pervasives in
+  a.(b)
+
+[@@@ocaml.warning "+A-44"]
+
+(* this should raise 52 (the new warning) *)
+let _ = fun compare ->
+  ignore compare;
+  let open Pervasives in
+  compare
+
+(* this should raise 53 (the new warning) *)
+let _ = fun (<=) ->
+  ignore (<=);
+  let open Pervasives in
+  (<=)
+
+let _ = fun (mod) ->
+  ignore (mod);
+  let open Pervasives in
+  (mod)
+
+let _ = fun (mod) a b ->
+  ignore (mod);
+  let open Pervasives in
+  a mod b
+
+let _ = fun (.()) ->
+  ignore (.());
+  let open Pervasives in
+  (.())
+
+let _ = fun (.()) a b ->
+  ignore (.());
+  let open Pervasives in
+  a.(b)
+
+[@@@ocaml.warning "-A"]
+
+(* this shouldn't raise anything *)
+
+let _ = fun compare ->
+  ignore compare;
+  let open Pervasives in
+  compare
+
+let _ = fun (<=) ->
+  ignore (<=);
+  let open Pervasives in
+  (<=)
+
+let _ = fun (mod) ->
+  ignore (mod);
+  let open Pervasives in
+  (mod)
+
+let _ = fun (mod) a b ->
+  ignore (mod);
+  let open Pervasives in
+  a mod b
+
+let _ = fun (.()) ->
+  ignore (.());
+  let open Pervasives in
+  (.())
+
+let _ = fun (.()) a b ->
+  ignore (.());
+  let open Pervasives in
+  a.(b)

--- a/testsuite/tests/warnings/w44.reference
+++ b/testsuite/tests/warnings/w44.reference
@@ -1,0 +1,24 @@
+File "w44.ml", line 38, characters 2-34:
+Warning 44: this open statement shadows the value identifier compare (which is later used)
+File "w44.ml", line 44, characters 2-31:
+Warning 44: this open statement shadows the value identifier <= (which is later used)
+File "w44.ml", line 49, characters 2-32:
+Warning 44: this open statement shadows the value identifier mod (which is later used)
+File "w44.ml", line 54, characters 2-34:
+Warning 44: this open statement shadows the value identifier mod (which is later used)
+File "w44.ml", line 59, characters 2-32:
+Warning 44: this open statement shadows the value identifier .() (which is later used)
+File "w44.ml", line 64, characters 2-32:
+Warning 44: this open statement shadows the value identifier .() (which is later used)
+File "w44.ml", line 72, characters 2-34:
+Warning 52: this open statement shadows the value identifier compare (which is later used)
+File "w44.ml", line 78, characters 2-31:
+Warning 53: this open statement shadows the operator ( <= ) (which is later used)
+File "w44.ml", line 83, characters 2-32:
+Warning 53: this open statement shadows the operator ( mod ) (which is later used)
+File "w44.ml", line 88, characters 2-34:
+Warning 53: this open statement shadows the operator ( mod ) (which is later used)
+File "w44.ml", line 93, characters 2-32:
+Warning 53: this open statement shadows the operator ( .() ) (which is later used)
+File "w44.ml", line 98, characters 2-32:
+Warning 53: this open statement shadows the operator ( .() ) (which is later used)

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -511,3 +511,16 @@ module Color = struct
       );
       ()
 end
+
+let prefix_symbols  = [ '!'; '?'; '~' ] ;;
+let infix_symbols = [ '='; '<'; '>'; '@'; '^'; '|'; '&'; '+'; '-'; '*'; '/';
+                      '$'; '%' ]
+let special_infix_strings =
+  ["asr"; "land"; "lor"; "lsl"; "lsr"; "lxor"; "mod"; "or"; ":="; "!=" ]
+
+let fixity = function
+  | "" -> `Normal
+  | s when List.mem s special_infix_strings -> `Infix
+  | s when List.mem s.[0] infix_symbols -> `Infix
+  | s when List.mem s.[0] prefix_symbols -> `Prefix
+  | _ -> `Normal

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -521,6 +521,7 @@ let special_infix_strings =
 let fixity = function
   | "" -> `Normal
   | s when List.mem s special_infix_strings -> `Infix
+  | s when s.[0] = '.' -> `Indexing
   | s when List.mem s.[0] infix_symbols -> `Infix
   | s when List.mem s.[0] prefix_symbols -> `Prefix
   | _ -> `Normal

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -234,3 +234,9 @@ module Color : sig
   val set_color_tag_handling : Format.formatter -> unit
   (* adds functions to support color tags to the given formatter. *)
 end
+
+(* fixity of an identifier, according to the OCaml lexical conventions.
+
+   "asr", "land", "mod" etc. are `Infix
+ *)
+val fixity : string -> [ `Prefix | `Infix | `Normal ]

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -239,4 +239,4 @@ end
 
    "asr", "land", "mod" etc. are `Infix
  *)
-val fixity : string -> [ `Prefix | `Infix | `Normal ]
+val fixity : string -> [ `Prefix | `Infix | `Normal | `Indexing ]

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -56,7 +56,7 @@ type t =
   | Ambiguous_name of string list * string list * bool (* 41 *)
   | Disambiguated_name of string            (* 42 *)
   | Nonoptional_label of string             (* 43 *)
-  | Open_shadow_identifier of string * string (* 44 *)
+  | Open_shadow_identifier_all of string * string (* 44 *)
   | Open_shadow_label_constructor of string * string (* 45 *)
   | Bad_env_variable of string * string     (* 46 *)
   | Attribute_payload of string * string    (* 47 *)
@@ -64,6 +64,8 @@ type t =
   | No_cmi_file of string                   (* 49 *)
   | Bad_docstring of bool                   (* 50 *)
   | Expect_tailcall                         (* 51 *)
+  | Open_shadow_identifier of string * string (* 52 *)
+  | Open_shadow_operator of string * string (* 53 *)
 ;;
 
 val parse_options : bool -> string -> unit;;


### PR DESCRIPTION
For more details on warnings when open-shadowed identifiers are used, see the discussion and pointers in [PR#6951](http://caml.inria.fr/mantis/view.php?id=6951).

In this proposed PR, warning 44 is preserved exactly as is (the goal is to help forward- and backward-compatibility), and two new warnings are added that refine its behavior: 52 fires on alphanumeric shadowing when 44 is disabled, and 53 fires on symbolic shadowing when 44 is disabled.

A consequence of this compatibility strategy (up for discussion) is that people using `+A-44` will see new warnings appearing (one must now use `+A-44-52-53` for the same effect).

I think we could consider enabling `+52` (shadowing of alphanumeric identifier) by default in 4.03, but this patch does not implement it.

Note that with the proposed implementation, `(asr)`, `(mod)` etc. are considered symbolic operators.
