### PR TITLE
Fix PR6998

### DIFF
--- a/Changes
+++ b/Changes
@@ -237,6 +237,8 @@ Bug fixes:
            %s#row when Bar contains private row types
 - PR#6992: Segfault from bug in GADT/module typing
 - PR#6993: Segfault from recursive modules violating exhaustiveness assumptions
+- PR#6998: Typer fails reading unnecessary cmis with -no-alias-deps and -w -49
+  (Leo White, report by Valentin Gatien-Baron)
 - PR#7003: String.sub causes segmentation fault
   (Damien Doligez, report by Radek Micek)
 - PR#7008: Fatal error in ocamlc with empty compilation unit name

--- a/Changes
+++ b/Changes
@@ -1012,7 +1012,7 @@ Other libraries:
 Type system:
 - PR#5759: use well-disciplined type information propagation to
   disambiguate label and constructor names
-  (Jacques Garrigue, Alain Frisch and Leo P. White)
+  (Jacques Garrigue, Alain Frisch and Leo White)
 * Propagate type information towards pattern-matching, even in the presence of
   polymorphic variants (discarding only information about possibly-present
   constructors). As a result, matching against absent constructors is no longer
@@ -1061,7 +1061,7 @@ Compilers:
 - PR#5571: incorrect ordinal number in error message
   (Alain Frisch, report by John Carr)
 - PR#6073: add signature to Tstr_include
-  (patch by Leo P. White)
+  (patch by Leo White)
 
 Standard library:
 - PR#5899: expose a way to inspect the current call stack,
@@ -1235,7 +1235,7 @@ Bug fixes:
 - PR#5814: read_cmt -annot does not report internal references
   (Alain Frisch)
 - PR#5815: Multiple exceptions in signatures gives an error
-  (Leo P. White)
+  (Leo White)
 - PR#5816: read_cmt -annot does not work for partial .cmt files
   (Alain Frisch)
 - PR#5819: segfault when using [with] on large recursive record (ocamlopt)
@@ -1273,7 +1273,7 @@ Bug fixes:
 - PR#5891: ocamlbuild: support rectypes tag for mlpack
   (Khoo Yit Phang)
 - PR#5892: GADT exhaustiveness check is broken
-  (Jacques Garrigue and Leo P. White)
+  (Jacques Garrigue and Leo White)
 - PR#5906: GADT exhaustiveness check is still broken
   (Jacques Garrigue, report by Sébastien Briais)
 - PR#5907: Undetected cycle during typecheck causes exceptions
@@ -1301,7 +1301,7 @@ Bug fixes:
 - PR#5945: Mix-up of Minor_heap_min and Minor_heap_max units
   (Benoît Vaugon)
 - PR#5948: GADT with polymorphic variants bug
-  (Jacques Garrigue, report by Leo P. White)
+  (Jacques Garrigue, report by Leo White)
 - PR#5953: Unix.system does not handle EINTR
   (Jérémie Dimino)
 - PR#5965: disallow auto-reference to a recursive module in its definition
@@ -1319,13 +1319,13 @@ Bug fixes:
 - PR#5982: caml_leave_blocking section and errno corruption
   (Jérémie Dimino)
 - PR#5985: Unexpected interaction between variance and GADTs
-  (Jacques Garrigue, Jeremy Yallop and Leo P. White and Gabriel Scherer)
+  (Jacques Garrigue, Jeremy Yallop and Leo White and Gabriel Scherer)
 - PR#5988: missing from the documentation: -impl is a valid flag for ocamlopt
   (Damien Doligez, report by Vincent Bernardoff)
 - PR#5989: Assumed inequalities involving private rows
   (Jacques Garrigue, report by Jeremy Yallop)
 - PR#5992: Crash when pattern-matching lazy values modifies the scrutinee
-  (Luc Maranget, Leo P. White)
+  (Luc Maranget, Leo White)
 - PR#5993: Variance of private type abbreviations not checked for modules
   (Jacques Garrigue)
 - PR#5997: Non-compatibility assumed for concrete types with same constructor
