### PR TITLE
Warning for possibly misspelled built-in attributes

### DIFF
--- a/.depend
+++ b/.depend
@@ -62,16 +62,18 @@ parsing/ast_mapper.cmx : parsing/parsetree.cmi utils/misc.cmx \
     parsing/longident.cmx parsing/location.cmx utils/config.cmx \
     utils/clflags.cmx parsing/asttypes.cmi parsing/ast_helper.cmx \
     parsing/ast_mapper.cmi
-parsing/attr_helper.cmo : parsing/parsetree.cmi parsing/location.cmi \
-    parsing/asttypes.cmi parsing/attr_helper.cmi
-parsing/attr_helper.cmx : parsing/parsetree.cmi parsing/location.cmx \
-    parsing/asttypes.cmi parsing/attr_helper.cmi
+parsing/attr_helper.cmo : utils/warnings.cmi parsing/parsetree.cmi \
+    utils/misc.cmi parsing/location.cmi parsing/asttypes.cmi \
+    parsing/attr_helper.cmi
+parsing/attr_helper.cmx : utils/warnings.cmx parsing/parsetree.cmi \
+    utils/misc.cmx parsing/location.cmx parsing/asttypes.cmi \
+    parsing/attr_helper.cmi
 parsing/builtin_attributes.cmo : utils/warnings.cmi parsing/parsetree.cmi \
-    parsing/location.cmi parsing/asttypes.cmi parsing/ast_mapper.cmi \
-    parsing/builtin_attributes.cmi
+    parsing/location.cmi parsing/attr_helper.cmi parsing/asttypes.cmi \
+    parsing/ast_mapper.cmi parsing/builtin_attributes.cmi
 parsing/builtin_attributes.cmx : utils/warnings.cmx parsing/parsetree.cmi \
-    parsing/location.cmx parsing/asttypes.cmi parsing/ast_mapper.cmx \
-    parsing/builtin_attributes.cmi
+    parsing/location.cmx parsing/attr_helper.cmx parsing/asttypes.cmi \
+    parsing/ast_mapper.cmx parsing/builtin_attributes.cmi
 parsing/docstrings.cmo : utils/warnings.cmi parsing/parsetree.cmi \
     parsing/location.cmi parsing/docstrings.cmi
 parsing/docstrings.cmx : utils/warnings.cmx parsing/parsetree.cmi \
@@ -600,10 +602,10 @@ bytecomp/symtable.cmx : utils/tbl.cmx bytecomp/runtimedef.cmx \
     parsing/asttypes.cmi bytecomp/symtable.cmi
 bytecomp/translattribute.cmo : utils/warnings.cmi typing/typedtree.cmi \
     parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    bytecomp/lambda.cmi bytecomp/translattribute.cmi
+    bytecomp/lambda.cmi parsing/attr_helper.cmi bytecomp/translattribute.cmi
 bytecomp/translattribute.cmx : utils/warnings.cmx typing/typedtree.cmx \
     parsing/parsetree.cmi parsing/longident.cmx parsing/location.cmx \
-    bytecomp/lambda.cmx bytecomp/translattribute.cmi
+    bytecomp/lambda.cmx parsing/attr_helper.cmx bytecomp/translattribute.cmi
 bytecomp/translclass.cmo : typing/types.cmi bytecomp/typeopt.cmi \
     typing/typedtree.cmi bytecomp/translobj.cmi bytecomp/translcore.cmi \
     typing/path.cmi bytecomp/matching.cmi parsing/location.cmi \

--- a/Changes
+++ b/Changes
@@ -459,7 +459,7 @@ Features wishes:
   (Eyyüb Sari)
 - PR#6924: tiny optim to avoid some spilling of floats in x87
   (Alain Frisch)
-- GPR#111: `(f [@taillcall]) x y` warns if `f x y` is not a tail-call
+- GPR#111: `(f [@tailcall]) x y` warns if `f x y` is not a tail-call
   (Simon Cruanes)
 - GPR#118: ocamldep -allow-approx: fallback to a lexer-based approximation
   (Frédéric Bour)

