### PR TITLE
MPR#7109: documentation and ocamldoc, fix bigarray documentation

### DIFF
--- a/Changes
+++ b/Changes
@@ -304,6 +304,8 @@ Manual:
   (Alain Frisch, John Whitington)
 - MPR#7092, GPR#379: Add missing documentation for new 4.03 features
   (Florian Angeletti)
+- MPR#7109, GPR#380: Fix bigarray documentation layout
+  (Florian Angeletti, Leo White)
 
 Bug fixes:
 - PR#3612: memory leak in bigarray read from file

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -288,7 +288,9 @@ module Analyser =
           let f {Types.cd_id=constructor_name;cd_args;cd_res=ret_type} =
             let constructor_name = Ident.name constructor_name in
             let comment_opt =
-              try List.assoc constructor_name name_comment_list
+              try match List.assoc constructor_name name_comment_list with
+                | Some { i_desc = None | Some []; _ } -> None
+                | x -> x
               with Not_found -> None
             in
             let vc_args =

--- a/otherlibs/bigarray/bigarray.mli
+++ b/otherlibs/bigarray/bigarray.mli
@@ -83,7 +83,7 @@ type ('a, 'b) kind =
   | Nativeint : (nativeint, nativeint_elt) kind
   | Complex32 : (Complex.t, complex32_elt) kind
   | Complex64 : (Complex.t, complex64_elt) kind
-  | Char : (char, int8_unsigned_elt) kind
+  | Char : (char, int8_unsigned_elt) kind (**)
 (** To each element kind is associated an OCaml type, which is
    the type of OCaml values that can be stored in the big array
    or read back from it.  This type is not necessarily the same
@@ -170,10 +170,10 @@ val char : (char, int8_unsigned_elt) kind
 
 (** {6 Array layouts} *)
 
-type c_layout = C_layout_typ
+type c_layout = C_layout_typ (**)
 (** See {!Bigarray.fortran_layout}.*)
 
-type fortran_layout = Fortran_layout_typ
+type fortran_layout = Fortran_layout_typ (**)
 (** To facilitate interoperability with existing C and Fortran code,
    this library supports two different memory layouts for big arrays,
    one compatible with the C conventions,


### PR DESCRIPTION
This pull request fixes the documentation layout in `otherlibs/bigarray.mli`.

Some documentation comments in `bigarray.mli` were wrongly attached to the last constructor of their related type definitions when they should have be attached to the type definition.

To fix this attachment problem, the two possible solutions are either to detach completely the concerned documentation comments or to add an empty documentation just after the last constructor.

The last solution gives the expected attachment and seems better on the long term; however most documentation generators tends to print these empty documentation comments as `(* *)`. 

Since these empty constructor comments do not really convey any information (except maybe "ocamldoc implementation is quite complex"), this pull request proposes to simply erase such empty comments in ocamldoc itself.

With these two commits, the bigarray documentation should be restored to its correct state.
