### PR TITLE
ocamlnat: fixes

### DIFF
--- a/asmcomp/asmgen.mli
+++ b/asmcomp/asmgen.mli
@@ -14,7 +14,7 @@
 
 val compile_implementation :
     ?toplevel:(string -> bool) ->
-    sourcefile:string ->
+    source_provenance:Timings.source_provenance ->
     string -> Format.formatter -> int * Lambda.lambda -> unit
 val compile_phrase :
     Format.formatter -> Cmm.phrase -> unit
@@ -25,6 +25,6 @@ val report_error: Format.formatter -> error -> unit
 
 
 val compile_unit:
-  sourcefile:string ->
+  source_provenance:Timings.source_provenance ->
   string(*asm file*) -> bool(*keep asm*) ->
   string(*obj file*) -> (unit -> unit) -> unit

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -268,7 +268,7 @@ let link_shared ppf objfiles output_name =
     then output_name ^ ".startup" ^ ext_asm
     else Filename.temp_file "camlstartup" ext_asm in
   let startup_obj = output_name ^ ".startup" ^ ext_obj in
-  Asmgen.compile_unit ~sourcefile:"startup"
+  Asmgen.compile_unit ~source_provenance:Timings.Startup
     startup !Clflags.keep_startup_file startup_obj
     (fun () ->
        make_shared_startup_file ppf
@@ -327,7 +327,7 @@ let link ppf objfiles output_name =
     then output_name ^ ".startup" ^ ext_asm
     else Filename.temp_file "camlstartup" ext_asm in
   let startup_obj = Filename.temp_file "camlstartup" ext_obj in
-  Asmgen.compile_unit ~sourcefile:"startup"
+  Asmgen.compile_unit ~source_provenance:Timings.Startup
     startup !Clflags.keep_startup_file startup_obj
     (fun () -> make_startup_file ppf units_tolink);
   Misc.try_finally

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -91,7 +91,7 @@ let make_package_object ppf members targetobj targetname coercion =
         | PM_intf -> None
         | PM_impl _ -> Some(Ident.create_persistent m.pm_name))
       members in
-  Asmgen.compile_implementation ~sourcefile:"pack"
+  Asmgen.compile_implementation ~source_provenance:(Timings.Pack targetname)
     (chop_extension_if_any objtemp) ppf
     (Translmod.transl_store_package
        components (Ident.create_persistent targetname) coercion);

--- a/asmcomp/compilenv.ml
+++ b/asmcomp/compilenv.ml
@@ -206,7 +206,11 @@ let symbol_for_global id =
   if Ident.is_predef_exn id then
     "caml_exn_" ^ Ident.name id
   else begin
-    match get_global_info id with
+    let unitname = Ident.name id in
+    match
+      try ignore (Hashtbl.find toplevel_approx unitname); None
+      with Not_found -> get_global_info id
+    with
     | None -> make_symbol ~unitname:(Ident.name id) None
     | Some ui -> make_symbol ~unitname:ui.ui_symbol None
   end

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -59,12 +59,12 @@ let (++) x f = f x
 let (+++) (x, y) f = (x, f y)
 
 let implementation ppf sourcefile outputprefix =
+  let source_provenance = Timings.File sourcefile in
   Compmisc.init_path true;
   let modulename = module_of_filename ppf sourcefile outputprefix in
   Env.set_unit_name modulename;
   let env = Compmisc.initial_env() in
-  Compilenv.reset ~source_provenance:(Timings.File sourcefile)
-    ?packname:!Clflags.for_package modulename;
+  Compilenv.reset ~source_provenance ?packname:!Clflags.for_package modulename;
   let cmxfile = outputprefix ^ ".cmx" in
   let objfile = outputprefix ^ ext_obj in
   let comp ast =
@@ -86,7 +86,7 @@ let implementation ppf sourcefile outputprefix =
           (fun (size, lambda) ->
             (size, Simplif.simplify_lambda lambda)
             +++ print_if ppf Clflags.dump_lambda Printlambda.lambda
-            ++ Asmgen.compile_implementation ~sourcefile outputprefix ppf;
+            ++ Asmgen.compile_implementation ~source_provenance outputprefix ppf;
             Compilenv.save_unit_info cmxfile)
     end;
     Warnings.check_fatal ();

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -165,7 +165,8 @@ let load_lambda ppf (size, lam) =
     else Filename.temp_file ("caml" ^ !phrase_name) ext_dll
   in
   let fn = Filename.chop_extension dll in
