### PR TITLE
Avoid overflow on 32-bit architectures causing bad GC behavior

### DIFF
--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -755,7 +755,7 @@ void caml_major_collection_slice (intnat howmuch)
   }
 
   if (caml_gc_phase == Phase_mark || caml_gc_phase == Phase_clean){
-    computed_work = (intnat) (p * (caml_stat_heap_wsz * 250
+    computed_work = (intnat) (p * ((double) caml_stat_heap_wsz * 250
                                    / (100 + caml_percent_free)
                                    + caml_incremental_roots_count));
   }else{


### PR DESCRIPTION
http://caml.inria.fr/mantis/view.php?id=7228

It would be worth creating a non-regression test for this one, but one should certainly include the fix in 4.03 even without the test.
