### PR TITLE
Manual: #help directive and immediate attribute

### DIFF
--- a/manual/manual/cmds/top.etex
+++ b/manual/manual/cmds/top.etex
@@ -349,12 +349,12 @@ will result in an ``unbound value "quit"'' error.
 \item[Environment queries]
   \begin{options}
   \item["#show_class "\var{class-path}";;"]\vspace{-4.7ex}
-  \item["#show_class_type "\var{class-path}";;"]
-  \item["#show_exception "\var{ident}";;"]
+  \item["#show_class_type "\var{class-path}";;"]\vspace{-4.7ex}
+  \item["#show_exception "\var{ident}";;"]\vspace{-4.7ex}
   \item["#show_module "\var{module-path}";;"]\vspace{-4.7ex}
   \item["#show_module_type "\var{modtype-path}";;"]\vspace{-4.7ex}
   \item["#show_type "\var{typeconstr}";;"]\vspace{-4.7ex}
-  \item["#show_val "\var{value-path}";;"]\vspace{-4.7ex}
+  \item["#show_val "\var{value-path}";;"]
     Print the signature of the corresponding component.
 
   \item["#show "\var{ident}";;"]
@@ -416,7 +416,7 @@ will result in an ``unbound value "quit"'' error.
     Ignore labels in function types if argument is "false", or switch back
     to default behaviour (commuting style) if argument is "true".
 
-  \item["#ppx  "\var{str}";;"]
+  \item["#ppx  \""\var{file-name}"\";;"]
     After parsing, pipe the abstract syntax tree through the preprocessor
     command.
 

--- a/manual/manual/cmds/top.etex
+++ b/manual/manual/cmds/top.etex
@@ -293,119 +293,151 @@ must be typed before the directive, and must not be confused with the
 typing "#quit;;" will exit the toplevel loop, but typing "quit;;"
 will result in an ``unbound value "quit"'' error.
 
+%
+% Remark: this list of options should be kept synchronized with the documentation
+% in toplevel/topdirs.ml.
+%
 \begin{options}
+\item[General]
+  \begin{options}
+  \item["#help;;"]
+    Prints a list of all available directives, with corresponding argument type
+    if appropriate.
+  \item["#quit;;"]
+    Exit the toplevel loop and terminate the "ocaml" command.
+  \end{options}
 
-\item["#quit;;"]
-Exit the toplevel loop and terminate the "ocaml" command.
+\item[Loading codes]
+  \begin{options}
 
-\item["#labels "\var{bool}";;"]
-Ignore labels in function types if argument is "false", or switch back
-to default behaviour (commuting style) if argument is "true".
+  \item["#cd \""\var{dir-name}"\";;"]
+    Change the current working directory.
 
-\item["#principal "\var{bool}";;"]
-If the argument is "true", check information paths during
-type-checking, to make sure that all types are derived in a principal
-way. If the argument is "false", do not check information paths.
+  \item["#directory \""\var{dir-name}"\";;"]
+    Add the given directory to the list of directories searched for
+    source and compiled files.
 
-\item["#rectypes;;"]
-Allow arbitrary recursive types during type-checking. Note: once
-enabled, this option cannot be disabled because that would lead to
-unsoundness of the type system.
+  \item["#remove_directory \""\var{dir-name}"\";;"]
+    Remove the given directory from the list of directories searched for
+    source and compiled files.  Do nothing if the list does not contain
+    the given directory.
 
-\item["#warnings \""\var{warning-list}"\";;"]
-Enable or disable warnings according to the argument.
+  \item["#load \""\var{file-name}"\";;"]
+    Load in memory a bytecode object file (".cmo" file) or library file
+    (".cma" file) produced by the batch compiler "ocamlc".
 
-\item["#warn_error \""\var{warning-list}"\";;"]
-Treat as errors the warnings enabled by the argument and as normal
-warnings the warnings disabled by the argument.
+  \item["#load_rec \""\var{file-name}"\";;"]
+    Load in memory a bytecode object file (".cmo" file) or library file
+    (".cma" file) produced by the batch compiler "ocamlc".
+    When loading an object file that depends on other modules
+    which have not been loaded yet, the .cmo files for these modules
+    are searched and loaded as well, recursively. The loading order
+    is not specified.
 
-\item["#directory \""\var{dir-name}"\";;"]
-Add the given directory to the list of directories searched for
-source and compiled files.
+  \item["#use \""\var{file-name}"\";;"]
+    Read, compile and execute source phrases from the given file.
+    This is textual inclusion: phrases are processed just as if
+    they were typed on standard input. The reading of the file stops at
+    the first error encountered.
 
