### PR TITLE
Local exception

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ TYPING=typing/ident.cmo typing/path.cmo \
   typing/tast_mapper.cmo \
   typing/cmt_format.cmo \
   typing/includemod.cmo typing/typetexp.cmo typing/parmatch.cmo \
-  typing/stypes.cmo typing/typecore.cmo \
-  typing/typedecl.cmo typing/typeclass.cmo \
+  typing/stypes.cmo typing/typedecl.cmo typing/typecore.cmo \
+  typing/typeclass.cmo \
   typing/typemod.cmo typing/untypeast.cmo
 
 COMP=bytecomp/lambda.cmo bytecomp/printlambda.cmo \

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -57,8 +57,8 @@ TYPING=typing/ident.cmo typing/path.cmo \
   typing/tast_mapper.cmo \
   typing/cmt_format.cmo \
   typing/includemod.cmo typing/typetexp.cmo typing/parmatch.cmo \
-  typing/stypes.cmo typing/typecore.cmo \
-  typing/typedecl.cmo typing/typeclass.cmo \
+  typing/stypes.cmo typing/typedecl.cmo typing/typecore.cmo \
+  typing/typeclass.cmo \
   typing/typemod.cmo typing/untypeast.cmo
 
 COMP=bytecomp/lambda.cmo bytecomp/printlambda.cmo \

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -126,6 +126,9 @@ type primitive =
   (* Integer to external pointer *)
   | Pint_as_pointer
 
+  (* Marker for static exception *)
+  | Pstatic_exn of Location.t
+
 and comparison =
     Ceq | Cneq | Clt | Cgt | Cle | Cge
 

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -126,6 +126,9 @@ type primitive =
   (* Integer to external pointer *)
   | Pint_as_pointer
 
+  (* Marker for static exception *)
+  | Pstatic_exn of Location.t
+
 and comparison =
     Ceq | Cneq | Clt | Cgt | Cle | Cge
 

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -245,6 +245,7 @@ let primitive ppf = function
   | Pbswap16 -> fprintf ppf "bswap16"
   | Pbbswap(bi) -> print_boxed_integer "bswap" ppf bi
   | Pint_as_pointer -> fprintf ppf "int_as_pointer"
+  | Pstatic_exn _ -> fprintf ppf "static_exn"
 
 let rec lam ppf = function
   | Lvar id ->

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -689,7 +689,8 @@ let rec handler_for local raised tag_ids = function
 
 let rec static id lam =
   match lam with
-  | Ltrywith(body, v, Lstaticcatch(e1, i, e2)) ->
+  | Ltrywith(body, v, Lstaticcatch(e1, i, e2))
+    when not (IdentSet.mem v (free_variables e2)) ->
       (* When multiple handlers in the try...with blocks have the same
          action (or or-pattern are used), they can be shared with a staticcatch.
          Let's put the staticcatch handler out of the trywith to simplify

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -761,6 +761,15 @@ let rec simplify_local_raises l =
       begin try check id (static id scope)
       with CanEscape -> l
       end
+  | Lprim(Pstatic_exn loc,
+          [Llet(Strict, id,
+                Lprim(Pccall{Primitive.prim_name = "caml_set_oo_id"}, _),
+               scope) as l0]) ->
+      begin try check id (static id scope)
+      with CanEscape ->
+        Location.prerr_warning loc Warnings.Exception_not_static;
+        l0
+      end
   | _ -> l
 
 

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -656,8 +656,11 @@ exception CanEscape
    by removing the part for the local exception. *)
 
 let rec handler_for local raised = function
-  | Lifthenelse(Lprim(Pintcomp Ceq, [Lvar v; exn]) as comp, body, rest)
-  | Lifthenelse(Lprim(Pintcomp Ceq, [Lprim(Pfield 0, [Lvar v]); exn]) as comp, body, rest)
+  | Lifthenelse
+      (Lprim
+         (Pintcomp Ceq, [Lvar v | Lprim(Pfield 0, [Lvar v]); exn]) as comp,
+       body, rest
+      )
     when Ident.same raised v ->
       begin match exn with
       | Lvar v when Ident.same local v ->

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -911,8 +911,14 @@ and transl_exp0 e =
   | Texp_letmodule(id, _, modl, body) ->
       Llet(Strict, id, !transl_module Tcoerce_none None modl, transl_exp body)
   | Texp_letexception(cd, body) ->
