### PR TITLE
Manual: fix uses of deprecated functions

### DIFF
--- a/manual/manual/tutorials/advexamples.etex
+++ b/manual/manual/tutorials/advexamples.etex
@@ -315,12 +315,12 @@ class ostring s =
   object
      method get n = String.get s n
      method print = print_string s
-     method copy = new ostring s
+     method escaped = new ostring (String.escaped s)
   end;;
 \end{caml_example}
-However, the method "copy" returns an object of the class "ostring",
+However, the method "escaped" returns an object of the class "ostring",
 and not an object of the current class. Hence, if the class is further
-extended, the method "copy" will only return an object of the parent
+extended, the method "escaped" will only return an object of the parent
 class.
 \begin{caml_example}
 class sub_string s =
@@ -338,11 +338,11 @@ class better_string s =
      val repr = s
      method get n = String.get repr n
      method print = print_string repr
-     method copy = {< repr = repr >}
-     method sub start len = {< repr = String.sub s  start len >}
+     method escaped = {< repr = String.escaped repr >}
+     method sub start len = {< repr = String.sub s start len >}
   end;;
 \end{caml_example}
-As shown in the inferred type, the methods "copy" and "sub" now return
+As shown in the inferred type, the methods "escaped" and "sub" now return
 objects of the same type as the one of the class.
 
 Another difficulty is the implementation of the method "concat".
@@ -357,7 +357,7 @@ class ostring s =
      method repr = repr
      method get n = String.get repr n
      method print = print_string repr
-     method copy = {< repr = repr >}
+     method escaped = {< repr = String.escaped repr >}
      method sub start len = {< repr = String.sub s start len >}
      method concat (t : 'mytype) = {< repr = repr ^ t#repr >}
   end;;

--- a/manual/manual/tutorials/advexamples.etex
+++ b/manual/manual/tutorials/advexamples.etex
@@ -315,7 +315,7 @@ class ostring s =
   object
      method get n = String.get s n
      method print = print_string s
-     method copy = new ostring (String.copy s)
+     method copy = new ostring s
   end;;
 \end{caml_example}
 However, the method "copy" returns an object of the class "ostring",
@@ -338,7 +338,7 @@ class better_string s =
      val repr = s
      method get n = String.get repr n
      method print = print_string repr
-     method copy = {< repr = String.copy repr >}
+     method copy = {< repr = repr >}
      method sub start len = {< repr = String.sub s  start len >}
   end;;
 \end{caml_example}
@@ -357,7 +357,7 @@ class ostring s =
      method repr = repr
      method get n = String.get repr n
      method print = print_string repr
-     method copy = {< repr = String.copy repr >}
+     method copy = {< repr = repr >}
      method sub start len = {< repr = String.sub s start len >}
      method concat (t : 'mytype) = {< repr = repr ^ t#repr >}
   end;;

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -243,13 +243,13 @@ Though all examples so far were written in purely applicative style,
 OCaml is also equipped with full imperative features. This includes the
 usual "while" and "for" loops, as well as mutable data structures such
 as arrays. Arrays are either given in extension between "[|" and "|]"
-brackets, or allocated and initialized with the "Array.create"
+brackets, or allocated and initialized with the "Array.make"
 function, then filled up later by assignments. For instance, the
 function below sums two vectors (represented as float arrays) componentwise.
 \begin{caml_example}
 let add_vect v1 v2 =
   let len = min (Array.length v1) (Array.length v2) in
-  let res = Array.create len 0.0 in
+  let res = Array.make len 0.0 in
   for i = 0 to len - 1 do
     res.(i) <- v1.(i) +. v2.(i)
   done;

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -61,13 +61,13 @@ usual basic data types: booleans, characters, and immutable character strings.
 "Hello world";;
 \end{caml_example}
 
-Predefined data structures include tuples, arrays, specialized byte
-arrays and lists. General mechanisms for defining your own data
-structures are also provided. They will be covered in more details
-later; for now, we concentrate on lists. Lists are either given in
-extension as a bracketed list of semicolon-separated elements, or built
-from the empty list "[]" (pronounce ``nil'') by adding elements in front
-using the "::" (``cons'') operator.
+Predefined data structures include tuples, arrays, and lists. General
+mechanisms for defining your own data structures are also provided.
+They will be covered in more details later; for now, we concentrate on lists.
+Lists are either given in extension as a bracketed list of
+semicolon-separated elements, or built from the empty list "[]"
+(pronounce ``nil'') by adding elements in front using the "::"
+(``cons'') operator.
 \begin{caml_example}
 let l = ["is"; "a"; "tale"; "told"; "etc."];;
 "Life" :: l;;

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -54,20 +54,20 @@ fib 10;;
 \pdfsection{Data types}
 
 In addition to integers and floating-point numbers, OCaml offers the
-usual basic data types: booleans, characters, and character strings.
+usual basic data types: booleans, characters, and immutable character strings.
 \begin{caml_example}
 (1 < 2) = false;;
 'a';;
 "Hello world";;
 \end{caml_example}
 
-Predefined data structures include tuples, arrays, and lists. General
-mechanisms for defining your own data structures are also provided.
-They will be covered in more details later; for now, we concentrate on lists.
-Lists are either given in extension as a bracketed list of
-semicolon-separated elements, or built from the empty list "[]"
-(pronounce ``nil'') by adding elements in front using the "::"
-(``cons'') operator.
+Predefined data structures include tuples, arrays, specialized byte
+arrays and lists. General mechanisms for defining your own data
+structures are also provided. They will be covered in more details
+later; for now, we concentrate on lists. Lists are either given in
+extension as a bracketed list of semicolon-separated elements, or built
+from the empty list "[]" (pronounce ``nil'') by adding elements in front
+using the "::" (``cons'') operator.
 \begin{caml_example}
 let l = ["is"; "a"; "tale"; "told"; "etc."];;
 "Life" :: l;;


### PR DESCRIPTION
This patch fixes the use of deprecated functions within the examples of the manual. There was two problematic subsections: one in the core language chapter ( see the first example [here](http://caml.inria.fr/pub/docs/manual-ocaml/coreexamples.html#sec12) ) due to `Array.create` and the other in the advanced examples chapter ( see the first example [here](http://caml.inria.fr/pub/docs/manual-ocaml/advexamples.html#sec52)) due to the recent separation between `bytes` and `string` .

I think it might be worthwhile to try to have a much clearer separation between `string` and `bytes` in the manual in the future. As a small step in this direction, I have added a very brief mention of the existence of `bytes` in the core language chapter and an immutable qualifier to the description of `strings`. 
