### PR TITLE
Change v=0x400 in OCAMLRUNPARAM to print more Gc stats on exit

### DIFF
--- a/Changes
+++ b/Changes
@@ -139,6 +139,8 @@ Runtime system:
   compiling the run-time system and C stub code.  (Xavier Leroy)
 - GPR#262: Multiple GC roots per compilation unit (Pierre Chambart, Mark
   Shinwell, review by Damien Doligez)
+- GPR#325: Add v=0x400 flag to OCAMLRUNPARAM to display GC stats on exit (Louis
+  Gesbert, review by Alain Frisch)
 
 Standard library:
 - PR#5197, GPR#63: Arg: allow flags such as --flag=arg as well as --flag arg

--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -113,10 +113,23 @@ CAMLprim value caml_sys_exit(value retcode)
       + (double) (caml_young_end - caml_young_ptr);
     double prowords = caml_stat_promoted_words;
     double majwords = caml_stat_major_words + (double) caml_allocated_words;
-    double allocated_words =
-      minwords + majwords - prowords;
-    caml_gc_message(0x400, "## Total allocated words: %ld\n",
-                    (long)allocated_words);
+    double allocated_words = minwords + majwords - prowords;
+    intnat mincoll = caml_stat_minor_collections;
+    intnat majcoll = caml_stat_major_collections;
+    intnat heap_words = caml_stat_heap_wsz;
+    intnat heap_chunks = caml_stat_heap_chunks;
+    intnat top_heap_words = caml_stat_top_heap_wsz;
+    intnat cpct = caml_stat_compactions;
+    caml_gc_message(0x400, "allocated_words: %ld\n", (long)allocated_words);
+    caml_gc_message(0x400, "minor_words: %ld\n", (long) minwords);
+    caml_gc_message(0x400, "promoted_words: %ld\n", (long) prowords);
+    caml_gc_message(0x400, "major_words: %ld\n", (long) majwords);
+    caml_gc_message(0x400, "minor_collections: %d\n", mincoll);
+    caml_gc_message(0x400, "major_collections: %d\n", majcoll);
+    caml_gc_message(0x400, "heap_words: %d\n", heap_words);
+    caml_gc_message(0x400, "heap_chunks: %d\n", heap_chunks);
+    caml_gc_message(0x400, "top_heap_words: %d\n", top_heap_words);
+    caml_gc_message(0x400, "compactions: %d\n", cpct);
   }
 
 #ifndef NATIVE_CODE

--- a/man/ocamlrun.m
+++ b/man/ocamlrun.m
@@ -200,6 +200,9 @@ shared libraries).
 .BR 0x200
 Computation of compaction-triggering condition.
 
+.BR 0x400
+Output GC statistics at program exit, in the same format as Gc.print_stat.
+
 The multiplier is
 .BR k ,
 .BR M ,\ or

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -115,6 +115,7 @@ type control =
        - [0x080] Calling of finalisation functions.
        - [0x100] Bytecode executable and shared library search at start-up.
        - [0x200] Computation of compaction-triggering condition.
+       - [0x400] Output GC statistics at program exit.
        Default: 0. *)
 
     mutable max_overhead : int;


### PR DESCRIPTION
In a format following that of Gc.print_stat. I chose to print only the "quick_stat"
values rather than call gc_ctrl.c::heap_stats because it's lighter, and the extra
information is typically not very useful at program exit.

Also adds documentation for the 0x400 and 0x800 flags
