### PR TITLE
Add various utility functions in Misc

### DIFF
--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -77,31 +77,36 @@ module Stdlib = struct
       | (hd1 :: tl1, hd2 :: tl2) -> eq hd1 hd2 && equal eq tl1 tl2
       | (_, _) -> false
 
-    let rec filter_map f l =
-      match l with
-      | [] -> []
-      | h :: t ->
-        match f h with
-        | None -> filter_map f t
-        | Some v -> v :: filter_map f t
+    let filter_map f l =
+      let rec aux acc l =
+        match l with
+        | [] -> List.rev acc
+        | h :: t ->
+          match f h with
+          | None -> aux acc t
+          | Some v -> aux (v :: acc) t
+      in
+      aux [] l
 
-    let rec map2_prefix f l1 l2 =
-      match l1, l2 with
-      | [], _ -> [], l2
-      | h::t, [] -> raise (Invalid_argument "map2_prefix")
-      | h1::t1, h2::t2 ->
-        let h = f h1 h2 in
-        let t, rem = map2_prefix f t1 t2 in
-        h :: t, rem
+    let map2_prefix f l1 l2 =
+      let rec aux acc l1 l2 =
+        match l1, l2 with
+        | [], _ -> (List.rev acc, l2)
+        | h::t, [] -> raise (Invalid_argument "map2_prefix")
+        | h1::t1, h2::t2 ->
+          let h = f h1 h2 in
+          aux (h :: acc) t1 t2
+      in
+      aux [] l1 l2
 
-    let rec some_if_all_elements_are_some = function
-      | [] -> Some []
-      | h::t ->
-        match some_if_all_elements_are_some t with
-        | None -> None
-        | Some t' -> match h with
-          | None -> None
-          | Some h' -> Some (h' :: t')
+    let some_if_all_elements_are_some l =
+      let rec aux acc l =
+        match l with
+        | [] -> Some (List.rev acc)
+        | None :: _ -> None
+        | Some h :: t -> aux (h :: acc) t
+      in
+      aux [] l
 
     let split_at n l =
       let rec aux n acc l =
@@ -110,8 +115,8 @@ module Stdlib = struct
         else
           match l with
           | [] -> raise (Invalid_argument "split_at")
-          | t::q ->
-              aux (n-1) (t::acc) q in
+          | t::q -> aux (n-1) (t::acc) q
+      in
       aux n [] l
   end
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -70,6 +70,73 @@ let rec samelist pred l1 l2 =
   | (hd1 :: tl1, hd2 :: tl2) -> pred hd1 hd2 && samelist pred tl1 tl2
   | (_, _) -> false
 
+let sameoption pred o1 o2 =
+  match (o1, o2) with
+  | None, None -> true
+  | Some e1, Some e2 -> pred e1 e2
+  | _, _ -> false
+
+let rec map2_head f l1 l2 =
+  match l1, l2 with
+  | [], _ -> [], l2
+  | h::t, [] -> raise (Invalid_argument "map2_head")
+  | h1::t1, h2::t2 ->
+      let h = f h1 h2 in
+      let (t,rem) = map2_head f t1 t2 in
+      h::t, rem
+
+let rec some_if_all_elements_are_some = function
+  | [] -> Some []
+  | h::t ->
+      match some_if_all_elements_are_some t with
+      | None -> None
+      | Some t' -> match h with
+        | None -> None
+        | Some h' -> Some (h' :: t')
+
+let split_at n l =
+  let rec aux n acc l =
+    if n = 0
+    then List.rev acc, l
+    else
+      match l with
+      | [] -> raise (Invalid_argument "split_at")
+      | t::q ->
+          aux (n-1) (t::acc) q in
+  aux n [] l
+
+let uniq_sort compare l =
+  let l = List.sort compare l in
+  let rec aux = function
+    | [] -> []
+    | [_] as l -> l
+    | h1 :: ((h2 :: _) as t) ->
+        if compare h1 h2 = 0
+        then aux t
+        else h1 :: aux t
+  in
+  aux l
+
+let rec filter_map f l =
+  match l with
+  | [] -> []
+  | h :: t ->
+    match f h with
+    | None -> filter_map f t
+    | Some v -> v :: filter_map f t
+
+let rec compare_lists compare l1 l2 =
+  match l1, l2 with
+  | [], [] -> 0
+  | [], _::_ -> -1
+  | _::_, [] -> 1
+  | h1::t1, h2::t2 ->
+    let c = compare h1 h2 in
+    if c <> 0 then
+      c
+    else
+      compare_lists compare t1 t2
+
 (* Options *)
 
 let may f = function
