### PR TITLE
Provide the option to bootstrap FlexDLL with OCaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -294,3 +294,6 @@
 /yacc/ocamlyacc
 /yacc/version.h
 /yacc/.gdb_history
+
+# Bootstrapped FlexDLL
+flexdll/

--- a/.gitignore
+++ b/.gitignore
@@ -294,6 +294,3 @@
 /yacc/ocamlyacc
 /yacc/version.h
 /yacc/.gdb_history
-
-# Bootstrapped FlexDLL
-flexdll/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "flexdll"]
+	path = flexdll
+	url = https://github.com/alainfrisch/flexdll.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@
 
 sudo: false
 language: c
+git:
+  submodules: false
 script: bash -ex .travis-ci.sh
 matrix:
   include:

--- a/Changes
+++ b/Changes
@@ -138,6 +138,8 @@ Compilers:
   (Leo White)
 - PR#6920: fix debug informations around uses of %apply or %revapply
   (Jérémie Dimino)
+- GPR#388: OCAML_FLEXLINK environment variable allows overriding flexlink
+  command (David Allsopp)
 
 Runtime system:
 - PR#3612: allow allocating custom block with finalizers in the minor heap

--- a/Changes
+++ b/Changes
@@ -522,6 +522,10 @@ Features wishes:
 - GPR#383: configure: define _ALL_SOURCE for build on AIX7.1
   (tkob)
 
+Build system:
+- GPR#388: FlexDLL added as a Git submodule and bootstrappable with the compiler
+  (David Allsopp)
+
 OCaml 4.02.3 (27 Jul 2015):
 ---------------------------
 

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -28,7 +28,7 @@ flexdll/Makefile:
 	@echo
 	@false
 
-# Bootstrapping FlexDLL - leaves a bytecode flexlink in flexdll/
+# Bootstrapping FlexDLL - leaves a bytecode image of flexlink in flexdll/
 flexdll: flexdll/Makefile
 	cd byterun ; $(MAKEREC) BOOTSTRAPPING_FLEXLINK=yes ocamlrun$(EXE)
 	cp byterun/ocamlrun.exe boot/ocamlrun.exe
@@ -38,11 +38,28 @@ flexdll: flexdll/Makefile
 # The executable header will not have been available - flexlink.exe is just the bytecode image
 	cd flexdll ; mv flexlink.exe flexlink
 	cd stdlib ; $(MAKEREC) FLEXLINK_CMD="../boot/ocamlrun ../flexdll/flexlink" camlheader
+
+install-flexdll:
+	mkdir -p $(INSTALL_BINDIR)
 # Assemble flexlink.exe
 	cat stdlib/camlheader flexdll/flexlink > flexdll/flexlink.exe ; chmod +x flexdll/flexlink.exe ; rm flexdll/flexlink
+# The $(if ...) installs the correct .manifest file for MSVC and MSVC64
+# (GNU make doesn't have ifeq as a function, hence slightly convoluted use of filter-out)
+	cp flexdll/flexlink.exe flexdll/flexdll_*.$(O) flexdll/flexdll.h $(if $(filter-out mingw,$(TOOLCHAIN)),flexdll/default$(filter-out _i386,_$(ARCH)).manifest) $(INSTALL_BINDIR)/
+# This is the flexlink-free version of ocamlrun, it won't be used during
+# compilation and will be overwritten when the finished OCaml is installed
+	cp boot/ocamlrun.exe $(INSTALL_BINDIR)/
 # Tidy-up the OCaml build tree ready for the next stage
 	cd byterun ; $(MAKEREC) clean
 	$(MAKEREC) partialclean
+
+# If Makefile.nt was used to bootstrap FlexDLL, then opt.opt will build a native
+# flexlink which install will put in $(INSTALL_BINDIR), overwriting the bytecode
+# version placed there by install-flexdll
+FLEXLINK_OPT=$(if $(or $(filter flexdll,$(MAKECMDGOALS)),$(wildcard flexdll/flexlink.exe)),flexlink_opt)
+
+flexlink_opt:
+	cd flexdll ; rm flexlink.exe ; $(MAKECMD) MSVC_DETECT=0 TOOLCHAIN=$(TOOLCHAIN) TOOLPREF=$(TOOLPREF) OCAMLOPT="../ocamlopt.opt -I ../stdlib" flexlink.exe
 
 # Recompile the system using the bootstrap compiler
 all: runtime ocamlc ocamllex ocamlyacc ocamltools library ocaml \
@@ -153,7 +170,7 @@ opt:
 
 # Native-code versions of the tools
 opt.opt: core opt-core ocamlc.opt all ocamlopt.opt ocamllex.opt \
-         ocamltoolsopt ocamltoolsopt.opt otherlibrariesopt $(OCAMLBUILDNATIVE) $(OCAMLDOC_OPT)
+         ocamltoolsopt ocamltoolsopt.opt otherlibrariesopt $(OCAMLBUILDNATIVE) $(OCAMLDOC_OPT) $(FLEXLINK_OPT)
 
 # Complete build using fast compilers
 world.opt: coldstart opt.opt
@@ -224,6 +241,7 @@ installopt:
 	done
 	if test -f ocamlopt.opt ; then $(MAKEREC) installoptopt; fi
 	cd tools; $(MAKEREC) installopt
+	if test -f ocamlopt.opt -a -f flexdll/flexlink.exe ; then cp flexdll/flexlink.exe $(INSTALL_BINDIR)/ ; fi
 
 installoptopt:
 	cp ocamlc.opt $(INSTALL_BINDIR)/ocamlc.opt$(EXE)
@@ -698,6 +716,6 @@ distclean:
 .PHONY: ocamltoolsopt.opt ocamlyacc opt-core opt opt.opt otherlibraries
 .PHONY: otherlibrariesopt promote promote-cross
 .PHONY: restore runtime runtimeopt makeruntimeopt world world.opt
-.PHONY: flexdll
+.PHONY: flexdll flexlink_opt
 
 include .depend

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -18,11 +18,22 @@ include Makefile.shared
 defaultentry:
 	@echo "Please refer to the installation instructions in file README.win32.adoc."
 
-# FlexDLL sources missing error message
-flexdll/Makefile:
-	@echo In order to bootstrap FlexDLL, you need to place the sources in flexdll.
+# FlexDLL sources missing error messages
+# Different git mechanism displayed depending on whether this source tree came
+# from a git clone or a source tarball.
+
+# Displayed in all cases
+flexdll-common-err:
+	@echo In order to bootstrap FlexDLL, you need to place the sources in flexdll
 	@echo This can either be done by downloading a source tarball from
 	@echo \  http://alain.frisch.fr/flexdll.html
+
+flexdll/Makefile: $(if $(wildcard flexdll/Makefile),,$(if $(wildcard .git),flexdll-common-err,flexdll-repo))
+	@echo or by checking out the flexdll submodule with
+	@echo \  git submodule update --init
+	@false
+
+flexdll-repo: flexdll-common-err
 	@echo or by cloning the git repository
 	@echo \  git clone https://github.com/alainfrisch/flexdll.git
 	@echo
