### PR TITLE
Toplevel truncates long strings and prints bytes.

### DIFF
--- a/Changes
+++ b/Changes
@@ -282,6 +282,8 @@ Toplevel and debugger:
   its command line (Alain Frisch)
 - PR#7119: ocaml doesn't respect [@@@warning] (Alain Frisch, report by
   Gabriel Radanne)
+- PR#7127, GPR#454: Toplevel truncates long strings and prints
+  bytes. (Junsong Li, review by Gabriel Scherer)
 
 Other libraries:
 * Unix library: channels created by Unix.in_channel_of_descr or

--- a/testsuite/tests/typing-extension-constructor/test.ml.reference
+++ b/testsuite/tests/typing-extension-constructor/test.ml.reference
@@ -9,5 +9,5 @@
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type extension_constructor/16
        but an expression was expected of type
-         extension_constructor/1210 = int
+         extension_constructor/1209 = int
 # 


### PR DESCRIPTION
The change
- Truncates long strings in REPL output
- Enables Bytes printing in REPL (ocaml -safe-string)
- Updates a test reference file.
