### PR TITLE
docstrings

### DIFF
--- a/Changes
+++ b/Changes
@@ -499,6 +499,9 @@ Bug fixes:
   (David Allsopp)
 - GPR#441: better type error location in presence of type constraints
   (Thomas Refis, report by Arseniy Alekseyev)
+- GPR#477: reallow docstrings inside object types, and inside polymorphic
+  variant and arrow types
+  (Thomas Refis)
 
 Features wishes:
 - PR#4518, GPR#29: change location format for reporting errors in ocamldoc

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -347,6 +347,10 @@ let extra_csig pos items = extra_text Ctf.text pos items
 let extra_def pos items =
   extra_text (fun txt -> [Ptop_def (Str.text txt)]) pos items
 
+let extra_rhs_core_type ct ~pos =
+  let docs = rhs_info pos in
+  { ct with ptyp_attributes = add_info_attrs docs ct.ptyp_attributes }
+
 type let_binding =
   { lb_pattern: pattern;
     lb_expression: expression;
@@ -2157,13 +2161,18 @@ core_type2:
     simple_core_type_or_tuple
       { $1 }
   | QUESTION LIDENT COLON core_type2 MINUSGREATER core_type2
-      { mktyp(Ptyp_arrow(Optional $2 , $4, $6)) }
+      { let param = extra_rhs_core_type $4 ~pos:4 in
+        mktyp (Ptyp_arrow(Optional $2 , param, $6)) }
   | OPTLABEL core_type2 MINUSGREATER core_type2
-      { mktyp(Ptyp_arrow(Optional $1 , $2, $4)) }
+      { let param = extra_rhs_core_type $2 ~pos:2 in
+        mktyp(Ptyp_arrow(Optional $1 , param, $4))
+      }
   | LIDENT COLON core_type2 MINUSGREATER core_type2
-      { mktyp(Ptyp_arrow(Labelled $1, $3, $5)) }
+      { let param = extra_rhs_core_type $3 ~pos:3 in
+        mktyp(Ptyp_arrow(Labelled $1, param, $5)) }
   | core_type2 MINUSGREATER core_type2
-      { mktyp(Ptyp_arrow(Nolabel, $1, $3)) }
+      { let param = extra_rhs_core_type $1 ~pos:1 in
+        mktyp(Ptyp_arrow(Nolabel, param, $3)) }
 ;
 
 simple_core_type:

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -2239,9 +2239,9 @@ row_field:
 ;
 tag_field:
     name_tag OF opt_ampersand amper_type_list attributes
-      { Rtag ($1, $5, $3, List.rev $4) }
+      { Rtag ($1, add_info_attrs (symbol_info ()) $5, $3, List.rev $4) }
   | name_tag attributes
-      { Rtag ($1, $2, true, []) }
+      { Rtag ($1, add_info_attrs (symbol_info ()) $2, true, []) }
 ;
 opt_ampersand:
     AMPERSAND                                   { true }
@@ -2269,13 +2269,26 @@ core_type_list:
   | core_type_list STAR simple_core_type        { $3 :: $1 }
 ;
 meth_list:
-    field SEMI meth_list                     { let (f, c) = $3 in ($1 :: f, c) }
-  | field opt_semi                              { [$1], Closed }
+    field_semi meth_list                     { let (f, c) = $2 in ($1 :: f, c) }
+  | field_semi                                  { [$1], Closed }
+  | field                                       { [$1], Closed }
   | DOTDOT                                      { [], Open }
 ;
 field:
-    label COLON poly_type_no_attr attributes    { ($1, $4, $3) }
+  label COLON poly_type_no_attr attributes
+    { ($1, add_info_attrs (symbol_info ()) $4, $3) }
 ;
+
+field_semi:
+  label COLON poly_type_no_attr attributes SEMI attributes
+    { let info =
+        match rhs_info 4 with
+        | Some _ as info_before_semi -> info_before_semi
+        | None -> symbol_info ()
+      in
+      ($1, add_info_attrs info ($4 @ $6), $3) }
+;
+
 label:
     LIDENT                                      { $1 }
 ;

--- a/testsuite/tests/parsing/docstrings.ml
+++ b/testsuite/tests/parsing/docstrings.ml
@@ -1,0 +1,16 @@
+type 'a with_default
+  =  ?size:int       (** default [42] *)
+  -> ?resizable:bool (** default [true] *)
+  -> 'a
+
+type obj = <
+  meth1 : int -> int;
+  (** method 1 *)
+
+  meth2: unit -> float (** method 2 *);
+>
+
+type var = [
+  | `Foo (** foo *)
+  | `Bar of int * string (** bar *)
+]

--- a/testsuite/tests/parsing/docstrings.ml.reference
+++ b/testsuite/tests/parsing/docstrings.ml.reference
@@ -1,0 +1,146 @@
+[
+  structure_item (docstrings.ml[1,0+0]..[4,105+7])
+    Pstr_type Rec
+    [
+      type_declaration "with_default" (docstrings.ml[1,0+8]..[1,0+20]) (docstrings.ml[1,0+0]..[4,105+7])
+        ptype_params =
+          [
+            core_type (docstrings.ml[1,0+5]..[1,0+7])
+              Ptyp_var a
+          ]
+        ptype_cstrs =
+          []
+        ptype_kind =
+          Ptype_abstract
+        ptype_private = Public
+        ptype_manifest =
+          Some
+            core_type (docstrings.ml[2,21+5]..[4,105+7])
+              Ptyp_arrow
+              Optional "size"
+              core_type (docstrings.ml[2,21+11]..[2,21+14])
+                attribute "ocaml.doc"
+                  [
+                    structure_item (docstrings.ml[2,21+21]..[2,21+40])
+                      Pstr_eval
+                      expression (docstrings.ml[2,21+21]..[2,21+40])
+                        Pexp_constant PConst_string(" default [42] ",None)
+                  ]
+                Ptyp_constr "int" (docstrings.ml[2,21+11]..[2,21+14])
+                []
+              core_type (docstrings.ml[3,62+5]..[4,105+7])
+                Ptyp_arrow
+                Optional "resizable"
+                core_type (docstrings.ml[3,62+16]..[3,62+20])
+                  attribute "ocaml.doc"
+                    [
+                      structure_item (docstrings.ml[3,62+21]..[3,62+42])
+                        Pstr_eval
+                        expression (docstrings.ml[3,62+21]..[3,62+42])
+                          Pexp_constant PConst_string(" default [true] ",None)
+                    ]
+                  Ptyp_constr "bool" (docstrings.ml[3,62+16]..[3,62+20])
+                  []
+                core_type (docstrings.ml[4,105+5]..[4,105+7])
+                  Ptyp_var a
+    ]
+  structure_item (docstrings.ml[6,114+0]..[11,208+1])
+    Pstr_type Rec
+    [
+      type_declaration "obj" (docstrings.ml[6,114+5]..[6,114+8]) (docstrings.ml[6,114+0]..[11,208+1])
+        ptype_params =
+          []
+        ptype_cstrs =
+          []
+        ptype_kind =
+          Ptype_abstract
+        ptype_private = Public
+        ptype_manifest =
+          Some
+            core_type (docstrings.ml[6,114+11]..[11,208+1])
+              Ptyp_object Closed
+                method meth1
+                  attribute "ocaml.doc"
+                    [
+                      structure_item (docstrings.ml[8,149+2]..[8,149+17])
+                        Pstr_eval
+                        expression (docstrings.ml[8,149+2]..[8,149+17])
+                          Pexp_constant PConst_string(" method 1 ",None)
+                    ]
+                  core_type (docstrings.ml[7,127+10]..[7,127+20])
+                    Ptyp_arrow
+                    Nolabel
+                    core_type (docstrings.ml[7,127+10]..[7,127+13])
+                      Ptyp_constr "int" (docstrings.ml[7,127+10]..[7,127+13])
+                      []
+                    core_type (docstrings.ml[7,127+17]..[7,127+20])
+                      Ptyp_constr "int" (docstrings.ml[7,127+17]..[7,127+20])
+                      []
+                method meth2
+                  attribute "ocaml.doc"
+                    [
+                      structure_item (docstrings.ml[10,168+23]..[10,168+38])
+                        Pstr_eval
+                        expression (docstrings.ml[10,168+23]..[10,168+38])
+                          Pexp_constant PConst_string(" method 2 ",None)
+                    ]
+                  core_type (docstrings.ml[10,168+9]..[10,168+22])
+                    Ptyp_arrow
+                    Nolabel
+                    core_type (docstrings.ml[10,168+9]..[10,168+13])
+                      Ptyp_constr "unit" (docstrings.ml[10,168+9]..[10,168+13])
+                      []
+                    core_type (docstrings.ml[10,168+17]..[10,168+22])
+                      Ptyp_constr "float" (docstrings.ml[10,168+17]..[10,168+22])
+                      []
+    ]
+  structure_item (docstrings.ml[13,211+0]..[16,280+1])
+    Pstr_type Rec
+    [
+      type_declaration "var" (docstrings.ml[13,211+5]..[13,211+8]) (docstrings.ml[13,211+0]..[16,280+1])
+        ptype_params =
+          []
+        ptype_cstrs =
+          []
+        ptype_kind =
+          Ptype_abstract
+        ptype_private = Public
+        ptype_manifest =
+          Some
+            core_type (docstrings.ml[13,211+11]..[16,280+1])
+              Ptyp_variant closed=Closed
+              [
+                Rtag "Foo" true
+                    attribute "ocaml.doc"
+                      [
+                        structure_item (docstrings.ml[14,224+9]..[14,224+19])
+                          Pstr_eval
+                          expression (docstrings.ml[14,224+9]..[14,224+19])
+                            Pexp_constant PConst_string(" foo ",None)
+                      ]
+                  []
+                Rtag "Bar" false
+                    attribute "ocaml.doc"
+                      [
+                        structure_item (docstrings.ml[15,244+25]..[15,244+35])
+                          Pstr_eval
+                          expression (docstrings.ml[15,244+25]..[15,244+35])
+                            Pexp_constant PConst_string(" bar ",None)
+                      ]
+                  [
+                    core_type (docstrings.ml[15,244+12]..[15,244+24])
+                      Ptyp_tuple
+                      [
+                        core_type (docstrings.ml[15,244+12]..[15,244+15])
+                          Ptyp_constr "int" (docstrings.ml[15,244+12]..[15,244+15])
+                          []
+                        core_type (docstrings.ml[15,244+18]..[15,244+24])
+                          Ptyp_constr "string" (docstrings.ml[15,244+18]..[15,244+24])
+                          []
+                      ]
+                  ]
+              ]
+              None
+    ]
+]
+


### PR DESCRIPTION
This PR adds support for documentation comments in the following positions:
1. on the parameters of a function type:  
   `type 'a with_optionnal = ?optionnal:unit (** optionnal! *) -> 'a`  
   `val f : ?foo:int (** default [0] *) -> bar:string (** doc *) -> unit (** doc *) -> unit`
2. inside polymorphic variant types:  
   `type t = [ `Foo (** foo! *) | `Bar of int * string (** bar? *) ]`
3. inside object types:  
   `type t = < foo: int -> int (** foo *) ; bar: int -> int; (** bar *) .. >`

Currently if warning 50 is enabled it will be emitted for every comment of the examples above.
This is unfortunate because people have not only been asking support for this for a while (see various issues on mantis), but have also been using that style while waiting for tooling support, see:
- examples of polymorphic variants documentation: [here](https://github.com/mirage/ocaml-cohttp/blob/master/lib/code.mli) and [there](https://github.com/janestreet/core/blob/master/src/signal.mli#L29)
- examples of function parameters annotations: [here](https://github.com/janestreet/core_kernel/blob/master/src/debug.mli#L46) and [there](https://github.com/janestreet/core_kernel/blob/master/src/in_channel.mli#L42),
- example of an object type definition with annotations on methods: [here](https://github.com/the-lambda-church/dmlenu/blob/master/lib/completion.mli#L9)

One should note that the warning inside object types as support was added in ocamldoc with [this commit](https://github.com/ocaml/ocaml/commit/1a3b58be2b3acd53a83e3afde36d3ac55041b3fc) (cf. [mantis PR#6274](http://caml.inria.fr/mantis/view.php?id=6274)).

The other two cases were not supported but remove an unnecessary limitation and conforms with the style people are already using.
