### PR TITLE
Restore [defaultentry] as the default target of Makefile

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -13,6 +13,9 @@
 #*                                                                        *
 #**************************************************************************
 
+# For users who don't read the INSTALL file
+defaultentry:
+
 # The main Makefile, fragments shared between Makefile and Makefile.nt
 
 include config/Makefile


### PR DESCRIPTION
- Makefile.shared does not have to be executable
- Restore [defaultentry] as the default target of Makefile
