### PR TITLE
Make Cmmgen understand constant bools

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -437,6 +437,11 @@ let safe_mod_bi =
 
 let test_bool = function
     Cop(Caddi, [Cop(Clsl, [c; Cconst_int 1]); Cconst_int 1]) -> c
+  | Cconst_int n ->
+      if n = 1 then
+        Cconst_int 0
+      else
+        Cconst_int 1
   | c -> Cop(Ccmpi Cne, [c; Cconst_int 1])
 
 (* Float *)


### PR DESCRIPTION
A change was lost in the PR https://github.com/ocaml/ocaml/pull/430 apparently in a merge problem: https://github.com/ocaml/ocaml/pull/430/commits/355cf1d40b854711911ed332e9472cbd231ffc78

This is recovering the obviously correct part of the patch (that we probably don't need to test).

I think this should go in 4.03 as this might be quite a serious regression for flambda.
