### PR TITLE
Make Pparse functions type-safe

### DIFF
--- a/Changes
+++ b/Changes
@@ -34,6 +34,10 @@ OCaml 4.04.0:
 
 - PR#7200, GPR#539: Improve, fix, and add test for parsing/pprintast.ml
   (Runhang Li, David Sheets, Alain Frisch)
+
+- GPR#351: make driver/pparse.ml functions type-safe
+  (Gabriel Scherer, Dmitrii Kosarev, review by Jérémie Dimino)
+
 - GPR#548: empty documentation comments
   (Florian Angeletti)
 

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -47,20 +47,26 @@ let remove_preprocessed inputfile =
     None -> ()
   | Some _ -> Misc.remove_file inputfile
 
+type 'a ast_kind =
+| Structure : Parsetree.structure ast_kind
+| Signature : Parsetree.signature ast_kind
+
+let magic_of_kind : type a . a ast_kind -> string = function
+  | Structure -> Config.ast_impl_magic_number
+  | Signature -> Config.ast_intf_magic_number
 
 (* Note: some of the functions here should go to Ast_mapper instead,
    which would encapsulate the "binary AST" protocol. *)
 
-let write_ast magic ast =
-  let fn = Filename.temp_file "camlppx" "" in
+let write_ast (type a) (kind : a ast_kind) fn (ast : a) =
   let oc = open_out_bin fn in
-  output_string oc magic;
-  output_value oc !Location.input_name;
-  output_value oc ast;
-  close_out oc;
-  fn
+  output_string oc (magic_of_kind kind);
+  output_value oc (!Location.input_name : string);
+  output_value oc (ast : a);
+  close_out oc
 
-let apply_rewriter magic fn_in ppx =
+let apply_rewriter kind fn_in ppx =
+  let magic = magic_of_kind kind in
   let fn_out = Filename.temp_file "camlppx" "" in
   let comm =
     Printf.sprintf "%s %s %s" ppx (Filename.quote fn_in) (Filename.quote fn_out)
@@ -84,13 +90,14 @@ let apply_rewriter magic fn_in ppx =
   end;
   fn_out
 
-let read_ast magic fn =
+let read_ast (type a) (kind : a ast_kind) fn : a =
   let ic = open_in_bin fn in
   try
+    let magic = magic_of_kind kind in
     let buffer = really_input_string ic (String.length magic) in
     assert(buffer = magic); (* already checked by apply_rewriter *)
-    Location.input_name := input_value ic;
-    let ast = input_value ic in
+    Location.input_name := (input_value ic : string);
+    let ast = (input_value ic : a) in
     close_in ic;
     Misc.remove_file fn;
     ast
@@ -99,34 +106,37 @@ let read_ast magic fn =
     Misc.remove_file fn;
     raise exn
 
-let rewrite magic ast ppxs =
-  read_ast magic
-    (List.fold_left (apply_rewriter magic) (write_ast magic ast)
-       (List.rev ppxs))
+let rewrite kind ppxs ast =
+  let fn = Filename.temp_file "camlppx" "" in
+  write_ast kind fn ast;
+  let fn = List.fold_left (apply_rewriter kind) fn (List.rev ppxs) in
+  read_ast kind fn
 
 let apply_rewriters_str ?(restore = true) ~tool_name ast =
   match !Clflags.all_ppx with
   | [] -> ast
   | ppxs ->
-      let ast = Ast_mapper.add_ppx_context_str ~tool_name ast in
-      let ast = rewrite Config.ast_impl_magic_number ast ppxs in
-      Ast_mapper.drop_ppx_context_str ~restore ast
+      ast
+      |> Ast_mapper.add_ppx_context_str ~tool_name
+      |> rewrite Structure ppxs
+      |> Ast_mapper.drop_ppx_context_str ~restore
 
 let apply_rewriters_sig ?(restore = true) ~tool_name ast =
   match !Clflags.all_ppx with
   | [] -> ast
   | ppxs ->
-      let ast = Ast_mapper.add_ppx_context_sig ~tool_name ast in
-      let ast = rewrite Config.ast_intf_magic_number ast ppxs in
-      Ast_mapper.drop_ppx_context_sig ~restore ast
+      ast
+      |> Ast_mapper.add_ppx_context_sig ~tool_name
+      |> rewrite Signature ppxs
+      |> Ast_mapper.drop_ppx_context_sig ~restore
 
-let apply_rewriters ?restore ~tool_name magic ast =
-  if magic = Config.ast_impl_magic_number then
-    Obj.magic (apply_rewriters_str ?restore ~tool_name (Obj.magic ast))
-  else if magic = Config.ast_intf_magic_number then
-    Obj.magic (apply_rewriters_sig ?restore ~tool_name (Obj.magic ast))
-  else
-    assert false
+let apply_rewriters ?restore ~tool_name
+    (type a) (kind : a ast_kind) (ast : a) : a =
+  match kind with
+  | Structure ->
+      apply_rewriters_str ?restore ~tool_name ast
+  | Signature ->
+      apply_rewriters_sig ?restore ~tool_name ast
 
 (* Parse a file or get a dumped syntax tree from it *)
 