-      Llet(Strict, cd.ext_id, transl_extension_constructor e.exp_env None cd,
-           transl_exp body)
+      let exn = transl_extension_constructor e.exp_env None cd  in
+      let r = Llet(Strict, cd.ext_id, exn, transl_exp body) in
+      if Attr_helper.has_no_payload_attribute ["static"; "ocaml.static"]
+          cd.ext_attributes
+      || Attr_helper.has_no_payload_attribute ["static"; "ocaml.static"]
+           e.exp_attributes
+      then Lprim(Pstatic_exn e.exp_loc, [r])
+      else r
   | Texp_pack modl ->
       !transl_module Tcoerce_none None modl
   | Texp_assert {exp_desc=Texp_construct(_, {cstr_name="false"}, _)} ->

--- a/bytecomp/translcore.mli
+++ b/bytecomp/translcore.mli
@@ -25,6 +25,9 @@ val transl_let: rec_flag -> value_binding list -> lambda -> lambda
 val transl_primitive: Location.t -> Primitive.description -> Env.t
                       -> Types.type_expr -> lambda
 
+val transl_extension_constructor: Env.t -> Path.t option ->
+  extension_constructor -> lambda
+
 val check_recursive_lambda: Ident.t list -> lambda -> bool
 
 type error =

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -45,24 +45,6 @@ let field_path path field =
 
 (* Compile type extensions *)
 
-let prim_set_oo_id =
-  Pccall (Primitive.simple ~name:"caml_set_oo_id" ~arity:1 ~alloc:false)
-
-let transl_extension_constructor env path ext =
-  let name =
-    match path with
-      None -> Ident.name ext.ext_id
-    | Some p -> Path.name p
-  in
-  match ext.ext_kind with
-    Text_decl(args, ret) ->
-      Lprim(prim_set_oo_id,
-            [Lprim(Pmakeblock(Obj.object_tag, Mutable),
-                   [Lconst(Const_base(Const_string (name,None)));
-                    Lconst(Const_base(Const_int 0))])])
-  | Text_rebind(path, lid) ->
-      transl_path ~loc:ext.ext_loc env path
-
 let transl_type_extension env rootpath tyext body =
   List.fold_right
     (fun ext body ->

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -108,6 +108,7 @@ module Exp = struct
   let setinstvar ?loc ?attrs a b = mk ?loc ?attrs (Pexp_setinstvar (a, b))
   let override ?loc ?attrs a = mk ?loc ?attrs (Pexp_override a)
   let letmodule ?loc ?attrs a b c= mk ?loc ?attrs (Pexp_letmodule (a, b, c))
+  let letexception ?loc ?attrs a b = mk ?loc ?attrs (Pexp_letexception (a, b))
   let assert_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_assert a)
   let lazy_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_lazy a)
   let poly ?loc ?attrs a b = mk ?loc ?attrs (Pexp_poly (a, b))

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -133,6 +133,8 @@ module Exp:
                   -> expression
     val letmodule: ?loc:loc -> ?attrs:attrs -> str -> module_expr -> expression
                    -> expression
+    val letexception: ?loc:loc -> ?attrs:attrs -> extension_constructor -> expression
+      -> expression
     val assert_: ?loc:loc -> ?attrs:attrs -> expression -> expression
     val lazy_: ?loc:loc -> ?attrs:attrs -> expression -> expression
     val poly: ?loc:loc -> ?attrs:attrs -> expression -> core_type option

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -368,6 +368,10 @@ module E = struct
     | Pexp_letmodule (s, me, e) ->
         letmodule ~loc ~attrs (map_loc sub s) (sub.module_expr sub me)
           (sub.expr sub e)
+    | Pexp_letexception (cd, e) ->
+        letexception ~loc ~attrs
+          (sub.extension_constructor sub cd)
+          (sub.expr sub e)
     | Pexp_assert e -> assert_ ~loc ~attrs (sub.expr sub e)
     | Pexp_lazy e -> lazy_ ~loc ~attrs (sub.expr sub e)
     | Pexp_poly (e, t) ->

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1243,7 +1243,8 @@ expr:
       { expr_of_let_bindings $1 $3 }
   | LET MODULE ext_attributes UIDENT module_binding_body IN seq_expr
       { mkexp_attrs (Pexp_letmodule(mkrhs $4 4, $5, $7)) $3 }
