### PR TITLE
More errors with unboxed and untagged attributes

### DIFF
--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -11,22 +11,22 @@
 (***********************************************************************)
 
 
-external a : (int [@untagged]) -> unit = "a"
-external b : (int32 [@unboxed]) -> unit = "b"
-external c : (int64 [@unboxed]) -> unit = "c"
-external d : (nativeint [@unboxed]) -> unit = "d"
-external e : (float [@unboxed]) -> unit = "e"
+external a : (int [@untagged]) -> unit = "a" "a_nat"
+external b : (int32 [@unboxed]) -> unit = "b" "b_nat"
+external c : (int64 [@unboxed]) -> unit = "c" "c_nat"
+external d : (nativeint [@unboxed]) -> unit = "d" "d_nat"
+external e : (float [@unboxed]) -> unit = "e" "e_nat"
 
 type t = private int
 
-external f : (t [@untagged]) -> unit = "f"
+external f : (t [@untagged]) -> unit = "f" "f_nat"
 
 module M : sig
-  external a : int -> (int [@untagged]) = "a"
-  external b : (int [@untagged]) -> int = "b"
+  external a : int -> (int [@untagged]) = "a" "a_nat"
+  external b : (int [@untagged]) -> int = "b" "b_nat"
 end = struct
-  external a : int -> (int [@untagged]) = "a"
-  external b : (int [@untagged]) -> int = "b"
+  external a : int -> (int [@untagged]) = "a" "a_nat"
+  external b : (int [@untagged]) -> int = "b" "b_nat"
 end;;
 
 module Global_attributes = struct
@@ -38,11 +38,12 @@ module Global_attributes = struct
   external d : float -> float = "d" "noalloc"
   external e : float -> float = "e"
 
+  (* Should outputs a warning: no native implementation provided *)
   external f : (int32 [@unboxed]) -> (int32 [@unboxed]) = "f" "noalloc"
-  external g : int32 -> int32 = "g" [@@unboxed] [@@noalloc]
+  external g : int32 -> int32 = "g" "g_nat" [@@unboxed] [@@noalloc]
 
-  external h : (int [@untagged]) -> (int [@untagged]) = "h" "noalloc"
-  external i : int -> int = "i" [@@untagged] [@@noalloc]
+  external h : (int [@untagged]) -> (int [@untagged]) = "h" "h_nat" "noalloc"
+  external i : int -> int = "i" "i_nat" [@@untagged] [@@noalloc]
 end;;
 
 module Old_style_warning = struct
@@ -51,74 +52,87 @@ module Old_style_warning = struct
   external b : float -> float = "b" "noalloc" "b_nat"
   external c : float -> float = "c" "c_nat" "float"
   external d : float -> float = "d" "noalloc"
+  external e : float -> float = "c" "float"
 end
 
 (* Bad: attributes not reported in the interface *)
 
 module Bad1 : sig
-  external f : int -> int = "f"
+  external f : int -> int = "f" "f_nat"
 end = struct
-  external f : int -> (int [@untagged]) = "f"
+  external f : int -> (int [@untagged]) = "f" "f_nat"
 end;;
 
 module Bad2 : sig
-  external f : int -> int = "a"
+  external f : int -> int = "a" "a_nat"
 end = struct
-  external f : (int [@untagged]) -> int = "f"
+  external f : (int [@untagged]) -> int = "f" "f_nat"
 end;;
 
 module Bad3 : sig
-  external f : float -> float = "f"
+  external f : float -> float = "f" "f_nat"
 end = struct
-  external f : float -> (float [@unboxed]) = "f"
+  external f : float -> (float [@unboxed]) = "f" "f_nat"
 end;;
 
 module Bad4 : sig
-  external f : float -> float = "a"
+  external f : float -> float = "a" "a_nat"
 end = struct
-  external f : (float [@unboxed]) -> float = "f"
+  external f : (float [@unboxed]) -> float = "f" "f_nat"
 end;;
 
 (* Bad: attributes in the interface but not in the implementation *)
 
 module Bad5 : sig
