### PR TITLE
Allow more CSE of loads from immutable blocks

### DIFF
--- a/asmcomp/CSEgen.mli
+++ b/asmcomp/CSEgen.mli
@@ -16,7 +16,7 @@
 type op_class =
   | Op_pure     (* pure, produce one result *)
   | Op_checkbound     (* checkbound-style: no result, can raise an exn *)
-  | Op_load           (* memory load *)
+  | Op_load of Asttypes.mutable_flag (* memory load *)
   | Op_store of bool  (* memory store, false = init, true = assign *)
   | Op_other   (* anything else that does not allocate nor store in memory *)
 

--- a/asmcomp/amd64/CSE.ml
+++ b/asmcomp/amd64/CSE.ml
@@ -27,7 +27,7 @@ method! class_of_operation op =
     | Ilea _ -> Op_pure
     | Istore_int(_, _, is_asg) | Istore_symbol(_, _, is_asg) -> Op_store is_asg
     | Ioffset_loc(_, _) -> Op_store true
-    | Ifloatarithmem _ | Ifloatsqrtf _ -> Op_load
+    | Ifloatarithmem _ | Ifloatsqrtf _ -> Op_load Asttypes.Mutable
     | Ibswap _ | Isqrtf -> super#class_of_operation op
     end
   | _ -> super#class_of_operation op

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -526,7 +526,7 @@ let emit_instr fallthrough i =
       if n <> 0
       then cfi_adjust_cfa_offset n;
       stack_offset := !stack_offset + n
-  | Lop(Iload(chunk, addr)) ->
+  | Lop(Iload(chunk, addr, _mutability)) ->
       let dest = res i 0 in
       begin match chunk with
       | Word_int | Word_val ->

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -187,7 +187,7 @@ method! select_operation op args =
       self#select_floatarith false Idivf Ifloatdiv args
   | Cextcall("sqrt", _, false, _) ->
      begin match args with
-       [Cop(Cload (Double|Double_u as chunk), [loc])] ->
+       [Cop(Cload (Double|Double_u as chunk, _), [loc])] ->
          let (addr, arg) = self#select_addressing chunk loc in
          (Ispecific(Ifloatsqrtf addr), [arg])
      | [arg] ->
@@ -221,11 +221,11 @@ method! select_operation op args =
 
 method select_floatarith commutative regular_op mem_op args =
   match args with
-    [arg1; Cop(Cload (Double|Double_u as chunk), [loc2])] ->
+    [arg1; Cop(Cload (Double|Double_u as chunk, _), [loc2])] ->
       let (addr, arg2) = self#select_addressing chunk loc2 in
       (Ispecific(Ifloatarithmem(mem_op, addr)),
                  [arg1; arg2])
-  | [Cop(Cload (Double|Double_u as chunk), [loc1]); arg2] when commutative ->
+  | [Cop(Cload (Double|Double_u as chunk, _), [loc1]); arg2] when commutative ->
       let (addr, arg1) = self#select_addressing chunk loc1 in
       (Ispecific(Ifloatarithmem(mem_op, addr)),
                  [arg2; arg1])

--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -39,7 +39,7 @@ let rec split_list n l =
 let rec build_closure_env env_param pos = function
     [] -> Tbl.empty
   | id :: rem ->
