### PR TITLE
More stable output for ocamldep

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ OCaml 4.04.0:
 
 (Changes that can break existing programs are marked with a "*")
 
+Tools:
+- GPR#452: Make the output of ocamldep is more stable (Alain Frisch)
+
 Build system:
 - GPR#324: Compiler developpers only: Adding new primitives to the
   standard runtime doesn't require anymore to run `make bootstrap`

--- a/tools/ocamldep.ml
+++ b/tools/ocamldep.ml
@@ -323,7 +323,7 @@ let ml_file_dependencies source_file =
                            Config.ast_impl_magic_number source_file
   in
   if !sort_files then
-    files := (source_file, ML, !Depend.free_structure_names) :: !files
+    files := (source_file, ML, extracted_deps) :: !files
   else
     if !raw_dependencies then begin
       print_raw_dependencies source_file extracted_deps

--- a/tools/ocamldep.ml
+++ b/tools/ocamldep.ml
@@ -361,16 +361,14 @@ let ml_file_dependencies source_file =
     read_parse_and_extract parse_use_file_as_impl Depend.add_implementation ()
                            Config.ast_impl_magic_number source_file
   in
-  let r = (source_file, ML, extracted_deps) in
-  files := r :: !files
+  files := (source_file, ML, extracted_deps) :: !files
 
 let mli_file_dependencies source_file =
   let (extracted_deps, ()) =
     read_parse_and_extract Parse.interface Depend.add_signature ()
                            Config.ast_intf_magic_number source_file
   in
-  let r = (source_file, MLI, extracted_deps) in
-  files := r :: !files
+  files := (source_file, MLI, extracted_deps) :: !files
 
 let process_file_as process_fun def source_file =
   Compenv.readenv ppf (Before_compile source_file);

--- a/tools/ocamldep.ml
+++ b/tools/ocamldep.ml
@@ -593,5 +593,5 @@ let _ =
     ] file_dependencies usage;
   Compenv.readenv ppf Before_link;
   if !sort_files then sort_files_by_dependencies !files
-  else List.iter print_file_dependencies !files;
+  else List.iter print_file_dependencies (List.sort compare !files);
   exit (if !error_occurred then 2 else 0)

--- a/tools/ocamldep.ml
+++ b/tools/ocamldep.ml
@@ -339,7 +339,7 @@ let print_mli_dependencies source_file extracted_deps =
       extracted_deps ([], []) in
   print_dependencies [basename ^ ".cmi"] byt_deps
 
-let print_dependencies (source_file, kind, extracted_deps) =
+let print_file_dependencies (source_file, kind, extracted_deps) =
   if !raw_dependencies then begin
     print_raw_dependencies source_file extracted_deps
   end else
@@ -362,8 +362,7 @@ let ml_file_dependencies source_file =
                            Config.ast_impl_magic_number source_file
   in
   let r = (source_file, ML, extracted_deps) in
-  if !sort_files then files := r :: !files
-  else print_dependencies r
+  files := r :: !files
 
 let mli_file_dependencies source_file =
   let (extracted_deps, ()) =
@@ -371,8 +370,7 @@ let mli_file_dependencies source_file =
                            Config.ast_intf_magic_number source_file
   in
   let r = (source_file, MLI, extracted_deps) in
-  if !sort_files then files := r :: !files
-  else print_dependencies r
+  files := r :: !files
 
 let process_file_as process_fun def source_file =
   Compenv.readenv ppf (Before_compile source_file);
@@ -594,5 +592,6 @@ let _ =
          " Print version number and exit";
     ] file_dependencies usage;
   Compenv.readenv ppf Before_link;
-  if !sort_files then sort_files_by_dependencies !files;
+  if !sort_files then sort_files_by_dependencies !files
+  else List.iter print_file_dependencies !files;
   exit (if !error_occurred then 2 else 0)


### PR DESCRIPTION
ocamldep currently outputs dependencies for all files passed on its command-line, using the ordering of files from the command-line.   For the .depend file in OCaml, the list of files passed to ocamldep is obtained with shell wildcards, and the ordering of the result is thus not stable across systems.  This leads to useless diff on this .depend file (such as https://github.com/ocaml/ocaml/commit/c739d0e590ed1b10bc9fc09a0e1046a4a1349785 ).

This PR delays the printing of dependencies until all files from the command-line have been processed and display the result after sorting them.  (Alternatively, one could collect the list of file, sort it, and process them one by one.  But I doubt that the increased memory usage and loss of incrementality of the output would become a problem.)

A tiny change of behavior is that options which affects the display of dependencies such as `-all` or `-modules` are now taken into account even if they appear after file names on the command line.  I believe this change is harmless.

I initially thought about sorting the list of dependencies for each file, but it seems the current display is stable enough (obtained by folding over sets, which is specified to be done in increasing order).
