### PR TITLE
Manual: underscore penalties with "-short-path"

### DIFF
--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -405,7 +405,9 @@ a future version of OCaml.
 \item["-short-paths"]
 When a type is visible under several module-paths, use the shortest
 one when printing the type's name in inferred interfaces and error and
-warning messages.
+warning messages. Identifier names starting with an underscore "_" or
+containing double underscores "__" incur a penalty of $+10$ when computing
+their length.
 
 \item["-strict-sequence"]
 Force the left-hand part of each sequence to have type unit.

--- a/manual/manual/cmds/native.etex
+++ b/manual/manual/cmds/native.etex
@@ -384,7 +384,9 @@ a future version of OCaml.
 \item["-short-paths"]
 When a type is visible under several module-paths, use the shortest
 one when printing the type's name in inferred interfaces and error and
-warning messages.
+warning messages. Identifier names starting with an underscore "_" or
+containing double underscores "__" incur a penalty of $+10$ when computing
+their length.
 
 \item["-strict-sequence"]
 Force the left-hand part of each sequence to have type unit.

--- a/manual/manual/cmds/top.etex
+++ b/manual/manual/cmds/top.etex
@@ -211,7 +211,9 @@ a future version of OCaml.
 \item["-short-paths"]
 When a type is visible under several module-paths, use the shortest
 one when printing the type's name in inferred interfaces and error and
-warning messages.
+warning messages. Identifier names starting with an underscore "_" or
+containing double underscores "__" incur a penalty of $+10$ when computing
+their length.
 
 \item["-stdin"]
 Read the standard input as a script file rather than starting an


### PR DESCRIPTION
This pull request documents the new tweaks added to the "-short-path" compiler option, i.e.
identifiers containing either a leading underscore or a double underscore incur a penalty of `+10`
when the compiler compute their length.
