### PR TITLE
Document and improve `./configure -no-native-compiler`

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -111,6 +111,9 @@ The `configure` script accepts the following options:
 -no-debugger::
         Do not build ocamldebug.
 
+-no-native-compiler::
+        Do not build the native compiler -- bytecode compilation only.
+
 -no-ocamldoc::
         Do not build ocamldoc.
 

--- a/configure
+++ b/configure
@@ -789,7 +789,7 @@ if test $with_sharedlibs = "yes"; then
     i[3456]86-*-haiku*)           natdynlink=true;;
     arm*-*-linux*)                natdynlink=true;;
     arm*-*-freebsd*)              natdynlink=true;;
-    earm*-*-netbsd*)               natdynlink=true;;
+    earm*-*-netbsd*)              natdynlink=true;;
     aarch64-*-linux*)             natdynlink=true;;
   esac
 fi
@@ -874,7 +874,7 @@ esac
 case "$native_compiler" in
     true) ;;
     false)
-      arch=none; model=default; system=unknown;;
+      arch=none; model=default; system=unknown; natdynlink=false;;
 esac
 
 if test -z "$ccoption"; then


### PR DESCRIPTION
This option implemented in #387 would be useful for making opam's bytecode-only switch more robust, as suggested by @dbuenzli  in [MPR#7172](http://caml.inria.fr/mantis/view.php?id=7172).