@@ -716,6 +727,6 @@ distclean:
 .PHONY: ocamltoolsopt.opt ocamlyacc opt-core opt opt.opt otherlibraries
 .PHONY: otherlibrariesopt promote promote-cross
 .PHONY: restore runtime runtimeopt makeruntimeopt world world.opt
-.PHONY: flexdll flexlink_opt
+.PHONY: flexdll flexlink_opt flexdll-common-err flexdll-repo
 
 include .depend

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -18,6 +18,10 @@ include Makefile.shared
 defaultentry:
 	@echo "Please refer to the installation instructions in file README.win32.adoc."
 
+FLEXDLL_SUBMODULE_PRESENT:=$(wildcard flexdll/Makefile)
+BOOT_FLEXLINK_CMD=$(if $(FLEXDLL_SUBMODULE_PRESENT),FLEXLINK_CMD="../boot/ocamlrun ../flexdll/flexlink.exe")
+CAMLOPT:=$(if $(FLEXDLL_SUBMODULE_PRESENT),OCAML_FLEXLINK="boot/ocamlrun flexdll/flexlink.exe") $(CAMLOPT)
+
 # FlexDLL sources missing error messages
 # Different git mechanism displayed depending on whether this source tree came
 # from a git clone or a source tarball.
@@ -39,38 +43,22 @@ flexdll-repo: flexdll-common-err
 	@echo
 	@false
 
-# Bootstrapping FlexDLL - leaves a bytecode image of flexlink in flexdll/
+# Bootstrapping FlexDLL - leaves a bytecode image of flexlink.exe in flexdll/
 flexdll: flexdll/Makefile
 	cd byterun ; $(MAKEREC) BOOTSTRAPPING_FLEXLINK=yes ocamlrun$(EXE)
 	cp byterun/ocamlrun.exe boot/ocamlrun.exe
 	cd stdlib ; $(MAKEREC) COMPILER=../boot/ocamlc stdlib.cma std_exit.cmo
 	cd stdlib ; cp stdlib.cma std_exit.cmo *.cmi ../boot
 	cd flexdll ; $(MAKECMD) MSVC_DETECT=0 TOOLCHAIN=$(TOOLCHAIN) TOOLPREF=$(TOOLPREF) CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false OCAMLOPT="../boot/ocamlrun ../boot/ocamlc -I ../boot" flexlink.exe support
-# The executable header will not have been available - flexlink.exe is just the bytecode image
-	cd flexdll ; mv flexlink.exe flexlink
-	cd stdlib ; $(MAKEREC) FLEXLINK_CMD="../boot/ocamlrun ../flexdll/flexlink" camlheader
-
-install-flexdll:
-	mkdir -p $(INSTALL_BINDIR)
-# Assemble flexlink.exe
-	cat stdlib/camlheader flexdll/flexlink > flexdll/flexlink.exe ; chmod +x flexdll/flexlink.exe ; rm flexdll/flexlink
-# The $(if ...) installs the correct .manifest file for MSVC and MSVC64
-# (GNU make doesn't have ifeq as a function, hence slightly convoluted use of filter-out)
-	cp flexdll/flexlink.exe flexdll/flexdll_*.$(O) flexdll/flexdll.h $(if $(filter-out mingw,$(TOOLCHAIN)),flexdll/default$(filter-out _i386,_$(ARCH)).manifest) $(INSTALL_BINDIR)/
-# This is the flexlink-free version of ocamlrun, it won't be used during
-# compilation and will be overwritten when the finished OCaml is installed
-	cp boot/ocamlrun.exe $(INSTALL_BINDIR)/
-# Tidy-up the OCaml build tree ready for the next stage
 	cd byterun ; $(MAKEREC) clean
 	$(MAKEREC) partialclean
 
-# If Makefile.nt was used to bootstrap FlexDLL, then opt.opt will build a native
-# flexlink which install will put in $(INSTALL_BINDIR), overwriting the bytecode
-# version placed there by install-flexdll
-FLEXLINK_OPT=$(if $(or $(filter flexdll,$(MAKECMDGOALS)),$(wildcard flexdll/flexlink.exe)),flexlink_opt)
-
-flexlink_opt:
-	cd flexdll ; rm flexlink.exe ; $(MAKECMD) MSVC_DETECT=0 TOOLCHAIN=$(TOOLCHAIN) TOOLPREF=$(TOOLPREF) OCAMLOPT="../ocamlopt.opt -I ../stdlib" flexlink.exe
+flexlink.opt:
+	cd flexdll ; \
+	mv flexlink.exe flexlink ; \
+	$(MAKECMD) OCAML_FLEXLINK="../boot/ocamlrun ./flexlink" MSVC_DETECT=0 TOOLCHAIN=$(TOOLCHAIN) TOOLPREF=$(TOOLPREF) OCAMLOPT="../ocamlopt.opt -I ../stdlib" flexlink.exe ; \
+	mv flexlink.exe flexlink.opt ; \
+	mv flexlink flexlink.exe
 
 # Recompile the system using the bootstrap compiler
 all: runtime ocamlc ocamllex ocamlyacc ocamltools library ocaml \
@@ -114,11 +102,11 @@ LIBFILES=stdlib.cma std_exit.cmo *.cmi camlheader
 
 # Start up the system from the distribution compiler
 coldstart:
-	cd byterun ; $(MAKEREC) all
+	cd byterun ; $(MAKEREC) $(BOOT_FLEXLINK_CMD) all
 	cp byterun/ocamlrun.exe boot/ocamlrun.exe
-	cd yacc ; $(MAKEREC) all
+	cd yacc ; $(MAKEREC) $(BOOT_FLEXLINK_CMD) all
 	cp yacc/ocamlyacc.exe boot/ocamlyacc.exe
-	cd stdlib ; $(MAKEREC) COMPILER=../boot/ocamlc all
+	cd stdlib ; $(MAKEREC) $(BOOT_FLEXLINK_CMD) COMPILER=../boot/ocamlc all
 	cd stdlib ; cp $(LIBFILES) ../boot
 
 # Build the core system: the minimum needed to make depend and bootstrap
@@ -180,8 +168,10 @@ opt:
 	$(MAKEREC) otherlibrariesopt ocamltoolsopt
 
 # Native-code versions of the tools
+# If the submodule is initialised, then opt.opt will build a native flexlink
 opt.opt: core opt-core ocamlc.opt all ocamlopt.opt ocamllex.opt \
-         ocamltoolsopt ocamltoolsopt.opt otherlibrariesopt $(OCAMLBUILDNATIVE) $(OCAMLDOC_OPT) $(FLEXLINK_OPT)
+         ocamltoolsopt ocamltoolsopt.opt otherlibrariesopt $(OCAMLBUILDNATIVE) \
+         $(OCAMLDOC_OPT) $(if $(wildcard flexdll/Makefile),flexlink.opt)
 
 # Complete build using fast compilers
 world.opt: coldstart opt.opt
