### PR TITLE
Add signature payloads for extension and attributes.

### DIFF
--- a/Changes
+++ b/Changes
@@ -58,6 +58,9 @@ Language features:
 - PR#6422, GPR#305: Support "exception" under or-patterns
   (Thomas Refis, with help and review from Alain Frisch, Luc Maranget, Gabriel
   Scherer, Leo White and Jeremy Yallop)
+- PR#6681 GPR#326: signature items are now accepted as payloads for
+  extension and attributes, using the syntax [%foo: SIG ] or [@foo: SIG ].
+  (Alain Frisch and Gabriel Radanne)
 
 Compilers:
 - PR#4800: better compilation of tuple assignment (Gabriel Scherer and

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1303,8 +1303,9 @@ The last two entries are valid for any $n > 3$.
 Attributes are ``decorations'' of the syntax tree which are mostly
 ignored by the type-checker but can be used by external tools.  An
 attribute is made of an identifier and a payload, which can be a
-structure, a type expression (prefixed with ":") or a pattern
-(prefixed with "?") optionally followed by a "when" clause:
+structure, a type expression (prefixed with ":"), a signature
+(prefixed with ":") or a pattern (prefixed with "?") optionally
+followed by a "when" clause:
 
 
 \begin{syntax}
@@ -1316,6 +1317,7 @@ attr-id:
 attr-payload:
     [ module-items ]
  |  ':' typexpr
+ |  ':' [ specification ]
  |  '?' pattern ['when' expr]
 ;
 \end{syntax}

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -618,6 +618,7 @@ let default_mapper =
     payload =
       (fun this -> function
          | PStr x -> PStr (this.structure this x)
+         | PSig x -> PSig (this.signature this x)
          | PTyp x -> PTyp (this.typ this x)
          | PPat (x, g) -> PPat (this.pat this x, map_opt (this.expr this) g)
       );

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -2400,6 +2400,7 @@ item_extension:
 ;
 payload:
     structure { PStr $1 }
+  | COLON signature { PSig $2 }
   | COLON core_type { PTyp $2 }
   | QUESTION pattern { PPat ($2, None) }
   | QUESTION pattern WHEN seq_expr { PPat ($2, Some $4) }

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -41,6 +41,7 @@ and attributes = attribute list
 
 and payload =
   | PStr of structure
