### PR TITLE
PR#6217 Improve perf. of functional record update

### DIFF
--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -1234,9 +1234,9 @@ and transl_setinstvar self var expr =
 
 and transl_record env all_labels repres lbl_expr_list opt_init_expr =
   let size = Array.length all_labels in
-  (* Determine if there are "enough" new fields *)
+  (* If this is a record update, determine if there are "enough" fields *)
   let no_init = match opt_init_expr with None -> true | _ -> false in
-  if no_init || size > 255
+  if no_init || size > Config.max_young_wosize
   then begin
     (* Allocate new record with given fields (and remaining fields
        taken from init_expr if any *)

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -1235,7 +1235,8 @@ and transl_setinstvar self var expr =
 and transl_record env all_labels repres lbl_expr_list opt_init_expr =
   let size = Array.length all_labels in
   (* Determine if there are "enough" new fields *)
-  if 3 + 2 * List.length lbl_expr_list >= size
+  let no_init = match opt_init_expr with None -> true | _ -> false in
+  if no_init || size > 255
   then begin
     (* Allocate new record with given fields (and remaining fields
        taken from init_expr if any *)

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -1234,9 +1234,10 @@ and transl_setinstvar self var expr =
 
 and transl_record env all_labels repres lbl_expr_list opt_init_expr =
   let size = Array.length all_labels in
-  (* If this is a record update, determine if there are "enough" fields *)
+  (* Determine if there are "enough" fields (only relevant if this is a
+     functional-style record update *)
   let no_init = match opt_init_expr with None -> true | _ -> false in
-  if no_init || size > Config.max_young_wosize
+  if no_init || size >= Config.max_young_wosize
   then begin
     (* Allocate new record with given fields (and remaining fields
        taken from init_expr if any *)


### PR DESCRIPTION
See [Mantis issue #6217](http://caml.inria.fr/mantis/view.php?id=6217). Benchmarking with `Core_bench` on a 2.5 GHz 64-bit Intel i5-2450M showed that fieldwise copy is always faster while the number of fields is smaller than `Max_young_wosize` (that is, 256); beyond that point the "duplication and modification" method becomes much faster.

Benchmark details:
[rfu_benchmarks.pdf](https://github.com/ocaml/ocaml/files/218048/rfu_benchmarks.pdf)
CSV results:
[rfu_bench.zip](https://github.com/ocaml/ocaml/files/218054/rfu_bench.zip)
