### PR TITLE
Add Ast_helper.Const

### DIFF
--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -29,6 +29,17 @@ let with_default_loc l f =
   try let r = f () in default_loc := old; r
   with exn -> default_loc := old; raise exn
 
+module Const = struct
+  let integer ?suffix i = Pconst_integer (i, suffix)
+  let int ?suffix i = integer ?suffix (string_of_int i)
+  let int32 ?(suffix='l') i = integer ~suffix (Int32.to_string i)
+  let int64 ?(suffix='L') i = integer ~suffix (Int64.to_string i)
+  let nativeint ?(suffix='n') i = integer ~suffix (Nativeint.to_string i)
+  let float ?suffix f = Pconst_float (f, suffix)
+  let char c = Pconst_char c
+  let string ?quotation_delimiter s = Pconst_string (s, quotation_delimiter)
+end
+
 module Typ = struct
   let mk ?(loc = !default_loc) ?(attrs = []) d =
     {ptyp_desc = d; ptyp_loc = loc; ptyp_attributes = attrs}

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -30,6 +30,19 @@ val with_default_loc: loc -> (unit -> 'a) -> 'a
     (** Set the [default_loc] within the scope of the execution
         of the provided function. *)
 
+(** {2 Constants} *)
+
+module Const : sig
+  val char : char -> constant
+  val string : ?quotation_delimiter:string -> string -> constant
+  val integer : ?suffix:char -> string -> constant
+  val int : ?suffix:char -> int -> constant
+  val int32 : ?suffix:char -> int32 -> constant
+  val int64 : ?suffix:char -> int64 -> constant
+  val nativeint : ?suffix:char -> nativeint -> constant
+  val float : ?suffix:char -> string -> constant
+end
+
 (** {2 Core language} *)
 
 (** Type expressions *)

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -626,13 +626,13 @@ let default_mapper =
 
 let rec extension_of_error {loc; msg; if_highlight; sub} =
   { loc; txt = "ocaml.error" },
-  PStr ([Str.eval (Exp.constant (PConst_string (msg, None)));
-         Str.eval (Exp.constant (PConst_string (if_highlight, None)))] @
+  PStr ([Str.eval (Exp.constant (Pconst_string (msg, None)));
+         Str.eval (Exp.constant (Pconst_string (if_highlight, None)))] @
         (List.map (fun ext -> Str.extension (extension_of_error ext)) sub))
 
 let attribute_of_warning loc s =
   { loc; txt = "ocaml.ppwarning" },
-  PStr ([Str.eval ~loc (Exp.constant (PConst_string (s, None)))])
+  PStr ([Str.eval ~loc (Exp.constant (Pconst_string (s, None)))])
 
 module StringMap = Map.Make(struct
     type t = string
@@ -660,7 +660,7 @@ module PpxContext = struct
 
   let lid name = { txt = Lident name; loc = Location.none }
 
-  let make_string x = Exp.constant (PConst_string (x, None))
+  let make_string x = Exp.constant (Pconst_string (x, None))
 
   let make_bool x =
     if x
@@ -715,7 +715,7 @@ module PpxContext = struct
   let restore fields =
     let field name payload =
       let rec get_string = function
-        | { pexp_desc = Pexp_constant (PConst_string (str, None)) } -> str
+        | { pexp_desc = Pexp_constant (Pconst_string (str, None)) } -> str
         | _ -> raise_errorf "Internal error: invalid [@@@ocaml.ppx.context \
                              { %s }] string syntax" name
       and get_bool pexp =

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -14,7 +14,7 @@ open Asttypes
 open Parsetree
 
 let string_of_cst = function
-  | PConst_string(s, _) -> Some s
+  | Pconst_string(s, _) -> Some s
   | _ -> None
 
 let string_of_payload = function
@@ -37,13 +37,13 @@ let rec error_of_extension ext =
     in
     begin match p with
     | PStr({pstr_desc=Pstr_eval
-              ({pexp_desc=Pexp_constant(PConst_string(msg,_))}, _)}::
+              ({pexp_desc=Pexp_constant(Pconst_string(msg,_))}, _)}::
            {pstr_desc=Pstr_eval
-              ({pexp_desc=Pexp_constant(PConst_string(if_highlight,_))}, _)}::
+              ({pexp_desc=Pexp_constant(Pconst_string(if_highlight,_))}, _)}::
            inner) ->
         Location.error ~loc ~if_highlight ~sub:(sub_from inner) msg
     | PStr({pstr_desc=Pstr_eval
-              ({pexp_desc=Pexp_constant(PConst_string(msg,_))}, _)}::inner) ->
+              ({pexp_desc=Pexp_constant(Pconst_string(msg,_))}, _)}::inner) ->
         Location.error ~loc ~sub:(sub_from inner) msg
     | _ -> Location.errorf ~loc "Invalid syntax for extension '%s'." txt
     end
