### PR TITLE
Precise non-backward change done on weak-pointers

### DIFF
--- a/Changes
+++ b/Changes
@@ -289,6 +289,9 @@ Runtime system:
   now support marshaled data bigger than 4 Gb.
   (Xavier Leroy)
 
+* GPR#22: The undocumented layout of weak arrays has been changed. Finalisation
+  functions are now run before the erasure of the corresponding values.
+
 * GPR#226: select higher levels of optimization for GCC >= 3.4 and Clang
   when compiling the run-time system and C stub code.
   "-std=gnu99 -O2 -fno-strict-aliasing -fwrapv" is used by default.

--- a/byterun/weak.c
+++ b/byterun/weak.c
@@ -250,11 +250,10 @@ CAMLprim value caml_weak_get (value ar, value n){
 CAMLprim value caml_ephe_get_data (value ar)
 {
   CAMLparam1 (ar);
-  mlsize_t offset = 1;
   CAMLlocal2 (res, elt);
                                                    Assert (Is_in_heap (ar));
-  elt = Field (ar, offset);
   if(caml_gc_phase == Phase_clean) caml_ephe_clean(ar);
+  elt = Field (ar, CAML_EPHE_DATA_OFFSET);
   if (elt == caml_ephe_none){
     res = None_val;
   }else{
@@ -316,19 +315,18 @@ CAMLprim value caml_weak_get_copy (value ar, value n){
 CAMLprim value caml_ephe_get_data_copy (value ar)
 {
   CAMLparam1 (ar);
-  mlsize_t offset = 1;
   CAMLlocal2 (res, elt);
   value v;  /* Caution: this is NOT a local root. */
                                                    Assert (Is_in_heap (ar));
 
-  v = Field (ar, offset);
   if (caml_gc_phase == Phase_clean) caml_ephe_clean(ar);
+  v = Field (ar, CAML_EPHE_DATA_OFFSET);
   if (v == caml_ephe_none) CAMLreturn (None_val);
   if (Is_block (v) && Is_in_heap_or_young(v)) {
     elt = caml_alloc (Wosize_val (v), Tag_val (v));
           /* The GC may erase or move v during this call to caml_alloc. */
-    v = Field (ar, offset);
     if (caml_gc_phase == Phase_clean) caml_ephe_clean(ar);
+    v = Field (ar, CAML_EPHE_DATA_OFFSET);
     if (v == caml_ephe_none) CAMLreturn (None_val);
     if (Tag_val (v) < No_scan_tag){
       mlsize_t i;

--- a/stdlib/weak.mli
+++ b/stdlib/weak.mli
@@ -22,8 +22,10 @@ type 'a t
 (** The type of arrays of weak pointers (weak arrays).  A weak
    pointer is a value that the garbage collector may erase whenever
    the value is not used any more (through normal pointers) by the
-   program.  Note that finalisation functions are run after the
-   weak pointers are erased.
+   program.  Note that finalisation functions are run before the
+   weak pointers are erased, because the finalisation functions
+   can make values alive again (before 4.03 the finalisation
+   functions were run before).
 
    A weak pointer is said to be full if it points to a value,
    empty if the value was erased by the GC.


### PR DESCRIPTION
Fix [#7173](http://caml.inria.fr/mantis/view.php?id=7173). There is a discussion in mantis if it should go to 4.03. I'm not convinced, except for the two first commits. I can create a separate GPR for them.
