### PR TITLE
Add BigArray.Genarray.free

### DIFF
--- a/otherlibs/bigarray/bigarray.ml
+++ b/otherlibs/bigarray/bigarray.ml
@@ -112,6 +112,7 @@ module Genarray = struct
      = "caml_ba_map_file_bytecode" "caml_ba_map_file"
   let map_file fd ?(pos = 0L) kind layout shared dims =
     map_internal fd kind layout shared dims pos
+  external free: ('a, 'b, 'c) t -> unit = "caml_ba_free"
 end
 
 module Array1 = struct
@@ -140,6 +141,7 @@ module Array1 = struct
     ba
   let map_file fd ?pos kind layout shared dim =
     Genarray.map_file fd ?pos kind layout shared [|dim|]
+  let free = Genarray.free
 end
 
 module Array2 = struct
@@ -185,6 +187,7 @@ module Array2 = struct
     ba
   let map_file fd ?pos kind layout shared dim1 dim2 =
     Genarray.map_file fd ?pos kind layout shared [|dim1;dim2|]
+  let free = Genarray.free
 end
 
 module Array3 = struct
@@ -240,6 +243,7 @@ module Array3 = struct
     ba
   let map_file fd ?pos kind layout shared dim1 dim2 dim3 =
     Genarray.map_file fd ?pos kind layout shared [|dim1;dim2;dim3|]
+  let free = Genarray.free
 end
 
 external genarray_of_array1: ('a, 'b, 'c) Array1.t -> ('a, 'b, 'c) Genarray.t

--- a/otherlibs/bigarray/bigarray.mli
+++ b/otherlibs/bigarray/bigarray.mli
@@ -458,6 +458,18 @@ module Genarray :
      underlying system calls.  [Invalid_argument] or [Failure] may be
      raised in cases where argument validation fails. *)
 
+  val free: ('a, 'b, 'c) t -> unit
+  (** Free the memory used by this array, setting all dimensions to
+      zero to prevent further use.
+
+      This is useful to ensure that memory-mapped files are closed promptly,
+      without waiting for the garbage collector. Otherwise, mapping a large
+      number of files may hit operating system limits on the number of open
+      files.
+
+      If e.g. [sub_left] is used to create multiple bigarrays backed
+      by the same memory block, [free] must be called on all of them
+      before the memory is actually released. *)
   end
 
 (** {6 One-dimensional arrays} *)
@@ -538,6 +550,10 @@ module Array1 : sig
   (** Like {!Bigarray.Array1.set}, but bounds checking is not always performed.
       Use with caution and only when the program logic guarantees that
       the access is within bounds. *)
+
+  val free: ('a, 'b, 'c) t -> unit
+  (** Free the array immediately, without waiting for the garbage collector.
+      See [Genarray.free] for details. *)
 
 end
 
@@ -642,6 +658,10 @@ module Array2 :
                      = "%caml_ba_unsafe_set_2"
   (** Like {!Bigarray.Array2.set}, but bounds checking is not always
       performed. *)
+
+  val free: ('a, 'b, 'c) t -> unit
+  (** free the array immediately, without waiting for the garbage collector.
+      see [genarray.free] for details. *)
 
 end
 
@@ -770,6 +790,10 @@ module Array3 :
                      = "%caml_ba_unsafe_set_3"
   (** Like {!Bigarray.Array3.set}, but bounds checking is not always
       performed. *)
+
+  val free: ('a, 'b, 'c) t -> unit
+  (** Free the array immediately, without waiting for the garbage collector.
+      See [Genarray.free] for details. *)
 
 end
 

--- a/otherlibs/bigarray/bigarray_stubs.c
+++ b/otherlibs/bigarray/bigarray_stubs.c
@@ -692,6 +692,23 @@ static void caml_ba_finalize(value v)
   }
 }
 
+CAMLprim void caml_ba_free(value v)
+{
+  struct caml_ba_array * b = Caml_ba_array_val(v);
+  int i;
+
+  /* Free data if we're the last user, or decr ref count if not */
+  caml_ba_finalize(v);
+
+  /* Prevent later GC or free from doing anything more */
+  b->flags = (b->flags & ~CAML_BA_MANAGED_MASK) | CAML_BA_EXTERNAL;
+  /* Disallow all access via this bigarray */
+  for (i = 0; i < b->num_dims; i++) b->dim[i] = Long_val(0);
+  /* Tidy up (and let C users know that the data is gone). */
+  b->data = NULL;
+  b->proxy = NULL;
+}
+
 /* Comparison of two big arrays */
 
 static int caml_ba_compare(value v1, value v2)


### PR DESCRIPTION
Free the memory used by a bigarray, setting all dimensions to zero to prevent further use.

This is useful to ensure that memory-mapped files are closed promptly, without waiting for the garbage collector. Otherwise, mapping a large number of files may hit operating system limits on the number of open files.

It's also needed in MirageOS, where some Xen protocols require shared memory to be unmapped at certain points.

If e.g. `sub_left` is used to create multiple bigarrays backed by the same memory block, `free` must be called on all of them before the memory is actually released.

Test program:

```
(* ocamlc unix.cma bigarray.cma test.ml -o test && ./test *)

open Bigarray

let maps = ref []

let open_and_close () =
  let fd = Unix.(openfile "/etc/passwd" [O_RDONLY; O_NONBLOCK] 0o644) in
  let mapped = Array1.map_file fd char c_layout false 100 in
  (* Make bug more obvious by ensuring no GC *)
  maps := mapped :: !maps;
  (* Array1.free mapped; *)
  Unix.close fd

let () =
  let i = ref 0 in
  while true do
    incr i;
    open_and_close ();
    Printf.printf "Mapped %d files\n%!" !i
  done
```

For me, on Linux, this prints:

```
...
Mapped 35589 files
Mapped 35590 files
Fatal error: exception Unix.Unix_error(Unix.ENFILE, "open", "/etc/passwd")
```
