### PR TITLE
OCAMLPARAM option passed using a configuration file

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -146,152 +146,152 @@ let can_discard = ref []
 let read_one_param ppf position name v =
   let set name options s =  setter ppf (fun b -> b) name options s in
   let clear name options s = setter ppf (fun b -> not b) name options s in
-      match name with
-      | "g" -> set "g" [ Clflags.debug ] v
-      | "p" -> set "p" [ Clflags.gprofile ] v
-      | "bin-annot" -> set "bin-annot" [ Clflags.binary_annotations ] v
-      | "annot" -> set "annot" [ Clflags.annotations ] v
-      | "absname" -> set "absname" [ Location.absname ] v
-      | "compat-32" -> set "compat-32" [ bytecode_compatible_32 ] v
-      | "noassert" -> set "noassert" [ noassert ] v
-      | "noautolink" -> set "noautolink" [ no_auto_link ] v
-      | "nostdlib" -> set "nostdlib" [ no_std_include ] v
-      | "linkall" -> set "linkall" [ link_everything ] v
-      | "nolabels" -> set "nolabels" [ classic ] v
-      | "principal" -> set "principal"  [ principal ] v
-      | "rectypes" -> set "rectypes" [ recursive_types ] v
-      | "safe-string" -> clear "safe-string" [ unsafe_string ] v
-      | "strict-sequence" -> set "strict-sequence" [ strict_sequence ] v
-      | "strict-formats" -> set "strict-formats" [ strict_formats ] v
-      | "thread" -> set "thread" [ use_threads ] v
-      | "unsafe" -> set "unsafe" [ fast ] v
-      | "verbose" -> set "verbose" [ verbose ] v
-      | "nopervasives" -> set "nopervasives" [ nopervasives ] v
-      | "slash" -> set "slash" [ force_slash ] v (* for ocamldep *)
-      | "keep-docs" -> set "keep-docs" [ Clflags.keep_docs ] v
-      | "keep-locs" -> set "keep-locs" [ Clflags.keep_locs ] v
+  match name with
+  | "g" -> set "g" [ Clflags.debug ] v
+  | "p" -> set "p" [ Clflags.gprofile ] v
+  | "bin-annot" -> set "bin-annot" [ Clflags.binary_annotations ] v
+  | "annot" -> set "annot" [ Clflags.annotations ] v
+  | "absname" -> set "absname" [ Location.absname ] v
+  | "compat-32" -> set "compat-32" [ bytecode_compatible_32 ] v
+  | "noassert" -> set "noassert" [ noassert ] v
+  | "noautolink" -> set "noautolink" [ no_auto_link ] v
+  | "nostdlib" -> set "nostdlib" [ no_std_include ] v
+  | "linkall" -> set "linkall" [ link_everything ] v
+  | "nolabels" -> set "nolabels" [ classic ] v
+  | "principal" -> set "principal"  [ principal ] v
+  | "rectypes" -> set "rectypes" [ recursive_types ] v
+  | "safe-string" -> clear "safe-string" [ unsafe_string ] v
+  | "strict-sequence" -> set "strict-sequence" [ strict_sequence ] v
+  | "strict-formats" -> set "strict-formats" [ strict_formats ] v
+  | "thread" -> set "thread" [ use_threads ] v
+  | "unsafe" -> set "unsafe" [ fast ] v
+  | "verbose" -> set "verbose" [ verbose ] v
+  | "nopervasives" -> set "nopervasives" [ nopervasives ] v
+  | "slash" -> set "slash" [ force_slash ] v (* for ocamldep *)
+  | "keep-docs" -> set "keep-docs" [ Clflags.keep_docs ] v
+  | "keep-locs" -> set "keep-locs" [ Clflags.keep_locs ] v
 
-      | "compact" -> clear "compact" [ optimize_for_speed ] v
-      | "no-app-funct" -> clear "no-app-funct" [ applicative_functors ] v
-      | "nodynlink" -> clear "nodynlink" [ dlcode ] v
-      | "short-paths" -> clear "short-paths" [ real_paths ] v
-      | "trans-mod" -> set "trans-mod" [ transparent_modules ] v
-      | "opaque" -> set "opaque" [ opaque ] v
+  | "compact" -> clear "compact" [ optimize_for_speed ] v
+  | "no-app-funct" -> clear "no-app-funct" [ applicative_functors ] v
+  | "nodynlink" -> clear "nodynlink" [ dlcode ] v
+  | "short-paths" -> clear "short-paths" [ real_paths ] v
+  | "trans-mod" -> set "trans-mod" [ transparent_modules ] v
+  | "opaque" -> set "opaque" [ opaque ] v
 
-      | "pp" -> preprocessor := Some v
-      | "runtime-variant" -> runtime_variant := v
-      | "cc" -> c_compiler := Some v
+  | "pp" -> preprocessor := Some v
+  | "runtime-variant" -> runtime_variant := v
+  | "cc" -> c_compiler := Some v
 
