### PR TITLE
Remove duplicate live_offset entries from frametables

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -256,12 +256,8 @@ let record_frame_label ?label live raise_ dbg =
       | _ -> ()
     )
     live;
-  frame_descriptors :=
-    { fd_lbl = lbl;
-      fd_frame_size = frame_size();
-      fd_live_offset = !live_offset;
-      fd_raise = raise_;
-      fd_debuginfo = dbg } :: !frame_descriptors;
+  record_frame_descr ~label:lbl ~frame_size:(frame_size())
+    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
   lbl
 
 let record_frame ?label live raise_ dbg =

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -116,12 +116,8 @@ let record_frame_label ?label live raise_ dbg =
           Misc.fatal_error ("bad GC root " ^ Reg.name r)
       | _ -> ())
     live;
-  frame_descriptors :=
-    { fd_lbl = lbl;
-      fd_frame_size = frame_size();
-      fd_live_offset = !live_offset;
-      fd_raise = raise_;
-      fd_debuginfo = dbg } :: !frame_descriptors;
+  record_frame_descr ~label:lbl ~frame_size:(frame_size())
+    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
   lbl
 
 let record_frame ?label live raise_ dbg =

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -114,6 +114,14 @@ type frame_descr =
 
 let frame_descriptors = ref([] : frame_descr list)
 
+let record_frame_descr ~label ~frame_size ~live_offset ~raise_frame debuginfo =
+  frame_descriptors :=
+    { fd_lbl = label;
+      fd_frame_size = frame_size;
+      fd_live_offset = List.sort_uniq (-) live_offset;
+      fd_raise = raise_frame;
+      fd_debuginfo = debuginfo } :: !frame_descriptors
+
 type emit_frame_actions =
   { efa_code_label: int -> unit;
     efa_data_label: int -> unit;

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -38,14 +38,13 @@ val emit_debug_info_gen :
   (file_num:int -> file_name:string -> unit) ->
   (file_num:int -> line:int -> col:int -> unit) -> unit
 
-type frame_descr =
-  { fd_lbl: int;                        (* Return address *)
-    fd_frame_size: int;                 (* Size of stack frame *)
-    fd_live_offset: int list;           (* Offsets/regs of live addresses *)
-    fd_raise: bool;                     (* Is frame for a raise? *)
-    fd_debuginfo: Debuginfo.t }         (* Location, if any *)
-
-val frame_descriptors : frame_descr list ref
+val record_frame_descr :
+  label:int ->              (* Return address *)
+  frame_size:int ->         (* Size of stack frame *)
+  live_offset:int list ->   (* Offsets/regs of live addresses *)
+  raise_frame:bool ->       (* Is frame for a raise? *)
+  Debuginfo.t ->            (* Location, if any *)
+  unit
 
 type emit_frame_actions =
   { efa_code_label: int -> unit;

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -207,12 +207,8 @@ let record_frame_label ?label live raise_ dbg =
           Misc.fatal_error ("bad GC root " ^ Reg.name r)
       | _ -> ())
     live;
-  frame_descriptors :=
-    { fd_lbl = lbl;
-      fd_frame_size = frame_size();
-      fd_live_offset = !live_offset;
-      fd_raise = raise_;
-      fd_debuginfo = dbg } :: !frame_descriptors;
+  record_frame_descr ~label:lbl ~frame_size:(frame_size())
+    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
   lbl
 
 let record_frame ?label live raise_ dbg =

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -317,12 +317,8 @@ let record_frame ?label live raise_ dbg =
           Misc.fatal_error ("bad GC root " ^ Reg.name r)
       | _ -> ())
     live;
-  frame_descriptors :=
-    { fd_lbl = lbl;
-      fd_frame_size = frame_size();
-      fd_live_offset = !live_offset;
-      fd_raise = raise_;
-      fd_debuginfo = dbg } :: !frame_descriptors;
+  record_frame_descr ~label:lbl ~frame_size:(frame_size())
+    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
   `{emit_label lbl}:\n`
 
 (* Record floating-point literals (for PPC32) *)

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -165,12 +165,8 @@ let record_frame ?label live raise_ dbg =
           Misc.fatal_error ("bad GC root " ^ Reg.name r)
       | _ -> ())
     live;
-  frame_descriptors :=
-    { fd_lbl = lbl;
-      fd_frame_size = frame_size();
-      fd_live_offset = !live_offset;
-      fd_raise = raise_;
-      fd_debuginfo = dbg } :: !frame_descriptors;
+  record_frame_descr ~label:lbl ~frame_size:(frame_size())
+    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
   lbl
 
 (* Record calls to caml_call_gc, emitted out of line. *)

--- a/asmcomp/sparc/emit.mlp
+++ b/asmcomp/sparc/emit.mlp
@@ -178,6 +178,7 @@ let record_frame ?label live =
           Misc.fatal_error ("bad GC root " ^ Reg.name r)
       | _ -> ())
     live;
+  live_offset := List.sort_uniq (-) !live_offset;
   frame_descriptors :=
     { fd_lbl = lbl;
       fd_frame_size = frame_size();


### PR DESCRIPTION
`Reg.Set` uses stamp for comparison. Hence, two virtual registers that map to the same real register may have different stamps. This leads to duplicate live_offset entries in the frametables. For example, on amd64,

```
$ wget https://raw.githubusercontent.com/dbuenzli/nbcodec/master/src/se.ml
$ ocamlopt.opt -S se.ml
```

See https://gist.github.com/kayceesrk/82c88ac67dcd7281a27a#file-se-s-L4523-L4528 for the output. The entry corresponds to the frametable for label .L375. The entry says that there are 3 live registers with offsets 3,3,5 which correspond to %rbx, %rbx, %rdi. The duplicate entries do not cause any problems since all the places where the frametable is currently used, the target operation happens to be idempotent. However, this is an undocumented fact, and any non-idempotent use of live_offsets from the frametable would lead to errors.

The fix is to simply sort and remove the duplicates as the number of live offsets is typically small.
