### PR TITLE
MPR#6120: Windows symlinks and corrected stat implementation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -41,6 +41,7 @@ ocamldoc/ocamldoc.sty    ocaml-typo=missing-header
 
 otherlibs/win32unix/readlink.c    ocaml-typo=long-line
 otherlibs/win32unix/stat.c        ocaml-typo=long-line
+otherlibs/win32unix/symlink.c     ocaml-typo=long-line
 
 # Line-ending specifications, for Windows interoperability
 *.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -39,6 +39,8 @@ ocamlbuild/TODO          ocaml-typo=missing-header
 ocamldoc/Changes.txt     ocaml-typo=missing-header
 ocamldoc/ocamldoc.sty    ocaml-typo=missing-header
 
+otherlibs/win32unix/stat.c    ocaml-typo=long-line
+
 # Line-ending specifications, for Windows interoperability
 *.sh text eol=lf
 *.sh.in text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -39,7 +39,8 @@ ocamlbuild/TODO          ocaml-typo=missing-header
 ocamldoc/Changes.txt     ocaml-typo=missing-header
 ocamldoc/ocamldoc.sty    ocaml-typo=missing-header
 
-otherlibs/win32unix/stat.c    ocaml-typo=long-line
+otherlibs/win32unix/readlink.c    ocaml-typo=long-line
+otherlibs/win32unix/stat.c        ocaml-typo=long-line
 
 # Line-ending specifications, for Windows interoperability
 *.sh text eol=lf

--- a/Changes
+++ b/Changes
@@ -305,6 +305,10 @@ Other libraries:
   Before, a handled signal could cause Unix.sleep to return early.
   Now, the sleep is restarted until the given time is elapsed.
   (Xavier Leroy)
+* PR#6120: implement Unix.symlink and Unix.readlink on Windows. Unix.symlink has
+  a new optional argument to_dir (ignored on non-native Windows platforms). stat
+  functions reimplemented to avoid buggy Microsoft CRT implementations (native
+  Windows only)
 - PR#6263: add kind_size_in_bytes and size_in_bytes functions
   to Bigarray module.
   (Runhang Li, review by Mark Shinwell)

--- a/otherlibs/threads/unix.ml
+++ b/otherlibs/threads/unix.ml
@@ -357,6 +357,7 @@ let pipe() =
   fd_pair
 
 external symlink : ?to_dir:bool -> string -> string -> unit = "unix_symlink"
+external has_symlink : unit -> bool = "unix_has_symlink"
 external readlink : string -> string = "unix_readlink"
 external mkfifo : string -> file_perm -> unit = "unix_mkfifo"
 

--- a/otherlibs/threads/unix.ml
+++ b/otherlibs/threads/unix.ml
@@ -356,7 +356,7 @@ let pipe() =
   set_nonblock out_fd;
   fd_pair
 
-external symlink : string -> string -> unit = "unix_symlink"
+external symlink : ?to_dir:bool -> string -> string -> unit = "unix_symlink"
 external readlink : string -> string = "unix_readlink"
 external mkfifo : string -> file_perm -> unit = "unix_mkfifo"
 

--- a/otherlibs/unix/symlink.c
+++ b/otherlibs/unix/symlink.c
@@ -19,9 +19,9 @@
 
 #ifdef HAS_SYMLINK
 
-CAMLprim value unix_symlink(value path1, value path2)
+CAMLprim value unix_symlink(value to_dir, value path1, value path2)
 {
-  CAMLparam2(path1, path2);
+  CAMLparam3(to_dir, path1, path2);
   char * p1;
   char * p2;
   int ret;
@@ -41,7 +41,7 @@ CAMLprim value unix_symlink(value path1, value path2)
 
 #else
 
-CAMLprim value unix_symlink(value path1, value path2)
+CAMLprim value unix_symlink(value to_dir, value path1, value path2)
 { invalid_argument("symlink not implemented"); }
 
 #endif

--- a/otherlibs/unix/symlink.c
+++ b/otherlibs/unix/symlink.c
@@ -39,9 +39,21 @@ CAMLprim value unix_symlink(value to_dir, value path1, value path2)
   CAMLreturn(Val_unit);
 }
 
