### PR TITLE
Windows sockets in asynchronous mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -204,6 +204,10 @@ Toplevel and debugger:
   (Junsong Li, review by Gabriel Scherer)
 
 Other libraries:
+* Unix library: channels created by Unix.in_channel_of_descr or
+  Unix.out_channel_of_descr no longer support text mode under Windows.
+  Calling [set_binary_mode_{in,out} chan false] on these channels
+  now causes an error.
 - PR#4023 and GPR#68: add Unix.sleepf (sleep with sub-second resolution)
   (Evgenii Lepikhin and Xavier Leroy)
 * Protect Unix.sleep against interruptions by handled signals.
@@ -240,6 +244,10 @@ Bug fixes:
   (Pierre Chambart, report by Gary Huber)
 * PR#4166, PR#6956: force linking when calling external C primitives
   (Jacques Garrigue, reports by Markus Mottl and Christophe Troestler)
+* PR#4466, PR#5325: under Windows, concurrent read and write operations
+    on the same socket could block unexpectedly.  Fixed by keeping sockets
+    in asynchronous mode rather than creating them in synchronous mode.
+  (Xavier Leroy)
 * PR#4539: change exception string raised when comparing functional values
   (Nicolas Braud-Santoni, report by Eric Cooper)
 - PR#4832: Filling bigarrays may block out runtime

--- a/byterun/caml/osdeps.h
+++ b/byterun/caml/osdeps.h
@@ -18,6 +18,18 @@
 
 #include "misc.h"
 
+/* Read at most [n] bytes from file descriptor [fd] into buffer [buf].
+   [is_socket] is true if [fd] refers to a socket.  (This distinction
+   matters for Win32, but not for Unix.)  Return number of bytes
+   read, or -1 if error. */
+extern int caml_read_fd(int fd, int is_socket, void * buf, int n);
+
+/* Write at most [n] bytes from buffer [buf] onto file descriptor [fd].
+   [is_socket] is true if [fd] refers to a socket.  (This distinction
+   matters for Win32, but not for Unix.)  Return number of bytes
+   written, or -1 if error. */
+extern int caml_write_fd(int fd, int is_socket, void * buf, int n);
+
 /* Decompose the given path into a list of directories, and add them
    to the given table.  Return the block to be freed later. */
 extern char * caml_decompose_path(struct ext_table * tbl, char * path);

--- a/byterun/caml/osdeps.h
+++ b/byterun/caml/osdeps.h
@@ -19,16 +19,20 @@
 #include "misc.h"
 
 /* Read at most [n] bytes from file descriptor [fd] into buffer [buf].
-   [is_socket] is true if [fd] refers to a socket.  (This distinction
-   matters for Win32, but not for Unix.)  Return number of bytes
-   read, or -1 if error. */
-extern int caml_read_fd(int fd, int is_socket, void * buf, int n);
+   [flags] indicates whether [fd] is a socket
+   (bit [CHANNEL_FLAG_FROM_SOCKET] is set in this case, see [io.h]).
+   (This distinction matters for Win32, but not for Unix.)
+   Return number of bytes read.
+   In case of error, raises [Sys_error] or [Sys_blocked_io]. */
+extern int caml_read_fd(int fd, int flags, void * buf, int n);
 
 /* Write at most [n] bytes from buffer [buf] onto file descriptor [fd].
-   [is_socket] is true if [fd] refers to a socket.  (This distinction
-   matters for Win32, but not for Unix.)  Return number of bytes
-   written, or -1 if error. */
-extern int caml_write_fd(int fd, int is_socket, void * buf, int n);
+   [flags] indicates whether [fd] is a socket
+   (bit [CHANNEL_FLAG_FROM_SOCKET] is set in this case, see [io.h]).
+   (This distinction matters for Win32, but not for Unix.)
+   Return number of bytes written.
+   In case of error, raises [Sys_error] or [Sys_blocked_io]. */
+extern int caml_write_fd(int fd, int flags, void * buf, int n);
 
 /* Decompose the given path into a list of directories, and add them
    to the given table.  Return the block to be freed later. */

