### PR TITLE
fix format-of-pointer warnings on 32-bit architectures

### DIFF
--- a/byterun/instrtrace.c
+++ b/byterun/instrtrace.c
@@ -183,19 +183,21 @@ caml_trace_value_file (value v, code_t prog, int proglen, FILE * f)
   if (prog && v % sizeof (int) == 0
            && (code_t) v >= prog
            && (code_t) v < (code_t) ((char *) prog + proglen))
-    fprintf (f, "=code@%ld", (code_t) v - prog);
+    fprintf (f, "=code@%" ARCH_INTNAT_PRINTF_FORMAT "d", (code_t) v - prog);
   else if (Is_long (v))
     fprintf (f, "=long%" ARCH_INTNAT_PRINTF_FORMAT "d", Long_val (v));
   else if ((void*)v >= (void*)caml_stack_low
            && (void*)v < (void*)caml_stack_high)
-    fprintf (f, "=stack_%ld", (intnat*)caml_stack_high - (intnat*)v);
+    fprintf (f, "=stack_%" ARCH_INTNAT_PRINTF_FORMAT "d",
+             (intnat*)caml_stack_high - (intnat*)v);
   else if (Is_block (v)) {
     int s = Wosize_val (v);
     int tg = Tag_val (v);
     int l = 0;
     switch (tg) {
     case Closure_tag:
-      fprintf (f, "=closure[s%d,cod%ld]", s, (code_t) (Code_val (v)) - prog);
+      fprintf (f, "=closure[s%d,cod%" ARCH_INTNAT_PRINTF_FORMAT "d]",
+               s, (code_t) (Code_val (v)) - prog);
       goto displayfields;
     case String_tag:
       l = caml_string_length (v);
@@ -250,7 +252,8 @@ caml_trace_accu_sp_file (value accu, value * sp, code_t prog, int proglen,
   value *p;
   fprintf (f, "accu=");
   caml_trace_value_file (accu, prog, proglen, f);
-  fprintf (f, "\n sp=%#" ARCH_INTNAT_PRINTF_FORMAT "x @%ld:",
+  fprintf (f, "\n sp=%#" ARCH_INTNAT_PRINTF_FORMAT "x "
+           "@%" ARCH_INTNAT_PRINTF_FORMAT "d:",
            (intnat) sp, caml_stack_high - sp);
   for (p = sp, i = 0; i < 12 + (1 << caml_trace_level) && p < caml_stack_high;
        p++, i++) {


### PR DESCRIPTION
Kakadu reports that `-with-debug-runtime` fails on his 32bit machine with the following errors:

```
gcc -c -DCAML_NAME_SPACE -g -DDEBUG -std=gnu99 -O2 -fno-strict-aliasing -fwrapv -Wall -Werror -D_FILE_OFFSET_BITS=64 -D_REENTRANT  instrtrace.c -o instrtrace.d.o
make[2]: Leaving directory `/home/kakadu/.opam/4.03.0+trunk/build/ocaml/byterun'
make[1]: Leaving directory `/home/kakadu/.opam/4.03.0+trunk/build/ocaml'
instrtrace.c: In function ‘caml_trace_value_file’:
instrtrace.c:186:5: error: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘int’ [-Werror=format=]
     fprintf (f, "=code@%ld", (code_t) v - prog);
     ^
instrtrace.c:191:5: error: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘int’ [-Werror=format=]
     fprintf (f, "=stack_%ld", (intnat*)caml_stack_high - (intnat*)v);
     ^
instrtrace.c:198:7: error: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘int’ [-Werror=format=]
       fprintf (f, "=closure[s%d,cod%ld]", s, (code_t) (Code_val (v)) - prog);
       ^
instrtrace.c: In function ‘caml_trace_accu_sp_file’:
instrtrace.c:254:12: error: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘int’ [-Werror=format=]
            (intnat) sp, caml_stack_high - sp);
            ^
instrtrace.c:257:5: error: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘int’ [-Werror=format=]
     fprintf (f, "\n[%ld] ", caml_stack_high - p);
     ^
cc1: all warnings being treated as errors
```

The patch tentatively fixes this issue. I don't have a 32bit machine under hand to test it, so confirmation that it fixes the issue (or reports of similar issues in other files) would be welcome.
