### PR TITLE
Build system: fix a few hardcoded ar commands.

### DIFF
--- a/asmrun/Makefile
+++ b/asmrun/Makefile
@@ -70,7 +70,7 @@ all-shared: libasmrun_pic.a libasmrun_shared.so
 
 libasmrun_pic.a: $(PICOBJS)
 	rm -f libasmrun_pic.a
-	ar rc libasmrun_pic.a $(PICOBJS)
+	$(ARCMD) rc libasmrun_pic.a $(PICOBJS)
 	$(RANLIB) libasmrun_pic.a
 
 libasmrun_shared.so: $(PICOBJS)

--- a/byterun/Makefile
+++ b/byterun/Makefile
@@ -45,7 +45,7 @@ all-shared: libcamlrun_pic.a libcamlrun_shared.so
 .PHONY: all-shared
 
 libcamlrun_pic.a: $(PICOBJS)
-	ar rc libcamlrun_pic.a $(PICOBJS)
+	$(ARCMD) rc libcamlrun_pic.a $(PICOBJS)
 	$(RANLIB) libcamlrun_pic.a
 
 libcamlrun_shared.so: $(PICOBJS)

--- a/config/Makefile-templ
+++ b/config/Makefile-templ
@@ -74,7 +74,7 @@ SHARPBANGSCRIPTS=true
 
 ### Magic declarations for ocamlbuild -- leave unchanged
 #ml let syslib x = "-l"^x;;
-#ml let mklib out files opts = Printf.sprintf "ar rc %s %s %s; ranlib %s" out opts files out;;
+#ml let mklib out files opts = Printf.sprintf "%sar rc %s %s %s; %sranlib %s" toolpref out opts files toolpref out;;
 
 ### How to invoke ranlib
 RANLIB=ranlib


### PR DESCRIPTION
They break cross-compiling scenarios.

A `git grep "ar rc"` also reveals the following occurences but I don't know exactly if something should be done about it or not: 

```
> git grep "ar rc"
config/Makefile-templ:#ml let mklib out files opts = Printf.sprintf "ar rc %s %s %s; ranlib %s" out opts files out;;
config/Makefile.mingw:MKLIB=rm -f $(1); $(TOOLPREF)ar rc $(1) $(2); $(RANLIB) $(1)
config/Makefile.mingw:#ml let mklib out files opts = Printf.sprintf "rm -f %s && %sar rcs %s %s %s" out toolpref opts out files;;
config/Makefile.mingw64:MKLIB=rm -f $(1); $(TOOLPREF)ar rc $(1) $(2); $(RANLIB) $(1)
config/Makefile.mingw64:#ml let mklib out files opts = Printf.sprintf "rm -f %s && %sar rcs %s %s %s" out toolpref opts out files;;
configure:MKLIB=${TOOLPREF}ar rc \$(1) \$(2); ${TOOLPREF}ranlib \$(1)
configure:#ml   Printf.sprintf "${TOOLPREF}ar rc %s %s %s;
```