@@ -79,6 +146,16 @@ let may f = function
 let may_map f = function
     Some x -> Some (f x)
   | None -> None
+
+let may_fold f a b =
+  match a with
+  | None -> b
+  | Some a -> f a b
+
+let may_default f a b =
+  match a with
+  | None -> b
+  | Some a -> f a
 
 (* File functions *)
 
@@ -235,18 +312,24 @@ let replace_substring ~before ~after str =
         List.rev (suffix :: acc)
   in String.concat after (search [] 0)
 
-let rev_split_words s =
+let rev_split_words ?separator s =
+  let is_separator c =
+    match separator with
+    | Some separator -> c = separator
+    | None ->
+      match c with
+      | ' ' | '\t' | '\r' | '\n' -> true
+      | _ -> false
+  in
   let rec split1 res i =
     if i >= String.length s then res else begin
-      match s.[i] with
-        ' ' | '\t' | '\r' | '\n' -> split1 res (i+1)
-      | _ -> split2 res i (i+1)
+      if is_separator s.[i] then split1 res (i+1)
+      else split2 res i (i+1)
     end
   and split2 res i j =
     if j >= String.length s then String.sub s i (j-i) :: res else begin
-      match s.[j] with
-        ' ' | '\t' | '\r' | '\n' -> split1 (String.sub s i (j-i) :: res) (j+1)
-      | _ -> split2 res i (j+1)
+      if is_separator s.[j] then split1 (String.sub s i (j-i) :: res) (j+1)
+      else split2 res i (j+1)
     end
   in split1 [] 0
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -49,20 +49,21 @@ module Stdlib : sig
         with respect to the given equality function. *)
 
     val filter_map : ('a -> 'b option) -> 'a t -> 'b t