-      (* assembly sources *)
-      |  "s" ->
-        set "s" [ Clflags.keep_asm_file ; Clflags.keep_startup_file ] v
-      |  "S" -> set "S" [ Clflags.keep_asm_file ] v
-      |  "dstartup" -> set "dstartup" [ Clflags.keep_startup_file ] v
+  (* assembly sources *)
+  |  "s" ->
+    set "s" [ Clflags.keep_asm_file ; Clflags.keep_startup_file ] v
+  |  "S" -> set "S" [ Clflags.keep_asm_file ] v
+  |  "dstartup" -> set "dstartup" [ Clflags.keep_startup_file ] v
 
-      (* warn-errors *)
-      | "we" | "warn-error" -> Warnings.parse_options true v
-      (* warnings *)
-      |  "w"  ->               Warnings.parse_options false v
-      (* warn-errors *)
-      | "wwe" ->               Warnings.parse_options false v
+  (* warn-errors *)
+  | "we" | "warn-error" -> Warnings.parse_options true v
+  (* warnings *)
+  |  "w"  ->               Warnings.parse_options false v
+  (* warn-errors *)
+  | "wwe" ->               Warnings.parse_options false v
 
-      (* inlining *)
-      | "inline" ->
-          let module F = Float_arg_helper in
-          begin match F.parse_no_error v inline_threshold with
-          | F.Ok -> ()
-          | F.Parse_failed exn ->
-              let error =
-                Printf.sprintf "bad syntax for \"inline\": %s"
-                  (Printexc.to_string exn)
-              in
-              Location.print_warning Location.none ppf
-                (Warnings.Bad_env_variable ("OCAMLPARAM", error))
-          end
+  (* inlining *)
+  | "inline" ->
+      let module F = Float_arg_helper in
+      begin match F.parse_no_error v inline_threshold with
+      | F.Ok -> ()
+      | F.Parse_failed exn ->
+          let error =
+            Printf.sprintf "bad syntax for \"inline\": %s"
+              (Printexc.to_string exn)
+          in
+          Location.print_warning Location.none ppf
+            (Warnings.Bad_env_variable ("OCAMLPARAM", error))
+      end
 
-      (* color output *)
-      | "color" ->
-          begin match parse_color_setting v with
-          | None ->
-            Location.print_warning Location.none ppf
-              (Warnings.Bad_env_variable ("OCAMLPARAM",
-               "bad value for \"color\", \
-                (expected \"auto\", \"always\" or \"never\")"))
-          | Some setting -> color := setting
-          end
+  (* color output *)
+  | "color" ->
+      begin match parse_color_setting v with
+      | None ->
+        Location.print_warning Location.none ppf
+          (Warnings.Bad_env_variable ("OCAMLPARAM",
+           "bad value for \"color\", \
+            (expected \"auto\", \"always\" or \"never\")"))
+      | Some setting -> color := setting
+      end
 
-      | "intf-suffix" -> Config.interface_suffix := v
+  | "intf-suffix" -> Config.interface_suffix := v
 
-      | "I" -> begin
-          match position with
-          | Before_args -> first_include_dirs := v :: !first_include_dirs
-          | Before_link | Before_compile _ ->
-            last_include_dirs := v :: !last_include_dirs
-        end
+  | "I" -> begin
+      match position with
+      | Before_args -> first_include_dirs := v :: !first_include_dirs
+      | Before_link | Before_compile _ ->
+        last_include_dirs := v :: !last_include_dirs
+    end
 
-      | "cclib" ->
-        begin
-          match position with
-          | Before_compile _ -> ()
-          | Before_link | Before_args ->
-            ccobjs := Misc.rev_split_words v @ !ccobjs
-        end
+  | "cclib" ->
+    begin
+      match position with
+      | Before_compile _ -> ()
+      | Before_link | Before_args ->
+        ccobjs := Misc.rev_split_words v @ !ccobjs
+    end
 
-      | "ccopts" ->
-        begin
-          match position with
-          | Before_link | Before_compile _ ->
-            last_ccopts := v :: !last_ccopts
-          | Before_args ->
-            first_ccopts := v :: !first_ccopts
-        end
+  | "ccopts" ->
+    begin
+      match position with
+      | Before_link | Before_compile _ ->
+        last_ccopts := v :: !last_ccopts
+      | Before_args ->
+        first_ccopts := v :: !first_ccopts
+    end
 
-      | "ppx" ->
-        begin
-          match position with
-          | Before_link | Before_compile _ ->
-            last_ppx := v :: !last_ppx
-          | Before_args ->
-            first_ppx := v :: !first_ppx
-        end
+  | "ppx" ->
+    begin
+      match position with
+      | Before_link | Before_compile _ ->
+        last_ppx := v :: !last_ppx
+      | Before_args ->
+        first_ppx := v :: !first_ppx
+    end
 
 
-      | "cmo" | "cma" ->
-        if not !native_code then
-        begin
-          match position with
-          | Before_link | Before_compile _ ->
-            last_objfiles := v ::! last_objfiles
-          | Before_args ->
-            first_objfiles := v :: !first_objfiles
-        end
+  | "cmo" | "cma" ->
+    if not !native_code then
+    begin
+      match position with
+      | Before_link | Before_compile _ ->
+        last_objfiles := v ::! last_objfiles
+      | Before_args ->
+        first_objfiles := v :: !first_objfiles
+    end
 
