### PR TITLE
A further MS Universal CRT tweak

### DIFF
--- a/byterun/str.c
+++ b/byterun/str.c
@@ -294,7 +294,7 @@ CAMLexport value caml_alloc_sprintf(const char * format, ...)
   int n;
   value res;
 
-#ifndef _WIN32
+#if !defined(_WIN32) || defined(_UCRT)
   /* C99-compliant implementation */
   va_start(args, format);
   /* "vsnprintf(dest, sz, format, args)" writes at most "sz" characters


### PR DESCRIPTION
[This blog post](http://blogs.msdn.com/b/vcblog/archive/2014/06/18/crt-features-fixes-and-breaking-changes-in-visual-studio-14-ctp1.aspx) announced the support in Visual Studio 2015 for compliant implementations of snprintf and vsnprintf which #405 took advantage of.
However, OCaml's usage of (v)snprintf (e.g. in caml_alloc_sprintf) doesn't in normal use rely on the output value, because the buffers are expected to big enough.
In passing, I noticed that MSDN documentation for [vsprintf](https://msdn.microsoft.com/en-us/library/1kt27hek.aspx) even in the Visual Studio 2015 version suggests that vsnprintf still behaves the old way and the page for [_snprintf](https://msdn.microsoft.com/en-us/library/2ts7cx93.aspx) doesn't even mention snprintf!
I did some further (simple) testing to ensure that the return value of VS 2015's vsnprintf and snprintf are in fact as expected (i.e. when the buffer isn't large enough, the length of the formatted string rather than a negative number). Fortunately, it seems that the blog post is correct, but no one got around to updating the CRT documentation!
This means that #405 is fine, but while checking this, I determined that the workaround in `byterun/str.c` for vsnprintf is no longer required for VS 2015 so altered the conditional define.
It's probably worth a wholesale review (perhaps creating a task/wiki list of the hacks) of Windows/MSVC specific pre-processor defines, but that feels like a job best done with or after having feature-based configure detection on the native branches. Even if it turns out just to be a very large Embrace-Extend-Extinguish, Microsoft do seem to be heading in a very standards-compliant direction these days, so it seems worth having the hacks listed for checking when newer versions come out!
