### PR TITLE
Merge signature and structure (parsing-wise)

### DIFF
--- a/Changes
+++ b/Changes
@@ -60,6 +60,8 @@ Language features:
 - GPR#282: change short-paths penalty heuristic to assign the same cost to
   idents containing double underscores as to idents starting with an underscore
   (Thomas Refis, Leo White)
+* PR#6681 GPR#312: signature items are now accepted as payloads for extension and attributes.
+  (Alain Frisch and Gabriel Radanne)
 
 Compilers:
 - PR#4800: better compilation of tuple assignment (Gabriel Scherer and
@@ -197,6 +199,8 @@ Toplevel and debugger:
    review by Gabriel Scherer and Jacques-Henri Jourdan)
 - PR#6935, GPR#298: crash in debugger when load_printer is given a directory
   (Junsong Li, review by Gabriel Scherer)
+* PR#6681 GPR#312: #use parsing rules are changed. A ";;" is needed between any structure element and a following directive.
+  (Alain Frisch and Gabriel Radanne)
 
 Other libraries:
 - PR#4023 and GPR#68: add Unix.sleepf (sleep with sub-second resolution)

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -108,12 +108,13 @@ let apply_rewriters_str ?(restore = true) ~tool_name ast =
       Ast_mapper.drop_ppx_context_str ~restore ast
 
 let apply_rewriters_sig ?(restore = true) ~tool_name ast =
+  (* TODO: merge with apply_rewriters_str *)
   match !Clflags.all_ppx with
   | [] -> ast
   | ppxs ->
-      let ast = Ast_mapper.add_ppx_context_sig ~tool_name ast in
+      let ast = Ast_mapper.add_ppx_context_str ~tool_name ast in
       let ast = rewrite Config.ast_intf_magic_number ast ppxs in
-      Ast_mapper.drop_ppx_context_sig ~restore ast
+      Ast_mapper.drop_ppx_context_str ~restore ast
 
 let apply_rewriters ?restore ~tool_name magic ast =
   if magic = Config.ast_impl_magic_number then

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -99,30 +99,18 @@ let rewrite magic ast ppxs =
     (List.fold_left (apply_rewriter magic) (write_ast magic ast)
        (List.rev ppxs))
 
-let apply_rewriters_str ?(restore = true) ~tool_name ast =
+let apply_rewriters ?(restore = true) ~tool_name magic ast =
   match !Clflags.all_ppx with
   | [] -> ast
   | ppxs ->
       let ast = Ast_mapper.add_ppx_context_str ~tool_name ast in
-      let ast = rewrite Config.ast_impl_magic_number ast ppxs in
+      let ast = rewrite magic ast ppxs in
       Ast_mapper.drop_ppx_context_str ~restore ast
 
-let apply_rewriters_sig ?(restore = true) ~tool_name ast =
-  (* TODO: merge with apply_rewriters_str *)
-  match !Clflags.all_ppx with
-  | [] -> ast
-  | ppxs ->
-      let ast = Ast_mapper.add_ppx_context_str ~tool_name ast in
-      let ast = rewrite Config.ast_intf_magic_number ast ppxs in
-      Ast_mapper.drop_ppx_context_str ~restore ast
-
-let apply_rewriters ?restore ~tool_name magic ast =
-  if magic = Config.ast_impl_magic_number then
-    Obj.magic (apply_rewriters_str ?restore ~tool_name (Obj.magic ast))
-  else if magic = Config.ast_intf_magic_number then
-    Obj.magic (apply_rewriters_sig ?restore ~tool_name (Obj.magic ast))
-  else
-    assert false
+let apply_rewriters_str ?restore ~tool_name ast =
+  apply_rewriters ?restore ~tool_name Config.ast_impl_magic_number ast
+let apply_rewriters_sig ?restore ~tool_name ast =
+  apply_rewriters ?restore ~tool_name Config.ast_intf_magic_number ast
 
 (* Parse a file or get a dumped syntax tree from it *)
 

--- a/driver/pparse.mli
+++ b/driver/pparse.mli
@@ -21,9 +21,10 @@ exception Error of error
 val preprocess : string -> string
 val remove_preprocessed : string -> unit
 val file :
