### PR TITLE
Manual: alternative polymorphic variants intro

### DIFF
--- a/manual/manual/tutorials/lablexamples.etex
+++ b/manual/manual/tutorials/lablexamples.etex
@@ -317,10 +317,12 @@ is only used when a more detailed specification is needed.
 Variants as presented in section~\ref{s:tut-recvariants} are a
 powerful tool to build data structures and algorithms. However they
 sometimes lack flexibility when used in modular programming. This is
-due to the fact every constructor reserves a name to be used with a
-unique type. One cannot use the same name in another type, or consider
-a value of some type to belong to some other type with more
-constructors.
+due to the fact that every constructor is assigned to an unique type
+when defined and used. Even if the same name appears in the definition
+of multiple types, the constructor itself belongs to only one type.
+Therefore, one cannot decide that a given constructor belongs to
+multiple types, or consider a value of some type to belong to some
+other type with more constructors.
 
 With polymorphic variants, this original assumption is removed. That
 is, a variant tag does not belong to any type in particular, the type


### PR DESCRIPTION
The introduction of polymorphic variant in the manual refers to the fact that constructor name are unique in a given module. Since this is not true anymore for Ocaml ≥ 4.01, and can be quite confusing, this pull request proposes an alternative wording for this introduction. Note that these new introduction explicitly refers to the possible reuse of constructor names, I could reword this part if it is problematic to mention 
_experimental_ features in the tutorial part of the manual.
