### PR TITLE
Stop ocaml{c,opt} -c foo.c displaying foo.c on stdout

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,7 +10,7 @@ Language features:
   Namely, the redundancy checker now checks whether the uncovered pattern
   of the pattern is actually inhabited, exploding at most one wild card.
   This is also done for exhaustiveness when there is only one case.
-  Additionnally, one can now write unreachable cases, of the form,
+  Additionally, one can now write unreachable cases, of the form,
   "pat -> .", which are treated by the redundancy check. (Jacques Garrigue)
 - PR#6374: allow "_ t" as a short-hand for "(_, _, ..) t" for n-ary type
   constructors (Alain Frisch)
@@ -101,8 +101,8 @@ Compilers:
 - PR#7067: Performance regression in the native compiler for long
   nested structures (Alain Frisch, report by Daniel Bünzli, review
   by Jacques Garrigue)
-- PR#7097:  Strange syntax error message around illegal packaged module signature
-  constraints (Alain Frisch, report by Jun Furuse)
+- PR#7097:  Strange syntax error message around illegal packaged module
+  signature constraints (Alain Frisch, report by Jun Furuse)
 - GPR#17: some cmm optimizations of integer operations with constants
   (Stephen Dolan, review by Pierre Chambart)
 - GPR#109: new unboxing strategy for float and int references (Vladimir Brankov,
@@ -138,6 +138,9 @@ Compilers:
   (Leo White)
 - PR#6920: fix debug informations around uses of %apply or %revapply
   (Jérémie Dimino)
+- GPR#407: don't display the name of compiled .c files when calling the
+  Microsoft C Compiler (same as the assembler).
+  (David Allsopp)
 
 Runtime system:
 - PR#3612: allow allocating custom block with finalizers in the minor heap

--- a/testsuite/makefiles/Makefile.one
+++ b/testsuite/makefiles/Makefile.one
@@ -29,7 +29,7 @@ CUSTOM_FLAG=`if [ -n "$(C_FILES)" ]; then echo '-custom'; fi`
 ADD_CFLAGS+=$(CUSTOM_FLAG)
 MYRUNTIME=`if [ -z "$(C_FILES)$(CUSTOM)" ]; then echo '$(OCAMLRUN)'; fi`
 
-CC=$(NATIVECC) $(NATIVECCCOMPOPTS)
+C_INCLUDES+=-I $(CTOPDIR)/byterun
 
 .PHONY: default
 default:
@@ -39,7 +39,7 @@ default:
 .PHONY: compile
 compile: $(ML_FILES)
 	@for file in $(C_FILES); do \
-	  $(NATIVECC) $(NATIVECCCOMPOPTS) -c -I$(CTOPDIR)/byterun $$file.c; \
+	  $(OCAMLC) -c $(C_INCLUDES) $$file.c; \
 	done;
 	@if $(NATIVECODE_ONLY); then : ; else \
 	  rm -f program.byte program.byte.exe; \

--- a/testsuite/makefiles/Makefile.several
+++ b/testsuite/makefiles/Makefile.several
@@ -36,7 +36,7 @@ check:
 .PHONY: run-all
 run-all:
 	@for file in $(C_FILES); do \
-	  $(CC) $(C_INCLUDES) -c $$file.c; \
+	  $(OCAMLC) -c $(C_INCLUDES) -c $$file.c; \
 	done;
 	@for file in $(F_FILES); do \
 	  $(FORTRAN_COMPILER) -c $$file.f; \

--- a/testsuite/tests/unboxed-primitive-args/Makefile
+++ b/testsuite/tests/unboxed-primitive-args/Makefile
@@ -15,6 +15,7 @@ LIBRARIES=unix bigarray
 MODULES=common
 MAIN_MODULE=main
 C_FILES=test_common stubs
+C_INCLUDES=-I $(OTOPDIR)/otherlibs/bigarray
 ADD_COMPFLAGS=-I $(OTOPDIR)/otherlibs/bigarray \
 	      -I $(OTOPDIR)/otherlibs/$(UNIXLIB)
 

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -48,25 +48,59 @@ let quote_optfile = function
   | None -> ""
   | Some f -> Filename.quote f
 