@@ -231,11 +221,19 @@ installbyt:
 	   else :; fi
 	if test -n "$(WITH_OCAMLBUILD)"; then (cd ocamlbuild; $(MAKE) install); \
 	   else :; fi
+	if test -n "$(FLEXDLL_SUBMODULE_PRESENT)"; then $(MAKEREC) install-flexdll; \
+	   else :; fi
 	cp config/Makefile $(INSTALL_LIBDIR)/Makefile.config
 	cp README.adoc $(INSTALL_DISTRIB)/Readme.general.txt
 	cp README.win32.adoc $(INSTALL_DISTRIB)/Readme.windows.txt
 	cp LICENSE $(INSTALL_DISTRIB)/License.txt
 	cp Changes $(INSTALL_DISTRIB)/Changes.txt
+
+install-flexdll:
+# The $(if ...) installs the correct .manifest file for MSVC and MSVC64
+# (GNU make doesn't have ifeq as a function, hence slightly convoluted use of filter-out)
+	cp flexdll/flexlink.exe $(if $(filter-out mingw,$(TOOLCHAIN)),flexdll/default$(filter-out _i386,_$(ARCH)).manifest) $(INSTALL_BINDIR)/
+	cp flexdll/flexdll_*.$(O) $(INSTALL_LIBDIR)
 
 # Installation of the native-code compiler
 installopt:
@@ -252,7 +250,7 @@ installopt:
 	done
 	if test -f ocamlopt.opt ; then $(MAKEREC) installoptopt; fi
 	cd tools; $(MAKEREC) installopt
-	if test -f ocamlopt.opt -a -f flexdll/flexlink.exe ; then cp flexdll/flexlink.exe $(INSTALL_BINDIR)/ ; fi
+	if test -f ocamlopt.opt -a -f flexdll/flexlink.opt ; then cp -f flexdll/flexlink.opt $(INSTALL_BINDIR)/flexlink.exe ; fi
 
 installoptopt:
 	cp ocamlc.opt $(INSTALL_BINDIR)/ocamlc.opt$(EXE)
@@ -546,7 +544,7 @@ partialclean::
 runtime: makeruntime stdlib/libcamlrun.$(A)
 
 makeruntime:
-	cd byterun ; $(MAKEREC) all
+	cd byterun ; $(MAKEREC) $(BOOT_FLEXLINK_CMD) all
 stdlib/libcamlrun.$(A): byterun/libcamlrun.$(A)
 	cp byterun/libcamlrun.$(A) stdlib/libcamlrun.$(A)
 clean::
@@ -572,11 +570,11 @@ alldepend::
 # The library
 
 library:
-	cd stdlib ; $(MAKEREC) all
+	cd stdlib ; $(MAKEREC) $(BOOT_FLEXLINK_CMD) all
 library-cross:
-	cd stdlib ; $(MAKEREC) CAMLRUN=../byterun/ocamlrun all
+	cd stdlib ; $(MAKEREC) $(BOOT_FLEXLINK_CMD) CAMLRUN=../byterun/ocamlrun all
 libraryopt:
-	cd stdlib ; $(MAKEREC) allopt
+	cd stdlib ; $(MAKEREC) $(BOOT_FLEXLINK_CMD) allopt
 partialclean::
 	cd stdlib ; $(MAKEREC) clean
 alldepend::
@@ -594,7 +592,7 @@ alldepend::
 	cd lex ; $(MAKEREC) depend
 
 ocamlyacc:
-	cd yacc ; $(MAKEREC) all
+	cd yacc ; $(MAKEREC) $(BOOT_FLEXLINK_CMD) all
 clean::
 	cd yacc ; $(MAKEREC) clean
 
@@ -665,7 +663,7 @@ ocamlbuild.byte: ocamlc otherlibraries
 	cd ocamlbuild && $(MAKE) all
 
 ocamlbuild.native: ocamlopt otherlibrariesopt
-	cd ocamlbuild && $(MAKE) allopt
+	cd ocamlbuild && $(if $(FLEXDLL_SUBMODULE_PRESENT),OCAML_FLEXLINK="../boot/ocamlrun ../flexdll/flexlink.exe") $(MAKE) allopt
 
 partialclean::
 	cd ocamlbuild && $(MAKE) clean
@@ -728,6 +726,6 @@ distclean:
 .PHONY: ocamltoolsopt.opt ocamlyacc opt-core opt opt.opt otherlibraries
 .PHONY: otherlibrariesopt promote promote-cross
 .PHONY: restore runtime runtimeopt makeruntimeopt world world.opt
-.PHONY: flexdll flexlink_opt flexdll-common-err flexdll-repo
+.PHONY: flexdll flexlink.opt flexdll-common-err flexdll-repo
 
 include .depend

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -369,6 +369,7 @@ utils/config.ml: utils/config.mlp config/Makefile
 	    -e 's|%%HOST%%|$(HOST)|' \
 	    -e 's|%%TARGET%%|$(TARGET)|' \
 	    -e 's|%%FLAMBDA%%|$(FLAMBDA)|' \
+	    -e 's|%%FLEXLINK_FLAGS%%|$(FLEXLINK_FLAGS)|' \
 	    utils/config.mlp > utils/config.ml
 
 partialclean::

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -18,6 +18,32 @@ include Makefile.shared
 defaultentry:
 	@echo "Please refer to the installation instructions in file README.win32.adoc."
 
+# FlexDLL sources missing error message
+flexdll/Makefile:
+	@echo In order to bootstrap FlexDLL, you need to place the sources in flexdll.
+	@echo This can either be done by downloading a source tarball from
+	@echo \  http://alain.frisch.fr/flexdll.html
+	@echo or by cloning the git repository
+	@echo \  git clone https://github.com/alainfrisch/flexdll.git
+	@echo
+	@false
+
+# Bootstrapping FlexDLL - leaves a bytecode flexlink in flexdll/
+flexdll: flexdll/Makefile
+	cd byterun ; $(MAKEREC) BOOTSTRAPPING_FLEXLINK=yes ocamlrun$(EXE)
+	cp byterun/ocamlrun.exe boot/ocamlrun.exe
+	cd stdlib ; $(MAKEREC) COMPILER=../boot/ocamlc stdlib.cma std_exit.cmo
+	cd stdlib ; cp stdlib.cma std_exit.cmo *.cmi ../boot
+	cd flexdll ; $(MAKECMD) MSVC_DETECT=0 TOOLCHAIN=$(TOOLCHAIN) TOOLPREF=$(TOOLPREF) CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false OCAMLOPT="../boot/ocamlrun ../boot/ocamlc -I ../boot" flexlink.exe support
+# The executable header will not have been available - flexlink.exe is just the bytecode image
+	cd flexdll ; mv flexlink.exe flexlink
+	cd stdlib ; $(MAKEREC) FLEXLINK_CMD="../boot/ocamlrun ../flexdll/flexlink" camlheader
+# Assemble flexlink.exe
+	cat stdlib/camlheader flexdll/flexlink > flexdll/flexlink.exe ; chmod +x flexdll/flexlink.exe ; rm flexdll/flexlink
+# Tidy-up the OCaml build tree ready for the next stage
+	cd byterun ; $(MAKEREC) clean
+	$(MAKEREC) partialclean
+
 # Recompile the system using the bootstrap compiler
 all: runtime ocamlc ocamllex ocamlyacc ocamltools library ocaml \
   otherlibraries $(OCAMLBUILDBYTE) $(WITH_DEBUGGER) \
