### PR TITLE
PR#6935:ocamldebug:load_printer raise uncaught exception when passing directory

### DIFF
--- a/Changes
+++ b/Changes
@@ -174,6 +174,8 @@ Toplevel and debugger:
 - PR#6468: toplevel now supports backtraces if invoked with OCAMLRUNPARAM=b
   (Peter Zotov and Jake Donham,
    review by Gabriel Scherer and Jacques-Henri Jourdan)
+- PR#6935, GPR#298: crash in debugger when load_printer is given a directory
+  (Junsong Li, review by Gabriel Scherer)
 
 Other libraries:
 - PR#4023 and GPR#68: add Unix.sleepf (sleep with sub-second resolution)

--- a/debugger/loadprinter.ml
+++ b/debugger/loadprinter.ml
@@ -76,6 +76,9 @@ let rec loadfiles ppf name =
   | Not_found ->
       fprintf ppf "Cannot find file %s@." name;
       false
+  | Sys_error msg ->
+      fprintf ppf "%s: %s@." name msg;
+      false
   | Dynlink.Error e ->
       raise(Error(Load_failure e))
 


### PR DESCRIPTION
Fix by catching Sys_error exception.
