### PR TITLE
Add (experimental) support for NetBSD/arm.

### DIFF
--- a/Changes
+++ b/Changes
@@ -435,6 +435,8 @@ Features wishes:
   This changes PR#6816 a little bit by reading the literal [123a] as a single token that can
   later be rewritten by a ppx preprocessor.
   (Hugo Heuzard)
+- GPR#308: add experimental support for NetBSD/arm (verified on RaspberryPi)
+  (Rich Neswold)
 
 OCaml 4.02.3 (27 Jul 2015):
 ---------------------------

--- a/README
+++ b/README
@@ -28,9 +28,10 @@ Tier 1 (actively used and maintained by the core OCaml team):
 
 Tier 2 (maintained when possible, with help from users):
 
-    AMD64              FreeBSD, OpenBSD
+    AMD64              FreeBSD, OpenBSD, NetBSD
     IA32 (Pentium)     NetBSD, OpenBSD, Solaris 9
     PowerPC            NetBSD
+    ARM                NetBSD
     SPARC              Solaris, Linux, NetBSD
 
 Other operating systems for the processors above have not been tested,

--- a/asmcomp/arm/arch.ml
+++ b/asmcomp/arm/arch.ml
@@ -22,7 +22,7 @@ type fpu = Soft | VFPv2 | VFPv3_D16 | VFPv3
 let abi =
   match Config.system with
     "linux_eabi" | "freebsd" -> EABI
-  | "linux_eabihf" -> EABI_HF
+  | "linux_eabihf" | "netbsd" -> EABI_HF
   | _ -> assert false
 
 let string_of_arch = function

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -820,7 +820,7 @@ let rec emit_all ninstr i =
 
 let emit_profile() =
   match Config.system with
-    "linux_eabi" | "linux_eabihf" ->
+    "linux_eabi" | "linux_eabihf" | "netbsd" ->
       `	push	\{lr}\n`;
       `	{emit_call "__gnu_mcount_nc"}\n`
   | _ -> ()
@@ -947,7 +947,7 @@ let end_assembly () =
   `	.type	{emit_symbol lbl}, %object\n`;
   `	.size	{emit_symbol lbl}, .-{emit_symbol lbl}\n`;
   begin match Config.system with
-    "linux_eabihf" | "linux_eabi" ->
+    "linux_eabihf" | "linux_eabi" | "netbsd" ->
       (* Mark stack as non-executable *)
       `	.section	.note.GNU-stack,\"\",%progbits\n`
   | _ -> ()

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -866,7 +866,7 @@ let rec emit_all i =
 let emit_profile() = ()   (* TODO *)
 (*
   match Config.system with
-    "linux_eabi" | "linux_eabihf" ->
+    "linux_eabi" | "linux_eabihf" | "netbsd" ->
       `	push	\{lr}\n`;
       `	{emit_call "__gnu_mcount_nc"}\n`
   | _ -> ()

--- a/asmrun/arm.S
+++ b/asmrun/arm.S
@@ -44,6 +44,26 @@
         cmp     \reg, #0
         beq     \lbl
         .endm
+#elif defined(SYS_netbsd)
+
+  #if defined(MODEL_armv6)
+        .arch   armv6
+        .fpu    vfpv2
+        .arm
+
+    /* Compatibility macros */
+        .macro  cbz reg, lbl
+        cmp     \reg, #0
+        beq     \lbl
+        .endm
+  #elif defined(MODEL_armv7)
+        .arch   armv7-a
+        .fpu    vfpv3-d16
+        .thumb
+  #else
+    #error "Only NetBSD eabihf supported"
+  #endif
+
 #elif defined(SYS_freebsd)
         .arch   armv6
         .arm
@@ -73,7 +93,7 @@ alloc_limit     .req    r11
 
 /* Support for profiling with gprof */
 
-#if defined(PROFILING) && (defined(SYS_linux_eabihf) || defined(SYS_linux_eabi))
+#if defined(PROFILING) && (defined(SYS_linux_eabihf) || defined(SYS_linux_eabi) || defined(SYS_netbsd))
 #define PROFILE \
         push    {lr}; CFI_ADJUST(4); \
         bl      __gnu_mcount_nc; CFI_ADJUST(-4)
@@ -98,7 +118,7 @@ caml_call_gc:
     /* Record lowest stack address */
         ldr     r12, =caml_bottom_of_stack
         str     sp, [r12]
-#if defined(SYS_linux_eabihf)
+#if defined(SYS_linux_eabihf) || defined(SYS_netbsd)
     /* Save caller floating-point registers on the stack */
         vpush   {d0-d7}; CFI_ADJUST(64)
 #endif
@@ -117,7 +137,7 @@ caml_call_gc:
         bl      caml_garbage_collection
     /* Restore integer registers and return address from the stack */
         pop     {r0-r7,r12,lr}; CFI_ADJUST(-40)
-#if defined(SYS_linux_eabihf)
+#if defined(SYS_linux_eabihf) || defined(SYS_netbsd)
     /* Restore floating-point registers from the stack */
         vpop    {d0-d7}; CFI_ADJUST(-64)
 #endif
@@ -272,7 +292,7 @@ caml_start_program:
 /* Arguments to the OCaml code are in r0...r3 */
 
 .Ljump_to_caml:
-#if defined(SYS_linux_eabihf)
+#if defined(SYS_linux_eabihf) || defined(SYS_netbsd)
     /* Save callee-save floating-point registers */
         vpush   {d8-d15}; CFI_ADJUST(64)
 #endif
@@ -327,7 +347,7 @@ caml_start_program:
         str     alloc_ptr, [r4]
     /* Reload callee-save registers and return address */
         pop     {r4-r8,r10,r11,lr}; CFI_ADJUST(-32)
-#if defined(SYS_linux_eabihf)
+#if defined(SYS_linux_eabihf) || defined(SYS_netbsd)
     /* Reload callee-save floating-point registers */
         vpop    {d8-d15}; CFI_ADJUST(-64)
 #endif

--- a/config/auto-aux/gethostbyaddr.c
+++ b/config/auto-aux/gethostbyaddr.c
@@ -19,6 +19,10 @@
 #include <sys/types.h>
 #include <netdb.h>
 
+#ifdef SYS_netbsd
+#error "this OS doesn't have gethostbyaddr_r"
+#endif
+
 int main(int argc, char ** argv)
 {
 #if NUM_ARGS == 7

--- a/config/auto-aux/gethostbyname.c
+++ b/config/auto-aux/gethostbyname.c
@@ -19,6 +19,10 @@
 #include <sys/types.h>
 #include <netdb.h>
 
+#ifdef SYS_netbsd
+#error "this OS doesn't have gethostbyname_r"
+#endif
+
 int main(int argc, char ** argv)
 {
 #if NUM_ARGS == 5

--- a/configure
+++ b/configure
@@ -778,6 +778,7 @@ if test $with_sharedlibs = "yes"; then
     i[3456]86-*-haiku*)           natdynlink=true;;
     arm*-*-linux*)                natdynlink=true;;
     arm*-*-freebsd*)              natdynlink=true;;