@@ -672,5 +698,6 @@ distclean:
 .PHONY: ocamltoolsopt.opt ocamlyacc opt-core opt opt.opt otherlibraries
 .PHONY: otherlibrariesopt promote promote-cross
 .PHONY: restore runtime runtimeopt makeruntimeopt world world.opt
+.PHONY: flexdll
 
 include .depend

--- a/byterun/Makefile.nt
+++ b/byterun/Makefile.nt
@@ -15,13 +15,20 @@ include Makefile.common
 
 CFLAGS=-DOCAML_STDLIB_DIR='"$(LIBDIR)"' $(IFLEXDIR)
 
+ifdef BOOTSTRAPPING_FLEXLINK
+MAKE_OCAMLRUN=$(MKEXE_BOOT)
+CFLAGS:=-DBOOTSTRAPPING_FLEXLINK $(CFLAGS)
+else
+MAKE_OCAMLRUN=$(MKEXE) -o $(1) $(2)
+endif
+
 DBGO=d.$(O)
 OBJS=$(COMMONOBJS:.o=.$(O)) win32.$(O) main.$(O)
 DOBJS=$(OBJS:.$(O)=.$(DBGO)) instrtrace.$(DBGO)
 
 ocamlrun$(EXE): libcamlrun.$(A) prims.$(O)
-	$(MKEXE) -o ocamlrun$(EXE) prims.$(O) $(call SYSLIB,ws2_32) \
-	         $(EXTRALIBS) libcamlrun.$(A)
+	$(call MAKE_OCAMLRUN,ocamlrun$(EXE),prims.$(O) libcamlrun.$(A) \
+	         $(call SYSLIB,ws2_32) $(EXTRALIBS))
 
 ocamlrund$(EXE): libcamlrund.$(A) prims.$(O) main.$(O)
 	$(MKEXE) -o ocamlrund$(EXE) $(BYTECCDBGCOMPOPTS) prims.$(O) \

--- a/byterun/caml/config.h
+++ b/byterun/caml/config.h
@@ -19,6 +19,9 @@
 /* <private> */
 #include "../../config/m.h"
 #include "../../config/s.h"
+#ifdef BOOTSTRAPPING_FLEXLINK
+#undef SUPPORT_DYNAMIC_LINKING
+#endif
 /* </private> */
 
 #ifndef CAML_NAME_SPACE

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -111,13 +111,19 @@ CPP=$(BYTECC) -E
 ### Flexlink
 FLEXLINK_CMD=flexlink
 FLEXDLL_CHAIN=mingw
-FLEXLINK=$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN) -stack 16777216 -link -static-libgcc
+# FLEXLINK_FLAGS must be safe to insert in an OCaml string
+#   (see ocamlmklibconfig.ml in tools/Makefile.nt)
+FLEXLINK_FLAGS=-chain $(FLEXDLL_CHAIN) -stack 16777216 -link -static-libgcc
+FLEXLINK=$(FLEXLINK_CMD) $(FLEXLINK_FLAGS)
 FLEXDIR:=$(shell $(FLEXLINK) -where 2>/dev/null)
 ifeq ($(FLEXDIR),)
 IFLEXDIR=
 else
 IFLEXDIR=-I"$(FLEXDIR)"
 endif
+# MKDLL, MKEXE and MKMAINDLL must ultimately be equivalent to
+#   $(FLEXLINK_CMD) $(FLEXLINK_FLAGS) [-exe|-maindll]
+# or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 MKDLL=$(FLEXLINK)
 MKEXE=$(FLEXLINK) -exe
 MKMAINDLL=$(FLEXLINK) -maindll

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -109,12 +109,21 @@ NATIVECCLIBS=-lws2_32
 CPP=$(BYTECC) -E
 
 ### Flexlink
-FLEXLINK=flexlink -chain mingw -stack 16777216 -link -static-libgcc
-FLEXDIR:=$(shell $(FLEXLINK) -where)
+FLEXLINK_CMD=flexlink
+FLEXDLL_CHAIN=mingw
+FLEXLINK=$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN) -stack 16777216 -link -static-libgcc
+FLEXDIR:=$(shell $(FLEXLINK) -where 2>/dev/null)
+ifeq ($(FLEXDIR),)
+IFLEXDIR=
+else
 IFLEXDIR=-I"$(FLEXDIR)"
+endif
 MKDLL=$(FLEXLINK)
 MKEXE=$(FLEXLINK) -exe
 MKMAINDLL=$(FLEXLINK) -maindll
+
+### Native command to build ocamlrun.exe without flexlink
+MKEXE_BOOT=$(BYTECC) -o $(1) $(2)
 
 ### How to build a static library
 MKLIB=rm -f $(1); $(TOOLPREF)ar rc $(1) $(2); $(RANLIB) $(1)

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -117,7 +117,7 @@ FLEXLINK_FLAGS=-chain $(FLEXDLL_CHAIN) -stack 16777216 -link -static-libgcc
 FLEXLINK=$(FLEXLINK_CMD) $(FLEXLINK_FLAGS)
 FLEXDIR:=$(shell $(FLEXLINK) -where 2>/dev/null)
 ifeq ($(FLEXDIR),)
-IFLEXDIR=
+IFLEXDIR=-I"../flexdll"
 else
 IFLEXDIR=-I"$(FLEXDIR)"
 endif

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -109,12 +109,21 @@ NATIVECCLIBS=-lws2_32
 CPP=$(BYTECC) -E
 
 ### Flexlink
-FLEXLINK=flexlink -chain mingw64 -stack 33554432
-FLEXDIR:=$(shell $(FLEXLINK) -where)
+FLEXLINK_CMD=flexlink
+FLEXDLL_CHAIN=mingw64
+FLEXLINK=$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN) -stack 33554432
+FLEXDIR:=$(shell $(FLEXLINK) -where 2>/dev/null)
+ifeq ($(FLEXDIR),)
+IFLEXDIR=
+else
 IFLEXDIR=-I"$(FLEXDIR)"
+endif
 MKDLL=$(FLEXLINK)
 MKEXE=$(FLEXLINK) -exe
 MKMAINDLL=$(FLEXLINK) -maindll
+
+### Native command to build ocamlrun.exe without flexlink
+MKEXE_BOOT=$(BYTECC) -o $(1) $(2)
 
 ### How to build a static library
 MKLIB=rm -f $(1); $(TOOLPREF)ar rc $(1) $(2); $(RANLIB) $(1)

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -111,13 +111,19 @@ CPP=$(BYTECC) -E
 ### Flexlink
 FLEXLINK_CMD=flexlink
 FLEXDLL_CHAIN=mingw64
