### PR TITLE
try to print error messages with flexible margin width

### DIFF
--- a/testsuite/tests/formatting/Makefile
+++ b/testsuite/tests/formatting/Makefile
@@ -1,0 +1,5 @@
+BASEDIR=../..
+MAIN_MODULE=margins
+
+include $(BASEDIR)/makefiles/Makefile.toplevel
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/formatting/margins.ml
+++ b/testsuite/tests/formatting/margins.ml
@@ -1,0 +1,7 @@
+let () = Format.pp_set_margin Format.std_formatter 20;;
+
+1 + "foo";;
+
+let () = Format.pp_set_margin Format.std_formatter 80;;
+
+1 + "foo";;

--- a/testsuite/tests/formatting/margins.ml.reference
+++ b/testsuite/tests/formatting/margins.ml.reference
@@ -1,0 +1,14 @@
+
+# #   Characters 5-10:
+  1 + "foo";;
+      ^^^^^
+Error: This expression has type
+         string
+       but an expression was expected of type
+         int
+#   #   Characters 5-10:
+  1 + "foo";;
+      ^^^^^
+Error: This expression has type string but an expression was expected of type
+         int
+# 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -485,7 +485,10 @@ module Color = struct
       mark_close_tag=(mark_close_tag ~or_else:functions.mark_close_tag);
     } in
     pp_set_mark_tags ppf true; (* enable tags *)
-    pp_set_formatter_tag_functions ppf functions'
+    pp_set_formatter_tag_functions ppf functions';
+    (* also setup margins *)
+    pp_set_margin ppf (pp_get_margin std_formatter());
+    ()
 
   external isatty : out_channel -> bool = "caml_sys_isatty"
 


### PR DESCRIPTION
Apparently, if the margins of `Format.std_formatter` are changed, the new margins are not used for the error/warning messages. This is a first attempt at fixing this, though I didn't write tests because I don't even know how to modify the margins in the first place would look like.

refers to #207 
