### PR TITLE
Documentation: missing escape characters

### DIFF
--- a/utils/numbers.mli
+++ b/utils/numbers.mli
@@ -19,7 +19,7 @@
 module Int : sig
   include Identifiable.S with type t = int
 
-  (** [zero_to_n n] is the set of numbers {0, ..., n} (inclusive). *)
+  (** [zero_to_n n] is the set of numbers \{0, ..., n\} (inclusive). *)
   val zero_to_n : int -> Set.t
 end
 


### PR DESCRIPTION
This pull request fix the missing escape characters in `utils/numbers.mli`, in order to make the manual build once again.