@@ -1371,7 +1371,7 @@ Bug fixes:
 - PR#6158: Fatal error using GADTs
   (Jacques Garrigue, report by Jeremy Yallop)
 - PR#6163: Assert_failure using polymorphic variants in GADTs
-  (Jacques Garrigue, report by Leo P. White)
+  (Jacques Garrigue, report by Leo White)
 - PR#6164: segmentation fault on Num.power_num of 0/1
   (Fabrice Le Fessant, report by Johannes Kanig)
 - PR#6210: Camlp4 location error

--- a/testsuite/makefiles/Makefile.common
+++ b/testsuite/makefiles/Makefile.common
@@ -67,7 +67,8 @@ OCAMLMKLIB=$(OCAMLRUN) $(OTOPDIR)/tools/ocamlmklib \
 		                  $(OTOPDIR)/ocamlopt $(OCFLAGS)"
 OCAMLYACC=$(TOPDIR)/yacc/ocamlyacc$(EXE)
 OCAMLBUILD=$(TOPDIR)/_build/ocamlbuild/ocamlbuild.native
-DUMPOBJ=$(OCAMLRUN) $(OTOPDIR)/tool/dumpobj
+DUMPOBJ=$(OCAMLRUN) $(OTOPDIR)/tools/dumpobj
+OBJINFO=$(OCAMLRUN) $(OTOPDIR)/tools/objinfo
 BYTECODE_ONLY=[ "$(ARCH)" = "none" -o "$(ASM)" = "none" ]
 NATIVECODE_ONLY=false
 

--- a/testsuite/tests/no-alias-deps/Makefile
+++ b/testsuite/tests/no-alias-deps/Makefile
@@ -1,0 +1,34 @@
+#########################################################################
+#                                                                       #
+#                                 OCaml                                 #
+#                                                                       #
+#                 Xavier Clerc, SED, INRIA Rocquencourt                 #
+#                                                                       #
+#   Copyright 2010 Institut National de Recherche en Informatique et    #
+#   en Automatique.  All rights reserved.  This file is distributed     #
+#   under the terms of the Q Public License version 1.0.                #
+#                                                                       #
+#########################################################################
+
+default: b.cmi c.cmi d.cmi aliases.ml
+	@$(OCAMLC) -c aliases.ml > aliases.ml.result 2>&1 || true
+	@$(OBJINFO) aliases.cmo | \
+	  sed -e "s/[a-f0-9]\{32\}/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/g" \
+	  > aliases.cmo.result 2>&1 || true
+	@for file in *.reference; do \
+	  printf " ... testing '$$file':"; \
+	  $(DIFF) $$file `basename $$file reference`result >/dev/null \
+          && echo " => passed" || echo " => failed"; \
+	done
+
+promote: defaultpromote
+
+clean: defaultclean
+	@rm -f *.result
+
+b.cmi: b.cmi.pre
+	cp b.cmi.pre b.cmi
+
+BASEDIR=../..
+include $(BASEDIR)/makefiles/Makefile.common
+COMPFLAGS = -no-alias-deps

--- a/testsuite/tests/no-alias-deps/aliases.cmo.reference
+++ b/testsuite/tests/no-alias-deps/aliases.cmo.reference
@@ -1,0 +1,12 @@
+File aliases.cmo
+Unit name: Aliases
+Interfaces imported:
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	Pervasives
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	D
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	CamlinternalFormatBasics
+	--------------------------------	C
+	--------------------------------	B
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	Aliases
+	--------------------------------	A
+Uses unsafe features: no
+Force link: no

--- a/testsuite/tests/no-alias-deps/aliases.ml
+++ b/testsuite/tests/no-alias-deps/aliases.ml
@@ -1,0 +1,5 @@
+module A' = A (* missing a.cmi *)
+module B' = B (* broken b.cmi *)
+module C' = C (* valid c.cmi *)
+module D' = D (* valid d.cmi *)
+let () = print_int D'.something

--- a/testsuite/tests/no-alias-deps/aliases.ml.reference
+++ b/testsuite/tests/no-alias-deps/aliases.ml.reference
@@ -1,0 +1,5 @@
+File "_none_", line 1:
+Warning 49: no cmi file was found in path for module A
+File "_none_", line 1:
+Warning 49: no valid cmi file was found in path for module B. b.cmi
+is not a compiled interface

