### PR TITLE
Add AppVeyor continuous integration

### DIFF
--- a/Makefile.nt
+++ b/Makefile.nt
@@ -273,7 +273,7 @@ installoptopt:
 # Run all tests
 
 tests: opt.opt
-	cd testsuite; $(MAKE) clean && $(MAKE) all
+	cd testsuite && $(MAKE) clean && $(MAKE) all
 
 # The clean target
 

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -185,32 +185,33 @@ INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 INSTALL_COMPLIBDIR=$(DESTDIR)$(COMPLIBDIR)
 INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 INSTALL_MANDIR=$(DESTDIR)$(MANDIR)
+INSTALL_DISTRIB=$(DESTDIR)$(PREFIX)
 
 install: installbyt installopt
 
 installbyt:
-	mkdir -p $(INSTALL_BINDIR)
-	mkdir -p $(INSTALL_LIBDIR)
-	mkdir -p $(INSTALL_STUBLIBDIR)
-	mkdir -p $(INSTALL_COMPLIBDIR)
-	cp VERSION $(INSTALL_LIBDIR)/
+	mkdir -p "$(INSTALL_BINDIR)"
+	mkdir -p "$(INSTALL_LIBDIR)"
+	mkdir -p "$(INSTALL_STUBLIBDIR)"
+	mkdir -p "$(INSTALL_COMPLIBDIR)"
+	cp VERSION "$(INSTALL_LIBDIR)/"
 	cd byterun ; $(MAKEREC) install
-	cp ocamlc $(INSTALL_BINDIR)/ocamlc.exe
-	cp ocaml $(INSTALL_BINDIR)/ocaml.exe
+	cp ocamlc "$(INSTALL_BINDIR)/ocamlc.exe"
+	cp ocaml "$(INSTALL_BINDIR)/ocaml.exe"
 	cd stdlib ; $(MAKEREC) install
