### PR TITLE
User-defined indexing operators: bigarray deprecated warning

### DIFF
--- a/Changes
+++ b/Changes
@@ -21,14 +21,16 @@ Language features:
   (Gabriel Scherer)
 - GPR#42: short functor type syntax: "S -> T" for "functor (_ : S) -> T"
   (Leo White)
-* GPR#69: Custom index operators: ( .() ), ( .[] ), ( .{} ) etc.
+- GPR#69: Custom index operators: ( .() ), ( .[] ), ( .{} ) etc.
   (Florian Angeletti)
   The syntax "foo.(bar) <- baz" now desugars into "( .()<- ) foo bar baz"; this
   should allow user to define their own notations by overriding.
   The bigarray notations ( .{} ), ( .{,} ) etc. are defined in the Bigarray
-  module, which means that the foo.{bar,baz} syntactic sugar is only available
-  when the Bigarray module is opened; this can break existing programs,
-  which should be fixed by opening the Bigarray module.
+  module, which means that the foo.{bar,baz} syntactic sugar should only be
+  available when the Bigarray is opened. To avoid breaking existing program,
+  the compiler emits, for now, a deprecated warning when these Bigarray
+  operators are used implicitly. Opening either the Bigarray.Operators or
+  Bigarray modules fixes this compatibility problem.
 - GPR#88: allow field punning in object copying expressions:
     {< x; y; >} is sugar for {< x = x; y = y; >}
   (Jeremy Yallop)

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1257,10 +1257,11 @@ to implement dynamic types.
 
 \section{Syntax for Bigarray access}\label{s:bigarray-access}
 
-(Introduced in Objective Caml 3.00, deprecated in 4.03)
+(Introduced in Objective Caml 3.00, deprecated in \ocamlversion)
 
-This extension has been superseded by the customizable index operators extension~\ref{s:index-operators}.
-Some source compatibility problems are documented in~\ref{s:bigarray-indexop-compatibility}.
+This extension has been superseded by the customizable index operators
+extension~\ref{s:index-operators}. Some source compatibility problems that
+can trigger a deprecated warning are documented in~\ref{s:bigarray-indexop-compatibility}.
 
 \section{Attributes}\label{s:attributes}
 
@@ -1931,7 +1932,8 @@ let x = v.{i} (* vector access *)
 let m = mat.{i,j} (* matrix access *)
 \end{verbatim}
 
-Another example, the "Bigarray"[\moduleref{Bigarray}] library defines these operators as
+Another example, the "Bigarray"[\moduleref{Bigarray}] library defines
+these operators in the "Operators" submodule as
 %
 \begin{tableau}{ll}{operator}{function}
 \entree{ "( .{} )"       } {"Array1.get"}
@@ -1945,18 +1947,25 @@ Another example, the "Bigarray"[\moduleref{Bigarray}] library defines these oper
 \end{tableau}
 %
 With these definitions, it is then possible to use the short syntax
-@bigarray'.{'index'}'@ with bigarray values by opening the "Bigarray"
-module in scope.
+@bigarray'.{'index'}'@ with bigarray values by opening the
+"Bigarray.Operators" submodule in scope. Since the "Operators" submodule
+is included inside the "Bigarray" module, opening the "Bigarray" module
+is another option to bring this operators in scope.
 
 \subsection{Backward compatibility warning for the "Bigarray" library} \label{s:bigarray-indexop-compatibility}
 
 One of the reasons behind the existence of the 6 special
-@"( .{"\ldots"} )"@ operators is to preserve backward compatibility
-with the "Bigarray" library special syntax. However, this extension
-\emph{does break} partially source compatibility with the bigarray
-syntax extension: before Ocaml 4.03, it was possible to use the
-@bigarray'.{'index'}'@ syntax without opening the "Bigarray"
-module. This usage is no longer possible since the @"(.{"\ldots"})"@
-index operators are now defined inside the "Bigarray" module. This
-problem can be fixed by opening the "Bigarray" module (or by bringing
-in scope the index operators defined in the "Bigarray" module).
+@"(" ".{"\ldots"}" ")"@ operators is to preserve backward compatibility
+with the "Bigarray" library special syntax. However, this backward
+compatibility is not perfect. On the one hand, the new extension should
+require to explicitly bring in scope the "Bigarray"
+@"(" ".{"\ldots"}" ")"@ operator before using them. On the other hand,
+with the deprecated bigarray syntax extension, these operators always
+implicitly referred to the "Bigarray" module. In order to bridge the gap
+between these two different behaviors, implicit uses of the
+@"Bigarray.(" ".{"\ldots"}" ")"@ operators are still allowed but emit a
+deprecated warning. This warning can be avoided by explicitly bringing
+in scope the corresponding @"Bigarray.(" ".{"\ldots"}" ")"@ operator;
+for instance by opening the "Bigarray.Operators" module or the
+"Bigarray" module. Note that this warning might turn in a full-fledged
+error in future versions.

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1769,9 +1769,9 @@ used directly in vanilla Ocaml. However, "-ppx" rewriters and other
 external tools can use this parser leniency to extend the language
 with new extension specific "#"-operators.
 
