### PR TITLE
PR#7165: guard against out-of-range integers in lexer directives

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+OCaml 4.04.0+dev:
+-----------------
+
+Bug fixes:
+- PR#7165, GPR#494: uncaught exception on invalid lexer directive
+  (Gabriel Scherer, report by KC Sivaramakrishnan using afl-fuzz)
+
 OCaml 4.03.0:
 -------------
 

--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -27,6 +27,7 @@ type error =
   | Unterminated_string_in_comment of Location.t * Location.t
   | Keyword_as_label of string
   | Invalid_literal of string
+  | Invalid_directive of string * string option
 ;;
 
 exception Error of error * Location.t

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -28,6 +28,7 @@ type error =
   | Unterminated_string_in_comment of Location.t * Location.t
   | Keyword_as_label of string
   | Invalid_literal of string
+  | Invalid_directive of string * string option
 ;;
 
 exception Error of error * Location.t;;
@@ -260,6 +261,12 @@ let report_error ppf = function
       fprintf ppf "`%s' is a keyword, it cannot be used as label name" kwd
   | Invalid_literal s ->
       fprintf ppf "Invalid literal %s" s
+  | Invalid_directive (dir, explanation) ->
+      fprintf ppf "Invalid lexer directive %S" dir;
+      begin match explanation with
+        | None -> ()
+        | Some expl -> fprintf ppf ": %s" expl
+      end
 
 let () =
   Location.register_error_of_exn
@@ -422,11 +429,23 @@ rule token = parse
         lexbuf.lex_curr_p <- { curpos with pos_cnum = curpos.pos_cnum - 1 };
         STAR
       }
-  | "#" [' ' '\t']* (['0'-'9']+ as num) [' ' '\t']*
-        ("\"" ([^ '\010' '\013' '\"' ] * as name) "\"")?
+  | ("#" [' ' '\t']* (['0'-'9']+ as num) [' ' '\t']*
+        ("\"" ([^ '\010' '\013' '\"' ] * as name) "\"")?) as directive
         [^ '\010' '\013'] * newline
-      { update_loc lexbuf name (int_of_string num) true 0;
-        token lexbuf
+      {
+        match int_of_string num with
+        | exception _ ->
+            (* PR#7165 *)
+            let loc = Location.curr lexbuf in
+            let explanation = "line number out of range" in
+            let error = Invalid_directive (directive, Some explanation) in
+            raise (Error (error, loc))
+        | line_num ->
+           (* Documentation says that the line number should be
+              positive, but we have never guarded against this and it
+              might have useful hackish uses. *)
+            update_loc lexbuf name line_num true 0;
+            token lexbuf
       }
   | "#"  { SHARP }
   | "&"  { AMPERSAND }

--- a/testsuite/tests/parsing/pr7165.ml
+++ b/testsuite/tests/parsing/pr7165.ml
@@ -1,0 +1,4 @@
+(* this is a lexer directive with an out-of-bound integer;
+   it should result in a lexing error instead of an
+   uncaught exception as in PR#7165 *)
+#9342101923012312312

--- a/testsuite/tests/parsing/pr7165.ml.reference
+++ b/testsuite/tests/parsing/pr7165.ml.reference
@@ -1,0 +1,2 @@
+File "pr7165.ml", line 4, characters 0-21:
+Error: Invalid directive "#9342101923012312312": line number out of range


### PR DESCRIPTION
This is a bug fix for [MPR#7165](http://caml.inria.fr/mantis/view.php?id=7165).
