### PR TITLE
Make backtraces aware of inlining

### DIFF
--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -508,17 +508,24 @@ let find_action idxs acts tag =
     (* Can this happen? *)
     None
 
+let subst_debuginfo loc dbg =
+  if !Clflags.debug then
+    Debuginfo.inline loc dbg
+  else
+    dbg
 
-let rec substitute fpc sb ulam =
+let rec substitute loc fpc sb ulam =
   match ulam with
     Uvar v ->
       begin try Tbl.find v sb with Not_found -> ulam end
   | Uconst _ -> ulam
   | Udirect_apply(lbl, args, dbg) ->
-      Udirect_apply(lbl, List.map (substitute fpc sb) args, dbg)
+      let dbg = subst_debuginfo loc dbg in
+      Udirect_apply(lbl, List.map (substitute loc fpc sb) args, dbg)
   | Ugeneric_apply(fn, args, dbg) ->
-      Ugeneric_apply(substitute fpc sb fn,
-                     List.map (substitute fpc sb) args, dbg)
+      let dbg = subst_debuginfo loc dbg in
+      Ugeneric_apply(substitute loc fpc sb fn,
+                     List.map (substitute loc fpc sb) args, dbg)
   | Uclosure(defs, env) ->
       (* Question: should we rename function labels as well?  Otherwise,
          there is a risk that function labels are not globally unique.
@@ -528,12 +535,12 @@ let rec substitute fpc sb ulam =
          - When we substitute offsets for idents bound by let rec
            in [close], case [Lletrec], we discard the original
            let rec body and use only the substituted term. *)
-      Uclosure(defs, List.map (substitute fpc sb) env)
-  | Uoffset(u, ofs) -> Uoffset(substitute fpc sb u, ofs)
+      Uclosure(defs, List.map (substitute loc fpc sb) env)
+  | Uoffset(u, ofs) -> Uoffset(substitute loc fpc sb u, ofs)
   | Ulet(str, kind, id, u1, u2) ->
       let id' = Ident.rename id in