+CAMLprim value unix_has_symlink(value unit)
+{
+  CAMLparam0();
+  CAMLreturn(Val_true);
+}
+
 #else
 
 CAMLprim value unix_symlink(value to_dir, value path1, value path2)
 { invalid_argument("symlink not implemented"); }
+
+CAMLprim value unix_has_symlink(value unit)
+{
+  CAMLparam0();
+  CAMLreturn(Val_false);
+}
 
 #endif

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -379,6 +379,7 @@ external closedir : dir_handle -> unit = "unix_closedir"
 
 external pipe : unit -> file_descr * file_descr = "unix_pipe"
 external symlink : ?to_dir:bool -> string -> string -> unit = "unix_symlink"
+external has_symlink : unit -> bool = "unix_has_symlink"
 external readlink : string -> string = "unix_readlink"
 external mkfifo : string -> file_perm -> unit = "unix_mkfifo"
 external select :

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -378,7 +378,7 @@ external rewinddir : dir_handle -> unit = "unix_rewinddir"
 external closedir : dir_handle -> unit = "unix_closedir"
 
 external pipe : unit -> file_descr * file_descr = "unix_pipe"
-external symlink : string -> string -> unit = "unix_symlink"
+external symlink : ?to_dir:bool -> string -> string -> unit = "unix_symlink"
 external readlink : string -> string = "unix_readlink"
 external mkfifo : string -> file_perm -> unit = "unix_mkfifo"
 external select :

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -707,6 +707,12 @@ val symlink : ?to_dir:bool -> string -> string -> unit
    {!has_symlink} can be used to check that a process is able to create symbolic
    links. *)
 
