### PR TITLE
configure: add an explicit -no-native-compiler switch

### DIFF
--- a/configure
+++ b/configure
@@ -48,6 +48,7 @@ with_ocamldoc=ocamldoc
 with_ocamlbuild=ocamlbuild
 with_frame_pointers=false
 no_naked_pointers=false
+native_compiler=true
 TOOLPREF=""
 with_cfi=true
 
@@ -159,6 +160,8 @@ while : ; do
         no_naked_pointers=true;;
     -no-cfi|--no-cfi)
         with_cfi=false;;
+    -no-native-compiler)
+        native_compiler=false;;
     *) if echo "$1" | grep -q -e '^--\?[a-zA-Z0-9-]\+='; then
          err "configure expects arguments of the form '-prefix /foo/bar'," \
              "not '-prefix=/foo/bar' (note the '=')."
@@ -860,6 +863,12 @@ esac
 
 case "$arch64,$arch,$model" in
   true,sparc,*|true,power,ppc|false,amd64,*)
+      arch=none; model=default; system=unknown;;
+esac
+
+case "$native_compiler" in
+    true) ;;
+    false)
       arch=none; model=default; system=unknown;;
 esac
 


### PR DESCRIPTION
I needed this switch to test builds of ocamlbuild in absence of a native compiler. I think it could be useful to others to test no-native environments.

This is orthogonal to the PR change, but downstream users may want to know how to test whether the native compiler is available from a script/Makefile/etc. I found three options:

```
$ ocamlc -config | grep architecture
architecture: none
$ cat $(ocamlc -where)/Makefile.config | grep "^ARCH"
ARCH=none
$ opam config var ocaml-native
false
```