+  | PSig of signature (* : SIG *)
   | PTyp of core_type  (* : T *)
   | PPat of pattern * expression option  (* ? P  or  ? P when E *)
 

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1019,6 +1019,7 @@ class printer  ()= object(self:'self)
           self#item_attributes attrs
     | PStr x -> self#structure f x
     | PTyp x -> pp f ":"; self#core_type f x
+    | PSig x -> pp f ":"; self#signature f x
     | PPat (x, None) -> pp f "?"; self#pattern f x
     | PPat (x, Some e) ->
       pp f "?"; self#pattern f x;

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -402,6 +402,7 @@ and attributes i ppf l =
 
 and payload i ppf = function
   | PStr x -> structure i ppf x
+  | PSig x -> signature i ppf x
   | PTyp x -> core_type i ppf x
   | PPat (x, None) -> pattern i ppf x
   | PPat (x, Some g) ->

--- a/testsuite/tests/parsing/attributes.ml
+++ b/testsuite/tests/parsing/attributes.ml
@@ -1,0 +1,34 @@
+[@@@foo]
+
+let (x[@foo]) : unit [@foo] = ()[@foo]
+  [@@foo]
+
+type t =
+  | Foo of (t[@foo]) [@foo]
+[@@foo]
+
+[@@@foo]
+
+
+module M = struct
+  type t = {
+    l : (t [@foo]) [@foo]
+  }
+    [@@foo]
+    [@@foo]
+
+  [@@@foo]
+end[@foo]
+[@@foo]
+
+module type S = sig
+
+  include (module type of (M[@foo]))[@foo] with type t := M.t[@foo]
+    [@@foo]
+
+  [@@@foo]
+
+end[@foo]
+[@@foo]
+
+[@@@foo]

--- a/testsuite/tests/parsing/attributes.ml.reference
+++ b/testsuite/tests/parsing/attributes.ml.reference
@@ -1,0 +1,153 @@
+[
+  structure_item (attributes.ml[1,0+0]..[1,0+8])
+    Pstr_attribute "foo"
+    []
+  structure_item (attributes.ml[3,10+0]..[4,49+9])
+    Pstr_value Nonrec
+    [
+      <def>
+          attribute "foo"
+            []
+        pattern (attributes.ml[3,10+4]..[3,10+38]) ghost
+          Ppat_constraint
+          pattern (attributes.ml[3,10+4]..[3,10+13])
+            attribute "foo"
+              []
+            Ppat_var "x" (attributes.ml[3,10+5]..[3,10+6])
+          core_type (attributes.ml[3,10+16]..[3,10+20])
+            attribute "foo"
+              []
+            Ptyp_constr "unit" (attributes.ml[3,10+16]..[3,10+20])
+            []
+        expression (attributes.ml[3,10+30]..[3,10+32])
+          attribute "foo"
+            []
+          Pexp_construct "()" (attributes.ml[3,10+30]..[3,10+32])
+          None
+    ]
+  structure_item (attributes.ml[6,60+0]..[8,97+7])
+    Pstr_type Rec
+    [
+      type_declaration "t" (attributes.ml[6,60+5]..[6,60+6]) (attributes.ml[6,60+0]..[8,97+7])
+        attribute "foo"
+          []
+        ptype_params =
+          []
+        ptype_cstrs =
+          []
+        ptype_kind =
+          Ptype_variant
+            [
+              (attributes.ml[7,69+2]..[7,69+27])
+                "Foo" (attributes.ml[7,69+4]..[7,69+7])
+                attribute "foo"
+                  []
+                [
+                  core_type (attributes.ml[7,69+12]..[7,69+13])
+                    attribute "foo"
+                      []
+                    Ptyp_constr "t" (attributes.ml[7,69+12]..[7,69+13])
+                    []
+                ]
+                None
+            ]
+        ptype_private = Public
+        ptype_manifest =
+          None
+    ]
+  structure_item (attributes.ml[10,106+0]..[10,106+8])
+    Pstr_attribute "foo"
+    []
+  structure_item (attributes.ml[13,117+0]..[22,224+7])
+    Pstr_module
+    "M" (attributes.ml[13,117+7]..[13,117+8])
+      attribute "foo"
+        []
+      module_expr (attributes.ml[13,117+11]..[21,214+3])
+        attribute "foo"
+          []
+        Pmod_structure
+        [
+          structure_item (attributes.ml[14,135+2]..[18,190+11])
+            Pstr_type Rec
+            [
+              type_declaration "t" (attributes.ml[14,135+7]..[14,135+8]) (attributes.ml[14,135+2]..[18,190+11])
+                attribute "foo"
+                  []
+                attribute "foo"
+                  []
+                ptype_params =
+                  []
+                ptype_cstrs =
+                  []
+                ptype_kind =
+                  Ptype_record
+                    [
+                      (attributes.ml[15,148+4]..[15,148+25])
+                        attribute "foo"
+                          []
+                        Immutable
+                        "l" (attributes.ml[15,148+4]..[15,148+5])                        core_type (attributes.ml[15,148+9]..[15,148+10])
+                          attribute "foo"
+                            []
+                          Ptyp_constr "t" (attributes.ml[15,148+9]..[15,148+10])
+                          []
+                    ]
+                ptype_private = Public
+                ptype_manifest =
+                  None
+            ]
+          structure_item (attributes.ml[20,203+2]..[20,203+10])
+            Pstr_attribute "foo"
+            []
+        ]
+  structure_item (attributes.ml[24,233+0]..[32,357+7])
+    Pstr_modtype "S" (attributes.ml[24,233+12]..[24,233+13])
+      attribute "foo"
+        []
+      module_type (attributes.ml[24,233+16]..[31,347+3])
+        attribute "foo"
+          []
+        Pmty_signature
+        [
+          signature_item (attributes.ml[26,254+2]..[27,322+11])
+            Psig_include
+            module_type (attributes.ml[26,254+10]..[26,254+61])
+              attribute "foo"
+                []
+              Pmty_with
+              module_type (attributes.ml[26,254+11]..[26,254+35])
+                attribute "foo"
+                  []
+                Pmty_typeof
+                module_expr (attributes.ml[26,254+27]..[26,254+28])
+                  attribute "foo"
+                    []
+                  Pmod_ident "M" (attributes.ml[26,254+27]..[26,254+28])
+              [
+                Pwith_typesubst
+                  type_declaration "t" (attributes.ml[26,254+53]..[26,254+54]) (attributes.ml[26,254+48]..[26,254+61])
+                    ptype_params =
+                      []
+                    ptype_cstrs =
+                      []
+                    ptype_kind =
+                      Ptype_abstract
+                    ptype_private = Public
+                    ptype_manifest =
+                      Some
+                        core_type (attributes.ml[26,254+58]..[26,254+61])
+                          Ptyp_constr "M.t" (attributes.ml[26,254+58]..[26,254+61])
+                          []
+              ]
+              attribute "foo"
+                []
+          signature_item (attributes.ml[29,335+2]..[29,335+10])
+            Psig_attribute "foo"
+            []
+        ]
+  structure_item (attributes.ml[34,366+0]..[34,366+8])
+    Pstr_attribute "foo"
+    []
+]
+

--- a/testsuite/tests/parsing/extensions.ml
+++ b/testsuite/tests/parsing/extensions.ml
@@ -1,0 +1,18 @@
+
+[%%foo let x = 1 in x]
+let [%foo 2+1] : [%foo bar.baz] = [%foo "foo"]
+
+[%%foo module M = [%bar] ]
+let [%foo let () = () ] : [%foo type t = t ] = [%foo class c = object end]
+
+[%%foo: 'a list]
+let [%foo: [`Foo] ] : [%foo: t -> t ] = [%foo: < foo : t > ]
+
+[%%foo? _ ]
+[%%foo? Some y when y > 0]
+let [%foo? (Bar x | Baz x) ] : [%foo? #bar ] = [%foo? { x }]
+
+[%%foo: module M : [%baz]]
+let [%foo: include S with type t = t ]
+  : [%foo: val x : t  val y : t]
+  = [%foo: type t = t ]

--- a/testsuite/tests/parsing/extensions.ml.reference
+++ b/testsuite/tests/parsing/extensions.ml.reference
@@ -1,0 +1,326 @@
+[
+  structure_item (extensions.ml[2,1+0]..[2,1+22])
+    Pstr_extension "foo"
+    [
+      structure_item (extensions.ml[2,1+7]..[2,1+21])
+        Pstr_eval
+        expression (extensions.ml[2,1+7]..[2,1+21])
+          Pexp_let Nonrec
+          [
+            <def>
+              pattern (extensions.ml[2,1+11]..[2,1+12])
+                Ppat_var "x" (extensions.ml[2,1+11]..[2,1+12])
+              expression (extensions.ml[2,1+15]..[2,1+16])
+                Pexp_constant PConst_int (1,None)
+          ]
+          expression (extensions.ml[2,1+20]..[2,1+21])
+            Pexp_ident "x" (extensions.ml[2,1+20]..[2,1+21])
+    ]
+  structure_item (extensions.ml[3,24+0]..[3,24+46])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extensions.ml[3,24+4]..[3,24+46]) ghost
+          Ppat_constraint
+          pattern (extensions.ml[3,24+4]..[3,24+14])
+            Ppat_extension "foo"
+            [
+              structure_item (extensions.ml[3,24+10]..[3,24+13])
+                Pstr_eval
+                expression (extensions.ml[3,24+10]..[3,24+13])
+                  Pexp_apply
+                  expression (extensions.ml[3,24+11]..[3,24+12])
+                    Pexp_ident "+" (extensions.ml[3,24+11]..[3,24+12])
+                  [
+                    <arg>
+                    Nolabel
+                      expression (extensions.ml[3,24+10]..[3,24+11])
+                        Pexp_constant PConst_int (2,None)
+                    <arg>
+                    Nolabel
+                      expression (extensions.ml[3,24+12]..[3,24+13])
+                        Pexp_constant PConst_int (1,None)
+                  ]
+            ]
+          core_type (extensions.ml[3,24+17]..[3,24+31])
+            Ptyp_extension "foo"
+            [
+              structure_item (extensions.ml[3,24+23]..[3,24+30])
+                Pstr_eval
+                expression (extensions.ml[3,24+23]..[3,24+30])
+                  Pexp_field
+                  expression (extensions.ml[3,24+23]..[3,24+26])
+                    Pexp_ident "bar" (extensions.ml[3,24+23]..[3,24+26])
+                  "baz" (extensions.ml[3,24+27]..[3,24+30])
+            ]
+        expression (extensions.ml[3,24+34]..[3,24+46])
+          Pexp_extension "foo"
+          [
+            structure_item (extensions.ml[3,24+40]..[3,24+45])
+              Pstr_eval
+              expression (extensions.ml[3,24+40]..[3,24+45])
+                Pexp_constant PConst_string("foo",None)
+          ]
+    ]
+  structure_item (extensions.ml[5,72+0]..[5,72+26])
+    Pstr_extension "foo"
+    [
+      structure_item (extensions.ml[5,72+7]..[5,72+24])
+        Pstr_module
+        "M" (extensions.ml[5,72+14]..[5,72+15])
+          module_expr (extensions.ml[5,72+18]..[5,72+24])
+            Pmod_extension "bar"
+            []
+    ]
+  structure_item (extensions.ml[6,99+0]..[6,99+74])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extensions.ml[6,99+4]..[6,99+74]) ghost
+          Ppat_constraint
+          pattern (extensions.ml[6,99+4]..[6,99+23])
+            Ppat_extension "foo"
+            [
+              structure_item (extensions.ml[6,99+10]..[6,99+21])
+                Pstr_value Nonrec
+                [
+                  <def>
+                    pattern (extensions.ml[6,99+14]..[6,99+16])
+                      Ppat_construct "()" (extensions.ml[6,99+14]..[6,99+16])
+                      None
+                    expression (extensions.ml[6,99+19]..[6,99+21])
+                      Pexp_construct "()" (extensions.ml[6,99+19]..[6,99+21])
+                      None
+                ]
+            ]
+          core_type (extensions.ml[6,99+26]..[6,99+44])
+            Ptyp_extension "foo"
+            [
+              structure_item (extensions.ml[6,99+32]..[6,99+42])
+                Pstr_type Rec
+                [
+                  type_declaration "t" (extensions.ml[6,99+37]..[6,99+38]) (extensions.ml[6,99+32]..[6,99+42])
+                    ptype_params =
+                      []
+                    ptype_cstrs =
+                      []
+                    ptype_kind =
+                      Ptype_abstract
+                    ptype_private = Public
+                    ptype_manifest =
+                      Some
+                        core_type (extensions.ml[6,99+41]..[6,99+42])
+                          Ptyp_constr "t" (extensions.ml[6,99+41]..[6,99+42])
+                          []
+                ]
+            ]
+        expression (extensions.ml[6,99+47]..[6,99+74])
+          Pexp_extension "foo"
+          [
+            structure_item (extensions.ml[6,99+53]..[6,99+73])
+              Pstr_class
+              [
+                class_declaration (extensions.ml[6,99+53]..[6,99+73])
+                  pci_virt = Concrete
+                  pci_params =
+                    []
+                  pci_name = "c" (extensions.ml[6,99+59]..[6,99+60])
+                  pci_expr =
+                    class_expr (extensions.ml[6,99+63]..[6,99+73])
+                      Pcl_structure
+                      class_structure
+                        pattern (extensions.ml[6,99+69]..[6,99+69]) ghost
+                          Ppat_any
+                        []
+              ]
+          ]
+    ]
+  structure_item (extensions.ml[8,175+0]..[8,175+16])
+    Pstr_extension "foo"
+    core_type (extensions.ml[8,175+8]..[8,175+15])
+      Ptyp_constr "list" (extensions.ml[8,175+11]..[8,175+15])
+      [
+        core_type (extensions.ml[8,175+8]..[8,175+10])
+          Ptyp_var a
+      ]
+  structure_item (extensions.ml[9,192+0]..[9,192+60])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extensions.ml[9,192+4]..[9,192+60]) ghost
+          Ppat_constraint
+          pattern (extensions.ml[9,192+4]..[9,192+19])
+            Ppat_extension "foo"
+            core_type (extensions.ml[9,192+11]..[9,192+17])
+              Ptyp_variant closed=Closed
+              [
+                Rtag "Foo" true
+                  []
+              ]
+              None
+          core_type (extensions.ml[9,192+22]..[9,192+37])
+            Ptyp_extension "foo"
+            core_type (extensions.ml[9,192+29]..[9,192+35])
+              Ptyp_arrow
+              Nolabel
+              core_type (extensions.ml[9,192+29]..[9,192+30])
+                Ptyp_constr "t" (extensions.ml[9,192+29]..[9,192+30])
+                []
+              core_type (extensions.ml[9,192+34]..[9,192+35])
+                Ptyp_constr "t" (extensions.ml[9,192+34]..[9,192+35])
+                []
+        expression (extensions.ml[9,192+40]..[9,192+60])
+          Pexp_extension "foo"
+          core_type (extensions.ml[9,192+47]..[9,192+58])
+            Ptyp_object Closed
+              method foo
+                core_type (extensions.ml[9,192+55]..[9,192+56])
+                  Ptyp_constr "t" (extensions.ml[9,192+55]..[9,192+56])
+                  []
+    ]
+  structure_item (extensions.ml[11,254+0]..[11,254+11])
+    Pstr_extension "foo"
+    pattern (extensions.ml[11,254+8]..[11,254+9])
+      Ppat_any
+  structure_item (extensions.ml[12,266+0]..[12,266+26])
+    Pstr_extension "foo"
+    pattern (extensions.ml[12,266+8]..[12,266+14])
+      Ppat_construct "Some" (extensions.ml[12,266+8]..[12,266+12])
+      Some
+        pattern (extensions.ml[12,266+13]..[12,266+14])
+          Ppat_var "y" (extensions.ml[12,266+13]..[12,266+14])
+    <when>
+      expression (extensions.ml[12,266+20]..[12,266+25])
+        Pexp_apply
+        expression (extensions.ml[12,266+22]..[12,266+23])
+          Pexp_ident ">" (extensions.ml[12,266+22]..[12,266+23])
+        [
+          <arg>
+          Nolabel
+            expression (extensions.ml[12,266+20]..[12,266+21])
+              Pexp_ident "y" (extensions.ml[12,266+20]..[12,266+21])
+          <arg>
+          Nolabel
+            expression (extensions.ml[12,266+24]..[12,266+25])
+              Pexp_constant PConst_int (0,None)
+        ]
+  structure_item (extensions.ml[13,293+0]..[13,293+60])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extensions.ml[13,293+4]..[13,293+60]) ghost
+          Ppat_constraint
+          pattern (extensions.ml[13,293+4]..[13,293+28])
+            Ppat_extension "foo"
+            pattern (extensions.ml[13,293+11]..[13,293+26])
+              Ppat_or
+              pattern (extensions.ml[13,293+12]..[13,293+17])
+                Ppat_construct "Bar" (extensions.ml[13,293+12]..[13,293+15])
+                Some
+                  pattern (extensions.ml[13,293+16]..[13,293+17])
+                    Ppat_var "x" (extensions.ml[13,293+16]..[13,293+17])
+              pattern (extensions.ml[13,293+20]..[13,293+25])
+                Ppat_construct "Baz" (extensions.ml[13,293+20]..[13,293+23])
+                Some
+                  pattern (extensions.ml[13,293+24]..[13,293+25])
+                    Ppat_var "x" (extensions.ml[13,293+24]..[13,293+25])
+          core_type (extensions.ml[13,293+31]..[13,293+44])
+            Ptyp_extension "foo"
+            pattern (extensions.ml[13,293+38]..[13,293+42])
+              Ppat_type
+              "bar" (extensions.ml[13,293+39]..[13,293+42])
+        expression (extensions.ml[13,293+47]..[13,293+60])
+          Pexp_extension "foo"
+          pattern (extensions.ml[13,293+54]..[13,293+59])
+            Ppat_record Closed
+            [
+              "x" (extensions.ml[13,293+56]..[13,293+57])
+                pattern (extensions.ml[13,293+56]..[13,293+57])
+                  Ppat_var "x" (extensions.ml[13,293+56]..[13,293+57])
+            ]
+    ]
+  structure_item (extensions.ml[15,355+0]..[15,355+26])
+    Pstr_extension "foo"
+    [
+      signature_item (extensions.ml[15,355+8]..[15,355+25])
+        Psig_module "M" (extensions.ml[15,355+15]..[15,355+16])
+        module_type (extensions.ml[15,355+19]..[15,355+25])
+          Pmod_extension "baz"
+          []
+    ]
+  structure_item (extensions.ml[16,382+0]..[18,454+23])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extensions.ml[16,382+4]..[18,454+23]) ghost
+          Ppat_constraint
+          pattern (extensions.ml[16,382+4]..[16,382+38])
+            Ppat_extension "foo"
+            [
+              signature_item (extensions.ml[16,382+11]..[16,382+36])
+                Psig_include
+                module_type (extensions.ml[16,382+19]..[16,382+36])
+                  Pmty_with
+                  module_type (extensions.ml[16,382+19]..[16,382+20])
+                    Pmty_ident "S" (extensions.ml[16,382+19]..[16,382+20])
+                  [
+                    Pwith_type "t" (extensions.ml[16,382+31]..[16,382+32])
+                      type_declaration "t" (extensions.ml[16,382+31]..[16,382+32]) (extensions.ml[16,382+26]..[16,382+36])
+                        ptype_params =
+                          []
+                        ptype_cstrs =
+                          []
+                        ptype_kind =
+                          Ptype_abstract
+                        ptype_private = Public
+                        ptype_manifest =
+                          Some
+                            core_type (extensions.ml[16,382+35]..[16,382+36])
+                              Ptyp_constr "t" (extensions.ml[16,382+35]..[16,382+36])
+                              []
+                  ]
+            ]
+          core_type (extensions.ml[17,421+4]..[17,421+32])
+            Ptyp_extension "foo"
+            [
+              signature_item (extensions.ml[17,421+11]..[17,421+20])
+                Psig_value
+                value_description "x" (extensions.ml[17,421+15]..[17,421+16]) (extensions.ml[17,421+11]..[17,421+20])
+                  core_type (extensions.ml[17,421+19]..[17,421+20])
+                    Ptyp_constr "t" (extensions.ml[17,421+19]..[17,421+20])
+                    []
+                  []
+              signature_item (extensions.ml[17,421+22]..[17,421+31])
+                Psig_value
+                value_description "y" (extensions.ml[17,421+26]..[17,421+27]) (extensions.ml[17,421+22]..[17,421+31])
+                  core_type (extensions.ml[17,421+30]..[17,421+31])
+                    Ptyp_constr "t" (extensions.ml[17,421+30]..[17,421+31])
+                    []
+                  []
+            ]
+        expression (extensions.ml[18,454+4]..[18,454+23])
+          Pexp_extension "foo"
+          [
+            signature_item (extensions.ml[18,454+11]..[18,454+21])
+              Psig_type Rec
+              [
+                type_declaration "t" (extensions.ml[18,454+16]..[18,454+17]) (extensions.ml[18,454+11]..[18,454+21])
+                  ptype_params =
+                    []
+                  ptype_cstrs =
+                    []
+                  ptype_kind =
+                    Ptype_abstract
+                  ptype_private = Public
+                  ptype_manifest =
+                    Some
+                      core_type (extensions.ml[18,454+20]..[18,454+21])
+                        Ptyp_constr "t" (extensions.ml[18,454+20]..[18,454+21])
+                        []
+              ]
+          ]
+    ]
+]
+
+File "extensions.ml", line 2, characters 3-6:
+Uninterpreted extension 'foo'.


### PR DESCRIPTION
See previous discussion in https://github.com/ocaml/ocaml/pull/312 and in [mantis ticket 6681](http://caml.inria.fr/mantis/view.php?id=6681).

This time, the patch is smaller!

@gasche Do you have an idea for a decent test other than "let's just dump and diff the parsetree" ?