-\section{Customizable index operators} \label{s:index-operators}
+\section{User-defined index operators} \label{s:index-operators}
 
-( Introduced in OCaml 4.03 )
+( Introduced in OCaml \ocamlversion )
 
 \begin{syntax}
 expr:
@@ -1803,7 +1803,7 @@ well-know syntax
                 & acces                 & assignment                        \\ \hline
 array           & @expr_a".("expr_i")"@ & @expr_a".("expr_i")" "<-" expr_v@ \\
 string or bytes & @expr_s".["expr_i"]"@ & @expr_s".["expr_i"]" "<-" expr_v@ \\
-bigarray & @expr_s".{"expr_i"}"@ & @expr_s".{"expr_i"}" "<-" expr_v@ \\ \hline
+bigarray        & @expr_s".{"expr_i"}"@ & @expr_s".{"expr_i"}" "<-" expr_v@ \\ \hline
 \end{tabular}\end{center}
 
 This extension generalizes this standard syntax by associating these
@@ -1821,11 +1821,11 @@ The concrete syntaxes "array.(index)",\dots, "bigarray.{index}<-value"
 are then redefined as syntactic sugar for these new operators
 %
 \begin{center}\begin{tabular}{lll} \hline
-              & concrete syntax                   & translation                            \\ \hline
-array-like    & @expr_a'.('expr_i')'@             & @'(' '.()' ')' expr_a expr_i@          \\
-              & @expr_a'.('expr_i')' '<-' expr_v@ & @'(' '.()<-' ')' expr_a expr_i expr_v@ \\ \hline
-string-like   & @expr_s'.['expr_i']'@             & @'(' '.[]' ')' expr_s expr_i@          \\
-              & @expr_s'.['expr_i']' '<-' expr_v@ & @'(' '.[]<-' ')' expr_s expr_i expr_v@ \\ \hline
+              & concrete syntax                     & translation                              \\ \hline
+array-like    & @expr_a'.('expr_i')'@               & @'(' '.()' ')' expr_a expr_i@            \\
+              & @expr_a'.('expr_i')' '<-' expr_v@   & @'(' '.()<-' ')' expr_a expr_i expr_v@   \\ \hline
+string-like   & @expr_s'.['expr_i']'@               & @'(' '.[]' ')' expr_s expr_i@            \\
+              & @expr_s'.['expr_i']' '<-' expr_v@   & @'(' '.[]<-' ')' expr_s expr_i expr_v@   \\ \hline
 bigarray-like & @expr_s'.{'expr_i^*'}'@             & @'(' '.{}' ')' expr_s expr_i^*@          \\
               & @expr_s'.{'expr_i^*'}' '<-' expr_v@ & @'(' '.{}<-' ')' expr_s expr_i^* expr_v@ \\ \hline
 \end{tabular}\end{center}
@@ -1910,7 +1910,7 @@ dimension $2$   & @expr_a'.{'i_1,i_2'}'@                     & @'(.{,})'   expr_
                 & @expr_a'.{'i_1,i_2} '<-' expr_v@           & @'(.{,}<-)' expr_a i_1 i_2 expr_v@                       \\ \hline
 dimension $3$   & @expr_a'.{'i_1,i_2,i_3'}'@                 & @'(.{,,})'   expr_a i_1 i_2 i_3@                         \\
                 & @expr_a'.{'i_1,i_2,i_3'}' '<-' expr_v@     & @'(.{,,}<-)' expr_a i_1 i_2 i_3 expr_v@                  \\ \hline
-dimension $n>3$ & @expr_a'.{'i_1,\ldots,i_n'}'@              &   @'(.{,..,})'  expr_a '[|'i_1';'\ldots';'i_n'|]'@       \\
+dimension $n>3$ & @expr_a'.{'i_1,\ldots,i_n'}'@              & @'(.{,..,})'  expr_a '[|'i_1';'\ldots';'i_n'|]'@         \\
                 & @expr_a'.{'i_1,\ldots,i_n'}' '<-' expr_v@  & @'(.{,..,}<-)' expr_a '[|'i_1';'\ldots';'i_n'|]' expr_v@ \\ \hline
 \end{tabular}\end{center}
 %

