### PR TITLE
Fix coreboot, update .depend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ coreboot:
 # Rebuild the library (using byterun/ocamlrun ./ocamlc)
 	$(MAKE) library-cross
 # Promote the new compiler and the new runtime
-	$(MAKE) promote
+	$(MAKE) CAMLRUN=byterun/ocamlrun promote
 # Rebuild the core system
 	$(MAKE) partialclean
 	$(MAKE) core

--- a/asmrun/.depend
+++ b/asmrun/.depend
@@ -1,1324 +1,1520 @@
 alloc.o: alloc.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/stacks.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/custom.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/stacks.h ../byterun/caml/memory.h
 array.o: array.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/signals.h
 backtrace.o: backtrace.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/backtrace_prim.h ../byterun/caml/fail.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/backtrace.h \
+ ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
+ ../byterun/caml/backtrace.h ../byterun/caml/fail.h
 backtrace_prim.o: backtrace_prim.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h stack.h
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/backtrace.h \
+ ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
+ ../byterun/caml/backtrace.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h stack.h
 callback.o: callback.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h
 clambda_checks.o: clambda_checks.c ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h
 compact.o: compact.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/weak.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/finalise.h ../byterun/caml/roots.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/freelist.h \
+ ../byterun/caml/gc.h ../byterun/caml/gc_ctrl.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/memory.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/roots.h \
+ ../byterun/caml/weak.h
 compare.o: compare.c ../byterun/caml/custom.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h
 custom.o: custom.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h
 debugger.o: debugger.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/debugger.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/config.h ../byterun/caml/debugger.h \
+ ../byterun/caml/misc.h
 dynlink.o: dynlink.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/dynlink.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/prims.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/alloc.h ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/dynlink.h \
+ ../byterun/caml/fail.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/osdeps.h ../byterun/caml/prims.h \
+ ../byterun/caml/signals.h
 extern.o: extern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/md5.h \
-  ../byterun/caml/memory.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/reverse.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/config.h ../byterun/caml/custom.h ../byterun/caml/fail.h \
+ ../byterun/caml/gc.h ../byterun/caml/intext.h ../byterun/caml/io.h \
+ ../byterun/caml/io.h ../byterun/caml/md5.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/reverse.h
 fail.o: fail.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/gc.h \
-  ../byterun/caml/memory.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/printexc.h \
-  ../byterun/caml/signals.h stack.h ../byterun/caml/roots.h \
-  ../byterun/caml/callback.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/gc.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/printexc.h ../byterun/caml/signals.h stack.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h \
+ ../byterun/caml/callback.h
 finalise.o: finalise.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/signals.h
 floats.o: floats.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h ../byterun/caml/stacks.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/reverse.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h
 freelist.o: freelist.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/freelist.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/freelist.h ../byterun/caml/misc.h \
+ ../byterun/caml/config.h ../byterun/caml/mlvalues.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h
 gc_ctrl.o: gc_ctrl.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/compact.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h stack.h \
-  ../byterun/caml/startup_aux.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
+ ../byterun/caml/compact.h ../byterun/caml/custom.h \
+ ../byterun/caml/fail.h ../byterun/caml/finalise.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/signals.h stack.h ../byterun/caml/startup_aux.h
 globroots.o: globroots.c ../byterun/caml/memory.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/globroots.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h \
+ ../byterun/caml/globroots.h ../byterun/caml/roots.h
 hash.o: hash.c ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/custom.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/hash.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/custom.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/hash.h
 intern.o: intern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/callback.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/md5.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/callback.h ../byterun/caml/config.h \
+ ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
+ ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/io.h \
+ ../byterun/caml/md5.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/reverse.h
 ints.o: ints.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/intext.h \
+ ../byterun/caml/io.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h
 io.o: io.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/io.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
+ ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/signals.h ../byterun/caml/sys.h
 lexing.o: lexing.c ../byterun/caml/fail.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/stacks.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h
 main.o: main.c ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/sys.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h ../byterun/caml/sys.h
 major_gc.o: major_gc.c ../byterun/caml/compact.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/custom.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/weak.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/custom.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/fail.h ../byterun/caml/finalise.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/weak.h
 md5.o: md5.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/md5.h ../byterun/caml/io.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/md5.h ../byterun/caml/io.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/io.h ../byterun/caml/reverse.h
 memory.o: memory.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/fail.h ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/signals.h
 meta.o: meta.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/fix_code.h \
-  ../byterun/caml/interp.h ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/prims.h ../byterun/caml/stacks.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/config.h ../byterun/caml/fail.h \
+ ../byterun/caml/fix_code.h ../byterun/caml/interp.h \
+ ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/prims.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h
 minor_gc.o: minor_gc.c ../byterun/caml/custom.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/weak.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/fail.h \
+ ../byterun/caml/finalise.h ../byterun/caml/roots.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/signals.h ../byterun/caml/weak.h
 misc.o: misc.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/version.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/config.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/version.h
 natdynlink.o: natdynlink.c ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h stack.h \
-  ../byterun/caml/callback.h ../byterun/caml/alloc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/fail.h ../byterun/caml/signals.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/misc.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h stack.h ../byterun/caml/callback.h \
+ ../byterun/caml/alloc.h ../byterun/caml/intext.h ../byterun/caml/io.h \
+ ../byterun/caml/osdeps.h ../byterun/caml/fail.h \
+ ../byterun/caml/signals.h
 obj.o: obj.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/interp.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/prims.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/interp.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/prims.h
 parsing.o: parsing.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/alloc.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/misc.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/alloc.h
 printexc.o: printexc.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/exec.h \
-  ../byterun/caml/callback.h ../byterun/caml/debugger.h \
-  ../byterun/caml/fail.h ../byterun/caml/printexc.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/exec.h ../byterun/caml/callback.h \
+ ../byterun/caml/debugger.h ../byterun/caml/fail.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/printexc.h
 roots.o: roots.c ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/globroots.h stack.h
-signals.o: signals.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/callback.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/signals.h \
-  ../byterun/caml/signals_machdep.h ../byterun/caml/sys.h
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/globroots.h ../byterun/caml/memory.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h stack.h \
+ ../byterun/caml/roots.h
 signals_asm.o: signals_asm.c ../byterun/caml/fail.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/signals_machdep.h \
-  signals_osdep.h stack.h
-startup.o: startup.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/custom.h \
-  ../byterun/caml/debugger.h ../byterun/caml/fail.h \
-  ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/printexc.h stack.h ../byterun/caml/startup_aux.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
+ ../byterun/caml/signals_machdep.h signals_osdep.h stack.h
+signals.o: signals.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/callback.h ../byterun/caml/config.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h \
+ ../byterun/caml/signals.h ../byterun/caml/signals_machdep.h \
+ ../byterun/caml/sys.h
 startup_aux.o: startup_aux.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/exec.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/startup_aux.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/exec.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/startup_aux.h
+startup.o: startup.c ../byterun/caml/callback.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/backtrace.h \
+ ../byterun/caml/exec.h ../byterun/caml/custom.h \
+ ../byterun/caml/debugger.h ../byterun/caml/fail.h \
+ ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/intext.h ../byterun/caml/io.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/printexc.h stack.h ../byterun/caml/startup_aux.h \
+ ../byterun/caml/sys.h
 str.o: str.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/mlvalues.h ../byterun/caml/misc.h
 sys.o: sys.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/debugger.h ../byterun/caml/fail.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/instruct.h \
-  ../byterun/caml/io.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/stacks.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/debugger.h \
+ ../byterun/caml/fail.h ../byterun/caml/gc_ctrl.h \
+ ../byterun/caml/instruct.h ../byterun/caml/io.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/signals.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/sys.h
 terminfo.o: terminfo.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/io.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/alloc.h ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/io.h \
+ ../byterun/caml/mlvalues.h
 unix.o: unix.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/fail.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/fail.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/signals.h ../byterun/caml/sys.h
 weak.o: weak.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/weak.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/weak.h
 alloc.p.o: alloc.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/stacks.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/custom.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/stacks.h ../byterun/caml/memory.h
 array.p.o: array.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/signals.h
 backtrace.p.o: backtrace.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/backtrace_prim.h ../byterun/caml/fail.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/backtrace.h \
+ ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
+ ../byterun/caml/backtrace.h ../byterun/caml/fail.h
 backtrace_prim.p.o: backtrace_prim.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h stack.h
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/backtrace.h \
+ ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
+ ../byterun/caml/backtrace.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h stack.h
 callback.p.o: callback.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h
 clambda_checks.p.o: clambda_checks.c ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h
 compact.p.o: compact.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/weak.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/finalise.h ../byterun/caml/roots.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/freelist.h \
+ ../byterun/caml/gc.h ../byterun/caml/gc_ctrl.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/memory.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/roots.h \
+ ../byterun/caml/weak.h
 compare.p.o: compare.c ../byterun/caml/custom.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h
 custom.p.o: custom.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h
 debugger.p.o: debugger.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/debugger.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/config.h ../byterun/caml/debugger.h \
+ ../byterun/caml/misc.h
 dynlink.p.o: dynlink.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/dynlink.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/prims.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/alloc.h ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/dynlink.h \
+ ../byterun/caml/fail.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/osdeps.h ../byterun/caml/prims.h \
+ ../byterun/caml/signals.h
 extern.p.o: extern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/md5.h \
-  ../byterun/caml/memory.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/reverse.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/config.h ../byterun/caml/custom.h ../byterun/caml/fail.h \
+ ../byterun/caml/gc.h ../byterun/caml/intext.h ../byterun/caml/io.h \
+ ../byterun/caml/io.h ../byterun/caml/md5.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/reverse.h
 fail.p.o: fail.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/gc.h \
