### PR TITLE
Remove Typedtree.optional

### DIFF
--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -720,7 +720,7 @@ and transl_exp0 e =
   | Texp_apply({ exp_desc = Texp_ident(path, _, {val_kind = Val_prim p});
                 exp_type = prim_type } as funct, oargs)
     when List.length oargs >= p.prim_arity
-    && List.for_all (fun (_, arg,_) -> arg <> None) oargs ->
+    && List.for_all (fun (_, arg) -> arg <> None) oargs ->
       let args, args' = cut p.prim_arity oargs in
       let wrap f =
         if args' = []
@@ -739,7 +739,7 @@ and transl_exp0 e =
       let wrap0 f =
         if args' = [] then f else wrap f in
       let args =
-         List.map (function _, Some x, _ -> x | _ -> assert false) args in
+         List.map (function _, Some x -> x | _ -> assert false) args in
       let argl = transl_list args in
       let public_send = p.prim_name = "%send"
         || not !Clflags.native_code && p.prim_name = "%sendcache"in
@@ -1073,7 +1073,7 @@ and transl_apply ?(should_be_tailcall=false) ?(inlined = Default_inline) lam sar
               Lvar id
         in
         let args, args' =
-          if List.for_all (fun (_,opt) -> opt = Optional) args then [], args
+          if List.for_all (fun (_,opt) -> opt) args then [], args
           else args, [] in
         let lam =
           if args = [] then lam else lapply lam (List.rev_map fst args) in
@@ -1099,7 +1099,7 @@ and transl_apply ?(should_be_tailcall=false) ?(inlined = Default_inline) lam sar
     | [] ->
         lapply lam (List.rev_map fst args)
   in
-  (build_apply lam [] (List.map (fun (l, x,o) -> may_map transl_exp x, o) sargs) : Lambda.lambda)
+  (build_apply lam [] (List.map (fun (l, x) -> may_map transl_exp x, Btype.is_optional l) sargs) : Lambda.lambda)
 
 and transl_function loc untuplify_fn repr partial cases =
   match cases with

--- a/bytecomp/translcore.mli
+++ b/bytecomp/translcore.mli
@@ -20,7 +20,7 @@ open Lambda
 val transl_exp: expression -> lambda
 val transl_apply: ?should_be_tailcall:bool
                   -> ?inlined:inline_attribute
-                  -> lambda -> (arg_label * expression option * optional) list
+                  -> lambda -> (arg_label * expression option) list
                   -> Location.t -> lambda
 val transl_let: rec_flag -> value_binding list -> lambda -> lambda
 val transl_primitive: Location.t -> Primitive.description -> Env.t

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -797,7 +797,7 @@ module Analyser =
                     Odoc_messages.object_end
           in
           let param_exps = List.fold_left
-              (fun acc -> fun (_, exp_opt, _) ->
+              (fun acc -> fun (_, exp_opt) ->
                 match exp_opt with
                   None -> acc
                 | Some e -> acc @ [e])
@@ -1464,7 +1464,7 @@ module Analyser =
           )
 
       | Parsetree.Pstr_recmodule mods ->
