### PR TITLE
PR#7075: fix repeated docstrings

### DIFF
--- a/Changes
+++ b/Changes
@@ -388,6 +388,8 @@ Bug fixes:
   (Xavier Leroy)
 - PR#7042 and GPR#295: CSE optimization confuses the FP literals +0.0 and -0.0
   (Xavier Leroy)
+- PR#7075: Fix repetitions in ocamldoc generated documentation
+  (Florian Angeletti)
 - PR#7082: Object type in recursive module's `with` annotation
 - PR#7096: ocamldoc uses an incorrect subscript/superscript style
 - GPR#205: Clear caml_backtrace_last_exn before registering as root

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -59,6 +59,13 @@ let (++) x f = f x
 
 let tool_name = "ocamldoc"
 
+(** Deactivate the generation of docstrings in the lexer *)
+let no_docstring f x =
+  Lexer.handle_docstrings := false;
+  let result = f x in
+  Lexer.handle_docstrings := true;
+  result
+
 let process_implementation_file ppf sourcefile =
   init_path ();
   let prefixname = Filename.chop_extension sourcefile in
@@ -69,7 +76,7 @@ let process_implementation_file ppf sourcefile =
   try
     let parsetree =
       Pparse.file ~tool_name Format.err_formatter inputfile
-        Parse.implementation ast_impl_magic_number
+        (no_docstring Parse.implementation) ast_impl_magic_number
     in
     let typedtree =
       Typemod.type_implementation
@@ -100,7 +107,7 @@ let process_interface_file ppf sourcefile =
   let inputfile = preprocess sourcefile in
   let ast =
     Pparse.file ~tool_name Format.err_formatter inputfile
-      Parse.interface ast_intf_magic_number
+      (no_docstring Parse.interface) ast_intf_magic_number
   in
   let sg = Typemod.type_interface (initial_env()) ast in
   Warnings.check_fatal ();

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -573,15 +573,10 @@ module Analyser =
                 ele.Parsetree.psig_desc
             in
             let new_pos =