-  formatter -> tool_name:string -> string -> (Lexing.lexbuf -> 'a) -> string ->
-  'a
-val apply_rewriters: ?restore:bool -> tool_name:string -> string -> 'a -> 'a
+  formatter -> tool_name:string -> string ->
+  (Lexing.lexbuf -> Parsetree.structure) -> string -> Parsetree.structure
+val apply_rewriters:
+  ?restore:bool -> tool_name:string -> string -> Parsetree.structure -> Parsetree.structure
   (** If [restore = true] (the default), cookies set by external
       rewriters will be kept for later calls. *)
 

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -1088,7 +1088,11 @@ module Analyser =
           (* don't care *)
           (0, env, [])
       | Parsetree.Pstr_attribute _
-      | Parsetree.Pstr_extension _ ->
+      | Parsetree.Pstr_extension _
+      | Parsetree.Psig_module _
+      | Parsetree.Psig_recmodule _
+      | Parsetree.Psig_include _
+      | Parsetree.Psig_class _ ->
           (0, env, [])
       | Parsetree.Pstr_value (rec_flag, pat_exp_list) ->
           (* of rec_flag * (pattern * expression) list *)

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -156,21 +156,21 @@ let mk ?(loc = !default_loc) ?(attrs = []) d =
 end
 
 module Sig = struct
-  let mk ?(loc = !default_loc) d = {psig_desc = d; psig_loc = loc}
+  let mk ?(loc = !default_loc) d = {pstr_desc = d; pstr_loc = loc}
 
-  let value ?loc a = mk ?loc (Psig_value a)
-  let type_ ?loc rec_flag a = mk ?loc (Psig_type (rec_flag, a))
-  let type_extension ?loc a = mk ?loc (Psig_typext a)
-  let exception_ ?loc a = mk ?loc (Psig_exception a)
+  let value ?loc a = mk ?loc (Pstr_primitive a)
+  let type_ ?loc rec_flag a = mk ?loc (Pstr_type (rec_flag,a))
+  let type_extension ?loc a = mk ?loc (Pstr_typext a)
+  let exception_ ?loc a = mk ?loc (Pstr_exception a)
   let module_ ?loc a = mk ?loc (Psig_module a)
   let rec_module ?loc a = mk ?loc (Psig_recmodule a)
-  let modtype ?loc a = mk ?loc (Psig_modtype a)
-  let open_ ?loc a = mk ?loc (Psig_open a)
+  let modtype ?loc a = mk ?loc (Pstr_modtype a)
+  let open_ ?loc a = mk ?loc (Pstr_open a)
   let include_ ?loc a = mk ?loc (Psig_include a)
   let class_ ?loc a = mk ?loc (Psig_class a)
-  let class_type ?loc a = mk ?loc (Psig_class_type a)
-  let extension ?loc ?(attrs = []) a = mk ?loc (Psig_extension (a, attrs))
-  let attribute ?loc a = mk ?loc (Psig_attribute a)
+  let class_type ?loc a = mk ?loc (Pstr_class_type a)
+  let extension ?loc ?(attrs = []) a = mk ?loc (Pstr_extension (a, attrs))
+  let attribute ?loc a = mk ?loc (Pstr_attribute a)
   let text txt =
     List.map
       (fun ds -> attribute ~loc:(docstring_loc ds) (text_attr ds))

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -228,7 +228,7 @@ module Mod:
 (** Signature items *)
 module Sig:
   sig
-    val mk: ?loc:loc -> signature_item_desc -> signature_item
+    val mk: ?loc:loc -> structure_item_desc -> signature_item
 
     val value: ?loc:loc -> value_description -> signature_item
     val type_: ?loc:loc -> rec_flag -> type_declaration list -> signature_item

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -237,27 +237,6 @@ module MT = struct
     | Pwith_typesubst d -> Pwith_typesubst (sub.type_declaration sub d)
     | Pwith_modsubst (s, lid) ->
         Pwith_modsubst (map_loc sub s, map_loc sub lid)
-
-  let map_signature_item sub {psig_desc = desc; psig_loc = loc} =
-    let open Sig in
-    let loc = sub.location sub loc in
-    match desc with
-    | Psig_value vd -> value ~loc (sub.value_description sub vd)
-    | Psig_type (rf, l) -> type_ ~loc rf (List.map (sub.type_declaration sub) l)
-    | Psig_typext te -> type_extension ~loc (sub.type_extension sub te)
-    | Psig_exception ed -> exception_ ~loc (sub.extension_constructor sub ed)
-    | Psig_module x -> module_ ~loc (sub.module_declaration sub x)
-    | Psig_recmodule l ->
-        rec_module ~loc (List.map (sub.module_declaration sub) l)
-    | Psig_modtype x -> modtype ~loc (sub.module_type_declaration sub x)
-    | Psig_open x -> open_ ~loc (sub.open_description sub x)
-    | Psig_include x -> include_ ~loc (sub.include_description sub x)
-    | Psig_class l -> class_ ~loc (List.map (sub.class_description sub) l)
-    | Psig_class_type l ->
-        class_type ~loc (List.map (sub.class_type_declaration sub) l)
-    | Psig_extension (x, attrs) ->
-        extension ~loc (sub.extension sub x) ~attrs:(sub.attributes sub attrs)
-    | Psig_attribute x -> attribute ~loc (sub.attribute sub x)
 end
 
 
@@ -305,6 +284,11 @@ module M = struct
     | Pstr_extension (x, attrs) ->
         extension ~loc (sub.extension sub x) ~attrs:(sub.attributes sub attrs)
     | Pstr_attribute x -> attribute ~loc (sub.attribute sub x)
+    | Psig_module x -> Sig.module_ ~loc (sub.module_declaration sub x)
+    | Psig_recmodule l ->
+        Sig.rec_module ~loc (List.map (sub.module_declaration sub) l)
+    | Psig_include x -> Sig.include_ ~loc (sub.include_description sub x)
+    | Psig_class l -> Sig.class_ ~loc (List.map (sub.class_description sub) l)
 end
 
 module E = struct
@@ -485,7 +469,7 @@ let default_mapper =
     structure_item = M.map_structure_item;
     module_expr = M.map;
     signature = (fun this l -> List.map (this.signature_item this) l);
-    signature_item = MT.map_signature_item;
+    signature_item = M.map_structure_item;
     module_type = MT.map;
     with_constraint = MT.map_with_constraint;
     class_declaration =
@@ -790,7 +774,7 @@ let ppx_context = PpxContext.make
 
 
 let apply_lazy ~source ~target mapper =
-  let implem ast =
+  let implem str ast =
     try
       let fields, ast =
         match ast with
@@ -800,7 +784,10 @@ let apply_lazy ~source ~target mapper =
       in
       PpxContext.restore fields;
       let mapper = mapper () in
-      let ast = mapper.structure mapper ast in
+      let ast =
+        if str then mapper.structure mapper ast
+        else mapper.signature mapper ast
+      in
       let fields = PpxContext.update_cookies fields in
       Str.attribute (PpxContext.mk fields) :: ast
     with exn ->
@@ -810,27 +797,6 @@ let apply_lazy ~source ~target mapper =
             pstr_loc  = Location.none}]
       | None -> raise exn
   in
