### PR TITLE
Shortcut for extension and attributes

### DIFF
--- a/Changes
+++ b/Changes
@@ -60,6 +60,10 @@ Language features:
 - PR#6681 GPR#326: signature items are now accepted as payloads for
   extension and attributes, using the syntax [%foo: SIG ] or [@foo: SIG ].
   (Alain Frisch and Gabriel Radanne)
+* GPR#342: Allow shortcuts for extension and attributes on all keywords.
+  The attribute in "let[@foo] .. in .." is now attached to the value binding,
+  not to the expression.
+  (Gabriel Radanne)
 * GPR#234: allow "[]" as a user-defined constructor. Demand parenthesis
   around "::" when using "::" as user-defined constructor.
   (Runhang Li, review by Damien Doligez)

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1706,7 +1706,8 @@ let f = function
 
 \section{Extension nodes}\label{s:extension-nodes}
 
-(Introduced in OCaml 4.02)
+(Introduced in OCaml 4.02,
+infix notations for constructs other than expressions added in 4.03)
 
 Extension nodes are generic placeholders in the syntax tree. They are
 rejected by the type-checker and are intended to be ``expanded'' by external
@@ -1765,23 +1766,24 @@ class-field:
 ;
 \end{syntax}
 
-An infix form is available for extension nodes as expressions, when
-the payload is a single expression.  This form applies to all
-expressions starting with one or two keywords: the first keyword
-followed by the percent sign and then an extension identifier.
+An infix form is available for extension nodes when
+the payload is of the same kind
+(expression with expression, pattern with pattern ...).
 
 Examples:
 
 \begin{verbatim}
 let%foo x = 2 in x + 1     === [%foo let x = 2 in x + 1]
 begin%foo ... end          === [%foo begin ... end]
+module%foo M = ..          === [%%foo module M = ... ]
+val%foo x : t              === [%%foo: val x : t]
 \end{verbatim}
 
 When this form is used together with the infix syntax for attributes,
 the attributes are considered to apply to the payload:
 
 \begin{verbatim}
-let%foo[@bar] x = 2 in x + 1 === [%foo (let x = 2 in x + 1) [@bar]]
+fun%foo[@bar] x -> x + 1 === [%foo (fun x -> x + 1)[@foo ] ];
 \end{verbatim}
 
 \subsection{Built-in extension nodes}

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1416,7 +1416,8 @@ The last two entries are valid for any $n > 3$.
 
 \section{Attributes}\label{s:attributes}
 
-(Introduced in OCaml 4.02)
+(Introduced in OCaml 4.02,
+infix notations for constructs other than expressions added in 4.03)
 
 Attributes are ``decorations'' of the syntax tree which are mostly
 ignored by the type-checker but can be used by external tools.  An
@@ -1584,17 +1585,24 @@ cannot be attached to these floating attributes in @class-field-spec@
 and @class-field@.)
 
 
-It is also possible to specify attributes on expressions using an
-infix syntax.  This applies to all expressions starting with one or
-two keywords: "assert", "begin", "for", "fun", "function", "if",
-"lazy", "let", "let module", "let open", "match", "new", "object",
-"try", "while".  Those expressions supports adding one or several
-attributes just after those initial keyword(s).  For instance:
+It is also possible to specify attributes using an infix syntax. For instance:
 
 \begin{verbatim}
-let [@foo][@bar x] x = 2 in x + 1 === (let x = 2 in x + 1)[@foo][@bar x]
-begin[@foo] ... end               === (begin ... end)[@foo]
+let[@foo] x = 2 in x + 1          === (let x = 2 [@@foo] in x + 1)
+begin[@foo][@bar x] ... end       === (begin ... end)[@foo][@@bar x]
+module[@foo] M = ...              === module M = ... [@@foo]
+type[@foo] t = T                  === type t = T [@@foo]
+method[@foo] m = ...              === method m = ... [@@foo]
 \end{verbatim}
+
+For "let", the attributes are applied to each bindings:
+
+\begin{verbatim}
+let[@foo] x = 2 and y = 3 in x + y === (let x = 2 [@@foo] and y = 3 in x + y)
+let[@foo] x = 2
+and[@bar] y = 3 in x + y           === (let x = 2 [@@foo] and y = 3 [@bar] in x + y)
+\end{verbatim}
+
 
 \subsection{Built-in attributes}
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -796,9 +796,9 @@ structure_item:
   | str_exception_declaration
       { let (l, ext) = $1 in mkstr_ext (Pstr_exception l) ext }
   | module_binding
-      { mkstr(Pstr_module $1) }
+      { let (body, ext) = $1 in mkstr_ext (Pstr_module body) ext }
   | rec_module_bindings
-      { mkstr(Pstr_recmodule(List.rev $1)) }
+      { let (l, ext) = $1 in mkstr_ext (Pstr_recmodule(List.rev l)) ext }
   | module_type_declaration
       { mkstr(Pstr_modtype $1) }
   | open_statement { mkstr(Pstr_open $1) }
@@ -828,22 +828,26 @@ module_binding_body:
       { mkmod(Pmod_functor(fst $1, snd $1, $2)) }
 ;
 module_binding:
-    MODULE UIDENT module_binding_body post_item_attributes
-      { Mb.mk (mkrhs $2 2) $3 ~attrs:$4
-              ~loc:(symbol_rloc ()) ~docs:(symbol_docs ()) }
+    MODULE ext_attributes UIDENT module_binding_body post_item_attributes
+      { let (ext, attrs) = $2 in
+        Mb.mk (mkrhs $3 3) $4 ~attrs:(attrs@$5)
+            ~loc:(symbol_rloc ()) ~docs:(symbol_docs ())
+      , ext }
 ;
 rec_module_bindings:
-    rec_module_binding                            { [$1] }
-  | rec_module_bindings and_module_binding        { $2 :: $1 }
+    rec_module_binding                     { let (b, ext) = $1 in ([b], ext) }
+  | rec_module_bindings and_module_binding { let (l, ext) = $1 in ($2 :: l, ext) }
 ;
 rec_module_binding:
-    MODULE REC UIDENT module_binding_body post_item_attributes
-      { Mb.mk (mkrhs $3 3) $4 ~attrs:$5
-              ~loc:(symbol_rloc ()) ~docs:(symbol_docs ()) }
+    MODULE ext_attributes REC UIDENT module_binding_body post_item_attributes
+      { let (ext, attrs) = $2 in
+        Mb.mk (mkrhs $4 4) $5 ~attrs:(attrs@$6)
+            ~loc:(symbol_rloc ()) ~docs:(symbol_docs ())
+      , ext }
 ;
 and_module_binding:
-    AND UIDENT module_binding_body post_item_attributes
-      { Mb.mk (mkrhs $2 2) $3 ~attrs:$4 ~loc:(symbol_rloc ())
+    AND attributes UIDENT module_binding_body post_item_attributes
+      { Mb.mk (mkrhs $3 3) $4 ~attrs:($2@$5) ~loc:(symbol_rloc ())
                ~text:(symbol_text ()) ~docs:(symbol_docs ()) }
 ;
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -786,9 +786,9 @@ structure_item:
     let_bindings
       { val_of_let_bindings $1 }
   | primitive_declaration
-      { mkstr (Pstr_primitive $1) }
+      { let (body, ext) = $1 in mkstr_ext (Pstr_primitive body) ext }
   | value_description
-      { mkstr (Pstr_primitive $1) }
+      { let (body, ext) = $1 in mkstr_ext (Pstr_primitive body) ext }
   | type_declarations
       { let (nr, l, ext ) = $1 in mkstr_ext (Pstr_type (nr, List.rev l)) ext }
   | str_type_extension
@@ -891,9 +891,9 @@ signature:
 ;
 signature_item:
     value_description
-      { mksig(Psig_value $1) }
+      { let (body, ext) = $1 in mksig_ext (Psig_value body) ext }
   | primitive_declaration
-      { mksig(Psig_value $1) }
+      { let (body, ext) = $1 in mksig_ext (Psig_value body) ext}
   | type_declarations
       { let (nr, l, ext) = $1 in mksig_ext (Psig_type (nr, List.rev l)) ext }
   | sig_type_extension
@@ -1769,9 +1769,11 @@ opt_pattern_type_constraint:
 /* Value descriptions */
 
 value_description:
-    VAL val_ident COLON core_type post_item_attributes
-      { Val.mk (mkrhs $2 2) $4 ~attrs:$5
-               ~loc:(symbol_rloc()) ~docs:(symbol_docs ()) }
+    VAL ext_attributes val_ident COLON core_type post_item_attributes
+      { let (ext, attrs) = $2 in
+        Val.mk (mkrhs $3 3) $5 ~attrs:(attrs@$6)
+              ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+      , ext }
 ;
 
 /* Primitive declarations */
@@ -1781,10 +1783,12 @@ primitive_declaration_body:
   | STRING primitive_declaration_body           { fst $1 :: $2 }
 ;
 primitive_declaration:
-    EXTERNAL val_ident COLON core_type EQUAL primitive_declaration_body
+    EXTERNAL ext_attributes val_ident COLON core_type EQUAL primitive_declaration_body
     post_item_attributes
-      { Val.mk (mkrhs $2 2) $4 ~prim:$6 ~attrs:$7
-               ~loc:(symbol_rloc ()) ~docs:(symbol_docs ()) }
+      { let (ext, attrs) = $2 in
+        Val.mk (mkrhs $3 3) $5 ~prim:$7 ~attrs:(attrs@$8)
+              ~loc:(symbol_rloc ()) ~docs:(symbol_docs ())
+      , ext }
 ;
 
 /* Type declarations */

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -801,7 +801,8 @@ structure_item:
       { let (l, ext) = $1 in mkstr_ext (Pstr_recmodule(List.rev l)) ext }
   | module_type_declaration
       { mkstr(Pstr_modtype $1) }
-  | open_statement { mkstr(Pstr_open $1) }
+  | open_statement
+      { let (body, ext) = $1 in mkstr_ext (Pstr_open body) ext }
   | class_declarations
       { let (l, ext) = $1 in mkstr_ext (Pstr_class (List.rev l)) ext }
   | class_type_declarations
@@ -909,7 +910,7 @@ signature_item:
   | module_type_declaration
       { mksig(Psig_modtype $1) }
   | open_statement
-      { mksig(Psig_open $1) }
+      { let (body, ext) = $1 in mksig_ext (Psig_open body) ext }
   | sig_include_statement
       { mksig(Psig_include $1) }
   | class_descriptions
@@ -923,9 +924,11 @@ signature_item:
         mksig(Psig_attribute $1) }
 ;
 open_statement:
