### PR TITLE
Fix compilation with Microsoft Universal CRT (Visual Studio 2015)

### DIFF
--- a/Changes
+++ b/Changes
@@ -447,6 +447,8 @@ Bug fixes:
   (Jérémie Dimino)
 - GPR#355: make ocamlnat build again
   (Jérémie Dimino, Thomas Refis)
+- GPR#405: fix compilation under Visual Studio 2015
+  (David Allsopp)
 
 Features wishes:
 - PR#4518, GPR#29: change location format for reporting errors in ocamldoc

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -196,7 +196,7 @@ extern void caml_set_fields (intnat v, unsigned long, unsigned long);
 
 /* snprintf emulation for Win32 */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(_UCRT)
 extern int caml_snprintf(char * buf, size_t size, const char * format, ...);
 #define snprintf caml_snprintf
 #endif

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -610,6 +610,7 @@ int caml_executable_name(char * name, int name_len)
 
 /* snprintf emulation */
 
+#if defined(_WIN32) && !defined(_UCRT)
 int caml_snprintf(char * buf, size_t size, const char * format, ...)
 {
   int len;
@@ -634,3 +635,4 @@ int caml_snprintf(char * buf, size_t size, const char * format, ...)
   va_end(args);
   return len;
 }
+#endif

--- a/stdlib/headernt.c
+++ b/stdlib/headernt.c
@@ -22,6 +22,10 @@
 #pragma comment(linker , "/entry:headerentry")
 #pragma comment(linker , "/subsystem:console")
 #pragma comment(lib , "kernel32")
+#ifdef _UCRT
+#pragma comment(lib , "ucrt.lib")
+#pragma comment(lib , "vcruntime.lib")
+#endif
 #endif
 
 char * default_runtime_name = RUNTIME_NAME;


### PR DESCRIPTION
Starting with Windows 10, Microsoft has moved large chunks of the CRT to a Windows system component called the Universal CRT. This contains the majority of the library functions - the portions necessary for a program runtime (e.g. main, etc.) remain in a separate library distributed with Visual Studio which is now called vcruntime, rather than msvcrt/msvcrun.

This means that in addition to `msvcrt.lib`, `ucrt.lib` and `vcruntime.lib` have to be linked. The linker handles this automatically in the vast majority of cases - 9a32fbc7b53956874b71c84d3e6521f276c6e347 fixes what appears to be an obscure case where it does not.

Additionally, the Universal CRT contains much better C99 support and in fact displays an error if snprintf is redefined.

These two patches together allow both the 32 and 64-bit ports to be built (as long as the flexdll_msvc.obj and flexdll_initer_msvc.obj have been recompiled using the Visual Studio 2015 C compiler).
