### PR TITLE
Add an unreachable construction to clambda

### DIFF
--- a/asmcomp/clambda.ml
+++ b/asmcomp/clambda.ml
@@ -53,6 +53,7 @@ type ulambda =
   | Ufor of Ident.t * ulambda * ulambda * direction_flag * ulambda
   | Uassign of Ident.t * ulambda
   | Usend of meth_kind * ulambda * ulambda * ulambda list * Debuginfo.t
+  | Uunreachable
 
 and ufunction = {
   label  : function_label;

--- a/asmcomp/clambda.mli
+++ b/asmcomp/clambda.mli
@@ -53,6 +53,7 @@ type ulambda =
   | Ufor of Ident.t * ulambda * ulambda * direction_flag * ulambda
   | Uassign of Ident.t * ulambda
   | Usend of meth_kind * ulambda * ulambda * ulambda list * Debuginfo.t
+  | Uunreachable
 
 and ufunction = {
   label  : function_label;

--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -83,6 +83,7 @@ let occurs_var var u =
     | Uassign(id, u) -> id = var || occurs u
     | Usend(_, met, obj, args, _) ->
         occurs met || occurs obj || List.exists occurs args
+    | Uunreachable -> false
   and occurs_array a =
     try
       for i = 0 to Array.length a - 1 do
@@ -234,6 +235,7 @@ let lambda_smaller lam threshold =
     | Usend(_, met, obj, args, _) ->
         size := !size + 8;
         lambda_size met; lambda_size obj; lambda_list_size args
+    | Uunreachable -> ()
   and lambda_list_size l = List.iter lambda_size l
   and lambda_array_size a = Array.iter lambda_size a in
   try
@@ -664,6 +666,8 @@ let rec substitute fpc sb ulam =
   | Usend(k, u1, u2, ul, dbg) ->
       Usend(k, substitute fpc sb u1, substitute fpc sb u2,
             List.map (substitute fpc sb) ul, dbg)
+  | Uunreachable ->
+      Uunreachable
 
 (* Perform an inline expansion *)
 
@@ -1350,6 +1354,7 @@ let collect_exported_structured_constants a =
     | Ufor (_, u1, u2, _, u3) -> ulam u1; ulam u2; ulam u3
     | Uassign (_, u) -> ulam u
     | Usend (_, u1, u2, ul, _) -> ulam u1; ulam u2; List.iter ulam ul
+    | Uunreachable -> ()
   in
   approx a
 

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -1642,6 +1642,8 @@ let rec transl env e =
       | Some (unboxed_id, bn) ->
           return_unit(Cassign(unboxed_id, transl_unbox_number env bn exp))
       end
+  | Uunreachable ->
+      Cop(Cload Word_int, [Cconst_int 0])
 
 and transl_ccall env prim args dbg =
   let transl_arg native_repr arg =

--- a/asmcomp/printclambda.ml
+++ b/asmcomp/printclambda.ml
@@ -157,6 +157,8 @@ let rec lam ppf = function
         else if k = Lambda.Cached then "cache"
         else "" in
       fprintf ppf "@[<2>(send%s@ %a@ %a%a)@]" kind lam obj lam met args largs
+  | Uunreachable ->
+      fprintf ppf "unreachable"
 
 and sequence ppf ulam = match ulam with
   | Usequence(l1, l2) ->


### PR DESCRIPTION
Flambda can sometimes prove that some expression is unreachable. This kind of expression is substituted to an explicit unreachable construction. If no cleaning is performed after, or in some cases, it cannot be removed, this can appear in clambda.

The generated code for it is an explicit segfault (dereferencing 0) that can quite easily be grepped in dumped cmm, mach or assembly.