-	cp lex/ocamllex $(INSTALL_BINDIR)/ocamllex.exe
-	cp yacc/ocamlyacc.exe $(INSTALL_BINDIR)/ocamlyacc.exe
+	cp lex/ocamllex "$(INSTALL_BINDIR)/ocamllex.exe"
+	cp yacc/ocamlyacc.exe "$(INSTALL_BINDIR)/ocamlyacc.exe"
 	cp utils/*.cmi utils/*.cmt utils/*.cmti \
 	   parsing/*.cmi parsing/*.cmt parsing/*.cmti \
 	   typing/*.cmi typing/*.cmt typing/*.cmti \
 	   bytecomp/*.cmi bytecomp/*.cmt bytecomp/*.cmti \
 	   driver/*.cmi driver/*.cmt driver/*.cmti \
-	   toplevel/*.cmi toplevel/*.cmt toplevel/*.cmti $(INSTALL_COMPLIBDIR)
+	   toplevel/*.cmi toplevel/*.cmt toplevel/*.cmti "$(INSTALL_COMPLIBDIR)"
 	cp compilerlibs/ocamlcommon.cma compilerlibs/ocamlbytecomp.cma \
 	   compilerlibs/ocamltoplevel.cma $(BYTESTART) $(TOPLEVELSTART) \
-	   $(INSTALL_COMPLIBDIR)
-	cp expunge $(INSTALL_LIBDIR)/expunge.exe
-	cp toplevel/topdirs.cmi $(INSTALL_LIBDIR)
+	   "$(INSTALL_COMPLIBDIR)"
+	cp expunge "$(INSTALL_LIBDIR)/expunge.exe"
+	cp toplevel/topdirs.cmi "$(INSTALL_LIBDIR)"
 	cd tools ; $(MAKEREC) install
 	for i in $(OTHERLIBRARIES); do \
 	  $(MAKEREC) -C otherlibs/$$i install || exit $$?; \
@@ -223,11 +224,11 @@ installbyt:
 	   else :; fi
 	if test -n "$(FLEXDLL_SUBMODULE_PRESENT)"; then $(MAKEREC) install-flexdll; \
 	   else :; fi
-	cp config/Makefile $(INSTALL_LIBDIR)/Makefile.config
-	cp README.adoc $(INSTALL_DISTRIB)/Readme.general.txt
-	cp README.win32.adoc $(INSTALL_DISTRIB)/Readme.windows.txt
-	cp LICENSE $(INSTALL_DISTRIB)/License.txt
-	cp Changes $(INSTALL_DISTRIB)/Changes.txt
+	cp config/Makefile "$(INSTALL_LIBDIR)/Makefile.config"
+	cp README.adoc "$(INSTALL_DISTRIB)/Readme.general.txt"
+	cp README.win32.adoc "$(INSTALL_DISTRIB)/Readme.windows.txt"
+	cp LICENSE "$(INSTALL_DISTRIB)/License.txt"
+	cp Changes "$(INSTALL_DISTRIB)/Changes.txt"
 
 install-flexdll:
 # The $(if ...) installs the correct .manifest file for MSVC and MSVC64
@@ -238,14 +239,14 @@ install-flexdll:
 # Installation of the native-code compiler
 installopt:
 	cd asmrun ; $(MAKEREC) install
-	cp ocamlopt $(INSTALL_BINDIR)/ocamlopt.exe
+	cp ocamlopt "$(INSTALL_BINDIR)/ocamlopt.exe"
 	cd stdlib ; $(MAKEREC) installopt
 	cp middle_end/*.cmi middle_end/*.cmt middle_end/*.cmti \
-		$(INSTALL_COMPLIBDIR)
+		"$(INSTALL_COMPLIBDIR)"
 	cp middle_end/base_types/*.cmi middle_end/base_types/*.cmt \
-		middle_end/base_types/*.cmti $(INSTALL_COMPLIBDIR)
-	cp asmcomp/*.cmi asmcomp/*.cmt asmcomp/*.cmti $(INSTALL_COMPLIBDIR)
-	cp compilerlibs/ocamloptcomp.cma $(OPTSTART) $(INSTALL_COMPLIBDIR)
+		middle_end/base_types/*.cmti "$(INSTALL_COMPLIBDIR)"
+	cp asmcomp/*.cmi asmcomp/*.cmt asmcomp/*.cmti "$(INSTALL_COMPLIBDIR)"
+	cp compilerlibs/ocamloptcomp.cma $(OPTSTART) "$(INSTALL_COMPLIBDIR)"
 	if test -n "$(WITH_OCAMLDOC)"; then (cd ocamldoc; $(MAKEREC) installopt); fi
 	if test -n "$(WITH_OCAMLBUILD)"; then (cd ocamlbuild; $(MAKE) installopt); \
 	   else :; fi
@@ -257,17 +258,17 @@ installopt:
 	if test -f ocamlopt.opt -a -f flexdll/flexlink.opt ; then cp -f flexdll/flexlink.opt $(INSTALL_BINDIR)/flexlink.exe ; fi
 
 installoptopt:
-	cp ocamlc.opt $(INSTALL_BINDIR)/ocamlc.opt$(EXE)
-	cp ocamlopt.opt $(INSTALL_BINDIR)/ocamlopt.opt$(EXE)
-	cp lex/ocamllex.opt $(INSTALL_BINDIR)/ocamllex.opt$(EXE)
+	cp ocamlc.opt "$(INSTALL_BINDIR)/ocamlc.opt$(EXE)"
+	cp ocamlopt.opt "$(INSTALL_BINDIR)/ocamlopt.opt$(EXE)"
+	cp lex/ocamllex.opt "$(INSTALL_BINDIR)/ocamllex.opt$(EXE)"
 	cp utils/*.cmx parsing/*.cmx typing/*.cmx bytecomp/*.cmx \
-           driver/*.cmx asmcomp/*.cmx $(INSTALL_COMPLIBDIR)
+           driver/*.cmx asmcomp/*.cmx "$(INSTALL_COMPLIBDIR)"
 	cp compilerlibs/ocamlcommon.cmxa compilerlibs/ocamlcommon.$(A) \
            compilerlibs/ocamlbytecomp.cmxa compilerlibs/ocamlbytecomp.$(A) \
            compilerlibs/ocamloptcomp.cmxa compilerlibs/ocamloptcomp.$(A) \
            $(BYTESTART:.cmo=.cmx) $(BYTESTART:.cmo=.$(O)) \
            $(OPTSTART:.cmo=.cmx) $(OPTSTART:.cmo=.$(O)) \
-           $(INSTALL_COMPLIBDIR)
+           "$(INSTALL_COMPLIBDIR)"
 
 clean:: partialclean
 

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -270,6 +270,13 @@ installoptopt:
            $(OPTSTART:.cmo=.cmx) $(OPTSTART:.cmo=.$(O)) \
            "$(INSTALL_COMPLIBDIR)"
 
+# Run all tests
+
+tests: opt.opt
+	cd testsuite; $(MAKE) clean && $(MAKE) all
+
+# The clean target
+
 clean:: partialclean
 
 # The compiler

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,51 @@
+# Compile the 64 bits version
+platform:
+  - x64
+
+branches:
+  only:
+    - trunk
+
+# Do a shallow clone of the repo to speed up the build
+clone_depth: 1
+
+environment:
+  global:
+    CYG_ROOT: C:/cygwin
+    CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
+    CYG_CACHE: C:/cygwin/var/cache/setup
+    OCAMLROOT: "%PROGRAMFILES%/OCaml"
+
+cache:
+  - C:\cygwin\var\cache\setup
+
+install:
+  - mkdir "%OCAMLROOT%"
+  - mkdir "%OCAMLROOT%/bin"
+  - mkdir "%OCAMLROOT%/bin/flexdll"
+  - appveyor DownloadFile "http://alain.frisch.fr/flexdll/flexdll-bin-0.34.zip" -FileName "flexdll.zip"
+  - cinst 7zip.commandline
+  - 7za x -y flexdll.zip
+  - for %%F in (*.c *.h *.exe *.o *.obj) do copy %%F "%OCAMLROOT%\bin\flexdll"
+  # Make sure the Cygwin path comes before the Git one (otherwise
+  # cygpath behaves crazily), but after the MSVC one.
+  - set Path=C:\cygwin\bin;%Path%
+  - '"%CYG_ROOT%\setup-x86.exe" -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P diffutils -P dos2unix -P gcc-core -P make -P ncurses >NUL'
+  - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
+  - call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
+  - set Path=%OCAMLROOT%\bin;%OCAMLROOT%\bin\flexdll;%Path%
+
+build_script:
+  - set PFPATH=%PROGRAMFILES%
+  - set FLEXDLLDIR=%OCAMLROOT%\bin\flexdll
+  - echo VCPATH="`cygpath -p '%Path%'`" > %CYG_ROOT%\tmp\msenv
+  - echo LIB="%LIB%" >> %CYG_ROOT%\tmp\msenv
+  - echo LIBPATH="%LIBPATH%" >> %CYG_ROOT%\tmp\msenv
+  - echo INCLUDE="%INCLUDE%;%FLEXDLLDIR%" >> %CYG_ROOT%\tmp\msenv
+  - echo FLPATH="`cygpath '%FLEXDLLDIR%'`" >> %CYG_ROOT%\tmp\msenv
+  - echo PATH="$VCPATH:$FLPATH:$PATH" >> %CYG_ROOT%\tmp\msenv
+  - echo export PATH LIB LIBPATH INCLUDE >> %CYG_ROOT%\tmp\msenv
+  - echo export OCAMLBUILD_FIND=/usr/bin/find >> %CYG_ROOT%\tmp\msenv
+  - "%CYG_ROOT%/bin/bash -lc \"tr -d '\\r' </tmp/msenv > ~/.msenv64\""
+  - "%CYG_ROOT%/bin/bash -lc \"echo '. ~/.msenv64' >> ~/.bash_profile\""
+  - '%CYG_ROOT%/bin/bash -lc "$APPVEYOR_BUILD_FOLDER/appveyor_build.sh"'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,3 +49,8 @@ build_script:
   - "%CYG_ROOT%/bin/bash -lc \"tr -d '\\r' </tmp/msenv > ~/.msenv64\""
   - "%CYG_ROOT%/bin/bash -lc \"echo '. ~/.msenv64' >> ~/.bash_profile\""
   - '%CYG_ROOT%/bin/bash -lc "$APPVEYOR_BUILD_FOLDER/appveyor_build.sh"'
+
+test_script:
+  - ocamlc -version
+  - set CAML_LD_LIBRARY_PATH=%OCAMLROOT%/lib/stublibs
+  - '%CYG_ROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && make -f Makefile.nt tests"'

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+function run {
+    NAME=$1
+    shift
+    echo "-=-=- $NAME -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
+    $@
+    CODE=$?
+    if [ $CODE -ne 0 ]; then
+        echo "-=-=- $NAME failed! -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
+        exit $CODE
+    else
+        echo "-=-=- End of $NAME -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
+    fi
+}
+
+cd $APPVEYOR_BUILD_FOLDER
+
+cp config/m-nt.h config/m.h
+cp config/s-nt.h config/s.h
+#cp config/Makefile.msvc config/Makefile
+cp config/Makefile.msvc64 config/Makefile
+
+PREFIX="C:/Program Files/OCaml"
+echo "Edit config/Makefile so set PREFIX=$PREFIX"
+cp config/Makefile config/Makefile.bak
+sed -e "s|PREFIX=.*|PREFIX=$PREFIX|" config/Makefile.bak > config/Makefile
+#run "Content of config/Makefile" cat config/Makefile
+
+run "make world" make -f Makefile.nt world
+run "make bootstrap" make -f Makefile.nt bootstrap
+run "make opt" make -f Makefile.nt opt
+run "make opt.opt" make -f Makefile.nt opt.opt
+run "make install" make -f Makefile.nt install

--- a/asmrun/Makefile.nt
+++ b/asmrun/Makefile.nt
@@ -61,7 +61,7 @@ amd64.o: amd64.S
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
 install:
-	cp libasmrun.$(A) $(INSTALL_LIBDIR)
+	cp libasmrun.$(A) "$(INSTALL_LIBDIR)"
 
 $(LINKEDFILES): %.c: ../byterun/%.c
 	cp ../byterun/$*.c $*.c

--- a/byterun/Makefile
+++ b/byterun/Makefile
@@ -66,9 +66,9 @@ install-noshared:
 .PHONY: install-noshared
 
 install-shared:
-	cp libcamlrun_shared.so $(INSTALL_LIBDIR)/libcamlrun_shared.so
-	cp libcamlrun_pic.a $(INSTALL_LIBDIR)/libcamlrun_pic.a
-	cd $(INSTALL_LIBDIR); $(RANLIB) libcamlrun_pic.a
+	cp libcamlrun_shared.so "$(INSTALL_LIBDIR)/libcamlrun_shared.so"
+	cp libcamlrun_pic.a "$(INSTALL_LIBDIR)/libcamlrun_pic.a"
+	cd "$(INSTALL_LIBDIR)"; $(RANLIB) libcamlrun_pic.a
 .PHONY: install-shared
 
 clean::

--- a/byterun/Makefile.common
+++ b/byterun/Makefile.common
@@ -63,15 +63,15 @@ INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
 
 install::
-	cp $(CAMLRUN)$(EXE) $(INSTALL_BINDIR)/ocamlrun$(EXE)
-	cp libcamlrun.$(A) $(INSTALL_LIBDIR)/libcamlrun.$(A)
-	cd $(INSTALL_LIBDIR); $(RANLIB) libcamlrun.$(A)
-	if test -d $(INSTALL_LIBDIR)/caml; then : ; \
-	  else mkdir $(INSTALL_LIBDIR)/caml; fi
+	cp $(CAMLRUN)$(EXE) "$(INSTALL_BINDIR)/ocamlrun$(EXE)"
+	cp libcamlrun.$(A) "$(INSTALL_LIBDIR)/libcamlrun.$(A)"
+	cd "$(INSTALL_LIBDIR)"; $(RANLIB) libcamlrun.$(A)
+	if test -d "$(INSTALL_LIBDIR)/caml"; then : ; \
+	  else mkdir "$(INSTALL_LIBDIR)/caml"; fi
 	for i in $(PUBLIC_INCLUDES); do \
-	  sed -f ../tools/cleanup-header caml/$$i > $(INSTALL_LIBDIR)/caml/$$i; \
+	  sed -f ../tools/cleanup-header caml/$$i > "$(INSTALL_LIBDIR)/caml/$$i"; \
 	done
-	cp ld.conf $(INSTALL_LIBDIR)/ld.conf
+	cp ld.conf "$(INSTALL_LIBDIR)/ld.conf"
 .PHONY: install
 
 install:: install-$(RUNTIMED)
@@ -84,8 +84,8 @@ install-noruntimed:
 # because it's an executable for the target machine, while we're installing
 # binaries for the host.
 install-runtimed:
-	cp ocamlrund$(EXE) $(INSTALL_BINDIR)/ocamlrund$(EXE)
-	cp libcamlrund.$(A) $(INSTALL_LIBDIR)/libcamlrund.$(A)
+	cp ocamlrund$(EXE) "$(INSTALL_BINDIR)/ocamlrund$(EXE)"
+	cp libcamlrund.$(A) "$(INSTALL_LIBDIR)/libcamlrund.$(A)"
 .PHONY: install-runtimed
 
 ifeq "$(RUNTIMEI)" "true"

--- a/debugger/Makefile.shared
+++ b/debugger/Makefile.shared
@@ -91,7 +91,7 @@ ocamldebug$(EXE): $(OBJS) $(OTHEROBJS)
 	$(CAMLC) $(LINKFLAGS) -o ocamldebug$(EXE) -linkall $(OTHEROBJS) $(OBJS)
 
 install:
-	cp ocamldebug$(EXE) $(INSTALL_BINDIR)/ocamldebug$(EXE)
+	cp ocamldebug$(EXE) "$(INSTALL_BINDIR)/ocamldebug$(EXE)"
 
 clean::
 	rm -f ocamldebug$(EXE)

--- a/ocamlbuild/Makefile
+++ b/ocamlbuild/Makefile
@@ -168,19 +168,19 @@ beforedepend:: glob_lexer.ml
 # Installation
 
 install:
-	$(CP) ocamlbuild.byte $(INSTALL_BINDIR)/ocamlbuild$(EXE)
-	$(CP) ocamlbuild.byte $(INSTALL_BINDIR)/ocamlbuild.byte$(EXE)
-	mkdir -p $(INSTALL_LIBDIR)
-	$(CP) $(INSTALL_LIB) $(INSTALL_LIBDIR)/
+	$(CP) ocamlbuild.byte "$(INSTALL_BINDIR)/ocamlbuild$(EXE)"
+	$(CP) ocamlbuild.byte "$(INSTALL_BINDIR)/ocamlbuild.byte$(EXE)"
+	mkdir -p "$(INSTALL_LIBDIR)"
+	$(CP) $(INSTALL_LIB) "$(INSTALL_LIBDIR)/"
 
 installopt:
 	if test -f ocamlbuild.native; then $(MAKE) installopt_really; fi
 
 installopt_really:
-	$(CP) ocamlbuild.native $(INSTALL_BINDIR)/ocamlbuild$(EXE)
-	$(CP) ocamlbuild.native $(INSTALL_BINDIR)/ocamlbuild.native$(EXE)
-	mkdir -p $(INSTALL_LIBDIR)
-	$(CP) $(INSTALL_LIB_OPT) $(INSTALL_LIBDIR)/
+	$(CP) ocamlbuild.native "$(INSTALL_BINDIR)/ocamlbuild$(EXE)"
+	$(CP) ocamlbuild.native "$(INSTALL_BINDIR)/ocamlbuild.native$(EXE)"
+	mkdir -p "$(INSTALL_LIBDIR)"
+	$(CP) $(INSTALL_LIB_OPT) "$(INSTALL_LIBDIR)/"
 
 # The generic rules
 

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -253,24 +253,24 @@ odoc_see_lexer.ml: odoc_see_lexer.mll
 # Installation targets
 ######################
 install: dummy
-	if test -d $(INSTALL_BINDIR); then : ; else $(MKDIR) $(INSTALL_BINDIR); fi
-	if test -d $(INSTALL_LIBDIR); then : ; else $(MKDIR) $(INSTALL_LIBDIR); fi
-	if test -d $(INSTALL_CUSTOMDIR); then : ; else $(MKDIR) $(INSTALL_CUSTOMDIR); fi
-	$(CP) $(OCAMLDOC) $(INSTALL_BINDIR)/$(OCAMLDOC)$(EXE)
-	$(CP) ocamldoc.hva *.cmi $(OCAMLDOC_LIBCMA) $(INSTALL_LIBDIR)
-	$(CP) $(INSTALL_MLIS) $(INSTALL_CMIS) $(INSTALL_LIBDIR)
-	if test -d $(INSTALL_MANODIR); then : ; else $(MKDIR) $(INSTALL_MANODIR); fi
-	if test -d stdlib_man; then $(CP) stdlib_man/* $(INSTALL_MANODIR); else : ; fi
+	if test -d "$(INSTALL_BINDIR)"; then : ; else $(MKDIR) "$(INSTALL_BINDIR)"; fi
+	if test -d "$(INSTALL_LIBDIR)"; then : ; else $(MKDIR) "$(INSTALL_LIBDIR)"; fi
+	if test -d "$(INSTALL_CUSTOMDIR)"; then : ; else $(MKDIR) "$(INSTALL_CUSTOMDIR)"; fi
+	$(CP) $(OCAMLDOC) "$(INSTALL_BINDIR)/$(OCAMLDOC)$(EXE)"
+	$(CP) ocamldoc.hva *.cmi $(OCAMLDOC_LIBCMA) "$(INSTALL_LIBDIR)"
+	$(CP) $(INSTALL_MLIS) $(INSTALL_CMIS) "$(INSTALL_LIBDIR)"
+	if test -d "$(INSTALL_MANODIR)"; then : ; else $(MKDIR) "$(INSTALL_MANODIR)"; fi
+	if test -d stdlib_man; then $(CP) stdlib_man/* "$(INSTALL_MANODIR)"; else : ; fi
 
 installopt:
 	if test -f $(OCAMLDOC_OPT); then $(MAKE) installopt_really ; fi
 
 installopt_really:
-	if test -d $(INSTALL_BINDIR); then : ; else $(MKDIR) $(INSTALL_BINDIR); fi
-	if test -d $(INSTALL_LIBDIR); then : ; else $(MKDIR) $(INSTALL_LIBDIR); fi
-	$(CP) $(OCAMLDOC_OPT) $(INSTALL_BINDIR)/$(OCAMLDOC_OPT)$(EXE)
-	$(CP) ocamldoc.hva *.cmx $(OCAMLDOC_LIBA) $(OCAMLDOC_LIBCMXA) $(INSTALL_LIBDIR)
-	$(CP) $(INSTALL_MLIS) $(INSTALL_CMIS) $(INSTALL_LIBDIR)
+	if test -d "$(INSTALL_BINDIR)"; then : ; else $(MKDIR) "$(INSTALL_BINDIR)"; fi
+	if test -d "$(INSTALL_LIBDIR)"; then : ; else $(MKDIR) "$(INSTALL_LIBDIR)"; fi
+	$(CP) $(OCAMLDOC_OPT) "$(INSTALL_BINDIR)/$(OCAMLDOC_OPT)$(EXE)"
+	$(CP) ocamldoc.hva *.cmx $(OCAMLDOC_LIBA) $(OCAMLDOC_LIBCMXA) "$(INSTALL_LIBDIR)"
+	$(CP) $(INSTALL_MLIS) $(INSTALL_CMIS) "$(INSTALL_LIBDIR)"
 
 # Testing :
 ###########

--- a/ocamldoc/Makefile.nt
+++ b/ocamldoc/Makefile.nt
@@ -210,21 +210,22 @@ odoc_see_lexer.ml: odoc_see_lexer.mll
 # Installation targets
 ######################
 install: dummy
-	$(MKDIR) -p $(INSTALL_BINDIR)
-	$(MKDIR) -p $(INSTALL_LIBDIR)
-	$(CP) $(OCAMLDOC) $(INSTALL_BINDIR)/$(OCAMLDOC)$(EXE)
-	$(CP) ocamldoc.hva *.cmi $(OCAMLDOC_LIBCMA) $(INSTALL_LIBDIR)
-	$(CP) $(INSTALL_MLIS) $(INSTALL_CMIS) $(INSTALL_LIBDIR)
+	$(MKDIR) -p "$(INSTALL_BINDIR)"
+	$(MKDIR) -p "$(INSTALL_LIBDIR)"
+	$(CP) $(OCAMLDOC) "$(INSTALL_BINDIR)/$(OCAMLDOC)$(EXE)"
+	$(CP) ocamldoc.hva *.cmi $(OCAMLDOC_LIBCMA) "$(INSTALL_LIBDIR)"
+	$(CP) $(INSTALL_MLIS) $(INSTALL_CMIS) "$(INSTALL_LIBDIR)"
 
 installopt:
 	if test -f $(OCAMLDOC_OPT); then $(MAKEREC) installopt_really; fi
 
 installopt_really:
-	$(MKDIR) -p $(INSTALL_BINDIR)
-	$(MKDIR) -p $(INSTALL_LIBDIR)
-	$(CP) $(OCAMLDOC_OPT) $(INSTALL_BINDIR)/$(OCAMLDOC_OPT)$(EXE)
-	$(CP) ocamldoc.hva $(OCAMLDOC_LIBA) $(OCAMLDOC_LIBCMXA) $(INSTALL_LIBDIR)
-	$(CP) $(INSTALL_MLIS) $(INSTALL_CMIS) $(INSTALL_LIBDIR)
+	$(MKDIR) -p "$(INSTALL_BINDIR)"
+	$(MKDIR) -p "$(INSTALL_LIBDIR)"
+	$(CP) $(OCAMLDOC_OPT) "$(INSTALL_BINDIR)/$(OCAMLDOC_OPT)$(EXE)"
+	$(CP) ocamldoc.hva $(OCAMLDOC_LIBA) $(OCAMLDOC_LIBCMXA) \
+	  "$(INSTALL_LIBDIR)"
+	$(CP) $(INSTALL_MLIS) $(INSTALL_CMIS) "$(INSTALL_LIBDIR)"
 
 
 # backup, clean and depend :

--- a/otherlibs/Makefile.shared
+++ b/otherlibs/Makefile.shared
@@ -62,16 +62,18 @@ INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 
 install::
 	if test -f dll$(CLIBNAME)$(EXT_DLL); then \
-	  cp dll$(CLIBNAME)$(EXT_DLL) $(INSTALL_STUBLIBDIR)/; fi
-	cp lib$(CLIBNAME).$(A) $(INSTALL_LIBDIR)/
-	cd $(INSTALL_LIBDIR); $(RANLIB) lib$(CLIBNAME).$(A)
-	cp $(LIBNAME).cma $(CMIFILES) $(CMIFILES:.cmi=.mli) $(INSTALL_LIBDIR)/
-	if test -n "$(HEADERS)"; then cp $(HEADERS) $(INSTALL_LIBDIR)/caml/; fi
+	  cp dll$(CLIBNAME)$(EXT_DLL) "$(INSTALL_STUBLIBDIR)/"; fi
+	cp lib$(CLIBNAME).$(A) "$(INSTALL_LIBDIR)/"
+	cd "$(INSTALL_LIBDIR)"; $(RANLIB) lib$(CLIBNAME).$(A)
+	cp $(LIBNAME).cma $(CMIFILES) $(CMIFILES:.cmi=.mli) "$(INSTALL_LIBDIR)/"
+	if test -n "$(HEADERS)"; then \
+	  cp $(HEADERS) "$(INSTALL_LIBDIR)/caml/"; fi
 
 installopt:
-	cp $(CAMLOBJS_NAT) $(LIBNAME).cmxa $(LIBNAME).$(A) $(INSTALL_LIBDIR)/
-	cd $(INSTALL_LIBDIR); $(RANLIB) $(LIBNAME).a
-	if test -f $(LIBNAME).cmxs; then cp $(LIBNAME).cmxs $(INSTALL_LIBDIR)/; fi
+	cp $(CAMLOBJS_NAT) $(LIBNAME).cmxa $(LIBNAME).$(A) "$(INSTALL_LIBDIR)/"
+	cd "$(INSTALL_LIBDIR)"; $(RANLIB) $(LIBNAME).a
+	if test -f $(LIBNAME).cmxs; then \
+	  cp $(LIBNAME).cmxs "$(INSTALL_LIBDIR)/"; fi
 
 partialclean:
 	rm -f *.cm*

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -81,13 +81,13 @@ extract_crc: dynlink.cma extract_crc.cmo
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
 install:
-	cp dynlink.cmi dynlink.cma dynlink.mli $(INSTALL_LIBDIR)
-	cp extract_crc $(INSTALL_LIBDIR)/extract_crc$(EXE)
+	cp dynlink.cmi dynlink.cma dynlink.mli "$(INSTALL_LIBDIR)"
+	cp extract_crc "$(INSTALL_LIBDIR)/extract_crc$(EXE)"
 
 installopt:
 	if $(NATDYNLINK); then \
-	  cp $(NATOBJS) dynlink.cmxa dynlink.$(A) $(INSTALL_LIBDIR) && \
-	  cd $(INSTALL_LIBDIR) && $(RANLIB) dynlink.$(A); \
+	  cp $(NATOBJS) dynlink.cmxa dynlink.$(A) "$(INSTALL_LIBDIR)" && \
+	  cd "$(INSTALL_LIBDIR)" && $(RANLIB) dynlink.$(A); \
 	fi
 
 partialclean:

--- a/otherlibs/systhreads/Makefile.nt
+++ b/otherlibs/systhreads/Makefile.nt
@@ -78,17 +78,18 @@ INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 
 install:
-	cp dllthreads.dll $(INSTALL_STUBLIBDIR)/dllthreads.dll
-	cp libthreads.$(A) $(INSTALL_LIBDIR)/libthreads.$(A)
-	mkdir -p $(INSTALL_LIBDIR)/threads
-	cp $(CMIFILES) threads.cma $(INSTALL_LIBDIR)/threads
-	rm -f $(INSTALL_LIBDIR)/threads/stdlib.cma
-	cp threads.h $(INSTALL_LIBDIR)/caml/threads.h
+	cp dllthreads.dll "$(INSTALL_STUBLIBDIR)/dllthreads.dll"
+	cp libthreads.$(A) "$(INSTALL_LIBDIR)/libthreads.$(A)"
+	mkdir -p "$(INSTALL_LIBDIR)/threads"
+	cp $(CMIFILES) threads.cma "$(INSTALL_LIBDIR)/threads"
+	rm -f "$(INSTALL_LIBDIR)/threads/stdlib.cma"
+	cp threads.h "$(INSTALL_LIBDIR)/caml/threads.h"
 
 installopt:
-	cp libthreadsnat.$(A) $(INSTALL_LIBDIR)/libthreadsnat.$(A)
-	cp $(THREAD_OBJS:.cmo=.cmx) threads.cmxa threads.$(A) $(INSTALL_LIBDIR)/threads
-	cp threads.cmxs $(INSTALL_LIBDIR)/threads
+	cp libthreadsnat.$(A) "$(INSTALL_LIBDIR)/libthreadsnat.$(A)"
+	cp $(THREAD_OBJS:.cmo=.cmx) threads.cmxa threads.$(A) \
+	  "$(INSTALL_LIBDIR)/threads"
+	cp threads.cmxs "$(INSTALL_LIBDIR)/threads"
 
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -25,22 +25,23 @@ allopt-prof: stdlib.p.cmxa std_exit.p.cmx
 installopt: installopt-default installopt-$(PROFILING)
 
 installopt-default:
-	cp stdlib.cmxa stdlib.a std_exit.o *.cmx $(INSTALL_LIBDIR)
-	cd $(INSTALL_LIBDIR); $(RANLIB) stdlib.a
+	cp stdlib.cmxa stdlib.a std_exit.o *.cmx "$(INSTALL_LIBDIR)"
+	cd "$(INSTALL_LIBDIR)"; $(RANLIB) stdlib.a
 
 installopt-noprof:
-	rm -f $(INSTALL_LIBDIR)/stdlib.p.cmxa; \
-	  ln -s stdlib.cmxa $(INSTALL_LIBDIR)/stdlib.p.cmxa
-	rm -f $(INSTALL_LIBDIR)/stdlib.p.a; \
-	  ln -s stdlib.a $(INSTALL_LIBDIR)/stdlib.p.a
-	rm -f $(INSTALL_LIBDIR)/std_exit.p.cmx; \
-	  ln -s std_exit.cmx $(INSTALL_LIBDIR)/std_exit.p.cmx
-	rm -f $(INSTALL_LIBDIR)/std_exit.p.o; \
-	  ln -s std_exit.o $(INSTALL_LIBDIR)/std_exit.p.o
+	rm -f "$(INSTALL_LIBDIR)/stdlib.p.cmxa"; \
+	  ln -s stdlib.cmxa "$(INSTALL_LIBDIR)/stdlib.p.cmxa"
+	rm -f "$(INSTALL_LIBDIR)/stdlib.p.a"; \
+	  ln -s stdlib.a "$(INSTALL_LIBDIR)/stdlib.p.a"
+	rm -f "$(INSTALL_LIBDIR)/std_exit.p.cmx"; \
+	  ln -s std_exit.cmx "$(INSTALL_LIBDIR)/std_exit.p.cmx"
+	rm -f "$(INSTALL_LIBDIR)/std_exit.p.o"; \
+	  ln -s std_exit.o "$(INSTALL_LIBDIR)/std_exit.p.o"
 
 installopt-prof:
-	cp stdlib.p.cmxa stdlib.p.a std_exit.p.cmx std_exit.p.o $(INSTALL_LIBDIR)
-	cd $(INSTALL_LIBDIR); $(RANLIB) stdlib.p.a
+	cp stdlib.p.cmxa stdlib.p.a std_exit.p.cmx std_exit.p.o \
+	  "$(INSTALL_LIBDIR)"
+	cd "$(INSTALL_LIBDIR)"; $(RANLIB) stdlib.p.a
 
 stdlib.p.cmxa: $(OBJS:.cmo=.p.cmx)
 	$(CAMLOPT) -a -o stdlib.p.cmxa $(OBJS:.cmo=.p.cmx)

--- a/stdlib/Makefile.nt
+++ b/stdlib/Makefile.nt
@@ -16,7 +16,7 @@ include Makefile.shared
 allopt: stdlib.cmxa std_exit.cmx
 
 installopt:
-	cp stdlib.cmxa stdlib.$(A) std_exit.$(O) *.cmx $(INSTALL_LIBDIR)
+	cp stdlib.cmxa stdlib.$(A) std_exit.$(O) *.cmx "$(INSTALL_LIBDIR)"
 
 camlheader target_camlheader camlheader_ur: headernt.c ../config/Makefile
 	$(BYTECC) $(BYTECCCOMPOPTS) -c -I../byterun \

--- a/stdlib/Makefile.shared
+++ b/stdlib/Makefile.shared
@@ -56,8 +56,8 @@ INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 install::
 	cp stdlib.cma std_exit.cmo *.cmi *.cmt *.cmti *.mli *.ml \
 	  camlheader_ur \
-	  $(INSTALL_LIBDIR)
-	cp target_camlheader $(INSTALL_LIBDIR)/camlheader
+	  "$(INSTALL_LIBDIR)"
+	cp target_camlheader "$(INSTALL_LIBDIR)/camlheader"
 
 ifeq "$(RUNTIMED)" "runtimed"
 install::
@@ -68,7 +68,6 @@ ifeq "$(RUNTIMEI)" "true"
 install::
 	cp target_camlheaderi $(INSTALL_LIBDIR)
 endif
-
 
 stdlib.cma: $(OBJS)
 	$(CAMLC) -a -o stdlib.cma $(OBJS)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -19,7 +19,7 @@ ocamlmktop: ocamlmktop.tpl ../config/Makefile
 	chmod +x ocamlmktop
 
 install::
-	cp ocamlmktop $(INSTALL_BINDIR)
+	cp ocamlmktop "$(INSTALL_BINDIR)"
 
 clean::
 	rm -f ocamlmktop

--- a/tools/Makefile.nt
+++ b/tools/Makefile.nt
@@ -23,7 +23,7 @@ ocamlmktop: $(OCAMLMKTOP)
 	$(CAMLC) $(LINKFLAGS) -o ocamlmktop $(OCAMLMKTOP_IMPORTS) $(OCAMLMKTOP)
 
 install::
-	cp ocamlmktop $(INSTALL_BINDIR)/ocamlmktop$(EXE)
+	cp ocamlmktop "$(INSTALL_BINDIR)/ocamlmktop$(EXE)"
 
 clean::
 	rm -f ocamlmktop objinfo_helper$(EXE).manifest

--- a/tools/Makefile.shared
+++ b/tools/Makefile.shared
@@ -60,9 +60,9 @@ INSTALL_BINDIR=$(DESTDIR)$(BINDIR)
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
 install::
-	cp ocamldep $(INSTALL_BINDIR)/ocamldep$(EXE)
-	if test -f ocamldep.opt; \
-	  then cp ocamldep.opt $(INSTALL_BINDIR)/ocamldep.opt$(EXE); else :; fi
+	cp ocamldep "$(INSTALL_BINDIR)/ocamldep$(EXE)"
+	if test -f ocamldep.opt; then \
+	  cp ocamldep.opt "$(INSTALL_BINDIR)/ocamldep.opt$(EXE)"; else :; fi
 
 # The profiler
 
@@ -87,13 +87,13 @@ ocamloptp: ocamloptp.cmo
 opt:: profiling.cmx
 
 install::
-	cp ocamlprof $(INSTALL_BINDIR)/ocamlprof$(EXE)
-	cp ocamlcp $(INSTALL_BINDIR)/ocamlcp$(EXE)
-	cp ocamloptp $(INSTALL_BINDIR)/ocamloptp$(EXE)
-	cp profiling.cmi profiling.cmo $(INSTALL_LIBDIR)
+	cp ocamlprof "$(INSTALL_BINDIR)/ocamlprof$(EXE)"
+	cp ocamlcp "$(INSTALL_BINDIR)/ocamlcp$(EXE)"
+	cp ocamloptp "$(INSTALL_BINDIR)/ocamloptp$(EXE)"
+	cp profiling.cmi profiling.cmo "$(INSTALL_LIBDIR)"
 
 installopt::
-	cp profiling.cmx profiling.$(O) $(INSTALL_LIBDIR)
+	cp profiling.cmx profiling.$(O) "$(INSTALL_LIBDIR)"
 
 clean::
 	rm -f ocamlprof ocamlcp ocamloptp
@@ -105,7 +105,7 @@ ocamlmklib: ocamlmklibconfig.cmo ocamlmklib.cmo
 	$(CAMLC) $(LINKFLAGS) -o ocamlmklib ocamlmklibconfig.cmo config.cmo ocamlmklib.cmo
 
 install::
-	cp ocamlmklib $(INSTALL_BINDIR)/ocamlmklib$(EXE)
+	cp ocamlmklib "$(INSTALL_BINDIR)/ocamlmklib$(EXE)"
 
 clean::
 	rm -f ocamlmklib
@@ -137,7 +137,7 @@ lexer299.ml: lexer299.mll
 	$(CAMLLEX) lexer299.mll
 
 #install::
-#	cp ocaml299to3 $(INSTALL_BINDIR)/ocaml299to3$(EXE)
+#	cp ocaml299to3 "$(INSTALL_BINDIR)/ocaml299to3$(EXE)"
 
 clean::
 	rm -f ocaml299to3 lexer299.ml
@@ -153,7 +153,7 @@ lexer301.ml: lexer301.mll
 	$(CAMLLEX) lexer301.mll
 
 #install::
-#	cp scrapelabels $(INSTALL_LIBDIR)
+#	cp scrapelabels "$(INSTALL_LIBDIR)"
 
 clean::
 	rm -f scrapelabels lexer301.ml
@@ -170,7 +170,7 @@ addlabels: addlabels.cmo
 		$(ADDLABELS_IMPORTS) addlabels.cmo
 
 #install::
-#	cp addlabels $(INSTALL_LIBDIR)
+#	cp addlabels "$(INSTALL_LIBDIR)"
 
 clean::
 	rm -f addlabels
@@ -235,7 +235,7 @@ opnames.ml: ../byterun/caml/instruct.h
 	unset LC_ALL || : ; \
 	unset LC_CTYPE || : ; \
 	unset LC_COLLATE LANG || : ; \
-	sed -e '/\/\*/d' \
+	sed -e '/[/][*]/d' \
 	    -e '/^#/d' \
 	    -e 's/enum \(.*\) {/let names_of_\1 = [|/' \
 	    -e 's/.*};$$/ |]/' \
