### PR TITLE
Fix memory leaks in intern.c when OOM is raised

### DIFF
--- a/Changes
+++ b/Changes
@@ -310,6 +310,8 @@ Bug fixes:
   (whitequark)
 - GPR#280: Fix stdlib dependencies for .p.cmx (Pierre Chambart,
   Mark Shinwell)
+- GPR#283: Fix memory leaks in intern.c when OOM is raised
+  (Marc Lasson, review by Alain Frisch)
 
 Features wishes:
 - PR#4714: List.cons

--- a/byterun/array.c
+++ b/byterun/array.c
@@ -391,12 +391,12 @@ CAMLprim value caml_array_concat(value al)
     lengths = static_lengths;
   } else {
     arrays = caml_stat_alloc(n * sizeof(value));
-    offsets = caml_stat_alloc_no_raise(n * sizeof(intnat));
+    offsets = malloc(n * sizeof(intnat));
     if (offsets == NULL) {
       caml_stat_free(arrays);
       caml_raise_out_of_memory();
     }
-    lengths = caml_stat_alloc_no_raise(n * sizeof(value));
+    lengths = malloc(n * sizeof(value));
     if (lengths == NULL) {
       caml_stat_free(offsets);
       caml_stat_free(arrays);

--- a/byterun/array.c
+++ b/byterun/array.c
@@ -12,7 +12,7 @@
 /***********************************************************************/
 
 /* Operations on arrays */
-
+#include <stdio.h>
 #include <string.h>
 #include "caml/alloc.h"
 #include "caml/fail.h"
@@ -391,8 +391,17 @@ CAMLprim value caml_array_concat(value al)
     lengths = static_lengths;
   } else {
     arrays = caml_stat_alloc(n * sizeof(value));
-    offsets = caml_stat_alloc(n * sizeof(intnat));
-    lengths = caml_stat_alloc(n * sizeof(value));
+    offsets = caml_stat_alloc_no_raise(n * sizeof(intnat));
+    if (offsets == NULL) {
+      caml_stat_free(arrays);
+      caml_raise_out_of_memory();
+    }
+    lengths = caml_stat_alloc_no_raise(n * sizeof(value));
+    if (lengths == NULL) {
+      caml_stat_free(offsets);
+      caml_stat_free(arrays);
+      caml_raise_out_of_memory();
+    }
   }
   /* Build the parameters to caml_array_gather */
   for (i = 0, l = al; l != Val_int(0); l = Field(l, 1), i++) {

--- a/byterun/array.c
+++ b/byterun/array.c
@@ -12,7 +12,6 @@
 /***********************************************************************/
 
 /* Operations on arrays */
-#include <stdio.h>
 #include <string.h>
 #include "caml/alloc.h"
 #include "caml/fail.h"

--- a/byterun/caml/memory.h
+++ b/byterun/caml/memory.h
@@ -41,6 +41,7 @@ CAMLextern void caml_modify (value *, value);
 CAMLextern void caml_initialize (value *, value);
 CAMLextern value caml_check_urgent_gc (value);
 CAMLextern void * caml_stat_alloc (asize_t);              /* Size in bytes. */
+CAMLextern void * caml_stat_alloc_no_raise (asize_t);     /* Size in bytes. */
 CAMLextern void caml_stat_free (void *);
 CAMLextern void * caml_stat_resize (void *, asize_t);     /* Size in bytes. */
 char *caml_alloc_for_heap (asize_t request);   /* Size in bytes. */

--- a/byterun/caml/memory.h
+++ b/byterun/caml/memory.h
@@ -42,7 +42,6 @@ CAMLextern void caml_modify (value *, value);
 CAMLextern void caml_initialize (value *, value);
 CAMLextern value caml_check_urgent_gc (value);
 CAMLextern void * caml_stat_alloc (asize_t);              /* Size in bytes. */
-CAMLextern void * caml_stat_alloc_no_raise (asize_t);     /* Size in bytes. */
 CAMLextern void caml_stat_free (void *);
 CAMLextern void * caml_stat_resize (void *, asize_t);     /* Size in bytes. */
 char *caml_alloc_for_heap (asize_t request);   /* Size in bytes. */

--- a/byterun/caml/memory.h
+++ b/byterun/caml/memory.h
@@ -34,6 +34,7 @@ extern "C" {
 
 
 CAMLextern value caml_alloc_shr (mlsize_t wosize, tag_t);
+CAMLextern value caml_alloc_shr_no_raise (mlsize_t wosize, tag_t);
 CAMLextern void caml_adjust_gc_speed (mlsize_t, mlsize_t);
 CAMLextern void caml_alloc_dependent_memory (mlsize_t bsz);
 CAMLextern void caml_free_dependent_memory (mlsize_t bsz);

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -130,8 +130,6 @@ static inline void readblock(void * dest, intnat len)
   intern_src += len;
 }
 
-
-
 static void intern_init(void * src, void * input)
 {
   /* This is asserted at the beginning of demarshaling primitives.

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -588,7 +588,7 @@ static void intern_alloc(mlsize_t whsize, mlsize_t num_objects)
   }
   obj_counter = 0;
   if (num_objects > 0) {
-    intern_obj_table = (value *) caml_stat_alloc_no_raise(num_objects * sizeof(value));
+    intern_obj_table = (value *) malloc(num_objects * sizeof(value));
     if (intern_obj_table == NULL) {
       intern_cleanup();
       caml_raise_out_of_memory();

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -576,8 +576,8 @@ static void intern_alloc(mlsize_t whsize, mlsize_t num_objects)
          intern_block into gray and break the Assert 3 lines down */
       if (intern_block == 0) {
         intern_obj_table = NULL;
-	intern_cleanup();
-	caml_raise_out_of_memory();
+        intern_cleanup();
+        caml_raise_out_of_memory();
       }
     }
     intern_header = Hd_val(intern_block);

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -571,9 +571,14 @@ static void intern_alloc(mlsize_t whsize, mlsize_t num_objects)
     }else if (wosize <= Max_young_wosize){
       intern_block = caml_alloc_small (wosize, String_tag);
     }else{
-      intern_block = caml_alloc_shr (wosize, String_tag);
+      intern_block = caml_alloc_shr_no_raise (wosize, String_tag);
       /* do not do the urgent_gc check here because it might darken
          intern_block into gray and break the Assert 3 lines down */
+      if (intern_block == 0) {
+        intern_obj_table = NULL;
+	intern_cleanup();
+	caml_raise_out_of_memory();
+      }
     }
     intern_header = Hd_val(intern_block);
     intern_color = Color_hd(intern_header);

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -623,9 +623,9 @@ static void intern_add_to_heap(mlsize_t whsize)
     caml_allocated_words +=
       Wsize_bsize ((char *) intern_dest - intern_extra_block);
     caml_add_to_heap(intern_extra_block);
-    intern_extra_block = NULL; // To prevent intern_cleanup freeing
+    intern_extra_block = NULL; // To prevent intern_cleanup freeing it
   } else {
-    intern_block = 0; // To preven intern_cleanup rewriting its header
+    intern_block = 0; // To prevent intern_cleanup rewriting its header
   }
 }
 

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -557,7 +557,7 @@ static void intern_alloc(mlsize_t whsize, mlsize_t num_objects)
       ((Bsize_wsize(whsize) + Page_size - 1) >> Page_log) << Page_log;
     intern_extra_block = caml_alloc_for_heap(request);
     if (intern_extra_block == NULL) {
-      intern_obj_table = NULL; 
+      intern_obj_table = NULL;
       intern_block = 0;
       intern_cleanup();
       caml_raise_out_of_memory();

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -405,20 +405,36 @@ color_t caml_allocation_color (void *hp)
   }
 }
 
