### PR TITLE
fix undefined left shift of negative value.

### DIFF
--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -68,7 +68,7 @@ typedef uintnat mark_t;
 
 /* Conversion macro names are always of the form  "to_from". */
 /* Example: Val_long as in "Val from long" or "Val of long". */
-#define Val_long(x)     (((intnat)(x) << 1) + 1)
+#define Val_long(x)     ((intnat) (((uintnat)(x) << 1)) + 1)
 #define Long_val(x)     ((x) >> 1)
 #define Max_long (((intnat)1 << (8 * sizeof(value) - 2)) - 1)
 #define Min_long (-((intnat)1 << (8 * sizeof(value) - 2)))


### PR DESCRIPTION
Left-shifting signed negative values is undefined behavior. From 6.5.7 of http://open-std.org/JTC1/SC22/WG14/www/docs/n1256.pdf:

```
If E1 has a signed type and nonnegative value,
and E1 × 2 E2 is representable in the result type,
then that is the resulting value; otherwise, the
behavior is undefined.
```

This patch also has the pleasant side effect of permitting build with clang.