--- a/testsuite/tests/no-alias-deps/b.cmi.pre
+++ b/testsuite/tests/no-alias-deps/b.cmi.pre
@@ -1,0 +1,1 @@
+Not a valid cmi file

--- a/testsuite/tests/no-alias-deps/c.mli
+++ b/testsuite/tests/no-alias-deps/c.mli
@@ -1,0 +1,1 @@
+val something : int

--- a/testsuite/tests/no-alias-deps/d.mli
+++ b/testsuite/tests/no-alias-deps/d.mli
@@ -1,0 +1,1 @@
+val something : int

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -297,12 +297,11 @@ type pers_struct =
     ps_sig: signature Lazy.t;
     ps_comps: module_components;
     ps_crcs: (string * Digest.t option) list;
-    mutable ps_crcs_checked: bool;
     ps_filename: string;
     ps_flags: pers_flags list }
 
 let persistent_structures =
-  (Hashtbl.create 17 : (string, pers_struct option) Hashtbl.t)
+  (Hashtbl.create 17 : (string, pers_struct) Hashtbl.t)
 
 (* Consistency between persistent structures *)
 
@@ -321,7 +320,6 @@ let clear_imports () =
   imported_units := StringSet.empty
 
 let check_consistency ps =
-  if not ps.ps_crcs_checked then
   try
     List.iter
       (fun (name, crco) ->
@@ -331,7 +329,6 @@ let check_consistency ps =
               add_import name;
               Consistbl.check crc_units name crc ps.ps_filename)
       ps.ps_crcs;
-    ps.ps_crcs_checked <- true;
   with Consistbl.Inconsistency(name, source, auth) ->
     error (Inconsistent_import(name, auth, source))
 
@@ -339,11 +336,12 @@ let check_consistency ps =
 
 let save_pers_struct crc ps =
   let modname = ps.ps_name in
-  Hashtbl.add persistent_structures modname (Some ps);
+  Hashtbl.add persistent_structures modname ps;
   Consistbl.set crc_units modname crc ps.ps_filename;
   add_import modname
 
-let read_pers_struct modname filename =
+let read_pers_struct check modname filename =
+  add_import modname;
   let cmi = read_cmi filename in
   let name = cmi.cmi_name in
   let sign = cmi.cmi_sign in
@@ -360,44 +358,72 @@ let read_pers_struct modname filename =
              ps_crcs = crcs;
              ps_filename = filename;
              ps_flags = flags;
-             ps_crcs_checked = false;
            } in
   if ps.ps_name <> modname then
     error (Illegal_renaming(modname, ps.ps_name, filename));
-  add_import name;
   List.iter
     (function Rectypes ->
       if not !Clflags.recursive_types then
         error (Need_recursive_types(ps.ps_name, !current_unit)))
     ps.ps_flags;
-  Hashtbl.add persistent_structures modname (Some ps);
+  if check then check_consistency ps;
+  Hashtbl.add persistent_structures modname ps;
   ps
 
-let find_pers_struct ?(check=true) name =
+let find_pers_struct check name =
   if name = "*predef*" then raise Not_found;