-  let iface ast =
-    try
-      let fields, ast =
-        match ast with
-        | {psig_desc = Psig_attribute ({txt = "ocaml.ppx.context"}, x)} :: l ->
-            PpxContext.get_fields x, l
-        | _ -> [], ast
-      in
-      PpxContext.restore fields;
-      let mapper = mapper () in
-      let ast = mapper.signature mapper ast in
-      let fields = PpxContext.update_cookies fields in
-      Sig.attribute (PpxContext.mk fields) :: ast
-    with exn ->
-      match error_of_exn exn with
-      | Some error ->
-          [{psig_desc = Psig_extension (extension_of_error error, []);
-            psig_loc  = Location.none}]
-      | None -> raise exn
-  in
-
   let ic = open_in_bin source in
   let magic =
     really_input_string ic (String.length Config.ast_impl_magic_number)
@@ -852,9 +818,9 @@ let apply_lazy ~source ~target mapper =
   in
 
   if magic = Config.ast_impl_magic_number then
-    rewrite (implem : structure -> structure)
+    rewrite (implem true : structure -> structure)
   else if magic = Config.ast_intf_magic_number then
-    rewrite (iface : signature -> signature)
+    rewrite (implem false : signature -> signature)
   else fail ()
 
 let drop_ppx_context_str ~restore = function
@@ -865,20 +831,8 @@ let drop_ppx_context_str ~restore = function
       items
   | items -> items
 
-let drop_ppx_context_sig ~restore = function
-  | {psig_desc = Psig_attribute({Location.txt = "ocaml.ppx.context"}, a)}
-    :: items ->
-      if restore then
-        PpxContext.restore (PpxContext.get_fields a);
-      items
-  | items -> items
-
 let add_ppx_context_str ~tool_name ast =
   Ast_helper.Str.attribute (ppx_context ~tool_name ()) :: ast
-
-let add_ppx_context_sig ~tool_name ast =
-  Ast_helper.Sig.attribute (ppx_context ~tool_name ()) :: ast
-
 
 let apply ~source ~target mapper =
   apply_lazy ~source ~target (fun () -> mapper)

--- a/parsing/ast_mapper.mli
+++ b/parsing/ast_mapper.mli
@@ -173,19 +173,10 @@ val add_ppx_context_str:
     items in order to pass the information to an external
     processor. *)
 
-val add_ppx_context_sig:
-    tool_name:string -> Parsetree.signature -> Parsetree.signature
-(** Same as [add_ppx_context_str], but for signatures. *)
-
-val drop_ppx_context_str:
-    restore:bool -> Parsetree.structure -> Parsetree.structure
+val drop_ppx_context_str: restore:bool -> Parsetree.structure -> Parsetree.structure
 (** Drop the ocaml.ppx.context attribute from a structure.  If
     [restore] is true, also restore the associated data in the current
     process. *)
-
-val drop_ppx_context_sig:
-    restore:bool -> Parsetree.signature -> Parsetree.signature
-(** Same as [drop_ppx_context_str], but for signatures. *)
 
 (** {2 Cookies} *)
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -860,15 +860,15 @@ signature:
 ;
 signature_item:
     value_description
-      { mksig(Psig_value $1) }
+      { mksig(Pstr_primitive $1) }
   | primitive_declaration
-      { mksig(Psig_value $1) }
+      { mksig(Pstr_primitive $1) }
   | type_declarations
-      { let (nr, l) = $1 in mksig(Psig_type (nr, List.rev l)) }
+      { let (nr, l) = $1 in mksig(Pstr_type (nr, List.rev l)) }
   | sig_type_extension
-      { mksig(Psig_typext $1) }
+      { mksig(Pstr_typext $1) }
   | sig_exception_declaration
-      { mksig(Psig_exception $1) }
+      { mksig(Pstr_exception $1) }
   | module_declaration
       { mksig(Psig_module $1) }
   | module_alias
@@ -876,20 +876,20 @@ signature_item:
   | rec_module_declarations
       { mksig(Psig_recmodule (List.rev $1)) }
   | module_type_declaration
-      { mksig(Psig_modtype $1) }
+      { mksig(Pstr_modtype $1) }
   | open_statement
-      { mksig(Psig_open $1) }
+      { mksig(Pstr_open $1) }
   | sig_include_statement
       { mksig(Psig_include $1) }
   | class_descriptions
       { mksig(Psig_class (List.rev $1)) }
   | class_type_declarations
-      { mksig(Psig_class_type (List.rev $1)) }
+      { mksig(Pstr_class_type (List.rev $1)) }
   | item_extension post_item_attributes
-      { mksig(Psig_extension ($1, (add_docs_attrs (symbol_docs ()) $2))) }
+      { mksig(Pstr_extension ($1, (add_docs_attrs (symbol_docs ()) $2))) }
   | floating_attribute
       { mark_symbol_docs ();
-        mksig(Psig_attribute $1) }
+        mksig(Pstr_attribute $1) }
 ;
 open_statement:
   | OPEN override_flag mod_longident post_item_attributes

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -657,26 +657,11 @@ use_file:
     use_file_body                        { extra_def 1 $1 }
 ;
 use_file_body:
-    use_file_tail                        { $1 }
-  | seq_expr post_item_attributes use_file_tail
-      { (text_def 1) @ Ptop_def[mkstrexp $1 $2] :: $3 }
-;
-use_file_tail:
-    EOF
-      { [] }
-  | SEMISEMI EOF
-      { text_def 1 }
-  | SEMISEMI seq_expr post_item_attributes use_file_tail
-      {  mark_rhs_docs 2 3;
-        (text_def 1) @ (text_def 2) @ Ptop_def[mkstrexp $2 $3] :: $4 }
-  | SEMISEMI structure_item use_file_tail
-      { (text_def 1) @ (text_def 2) @ Ptop_def[$2] :: $3 }
-  | SEMISEMI toplevel_directive use_file_tail
-      {  mark_rhs_docs 2 3;
-        (text_def 1) @ (text_def 2) @ $2 :: $3 }
-  | structure_item use_file_tail
-      { (text_def 1) @ Ptop_def[$1] :: $2 }
-  | toplevel_directive use_file_tail
+  | top_structure EOF
+      { [Ptop_def $1] }
+  | top_structure SEMISEMI use_file_body
+      { Ptop_def $1 :: (text_def 2) @ $3 }
+  | toplevel_directive use_file_body
       { mark_rhs_docs 1 1;
         (text_def 1) @ $1 :: $2 }
 ;

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -809,12 +809,12 @@ str_sig_item:
         | Str l -> mkstr(Pstr_class(List.rev l))
         | Sig l -> mkstr(Psig_class(List.rev l))
       }
