### PR TITLE
Warnings documentation

### DIFF
--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -754,6 +754,87 @@ command line, and possibly the "-custom" option.
 This section describes and explains in detail some warnings:
 
 \begin{options}
+\item[Warning 52: fragile constant pattern]
+
+  Some constructors, such as the exception constructors "Failure" and
+  "Invalid_argument", take as parameter a "string" value holding
+  a text message intended for the user.
+
+  These text messages are usually not stable over time: call sites
+  building these constructors may refine the message in a future
+  version to make it more explicit, etc. Therefore, it is dangerous to
+  match over the precise value of the message. For example, until
+  OCaml 4.02, "Array.iter2" would raise the exception
+\begin{verbatim}
+  Invalid_argument "arrays must have the same length"
+\end{verbatim}
+  Since 4.03 it raises the more helpful message
+\begin{verbatim}
+  Invalid_argument "Array.iter2: arrays must have the same length"
+\end{verbatim}
+  but this means that any code of the form
+\begin{verbatim}
+  try ...
+  with Invalid_argument "arrays must have the same length" -> ...
+\end{verbatim}
+  is now broken and may suffer from uncaught exceptions.
+
+  Warning 52 is there to prevent users from writing such fragile code
+  in the first place. It does not occur on every matching on a literal
+  string, but only in the case in which library authors expressed
+  their intent to possibly change the constructor parameter value in
+  the future, by using the attribute "ocaml.warn_on_literal_pattern"
+  (see the manual section on builtin attributes in
+  \ref{ss:builtin-attributes}):
+\begin{verbatim}
+  type t =
+    | Foo of string [@ocaml.warn_on_literal_pattern]
+    | Bar of string
+
+  let no_warning = function
+    | Bar "specific value" -> 0
+    | _ -> 1
+
+  let warning = function
+    | Foo "specific value" -> 0
+    | _ _ -> 1
+
+>    | Foo "specific value" -> 0
+>          ^^^^^^^^^^^^^^^^
+> Warning 52: the argument of this constructor should not be matched against a
+> constant pattern; the actual value of the argument could change
+> in the future.
+\end{verbatim}
+
+  If your code raises this warning, you should {\em not} change the
+  way you test for the specific string to avoid the warning (for
+  example using a string equality inside the right-hand-side instead
+  of a literal pattern), as your code would remain fragile. You should
+  instead enlarge the scope of the pattern by matching on all possible
+  values. This may require some care: if the scrutinee may return
+  several different cases of the same pattern, or raise distinct
+  instances of the same exception, you may need to modify your code to
+  separate those several cases.
+
+  For example,
+\begin{verbatim}
+try (int_of_string count_str, bool_of_string choice_str) with
+  | Failure "int_of_string" -> (0, true)
+  | Failure "bool_of_string" -> (-1, false)
+\end{verbatim}
+  should be rewritten into more atomic tests. For example,
+  using the "exception" patterns documented in Section~\ref{s:exception-match},
+  one can write:
+\begin{verbatim}
+match int_of_string count_str with
+  | exception (Failure _) -> (0, true)
+  | count ->
+    begin match bool_of_string choice_str with
+    | exception (Failure _) -> (-1, false)
+    | choice -> (count, choice)
+    end
+\end{verbatim}
+
 \item[Warning 57: ambiguous variables in or-patterns]
   The semantics of or-patterns in OCaml is specified with
   a left-to-right bias: a value \var{v} matches the pattern \var{p} "|" \var{q}
@@ -793,5 +874,4 @@ This section describes and explains in detail some warnings:
  semantics (any branch can be taken) relatively to a specific guard.
  More precisely, it warns when guard uses ``ambiguous'' variables, that are bound
  to different parts of the scrutinees by different sides of a or-pattern.
-
 \end{options}

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -497,6 +497,7 @@ that are currently defined are ignored. The warnings are as follows.
 \begin{options}
 \input{warnings-help.tex}
 \end{options}
+Some warnings are described in more detail in section~\ref{s:comp-warnings}.
 
 The default setting is "-w +a-4-6-7-9-27-29-32..39-41..42-44-45".
 It is displayed by "ocamlc -help".
