### PR TITLE
Bidirectional type checking for applications

### DIFF
--- a/testsuite/tests/typing-gadts/test.ml.principal.reference
+++ b/testsuite/tests/typing-gadts/test.ml.principal.reference
@@ -144,25 +144,25 @@ Error: This pattern matches values of type 'a t
 #   val ky : 'a -> 'a -> 'a = <fun>
 #       val test : 'a t -> 'a = <fun>
 #       val test : 'a t -> int = <fun>
-#       Characters 49-61:
+#       Characters 60-61:
     function Int -> ky (1 : a) 1  (* fails *)
-                    ^^^^^^^^^^^^
-Error: This expression has type a = int
-       but an expression was expected of type 'a
+                               ^
+Error: This expression has type int but an expression was expected of type
+         a = int
        This instance of int is ambiguous:
        it would escape the scope of its equation
-#         Characters 70-82:
+#         Characters 81-82:
     let r = match x with Int -> ky (1 : a) 1  (* fails *)
-                                ^^^^^^^^^^^^
-Error: This expression has type a = int
-       but an expression was expected of type 'a
+                                           ^
+Error: This expression has type int but an expression was expected of type
+         a = int
        This instance of int is ambiguous:
        it would escape the scope of its equation
-#       Characters 69-81:
+#       Characters 74-81:
     let r = match x with Int -> ky 1 (1 : a)  (* fails *)
-                                ^^^^^^^^^^^^
+                                     ^^^^^^^
 Error: This expression has type a = int
-       but an expression was expected of type 'a
+       but an expression was expected of type int
        This instance of int is ambiguous:
        it would escape the scope of its equation
 #       val test : 'a t -> int = <fun>
@@ -172,11 +172,11 @@ Error: This expression has type a = int
 #         val test2 : 'a t -> 'a option = <fun>
 #         val test2 : 'a t -> 'a option = <fun>
 #           val test2 : 'a t -> 'a option = <fun>
-#           Characters 152-154:
+#           Characters 153-154:
     begin match x with Int -> u := Some 1; r := !u end;
-                                                ^^
-Error: This expression has type int option
-       but an expression was expected of type a option
+                                                 ^
+Error: This expression has type int option ref
+       but an expression was expected of type a option ref
        Type int is not compatible with type a = int 
        This instance of int is ambiguous:
        it would escape the scope of its equation

--- a/testsuite/tests/typing-gadts/test.ml.reference
+++ b/testsuite/tests/typing-gadts/test.ml.reference
@@ -145,25 +145,25 @@ Error: This pattern matches values of type 'a t
 #   val ky : 'a -> 'a -> 'a = <fun>
 #       val test : 'a t -> 'a = <fun>
 #       val test : 'a t -> int = <fun>
-#       Characters 49-61:
+#       Characters 60-61:
     function Int -> ky (1 : a) 1  (* fails *)
-                    ^^^^^^^^^^^^
-Error: This expression has type a = int
-       but an expression was expected of type 'a
+                               ^
+Error: This expression has type int but an expression was expected of type
+         a = int
        This instance of int is ambiguous:
        it would escape the scope of its equation
-#         Characters 70-82:
+#         Characters 81-82:
     let r = match x with Int -> ky (1 : a) 1  (* fails *)
-                                ^^^^^^^^^^^^
-Error: This expression has type a = int
-       but an expression was expected of type 'a
+                                           ^
+Error: This expression has type int but an expression was expected of type
+         a = int
        This instance of int is ambiguous:
        it would escape the scope of its equation
-#       Characters 69-81:
+#       Characters 74-81:
     let r = match x with Int -> ky 1 (1 : a)  (* fails *)
-                                ^^^^^^^^^^^^
+                                     ^^^^^^^
 Error: This expression has type a = int
-       but an expression was expected of type 'a
+       but an expression was expected of type int
        This instance of int is ambiguous:
        it would escape the scope of its equation
 #       val test : 'a t -> int = <fun>
@@ -173,11 +173,11 @@ Error: This expression has type a = int
 #         val test2 : 'a t -> 'a option = <fun>
 #         val test2 : 'a t -> 'a option = <fun>
 #           val test2 : 'a t -> 'a option = <fun>
-#           Characters 152-154:
+#           Characters 153-154:
     begin match x with Int -> u := Some 1; r := !u end;
