### PR TITLE
add colors into error reporting for `[%ocaml.error "oops"]`

### DIFF
--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -435,7 +435,7 @@ external reraise : exn -> 'a = "%reraise"
 let rec report_exception_rec n ppf exn =
   try match error_of_exn exn with
   | Some err ->
-      fprintf ppf "@[%a@]@." report_error err
+      fprintf ppf "@[%a %a@]@." print_error_prefix () report_error err
   | None -> reraise exn
   with exn when n > 0 ->
     report_exception_rec (n-1) ppf exn

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -109,11 +109,6 @@ val error: ?loc:t -> ?sub:error list -> ?if_highlight:string -> string -> error
 val errorf: ?loc:t -> ?sub:error list -> ?if_highlight:string
             -> ('a, Format.formatter, unit, error) format4 -> 'a
 
-val errorf_prefixed : ?loc:t -> ?sub:error list -> ?if_highlight:string
-                    -> ('a, Format.formatter, unit, error) format4 -> 'a
-  (* same as {!errorf}, but prints the error prefix "Error:" before yielding
-   * to the format string *)
-
 val raise_errorf: ?loc:t -> ?sub:error list -> ?if_highlight:string
             -> ('a, Format.formatter, unit, 'b) format4 -> 'a
 

--- a/parsing/syntaxerr.ml
+++ b/parsing/syntaxerr.ml
@@ -27,9 +27,9 @@ exception Escape_error
 
 let prepare_error = function
   | Unclosed(opening_loc, opening, closing_loc, closing) ->
-      Location.errorf_prefixed ~loc:closing_loc
+      Location.errorf ~loc:closing_loc
         ~sub:[
-          Location.errorf_prefixed ~loc:opening_loc
+          Location.errorf ~loc:opening_loc
             "This '%s' might be unmatched" opening
         ]
         ~if_highlight:
@@ -39,24 +39,24 @@ let prepare_error = function
         "Syntax error: '%s' expected" closing
 
   | Expecting (loc, nonterm) ->
-      Location.errorf_prefixed ~loc "Syntax error: %s expected." nonterm
+      Location.errorf ~loc "Syntax error: %s expected." nonterm
   | Not_expecting (loc, nonterm) ->
-      Location.errorf_prefixed ~loc "Syntax error: %s not expected." nonterm
+      Location.errorf ~loc "Syntax error: %s not expected." nonterm
   | Applicative_path loc ->
-      Location.errorf_prefixed ~loc
+      Location.errorf ~loc
         "Syntax error: applicative paths of the form F(X).t \
          are not supported when the option -no-app-func is set."
   | Variable_in_scope (loc, var) ->
-      Location.errorf_prefixed ~loc
+      Location.errorf ~loc
         "In this scoped type, variable '%s \
          is reserved for the local type %s."
          var var
   | Other loc ->
-      Location.errorf_prefixed ~loc "Syntax error"
+      Location.errorf ~loc "Syntax error"
   | Ill_formed_ast (loc, s) ->
-      Location.errorf_prefixed ~loc "broken invariant in parsetree: %s" s
+      Location.errorf ~loc "broken invariant in parsetree: %s" s
   | Invalid_package_type (loc, s) ->
-      Location.errorf_prefixed ~loc "invalid package type: %s" s
+      Location.errorf ~loc "invalid package type: %s" s
 
 let () =
   Location.register_error_of_exn


### PR DESCRIPTION
Should fix http://caml.inria.fr/mantis/view.php?id=7147