-CAMLexport value caml_alloc_shr_no_raise (mlsize_t wosize, tag_t tag)
+
+static int caml_alloc_shr_return = 0;
+
+/* Invariant:
+       caml_alloc_shr_return is set => no exception inside caml_alloc_shr
+
+   If this invariant is broken, then the function caml_alloc_shr_no_raise will
+   not be able to set caml_alloc_shr_return back to 0. */
+CAMLexport value caml_alloc_shr (mlsize_t wosize, tag_t tag)
 {
   header_t *hp;
   value *new_block;
 
-  if (wosize > Max_wosize) return 0;
+  if (wosize > Max_wosize) {
+    if (caml_alloc_shr_return)
+      return 0;
+    else
+      caml_raise_out_of_memory();
+  }
+
   hp = caml_fl_allocate (wosize);
   if (hp == NULL){
     new_block = expand_heap (wosize);
     if (new_block == NULL) {
       if (caml_in_minor_collection)
         caml_fatal_error ("Fatal error: out of memory.\n");
-      else
+      else if (caml_alloc_shr_return)
         return 0;
+      else
+        caml_raise_out_of_memory();
     }
     caml_fl_add_blocks ((value) new_block);
     hp = caml_fl_allocate (wosize);
@@ -452,10 +468,11 @@ CAMLexport value caml_alloc_shr_no_raise (mlsize_t wosize, tag_t tag)
   return Val_hp (hp);
 }
 
-CAMLexport value caml_alloc_shr (mlsize_t wosize, tag_t tag) {
-  value res = caml_alloc_shr_no_raise (wosize, tag);
-  if (res == 0)
-    caml_raise_out_of_memory();
+CAMLexport value caml_alloc_shr_no_raise (mlsize_t wosize, tag_t tag) {
+  value res;
+  caml_alloc_shr_return = 1;
+  res = caml_alloc_shr (wosize, tag);
+  caml_alloc_shr_return = 0;
   return res;
 }
 

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -405,6 +405,8 @@ color_t caml_allocation_color (void *hp)
   }
 }
 