@@ -148,7 +158,13 @@ let open_and_check_magic inputfile ast_magic =
   in
   (ic, is_ast_file)
 
-let file_aux ppf ~tool_name inputfile parse_fun invariant_fun ast_magic =
+let parse (type a) (kind : a ast_kind) lexbuf : a =
+  match kind with
+  | Structure -> Parse.implementation lexbuf
+  | Signature -> Parse.interface lexbuf
+
+let file_aux ppf ~tool_name inputfile (type a) parse_fun invariant_fun (kind : a ast_kind) =
+  let ast_magic = magic_of_kind kind in
   let (ic, is_ast_file) = open_and_check_magic inputfile ast_magic in
   let ast =
     try
@@ -157,8 +173,8 @@ let file_aux ppf ~tool_name inputfile parse_fun invariant_fun ast_magic =
           (* FIXME make this a proper warning *)
           fprintf ppf "@[Warning: %s@]@."
             "option -unsafe used with a preprocessor returning a syntax tree";
-        Location.input_name := input_value ic;
-        input_value ic
+        Location.input_name := (input_value ic : string);
+        (input_value ic : a)
       end else begin
         seek_in ic 0;
         Location.input_name := inputfile;
@@ -169,12 +185,12 @@ let file_aux ppf ~tool_name inputfile parse_fun invariant_fun ast_magic =
     with x -> close_in ic; raise x
   in
   close_in ic;
-  let ast = apply_rewriters ~restore:false ~tool_name ast_magic ast in
+  let ast = apply_rewriters ~restore:false ~tool_name kind ast in
   if is_ast_file || !Clflags.all_ppx <> [] then invariant_fun ast;
   ast
 
-let file ppf ~tool_name inputfile parse_fun ast_magic =
-  file_aux ppf ~tool_name inputfile parse_fun ignore ast_magic
+let file ppf ~tool_name inputfile parse_fun ast_kind =
+  file_aux ppf ~tool_name inputfile parse_fun ignore ast_kind
 
 let report_error ppf = function
   | CannotRun cmd ->
@@ -191,11 +207,12 @@ let () =
       | _ -> None
     )
 
-let parse_all ~tool_name parse_fun invariant_fun magic ppf sourcefile =
+let parse_file ~tool_name invariant_fun kind ppf sourcefile =
   Location.input_name := sourcefile;
   let inputfile = preprocess sourcefile in
   let ast =
-    try file_aux ppf ~tool_name inputfile parse_fun invariant_fun magic
+    let parse_fun = Timings.(time (Parsing sourcefile)) (parse kind) in
+    try file_aux ppf ~tool_name inputfile parse_fun invariant_fun kind
     with exn ->
       remove_preprocessed inputfile;
       raise exn
@@ -204,12 +221,6 @@ let parse_all ~tool_name parse_fun invariant_fun magic ppf sourcefile =
   ast
 
 let parse_implementation ppf ~tool_name sourcefile =
-  parse_all ~tool_name
-    (Timings.(time (Parsing sourcefile)) Parse.implementation)
-    Ast_invariants.structure
-    Config.ast_impl_magic_number ppf sourcefile
+  parse_file ~tool_name Ast_invariants.structure Structure ppf sourcefile
 let parse_interface ppf ~tool_name sourcefile =
-  parse_all ~tool_name
-    (Timings.(time (Parsing sourcefile)) Parse.interface)
-    Ast_invariants.signature
-    Config.ast_intf_magic_number ppf sourcefile
+  parse_file ~tool_name Ast_invariants.signature Signature ppf sourcefile

--- a/driver/pparse.mli
+++ b/driver/pparse.mli
@@ -23,10 +23,19 @@ exception Error of error
 
 val preprocess : string -> string
 val remove_preprocessed : string -> unit
