### PR TITLE
Allow automatic re-running of failed tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -527,6 +527,8 @@ Features wishes:
   of a type error clash. (Hugo Heuzard)
 - GPR#383: configure: define _ALL_SOURCE for build on AIX7.1
   (tkob)
+- GPR#401: automatically retry failed test directories in the testsuite
+  (David Allsopp)
 
 Build system:
 - GPR#388: FlexDLL added as a Git submodule and bootstrappable with the compiler

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -190,3 +190,4 @@ CTOPDIR=$(TOPDIR)
 CYGPATH=cygpath -m
 DIFF=diff -q --strip-trailing-cr
 SET_LD_PATH=PATH="$(PATH):$(LD_PATH)"
+MAX_TESTSUITE_DIR_RETRIES=1

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -190,3 +190,4 @@ CTOPDIR=$(TOPDIR)
 CYGPATH=cygpath -m
 DIFF=diff -q --strip-trailing-cr
 SET_LD_PATH=PATH="$(PATH):$(LD_PATH)"
+MAX_TESTSUITE_DIR_RETRIES=1

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -194,3 +194,4 @@ DIFF=diff -q --strip-trailing-cr
 FIND=/usr/bin/find
 SORT=/usr/bin/sort
 SET_LD_PATH=PATH="$(PATH):$(LD_PATH)"
+MAX_TESTSUITE_DIR_RETRIES=1

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -198,3 +198,4 @@ DIFF=diff -q --strip-trailing-cr
 FIND=/usr/bin/find
 SORT=/usr/bin/sort
 SET_LD_PATH=PATH="$(PATH):$(LD_PATH)"
+MAX_TESTSUITE_DIR_RETRIES=1

--- a/configure
+++ b/configure
@@ -52,6 +52,7 @@ native_compiler=true
 TOOLPREF=""
 with_cfi=true
 flambda=false
+max_testsuite_dir_retries=0
 
 # Try to turn internationalization off, can cause config.guess to malfunction!
 unset LANG
@@ -1810,6 +1811,7 @@ if [ "$ostype" = Cygwin ]; then
   echo "DIFF=diff -q --strip-trailing-cr" >>Makefile
 fi
 echo "FLAMBDA=$flambda" >> Makefile
+echo "MAX_TESTSUITE_DIR_RETRIES=$max_testsuite_dir_retries" >> Makefile
 
 
 rm -f tst hasgot.c

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -21,42 +21,31 @@ include ../config/Makefile
 default:
 	@echo "Available targets:"
 	@echo "  all             launch all tests"
+	@echo "  all-foo         launch all tests beginning with foo"
 	@echo "  list FILE=f     launch the tests listed in f (one per line)"
 	@echo "  one DIR=p       launch the tests located in path p"
 	@echo "  promote DIR=p   promote the reference files for the tests in p"
 	@echo "  lib             build library modules"
 	@echo "  clean           delete generated files"
 	@echo "  report          print the report for the last execution"
