### PR TITLE
Fix name of install document and remove 'maccaml' from README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,7 +47,7 @@ renaming of standard library functions.
 == CONTENTS
 
   Changes::               what's new with each release
-  INSTALL::               instructions for installation
+  INSTALL.adoc::          instructions for installation
   LICENSE::               license and copyright notice
   Makefile::              main Makefile
   README.adoc::           this file
@@ -62,7 +62,6 @@ renaming of standard library functions.
   driver/::               driver code for the compilers
   emacs/::                editing mode and debugger interface for GNU Emacs
   lex/::                  lexer generator
-  maccaml/::              the Macintosh GUI
   ocamldoc/::             documentation generator
   otherlibs/::            several external libraries
   parsing/::              syntax analysis


### PR DESCRIPTION
The following files are not described in "CONTENTS". I am happy to provide another pull request which adds them, if we actually want all them there:

CONTRIBUTING.md
Makefile.nt
Makefile.shared
VERSION
appveyor.yml
appveyor_build.sh
compilerlibs
configure
experimental
flexdll
man
manual
middle_end
testsuite