-  external f : int -> (int [@untagged]) = "f"
+  external f : int -> (int [@untagged]) = "f" "f_nat"
 end = struct
-  external f : int -> int = "f"
+  external f : int -> int = "f" "f_nat"
 end;;
 
 module Bad6 : sig
-  external f : (int [@untagged]) -> int = "f"
+  external f : (int [@untagged]) -> int = "f" "f_nat"
 end = struct
-  external f : int -> int = "a"
+  external f : int -> int = "a" "a_nat"
 end;;
 
 module Bad7 : sig
-  external f : float -> (float [@unboxed]) = "f"
+  external f : float -> (float [@unboxed]) = "f" "f_nat"
 end = struct
-  external f : float -> float = "f"
+  external f : float -> float = "f" "f_nat"
 end;;
 
 module Bad8 : sig
-  external f : (float [@unboxed]) -> float = "f"
+  external f : (float [@unboxed]) -> float = "f" "f_nat"
 end = struct
-  external f : float -> float = "a"
+  external f : float -> float = "a" "a_nat"
 end;;
 
 (* Bad: unboxed or untagged with the wrong type *)
 
-external g : (float [@untagged]) -> float = "g";;
-external h : (int [@unboxed]) -> float = "h";;
+external g : (float [@untagged]) -> float = "g" "g_nat";;
+external h : (int [@unboxed]) -> float = "h" "h_nat";;
+
+(* Bad: unboxing the function type *)
+external i : int -> float [@unboxed] = "i" "i_nat";;
+
+(* Bad: unboxing a "deep" sub-type. *)
+external j : int -> (float [@unboxed]) * float = "j" "j_nat";;
 
 (* This should be rejected, but it is quite complicated to do
    in the current state of things *)
 
-external i : int -> float [@unboxed] = "i";;
-external j : int -> (float [@unboxed]) * float = "j";;
-external k : int -> (float [@unboxd]) = "k";;
+external k : int -> (float [@unboxd]) = "k" "k_nat";;
 
 (* Bad: old style annotations + new style attributes *)
 
 external l : float -> float = "l" "l_nat" "float" [@@unboxed];;
 external m : (float [@unboxed]) -> float = "m" "m_nat" "float";;
 external n : float -> float = "n" "noalloc" [@@noalloc];;
+
+(* Warnings: unboxed / untagged without any native implementation *)
+external o : (float[@unboxed]) -> float = "o";;
+external p : float -> (float[@unboxed]) = "p";;
+external q : (int[@untagged]) -> float = "q";;
+external r : int -> (int[@untagged]) = "r";;
+external s : int -> int = "s" [@@untagged];;
+external t : float -> float = "t" [@@unboxed];;

--- a/testsuite/tests/typing-unboxed/test.ml.reference
+++ b/testsuite/tests/typing-unboxed/test.ml.reference
@@ -1,29 +1,21 @@
 
-#                                                           external a : (int [@untagged]) -> unit = "a"
-external b : (int32 [@unboxed]) -> unit = "b"
-external c : (int64 [@unboxed]) -> unit = "c"
-external d : (nativeint [@unboxed]) -> unit = "d"
-external e : (float [@unboxed]) -> unit = "e"
+#                                                           external a : (int [@untagged]) -> unit = "a" "a_nat"
+external b : (int32 [@unboxed]) -> unit = "b" "b_nat"
+external c : (int64 [@unboxed]) -> unit = "c" "c_nat"
+external d : (nativeint [@unboxed]) -> unit = "d" "d_nat"
+external e : (float [@unboxed]) -> unit = "e" "e_nat"
 type t = private int
-external f : (t [@untagged]) -> unit = "f"
+external f : (t [@untagged]) -> unit = "f" "f_nat"
 module M :
   sig
-    external a : int -> (int [@untagged]) = "a"
-    external b : (int [@untagged]) -> int = "b"
+    external a : int -> (int [@untagged]) = "a" "a_nat"
+    external b : (int [@untagged]) -> int = "b" "b_nat"
   end
