### PR TITLE
objinfo: tell when the object file comes from a different OCaml version

### DIFF
--- a/Changes
+++ b/Changes
@@ -51,6 +51,10 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+ - #463: a new Misc.Magic_number module for user-friendly parsing
+   and validation of OCaml magic numbers.
+   (Gabriel Scherer, review by Gabriel Radanne and Damien Doligez)
+
 - #8970: separate value patterns (matching on values) from computation patterns
   (matching on the effects of a copmutation) in the typedtree.
   (Gabriel Scherer, review by Jacques Garrigue and Alain Frisch)

--- a/Changes
+++ b/Changes
@@ -31,6 +31,10 @@ Working version
 
 ### Tools:
 
+- #463: objinfo: better errors on object files coming
+  from a different (older or newer), incompatible compiler version.
+  (Gabriel Scherer, review by Gabriel Radanne and Damien Doligez)
+
 ### Manual and documentation:
 
 ### Compiler user-interface and warnings:

--- a/testsuite/tests/utils/magic_number.ml
+++ b/testsuite/tests/utils/magic_number.ml
@@ -1,0 +1,38 @@
+(* TEST
+include config
+binary_modules = "config build_path_prefix_map misc"
+* bytecode
+*)
+
+open Misc
+open Magic_number
+
+(* sanity checking: the magic number at a given kind can be parsed back *)
+let error kind test =
+  fatal_errorf
+    "Internal compiler error (%s): there is a magic number mismatch on kind %s"
+    test
+    (string_of_kind kind)
+
+let check_raw_kind kind =
+  let valid =
+    match parse_kind (raw_kind kind) with
+      | None -> false
+      | Some kind_roundtrip ->
+         kind_roundtrip = kind
+  in
+  if not valid then error kind "raw_kind"
+
+let check_current_raw kind =
+  let valid =
+    match parse (current_raw kind) with
+      | Error _ -> false
+      | Ok magic ->
+         magic.kind = kind
+         && raw magic = current_raw kind
+  in
+  if not valid then error kind "current_raw"
+
+let () =
+  all_kinds
+  |> List.iter (fun kind -> check_raw_kind kind; check_current_raw kind)

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -20,7 +20,6 @@
 
 open Printf
 open Misc
-open Config
 open Cmo_format
 
 (* Command line options to prevent printing approximation,
@@ -29,6 +28,8 @@ open Cmo_format
 let no_approx = ref false
 let no_code = ref false
 let no_crc = ref false
+
+module Magic_number = Misc.Magic_number
 
 let input_stringlist ic len =
   let get_string_list sect len =
@@ -242,7 +243,7 @@ let dump_byte ic =
     )
     toc
 
-let read_dyn_header filename ic =
+let find_dyn_offset filename =
   let helper = Filename.concat Config.standard_library "objinfo_helper" in
   let tempfile = Filename.temp_file "objinfo" ".out" in
   try
@@ -258,74 +259,136 @@ let read_dyn_header filename ic =
          try_finally
            ~always:(fun () -> Scanf.Scanning.close_in tc)
            (fun () ->
-              let ofs = Scanf.bscanf tc "%Ld" (fun x -> x) in
-              LargeFile.seek_in ic ofs;
-              Some(input_value ic : dynheader)))
+              Scanf.bscanf tc "%Ld" (fun x -> Some x)))
   with Failure _ | Sys_error _ -> None
 