-  ../byterun/caml/memory.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/printexc.h \
-  ../byterun/caml/signals.h stack.h ../byterun/caml/roots.h \
-  ../byterun/caml/callback.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/gc.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/printexc.h ../byterun/caml/signals.h stack.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h \
+ ../byterun/caml/callback.h
 finalise.p.o: finalise.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/signals.h
 floats.p.o: floats.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h ../byterun/caml/stacks.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/reverse.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h
 freelist.p.o: freelist.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/freelist.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/freelist.h ../byterun/caml/misc.h \
+ ../byterun/caml/config.h ../byterun/caml/mlvalues.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h
 gc_ctrl.p.o: gc_ctrl.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/compact.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h stack.h \
-  ../byterun/caml/startup_aux.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
+ ../byterun/caml/compact.h ../byterun/caml/custom.h \
+ ../byterun/caml/fail.h ../byterun/caml/finalise.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/signals.h stack.h ../byterun/caml/startup_aux.h
 globroots.p.o: globroots.c ../byterun/caml/memory.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/globroots.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h \
+ ../byterun/caml/globroots.h ../byterun/caml/roots.h
 hash.p.o: hash.c ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/custom.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/hash.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/custom.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/hash.h
 intern.p.o: intern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/callback.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/md5.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/callback.h ../byterun/caml/config.h \
+ ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
+ ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/io.h \
+ ../byterun/caml/md5.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/reverse.h
 ints.p.o: ints.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/intext.h \
+ ../byterun/caml/io.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h
 io.p.o: io.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/io.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
+ ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/signals.h ../byterun/caml/sys.h
 lexing.p.o: lexing.c ../byterun/caml/fail.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/stacks.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h
 main.p.o: main.c ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/sys.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h ../byterun/caml/sys.h
 major_gc.p.o: major_gc.c ../byterun/caml/compact.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/custom.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/weak.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/custom.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/fail.h ../byterun/caml/finalise.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/weak.h
 md5.p.o: md5.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/md5.h ../byterun/caml/io.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/md5.h ../byterun/caml/io.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/io.h ../byterun/caml/reverse.h
 memory.p.o: memory.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/fail.h ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/signals.h
 meta.p.o: meta.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/fix_code.h \
-  ../byterun/caml/interp.h ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/prims.h ../byterun/caml/stacks.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/config.h ../byterun/caml/fail.h \
+ ../byterun/caml/fix_code.h ../byterun/caml/interp.h \
+ ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/prims.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h
 minor_gc.p.o: minor_gc.c ../byterun/caml/custom.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/weak.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/fail.h \
+ ../byterun/caml/finalise.h ../byterun/caml/roots.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/signals.h ../byterun/caml/weak.h
 misc.p.o: misc.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/version.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/config.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/version.h
 natdynlink.p.o: natdynlink.c ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h stack.h \
-  ../byterun/caml/callback.h ../byterun/caml/alloc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/fail.h ../byterun/caml/signals.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/misc.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h stack.h ../byterun/caml/callback.h \
+ ../byterun/caml/alloc.h ../byterun/caml/intext.h ../byterun/caml/io.h \
+ ../byterun/caml/osdeps.h ../byterun/caml/fail.h \
+ ../byterun/caml/signals.h
 obj.p.o: obj.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/interp.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/prims.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/interp.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/prims.h
 parsing.p.o: parsing.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/alloc.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/misc.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/alloc.h
 printexc.p.o: printexc.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/exec.h \
-  ../byterun/caml/callback.h ../byterun/caml/debugger.h \
-  ../byterun/caml/fail.h ../byterun/caml/printexc.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/exec.h ../byterun/caml/callback.h \
+ ../byterun/caml/debugger.h ../byterun/caml/fail.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/printexc.h
 roots.p.o: roots.c ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/globroots.h stack.h
-signals.p.o: signals.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/callback.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/signals.h \
-  ../byterun/caml/signals_machdep.h ../byterun/caml/sys.h
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/globroots.h ../byterun/caml/memory.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h stack.h \
+ ../byterun/caml/roots.h
 signals_asm.p.o: signals_asm.c ../byterun/caml/fail.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/signals_machdep.h \
-  signals_osdep.h stack.h
-startup.p.o: startup.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/custom.h \
-  ../byterun/caml/debugger.h ../byterun/caml/fail.h \
-  ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/printexc.h stack.h ../byterun/caml/startup_aux.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
+ ../byterun/caml/signals_machdep.h signals_osdep.h stack.h
+signals.p.o: signals.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/callback.h ../byterun/caml/config.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h \
+ ../byterun/caml/signals.h ../byterun/caml/signals_machdep.h \
+ ../byterun/caml/sys.h
 startup_aux.p.o: startup_aux.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/exec.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/startup_aux.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/exec.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/startup_aux.h
+startup.p.o: startup.c ../byterun/caml/callback.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/backtrace.h \
+ ../byterun/caml/exec.h ../byterun/caml/custom.h \
+ ../byterun/caml/debugger.h ../byterun/caml/fail.h \
+ ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/intext.h ../byterun/caml/io.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/printexc.h stack.h ../byterun/caml/startup_aux.h \
+ ../byterun/caml/sys.h
 str.p.o: str.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/mlvalues.h ../byterun/caml/misc.h
 sys.p.o: sys.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/debugger.h ../byterun/caml/fail.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/instruct.h \
-  ../byterun/caml/io.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/stacks.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/debugger.h \
+ ../byterun/caml/fail.h ../byterun/caml/gc_ctrl.h \
+ ../byterun/caml/instruct.h ../byterun/caml/io.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/signals.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/sys.h
 terminfo.p.o: terminfo.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/io.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/alloc.h ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/io.h \
+ ../byterun/caml/mlvalues.h
 unix.p.o: unix.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/fail.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/fail.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/signals.h ../byterun/caml/sys.h
 weak.p.o: weak.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/weak.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/weak.h
 alloc.d.o: alloc.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/stacks.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/custom.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/stacks.h ../byterun/caml/memory.h
 array.d.o: array.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/signals.h
 backtrace.d.o: backtrace.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/backtrace_prim.h ../byterun/caml/fail.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/backtrace.h \
+ ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
+ ../byterun/caml/backtrace.h ../byterun/caml/fail.h
 backtrace_prim.d.o: backtrace_prim.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h stack.h
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/backtrace.h \
+ ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
+ ../byterun/caml/backtrace.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h stack.h
 callback.d.o: callback.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h
 clambda_checks.d.o: clambda_checks.c ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h
 compact.d.o: compact.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/weak.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/finalise.h ../byterun/caml/roots.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/freelist.h \
+ ../byterun/caml/gc.h ../byterun/caml/gc_ctrl.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/memory.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/roots.h \
+ ../byterun/caml/weak.h
 compare.d.o: compare.c ../byterun/caml/custom.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h
 custom.d.o: custom.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h
 debugger.d.o: debugger.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/debugger.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/config.h ../byterun/caml/debugger.h \
+ ../byterun/caml/misc.h
 dynlink.d.o: dynlink.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/dynlink.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/prims.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/alloc.h ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/dynlink.h \
+ ../byterun/caml/fail.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/osdeps.h ../byterun/caml/prims.h \
+ ../byterun/caml/signals.h
 extern.d.o: extern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/md5.h \
-  ../byterun/caml/memory.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/reverse.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/config.h ../byterun/caml/custom.h ../byterun/caml/fail.h \
+ ../byterun/caml/gc.h ../byterun/caml/intext.h ../byterun/caml/io.h \
+ ../byterun/caml/io.h ../byterun/caml/md5.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/reverse.h
 fail.d.o: fail.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/gc.h \
-  ../byterun/caml/memory.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/printexc.h \
-  ../byterun/caml/signals.h stack.h ../byterun/caml/roots.h \
-  ../byterun/caml/callback.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/gc.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/printexc.h ../byterun/caml/signals.h stack.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h \
+ ../byterun/caml/callback.h
 finalise.d.o: finalise.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/signals.h
 floats.d.o: floats.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h ../byterun/caml/stacks.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/reverse.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h
 freelist.d.o: freelist.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/freelist.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/freelist.h ../byterun/caml/misc.h \
+ ../byterun/caml/config.h ../byterun/caml/mlvalues.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h
 gc_ctrl.d.o: gc_ctrl.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/compact.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h stack.h \
-  ../byterun/caml/startup_aux.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
+ ../byterun/caml/compact.h ../byterun/caml/custom.h \
+ ../byterun/caml/fail.h ../byterun/caml/finalise.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/signals.h stack.h ../byterun/caml/startup_aux.h
 globroots.d.o: globroots.c ../byterun/caml/memory.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/globroots.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h \
+ ../byterun/caml/globroots.h ../byterun/caml/roots.h
 hash.d.o: hash.c ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/custom.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/hash.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/custom.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/hash.h
 intern.d.o: intern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/callback.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/md5.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/callback.h ../byterun/caml/config.h \
+ ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
+ ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/io.h \
+ ../byterun/caml/md5.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/reverse.h
 ints.d.o: ints.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/intext.h \
+ ../byterun/caml/io.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h
 io.d.o: io.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/io.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
+ ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/signals.h ../byterun/caml/sys.h
 lexing.d.o: lexing.c ../byterun/caml/fail.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/stacks.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h
 main.d.o: main.c ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/sys.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h ../byterun/caml/sys.h
 major_gc.d.o: major_gc.c ../byterun/caml/compact.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/custom.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/weak.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/custom.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/fail.h ../byterun/caml/finalise.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/weak.h
 md5.d.o: md5.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/md5.h ../byterun/caml/io.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/md5.h ../byterun/caml/io.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/io.h ../byterun/caml/reverse.h
 memory.d.o: memory.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/fail.h ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/signals.h
 meta.d.o: meta.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/fix_code.h \
