### PR TITLE
Improve comment on Lazy.from_fun

### DIFF
--- a/stdlib/lazy.mli
+++ b/stdlib/lazy.mli
@@ -62,6 +62,11 @@ val force_val : 'a t -> 'a;;
 
 val from_fun : (unit -> 'a) -> 'a t;;
 (** [from_fun f] is the same as [lazy (f ())] but slightly more efficient.
+
+    [from_fun] should only be used if the function [f] is already defined.
+    In particular it is always less efficient to write
+    [from_fun (fun () -> expr)] than [lazy expr].
+
     @since 4.00.0 *)
 
 val from_val : 'a -> 'a t;;


### PR DESCRIPTION
Jeremie noticed that Jane Street code had a lot of occurrences of:

Lazy.from_fun (fun () -> ...)

instead of:

lazy ...

This may be because of the comment on Lazy.from_fun in the stdlib, which this pull request aims to improve.