@@ -748,3 +749,49 @@ command line, and possibly the "-custom" option.
 
 \end{options}
 
+\section{Warning reference} \label{s:comp-warnings}
+
+This section describes and explains in detail some warnings:
+
+\begin{options}
+\item[Warning 57: ambiguous variables in or-patterns]
+  The semantics of or-patterns in OCaml is specified with
+  a left-to-right bias: a value \var{v} matches the pattern \var{p} "|" \var{q}
+  if it matches \var{p} or \var{q}, but if it matches both,
+  the environment captured by the match is the environment captured by
+  \var{p}, never the one captured by \var{q}.
+
+  While this property is generally intuitive, there is at least one specific
+  case where a different semantics might be expected.
+  Consider a pattern followed by a when-guard:
+  "|"~\var{p}~"when"~\var{g}~"->"~\var{e}, for example:
+\begin{verbatim}
+     | ((Const x, _) | (_, Const x)) when is_neutral x -> branch
+\end{verbatim}
+  The semantics is clear:
+  match the scrutinee against the pattern, if it matches, test the guard,
+  and if the guard passes, take the branch.
+  In particular, consider the input "(Const"~\var{a}", Const"~\var{b}")", where
+  \var{a} fails the test "is_neutral"~\var{a}, while \var{b} passes the test
+  "is_neutral"~\var{b}.  With the left-to-right semantics, the clause above is
+  {\em not} taken by its input: matching "(Const"~\var{a}", Const"~\var{b}")"
+  against the or-pattern succeeds in the left branch, it returns the
+  environment \var{x}~"->"~\var{a}, and then the guard
+  "is_neutral"~\var{a} is tested and fails, the branch is not taken.
+
+  However, another semantics may be considered more natural here:
+  any pair that has one side passing the test will take the branch. With this
+  semantics the previous code fragment would be equivalent to
+\begin{verbatim}
+     | (Const x, _) when is_neutral x -> branch
+     | (_, Const x) when is_neutral x -> branch
+\end{verbatim}
+  This is {\em not} the semantics adopted by OCaml.
+
+ Warning 57 is dedicated to these confusing cases where the
+ specified left-to-right semantics is not equivalent to a non-deterministic
+ semantics (any branch can be taken) relatively to a specific guard.
+ More precisely, it warns when guard uses ``ambiguous'' variables, that are bound
+ to different parts of the scrutinees by different sides of a or-pattern.
+
+\end{options}

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -835,7 +835,7 @@ match int_of_string count_str with
     end
 \end{verbatim}
 
-\item[Warning 57: ambiguous variables in or-patterns]
+\item[Warning 57: Ambiguous or-pattern variables under guard]
   The semantics of or-patterns in OCaml is specified with
   a left-to-right bias: a value \var{v} matches the pattern \var{p} "|" \var{q}
   if it matches \var{p} or \var{q}, but if it matches both,

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -753,8 +753,8 @@ command line, and possibly the "-custom" option.
 
 This section describes and explains in detail some warnings:
 
-\begin{options}
-\item[Warning 52: fragile constant pattern]
+\subsection{Warning 52: fragile constant pattern}
+\label{ss:warn52}
 
   Some constructors, such as the exception constructors "Failure" and
   "Invalid_argument", take as parameter a "string" value holding
@@ -835,7 +835,9 @@ match int_of_string count_str with
     end
 \end{verbatim}
 
-\item[Warning 57: Ambiguous or-pattern variables under guard]
+\subsection{Warning 57: Ambiguous or-pattern variables under guard}
+\label{ss:warn57}
+
   The semantics of or-patterns in OCaml is specified with
   a left-to-right bias: a value \var{v} matches the pattern \var{p} "|" \var{q}
   if it matches \var{p} or \var{q}, but if it matches both,
@@ -874,4 +876,3 @@ match int_of_string count_str with
  semantics (any branch can be taken) relatively to a specific guard.
  More precisely, it warns when guard uses ``ambiguous'' variables, that are bound
  to different parts of the scrutinees by different sides of a or-pattern.
