### PR TITLE
Optim hashtbl

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,9 @@ OCaml 4.04.0:
 Tools:
 - GPR#452: Make the output of ocamldep is more stable (Alain Frisch)
 
+Standard library:
+- PR#4747, GPR#328: Optimize Hashtbl (Alain Frisch)
+
 Build system:
 - GPR#324: Compiler developpers only: Adding new primitives to the
   standard runtime doesn't require anymore to run `make bootstrap`

--- a/Changes
+++ b/Changes
@@ -7,7 +7,10 @@ Tools:
 - GPR#452: Make the output of ocamldep is more stable (Alain Frisch)
 
 Standard library:
-- PR#4747, GPR#328: Optimize Hashtbl (Alain Frisch)
+- PR#4747, GPR#328: Optimize Hashtbl but using in-place updates of its
+  internal bucket lists.  All operations run in constant stack size
+  and are usually faster, except Hashtbl.copy which can be much
+  slower. (Alain Frisch)
 
 Build system:
 - GPR#324: Compiler developpers only: Adding new primitives to the


### PR DESCRIPTION
This is a follow up to http://caml.inria.fr/mantis/view.php?id=4747.

I propose to implement buckets of hash tables using inline records, to allow keeping the same concrete compact representation as today while allowing to mutate the field of each bucket cell.  Thanks to this change, one can avoid all non tailrec functions (and hence fix the original bug) and many allocations.

Interestingly, all three fields of cells can be mutated:
- The `key` and `data` fields are modified by `Hashtbl.replace` so that it doesn't allocate at all when a binding with an equal key was already in the table (one needs to update the `key` to keep the previous behavior, although one could consider a faster version of replace which does not update it -- this would be fine for the vast majority of uses and avoid 1/2 of the mutations in that case).
- The `rest` field is modified in `Hashtbl.remove` in order to remove a cell from the bucket list, and in `resize` in order to append to the tail of a bucket (allowing to treat all cells sequentially and keep the function tailrec).

One downside of this approach is that `Hashtbl.copy` cannot simply do a shallow copy the array of buckets anymore. It needs to copy each bucket.  This is done in a tailrec function again, but obviously, this can be quite costly.  I doubt this function is used a lot, and `Hashtbl.copy` is not completely cheap anyway.

I've attached a micro-benchmark on Mantis, with results in a note below.  Except for `Hashtbl.copy`, the result are quite encouraging, with gains often above 25%.  Considering that Hashtbl is used very pervasively, this is certainly worth considering.  (I'm also quite confident that gains would be even higher for js_of_ocaml.)

[EDIT: this is no longer WIP; this should be ready for inclusion.]