+    earm*-*-netbsd*)               natdynlink=true;;
     aarch64-*-linux*)             natdynlink=true;;
   esac
 fi
@@ -831,6 +832,8 @@ case "$target" in
   armv6t2*-*-linux-gnueabi)     arch=arm; model=armv6t2; system=linux_eabi;;
   armv6*-*-linux-gnueabi)       arch=arm; model=armv6; system=linux_eabi;;
   armv6*-*-freebsd*)            arch=arm; model=armv6; system=freebsd;;
+  earmv6*-*-netbsd*)		arch=arm; model=armv6; system=netbsd;;
+  earmv7*-*-netbsd*)		arch=arm; model=armv7; system=netbsd;;
   armv5te*-*-linux-gnueabi)     arch=arm; model=armv5te; system=linux_eabi;;
   armv5*-*-linux-gnueabi)       arch=arm; model=armv5; system=linux_eabi;;
   arm*-*-linux-gnueabi)         arch=arm; system=linux_eabi;;
@@ -935,6 +938,7 @@ case "$arch,$system" in
   amd64,openbsd) profiling='prof';;
   amd64,freebsd) profiling='prof';;
   amd64,netbsd) profiling='prof';;
+  arm,netbsd) profiling='prof';;
   amd64,gnu) profiling='prof';;
   arm,linux*) profiling='prof';;
   power,elf) profiling='prof';;

--- a/configure
+++ b/configure
@@ -1330,7 +1330,7 @@ fi
 
 nargs=none
 for i in 5 6; do
-  if sh ./trycompile -DNUM_ARGS=${i} gethostbyname.c; then nargs=$i; break; fi
+  if sh ./trycompile -DSYS_${system} -DNUM_ARGS=${i} gethostbyname.c; then nargs=$i; break; fi
 done
 if test $nargs != "none"; then
   inf "gethostbyname_r() found (with ${nargs} arguments)."
@@ -1339,7 +1339,7 @@ fi
 
 nargs=none
 for i in 7 8; do
-  if sh ./trycompile -DNUM_ARGS=${i} gethostbyaddr.c; then nargs=$i; break; fi
+  if sh ./trycompile -DSYS_${system} -DNUM_ARGS=${i} gethostbyaddr.c; then nargs=$i; break; fi
 done
 if test $nargs != "none"; then
   inf "gethostbyaddr_r() found (with ${nargs} arguments)."


### PR DESCRIPTION
I'd like to submit experimental support for the NetBSD/arm platform. These changes allow a RaspberryPi (running NetBSD 7) to build the OCaml tools, including the native compiler. NetBSD's support for ARM closely matches Linux's `eabi_hf`, so most of the work was riding the coattails of that effort.

I've written a few simple test modules to try to exercise the compiler and the generated code and everything has worked so far. The native compiler built the `.opt` tools successfully and my test modules checked to see that floating point appeared to be working. I'm hoping to get a Beaglebone Black loaded soon with NetBSD so I can verify `armv7` support.
