### PR TITLE
testsuite: optional 'parallel' target uses GNU parallel to halve testing time

### DIFF
--- a/Changes
+++ b/Changes
@@ -547,6 +547,9 @@ Features wishes:
   (tkob)
 - GPR#401: automatically retry failed test directories in the testsuite
   (David Allsopp)
+- GPR#451: an optional 'parallel' target in testsuite/Makefile using the
+  GNU parallel tool to run tests in parallel.
+  (Gabriel Scherer)
 
 Build system:
 - GPR#388: FlexDLL added as a Git submodule and bootstrappable with the compiler

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -22,6 +22,8 @@ default:
 	@echo "Available targets:"
 	@echo "  all             launch all tests"
 	@echo "  all-foo         launch all tests beginning with foo"
+	@echo "  parallel        launch all tests using GNU parallel"
+	@echo "  parallel-foo    launch all tests beginning with foo using GNU parallel"
 	@echo "  list FILE=f     launch the tests listed in f (one per line)"
 	@echo "  one DIR=p       launch the tests located in path p"
 	@echo "  promote DIR=p   promote the reference files for the tests in p"
@@ -29,7 +31,7 @@ default:
 	@echo "  clean           delete generated files"
 	@echo "  report          print the report for the last execution"
 	@echo
-	@echo "all* and list can automatically re-run failed test directories if"
+	@echo "all*, parallel* and list can automatically re-run failed test directories if"
 	@echo "MAX_TESTSUITE_DIR_RETRIES permits (default value = $(MAX_TESTSUITE_DIR_RETRIES))"
 
 .PHONY: all
@@ -47,6 +49,50 @@ all-%: lib
 	done 2>&1 | tee _log
 	@$(MAKE) $(NO_PRINT) retries
 	@$(MAKE) report
+
+# The targets below use GNU parallel to paralellize tests
+# 'make all' and 'make parallel' should be equivalent
+#
+# parallel uses specific logic to make sure the output of the commands
+# run in parallel are not mangled. By default, it will reproduce
+# the output of each completed command atomically, in order of completion.
+#
+# With the --keep-order option, we ask it to save the completed output
+# and replay them in invocation order instead. In theory this costs
+# a tiny bit of performance, but I could not measure any difference.
+# In theory again, the reporting logic works fine with test outputs
+# coming in in arbitrary order (so we should not need --keep-order),
+# but keeping the output deterministic is guaranteed to make
+# someone's life easier at least once in the future.
+#
+# Finally, note that the command we run has a 2>&1 redirection, as
+# in the other make targets. If we removed the quoting around
+# "$(MAKE) ... 2>&1", the rediction would apply to the complete output
+# of parallel, and have a slightly different behavior: by default parallel
+# cleanly separates the stdout and stderr output of each completed command,
+# printing stderr first then stdout second (for each command).
+# I chose to keep the previous behavior exactly unchanged,
+# but the demangling separation is arguably nicer behavior that we might
+# want to implement at the exec-one level to also have it in the 'all' target.
+.PHONY: parallel-%
+parallel-%: lib
+	@echo | parallel >/dev/null 2>/dev/null \
+	  || (echo "Unable to run the GNU parallel tool;";\
+	      echo "You should install it before using the parallel* targets.";\
+	      exit 1)
+	@echo | parallel --gnu --no-notice >/dev/null 2>/dev/null \
+	  || (echo "Your 'parallel' tool seems incompatible with GNU parallel;";\
+	      echo "This target requires GNU parallel.";\
+	      exit 1)
+	@for dir in tests/$**; do echo $$dir; done \
+	| parallel --gnu --no-notice --keep-order \
+	    "$(MAKE) $(NO_PRINT) exec-one DIR={} 2>&1" \
+	| tee _log
+	@$(MAKE) $(NO_PRINT) retries
+	@$(MAKE) report
+
+.PHONY: parallel
+parallel: parallel-*
 
 .PHONY: list
 list: lib


### PR DESCRIPTION
See the run logs below. Using 'parallel' reduces the time to run the
full testsuite from 2m30s to 0m57s on my machine.

All tests are run in parallel, including lib-threads.

We ask parallel to preserve output order, so it should be
deterministic. (Individual tests may mangle stdout and stderr in
fragile ways, though.) See the Makefile comment for details.

```
rm -f _log; make clean;
time make all;
cp _log /tmp/trunk_log

> real  2m29.947s
> user  1m35.937s
> sys   0m17.467s

rm -f _log; make clean;
time make parallel;
cp _log /tmp/parallel_log

> real  0m56.611s
> user  2m20.861s
> sys   0m21.511s

diff -u /tmp/{trunk,parallel}_log | wc -l

> 0

rm /tmp/{trunk,parallel}_log
```
