### PR TITLE
Unbox Sys.time and compare primitive

### DIFF
--- a/Changes
+++ b/Changes
@@ -154,6 +154,11 @@ Standard library:
   * Int{32,64}.float_of_bits
   * Int{32,64}.bits_of_float
   (Jérémie Dimino)
+- GPR#281: Switch the following externals to [@@unboxed]:
+  * Sys.time (and [@@noalloc])
+  * Pervasives.ldexp (and [@@noalloc])
+  * Pervasives.compare for float, nativeint, int32, int64.
+  (Bobot François)
 
 Type system:
 - PR#5545: Type annotations on methods cannot control the choice of abbreviation

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -103,18 +103,21 @@ let comparisons_table = create_hashtable 11 [
        Pbintcomp(Pint64, Cge),
        false);
   "%compare",
+      let unboxed_compare name native_repr =
+        Pccall( Primitive.make ~name ~alloc:false
+                  ~native_name:(name^"_unboxed")
+                  ~native_repr_args:[native_repr;native_repr]
+                  ~native_repr_res:Untagged_int
+              ) in
       (Pccall(Primitive.simple ~name:"caml_compare" ~arity:2 ~alloc:true),
+       (* Not unboxed since the comparison is done directly on tagged int *)
        Pccall(Primitive.simple ~name:"caml_int_compare" ~arity:2 ~alloc:false),
-       Pccall(Primitive.simple ~name:"caml_float_compare" ~arity:2
-                ~alloc:false),
+       unboxed_compare "caml_float_compare" Unboxed_float,
        Pccall(Primitive.simple ~name:"caml_string_compare" ~arity:2
                 ~alloc:false),
-       Pccall(Primitive.simple ~name:"caml_nativeint_compare" ~arity:2
-                ~alloc:false),
-       Pccall(Primitive.simple ~name:"caml_int32_compare" ~arity:2
-                ~alloc:false),
-       Pccall(Primitive.simple ~name:"caml_int64_compare" ~arity:2
-                ~alloc:false),
+       unboxed_compare "caml_nativeint_compare" (Unboxed_integer Pnativeint),
+       unboxed_compare "caml_int32_compare" (Unboxed_integer Pint32),
+       unboxed_compare "caml_int64_compare" (Unboxed_integer Pint64),
        false)
 ]
 

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -438,15 +438,18 @@ CAMLprim value caml_gt_float(value f, value g)
   return Val_bool(Double_val(f) > Double_val(g));
 }
 
-CAMLprim value caml_float_compare(value vf, value vg)
+intnat caml_float_compare_unboxed(double f, double g)
 {
-  double f = Double_val(vf);
-  double g = Double_val(vg);
   /* If one or both of f and g is NaN, order according to the convention
      NaN = NaN and NaN < x for all other floats x. */
   /* This branchless implementation is from GPR#164.
      Note that [f == f] if and only if f is not NaN. */
-  return Val_int((f > g) - (f < g) + (f == f) - (g == g));
+  return (f > g) - (f < g) + (f == f) - (g == g);
+}
+
+CAMLprim value caml_float_compare(value vf, value vg)
+{
+  return Val_int(caml_float_compare_unboxed(Double_val(vf),Double_val(vg)));
 }
 
 enum { FP_normal, FP_subnormal, FP_zero, FP_infinite, FP_nan };

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -225,6 +225,13 @@ CAMLprim value caml_frexp_float(value f)
   CAMLreturn (res);
 }
 