@@ -276,8 +276,8 @@ objinfo: objinfo_helper$(EXE) $(OBJINFO)
 	$(CAMLC) -o objinfo $(OBJINFO)
 
 install::
-	cp objinfo $(INSTALL_BINDIR)/ocamlobjinfo$(EXE)
-	cp objinfo_helper$(EXE) $(INSTALL_LIBDIR)/objinfo_helper$(EXE)
+	cp objinfo "$(INSTALL_BINDIR)/ocamlobjinfo$(EXE)"
+	cp objinfo_helper$(EXE) "$(INSTALL_LIBDIR)/objinfo_helper$(EXE)"
 
 clean::
 	rm -f objinfo objinfo_helper$(EXE)


### PR DESCRIPTION
This enables AppVeyor to compile OCaml Win64.  So far it [chokes](https://ci.appveyor.com/project/Chris00/ocaml/build/1.0.43#L743) on

``` make
    sed -e '/\/\*/d' \
        -e '/^#/d' \
        -e 's/enum \(.*\) {/let names_of_\1 = [|/' \
        -e 's/.*};$$/ |]/' \
        -e 's/\([A-Z][A-Z_0-9a-z]*\)/"\1"/g' \
        -e 's/,/;/g' \
```

in `Makefile.shared`.  Anybody has an idea? (I am a bit surprised as the Win64 compilation has obviously been tested.)
