### PR TITLE
PR#7169: Rephrase non-exhaustivity warning message to avoid confusion

### DIFF
--- a/Changes
+++ b/Changes
@@ -50,6 +50,10 @@ OCaml 4.04.0:
   (Unused exception or extension constructor)
   (Gabriel Scherer)
 
+- PR#7169, clarify the wording of Warning 8
+  (Non-exhaustivity warning for pattern matching)
+  (Florian Angeletti, review and report by Gabriel Scherer)
+
 ### Tools:
 
 - MPR#7189: toplevel #show, follow chains of module aliases

--- a/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml.reference
+++ b/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml.reference
@@ -5,7 +5,7 @@
       | Some false -> ()
       | None -> ()
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Some true
 val test_match_exhaustiveness : unit -> unit = <fun>
 # 

--- a/testsuite/tests/typing-extensions/open_types.ml.reference
+++ b/testsuite/tests/typing-extensions/open_types.ml.reference
@@ -75,7 +75,7 @@ Error: Signature mismatch:
   let f = function Foo -> ()
           ^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 *extension*
 Matching over values of extensible variant types (the *extension* above)
 must include a wild card pattern in order to be exhaustive.
@@ -88,7 +88,7 @@ val f : foo -> unit = <fun>
     | _::_::_ -> 3
     | [] -> 2
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 *extension*::[]
 Matching over values of extensible variant types (the *extension* above)
 must include a wild card pattern in order to be exhaustive.

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -10,7 +10,7 @@ let fbool (type t) (x : t) (tag : t ty) =
 type 'a ty = Int : int ty | Bool : bool ty
 Line _, characters 2-30:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Int
 val fbool : 'a -> 'a ty -> 'a = <fun>
 |}];;
@@ -24,7 +24,7 @@ let fint (type t) (x : t) (tag : t ty) =
 [%%expect{|
 Line _, characters 2-33:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Bool
 val fint : 'a -> 'a ty -> bool = <fun>
 |}];;