--- a/Changes
+++ b/Changes
@@ -498,6 +498,8 @@ Features wishes:
   (Rich Neswold)
 - GPR#365: prevent printing just a single type variable on one side
   of a type error clash. (Hugo Heuzard)
+- GPR#372: add a warning for possibly mispelled builtin attribute
+  (Florian Angeletti)
 
 OCaml 4.02.3 (27 Jul 2015):
 ---------------------------

--- a/bytecomp/translattribute.ml
+++ b/bytecomp/translattribute.ml
@@ -20,12 +20,12 @@ let inlined_names = Attr_helper.std_namespace "inlined"
 
 let inline = Attr_helper.{
     names=inline_names;
-    neighbouring_names=inlined_names;
+    neighbouring_names= "online" :: inlined_names;
     max_distance=1
   }
 let inlined = Attr_helper.{
     names=inlined_names;
-    neighbouring_names=inline_names;
+    neighbouring_names= "online" :: inline_names;
     max_distance=2
   }
 let tailcall = Attr_helper.create "tailcall"

--- a/bytecomp/translattribute.ml
+++ b/bytecomp/translattribute.ml
@@ -18,8 +18,8 @@ open Location
 let inline_names = Attr_helper.std_namespace "inline"
 let inlined_names = Attr_helper.std_namespace "inlined"
 
-let inline = Attr_helper.{names=inline_names; context=inlined_names}
-let inlined = Attr_helper.{names=inlined_names; context=inline_names}
+let inline = Attr_helper.{names=inline_names; neighbouring_names=inlined_names}
+let inlined = Attr_helper.{names=inlined_names; neighbouring_names=inline_names}
 let tailcall = Attr_helper.create "tailcall"
 
 let is_inline_attribute = Attr_helper.is_attribute inline

--- a/bytecomp/translattribute.ml
+++ b/bytecomp/translattribute.ml
@@ -14,13 +14,17 @@ open Typedtree
 open Lambda
 open Location
 
-let is_inline_attribute = function
-  | {txt=("inline"|"ocaml.inline")}, _ -> true
-  | _ -> false
 
