### PR TITLE
Allow toplevel value to be used for preprocessing

### DIFF
--- a/.depend
+++ b/.depend
@@ -1952,9 +1952,9 @@ middle_end/base_types/variable.cmi : utils/identifiable.cmi typing/ident.cmi \
     middle_end/base_types/compilation_unit.cmi
 driver/compdynlink.cmi :
 driver/compenv.cmo : utils/warnings.cmi utils/misc.cmi parsing/location.cmi \
-    utils/config.cmi utils/clflags.cmi driver/compenv.cmi
+    utils/config.cmi utils/clflags.cmi driver/compenv.cmi driver/pparse.cmi
 driver/compenv.cmx : utils/warnings.cmx utils/misc.cmx parsing/location.cmx \
-    utils/config.cmx utils/clflags.cmx driver/compenv.cmi
+    utils/config.cmx utils/clflags.cmx driver/compenv.cmi driver/pparse.cmi
 driver/compenv.cmi :
 driver/compile.cmo : utils/warnings.cmi typing/typemod.cmi \
     typing/typedtree.cmi typing/typecore.cmi bytecomp/translmod.cmi \

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -525,7 +525,9 @@ let readenv ppf position =
   apply_config_file ppf position;
   read_OCAMLPARAM ppf position;
   all_ccopts := !last_ccopts @ !first_ccopts;
-  all_ppx := !last_ppx @ !first_ppx
+  all_ppx := !last_ppx @ !first_ppx;
+  Pparse.clear_ppx();
+  List.iter (fun path -> Pparse.add_external_ppx ~path) !all_ppx
 
 let get_objfiles ~with_ocamlparam =
   if with_ocamlparam then

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -119,6 +119,9 @@ type rewriter_kind =
 let installed_ppxs = ref []
 
 let clear_ppx () = installed_ppxs := []
+let clear_in_process_ppx () =
+  installed_ppxs := List.filter (function External _ -> true | _ -> false) !installed_ppxs
+
 let add_external_ppx ~path =
   installed_ppxs := (External path) :: !installed_ppxs
 

--- a/driver/pparse.mli
+++ b/driver/pparse.mli
@@ -28,6 +28,10 @@ type 'a ast_kind =
 | Structure : Parsetree.structure ast_kind
 | Signature : Parsetree.signature ast_kind
 
+val clear_ppx : unit -> unit
+val add_external_ppx : path:string -> unit
+val add_in_process_ppx : Ast_mapper.mapper -> unit
+
 val read_ast : 'a ast_kind -> string -> 'a
 val write_ast : 'a ast_kind -> string -> 'a -> unit
 

--- a/driver/pparse.mli
+++ b/driver/pparse.mli
@@ -31,11 +31,15 @@ type 'a ast_kind =
 val clear_ppx : unit -> unit
 (** Forget about all installed rewriters: in-process and external ones *)
 
-val clear_in_process_ppx: unit -> unit
+val clear_in_process_ppxs: unit -> unit
 (** Forget about all installed in-process rewriters *)
 
+val disable_in_process_ppx: Longident.t -> unit
+(** [diable_in_process_ppx lid] forgets in-process ppx installed using
+    specified `lid` *)
+
 val add_external_ppx : path:string -> unit
-val add_in_process_ppx : Ast_mapper.mapper -> unit
+val add_in_process_ppx : Longident.t -> Ast_mapper.mapper -> unit
 
 val read_ast : 'a ast_kind -> string -> 'a
 val write_ast : 'a ast_kind -> string -> 'a -> unit

--- a/driver/pparse.mli
+++ b/driver/pparse.mli
@@ -34,8 +34,8 @@ val clear_ppx : unit -> unit
 val clear_in_process_ppxs: unit -> unit
 (** Forget about all installed in-process rewriters *)
 
