### PR TITLE
Clear Spill.destroyed_at_fork to avoid memory blowup

### DIFF
--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -196,11 +196,13 @@ let rec reload i before =
        finally)
   | Iloop(body) ->
       let date_start = !current_date in
+      let destroyed_at_fork_start = !destroyed_at_fork in
       let at_head = ref before in
       let final_body = ref body in
       begin try
         while true do
           current_date := date_start;
+          destroyed_at_fork := destroyed_at_fork_start;
           let (new_body, new_at_head) = reload body !at_head in
           let merged_at_head = Reg.Set.union !at_head new_at_head in
           if Reg.Set.equal merged_at_head !at_head then begin
@@ -390,7 +392,8 @@ let rec spill i finally =
 let reset () =
   spill_env := Reg.Map.empty;
   use_date := Reg.Map.empty;
-  current_date := 0
+  current_date := 0;
+  destroyed_at_fork := []
 
 let fundecl f =
   reset ();
@@ -401,6 +404,7 @@ let fundecl f =
     add_spills (Reg.inter_set_array tospill_at_entry f.fun_args) body2 in
   spill_env := Reg.Map.empty;
   use_date := Reg.Map.empty;
+  destroyed_at_fork := [];
   { fun_name = f.fun_name;
     fun_args = f.fun_args;
     fun_body = new_body;


### PR DESCRIPTION
`destroyed_at_fork` is never cleared. This means that the whole code is kept in memory. Moreover, the loop construction is handled by reaching a fixpoint traversing the code multiple times, and potentially filling `destroyed_at_fork` with values that could not be used later. This can provoke unreasonable memory usage on big files with branches in nested loops. One such example was found when compiling `kernel/term.ml` from coq with aggressive inlining options. This resulted in a heap greater than 11GB.

To avoid this problem this patch adds cleans `destroyed_at_fork` at the end, at the beginning (useless, but it seems cleaner) and during each loop.