+// Seems dumb but intnat could not correspond to int type.
+double caml_ldexp_float_unboxed(double f, intnat i)
+{
+  return ldexp(f, i);
+}
+
+
 CAMLprim value caml_ldexp_float(value f, value i)
 {
   return caml_copy_double(ldexp(Double_val(f), Int_val(i)));

--- a/byterun/ints.c
+++ b/byterun/ints.c
@@ -305,12 +305,14 @@ double caml_int32_to_float_unboxed(int32_t x)
 CAMLprim value caml_int32_to_float(value v)
 { return caml_copy_double((double)(Int32_val(v))); }
 
+intnat caml_int32_compare_unboxed(int32_t i1, int32_t i2)
+{
+  return (i1 > i2) - (i1 < i2);
+}
+
 CAMLprim value caml_int32_compare(value v1, value v2)
 {
-  int32_t i1 = Int32_val(v1);
-  int32_t i2 = Int32_val(v2);
-  int res = (i1 > i2) - (i1 < i2);
-  return Val_int(res);
+  return Val_int(caml_int32_compare_unboxed(Int32_val(v1),Int32_val(v2)));
 }
 
 CAMLprim value caml_int32_format(value fmt, value arg)
@@ -539,11 +541,14 @@ CAMLprim value caml_int64_of_nativeint(value v)
 CAMLprim value caml_int64_to_nativeint(value v)
 { return caml_copy_nativeint((intnat) (Int64_val(v))); }
 
+intnat caml_int64_compare_unboxed(int64_t i1, int64_t i2)
+{
+  return (i1 > i2) - (i1 < i2);
+}
+
 CAMLprim value caml_int64_compare(value v1, value v2)
 {
-  int64_t i1 = Int64_val(v1);
-  int64_t i2 = Int64_val(v2);
-  return Val_int((i1 > i2) - (i1 < i2));
+  return Val_int(caml_int64_compare_unboxed(Int64_val(v1),Int64_val(v2)));
 }
 
 CAMLprim value caml_int64_format(value fmt, value arg)
@@ -796,12 +801,15 @@ CAMLprim value caml_nativeint_of_int32(value v)
 CAMLprim value caml_nativeint_to_int32(value v)
 { return caml_copy_int32(Nativeint_val(v)); }
 
+intnat caml_nativeint_compare_unboxed(intnat i1, intnat i2)
+{
+  return (i1 > i2) - (i1 < i2);
+}
+
 CAMLprim value caml_nativeint_compare(value v1, value v2)
 {
-  intnat i1 = Nativeint_val(v1);
-  intnat i2 = Nativeint_val(v2);
-  int res = (i1 > i2) - (i1 < i2);
-  return Val_int(res);
+  return Val_int(caml_nativeint_compare_unboxed(Nativeint_val(v1),
+                                                Nativeint_val(v2)));
 }
 
 CAMLprim value caml_nativeint_format(value fmt, value arg)

--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -334,14 +334,14 @@ CAMLprim value caml_sys_system_command(value command)
   CAMLreturn (Val_int(retcode));
 }
 
-CAMLprim value caml_sys_time(value unit)
+double caml_sys_time_unboxed(value unit)
 {
 #ifdef HAS_GETRUSAGE
   struct rusage ru;
 
   getrusage (RUSAGE_SELF, &ru);
-  return caml_copy_double (ru.ru_utime.tv_sec + ru.ru_utime.tv_usec / 1e6
-                           + ru.ru_stime.tv_sec + ru.ru_stime.tv_usec / 1e6);
+  return ru.ru_utime.tv_sec + ru.ru_utime.tv_usec / 1e6
+    + ru.ru_stime.tv_sec + ru.ru_stime.tv_usec / 1e6;
 #else
   #ifdef HAS_TIMES
     #ifndef CLK_TCK
@@ -353,12 +353,17 @@ CAMLprim value caml_sys_time(value unit)
     #endif
     struct tms t;
     times(&t);
-    return caml_copy_double((double)(t.tms_utime + t.tms_stime) / CLK_TCK);
+    return (double)(t.tms_utime + t.tms_stime) / CLK_TCK;
   #else
     /* clock() is standard ANSI C */
-    return caml_copy_double((double)clock() / CLOCKS_PER_SEC);
+    return (double)clock() / CLOCKS_PER_SEC;
   #endif
 #endif
+}
+
+CAMLprim value caml_sys_time(value unit)
+{
+  return caml_copy_double(caml_sys_time_unboxed(unit));
 }
 
 #ifdef _WIN32

--- a/otherlibs/threads/pervasives.ml
+++ b/otherlibs/threads/pervasives.ml
@@ -154,7 +154,8 @@ external copysign : float -> float -> float
 external mod_float : float -> float -> float = "caml_fmod_float" "fmod"
   [@@unboxed] [@@noalloc]
 external frexp : float -> float * int = "caml_frexp_float"
-external ldexp : float -> int -> float = "caml_ldexp_float"
+external ldexp : (float [@unboxed]) -> (int [@untagged]) -> (float [@unboxed]) =
+  "caml_ldexp_float" "caml_ldexp_float_unboxed" [@@noalloc]
 external modf : float -> float * float = "caml_modf_float"
 external float : int -> float = "%floatofint"
 external float_of_int : int -> float = "%floatofint"

--- a/stdlib/pervasives.ml
+++ b/stdlib/pervasives.ml
@@ -150,7 +150,8 @@ external copysign : float -> float -> float
 external mod_float : float -> float -> float = "caml_fmod_float" "fmod"
   [@@unboxed] [@@noalloc]
 external frexp : float -> float * int = "caml_frexp_float"
-external ldexp : float -> int -> float = "caml_ldexp_float"
+external ldexp : (float [@unboxed]) -> (int [@untagged]) -> (float [@unboxed]) =
+  "caml_ldexp_float" "caml_ldexp_float_unboxed" [@@noalloc]
 external modf : float -> float * float = "caml_modf_float"
 external float : int -> float = "%floatofint"
 external float_of_int : int -> float = "%floatofint"

--- a/stdlib/pervasives.mli
+++ b/stdlib/pervasives.mli
@@ -454,7 +454,9 @@ external frexp : float -> float * int = "caml_frexp_float"
    zero.  When [f] is non-zero, they are defined by
    [f = x *. 2 ** n] and [0.5 <= x < 1.0]. *)
 
