### PR TITLE
configure: use preprocessor to get infos about target arch

### DIFF
--- a/config/auto-aux/ansi.c
+++ b/config/auto-aux/ansi.c
@@ -11,15 +11,12 @@
 /*                                                                     */
 /***********************************************************************/
 
-int main()
-{
 #ifdef __STDC__
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-  return 0;
+0
 #else
-  return 1;
+1
 #endif
 #else
-  return 2;
+2
 #endif
-}

--- a/config/auto-aux/endian2.c
+++ b/config/auto-aux/endian2.c
@@ -1,0 +1,40 @@
+/***********************************************************************/
+/*                                                                     */
+/*                                OCaml                                */
+/*                                                                     */
+/*  Contributed by Stefan Hellermann <stefan@the2masters.de>           */
+/*                                                                     */
+/*  Copyright 2015 Institut National de Recherche en Informatique et   */
+/*  en Automatique.  All rights reserved.  This file is distributed    */
+/*  under the terms of the GNU Library General Public License, with    */
+/*  the special exception on linking described in file ../../LICENSE.  */
+/*                                                                     */
+/***********************************************************************/
+
+// Try to find the right includes
+#if defined(__linux__) || defined(__CYGWIN__)
+#  define _BSD_SOURCE
+#  define _DEFAULT_SOURCE
+#  include <endian.h>
+#elif defined(__APPLE__)
+#  include <libkern/OSByteOrder.h>
+#elif defined(BSD)
+#   include <sys/endian.h>
+#elif defined(_WIN16) || defined(_WIN32) || defined(_WIN64)
+#  include <winsock2.h>
+#  include <sys/param.h>
+#endif
+
+#if defined(__BIG_ENDIAN__) || \
+  defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__ || \
+  defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN || \
+  defined(BYTE_ORDER) && BYTE_ORDER == BIG_ENDIAN
+0
+#elif defined(__LITTLE_ENDIAN__) || \
+  defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ || \
+  defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN || \
+  defined(BYTE_ORDER) && BYTE_ORDER == LITTLE_ENDIAN
+1
+#else
+#  error Cannot detect endianess of target
+#endif

--- a/config/auto-aux/preprocesstest
+++ b/config/auto-aux/preprocesstest
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+#########################################################################
+#                                                                       #
+#                                 OCaml                                 #
+#                                                                       #
+#            Xavier Leroy, projet Cristal, INRIA Rocquencourt           #
+#                                                                       #
+#   Copyright 1995 Institut National de Recherche en Informatique et    #
+#   en Automatique.  All rights reserved.  This file is distributed     #
+#   under the terms of the GNU Library General Public License, with     #
+#   the special exception on linking described in file ../../LICENSE.   #
+#                                                                       #
+#########################################################################
+
+if test "$verbose" = yes; then
+echo "preprocesstest: $cc -o tst $* $cclibs" >&2
+$cc -E -P -o tst $* $cclibs || exit 100
+else
+$cc -E -P -o tst $* $cclibs 2> /dev/null || exit 100
+fi
+tail -n 1 ./tst

--- a/config/auto-aux/sizes.c
+++ b/config/auto-aux/sizes.c
@@ -2,24 +2,76 @@
 /*                                                                     */
 /*                                OCaml                                */
 /*                                                                     */
-/*            Xavier Leroy, projet Cristal, INRIA Rocquencourt         */
+/*  Contributed by Stefan Hellermann <stefan@the2masters.de>           */
 /*                                                                     */
-/*  Copyright 1996 Institut National de Recherche en Informatique et   */
+/*  Copyright 2015 Institut National de Recherche en Informatique et   */
 /*  en Automatique.  All rights reserved.  This file is distributed    */
 /*  under the terms of the GNU Library General Public License, with    */
 /*  the special exception on linking described in file ../../LICENSE.  */
 /*                                                                     */
 /***********************************************************************/
 
-#include <stdio.h>
+#include <limits.h>
+#include <stdint.h>
 
-int main(int argc, char **argv)
-{
-  printf("%d %d %d %d %d\n",
-         (int) sizeof(int),
-         (int) sizeof(long),
-         (int) sizeof(long *),
-         (int) sizeof(short),
-         (int) sizeof(long long));
-  return 0;
-}
+#if UINT_MAX == 255ULL
+#define SIZEOFINT 1
+#elif UINT_MAX == 65535ULL
+#define SIZEOFINT 2
+#elif UINT_MAX == 4294967295ULL
+#define SIZEOFINT 4
+#elif UINT_MAX == 18446744073709551615ULL
+#define SIZEOFINT 8
+#else
+#error Cannot evaluate sizeof(int)
+#endif
+
+#if ULONG_MAX == 255ULL
+#define SIZEOFLONG 1
+#elif ULONG_MAX == 65535ULL
+#define SIZEOFLONG 2
+#elif ULONG_MAX == 4294967295ULL
+#define SIZEOFLONG 4
+#elif ULONG_MAX == 18446744073709551615ULL
+#define SIZEOFLONG 8
+#else
+#error Cannot evaluate sizeof(long)
+#endif
+
+#if SIZE_MAX == 255ULL
+#define SIZEOFPOINTER 1
+#elif SIZE_MAX == 65535ULL
+#define SIZEOFPOINTER 2
+#elif SIZE_MAX == 4294967295ULL
+#define SIZEOFPOINTER 4
+#elif SIZE_MAX == 18446744073709551615ULL
+#define SIZEOFPOINTER 8
+#else
+#error Cannot evaluate sizeof(void *)
+#endif
+
+#if USHRT_MAX == 255ULL
+#define SIZEOFSHORT 1
+#elif USHRT_MAX == 65535ULL
+#define SIZEOFSHORT 2
+#elif USHRT_MAX == 4294967295ULL
+#define SIZEOFSHORT 4
+#elif USHRT_MAX == 18446744073709551615ULL
+#define SIZEOFSHORT 8
+#else
+#error Cannot evaluate sizeof(short)
+#endif
+
+#if ULLONG_MAX == 255ULL
+#define SIZEOFLONGLONG 1
+#elif ULLONG_MAX == 65535ULL
+#define SIZEOFLONGLONG 2
+#elif ULLONG_MAX == 4294967295ULL
+#define SIZEOFLONGLONG 4
+#elif ULLONG_MAX == 18446744073709551615ULL
+#define SIZEOFLONGLONG 8
+#else
+#error Cannot evaluate sizeof(long long)
+#endif
+
+SIZEOFINT SIZEOFLONG SIZEOFPOINTER SIZEOFSHORT SIZEOFLONGLONG