-\item["#remove_directory \""\var{dir-name}"\";;"]
-Remove the given directory from the list of directories searched for
-source and compiled files.  Do nothing if the list does not contain
-the given directory.
+  \item["#mod_use \""\var{file-name}"\";;"]
+    Similar to "#use" but also wrap the code into a top-level module of the
+    same name as capitalized file name without extensions, following
+    semantics of the compiler.
+  \end{options}
 
-\item["#cd \""\var{dir-name}"\";;"]
-Change the current working directory.
+\item[Environment queries]
+  \begin{options}
+  \item["#show_class "\var{class-path}";;"]\vspace{-4.7ex}
+  \item["#show_class_type "\var{class-path}";;"]
+  \item["#show_exception "\var{ident}";;"]
+  \item["#show_module "\var{module-path}";;"]\vspace{-4.7ex}
+  \item["#show_module_type "\var{modtype-path}";;"]\vspace{-4.7ex}
+  \item["#show_type "\var{typeconstr}";;"]\vspace{-4.7ex}
+  \item["#show_val "\var{value-path}";;"]\vspace{-4.7ex}
+    Print the signature of the corresponding component.
 
-\item["#load \""\var{file-name}"\";;"]
-Load in memory a bytecode object file (".cmo" file) or library file
-(".cma" file) produced by the batch compiler "ocamlc".
+  \item["#show "\var{ident}";;"]
+    Print the signatures of components with name \var{ident} in all the
+    above categories.
+    \end{options}
 
-\item["#load_rec \""\var{file-name}"\";;"]
-Load in memory a bytecode object file (".cmo" file) or library file
-(".cma" file) produced by the batch compiler "ocamlc".
-When loading an object file that depends on other modules
-which have not been loaded yet, the .cmo files for these modules
-are searched and loaded as well, recursively. The loading order
-is not specified.
+\item[Pretty-printing]
+  \begin{options}
 
-\item["#use \""\var{file-name}"\";;"]
-Read, compile and execute source phrases from the given file.
-This is textual inclusion: phrases are processed just as if
-they were typed on standard input. The reading of the file stops at
-the first error encountered.
+  \item["#install_printer "\var{printer-name}";;"]
+    This directive registers the function named \var{printer-name} (a
+    value path) as a printer for values whose types match the argument
+    type of the function. That is, the toplevel loop will call
+    \var{printer-name} when it has such a value to print.
 
-\item["#mod_use \""\var{file-name}"\";;"]
-Similar to "#use" but also wrap the code into a top-level module of the
-same name as capitalized file name without extensions, following
-semantics of the compiler.
+    The printing function \var{printer-name} should have type
+    @"Format.formatter" "->" @t@ "->" "unit"@, where @@t@@ is the
+    type for the values to be printed, and should output its textual
+    representation for the value of type @@t@@ on the given formatter,
+    using the functions provided by the "Format" library.  For backward
+    compatibility, \var{printer-name} can also have type
+    @@t@ "->" "unit"@ and should then output on the standard
+    formatter, but this usage is deprecated.
 
-\item["#install_printer "\var{printer-name}";;"]
-This directive registers the function named \var{printer-name} (a
-value path) as a printer for values whose types match the argument
-type of the function. That is, the toplevel loop will call
-\var{printer-name} when it has such a value to print.
+  \item["#print_depth "\var{n}";;"]
+    Limit the printing of values to a maximal depth of \var{n}.
+    The parts of values whose depth exceeds \var{n} are printed as "..."
+    (ellipsis).
 
-The printing function \var{printer-name} should have type
-@"Format.formatter" "->" @t@ "->" "unit"@, where @@t@@ is the
-type for the values to be printed, and should output its textual
-representation for the value of type @@t@@ on the given formatter,
-using the functions provided by the "Format" library.  For backward
-compatibility, \var{printer-name} can also have type
-@@t@ "->" "unit"@ and should then output on the standard
-formatter, but this usage is deprecated.
+  \item["#print_length "\var{n}";;"]
+    Limit the number of value nodes printed to at most \var{n}.
+    Remaining parts of values are printed as "..." (ellipsis).
 
-\item["#remove_printer "\var{printer-name}";;"]
-Remove the named function from the table of toplevel printers.
+  \item["#remove_printer "\var{printer-name}";;"]
+    Remove the named function from the table of toplevel printers.
+\end{options}
 
