### PR TITLE
Enable opaque option in ocamlc

### DIFF
--- a/driver/main.ml
+++ b/driver/main.ml
@@ -107,6 +107,7 @@ module Options = Main_args.Make_bytecomp_options (struct
   let _noautolink = set no_auto_link
   let _nostdlib = set no_std_include
   let _o s = output_name := Some s
+  let _opaque = set opaque
   let _open s = open_modules := s :: !open_modules
   let _output_obj () = output_c_object := true; custom_runtime := true
   let _output_complete_obj () =

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -700,6 +700,7 @@ module type Compiler_options = sig
   val _linkall : unit -> unit
   val _noautolink : unit -> unit
   val _o : string -> unit
+  val _opaque :  unit -> unit
   val _output_obj : unit -> unit
   val _output_complete_obj : unit -> unit
   val _pack : unit -> unit
@@ -806,7 +807,6 @@ module type Optcomp_options = sig
   val _pp : string -> unit
   val _S : unit -> unit
   val _shared : unit -> unit
-  val _opaque :  unit -> unit
 end;;
 
 module type Opttop_options = sig
@@ -881,6 +881,7 @@ struct
     mk_nolabels F._nolabels;
     mk_nostdlib F._nostdlib;
     mk_o F._o;
+    mk_opaque F._opaque;
     mk_open F._open;
     mk_output_obj F._output_obj;
     mk_output_complete_obj F._output_complete_obj;
@@ -1018,6 +1019,7 @@ struct
     mk_o F._o;
     mk_o2 F._o2;
     mk_o3 F._o3;
+    mk_opaque F._opaque;
     mk_open F._open;
     mk_output_obj F._output_obj;
     mk_output_complete_obj F._output_complete_obj;
@@ -1081,7 +1083,6 @@ struct
     mk_dstartup F._dstartup;
     mk_dtimings F._dtimings;
     mk_dump_pass F._dump_pass;
-    mk_opaque F._opaque;
   ]
 end;;
 

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -67,6 +67,7 @@ module type Compiler_options =  sig
   val _linkall : unit -> unit
   val _noautolink : unit -> unit
   val _o : string -> unit
+  val _opaque :  unit -> unit
   val _output_obj : unit -> unit
   val _output_complete_obj : unit -> unit
   val _pack : unit -> unit
@@ -173,7 +174,6 @@ module type Optcomp_options = sig
   val _pp : string -> unit
   val _S : unit -> unit
   val _shared : unit -> unit
-  val _opaque :  unit -> unit
 end;;
 
 module type Opttop_options = sig

--- a/tools/ocamlcp.ml
+++ b/tools/ocamlcp.ml
@@ -74,6 +74,7 @@ module Options = Main_args.Make_bytecomp_options (struct
   let _noautolink = option "-noautolink"
   let _nostdlib = option "-nostdlib"
   let _o s = option_with_arg "-o" s
+  let _opaque = option "-opaque"
   let _open s = option_with_arg "-open" s
   let _output_obj = option "-output-obj"
   let _output_complete_obj = option "-output-complete-obj"


### PR DESCRIPTION
Since `-opaque` now affects `.cmi` files as well as `.cmx` files it should be enabled for ocamlc. This addresses @gasche's comment on #319.