-\end{options}

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1642,6 +1642,7 @@ and[@bar] y = 3 in x + y           === (let x = 2 [@@foo] and y = 3 [@bar] in x 
 
 
 \subsection{Built-in attributes}
+\label{ss:builtin-attributes}
 
 Some attributes are understood by the type-checker:
 \begin{itemize}

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
@@ -18,7 +18,7 @@ then just above there should be *no* warning text.
 #                   Characters 46-71:
     | ((Val x, _) | (_, Val x)) when x < 0 -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57: Ambiguous guarded pattern, variable x may match different or-pattern arguments
+Warning 57: Ambiguous guarded pattern, variable x may match different or-pattern arguments (see manual section 8.5)
 val ambiguous_typical_example : expr * expr -> unit = <fun>
 #   Note that an Assert_failure is expected just below.
 #   Exception: Assert_failure ("//toplevel//", 23, 6).
@@ -33,19 +33,19 @@ val ambiguous_typical_example : expr * expr -> unit = <fun>
 #         Characters 33-72:
     | (`B (x, _, Some y) | `B (x, Some y, _)) when y -> ignore x
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57: Ambiguous guarded pattern, variable y may match different or-pattern arguments
+Warning 57: Ambiguous guarded pattern, variable y may match different or-pattern arguments (see manual section 8.5)
 val ambiguous__y : [> `B of 'a * bool option * bool option ] -> unit = <fun>
 #   * * * * * * * *         val not_ambiguous__rhs_not_protected :
   [> `B of 'a * bool option * bool option ] -> unit = <fun>
 #         Characters 35-74:
     | (`B (x, _, Some y) | `B (x, Some y, _)) when x < y -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57: Ambiguous guarded pattern, variable y may match different or-pattern arguments
+Warning 57: Ambiguous guarded pattern, variable y may match different or-pattern arguments (see manual section 8.5)
 val ambiguous__x_y : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 #         Characters 37-76:
     | (`B (x, z, Some y) | `B (x, Some y, z)) when x < y || Some x = z -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57: Ambiguous guarded pattern, variables y,z may match different or-pattern arguments
+Warning 57: Ambiguous guarded pattern, variables y,z may match different or-pattern arguments (see manual section 8.5)
 val ambiguous__x_y_z : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 #         val not_ambiguous__disjoint_in_depth :
   [> `A of [> `B of bool | `C of bool ] ] -> unit = <fun>
@@ -54,7 +54,7 @@ val ambiguous__x_y_z : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 #         Characters 40-76:
     | `A (`B (Some x, _) | `B (_, Some x)) when x -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57: Ambiguous guarded pattern, variable x may match different or-pattern arguments
+Warning 57: Ambiguous guarded pattern, variable x may match different or-pattern arguments (see manual section 8.5)
 val ambiguous__in_depth :
   [> `A of [> `B of bool option * bool option ] ] -> unit = <fun>
 #               val not_ambiguous__several_orpats :
@@ -66,7 +66,7 @@ val ambiguous__in_depth :
 #           Characters 43-140:
   ....`A ((`B (Some x, _) | `B (_, Some x)),
           (`C (Some y, Some _, _) | `C (Some y, _, Some _))).................
-Warning 57: Ambiguous guarded pattern, variable x may match different or-pattern arguments
+Warning 57: Ambiguous guarded pattern, variable x may match different or-pattern arguments (see manual section 8.5)
 val ambiguous__first_orpat :
   [> `A of
        [> `B of 'a option * 'a option ] *
@@ -75,7 +75,7 @@ val ambiguous__first_orpat :
 #           Characters 44-141:
   ....`A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
           (`C (Some y, _) | `C (_, Some y))).................
-Warning 57: Ambiguous guarded pattern, variable y may match different or-pattern arguments
+Warning 57: Ambiguous guarded pattern, variable y may match different or-pattern arguments (see manual section 8.5)
 val ambiguous__second_orpat :
   [> `A of
        [> `B of 'a option * 'b option * 'c option ] *
@@ -97,13 +97,13 @@ val ambiguous__second_orpat :
 #             Characters 40-73:
   ..X (Z x,Y (y,0))
   | X (Z y,Y (x,_))
-Warning 57: Ambiguous guarded pattern, variables x,y may match different or-pattern arguments
+Warning 57: Ambiguous guarded pattern, variables x,y may match different or-pattern arguments (see manual section 8.5)
 val ambiguous__amoi : amoi -> int = <fun>
 #     module type S = sig val b : bool end
 #           Characters 56-101:
   ....(module M:S),_,(1,_)
     | _,(module M:S),(_,1)...................
-Warning 57: Ambiguous guarded pattern, variable M may match different or-pattern arguments
+Warning 57: Ambiguous guarded pattern, variable M may match different or-pattern arguments (see manual section 8.5)
 val ambiguous__module_variable :
   (module S) * (module S) * (int * int) -> bool -> int = <fun>
 #           val not_ambiguous__module_variable :
@@ -123,7 +123,7 @@ It will remain exhaustive when constructors are added to type t.
 Characters 55-107:
     | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57: Ambiguous guarded pattern, variables x,y may match different or-pattern arguments
+Warning 57: Ambiguous guarded pattern, variables x,y may match different or-pattern arguments (see manual section 8.5)
 val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t -> int =
   <fun>
 # 

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
@@ -18,7 +18,8 @@ then just above there should be *no* warning text.
 #                   Characters 46-71:
     | ((Val x, _) | (_, Val x)) when x < 0 -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57: Ambiguous guarded pattern, variable x may match different or-pattern arguments (see manual section 8.5)
+Warning 57: Ambiguous or-pattern variables under guard;
+variable x may match different arguments. (See manual section 8.5)
 val ambiguous_typical_example : expr * expr -> unit = <fun>
 #   Note that an Assert_failure is expected just below.
 #   Exception: Assert_failure ("//toplevel//", 23, 6).
@@ -33,19 +34,22 @@ val ambiguous_typical_example : expr * expr -> unit = <fun>
 #         Characters 33-72:
     | (`B (x, _, Some y) | `B (x, Some y, _)) when y -> ignore x
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57: Ambiguous guarded pattern, variable y may match different or-pattern arguments (see manual section 8.5)
+Warning 57: Ambiguous or-pattern variables under guard;
+variable y may match different arguments. (See manual section 8.5)
 val ambiguous__y : [> `B of 'a * bool option * bool option ] -> unit = <fun>
 #   * * * * * * * *         val not_ambiguous__rhs_not_protected :
   [> `B of 'a * bool option * bool option ] -> unit = <fun>
 #         Characters 35-74:
     | (`B (x, _, Some y) | `B (x, Some y, _)) when x < y -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57: Ambiguous guarded pattern, variable y may match different or-pattern arguments (see manual section 8.5)
+Warning 57: Ambiguous or-pattern variables under guard;
+variable y may match different arguments. (See manual section 8.5)
 val ambiguous__x_y : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 #         Characters 37-76:
     | (`B (x, z, Some y) | `B (x, Some y, z)) when x < y || Some x = z -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57: Ambiguous guarded pattern, variables y,z may match different or-pattern arguments (see manual section 8.5)
+Warning 57: Ambiguous or-pattern variables under guard;
+variables y,z may match different arguments. (See manual section 8.5)
 val ambiguous__x_y_z : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 #         val not_ambiguous__disjoint_in_depth :
   [> `A of [> `B of bool | `C of bool ] ] -> unit = <fun>
@@ -54,7 +58,8 @@ val ambiguous__x_y_z : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 #         Characters 40-76:
     | `A (`B (Some x, _) | `B (_, Some x)) when x -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57: Ambiguous guarded pattern, variable x may match different or-pattern arguments (see manual section 8.5)
+Warning 57: Ambiguous or-pattern variables under guard;
+variable x may match different arguments. (See manual section 8.5)
 val ambiguous__in_depth :
   [> `A of [> `B of bool option * bool option ] ] -> unit = <fun>
 #               val not_ambiguous__several_orpats :
@@ -66,7 +71,8 @@ val ambiguous__in_depth :
 #           Characters 43-140:
   ....`A ((`B (Some x, _) | `B (_, Some x)),
           (`C (Some y, Some _, _) | `C (Some y, _, Some _))).................
-Warning 57: Ambiguous guarded pattern, variable x may match different or-pattern arguments (see manual section 8.5)
+Warning 57: Ambiguous or-pattern variables under guard;
+variable x may match different arguments. (See manual section 8.5)
 val ambiguous__first_orpat :
   [> `A of
        [> `B of 'a option * 'a option ] *
@@ -75,7 +81,8 @@ val ambiguous__first_orpat :
 #           Characters 44-141:
   ....`A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
           (`C (Some y, _) | `C (_, Some y))).................
-Warning 57: Ambiguous guarded pattern, variable y may match different or-pattern arguments (see manual section 8.5)
+Warning 57: Ambiguous or-pattern variables under guard;
+variable y may match different arguments. (See manual section 8.5)
 val ambiguous__second_orpat :
   [> `A of
        [> `B of 'a option * 'b option * 'c option ] *
@@ -97,13 +104,15 @@ val ambiguous__second_orpat :
 #             Characters 40-73:
   ..X (Z x,Y (y,0))
   | X (Z y,Y (x,_))
-Warning 57: Ambiguous guarded pattern, variables x,y may match different or-pattern arguments (see manual section 8.5)
+Warning 57: Ambiguous or-pattern variables under guard;
+variables x,y may match different arguments. (See manual section 8.5)
 val ambiguous__amoi : amoi -> int = <fun>
 #     module type S = sig val b : bool end
 #           Characters 56-101:
   ....(module M:S),_,(1,_)
     | _,(module M:S),(_,1)...................
-Warning 57: Ambiguous guarded pattern, variable M may match different or-pattern arguments (see manual section 8.5)
+Warning 57: Ambiguous or-pattern variables under guard;
+variable M may match different arguments. (See manual section 8.5)
 val ambiguous__module_variable :
   (module S) * (module S) * (int * int) -> bool -> int = <fun>
 #           val not_ambiguous__module_variable :
@@ -123,7 +132,8 @@ It will remain exhaustive when constructors are added to type t.
 Characters 55-107:
     | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 57: Ambiguous guarded pattern, variables x,y may match different or-pattern arguments (see manual section 8.5)
+Warning 57: Ambiguous or-pattern variables under guard;
+variables x,y may match different arguments. (See manual section 8.5)
 val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t -> int =
   <fun>
 # 

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -456,7 +456,7 @@ let message = function
             "variables " ^ String.concat "," vars in
       Printf.sprintf
         "Ambiguous guarded pattern, %s may match different or-pattern \
-          arguments"
+          arguments (see manual section 8.5)"
         msg
   | No_cmx_file name ->
       Printf.sprintf

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -434,7 +434,7 @@ let message = function
       Printf.sprintf
         "the argument of this constructor should not be matched against a\n\
          constant pattern; the actual value of the argument could change\n\
-         in the future"
+         in the future."
   | Unreachable_case ->
       "this match case is unreachable.\n\
        Consider replacing it with a refutation case '<pat> -> .'"

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -455,8 +455,8 @@ let message = function
         | _::_ ->
             "variables " ^ String.concat "," vars in
       Printf.sprintf
-        "Ambiguous guarded pattern, %s may match different or-pattern \
-          arguments (see manual section 8.5)"
+        "Ambiguous or-pattern variables under guard;\n\
+         %s may match different arguments. (See manual section 8.5)"
         msg
   | No_cmx_file name ->
       Printf.sprintf
@@ -562,7 +562,7 @@ let descriptions =
    54, "Attribute used more than once on an expression";
    55, "Inlining impossible";
    56, "Unreachable case in a pattern-matching (based on type information).";
-   57, "Ambiguous binding by pattern.";
+   57, "Ambiguous or-pattern variables under guard";
    58, "Missing cmx file";
    59, "Assignment to non-mutable value";
   ]


### PR DESCRIPTION
This branch adds some documentation in the manual for two warnings that are new in 4.03 and non-trivial for users to understand and adapt to, namely:
- `52: Fragile constant pattern.`
- `57: Ambiguous or-pattern variables under guard.`

I think it would be good to have it in 4.03 ( @damiendoligez ? ). Most of the changes are only to the manual, so I would confidently merge them myself, but I also did a few minor changes to the wording of user-facing messages for Warning 57 to make them more homogeneous.

This work has been started by @Octachron , who may also have a few extra changes to suggest before a merge?

The idea is to grow the set of warning that are documented over time, but focus on those that do need more complete explanations.
