### PR TITLE
Warnings emitted by the compiler may contain \r\r\n on Windows (MPR#7106)

### DIFF
--- a/tools/Makefile.shared
+++ b/tools/Makefile.shared
@@ -75,11 +75,11 @@ ocamlprof: $(CSLPROF) profiling.cmo
 	$(CAMLC) $(LINKFLAGS) -o ocamlprof $(CSLPROF_IMPORTS) $(CSLPROF)
 
 ocamlcp: ocamlcp.cmo
-	$(CAMLC) $(LINKFLAGS) -o ocamlcp warnings.cmo misc.cmo config.cmo \
+	$(CAMLC) $(LINKFLAGS) -o ocamlcp misc.cmo warnings.cmo config.cmo \
                  identifiable.cmo numbers.cmo arg_helper.cmo clflags.cmo main_args.cmo ocamlcp.cmo
 
 ocamloptp: ocamloptp.cmo
-	$(CAMLC) $(LINKFLAGS) -o ocamloptp warnings.cmo misc.cmo config.cmo \
+	$(CAMLC) $(LINKFLAGS) -o ocamloptp misc.cmo warnings.cmo config.cmo \
                  identifiable.cmo numbers.cmo arg_helper.cmo clflags.cmo main_args.cmo \
 	         ocamloptp.cmo
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -629,42 +629,9 @@ module Color = struct
       ()
 end
 
-(*
- * Reduce \r\n to \n. Ignore \r which is not followed by \n
- *)
 let normalise_eol s =
-  let l' = String.length s in
-  (*
-   * Compute length of final string by identifying \r which is followed by \n
-   *)
-  let l =
-    let rec g b n i =
-      if i < 0 then
-        n
-      else
-        let c = s.[i] in
-        if c = '\r' && b then
-          g false n (pred i)
-        else
-          g (c = '\n') (succ n) (pred i)
-    in
-      g false 0 (pred l') in
-  (*
-   * Number of \r characters which will be squashed
-   *)
-  let count = l' - l in
-  (*
-   * Present offset for copying from [s] to the result
-   *)
-  let offset = ref 0 in
-  let f i =
-    let ofs = !offset in
-    (*
-     * ofs < count => there are still \r to squash; therefore i + ofs is not
-     * the last character of [s].
-     *)
-    if ofs < count && s.[i + ofs] = '\r' && s.[i + ofs + 1] = '\n' then
-      incr offset;
-    s.[i + !offset]
-  in
-    String.init l f
+  let b = Buffer.create 80 in
+    for i = 0 to String.length s - 1 do
+      if s.[i] <> '\r' then Buffer.add_char b s.[i]
+    done;
+    Buffer.contents b

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -628,3 +628,43 @@ module Color = struct
       );
       ()
 end
+
+(*
+ * Reduce \r\n to \n. Ignore \r which is not followed by \n
+ *)
+let normalise_eol s =
+  let l' = String.length s in
+  (*
+   * Compute length of final string by identifying \r which is followed by \n
+   *)
+  let l =
+    let rec g b n i =
+      if i < 0 then
+        n
+      else
+        let c = s.[i] in
+        if c = '\r' && b then
+          g false n (pred i)
+        else
+          g (c = '\n') (succ n) (pred i)
+    in
+      g false 0 (pred l') in
+  (*
+   * Number of \r characters which will be squashed
+   *)
+  let count = l' - l in
+  (*
+   * Present offset for copying from [s] to the result
+   *)
+  let offset = ref 0 in
+  let f i =
+    let ofs = !offset in
+    (*
+     * ofs < count => there are still \r to squash; therefore i + ofs is not
+     * the last character of [s].
+     *)
+    if ofs < count && s.[i + ofs] = '\r' && s.[i + ofs + 1] = '\n' then
+      incr offset;
+    s.[i + !offset]
+  in
+    String.init l f

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -297,8 +297,6 @@ module Color : sig
 end
 
 val normalise_eol : string -> string
-(** [normalise_eol s] returns a fresh copy of [s] with any '\r' character which
-   appears before a '\n' character removed. Intended for pre-processing text
-   which will subsequently be printed on a channel which performs EOL
-   transformations (i.e. Windows) but leaves any instances of '\r' which are
-   intended for genuine carriage return. *)
+(** [normalise_eol s] returns a fresh copy of [s] with any '\r' characters
+   removed. Intended for pre-processing text which will subsequently be printed
+   on a channel which performs EOL transformations (i.e. Windows) *)

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -295,3 +295,10 @@ module Color : sig
   val set_color_tag_handling : Format.formatter -> unit
   (* adds functions to support color tags to the given formatter. *)
 end
+
+val normalise_eol : string -> string
+(** [normalise_eol s] returns a fresh copy of [s] with any '\r' character which
+   appears before a '\n' character removed. Intended for pre-processing text
+   which will subsequently be printed on a channel which performs EOL
+   transformations (i.e. Windows) but leaves any instances of '\r' which are
+   intended for genuine carriage return. *)

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -271,7 +271,14 @@ let () = parse_options true defaults_warn_error;;
 let message = function
   | Comment_start -> "this is the start of a comment."
   | Comment_not_end -> "this is not the end of a comment."
-  | Deprecated s -> "deprecated: " ^ s
+  | Deprecated s ->
+      (* Reduce \r\n to \n:
+           - Prevents any \r characters being printed on Unix when processing
+             Windows sources
+           - Prevents \r\r\n being generated on Windows, which affects the
+             testsuite
+       *)
+       "deprecated: " ^ Misc.normalise_eol s
   | Fragile_match "" ->
       "this pattern-matching is fragile."
   | Fragile_match s ->
@@ -454,14 +461,7 @@ let message = function
 let nerrors = ref 0;;
 
 let print ppf w =
-  (* Reduce \r\n in any warning messages to \n:
-       - Prevents any \r characters being printed on Unix when processing
-         Windows sources
-       - Prevents \r\r\n being generated on Windows, which affects the testsuite
-     Although applied to all messages, the principal culprit at the time of
-     writing was the Deprecated constructor.
-   *)
-  let msg = Misc.normalise_eol (message w) in
+  let msg = message w in
   let num = number w in
   Format.fprintf ppf "%d: %s" num msg;
   Format.pp_print_flush ppf ();

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -454,7 +454,14 @@ let message = function
 let nerrors = ref 0;;
 
 let print ppf w =
-  let msg = message w in
+  (* Reduce \r\n in any warning messages to \n:
+       - Prevents any \r characters being printed on Unix when processing
+         Windows sources
+       - Prevents \r\r\n being generated on Windows, which affects the testsuite
+     Although applied to all messages, the principal culprit at the time of
+     writing was the Deprecated constructor.
+   *)
+  let msg = Misc.normalise_eol (message w) in
   let num = number w in
   Format.fprintf ppf "%d: %s" num msg;
   Format.pp_print_flush ppf ();


### PR DESCRIPTION
See http://caml.inria.fr/mantis/view.php?id=7106
