### PR TITLE
Fix documentation comments on let bindings

### DIFF
--- a/parsing/docstrings.ml
+++ b/parsing/docstrings.ml
@@ -128,6 +128,7 @@ let add_info_attrs info attrs =
 type text = docstring list
 
 let empty_text = []
+let empty_text_lazy = lazy []
 
 let text_loc = {txt = "ocaml.text"; loc = Location.none}
 

--- a/parsing/docstrings.mli
+++ b/parsing/docstrings.mli
@@ -117,6 +117,7 @@ val rhs_info : int -> info
 type text = docstring list
 
 val empty_text : text
+val empty_text_lazy : text Lazy.t
 
 val text_attr : docstring -> Parsetree.attribute
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -365,12 +365,13 @@ type let_bindings =
     lbs_extension: string Asttypes.loc option;
     lbs_loc: Location.t }
 
-let mklb (p, e) attrs =
+let mklb first (p, e) attrs =
   { lb_pattern = p;
     lb_expression = e;
     lb_attributes = attrs;
     lb_docs = symbol_docs_lazy ();
-    lb_text = symbol_text_lazy ();
+    lb_text = if first then empty_text_lazy
+              else symbol_text_lazy ();
     lb_loc = symbol_rloc (); }
 
 let mklbs ext rf lb =
@@ -1630,11 +1631,11 @@ let_bindings:
 let_binding:
     LET ext_attributes rec_flag let_binding_body post_item_attributes
       { let (ext, attr) = $2 in
-        mklbs ext $3 (mklb $4 (attr@$5)) }
+        mklbs ext $3 (mklb true $4 (attr@$5)) }
 ;
 and_let_binding:
     AND attributes let_binding_body post_item_attributes
-      { mklb $3 ($2@$4) }
+      { mklb false $3 ($2@$4) }
 ;
 fun_binding:
     strict_binding


### PR DESCRIPTION
This fixes one of the issues mentioned in MPR7197.

Before this patch floating comments before a let binding would appear twice in the AST.