+let exit_err msg = print_endline msg; exit 2
+let exit_errf fmt = Printf.ksprintf exit_err fmt
+
+let exit_magic_msg msg =
+  exit_errf
+     "Wrong magic number:\n\
+      this tool only supports object files produced by compiler version\n\
+      \t%s\n\
+      %s"
+    Sys.ocaml_version msg
+
+let exit_magic_error ~expected_kind err =
+  exit_magic_msg Magic_number.(match err with
+    | Parse_error err -> explain_parse_error expected_kind err
+    | Unexpected_error err -> explain_unexpected_error err)
+
+(* assume that 'ic' is already positioned at the right place
+   depending on the format (usually right after the magic number,
+   but Exec and Cmxs differ) *)
+let dump_obj_by_kind filename ic obj_kind =
+  let open Magic_number in
+  match obj_kind with
+    | Cmo ->
+       let cu_pos = input_binary_int ic in
+       seek_in ic cu_pos;
+       let cu = (input_value ic : compilation_unit) in
+       close_in ic;
+       print_cmo_infos cu
+    | Cma ->
+       let toc_pos = input_binary_int ic in
+       seek_in ic toc_pos;
+       let toc = (input_value ic : library) in
+       close_in ic;
+       print_cma_infos toc
+    | Cmi | Cmt ->
+       close_in ic;
+       let cmi, cmt = Cmt_format.read filename in
+       begin match cmi with
+         | None -> ()
+         | Some cmi ->
+            print_cmi_infos cmi.Cmi_format.cmi_name cmi.Cmi_format.cmi_crcs
+       end;
+       begin match cmt with
+         | None -> ()
+         | Some cmt -> print_cmt_infos cmt
+       end
+    | Cmx _config ->
+       let ui = (input_value ic : unit_infos) in
+       let crc = Digest.input ic in
+       close_in ic;
+       print_cmx_infos (ui, crc)
+    | Cmxa _config ->
+       let li = (input_value ic : library_infos) in
+       close_in ic;
+       print_cmxa_infos li
+    | Exec ->
+       (* no assumptions on [ic] position,
+          [dump_byte] will seek at the right place *)
+       dump_byte ic;
+       close_in ic
+    | Cmxs ->
+       (* we assume we are at the offset of the dynamic information,
+          as returned by [find_dyn_offset]. *)
+       let header = (input_value ic : dynheader) in
+       close_in ic;
+       print_cmxs_infos header;
+    | Ast_impl | Ast_intf ->
+       exit_errf "The object file type %S \
+                  is currently unsupported by this tool."
+         (human_name_of_kind obj_kind)
+
 let dump_obj filename =
+  let open Magic_number in
+  let dump_standard ic =
+    match read_current_info ~expected_kind:None ic with
+      | Error ((Unexpected_error _) as err) ->
+         exit_magic_error ~expected_kind:None err
+      | Ok { kind; version = _ } ->
+         dump_obj_by_kind filename ic kind;
+         Ok ()
+      | Error (Parse_error head_error) ->
+         Error head_error
+  and dump_exec ic =
+    let pos_trailer = in_channel_length ic - Magic_number.magic_length in
+    let _ = seek_in ic pos_trailer in
+    let expected_kind = Some Exec in
+    match read_current_info ~expected_kind ic with
+      | Error ((Unexpected_error _) as err) ->
+         exit_magic_error ~expected_kind err
+      | Ok _ ->
+         dump_obj_by_kind filename ic Exec;
+         Ok ()
+      | Error (Parse_error _)  ->
+         Error ()
+  and dump_cmxs ic =
+    flush stdout;
+    match find_dyn_offset filename with
+      | None ->
+         exit_errf "Unable to read info on %s %s."
+           (human_name_of_kind Cmxs) filename
+      | Some offset ->
+         LargeFile.seek_in ic offset;
+         let header = (input_value ic : dynheader) in
+         let expected_kind = Some Cmxs in
+         match parse header.dynu_magic with
+           | Error err ->
+              exit_magic_error ~expected_kind (Parse_error err)
+           | Ok info ->
+         match check_current Cmxs info with
+           | Error err ->
+              exit_magic_error ~expected_kind (Unexpected_error err)
+           | Ok () ->
+         LargeFile.seek_in ic offset;
+         dump_obj_by_kind filename ic Cmxs;
+         ()
+  in
   printf "File %s\n" filename;
   let ic = open_in_bin filename in
