### PR TITLE
Fix some instruction size on ppc64

### DIFF
--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -424,7 +424,8 @@ module BR = Branch_relaxation.Make (struct
     | ELF64v2 -> (fun a b c -> c)
 
   let load_store_size = function
-    | Ibased(s, d) -> 2
+    | Ibased(s, d) ->
+        if !big_toc || !Clflags.for_package <> None then 3 else 2
     | Iindexed ofs -> if is_immediate ofs then 1 else 3
     | Iindexed2 -> 1
 
@@ -434,7 +435,8 @@ module BR = Branch_relaxation.Make (struct
     | Lop(Iconst_int n | Iconst_blockheader n) ->
       if is_native_immediate n then 1 else 2
     | Lop(Iconst_float s) -> size 2 1 1
-    | Lop(Iconst_symbol s) -> size 2 1 1
+    | Lop(Iconst_symbol s) ->
+        size 2 1 (if !big_toc || !Clflags.for_package <> None then 2 else 1)
     | Lop(Icall_ind) -> size 2 5 4
     | Lop(Icall_imm s) -> size 1 3 3
     | Lop(Itailcall_ind) -> size 5 7 6


### PR DESCRIPTION
When using `-for-pack` on ppc64 some instruction size are miscalculated, leading to a problem with too long jumps.

This is due to `emit_tocload` generating a bit bigger code.

Notice that I didn't go through every use of `emit_tocload` to ensure that it is always ok. It is just the first patch that allows my case to build. (some big code generated by flambda on ocamlbuild's pack).
