### PR TITLE
Fix stdlib dependencies for .p.cmx

### DIFF
--- a/Changes
+++ b/Changes
@@ -259,6 +259,8 @@ Bug fixes:
   (Daniel Bünzli)
 - GPR#251: fix cross-compilation with ocamldoc enabled
   (whitequark)
+- GPR#280: Fix stdlib dependencies for .p.cmx (Pierre Chambart,
+  Mark Shinwell)
 
 Features wishes:
 - PR#4714: List.cons

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -139,16 +139,16 @@ printf.cmo : camlinternalFormatBasics.cmi camlinternalFormat.cmi buffer.cmi \
     printf.cmi
 printf.cmx : camlinternalFormatBasics.cmx camlinternalFormat.cmx buffer.cmx \
     printf.cmi
-queue.cmo : obj.cmi queue.cmi
-queue.cmx : obj.cmx queue.cmi
+queue.cmo : queue.cmi
+queue.cmx : queue.cmi
 random.cmo : pervasives.cmi nativeint.cmi int64.cmi int32.cmi digest.cmi \
     char.cmi array.cmi random.cmi
 random.cmx : pervasives.cmx nativeint.cmx int64.cmx int32.cmx digest.cmx \
     char.cmx array.cmx random.cmi
-scanf.cmo : string.cmi printf.cmi pervasives.cmi list.cmi \
+scanf.cmo : weak.cmi string.cmi printf.cmi pervasives.cmi hashtbl.cmi \
     camlinternalFormatBasics.cmi camlinternalFormat.cmi bytes.cmi buffer.cmi \
     scanf.cmi
-scanf.cmx : string.cmx printf.cmx pervasives.cmx list.cmx \
+scanf.cmx : weak.cmx string.cmx printf.cmx pervasives.cmx hashtbl.cmx \
     camlinternalFormatBasics.cmx camlinternalFormat.cmx bytes.cmx buffer.cmx \
     scanf.cmi
 set.cmo : list.cmi set.cmi
@@ -163,8 +163,8 @@ stdLabels.cmo : stringLabels.cmi listLabels.cmi bytesLabels.cmi \
     arrayLabels.cmi stdLabels.cmi
 stdLabels.cmx : stringLabels.cmx listLabels.cmx bytesLabels.cmx \
     arrayLabels.cmx stdLabels.cmi
-stream.cmo : string.cmi obj.cmi list.cmi lazy.cmi bytes.cmi stream.cmi
-stream.cmx : string.cmx obj.cmx list.cmx lazy.cmx bytes.cmx stream.cmi
+stream.cmo : string.cmi list.cmi lazy.cmi bytes.cmi stream.cmi
+stream.cmx : string.cmx list.cmx lazy.cmx bytes.cmx stream.cmi
 stringLabels.cmo : string.cmi stringLabels.cmi
 stringLabels.cmx : string.cmx stringLabels.cmi
 string.cmo : pervasives.cmi list.cmi bytes.cmi string.cmi
@@ -175,127 +175,127 @@ weak.cmo : sys.cmi obj.cmi hashtbl.cmi array.cmi weak.cmi
 weak.cmx : sys.cmx obj.cmx hashtbl.cmx array.cmx weak.cmi
 arg.cmo : sys.cmi string.cmi printf.cmi list.cmi buffer.cmi array.cmi \
     arg.cmi
-arg.p.cmx : sys.p.cmx string.p.cmx printf.p.cmx list.p.cmx buffer.p.cmx array.p.cmx \
+arg.p.cmx : sys.cmx string.cmx printf.cmx list.cmx buffer.cmx array.cmx \
     arg.cmi
 arrayLabels.cmo : array.cmi arrayLabels.cmi
-arrayLabels.p.cmx : array.p.cmx arrayLabels.cmi
+arrayLabels.p.cmx : array.cmx arrayLabels.cmi
 array.cmo : array.cmi
 array.p.cmx : array.cmi
 buffer.cmo : sys.cmi string.cmi bytes.cmi buffer.cmi
-buffer.p.cmx : sys.p.cmx string.p.cmx bytes.p.cmx buffer.cmi
+buffer.p.cmx : sys.cmx string.cmx bytes.cmx buffer.cmi
 bytesLabels.cmo : bytes.cmi bytesLabels.cmi
-bytesLabels.p.cmx : bytes.p.cmx bytesLabels.cmi
+bytesLabels.p.cmx : bytes.cmx bytesLabels.cmi
 bytes.cmo : pervasives.cmi list.cmi char.cmi bytes.cmi
