### PR TITLE
Report from the Downstream trenches

### DIFF
--- a/asmrun/arm.S
+++ b/asmrun/arm.S
@@ -518,3 +518,6 @@ caml_system__frametable:
         .align  2
         .type   caml_system__frametable, %object
         .size   caml_system__frametable, .-caml_system__frametable
+
+    /* Mark stack as non-executable, PR#4564 */
+        .section .note.GNU-stack,"",%progbits

--- a/asmrun/arm64.S
+++ b/asmrun/arm64.S
@@ -553,3 +553,6 @@ caml_system__frametable:
         .align  3
         .type   caml_system__frametable, %object
         .size   caml_system__frametable, .-caml_system__frametable
+
+    /* Mark stack as non-executable, PR#4564 */
+        .section .note.GNU-stack,"",%progbits

--- a/configure
+++ b/configure
@@ -1687,6 +1687,10 @@ if $no_naked_pointers; then
   echo "#define NO_NAKED_POINTERS" >> m.h
 fi
 
+# Allow user defined C Compiler flags
+bytecccompopts="$bytecccompopts $CFLAGS"
+nativecccompopts="$nativecccompopts $CFLAGS"
+
 # Finish generated files
 
 cclibs="$cclibs $mathlib"

--- a/ocamldoc/odoc_man.ml
+++ b/ocamldoc/odoc_man.ml
@@ -864,14 +864,13 @@ class man =
     (** Generate the man page for the given class.*)
     method generate_for_class cl =
       Odoc_info.reset_type_names () ;
-      let date = Unix.time () in
       let file = self#file_name cl.cl_name in
       try
         let chanout = self#open_out file in
         let b = new_buf () in
         bs b (".TH \""^cl.cl_name^"\" ");
         bs b !man_section ;
