### PR TITLE
Compute module block size in transl_structure

### DIFF
--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -359,7 +359,7 @@ let rec transl_module cc rootpath mexp =
           apply_coercion Strict cc
             (transl_path ~loc:mexp.mod_loc mexp.mod_env path)
       | Tmod_structure str ->
-          transl_struct [] cc rootpath str
+          fst (transl_struct [] cc rootpath str)
       | Tmod_functor( param, _, mty, body) ->
           let bodypath = functor_path rootpath param in
           let inline_attribute =
@@ -407,7 +407,8 @@ and transl_structure fields cc rootpath = function
       begin match cc with
         Tcoerce_none ->
           Lprim(Pmakeblock(0, Immutable),
-                List.map (fun id -> Lvar id) (List.rev fields))
+                List.map (fun id -> Lvar id) (List.rev fields)),
+            List.length fields
       | Tcoerce_structure(pos_cc_list, id_pos_list) ->
               (* Do not ignore id_pos_list ! *)
           (*Format.eprintf "%a@.@[" Includemod.print_coercion cc;
@@ -430,18 +431,20 @@ and transl_structure fields cc rootpath = function
           and id_pos_list =
             List.filter (fun (id,_,_) -> not (IdentSet.mem id ids)) id_pos_list
           in
-          wrap_id_pos_list id_pos_list get_field lam
+          wrap_id_pos_list id_pos_list get_field lam,
+            List.length pos_cc_list
       | _ ->
           fatal_error "Translmod.transl_structure"
       end
   | item :: rem ->
       match item.str_desc with
       | Tstr_eval (expr, _) ->
-          Lsequence(transl_exp expr, transl_structure fields cc rootpath rem)
+          let body, size = transl_structure fields cc rootpath rem in
+          Lsequence(transl_exp expr, body), size
       | Tstr_value(rec_flag, pat_expr_list) ->
           let ext_fields = rev_let_bound_idents pat_expr_list @ fields in
-          transl_let rec_flag pat_expr_list
-            (transl_structure ext_fields cc rootpath rem)
+          let body, size = transl_structure ext_fields cc rootpath rem in
+          transl_let rec_flag pat_expr_list body, size
       | Tstr_primitive descr ->
           record_primitive descr.val_val;
           transl_structure fields cc rootpath rem
@@ -449,33 +452,47 @@ and transl_structure fields cc rootpath = function
           transl_structure fields cc rootpath rem
       | Tstr_typext(tyext) ->
           let ids = List.map (fun ext -> ext.ext_id) tyext.tyext_constructors in
-          transl_type_extension item.str_env rootpath tyext
-            (transl_structure (List.rev_append ids fields) cc rootpath rem)
+          let body, size =
+            transl_structure (List.rev_append ids fields) cc rootpath rem
+          in
+          transl_type_extension item.str_env rootpath tyext body, size
       | Tstr_exception ext ->
           let id = ext.ext_id in
           let path = field_path rootpath id in
+          let body, size = transl_structure (id :: fields) cc rootpath rem in
           Llet(Strict, id, transl_extension_constructor item.str_env path ext,
-               transl_structure (id :: fields) cc rootpath rem)
+               body), size
       | Tstr_module mb ->
           let id = mb.mb_id in
+          let body, size = transl_structure (id :: fields) cc rootpath rem in
+          let module_body =
+            transl_module Tcoerce_none (field_path rootpath id) mb.mb_expr
+          in
+          let module_body =
+            Translattribute.add_inline_attribute module_body mb.mb_loc mb.mb_attributes
+          in
           Llet(pure_module mb.mb_expr, id,
-               Translattribute.add_inline_attribute
-                 (transl_module Tcoerce_none (field_path rootpath id) mb.mb_expr)
-                 mb.mb_loc mb.mb_attributes,
-               transl_structure (id :: fields) cc rootpath rem)
+               module_body,
+               body), size
       | Tstr_recmodule bindings ->
           let ext_fields =
             List.rev_append (List.map (fun mb -> mb.mb_id) bindings) fields
           in
-          compile_recmodule
-            (fun id modl ->
-               transl_module Tcoerce_none (field_path rootpath id) modl)
-            bindings
-            (transl_structure ext_fields cc rootpath rem)
+          let body, size = transl_structure ext_fields cc rootpath rem in
+          let lam =
+            compile_recmodule
+              (fun id modl ->
+                 transl_module Tcoerce_none (field_path rootpath id) modl)
+              bindings
+              body
+          in
+          lam, size
       | Tstr_class cl_list ->
           let (ids, class_bindings) = transl_class_bindings cl_list in
