### PR TITLE
Improve the code generation for if equivalent to seqand or sequor

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2235,8 +2235,10 @@ and exit_if_true env cond nfail otherwise =
   match cond with
   | Uconst (Uconst_ptr 0) -> otherwise
   | Uconst (Uconst_ptr 1) -> Cexit (nfail,[])
+  | Uifthenelse (arg1, Uconst (Uconst_ptr 1), arg2)
   | Uprim(Psequor, [arg1; arg2], _) ->
       exit_if_true env arg1 nfail (exit_if_true env arg2 nfail otherwise)
+  | Uifthenelse (_, _, Uconst (Uconst_ptr 0))
   | Uprim(Psequand, _, _) ->
       begin match otherwise with
       | Cexit (raise_num,[]) ->
@@ -2265,8 +2267,10 @@ and exit_if_false env cond otherwise nfail =
   match cond with
   | Uconst (Uconst_ptr 0) -> Cexit (nfail,[])
   | Uconst (Uconst_ptr 1) -> otherwise
+  | Uifthenelse (arg1, arg2, Uconst (Uconst_ptr 0))
   | Uprim(Psequand, [arg1; arg2], _) ->
       exit_if_false env arg1 (exit_if_false env arg2 otherwise nfail) nfail
+  | Uifthenelse (_, Uconst (Uconst_ptr 1), _)
   | Uprim(Psequor, _, _) ->
       begin match otherwise with
       | Cexit (raise_num,[]) ->

--- a/testsuite/tests/basic-more/if_in_if.ml
+++ b/testsuite/tests/basic-more/if_in_if.ml
@@ -1,0 +1,41 @@
+
+let sequor b1 b2 =
+  let b1 = ref b1 in
+  let b2 = ref b2 in
+  let b1 = !b1 in
+  let b2 = !b2 in
+  if (if b1 then true else b2 && if b1 then true else b2) then "true" else "false"
+
+let sequand b1 b2 =
+  let b1 = ref b1 in
+  let b2 = ref b2 in
+  let b1 = !b1 in
+  let b2 = !b2 in
+  if (if b1 then b2 else false && if b1 then b2 else false) then "true" else "false"
+
+let sequor' b1 b2 =
+  let b1 = ref b1 in
+  let b2 = ref b2 in
+  let b1 = !b1 in
+  let b2 = !b2 in
+  if (if b1 then true else b2 || if b1 then true else b2) then "true" else "false"
+
+let sequand' b1 b2 =
+  let b1 = ref b1 in
+  let b2 = ref b2 in
+  let b1 = !b1 in
+  let b2 = !b2 in
+  if (if b1 then b2 else false || if b1 then b2 else false) then "true" else "false"
+
+let test b1 b2 =
+  assert(sequor b1 b2 = if b1 || b2 then "true" else "false");
+  assert(sequor' b1 b2 = if b1 || b2 then "true" else "false");
+  assert(sequand b1 b2 = if b1 && b2 then "true" else "false");
+  assert(sequand' b1 b2 = if b1 && b2 then "true" else "false")
+
+let () =
+  test false false;
+  test false true;
+  test true false;
+  test true true
+

--- a/testsuite/tests/basic-more/if_in_if.reference
+++ b/testsuite/tests/basic-more/if_in_if.reference
@@ -1,0 +1,2 @@
+
+All tests succeeded.


### PR DESCRIPTION
Some `if` based expressions are equivalent to the sequential `and` and `or` primitive. This patch allows them to benefit from the same optimizations in cmmgen.
- `if x then true else y` is equivalent to `x || y`
- `if x then y else false` is equivalent to `x && y`

In the flambda patch, we deconstruct the `Psequand` and `Psequor` primitives early to simplify the general handling of primitives, so this patch is required to avoid loosing the benefit of that optimization.
