### PR TITLE
Fix PR#6745 by forcing alias export if already in scope

### DIFF
--- a/Changes
+++ b/Changes
@@ -273,6 +273,8 @@ Bug fixes:
   (Damien Doligez)
 - PR#6672: Unused variance specification allowed in with constraint
 - PR#6744: Univars can escape through polymorphic variants (partial fix)
+* PR#6745: `as` ignored on types containing universal variables
+    (a type error occurs instead of being ignored)
 - PR#6776: Failure to kill the "tick" thread, segfault when exiting the runtime
 - PR#6752: Extensible variant types and scope escaping
 - PR#6808: the parsing of OCAMLRUNPARAM is too lax

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -687,3 +687,8 @@ let (n : 'b -> < m : 'a . ([< `Foo of int] as 'b) -> 'a >) = fun x ->
 let f b (x: 'x) =
   let module M = struct type t = A end in
   if b then x else M.A;;
+
+
+(* PR#6745 *)
+type 'a r = { x: 'b. 'b list as 'a };; (* Should fail? *)
+type 'a r = { x: 'b. int list as 'a };; (* ok *)

--- a/testsuite/tests/typing-poly/poly.ml.principal.reference
+++ b/testsuite/tests/typing-poly/poly.ml.principal.reference
@@ -672,4 +672,10 @@ Error: This method has type ([< `Foo of 'b ] as 'a) -> 'b
                      ^^^
 Error: This expression has type M.t but an expression was expected of type 'x
        The type constructor M.t would escape its scope
+#       Characters 37-50:
+  type 'a r = { x: 'b. 'b list as 'a };; (* Should fail? *)
+                       ^^^^^^^^^^^^^
+Error: This type 'b list should be an instance of type 'a
+       The universal variable 'b would escape its scope
+# type 'a r = { x : int list; } constraint 'a = int list
 # 

--- a/testsuite/tests/typing-poly/poly.ml.reference
+++ b/testsuite/tests/typing-poly/poly.ml.reference
@@ -626,4 +626,10 @@ Error: This expression has type < m : 'x. [< `Foo of 'x ] -> 'x >
                      ^^^
 Error: This expression has type M.t but an expression was expected of type 'x
        The type constructor M.t would escape its scope
+#       Characters 37-50:
+  type 'a r = { x: 'b. 'b list as 'a };; (* Should fail? *)
+                       ^^^^^^^^^^^^^
+Error: This type 'b list should be an instance of type 'a
+       The universal variable 'b would escape its scope
+# type 'a r = { x : 'a; } constraint 'a = int list
 # 


### PR DESCRIPTION
This is GPR for fixing [PR#6745](http://caml.inria.fr/mantis/view.php?id=6745).
The test suite theory goes through, but in theory it could break some code relying on the weird behavior of nor exporting an alias if it contains universal variables.
Note that we only force the exports of variables whose name is already in the outer scope.

A drawback of the current version of this patch is that it is not symmetrical: if you have a first alias that is exported, then the next one will have to be exported too, possibly causing an error, whereas in the opposite order only the second one would be exported. I suppose this is the reason for the current weird behavior.