-bytes.p.cmx : pervasives.p.cmx list.p.cmx char.p.cmx bytes.cmi
+bytes.p.cmx : pervasives.cmx list.cmx char.cmx bytes.cmi
 callback.cmo : obj.cmi callback.cmi
-callback.p.cmx : obj.p.cmx callback.cmi
+callback.p.cmx : obj.cmx callback.cmi
 camlinternalFormatBasics.cmo : camlinternalFormatBasics.cmi
 camlinternalFormatBasics.p.cmx : camlinternalFormatBasics.cmi
 camlinternalFormat.cmo : sys.cmi string.cmi char.cmi \
     camlinternalFormatBasics.cmi bytes.cmi buffer.cmi camlinternalFormat.cmi
-camlinternalFormat.p.cmx : sys.p.cmx string.p.cmx char.p.cmx \
-    camlinternalFormatBasics.p.cmx bytes.p.cmx buffer.p.cmx camlinternalFormat.cmi
+camlinternalFormat.p.cmx : sys.cmx string.cmx char.cmx \
+    camlinternalFormatBasics.cmx bytes.cmx buffer.cmx camlinternalFormat.cmi
 camlinternalLazy.cmo : obj.cmi camlinternalLazy.cmi
-camlinternalLazy.p.cmx : obj.p.cmx camlinternalLazy.cmi
+camlinternalLazy.p.cmx : obj.cmx camlinternalLazy.cmi
 camlinternalMod.cmo : obj.cmi camlinternalOO.cmi array.cmi \
     camlinternalMod.cmi
-camlinternalMod.p.cmx : obj.p.cmx camlinternalOO.p.cmx array.p.cmx \
+camlinternalMod.p.cmx : obj.cmx camlinternalOO.cmx array.cmx \
     camlinternalMod.cmi
 camlinternalOO.cmo : sys.cmi string.cmi obj.cmi map.cmi list.cmi char.cmi \
     array.cmi camlinternalOO.cmi
-camlinternalOO.p.cmx : sys.p.cmx string.p.cmx obj.p.cmx map.p.cmx list.p.cmx char.p.cmx \
-    array.p.cmx camlinternalOO.cmi
+camlinternalOO.p.cmx : sys.cmx string.cmx obj.cmx map.cmx list.cmx char.cmx \
+    array.cmx camlinternalOO.cmi
 char.cmo : char.cmi
 char.p.cmx : char.cmi
 complex.cmo : complex.cmi
 complex.p.cmx : complex.cmi
 digest.cmo : string.cmi char.cmi bytes.cmi digest.cmi
-digest.p.cmx : string.p.cmx char.p.cmx bytes.p.cmx digest.cmi
+digest.p.cmx : string.cmx char.cmx bytes.cmx digest.cmi
 filename.cmo : sys.cmi string.cmi random.cmi printf.cmi lazy.cmi buffer.cmi \
     filename.cmi
-filename.p.cmx : sys.p.cmx string.p.cmx random.p.cmx printf.p.cmx lazy.p.cmx buffer.p.cmx \
+filename.p.cmx : sys.cmx string.cmx random.cmx printf.cmx lazy.cmx buffer.cmx \
     filename.cmi
 format.cmo : string.cmi pervasives.cmi camlinternalFormatBasics.cmi \
     camlinternalFormat.cmi buffer.cmi format.cmi
-format.p.cmx : string.p.cmx pervasives.p.cmx camlinternalFormatBasics.p.cmx \
-    camlinternalFormat.p.cmx buffer.p.cmx format.cmi
+format.p.cmx : string.cmx pervasives.cmx camlinternalFormatBasics.cmx \
+    camlinternalFormat.cmx buffer.cmx format.cmi
 gc.cmo : sys.cmi printf.cmi gc.cmi
-gc.p.cmx : sys.p.cmx printf.p.cmx gc.cmi
+gc.p.cmx : sys.cmx printf.cmx gc.cmi
 genlex.cmo : string.cmi stream.cmi list.cmi hashtbl.cmi char.cmi bytes.cmi \
     genlex.cmi
-genlex.p.cmx : string.p.cmx stream.p.cmx list.p.cmx hashtbl.p.cmx char.p.cmx bytes.p.cmx \
+genlex.p.cmx : string.cmx stream.cmx list.cmx hashtbl.cmx char.cmx bytes.cmx \
     genlex.cmi
 hashtbl.cmo : sys.cmi string.cmi random.cmi obj.cmi lazy.cmi array.cmi \
     hashtbl.cmi
