### PR TITLE
Suggest to open Bigarray when using its indexing operators.

### DIFF
--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -991,7 +991,14 @@ let report_error env ppf = function
         s "Multiple occurences are not allowed."
   | Unbound_value lid ->
       fprintf ppf "Unbound value %a" longident lid;
-      spellcheck ppf fold_values env lid;
+      begin match lid with
+      | Longident.Lident (".{}" | ".{,}" | ".{,,}" | ".{,..,}"
+                         |".{}<-" | ".{,}<-" | ".{,,}<-" | ".{,..,}<-"
+                         ) ->
+          fprintf ppf " (you might want to 'open Bigarray')"
+      | _ ->
+          spellcheck ppf fold_values env lid
+      end
   | Unbound_module lid ->
       fprintf ppf "Unbound module %a" longident lid;
       spellcheck ppf fold_modules env lid;


### PR DESCRIPTION
This PR implements the proposal from http://caml.inria.fr/mantis/view.php?id=6765 .  Now that .{}-like operators are user-definable, one needs to explicitly `open Bigarray`.  To help with the transition, this PR adapts the "Unbound value" error printer to suggest opening Bigarray.

If #248 is accepted, one should change the text of the suggestion.

Note that on Mantis, it was also discussed to add a hack to automatically lookup those operators in Bigarray and issue a warning.  Perhaps we should accept the patch there and keep this PR for later (when the hack is removed).