-  ../byterun/caml/interp.h ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/prims.h ../byterun/caml/stacks.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/config.h ../byterun/caml/fail.h \
+ ../byterun/caml/fix_code.h ../byterun/caml/interp.h \
+ ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/prims.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h
 minor_gc.d.o: minor_gc.c ../byterun/caml/custom.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/weak.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/fail.h \
+ ../byterun/caml/finalise.h ../byterun/caml/roots.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/signals.h ../byterun/caml/weak.h
 misc.d.o: misc.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/version.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/config.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/version.h
 natdynlink.d.o: natdynlink.c ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h stack.h \
-  ../byterun/caml/callback.h ../byterun/caml/alloc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/fail.h ../byterun/caml/signals.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/misc.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h stack.h ../byterun/caml/callback.h \
+ ../byterun/caml/alloc.h ../byterun/caml/intext.h ../byterun/caml/io.h \
+ ../byterun/caml/osdeps.h ../byterun/caml/fail.h \
+ ../byterun/caml/signals.h
 obj.d.o: obj.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/interp.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/prims.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/interp.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/prims.h
 parsing.d.o: parsing.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/alloc.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/misc.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/alloc.h
 printexc.d.o: printexc.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/exec.h \
-  ../byterun/caml/callback.h ../byterun/caml/debugger.h \
-  ../byterun/caml/fail.h ../byterun/caml/printexc.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/exec.h ../byterun/caml/callback.h \
+ ../byterun/caml/debugger.h ../byterun/caml/fail.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/printexc.h
 roots.d.o: roots.c ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/globroots.h stack.h
-signals.d.o: signals.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/callback.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/signals.h \
-  ../byterun/caml/signals_machdep.h ../byterun/caml/sys.h
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/globroots.h ../byterun/caml/memory.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h stack.h \
+ ../byterun/caml/roots.h
 signals_asm.d.o: signals_asm.c ../byterun/caml/fail.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/signals_machdep.h \
-  signals_osdep.h stack.h
-startup.d.o: startup.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/custom.h \
-  ../byterun/caml/debugger.h ../byterun/caml/fail.h \
-  ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/printexc.h stack.h ../byterun/caml/startup_aux.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
+ ../byterun/caml/signals_machdep.h signals_osdep.h stack.h
+signals.d.o: signals.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/callback.h ../byterun/caml/config.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h \
+ ../byterun/caml/signals.h ../byterun/caml/signals_machdep.h \
+ ../byterun/caml/sys.h
 startup_aux.d.o: startup_aux.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/exec.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/startup_aux.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/exec.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/startup_aux.h
+startup.d.o: startup.c ../byterun/caml/callback.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/backtrace.h \
+ ../byterun/caml/exec.h ../byterun/caml/custom.h \
+ ../byterun/caml/debugger.h ../byterun/caml/fail.h \
+ ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/intext.h ../byterun/caml/io.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/printexc.h stack.h ../byterun/caml/startup_aux.h \
+ ../byterun/caml/sys.h
 str.d.o: str.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/mlvalues.h ../byterun/caml/misc.h
 sys.d.o: sys.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/debugger.h ../byterun/caml/fail.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/instruct.h \
-  ../byterun/caml/io.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/stacks.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/debugger.h \
+ ../byterun/caml/fail.h ../byterun/caml/gc_ctrl.h \
+ ../byterun/caml/instruct.h ../byterun/caml/io.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/signals.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/sys.h
 terminfo.d.o: terminfo.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/io.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/alloc.h ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/io.h \
+ ../byterun/caml/mlvalues.h
 unix.d.o: unix.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/fail.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/fail.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/signals.h ../byterun/caml/sys.h
 weak.d.o: weak.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/weak.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/weak.h
 alloc.i.o: alloc.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/stacks.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/custom.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/stacks.h ../byterun/caml/memory.h
 array.i.o: array.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/signals.h
 backtrace.i.o: backtrace.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/backtrace_prim.h ../byterun/caml/fail.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/backtrace.h \
+ ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
+ ../byterun/caml/backtrace.h ../byterun/caml/fail.h
 backtrace_prim.i.o: backtrace_prim.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h stack.h
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/backtrace.h \
+ ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
+ ../byterun/caml/backtrace.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h stack.h
 callback.i.o: callback.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h
 clambda_checks.i.o: clambda_checks.c ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h
 compact.i.o: compact.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/weak.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/finalise.h ../byterun/caml/roots.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/freelist.h \
+ ../byterun/caml/gc.h ../byterun/caml/gc_ctrl.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/memory.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/roots.h \
+ ../byterun/caml/weak.h
 compare.i.o: compare.c ../byterun/caml/custom.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h
 custom.i.o: custom.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h
 debugger.i.o: debugger.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/debugger.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/config.h ../byterun/caml/debugger.h \
+ ../byterun/caml/misc.h
 dynlink.i.o: dynlink.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/dynlink.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/prims.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/alloc.h ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/dynlink.h \
+ ../byterun/caml/fail.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/osdeps.h ../byterun/caml/prims.h \
+ ../byterun/caml/signals.h
 extern.i.o: extern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/md5.h \
-  ../byterun/caml/memory.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/reverse.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/config.h ../byterun/caml/custom.h ../byterun/caml/fail.h \
+ ../byterun/caml/gc.h ../byterun/caml/intext.h ../byterun/caml/io.h \
+ ../byterun/caml/io.h ../byterun/caml/md5.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/reverse.h
 fail.i.o: fail.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/gc.h \
-  ../byterun/caml/memory.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/printexc.h \
-  ../byterun/caml/signals.h stack.h ../byterun/caml/roots.h \
-  ../byterun/caml/callback.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/gc.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/printexc.h ../byterun/caml/signals.h stack.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h \
+ ../byterun/caml/callback.h
 finalise.i.o: finalise.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/signals.h
 floats.i.o: floats.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h ../byterun/caml/stacks.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/reverse.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h
 freelist.i.o: freelist.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/freelist.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/freelist.h ../byterun/caml/misc.h \
+ ../byterun/caml/config.h ../byterun/caml/mlvalues.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h
 gc_ctrl.i.o: gc_ctrl.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/compact.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h stack.h \
-  ../byterun/caml/startup_aux.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
+ ../byterun/caml/compact.h ../byterun/caml/custom.h \
+ ../byterun/caml/fail.h ../byterun/caml/finalise.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/signals.h stack.h ../byterun/caml/startup_aux.h
 globroots.i.o: globroots.c ../byterun/caml/memory.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/globroots.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h \
+ ../byterun/caml/globroots.h ../byterun/caml/roots.h
 hash.i.o: hash.c ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/custom.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/hash.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/custom.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/hash.h
 intern.i.o: intern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/callback.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/md5.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/callback.h ../byterun/caml/config.h \
+ ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
+ ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/io.h \
+ ../byterun/caml/md5.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/reverse.h
 ints.i.o: ints.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/intext.h \
+ ../byterun/caml/io.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h
 io.i.o: io.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/io.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
+ ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/signals.h ../byterun/caml/sys.h
 lexing.i.o: lexing.c ../byterun/caml/fail.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/stacks.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h
 main.i.o: main.c ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/sys.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h ../byterun/caml/sys.h
 major_gc.i.o: major_gc.c ../byterun/caml/compact.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/custom.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/weak.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/custom.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/fail.h ../byterun/caml/finalise.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/weak.h
 md5.i.o: md5.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/md5.h ../byterun/caml/io.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/md5.h ../byterun/caml/io.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/io.h ../byterun/caml/reverse.h
 memory.i.o: memory.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/signals.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/fail.h ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/signals.h
 meta.i.o: meta.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/fix_code.h \
-  ../byterun/caml/interp.h ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/prims.h ../byterun/caml/stacks.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/config.h ../byterun/caml/fail.h \
+ ../byterun/caml/fix_code.h ../byterun/caml/interp.h \
+ ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/prims.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h
 minor_gc.i.o: minor_gc.c ../byterun/caml/custom.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/weak.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/fail.h \
+ ../byterun/caml/finalise.h ../byterun/caml/roots.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/signals.h ../byterun/caml/weak.h
 misc.i.o: misc.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/version.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/misc.h \
+ ../byterun/caml/config.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/version.h
 natdynlink.i.o: natdynlink.c ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h stack.h \
-  ../byterun/caml/callback.h ../byterun/caml/alloc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/fail.h ../byterun/caml/signals.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/misc.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h stack.h ../byterun/caml/callback.h \
+ ../byterun/caml/alloc.h ../byterun/caml/intext.h ../byterun/caml/io.h \
+ ../byterun/caml/osdeps.h ../byterun/caml/fail.h \
+ ../byterun/caml/signals.h
 obj.i.o: obj.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/interp.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/prims.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/interp.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/prims.h
 parsing.i.o: parsing.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/alloc.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/misc.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/alloc.h
 printexc.i.o: printexc.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/exec.h \
-  ../byterun/caml/callback.h ../byterun/caml/debugger.h \
-  ../byterun/caml/fail.h ../byterun/caml/printexc.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/exec.h ../byterun/caml/callback.h \
+ ../byterun/caml/debugger.h ../byterun/caml/fail.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/printexc.h
 roots.i.o: roots.c ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/globroots.h stack.h