-hashtbl.p.cmx : sys.p.cmx string.p.cmx random.p.cmx obj.p.cmx lazy.p.cmx array.p.cmx \
+hashtbl.p.cmx : sys.cmx string.cmx random.cmx obj.cmx lazy.cmx array.cmx \
     hashtbl.cmi
 int32.cmo : pervasives.cmi int32.cmi
-int32.p.cmx : pervasives.p.cmx int32.cmi
+int32.p.cmx : pervasives.cmx int32.cmi
 int64.cmo : pervasives.cmi int64.cmi
-int64.p.cmx : pervasives.p.cmx int64.cmi
+int64.p.cmx : pervasives.cmx int64.cmi
 lazy.cmo : obj.cmi camlinternalLazy.cmi lazy.cmi
-lazy.p.cmx : obj.p.cmx camlinternalLazy.p.cmx lazy.cmi
+lazy.p.cmx : obj.cmx camlinternalLazy.cmx lazy.cmi
 lexing.cmo : sys.cmi string.cmi bytes.cmi array.cmi lexing.cmi
-lexing.p.cmx : sys.p.cmx string.p.cmx bytes.p.cmx array.p.cmx lexing.cmi
+lexing.p.cmx : sys.cmx string.cmx bytes.cmx array.cmx lexing.cmi
 listLabels.cmo : list.cmi listLabels.cmi
-listLabels.p.cmx : list.p.cmx listLabels.cmi
+listLabels.p.cmx : list.cmx listLabels.cmi
 list.cmo : list.cmi
 list.p.cmx : list.cmi
 map.cmo : map.cmi
 map.p.cmx : map.cmi
 marshal.cmo : bytes.cmi marshal.cmi
-marshal.p.cmx : bytes.p.cmx marshal.cmi
+marshal.p.cmx : bytes.cmx marshal.cmi
 moreLabels.cmo : set.cmi map.cmi hashtbl.cmi moreLabels.cmi
-moreLabels.p.cmx : set.p.cmx map.p.cmx hashtbl.p.cmx moreLabels.cmi
+moreLabels.p.cmx : set.cmx map.cmx hashtbl.cmx moreLabels.cmi
 nativeint.cmo : sys.cmi pervasives.cmi nativeint.cmi
-nativeint.p.cmx : sys.p.cmx pervasives.p.cmx nativeint.cmi
+nativeint.p.cmx : sys.cmx pervasives.cmx nativeint.cmi
 obj.cmo : marshal.cmi int32.cmi array.cmi obj.cmi
-obj.p.cmx : marshal.p.cmx int32.p.cmx array.p.cmx obj.cmi
+obj.p.cmx : marshal.cmx int32.cmx array.cmx obj.cmi
 oo.cmo : camlinternalOO.cmi oo.cmi
-oo.p.cmx : camlinternalOO.p.cmx oo.cmi
+oo.p.cmx : camlinternalOO.cmx oo.cmi
 parsing.cmo : obj.cmi lexing.cmi array.cmi parsing.cmi
-parsing.p.cmx : obj.p.cmx lexing.p.cmx array.p.cmx parsing.cmi
+parsing.p.cmx : obj.cmx lexing.cmx array.cmx parsing.cmi
 pervasives.cmo : camlinternalFormatBasics.cmi pervasives.cmi
-pervasives.p.cmx : camlinternalFormatBasics.p.cmx pervasives.cmi
+pervasives.p.cmx : camlinternalFormatBasics.cmx pervasives.cmi
 printexc.cmo : printf.cmi pervasives.cmi obj.cmi buffer.cmi array.cmi \
     printexc.cmi
-printexc.p.cmx : printf.p.cmx pervasives.p.cmx obj.p.cmx buffer.p.cmx array.p.cmx \
+printexc.p.cmx : printf.cmx pervasives.cmx obj.cmx buffer.cmx array.cmx \
     printexc.cmi
 printf.cmo : camlinternalFormatBasics.cmi camlinternalFormat.cmi buffer.cmi \
     printf.cmi
-printf.p.cmx : camlinternalFormatBasics.p.cmx camlinternalFormat.p.cmx buffer.p.cmx \
+printf.p.cmx : camlinternalFormatBasics.cmx camlinternalFormat.cmx buffer.cmx \
     printf.cmi
-queue.cmo : obj.cmi queue.cmi
-queue.p.cmx : obj.p.cmx queue.cmi
+queue.cmo : queue.cmi
+queue.p.cmx : queue.cmi
 random.cmo : pervasives.cmi nativeint.cmi int64.cmi int32.cmi digest.cmi \
     char.cmi array.cmi random.cmi