-  let len_magic_number = String.length cmo_magic_number in
-  let magic_number = really_input_string ic len_magic_number in
-  if magic_number = cmo_magic_number then begin
-    let cu_pos = input_binary_int ic in
-    seek_in ic cu_pos;
-    let cu = (input_value ic : compilation_unit) in
-    close_in ic;
-    print_cmo_infos cu
-  end else if magic_number = cma_magic_number then begin
-    let toc_pos = input_binary_int ic in
-    seek_in ic toc_pos;
-    let toc = (input_value ic : library) in
-    close_in ic;
-    print_cma_infos toc
-  end else if magic_number = cmi_magic_number ||
-              magic_number = cmt_magic_number then begin
-    close_in ic;
-    let cmi, cmt = Cmt_format.read filename in
-    begin match cmi with
-     | None -> ()
-     | Some cmi ->
-         print_cmi_infos cmi.Cmi_format.cmi_name cmi.Cmi_format.cmi_crcs
-    end;
-    begin match cmt with
-     | None -> ()
-     | Some cmt -> print_cmt_infos cmt
-    end
-  end else if magic_number = cmx_magic_number then begin
-    let ui = (input_value ic : unit_infos) in
-    let crc = Digest.input ic in
-    close_in ic;
-    print_cmx_infos (ui, crc)
-  end else if magic_number = cmxa_magic_number then begin
-    let li = (input_value ic : library_infos) in
-    close_in ic;
-    print_cmxa_infos li
-  end else begin
-    let pos_trailer = in_channel_length ic - len_magic_number in
-    let _ = seek_in ic pos_trailer in
-    let magic_number = really_input_string ic len_magic_number in
-    if magic_number = Config.exec_magic_number then begin
-      dump_byte ic;
-      close_in ic
-    end else if Filename.check_suffix filename ".cmxs" then begin
-      flush stdout;
-      match read_dyn_header filename ic with
-      | None ->
-          printf "Unable to read info on file %s\n" filename;
-          exit 2
-      | Some header ->
-          if header.dynu_magic = Config.cmxs_magic_number then
-            print_cmxs_infos header
-          else begin
-            printf "Wrong magic number\n"; exit 2
-          end;
-          close_in ic
-    end else begin
-      printf "Not an OCaml object file\n"; exit 2
-    end
-  end
+  match dump_standard ic with
+    | Ok () -> ()
+    | Error head_error ->
+  match dump_exec ic with
+    | Ok () -> ()
+    | Error () ->
+  if Filename.check_suffix filename ".cmxs"
+  then dump_cmxs ic
+  else exit_magic_error ~expected_kind:None (Parse_error head_error)
 
 let arg_list = [
   "-no-approx", Arg.Set no_approx,

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -937,3 +937,256 @@ module EnvLazy = struct
     loop !log
 
 end
+
+
+module Magic_number = struct
+  type native_obj_config = {
+    flambda : bool;
+  }
+  let native_obj_config = {
+    flambda = Config.flambda;
+  }
+
+  type version = int
+
+  type kind =
+    | Exec
+    | Cmi | Cmo | Cma
+    | Cmx of native_obj_config | Cmxa of native_obj_config
+    | Cmxs
+    | Cmt
+    | Ast_impl | Ast_intf
+
+  (* please keep up-to-date, this is used for sanity checking *)
+  let all_native_obj_configs = [
+      {flambda = true};
+      {flambda = false};
+    ]
+  let all_kinds = [
+    Exec;
+    Cmi; Cmo; Cma;
+  ]
+  @ List.map (fun conf -> Cmx conf) all_native_obj_configs
+  @ List.map (fun conf -> Cmxa conf) all_native_obj_configs
+  @ [
+    Cmt;
+    Ast_impl; Ast_intf;
+  ]
+
+  type raw = string
+  type info = {
+    kind: kind;
+    version: version;
+  }
+
+  type raw_kind = string
+
+  let parse_kind : raw_kind -> kind option = function
+    | "Caml1999X" -> Some Exec
+    | "Caml1999I" -> Some Cmi
+    | "Caml1999O" -> Some Cmo
+    | "Caml1999A" -> Some Cma
+    | "Caml1999y" -> Some (Cmx {flambda = true})
+    | "Caml1999Y" -> Some (Cmx {flambda = false})
+    | "Caml1999z" -> Some (Cmxa {flambda = true})
+    | "Caml1999Z" -> Some (Cmxa {flambda = false})
+
+    (* Caml2007D and Caml2012T were used instead of the common Caml1999 prefix
+       between the introduction of those magic numbers and October 2017
+       (8ba70ff194b66c0a50ffb97d41fe9c4bdf9362d6).
+
+       We accept them here, but will always produce/show kind prefixes
+       that follow the current convention, Caml1999{D,T}. *)
+    | "Caml2007D" | "Caml1999D" -> Some Cmxs
+    | "Caml2012T" | "Caml1999T" -> Some Cmt
+
+    | "Caml1999M" -> Some Ast_impl
+    | "Caml1999N" -> Some Ast_intf
+    | _ -> None
+
+  (* note: over time the magic kind number has changed for certain kinds;
+     this function returns them as they are produced by the current compiler,
+     but [parse_kind] accepts older formats as well. *)
+  let raw_kind : kind -> raw = function
+    | Exec -> "Caml1999X"
+    | Cmi -> "Caml1999I"
+    | Cmo -> "Caml1999O"
+    | Cma -> "Caml1999A"
+    | Cmx config ->
+       if config.flambda
+       then "Caml1999y"
+       else "Caml1999Y"
+    | Cmxa config ->
+       if config.flambda
+       then "Caml1999z"
+       else "Caml1999Z"
+    | Cmxs -> "Caml1999D"
+    | Cmt -> "Caml1999T"
+    | Ast_impl -> "Caml1999M"
+    | Ast_intf -> "Caml1999N"
+
+  let string_of_kind : kind -> string = function
+    | Exec -> "exec"
+    | Cmi -> "cmi"
+    | Cmo -> "cmo"
+    | Cma -> "cma"
+    | Cmx _ -> "cmx"
+    | Cmxa _ -> "cmxa"
+    | Cmxs -> "cmxs"
+    | Cmt -> "cmt"
+    | Ast_impl -> "ast_impl"
+    | Ast_intf -> "ast_intf"
+
+  let human_description_of_native_obj_config : native_obj_config -> string =
+    fun[@warning "+9"] {flambda} ->
+      if flambda then "flambda" else "non flambda"
+
+  let human_name_of_kind : kind -> string = function
+    | Exec -> "executable"
+    | Cmi -> "compiled interface file"
+    | Cmo -> "bytecode object file"
+    | Cma -> "bytecode library"
+    | Cmx config ->
+       Printf.sprintf "native compilation unit description (%s)"
+         (human_description_of_native_obj_config config)
+    | Cmxa config ->
+       Printf.sprintf "static native library (%s)"
+         (human_description_of_native_obj_config config)
+    | Cmxs -> "dynamic native library"
+    | Cmt -> "compiled typedtree file"
+    | Ast_impl -> "serialized implementation AST"
+    | Ast_intf -> "serialized interface AST"
+
+  let kind_length = 9
+  let version_length = 3
+  let magic_length =
+    kind_length + version_length
+
+  type parse_error =
+    | Truncated of string
+    | Not_a_magic_number of string
+
+  let explain_parse_error kind_opt error =
+       Printf.sprintf
+         "We expected a valid %s, but the file %s."
+         (Option.fold ~none:"object file" ~some:human_name_of_kind kind_opt)
+         (match error with
+            | Truncated "" -> "is empty"
+            | Truncated _ -> "is truncated"
+            | Not_a_magic_number _ -> "has a different format")
+
+  let parse s : (info, parse_error) result =
+    if String.length s = magic_length then begin
+      let raw_kind = String.sub s 0 kind_length in
+      let raw_version = String.sub s kind_length version_length in
+      match parse_kind raw_kind with
+      | None -> Error (Not_a_magic_number s)
+      | Some kind ->
+          begin match int_of_string raw_version with
+          | exception _ -> Error (Truncated s)
+          | version -> Ok { kind; version }
+          end
+    end
+    else begin
+      (* a header is "truncated" if it starts like a valid magic number,
+         that is if its longest segment of length at most [kind_length]
+         is a prefix of [raw_kind kind] for some kind [kind] *)
+      let sub_length = min kind_length (String.length s) in
+      let starts_as kind =
+        String.sub s 0 sub_length = String.sub (raw_kind kind) 0 sub_length
+      in
+      if List.exists starts_as all_kinds then Error (Truncated s)
+      else Error (Not_a_magic_number s)
+    end
+
+  let read_info ic =
+    let header = Buffer.create magic_length in
+    begin
+      try Buffer.add_channel header ic magic_length
+      with End_of_file -> ()
+    end;
+    parse (Buffer.contents header)
+
+  let raw { kind; version; } =
+    Printf.sprintf "%s%03d" (raw_kind kind) version
+
+  let current_raw kind =
+    let open Config in
+    match[@warning "+9"] kind with
+      | Exec -> exec_magic_number
+      | Cmi -> cmi_magic_number
+      | Cmo -> cmo_magic_number
+      | Cma -> cma_magic_number
+      | Cmx config ->
+         (* the 'if' guarantees that in the common case
+            we return the "trusted" value from Config. *)
+         let reference = cmx_magic_number in
+         if config = native_obj_config then reference
+         else
+           (* otherwise we stitch together the magic number
+              for a different configuration by concatenating
+              the right magic kind at this configuration
+              and the rest of the current raw number for our configuration. *)
+           let raw_kind = raw_kind kind in
+           let len = String.length raw_kind in
+           raw_kind ^ String.sub reference len (String.length reference - len)
+      | Cmxa config ->
+         let reference = cmxa_magic_number in
+         if config = native_obj_config then reference
+         else
+           let raw_kind = raw_kind kind in
+           let len = String.length raw_kind in
+           raw_kind ^ String.sub reference len (String.length reference - len)
+      | Cmxs -> cmxs_magic_number
+      | Cmt -> cmt_magic_number
+      | Ast_intf -> ast_intf_magic_number
+      | Ast_impl -> ast_impl_magic_number
+
+  (* it would seem more direct to define current_version with the
+     correct numbers and current_raw on top of it, but for now we
+     consider the Config.foo values to be ground truth, and don't want
+     to trust the present module instead. *)
+  let current_version kind =
+    let raw = current_raw kind in
+    try int_of_string (String.sub raw kind_length version_length)
+    with _ -> assert false
+
+  type 'a unexpected = { expected : 'a; actual : 'a }
+  type unexpected_error =
+    | Kind of kind unexpected
+    | Version of kind * version unexpected
+
+  let explain_unexpected_error = function
+    | Kind { actual; expected } ->
+        Printf.sprintf "We expected a %s (%s) but got a %s (%s) instead."
+          (human_name_of_kind expected) (string_of_kind expected)
+          (human_name_of_kind actual) (string_of_kind actual)
+    | Version (kind, { actual; expected }) ->
+        Printf.sprintf "This seems to be a %s (%s) for %s version of OCaml."
+          (human_name_of_kind kind) (string_of_kind kind)
+          (if actual < expected then "an older" else "a newer")
+
+  let check_current expected_kind { kind; version } : _ result =
+    if kind <> expected_kind then begin
+      let actual, expected = kind, expected_kind in
+      Error (Kind { actual; expected })
+    end else begin
+      let actual, expected = version, current_version kind in
+      if actual <> expected
+      then Error (Version (kind, { actual; expected }))
+      else Ok ()
+    end
+
+  type error =
+    | Parse_error of parse_error
+    | Unexpected_error of unexpected_error
+
+  let read_current_info ~expected_kind ic =
+    match read_info ic with
+      | Error err -> Error (Parse_error err)
+      | Ok info ->
+         let kind = Option.value ~default:info.kind expected_kind in
+         match check_current kind info with
+           | Error err -> Error (Unexpected_error err)
+           | Ok () -> Ok info
+end

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -486,3 +486,203 @@ module EnvLazy: sig
   val backtrack : log -> unit
 
 end
+
+
+module Magic_number : sig
+  (** a typical magic number is "Caml1999I011"; it is formed of an
+      alpha-numeric prefix, here Caml1990I, followed by a version,
+      here 011. The prefix identifies the kind of the versioned data:
+      here the I indicates that it is the magic number for .cmi files.
+
+      All magic numbers have the same byte length, [magic_length], and
+      this is important for users as it gives them the number of bytes
+      to read to obtain the byte sequence that should be a magic
+      number. Typical user code will look like:
+      {[
+        let ic = open_in_bin path in
+        let magic =
+          try really_input_string ic Magic_number.magic_length
+          with End_of_file -> ... in
+        match Magic_number.parse magic with
+        | Error parse_error -> ...
+        | Ok info -> ...
+      ]}
+
+      A given compiler version expects one specific version for each
+      kind of object file, and will fail if given an unsupported
+      version. Because versions grow monotonically, you can compare
+      the parsed version with the expected "current version" for
+      a kind, to tell whether the wrong-magic object file comes from
+      the past or from the future.
+
+      An example of code block that expects the "currently supported version"
+      of a given kind of magic numbers, here [Cmxa], is as follows:
+      {[
+        let ic = open_in_bin path in
+        begin
+          try Magic_number.(expect_current Cmxa (get_info ic)) with
+          | Parse_error error -> ...
+          | Unexpected error -> ...
+        end;
+        ...
+      ]}
+
+      Parse errors distinguish inputs that are [Not_a_magic_number str],
+      which are likely to come from the file being completely
+      different, and [Truncated str], raised by headers that are the
+      (possibly empty) prefix of a valid magic number.
+
+      Unexpected errors correspond to valid magic numbers that are not
+      the one expected, either because it corresponds to a different
+      kind, or to a newer or older version.
+
+      The helper functions [explain_parse_error] and [explain_unexpected_error]
+      will generate a textual explanation of each error,
+      for use in error messages.
+
+      @since 4.11.0
+  *)
+
+  type native_obj_config = {
+    flambda : bool;
+  }
+  (** native object files have a format and magic number that depend
+     on certain native-compiler configuration parameters. This
+     configuration space is expressed by the [native_obj_config]
+     type. *)
+
+  val native_obj_config : native_obj_config
+  (** the native object file configuration of the active/configured compiler. *)
+
+  type version = int
+
+  type kind =
+    | Exec
+    | Cmi | Cmo | Cma
+    | Cmx of native_obj_config | Cmxa of native_obj_config
+    | Cmxs
+    | Cmt | Ast_impl | Ast_intf
+
+  type info = {
+    kind: kind;
+    version: version;
+    (** Note: some versions of the compiler use the same [version] suffix
+        for all kinds, but others use different versions counters for different
+        kinds. We may only assume that versions are growing monotonically
+        (not necessarily always by one) between compiler versions. *)
+  }
+
+  type raw = string
+  (** the type of raw magic numbers,
+      such as "Caml1999A027" for the .cma files of OCaml 4.10 *)
+
+  (** {3 Parsing magic numbers} *)
+
+  type parse_error =
+    | Truncated of string
+    | Not_a_magic_number of string
+
+  val explain_parse_error : kind option -> parse_error -> string
+  (** Produces an explanation for a parse error. If no kind is provided,
+      we use an unspecific formulation suggesting that any compiler-produced
+      object file would have been satisfying. *)
+
+  val parse : raw -> (info, parse_error) result
+  (** Parses a raw magic number *)
+
+  val read_info : in_channel -> (info, parse_error) result
+  (** Read a raw magic number from an input channel.
+
+      If the data read [str] is not a valid magic number, it can be
+      recovered from the [Truncated str | Not_a_magic_number str]
+      payload of the [Error parse_error] case.
+
+      If parsing succeeds with an [Ok info] result, we know that
+      exactly [magic_length] bytes have been consumed from the
+      input_channel.
+
+      If you also wish to enforce that the magic number
+      is at the current version, see {!read_current_info} below.
+   *)
+
+  val magic_length : int
+  (** all magic numbers take the same number of bytes *)
+
+
+  (** {3 Checking that magic numbers are current} *)
+
+  type 'a unexpected = { expected : 'a; actual : 'a }
+  type unexpected_error =
+    | Kind of kind unexpected
+    | Version of kind * version unexpected
+
+  val check_current : kind -> info -> (unit, unexpected_error) result
+  (** [check_current kind info] checks that the provided magic [info]
+      is the current version of [kind]'s magic header. *)
+
+  val explain_unexpected_error : unexpected_error -> string
+  (** Provides an explanation of the [unexpected_error]. *)
+
+  type error =
+    | Parse_error of parse_error
+    | Unexpected_error of unexpected_error
+
+  val read_current_info :
+    expected_kind:kind option -> in_channel -> (info, error) result
+  (** Read a magic number as [read_info],
+      and check that it is the current version as its kind.
+      If the [expected_kind] argument is [None], any kind is accepted. *)
+
+
+  (** {3 Information on magic numbers} *)
+
+  val string_of_kind : kind -> string
+  (** a user-printable string for a kind, eg. "exec" or "cmo", to use
+      in error messages. *)
+
+  val human_name_of_kind : kind -> string
+  (** a user-meaningful name for a kind, eg. "executable file" or
+      "bytecode object file", to use in error messages. *)
+
+  val current_raw : kind -> raw
+  (** the current magic number of each kind *)
+
+  val current_version : kind -> version
+  (** the current version of each kind *)
+
+
+  (** {3 Raw representations}
+
+      Mainly for internal usage and testing. *)
+
+  type raw_kind = string
+  (** the type of raw magic numbers kinds,
+      such as "Caml1999A" for .cma files *)
+
+  val parse_kind : raw_kind -> kind option
+  (** parse a raw kind into a kind *)
+
+  val raw_kind : kind -> raw_kind
+  (** the current raw representation of a kind.
+
+      In some cases the raw representation of a kind has changed
+      over compiler versions, so other files of the same kind
+      may have different raw kinds.
+      Note that all currently known cases are parsed correctly by [parse_kind].
+  *)
+
+  val raw : info -> raw
+  (** A valid raw representation of the magic number.
+
+      Due to past and future changes in the string representation of
+      magic numbers, we cannot guarantee that the raw strings returned
+      for past and future versions actually match the expectations of
+      those compilers. The representation is accurate for current
+      versions, and it is correctly parsed back into the desired
+      version by the parsing functions above.
+   *)
+
+  (**/**)
+
+  val all_kinds : kind list
+end


### PR DESCRIPTION
When passed an object file that comes from a different OCaml version,
objinfo will currently just detect that the magic number is not what
it expects, and claim it is not a valid file. This is irritating.

The current patch implements some more advanced handling of magic
number in a new Misc.Magic_number module, inspired by js_of_ocaml
Misc.MagicNumber module
  https://github.com/ocsigen/js_of_ocaml/blob/151b811/compiler/util.cppo.ml#L277-L347
that lets us easily tell the difference between "not a valid magic number"
and "a valid magic number, but with another version".

The error message output by objinfo now looks like this:

```
$ ./objinfo ./ocamldep.cmo
File ./ocamldep.cmo
Wrong magic number:
this tool only supports object files produced by compiler version
    4.03.0+dev12-2015-11-20,
and this object file (cmo) seems to come from an older version.
```