--- a/testsuite/tests/lib-bigarray-warnings/Makefile
+++ b/testsuite/tests/lib-bigarray-warnings/Makefile
@@ -1,0 +1,39 @@
+#########################################################################
+#                                                                       #
+#                                 OCaml                                 #
+#                                                                       #
+#                 Xavier Clerc, SED, INRIA Rocquencourt                 #
+#                                                                       #
+#   Copyright 2010 Institut National de Recherche en Informatique et    #
+#   en Automatique.  All rights reserved.  This file is distributed     #
+#   under the terms of the Q Public License version 1.0.                #
+#                                                                       #
+#########################################################################
+
+BASEDIR=../..
+LIBRARIES=bigarray
+CMA=$(LIBRARIES:=.cma)
+CMXA=$(LIBRARIES:=.cmxa)
+FLAGS=-w A \
+-I $(OTOPDIR)/otherlibs/bigarray
+
+EXECNAME=./program
+
+run-all:
+	@for file in *.ml; do \
+	  printf " ... testing '$$file'"; \
+	  F="`basename $$file .ml`"; \
+	  $(OCAMLC) $(FLAGS) $(CMA) -o $(EXECNAME) $$file 2>$$F.result; \
+	  $(DIFF) $$F.reference $$F.result >/dev/null \
+	  &&  printf " ... ocamlopt testing"; \
+	  $(OCAMLOPT) $(FLAGS) $(CMXA) -o $(EXECNAME) $$file 2>$$F.result; \
+	  $(DIFF) $$F.reference $$F.result >/dev/null \
+	  && echo ": => passed" || echo ": => failed"; \
+	done;
+
+promote: defaultpromote
+
+clean: defaultclean
+	@rm -f *.result $(EXECNAME)
+
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/lib-bigarray-warnings/indexop_deprecated.ml
+++ b/testsuite/tests/lib-bigarray-warnings/indexop_deprecated.ml
@@ -1,0 +1,64 @@
+
+module Defs = struct
+  open Bigarray
+
+  let c_float f = f float32 c_layout
+
+  let a_1 =
+    let a = c_float Array1.create 1 in
+    a.{0} <- 1.;
+    a
+
+  let a_2 =
+    let a = c_float Array2.create 1 1 in
+    a.{0,0} <- 1.;
+    a
+
+  let a_3 =
+    let a = c_float Array3.create 1 1 1 in
+    a.{0,0,0} <- 1.;
+    a
+
+  let a_gen =
+    let a = c_float Genarray.create [|1;1;1;1|] in
+    a.{0,0,0,0} <- 1.;
+    a
+
+end
+open Defs
+
+(* Deprecated use of .{} when they are not in scope *)
+let test =
+    a_1.{0} <- a_1.{0}
+  ; a_2.{0,0} <- a_2.{0,0}
+  ; a_3.{0,0,0} <- a_3.{0,0,0}
+  ; a_gen.{0,0,0,0} <- a_gen.{0,0,0,0}
+
+module Explicit_bigarray = struct
+  open Bigarray
+
+(* Bigarray.{} operators *)
+let test =
+    a_1.{0} <- a_1.{0}
+  ; a_2.{0,0} <- a_2.{0,0}
+  ; a_3.{0,0,0} <- a_3.{0,0,0}
+  ; a_gen.{0,0,0,0} <- a_gen.{0,0,0,0}
+end
+
+module User_defined = struct
+  let ( .{} )   _a _k = ()
+  let ( .{}<- ) _a _k _x = ()
+  let ( .{,} )   _a _k _l = ()
+  let ( .{,}<- ) _a _k _l _x = ()
+  let ( .{,,} )   _a _k _l _m = ()
+  let ( .{,,}<- ) _a _k _l _m _x = ()
+  let ( .{,..,} )   _a _ks = ()
+  let ( .{,..,}<- ) _a _ks _x = ()
+
+(* User defined .{} operators *)
+let test =
+    a_1.{0} <- a_1.{0}
+  ; a_2.{0,0} <- a_2.{0,0}
+  ; a_3.{0,0,0} <- a_3.{0,0,0}
+  ; a_gen.{0,0,0,0} <- a_gen.{0,0,0,0}
+end

