### PR TITLE
AMA about Flambda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -674,6 +674,19 @@ partialclean::
 alldepend::
 	cd ocamldoc && $(MAKE) depend
 
+middle_end_doc:
+	mkdir middle_end_doc
+
+middle-end_html_doc: ocamldoc | middle_end_doc
+	$(CAMLRUN) ocamldoc/ocamldoc -html -d middle_end_doc \
+	  -I utils -I middle_end -I middle_end/base_types -I bytecomp \
+	  -I typing -I parsing -I asmcomp \
+	  utils/identifiable.mli bytecomp/lambda.mli asmcomp/clambda.mli \
+	  $(MIDDLE_END:.cmo=.mli)
+
+partialclean::
+	rm -rf flambda_doc
+
 # The extra libraries
 
 otherlibraries: ocamltools

--- a/middle_end/HACKING.adoc
+++ b/middle_end/HACKING.adoc
@@ -1,0 +1,70 @@
+== Getting a grasp of the Flambda
+
+Flambda is an intermediate representation generated from Lambda by
+Closure_conversion. The representation is defined as a tree of various
+types:
+
+  - Flambda.program is the tree root: it is a sequence of top level
+    expressions.
+  - Flambda.t is the global expression structure
+  - Flambda.named are the let-bound expressions
+
+To understand what everything represents and how this relates to other
+representations Closure_conversion and Flambda_to_clambda are probably
+worth reading.
+
+The middle-end entry point is Middle_end. It contains the code the
+chains the transformations. To quickly see the effect of every pass,
+it is possible to look at the generated code between each one using:
+
+    ocamlopt -dflambda-verbose file.ml
+
+Some passes or analysis are not directly called by Middle_end, for
+instance, when the result of the analysis is used by a pass or when a
+transformation occur during inlining. The `-dump-pass` option can
+display what is happening during those passes. The list of covered
+passes is available with `ocamlopt --help`.
+
+== The inliner
+
+At the heart of Flambda is the inliner.
+  - Inline_and_simplify.run is the entry point. It is a tree
+    traversal maintaining an environment containing an approximation
+    of the set of possible values that variables can carry and use
+    this to perform local optimisations. In particular, if a variable
+    carry a given function, and that variable is used for a call,
+    inlining can occur.
+
+  - Inlining_decision contains the inlining heuristic.
+
+  - Simple_value_approx contains the value approximation type.
+
+  - Inlining_transform contains the functions effectively duplicating
+    code for inlining and specialization.
+
+== Writing a new optimization pass
+
+Most optimization passes can be simply written as a function of type
+`Flambda.program -> Flambda.program` and inserted in Middle_end in the
+`loop` function. `Initialize_symbol_to_let_symbol` is an example of a
+really simple pass. Usually most passes will only need to rewrite parts
+of the tree. Those can usually be quite easily written as an invocation
+of a mapper from `Flambda_iterators`. If the traversal cannot be
+written as a simple mapper, it is possible to use
+`Flambda_iterators.map_subexpressions` instead to control more
+precisely the iteration order.
+
+Note that Flambda expressions can contain extremely long sequences of
+lets, hence any loop traversing Flambda expressions must be
+tail-recursive when iterating on the body of lets. The Flambda module
+provides Helpers functions for let mapping and iterations.
+
+== Checks
+
+Some flambda properties cannot be enforced by the type (for instance
+that every variable used is bound). To help maintain such invariants
+and pinpoint quickly the culprit if a pass fails to maintain it, the
+special invariant checking pass `Flambda_invariants` is called between
+each transformation. If any new pass needs new invariants, a check for
+those should be added there.
+

--- a/middle_end/flambda_invariants.ml
+++ b/middle_end/flambda_invariants.ml
@@ -16,10 +16,6 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-type flambda_kind =
-  | Normal
-  | Lifted
-
 (* Explicit "ignore" functions.  We name every pattern variable, avoiding
    underscores, to try to avoid accidentally failing to handle (for example)
    a particular variable.
@@ -672,8 +668,7 @@ let _every_move_within_set_of_closures_is_to_a_function_in_the_free_vars
                          (fun_var, missing_dependencies)))
           funs)
 
-let check_exn ?(kind=Normal) ?(cmxfile=false) (flam:Flambda.program) =
-  ignore kind;
+let check_exn ?(cmxfile=false) (flam:Flambda.program) =
   try
     variable_and_symbol_invariants flam;
     no_closure_id_is_bound_multiple_times flam;

--- a/middle_end/flambda_invariants.mli
+++ b/middle_end/flambda_invariants.mli
@@ -16,14 +16,9 @@
 
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
-type flambda_kind =
-  | Normal
-  | Lifted
-
 (** Checking of invariants on Flambda expressions.  Raises an exception if
     a check fails. *)
 val check_exn
-   : ?kind:flambda_kind
-  -> ?cmxfile:bool
+   : ?cmxfile:bool
   -> Flambda.program
   -> unit