-external ldexp : float -> int -> float = "caml_ldexp_float"
+
+external ldexp : (float [@unboxed]) -> (int [@untagged]) -> (float [@unboxed]) =
+  "caml_ldexp_float" "caml_ldexp_float_unboxed" [@@noalloc]
 (** [ldexp x n] returns [x *. 2 ** n]. *)
 
 external modf : float -> float * float = "caml_modf_float"

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -53,7 +53,8 @@ external getenv : string -> string = "caml_sys_getenv"
 external command : string -> int = "caml_sys_system_command"
 (** Execute the given shell command and return its exit code. *)
 
-external time : unit -> float = "caml_sys_time"
+external time : unit -> (float [@unboxed]) =
+  "caml_sys_time" "caml_sys_time_unboxed" [@@noalloc]
 (** Return the processor time, in seconds, used by the program
    since the beginning of execution. *)
 

--- a/stdlib/sys.mlp
+++ b/stdlib/sys.mlp
@@ -44,7 +44,8 @@ external remove: string -> unit = "caml_sys_remove"
 external rename : string -> string -> unit = "caml_sys_rename"
 external getenv: string -> string = "caml_sys_getenv"
 external command: string -> int = "caml_sys_system_command"
-external time: unit -> float = "caml_sys_time"
+external time: unit -> (float [@unboxed]) =
+  "caml_sys_time" "caml_sys_time_unboxed" [@@noalloc]
 external chdir: string -> unit = "caml_sys_chdir"
 external getcwd: unit -> string = "caml_sys_getcwd"
 external readdir : string -> string array = "caml_sys_read_directory"

--- a/testsuite/tests/float-unboxing/float_subst_boxed_number.ml
+++ b/testsuite/tests/float-unboxing/float_subst_boxed_number.ml
@@ -74,5 +74,15 @@ let unbox_classify_float () =
     x := !x +. 1.
   done
 
+let unbox_compare_float () =
+  let module M = struct type sf = { mutable x: float; y: float; } end in
+  let x = { M.x=100. ; y=1. } in
+  for i = 1 to 1000 do
+    assert (compare x.M.x x.M.y >= 0);
+    x.M.x <- x.M.x +. 1.
+  done
+
 let () =
-  check_noalloc "classify float" unbox_classify_float
+  check_noalloc "classify float" unbox_classify_float;
+  check_noalloc "compare float" unbox_compare_float;
+  ()

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -69,6 +69,14 @@ let simple ~name ~arity ~alloc =
    prim_native_repr_args = make_native_repr_args arity Same_as_ocaml_repr;
    prim_native_repr_res = Same_as_ocaml_repr}
 
+let make ~name ~alloc ~native_name ~native_repr_args ~native_repr_res =
+  {prim_name = name;
+   prim_arity = List.length native_repr_args;
+   prim_alloc = alloc;
+   prim_native_name = native_name;
+   prim_native_repr_args = native_repr_args;
+   prim_native_repr_res = native_repr_res}
+
 let parse_declaration valdecl ~native_repr_args ~native_repr_res =
   let arity = List.length native_repr_args in
   let name, native_name, old_style_noalloc, old_style_float =

--- a/typing/primitive.mli
+++ b/typing/primitive.mli
@@ -30,10 +30,20 @@ type description = private
     prim_native_repr_args: native_repr list;
     prim_native_repr_res: native_repr }
 
+(* Invariant [List.length d.prim_native_repr_args = d.prim_arity] *)
+
 val simple
   :  name:string
   -> arity:int
   -> alloc:bool
+  -> description
+
+val make
+  :  name:string
+  -> alloc:bool
+  -> native_name:string
+  -> native_repr_args: native_repr list
+  -> native_repr_res: native_repr
   -> description
 
 val parse_declaration


### PR DESCRIPTION
Unbox the primitive listed in #272 but not unboxed in #277:
- `Sys.time`
- `Pervasives.ldexp`
- Specialize version of `%compare` for `float`, `int32,`int64`,`nativeint`

In #164 the unboxing of `compare` for floats have already been proposed and refused because `compare` is generally used in the context of collections (Maps, Sets, etc). I would argue that it is specifically interesting in this context when the keys are for example structure of floats (where the floats are inlined):

``` ocaml
type point = { x: float; y: float; }

let compare_point a b =
  let c = compare a.x b.x in
  if c <> 0 then c
  else compare a.y x.y
```

A quick benchmark (without core_bench not currently installable ) :
Using `caml_compare` on the type point directly: 1 (reference)
Using `caml_compare_float` in `compare_point`: 0.7
Using `caml_compare_float_unboxed` in `compare_point`: 0.5

The gain between the second and third case is obtained because there is no allocation in the third one. 
