### PR TITLE
Manual: new purely syntactic forms

### DIFF
--- a/manual/manual/refman/expr.etex
+++ b/manual/manual/refman/expr.etex
@@ -39,8 +39,10 @@ expr:
   | expr '::' expr
   | '[' expr { ';' expr } [';'] ']'
   | '[|' expr { ';' expr } [';'] '|]'
-  | '{' field '=' expr { ';' field '=' expr } [';'] '}'
-  | '{' expr 'with' field '=' expr { ';' field '=' expr } [';'] '}'
+  | '{' field [':' typexpr] '=' expr%
+    { ';' field [':' typexpr] '=' expr } [';'] '}'
+  | '{' expr 'with' field [':' typexpr] '=' expr%
+    { ';' field [':' typexpr] '=' expr } [';'] '}'
   | expr {{ argument }}
   | prefix-symbol expr
   | '-' expr
@@ -534,7 +536,10 @@ The fields @field_1@ to @field_n@ must all belong to the same record
 type; each field of this record type must appear exactly
 once in the record expression, though they can appear in any
 order. The order in which @expr_1@ to @expr_n@ are evaluated is not
-specified.
+specified. Optional type constraints can be added after each field
+@'{' field_1 ':' typexpr_1 '=' expr_1 ';'%
+ \ldots ';' field_n ':' typexpr_n '=' expr_n '}'@
+to force the type of @field_k@ to be compatible with @typexpr_k@.
 
 The expression
 @"{" expr "with" field_1 "=" expr_1 ";" \ldots ";" field_n "=" expr_n "}"@
@@ -542,7 +547,11 @@ builds a fresh record with fields @field_1 \ldots field_n@ equal to
 @expr_1 \ldots expr_n@, and all other fields having the same value as
 in the record @expr@.  In other terms, it returns a shallow copy of
 the record @expr@, except for the fields @field_1 \ldots field_n@,
-which are initialized to @expr_1 \ldots expr_n@.
+which are initialized to @expr_1 \ldots expr_n@. As previously, it is
+possible to add an optional type constraint on each field being updated
+with
+@"{" expr "with" field_1 ':' typexpr_1 "=" expr_1 ";" %
+ \ldots ";" field_n ':' typexpr_n "=" expr_n "}"@.
 
 The expression @expr_1 '.' field@ evaluates @expr_1@ to a record
 value, and returns the value associated to @field@ in this record

--- a/manual/manual/refman/expr.etex
+++ b/manual/manual/refman/expr.etex
@@ -266,6 +266,15 @@ is equivalent to
   @"fun" parameter_1 "->" \ldots "fun" parameter_n "->" %
   (expr ":" typexpr )@
 \end{center}
+Beware of the small syntactic difference between a type constraint on
+the last parameter
+\begin{center}
+  @"fun" parameter_1 \ldots (parameter_n":"typexpr)"->" expr @
+\end{center}
+and one on the result
+\begin{center}
+  @"fun" parameter_1 \ldots parameter_n":" typexpr "->" expr @
+\end{center}
 
 The parameter patterns @"~"lab@ and @"~("lab [":" typ]")"@
 are shorthands for respectively @"~"lab":"lab@ and

--- a/manual/manual/refman/expr.etex
+++ b/manual/manual/refman/expr.etex
@@ -60,7 +60,7 @@ expr:
   | expr ';' expr
   | 'match' expr 'with' pattern-matching
   | 'function' pattern-matching
-  | 'fun' {{ parameter }} '->' expr
+  | 'fun' {{ parameter }} [ ':' typexpr ] '->' expr
   | 'try' expr 'with' pattern-matching
   | 'let' ['rec'] let-binding { 'and' let-binding } 'in' expr
   | 'new' class-path
@@ -254,6 +254,17 @@ The other form of function definition is introduced by the keyword "fun":
 This expression is equivalent to:
 \begin{center}
 @"fun" parameter_1 "->" \ldots "fun" parameter_n "->" expr@
+\end{center}
+
+An optional type constraint @typexpr@ can be added before "->" to enforce
+the type of the result to be compatible with the constraint @typexpr@:
+\begin{center}
+@"fun" parameter_1 \ldots parameter_n ":" typexpr "->" expr@
+\end{center}
+is equivalent to
+\begin{center}
+  @"fun" parameter_1 "->" \ldots "fun" parameter_n "->" %
+  (expr ":" typexpr )@
 \end{center}
 
 The parameter patterns @"~"lab@ and @"~("lab [":" typ]")"@

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -511,12 +511,12 @@ polymorphic.
 \ikwd{type\@\texttt{type}}
 \ikwd{fun\@\texttt{fun}}
 