-val disable_in_process_ppx: Longident.t -> unit
-(** [diable_in_process_ppx lid] forgets in-process ppx installed using
+val remove_in_process_ppx: Longident.t -> unit
+(** [remove_in_process_ppx lid] forgets in-process ppx installed using
     specified `lid` *)
 
 val add_external_ppx : path:string -> unit

--- a/driver/pparse.mli
+++ b/driver/pparse.mli
@@ -29,6 +29,11 @@ type 'a ast_kind =
 | Signature : Parsetree.signature ast_kind
 
 val clear_ppx : unit -> unit
+(** Forget about all installed rewriters: in-process and external ones *)
+
+val clear_in_process_ppx: unit -> unit
+(** Forget about all installed in-process rewriters *)
+
 val add_external_ppx : path:string -> unit
 val add_in_process_ppx : Ast_mapper.mapper -> unit
 

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -668,6 +668,7 @@ let tool_name_ref = ref "_none_"
 
 let tool_name () = !tool_name_ref
 
+let set_tool_name name = tool_name_ref := name
 
 module PpxContext = struct
   open Longident

--- a/parsing/ast_mapper.mli
+++ b/parsing/ast_mapper.mli
@@ -117,6 +117,8 @@ val tool_name: unit -> string
     [Config.load_path], [Clflags.open_modules], [Clflags.for_package],
     [Clflags.debug]. *)
 