-FLEXLINK=$(FLEXLINK_CMD) -chain $(FLEXDLL_CHAIN) -stack 33554432
+# FLEXLINK_FLAGS must be safe to insert in an OCaml string
+#   (see ocamlmklibconfig.ml in tools/Makefile.nt)
+FLEXLINK_FLAGS=-chain $(FLEXDLL_CHAIN) -stack 33554432
+FLEXLINK=$(FLEXLINK_CMD) $(FLEXLINK_FLAGS)
 FLEXDIR:=$(shell $(FLEXLINK) -where 2>/dev/null)
 ifeq ($(FLEXDIR),)
 IFLEXDIR=
 else
 IFLEXDIR=-I"$(FLEXDIR)"
 endif
+# MKDLL, MKEXE and MKMAINDLL must ultimately be equivalent to
+#   $(FLEXLINK_CMD) $(FLEXLINK_FLAGS) [-exe|-maindll]
+# or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 MKDLL=$(FLEXLINK)
 MKEXE=$(FLEXLINK) -exe
 MKMAINDLL=$(FLEXLINK) -maindll

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -117,7 +117,7 @@ FLEXLINK_FLAGS=-chain $(FLEXDLL_CHAIN) -stack 33554432
 FLEXLINK=$(FLEXLINK_CMD) $(FLEXLINK_FLAGS)
 FLEXDIR:=$(shell $(FLEXLINK) -where 2>/dev/null)
 ifeq ($(FLEXDIR),)
-IFLEXDIR=
+IFLEXDIR=-I"../flexdll"
 else
 IFLEXDIR=-I"$(FLEXDIR)"
 endif

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -108,7 +108,7 @@ FLEXLINK_FLAGS=-merge-manifest -stack 16777216
 FLEXLINK=$(FLEXLINK_CMD) $(FLEXLINK_FLAGS)
 FLEXDIR:=$(shell $(FLEXLINK) -where 2>/dev/null)
 ifeq ($(FLEXDIR),)
-IFLEXDIR=
+IFLEXDIR=-I"../flexdll"
 else
 IFLEXDIR=-I"$(FLEXDIR)"
 endif

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -102,13 +102,19 @@ CPP=cl -nologo -EP
 ### Flexlink
 FLEXLINK_CMD=flexlink
 FLEXDLL_CHAIN=msvc
-FLEXLINK=$(FLEXLINK_CMD) -merge-manifest -stack 16777216
+# FLEXLINK_FLAGS must be safe to insert in an OCaml string
+#   (see ocamlmklibconfig.ml in tools/Makefile.nt)
+FLEXLINK_FLAGS=-merge-manifest -stack 16777216
+FLEXLINK=$(FLEXLINK_CMD) $(FLEXLINK_FLAGS)
 FLEXDIR:=$(shell $(FLEXLINK) -where 2>/dev/null)
 ifeq ($(FLEXDIR),)
 IFLEXDIR=
 else
 IFLEXDIR=-I"$(FLEXDIR)"
 endif
+# MKDLL, MKEXE and MKMAINDLL must ultimately be equivalent to
+#   $(FLEXLINK_CMD) $(FLEXLINK_FLAGS) [-exe|-maindll]
+# or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 MKDLL=$(FLEXLINK)
 MKEXE=$(FLEXLINK) -exe
 MKMAINDLL=$(FLEXLINK) -maindll

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -100,12 +100,22 @@ NATIVECCLIBS=advapi32.lib ws2_32.lib
 CPP=cl -nologo -EP
 
 ### Flexlink
-FLEXLINK=flexlink -merge-manifest -stack 16777216
-FLEXDIR:=$(shell $(FLEXLINK) -where)
+FLEXLINK_CMD=flexlink
+FLEXDLL_CHAIN=msvc
+FLEXLINK=$(FLEXLINK_CMD) -merge-manifest -stack 16777216
+FLEXDIR:=$(shell $(FLEXLINK) -where 2>/dev/null)
+ifeq ($(FLEXDIR),)
+IFLEXDIR=
+else
 IFLEXDIR=-I"$(FLEXDIR)"
+endif
 MKDLL=$(FLEXLINK)
 MKEXE=$(FLEXLINK) -exe
 MKMAINDLL=$(FLEXLINK) -maindll
+
+### Native command to build ocamlrun.exe without flexlink
+MERGEMANIFESTEXE=test ! -f $(1).manifest || mt -nologo -outputresource:$(1) -manifest $(1).manifest && rm -f $(1).manifest
+MKEXE_BOOT=$(BYTECC) /Fe$(1) $(2) /link /subsystem:console && ($(MERGEMANIFESTEXE))
 
 ### How to build a static library
 MKLIB=link -lib -nologo -out:$(1) $(2)

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -112,7 +112,7 @@ FLEXLINK_FLAGS=-x64 -merge-manifest -stack 33554432
 FLEXLINK=$(FLEXLINK_CMD) $(FLEXLINK_FLAGS)
 FLEXDIR:=$(shell $(FLEXLINK) -where 2>/dev/null)
 ifeq ($(FLEXDIR),)
-IFLEXDIR=
+IFLEXDIR=-I"../flexdll"
 else
 IFLEXDIR=-I"$(FLEXDIR)"
 endif

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -106,13 +106,19 @@ CPP=cl -nologo -EP
 ### Flexlink
 FLEXLINK_CMD=flexlink
 FLEXDLL_CHAIN=msvc64
-FLEXLINK=$(FLEXLINK_CMD) -x64 -merge-manifest -stack 33554432
+# FLEXLINK_FLAGS must be safe to insert in an OCaml string
+#   (see ocamlmklibconfig.ml in tools/Makefile.nt)
+FLEXLINK_FLAGS=-x64 -merge-manifest -stack 33554432
+FLEXLINK=$(FLEXLINK_CMD) $(FLEXLINK_FLAGS)
 FLEXDIR:=$(shell $(FLEXLINK) -where 2>/dev/null)
 ifeq ($(FLEXDIR),)
 IFLEXDIR=
 else
 IFLEXDIR=-I"$(FLEXDIR)"
 endif
+# MKDLL, MKEXE and MKMAINDLL must ultimately be equivalent to
+#   $(FLEXLINK_CMD) $(FLEXLINK_FLAGS) [-exe|-maindll]
+# or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 MKDLL=$(FLEXLINK)
 MKEXE=$(FLEXLINK) -exe
 MKMAINDLL=$(FLEXLINK) -maindll

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -104,12 +104,22 @@ NATIVECCLIBS=advapi32.lib ws2_32.lib $(EXTRALIBS)
 CPP=cl -nologo -EP
 
 ### Flexlink
-FLEXLINK=flexlink -x64 -merge-manifest -stack 33554432
-FLEXDIR:=$(shell $(FLEXLINK) -where)
+FLEXLINK_CMD=flexlink
+FLEXDLL_CHAIN=msvc64
+FLEXLINK=$(FLEXLINK_CMD) -x64 -merge-manifest -stack 33554432
+FLEXDIR:=$(shell $(FLEXLINK) -where 2>/dev/null)
+ifeq ($(FLEXDIR),)
+IFLEXDIR=
+else
 IFLEXDIR=-I"$(FLEXDIR)"