-  Asmgen.compile_implementation ~toplevel:need_symbol fn ppf (size, slam);
+  Asmgen.compile_implementation ~source_provenance:Timings.Toplevel
+    ~toplevel:need_symbol fn ppf (size, slam);
   Asmlink.call_linker_shared [fn ^ ext_obj] dll;
   Sys.remove (fn ^ ext_obj);
 
@@ -217,7 +218,8 @@ let execute_phrase print_outcome ppf phr =
       let oldenv = !toplevel_env in
       incr phrase_seqid;
       phrase_name := Printf.sprintf "TOP%i" !phrase_seqid;
-      Compilenv.reset ?packname:None !phrase_name;
+      Compilenv.reset ~source_provenance:Timings.Toplevel
+        ?packname:None !phrase_name;
       Typecore.reset_delayed_checks ();
       let (str, sg, newenv) = Typemod.type_toplevel_phrase oldenv sstr in
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;

--- a/utils/timings.ml
+++ b/utils/timings.ml
@@ -25,10 +25,10 @@ type compiler_pass =
   | Typing of file
   | Transl of file
   | Generate of file
-  | Assemble of file
-  | Clambda of file
-  | Cmm of file
-  | Compile_phrases of file
+  | Assemble of source_provenance
+  | Clambda of source_provenance
+  | Cmm of source_provenance
+  | Compile_phrases of source_provenance
   | Selection of source_provenance
   | Comballoc of source_provenance
   | CSE of source_provenance
@@ -108,10 +108,10 @@ let pass_name = function
   | Typing file -> Printf.sprintf "typing(%s)" file
   | Transl file -> Printf.sprintf "transl(%s)" file
   | Generate file -> Printf.sprintf "generate(%s)" file
-  | Assemble file -> Printf.sprintf "assemble(%s)" file
-  | Clambda file -> Printf.sprintf "clambda(%s)" file
-  | Cmm file -> Printf.sprintf "cmm(%s)" file
-  | Compile_phrases file -> Printf.sprintf "compile_phrases(%s)" file
+  | Assemble k -> Printf.sprintf "assemble(%s)" (kind_name k)
+  | Clambda k -> Printf.sprintf "clambda(%s)" (kind_name k)
+  | Cmm k -> Printf.sprintf "cmm(%s)" (kind_name k)
+  | Compile_phrases k -> Printf.sprintf "compile_phrases(%s)" (kind_name k)
   | Selection k -> Printf.sprintf "selection(%s)" (kind_name k)
   | Comballoc k -> Printf.sprintf "comballoc(%s)" (kind_name k)
   | CSE k -> Printf.sprintf "cse(%s)" (kind_name k)

--- a/utils/timings.ml
+++ b/utils/timings.ml
@@ -16,6 +16,7 @@ type source_provenance =
   | File of file
   | Pack of string
   | Startup
+  | Toplevel
 
 type compiler_pass =
   | All
@@ -98,6 +99,7 @@ let kind_name = function
   | File f -> Printf.sprintf "sourcefile(%s)" f
   | Pack p -> Printf.sprintf "pack(%s)" p
   | Startup -> "startup"
+  | Toplevel  -> "toplevel"
 
 let pass_name = function
   | All -> "all"

--- a/utils/timings.mli
+++ b/utils/timings.mli
@@ -27,10 +27,10 @@ type compiler_pass =
   | Typing of file
   | Transl of file
   | Generate of file
-  | Assemble of file
-  | Clambda of file
-  | Cmm of file
-  | Compile_phrases of file
+  | Assemble of source_provenance
+  | Clambda of source_provenance
+  | Cmm of source_provenance
+  | Compile_phrases of source_provenance
   | Selection of source_provenance
   | Comballoc of source_provenance
   | CSE of source_provenance

--- a/utils/timings.mli
+++ b/utils/timings.mli
@@ -18,6 +18,7 @@ type source_provenance =
   | File of file
   | Pack of string
   | Startup
+  | Toplevel
 
 type compiler_pass =
   | All


### PR DESCRIPTION
The build was broken, again.
If it breaks again I probably won't do another PR here and just wait for flambda to get merged ( https://github.com/chambart/ocaml-1/pull/21 is a working version of ocamlnat on flambda supporting both backends).

With the build fixed I noticed that https://github.com/ocaml/ocaml/commit/9216c69017dedfe0411851bf8218d6c71c5019c9 didn't handle the case were an unit was generated by the toplevel. I think my patch is correct but would appreciate it if @lpw25 could have a look.