-    (** [filter_map f l] is the list [List.map f l] with only the
-        elements matching [Some _]. *)
+    (** [filter_map f l] applies [f] to every element of [l], filters
+        out the [None] elements and returns the list of the arguments of
+        the [Some] elements. *)
 
     val some_if_all_elements_are_some : 'a option t -> 'a t option
     (** If all elements of the given list are [Some _] then [Some xs]
         is returned with the [xs] being the contents of those [Some]s, with
-        order preserved.  Otherwise returns [None]. *)
+        order preserved.  Otherwise return [None]. *)
 
     val map2_prefix : ('a -> 'b -> 'c) -> 'a t -> 'b t -> ('c t * 'b t)
     (** [let r1, r2 = map2_prefix f l1 l2]
         If [l1] is of length n and [l2 = h2 @ t2] with h2 of length n,
         r1 is [List.map2 f l1 h1] and r2 is t2. *)
 
-    val split_at: int -> 'a t -> 'a t * 'a t
+    val split_at : int -> 'a t -> 'a t * 'a t
     (** [split_at n l] returns the pair [before, after] where [before] is
         the [n] first elements of [l] and [after] the remaining ones.
         If [l] has less than [n] elements, raises Invalid_argument. *)
@@ -83,7 +84,9 @@ module Stdlib : sig
     type t = string
 
     val split : t -> on:char -> t list
-    (** Splits the given string at every occurrence of the given character. *)
+    (** Splits the given string at every occurrence of the given separator.
+        Does not return empty substrings when the separator is repeated or
+        present at the start or end of the string. *)
   end
 end
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -38,9 +38,30 @@ val split_last: 'a list -> 'a list * 'a
 val samelist: ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
         (* Like [List.for_all2] but returns [false] if the two
            lists have different length. *)
-
+val sameoption: ('a -> 'a -> bool) -> 'a option -> 'a option -> bool
+val map2_head: ('a -> 'b -> 'c) -> 'a list -> 'b list -> ('c list * 'b list)
+        (* [let (r1,r2) = map2_head f l1 l2]
+           If [l1] is of length n and [l2 = h2 @ t2] with h2 of length n
+           and t2 of length k, r1 is [List.map2 f l1 h1] and r2 is t2 *)
+val some_if_all_elements_are_some: 'a option list -> 'a list option
+val split_at: int -> 'a list -> 'a list * 'a list
+        (* [split_at n l] returns the couple [before, after]
+           where [before] are the [n] first elements of [l] and [after]
+           are the remaining ones.
+           If [l] has less than [n] elements, raises Invalid_argument *)
+val uniq_sort : ('a -> 'a -> int) -> 'a list -> 'a list
+        (* Sorts and remove duplicated elements according to the
+           comparison function *)
+val filter_map : ('a -> 'b option) -> 'a list -> 'b list
+        (* [filter_map f l] is the list [List.map f l] with only the
+           elements matching [Some _] *)
+val compare_lists : ('a -> 'a -> int) -> 'a list -> 'a list -> int
+        (* compare_lists is the lexicographic order supported by the
+           provided order *)
 val may: ('a -> unit) -> 'a option -> unit
 val may_map: ('a -> 'b) -> 'a option -> 'b option
+val may_fold: ('a -> 'b -> 'b) -> 'a option -> 'b -> 'b
+val may_default: ('a -> 'b) -> 'a option -> 'b -> 'b
 
 val find_in_path: string list -> string -> string
         (* Search a file in a list of directories. *)
@@ -118,8 +139,9 @@ val replace_substring: before:string -> after:string -> string -> string
            occurences of [before] with [after] in [str] and returns
            the resulting string. *)
 
-val rev_split_words: string -> string list
-        (* [rev_split_words s] splits [s] in blank-separated words, and return
+val rev_split_words: ?separator:char -> string -> string list
+        (* [rev_split_words s] splits [s] in blank-separated words (or
+           [separator]-separated words if specified), and return
            the list of words in reverse order. *)
 
 val get_ref: 'a list ref -> 'a list

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -25,8 +25,6 @@ val for_all2: ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
         (* Same as [List.for_all] but for a binary predicate.
            In addition, this [for_all2] never fails: given two lists
            with different lengths, it returns false. *)
-val filter_map: ('a -> 'b option) -> 'a list -> 'b list
-        (* Same as [List.map] but removes [None] from the output *)
 val replicate_list: 'a -> int -> 'a list
         (* [replicate_list elem n] is the list with [n] elements
            all identical to [elem]. *)
@@ -35,33 +33,59 @@ val list_remove: 'a -> 'a list -> 'a list
            element equal to [x] removed. *)
 val split_last: 'a list -> 'a list * 'a
         (* Return the last element and the other elements of the given list. *)
-val samelist: ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
-        (* Like [List.for_all2] but returns [false] if the two
-           lists have different length. *)
-val sameoption: ('a -> 'a -> bool) -> 'a option -> 'a option -> bool
-val map2_head: ('a -> 'b -> 'c) -> 'a list -> 'b list -> ('c list * 'b list)
-        (* [let (r1,r2) = map2_head f l1 l2]
-           If [l1] is of length n and [l2 = h2 @ t2] with h2 of length n
-           and t2 of length k, r1 is [List.map2 f l1 h1] and r2 is t2 *)
-val some_if_all_elements_are_some: 'a option list -> 'a list option
-val split_at: int -> 'a list -> 'a list * 'a list
-        (* [split_at n l] returns the couple [before, after]
-           where [before] are the [n] first elements of [l] and [after]
-           are the remaining ones.
-           If [l] has less than [n] elements, raises Invalid_argument *)
-val uniq_sort : ('a -> 'a -> int) -> 'a list -> 'a list
-        (* Sorts and remove duplicated elements according to the
-           comparison function *)
-val filter_map : ('a -> 'b option) -> 'a list -> 'b list
-        (* [filter_map f l] is the list [List.map f l] with only the
-           elements matching [Some _] *)
-val compare_lists : ('a -> 'a -> int) -> 'a list -> 'a list -> int
-        (* compare_lists is the lexicographic order supported by the
-           provided order *)
 val may: ('a -> unit) -> 'a option -> unit
 val may_map: ('a -> 'b) -> 'a option -> 'b option
-val may_fold: ('a -> 'b -> 'b) -> 'a option -> 'b -> 'b
-val may_default: ('a -> 'b) -> 'a option -> 'b -> 'b
+
+module Stdlib : sig
+  module List : sig
+    type 'a t = 'a list
+
+    val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
+    (** The lexicographic order supported by the provided order.
+        There is no constraint on the relative lengths of the lists. *)
+
+    val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+    (** Returns [true] iff the given lists have the same length and content
+        with respect to the given equality function. *)
+
+    val filter_map : ('a -> 'b option) -> 'a t -> 'b t
+    (** [filter_map f l] is the list [List.map f l] with only the
+        elements matching [Some _]. *)
+
+    val some_if_all_elements_are_some : 'a option t -> 'a t option
+    (** If all elements of the given list are [Some _] then [Some xs]
+        is returned with the [xs] being the contents of those [Some]s, with
+        order preserved.  Otherwise returns [None]. *)
+
+    val map2_prefix : ('a -> 'b -> 'c) -> 'a t -> 'b t -> ('c t * 'b t)
+    (** [let r1, r2 = map2_prefix f l1 l2]
+        If [l1] is of length n and [l2 = h2 @ t2] with h2 of length n,
+        r1 is [List.map2 f l1 h1] and r2 is t2. *)
+
+    val split_at: int -> 'a t -> 'a t * 'a t
+    (** [split_at n l] returns the pair [before, after] where [before] is
+        the [n] first elements of [l] and [after] the remaining ones.
+        If [l] has less than [n] elements, raises Invalid_argument. *)
+  end
+
+  module Option : sig
+    type 'a t = 'a option
+
+    val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+    val iter : ('a -> unit) -> 'a t -> unit
+    val map : ('a -> 'b) -> 'a t -> 'b t
+    val fold : ('a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+    val value_default : ('a -> 'b) -> default:'b -> 'a t -> 'b
+  end
+
+  module String : sig
+    type t = string
+
+    val split : t -> on:char -> t list
+    (** Splits the given string at every occurrence of the given character. *)
+  end
+end
 
 val find_in_path: string list -> string -> string
         (* Search a file in a list of directories. *)
@@ -139,9 +163,8 @@ val replace_substring: before:string -> after:string -> string -> string
            occurences of [before] with [after] in [str] and returns
            the resulting string. *)
 
-val rev_split_words: ?separator:char -> string -> string list
-        (* [rev_split_words s] splits [s] in blank-separated words (or
-           [separator]-separated words if specified), and return
+val rev_split_words: string -> string list
+        (* [rev_split_words s] splits [s] in blank-separated words, and returns
            the list of words in reverse order. *)
 
 val get_ref: 'a list ref -> 'a list


### PR DESCRIPTION
Flambda depends on various extra functions that should arguably live in the standard library, but to avoid arguments about the standard library, are proposed to live in [Misc] for the moment since they do not require internal access to representations.

The change to [rev_split_words] is required for an argument parsing module that will be submitted shortly.
