### PR TITLE
Changes allowing old Microsoft C Compilers still to build OCaml

### DIFF
--- a/Changes
+++ b/Changes
@@ -332,6 +332,9 @@ Other libraries:
   (Xavier Leroy)
 - PR#7024: in documentation of Str regular expressions, clarify what
     "end of line" means for "^" and "$" regexps.
+- GPR#384: Fix compilation of Unix with older Microsoft C Compilers (pre-release
+  Visual Studio 2005 and ealier)
+  (David Allsopp)
 
 OCamldep:
 - GPR#286: add support for module aliases

--- a/Changes
+++ b/Changes
@@ -191,7 +191,8 @@ Runtime system:
 - GPR#297: Several changes to improve the worst-case GC pause time.
   (Damien Doligez, with help from Leo White and Francois Bobot)
 - GPR#384: Fix compilation using old Microsoft C Compilers not supporting secure
-  CRT functions (SDK Visual Studio 2005 compiler and earlier)
+  CRT functions (SDK Visual Studio 2005 compiler and earlier) and standard
+  64-bit integer literals (Visual Studio .NET 2002 and earlier)
   (David Allsopp)
 
 Standard library:

--- a/Changes
+++ b/Changes
@@ -190,6 +190,9 @@ Runtime system:
   Gesbert, review by Alain Frisch)
 - GPR#297: Several changes to improve the worst-case GC pause time.
   (Damien Doligez, with help from Leo White and Francois Bobot)
+- GPR#384: Fix compilation using old Microsoft C Compilers not supporting secure
+  CRT functions (SDK Visual Studio 2005 compiler and earlier)
+  (David Allsopp)
 
 Standard library:
 - PR#1460, GPR#230: Array.map2, Array.iter2

--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -86,7 +86,7 @@ extern value caml_start_program (void);
 extern void caml_init_ieee_floats (void);
 extern void caml_init_signals (void);
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
 
 /* PR 4887: avoid crash box of windows runtime on some system calls */
 extern void caml_install_invalid_parameter_handler();
@@ -103,7 +103,7 @@ void caml_main(char **argv)
 
   caml_init_frame_descriptors();
   caml_init_ieee_floats();
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();
 #endif
   caml_init_custom_operations();

--- a/byterun/compare.c
+++ b/byterun/compare.c
@@ -19,6 +19,10 @@
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
 
+#if defined(LACKS_SANE_NAN) && !defined(isnan)
+#define isnan _isnan
+#endif
+
 /* Structural comparison on trees. */
 
 struct compare_item { value * v1, * v2; mlsize_t count; };
@@ -172,8 +176,19 @@ static intnat compare_val(value v1, value v2, int total)
     case Double_tag: {
       double d1 = Double_val(v1);
       double d2 = Double_val(v2);
+#ifdef LACKS_SANE_NAN
+      if (isnan(d2)) {
+        if (! total) return UNORDERED;
+        if (isnan(d1)) break;
+        return GREATER;
+      } else if (isnan(d1)) {
+        if (! total) return UNORDERED;
+        return LESS;
+      }
+#endif
       if (d1 < d2) return LESS;
       if (d1 > d2) return GREATER;
+#ifndef LACKS_SANE_NAN
       if (d1 != d2) {
         if (! total) return UNORDERED;
         /* One or both of d1 and d2 is NaN.  Order according to the
@@ -182,6 +197,7 @@ static intnat compare_val(value v1, value v2, int total)
         if (d2 == d2) return LESS;    /* d2 is not NaN, d1 is NaN */
         /* d1 and d2 are both NaN, thus equal: continue comparison */
       }
+#endif
       break;
     }
     case Double_array_tag: {
@@ -192,14 +208,26 @@ static intnat compare_val(value v1, value v2, int total)
       for (i = 0; i < sz1; i++) {
         double d1 = Double_field(v1, i);
         double d2 = Double_field(v2, i);
+#ifdef LACKS_SANE_NAN
+        if (isnan(d2)) {
+          if (! total) return UNORDERED;
+          if (isnan(d1)) break;
+          return GREATER;
+        } else if (isnan(d1)) {
+          if (! total) return UNORDERED;
+          return LESS;
+        }
+#endif
         if (d1 < d2) return LESS;
         if (d1 > d2) return GREATER;
+#ifndef LACKS_SANE_NAN
         if (d1 != d2) {
           if (! total) return UNORDERED;
           /* See comment for Double_tag case */
           if (d1 == d1) return GREATER;
           if (d2 == d2) return LESS;
         }
+#endif
       }
       break;
     }