-signals.i.o: signals.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/callback.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/signals.h \
-  ../byterun/caml/signals_machdep.h ../byterun/caml/sys.h
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/globroots.h ../byterun/caml/memory.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h stack.h \
+ ../byterun/caml/roots.h
 signals_asm.i.o: signals_asm.c ../byterun/caml/fail.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/signals_machdep.h \
-  signals_osdep.h stack.h
-startup.i.o: startup.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/custom.h \
-  ../byterun/caml/debugger.h ../byterun/caml/fail.h \
-  ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/printexc.h stack.h ../byterun/caml/startup_aux.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
+ ../byterun/caml/signals_machdep.h signals_osdep.h stack.h
+signals.i.o: signals.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/callback.h ../byterun/caml/config.h \
+ ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/roots.h ../byterun/caml/memory.h \
+ ../byterun/caml/signals.h ../byterun/caml/signals_machdep.h \
+ ../byterun/caml/sys.h
 startup_aux.i.o: startup_aux.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/exec.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/startup_aux.h
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/exec.h ../byterun/caml/memory.h \
+ ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/startup_aux.h
+startup.i.o: startup.c ../byterun/caml/callback.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/misc.h ../byterun/caml/backtrace.h \
+ ../byterun/caml/exec.h ../byterun/caml/custom.h \
+ ../byterun/caml/debugger.h ../byterun/caml/fail.h \
+ ../byterun/caml/freelist.h ../byterun/caml/gc.h \
+ ../byterun/caml/gc_ctrl.h ../byterun/caml/intext.h ../byterun/caml/io.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/printexc.h stack.h ../byterun/caml/startup_aux.h \
+ ../byterun/caml/sys.h
 str.i.o: str.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/mlvalues.h ../byterun/caml/misc.h
 sys.i.o: sys.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/debugger.h ../byterun/caml/fail.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/instruct.h \
-  ../byterun/caml/io.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/stacks.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/alloc.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/debugger.h \
+ ../byterun/caml/fail.h ../byterun/caml/gc_ctrl.h \
+ ../byterun/caml/instruct.h ../byterun/caml/io.h ../byterun/caml/misc.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/signals.h ../byterun/caml/stacks.h \
+ ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/sys.h
 terminfo.i.o: terminfo.c ../byterun/caml/config.h \
-  ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
-  ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/io.h
+ ../byterun/caml/../../config/m.h ../byterun/caml/../../config/s.h \
+ ../byterun/caml/alloc.h ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/io.h \
+ ../byterun/caml/mlvalues.h
 unix.i.o: unix.c ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/fail.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
-  ../byterun/caml/sys.h
+ ../byterun/caml/../../config/s.h ../byterun/caml/fail.h \
+ ../byterun/caml/misc.h ../byterun/caml/config.h \
+ ../byterun/caml/mlvalues.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
+ ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
+ ../byterun/caml/misc.h ../byterun/caml/osdeps.h \
+ ../byterun/caml/signals.h ../byterun/caml/sys.h
 weak.i.o: weak.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
-  ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/weak.h
+ ../byterun/caml/config.h ../byterun/caml/../../config/m.h \
+ ../byterun/caml/../../config/s.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/fail.h ../byterun/caml/major_gc.h \
+ ../byterun/caml/freelist.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
+ ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
+ ../byterun/caml/address_class.h ../byterun/caml/mlvalues.h \
+ ../byterun/caml/weak.h

--- a/byterun/.depend
+++ b/byterun/.depend
@@ -1,900 +1,1028 @@
 alloc.o: alloc.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/address_class.h caml/mlvalues.h caml/stacks.h caml/memory.h
 array.o: array.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/signals.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
+ caml/mlvalues.h caml/signals.h
 backtrace.o: backtrace.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
-  caml/exec.h caml/backtrace_prim.h caml/fail.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h
 backtrace_prim.o: backtrace_prim.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/misc.h \
-  caml/alloc.h caml/custom.h caml/io.h caml/instruct.h caml/intext.h \
-  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/startup.h \
-  caml/stacks.h caml/sys.h caml/backtrace.h caml/fail.h \
-  caml/backtrace_prim.h
+ caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/config.h \
+ caml/misc.h caml/alloc.h caml/mlvalues.h caml/custom.h caml/io.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/exec.h caml/fix_code.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/startup.h caml/exec.h caml/stacks.h \
+ caml/memory.h caml/sys.h caml/backtrace.h caml/fail.h \
+ caml/backtrace_prim.h caml/backtrace.h
 callback.o: callback.c caml/callback.h caml/compatibility.h \
-  caml/mlvalues.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/interp.h caml/instruct.h caml/fix_code.h caml/stacks.h
+ caml/mlvalues.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
+ caml/stacks.h caml/memory.h
 compact.o: compact.c caml/address_class.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
-  caml/misc.h caml/mlvalues.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/gc_ctrl.h caml/weak.h
+ caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
+ caml/misc.h caml/mlvalues.h caml/config.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h
 compare.o: compare.c caml/custom.h caml/compatibility.h caml/mlvalues.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
-  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/misc.h caml/mlvalues.h
 custom.o: custom.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/custom.h caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/mlvalues.h
 debugger.o: debugger.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/debugger.h caml/fail.h caml/fix_code.h \
-  caml/instruct.h caml/intext.h caml/io.h caml/stacks.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/sys.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/config.h caml/debugger.h caml/misc.h caml/fail.h \
+ caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/io.h \
+ caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/sys.h
 dynlink.o: dynlink.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/dynlink.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/osdeps.h caml/prims.h caml/signals.h
+ caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/osdeps.h caml/prims.h \
+ caml/signals.h
 extern.o: extern.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
-  caml/io.h caml/md5.h caml/memory.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/reverse.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 fail.o: fail.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/printexc.h caml/signals.h caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h caml/stacks.h \
+ caml/memory.h
 finalise.o: finalise.c caml/callback.h caml/compatibility.h \
-  caml/mlvalues.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/fail.h caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/signals.h
+ caml/mlvalues.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/fail.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/signals.h
 fix_code.o: fix_code.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/debugger.h caml/misc.h \
-  caml/mlvalues.h caml/fix_code.h caml/instruct.h caml/intext.h \
-  caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h
+ caml/../../config/s.h caml/compatibility.h caml/debugger.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/fix_code.h caml/instruct.h \
+ caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 floats.o: floats.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h \
-  caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
 freelist.o: freelist.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/freelist.h caml/misc.h \
-  caml/mlvalues.h caml/gc.h caml/gc_ctrl.h caml/memory.h caml/major_gc.h \
-  caml/minor_gc.h caml/address_class.h
+ caml/../../config/s.h caml/compatibility.h caml/freelist.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/major_gc.h caml/misc.h caml/mlvalues.h
 gc_ctrl.o: gc_ctrl.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
-  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/gc_ctrl.h caml/signals.h caml/stacks.h \
-  caml/startup_aux.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
+ caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/signals.h caml/stacks.h caml/startup_aux.h
 globroots.o: globroots.c caml/memory.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/gc.h caml/mlvalues.h \
-  caml/misc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/roots.h caml/globroots.h
+ caml/../../config/m.h caml/../../config/s.h caml/gc.h caml/mlvalues.h \
+ caml/misc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/globroots.h caml/roots.h
 hash.o: hash.c caml/mlvalues.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/custom.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/hash.h
+ caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/custom.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/hash.h
 instrtrace.o: instrtrace.c
 intern.o: intern.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/callback.h caml/custom.h caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/callback.h caml/config.h caml/custom.h caml/fail.h \
+ caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp.o: interp.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
-  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/prims.h caml/signals.h caml/stacks.h caml/startup_aux.h \
-  caml/jumptbl.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
+ caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
+ caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/stacks.h caml/memory.h caml/startup_aux.h \
+ caml/jumptbl.h
 ints.o: ints.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h
 io.o: io.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/alloc.h caml/misc.h caml/mlvalues.h \
-  caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/osdeps.h caml/signals.h caml/sys.h
+ caml/compatibility.h caml/alloc.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/signals.h caml/sys.h
 lexing.o: lexing.c caml/fail.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
 main.o: main.c caml/misc.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/sys.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/misc.h \
+ caml/sys.h
 major_gc.o: major_gc.c caml/compact.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/misc.h caml/custom.h \
-  caml/mlvalues.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/gc_ctrl.h caml/weak.h
+ caml/../../config/s.h caml/compatibility.h caml/misc.h caml/custom.h \
+ caml/mlvalues.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/weak.h
 md5.o: md5.c caml/alloc.h caml/compatibility.h caml/misc.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h \
-  caml/fail.h caml/md5.h caml/io.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/fail.h \
+ caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
+ caml/io.h caml/reverse.h
 memory.o: memory.c caml/address_class.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
-  caml/misc.h caml/mlvalues.h caml/fail.h caml/freelist.h caml/gc.h \
-  caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
-  caml/signals.h
+ caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
+ caml/misc.h caml/mlvalues.h caml/config.h caml/fail.h caml/freelist.h \
+ caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h
 meta.o: meta.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/fix_code.h caml/interp.h \
-  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/address_class.h caml/prims.h \
-  caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/config.h caml/fail.h caml/fix_code.h caml/interp.h \
+ caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
+ caml/memory.h
 minor_gc.o: minor_gc.c caml/custom.h caml/compatibility.h caml/mlvalues.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
-  caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/gc_ctrl.h caml/signals.h caml/weak.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
+ caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
 misc.o: misc.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/misc.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/version.h
