### PR TITLE
[RFC] Improvements to flambda's "inlining report" generation

### DIFF
--- a/.depend
+++ b/.depend
@@ -73,11 +73,11 @@ parsing/ast_helper.cmx : parsing/parsetree.cmi parsing/longident.cmx \
     parsing/location.cmx parsing/docstrings.cmx parsing/asttypes.cmi \
     parsing/ast_helper.cmi
 parsing/ast_invariants.cmo : parsing/syntaxerr.cmi parsing/parsetree.cmi \
-    parsing/longident.cmi parsing/asttypes.cmi parsing/ast_iterator.cmi \
-    parsing/ast_invariants.cmi
+    parsing/longident.cmi parsing/builtin_attributes.cmi parsing/asttypes.cmi \
+    parsing/ast_iterator.cmi parsing/ast_invariants.cmi
 parsing/ast_invariants.cmx : parsing/syntaxerr.cmx parsing/parsetree.cmi \
-    parsing/longident.cmx parsing/asttypes.cmi parsing/ast_iterator.cmx \
-    parsing/ast_invariants.cmi
+    parsing/longident.cmx parsing/builtin_attributes.cmx parsing/asttypes.cmi \
+    parsing/ast_iterator.cmx parsing/ast_invariants.cmi
 parsing/ast_iterator.cmo : parsing/parsetree.cmi parsing/location.cmi \
     parsing/ast_iterator.cmi
 parsing/ast_iterator.cmx : parsing/parsetree.cmi parsing/location.cmx \
@@ -150,10 +150,10 @@ typing/cmt_format.cmi : typing/types.cmi typing/typedtree.cmi \
 typing/ctype.cmi : typing/types.cmi typing/path.cmi parsing/longident.cmi \
     typing/ident.cmi typing/env.cmi parsing/asttypes.cmi
 typing/datarepr.cmi : typing/types.cmi typing/path.cmi typing/ident.cmi
+typing/envaux.cmi : typing/subst.cmi typing/path.cmi typing/env.cmi
 typing/env.cmi : utils/warnings.cmi typing/types.cmi typing/subst.cmi \
     typing/path.cmi parsing/longident.cmi parsing/location.cmi \
     typing/ident.cmi utils/consistbl.cmi parsing/asttypes.cmi
-typing/envaux.cmi : typing/subst.cmi typing/path.cmi typing/env.cmi
 typing/ident.cmi : utils/identifiable.cmi
 typing/includeclass.cmi : typing/types.cmi typing/env.cmi typing/ctype.cmi
 typing/includecore.cmi : typing/types.cmi typing/typedtree.cmi \
@@ -172,10 +172,10 @@ typing/path.cmi : typing/ident.cmi
 typing/predef.cmi : typing/types.cmi typing/path.cmi typing/ident.cmi
 typing/primitive.cmi : parsing/parsetree.cmi typing/outcometree.cmi \
     parsing/location.cmi
+typing/printtyped.cmi : typing/typedtree.cmi
 typing/printtyp.cmi : typing/types.cmi typing/path.cmi \
     typing/outcometree.cmi parsing/longident.cmi typing/ident.cmi \
     typing/env.cmi parsing/asttypes.cmi
-typing/printtyped.cmi : typing/typedtree.cmi
 typing/stypes.cmi : typing/typedtree.cmi parsing/location.cmi \
     typing/annot.cmi
 typing/subst.cmi : typing/types.cmi typing/path.cmi typing/ident.cmi
@@ -191,11 +191,11 @@ typing/typedecl.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
     parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
     typing/includecore.cmi typing/ident.cmi typing/env.cmi \
     parsing/asttypes.cmi
+typing/typedtreeIter.cmi : typing/typedtree.cmi parsing/asttypes.cmi
+typing/typedtreeMap.cmi : typing/typedtree.cmi
 typing/typedtree.cmi : typing/types.cmi typing/primitive.cmi typing/path.cmi \
     parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
     typing/ident.cmi typing/env.cmi parsing/asttypes.cmi
-typing/typedtreeIter.cmi : typing/typedtree.cmi parsing/asttypes.cmi
-typing/typedtreeMap.cmi : typing/typedtree.cmi
 typing/typemod.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
     parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
     typing/includemod.cmi typing/ident.cmi typing/env.cmi \
@@ -225,12 +225,12 @@ typing/cmt_format.cmx : typing/types.cmx typing/typedtree.cmx \
     typing/tast_mapper.cmx utils/misc.cmx parsing/location.cmx \
     parsing/lexer.cmx typing/env.cmx utils/config.cmx typing/cmi_format.cmx \
     utils/clflags.cmx typing/cmt_format.cmi
-typing/ctype.cmo : typing/types.cmi typing/subst.cmi typing/path.cmi \
-    utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
+typing/ctype.cmo : typing/types.cmi typing/subst.cmi typing/predef.cmi \
+    typing/path.cmi utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
     typing/ident.cmi typing/env.cmi utils/clflags.cmi typing/btype.cmi \
     parsing/asttypes.cmi typing/ctype.cmi
-typing/ctype.cmx : typing/types.cmx typing/subst.cmx typing/path.cmx \
-    utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
+typing/ctype.cmx : typing/types.cmx typing/subst.cmx typing/predef.cmx \
+    typing/path.cmx utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
     typing/ident.cmx typing/env.cmx utils/clflags.cmx typing/btype.cmx \
     parsing/asttypes.cmi typing/ctype.cmi
 typing/datarepr.cmo : typing/types.cmi typing/path.cmi parsing/location.cmi \
@@ -239,6 +239,12 @@ typing/datarepr.cmo : typing/types.cmi typing/path.cmi parsing/location.cmi \
 typing/datarepr.cmx : typing/types.cmx typing/path.cmx parsing/location.cmx \
     typing/ident.cmx typing/btype.cmx parsing/asttypes.cmi \
     typing/datarepr.cmi
+typing/envaux.cmo : typing/types.cmi typing/subst.cmi typing/printtyp.cmi \
+    typing/path.cmi utils/misc.cmi typing/ident.cmi typing/env.cmi \
+    parsing/asttypes.cmi typing/envaux.cmi
+typing/envaux.cmx : typing/types.cmx typing/subst.cmx typing/printtyp.cmx \
+    typing/path.cmx utils/misc.cmx typing/ident.cmx typing/env.cmx \
+    parsing/asttypes.cmi typing/envaux.cmi
 typing/env.cmo : utils/warnings.cmi typing/types.cmi utils/tbl.cmi \
     typing/subst.cmi typing/predef.cmi typing/path.cmi utils/misc.cmi \
     parsing/longident.cmi parsing/location.cmi typing/ident.cmi \
@@ -251,12 +257,6 @@ typing/env.cmx : utils/warnings.cmx typing/types.cmx utils/tbl.cmx \
     typing/datarepr.cmx utils/consistbl.cmx utils/config.cmx \
     typing/cmi_format.cmx utils/clflags.cmx parsing/builtin_attributes.cmx \
     typing/btype.cmx parsing/asttypes.cmi typing/env.cmi
-typing/envaux.cmo : typing/types.cmi typing/subst.cmi typing/printtyp.cmi \
-    typing/path.cmi utils/misc.cmi typing/ident.cmi typing/env.cmi \
-    parsing/asttypes.cmi typing/envaux.cmi
-typing/envaux.cmx : typing/types.cmx typing/subst.cmx typing/printtyp.cmx \
-    typing/path.cmx utils/misc.cmx typing/ident.cmx typing/env.cmx \
-    parsing/asttypes.cmi typing/envaux.cmi
 typing/ident.cmo : utils/identifiable.cmi typing/ident.cmi
 typing/ident.cmx : utils/identifiable.cmx typing/ident.cmi
 typing/includeclass.cmo : typing/types.cmi typing/printtyp.cmi \