-      Tbl.add id (Uprim(Pfield pos, [Uvar env_param], Debuginfo.none))
+      Tbl.add id (Uprim(Pimmutable_field pos, [Uvar env_param], Debuginfo.none))
               (build_closure_env env_param (pos+1) rem)
 
 (* Auxiliary for accessing globals.  We change the name of the global

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -70,7 +70,7 @@ type memory_chunk =
 type operation =
     Capply of machtype * Debuginfo.t
   | Cextcall of string * machtype * bool * Debuginfo.t
-  | Cload of memory_chunk
+  | Cload of memory_chunk * Asttypes.mutable_flag
   | Calloc
   | Cstore of memory_chunk
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -82,7 +82,7 @@ type memory_chunk =
 type operation =
     Capply of machtype * Debuginfo.t
   | Cextcall of string * machtype * bool * Debuginfo.t
-  | Cload of memory_chunk
+  | Cload of memory_chunk * Asttypes.mutable_flag
   | Calloc
   | Cstore of memory_chunk
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -440,15 +440,15 @@ let rec unbox_float = function
   | Cswitch(e, tbl, el) -> Cswitch(e, tbl, Array.map unbox_float el)
   | Ccatch(n, ids, e1, e2) -> Ccatch(n, ids, unbox_float e1, unbox_float e2)
   | Ctrywith(e1, id, e2) -> Ctrywith(unbox_float e1, id, unbox_float e2)
-  | c -> Cop(Cload Double_u, [c])
+  | c -> Cop(Cload (Double_u, Mutable), [c])
 
 (* Complex *)
 
 let box_complex c_re c_im =
   Cop(Calloc, [alloc_floatarray_header 2; c_re; c_im])
 
-let complex_re c = Cop(Cload Double_u, [c])
-let complex_im c = Cop(Cload Double_u,
+let complex_re c = Cop(Cload (Double_u, Immutable), [c])
+let complex_im c = Cop(Cload (Double_u, Immutable),
                        [Cop(Cadda, [c; Cconst_int size_float])])
 
 (* Unit *)
@@ -485,15 +485,17 @@ let field_address ptr n =
   then ptr
   else Cop(Cadda, [ptr; Cconst_int(n * size_addr)])
 
-
 let get_field ptr n =
-  Cop(Cload Word_val, [field_address ptr n])
+  Cop(Cload (Word_val, Mutable), [field_address ptr n])
+
+let get_immutable_field ptr n =
+  Cop(Cload (Word_val, Immutable), [field_address ptr n])
 
 let set_field ptr n newval =
   Cop(Cstore Word_val, [field_address ptr n; newval])
 
 let header ptr =
-  Cop(Cload Word_int, [Cop(Cadda, [ptr; Cconst_int(-size_int)])])
+  Cop(Cload (Word_int, Mutable), [Cop(Cadda, [ptr; Cconst_int(-size_int)])])
 
 let tag_offset =
   if big_endian then -1 else -size_int
@@ -502,7 +504,7 @@ let get_tag ptr =
   if Proc.word_addressed then           (* If byte loads are slow *)
     Cop(Cand, [header ptr; Cconst_int 255])
   else                                  (* If byte loads are efficient *)
-    Cop(Cload Byte_unsigned,
+    Cop(Cload (Byte_unsigned, Mutable),
         [Cop(Cadda, [ptr; Cconst_int(tag_offset)])])
 
 let get_size ptr =
@@ -561,11 +563,11 @@ let array_indexing ?typ log2size ptr ofs =
                    Cconst_int((-1) lsl (log2size - 1))])
 
 let addr_array_ref arr ofs =
-  Cop(Cload Word_val, [array_indexing log2_size_addr arr ofs])
+  Cop(Cload (Word_val, Mutable), [array_indexing log2_size_addr arr ofs])
 let int_array_ref arr ofs =
-  Cop(Cload Word_int, [array_indexing log2_size_addr arr ofs])
+  Cop(Cload (Word_int, Mutable), [array_indexing log2_size_addr arr ofs])
 let unboxed_float_array_ref arr ofs =
-  Cop(Cload Double_u, [array_indexing log2_size_float arr ofs])
+  Cop(Cload (Double_u, Immutable), [array_indexing log2_size_float arr ofs])
 let float_array_ref arr ofs =
   box_float(unboxed_float_array_ref arr ofs)
 
@@ -592,7 +594,7 @@ let string_length exp =
               Cconst_int 1]),
          Cop(Csubi,
              [Cvar tmp_var;
-               Cop(Cload Byte_unsigned,
+               Cop(Cload (Byte_unsigned, Mutable),
                      [Cop(Cadda, [str; Cvar tmp_var])])])))
 
 (* Message sending *)
@@ -604,7 +606,7 @@ let lookup_tag obj tag =
 
 let lookup_label obj lab =
   bind "lab" lab (fun lab ->
-    let table = Cop (Cload Word_val, [obj]) in
+    let table = Cop (Cload (Word_val, Mutable), [obj]) in
     addr_array_ref table lab)
 
 let call_cached_method obj tag cache pos args dbg =
@@ -777,8 +779,8 @@ let split_int64_for_32bit_target arg =
     in
     let least_sig_addr = Cop (Cadda, [Cconst_int least_sig_ofs; arg]) in
     let most_sig_addr = Cop (Cadda, [Cconst_int most_sig_ofs; arg]) in