+ caml/compatibility.h caml/misc.h caml/config.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/version.h
 obj.o: obj.c caml/alloc.h caml/compatibility.h caml/misc.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h \
-  caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/minor_gc.h caml/address_class.h caml/prims.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/fail.h \
+ caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h
 parsing.o: parsing.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/misc.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/alloc.h
+ caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/config.h \
+ caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/alloc.h
 prims.o: prims.c caml/mlvalues.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/prims.h
+ caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/prims.h
 printexc.o: printexc.c caml/backtrace.h caml/mlvalues.h \
-  caml/compatibility.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/printexc.h
+ caml/compatibility.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/exec.h caml/callback.h \
+ caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h
 roots.o: roots.c caml/finalise.h caml/roots.h caml/misc.h \
-  caml/compatibility.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/globroots.h caml/stacks.h
-signals.o: signals.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/callback.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/roots.h caml/signals.h caml/signals_machdep.h caml/sys.h
+ caml/compatibility.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
 signals_byt.o: signals_byt.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/signals.h \
-  caml/signals_machdep.h
+ caml/../../config/s.h caml/compatibility.h caml/memory.h caml/config.h \
+ caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/signals.h \
+ caml/signals_machdep.h
+signals.o: signals.c caml/alloc.h caml/compatibility.h caml/misc.h \
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/callback.h caml/config.h caml/fail.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h
 stacks.o: stacks.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/fail.h caml/misc.h \
-  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h
-startup.o: startup.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/custom.h caml/debugger.h caml/dynlink.h caml/fail.h \
-  caml/fix_code.h caml/freelist.h caml/gc_ctrl.h caml/instrtrace.h \
-  caml/interp.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
-  caml/prims.h caml/printexc.h caml/reverse.h caml/signals.h \
-  caml/stacks.h caml/sys.h caml/startup.h caml/startup_aux.h \
-  caml/version.h
+ caml/../../config/s.h caml/compatibility.h caml/fail.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/misc.h caml/mlvalues.h caml/stacks.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h
 startup_aux.o: startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/compatibility.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/exec.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/startup_aux.h
+ caml/compatibility.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/exec.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/startup_aux.h
+startup.o: startup.c caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
+ caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h caml/exec.h \
+ caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
+ caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/prims.h caml/printexc.h caml/reverse.h caml/signals.h \
+ caml/stacks.h caml/memory.h caml/sys.h caml/startup.h caml/startup_aux.h \
+ caml/version.h
 str.o: str.c caml/alloc.h caml/compatibility.h caml/misc.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h \
-  caml/fail.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/fail.h \
+ caml/mlvalues.h caml/misc.h
 sys.o: sys.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/alloc.h caml/misc.h caml/mlvalues.h \
-  caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/instruct.h caml/io.h \
-  caml/osdeps.h caml/signals.h caml/stacks.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/sys.h
+ caml/compatibility.h caml/alloc.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
+ caml/instruct.h caml/io.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/signals.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/sys.h
 terminfo.o: terminfo.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/fail.h caml/io.h
+ caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/fail.h caml/io.h caml/mlvalues.h
 unix.o: unix.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/fail.h caml/misc.h caml/mlvalues.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/signals.h \
-  caml/sys.h
+ caml/compatibility.h caml/fail.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/misc.h caml/osdeps.h \
+ caml/signals.h caml/sys.h
 weak.o: weak.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/weak.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/address_class.h caml/mlvalues.h caml/weak.h
+win32.o: win32.c caml/alloc.h caml/compatibility.h caml/misc.h \
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/address_class.h caml/fail.h caml/io.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/osdeps.h caml/signals.h caml/sys.h \
+ caml/config.h
 alloc.d.o: alloc.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/address_class.h caml/mlvalues.h caml/stacks.h caml/memory.h
 array.d.o: array.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/signals.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
+ caml/mlvalues.h caml/signals.h
 backtrace.d.o: backtrace.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
-  caml/exec.h caml/backtrace_prim.h caml/fail.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h
 backtrace_prim.d.o: backtrace_prim.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/misc.h \
-  caml/alloc.h caml/custom.h caml/io.h caml/instruct.h caml/intext.h \
-  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/startup.h \
-  caml/stacks.h caml/sys.h caml/backtrace.h caml/fail.h \
-  caml/backtrace_prim.h
+ caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/config.h \
+ caml/misc.h caml/alloc.h caml/mlvalues.h caml/custom.h caml/io.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/exec.h caml/fix_code.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/startup.h caml/exec.h caml/stacks.h \
+ caml/memory.h caml/sys.h caml/backtrace.h caml/fail.h \
+ caml/backtrace_prim.h caml/backtrace.h
 callback.d.o: callback.c caml/callback.h caml/compatibility.h \
-  caml/mlvalues.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/interp.h caml/instruct.h caml/fix_code.h caml/stacks.h
+ caml/mlvalues.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
+ caml/stacks.h caml/memory.h
 compact.d.o: compact.c caml/address_class.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
-  caml/misc.h caml/mlvalues.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/gc_ctrl.h caml/weak.h
+ caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
+ caml/misc.h caml/mlvalues.h caml/config.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h
 compare.d.o: compare.c caml/custom.h caml/compatibility.h caml/mlvalues.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
-  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/misc.h caml/mlvalues.h
 custom.d.o: custom.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/custom.h caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/mlvalues.h
 debugger.d.o: debugger.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/debugger.h caml/fail.h caml/fix_code.h \
-  caml/instruct.h caml/intext.h caml/io.h caml/stacks.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/sys.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/config.h caml/debugger.h caml/misc.h caml/fail.h \
+ caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/io.h \
+ caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/sys.h
 dynlink.d.o: dynlink.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/dynlink.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/osdeps.h caml/prims.h caml/signals.h
+ caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/osdeps.h caml/prims.h \
+ caml/signals.h
 extern.d.o: extern.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
-  caml/io.h caml/md5.h caml/memory.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/reverse.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 fail.d.o: fail.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/printexc.h caml/signals.h caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h caml/stacks.h \
+ caml/memory.h
 finalise.d.o: finalise.c caml/callback.h caml/compatibility.h \
-  caml/mlvalues.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/fail.h caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/signals.h
+ caml/mlvalues.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/fail.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/signals.h
 fix_code.d.o: fix_code.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/debugger.h caml/misc.h \
-  caml/mlvalues.h caml/fix_code.h caml/instruct.h caml/intext.h \
-  caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h
+ caml/../../config/s.h caml/compatibility.h caml/debugger.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/fix_code.h caml/instruct.h \
+ caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 floats.d.o: floats.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h \
-  caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
 freelist.d.o: freelist.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/freelist.h caml/misc.h \
-  caml/mlvalues.h caml/gc.h caml/gc_ctrl.h caml/memory.h caml/major_gc.h \
-  caml/minor_gc.h caml/address_class.h
+ caml/../../config/s.h caml/compatibility.h caml/freelist.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/major_gc.h caml/misc.h caml/mlvalues.h
 gc_ctrl.d.o: gc_ctrl.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
-  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/gc_ctrl.h caml/signals.h caml/stacks.h \
-  caml/startup_aux.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
+ caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/signals.h caml/stacks.h caml/startup_aux.h
 globroots.d.o: globroots.c caml/memory.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/gc.h caml/mlvalues.h \
-  caml/misc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/roots.h caml/globroots.h
+ caml/../../config/m.h caml/../../config/s.h caml/gc.h caml/mlvalues.h \
+ caml/misc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/globroots.h caml/roots.h
 hash.d.o: hash.c caml/mlvalues.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/custom.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/hash.h
+ caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/custom.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/hash.h
 instrtrace.d.o: instrtrace.c caml/instrtrace.h caml/mlvalues.h \
-  caml/compatibility.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/instruct.h caml/opnames.h \
-  caml/prims.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/startup_aux.h
+ caml/compatibility.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/instruct.h caml/misc.h \
+ caml/mlvalues.h caml/opnames.h caml/prims.h caml/stacks.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/startup_aux.h
 intern.d.o: intern.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/callback.h caml/custom.h caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/callback.h caml/config.h caml/custom.h caml/fail.h \
+ caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp.d.o: interp.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
-  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/prims.h caml/signals.h caml/stacks.h caml/startup_aux.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
+ caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
+ caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/stacks.h caml/memory.h caml/startup_aux.h
 ints.d.o: ints.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h
 io.d.o: io.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/alloc.h caml/misc.h caml/mlvalues.h \
-  caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/osdeps.h caml/signals.h caml/sys.h
+ caml/compatibility.h caml/alloc.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/signals.h caml/sys.h
 lexing.d.o: lexing.c caml/fail.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
 main.d.o: main.c caml/misc.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/sys.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/misc.h \
+ caml/sys.h
 major_gc.d.o: major_gc.c caml/compact.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/misc.h caml/custom.h \
-  caml/mlvalues.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/gc_ctrl.h caml/weak.h
+ caml/../../config/s.h caml/compatibility.h caml/misc.h caml/custom.h \
+ caml/mlvalues.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/weak.h
 md5.d.o: md5.c caml/alloc.h caml/compatibility.h caml/misc.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h \
-  caml/fail.h caml/md5.h caml/io.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/fail.h \
+ caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
+ caml/io.h caml/reverse.h
 memory.d.o: memory.c caml/address_class.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
-  caml/misc.h caml/mlvalues.h caml/fail.h caml/freelist.h caml/gc.h \
-  caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
-  caml/signals.h
+ caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
+ caml/misc.h caml/mlvalues.h caml/config.h caml/fail.h caml/freelist.h \
+ caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h
 meta.d.o: meta.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/fix_code.h caml/interp.h \