-  | OPEN override_flag mod_longident post_item_attributes
-      { Opn.mk (mkrhs $3 3) ~override:$2 ~attrs:$4
-          ~loc:(symbol_rloc()) ~docs:(symbol_docs ()) }
+  | OPEN override_flag ext_attributes mod_longident post_item_attributes
+      { let (ext, attrs) = $3 in
+        Opn.mk (mkrhs $4 4) ~override:$2 ~attrs:(attrs@$5)
+          ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+      , ext}
 ;
 sig_include_statement:
     INCLUDE module_type post_item_attributes %prec below_WITH

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -803,9 +803,9 @@ structure_item:
       { mkstr(Pstr_modtype $1) }
   | open_statement { mkstr(Pstr_open $1) }
   | class_declarations
-      { mkstr(Pstr_class (List.rev $1)) }
+      { let (l, ext) = $1 in mkstr_ext (Pstr_class (List.rev l)) ext }
   | class_type_declarations
-      { mkstr(Pstr_class_type (List.rev $1)) }
+      { let (l, ext) = $1 in mkstr_ext (Pstr_class_type (List.rev l)) ext }
   | str_include_statement
       { mkstr(Pstr_include $1) }
   | item_extension post_item_attributes
@@ -913,9 +913,9 @@ signature_item:
   | sig_include_statement
       { mksig(Psig_include $1) }
   | class_descriptions
-      { mksig(Psig_class (List.rev $1)) }
+      { let (l, ext) = $1 in mksig_ext (Psig_class (List.rev l)) ext }
   | class_type_declarations
-      { mksig(Psig_class_type (List.rev $1)) }
+      { let (l, ext) = $1 in mksig_ext (Psig_class_type (List.rev l)) ext }
   | item_extension post_item_attributes
       { mksig(Psig_extension ($1, (add_docs_attrs (symbol_docs ()) $2))) }
   | floating_attribute
@@ -983,20 +983,22 @@ module_type_declaration:
 /* Class expressions */
 
 class_declarations:
-    class_declaration                           { [$1] }
-  | class_declarations and_class_declaration    { $2 :: $1 }
+    class_declaration                           { let (body, ext) = $1 in ([body], ext) }
+  | class_declarations and_class_declaration    { let (l, ext) = $1 in ($2 :: l, ext) }
 ;
 class_declaration:
-    CLASS virtual_flag class_type_parameters LIDENT class_fun_binding
+    CLASS ext_attributes virtual_flag class_type_parameters LIDENT class_fun_binding
     post_item_attributes
-      { Ci.mk (mkrhs $4 4) $5 ~virt:$2 ~params:$3 ~attrs:$6
-              ~loc:(symbol_rloc ()) ~docs:(symbol_docs ()) }
+      { let (ext, attrs) = $2 in
+        Ci.mk (mkrhs $5 5) $6 ~virt:$3 ~params:$4 ~attrs:(attrs@$7)
+            ~loc:(symbol_rloc ()) ~docs:(symbol_docs ())
+      , ext }
 ;
 and_class_declaration:
-    AND virtual_flag class_type_parameters LIDENT class_fun_binding
+    AND attributes virtual_flag class_type_parameters LIDENT class_fun_binding
     post_item_attributes