@@ -113,7 +113,7 @@ let emit_external_warnings =
         begin match a with
         | {txt="ocaml.ppwarning"|"ppwarning"},
           PStr[{pstr_desc=Pstr_eval({pexp_desc=Pexp_constant
-                                         (PConst_string (s, _))},_);
+                                         (Pconst_string (s, _))},_);
                 pstr_loc}] ->
             Location.prerr_warning pstr_loc (Warnings.Preprocessor s)
         | _ -> ()

--- a/parsing/docstrings.ml
+++ b/parsing/docstrings.ml
@@ -85,7 +85,7 @@ let doc_loc = {txt = "ocaml.doc"; loc = Location.none}
 let docs_attr ds =
   let open Parsetree in
   let exp =
-    { pexp_desc = Pexp_constant (PConst_string(ds.ds_body, None));
+    { pexp_desc = Pexp_constant (Pconst_string(ds.ds_body, None));
       pexp_loc = ds.ds_loc;
       pexp_attributes = []; }
   in
@@ -134,7 +134,7 @@ let text_loc = {txt = "ocaml.text"; loc = Location.none}
 let text_attr ds =
   let open Parsetree in
   let exp =
-    { pexp_desc = Pexp_constant (PConst_string(ds.ds_body, None));
+    { pexp_desc = Pexp_constant (Pconst_string(ds.ds_body, None));
       pexp_loc = ds.ds_loc;
       pexp_attributes = []; }
   in

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -79,18 +79,18 @@ let neg_string f =
 
 let mkuminus name arg =
   match name, arg.pexp_desc with
-  | "-", Pexp_constant(PConst_int (n,m)) ->
-      mkexp(Pexp_constant(PConst_int(neg_string n,m)))
-  | ("-" | "-."), Pexp_constant(PConst_float (f, m)) ->
-      mkexp(Pexp_constant(PConst_float(neg_string f, m)))
+  | "-", Pexp_constant(Pconst_integer (n,m)) ->
+      mkexp(Pexp_constant(Pconst_integer(neg_string n,m)))
+  | ("-" | "-."), Pexp_constant(Pconst_float (f, m)) ->
+      mkexp(Pexp_constant(Pconst_float(neg_string f, m)))
   | _ ->
       mkexp(Pexp_apply(mkoperator ("~" ^ name) 1, [Nolabel, arg]))
 
 let mkuplus name arg =
   let desc = arg.pexp_desc in
   match name, desc with
-  | "+", Pexp_constant(PConst_int _)
-  | ("+" | "+."), Pexp_constant(PConst_float _) -> mkexp desc
+  | "+", Pexp_constant(Pconst_integer _)
+  | ("+" | "+."), Pexp_constant(Pconst_float _) -> mkexp desc
   | _ ->
       mkexp(Pexp_apply(mkoperator ("~" ^ name) 1, [Nolabel, arg]))
 
@@ -2169,17 +2169,17 @@ label:
 /* Constants */
 
 constant:
-  | INT                               { let (n, m) = $1 in PConst_int (n, m) }
-  | CHAR                              { PConst_char $1 }
-  | STRING                            { let (s, d) = $1 in PConst_string (s, d) }
-  | FLOAT                             { let (f, m) = $1 in PConst_float (f, m) }
+  | INT                               { let (n, m) = $1 in Pconst_integer (n, m) }
+  | CHAR                              { Pconst_char $1 }
+  | STRING                            { let (s, d) = $1 in Pconst_string (s, d) }
+  | FLOAT                             { let (f, m) = $1 in Pconst_float (f, m) }
 ;
 signed_constant:
     constant                               { $1 }
-  | MINUS INT                              { let (n, m) = $2 in PConst_int("-" ^ n, m) }
-  | MINUS FLOAT                            { let (f, m) = $2 in PConst_float("-" ^ f, m) }
-  | PLUS INT                               { let (n, m) = $2 in PConst_int (n, m) }
-  | PLUS FLOAT                             { let (f, m) = $2 in PConst_float(f, m) }
+  | MINUS INT                              { let (n, m) = $2 in Pconst_integer("-" ^ n, m) }
+  | MINUS FLOAT                            { let (f, m) = $2 in Pconst_float("-" ^ f, m) }
+  | PLUS INT                               { let (n, m) = $2 in Pconst_integer (n, m) }
+  | PLUS FLOAT                             { let (f, m) = $2 in Pconst_float(f, m) }
 ;
 
 /* Identifiers and long identifiers */

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -15,19 +15,19 @@
 open Asttypes
 
 type constant =
-    PConst_int of string * char option
+    Pconst_integer of string * char option
   (* 3 3l 3L 3n
 
      Suffixes [g-z][G-Z] are accepted by the parser.
      Suffixes except 'l', 'L' and 'n' are rejected by the typechecker
   *)
-  | PConst_char of char
+  | Pconst_char of char
   (* 'c' *)
-  | PConst_string of string * string option
+  | Pconst_string of string * string option
   (* "constant"
      {delim|other constant|delim}
   *)
-  | PConst_float of string * char option
+  | Pconst_float of string * char option
   (* 3.4 2e5 1.4e-4
 
      Suffixes [g-z][G-Z] are accepted by the parser.

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -16,9 +16,23 @@ open Asttypes
 
 type constant =
     PConst_int of string * char option
+  (* 3 3l 3L 3n
+
+     Suffixes [g-z][G-Z] are accepted by the parser.
+     Suffixes except 'l', 'L' and 'n' are rejected by the typechecker
+  *)
   | PConst_char of char
+  (* 'c' *)
   | PConst_string of string * string option
+  (* "constant"
+     {delim|other constant|delim}
+  *)
   | PConst_float of string * char option
+  (* 3.4 2e5 1.4e-4
+
+     Suffixes [g-z][G-Z] are accepted by the parser.
+     Suffixes are rejected by the typechecker.
+  *)
 
 (** {2 Extension points} *)
 

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -168,13 +168,13 @@ class printer  ()= object(self:'self)
         pp f "%a(%a)" self#longident y self#longident s
   method longident_loc f x = pp f "%a" self#longident x.txt
   method constant f  = function
-    | PConst_char i -> pp f "%C"  i
-    | PConst_string (i, None) -> pp f "%S" i
-    | PConst_string (i, Some delim) -> pp f "{%s|%s|%s}" delim i delim
-    | PConst_int (i,None) -> self#paren (i.[0]='-') (fun f -> pp f "%s") f i
-    | PConst_int (i,Some m) -> self#paren (i.[0]='-') (fun f (i,m) -> pp f "%s%c" i m) f (i,m)
-    | PConst_float (i,None) -> self#paren (i.[0]='-') (fun f -> pp f "%s") f i
-    | PConst_float (i, Some m) -> self#paren (i.[0]='-') (fun f (i,m) -> pp f "%s%c" i m) f (i,m)
+    | Pconst_char i -> pp f "%C"  i
+    | Pconst_string (i, None) -> pp f "%S" i
+    | Pconst_string (i, Some delim) -> pp f "{%s|%s|%s}" delim i delim
+    | Pconst_integer (i,None) -> self#paren (i.[0]='-') (fun f -> pp f "%s") f i
+    | Pconst_integer (i,Some m) -> self#paren (i.[0]='-') (fun f (i,m) -> pp f "%s%c" i m) f (i,m)
+    | Pconst_float (i,None) -> self#paren (i.[0]='-') (fun f -> pp f "%s") f i
+    | Pconst_float (i, Some m) -> self#paren (i.[0]='-') (fun f (i,m) -> pp f "%s%c" i m) f (i,m)
 
   (* trailing space*)
   method mutable_flag f   = function

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -55,12 +55,12 @@ let fmt_char_option f = function
 
 let fmt_constant f x =
   match x with
-  | PConst_int (i,m) -> fprintf f "PConst_int (%s,%a)" i fmt_char_option m;
-  | PConst_char (c) -> fprintf f "PConst_char %02x" (Char.code c);
-  | PConst_string (s, None) -> fprintf f "PConst_string(%S,None)" s;
-  | PConst_string (s, Some delim) ->
+  | Pconst_integer (i,m) -> fprintf f "PConst_int (%s,%a)" i fmt_char_option m;
+  | Pconst_char (c) -> fprintf f "PConst_char %02x" (Char.code c);
+  | Pconst_string (s, None) -> fprintf f "PConst_string(%S,None)" s;
+  | Pconst_string (s, Some delim) ->
       fprintf f "PConst_string (%S,Some %S)" s delim;
-  | PConst_float (s,m) -> fprintf f "PConst_float (%s,%a)" s fmt_char_option m;
+  | Pconst_float (s,m) -> fprintf f "PConst_float (%s,%a)" s fmt_char_option m;
 ;;
 
 let fmt_mutable_flag f x =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -265,31 +265,31 @@ let type_constant = function
   | Const_nativeint _ -> instance_def Predef.type_nativeint
 
 let constant : Parsetree.constant -> (Asttypes.constant, error) result = function
-  | PConst_int (i,None) ->
+  | Pconst_integer (i,None) ->
      begin
        try Ok (Const_int (Misc.Int_literal_converter.int i))
        with Failure _ -> Error (Literal_overflow "int")
      end
-  | PConst_int (i,Some 'l') ->
+  | Pconst_integer (i,Some 'l') ->
      begin
        try Ok (Const_int32 (Misc.Int_literal_converter.int32 i))
        with Failure _ -> Error (Literal_overflow "int32")
      end
-  | PConst_int (i,Some 'L') ->
+  | Pconst_integer (i,Some 'L') ->
      begin
        try Ok (Const_int64 (Misc.Int_literal_converter.int64 i))
        with Failure _ -> Error (Literal_overflow "int64")
      end
-  | PConst_int (i,Some 'n') ->
+  | Pconst_integer (i,Some 'n') ->
      begin
        try Ok (Const_nativeint (Misc.Int_literal_converter.nativeint i))
        with Failure _ -> Error (Literal_overflow "nativeint")
      end
-  | PConst_int (i,Some c) -> Error (Unknown_literal (i, c))
-  | PConst_char c -> Ok (Const_char c)
-  | PConst_string (s,d) -> Ok (Const_string (s,d))
-  | PConst_float (f,None)-> Ok (Const_float f)
-  | PConst_float (f,Some c) -> Error (Unknown_literal (f, c))
+  | Pconst_integer (i,Some c) -> Error (Unknown_literal (i, c))
+  | Pconst_char c -> Ok (Const_char c)
+  | Pconst_string (s,d) -> Ok (Const_string (s,d))
+  | Pconst_float (f,None)-> Ok (Const_float f)
+  | Pconst_float (f,Some c) -> Error (Unknown_literal (f, c))
 
 let constant_or_raise env loc cst =
   match constant cst with
@@ -1070,14 +1070,14 @@ let rec type_pat ~constrs ~labels ~no_existentials ~mode ~explode ~env
         pat_type = expected_ty;
         pat_attributes = sp.ppat_attributes;
         pat_env = !env }
-  | Ppat_interval (PConst_char c1, PConst_char c2) ->
+  | Ppat_interval (Pconst_char c1, Pconst_char c2) ->
       let open Ast_helper.Pat in
       let gloc = {loc with Location.loc_ghost=true} in
       let rec loop c1 c2 =
-        if c1 = c2 then constant ~loc:gloc (PConst_char c1)
+        if c1 = c2 then constant ~loc:gloc (Pconst_char c1)
         else
           or_ ~loc:gloc
-            (constant ~loc:gloc (PConst_char c1))
+            (constant ~loc:gloc (Pconst_char c1))
             (loop (Char.chr(Char.code c1 + 1)) c2)
       in
       let p = if c1 <= c2 then loop c1 c2 else loop c2 c1 in
@@ -1948,7 +1948,7 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
           exp_attributes = sexp.pexp_attributes;
           exp_env = env }
       end
-  | Pexp_constant(PConst_string (str, _) as cst) -> (
+  | Pexp_constant(Pconst_string (str, _) as cst) -> (
     let cst = constant_or_raise env loc cst in
     (* Terrible hack for format strings *)
     let ty_exp = expand_head env ty_expected in
@@ -2990,9 +2990,9 @@ and type_format loc str env =
           | _ :: _ :: _ -> Some (mk_exp_loc (Pexp_tuple args)) in
         mk_exp_loc (Pexp_construct (mk_lid_loc lid, arg)) in
       let mk_cst cst = mk_exp_loc (Pexp_constant cst) in
-      let mk_int n = mk_cst (PConst_int (string_of_int n, None))
-      and mk_string str = mk_cst (PConst_string (str, None))
-      and mk_char chr = mk_cst (PConst_char chr) in
+      let mk_int n = mk_cst (Pconst_integer (string_of_int n, None))
+      and mk_string str = mk_cst (Pconst_string (str, None))
+      and mk_char chr = mk_cst (Pconst_char chr) in
       let rec mk_formatting_lit fmting = match fmting with
         | Close_box ->
           mk_constr "Close_box" []

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -113,13 +113,13 @@ let fresh_name s env =
 (** Mapping functions. *)
 
 let constant = function
-  | Const_char c -> PConst_char c
-  | Const_string (s,d) -> PConst_string (s,d)
-  | Const_int i -> PConst_int (string_of_int i, None)
-  | Const_int32 i -> PConst_int (Int32.to_string i, Some 'l')
-  | Const_int64 i -> PConst_int (Int64.to_string i, Some 'L')
-  | Const_nativeint i -> PConst_int (Nativeint.to_string i, Some 'n')
-  | Const_float f -> PConst_float (f,None)
+  | Const_char c -> Pconst_char c
+  | Const_string (s,d) -> Pconst_string (s,d)
+  | Const_int i -> Pconst_integer (string_of_int i, None)
+  | Const_int32 i -> Pconst_integer (Int32.to_string i, Some 'l')
+  | Const_int64 i -> Pconst_integer (Int64.to_string i, Some 'L')
+  | Const_nativeint i -> Pconst_integer (Nativeint.to_string i, Some 'n')
+  | Const_float f -> Pconst_float (f,None)
 
 let attribute sub (s, p) = (map_loc sub s, p)
 let attributes sub l = List.map (sub.attribute sub) l


### PR DESCRIPTION
The parsetree now has its own constant type. Additionally, the int and float constructors now take a string and an option, which is not the most convenient thing.
This small module add a few convenient functions for Parsetree.constant.

I considered adding int64 and int32 too, should I ?

I didn't added an entry to the changelog since it's a natural addition after @hhugo's changes.
