### PR TITLE
Expose more things in Predef

### DIFF
--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -91,6 +91,21 @@ and ident_assert_failure = ident_create_predef_exn "Assert_failure"
 and ident_undefined_recursive_module =
         ident_create_predef_exn "Undefined_recursive_module"
 
+let all_predef_exns = [
+  ident_match_failure;
+  ident_out_of_memory;
+  ident_invalid_argument;
+  ident_failure;
+  ident_not_found;
+  ident_sys_error;
+  ident_end_of_file;
+  ident_division_by_zero;
+  ident_stack_overflow;
+  ident_sys_blocked_io;
+  ident_assert_failure;
+  ident_undefined_recursive_module;
+]
+
 let path_match_failure = Pident ident_match_failure
 and path_assert_failure = Pident ident_assert_failure
 and path_undefined_recursive_module = Pident ident_undefined_recursive_module

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -48,7 +48,6 @@ val path_int64: Path.t
 val path_lazy_t: Path.t
 val path_extension_constructor: Path.t
 
-val ident_division_by_zero: Ident.t
 val path_match_failure: Path.t
 val path_assert_failure : Path.t
 val path_undefined_recursive_module : Path.t
@@ -67,5 +66,9 @@ val build_initial_env:
 val builtin_values: (string * Ident.t) list
 val builtin_idents: (string * Ident.t) list
 
-(** All predefined exceptions *)
+(** All predefined exceptions, exposed as [Ident.t] for flambda (for
+    building value approximations).
+    The [Ident.t] for division by zero is also exported explicitly
+    so flambda can generate code to raise it. *)
+val ident_division_by_zero: Ident.t
 val all_predef_exns : Ident.t list

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -48,6 +48,7 @@ val path_int64: Path.t
 val path_lazy_t: Path.t
 val path_extension_constructor: Path.t
 
+val ident_division_by_zero: Ident.t
 val path_match_failure: Path.t
 val path_assert_failure : Path.t
 val path_undefined_recursive_module : Path.t
@@ -65,3 +66,6 @@ val build_initial_env:
 
 val builtin_values: (string * Ident.t) list
 val builtin_idents: (string * Ident.t) list
+
+(** All predefined exceptions *)
+val all_predef_exns : Ident.t list


### PR DESCRIPTION
This exposes:
1. The identifier for the "division by zero" exception.
2. A list of all predefined exception identifiers.