-    Ctuple [Cop (Cload Thirtytwo_unsigned, [least_sig_addr]);
-            Cop (Cload Thirtytwo_unsigned, [most_sig_addr])])
+    Ctuple [Cop (Cload (Thirtytwo_unsigned, Mutable), [least_sig_addr]);
+            Cop (Cload (Thirtytwo_unsigned, Mutable), [most_sig_addr])])
 
 let rec unbox_int bi arg =
   match arg with
@@ -803,7 +805,7 @@ let rec unbox_int bi arg =
       if size_int = 4 && bi = Pint64 then
         split_int64_for_32bit_target arg
       else
-        Cop(Cload(if bi = Pint32 then Thirtytwo_signed else Word_int),
+        Cop(Cload((if bi = Pint32 then Thirtytwo_signed else Word_int), Mutable),
             [Cop(Cadda, [arg; Cconst_int size_addr])])
 
 let make_unsigned_int bi arg =
@@ -874,7 +876,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
       else
         bind "idx" arg (fun idx ->
           (* Load the untagged int bound for the given dimension *)
-          let bound = Cop(Cload Word_int,[field_address b dim_ofs]) in
+          let bound = Cop(Cload (Word_int, Mutable),[field_address b dim_ofs]) in
           let idxn = untag_int idx in
           check_ba_bound bound idxn idx)
   | arg1 :: argl ->
@@ -882,7 +884,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
          *)
       let rem = ba_indexing (dim_ofs + delta_ofs) delta_ofs argl in
       (* Load the untagged int bound for the given dimension *)
-      let bound = Cop(Cload Word_int, [field_address b dim_ofs]) in
+      let bound = Cop(Cload (Word_int, Mutable), [field_address b dim_ofs]) in
       if unsafe then add_int (mul_int (decr_int rem) bound) arg1
       else
         bind "idx" arg1 (fun idx ->
@@ -904,7 +906,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
     bigarray_elt_size elt_kind in
   (* [array_indexing] can simplify the given expressions *)
   array_indexing ~typ:Int (log2 elt_size)
-                 (Cop(Cload Word_int, [field_address b 1])) offset
+                 (Cop(Cload (Word_int, Mutable), [field_address b 1])) offset
 
 let bigarray_word_kind = function
     Pbigarray_unknown -> assert false
@@ -930,10 +932,10 @@ let bigarray_get unsafe elt_kind layout b args dbg =
         bind "addr" (bigarray_indexing unsafe elt_kind layout b args dbg)
           (fun addr ->
           box_complex
-            (Cop(Cload kind, [addr]))
-            (Cop(Cload kind, [Cop(Cadda, [addr; Cconst_int sz])])))
+            (Cop(Cload (kind, Mutable), [addr]))
+            (Cop(Cload (kind, Mutable), [Cop(Cadda, [addr; Cconst_int sz])])))
     | _ ->
-        Cop(Cload (bigarray_word_kind elt_kind),
+        Cop(Cload (bigarray_word_kind elt_kind, Mutable),
             [bigarray_indexing unsafe elt_kind layout b args dbg]))
 
 let bigarray_set unsafe elt_kind layout b args newval dbg =
@@ -955,10 +957,10 @@ let bigarray_set unsafe elt_kind layout b args newval dbg =
 
 let unaligned_load_16 ptr idx =
   if Arch.allow_unaligned_access
-  then Cop(Cload Sixteen_unsigned, [add_int ptr idx])
+  then Cop(Cload (Sixteen_unsigned, Mutable), [add_int ptr idx])
   else
-    let v1 = Cop(Cload Byte_unsigned, [add_int ptr idx]) in
-    let v2 = Cop(Cload Byte_unsigned,
+    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int ptr idx]) in
+    let v2 = Cop(Cload (Byte_unsigned, Mutable),
                  [add_int (add_int ptr idx) (Cconst_int 1)]) in
     let b1, b2 = if Arch.big_endian then v1, v2 else v2, v1 in
     Cop(Cor, [lsl_int b1 (Cconst_int 8); b2])
@@ -977,14 +979,14 @@ let unaligned_set_16 ptr idx newval =
 
 let unaligned_load_32 ptr idx =
   if Arch.allow_unaligned_access
-  then Cop(Cload Thirtytwo_unsigned, [add_int ptr idx])
+  then Cop(Cload (Thirtytwo_unsigned, Mutable), [add_int ptr idx])
   else
