### PR TITLE
Define _ALL_SOURCE for AIX 7.1

### DIFF
--- a/Changes
+++ b/Changes
@@ -504,6 +504,8 @@ Features wishes:
   (Rich Neswold)
 - GPR#365: prevent printing just a single type variable on one side
   of a type error clash. (Hugo Heuzard)
+- GPR#383: configure: define _ALL_SOURCE for build on AIX7.1
+  (tkob)
 
 OCaml 4.02.3 (27 Jul 2015):
 ---------------------------

--- a/configure
+++ b/configure
@@ -375,7 +375,7 @@ case "$bytecc,$target" in
     bytecccompopts="$bytecccompopts -DUMK";;
   *,powerpc-*-aix*)
     # Avoid name-space pollution by requiring Unix98-conformant includes
-    bytecccompopts="$bytecccompopts -D_XOPEN_SOURCE=500";;
+    bytecccompopts="$bytecccompopts -D_XOPEN_SOURCE=500 -D_ALL_SOURCE";;
   *,*-*-cygwin*)
     case $target in
       i686-*) flavor=cygwin;;


### PR DESCRIPTION
This PR modifies configure scripts so that `-D_ALL_SOURCE` is added for AIX.

This is needed because some required constants and prototypes are defined
inside `#ifdef _ALL_SOURCE`

Examples are:
- AI_NUMERICHOST constant in netdb.h (used from getaddrinfo.c)
- chroot prototype in unistd.h (used from chroot.c)