+/* The implementation of this function is obtained by copy/pasting the implementation
+   of caml_alloc_shr below and replacing caml_raise_out_of_memory() by return 0; */
 CAMLexport value caml_alloc_shr_no_raise (mlsize_t wosize, tag_t tag)
 {
   header_t *hp;
@@ -453,11 +455,49 @@ CAMLexport value caml_alloc_shr_no_raise (mlsize_t wosize, tag_t tag)
 }
 
 CAMLexport value caml_alloc_shr (mlsize_t wosize, tag_t tag) {
-  value v = caml_alloc_shr_no_raise(wosize, tag);
-  if (v == 0) {
-    caml_raise_out_of_memory();
+  header_t *hp;
+  value *new_block;
+
+  if (wosize > Max_wosize) caml_raise_out_of_memory();
+  hp = caml_fl_allocate (wosize);
+  if (hp == NULL){
+    new_block = expand_heap (wosize);
+    if (new_block == NULL) {
+      if (caml_in_minor_collection)
+        caml_fatal_error ("Fatal error: out of memory.\n");
+      else
+        caml_raise_out_of_memory();
+    }
+    caml_fl_add_blocks ((value) new_block);
+    hp = caml_fl_allocate (wosize);
   }
-  return v;
+
+  Assert (Is_in_heap (Val_hp (hp)));
+
+  /* Inline expansion of caml_allocation_color. */
+  if (caml_gc_phase == Phase_mark
+      || (caml_gc_phase == Phase_sweep && (addr)hp >= (addr)caml_gc_sweep_hp)){
+    Hd_hp (hp) = Make_header (wosize, tag, Caml_black);
+  }else{
+    Assert (caml_gc_phase == Phase_idle
+            || (caml_gc_phase == Phase_sweep
+                && (addr)hp < (addr)caml_gc_sweep_hp));
+    Hd_hp (hp) = Make_header (wosize, tag, Caml_white);
+  }
+  Assert (Hd_hp (hp) == Make_header (wosize, tag, caml_allocation_color (hp)));
+  caml_allocated_words += Whsize_wosize (wosize);
+  if (caml_allocated_words > caml_minor_heap_wsz){
+    caml_urge_major_slice ();
+  }
+#ifdef DEBUG
+  {
+    uintnat i;
+    for (i = 0; i < wosize; i++){
+      Field (Val_hp (hp), i) = Debug_uninit_major;
+    }
+  }
+#endif
+  return Val_hp (hp);
 }
 
 /* Dependent memory is all memory blocks allocated out of the heap
@@ -589,17 +629,6 @@ CAMLexport void * caml_stat_alloc (asize_t sz)
 
   /* malloc() may return NULL if size is 0 */
   if (result == NULL && sz != 0) caml_raise_out_of_memory ();
-#ifdef DEBUG
-  memset (result, Debug_uninit_stat, sz);
-#endif
-  return result;
-}
-
-/* [sz] is a number of bytes */
-CAMLexport void * caml_stat_alloc_no_raise (asize_t sz)
-{
-  void * result = malloc (sz);
-
 #ifdef DEBUG
   memset (result, Debug_uninit_stat, sz);
 #endif

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -587,6 +587,17 @@ CAMLexport void * caml_stat_alloc (asize_t sz)
   return result;
 }
 