-          (* FIXME Here problem: no link with module types 
+          (* FIXME Here problem: no link with module types
              in module constraints *)
           let new_env =
             List.fold_left

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -818,7 +818,7 @@ and longident_x_expression i ppf (li, _, e) =
   line i ppf "%a\n" fmt_longident li;
   expression (i+1) ppf e;
 
-and label_x_expression i ppf (l, e, _) =
+and label_x_expression i ppf (l, e) =
   line i ppf "<arg>\n";
   arg_label (i+1) ppf l;
   (match e with None -> () | Some e -> expression (i+1) ppf e)

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -231,7 +231,7 @@ let expr sub x =
     | Texp_apply (exp, list) ->
         Texp_apply (
           sub.expr sub exp,
-          List.map (tuple3 id (opt (sub.expr sub)) id) list
+          List.map (tuple2 id (opt (sub.expr sub))) list
         )
     | Texp_match (exp, cases, exn_cases, p) ->
         Texp_match (
@@ -489,7 +489,7 @@ let class_expr sub x =
     | Tcl_apply (cl, args) ->
         Tcl_apply (
           sub.class_expr sub cl,
-          List.map (tuple3 id (opt (sub.expr sub)) id) args
+          List.map (tuple2 id (opt (sub.expr sub))) args
         )
     | Tcl_let (rec_flag, value_bindings, ivars, cl) ->
         let (rec_flag, value_bindings) =

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1016,8 +1016,7 @@ and class_expr cl_num val_env met_env scl =
         | Cty_arrow (l, ty, ty_fun), Cty_arrow (_, ty0, ty_fun0)
           when sargs <> [] || more_sargs <> [] ->
             let name = Btype.label_name l
-            and optional =
-              if Btype.is_optional l then Optional else Required in
+            and optional = Btype.is_optional l in
             let sargs, more_sargs, arg =
               if ignore_labels && not (Btype.is_optional l) then begin
                 match sargs, more_sargs with
@@ -1042,11 +1041,11 @@ and class_expr cl_num val_env met_env scl =
                       Btype.extract_label name more_sargs
                     in (l', sarg0, sargs @ sargs1, sargs2)
                 in
-                if optional = Required && Btype.is_optional l' then
+                if not optional && Btype.is_optional l' then
                   Location.prerr_warning sarg0.pexp_loc
                     (Warnings.Nonoptional_label (Printtyp.string_of_label l));
                 sargs, more_sargs,
-                if optional = Required || Btype.is_optional l' then
+                if not optional || Btype.is_optional l' then
                   Some (type_argument val_env sarg0 ty ty0)
                 else
                   let ty' = extract_option_type val_env ty
@@ -1063,7 +1062,7 @@ and class_expr cl_num val_env met_env scl =
                 else None
             in
             let omitted = if arg = None then (l,ty0) :: omitted else omitted in
-            type_args ((l,arg,optional)::args) omitted ty_fun ty_fun0
+            type_args ((l,arg)::args) omitted ty_fun ty_fun0
               sargs more_sargs
         | _ ->
             match sargs @ more_sargs with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1519,8 +1519,8 @@ let rec is_nonexpansive exp =
       List.for_all (fun vb -> is_nonexpansive vb.vb_expr) pat_exp_list &&
       is_nonexpansive body
   | Texp_function _ -> true
-  | Texp_apply(e, (_,None,_)::el) ->
-      is_nonexpansive e && List.for_all is_nonexpansive_opt (List.map snd3 el)
+  | Texp_apply(e, (_,None)::el) ->
+      is_nonexpansive e && List.for_all is_nonexpansive_opt (List.map snd el)
   | Texp_match(e, cases, [], _) ->
       is_nonexpansive e &&
       List.for_all
@@ -2511,8 +2511,8 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
                                   exp_loc = obj.exp_loc; exp_extra = [];
                                   exp_type = desc.val_type;
                                   exp_attributes = []; (* check *)
-                                  exp_env = env},
-                            Required ])
+                                  exp_env = env}
+                          ])
                   in
                   (Tmeth_name met, Some (re {exp_desc = exp;
                                              exp_loc = loc; exp_extra = [];
@@ -3251,7 +3251,7 @@ and type_argument ?recarg env sarg ty_expected' ty_expected =
         match (expand_head env ty_fun).desc with
         | Tarrow (l,ty_arg,ty_fun,_) when is_optional l ->
             let ty = option_none (instance env ty_arg) sarg.pexp_loc in
-            make_args ((l, Some ty, Optional) :: args) ty_fun
+            make_args ((l, Some ty) :: args) ty_fun
         | Tarrow (l,_,ty_res',_) when l = Nolabel || !Clflags.classic ->
             List.rev args, ty_fun, no_labels ty_res'
         | Tvar _ ->  List.rev args, ty_fun, false
@@ -3288,14 +3288,14 @@ and type_argument ?recarg env sarg ty_expected' ty_expected =
           {texp with exp_type = ty_res; exp_desc =
            Texp_apply
              (texp,
-              args @ [Nolabel, Some eta_var, Required])}
+              args @ [Nolabel, Some eta_var])}
         in
         { texp with exp_type = ty_fun; exp_desc =
           Texp_function(Nolabel, [case eta_pat e], Total) }
       in
       Location.prerr_warning texp.exp_loc
         (Warnings.Eliminated_optional_arguments
-           (List.map (fun (l, _, _) -> Printtyp.string_of_label l) args));
+           (List.map (fun (l, _) -> Printtyp.string_of_label l) args));
       if warn then Location.prerr_warning texp.exp_loc
           (Warnings.Without_principality "eliminated optional argument");
       if is_nonexpansive texp then func texp else
@@ -3327,13 +3327,12 @@ and type_application env funct sargs =
   let ignored = ref [] in
   let rec type_unknown_args
       (args :
-      (Asttypes.arg_label * (unit -> Typedtree.expression) option *
-         Typedtree.optional) list)
+      (Asttypes.arg_label * (unit -> Typedtree.expression) option) list)
     omitted ty_fun = function
       [] ->
         (List.map
-            (function l, None, x -> l, None, x
-                | l, Some f, x -> l, Some (f ()), x)
+            (function l, None -> l, None
+                | l, Some f -> l, Some (f ()))
            (List.rev args),
          instance env (result_type omitted ty_fun))
     | (l1, sarg1) :: sargl ->