-                                                ^^
-Error: This expression has type int option
-       but an expression was expected of type a option
+                                                 ^
+Error: This expression has type int option ref
+       but an expression was expected of type a option ref
        Type int is not compatible with type a = int 
        This instance of int is ambiguous:
        it would escape the scope of its equation

--- a/testsuite/tests/typing-objects/Exemples.ml.principal.reference
+++ b/testsuite/tests/typing-objects/Exemples.ml.principal.reference
@@ -6,7 +6,7 @@
 #   - : int = 7
 # - : unit = ()
 # - : int = 10
-#   val q : < get_x : int; move : int -> unit > = <obj>
+#   val q : point = <obj>
 #   - : int * int = (10, 17)
 #           class color_point :
   int ->
@@ -64,7 +64,7 @@ Error: Some type variables are unbound in this type:
     method set_center : 'a -> unit
   end
 #   val c : point circle = <obj>
-val c' : < color : string; get_x : int; move : int -> unit > circle = <obj>
+val c' : color_point circle = <obj>
 #           class ['a] color_circle :
   'a ->
   object

--- a/testsuite/tests/typing-warnings/coercions.ml.principal.reference
+++ b/testsuite/tests/typing-warnings/coercions.ml.principal.reference
@@ -8,8 +8,8 @@ Warning 18: this coercion to format6 is not principal.
   fun b -> if b then "x" else format_of_string "y";;
                               ^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type
-         ('a, 'b, 'c, 'd, 'd, 'a) format6 =
-           ('a, 'b, 'c, 'd, 'd, 'a) CamlinternalFormatBasics.format6
+         ('a, 'b, 'c, 'd, 'e, 'f) format6 =
+           ('a, 'b, 'c, 'd, 'e, 'f) CamlinternalFormatBasics.format6
        but an expression was expected of type string
 # - : bool -> ('a, 'b, 'a) format = <fun>
 #                   module PR7135 :

--- a/testsuite/tests/typing-warnings/coercions.ml.reference
+++ b/testsuite/tests/typing-warnings/coercions.ml.reference
@@ -4,8 +4,8 @@
   fun b -> if b then "x" else format_of_string "y";;
                               ^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type
-         ('a, 'b, 'c, 'd, 'd, 'a) format6 =
-           ('a, 'b, 'c, 'd, 'd, 'a) CamlinternalFormatBasics.format6
+         ('a, 'b, 'c, 'd, 'e, 'f) format6 =
+           ('a, 'b, 'c, 'd, 'e, 'f) CamlinternalFormatBasics.format6
        but an expression was expected of type string
 # - : bool -> ('a, 'b, 'a) format = <fun>
 #                   module PR7135 :

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2110,7 +2110,7 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
       end_def ();
       wrap_trace_gadt_instances env (lower_args []) ty;
       begin_def ();
-      let (args, ty_res) = type_application env funct sargs in
+      let (args, ty_res) = type_application loc env funct sargs ty_expected in
       end_def ();
       unify_var env (newvar()) funct.exp_type;
       rue {
@@ -3415,7 +3415,7 @@ and type_argument ?recarg env sarg ty_expected' ty_expected =
       unify_exp env texp ty_expected;
       texp
 
-and type_application env funct sargs =
+and type_application loc env funct sargs ty_expected =
   (* funct.exp_type may be generic *)
   let result_type omitted ty_fun =
     List.fold_left
@@ -3432,11 +3432,13 @@ and type_application env funct sargs =
       (Asttypes.arg_label * (unit -> Typedtree.expression) option) list)
     omitted ty_fun = function
       [] ->
-        (List.map
-            (function l, None -> l, None
-                | l, Some f -> l, Some (f ()))
-           (List.rev args),
-         instance env (result_type omitted ty_fun))
+        let result_type = instance env (result_type omitted ty_fun) in
+        unify_exp_types loc env result_type (instance env ty_expected);
+        let force = function
+          | (l, None) -> (l, None)
+          | (l, Some f) -> (l, Some (f ()))
+        in
+        (List.map force (List.rev args), result_type)
     | (l1, sarg1) :: sargl ->
         let (ty1, ty2) =
           let ty_fun = expand_head env ty_fun in


### PR DESCRIPTION
The following patch propagates types to arguments of an application prior to typechecking them.
The testsuite succeeds: the failures reported are due to slightly different inferred signatures and error messages, but the semantics are otherwise unchanged.

The main motivation for this patch is to improve error messages and get finer types and completions in Merlin.
In particular for code mixing higher-order functions and structural types (e.g. js_of_ocaml) the experience is much better.
