### PR TITLE
Change the interface of Cmmgen to accept preallocated blocks and constants as argument

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -126,8 +126,8 @@ let compile_unit ~source_provenance asm_filename keep_asm obj_filename gen =
 
 let gen_implementation ?toplevel ~source_provenance ppf (size, lam) =
   let main_module_block =
-    Clambda.{
-      symbol = Compilenv.make_symbol None;
+    {
+      Clambda.symbol = Compilenv.make_symbol None;
       exported = true;
       tag = 0;
       size;

--- a/asmcomp/clambda.ml
+++ b/asmcomp/clambda.ml
@@ -89,6 +89,21 @@ type value_approximation =
   | Value_const of uconstant
   | Value_global_field of string * int
 
+(* Preallocated globals *)
+
+type preallocated_block = {
+  symbol : string;
+  exported : bool;
+  tag : int;
+  size : int;
+}
+
+type preallocated_constant = {
+  symbol : string;
+  exported : bool;
+  definition : ustructured_constant;
+}
+
 (* Comparison functions for constants.  We must not use Pervasives.compare
    because it compares "0.0" and "-0.0" equal.  (PR#6442) *)
 

--- a/asmcomp/clambda.mli
+++ b/asmcomp/clambda.mli
@@ -95,3 +95,16 @@ val compare_structured_constants:
         ustructured_constant -> ustructured_constant -> int
 val compare_constants:
         uconstant -> uconstant -> int
+
+type preallocated_block = {
+  symbol : string;
+  exported : bool;
+  tag : int;
+  size : int;
+}
+
+type preallocated_constant = {
+  symbol : string;
+  exported : bool;
+  definition : ustructured_constant;
+}

--- a/asmcomp/cmmgen.mli
+++ b/asmcomp/cmmgen.mli
@@ -12,7 +12,11 @@
 
 (* Translation from closed lambda to C-- *)
 
-val compunit: int -> Clambda.ulambda -> Cmm.phrase list
+val compunit:
+    Clambda.ulambda
+    * Clambda.preallocated_block list
+    * Clambda.preallocated_constant list
+  -> Cmm.phrase list
 
 val apply_function: int -> Cmm.phrase
 val send_function: int -> Cmm.phrase

--- a/asmcomp/compilenv.ml
+++ b/asmcomp/compilenv.ml
@@ -294,9 +294,13 @@ let clear_structured_constants () =
 
 let structured_constants () =
   List.map
-    (fun (lbl, cst) ->
-       (lbl, Hashtbl.mem exported_constants lbl, cst)
-    ) (!structured_constants).strcst_all
+    (fun (symbol, definition) ->
+       Clambda.{
+         symbol;
+         exported = Hashtbl.mem exported_constants symbol;
+         definition;
+       })
+    (!structured_constants).strcst_all
 
 (* Error report *)
 

--- a/asmcomp/compilenv.ml
+++ b/asmcomp/compilenv.ml
@@ -295,8 +295,8 @@ let clear_structured_constants () =
 let structured_constants () =
   List.map
     (fun (symbol, definition) ->
-       Clambda.{
-         symbol;
+       {
+         Clambda.symbol;
          exported = Hashtbl.mem exported_constants symbol;
          definition;
        })

--- a/asmcomp/compilenv.mli
+++ b/asmcomp/compilenv.mli
@@ -65,7 +65,7 @@ val new_structured_constant:
   shared:bool -> (* can be shared with another structually equal constant *)
   string
 val structured_constants:
-  unit -> (string * bool * Clambda.ustructured_constant) list
+  unit -> Clambda.preallocated_constant list
 val clear_structured_constants: unit -> unit
 val add_exported_constant: string -> unit
 


### PR DESCRIPTION
Flambda can generate more preallocated blocks than only the toplevel module and handle constants differently (without using Compilenv), hence those are passed to cmmgen as arguments.

This is probably the simplest version for maintain the compatibility with both Closure and Flambda.

This PR is split in two patch that are probably simpler to read separately.
