### PR TITLE
Fix Makefile parallelisation problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,7 @@ defaultentry:
 # Recompile the system using the bootstrap compiler
 all: $(runtime) ocamlc ocamlyacc ocamllex ocamlyacc ocamltools library \
 	ocaml otherlibraries $(OCAMLBUILDBYTE) $(WITH_DEBUGGER) \
-	$(WITH_OCAMLDOC)
-	if test -n "$(WITH_OCAMLDOC)"; then $(MAKE) manpages; else :; fi
+	$(WITH_OCAMLDOC) manpages
 
 # Compile everything the first time
 world: coldstart all
@@ -665,8 +664,8 @@ alldepend::
 ocamldoc: ocamlc ocamlyacc ocamllex library otherlibrary_str otherlibrary_unix otherlibrary_dynlink
 	cd ocamldoc && $(MAKE) exe lib generators
 
-manpages: ocamldoc
-	cd ocamldoc && $(MAKE) manpages
+manpages: $(WITH_OCAMLDOC)
+	if test -n "$(WITH_OCAMLDOC)"; then cd ocamldoc && $(MAKE) manpages; else :; fi
 
 ocamldoc.opt: ocamlc.opt ocamlyacc ocamllex ocamldoc \
 	otherlibraryopt_str otherlibraryopt_unix otherlibraryopt_dynlink

--- a/Makefile
+++ b/Makefile
@@ -469,7 +469,7 @@ ALLCMOS=$(COMMON) $(BYTECOMP) $(ASMCOMP) $(BYTESTART) $(OPTSTART) \
 	$(TOPLEVEL) $(TOPLEVELSTART)
 $(ALLCMOS) $(ALLCMOS:.cmo=.cmi): boot/ocamlrun$(EXE) boot/stdlib.cma
 
-$(COMMON:.cmo=.cmx) $(BYTECOMP:.cmo=.cmx) $(ASMCOMP:.cmo=.cmx): ocamlopt
+$(COMMON:.cmo=.cmx) $(BYTECOMP:.cmo=.cmx) $(ASMCOMP:.cmo=.cmx): ocamlopt libraryopt
 
 # The numeric opcodes
 
@@ -647,7 +647,7 @@ ocamltools: ocamlc ocamlyacc ocamllex asmcomp/cmx_format.cmi \
             asmcomp/printclambda.cmo
 	cd tools; $(MAKE) all
 
-ocamltoolsopt: ocamlopt
+ocamltoolsopt: ocamlopt libraryopt
 	cd tools; $(MAKE) opt
 
 ocamltoolsopt.opt: ocamlc.opt ocamlyacc ocamllex asmcomp/cmx_format.cmi \
@@ -765,7 +765,7 @@ alldepend::
 ocamlbuild.byte: ocamlc otherlibraries
 	cd ocamlbuild && $(MAKE) all
 
-ocamlbuild.native: ocamlopt otherlibrariesopt
+ocamlbuild.native: ocamlopt libraryopt otherlibrariesopt
 	cd ocamlbuild && $(MAKE) allopt
 
 partialclean::

--- a/ocamldoc/.depend
+++ b/ocamldoc/.depend
@@ -267,3 +267,11 @@ odoc_str.cmi : ../typing/types.cmi odoc_value.cmo odoc_type.cmo \
 odoc_text.cmi : odoc_types.cmi
 odoc_text_parser.cmi : odoc_types.cmi
 odoc_types.cmi : ../parsing/location.cmi
+generators/odoc_literate.cmo : odoc_info.cmi odoc_html.cmo odoc_gen.cmi \
+    odoc_args.cmi
+generators/odoc_literate.cmx : odoc_info.cmx odoc_html.cmx odoc_gen.cmx \
+    odoc_args.cmx
+generators/odoc_todo.cmo : odoc_module.cmo odoc_info.cmi odoc_html.cmo \
+    odoc_gen.cmi odoc_args.cmi
+generators/odoc_todo.cmx : odoc_module.cmx odoc_info.cmx odoc_html.cmx \
+    odoc_gen.cmx odoc_args.cmx

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -362,7 +362,8 @@ depend::
 	$(OCAMLLEX) odoc_lexer.mll
 	$(OCAMLLEX) odoc_ocamlhtml.mll
 	$(OCAMLLEX) odoc_see_lexer.mll
-	$(OCAMLDEP) $(INCLUDES_DEP) *.mll *.mly *.ml *.mli > .depend
+	$(OCAMLDEP) $(INCLUDES_DEP) *.mll *.mly *.ml *.mli \
+		generators/*.ml generators/*.mli > .depend
 
 dummy:
 


### PR DESCRIPTION
The makefile is somewhat more parallel than it used to be, but still has quite a lot of problems.
This is an attempt at fixing more problems that allows to build with `make -j` on a massively parallel computer.

```
time make -j 160 world.opt
...
real    0m51.843s
user    6m22.741s
sys 0m18.368s
```

There is probably still some room for improvement, but what is really missing is some cleaning.