@@ -321,6 +321,12 @@ typing/primitive.cmo : utils/warnings.cmi parsing/parsetree.cmi \
 typing/primitive.cmx : utils/warnings.cmx parsing/parsetree.cmi \
     typing/outcometree.cmi utils/misc.cmx parsing/location.cmx \
     parsing/attr_helper.cmx typing/primitive.cmi
+typing/printtyped.cmo : typing/typedtree.cmi parsing/printast.cmi \
+    typing/path.cmi utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
+    typing/ident.cmi parsing/asttypes.cmi typing/printtyped.cmi
+typing/printtyped.cmx : typing/typedtree.cmx parsing/printast.cmx \
+    typing/path.cmx utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
+    typing/ident.cmx parsing/asttypes.cmi typing/printtyped.cmi
 typing/printtyp.cmo : typing/types.cmi typing/primitive.cmi \
     typing/predef.cmi typing/path.cmi parsing/parsetree.cmi \
     typing/outcometree.cmi typing/oprint.cmi utils/misc.cmi \
@@ -333,12 +339,6 @@ typing/printtyp.cmx : typing/types.cmx typing/primitive.cmx \
     parsing/longident.cmx parsing/location.cmx typing/ident.cmx \
     typing/env.cmx typing/ctype.cmx utils/clflags.cmx typing/btype.cmx \
     parsing/asttypes.cmi typing/printtyp.cmi
-typing/printtyped.cmo : typing/typedtree.cmi parsing/printast.cmi \
-    typing/path.cmi utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi parsing/asttypes.cmi typing/printtyped.cmi
-typing/printtyped.cmx : typing/typedtree.cmx parsing/printast.cmx \
-    typing/path.cmx utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
-    typing/ident.cmx parsing/asttypes.cmi typing/printtyped.cmi
 typing/stypes.cmo : typing/typedtree.cmi typing/printtyp.cmi \
     parsing/location.cmi utils/clflags.cmi typing/annot.cmi typing/stypes.cmi
 typing/stypes.cmx : typing/typedtree.cmx typing/printtyp.cmx \
@@ -407,14 +407,6 @@ typing/typedecl.cmx : utils/warnings.cmx typing/typetexp.cmx \
     utils/clflags.cmx typing/btype.cmx parsing/attr_helper.cmx \
     parsing/asttypes.cmi parsing/ast_iterator.cmx parsing/ast_helper.cmx \
     typing/typedecl.cmi
-typing/typedtree.cmo : typing/types.cmi typing/primitive.cmi typing/path.cmi \
-    parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
-    parsing/location.cmi typing/ident.cmi typing/env.cmi parsing/asttypes.cmi \
-    typing/typedtree.cmi
-typing/typedtree.cmx : typing/types.cmx typing/primitive.cmx typing/path.cmx \
-    parsing/parsetree.cmi utils/misc.cmx parsing/longident.cmx \
-    parsing/location.cmx typing/ident.cmx typing/env.cmx parsing/asttypes.cmi \
-    typing/typedtree.cmi
 typing/typedtreeIter.cmo : typing/typedtree.cmi utils/misc.cmi \
     parsing/asttypes.cmi typing/typedtreeIter.cmi
 typing/typedtreeIter.cmx : typing/typedtree.cmx utils/misc.cmx \
@@ -423,6 +415,14 @@ typing/typedtreeMap.cmo : typing/typedtree.cmi utils/misc.cmi \
     typing/typedtreeMap.cmi
 typing/typedtreeMap.cmx : typing/typedtree.cmx utils/misc.cmx \
     typing/typedtreeMap.cmi
+typing/typedtree.cmo : typing/types.cmi typing/primitive.cmi typing/path.cmi \
+    parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
+    parsing/location.cmi typing/ident.cmi typing/env.cmi parsing/asttypes.cmi \
+    typing/typedtree.cmi
+typing/typedtree.cmx : typing/types.cmx typing/primitive.cmx typing/path.cmx \
+    parsing/parsetree.cmi utils/misc.cmx parsing/longident.cmx \
+    parsing/location.cmx typing/ident.cmx typing/env.cmx parsing/asttypes.cmi \
+    typing/typedtree.cmi
 typing/typemod.cmo : utils/warnings.cmi typing/typetexp.cmi typing/types.cmi \
     typing/typedtree.cmi typing/typedecl.cmi typing/typecore.cmi \
     typing/typeclass.cmi typing/subst.cmi typing/stypes.cmi \
@@ -686,7 +686,6 @@ bytecomp/typeopt.cmo : typing/types.cmi typing/typedtree.cmi \
 bytecomp/typeopt.cmx : typing/types.cmx typing/typedtree.cmx \
     typing/predef.cmx typing/path.cmx bytecomp/lambda.cmx typing/ident.cmx \
     typing/env.cmx typing/ctype.cmx bytecomp/typeopt.cmi
-asmcomp/CSEgen.cmi : asmcomp/mach.cmi
 asmcomp/asmgen.cmi : utils/timings.cmi bytecomp/lambda.cmi \
     middle_end/flambda.cmi asmcomp/cmm.cmi middle_end/backend_intf.cmi
 asmcomp/asmlibrarian.cmi :
@@ -701,10 +700,10 @@ asmcomp/clambda.cmi : bytecomp/lambda.cmi typing/ident.cmi \
 asmcomp/closure.cmi : bytecomp/lambda.cmi asmcomp/clambda.cmi
 asmcomp/closure_offsets.cmi : middle_end/base_types/var_within_closure.cmi \
     middle_end/flambda.cmi middle_end/base_types/closure_id.cmi
-asmcomp/cmm.cmi : bytecomp/lambda.cmi typing/ident.cmi \
-    bytecomp/debuginfo.cmi
 asmcomp/cmmgen.cmi : asmcomp/cmx_format.cmi asmcomp/cmm.cmi \
     asmcomp/clambda.cmi
+asmcomp/cmm.cmi : bytecomp/lambda.cmi typing/ident.cmi \
+    bytecomp/debuginfo.cmi
 asmcomp/cmx_format.cmi : asmcomp/export_info.cmi asmcomp/clambda.cmi
 asmcomp/coloring.cmi :
 asmcomp/comballoc.cmi : asmcomp/mach.cmi
@@ -714,9 +713,12 @@ asmcomp/compilenv.cmi : utils/timings.cmi middle_end/base_types/symbol.cmi \
     middle_end/flambda.cmi asmcomp/export_info.cmi \
     middle_end/base_types/compilation_unit.cmi asmcomp/cmx_format.cmi \
     middle_end/base_types/closure_id.cmi asmcomp/clambda.cmi
+asmcomp/CSEgen.cmi : asmcomp/mach.cmi
 asmcomp/deadcode.cmi : asmcomp/mach.cmi
-asmcomp/emit.cmi : asmcomp/linearize.cmi asmcomp/cmm.cmi
 asmcomp/emitaux.cmi : bytecomp/debuginfo.cmi
+asmcomp/emit.cmi : asmcomp/linearize.cmi asmcomp/cmm.cmi
+asmcomp/export_info_for_pack.cmi : asmcomp/export_info.cmi \
+    middle_end/base_types/compilation_unit.cmi
 asmcomp/export_info.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
@@ -725,8 +727,6 @@ asmcomp/export_info.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/export_id.cmi \
     middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/closure_id.cmi
-asmcomp/export_info_for_pack.cmi : asmcomp/export_info.cmi \
-    middle_end/base_types/compilation_unit.cmi
 asmcomp/flambda_to_clambda.cmi : middle_end/base_types/symbol.cmi \
     middle_end/flambda.cmi asmcomp/export_info.cmi asmcomp/clambda.cmi
 asmcomp/import_approx.cmi : middle_end/base_types/symbol.cmi \