+	@echo
+	@echo "all* and list can automatically re-run failed test directories if"
+	@echo "MAX_TESTSUITE_DIR_RETRIES permits (default value = $(MAX_TESTSUITE_DIR_RETRIES))"
 
 .PHONY: all
 all: lib
 	@for dir in tests/*; do \
 	  $(MAKE) $(NO_PRINT) exec-one DIR=$$dir; \
 	done 2>&1 | tee _log
+	@$(MAKE) $(NO_PRINT) retries
 	@$(MAKE) report
 
-all-basic: lib
-	@for dir in tests/basic*; do \
+.PHONY: all-%
+all-%: lib
+	@for dir in tests/$**; do \
 	  $(MAKE) $(NO_PRINT) exec-one DIR=$$dir; \
 	done 2>&1 | tee _log
-	@$(MAKE) report
-
-all-lib: lib
-	@for dir in tests/lib-*; do \
-	  $(MAKE) $(NO_PRINT) exec-one DIR=$$dir; \
-	done 2>&1 | tee _log
-	@$(MAKE) report
-
-all-typing: lib
-	@for dir in tests/typing-*; do \
-	  $(MAKE) $(NO_PRINT) exec-one DIR=$$dir; \
-	done 2>&1 | tee _log
-	@$(MAKE) report
-
-all-tool: lib
-	@for dir in tests/tool-*; do \
-	  $(MAKE) $(NO_PRINT) exec-one DIR=$$dir; \
-	done 2>&1 | tee _log
+	@$(MAKE) $(NO_PRINT) retries
 	@$(MAKE) report
 
 .PHONY: list
@@ -68,6 +57,7 @@ list: lib
 	@while read LINE; do \
 	  $(MAKE) $(NO_PRINT) exec-one DIR=$$LINE; \
 	done <$(FILE) 2>&1 | tee _log
+	@$(MAKE) $(NO_PRINT) retries
 	@$(MAKE) report
 
 .PHONY: one
@@ -94,6 +84,18 @@ exec-one:
 	  echo "Running tests from '$$DIR' ..."; \
 	  cd $(DIR) && \
 	  $(MAKE) TERM=dumb BASEDIR=$(BASEDIR) || echo '=> unexpected error'; \
+	fi
+
+.PHONY: clean-one
+clean-one:
+	@if [ ! -f $(DIR)/Makefile ]; then \
+	  for dir in $(DIR)/*; do \
+	    if [ -d $$dir ]; then \
+	      $(MAKE) clean-one DIR=$$dir; \
+	    fi; \
+	  done; \
+	else \
+	  cd $(DIR) && $(MAKE) TERM=dumb BASEDIR=$(BASEDIR) clean; \
 	fi
 
 .PHONY: promote
@@ -123,6 +125,21 @@ clean:
 report:
 	@if [ ! -f _log ]; then echo "No '_log' file."; exit 1; fi
 	@awk -f makefiles/summarize.awk <_log
+
+retry-list:
+	@while read LINE; do \
+	  if [ -n "$$LINE" ] ; then \
+	    echo re-ran $$LINE>>_log; \
+	    $(MAKE) $(NO_PRINT) clean-one DIR=$$LINE; \
+	    $(MAKE) $(NO_PRINT) exec-one DIR=$$LINE 2>&1 | tee -a _log ; \
+	  fi \
+	done <_retries;
+	@$(MAKE) $(NO_PRINT) retries
+
+retries:
+	@awk -v retries=1 -v max_retries=$(MAX_TESTSUITE_DIR_RETRIES) -f makefiles/summarize.awk <_log >_retries
+	@test `cat _retries | wc -l` -eq 0 || $(MAKE) $(NO_PRINT) retry-list
+	@rm -f _retries
 
 .PHONY: empty
 empty:

--- a/testsuite/makefiles/Makefile.one
+++ b/testsuite/makefiles/Makefile.one
@@ -34,7 +34,8 @@ C_INCLUDES+=-I $(CTOPDIR)/byterun
 .PHONY: default
 default:
 	@$(MAKE) compile
-	@$(SET_LD_PATH) $(MAKE) run
+	@$(NATIVECODE_ONLY) && $(BYTECODE_ONLY) && echo " ... testing => skipped" || \
+	$(SET_LD_PATH) $(MAKE) run
 
 .PHONY: compile
 compile: $(ML_FILES)

--- a/testsuite/makefiles/Makefile.several
+++ b/testsuite/makefiles/Makefile.several
@@ -27,10 +27,14 @@ ADD_OPTFLAGS+=$(FORTRAN_LIB)
 
 C_INCLUDES+=-I $(CTOPDIR)/byterun -I$(CTOPDIR)/otherlibs/bigarray
 
+SKIP=false
+
 .PHONY: check
 check:
 	@if [ -n "$(FORTRAN_COMPILER)" -o -z "$(F_FILES)" ]; then \
 	  $(SET_LD_PATH) $(MAKE) run-all; \
+	else \
+	  $(MAKE) C_FILES= F_FILES= SKIP=true run-all; \
 	fi
 
 .PHONY: run-all
@@ -42,10 +46,16 @@ run-all:
 	  $(FORTRAN_COMPILER) -c $$file.f; \
 	done;
 	@for file in *.ml; do \
-	  if [ -f `basename $$file ml`precheck ]; then \
-	    TOOLCHAIN=$(TOOLCHAIN) sh `basename $$file ml`precheck || continue; \
-	  fi; \
 	  printf " ... testing '$$file':"; \
+	  if $(SKIP) ; then \
+	    echo " => skipped"; continue; \
+	  fi; \
+	  if [ -f `basename $$file ml`precheck ]; then \
+	    if ! TOOLCHAIN=$(TOOLCHAIN) sh `basename $$file ml`precheck ; then \
+	      echo " => skipped"; \
+	      continue; \
+	    fi; \
+	  fi; \
 	  $(MAKE) run-file DESC=ocamlc COMP='$(OCAMLC)' \
 	          RUNTIME='$(MYRUNTIME)' \
 	          COMPFLAGS='-w a $(ADD_COMPFLAGS) $(ADD_CFLAGS) $(O_FILES) \

--- a/testsuite/makefiles/summarize.awk
+++ b/testsuite/makefiles/summarize.awk
@@ -117,18 +117,26 @@ END {
     }else{
         if (!retries){
             for (key in RESULTS){
-                switch (RESULTS[key]) {
-                case "p":
+                r = RESULTS[key];
+                if (r == "p"){
                     ++ passed;
-                    break
-                case "f":
+                }else if (r == "f"){
                     ++ failed;
                     fail[failidx++] = key;
-                    break
-                case "e":
+                }else if (r == "e"){
                     ++ unexped;
                     unexp[unexpidx++] = key;
-                    break
+                }else if (r == "s"){
+                    ++ skipped;
+                    curdir = DIRS[key];
+                    if (curdir in SKIPPED){
+                        if (SKIPPED[curdir]){
+                            SKIPPED[curdir] = 0;
+                            skips[skipidx++] = curdir;
+                        }
+                    }else{
+                        skips[skipidx++] = key;
+                    }
                 }
             }
             printf("\n");

--- a/testsuite/makefiles/summarize.awk
+++ b/testsuite/makefiles/summarize.awk
@@ -142,13 +142,13 @@ END {
             }
             printf("\n");
             printf("Summary:\n");
-            printf("  %3d test(s) passed\n", passed);
-            printf("  %3d test(s) skipped\n", skipped);
-            printf("  %3d test(s) failed\n", failed);
-            printf("  %3d unexpected error(s)\n", unexped);
+            printf("  %3d test%s passed\n", passed, (passed == 1 ? "" : "s"));
+            printf("  %3d test%s skipped\n", skipped, (skipped == 1 ? "" : "s"));
+            printf("  %3d test%s failed\n", failed, (failed == 1 ? "" : "s"));
+            printf("  %3d unexpected error%s\n", unexped, (unexped == 1 ? "" : "s"));
             printf("  %3d tests considered%s\n", length(RESULTS), (length(RESULTS) != passed + skipped + failed + unexped ? " (totals don't add up??)": ""));
             if (reran != 0){
-                printf("  %3d test dir re-run(s)\n", reran);
+                printf("  %3d test dir re-run%s\n", reran, (reran == 1 ? "" : "s"));
             }
             if (failed != 0){
                 printf("\nList of failed tests:\n");
@@ -164,7 +164,7 @@ END {
             }
             printf("\n");
             if (failed || unexped){
-                printf("#### Some tests failed. Exiting with error status.\n\n");
+                printf("#### Something failed. Exiting with error status.\n\n");
                 exit 4;
             }
         }else{

--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -27,7 +27,7 @@ OBJS=parsecmmaux.cmo parsecmm.cmo lexcmm.cmo
 ADD_COMPFLAGS=$(INCLUDES) -w -40 -g
 
 default:
-	@if $(BYTECODE_ONLY) ; then : ; else \
+	@if $(BYTECODE_ONLY) || $(SKIP) ; then $(MAKE) skips ; else \
 	  $(MAKE) all; \
 	fi
 
@@ -60,6 +60,11 @@ ARGS_tagged-fib=-DINT_INT -DFUN=fib main.c
 ARGS_tagged-integr=-DINT_FLOAT -DFUN=test main.c
 ARGS_tagged-quicksort=-DSORT -DFUN=quicksort main.c
 ARGS_tagged-tak=-DUNIT_INT -DFUN=takmain main.c
+
+skips:
+	@for c in $(CASES) $(MLCASES); do \
+	  echo " ... testing '$$c': => skipped"; \
+	done
 
 one_ml:
 	@$(OCAMLOPT) -o $(NAME).exe $(NAME).ml && \

--- a/testsuite/tests/backtrace/Makefile
+++ b/testsuite/tests/backtrace/Makefile
@@ -21,7 +21,7 @@ OTHERFILESNOINLINING_NATIVE=backtraces_and_finalizers.ml
 
 default:
 	@$(MAKE) byte
-	@if $(BYTECODE_ONLY); then : ; else $(MAKE) native; fi
+	@if $(BYTECODE_ONLY); then $(MAKE) skip ; else $(MAKE) native; fi
 
 .PHONY: byte
 byte:
@@ -48,6 +48,17 @@ byte:
 	       >$$F.byte.result 2>&1; \
 	  $(DIFF) $$F.reference $$F.byte.result >/dev/null \
 	  && echo " => passed" || echo " => failed"; \
+	done
+
+.PHONY: skip
+skip:
+	@for file in $(ABCDFILES); do \
+	  for arg in a b c d ''; do \
+	    echo " ... testing '$$file' with ocamlopt and argument '$$arg': => skipped"; \
+	  done; \
+	done
+	@for file in $(OTHERFILES) $(OTHERFILESNOINLINING) $(OTHERFILESNOINLINING_NATIVE); do \
+	  echo " ... testing '$$file' with ocamlopt: => skipped"; \
 	done
 
 .PHONY: native

--- a/testsuite/tests/callback/Makefile
+++ b/testsuite/tests/callback/Makefile
@@ -21,11 +21,18 @@ default:
 	@case " $(OTHERLIBRARIES) " in \
 	  *' unix '*) $(SET_LD_PATH) $(MAKE) run-byte; \
 	              $(SET_LD_PATH) $(MAKE) run-opt;; \
+	  *) $(MAKE) skip;; \
 	esac
 
 .PHONY: common
 common:
 	@$(CC) -c callbackprim.c
+
+.PHONY: skip
+skip:
+	@for c in bytecode native; do \
+	  echo " ... testing '$$c': => skipped" ; \
+	done
 
 .PHONY: run-byte
 run-byte: common

--- a/testsuite/tests/lib-dynlink-csharp/Makefile
+++ b/testsuite/tests/lib-dynlink-csharp/Makefile
@@ -16,15 +16,8 @@ CSC=csc
 COMPFLAGS=-I $(OTOPDIR)/otherlibs/bigarray
 LD_PATH=$(TOPDIR)/otherlibs/bigarray
 
-.PHONY: default
 default:
-	@if ! $(SUPPORTS_SHARED_LIBRARIES); then \
-	  echo 'skipped (shared libraries not available)'; \
-	elif $(BYTECODE_ONLY); then \
-	  echo 'skipped (native compiler not available)' ; \
-	else \
-	  $(SET_LD_PATH) $(MAKE) all; \
-	fi
+	@$(SET_LD_PATH) $(MAKE) all
 
 .PHONY: all
 all: prepare bytecode bytecode-dll native native-dll
@@ -37,7 +30,7 @@ prepare:
 .PHONY: bytecode
 bytecode:
 	@printf " ... testing 'bytecode':"
-	@if [ ! `which $(CSC) >/dev/null 2>&1` ]; then \
+	@if ! $(SUPPORTS_SHARED_LIBRARIES) || [ ! `which $(CSC) >/dev/null 2>&1` ]; then \
 	  echo " => skipped"; \
 	else \
 	  $(OCAMLC) -output-obj -o main.dll dynlink.cma main.ml entry.c; \
@@ -50,7 +43,7 @@ bytecode:
 .PHONY: bytecode-dll
 bytecode-dll:
 	@printf " ... testing 'bytecode-dll':"
-	@if [ ! `which $(CSC) > /dev/null 2>&1` ]; then \
+	@if ! $(SUPPORTS_SHARED_LIBRARIES) || [ ! `which $(CSC) > /dev/null 2>&1` ]; then \
 	  echo " => skipped"; \
 	else \
 	  $(OCAMLC) -output-obj -o main_obj.$(O) dynlink.cma entry.c main.ml; \
@@ -65,7 +58,7 @@ bytecode-dll:
 .PHONY: native
 native:
 	@printf " ... testing 'native':"
-	@if [ ! `which $(CSC) > /dev/null 2>&1` ]; then \
+	@if ! $(SUPPORTS_SHARED_LIBRARIES) || $(BYTECODE_ONLY) || [ ! `which $(CSC) > /dev/null 2>&1` ]; then \
 	  echo " => skipped"; \
 	else \
 	  $(OCAMLOPT) -output-obj -o main.dll dynlink.cmxa entry.c main.ml; \
@@ -78,7 +71,7 @@ native:
 .PHONY: native-dll
 native-dll:
 	@printf " ... testing 'native-dll':"
-	@if [ ! `which $(CSC) > /dev/null 2>&1` ]; then \
+	@if ! $(SUPPORTS_SHARED_LIBRARIES) || $(BYTECODE_ONLY) || [ ! `which $(CSC) > /dev/null 2>&1` ]; then \
 	  echo " => skipped"; \
 	else \
 	  $(OCAMLOPT) -output-obj -o main_obj.$(O) dynlink.cmxa entry.c \

--- a/testsuite/tests/lib-dynlink-native/Makefile
+++ b/testsuite/tests/lib-dynlink-native/Makefile
@@ -20,10 +20,8 @@ LD_PATH = $(TOPDIR)/otherlibs/$(UNIXLIBVAR)unix:$(TOPDIR)/otherlibs/systhreads\
 
 .PHONY: default
 default:
-	@if ! $(SUPPORTS_SHARED_LIBRARIES); then \
-	  echo 'skipped (shared libraries not available)'; \
-	elif $(BYTECODE_ONLY); then \
-	  echo 'skipped (native compiler not available)' ; \
+	@if ! $(SUPPORTS_SHARED_LIBRARIES) || $(BYTECODE_ONLY) ; then \
+	  echo " ... testing 'main' => skipped"; \
 	else \
 	   $(SET_LD_PATH) $(MAKE) all; \
 	fi

--- a/testsuite/tests/opaque/Makefile
+++ b/testsuite/tests/opaque/Makefile
@@ -14,9 +14,16 @@ BASEDIR=../..
 
 .PHONY: default
 default:
-	@if $(BYTECODE_ONLY); then : ; else \
+	@if $(BYTECODE_ONLY); then $(MAKE) skip ; else \
 	  $(MAKE) compile; \
 	fi
+
+.PHONY: skip
+skip:
+	@echo " ... testing 'test' with ordinary compilation => skipped"
+	@echo " ... testing 'test' with change to opaque interface => skipped"
+	@echo " ... testing 'test' with change to opaque implementation => skipped"
+	@echo " ... testing 'test' with change to non-opaque implementation => skipped"
 
 .PHONY: compile
 compile:

--- a/testsuite/tests/runtime-errors/Makefile
+++ b/testsuite/tests/runtime-errors/Makefile
@@ -52,7 +52,7 @@ run:
 	    echo " => unexpected error"; \
 	  fi; \
 	  fn=`basename $$f bytecode`native; \
-	  if $(BYTECODE_ONLY) || [ ! -f "$${fn}$(EXE)" ] ; then : ; else \
+	  if $(BYTECODE_ONLY) || [ ! -f "$${fn}$(EXE)" ] ; then echo " ... testing '$$fn': => skipped" ; else \
 	    printf " ... testing '$$fn':"; \
 	    if [ $$ul -eq 1 ] ; then \
 	      ./$${fn}$(EXE) >$$fn.result 2>&1 || true; \

--- a/testsuite/tests/warnings/Makefile
+++ b/testsuite/tests/warnings/Makefile
@@ -23,13 +23,15 @@ run-all:
 	  $(DIFF) $$F.reference $$F.result >/dev/null \
 	  && echo " => passed" || echo " => failed"; \
 	done;
-	@if $(BYTECODE_ONLY); then :; else for file in *.opt.ml; do \
+	@for file in *.opt.ml; do \
 	  printf " ... testing '$$file' with ocamlopt:"; \
-	  F="`basename $$file .ml`"; \
-	  $(OCAMLOPT) $(FLAGS) -c $$file 2>$$F.opt_result; \
-	  $(DIFF) $$F.opt_reference $$F.opt_result >/dev/null \
-	  && echo " => passed" || echo " => failed"; \
-	done fi;
+	  if $(BYTECODE_ONLY); then echo " => skipped"; else \
+	    F="`basename $$file .ml`"; \
+	    $(OCAMLOPT) $(FLAGS) -c $$file 2>$$F.opt_result; \
+	    $(DIFF) $$F.opt_reference $$F.opt_result >/dev/null \
+	    && echo " => passed" || echo " => failed"; \
+	  fi \
+	done;
 
 promote: defaultpromote
 


### PR DESCRIPTION
Various tests are documented as occasionally failing (e.g. lib-threads) - some commands, especially in the Windows ports, can fail randomly and simply need to be re-run.
This patch adds a `MAX_RETRIES` setting to `testsuite/Makefile` which permits automatically re-running an entire directory of tests up `MAX_RETRIES` times if any of the tests fail. The summary-generator is updated to display the union of all the test results - i.e. if a test passes in any of the runs, then it is deemed to have passed.
May hopefully provide a slightly more reliable (or quiet) testsuite mode for Windows CI builds.
I tried an earlier version for re-running the specific test that failed, rather than the entire directory, but that very quickly became a very invasive change...