-  | LET EXCEPTION ext_attributes constr_ident generalized_constructor_arguments attributes IN seq_expr
+  | LET EXCEPTION ext_attributes constr_ident generalized_constructor_arguments
+    attributes IN seq_expr
       { let args, res = $5 in
         let ex =
           Te.decl (mkrhs $4 4) ~args ?res ~attrs:$6

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1243,6 +1243,14 @@ expr:
       { expr_of_let_bindings $1 $3 }
   | LET MODULE ext_attributes UIDENT module_binding_body IN seq_expr
       { mkexp_attrs (Pexp_letmodule(mkrhs $4 4, $5, $7)) $3 }
+  | LET EXCEPTION ext_attributes constr_ident generalized_constructor_arguments attributes IN seq_expr
+      { let args, res = $5 in
+        let ex =
+          Te.decl (mkrhs $4 4) ~args ?res ~attrs:$6
+            ~loc:(symbol_rloc())
+        in
+        mkexp_attrs (Pexp_letexception(ex, $8)) $3
+      }
   | LET OPEN override_flag ext_attributes mod_longident IN seq_expr
       { mkexp_attrs (Pexp_open($3, mkrhs $5 5, $7)) $4 }
   | FUNCTION ext_attributes opt_bar match_cases

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -294,6 +294,8 @@ and expression_desc =
         (* {< x1 = E1; ...; Xn = En >} *)
   | Pexp_letmodule of string loc * module_expr * expression
         (* let module M = ME in E *)
+  | Pexp_letexception of extension_constructor * expression
+        (* let exception C in E *)
   | Pexp_assert of expression
         (* assert E
            Note: "assert false" is treated in a special way by the

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -610,8 +610,10 @@ class printer  ()= object(self:'self)
     | Pexp_letmodule (s, me, e) ->
         pp f "@[<hov2>let@ module@ %s@ =@ %a@ in@ %a@]" s.txt
           self#reset#module_expr me  self#expression e
-    | Pexp_letexception  _ ->
-        assert false (* TODO *)
+    | Pexp_letexception (cd, e) ->
+        pp f "@[<hov2>let@ exception@ %a@ in@ %a@]"
+          self#extension_constructor cd
+          self#expression e
     | Pexp_assert e ->
         pp f "@[<hov2>assert@ %a@]" self#simple_expr e
     | Pexp_lazy (e) ->

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -515,7 +515,7 @@ class printer  ()= object(self:'self)
         self#paren true self#reset#expression f x
     | Pexp_ifthenelse _ | Pexp_sequence _ when ifthenelse ->
         self#paren true self#reset#expression f x
-    | Pexp_let _ | Pexp_letmodule _ when semi ->
+    | Pexp_let _ | Pexp_letmodule _ | Pexp_letexception _ when semi ->
         self#paren true self#reset#expression f x
     | Pexp_fun (l, e0, p, e) ->
         pp f "@[<2>fun@;%a@;->@;%a@]"
@@ -610,6 +610,8 @@ class printer  ()= object(self:'self)
     | Pexp_letmodule (s, me, e) ->
         pp f "@[<hov2>let@ module@ %s@ =@ %a@ in@ %a@]" s.txt
           self#reset#module_expr me  self#expression e
+    | Pexp_letexception  _ ->
+        assert false (* TODO *)
     | Pexp_assert e ->
         pp f "@[<hov2>assert@ %a@]" self#simple_expr e
     | Pexp_lazy (e) ->

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -337,6 +337,10 @@ and expression i ppf x =
       line i ppf "Pexp_letmodule %a\n" fmt_string_loc s;
       module_expr i ppf me;
       expression i ppf e;
+  | Pexp_letexception (cd, e) ->
+      line i ppf "Pexp_letexception\n";
+      extension_constructor i ppf cd;
+      expression i ppf e;
   | Pexp_assert (e) ->
       line i ppf "Pexp_assert\n";
       expression i ppf e;

--- a/testsuite/tests/warnings/w53.ml
+++ b/testsuite/tests/warnings/w53.ml
@@ -87,8 +87,8 @@ let f7 x =
 
 
 let f8 x =
+  let exception[@static] Foo in (* ok *)
   let exception[@static] Ret of bool * int in (* bad *)
-  let exception[@static] Foo in (* bad, but could be turned into static exn *)
   let r = ref 0 in
   try
     for _i = 1 to 10000 do

--- a/testsuite/tests/warnings/w53.ml
+++ b/testsuite/tests/warnings/w53.ml
@@ -43,3 +43,65 @@ let f5 i =
     with E | F | Exit -> 0
        | Not_found -> 1
        | G (x, y) -> x + y
+
+
+(* ok *)
+let f6 x =
+  let exception[@static] Ret of bool * int in
+  let r = ref 0 in
+  try
+    for _i = 1 to 10000 do
+      r := !r + x;
+      if !r > 1000 then raise (Ret (true, !r));
+
+      r := !r + x;
+      if !r > 1000 then raise (Ret (false, !r));
+    done;
+    !r
+  with
+  | Ret (true, x) -> x
+  | Ret (false, x) -> x
+
+
+(* ok *)
+let f7 x =
+  let exception[@static] Ret of bool * int in
+  let exception[@static] Foo in
+  let r = ref 0 in
+  try
+    for _i = 1 to 10000 do
+      r := !r + x;
+      if !r > 1000 then raise (Ret (true, !r));
+
+      r := !r + x;
+      if !r > 1000 then raise (Ret (false, !r));
+
+      if !r = 200 then raise Foo;
+      if !r = 100 then raise Exit;
+    done;
+    !r
+  with
+  | Ret (true, x) -> x
+  | Ret (false, x) -> -x
+  | Foo | Exit -> 42
+
+
+let f8 x =
+  let exception[@static] Ret of bool * int in (* bad *)
+  let exception[@static] Foo in (* bad, but could be turned into static exn *)
+  let r = ref 0 in
+  try
+    for _i = 1 to 10000 do
+      r := !r + x;
+      if !r > 1000 then raise (Ret (true, !r));
+
+      r := !r + x;
+      if !r > 1000 then raise (Ret (false, !r));
+
+      if !r = 200 then raise Foo;
+      if !r = 100 then raise Exit;
+    done;
+    !r
+  with
+  | Ret (true, x) -> x
+  | Foo | Exit -> 42

--- a/testsuite/tests/warnings/w53.ml
+++ b/testsuite/tests/warnings/w53.ml
@@ -1,0 +1,45 @@
+(* bad *)
+let f1 () =
+  let exception[@static] E in
+  E
+
+
+(* ok *)
+let f2 () =
+  let exception[@static] E in
+  try raise E
+  with E -> ()
+
+
+(* ok *)
+let f3 () =
+  let exception[@static] E in
+  fun () ->
+    try raise E
+    with E -> ()
+
+
+(* bad *)
+let f4 () =
+  let exception[@static] E in
+  try
+    fun () -> raise E
+  with E -> fun () -> ()
+
+
+(* ok *)
+let f5 i =
+  let exception[@static] E in
+  let exception[@static] F in
+  let exception[@static] G of int * int in
+  fun () ->
+    try
+      if i = 1 then raise E
+      else if i = 2 then raise Exit
+      else if i = 3 then raise Not_found
+      else if i = 4 then raise F
+      else if i = 5 then raise (G (40, 2))
+      else i
+    with E | F | Exit -> 0
+       | Not_found -> 1
+       | G (x, y) -> x + y

--- a/testsuite/tests/warnings/w53.reference
+++ b/testsuite/tests/warnings/w53.reference
@@ -1,0 +1,4 @@
+File "w53.ml", line 24, characters 2-85:
+Warning 53: this exception is not static
+File "w53.ml", line 3, characters 2-34:
+Warning 53: this exception is not static

--- a/testsuite/tests/warnings/w53.reference
+++ b/testsuite/tests/warnings/w53.reference
@@ -1,3 +1,7 @@
+File "w53.ml", line 92, characters 2-373:
+Warning 53: this exception is not static
+File "w53.ml", line 91, characters 2-420:
+Warning 53: this exception is not static
 File "w53.ml", line 24, characters 2-85:
 Warning 53: this exception is not static
 File "w53.ml", line 3, characters 2-34:

--- a/testsuite/tests/warnings/w53.reference
+++ b/testsuite/tests/warnings/w53.reference
@@ -1,6 +1,4 @@
-File "w53.ml", line 92, characters 2-373:
-Warning 53: this exception is not static
-File "w53.ml", line 91, characters 2-420:
+File "w53.ml", line 91, characters 2-397:
 Warning 53: this exception is not static
 File "w53.ml", line 24, characters 2-85:
 Warning 53: this exception is not static

--- a/tools/depend.ml
+++ b/tools/depend.ml
@@ -192,6 +192,7 @@ let rec add_expr bv exp =
   | Pexp_override sel -> List.iter (fun (_s, e) -> add_expr bv e) sel
   | Pexp_letmodule(id, m, e) ->
       add_module bv m; add_expr (StringSet.add id.txt bv) e
+  | Pexp_letexception(_, e) -> add_expr bv e
   | Pexp_assert (e) -> add_expr bv e
   | Pexp_lazy (e) -> add_expr bv e
   | Pexp_poly (e, t) -> add_expr bv e; add_opt add_type bv t

--- a/tools/ocamlprof.ml
+++ b/tools/ocamlprof.ml
@@ -281,6 +281,9 @@ and rw_exp iflag sexp =
       rewrite_mod iflag smod;
       rewrite_exp iflag sexp
 
+  | Pexp_letexception (_cd, exp) ->
+      rewrite_exp iflag exp
+
   | Pexp_assert (cond) -> rewrite_exp iflag cond
 
   | Pexp_lazy (expr) -> rewrite_exp iflag expr

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -359,6 +359,10 @@ and expression i ppf x =
       line i ppf "Texp_letmodule \"%a\"\n" fmt_ident s;
       module_expr i ppf me;
       expression i ppf e;
+  | Texp_letexception (cd, e) ->
+      line i ppf "Pexp_letexception\n";
+      extension_constructor i ppf cd;
+      expression i ppf e;
   | Texp_assert (e) ->
       line i ppf "Texp_assert";
       expression i ppf e;

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -320,6 +320,11 @@ let expr sub x =
           sub.module_expr sub mexpr,
           sub.expr sub exp
         )
+    | Texp_letexception (cd, exp) ->
+        Texp_letexception (
+          sub.extension_constructor sub cd,
+          sub.expr sub exp
+        )
     | Texp_assert exp ->
         Texp_assert (sub.expr sub exp)
     | Texp_lazy exp ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -158,6 +158,7 @@ let iter_expression f e =
     | Pexp_send (e, _)
     | Pexp_constraint (e, _)
     | Pexp_coerce (e, _, _)
+    | Pexp_letexception (_, e)
     | Pexp_field (e, _) -> expr e
     | Pexp_while (e1, e2)
     | Pexp_sequence (e1, e2)
@@ -2588,6 +2589,16 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
         exp_type = ty;
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
+  | Pexp_letexception(cd, sbody) ->
+      let (cd, newenv) = Typedecl.transl_exception env cd in
+      let body = type_expect newenv sbody ty_expected in
+      re {
+        exp_desc = Texp_letexception(cd, body);
+        exp_loc = loc; exp_extra = [];
+        exp_type = body.exp_type;
+        exp_attributes = sexp.pexp_attributes;
+        exp_env = env }
+
   | Pexp_assert (e) ->
       let cond = type_expect env e Predef.type_bool in
       let exp_type =

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -101,6 +101,7 @@ and expression_desc =
   | Texp_setinstvar of Path.t * Path.t * string loc * expression
   | Texp_override of Path.t * (Path.t * string loc * expression) list
   | Texp_letmodule of Ident.t * string loc * module_expr * expression
+  | Texp_letexception of extension_constructor * expression
   | Texp_assert of expression
   | Texp_lazy of expression
   | Texp_object of class_structure * string list

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -100,6 +100,7 @@ and expression_desc =
   | Texp_setinstvar of Path.t * Path.t * string loc * expression
   | Texp_override of Path.t * (Path.t * string loc * expression) list
   | Texp_letmodule of Ident.t * string loc * module_expr * expression
+  | Texp_letexception of extension_constructor * expression
   | Texp_assert of expression
   | Texp_lazy of expression
   | Texp_object of class_structure * string list

--- a/typing/typedtreeIter.ml
+++ b/typing/typedtreeIter.ml
@@ -339,6 +339,9 @@ module MakeIterator(Iter : IteratorArgument) : sig
         | Texp_letmodule (id, _, mexpr, exp) ->
             iter_module_expr mexpr;
             iter_expression exp
+        | Texp_letexception (cd, exp) ->
+            iter_extension_constructor cd;
+            iter_expression exp
         | Texp_assert exp -> iter_expression exp
         | Texp_lazy exp -> iter_expression exp
         | Texp_object (cl, _) ->

--- a/typing/typedtreeMap.ml
+++ b/typing/typedtreeMap.ml
@@ -368,6 +368,11 @@ module MakeMap(Map : MapArgument) = struct
             map_module_expr mexpr,
             map_expression exp
           )
+        | Texp_letexception (cd, exp) ->
+          Texp_letexception (
+            map_extension_constructor cd,
+            map_expression exp
+          )
         | Texp_assert exp -> Texp_assert (map_expression exp)
         | Texp_lazy exp -> Texp_lazy (map_expression exp)
         | Texp_object (cl, string_list) ->

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -438,6 +438,9 @@ let expression sub exp =
     | Texp_letmodule (_id, name, mexpr, exp) ->
         Pexp_letmodule (name, sub.module_expr sub mexpr,
           sub.expr sub exp)
+    | Texp_letexception (ext, exp) ->
+        Pexp_letexception (sub.extension_constructor sub ext,
+                           sub.expr sub exp)
     | Texp_assert exp -> Pexp_assert (sub.expr sub exp)
     | Texp_lazy exp -> Pexp_lazy (sub.expr sub exp)
     | Texp_object (cl, _) ->

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -70,6 +70,7 @@ type t =
   | Bad_docstring of bool                   (* 50 *)
   | Expect_tailcall                         (* 51 *)
   | Fragile_literal_pattern                 (* 52 *)
+  | Exception_not_static                    (* 53 *)
 ;;
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
@@ -131,9 +132,10 @@ let number = function
   | Bad_docstring _ -> 50
   | Expect_tailcall -> 51
   | Fragile_literal_pattern -> 52
+  | Exception_not_static -> 53
 ;;
 
-let last_warning_number = 52
+let last_warning_number = 53
 (* Must be the max number returned by the [number] function. *)
 
 let letter = function
@@ -403,6 +405,8 @@ let message = function
       Printf.sprintf "the argument of this constructor should not be matched against a \
                       constant pattern; the actual value of the argument could change \
                       in the future"
+  | Exception_not_static ->
+      "this exception is not static"
 ;;
 
 let nerrors = ref 0;;
@@ -490,6 +494,7 @@ let descriptions =
    50, "Unexpected documentation comment.";
    51, "Warning on non-tail calls if @tailcall present.";
    52, "Fragile constant pattern.";
+   54, "Local exception marked with @static is not static."
   ]
 ;;
 

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -494,7 +494,7 @@ let descriptions =
    50, "Unexpected documentation comment.";
    51, "Warning on non-tail calls if @tailcall present.";
    52, "Fragile constant pattern.";
-   54, "Local exception marked with @static is not static."
+   53, "Local exception marked with @static is not static."
   ]
 ;;
 

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -65,6 +65,7 @@ type t =
   | Bad_docstring of bool                   (* 50 *)
   | Expect_tailcall                         (* 51 *)
   | Fragile_literal_pattern                 (* 52 *)
+  | Exception_not_static                    (* 53 *)
 ;;
 
 val parse_options : bool -> string -> unit;;


### PR DESCRIPTION
This is a follow up to http://caml.inria.fr/mantis/view.php?id=5879 .  More specially, this is an updated version of the local_exn.diff patch submitted there.

Expressions are extended with local exception definition:

```
  let exception C of .... in
  ...
```

This can be useful in itself when an exception is used for local control flow, and is not intended to be used externally.

More interestingly, an optimization pass detects when the exception is used purely locally.  This means that the exception is only used in `raise` context, or pattern matched by a `try..with` or `match...with exception`;  moreover, each `raise` of the exception must be captured by a handler in the same function (both can be in a nested function, but they must be at the same level).    When it is the case, the exception cannot escape, and each it is trivial to associate to each `raise` its corresponding handler.  The exception is then translated to "staticraise/staticcatch" in the lambda intermediate language, which corresponds to jumps (and they can cross try...with boundaries).

All the optimization is implemented in simplif.ml, by reverse engineering the code compiled for generic `try...with` handler.  This can be fragile (e.g. the code is quite different in bytecode -g mode because other simplifications are disabled, which makes the detection harder), especially to detect cases where the same `try...with` handler matches both static and non-static exceptions.

An attribute `[@static]` or `[@ocaml.static]` can be used to get a warning when the local exception is not compiled to a static one:

```
  let exception[@static] C of int in ...
  let exception C of int [@static] in ...
```

In the Mantis ticket, I argued for a really new language construct to express these static exceptions.  The advantage was a potentially lighter syntax (no need to declare the jump labels), and more explicit guarantees (without requiring attributes).  As discussed on Mantis, it seems impossible to turn exceptions into static ones if they are not local, hence the introduction of a new language construct (local exceptions) here, but arguably, this one fits better in the current language design that "static exceptions".
