### PR TITLE
MPR#7189: toplevel #show, follow chains of module aliases

### DIFF
--- a/Changes
+++ b/Changes
@@ -52,6 +52,12 @@ OCaml 4.04.0:
 
 ### Tools:
 
+- MPR#7189: toplevel #show, follow chains of module aliases
+  (Gabriel Scherer, report by Daniel Bünzli, review by Thomas Refis)
+
+- MPR#7248: have ocamldep interpret -open arguments in left-to-right order
+  (Gabriel Scherer, report by Anton Bachin)
+
 - GPR#452: Make the output of ocamldep more stable
   (Alain Frisch)
 
@@ -61,9 +67,6 @@ OCaml 4.04.0:
 
 - GPR#613: make ocamldoc use -open arguments
   (Florian Angeletti)
-
-- MPR#7248: have ocamldep interpret -open arguments in left-to-right order
-  (Gabriel Scherer, report by Anton Bachin)
 
 - Add the -no-version option to the toplevel
   (Sébastien Hinderer)


### PR DESCRIPTION
[MPR#7189](http://caml.inria.fr/mantis/view.php?id=7189): toplevel #show, follow chains of module aliases

Before this patch,

```
module A = struct let x = 1 end;;
module B = struct module M = A end;;
module C = B.M;;
module D = C;;
#show D;;
```

would print

```
module D = C
```

now it prints

```
module D = C
module D = B.M
module D = A
module D : sig val x : int end
```

Note that one might expect to read

```
module D = C
module C = ...
```

instead, but this would result in the next line being

```
module B.M = ...
```

which is not syntactically correct.

Note that this approach could be generalized to other forms of
aliases-following, types in particular.
