### PR TITLE
Check for negative start element in Array.sub

### DIFF
--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -59,7 +59,7 @@ let append a1 a2 =
   else append_prim a1 a2
 
 let sub a ofs len =
-  if len < 0 || ofs > length a - len
+  if ofs < 0 || len < 0 || ofs > length a - len
   then invalid_arg "Array.sub"
   else unsafe_sub a ofs len
 

--- a/testsuite/tests/basic/arrays.ml
+++ b/testsuite/tests/basic/arrays.ml
@@ -134,7 +134,7 @@ let test8 () =
     ignore (Array.sub [|3;4|] max_int 1); print_string "Test 8.3: failed\n"
   with Invalid_argument _ -> ());
   (try
-    ignore (Array.sub [|3;4|] (-1) 1); print_string "Test 8.3: failed\n"
+    ignore (Array.sub [|3;4|] (-1) 1); print_string "Test 8.4: failed\n"
   with Invalid_argument _ -> ())
 
 let _ =

--- a/testsuite/tests/basic/arrays.ml
+++ b/testsuite/tests/basic/arrays.ml
@@ -132,6 +132,9 @@ let test8 () =
   with Invalid_argument _ -> ());
   (try
     ignore (Array.sub [|3;4|] max_int 1); print_string "Test 8.3: failed\n"
+  with Invalid_argument _ -> ());
+  (try
+    ignore (Array.sub [|3;4|] (-1) 1); print_string "Test 8.3: failed\n"
   with Invalid_argument _ -> ())
 
 let _ =


### PR DESCRIPTION
Before:

``` ocaml
# Array.sub [|0;1|] (-1) 1;;
- : int array = [|1408|]
# Array.sub [|0;1|] (-1000000) 1000000;;
Segmentation fault
```

After:

``` ocaml
# Array.sub [|0;1|] (-1) 1;;
Exception: Invalid_argument "Array.sub".
# Array.sub [|0;1|] (-1000000) 1000000;;
Exception: Invalid_argument "Array.sub".
```