--- a/testsuite/tests/typing-gadts/pr5785.ml
+++ b/testsuite/tests/typing-gadts/pr5785.ml
@@ -11,7 +11,7 @@ end;;
 [%%expect{|
 Line _, characters 43-100:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 (Two, One)
 module Add :
   functor (T : sig type two end) ->

--- a/testsuite/tests/typing-gadts/pr5906.ml
+++ b/testsuite/tests/typing-gadts/pr5906.ml
@@ -25,7 +25,7 @@ type (_, _, _) binop =
   | Add : (int, int, int) binop
 Line _, characters 2-195:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 (Eq, Int _, _)
 val eval : ('a, 'b, 'c) binop -> 'a constant -> 'b constant -> 'c constant =
   <fun>

--- a/testsuite/tests/typing-gadts/pr5981.ml
+++ b/testsuite/tests/typing-gadts/pr5981.ml
@@ -10,7 +10,7 @@ end;;
 [%%expect{|
 Line _, characters 47-84:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 (A, A)
 module F :
   functor (S : sig type 'a t end) ->
@@ -35,7 +35,7 @@ end;;
 [%%expect{|
 Line _, characters 15-52:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 (A, A)
 module F :
   functor (S : sig type 'a t end) ->

--- a/testsuite/tests/typing-gadts/pr5989.ml
+++ b/testsuite/tests/typing-gadts/pr5989.ml
@@ -23,7 +23,7 @@ type (_, _) t = Any : ('a, 'b) t | Eq : ('a, 'a) t
 module M : sig type s = private [> `A ] val eq : (s, [ `A | `B ]) t end
 Line _, characters 39-64:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Eq
 val f : (M.s, [ `A | `B ]) t -> string = <fun>
 Exception: Match_failure ("", 16, 39).
@@ -51,7 +51,7 @@ module N :
   end
 Line _, characters 49-74:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Eq
 val f : (N.s, < a : int; b : bool >) t -> string = <fun>
 |}];;

--- a/testsuite/tests/typing-gadts/pr5997.ml
+++ b/testsuite/tests/typing-gadts/pr5997.ml
@@ -20,7 +20,7 @@ module U : sig type t = T end
 module M : sig type t = T val comp : (U.t, t) comp end
 Line _, characters 0-33:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Eq
 Exception: Match_failure ("", 16, 0).
 |}];;
@@ -41,7 +41,7 @@ module U : sig type t = { x : int; } end
 module M : sig type t = { x : int; } val comp : (U.t, t) comp end
 Line _, characters 0-33:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Eq
 Exception: Match_failure ("", 11, 0).
 |}];;

--- a/testsuite/tests/typing-gadts/pr6241.ml
+++ b/testsuite/tests/typing-gadts/pr6241.ml
@@ -19,7 +19,7 @@ let x = N.f A;;
 type (_, _) t = A : ('a, 'a) t | B : string -> ('a, 'b) t
 Line _, characters 52-74:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 A
 module M :
   functor (A : sig module type T end) (B : sig module type T end) ->

--- a/testsuite/tests/typing-gadts/pr6993_bad.ml
+++ b/testsuite/tests/typing-gadts/pr6993_bad.ml
@@ -15,7 +15,7 @@ f B.eq;;
 type (_, _) eqp = Y : ('a, 'a) eqp | N : string -> ('a, 'b) eqp
 Line _, characters 36-66:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Y
 val f : ('a list, 'a) eqp -> unit = <fun>
 module rec A : sig type t = B.t list end

--- a/testsuite/tests/typing-gadts/pr7016.ml
+++ b/testsuite/tests/typing-gadts/pr7016.ml
@@ -9,7 +9,7 @@ type (_, _) t =
   | Cons : 'a * ('b, 'tl) t -> ('a * 'b, 'tl) t
 Line _, characters 9-43:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Nil
 val get1 : ('b * 'a, 'a) t -> 'b = <fun>
 |}];;

--- a/testsuite/tests/typing-gadts/pr7234.ml
+++ b/testsuite/tests/typing-gadts/pr7234.ml
@@ -6,7 +6,7 @@ type (_, _) eq = Eq : ('a, 'a) eq | Neq : int -> ('a, 'b) eq
 type 'a t
 Line _, characters 15-40:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Eq
 val f : ('a, 'a t) eq -> int = <fun>
 |}];;
@@ -17,7 +17,7 @@ end;;
 [%%expect{|
 Line _, characters 16-43:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Eq
 module F :
   functor (T : sig type _ t end) -> sig val f : ('a, 'a T.t) eq -> int end

--- a/testsuite/tests/typing-gadts/pr7269.ml
+++ b/testsuite/tests/typing-gadts/pr7269.ml
@@ -9,7 +9,7 @@ and sub = [ `B ]
 type +'a t = T : [< `Conj of 'a & sub | `Other of string ] -> 'a t
 Line _, characters 6-47:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 T (`Conj _)
 val f : s t -> unit = <fun>
 Exception: Match_failure ("", 4, 6).
@@ -35,7 +35,7 @@ module M :
   end
 Line _, characters 12-59:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 T (`Conj _)
 Exception: Match_failure ("", 11, 12).
 |}];;
@@ -65,7 +65,7 @@ module M :
   end
 Line _, characters 21-57:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 `Conj _
 Exception: Match_failure ("", 13, 21).
 |}];;

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -101,11 +101,11 @@ module Nonexhaustive =
 [%%expect{|
 Line _, characters 6-34:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 C1 _
 Line _, characters 6-77:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 (Bar _, Foo _)
 module Nonexhaustive :
   sig
@@ -150,11 +150,11 @@ end;;
 [%%expect{|
 Line _, characters 10-18:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 None
 Line _, characters 10-18:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Nothing
 module PR6862 :
   sig
@@ -247,7 +247,7 @@ end;;
 [%%expect{|
 Line _, characters 4-50:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Any
 module PR6801 :
   sig
@@ -850,7 +850,7 @@ let f : type a. a ty -> a t -> int = fun x y ->
 [%%expect{|
 Line _, characters 2-153:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 (TE TC, D [| 0. |])
 val f : 'a ty -> 'a t -> int = <fun>
 |}];;
@@ -903,7 +903,7 @@ let f : type a. a ty -> a t -> int = fun x y ->
 type ('a, 'b) pair = { left : 'a; right : 'b; }
 Line _, characters 2-244:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 {left=TE TC; right=D [| 0. |]}
 val f : 'a ty -> 'a t -> int = <fun>
 |}];;

--- a/testsuite/tests/typing-gadts/yallop_bugs.ml
+++ b/testsuite/tests/typing-gadts/yallop_bugs.ml
@@ -50,7 +50,7 @@ let check : type s . s t * s -> bool = function
 type _ t = IntLit : int t | BoolLit : bool t
 Line _, characters 39-99:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 (IntLit, 0)
 val check : 's t * 's -> bool = <fun>
 |}];;
@@ -65,7 +65,7 @@ let check : type s . (s t, s) pair -> bool = function
 type ('a, 'b) pair = { fst : 'a; snd : 'b; }
 Line _, characters 45-134:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 {fst=IntLit; snd=0}
 val check : ('s t, 's) pair -> bool = <fun>
 |}];;

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -112,7 +112,7 @@ module PR6505b :
   end
 Line _, characters 23-57:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 `Foo _
 Exception: Match_failure ("", 6, 23).
 |}]

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -912,19 +912,19 @@ type t = A | B
 - : [< `A | `B ] * t -> int = <fun>
 Line _, characters 0-41:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 (`AnyExtraTag, `AnyExtraTag)
 - : [> `A | `B ] * [> `A | `B ] -> int = <fun>
 Line _, characters 0-29:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 (_, 0)
 Line _, characters 21-24:
 Warning 11: this match case is unused.
 - : [< `B ] * int -> int = <fun>
 Line _, characters 0-29:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 (0, _)
 Line _, characters 21-24:
 Warning 11: this match case is unused.

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -32,7 +32,8 @@ type 'a pair = {left: 'a; right: 'a};;
 
 let f : (int t box pair * bool) option -> unit = function None -> ();;
 let f : (string t box pair * bool) option -> unit = function None -> ();;
-
+let f = function {left=Box 0; _ } -> ();;
+let f = function {left=Box 0;right=Box 1} -> ();;
 
 (* Examples from ML2015 paper *)
 

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml.reference
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml.reference
@@ -65,7 +65,21 @@ Here is an example of a case that is not matched:
 Some ({left=Box A; right=Box A}, _)
 val f : (int t box pair * bool) option -> unit = <fun>
 # val f : (string t box pair * bool) option -> unit = <fun>
-#               type _ t = Int : int t | Bool : bool t
+# Characters 8-39:
+  let f = function {left=Box 0; _ } -> ();;
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+{left=Box 1; _ }
+val f : int box pair -> unit = <fun>
+# Characters 8-47:
+  let f = function {left=Box 0;right=Box 1} -> ();;
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+{left=Box 0; right=Box 0}
+val f : int box pair -> unit = <fun>
+#             type _ t = Int : int t | Bool : bool t
 #         val f : 'a t -> 'a = <fun>
 #     val g : int t -> int = <fun>
 #         val h : 'a t -> 'a t -> bool = <fun>

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml.reference
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml.reference
@@ -4,7 +4,7 @@
       None, None -> 1
     | Some _, Some _ -> 2..
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 ((Some _, None)|(None, Some _))
 val f : 'a option * 'b option -> int = <fun>
 #             type _ t = A : int t | B : bool t | C : char t | D : float t
@@ -14,7 +14,7 @@ type v = E | F | G
   .function A, A, A, A, A, A, A, _, U, U -> 1
      | _, _, _, _, _, _, _, G, _, _ -> 1
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 (A, A, A, A, A, A, B, (E|F), _, _)
 Characters 172-200:
      | _, _, _, _, _, _, _, G, _, _ -> 1
@@ -52,7 +52,7 @@ val f : unit t option -> int = <fun>
   let f (x : int t option) = match x with None -> 1;; (* warn *)
                              ^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Some A
 val f : int t option -> int = <fun>
 #         type 'a box = Box of 'a
@@ -61,7 +61,7 @@ type 'a pair = { left : 'a; right : 'a; }
   let f : (int t box pair * bool) option -> unit = function None -> ();;
                                                    ^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Some ({left=Box A; right=Box A}, _)
 val f : (int t box pair * bool) option -> unit = <fun>
 # val f : (string t box pair * bool) option -> unit = <fun>
@@ -75,7 +75,7 @@ module A : sig type a type b val eq : (a, b) cmp end
   let f : (A.a, A.b) cmp -> unit = function Any -> ()
                                    ^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Eq
 val f : (A.a, A.b) cmp -> unit = <fun>
 #     val deep : char t option -> char = <fun>
@@ -90,7 +90,7 @@ type _ succ = Succ
     function None -> false
     ^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Some (PlusS _)
 val harder : (zero succ, zero succ, zero succ) plus option -> bool = <fun>
 #     val harder : (zero succ, zero succ, zero succ) plus option -> bool = <fun>

--- a/testsuite/tests/typing-warnings/pr5892.ml.reference
+++ b/testsuite/tests/typing-warnings/pr5892.ml.reference
@@ -6,7 +6,7 @@
   let f : label choice -> bool = function Left -> true;; (* warn *)
                                  ^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Right
 val f : CamlinternalOO.label choice -> bool = <fun>
 # 

--- a/testsuite/tests/typing-warnings/pr7085.ml.reference
+++ b/testsuite/tests/typing-warnings/pr7085.ml.reference
@@ -3,7 +3,7 @@
        match M.is_t () with None -> 0
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 Some (Is Eq)
 module TypEq : sig type (_, _) t = Eq : ('a, 'a) t end
 module type T =

--- a/testsuite/tests/warnings/w01.reference
+++ b/testsuite/tests/warnings/w01.reference
@@ -5,7 +5,7 @@ Warning 5: this function application is partial,
 maybe some arguments are missing.
 File "w01.ml", line 20, characters 4-5:
 Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a value that is not matched:
+Here is an example of a case that is not matched:
 0
 File "w01.ml", line 25, characters 0-1:
 Warning 10: this expression should have type unit.

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -137,6 +137,13 @@ let get_type_path ty tenv =
 open Format
 ;;
 
+let pretty_record_elision_mark ppf = function
+  | [] -> () (* should not happen, empty record pattern *)
+  | (_, lbl, _) :: q ->
+      (* we assume that there is no label repetitions here *)
+      if Array.length lbl.lbl_all > 1 + List.length q then
+        fprintf ppf ";@ _@ "
+
 let is_cons = function
 | {cstr_name = "::"} -> true
 | _ -> false
@@ -187,12 +194,13 @@ let rec pretty_val ppf v =
   | Tpat_variant (l, Some w, _) ->
       fprintf ppf "@[<2>`%s@ %a@]" l pretty_arg w
   | Tpat_record (lvs,_) ->
-      fprintf ppf "@[{%a}@]"
-        pretty_lvals
-        (List.filter
-           (function
-             | (_,_,{pat_desc=Tpat_any}) -> false (* do not show lbl=_ *)
-             | _ -> true) lvs)
+      let filtered_lvs = List.filter
+          (function
+            | (_,_,{pat_desc=Tpat_any}) -> false (* do not show lbl=_ *)
+            | _ -> true) lvs in
+      fprintf ppf "@[{%a%a}@]"
+        pretty_lvals filtered_lvs
+        pretty_record_elision_mark filtered_lvs
   | Tpat_array vs ->
       fprintf ppf "@[[| %a |]@]" (pretty_vals " ;") vs
   | Tpat_lazy v ->

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -306,7 +306,7 @@ let message = function
   | Partial_match "" -> "this pattern-matching is not exhaustive."
   | Partial_match s ->
       "this pattern-matching is not exhaustive.\n\
-       Here is an example of a value that is not matched:\n" ^ s
+       Here is an example of a case that is not matched:\n" ^ s
   | Non_closed_record_pattern s ->
       "the following labels are not bound in this record pattern:\n" ^ s ^
       "\nEither bind these labels explicitly or add '; _' to the pattern."


### PR DESCRIPTION
This PR proposes to rephrase the warning for non-exhaustive patterns to make it clearer that counter-examples printed by the warning are patterns or cases and not values (that could be constructed).

For instance, with the current warning message, the following code

``` OCaml
type t = { left:int ; right:int }
let f = function { left = 0; _ } -> ();;
```

raises a warning 

```
Warning 8: this pattern-matching is not exhaustive.
Here is an example of a value that is not matched:                                     
{left=1}
```

This warning is confusing for beginners on at least two fronts. First, `{left=1}` is not a valid ocaml value. A beginner trying to see what happens when computing `f {left=1}` may be lost in the error raised by the compiler. The counter-example `{left=1}` is a pattern and should not be introduced as a value. Rewording the warning message as

```
Warning 8: this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:                                     
{left=1}
```

solves this ambiguity without decreasing the information density of the warning.
This is the object of the first commit in this PR.

Second, the pattern `{left=1}` elides the field `right` without any indication that fields have been elided. Adding a trailing `; _` when fields have been elided would correct this lack of information and reinforces the notion that the counter-example is a pattern:

```
Warning 8: this pattern-matching is not exhaustive.
Here is an example of a value that is not matched:                                     
{left=1; _ }
```

The second commit in this PR modifies the pattern pretty printer in `typing\parmatch.ml`
to add this trailing `_` when record patterns are not closed.

See also [mantis:7169](http://caml.inria.fr/mantis/view.php?id=7169) for more discussions.