-        bs b (" "^(Odoc_misc.string_of_date ~hour: false date)^" ");
+        bs b (" source: "^Odoc_misc.current_date^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
 
@@ -923,14 +922,13 @@ class man =
     (** Generate the man page for the given class type.*)
     method generate_for_class_type ct =
       Odoc_info.reset_type_names () ;
-      let date = Unix.time () in
       let file = self#file_name ct.clt_name in
       try
         let chanout = self#open_out file in
         let b = new_buf () in
         bs b (".TH \""^ct.clt_name^"\" ");
         bs b !man_section ;
-        bs b (" "^(Odoc_misc.string_of_date ~hour: false date)^" ");
+        bs b (" source: "^Odoc_misc.current_date^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
 
@@ -1016,14 +1014,13 @@ class man =
     (** Generate the man file for the given module type.
        @raise Failure if an error occurs.*)
     method generate_for_module_type mt =
-      let date = Unix.time () in
       let file = self#file_name mt.mt_name in
       try
         let chanout = self#open_out file in
         let b = new_buf () in
         bs b (".TH \""^mt.mt_name^"\" ");
         bs b !man_section ;
-        bs b (" "^(Odoc_misc.string_of_date ~hour: false date)^" ");
+        bs b (" source: "^Odoc_misc.current_date^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
 
@@ -1099,14 +1096,13 @@ class man =
     (** Generate the man file for the given module.
        @raise Failure if an error occurs.*)
     method generate_for_module m =
-      let date = Unix.time () in
       let file = self#file_name m.m_name in
       try
         let chanout = self#open_out file in
         let b = new_buf () in
         bs b (".TH \""^m.m_name^"\" ");
         bs b !man_section ;
-        bs b (" "^(Odoc_misc.string_of_date ~hour: false date)^" ");
+        bs b (" source: "^Odoc_misc.current_date^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
 
@@ -1206,14 +1202,13 @@ class man =
           | Res_const (_,f) -> f.vc_name
          )
      in
-     let date = Unix.time () in
       let file = self#file_name name in
       try
         let chanout = self#open_out file in
         let b = new_buf () in
         bs b (".TH \""^name^"\" ");
         bs b !man_section ;
-        bs b (" "^(Odoc_misc.string_of_date ~hour: false date)^" ");
+        bs b (" source: "^Odoc_misc.current_date^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
         bs b ".SH NAME\n";

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -223,9 +223,9 @@ let apply_opt f v_opt =
     None -> None
   | Some v -> Some (f v)
 
-let string_of_date ?(hour=true) d =
+let string_of_date ?(absolute=false) ?(hour=true) d =
   let add_0 s = if String.length s < 2 then "0"^s else s in
-  let t = Unix.localtime d in
+  let t = (if absolute then Unix.gmtime else Unix.localtime) d in
   (string_of_int (t.Unix.tm_year + 1900))^"-"^
   (add_0 (string_of_int (t.Unix.tm_mon + 1)))^"-"^
   (add_0 (string_of_int t.Unix.tm_mday))^
@@ -237,6 +237,14 @@ let string_of_date ?(hour=true) d =
    else
      ""
   )
+
+let current_date =
+  let time =
+    try
+      float_of_string (Sys.getenv "SOURCE_DATE_EPOCH")
+    with
+      Not_found -> Unix.time ()
+  in string_of_date ~absolute: true ~hour: false time
 
 
 let rec text_list_concat sep l =

--- a/ocamldoc/odoc_misc.mli
+++ b/ocamldoc/odoc_misc.mli
@@ -62,7 +62,12 @@ val apply_opt : ('a -> 'b) -> 'a option -> 'b option
 
 (** Return a string representing a date given as a number of seconds
    since 1970. The hour is optionnaly displayed. *)
-val string_of_date : ?hour:bool -> float -> string
+val string_of_date : ?absolute:bool -> ?hour:bool -> float -> string
+
+(* Value returned by string_of_date for current time.
+ * Uses environment variable SOURCE_DATE_EPOCH if set; falls back to
+ * current timestamp otherwise. *)
+val current_date : string
 
 (** Return the first sentence (until the first dot) of a text.
    Don't stop in the middle of [Code], [Verbatim], [List], [Lnum],


### PR DESCRIPTION
I recently had a look at some downstream patches, namely those of Fedora and Debian, which are available at:
- https://git.fedorahosted.org/cgit/fedora-ocaml.git/
- http://anonscm.debian.org/cgit/pkg-ocaml-maint/packages/ocaml.git

(These are the only two downstream distributions of 4.02 with significant patchsets I know of, more URLs are welcome. OpenBSD seems to be packaging 4.01 for now ( http://ports.su/lang/ocaml ), with a single patch that was already merged upstream.)

The present PR is an aggregation the patches that I feel confident can be merged (low regression risk and potentially useful feature).

In a second section I will also list patches that I haven't included, but on which I would be interested in some feedback.
## Included in this PR
#### Marking stacks as non-executable

Fedora integrates since 2008 patches to mark the stack as non-executable on arm and power:
- https://git.fedorahosted.org/cgit/fedora-ocaml.git/commit/?h=fedora-24-4.02&id=e3a29e8c9e85c5d1a4dc28f2ab746dae57c2636b
- https://git.fedorahosted.org/cgit/fedora-ocaml.git/commit/?h=fedora-24-4.02&id=e6b37c1b0c9ee724ae81b74a84e133a75ed9e3a3

They have been submitted upstream in 2008, together with a similar feature for x86(-64), and at the time Xavier decided to be prudent and only merge the x86 part. Given the time they had for testing among Fedora user, they should be safe to integrate now.

This PR contains the ARM change only. The PowerPC backend(s) in trunk are fairly different from 4.02.3, and the [Fedora patch](https://git.fedorahosted.org/cgit/fedora-ocaml.git/commit/?h=fedora-24-4.02&id=e6b37c1b0c9ee724ae81b74a84e133a75ed9e3a3) does not apply anymore. In fact I wonder if [this stack declaration](https://github.com/ocaml/ocaml/blob/6cd8656249ae21180aa7162b1bcb372e6ae8727c/asmcomp/power/emit.mlp#L1219) in the current backend doesn't already implement this -- the `: .previous` bit in the Fedora patches is absent upstream, does it change anything?
#### configure: include user-defined $CFLAGS in C compiler flags.

https://git.fedorahosted.org/cgit/fedora-ocaml.git/commit/?h=fedora-24-4.02&id=613c9273f4cd73eb6e6750d8be29d7fa7f5a68c9

The configure code affected by this patch has changed significantly due to @xavierleroy 's rewrite in #226 , but I think the feature still makes sense. A double check that the rebased patch also still does would be welcome.
#### Enable ocamldoc to build reproducible manpages

http://anonscm.debian.org/cgit/pkg-ocaml-maint/packages/ocaml.git/tree/debian/patches/0010-Enable-ocamldoc-to-build-reproducible-manpages.patch?id=0f93e9ee91dfa37f2e6209c306fe8f2dbc46e540

I have already proposed this slightly more ambitious patch as an independent pull request ( #321 ); given the absence of reaction, I conclude that people don't care. I would like to merge it. The risk of regression is very low and I like the "reproducible" work.
## Not in this PR, feedback is welcome
#### Pass --no-relax to ld on alpha

http://anonscm.debian.org/cgit/pkg-ocaml-maint/packages/ocaml.git/tree/debian/patches/0001-Pass-no-relax-to-ld-on-alpha.patch?id=0f93e9ee91dfa37f2e6209c306fe8f2dbc46e540

I would trust Debian testing on alpha machines, but I don't know how to rebase this patch (the alpha configure options have changed too much).
#### disabling RPATH

It seems that nobody likes RPATH. I don't know anything about it, but maybe if two distributors independently decided to disable it, it is a sign that we could get rid of it upstream as well?
- https://git.fedorahosted.org/cgit/fedora-ocaml.git/commit/?h=fedora-24-4.02&id=73db2ab33221880d2399b2e98038219d798861ff
- http://anonscm.debian.org/cgit/pkg-ocaml-maint/packages/ocaml.git/tree/debian/patches/0003-Don-t-use-rpath.patch?id=0f93e9ee91dfa37f2e6209c306fe8f2dbc46e540
#### -Wl filtered from linkflags

Debian filters linkflags passed to ld by ocamlopt -pack and -output-obj to remove the "-Wl," parts, which are only used when ocamlopt calls gcc.
- http://anonscm.debian.org/cgit/pkg-ocaml-maint/packages/ocaml.git/tree/debian/patches/0002-Call-ld-with-proper-flags.patch?id=0f93e9ee91dfa37f2e6209c306fe8f2dbc46e540
