### PR TITLE
Build the compiler with debugging informations

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -17,8 +17,8 @@ CAMLRUN ?= boot/ocamlrun
 CAMLYACC ?= boot/ocamlyacc
 include stdlib/StdlibModules
 
-CAMLC=$(CAMLRUN) boot/ocamlc -nostdlib -I boot
-CAMLOPT=$(CAMLRUN) ./ocamlopt -nostdlib -I stdlib -I otherlibs/dynlink
+CAMLC=$(CAMLRUN) boot/ocamlc -g -nostdlib -I boot
+CAMLOPT=$(CAMLRUN) ./ocamlopt -g -nostdlib -I stdlib -I otherlibs/dynlink
 COMPFLAGS=-strict-sequence -w +33..39+48+50 -warn-error A -bin-annot \
           -safe-string $(INCLUDES)
 LINKFLAGS=


### PR DESCRIPTION
I think that the impact on performances on the compiler is not sufficiently big to justify not adding debug informations to the compiler.

They are currently not very useful since they are cut early by the main and optmain module, but I will propose a later patch to fix those if everybody is ok to enable -g.