@@ -743,8 +743,8 @@ asmcomp/printlinear.cmi : asmcomp/linearize.cmi
 asmcomp/printmach.cmi : asmcomp/reg.cmi asmcomp/mach.cmi
 asmcomp/proc.cmi : asmcomp/reg.cmi asmcomp/mach.cmi
 asmcomp/reg.cmi : typing/ident.cmi asmcomp/cmm.cmi
-asmcomp/reload.cmi : asmcomp/mach.cmi
 asmcomp/reloadgen.cmi : asmcomp/reg.cmi asmcomp/mach.cmi
+asmcomp/reload.cmi : asmcomp/mach.cmi
 asmcomp/schedgen.cmi : asmcomp/mach.cmi asmcomp/linearize.cmi
 asmcomp/scheduling.cmi : asmcomp/linearize.cmi
 asmcomp/selectgen.cmi : utils/tbl.cmi asmcomp/reg.cmi asmcomp/mach.cmi \
@@ -759,12 +759,6 @@ asmcomp/x86_dsl.cmi : asmcomp/x86_ast.cmi
 asmcomp/x86_gas.cmi : asmcomp/x86_ast.cmi
 asmcomp/x86_masm.cmi : asmcomp/x86_ast.cmi
 asmcomp/x86_proc.cmi : asmcomp/x86_ast.cmi
-asmcomp/CSE.cmo : asmcomp/mach.cmi asmcomp/CSEgen.cmi asmcomp/arch.cmo
-asmcomp/CSE.cmx : asmcomp/mach.cmx asmcomp/CSEgen.cmx asmcomp/arch.cmx
-asmcomp/CSEgen.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/mach.cmi \
-    asmcomp/cmm.cmi asmcomp/CSEgen.cmi
-asmcomp/CSEgen.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/mach.cmx \
-    asmcomp/cmm.cmx asmcomp/CSEgen.cmi
 asmcomp/arch.cmo : utils/clflags.cmi
 asmcomp/arch.cmx : utils/clflags.cmx
 asmcomp/asmgen.cmo : asmcomp/un_anf.cmi bytecomp/translmod.cmi \
@@ -829,14 +823,14 @@ asmcomp/asmpackager.cmx : typing/typemod.cmx bytecomp/translmod.cmx \
     middle_end/base_types/compilation_unit.cmx asmcomp/cmx_format.cmi \
     utils/clflags.cmx utils/ccomp.cmx asmcomp/asmlink.cmx asmcomp/asmgen.cmx \
     asmcomp/asmpackager.cmi
+asmcomp/branch_relaxation_intf.cmo : asmcomp/linearize.cmi asmcomp/arch.cmo
+asmcomp/branch_relaxation_intf.cmx : asmcomp/linearize.cmx asmcomp/arch.cmx
 asmcomp/branch_relaxation.cmo : utils/misc.cmi asmcomp/mach.cmi \
     asmcomp/linearize.cmi asmcomp/cmm.cmi asmcomp/branch_relaxation_intf.cmo \
     asmcomp/branch_relaxation.cmi
 asmcomp/branch_relaxation.cmx : utils/misc.cmx asmcomp/mach.cmx \
     asmcomp/linearize.cmx asmcomp/cmm.cmx asmcomp/branch_relaxation_intf.cmx \
     asmcomp/branch_relaxation.cmi
-asmcomp/branch_relaxation_intf.cmo : asmcomp/linearize.cmi asmcomp/arch.cmo
-asmcomp/branch_relaxation_intf.cmx : asmcomp/linearize.cmx asmcomp/arch.cmx
 asmcomp/build_export_info.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
@@ -883,10 +877,6 @@ asmcomp/closure_offsets.cmx : middle_end/base_types/variable.cmx \
     middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
     middle_end/flambda.cmx middle_end/base_types/closure_id.cmx \
     asmcomp/closure_offsets.cmi
-asmcomp/cmm.cmo : bytecomp/lambda.cmi typing/ident.cmi \
-    bytecomp/debuginfo.cmi asmcomp/arch.cmo asmcomp/cmm.cmi
-asmcomp/cmm.cmx : bytecomp/lambda.cmx typing/ident.cmx \
-    bytecomp/debuginfo.cmx asmcomp/arch.cmx asmcomp/cmm.cmi
 asmcomp/cmmgen.cmo : asmcomp/un_anf.cmi typing/types.cmi bytecomp/switch.cmi \
     asmcomp/strmatch.cmi asmcomp/proc.cmi bytecomp/printlambda.cmi \
     typing/primitive.cmi utils/misc.cmi bytecomp/lambda.cmi typing/ident.cmi \
@@ -901,6 +891,10 @@ asmcomp/cmmgen.cmx : asmcomp/un_anf.cmx typing/types.cmx bytecomp/switch.cmx \
     asmcomp/cmx_format.cmi asmcomp/cmm.cmx utils/clflags.cmx \
     asmcomp/clambda.cmx parsing/asttypes.cmi asmcomp/arch.cmx \
     asmcomp/cmmgen.cmi
+asmcomp/cmm.cmo : bytecomp/lambda.cmi typing/ident.cmi \
+    bytecomp/debuginfo.cmi asmcomp/arch.cmo asmcomp/cmm.cmi
+asmcomp/cmm.cmx : bytecomp/lambda.cmx typing/ident.cmx \
+    bytecomp/debuginfo.cmx asmcomp/arch.cmx asmcomp/cmm.cmi
 asmcomp/coloring.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/coloring.cmi
 asmcomp/coloring.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/coloring.cmi
 asmcomp/comballoc.cmo : asmcomp/reg.cmi asmcomp/mach.cmi utils/config.cmi \
@@ -923,10 +917,20 @@ asmcomp/compilenv.cmx : utils/warnings.cmx middle_end/base_types/symbol.cmx \
     middle_end/base_types/compilation_unit.cmx asmcomp/cmx_format.cmi \
     middle_end/base_types/closure_id.cmx asmcomp/clambda.cmx \
     asmcomp/compilenv.cmi
+asmcomp/CSEgen.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/mach.cmi \
+    asmcomp/cmm.cmi asmcomp/CSEgen.cmi
+asmcomp/CSEgen.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/mach.cmx \
+    asmcomp/cmm.cmx asmcomp/CSEgen.cmi
+asmcomp/CSE.cmo : asmcomp/mach.cmi asmcomp/CSEgen.cmi asmcomp/arch.cmo
+asmcomp/CSE.cmx : asmcomp/mach.cmx asmcomp/CSEgen.cmx asmcomp/arch.cmx
 asmcomp/deadcode.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/mach.cmi \
     asmcomp/deadcode.cmi
 asmcomp/deadcode.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/mach.cmx \
     asmcomp/deadcode.cmi
+asmcomp/emitaux.cmo : asmcomp/linearize.cmi bytecomp/debuginfo.cmi \
+    utils/config.cmi utils/clflags.cmi asmcomp/arch.cmo asmcomp/emitaux.cmi
+asmcomp/emitaux.cmx : asmcomp/linearize.cmx bytecomp/debuginfo.cmx \
+    utils/config.cmx utils/clflags.cmx asmcomp/arch.cmx asmcomp/emitaux.cmi
 asmcomp/emit.cmo : asmcomp/x86_proc.cmi asmcomp/x86_masm.cmi \
     asmcomp/x86_gas.cmi asmcomp/x86_dsl.cmi asmcomp/x86_ast.cmi \
     asmcomp/reg.cmi asmcomp/proc.cmi utils/misc.cmi asmcomp/mach.cmi \
@@ -941,26 +945,6 @@ asmcomp/emit.cmx : asmcomp/x86_proc.cmx asmcomp/x86_masm.cmx \
     bytecomp/debuginfo.cmx utils/config.cmx asmcomp/compilenv.cmx \
     asmcomp/cmm.cmx utils/clflags.cmx asmcomp/branch_relaxation.cmx \
     asmcomp/arch.cmx asmcomp/emit.cmi
