### PR TITLE
Travis build ocamlnat

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -32,6 +32,7 @@ EOF
     ./configure --prefix $PREFIX -with-debug-runtime -with-instrumented-runtime
     export PATH=$PREFIX/bin:$PATH
     make world.opt
+    make ocamlnat
     make install
     (cd testsuite && make all)
     (cd testsuite && make USE_RUNTIME="d" all)


### PR DESCRIPTION
To prevent ocamlnat from being continuously broken, I suggest that we should add it to the travis script.
This is minimal (as we don't test if it works). For a better test, we should probably have an `--with-ocamlnat` configure flag to build it in `make world` and be able to test its presence in the testsuite makefiles.