--- a/configure
+++ b/configure
@@ -433,23 +433,19 @@ export cc cclibs verbose
 
 # Check C compiler.
 
-cc="$bytecc $bytecccompopts $bytecclinkopts" sh ./runtest ansi.c
-case $? in
-  0) inf "The C compiler is ISO C99 compliant." ;;
-  1) wrn "The C compiler is ANSI / ISO C90 compliant, but not ISO C99" \
-         "compliant.";;
-  2) err "The C compiler $cc is not ISO C compliant.\n" \
-         "You need an ISO C99 compiler to build OCaml.";;
-  *)
-     if $cross_compiler; then
-       wrn "Unable to compile the test program.\n" \
-           "This failure is expected for cross-compilation:\n" \
-           "we will assume the C compiler is ISO C99-compliant."
-     else
-       err "Unable to compile the test program.\n" \
-           "Make sure the C compiler $cc is properly installed."
-     fi;;
-esac
+cc="$bytecc $bytecccompopts $bytecclinkopts" ret=`sh ./preprocesstest ansi.c`
+if test "$?" -eq 0; then
+  case $ret in
+    0) inf "The C compiler is ISO C99 compliant." ;;
+    1) wrn "The C compiler is ANSI / ISO C90 compliant, but not ISO C99" \
+           "compliant.";;
+    *) err "The C compiler $cc is not ISO C compliant.\n" \
+           "You need an ISO C99 compiler to build OCaml.";;
+  esac
+else
+  err "Unable to compile the test program.\n" \
+      "Make sure the C compiler $cc is properly installed."
+fi
 
 # For cross-compilation, we need a host-based ocamlrun and ocamlyacc,
 # and the user must specify the target BINDIR

--- a/configure
+++ b/configure
@@ -552,8 +552,13 @@ echo "#define SIZEOF_LONGLONG $5" >> m.h
 
 # Determine endianness
 
-sh ./runtest endian.c
-case $? in
+if $cross_compiler; then
+  ret=`sh ./preprocesstest endian2.c`
+else
+  sh ./runtest endian.c
+  ret=$?
+fi
+case "$ret" in
   0) inf "This is a big-endian architecture."
      echo "#define ARCH_BIG_ENDIAN" >> m.h;;
   1) inf "This is a little-endian architecture."
@@ -563,7 +568,7 @@ case $? in
   *) case $target in
        *-*-mingw*) inf "This is a little-endian architecture."
                    echo "#undef ARCH_BIG_ENDIAN" >> m.h;;
-       *) wrn "Something went wrong during endianness determination.\n" \
+       *) err "Something went wrong during endianness determination.\n" \
               "You will have to figure out endianness yourself\n" \
               "(option ARCH_BIG_ENDIAN in m.h).";;
      esac;;

--- a/configure
+++ b/configure
@@ -495,7 +495,7 @@ fi # cross-compiler
 # a 64-bit integer type
 
 inf "Checking the sizes of integers and pointers..."
-ret=`sh ./runtest sizes.c`
+ret=`sh ./preprocesstest sizes.c`
 # $1 = sizeof(int)
 # $2 = sizeof(long)
 # $3 = sizeof(pointers)


### PR DESCRIPTION
I'm trying to port OCaml to the openwrt router distribution [1]. Openwrt makes heavy use of cross-compiling, and supports about 40 different target archs.
When cross-compiling OCaml the configure script fails on 4 tests, it cannot detect integer and pointer sizes, it cannot detect endianess and fails to detect C99 conformance (only in trunk). I could now add rules and manually set the values for all 40 openwrt targets into the configure script, but I think this doesn't scale well and is only useful for openwrt.

So I sat down and wrote an alternative way to detect pointer sizes and endianess by using the preprocessor and parsing it's output. Detecting Endianess by the preprocessor is only done in case of cross-compilation. This is currently lightly tested on a few archs, so please comment and test.

@xavierleroy would you accept this endian2.c file as fallback in cross-compilation case?

I actually don't know why the C99 conformance test failed, as there is a special check for the cross-compilation case, but it was to easy to replace the test with a preprocessor-based check.

[1] https://openwrt.org/