-asmcomp/emitaux.cmo : asmcomp/linearize.cmi bytecomp/debuginfo.cmi \
-    utils/config.cmi utils/clflags.cmi asmcomp/arch.cmo asmcomp/emitaux.cmi
-asmcomp/emitaux.cmx : asmcomp/linearize.cmx bytecomp/debuginfo.cmx \
-    utils/config.cmx utils/clflags.cmx asmcomp/arch.cmx asmcomp/emitaux.cmi
-asmcomp/export_info.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    middle_end/simple_value_approx.cmi \
-    middle_end/base_types/set_of_closures_id.cmi middle_end/flambda.cmi \
-    middle_end/base_types/export_id.cmi \
-    middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi asmcomp/export_info.cmi
-asmcomp/export_info.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
-    middle_end/simple_value_approx.cmx \
-    middle_end/base_types/set_of_closures_id.cmx middle_end/flambda.cmx \
-    middle_end/base_types/export_id.cmx \
-    middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx asmcomp/export_info.cmi
 asmcomp/export_info_for_pack.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/symbol.cmi \
@@ -979,6 +963,22 @@ asmcomp/export_info_for_pack.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/export_id.cmx \
     middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/closure_id.cmx asmcomp/export_info_for_pack.cmi
+asmcomp/export_info.cmo : middle_end/base_types/variable.cmi \
+    middle_end/base_types/var_within_closure.cmi \
+    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
+    middle_end/simple_value_approx.cmi \
+    middle_end/base_types/set_of_closures_id.cmi middle_end/flambda.cmi \
+    middle_end/base_types/export_id.cmi \
+    middle_end/base_types/compilation_unit.cmi \
+    middle_end/base_types/closure_id.cmi asmcomp/export_info.cmi
+asmcomp/export_info.cmx : middle_end/base_types/variable.cmx \
+    middle_end/base_types/var_within_closure.cmx \
+    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
+    middle_end/simple_value_approx.cmx \
+    middle_end/base_types/set_of_closures_id.cmx middle_end/flambda.cmx \
+    middle_end/base_types/export_id.cmx \
+    middle_end/base_types/compilation_unit.cmx \
+    middle_end/base_types/closure_id.cmx asmcomp/export_info.cmi
 asmcomp/flambda_to_clambda.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
@@ -1071,14 +1071,14 @@ asmcomp/proc.cmx : asmcomp/x86_proc.cmx asmcomp/reg.cmx utils/misc.cmx \
     asmcomp/proc.cmi
 asmcomp/reg.cmo : typing/ident.cmi asmcomp/cmm.cmi asmcomp/reg.cmi
 asmcomp/reg.cmx : typing/ident.cmx asmcomp/cmm.cmx asmcomp/reg.cmi
-asmcomp/reload.cmo : asmcomp/reloadgen.cmi asmcomp/reg.cmi asmcomp/mach.cmi \
-    asmcomp/cmm.cmi utils/clflags.cmi asmcomp/reload.cmi
-asmcomp/reload.cmx : asmcomp/reloadgen.cmx asmcomp/reg.cmx asmcomp/mach.cmx \
-    asmcomp/cmm.cmx utils/clflags.cmx asmcomp/reload.cmi
 asmcomp/reloadgen.cmo : asmcomp/reg.cmi utils/misc.cmi asmcomp/mach.cmi \
     asmcomp/reloadgen.cmi
 asmcomp/reloadgen.cmx : asmcomp/reg.cmx utils/misc.cmx asmcomp/mach.cmx \
     asmcomp/reloadgen.cmi
+asmcomp/reload.cmo : asmcomp/reloadgen.cmi asmcomp/reg.cmi asmcomp/mach.cmi \
+    asmcomp/cmm.cmi utils/clflags.cmi asmcomp/reload.cmi
+asmcomp/reload.cmx : asmcomp/reloadgen.cmx asmcomp/reg.cmx asmcomp/mach.cmx \
+    asmcomp/cmm.cmx utils/clflags.cmx asmcomp/reload.cmi
 asmcomp/schedgen.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/mach.cmi \
     asmcomp/linearize.cmi asmcomp/cmm.cmi asmcomp/arch.cmo \
     asmcomp/schedgen.cmi
@@ -1148,19 +1148,22 @@ middle_end/augment_specialised_args.cmi : middle_end/base_types/variable.cmi \
 middle_end/backend_intf.cmi : middle_end/base_types/symbol.cmi \
     middle_end/simple_value_approx.cmi typing/ident.cmi \
     middle_end/base_types/closure_id.cmi
-middle_end/closure_conversion.cmi : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/flambda.cmi middle_end/backend_intf.cmi
 middle_end/closure_conversion_aux.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/symbol.cmi \
     middle_end/base_types/static_exception.cmi \
     middle_end/base_types/mutable_variable.cmi bytecomp/lambda.cmi \
     typing/ident.cmi
+middle_end/closure_conversion.cmi : bytecomp/lambda.cmi typing/ident.cmi \
+    middle_end/flambda.cmi middle_end/backend_intf.cmi
 middle_end/effect_analysis.cmi : middle_end/flambda.cmi
 middle_end/extract_projections.cmi : middle_end/base_types/variable.cmi \
     middle_end/projection.cmi middle_end/inline_and_simplify_aux.cmi \
     middle_end/flambda.cmi
 middle_end/find_recursive_functions.cmi : middle_end/base_types/variable.cmi \
     middle_end/flambda.cmi middle_end/backend_intf.cmi
+middle_end/flambda_invariants.cmi : middle_end/flambda.cmi
+middle_end/flambda_iterators.cmi : middle_end/base_types/variable.cmi \
+    middle_end/base_types/symbol.cmi middle_end/flambda.cmi
 middle_end/flambda.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
     middle_end/base_types/static_exception.cmi \
@@ -1170,9 +1173,6 @@ middle_end/flambda.cmi : middle_end/base_types/variable.cmi \
     bytecomp/lambda.cmi utils/identifiable.cmi bytecomp/debuginfo.cmi \
     middle_end/base_types/closure_id.cmi parsing/asttypes.cmi \
     middle_end/allocated_const.cmi
-middle_end/flambda_invariants.cmi : middle_end/flambda.cmi
-middle_end/flambda_iterators.cmi : middle_end/base_types/variable.cmi \
-    middle_end/base_types/symbol.cmi middle_end/flambda.cmi
 middle_end/flambda_utils.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
@@ -1190,9 +1190,6 @@ middle_end/inconstant_idents.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/set_of_closures_id.cmi middle_end/flambda.cmi \
     middle_end/base_types/compilation_unit.cmi middle_end/backend_intf.cmi
 middle_end/initialize_symbol_to_let_symbol.cmi : middle_end/flambda.cmi
-middle_end/inline_and_simplify.cmi : middle_end/base_types/variable.cmi \
-    middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi \
-    middle_end/backend_intf.cmi
 middle_end/inline_and_simplify_aux.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/symbol.cmi \
     middle_end/base_types/static_exception.cmi \
@@ -1202,17 +1199,20 @@ middle_end/inline_and_simplify_aux.cmi : middle_end/base_types/variable.cmi \
     middle_end/inlining_stats_types.cmi middle_end/inlining_cost.cmi \
     middle_end/freshening.cmi middle_end/flambda.cmi bytecomp/debuginfo.cmi \
     middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi
+middle_end/inline_and_simplify.cmi : middle_end/base_types/variable.cmi \
+    middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi \
+    middle_end/backend_intf.cmi
 middle_end/inlining_cost.cmi : middle_end/projection.cmi \
     middle_end/flambda.cmi
