### PR TITLE
Handling of [@inline] attribute for functors

### DIFF
--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -176,6 +176,7 @@ type shared_code = (int * int) list
 
 type function_attribute = {
   inline : inline_attribute;
+  is_a_functor: bool;
 }
 
 type lambda =
@@ -237,6 +238,7 @@ let lambda_unit = Lconst const_unit
 
 let default_function_attribute = {
   inline = Default_inline;
+  is_a_functor = false;
 }
 
 (* Build sharing keys *)

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -185,6 +185,7 @@ type shared_code = (int * int) list     (* stack size -> code label *)
 
 type function_attribute = {
   inline : inline_attribute;
+  is_a_functor: bool;
 }
 
 type lambda =

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -246,7 +246,9 @@ let primitive ppf = function
   | Pbbswap(bi) -> print_boxed_integer "bswap" ppf bi
   | Pint_as_pointer -> fprintf ppf "int_as_pointer"
 
-let function_attribute ppf { inline } =
+let function_attribute ppf { inline; is_a_functor } =
+  if is_a_functor then
+    fprintf ppf "is_a_functor@ ";
   match inline with
   | Default_inline -> ()
   | Always_inline -> fprintf ppf "always_inline@ "

--- a/bytecomp/translattribute.mli
+++ b/bytecomp/translattribute.mli
@@ -15,19 +15,28 @@ val check_attribute
   -> string Location.loc * _
   -> unit
 
+val check_attribute_on_module
+   : Typedtree.module_expr
+  -> string Location.loc * _
+  -> unit
+
 val add_inline_attribute
    : Lambda.lambda
   -> Location.t
-  -> Parsetree.attribute list
+  -> Parsetree.attributes
   -> Lambda.lambda
 
 val get_inline_attribute
-   : (string Location.loc * Parsetree.payload) list
+   : Parsetree.attributes
   -> Lambda.inline_attribute
 
-val get_inlined_attribute
+val get_and_remove_inlined_attribute
    : Typedtree.expression
   -> Lambda.inline_attribute * Typedtree.expression
+
+val get_and_remove_inlined_attribute_on_module
+   : Typedtree.module_expr
+  -> Lambda.inline_attribute * Typedtree.module_expr
 
 val get_tailcall_attribute
    : Typedtree.expression

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -691,6 +691,7 @@ and transl_exp0 e =
             transl_function e.exp_loc !Clflags.native_code repr partial pl)
       in
       let attr = {
+        default_function_attribute with
         inline = Translattribute.get_inline_attribute e.exp_attributes;
       }
       in
@@ -708,7 +709,7 @@ and transl_exp0 e =
             Translattribute.get_tailcall_attribute funct
           in
           let inlined, funct =
-            Translattribute.get_inlined_attribute funct
+            Translattribute.get_and_remove_inlined_attribute funct
           in
           let e = { e with exp_desc = Texp_apply(funct, oargs) } in
           event_after e (transl_apply ~should_be_tailcall ~inlined
@@ -764,7 +765,7 @@ and transl_exp0 e =
         Translattribute.get_tailcall_attribute funct
       in
       let inlined, funct =
-        Translattribute.get_inlined_attribute funct
+        Translattribute.get_and_remove_inlined_attribute funct
       in
       let e = { e with exp_desc = Texp_apply(funct, oargs) } in
       event_after e (transl_apply ~should_be_tailcall ~inlined

--- a/testsuite/tests/warnings/w53.ml
+++ b/testsuite/tests/warnings/w53.ml
@@ -13,3 +13,19 @@ let n x = x [@ocaml.tailcall] (* rejected *)
 let o x = (h [@tailcall]) x (* accepted *)
 let p x = (h [@ocaml.tailcall]) x (* accepted *)
 let q x = h x [@tailcall] (* rejected *)
+
+module type E = sig end
+
+module A(E:E) = struct end [@@inline] (* accepted *)
+module A'(E:E) = struct end [@@ocaml.inline] (* accepted *)
+module B = ((functor (E:E) -> struct end) [@inline]) (* accepted *)
+module B' = ((functor (E:E) -> struct end) [@ocaml.inline]) (* accepted *)
+module C = struct end [@@inline] (* rejected *)
+module C' = struct end [@@ocaml.inline] (* rejected *)
+module D = struct end [@@inlined] (* rejected *)
+module D' = struct end [@@ocaml.inlined] (* rejected *)
+
+module F = (A [@inlined])(struct end) (* accepted *)
+module F' = (A [@ocaml.inlined])(struct end) (* accepted *)
+module G = (A [@inline])(struct end) (* rejected *)
+module G' = (A [@ocaml.inline])(struct end) (* rejected *)

--- a/testsuite/tests/warnings/w53.reference
+++ b/testsuite/tests/warnings/w53.reference
@@ -1,5 +1,13 @@
 File "w53.ml", line 2, characters 4-5:
 Warning 32: unused value h.
+File "w53.ml", line 31, characters 17-29:
+Warning 53: the "ocaml.inline" attribute cannot appear in this context
+File "w53.ml", line 30, characters 16-22:
+Warning 53: the "inline" attribute cannot appear in this context
+File "w53.ml", line 24, characters 0-39:
+Warning 53: the "inline" attribute cannot appear in this context
+File "w53.ml", line 23, characters 0-32:
+Warning 53: the "inline" attribute cannot appear in this context
 File "w53.ml", line 15, characters 16-24:
 Warning 53: the "tailcall" attribute cannot appear in this context
 File "w53.ml", line 12, characters 14-28:


### PR DESCRIPTION
This patch allows to add the `[@inline]` and `[@inlined]` attributes in those contexts:

``` ocaml
module A(E:E) = struct end [@@inline]
module B = ((functor (E:E) -> struct end) [@inline])
module F = (A [@inlined])(struct end)
```

This patch also propagate the information that a function was a functor in the original source. This allows to have a different inlining heuristic for functors.
