### PR TITLE
Make travis runs the testsuite with the debug runtime

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -29,7 +29,7 @@ control.
 ------------------------------------------------------------------------
 EOF
     mkdir -p $PREFIX
-    ./configure --prefix $PREFIX
+    ./configure --prefix $PREFIX -with-debug-runtime -with-instrumented-runtime
     export PATH=$PREFIX/bin:$PATH
     make world.opt
     make install

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -34,6 +34,7 @@ EOF
     make world.opt
     make install
     (cd testsuite && make all)
+    (cd testsuite && make USE_RUNTIME="d" all)
     mkdir external-packages
     cd external-packages
     git clone git://github.com/ocaml/camlp4

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -326,7 +326,6 @@ void caml_empty_minor_heap (void)
       }
     }
     CAML_INSTR_TIME (tmr, "minor/update_weak");
-    CAMLassert (caml_young_ptr >= caml_young_alloc_start);
     caml_stat_minor_words += caml_young_alloc_end - caml_young_ptr;
     caml_gc_clock += (double) (caml_young_alloc_end - caml_young_ptr)
                      / caml_minor_heap_wsz;

--- a/configure
+++ b/configure
@@ -1061,6 +1061,23 @@ if test "$with_curses" = "yes"; then
   done
 fi
 
+# For instrumented runtime
+# (clock_gettime needs -lrt for glibc before 2.17)
+if $with_instrumented_runtime; then
+  with_instrumented_runtime=false #enabled it only if found
+  for libs in "" "-lrt"; do
+    if sh ./hasgot $libs clock_gettime; then
+      inf "clock_gettime functions found (with libraries '$libs')"
+      instrumented_runtime_libs="${libs}"
+      with_instrumented_runtime=true;
+      break
+    fi
+  done
+  if ! $with_instrumented_runtime; then
+      err "clock_gettime functions not found. Instrumented runtime can't be built."
+  fi
+fi
+
 # Configuration for the libraries
 
 case "$system" in
@@ -1719,7 +1736,8 @@ cclibs="$cclibs $mathlib"
 echo "BYTECC=$bytecc" >> Makefile
 echo "BYTECCCOMPOPTS=$bytecccompopts" >> Makefile
 echo "BYTECCLINKOPTS=$bytecclinkopts" >> Makefile
-echo "BYTECCLIBS=$cclibs $dllib $curseslibs $pthread_link" >> Makefile
+echo "BYTECCLIBS=$cclibs $dllib $curseslibs $pthread_link \
+                 $instrumented_runtime_libs" >> Makefile
 echo "BYTECCRPATH=$byteccrpath" >> Makefile
 echo "EXE=$exe" >> Makefile
 echo "SUPPORTS_SHARED_LIBRARIES=$shared_libraries_supported" >> Makefile

--- a/testsuite/makefiles/Makefile.common
+++ b/testsuite/makefiles/Makefile.common
@@ -43,7 +43,17 @@ SET_LD_PATH=CAML_LD_LIBRARY_PATH="$(LD_PATH)"
 
 include $(TOPDIR)/config/Makefile
 
-OCAMLRUN=$(TOPDIR)/boot/ocamlrun$(EXE)
+ifneq ($(USE_RUNTIME),)
+#Check USE_RUNTIME value
+ifeq ($(findstring $(USE_RUNTIME),d i),)
+$(error If set, USE_RUNTIME must be equal to "d" (debug runtime) or "i" (instrumented runtime))
+endif
+
+RUNTIME_VARIANT=-I $(OTOPDIR)/asmrun -I $(OTOPDIR)/byterun -runtime-variant $(USE_RUNTIME)
+export OCAMLRUNPARAM?=v=0
+endif
+
+OCAMLRUN=$(TOPDIR)/byterun/ocamlrun$(USE_RUNTIME)$(EXE)
 
 OCFLAGS=-nostdlib -I $(OTOPDIR)/stdlib $(COMPFLAGS)
 OCOPTFLAGS=
