### PR TITLE
A more efficient implementation of ifprintf

### DIFF
--- a/Changes
+++ b/Changes
@@ -105,6 +105,8 @@ Runtime system:
   Shinwell, review by Damien Doligez)
 
 Standard library:
+- PR#7034: More efficient ifprintf implementation
+  (Jeremy Yallop, review by Gabriel Scherer)
 - PR#6316: Scanf.scanf failure on %u formats when reading big integers
   (Xavier Leroy, Benoît Vaugon)
 - PR#6390, GPR#36: expose Sys.{int_size,max_wosize} for improved js_of_ocaml

--- a/stdlib/camlinternalFormat.mli
+++ b/stdlib/camlinternalFormat.mli
@@ -59,6 +59,8 @@ val make_printf :
   ('b -> ('b, 'c) acc -> 'd) -> 'b -> ('b, 'c) acc ->
   ('a, 'b, 'c, 'c, 'c, 'd) CamlinternalFormatBasics.fmt -> 'a
 
+val make_iprintf : ('b -> 'f) -> 'b -> ('a, 'b, 'c, 'd, 'e, 'f) fmt -> 'a
+
 val output_acc : out_channel -> (out_channel, unit) acc -> unit
 val bufput_acc : Buffer.t -> (Buffer.t, unit) acc -> unit
 val strput_acc : Buffer.t -> (unit, string) acc -> unit

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1181,10 +1181,7 @@ let kfprintf k ppf (Format (fmt, _)) =
     ppf End_of_acc fmt
 
 and ikfprintf k ppf (Format (fmt, _)) =
-  make_printf
-    (fun _ _ -> k ppf)
-    ppf End_of_acc fmt
-;;
+  make_iprintf k ppf fmt
 
 let fprintf ppf = kfprintf ignore ppf;;
 let ifprintf ppf = ikfprintf ignore ppf;;

--- a/stdlib/printf.ml
+++ b/stdlib/printf.ml
@@ -19,7 +19,7 @@ let kfprintf k o (Format (fmt, _)) =
 let kbprintf k b (Format (fmt, _)) =
   make_printf (fun b acc -> bufput_acc b acc; k b) b End_of_acc fmt
 let ikfprintf k oc (Format (fmt, _)) =
-  make_printf (fun oc _ -> k oc) oc End_of_acc fmt
+  make_iprintf k oc fmt
 
 let fprintf oc fmt = kfprintf ignore oc fmt
 let bprintf b fmt = kbprintf ignore b fmt


### PR DESCRIPTION
### Background

A common pattern in logging libraries is to have functions which perform logging conditionally, as in the following excerpt from [dolog](https://github.com/UnixJunkie/dolog/blob/f5c7f215/lib/log.ml#L172-L177):

``` ocaml
let log lvl fmt =
  if int_of_level lvl >= int_of_level !level then
    let now = timestamp_str lvl in
    fprintf !output ("%s" ^^ fmt ^^ "\n%!") now
  else
    ifprintf !output fmt
```

The functions [`Printf.ifprintf`](https://github.com/ocaml/ocaml/blob/9feda5c1/stdlib/printf.mli#L130-L134), [`Format.ifprintf`](https://github.com/ocaml/ocaml/blob/9feda5c1/stdlib/format.mli#L691-L695) play an important role in the definition of such functions; although the desired behaviour when the condition is false is to do nothing, omitting the `else` branch altogether would result in ill-typed code.  In other words, functions like `ifprintf`, which accept and discard arguments according to a format specification, make it possible to do nothing in a well-typed way. 

In the [current implementation](https://github.com/ocaml/ocaml/blob/9feda5c1/stdlib/printf.ml#L26) calling `ifprintf` involves a [non-trivial overhead](https://github.com/mirage/ocaml-git/pull/130#issuecomment-149218374), since the underlying implementation for all `*printf` functions does things like [parsing strings](https://github.com/ocaml/ocaml/blob/9feda5c1/stdlib/camlinternalFormat.ml#L1330-L1332) and [allocating accumulator structures](https://github.com/ocaml/ocaml/blob/9feda5c1/stdlib/camlinternalFormat.ml#L1459), regardless of whether the arguments to the function are actually used.
### This change

This pull request implements a specialized version of `ifprintf` which avoids some of the unnecessary overhead.  The implementation is based on a specialised version of `make_printf`, `make_iprintf`, which avoids building an accumulator, parsing precision strings, etc.  Basic tests [indicate](https://github.com/mirage/ocaml-git/pull/130#issuecomment-149219411) a (very) approximate halving of time and memory overhead.

Since the number of arguments to `ifprintf` is determined by the format string, there is still some overhead from closure allocation which seems more difficult to eliminate.  Additionally, in a couple of complicated but fairly rare cases (`Ignored_param`, `Format_subst`), `make_iprintf` simply calls the existing generic functions, since the substantial additional code that would be needed to implement specialized versions doesn't really seem justified.
### Previous discussion.

The idea of implementing a specialized `ifprintf` was discussed from the very beginning of the switch to the GADT-based format implementation.  Here are a couple of comments from the Mantis issue ([6017](http://caml.inria.fr/mantis/view.php?id=6017)), which were followed by some brief discussion:

> Is it possible to reduce the cost of ifprintf? A specialized version of `make_printf: (a, b, c, c, c, unit) CamlinternalFormatBasics.format6 -> a` that construct nothing except closure?
> - bobot (http://caml.inria.fr/mantis/view.php?id=6017#c9322)

and

> I wrote in my project (https://github.com/Kappa-Dev/KaSim [^]) the function :
> 
> ``` ocaml
> let tag_if_debug s =
>   if !Parameter.debugModeOn
>   then Format.kfprintf (fun f -> Format.pp_print_newline f ())
>                Format.std_formatter s
>   else Format.ifprintf Format.std_formatter s
> ```
> 
> hoping that `"tag_if_debug "%a" Pp.map my_huge_map"` costs nothing when not in mode debug. Gasche told me that it is not the case and asks me to report this here as this question has been raised already. 
> - pboutill http://caml.inria.fr/mantis/view.php?id=6017#c12666