-let is_inlined_attribute = function
-  | {txt=("inlined"|"ocaml.inlined")}, _ -> true
-  | _ -> false
+let inline_names = Attr_helper.std_namespace "inline"
+let inlined_names = Attr_helper.std_namespace "inlined"
+
+let inline = Attr_helper.{names=inline_names; context=inlined_names}
+let inlined = Attr_helper.{names=inlined_names; context=inline_names}
+let tailcall = Attr_helper.create "tailcall"
+
+let is_inline_attribute = Attr_helper.is_attribute inline
+let is_inlined_attribute = Attr_helper.is_attribute inlined
+let is_tailcall_attribute = Attr_helper.is_attribute tailcall
 
 (* the 'inline' and 'inlined' attributes can be used as
    [@inline], [@inline never] or [@inline always].
@@ -99,10 +103,6 @@ let get_and_remove_inlined_attribute_on_module e =
 (* It also remove the attribute from the expression, like
    get_inlined_attribute *)
 let get_tailcall_attribute e =
-  let is_tailcall_attribute = function
-    | {txt=("tailcall"|"ocaml.tailcall")}, _ -> true
-    | _ -> false
-  in
   let tailcalls, exp_attributes =
     List.partition is_tailcall_attribute e.exp_attributes
   in
@@ -116,33 +116,29 @@ let get_tailcall_attribute e =
       end;
       true, { e with exp_attributes }
 
-let check_attribute e ({ txt; loc }, _) =
-  match txt with
-  | "inline" | "ocaml.inline" ->  begin
+let check_attribute e  ( ({loc;txt}, _ ) as attr ) =
+  let is = Attr_helper.is_attribute ~warn:false in
+  if is inline attr then
       match e.exp_desc with
       | Texp_function _ -> ()
       | _ ->
           Location.prerr_warning loc
             (Warnings.Misplaced_attribute txt)
-    end
-  | "inlined" | "ocaml.inlined"
-  | "tailcall" | "ocaml.tailcall" ->
+  else if is inlined attr || is tailcall attr then
       (* Removed by the Texp_apply cases *)
       Location.prerr_warning loc
         (Warnings.Misplaced_attribute txt)
-  | _ -> ()
 
-let check_attribute_on_module e ({ txt; loc }, _) =
-  match txt with
-  | "inline" | "ocaml.inline" ->  begin
+let check_attribute_on_module e ( ({loc;txt}, _ ) as attr ) =
+  if Attr_helper.is_attribute inline attr then
+    begin
       match e.mod_desc with
       | Tmod_functor _ -> ()
       | _ ->
           Location.prerr_warning loc
             (Warnings.Misplaced_attribute txt)
     end
-  | "inlined" | "ocaml.inlined" ->
+  else if Attr_helper.is_attribute inlined attr then
       (* Removed by the Texp_apply cases *)
       Location.prerr_warning loc
         (Warnings.Misplaced_attribute txt)
-  | _ -> ()

--- a/bytecomp/translattribute.ml
+++ b/bytecomp/translattribute.ml
@@ -18,8 +18,16 @@ open Location
 let inline_names = Attr_helper.std_namespace "inline"
 let inlined_names = Attr_helper.std_namespace "inlined"
 
-let inline = Attr_helper.{names=inline_names; neighbouring_names=inlined_names}
-let inlined = Attr_helper.{names=inlined_names; neighbouring_names=inline_names}
+let inline = Attr_helper.{
+    names=inline_names;
+    neighbouring_names=inlined_names;
+    max_distance=1
+  }
+let inlined = Attr_helper.{
+    names=inlined_names;
+    neighbouring_names=inline_names;
+    max_distance=2
+  }
 let tailcall = Attr_helper.create "tailcall"
 
 let is_inline_attribute = Attr_helper.is_attribute inline

--- a/bytecomp/translattribute.mli
+++ b/bytecomp/translattribute.mli
@@ -12,12 +12,12 @@
 
 val check_attribute
    : Typedtree.expression
-  -> string Location.loc * _
+  -> string Location.loc * Parsetree.payload
   -> unit
 
 val check_attribute_on_module
    : Typedtree.module_expr
-  -> string Location.loc * _
+  -> string Location.loc * Parsetree.payload
   -> unit
 
 val add_inline_attribute

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1540,13 +1540,14 @@ Some attributes are understood by the type-checker:
   need to communicate warnings to the user.  This could also be used
   to mark explicitly some code location for further inspection.
 \end{itemize}
-
+Spelling mistakes on these built-in attributes might be detected by turning on
+the warning 59.
 \begin{verbatim}
 module X = struct
   [@@@warning "+9"]  (* locally enable warning 9 in this structure *)
   ...
 end
-  [@@deprecated "Please is module 'Y' instead."]
+  [@@deprecated "Please use module 'Y' instead."]
 
 let x = begin[@warning "+9] ... end in ....
 

--- a/parsing/attr_helper.ml
+++ b/parsing/attr_helper.ml
@@ -19,8 +19,52 @@ type error =
 
 exception Error of Location.t * error
 
-let get_no_payload_attribute alt_names attrs =
-  match List.filter (fun (n, _) -> List.mem n.txt alt_names) attrs with
+type identifier = { names: string list; context: string list}
+
+let std_namespace name = [ name; "ocaml." ^ name]
+let create ?(context=[]) name = {names = std_namespace name; context}
+
+let attribute_max_distance = ref 2
+
+let distance txt_1 txt_2 =
+  Misc.edit_distance txt_1 txt_2 !attribute_max_distance
+
+let min_distance txt x name_y =
+  let dy = distance txt name_y in
+  match x, dy  with
+  |  _ , None -> x
+  | Some (dx, _), Some dy when dx <= dy -> x
+  | _, Some dy -> Some ( dy, name_y)
+
+let set_projector set txt =
+  List.fold_left (min_distance txt) None set
+
+let is_warning_active () =
+  let open Warnings in
+  is_active ( Misspelled_attribute ("","") )
+
+let is_attribute ?(warn=true) {names;context} ({txt;loc}, _ )  =
+  if not warn || not (is_warning_active ())then
+    List.mem txt names
+  else
+    let nearest_name = set_projector names txt
+    and nearest_context = set_projector context txt in
+    let warn name =
+            Location.prerr_warning loc
+              (Warnings.Misspelled_attribute (txt,name)) in
+    match nearest_name, nearest_context with
+    | Some (0, _), _ -> true
+    | _ , Some(0, _) -> false
+    | Some (dx,x) , Some (dy,y) ->
+        if dx <= dy then
+          warn x;
+             false
+    | Some (dx,x), None -> warn x; false
+    | _ -> false
+
+
+let get_no_payload_attribute ?(warn=true) identifier attrs =
+  match List.filter (is_attribute ~warn identifier) attrs with
   | [] -> None
   | [ (name, PStr []) ] -> Some name
   | [ (name, _) ] ->
@@ -28,8 +72,8 @@ let get_no_payload_attribute alt_names attrs =
   | _ :: (name, _) :: _ ->
     raise (Error (name.loc, Multiple_attributes name.txt))
 
-let has_no_payload_attribute alt_names attrs =
-  match get_no_payload_attribute alt_names attrs with
+let has_no_payload_attribute ?(warn=true) identifier attrs =
+  match get_no_payload_attribute ~warn identifier attrs with
   | None   -> false
   | Some _ -> true
 

--- a/parsing/attr_helper.ml
+++ b/parsing/attr_helper.ml
@@ -19,37 +19,37 @@ type error =
 
 exception Error of Location.t * error
 
-type identifier = { names: string list; neighbouring_names: string list}
+type identifier =
+  { names: string list; neighbouring_names: string list; max_distance:int }
 
 let std_namespace name = [ name; "ocaml." ^ name]
-let create ?(neighbouring_names=[]) name =
-  {names = std_namespace name; neighbouring_names }
+let create ?(neighbouring_names=[]) ?(max_distance=2) name =
+  {names = std_namespace name; neighbouring_names; max_distance }
 
 let attribute_max_distance = ref 2
 
-let distance txt_1 txt_2 =
-  Misc.edit_distance txt_1 txt_2 !attribute_max_distance
-
-let min_distance txt x name_y =
-  let dy = distance txt name_y in
+let min_distance cutoff_distance txt x name_y =
+  let dy = Misc.edit_distance txt name_y cutoff_distance in
   match x, dy  with
   |  _ , None -> x
   | Some (dx, _), Some dy when dx <= dy -> x
   | _, Some dy -> Some ( dy, name_y)
 
-let set_projector set txt =
-  List.fold_left (min_distance txt) None set
+let set_projector cutoff_distance set txt =
+  List.fold_left (min_distance cutoff_distance txt) None set
 
 let is_warning_active () =
   let open Warnings in
   is_active ( Misspelled_attribute ("","") )
 
-let is_attribute ?(warn=true) {names;neighbouring_names} ({txt;loc}, _ )  =
+let is_attribute ?(warn=true) {names;neighbouring_names;max_distance}
+    ({txt;loc}, _ )  =
   let result = List.mem txt names in
   let () = (* misspelling check *)
     if not result && warn && is_warning_active () then
-      let nearest_name = set_projector names txt
-      and nearest_neighborhood = set_projector neighbouring_names txt in
+      let nearest_name = set_projector max_distance names txt
+      and nearest_neighborhood =
+        set_projector max_distance neighbouring_names txt in
       let warn name =
         Location.prerr_warning loc
           (Warnings.Misspelled_attribute (txt,name)) in

--- a/parsing/attr_helper.mli
+++ b/parsing/attr_helper.mli
@@ -19,14 +19,28 @@ type error =
   | Multiple_attributes of string
   | No_payload_expected of string
 
-(** The [string list] argument of the following functions is a list of
-    alternative names for the attribute we are looking for. For instance:
+type identifier = { names: string list; context: string list }
+
+val std_namespace: string -> string list
+val create: ?context:string list -> string -> identifier
+
+(** The [identifier] argument of the following functions is a
+    list of alternative names for the attribute we are looking for and a list of
+    possible other related names that could appear in this context. For instance:
 
     {[
-      ["foo"; "ocaml.foo"]
-    ]} *)
-val get_no_payload_attribute : string list -> attributes -> string loc option
-val has_no_payload_attribute : string list -> attributes -> bool
+      { names=["foo"; "ocaml.foo"]; context=[ "fooo"; "ocaml.fooo"] }
+    ]}
+
+    During attribute identification, a warning is emitted if the nearest
+    name in the union of names and context is in the list of possible
+    names and is at a distance inferior to [attribute_max_distance] *)
+val attribute_max_distance: int ref
+val is_attribute: ?warn:bool -> identifier -> attribute -> bool
+val get_no_payload_attribute:
+  ?warn:bool -> identifier -> attributes -> string loc option
+val has_no_payload_attribute :
+  ?warn:bool -> identifier -> attributes -> bool
 
 exception Error of Location.t * error
 