-\item["#trace "\var{function-name}";;"]
-After executing this directive, all calls to the function named
-\var{function-name} will be ``traced''. That is, the argument and the
-result are displayed for each call, as well as the exceptions escaping
-out of the function, raised either by the function itself or by
-another function it calls. If the function is curried, each argument
-is printed as it is passed to the function.
+\item[Tracing]
+  \begin{options}
+  \item["#trace "\var{function-name}";;"]
+    After executing this directive, all calls to the function named
+    \var{function-name} will be ``traced''. That is, the argument and the
+    result are displayed for each call, as well as the exceptions escaping
+    out of the function, raised either by the function itself or by
+    another function it calls. If the function is curried, each argument
+    is printed as it is passed to the function.
 
-\item["#untrace "\var{function-name}";;"]
-Stop tracing the given function.
+  \item["#untrace "\var{function-name}";;"]
+    Stop tracing the given function.
 
-\item["#untrace_all;;"]
-Stop tracing all functions traced so far.
+  \item["#untrace_all;;"]
+    Stop tracing all functions traced so far.
+  \end{options}
 
-\item["#print_depth "\var{n}";;"]
-Limit the printing of values to a maximal depth of \var{n}.
-The parts of values whose depth exceeds \var{n} are printed as "..."
-(ellipsis).
+\item[Compiler options]
+  \begin{options}
+  \item["#labels "\var{bool}";;"]
+    Ignore labels in function types if argument is "false", or switch back
+    to default behaviour (commuting style) if argument is "true".
 
-\item["#print_length "\var{n}";;"]
-Limit the number of value nodes printed to at most \var{n}.
-Remaining parts of values are printed as "..." (ellipsis).
+  \item["#ppx  "\var{str}";;"]
+    After parsing, pipe the abstract syntax tree through the preprocessor
+    command.
 
-\item["#show_val "\var{value-path}";;"]\vspace{-4.7ex}
-\item["#show_type "\var{typeconstr}";;"]\vspace{-4.7ex}
-\item["#show_module "\var{module-path}";;"]\vspace{-4.7ex}
-\item["#show_module_type "\var{modtype-path}";;"]\vspace{-4.7ex}
-\item["#show_class "\var{class-path}";;"]\vspace{-4.7ex}
-\item["#show_class_type "\var{class-path}";;"]
-Print the signature of the corresponding component.
+  \item["#principal "\var{bool}";;"]
+    If the argument is "true", check information paths during
+    type-checking, to make sure that all types are derived in a principal
+    way. If the argument is "false", do not check information paths.
 
-\item["#show "\var{ident}";;"]
-Print the signatures of components with name \var{ident} in all the
-above categories.
+  \item["#rectypes;;"]
+    Allow arbitrary recursive types during type-checking. Note: once
+    enabled, this option cannot be disabled because that would lead to
+    unsoundness of the type system.
+
+  \item["#warn_error \""\var{warning-list}"\";;"]
+    Treat as errors the warnings enabled by the argument and as normal
+    warnings the warnings disabled by the argument.
+
+  \item["#warnings \""\var{warning-list}"\";;"]
+    Enable or disable warnings according to the argument.
+
+  \end{options}
 
 \end{options}
 

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1675,6 +1675,12 @@ Some attributes are understood by the type-checker:
   ``noalloc'', ``unboxed'' and ``untagged'' can be used on external
   definitions to obtain finer control over the C-to-OCaml interface. See
   \ref{s:C-cheaper-call} for more details.
+\item
+  ``ocaml.immediate'' or ``immediate'' applied on an abstract type mark the type as
+  having a non-pointer implementation (e.g. ``int'', ``bool'', ``char'' or
+  enumerated types). Mutation of these immediate types does not activate the
+  garbage collector's write barrier, which can significantly boost performance in
+  programs relying heavily on mutable state.
 \end{itemize}
 
 \begin{verbatim}
@@ -1707,6 +1713,14 @@ type fragile =
 let f = function
 | Int 0 | String "constant" -> () (* trigger warning 52 *)
 | _ -> ()
+
+module Immediate: sig
+  type t [@@immediate]
+  val x: t ref
+end = struct
+  type t = A | B
+  let x = ref 0
+end
   ....
 
 \end{verbatim}

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -50,7 +50,8 @@ let order_of_sections =
 
     section_undocumented;
   ])
-
+(* Do not forget to keep the directives synchronized with the manual in
+   manual/manual/cmds/top.etex *)
 
 (* To quit *)
 


### PR DESCRIPTION
This pull request document the last items in [mantis:7092](http://caml.inria.fr/mantis/view.php?id=7092):
- First, it synchronizes the manual documentation with the help directives, up to some minors differences
  due to the greater flexibility of the manual documentation:
  - Related commands ( e.g directory and remove_directory ) are grouped together
  - The description of `show_variant` commands is shared between all minor variants.

In particular, the help and ppx directives are now documented.
- Second, it documents the immediate attribute for abstract type with an immediate representation 
