### PR TITLE
Document types.mli and typedtree.mli

### DIFF
--- a/parsing/asttypes.mli
+++ b/parsing/asttypes.mli
@@ -25,6 +25,7 @@ type rec_flag = Nonrecursive | Recursive
 
 type direction_flag = Upto | Downto
 
+(* Order matters, used in polymorphic comparison *)
 type private_flag = Private | Public
 
 type mutable_flag = Immutable | Mutable

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -10,7 +10,13 @@
 (*                                                                     *)
 (***********************************************************************)
 
-(* Abstract syntax tree after typing *)
+(** Abstract syntax tree after typing *)
+
+
+(** By comparison with {!Parsetree}:
+    - Every {!Longindent.t} is accompanied by a resolved {!Path.t}.
+
+*)
 
 open Asttypes
 open Types
@@ -19,8 +25,12 @@ open Types
 
 type partial = Partial | Total
 
+(** {2 Extension points} *)
+
 type attribute = Parsetree.attribute
 type attributes = attribute list
+
+(** {2 Core language} *)
 
 type pattern =
   { pat_desc: pattern_desc;
@@ -33,24 +43,64 @@ type pattern =
 
 and pat_extra =
   | Tpat_constraint of core_type
+        (** P : T          { pat_desc = P
+                           ; pat_extra = (Tpat_constraint T, _, _) :: ... }
+         *)
   | Tpat_type of Path.t * Longident.t loc
+        (** #tconst        { pat_desc = disjunction
+                           ; pat_extra = (Tpat_type (P, "tconst"), _, _) :: ... }
+
+                           where [disjunction] is a [Tpat_or _] representing the
+                           branches of [tconst].
+         *)
   | Tpat_unpack
+        (** (module P)     { pat_desc  = Tpat_var "P"
+                           ; pat_extra = (Tpat_unpack, _, _) :: ... }
+         *)
 
 and pattern_desc =
     Tpat_any
+        (** _ *)
   | Tpat_var of Ident.t * string loc
+        (** x *)
   | Tpat_alias of pattern * Ident.t * string loc
+        (** P as a *)
   | Tpat_constant of constant
+        (** 1, 'a', "true", 1.0, 1l, 1L, 1n *)
   | Tpat_tuple of pattern list
+        (** (P1, ..., Pn)
+
+            Invariant: n >= 2
+         *)
   | Tpat_construct of
       Longident.t loc * constructor_description * pattern list
+        (** C                []
+            C P              [P]
+            C (P1, ..., Pn)  [P1; ...; Pn]
+          *)
   | Tpat_variant of label * pattern option * row_desc ref
+        (** `A             (None)
+            `A P           (Some P)
+
+            See {!Types.row_desc} for an explanation of the last parameter.
+         *)
   | Tpat_record of
       (Longident.t loc * label_description * pattern) list *
         closed_flag
+        (** { l1=P1; ...; ln=Pn }     (flag = Closed)
+            { l1=P1; ...; ln=Pn; _}   (flag = Open)
+
+            Invariant: n > 0
+         *)
   | Tpat_array of pattern list
+        (** [| P1; ...; Pn |] *)
   | Tpat_or of pattern * pattern * row_desc option
+        (** P1 | P2
+
+            [row_desc = Some _] when translating [Ppat_type _], [None] otherwise.
+         *)
   | Tpat_lazy of pattern