--- a/parsing/attr_helper.mli
+++ b/parsing/attr_helper.mli
@@ -19,27 +19,36 @@ type error =
   | Multiple_attributes of string
   | No_payload_expected of string
 
-val attribute_max_distance: int ref
-
-type identifier = { names: string list; neighbouring_names: string list }
+type identifier =
+  { names: string list; neighbouring_names: string list; max_distance:int }
 (** The identifier type represents the information needed to recognize
    a given attribute even in presence of spelling mistakes
    - The field [names] lists all possible names for the attribute
-   - The field [neighbouring_names] enumerates similar names that might appear;
+   - The field [neighbouring_names] enumerates similar names that might appear,
     potentially mispelled, in the same context as the attribute and should not
     be misidentified as the attribute.
+    - The field [max_distance] is the maximal distance beyond which words are
+    always considered as distinct words rather than misspelling. The choice of
+    [max_distance] should be a compromise between false positive and false negative
+    rates. In doubt, 1 or 2 are good default values.
 
     For instance, for an attribute [foo] that might appear in the same
     context than an [fooo] attribute, the identifier could be
 
     {[
-      { names=["foo"; "ocaml.foo"]; neighbouring_names=[ "fooo"; "ocaml.fooo"] }
+      {
+        names=["foo"; "ocaml.foo"];
+        neighbouring_names=[ "fooo"; "ocaml.fooo"];
+        max_distance=2
+      }
     ]}
+    More concrete examples can be found in {!Builtin_attributes} and
+    {!Translattribute}.
 
     A name which does not belong to the [names] list is considered to be a
     misspelled version of the identifier if:
      - the minimal distance [d] between the name and the list of attributes name
-    is less than [!attribute_max_distance]
+    is less than [max_distance]
     - no name in the [neighbouring_names] list is at a distance strictly inferior
     to [d].
 
@@ -50,7 +59,8 @@ type identifier = { names: string list; neighbouring_names: string list }
 val std_namespace: string -> string list
 
 (** Create a standard identifier from a short name *)
-val create: ?neighbouring_names:string list -> string -> identifier
+val create:
+  ?neighbouring_names:string list -> ?max_distance:int -> string -> identifier
 
 (** In the three following functions, a warning is emitted if a misspelled
     version of the identifier is detected *)

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -18,8 +18,8 @@ let ppwarning_names = Attr_helper.std_namespace "ppwarning"
 
 let deprecated = Attr_helper.create "deprecated"
 let deprecated_mutable = Attr_helper.create "deprecated_mutable"
-let warning = Attr_helper.{ names= warning_names; context= ppwarning_names}
-let ppwarning = Attr_helper.{names= ppwarning_names; context= warning_names}
+let warning = Attr_helper.{ names=warning_names; neighbouring_names=ppwarning_names}
+let ppwarning = Attr_helper.{names=ppwarning_names; neighbouring_names=warning_names}
 let warnerror = Attr_helper.create "warnerror"
 let warn_on_literal_pattern = Attr_helper.create "warn_on_literal_pattern"
 let explicit_arity = Attr_helper.create "explicit_arity"

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -20,7 +20,7 @@ let deprecated = Attr_helper.create "deprecated"
 let deprecated_mutable = Attr_helper.create "deprecated_mutable"
 let warning = Attr_helper.{
     names=warning_names;
-    neighbouring_names=ppwarning_names;
+    neighbouring_names= "warding" :: ppwarning_names;
     max_distance=1
   }
 let ppwarning = Attr_helper.{

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -18,8 +18,16 @@ let ppwarning_names = Attr_helper.std_namespace "ppwarning"
 
 let deprecated = Attr_helper.create "deprecated"
 let deprecated_mutable = Attr_helper.create "deprecated_mutable"
-let warning = Attr_helper.{ names=warning_names; neighbouring_names=ppwarning_names}
-let ppwarning = Attr_helper.{names=ppwarning_names; neighbouring_names=warning_names}
+let warning = Attr_helper.{
+    names=warning_names;
+    neighbouring_names=ppwarning_names;
+    max_distance=1
+  }
+let ppwarning = Attr_helper.{
+    names=ppwarning_names;
+    neighbouring_names=warning_names;
+    max_distance=1;
+  }
 let warnerror = Attr_helper.create "warnerror"
 let warn_on_literal_pattern = Attr_helper.create "warn_on_literal_pattern"
 let explicit_arity = Attr_helper.create "explicit_arity"

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -115,7 +115,6 @@ external h : (int [@unboxed]) -> float = "h";;
 
 external i : int -> float [@unboxed] = "i";;
 external j : int -> (float [@unboxed]) * float = "j";;
-external k : int -> (float [@unboxd]) = "k";;
 
 (* Bad: old style annotations + new style attributes *)
 

--- a/testsuite/tests/typing-unboxed/test.ml.reference
+++ b/testsuite/tests/typing-unboxed/test.ml.reference
@@ -153,7 +153,6 @@ Error: Don't know how to untag this type. Only int can be untagged
 Error: Don't know how to unbox this type. Only float, int32, int64 and nativeint can be unboxed
 #   *     external i : int -> float = "i"
 # external j : int -> float * float = "j"
-# external k : int -> float = "k"
 #       Characters 58-119:
   external l : float -> float = "l" "l_nat" "float" [@@unboxed];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/warnings/w59.ml
+++ b/testsuite/tests/warnings/w59.ml
@@ -1,0 +1,27 @@
+let id x = x [@@inlne]
+let f x = ( (fun x->x) [@inlne] [@inlind] ) x (* trigger 2*2=4 warnings *)
+let () = (f [@inlind]) ()
+
+let () = ( (fun x -> x) [@inlined] ) () (* no spelling mistake detected *)
+
+[@@@warnerrror "+500"]
+
+type 'a trap = Nothing of 'a [@warn_on_litteral_pattern]
+let warn_pattern = function Nothing 0 -> true | Nothing _ -> false
+
+let rec nop =
+  function[@warnig "-300"]
+  | _ :: q ->  ( nop[@tailcal] ) q
+  | [] -> []
+
+module Archaic = struct end [@@deprecate] (* trigger 2 warnings? *)
+
+type 'a immutable = { mutable content: 'a [@deprecate_mutable] }
+
+let f x = x.content <- 1
+
+external k : (int [@untaged]) -> (float [@unboxd]) = "k" [@@no_alloc]
+
+module Deactivate_warning = struct
+external k : (int [@untaged]) -> (float [@unboxd]) = "k" [@@no_alloc]
+end[@@warning "-59"]

--- a/testsuite/tests/warnings/w59.reference
+++ b/testsuite/tests/warnings/w59.reference
@@ -1,0 +1,30 @@
+File "w59.ml", line 7, characters 4-14:
+Warning 59: possibly misspelled attribute 'warnerrror' in place of 'warnerror'
+File "w59.ml", line 9, characters 31-55:
+Warning 59: possibly misspelled attribute 'warn_on_litteral_pattern' in place of 'warn_on_literal_pattern'
+File "w59.ml", line 13, characters 12-18:
+Warning 59: possibly misspelled attribute 'warnig' in place of 'warning'
+File "w59.ml", line 17, characters 31-40:
+Warning 59: possibly misspelled attribute 'deprecate' in place of 'deprecated'
+File "w59.ml", line 19, characters 44-61:
+Warning 59: possibly misspelled attribute 'deprecate_mutable' in place of 'deprecated_mutable'
+File "w59.ml", line 23, characters 20-27:
+Warning 59: possibly misspelled attribute 'untaged' in place of 'untagged'
+File "w59.ml", line 23, characters 42-48:
+Warning 59: possibly misspelled attribute 'unboxd' in place of 'unboxed'
+File "w59.ml", line 23, characters 60-68:
+Warning 59: possibly misspelled attribute 'no_alloc' in place of 'noalloc'
+File "w59.ml", line 17, characters 31-40:
+Warning 59: possibly misspelled attribute 'deprecate' in place of 'deprecated'
+File "w59.ml", line 14, characters 22-29:
+Warning 59: possibly misspelled attribute 'tailcal' in place of 'tailcall'
+File "w59.ml", line 3, characters 14-20:
+Warning 59: possibly misspelled attribute 'inlind' in place of 'inlined'
+File "w59.ml", line 2, characters 34-40:
+Warning 59: possibly misspelled attribute 'inlind' in place of 'inlined'
+File "w59.ml", line 2, characters 25-30:
+Warning 59: possibly misspelled attribute 'inlne' in place of 'inline'
+File "w59.ml", line 2, characters 34-40:
+Warning 59: possibly misspelled attribute 'inlind' in place of 'inline'
+File "w59.ml", line 1, characters 16-21:
+Warning 59: possibly misspelled attribute 'inlne' in place of 'inline'

--- a/tools/Makefile.shared
+++ b/tools/Makefile.shared
@@ -38,7 +38,8 @@ CAMLDEP_OBJ=depend.cmo ocamldep.cmo
 CAMLDEP_IMPORTS=timings.cmo misc.cmo config.cmo clflags.cmo terminfo.cmo \
   warnings.cmo location.cmo longident.cmo docstrings.cmo \
   syntaxerr.cmo ast_helper.cmo parser.cmo lexer.cmo parse.cmo \
-  ccomp.cmo ast_mapper.cmo pparse.cmo compenv.cmo builtin_attributes.cmo
+  ccomp.cmo ast_mapper.cmo pparse.cmo compenv.cmo attr_helper.cmo \
+  builtin_attributes.cmo
 
 ocamldep: depend.cmi $(CAMLDEP_OBJ)
 	$(CAMLC) $(LINKFLAGS) -compat-32 -o ocamldep $(CAMLDEP_IMPORTS) $(CAMLDEP_OBJ)

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -91,7 +91,7 @@ let parse_declaration valdecl ~native_repr_args ~native_repr_res =
         fatal_error "Primitive.parse_declaration"
   in
   let noalloc_attribute =
-    Attr_helper.has_no_payload_attribute ["noalloc"; "ocaml.noalloc"]
+    Attr_helper.has_no_payload_attribute (Attr_helper.create "noalloc")
       valdecl.pval_attributes
   in
   if old_style_float &&

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -91,7 +91,9 @@ let parse_declaration valdecl ~native_repr_args ~native_repr_res =
         fatal_error "Primitive.parse_declaration"
   in
   let noalloc_attribute =
-    Attr_helper.has_no_payload_attribute (Attr_helper.create "noalloc")
+    Attr_helper.has_no_payload_attribute
+      (Attr_helper.create ~max_distance:1 "noalloc")
+      (* 10x more possible false positives at max_distance=2 *)
       valdecl.pval_attributes
   in
   if old_style_float &&

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1366,8 +1366,8 @@ type native_repr_attribute =
 
 let get_native_repr_attribute attrs ~global_repr =
   match
-    Attr_helper.get_no_payload_attribute ["unboxed"; "ocaml.unboxed"]  attrs,
-    Attr_helper.get_no_payload_attribute ["untagged"; "ocaml.untagged"] attrs,
+    Attr_helper.get_no_payload_attribute (Attr_helper.create "unboxed")  attrs,
+    Attr_helper.get_no_payload_attribute (Attr_helper.create "untagged") attrs,
     global_repr
   with
   | None, None, None -> Native_repr_attr_absent

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1364,10 +1364,17 @@ type native_repr_attribute =
   | Native_repr_attr_absent
   | Native_repr_attr_present of native_repr_kind
 
+let unboxed = Attr_helper.create "unboxed"
+    ~neighbouring_names:["boxed";"unmixed";"unbound";"unfixed"]
+
+let untagged = Attr_helper.create "untagged"
+    ~neighbouring_names:["tagged"]
+
+
 let get_native_repr_attribute attrs ~global_repr =
   match
-    Attr_helper.get_no_payload_attribute (Attr_helper.create "unboxed")  attrs,
-    Attr_helper.get_no_payload_attribute (Attr_helper.create "untagged") attrs,
+    Attr_helper.get_no_payload_attribute unboxed attrs,
+    Attr_helper.get_no_payload_attribute untagged attrs,
     global_repr
   with
   | None, None, None -> Native_repr_attr_absent

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -76,6 +76,7 @@ type t =
   | Unreachable_case                        (* 56 *)
   | Ambiguous_pattern of string list        (* 57 *)
   | No_cmx_file of string                   (* 58 *)
+  | Misspelled_attribute of string * string (* 59 *)
 ;;
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
@@ -143,9 +144,10 @@ let number = function
   | Unreachable_case -> 56
   | Ambiguous_pattern _ -> 57
   | No_cmx_file _ -> 58
+  | Misspelled_attribute _ -> 59
 ;;
 
-let last_warning_number = 58
+let last_warning_number = 59
 ;;
 (* Must be the max number returned by the [number] function. *)
 
@@ -445,6 +447,9 @@ let message = function
       Printf.sprintf
         "no cmx file was found in path for module %s, \
          and its interface was not compiled with -opaque" name
+  | Misspelled_attribute (misspelled, correct) ->
+      Printf.sprintf
+      "possibly misspelled attribute '%s' in place of '%s'" misspelled correct
 ;;
 
 let nerrors = ref 0;;
@@ -541,6 +546,7 @@ let descriptions =
    56, "Unreachable case in a pattern-matching (based on type information).";
    57, "Ambiguous binding by pattern.";
    58, "Missing cmx file";
+   59, "Possibly misspelled built-in attribute"
   ]
 ;;
 

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -71,6 +71,7 @@ type t =
   | Unreachable_case                        (* 56 *)
   | Ambiguous_pattern of string list        (* 57 *)
   | No_cmx_file of string                   (* 58 *)
+  | Misspelled_attribute of string * string (* 59 *)
 ;;
 
 val parse_options : bool -> string -> unit;;


### PR DESCRIPTION
This pull request adds a simplistic safety net against misspelled built-in attributes.

Since some builtin attributes can be silently deactivated by a spelling error, this patch tries to catch basic spelling mistakes and expose them before they can cause any harms. 

The chosen model is a set of opt-in functions for detecting possibly misspelled attribute in `parsing/attr_helper` using the edit_distance already implemented in `util/misc`. To decrease the number of false positive the maximal edit distance for identifying misspelling is quite small. 

In a semi-related way, this patch also corrects a spelling mistake on the `tailcall` attribute in the changelog. 