### PR DESCRIPTION
Following a discussion on the mailing list, I propose to try something: Ask questions about the code in flambda, and I will try to answer with documentation.

Let's see if this can work.

To answer a few questions that can't really be answered as comments:
- Flambda is a new intermediate language introduced in 4.03, enabled when the compiler is configured with the `-flambda` option. More general details are available in @yminsky post at https://blogs.janestreet.com/flambda/
- It is probably not possible to extend the language there, or if it were it would not be desirable: This is after the split between the bytecode and native code backend, hence a language feature implemented there wouldn't be available in bytecode or js_of_ocaml. It is only concerned with native code performances.
- It is reasonably easy to write a new optimization pass, I will add a 'quick start guide' in a `Hacking` file in the `middle-end` directory as suggested by @Drup. The overall code base can be quite overwhelming at first but I thing that it is possible to get a good idea of what is going on by looking only at few files.
- There is an non-compressible cost of traversing more code for flambda compared to closure, also the more 'regular' representation is less compact than the previous one. I'm not sure yet how much this is, but I'm quite certain that we are not there yet. `-Oclassic` can probably be quite close to the old mode, an `O1` (no option) can probably be made quite close (but still arbitrary longer in certain cases where it benefits a lot, like an almost empty module with a single functor instantiation). As an example, I compiled camlinternalFormat with flambda in `-Oclassic` ( I removed quite a lot of the pass that where completely negligible ):

```
../boot/ocamlrun ../ocamlopt -dtimings -strict-sequence -absname -w +a-4-9-41-42-44-45-48 -g -warn-error A -bin-annot -nostdlib -safe-string -strict-formats -Oclassic `./Compflags camlinternalFormat.cmx` -c camlinternalFormat.ml
all: 3.240s
typing(camlinternalFormat.ml): 1.304s
generate(camlinternalFormat.ml): 1.808s
flambda(closure_conversion)(sourcefile(camlinternalFormat.ml)): 0.068s
flambda(middle_end)(sourcefile(camlinternalFormat.ml)): 1.188s
flambda(lift_lets 1)(sourcefile(camlinternalFormat.ml)): 0.032s
flambda(Inline_and_simplify)(sourcefile(camlinternalFormat.ml)): 0.156s
flambda(Ref_to_variables)(sourcefile(camlinternalFormat.ml)): 0.016s
flambda(Remove_unused_closure_vars 2)(sourcefile(camlinternalFormat.ml)): 0.008s
flambda(Remove_unused_closure_vars)(sourcefile(camlinternalFormat.ml)): 0.012s
flambda(Lift_constants)(sourcefile(camlinternalFormat.ml)): 0.168s
flambda(Share_constants)(sourcefile(camlinternalFormat.ml)): 0.012s
flambda(check)(sourcefile(camlinternalFormat.ml)): 0.604s
flambda(backend)(sourcefile(camlinternalFormat.ml)): 0.032s
cmm(sourcefile(camlinternalFormat.ml)): 0.072s
compile_phrases(sourcefile(camlinternalFormat.ml)): 0.392s
cse(sourcefile(camlinternalFormat.ml)): 0.028s
selection(sourcefile(camlinternalFormat.ml)): 0.028s
spill(sourcefile(camlinternalFormat.ml)): 0.064s
regalloc(sourcefile(camlinternalFormat.ml)): 0.136s
```

We see that here the biggest flambda costs comes from the checks, followed lift_constants and inline_and_simplify. With a more agressive inlining inline_and_simplify is more expansive: in `O1`

```
flambda(Inline_and_simplify)(sourcefile(camlinternalFormat.ml)): 0.276s
flambda(Inline_and_simplify noinline)(sourcefile(camlinternalFormat.ml)): 0.108s
flambda(Lift_constants)(sourcefile(camlinternalFormat.ml)): 0.172s
flambda(check)(sourcefile(camlinternalFormat.ml)): 0.896s
```

So here we can of course gain quite a lot by disabling checks. I don't recommend doing that for 4.03 as this is the first release of flambda and I'd like to catch as much bugs with that as possible. We never really tried to make it really efficient, but this is probably not a good idea as this would probably make it quite unreadable, which would completely defeat the purpose.

I want to optimize Lift_constants during the next release. It is a quite intricate pass that allocates a lot of tables and maps and traverse the code multiple times. There is probably some reasonable optimizations there to do.

For Inline_and_simplify this is quite different: it has already been optimized quite a lot. But there is an inherent cost to traversing the code while maintaining some quite complex environment. It should be possible to improve it a bit by preventing allocations when the code doesn't change, but I fear this would cost too much in readability. But this should be acceptable. What can cost a lot more in there are the failed inlining attempts. It is possible to improve that by providing some more guiding heuristics to make the inliner more aggressive on some obviously right cases, and make it less aggressive in the general case.