+  | let_bindings
+      { val_of_let_bindings $1 }
 
 ;
 structure_item:
     str_sig_item { $1 }
-  | let_bindings
-      { val_of_let_bindings $1 }
   | str_include_statement
       { mkstr(Pstr_include $1) }
 ;

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -755,15 +755,28 @@ structure_tail:
   | SEMISEMI structure   { (text_str 1) @ $2 }
   | structure_item structure_tail { (text_str 1) @ $1 :: $2 }
 ;
-structure_item:
-    let_bindings
-      { val_of_let_bindings $1 }
+str_sig_item:
   | primitive_declaration
       { mkstr (Pstr_primitive $1) }
   | value_description
       { mkstr (Pstr_primitive $1) }
   | type_declarations
       { let (nr, l) = $1 in mkstr(Pstr_type (nr, List.rev l)) }
+  | module_type_declaration
+      { mkstr(Pstr_modtype $1) }
+  | open_statement { mkstr(Pstr_open $1) }
+  | class_type_declarations
+      { mkstr(Pstr_class_type (List.rev $1)) }
+  | item_extension post_item_attributes
+      { mkstr(Pstr_extension ($1, (add_docs_attrs (symbol_docs ()) $2))) }
+  | floating_attribute
+      { mark_symbol_docs ();
+        mkstr(Pstr_attribute $1) }
+;
+structure_item:
+    str_sig_item { $1 }
+  | let_bindings
+      { val_of_let_bindings $1 }
   | str_type_extension
       { mkstr(Pstr_typext $1) }
   | str_exception_declaration
@@ -772,20 +785,10 @@ structure_item:
       { mkstr(Pstr_module $1) }
   | rec_module_bindings
       { mkstr(Pstr_recmodule(List.rev $1)) }
-  | module_type_declaration
-      { mkstr(Pstr_modtype $1) }
-  | open_statement { mkstr(Pstr_open $1) }
   | class_declarations
       { mkstr(Pstr_class (List.rev $1)) }
-  | class_type_declarations
-      { mkstr(Pstr_class_type (List.rev $1)) }
   | str_include_statement
       { mkstr(Pstr_include $1) }
-  | item_extension post_item_attributes
-      { mkstr(Pstr_extension ($1, (add_docs_attrs (symbol_docs ()) $2))) }
-  | floating_attribute
-      { mark_symbol_docs ();
-        mkstr(Pstr_attribute $1) }
 ;
 str_include_statement:
     INCLUDE module_expr post_item_attributes
@@ -859,12 +862,7 @@ signature:
   | signature_item signature { (text_sig 1) @ $1 :: $2 }
 ;
 signature_item:
-    value_description
-      { mksig(Pstr_primitive $1) }
-  | primitive_declaration
-      { mksig(Pstr_primitive $1) }
-  | type_declarations
-      { let (nr, l) = $1 in mksig(Pstr_type (nr, List.rev l)) }
+    str_sig_item { $1 }
   | sig_type_extension
       { mksig(Pstr_typext $1) }
   | sig_exception_declaration
@@ -875,21 +873,10 @@ signature_item:
       { mksig(Psig_module $1) }
   | rec_module_declarations
       { mksig(Psig_recmodule (List.rev $1)) }
-  | module_type_declaration
-      { mksig(Pstr_modtype $1) }
-  | open_statement
-      { mksig(Pstr_open $1) }
   | sig_include_statement
       { mksig(Psig_include $1) }
   | class_descriptions
       { mksig(Psig_class (List.rev $1)) }
-  | class_type_declarations
-      { mksig(Pstr_class_type (List.rev $1)) }
-  | item_extension post_item_attributes
-      { mksig(Pstr_extension ($1, (add_docs_attrs (symbol_docs ()) $2))) }
-  | floating_attribute
-      { mark_symbol_docs ();
-        mksig(Pstr_attribute $1) }
 ;
 open_statement:
   | OPEN override_flag mod_longident post_item_attributes

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1244,7 +1244,7 @@ expr:
       {
         match $5 with
         | Str m -> mkexp_attrs (Pexp_letmodule(mkrhs $4 4, m, $7)) $3
-        | Sig m -> assert false (* TODO *)
+        | Sig m -> raise Syntaxerr.(Error (Invalid_module_type (m.pmty_loc)))
       }
   | LET OPEN override_flag ext_attributes mod_longident IN seq_expr
       { mkexp_attrs (Pexp_open($3, mkrhs $5 5, $7)) $4 }

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -639,43 +639,7 @@ and module_type_desc =
 
 and signature = signature_item list
 
