### PR TITLE
Relax the invariant for tuple argument

### DIFF
--- a/parsing/ast_invariants.ml
+++ b/parsing/ast_invariants.ml
@@ -20,7 +20,7 @@ let err = Syntaxerr.ill_formed_ast
 
 let empty_record loc = err loc "Records cannot be empty."
 let empty_variant loc = err loc "Variant types cannot be empty."
-let invalid_tuple loc = err loc "Tuples must have at least 2 components."
+let invalid_tuple loc = err loc "Tuples must have at least 1 component."
 let no_args loc = err loc "Function application with no argument."
 let empty_let loc = err loc "Let with no bindings."
 let empty_type loc = err loc "Type declarations cannot be empty."
@@ -48,7 +48,7 @@ let iterator =
     super.typ self ty;
     let loc = ty.ptyp_loc in
     match ty.ptyp_desc with
-    | Ptyp_tuple ([] | [_]) -> invalid_tuple loc
+    | Ptyp_tuple ([]) -> invalid_tuple loc
     | Ptyp_class (id, _) -> simple_longident id
     | Ptyp_package (_, cstrs) ->
       List.iter (fun (id, _) -> simple_longident id) cstrs
@@ -58,7 +58,7 @@ let iterator =
     super.pat self pat;
     let loc = pat.ppat_loc in
     match pat.ppat_desc with
-    | Ppat_tuple ([] | [_]) -> invalid_tuple loc
+    | Ppat_tuple ([]) -> invalid_tuple loc
     | Ppat_record ([], _) -> empty_record loc
     | Ppat_construct (id, _) -> simple_longident id
     | Ppat_record (fields, _) ->
@@ -69,7 +69,7 @@ let iterator =
     super.expr self exp;
     let loc = exp.pexp_loc in
     match exp.pexp_desc with
-    | Pexp_tuple ([] | [_]) -> invalid_tuple loc
+    | Pexp_tuple ([]) -> invalid_tuple loc
     | Pexp_record ([], _) -> empty_record loc
     | Pexp_apply (_, []) -> no_args loc
     | Pexp_let (_, [], _) -> empty_let loc


### PR DESCRIPTION
The revised syntax (http://camlp5.gforge.inria.fr/doc/htmlc/revsynt.html) uses
`C 1 2` and `C (1, 2)` to differentiate a non-unary constructor from an unary constructor.

To differentiate `C (1, 2)` from `C 1 2`, camlp5 uses a trick that adds a superfluous tuple with "explicit_arity" to generate an AST like:

```
expression
  attribute "ocaml.explicit_arity"
  []
  Pexp_construct "Some"
  Some
    expression
      Pexp_tuple <-- * superflous tuple with only one item in it *
      [
        expression
          Pexp_tuple
          [
            expression
              Pexp_constant Const_int 1
            expression
              Pexp_constant Const_int 2
          ]
      ]
```

This works fine until 4.03, where a new invariant prevents tuples with a single argument
from being generated.

This diff relaxes the constraint to allow tuples to have single argument (mathematically this is called a "singleton"? ).

cc @kayceesrk @jordwalke @diml @chenglou