+/* [sz] is a number of bytes */
+CAMLexport void * caml_stat_alloc_no_raise (asize_t sz)
+{
+  void * result = malloc (sz);
+
+#ifdef DEBUG
+  memset (result, Debug_uninit_stat, sz);
+#endif
+  return result;
+}
+
 CAMLexport void caml_stat_free (void * blk)
 {
   free (blk);

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -130,7 +130,9 @@ void caml_oldify_one (value v, value *p)
         value field0;
 
         sz = Wosize_hd (hd);
-        result = caml_alloc_shr (sz, tag);
+        result = caml_alloc_shr_no_raise (sz, tag);
+        if (result == 0)
+          caml_raise_out_of_memory ();
         *p = result;
         field0 = Field (v, 0);
         Hd_val (v) = 0;            /* Set forward flag */
@@ -147,7 +149,9 @@ void caml_oldify_one (value v, value *p)
         }
       }else if (tag >= No_scan_tag){
         sz = Wosize_hd (hd);
-        result = caml_alloc_shr (sz, tag);
+        result = caml_alloc_shr_no_raise (sz, tag);
+        if (result == 0)
+          caml_raise_out_of_memory();
         for (i = 0; i < sz; i++) Field (result, i) = Field (v, i);
         Hd_val (v) = 0;            /* Set forward flag */
         Field (v, 0) = result;     /*  and forward pointer. */
@@ -176,7 +180,9 @@ void caml_oldify_one (value v, value *p)
         if (!vv || ft == Forward_tag || ft == Lazy_tag || ft == Double_tag){
           /* Do not short-circuit the pointer.  Copy as a normal block. */
           Assert (Wosize_hd (hd) == 1);
-          result = caml_alloc_shr (1, Forward_tag);
+          result = caml_alloc_shr_no_raise (1, Forward_tag);
+          if (result == 0)
+            caml_raise_out_of_memory();
           *p = result;
           Hd_val (v) = 0;             /* Set (GC) forward flag */
           Field (v, 0) = result;      /*  and forward pointer. */

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -130,9 +130,7 @@ void caml_oldify_one (value v, value *p)
         value field0;
 
         sz = Wosize_hd (hd);
-        result = caml_alloc_shr_no_raise (sz, tag);
-        if (result == 0)
-          caml_raise_out_of_memory ();
+        result = caml_alloc_shr (sz, tag);
         *p = result;
         field0 = Field (v, 0);
         Hd_val (v) = 0;            /* Set forward flag */
@@ -149,9 +147,7 @@ void caml_oldify_one (value v, value *p)
         }
       }else if (tag >= No_scan_tag){
         sz = Wosize_hd (hd);
-        result = caml_alloc_shr_no_raise (sz, tag);
-        if (result == 0)
-          caml_raise_out_of_memory();
+        result = caml_alloc_shr (sz, tag);
         for (i = 0; i < sz; i++) Field (result, i) = Field (v, i);
         Hd_val (v) = 0;            /* Set forward flag */
         Field (v, 0) = result;     /*  and forward pointer. */
@@ -180,9 +176,7 @@ void caml_oldify_one (value v, value *p)
         if (!vv || ft == Forward_tag || ft == Lazy_tag || ft == Double_tag){
           /* Do not short-circuit the pointer.  Copy as a normal block. */
           Assert (Wosize_hd (hd) == 1);
-          result = caml_alloc_shr_no_raise (1, Forward_tag);
-          if (result == 0)
-            caml_raise_out_of_memory();
+          result = caml_alloc_shr (1, Forward_tag);
           *p = result;
           Hd_val (v) = 0;             /* Set (GC) forward flag */
           Field (v, 0) = result;      /*  and forward pointer. */


### PR DESCRIPTION
In the function, `intern_alloc` a call to caml_alloc_for_heap is very likely to
return NULL when reading a big marshaled value. If that happens, before raising
out_of_memory, it should call the `intern_cleanup` function to free the stack
as well as `intern_input` that may have been malloced by `caml_input_val`.
Similarly, `intern_cleanup` should also be called when we are not able to
allocate `intern_obj_table`. To do that, I added a function
`caml_stat_alloc_no_raise` which, like its brother, `caml_stat_alloc` wraps
some debugging information around a call to malloc. I could have used directly
malloc instead of adding a new function to memory.c, as it is done in other
places of the code (it has the drawback of not adding the debug tag).

Note that this fix is not perfect. The function `intern_alloc` could also raise
out_of_memory through its call to `caml_alloc_shr`. It is less likely to happen
since caml_alloc_shr is only called when the input is smaller than Max_wosize
but it could happen. In that case, there will be leak (but a smaller one).
