### PR TITLE
Fix incorrect mutability flag when records are built using "with"

### DIFF
--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -1170,7 +1170,8 @@ and transl_record env all_labels repres lbl_expr_list opt_init_expr =
       lbl_expr_list;
     let ll = Array.to_list lv in
     let mut =
-      if List.exists (fun lbl -> lbl.lbl_mut = Mutable) all_labels
+      if List.exists (fun lbl -> lbl.lbl_mut = Mutable)
+        (Array.to_list all_labels)
       then Mutable
       else Immutable in
     let lam =

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -1170,7 +1170,7 @@ and transl_record env all_labels repres lbl_expr_list opt_init_expr =
       lbl_expr_list;
     let ll = Array.to_list lv in
     let mut =
-      if List.exists (fun (_, lbl, expr) -> lbl.lbl_mut = Mutable) lbl_expr_list
+      if List.exists (fun lbl -> lbl.lbl_mut = Mutable) all_labels
       then Mutable
       else Immutable in
     let lam =


### PR DESCRIPTION
When records are built using "with", in some cases (those where the method of compilation is not to use [Pduprecord]), the current compiler only looks at the fields written out in the "with" expression to determine whether the resulting record should be mutable or not.  I think this is wrong.  For example:

``` ocaml
type t = {
  foo : int;
  mutable bar : int;
}

let () =
  let a : t = { foo = 1; bar = 2; } in
  let b = { a with foo = 1; } in
  b.bar <- 42
```

yields [b] being marked as immutable, even though we can still update [b.bar]:

``` scheme
(let
  (match/1213 =
     (let
       (a/1207 = (makemutable 0 1 2)
        b/1208 = (makeblock 0 1 (field 1 a/1207)))
       (setfield_imm 1 b/1208 42)))    ;; whoops!
  (makeblock 0))
```

I think this patch is a sufficient fix.  After the patch we get:

``` scheme
(let
  (match/1213 =
     (let
       (a/1207 = (makemutable 0 1 2)
        b/1208 = (makemutable 0 1 (field 1 a/1207)))
       (setfield_imm 1 b/1208 42)))
  (makeblock 0))
```

(Incidentally, this was caught by the flambda compiler complaining about updates on immutable fields, so it's nice to see the compiler is learning to debug itself...)