-  let r =
-    try Some (Hashtbl.find persistent_structures name)
-    with Not_found -> None
-  in
-  let ps =
-    match r with
-    | Some None -> raise Not_found
-    | Some (Some sg) -> sg
-    | None ->
-       (* PR#6843: record the weak dependency ([add_import]) even if
-          the [find_in_path_uncap] call below fails to find the .cmi,
-          to help make builds more deterministic. *)
-        add_import name;
-        let filename =
-          try find_in_path_uncap !load_path (name ^ ".cmi")
-          with Not_found ->
-            Hashtbl.add persistent_structures name None;
-            raise Not_found
-        in
-        read_pers_struct name filename
-  in
-  if check then check_consistency ps;
-  ps
+  try
+    Hashtbl.find persistent_structures name
+  with Not_found ->
+    let filename = find_in_path_uncap !load_path (name ^ ".cmi") in
+    read_pers_struct check name filename
+
+(* Emits a warning if there is no valid cmi for name *)
+let check_pers_struct name =
+  match find_pers_struct false name with
+  | _ -> ()
+  | exception Not_found ->
+      let warn = Warnings.No_cmi_file(name, None) in
+        Location.prerr_warning Location.none warn
+  | exception Cmi_format.Error err ->
+      let msg = Format.asprintf "%a" Cmi_format.report_error err in
+      let warn = Warnings.No_cmi_file(name, Some msg) in
+        Location.prerr_warning Location.none warn
+  | exception Error err ->
+      let msg =
+        match err with
+        | Illegal_renaming(name, ps_name, filename) ->
+            Format.asprintf
+              " %a@ contains the compiled interface for @ \
+               %s when %s was expected"
+              Location.print_filename filename ps_name name
+        | Inconsistent_import _ -> assert false
+        | Need_recursive_types(name, _) ->
+            Format.sprintf
+              "%s uses recursive types"
+              name
+        | Missing_module _ -> assert false
+        | Illegal_value_name _ -> assert false
+      in
+      let warn = Warnings.No_cmi_file(name, Some msg) in
+        Location.prerr_warning Location.none warn
+
+let read_pers_struct modname filename =
+  read_pers_struct true modname filename
+
+let find_pers_struct name =
+  find_pers_struct true name
+
+let check_pers_struct name =
+  if not (Hashtbl.mem persistent_structures name) then begin
+    (* PR#6843: record the weak dependency ([add_import]) regardless of
+       whether the check suceeds, to help make builds more
+       deterministic. *)
+    add_import name;
+    if (Warnings.is_active (Warnings.No_cmi_file("", None))) then
+      !add_delayed_check_forward
+        (fun () -> check_pers_struct name)
+  end
 
 let reset_cache () =
   current_unit := "";
@@ -412,7 +438,7 @@ let reset_cache_toplevel () =
   (* Delete 'missing cmi' entries from the cache. *)
   let l =
     Hashtbl.fold
-      (fun name r acc -> if r = None then name :: acc else acc)
+      (fun name r acc -> name :: acc)
       persistent_structures []
   in
   List.iter (Hashtbl.remove persistent_structures) l;
@@ -724,10 +750,7 @@ and lookup_module ~load lid env : Path.t =
         p
       with Not_found ->
         if s = !current_unit then raise Not_found;
-        if !Clflags.transparent_modules && not load then
-          try ignore (find_pers_struct ~check:false s)
-          with Not_found ->
-            Location.prerr_warning Location.none (Warnings.No_cmi_file s)
+        if !Clflags.transparent_modules && not load then check_pers_struct s
         else ignore (find_pers_struct s);
         Pident(Ident.create_persistent s)
       end
@@ -996,11 +1019,9 @@ let iter_env proj1 proj2 f env () =
     in iter_env_cont := (path, cont) :: !iter_env_cont
   in
   Hashtbl.iter
-    (fun s pso ->
-      match pso with None -> ()
-      | Some ps ->
-          let id = Pident (Ident.create_persistent s) in
-          iter_components id id ps.ps_comps)
+    (fun s ps ->
+       let id = Pident (Ident.create_persistent s) in
+       iter_components id id ps.ps_comps)
     persistent_structures;
   Ident.iter
     (fun id ((path, comps), _) -> iter_components (Pident id) path comps)
@@ -1020,7 +1041,7 @@ let same_types env1 env2 =
 
 let used_persistent () =
   let r = ref Concr.empty in
-  Hashtbl.iter (fun s pso -> if pso != None then r := Concr.add s !r)
+  Hashtbl.iter (fun s ps -> r := Concr.add s !r)
     persistent_structures;
   !r
 
@@ -1643,7 +1664,6 @@ let open_signature ?(loc = Location.none) ?(toplevel = false) ovf root sg env =
 
 let read_signature modname filename =
   let ps = read_pers_struct modname filename in
-  check_consistency ps;
   Lazy.force ps.ps_sig
 
 (* Return the CRC of the interface of the given compilation unit *)
