### PR TITLE
PR#7026: optimize assignments with non-parametrized polymorphic variants

### DIFF
--- a/Changes
+++ b/Changes
@@ -59,6 +59,8 @@ Language features:
 Compilers:
 - PR#4800: better compilation of tuple assignment (Gabriel Scherer and
   Alain Frisch)
+- PR#6400: better error message for '_' used as an expression
+  (Alain Frisch, report by whitequark)
 - PR#6501: harden the native-code generator against certain uses of "%identity"
   (Xavier Leroy, report by Antoine Miné).
 - PR#6636: add --version option
@@ -79,8 +81,8 @@ Compilers:
   the stack (Marc Lasson, review by Xavier Leroy)
 - PR#7018: fix missing identifier renaming during inlining (Alain Frisch,
   review by Xavier Leroy)
-- PR#6400: better error message for '_' used as an expression
-  (Alain Frisch, report by whitequark)
+- PR#7026, GPR#288: remove write barrier for polymorphic variants without arguments
+  (Simon Cruanes)
 - GPR#17: some cmm optimizations of integer operations with constants
   (Stephen Dolan, review by Pierre Chambart)
 - GPR#109: new unboxing strategy for float and int references (Vladimir Brankov,

--- a/bytecomp/typeopt.ml
+++ b/bytecomp/typeopt.ml
@@ -49,6 +49,15 @@ let maybe_pointer_type env typ =
            causing some .cmi files to be unavailable.
            Maybe we should emit a warning. *)
       end
+  | Tvariant row ->
+      let row = Btype.row_repr row in
+      (* if all labels are devoid of arguments, not a pointer *)
+      not row.row_closed
+      || List.exists
+          (function
+            | _, (Rpresent (Some _) | Reither (false, _, _, _)) -> true
+            | _ -> false)
+          row.row_fields
   | _ -> true
 
 let maybe_pointer exp = maybe_pointer_type exp.exp_env exp.exp_type

--- a/testsuite/tests/translprim/ref_spec.ml
+++ b/testsuite/tests/translprim/ref_spec.ml
@@ -40,3 +40,13 @@ gen_rec.y <- D "foo";;
 gen_rec.y <- C;;
 flt_rec.y <- 1.;;
 flt_rec'.z <- 1.;;
+
+(* must use a write barrier, type is open *)
+let set_open_poly (r:[>`Foo] ref) y = r := y ;;
+let set_open_poly (r:[<`Foo] ref) y = r := y ;;
+let set_open_poly (r:[`Foo] ref) y = r := y ;;
+let set_open_poly (r:[< `Bar | `Foo | `Baz > `Foo `Bar] ref) y = r := y ;;
+let set_open_poly (r:[>`Foo of int] ref) y = r := y ;;
+let set_open_poly (r:[<`Foo of int] ref) y = r := y ;;
+let set_open_poly (r:[`Foo of int] ref) y = r := y ;;
+let set_open_poly (r:[< `Bar | `Foo of float | `Baz > `Foo `Bar] ref) y = r := y ;;

--- a/testsuite/tests/translprim/ref_spec.ml.reference
+++ b/testsuite/tests/translprim/ref_spec.ml.reference
@@ -6,7 +6,7 @@
      cst_ref = (makemutable 0 0a)
      gen_ref = (makemutable 0 0a)
      flt_ref = (makemutable 0 0.))
-    (seq (setfield_imm 0 int_ref 2) (setfield_ptr 0 var_ref 66a)
+    (seq (setfield_imm 0 int_ref 2) (setfield_imm 0 var_ref 66a)
       (setfield_ptr 0 vargen_ref [0: 66 0])
       (setfield_ptr 0 vargen_ref 67a) (setfield_imm 0 cst_ref 1a)
       (setfield_ptr 0 gen_ref [0: "foo"])
@@ -20,14 +20,31 @@
          flt_rec = (makemutable 0 0a 0.)
          flt_rec' = (makearray[float] 0. 0.))
         (seq (setfield_imm 1 int_rec 2)
-          (setfield_ptr 1 var_rec 66a)
+          (setfield_imm 1 var_rec 66a)
           (setfield_ptr 1 vargen_rec [0: 66 0])
           (setfield_ptr 1 vargen_rec 67a)
           (setfield_imm 1 cst_rec 1a)
           (setfield_ptr 1 gen_rec [0: "foo"])
           (setfield_ptr 1 gen_rec 0a) (setfield_ptr 1 flt_rec 1.)
           (setfloatfield 1 flt_rec' 1.)
-          (makeblock 0 int_ref var_ref vargen_ref cst_ref
-            gen_ref flt_ref int_rec var_rec
-            vargen_rec cst_rec gen_rec flt_rec
-            flt_rec'))))))
+          (let
+            (set_open_poly =
+               (function r y (setfield_ptr 0 r y))
+             set_open_poly =
+               (function r y (setfield_imm 0 r y))
+             set_open_poly =
+               (function r y (setfield_imm 0 r y))
+             set_open_poly =
+               (function r y (setfield_imm 0 r y))
+             set_open_poly =
+               (function r y (setfield_ptr 0 r y))
+             set_open_poly =
+               (function r y (setfield_ptr 0 r y))
+             set_open_poly =
+               (function r y (setfield_ptr 0 r y))
+             set_open_poly =
+               (function r y (setfield_ptr 0 r y)))
+            (makeblock 0 int_ref var_ref vargen_ref
+              cst_ref gen_ref flt_ref int_rec
+              var_rec vargen_rec cst_rec gen_rec
+              flt_rec flt_rec' set_open_poly)))))))


### PR DESCRIPTION
See http://caml.inria.fr/mantis/view.php?id=7026
I am not very confident in my patch, although it looks like it solves the test case above, for I am not familiar with `typing/types.ml`. Maybe I missed a case.

It might also be interesting to do the same for arrays.