--- a/byterun/io.c
+++ b/byterun/io.c
@@ -271,6 +271,7 @@ static int do_read(int fd, int flags, char *p, unsigned int n)
 
   caml_enter_blocking_section();
   retcode = caml_read_fd(fd, flags & CHANNEL_FLAG_FROM_SOCKET, p, n);
+  caml_leave_blocking_section();
   if (retcode == -1) caml_sys_io_error(NO_ARG);
   return retcode;
 }

--- a/byterun/io.c
+++ b/byterun/io.c
@@ -454,8 +454,7 @@ CAMLexport void caml_finalize_channel(value vchan)
     */
     if (chan->name && caml_runtime_warnings_active())
       fprintf(stderr,
-              "[ocaml] (moreover, it has unflushed data)\n",
-              chan->name
+              "[ocaml] (moreover, it has unflushed data)\n"
               );
   } else {
     unlink_channel(chan);

--- a/byterun/io.c
+++ b/byterun/io.c
@@ -33,6 +33,7 @@
 #include "caml/memory.h"
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
+#include "caml/osdeps.h"
 #include "caml/signals.h"
 #include "caml/sys.h"
 
@@ -158,25 +159,12 @@ CAMLexport int caml_channel_binary_mode(struct channel *channel)
 #define EWOULDBLOCK (-1)
 #endif
 
-static int do_write(int fd, char *p, int n)
+static int do_write(int fd, int flags, char *p, int n)
 {
   int retcode;
-
-again:
   caml_enter_blocking_section();
-  retcode = write(fd, p, n);
+  retcode = caml_write_fd(fd, flags & CHANNEL_FLAG_FROM_SOCKET, p, n);
   caml_leave_blocking_section();
-  if (retcode == -1) {
-    if (errno == EINTR) goto again;
-    if ((errno == EAGAIN || errno == EWOULDBLOCK) && n > 1) {
-      /* We couldn't do a partial write here, probably because
-         n <= PIPE_BUF and POSIX says that writes of less than
-         PIPE_BUF characters must be atomic.
-         We first try again with a partial write of 1 character.
-         If that fails too, we'll raise Sys_blocked_io below. */
-      n = 1; goto again;
-    }
-  }
   if (retcode == -1) caml_sys_io_error(NO_ARG);
   CAMLassert (retcode > 0);
   return retcode;
@@ -194,7 +182,7 @@ CAMLexport int caml_flush_partial(struct channel *channel)
   towrite = channel->curr - channel->buff;
   CAMLassert (towrite >= 0);
   if (towrite > 0) {
-    written = do_write(channel->fd, channel->buff, towrite);
+    written = do_write(channel->fd, channel->flags, channel->buff, towrite);
     channel->offset += written;
     if (written < towrite)
       memmove(channel->buff, channel->buff + written, towrite - written);
@@ -238,7 +226,7 @@ CAMLexport int caml_putblock(struct channel *channel, char *p, intnat len)
        fits to buffer and write the buffer */
     memmove(channel->curr, p, free);
     towrite = channel->end - channel->buff;
-    written = do_write(channel->fd, channel->buff, towrite);
+    written = do_write(channel->fd, channel->flags, channel->buff, towrite);
     if (written < towrite)
       memmove(channel->buff, channel->buff + written, towrite - written);
     channel->offset += written;
@@ -277,30 +265,28 @@ CAMLexport file_offset caml_pos_out(struct channel *channel)
 
 /* Input */
 
-/* caml_do_read is exported for Cash */
-CAMLexport int caml_do_read(int fd, char *p, unsigned int n)
+static int do_read(int fd, int flags, char *p, unsigned int n)
 {
   int retcode;
 
-  do {
-    caml_enter_blocking_section();
-    retcode = read(fd, p, n);
-#if defined(_WIN32)
-    if (retcode == -1 && errno == ENOMEM && n > 16384){
-      retcode = read(fd, p, 16384);
-    }
-#endif
-    caml_leave_blocking_section();
-  } while (retcode == -1 && errno == EINTR);
+  caml_enter_blocking_section();
+  retcode = caml_read_fd(fd, flags & CHANNEL_FLAG_FROM_SOCKET, p, n);
   if (retcode == -1) caml_sys_io_error(NO_ARG);
   return retcode;
+}
+
+/* caml_do_read is exported for Cash */
+CAMLexport int caml_do_read(int fd, char *p, unsigned int n)
+{
+  return do_read(fd, 0, p, n);
 }
 
 CAMLexport unsigned char caml_refill(struct channel *channel)
 {
   int n;
 
-  n = caml_do_read(channel->fd, channel->buff, channel->end - channel->buff);
+  n = do_read(channel->fd, channel->flags, 
+              channel->buff, channel->end - channel->buff);
   if (n == 0) caml_raise_end_of_file();
   channel->offset += n;
   channel->max = channel->buff + n;
@@ -337,8 +323,8 @@ CAMLexport int caml_getblock(struct channel *channel, char *p, intnat len)
     channel->curr += avail;
     return avail;
   } else {
-    nread = caml_do_read(channel->fd, channel->buff,
-                         channel->end - channel->buff);
+    nread = do_read(channel->fd, channel->flags, channel->buff,
+                    channel->end - channel->buff);
     channel->offset += nread;
     channel->max = channel->buff + nread;
     if (n > nread) n = nread;
@@ -407,7 +393,8 @@ CAMLexport intnat caml_input_scan_line(struct channel *channel)
         return -(channel->max - channel->curr);
       }
       /* Fill the buffer as much as possible */
-      n = caml_do_read(channel->fd, channel->max, channel->end - channel->max);
+      n = do_read(channel->fd, channel->flags, 
+                  channel->max, channel->end - channel->max);
       if (n == 0) {
         /* End-of-file encountered. Return the number of characters in the
            buffer, with negative sign since we haven't encountered
@@ -603,6 +590,15 @@ CAMLprim value caml_ml_set_binary_mode(value vchannel, value mode)
 {
 #if defined(_WIN32) || defined(__CYGWIN__)
   struct channel * channel = Channel(vchannel);
+#if defined(_WIN32)
+  /* The implementation of [caml_read_fd] and [caml_write_fd] in win32.c
+     doesn't support socket I/O with CRLF conversion. */
+  if (channel->flags & CHANNEL_FLAG_FROM_SOCKET != 0
+      && ! Bool_val(mode)) {
+    errno = EINVAL;
+    caml_sys_error(NO_ARG);
+  }
+#endif
   if (setmode(channel->fd, Bool_val(mode) ? O_BINARY : O_TEXT) == -1)
     caml_sys_error(NO_ARG);
 #endif
@@ -778,7 +774,7 @@ CAMLprim value caml_ml_input(value vchannel, value buff, value vstart,
     channel->curr += avail;
     n = avail;
   } else {
-    nread = caml_do_read(channel->fd, channel->buff,
+    nread = do_read(channel->fd, channel->flags, channel->buff,
                          channel->end - channel->buff);
     channel->offset += nread;
     channel->max = channel->buff + nread;

--- a/byterun/unix.c
+++ b/byterun/unix.c
@@ -39,9 +39,12 @@
 #else
 #include <sys/dir.h>
 #endif
+#include "caml/fail.h"
 #include "caml/memory.h"
 #include "caml/misc.h"
 #include "caml/osdeps.h"
+#include "caml/signals.h"
+#include "caml/sys.h"
 
 #ifndef S_ISREG
 #define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -296,6 +296,9 @@ val in_channel_of_descr : file_descr -> in_channel
 (** Create an input channel reading from the given descriptor.
    The channel is initially in binary mode; use
    [set_binary_mode_in ic false] if text mode is desired.
+   Text mode is supported only if the descriptor refers to a file
+   or pipe, but is not supported if it refers to a socket.
+
    Beware that channels are buffered so more characters may have been
    read from the file descriptor than those accessed using channel functions.
    Channels also keep a copy of the current position in the file.
@@ -308,6 +311,9 @@ val out_channel_of_descr : file_descr -> out_channel
 (** Create an output channel writing on the given descriptor.
    The channel is initially in binary mode; use
    [set_binary_mode_out oc false] if text mode is desired.
+   Text mode is supported only if the descriptor refers to a file
+   or pipe, but is not supported if it refers to a socket.
+
    Beware that channels are buffered so you may have to [flush] them
    to ensure that all data has been sent to the file descriptor.
    Channels also keep a copy of the current position in the file.

--- a/otherlibs/win32unix/accept.c
+++ b/otherlibs/win32unix/accept.c
@@ -16,7 +16,6 @@
 #include <caml/memory.h>
 #include <caml/signals.h>
 #include "unixsupport.h"
-#include <mswsock.h>   // for SO_OPENTYPE and SO_SYNCHRONOUS_NONALERT
 #include "socketaddr.h"
 
 CAMLprim value unix_accept(sock)
@@ -25,30 +24,15 @@ CAMLprim value unix_accept(sock)
   SOCKET sconn = Socket_val(sock);
   SOCKET snew;
   value fd = Val_unit, adr = Val_unit, res;
-  int oldvalue, oldvaluelen, newvalue, retcode;
   union sock_addr_union addr;
   socklen_param_type addr_len;
   DWORD err = 0;
 
-  oldvaluelen = sizeof(oldvalue);
-  retcode = getsockopt(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE,
-                       (char *) &oldvalue, &oldvaluelen);
-  if (retcode == 0) {
-    /* Set sockets to synchronous mode */
-    newvalue = SO_SYNCHRONOUS_NONALERT;
-    setsockopt(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE,
-               (char *) &newvalue, sizeof(newvalue));
-  }
   addr_len = sizeof(sock_addr);
   enter_blocking_section();
   snew = accept(sconn, &addr.s_gen, &addr_len);
   if (snew == INVALID_SOCKET) err = WSAGetLastError ();
   leave_blocking_section();
-  if (retcode == 0) {
-    /* Restore initial mode */
-    setsockopt(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE,
-               (char *) &oldvalue, oldvaluelen);
-  }
   if (snew == INVALID_SOCKET) {
     win32_maperr(err);
     uerror("accept", Nothing);

--- a/otherlibs/win32unix/socket.c
+++ b/otherlibs/win32unix/socket.c
@@ -13,7 +13,6 @@
 
 #include <caml/mlvalues.h>
 #include "unixsupport.h"
-#include <mswsock.h>   // for SO_OPENTYPE and SO_SYNCHRONOUS_NONALERT
 
 int socket_domain_table[] = {
   PF_UNIX, PF_INET,
@@ -32,7 +31,6 @@ CAMLprim value unix_socket(domain, type, proto)
      value domain, type, proto;
 {
   SOCKET s;
-  int oldvalue, oldvaluelen, newvalue, retcode;
 
   #ifndef HAS_IPV6
   /* IPv6 requires WinSock2, we must raise an error on PF_INET6 */
@@ -42,23 +40,9 @@ CAMLprim value unix_socket(domain, type, proto)
   }
   #endif
 
-  oldvaluelen = sizeof(oldvalue);
-  retcode = getsockopt(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE,
-                       (char *) &oldvalue, &oldvaluelen);
-  if (retcode == 0) {
-    /* Set sockets to synchronous mode */
-    newvalue = SO_SYNCHRONOUS_NONALERT;
-    setsockopt(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE,
-               (char *) &newvalue, sizeof(newvalue));
-  }
   s = socket(socket_domain_table[Int_val(domain)],
                    socket_type_table[Int_val(type)],
                    Int_val(proto));
-  if (retcode == 0) {
-    /* Restore initial mode */
-    setsockopt(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE,
-               (char *) &oldvalue, oldvaluelen);
-  }
   if (s == INVALID_SOCKET) {
     win32_maperr(WSAGetLastError());
     uerror("socket", Nothing);

--- a/testsuite/tests/lib-threads/pr4466.ml
+++ b/testsuite/tests/lib-threads/pr4466.ml
@@ -1,0 +1,82 @@
+(***********************************************************************)
+(*                                                                     *)
+(*                                OCaml                                *)
+(*                                                                     *)
+(*            Xavier Leroy, projet Gallium, INRIA Paris                *)
+(*                                                                     *)
+(*  Copyright 2015 Institut National de Recherche en Informatique et   *)
+(*  en Automatique.  All rights reserved.  This file is distributed    *)
+(*  under the terms of the Q Public License version 1.0.               *)
+(*                                                                     *)
+(***********************************************************************)
+
+open Printf
+
+(* Regression test for PR#4466: select timeout with simultaneous read
+   and write on socket in Windows. *)
+
+(* Scenario:
+     - thread [server] implements a simple 'echo' server on a socket
+     - thread [reader] selects then reads from a socket connected to
+       the echo server and copies to standard output
+     - main program executes [writer], which writes to the same socket
+       (the one connected to the echo server)
+*)
+
+let serve_connection s =
+  let buf = String.make 1024 '>' in
+  while true do
+    let n = Unix.recv s buf 2 (String.length buf - 2) [] in
+    if n = 0 then begin
+      Unix.close s; Thread.exit ()
+    end else begin
+      ignore (Unix.send s buf 0 (n + 2) [])
+    end
+  done
+
+let server sock =
+  while true do
+    let (s, _) = Unix.accept sock in
+    ignore(Thread.create serve_connection s)
+  done
+
+let reader s =
+  let buf = String.make 16 ' ' in
+  match Unix.select [s] [] [] 10.0 with
+  | (_::_, _, _) ->
+      printf "Selected\n%!";
+      let n = Unix.recv s buf 0 (String.length buf) [] in
+      printf "Data read: %s\n%!" (String.sub buf 0 n)
+  | ([], _, _) ->
+      printf "TIMEOUT\n%!"
+
+let writer s msg =
+  ignore (Unix.send s msg 0 (String.length msg) [])
+
+let _ =
+  let addr = Unix.ADDR_INET(Unix.inet_addr_loopback, 9876) in
+  let serv =
+    Unix.socket (Unix.domain_of_sockaddr addr) Unix.SOCK_STREAM 0 in
+  Unix.setsockopt serv Unix.SO_REUSEADDR true;
+  Unix.bind serv addr;
+  Unix.listen serv 5;
+  ignore (Thread.create server serv);
+  Thread.delay 0.2;
+  let client =
+    Unix.socket (Unix.domain_of_sockaddr addr) Unix.SOCK_STREAM 0 in
+  Unix.connect client addr;
+  (* Send before select & read *)
+  writer client "1111";
+  let a = Thread.create reader client in
+  Thread.delay 0.1;
+  Thread.join a;
+  (* Select then send *)
+  let a = Thread.create reader client in
+  Thread.delay 0.1;
+  writer client "2222";
+  Thread.join a;
+  (* Select then send again *)
+  let a = Thread.create reader client in
+  Thread.delay 0.1;
+  writer client "3333";
+  Thread.join a

--- a/testsuite/tests/lib-threads/pr4466.reference
+++ b/testsuite/tests/lib-threads/pr4466.reference
@@ -1,0 +1,6 @@
+Selected
+Data read: >>1111
+Selected
+Data read: >>2222
+Selected
+Data read: >>3333

--- a/testsuite/tests/lib-threads/pr5325.ml
+++ b/testsuite/tests/lib-threads/pr5325.ml
@@ -1,0 +1,70 @@
+(***********************************************************************)
+(*                                                                     *)
+(*                                OCaml                                *)
+(*                                                                     *)
+(*            Xavier Leroy, projet Gallium, INRIA Paris                *)
+(*                                                                     *)
+(*  Copyright 2015 Institut National de Recherche en Informatique et   *)
+(*  en Automatique.  All rights reserved.  This file is distributed    *)
+(*  under the terms of the Q Public License version 1.0.               *)
+(*                                                                     *)
+(***********************************************************************)
+
+open Printf
+
+(* Regression test for PR#5325: simultaneous read and write on socket
+   in Windows. *)
+
+(* Scenario:
+     - thread [server] implements a simple 'echo' server on a socket
+     - thread [reader] reads from a socket connected to the echo server
+       and copies to standard output
+     - main program executes [writer], which writes to the same socket
+       (the one connected to the echo server)
+     - thread [timeout] causes a failure if nothing happens in 10 seconds.
+*)
+
+let serve_connection s =
+  let buf = String.make 1024 '>' in
+  let n = Unix.read s buf 2 (String.length buf - 2) in
+  ignore (Unix.write s buf 0 (n + 2));
+  Unix.close s
+
+let server sock =
+  while true do
+    let (s, _) = Unix.accept sock in
+    ignore(Thread.create serve_connection s)
+  done
+
+let timeout () =
+  Thread.delay 10.0;
+  printf "Time out, exiting...\n%!";
+  exit 2
+
+let reader s =
+  let buf = String.make 1024 ' ' in
+  let n = Unix.read s buf 0 (String.length buf) in
+  print_string (String.sub buf 0 n); flush stdout
+
+let writer s msg =
+  ignore (Unix.write s msg 0 (String.length msg));
+  Unix.shutdown s Unix.SHUTDOWN_SEND
+
+let _ =
+  let addr = Unix.ADDR_INET(Unix.inet_addr_loopback, 9876) in
+  let serv =
+    Unix.socket (Unix.domain_of_sockaddr addr) Unix.SOCK_STREAM 0 in
+  Unix.setsockopt serv Unix.SO_REUSEADDR true;
+  Unix.bind serv addr;
+  Unix.listen serv 5;
+  ignore (Thread.create server serv);
+  ignore (Thread.create timeout ());
+  Thread.delay 0.5;
+  let client =
+    Unix.socket (Unix.domain_of_sockaddr addr) Unix.SOCK_STREAM 0 in
+  Unix.connect client addr;
+  let rd = Thread.create reader client in
+  Thread.delay 0.5;
+  writer client "Client data\n";
+  Thread.join rd
+    

--- a/testsuite/tests/lib-threads/pr5325.reference
+++ b/testsuite/tests/lib-threads/pr5325.reference
@@ -1,0 +1,1 @@
+>>Client data

--- a/testsuite/tests/lib-threads/socketsbuf.ml
+++ b/testsuite/tests/lib-threads/socketsbuf.ml
@@ -1,0 +1,54 @@
+(***********************************************************************)
+(*                                                                     *)
+(*                                OCaml                                *)
+(*                                                                     *)
+(*            Xavier Leroy, projet Cristal, INRIA Rocquencourt         *)
+(*                                                                     *)
+(*  Copyright 1996 Institut National de Recherche en Informatique et   *)
+(*  en Automatique.  All rights reserved.  This file is distributed    *)
+(*  under the terms of the Q Public License version 1.0.               *)
+(*                                                                     *)
+(***********************************************************************)
+
+open Printf
+
+(* Threads, sockets, and buffered I/O channels *)
+(* Serves as a regression test for PR#5578 *)
+
+let serve_connection s =
+  let ic = Unix.in_channel_of_descr s
+  and oc = Unix.out_channel_of_descr s in
+  let l = input_line ic in
+  fprintf oc ">>%s\n" l;
+  close_out oc
+
+let server sock =
+  while true do
+    let (s, _) = Unix.accept sock in
+    ignore(Thread.create serve_connection s)
+  done
+
+let client (addr, msg) =
+  let sock =
+    Unix.socket (Unix.domain_of_sockaddr addr) Unix.SOCK_STREAM 0 in
+  Unix.connect sock addr;
+  let ic = Unix.in_channel_of_descr sock
+  and oc = Unix.out_channel_of_descr sock in
+  output_string oc msg; flush oc;
+  let l = input_line ic in
+  printf "%s\n%!" l
+
+let _ =
+  let addr = Unix.ADDR_INET(Unix.inet_addr_loopback, 9876) in
+  let sock =
+    Unix.socket (Unix.domain_of_sockaddr addr) Unix.SOCK_STREAM 0 in
+  Unix.setsockopt sock Unix.SO_REUSEADDR true;
+  Unix.bind sock addr;
+  Unix.listen sock 5;
+  ignore (Thread.create server sock);
+  ignore (Thread.create client (addr, "Client #1\n"));
+  Thread.delay 0.5;
+  client (addr, "Client #2\n")
+
+
+  

--- a/testsuite/tests/lib-threads/socketsbuf.reference
+++ b/testsuite/tests/lib-threads/socketsbuf.reference
@@ -1,0 +1,2 @@
+>>Client #1
+>>Client #2


### PR DESCRIPTION
This is a tentative fix for Mantis problem reports 4466, 5325, and probably 6771 as well.
## Background

Windows sockets can be created in two modes (at least): asynchronous (the default) and synchronous (what OCaml currently uses).

For `send` and `recv` system calls, the socket mode makes no difference.  However, it makes a difference for `ReadFile` and `WriteFile` system calls: when used in nonoverlapping mode (the default), these syscalls fail on asynchronous sockets.

In the OCaml Unix library, we carefully use `send` and `recv` to implement `Unix.read` and `Unix.write` on a socket.  Hence the socket mode makes no difference.

In the OCaml standard library, for buffered I/O channels, we rely on MSVCRT's emulation of the `read` and `write` Unix system calls, which is implemented in terms of nonoverlapping 
`ReadFile` and `WriteFile` system calls.  This is why OCaml currently creates sockets in synchronous mode, in order for the following kind of code to work:

```
let s = Unix.socket ... ... ... in
...
let ic = Unix.in_channel_of_descr s in
...
input_line ic
```

(Mantis PR#5578 shows the failure if sockets are created in asynchronous mode.)

However, synchronous sockets cause a number of problems of the "some socket I/O blocks or times out when it should not" kind: see PR#4466 and PR#5325 for examples. 
## Proposed solution
- Create sockets in asynchronous mode (the default mode for Winsock2).
- Adjust the implementation of buffered I/O channels so that they work with channels created over sockets:
  - Move `do_read` and `do_write` from byterun/io.c to the OS-dependent file byterun/unix.c and byterun/win32.c
  - Pass the channel flags to these two functions.  These flags tell them whether the file descriptor is a socket.
  - The byterun/unix.c implementation ignores flags and behaves like the old code.
  - The byterun/win32.c implementation directly calls `send` or `recv` to operate over a socket, bypassing MSVCRT's `read` and `write` emulation.  Over a regular file, it behaves like the old code.

Regression tests were added for MPR 4466, 5325 and 5578, suggesting that the issue is fixed.
## Limitations
- Only tested with the Mingw port in 64 bits.  Needs testing with MSVC.
- A channel created over a socket can no longer be put in text mode.  The CRLF conversions associated with text mode channels is done by MSVCRT's `read` and `write` emulation.  Now we bypass these emulations for sockets, and I didn't feel (yet) like reimplementing the CRLF conversion.  For the time being, `set_binary_mode` fails if a channel over a socket is switched to text mode.