@@ -1662,7 +1682,7 @@ let crc_of_unit name =
 
 (* Return the list of imported interfaces with their CRCs *)
 
-let imports() =
+let imports () =
   Consistbl.extract (StringSet.elements !imported_units) crc_units
 
 (* Save a signature to a file *)
@@ -1695,7 +1715,6 @@ let save_signature_with_imports sg modname filename imports =
         ps_crcs = (cmi.cmi_name, Some crc) :: imports;
         ps_filename = filename;
         ps_flags = cmi.cmi_flags;
-        ps_crcs_checked = false;
       } in
     save_pers_struct crc ps;
     sg
@@ -1758,11 +1777,8 @@ let fold_modules f lid env acc =
       in
       Hashtbl.fold
         (fun name ps acc ->
-          match ps with
-              None -> acc
-            | Some ps ->
-              f name (Pident(Ident.create_persistent name))
-                     (md (Mty_signature (Lazy.force ps.ps_sig))) acc)
+           f name (Pident(Ident.create_persistent name))
+             (md (Mty_signature (Lazy.force ps.ps_sig))) acc)
         persistent_structures
         acc
     | Some l ->

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -387,16 +387,17 @@ let find_pers_struct check name =
 
 (* Emits a warning if there is no valid cmi for name *)
 let check_pers_struct name =
-  match find_pers_struct false name with
-  | _ -> ()
-  | exception Not_found ->
+  try
+    ignore (find_pers_struct false name)
+  with
+  | Not_found ->
       let warn = Warnings.No_cmi_file(name, None) in
         Location.prerr_warning Location.none warn
-  | exception Cmi_format.Error err ->
+  | Cmi_format.Error err ->
       let msg = Format.asprintf "%a" Cmi_format.report_error err in
       let warn = Warnings.No_cmi_file(name, Some msg) in
         Location.prerr_warning Location.none warn
-  | exception Error err ->
+  | Error err ->
       let msg =
         match err with
         | Illegal_renaming(name, ps_name, filename) ->

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -66,7 +66,7 @@ type t =
   | Bad_env_variable of string * string     (* 46 *)
   | Attribute_payload of string * string    (* 47 *)
   | Eliminated_optional_arguments of string list (* 48 *)
-  | No_cmi_file of string                   (* 49 *)
+  | No_cmi_file of string * string option   (* 49 *)
   | Bad_docstring of bool                   (* 50 *)
   | Expect_tailcall                         (* 51 *)
   | Fragile_literal_pattern                 (* 52 *)
@@ -401,8 +401,12 @@ let message = function
       Printf.sprintf "implicit elimination of optional argument%s %s"
         (if List.length sl = 1 then "" else "s")
         (String.concat ", " sl)
-  | No_cmi_file s ->
-      "no cmi file was found in path for module " ^ s
+  | No_cmi_file(name, None) ->
+      "no cmi file was found in path for module " ^ name
+  | No_cmi_file(name, Some msg) ->
+      Printf.sprintf
+        "no valid cmi file was found in path for module %s. %s"
+        name msg
   | Bad_docstring unattached ->
       if unattached then "unattached documentation comment (ignored)"
       else "ambiguous documentation comment"

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -61,7 +61,7 @@ type t =
   | Bad_env_variable of string * string     (* 46 *)
   | Attribute_payload of string * string    (* 47 *)
   | Eliminated_optional_arguments of string list (* 48 *)
-  | No_cmi_file of string                   (* 49 *)
+  | No_cmi_file of string * string option   (* 49 *)
   | Bad_docstring of bool                   (* 50 *)
   | Expect_tailcall                         (* 51 *)
   | Fragile_literal_pattern                 (* 52 *)


### PR DESCRIPTION
This patch addresses [pr6998](http://caml.inria.fr/mantis/view.php?id=6998) by treating corrupted or incorrect cmi files as an instance of warning 49 (no cmi file for an alias) when they are only read for an alias. If warning 49 is disabled the cmi files are not even read.

To avoid having emitting gratuitous warning 49s for aliases which also cause errors later in the file (e.g. when that alias is used), we delay performing the check until the end of compilation.