-          Lletrec(class_bindings,
-                  transl_structure (List.rev_append ids fields) cc rootpath rem)
+          let body, size =
+            transl_structure (List.rev_append ids fields) cc rootpath rem
+          in
+          Lletrec(class_bindings, body), size
       | Tstr_include incl ->
           let ids = bound_value_identifiers incl.incl_type in
           let modl = incl.incl_mod in
@@ -484,10 +501,12 @@ and transl_structure fields cc rootpath = function
               [] ->
                 transl_structure newfields cc rootpath rem
             | id :: ids ->
-                Llet(Alias, id, Lprim(Pfield pos, [Lvar mid]),
-                     rebind_idents (pos + 1) (id :: newfields) ids) in
+                let body, size = rebind_idents (pos + 1) (id :: newfields) ids in
+                Llet(Alias, id, Lprim(Pfield pos, [Lvar mid]), body), size
+          in
+          let body, size = rebind_idents 0 fields ids in
           Llet(pure_module modl, mid, transl_module Tcoerce_none None modl,
-               rebind_idents 0 fields ids)
+               body), size
 
       | Tstr_modtype _
       | Tstr_open _
@@ -539,16 +558,22 @@ let wrap_globals body =
 
 (* Compile an implementation *)
 
-let transl_implementation module_name (str, cc) =
+let transl_implementation_flambda module_name (str, cc) =
   reset_labels ();
   primitive_declarations := [];
   Hashtbl.clear used_primitives;
   let module_id = Ident.create_persistent module_name in
-  let body =
+  let body, size =
     transl_label_init
-      (transl_struct [] cc (global_path module_id) str) in
-  Lprim(Psetglobal module_id, [wrap_globals body])
+      (fun () -> transl_struct [] cc (global_path module_id) str)
+  in
+  module_id, (wrap_globals body, size)
 
+let transl_implementation module_name (str, cc) =
+  let module_id, (module_initializer, _size) =
+    transl_implementation_flambda module_name (str, cc)
+  in
+  Lprim (Psetglobal module_id, [module_initializer])
 
 (* Build the list of value identifiers defined by a toplevel structure
    (excluding primitive declarations). *)
@@ -913,7 +938,7 @@ let toploop_setvalue id lam =
 
 let toploop_setvalue_id id = toploop_setvalue id (Lvar id)
 
-let close_toplevel_term lam =
+let close_toplevel_term (lam, ()) =
   IdentSet.fold (fun id l -> Llet(Strict, id, toploop_getvalue id, l))
                 (free_variables lam) lam
 
@@ -982,7 +1007,8 @@ let transl_toplevel_item item =
       lambda_unit
 
 let transl_toplevel_item_and_close itm =
-  close_toplevel_term (transl_label_init (transl_toplevel_item itm))
+  close_toplevel_term
+    (transl_label_init (fun () -> transl_toplevel_item itm, ()))
 
 let transl_toplevel_definition str =
   reset_labels ();

--- a/bytecomp/translobj.ml
+++ b/bytecomp/translobj.ml
@@ -91,7 +91,8 @@ let prim_makearray =
   Primitive.simple ~name:"caml_make_vect" ~arity:2 ~alloc:true
 
 (* Also use it for required globals *)
-let transl_label_init expr =
+let transl_label_init_general f =
+  let expr, size = f () in
   let expr =
     Hashtbl.fold
       (fun c id expr -> Llet(Alias, id, Lconst c, expr))
@@ -104,7 +105,7 @@ let transl_label_init expr =
   in
   Env.reset_required_globals ();*)
   reset_labels ();
-  expr
+  expr, size
 
 let transl_store_label_init glob size f arg =
   method_cache := Lprim(Pfield size, [Lprim(Pgetglobal glob, [])]);
@@ -118,7 +119,11 @@ let transl_store_label_init glob size f arg =
             Lprim (Pccall prim_makearray, [int !method_count; int 0])]),
      expr))
   in
-  (size, transl_label_init expr)
+  let lam, size = transl_label_init_general (fun () -> (expr, size)) in
+  size, lam
+
+let transl_label_init f =
+  transl_label_init_general f
 
 (* Share classes *)
 

--- a/bytecomp/translobj.mli
+++ b/bytecomp/translobj.mli
@@ -18,7 +18,7 @@ val share: structured_constant -> lambda
 val meth: lambda -> string -> lambda * lambda list
 
 val reset_labels: unit -> unit
-val transl_label_init: lambda -> lambda
+val transl_label_init: (unit -> lambda * 'a) -> lambda * 'a
 val transl_store_label_init:
     Ident.t -> int -> ('a -> lambda) -> 'a -> int * lambda
 


### PR DESCRIPTION
This patch causes transl_structure to compute the size of the returned module block.  (Note that this is the bytecode / flambda version, so there's no fancy stuff going on with sub-module fields being lifted to the toplevel.)