+        (** lazy P *)
 
 and expression =
   { exp_desc: expression_desc;
@@ -63,22 +113,73 @@ and expression =
 
 and exp_extra =
   | Texp_constraint of core_type
+        (** E : T *)
   | Texp_coerce of core_type option * core_type
+        (** E :> T           [Texp_coerce (None, T)]
+            E : T0 :> T      [Texp_coerce (Some T0, T)]
+         *)
   | Texp_open of override_flag * Path.t * Longident.t loc * Env.t
+        (** let open[!] M in     [Texp_open (!, P, M, env)]
+                                 where [env] is the environment after opening [P]
+         *)
   | Texp_poly of core_type option
+        (** Used for method bodies. *)
   | Texp_newtype of string
+        (** fun (type t) ->  *)
 
 and expression_desc =
     Texp_ident of Path.t * Longident.t loc * Types.value_description
+        (** x
+            M.x
+         *)
   | Texp_constant of constant
+        (** 1, 'a', "true", 1.0, 1l, 1L, 1n *)
   | Texp_let of rec_flag * value_binding list * expression
+        (** let P1 = E1 and ... and Pn = EN in E       (flag = Nonrecursive)
+            let rec P1 = E1 and ... and Pn = EN in E   (flag = Recursive)
+         *)
   | Texp_function of arg_label * case list * partial
+        (** [Pexp_fun] and [Pexp_function] both translate to [Texp_function].
+            See {!Parsetree} for more details.
+
+            partial =
+              [Partial] if the pattern match is partial
+              [Total] otherwise.
+         *)
   | Texp_apply of expression * (arg_label * expression option) list
+        (** E0 ~l1:E1 ... ~ln:En
+
+            The expression can be None if the expression is abstracted over
+            this argument. It currently appears when a label is applied.
+
+            For example:
+            let f x ~y = x + y in
+            f ~y:3
+
+            The resulting typedtree for the application is:
+            Texp_apply (Texp_ident "f/1037",
+                        [(Nolabel, None);
+                         (Labelled "y", Some (Texp_constant Const_int 3))
+                        ])
+         *)
   | Texp_match of expression * case list * case list * partial
+        (** match E0 with
+            | P1 -> E1
+            | P2 -> E2
+            | exception P3 -> E3
+
+            [Texp_match (E0, [(P1, E1); (P2, E2)], [(P3, E3)], _)]
+         *)
   | Texp_try of expression * case list
+        (** try E with P1 -> E1 | ... | PN -> EN *)
   | Texp_tuple of expression list
+        (** (E1, ..., EN) *)
   | Texp_construct of
       Longident.t loc * constructor_description * expression list
+        (** C                []
+            C E              [E]
+            C (E1, ..., En)  [E1;...;En]
+         *)
   | Texp_variant of label * expression option
   | Texp_record of
       (Longident.t loc * label_description * expression) list *
@@ -180,9 +281,12 @@ and module_expr =
     mod_attributes: attributes;
    }
 
+(** Annotations for [Tmod_constraint]. *)
 and module_type_constraint =
-    Tmodtype_implicit
+  | Tmodtype_implicit
+  (** The module type constraint has been synthesized during typecheking. *)
   | Tmodtype_explicit of module_type
+  (** The module type was in the source file. *)
 
 and module_expr_desc =
     Tmod_ident of Path.t * Longident.t loc
@@ -191,6 +295,9 @@ and module_expr_desc =
   | Tmod_apply of module_expr * module_expr * module_coercion
   | Tmod_constraint of
       module_expr * Types.module_type * module_type_constraint * module_coercion