-  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/address_class.h caml/prims.h \
-  caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/config.h caml/fail.h caml/fix_code.h caml/interp.h \
+ caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
+ caml/memory.h
 minor_gc.d.o: minor_gc.c caml/custom.h caml/compatibility.h caml/mlvalues.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
-  caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/gc_ctrl.h caml/signals.h caml/weak.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
+ caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
 misc.d.o: misc.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/misc.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/version.h
+ caml/compatibility.h caml/misc.h caml/config.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/version.h
 obj.d.o: obj.c caml/alloc.h caml/compatibility.h caml/misc.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h \
-  caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/minor_gc.h caml/address_class.h caml/prims.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/fail.h \
+ caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h
 parsing.d.o: parsing.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/misc.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/alloc.h
+ caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/config.h \
+ caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/alloc.h
 prims.d.o: prims.c caml/mlvalues.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/prims.h
+ caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/prims.h
 printexc.d.o: printexc.c caml/backtrace.h caml/mlvalues.h \
-  caml/compatibility.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/printexc.h
+ caml/compatibility.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/exec.h caml/callback.h \
+ caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h
 roots.d.o: roots.c caml/finalise.h caml/roots.h caml/misc.h \
-  caml/compatibility.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/globroots.h caml/stacks.h
-signals.d.o: signals.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/callback.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/roots.h caml/signals.h caml/signals_machdep.h caml/sys.h
+ caml/compatibility.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
 signals_byt.d.o: signals_byt.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/signals.h \
-  caml/signals_machdep.h
+ caml/../../config/s.h caml/compatibility.h caml/memory.h caml/config.h \
+ caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/signals.h \
+ caml/signals_machdep.h
+signals.d.o: signals.c caml/alloc.h caml/compatibility.h caml/misc.h \
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/callback.h caml/config.h caml/fail.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h
 stacks.d.o: stacks.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/fail.h caml/misc.h \
-  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h
-startup.d.o: startup.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/custom.h caml/debugger.h caml/dynlink.h caml/fail.h \
-  caml/fix_code.h caml/freelist.h caml/gc_ctrl.h caml/instrtrace.h \
-  caml/interp.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
-  caml/prims.h caml/printexc.h caml/reverse.h caml/signals.h \
-  caml/stacks.h caml/sys.h caml/startup.h caml/startup_aux.h \
-  caml/version.h
+ caml/../../config/s.h caml/compatibility.h caml/fail.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/misc.h caml/mlvalues.h caml/stacks.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h
 startup_aux.d.o: startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/compatibility.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/exec.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/startup_aux.h
+ caml/compatibility.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/exec.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/startup_aux.h
+startup.d.o: startup.c caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
+ caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h caml/exec.h \
+ caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
+ caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/prims.h caml/printexc.h caml/reverse.h caml/signals.h \
+ caml/stacks.h caml/memory.h caml/sys.h caml/startup.h caml/startup_aux.h \
+ caml/version.h
 str.d.o: str.c caml/alloc.h caml/compatibility.h caml/misc.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h \
-  caml/fail.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/fail.h \
+ caml/mlvalues.h caml/misc.h
 sys.d.o: sys.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/alloc.h caml/misc.h caml/mlvalues.h \
-  caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/instruct.h caml/io.h \
-  caml/osdeps.h caml/signals.h caml/stacks.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/sys.h
+ caml/compatibility.h caml/alloc.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
+ caml/instruct.h caml/io.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/signals.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/sys.h
 terminfo.d.o: terminfo.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/fail.h caml/io.h
+ caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/fail.h caml/io.h caml/mlvalues.h
 unix.d.o: unix.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/fail.h caml/misc.h caml/mlvalues.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/signals.h \
-  caml/sys.h
+ caml/compatibility.h caml/fail.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/misc.h caml/osdeps.h \
+ caml/signals.h caml/sys.h
 weak.d.o: weak.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/weak.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/address_class.h caml/mlvalues.h caml/weak.h
+win32.d.o: win32.c caml/alloc.h caml/compatibility.h caml/misc.h \
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/address_class.h caml/fail.h caml/io.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/osdeps.h caml/signals.h caml/sys.h \
+ caml/config.h
 alloc.i.o: alloc.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/address_class.h caml/mlvalues.h caml/stacks.h caml/memory.h
 array.i.o: array.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/signals.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
+ caml/mlvalues.h caml/signals.h
 backtrace.i.o: backtrace.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
-  caml/exec.h caml/backtrace_prim.h caml/fail.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h
 backtrace_prim.i.o: backtrace_prim.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/misc.h \
-  caml/alloc.h caml/custom.h caml/io.h caml/instruct.h caml/intext.h \
-  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/startup.h \
-  caml/stacks.h caml/sys.h caml/backtrace.h caml/fail.h \
-  caml/backtrace_prim.h
+ caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/config.h \
+ caml/misc.h caml/alloc.h caml/mlvalues.h caml/custom.h caml/io.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/exec.h caml/fix_code.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/startup.h caml/exec.h caml/stacks.h \
+ caml/memory.h caml/sys.h caml/backtrace.h caml/fail.h \
+ caml/backtrace_prim.h caml/backtrace.h
 callback.i.o: callback.c caml/callback.h caml/compatibility.h \
-  caml/mlvalues.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/interp.h caml/instruct.h caml/fix_code.h caml/stacks.h
+ caml/mlvalues.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
+ caml/stacks.h caml/memory.h
 compact.i.o: compact.c caml/address_class.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
-  caml/misc.h caml/mlvalues.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/gc_ctrl.h caml/weak.h
+ caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
+ caml/misc.h caml/mlvalues.h caml/config.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h
 compare.i.o: compare.c caml/custom.h caml/compatibility.h caml/mlvalues.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
-  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/misc.h caml/mlvalues.h
 custom.i.o: custom.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/custom.h caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/mlvalues.h
 debugger.i.o: debugger.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/debugger.h caml/fail.h caml/fix_code.h \
-  caml/instruct.h caml/intext.h caml/io.h caml/stacks.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/sys.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/config.h caml/debugger.h caml/misc.h caml/fail.h \
+ caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/io.h \
+ caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/sys.h
 dynlink.i.o: dynlink.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/dynlink.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/osdeps.h caml/prims.h caml/signals.h
+ caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/osdeps.h caml/prims.h \
+ caml/signals.h
 extern.i.o: extern.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
-  caml/io.h caml/md5.h caml/memory.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/reverse.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 fail.i.o: fail.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/printexc.h caml/signals.h caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h caml/stacks.h \
+ caml/memory.h
 finalise.i.o: finalise.c caml/callback.h caml/compatibility.h \
-  caml/mlvalues.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/fail.h caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/signals.h
+ caml/mlvalues.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/fail.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/signals.h
 fix_code.i.o: fix_code.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/debugger.h caml/misc.h \
-  caml/mlvalues.h caml/fix_code.h caml/instruct.h caml/intext.h \
-  caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h
+ caml/../../config/s.h caml/compatibility.h caml/debugger.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/fix_code.h caml/instruct.h \
+ caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 floats.i.o: floats.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h \
-  caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
 freelist.i.o: freelist.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/freelist.h caml/misc.h \
-  caml/mlvalues.h caml/gc.h caml/gc_ctrl.h caml/memory.h caml/major_gc.h \
-  caml/minor_gc.h caml/address_class.h
+ caml/../../config/s.h caml/compatibility.h caml/freelist.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/major_gc.h caml/misc.h caml/mlvalues.h
 gc_ctrl.i.o: gc_ctrl.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
-  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/gc_ctrl.h caml/signals.h caml/stacks.h \
-  caml/startup_aux.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
+ caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/signals.h caml/stacks.h caml/startup_aux.h
 globroots.i.o: globroots.c caml/memory.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/gc.h caml/mlvalues.h \
-  caml/misc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/roots.h caml/globroots.h
+ caml/../../config/m.h caml/../../config/s.h caml/gc.h caml/mlvalues.h \
+ caml/misc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/globroots.h caml/roots.h
 hash.i.o: hash.c caml/mlvalues.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/custom.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/hash.h
+ caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/custom.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/hash.h
 instrtrace.i.o: instrtrace.c
 intern.i.o: intern.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/callback.h caml/custom.h caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/callback.h caml/config.h caml/custom.h caml/fail.h \
+ caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp.i.o: interp.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
-  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/prims.h caml/signals.h caml/stacks.h caml/startup_aux.h \
-  caml/jumptbl.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
+ caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
+ caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/stacks.h caml/memory.h caml/startup_aux.h \
+ caml/jumptbl.h
 ints.i.o: ints.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h
 io.i.o: io.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/alloc.h caml/misc.h caml/mlvalues.h \
-  caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/osdeps.h caml/signals.h caml/sys.h
+ caml/compatibility.h caml/alloc.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/signals.h caml/sys.h
 lexing.i.o: lexing.c caml/fail.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
 main.i.o: main.c caml/misc.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/sys.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/misc.h \
+ caml/sys.h
 major_gc.i.o: major_gc.c caml/compact.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/misc.h caml/custom.h \
-  caml/mlvalues.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/gc_ctrl.h caml/weak.h
+ caml/../../config/s.h caml/compatibility.h caml/misc.h caml/custom.h \
+ caml/mlvalues.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/weak.h
 md5.i.o: md5.c caml/alloc.h caml/compatibility.h caml/misc.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h \
