### PR TITLE
Const_float_array are constant for branch merging

### DIFF
--- a/Changes
+++ b/Changes
@@ -138,6 +138,8 @@ Compilers:
   (Leo White)
 - PR#6920: fix debug informations around uses of %apply or %revapply
   (Jérémie Dimino)
+- GPR#431: permit constant float arrays to be eligible for pattern match
+  branch merging (Pierre Chambart)
 
 Runtime system:
 - PR#3612: allow allocating custom block with finalizers in the minor heap

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -274,7 +274,7 @@ let make_key e =
         try Ident.find_same id env
         with Not_found -> e
       end
-    | Lconst  (Const_base (Const_string _)|Const_float_array _) ->
+    | Lconst  (Const_base (Const_string _)) ->
         (* Mutable constants are not shared *)
         raise Not_simple
     | Lconst _ -> e


### PR DESCRIPTION
Following discussions on https://github.com/ocaml/ocaml/pull/417 it appeared that Const_float_arrays build immutable values, but that pattern matching branch merging wrongly believe that it is not the case.

This fix cases like this where the branch where not merged.

```
let f x =
  match x with
  | None -> [|1.|]
  | Some _ -> [|1.|]
```

Notice that it effectively not make those mergeable:

```
let g x =
  match x with
  | None -> [|0.|]
  | Some _ -> [|-.0.|]
```

This is a minor performance patch, but I think that it is important for documentation purpose.