-#                               module Global_attributes :
-  sig
-    external a : float -> float = "a" "a_nat" [@@unboxed] [@@noalloc]
-    external b : float -> float = "b" "b_nat" [@@noalloc]
-    external c : float -> float = "c" "c_nat" [@@unboxed] [@@noalloc]
-    external d : float -> float = "d" [@@noalloc]
-    external e : float -> float = "e"
-    external f : int32 -> int32 = "f" [@@unboxed] [@@noalloc]
-    external g : int32 -> int32 = "g" [@@unboxed] [@@noalloc]
-    external h : int -> int = "h" [@@untagged] [@@noalloc]
-    external i : int -> int = "i" [@@untagged] [@@noalloc]
-  end
-#                               Characters 63-122:
+#                                 Characters 383-452:
+    external f : (int32 [@unboxed]) -> (int32 [@unboxed]) = "f" "noalloc"
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The native code version of the primitive is mandatory when attributes [@untagged] or [@unboxed] are present
+#                                 Characters 63-122:
     external a : float -> float = "a" "noalloc" "a_nat" "float"
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 3: deprecated: [@@unboxed] + [@@noalloc] should be used instead of "float"
@@ -39,121 +31,127 @@ Characters 231-274:
     external d : float -> float = "d" "noalloc"
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 3: deprecated: [@@noalloc] should be used instead of "noalloc"
-Characters 389-445:
+Characters 441-505:
   ......struct
-    external f : int -> (int [@untagged]) = "f"
+    external f : int -> (int [@untagged]) = "f" "f_nat"
   end..
 Error: Signature mismatch:
        Modules do not match:
-         sig external f : int -> (int [@untagged]) = "f" end
+         sig external f : int -> (int [@untagged]) = "f" "f_nat" end
        is not included in
-         sig external f : int -> int = "f" end
+         sig external f : int -> int = "f" "f_nat" end
        Values do not match:
-         external f : int -> (int [@untagged]) = "f"
+         external f : int -> (int [@untagged]) = "f" "f_nat"
        is not included in
-         external f : int -> int = "f"
-#           Characters 57-113:
+         external f : int -> int = "f" "f_nat"
+#           Characters 65-129:
   ......struct
-    external f : (int [@untagged]) -> int = "f"
+    external f : (int [@untagged]) -> int = "f" "f_nat"
   end..
 Error: Signature mismatch:
        Modules do not match:
-         sig external f : (int [@untagged]) -> int = "f" end
+         sig external f : (int [@untagged]) -> int = "f" "f_nat" end
        is not included in
-         sig external f : int -> int = "a" end
+         sig external f : int -> int = "a" "a_nat" end
        Values do not match:
-         external f : (int [@untagged]) -> int = "f"
+         external f : (int [@untagged]) -> int = "f" "f_nat"
        is not included in
-         external f : int -> int = "a"
-#           Characters 61-120:
+         external f : int -> int = "a" "a_nat"
+#           Characters 69-136:
   ......struct
-    external f : float -> (float [@unboxed]) = "f"
+    external f : float -> (float [@unboxed]) = "f" "f_nat"
   end..
 Error: Signature mismatch:
        Modules do not match:
-         sig external f : float -> (float [@unboxed]) = "f" end
+         sig external f : float -> (float [@unboxed]) = "f" "f_nat" end
        is not included in
-         sig external f : float -> float = "f" end
+         sig external f : float -> float = "f" "f_nat" end
        Values do not match:
-         external f : float -> (float [@unboxed]) = "f"
+         external f : float -> (float [@unboxed]) = "f" "f_nat"
        is not included in
-         external f : float -> float = "f"
-#           Characters 61-120:
+         external f : float -> float = "f" "f_nat"
+#           Characters 69-136:
   ......struct
-    external f : (float [@unboxed]) -> float = "f"
+    external f : (float [@unboxed]) -> float = "f" "f_nat"
   end..
 Error: Signature mismatch:
        Modules do not match:
