### PR TITLE
Fix instrumented runtime for glibc < 2.17

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -29,7 +29,7 @@ control.
 ------------------------------------------------------------------------
 EOF
     mkdir -p $PREFIX
-    ./configure --prefix $PREFIX
+    ./configure --prefix $PREFIX -with-debug-runtime -with-instrumented-runtime
     export PATH=$PREFIX/bin:$PATH
     make world.opt
     make install

--- a/configure
+++ b/configure
@@ -1061,6 +1061,23 @@ if test "$with_curses" = "yes"; then
   done
 fi
 
+# For instrumented runtime
+# (clock_gettime needs -lrt for glibc before 2.17)
+if $with_instrumented_runtime; then
+  with_instrumented_runtime=false #enabled it only if found
+  for libs in "" "-lrt"; do
+    if sh ./hasgot $libs clock_gettime; then
+      inf "clock_gettime functions found (with libraries '$libs')"
+      instrumented_runtime_libs="${libs}"
+      with_instrumented_runtime=true;
+      break
+    fi
+  done
+  if ! $with_instrumented_runtime; then
+      err "clock_gettime functions not found. Instrumented runtime can't be built."
+  fi
+fi
+
 # Configuration for the libraries
 
 case "$system" in
@@ -1719,7 +1736,8 @@ cclibs="$cclibs $mathlib"
 echo "BYTECC=$bytecc" >> Makefile
 echo "BYTECCCOMPOPTS=$bytecccompopts" >> Makefile
 echo "BYTECCLINKOPTS=$bytecclinkopts" >> Makefile
-echo "BYTECCLIBS=$cclibs $dllib $curseslibs $pthread_link" >> Makefile
+echo "BYTECCLIBS=$cclibs $dllib $curseslibs $pthread_link \
+                 $instrumented_runtime_libs" >> Makefile
 echo "BYTECCRPATH=$byteccrpath" >> Makefile
 echo "EXE=$exe" >> Makefile
 echo "SUPPORTS_SHARED_LIBRARIES=$shared_libraries_supported" >> Makefile


### PR DESCRIPTION
- Compile the instrumented runtime, for catching errors in CAML_INSTR
    macros.
- Compile the debug runtime for compile time errors in Assert.
