### PR TITLE
Make CamlinternalMod.init_mod robust to optimization

### DIFF
--- a/stdlib/camlinternalMod.ml
+++ b/stdlib/camlinternalMod.ml
@@ -31,7 +31,7 @@ let rec init_mod loc shape =
          and eight environment entries makes 11 words. *)
       let closure = Obj.new_block Obj.closure_tag 11 in
       let template =
-        Obj.repr(fun _ -> raise (Undefined_recursive_module loc))
+        Obj.repr (fun _ -> raise (Undefined_recursive_module loc))
       in
       overwrite closure template;
       closure

--- a/stdlib/camlinternalMod.ml
+++ b/stdlib/camlinternalMod.ml
@@ -18,15 +18,23 @@ type shape =
   | Module of shape array
   | Value of Obj.t
 
+let overwrite o n =
+  assert (Obj.size o >= Obj.size n);
+  for i = 0 to Obj.size n - 1 do
+    Obj.set_field o i (Obj.field n i)
+  done
+
 let rec init_mod loc shape =
   match shape with
   | Function ->
-      let pad1 = 1 and pad2 = 2 and pad3 = 3 and pad4 = 4
-      and pad5 = 5 and pad6 = 6 and pad7 = 7 and pad8 = 8 in
-      Obj.repr(fun _ ->
-        ignore pad1; ignore pad2; ignore pad3; ignore pad4;
-        ignore pad5; ignore pad6; ignore pad7; ignore pad8;
-        raise (Undefined_recursive_module loc))
+      (* Two code pointer words (curried and full application), arity
+         and eight environment entries makes 11 words. *)
+      let closure = Obj.new_block Obj.closure_tag 11 in
+      let template =
+        Obj.repr(fun _ -> raise (Undefined_recursive_module loc))
+      in
+      overwrite closure template;
+      closure
   | Lazy ->
       Obj.repr (lazy (raise (Undefined_recursive_module loc)))
   | Class ->
@@ -35,12 +43,6 @@ let rec init_mod loc shape =
       Obj.repr (Array.map (init_mod loc) comps)
   | Value v ->
       v
-
-let overwrite o n =
-  assert (Obj.size o >= Obj.size n);
-  for i = 0 to Obj.size n - 1 do
-    Obj.set_field o i (Obj.field n i)
-  done
 
 let rec update_mod shape o n =
   match shape with


### PR DESCRIPTION
The Flambda optimizers have exposed that CamlinternalMod.init_mod is not robust.

Optimization of this function causes the various "pad" variables to be seen as unused; thus, they are omitted from the closure.  The closure then becomes constant and can be assigned to a symbol.  Either or both of these occurrences can make things go horribly wrong.

Even though we're not merging Flambda yet, cleaning this up seems like a good idea.  Pierre and I think the code in this pull request seems correct.  It's been tested on Alt-Ergo which apparently contains a lot of recursive modules.  OK for trunk?