-         sig external f : (float [@unboxed]) -> float = "f" end
+         sig external f : (float [@unboxed]) -> float = "f" "f_nat" end
        is not included in
-         sig external f : float -> float = "a" end
+         sig external f : float -> float = "a" "a_nat" end
        Values do not match:
-         external f : (float [@unboxed]) -> float = "f"
+         external f : (float [@unboxed]) -> float = "f" "f_nat"
        is not included in
-         external f : float -> float = "a"
-#               Characters 141-183:
+         external f : float -> float = "a" "a_nat"
+#               Characters 149-199:
   ......struct
-    external f : int -> int = "f"
+    external f : int -> int = "f" "f_nat"
   end..
 Error: Signature mismatch:
        Modules do not match:
-         sig external f : int -> int = "f" end
+         sig external f : int -> int = "f" "f_nat" end
        is not included in
-         sig external f : int -> (int [@untagged]) = "f" end
+         sig external f : int -> (int [@untagged]) = "f" "f_nat" end
        Values do not match:
-         external f : int -> int = "f"
+         external f : int -> int = "f" "f_nat"
        is not included in
-         external f : int -> (int [@untagged]) = "f"
-#           Characters 71-113:
+         external f : int -> (int [@untagged]) = "f" "f_nat"
+#           Characters 79-129:
   ......struct
-    external f : int -> int = "a"
+    external f : int -> int = "a" "a_nat"
   end..
 Error: Signature mismatch:
        Modules do not match:
-         sig external f : int -> int = "a" end
+         sig external f : int -> int = "a" "a_nat" end
        is not included in
-         sig external f : (int [@untagged]) -> int = "f" end
+         sig external f : (int [@untagged]) -> int = "f" "f_nat" end
        Values do not match:
-         external f : int -> int = "a"
+         external f : int -> int = "a" "a_nat"
        is not included in
-         external f : (int [@untagged]) -> int = "f"
-#           Characters 74-120:
+         external f : (int [@untagged]) -> int = "f" "f_nat"
+#           Characters 82-136:
   ......struct
-    external f : float -> float = "f"
+    external f : float -> float = "f" "f_nat"
   end..
 Error: Signature mismatch:
        Modules do not match:
-         sig external f : float -> float = "f" end
+         sig external f : float -> float = "f" "f_nat" end
        is not included in
-         sig external f : float -> (float [@unboxed]) = "f" end
+         sig external f : float -> (float [@unboxed]) = "f" "f_nat" end
        Values do not match:
-         external f : float -> float = "f"
+         external f : float -> float = "f" "f_nat"
        is not included in
-         external f : float -> (float [@unboxed]) = "f"
-#           Characters 74-120:
+         external f : float -> (float [@unboxed]) = "f" "f_nat"
+#           Characters 82-136:
   ......struct
-    external f : float -> float = "a"
+    external f : float -> float = "a" "a_nat"
   end..
 Error: Signature mismatch:
        Modules do not match:
-         sig external f : float -> float = "a" end
+         sig external f : float -> float = "a" "a_nat" end
        is not included in
-         sig external f : (float [@unboxed]) -> float = "f" end
+         sig external f : (float [@unboxed]) -> float = "f" "f_nat" end
        Values do not match:
-         external f : float -> float = "a"
+         external f : float -> float = "a" "a_nat"
        is not included in
-         external f : (float [@unboxed]) -> float = "f"
+         external f : (float [@unboxed]) -> float = "f" "f_nat"
 #       Characters 67-72:
-  external g : (float [@untagged]) -> float = "g";;
+  external g : (float [@untagged]) -> float = "g" "g_nat";;
                 ^^^^^
 Error: Don't know how to untag this type. Only int can be untagged
 # Characters 14-17:
-  external h : (int [@unboxed]) -> float = "h";;
+  external h : (int [@unboxed]) -> float = "h" "h_nat";;
                 ^^^
 Error: Don't know how to unbox this type. Only float, int32, int64 and nativeint can be unboxed