-      { Ci.mk (mkrhs $4 4) $5 ~virt:$2 ~params:$3
-         ~attrs:$6 ~loc:(symbol_rloc ())
+      { Ci.mk (mkrhs $5 5) $6 ~virt:$3 ~params:$4
+         ~attrs:($2@$7) ~loc:(symbol_rloc ())
          ~text:(symbol_text ()) ~docs:(symbol_docs ()) }
 ;
 class_fun_binding:
@@ -1202,37 +1204,41 @@ constrain_field:
         core_type EQUAL core_type          { $1, $3 }
 ;
 class_descriptions:
-    class_description                           { [$1] }
-  | class_descriptions and_class_description    { $2 :: $1 }
+    class_description                           { let (body, ext) = $1 in ([body],ext) }
+  | class_descriptions and_class_description    { let (l, ext) = $1 in ($2 :: l, ext) }
 ;
 class_description:
-    CLASS virtual_flag class_type_parameters LIDENT COLON class_type
+    CLASS ext_attributes virtual_flag class_type_parameters LIDENT COLON class_type
     post_item_attributes
-      { Ci.mk (mkrhs $4 4) $6 ~virt:$2 ~params:$3 ~attrs:$7
-              ~loc:(symbol_rloc ()) ~docs:(symbol_docs ()) }
+      { let (ext, attrs) = $2 in
+        Ci.mk (mkrhs $5 5) $7 ~virt:$3 ~params:$4 ~attrs:$8
+            ~loc:(symbol_rloc ()) ~docs:(symbol_docs ())
+      , ext }
 ;
 and_class_description:
-    AND virtual_flag class_type_parameters LIDENT COLON class_type
+    AND attributes virtual_flag class_type_parameters LIDENT COLON class_type
     post_item_attributes
-      { Ci.mk (mkrhs $4 4) $6 ~virt:$2 ~params:$3
-              ~attrs:$7 ~loc:(symbol_rloc ())
+      { Ci.mk (mkrhs $5 5) $7 ~virt:$3 ~params:$4
+              ~attrs:($2@$8) ~loc:(symbol_rloc ())
               ~text:(symbol_text ()) ~docs:(symbol_docs ()) }
 ;
 class_type_declarations:
-    class_type_declaration                              { [$1] }
-  | class_type_declarations and_class_type_declaration  { $2 :: $1 }
+    class_type_declaration                              { let (body, ext) = $1 in ([body],ext) }
+  | class_type_declarations and_class_type_declaration  { let (l, ext) = $1 in ($2 :: l, ext) }
 ;
 class_type_declaration:
-    CLASS TYPE virtual_flag class_type_parameters LIDENT EQUAL
+    CLASS TYPE ext_attributes virtual_flag class_type_parameters LIDENT EQUAL
     class_signature post_item_attributes
-      { Ci.mk (mkrhs $5 5) $7 ~virt:$3 ~params:$4 ~attrs:$8
-              ~loc:(symbol_rloc ()) ~docs:(symbol_docs ()) }
+      { let (ext, attrs) = $3 in
+        Ci.mk (mkrhs $6 6) $8 ~virt:$4 ~params:$5 ~attrs:(attrs@$9)
+            ~loc:(symbol_rloc ()) ~docs:(symbol_docs ())
+      , ext}
 ;
 and_class_type_declaration:
-    AND virtual_flag class_type_parameters LIDENT EQUAL
+    AND attributes virtual_flag class_type_parameters LIDENT EQUAL
     class_signature post_item_attributes
-      { Ci.mk (mkrhs $4 4) $6 ~virt:$2 ~params:$3
-         ~attrs:$7 ~loc:(symbol_rloc ())
+      { Ci.mk (mkrhs $5 5) $7 ~virt:$3 ~params:$4
+         ~attrs:($2@$8) ~loc:(symbol_rloc ())
          ~text:(symbol_text ()) ~docs:(symbol_docs ()) }
 ;
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -68,6 +68,7 @@ let ghpat d = Pat.mk ~loc:(symbol_gloc ()) d
 let ghtyp d = Typ.mk ~loc:(symbol_gloc ()) d
 let ghloc d = { txt = d; loc = symbol_gloc () }
 let ghstr d = Str.mk ~loc:(symbol_gloc()) d
+let ghsig d = Sig.mk ~loc:(symbol_gloc()) d
 
 let mkinfix arg1 name arg2 =
   mkexp(Pexp_apply(mkoperator name 2, [Nolabel, arg1; Nolabel, arg2]))
@@ -281,6 +282,22 @@ let wrap_exp_attrs body (ext, attrs) =
 
 let mkexp_attrs d attrs =
   wrap_exp_attrs (mkexp d) attrs
+
+let wrap_str_ext body ext =
+  match ext with
+  | None -> body
+  | Some id -> ghstr(Pstr_extension ((id, PStr [body]), []))
+
+let mkstr_ext d ext =
+  wrap_str_ext (mkstr d) ext
+
+let wrap_sig_ext body ext =
+  match ext with
+  | None -> body
+  | Some id -> ghsig(Psig_extension ((id, PSig [body]), []))
+
+let mksig_ext d ext =
+  wrap_sig_ext (mksig d) ext
 
 let text_str pos = Str.text (rhs_text pos)
 let text_sig pos = Sig.text (rhs_text pos)

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -800,7 +800,7 @@ structure_item:
   | rec_module_bindings
       { let (l, ext) = $1 in mkstr_ext (Pstr_recmodule(List.rev l)) ext }
   | module_type_declaration
-      { mkstr(Pstr_modtype $1) }
+      { let (body, ext) = $1 in mkstr_ext (Pstr_modtype body) ext }
   | open_statement
       { let (body, ext) = $1 in mkstr_ext (Pstr_open body) ext }
   | class_declarations
@@ -908,7 +908,7 @@ signature_item:
   | rec_module_declarations
       { let (l, ext) = $1 in mksig_ext (Psig_recmodule (List.rev l)) ext }
   | module_type_declaration
-      { mksig(Psig_modtype $1) }
+      { let (body, ext) = $1 in mksig_ext (Psig_modtype body) ext }
   | open_statement
       { let (body, ext) = $1 in mksig_ext (Psig_open body) ext }
   | sig_include_statement
@@ -979,9 +979,11 @@ module_type_declaration_body:
   | EQUAL module_type         { Some $2 }
 ;
 module_type_declaration:
-    MODULE TYPE ident module_type_declaration_body post_item_attributes
-      { Mtd.mk (mkrhs $3 3) ?typ:$4 ~attrs:$5
-          ~loc:(symbol_rloc()) ~docs:(symbol_docs ()) }
+    MODULE TYPE ext_attributes ident module_type_declaration_body post_item_attributes
+      { let (ext, attrs) = $3 in
+        Mtd.mk (mkrhs $4 4) ?typ:$5 ~attrs:(attrs@$6)
+          ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+      , ext }
 ;
 /* Class expressions */
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -808,7 +808,7 @@ structure_item:
   | class_type_declarations
       { let (l, ext) = $1 in mkstr_ext (Pstr_class_type (List.rev l)) ext }
   | str_include_statement
-      { mkstr(Pstr_include $1) }
+      { let (body, ext) = $1 in mkstr_ext (Pstr_include body) ext }
   | item_extension post_item_attributes
       { mkstr(Pstr_extension ($1, (add_docs_attrs (symbol_docs ()) $2))) }
   | floating_attribute
@@ -816,9 +816,11 @@ structure_item:
         mkstr(Pstr_attribute $1) }
 ;
 str_include_statement:
-    INCLUDE module_expr post_item_attributes
-      { Incl.mk $2 ~attrs:$3
-                ~loc:(symbol_rloc()) ~docs:(symbol_docs ()) }
+    INCLUDE ext_attributes module_expr post_item_attributes
+      { let (ext, attrs) = $2 in
+        Incl.mk $3 ~attrs:(attrs@$4)
+            ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+      , ext }
 ;
 module_binding_body:
     EQUAL module_expr
@@ -912,7 +914,7 @@ signature_item:
   | open_statement
       { let (body, ext) = $1 in mksig_ext (Psig_open body) ext }
   | sig_include_statement
-      { mksig(Psig_include $1) }
+      { let (body, ext) = $1 in mksig_ext (Psig_include body) ext }
   | class_descriptions
       { let (l, ext) = $1 in mksig_ext (Psig_class (List.rev l)) ext }
   | class_type_declarations
@@ -931,9 +933,11 @@ open_statement:
       , ext}
 ;
 sig_include_statement:
-    INCLUDE module_type post_item_attributes %prec below_WITH
-      { Incl.mk $2 ~attrs:$3
-                ~loc:(symbol_rloc()) ~docs:(symbol_docs ()) }
+    INCLUDE ext_attributes module_type post_item_attributes %prec below_WITH
+      { let (ext, attrs) = $2 in
+        Incl.mk $3 ~attrs:(attrs@$4)
+            ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+      , ext}
 ;
 module_declaration_body:
     COLON module_type

--- a/testsuite/tests/parsing/shortcut_ext_attr.ml
+++ b/testsuite/tests/parsing/shortcut_ext_attr.ml
@@ -1,0 +1,98 @@
+
+(* Expressions *)
+let () =
+  let%foo[@foo] x = 3
+  and[@foo] y = 4 in
+  (let module%foo[@foo] M = M in ()) ;
+  (let open%foo[@foo] M in ()) ;
+  (fun%foo[@foo] x -> ()) ;
+  (function%foo[@foo] x -> ()) ;
+  (try%foo[@foo] () with _ -> ()) ;
+  (if%foo[@foo] () then () else ()) ;
+  while%foo[@foo] () do () done ;
+  for%foo[@foo] x = () to () do () done ;
+  assert%foo[@foo] true ;
+  lazy%foo[@foo] x ;
+  object%foo[@foo] end ;
+  begin%foo[@foo] 3 end ;
+  new%foo[@foo] x ;
+
+  match%foo[@foo] () with
+  (* Pattern expressions *)
+  | lazy%foo[@foo] x -> ()
+  | exception%foo[@foo] x -> ()
+
+
+(* Class expressions *)
+class x =
+  fun[@foo] x ->
+  let[@foo] x = 3 in
+  object[@foo]
+    inherit[@foo] x
+    val[@foo] x = 3
+    method[@foo] x = 3
+    initializer[@foo] x
+  end
+
+(* Type expressions *)
+type t =
+  (module%foo[@foo] M)
+
+(* Module expressions *)
+module M =
+  functor[@foo] (M : S) ->
+    (val[@foo] x)
+    (struct[@foo] end)
+
+(* Module type expression *)
+module type S =
+  functor[@foo] (M:S) ->
+    (module type of[@foo] M) ->
+    (sig[@foo] end)
+
+(* Structure items *)
+let%foo[@foo] x = 4
+and[@foo] y = x
+
+type%foo[@foo] t = int
+and[@foo] t = int
+type%foo[@foo] t += T
+
+class%foo[@foo] x = x
+class type%foo[@foo] x = x
+external%foo[@foo] x : _  = ""
+exception%foo[@foo] X
+
+module%foo[@foo] M = M
+module%foo[@foo] rec M : S = M
+and[@foo] M : S = M
+module type%foo[@foo] S = S
+
+include%foo[@foo] M
+open%foo[@foo] M
+
+(* Signature items *)
+module type S = sig
+  val%foo[@foo] x : t
+  external%foo[@foo] x : t = ""
+
+  type%foo[@foo] t = int
+  and[@foo] t' = int
+  type%foo[@foo] t += T
+
+  exception%foo[@foo] X
+
+  module%foo[@foo] M : S
+  module%foo[@foo] rec M : S
+  and[@foo] M : S
+  module%foo[@foo] M = M
+
+  module type%foo[@foo] S = S
+
+  include%foo[@foo] M
+  open%foo[@foo] M
+
+  class%foo[@foo] x : t
+  class type%foo[@foo] x = x
+
+end

--- a/testsuite/tests/parsing/shortcut_ext_attr.ml.reference
+++ b/testsuite/tests/parsing/shortcut_ext_attr.ml.reference
@@ -1,0 +1,853 @@
+[
+  structure_item (shortcut_ext_attr.ml[3,19+0]..[23,554+31])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (shortcut_ext_attr.ml[3,19+4]..[3,19+6])
+          Ppat_construct "()" (shortcut_ext_attr.ml[3,19+4]..[3,19+6])
+          None
+        expression (shortcut_ext_attr.ml[4,28+2]..[23,554+31]) ghost
+          Pexp_extension "foo"
+          [
+            structure_item (shortcut_ext_attr.ml[4,28+2]..[23,554+31])
+              Pstr_eval
+              expression (shortcut_ext_attr.ml[4,28+2]..[23,554+31])
+                Pexp_let Nonrec
+                [
+                  <def>
+                      attribute "foo"
+                        []
+                    pattern (shortcut_ext_attr.ml[4,28+16]..[4,28+17])
+                      Ppat_var "x" (shortcut_ext_attr.ml[4,28+16]..[4,28+17])
+                    expression (shortcut_ext_attr.ml[4,28+20]..[4,28+21])
+                      Pexp_constant PConst_int (3,None)
+                  <def>
+                      attribute "foo"
+                        []
+                    pattern (shortcut_ext_attr.ml[5,50+12]..[5,50+13])
+                      Ppat_var "y" (shortcut_ext_attr.ml[5,50+12]..[5,50+13])
+                    expression (shortcut_ext_attr.ml[5,50+16]..[5,50+17])
+                      Pexp_constant PConst_int (4,None)
+                ]
+                expression (shortcut_ext_attr.ml[6,71+2]..[23,554+31])
+                  Pexp_sequence
+                  expression (shortcut_ext_attr.ml[6,71+2]..[6,71+36])
+                    Pexp_extension "foo"
+                    [
+                      structure_item (shortcut_ext_attr.ml[6,71+3]..[6,71+35])
+                        Pstr_eval
+                        expression (shortcut_ext_attr.ml[6,71+3]..[6,71+35])
+                          attribute "foo"
+                            []
+                          Pexp_letmodule "M" (shortcut_ext_attr.ml[6,71+24]..[6,71+25])
+                          module_expr (shortcut_ext_attr.ml[6,71+28]..[6,71+29])
+                            Pmod_ident "M" (shortcut_ext_attr.ml[6,71+28]..[6,71+29])
+                          expression (shortcut_ext_attr.ml[6,71+33]..[6,71+35])
+                            Pexp_construct "()" (shortcut_ext_attr.ml[6,71+33]..[6,71+35])
+                            None
+                    ]
+                  expression (shortcut_ext_attr.ml[7,110+2]..[23,554+31])
+                    Pexp_sequence
+                    expression (shortcut_ext_attr.ml[7,110+2]..[7,110+30])
+                      Pexp_extension "foo"
+                      [
+                        structure_item (shortcut_ext_attr.ml[7,110+3]..[7,110+29])
+                          Pstr_eval
+                          expression (shortcut_ext_attr.ml[7,110+3]..[7,110+29])
+                            attribute "foo"
+                              []
+                            Pexp_open Fresh ""M" (shortcut_ext_attr.ml[7,110+22]..[7,110+23])"
+                            expression (shortcut_ext_attr.ml[7,110+27]..[7,110+29])
+                              Pexp_construct "()" (shortcut_ext_attr.ml[7,110+27]..[7,110+29])
+                              None
+                      ]
+                    expression (shortcut_ext_attr.ml[8,143+2]..[23,554+31])
+                      Pexp_sequence
+                      expression (shortcut_ext_attr.ml[8,143+2]..[8,143+25])
+                        Pexp_extension "foo"
+                        [
+                          structure_item (shortcut_ext_attr.ml[8,143+3]..[8,143+24])
+                            Pstr_eval
+                            expression (shortcut_ext_attr.ml[8,143+3]..[8,143+24])
+                              attribute "foo"
+                                []
+                              Pexp_fun
+                              Nolabel
+                              None
+                              pattern (shortcut_ext_attr.ml[8,143+17]..[8,143+18])
+                                Ppat_var "x" (shortcut_ext_attr.ml[8,143+17]..[8,143+18])
+                              expression (shortcut_ext_attr.ml[8,143+22]..[8,143+24])
+                                Pexp_construct "()" (shortcut_ext_attr.ml[8,143+22]..[8,143+24])
+                                None
+                        ]
+                      expression (shortcut_ext_attr.ml[9,171+2]..[23,554+31])
+                        Pexp_sequence
+                        expression (shortcut_ext_attr.ml[9,171+2]..[9,171+30])
+                          Pexp_extension "foo"
+                          [
+                            structure_item (shortcut_ext_attr.ml[9,171+3]..[9,171+29])
+                              Pstr_eval
+                              expression (shortcut_ext_attr.ml[9,171+3]..[9,171+29])
+                                attribute "foo"
+                                  []
+                                Pexp_function
+                                [
+                                  <case>
+                                    pattern (shortcut_ext_attr.ml[9,171+22]..[9,171+23])
+                                      Ppat_var "x" (shortcut_ext_attr.ml[9,171+22]..[9,171+23])
+                                    expression (shortcut_ext_attr.ml[9,171+27]..[9,171+29])
+                                      Pexp_construct "()" (shortcut_ext_attr.ml[9,171+27]..[9,171+29])
+                                      None
+                                ]
+                          ]
+                        expression (shortcut_ext_attr.ml[10,204+2]..[23,554+31])
+                          Pexp_sequence
+                          expression (shortcut_ext_attr.ml[10,204+2]..[10,204+33])
+                            Pexp_extension "foo"
+                            [
+                              structure_item (shortcut_ext_attr.ml[10,204+3]..[10,204+32])
+                                Pstr_eval
+                                expression (shortcut_ext_attr.ml[10,204+3]..[10,204+32])
+                                  attribute "foo"
+                                    []
+                                  Pexp_try
+                                  expression (shortcut_ext_attr.ml[10,204+17]..[10,204+19])
+                                    Pexp_construct "()" (shortcut_ext_attr.ml[10,204+17]..[10,204+19])
+                                    None
+                                  [
+                                    <case>
+                                      pattern (shortcut_ext_attr.ml[10,204+25]..[10,204+26])
+                                        Ppat_any
+                                      expression (shortcut_ext_attr.ml[10,204+30]..[10,204+32])
+                                        Pexp_construct "()" (shortcut_ext_attr.ml[10,204+30]..[10,204+32])
+                                        None
+                                  ]
+                            ]
+                          expression (shortcut_ext_attr.ml[11,240+2]..[23,554+31])
+                            Pexp_sequence
+                            expression (shortcut_ext_attr.ml[11,240+2]..[11,240+35])
+                              Pexp_extension "foo"
+                              [
+                                structure_item (shortcut_ext_attr.ml[11,240+3]..[11,240+34])
+                                  Pstr_eval
+                                  expression (shortcut_ext_attr.ml[11,240+3]..[11,240+34])
+                                    attribute "foo"
+                                      []
+                                    Pexp_ifthenelse
+                                    expression (shortcut_ext_attr.ml[11,240+16]..[11,240+18])
+                                      Pexp_construct "()" (shortcut_ext_attr.ml[11,240+16]..[11,240+18])
+                                      None
+                                    expression (shortcut_ext_attr.ml[11,240+24]..[11,240+26])
+                                      Pexp_construct "()" (shortcut_ext_attr.ml[11,240+24]..[11,240+26])
+                                      None
+                                    Some
+                                      expression (shortcut_ext_attr.ml[11,240+32]..[11,240+34])
+                                        Pexp_construct "()" (shortcut_ext_attr.ml[11,240+32]..[11,240+34])
+                                        None
+                              ]
+                            expression (shortcut_ext_attr.ml[12,278+2]..[23,554+31])
+                              Pexp_sequence
+                              expression (shortcut_ext_attr.ml[12,278+2]..[12,278+31]) ghost
+                                Pexp_extension "foo"
+                                [
+                                  structure_item (shortcut_ext_attr.ml[12,278+2]..[12,278+31])
+                                    Pstr_eval
+                                    expression (shortcut_ext_attr.ml[12,278+2]..[12,278+31])
+                                      attribute "foo"
+                                        []
+                                      Pexp_while
+                                      expression (shortcut_ext_attr.ml[12,278+18]..[12,278+20])
+                                        Pexp_construct "()" (shortcut_ext_attr.ml[12,278+18]..[12,278+20])
+                                        None
+                                      expression (shortcut_ext_attr.ml[12,278+24]..[12,278+26])
+                                        Pexp_construct "()" (shortcut_ext_attr.ml[12,278+24]..[12,278+26])
+                                        None
+                                ]
+                              expression (shortcut_ext_attr.ml[13,312+2]..[23,554+31])
+                                Pexp_sequence
+                                expression (shortcut_ext_attr.ml[13,312+2]..[13,312+39]) ghost
+                                  Pexp_extension "foo"
+                                  [
+                                    structure_item (shortcut_ext_attr.ml[13,312+2]..[13,312+39])
+                                      Pstr_eval
+                                      expression (shortcut_ext_attr.ml[13,312+2]..[13,312+39])
+                                        attribute "foo"
+                                          []
+                                        Pexp_for Up
+                                        pattern (shortcut_ext_attr.ml[13,312+16]..[13,312+17])
+                                          Ppat_var "x" (shortcut_ext_attr.ml[13,312+16]..[13,312+17])
+                                        expression (shortcut_ext_attr.ml[13,312+20]..[13,312+22])
+                                          Pexp_construct "()" (shortcut_ext_attr.ml[13,312+20]..[13,312+22])
+                                          None
+                                        expression (shortcut_ext_attr.ml[13,312+26]..[13,312+28])
+                                          Pexp_construct "()" (shortcut_ext_attr.ml[13,312+26]..[13,312+28])
+                                          None
+                                        expression (shortcut_ext_attr.ml[13,312+32]..[13,312+34])
+                                          Pexp_construct "()" (shortcut_ext_attr.ml[13,312+32]..[13,312+34])
+                                          None
+                                  ]
+                                expression (shortcut_ext_attr.ml[14,354+2]..[23,554+31])
+                                  Pexp_sequence
+                                  expression (shortcut_ext_attr.ml[14,354+2]..[14,354+23]) ghost
+                                    Pexp_extension "foo"
+                                    [
+                                      structure_item (shortcut_ext_attr.ml[14,354+2]..[14,354+23])
+                                        Pstr_eval
+                                        expression (shortcut_ext_attr.ml[14,354+2]..[14,354+23])
+                                          attribute "foo"
+                                            []
+                                          Pexp_assert
+                                          expression (shortcut_ext_attr.ml[14,354+19]..[14,354+23])
+                                            Pexp_construct "true" (shortcut_ext_attr.ml[14,354+19]..[14,354+23])
+                                            None
+                                    ]
+                                  expression (shortcut_ext_attr.ml[15,380+2]..[23,554+31])
+                                    Pexp_sequence
+                                    expression (shortcut_ext_attr.ml[15,380+2]..[15,380+18]) ghost
+                                      Pexp_extension "foo"
+                                      [
+                                        structure_item (shortcut_ext_attr.ml[15,380+2]..[15,380+18])
+                                          Pstr_eval
+                                          expression (shortcut_ext_attr.ml[15,380+2]..[15,380+18])
+                                            attribute "foo"
+                                              []
+                                            Pexp_lazy
+                                            expression (shortcut_ext_attr.ml[15,380+17]..[15,380+18])
+                                              Pexp_ident "x" (shortcut_ext_attr.ml[15,380+17]..[15,380+18])
+                                      ]
+                                    expression (shortcut_ext_attr.ml[16,401+2]..[23,554+31])
+                                      Pexp_sequence
+                                      expression (shortcut_ext_attr.ml[16,401+2]..[16,401+22]) ghost
+                                        Pexp_extension "foo"
+                                        [
+                                          structure_item (shortcut_ext_attr.ml[16,401+2]..[16,401+22])
+                                            Pstr_eval
+                                            expression (shortcut_ext_attr.ml[16,401+2]..[16,401+22])
+                                              attribute "foo"
+                                                []
+                                              Pexp_object
+                                              class_structure
+                                                pattern (shortcut_ext_attr.ml[16,401+18]..[16,401+18]) ghost
+                                                  Ppat_any
+                                                []
+                                        ]
+                                      expression (shortcut_ext_attr.ml[17,426+2]..[23,554+31])
+                                        Pexp_sequence
+                                        expression (shortcut_ext_attr.ml[17,426+2]..[17,426+23]) ghost
+                                          Pexp_extension "foo"
+                                          [
+                                            structure_item (shortcut_ext_attr.ml[17,426+2]..[17,426+23])
+                                              Pstr_eval
+                                              expression (shortcut_ext_attr.ml[17,426+2]..[17,426+23])
+                                                attribute "foo"
+                                                  []
+                                                Pexp_constant PConst_int (3,None)
+                                          ]
+                                        expression (shortcut_ext_attr.ml[18,452+2]..[23,554+31])
+                                          Pexp_sequence
+                                          expression (shortcut_ext_attr.ml[18,452+2]..[18,452+17]) ghost
+                                            Pexp_extension "foo"
+                                            [
+                                              structure_item (shortcut_ext_attr.ml[18,452+2]..[18,452+17])
+                                                Pstr_eval
+                                                expression (shortcut_ext_attr.ml[18,452+2]..[18,452+17])
+                                                  attribute "foo"
+                                                    []
+                                                  Pexp_new "x" (shortcut_ext_attr.ml[18,452+16]..[18,452+17])
+                                            ]
+                                          expression (shortcut_ext_attr.ml[20,473+2]..[23,554+31]) ghost
+                                            Pexp_extension "foo"
+                                            [
+                                              structure_item (shortcut_ext_attr.ml[20,473+2]..[23,554+31])
+                                                Pstr_eval
+                                                expression (shortcut_ext_attr.ml[20,473+2]..[23,554+31])
+                                                  attribute "foo"
+                                                    []
+                                                  Pexp_match
+                                                  expression (shortcut_ext_attr.ml[20,473+18]..[20,473+20])
+                                                    Pexp_construct "()" (shortcut_ext_attr.ml[20,473+18]..[20,473+20])
+                                                    None
+                                                  [
+                                                    <case>
+                                                      pattern (shortcut_ext_attr.ml[22,527+4]..[22,527+20]) ghost
+                                                        Ppat_extension "foo"
+                                                        pattern (shortcut_ext_attr.ml[22,527+4]..[22,527+20])
+                                                          attribute "foo"
+                                                            []
+                                                          Ppat_lazy
+                                                          pattern (shortcut_ext_attr.ml[22,527+19]..[22,527+20])
+                                                            Ppat_var "x" (shortcut_ext_attr.ml[22,527+19]..[22,527+20])
+                                                      expression (shortcut_ext_attr.ml[22,527+24]..[22,527+26])
+                                                        Pexp_construct "()" (shortcut_ext_attr.ml[22,527+24]..[22,527+26])
+                                                        None
+                                                    <case>
+                                                      pattern (shortcut_ext_attr.ml[23,554+4]..[23,554+25]) ghost
+                                                        Ppat_extension "foo"
+                                                        pattern (shortcut_ext_attr.ml[23,554+4]..[23,554+25])
+                                                          attribute "foo"
+                                                            []
+                                                          Ppat_exception
+                                                          pattern (shortcut_ext_attr.ml[23,554+24]..[23,554+25])
+                                                            Ppat_var "x" (shortcut_ext_attr.ml[23,554+24]..[23,554+25])
+                                                      expression (shortcut_ext_attr.ml[23,554+29]..[23,554+31])
+                                                        Pexp_construct "()" (shortcut_ext_attr.ml[23,554+29]..[23,554+31])
+                                                        None
+                                                  ]
+                                            ]
+          ]
+    ]
+  structure_item (shortcut_ext_attr.ml[27,612+0]..[35,762+5])
+    Pstr_class
+    [
+      class_declaration (shortcut_ext_attr.ml[27,612+0]..[35,762+5])
+        pci_virt = Concrete
+        pci_params =
+          []
+        pci_name = "x" (shortcut_ext_attr.ml[27,612+6]..[27,612+7])
+        pci_expr =
+          class_expr (shortcut_ext_attr.ml[28,622+12]..[35,762+5])
+            attribute "foo"
+              []
+            Pcl_fun
+            Nolabel
+            None
+            pattern (shortcut_ext_attr.ml[28,622+12]..[28,622+13])
+              Ppat_var "x" (shortcut_ext_attr.ml[28,622+12]..[28,622+13])
+            class_expr (shortcut_ext_attr.ml[29,639+2]..[35,762+5])
+              Pcl_let Nonrec
+              [
+                <def>
+                    attribute "foo"
+                      []
+                  pattern (shortcut_ext_attr.ml[29,639+12]..[29,639+13])
+                    Ppat_var "x" (shortcut_ext_attr.ml[29,639+12]..[29,639+13])
+                  expression (shortcut_ext_attr.ml[29,639+16]..[29,639+17])
+                    Pexp_constant PConst_int (3,None)
+              ]
+              class_expr (shortcut_ext_attr.ml[30,660+2]..[35,762+5])
+                attribute "foo"
+                  []
+                Pcl_structure
+                class_structure
+                  pattern (shortcut_ext_attr.ml[30,660+14]..[30,660+14]) ghost
+                    Ppat_any
+                  [
+                    class_field (shortcut_ext_attr.ml[31,675+4]..[31,675+19])
+                        attribute "foo"
+                          []
+                      Pcf_inherit Fresh
+                        class_expr (shortcut_ext_attr.ml[31,675+18]..[31,675+19])
+                          Pcl_constr "x" (shortcut_ext_attr.ml[31,675+18]..[31,675+19])
+                          []
+                        None
+                    class_field (shortcut_ext_attr.ml[32,695+4]..[32,695+19])
+                        attribute "foo"
+                          []
+                      Pcf_val Immutable
+                        "x" (shortcut_ext_attr.ml[32,695+14]..[32,695+15])
+                        Concrete Fresh
+                        expression (shortcut_ext_attr.ml[32,695+18]..[32,695+19])
+                          Pexp_constant PConst_int (3,None)
+                    class_field (shortcut_ext_attr.ml[33,715+4]..[33,715+22])
+                        attribute "foo"
+                          []
+                      Pcf_method Public
+                        "x" (shortcut_ext_attr.ml[33,715+17]..[33,715+18])
+                        Concrete Fresh
+                        expression (shortcut_ext_attr.ml[33,715+10]..[33,715+22]) ghost
+                          Pexp_poly
+                          expression (shortcut_ext_attr.ml[33,715+21]..[33,715+22])
+                            Pexp_constant PConst_int (3,None)
+                          None
+                    class_field (shortcut_ext_attr.ml[34,738+4]..[34,738+23])
+                        attribute "foo"
+                          []
+                      Pcf_initializer
+                        expression (shortcut_ext_attr.ml[34,738+22]..[34,738+23])
+                          Pexp_ident "x" (shortcut_ext_attr.ml[34,738+22]..[34,738+23])
+                  ]
+    ]
+  structure_item (shortcut_ext_attr.ml[38,792+0]..[39,801+22])
+    Pstr_type Rec
+    [
+      type_declaration "t" (shortcut_ext_attr.ml[38,792+5]..[38,792+6]) (shortcut_ext_attr.ml[38,792+0]..[39,801+22])
+        ptype_params =
+          []
+        ptype_cstrs =
+          []
+        ptype_kind =
+          Ptype_abstract
+        ptype_private = Public
+        ptype_manifest =
+          Some
+            core_type (shortcut_ext_attr.ml[39,801+2]..[39,801+22]) ghost
+              Ptyp_extension "foo"
+              core_type (shortcut_ext_attr.ml[39,801+2]..[39,801+22])
+                attribute "foo"
+                  []
+                Ptyp_package "M" (shortcut_ext_attr.ml[39,801+20]..[39,801+21])
+                []
+    ]
+  structure_item (shortcut_ext_attr.ml[42,850+0]..[45,906+22])
+    Pstr_module
+    "M" (shortcut_ext_attr.ml[42,850+7]..[42,850+8])
+      module_expr (shortcut_ext_attr.ml[43,861+2]..[45,906+22])
+        attribute "foo"
+          []
+        Pmod_functor "M" (shortcut_ext_attr.ml[43,861+17]..[43,861+18])
+        module_type (shortcut_ext_attr.ml[43,861+21]..[43,861+22])
+          Pmty_ident "S" (shortcut_ext_attr.ml[43,861+21]..[43,861+22])
+        module_expr (shortcut_ext_attr.ml[44,888+4]..[45,906+22])
+          Pmod_apply
+          module_expr (shortcut_ext_attr.ml[44,888+4]..[44,888+17])
+            attribute "foo"
+              []
+            Pmod_unpack
+            expression (shortcut_ext_attr.ml[44,888+15]..[44,888+16])
+              Pexp_ident "x" (shortcut_ext_attr.ml[44,888+15]..[44,888+16])
+          module_expr (shortcut_ext_attr.ml[45,906+5]..[45,906+21])
+            attribute "foo"
+              []
+            Pmod_structure
+            []
+  structure_item (shortcut_ext_attr.ml[48,959+0]..[51,1032+19])
+    Pstr_modtype "S" (shortcut_ext_attr.ml[48,959+12]..[48,959+13])
+      module_type (shortcut_ext_attr.ml[49,975+2]..[51,1032+19])
+        attribute "foo"
+          []
+        Pmty_functor "M" (shortcut_ext_attr.ml[49,975+17]..[49,975+18])
+        module_type (shortcut_ext_attr.ml[49,975+19]..[49,975+20])
+          Pmty_ident "S" (shortcut_ext_attr.ml[49,975+19]..[49,975+20])
+        module_type (shortcut_ext_attr.ml[50,1000+4]..[51,1032+19])
+          Pmty_functor "_" (_none_[1,0+-1]..[1,0+-1]) ghost
+          module_type (shortcut_ext_attr.ml[50,1000+5]..[50,1000+27])
+            attribute "foo"
+              []
+            Pmty_typeof
+            module_expr (shortcut_ext_attr.ml[50,1000+26]..[50,1000+27])
+              Pmod_ident "M" (shortcut_ext_attr.ml[50,1000+26]..[50,1000+27])
+          module_type (shortcut_ext_attr.ml[51,1032+5]..[51,1032+18])
+            attribute "foo"
+              []
+            Pmty_signature
+            []
+  structure_item (shortcut_ext_attr.ml[54,1075+0]..[55,1095+15]) ghost
+    Pstr_extension "foo"
+    [
+      structure_item (shortcut_ext_attr.ml[54,1075+0]..[55,1095+15])
+        Pstr_value Nonrec
+        [
+          <def>
+              attribute "foo"
+                []
+            pattern (shortcut_ext_attr.ml[54,1075+14]..[54,1075+15])
+              Ppat_var "x" (shortcut_ext_attr.ml[54,1075+14]..[54,1075+15])
+            expression (shortcut_ext_attr.ml[54,1075+18]..[54,1075+19])
+              Pexp_constant PConst_int (4,None)
+          <def>
+              attribute "foo"
+                []
+            pattern (shortcut_ext_attr.ml[55,1095+10]..[55,1095+11])
+              Ppat_var "y" (shortcut_ext_attr.ml[55,1095+10]..[55,1095+11])
+            expression (shortcut_ext_attr.ml[55,1095+14]..[55,1095+15])
+              Pexp_ident "x" (shortcut_ext_attr.ml[55,1095+14]..[55,1095+15])
+        ]
+    ]
+  structure_item (shortcut_ext_attr.ml[57,1112+0]..[58,1135+17]) ghost
+    Pstr_extension "foo"
+    [
+      structure_item (shortcut_ext_attr.ml[57,1112+0]..[58,1135+17])
+        Pstr_type Rec
+        [
+          type_declaration "t" (shortcut_ext_attr.ml[57,1112+15]..[57,1112+16]) (shortcut_ext_attr.ml[57,1112+0]..[57,1112+22])
+            attribute "foo"
+              []
+            ptype_params =
+              []
+            ptype_cstrs =
+              []
+            ptype_kind =
+              Ptype_abstract
+            ptype_private = Public
+            ptype_manifest =
+              Some
+                core_type (shortcut_ext_attr.ml[57,1112+19]..[57,1112+22])
+                  Ptyp_constr "int" (shortcut_ext_attr.ml[57,1112+19]..[57,1112+22])
+                  []
+          type_declaration "t" (shortcut_ext_attr.ml[58,1135+10]..[58,1135+11]) (shortcut_ext_attr.ml[58,1135+0]..[58,1135+17])
+            attribute "foo"
+              []
+            ptype_params =
+              []
+            ptype_cstrs =
+              []
+            ptype_kind =
+              Ptype_abstract
+            ptype_private = Public
+            ptype_manifest =
+              Some
+                core_type (shortcut_ext_attr.ml[58,1135+14]..[58,1135+17])
+                  Ptyp_constr "int" (shortcut_ext_attr.ml[58,1135+14]..[58,1135+17])
+                  []
+        ]
+    ]
+  structure_item (shortcut_ext_attr.ml[59,1153+0]..[59,1153+21]) ghost
+    Pstr_extension "foo"
+    [
+      structure_item (shortcut_ext_attr.ml[59,1153+0]..[59,1153+21])
+        Pstr_typext
+        type_extension
+          attribute "foo"
+            []
+          ptyext_path = "t" (shortcut_ext_attr.ml[59,1153+15]..[59,1153+16])
+          ptyext_params =
+            []
+          ptyext_constructors =
+            [
+              extension_constructor (shortcut_ext_attr.ml[59,1153+20]..[59,1153+21])
+                pext_name = "T"
+                pext_kind =
+                  Pext_decl
+                    []
+                    None
+            ]
+          ptyext_private = Public
+    ]
+  structure_item (shortcut_ext_attr.ml[61,1176+0]..[61,1176+21]) ghost
+    Pstr_extension "foo"
+    [
+      structure_item (shortcut_ext_attr.ml[61,1176+0]..[61,1176+21])
+        Pstr_class
+        [
+          class_declaration (shortcut_ext_attr.ml[61,1176+0]..[61,1176+21])
+            attribute "foo"
+              []
+            pci_virt = Concrete
+            pci_params =
+              []
+            pci_name = "x" (shortcut_ext_attr.ml[61,1176+16]..[61,1176+17])
+            pci_expr =
+              class_expr (shortcut_ext_attr.ml[61,1176+20]..[61,1176+21])
+                Pcl_constr "x" (shortcut_ext_attr.ml[61,1176+20]..[61,1176+21])
+                []
+        ]
+    ]
+  structure_item (shortcut_ext_attr.ml[62,1198+0]..[62,1198+26]) ghost
+    Pstr_extension "foo"
+    [
+      structure_item (shortcut_ext_attr.ml[62,1198+0]..[62,1198+26])
+        Pstr_class_type
+        [
+          class_type_declaration (shortcut_ext_attr.ml[62,1198+0]..[62,1198+26])
+            attribute "foo"
+              []
+            pci_virt = Concrete
+            pci_params =
+              []
+            pci_name = "x" (shortcut_ext_attr.ml[62,1198+21]..[62,1198+22])
+            pci_expr =
+              class_type (shortcut_ext_attr.ml[62,1198+25]..[62,1198+26])
+                Pcty_constr "x" (shortcut_ext_attr.ml[62,1198+25]..[62,1198+26])
+                []
+        ]
+    ]
+  structure_item (shortcut_ext_attr.ml[63,1225+0]..[63,1225+30]) ghost
+    Pstr_extension "foo"
+    [
+      structure_item (shortcut_ext_attr.ml[63,1225+0]..[63,1225+30])
+        Pstr_primitive
+        value_description "x" (shortcut_ext_attr.ml[63,1225+19]..[63,1225+20]) (shortcut_ext_attr.ml[63,1225+0]..[63,1225+30])
+          attribute "foo"
+            []
+          core_type (shortcut_ext_attr.ml[63,1225+23]..[63,1225+24])
+            Ptyp_any
+          [
+            ""
+          ]
+    ]
+  structure_item (shortcut_ext_attr.ml[64,1256+0]..[64,1256+21]) ghost
+    Pstr_extension "foo"
+    [
+      structure_item (shortcut_ext_attr.ml[64,1256+0]..[64,1256+21])
+        Pstr_exception
+        extension_constructor (shortcut_ext_attr.ml[64,1256+0]..[64,1256+21])
+          pext_name = "X"
+          pext_kind =
+            Pext_decl
+              []
+              None
+    ]
+  structure_item (shortcut_ext_attr.ml[66,1279+0]..[66,1279+22]) ghost
+    Pstr_extension "foo"
+    [
+      structure_item (shortcut_ext_attr.ml[66,1279+0]..[66,1279+22])
+        Pstr_module
+        "M" (shortcut_ext_attr.ml[66,1279+17]..[66,1279+18])
+          attribute "foo"
+            []
+          module_expr (shortcut_ext_attr.ml[66,1279+21]..[66,1279+22])
+            Pmod_ident "M" (shortcut_ext_attr.ml[66,1279+21]..[66,1279+22])
+    ]
+  structure_item (shortcut_ext_attr.ml[67,1302+0]..[68,1333+19]) ghost
+    Pstr_extension "foo"
+    [
+      structure_item (shortcut_ext_attr.ml[67,1302+0]..[68,1333+19])
+        Pstr_recmodule
+        [
+          "M" (shortcut_ext_attr.ml[67,1302+21]..[67,1302+22])
+            attribute "foo"
+              []
+            module_expr (shortcut_ext_attr.ml[67,1302+23]..[67,1302+30])
+              Pmod_constraint
+              module_expr (shortcut_ext_attr.ml[67,1302+29]..[67,1302+30])
+                Pmod_ident "M" (shortcut_ext_attr.ml[67,1302+29]..[67,1302+30])
+              module_type (shortcut_ext_attr.ml[67,1302+25]..[67,1302+26])
+                Pmty_ident "S" (shortcut_ext_attr.ml[67,1302+25]..[67,1302+26])
+          "M" (shortcut_ext_attr.ml[68,1333+10]..[68,1333+11])
+            attribute "foo"
+              []
+            module_expr (shortcut_ext_attr.ml[68,1333+12]..[68,1333+19])
+              Pmod_constraint
+              module_expr (shortcut_ext_attr.ml[68,1333+18]..[68,1333+19])
+                Pmod_ident "M" (shortcut_ext_attr.ml[68,1333+18]..[68,1333+19])
+              module_type (shortcut_ext_attr.ml[68,1333+14]..[68,1333+15])
+                Pmty_ident "S" (shortcut_ext_attr.ml[68,1333+14]..[68,1333+15])
+        ]
+    ]
+  structure_item (shortcut_ext_attr.ml[69,1353+0]..[69,1353+27]) ghost
+    Pstr_extension "foo"
+    [
+      structure_item (shortcut_ext_attr.ml[69,1353+0]..[69,1353+27])
+        Pstr_modtype "S" (shortcut_ext_attr.ml[69,1353+22]..[69,1353+23])
+          attribute "foo"
+            []
+          module_type (shortcut_ext_attr.ml[69,1353+26]..[69,1353+27])
+            Pmty_ident "S" (shortcut_ext_attr.ml[69,1353+26]..[69,1353+27])
+    ]
+  structure_item (shortcut_ext_attr.ml[71,1382+0]..[71,1382+19]) ghost
+    Pstr_extension "foo"
+    [
+      structure_item (shortcut_ext_attr.ml[71,1382+0]..[71,1382+19])
+        Pstr_include          attribute "foo"
+            []
+        module_expr (shortcut_ext_attr.ml[71,1382+18]..[71,1382+19])
+          Pmod_ident "M" (shortcut_ext_attr.ml[71,1382+18]..[71,1382+19])
+    ]
+  structure_item (shortcut_ext_attr.ml[72,1402+0]..[72,1402+16]) ghost
+    Pstr_extension "foo"
+    [
+      structure_item (shortcut_ext_attr.ml[72,1402+0]..[72,1402+16])
+        Pstr_open Fresh "M" (shortcut_ext_attr.ml[72,1402+15]..[72,1402+16])
+          attribute "foo"
+            []
+    ]
+  structure_item (shortcut_ext_attr.ml[75,1442+0]..[98,1838+3])
+    Pstr_modtype "S" (shortcut_ext_attr.ml[75,1442+12]..[75,1442+13])
+      module_type (shortcut_ext_attr.ml[75,1442+16]..[98,1838+3])
+        Pmty_signature
+        [
+          signature_item (shortcut_ext_attr.ml[76,1462+2]..[76,1462+21]) ghost
+            Psig_extension "foo"
+            [
+              signature_item (shortcut_ext_attr.ml[76,1462+2]..[76,1462+21])
+                Psig_value
+                value_description "x" (shortcut_ext_attr.ml[76,1462+16]..[76,1462+17]) (shortcut_ext_attr.ml[76,1462+2]..[76,1462+21])
+                  attribute "foo"
+                    []
+                  core_type (shortcut_ext_attr.ml[76,1462+20]..[76,1462+21])
+                    Ptyp_constr "t" (shortcut_ext_attr.ml[76,1462+20]..[76,1462+21])
+                    []
+                  []
+            ]
+          signature_item (shortcut_ext_attr.ml[77,1484+2]..[77,1484+31]) ghost
+            Psig_extension "foo"
+            [
+              signature_item (shortcut_ext_attr.ml[77,1484+2]..[77,1484+31])
+                Psig_value
+                value_description "x" (shortcut_ext_attr.ml[77,1484+21]..[77,1484+22]) (shortcut_ext_attr.ml[77,1484+2]..[77,1484+31])
+                  attribute "foo"
+                    []
+                  core_type (shortcut_ext_attr.ml[77,1484+25]..[77,1484+26])
+                    Ptyp_constr "t" (shortcut_ext_attr.ml[77,1484+25]..[77,1484+26])
+                    []
+                  [
+                    ""
+                  ]
+            ]
+          signature_item (shortcut_ext_attr.ml[79,1517+2]..[80,1542+20]) ghost
+            Psig_extension "foo"
+            [
+              signature_item (shortcut_ext_attr.ml[79,1517+2]..[80,1542+20])
+                Psig_type Rec
+                [
+                  type_declaration "t" (shortcut_ext_attr.ml[79,1517+17]..[79,1517+18]) (shortcut_ext_attr.ml[79,1517+2]..[79,1517+24])
+                    attribute "foo"
+                      []
+                    ptype_params =
+                      []
+                    ptype_cstrs =
+                      []
+                    ptype_kind =
+                      Ptype_abstract
+                    ptype_private = Public
+                    ptype_manifest =
+                      Some
+                        core_type (shortcut_ext_attr.ml[79,1517+21]..[79,1517+24])
+                          Ptyp_constr "int" (shortcut_ext_attr.ml[79,1517+21]..[79,1517+24])
+                          []
+                  type_declaration "t'" (shortcut_ext_attr.ml[80,1542+12]..[80,1542+14]) (shortcut_ext_attr.ml[80,1542+2]..[80,1542+20])
+                    attribute "foo"
+                      []
+                    ptype_params =
+                      []
+                    ptype_cstrs =
+                      []
+                    ptype_kind =
+                      Ptype_abstract
+                    ptype_private = Public
+                    ptype_manifest =
+                      Some
+                        core_type (shortcut_ext_attr.ml[80,1542+17]..[80,1542+20])
+                          Ptyp_constr "int" (shortcut_ext_attr.ml[80,1542+17]..[80,1542+20])
+                          []
+                ]
+            ]
+          signature_item (shortcut_ext_attr.ml[81,1563+2]..[81,1563+23]) ghost
+            Psig_extension "foo"
+            [
+              signature_item (shortcut_ext_attr.ml[81,1563+2]..[81,1563+23])
+                Psig_typext
+                type_extension
+                  ptyext_path = "t" (shortcut_ext_attr.ml[81,1563+17]..[81,1563+18])
+                  ptyext_params =
+                    []
+                  ptyext_constructors =
+                    [
+                      extension_constructor (shortcut_ext_attr.ml[81,1563+22]..[81,1563+23])
+                        pext_name = "T"
+                        pext_kind =
+                          Pext_decl
+                            []
+                            None
+                    ]
+                  ptyext_private = Public
+            ]
+          signature_item (shortcut_ext_attr.ml[83,1588+2]..[83,1588+23]) ghost
+            Psig_extension "foo"
+            [
+              signature_item (shortcut_ext_attr.ml[83,1588+2]..[83,1588+23])
+                Psig_exception
+                extension_constructor (shortcut_ext_attr.ml[83,1588+2]..[83,1588+23])
+                  pext_name = "X"
+                  pext_kind =
+                    Pext_decl
+                      []
+                      None
+            ]
+          signature_item (shortcut_ext_attr.ml[85,1613+2]..[85,1613+24]) ghost
+            Psig_extension "foo"
+            [
+              signature_item (shortcut_ext_attr.ml[85,1613+2]..[85,1613+24])
+                Psig_module "M" (shortcut_ext_attr.ml[85,1613+19]..[85,1613+20])
+                  attribute "foo"
+                    []
+                module_type (shortcut_ext_attr.ml[85,1613+23]..[85,1613+24])
+                  Pmty_ident "S" (shortcut_ext_attr.ml[85,1613+23]..[85,1613+24])
+            ]
+          signature_item (shortcut_ext_attr.ml[86,1638+2]..[87,1667+17]) ghost
+            Psig_extension "foo"
+            [
+              signature_item (shortcut_ext_attr.ml[86,1638+2]..[87,1667+17])
+                Psig_recmodule
+                [
+                  "M" (shortcut_ext_attr.ml[86,1638+23]..[86,1638+24])
+                    attribute "foo"
+                      []
+                    module_type (shortcut_ext_attr.ml[86,1638+27]..[86,1638+28])
+                      Pmty_ident "S" (shortcut_ext_attr.ml[86,1638+27]..[86,1638+28])
+                  "M" (shortcut_ext_attr.ml[87,1667+12]..[87,1667+13])
+                    attribute "foo"
+                      []
+                    module_type (shortcut_ext_attr.ml[87,1667+16]..[87,1667+17])
+                      Pmty_ident "S" (shortcut_ext_attr.ml[87,1667+16]..[87,1667+17])
+                ]
+            ]
+          signature_item (shortcut_ext_attr.ml[88,1685+2]..[88,1685+24]) ghost
+            Psig_extension "foo"
+            [
+              signature_item (shortcut_ext_attr.ml[88,1685+2]..[88,1685+24])
+                Psig_module "M" (shortcut_ext_attr.ml[88,1685+19]..[88,1685+20])
+                  attribute "foo"
+                    []
+                module_type (shortcut_ext_attr.ml[88,1685+23]..[88,1685+24])
+                  Pmty_alias "M" (shortcut_ext_attr.ml[88,1685+23]..[88,1685+24])
+            ]
+          signature_item (shortcut_ext_attr.ml[90,1711+2]..[90,1711+29]) ghost
+            Psig_extension "foo"
+            [
+              signature_item (shortcut_ext_attr.ml[90,1711+2]..[90,1711+29])
+                Psig_modtype "S" (shortcut_ext_attr.ml[90,1711+24]..[90,1711+25])
+                  attribute "foo"
+                    []
+                  module_type (shortcut_ext_attr.ml[90,1711+28]..[90,1711+29])
+                    Pmty_ident "S" (shortcut_ext_attr.ml[90,1711+28]..[90,1711+29])
+            ]
+          signature_item (shortcut_ext_attr.ml[92,1742+2]..[92,1742+21]) ghost
+            Psig_extension "foo"
+            [
+              signature_item (shortcut_ext_attr.ml[92,1742+2]..[92,1742+21])
+                Psig_include
+                module_type (shortcut_ext_attr.ml[92,1742+20]..[92,1742+21])
+                  Pmty_ident "M" (shortcut_ext_attr.ml[92,1742+20]..[92,1742+21])
+                  attribute "foo"
+                    []
+            ]
+          signature_item (shortcut_ext_attr.ml[93,1764+2]..[93,1764+18]) ghost
+            Psig_extension "foo"
+            [
+              signature_item (shortcut_ext_attr.ml[93,1764+2]..[93,1764+18])
+                Psig_open Fresh "M" (shortcut_ext_attr.ml[93,1764+17]..[93,1764+18])
+                  attribute "foo"
+                    []
+            ]
+          signature_item (shortcut_ext_attr.ml[95,1784+2]..[95,1784+23]) ghost
+            Psig_extension "foo"
+            [
+              signature_item (shortcut_ext_attr.ml[95,1784+2]..[95,1784+23])
+                Psig_class
+                [
+                  class_description (shortcut_ext_attr.ml[95,1784+2]..[95,1784+23])
+                    pci_virt = Concrete
+                    pci_params =
+                      []
+                    pci_name = "x" (shortcut_ext_attr.ml[95,1784+18]..[95,1784+19])
+                    pci_expr =
+                      class_type (shortcut_ext_attr.ml[95,1784+22]..[95,1784+23])
+                        Pcty_constr "t" (shortcut_ext_attr.ml[95,1784+22]..[95,1784+23])
+                        []
+                ]
+            ]
+          signature_item (shortcut_ext_attr.ml[96,1808+2]..[96,1808+28]) ghost
+            Psig_extension "foo"
+            [
+              signature_item (shortcut_ext_attr.ml[96,1808+2]..[96,1808+28])
+                Psig_class_type
+                [
+                  class_type_declaration (shortcut_ext_attr.ml[96,1808+2]..[96,1808+28])
+                    attribute "foo"
+                      []
+                    pci_virt = Concrete
+                    pci_params =
+                      []
+                    pci_name = "x" (shortcut_ext_attr.ml[96,1808+23]..[96,1808+24])
+                    pci_expr =
+                      class_type (shortcut_ext_attr.ml[96,1808+27]..[96,1808+28])
+                        Pcty_constr "x" (shortcut_ext_attr.ml[96,1808+27]..[96,1808+28])
+                        []
+                ]
+            ]
+        ]
+]
+
+File "shortcut_ext_attr.ml", line 4, characters 6-9:
+Uninterpreted extension 'foo'.


### PR DESCRIPTION
Since we are just finished with https://github.com/ocaml/ocaml/pull/326, Let's move on. :]

In current OCaml, instead of writing

``` ocaml
[%foo 
  let x = ...
]
```

it is possible to write

``` ocaml
let%foo x = ...
```

For some reason, this shortcut was added only for the `let`, but not for the other structure. Additionally, it is possible to write `let[@foo] x = ... in ...` but it's not possible to use it on structure items. This patchset adds extension and attributes shortcut on every structure and signature items.

Example of use cases:
- In eliom, for location annotations
- In [ppx_inline_test](https://github.com/janestreet/ppx_inline_test), it allows to replace the akward 

``` ocaml
let%test_module "name" = (module <module-expr>)
```

by the more natural

``` ocaml
module%test My_test = <module-expr>
```

I will add tests/changelog when the conversation reaches a fixpoint.