-    let v1 = Cop(Cload Byte_unsigned, [add_int ptr idx]) in
-    let v2 = Cop(Cload Byte_unsigned,
+    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int ptr idx]) in
+    let v2 = Cop(Cload (Byte_unsigned, Mutable),
                  [add_int (add_int ptr idx) (Cconst_int 1)]) in
-    let v3 = Cop(Cload Byte_unsigned,
+    let v3 = Cop(Cload (Byte_unsigned, Mutable),
                  [add_int (add_int ptr idx) (Cconst_int 2)]) in
-    let v4 = Cop(Cload Byte_unsigned,
+    let v4 = Cop(Cload (Byte_unsigned, Mutable),
                  [add_int (add_int ptr idx) (Cconst_int 3)]) in
     let b1, b2, b3, b4 =
       if Arch.big_endian
@@ -1023,22 +1025,22 @@ let unaligned_set_32 ptr idx newval =
 let unaligned_load_64 ptr idx =
   assert(size_int = 8);
   if Arch.allow_unaligned_access
-  then Cop(Cload Word_int, [add_int ptr idx])
+  then Cop(Cload (Word_int, Mutable), [add_int ptr idx])
   else
-    let v1 = Cop(Cload Byte_unsigned, [add_int ptr idx]) in
-    let v2 = Cop(Cload Byte_unsigned,
+    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int ptr idx]) in
+    let v2 = Cop(Cload (Byte_unsigned, Mutable),
                  [add_int (add_int ptr idx) (Cconst_int 1)]) in
-    let v3 = Cop(Cload Byte_unsigned,
+    let v3 = Cop(Cload (Byte_unsigned, Mutable),
                  [add_int (add_int ptr idx) (Cconst_int 2)]) in
-    let v4 = Cop(Cload Byte_unsigned,
+    let v4 = Cop(Cload (Byte_unsigned, Mutable),
                  [add_int (add_int ptr idx) (Cconst_int 3)]) in
-    let v5 = Cop(Cload Byte_unsigned,
+    let v5 = Cop(Cload (Byte_unsigned, Mutable),
                  [add_int (add_int ptr idx) (Cconst_int 4)]) in
-    let v6 = Cop(Cload Byte_unsigned,
+    let v6 = Cop(Cload (Byte_unsigned, Mutable),
                  [add_int (add_int ptr idx) (Cconst_int 5)]) in
-    let v7 = Cop(Cload Byte_unsigned,
+    let v7 = Cop(Cload (Byte_unsigned, Mutable),
                  [add_int (add_int ptr idx) (Cconst_int 6)]) in
-    let v8 = Cop(Cload Byte_unsigned,
+    let v8 = Cop(Cload (Byte_unsigned, Mutable),
                  [add_int (add_int ptr idx) (Cconst_int 7)]) in
     let b1, b2, b3, b4, b5, b6, b7, b8 =
       if Arch.big_endian
@@ -1525,7 +1527,7 @@ let rec transl env e =
             dbg)
       | (Pbigarraydim(n), [b]) ->
           let dim_ofs = 4 + n in
-          tag_int (Cop(Cload Word_int, [field_address (transl env b) dim_ofs]))
+          tag_int (Cop(Cload (Word_int, Mutable), [field_address (transl env b) dim_ofs]))
       | (p, [arg]) ->
           transl_prim_1 env p arg dbg
       | (p, [arg1; arg2]) ->
@@ -1684,10 +1686,12 @@ and transl_prim_1 env p arg dbg =
   (* Heap operations *)
   | Pfield n ->
       get_field (transl env arg) n
+  | Pimmutable_field n ->
+      get_immutable_field (transl env arg) n
   | Pfloatfield n ->
       let ptr = transl env arg in
       box_float(
-        Cop(Cload Double_u,
+        Cop(Cload (Double_u, Immutable),
             [if n = 0 then ptr
                        else Cop(Cadda, [ptr; Cconst_int(n * size_float)])]))
   | Pint_as_pointer ->
@@ -1722,7 +1726,7 @@ and transl_prim_1 env p arg dbg =
       return_unit
         (bind "ref" (transl env arg) (fun arg ->
           Cop(Cstore Word_int,
-              [arg; add_const (Cop(Cload Word_int, [arg])) (n lsl 1)])))
+              [arg; add_const (Cop(Cload (Word_int, Mutable), [arg])) (n lsl 1)])))
   (* Floating-point operations *)
   | Pfloatofint ->
       box_float(Cop(Cfloatofint, [untag_int(transl env arg)]))
@@ -1872,7 +1876,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
 
   (* String operations *)
   | Pstringrefu ->
-      tag_int(Cop(Cload Byte_unsigned,
+      tag_int(Cop(Cload (Byte_unsigned, Mutable),
                   [add_int (transl env arg1) (untag_int(transl env arg2))]))
   | Pstringrefs ->
       tag_int
@@ -1880,7 +1884,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
           bind "index" (untag_int (transl env arg2)) (fun idx ->
             Csequence(
               make_checkbound dbg [string_length str; idx],
-              Cop(Cload Byte_unsigned, [add_int str idx])))))
+              Cop(Cload (Byte_unsigned, Mutable), [add_int str idx])))))
 
   | Pstring_load_16(unsafe) ->
      tag_int