-random.p.cmx : pervasives.p.cmx nativeint.p.cmx int64.p.cmx int32.p.cmx digest.p.cmx \
-    char.p.cmx array.p.cmx random.cmi
-scanf.cmo : string.cmi printf.cmi pervasives.cmi list.cmi \
+random.p.cmx : pervasives.cmx nativeint.cmx int64.cmx int32.cmx digest.cmx \
+    char.cmx array.cmx random.cmi
+scanf.cmo : weak.cmi string.cmi printf.cmi pervasives.cmi hashtbl.cmi \
     camlinternalFormatBasics.cmi camlinternalFormat.cmi bytes.cmi buffer.cmi \
     scanf.cmi
-scanf.p.cmx : string.p.cmx printf.p.cmx pervasives.p.cmx list.p.cmx \
-    camlinternalFormatBasics.p.cmx camlinternalFormat.p.cmx bytes.p.cmx buffer.p.cmx \
+scanf.p.cmx : weak.cmx string.cmx printf.cmx pervasives.cmx hashtbl.cmx \
+    camlinternalFormatBasics.cmx camlinternalFormat.cmx bytes.cmx buffer.cmx \
     scanf.cmi
 set.cmo : list.cmi set.cmi
-set.p.cmx : list.p.cmx set.cmi
+set.p.cmx : list.cmx set.cmi
 sort.cmo : array.cmi sort.cmi
-sort.p.cmx : array.p.cmx sort.cmi
+sort.p.cmx : array.cmx sort.cmi
 stack.cmo : list.cmi stack.cmi
-stack.p.cmx : list.p.cmx stack.cmi
+stack.p.cmx : list.cmx stack.cmi
 std_exit.cmo :
-std_exit.p.cmx :
+std_exit.cmx :
 stdLabels.cmo : stringLabels.cmi listLabels.cmi bytesLabels.cmi \
     arrayLabels.cmi stdLabels.cmi
-stdLabels.p.cmx : stringLabels.p.cmx listLabels.p.cmx bytesLabels.p.cmx \
-    arrayLabels.p.cmx stdLabels.cmi
-stream.cmo : string.cmi obj.cmi list.cmi lazy.cmi bytes.cmi stream.cmi
-stream.p.cmx : string.p.cmx obj.p.cmx list.p.cmx lazy.p.cmx bytes.p.cmx stream.cmi
+stdLabels.p.cmx : stringLabels.cmx listLabels.cmx bytesLabels.cmx \
+    arrayLabels.cmx stdLabels.cmi
+stream.cmo : string.cmi list.cmi lazy.cmi bytes.cmi stream.cmi
+stream.p.cmx : string.cmx list.cmx lazy.cmx bytes.cmx stream.cmi
 stringLabels.cmo : string.cmi stringLabels.cmi
-stringLabels.p.cmx : string.p.cmx stringLabels.cmi
+stringLabels.p.cmx : string.cmx stringLabels.cmi
 string.cmo : pervasives.cmi list.cmi bytes.cmi string.cmi
-string.p.cmx : pervasives.p.cmx list.p.cmx bytes.p.cmx string.cmi
+string.p.cmx : pervasives.cmx list.cmx bytes.cmx string.cmi
 sys.cmo : sys.cmi
 sys.p.cmx : sys.cmi
 weak.cmo : sys.cmi obj.cmi hashtbl.cmi array.cmi weak.cmi
-weak.p.cmx : sys.p.cmx obj.p.cmx hashtbl.p.cmx array.p.cmx weak.cmi
+weak.p.cmx : sys.cmx obj.cmx hashtbl.cmx array.cmx weak.cmi

--- a/stdlib/Makefile.shared
+++ b/stdlib/Makefile.shared
@@ -107,6 +107,9 @@ clean::
 
 include .depend
 
+# Note that .p.cmx targets do not depend (for compilation) upon other
+# .p.cmx files.  When the compiler imports another compilation unit,
+# it looks for the .cmx file (not .p.cmx).
 depend:
 	$(CAMLDEP) *.mli *.ml > .depend
-	$(CAMLDEP) *.ml | sed -e 's/\.cmx/.p.cmx/g' >>.depend
+	$(CAMLDEP) *.ml | sed -e 's/\.cmx : /.p.cmx : /g' >>.depend


### PR DESCRIPTION
Pierre and I were investigating some "corrupted compilation unit" errors I've been getting when using make -j16 for building the compiler.  It looks like the dependencies for the .p.cmx targets in the stdlib were wrong.  In particular, if foo.ml depends on list.ml, then foo.p.cmx does not have a compilation dependency on list.p.cmx; the compiler actually reads list.cmx when importing [List].
