### PR TITLE
Make `boot/ocamlc` read directly `byterun/primitives`

### DIFF
--- a/Changes
+++ b/Changes
@@ -132,6 +132,9 @@ Runtime system:
   compiling the run-time system and C stub code.  (Xavier Leroy)
 - GPR#262: Multiple GC roots per compilation unit (Pierre Chambart, Mark
   Shinwell, review by Damien Doligez)
+- GPR#324: Compiler developpers only: Adding new primitives to the
+  standard runtime doesn't require anymore to run `make bootstrap`
+  (François Bobot)
 
 Standard library:
 - PR#5197, GPR#63: Arg: allow flags such as --flag=arg as well as --flag arg

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ coldstart:
 	cp byterun/ocamlrun$(EXE) boot/ocamlrun$(EXE)
 	cd yacc; $(MAKE) all
 	cp yacc/ocamlyacc$(EXE) boot/ocamlyacc$(EXE)
-	cd stdlib; $(MAKE) COMPILER=../boot/ocamlc all
+	cd stdlib; $(MAKE) COMPILER="../boot/ocamlc -use-prims ../byterun/primitives" all
 	cd stdlib; cp $(LIBFILES) ../boot
 	if test -f boot/libcamlrun.a; then :; else \
 	  ln -s ../byterun/libcamlrun.a boot/libcamlrun.a; fi

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -64,7 +64,7 @@ coldstart:
 	cp byterun/ocamlrun.exe boot/ocamlrun.exe
 	cd yacc ; $(MAKEREC) all
 	cp yacc/ocamlyacc.exe boot/ocamlyacc.exe
-	cd stdlib ; $(MAKEREC) COMPILER=../boot/ocamlc all
+	cd stdlib ; $(MAKEREC) COMPILER="../boot/ocamlc -use-prims ../byterun/primitives" all
 	cd stdlib ; cp $(LIBFILES) ../boot
 
 # Build the core system: the minimum needed to make depend and bootstrap

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -17,7 +17,7 @@ CAMLRUN ?= boot/ocamlrun
 CAMLYACC ?= boot/ocamlyacc
 include stdlib/StdlibModules
 
-CAMLC=$(CAMLRUN) boot/ocamlc -g -nostdlib -I boot
+CAMLC=$(CAMLRUN) boot/ocamlc -g -nostdlib -I boot -use-prims byterun/primitives
 CAMLOPT=$(CAMLRUN) ./ocamlopt -g -nostdlib -I stdlib -I otherlibs/dynlink
 COMPFLAGS=-strict-sequence -w +33..39+48+50 -warn-error A -bin-annot \
           -safe-string $(INCLUDES)

--- a/byterun/Makefile.common
+++ b/byterun/Makefile.common
@@ -39,7 +39,7 @@ PUBLIC_INCLUDES=\
   version.h
 
 
-all:: ocamlrun$(EXE) ld.conf libcamlrun.$(A) all-$(RUNTIMED)
+all:: ocamlrun$(EXE) ld.conf libcamlrun.$(A) all-$(RUNTIMED) primitives
 .PHONY: all
 
 all-noruntimed:

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -15,7 +15,7 @@ include ../config/Makefile
 CAMLRUN ?= ../boot/ocamlrun
 CAMLYACC ?= ../boot/ocamlyacc
 
-CAMLC=$(CAMLRUN) ../boot/ocamlc -strict-sequence -nostdlib -I ../boot
+CAMLC=$(CAMLRUN) ../boot/ocamlc -strict-sequence -nostdlib -I ../boot -use-prims ../byterun/primitives
 CAMLOPT=$(CAMLRUN) ../ocamlopt -nostdlib -I ../stdlib
 COMPFLAGS=-w +33..39 -warn-error A -bin-annot -safe-string
 LINKFLAGS=

--- a/lex/Makefile.nt
+++ b/lex/Makefile.nt
@@ -16,7 +16,7 @@ include ../config/Makefile
 CAMLRUN ?= ../boot/ocamlrun
 CAMLYACC ?= ../boot/ocamlyacc
 
-CAMLC=$(CAMLRUN) ../boot/ocamlc -I ../boot
+CAMLC=$(CAMLRUN) ../boot/ocamlc -I ../boot -use-prims ../byterun/primitives
 CAMLOPT=$(CAMLRUN) ../ocamlopt -I ../stdlib
 COMPFLAGS=-warn-error A
 LINKFLAGS=

--- a/stdlib/Makefile.shared
+++ b/stdlib/Makefile.shared
@@ -88,8 +88,9 @@ clean::
 	$(CAMLOPT) $(COMPFLAGS) `./Compflags $@` -p -c -o $*.p.cmx $<
 
 # Dependencies on the compiler
-$(OBJS) std_exit.cmo: $(COMPILER)
-$(OBJS:.cmo=.cmi) std_exit.cmi: $(COMPILER)
+COMPILER_DEPS=$(filter-out -use-prims, $(COMPILER))
+$(OBJS) std_exit.cmo: $(COMPILER_DEPS)
+$(OBJS:.cmo=.cmi) std_exit.cmi: $(COMPILER_DEPS)
 $(OBJS:.cmo=.cmx) std_exit.cmx: $(OPTCOMPILER)
 $(OBJS:.cmo=.p.cmx) std_exit.p.cmx: $(OPTCOMPILER)
 

--- a/tools/Makefile.shared
+++ b/tools/Makefile.shared
@@ -14,7 +14,7 @@ include ../config/Makefile
 CAMLRUN ?= ../boot/ocamlrun
 CAMLYACC ?= ../boot/ocamlyacc
 
-CAMLC=$(CAMLRUN) ../boot/ocamlc -nostdlib -I ../boot
+CAMLC=$(CAMLRUN) ../boot/ocamlc -nostdlib -I ../boot -use-prims ../byterun/primitives
 CAMLOPT=$(CAMLRUN) ../ocamlopt -nostdlib -I ../stdlib
 CAMLLEX=$(CAMLRUN) ../boot/ocamllex
 INCLUDES=-I ../utils -I ../parsing -I ../typing -I ../bytecomp -I ../asmcomp \


### PR DESCRIPTION
`boot/*` are often responsible for merge conflict in github or rebase conflict during development, because they are binaries. People needs to modifies `boot/ocamlc` each time the set of primitives in the default runtime is modified.

This merge request proposes to use for `boot/ocamlc` the option `-use-prims byterun/primitives`. It allows to add new primitive and use it in the standard library without bootstrapping. Compilation with `./ocamlc`,`./ocamlopt` are not modified.

For example you can compile with the following patch without the errors:

```
File "_none_", line 1:
Error: Error while linking boot/stdlib.cma(Weak):
The external function `caml_test_add_prim' is not available
```

``` diff
diff --git a/byterun/weak.c b/byterun/weak.c
index 3614d11..29e1845 100644
--- a/byterun/weak.c
+++ b/byterun/weak.c
@@ -190,3 +190,8 @@ CAMLprim value caml_weak_blit (value ars, value ofs,
   }
   return Val_unit;
 }
+
+CAMLprim value caml_test_add_prim (value ar, value n)
+{
+  return ar;
+}
diff --git a/stdlib/weak.ml b/stdlib/weak.ml
index 71385c9..5dc37b4 100644
--- a/stdlib/weak.ml
+++ b/stdlib/weak.ml
@@ -303,3 +303,7 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
   ;;

 end;;
+
+external test_add_prim: int -> int -> int = "caml_test_add_prim"
+
+let _ = test_add_prim 1 2
```

I think that work also for removing some primitives but I don't know which exactly.

This could wait after 4.03 since it only simplifies compiler development.