@@ -1893,9 +1897,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
      tag_int
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2)) (fun idx ->
-        bind "ba_data" (Cop(Cload Word_int, [field_address ba 1]))
+        bind "ba_data" (Cop(Cload (Word_int, Mutable), [field_address ba 1]))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload Word_int,
+          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
                                                [field_address ba 5]))
                                           (Cconst_int 1)) idx
                       (unaligned_load_16 ba_data idx)))))
@@ -1911,9 +1915,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
      box_int Pint32
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2)) (fun idx ->
-        bind "ba_data" (Cop(Cload Word_int, [field_address ba 1]))
+        bind "ba_data" (Cop(Cload (Word_int, Mutable), [field_address ba 1]))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload Word_int,
+          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
                                                [field_address ba 5]))
                                           (Cconst_int 3)) idx
                       (unaligned_load_32 ba_data idx)))))
@@ -1929,9 +1933,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
      box_int Pint64
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2)) (fun idx ->
-        bind "ba_data" (Cop(Cload Word_int, [field_address ba 1]))
+        bind "ba_data" (Cop(Cload (Word_int, Mutable), [field_address ba 1]))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload Word_int,
+          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
                                                [field_address ba 5]))
                                           (Cconst_int 7)) idx
                       (unaligned_load_64 ba_data idx)))))
@@ -1992,7 +1996,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
   | Pbittest ->
       bind "index" (untag_int(transl env arg2)) (fun idx ->
         tag_int(
-          Cop(Cand, [Cop(Clsr, [Cop(Cload Byte_unsigned,
+          Cop(Cand, [Cop(Clsr, [Cop(Cload (Byte_unsigned, Mutable),
                                     [add_int (transl env arg1)
                                       (Cop(Clsr, [idx; Cconst_int 3]))]);
                                 Cop(Cand, [idx; Cconst_int 7])]);
@@ -2139,9 +2143,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2)) (fun idx ->
         bind "newval" (untag_int (transl env arg3)) (fun newval ->
-        bind "ba_data" (Cop(Cload Word_int, [field_address ba 1]))
+        bind "ba_data" (Cop(Cload (Word_int, Mutable), [field_address ba 1]))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload Word_int,
+          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
                                                [field_address ba 5]))
                                           (Cconst_int 1))
                       idx (unaligned_set_16 ba_data idx newval))))))
@@ -2159,9 +2163,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2)) (fun idx ->
         bind "newval" (transl_unbox_int env Pint32 arg3) (fun newval ->
-        bind "ba_data" (Cop(Cload Word_int, [field_address ba 1]))
+        bind "ba_data" (Cop(Cload (Word_int, Mutable), [field_address ba 1]))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload Word_int,
+          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
                                                [field_address ba 5]))
                                           (Cconst_int 3))
                       idx (unaligned_set_32 ba_data idx newval))))))
@@ -2179,9 +2183,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2)) (fun idx ->
         bind "newval" (transl_unbox_int env Pint64 arg3) (fun newval ->
-        bind "ba_data" (Cop(Cload Word_int, [field_address ba 1]))
+        bind "ba_data" (Cop(Cload (Word_int, Mutable), [field_address ba 1]))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload Word_int,
+          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
                                                [field_address ba 5]))
                                           (Cconst_int 7)) idx
                       (unaligned_set_64 ba_data idx newval))))))