+val set_tool_name: string -> unit
+(** Sets name of tool which is going to apply PPX preprocessor *)
 
 val apply: source:string -> target:string -> mapper -> unit
 (** Apply a mapper (parametrized by the unit name) to a dumped

--- a/testsuite/tests/tool-toplevel/in_process_ppx.ml
+++ b/testsuite/tests/tool-toplevel/in_process_ppx.ml
@@ -1,0 +1,59 @@
+#ppxs_clear;;
+#dump_parsetree false;;
+#dump_source false;;
+#directory "../../../utils";;
+#load "misc.cmo";;
+#load "terminfo.cmo";;
+#load "warnings.cmo";;
+#load "config.cmo";;
+#load "identifiable.cmo";;
+#load "numbers.cmo";;
+#load "arg_helper.cmo";;
+#load "clflags.cmo";;
+#directory "../../..//parsing";;
+#load "location.cmo";;
+#load "docstrings.cmo";;
+#load "ast_helper.cmo";;
+#load "ast_mapper.cmo";;
+#load "longident.cmo";;
+#load "pprintast.cmo";;
+(* #directory "compilerlibs";; *)
+(* #load "ocamlcommon.cma";; *)
+(* #directory "../parsing";; *)
+(* #load "longident.cmo";; *)
+(* #load "ast_mapper.cmo";; *)
+
+
+let mapper1 =
+  let open Ast_mapper in
+  let open Parsetree in
+
+  { default_mapper
+    with structure = fun mapper item ->
+      print_endline "got a structure";
+      default_mapper.structure mapper item
+    }
+;;
+
+let mapper2 =
+  let open Ast_mapper in
+  let open Parsetree in
+
+  { default_mapper with
+     expr = fun mapper e ->
+       begin
+         print_endline "got an expr";
+         Pprintast.expression Format.std_formatter e;
+         Format.print_flush ();
+         print_endline "";
+         match e with
+         | {pexp_desc=Pexp_constant (Pconst_char 'a');_} ->
+             {e with pexp_desc=Pexp_constant (Pconst_char 'A')}
+         | e -> default_mapper.expr mapper e
+       end
+    }
+;;
+
+#plugin_ppx mapper1;;
+#plugin_ppx mapper2;;
+print_char 'a';;

--- a/testsuite/tests/tool-toplevel/in_process_ppx.ml
+++ b/testsuite/tests/tool-toplevel/in_process_ppx.ml
@@ -10,18 +10,13 @@
 #load "numbers.cmo";;
 #load "arg_helper.cmo";;
 #load "clflags.cmo";;
-#directory "../../..//parsing";;
+#directory "../../../parsing";;
 #load "location.cmo";;
 #load "docstrings.cmo";;
 #load "ast_helper.cmo";;
 #load "ast_mapper.cmo";;
 #load "longident.cmo";;
 #load "pprintast.cmo";;
-(* #directory "compilerlibs";; *)
-(* #load "ocamlcommon.cma";; *)
-(* #directory "../parsing";; *)
-(* #load "longident.cmo";; *)
-(* #load "ast_mapper.cmo";; *)
 
 
 let mapper1 =
@@ -57,3 +52,4 @@ let mapper2 =
 #plugin_ppx mapper1;;
 #plugin_ppx mapper2;;
 print_char 'a';;
+#plugin_ppx print_endline;;

--- a/testsuite/tests/tool-toplevel/in_process_ppx.ml
+++ b/testsuite/tests/tool-toplevel/in_process_ppx.ml
@@ -1,4 +1,4 @@
-#ppxs_clear;;
+#clear_in_process_ppxs;;
 #dump_parsetree false;;
 #dump_source false;;
 #directory "../../../utils";;
@@ -49,7 +49,9 @@ let mapper2 =
     }
 ;;
 
-#plugin_ppx mapper1;;
-#plugin_ppx mapper2;;
+#in_process_ppx mapper1;;
+#in_process_ppx mapper2;;
 print_char 'a';;
-#plugin_ppx print_endline;;
+#in_process_ppx print_endline;;
+#remove_in_process_ppx mapper1;;
+#remove_in_process_ppx mapper2;;

--- a/testsuite/tests/tool-toplevel/in_process_ppx.ml.reference
+++ b/testsuite/tests/tool-toplevel/in_process_ppx.ml.reference
@@ -1,0 +1,42 @@
+
+# # # # # # # # # # # # # # # # # # # #                                 val mapper1 : Ast_mapper.mapper =
+  {Ast_mapper.attribute = <fun>; attributes = <fun>; case = <fun>;
+   cases = <fun>; class_declaration = <fun>; class_description = <fun>;
+   class_expr = <fun>; class_field = <fun>; class_signature = <fun>;
+   class_structure = <fun>; class_type = <fun>;
+   class_type_declaration = <fun>; class_type_field = <fun>;
+   constructor_declaration = <fun>; expr = <fun>; extension = <fun>;
+   extension_constructor = <fun>; include_declaration = <fun>;
+   include_description = <fun>; label_declaration = <fun>; location = <fun>;
+   module_binding = <fun>; module_declaration = <fun>; module_expr = <fun>;
+   module_type = <fun>; module_type_declaration = <fun>;
+   open_description = <fun>; pat = <fun>; payload = <fun>; signature = <fun>;
+   signature_item = <fun>; structure = <fun>; structure_item = <fun>;
+   typ = <fun>; type_declaration = <fun>; type_extension = <fun>;
+   type_kind = <fun>; value_binding = <fun>; value_description = <fun>;
+   with_constraint = <fun>}
+#                                     val mapper2 : Ast_mapper.mapper =
+  {Ast_mapper.attribute = <fun>; attributes = <fun>; case = <fun>;
+   cases = <fun>; class_declaration = <fun>; class_description = <fun>;
+   class_expr = <fun>; class_field = <fun>; class_signature = <fun>;
+   class_structure = <fun>; class_type = <fun>;
+   class_type_declaration = <fun>; class_type_field = <fun>;
+   constructor_declaration = <fun>; expr = <fun>; extension = <fun>;
+   extension_constructor = <fun>; include_declaration = <fun>;
+   include_description = <fun>; label_declaration = <fun>; location = <fun>;
+   module_binding = <fun>; module_declaration = <fun>; module_expr = <fun>;
+   module_type = <fun>; module_type_declaration = <fun>;
+   open_description = <fun>; pat = <fun>; payload = <fun>; signature = <fun>;
+   signature_item = <fun>; structure = <fun>; structure_item = <fun>;
+   typ = <fun>; type_declaration = <fun>; type_extension = <fun>;
+   type_kind = <fun>; value_binding = <fun>; value_description = <fun>;
+   with_constraint = <fun>}
+#   # # got a structure
+got an expr
+print_char 'a'
+got an expr
+'a'
+got an expr
+print_char
+A- : unit = ()
+# 

--- a/testsuite/tests/tool-toplevel/in_process_ppx.ml.reference
+++ b/testsuite/tests/tool-toplevel/in_process_ppx.ml.reference
@@ -40,4 +40,4 @@ got an expr
 print_char
 A- : unit = ()
 # Type of the value should be 'Ast_mapper.mapper'. Nothing added.
-# 
+# # # 

--- a/testsuite/tests/tool-toplevel/in_process_ppx.ml.reference
+++ b/testsuite/tests/tool-toplevel/in_process_ppx.ml.reference
@@ -1,5 +1,5 @@
 
-# # # # # # # # # # # # # # # # # # # #                                 val mapper1 : Ast_mapper.mapper =
+# # # # # # # # # # # # # # # # # # # #                       val mapper1 : Ast_mapper.mapper =
   {Ast_mapper.attribute = <fun>; attributes = <fun>; case = <fun>;
    cases = <fun>; class_declaration = <fun>; class_description = <fun>;
    class_expr = <fun>; class_field = <fun>; class_signature = <fun>;
@@ -39,4 +39,5 @@ got an expr
 got an expr
 print_char
 A- : unit = ()
+# Type of the value should be 'Ast_mapper.mapper'. Nothing added.
 # 

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -711,6 +711,27 @@ let _ = add_directive "print_length"
 
 (* Set various compiler flags *)
 
+let _ = add_directive "dump_parsetree"
+    (Directive_bool(fun b -> Clflags.dump_parsetree := b))
+    {
+      section = section_options;
+      doc = "Choose whether to dump parsed tree.";
+    }
+
+let _ = add_directive "dump_typedtree"
+    (Directive_bool(fun b -> Clflags.dump_typedtree := b))
+    {
+      section = section_options;
+      doc = "Choose whether to dump typed tree.";
+    }
+
+let _ = add_directive "dump_source"
+    (Directive_bool(fun b -> Clflags.dump_source := b))
+    {
+      section = section_options;
+      doc = "Choose whether to dump source after preprocessing.";
+    }
+
 let _ = add_directive "labels"
     (Directive_bool(fun b -> Clflags.classic := not b))
     {

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -416,7 +416,7 @@ let install_ppx_mapper ppf (lid: Longident.t) =
     Ctype.end_def();
 
     let mapper = eval_path !toplevel_env path in
-    Pparse.add_in_process_ppx (Obj.obj mapper)
+    Pparse.add_in_process_ppx lid (Obj.obj mapper)
   with
   | Ctype.Unify _ ->
       fprintf ppf "Type of the value should be 'Ast_mapper.mapper'. Nothing added.\n%!"
@@ -430,24 +430,23 @@ let _ = add_directive "ppx"
           syntax tree through the preprocessor command.";
     }
 
-let _ = add_directive "plugin_ppx"
+let _ = add_directive "in_process_ppx"
     (Directive_ident(install_ppx_mapper std_out))
     {
       section = section_options;
       doc = "After parsing, pipe the abstract \
-          syntax tree to specified PPX mappers.";
+          syntax tree to specified PPX mapper.";
     }
 
-let _ = add_directive "ppxs_clear"
-    (Directive_none Pparse.clear_ppx)
+let _ = add_directive "remove_in_process_ppx"
+    (Directive_ident Pparse.disable_in_process_ppx)
     {
       section = section_options;
-      doc = "Forget all added PPX preprocessor \
-             (external and in-process)";
+      doc = "Forget specified in-process PPX preprocessor";
     }
 
-let _ = add_directive "remove_in_process_ppxs"
-    (Directive_none Pparse.clear_in_process_ppx)
+let _ = add_directive "clear_in_process_ppxs"
+    (Directive_none Pparse.clear_in_process_ppxs)
     {
       section = section_options;
       doc = "Forget all added in process PPX preprocessors";

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -439,7 +439,7 @@ let _ = add_directive "in_process_ppx"
     }
 
 let _ = add_directive "remove_in_process_ppx"
-    (Directive_ident Pparse.disable_in_process_ppx)
+    (Directive_ident Pparse.remove_in_process_ppx)
     {
       section = section_options;
       doc = "Forget specified in-process PPX preprocessor";

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -446,6 +446,13 @@ let _ = add_directive "ppxs_clear"
              (external and in-process)";
     }
 
+let _ = add_directive "remove_in_process_ppxs"
+    (Directive_none Pparse.clear_in_process_ppx)
+    {
+      section = section_options;
+      doc = "Forget all added in process PPX preprocessors";
+    }
+
 (* The trace *)
 
 external current_environment: unit -> Obj.t = "caml_get_current_environment"


### PR DESCRIPTION
I was building a custom js_of_ocaml toplevel recently and I needed to embed PPX syntax extension. By default it uses system call to invoke preprocessor which doesn't suite js_of_ocaml. The patch allows toplevel values of type `Ast_mapper.mapper` to be used while preprocessing the source.

P.S. Happy New Year :)