--- a/byterun/ints.c
+++ b/byterun/ints.c
@@ -497,18 +497,25 @@ value caml_int64_direct_bswap(value v)
 { return caml_swap64(v); }
 #endif
 
+/* Microsoft introduced the LL integer literal suffix in Visual C++ .NET 2003 */
+#if defined(_MSC_VER) && _MSC_VER < 1400
+#define INT64_LITERAL(s) s ## i64
+#else
+#define INT64_LITERAL(s) s ## LL
+#endif
+
 CAMLprim value caml_int64_bswap(value v)
 {
   int64_t x = Int64_val(v);
   return caml_copy_int64
-    (((x & 0x00000000000000FFULL) << 56) |
-     ((x & 0x000000000000FF00ULL) << 40) |
-     ((x & 0x0000000000FF0000ULL) << 24) |
-     ((x & 0x00000000FF000000ULL) << 8) |
-     ((x & 0x000000FF00000000ULL) >> 8) |
-     ((x & 0x0000FF0000000000ULL) >> 24) |
-     ((x & 0x00FF000000000000ULL) >> 40) |
-     ((x & 0xFF00000000000000ULL) >> 56));
+    (((x & INT64_LITERAL(0x00000000000000FFU)) << 56) |
+     ((x & INT64_LITERAL(0x000000000000FF00U)) << 40) |
+     ((x & INT64_LITERAL(0x0000000000FF0000U)) << 24) |
+     ((x & INT64_LITERAL(0x00000000FF000000U)) << 8) |
+     ((x & INT64_LITERAL(0x000000FF00000000U)) >> 8) |
+     ((x & INT64_LITERAL(0x0000FF0000000000U)) >> 24) |
+     ((x & INT64_LITERAL(0x00FF000000000000U)) >> 40) |
+     ((x & INT64_LITERAL(0xFF00000000000000U)) >> 56));
 }
 
 CAMLprim value caml_int64_of_int(value v)

--- a/byterun/startup.c
+++ b/byterun/startup.c
@@ -257,7 +257,7 @@ extern void caml_init_ieee_floats (void);
 extern void caml_signal_thread(void * lpParam);
 #endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
 
 /* PR 4887: avoid crash box of windows runtime on some system calls */
 extern void caml_install_invalid_parameter_handler();
@@ -279,7 +279,7 @@ CAMLexport void caml_main(char **argv)
   /* Machine-dependent initialization of the floating-point hardware
      so that it behaves as much as possible as specified in IEEE */
   caml_init_ieee_floats();
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();
 #endif
   caml_init_custom_operations();
