### PR TITLE
Extended static exceptions for 4.05

### DIFF
--- a/asmcomp/CSEgen.ml
+++ b/asmcomp/CSEgen.ml
@@ -349,9 +349,11 @@ method private cse n i =
   | Iloop(body) ->
       {i with desc = Iloop(self#cse empty_numbering body);
               next = self#cse empty_numbering i.next}
-  | Icatch(nfail, body, handler) ->
-      {i with desc = Icatch(nfail, self#cse n body,
-                            self#cse empty_numbering handler);
+  | Icatch(handlers, body) ->
+      let aux (nfail, handler) =
+        nfail, self#cse empty_numbering handler
+      in
+      {i with desc = Icatch(List.map aux handlers, self#cse n body);
               next = self#cse empty_numbering i.next}
   | Itrywith(body, handler) ->
       {i with desc = Itrywith(self#cse n body,

--- a/asmcomp/CSEgen.ml
+++ b/asmcomp/CSEgen.ml
@@ -349,11 +349,11 @@ method private cse n i =
   | Iloop(body) ->
       {i with desc = Iloop(self#cse empty_numbering body);
               next = self#cse empty_numbering i.next}
-  | Icatch(handlers, body) ->
+  | Icatch(rec_flag, handlers, body) ->
       let aux (nfail, handler) =
         nfail, self#cse empty_numbering handler
       in
-      {i with desc = Icatch(List.map aux handlers, self#cse n body);
+      {i with desc = Icatch(rec_flag, List.map aux handlers, self#cse n body);
               next = self#cse empty_numbering i.next}
   | Itrywith(body, handler) ->
       {i with desc = Itrywith(self#cse n body,

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -167,7 +167,7 @@ type expression =
   | Cifthenelse of expression * expression * expression
   | Cswitch of expression * int array * expression array * Debuginfo.t
   | Cloop of expression
-  | Ccatch of int * Ident.t list * expression * expression
+  | Ccatch of (int * Ident.t list * expression) list * expression
   | Cexit of int * expression list
   | Ctrywith of expression * Ident.t * expression
 
@@ -196,6 +196,9 @@ type data_item =
 type phrase =
     Cfunction of fundecl
   | Cdata of data_item list
+
+let ccatch (i, ids, e1, e2)=
+  Ccatch([i, ids, e2], e1)
 
 let reset () =
   label_counter := 99

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -117,6 +117,8 @@ type raise_kind =
   | Raise_withtrace
   | Raise_notrace
 
+type rec_flag = Nonrecursive | Recursive
+
 type memory_chunk =
     Byte_unsigned
   | Byte_signed
@@ -167,7 +169,7 @@ type expression =
   | Cifthenelse of expression * expression * expression
   | Cswitch of expression * int array * expression array * Debuginfo.t
   | Cloop of expression
-  | Ccatch of (int * Ident.t list * expression) list * expression
+  | Ccatch of rec_flag * (int * Ident.t list * expression) list * expression
   | Cexit of int * expression list
   | Ctrywith of expression * Ident.t * expression
 
@@ -198,7 +200,7 @@ type phrase =
   | Cdata of data_item list
 
 let ccatch (i, ids, e1, e2)=
-  Ccatch([i, ids, e2], e1)
+  Ccatch(Nonrecursive, [i, ids, e2], e1)
 
 let reset () =
   label_counter := 99

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -143,7 +143,7 @@ and expression =
   | Cifthenelse of expression * expression * expression
   | Cswitch of expression * int array * expression array * Debuginfo.t
   | Cloop of expression
-  | Ccatch of int * Ident.t list * expression * expression
+  | Ccatch of (int * Ident.t list * expression) list * expression
   | Cexit of int * expression list
   | Ctrywith of expression * Ident.t * expression
 
@@ -172,5 +172,7 @@ type data_item =
 type phrase =
     Cfunction of fundecl
   | Cdata of data_item list
+
+val ccatch : int * Ident.t list * expression * expression -> expression
 
 val reset : unit -> unit

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -90,6 +90,8 @@ type raise_kind =
   | Raise_withtrace
   | Raise_notrace
 
+type rec_flag = Nonrecursive | Recursive
+
 type memory_chunk =
     Byte_unsigned
   | Byte_signed
@@ -143,7 +145,7 @@ and expression =
   | Cifthenelse of expression * expression * expression
   | Cswitch of expression * int array * expression array * Debuginfo.t
   | Cloop of expression
-  | Ccatch of (int * Ident.t list * expression) list * expression
+  | Ccatch of rec_flag * (int * Ident.t list * expression) list * expression
   | Cexit of int * expression list
   | Ctrywith of expression * Ident.t * expression
 

--- a/asmcomp/comballoc.ml
+++ b/asmcomp/comballoc.ml
@@ -77,11 +77,12 @@ let rec combine i allocstate =
       let newbody = combine_restart body in
       (instr_cons (Iloop(newbody)) i.arg i.res i.next,
        allocated_size allocstate)
-  | Icatch(io, body, handler) ->
+  | Icatch(handlers, body) ->
       let (newbody, sz) = combine body allocstate in
-      let newhandler = combine_restart handler in
+      let newhandlers =
+        List.map (fun (io, handler) -> io, combine_restart handler) handlers in
       let newnext = combine_restart i.next in
-      (instr_cons (Icatch(io, newbody, newhandler)) i.arg i.res newnext, sz)
+      (instr_cons (Icatch(newhandlers, newbody)) i.arg i.res newnext, sz)
   | Itrywith(body, handler) ->
       let (newbody, sz) = combine body allocstate in
       let newhandler = combine_restart handler in

--- a/asmcomp/comballoc.ml
+++ b/asmcomp/comballoc.ml
@@ -77,12 +77,13 @@ let rec combine i allocstate =
       let newbody = combine_restart body in
       (instr_cons (Iloop(newbody)) i.arg i.res i.next,
        allocated_size allocstate)
-  | Icatch(handlers, body) ->
+  | Icatch(rec_flag, handlers, body) ->
       let (newbody, sz) = combine body allocstate in
       let newhandlers =
         List.map (fun (io, handler) -> io, combine_restart handler) handlers in
       let newnext = combine_restart i.next in
-      (instr_cons (Icatch(newhandlers, newbody)) i.arg i.res newnext, sz)
+      (instr_cons (Icatch(rec_flag, newhandlers, newbody))
+         i.arg i.res newnext, sz)
   | Itrywith(body, handler) ->
       let (newbody, sz) = combine body allocstate in
       let newhandler = combine_restart handler in

--- a/asmcomp/deadcode.ml
+++ b/asmcomp/deadcode.ml
@@ -58,7 +58,7 @@ let rec deadcode i =
       let (body', _) = deadcode body in
       let (s, _) = deadcode i.next in
       ({i with desc = Iloop body'; next = s}, i.live)
-  | Icatch(handlers, body) ->
+  | Icatch(rec_flag, handlers, body) ->
       let (body', _) = deadcode body in
       let handlers' =
         List.map (fun (nfail, handler) ->
@@ -67,7 +67,7 @@ let rec deadcode i =
           handlers
       in
       let (s, _) = deadcode i.next in
-      ({i with desc = Icatch(handlers', body'); next = s}, i.live)
+      ({i with desc = Icatch(rec_flag, handlers', body'); next = s}, i.live)
   | Iexit _nfail ->
       (i, i.live)
   | Itrywith(body, handler) ->

--- a/asmcomp/deadcode.ml
+++ b/asmcomp/deadcode.ml
@@ -58,12 +58,17 @@ let rec deadcode i =
       let (body', _) = deadcode body in
       let (s, _) = deadcode i.next in
       ({i with desc = Iloop body'; next = s}, i.live)
-  | Icatch(nfail, body, handler) ->
+  | Icatch(handlers, body) ->
       let (body', _) = deadcode body in
-      let (handler', _) = deadcode handler in
+      let handlers' =
+        List.map (fun (nfail, handler) ->
+            let (handler', _) = deadcode handler in
+            nfail, handler')
+          handlers
+      in
       let (s, _) = deadcode i.next in
-      ({i with desc = Icatch(nfail, body', handler'); next = s}, i.live)
-  | Iexit _ ->
+      ({i with desc = Icatch(handlers', body'); next = s}, i.live)
+  | Iexit _nfail ->
       (i, i.live)
   | Itrywith(body, handler) ->
       let (body', _) = deadcode body in

--- a/asmcomp/interf.ml
+++ b/asmcomp/interf.ml
@@ -107,7 +107,7 @@ let build_graph fundecl =
         interf i.next
     | Iloop body ->
         interf body; interf i.next
-    | Icatch(handlers, body) ->
+    | Icatch(_rec_flag, handlers, body) ->
         interf body;
         List.iter (fun (_, handler) -> interf handler) handlers;
         interf i.next
@@ -147,7 +147,6 @@ let build_graph fundecl =
       let r = arg.(i) in r.spill_cost <- r.spill_cost + cost
     done in
 
-  let recursive_handlers = Mach.recursive_handlers fundecl.fun_body in
   (* Compute preferences and spill costs *)
 
   let rec prefer weight i =
@@ -182,17 +181,16 @@ let build_graph fundecl =
         (* Avoid overflow of weight and spill_cost *)
         prefer (if weight < 1000 then 8 * weight else weight) body;
         prefer weight i.next
-    | Icatch(handlers, body) ->
+    | Icatch(rec_flag, handlers, body) ->
         prefer weight body;
-        List.iter (fun (nfail, handler) ->
+        List.iter (fun (_nfail, handler) ->
             let weight =
-              if Numbers.Int.Set.mem nfail recursive_handlers
-              then
-                (* Avoid overflow of weight and spill_cost *)
-                if weight < 1000 then 8 * weight else weight
-              else
-                (* TODO: reduce weight of non mandatory branches *)
-                weight in
+              match rec_flag with
+              | Cmm.Recursive ->
+                  (* Avoid overflow of weight and spill_cost *)
+                  if weight < 1000 then 8 * weight else weight
+              | Cmm.Nonrecursive ->
+                  weight in
             prefer weight handler) handlers;
         prefer weight i.next
     | Iexit _ ->

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -255,21 +255,24 @@ let rec linear i n =
       cons_instr (Llabel lbl_head) n2
   | Icatch(handlers, body) ->
       let (lbl_end, n1) = get_label(linear i.Mach.next n) in
-      let labels = List.map (fun (_io, handler) ->
+      (* CR mshinwell for pchambart:
+         1. rename "io"
+         2. Make sure the test cases cover the "Iend" cases too *)
+      let labels_at_entry_to_handlers = List.map (fun (_io, handler) ->
           match handler.Mach.desc with
           | Iend -> lbl_end
           | _ -> Cmm.new_label ())
           handlers in
       let exit_label_add = List.map2
           (fun (io, _) lbl -> (io, (lbl, !try_depth)))
-          handlers labels in
+          handlers labels_at_entry_to_handlers in
       let previous_exit_label = !exit_label in
       exit_label := exit_label_add @ !exit_label;
       let n2 = List.fold_left2 (fun n (_io, handler) lbl_handler ->
           match handler.Mach.desc with
           | Iend -> n
           | _ -> cons_instr (Llabel lbl_handler) (linear handler n))
-          n1 handlers labels
+          n1 handlers labels_at_entry_to_handlers
       in
       let n3 = linear body (add_branch lbl_end n2) in
       exit_label := previous_exit_label;

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -253,12 +253,26 @@ let rec linear i n =
       let n1 = linear i.Mach.next n in
       let n2 = linear body (cons_instr (Lbranch lbl_head) n1) in
       cons_instr (Llabel lbl_head) n2
-  | Icatch(io, body, handler) ->
+  | Icatch(handlers, body) ->
       let (lbl_end, n1) = get_label(linear i.Mach.next n) in
-      let (lbl_handler, n2) = get_label(linear handler n1) in
-      exit_label := (io, (lbl_handler, !try_depth)) :: !exit_label ;
+      let labels = List.map (fun (_io, handler) ->
+          match handler.Mach.desc with
+          | Iend -> lbl_end
+          | _ -> Cmm.new_label ())
+          handlers in
+      let exit_label_add = List.map2
+          (fun (io, _) lbl -> (io, (lbl, !try_depth)))
+          handlers labels in
+      let previous_exit_label = !exit_label in
+      exit_label := exit_label_add @ !exit_label;
+      let n2 = List.fold_left2 (fun n (_io, handler) lbl_handler ->
+          match handler.Mach.desc with
+          | Iend -> n
+          | _ -> cons_instr (Llabel lbl_handler) (linear handler n))
+          n1 handlers labels
+      in
       let n3 = linear body (add_branch lbl_end n2) in
-      exit_label := List.tl !exit_label;
+      exit_label := previous_exit_label;
       n3
   | Iexit nfail ->
       let lbl, t = find_exit_label_try_depth nfail in

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -258,17 +258,17 @@ let rec linear i n =
       (* CR mshinwell for pchambart:
          1. rename "io"
          2. Make sure the test cases cover the "Iend" cases too *)
-      let labels_at_entry_to_handlers = List.map (fun (_io, handler) ->
+      let labels_at_entry_to_handlers = List.map (fun (_nfail, handler) ->
           match handler.Mach.desc with
           | Iend -> lbl_end
           | _ -> Cmm.new_label ())
           handlers in
       let exit_label_add = List.map2
-          (fun (io, _) lbl -> (io, (lbl, !try_depth)))
+          (fun (nfail, _) lbl -> (nfail, (lbl, !try_depth)))
           handlers labels_at_entry_to_handlers in
       let previous_exit_label = !exit_label in
       exit_label := exit_label_add @ !exit_label;
-      let n2 = List.fold_left2 (fun n (_io, handler) lbl_handler ->
+      let n2 = List.fold_left2 (fun n (_nfail, handler) lbl_handler ->
           match handler.Mach.desc with
           | Iend -> n
           | _ -> cons_instr (Llabel lbl_handler) (linear handler n))

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -253,7 +253,7 @@ let rec linear i n =
       let n1 = linear i.Mach.next n in
       let n2 = linear body (cons_instr (Lbranch lbl_head) n1) in
       cons_instr (Llabel lbl_head) n2
-  | Icatch(handlers, body) ->
+  | Icatch(_rec_flag, handlers, body) ->
       let (lbl_end, n1) = get_label(linear i.Mach.next n) in
       (* CR mshinwell for pchambart:
          1. rename "io"

--- a/asmcomp/liveness.ml
+++ b/asmcomp/liveness.ml
@@ -105,42 +105,42 @@ let rec live i finally =
       !at_top
   | Icatch(handlers, body) ->
       let at_join = live i.next finally in
-
       let aux (nfail,handler) (nfail', before_handler) =
         assert(nfail = nfail');
         let before_handler' = live handler at_join in
-        nfail, Reg.Set.union before_handler before_handler' in
-
+        nfail, Reg.Set.union before_handler before_handler'
+      in
       let aux_equal (nfail, before_handler) (nfail', before_handler') =
         assert(nfail = nfail');
-        Reg.Set.equal before_handler before_handler' in
-
+        Reg.Set.equal before_handler before_handler'
+      in
       let live_at_exit_before = !live_at_exit in
-
       let live_at_exit_add before_handlers =
         List.map (fun (nfail, before_handler) ->
             (nfail, (ref false, before_handler)))
-          before_handlers in
-
+          before_handlers
+      in
       let rec fixpoint before_handlers =
         let live_at_exit_add = live_at_exit_add before_handlers in
         live_at_exit := live_at_exit_add @ !live_at_exit;
         let before_handlers' = List.map2 aux handlers before_handlers in
         live_at_exit := live_at_exit_before;
+        (* [used] is there to stop behaviour exponential in the nesting depth
+           of static-catch constructs in the simple cases (where only one
+           iteration is required to reach a fixpoint). *)
         let not_used = List.for_all
-            (fun (_,(used,_)) -> not !used) live_at_exit_add in
+            (fun (_, (used, _)) -> not !used) live_at_exit_add in
         if not_used || List.for_all2 aux_equal before_handlers before_handlers'
         then before_handlers'
         else fixpoint before_handlers'
       in
-
       let init_state =
-        List.map (fun (nfail, _handler) -> nfail, Reg.Set.empty) handlers in
+        List.map (fun (nfail, _handler) -> nfail, Reg.Set.empty) handlers
+      in
       let before_handler = fixpoint init_state in
-      (* We could use handler.live instead of Reg.Set.empty as the initialisation
-         but we would need to clean the live field before doing the analysis
-         (to remove remaining of previous passes) *)
-
+      (* We could use handler.live instead of Reg.Set.empty as the initial
+         value but we would need to clean the live field before doing the
+         analysis (to remove remnants of previous passes). *)
       live_at_exit := (live_at_exit_add before_handler) @ !live_at_exit;
       let before_body = live body at_join in
       live_at_exit := live_at_exit_before;

--- a/asmcomp/liveness.ml
+++ b/asmcomp/liveness.ml
@@ -22,7 +22,9 @@ let live_at_exit = ref []
 
 let find_live_at_exit k =
   try
-    List.assoc k !live_at_exit
+    let (used, set) = List.assoc k !live_at_exit in
+    used := true;
+    set
   with
   | Not_found -> Misc.fatal_error "Liveness.find_live_at_exit"
 
@@ -101,14 +103,47 @@ let rec live i finally =
       end;
       i.live <- !at_top;
       !at_top
-  | Icatch(nfail, body, handler) ->
+  | Icatch(handlers, body) ->
       let at_join = live i.next finally in
-      let before_handler = live handler at_join in
-      let before_body =
-          live_at_exit := (nfail,before_handler) :: !live_at_exit ;
-          let before_body = live body at_join in
-          live_at_exit := List.tl !live_at_exit ;
-          before_body in
+
+      let aux (nfail,handler) (nfail', before_handler) =
+        assert(nfail = nfail');
+        let before_handler' = live handler at_join in
+        nfail, Reg.Set.union before_handler before_handler' in
+
+      let aux_equal (nfail, before_handler) (nfail', before_handler') =
+        assert(nfail = nfail');
+        Reg.Set.equal before_handler before_handler' in
+
+      let live_at_exit_before = !live_at_exit in
+
+      let live_at_exit_add before_handlers =
+        List.map (fun (nfail, before_handler) ->
+            (nfail, (ref false, before_handler)))
+          before_handlers in
+
+      let rec fixpoint before_handlers =
+        let live_at_exit_add = live_at_exit_add before_handlers in
+        live_at_exit := live_at_exit_add @ !live_at_exit;
+        let before_handlers' = List.map2 aux handlers before_handlers in
+        live_at_exit := live_at_exit_before;
+        let not_used = List.for_all
+            (fun (_,(used,_)) -> not !used) live_at_exit_add in
+        if not_used || List.for_all2 aux_equal before_handlers before_handlers'
+        then before_handlers'
+        else fixpoint before_handlers'
+      in
+
+      let init_state =
+        List.map (fun (nfail, _handler) -> nfail, Reg.Set.empty) handlers in
+      let before_handler = fixpoint init_state in
+      (* We could use handler.live instead of Reg.Set.empty as the initialisation
+         but we would need to clean the live field before doing the analysis
+         (to remove remaining of previous passes) *)
+
+      live_at_exit := (live_at_exit_add before_handler) @ !live_at_exit;
+      let before_body = live body at_join in
+      live_at_exit := live_at_exit_before;
       i.live <- before_body;
       before_body
   | Iexit nfail ->

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -75,7 +75,7 @@ and instruction_desc =
   | Iifthenelse of test * instruction * instruction
   | Iswitch of int array * instruction array
   | Iloop of instruction
-  | Icatch of int * instruction * instruction
+  | Icatch of (int * instruction) list * instruction
   | Iexit of int
   | Itrywith of instruction * instruction
   | Iraise of Cmm.raise_kind
@@ -136,8 +136,10 @@ let rec instr_iter f i =
           instr_iter f i.next
       | Iloop(body) ->
           instr_iter f body; instr_iter f i.next
-      | Icatch(_, body, handler) ->
-          instr_iter f body; instr_iter f handler; instr_iter f i.next
+      | Icatch(handlers, body) ->
+          instr_iter f body;
+          List.iter (fun (_n, handler) -> instr_iter f handler) handlers;
+          instr_iter f i.next
       | Iexit _ -> ()
       | Itrywith(body, handler) ->
           instr_iter f body; instr_iter f handler; instr_iter f i.next
@@ -177,3 +179,59 @@ let spacetime_node_hole_pointer_is_live_before insn =
     end
   | Iend | Ireturn | Iifthenelse _ | Iswitch _ | Iloop _ | Icatch _
   | Iexit _ | Itrywith _ | Iraise _ -> false
+
+module LabelSet = Numbers.Int.Set
+
+type result =
+  { reachable_exits : LabelSet.t;
+    recursive_handlers : LabelSet.t }
+
+let empty_result =
+  { reachable_exits = LabelSet.empty;
+    recursive_handlers = LabelSet.empty }
+
+let result_union r1 r2 =
+  { reachable_exits =
+      LabelSet.union r1.reachable_exits r2.reachable_exits;
+    recursive_handlers =
+      LabelSet.union r1.recursive_handlers r2.recursive_handlers }
+
+let recursive_handlers i =
+  let rec loop i =
+    match i.desc with
+      Iend -> empty_result
+    | Ireturn | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) -> empty_result
+    | Iraise _ -> empty_result
+    | Iifthenelse(_tst, ifso, ifnot) ->
+        result_union
+          (result_union (loop ifso) (loop ifnot))
+          (loop i.next)
+    | Iswitch(_index, cases) ->
+        Array.fold_left (fun acc case -> result_union acc (loop case))
+          (loop i.next) cases
+    | Iloop body ->
+        result_union (loop body) (loop i.next)
+    | Icatch(handlers, body) ->
+        let r =
+          List.fold_left (fun acc (nfail, handler) ->
+              let acc = result_union acc (loop handler) in
+              if LabelSet.mem nfail acc.reachable_exits
+              then { acc with
+                     recursive_handlers =
+                       LabelSet.add nfail acc.recursive_handlers }
+              else acc)
+            empty_result handlers
+        in
+        result_union r
+          (result_union (loop body) (loop i.next))
+    | Iexit n ->
+        { empty_result with
+          reachable_exits = LabelSet.singleton n }
+    | Itrywith(body, handler) ->
+        result_union
+          (result_union (loop body) (loop handler))
+          (loop i.next)
+    | Iop _ ->
+        loop i.next
+  in
+  (loop i).recursive_handlers

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -124,4 +124,6 @@ val instr_iter: (instruction -> unit) -> instruction -> unit
 
 val spacetime_node_hole_pointer_is_live_before : instruction -> bool
 
+(* CR mshinwell: change Icatch to have a record, then simplify this
+   function *)
 val recursive_handlers: instruction -> Numbers.Int.Set.t

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -85,7 +85,7 @@ and instruction_desc =
   | Iifthenelse of test * instruction * instruction
   | Iswitch of int array * instruction array
   | Iloop of instruction
-  | Icatch of (int * instruction) list * instruction
+  | Icatch of Cmm.rec_flag * (int * instruction) list * instruction
   | Iexit of int
   | Itrywith of instruction * instruction
   | Iraise of Cmm.raise_kind
@@ -123,7 +123,3 @@ val instr_cons_debug:
 val instr_iter: (instruction -> unit) -> instruction -> unit
 
 val spacetime_node_hole_pointer_is_live_before : instruction -> bool
-
-(* CR mshinwell: change Icatch to have a record, then simplify this
-   function *)
-val recursive_handlers: instruction -> Numbers.Int.Set.t

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -85,7 +85,7 @@ and instruction_desc =
   | Iifthenelse of test * instruction * instruction
   | Iswitch of int array * instruction array
   | Iloop of instruction
-  | Icatch of int * instruction * instruction
+  | Icatch of (int * instruction) list * instruction
   | Iexit of int
   | Itrywith of instruction * instruction
   | Iraise of Cmm.raise_kind
@@ -123,3 +123,5 @@ val instr_cons_debug:
 val instr_iter: (instruction -> unit) -> instruction -> unit
 
 val spacetime_node_hole_pointer_is_live_before : instruction -> bool
+
+val recursive_handlers: instruction -> Numbers.Int.Set.t

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -18,6 +18,10 @@
 open Format
 open Cmm
 
+let rec_flag ppf = function
+  | Nonrecursive -> ()
+  | Recursive -> fprintf ppf " rec"
+
 let machtype_component ppf = function
   | Val -> fprintf ppf "val"
   | Addr -> fprintf ppf "addr"
@@ -161,7 +165,7 @@ let rec expr ppf = function
       fprintf ppf "@[<v 0>@[<2>(switch@ %a@ @]%t)@]" expr e1 print_cases
   | Cloop e ->
       fprintf ppf "@[<2>(loop@ %a)@]" sequence e
-  | Ccatch(handlers, e1) ->
+  | Ccatch(flag, handlers, e1) ->
       let print_handler ppf (i, ids, e2) =
         fprintf ppf "(%d%a)@ %a"
           i
@@ -175,7 +179,8 @@ let rec expr ppf = function
         List.iter (print_handler ppf) l
       in
       fprintf ppf
-        "@[<2>(catch@ %a@;<1 -2>with%a)@]"
+        "@[<2>(catch%a@ %a@;<1 -2>with%a)@]"
+        rec_flag flag
         sequence e1
         print_handlers handlers
   | Cexit (i, el) ->

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -161,17 +161,25 @@ let rec expr ppf = function
       fprintf ppf "@[<v 0>@[<2>(switch@ %a@ @]%t)@]" expr e1 print_cases
   | Cloop e ->
       fprintf ppf "@[<2>(loop@ %a)@]" sequence e
-  | Ccatch(i, ids, e1, e2) ->
+  | Ccatch(handlers, e1) ->
+      let print_handler ppf (i, ids, e2) =
+        fprintf ppf "(%d%a)@ %a"
+          i
+          (fun ppf ids ->
+             List.iter
+               (fun id -> fprintf ppf " %a" Ident.print id)
+               ids) ids
+          sequence e2
+      in
+      let print_handlers ppf l =
+        List.iter (print_handler ppf) l
+      in
       fprintf ppf
-        "@[<2>(catch@ %a@;<1 -2>with(%d%a)@ %a)@]"
-        sequence e1 i
-        (fun ppf ids ->
-          List.iter
-            (fun id -> fprintf ppf " %a" Ident.print id)
-            ids) ids
-        sequence e2
+        "@[<2>(catch@ %a@;<1 -2>with%a)@]"
+        sequence e1
+        print_handlers handlers
   | Cexit (i, el) ->
-      fprintf ppf "@[<2>(exit %d" i ;
+      fprintf ppf "@[<2>(exit %d" i;
       List.iter (fun e -> fprintf ppf "@ %a" expr e) el;
       fprintf ppf ")@]"
   | Ctrywith(e1, id, e2) ->

--- a/asmcomp/printcmm.mli
+++ b/asmcomp/printcmm.mli
@@ -17,6 +17,7 @@
 
 open Format
 
+val rec_flag : formatter -> Cmm.rec_flag -> unit
 val machtype_component : formatter -> Cmm.machtype_component -> unit
 val machtype : formatter -> Cmm.machtype_component array -> unit
 val comparison : Cmm.comparison -> string

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -190,10 +190,19 @@ let rec instr ppf i =
       fprintf ppf "@,endswitch"
   | Iloop(body) ->
       fprintf ppf "@[<v 2>loop@,%a@;<0 -2>endloop@]" instr body
-  | Icatch(i, body, handler) ->
-      fprintf
-        ppf "@[<v 2>catch@,%a@;<0 -2>with(%d)@,%a@;<0 -2>endcatch@]"
-        instr body i instr handler
+  | Icatch(handlers, body) ->
+      fprintf ppf "@[<v 2>catch@,%a@;<0 -2>with" instr body;
+      let h (nfail, handler) =
+        fprintf ppf "(%d)@,%a@;" nfail instr handler in
+      let rec aux = function
+        | [] -> ()
+        | [v] -> h v
+        | v :: t ->
+            h v;
+            fprintf ppf "@ and";
+            aux t
+      in
+      aux handlers
   | Iexit i ->
       fprintf ppf "exit(%d)" i
   | Itrywith(body, handler) ->

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -190,8 +190,9 @@ let rec instr ppf i =
       fprintf ppf "@,endswitch"
   | Iloop(body) ->
       fprintf ppf "@[<v 2>loop@,%a@;<0 -2>endloop@]" instr body
-  | Icatch(handlers, body) ->
-      fprintf ppf "@[<v 2>catch@,%a@;<0 -2>with" instr body;
+  | Icatch(flag, handlers, body) ->
+      fprintf ppf "@[<v 2>catch%a@,%a@;<0 -2>with"
+        Printcmm.rec_flag flag instr body;
       let h (nfail, handler) =
         fprintf ppf "(%d)@,%a@;" nfail instr handler in
       let rec aux = function

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -112,9 +112,12 @@ method private reload i =
           (self#reload i.next))
   | Iloop body ->
       instr_cons (Iloop(self#reload body)) [||] [||] (self#reload i.next)
-  | Icatch(nfail, body, handler) ->
+  | Icatch(handlers, body) ->
+      let new_handlers = List.map
+          (fun (nfail, handler) -> nfail, self#reload handler)
+          handlers in
       instr_cons
-        (Icatch(nfail, self#reload body, self#reload handler)) [||] [||]
+        (Icatch(new_handlers, self#reload body)) [||] [||]
         (self#reload i.next)
   | Iexit i ->
       instr_cons (Iexit i) [||] [||] dummy_instr

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -112,12 +112,12 @@ method private reload i =
           (self#reload i.next))
   | Iloop body ->
       instr_cons (Iloop(self#reload body)) [||] [||] (self#reload i.next)
-  | Icatch(handlers, body) ->
+  | Icatch(rec_flag, handlers, body) ->
       let new_handlers = List.map
           (fun (nfail, handler) -> nfail, self#reload handler)
           handlers in
       instr_cons
-        (Icatch(new_handlers, self#reload body)) [||] [||]
+        (Icatch(rec_flag, new_handlers, self#reload body)) [||] [||]
         (self#reload i.next)
   | Iexit i ->
       instr_cons (Iexit i) [||] [||] dummy_instr

--- a/asmcomp/selectgen.mli
+++ b/asmcomp/selectgen.mli
@@ -16,7 +16,11 @@
 (* Selection of pseudo-instructions, assignment of pseudo-registers,
    sequentialization. *)
 
-type environment = (Ident.t, Reg.t array) Tbl.t
+type environment
+
+val env_add : Ident.t -> Reg.t array -> environment -> environment
+
+val env_find : Ident.t -> environment -> Reg.t array
 
 val size_expr : environment -> Cmm.expression -> int
 
@@ -107,34 +111,35 @@ class virtual selector_generic : object
   method adjust_type : Reg.t -> Reg.t -> unit
   method adjust_types : Reg.t array -> Reg.t array -> unit
   method emit_expr :
-    (Ident.t, Reg.t array) Tbl.t -> Cmm.expression -> Reg.t array option
-  method emit_tail : (Ident.t, Reg.t array) Tbl.t -> Cmm.expression -> unit
+    environment -> Cmm.expression -> Reg.t array option
+  method emit_tail : environment -> Cmm.expression -> unit
 
   (* Only for the use of [Spacetime_profiling]. *)
   method select_allocation : int -> Mach.operation
-  method select_allocation_args : (Ident.t, Reg.t array) Tbl.t -> Reg.t array
+  method select_allocation_args : environment -> Reg.t array
   method select_checkbound : unit -> Mach.integer_operation
   method select_checkbound_extra_args : unit -> Cmm.expression list
   method emit_blockheader
-     : (Ident.t, Reg.t array) Tbl.t
+     : environment
     -> nativeint
     -> Debuginfo.t
     -> Reg.t array option
   method about_to_emit_call
-     : (Ident.t, Reg.t array) Tbl.t
+     : environment
     -> Mach.instruction_desc
     -> Reg.t array
     -> Reg.t array option
-  method initial_env : unit -> (Ident.t, Reg.t array) Tbl.t
+  method initial_env : unit -> environment
   method insert_prologue
      : Cmm.fundecl
     -> loc_arg:Reg.t array
     -> rarg:Reg.t array
     -> spacetime_node_hole:(Ident.t * Reg.t array) option
-    -> env:(Ident.t, Reg.t array) Tbl.t
+    -> env:environment
     -> Mach.spacetime_shape option
 
   val mutable instr_seq : Mach.instruction
+
 end
 
 val reset : unit -> unit

--- a/asmcomp/spacetime_profiling.ml
+++ b/asmcomp/spacetime_profiling.ml
@@ -254,7 +254,7 @@ class virtual instruction_selection = object (self)
     (* [callee] is a pseudoregister, so we have to bind it in the environment
        and reference the variable to which it is bound. *)
     let callee_ident = Ident.create "callee" in
-    let env = Tbl.add callee_ident [| callee |] env in
+    let env = Selectgen.env_add callee_ident [| callee |] env in
     let instrumentation =
       code_for_call
         ~node:(Lazy.force !spacetime_node)
@@ -320,7 +320,7 @@ class virtual instruction_selection = object (self)
       in
       disable_instrumentation <- false;
       let node = Lazy.force !spacetime_node_ident in
-      let node_reg = Tbl.find node env in
+      let node_reg = Selectgen.env_find node env in
       self#insert_moves node_temp_reg node_reg
     end
 
@@ -356,7 +356,7 @@ class virtual instruction_selection = object (self)
 
   method! select_allocation_args env =
     if self#can_instrument () then begin
-      let regs = Tbl.find (Lazy.force !spacetime_node_ident) env in
+      let regs = Selectgen.env_find (Lazy.force !spacetime_node_ident) env in
       match regs with
       | [| reg |] -> [| reg |]
       | _ -> failwith "Expected one register only for spacetime_node_ident"
@@ -393,7 +393,8 @@ class virtual instruction_selection = object (self)
   method! initial_env () =
     let env = super#initial_env () in
     if Config.spacetime then
-      Tbl.add (Lazy.force !spacetime_node_ident) (self#regs_for Cmm.typ_int) env
+      Selectgen.env_add (Lazy.force !spacetime_node_ident)
+        (self#regs_for Cmm.typ_int) env
     else
       env
 

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -231,6 +231,9 @@ let rec reload i before =
           List.map2 (fun (nfail', handler) (nfail, at_exit) ->
               assert(nfail = nfail');
               reload handler at_exit) handlers at_exits in
+        (* CR mshinwell for pchambart: This should have the "used" thing to
+           stop exponential behaviour.  Also reference the comment about
+           "used" that's now in liveness.ml. *)
         let equal = List.for_all2 (fun (nfail', at_exit) (nfail, new_set) ->
             assert(nfail = nfail');
             Reg.Set.equal at_exit !new_set)
@@ -283,6 +286,8 @@ let rec reload i before =
    NB ter: is it the same thing for catch bodies ?
 *)
 
+(* CR mshinwell for pchambart: Try to test the new algorithms for dealing
+   with Icatch. *)
 
 let spill_at_exit = ref []
 let find_spill_at_exit k =

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -219,16 +219,35 @@ let rec reload i before =
       let (new_next, finally) = reload i.next Reg.Set.empty in
       (instr_cons (Iloop(!final_body)) i.arg i.res new_next,
        finally)
-  | Icatch(nfail, body, handler) ->
-      let new_set = ref Reg.Set.empty in
-      reload_at_exit := (nfail, new_set) :: !reload_at_exit ;
+  | Icatch(handlers, body) ->
+      let new_sets = List.map
+          (fun (nfail, _) -> nfail, ref Reg.Set.empty) handlers in
+      let previous_reload_at_exit = !reload_at_exit in
+      reload_at_exit := new_sets @ !reload_at_exit ;
       let (new_body, after_body) = reload body before in
-      let at_exit = !new_set in
-      reload_at_exit := List.tl !reload_at_exit ;
-      let (new_handler, after_handler) = reload handler at_exit in
-      let (new_next, finally) =
-        reload i.next (Reg.Set.union after_body after_handler) in
-      (instr_cons (Icatch(nfail, new_body, new_handler)) i.arg i.res new_next,
+      let rec fixpoint () =
+        let at_exits = List.map (fun (nfail, set) -> (nfail, !set)) new_sets in
+        let res =
+          List.map2 (fun (nfail', handler) (nfail, at_exit) ->
+              assert(nfail = nfail');
+              reload handler at_exit) handlers at_exits in
+        let equal = List.for_all2 (fun (nfail', at_exit) (nfail, new_set) ->
+            assert(nfail = nfail');
+            Reg.Set.equal at_exit !new_set)
+            at_exits new_sets in
+        if equal
+        then res
+        else fixpoint () in
+      let res = fixpoint () in
+      reload_at_exit := previous_reload_at_exit;
+      let union = List.fold_left
+          (fun acc (_, after_handler) -> Reg.Set.union acc after_handler)
+          after_body res in
+      let (new_next, finally) = reload i.next union in
+      let new_handlers = List.map2
+          (fun (nfail, _) (new_handler, _) -> nfail, new_handler)
+          handlers res in
+      (instr_cons (Icatch(new_handlers, new_body)) i.arg i.res new_next,
        finally)
   | Iexit nfail ->
       let set = find_reload_at_exit nfail in
@@ -268,7 +287,9 @@ let rec reload i before =
 let spill_at_exit = ref []
 let find_spill_at_exit k =
   try
-    List.assoc k !spill_at_exit
+    let used, set = List.assoc k !spill_at_exit in
+    used := true;
+    set
   with
   | Not_found -> Misc.fatal_error "Spill.find_spill_at_exit"
 
@@ -311,7 +332,7 @@ let rec spill i finally =
       let (new_ifso, before_ifso) = spill ifso at_join in
       let (new_ifnot, before_ifnot) = spill ifnot at_join in
       if
-        !inside_loop || !inside_arm
+        !inside_loop || !inside_arm || !inside_catch
       then
         (instr_cons (Iifthenelse(test, new_ifso, new_ifnot))
                      i.arg i.res new_next,
@@ -365,16 +386,37 @@ let rec spill i finally =
       inside_loop := saved_inside_loop;
       (instr_cons (Iloop(!final_body)) i.arg i.res new_next,
        !at_head)
-  | Icatch(nfail, body, handler) ->
+  | Icatch(handlers, body) ->
       let (new_next, at_join) = spill i.next finally in
-      let (new_handler, at_exit) = spill handler at_join in
       let saved_inside_catch = !inside_catch in
       inside_catch := true ;
-      spill_at_exit := (nfail, at_exit) :: !spill_at_exit ;
-      let (new_body, before) = spill body at_join in
-      spill_at_exit := List.tl !spill_at_exit;
+      let previous_spill_at_exit = !spill_at_exit in
+      let spill_at_exit_add at_exits = List.map2
+          (fun (nfail,_) at_exit -> nfail, (ref false, at_exit))
+          handlers at_exits
+      in
+      let rec fixpoint at_exits =
+        let spill_at_exit_add = spill_at_exit_add at_exits in
+        spill_at_exit := spill_at_exit_add @ !spill_at_exit;
+        let res = List.map (fun (_, handler) -> spill handler at_join) handlers in
+        spill_at_exit := previous_spill_at_exit;
+        let equal =
+          List.for_all2 (fun (_new_handler, new_at_exit) (_, (used, at_exit)) ->
+              Reg.Set.equal at_exit new_at_exit || not !used)
+            res spill_at_exit_add in
+        if equal
+        then res
+        else fixpoint (List.map snd res) in
+      let res = fixpoint (List.map (fun _ -> Reg.Set.empty) handlers) in
       inside_catch := saved_inside_catch ;
-      (instr_cons (Icatch(nfail, new_body, new_handler)) i.arg i.res new_next,
+      let spill_at_exit_add = spill_at_exit_add (List.map snd res) in
+      spill_at_exit := spill_at_exit_add @ !spill_at_exit;
+      let (new_body, before) = spill body at_join in
+      spill_at_exit := previous_spill_at_exit;
+      let new_handlers = List.map2
+          (fun (nfail, _) (handler, _) -> nfail, handler)
+          handlers res in
+      (instr_cons (Icatch(new_handlers, new_body)) i.arg i.res new_next,
        before)
   | Iexit nfail ->
       (i, find_spill_at_exit nfail)

--- a/asmcomp/split.ml
+++ b/asmcomp/split.ml
@@ -165,16 +165,23 @@ let rec rename i sub =
       let (new_next, sub_next) = rename i.next (merge_substs sub sub_body i) in
       (instr_cons (Iloop(new_body)) [||] [||] new_next,
        sub_next)
-  | Icatch(nfail, body, handler) ->
-      let new_subst = ref None in
-      exit_subst := (nfail, new_subst) :: !exit_subst ;
+  | Icatch(handlers, body) ->
+      let new_subst = List.map (fun (nfail, _) -> nfail, ref None)
+          handlers in
+      let previous_exit_subst = !exit_subst in
+      exit_subst := new_subst @ !exit_subst;
       let (new_body, sub_body) = rename body sub in
-      let sub_entry_handler = !new_subst in
-      exit_subst := List.tl !exit_subst;
-      let (new_handler, sub_handler) = rename handler sub_entry_handler in
-      let (new_next, sub_next) =
-        rename i.next (merge_substs sub_body sub_handler i.next) in
-      (instr_cons (Icatch(nfail, new_body, new_handler)) [||] [||] new_next,
+      let res = List.map2 (fun (_, handler) (_, new_subst) -> rename handler !new_subst)
+          handlers new_subst in
+      exit_subst := previous_exit_subst;
+      let merged_subst =
+        List.fold_left (fun acc (_, sub_handler) ->
+            merge_substs acc sub_handler i.next)
+          sub_body res in
+      let (new_next, sub_next) = rename i.next merged_subst in
+      let new_handlers = List.map2 (fun (nfail, _) (handler, _) ->
+          (nfail, handler)) handlers res in
+      (instr_cons (Icatch(new_handlers, new_body)) [||] [||] new_next,
        sub_next)
   | Iexit nfail ->
       let r = find_exit_subst nfail in

--- a/asmcomp/split.ml
+++ b/asmcomp/split.ml
@@ -165,7 +165,7 @@ let rec rename i sub =
       let (new_next, sub_next) = rename i.next (merge_substs sub sub_body i) in
       (instr_cons (Iloop(new_body)) [||] [||] new_next,
        sub_next)
-  | Icatch(handlers, body) ->
+  | Icatch(rec_flag, handlers, body) ->
       let new_subst = List.map (fun (nfail, _) -> nfail, ref None)
           handlers in
       let previous_exit_subst = !exit_subst in
@@ -181,7 +181,8 @@ let rec rename i sub =
       let (new_next, sub_next) = rename i.next merged_subst in
       let new_handlers = List.map2 (fun (nfail, _) (handler, _) ->
           (nfail, handler)) handlers res in
-      (instr_cons (Icatch(new_handlers, new_body)) [||] [||] new_next,
+      (instr_cons
+         (Icatch(rec_flag, new_handlers, new_body)) [||] [||] new_next,
        sub_next)
   | Iexit nfail ->
       let r = find_exit_subst nfail in

--- a/asmcomp/strmatch.ml
+++ b/asmcomp/strmatch.ml
@@ -377,7 +377,7 @@ module Make(I:I) = struct
     | Cexit (_e,[]) ->  k arg
     | _ ->
         let e =  next_raise_count () in
-        Ccatch (e,[],k (Cexit (e,[])),arg)
+        ccatch (e,[],k (Cexit (e,[])),arg)
 
     let compile dbg str default cases =
 (* We do not attempt to really optimise default=None *)

--- a/testsuite/makefiles/Makefile.common
+++ b/testsuite/makefiles/Makefile.common
@@ -57,9 +57,8 @@ defaultclean:
 .mll.ml:
 	@$(OCAMLLEX) -q $< > /dev/null
 
-.cmm.o:
-	@$(OCAMLRUN) ./codegen $*.cmm > $*.s
-	@$(ASM) -o $*.o $*.s
+.cmm.s:
+	@$(OCAMLRUN) ./codegen -S $*.cmm
 
 .cmm.obj:
 	@$(OCAMLRUN) ./codegen $*.cmm \

--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -61,7 +61,7 @@ ARGS_is_static_flambda=\
 
 CASES=fib tak quicksort quicksort2 soli \
       arith checkbound tagged-fib tagged-integr tagged-quicksort tagged-tak \
-      catch-try catch-rec even-odd pgcd
+      catch-try catch-rec even-odd even-odd-spill pgcd
 ARGS_fib=-DINT_INT -DFUN=fib main.c
 ARGS_tak=-DUNIT_INT -DFUN=takmain main.c
 ARGS_quicksort=-DSORT -DFUN=quicksort main.c
@@ -77,6 +77,7 @@ ARGS_tagged-tak=-DUNIT_INT -DFUN=takmain main.c
 ARGS_catch-try=-DINT_INT -DFUN=catch_exit main.c
 ARGS_catch-rec=-DINT_INT -DFUN=catch_fact main.c
 ARGS_even-odd=-DINT_INT -DFUN=is_even main.c
+ARGS_even-odd-spill=-DINT_INT -DFUN=is_even main.c
 ARGS_pgcd=-DINT_INT -DFUN=pgcd_30030 main.c
 
 skips:

--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -16,6 +16,7 @@
 BASEDIR=../..
 
 INCLUDES=\
+  -I $(OTOPDIR)/parsing \
   -I $(OTOPDIR)/utils \
   -I $(OTOPDIR)/typing \
   -I $(OTOPDIR)/middle_end \
@@ -39,6 +40,8 @@ all:
 	@$(MAKE) arch codegen
 	@$(MAKE) tests
 
+main.cmo: parsecmm.cmo
+
 codegen: parsecmm.ml lexcmm.ml $(OBJS:.cmo=.cmi) $(OBJS) main.cmo
 	@$(OCAMLC) $(LINKFLAGS) -o codegen $(OTHEROBJS) $(OBJS) main.cmo
 
@@ -57,7 +60,8 @@ ARGS_is_static_flambda=\
   -I $(OTOPDIR)/byterun is_in_static_data.c is_static_flambda_dep.ml
 
 CASES=fib tak quicksort quicksort2 soli \
-      arith checkbound tagged-fib tagged-integr tagged-quicksort tagged-tak
+      arith checkbound tagged-fib tagged-integr tagged-quicksort tagged-tak \
+      catch-try catch-rec even-odd pgcd
 ARGS_fib=-DINT_INT -DFUN=fib main.c
 ARGS_tak=-DUNIT_INT -DFUN=takmain main.c
 ARGS_quicksort=-DSORT -DFUN=quicksort main.c
@@ -70,6 +74,10 @@ ARGS_tagged-fib=-DINT_INT -DFUN=fib main.c
 ARGS_tagged-integr=-DINT_FLOAT -DFUN=test main.c
 ARGS_tagged-quicksort=-DSORT -DFUN=quicksort main.c
 ARGS_tagged-tak=-DUNIT_INT -DFUN=takmain main.c
+ARGS_catch-try=-DINT_INT -DFUN=catch_exit main.c
+ARGS_catch-rec=-DINT_INT -DFUN=catch_fact main.c
+ARGS_even-odd=-DINT_INT -DFUN=is_even main.c
+ARGS_pgcd=-DINT_INT -DFUN=pgcd_30030 main.c
 
 skips:
 	@for c in $(CASES) $(MLCASES); do \

--- a/testsuite/tests/asmcomp/catch-rec.cmm
+++ b/testsuite/tests/asmcomp/catch-rec.cmm
@@ -1,0 +1,5 @@
+(function "catch_fact" (b:int)
+  (catch (exit fact b 1)
+   with (fact c acc)
+     (if (== c 0) acc
+         (exit fact (- c 1) ( * c acc)))))

--- a/testsuite/tests/asmcomp/catch-try.cmm
+++ b/testsuite/tests/asmcomp/catch-try.cmm
@@ -1,0 +1,7 @@
+
+(function "catch_exit" (b:int)
+  (+ 33
+  (catch
+    (try (exit lbl 12)
+     with var 456)
+   with (lbl x) (+ x 789))))

--- a/testsuite/tests/asmcomp/even-odd-spill.cmm
+++ b/testsuite/tests/asmcomp/even-odd-spill.cmm
@@ -1,0 +1,19 @@
+("format_odd": string "odd %d\n\000")
+("format_even": string "even %d\n\000")
+
+(function "force_spill" (a:int) 0)
+
+(function "is_even" (b:int)
+  (catch (exit even b)
+   with (odd v)
+     (if (== v 0) 0
+         (seq
+           (extcall "printf_int" "format_odd" v unit)
+           (let v2 (- v 1)
+             (app "force_spill" 0 int)
+             (exit even v2))))
+   and (even v)
+     (if (== v 0) 1
+         (seq
+           (extcall "printf_int" "format_even" v unit)
+           (exit odd (- v 1))))))

--- a/testsuite/tests/asmcomp/even-odd.cmm
+++ b/testsuite/tests/asmcomp/even-odd.cmm
@@ -1,0 +1,8 @@
+(function "is_even" (b:int)
+  (catch (exit even b)
+   with (odd v)
+     (if (== v 0) 0
+         (exit even (- b 1)))
+   and (even v)
+     (if (== v 0) 1
+         (exit odd (- b 1)))))

--- a/testsuite/tests/asmcomp/even-odd.cmm
+++ b/testsuite/tests/asmcomp/even-odd.cmm
@@ -2,7 +2,7 @@
   (catch (exit even b)
    with (odd v)
      (if (== v 0) 0
-         (exit even (- b 1)))
+         (exit even (- v 1)))
    and (even v)
      (if (== v 0) 1
-         (exit odd (- b 1)))))
+         (exit odd (- v 1)))))

--- a/testsuite/tests/asmcomp/main.ml
+++ b/testsuite/tests/asmcomp/main.ml
@@ -46,6 +46,7 @@ let main() =
        " Output file to filename.s (default is stdout)";
      "-g", Arg.Set Clflags.debug, "";
      "-dcmm", Arg.Set dump_cmm, "";
+     "-dcse", Arg.Set dump_cse, "";
      "-dsel", Arg.Set dump_selection, "";
      "-dlive", Arg.Unit(fun () -> dump_live := true;
                                   Printmach.print_live := true), "";

--- a/testsuite/tests/asmcomp/main.ml
+++ b/testsuite/tests/asmcomp/main.ml
@@ -1,11 +1,17 @@
 open Clflags
+let write_asm_file = ref false
 
 let compile_file filename =
+  if !write_asm_file then begin
+    let out_name = Filename.chop_extension filename ^ ".s" in
+    Emitaux.output_channel := open_out out_name
+  end; (* otherwise, stdout *)
   Clflags.dlcode := false;
   Compilenv.reset ~source_provenance:(Timings.File filename) "test";
   Emit.begin_assembly();
   let ic = open_in filename in
   let lb = Lexing.from_channel ic in
+  lb.Lexing.lex_curr_p <- { lb.Lexing.lex_curr_p with pos_fname = filename };
   try
     while true do
       Asmgen.compile_phrase Format.std_formatter
@@ -13,14 +19,20 @@ let compile_file filename =
     done
   with
       End_of_file ->
-        close_in ic; Emit.end_assembly()
+        close_in ic; Emit.end_assembly();
+        if !write_asm_file then close_out !Emitaux.output_channel
     | Lexcmm.Error msg ->
         close_in ic; Lexcmm.report_error lb msg
     | Parsing.Parse_error ->
         close_in ic;
-        prerr_string "Syntax error near character ";
-        prerr_int (Lexing.lexeme_start lb);
-        prerr_newline()
+        let start_p = Lexing.lexeme_start_p lb in
+        let end_p = Lexing.lexeme_end_p lb in
+        Printf.eprintf "File \"%s\", line %i, characters %i-%i:\n\
+                        Syntax error.\n%!"
+          filename
+          start_p.Lexing.pos_lnum
+          (start_p.Lexing.pos_cnum - start_p.Lexing.pos_bol)
+          (end_p.Lexing.pos_cnum - start_p.Lexing.pos_bol)
     | Parsecmmaux.Error msg ->
         close_in ic; Parsecmmaux.report_error msg
     | x ->
@@ -30,6 +42,9 @@ let usage = "Usage: codegen <options> <files>\noptions are:"
 
 let main() =
   Arg.parse [
+     "-S", Arg.Set write_asm_file,
+       " Output file to filename.s (default is stdout)";
+     "-g", Arg.Set Clflags.debug, "";
      "-dcmm", Arg.Set dump_cmm, "";
      "-dsel", Arg.Set dump_selection, "";
      "-dlive", Arg.Unit(fun () -> dump_live := true;
@@ -41,7 +56,10 @@ let main() =
      "-dalloc", Arg.Set dump_regalloc, "";
      "-dreload", Arg.Set dump_reload, "";
      "-dscheduling", Arg.Set dump_scheduling, "";
-     "-dlinear", Arg.Set dump_linear, ""
+     "-dlinear", Arg.Set dump_linear, "";
+     "-dtimings", Arg.Set print_timings, "";
     ] compile_file usage
 
-let _ = (*Printexc.catch*) main (); exit 0
+let _ = (*Printexc.catch*) Timings.(time All) main ();
+  if !Clflags.print_timings then Timings.print Format.std_formatter;
+  exit 0

--- a/testsuite/tests/asmcomp/parsecmm.mly
+++ b/testsuite/tests/asmcomp/parsecmm.mly
@@ -195,13 +195,13 @@ expr:
           match $3 with
             Cconst_int x when x <> 0 -> $4
           | _ -> Cifthenelse($3, $4, (Cexit(0,[]))) in
-        Ccatch([0, [], Cloop body], Ctuple []) }
+        Ccatch(Recursive, [0, [], Cloop body], Ctuple []) }
   | LPAREN EXIT IDENT exprlist RPAREN
     { Cexit(find_label $3, List.rev $4) }
   | LPAREN CATCH sequence WITH catch_handlers RPAREN
     { let handlers = $5 in
       List.iter (fun (_, l, _) -> List.iter unbind_ident l) handlers;
-      Ccatch(handlers, $3) }
+      Ccatch(Recursive, handlers, $3) }
   | EXIT        { Cexit(0,[]) }
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
                 { unbind_ident $5; Ctrywith($3, $5, $6) }

--- a/testsuite/tests/asmcomp/parsecmmaux.ml
+++ b/testsuite/tests/asmcomp/parsecmmaux.ml
@@ -6,9 +6,15 @@ type error =
 exception Error of error
 
 let tbl_ident = (Hashtbl.create 57 : (string, Ident.t) Hashtbl.t)
+let tbl_label = (Hashtbl.create 57 : (string, int) Hashtbl.t)
+
+let ident_name s =
+  match String.index s '/' with
+  | exception Not_found -> s
+  | n -> String.sub s 0 n
 
 let bind_ident s =
-  let id = Ident.create s in
+  let id = Ident.create (ident_name s) in
   Hashtbl.add tbl_ident s id;
   id
 
@@ -21,6 +27,17 @@ let find_ident s =
 let unbind_ident id =
   Hashtbl.remove tbl_ident (Ident.name id)
 
+let find_label s =
+  try
+    Hashtbl.find tbl_label s
+  with Not_found ->
+    let lbl = Lambda.next_raise_count () in
+    Hashtbl.add tbl_label s lbl;
+    lbl
+
 let report_error = function
     Unbound s ->
       prerr_string "Unbound identifier "; prerr_string s; prerr_endline "."
+
+let debuginfo ?(loc=Location.symbol_rloc ()) () =
+  Debuginfo.(from_location loc)

--- a/testsuite/tests/asmcomp/parsecmmaux.mli
+++ b/testsuite/tests/asmcomp/parsecmmaux.mli
@@ -4,6 +4,10 @@ val bind_ident: string -> Ident.t
 val find_ident: string -> Ident.t
 val unbind_ident: Ident.t -> unit
 
+val find_label: string -> int
+
+val debuginfo: ?loc:Location.t -> unit -> Debuginfo.t
+
 type error =
     Unbound of string
 

--- a/testsuite/tests/asmcomp/pgcd.cmm
+++ b/testsuite/tests/asmcomp/pgcd.cmm
@@ -1,0 +1,9 @@
+(function "pgcd_30030" (a:int)
+  (catch (exit pgcd a 30030)
+   with (pgcd n m)
+     (if (> n m)
+         (exit pgcd m n)
+         (if (== n 0)
+             m
+             (let (r (mod m n))
+                     (exit pgcd r n))))))


### PR DESCRIPTION
This branch is an update of https://github.com/ocaml/ocaml/pull/98 for 4.04

This only contains the part about extending the Cmm Ccatch construction to allow recursive cases and the handling in further backend passes.

As noted by @xavierleroy in the other pull request, the name of this construction should change, but for patch maintanability, I'd prefer to do that in a separate patch if this one is accepted.

I didn't change it yet, but I'd like to require a `rec` annotation for recursive cases. Mainly for being more explicit and allow to be a bit faster in the passes that needs to reach a fixpoint in the recursive case.

Notice that now, registers are a bit more typed. Currently this patch only accept registers of type `val` as arguments (as before), but we might need to put anything in there (in particular values built with Ctuple). There are multiple possibilities to do that, but I don't want to finish implementing any before having received some feedback on what would be prefered.
- Do the typing on Cmm. The drawback being that it almost requires to duplicates large parts of selectgen to propagate the same types everywhere.
- Do the typing on Mach. I find that quite inelegant as this would require to either duplicate the mach to have a special version for 'typing' containing type variables, or change the Cmm.machtype to allow some type variable register (and pollute every pass with that).
- Requite a type annotation on Ccatch like for function argument and application. (This is the solution I prefer) The drawback would be obviously that this requires a bit more work for the pass generating it (currently the transformation patch would obviously be just adding the `Val` annotation everywhere).

Note that for testing purpose I extended a bit the cmm parser to accept actual output of `-dcmm` and be a bit more convenient.

Nothing except the backend change is provided here, in particular, the generated code won't benefit for any optimisation yet. There is a small difference in the output of Selectgen as recursive cases might require an additionnal register move (as shown in the following swap example). When this is not required, the register allocator should coalesce the intermediate temporary registers and the generated code shouldn't differ.

```
(function swap (n : int a : val b : val)
  (catch (exit swap n a b)
   with (swap n a b)
     (if (<= n 0)
         a
         (exit swap (- n 1) b a))))
```

``` assembly
swap:
.L102:
    movq    %rax, %rsi
    movq    %rbx, %rax
.L100:
    cmpq    $0, %rsi
    jg          .L101
    ret
.L101:
    decq    %rsi
    movq    %rax, %rbx
    movq    %rdi, %rax
    movq    %rbx, %rdi
    jmp     .L100
```

The first thing to do after a potential merge of this is a cleanup: rename the constructors, remove the Cloop construction, then propagate those constructions up to flambda.
