### PR TITLE
New warning 59: assignment to non-mutable value

### DIFF
--- a/man/ocamlc.m
+++ b/man/ocamlc.m
@@ -855,6 +855,9 @@ mutually recursive types.
 50
 \ \ Unexpected documentation comment.
 
+59
+\ \ Assignment on non-mutable value.
+
 The letters stand for the following sets of warnings.  Any letter not
 mentioned here corresponds to the empty set.
 

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -76,7 +76,7 @@ type t =
   | Unreachable_case                        (* 56 *)
   | Ambiguous_pattern of string list        (* 57 *)
   | No_cmx_file of string                   (* 58 *)
-  | Assignment_on_non_mutable_value         (* 59 *)
+  | Assignment_to_non_mutable_value         (* 59 *)
 ;;
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
@@ -144,7 +144,7 @@ let number = function
   | Unreachable_case -> 56
   | Ambiguous_pattern _ -> 57
   | No_cmx_file _ -> 58
-  | Assignment_on_non_mutable_value -> 59
+  | Assignment_to_non_mutable_value -> 59
 ;;
 
 let last_warning_number = 59
@@ -434,7 +434,7 @@ let message = function
       Printf.sprintf "the %S attribute is used more than once on this expression" attr_name
   | Inlining_impossible reason ->
       Printf.sprintf "Inlining impossible in this context: %s" reason
-  | Assignment_on_non_mutable_value -> "Assignment to non-mutable value"
+  | Assignment_to_non_mutable_value -> "Assignment to non-mutable value"
   | Ambiguous_pattern vars ->
       let msg =
         let vars = List.sort String.compare vars in

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -545,7 +545,7 @@ let descriptions =
    56, "Unreachable case in a pattern-matching (based on type information).";
    57, "Ambiguous binding by pattern.";
    58, "Missing cmx file";
-   59, "Assignment on non-mutable value";
+   59, "Assignment to non-mutable value";
   ]
 ;;
 

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -76,6 +76,7 @@ type t =
   | Unreachable_case                        (* 56 *)
   | Ambiguous_pattern of string list        (* 57 *)
   | No_cmx_file of string                   (* 58 *)
+  | Assignment_on_non_mutable_value         (* 59 *)
 ;;
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
@@ -143,10 +144,12 @@ let number = function
   | Unreachable_case -> 56
   | Ambiguous_pattern _ -> 57
   | No_cmx_file _ -> 58
+  | Assignment_on_non_mutable_value -> 59
 ;;
 
-let last_warning_number = 58
+let last_warning_number = 59
 ;;
+
 (* Must be the max number returned by the [number] function. *)
 
 let letter = function
@@ -431,6 +434,7 @@ let message = function
       Printf.sprintf "the %S attribute is used more than once on this expression" attr_name
   | Inlining_impossible reason ->
       Printf.sprintf "Inlining impossible in this context: %s" reason
+  | Assignment_on_non_mutable_value -> "Assignment to non-mutable value"
   | Ambiguous_pattern vars ->
       let msg =
         let vars = List.sort String.compare vars in
@@ -541,6 +545,7 @@ let descriptions =
    56, "Unreachable case in a pattern-matching (based on type information).";
    57, "Ambiguous binding by pattern.";
    58, "Missing cmx file";
+   59, "Assignment on non-mutable value";
   ]
 ;;
 

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -434,7 +434,6 @@ let message = function
       Printf.sprintf "the %S attribute is used more than once on this expression" attr_name
   | Inlining_impossible reason ->
       Printf.sprintf "Inlining impossible in this context: %s" reason
-  | Assignment_to_non_mutable_value -> "Assignment to non-mutable value"
   | Ambiguous_pattern vars ->
       let msg =
         let vars = List.sort String.compare vars in
@@ -449,6 +448,7 @@ let message = function
       Printf.sprintf
         "no cmx file was found in path for module %s, \
          and its interface was not compiled with -opaque" name
+  | Assignment_to_non_mutable_value -> "Assignment to non-mutable value"
 ;;
 
 let nerrors = ref 0;;

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -71,7 +71,7 @@ type t =
   | Unreachable_case                        (* 56 *)
   | Ambiguous_pattern of string list        (* 57 *)
   | No_cmx_file of string                   (* 58 *)
-  | Assignment_on_non_mutable_value         (* 59 *)
+  | Assignment_to_non_mutable_value         (* 59 *)
 ;;
 
 val parse_options : bool -> string -> unit;;

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -71,6 +71,7 @@ type t =
   | Unreachable_case                        (* 56 *)
   | Ambiguous_pattern of string list        (* 57 *)
   | No_cmx_file of string                   (* 58 *)
+  | Assignment_on_non_mutable_value         (* 59 *)
 ;;
 
 val parse_options : bool -> string -> unit;;


### PR DESCRIPTION
This new warning is generated by the Flambda simplifier if it manages to detect that there is an assignment to a non-mutable value.  As per the comment in obj.mli, such assignments are strictly forbidden, since they may invalidate the value approximations propagated during simplification.
