### PR TITLE
Remove dead code related to old MMAP_INTERVAL

### DIFF
--- a/byterun/gc_ctrl.c
+++ b/byterun/gc_ctrl.c
@@ -607,8 +607,6 @@ CAMLprim value caml_runtime_variant (value unit)
   return caml_copy_string ("d");
 #elif defined (CAML_INSTR)
   return caml_copy_string ("i");
-#elif defined (MMAP_INTERVAL)
-  return caml_copy_string ("m");
 #else
   return caml_copy_string ("");
 #endif


### PR DESCRIPTION
MMAP_INTERVAL is no longer used, this, this code is unreachable.