+    (** ME          (constraint = Tmodtype_implicit)
+        (ME : MT)   (constraint = Tmodtype_explicit MT)
+     *)
   | Tmod_unpack of expression * Types.module_type
 
 and structure = {
@@ -341,9 +448,10 @@ and with_constraint =
   | Twith_modsubst of Path.t * Longident.t loc
 
 and core_type =
-(* mutable because of [Typeclass.declare_method] *)
   { mutable ctyp_desc : core_type_desc;
+      (** mutable because of [Typeclass.declare_method] *)
     mutable ctyp_type : type_expr;
+      (** mutable because of [Typeclass.declare_method] *)
     ctyp_env : Env.t; (* BINANNOT ADDED *)
     ctyp_loc : Location.t;
     ctyp_attributes: attributes;
@@ -519,7 +627,7 @@ val rev_let_bound_idents: value_binding list -> Ident.t list
 val let_bound_idents_with_loc:
     value_binding list -> (Ident.t * string loc) list
 
-(* Alpha conversion of patterns *)
+(** Alpha conversion of patterns *)
 val alpha_pat: (Ident.t * Ident.t) list -> pattern -> pattern
 
 val mknoloc: 'a -> 'a Asttypes.loc

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -19,7 +19,7 @@ open Asttypes
 type type_expr =
   { mutable desc: type_desc;
     mutable level: int;
-    mutable id: int }
+    id: int }
 
 and type_desc =
     Tvar of string option

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -10,32 +10,146 @@
 (*                                                                     *)
 (***********************************************************************)
 
-(* Representation of types and declarations *)
+(** {0 Representation of types and declarations} *)
 
+(** [Types] defines the representation of types and declarations (that is, the
+    content of module signatures).
+
+    CMI files are made of marshalled types.
+*)
+
+(** Asttypes exposes basic definitions shared both by Parsetree and Types. *)
 open Asttypes
 
-(* Type expressions for the core language *)
+(** Type expressions for the core language.
 
+    The [type_desc] variant defines all the possible type expressions one can
+    find in OCaml. [type_expr] wraps this with some annotations.
+
+    The [level] field tracks the level of polymorphism associated to a type,
+    guiding the generalization algorithm.
+    Put shortly, when referring to a type in a given environment, both the type
+    and the environment have a level. If the type has an higher level, then it
+    can be considered fully polymorphic (type variables will be printed as
+    ['a]), otherwise it'll be weakly polymorphic, or non generalized (type
+    variables printed as ['_a]).
+    See [http://okmij.org/ftp/ML/generalization.html] for more information.
+
+    Note about [type_declaration]: one should not make the confusion between
+    [type_expr] and [type_declaration].
+
+    [type_declaration] refers specifically to the [type] construct in OCaml
+    language, where you create and name a new type or type alias.
+
+    [type_expr] is used when you refer to existing types, e.g. when annotating
+    the expected type of a value.
+
+    Also, as the type system of OCaml is generative, a [type_declaration] can
+    have the side-effect of introducing a new type constructor, different from
+    all other known types.
+    Whereas [type_expr] is a pure construct which allows referring to existing
+    types.
+
+    Note on mutability: TBD.
+ *)
 type type_expr =
   { mutable desc: type_desc;
     mutable level: int;
     mutable id: int }
 
 and type_desc =
-    Tvar of string option
-  | Tarrow of arg_label * type_expr * type_expr * commutable
-  | Ttuple of type_expr list
-  | Tconstr of Path.t * type_expr list * abbrev_memo ref
-  | Tobject of type_expr * (Path.t * type_expr list) option ref
-  | Tfield of string * field_kind * type_expr * type_expr
-  | Tnil
-  | Tlink of type_expr
-  | Tsubst of type_expr         (* for copying *)
-  | Tvariant of row_desc
-  | Tunivar of string option
-  | Tpoly of type_expr * type_expr list
-  | Tpackage of Path.t * Longident.t list * type_expr list
+  | Tvar of string option
+  (** [Tvar (Some "a")] ==> ['a] or ['_a]
+      [Tvar None]       ==> [_] *)
 
+  | Tarrow of arg_label * type_expr * type_expr * commutable
+  (** [Tarrow (Nolabel,      e1, e2, c)] ==> [e1    -> e2]
+      [Tarrow (Labelled "l", e1, e2, c)] ==> [l:e1  -> e2]
+      [Tarrow (Optional "l", e1, e2, c)] ==> [?l:e1 -> e2]
+
+      See [commutable] for the last argument. *)
+
+  | Ttuple of type_expr list
+  (** [Ttuple [t1;...;tn]] ==> [(t1 * ... * tn)] *)
+
+  | Tconstr of Path.t * type_expr list * abbrev_memo ref
+  (** [Tconstr (`A.B.t', [t1;...;tn], _)] ==> [(t1,...,tn) A.B.t]
+      The last parameter keep tracks of known expansions, see [abbrev_memo]. *)
+
+  | Tobject of type_expr * (Path.t * type_expr list) option ref
+  (** [Tobject (`f1:t1;...;fn: tn', `None')] ==> [< f1: t1; ...; fn: tn >]
+      f1, fn are represented as a linked list of types using Tfield and Tnil
+      constructors.
+
+      [Tobject (_, `Some (`A.ct', [t1;...;tn]')] ==> [(t1, ..., tn) A.ct].
+      where A.ct is the type of some class.
+
+      There are also special cases for so-called "class-types", cf. [Typeclass]
+      and [Ctype.set_object_name]:
+
+        [Tobject (Tfield(_,_,…(Tfield(_,_,rv)…), Some(`A.#ct`, [rv;t1;…;tn])]
+             ==> [(t1, …, tn) #A.ct]
+        [Tobject (_, Some(`A.#ct`, [Tnil;t1;…;tn])] ==> [(t1, …, tn) A.ct]
+
+      where [rv] is the hidden row variable.
+  *)
+
+  | Tfield of string * field_kind * type_expr * type_expr
+  (** [Tfield ("foo", Fpresent, t, ts)] ==> [<...; foo : t; ts>] *)
+
+  | Tnil
+  (** [Tnil] ==> [<...; >] *)
+
+  | Tlink of type_expr
+  (** Indirection used by unification engine. *)
+
+  | Tsubst of type_expr         (* for copying *)
+  (** [Tsubst] is used temporarily to store information in low-level
+      functions manipulating representation of types, such as
+      instantiation or copy.
+      This constructor should not appear outside of these cases. *)
+
+  | Tvariant of row_desc
+  (** Representation of polymorphic variants, see [row_desc]. *)
+
+  | Tunivar of string option
+  (** Occurrence of a type variable introduced by a
+      forall quantifier / [Tpoly]. *)
+
+  | Tpoly of type_expr * type_expr list
+  (** [Tpoly (ty,tyl)] ==> ['a1... 'an. ty],
+      where 'a1 ... 'an are names given to types in tyl
+      and occurences of those types in ty. *)
+
+  | Tpackage of Path.t * Longident.t list * type_expr list
+  (** Type of a first-class module (a.k.a package). *)
+
+(** [  `X | `Y ]       (row_closed = true)
+    [< `X | `Y ]       (row_closed = true)
+    [> `X | `Y ]       (row_closed = false)
+    [< `X | `Y > `X ]  (row_closed = true)
+
+    type t = [> `X ] as 'a      (row_more = Tvar a)
+    type t = private [> `X ]    (row_more = Tconstr (t#row, [], ref Mnil)
+
+    And for:
+
+        let f = function `X -> `X -> | `Y -> `X
+
+    the type of "f" will be a [Tarrow] whose lhs will (basically) be:
+
+        Tvariant { row_fields = [("X", _)];
+                   row_more   =
+                     Tvariant { row_fields = [("Y", _)];
+                                row_more   =
+                                  Tvariant { row_fields = [];
+                                             row_more   = _;
+                                             _ };
+                                _ };
+                   _
+                 }
+
+*)
 and row_desc =
     { row_fields: (label * row_field) list;
       row_more: type_expr;
@@ -52,16 +166,59 @@ and row_field =
            is erased later *)
   | Rabsent
 
+(** [abbrev_memo] allows one to keep track of different expansions of a type
+    alias. This is done for performance purposes.
+
+    For instance, when defining [type 'a pair = 'a * 'a], when one refers to an
+    ['a pair], it is just a shortcut for the ['a * 'a] type.
+    This expansion will be stored in the [abbrev_memo] of the corresponding
+    [Tconstr] node.
+
+    In practice, [abbrev_memo] behaves like list of expansions with a mutable
+    tail.
+
+    Note on marshalling: [abbrev_memo] must not appear in saved types.
+    [Btype], with [cleanup_abbrev] and [memo], takes care of tracking and
+    removing abbreviations.
+*)
 and abbrev_memo =
-    Mnil
+  | Mnil (** No known abbrevation *)
+
   | Mcons of private_flag * Path.t * type_expr * type_expr * abbrev_memo
+  (** Found one abbreviation.
+      A valid abbreviation should be at least as visible and reachable by the
+      same path.
+      The first expression is the abbreviation and the second the expansion. *)
+
   | Mlink of abbrev_memo ref
+  (** Abbreviations can be found after this indirection *)
 
 and field_kind =
     Fvar of field_kind option ref
   | Fpresent
   | Fabsent
 
+(** [commutable] is a flag appended to every arrow type.
+
+    When typing an application, if the type of the functional is
+    known, its type is instantiated with [Cok] arrows, otherwise as
+    [Clink (ref Cunknown)].
+
+    When the type is not known, the application will be used to infer
+    the actual type.  This is fragile in presence of labels where
+    there is no principal type.
+
+    Two incompatible applications relying on [Cunknown] arrows will
+    trigger an error.
+
+    let f g =
+      g ~a:() ~b:();
+      g ~b:() ~a:();
+
+    Error: This function is applied to arguments
+    in an order different from other calls.
+    This is only allowed when the real type is known.
+*)
 and commutable =
     Cok
   | Cunknown

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -55,7 +55,7 @@ open Asttypes
 type type_expr =
   { mutable desc: type_desc;
     mutable level: int;
-    mutable id: int }
+    id: int }
 
 and type_desc =
   | Tvar of string option


### PR DESCRIPTION
This is a gathering of comments made separately by @def-lkb and @Drup ages ago.
I rebased them on top of trunk, updated them to reflect AST changes and fixed some comments placement ambiguity.

There is no update to the changelog, I'm not sure if one is necessary, or useful. (I kept the original commiters, so the name of these glorious heroes is not lost!).

There is no update to the testsuite!

The correctness of the comments in types.mli is not guaranteed, so proof reading them would be nice (but they should be alright).

The comments (on the typedtree in particular) are incomplete. But considering they have been waiting for several months (years) it is unlikely than any of the authors of this pull request will complete them in the near future. I don't think this should block integration.