+endif
 MKDLL=$(FLEXLINK)
 MKEXE=$(FLEXLINK) -exe
 MKMAINDLL=$(FLEXLINK) -maindll
+
+### Native command to build ocamlrun.exe without flexlink
+MERGEMANIFESTEXE=test ! -f $(1).manifest || mt -nologo -outputresource:$(1) -manifest $(1).manifest && rm -f $(1).manifest
+MKEXE_BOOT=$(BYTECC) /Fe$(1) $(2) /link /subsystem:console && ($(MERGEMANIFESTEXE))
 
 ### How to build a static library
 MKLIB=link -lib -nologo -machine:AMD64 /out:$(1) $(2)

--- a/lex/Makefile.nt
+++ b/lex/Makefile.nt
@@ -17,7 +17,7 @@ CAMLRUN ?= ../boot/ocamlrun
 CAMLYACC ?= ../boot/ocamlyacc
 
 CAMLC=$(CAMLRUN) ../boot/ocamlc -I ../boot
-CAMLOPT=$(CAMLRUN) ../ocamlopt -I ../stdlib
+CAMLOPT=$(if $(wildcard ../flexdll/Makefile),OCAML_FLEXLINK="../boot/ocamlrun ../flexdll/flexlink.exe") $(CAMLRUN) ../ocamlopt -I ../stdlib
 COMPFLAGS=-warn-error A
 LINKFLAGS=
 YACCFLAGS=-v

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -519,6 +519,14 @@ Display a short usage summary and exit.
 %
 \end{options}
 
+\noindent
+On native Windows, the following environment variable is also consulted:
+
+\begin{options}
+\item["OCAML_FLEXLINK"]  Alternative executable to use instead of the
+configured value. Primarily used for bootstrapping.
+\end{options}
+
 \section{Modules and the file system}
 
 This short section is intended to clarify the relationship between the

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -2232,6 +2232,14 @@ libraries are supported) and "lib"\var{outputc}".a".
 If not specified, defaults to the output name given with "-o".
 \end{options}
 
+\noindent
+On native Windows, the following environment variable is also consulted:
+
+\begin{options}
+\item["OCAML_FLEXLINK"]  Alternative executable to use instead of the
+configured value. Primarily used for bootstrapping.
+\end{options}
+
 \paragraph{Example} Consider an OCaml interface to the standard "libz"
 C library for reading and writing compressed files.  Assume this
 library resides in "/usr/local/zlib".  This interface is

--- a/manual/manual/cmds/native.etex
+++ b/manual/manual/cmds/native.etex
@@ -505,6 +505,14 @@ Display a short usage summary and exit.
 %
 \end{options}
 
+\noindent
+On native Windows, the following environment variable is also consulted:
+
+\begin{options}
+\item["OCAML_FLEXLINK"]  Alternative executable to use instead of the
+configured value. Primarily used for bootstrapping.
+\end{options}
+
 \paragraph{Options for the IA32 architecture}
 The IA32 code generator (Intel Pentium, AMD Athlon) supports the
 following additional option:

--- a/ocamldoc/Makefile.nt
+++ b/ocamldoc/Makefile.nt
@@ -18,7 +18,7 @@ CAMLYACC ?= ../boot/ocamlyacc
 ##########################
 ROOTDIR   = ..
 OCAMLC    = $(CAMLRUN) $(ROOTDIR)/ocamlc -nostdlib -I $(ROOTDIR)/stdlib