@@ -57,15 +67,15 @@ endif
 OCAML=$(OCAMLRUN) $(OTOPDIR)/ocaml $(OCFLAGS) \
       -init $(OTOPDIR)/testsuite/lib/empty
 FLEXLINK_PREFIX=$(if $(FLEXLINK),$(if $(wildcard $(TOPDIR)/flexdll/Makefile),OCAML_FLEXLINK="$(WINTOPDIR)/boot/ocamlrun $(WINTOPDIR)/flexdll/flexlink.exe" ))
-OCAMLC=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlc $(CUSTOM) $(OCFLAGS)
-OCAMLOPT=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlopt $(OCFLAGS)
+OCAMLC=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlc $(CUSTOM) $(OCFLAGS) $(RUNTIME_VARIANT)
+OCAMLOPT=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/ocamlopt $(OCFLAGS) $(RUNTIME_VARIANT)
 OCAMLDOC=$(OCAMLRUN) $(OTOPDIR)/ocamldoc/ocamldoc
 OCAMLLEX=$(OCAMLRUN) $(OTOPDIR)/lex/ocamllex
 OCAMLMKLIB=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/tools/ocamlmklib \
-		       -ocamlc "$(OTOPDIR)/boot/ocamlrun$(EXE) \
-		                $(OTOPDIR)/ocamlc $(OCFLAGS)" \
-		       -ocamlopt "$(OTOPDIR)/boot/ocamlrun$(EXE) \
-		                  $(OTOPDIR)/ocamlopt $(OCFLAGS)"
+		       -ocamlc "$(OTOPDIR)/byterun/ocamlrun$(USE_RUNTIME)$(EXE) \
+		                $(OTOPDIR)/ocamlc $(OCFLAGS) $(RUNTIME_VARIANT)" \
+		       -ocamlopt "$(OTOPDIR)/byterun/ocamlrun$(USE_RUNTIME)$(EXE) \
+		                  $(OTOPDIR)/ocamlopt $(OCFLAGS) $(RUNTIME_VARIANT)"
 OCAMLYACC=$(TOPDIR)/yacc/ocamlyacc$(EXE)
 OCAMLBUILD=$(TOPDIR)/_build/ocamlbuild/ocamlbuild.native
 DUMPOBJ=$(OCAMLRUN) $(OTOPDIR)/tools/dumpobj

--- a/testsuite/tests/backtrace/Makefile
+++ b/testsuite/tests/backtrace/Makefile
@@ -70,7 +70,7 @@ native:
 	  $(OCAMLOPT) -g -o $(EXECNAME) $$file; \
 	  printf " ... testing '$$file' with ocamlopt:"; \
 	  F="`basename $$file .ml`"; \
-	  (OCAMLRUNPARAM=$OCAMLRUNPARAM,b=1 \
+	  (OCAMLRUNPARAM=$$OCAMLRUNPARAM,b=1 \
             ./$(EXECNAME) $$arg || true) \
 	       >$$F.native.result 2>&1; \
 	  $(DIFF) $$F.reference $$F.native.result >/dev/null \

--- a/testsuite/tests/lib-dynlink-bytecode/Makefile
+++ b/testsuite/tests/lib-dynlink-bytecode/Makefile
@@ -39,7 +39,7 @@ compile:
 	@rm -f main static custom custom.exe
 	@$(OCAMLC) -o main dynlink.cma registry.cmo main.cmo
 	@$(OCAMLC) -o static -linkall registry.cmo plug1.cma plug2.cma \
-	           -use-runtime $(OTOPDIR)/boot/ocamlrun$(EXE)
+	           -use-runtime $(OTOPDIR)/byterun/ocamlrun$(USE_RUNTIME)$(EXE)
 	@$(OCAMLC) -o custom$(EXE) -custom -linkall registry.cmo plug2.cma \
 	           plug1.cma -I .
 


### PR DESCRIPTION
At the current time, some tests are failing when run with the debug runtime:

```
file signals_asm.c; line 70 ### Assertion failed: caml_young_ptr >= caml_young_alloc_start
```

This pull-request doesn't fix the root of the problem but just add to travis the ability to catch future one. It also compile the instrumented runtime, for catching errors in `CAML_INSTR` macros. It shouldn't be merged before fixing the problem in `signal_asm.c`.