-#   *     external i : int -> float = "i"
-# external j : int -> float * float = "j"
-# external k : int -> float = "k"
+#     Characters 52-64:
+  external i : int -> float [@unboxed] = "i" "i_nat";;
+               ^^^^^^^^^^^^
+Error: Don't know how to unbox this type. Only float, int32, int64 and nativeint can be unboxed
+#     Characters 61-66:
+  external j : int -> (float [@unboxed]) * float = "j" "j_nat";;
+                       ^^^^^
+Error: The attribute '@unboxed' should be attached to a direct argument or result of the primitive, it should not occur deeply into its type
+#   *     external k : int -> float = "k" "k_nat"
 #       Characters 58-119:
   external l : float -> float = "l" "l_nat" "float" [@@unboxed];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -166,4 +164,28 @@ Error: Cannot use "float" in conjunction with [@unboxed]/[@untagged]
   external n : float -> float = "n" "noalloc" [@@noalloc];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Cannot use "noalloc" in conjunction with [@@noalloc]
+#     Characters 70-115:
+  external o : (float[@unboxed]) -> float = "o";;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The native code version of the primitive is mandatory when attributes [@untagged] or [@unboxed] are present
+# Characters 0-45:
+  external p : float -> (float[@unboxed]) = "p";;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The native code version of the primitive is mandatory when attributes [@untagged] or [@unboxed] are present
+# Characters 0-44:
+  external q : (int[@untagged]) -> float = "q";;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The native code version of the primitive is mandatory when attributes [@untagged] or [@unboxed] are present
+# Characters 0-42:
+  external r : int -> (int[@untagged]) = "r";;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The native code version of the primitive is mandatory when attributes [@untagged] or [@unboxed] are present
+# Characters 0-42:
+  external s : int -> int = "s" [@@untagged];;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The native code version of the primitive is mandatory when attributes [@untagged] or [@unboxed] are present
+# Characters 0-45:
+  external t : float -> float = "t" [@@unboxed];;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The native code version of the primitive is mandatory when attributes [@untagged] or [@unboxed] are present
 # 

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -34,6 +34,7 @@ type description =
 type error =
   | Old_style_float_with_native_repr_attribute
   | Old_style_noalloc_with_noalloc_attribute
+  | No_native_primitive_with_repr_attribute
 
 exception Error of Location.t * error
 
@@ -113,6 +114,11 @@ let parse_declaration valdecl ~native_repr_args ~native_repr_res =
     Location.prerr_warning valdecl.pval_loc
       (Warnings.Deprecated "[@@noalloc] should be used instead of \
                             \"noalloc\"");
+  if native_name = "" &&
+     not (List.for_all is_ocaml_repr native_repr_args &&
+          is_ocaml_repr native_repr_res) then
+    raise (Error (valdecl.pval_loc,
+                  No_native_primitive_with_repr_attribute));
   let noalloc = old_style_noalloc || noalloc_attribute in
   let native_repr_args, native_repr_res =
     if old_style_float then
@@ -200,6 +206,10 @@ let report_error ppf err =
   | Old_style_noalloc_with_noalloc_attribute ->
     Format.fprintf ppf "Cannot use \"noalloc\" in conjunction with \
                         [%@%@noalloc]"
+  | No_native_primitive_with_repr_attribute ->
+    Format.fprintf ppf
+      "The native code version of the primitive is mandatory when \
+       attributes [%@untagged] or [%@unboxed] are present"
 
 let () =
   Location.register_error_of_exn

--- a/typing/primitive.mli
+++ b/typing/primitive.mli
@@ -63,5 +63,6 @@ val byte_name: description -> string
 type error =
   | Old_style_float_with_native_repr_attribute
   | Old_style_noalloc_with_noalloc_attribute
+  | No_native_primitive_with_repr_attribute
 
 exception Error of Location.t * error

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -50,6 +50,7 @@ type error =
   | Val_in_structure
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
+  | Deep_unbox_or_untag_attribute of native_repr_kind
 
 open Typedtree
 