-OCAMLOPT  = $(CAMLRUN) $(ROOTDIR)/ocamlopt -nostdlib -I $(ROOTDIR)/stdlib
+OCAMLOPT  = $(if $(wildcard $(ROOTDIR)/flexdll/Makefile),OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe") $(CAMLRUN) $(ROOTDIR)/ocamlopt -nostdlib -I $(ROOTDIR)/stdlib
 OCAMLDEP  = $(CAMLRUN) $(ROOTDIR)/tools/ocamldep
 OCAMLLEX  = $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
 OCAMLLIB  = $(LIBDIR)

--- a/otherlibs/Makefile.nt
+++ b/otherlibs/Makefile.nt
@@ -15,6 +15,8 @@
 
 include ../Makefile
 
+export OCAML_FLEXLINK:=$(if $(wildcard $(ROOTDIR)/flexdll/Makefile),$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe)
+
 # The Unix version now works fine under Windows
 
 # Note .. is the current directory (this makefile is included from

--- a/otherlibs/systhreads/Makefile.nt
+++ b/otherlibs/systhreads/Makefile.nt
@@ -22,6 +22,8 @@ COMPFLAGS=-w +33 -warn-error A -g
 MKLIB=$(CAMLRUN) ../../tools/ocamlmklib
 CFLAGS=-I../../byterun $(EXTRACFLAGS)
 
+export OCAML_FLEXLINK:=$(if $(wildcard ../../flexdll/Makefile),../../boot/ocamlrun ../../flexdll/flexlink.exe)
+
 CAMLOBJS=thread.cmo mutex.cmo condition.cmo event.cmo threadUnix.cmo
 CMIFILES=$(CAMLOBJS:.cmo=.cmi)
 COBJS=st_stubs_b.$(O)

--- a/testsuite/makefiles/Makefile.common
+++ b/testsuite/makefiles/Makefile.common
@@ -56,11 +56,12 @@ endif
 
 OCAML=$(OCAMLRUN) $(OTOPDIR)/ocaml $(OCFLAGS) \
       -init $(OTOPDIR)/testsuite/lib/empty
-OCAMLC=$(OCAMLRUN) $(OTOPDIR)/ocamlc $(CUSTOM) $(OCFLAGS)
-OCAMLOPT=$(OCAMLRUN) $(OTOPDIR)/ocamlopt $(OCFLAGS)
+FLEXLINK_PREFIX=$(if $(FLEXLINK),$(if $(wildcard $(TOPDIR)/flexdll/Makefile),OCAML_FLEXLINK="$(WINTOPDIR)/boot/ocamlrun $(WINTOPDIR)/flexdll/flexlink.exe" ))
+OCAMLC=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlc $(CUSTOM) $(OCFLAGS)
+OCAMLOPT=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlopt $(OCFLAGS)
 OCAMLDOC=$(OCAMLRUN) $(OTOPDIR)/ocamldoc/ocamldoc
 OCAMLLEX=$(OCAMLRUN) $(OTOPDIR)/lex/ocamllex
-OCAMLMKLIB=$(OCAMLRUN) $(OTOPDIR)/tools/ocamlmklib \
+OCAMLMKLIB=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/tools/ocamlmklib \
 		       -ocamlc "$(OTOPDIR)/boot/ocamlrun$(EXE) \
 		                $(OTOPDIR)/ocamlc $(OCFLAGS)" \
 		       -ocamlopt "$(OTOPDIR)/boot/ocamlrun$(EXE) \

--- a/tools/Makefile.nt
+++ b/tools/Makefile.nt
@@ -22,17 +22,6 @@ OCAMLMKTOP_IMPORTS=misc.cmo identifiable.cmo numbers.cmo config.cmo clflags.cmo 
 ocamlmktop: $(OCAMLMKTOP)
 	$(CAMLC) $(LINKFLAGS) -o ocamlmktop $(OCAMLMKTOP_IMPORTS) $(OCAMLMKTOP)
 
-ocamlmklibconfig.ml:: ../config/Makefile Makefile
-	echo "let mkdll = try \
-                let flexlink = \
-                  let flexlink = Sys.getenv \"OCAML_FLEXLINK\" in \
-                  let f i = \
-                    let c = flexlink.[i] in \
-                    if c = '/' then '\\\\' else c in \
-                  (String.init (String.length flexlink) f) ^ \" $(FLEXLINK_FLAGS)\" in \
-                Printf.sprintf \"%s %s\" flexlink \"$(FLEXLINK_FLAGS)\" \
-              with Not_found -> mkdll">> $@
-
 install::
 	cp ocamlmktop $(INSTALL_BINDIR)/ocamlmktop$(EXE)
 

--- a/tools/Makefile.nt
+++ b/tools/Makefile.nt
@@ -20,6 +20,17 @@ OCAMLMKTOP_IMPORTS=misc.cmo identifiable.cmo numbers.cmo config.cmo clflags.cmo 
 ocamlmktop: $(OCAMLMKTOP)
 	$(CAMLC) $(LINKFLAGS) -o ocamlmktop $(OCAMLMKTOP_IMPORTS) $(OCAMLMKTOP)
 
+ocamlmklibconfig.ml:: ../config/Makefile
+	echo "let mkdll = try \
+                let flexlink = \
+                  let flexlink = Sys.getenv \"OCAML_FLEXLINK\" in \
+                  let f i = \
+                    let c = flexlink.[i] in \
+                    if c = '/' then '\\\\' else c in \
+                  (String.init (String.length flexlink) f) ^ \" $(FLEXLINK_FLAGS)\" in \
+                Printf.sprintf \"%s %s\" flexlink \"$(FLEXLINK_FLAGS)\" \
+              with Not_found -> mkdll">> $@
+
 install::
 	cp ocamlmktop $(INSTALL_BINDIR)/ocamlmktop$(EXE)
 

--- a/tools/Makefile.nt
+++ b/tools/Makefile.nt
@@ -12,6 +12,8 @@
 
 include Makefile.shared
 
+CAMLOPT:=$(if $(wildcard ../flexdll/Makefile),OCAML_FLEXLINK="../boot/ocamlrun ../flexdll/flexlink.exe") $(CAMLOPT)
+
 # To make custom toplevels
 
 OCAMLMKTOP=ocamlmktop.cmo
@@ -20,7 +22,7 @@ OCAMLMKTOP_IMPORTS=misc.cmo identifiable.cmo numbers.cmo config.cmo clflags.cmo 
 ocamlmktop: $(OCAMLMKTOP)
 	$(CAMLC) $(LINKFLAGS) -o ocamlmktop $(OCAMLMKTOP_IMPORTS) $(OCAMLMKTOP)
 
-ocamlmklibconfig.ml:: ../config/Makefile
+ocamlmklibconfig.ml:: ../config/Makefile Makefile
 	echo "let mkdll = try \
                 let flexlink = \
                   let flexlink = Sys.getenv \"OCAML_FLEXLINK\" in \

--- a/tools/Makefile.shared
+++ b/tools/Makefile.shared
@@ -109,7 +109,7 @@ install::
 clean::
 	rm -f ocamlmklib
 
-ocamlmklibconfig.ml:: ../config/Makefile
+ocamlmklibconfig.ml:: ../config/Makefile Makefile
 	(echo 'let bindir = "$(BINDIR)"'; \
          echo 'let ext_lib = "$(EXT_LIB)"'; \
          echo 'let ext_dll = "$(EXT_DLL)"'; \

--- a/tools/Makefile.shared
+++ b/tools/Makefile.shared
@@ -101,7 +101,7 @@ clean::
 # To help building mixed-mode libraries (OCaml + C)
 
 ocamlmklib: ocamlmklibconfig.cmo ocamlmklib.cmo
-	$(CAMLC) $(LINKFLAGS) -o ocamlmklib ocamlmklibconfig.cmo ocamlmklib.cmo
+	$(CAMLC) $(LINKFLAGS) -o ocamlmklib ocamlmklibconfig.cmo config.cmo ocamlmklib.cmo
 
 install::
 	cp ocamlmklib $(INSTALL_BINDIR)/ocamlmklib$(EXE)
@@ -109,12 +109,9 @@ install::
 clean::
 	rm -f ocamlmklib
 
-ocamlmklibconfig.ml:: ../config/Makefile Makefile
+ocamlmklibconfig.ml: ../config/Makefile Makefile
 	(echo 'let bindir = "$(BINDIR)"'; \
-         echo 'let ext_lib = "$(EXT_LIB)"'; \
-         echo 'let ext_dll = "$(EXT_DLL)"'; \
          echo 'let supports_shared_libraries = $(SUPPORTS_SHARED_LIBRARIES)';\
-         echo 'let mkdll = "$(MKDLL)"'; \
          echo 'let byteccrpath = "$(BYTECCRPATH)"'; \
          echo 'let nativeccrpath = "$(NATIVECCRPATH)"'; \
          echo 'let mksharedlibrpath = "$(MKSHAREDLIBRPATH)"'; \

--- a/tools/Makefile.shared
+++ b/tools/Makefile.shared
@@ -109,7 +109,7 @@ install::
 clean::
 	rm -f ocamlmklib
 
-ocamlmklibconfig.ml: ../config/Makefile
+ocamlmklibconfig.ml:: ../config/Makefile
 	(echo 'let bindir = "$(BINDIR)"'; \
          echo 'let ext_lib = "$(EXT_LIB)"'; \
          echo 'let ext_dll = "$(EXT_DLL)"'; \

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -244,9 +244,9 @@ let build_libs () =
     if !dynlink then begin
       let retcode = command
           (Printf.sprintf "%s %s -o %s %s %s %s %s %s"
-             mkdll
+             Config.mkdll
              (if !debug then "-g" else "")
-             (prepostfix "dll" !output_c ext_dll)
+             (prepostfix "dll" !output_c Config.ext_dll)
              (String.concat " " !c_objs)
              (String.concat " " !c_opts)
              (String.concat " " !ld_opts)
@@ -256,9 +256,9 @@ let build_libs () =
       in
       if retcode <> 0 then if !failsafe then dynlink := false else exit 2
     end;
-    safe_remove (prepostfix "lib" !output_c ext_lib);
+    safe_remove (prepostfix "lib" !output_c Config.ext_lib);
     scommand
-      (mklib (prepostfix "lib" !output_c ext_lib)
+      (mklib (prepostfix "lib" !output_c Config.ext_lib)
              (String.concat " " !c_objs) "");
   end;
   if !bytecode_objs <> [] then

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -44,9 +44,23 @@ let native_pack_linker = "%%PACKLD%%"
 let ranlib = "%%RANLIBCMD%%"
 let ar = "%%ARCMD%%"
 let cc_profile = "%%CC_PROFILE%%"
-let mkdll = "%%MKDLL%%"
-let mkexe = "%%MKEXE%%"
-let mkmaindll = "%%MKMAINDLL%%"
+let mkdll, mkexe, mkmaindll =
+  (* @@DRA Cygwin - but only if shared libraries are enabled, which we should be able to detect? *)
+  if Sys.os_type = "Win32" then
+    try
+      let flexlink =
+        let flexlink = Sys.getenv "OCAML_FLEXLINK" in
+        let f i =
+          let c = flexlink.[i] in
+          if c = '/' then '\\' else c in
+        (String.init (String.length flexlink) f) ^ " %%FLEXLINK_FLAGS%%" in
+      flexlink,
+      flexlink ^ " -exe",
+      flexlink ^ " -maindll"
+    with Not_found ->
+      "%%MKDLL%%", "%%MKEXE%%", "%%MKMAINDLL%%"
+  else
+    "%%MKDLL%%", "%%MKEXE%%", "%%MKMAINDLL%%"
 
 let flambda = %%FLAMBDA%%
 


### PR DESCRIPTION
### Preamble

This pull request contains a submodule which at present refers to a commit which has not yet been merged into FlexDLL (see https://github.com/alainfrisch/flexdll/pull/14). If you wish to experiment with the PR, you need to do one of two things:
1. Run `git submodule update --init`, ignore the error message and then from the `flexdll` directory run `git remote add -f dra27 https://github.com/dra27/flexdll.git` followed by `git checkout visual-studio`
2. Run `git submodule init`, edit `.git/config` and change the URL for the flexdll repository to mine and then run `git submodule update`

Obviously, notwithstanding other reasons, this PR should not be merged until https://github.com/alainfrisch/flexdll/pull/14 is resolved.
### Abstract (!)

This PR provides the _option_ of bootstrapping FlexDLL from sources as part of the general build process for native Windows OCaml. At present, this support is not offered for Cygwin (see below).

The philosophical arguments for doing this have already been [aired on at least one occasion](https://sympa.inria.fr/sympa/arc/caml-list/2015-10/msg00165.html), but there are two more concrete reasons for the desirability of being able to do this:
1. Ease of compilation from sources - having the option of compiling both together results in much simpler instructions for the end-user (especially a beginner).
2. OPAM. OPAM, at least at present, is intended to be a source distribution of OCaml - at present, the only binary which has to be installed and managed is Cygwin. FlexDLL sits in an odd place, given that it must be awkwardly installed before the compiler in a switch - OPAM therefore benefits both philosophically and literally from being able to install OCaml and FlexDLL as one.
### Cygwin

Cygwin OCaml uses FlexDLL to enable shared libraries - some of the changes I have made are in fact porting existing functionality in the Unix build system to allow Cygwin flexlink to be bootstrapped, because there is/was no binary distribution. I have not extended this full bootstrapping support to Cygwin _yet_ for two reasons:
1. It is more effort (and, as it happens, for a platform I don't care about, but that's by the by) and involves (more) duplication of existing code between the Unix and Win32 code branches.
2. Cygwin is built using the `configure` rather than `Makefile`-editing route.

At some point in the coming months, if nobody else gets there first, I shall contribute a unified build system for the native Windows ports via `configure` and I would like to propose that full bootstrapping for Cygwin of FlexDLL be left until that work is done (by whoever).
### Commentary

Overall, it is pleasing (to me, at least) how few changes are required to facilitate this - which I hope may aid in its acceptance.

The eight commits include an earlier partial effort (09feadf82316ee01978dd846a58d4d9f3765efd7 and 29f7d7dc3fb12e075ef2b0535377354c6ad6ffa6). This simpler approach allowed the user to say

``` sh
make -f Makefile.nt flexdll install-flexdll
```

which allowed a byte-code flexlink to be compiled and pre-installed. However, it still assumes that the user has set their `PATH` appropriately so that that flexlink can then be used in the main build process for OCaml. 

In that earlier work, the flexdll sources have to downloaded (either by source tarball or by git clone) and placed into the OCaml source tree prior to issuing `make -f Makefile.nt flexdll`. However, this is far from the best way for Git - both the fact that OCaml and FlexDLL are truly separate projects and the fact that it remains possible to compile OCaml without also compiling FlexDLL makes the repository a _perfect_ candidate for a Git submodule which is what is then added in d8a35be73364b8108b0a938f02e9a5bacb7d9a6c. Error messages in `Makefile.nt` are added which alert the user to the absence of flexlink and advise how to fix the problem (this is part of the reason for not incorporating this to Cygwin at the moment, as such testing really should be in `configure`).

In order to allow the OCaml build procedure to use a locally bootstrapped copy of FlexDLL, it is necessary to add one feature to the compilers and to `ocamlmklib` - there needs to be a way to override the `flexlink` command (or, more specifically, `Config.mkexe`, `Config.mkdll` and `Config.mkmaindll`). The only alternative I could see would be to build two copies of the compiler and `ocamlmklib` which I don't think is an acceptable burden to add to the build process - both in terms of time and complexity of understanding. My solution instead in f4fd8b1350641f01798fbed4960b61597386959b is to split the `FLEXLINK` Makefile variable into known constituent parts and then to allow it to be overridden at runtime by an `OCAML_FLEXLINK` environment variable (i.e. the way in which `mkexe`, `mkdll` and `mkmaindll` is less general than it was before).

Finally, 9b624040ac3b3543975f73d6f9bbbe107471deac utilises this new feature to allow a bootstrapped FlexDLL to be used if `flexlink` is not found in `PATH`. It also amends the `opt.opt` target to build a native code version of `flexlink.exe` _only if FlexDLL was bootstrapped in the first place_ and the `installbyt` target also installs `flexlink.exe` and the required FlexDLL object files and manifests again, _only if FlexDLL was bootstrapped in the first place_. The change to the build process principally involves communicating either a revised `OCAMLOPT` variable or a `OCAML_FLEXLINK=...` line to be used, similar to the overriding already in various places to specify the boot compiler. At present, the expressions used are more verbose than would be ideal (especially the need to translate forward slashes to backslashes), however this would be vastly simplified by the use of a `configure` script for the native Windows ports, so I would crave your patience with the very long `$(if $(shell ... ))` lines!

This has been tested with all four native Windows ports (running `make -f Makefile.nt [flexdll] world bootstrap opt opt.opt install`) both with and without the submodule initialised and in all eight builds the test-suite (utilising various patches pending in #366 and #384) runs with 100% pass rate.

I haven't updated `README.win32.adoc` with instructions because I can't be bothered to update a guide which I'm already planning on completely rewriting once I've finished the Visual Studio testing which has been yielding all these patches...

Thank you for getting to the bottom :smile:
