### PR TITLE
Prevent getenv and trace file-system for security applications

### DIFF
--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -124,7 +124,84 @@ CAMLnoreturn_end;
 CAMLextern char * caml_strdup(const char * s);
 CAMLextern char * caml_strconcat(int n, ...); /* n args of const char * type */
 
-/* <private> */
+/* Use macros for some system calls being called from OCaml itself.
+  These calls can be either traced for security reasons, or changed to
+  virtualize the program. */
+
+#ifndef CAML_WITH_CPLUGINS
+
+#define CAML_SYS_EXIT(retcode) exit(retcode)
+#define CAML_SYS_OPEN(filename,flags,perm) open(filename,flags,perm)
+#define CAML_SYS_CLOSE(fd) close(fd)
+#define CAML_SYS_STAT(filename,st) stat(filename,st)
+#define CAML_SYS_UNLINK(filename) unlink(filename)
+#define CAML_SYS_RENAME(old_name,new_name) rename(old_name, new_name)
+#define CAML_SYS_CHDIR(dirname) chdir(dirname)
+#define CAML_SYS_GETENV(varname) getenv(varname)
+#define CAML_SYS_SYSTEM(command) system(command)
+#define CAML_SYS_READ_DIRECTORY(dirname,tbl) caml_read_directory(dirname,tbl)
+
+#else
+
+#define CAML_CPLUGINS_EXIT 0
+#define CAML_CPLUGINS_OPEN 1
+#define CAML_CPLUGINS_CLOSE 2
+#define CAML_CPLUGINS_STAT 3
+#define CAML_CPLUGINS_UNLINK 4
+#define CAML_CPLUGINS_RENAME 5
+#define CAML_CPLUGINS_CHDIR 6
+#define CAML_CPLUGINS_GETENV 7
+#define CAML_CPLUGINS_SYSTEM 8
+#define CAML_CPLUGINS_READ_DIRECTORY 9
+
+extern intnat (*caml_cplugins_prim)(int,intnat,intnat,intnat);
+
+#define CAML_SYS_PRIM_1(code,prim,arg1)               \
+  (caml_cplugins_prim == NULL) ? prim(arg1) :    \
+  caml_cplugins_prim(code,(intnat) (arg1),0,0)
+#define CAML_SYS_STRING_PRIM_1(code,prim,arg1)               \
+  (caml_cplugins_prim == NULL) ? prim(arg1) :    \
+  (char*)caml_cplugins_prim(code,(intnat) (arg1),0,0)
+#define CAML_SYS_PRIM_2(code,prim,arg1,arg2)                         \
+  (caml_cplugins_prim == NULL) ? prim(arg1,arg2) :              \
+  caml_cplugins_prim(code,(intnat) (arg1), (intnat) (arg2),0)
+#define CAML_SYS_PRIM_3(code,prim,arg1,arg2,arg3)                            \
+  (caml_cplugins_prim == NULL) ? prim(arg1,arg2,arg3) :                 \
+  caml_cplugins_prim(code,(intnat) (arg1), (intnat) (arg2),(intnat) (arg3))
+
+#define CAML_SYS_EXIT(retcode) \
+  CAML_SYS_PRIM_1(CAML_CPLUGINS_EXIT,exit,retcode)
+#define CAML_SYS_OPEN(filename,flags,perm)                      \
+  CAML_SYS_PRIM_3(CAML_CPLUGINS_OPEN,open,filename,flags,perm)
+#define CAML_SYS_CLOSE(fd)                      \
+  CAML_SYS_PRIM_1(CAML_CPLUGINS_CLOSE,close,fd)
+#define CAML_SYS_STAT(filename,st)                      \
+  CAML_SYS_PRIM_2(CAML_CPLUGINS_STAT,stat,filename,st)
+#define CAML_SYS_UNLINK(filename)                       \
+  CAML_SYS_PRIM_1(CAML_CPLUGINS_UNLINK,unlink,filename)
+#define CAML_SYS_RENAME(old_name,new_name)                              \
+  CAML_SYS_PRIM_2(CAML_CPLUGINS_RENAME,rename,old_name,new_name)
+#define CAML_SYS_CHDIR(dirname)                         \
+  CAML_SYS_PRIM_1(CAML_CPLUGINS_CHDIR,chdir,dirname)
+#define CAML_SYS_GETENV(varname)                        \
+  CAML_SYS_STRING_PRIM_1(CAML_CPLUGINS_GETENV,getenv,varname)
+#define CAML_SYS_SYSTEM(command)                        \
+  CAML_SYS_PRIM_1(CAML_CPLUGINS_SYSTEM,system,command)
+#define CAML_SYS_READ_DIRECTORY(dirname,tbl)                            \
+  CAML_SYS_PRIM_2(CAML_CPLUGINS_READ_DIRECTORY,caml_read_directory,     \
+                  dirname,tbl)
+
+extern void caml_cplugins_init(char * exe_name, char ** argv);
+
+/* A plugin MUST define a symbol "caml_cplugin_init" with the prototype:
+
+void caml_cplugin_init(char* exe_name, char** argv)
+*/
+
+/* to write plugins for CAML_SYS_READ_DIRECTORY, we will need the
+   definition of struct ext_table to be public. */
+
+#endif
 
 /* Data structures */
 
