### PR TITLE
Manual: collection of minor updates and fixes

### DIFF
--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -553,9 +553,9 @@ If several locally abstract types need to be introduced, it is possible to use
 the syntax
 @"fun" '(' "type" typeconstr-name_1 \ldots typeconstr-name_n ')' "->" expr@
 as syntactic sugar for @"fun" '(' "type" typeconstr-name_1 ')' "->" \ldots "->"
-'(' "type" typeconstr-name_n ')' "->" expr@. For instance,
+"fun" '(' "type" typeconstr-name_n ')' "->" expr@. For instance,
 \begin{verbatim}
-        let f = fun (type t u v) -> (foo : (t * u * v) list) -> ...
+        let f = fun (type t u v) -> fun (foo : (t * u * v) list) -> ...
 \end{verbatim}
 
 This construction is useful because the type constructors it introduces

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1675,10 +1675,10 @@ module X = struct
 end
   [@@deprecated "Please use module 'Y' instead."]
 
-let x = begin[@warning "+9] ... end in ....
+let x = begin[@warning "+9"] ... end in ....
 
 type t = A | B
-  [@@deprecated "Please use type 's' instead.]
+  [@@deprecated "Please use type 's' instead."]
 
 let f x =
   assert (x >= 0) [@ppwarning "TODO: remove this later"];

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -556,6 +556,7 @@ as syntactic sugar for @"fun" '(' "type" typeconstr-name_1 ')' "->" \ldots "->"
 "fun" '(' "type" typeconstr-name_n ')' "->" expr@. For instance,
 \begin{verbatim}
         let f = fun (type t u v) -> fun (foo : (t * u * v) list) -> ...
+        let f' (type t u v) (foo : (t * u * v) list) = ...
 \end{verbatim}
 
 This construction is useful because the type constructors it introduces

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -447,9 +447,9 @@ For example, assuming the record type
 \end{verbatim}
 has been declared, the following expressions are equivalent:
 \begin{verbatim}
-          let x = 1 and y = 2 in { x = x; y = y }
-          let x = 1 and y = 2 in { x; y }
-          let x = 1 and y = 2 in { x = x; y }
+          let x = 1. and y = 2. in { x = x; y = y },
+          let x = 1. and y = 2. in { x; y },
+          let x = 1. and y = 2. in { x = x; y }
 \end{verbatim}
 On the object side, all following methods are equivalent:
 \begin{verbatim}
@@ -462,8 +462,8 @@ On the object side, all following methods are equivalent:
 \end{verbatim}
 Likewise, the following functions are equivalent:
 \begin{verbatim}
-          fun {x = x; y = y} -> x + y
-          fun {x; y} -> x + y
+          fun {x = x; y = y} -> x +. y
+          fun {x; y} -> x +. y
 \end{verbatim}
 
 Optionally, a record pattern can be terminated by @';' '_'@ to convey the
@@ -474,11 +474,11 @@ the compiler will warn when a record pattern fails to list all fields of
 the corresponding record type and is not terminated by @';' '_'@.
 Continuing the "point" example above,
 \begin{verbatim}
-          fun {x} -> x + 1
+          fun {x} -> x +. 1.
 \end{verbatim}
 \noindent will warn if warning 9 is on, while
 \begin{verbatim}
-          fun {x; _} -> x + 1
+          fun {x; _} -> x +. 1.
 \end{verbatim}
 \noindent will not warn.  This warning can help spot program points where
 record patterns may need to be modified after new fields are added to a

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1802,8 +1802,11 @@ type t = ..
 type t += X of int | Y of string
 let x = [%extension_constructor X]
 let y = [%extension_constructor Y]
-let () = assert (x <> y)
 \end{verbatim}
+\caml
+\? x <> y;;
+\:- : bool = true
+\endcaml
 
 \section{Quoted strings}\label{s:quoted-strings}
 

--- a/manual/manual/tutorials/moduleexamples.etex
+++ b/manual/manual/tutorials/moduleexamples.etex
@@ -227,7 +227,7 @@ module NoCaseString =
   struct
     type t = string
     let compare s1 s2 =
-      OrderedString.compare (String.lowercase s1) (String.lowercase s2)
+      OrderedString.compare (String.lowercase_ascii s1) (String.lowercase_ascii s2)
   end;;
 module NoCaseStringSet = AbstractSet(NoCaseString);;
 NoCaseStringSet.add "FOO" AbstractStringSet.empty;;


### PR DESCRIPTION
This pull requestion is a collection of fixes and minor updates for the manual that had escaped my attention previously. The fix are in commit orders:
- fix some missing quotes in the built-in attribute example
- fix and improve the example for the multiple locally abstract types
- replace the deprecated `lowercase` by `lowercase_ascii` in the module chapter
- uniformize types in the "record and object notations" section
- improve the `[%extension_constructor]` example