-      | "cmx" | "cmxa" ->
-        if !native_code then
-        begin
-          match position with
-          | Before_link | Before_compile _ ->
-            last_objfiles := v ::! last_objfiles
-          | Before_args ->
-            first_objfiles := v :: !first_objfiles
-        end
+  | "cmx" | "cmxa" ->
+    if !native_code then
+    begin
+      match position with
+      | Before_link | Before_compile _ ->
+        last_objfiles := v ::! last_objfiles
+      | Before_args ->
+        first_objfiles := v :: !first_objfiles
+    end
 
-      | "pic" ->
-        if !native_code then
-          set "pic" [ pic_code ] v
+  | "pic" ->
+    if !native_code then
+      set "pic" [ pic_code ] v
 
-      | "can-discard" ->
-        can_discard := v ::!can_discard
+  | "can-discard" ->
+    can_discard := v ::!can_discard
 
-      | "timings" -> set "timings" [ print_timings ] v
+  | "timings" -> set "timings" [ print_timings ] v
 
-      | _ ->
-        if not (List.mem name !can_discard) then begin
-          can_discard := name :: !can_discard;
-          Printf.eprintf
-            "Warning: discarding value of variable %S in OCAMLPARAM\n%!"
-            name
-        end
+  | _ ->
+    if not (List.mem name !can_discard) then begin
+      can_discard := name :: !can_discard;
+      Printf.eprintf
+        "Warning: discarding value of variable %S in OCAMLPARAM\n%!"
+        name
+    end
 
 let read_OCAMLPARAM ppf position =
   try

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -378,7 +378,9 @@ let matching_filename filename { pattern } =
     filename = pattern
 
 let apply_config_file ppf position =
-  let config_file = Filename.concat Config.standard_library "compiler_configuration" in
+  let config_file =
+    Filename.concat Config.standard_library "ocaml_compiler_internal_params"
+  in
   let config =
     if Sys.file_exists config_file then
       load_config ppf config_file

--- a/driver/compenv.mli
+++ b/driver/compenv.mli
@@ -30,8 +30,10 @@ val implicit_modules : string list ref
 (* return the list of objfiles, after OCAMLPARAM and List.rev *)
 val get_objfiles : unit -> string list
 
+type filename = string
+
 type readenv_position =
-  Before_args | Before_compile | Before_link
+  Before_args | Before_compile of filename | Before_link
 
 val readenv : Format.formatter -> readenv_position -> unit
 

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -54,11 +54,11 @@ let ppf = Format.err_formatter
 
 (* Error messages to standard error formatter *)
 let anonymous filename =
-  readenv ppf Before_compile; process_file ppf filename;;
+  readenv ppf (Before_compile filename); process_file ppf filename;;
 let impl filename =
-  readenv ppf Before_compile; process_implementation_file ppf filename;;
+  readenv ppf (Before_compile filename); process_implementation_file ppf filename;;
 let intf filename =
-  readenv ppf Before_compile; process_interface_file ppf filename;;
+  readenv ppf (Before_compile filename); process_interface_file ppf filename;;
 
 let show_config () =
   Config.print_config stdout;

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -56,11 +56,11 @@ let ppf = Format.err_formatter
 
 (* Error messages to standard error formatter *)
 let anonymous filename =
-  readenv ppf Before_compile; process_file ppf filename;;
+  readenv ppf (Before_compile filename); process_file ppf filename;;
 let impl filename =
-  readenv ppf Before_compile; process_implementation_file ppf filename;;
+  readenv ppf (Before_compile filename); process_implementation_file ppf filename;;
 let intf filename =
-  readenv ppf Before_compile; process_interface_file ppf filename;;
+  readenv ppf (Before_compile filename); process_interface_file ppf filename;;
 
 let show_config () =
   Config.print_config stdout;

--- a/tools/ocamldep.ml
+++ b/tools/ocamldep.ml
@@ -367,7 +367,7 @@ let mli_file_dependencies source_file =
     end
 
 let process_file_as process_fun def source_file =
-  Compenv.readenv ppf Before_compile;
+  Compenv.readenv ppf (Before_compile source_file);
   load_path := [];
   List.iter add_to_load_path (
       (!Compenv.last_include_dirs @


### PR DESCRIPTION
This PR propose to allow adding options using a file named `compiler_configuration` present in the library directory.

Each line of this file can be either:

```
* : option = value
```

```
source_filename: option = value
```

The options are in the format of the OCAMLPARAM environment variable.

This kind of configuration is useful for bulk tests. It can also be used as a simple mean of providing a compiler with different default options (as an OPAM switch for instance),.

This proved very useful for testing/debugging Flambda, and benchmarking OCaml in general (a branch of trunk with this patch was maintained for it).

This patch is split in two for readability. The second one contains only whitespace changes.