-(Introduced in OCaml 3.12)
+(Introduced in OCaml 3.12, short syntax added in 4.03)
 
 \begin{syntax}
 parameter:
        ...
-     | '(' "type" typeconstr-name ')'
+     | '(' "type" {{typeconstr-name}} ')'
 \end{syntax}
 
 The expression @"fun" '(' "type" typeconstr-name ')' "->" expr@ introduces a
@@ -535,8 +535,16 @@ and even use the alternative syntax for declaring functions:
 \begin{verbatim}
         let f (type t) (foo : t list) = ...
 \end{verbatim}
+If several locally abstract types need to be introduced, it is possible to use
+the syntax
+@"fun" '(' "type" typeconstr-name_1 \ldots typeconstr-name_n ')' "->" expr@
+as syntactic sugar for @"fun" '(' "type" typeconstr-name_1 ')' "->" \ldots "->"
+'(' "type" typeconstr-name_n ')' "->" expr@. For instance,
+\begin{verbatim}
+        let f = fun (type t u v) -> (foo : (t * u * v) list) -> ...
+\end{verbatim}
 
-This construction is useful because the type constructor it introduces
+This construction is useful because the type constructors it introduces
 can be used in places where a type variable is not allowed. For
 instance, one can use it to define an exception in a local module
 within a polymorphic function.

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -417,9 +417,9 @@ expr:
 
 When the body of a local open expression is delimited by @'[' ']'@,  @'[|' '|]'@,  @'{' '}'@, or @'{<' '>}'@, the parentheses can be omitted.  For example, @module-path'.['expr']'@ is equivalent to @module-path'.(['expr'])'@, and @module-path'.[|' expr '|]'@ is equivalent to @module-path'.([|' expr '|])'@.
 
-\section{Record notations}
+\section{Record and object notations}
 
-(Introduced in OCaml 3.12)
+(Introduced in OCaml 3.12, object copy notation added in Ocaml 4.03)
 
 \begin{syntax}
 pattern:
@@ -430,13 +430,14 @@ expr:
      ...
   | '{' field ['=' expr] { ';' field ['=' expr] } [';'] '}'
   | '{' expr 'with' field ['=' expr] { ';' field ['=' expr] } [';'] '}'
+  | '{' '<' expr 'with' field ['=' expr] { ';' field ['=' expr] } [';'] '>' '}'
+
 \end{syntax}
 
-In a record pattern or a record construction expression, a single
-identifier @id@ stands for @id '=' id@, and a qualified identifier
+In a record pattern, a record construction expression or an object copy expression,
+a single identifier @id@ stands for @id '=' id@, and a qualified identifier
 @module-path '.' id@ stands for @module-path '.' id '=' id@.
-For example, assuming
-the record type
+For example, assuming the record type
 \begin{verbatim}
           type point = { x: float; y: float }
 \end{verbatim}
@@ -445,6 +446,15 @@ has been declared, the following expressions are equivalent:
           let x = 1 and y = 2 in { x = x; y = y }
           let x = 1 and y = 2 in { x; y }
           let x = 1 and y = 2 in { x = x; y }
+\end{verbatim}
+On the object side, all following methods are equivalent:
+\begin{verbatim}
+          object
+            val x=0. val y=0. val z=0.
+            method f_0 x y = {< x; y >}
+            method f_1 x y = {< x = x; y >}
+            method f_2 x y = {< x=x ; y = y >}
+          end
 \end{verbatim}
 Likewise, the following functions are equivalent:
 \begin{verbatim}

--- a/manual/manual/refman/modtypes.etex
+++ b/manual/manual/refman/modtypes.etex
@@ -23,6 +23,7 @@ module-type:
           modtype-path
         | 'sig' { specification [';;'] } 'end'
         | 'functor' '(' module-name ':' module-type ')' '->' module-type
+        | module-type '->' module-type
         | module-type 'with' mod-constraint { 'and' mod-constraint }
         | '(' module-type ')'
 ;
@@ -245,9 +246,13 @@ is the type of functors (functions from modules to modules) that take
 as argument a module of type @module-type_1@ and return as result a
 module of type @module-type_2@. The module type @module-type_2@ can
 use the name @module-name@ to refer to type components of the actual
-argument of the functor. No restrictions are placed on the type of the
-functor argument; in particular, a functor may take another functor as
-argument (``higher-order'' functor).
+argument of the functor. If the type @module-type_2@ does not
+depend on type components of @module-name@, the module type expression
+can be simplified with the alternative short syntax
+@ module-type_1 '->' module-type_2 @.
+No restrictions are placed on the type of the functor argument; in
+particular, a functor may take another functor as argument
+(``higher-order'' functor).
 
 \subsection{The "with" operator}
 