+let display_msvc_output file name =
+  let c = open_in file in
+  try
+    let first = input_line c in
+    if first <> name then
+      print_string first;
+    while true do
+      print_string (input_line c)
+    done
+  with _ ->
+    close_in c;
+    Sys.remove file
+
 let compile_file ~output_name name =
-  command
-    (Printf.sprintf
-       "%s%s -c %s %s %s %s %s"
-       (match !Clflags.c_compiler with
-        | Some cc -> cc
-        | None ->
-            if !Clflags.native_code
-            then Config.native_c_compiler
-            else Config.bytecomp_c_compiler)
-       (match output_name, Config.ccomp_type with
-          | Some n, "msvc" -> " /Fo" ^ Filename.quote n
-          | Some n, _ -> " -o " ^ Filename.quote n
-          | None, _ -> "")
-       (if !Clflags.debug && Config.ccomp_type <> "msvc" then "-g" else "")
-       (String.concat " " (List.rev !Clflags.all_ccopts))
-       (quote_prefixed "-I" (List.rev !Clflags.include_dirs))
-       (Clflags.std_include_flag "-I")
-       (Filename.quote name))
+  let (pipe, file) =
+    if Config.ccomp_type = "msvc" && not !Clflags.verbose then
+      try
+        let (t, c) = Filename.open_temp_file "msvc" "stdout" in
+        close_out c;
+        (Printf.sprintf " > %s" (Filename.quote t), t)
+      with _ ->
+        ("", "")
+    else
+      ("", "") in
+  let exit =
+    command
+      (Printf.sprintf
+         "%s%s -c %s %s %s %s %s%s"
+         (match !Clflags.c_compiler with
+          | Some cc -> cc
+          | None ->
+              if !Clflags.native_code
+              then Config.native_c_compiler
+              else Config.bytecomp_c_compiler)
+         (match output_name, Config.ccomp_type with
+            | Some n, "msvc" -> " /Fo" ^ Filename.quote n
+            | Some n, _ -> " -o " ^ Filename.quote n
+            | None, _ -> "")
+         (if !Clflags.debug && Config.ccomp_type <> "msvc" then "-g" else "")
+         (String.concat " " (List.rev !Clflags.all_ccopts))
+         (quote_prefixed "-I" (List.rev !Clflags.include_dirs))
+         (Clflags.std_include_flag "-I")
+         (Filename.quote name)
+         (* cl tediously includes the name of the C file as the first thing it
+            outputs (in fairness, the tedious thing is that there's no switch to
+            disable this behaviour). In the absence of the Unix module, use
+            a temporary file to filter the output (cannot pipe the output to a
+            filter because this removes the exit status of cl, which is wanted.
+          *)
+         pipe) in
+  if pipe <> ""
+  then display_msvc_output file name;
+  exit
 
 let create_archive archive file_list =
   Misc.remove_file archive;


### PR DESCRIPTION
Microsoft's C Compiler (cl) displays the name of the .c file it is compiling on stdout and there is no switch to suppress this behaviour (tediously).

The assembler (ml{,64}) does the same thing, but fortunately the output of that command can simply be piped to NUL (see [asmcomp/x86_proc.ml, line 243](https://github.com/ocaml/ocaml/blob/trunk/asmcomp/x86_proc.ml#L243)). Obviously that can't be done for invocations of the C compiler, or we'd never see warnings/errors.

The "ideal" solution would be either to pipe stdout and ignore exactly the first line if it is the name of the .c file being compiled or pipe stdout to something equivalent to `tail -n +2` but the former would require merging a large chunk of the pipes and process handling sections of win32unix into ocamlrun (or a similarly invasive change to link the compilers with unix.cm{,x}a) and the latter doesn't have an obvious guaranteed equivalent under Windows.

This solution uses findstr, which is a Windows system component available on all supported versions of Windows.

This code works with .c filenames containing spaces. It would be nice to be able to extend the behaviour to the OCaml build process, but that would involve either converting the invocation of CC to `$(call ...)` (invasive diff) or compiling .c files via the boot compiler (slow), so I'll just have to keep grinding my teeth at all the extra lines in build logs!
