### PR TITLE
Attempt to fix PR7157 (too many minor collections)

### DIFF
--- a/byterun/caml/minor_gc.h
+++ b/byterun/caml/minor_gc.h
@@ -87,6 +87,7 @@ static inline void add_to_ephe_ref_table (struct caml_ephe_ref_table *tbl,
   ephe_ref = tbl->ptr++;
   ephe_ref->ephe = ar;
   ephe_ref->offset = offset;
+  Assert(ephe_ref->offset < Wosize_val(ephe_ref->ephe));
 }
 
 #endif /* CAML_MINOR_GC_H */

--- a/byterun/caml/weak.h
+++ b/byterun/caml/weak.h
@@ -29,6 +29,7 @@ extern value caml_ephe_none;
        others       2..:  keys;
 
     A weak pointer is an ephemeron with the data at caml_ephe_none
+    If fields are added, don't forget to update weak.ml [additional_values].
  */
 
 #define CAML_EPHE_LINK_OFFSET 0

--- a/stdlib/weak.ml
+++ b/stdlib/weak.ml
@@ -19,7 +19,10 @@ type 'a t;;
 
 external create : int -> 'a t = "caml_weak_create";;
 
-let length x = Obj.size(Obj.repr x) - 2;;
+(** number of additional values in a weak pointer *)
+let additional_values = 2
+
+let length x = Obj.size(Obj.repr x) - additional_values;;
 
 external set : 'a t -> int -> 'a option -> unit = "caml_weak_set";;
 external get : 'a t -> int -> 'a option = "caml_weak_get";;
@@ -162,7 +165,7 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
         t.table.(t.rover) <- emptybucket;
         t.hashes.(t.rover) <- [| |];
       end else begin
-        Obj.truncate (Obj.repr bucket) (prev_len + 1);
+        Obj.truncate (Obj.repr bucket) (prev_len + additional_values);
         Obj.truncate (Obj.repr hbucket) prev_len;
       end;
       if len > t.limit && prev_len <= t.limit then t.oversize <- t.oversize - 1;


### PR DESCRIPTION
https://github.com/ocaml/ocaml/commit/d94f1da32f75793c2dee162df82990ca6f4adaa4 appears to have introduced a regression, with increased numbers of minor collections.

In the function realloc_generic_table there is pointer arithmetic, at first sight unchanged by this patch, that starts from e.g. "tbl->base".  The units of the arithmetic will be the size of the underlying type (T when tbl->base has type T\* ).  In the 4.03 branch, T is just "char" (in the patch it was "void", but the common interpretation of that having the same size as "char" would have also produced the bug).  As such, the result of calculations that add to the base pointer would be rather smaller than prior to the above patch, when the underlying type was "value*".  Consequentially the ref table would become full more often and trigger more minor GCs (from line 510 of byterun/minor_gc.c).

This patch changes the underlying type to "void*" instead, which should restore the old behaviour.

I haven't yet tested this since others should probably give opinions first.
