### PR TITLE
PR#7031: Ambiguous guarded or-patterns

### DIFF
--- a/Changes
+++ b/Changes
@@ -355,6 +355,8 @@ Features wishes:
   (Eyyüb Sari)
 - PR#6924: tiny optim to avoid some spilling of floats in x87
   (Alain Frisch)
+- PR#7031: warning on ambiguous guarded or-patterns
+  (Gabriel Scherer, report by Martin Clochard and Claude Marché)
 - GPR#111: `(f [@taillcall]) x y` warns if `f x y` is not a tail-call
   (Simon Cruanes)
 - GPR#118: ocamldep -allow-approx: fallback to a lexer-based approximation

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -1,0 +1,166 @@
+let () = print_endline "\n\
+  <----------------------------------------------------------------------\n\
+  To check the result file for this test, it suffices to look for \"val\"\n\
+  lines corresponding to toplevel answers. If they start with\n\
+  \n\
+  \    val ambiguous_...\n\
+  \n\
+  then just above there should be the warning text for Warning 57\n\
+  (we try to avoid all other warnings). If they start with\n\
+  \n\
+  \   val not_ambiguous_...\n\
+  \n\
+  then just above there should be *no* warning text.\n\
+  ---------------------------------------------------------------------->\n\
+";;
+
+
+type expr = Val of int | Rest;;
+
+let ambiguous_typical_example = function
+  | ((Val x, _) | (_, Val x)) when x < 0 -> ()
+  | (_, Rest) -> ()
+  | (_, Val x) ->
+      (* the reader might expect *)
+      assert (x >= 0);
+      (* to hold here, but it is wrong! *)
+      ()
+;;
+
+let () = print_endline "Note that an Assert_failure is expected just below.";;
+let fails = ambiguous_typical_example (Val 2, Val (-1))
+;;
+
+let not_ambiguous__no_orpat = function
+  | Some x when x > 0 -> ()
+  | Some _ -> ()
+  | None -> ()
+;;
+
+let not_ambiguous__no_guard = function
+  | `A -> ()
+  | (`B | `C) -> ()
+;;
+
+let not_ambiguous__no_patvar_in_guard b = function
+  | (`B x | `C x) when b -> ignore x
+  | _ -> ()
+;;
+
+let not_ambiguous__disjoint_cases = function
+  | (`B x | `C x) when x -> ()
+  | _ -> ()
+;;
+
+(* the curious (..., _, Some _) | (..., Some _, _) device used in
+   those tests serves to avoid warning 12 (this sub-pattern
+   is unused), by making sure that, even if the two sides of the
+   disjunction overlap, none is fully included in the other. *)
+let not_ambiguous__prefix_variables = function
+  | (`B (x, _, Some y) | `B (x, Some y, _)) when x -> ignore y
+  | _ -> ()
+;;
+
+let ambiguous__y = function
+  | (`B (x, _, Some y) | `B (x, Some y, _)) when y -> ignore x
+  | _ -> ()
+;;
+
+(* it should be understood that the ambiguity warning only protects
+     (p | q) when guard -> ...
+   it will never warn on
+     (p | q) -> if guard ...
+
+   This is not a limitation. The point is that people have an
+   intuitive understanding of [(p | q) when guard -> ...] that differs
+   from the reality, while there is no such issue with
+   [(p | q) -> if guard ...].
+*)
+let not_ambiguous__rhs_not_protected = function
+  | (`B (x, _, Some y) | `B (x, Some y, _)) -> if y then ignore x else ()
+  | _ -> ()
+;;
+
+let ambiguous__x_y = function
+  | (`B (x, _, Some y) | `B (x, Some y, _)) when x < y -> ()
+  | _ -> ()
+;;
+
+let ambiguous__x_y_z = function
+  | (`B (x, z, Some y) | `B (x, Some y, z)) when x < y || Some x = z -> ()
+  | _ -> ()
+;;
+
+let not_ambiguous__disjoint_in_depth = function
+  | `A (`B x | `C x) when x -> ()
+  | _ -> ()
+;;
+
+let not_ambiguous__prefix_variables_in_depth = function
+  | `A (`B (x, `C1) | `B (x, `C2)) when x -> ()
+  | _ -> ()
+;;
+
+let ambiguous__in_depth = function
+  | `A (`B (Some x, _) | `B (_, Some x)) when x -> ()
+  | _ -> ()
+;;
+
+let not_ambiguous__several_orpats = function
+  | `A ((`B (x, Some _, _) | `B (x, _, Some _)),
+        (`C (y, Some _, _) | `C (y, _, Some _)),
+        (`D1 (_, z, Some _, _) | `D2 (_, z, _, Some _))) when x < y && x < z -> ()
+  | _ -> ()
+;;
+
+let ambiguous__first_orpat = function
+  | `A ((`B (Some x, _) | `B (_, Some x)),
+        (`C (Some y, Some _, _) | `C (Some y, _, Some _))) when x < y -> ()
+  | _ -> ()
+;;
+
+let ambiguous__second_orpat = function
+  | `A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
+        (`C (Some y, _) | `C (_, Some y))) when x < y -> ()
+  | _ -> ()
+;;
+
+(* check that common prefixes work as expected *)
+let not_ambiguous__pairs = function
+  | (x, Some _, _) | (x, _, Some _) when x -> ()
+  | _ -> ()
+;;
+
+let not_ambiguous__vars =
+  begin[@warning "-12"] function
+  | (x | x) when x -> ()
+  | _ -> ()
+  end
+;;
+
+let not_ambiguous__as p = function
+  | (([], _) as x | ((_, []) as x)) when p x -> ()
+  | _ -> ()
+;;
+
+let not_ambiguous__as_var p = function
+  | (([], _) as x | x) when p x -> ()
+  | _ -> ()
+;;
+
+let not_ambiguous__var_as p = function
+  | (x, Some _, _) | (([], _) as x, _, Some _) when p x -> ()
+  | _ -> ()
+;;
+
+let not_ambiguous__lazy = function
+  | (([], _), lazy x) | ((_, []), lazy x) when x -> ()
+  | _ -> ()
+
+;;
+
+type t = A of int * int option * int option | B;;
+let not_ambiguous__constructor = function
+  | A (x, Some _, _) | A (x, _, Some _) when x > 0 -> ()
+  | A _ | B -> ()
+;;

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
@@ -1,0 +1,187 @@
+
+#                             
+<----------------------------------------------------------------------
+To check the result file for this test, it suffices to look for "val"
+lines corresponding to toplevel answers. If they start with
+
+    val ambiguous_...
+
+then just above there should be the warning text for Warning 57
+(we try to avoid all other warnings). If they start with
+
+   val not_ambiguous_...
+
+then just above there should be *no* warning text.
+---------------------------------------------------------------------->
+
+#     type expr = Val of int | Rest
+#                   Characters 46-71:
+    | ((Val x, _) | (_, Val x)) when x < 0 -> ()
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous guarded or-pattern: the guard variable x
+may match incompatible parts of several or-patterns.
+
+When you write [(p | q) when guard], the pattern is matched,
+and then the guard tested. If the guard fails, the clause is
+not selected. In particular, if a value matches both [p] and [q],
+only [p when guard] is tested.
+
+Unfortunately, many code readers wrongly expect this construction
+to be equivalent to the imaginary [p when guard | q when guard].
+If a value may match both [p] and [q], and [guard] uses
+variables bound in different places on both sides, then
+those two interpretations differ. This ambiguous code is confusing
+and should be avoided.
+val ambiguous_typical_example : expr * expr -> unit = <fun>
+#   Note that an Assert_failure is expected just below.
+#   Exception: Assert_failure ("//toplevel//", 23, 6).
+#           val not_ambiguous__no_orpat : int option -> unit = <fun>
+#         val not_ambiguous__no_guard : [< `A | `B | `C ] -> unit = <fun>
+#         val not_ambiguous__no_patvar_in_guard :
+  bool -> [> `B of 'a | `C of 'a ] -> unit = <fun>
+#         val not_ambiguous__disjoint_cases : [> `B of bool | `C of bool ] -> unit =
+  <fun>
+#   * * *         val not_ambiguous__prefix_variables :
+  [> `B of bool * 'a option * 'a option ] -> unit = <fun>
+#         Characters 33-72:
+    | (`B (x, _, Some y) | `B (x, Some y, _)) when y -> ignore x
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous guarded or-pattern: the guard variable y
+may match incompatible parts of several or-patterns.
+
+When you write [(p | q) when guard], the pattern is matched,
+and then the guard tested. If the guard fails, the clause is
+not selected. In particular, if a value matches both [p] and [q],
+only [p when guard] is tested.
+
+Unfortunately, many code readers wrongly expect this construction
+to be equivalent to the imaginary [p when guard | q when guard].
+If a value may match both [p] and [q], and [guard] uses
+variables bound in different places on both sides, then
+those two interpretations differ. This ambiguous code is confusing
+and should be avoided.
+val ambiguous__y : [> `B of 'a * bool option * bool option ] -> unit = <fun>
+#   * * * * * * * * *         val not_ambiguous__rhs_not_protected :
+  [> `B of 'a * bool option * bool option ] -> unit = <fun>
+#         Characters 35-74:
+    | (`B (x, _, Some y) | `B (x, Some y, _)) when x < y -> ()
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous guarded or-pattern: the guard variable y
+may match incompatible parts of several or-patterns.
+
+When you write [(p | q) when guard], the pattern is matched,
+and then the guard tested. If the guard fails, the clause is
+not selected. In particular, if a value matches both [p] and [q],
+only [p when guard] is tested.
+
+Unfortunately, many code readers wrongly expect this construction
+to be equivalent to the imaginary [p when guard | q when guard].
+If a value may match both [p] and [q], and [guard] uses
+variables bound in different places on both sides, then
+those two interpretations differ. This ambiguous code is confusing
+and should be avoided.
+val ambiguous__x_y : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
+#         Characters 37-76:
+    | (`B (x, z, Some y) | `B (x, Some y, z)) when x < y || Some x = z -> ()
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous guarded or-pattern: the guard variables y and z
+may match incompatible parts of several or-patterns.
+
+When you write [(p | q) when guard], the pattern is matched,
+and then the guard tested. If the guard fails, the clause is
+not selected. In particular, if a value matches both [p] and [q],
+only [p when guard] is tested.
+
+Unfortunately, many code readers wrongly expect this construction
+to be equivalent to the imaginary [p when guard | q when guard].
+If a value may match both [p] and [q], and [guard] uses
+variables bound in different places on both sides, then
+those two interpretations differ. This ambiguous code is confusing
+and should be avoided.
+val ambiguous__x_y_z : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
+#         val not_ambiguous__disjoint_in_depth :
+  [> `A of [> `B of bool | `C of bool ] ] -> unit = <fun>
+#         val not_ambiguous__prefix_variables_in_depth :
+  [> `A of [> `B of bool * [> `C1 | `C2 ] ] ] -> unit = <fun>
+#         Characters 43-76:
+    | `A (`B (Some x, _) | `B (_, Some x)) when x -> ()
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous guarded or-pattern: the guard variable x
+may match incompatible parts of several or-patterns.
+
+When you write [(p | q) when guard], the pattern is matched,
+and then the guard tested. If the guard fails, the clause is
+not selected. In particular, if a value matches both [p] and [q],
+only [p when guard] is tested.
+
+Unfortunately, many code readers wrongly expect this construction
+to be equivalent to the imaginary [p when guard | q when guard].
+If a value may match both [p] and [q], and [guard] uses
+variables bound in different places on both sides, then
+those two interpretations differ. This ambiguous code is confusing
+and should be avoided.
+val ambiguous__in_depth :
+  [> `A of [> `B of bool option * bool option ] ] -> unit = <fun>
+#             val not_ambiguous__several_orpats :
+  [> `A of
+       [> `B of 'a * 'b option * 'c option ] *
+       [> `C of 'a * 'd option * 'e option ] *
+       [> `D1 of 'f * 'a * 'g option * 'h | `D2 of 'i * 'a * 'j * 'k option ] ] ->
+  unit = <fun>
+#           Characters 47-80:
+    | `A ((`B (Some x, _) | `B (_, Some x)),
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous guarded or-pattern: the guard variable x
+may match incompatible parts of several or-patterns.
+
+When you write [(p | q) when guard], the pattern is matched,
+and then the guard tested. If the guard fails, the clause is
+not selected. In particular, if a value matches both [p] and [q],
+only [p when guard] is tested.
+
+Unfortunately, many code readers wrongly expect this construction
+to be equivalent to the imaginary [p when guard | q when guard].
+If a value may match both [p] and [q], and [guard] uses
+variables bound in different places on both sides, then
+those two interpretations differ. This ambiguous code is confusing
+and should be avoided.
+val ambiguous__first_orpat :
+  [> `A of
+       [> `B of 'a option * 'a option ] *
+       [> `C of 'a option * 'b option * 'c option ] ] ->
+  unit = <fun>
+#           Characters 107-140:
+          (`C (Some y, _) | `C (_, Some y))) when x < y -> ()
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous guarded or-pattern: the guard variable y
+may match incompatible parts of several or-patterns.
+
+When you write [(p | q) when guard], the pattern is matched,
+and then the guard tested. If the guard fails, the clause is
+not selected. In particular, if a value matches both [p] and [q],
+only [p when guard] is tested.
+
+Unfortunately, many code readers wrongly expect this construction
+to be equivalent to the imaginary [p when guard | q when guard].
+If a value may match both [p] and [q], and [guard] uses
+variables bound in different places on both sides, then
+those two interpretations differ. This ambiguous code is confusing
+and should be avoided.
+val ambiguous__second_orpat :
+  [> `A of
+       [> `B of 'a option * 'b option * 'c option ] *
+       [> `C of 'a option * 'a option ] ] ->
+  unit = <fun>
+#           val not_ambiguous__pairs : bool * 'a option * 'b option -> unit = <fun>
+#             val not_ambiguous__vars : bool -> unit = <fun>
+#         val not_ambiguous__as :
+  ('a list * 'b list -> bool) -> 'a list * 'b list -> unit = <fun>
+#         val not_ambiguous__as_var : ('a list * 'b -> bool) -> 'a list * 'b -> unit =
+  <fun>
+#         val not_ambiguous__var_as :
+  ('a list * 'b -> bool) -> ('a list * 'b) * 'c option * 'd option -> unit =
+  <fun>
+#           val not_ambiguous__lazy : ('a list * 'b list) * bool lazy_t -> unit = <fun>
+#   type t = A of int * int option * int option | B
+#       val not_ambiguous__constructor : t -> unit = <fun>
+# 

--- a/tools/Makefile.shared
+++ b/tools/Makefile.shared
@@ -73,11 +73,12 @@ ocamlprof: $(CSLPROF) profiling.cmo
 	$(CAMLC) $(LINKFLAGS) -o ocamlprof $(CSLPROF_IMPORTS) $(CSLPROF)
 
 ocamlcp: ocamlcp.cmo
-	$(CAMLC) $(LINKFLAGS) -o ocamlcp warnings.cmo main_args.cmo ocamlcp.cmo
+	$(CAMLC) $(LINKFLAGS) -o ocamlcp \
+	  misc.cmo warnings.cmo main_args.cmo ocamlcp.cmo
 
 ocamloptp: ocamloptp.cmo
-	$(CAMLC) $(LINKFLAGS) -o ocamloptp warnings.cmo main_args.cmo \
-	         ocamloptp.cmo
+	$(CAMLC) $(LINKFLAGS) -o ocamloptp \
+	  misc.cmo warnings.cmo main_args.cmo ocamloptp.cmo
 
 opt:: profiling.cmx
 

--- a/typing/ident.ml
+++ b/typing/ident.ml
@@ -52,6 +52,8 @@ let same i1 i2 = i1 = i2
        then i1.stamp = i2.stamp
        else i2.stamp = 0 && i1.name = i2.name *)
 
+let compare i1 i2 = Pervasives.compare i1 i2
+
 let binding_time i = i.stamp
 
 let current_time() = !currentstamp

--- a/typing/ident.mli
+++ b/typing/ident.mli
@@ -36,6 +36,9 @@ val hide: t -> t
            When put in a 'a tbl, this identifier can only be looked
            up by name. *)
 
+val compare : t -> t -> int
+(* Compare identifiers by binding location *)
+
 val make_global: t -> unit
 val global: t -> bool
 val is_predef_exn: t -> bool

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -298,7 +298,7 @@ module P = struct
 end
 module PathSet = Set.Make (P)
 module PathMap = Map.Make (P)
-module IdentSet = Set.Make (struct type t = Ident.t let compare = compare end)
+module IdentSet = Set.Make (Ident)
 
 let rec get_prefixes = function
     Pident _ -> PathSet.empty

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -38,6 +38,8 @@ exception Empty
 val lub : pattern -> pattern -> pattern
 val lubs : pattern list -> pattern list -> pattern list
 
+val check_ambiguous_guarded_disjunction : pattern -> expression -> unit
+
 val get_mins : ('a -> 'a -> bool) -> 'a list -> 'a list
 
 (* Those two functions recombine one pattern and its arguments:

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -48,6 +48,14 @@ let rec head = function
   | Pdot(p, s, pos) -> head p
   | Papply(p1, p2) -> assert false
 
+let heads p =
+  let rec heads p acc = match p with
+    | Pident id -> id :: acc
+    | Pdot (p, _s, _pos) -> heads p acc
+    | Papply(p1, p2) ->
+        heads p1 (heads p2 acc)
+  in heads p []
+
 let rec last = function
   | Pident id -> Ident.name id
   | Pdot(_, s, _) -> s

--- a/typing/path.mli
+++ b/typing/path.mli
@@ -27,6 +27,8 @@ val name: ?paren:(string -> bool) -> t -> string
     (* [paren] tells whether a path suffix needs parentheses *)
 val head: t -> Ident.t
 
+val heads: t -> Ident.t list
+
 val last: t -> string
 
 type typath =

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1397,7 +1397,9 @@ let explanation unif t3 t4 ppf =
         fprintf ppf "@,@[<hov>This instance of %a is ambiguous:@ %s@]"
           type_expr t'
           "it would escape the scope of its equation"
-  | Tfield (lab, _, _, _), _
+  | Tfield (lab, _, _, _), _ when lab = dummy_method ->
+      fprintf ppf
+        "@,Self type cannot be unified with a closed object type"
   | _, Tfield (lab, _, _, _) when lab = dummy_method ->
       fprintf ppf
         "@,Self type cannot be unified with a closed object type"

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -250,7 +250,6 @@ let all_idents_cases el =
     el;
   Hashtbl.fold (fun x () rest -> x :: rest) idents []
 
-
 (* Typing of constants *)
 
 let type_constant = function
@@ -3729,13 +3728,15 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
           else ty_res in
 (*        Format.printf "@[%i %i, ty_res' =@ %a@]@." lev (get_current_level())
           Printtyp.raw_type_expr ty_res'; *)
-        let guard =
-          match pc_guard with
-          | None -> None
-          | Some scond ->
-              Some
-                (type_expect ext_env (wrap_unpacks scond unpacks)
-                   Predef.type_bool)
+         let guard =
+           match pc_guard with
+           | None -> None
+           | Some scond ->
+               let scond = wrap_unpacks scond unpacks in
+               let guard = type_expect ext_env scond Predef.type_bool in
+               Parmatch.check_ambiguous_guarded_disjunction
+                 pat guard;
+               Some guard
         in
         let exp = type_expect ?in_function ext_env sexp ty_res' in
         {

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -308,14 +308,16 @@ let extract_label_names sexp env ty =
 let explicit_arity =
   List.exists
     (function
-      | ({txt="ocaml.explicit_arity"|"explicit_arity"; _}, _) -> true
+      | ({txt="ocaml.explicit_arity"
+                   |"explicit_arity"; _}, _) -> true
       | _ -> false
     )
 
 let warn_on_literal_pattern =
   List.exists
     (function
-      | ({txt="ocaml.warn_on_literal_pattern"|"warn_on_literal_pattern"; _}, _) -> true
+      | ({txt="ocaml.warn_on_literal_pattern"
+                   |"warn_on_literal_pattern"; _}, _) -> true
       | _ -> false
     )
 
@@ -1123,9 +1125,10 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
             replicate_list sp constr.cstr_arity
         | Some sp -> [sp] in
       begin match sargs with
-      | [{ppat_desc = Ppat_constant _} as sp] when warn_on_literal_pattern constr.cstr_attributes ->
-            Location.prerr_warning sp.ppat_loc
-              Warnings.Fragile_literal_pattern
+      | [{ppat_desc = Ppat_constant _} as sp] when
+          warn_on_literal_pattern constr.cstr_attributes
+        -> Location.prerr_warning sp.ppat_loc
+             Warnings.Fragile_literal_pattern
       | _ -> ()
       end;
       if List.length sargs <> constr.cstr_arity then
@@ -2842,8 +2845,9 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
                       exp.exp_extra;
       }
 
-  | Pexp_extension ({ txt = ("ocaml.extension_constructor"|"extension_constructor"); _ },
-                    payload) ->
+  | Pexp_extension
+      ({ txt = ("ocaml.extension_constructor"|"extension_constructor"); _ },
+       payload) ->
       begin match payload with
       | PStr [ { pstr_desc =
                    Pstr_eval ({ pexp_desc = Pexp_construct (lid, None); _ }, _)

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -69,6 +69,7 @@ type t =
   | Duplicated_attribute of string          (* 54 *)
   | Inlining_impossible of string           (* 55 *)
   | Unreachable_case                        (* 56 *)
+  | Ambiguous_guarded_disjunction of string list (* 57 *)
 ;;
 
 val parse_options : bool -> string -> unit;;


### PR DESCRIPTION
[PR#7031: Warn on ambiguous variables used in a when clause](http://caml.inria.fr/mantis/view.php?id=7031)

Faulty code:

``` ocaml
      let unify my_var unif_var = function
      | ( (Var x, t) | (t, Var x) ) when x = my_var -> unif_var x t
      | _, _ -> ();;
```

Warning text:

> ```
> Characters 39-66:
>   | ( (Var x, t) | (t, Var x) ) when x = my_var -> unif_var x t
>     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 
> Warning 57: Ambiguous guarded or-pattern: the guard variable x
> may match incompatible parts of several or-patterns.
> 
> When you write [(p | q) when guard], the pattern is matched,
> and then the guard tested. If the guard fails, the clause is
> not selected. In particular, if a value matches both [p] and [q],
> only [p when guard] is tested.
> 
> Unfortunately, many code readers wrongly expect this construction
> to be equivalent to the imaginary [p when guard | q when guard].
> If a value may match both [p] and [q], and [guard] uses
> variables bound in different places on both sides, then
> those two interpretations differ. This ambiguous code is confusing
> and should be avoided.
> ```