-              match ele.Parsetree.psig_desc with
-              | Parsetree.Psig_attribute ({Asttypes.txt = "ocaml.text"}, _) -> last_pos
-                  (* This "signature item" is actually a doc comment; the item is ignored
-                     but don't skip the comment. *)
-              | _ ->
-                 (ele.Parsetree.psig_loc.Location.loc_end.Lexing.pos_cnum + maybe_more)
-                   (* for the comments of constructors in types,
-                      which are after the constructor definition and can
-                      go beyond ele.Parsetree.psig_loc.Location.loc_end.Lexing.pos_cnum *)
+              ele.Parsetree.psig_loc.Location.loc_end.Lexing.pos_cnum + maybe_more
+              (* for the comments of constructors in types,
+                 which are after the constructor definition and can
+                 go beyond ele.Parsetree.psig_loc.Location.loc_end.Lexing.pos_cnum *)
             in
             f (acc_eles @ (ele_comments @ elements))
               new_env

--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -38,6 +38,7 @@ val in_string : unit -> bool;;
 
 
 val print_warnings : bool ref
+val handle_docstrings: bool ref
 val comments : unit -> (string * Location.t) list
 val token_with_comments : Lexing.lexbuf -> Parser.token
 

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -212,6 +212,7 @@ let warn_latin1 lexbuf =
     (Warnings.Deprecated "ISO-Latin1 characters in identifiers")
 ;;
 
+let handle_docstrings = ref true
 let comment_list = ref []
 
 let add_comment com =
@@ -377,7 +378,11 @@ rule token = parse
         COMMENT (s, loc) }
   | "(**"
       { let s, loc = with_comment_buffer comment lexbuf in
-        DOCSTRING (Docstrings.docstring s loc) }
+        if !handle_docstrings then
+          DOCSTRING (Docstrings.docstring s loc)
+        else
+          COMMENT ("*" ^ s, loc)
+      }
   | "(**" ('*'+) as stars
       { let s, loc =
           with_comment_buffer

--- a/testsuite/tests/tool-ocamldoc-2/Makefile
+++ b/testsuite/tests/tool-ocamldoc-2/Makefile
@@ -1,0 +1,50 @@
+#########################################################################
+#                                                                       #
+#                                 OCaml                                 #
+#                                                                       #
+#                 Xavier Clerc, SED, INRIA Rocquencourt                 #
+#                                                                       #
+#   Copyright 2010 Institut National de Recherche en Informatique et    #
+#   en Automatique.  All rights reserved.  This file is distributed     #
+#   under the terms of the Q Public License version 1.0.                #
+#                                                                       #
+#########################################################################
+
+BASEDIR=../..
+COMPFLAGS=-I $(OTOPDIR)/ocamldoc
+LD_PATH=$(TOPDIR)/otherlibs/$(UNIXLIBVAR)unix:$(TOPDIR)/otherlibs/str
+DOCFLAGS=-I $(OTOPDIR)/stdlib $(COMPFLAGS)\
+	-latextitle "6,subsection*" \
+	-latextitle "7,subsubsection*" \
+	-latex-type-prefix "TYP" \
+	-latex-module-prefix "" \
+	-latex-module-type-prefix "" \
+	-latex-value-prefix ""
+
+.PHONY: default
+default:
+	@if ! $(SUPPORTS_SHARED_LIBRARIES); then \
+	  echo 'skipped (shared libraries not available)'; \
+	else \
+	  $(SET_LD_PATH) $(MAKE) run; \
+	fi
+
+.PHONY: run
+run: *.mli
+	@for file in *.mli; do \
+	  printf " ... testing '$$file'"; \
+	  F="`basename $$file .mli`"; \
+	  $(OCAMLDOC) $(DOCFLAGS) -hide-warnings -latex $ \
+	              -o $$F.result $$file; \
+	  $(DIFF) $$F.reference $$F.result >/dev/null \
+	  && echo " => passed" || echo " => failed"; \
+	done
+
+.PHONY: promote
+promote: defaultpromote
+
+.PHONY: clean
+clean: defaultclean
+	@rm -f *.result *.html *.tex *.log *.out *.sty *.toc *.css *.aux
+
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/tool-ocamldoc-2/test.mli
+++ b/testsuite/tests/tool-ocamldoc-2/test.mli
@@ -1,0 +1,30 @@
+
+(** Ten comments for tests *)
+
+(** {6 A first comments for title } *)
+
+(** {7 A subsection for ocamldoc *} *)
+
+(** {7 Bis } *)
+
+(** {7 Ter } *)
+
+(** {6 A new section } *)
+
+(** {7 And its subsection } *)
+
+(** {7 Encore } *)
+
+(** Encore! Encore! *)
+
+
+(**/**)
+module Silence : sig
+  (** At last *)
+end
+
+(**/**)
+
+(** {7 With strange aeons } *)
+
+module End : sig end

--- a/testsuite/tests/tool-ocamldoc-2/test.reference
+++ b/testsuite/tests/tool-ocamldoc-2/test.reference
@@ -1,0 +1,74 @@
+\documentclass[11pt]{article} 
+\usepackage[latin1]{inputenc} 
+\usepackage[T1]{fontenc} 
+\usepackage{textcomp}
+\usepackage{fullpage} 
+\usepackage{url} 
+\usepackage{ocamldoc}
+\begin{document}
+\tableofcontents
+\section{Module {\tt{Test}} : Ten comments for tests}
+\label{Test}\index{Test@\verb`Test`}
+
+
+
+
+\ocamldocvspace{0.5cm}
+
+
+
+\subsection*{A first comments for title }
+
+
+
+
+\subsubsection*{A subsection for ocamldoc *}
+
+
+
+
+\subsubsection*{Bis }
+
+
+
+
+\subsubsection*{Ter }
+
+
+
+
+\subsection*{A new section }
+
+
+
+
+\subsubsection*{And its subsection }
+
+
+
+
+\subsubsection*{Encore }
+
+
+
+
+Encore! Encore!
+
+
+
+\subsubsection*{With strange aeons }
+
+
+
+
+\begin{ocamldoccode}
+{\tt{module }}{\tt{End}}{\tt{ : }}\end{ocamldoccode}
+\label{Test.End}\index{End@\verb`End`}
+
+\begin{ocamldocsigend}
+\end{ocamldocsigend}
+
+
+
+
+\end{document}


### PR DESCRIPTION
This pull request hopefully fixes the problem of the repetition of documentation comments in ocamldoc-generated documentations. At least, it fixes all repetition and empty section title problems reported in [mantis:7075](http://caml.inria.fr/mantis/view.php?id=7075).
