### PR TITLE
Better type error location in presence of constraints

### DIFF
--- a/Changes
+++ b/Changes
@@ -457,6 +457,8 @@ Bug fixes:
   (Jérémie Dimino, Thomas Refis)
 - GPR#405: fix compilation under Visual Studio 2015
   (David Allsopp)
+- GPR#441: better type error location in presence of type constraints
+  (Thomas Refis, report by Arseniy Alekseyev)
 
 Features wishes:
 - PR#4518, GPR#29: change location format for reporting errors in ocamldoc

--- a/testsuite/tests/typing-gadts/pr6690.ml.reference
+++ b/testsuite/tests/typing-gadts/pr6690.ml.reference
@@ -5,18 +5,16 @@ type 'a local_visit_action
 type ('a, 'result, 'visit_action) context =
     Local : ('a, 'a * insert, 'a local_visit_action) context
   | Global : ('a, 'a, 'a visit_action) context
-#             Characters 11-166:
-  ..........(type visit_action)
-      : (_, _, visit_action) context -> _ -> visit_action =
+#             Characters 35-166:
+  ....: (_, _, visit_action) context -> _ -> visit_action =
     function
     | Local -> fun _ -> raise Exit
     | Global -> fun _ -> raise Exit
 Error: This expression has type ($0, $0 * insert, 'a) context -> 'b -> 'a
        but an expression was expected of type 'c
        The type constructor $0 would escape its scope
-#             Characters 11-174:
-  ..........(type visit_action)
-      : ('a, 'result, visit_action) context -> 'a -> visit_action =
+#             Characters 35-174:
+  ....: ('a, 'result, visit_action) context -> 'a -> visit_action =
     function
     | Local -> fun _ -> raise Exit
     | Global -> fun _ -> raise Exit

--- a/testsuite/tests/typing-gadts/test.ml.principal.reference
+++ b/testsuite/tests/typing-gadts/test.ml.principal.reference
@@ -360,9 +360,9 @@ Error: This expression has type t = < foo : int; .. >
        but an expression was expected of type < bar : int; foo : int >
        Type $0 = < bar : int; .. > is not compatible with type < bar : int > 
        The first object type has an abstract row, it cannot be closed
-#         Characters 98-99:
+#         Characters 97-121:
     (x:<foo:int;bar:int;..>)
-     ^
+    ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type < bar : int; foo : int; .. >
        but an expression was expected of type 'a
        The type constructor $1 would escape its scope

--- a/testsuite/tests/typing-gadts/test.ml.reference
+++ b/testsuite/tests/typing-gadts/test.ml.reference
@@ -347,9 +347,9 @@ Error: This expression has type t = < foo : int; .. >
        but an expression was expected of type < bar : int; foo : int >
        Type $0 = < bar : int; .. > is not compatible with type < bar : int > 
        The first object type has an abstract row, it cannot be closed
-#         Characters 98-99:
+#         Characters 97-121:
     (x:<foo:int;bar:int;..>)
-     ^
+    ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type < bar : int; foo : int; .. >
        but an expression was expected of type 'a
        The type constructor $1 would escape its scope


### PR DESCRIPTION
Before:

```
# let x : string = (5 : int);;
                    ^
Error: This expression has type int but an expression was expected of type
         string
```

```
# let x : string = (let open Buffer in create 3 : Buffer.t);;
                                       ^^^^^^^^
Error: This expression has type Buffer.t
       but an expression was expected of type string
```

```
# let x : string = let open Buffer in (create 3 : t);;
                                       ^^^^^^^^
Error: This expression has type Buffer.t
       but an expression was expected of type string
```

After:

```
# let x : string = (5 : int);;
                   ^^^^^^^^^
Error: This expression has type int but an expression was expected of type
         string
```

```
# let x : string = (let open Buffer in create 3 : Buffer.t);;
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: This expression has type Buffer.t
       but an expression was expected of type string
```

```
# let x : string = let open Buffer in (create 3 : t);;
                                      ^^^^^^^^^^^^^^
Error: This expression has type Buffer.t
       but an expression was expected of type string
```

---

N.B. `tests/typing-gadts/pr6690.ml.reference` was modified and it's not obvious if it's for the better or not.
On the current trunk the error location started on `(type visit_action)` and ended at the end of the function. After this patch it starts at the colon (and end at the end of the function).
Leo seems to think this is fine, personally I don't understant the error message so I don't really appreciate if the location change is an improvement or not.
