### PR TITLE
configure: use preprocessor to get infos about target arch

### DIFF
--- a/config/auto-aux/endian.c
+++ b/config/auto-aux/endian.c
@@ -1,40 +1,26 @@
-/***********************************************************************/
-/*                                                                     */
-/*                                OCaml                                */
-/*                                                                     */
-/*            Xavier Leroy, projet Cristal, INRIA Rocquencourt         */
-/*                                                                     */
-/*  Copyright 1996 Institut National de Recherche en Informatique et   */
-/*  en Automatique.  All rights reserved.  This file is distributed    */
-/*  under the terms of the GNU Library General Public License, with    */
-/*  the special exception on linking described in file ../../LICENSE.  */
-/*                                                                     */
-/***********************************************************************/
-
-#include <string.h>
-#include "m.h"
-
-#ifndef ARCH_SIXTYFOUR
-long intval = 0x41424344L;
-char * bigendian = "ABCD";
-char * littleendian = "DCBA";
-#else
-long intval = 0x4142434445464748L;
-char * bigendian = "ABCDEFGH";
-char * littleendian = "HGFEDCBA";
+// Try to find the right includes
+#if defined(__linux__) || defined(__CYGWIN__)
+#  define _BSD_SOURCE
+#  include <endian.h>
+#elif defined(__APPLE__)
+#  include <libkern/OSByteOrder.h>
+#elif defined(BSD)
+#   include <sys/endian.h>
+#elif defined(_WIN16) || defined(_WIN32) || defined(_WIN64)
+#  include <winsock2.h>
+#  include <sys/param.h>
 #endif
 
-int main(void)
-{
-  long n[2];
-  char * p;
-
-  n[0] = intval;
-  n[1] = 0;
-  p = (char *) n;
-  if (strcmp(p, bigendian) == 0)
-    return 0;
-  if (strcmp(p, littleendian) == 0)
-    return 1;
-  return 2;
-}
+#if defined(__BIG_ENDIAN__) || \
+  defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__ || \
+  defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN || \
+  defined(BYTE_ORDER) && BYTE_ORDER == BIG_ENDIAN
+0
+#elif defined(__LITTLE_ENDIAN__) || \
+  defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ || \
+  defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN || \
+  defined(BYTE_ORDER) && BYTE_ORDER == LITTLE_ENDIAN
+1
+#else
+#  error Cannot detect endianess of target
+#endif

--- a/config/auto-aux/preprocesstest
+++ b/config/auto-aux/preprocesstest
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+#########################################################################
+#                                                                       #
+#                                 OCaml                                 #
+#                                                                       #
+#            Xavier Leroy, projet Cristal, INRIA Rocquencourt           #
+#                                                                       #
+#   Copyright 1995 Institut National de Recherche en Informatique et    #
+#   en Automatique.  All rights reserved.  This file is distributed     #
+#   under the terms of the GNU Library General Public License, with     #
+#   the special exception on linking described in file ../../LICENSE.   #
+#                                                                       #
+#########################################################################
+
+if test "$verbose" = yes; then
+echo "preprocesstest: $cc -o tst $* $cclibs" >&2
+$cc -E -P -o tst $* $cclibs || exit 100
+else
+$cc -E -P -o tst $* $cclibs 2> /dev/null || exit 100
+fi
+tail -n 1 ./tst

--- a/config/auto-aux/sizes.c
+++ b/config/auto-aux/sizes.c
@@ -1,25 +1,64 @@
-/***********************************************************************/
-/*                                                                     */
-/*                                OCaml                                */
-/*                                                                     */
-/*            Xavier Leroy, projet Cristal, INRIA Rocquencourt         */
-/*                                                                     */
-/*  Copyright 1996 Institut National de Recherche en Informatique et   */
-/*  en Automatique.  All rights reserved.  This file is distributed    */
-/*  under the terms of the GNU Library General Public License, with    */
-/*  the special exception on linking described in file ../../LICENSE.  */
-/*                                                                     */
-/***********************************************************************/
+#include <limits.h>
+#include <stdint.h>
 
-#include <stdio.h>
+#if UINT_MAX == 255ULL
+#define SIZEOFINT 1
+#elif UINT_MAX == 65535ULL
+#define SIZEOFINT 2
+#elif UINT_MAX == 4294967295ULL
+#define SIZEOFINT 4
+#elif UINT_MAX == 18446744073709551615ULL
+#define SIZEOFINT 8
+#else
+#error Cannot evaluate sizeof(int)
+#endif
 