+middle_end/inlining_decision_intf.cmi : middle_end/base_types/variable.cmi \
+    middle_end/simple_value_approx.cmi middle_end/inline_and_simplify_aux.cmi \
+    middle_end/flambda.cmi bytecomp/debuginfo.cmi \
+    middle_end/base_types/closure_id.cmi
 middle_end/inlining_decision.cmi : middle_end/base_types/variable.cmi \
     middle_end/simple_value_approx.cmi bytecomp/lambda.cmi \
     middle_end/inlining_decision_intf.cmi \
     middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi \
     bytecomp/debuginfo.cmi middle_end/base_types/closure_id.cmi
-middle_end/inlining_decision_intf.cmi : middle_end/base_types/variable.cmi \
-    middle_end/simple_value_approx.cmi middle_end/inline_and_simplify_aux.cmi \
-    middle_end/flambda.cmi bytecomp/debuginfo.cmi \
-    middle_end/base_types/closure_id.cmi
 middle_end/inlining_stats.cmi : middle_end/inlining_stats_types.cmi \
     bytecomp/debuginfo.cmi middle_end/base_types/closure_id.cmi
 middle_end/inlining_stats_types.cmi : middle_end/inlining_cost.cmi
@@ -1248,11 +1248,11 @@ middle_end/simple_value_approx.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
     middle_end/freshening.cmi middle_end/flambda.cmi \
     middle_end/base_types/export_id.cmi middle_end/base_types/closure_id.cmi
-middle_end/simplify_boxed_integer_ops.cmi : \
-    middle_end/simplify_boxed_integer_ops_intf.cmi
 middle_end/simplify_boxed_integer_ops_intf.cmi : \
     middle_end/simple_value_approx.cmi bytecomp/lambda.cmi \
     middle_end/inlining_cost.cmi middle_end/flambda.cmi
+middle_end/simplify_boxed_integer_ops.cmi : \
+    middle_end/simplify_boxed_integer_ops_intf.cmi
 middle_end/simplify_common.cmi : middle_end/simple_value_approx.cmi \
     bytecomp/lambda.cmi middle_end/inlining_cost.cmi middle_end/flambda.cmi
 middle_end/simplify_primitives.cmi : middle_end/base_types/variable.cmi \
@@ -1297,6 +1297,18 @@ middle_end/augment_specialised_args.cmx : middle_end/base_types/variable.cmx \
     bytecomp/debuginfo.cmx middle_end/base_types/closure_id.cmx \
     utils/clflags.cmx middle_end/backend_intf.cmi \
     middle_end/augment_specialised_args.cmi
+middle_end/closure_conversion_aux.cmo : middle_end/base_types/variable.cmi \
+    middle_end/base_types/symbol.cmi \
+    middle_end/base_types/static_exception.cmi typing/primitive.cmi \
+    utils/numbers.cmi middle_end/base_types/mutable_variable.cmi \
+    utils/misc.cmi bytecomp/lambda.cmi typing/ident.cmi \
+    middle_end/closure_conversion_aux.cmi
+middle_end/closure_conversion_aux.cmx : middle_end/base_types/variable.cmx \
+    middle_end/base_types/symbol.cmx \
+    middle_end/base_types/static_exception.cmx typing/primitive.cmx \
+    utils/numbers.cmx middle_end/base_types/mutable_variable.cmx \
+    utils/misc.cmx bytecomp/lambda.cmx typing/ident.cmx \
+    middle_end/closure_conversion_aux.cmi
 middle_end/closure_conversion.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
     middle_end/base_types/static_exception.cmi bytecomp/simplif.cmi \
@@ -1325,18 +1337,6 @@ middle_end/closure_conversion.cmx : middle_end/base_types/variable.cmx \
     middle_end/closure_conversion_aux.cmx utils/clflags.cmx \
     middle_end/backend_intf.cmi parsing/asttypes.cmi \
     middle_end/closure_conversion.cmi
-middle_end/closure_conversion_aux.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi typing/primitive.cmi \
-    utils/numbers.cmi middle_end/base_types/mutable_variable.cmi \
-    utils/misc.cmi bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/closure_conversion_aux.cmi
-middle_end/closure_conversion_aux.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/symbol.cmx \
-    middle_end/base_types/static_exception.cmx typing/primitive.cmx \
-    utils/numbers.cmx middle_end/base_types/mutable_variable.cmx \
-    utils/misc.cmx bytecomp/lambda.cmx typing/ident.cmx \
-    middle_end/closure_conversion_aux.cmi
 middle_end/effect_analysis.cmo : middle_end/semantics_of_primitives.cmi \
     utils/misc.cmi bytecomp/lambda.cmi middle_end/flambda.cmi \
     middle_end/effect_analysis.cmi
@@ -1361,30 +1361,6 @@ middle_end/find_recursive_functions.cmo : middle_end/base_types/variable.cmi \
 middle_end/find_recursive_functions.cmx : middle_end/base_types/variable.cmx \
     utils/strongly_connected_components.cmx middle_end/flambda_utils.cmx \
     middle_end/flambda.cmx middle_end/find_recursive_functions.cmi
-middle_end/flambda.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi \
-    middle_end/base_types/set_of_closures_origin.cmi \
-    middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
-    bytecomp/printlambda.cmi utils/numbers.cmi \
-    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    bytecomp/lambda.cmi utils/identifiable.cmi bytecomp/debuginfo.cmi \
-    middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
-    parsing/asttypes.cmi middle_end/allocated_const.cmi \
-    middle_end/flambda.cmi
-middle_end/flambda.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
-    middle_end/base_types/static_exception.cmx \
-    middle_end/base_types/set_of_closures_origin.cmx \
-    middle_end/base_types/set_of_closures_id.cmx middle_end/projection.cmx \
-    bytecomp/printlambda.cmx utils/numbers.cmx \
-    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    bytecomp/lambda.cmx utils/identifiable.cmx bytecomp/debuginfo.cmx \
-    middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
-    parsing/asttypes.cmi middle_end/allocated_const.cmx \
-    middle_end/flambda.cmi
 middle_end/flambda_invariants.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
@@ -1415,6 +1391,30 @@ middle_end/flambda_iterators.cmo : middle_end/base_types/variable.cmi \
     utils/misc.cmi middle_end/flambda.cmi middle_end/flambda_iterators.cmi
 middle_end/flambda_iterators.cmx : middle_end/base_types/variable.cmx \
     utils/misc.cmx middle_end/flambda.cmx middle_end/flambda_iterators.cmi
+middle_end/flambda.cmo : middle_end/base_types/variable.cmi \
+    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
+    middle_end/base_types/static_exception.cmi \
+    middle_end/base_types/set_of_closures_origin.cmi \
+    middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
+    bytecomp/printlambda.cmi utils/numbers.cmi \
+    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
+    bytecomp/lambda.cmi utils/identifiable.cmi bytecomp/debuginfo.cmi \
+    middle_end/base_types/compilation_unit.cmi \
+    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
+    parsing/asttypes.cmi middle_end/allocated_const.cmi \
+    middle_end/flambda.cmi
+middle_end/flambda.cmx : middle_end/base_types/variable.cmx \
+    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
+    middle_end/base_types/static_exception.cmx \
+    middle_end/base_types/set_of_closures_origin.cmx \
+    middle_end/base_types/set_of_closures_id.cmx middle_end/projection.cmx \
+    bytecomp/printlambda.cmx utils/numbers.cmx \
+    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
+    bytecomp/lambda.cmx utils/identifiable.cmx bytecomp/debuginfo.cmx \
+    middle_end/base_types/compilation_unit.cmx \
+    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
+    parsing/asttypes.cmi middle_end/allocated_const.cmx \
+    middle_end/flambda.cmi
 middle_end/flambda_utils.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/symbol.cmi bytecomp/switch.cmi \
