### PR TITLE
Fix printing for constrained infix operator bindings:

### DIFF
--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1058,7 +1058,7 @@ class printer  ()= object(self:'self)
             pp f "(%a@;:%a)=@;%a" self#simple_pattern p
               self#core_type ty self#expression x)
     | Pexp_constraint (e,t1),Ppat_var {txt;_} ->
-        pp f "%s:@ %a@;=@;%a" txt self#core_type t1 self#expression e
+        pp f "%a@;:@ %a@;=@;%a" protect_ident txt self#core_type t1 self#expression e
     | (_, Ppat_var _) ->
         pp f "%a@ %a" self#simple_pattern p pp_print_pexp_function x
     | _ ->


### PR DESCRIPTION
This fixes one of many minor problems with the pretty printer (used by `-dsource`).  The code:

``` ocaml
   let (++) : _  = (+)
```

was previously printed as

``` ocaml
   let ++ : _  = (+)
```
