### PR TITLE
Fix native Windows ports (problems with #423 and #425)

### DIFF
--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -86,6 +86,7 @@ RUNTIMED=noruntimed
 ASM_CFI_SUPPORTED=false
 UNIXLIB=win32unix
 GRAPHLIB=win32graph
+FLAMBDA=false
 
 ########## Configuration for the bytecode compiler
 

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -86,6 +86,7 @@ RUNTIMED=noruntimed
 ASM_CFI_SUPPORTED=false
 UNIXLIB=win32unix
 GRAPHLIB=win32graph
+FLAMBDA=false
 
 ########## Configuration for the bytecode compiler
 

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -77,6 +77,7 @@ RUNTIMED=noruntimed
 ASM_CFI_SUPPORTED=false
 UNIXLIB=win32unix
 GRAPHLIB=win32graph
+FLAMBDA=false
 
 ########## Configuration for the bytecode compiler
 

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -76,6 +76,7 @@ RUNTIMED=noruntimed
 ASM_CFI_SUPPORTED=false
 UNIXLIB=win32unix
 GRAPHLIB=win32graph
+FLAMBDA=false
 
 ########## Configuration for the bytecode compiler
 

--- a/tools/Makefile.nt
+++ b/tools/Makefile.nt
@@ -15,7 +15,7 @@ include Makefile.shared
 # To make custom toplevels
 
 OCAMLMKTOP=ocamlmktop.cmo
-OCAMLMKTOP_IMPORTS=misc.cmo identifiable.cmo numbers.cmo config.cmo clflags.cmo ccomp.cmo
+OCAMLMKTOP_IMPORTS=misc.cmo identifiable.cmo numbers.cmo config.cmo arg_helper.cmo clflags.cmo ccomp.cmo
 
 ocamlmktop: $(OCAMLMKTOP)
 	$(CAMLC) $(LINKFLAGS) -o ocamlmktop $(OCAMLMKTOP_IMPORTS) $(OCAMLMKTOP)


### PR DESCRIPTION
#423 breaks the native Windows building of ocamlmktop (which is not a script)
#425 does not define FLAMBDA for the native Windows ports, corrupting utils/config.ml
