### PR TITLE
Fix few reference files in the test suite

### DIFF
--- a/testsuite/tests/typing-gadts/pr5332.ml.reference
+++ b/testsuite/tests/typing-gadts/pr5332.ml.reference
@@ -10,5 +10,5 @@
      | _ -> .   (* error *)
        ^
 Error: This match case could not be refuted.
-       Here is an example of value that would reach it: (Tint, Tvar Zero)
+       Here is an example of a value that would reach it: (Tint, Tvar Zero)
 #     

--- a/testsuite/tests/typing-gadts/pr6163.ml.principal.reference
+++ b/testsuite/tests/typing-gadts/pr6163.ml.principal.reference
@@ -9,6 +9,6 @@
     | _ -> .  (* error *)
       ^
 Error: This match case could not be refuted.
-       Here is an example of value that would reach it:
+       Here is an example of a value that would reach it:
        Succ (Succ (Succ (Succ (Succ Zero))))
 # 

--- a/testsuite/tests/typing-gadts/pr6163.ml.reference
+++ b/testsuite/tests/typing-gadts/pr6163.ml.reference
@@ -9,6 +9,6 @@
     | _ -> .  (* error *)
       ^
 Error: This match case could not be refuted.
-       Here is an example of value that would reach it:
+       Here is an example of a value that would reach it:
        Succ (Succ (Succ (Succ (Succ Zero))))
 # 


### PR DESCRIPTION
This is a small fix to update few reference files in tests/typing-gadt to cope with the altered error message for non-refutable pattern, i.e. invalid use of `| _ -> .`. Note that the test suite still fails after this fix due to a failed assertion in parmatch.ml raised in tool-ocamloc.