@@ -1475,6 +1475,32 @@ middle_end/initialize_symbol_to_let_symbol.cmo : \
 middle_end/initialize_symbol_to_let_symbol.cmx : \
     middle_end/base_types/variable.cmx utils/misc.cmx middle_end/flambda.cmx \
     middle_end/initialize_symbol_to_let_symbol.cmi
+middle_end/inline_and_simplify_aux.cmo : middle_end/base_types/variable.cmi \
+    middle_end/base_types/var_within_closure.cmi \
+    middle_end/base_types/symbol.cmi \
+    middle_end/base_types/static_exception.cmi \
+    middle_end/simple_value_approx.cmi \
+    middle_end/base_types/set_of_closures_origin.cmi \
+    middle_end/projection.cmi utils/numbers.cmi \
+    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
+    middle_end/inlining_stats.cmi middle_end/inlining_cost.cmi \
+    middle_end/freshening.cmi middle_end/flambda.cmi \
+    middle_end/base_types/compilation_unit.cmi \
+    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
+    middle_end/backend_intf.cmi middle_end/inline_and_simplify_aux.cmi
+middle_end/inline_and_simplify_aux.cmx : middle_end/base_types/variable.cmx \
+    middle_end/base_types/var_within_closure.cmx \
+    middle_end/base_types/symbol.cmx \
+    middle_end/base_types/static_exception.cmx \
+    middle_end/simple_value_approx.cmx \
+    middle_end/base_types/set_of_closures_origin.cmx \
+    middle_end/projection.cmx utils/numbers.cmx \
+    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
+    middle_end/inlining_stats.cmx middle_end/inlining_cost.cmx \
+    middle_end/freshening.cmx middle_end/flambda.cmx \
+    middle_end/base_types/compilation_unit.cmx \
+    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
+    middle_end/backend_intf.cmi middle_end/inline_and_simplify_aux.cmi
 middle_end/inline_and_simplify.cmo : utils/warnings.cmi \
     middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
@@ -1515,32 +1541,6 @@ middle_end/inline_and_simplify.cmx : utils/warnings.cmx \
     bytecomp/debuginfo.cmx middle_end/base_types/closure_id.cmx \
     utils/clflags.cmx middle_end/backend_intf.cmi \
     middle_end/allocated_const.cmx middle_end/inline_and_simplify.cmi
-middle_end/inline_and_simplify_aux.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi \
-    middle_end/simple_value_approx.cmi \
-    middle_end/base_types/set_of_closures_origin.cmi \
-    middle_end/projection.cmi utils/numbers.cmi \
-    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    middle_end/inlining_stats.cmi middle_end/inlining_cost.cmi \
-    middle_end/freshening.cmi middle_end/flambda.cmi \
-    middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
-    middle_end/backend_intf.cmi middle_end/inline_and_simplify_aux.cmi
-middle_end/inline_and_simplify_aux.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/symbol.cmx \
-    middle_end/base_types/static_exception.cmx \
-    middle_end/simple_value_approx.cmx \
-    middle_end/base_types/set_of_closures_origin.cmx \
-    middle_end/projection.cmx utils/numbers.cmx \
-    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    middle_end/inlining_stats.cmx middle_end/inlining_cost.cmx \
-    middle_end/freshening.cmx middle_end/flambda.cmx \
-    middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
-    middle_end/backend_intf.cmi middle_end/inline_and_simplify_aux.cmi
 middle_end/inlining_cost.cmo : middle_end/base_types/variable.cmi \
     middle_end/projection.cmi typing/primitive.cmi utils/misc.cmi \
     bytecomp/lambda.cmi middle_end/flambda_iterators.cmi \
@@ -1842,10 +1842,10 @@ middle_end/base_types/static_exception.cmi : utils/identifiable.cmi
 middle_end/base_types/symbol.cmi : middle_end/base_types/linkage_name.cmi \
     utils/identifiable.cmi middle_end/base_types/compilation_unit.cmi
 middle_end/base_types/tag.cmi : utils/identifiable.cmi
-middle_end/base_types/var_within_closure.cmi : \
-    middle_end/base_types/closure_element.cmi
 middle_end/base_types/variable.cmi : utils/identifiable.cmi typing/ident.cmi \
     middle_end/base_types/compilation_unit.cmi
+middle_end/base_types/var_within_closure.cmi : \
+    middle_end/base_types/closure_element.cmi
 middle_end/base_types/closure_element.cmo : \
     middle_end/base_types/variable.cmi \
     middle_end/base_types/closure_element.cmi
@@ -1916,24 +1916,24 @@ middle_end/base_types/tag.cmo : utils/numbers.cmi utils/misc.cmi \
     utils/identifiable.cmi middle_end/base_types/tag.cmi
 middle_end/base_types/tag.cmx : utils/numbers.cmx utils/misc.cmx \
     utils/identifiable.cmx middle_end/base_types/tag.cmi
-middle_end/base_types/var_within_closure.cmo : \
-    middle_end/base_types/closure_element.cmi \
-    middle_end/base_types/var_within_closure.cmi
-middle_end/base_types/var_within_closure.cmx : \
-    middle_end/base_types/closure_element.cmx \
-    middle_end/base_types/var_within_closure.cmi
 middle_end/base_types/variable.cmo : utils/misc.cmi utils/identifiable.cmi \
     typing/ident.cmi middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/variable.cmi
 middle_end/base_types/variable.cmx : utils/misc.cmx utils/identifiable.cmx \
     typing/ident.cmx middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/variable.cmi
+middle_end/base_types/var_within_closure.cmo : \
+    middle_end/base_types/closure_element.cmi \
+    middle_end/base_types/var_within_closure.cmi
+middle_end/base_types/var_within_closure.cmx : \
+    middle_end/base_types/closure_element.cmx \
+    middle_end/base_types/var_within_closure.cmi
 driver/compenv.cmi :
 driver/compile.cmi :
 driver/compmisc.cmi : typing/env.cmi
 driver/errors.cmi :
-driver/main.cmi :
 driver/main_args.cmi :
+driver/main.cmi :
 driver/optcompile.cmi : middle_end/backend_intf.cmi
 driver/opterrors.cmi :
 driver/optmain.cmi :
@@ -1970,6 +1970,10 @@ driver/compmisc.cmx : typing/typemod.cmx utils/misc.cmx \
     parsing/asttypes.cmi driver/compmisc.cmi
 driver/errors.cmo : parsing/location.cmi driver/errors.cmi
 driver/errors.cmx : parsing/location.cmx driver/errors.cmi
+driver/main_args.cmo : utils/warnings.cmi utils/clflags.cmi \
+    driver/main_args.cmi
+driver/main_args.cmx : utils/warnings.cmx utils/clflags.cmx \
+    driver/main_args.cmi
 driver/main.cmo : utils/warnings.cmi utils/timings.cmi utils/misc.cmi \
     driver/main_args.cmi parsing/location.cmi utils/config.cmi \
     driver/compmisc.cmi driver/compile.cmi driver/compenv.cmi \
@@ -1980,10 +1984,6 @@ driver/main.cmx : utils/warnings.cmx utils/timings.cmx utils/misc.cmx \
     driver/compmisc.cmx driver/compile.cmx driver/compenv.cmx \
     utils/clflags.cmx bytecomp/bytepackager.cmx bytecomp/bytelink.cmx \
     bytecomp/bytelibrarian.cmx driver/main.cmi
-driver/main_args.cmo : utils/warnings.cmi utils/clflags.cmi \
-    driver/main_args.cmi
-driver/main_args.cmx : utils/warnings.cmx utils/clflags.cmx \
-    driver/main_args.cmi
 driver/optcompile.cmo : utils/warnings.cmi typing/typemod.cmi \
     typing/typedtree.cmi typing/typecore.cmi bytecomp/translmod.cmi \
     utils/timings.cmi typing/stypes.cmi bytecomp/simplif.cmi \