-      Ulet(str, kind, id', substitute fpc sb u1,
-           substitute fpc (Tbl.add id (Uvar id') sb) u2)
+      Ulet(str, kind, id', substitute loc fpc sb u1,
+           substitute loc fpc (Tbl.add id (Uvar id') sb) u2)
   | Uletrec(bindings, body) ->
       let bindings1 =
         List.map (fun (id, rhs) -> (id, Ident.rename id, rhs)) bindings in
@@ -543,17 +550,17 @@ let rec substitute fpc sb ulam =
           bindings1 sb in
       Uletrec(
         List.map
-           (fun (_id, id', rhs) -> (id', substitute fpc sb' rhs))
+           (fun (_id, id', rhs) -> (id', substitute loc fpc sb' rhs))
            bindings1,
-        substitute fpc sb' body)
+        substitute loc fpc sb' body)
   | Uprim(p, args, dbg) ->
-      let sargs =
-        List.map (substitute fpc sb) args in
+      let sargs = List.map (substitute loc fpc sb) args in
+      let dbg = subst_debuginfo loc dbg in
       let (res, _) =
         simplif_prim fpc p (sargs, List.map approx_ulam sargs) dbg in
       res
   | Uswitch(arg, sw) ->
-      let sarg = substitute fpc sb arg in
+      let sarg = substitute loc fpc sb arg in
       let action =
         (* Unfortunately, we cannot easily deal with the
            case of a constructed block (makeblock) bound to a local
@@ -569,23 +576,23 @@ let rec substitute fpc sb ulam =
         | _ -> None
       in
       begin match action with
-      | Some u -> substitute fpc sb u
+      | Some u -> substitute loc fpc sb u
       | None ->
           Uswitch(sarg,
                   { sw with
                     us_actions_consts =
-                      Array.map (substitute fpc sb) sw.us_actions_consts;
+                      Array.map (substitute loc fpc sb) sw.us_actions_consts;
                     us_actions_blocks =
-                      Array.map (substitute fpc sb) sw.us_actions_blocks;
+                      Array.map (substitute loc fpc sb) sw.us_actions_blocks;
                   })
       end
   | Ustringswitch(arg,sw,d) ->
       Ustringswitch
-        (substitute fpc sb arg,
-         List.map (fun (s,act) -> s,substitute fpc sb act) sw,
-         Misc.may_map (substitute fpc sb) d)
+        (substitute loc fpc sb arg,
+         List.map (fun (s,act) -> s,substitute loc fpc sb act) sw,
+         Misc.may_map (substitute loc fpc sb) d)
   | Ustaticfail (nfail, args) ->
-      Ustaticfail (nfail, List.map (substitute fpc sb) args)
+      Ustaticfail (nfail, List.map (substitute loc fpc sb) args)
   | Ucatch(nfail, ids, u1, u2) ->
       let ids' = List.map Ident.rename ids in
       let sb' =
@@ -593,38 +600,39 @@ let rec substitute fpc sb ulam =
           (fun id id' s -> Tbl.add id (Uvar id') s)
           ids ids' sb
       in
-      Ucatch(nfail, ids', substitute fpc sb u1, substitute fpc sb' u2)
+      Ucatch(nfail, ids', substitute loc fpc sb u1, substitute loc fpc sb' u2)
   | Utrywith(u1, id, u2) ->
       let id' = Ident.rename id in
-      Utrywith(substitute fpc sb u1, id',
-               substitute fpc (Tbl.add id (Uvar id') sb) u2)
+      Utrywith(substitute loc fpc sb u1, id',
+               substitute loc fpc (Tbl.add id (Uvar id') sb) u2)
   | Uifthenelse(u1, u2, u3) ->
-      begin match substitute fpc sb u1 with
+      begin match substitute loc fpc sb u1 with
         Uconst (Uconst_ptr n) ->
-          if n <> 0 then substitute fpc sb u2 else substitute fpc sb u3
+          if n <> 0 then substitute loc fpc sb u2 else substitute loc fpc sb u3
       | Uprim(Pmakeblock _, _, _) ->
-          substitute fpc sb u2
+          substitute loc fpc sb u2
       | su1 ->
-          Uifthenelse(su1, substitute fpc sb u2, substitute fpc sb u3)
+          Uifthenelse(su1, substitute loc fpc sb u2, substitute loc fpc sb u3)
       end
   | Usequence(u1, u2) ->
-      Usequence(substitute fpc sb u1, substitute fpc sb u2)
+      Usequence(substitute loc fpc sb u1, substitute loc fpc sb u2)
   | Uwhile(u1, u2) ->
-      Uwhile(substitute fpc sb u1, substitute fpc sb u2)
+      Uwhile(substitute loc fpc sb u1, substitute loc fpc sb u2)
   | Ufor(id, u1, u2, dir, u3) ->
       let id' = Ident.rename id in
-      Ufor(id', substitute fpc sb u1, substitute fpc sb u2, dir,
-           substitute fpc (Tbl.add id (Uvar id') sb) u3)
+      Ufor(id', substitute loc fpc sb u1, substitute loc fpc sb u2, dir,
+           substitute loc fpc (Tbl.add id (Uvar id') sb) u3)
   | Uassign(id, u) ->
       let id' =
         try
           match Tbl.find id sb with Uvar i -> i | _ -> assert false
         with Not_found ->
           id in
-      Uassign(id', substitute fpc sb u)
+      Uassign(id', substitute loc fpc sb u)
   | Usend(k, u1, u2, ul, dbg) ->
-      Usend(k, substitute fpc sb u1, substitute fpc sb u2,
-            List.map (substitute fpc sb) ul, dbg)
+      let dbg = subst_debuginfo loc dbg in
+      Usend(k, substitute loc fpc sb u1, substitute loc fpc sb u2,
+            List.map (substitute loc fpc sb) ul, dbg)
   | Uunreachable ->
       Uunreachable
 
@@ -638,12 +646,12 @@ let no_effects = function
   | Uclosure _ -> true
   | u -> is_simple_argument u
 
-let rec bind_params_rec fpc subst params args body =
+let rec bind_params_rec loc fpc subst params args body =
   match (params, args) with
-    ([], []) -> substitute fpc subst body
+    ([], []) -> substitute loc fpc subst body
   | (p1 :: pl, a1 :: al) ->
       if is_simple_argument a1 then
-        bind_params_rec fpc (Tbl.add p1 a1 subst) pl al body
+        bind_params_rec loc fpc (Tbl.add p1 a1 subst) pl al body
       else begin
         let p1' = Ident.rename p1 in
         let u1, u2 =
@@ -654,17 +662,17 @@ let rec bind_params_rec fpc subst params args body =
               a1, Uvar p1'
         in
         let body' =
-          bind_params_rec fpc (Tbl.add p1 u2 subst) pl al body in
+          bind_params_rec loc fpc (Tbl.add p1 u2 subst) pl al body in
         if occurs_var p1 body then Ulet(Immutable, Pgenval, p1', u1, body')
         else if no_effects a1 then body'
         else Usequence(a1, body')
       end
   | (_, _) -> assert false
 
-let bind_params fpc params args body =
+let bind_params loc fpc params args body =
   (* Reverse parameters and arguments to preserve right-to-left
      evaluation order (PR#2910). *)
-  bind_params_rec fpc Tbl.empty (List.rev params) (List.rev args) body
+  bind_params_rec loc fpc Tbl.empty (List.rev params) (List.rev args) body
 
 (* Check if a lambda term is ``pure'',
    that is without side-effects *and* not containing function definitions *)
@@ -695,7 +703,7 @@ let direct_apply fundesc funct ufunct uargs ~loc ~attribute =
           "Function information unavailable";
         Udirect_apply(fundesc.fun_label, app_args, Debuginfo.none)
     | Some(params, body), _  ->
-        bind_params fundesc.fun_float_const_prop params app_args body
+        bind_params loc fundesc.fun_float_const_prop params app_args body
   in
   (* If ufunct can contain side-effects or function definitions,
      we must make sure that it is evaluated exactly once.
@@ -750,23 +758,28 @@ let excessive_function_nesting_depth = 5
 (* Decorate clambda term with debug information *)
 
 let rec add_debug_info ev u =
+  let put_dinfo dinfo ev =
+    if Debuginfo.is_none dinfo then
+      Debuginfo.from_call ev
+    else dinfo
+  in
   match ev.lev_kind with
   | Lev_after _ ->
       begin match u with
-      | Udirect_apply(lbl, args, _dinfo) ->
-          Udirect_apply(lbl, args, Debuginfo.from_call ev)
-      | Ugeneric_apply(Udirect_apply(lbl, args1, _dinfo1),
-                       args2, _dinfo2) ->
-          Ugeneric_apply(Udirect_apply(lbl, args1, Debuginfo.from_call ev),
-                         args2, Debuginfo.from_call ev)
-      | Ugeneric_apply(fn, args, _dinfo) ->
-          Ugeneric_apply(fn, args, Debuginfo.from_call ev)
-      | Uprim(Praise k, args, _dinfo) ->
-          Uprim(Praise k, args, Debuginfo.from_call ev)
-      | Uprim(p, args, _dinfo) ->
-          Uprim(p, args, Debuginfo.from_call ev)
-      | Usend(kind, u1, u2, args, _dinfo) ->
-          Usend(kind, u1, u2, args, Debuginfo.from_call ev)
+      | Udirect_apply(lbl, args, dinfo) ->
+          Udirect_apply(lbl, args, put_dinfo dinfo ev)
+      | Ugeneric_apply(Udirect_apply(lbl, args1, dinfo1),
+                       args2, dinfo2) ->
+          Ugeneric_apply(Udirect_apply(lbl, args1, put_dinfo dinfo1 ev),
+                         args2, put_dinfo dinfo2 ev)
+      | Ugeneric_apply(fn, args, dinfo) ->
+          Ugeneric_apply(fn, args, put_dinfo dinfo ev)
+      | Uprim(Praise k, args, dinfo) ->
+          Uprim(Praise k, args, put_dinfo dinfo ev)
+      | Uprim(p, args, dinfo) ->
+          Uprim(p, args, put_dinfo dinfo ev)
+      | Usend(kind, u1, u2, args, dinfo) ->
+          Usend(kind, u1, u2, args, put_dinfo dinfo ev)
       | Usequence(u1, u2) ->
           Usequence(u1, add_debug_info ev u2)
       | _ -> u
@@ -836,11 +849,13 @@ let rec close fenv cenv = function
         ((ufunct, Value_closure(fundesc, approx_res)),
          [Uprim(Pmakeblock _, uargs, _)])
         when List.length uargs = - fundesc.fun_arity ->
-          let app = direct_apply ~loc ~attribute fundesc funct ufunct uargs in
+          let app =
+            direct_apply ~loc ~attribute fundesc funct ufunct uargs in
           (app, strengthen_approx app approx_res)
       | ((ufunct, Value_closure(fundesc, approx_res)), uargs)
         when nargs = fundesc.fun_arity ->
-          let app = direct_apply ~loc ~attribute fundesc funct ufunct uargs in
+          let app =
+            direct_apply ~loc ~attribute fundesc funct ufunct uargs in
           (app, strengthen_approx app approx_res)
 
       | ((_ufunct, Value_closure(fundesc, _approx_res)), uargs)
@@ -881,8 +896,9 @@ let rec close fenv cenv = function
         when fundesc.fun_arity > 0 && nargs > fundesc.fun_arity ->
           let (first_args, rem_args) = split_list fundesc.fun_arity uargs in
           warning_if_forced_inline ~loc ~attribute "Over-application";
-          (Ugeneric_apply(direct_apply ~loc ~attribute fundesc funct ufunct
-                          first_args, rem_args, Debuginfo.none),
+          (Ugeneric_apply(direct_apply ~loc ~attribute
+                            fundesc funct ufunct first_args,
+                          rem_args, Debuginfo.none),
            Value_unknown)
       | ((ufunct, _), uargs) ->
           warning_if_forced_inline ~loc ~attribute "Unknown function";
@@ -924,8 +940,8 @@ let rec close fenv cenv = function
             (fun (id, pos, _approx) sb ->
               Tbl.add id (Uoffset(Uvar clos_ident, pos)) sb)
             infos Tbl.empty in
-        (Ulet(Immutable, Pgenval,
-              clos_ident, clos, substitute !Clflags.float_const_prop sb ubody),
+        (Ulet(Immutable, Pgenval, clos_ident, clos,
+              substitute Location.none !Clflags.float_const_prop sb ubody),
          approx)
       end else begin
         (* General case: recursive definition of values *)

--- a/asmrun/backtrace_prim.c
+++ b/asmrun/backtrace_prim.c
@@ -27,20 +27,6 @@
 #include "caml/mlvalues.h"
 #include "stack.h"
 
-/* In order to prevent the GC from walking through the debug information
-   (which have no headers), we transform frame_descr pointers into
-   31/63 bits ocaml integers by shifting them by 1 to the right. We do
-   not lose information as descr pointers are aligned.  */
-value caml_val_raw_backtrace_slot(backtrace_slot pc)
-{
-  return Val_long((uintnat)pc>>1);
-}
-
-backtrace_slot caml_raw_backtrace_slot_val(value v)
-{
-  return ((backtrace_slot)(Long_val(v)<<1));
-}
-
 /* Returns the next frame descriptor (or NULL if none is available),
    and updates *pc and *sp to point to the following one.  */
 frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp)
@@ -167,53 +153,73 @@ CAMLprim value caml_get_current_callstack(value max_frames_value)
     for (trace_pos = 0; trace_pos < trace_size; trace_pos++) {
       frame_descr * descr = caml_next_frame_descriptor(&pc, &sp);
       Assert(descr != NULL);
-      Store_field(trace, trace_pos,
-                  caml_val_raw_backtrace_slot((backtrace_slot) descr));
+      Field(trace, trace_pos) = Val_backtrace_slot((backtrace_slot) descr);
     }
   }
 
   CAMLreturn(trace);
 }
 
-/* Extract location information for the given frame descriptor */
-void caml_extract_location_info(backtrace_slot slot,
-                                /*out*/ struct caml_loc_info * li)
+
+debuginfo caml_debuginfo_extract(backtrace_slot slot)
 {
   uintnat infoptr;
-  uint32_t info1, info2;
   frame_descr * d = (frame_descr *)slot;
 
-  /* If no debugging information available, print nothing.
-     When everything is compiled with -g, this corresponds to
-     compiler-inserted re-raise operations. */
   if ((d->frame_size & 1) == 0) {
-    li->loc_valid = 0;
-    li->loc_is_raise = 1;
-    li->loc_is_inlined = 0;
-    return;
+    return NULL;
   }
   /* Recover debugging info */
   infoptr = ((uintnat) d +
              sizeof(char *) + sizeof(short) + sizeof(short) +
              sizeof(short) * d->num_live + sizeof(frame_descr *) - 1)
             & -sizeof(frame_descr *);
-  infoptr = *(uintnat*)infoptr;
-  info1 = ((uint32_t *)infoptr)[0];
-  info2 = ((uint32_t *)infoptr)[1];
+  return *((debuginfo*)infoptr);
+}
+
+debuginfo caml_debuginfo_next(debuginfo dbg)
+{
+  uint32_t * infoptr;
+
+  if (dbg == NULL)
+    return NULL;
+
+  infoptr = dbg;
+  infoptr += 2; /* Two packed info fields */
+  return *((debuginfo*)infoptr);
+}
+
+/* Extract location information for the given frame descriptor */
+void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
+{
+  uint32_t info1, info2;
+
+  /* If no debugging information available, print nothing.
+     When everything is compiled with -g, this corresponds to
+     compiler-inserted re-raise operations. */
+  if (dbg == NULL) {
+    li->loc_valid = 0;
+    li->loc_is_raise = 1;
+    li->loc_is_inlined = 0;
+    return;
+  }
+  /* Recover debugging info */
+  info1 = ((uint32_t *)dbg)[0];
+  info2 = ((uint32_t *)dbg)[1];
   /* Format of the two info words:
        llllllllllllllllllll aaaaaaaa bbbbbbbbbb nnnnnnnnnnnnnnnnnnnnnnnn kk
                           44       36         26                       2  0
                        (32+12)    (32+4)
      k ( 2 bits): 0 if it's a call
                   1 if it's a raise
-     n (24 bits): offset (in 4-byte words) of file name relative to infoptr
+     n (24 bits): offset (in 4-byte words) of file name relative to dbg
      l (20 bits): line number
      a ( 8 bits): beginning of character range
      b (10 bits): end of character range */
   li->loc_valid = 1;
   li->loc_is_raise = (info1 & 3) == 1;
-  li->loc_is_inlined = 0;
-  li->loc_filename = (char *) infoptr + (info1 & 0x3FFFFFC);
+  li->loc_is_inlined = caml_debuginfo_next(dbg) != NULL;
+  li->loc_filename = (char *) dbg + (info1 & 0x3FFFFFC);
   li->loc_lnum = info2 >> 12;
   li->loc_startchr = (info2 >> 4) & 0xFF;
   li->loc_endchr = ((info2 & 0xF) << 6) | (info1 >> 26);

--- a/asmrun/roots.c
+++ b/asmrun/roots.c
@@ -83,7 +83,7 @@ static frame_descr * next_frame_descr(frame_descr * d) {
      sizeof(char *) + sizeof(short) + sizeof(short) +
      sizeof(short) * d->num_live + sizeof(frame_descr *) - 1)
     & -sizeof(frame_descr *);
-  if (d->frame_size & 1) nextd += 8;
+  if (d->frame_size & 1) nextd += sizeof(void *); /* pointer to debuginfo */
   return((frame_descr *) nextd);
 }
 

--- a/bytecomp/debuginfo.mli
+++ b/bytecomp/debuginfo.mli
@@ -37,5 +37,6 @@ val from_raise: Lambda.lambda_event -> t
 
 val to_location: t -> Location.t
 
+val concat: t -> t -> t
 val inline: Location.t -> t -> t
 val unroll_inline_chain : t -> t * t list

--- a/bytecomp/debuginfo.mli
+++ b/bytecomp/debuginfo.mli
@@ -13,9 +13,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type kind = Dinfo_call | Dinfo_raise
+type kind = Dinfo_call | Dinfo_raise | Dinfo_inline of t
 
-type t = private {
+and t = private {
   dinfo_kind: kind;
   dinfo_file: string;
   dinfo_line: int;
@@ -36,3 +36,6 @@ val from_call: Lambda.lambda_event -> t
 val from_raise: Lambda.lambda_event -> t
 
 val to_location: t -> Location.t
+
+val inline: Location.t -> t -> t
+val unroll_inline_chain : t -> t * t list

--- a/byterun/backtrace.c
+++ b/byterun/backtrace.c
@@ -107,6 +107,7 @@ CAMLexport void caml_print_exception_backtrace(void)
 {
   int i;
   struct caml_loc_info li;
+  debuginfo dbg;
 
   if (!caml_debug_info_available()) {
     fprintf(stderr, "(Cannot print stack backtrace: "
@@ -115,9 +116,13 @@ CAMLexport void caml_print_exception_backtrace(void)
   }
 
   for (i = 0; i < caml_backtrace_pos; i++) {
-    caml_debuginfo_location(
-        caml_debuginfo_extract(caml_backtrace_buffer[i]), &li);
-    print_location(&li, i);
+    for (dbg = caml_debuginfo_extract(caml_backtrace_buffer[i]);
+         dbg != NULL;
+         dbg = caml_debuginfo_next(dbg))
+    {
+      caml_debuginfo_location(dbg, &li);
+      print_location(&li, i);
+    }
   }
 }
 

--- a/byterun/backtrace.c
+++ b/byterun/backtrace.c
@@ -253,6 +253,27 @@ CAMLprim value caml_raw_backtrace_slot(value bt, value index)
   return Val_debuginfo(dbg);
 }
 
+CAMLprim value caml_raw_backtrace_next_slot(value slot)
+{
+  debuginfo dbg;
+
+  CAMLparam1(slot);
+  CAMLlocal1(v);
+
+  dbg = Debuginfo_val(slot);
+  dbg = caml_debuginfo_next(dbg);
+
+  if (dbg == NULL)
+    v = Val_int(0); /* None */
+  else
+  {
+    v = caml_alloc(1, 0);
+    Field(v, 0) = Val_debuginfo(dbg);
+  }
+
+  CAMLreturn(v);
+}
+
 /* the function below is deprecated: we previously returned directly
    the OCaml-usable representation, instead of the raw backtrace as an
    abstract type, but this has a large performance overhead if you

--- a/byterun/backtrace.c
+++ b/byterun/backtrace.c
@@ -207,11 +207,11 @@ CAMLprim value caml_convert_raw_backtrace(value bt)
 {
   CAMLparam1(bt);
   CAMLlocal1(array);
+  intnat i, index;
 
   if (!caml_debug_info_available())
     caml_failwith("No debug information available");
 
-  intnat i, index;
   for (i = 0, index = 0; i < Wosize_val(bt); ++i)
   {
     debuginfo dbg;
@@ -245,11 +245,14 @@ CAMLprim value caml_raw_backtrace_length(value bt)
 
 CAMLprim value caml_raw_backtrace_slot(value bt, value index)
 {
-  uintnat i = Long_val(index);
+  uintnat i;
+  debuginfo dbg;
+
+  i = Long_val(index);
   if (i >= Wosize_val(bt))
     caml_invalid_argument("Printexc.get_raw_backtrace_slot: "
                           "index out of bounds");
-  debuginfo dbg = caml_debuginfo_extract(Backtrace_slot_val(Field(bt, i)));
+  dbg = caml_debuginfo_extract(Backtrace_slot_val(Field(bt, i)));
   return Val_debuginfo(dbg);
 }
 

--- a/byterun/backtrace_prim.c
+++ b/byterun/backtrace_prim.c
@@ -449,6 +449,7 @@ void caml_extract_location_info(backtrace_slot slot,
     return;
   }
   li->loc_valid = 1;
+  li->loc_is_inlined = 0;
   li->loc_filename = event->ev_filename;
   li->loc_lnum = event->ev_lnum;
   li->loc_startchr = event->ev_startchr;

--- a/byterun/backtrace_prim.c
+++ b/byterun/backtrace_prim.c
@@ -247,24 +247,6 @@ void caml_stash_backtrace(value exn, code_t pc, value * sp, int reraise)
   }
 }
 
-/* In order to prevent the GC from walking through the debug
-   information (which have no headers), we transform code pointers to
-   31/63 bits ocaml integers by shifting them by 1 to the right. We do
-   not lose information as code pointers are aligned.
-
-   In particular, we do not need to use [caml_modify] when setting
-   an array element with such a value.
-*/
-value caml_val_raw_backtrace_slot(backtrace_slot pc)
-{
-  return Val_long ((uintnat)pc >> 1);
-}
-
-backtrace_slot caml_raw_backtrace_slot_val(value v)
-{
-  return ((backtrace_slot)(Long_val(v) << 1));
-}
-
 /* returns the next frame pointer (or NULL if none is available);
    updates *sp to point to the following one, and *trsp to the next
    trap frame, which we will skip when we reach it  */
@@ -323,7 +305,7 @@ CAMLprim value caml_get_current_callstack(value max_frames_value)
     for (trace_pos = 0; trace_pos < trace_size; trace_pos++) {
       code_t p = caml_next_frame_pointer(&sp, &trsp);
       Assert(p != NULL);
-      Store_field(trace, trace_pos, caml_val_raw_backtrace_slot(p));
+      Field(trace, trace_pos) = Val_backtrace_slot(p);
     }
   }
 
@@ -436,10 +418,10 @@ static struct ev_info *event_for_location(code_t pc)
 
 /* Extract location information for the given PC */
 
-void caml_extract_location_info(backtrace_slot slot,
-                                /*out*/ struct caml_loc_info * li)
+void caml_debuginfo_location(debuginfo dbg,
+                             /*out*/ struct caml_loc_info * li)
 {
-  code_t pc = slot;
+  code_t pc = dbg;
   struct ev_info *event = event_for_location(pc);
   li->loc_is_raise =
     caml_is_instruction(*pc, RAISE) ||
@@ -454,4 +436,15 @@ void caml_extract_location_info(backtrace_slot slot,
   li->loc_lnum = event->ev_lnum;
   li->loc_startchr = event->ev_startchr;
   li->loc_endchr = event->ev_endchr;
+}
+
+debuginfo caml_debuginfo_extract(backtrace_slot slot)
+{
+  return (debuginfo)slot;
+}
+
+debuginfo caml_debuginfo_next(debuginfo dbg)
+{
+  /* No inlining in bytecode */
+  return NULL;
 }

--- a/byterun/caml/backtrace_prim.h
+++ b/byterun/caml/backtrace_prim.h
@@ -36,6 +36,7 @@ struct caml_loc_info {
   int loc_lnum;
   int loc_startchr;
   int loc_endchr;
+  int loc_is_inlined;
 };
 
 /* Check availability of debug information before extracting a trace.

--- a/byterun/caml/backtrace_prim.h
+++ b/byterun/caml/backtrace_prim.h
@@ -39,20 +39,34 @@ struct caml_loc_info {
   int loc_is_inlined;
 };
 
+/* When compiling with -g, backtrace slots have debug info associated.
+ * When a call is inlined in native mode, debuginfos form a linked list.
+ */
+typedef void * debuginfo;
+
 /* Check availability of debug information before extracting a trace.
  * Relevant for bytecode, always true for native code. */
 int caml_debug_info_available(void);
 
-/* Extract locations from backtrace_slot */
-void caml_extract_location_info(backtrace_slot pc,
-                                /*out*/ struct caml_loc_info * li);
+/* Return debuginfo associated to a slot or NULL. */
+debuginfo caml_debuginfo_extract(backtrace_slot slot);
 
-/* Expose a [backtrace_slot] as a OCaml value of type [raw_backtrace_slot].
- * The value returned should be an immediate and not an OCaml block, so that it
- * is safe to store using direct assignment and [Field], and not [Store_field] /
- * [caml_modify].  */
-value caml_val_raw_backtrace_slot(backtrace_slot pc);
-backtrace_slot caml_raw_backtrace_slot_val(value slot);
+/* In case of an inlined call return next debuginfo or NULL otherwise. */
+debuginfo caml_debuginfo_next(debuginfo dbg);
+
+/* Extract locations from backtrace_slot */
+void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li);
+
+/* In order to prevent the GC from walking through the debug
+   information (which have no headers), we transform slots to 31/63 bits
+   ocaml integers by shifting them by 1 to the right. We do not lose
+   information as slots are aligned.
+
+   In particular, we do not need to use [caml_modify] when setting
+   an array element with such a value.
+ */
+#define Val_backtrace_slot(bslot) (Val_long(((uintnat)(bslot))>>1))
+#define Backtrace_slot_val(vslot) ((backtrace_slot)(Long_val(vslot) << 1))
 
 #define BACKTRACE_BUFFER_SIZE 1024
 

--- a/middle_end/flambda.ml
+++ b/middle_end/flambda.ml
@@ -492,7 +492,7 @@ let rec print_program_body ppf (program : program_body) =
       (Format.pp_print_list lam) fields;
     print_program_body ppf program
   | Effect (expr, program) ->
-    fprintf ppf "@[effect @[<hv 1>%a@]@@]@."
+    fprintf ppf "@[effect @[<hv 1>%a@]@]@."
       lam expr;
     print_program_body ppf program;
   | End root -> fprintf ppf "End %a" Symbol.print root

--- a/middle_end/flambda.ml
+++ b/middle_end/flambda.ml
@@ -189,7 +189,7 @@ let rec lam ppf (flam : t) =
   match flam with
   | Var (id) ->
       Variable.print ppf id
-  | Apply({func; args; kind; inline}) ->
+  | Apply({func; args; kind; inline; dbg}) ->
     let direct ppf () =
       match kind with
       | Indirect -> ()
@@ -202,7 +202,8 @@ let rec lam ppf (flam : t) =
       | Unroll i -> fprintf ppf "<unroll %i>" i
       | Default_inline -> ()
     in
-    fprintf ppf "@[<2>(apply%a%a@ %a%a)@]" direct () inline ()
+    fprintf ppf "@[<2>(apply%a%a<%s>@ %a%a)@]" direct () inline ()
+      (Debuginfo.to_string dbg)
       Variable.print func Variable.print_list args
   | Assign { being_assigned; new_value; } ->
     fprintf ppf "@[<2>(assign@ %a@ %a)@]"
@@ -343,8 +344,9 @@ and print_named ppf (named : named) =
     print_move_within_set_of_closures ppf move_within_set_of_closures
   | Set_of_closures (set_of_closures) ->
     print_set_of_closures ppf set_of_closures
-  | Prim(prim, args, _) ->
-    fprintf ppf "@[<2>(%a%a)@]" Printlambda.primitive prim
+  | Prim(prim, args, dbg) ->
+    fprintf ppf "@[<2>(%a<%s>%a)@]" Printlambda.primitive prim
+      (Debuginfo.to_string dbg)
       Variable.print_list args
   | Expr expr ->
     fprintf ppf "*%a" lam expr

--- a/middle_end/inline_and_simplify.ml
+++ b/middle_end/inline_and_simplify.ml
@@ -668,6 +668,7 @@ and simplify_apply env r ~(apply : Flambda.apply) : Flambda.t * R.t =
     Flambda. func = lhs_of_application; args; kind = _; dbg;
     inline = inline_requested; specialise = specialise_requested;
   } = apply in
+  let dbg = E.add_inlined_debuginfo env ~dbg in
   simplify_free_variable env lhs_of_application
     ~f:(fun env lhs_of_application lhs_of_application_approx ->
       simplify_free_variables env args ~f:(fun env args args_approxs ->
@@ -978,6 +979,7 @@ and simplify_named env r (tree : Flambda.named) : Flambda.named * R.t =
   | Move_within_set_of_closures move_within_set_of_closures ->
     simplify_move_within_set_of_closures env r ~move_within_set_of_closures
   | Prim (prim, args, dbg) ->
+    let dbg = E.add_inlined_debuginfo env ~dbg in
     simplify_free_variables_named env args ~f:(fun env args args_approxs ->
       let tree = Flambda.Prim (prim, args, dbg) in
       begin match prim, args, args_approxs with
@@ -1222,6 +1224,7 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
     let body, r = simplify env r body in
     While (cond, body), ret r (A.value_unknown Other)
   | Send { kind; meth; obj; args; dbg; } ->
+    let dbg = E.add_inlined_debuginfo env ~dbg in
     simplify_free_variable env meth ~f:(fun env meth _meth_approx ->
       simplify_free_variable env obj ~f:(fun env obj _obj_approx ->
         simplify_free_variables env args ~f:(fun _env args _args_approx ->

--- a/middle_end/inline_and_simplify_aux.ml
+++ b/middle_end/inline_and_simplify_aux.ml
@@ -41,6 +41,7 @@ module Env = struct
     actively_unrolling : int Set_of_closures_origin.Map.t;
     closure_depth : int;
     inlining_stats_closure_stack : Inlining_stats.Closure_stack.t;
+    inlined_debuginfo : Debuginfo.t;
   }
 
   let create ~never_inline ~backend ~round =
@@ -63,6 +64,7 @@ module Env = struct
       closure_depth = 0;
       inlining_stats_closure_stack =
         Inlining_stats.Closure_stack.create ();
+      inlined_debuginfo = Debuginfo.none;
     }
 
   let backend t = t.backend
@@ -73,6 +75,7 @@ module Env = struct
       approx = Variable.Map.empty;
       projections = Projection.Map.empty;
       freshening = Freshening.empty_preserving_activation_state env.freshening;
+      inlined_debuginfo = Debuginfo.none;
     }
 
   let inlining_level_up env =
@@ -395,6 +398,12 @@ module Env = struct
   let record_decision t decision =
     Inlining_stats.record_decision decision
       ~closure_stack:t.inlining_stats_closure_stack
+
+  let inline_debuginfo t ~dbg =
+    { t with inlined_debuginfo = Debuginfo.concat dbg t.inlined_debuginfo }
+
+  let add_inlined_debuginfo t ~dbg =
+    Debuginfo.concat t.inlined_debuginfo dbg
 end
 
 let initial_inlining_threshold ~round : Inlining_cost.Threshold.t =

--- a/middle_end/inline_and_simplify_aux.mli
+++ b/middle_end/inline_and_simplify_aux.mli
@@ -253,6 +253,16 @@ module Env : sig
 
   (** Print a human-readable version of the given environment. *)
   val print : Format.formatter -> t -> unit
+
+  (** The environment maintains a list of sites that got inlined to produce
+      precise location information.
+
+      When inlining a call-site, call this function to concatenate the
+      call-site location to the existing list of sites. *)
+  val inline_debuginfo : t -> dbg:Debuginfo.t -> t
+
+  (** Appends the locations of inlined call-sites to the [~dbg] argument *)
+  val add_inlined_debuginfo : t -> dbg:Debuginfo.t -> Debuginfo.t
 end
 
 module Result : sig

--- a/middle_end/inlining_decision.ml
+++ b/middle_end/inlining_decision.ml
@@ -37,7 +37,7 @@ let inline env r ~lhs_of_application
     ~(function_decls : Flambda.function_declarations)
     ~closure_id_being_applied ~(function_decl : Flambda.function_declaration)
     ~value_set_of_closures ~only_use_of_function ~original ~recursive
-    ~(args : Variable.t list) ~size_from_approximation ~simplify
+    ~(args : Variable.t list) ~size_from_approximation ~dbg ~simplify
     ~(inline_requested : Lambda.inline_attribute)
     ~(specialise_requested : Lambda.specialise_attribute)
     ~self_call ~fun_cost ~inlining_threshold =
@@ -192,7 +192,7 @@ let inline env r ~lhs_of_application
       Inlining_transforms.inline_by_copying_function_body ~env
         ~r:(R.reset_benefit r) ~function_decls ~lhs_of_application
         ~closure_id_being_applied ~specialise_requested ~inline_requested
-        ~function_decl ~args ~simplify
+        ~function_decl ~args ~dbg ~simplify
     in
     let num_direct_applications_seen =
       (R.num_direct_applications r_inlined) - (R.num_direct_applications r)
@@ -528,9 +528,10 @@ let for_call_site ~env ~r ~(function_decls : Flambda.function_declarations)
   in
   if function_decl.stub then
     let body, r =
-      Inlining_transforms.inline_by_copying_function_body ~env ~r
-        ~function_decls ~lhs_of_application ~closure_id_being_applied
-        ~inline_requested ~specialise_requested ~function_decl ~args ~simplify
+      Inlining_transforms.inline_by_copying_function_body ~env
+        ~r ~function_decls ~lhs_of_application
+        ~closure_id_being_applied ~specialise_requested ~inline_requested
+        ~function_decl ~args ~dbg ~simplify
     in
     simplify env r body
   else if E.never_inline env then
@@ -629,7 +630,7 @@ let for_call_site ~env ~r ~(function_decls : Flambda.function_declarations)
               ~closure_id_being_applied ~function_decl ~value_set_of_closures
               ~only_use_of_function ~original ~recursive
               ~inline_requested ~specialise_requested ~args
-              ~size_from_approximation ~simplify ~fun_cost ~self_call
+              ~size_from_approximation ~dbg ~simplify ~fun_cost ~self_call
               ~inlining_threshold
           in
           match inline_result with

--- a/middle_end/inlining_transforms.ml
+++ b/middle_end/inlining_transforms.ml
@@ -116,7 +116,7 @@ let inline_by_copying_function_body ~env ~r
       ~(inline_requested : Lambda.inline_attribute)
       ~(specialise_requested : Lambda.specialise_attribute)
       ~closure_id_being_applied
-      ~(function_decl : Flambda.function_declaration) ~args ~simplify =
+      ~(function_decl : Flambda.function_declaration) ~args ~dbg ~simplify =
   assert (E.mem env lhs_of_application);
   assert (List.for_all (E.mem env) args);
   let r =
@@ -175,6 +175,7 @@ let inline_by_copying_function_body ~env ~r
       bindings_for_vars_bound_by_closure_and_params_to_args
   in
   let env = E.activate_freshening (E.set_never_inline env) in
+  let env = E.inline_debuginfo ~dbg env in
   simplify env r expr
 
 let inline_by_copying_function_declaration ~env ~r

--- a/middle_end/inlining_transforms.mli
+++ b/middle_end/inlining_transforms.mli
@@ -74,6 +74,7 @@ val inline_by_copying_function_body
   -> closure_id_being_applied:Closure_id.t
   -> function_decl:Flambda.function_declaration
   -> args:Variable.t list
+  -> dbg:Debuginfo.t
   -> simplify:Inlining_decision_intf.simplify
   -> Flambda.t * Inline_and_simplify_aux.Result.t
 

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -84,7 +84,7 @@ let catch fct arg =
     exit 2
 
 type raw_backtrace_slot
-type raw_backtrace = raw_backtrace_slot array
+type raw_backtrace
 
 external get_raw_backtrace:
   unit -> raw_backtrace = "caml_get_exception_raw_backtrace"
@@ -104,8 +104,11 @@ let _ = [Known_location (false, "", 0, 0, 0, false); Unknown_location false]
 external convert_raw_backtrace_slot:
   raw_backtrace_slot -> backtrace_slot = "caml_convert_raw_backtrace_slot"
 
-let convert_raw_backtrace rbckt =
-  try Some (Array.map convert_raw_backtrace_slot rbckt)
+external convert_raw_backtrace:
+  raw_backtrace -> backtrace_slot array = "caml_convert_raw_backtrace"
+
+let convert_raw_backtrace bt =
+  try Some (convert_raw_backtrace bt)
   with Failure _ -> None
 
 let format_backtrace_slot pos slot =
@@ -214,8 +217,11 @@ module Slot = struct
   let location = backtrace_slot_location
 end
 
-let raw_backtrace_length bckt = Array.length bckt
-let get_raw_backtrace_slot bckt i = Array.get bckt i
+external raw_backtrace_length :
+  raw_backtrace -> int = "caml_raw_backtrace_length" [@@noalloc]
+
+external get_raw_backtrace_slot :
+  raw_backtrace -> int -> raw_backtrace_slot = "caml_raw_backtrace_slot"
 
 (* confusingly named:
    returns the *string* corresponding to the global current backtrace *)

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -90,16 +90,23 @@ external get_raw_backtrace:
   unit -> raw_backtrace = "caml_get_exception_raw_backtrace"
 
 type backtrace_slot =
-  | Known_location of bool   (* is_raise *)
-                    * string (* filename *)
-                    * int    (* line number *)
-                    * int    (* start char *)
-                    * int    (* end char *)
-                    * bool   (* is_inline *)
-  | Unknown_location of bool (*is_raise*)
+  | Known_location of {
+      is_raise    : bool;
+      filename    : string;
+      line_number : int;
+      start_char  : int;
+      end_char    : int;
+      is_inline   : bool;
+    }
+  | Unknown_location of {
+      is_raise : bool
+    }
 
 (* to avoid warning *)
-let _ = [Known_location (false, "", 0, 0, 0, false); Unknown_location false]
+let _ = [Known_location { is_raise = false; filename = "";
+                          line_number = 0; start_char = 0; end_char = 0;
+                          is_inline = false };
+         Unknown_location { is_raise = false }]
 
 external convert_raw_backtrace_slot:
   raw_backtrace_slot -> backtrace_slot = "caml_convert_raw_backtrace_slot"
@@ -119,14 +126,16 @@ let format_backtrace_slot pos slot =
       if pos = 0 then "Raised by primitive operation at" else "Called from"
   in
   match slot with
-  | Unknown_location true -> (* compiler-inserted re-raise, skipped *) None
-  | Unknown_location false ->
-      Some (sprintf "%s unknown location" (info false))
-  | Known_location(is_raise, filename, lineno, startchar, endchar, is_inline) ->
+  | Unknown_location l ->
+      if l.is_raise then
+        (* compiler-inserted re-raise, skipped *) None
+      else
+        Some (sprintf "%s unknown location" (info false))
+  | Known_location l ->
       Some (sprintf "%s file \"%s\"%s, line %d, characters %d-%d"
-              (info is_raise) filename
-              (if is_inline then " (inlined)" else "")
-              lineno startchar endchar)
+              (info l.is_raise) l.filename
+              (if l.is_inline then " (inlined)" else "")
+              l.line_number l.start_char l.end_char)
 
 let print_exception_backtrace outchan backtrace =
   match backtrace with
@@ -164,11 +173,11 @@ let raw_backtrace_to_string raw_backtrace =
   backtrace_to_string (convert_raw_backtrace raw_backtrace)
 
 let backtrace_slot_is_raise = function
-  | Known_location(is_raise, _, _, _, _, _) -> is_raise
-  | Unknown_location(is_raise) -> is_raise
+  | Known_location l -> l.is_raise
+  | Unknown_location l -> l.is_raise
 
 let backtrace_slot_is_inline = function
-  | Known_location(_, _, _, _, _, is_inline) -> is_inline
+  | Known_location l -> l.is_inline
   | Unknown_location _ -> false
 
 type location = {
@@ -180,13 +189,12 @@ type location = {
 
 let backtrace_slot_location = function
   | Unknown_location _ -> None
-  | Known_location(_is_raise, filename, line_number,
-                   start_char, end_char, _is_inline) ->
+  | Known_location l ->
     Some {
-      filename;
-      line_number;
-      start_char;
-      end_char;
+      filename    = l.filename;
+      line_number = l.line_number;
+      start_char  = l.start_char;
+      end_char    = l.end_char;
     }
 
 let backtrace_slots raw_backtrace =

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -223,6 +223,9 @@ external raw_backtrace_length :
 external get_raw_backtrace_slot :
   raw_backtrace -> int -> raw_backtrace_slot = "caml_raw_backtrace_slot"
 
+external get_raw_backtrace_next_slot :
+  raw_backtrace_slot -> raw_backtrace_slot option = "caml_raw_backtrace_next_slot"
+
 (* confusingly named:
    returns the *string* corresponding to the global current backtrace *)
 let get_backtrace () =

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -285,6 +285,12 @@ val convert_raw_backtrace_slot : raw_backtrace_slot -> backtrace_slot
 *)
 
 
+val get_raw_backtrace_next_slot : raw_backtrace_slot -> raw_backtrace_slot option
+(** [get_raw_backtrace_next_slot slot] returns the next slot inlined, if any.
+
+    @since 4.04.0
+*)
+
 (** {6 Exception slots} *)
 
 val exn_slot_id: exn -> int

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -211,6 +211,14 @@ module Slot : sig
       @since 4.02
   *)
 
+  val is_inline : t -> bool
+  (** [is_inline slot] is [true] when [slot] refers to a call
+      that got inlined by the compiler, and [false] when it comes from
+      any other context.
+
+      @since 4.04.0
+  *)
+
   val location : t -> location option
   (** [location slot] returns the location information of the slot,
       if available, and [None] otherwise.

--- a/testsuite/tests/backtrace/Makefile
+++ b/testsuite/tests/backtrace/Makefile
@@ -19,8 +19,13 @@ EXECNAME=program$(EXE)
 ABCDFILES=backtrace.ml
 OTHERFILES=backtrace2.ml backtrace3.ml raw_backtrace.ml \
            backtrace_deprecated.ml backtrace_slots.ml
+INLININGFILES=inline_test.ml inline_traversal_test.ml
 OTHERFILESNOINLINING=pr6920_why_at.ml pr6920_why_swallow.ml
 OTHERFILESNOINLINING_NATIVE=backtraces_and_finalizers.ml
+
+# Keep only filenames, lines and character ranges
+LOCATIONFILTER=grep -o \
+							 '[a-zA-Z_]\+\.ml\(:[0-9]\+\)\?\|\(line\|characters\) [0-9-]\+'
 
 default:
 	@$(MAKE) byte
@@ -51,6 +56,18 @@ byte:
 	       >$$F.byte.result 2>&1; \
 	  $(DIFF) $$F.reference $$F.byte.result >/dev/null \
 	  && echo " => passed" || echo " => failed"; \
+	done;
+	@for file in $(INLININGFILES); \
+	do \
+	  rm -f program program.exe; \
+	  $(OCAMLC) -g -o $(EXECNAME) $$file; \
+	  printf " ... testing '$$file' with ocamlc:"; \
+	  F="`basename $$file .ml`"; \
+	  (OCAMLRUNPARAM=$$OCAMLRUNPARAM,b=1 \
+    	$(OCAMLRUN) $(EXECNAME) $$arg 2>&1 || true) \
+			| $(LOCATIONFILTER) >$$F.byte.result 2>&1; \
+	  $(DIFF) $$F.reference $$F.byte.result >/dev/null \
+	  && echo " => passed" || echo " => failed"; \
 	done
 
 .PHONY: skip
@@ -62,7 +79,7 @@ skip:
 	  done; \
 	done
 	@for file in $(OTHERFILES) $(OTHERFILESNOINLINING) \
-	             $(OTHERFILESNOINLINING_NATIVE); do \
+	             $(OTHERFILESNOINLINING_NATIVE) $(INLININGFILES); do \
 	  echo " ... testing '$$file' with ocamlopt: => skipped"; \
 	done
 
@@ -103,7 +120,29 @@ native:
 	       >$$F.native.result 2>&1; \
 	  $(DIFF) $$F.reference $$F.native.result >/dev/null \
 	  && echo " => passed" || echo " => failed"; \
+	done;
+	@for file in $(INLININGFILES); \
+	do \
+	  rm -f program program.exe; \
+	  $(OCAMLOPT) -g -o $(EXECNAME) $$file; \
+	  printf " ... testing '$$file' with ocamlopt:"; \
+	  F="`basename $$file .ml`"; \
+	  (OCAMLRUNPARAM=$$OCAMLRUNPARAM,b=1 \
+    	./$(EXECNAME) $$arg 2>&1 || true) \
+		 	| $(LOCATIONFILTER) >$$F.native.result; \
+	  $(DIFF) $$F.reference $$F.native.result >/dev/null \
+	  && echo " => passed" || echo " => failed"; \
+	  rm -f program program.exe; \
+	  $(OCAMLOPT) -g -o $(EXECNAME) -O3 $$file; \
+	  printf " ... testing '$$file' with ocamlopt -O3:"; \
+	  F="`basename $$file .ml`"; \
+	  (OCAMLRUNPARAM=$$OCAMLRUNPARAM,b=1 \
+    	./$(EXECNAME) $$arg 2>&1 || true) \
+		 	| $(LOCATIONFILTER) >$$F.O3.result; \
+	  $(DIFF) $$F.reference $$F.O3.result >/dev/null \
+	  && echo " => passed" || echo " => failed"; \
 	done
+
 
 .PHONY: promote
 promote: defaultpromote

--- a/testsuite/tests/backtrace/inline_test.byte.reference
+++ b/testsuite/tests/backtrace/inline_test.byte.reference
@@ -1,0 +1,6 @@
+Fatal error: exception Failure("test")
+Raised at file "inline_test.ml", line 5, characters 8-24
+Called from file "inline_test.ml", line 8, characters 2-5
+Called from file "inline_test.ml", line 11, characters 12-17
+Called from file "inline_test.ml", line 14, characters 5-8
+Called from file "inline_test.ml", line 18, characters 2-6

--- a/testsuite/tests/backtrace/inline_test.ml
+++ b/testsuite/tests/backtrace/inline_test.ml
@@ -1,0 +1,18 @@
+
+(* A test for inlined stack backtraces *)
+
+let f x =
+  raise (Failure "test") + 1
+
+let g x =
+  f x + 1
+
+let h x =
+  print_int (g x); print_endline "h"
+
+let i x =
+  if h x = () then ()
+
+let () =
+  Printexc.record_backtrace true;
+  i ()

--- a/testsuite/tests/backtrace/inline_test.reference
+++ b/testsuite/tests/backtrace/inline_test.reference
@@ -1,0 +1,15 @@
+inline_test.ml
+line 5
+characters 8-24
+inline_test.ml
+line 8
+characters 2-5
+inline_test.ml
+line 11
+characters 12-17
+inline_test.ml
+line 14
+characters 5-8
+inline_test.ml
+line 18
+characters 2-6

--- a/testsuite/tests/backtrace/inline_traversal_test.ml
+++ b/testsuite/tests/backtrace/inline_traversal_test.ml
@@ -1,0 +1,46 @@
+
+(* A test for inlined stack backtraces *)
+
+let f x =
+  raise (Failure "test") + 1
+
+let g x =
+  f x + 1
+
+let h x =
+  print_int (g x); print_endline "h"
+
+let i x =
+  if h x = () then ()
+
+let () =
+  let open Printexc in
+  record_backtrace true;
+  try i ()
+  with _ ->
+    let trace = get_raw_backtrace () in
+    let print_slot slot =
+      let x = convert_raw_backtrace_slot slot in
+      let is_raise = Slot.is_raise x in
+      let is_inline = Slot.is_inline x in
+      let location = match Slot.location x with
+        | None -> "<unknown>"
+        | Some {filename; line_number; _} ->
+            filename ^ ":" ^ string_of_int line_number
+      in
+      Printf.printf "- %s%s%s\n"
+        location
+        (if is_inline then " inlined" else "")
+        (if is_raise then ", raise" else "")
+    in
+    let rec print_slots = function
+      | None -> ()
+      | Some slot ->
+        print_slot slot;
+        print_slots (get_raw_backtrace_next_slot slot)
+    in
+    for i = 0 to raw_backtrace_length trace - 1 do
+      let slot = get_raw_backtrace_slot trace i in
+      Printf.printf "Frame %d\n" i;
+      print_slots (Some slot)
+    done

--- a/testsuite/tests/backtrace/inline_traversal_test.reference
+++ b/testsuite/tests/backtrace/inline_traversal_test.reference
@@ -1,0 +1,5 @@
+inline_traversal_test.ml:5
+inline_traversal_test.ml:8
+inline_traversal_test.ml:11
+inline_traversal_test.ml:14
+inline_traversal_test.ml:19


### PR DESCRIPTION
This pull request makes the backtrace infrastructure robust to inlining.
It already improves the developer experience, but will be even more important with the stronger inlining that is coming.

While it should be usable as it is, I would like to discuss two points to improve before considering a merge.
### Printexc API

Printexc allows the user to observe a backtrace mainly by offering random access to "slots".
An "O(1)" cost is implicitly assumed, but not really practical: for instance with inlining, there are more frames than slots in the backtrace buffer.
Flattening the array is required before indexing, which in turns require to distinguish between normal frames and inlined frames in the raw_backtrace, etc.

The patch tries to hide all differences, but the implementation could be significantly simpler with a few changes.
As @gasche already suggested that we could cleanup Printexc, my idea would be to:
- deprecate random access, and either make it only observe the 'physical backtrace' (without inlined frames), or explicitly not "O(1)"
- use iter-like functions as the main way to observe the trace.

Also, coming up with better names and a better 'story' than (raw) backtrace/slot could be helpful for users; though I don't know what other opinions are and I have nothing to suggest :).
### Representation of backtraces

In the mainline OCaml compiler, debug information are stored in a packed way at the end of each frame descriptor.
Debug information fits in a word, using relative adressing to store the filename and bit twiddling to pack coordinates.

My understanding is that this was done to maximize locality, efficient traversal of frame table being critical for GC performance.
However I would like to simplify representation by adding an indirection (just a pointer) to access the debug data.
These are not needed on critical path, so indirection shouldn't affect performance. Frame descriptor size is unchanged.

Debug information would be a few bytes larger, but the representation would be simpler and more uniform (in this case, debug info are extended with a linked list of inlined frames).
