### PR TITLE
Avoid hard-coded paths in installed binaries

### DIFF
--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -51,8 +51,8 @@ camlheaderi target_camlheaderi: \
   header.c ../config/Makefile
 	if $(SHARPBANGSCRIPTS); then \
 	  for suff in '' d i; do \
-	    echo '#!$(BINDIR)/ocamlrun'$$suff > camlheader$$suff && \
-	    echo '#!$(TARGET_BINDIR)/ocamlrun'$$suff > target_camlheader$$suff; \
+	    echo '#!/usr/bin/env ocamlrun'$$suff > camlheader$$suff && \
+	    echo '#!/usr/bin/env ocamlrun'$$suff > target_camlheader$$suff; \
 	  done && \
 	  echo '#!' | tr -d '\012' > camlheader_ur; \
 	else \


### PR DESCRIPTION
At the moment, the path to `ocamlrun` is encoded in the shebang at compile time.

Some package managers allow to install into $HOME (without root), so the path to the interpreter is not fixed. See for example [this discussion on the Conda mailing list](https://groups.google.com/a/continuum.io/forum/?fromgroups#!topic/anaconda/vE4D9p4qy84).

It's more portable to use the [env utility](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/env.html) in the shebang line.