--- a/testsuite/tests/lib-bigarray-warnings/indexop_deprecated.reference
+++ b/testsuite/tests/lib-bigarray-warnings/indexop_deprecated.reference
@@ -1,0 +1,16 @@
+File "indexop_deprecated.ml", line 32, characters 4-22:
+Warning 3: deprecated: implicit use of Bigarray.( .{}<- ) when it was not in scope. To avoid this warning, you can open either the Bigarray.Operators or Bigarray module.
+File "indexop_deprecated.ml", line 32, characters 15-22:
+Warning 3: deprecated: implicit use of Bigarray.( .{} ) when it was not in scope. To avoid this warning, you can open either the Bigarray.Operators or Bigarray module.
+File "indexop_deprecated.ml", line 33, characters 4-26:
+Warning 3: deprecated: implicit use of Bigarray.( .{,}<- ) when it was not in scope. To avoid this warning, you can open either the Bigarray.Operators or Bigarray module.
+File "indexop_deprecated.ml", line 33, characters 17-26:
+Warning 3: deprecated: implicit use of Bigarray.( .{,} ) when it was not in scope. To avoid this warning, you can open either the Bigarray.Operators or Bigarray module.
+File "indexop_deprecated.ml", line 34, characters 4-30:
+Warning 3: deprecated: implicit use of Bigarray.( .{,,}<- ) when it was not in scope. To avoid this warning, you can open either the Bigarray.Operators or Bigarray module.
+File "indexop_deprecated.ml", line 34, characters 19-30:
+Warning 3: deprecated: implicit use of Bigarray.( .{,,} ) when it was not in scope. To avoid this warning, you can open either the Bigarray.Operators or Bigarray module.
+File "indexop_deprecated.ml", line 35, characters 4-38:
+Warning 3: deprecated: implicit use of Bigarray.( .{,..,}<- ) when it was not in scope. To avoid this warning, you can open either the Bigarray.Operators or Bigarray module.
+File "indexop_deprecated.ml", line 35, characters 23-38:
+Warning 3: deprecated: implicit use of Bigarray.( .{,..,} ) when it was not in scope. To avoid this warning, you can open either the Bigarray.Operators or Bigarray module.

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -146,10 +146,35 @@ let find_class env loc lid =
   Builtin_attributes.check_deprecated loc decl.cty_attributes (Path.name path);
   r
 
+(* With the simplification of index operators, the expressions a.{..}
+  are no longer resolved to Bigarray.Array[n].[g|s]et. To ease the transition
+  period, we catch the cases where the index operators .{}/.{,}.. are not bound
+  in the current scope and tranlate then to Bigarray.(..)  with a deprecated
+  warning. *)
+let lookup_value_deprecated loc ?(loc=loc) lid env=
+  let lookup_deprecated lid env =
+    match lid with
+    | Longident.Lident(
+        ".{}" | ".{}<-"
+        | ".{,}" | ".{,}<-"
+        | ".{,,}" | ".{,,}<-"
+        | ".{,..,}" | ".{,..,}<-" as s) ->
+        let lid' =  Longident.( Ldot( Lident "Bigarray" , s ) ) in
+        let r = Env.lookup_value ~loc lid' env in
+        Location.prerr_warning loc ( Warnings.Deprecated (
+            Printf.sprintf
+              "implicit use of Bigarray.( %s ) when it was not in scope. \
+               To avoid this warning, you can open either the \
+               Bigarray.Operators or Bigarray module." s ));
+        r
+    | _ -> raise Not_found in
+  try Env.lookup_value ~loc lid env with
+  | Not_found -> lookup_deprecated lid env
+
 let find_value env loc lid =
   Env.check_value_name (Longident.last lid) loc;
   let (path, decl) as r =
-    find_component Env.lookup_value (fun lid -> Unbound_value lid) env loc lid
+    find_component (lookup_value_deprecated loc) (fun lid -> Unbound_value lid) env loc lid
   in
   Builtin_attributes.check_deprecated loc decl.val_attributes (Path.name path);
   r


### PR DESCRIPTION
The aim of this commit is to preserve source compatibility between the user-defined indexing operators and the main branch when using the `Bigarray` library.

On the one hand, the user-defined indexing operators branch require to explicitly bring in scope the `Bigarray.( .{...} )` before using them. On the other hand, in the main branch, these operators always implicitly refer to the `Bigarray` module. 

In order to bridge the gap between these two different behaviors, this pull request introduces a temporary hack to allow implicit uses of the `Bigarray.( .{...} )` index operators in the user-defined indexing operators branch. However, these implicit uses of `Bigarray.( .{...} )` operator trigger a deprecated warning (in the user-defined branch).

This warning can be avoided by explicitly bringing in scope the corresponding `Bigarray.( .{...} )` operator; for instance by opening either the `Bigarray` module or the `Bigarray.Operators` module.
