### PR TITLE
Make Obj.is_block an inline OCaml function instead of a C primitive

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,6 +26,10 @@ OCaml 4.04.0:
 
 ### Standard library:
 
+- GPR#427: Obj.is_block is now an inlined OCaml function instead of a
+  C external.  This should be faster.
+  (Demi Obenour)
+
 - PR#4747, GPR#328: Optimize Hashtbl by using in-place updates of its
   internal bucket lists.  All operations run in constant stack size
   and are usually faster, except Hashtbl.copy which can be much

--- a/byterun/obj.c
+++ b/byterun/obj.c
@@ -44,7 +44,7 @@ CAMLprim value caml_static_resize(value blk, value new_size)
   return (value) caml_stat_resize((char *) blk, (asize_t) Long_val(new_size));
 }
 
-// unused since GPR#427
+/* unused since GPR#427 */
 CAMLprim value caml_obj_is_block(value arg)
 {
   return Val_bool(Is_block(arg));

--- a/byterun/obj.c
+++ b/byterun/obj.c
@@ -43,7 +43,8 @@ CAMLprim value caml_static_resize(value blk, value new_size)
 {
   return (value) caml_stat_resize((char *) blk, (asize_t) Long_val(new_size));
 }
-// unused
+
+// unused since GPR#427
 CAMLprim value caml_obj_is_block(value arg)
 {
   return Val_bool(Is_block(arg));

--- a/byterun/obj.c
+++ b/byterun/obj.c
@@ -43,7 +43,7 @@ CAMLprim value caml_static_resize(value blk, value new_size)
 {
   return (value) caml_stat_resize((char *) blk, (asize_t) Long_val(new_size));
 }
-
+// unused
 CAMLprim value caml_obj_is_block(value arg)
 {
   return Val_bool(Is_block(arg));

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -22,7 +22,7 @@ external obj : t -> 'a = "%identity"
 external magic : 'a -> 'b = "%identity"
 external is_int : t -> bool = "%obj_is_int"
 let is_block a = is_int a |> not
-[@@ocaml.inline]
+  [@@ocaml.inline]
 external tag : t -> int = "caml_obj_tag"
 external set_tag : t -> int -> unit = "caml_obj_set_tag"
 external size : t -> int = "%obj_size"

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -20,8 +20,9 @@ type t
 external repr : 'a -> t = "%identity"
 external obj : t -> 'a = "%identity"
 external magic : 'a -> 'b = "%identity"
-external is_block : t -> bool = "caml_obj_is_block"
 external is_int : t -> bool = "%obj_is_int"
+let is_block a = is_int a |> not
+[@@ocaml.inline]
 external tag : t -> int = "caml_obj_tag"
 external set_tag : t -> int -> unit = "caml_obj_set_tag"
 external size : t -> int = "%obj_size"

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -21,8 +21,8 @@ external repr : 'a -> t = "%identity"
 external obj : t -> 'a = "%identity"
 external magic : 'a -> 'b = "%identity"
 external is_int : t -> bool = "%obj_is_int"
-let is_block a = is_int a |> not
-  [@@ocaml.inline]
+let is_block a = not (is_int a)
+  [@@inline always]
 external tag : t -> int = "caml_obj_tag"
 external set_tag : t -> int -> unit = "caml_obj_set_tag"
 external size : t -> int = "%obj_size"
@@ -32,7 +32,9 @@ external set_field : t -> int -> t -> unit = "%obj_set_field"
 external array_get: 'a array -> int -> 'a = "%array_safe_get"
 external array_set: 'a array -> int -> 'a -> unit = "%array_safe_set"
 let double_field x i = array_get (obj x : float array) i
+  [@@inline always]
 let set_double_field x i v = array_set (obj x : float array) i v
+  [@@inline always]
 external new_block : int -> int -> t = "caml_obj_block"
 external dup : t -> t = "caml_obj_dup"
 external truncate : t -> int -> unit = "caml_obj_truncate"
@@ -79,9 +81,11 @@ let extension_constructor x =
     if (tag name) = string_tag then (obj slot : extension_constructor)
     else invalid_arg "Obj.extension_constructor"
 
+[@@inline always]
 let extension_name (slot : extension_constructor) =
   (obj (field (repr slot) 0) : string)
 
+[@@inline always]
 let extension_id (slot : extension_constructor) =
   (obj (field (repr slot) 1) : int)
 

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -21,8 +21,7 @@ external repr : 'a -> t = "%identity"
 external obj : t -> 'a = "%identity"
 external magic : 'a -> 'b = "%identity"
 external is_int : t -> bool = "%obj_is_int"
-let is_block a = not (is_int a)
-  [@@inline always]
+let [@inline always] is_block a = not (is_int a)
 external tag : t -> int = "caml_obj_tag"
 external set_tag : t -> int -> unit = "caml_obj_set_tag"
 external size : t -> int = "%obj_size"
@@ -31,10 +30,9 @@ external field : t -> int -> t = "%obj_field"
 external set_field : t -> int -> t -> unit = "%obj_set_field"
 external array_get: 'a array -> int -> 'a = "%array_safe_get"
 external array_set: 'a array -> int -> 'a -> unit = "%array_safe_set"
-let double_field x i = array_get (obj x : float array) i
-  [@@inline always]
-let set_double_field x i v = array_set (obj x : float array) i v
-  [@@inline always]
+let [@inline always] double_field x i = array_get (obj x : float array) i
+let [@inline always] set_double_field x i v =
+  array_set (obj x : float array) i v
 external new_block : int -> int -> t = "caml_obj_block"
 external dup : t -> t = "caml_obj_dup"
 external truncate : t -> int -> unit = "caml_obj_truncate"
@@ -81,12 +79,10 @@ let extension_constructor x =
     if (tag name) = string_tag then (obj slot : extension_constructor)
     else invalid_arg "Obj.extension_constructor"
 
-[@@inline always]
-let extension_name (slot : extension_constructor) =
+let [@inline always] extension_name (slot : extension_constructor) =
   (obj (field (repr slot) 0) : string)
 
-[@@inline always]
-let extension_id (slot : extension_constructor) =
+let [@inline always] extension_id (slot : extension_constructor) =
   (obj (field (repr slot) 1) : int)
 
 module Ephemeron = struct

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -23,7 +23,9 @@ type t
 external repr : 'a -> t = "%identity"
 external obj : t -> 'a = "%identity"
 external magic : 'a -> 'b = "%identity"
-external is_block : t -> bool = "caml_obj_is_block"
+val is_block : t -> bool
+[@@ocaml.inline]
+
 external is_int : t -> bool = "%obj_is_int"
 external tag : t -> int = "caml_obj_tag"
 external size : t -> int = "%obj_size"

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -24,8 +24,7 @@ external repr : 'a -> t = "%identity"
 external obj : t -> 'a = "%identity"
 external magic : 'a -> 'b = "%identity"
 val is_block : t -> bool
-[@@ocaml.inline]
-
+  [@@ocaml.inline]
 external is_int : t -> bool = "%obj_is_int"
 external tag : t -> int = "caml_obj_tag"
 external size : t -> int = "%obj_size"

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -23,8 +23,7 @@ type t
 external repr : 'a -> t = "%identity"
 external obj : t -> 'a = "%identity"
 external magic : 'a -> 'b = "%identity"
-val is_block : t -> bool
-  [@@inline always]
+val [@inline always] is_block : t -> bool
 external is_int : t -> bool = "%obj_is_int"
 external tag : t -> int = "caml_obj_tag"
 external size : t -> int = "%obj_size"
@@ -57,10 +56,9 @@ external field : t -> int -> t = "%obj_field"
 external set_field : t -> int -> t -> unit = "%obj_set_field"
 external set_tag : t -> int -> unit = "caml_obj_set_tag"
 
-val double_field : t -> int -> float  (* @since 3.11.2 *)
-  [@@inline always]
-val set_double_field : t -> int -> float -> unit  (* @since 3.11.2 *)
-  [@@inline always]
+val [@inline always] double_field : t -> int -> float  (* @since 3.11.2 *)
+val [@inline always] set_double_field : t -> int -> float -> unit
+  (* @since 3.11.2 *)
 external new_block : int -> int -> t = "caml_obj_block"
 external dup : t -> t = "caml_obj_dup"
 external truncate : t -> int -> unit = "caml_obj_truncate"
@@ -89,9 +87,8 @@ val out_of_heap_tag : int
 val unaligned_tag : int   (* should never happen @since 3.11.0 *)
 
 val extension_constructor : 'a -> extension_constructor
-  [@@inline always]
-val extension_name : extension_constructor -> string
-val extension_id : extension_constructor -> int
+val [@inline always] extension_name : extension_constructor -> string
+val [@inline always] extension_id : extension_constructor -> int
 
 (** The following two functions are deprecated.  Use module {!Marshal}
     instead. *)

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -24,7 +24,7 @@ external repr : 'a -> t = "%identity"
 external obj : t -> 'a = "%identity"
 external magic : 'a -> 'b = "%identity"
 val is_block : t -> bool
-  [@@ocaml.inline]
+  [@@inline always]
 external is_int : t -> bool = "%obj_is_int"
 external tag : t -> int = "caml_obj_tag"
 external size : t -> int = "%obj_size"
@@ -58,7 +58,9 @@ external set_field : t -> int -> t -> unit = "%obj_set_field"
 external set_tag : t -> int -> unit = "caml_obj_set_tag"
 
 val double_field : t -> int -> float  (* @since 3.11.2 *)
+  [@@inline always]
 val set_double_field : t -> int -> float -> unit  (* @since 3.11.2 *)
+  [@@inline always]
 external new_block : int -> int -> t = "caml_obj_block"
 external dup : t -> t = "caml_obj_dup"
 external truncate : t -> int -> unit = "caml_obj_truncate"
@@ -87,6 +89,7 @@ val out_of_heap_tag : int
 val unaligned_tag : int   (* should never happen @since 3.11.0 *)
 
 val extension_constructor : 'a -> extension_constructor
+  [@@inline always]
 val extension_name : extension_constructor -> string
 val extension_id : extension_constructor -> int
 


### PR DESCRIPTION
`Obj.is_block` is currently a C primitive.  This patch replaces it with an inlined OCaml function written in terms of `Obj.is_int`.  This should be simpler and faster.

Test suite passes.
