### PR TITLE
Warning 50 stdlib

### DIFF
--- a/otherlibs/Makefile.shared
+++ b/otherlibs/Makefile.shared
@@ -22,7 +22,7 @@ CAMLYACC ?= $(ROOTDIR)/boot/ocamlyacc
 
 # Compilation options
 CC=$(BYTECC)
-COMPFLAGS=-w +33..39 -warn-error A -bin-annot -g -safe-string $(EXTRACAMLFLAGS)
+COMPFLAGS=-w +33..39+50 -warn-error A -bin-annot -g -safe-string $(EXTRACAMLFLAGS)
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS=-O3
 else

--- a/otherlibs/num/arith_status.mli
+++ b/otherlibs/num/arith_status.mli
@@ -20,6 +20,7 @@ val arith_status: unit -> unit
 
 val get_error_when_null_denominator : unit -> bool
         (** See {!Arith_status.set_error_when_null_denominator}.*)
+
 val set_error_when_null_denominator : bool -> unit
         (** Get or set the flag [null_denominator]. When on, attempting to
            create a rational with a null denominator raises an exception.
@@ -28,6 +29,7 @@ val set_error_when_null_denominator : bool -> unit
 
 val get_normalize_ratio : unit -> bool
         (** See {!Arith_status.set_normalize_ratio}.*)
+
 val set_normalize_ratio : bool -> unit
         (** Get or set the flag [normalize_ratio]. When on, rational
            numbers are normalized after each operation. When off,
@@ -36,6 +38,7 @@ val set_normalize_ratio : bool -> unit
 
 val get_normalize_ratio_when_printing : unit -> bool
         (** See {!Arith_status.set_normalize_ratio_when_printing}.*)
+
 val set_normalize_ratio_when_printing : bool -> unit
         (** Get or set the flag [normalize_ratio_when_printing].
            When on, rational numbers are normalized before being printed.
@@ -44,6 +47,7 @@ val set_normalize_ratio_when_printing : bool -> unit
 
 val get_approx_printing : unit -> bool
         (** See {!Arith_status.set_approx_printing}.*)
+
 val set_approx_printing : bool -> unit
         (** Get or set the flag [approx_printing].
            When on, rational numbers are printed as a decimal approximation.
@@ -52,6 +56,7 @@ val set_approx_printing : bool -> unit
 
 val get_floating_precision : unit -> int
         (** See {!Arith_status.set_floating_precision}.*)
+
 val set_floating_precision : int -> unit
         (** Get or set the parameter [floating_precision].
            This parameter is the number of digits displayed when

--- a/otherlibs/num/big_int.mli
+++ b/otherlibs/num/big_int.mli
@@ -25,6 +25,7 @@ type big_int
 
 val zero_big_int : big_int
         (** The big integer [0]. *)
+
 val unit_big_int : big_int
         (** The big integer [1]. *)
 
@@ -32,28 +33,39 @@ val unit_big_int : big_int
 
 val minus_big_int : big_int -> big_int
         (** Unary negation. *)
+
 val abs_big_int : big_int -> big_int
         (** Absolute value. *)
+
 val add_big_int : big_int -> big_int -> big_int
         (** Addition. *)
+
 val succ_big_int : big_int -> big_int
         (** Successor (add 1). *)
+
 val add_int_big_int : int -> big_int -> big_int
         (** Addition of a small integer to a big integer. *)
+
 val sub_big_int : big_int -> big_int -> big_int
         (** Subtraction. *)
+
 val pred_big_int : big_int -> big_int
         (** Predecessor (subtract 1). *)
+
 val mult_big_int : big_int -> big_int -> big_int
         (** Multiplication of two big integers. *)
+
 val mult_int_big_int : int -> big_int -> big_int
         (** Multiplication of a big integer by a small integer *)
+
 val square_big_int: big_int -> big_int
         (** Return the square of the given big integer *)
+
 val sqrt_big_int: big_int -> big_int
         (** [sqrt_big_int a] returns the integer square root of [a],
            that is, the largest big integer [r] such that [r * r <= a].
            Raise [Invalid_argument] if [a] is negative. *)
+
 val quomod_big_int : big_int -> big_int -> big_int * big_int
         (** Euclidean division of two big integers.
            The first part of the result is the quotient,
@@ -61,14 +73,18 @@ val quomod_big_int : big_int -> big_int -> big_int * big_int
            Writing [(q,r) = quomod_big_int a b], we have
            [a = q * b + r] and [0 <= r < |b|].
            Raise [Division_by_zero] if the divisor is zero. *)
+
 val div_big_int : big_int -> big_int -> big_int
         (** Euclidean quotient of two big integers.
            This is the first result [q] of [quomod_big_int] (see above). *)
+
 val mod_big_int : big_int -> big_int -> big_int
         (** Euclidean modulus of two big integers.
            This is the second result [r] of [quomod_big_int] (see above). *)
+
 val gcd_big_int : big_int -> big_int -> big_int
         (** Greatest common divisor of two big integers. *)
+
 val power_int_positive_int: int -> int -> big_int
 val power_big_int_positive_int: big_int -> int -> big_int
 val power_int_positive_big_int: int -> big_int -> big_int
@@ -84,23 +100,29 @@ val power_big_int_positive_big_int: big_int -> big_int -> big_int
 val sign_big_int : big_int -> int
         (** Return [0] if the given big integer is zero,
            [1] if it is positive, and [-1] if it is negative. *)
+
 val compare_big_int : big_int -> big_int -> int
         (** [compare_big_int a b] returns [0] if [a] and [b] are equal,
            [1] if [a] is greater than [b], and [-1] if [a] is smaller
            than [b]. *)
+
 val eq_big_int : big_int -> big_int -> bool
 val le_big_int : big_int -> big_int -> bool
 val ge_big_int : big_int -> big_int -> bool
 val lt_big_int : big_int -> big_int -> bool
 val gt_big_int : big_int -> big_int -> bool
         (** Usual boolean comparisons between two big integers. *)
+
 val max_big_int : big_int -> big_int -> big_int
         (** Return the greater of its two arguments. *)
+
 val min_big_int : big_int -> big_int -> big_int
         (** Return the smaller of its two arguments. *)
+
 val num_digits_big_int : big_int -> int
         (** Return the number of machine words used to store the
            given big integer.  *)
+
 val num_bits_big_int : big_int -> int
         (** Return the number of significant bits in the absolute
             value of the given big integer.  [num_bits_big_int a]
@@ -112,6 +134,7 @@ val num_bits_big_int : big_int -> int
 val string_of_big_int : big_int -> string
         (** Return the string representation of the given big integer,
            in decimal (base 10). *)
+
 val big_int_of_string : string -> big_int
         (** Convert a string to a big integer, in decimal.
            The string consists of an optional [-] or [+] sign,
@@ -121,6 +144,7 @@ val big_int_of_string : string -> big_int
 
 val big_int_of_int : int -> big_int
         (** Convert a small integer to a big integer. *)
+
 val is_int_big_int : big_int -> bool
         (** Test whether the given big integer is small enough to
            be representable as a small integer (type [int])
@@ -129,6 +153,7 @@ val is_int_big_int : big_int -> bool
            [a] is between 2{^30} and 2{^30}-1.  On a 64-bit platform,
            [is_int_big_int a] returns [true] if and only if
            [a] is between -2{^62} and 2{^62}-1. *)
+
 val int_of_big_int : big_int -> int
         (** Convert a big integer to a small integer (type [int]).
            Raises [Failure "int_of_big_int"] if the big integer
@@ -136,18 +161,23 @@ val int_of_big_int : big_int -> int
 
 val big_int_of_int32 : int32 -> big_int
         (** Convert a 32-bit integer to a big integer. *)
+
 val big_int_of_nativeint : nativeint -> big_int
         (** Convert a native integer to a big integer. *)
+
 val big_int_of_int64 : int64 -> big_int
         (** Convert a 64-bit integer to a big integer. *)
+
 val int32_of_big_int : big_int -> int32
         (** Convert a big integer to a 32-bit integer.
             Raises [Failure] if the big integer is outside the
             range \[-2{^31}, 2{^31}-1\]. *)
+
 val nativeint_of_big_int : big_int -> nativeint
         (** Convert a big integer to a native integer.
             Raises [Failure] if the big integer is outside the
             range [[Nativeint.min_int, Nativeint.max_int]]. *)
+
 val int64_of_big_int : big_int -> int64
         (** Convert a big integer to a 64-bit integer.
             Raises [Failure] if the big integer is outside the
@@ -162,25 +192,31 @@ val float_of_big_int : big_int -> float
 val and_big_int : big_int -> big_int -> big_int
         (** Bitwise logical 'and'.
             The arguments must be positive or zero. *)
+
 val or_big_int : big_int -> big_int -> big_int
         (** Bitwise logical 'or'.
             The arguments must be positive or zero. *)
+
 val xor_big_int : big_int -> big_int -> big_int
         (** Bitwise logical 'exclusive or'.
             The arguments must be positive or zero. *)
+
 val shift_left_big_int : big_int -> int -> big_int
         (** [shift_left_big_int b n] returns [b] shifted left by [n] bits.
             Equivalent to multiplication by 2^n. *)
+
 val shift_right_big_int : big_int -> int -> big_int
         (** [shift_right_big_int b n] returns [b] shifted right by [n] bits.
             Equivalent to division by 2^n with the result being
             rounded towards minus infinity. *)
+
 val shift_right_towards_zero_big_int : big_int -> int -> big_int
         (** [shift_right_towards_zero_big_int b n] returns [b] shifted
             right by [n] bits.  The shift is performed on the absolute
             value of [b], and the result has the same sign as [b].
             Equivalent to division by 2^n with the result being
             rounded towards zero. *)
+
 val extract_big_int : big_int -> int -> int -> big_int
         (** [extract_big_int bi ofs n] returns a nonnegative number
             corresponding to bits [ofs] to [ofs + n - 1] of the

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -879,6 +879,7 @@ val alarm : int -> int
 
 val sleep : int -> unit
 (** Stop execution for the given number of seconds. *)
+
 val sleepf : float -> unit
 (** Stop execution for the given number of seconds.  Like [sleep],
     but fractions of seconds are supported. *)
@@ -1365,7 +1366,8 @@ val getaddrinfo:
 
 type name_info =
   { ni_hostname : string;               (** Name or IP address of host *)
-    ni_service : string }               (** Name of service or port number *)
+    ni_service : string                 (** Name of service or port number *)
+  }
 (** Host and service information returned by {!Unix.getnameinfo}. *)
 
 type getnameinfo_option =

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -1243,7 +1243,8 @@ val getaddrinfo:
 
 type name_info =
   { ni_hostname : string;               (** Name or IP address of host *)
-    ni_service : string }               (** Name of service or port number *)
+    ni_service : string                 (** Name of service or port number *)
+  }
 (** Host and service information returned by {!Unix.getnameinfo}. *)
 
 type getnameinfo_option =

--- a/stdlib/Makefile.shared
+++ b/stdlib/Makefile.shared
@@ -20,7 +20,7 @@ TARGET_BINDIR ?= $(BINDIR)
 
 COMPILER=../ocamlc
 CAMLC=$(CAMLRUN) $(COMPILER)
-COMPFLAGS=-strict-sequence -w +32+33..39 -g -warn-error A -bin-annot -nostdlib \
+COMPFLAGS=-strict-sequence -w +32+33..39+50 -g -warn-error A -bin-annot -nostdlib \
           -safe-string
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS=-O3

--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -46,7 +46,7 @@ type error =
   | Missing of string
   | Message of string
 
-exception Stop of error;; (* used internally *)
+exception Stop of error (* used internally *)
 
 open Printf
 
@@ -55,19 +55,19 @@ let rec assoc3 x l =
   | [] -> raise Not_found
   | (y1, y2, y3) :: t when y1 = x -> y2
   | _ :: t -> assoc3 x t
-;;
+
 
 let split s =
   let i = String.index s '=' in
   let len = String.length s in
   String.sub s 0 i, String.sub s (i+1) (len-(i+1))
-;;
+
 
 let make_symlist prefix sep suffix l =
   match l with
   | [] -> "<none>"
   | h::t -> (List.fold_left (fun x y -> x ^ sep ^ y) (prefix ^ h) t) ^ suffix
-;;
+
 
 let print_spec buf (key, spec, doc) =
   if String.length doc > 0 then
@@ -76,9 +76,9 @@ let print_spec buf (key, spec, doc) =
         bprintf buf "  %s %s%s\n" key (make_symlist "{" "|" "}" l) doc
     | _ ->
         bprintf buf "  %s %s\n" key doc
-;;
 
-let help_action () = raise (Stop (Unknown "-help"));;
+
+let help_action () = raise (Stop (Unknown "-help"))
 
 let add_help speclist =
   let add1 =
@@ -91,24 +91,24 @@ let add_help speclist =
             ["--help", Unit help_action, " Display this list of options"]
   in
   speclist @ (add1 @ add2)
-;;
+
 
 let usage_b buf speclist errmsg =
   bprintf buf "%s\n" errmsg;
-  List.iter (print_spec buf) (add_help speclist);
-;;
+  List.iter (print_spec buf) (add_help speclist)
+
 
 let usage_string speclist errmsg =
   let b = Buffer.create 200 in
   usage_b b speclist errmsg;
-  Buffer.contents b;
-;;
+  Buffer.contents b
+
 
 let usage speclist errmsg =
-  eprintf "%s" (usage_string speclist errmsg);
-;;
+  eprintf "%s" (usage_string speclist errmsg)
 
-let current = ref 0;;
+
+let current = ref 0
 
 let bool_of_string_opt x =
   try Some (bool_of_string x)
@@ -247,28 +247,28 @@ let parse_argv_dynamic ?(current=current) argv speclist anonfun errmsg =
       (try anonfun s with Bad m -> stop (Message m));
       incr current;
     end;
-  done;
-;;
+  done
+
 
 let parse_argv ?(current=current) argv speclist anonfun errmsg =
-  parse_argv_dynamic ~current:current argv (ref speclist) anonfun errmsg;
-;;
+  parse_argv_dynamic ~current:current argv (ref speclist) anonfun errmsg
+
 
 let parse l f msg =
   try
-    parse_argv Sys.argv l f msg;
+    parse_argv Sys.argv l f msg
   with
-  | Bad msg -> eprintf "%s" msg; exit 2;
-  | Help msg -> printf "%s" msg; exit 0;
-;;
+  | Bad msg -> eprintf "%s" msg; exit 2
+  | Help msg -> printf "%s" msg; exit 0
+
 
 let parse_dynamic l f msg =
   try
-    parse_argv_dynamic Sys.argv l f msg;
+    parse_argv_dynamic Sys.argv l f msg
   with
-  | Bad msg -> eprintf "%s" msg; exit 2;
-  | Help msg -> printf "%s" msg; exit 0;
-;;
+  | Bad msg -> eprintf "%s" msg; exit 2
+  | Help msg -> printf "%s" msg; exit 0
+
 
 let second_word s =
   let len = String.length s in
@@ -279,13 +279,13 @@ let second_word s =
   in
   try loop (String.index s ' ')
   with Not_found -> len
-;;
+
 
 let max_arg_len cur (kwd, spec, doc) =
   match spec with
   | Symbol _ -> max cur (String.length kwd)
   | _ -> max cur (String.length kwd + second_word doc)
-;;
+
 
 let add_padding len ksd =
   match ksd with
@@ -308,11 +308,11 @@ let add_padding len ksd =
         let prefix = String.sub msg 0 cutcol in
         let suffix = String.sub msg cutcol (String.length msg - cutcol) in
         (kwd, spec, prefix ^ spaces ^ suffix)
-;;
+
 
 let align ?(limit=max_int) speclist =
   let completed = add_help speclist in
   let len = List.fold_left max_arg_len 0 completed in
   let len = min len limit in
   List.map (add_padding len) completed
-;;
+

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -143,7 +143,7 @@ val usage_string : (key * spec * doc) list -> usage_msg -> string
 (** Returns the message that would have been printed by {!Arg.usage},
     if provided with the same parameters. *)
 
-val align: ?limit: int -> (key * spec * doc) list -> (key * spec * doc) list;;
+val align: ?limit: int -> (key * spec * doc) list -> (key * spec * doc) list
 (** Align the documentation strings by inserting spaces at the first
     space, according to the length of the keyword.  Use a
     space as the first character in a doc string if you want to

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -132,7 +132,7 @@ let to_list a =
 let rec list_length accu = function
   | [] -> accu
   | h::t -> list_length (succ accu) t
-;;
+
 
 let of_list = function
     [] -> [||]
@@ -189,7 +189,7 @@ let memq x a =
     else loop (succ i) in
   loop 0
 
-exception Bottom of int;;
+exception Bottom of int
 let sort cmp a =
   let maxson l i =
     let i31 = i+i+i+1 in
@@ -236,10 +236,10 @@ let sort cmp a =
     set a i (get a 0);
     trickleup (bubble i 0) e;
   done;
-  if l > 1 then (let e = (get a 1) in set a 1 (get a 0); set a 0 e);
-;;
+  if l > 1 then (let e = (get a 1) in set a 1 (get a 0); set a 0 e)
 
-let cutoff = 5;;
+
+let cutoff = 5
 let stable_sort cmp a =
   let merge src1ofs src1len src2 src2ofs src2len dst dstofs =
     let src1r = src1ofs + src1len and src2r = src2ofs + src2len in
@@ -289,7 +289,7 @@ let stable_sort cmp a =
     sortto l1 t 0 l2;
     sortto 0 a l2 l1;
     merge l2 l1 t 0 l2 a 0;
-  end;
-;;
+  end
 
-let fast_sort = stable_sort;;
+
+let fast_sort = stable_sort

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -34,7 +34,7 @@ let sub b ofs len =
   if ofs < 0 || len < 0 || ofs > b.position - len
   then invalid_arg "Buffer.sub"
   else Bytes.sub_string b.buffer ofs len
-;;
+
 
 let blit src srcoff dst dstoff len =
   if len < 0 || srcoff < 0 || srcoff > src.position - len
@@ -42,13 +42,13 @@ let blit src srcoff dst dstoff len =
   then invalid_arg "Buffer.blit"
   else
     Bytes.unsafe_blit src.buffer srcoff dst dstoff len
-;;
+
 
 let nth b ofs =
   if ofs < 0 || ofs >= b.position then
    invalid_arg "Buffer.nth"
   else Bytes.unsafe_get b.buffer ofs
-;;
+
 
 let length b = b.position
 
@@ -124,7 +124,7 @@ let output_buffer oc b =
 let closing = function
   | '(' -> ')'
   | '{' -> '}'
-  | _ -> assert false;;
+  | _ -> assert false
 
 (* opening and closing: open and close characters, typically ( and )
    k: balance of opening and closing chars
@@ -137,7 +137,7 @@ let advance_to_closing opening closing k s start =
     if s.[i] = closing then
       if k = 0 then i else advance (k - 1) (i + 1) lim
     else advance k (i + 1) lim in
-  advance k start (String.length s);;
+  advance k start (String.length s)
 
 let advance_to_non_alpha s start =
   let rec advance i lim =
@@ -145,7 +145,7 @@ let advance_to_non_alpha s start =
     match s.[i] with
     | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' -> advance (i + 1) lim
     | _ -> i in
-  advance start (String.length s);;
+  advance start (String.length s)
 
 (* We are just at the beginning of an ident in s, starting at start. *)
 let find_ident s start lim =
@@ -159,7 +159,7 @@ let find_ident s start lim =
   (* Regular ident *)
   | _ ->
      let stop = advance_to_non_alpha s (start + 1) in
-     String.sub s start (stop - start), stop;;
+     String.sub s start (stop - start), stop
 
 (* Substitute $ident, $(ident), or ${ident} in s,
     according to the function mapping f. *)
@@ -187,4 +187,4 @@ let add_substitute b f s =
          subst current (i + 1)
     end else
     if previous = '\\' then add_char b previous in
-  subst ' ' 0;;
+  subst ' ' 0

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -44,7 +44,7 @@ let init n f =
   done;
   s
 
-let empty = create 0;;
+let empty = create 0
 
 let copy s =
   let len = length s in
@@ -122,7 +122,7 @@ let cat s1 s2 =
   unsafe_blit s1 0 r 0 l1;
   unsafe_blit s2 0 r l1 l2;
   r
-;;
+
 
 external char_code: char -> int = "%identity"
 external char_chr: int -> char = "%identity"
@@ -217,27 +217,27 @@ let uncapitalize_ascii s = apply1 Char.lowercase_ascii s
 
 let rec index_rec s lim i c =
   if i >= lim then raise Not_found else
-  if unsafe_get s i = c then i else index_rec s lim (i + 1) c;;
+  if unsafe_get s i = c then i else index_rec s lim (i + 1) c
 
-let index s c = index_rec s (length s) 0 c;;
+let index s c = index_rec s (length s) 0 c
 
 let index_from s i c =
   let l = length s in
   if i < 0 || i > l then invalid_arg "String.index_from / Bytes.index_from" else
-  index_rec s l i c;;
+  index_rec s l i c
 
 let rec rindex_rec s i c =
   if i < 0 then raise Not_found else
-  if unsafe_get s i = c then i else rindex_rec s (i - 1) c;;
+  if unsafe_get s i = c then i else rindex_rec s (i - 1) c
 
-let rindex s c = rindex_rec s (length s - 1) c;;
+let rindex s c = rindex_rec s (length s - 1) c
 
 let rindex_from s i c =
   if i < -1 || i >= length s then
     invalid_arg "String.rindex_from / Bytes.rindex_from"
   else
     rindex_rec s i c
-;;
+
 
 let contains_from s i c =
   let l = length s in
@@ -245,16 +245,16 @@ let contains_from s i c =
     invalid_arg "String.contains_from / Bytes.contains_from"
   else
     try ignore (index_rec s l i c); true with Not_found -> false
-;;
 
-let contains s c = contains_from s 0 c;;
+
+let contains s c = contains_from s 0 c
 
 let rcontains_from s i c =
   if i < 0 || i >= length s then
     invalid_arg "String.rcontains_from / Bytes.rcontains_from"
   else
     try ignore (rindex_rec s i c); true with Not_found -> false
-;;
+
 
 type t = bytes
 

--- a/stdlib/camlinternalFormatBasics.ml
+++ b/stdlib/camlinternalFormatBasics.ml
@@ -107,11 +107,11 @@ position in the format tail (('u, .., 'f) fmt). This means that the
 type of the expected format parameter depends of where the %(...%)
 are in the format string:
 
-  # Printf.printf "%(%)";;
+  # Printf.printf "%(%)"
   - : (unit, out_channel, unit, '_a, '_a, unit)
       CamlinternalFormatBasics.format6 -> unit
   = <fun>
-  # Printf.printf "%(%)%d";;
+  # Printf.printf "%(%)%d"
   - : (int -> unit, out_channel, unit, '_a, '_a, int -> unit)
       CamlinternalFormatBasics.format6 -> int -> unit
   = <fun>

--- a/stdlib/camlinternalLazy.ml
+++ b/stdlib/camlinternalLazy.ml
@@ -15,9 +15,9 @@
 
 (* Internals of forcing lazy values. *)
 
-exception Undefined;;
+exception Undefined
 
-let raise_undefined = Obj.repr (fun () -> raise Undefined);;
+let raise_undefined = Obj.repr (fun () -> raise Undefined)
 
 (* Assume [blk] is a block with tag lazy *)
 let force_lazy_block (blk : 'arg lazy_t) =
@@ -32,7 +32,7 @@ let force_lazy_block (blk : 'arg lazy_t) =
   with e ->
     Obj.set_field (Obj.repr blk) 0 (Obj.repr (fun () -> raise e));
     raise e
-;;
+
 
 (* Assume [blk] is a block with tag lazy *)
 let force_val_lazy_block (blk : 'arg lazy_t) =
@@ -43,7 +43,7 @@ let force_val_lazy_block (blk : 'arg lazy_t) =
   Obj.set_field (Obj.repr blk) 0 (Obj.repr result);
   Obj.set_tag (Obj.repr blk) (Obj.forward_tag);
   result
-;;
+
 
 (* [force] is not used, since [Lazy.force] is declared as a primitive
    whose code inlines the tag tests of its argument.  This function is
@@ -55,7 +55,7 @@ let force (lzv : 'arg lazy_t) =
   if t = Obj.forward_tag then (Obj.obj (Obj.field x 0) : 'arg) else
   if t <> Obj.lazy_tag then (Obj.obj x : 'arg)
   else force_lazy_block lzv
-;;
+
 
 let force_val (lzv : 'arg lazy_t) =
   let x = Obj.repr lzv in
@@ -63,4 +63,4 @@ let force_val (lzv : 'arg lazy_t) =
   if t = Obj.forward_tag then (Obj.obj (Obj.field x 0) : 'arg) else
   if t <> Obj.lazy_tag then (Obj.obj x : 'arg)
   else force_val_lazy_block lzv
-;;
+

--- a/stdlib/camlinternalLazy.mli
+++ b/stdlib/camlinternalLazy.mli
@@ -17,11 +17,11 @@
     All functions in this module are for system use only, not for the
     casual user. *)
 
-exception Undefined;;
+exception Undefined
 
-val force_lazy_block : 'a lazy_t -> 'a ;;
+val force_lazy_block : 'a lazy_t -> 'a 
 
-val force_val_lazy_block : 'a lazy_t -> 'a ;;
+val force_val_lazy_block : 'a lazy_t -> 'a 
 
-val force : 'a lazy_t -> 'a ;;
-val force_val : 'a lazy_t -> 'a ;;
+val force : 'a lazy_t -> 'a 
+val force_val : 'a lazy_t -> 'a 

--- a/stdlib/ephemeron.ml
+++ b/stdlib/ephemeron.ml
@@ -55,7 +55,7 @@ module GenHashTable = struct
 
     and 'a bucketlist =
     | Empty
-    | Cons of int (** hash of the key *) * 'a H.container * 'a bucketlist
+    | Cons of int (* hash of the key *) * 'a H.container * 'a bucketlist
 
     (** the hash of the key is kept in order to test the equality of the hash
       before the key. Same reason as for Weak.Make *)
@@ -167,7 +167,7 @@ module GenHashTable = struct
             | ETrue -> h.size <- h.size - 1; next
             | EFalse -> Cons(hk, c, remove_bucket next)
             | EDead ->
-                (** The dead key is automatically removed. It is acceptable
+                (* The dead key is automatically removed. It is acceptable
                     for this function since it already removes a binding *)
                 h.size <- h.size - 1;
                 remove_bucket next
@@ -188,8 +188,8 @@ module GenHashTable = struct
           | ETrue ->
               begin match H.get_data c with
               | None ->
-                  (** This case is not impossible because the gc can run between
-                      H.equal and H.get_data *)
+                  (* This case is not impossible because the gc can run between
+                     H.equal and H.get_data *)
                   find_rec key hkey rest
               | Some d -> d
               end
@@ -202,7 +202,7 @@ module GenHashTable = struct
 
     let find h key =
       let hkey = H.hash h.seed key in
-      (** TODO inline 3 iterations *)
+      (* TODO inline 3 iterations *)
       find_rec key hkey (h.data.(key_index h hkey))
 
     let find_all h key =
@@ -401,8 +401,8 @@ module K1 = struct
         c
       let hash = H.hash
       let equal c k =
-        (** {!get_key_copy} is not used because the equality of the user can be
-            the physical equality *)
+        (* {!get_key_copy} is not used because the equality of the user can be
+           the physical equality *)
         match get_key c with
         | None -> GenHashTable.EDead
         | Some k' ->

--- a/stdlib/ephemeron.mli
+++ b/stdlib/ephemeron.mli
@@ -80,6 +80,7 @@ module type S = sig
 
   val clean: 'a t -> unit
   (** remove all dead bindings. Done automatically during automatic resizing. *)
+
   val stats_alive: 'a t -> Hashtbl.statistics
   (** same as {!Hashtbl.SeededS.stats} but only count the alive bindings *)
 end
@@ -93,6 +94,7 @@ module type SeededS = sig
   include Hashtbl.SeededS
   val clean: 'a t -> unit
   (** remove all dead bindings. Done automatically during automatic resizing. *)
+
   val stats_alive: 'a t -> Hashtbl.statistics
   (** same as {!Hashtbl.SeededS.stats} but only count the alive bindings *)
 end
@@ -192,43 +194,58 @@ module K2 : sig
 
   val get_key1: ('k1,'k2,'d) t -> 'k1 option
   (** Same as {!Ephemeron.K1.get_key} *)
+
   val get_key1_copy: ('k1,'k2,'d) t -> 'k1 option
   (** Same as {!Ephemeron.K1.get_key_copy} *)
+
   val set_key1: ('k1,'k2,'d) t -> 'k1 -> unit
   (** Same as {!Ephemeron.K1.set_key} *)
+
   val unset_key1: ('k1,'k2,'d) t -> unit
   (** Same as {!Ephemeron.K1.unset_key} *)
+
   val check_key1: ('k1,'k2,'d) t ->  bool
   (** Same as {!Ephemeron.K1.check_key} *)
 
   val get_key2: ('k1,'k2,'d) t -> 'k2 option
   (** Same as {!Ephemeron.K1.get_key} *)
+
   val get_key2_copy: ('k1,'k2,'d) t -> 'k2 option
   (** Same as {!Ephemeron.K1.get_key_copy} *)
+
   val set_key2: ('k1,'k2,'d) t -> 'k2 -> unit
   (** Same as {!Ephemeron.K1.get_key} *)
+
   val unset_key2: ('k1,'k2,'d) t -> unit
   (** Same as {!Ephemeron.K1.unset_key} *)
+
   val check_key2: ('k1,'k2,'d) t -> bool
   (** Same as {!Ephemeron.K1.check_key} *)
 
   val blit_key1  : ('k1,_,_) t -> ('k1,_,_) t -> unit
   (** Same as {!Ephemeron.K1.blit_key} *)
+
   val blit_key2  : (_,'k2,_) t -> (_,'k2,_) t -> unit
   (** Same as {!Ephemeron.K1.blit_key} *)
+
   val blit_key12 : ('k1,'k2,_) t -> ('k1,'k2,_) t -> unit
   (** Same as {!Ephemeron.K1.blit_key} *)
 
   val get_data: ('k1,'k2,'d) t -> 'd option
   (** Same as {!Ephemeron.K1.get_data} *)
+
   val get_data_copy: ('k1,'k2,'d) t -> 'd option
   (** Same as {!Ephemeron.K1.get_data_copy} *)
+
   val set_data: ('k1,'k2,'d) t -> 'd -> unit
   (** Same as {!Ephemeron.K1.set_data} *)
+
   val unset_data: ('k1,'k2,'d) t -> unit
   (** Same as {!Ephemeron.K1.unset_data} *)
+
   val check_data: ('k1,'k2,'d) t -> bool
   (** Same as {!Ephemeron.K1.check_data} *)
+
   val blit_data: ('k1,'k2,'d) t -> ('k1,'k2,'d) t -> unit
   (** Same as {!Ephemeron.K1.blit_data} *)
 
@@ -256,12 +273,16 @@ module Kn : sig
 
   val get_key: ('k,'d) t -> int -> 'k option
   (** Same as {!Ephemeron.K1.get_key} *)
+
   val get_key_copy: ('k,'d) t -> int -> 'k option
   (** Same as {!Ephemeron.K1.get_key_copy} *)
+
   val set_key: ('k,'d) t -> int -> 'k -> unit
   (** Same as {!Ephemeron.K1.set_key} *)
+
   val unset_key: ('k,'d) t -> int -> unit
   (** Same as {!Ephemeron.K1.unset_key} *)
+
   val check_key: ('k,'d) t -> int ->  bool
   (** Same as {!Ephemeron.K1.check_key} *)
 
@@ -270,14 +291,19 @@ module Kn : sig
 
   val get_data: ('k,'d) t -> 'd option
   (** Same as {!Ephemeron.K1.get_data} *)
+
   val get_data_copy: ('k,'d) t -> 'd option
   (** Same as {!Ephemeron.K1.get_data_copy} *)
+
   val set_data: ('k,'d) t -> 'd -> unit
   (** Same as {!Ephemeron.K1.set_data} *)
+
   val unset_data: ('k,'d) t -> unit
   (** Same as {!Ephemeron.K1.unset_data} *)
+
   val check_data: ('k,'d) t -> bool
   (** Same as {!Ephemeron.K1.check_data} *)
+
   val blit_data: ('k,'d) t -> ('k,'d) t -> unit
   (** Same as {!Ephemeron.K1.blit_data} *)
 
@@ -307,11 +333,13 @@ module GenHashTable: sig
   sig
     type t
     (** keys *)
+
     type 'a container
     (** contains keys and the associated data *)
 
     val hash: int -> t -> int
     (** same as {!Hashtbl.SeededHashedType} *)
+
     val equal: 'a container -> t -> equal
     (** equality predicate used to compare a key with the one in a
         container. Can return [EDead] if the keys in the container are
@@ -320,12 +348,16 @@ module GenHashTable: sig
     val create: t -> 'a -> 'a container
     (** [create key data] creates a container from
         some initials keys and one data *)
+
     val get_key: 'a container -> t option
     (** [get_key cont] returns the keys if they are all alive *)
+
     val get_data: 'a container -> 'a option
     (** [get_data cont] return the data if it is alive *)
+
     val set_key_data: 'a container -> t -> 'a -> unit
     (** [set_key_data cont] modify the key and data *)
+
     val check_key: 'a container -> bool
     (** [check_key cont] checks if all the keys contained in the data
         are alive *)

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -74,7 +74,7 @@ module Unix = struct
   let parent_dir_name = ".."
   let dir_sep = "/"
   let is_dir_sep s i = s.[i] = '/'
-  let is_relative n = String.length n < 1 || n.[0] <> '/';;
+  let is_relative n = String.length n < 1 || n.[0] <> '/'
   let is_implicit n =
     is_relative n
     && (String.length n < 2 || String.sub n 0 2 <> "./")
@@ -210,12 +210,12 @@ let chop_extension name =
 external open_desc: string -> open_flag list -> int -> int = "caml_sys_open"
 external close_desc: int -> unit = "caml_sys_close"
 
-let prng = lazy(Random.State.make_self_init ());;
+let prng = lazy(Random.State.make_self_init ())
 
 let temp_file_name temp_dir prefix suffix =
   let rnd = (Random.State.bits (Lazy.force prng)) land 0xFFFFFF in
   concat temp_dir (Printf.sprintf "%s%06x%s" prefix rnd suffix)
-;;
+
 
 let current_temp_dir_name = ref temp_dir_name
 

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -22,12 +22,12 @@
 
 (* A devoted type for sizes to avoid confusion
    between sizes and mere integers. *)
-type size;;
+type size
 
 external size_of_int : int -> size = "%identity"
-;;
+
 external int_of_size : size -> int = "%identity"
-;;
+
 
 (* The pretty-printing boxes definition:
    a pretty-printing box is either
@@ -45,7 +45,7 @@ external int_of_size : size -> int = "%identity"
 *)
 type box_type = CamlinternalFormatBasics.block_type =
   | Pp_hbox | Pp_vbox | Pp_hvbox | Pp_hovbox | Pp_box | Pp_fits
-;;
+
 
 (* The pretty-printing tokens definition:
    are either text to print or pretty printing
@@ -68,7 +68,7 @@ type pp_token =
 and tag = string
 
 and tbox = Pp_tbox of int list ref  (* Tabulation box *)
-;;
+
 
 (* The pretty-printer queue definition:
    pretty-printing material is not written in the output as soon as emitted;
@@ -89,13 +89,13 @@ and 'a queue_cell = {
   mutable head : 'a;
   mutable tail : 'a queue_elem;
 }
-;;
+
 
 type 'a queue = {
   mutable insert : 'a queue_elem;
   mutable body : 'a queue_elem;
 }
-;;
+
 
 (* The pretty-printer queue: queue element definition.
    The pretty-printer queue contains formatting elements to be printed.
@@ -109,20 +109,20 @@ type pp_queue_elem = {
   token : pp_token;
   length : int;
 }
-;;
+
 
 (* The pretty-printer queue definition. *)
-type pp_queue = pp_queue_elem queue;;
+type pp_queue = pp_queue_elem queue
 
 (* The pretty-printer scanning stack. *)
 
 (* The pretty-printer scanning stack: scanning element definition.
    Each element is (left_total, queue element) where left_total
    is the value of pp_left_total when the element has been enqueued. *)
-type pp_scan_elem = Scan_elem of int * pp_queue_elem;;
+type pp_scan_elem = Scan_elem of int * pp_queue_elem
 
 (* The pretty-printer scanning stack definition. *)
-type pp_scan_stack = pp_scan_elem list;;
+type pp_scan_stack = pp_scan_elem list
 
 (* The pretty-printer formatting stack:
    the formatting stack contains the description of all the currently active
@@ -131,13 +131,13 @@ type pp_scan_stack = pp_scan_elem list;;
 
 (* The pretty-printer formatting stack: formatting stack element definition.
    Each stack element describes a pretty-printing box. *)
-type pp_format_elem = Format_elem of box_type * int;;
+type pp_format_elem = Format_elem of box_type * int
 
 (* The pretty-printer formatting stack definition. *)
-type pp_format_stack = pp_format_elem list;;
+type pp_format_stack = pp_format_elem list
 
 (* The pretty-printer semantics tag stack definition. *)
-type pp_tag_stack = tag list;;
+type pp_tag_stack = tag list
 
 (* The formatter definition.
    Each formatter value is a pretty-printer instance with all its
@@ -192,7 +192,7 @@ type formatter = {
   (* The pretty-printer queue. *)
   mutable pp_queue : pp_queue;
 }
-;;
+
 
 (* The formatter specific tag handling functions. *)
 type formatter_tag_functions = {
@@ -201,7 +201,7 @@ type formatter_tag_functions = {
   print_open_tag : tag -> unit;
   print_close_tag : tag -> unit;
 }
-;;
+
 
 (* The formatter functions to output material. *)
 type formatter_out_functions = {
@@ -210,7 +210,7 @@ type formatter_out_functions = {
   out_newline : unit -> unit;
   out_spaces : int -> unit;
 }
-;;
+
 
 (*
 
@@ -220,9 +220,9 @@ type formatter_out_functions = {
 
 (* Queues auxiliaries. *)
 
-let make_queue () = { insert = Nil; body = Nil; };;
+let make_queue () = { insert = Nil; body = Nil; }
 
-let clear_queue q = q.insert <- Nil; q.body <- Nil;;
+let clear_queue q = q.insert <- Nil; q.body <- Nil
 
 let add_queue x q =
   let c = Cons { head = x; tail = Nil; } in
@@ -232,14 +232,14 @@ let add_queue x q =
   (* Invariant: when insert is Nil body should be Nil. *)
   | { insert = Nil; body = _; } ->
     q.insert <- c; q.body <- c
-;;
 
-exception Empty_queue;;
+
+exception Empty_queue
 
 let peek_queue = function
   | { body = Cons { head = x; tail = _; }; _ } -> x
   | { body = Nil; insert = _; } -> raise Empty_queue
-;;
+
 
 let take_queue = function
   | { body = Cons { head = x; tail = tl; }; _ } as q ->
@@ -247,18 +247,18 @@ let take_queue = function
     if tl = Nil then q.insert <- Nil; (* Maintain the invariant. *)
     x
   | { body = Nil; insert = _; } -> raise Empty_queue
-;;
+
 
 (* Enter a token in the pretty-printer queue. *)
 let pp_enqueue state ({ length = len; _} as token) =
   state.pp_right_total <- state.pp_right_total + len;
   add_queue token state.pp_queue
-;;
+
 
 let pp_clear_queue state =
   state.pp_left_total <- 1; state.pp_right_total <- 1;
   clear_queue state.pp_queue
-;;
+
 
 (* Pp_infinity: large value for default tokens size.
 
@@ -280,7 +280,7 @@ let pp_clear_queue state =
    + 1 is in practice large enough, there is no need to attempt to set
    pp_infinity to the theoretically maximum limit. It is not worth the
    burden ! *)
-let pp_infinity = 1000000010;;
+let pp_infinity = 1000000010
 
 (* Output functions for the formatter. *)
 let pp_output_string state s = state.pp_out_string s 0 (String.length s)
@@ -297,16 +297,16 @@ let break_new_line state offset width =
   state.pp_current_indent <- real_indent;
   state.pp_space_left <- state.pp_margin - state.pp_current_indent;
   pp_output_spaces state state.pp_current_indent
-;;
+
 
 (* To force a line break inside a box: no offset is added. *)
-let break_line state width = break_new_line state 0 width;;
+let break_line state width = break_new_line state 0 width
 
 (* To format a break that fits on the current line. *)
 let break_same_line state width =
   state.pp_space_left <- state.pp_space_left - width;
   pp_output_spaces state width
-;;
+
 
 (* To indent no more than pp_max_indent, if one tries to open a box
    beyond pp_max_indent, then the box is rejected on the left
@@ -320,7 +320,7 @@ let pp_force_break_line state =
        | Pp_vbox | Pp_hvbox | Pp_hovbox | Pp_box ->
          break_line state width)
   | [] -> pp_output_newline state
-;;
+
 
 (* To skip a token, if the previous line has been broken. *)
 let pp_skip_token state =
@@ -329,7 +329,7 @@ let pp_skip_token state =
   | { elem_size = size; length = len; token = _; } ->
     state.pp_left_total <- state.pp_left_total - len;
     state.pp_space_left <- state.pp_space_left + int_of_size size
-;;
+
 
 (*
 
@@ -455,7 +455,7 @@ let format_pp_token state size = function
        state.pp_mark_stack <- tags
      | [] -> () (* No more tag to close. *)
      end
-;;
+
 
 (* Print if token size is known else printing is delayed.
    Size is known when not negative.
@@ -476,31 +476,31 @@ let rec advance_loop state =
       state.pp_left_total <- len + state.pp_left_total;
       advance_loop state
     end
-;;
+
 
 let advance_left state =
   try advance_loop state with
   | Empty_queue -> ()
-;;
+
 
 (* To enqueue a token : try to advance. *)
-let enqueue_advance state tok = pp_enqueue state tok; advance_left state;;
+let enqueue_advance state tok = pp_enqueue state tok; advance_left state
 
 (* Building pretty-printer queue elements. *)
 let make_queue_elem size tok len =
   { elem_size = size; token = tok; length = len; }
-;;
+
 
 (* To enqueue strings. *)
 let enqueue_string_as state size s =
   let len = int_of_size size in
   enqueue_advance state (make_queue_elem size (Pp_text s) len)
-;;
+
 
 let enqueue_string state s =
   let len = String.length s in
   enqueue_string_as state (size_of_int len) s
-;;
+
 
 (* Routines for scan stack
    determine size of boxes. *)
@@ -509,10 +509,10 @@ let enqueue_string state s =
 let scan_stack_bottom =
   let q_elem = make_queue_elem (size_of_int (-1)) (Pp_text "") 0 in
   [Scan_elem (-1, q_elem)]
-;;
+
 
 (* Clearing the pretty-printer scanning stack. *)
-let clear_scan_stack state = state.pp_scan_stack <- scan_stack_bottom;;
+let clear_scan_stack state = state.pp_scan_stack <- scan_stack_bottom
 
 (* Setting the size of boxes on scan stack:
    if ty = true then size of break is set else size of box is set;
@@ -550,7 +550,7 @@ let set_size state ty =
         () (* scan_push is only used for breaks and boxes. *)
       end
   | [] -> () (* scan_stack is never empty. *)
-;;
+
 
 (* Push a token on pretty-printer scanning stack.
    If b is true set_size is called. *)
@@ -559,7 +559,7 @@ let scan_push state b tok =
   if b then set_size state true;
   state.pp_scan_stack <-
     Scan_elem (state.pp_right_total, tok) :: state.pp_scan_stack
-;;
+
 
 (* To open a new box :
    the user may set the depth bound pp_max_boxes
@@ -575,10 +575,10 @@ let pp_open_box_gen state indent br_ty =
     scan_push state false elem else
   if state.pp_curr_depth = state.pp_max_boxes
   then enqueue_string state state.pp_ellipsis
-;;
+
 
 (* The box which is always opened. *)
-let pp_open_sys_box state = pp_open_box_gen state 0 Pp_hovbox;;
+let pp_open_sys_box state = pp_open_box_gen state 0 Pp_hovbox
 
 (* Close a box, setting sizes of its sub boxes. *)
 let pp_close_box state () =
@@ -592,7 +592,7 @@ let pp_close_box state () =
     end;
     state.pp_curr_depth <- state.pp_curr_depth - 1;
   end
-;;
+
 
 (* Open a tag, pushing it on the tag stack. *)
 let pp_open_tag state tag_name =
@@ -607,7 +607,7 @@ let pp_open_tag state tag_name =
       token = Pp_open_tag tag_name;
       length = 0;
     }
-;;
+
 
 (* Close a tag, popping it from the tag stack. *)
 let pp_close_tag state () =
@@ -625,15 +625,15 @@ let pp_close_tag state () =
       state.pp_tag_stack <- tags
     | _ -> () (* No more tag to close. *)
   end
-;;
 
-let pp_set_print_tags state b = state.pp_print_tags <- b;;
-let pp_set_mark_tags state b = state.pp_mark_tags <- b;;
-let pp_get_print_tags state () = state.pp_print_tags;;
-let pp_get_mark_tags state () = state.pp_mark_tags;;
+
+let pp_set_print_tags state b = state.pp_print_tags <- b
+let pp_set_mark_tags state b = state.pp_mark_tags <- b
+let pp_get_print_tags state () = state.pp_print_tags
+let pp_get_mark_tags state () = state.pp_mark_tags
 let pp_set_tags state b =
   pp_set_print_tags state b; pp_set_mark_tags state b
-;;
+
 
 (* Handling tag handling functions: get/set functions. *)
 let pp_get_formatter_tag_functions state () = {
@@ -642,7 +642,7 @@ let pp_get_formatter_tag_functions state () = {
   print_open_tag = state.pp_print_open_tag;
   print_close_tag = state.pp_print_close_tag;
 }
-;;
+
 
 let pp_set_formatter_tag_functions state {
      mark_open_tag = mot;
@@ -654,7 +654,7 @@ let pp_set_formatter_tag_functions state {
   state.pp_mark_close_tag <- mct;
   state.pp_print_open_tag <- pot;
   state.pp_print_close_tag <- pct
-;;
+
 
 (* Initialize pretty-printer. *)
 let pp_rinit state =
@@ -668,7 +668,7 @@ let pp_rinit state =
   state.pp_curr_depth <- 0;
   state.pp_space_left <- state.pp_margin;
   pp_open_sys_box state
-;;
+
 
 (* Flushing pretty-printer queue. *)
 let pp_flush_queue state b =
@@ -679,7 +679,7 @@ let pp_flush_queue state b =
   advance_left state;
   if b then pp_output_newline state;
   pp_rinit state
-;;
+
 
 (*
 
@@ -691,29 +691,29 @@ let pp_flush_queue state b =
 let pp_print_as_size state size s =
   if state.pp_curr_depth < state.pp_max_boxes
   then enqueue_string_as state size s
-;;
+
 
 let pp_print_as state isize s =
   pp_print_as_size state (size_of_int isize) s
-;;
+
 
 let pp_print_string state s =
   pp_print_as state (String.length s) s
-;;
+
 
 (* To format an integer. *)
-let pp_print_int state i = pp_print_string state (string_of_int i);;
+let pp_print_int state i = pp_print_string state (string_of_int i)
 
 (* To format a float. *)
-let pp_print_float state f = pp_print_string state (string_of_float f);;
+let pp_print_float state f = pp_print_string state (string_of_float f)
 
 (* To format a boolean. *)
-let pp_print_bool state b = pp_print_string state (string_of_bool b);;
+let pp_print_bool state b = pp_print_string state (string_of_bool b)
 
 (* To format a char. *)
 let pp_print_char state c =
   pp_print_as state 1 (String.make 1 c)
-;;
+
 
 (* Opening boxes. *)
 let pp_open_hbox state () = pp_open_box_gen state 0 Pp_hbox
@@ -722,7 +722,7 @@ and pp_open_vbox state indent = pp_open_box_gen state indent Pp_vbox
 and pp_open_hvbox state indent = pp_open_box_gen state indent Pp_hvbox
 and pp_open_hovbox state indent = pp_open_box_gen state indent Pp_hovbox
 and pp_open_box state indent = pp_open_box_gen state indent Pp_box
-;;
+
 
 (* Printing all queued text.
    [print_newline] prints a new line after flushing the queue.
@@ -731,19 +731,19 @@ let pp_print_newline state () =
   pp_flush_queue state true; state.pp_out_flush ()
 and pp_print_flush state () =
   pp_flush_queue state false; state.pp_out_flush ()
-;;
+
 
 (* To get a newline when one does not want to close the current box. *)
 let pp_force_newline state () =
   if state.pp_curr_depth < state.pp_max_boxes then
     enqueue_advance state (make_queue_elem (size_of_int 0) Pp_newline 0)
-;;
+
 
 (* To format something, only in case the line has just been broken. *)
 let pp_print_if_newline state () =
   if state.pp_curr_depth < state.pp_max_boxes then
     enqueue_advance state (make_queue_elem (size_of_int 0) Pp_if_newline 0)
-;;
+
 
 (* Printing break hints:
    A break hint indicates where a box may be broken.
@@ -757,7 +757,7 @@ let pp_print_break state width offset =
         (Pp_break (width, offset))
         width in
     scan_push state true elem
-;;
+
 
 (* Print a space :
    a space is a break hint that prints a single space if the break does not
@@ -766,7 +766,7 @@ let pp_print_break state width offset =
    line. *)
 let pp_print_space state () = pp_print_break state 1 0
 and pp_print_cut state () = pp_print_break state 0 0
-;;
+
 
 (* Tabulation boxes. *)
 let pp_open_tbox state () =
@@ -775,7 +775,7 @@ let pp_open_tbox state () =
     let elem =
       make_queue_elem (size_of_int 0) (Pp_tbegin (Pp_tbox (ref []))) 0 in
     enqueue_advance state elem
-;;
+
 
 (* Close a tabulation box. *)
 let pp_close_tbox state () =
@@ -786,7 +786,7 @@ let pp_close_tbox state () =
      enqueue_advance state elem;
      state.pp_curr_depth <- state.pp_curr_depth - 1
   end
-;;
+
 
 (* Print a tabulation break. *)
 let pp_print_tbreak state width offset =
@@ -797,16 +797,16 @@ let pp_print_tbreak state width offset =
         (Pp_tbreak (width, offset))
         width in
     scan_push state true elem
-;;
 
-let pp_print_tab state () = pp_print_tbreak state 0 0;;
+
+let pp_print_tab state () = pp_print_tbreak state 0 0
 
 let pp_set_tab state () =
   if state.pp_curr_depth < state.pp_max_boxes then
     let elem =
       make_queue_elem (size_of_int 0) Pp_stab 0 in
     enqueue_advance state elem
-;;
+
 
 (*
 
@@ -815,22 +815,22 @@ let pp_set_tab state () =
 *)
 
 (* Set_max_boxes. *)
-let pp_set_max_boxes state n = if n > 1 then state.pp_max_boxes <- n;;
+let pp_set_max_boxes state n = if n > 1 then state.pp_max_boxes <- n
 
 (* To know the current maximum number of boxes allowed. *)
-let pp_get_max_boxes state () = state.pp_max_boxes;;
+let pp_get_max_boxes state () = state.pp_max_boxes
 
-let pp_over_max_boxes state () = state.pp_curr_depth = state.pp_max_boxes;;
+let pp_over_max_boxes state () = state.pp_curr_depth = state.pp_max_boxes
 
 (* Ellipsis. *)
 let pp_set_ellipsis_text state s = state.pp_ellipsis <- s
 and pp_get_ellipsis_text state () = state.pp_ellipsis
-;;
+
 
 (* To set the margin of pretty-printer. *)
 let pp_limit n =
   if n < pp_infinity then n else pred pp_infinity
-;;
+
 
 (* Internal pretty-printer functions. *)
 let pp_set_min_space_left state n =
@@ -839,16 +839,16 @@ let pp_set_min_space_left state n =
     state.pp_min_space_left <- n;
     state.pp_max_indent <- state.pp_margin - state.pp_min_space_left;
     pp_rinit state
-;;
+
 
 (* Initially, we have :
    pp_max_indent = pp_margin - pp_min_space_left, and
    pp_space_left = pp_margin. *)
 let pp_set_max_indent state n =
   pp_set_min_space_left state (state.pp_margin - n)
-;;
 
-let pp_get_max_indent state () = state.pp_max_indent;;
+
+let pp_get_max_indent state () = state.pp_max_indent
 
 let pp_set_margin state n =
   if n >= 1 then
@@ -865,9 +865,9 @@ let pp_set_margin state n =
                 (state.pp_margin / 2)) 1 in
     (* Rebuild invariants. *)
     pp_set_max_indent state new_max_indent
-;;
 
-let pp_get_margin state () = state.pp_margin;;
+
+let pp_get_margin state () = state.pp_margin
 
 (* Setting a formatter basic output functions. *)
 let pp_set_formatter_out_functions state {
@@ -879,8 +879,8 @@ let pp_set_formatter_out_functions state {
   state.pp_out_string <- f;
   state.pp_out_flush <- g;
   state.pp_out_newline <- h;
-  state.pp_out_spaces <- i;
-;;
+  state.pp_out_spaces <- i
+
 
 let pp_get_formatter_out_functions state () = {
   out_string = state.pp_out_string;
@@ -888,21 +888,21 @@ let pp_get_formatter_out_functions state () = {
   out_newline = state.pp_out_newline;
   out_spaces = state.pp_out_spaces;
 }
-;;
+
 
 (* Setting a formatter basic string output and flush functions. *)
 let pp_set_formatter_output_functions state f g =
   state.pp_out_string <- f; state.pp_out_flush <- g
-;;
+
 let pp_get_formatter_output_functions state () =
   (state.pp_out_string, state.pp_out_flush)
-;;
+
 
 (* The default function to output new lines. *)
-let display_newline state () = state.pp_out_string "\n" 0  1;;
+let display_newline state () = state.pp_out_string "\n" 0  1
 
 (* The default function to output spaces. *)
-let blank_line = String.make 80 ' ';;
+let blank_line = String.make 80 ' '
 let rec display_blanks state n =
   if n > 0 then
   if n <= 80 then state.pp_out_string blank_line 0 n else
@@ -910,7 +910,7 @@ let rec display_blanks state n =
     state.pp_out_string blank_line 0 80;
     display_blanks state (n - 80)
   end
-;;
+
 
 (* Setting a formatter basic output functions as printing to a given
    [Pervasive.out_channel] value. *)
@@ -918,8 +918,8 @@ let pp_set_formatter_out_channel state os =
   state.pp_out_string <- output_substring os;
   state.pp_out_flush <- (fun () -> flush os);
   state.pp_out_newline <- display_newline state;
-  state.pp_out_spaces <- display_blanks state;
-;;
+  state.pp_out_spaces <- display_blanks state
+
 
 (*
 
@@ -927,11 +927,11 @@ let pp_set_formatter_out_channel state os =
 
 *)
 
-let default_pp_mark_open_tag s = "<" ^ s ^ ">";;
-let default_pp_mark_close_tag s = "</" ^ s ^ ">";;
+let default_pp_mark_open_tag s = "<" ^ s ^ ">"
+let default_pp_mark_close_tag s = "</" ^ s ^ ">"
 
-let default_pp_print_open_tag = ignore;;
-let default_pp_print_close_tag = ignore;;
+let default_pp_print_open_tag = ignore
+let default_pp_print_close_tag = ignore
 
 (* Bulding a formatter given its basic output functions.
    Other fields get reasonable default values. *)
@@ -974,7 +974,7 @@ let pp_make_formatter f g h i =
     pp_print_close_tag = default_pp_print_close_tag;
     pp_queue = pp_queue;
   }
-;;
+
 
 (* Make a formatter with default functions to output spaces and new lines. *)
 let make_formatter output flush =
@@ -982,33 +982,33 @@ let make_formatter output flush =
   ppf.pp_out_newline <- display_newline ppf;
   ppf.pp_out_spaces <- display_blanks ppf;
   ppf
-;;
+
 
 (* Make a formatter writing to a given [Pervasive.out_channel] value. *)
 let formatter_of_out_channel oc =
   make_formatter (output_substring oc) (fun () -> flush oc)
-;;
+
 
 (* Make a formatter writing to a given [Buffer.t] value. *)
 let formatter_of_buffer b =
   make_formatter (Buffer.add_substring b) ignore
-;;
+
 
 (* Allocating buffer for pretty-printing purposes.
    Default buffer size is pp_buffer_size or 512.
 *)
-let pp_buffer_size = 512;;
-let pp_make_buffer () = Buffer.create pp_buffer_size;;
+let pp_buffer_size = 512
+let pp_make_buffer () = Buffer.create pp_buffer_size
 
 (* The standard (shared) buffer. *)
-let stdbuf = pp_make_buffer ();;
+let stdbuf = pp_make_buffer ()
 
 (* Predefined formatters standard formatter to print
    to [Pervasives.stdout], [Pervasives.stderr], and {!stdbuf}. *)
 let std_formatter = formatter_of_out_channel Pervasives.stdout
 and err_formatter = formatter_of_out_channel Pervasives.stderr
 and str_formatter = formatter_of_buffer stdbuf
-;;
+
 
 (* [flush_buffer_formatter buf ppf] flushes formatter [ppf],
    then return the contents of buffer [buff] thst is reset.
@@ -1019,10 +1019,10 @@ let flush_buffer_formatter buf ppf =
   let s = Buffer.contents buf in
   Buffer.reset buf;
   s
-;;
+
 
 (* Flush [str_formatter] and get the contents of [stdbuf]. *)
-let flush_str_formatter () = flush_buffer_formatter stdbuf str_formatter;;
+let flush_str_formatter () = flush_buffer_formatter stdbuf str_formatter
 
 (*
 
@@ -1100,7 +1100,7 @@ and get_mark_tags =
   pp_get_mark_tags std_formatter
 and set_tags =
   pp_set_tags std_formatter
-;;
+
 
 (* Convenience functions *)
 
@@ -1250,10 +1250,10 @@ let kfprintf k ppf (Format (fmt, _)) =
 and ikfprintf k ppf (Format (fmt, _)) =
   make_iprintf k ppf fmt
 
-let fprintf ppf = kfprintf ignore ppf;;
-let ifprintf ppf = ikfprintf ignore ppf;;
-let printf fmt = fprintf std_formatter fmt;;
-let eprintf fmt = fprintf err_formatter fmt;;
+let fprintf ppf = kfprintf ignore ppf
+let ifprintf ppf = ikfprintf ignore ppf
+let printf fmt = fprintf std_formatter fmt
+let eprintf fmt = fprintf err_formatter fmt
 
 let ksprintf k (Format (fmt, _)) =
   let b = pp_make_buffer () in
@@ -1262,9 +1262,9 @@ let ksprintf k (Format (fmt, _)) =
     strput_acc ppf acc;
     k (flush_buffer_formatter b ppf) in
   make_printf k () End_of_acc fmt
-;;
 
-let sprintf fmt = ksprintf (fun s -> s) fmt;;
+
+let sprintf fmt = ksprintf (fun s -> s) fmt
 
 let kasprintf k (Format (fmt, _)) =
   let b = pp_make_buffer () in
@@ -1273,13 +1273,13 @@ let kasprintf k (Format (fmt, _)) =
     output_acc ppf acc;
     k (flush_buffer_formatter b ppf) in
   make_printf k ppf End_of_acc fmt
-;;
 
-let asprintf fmt = kasprintf (fun s -> s) fmt;;
+
+let asprintf fmt = kasprintf (fun s -> s) fmt
 
 (* Output everything left in the pretty printer queue at end of execution. *)
-at_exit print_flush
-;;
+let () = at_exit print_flush
+
 
 (*
 
@@ -1292,24 +1292,24 @@ let pp_set_all_formatter_output_functions state
     ~out:f ~flush:g ~newline:h ~spaces:i =
   pp_set_formatter_output_functions state f g;
   state.pp_out_newline <- h;
-  state.pp_out_spaces <- i;
-;;
+  state.pp_out_spaces <- i
+
 
 (* Deprecated : subsumed by pp_get_formatter_out_functions *)
 let pp_get_all_formatter_output_functions state () =
   (state.pp_out_string, state.pp_out_flush,
    state.pp_out_newline, state.pp_out_spaces)
-;;
+
 
 (* Deprecated : subsumed by set_formatter_out_functions *)
 let set_all_formatter_output_functions =
   pp_set_all_formatter_output_functions std_formatter
-;;
+
 
 (* Deprecated : subsumed by get_formatter_out_functions *)
 let get_all_formatter_output_functions =
   pp_get_all_formatter_output_functions std_formatter
-;;
+
 
 (* Deprecated : error prone function, do not use it.
    Define a formatter of your own writing to the buffer,
@@ -1319,7 +1319,7 @@ let get_all_formatter_output_functions =
 let bprintf b (Format (fmt, _) : ('a, formatter, unit) format) =
   let k ppf acc = output_acc ppf acc; pp_flush_queue ppf false in
   make_printf k (formatter_of_buffer b) End_of_acc fmt
-;;
+
 
 (* Deprecated : alias for ksprintf. *)
-let kprintf = ksprintf;;
+let kprintf = ksprintf

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -30,7 +30,7 @@ type stat = {
   compactions : int;
   top_heap_words : int;
   stack_size : int;
-};;
+}
 
 type control = {
   mutable minor_heap_size : int;
@@ -41,24 +41,24 @@ type control = {
   mutable stack_limit : int;
   mutable allocation_policy : int;
   window_size : int;
-};;
+}
 
-external stat : unit -> stat = "caml_gc_stat";;
-external quick_stat : unit -> stat = "caml_gc_quick_stat";;
-external counters : unit -> (float * float * float) = "caml_gc_counters";;
-external get : unit -> control = "caml_gc_get";;
-external set : control -> unit = "caml_gc_set";;
-external minor : unit -> unit = "caml_gc_minor";;
-external major_slice : int -> int = "caml_gc_major_slice";;
-external major : unit -> unit = "caml_gc_major";;
-external full_major : unit -> unit = "caml_gc_full_major";;
-external compact : unit -> unit = "caml_gc_compaction";;
+external stat : unit -> stat = "caml_gc_stat"
+external quick_stat : unit -> stat = "caml_gc_quick_stat"
+external counters : unit -> (float * float * float) = "caml_gc_counters"
+external get : unit -> control = "caml_gc_get"
+external set : control -> unit = "caml_gc_set"
+external minor : unit -> unit = "caml_gc_minor"
+external major_slice : int -> int = "caml_gc_major_slice"
+external major : unit -> unit = "caml_gc_major"
+external full_major : unit -> unit = "caml_gc_full_major"
+external compact : unit -> unit = "caml_gc_compaction"
 external get_minor_free : unit -> int = "caml_get_minor_free" [@@noalloc]
 external get_bucket : int -> int = "caml_get_major_bucket" [@@noalloc]
 external get_credit : unit -> int = "caml_get_major_credit" [@@noalloc]
 external huge_fallback_count : unit -> int = "caml_gc_huge_fallback_count"
 
-open Printf;;
+open Printf
 
 let print_stat c =
   let st = stat () in
@@ -81,32 +81,32 @@ let print_stat c =
   fprintf c "\n";
   fprintf c "live_blocks: %d\n" st.live_blocks;
   fprintf c "free_blocks: %d\n" st.free_blocks;
-  fprintf c "heap_chunks: %d\n" st.heap_chunks;
-;;
+  fprintf c "heap_chunks: %d\n" st.heap_chunks
+
 
 let allocated_bytes () =
   let (mi, pro, ma) = counters () in
   (mi +. ma -. pro) *. float_of_int (Sys.word_size / 8)
-;;
-
-external finalise : ('a -> unit) -> 'a -> unit = "caml_final_register";;
-external finalise_release : unit -> unit = "caml_final_release";;
 
 
-type alarm = bool ref;;
-type alarm_rec = {active : alarm; f : unit -> unit};;
+external finalise : ('a -> unit) -> 'a -> unit = "caml_final_register"
+external finalise_release : unit -> unit = "caml_final_release"
+
+
+type alarm = bool ref
+type alarm_rec = {active : alarm; f : unit -> unit}
 
 let rec call_alarm arec =
   if !(arec.active) then begin
     finalise call_alarm arec;
     arec.f ();
-  end;
-;;
+  end
+
 
 let create_alarm f =
   let arec = { active = ref true; f = f } in
   finalise call_alarm arec;
   arec.active
-;;
 
-let delete_alarm a = a := false;;
+
+let delete_alarm a = a := false

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -180,7 +180,7 @@ external set : control -> unit = "caml_gc_set"
 external minor : unit -> unit = "caml_gc_minor"
 (** Trigger a minor collection. *)
 
-external major_slice : int -> int = "caml_gc_major_slice";;
+external major_slice : int -> int = "caml_gc_major_slice"
 (** [major_slice n]
     Do a minor collection and a slice of major collection. [n] is the
     size of the slice: the GC will do enough work to free (on average)
@@ -257,7 +257,7 @@ val finalise : ('a -> unit) -> 'a -> unit
 
    Instead you should make sure that [v] is not in the closure of
    the finalisation function by writing:
-   - [ let f = fun x -> ... ;; let v = ... in Gc.finalise f v ]
+   - [ let f = fun x -> ...  let v = ... in Gc.finalise f v ]
 
 
    The [f] function can use all features of OCaml, including
@@ -289,7 +289,7 @@ val finalise : ('a -> unit) -> 'a -> unit
    heap-allocated and non-constant except when the length argument is [0].
 *)
 
-val finalise_release : unit -> unit;;
+val finalise_release : unit -> unit
 (** A finalisation function may call [finalise_release] to tell the
     GC that it can launch the next finalisation function without waiting
     for the current one to return. *)

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -227,7 +227,7 @@ val stats : ('a, 'b) t -> statistics
       module IntHashtbl = Hashtbl.Make(IntHash)
 
       let h = IntHashtbl.create 17 in
-      IntHashtbl.add h 12 "hello";;
+      IntHashtbl.add h 12 "hello"
     ]}
 
     This creates a new module [IntHashtbl], with a new type ['a

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -244,8 +244,10 @@ module type HashedType =
   sig
     type t
       (** The type of the hashtable keys. *)
+
     val equal : t -> t -> bool
       (** The equality predicate used to compare keys. *)
+
     val hash : t -> int
       (** A hashing function on keys. It must be such that if two keys are
           equal according to [equal], then they have identical hash values
@@ -300,8 +302,10 @@ module type SeededHashedType =
   sig
     type t
       (** The type of the hashtable keys. *)
+
     val equal: t -> t -> bool
       (** The equality predicate used to compare keys. *)
+
     val hash: int -> t -> int
       (** A seeded hashing function on keys.  The first argument is
           the seed.  It must be the case that if [equal x y] is true,

--- a/stdlib/lazy.ml
+++ b/stdlib/lazy.ml
@@ -45,23 +45,23 @@
    rules for the [lazy] keyword.
 *)
 
-type 'a t = 'a lazy_t;;
+type 'a t = 'a lazy_t
 
-exception Undefined = CamlinternalLazy.Undefined;;
+exception Undefined = CamlinternalLazy.Undefined
 
-external make_forward : 'a -> 'a lazy_t = "caml_lazy_make_forward";;
+external make_forward : 'a -> 'a lazy_t = "caml_lazy_make_forward"
 
-external force : 'a t -> 'a = "%lazy_force";;
+external force : 'a t -> 'a = "%lazy_force"
 
-(* let force = force;; *)
+(* let force = force *)
 
-let force_val = CamlinternalLazy.force_val;;
+let force_val = CamlinternalLazy.force_val
 
 let from_fun (f : unit -> 'arg) =
   let x = Obj.new_block Obj.lazy_tag 1 in
   Obj.set_field x 0 (Obj.repr f);
   (Obj.obj x : 'arg t)
-;;
+
 
 let from_val (v : 'arg) =
   let t = Obj.tag (Obj.repr v) in
@@ -70,12 +70,12 @@ let from_val (v : 'arg) =
   end else begin
     (Obj.magic v : 'arg t)
   end
-;;
 
-let is_val (l : 'arg t) = Obj.tag (Obj.repr l) <> Obj.lazy_tag;;
 
-let lazy_from_fun = from_fun;;
+let is_val (l : 'arg t) = Obj.tag (Obj.repr l) <> Obj.lazy_tag
 
-let lazy_from_val = from_val;;
+let lazy_from_fun = from_fun
 
-let lazy_is_val = is_val;;
+let lazy_from_val = from_val
+
+let lazy_is_val = is_val

--- a/stdlib/lazy.mli
+++ b/stdlib/lazy.mli
@@ -15,7 +15,7 @@
 
 (** Deferred computations. *)
 
-type 'a t = 'a lazy_t;;
+type 'a t = 'a lazy_t
 (** A value of type ['a Lazy.t] is a deferred computation, called
    a suspension, that has a result of type ['a].  The special
    expression syntax [lazy (expr)] makes a suspension of the
@@ -40,10 +40,10 @@ type 'a t = 'a lazy_t;;
 *)
 
 
-exception Undefined;;
+exception Undefined
 
-(* val force : 'a t -> 'a ;; *)
-external force : 'a t -> 'a = "%lazy_force";;
+(* val force : 'a t -> 'a  *)
+external force : 'a t -> 'a = "%lazy_force"
 (** [force x] forces the suspension [x] and returns its result.
    If [x] has already been forced, [Lazy.force x] returns the
    same value again without recomputing it.  If it raised an exception,
@@ -52,7 +52,7 @@ external force : 'a t -> 'a = "%lazy_force";;
    recursively.
 *)
 
-val force_val : 'a t -> 'a;;
+val force_val : 'a t -> 'a
 (** [force_val x] forces the suspension [x] and returns its
     result.  If [x] has already been forced, [force_val x]
     returns the same value again without recomputing it.
@@ -62,7 +62,7 @@ val force_val : 'a t -> 'a;;
     whether [force_val x] raises the same exception or [Undefined].
 *)
 
-val from_fun : (unit -> 'a) -> 'a t;;
+val from_fun : (unit -> 'a) -> 'a t
 (** [from_fun f] is the same as [lazy (f ())] but slightly more efficient.
 
     [from_fun] should only be used if the function [f] is already defined.
@@ -71,25 +71,25 @@ val from_fun : (unit -> 'a) -> 'a t;;
 
     @since 4.00.0 *)
 
-val from_val : 'a -> 'a t;;
+val from_val : 'a -> 'a t
 (** [from_val v] returns an already-forced suspension of [v].
     This is for special purposes only and should not be confused with
     [lazy (v)].
     @since 4.00.0 *)
 
-val is_val : 'a t -> bool;;
+val is_val : 'a t -> bool
 (** [is_val x] returns [true] if [x] has already been forced and
     did not raise an exception.
     @since 4.00.0 *)
 
 val lazy_from_fun : (unit -> 'a) -> 'a t
-  [@@ocaml.deprecated "Use Lazy.from_fun instead."];;
+  [@@ocaml.deprecated "Use Lazy.from_fun instead."]
 (** @deprecated synonym for [from_fun]. *)
 
 val lazy_from_val : 'a -> 'a t
-  [@@ocaml.deprecated "Use Lazy.from_val instead."];;
+  [@@ocaml.deprecated "Use Lazy.from_val instead."]
 (** @deprecated synonym for [from_val]. *)
 
 val lazy_is_val : 'a t -> bool
-  [@@ocaml.deprecated "Use Lazy.is_val instead."];;
+  [@@ocaml.deprecated "Use Lazy.is_val instead."]
 (** @deprecated synonym for [is_val]. *)

--- a/stdlib/lexing.ml
+++ b/stdlib/lexing.ml
@@ -69,7 +69,7 @@ let engine tbl state buf =
                        with pos_cnum = buf.lex_abs_pos + buf.lex_curr_pos};
   end;
   result
-;;
+
 
 let new_engine tbl state buf =
   let result = c_new_engine tbl state buf in
@@ -79,7 +79,7 @@ let new_engine tbl state buf =
                        with pos_cnum = buf.lex_abs_pos + buf.lex_curr_pos};
   end;
   result
-;;
+
 
 let lex_refill read_fun aux_buffer lexbuf =
   let read =
@@ -143,7 +143,7 @@ let zero_pos = {
   pos_lnum = 1;
   pos_bol = 0;
   pos_cnum = 0;
-};;
+}
 
 let from_function f =
   { refill_buff = lex_refill f (Bytes.create 512);
@@ -207,11 +207,11 @@ let sub_lexeme_char_opt lexbuf i =
 let lexeme_char lexbuf i =
   Bytes.get lexbuf.lex_buffer (lexbuf.lex_start_pos + i)
 
-let lexeme_start lexbuf = lexbuf.lex_start_p.pos_cnum;;
-let lexeme_end lexbuf = lexbuf.lex_curr_p.pos_cnum;;
+let lexeme_start lexbuf = lexbuf.lex_start_p.pos_cnum
+let lexeme_end lexbuf = lexbuf.lex_curr_p.pos_cnum
 
-let lexeme_start_p lexbuf = lexbuf.lex_start_p;;
-let lexeme_end_p lexbuf = lexbuf.lex_curr_p;;
+let lexeme_start_p lexbuf = lexbuf.lex_start_p
+let lexeme_end_p lexbuf = lexbuf.lex_curr_p
 
 let new_line lexbuf =
   let lcp = lexbuf.lex_curr_p in
@@ -219,7 +219,7 @@ let new_line lexbuf =
     pos_lnum = lcp.pos_lnum + 1;
     pos_bol = lcp.pos_cnum;
   }
-;;
+
 
 
 (* Discard data left in lexer buffer. *)
@@ -229,4 +229,4 @@ let flush_input lb =
   lb.lex_abs_pos <- 0;
   lb.lex_curr_p <- {lb.lex_curr_p with pos_cnum = 0};
   lb.lex_buffer_len <- 0;
-;;
+

--- a/stdlib/lexing.mli
+++ b/stdlib/lexing.mli
@@ -37,7 +37,7 @@ type position = {
    how the lexing engine will manage positions.
  *)
 
-val dummy_pos : position;;
+val dummy_pos : position
 (** A value of type [position], guaranteed to be different from any
    valid position.
  *)

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -70,7 +70,7 @@ let rev_map f l =
     | a::l -> rmap_f (f a :: accu) l
   in
   rmap_f [] l
-;;
+
 
 let rec iter f = function
     [] -> ()
@@ -106,7 +106,7 @@ let rev_map2 f l1 l2 =
     | (_, _) -> invalid_arg "List.rev_map2"
   in
   rmap2_f [] l1 l2
-;;
+
 
 let rec iter2 f l1 l2 =
   match (l1, l2) with
@@ -218,7 +218,7 @@ let rec merge cmp l1 l2 =
       if cmp h1 h2 <= 0
       then h1 :: merge cmp t1 l2
       else h2 :: merge cmp l1 t2
-;;
+
 
 let rec chop k l =
   if k = 0 then l else begin
@@ -226,7 +226,7 @@ let rec chop k l =
     | x::t -> chop (k-1) t
     | _ -> assert false
   end
-;;
+
 
 let stable_sort cmp l =
   let rec rev_merge l1 l2 accu =
@@ -292,10 +292,10 @@ let stable_sort cmp l =
   in
   let len = length l in
   if len < 2 then l else sort len l
-;;
 
-let sort = stable_sort;;
-let fast_sort = stable_sort;;
+
+let sort = stable_sort
+let fast_sort = stable_sort
 
 (* Note: on a list of length between about 100000 (depending on the minor
    heap size and the type of the list) and Sys.max_array_size, it is
@@ -320,13 +320,13 @@ let array_to_list_in_place a =
     end
   in
   loop [] (l-1000) l
-;;
+
 
 let stable_sort cmp l =
   let a = Array.of_list l in
   Array.stable_sort cmp a;
   array_to_list_in_place a
-;;
+
 *)
 
 
@@ -430,4 +430,4 @@ let sort_uniq cmp l =
   in
   let len = length l in
   if len < 2 then l else sort len l
-;;
+

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -47,6 +47,7 @@ module type OrderedType =
   sig
     type t
       (** The type of the map keys. *)
+
     val compare : t -> t -> int
       (** A total ordering function over the keys.
           This is a two-argument function [f] such that

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -100,32 +100,43 @@ module Ephemeron: sig
   val create: int -> t
   (** [create n] returns an ephemeron with [n] keys.
       All the keys and the data are initially empty *)
+
   val length: t -> int
   (** return the number of keys *)
 
   val get_key: t -> int -> obj_t option
   (** Same as {!Ephemeron.K1.get_key} *)
+
   val get_key_copy: t -> int -> obj_t option
   (** Same as {!Ephemeron.K1.get_key_copy} *)
+
   val set_key: t -> int -> obj_t -> unit
   (** Same as {!Ephemeron.K1.set_key} *)
+
   val unset_key: t -> int -> unit
   (** Same as {!Ephemeron.K1.unset_key} *)
+
   val check_key: t -> int -> bool
   (** Same as {!Ephemeron.K1.check_key} *)
+
   val blit_key : t -> int -> t -> int -> int -> unit
   (** Same as {!Ephemeron.K1.blit_key} *)
 
   val get_data: t -> obj_t option
   (** Same as {!Ephemeron.K1.get_data} *)
+
   val get_data_copy: t -> obj_t option
   (** Same as {!Ephemeron.K1.get_data_copy} *)
+
   val set_data: t -> obj_t -> unit
   (** Same as {!Ephemeron.K1.set_data} *)
+
   val unset_data: t -> unit
   (** Same as {!Ephemeron.K1.unset_data} *)
+
   val check_data: t -> bool
   (** Same as {!Ephemeron.K1.check_data} *)
+
   val blit_data : t -> t -> unit
   (** Same as {!Ephemeron.K1.blit_data} *)
 end

--- a/stdlib/parsing.ml
+++ b/stdlib/parsing.ml
@@ -195,15 +195,15 @@ let symbol_start_pos () =
     end
   in
   loop env.rule_len
-;;
-let symbol_end_pos () = env.symb_end_stack.(env.asp);;
-let rhs_start_pos n = env.symb_start_stack.(env.asp - (env.rule_len - n));;
-let rhs_end_pos n = env.symb_end_stack.(env.asp - (env.rule_len - n));;
 
-let symbol_start () = (symbol_start_pos ()).pos_cnum;;
-let symbol_end () = (symbol_end_pos ()).pos_cnum;;
-let rhs_start n = (rhs_start_pos n).pos_cnum;;
-let rhs_end n = (rhs_end_pos n).pos_cnum;;
+let symbol_end_pos () = env.symb_end_stack.(env.asp)
+let rhs_start_pos n = env.symb_start_stack.(env.asp - (env.rule_len - n))
+let rhs_end_pos n = env.symb_end_stack.(env.asp - (env.rule_len - n))
+
+let symbol_start () = (symbol_start_pos ()).pos_cnum
+let symbol_end () = (symbol_end_pos ()).pos_cnum
+let rhs_start n = (rhs_start_pos n).pos_cnum
+let rhs_end n = (rhs_end_pos n).pos_cnum
 
 let is_current_lookahead tok =
   (!current_lookahead_fun)(Obj.repr tok)

--- a/stdlib/parsing.mli
+++ b/stdlib/parsing.mli
@@ -35,7 +35,7 @@ val rhs_start : int -> int
 val rhs_end : int -> int
 (** See {!Parsing.rhs_start}. *)
 
-val symbol_start_pos : unit -> Lexing.position;;
+val symbol_start_pos : unit -> Lexing.position
 (** Same as [symbol_start], but return a [position] instead of an offset. *)
 
 val symbol_end_pos : unit -> Lexing.position

--- a/stdlib/pervasives.ml
+++ b/stdlib/pervasives.ml
@@ -256,9 +256,9 @@ let valid_float_lexem s =
     | _ -> s
   in
   loop 0
-;;
 
-let string_of_float f = valid_float_lexem (format_float "%.12g" f);;
+
+let string_of_float f = valid_float_lexem (format_float "%.12g" f)
 
 external float_of_string : string -> float = "caml_float_of_string"
 
@@ -438,7 +438,7 @@ external seek_in : in_channel -> int -> unit = "caml_ml_seek_in"
 external pos_in : in_channel -> int = "caml_ml_pos_in"
 external in_channel_length : in_channel -> int = "caml_ml_channel_size"
 external close_in : in_channel -> unit = "caml_ml_close_channel"
-let close_in_noerr ic = (try close_in ic with _ -> ());;
+let close_in_noerr ic = (try close_in ic with _ -> ())
 external set_binary_mode_in : in_channel -> bool -> unit
                             = "caml_ml_set_binary_mode"
 

--- a/stdlib/pervasives.mli
+++ b/stdlib/pervasives.mli
@@ -152,21 +152,25 @@ external __LOC__ : string = "%loc_LOC"
     error format of OCaml: "File %S, line %d, characters %d-%d".
     @since 4.02.0
  *)
+
 external __FILE__ : string = "%loc_FILE"
 (** [__FILE__] returns the name of the file currently being
     parsed by the compiler.
     @since 4.02.0
 *)
+
 external __LINE__ : int = "%loc_LINE"
 (** [__LINE__] returns the line number at which this expression
     appears in the file currently being parsed by the compiler.
     @since 4.02.0
  *)
+
 external __MODULE__ : string = "%loc_MODULE"
 (** [__MODULE__] returns the module name of the file being
     parsed by the compiler.
     @since 4.02.0
  *)
+
 external __POS__ : string * int * int * int = "%loc_POS"
 (** [__POS__] returns a tuple [(file,lnum,cnum,enum)], corresponding
     to the location at which this expression appears in the file
@@ -183,12 +187,14 @@ external __LOC_OF__ : 'a -> string * 'a = "%loc_LOC"
     %d, characters %d-%d".
     @since 4.02.0
  *)
+
 external __LINE_OF__ : 'a -> int * 'a = "%loc_LINE"
 (** [__LINE__ expr] returns a pair [(line, expr)], where [line] is the
     line number at which the expression [expr] appears in the file
     currently being parsed by the compiler.
     @since 4.02.0
  *)
+
 external __POS_OF__ : 'a -> (string * int * int * int) * 'a = "%loc_POS"
 (** [__POS_OF__ expr] returns a pair [(loc,expr)], where [loc] is a
     tuple [(file,lnum,cnum,enum)] corresponding to the location at

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -13,11 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Printf;;
+open Printf
 
 let printers = ref []
 
-let locfmt = format_of_string "File \"%s\", line %d, characters %d-%d: %s";;
+let locfmt = format_of_string "File \"%s\", line %d, characters %d-%d: %s"
 
 let field x i =
   let f = Obj.field x i in
@@ -29,18 +29,18 @@ let field x i =
     string_of_float (Obj.magic f : float)
   else
     "_"
-;;
+
 let rec other_fields x i =
   if i >= Obj.size x then ""
   else sprintf ", %s%s" (field x i) (other_fields x (i+1))
-;;
+
 let fields x =
   match Obj.size x with
   | 0 -> ""
   | 1 -> ""
   | 2 -> sprintf "(%s)" (field x 1)
   | n -> sprintf "(%s%s)" (field x 1) (other_fields x 2)
-;;
+
 
 let to_string x =
   let rec conv = function

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -25,17 +25,17 @@
    passes all the Diehard tests.
 *)
 
-external random_seed: unit -> int array = "caml_sys_random_seed";;
+external random_seed: unit -> int array = "caml_sys_random_seed"
 
 module State = struct
 
-  type t = { st : int array; mutable idx : int };;
+  type t = { st : int array; mutable idx : int }
 
-  let new_state () = { st = Array.make 55 0; idx = 0 };;
+  let new_state () = { st = Array.make 55 0; idx = 0 }
   let assign st1 st2 =
     Array.blit st2.st 0 st1.st 0 55;
-    st1.idx <- st2.idx;
-  ;;
+    st1.idx <- st2.idx
+  
 
   let full_init s seed =
     let combine accu x = Digest.string (accu ^ string_of_int x) in
@@ -55,22 +55,22 @@ module State = struct
       accu := combine !accu seed.(k);
       s.st.(j) <- (s.st.(j) lxor extract !accu) land 0x3FFFFFFF;  (* PR#5575 *)
     done;
-    s.idx <- 0;
-  ;;
+    s.idx <- 0
+  
 
   let make seed =
     let result = new_state () in
     full_init result seed;
     result
-  ;;
+  
 
-  let make_self_init () = make (random_seed ());;
+  let make_self_init () = make (random_seed ())
 
   let copy s =
     let result = new_state () in
     assign result s;
     result
-  ;;
+  
 
   (* Returns 30 random bits as an integer 0 <= x < 1073741824 *)
   let bits s =
@@ -81,18 +81,18 @@ module State = struct
     let newval30 = newval land 0x3FFFFFFF in  (* PR#5575 *)
     s.st.(s.idx) <- newval30;
     newval30
-  ;;
+  
 
   let rec intaux s n =
     let r = bits s in
     let v = r mod n in
     if r - v > 0x3FFFFFFF - n + 1 then intaux s n else v
-  ;;
+  
   let int s bound =
     if bound > 0x3FFFFFFF || bound <= 0
     then invalid_arg "Random.int"
     else intaux s bound
-  ;;
+  
 
   let rec int32aux s n =
     let b1 = Int32.of_int (bits s) in
@@ -102,12 +102,12 @@ module State = struct
     if Int32.sub r v > Int32.add (Int32.sub Int32.max_int n) 1l
     then int32aux s n
     else v
-  ;;
+  
   let int32 s bound =
     if bound <= 0l
     then invalid_arg "Random.int32"
     else int32aux s bound
-  ;;
+  
 
   let rec int64aux s n =
     let b1 = Int64.of_int (bits s) in
@@ -118,18 +118,18 @@ module State = struct
     if Int64.sub r v > Int64.add (Int64.sub Int64.max_int n) 1L
     then int64aux s n
     else v
-  ;;
+  
   let int64 s bound =
     if bound <= 0L
     then invalid_arg "Random.int64"
     else int64aux s bound
-  ;;
+  
 
   let nativeint =
     if Nativeint.size = 32
     then fun s bound -> Nativeint.of_int32 (int32 s (Nativeint.to_int32 bound))
     else fun s bound -> Int64.to_nativeint (int64 s (Int64.of_nativeint bound))
-  ;;
+  
 
   (* Returns a float 0 <= x <= 1 with at most 60 bits of precision. *)
   let rawfloat s =
@@ -137,13 +137,13 @@ module State = struct
     and r1 = Pervasives.float (bits s)
     and r2 = Pervasives.float (bits s)
     in (r1 /. scale +. r2) /. scale
-  ;;
+  
 
-  let float s bound = rawfloat s *. bound;;
+  let float s bound = rawfloat s *. bound
 
-  let bool s = (bits s land 1 = 0);;
+  let bool s = (bits s land 1 = 0)
 
-end;;
+end
 
 (* This is the state you get with [init 27182818] and then applying
    the "land 0x3FFFFFFF" filter to them.  See #5575, #5793, #5977. *)
@@ -161,24 +161,24 @@ let default = {
       0x2fbf967a;
     |];
   State.idx = 0;
-};;
+}
 
-let bits () = State.bits default;;
-let int bound = State.int default bound;;
-let int32 bound = State.int32 default bound;;
-let nativeint bound = State.nativeint default bound;;
-let int64 bound = State.int64 default bound;;
-let float scale = State.float default scale;;
-let bool () = State.bool default;;
+let bits () = State.bits default
+let int bound = State.int default bound
+let int32 bound = State.int32 default bound
+let nativeint bound = State.nativeint default bound
+let int64 bound = State.int64 default bound
+let float scale = State.float default scale
+let bool () = State.bool default
 
-let full_init seed = State.full_init default seed;;
-let init seed = State.full_init default [| seed |];;
-let self_init () = full_init (random_seed());;
+let full_init seed = State.full_init default seed
+let init seed = State.full_init default [| seed |]
+let self_init () = full_init (random_seed())
 
 (* Manipulating the current state. *)
 
-let get_state () = State.copy default;;
-let set_state s = State.assign default s;;
+let get_state () = State.copy default
+let set_state s = State.assign default s
 
 (********************
 
@@ -190,19 +190,19 @@ let set_state s = State.assign default s;;
 
   Some results:
 
-init 27182818; chisquare int 100000 1000;;
-init 27182818; chisquare int 100000 100;;
-init 27182818; chisquare int 100000 5000;;
-init 27182818; chisquare int 1000000 1000;;
-init 27182818; chisquare int 100000 1024;;
-init 299792643; chisquare int 100000 1024;;
-init 14142136; chisquare int 100000 1024;;
-init 27182818; init_diff 1024; chisquare diff 100000 1024;;
-init 27182818; init_diff 100; chisquare diff 100000 100;;
-init 27182818; init_diff2 1024; chisquare diff2 100000 1024;;
-init 27182818; init_diff2 100; chisquare diff2 100000 100;;
-init 14142136; init_diff2 100; chisquare diff2 100000 100;;
-init 299792643; init_diff2 100; chisquare diff2 100000 100;;
+init 27182818; chisquare int 100000 1000
+init 27182818; chisquare int 100000 100
+init 27182818; chisquare int 100000 5000
+init 27182818; chisquare int 1000000 1000
+init 27182818; chisquare int 100000 1024
+init 299792643; chisquare int 100000 1024
+init 14142136; chisquare int 100000 1024
+init 27182818; init_diff 1024; chisquare diff 100000 1024
+init 27182818; init_diff 100; chisquare diff 100000 100
+init 27182818; init_diff2 1024; chisquare diff2 100000 1024
+init 27182818; init_diff2 100; chisquare diff2 100000 100
+init 14142136; init_diff2 100; chisquare diff2 100000 100
+init 299792643; init_diff2 100; chisquare diff2 100000 100
 - : float * float * float = (936.754446796632465, 997.5, 1063.24555320336754)
 # - : float * float * float = (80., 89.7400000000052387, 120.)
 # - : float * float * float = (4858.57864376269, 5045.5, 5141.42135623731)
@@ -225,7 +225,7 @@ let rec sumsq v i0 i1 =
   if i0 >= i1 then 0.0
   else if i1 = i0 + 1 then Pervasives.float v.(i0) *. Pervasives.float v.(i0)
   else sumsq v i0 ((i0+i1)/2) +. sumsq v ((i0+i1)/2) i1
-;;
+
 
 let chisquare g n r =
   if n <= 10 * r then invalid_arg "chisquare";
@@ -239,12 +239,12 @@ let chisquare g n r =
   and n = Pervasives.float n in
   let sr = 2.0 *. sqrt r in
   (r -. sr,   (r *. t /. n) -. n,   r +. sr)
-;;
+
 
 (* This is to test for linear dependencies between successive random numbers.
 *)
-let st = ref 0;;
-let init_diff r = st := int r;;
+let st = ref 0
+let init_diff r = st := int r
 let diff r =
   let x1 = !st
   and x2 = int r
@@ -254,16 +254,16 @@ let diff r =
     x1 - x2
   else
     r + x1 - x2
-;;
+
 
 let st1 = ref 0
 and st2 = ref 0
-;;
+
 
 (* This is to test for quadratic dependencies between successive random
    numbers.
 *)
-let init_diff2 r = st1 := int r; st2 := int r;;
+let init_diff2 r = st1 := int r; st2 := int r
 let diff2 r =
   let x1 = !st1
   and x2 = !st2
@@ -272,6 +272,6 @@ let diff2 r =
   st1 := x2;
   st2 := x3;
   (x3 - x2 - x2 + x1 + 2*r) mod r
-;;
+
 
 ********************)

--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -42,15 +42,15 @@ val int : int -> int
      and [bound] (exclusive).  [bound] must be greater than 0 and less
      than 2{^30}. *)
 
-val int32 : Int32.t -> Int32.t;;
+val int32 : Int32.t -> Int32.t
 (** [Random.int32 bound] returns a random integer between 0 (inclusive)
      and [bound] (exclusive).  [bound] must be greater than 0. *)
 
-val nativeint : Nativeint.t -> Nativeint.t;;
+val nativeint : Nativeint.t -> Nativeint.t
 (** [Random.nativeint bound] returns a random integer between 0 (inclusive)
      and [bound] (exclusive).  [bound] must be greater than 0. *)
 
-val int64 : Int64.t -> Int64.t;;
+val int64 : Int64.t -> Int64.t
 (** [Random.int64 bound] returns a random integer between 0 (inclusive)
      and [bound] (exclusive).  [bound] must be greater than 0. *)
 
@@ -97,7 +97,7 @@ module State : sig
   (** These functions are the same as the basic functions, except that they
       use (and update) the given PRNG state instead of the default one.
   *)
-end;;
+end
 
 
 val get_state : unit -> State.t

--- a/stdlib/scanf.ml
+++ b/stdlib/scanf.ml
@@ -25,129 +25,129 @@ open CamlinternalFormat
 *)
 type ('a, 'b, 'c, 'd, 'e, 'f) format6 =
   ('a, 'b, 'c, 'd, 'e, 'f) Pervasives.format6
-;;
+
 
 (* The run-time library for scanners. *)
 
 (* Scanning buffers. *)
 module type SCANNING = sig
 
-  type in_channel;;
+  type in_channel
 
-  type scanbuf = in_channel;;
+  type scanbuf = in_channel
 
-  type file_name = string;;
+  type file_name = string
 
-  val stdin : in_channel;;
+  val stdin : in_channel
   (* The scanning buffer reading from [Pervasives.stdin].
      [stdib] is equivalent to [Scanning.from_channel Pervasives.stdin]. *)
 
-  val stdib : in_channel;;
+  val stdib : in_channel
   (* An alias for [Scanf.stdin], the scanning buffer reading from
      [Pervasives.stdin]. *)
 
-  val next_char : scanbuf -> char;;
+  val next_char : scanbuf -> char
   (* [Scanning.next_char ib] advance the scanning buffer for
      one character.
      If no more character can be read, sets a end of file condition and
      returns '\000'. *)
 
-  val invalidate_current_char : scanbuf -> unit;;
+  val invalidate_current_char : scanbuf -> unit
   (* [Scanning.invalidate_current_char ib] mark the current_char as already
      scanned. *)
 
-  val peek_char : scanbuf -> char;;
+  val peek_char : scanbuf -> char
   (* [Scanning.peek_char ib] returns the current char available in
      the buffer or reads one if necessary (when the current character is
      already scanned).
      If no character can be read, sets an end of file condition and
      returns '\000'. *)
 
-  val checked_peek_char : scanbuf -> char;;
+  val checked_peek_char : scanbuf -> char
   (* Same as [Scanning.peek_char] above but always returns a valid char or
      fails: instead of returning a null char when the reading method of the
      input buffer has reached an end of file, the function raises exception
      [End_of_file]. *)
 
-  val store_char : int -> scanbuf -> char -> int;;
+  val store_char : int -> scanbuf -> char -> int
   (* [Scanning.store_char lim ib c] adds [c] to the token buffer
      of the scanning buffer [ib]. It also advances the scanning buffer for
      one character and returns [lim - 1], indicating the new limit for the
      length of the current token. *)
 
-  val skip_char : int -> scanbuf -> int;;
+  val skip_char : int -> scanbuf -> int
   (* [Scanning.skip_char lim ib] ignores the current character. *)
 
-  val ignore_char : int -> scanbuf -> int;;
+  val ignore_char : int -> scanbuf -> int
   (* [Scanning.ignore_char ib lim] ignores the current character and
      decrements the limit. *)
 
-  val token : scanbuf -> string;;
+  val token : scanbuf -> string
   (* [Scanning.token ib] returns the string stored into the token
      buffer of the scanning buffer: it returns the token matched by the
      format. *)
 
-  val reset_token : scanbuf -> unit;;
+  val reset_token : scanbuf -> unit
   (* [Scanning.reset_token ib] resets the token buffer of
      the given scanning buffer. *)
 
-  val char_count : scanbuf -> int;;
+  val char_count : scanbuf -> int
   (* [Scanning.char_count ib] returns the number of characters
      read so far from the given buffer. *)
 
-  val line_count : scanbuf -> int;;
+  val line_count : scanbuf -> int
   (* [Scanning.line_count ib] returns the number of new line
      characters read so far from the given buffer. *)
 
-  val token_count : scanbuf -> int;;
+  val token_count : scanbuf -> int
   (* [Scanning.token_count ib] returns the number of tokens read
      so far from [ib]. *)
 
-  val eof : scanbuf -> bool;;
+  val eof : scanbuf -> bool
   (* [Scanning.eof ib] returns the end of input condition
      of the given buffer. *)
 
-  val end_of_input : scanbuf -> bool;;
+  val end_of_input : scanbuf -> bool
   (* [Scanning.end_of_input ib] tests the end of input condition
      of the given buffer (if no char has ever been read, an attempt to
      read one is performed). *)
 
-  val beginning_of_input : scanbuf -> bool;;
+  val beginning_of_input : scanbuf -> bool
   (* [Scanning.beginning_of_input ib] tests the beginning of input
      condition of the given buffer. *)
 
-  val name_of_input : scanbuf -> string;;
+  val name_of_input : scanbuf -> string
   (* [Scanning.name_of_input ib] returns the name of the character
      source for input buffer [ib]. *)
 
-  val open_in : file_name -> in_channel;;
-  val open_in_bin : file_name -> in_channel;;
-  val from_file : file_name -> in_channel;;
-  val from_file_bin : file_name -> in_channel;;
-  val from_string : string -> in_channel;;
-  val from_function : (unit -> char) -> in_channel;;
-  val from_channel : Pervasives.in_channel -> in_channel;;
+  val open_in : file_name -> in_channel
+  val open_in_bin : file_name -> in_channel
+  val from_file : file_name -> in_channel
+  val from_file_bin : file_name -> in_channel
+  val from_string : string -> in_channel
+  val from_function : (unit -> char) -> in_channel
+  val from_channel : Pervasives.in_channel -> in_channel
 
-  val close_in : in_channel -> unit;;
+  val close_in : in_channel -> unit
 
-  val memo_from_channel : Pervasives.in_channel -> in_channel;;
+  val memo_from_channel : Pervasives.in_channel -> in_channel
   (* Obsolete. *)
 
 end
-;;
+
 
 module Scanning : SCANNING = struct
 
   (* The run-time library for scanf. *)
 
-  type file_name = string;;
+  type file_name = string
 
   type in_channel_name =
     | From_channel of Pervasives.in_channel
     | From_file of file_name * Pervasives.in_channel
     | From_function
     | From_string
-  ;;
+  
 
   type in_channel = {
     mutable ic_eof : bool;
@@ -160,11 +160,11 @@ module Scanning : SCANNING = struct
     ic_token_buffer : Buffer.t;
     ic_input_name : in_channel_name;
   }
-  ;;
+  
 
-  type scanbuf = in_channel;;
+  type scanbuf = in_channel
 
-  let null_char = '\000';;
+  let null_char = '\000'
 
   (* Reads a new character from input buffer.
      Next_char never fails, even in case of end of input:
@@ -183,13 +183,13 @@ module Scanning : SCANNING = struct
       ib.ic_current_char_is_valid <- false;
       ib.ic_eof <- true;
       c
-  ;;
+  
 
   let peek_char ib =
     if ib.ic_current_char_is_valid
     then ib.ic_current_char
     else next_char ib
-  ;;
+  
 
   (* Returns a valid current char for the input buffer. In particular
      no irrelevant null character (as set by [next_char] in case of end
@@ -200,16 +200,16 @@ module Scanning : SCANNING = struct
     let c = peek_char ib in
     if ib.ic_eof then raise End_of_file;
     c
-  ;;
+  
 
   let end_of_input ib =
     ignore (peek_char ib);
     ib.ic_eof
-  ;;
+  
 
-  let eof ib = ib.ic_eof;;
+  let eof ib = ib.ic_eof
 
-  let beginning_of_input ib = ib.ic_char_count = 0;;
+  let beginning_of_input ib = ib.ic_char_count = 0
 
   let name_of_input ib =
     match ib.ic_input_name with
@@ -217,19 +217,19 @@ module Scanning : SCANNING = struct
     | From_file (fname, _ic) -> fname
     | From_function -> "unnamed function"
     | From_string -> "unnamed character string"
-  ;;
+  
 
   let char_count ib =
     if ib.ic_current_char_is_valid
     then ib.ic_char_count - 1
     else ib.ic_char_count
-  ;;
+  
 
-  let line_count ib = ib.ic_line_count;;
+  let line_count ib = ib.ic_line_count
 
-  let reset_token ib = Buffer.reset ib.ic_token_buffer;;
+  let reset_token ib = Buffer.reset ib.ic_token_buffer
 
-  let invalidate_current_char ib = ib.ic_current_char_is_valid <- false;;
+  let invalidate_current_char ib = ib.ic_current_char_is_valid <- false
 
   let token ib =
     let token_buffer = ib.ic_token_buffer in
@@ -237,23 +237,23 @@ module Scanning : SCANNING = struct
     Buffer.clear token_buffer;
     ib.ic_token_count <- succ ib.ic_token_count;
     tok
-  ;;
+  
 
-  let token_count ib = ib.ic_token_count;;
+  let token_count ib = ib.ic_token_count
 
   let skip_char width ib =
     invalidate_current_char ib;
     width
-  ;;
+  
 
-  let ignore_char width ib = skip_char (width - 1) ib;;
+  let ignore_char width ib = skip_char (width - 1) ib
 
   let store_char width ib c =
     Buffer.add_char ib.ic_token_buffer c;
     ignore_char width ib
-  ;;
+  
 
-  let default_token_buffer_size = 1024;;
+  let default_token_buffer_size = 1024
 
   let create iname next = {
     ic_eof = false;
@@ -266,7 +266,7 @@ module Scanning : SCANNING = struct
     ic_token_buffer = Buffer.create default_token_buffer_size;
     ic_input_name = iname;
   }
-  ;;
+  
 
   let from_string s =
     let i = ref 0 in
@@ -277,9 +277,9 @@ module Scanning : SCANNING = struct
       incr i;
       c in
     create From_string next
-  ;;
+  
 
-  let from_function = create From_function;;
+  let from_function = create From_function
 
   (* Scanning from an input channel. *)
 
@@ -322,14 +322,14 @@ module Scanning : SCANNING = struct
   *)
 
   (* Perform bufferized input to improve efficiency. *)
-  let file_buffer_size = ref 1024;;
+  let file_buffer_size = ref 1024
 
   (* The scanner closes the input channel at end of input. *)
-  let scan_close_at_end ic = Pervasives.close_in ic; raise End_of_file;;
+  let scan_close_at_end ic = Pervasives.close_in ic; raise End_of_file
 
   (* The scanner does not close the input channel at end of input:
      it just raises [End_of_file]. *)
-  let scan_raise_at_end _ic = raise End_of_file;;
+  let scan_raise_at_end _ic = raise End_of_file
 
   let from_ic scan_close_ic iname ic =
     let len = !file_buffer_size in
@@ -347,10 +347,10 @@ module Scanning : SCANNING = struct
         end
       end in
     create iname next
-  ;;
+  
 
-  let from_ic_close_at_end = from_ic scan_close_at_end;;
-  let from_ic_raise_at_end = from_ic scan_raise_at_end;;
+  let from_ic_close_at_end = from_ic scan_close_at_end
+  let from_ic_raise_at_end = from_ic scan_raise_at_end
 
   (* The scanning buffer reading from [Pervasives.stdin].
      One could try to define [stdib] as a scanning buffer reading a character
@@ -370,9 +370,9 @@ module Scanning : SCANNING = struct
   let stdin =
     from_ic scan_raise_at_end
       (From_file ("-", Pervasives.stdin)) Pervasives.stdin
-  ;;
+  
 
-  let stdib = stdin;;
+  let stdib = stdin
 
   let open_in_file open_in fname =
     match fname with
@@ -380,17 +380,17 @@ module Scanning : SCANNING = struct
     | fname ->
       let ic = open_in fname in
       from_ic_close_at_end (From_file (fname, ic)) ic
-  ;;
+  
 
-  let open_in = open_in_file Pervasives.open_in;;
-  let open_in_bin = open_in_file Pervasives.open_in_bin;;
+  let open_in = open_in_file Pervasives.open_in
+  let open_in_bin = open_in_file Pervasives.open_in_bin
 
-  let from_file = open_in;;
-  let from_file_bin = open_in_bin;;
+  let from_file = open_in
+  let from_file_bin = open_in_bin
 
   let from_channel ic =
     from_ic_raise_at_end (From_channel ic) ic
-  ;;
+  
 
   let close_in ib =
     match ib.ic_input_name with
@@ -398,7 +398,7 @@ module Scanning : SCANNING = struct
       Pervasives.close_in ic
     | From_file (_fname, ic) -> Pervasives.close_in ic
     | From_function | From_string -> ()
-  ;;
+  
 
   (*
      Obsolete: a memo [from_channel] version to build a [Scanning.in_channel]
@@ -424,28 +424,28 @@ module Scanning : SCANNING = struct
          from_ic scan_close_ic (From_channel ic) ic in
        memo := (ic, ib) :: !memo;
        ib)
-  ;;
+  
 
   (* Obsolete: see {!memo_from_ic} above. *)
-  let memo_from_channel = memo_from_ic scan_raise_at_end;;
+  let memo_from_channel = memo_from_ic scan_raise_at_end
 
 end
-;;
+
 
 (* Formatted input functions. *)
 
 type ('a, 'b, 'c, 'd) scanner =
      ('a, Scanning.in_channel, 'b, 'c, 'a -> 'd, 'd) format6 -> 'c
-;;
+
 
 (* Reporting errors. *)
-exception Scan_failure of string;;
+exception Scan_failure of string
 
-let bad_input s = raise (Scan_failure s);;
+let bad_input s = raise (Scan_failure s)
 
 let bad_input_escape c =
   bad_input (Printf.sprintf "illegal escape character %C" c)
-;;
+
 
 let bad_token_length message =
   bad_input
@@ -453,7 +453,7 @@ let bad_token_length message =
        "scanning of %s failed: \
         the specified length was too short for token"
        message)
-;;
+
 
 let bad_end_of_input message =
   bad_input
@@ -461,23 +461,23 @@ let bad_end_of_input message =
        "scanning of %s failed: \
         premature end of file occurred before end of token"
        message)
-;;
+
 
 let bad_float () =
   bad_input "no dot or exponent part found in float token"
-;;
+
 
 let bad_hex_float () =
   bad_input "not a valid float in hexadecimal notation"
-;;
+
 
 let character_mismatch_err c ci =
   Printf.sprintf "looking for %C, found %C" c ci
-;;
+
 
 let character_mismatch c ci =
   bad_input (character_mismatch_err c ci)
-;;
+
 
 let rec skip_whites ib =
   let c = Scanning.peek_char ib in
@@ -487,7 +487,7 @@ let rec skip_whites ib =
       Scanning.invalidate_current_char ib; skip_whites ib
     | _ -> ()
   end
-;;
+
 
 (* Checking that [c] is indeed in the input, then skips it.
    In this case, the character [c] has been explicitly specified in the
@@ -520,20 +520,20 @@ and check_newline ib =
   | '\n' -> Scanning.invalidate_current_char ib
   | '\r' -> Scanning.invalidate_current_char ib; check_this_char ib '\n'
   | _ -> character_mismatch '\n' ci
-;;
+
 
 (* Extracting tokens from the output token buffer. *)
 
-let token_char ib = (Scanning.token ib).[0];;
+let token_char ib = (Scanning.token ib).[0]
 
-let token_string = Scanning.token;;
+let token_string = Scanning.token
 
 let token_bool ib =
   match Scanning.token ib with
   | "true" -> true
   | "false" -> false
   | s -> bad_input (Printf.sprintf "invalid boolean '%s'" s)
-;;
+
 
 (* The type of integer conversions. *)
 type integer_conversion =
@@ -543,7 +543,7 @@ type integer_conversion =
   | O_conversion (* Unsigned octal conversion *)
   | U_conversion (* Unsigned decimal conversion *)
   | X_conversion (* Unsigned hexadecimal conversion *)
-;;
+
 
 let integer_conversion_of_char = function
   | 'b' -> B_conversion
@@ -553,7 +553,7 @@ let integer_conversion_of_char = function
   | 'u' -> U_conversion
   | 'x' | 'X' -> X_conversion
   | _ -> assert false
-;;
+
 
 (* Extract an integer literal token.
    Since the functions Pervasives.*int*_of_string do not accept a leading +,
@@ -568,14 +568,14 @@ let token_int_literal conv ib =
     | B_conversion -> "0b" ^ Scanning.token ib in
   let l = String.length tok in
   if l = 0 || tok.[0] <> '+' then tok else String.sub tok 1 (l - 1)
-;;
+
 
 (* All the functions that convert a string to a number raise the exception
    Failure when the conversion is not possible.
    This exception is then trapped in [kscanf]. *)
-let token_int conv ib = int_of_string (token_int_literal conv ib);;
+let token_int conv ib = int_of_string (token_int_literal conv ib)
 
-let token_float ib = float_of_string (Scanning.token ib);;
+let token_float ib = float_of_string (Scanning.token ib)
 
 (* To scan native ints, int32 and int64 integers.
    We cannot access to conversions to/from strings for those types,
@@ -585,17 +585,17 @@ let token_float ib = float_of_string (Scanning.token ib);;
    available in the runtime. *)
 external nativeint_of_string : string -> nativeint
   = "caml_nativeint_of_string"
-;;
+
 external int32_of_string : string -> int32
   = "caml_int32_of_string"
-;;
+
 external int64_of_string : string -> int64
   = "caml_int64_of_string"
-;;
 
-let token_nativeint conv ib = nativeint_of_string (token_int_literal conv ib);;
-let token_int32 conv ib = int32_of_string (token_int_literal conv ib);;
-let token_int64 conv ib = int64_of_string (token_int_literal conv ib);;
+
+let token_nativeint conv ib = nativeint_of_string (token_int_literal conv ib)
+let token_int32 conv ib = int32_of_string (token_int_literal conv ib)
+let token_int64 conv ib = int64_of_string (token_int_literal conv ib)
 
 (* Scanning numbers. *)
 
@@ -622,7 +622,7 @@ let rec scan_decimal_digit_star width ib =
     let width = Scanning.ignore_char width ib in
     scan_decimal_digit_star width ib
   | _ -> width
-;;
+
 
 let scan_decimal_digit_plus width ib =
   if width = 0 then bad_token_length "decimal digits" else
@@ -633,7 +633,7 @@ let scan_decimal_digit_plus width ib =
     scan_decimal_digit_star width ib
   | c ->
     bad_input (Printf.sprintf "character %C is not a decimal digit" c)
-;;
+
 
 (* To scan numbers from other bases, we use a predicate argument to
    scan digits. *)
@@ -651,7 +651,7 @@ let scan_digit_star digitp width ib =
       scan_digits width ib
     | _ -> width in
   scan_digits width ib
-;;
+
 
 let scan_digit_plus basis digitp width ib =
   (* Ensure we have got enough width left,
@@ -663,31 +663,31 @@ let scan_digit_plus basis digitp width ib =
     scan_digit_star digitp width ib
   else
     bad_input (Printf.sprintf "character %C is not a valid %s digit" c basis)
-;;
+
 
 let is_binary_digit = function
   | '0' .. '1' -> true
   | _ -> false
-;;
 
-let scan_binary_int = scan_digit_plus "binary" is_binary_digit;;
+
+let scan_binary_int = scan_digit_plus "binary" is_binary_digit
 
 let is_octal_digit = function
   | '0' .. '7' -> true
   | _ -> false
-;;
 
-let scan_octal_int = scan_digit_plus "octal" is_octal_digit;;
+
+let scan_octal_int = scan_digit_plus "octal" is_octal_digit
 
 let is_hexa_digit = function
   | '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' -> true
   | _ -> false
-;;
 
-let scan_hexadecimal_int = scan_digit_plus "hexadecimal" is_hexa_digit;;
+
+let scan_hexadecimal_int = scan_digit_plus "hexadecimal" is_hexa_digit
 
 (* Scan a decimal integer. *)
-let scan_unsigned_decimal_int = scan_decimal_digit_plus;;
+let scan_unsigned_decimal_int = scan_decimal_digit_plus
 
 let scan_sign width ib =
   let c = Scanning.checked_peek_char ib in
@@ -695,12 +695,12 @@ let scan_sign width ib =
   | '+' -> Scanning.store_char width ib c
   | '-' -> Scanning.store_char width ib c
   | _ -> width
-;;
+
 
 let scan_optionally_signed_decimal_int width ib =
   let width = scan_sign width ib in
   scan_unsigned_decimal_int width ib
-;;
+
 
 (* Scan an unsigned integer that could be given in any (common) basis.
    If digits are prefixed by one of 0x, 0X, 0o, or 0b, the number is
@@ -719,12 +719,12 @@ let scan_unsigned_int width ib =
     | 'b' -> scan_binary_int (Scanning.store_char width ib c) ib
     | _ -> scan_decimal_digit_star width ib end
   | _ -> scan_unsigned_decimal_int width ib
-;;
+
 
 let scan_optionally_signed_int width ib =
   let width = scan_sign width ib in
   scan_unsigned_int width ib
-;;
+
 
 let scan_int_conversion conv width ib =
   match conv with
@@ -734,7 +734,7 @@ let scan_int_conversion conv width ib =
   | O_conversion -> scan_octal_int width ib
   | U_conversion -> scan_unsigned_decimal_int width ib
   | X_conversion -> scan_hexadecimal_int width ib
-;;
+
 
 (* Scanning floating point numbers. *)
 
@@ -747,7 +747,7 @@ let scan_fractional_part width ib =
   | '0' .. '9' as c ->
     scan_decimal_digit_star (Scanning.store_char width ib c) ib
   | _ -> width
-;;
+
 
 (* Exp part is optional and can be reduced to 0 digits. *)
 let scan_exponent_part width ib =
@@ -758,7 +758,7 @@ let scan_exponent_part width ib =
   | 'e' | 'E' as c ->
     scan_optionally_signed_decimal_int (Scanning.store_char width ib c) ib
   | _ -> width
-;;
+
 
 (* Scan the integer part of a floating point number, (not using the
    OCaml lexical convention since the integer part can be empty):
@@ -767,7 +767,7 @@ let scan_exponent_part width ib =
 let scan_integer_part width ib =
   let width = scan_sign width ib in
   scan_decimal_digit_star width ib
-;;
+
 
 (*
    For the time being we have (as found in scanf.mli):
@@ -813,7 +813,7 @@ let scan_float width precision ib =
     scan_exponent_part width ib, precision
   | _ ->
     scan_exponent_part width ib, precision
-;;
+
 
 let check_case_insensitive_string width ib error str =
   let lowercase c =
@@ -830,7 +830,7 @@ let check_case_insensitive_string width ib error str =
     width := Scanning.store_char !width ib c;
   done;
   !width
-;;
+
 
 let scan_hex_float width precision ib =
   if width = 0 || Scanning.end_of_input ib then bad_hex_float ();
@@ -874,7 +874,7 @@ let scan_hex_float width precision ib =
     if width = 0 || Scanning.end_of_input ib then bad_hex_float ();
     check_case_insensitive_string width ib bad_hex_float "nfinity"
   | _ -> bad_hex_float ()
-;;
+
 
 let scan_caml_float_rest width precision ib =
   if width = 0 || Scanning.end_of_input ib then bad_float ();
@@ -899,7 +899,7 @@ let scan_caml_float_rest width precision ib =
   | 'e' | 'E' ->
     scan_exponent_part width ib
   | _ -> bad_float ()
-;;
+
 
 let scan_caml_float width precision ib =
   if width = 0 || Scanning.end_of_input ib then bad_float ();
@@ -947,7 +947,7 @@ let scan_caml_float width precision ib =
   | 'n' ->
 *)
   | _ -> bad_float ()
-;;
+
 
 (* Scan a regular string:
    stops when encountering a space, if no scanning indication has been given;
@@ -968,7 +968,7 @@ let scan_string stp width ib =
         | ' ' | '\t' | '\n' | '\r' -> width
         | _ -> loop (Scanning.store_char width ib c) in
   loop width
-;;
+
 
 (* Scan a char: peek strictly one character in the input, whatsoever. *)
 let scan_char width ib =
@@ -976,7 +976,7 @@ let scan_char width ib =
      calling scan_char, in the main scanning function.
     if width = 0 then bad_token_length "a character" else *)
   Scanning.store_char width ib (Scanning.checked_peek_char ib)
-;;
+
 
 let char_for_backslash = function
   | 'n' -> '\010'
@@ -984,11 +984,11 @@ let char_for_backslash = function
   | 'b' -> '\008'
   | 't' -> '\009'
   | c -> c
-;;
+
 
 (* The integer value corresponding to the facial value of a valid
    decimal digit character. *)
-let decimal_value_of_char c = int_of_char c - int_of_char '0';;
+let decimal_value_of_char c = int_of_char c - int_of_char '0'
 
 let char_for_decimal_code c0 c1 c2 =
   let c =
@@ -1000,7 +1000,7 @@ let char_for_decimal_code c0 c1 c2 =
       (Printf.sprintf
          "bad character decimal encoding \\%c%c%c" c0 c1 c2) else
   char_of_int c
-;;
+
 
 (* The integer value corresponding to the facial value of a valid
    hexadecimal digit character. *)
@@ -1016,7 +1016,7 @@ let hexadecimal_value_of_char c =
   if d >= int_of_char 'A' then
     d - 55  (* 10 + int_of_char c - int_of_char 'A' *) else
     d - int_of_char '0'
-;;
+
 
 let char_for_hexadecimal_code c1 c2 =
   let c =
@@ -1026,7 +1026,7 @@ let char_for_hexadecimal_code c1 c2 =
     bad_input
       (Printf.sprintf "bad character hexadecimal encoding \\%c%c" c1 c2) else
   char_of_int c
-;;
+
 
 (* Called in particular when encountering '\\' as starter of a char.
    Stops before the corresponding '\''. *)
@@ -1035,10 +1035,10 @@ let check_next_char message width ib =
   let c = Scanning.peek_char ib in
   if Scanning.eof ib then bad_end_of_input message else
   c
-;;
 
-let check_next_char_for_char = check_next_char "a Char";;
-let check_next_char_for_string = check_next_char "a String";;
+
+let check_next_char_for_char = check_next_char "a Char"
+let check_next_char_for_string = check_next_char "a String"
 
 let scan_backslash_char width ib =
   match check_next_char_for_char width ib with
@@ -1065,7 +1065,7 @@ let scan_backslash_char width ib =
     Scanning.store_char (width - 2) ib (char_for_hexadecimal_code c1 c2)
   | c ->
     bad_input_escape c
-;;
+
 
 (* Scan a character (an OCaml token). *)
 let scan_caml_char width ib =
@@ -1088,7 +1088,7 @@ let scan_caml_char width ib =
     | c -> character_mismatch '\'' c in
 
   find_start width
-;;
+
 
 (* Scan a delimited string (an OCaml token). *)
 let scan_caml_string width ib =
@@ -1121,7 +1121,7 @@ let scan_caml_string width ib =
     | _ -> find_stop width in
 
   find_start width
-;;
+
 
 (* Scan a boolean (an OCaml token). *)
 let scan_bool ib =
@@ -1134,7 +1134,7 @@ let scan_bool ib =
       bad_input
         (Printf.sprintf "the character %C cannot start a boolean" c) in
   scan_string None m ib
-;;
+
 
 (* Scan a string containing elements in char_set and terminated by scan_indic
    if provided. *)
@@ -1155,7 +1155,7 @@ let scan_chars_in_char_set char_set scan_indic width ib =
       if c = ci
       then Scanning.invalidate_current_char ib
       else character_mismatch c ci
-;;
+
 
 (* The global error report function for [Scanf]. *)
 let scanf_bad_input ib = function
@@ -1163,7 +1163,7 @@ let scanf_bad_input ib = function
     let i = Scanning.char_count ib in
     bad_input (Printf.sprintf "scanf: bad input at char number %i: %s" i s)
   | x -> raise x
-;;
+
 
 (* Get the content of a counter from an input buffer. *)
 let get_counter ib counter =
@@ -1171,13 +1171,13 @@ let get_counter ib counter =
   | Line_counter -> Scanning.line_count ib
   | Char_counter -> Scanning.char_count ib
   | Token_counter -> Scanning.token_count ib
-;;
+
 
 (* Compute the width of a padding option (see "%42{" and "%123("). *)
 let width_of_pad_opt pad_opt = match pad_opt with
   | None -> max_int
   | Some width -> width
-;;
+
 
 let stopper_of_formatting_lit fmting =
   if fmting = Escaped_percent then '%', "" else
@@ -1185,7 +1185,7 @@ let stopper_of_formatting_lit fmting =
     let stp = str.[1] in
     let sub_str = String.sub str 2 (String.length str - 2) in
     stp, sub_str
-;;
+
 
 (******************************************************************************)
                            (* Readers managment *)
@@ -1404,7 +1404,7 @@ fun ib fmt readers -> match fmt with
            are typed in the same way.
 
            # Scanf.sscanf "\"%_r%d\"3" "%(%d%_r%)" ignore
-             (fun fmt n -> string_of_format fmt, n);;
+             (fun fmt n -> string_of_format fmt, n)
            Exception: CamlinternalFormat.Type_mismatch.
 
            We should properly catch this exception.
@@ -1515,13 +1515,13 @@ let kscanf ib ef (Format (fmt, str)) =
 
 (***)
 
-let kbscanf = kscanf;;
-let bscanf ib fmt = kbscanf ib scanf_bad_input fmt;;
+let kbscanf = kscanf
+let bscanf ib fmt = kbscanf ib scanf_bad_input fmt
 
-let ksscanf s ef fmt = kbscanf (Scanning.from_string s) ef fmt;;
-let sscanf s fmt = kbscanf (Scanning.from_string s) scanf_bad_input fmt;;
+let ksscanf s ef fmt = kbscanf (Scanning.from_string s) ef fmt
+let sscanf s fmt = kbscanf (Scanning.from_string s) scanf_bad_input fmt
 
-let scanf fmt = kscanf Scanning.stdib scanf_bad_input fmt;;
+let scanf fmt = kscanf Scanning.stdib scanf_bad_input fmt
 
 (***)
 
@@ -1536,13 +1536,13 @@ let bscanf_format :
       try format_of_string_format str format
       with Failure msg -> bad_input msg in
     f fmt'
-;;
+
 
 let sscanf_format :
   string -> ('a, 'b, 'c, 'd, 'e, 'f) format6 ->
   (('a, 'b, 'c, 'd, 'e, 'f) format6 -> 'g) -> 'g =
   fun s format f -> bscanf_format (Scanning.from_string s) format f
-;;
+
 
 let string_to_String s =
   let l = String.length s in
@@ -1555,16 +1555,16 @@ let string_to_String s =
   done;
   Buffer.add_char b '\"';
   Buffer.contents b
-;;
+
 
 let format_from_string s fmt =
   sscanf_format (string_to_String s) fmt (fun x -> x)
-;;
+
 
 let unescaped s =
   sscanf ("\"" ^ s ^ "\"") "%S%!" (fun x -> x)
-;;
+
 
 (* Deprecated *)
-let kfscanf ic ef fmt = kbscanf (Scanning.memo_from_channel ic) ef fmt;;
-let fscanf ic fmt = kscanf (Scanning.memo_from_channel ic) scanf_bad_input fmt;;
+let kfscanf ic ef fmt = kbscanf (Scanning.memo_from_channel ic) ef fmt
+let fscanf ic fmt = kscanf (Scanning.memo_from_channel ic) scanf_bad_input fmt

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -48,6 +48,7 @@ module type OrderedType =
   sig
     type t
       (** The type of the set elements. *)
+
     val compare : t -> t -> int
       (** A total ordering function over the set elements.
           This is a two-argument function [f] such that

--- a/stdlib/stream.ml
+++ b/stdlib/stream.ml
@@ -25,9 +25,9 @@ and 'a data =
 and 'a gen = { mutable curr : 'a option option; func : int -> 'a option }
 and buffio =
   { ic : in_channel; buff : bytes; mutable len : int; mutable ind : int }
-;;
-exception Failure;;
-exception Error of string;;
+
+exception Failure
+exception Error of string
 
 let count = function
   | None -> 0
@@ -38,7 +38,7 @@ let data = function
 
 let fill_buff b =
   b.len <- input b.ic b.buff 0 (Bytes.length b.buff); b.ind <- 0
-;;
+
 
 let rec get_data : type v. int -> v data -> v data = fun count d -> match d with
  (* Returns either Sempty or Scons(a, _) even when d is a generator
@@ -68,7 +68,7 @@ let rec get_data : type v. int -> v data -> v data = fun count d -> match d with
        (* Warning: anyone using g thinks that an item has been read *)
        b.ind <- succ b.ind; Scons(r, d)
  | Slazy f -> get_data count (Lazy.force f)
-;;
+
 
 let rec peek_data : type v. v cell -> v option = fun s ->
  (* consult the first item of s *)
@@ -88,12 +88,12 @@ let rec peek_data : type v. v cell -> v option = fun s ->
      if b.ind >= b.len then fill_buff b;
      if b.len == 0 then begin s.data <- Sempty; None end
      else Some (Bytes.unsafe_get b.buff b.ind)
-;;
+
 
 let peek = function
   | None -> None
   | Some s -> peek_data s
-;;
+
 
 let rec junk_data : type v. v cell -> unit = fun s ->
   match s.data with
@@ -104,7 +104,7 @@ let rec junk_data : type v. v cell -> unit = fun s ->
       match peek_data s with
         None -> ()
       | Some _ -> junk_data s
-;;
+
 
 let junk = function
   | None -> ()
@@ -118,14 +118,14 @@ let rec nget_data n s =
         junk_data s;
         let (al, d, k) = nget_data (pred n) s in a :: al, Scons (a, d), succ k
     | None -> [], s.data, 0
-;;
+
 
 let npeek_data n s =
   let (al, d, len) = nget_data n s in
   s.count <- (s.count - len);
   s.data <- d;
   al
-;;
+
 
 let npeek n = function
   | None -> []
@@ -135,13 +135,13 @@ let next s =
   match peek s with
     Some a -> junk s; a
   | None -> raise Failure
-;;
+
 
 let empty s =
   match peek s with
     Some _ -> raise Failure
   | None -> ()
-;;
+
 
 let iter f strm =
   let rec do_rec () =
@@ -150,15 +150,15 @@ let iter f strm =
     | None -> ()
   in
   do_rec ()
-;;
+
 
 (* Stream building functions *)
 
-let from f = Some {count = 0; data = Sgen {curr = None; func = f}};;
+let from f = Some {count = 0; data = Sgen {curr = None; func = f}}
 
 let of_list l =
   Some {count = 0; data = List.fold_right (fun x l -> Scons (x, l)) l Sempty}
-;;
+
 
 let of_string s =
   let count = ref 0 in
@@ -173,7 +173,7 @@ let of_string s =
     if c < String.length s
     then (incr count; Some s.[c])
     else None)
-;;
+
 
 let of_bytes s =
   let count = ref 0 in
@@ -182,27 +182,27 @@ let of_bytes s =
     if c < Bytes.length s
     then (incr count; Some (Bytes.get s c))
     else None)
-;;
+
 
 let of_channel ic =
   Some {count = 0;
         data = Sbuffio {ic = ic; buff = Bytes.create 4096; len = 0; ind = 0}}
-;;
+
 
 (* Stream expressions builders *)
 
-let iapp i s = Some {count = 0; data = Sapp (data i, data s)};;
-let icons i s = Some {count = 0; data = Scons (i, data s)};;
-let ising i = Some {count = 0; data = Scons (i, Sempty)};;
+let iapp i s = Some {count = 0; data = Sapp (data i, data s)}
+let icons i s = Some {count = 0; data = Scons (i, data s)}
+let ising i = Some {count = 0; data = Scons (i, Sempty)}
 
 let lapp f s =
   Some {count = 0; data = Slazy (lazy(Sapp (data (f ()), data s)))}
-;;
-let lcons f s = Some {count = 0; data = Slazy (lazy(Scons (f (), data s)))};;
-let lsing f = Some {count = 0; data = Slazy (lazy(Scons (f (), Sempty)))};;
 
-let sempty = None;;
-let slazy f = Some {count = 0; data = Slazy (lazy(data (f ())))};;
+let lcons f s = Some {count = 0; data = Slazy (lazy(Scons (f (), data s)))}
+let lsing f = Some {count = 0; data = Slazy (lazy(Scons (f (), Sempty)))}
+
+let sempty = None
+let slazy f = Some {count = 0; data = Slazy (lazy(data (f ())))}
 
 (* For debugging use *)
 
@@ -231,4 +231,4 @@ and dump_data : type v. (v -> unit) -> v data -> unit = fun f ->
   | Slazy _ -> print_string "Slazy"
   | Sgen _ -> print_string "Sgen"
   | Sbuffio b -> print_string "Sbuffio"
-;;
+

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -266,7 +266,7 @@ val catch_break : bool -> unit
    terminate the program on user interrupt. *)
 
 
-val ocaml_version : string;;
+val ocaml_version : string
 (** [ocaml_version] is the version of OCaml.
     It is a string of the form ["major.minor[.patchlevel][+additional-info]"],
     where [major], [minor], and [patchlevel] are integers, and

--- a/stdlib/sys.mlp
+++ b/stdlib/sys.mlp
@@ -38,7 +38,7 @@ let unix = unix ()
 let win32 = win32 ()
 let cygwin = cygwin ()
 let max_array_length = max_wosize ()
-let max_string_length = word_size / 8 * max_array_length - 1;;
+let max_string_length = word_size / 8 * max_array_length - 1
 external runtime_variant : unit -> string = "caml_runtime_variant"
 external runtime_parameters : unit -> string = "caml_runtime_parameters"
 
@@ -111,7 +111,7 @@ external runtime_warnings_enabled: unit -> bool =
 
 (* The version string is found in file ../VERSION *)
 
-let ocaml_version = "%%VERSION%%";;
+let ocaml_version = "%%VERSION%%"
 
 (* Optimization *)
 

--- a/stdlib/weak.ml
+++ b/stdlib/weak.ml
@@ -15,20 +15,20 @@
 
 (** Weak array operations *)
 
-type 'a t;;
+type 'a t
 
-external create : int -> 'a t = "caml_weak_create";;
+external create : int -> 'a t = "caml_weak_create"
 
 (** number of additional values in a weak pointer *)
 let additional_values = 2
 
-let length x = Obj.size(Obj.repr x) - additional_values;;
+let length x = Obj.size(Obj.repr x) - additional_values
 
-external set : 'a t -> int -> 'a option -> unit = "caml_weak_set";;
-external get : 'a t -> int -> 'a option = "caml_weak_get";;
-external get_copy : 'a t -> int -> 'a option = "caml_weak_get_copy";;
-external check : 'a t -> int -> bool = "caml_weak_check";;
-external blit : 'a t -> int -> 'a t -> int -> int -> unit = "caml_weak_blit";;
+external set : 'a t -> int -> 'a option -> unit = "caml_weak_set"
+external get : 'a t -> int -> 'a option = "caml_weak_get"
+external get_copy : 'a t -> int -> 'a option = "caml_weak_get_copy"
+external check : 'a t -> int -> bool = "caml_weak_check"
+external blit : 'a t -> int -> 'a t -> int -> int -> unit = "caml_weak_blit"
 (* blit: src srcoff dst dstoff len *)
 
 let fill ar ofs len x =
@@ -39,7 +39,7 @@ let fill ar ofs len x =
       set ar i x
     done
   end
-;;
+
 
 (** Weak hash tables *)
 
@@ -58,15 +58,15 @@ module type S = sig
   val fold : (data -> 'a -> 'a) -> t -> 'a -> 'a
   val count : t -> int
   val stats : t -> int * int * int * int * int * int
-end;;
+end
 
 module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
 
-  type 'a weak_t = 'a t;;
-  let weak_create = create;;
-  let emptybucket = weak_create 0;;
+  type 'a weak_t = 'a t
+  let weak_create = create
+  let emptybucket = weak_create 0
 
-  type data = H.t;;
+  type data = H.t
 
   type t = {
     mutable table : data weak_t array;
@@ -74,12 +74,12 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
     mutable limit : int;               (* bucket size limit *)
     mutable oversize : int;            (* number of oversize buckets *)
     mutable rover : int;               (* for internal bookkeeping *)
-  };;
+  }
 
-  let get_index t h = (h land max_int) mod (Array.length t.table);;
+  let get_index t h = (h land max_int) mod (Array.length t.table)
 
-  let limit = 7;;
-  let over_limit = 2;;
+  let limit = 7
+  let over_limit = 2
 
   let create sz =
     let sz = if sz < 7 then 7 else sz in
@@ -90,7 +90,7 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
       limit = limit;
       oversize = 0;
       rover = 0;
-    };;
+    }
 
   let clear t =
     for i = 0 to Array.length t.table - 1 do
@@ -98,8 +98,8 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
       t.hashes.(i) <- [| |];
     done;
     t.limit <- limit;
-    t.oversize <- 0;
-  ;;
+    t.oversize <- 0
+  
 
   let fold f t init =
     let rec fold_bucket i b accu =
@@ -109,7 +109,7 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
       | None -> fold_bucket (i+1) b accu
     in
     Array.fold_right (fold_bucket 0) t.table init
-  ;;
+  
 
   let iter f t =
     let rec iter_bucket i b =
@@ -119,7 +119,7 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
       | None -> iter_bucket (i+1) b
     in
     Array.iter (iter_bucket 0) t.table
-  ;;
+  
 
   let iter_weak f t =
     let rec iter_bucket i j b =
@@ -129,19 +129,19 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
       | false -> iter_bucket (i+1) j b
     in
     Array.iteri (iter_bucket 0) t.table
-  ;;
+  
 
   let rec count_bucket i b accu =
     if i >= length b then accu else
     count_bucket (i+1) b (accu + (if check b i then 1 else 0))
-  ;;
+  
 
   let count t =
     Array.fold_right (count_bucket 0) t.table 0
-  ;;
+  
 
-  let next_sz n = min (3 * n / 2 + 3) Sys.max_array_length;;
-  let prev_sz n = ((n - 3) * 2 + 2) / 3;;
+  let next_sz n = min (3 * n / 2 + 3) Sys.max_array_length
+  let prev_sz n = ((n - 3) * 2 + 2) / 3
 
   let test_shrink_bucket t =
     let bucket = t.table.(t.rover) in
@@ -170,8 +170,8 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
       end;
       if len > t.limit && prev_len <= t.limit then t.oversize <- t.oversize - 1;
     end;
-    t.rover <- (t.rover + 1) mod (Array.length t.table);
-  ;;
+    t.rover <- (t.rover + 1) mod (Array.length t.table)
+  
 
   let rec resize t =
     let oldlen = Array.length t.table in
@@ -222,13 +222,13 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
         hashes.(i) <- h;
       end;
     in
-    loop 0;
-  ;;
+    loop 0
+  
 
   let add t d =
     let h = H.hash d in
-    add_aux t set (Some d) h (get_index t h);
-  ;;
+    add_aux t set (Some d) h (get_index t h)
+  
 
   let find_or t d ifnotfound =
     let h = H.hash d in
@@ -249,13 +249,13 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
       end else loop (i + 1)
     in
     loop 0
-  ;;
+  
 
   let merge t d =
     find_or t d (fun h index -> add_aux t set (Some d) h index; d)
-  ;;
+  
 
-  let find t d = find_or t d (fun h index -> raise Not_found);;
+  let find t d = find_or t d (fun h index -> raise Not_found)
 
   let find_shadow t d iffound ifnotfound =
     let h = H.hash d in
@@ -272,11 +272,11 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
       end else loop (i + 1)
     in
     loop 0
-  ;;
+  
 
-  let remove t d = find_shadow t d (fun w i -> set w i None) ();;
+  let remove t d = find_shadow t d (fun w i -> set w i None) ()
 
-  let mem t d = find_shadow t d (fun w i -> true) false;;
+  let mem t d = find_shadow t d (fun w i -> true) false
 
   let find_all t d =
     let h = H.hash d in
@@ -297,7 +297,7 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
       end else loop (i + 1) accu
     in
     loop 0 []
-  ;;
+  
 
   let stats t =
     let len = Array.length t.table in
@@ -305,6 +305,6 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
     Array.sort compare lens;
     let totlen = Array.fold_left ( + ) 0 lens in
     (len, count t, totlen, lens.(0), lens.(len/2), lens.(len-1))
-  ;;
+  
 
-end;;
+end

--- a/stdlib/weak.mli
+++ b/stdlib/weak.mli
@@ -106,48 +106,61 @@ val blit : 'a t -> int -> 'a t -> int -> int -> unit
 module type S = sig
   type data
     (** The type of the elements stored in the table. *)
+
   type t
     (** The type of tables that contain elements of type [data].
         Note that weak hash sets cannot be marshaled using
         {!Pervasives.output_value} or the functions of the {!Marshal}
         module. *)
+
   val create : int -> t
     (** [create n] creates a new empty weak hash set, of initial
         size [n].  The table will grow as needed. *)
+
   val clear : t -> unit
     (** Remove all elements from the table. *)
+
   val merge : t -> data -> data
     (** [merge t x] returns an instance of [x] found in [t] if any,
         or else adds [x] to [t] and return [x]. *)
+
   val add : t -> data -> unit
     (** [add t x] adds [x] to [t].  If there is already an instance
         of [x] in [t], it is unspecified which one will be
         returned by subsequent calls to [find] and [merge]. *)
+
   val remove : t -> data -> unit
     (** [remove t x] removes from [t] one instance of [x].  Does
         nothing if there is no instance of [x] in [t]. *)
+
   val find : t -> data -> data
     (** [find t x] returns an instance of [x] found in [t].
         Raise [Not_found] if there is no such element. *)
+
   val find_all : t -> data -> data list
     (** [find_all t x] returns a list of all the instances of [x]
         found in [t]. *)
+
   val mem : t -> data -> bool
     (** [mem t x] returns [true] if there is at least one instance
         of [x] in [t], false otherwise. *)
+
   val iter : (data -> unit) -> t -> unit
     (** [iter f t] calls [f] on each element of [t], in some unspecified
         order.  It is not specified what happens if [f] tries to change
         [t] itself. *)
+
   val fold : (data -> 'a -> 'a) -> t -> 'a -> 'a
     (** [fold f t init] computes [(f d1 (... (f dN init)))] where
         [d1 ... dN] are the elements of [t] in some unspecified order.
         It is not specified what happens if [f] tries to change [t]
         itself. *)
+
   val count : t -> int
     (** Count the number of elements in the table.  [count t] gives the
         same result as [fold (fun _ n -> n+1) t 0] but does not delay the
         deallocation of the dead elements. *)
+
   val stats : t -> int * int * int * int * int * int
     (** Return statistics on the table.  The numbers are, in order:
         table length, number of entries, sum of bucket lengths,

--- a/stdlib/weak.mli
+++ b/stdlib/weak.mli
@@ -152,10 +152,10 @@ module type S = sig
     (** Return statistics on the table.  The numbers are, in order:
         table length, number of entries, sum of bucket lengths,
         smallest bucket length, median bucket length, biggest bucket length. *)
-end;;
+end
 (** The output signature of the functor {!Weak.Make}. *)
 
-module Make (H : Hashtbl.HashedType) : S with type data = H.t;;
+module Make (H : Hashtbl.HashedType) : S with type data = H.t
 (** Functor building an implementation of the weak hash set structure.
     [H.equal] can't be the physical equality, since only shallow
     copies of the elements in the set are given to it.


### PR DESCRIPTION
This PR turns on warning 50 for the stdlib and otherlibs, and fixes up the resulting warnings.

It is based on #528 so the diff includes those changes as well.

As with #528, I've made the pull request against 4.03 because it fixes the attachment of comments to definitions, which is now used by merlin and so is worth fixing for the release.
