### PR TITLE
Travis: update CI to use container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 #                                                                       #
 #                                 OCaml                                 #
 #                                                                       #
-#              Anil Madhavapeddy, OCaml Labs                            #
+#              Anil Madhavapeddy, University of Cambridge               #
 #                                                                       #
 #   Copyright 2014 Institut National de Recherche en Informatique et    #
 #   en Automatique.  All rights reserved.  This file is distributed     #
@@ -12,5 +12,22 @@
 
 language: c
 script: bash -ex .travis-ci.sh
+sudo: false
+addons:
+  apt:
+    sources:
+    - llvm-toolchain-precise-3.6
+    - ubuntu-toolchain-r-test
+    packages:
+    - build-essential
+    - clang-3.6
+    - m4
+    - aspcud
 env:
-   - XARCH=i386
+- MODE=gcc
+- MODE=gcc CONFIGURE_FLAGS=-with-debug-runtime
+- MODE=clang-scan
+before_install:
+- openssl aes-256-cbc -K $encrypted_9df4cc675af8_key -iv $encrypted_9df4cc675af8_iv
+  -in .deploy_key.enc -out .deploy_key -d
+- chmod 600 .deploy_key


### PR DESCRIPTION
This is the faster, preferred method of using Travis now since it
uses a lightweight container and not a full VM to do the build.
http://docs.travis-ci.com/user/workers/container-based-infrastructure/

The commit also adds a couple of options to the build matrix:
- A debug and non-debug runtime build to ensure both build
- A clang-based static analysis pass on the runtime
- OPAM 1.2 is now built instead of OPAM trunk
