### PR TITLE
Ambiguous var orpat

### DIFF
--- a/Changes
+++ b/Changes
@@ -93,6 +93,8 @@ Compilers:
   review by Xavier Leroy)
 - PR#7026, GPR#288: remove write barrier for polymorphic variants without arguments
   (Simon Cruanes)
+- PR#7031: new warning, ambiguous guarded or-patterns (Luc Maranget,
+  Gabriel Scherer, report by Martin Clochard and Claude Marché).
 - PR#7067: Performance regression in the native compiler for long
   nested structures (Alain Frisch, report by Daniel Bünzli, review
   by Jacques Garrigue)

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -166,12 +166,27 @@ let not_ambiguous__constructor = function
 ;;
 
 
-type tt = Z of int | Y of int * int  | X of tt * tt
+type amoi = Z of int | Y of int * int  | X of amoi * amoi
 ;;
 
-let ambiguous a = match a with
+let ambiguous__amoi a = match a with
 | X (Z x,Y (y,0))
 | X (Z y,Y (x,_))
  when x+y > 0 -> 0
 | X _|Y _|Z _ -> 1
+;;
+
+module type S = sig val b : bool end
+;;
+
+let ambiguous__module_variable x b =  match x with
+  | (module M:S),_,(1,_)
+  | _,(module M:S),(_,1) when M.b && b -> 1
+  | _ -> 2
+;;
+
+let not_ambiguous__module_variable x b =  match x with
+  | (module M:S),_,(1,_)
+  | _,(module M:S),(_,1) when b -> 1
+  | _ -> 2
 ;;

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -1,0 +1,177 @@
+let () = print_endline "\n\
+  <----------------------------------------------------------------------\n\
+  To check the result file for this test, it suffices to look for \"val\"\n\
+  lines corresponding to toplevel answers. If they start with\n\
+  \n\
+  \    val ambiguous_...\n\
+  \n\
+  then just above there should be the warning text for Warning 57\n\
+  (we try to avoid all other warnings). If they start with\n\
+  \n\
+  \   val not_ambiguous_...\n\
+  \n\
+  then just above there should be *no* warning text.\n\
+  ---------------------------------------------------------------------->\n\
+";;
+
+
+type expr = Val of int | Rest;;
+
+let ambiguous_typical_example = function
+  | ((Val x, _) | (_, Val x)) when x < 0 -> ()
+  | (_, Rest) -> ()
+  | (_, Val x) ->
+      (* the reader might expect *)
+      assert (x >= 0);
+      (* to hold here, but it is wrong! *)
+      ()
+;;
+
+let () = print_endline "Note that an Assert_failure is expected just below.";;
+let fails = ambiguous_typical_example (Val 2, Val (-1))
+;;
+
+let not_ambiguous__no_orpat = function
+  | Some x when x > 0 -> ()
+  | Some _ -> ()
+  | None -> ()
+;;
+
+let not_ambiguous__no_guard = function
+  | `A -> ()
+  | (`B | `C) -> ()
+;;
+
+let not_ambiguous__no_patvar_in_guard b = function
+  | (`B x | `C x) when b -> ignore x
+  | _ -> ()
+;;
+
+let not_ambiguous__disjoint_cases = function
+  | (`B x | `C x) when x -> ()
+  | _ -> ()
+;;
+
+(* the curious (..., _, Some _) | (..., Some _, _) device used in
+   those tests serves to avoid warning 12 (this sub-pattern
+   is unused), by making sure that, even if the two sides of the
+   disjunction overlap, none is fully included in the other. *)
+let not_ambiguous__prefix_variables = function
+  | (`B (x, _, Some y) | `B (x, Some y, _)) when x -> ignore y
+  | _ -> ()
+;;
+
+let ambiguous__y = function
+  | (`B (x, _, Some y) | `B (x, Some y, _)) when y -> ignore x
+  | _ -> ()
+;;
+
+(* it should be understood that the ambiguity warning only protects
+     (p | q) when guard -> ...
+   it will never warn on
+     (p | q) -> if guard ...
+   This is not a limitation. The point is that people have an
+   intuitive understanding of [(p | q) when guard -> ...] that differs
+   from the reality, while there is no such issue with
+   [(p | q) -> if guard ...].
+*)
+let not_ambiguous__rhs_not_protected = function
+  | (`B (x, _, Some y) | `B (x, Some y, _)) -> if y then ignore x else ()
+  | _ -> ()
+;;
+
+let ambiguous__x_y = function
+  | (`B (x, _, Some y) | `B (x, Some y, _)) when x < y -> ()
+  | _ -> ()
+;;
+
+let ambiguous__x_y_z = function
+  | (`B (x, z, Some y) | `B (x, Some y, z)) when x < y || Some x = z -> ()
+  | _ -> ()
+;;
+
+let not_ambiguous__disjoint_in_depth = function
+  | `A (`B x | `C x) when x -> ()
+  | _ -> ()
+;;
+
+let not_ambiguous__prefix_variables_in_depth = function
+  | `A (`B (x, `C1) | `B (x, `C2)) when x -> ()
+  | _ -> ()
+;;
+
+let ambiguous__in_depth = function
+  | `A (`B (Some x, _) | `B (_, Some x)) when x -> ()
+  | _ -> ()
+;;
+
+let not_ambiguous__several_orpats = function
+  | `A ((`B (x, Some _, _) | `B (x, _, Some _)),
+        (`C (y, Some _, _) | `C (y, _, Some _)),
+        (`D1 (_, z, Some _, _) | `D2 (_, z, _, Some _))) when x < y && x < z -> ()
+  | _ -> ()
+;;
+
+let ambiguous__first_orpat = function
+  | `A ((`B (Some x, _) | `B (_, Some x)),
+        (`C (Some y, Some _, _) | `C (Some y, _, Some _))) when x < y -> ()
+  | _ -> ()
+;;
+
+let ambiguous__second_orpat = function
+  | `A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
+        (`C (Some y, _) | `C (_, Some y))) when x < y -> ()
+  | _ -> ()
+;;
+
+(* check that common prefixes work as expected *)
+let not_ambiguous__pairs = function
+  | (x, Some _, _) | (x, _, Some _) when x -> ()
+  | _ -> ()
+;;
+
+let not_ambiguous__vars =
+  begin[@warning "-12"] function
+  | (x | x) when x -> ()
+  | _ -> ()
+  end
+;;
+
+let not_ambiguous__as p = function
+  | (([], _) as x | ((_, []) as x)) when p x -> ()
+  | _ -> ()
+;;
+
+let not_ambiguous__as_var p = function
+  | (([], _) as x | x) when p x -> ()
+  | _ -> ()
+;;
+
+let not_ambiguous__var_as p = function
+  | (x, Some _, _) | (([], _) as x, _, Some _) when p x -> ()
+  | _ -> ()
+;;
+
+let not_ambiguous__lazy = function
+  | (([], _), lazy x) | ((_, []), lazy x) when x -> ()
+  | _ -> ()
+
+;;
+
+type t = A of int * int option * int option | B;;
+
+let not_ambiguous__constructor = function
+  | A (x, Some _, _) | A (x, _, Some _) when x > 0 -> ()
+  | A _ | B -> ()
+;;
+
+
+type tt = Z of int | Y of int * int  | X of tt * tt
+;;
+
+let ambiguous a = match a with
+| X (Z x,Y (y,0))
+| X (Z y,Y (x,_))
+ when x+y > 0 -> 0
+| X _|Y _|Z _ -> 1
+;;

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
@@ -93,10 +93,19 @@ val ambiguous__second_orpat :
 #           val not_ambiguous__lazy : ('a list * 'b list) * bool lazy_t -> unit = <fun>
 #   type t = A of int * int option * int option | B
 #         val not_ambiguous__constructor : t -> unit = <fun>
-#       type tt = Z of int | Y of int * int | X of tt * tt
-#             Characters 34-67:
+#       type amoi = Z of int | Y of int * int | X of amoi * amoi
+#             Characters 40-73:
   ..X (Z x,Y (y,0))
   | X (Z y,Y (x,_))
 Warning 57: Ambiguous guarded pattern, variables x,y may match different or-pattern arguments
-val ambiguous : tt -> int = <fun>
+val ambiguous__amoi : amoi -> int = <fun>
+#     module type S = sig val b : bool end
+#           Characters 56-101:
+  ....(module M:S),_,(1,_)
+    | _,(module M:S),(_,1)...................
+Warning 57: Ambiguous guarded pattern, variable M may match different or-pattern arguments
+val ambiguous__module_variable :
+  (module S) * (module S) * (int * int) -> bool -> int = <fun>
+#           val not_ambiguous__module_variable :
+  (module S) * (module S) * (int * int) -> bool -> int = <fun>
 # 

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
@@ -1,0 +1,102 @@
+
+#                             
+<----------------------------------------------------------------------
+To check the result file for this test, it suffices to look for "val"
+lines corresponding to toplevel answers. If they start with
+
+    val ambiguous_...
+
+then just above there should be the warning text for Warning 57
+(we try to avoid all other warnings). If they start with
+
+   val not_ambiguous_...
+
+then just above there should be *no* warning text.
+---------------------------------------------------------------------->
+
+#     type expr = Val of int | Rest
+#                   Characters 46-71:
+    | ((Val x, _) | (_, Val x)) when x < 0 -> ()
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous guarded pattern, variable x may match different or-pattern arguments
+val ambiguous_typical_example : expr * expr -> unit = <fun>
+#   Note that an Assert_failure is expected just below.
+#   Exception: Assert_failure ("//toplevel//", 23, 6).
+#           val not_ambiguous__no_orpat : int option -> unit = <fun>
+#         val not_ambiguous__no_guard : [< `A | `B | `C ] -> unit = <fun>
+#         val not_ambiguous__no_patvar_in_guard :
+  bool -> [> `B of 'a | `C of 'a ] -> unit = <fun>
+#         val not_ambiguous__disjoint_cases : [> `B of bool | `C of bool ] -> unit =
+  <fun>
+#   * * *         val not_ambiguous__prefix_variables :
+  [> `B of bool * 'a option * 'a option ] -> unit = <fun>
+#         Characters 33-72:
+    | (`B (x, _, Some y) | `B (x, Some y, _)) when y -> ignore x
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous guarded pattern, variable y may match different or-pattern arguments
+val ambiguous__y : [> `B of 'a * bool option * bool option ] -> unit = <fun>
+#   * * * * * * * *         val not_ambiguous__rhs_not_protected :
+  [> `B of 'a * bool option * bool option ] -> unit = <fun>
+#         Characters 35-74:
+    | (`B (x, _, Some y) | `B (x, Some y, _)) when x < y -> ()
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous guarded pattern, variable y may match different or-pattern arguments
+val ambiguous__x_y : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
+#         Characters 37-76:
+    | (`B (x, z, Some y) | `B (x, Some y, z)) when x < y || Some x = z -> ()
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous guarded pattern, variables y,z may match different or-pattern arguments
+val ambiguous__x_y_z : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
+#         val not_ambiguous__disjoint_in_depth :
+  [> `A of [> `B of bool | `C of bool ] ] -> unit = <fun>
+#         val not_ambiguous__prefix_variables_in_depth :
+  [> `A of [> `B of bool * [> `C1 | `C2 ] ] ] -> unit = <fun>
+#         Characters 40-76:
+    | `A (`B (Some x, _) | `B (_, Some x)) when x -> ()
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous guarded pattern, variable x may match different or-pattern arguments
+val ambiguous__in_depth :
+  [> `A of [> `B of bool option * bool option ] ] -> unit = <fun>
+#             val not_ambiguous__several_orpats :
+  [> `A of
+       [> `B of 'a * 'b option * 'c option ] *
+       [> `C of 'a * 'd option * 'e option ] *
+       [> `D1 of 'f * 'a * 'g option * 'h | `D2 of 'i * 'a * 'j * 'k option ] ] ->
+  unit = <fun>
+#           Characters 43-140:
+  ....`A ((`B (Some x, _) | `B (_, Some x)),
+          (`C (Some y, Some _, _) | `C (Some y, _, Some _))).................
+Warning 57: Ambiguous guarded pattern, variable x may match different or-pattern arguments
+val ambiguous__first_orpat :
+  [> `A of
+       [> `B of 'a option * 'a option ] *
+       [> `C of 'a option * 'b option * 'c option ] ] ->
+  unit = <fun>
+#           Characters 44-141:
+  ....`A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
+          (`C (Some y, _) | `C (_, Some y))).................
+Warning 57: Ambiguous guarded pattern, variable y may match different or-pattern arguments
+val ambiguous__second_orpat :
+  [> `A of
+       [> `B of 'a option * 'b option * 'c option ] *
+       [> `C of 'a option * 'a option ] ] ->
+  unit = <fun>
+#           val not_ambiguous__pairs : bool * 'a option * 'b option -> unit = <fun>
+#             val not_ambiguous__vars : bool -> unit = <fun>
+#         val not_ambiguous__as :
+  ('a list * 'b list -> bool) -> 'a list * 'b list -> unit = <fun>
+#         val not_ambiguous__as_var : ('a list * 'b -> bool) -> 'a list * 'b -> unit =
+  <fun>
+#         val not_ambiguous__var_as :
+  ('a list * 'b -> bool) -> ('a list * 'b) * 'c option * 'd option -> unit =
+  <fun>
+#           val not_ambiguous__lazy : ('a list * 'b list) * bool lazy_t -> unit = <fun>
+#   type t = A of int * int option * int option | B
+#         val not_ambiguous__constructor : t -> unit = <fun>
+#       type tt = Z of int | Y of int * int | X of tt * tt
+#             Characters 34-67:
+  ..X (Z x,Y (y,0))
+  | X (Z y,Y (x,_))
+Warning 57: Ambiguous guarded pattern, variables x,y may match different or-pattern arguments
+val ambiguous : tt -> int = <fun>
+# 

--- a/typing/ident.ml
+++ b/typing/ident.ml
@@ -52,6 +52,8 @@ let same i1 i2 = i1 = i2
        then i1.stamp = i2.stamp
        else i2.stamp = 0 && i1.name = i2.name *)
 
+let compare i1 i2 = Pervasives.compare i1 i2
+
 let binding_time i = i.stamp
 
 let current_time() = !currentstamp

--- a/typing/ident.mli
+++ b/typing/ident.mli
@@ -36,6 +36,9 @@ val hide: t -> t
            When put in a 'a tbl, this identifier can only be looked
            up by name. *)
 
+val compare : t -> t -> int
+(* Compare identifiers by binding location *)
+
 val make_global: t -> unit
 val global: t -> bool
 val is_predef_exn: t -> bool

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -298,7 +298,7 @@ module P = struct
 end
 module PathSet = Set.Make (P)
 module PathMap = Map.Make (P)
-module IdentSet = Set.Make (struct type t = Ident.t let compare = compare end)
+module IdentSet = Set.Make (Ident)
 
 let rec get_prefixes = function
     Pident _ -> PathSet.empty

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -73,3 +73,6 @@ val check_unused:
 (* Irrefutability tests *)
 val irrefutable : pattern -> bool
 val fluid : pattern -> bool
+
+(* Ambiguous bindings *)
+val check_ambiguous_bindings : case list -> unit

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -48,6 +48,14 @@ let rec head = function
   | Pdot(p, s, pos) -> head p
   | Papply(p1, p2) -> assert false
 
+let heads p =
+  let rec heads p acc = match p with
+    | Pident id -> id :: acc
+    | Pdot (p, _s, _pos) -> heads p acc
+    | Papply(p1, p2) ->
+        heads p1 (heads p2 acc)
+  in heads p []
+
 let rec last = function
   | Pident id -> Ident.name id
   | Pdot(_, s, _) -> s

--- a/typing/path.mli
+++ b/typing/path.mli
@@ -27,6 +27,8 @@ val name: ?paren:(string -> bool) -> t -> string
     (* [paren] tells whether a path suffix needs parentheses *)
 val head: t -> Ident.t
 
+val heads: t -> Ident.t list
+
 val last: t -> string
 
 type typath =

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1397,7 +1397,9 @@ let explanation unif t3 t4 ppf =
         fprintf ppf "@,@[<hov>This instance of %a is ambiguous:@ %s@]"
           type_expr t'
           "it would escape the scope of its equation"
-  | Tfield (lab, _, _, _), _
+  | Tfield (lab, _, _, _), _ when lab = dummy_method ->
+      fprintf ppf
+        "@,Self type cannot be unified with a closed object type"
   | _, Tfield (lab, _, _, _) when lab = dummy_method ->
       fprintf ppf
         "@,Self type cannot be unified with a closed object type"

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3806,7 +3806,8 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
   let unused_check ty_arg () =
     List.iter (fun (pat, (env, _)) -> check_absent_variant env pat)
       pat_env_list;
-    check_unused ~lev env (instance env ty_arg) cases
+    check_unused ~lev env (instance env ty_arg) cases ;
+    Parmatch.check_ambiguous_bindings cases
   in
   if contains_polyvars || do_init then
     let ty_arg_check =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1278,11 +1278,14 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
       begin match
         if mode = Split_or || mode = Splitting_or then raise Need_backtrack;
         let initial_pattern_variables = !pattern_variables in
+        let initial_module_variables = !module_variables in
         let p1 =
           try Some (type_pat ~mode:Inside_or sp1 expected_ty (fun x -> x))
           with Need_backtrack -> None in
         let p1_variables = !pattern_variables in
+        let p1_module_variables = !module_variables in
         pattern_variables := initial_pattern_variables;
+        module_variables := initial_module_variables;
         let p2 =
           try Some (type_pat ~mode:Inside_or sp2 expected_ty (fun x -> x))
           with Need_backtrack -> None in
@@ -1294,6 +1297,7 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
         let alpha_env =
           enter_orpat_variables loc !env p1_variables p2_variables in
         pattern_variables := p1_variables;
+        module_variables := p1_module_variables;
         { pat_desc = Tpat_or(p1, alpha_pat alpha_env p2, None);
           pat_loc = loc; pat_extra=[];
           pat_type = expected_ty;

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -431,13 +431,14 @@ let message = function
       Printf.sprintf "Inlining impossible in this context: %s" reason
   | Ambiguous_pattern vars ->
       let msg =
-        let vars,last = Misc.split_last (List.sort String.compare vars) in
+        let vars = List.sort String.compare vars in
         match vars with
-        | [] -> "variable " ^ last
+        | [] -> assert false
+        | [x] -> "variable " ^ x
         | _::_ ->
-            "variables" ^
-            String.concat "," vars ^ " and " ^ last in
-      Printf.sprintf "Ambiguous bindings by pattern on %s" msg
+            "variables " ^ String.concat "," vars in
+      Printf.sprintf
+        "Ambiguous guarded pattern, %s may match different or-pattern arguments" msg
 ;;
 
 let nerrors = ref 0;;

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -74,6 +74,7 @@ type t =
   | Duplicated_attribute of string          (* 54 *)
   | Inlining_impossible of string           (* 55 *)
   | Unreachable_case                        (* 56 *)
+  | Ambiguous_pattern of string list        (* 57 *)
 ;;
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
@@ -139,9 +140,10 @@ let number = function
   | Duplicated_attribute _ -> 54
   | Inlining_impossible _ -> 55
   | Unreachable_case -> 56
+  | Ambiguous_pattern _ -> 57
 ;;
 
-let last_warning_number = 56
+let last_warning_number = 57
 ;;
 (* Must be the max number returned by the [number] function. *)
 
@@ -427,6 +429,15 @@ let message = function
       Printf.sprintf "the %S attribute is used more than once on this expression" attr_name
   | Inlining_impossible reason ->
       Printf.sprintf "Inlining impossible in this context: %s" reason
+  | Ambiguous_pattern vars ->
+      let msg =
+        let vars,last = Misc.split_last (List.sort String.compare vars) in
+        match vars with
+        | [] -> "variable " ^ last
+        | _::_ ->
+            "variables" ^
+            String.concat "," vars ^ " and " ^ last in
+      Printf.sprintf "Ambiguous bindings by pattern on %s" msg
 ;;
 
 let nerrors = ref 0;;
@@ -520,7 +531,8 @@ let descriptions =
    53, "Attribute cannot appear in this context";
    54, "Attribute used more than once on an expression";
    55, "Inlining impossible";
-   56, "Unreachable case in a pattern-matching (based on type information)."
+   56, "Unreachable case in a pattern-matching (based on type information).";
+   57, "Ambiguous binding by pattern.";
   ]
 ;;
 

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -69,6 +69,7 @@ type t =
   | Duplicated_attribute of string          (* 54 *)
   | Inlining_impossible of string           (* 55 *)
   | Unreachable_case                        (* 56 *)
+  | Ambiguous_pattern of string list        (* 57 *)
 ;;
 
 val parse_options : bool -> string -> unit;;


### PR DESCRIPTION
# A new warning related to pattern matching.

In some occasion the combination of or-patterns and when guards may lead to bugs due
to (wrong) expected semantics.
## Example

Consider the simple type of expressions
`
type exp = Const of int | Var of string | Mult of exp * exp
;;
`
Neutral element is checked by the following function
`
let is_neutral = function
  | 1 -> true
  | _ -> false
;;
`
And, here we go, this fuction is an _intelligent_ constuctor for mult:

```
let mult x y = match x,y with
| (Const i,z)
| (z,Const i)
  when is_neutral i -> z
| _,_ -> Mult (x,y)
;;
```

One may think that `mult (Const 2) (Const 1)` will yield `Const 2`. This is not the case as, according to semantics:
-  The value (Const 2,Const 1) is an instance of the first pattern (Const i,z) and thus the variable `i` is bound to the constant `2`.
- The guard `is_neutral 2` yields false.
- And thus `mult (Const 2) (Const 1)` yields `Mult (Const 2) (Const 1)`.

The new warning detects such a situation:
`
File "t.ml", line 10, characters 2-27:
Warning 57: Ambiguous guarded pattern, variable i may match different or-pattern arguments
`
## Semantics

The new warning lists variables that occur free in a `when` guard and that may be bound to different sub-parts of the matched value by different arguments of or-patterns.
## Significance

The new warning is useful for advanced users and is believed not to occur too frequently. It may draw attention on bugs. It is enabled by default.
## Potential enhancements

Provide a and example of a value that can be matched ambiguously.
Restrict warning to values that are not matched by higher priority patterns as in:

```
let mult x y = match x,y with
| (Const i,Const j) -> Const (i*j)
| (Const i,z)
| (z,Const i)
  when is_neutral i -> z
| _,_ -> Mult (x,y)
```
