### PR TITLE
Simpler heuristic to determine reraises

### DIFF
--- a/asmrun/backtrace_prim.c
+++ b/asmrun/backtrace_prim.c
@@ -87,10 +87,7 @@ frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp)
    [caml_get_current_callstack] was implemented. */
 void caml_stash_backtrace(value exn, uintnat pc, char * sp, char * trapsp)
 {
-  if (exn != caml_backtrace_last_exn) {
-    caml_backtrace_pos = 0;
-    caml_backtrace_last_exn = exn;
-  }
+  caml_backtrace_last_exn = exn;
   if (caml_backtrace_buffer == NULL) {
     Assert(caml_backtrace_pos == 0);
     caml_backtrace_buffer = malloc(BACKTRACE_BUFFER_SIZE

--- a/byterun/backtrace_prim.c
+++ b/byterun/backtrace_prim.c
@@ -219,7 +219,7 @@ CAMLprim value caml_remove_debug_info(code_t start)
 void caml_stash_backtrace(value exn, code_t pc, value * sp, int reraise)
 {
   if (pc != NULL) pc = pc - 1;
-  if (exn != caml_backtrace_last_exn || !reraise) {
+  if (!reraise) {
     caml_backtrace_pos = 0;
     caml_backtrace_last_exn = exn;
   }


### PR DESCRIPTION
This patch simplify the heuristic to determine when a raise is a reraise.

A raise starts a fresh backtrace whereas a reraise appends to the existing backtrace. But when coding, one almost only uses the 'raise' primitive. Letting the compiler determine when a raise is a reraise significantly improve quality of backtraces.

The basic idea is to consider that a raise statically occuring inside the handler of a try statement is a re-raise. However the current heuristic feels a bit too conservative: it tries to determine that the reraised exception is the same as the original one by tracking its name.

The patch just considers that any exception raised inside the handler is a reraise.
While being simpler, it fits better the pattern of wrapping an exception with more information before reraising it.

This work will be followed by one extending the backtrace API to observe the multiple raised exceptions.