-  caml/fail.h caml/md5.h caml/io.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/fail.h \
+ caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
+ caml/io.h caml/reverse.h
 memory.i.o: memory.c caml/address_class.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
-  caml/misc.h caml/mlvalues.h caml/fail.h caml/freelist.h caml/gc.h \
-  caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
-  caml/signals.h
+ caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
+ caml/misc.h caml/mlvalues.h caml/config.h caml/fail.h caml/freelist.h \
+ caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h
 meta.i.o: meta.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/fix_code.h caml/interp.h \
-  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/address_class.h caml/prims.h \
-  caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/config.h caml/fail.h caml/fix_code.h caml/interp.h \
+ caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
+ caml/memory.h
 minor_gc.i.o: minor_gc.c caml/custom.h caml/compatibility.h caml/mlvalues.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
-  caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/gc_ctrl.h caml/signals.h caml/weak.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
+ caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
 misc.i.o: misc.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/misc.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/version.h
+ caml/compatibility.h caml/misc.h caml/config.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/version.h
 obj.i.o: obj.c caml/alloc.h caml/compatibility.h caml/misc.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h \
-  caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/minor_gc.h caml/address_class.h caml/prims.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/fail.h \
+ caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h
 parsing.i.o: parsing.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/misc.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/alloc.h
+ caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/config.h \
+ caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/alloc.h
 prims.i.o: prims.c caml/mlvalues.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/prims.h
+ caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/prims.h
 printexc.i.o: printexc.c caml/backtrace.h caml/mlvalues.h \
-  caml/compatibility.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/printexc.h
+ caml/compatibility.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/exec.h caml/callback.h \
+ caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h
 roots.i.o: roots.c caml/finalise.h caml/roots.h caml/misc.h \
-  caml/compatibility.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/globroots.h caml/stacks.h
-signals.i.o: signals.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/callback.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/roots.h caml/signals.h caml/signals_machdep.h caml/sys.h
+ caml/compatibility.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
 signals_byt.i.o: signals_byt.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/signals.h \
-  caml/signals_machdep.h
+ caml/../../config/s.h caml/compatibility.h caml/memory.h caml/config.h \
+ caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/signals.h \
+ caml/signals_machdep.h
+signals.i.o: signals.c caml/alloc.h caml/compatibility.h caml/misc.h \
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/callback.h caml/config.h caml/fail.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h
 stacks.i.o: stacks.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/fail.h caml/misc.h \
-  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h
-startup.i.o: startup.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/custom.h caml/debugger.h caml/dynlink.h caml/fail.h \
-  caml/fix_code.h caml/freelist.h caml/gc_ctrl.h caml/instrtrace.h \
-  caml/interp.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
-  caml/prims.h caml/printexc.h caml/reverse.h caml/signals.h \
-  caml/stacks.h caml/sys.h caml/startup.h caml/startup_aux.h \
-  caml/version.h
+ caml/../../config/s.h caml/compatibility.h caml/fail.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/misc.h caml/mlvalues.h caml/stacks.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h
 startup_aux.i.o: startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/compatibility.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/exec.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/startup_aux.h
+ caml/compatibility.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/exec.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/startup_aux.h
+startup.i.o: startup.c caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
+ caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h caml/exec.h \
+ caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
+ caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/prims.h caml/printexc.h caml/reverse.h caml/signals.h \
+ caml/stacks.h caml/memory.h caml/sys.h caml/startup.h caml/startup_aux.h \
+ caml/version.h
 str.i.o: str.c caml/alloc.h caml/compatibility.h caml/misc.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h \
-  caml/fail.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/fail.h \
+ caml/mlvalues.h caml/misc.h
 sys.i.o: sys.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/alloc.h caml/misc.h caml/mlvalues.h \
-  caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/instruct.h caml/io.h \
-  caml/osdeps.h caml/signals.h caml/stacks.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/sys.h
+ caml/compatibility.h caml/alloc.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
+ caml/instruct.h caml/io.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/signals.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/sys.h
 terminfo.i.o: terminfo.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/fail.h caml/io.h
+ caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/fail.h caml/io.h caml/mlvalues.h
 unix.i.o: unix.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/fail.h caml/misc.h caml/mlvalues.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/signals.h \
-  caml/sys.h
+ caml/compatibility.h caml/fail.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/misc.h caml/osdeps.h \
+ caml/signals.h caml/sys.h
 weak.i.o: weak.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/weak.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/address_class.h caml/mlvalues.h caml/weak.h
+win32.i.o: win32.c caml/alloc.h caml/compatibility.h caml/misc.h \
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/address_class.h caml/fail.h caml/io.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/osdeps.h caml/signals.h caml/sys.h \
+ caml/config.h
 alloc.pic.o: alloc.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/address_class.h caml/mlvalues.h caml/stacks.h caml/memory.h
 array.pic.o: array.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/signals.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/misc.h \
+ caml/mlvalues.h caml/signals.h
 backtrace.pic.o: backtrace.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
-  caml/exec.h caml/backtrace_prim.h caml/fail.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/backtrace.h caml/exec.h \
+ caml/backtrace_prim.h caml/backtrace.h caml/fail.h
 backtrace_prim.pic.o: backtrace_prim.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/misc.h \
-  caml/alloc.h caml/custom.h caml/io.h caml/instruct.h caml/intext.h \
-  caml/exec.h caml/fix_code.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/startup.h \
-  caml/stacks.h caml/sys.h caml/backtrace.h caml/fail.h \
-  caml/backtrace_prim.h
+ caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/config.h \
+ caml/misc.h caml/alloc.h caml/mlvalues.h caml/custom.h caml/io.h \
+ caml/instruct.h caml/intext.h caml/io.h caml/exec.h caml/fix_code.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/startup.h caml/exec.h caml/stacks.h \
+ caml/memory.h caml/sys.h caml/backtrace.h caml/fail.h \
+ caml/backtrace_prim.h caml/backtrace.h
 callback.pic.o: callback.c caml/callback.h caml/compatibility.h \
-  caml/mlvalues.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/interp.h caml/instruct.h caml/fix_code.h caml/stacks.h
+ caml/mlvalues.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/mlvalues.h caml/interp.h caml/instruct.h caml/fix_code.h \
+ caml/stacks.h caml/memory.h
 compact.pic.o: compact.c caml/address_class.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
-  caml/misc.h caml/mlvalues.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/gc_ctrl.h caml/weak.h
+ caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
+ caml/misc.h caml/mlvalues.h caml/config.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/mlvalues.h caml/roots.h caml/weak.h
 compare.pic.o: compare.c caml/custom.h caml/compatibility.h caml/mlvalues.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
-  caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
+ caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/misc.h caml/mlvalues.h
 custom.pic.o: custom.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/custom.h caml/fail.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/mlvalues.h
 debugger.pic.o: debugger.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/debugger.h caml/fail.h caml/fix_code.h \
-  caml/instruct.h caml/intext.h caml/io.h caml/stacks.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/sys.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/config.h caml/debugger.h caml/misc.h caml/fail.h \
+ caml/fix_code.h caml/instruct.h caml/intext.h caml/io.h caml/io.h \
+ caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/sys.h
 dynlink.pic.o: dynlink.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/dynlink.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/osdeps.h caml/prims.h caml/signals.h
+ caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/dynlink.h caml/fail.h caml/mlvalues.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/osdeps.h caml/prims.h \
+ caml/signals.h
 extern.pic.o: extern.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/gc.h caml/intext.h \
-  caml/io.h caml/md5.h caml/memory.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/reverse.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/config.h caml/custom.h caml/fail.h caml/gc.h \
+ caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 fail.pic.o: fail.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/printexc.h caml/signals.h caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/misc.h caml/mlvalues.h caml/printexc.h caml/signals.h caml/stacks.h \
+ caml/memory.h
 finalise.pic.o: finalise.c caml/callback.h caml/compatibility.h \
-  caml/mlvalues.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/fail.h caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/signals.h
+ caml/mlvalues.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/fail.h caml/mlvalues.h \
+ caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/signals.h
 fix_code.pic.o: fix_code.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/debugger.h caml/misc.h \
-  caml/mlvalues.h caml/fix_code.h caml/instruct.h caml/intext.h \
-  caml/io.h caml/md5.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h
+ caml/../../config/s.h caml/compatibility.h caml/debugger.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/fix_code.h caml/instruct.h \
+ caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/misc.h caml/mlvalues.h caml/reverse.h
 floats.pic.o: floats.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h \
-  caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
+ caml/misc.h caml/reverse.h caml/stacks.h caml/memory.h
 freelist.pic.o: freelist.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/freelist.h caml/misc.h \
-  caml/mlvalues.h caml/gc.h caml/gc_ctrl.h caml/memory.h caml/major_gc.h \
-  caml/minor_gc.h caml/address_class.h
+ caml/../../config/s.h caml/compatibility.h caml/freelist.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/major_gc.h caml/misc.h caml/mlvalues.h
 gc_ctrl.pic.o: gc_ctrl.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
-  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/gc_ctrl.h caml/signals.h caml/stacks.h \
-  caml/startup_aux.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
+ caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/memory.h caml/minor_gc.h caml/misc.h \
+ caml/mlvalues.h caml/signals.h caml/stacks.h caml/startup_aux.h
 globroots.pic.o: globroots.c caml/memory.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/gc.h caml/mlvalues.h \
-  caml/misc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/roots.h caml/globroots.h
+ caml/../../config/m.h caml/../../config/s.h caml/gc.h caml/mlvalues.h \
+ caml/misc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/globroots.h caml/roots.h
 hash.pic.o: hash.c caml/mlvalues.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/custom.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/hash.h
+ caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/custom.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/hash.h
 instrtrace.pic.o: instrtrace.c
 intern.pic.o: intern.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/callback.h caml/custom.h caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/callback.h caml/config.h caml/custom.h caml/fail.h \
+ caml/gc.h caml/intext.h caml/io.h caml/io.h caml/md5.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/mlvalues.h caml/misc.h caml/reverse.h
 interp.pic.o: interp.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
-  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/prims.h caml/signals.h caml/stacks.h caml/startup_aux.h \
-  caml/jumptbl.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
+ caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
+ caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/prims.h \
+ caml/signals.h caml/stacks.h caml/memory.h caml/startup_aux.h \
+ caml/jumptbl.h
 ints.pic.o: ints.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h
 io.pic.o: io.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/alloc.h caml/misc.h caml/mlvalues.h \
-  caml/custom.h caml/fail.h caml/io.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/osdeps.h caml/signals.h caml/sys.h
+ caml/compatibility.h caml/alloc.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/signals.h caml/sys.h
 lexing.pic.o: lexing.c caml/fail.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
 main.pic.o: main.c caml/misc.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/sys.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/misc.h \
+ caml/sys.h
 major_gc.pic.o: major_gc.c caml/compact.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/misc.h caml/custom.h \
-  caml/mlvalues.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/gc_ctrl.h caml/weak.h
+ caml/../../config/s.h caml/compatibility.h caml/misc.h caml/custom.h \
+ caml/mlvalues.h caml/config.h caml/fail.h caml/finalise.h caml/roots.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/freelist.h caml/gc.h caml/gc_ctrl.h \
+ caml/major_gc.h caml/misc.h caml/mlvalues.h caml/roots.h caml/weak.h
 md5.pic.o: md5.c caml/alloc.h caml/compatibility.h caml/misc.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h \
-  caml/fail.h caml/md5.h caml/io.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/fail.h \
+ caml/md5.h caml/io.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/mlvalues.h \
+ caml/io.h caml/reverse.h
 memory.pic.o: memory.c caml/address_class.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
-  caml/misc.h caml/mlvalues.h caml/fail.h caml/freelist.h caml/gc.h \
-  caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
-  caml/signals.h
+ caml/../../config/m.h caml/../../config/s.h caml/compatibility.h \
+ caml/misc.h caml/mlvalues.h caml/config.h caml/fail.h caml/freelist.h \
+ caml/gc.h caml/gc_ctrl.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/signals.h
 meta.pic.o: meta.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/fix_code.h caml/interp.h \
-  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/address_class.h caml/prims.h \
-  caml/stacks.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/config.h caml/fail.h caml/fix_code.h caml/interp.h \
+ caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h caml/stacks.h \
+ caml/memory.h
 minor_gc.pic.o: minor_gc.c caml/custom.h caml/compatibility.h caml/mlvalues.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
-  caml/fail.h caml/finalise.h caml/roots.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/gc_ctrl.h caml/signals.h caml/weak.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h caml/misc.h \
+ caml/config.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/gc.h caml/gc_ctrl.h caml/major_gc.h \
+ caml/memory.h caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/signals.h caml/weak.h
 misc.pic.o: misc.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/misc.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/version.h
+ caml/compatibility.h caml/misc.h caml/config.h caml/memory.h caml/gc.h \
+ caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/version.h
 obj.pic.o: obj.c caml/alloc.h caml/compatibility.h caml/misc.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h \
-  caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/minor_gc.h caml/address_class.h caml/prims.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/fail.h \
+ caml/gc.h caml/interp.h caml/major_gc.h caml/freelist.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
+ caml/minor_gc.h caml/misc.h caml/mlvalues.h caml/prims.h
 parsing.pic.o: parsing.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/misc.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/alloc.h
+ caml/../../config/s.h caml/compatibility.h caml/mlvalues.h caml/config.h \
+ caml/misc.h caml/memory.h caml/gc.h caml/mlvalues.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/alloc.h
 prims.pic.o: prims.c caml/mlvalues.h caml/compatibility.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/prims.h
+ caml/../../config/m.h caml/../../config/s.h caml/misc.h caml/prims.h
 printexc.pic.o: printexc.c caml/backtrace.h caml/mlvalues.h \
-  caml/compatibility.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/printexc.h
+ caml/compatibility.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/exec.h caml/callback.h \
+ caml/debugger.h caml/fail.h caml/misc.h caml/mlvalues.h caml/printexc.h
 roots.pic.o: roots.c caml/finalise.h caml/roots.h caml/misc.h \
-  caml/compatibility.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/globroots.h caml/stacks.h
-signals.pic.o: signals.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/callback.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/roots.h caml/signals.h caml/signals_machdep.h caml/sys.h
+ caml/compatibility.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/globroots.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
+ caml/misc.h caml/mlvalues.h caml/roots.h caml/stacks.h
 signals_byt.pic.o: signals_byt.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/memory.h caml/gc.h \
-  caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/signals.h \
-  caml/signals_machdep.h
+ caml/../../config/s.h caml/compatibility.h caml/memory.h caml/config.h \
+ caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/signals.h \
+ caml/signals_machdep.h
+signals.pic.o: signals.c caml/alloc.h caml/compatibility.h caml/misc.h \
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/callback.h caml/config.h caml/fail.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/mlvalues.h caml/roots.h \
+ caml/memory.h caml/signals.h caml/signals_machdep.h caml/sys.h
 stacks.pic.o: stacks.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/fail.h caml/misc.h \
-  caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h
-startup.pic.o: startup.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/custom.h caml/debugger.h caml/dynlink.h caml/fail.h \
-  caml/fix_code.h caml/freelist.h caml/gc_ctrl.h caml/instrtrace.h \
-  caml/interp.h caml/intext.h caml/io.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
-  caml/prims.h caml/printexc.h caml/reverse.h caml/signals.h \
-  caml/stacks.h caml/sys.h caml/startup.h caml/startup_aux.h \
-  caml/version.h
+ caml/../../config/s.h caml/compatibility.h caml/fail.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/misc.h caml/mlvalues.h caml/stacks.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h
 startup_aux.pic.o: startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/compatibility.h caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/misc.h caml/exec.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/startup_aux.h
+ caml/compatibility.h caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/misc.h caml/exec.h caml/memory.h caml/gc.h \
+ caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
+ caml/startup_aux.h
+startup.pic.o: startup.c caml/config.h caml/../../config/m.h \
+ caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
+ caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h caml/exec.h \
+ caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
+ caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/io.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/minor_gc.h caml/misc.h caml/mlvalues.h \
+ caml/osdeps.h caml/prims.h caml/printexc.h caml/reverse.h caml/signals.h \
+ caml/stacks.h caml/memory.h caml/sys.h caml/startup.h caml/startup_aux.h \
+ caml/version.h
 str.pic.o: str.c caml/alloc.h caml/compatibility.h caml/misc.h caml/config.h \
-  caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h \
-  caml/fail.h
+ caml/../../config/m.h caml/../../config/s.h caml/mlvalues.h caml/fail.h \
+ caml/mlvalues.h caml/misc.h
 sys.pic.o: sys.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/alloc.h caml/misc.h caml/mlvalues.h \
-  caml/debugger.h caml/fail.h caml/gc_ctrl.h caml/instruct.h caml/io.h \
-  caml/osdeps.h caml/signals.h caml/stacks.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/sys.h
+ caml/compatibility.h caml/alloc.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
+ caml/instruct.h caml/io.h caml/misc.h caml/mlvalues.h caml/osdeps.h \
+ caml/signals.h caml/stacks.h caml/memory.h caml/gc.h caml/major_gc.h \
+ caml/freelist.h caml/minor_gc.h caml/address_class.h caml/sys.h
 terminfo.pic.o: terminfo.c caml/config.h caml/../../config/m.h \
-  caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/fail.h caml/io.h
+ caml/../../config/s.h caml/compatibility.h caml/alloc.h caml/misc.h \
+ caml/config.h caml/mlvalues.h caml/fail.h caml/io.h caml/mlvalues.h
 unix.pic.o: unix.c caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/compatibility.h caml/fail.h caml/misc.h caml/mlvalues.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/signals.h \
-  caml/sys.h
+ caml/compatibility.h caml/fail.h caml/misc.h caml/config.h \
+ caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
+ caml/minor_gc.h caml/address_class.h caml/misc.h caml/osdeps.h \
+ caml/signals.h caml/sys.h
 weak.pic.o: weak.c caml/alloc.h caml/compatibility.h caml/misc.h \
-  caml/config.h caml/../../config/m.h caml/../../config/s.h \
-  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/weak.h
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
+ caml/memory.h caml/gc.h caml/major_gc.h caml/minor_gc.h \
+ caml/address_class.h caml/mlvalues.h caml/weak.h
+win32.pic.o: win32.c caml/alloc.h caml/compatibility.h caml/misc.h \
+ caml/config.h caml/../../config/m.h caml/../../config/s.h \
+ caml/mlvalues.h caml/address_class.h caml/fail.h caml/io.h caml/memory.h \
+ caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
+ caml/address_class.h caml/misc.h caml/osdeps.h caml/signals.h caml/sys.h \
+ caml/config.h


### PR DESCRIPTION
- Fix coreboot target. This target calls promote, which itself now
  uses tools/stripdebug. This executable has to be ran with the new
  runtime, not the one in boot/.
- Update .depend for byterun/ and asmrun/
