### PR TITLE
Fix PR6972

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -245,7 +245,9 @@ let add_comment com =
   comment_list := com :: !comment_list
 
 let add_docstring_comment ds =
-  let com = (Docstrings.docstring_body ds, Docstrings.docstring_loc ds) in
+  let com =
+    ("*" ^ Docstrings.docstring_body ds, Docstrings.docstring_loc ds)
+  in
     add_comment com
 
 let comments () = List.rev !comment_list


### PR DESCRIPTION
Put the \* back on the doc comments in the cmt_comments field.