-int main(int argc, char **argv)
-{
-  printf("%d %d %d %d %d\n",
-         (int) sizeof(int),
-         (int) sizeof(long),
-         (int) sizeof(long *),
-         (int) sizeof(short),
-         (int) sizeof(long long));
-  return 0;
-}
+#if ULONG_MAX == 255ULL
+#define SIZEOFLONG 1
+#elif ULONG_MAX == 65535ULL
+#define SIZEOFLONG 2
+#elif ULONG_MAX == 4294967295ULL
+#define SIZEOFLONG 4
+#elif ULONG_MAX == 18446744073709551615ULL
+#define SIZEOFLONG 8
+#else
+#error Cannot evaluate sizeof(long)
+#endif
+
+#if SIZE_MAX == 255ULL
+#define SIZEOFPOINTER 1
+#elif SIZE_MAX == 65535ULL
+#define SIZEOFPOINTER 2
+#elif SIZE_MAX == 4294967295ULL
+#define SIZEOFPOINTER 4
+#elif SIZE_MAX == 18446744073709551615ULL
+#define SIZEOFPOINTER 8
+#else
+#error Cannot evaluate sizeof(*ptr)
+#endif
+
+#if USHRT_MAX == 255ULL
+#define SIZEOFSHORT 1
+#elif USHRT_MAX == 65535ULL
+#define SIZEOFSHORT 2
+#elif USHRT_MAX == 4294967295ULL
+#define SIZEOFSHORT 4
+#elif USHRT_MAX == 18446744073709551615ULL
+#define SIZEOFSHORT 8
+#else
+#error Cannot evaluate sizeof(short)
+#endif
+
+#if ULLONG_MAX == 255ULL
+#define SIZEOFLONGLONG 1
+#elif ULLONG_MAX == 65535ULL
+#define SIZEOFLONGLONG 2
+#elif ULLONG_MAX == 4294967295ULL
+#define SIZEOFLONGLONG 4
+#elif ULLONG_MAX == 18446744073709551615ULL
+#define SIZEOFLONGLONG 8
+#else
+#error Cannot evaluate sizeof(long long)
+#endif
+
+SIZEOFINT SIZEOFLONG SIZEOFPOINTER SIZEOFSHORT SIZEOFLONGLONG

--- a/configure
+++ b/configure
@@ -552,22 +552,26 @@ echo "#define SIZEOF_LONGLONG $5" >> m.h
 
 # Determine endianness
 
-sh ./runtest endian.c
-case $? in
-  0) inf "This is a big-endian architecture."
-     echo "#define ARCH_BIG_ENDIAN" >> m.h;;
-  1) inf "This is a little-endian architecture."
-     echo "#undef ARCH_BIG_ENDIAN" >> m.h;;
-  2) err "This architecture seems to be neither big endian nor little" \
-         "endian.\n OCaml won't run on this architecture.";;
-  *) case $target in
+ret=`sh ./preprocesstest endian.c`
+if test "$?" -eq 0; then
+  set $ret
+  case "$1" in
+    0) inf "This is a big-endian architecture."
+       echo "#define ARCH_BIG_ENDIAN" >> m.h;;
+    1) inf "This is a little-endian architecture."
+       echo "#undef ARCH_BIG_ENDIAN" >> m.h;;
+    *) err "This architecture seems to be neither big endian nor little" \
+           "endian.\n OCaml won't run on this architecture.";;
+  esac
+else
+  case $target in
        *-*-mingw*) inf "This is a little-endian architecture."
                    echo "#undef ARCH_BIG_ENDIAN" >> m.h;;
        *) wrn "Something went wrong during endianness determination.\n" \
               "You will have to figure out endianness yourself\n" \
               "(option ARCH_BIG_ENDIAN in m.h).";;
-     esac;;
-esac
+     esac
+fi
 
 # Determine alignment constraints
 

--- a/configure
+++ b/configure
@@ -495,7 +495,7 @@ fi # cross-compiler
 # a 64-bit integer type
 
 inf "Checking the sizes of integers and pointers..."
-ret=`sh ./runtest sizes.c`
+ret=`sh ./preprocesstest sizes.c`
 # $1 = sizeof(int)
 # $2 = sizeof(long)
 # $3 = sizeof(pointers)


### PR DESCRIPTION
I'm trying to port OCaml to the openwrt router distribution [1]. Openwrt makes heavy use of cross-compiling, and supports about 40 different target archs.
When cross-compiling OCaml the configure script fails on 2 tests, it cannot detect integer and pointer sizes and it cannot detect endianess. I could now add rules and manually set the values for all 40 openwrt targets into the configure script, but I think this doesn't scale well and is only useful for openwrt.

So I sat down and wrote an alternative way to detect pointer sizes and endianess by using the preprocessor and parsing it's output. This is currently lightly tested on a few archs, so please comment and test.

There is also a test in configure script which checks if negative division rounds to zero. This check currently fails in case of cross-compile, but is only a warning. I see no way to do this check in the preprocessor.
Is this test really needed? Which compiler do misbehave? Sind C99 round to zero is mandated by the C Standard.

[1] https://openwrt.org/