-and signature_item =
-    {
-     psig_desc: signature_item_desc;
-     psig_loc: Location.t;
-    }
-
-and signature_item_desc =
-  | Psig_value of value_description
-        (*
-          val x: T
-          external x: T = "s1" ... "sn"
-         *)
-  | Psig_type of rec_flag * type_declaration list
-        (* type t1 = ... and ... and tn = ... *)
-  | Psig_typext of type_extension
-        (* type t1 += ... *)
-  | Psig_exception of extension_constructor
-        (* exception C of T *)
-  | Psig_module of module_declaration
-        (* module X : MT *)
-  | Psig_recmodule of module_declaration list
-        (* module rec X1 : MT1 and ... and Xn : MTn *)
-  | Psig_modtype of module_type_declaration
-        (* module type S = MT
-           module type S *)
-  | Psig_open of open_description
-        (* open X *)
-  | Psig_include of include_description
-        (* include MT *)
-  | Psig_class of class_description list
-        (* class c1 : ... and ... and cn : ... *)
-  | Psig_class_type of class_type_declaration list
-        (* class type ct1 = ... and ... and ctn = ... *)
-  | Psig_attribute of attribute
-        (* [@@@id] *)
-  | Psig_extension of extension * attributes
-        (* [%%id] *)
+and signature_item = structure_item
 
 and module_declaration =
     {
@@ -803,6 +767,18 @@ and structure_item_desc =
         (* [@@@id] *)
   | Pstr_extension of extension * attributes
         (* [%%id] *)
+
+(* TODO:
+   - restrict typext/exception in signatures during type-checking
+*)
+  | Psig_module of module_declaration
+        (* module X : MT *)
+  | Psig_recmodule of module_declaration list
+        (* module rec X1 : MT1 and ... and Xn : MTn *)
+  | Psig_include of include_description
+        (* include MT *)
+  | Psig_class of class_description list
+        (* class c1 : ... and ... and cn : ... *)
 
 and value_binding =
   {

--- a/parsing/pprintast.mli
+++ b/parsing/pprintast.mli
@@ -94,9 +94,7 @@ class printer :
     method reset_pipe : 'b
 
     method signature :
-      Format.formatter -> Parsetree.signature_item list -> unit
-    method signature_item :
-      Format.formatter -> Parsetree.signature_item -> unit
+      Format.formatter -> Parsetree.structure -> unit
     method simple_expr : Format.formatter -> Parsetree.expression -> unit
     method simple_pattern : Format.formatter -> Parsetree.pattern -> unit
     method string_quot : Format.formatter -> Asttypes.label -> unit

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -638,8 +638,9 @@ and module_type i ppf x =
       line i ppf "Pmod_extension \"%s\"\n" s.txt;
       payload i ppf arg
 
-and signature i ppf x = list i signature_item ppf x
+and signature i ppf x = structure i ppf x
 
+(*
 and signature_item i ppf x =
   line i ppf "signature_item %a\n" fmt_location x.psig_loc;
   let i = i+1 in
@@ -689,6 +690,7 @@ and signature_item i ppf x =
   | Psig_attribute (s, arg) ->
       line i ppf "Psig_attribute \"%s\"\n" s.txt;
       payload i ppf arg
+*)
 
 and modtype_declaration i ppf = function
   | None -> line i ppf "#abstract"
@@ -796,6 +798,20 @@ and structure_item i ppf x =
   | Pstr_attribute (s, arg) ->
       line i ppf "Pstr_attribute \"%s\"\n" s.txt;
       payload i ppf arg
+  | Psig_module pmd ->
+      line i ppf "Psig_module %a\n" fmt_string_loc pmd.pmd_name;
+      attributes i ppf pmd.pmd_attributes;
+      module_type i ppf pmd.pmd_type
+  | Psig_recmodule decls ->
+      line i ppf "Psig_recmodule\n";
+      list i module_declaration ppf decls;
+  | Psig_include incl ->
+      line i ppf "Psig_include\n";
+      module_type i ppf incl.pincl_mod;
+      attributes i ppf incl.pincl_attributes
+  | Psig_class (l) ->
+      line i ppf "Psig_class\n";
+      list i class_description ppf l;
 
 and module_declaration i ppf pmd =
   string_loc i ppf pmd.pmd_name;
@@ -892,8 +908,8 @@ and directive_argument i ppf x =
   | Pdir_bool (b) -> line i ppf "Pdir_bool %s\n" (string_of_bool b);
 ;;
 
-let interface ppf x = list 0 signature_item ppf x;;
+let interface ppf x = signature 0 ppf x;;
 
-let implementation ppf x = list 0 structure_item ppf x;;
+let implementation ppf x = structure 0 ppf x;;
 
 let top_phrase ppf x = toplevel_phrase 0 ppf x;;

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -640,58 +640,6 @@ and module_type i ppf x =
 
 and signature i ppf x = structure i ppf x
 
-(*
-and signature_item i ppf x =
-  line i ppf "signature_item %a\n" fmt_location x.psig_loc;
-  let i = i+1 in
-  match x.psig_desc with
-  | Psig_value vd ->
-      line i ppf "Psig_value\n";
-      value_description i ppf vd;
-  | Psig_type (rf, l) ->
-      line i ppf "Psig_type %a\n" fmt_rec_flag rf;
-      list i type_declaration ppf l;
-  | Psig_typext te ->
-      line i ppf "Psig_typext\n";
-      type_extension i ppf te
-  | Psig_exception ext ->
-      line i ppf "Psig_exception\n";
-      extension_constructor i ppf ext;
-  | Psig_module pmd ->
-      line i ppf "Psig_module %a\n" fmt_string_loc pmd.pmd_name;
-      attributes i ppf pmd.pmd_attributes;
-      module_type i ppf pmd.pmd_type
-  | Psig_recmodule decls ->
-      line i ppf "Psig_recmodule\n";
-      list i module_declaration ppf decls;
-  | Psig_modtype x ->
-      line i ppf "Psig_modtype %a\n" fmt_string_loc x.pmtd_name;
-      attributes i ppf x.pmtd_attributes;
-      modtype_declaration i ppf x.pmtd_type
-  | Psig_open od ->
-      line i ppf "Psig_open %a %a\n"
-        fmt_override_flag od.popen_override
-        fmt_longident_loc od.popen_lid;
-      attributes i ppf od.popen_attributes
-  | Psig_include incl ->
-      line i ppf "Psig_include\n";
-      module_type i ppf incl.pincl_mod;
-      attributes i ppf incl.pincl_attributes
-  | Psig_class (l) ->
-      line i ppf "Psig_class\n";
-      list i class_description ppf l;
-  | Psig_class_type (l) ->
-      line i ppf "Psig_class_type\n";
-      list i class_type_declaration ppf l;
-  | Psig_extension ((s, arg), attrs) ->
-      line i ppf "Psig_extension \"%s\"\n" s.txt;
-      attributes i ppf attrs;
-      payload i ppf arg
-  | Psig_attribute (s, arg) ->
-      line i ppf "Psig_attribute \"%s\"\n" s.txt;
-      payload i ppf arg
-*)
-
 and modtype_declaration i ppf = function
   | None -> line i ppf "#abstract"
   | Some mt -> module_type (i+1) ppf mt

--- a/parsing/printast.mli
+++ b/parsing/printast.mli
@@ -13,8 +13,8 @@
 open Parsetree;;
 open Format;;
 
-val interface : formatter -> signature_item list -> unit;;
-val implementation : formatter -> structure_item list -> unit;;
+val interface : formatter -> signature -> unit;;
+val implementation : formatter -> structure -> unit;;
 val top_phrase : formatter -> toplevel_phrase -> unit;;
 
 val expression: int -> formatter -> expression -> unit

--- a/parsing/syntaxerr.ml
+++ b/parsing/syntaxerr.ml
@@ -21,6 +21,7 @@ type error =
   | Other of Location.t
   | Ill_formed_ast of Location.t * string
   | Mixed_definition_declaration of Location.t
+  | Invalid_module_type of Location.t
 
 exception Error of error
 exception Escape_error
@@ -57,6 +58,8 @@ let prepare_error = function
       Location.errorf_prefixed ~loc "broken invariant in parsetree: %s" s
   | Mixed_definition_declaration loc ->
       Location.errorf_prefixed ~loc "definitions and declarations cannot be mixed"
+  | Invalid_module_type loc ->
+      Location.errorf_prefixed ~loc "This expression defines a module type. A module expression was expected."
 
 let () =
   Location.register_error_of_exn
@@ -77,7 +80,9 @@ let location_of_error = function
   | Not_expecting (l, _)
   | Ill_formed_ast (l, _)
   | Mixed_definition_declaration l
-  | Expecting (l, _) -> l
+  | Expecting (l, _)
+  | Invalid_module_type l
+    -> l
 
 
 let ill_formed_ast loc s =

--- a/parsing/syntaxerr.ml
+++ b/parsing/syntaxerr.ml
@@ -20,6 +20,7 @@ type error =
   | Variable_in_scope of Location.t * string
   | Other of Location.t
   | Ill_formed_ast of Location.t * string
+  | Mixed_definition_declaration of Location.t
 
 exception Error of error
 exception Escape_error
@@ -54,6 +55,8 @@ let prepare_error = function
       Location.errorf_prefixed ~loc "Syntax error"
   | Ill_formed_ast (loc, s) ->
       Location.errorf_prefixed ~loc "broken invariant in parsetree: %s" s
+  | Mixed_definition_declaration loc ->
+      Location.errorf_prefixed ~loc "definitions and declarations cannot be mixed"
 
 let () =
   Location.register_error_of_exn
@@ -73,6 +76,7 @@ let location_of_error = function
   | Other l
   | Not_expecting (l, _)
   | Ill_formed_ast (l, _)
+  | Mixed_definition_declaration l
   | Expecting (l, _) -> l
 
 

--- a/parsing/syntaxerr.mli
+++ b/parsing/syntaxerr.mli
@@ -22,6 +22,7 @@ type error =
   | Variable_in_scope of Location.t * string
   | Other of Location.t
   | Ill_formed_ast of Location.t * string
+  | Mixed_definition_declaration of Location.t
 
 exception Error of error
 exception Escape_error

--- a/parsing/syntaxerr.mli
+++ b/parsing/syntaxerr.mli
@@ -23,6 +23,7 @@ type error =
   | Other of Location.t
   | Ill_formed_ast of Location.t * string
   | Mixed_definition_declaration of Location.t
+  | Invalid_module_type of Location.t
 
 exception Error of error
 exception Escape_error

--- a/testsuite/tests/parsing-toplevel/Makefile
+++ b/testsuite/tests/parsing-toplevel/Makefile
@@ -1,0 +1,16 @@
+#########################################################################
+#                                                                       #
+#                                 OCaml                                 #
+#                                                                       #
+#                  Jeremie Dimino, Jane Street Europe                   #
+#                                                                       #
+#   Copyright 2010 Institut National de Recherche en Informatique et    #
+#   en Automatique.  All rights reserved.  This file is distributed     #
+#   under the terms of the Q Public License version 1.0.                #
+#                                                                       #
+#########################################################################
+
+BASEDIR=../..
+TOPFLAGS+=-dparsetree
+include $(BASEDIR)/makefiles/Makefile.toplevel
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/parsing-toplevel/toplevel_max.ml
+++ b/testsuite/tests/parsing-toplevel/toplevel_max.ml
@@ -1,0 +1,14 @@
+(* This file tests the maximum amount of SEMISEMI so that #use works. *)
+
+#cd "." ;;
+#print_depth 20 ;;
+
+;;
+
+let x = 3 ;;
+type t = int ;;
+
+#show_val x ;; ;;
+#show_type t ;;
+
+;;

--- a/testsuite/tests/parsing-toplevel/toplevel_max.ml.reference
+++ b/testsuite/tests/parsing-toplevel/toplevel_max.ml.reference
@@ -1,0 +1,58 @@
+
+#     # Ptop_def
+  []
+Ptop_def
+  []
+Ptop_def
+  []
+Ptop_dir "cd"
+Pdir_string "."
+Ptop_dir "print_depth"
+Pdir_int 20
+#   Ptop_def
+  []
+#   Ptop_def
+  [
+    structure_item (//toplevel//[5,1+0]..[5,1+9])
+      Pstr_value Nonrec
+      [
+        <def>
+          pattern (//toplevel//[5,1+4]..[5,1+5])
+            Ppat_var "x" (//toplevel//[5,1+4]..[5,1+5])
+          expression (//toplevel//[5,1+8]..[5,1+9])
+            Pexp_constant Const_int 3
+      ]
+  ]
+
+val x : int = 3
+# Ptop_def
+  [
+    structure_item (//toplevel//[5,1+-1]..[5,1+11])
+      Pstr_type Rec
+      [
+        type_declaration "t" (//toplevel//[5,1+4]..[5,1+5]) (//toplevel//[5,1+-1]..[5,1+11])
+          ptype_params =
+            []
+          ptype_cstrs =
+            []
+          ptype_kind =
+            Ptype_abstract
+          ptype_private = Public
+          ptype_manifest =
+            Some
+              core_type (//toplevel//[5,1+8]..[5,1+11])
+                Ptyp_constr "int" (//toplevel//[5,1+8]..[5,1+11])
+                []
+      ]
+  ]
+
+type t = int
+#   Ptop_dir "show_val"
+Pdir_ident "x"
+val x : int
+# Ptop_dir "show_type"
+Pdir_ident "t"
+type nonrec t = int
+#   # Ptop_def
+  []
+

--- a/testsuite/tests/parsing-toplevel/toplevel_min.ml
+++ b/testsuite/tests/parsing-toplevel/toplevel_min.ml
@@ -1,0 +1,10 @@
+(* This file tests the minimum amount of SEMISEMI so that #use works. *)
+
+#cd "."
+#print_depth 20
+
+let x = 3
+type t = int ;;
+
+#show_val x
+#show_type t

--- a/testsuite/tests/parsing-toplevel/toplevel_min.ml.reference
+++ b/testsuite/tests/parsing-toplevel/toplevel_min.ml.reference
@@ -1,0 +1,17 @@
+
+#             Ptop_def
+  []
+Ptop_def
+  []
+Ptop_def
+  []
+Characters 82-83:
+  #print_depth 20
+  ^
+Error: Syntax error
+#       
+Characters 13-14:
+  #show_type t
+  ^
+Error: Syntax error
+# 

--- a/tools/depend.ml
+++ b/tools/depend.ml
@@ -238,45 +238,7 @@ and add_modtype bv mty =
   | Pmty_typeof m -> add_module bv m
   | Pmty_extension _ -> ()
 
-and add_signature bv = function
-    [] -> ()
-  | item :: rem -> add_signature (add_sig_item bv item) rem
-
-and add_sig_item bv item =
-  match item.psig_desc with
-    Psig_value vd ->
-      add_type bv vd.pval_type; bv
-  | Psig_type (_, dcls) ->
-      List.iter (add_type_declaration bv) dcls; bv
-  | Psig_typext te ->
-      add_type_extension bv te; bv
-  | Psig_exception pext ->
-      add_extension_constructor bv pext; bv
-  | Psig_module pmd ->
-      add_modtype bv pmd.pmd_type; StringSet.add pmd.pmd_name.txt bv
-  | Psig_recmodule decls ->
-      let bv' =
-        List.fold_right StringSet.add
-                        (List.map (fun pmd -> pmd.pmd_name.txt) decls) bv
-      in
-      List.iter (fun pmd -> add_modtype bv' pmd.pmd_type) decls;
-      bv'
-  | Psig_modtype x ->
-      begin match x.pmtd_type with
-        None -> ()
-      | Some mty -> add_modtype bv mty
-      end;
-      bv
-  | Psig_open od ->
-      open_module bv od.popen_lid.txt; bv
-  | Psig_include incl ->
-      add_modtype bv incl.pincl_mod; bv
-  | Psig_class cdl ->
-      List.iter (add_class_description bv) cdl; bv
-  | Psig_class_type cdtl ->
-      List.iter (add_class_type_declaration bv) cdtl; bv
-  | Psig_attribute _ | Psig_extension _ ->
-      bv
+and add_signature bv l = ignore (add_structure bv l)
 
 and add_module bv modl =
   match modl.pmod_desc with
@@ -338,6 +300,19 @@ and add_struct_item bv item =
       add_module bv incl.pincl_mod; bv
   | Pstr_attribute _ | Pstr_extension _ ->
       bv
+  | Psig_module pmd ->
+      add_modtype bv pmd.pmd_type; StringSet.add pmd.pmd_name.txt bv
+  | Psig_recmodule decls ->
+      let bv' =
+        List.fold_right StringSet.add
+                        (List.map (fun pmd -> pmd.pmd_name.txt) decls) bv
+      in
+      List.iter (fun pmd -> add_modtype bv' pmd.pmd_type) decls;
+      bv'
+  | Psig_include incl ->
+      add_modtype bv incl.pincl_mod; bv
+  | Psig_class cdl ->
+      List.iter (add_class_description bv) cdl; bv
 
 and add_use_file bv top_phrs =
   ignore (List.fold_left add_top_phrase bv top_phrs)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -206,6 +206,7 @@ let iter_expression f e =
     | Pstr_module {pmb_expr = me} -> module_expr me
     | Pstr_recmodule l -> List.iter (fun x -> module_expr x.pmb_expr) l
     | Pstr_class cdl -> List.iter (fun c -> class_expr c.pci_expr) cdl
+    | Psig_module _ | Psig_recmodule _ | Psig_include _ | Psig_class _ -> ()
 
   and class_expr ce =
     match ce.pcl_desc with

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -50,6 +50,7 @@ type error =
   | Val_in_structure
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
+  | Rebinding_in_signature
 
 open Typedtree
 
@@ -1146,6 +1147,8 @@ let transl_extension_constructor env type_path type_params
             sargs sret_type
         in
           args, ret_type, Text_decl(targs, tret_type)
+    | Pext_rebind lid when Env.is_in_signature env ->
+        raise (Error (lid.loc, Rebinding_in_signature))
     | Pext_rebind lid ->
         let cdescr = Typetexp.find_constructor env sext.pext_loc lid.txt in
         let usage =
@@ -1799,6 +1802,8 @@ let report_error ppf = function
   | Cannot_unbox_or_untag_type Untagged ->
       fprintf ppf "Don't know how to untag this type. Only int \
                    can be untagged"
+  | Rebinding_in_signature ->
+      fprintf ppf "Rebinding is not allowed in signatures"
 
 let () =
   Location.register_error_of_exn

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -87,6 +87,7 @@ type error =
   | Val_in_structure
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
+  | Rebinding_in_signature
 
 exception Error of Location.t * error
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -316,6 +316,39 @@ let map_ext fn exts rem =
   | [] -> rem
   | d1 :: dl -> fn Text_first d1 :: map_end (fn Text_next) dl rem
 
+
+(* Helper for module aliases.
+   Note:  we should drop Pmty_alias from the Parsetree and treat
+   aliases directly as Pstr_module items in signatures. *)
+
+let pmd_of_pmb env
+    {pmb_name; pmb_expr = {
+         pmod_desc = desc;
+         pmod_loc;
+         pmod_attributes;
+       };
+     pmb_attributes; pmb_loc} =
+  match desc with
+  | Pmod_ident lid ->
+      {
+        pmd_name = pmb_name;
+        pmd_type = {
+          pmty_desc = Pmty_alias lid;
+          pmty_loc = pmod_loc;
+          pmty_attributes = pmod_attributes;
+        };
+        pmd_attributes = pmb_attributes;
+        pmd_loc = pmb_loc;
+      }
+  | _ ->
+      raise (Error (pmb_loc, env, Invalid_item_in_signature))
+
+let norm_sig_item env = function
+  | {pstr_desc = Pstr_module pmb} as item ->
+      {item with pstr_desc = Psig_module (pmd_of_pmb env pmb)}
+  | item ->
+      item
+
 (* Auxiliary for translating recursively-defined module types.
    Return a module type that approximates the shape of the given module
    type AST.  Retain only module, type, and module type
@@ -357,6 +390,7 @@ and approx_sig env ssg =
   match ssg with
     [] -> []
   | item :: srem ->
+      let item = norm_sig_item env item in
       match item.pstr_desc with
       | Pstr_type (rec_flag, sdecls) ->
           let decls = Typedecl.approx_type_decl env sdecls in
@@ -573,6 +607,7 @@ and transl_signature env sg =
     match sg with
       [] -> [], [], env
     | item :: srem ->
+        let item = norm_sig_item env item in
         let loc = item.pstr_loc in
         match item.pstr_desc with
         | Pstr_primitive sdesc ->

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -71,6 +71,8 @@ type error =
   | Recursive_module_require_explicit_type
   | Apply_generative
   | Cannot_scrape_alias of Path.t
+  | Invalid_item_in_signature
+  | Invalid_item_in_structure
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -470,29 +470,29 @@ let signature_item sub item =
   let desc =
     match item.sig_desc with
       Tsig_value v ->
-        Psig_value (sub.value_description sub v)
+        Pstr_primitive (sub.value_description sub v)
     | Tsig_type (rec_flag, list) ->
-        Psig_type (rec_flag, List.map (sub.type_declaration sub) list)
+        Pstr_type (rec_flag, List.map (sub.type_declaration sub) list)
     | Tsig_typext tyext ->
-        Psig_typext (sub.type_extension sub tyext)
+        Pstr_typext (sub.type_extension sub tyext)
     | Tsig_exception ext ->
-        Psig_exception (sub.extension_constructor sub ext)
+        Pstr_exception (sub.extension_constructor sub ext)
     | Tsig_module md ->
         Psig_module (sub.module_declaration sub md)
     | Tsig_recmodule list ->
         Psig_recmodule (List.map (sub.module_declaration sub) list)
     | Tsig_modtype mtd ->
-        Psig_modtype (sub.module_type_declaration sub mtd)
+        Pstr_modtype (sub.module_type_declaration sub mtd)
     | Tsig_open od ->
-        Psig_open (sub.open_description sub od)
+        Pstr_open (sub.open_description sub od)
     | Tsig_include incl ->
         Psig_include (sub.include_description sub incl)
     | Tsig_class list ->
         Psig_class (List.map (sub.class_description sub) list)
     | Tsig_class_type list ->
-        Psig_class_type (List.map (sub.class_type_declaration sub) list)
+        Pstr_class_type (List.map (sub.class_type_declaration sub) list)
     | Tsig_attribute x ->
-        Psig_attribute x
+        Pstr_attribute x
   in
   Sig.mk ~loc desc
 


### PR DESCRIPTION
Beginning of the discussion and original motivation are in [mantis ticket 6681](http://caml.inria.fr/mantis/view.php?id=6681).

The main original issue was that it is not possible to write the following code inside a `.mli`:

``` ocaml
[%%foo 
  val x : int
  module M : S 
]
```

The payload of an extension must be a structure. The recent introduction of val into structure doesn't solve this, I want to be able to have any signature items in my payload. 

After discussion, @alainfrisch proposed (and implemented) to merge structures and signatures in the parser, so that the payload is allowed more freedom. Wrongly formated parsetrees are rejected with a new error: "This kind of item is not valid in structures" (resp. "signatures") (Improvements on the wording are very welcome). This also means that the syntax error messages are oh-so-slightly better. :)

This leads to a conflict in the grammar, which is solved by being more strict in what the `#use` directive parses: a ";;" must always be introduced between a structure and a directive. See the test case for an example. This was already the case for a significant part of the structure items (in particular, the `let`). I lack data to see how much breakage this would cause. If it's considered too much, we may be able to refine that restriction. 

The new form of the parsetree doesn't break ppxs as much as you could think (at least ppx_deriving, lwt, and jsoo are left unharmed, I didn't tried janestreet's ppxs since there are independent breakages due to 4.03, but I doubt it will be terrible). 

test passes, it bootstraps and I tried all the large camlp4-independent codebases I could find. Generated documentation also seems correct on lwt. I advise reading commit by commit.
