### PR TITLE
expose function to flush formatter's internal queue

### DIFF
--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -898,6 +898,9 @@ let pp_get_formatter_output_functions state () =
   (state.pp_out_string, state.pp_out_flush)
 ;;
 
+let pp_flush_formatter state =
+  pp_flush_queue state false
+
 (* The default function to output new lines. *)
 let display_newline state () = state.pp_out_string "\n" 0  1;;
 

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -565,6 +565,8 @@ val pp_get_formatter_out_functions :
    evaluation of these primitives. For instance,
    [print_string] is equal to [pp_print_string std_formatter]. *)
 
+val pp_flush_formatter : formatter -> unit
+
 (** {6 Convenience formatting functions.} *)
 
 val pp_print_list:

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -566,6 +566,12 @@ val pp_get_formatter_out_functions :
    [print_string] is equal to [pp_print_string std_formatter]. *)
 
 val pp_flush_formatter : formatter -> unit
+(** [pp_flush_formatter fmt] flushes [fmt]'s internal queue, ensuring that all
+    the printing and flushing actions have been performed. In addition, this
+    operation will close all boxes and reset the state of the formatter.
+    
+    This will not flush [fmt]'s output. In most cases, the user may want to use
+    {!pp_print_flush} instead. *)
 
 (** {6 Convenience formatting functions.} *)
 


### PR DESCRIPTION
Previous to this commit the Format API did not allow the user to flush a formatter's internal queue without also flushing the formatter's output stream. This was a problem for custom formatters that may have been used in conjunction with `kfprintf` or `ikfprintf`. When the continuation was called, the formatter's queue of operations may not have been flushed. The only way that the user could force a queue flush was to call `pp_print_flush`, forcing the user to introduce a blocking call before it was necessary, regardless of other buffer state within the system.

Exposing the internal queue flushing operation solves this problem.

Names may be changed to protect aesthetic sensibilities.
