### PR TITLE
Add explicit duplication of literal arrays

### DIFF
--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -113,7 +113,7 @@ let prim_size prim args =
   | Praise _ -> 4
   | Pstringlength -> 5
   | Pstringrefs | Pstringsets -> 6
-  | Pmakearray kind -> 5 + List.length args
+  | Pmakearray _ -> 5 + List.length args
   | Parraylength kind -> if kind = Pgenarray then 6 else 2
   | Parrayrefu kind -> if kind = Pgenarray then 12 else 2
   | Parraysetu kind -> if kind = Pgenarray then 16 else 4

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -1507,7 +1507,12 @@ let rec transl env e =
              1. When using Closure, all the time.
              2. When using Flambda, if a float array longer than
              [Translcore.use_dup_for_constant_arrays_bigger_than] turns out
-             to be non-constant. *)
+             to be non-constant.
+             If for some reason Flambda fails to lift a constant array we
+             could in theory also end up here.
+             Note that [kind] above is unconstrained, but with the current
+             state of [Translcore], we will in fact only get here with
+             [Pfloatarray]s. *)
           assert (kind = kind');
           transl_make_array env kind args
       | (Pduparray _, [arg]) ->

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -1502,8 +1502,13 @@ let rec transl env e =
           make_alloc tag (List.map (transl env) args)
       | (Pccall prim, args) ->
           transl_ccall env prim args dbg
-      | (Pduparray (Pfloatarray as kind, _),
-            [Uprim (Pmakearray (Pfloatarray, _), args, _dbg)]) ->
+      | (Pduparray (kind, _), [Uprim (Pmakearray (kind', _), args, _dbg)]) ->
+          (* We arrive here in two cases:
+             1. When using Closure, all the time.
+             2. When using Flambda, if a float array longer than
+             [Translcore.use_dup_for_constant_arrays_bigger_than] turns out
+             to be non-constant. *)
+          assert (kind = kind');
           transl_make_array env kind args
       | (Pduparray _, [arg]) ->
           let prim_obj_dup =

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -153,10 +153,11 @@ let rec size_of_lambda = function
   | Llet(str, id, arg, body) -> size_of_lambda body
   | Lletrec(bindings, body) -> size_of_lambda body
   | Lprim(Pmakeblock(tag, mut), args) -> RHS_block (List.length args)
-  | Lprim (Pmakearray (Paddrarray|Pintarray), args) ->
+  | Lprim (Pmakearray ((Paddrarray|Pintarray), _), args) ->
       RHS_block (List.length args)
-  | Lprim (Pmakearray Pfloatarray, args) -> RHS_floatblock (List.length args)
-  | Lprim (Pmakearray Pgenarray, args) -> assert false
+  | Lprim (Pmakearray (Pfloatarray, _), args) ->
+      RHS_floatblock (List.length args)
+  | Lprim (Pmakearray (Pgenarray, _), args) -> assert false
   | Lprim (Pduprecord ((Record_regular | Record_inlined _), size), args) ->
       RHS_block size
   | Lprim (Pduprecord (Record_extension, size), args) ->
@@ -632,7 +633,7 @@ let rec comp_expr env exp sz cont =
         (Kpush::
          Kconst (Const_base (Const_int n))::
          Kaddint::cont)
-  | Lprim(Pmakearray kind, args) ->
+  | Lprim(Pmakearray (kind, _), args) ->
       begin match kind with
         Pintarray | Paddrarray ->
           comp_args env args sz (Kmakeblock(List.length args, 0) :: cont)
@@ -645,6 +646,13 @@ let rec comp_expr env exp sz cont =
                  (Kmakeblock(List.length args, 0) ::
                   Kccall("caml_make_array", 1) :: cont)
       end
+  | Lprim (Pduparray _, [arg]) ->
+    let prim_obj_dup =
+      Primitive.simple ~name:"caml_obj_dup" ~arity:1 ~alloc:true
+    in
+    comp_expr env (Lprim (Pccall prim_obj_dup, [arg])) sz cont
+  | Lprim (Pduparray _, _) ->
+    Misc.fatal_error "Bytegen.comp_expr: Pduparray takes exactly one arg"
 (* Integer first for enabling futher optimization (cf. emitcode.ml)  *)
   | Lprim (Pintcomp c, [arg ; (Lconst _ as k)]) ->
       let p = Pintcomp (commute_comparison c)

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -646,13 +646,16 @@ let rec comp_expr env exp sz cont =
                  (Kmakeblock(List.length args, 0) ::
                   Kccall("caml_make_array", 1) :: cont)
       end
+  | Lprim (Pduparray (kind, mutability), [Lprim (Pmakearray (kind', _), args)]) ->
+      assert (kind = kind');
+      comp_expr env (Lprim (Pmakearray (kind, mutability), args)) sz cont
   | Lprim (Pduparray _, [arg]) ->
-    let prim_obj_dup =
-      Primitive.simple ~name:"caml_obj_dup" ~arity:1 ~alloc:true
-    in
-    comp_expr env (Lprim (Pccall prim_obj_dup, [arg])) sz cont
+      let prim_obj_dup =
+        Primitive.simple ~name:"caml_obj_dup" ~arity:1 ~alloc:true
+      in
+      comp_expr env (Lprim (Pccall prim_obj_dup, [arg])) sz cont
   | Lprim (Pduparray _, _) ->
-    Misc.fatal_error "Bytegen.comp_expr: Pduparray takes exactly one arg"
+      Misc.fatal_error "Bytegen.comp_expr: Pduparray takes exactly one arg"
 (* Integer first for enabling futher optimization (cf. emitcode.ml)  *)
   | Lprim (Pintcomp c, [arg ; (Lconst _ as k)]) ->
       let p = Pintcomp (commute_comparison c)

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -77,7 +77,8 @@ type primitive =
   (* String operations *)
   | Pstringlength | Pstringrefu | Pstringsetu | Pstringrefs | Pstringsets
   (* Array operations *)
-  | Pmakearray of array_kind
+  | Pmakearray of array_kind * mutable_flag
+  | Pduparray of array_kind * mutable_flag
   | Parraylength of array_kind
   | Parrayrefu of array_kind
   | Parraysetu of array_kind

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -80,7 +80,11 @@ type primitive =
   (* String operations *)
   | Pstringlength | Pstringrefu | Pstringsetu | Pstringrefs | Pstringsets
   (* Array operations *)
-  | Pmakearray of array_kind
+  | Pmakearray of array_kind * mutable_flag
+  | Pduparray of array_kind * mutable_flag
+  (** For [Pduparray], the argument must be an immutable array.
+      The arguments of [Pduparray] give the kind and mutability of the
+      array being *produced* by the duplication. *)
   | Parraylength of array_kind
   | Parrayrefu of array_kind
   | Parraysetu of array_kind

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -177,7 +177,10 @@ let primitive ppf = function
   | Pstringrefs -> fprintf ppf "string.get"
   | Pstringsets -> fprintf ppf "string.set"
   | Parraylength k -> fprintf ppf "array.length[%s]" (array_kind k)
-  | Pmakearray k -> fprintf ppf "makearray[%s]" (array_kind k)
+  | Pmakearray (k, Mutable) -> fprintf ppf "makearray[%s]" (array_kind k)
+  | Pmakearray (k, Immutable) -> fprintf ppf "makearray_imm[%s]" (array_kind k)
+  | Pduparray (k, Mutable) -> fprintf ppf "duparray[%s]" (array_kind k)
+  | Pduparray (k, Immutable) -> fprintf ppf "duparray_imm[%s]" (array_kind k)
   | Parrayrefu k -> fprintf ppf "array.unsafe_get[%s]" (array_kind k)
   | Parraysetu k -> fprintf ppf "array.unsafe_set[%s]" (array_kind k)
   | Parrayrefs k -> fprintf ppf "array.get[%s]" (array_kind k)
@@ -312,6 +315,7 @@ let name_of_primitive = function
   | Pstringsets -> "Pstringsets"
   | Parraylength _ -> "Parraylength"
   | Pmakearray _ -> "Pmakearray"
+  | Pduparray _ -> "Pduparray"
   | Parrayrefu _ -> "Parrayrefu"
   | Parraysetu _ -> "Parraysetu"
   | Parrayrefs _ -> "Parrayrefs"

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -1212,10 +1212,7 @@ and transl_record env all_labels repres lbl_expr_list opt_init_expr =
         | Record_regular -> Lconst(Const_block(0, cl))
         | Record_inlined tag -> Lconst(Const_block(tag, cl))
         | Record_float ->
-            if !Clflags.native_code then
-              Lprim (Pmakearray (Pfloatarray, Immutable), ll)
-            else
-              Lconst(Const_float_array(List.map extract_float cl))
+            Lconst(Const_float_array(List.map extract_float cl))
         | Record_extension ->
             raise Not_constant
       with Not_constant ->

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -865,10 +865,10 @@ and transl_exp0 e =
                code operating on polymorphic arrays, or functions such as
                [caml_array_blit].
                To avoid having different Lambda code for bytecode/Closure vs.
-               flambda, we always generate [Pduparray] here, and deal with it in
+               Flambda, we always generate [Pduparray] here, and deal with it in
                [Bytegen] (or in the case of Closure, in [Cmmgen], which already
                has to handle [Pduparray Pmakearray Pfloatarray] in the case where
-               the array turned out to be inconstant.
+               the array turned out to be inconstant).
                When not [Pfloatarray], the exception propagates to the handler
                below. *)
             let imm_array = Lprim (Pmakearray (kind, Immutable), ll) in

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -30,6 +30,8 @@ type error =
 
 exception Error of Location.t * error
 
+let use_dup_for_constant_arrays_bigger_than = 4
+
 (* Forward declaration -- to be filled in by Translmod.transl_module *)
 let transl_module =
   ref((fun cc rootpath modl -> assert false) :
@@ -443,8 +445,8 @@ let check_recursive_lambda idlist lam =
         let idlist' = add_letrec bindings idlist in
         List.for_all (fun (id, arg) -> check idlist' arg) bindings &&
         check_top idlist' body
-    | Lprim (Pmakearray (Pgenarray), args) -> false
-    | Lprim (Pmakearray Pfloatarray, args) ->
+    | Lprim (Pmakearray (Pgenarray, _), args) -> false
+    | Lprim (Pmakearray (Pfloatarray, _), args) ->
         List.for_all (check idlist) args
     | Lsequence (lam1, lam2) -> check idlist lam1 && check_top idlist lam2
     | Levent (lam, _) -> check_top idlist lam
@@ -463,8 +465,8 @@ let check_recursive_lambda idlist lam =
         check idlist' body
     | Lprim(Pmakeblock(tag, mut), args) ->
         List.for_all (check idlist) args
-    | Lprim (Pmakearray Pfloatarray, _) -> false
-    | Lprim(Pmakearray(_), args) ->
+    | Lprim (Pmakearray (Pfloatarray, _), _) -> false
+    | Lprim (Pmakearray _, args) ->
         List.for_all (check idlist) args
     | Lsequence (lam1, lam2) -> check idlist lam1 && check idlist lam2
     | Levent (lam, _) -> check idlist lam
@@ -848,20 +850,35 @@ and transl_exp0 e =
       let kind = array_kind e in
       let ll = transl_list expr_list in
       begin try
+        (* For native code the decision as to which compilation strategy to
+           use is made later.  This enables the Flambda passes to lift certain
+           kinds of array definitions to symbols. *)
         (* Deactivate constant optimization if array is small enough *)
-        if List.length ll <= 4 then raise Not_constant;
-        let cl = List.map extract_constant ll in
-        let master =
-          match kind with
-          | Paddrarray | Pintarray ->
-              Lconst(Const_block(0, cl))
-          | Pfloatarray ->
-              Lconst(Const_float_array(List.map extract_float cl))
-          | Pgenarray ->
-              raise Not_constant in             (* can this really happen? *)
-        Lprim(Pccall prim_obj_dup, [master])
+        if List.length ll <= use_dup_for_constant_arrays_bigger_than
+        then begin
+          raise Not_constant
+        end;
+        (* We cannot currently lift [Pintarray] arrays safely in Flambda
+           because [caml_modify] might be called upon them (e.g. from
+           code operating on polymorphic arrays, or functions such as
+           [caml_array_blit]. *)
+        if !Clflags.native_code && kind = Pfloatarray then
+          let imm_array = Lprim (Pmakearray (kind, Immutable), ll) in
+          Lprim (Pduparray (kind, Mutable), [imm_array])
+        else begin
+          let cl = List.map extract_constant ll in
+          let master =
+            match kind with
+            | Paddrarray | Pintarray ->
+                Lconst(Const_block(0, cl))
+            | Pfloatarray ->
+                Lconst(Const_float_array(List.map extract_float cl))
+            | Pgenarray ->
+                raise Not_constant in             (* can this really happen? *)
+          Lprim(Pccall prim_obj_dup, [master])
+        end
       with Not_constant ->
-        Lprim(Pmakearray kind, ll)
+        Lprim(Pmakearray (kind, Mutable), ll)
       end
   | Texp_ifthenelse(cond, ifso, Some ifnot) ->
       Lifthenelse(transl_exp cond,
@@ -1195,14 +1212,17 @@ and transl_record env all_labels repres lbl_expr_list opt_init_expr =
         | Record_regular -> Lconst(Const_block(0, cl))
         | Record_inlined tag -> Lconst(Const_block(tag, cl))
         | Record_float ->
-            Lconst(Const_float_array(List.map extract_float cl))
+            if !Clflags.native_code then
+              Lprim (Pmakearray (Pfloatarray, Immutable), ll)
+            else
+              Lconst(Const_float_array(List.map extract_float cl))
         | Record_extension ->
             raise Not_constant
       with Not_constant ->
         match repres with
           Record_regular -> Lprim(Pmakeblock(0, mut), ll)
         | Record_inlined tag -> Lprim(Pmakeblock(tag, mut), ll)
-        | Record_float -> Lprim(Pmakearray Pfloatarray, ll)
+        | Record_float -> Lprim(Pmakearray (Pfloatarray, mut), ll)
         | Record_extension ->
             let path =
               match all_labels.(0).lbl_res.desc with

--- a/middle_end/closure_conversion.ml
+++ b/middle_end/closure_conversion.ml
@@ -149,7 +149,8 @@ let rec close_const t env (const : Lambda.structured_constant)
   | Const_pointer c -> Const (Const_pointer c), "pointer"
   | Const_immstring c -> Allocated_const (Immutable_string c), "immstring"
   | Const_float_array c ->
-    Allocated_const (Float_array (List.map float_of_string c)), "float_array"
+    Allocated_const (Immutable_float_array (List.map float_of_string c)),
+      "float_array"
   | Const_block _ ->
     Expr (close t env (eliminate_const_block const)), "const_block"
 


### PR DESCRIPTION
Create a new primitive to replace obj_dup when duplicating arrays. This allows to propagate some knowledge about the usage n particular this allows to statically allocate the array and assign it a symbol.

This only applies to float arrays currently since they are the only mutable values that can currently be statically allocated, but this will change if some gc constraints are lifted later.

This allows to have `b` be statically allocated in that case for instance (in flambda)

```
let a = [|1.;2.;3.|]
let b = (a, a)
```

This was introduce originally to reduce the cost of compiling big literal float arrays.