@@ -2574,7 +2578,7 @@ let cache_public_method meths tag cache =
   Clet (
   li, Cconst_int 3,
   Clet (
-  hi, Cop(Cload Word_int, [meths]),
+  hi, Cop(Cload (Word_int, Mutable), [meths]),
   Csequence(
   Ccatch
     (raise_num, [],
@@ -2588,7 +2592,7 @@ let cache_public_method meths tag cache =
         Cifthenelse
           (Cop (Ccmpi Clt,
                 [tag;
-                 Cop(Cload Word_int,
+                 Cop(Cload (Word_int, Mutable),
                      [Cop(Cadda,
                           [meths; lsl_const (Cvar mi) log2_size_addr])])]),
            Cassign(hi, Cop(Csubi, [Cvar mi; Cconst_int 2])),
@@ -2652,17 +2656,17 @@ let send_function arity =
     let cached_pos = Cvar cached in
     let tag_pos = Cop(Cadda, [Cop (Cadda, [cached_pos; Cvar meths]);
                               Cconst_int(3*size_addr-1)]) in
-    let tag' = Cop(Cload Word_int, [tag_pos]) in
+    let tag' = Cop(Cload (Word_int, Mutable), [tag_pos]) in
     Clet (
-    meths, Cop(Cload Word_val, [obj]),
+    meths, Cop(Cload (Word_val, Mutable), [obj]),
     Clet (
-    cached, Cop(Cand, [Cop(Cload Word_int, [cache]); mask]),
+    cached, Cop(Cand, [Cop(Cload (Word_int, Mutable), [cache]); mask]),
     Clet (
     real,
     Cifthenelse(Cop(Ccmpa Cne, [tag'; tag]),
                 cache_public_method (Cvar meths) tag cache,
                 cached_pos),
-    Cop(Cload Word_val, [Cop(Cadda, [Cop (Cadda, [Cvar real; Cvar meths]);
+    Cop(Cload (Word_val, Mutable), [Cop(Cadda, [Cop (Cadda, [Cvar real; Cvar meths]);
                                      Cconst_int(2*size_addr-1)])]))))
 
   in
@@ -2860,7 +2864,7 @@ let entry_point namelist =
   let incr_global_inited =
     Cop(Cstore Word_int,
         [Cconst_symbol "caml_globals_inited";
-         Cop(Caddi, [Cop(Cload Word_int, [Cconst_symbol "caml_globals_inited"]);
+         Cop(Caddi, [Cop(Cload (Word_int, Mutable), [Cconst_symbol "caml_globals_inited"]);
                      Cconst_int 1])]) in
   let body =
     List.fold_right

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -45,7 +45,7 @@ type operation =
   | Itailcall_imm of string
   | Iextcall of string * bool
   | Istackoffset of int
-  | Iload of Cmm.memory_chunk * Arch.addressing_mode
+  | Iload of Cmm.memory_chunk * Arch.addressing_mode * Asttypes.mutable_flag
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
   | Ialloc of int
   | Iintop of integer_operation

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -45,7 +45,7 @@ type operation =
   | Itailcall_imm of string
   | Iextcall of string * bool    (* false = noalloc, true = alloc *)
   | Istackoffset of int
-  | Iload of Cmm.memory_chunk * Arch.addressing_mode
+  | Iload of Cmm.memory_chunk * Arch.addressing_mode * Asttypes.mutable_flag
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
                                  (* false = initialization, true = assignment *)
   | Ialloc of int

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -54,7 +54,8 @@ let operation = function
   | Capply(ty, d) -> "app" ^ Debuginfo.to_string d
   | Cextcall(lbl, ty, alloc, d) ->
       Printf.sprintf "extcall \"%s\"%s" lbl (Debuginfo.to_string d)
-  | Cload c -> Printf.sprintf "load %s" (chunk c)
+  | Cload (c, Asttypes.Mutable) -> Printf.sprintf "load %s" (chunk c)
+  | Cload (c, Asttypes.Immutable) -> Printf.sprintf "load_imm %s" (chunk c)
   | Calloc -> "alloc"
   | Cstore c -> Printf.sprintf "store %s" (chunk c)
   | Caddi -> "+"

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -120,8 +120,11 @@ let operation op arg ppf res =
       (if alloc then "" else " (noalloc)")
   | Istackoffset n ->
       fprintf ppf "offset stack %i" n
-  | Iload(chunk, addr) ->
+  | Iload(chunk, addr, Asttypes.Mutable) ->
       fprintf ppf "%s[%a]"
+       (Printcmm.chunk chunk) (Arch.print_addressing reg addr) arg
+  | Iload(chunk, addr, Asttypes.Immutable) ->
+      fprintf ppf "%s(imm)[%a]"
        (Printcmm.chunk chunk) (Arch.print_addressing reg addr) arg
   | Istore(chunk, addr, is_assign) ->
       fprintf ppf "%s[%a] := %a %s"

--- a/asmcomp/schedgen.ml
+++ b/asmcomp/schedgen.ml
@@ -132,7 +132,8 @@ let rec remove_instr node = function
 
 (* We treat Lreloadretaddr as a word-sized load *)
 
-let some_load = (Iload(Cmm.Word_int, Arch.identity_addressing))
+let some_load =
+  Iload(Cmm.Word_int, Arch.identity_addressing, Asttypes.Mutable)
 
 (* The generic scheduler *)
 
@@ -178,7 +179,7 @@ method is_store = function
   | _ -> false
 
 method is_load = function
-    Iload(_, _) -> true
+    Iload(_, _, _) -> true
   | _ -> false
 
 method is_checkbound = function

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -25,7 +25,7 @@ type environment = (Ident.t, Reg.t array) Tbl.t
 let oper_result_type = function
     Capply(ty, _) -> ty
   | Cextcall(s, ty, alloc, _) -> ty
-  | Cload c ->
+  | Cload (c, _mutability) ->
       begin match c with
       | Word_val -> typ_val
       | Single | Double | Double_u -> typ_float
@@ -251,9 +251,9 @@ method select_operation op args =
     (Capply(ty, dbg), Cconst_symbol s :: rem) -> (Icall_imm s, rem)
   | (Capply(ty, dbg), _) -> (Icall_ind, args)
   | (Cextcall(s, ty, alloc, dbg), _) -> (Iextcall(s, alloc), args)
-  | (Cload chunk, [arg]) ->
+  | (Cload (chunk, mutability), [arg]) ->
       let (addr, eloc) = self#select_addressing chunk arg in
-      (Iload(chunk, addr), [eloc])
+      (Iload(chunk, addr, mutability), [eloc])
   | (Cstore chunk, [arg1; arg2]) ->
       let (addr, eloc) = self#select_addressing chunk arg1 in
       if chunk = Word_int || chunk = Word_val then begin

--- a/asmcomp/strmatch.ml
+++ b/asmcomp/strmatch.ml
@@ -69,7 +69,8 @@ module Make(I:I) = struct
 
   let mk_let_cell id str ind body =
     let cell =
-      Cop(Cload Word_int,[Cop(Cadda,[str;Cconst_int(Arch.size_int*ind)])]) in
+      Cop(Cload (Word_int, Asttypes.Mutable),
+        [Cop(Cadda,[str;Cconst_int(Arch.size_int*ind)])]) in
     Clet(id, cell, body)
 
   let mk_let_size id str body =

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -42,6 +42,7 @@ type primitive =
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag
   | Pfield of int
+  | Pimmutable_field of int
   | Psetfield of int * bool
   | Pfloatfield of int
   | Psetfloatfield of int

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -42,6 +42,7 @@ type primitive =
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag
   | Pfield of int
+  | Pimmutable_field of int
   | Psetfield of int * bool
   | Pfloatfield of int
   | Psetfloatfield of int

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -110,6 +110,7 @@ let primitive ppf = function
   | Pmakeblock(tag, Immutable) -> fprintf ppf "makeblock %i" tag
   | Pmakeblock(tag, Mutable) -> fprintf ppf "makemutable %i" tag
   | Pfield n -> fprintf ppf "field %i" n
+  | Pimmutable_field n -> fprintf ppf "imm_field %i" n
   | Psetfield(n, ptr) ->
       let instr = if ptr then "setfield_ptr " else "setfield_imm " in
       fprintf ppf "%s%i" instr n


### PR DESCRIPTION
Morally speaking, this patch is small: it changes CSEgen so that values computed by loading from an immutable place are not killed by stores.

The specific near-term aim is to permit accesses to closure environments to be subject to CSE.

With flambda I measure this patch giving a 2.5% speedup on Knuth-Bendix, which is quite significant for a small change.

@lpw25 has a more complete implementation of the front-end portion of this patch on the multicore branch that, instead of adding Pimmutable_field, alters Pfield to always carry such information (together with a flag saying whether the value is always immediate).  This could have fairly wide applicability, e.g. in reading from record fields, which more often than not are immutable.  I would like to consider merging that patch in the future---I haven't got time right now---but I think this one is a reasonable step along the way.

(I will adjust the code for the other backends if this is accepted.)
