### PR TITLE
Enable tests/asmcomp for MSVC

### DIFF
--- a/testsuite/makefiles/Makefile.common
+++ b/testsuite/makefiles/Makefile.common
@@ -91,7 +91,7 @@ defaultclean:
 	done
 
 .SUFFIXES:
-.SUFFIXES: .mli .ml .mly .mll .cmi .cmo .cmx .cmm .cmxa .s .S .o .so .c .f
+.SUFFIXES: .mli .ml .mly .mll .cmi .cmo .cmx .cmm .cmxa .s .S .$(O) .so .c .f
 
 .mli.cmi:
 	@$(OCAMLC) -c $(ADD_COMPFLAGS) $<
@@ -121,6 +121,11 @@ defaultclean:
 .cmm.o:
 	@$(OCAMLRUN) ./codegen $*.cmm > $*.s
 	@$(ASM) -o $*.o $*.s
+
+.cmm.obj:
+	@$(OCAMLRUN) ./codegen $*.cmm | grep -v "_caml_\(young_ptr\|young_limit\|extra_params\|allocN\|raise_exn\|reraise_exn\)" > $*.s
+	@set -o pipefail ; \
+	$(ASM) $*.obj $*.s | tail -n +2
 
 .S.o:
 	@$(ASPP) $(ASPPFLAGS) -DSYS_$(SYSTEM) -DMODEL_$(MODEL) -o $*.o $*.S

--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -12,9 +12,6 @@
 
 BASEDIR=../..
 
-CC=$(NATIVECC)
-CFLAGS=$(NATIVECCCOMPOPTS) -g
-
 INCLUDES=\
   -I $(OTOPDIR)/utils \
   -I $(OTOPDIR)/typing \
@@ -30,7 +27,7 @@ OBJS=parsecmmaux.cmo parsecmm.cmo lexcmm.cmo
 ADD_COMPFLAGS=$(INCLUDES) -w -40 -g
 
 default:
-	@if $(BYTECODE_ONLY) || [ -z "$(ASPP)" ]; then : ; else \
+	@if $(BYTECODE_ONLY) ; then : ; else \
 	  $(MAKE) all; \
 	fi
 
@@ -64,31 +61,43 @@ ARGS_tagged-integr=-DINT_FLOAT -DFUN=test main.c
 ARGS_tagged-quicksort=-DSORT -DFUN=quicksort main.c
 ARGS_tagged-tak=-DUNIT_INT -DFUN=takmain main.c
 
-tests: $(CASES:=.o)
+one_ml:
+	@$(OCAMLOPT) -o $(NAME).exe $(NAME).ml && \
+	./$(NAME).exe && echo " => passed" || echo " => failed"
+
+one:
+	@set -o pipefail ; \
+	$(call CC,$(NAME).out $(ARGS_$(NAME)) $(NAME).$(O) $(ARCH).$(O)) \
+	&& echo " => passed" || echo " => failed"
+
+clean: defaultclean
+	@rm -f ./codegen *.out *.$(O) *.exe
+	@rm -f parsecmm.ml parsecmm.mli lexcmm.ml
+	@rm -f $(CASES:=.s)
+
+include $(BASEDIR)/makefiles/Makefile.common
+
+ifeq ($(CCOMPTYPE),msvc)
+CC=$(NATIVECC) $(CFLAGS) /Fe$(1) | tail -n +2
+CFLAGS=$(NATIVECCCOMPOPTS)
+else
+CC=$(NATIVECC) $(CFLAGS) -o $(1)
+CFLAGS=$(NATIVECCCOMPOPTS) -g
+endif
+tests: $(CASES:=.$(O))
 	@for c in $(CASES); do \
 	  printf " ... testing '$$c':"; \
-	  $(MAKE) one CC="$(CC) $(CFLAGS)" NAME=$$c; \
+	  $(MAKE) one NAME=$$c; \
 	done
 	@for c in $(MLCASES); do \
 	  printf " ... testing '$$c':"; \
           $(MAKE) one_ml NAME=$$c; \
         done
 
-one_ml:
-	@$(OCAMLOPT) -o $(NAME).exe $(NAME).ml && \
-	./$(NAME).exe && echo " => passed" || echo " => failed"
-
-one:
-	@$(CC) -o $(NAME).out $(ARGS_$(NAME)) $(NAME).o $(ARCH).o \
-	&& echo " => passed" || echo " => failed"
-
-clean: defaultclean
-	@rm -f ./codegen *.out *.o *.obj *.exe
-	@rm -f parsecmm.ml parsecmm.mli lexcmm.ml
-	@rm -f $(CASES:=.s)
-
-include $(BASEDIR)/makefiles/Makefile.common
-
 promote:
 
-arch: $(ARCH).o
+arch: $(ARCH).$(O)
+
+i386.obj: i386nt.asm
+	@set -o pipefail ; \
+	$(ASM) $@ $^ | tail -n +2

--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -66,8 +66,7 @@ one_ml:
 	./$(NAME).exe && echo " => passed" || echo " => failed"
 
 one:
-	@set -o pipefail ; \
-	$(call CC,$(NAME).out $(ARGS_$(NAME)) $(NAME).$(O) $(ARCH).$(O)) \
+	@$(call CC,$(NAME).out $(ARGS_$(NAME)) $(NAME).$(O) $(ARCH).$(O)) \
 	&& echo " => passed" || echo " => failed"
 
 clean: defaultclean
@@ -78,7 +77,7 @@ clean: defaultclean
 include $(BASEDIR)/makefiles/Makefile.common
 
 ifeq ($(CCOMPTYPE),msvc)
-CC=$(NATIVECC) $(CFLAGS) /Fe$(1) | tail -n +2
+CC=set -o pipefail ; $(NATIVECC) $(CFLAGS) /Fe$(1) | tail -n +2
 CFLAGS=$(NATIVECCCOMPOPTS)
 else
 CC=$(NATIVECC) $(CFLAGS) -o $(1)


### PR DESCRIPTION
I've been picking up on tests which aren't run at all under the MSVC versions of the testsuite.
As far as I could tell, tests/asmcomp was simply disabled when the testsuite was ported - but I noticed that there was a very old i386nt.asm file there so thought I'd have a go.
This commit (badly) re-enables it for 32-bit MSVC, and it seems to be working - I don't know exactly what's necessary for 64-bit MSVC (it looks like it's a case of hacking the appropriate file from asmrun, but I'd be doing just that - hacking!)
Is someone more expert than I willing either to take this and complete it, or point me in a less hackish direction to complete it?