@@ -139,6 +216,8 @@ extern int caml_ext_table_add(struct ext_table * tbl, void * data);
 extern void caml_ext_table_remove(struct ext_table * tbl, void * data);
 extern void caml_ext_table_free(struct ext_table * tbl, int free_entries);
 extern void caml_ext_table_clear(struct ext_table * tbl, int free_entries);
+
+/* <private> */
 
 /* GC flags and messages */
 

--- a/byterun/caml/sys.h
+++ b/byterun/caml/sys.h
@@ -18,6 +18,10 @@
 
 #include "misc.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define NO_ARG Val_int(0)
 
 CAMLextern void caml_sys_error (value);
@@ -27,5 +31,9 @@ extern void caml_sys_init (char * exe_name, char ** argv);
 CAMLextern value caml_sys_exit (value);
 
 extern char * caml_exe_name;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CAML_SYS_H */

--- a/byterun/io.c
+++ b/byterun/io.c
@@ -110,7 +110,7 @@ static void unlink_channel(struct channel *channel)
 
 CAMLexport void caml_close_channel(struct channel *channel)
 {
-  close(channel->fd);
+  CAML_SYS_CLOSE(channel->fd); 
   if (channel->refcount > 0) return;
   if (caml_channel_mutex_free != NULL) (*caml_channel_mutex_free)(channel);
   unlink_channel(channel);
@@ -530,7 +530,7 @@ CAMLprim value caml_ml_close_channel(value vchannel)
 
   if (do_syscall) {
     caml_enter_blocking_section();
-    result = close(fd);
+    result = CAML_SYS_CLOSE(fd);
     caml_leave_blocking_section();
   }
 

--- a/byterun/printexc.c
+++ b/byterun/printexc.c
@@ -141,5 +141,5 @@ void caml_fatal_uncaught_exception(value exn)
   else
     default_fatal_uncaught_exception(exn);
   /* Terminate the process */
-  exit(2);
+  CAML_SYS_EXIT(2); exit(2); /* Second exit needed for the Noreturn flag */
 }

--- a/configure
+++ b/configure
@@ -54,6 +54,8 @@ TOOLPREF=""
 with_cfi=true
 flambda=false
 max_testsuite_dir_retries=0
+with_cplugins=true
+with_fpic=false
 
 # Try to turn internationalization off, can cause config.guess to malfunction!
 unset LANG
@@ -167,6 +169,10 @@ while : ; do
         native_compiler=false;;
     -flambda|--flambda)
         flambda=true;;
+    -no-cplugins|--no-cplugins)
+        with_cplugins=false;;
+    -fPIC|--fPIC)
+        with_fpic=true;;
     *) if echo "$1" | grep -q -e '^--\?[a-zA-Z0-9-]\+='; then
          err "configure expects arguments of the form '-prefix /foo/bar'," \
              "not '-prefix=/foo/bar' (note the '=')."
@@ -1742,6 +1748,30 @@ else
     has_huge_pages=false
 fi
 
+
+if ! $shared_libraries_supported; then
+  with_cplugins=false
+fi
+
+if $with_cplugins; then
+  with_fpic=true
+fi
+
+if $with_fpic; then
+  bytecccompopts="$bytecccompopts $sharedcccompopts"
+  nativecccompopts="$nativecccompopts $sharedcccompopts"
+  aspp="$aspp $sharedcccompopts"
+fi
+
+
+if $with_cplugins; then
+  echo "#define CAML_WITH_CPLUGINS" >> m.h
+fi
+
+if $with_fpic; then
+  echo "#define CAML_WITH_FPIC" >> m.h
+fi
+
 # Finish generated files
 
 cclibs="$cclibs $mathlib"
@@ -1816,6 +1846,8 @@ echo "WITH_DEBUGGER=${with_debugger}" >>Makefile
 echo "WITH_OCAMLDOC=${with_ocamldoc}" >>Makefile
 echo "ASM_CFI_SUPPORTED=$asm_cfi_supported" >> Makefile
 echo "WITH_FRAME_POINTERS=$with_frame_pointers" >> Makefile
+echo "WITH_CPLUGINS=$with_cplugins" >> Makefile
+echo "WITH_FPIC=$with_fpic" >> Makefile
 echo "TARGET=$target" >> Makefile
 echo "HOST=$host" >> Makefile
 if [ "$ostype" = Cygwin ]; then
@@ -1884,6 +1916,16 @@ else
   inf "        naked pointers forbidden.. yes"
   else
   inf "        naked pointers forbidden.. no"
+  fi
+  if $with_cplugins; then
+  inf "        C plugins................. yes"
+  else
+  inf "        C plugins................. no"
+  fi
+  if $with_fpic; then
+  inf "        compile with -fPIC........ yes"
+  else
+  inf "        compile with -fPIC........ no"
   fi
   inf "        native dynlink ........... $natdynlink"
   if test "$profiling" = "prof"; then


### PR DESCRIPTION
The following PR provides two features:
- a configure option `--no-getenv` that prevents the runtime from using `getenv` (`Sys.getenv` is still working normally). It can be used to compile an application in a security context, to prevent attackers from using the env. variables used by the runtime to temper the application behavior (debugger socket, gc tuning, etc.)
- the ability to load C plugins, specified in a `CAML_CPLUGINS` env variable, for example to monitor calls to some system calls in a security context (they could also be used to add setup GC hooks for example). This ability can be disabled using a new configure option `--no-cplugins` (and of course, it is disabled by `--no-getenv`).
