### PR TITLE
Configure option to enable the flambda middle-end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,7 @@ utils/config.ml: utils/config.mlp config/Makefile
 	    -e 's|%%MKMAINDLL%%|$(MKMAINDLL)|' \
 	    -e 's|%%HOST%%|$(HOST)|' \
 	    -e 's|%%TARGET%%|$(TARGET)|' \
+	    -e 's|%%FLAMBDA%%|$(FLAMBDA)|' \
 	    utils/config.mlp > utils/config.ml
 
 partialclean::

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -313,6 +313,7 @@ utils/config.ml: utils/config.mlp config/Makefile
 	    -e 's|%%CC_PROFILE%%||' \
 	    -e 's|%%HOST%%|$(HOST)|' \
 	    -e 's|%%TARGET%%|$(TARGET)|' \
+	    -e 's|%%FLAMBDA%%|$(FLAMBDA)|' \
 	    utils/config.mlp > utils/config.ml
 
 partialclean::

--- a/configure
+++ b/configure
@@ -51,6 +51,7 @@ no_naked_pointers=false
 native_compiler=true
 TOOLPREF=""
 with_cfi=true
+flambda=false
 
 # Try to turn internationalization off, can cause config.guess to malfunction!
 unset LANG
@@ -162,6 +163,8 @@ while : ; do
         with_cfi=false;;
     -no-native-compiler)
         native_compiler=false;;
+    -flambda)
+        flambda=true;;
     *) if echo "$1" | grep -q -e '^--\?[a-zA-Z0-9-]\+='; then
          err "configure expects arguments of the form '-prefix /foo/bar'," \
              "not '-prefix=/foo/bar' (note the '=')."
@@ -1788,6 +1791,7 @@ echo "HOST=$host" >> Makefile
 if [ "$ostype" = Cygwin ]; then
   echo "DIFF=diff -q --strip-trailing-cr" >>Makefile
 fi
+echo "FLAMBDA=$flambda" >> Makefile
 
 
 rm -f tst hasgot.c
@@ -1855,6 +1859,11 @@ else
   inf "        profiling with gprof ..... supported"
   else
   inf "        profiling with gprof ..... not supported"
+  fi
+  if test "$flambda" = "true"; then
+  inf "        using flambda middle-end . yes"
+  else
+  inf "        using flambda middle-end . no"
   fi
 fi
 

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -127,3 +127,6 @@ val target : string
         (* Whether the compiler is a cross-compiler *)
 
 val print_config : out_channel -> unit;;
+
+val flambda : bool
+        (* Whether the compiler was configured for flambda *)

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -48,12 +48,22 @@ let mkdll = "%%MKDLL%%"
 let mkexe = "%%MKEXE%%"
 let mkmaindll = "%%MKMAINDLL%%"
 
+let flambda = %%FLAMBDA%%
+
 let exec_magic_number = "Caml1999X011"
 and cmi_magic_number = "Caml1999I020"
 and cmo_magic_number = "Caml1999O011"
 and cma_magic_number = "Caml1999A012"
-and cmx_magic_number = "Caml1999Y015"
-and cmxa_magic_number = "Caml1999Z014"
+and cmx_magic_number =
+  if flambda then
+    "Caml1999Y016"
+  else
+    "Caml1999Y015"
+and cmxa_magic_number =
+  if flambda then
+    "Caml1999Z015"
+  else
+    "Caml1999Z014"
 and ast_impl_magic_number = "Caml1999M019"
 and ast_intf_magic_number = "Caml1999N018"
 and cmxs_magic_number = "Caml2007D002"
@@ -126,6 +136,7 @@ let print_config oc =
   p_bool "systhread_supported" systhread_supported;
   p "host" host;
   p "target" target;
+  p_bool "flambda" flambda;
 
   (* print the magic number *)
   p "exec_magic_number" exec_magic_number;


### PR DESCRIPTION
Since Flambda cmx files are expected to be different from closure ones, the magic number will not be the same when this option is enabled.
