### PR TITLE
Fix PR7040: report duplicate methods in a class, also for virtual methods

### DIFF
--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -630,10 +630,12 @@ let rec class_field self_loc cl_num self_type meths vars
 
   | Pcf_method (lab, priv, Cfk_virtual sty) ->
       let cty = virtual_method val_env meths self_type lab.txt priv sty loc in
+      if Concr.mem lab.txt local_meths then
+        raise(Error(loc, val_env, Duplicate ("method", lab.txt)));
       (val_env, met_env, par_env,
         lazy (mkcf(Tcf_method (lab, priv, Tcfk_virtual cty)))
        ::fields,
-        concr_meths, warn_vals, inher, local_meths, local_vals)
+        concr_meths, warn_vals, inher, Concr.add lab.txt local_meths, local_vals)
 
   | Pcf_method (lab, priv, Cfk_concrete (ovf, expr))  ->
       let expr =


### PR DESCRIPTION
See http://caml.inria.fr/mantis/view.php?id=7040

There is already an error that reports duplicated methods in a class:

``` ocaml
# class c = object method x = 1 method x = 2 end;;
Characters 30-42:
  class c = object method x = 1 method x = 2 end;;
                                ^^^^^^^^^^^^
Error: The method `x' has multiple definitions in this object
```

This PR triggers the same error in case of duplication between two virtual methods or one virtual and one non-virtual method.
