### PR TITLE
short-paths: fix and twix

### DIFF
--- a/Changes
+++ b/Changes
@@ -53,6 +53,9 @@ Language features:
   (Valentin Gatien-Baron, review by Jérémie Dimino)
 - PR#6806: Allow type annotations before the "->" in "fun <args> -> <expr>"
   (Valentin Gatien-Baron, review by Jérémie Dimino)
+- GPR#282: change short-paths penalty heuristic to assign the same cost to
+  idents containing double underscores as to idents starting with an underscore
+  (Thomas Refis, Leo White)
 
 Compilers:
 - PR#4800: better compilation of tuple assignment (Gabriel Scherer and
@@ -94,6 +97,9 @@ Compilers:
   (Mark Shinwell)
 - GPR#270: Make [transl_exception_constructor] generate [Immutable] blocks
   (Mark Shinwell)
+- GPR#282: relax short-paths safety check in presence of module aliases, take
+  penalty into account while building the printing map.
+  (Thomas Refis, Leo White)
 
 Runtime system:
 - PR#3612: allow allocating custom block with finalizers in the minor heap

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -277,10 +277,21 @@ let rec normalize_type_path ?(cache=false) env p =
   with
     Not_found -> (p, Id)
 
+let penalty s =
+  if s <> "" && s.[0] = '_' then
+    10
+  else
+    try
+      for i = 0 to String.length s - 2 do
+        if s.[i] = '_' && s.[i + 1] = '_' then
+          raise Exit
+      done;
+      1
+    with Exit -> 10
+
 let rec path_size = function
     Pident id ->
-      (let s = Ident.name id in if s <> "" && s.[0] = '_' then 10 else 1),
-      -Ident.binding_time id
+      penalty (Ident.name id), -Ident.binding_time id
   | Pdot (p, _, _) ->
       let (l, b) = path_size p in (1+l, b)
   | Papply (p1, p2) ->

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -360,7 +360,7 @@ let best_type_path p =
     let (p', s) = normalize_type_path !printing_env p in
     let get_path () = get_best_path (PathMap.find  p' !printing_map) in
     while !printing_cont <> [] &&
-      try ignore (get_path ()); false with Not_found -> true
+      try fst (path_size (get_path ())) > !printing_depth with Not_found -> true
     do
       printing_cont := List.map snd (Env.run_iter_cont !printing_cont);
       incr printing_depth;


### PR DESCRIPTION
This pull-request contains 3 commits aiming to improve the behavior of -short-paths.
I think @garrigue should be the one to look over this.
## 1st commit

This commit is related to PR#6812 and brings a small improvement to the already merged fix.
The commit message, read in the context of PR#6812, should be enough to convince onself that the patch is correct (and safe).

Note that a similar patch has been applied to merlin, giving great results. For example on:

``` ocaml
open Async.Std

let _ =
  (>>=)
```

asking for the type of bind would print `'a Async_kernel.Deferred0.t -> ('a -> 'b Async_kernel.Deferred0.t) -> 'b Async_kernel.Deferred0.t` whereas after applying this patch it displays `'a Deferred.t -> ('a -> 'b Deferred.t) -> 'b Deferred.t`
## 2nd commit

Before this commit the printing map would be grown until `get_path` returned a result, regardless of the fact that the returned path might not be the "best" one.
The reason being (I assume):  "once you get a result, there is no need to look in deeper structures as the resulting paths can only be longer than the current one".

This fails to account for the penality assigned to some paths whose "size" could be considered higher than for paths with more components.

After this patch the printing map is grown until the size of the result is actually lesser than (or equal to) the current printing depth (or the whole environment is exhausted). The size of the path being lesser or equal to the current printing depth implies that no penality applies to the current path, it is therefore impossible to find a "smaller" one in deeper structures.

As a side note: `printing_depth` was previously only written to, but never read.
## 3rd commit

This commit tweaks the penality heuristic, which already gave a higher penality to idents starting with an underscore, to give the same high penality to idents containing a double underscore.

We use this at Jane Street to hide module names we do not want to be displayed.
Indeed since we moved away from using packed modules every module is prefixed by the name of the library containing it and a double underscore and each library includes a file aliasing all these modules back to their short names.
For example we have in core_kernel we have the file `hash_set.ml`, which will be used to obtain `core_kernel__Hash_set.cm*` and we have a file `core_kernel.ml` which contains the line `module Hash_set = Core_kernel__Hash_set`.  That short name being the one we use everywhere.
However in error messages `Core_kernel__Hash_set.t` is considered shorter than `Core_kernel.Hash_set.t`, which means that in error messages the former is used.

The tweak proposed in this commit assign a high enough penality to module names containing a double underscore for `Core_kernel.Hash_set.t` to be always chosen over `Core_kernel__Hash_set.t`.