@@ -3370,14 +3369,14 @@ and type_application env funct sargs =
                   raise(Error(funct.exp_loc, env, Apply_non_function
                                 (expand_head env funct.exp_type)))
         in
-        let optional = if is_optional l1 then Optional else Required in
+        let optional = is_optional l1 in
         let arg1 () =
           let arg1 = type_expect env sarg1 ty1 in
-          if optional = Optional then
+          if optional then
             unify_exp env arg1 (type_option(newvar()));
           arg1
         in
-        type_unknown_args ((l1, Some arg1, optional) :: args) omitted ty2 sargl
+        type_unknown_args ((l1, Some arg1) :: args) omitted ty2 sargl
   in
   let ignore_labels =
     !Clflags.classic ||
@@ -3410,7 +3409,7 @@ and type_application env funct sargs =
           end
         in
         let name = label_name l
-        and optional = if is_optional l then Optional else Required in
+        and optional = is_optional l in
         let sargs, more_sargs, arg =
           if ignore_labels && not (is_optional l) then begin
             (* In classic mode, omitted = [] *)
@@ -3443,11 +3442,11 @@ and type_application env funct sargs =
                     (Warnings.Not_principal "commuting this argument");
                 (l', sarg0, sargs @ sargs1, sargs2)
             in
-            if optional = Required && is_optional l' then
+            if not optional && is_optional l' then
               Location.prerr_warning sarg0.pexp_loc
                 (Warnings.Nonoptional_label (Printtyp.string_of_label l));
             sargs, more_sargs,
-            if optional = Required || is_optional l' then
+            if not optional || is_optional l' then
               Some (fun () -> type_argument env sarg0 ty ty0)
             else begin
               may_warn sarg0.pexp_loc
@@ -3458,7 +3457,7 @@ and type_application env funct sargs =
             end
           with Not_found ->
             sargs, more_sargs,
-            if optional = Optional &&
+            if optional &&
               (List.mem_assoc Nolabel sargs
                || List.mem_assoc Nolabel more_sargs)
             then begin
@@ -3475,7 +3474,7 @@ and type_application env funct sargs =
         let omitted =
           if arg = None then (l,ty,lv) :: omitted else omitted in
         let ty_old = if sargs = [] then ty_fun else ty_old in
-        type_args ((l,arg,optional)::args) omitted ty_fun ty_fun0
+        type_args ((l,arg)::args) omitted ty_fun ty_fun0
           ty_old sargs more_sargs
     | _ ->
         match sargs with
@@ -3501,7 +3500,7 @@ and type_application env funct sargs =
           add_delayed_check (fun () -> check_application_result env false exp)
       | _ -> ()
       end;
-      ([Nolabel, Some exp, Required], ty_res)
+      ([Nolabel, Some exp], ty_res)
   | _ ->
       let ty = funct.exp_type in
       if ignore_labels then

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -19,7 +19,6 @@ open Types
 (* Value expressions for the core language *)
 
 type partial = Partial | Total
-type optional = Required | Optional
 
 type attribute = Parsetree.attribute
 type attributes = attribute list
@@ -75,7 +74,7 @@ and expression_desc =
   | Texp_constant of constant
   | Texp_let of rec_flag * value_binding list * expression
   | Texp_function of arg_label * case list * partial
-  | Texp_apply of expression * (arg_label * expression option * optional) list
+  | Texp_apply of expression * (arg_label * expression option) list
   | Texp_match of expression * case list * case list * partial
   | Texp_try of expression * case list
   | Texp_tuple of expression list
@@ -135,7 +134,7 @@ and class_expr_desc =
   | Tcl_fun of
       arg_label * pattern * (Ident.t * string loc * expression) list
       * class_expr * partial
-  | Tcl_apply of class_expr * (arg_label * expression option * optional) list
+  | Tcl_apply of class_expr * (arg_label * expression option) list
   | Tcl_let of rec_flag * value_binding list *
                   (Ident.t * string loc * expression) list * class_expr
   | Tcl_constraint of

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -18,7 +18,6 @@ open Types
 (* Value expressions for the core language *)
 
 type partial = Partial | Total
-type optional = Required | Optional
 
 type attribute = Parsetree.attribute
 type attributes = attribute list
@@ -74,7 +73,7 @@ and expression_desc =
   | Texp_constant of constant
   | Texp_let of rec_flag * value_binding list * expression
   | Texp_function of arg_label * case list * partial
-  | Texp_apply of expression * (arg_label * expression option * optional) list
+  | Texp_apply of expression * (arg_label * expression option) list
   | Texp_match of expression * case list * case list * partial
   | Texp_try of expression * case list
   | Texp_tuple of expression list
@@ -134,7 +133,7 @@ and class_expr_desc =
   | Tcl_fun of
       arg_label * pattern * (Ident.t * string loc * expression) list
       * class_expr * partial
-  | Tcl_apply of class_expr * (arg_label * expression option * optional) list
+  | Tcl_apply of class_expr * (arg_label * expression option) list
   | Tcl_let of rec_flag * value_binding list *
                   (Ident.t * string loc * expression) list * class_expr
   | Tcl_constraint of

--- a/typing/typedtreeIter.ml
+++ b/typing/typedtreeIter.ml
@@ -270,7 +270,7 @@ module MakeIterator(Iter : IteratorArgument) : sig
             iter_cases cases
         | Texp_apply (exp, list) ->
             iter_expression exp;
-            List.iter (fun (label, expo, _) ->
+            List.iter (fun (label, expo) ->
                 match expo with
                   None -> ()
                 | Some exp -> iter_expression exp
@@ -482,7 +482,7 @@ module MakeIterator(Iter : IteratorArgument) : sig
 
         | Tcl_apply (cl, args) ->
             iter_class_expr cl;
-            List.iter (fun (label, expo, _) ->
+            List.iter (fun (label, expo) ->
                 match expo with
                   None -> ()
                 | Some exp -> iter_expression exp

--- a/typing/typedtreeMap.ml
+++ b/typing/typedtreeMap.ml
@@ -272,13 +272,13 @@ module MakeMap(Map : MapArgument) = struct
           Texp_function (label, map_cases cases, partial)
         | Texp_apply (exp, list) ->
           Texp_apply (map_expression exp,
-                      List.map (fun (label, expo, optional) ->
+                      List.map (fun (label, expo) ->
                         let expo =
                           match expo with
                               None -> expo
                             | Some exp -> Some (map_expression exp)
                         in
-                        (label, expo, optional)
+                        (label, expo)
                       ) list )
         | Texp_match (exp, list1, list2, partial) ->
           Texp_match (
@@ -539,9 +539,8 @@ module MakeMap(Map : MapArgument) = struct
 
         | Tcl_apply (cl, args) ->
           Tcl_apply (map_class_expr cl,
-                     List.map (fun (label, expo, optional) ->
-                       (label, may_map map_expression expo,
-                        optional)
+                     List.map (fun (label, expo) ->
+                       (label, may_map map_expression expo)
                      ) args)
         | Tcl_let (rec_flat, bindings, ivars, cl) ->
           Tcl_let (rec_flat, map_bindings rec_flat bindings,

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -366,7 +366,7 @@ let expression sub exp =
                           (sub.cases sub cases))
     | Texp_apply (exp, list) ->
         Pexp_apply (sub.expr sub exp,
-          List.fold_right (fun (label, expo, _) list ->
+          List.fold_right (fun (label, expo) list ->
               match expo with
                 None -> list
               | Some exp -> (label, sub.expr sub exp) :: list
@@ -596,7 +596,7 @@ let class_expr sub cexpr =
 
     | Tcl_apply (cl, args) ->
         Pcl_apply (sub.class_expr sub cl,
-          List.fold_right (fun (label, expo, _) list ->
+          List.fold_right (fun (label, expo) list ->
               match expo with
                 None -> list
               | Some exp -> (label, sub.expr sub exp) :: list


### PR DESCRIPTION
From comments in `typedtree.mli`:

When introduced in 2000, this [type] enabled a more efficient code generation
for optional arguments. However, today the information is redundant as labels
are passed to `transl_apply` too. Could be cleaned up.