-val file :
-  formatter -> tool_name:string -> string -> (Lexing.lexbuf -> 'a) -> string ->
-  'a
-val apply_rewriters: ?restore:bool -> tool_name:string -> string -> 'a -> 'a
+
+type 'a ast_kind =
+| Structure : Parsetree.structure ast_kind
+| Signature : Parsetree.signature ast_kind
+
+val read_ast : 'a ast_kind -> string -> 'a
+val write_ast : 'a ast_kind -> string -> 'a -> unit
+
+val file : formatter -> tool_name:string -> string ->
+  (Lexing.lexbuf -> 'a) -> 'a ast_kind -> 'a
+
+val apply_rewriters: ?restore:bool -> tool_name:string ->
+  'a ast_kind -> 'a -> 'a
   (** If [restore = true] (the default), cookies set by external
       rewriters will be kept for later calls. *)
 
@@ -36,7 +45,6 @@ val apply_rewriters_str:
 val apply_rewriters_sig:
   ?restore:bool -> tool_name:string -> Parsetree.signature ->
   Parsetree.signature
-
 
 val report_error : formatter -> error -> unit
 
@@ -49,4 +57,3 @@ val parse_interface:
 (* [call_external_preprocessor sourcefile pp] *)
 val call_external_preprocessor : string -> string -> string
 val open_and_check_magic : string -> string -> in_channel * bool
-val read_ast : string -> string -> 'a

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -18,7 +18,6 @@
 
 let print_DEBUG s = print_string s ; print_newline ()
 
-open Config
 open Format
 open Typedtree
 
@@ -28,7 +27,7 @@ open Typedtree
    then the directories specified with the -I option (in command-line order),
    then the standard library directory. *)
 let init_path () =
-  load_path :=
+  Config.load_path :=
     "" :: List.rev (Config.standard_library :: !Clflags.include_dirs);
   Env.reset_cache ()
 
@@ -88,7 +87,7 @@ let process_implementation_file sourcefile =
   try
     let parsetree =
       Pparse.file ~tool_name Format.err_formatter inputfile
-        (no_docstring Parse.implementation) ast_impl_magic_number
+        (no_docstring Parse.implementation) Pparse.Structure
     in
     let typedtree =
       Typemod.type_implementation
@@ -119,7 +118,7 @@ let process_interface_file sourcefile =
   let inputfile = preprocess sourcefile in
   let ast =
     Pparse.file ~tool_name Format.err_formatter inputfile
-      (no_docstring Parse.interface) ast_intf_magic_number
+      (no_docstring Parse.interface) Pparse.Signature
   in
   let sg = Typemod.type_interface (initial_env()) ast in
   Warnings.check_fatal ();

--- a/tools/ocamldep.ml
+++ b/tools/ocamldep.ml
@@ -279,15 +279,14 @@ let read_and_approximate inputfile =
     report_err exn;
     !Depend.free_structure_names
 
-let read_parse_and_extract parse_function extract_function def magic
-    source_file =
+let read_parse_and_extract parse_function extract_function def ast_kind source_file =
   Depend.free_structure_names := Depend.StringSet.empty;
   try
     let input_file = Pparse.preprocess source_file in
     begin try
       let ast =
         Pparse.file ~tool_name Format.err_formatter
-                    input_file parse_function magic
+                    input_file parse_function ast_kind
       in
       let bound_vars =
         List.fold_left
@@ -359,14 +358,14 @@ let ml_file_dependencies source_file =
   in
   let (extracted_deps, ()) =
     read_parse_and_extract parse_use_file_as_impl Depend.add_implementation ()
-                           Config.ast_impl_magic_number source_file
+                           Pparse.Structure source_file
   in
   files := (source_file, ML, extracted_deps) :: !files
 
 let mli_file_dependencies source_file =
   let (extracted_deps, ()) =
     read_parse_and_extract Parse.interface Depend.add_signature ()
-                           Config.ast_intf_magic_number source_file
+                           Pparse.Signature source_file
   in
   files := (source_file, MLI, extracted_deps) :: !files
 
@@ -494,11 +493,11 @@ let rec dump_map s0 ppf m =
 
 let process_ml_map =
   read_parse_and_extract Parse.implementation Depend.add_implementation_binding
-                         StringMap.empty Config.ast_impl_magic_number
+                         StringMap.empty Pparse.Structure
 
 let process_mli_map =
   read_parse_and_extract Parse.interface Depend.add_signature_binding
-                         StringMap.empty Config.ast_intf_magic_number
+                         StringMap.empty Pparse.Signature
 
 let parse_map fname =
   map_files := fname :: !map_files ;


### PR DESCRIPTION
In order to remove some redundancy, the Pparse modules used a dirty
Obj.magic trick to manipulate either structure or signature values
(ASTs parsed from source files). This unsafe approach means that
programming mistakes may result in broken type soudness, and indeed
I myself had to track a very puzzling Segfault during the development
of my Menhir backend (due to a copy-paste error I was passing
Parse.implementation instead of Parse.interface somewhere). Wondering
why your parser generator seems to generate segfaulting parsers is
Not Fun.

This change means that the external interface of Pparse has changed
a bit. There is no way to fulfill the type of Pparse.file in
a type-safe way

```
val file : formatter -> tool_name:string -> string ->
  (Lexing.lexbuf -> 'a) -> string -> 'a
```

as it promises to be able to process any ast type 'a depending on the
magic number (the last string argument). The knew type-safe interface is

```
val file : formatter -> tool_name:string -> string ->
  (Lexing.lexbuf -> 'a) -> 'a ast_kind -> 'a
```

where ['a ast_kind] is a GADT type:

```
type 'a ast_kind =
| Structure : Parsetree.structure ast_kind
| Signature : Parsetree.signature ast_kind
```