@@ -1393,9 +1394,29 @@ let native_repr_of_type env kind ty =
   | _ ->
     None
 
+(* Raises an error when [core_type] contains an [@unboxed] or [@untagged]
+   attribute in a strict sub-term. *)
+let error_if_has_deep_native_repr_attributes core_type =
+  let open Ast_mapper in
+  let this_mapper =
+    { default_mapper with typ = fun mapper core_type ->
+      begin
+        match
+          get_native_repr_attribute core_type.ptyp_attributes ~global_repr:None
+        with
+        | Native_repr_attr_present kind ->
+           raise (Error (core_type.ptyp_loc, Deep_unbox_or_untag_attribute kind))
+        | Native_repr_attr_absent -> ()
+      end;
+      default_mapper.typ mapper core_type }
+  in
+  ignore (default_mapper.typ this_mapper core_type : Parsetree.core_type)
+
 let make_native_repr env core_type ty ~global_repr =
+  error_if_has_deep_native_repr_attributes core_type;
   match get_native_repr_attribute core_type.ptyp_attributes ~global_repr with
-  | Native_repr_attr_absent -> Same_as_ocaml_repr
+  | Native_repr_attr_absent ->
+    Same_as_ocaml_repr
   | Native_repr_attr_present kind ->
     begin match native_repr_of_type env kind ty with
     | None ->
@@ -1404,14 +1425,18 @@ let make_native_repr env core_type ty ~global_repr =
     end
 
 let rec parse_native_repr_attributes env core_type ty ~global_repr =
-  match core_type.ptyp_desc, (Ctype.repr ty).desc with
-  | Ptyp_arrow (_, ct1, ct2), Tarrow (_, t1, t2, _) ->
+  match core_type.ptyp_desc, (Ctype.repr ty).desc,
+    get_native_repr_attribute core_type.ptyp_attributes ~global_repr:None
+  with
+  | Ptyp_arrow _, Tarrow _, Native_repr_attr_present kind  ->
+    raise (Error (core_type.ptyp_loc, Cannot_unbox_or_untag_type kind))
+  | Ptyp_arrow (_, ct1, ct2), Tarrow (_, t1, t2, _), _ ->
     let repr_arg = make_native_repr env ct1 t1 ~global_repr in
     let repr_args, repr_res =
       parse_native_repr_attributes env ct2 t2 ~global_repr
     in
     (repr_arg :: repr_args, repr_res)
-  | Ptyp_arrow _, _ | _, Tarrow _ -> assert false
+  | Ptyp_arrow _, _, _ | _, Tarrow _, _ -> assert false
   | _ -> ([], make_native_repr env core_type ty ~global_repr)
 
 (* Translate a value declaration *)
@@ -1799,6 +1824,11 @@ let report_error ppf = function
   | Cannot_unbox_or_untag_type Untagged ->
       fprintf ppf "Don't know how to untag this type. Only int \
                    can be untagged"
+  | Deep_unbox_or_untag_attribute kind ->
+      fprintf ppf
+        "The attribute '%s' should be attached to a direct argument or \
+         result of the primitive, it should not occur deeply into its type"
+        (match kind with Unboxed -> "@unboxed" | Untagged -> "@untagged")
 
 let () =
   Location.register_error_of_exn

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -87,6 +87,7 @@ type error =
   | Val_in_structure
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
+  | Deep_unbox_or_untag_attribute of native_repr_kind
 
 exception Error of Location.t * error
 


### PR DESCRIPTION
This commit implements a new warning to inform users about unused
untagged and unboxed attributes in external declarations.

There are two variants of the warning:
- One when the external does not contain a native version of
  the primitive,
- One when the attribute occurs deeply into the type

Finally, an error of the kind "cannot unboxed/untagged this type"
when the attribute is applied to the whole function type.

This make the use of these attributes a bit less dangerous, but
it does not solve the "typo" issue: if the attributes are misspelled 
they are still silently ignored (this is a source of random segfaults).
