### PR TITLE
remove unused (and wrong?) line in cmmgen.ml

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -427,7 +427,6 @@ let safe_mod_bi =
 
 let test_bool = function
     Cop(Caddi, [Cop(Clsl, [c; Cconst_int 1]); Cconst_int 1]) -> c
-  | Cop(Clsl, [c; Cconst_int 1]) -> c
   | c -> Cop(Ccmpi Cne, [c; Cconst_int 1])
 
 (* Float *)


### PR DESCRIPTION
Consider this function found in `cmmgen.ml`:

```
 let test_bool = function
     Cop(Caddi, [Cop(Clsl, [c; Cconst_int 1]); Cconst_int 1]) -> c
   | Cop(Clsl, [c; Cconst_int 1]) -> c
   | c -> Cop(Ccmpi Cne, [c; Cconst_int 1])
```

I am questioning the correctness of the second clause when `c` is `Const_int 0`: if I read it correctly it says that 0 is equal to 1. Moreover, it is never triggered when compiling the system, the testsuite, or any of about 150 OPAM packages that I tried.