--- a/manual/manual/refman/patterns.etex
+++ b/manual/manual/refman/patterns.etex
@@ -15,7 +15,8 @@ pattern:
   | "`"tag-name pattern
   | "#"typeconstr
   | pattern {{ ',' pattern }}
-  | '{' field '=' pattern { ';' field '=' pattern } [ ';' ] '}'
+  | '{' field [':' typexpr] '=' pattern%
+    { ';' field [':' typexpr] '=' pattern } [ ';' ] '}'
   | '[' pattern { ';' pattern } [ ';' ] ']'
   | pattern '::' pattern
   | '[|' pattern { ';' pattern } [ ';' ] '|]'
@@ -140,7 +141,10 @@ pattern_n "}"@ matches records that define at least the fields
 @field_i@ matches the pattern @pattern_i@, for \fromoneto{i}{n}.
 The record value can define more fields than @field_1@ \ldots
 @field_n@; the values associated to these extra fields are not taken
-into account for matching.
+into account for matching. Optional type constraints can be added field
+by field with @"{" field_1 ":" typexpr_1 "=" pattern_1 ";"%
+\ldots ";"field_n ":" typexpr_n "=" pattern_n "}"@ to force the type
+of @field_k@ to be compatible with @typexpr_k@.
 
 \subsubsection*{Array patterns}
 

--- a/manual/manual/refman/types.etex
+++ b/manual/manual/refman/types.etex
@@ -47,19 +47,19 @@ in type constraints over patterns and expressions.
 \subsubsection*{Type variables}
 
 The type expression @"'" ident@ stands for the type variable named
-@ident@. The type expression @"_"@ stands for an anonymous type variable.
-In data type definitions, type variables are names for the
-data type parameters. In type constraints, they represent unspecified
-types that can be instantiated by any type to satisfy the type
-constraint.  In general the scope of a named type variable is the
-whole top-level phrase where it appears, and it can only be
-generalized when leaving
-this scope.  Anonymous variables have no such restriction.
-In the following cases, the scope of named type variables is
-restricted to the type expression where they appear: 1) for universal
-(explicitly polymorphic) type variables; 2) for type variables that
-only appear in public method specifications (as those variables will
-be made universal, as described in section~\ref{sec-methspec});
+@ident@. The type expression @"_"@ stands for either an anonymous type
+variable or anonymous type parameters. In data type definitions, type
+variables are names for the data type parameters. In type constraints,
+they represent unspecified types that can be instantiated by any type
+to satisfy the type constraint.  In general the scope of a named type
+variable is the whole top-level phrase where it appears, and it can
+only be generalized when leaving this scope.  Anonymous variables have
+no such restriction. In the following cases, the scope of named type
+variables is restricted to the type expression where they appear:
+1) for universal (explicitly polymorphic) type variables;
+2) for type variables that only appear in public method specifications
+(as those variables will be made universal, as described in
+section~\ref{sec-methspec});
 3) for variables used as aliases, when the type they are aliased to
 would be invalid in the scope of the enclosing definition ({\it i.e.}
 when it contains free universal type variables, or locally
@@ -103,6 +103,11 @@ The type expression @(typexpr_1,\ldots,typexpr_n) typeconstr@, where
 @typeconstr@ is a type constructor with $n$ parameters, denotes the
 application of the $n$-ary type constructor @typeconstr@ to the types
 @typexpr_1@ through @typexpr_n@.
+
+In the type expression @ "_"  typeconstr @, the anonymous type expression
+@ "_" @ stands in for anonymous type parameters and is equivalent to
+@ ("_", \ldots,"_") @ with as many repetitions of "_" as the arity of
+@typeconstr@.
 
 \subsubsection*{Aliased and recursive types}
 


### PR DESCRIPTION
This pull request proposes some documentation for the purely syntactic new features
integrated in 4.03.

Due to the incremental nature of these changes, most of the new documentation
has been added to chapter 6, core language,:
- `_ t` as a short-hand for `(_, ... _) t`. 
- Short functor syntax `S -> T`.
- Type annotations on record fields.
- Type annotations before the `->` in `fun <args> -> <expr>`.

The other changes corresponded to extension of features described in chapter 7, language extension, and thus have been added to this chapter 
- Field punning in object copying expressions `{< x = x; y = y >}`.
- `(type a b)` as syntactic sugar for `(type a) (type b)`.

These changes are still fresh, and I will probably revise them in the upcoming week.