+val has_symlink : unit -> bool
+(** Returns [true] if the user is able to create symbolic links. On Windows,
+   this indicates that the user not only has the SeCreateSymbolicLinkPrivilege
+   but is also running elevated, if necessary. On other platforms, this is
+   simply indicates that the symlink system call is available. *)
+
 val readlink : string -> string
 (** Read the contents of a link.
 

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -675,11 +675,37 @@ val close_process_full :
 (** {6 Symbolic links} *)
 
 
-val symlink : string -> string -> unit
-(** [symlink source dest] creates the file [dest] as a symbolic link
-   to the file [source].
+val symlink : ?to_dir:bool -> string -> string -> unit
+(** [symlink ?to_dir source dest] creates the file [dest] as a symbolic link
+   to the file [source]. On Windows, [~to_dir] indicates if the symbolic link
+   points to a directory or a file; if omitted, [symlink] examines [source]
+   using [stat] and picks appropriately, if [source] does not exist then [false]
+   is assumed (for this reason, it is recommended that the [~to_dir] parameter
+   be specified in new code). On Unix, [~to_dir] ignored.
 
-   On Windows: not implemented. *)
+   Windows symbolic links are available in Windows Vista onwards. There are some
+   important differences between Windows symlinks and their POSIX counterparts.
+
+   Windows symbolic links come in two flavours: directory and regular, which
+   designate whether the symbolic link points to a directory or a file. The type
+   must be correct - a directory symlink which actually points to a file cannot
+   be selected with chdir and a file symlink which actually points to a
+   directory cannot be read or written (note that Cygwin's emulation layer
+   ignores this distinction).
+
+   When symbolic links are created to existing targets, this distinction doesn't
+   matter and [symlink] will automatically create the correct kind of symbolic
+   link. The distinction matters when a symbolic link is created to a
+   non-existent target.
+
+   The other caveat is that by default symbolic links are a privileged
+   operation. Administrators will always need to be running elevated (or with
+   UAC disabled) and by default normal user accounts need to be granted the
+   SeCreateSymbolicLinkPrivilege via Local Security Policy (secpol.msc) or via
+   Active Directory.
+
+   {!has_symlink} can be used to check that a process is able to create symbolic
+   links. *)
 
 val readlink : string -> string
 (** Read the contents of a link.

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -622,6 +622,12 @@ val symlink : ?to_dir:bool -> src:string -> dst:string -> unit
 (** [symlink source dest] creates the file [dest] as a symbolic link
    to the file [source]. See {!Unix.symlink} for details of [~to_dir] *)
 
+val has_symlink : unit -> bool
+(** Returns [true] if the user is able to create symbolic links. On Windows,
+   this indicates that the user not only has the SeCreateSymbolicLinkPrivilege
+   but is also running elevated, if necessary. On other platforms, this is
+   simply indicates that the symlink system call is available. *)
+
 val readlink : string -> string
 (** Read the contents of a link. *)
 

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -618,9 +618,9 @@ val close_process_full :
 (** {6 Symbolic links} *)
 
 
-val symlink : src:string -> dst:string -> unit
+val symlink : ?to_dir:bool -> src:string -> dst:string -> unit
 (** [symlink source dest] creates the file [dest] as a symbolic link
-   to the file [source]. *)
+   to the file [source]. See {!Unix.symlink} for details of [~to_dir] *)
 
 val readlink : string -> string
 (** Read the contents of a link. *)

--- a/otherlibs/win32unix/Makefile.nt
+++ b/otherlibs/win32unix/Makefile.nt
@@ -16,7 +16,7 @@ WIN_FILES = accept.c bind.c channels.c close.c \
   close_on.c connect.c createprocess.c dup.c dup2.c errmsg.c \
   getpeername.c getpid.c getsockname.c gettimeofday.c \
   link.c listen.c lockf.c lseek.c nonblock.c \
-  mkdir.c open.c pipe.c read.c rename.c \
+  mkdir.c open.c pipe.c read.c readlink.c rename.c \
   select.c sendrecv.c \
   shutdown.c sleep.c socket.c sockopt.c startup.c stat.c \
   system.c times.c unixsupport.c windir.c winwait.c write.c \

--- a/otherlibs/win32unix/Makefile.nt
+++ b/otherlibs/win32unix/Makefile.nt
@@ -34,12 +34,13 @@ UNIX_CAML_FILES = unix.mli unixLabels.mli unixLabels.ml
 
 ALL_FILES=$(WIN_FILES) $(UNIX_FILES)
 WSOCKLIB=$(call SYSLIB,ws2_32)
+ADVAPI32LIB=$(call SYSLIB,advapi32)
 
 LIBNAME=unix
 COBJS=$(ALL_FILES:.c=.$(O))
 CAMLOBJS=unix.cmo unixLabels.cmo
-LINKOPTS=-cclib $(WSOCKLIB)
-LDOPTS=-ldopt $(WSOCKLIB)
+LINKOPTS=-cclib $(WSOCKLIB) -cclib $(ADVAPI32LIB)
+LDOPTS=-ldopt $(WSOCKLIB) -ldopt $(ADVAPI32LIB)
 EXTRACAMLFLAGS=-nolabels
 EXTRACFLAGS=-I../unix
 HEADERS=unixsupport.h socketaddr.h

--- a/otherlibs/win32unix/Makefile.nt
+++ b/otherlibs/win32unix/Makefile.nt
@@ -19,7 +19,7 @@ WIN_FILES = accept.c bind.c channels.c close.c \
   mkdir.c open.c pipe.c read.c readlink.c rename.c \
   select.c sendrecv.c \
   shutdown.c sleep.c socket.c sockopt.c startup.c stat.c \
-  system.c times.c unixsupport.c windir.c winwait.c write.c \
+  symlink.c system.c times.c unixsupport.c windir.c winwait.c write.c \
   winlist.c winworker.c windbug.c
 
 # Files from the ../unix directory

--- a/otherlibs/win32unix/readlink.c
+++ b/otherlibs/win32unix/readlink.c
@@ -1,0 +1,104 @@
+/***********************************************************************/
+/*                                                                     */
+/*                                OCaml                                */
+/*                                                                     */
+/*               David Allsopp, MetaStack Solutions Ltd.               */
+/*                                                                     */
+/*  Copyright 2015 MetaStack Solutions Ltd.  All rights reserved.      */
+/*  This file is distributed under the terms of the GNU Library        */
+/*  General Public License, with the special exception on linking      */
+/*  described in file ../../LICENSE.                                   */
+/*                                                                     */
+/***********************************************************************/
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/signals.h>
+#include "unixsupport.h"
+#include <errno.h>
+#include <winioctl.h>
+
+CAMLprim value unix_readlink(value opath)
+{
+  CAMLparam1(opath);
+  CAMLlocal1(result);
+  HANDLE h;
+  char* path = String_val(opath);
+  DWORD attributes;
+
+  caml_enter_blocking_section();
+  attributes = GetFileAttributes(path);
+  caml_leave_blocking_section();
+
+  if (attributes == INVALID_FILE_ATTRIBUTES) {
+    win32_maperr(GetLastError());
+    uerror("readlink", opath);
+  }
+  else if (!(attributes & FILE_ATTRIBUTE_REPARSE_POINT)) {
+    errno = EINVAL;
+    uerror("readlink", opath);
+  }
+  else {
+    caml_enter_blocking_section();
+    if ((h = CreateFile(path,
+                        FILE_READ_ATTRIBUTES,
+                        FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                        NULL,
+                        OPEN_EXISTING,
+                        FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+                        NULL)) == INVALID_HANDLE_VALUE) {
+      caml_leave_blocking_section();
+      errno = ENOENT;
+      uerror("readlink", opath);
+    }
+    else {
+      char buffer[16384];
+      DWORD read;
+      REPARSE_DATA_BUFFER* point;
+
+      if (DeviceIoControl(h, FSCTL_GET_REPARSE_POINT, NULL, 0, buffer, 16384, &read, NULL)) {
+        caml_leave_blocking_section();
+        point = (REPARSE_DATA_BUFFER*)buffer;
+        if (point->ReparseTag == IO_REPARSE_TAG_SYMLINK) {
+          int cbLen = point->SymbolicLinkReparseBuffer.SubstituteNameLength / sizeof(WCHAR);
+          int len;
+          len = WideCharToMultiByte(
+                  CP_THREAD_ACP,
+                  0,
+                  point->SymbolicLinkReparseBuffer.PathBuffer + point->SymbolicLinkReparseBuffer.SubstituteNameOffset / 2,
+                  cbLen,
+                  NULL,
+                  0,
+                  NULL,
+                  NULL);
+          result = caml_alloc_string(len);
+          WideCharToMultiByte(
+            CP_THREAD_ACP,
+            0,
+            point->SymbolicLinkReparseBuffer.PathBuffer + point->SymbolicLinkReparseBuffer.SubstituteNameOffset / 2,
+            cbLen,
+            String_val(result),
+            len,
+            NULL,
+            NULL);
+          CloseHandle(h);
+        }
+        else {
+          errno = EINVAL;
+          CloseHandle(h);
+          uerror("readline", opath);
+        }
+      }
+      else {
+        caml_leave_blocking_section();
+        win32_maperr(GetLastError());
+        CloseHandle(h);
+        uerror("readlink", opath);
+      }
+    }
+  }
+
+  CAMLreturn(result);
+}

--- a/otherlibs/win32unix/stat.c
+++ b/otherlibs/win32unix/stat.c
@@ -43,45 +43,6 @@
 #define S_IFBLK 0
 #endif
 
-/*
- * This structure is defined inconsistently. mingw64 has it in ntdef.h (which
- * doesn't look like a primary header) and technically it's part of ntifs.h in
- * the WDK. Requiring the WDK is a bit extreme, so the definition is taken from
- * ntdef.h. Both ntdef.h and ntifs.h define REPARSE_DATA_BUFFER_HEADER_SIZE
- */
-#ifndef REPARSE_DATA_BUFFER_HEADER_SIZE
-typedef struct _REPARSE_DATA_BUFFER
-{
-  ULONG  ReparseTag;
-  USHORT ReparseDataLength;
-  USHORT Reserved;
-  union
-  {
-    struct
-    {
-      USHORT SubstituteNameOffset;
-      USHORT SubstituteNameLength;
-      USHORT PrintNameOffset;
-      USHORT PrintNameLength;
-      ULONG  Flags;
-      WCHAR  PathBuffer[1];
-    } SymbolicLinkReparseBuffer;
-    struct
-    {
-      USHORT SubstituteNameOffset;
-      USHORT SubstituteNameLength;
-      USHORT PrintNameOffset;
-      USHORT PrintNameLength;
-      WCHAR  PathBuffer[1];
-    } MountPointReparseBuffer;
-    struct
-    {
-      UCHAR  DataBuffer[1];
-    } GenericReparseBuffer;
-  };
-} REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
-#endif
-
 static int file_kind_table[] = {
   S_IFREG, S_IFDIR, S_IFCHR, S_IFBLK, S_IFLNK, S_IFIFO, S_IFSOCK
 };

--- a/otherlibs/win32unix/stat.c
+++ b/otherlibs/win32unix/stat.c
@@ -38,7 +38,7 @@ static int file_kind_table[] = {
   S_IFREG, S_IFDIR, S_IFCHR, S_IFBLK, S_IFLNK, S_IFIFO, S_IFSOCK
 };
 
-static value stat_aux(int use_64, struct _stati64 *buf)
+static value stat_aux(int use_64, struct _stat64 *buf)
 {
   CAMLparam0 ();
   CAMLlocal1 (v);
@@ -64,10 +64,10 @@ static value stat_aux(int use_64, struct _stati64 *buf)
 CAMLprim value unix_stat(value path)
 {
   int ret;
-  struct _stati64 buf;
+  struct _stat64 buf;
 
   caml_unix_check_path(path, "stat");
-  ret = _stati64(String_val(path), &buf);
+  ret = _stat64(String_val(path), &buf);
   if (ret == -1) uerror("stat", path);
   if (buf.st_size > Max_long) {
     win32_maperr(ERROR_ARITHMETIC_OVERFLOW);
@@ -79,10 +79,10 @@ CAMLprim value unix_stat(value path)
 CAMLprim value unix_stat_64(value path)
 {
   int ret;
-  struct _stati64 buf;
+  struct _stat64 buf;
 
   caml_unix_check_path(path, "stat");
-  ret = _stati64(String_val(path), &buf);
+  ret = _stat64(String_val(path), &buf);
   if (ret == -1) uerror("stat", path);
   return stat_aux(1, &buf);
 }
@@ -90,9 +90,9 @@ CAMLprim value unix_stat_64(value path)
 CAMLprim value unix_fstat(value handle)
 {
   int ret;
-  struct _stati64 buf;
+  struct _stat64 buf;
 
-  ret = _fstati64(win_CRT_fd_of_filedescr(handle), &buf);
+  ret = _fstat64(win_CRT_fd_of_filedescr(handle), &buf);
   if (ret == -1) uerror("fstat", Nothing);
   if (buf.st_size > Max_long) {
     win32_maperr(ERROR_ARITHMETIC_OVERFLOW);
@@ -104,9 +104,9 @@ CAMLprim value unix_fstat(value handle)
 CAMLprim value unix_fstat_64(value handle)
 {
   int ret;
-  struct _stati64 buf;
+  struct _stat64 buf;
 
-  ret = _fstati64(win_CRT_fd_of_filedescr(handle), &buf);
+  ret = _fstat64(win_CRT_fd_of_filedescr(handle), &buf);
   if (ret == -1) uerror("fstat", Nothing);
   return stat_aux(1, &buf);
 }

--- a/otherlibs/win32unix/symlink.c
+++ b/otherlibs/win32unix/symlink.c
@@ -1,0 +1,42 @@
+/***********************************************************************/
+/*                                                                     */
+/*                                OCaml                                */
+/*                                                                     */
+/*               David Allsopp, MetaStack Solutions Ltd.               */
+/*                                                                     */
+/*  Copyright 2015 MetaStack Solutions Ltd.  All rights reserved.      */
+/*  This file is distributed under the terms of the GNU Library        */
+/*  General Public License, with the special exception on linking      */
+/*  described in file ../../LICENSE.                                   */
+/*                                                                     */
+/***********************************************************************/
+
+/*
+ * Windows Vista functions enabled
+ */
+#define _WIN32_WINNT 0x0600
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/signals.h>
+#include "unixsupport.h"
+
+CAMLprim value unix_symlink(value to_dir, value source, value dest)
+{
+  CAMLparam3(to_dir, source, dest);
+  DWORD flags = (Bool_val(to_dir) ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0);
+  BOOL result;
+
+  caml_enter_blocking_section();
+  result = CreateSymbolicLink(String_val(dest), String_val(source), flags);
+  caml_leave_blocking_section();
+
+  if (!result) {
+    win32_maperr(GetLastError());
+    uerror("symlink", dest);
+  }
+
+  CAMLreturn(Val_unit);
+}

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -374,7 +374,20 @@ let mkfifo name perm = invalid_arg "Unix.mkfifo not implemented"
 (* Symbolic links *)
 
 external readlink : string -> string = "unix_readlink"
-let symlink path1 path2 = invalid_arg "Unix.symlink not implemented"
+external symlink_stub : bool -> string -> string -> unit = "unix_symlink"
+
+let symlink ?to_dir source dest =
+  let to_dir =
+    match to_dir with
+      Some to_dir ->
+        to_dir
+    | None ->
+        try
+          LargeFile.((stat source).st_kind = S_DIR)
+        with _ ->
+          false
+  in
+    symlink_stub to_dir source dest
 
 (* Locking *)
 

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -389,6 +389,8 @@ let symlink ?to_dir source dest =
   in
     symlink_stub to_dir source dest
 
+external has_symlink : unit -> bool = "unix_has_symlink"
+
 (* Locking *)
 
 type lock_command =

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -373,7 +373,7 @@ let mkfifo name perm = invalid_arg "Unix.mkfifo not implemented"
 
 (* Symbolic links *)
 
-let readlink path = invalid_arg "Unix.readlink not implemented"
+external readlink : string -> string = "unix_readlink"
 let symlink path1 path2 = invalid_arg "Unix.symlink not implemented"
 
 (* Locking *)

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -251,7 +251,7 @@ type stats =
     st_ctime : float }
 
 external stat : string -> stats = "unix_stat"
-let lstat = stat
+external lstat : string -> stats = "unix_lstat"
 external fstat : file_descr -> stats = "unix_fstat"
 let isatty fd =
   match (fstat fd).st_kind with S_CHR -> true | _ -> false
@@ -287,7 +287,7 @@ module LargeFile =
         st_ctime : float;
       }
     external stat : string -> stats = "unix_stat_64"
-    let lstat = stat
+    external lstat : string -> stats = "unix_lstat_64"
     external fstat : file_descr -> stats = "unix_fstat_64"
   end
 

--- a/otherlibs/win32unix/unixsupport.h
+++ b/otherlibs/win32unix/unixsupport.h
@@ -76,4 +76,43 @@ extern char ** cstringvect(value arg, char * cmdname);
 }
 #endif
 
+/*
+ * This structure is defined inconsistently. mingw64 has it in ntdef.h (which
+ * doesn't look like a primary header) and technically it's part of ntifs.h in
+ * the WDK. Requiring the WDK is a bit extreme, so the definition is taken from
+ * ntdef.h. Both ntdef.h and ntifs.h define REPARSE_DATA_BUFFER_HEADER_SIZE
+ */
+#ifndef REPARSE_DATA_BUFFER_HEADER_SIZE
+typedef struct _REPARSE_DATA_BUFFER
+{
+  ULONG  ReparseTag;
+  USHORT ReparseDataLength;
+  USHORT Reserved;
+  union
+  {
+    struct
+    {
+      USHORT SubstituteNameOffset;
+      USHORT SubstituteNameLength;
+      USHORT PrintNameOffset;
+      USHORT PrintNameLength;
+      ULONG  Flags;
+      WCHAR  PathBuffer[1];
+    } SymbolicLinkReparseBuffer;
+    struct
+    {
+      USHORT SubstituteNameOffset;
+      USHORT SubstituteNameLength;
+      USHORT PrintNameOffset;
+      USHORT PrintNameLength;
+      WCHAR  PathBuffer[1];
+    } MountPointReparseBuffer;
+    struct
+    {
+      UCHAR  DataBuffer[1];
+    } GenericReparseBuffer;
+  };
+} REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
+#endif
+
 #endif /* CAML_UNIXSUPPORT_H */


### PR DESCRIPTION
See also the discussion [in Mantis](http://caml.inria.fr/mantis/view.php?id=6120)

Implements `Unix.readlink` and `Unix.symlink` for Windows. Windows symbolic links are a little, both in their implementation and availability - the weirdness of both is documented in unix.mli both in `Unix.symlink` and the new `Unix.has_symlink` function.

Microsoft's implementation of `stat` is, politely put, flaky and there is no implementation of `lstat`. The stat functions are therefore completely re-implemented - though the algorithm for the Microsoft implementation is maintained in various places (e.g. setting the execute bit). The new implementation populates `st_dev` using the device's serial number rather than a simulated value and also populates `st_ino` (critical for ocamlbuild to be able to use the new symbolic link support)