--- a/middle_end/inlining_stats_types.ml
+++ b/middle_end/inlining_stats_types.ml
@@ -18,6 +18,8 @@
 
 module Wsb = Inlining_cost.Whether_sufficient_benefit
 
+let choose_rhyme () = if Random.bool () then `ion else `ound
+
 let print_stars ppf n =
   let s = String.make n '*' in
   Format.fprintf ppf "%s" s
@@ -40,21 +42,41 @@ module Inlined = struct
     | Without_subfunctions of Wsb.t
     | With_subfunctions of Wsb.t * Wsb.t
 
-  let summary ppf = function
+  let summary ~rhyme ppf = function
     | Annotation ->
-      Format.pp_print_text ppf
-        "This function was inlined because of an annotation."
+        begin match rhyme with
+        | `ion ->
+            Format.pp_print_string ppf
+              "This function was inlined because of an annotation\n"
+        | `ound ->
+            Format.pp_print_string ppf
+              "This function was inlined because an annotation was found\n"
+        end
     | Decl_local_to_application ->
-      Format.pp_print_text ppf
-        "This function was inlined because it was local to this application."
+        begin match rhyme with
+        | `ion ->
+            Format.pp_print_string ppf
+              "This function was inlined because it was local to this application."
+        | `ound ->
+            Format.pp_print_string ppf
+              "We inlined this function\n\
+               Because its declaration was bound\n\
+               To this application\n"
+        end
+    | With_subfunctions _
     | Without_subfunctions _ ->
-      Format.pp_print_text ppf
-        "This function was inlined because \
-         the expected benefit outweighed the change in code size."
-    | With_subfunctions _ ->
-      Format.pp_print_text ppf
-        "This function was inlined because \
-         the expected benefit outweighed the change in code size."
+        begin match rhyme with
+        | `ion ->
+            Format.pp_print_string ppf
+              "We inlined this function\n\
+               As the change in code size was outweighed\n\
+               By the benefit we expected\n"
+        | `ound ->
+            Format.pp_print_string ppf
+              "Inlining this function was sound\n\
+               As the change in code size was outweighed\n\
+               By the benefit we expected\n"
+        end
 
   let calculation ~depth ppf = function
     | Annotation -> ()
@@ -82,39 +104,80 @@ module Not_inlined = struct
     | With_subfunctions of Wsb.t * Wsb.t
 
 
-  let summary ppf = function
+  let summary ~rhyme ppf = function
     | Classic_mode ->
-      Format.pp_print_text ppf
-        "This function was prevented from inlining by `-Oclassic'."
-    | Function_obviously_too_large size ->
-      Format.pp_print_text ppf
-        "This function was not inlined because \
-         it was obviously too large";
-        Format.fprintf ppf "(%i)" size
+        begin match rhyme with
+        | `ion ->
+            Format.pp_print_string ppf
+              "This function was not inlined\n\
+               Indeed by the user it was declined\n\
+               When he specified the `-Oclassic' option\n"
+        | `ound ->
+            Format.pp_print_string ppf
+              "We did not look around\n\
+               To see if we could inline this function\n\
+               As the user specified the `-Oclassic' option\n"
+        end
+    | With_subfunctions _
+    | Without_subfunctions _
+    | Function_obviously_too_large _ ->
+        begin match rhyme with
+        | `ion ->
+            Format.pp_print_string ppf
+              "Compared to the code size evolution\n\
+               The expected benefit was to slim\n\
+               To inline this function on a whim\n"
+        | `ound ->
+            Format.pp_print_string ppf
+              "We once decided of a bound\n\
+               Over which no function could be inlined\n\
+               And this one was of that kind\n"
+        end
     | Annotation ->
-      Format.pp_print_text ppf
-        "This function was not inlined because \
-         of an annotation."
+        begin match rhyme with
+        | `ion ->
+            Format.pp_print_string ppf
+              "This function was not inlined because of an annotation\n"
+        | `ound ->
+            Format.pp_print_string ppf
+              "This function was not inlined because an annotation was found\n"
+        end
     | Unspecialised ->
-      Format.pp_print_text ppf
-        "This function was not inlined because \
-         its parameters could not be specialised."
+        begin match rhyme with
+        | `ion ->
+            Format.pp_print_string ppf
+              "We did not inline this function\n\
+               Because its parameters admitted no specialisation\n"
+        | `ound ->
+            Format.pp_print_string ppf
+              "No possible specialisation was found\n\
+               For the parameters of this function\n\
+               Clearly to being inlined it had no pretention\n"
+        end
     | Unrolling_depth_exceeded ->
-      Format.pp_print_text ppf
-        "This function was not inlined because \
-         its unrolling depth was exceeded."
+        begin match rhyme with
+        | `ion ->
+            Format.pp_print_string ppf
+              "We did not inline this function\n\
+               It could not even be considered\n\
+               As its unrolling depth was exceeded\n "
+        | `ound ->
+            Format.pp_print_string ppf
+              "Its unrolling depth was too profound\n\
+               For any inlining of this function\n\
+               To ever be a viable option\n "
+        end
     | Self_call ->
-      Format.pp_print_text ppf
-        "This function was not inlined because \
-         it was a self call."
-    | Without_subfunctions _ ->
-      Format.pp_print_text ppf
-        "This function was not inlined because \
-         the expected benefit did not outweigh the change in code size."
-    | With_subfunctions _ ->
-      Format.pp_print_text ppf
-        "This function was not inlined because \
-         the expected benefit did not outweigh the change in code size."
+        begin match rhyme with
+        | `ion ->
+            Format.pp_print_string ppf
+              "This function was not inlined because it was self recursion."
+        | `ound ->
+            Format.pp_print_string ppf
+              "When we looked at this we frowned\n\
+               This function was not inlined\n\
+               To self calls we are blind\n "
+        end
 
   let calculation ~depth ppf = function
     | Classic_mode
@@ -140,18 +203,30 @@ module Specialised = struct
     | Without_subfunctions of Wsb.t
     | With_subfunctions of Wsb.t * Wsb.t
 
-  let summary ppf = function
+  let summary ~rhyme ppf = function
     | Annotation ->
-      Format.pp_print_text ppf
-        "This function was specialised because of an annotation."
+        begin match rhyme with
+        | `ion ->
+            Format.pp_print_string ppf
+              "This function was specialised because of an annotation\n"
+        | `ound ->
+            Format.pp_print_string ppf
+              "This function was specialised because an annotation was found\n"
+        end
+    | With_subfunctions _
     | Without_subfunctions _ ->
-      Format.pp_print_text ppf
-        "This function was specialised because the expected benefit \
-         outweighed the change in code size."
-    | With_subfunctions _ ->
-      Format.pp_print_text ppf
-        "This function was specialised because the expected benefit \
-         outweighed the change in code size."
+        begin match rhyme with
+        | `ion ->
+            Format.pp_print_string ppf
+              "We specialised this function\n\
+               As the change in code size is outweighed\n\
+               By the benefit which is expected\n"
+        | `ound ->
+            Format.pp_print_string ppf
+              "This function was specialised this time around\n\
+               As the change in code size is outweighed\n\
+               By the benefit which is expected\n"
+        end
 
 
   let calculation ~depth ppf = function
@@ -180,43 +255,51 @@ module Not_specialised = struct
 
   let summary ppf = function
     | Classic_mode ->
-      Format.pp_print_text ppf
-        "This function was prevented from specialising by \
-          `-Oclassic'."
-    | Function_obviously_too_large size ->
-      Format.pp_print_text ppf
-        "This function was not specialised because \
-         it was obviously too large";
-        Format.fprintf ppf "(%i)" size
+      Format.pp_print_string ppf
+        "The use of `-Oclassic' prevented\n\
+         This function from being specialised\n"
+    | Function_obviously_too_large _ ->
+      Format.pp_print_string ppf
+        "Because it was obviously too\n\
+         Large This function\n\
+         Deserved no specialisation\n\
+         At least from our point of view\n"
     | Annotation ->