@@ -395,7 +395,7 @@ CAMLexport void caml_startup_code(
   static char proc_self_exe[256];
 
   caml_init_ieee_floats();
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();
 #endif
   caml_init_custom_operations();

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -577,7 +577,7 @@ int caml_win32_random_seed (intnat data[16])
 }
 
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
 
 static void invalid_parameter_handler(const wchar_t* expression,
    const wchar_t* function,

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -610,6 +610,26 @@ int caml_executable_name(char * name, int name_len)
 
 /* snprintf emulation */
 
+#ifdef LACKS_VSCPRINTF
+/* No _vscprintf until Visual Studio .NET 2002 and sadly no version number
+   in the CRT headers until Visual Studio 2005 so forced to predicate this
+   on the compiler version instead */
+int _vscprintf(const char * format, va_list args)
+{
+  int n;
+  int sz = 5;
+  char* buf = (char*)malloc(sz);
+  n = _vsnprintf(buf, sz, format, args);
+  while (n < 0 || n > sz) {
+    sz += 512;
+    buf = (char*)realloc(buf, sz);
+    n = _vsnprintf(buf, sz, format, args);
+  }
+  free(buf);
+  return n;
+}
+#endif
+
 #if defined(_WIN32) && !defined(_UCRT)
 int caml_snprintf(char * buf, size_t size, const char * format, ...)
 {

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -47,6 +47,12 @@
 #define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
 #endif
 
+/* Very old Microsoft headers don't include intptr_t */
+#if defined(_MSC_VER) && !defined(_UINTPTR_T_DEFINED)
+typedef unsigned int uintptr_t;
+#define _UINTPTR_T_DEFINED
+#endif
+
 CAMLnoreturn_start
 static void caml_win32_sys_error (int errnum)
 CAMLnoreturn_end;

--- a/config/s-nt.h
+++ b/config/s-nt.h
@@ -32,3 +32,6 @@
 #define HAS_IPV6
 #define HAS_NICE
 #define SUPPORT_DYNAMIC_LINKING
+#if defined(_MSC_VER) && _MSC_VER < 1300
+#define LACKS_SANE_NAN
+#endif

--- a/config/s-nt.h
+++ b/config/s-nt.h
@@ -34,4 +34,5 @@
 #define SUPPORT_DYNAMIC_LINKING
 #if defined(_MSC_VER) && _MSC_VER < 1300
 #define LACKS_SANE_NAN
+#define LACKS_VSCPRINTF
 #endif

--- a/otherlibs/win32unix/channels.c
+++ b/otherlibs/win32unix/channels.c
@@ -44,6 +44,9 @@ CAMLprim value win_inchannel_of_filedescr(value handle)
   CAMLlocal1(vchan);
   struct channel * chan;
 
+#if defined(_MSC_VER) && _MSC_VER < 1400
+  fflush(stdin);
+#endif
   chan = caml_open_descriptor_in(win_CRT_fd_of_filedescr(handle));
   if (Descr_kind_val(handle) == KIND_SOCKET)
     chan->flags |= CHANNEL_FLAG_FROM_SOCKET;

--- a/otherlibs/win32unix/channels.c
+++ b/otherlibs/win32unix/channels.c
@@ -18,6 +18,11 @@
 #include "unixsupport.h"
 #include <fcntl.h>
 
+#if defined(_MSC_VER) && !defined(_INTPTR_T_DEFINED)
+typedef int intptr_t;
+#define _INTPTR_T_DEFINED
+#endif
+
 extern intptr_t _get_osfhandle(int);
 extern int _open_osfhandle(intptr_t, int);
 

--- a/otherlibs/win32unix/gettimeofday.c
+++ b/otherlibs/win32unix/gettimeofday.c
@@ -25,6 +25,14 @@ CAMLprim value unix_gettimeofday(value unit)
   FILETIME ft;
   double tm;
   GetSystemTimeAsFileTime(&ft);
+#if defined(_MSC_VER) && _MSC_VER < 1300
+  /* This compiler can't cast uint64_t to double! Fortunately, this doesn't
+     matter since SYSTEMTIME is only ever 63-bit (maximum value 31-Dec-30827
+     23:59:59.999, and it requires some skill to set the clock past 2099!)
+   */
+  tm = *(int64_t *)&ft - epoch_ft; /* shift to Epoch-relative time */
+#else
   tm = *(uint64_t *)&ft - epoch_ft; /* shift to Epoch-relative time */
+#endif
   return copy_double(tm * 1e-7);  /* tm is in 100ns */
 }

--- a/otherlibs/win32unix/times.c
+++ b/otherlibs/win32unix/times.c
@@ -18,7 +18,15 @@
 
 
 double to_sec(FILETIME ft) {
+#if defined(_MSC_VER) && _MSC_VER < 1300
+  /* See gettimeofday.c - it is not possible for these values to be 64-bit, so
+     there's no worry about using a signed struct in order to work around the
+     lack of support for casting int64_t to double.
+   */
+  LARGE_INTEGER tmp;
+#else
   ULARGE_INTEGER tmp;
+#endif
 
   tmp.u.LowPart = ft.dwLowDateTime;
   tmp.u.HighPart = ft.dwHighDateTime;

--- a/otherlibs/win32unix/windbug.h
+++ b/otherlibs/win32unix/windbug.h
@@ -35,6 +35,16 @@
 /* Test if we are in dbug mode */
 int  debug_test    (void);
 
+#elif defined(_MSC_VER) && _MSC_VER < 1300
+
+#define DEBUG_PRINT(fmt)
+
+/* __pragma wasn't added until Visual C++ .NET 2002, so simply disable the
+   warning entirely
+ */
+
+#pragma warning (disable:4002)
+
 #elif defined(_MSC_VER) && _MSC_VER <= 1400
 
 /* Not all versions of the Visual Studio 2005 C Compiler (Version 14) support

--- a/otherlibs/win32unix/windbug.h
+++ b/otherlibs/win32unix/windbug.h
@@ -35,6 +35,24 @@
 /* Test if we are in dbug mode */
 int  debug_test    (void);
 
+#elif defined(_MSC_VER) && _MSC_VER <= 1400
+
+/* Not all versions of the Visual Studio 2005 C Compiler (Version 14) support
+   variadic macros, hence the test for this branch being <= 1400 rather than
+   < 1400.
+   This convoluted pair of macros allow DEBUG_PRINT to remain while temporarily
+   suppressing the warning displayed for a macro called with too many
+   parameters.
+ */
+#define DEBUG_PRINT_S(fmt) __pragma(warning(pop))
+#define DEBUG_PRINT \
+  __pragma(warning(push)) \
+  __pragma(warning(disable:4002)) \
+  DEBUG_PRINT_S
+
 #else
+
+/* Visual Studio supports variadic macros in all versions from 2008 (CL 15). */
 #define DEBUG_PRINT(fmt, ...)
+
 #endif


### PR DESCRIPTION
The product of some testing of very old Microsoft C Compilers - posting the PR to ask very quickly for help with the very weird patch in https://github.com/ocaml/ocaml/commit/47d6ce213c91e86e223a64190a45286da1c590a5!

Each commit fixes three distinct faults:
- https://github.com/ocaml/ocaml/commit/b9ca576c7958eee33b82bac9a4cf89201994b249 (see also [MPR4887](http://caml.inria.fr/mantis/view.php?id=4887)) more correctly bounds the code for _set_invalid_parameter_handler with the proper detection for the secure API changes.
- https://github.com/ocaml/ocaml/commit/9f310fa0b02ce5f605bf18da600973bd3e00b466 fixes the lack of support for variadic macros in all editions of the C pre-processor prior to Visual Studio 2008 (I haven't bothered to correct the `DEBUG` branch for compilers that old - if someone ever has the need to debug `otherlibs/win32unix/select.c` on such a compiler, they're welcome to write the tedious macro to support it!)
- https://github.com/ocaml/ocaml/commit/47d6ce213c91e86e223a64190a45286da1c590a5 is necessary for Unix.in_channel_of_descr to work when compiled with Visual Studio .NET 2003. I freely admit that this compiler is so old as to be almost not worth any attention, but I was wondering if an expert looking at the simple patch (it was identified as a result of inserting `printf`s to identify the failure and then going from there...) may lead to a more proper patch with comments. It's pretty cool if OCaml does still build successfully on a compiler released 12 years ago - it also has the "benefit" of meaning that the MSVC port can be built using the same runtime as the MinGW port (i.e. you "need" Visual Studio .NET 2003 to build against msvcrt.dll)

Or the whole thing can be dropped - the whole exercise is part of revising the Windows build instructions and seeing just how far back support still extends. I personally find it interesting/impressive that so few changes are apparently necessary...