-      Format.pp_print_text ppf
-        "This function was not specialised because \
-         of an annotation."
+      Format.pp_print_string ppf
+        "The presence of an annotation\n\
+         Prevented the specialisation of this function\n"
     | Not_recursive ->
-      Format.pp_print_text ppf
-        "This function was not specialised because \
-         it is not recursive."
+      Format.pp_print_string ppf
+        "As it contained no recursion\n\
+         We did not specialise this function\n"
     | Not_closed ->
-      Format.pp_print_text ppf
-        "This function was not specialised because \
-         it is not closed."
+      Format.pp_print_string ppf
+        "For this function\n\
+         To specialisation\n\
+         We were opposed\n\
+         As it isn't closed\n"
     | No_invariant_parameters ->
-      Format.pp_print_text ppf
-        "This function was not specialised because \
-          it has no invariant parameters."
+      Format.pp_print_string ppf
+        "As none of its parameters is invariant\n\
+         This function won't be specialised for the moment\n"
     | No_useful_approximations ->
-      Format.pp_print_text ppf
-        "This function was not specialised because \
-         there was no useful information about any of its invariant \
-         parameters."
+      Format.pp_print_string ppf
+        "We found no information that matters\n\
+         About its invariant parameters\n\
+         So no specialisation\n\
+         Was done to this function\n"
     | Self_call ->
-      Format.pp_print_text ppf
-        "This function was not specialised because \
-         it was a self call."
+      Format.pp_print_string ppf
+        "This was a self call\n\
+         And although producing a rhyme we shall\n\
+         What matters in the end is the following decision\n\
+         We did not specialise this function\n"
     | Not_beneficial _ ->
-      Format.pp_print_text ppf
-        "This function was not specialised because \
-          the expected benefit did not outweigh the change in code size."
+      Format.pp_print_string ppf
+        "In the case of this function\n\
+         The expected benefit was to slim\n\
+         Compared to the code size evolution\n\
+         To specialise it on a whim\n"
 
   let calculation ~depth ppf = function
     | Classic_mode
@@ -239,14 +322,33 @@ module Prevented = struct
     | Function_prevented_from_inlining
     | Level_exceeded
 
-  let summary ppf = function
+  let summary ~rhyme ppf = function
     | Function_prevented_from_inlining ->
-      Format.pp_print_text ppf
-        "This function was prevented from inlining or specialising."
+        begin match rhyme with
+        | `ion ->
+            Format.pp_print_string ppf
+              "No inlining or specialising could be done with this function\n"
+        | `ound ->
+            Format.pp_print_string ppf
+              "Inlining or specialising would not have been unsound\n\
+               However it was of so little worth\n\
+               That the operation wasn't even put forth\n"
+        end
     | Level_exceeded ->
-      Format.pp_print_text ppf
-        "This function was prevented from inlining or specialising \
-         because the inlining depth was exceeded."
+        begin match rhyme with
+        | `ion ->
+            Format.pp_print_string ppf
+              "From inlining or specialising this function\n\
+               Was prevented\n\
+               As the inlining depth was exceeded\n"
+        | `ound ->
+            Format.pp_print_string ppf
+              "Since the inlining depth was too profound\n\
+               It was decided that no operation\n\
+               Neither inlining\n\
+               Nor specialising\n\
+               Could be done on this function\n"
+        end
 end
 
 module Decision = struct
@@ -256,17 +358,17 @@ module Decision = struct
     | Inlined of Not_specialised.t * Inlined.t
     | Unchanged of Not_specialised.t * Not_inlined.t
 
-  let summary ppf = function
+  let summary ~rhyme ppf = function
     | Prevented p ->
-      Prevented.summary ppf p
+      Prevented.summary ~rhyme ppf p
     | Specialised s ->
-      Specialised.summary ppf s
+      Specialised.summary ~rhyme ppf s
     | Inlined (s, i) ->
-      Format.fprintf ppf "@[<v>@[%a@]@;@;@[%a@]@]"
-        Not_specialised.summary s Inlined.summary i
+      Format.fprintf ppf "%a\n%a"
+        Not_specialised.summary s (Inlined.summary ~rhyme) i
     | Unchanged (s, i) ->
-      Format.fprintf ppf "@[<v>@[%a@]@;@;@[%a@]@]"
-        Not_specialised.summary s Not_inlined.summary i
+      Format.fprintf ppf "%a\n%a"
+        Not_specialised.summary s (Not_inlined.summary ~rhyme) i
 
   let calculation ~depth ppf = function
     | Prevented _ -> ()

--- a/middle_end/inlining_stats_types.mli
+++ b/middle_end/inlining_stats_types.mli
@@ -75,6 +75,8 @@ module Prevented : sig
     | Level_exceeded
 end
 
+val choose_rhyme : unit -> [ `ion | `ound ]
+
 module Decision : sig
 
   type t =
@@ -83,6 +85,6 @@ module Decision : sig
     | Inlined of Not_specialised.t * Inlined.t
     | Unchanged of Not_specialised.t * Not_inlined.t
 
-  val summary : Format.formatter -> t -> unit
+  val summary : rhyme:[ `ion | `ound ] -> Format.formatter -> t -> unit
   val calculation : depth:int -> Format.formatter -> t -> unit
 end


### PR DESCRIPTION
The current draft of the flambda manual states:
> If the -inlining-report option is provided to the compiler then a file will be emitted corresponding to each round of optimisation. For the OCaml source file basename.ml the files are named basename.round.inlining.org, with round a zero-based integer. Inside the files, which are formatted as “org mode”, will be found English prose describing the decisions that the inliner took.

There are two things slightly disturbing with that:

1. org-mode is an unreadable markup language which is only used because (as its name suggests) there is good support for it in emacs. But anyone using another editor ([atom](https://atom.io/) anyone?) is stuck with a language almost as bad as tex which doesn't even have the excuse of being "the standard"
2. english prose seem like a poor choice considering the fact that many ocaml user are not native english speakers.

To these problems I propose the following solution: drop the pseudo-structural formating provided by org-mode and replace the english prose by verses written in english. The major advantage of verses over prose here is that lines are short, so easier to take in for non native speakers, and there is a rythme to it that makes it bearable to read this otherwise dull report generated by the compiler.

Before more discussions, here is the report generated for the first pass of optimisation on stdlib/ephemeron.ml:
- in org-prose: http://pastebin.com/raw/adABtMsQ
- in lyrical text: http://pastebin.com/raw/UD9mKRZV

I think we will all agree that, while it still needs to be improved, the lyrical version is already much more enjoyable.

# Notes about the implementation:
- I tried to make the patch non intrusive so I kept the preexisting structure to format te report. This of course limits the poetic aspect of the text which we generate. This was acceptable as a first step but once we are all agreed that verses are the way to go, this should be changed IMHO.
- The "benefit calculation" are not printed anymore. Not only were they of little interest, they are also unpleasant from a typographic point of view.
- There is no smart formatting done on the generated text. Perhaps if ocaml had a module in its standard library akin to left-pad could we do some better formatting. But this felt out of scope for this PR.

# Notes about style:
- No particular metre was chosen for the generated report. This is mostly a matter of taste I think, but perhaps there is currently a well established style in the english speaking community that everyone is supposed to follow. If this is the case I will not strongly object to people try to restrict the reports to a particular metre.
- Some rhymes are a bit clunky, I justify this by the fact that I am not a native english speaker and welcome any proposal trying to improve the text.

Apart frm that I am sure that the code contains some typos and formatting errors, as is often the case in such PRs, please do not hesitate to point them out!