### PR TITLE
Ensure that register typing constraints are respected at join points

### DIFF
--- a/Changes
+++ b/Changes
@@ -1006,6 +1006,11 @@ Features wishes:
   GNU parallel tool to run tests in parallel.
   (Gabriel Scherer)
 
+- GPR#555: ensure that register typing constraints are respected at
+  join points in the control flow graph
+  (Mark Shinwell, debugging & test case by Arseniy Alekseyev and Leo White,
+    code review by Xavier Leroy)
+
 Build system:
 =============
 

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -56,6 +56,20 @@ val typ_int: machtype
 val typ_float: machtype
 
 val size_component: machtype_component -> int
+
+(** Least upper bound of two [machtype_component]s. *)
+val lub_component
+   : machtype_component
+  -> machtype_component
+  -> machtype_component
+
+(** Returns [true] iff the first supplied [machtype_component] is greater than
+    or equal to the second under the relation used by [lub_component]. *)
+val ge_component
+   : machtype_component
+  -> machtype_component
+  -> bool
+
 val size_machtype: machtype -> int
 
 type comparison =

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -117,14 +117,19 @@ let join opt_r1 seq1 opt_r2 seq2 =
       assert (l1 = Array.length r2);
       let r = Array.make l1 Reg.dummy in
       for i = 0 to l1-1 do
-        if Reg.anonymous r1.(i) then begin
+        if Reg.anonymous r1.(i)
+          && Cmm.ge_component r1.(i).typ r2.(i).typ
+        then begin
           r.(i) <- r1.(i);
           seq2#insert_move r2.(i) r1.(i)
-        end else if Reg.anonymous r2.(i) then begin
+        end else if Reg.anonymous r2.(i)
+          && Cmm.ge_component r2.(i).typ r1.(i).typ
+        then begin
           r.(i) <- r2.(i);
           seq1#insert_move r1.(i) r2.(i)
         end else begin
-          r.(i) <- Reg.create r1.(i).typ;
+          let typ = Cmm.lub_component r1.(i).typ r2.(i).typ in
+          r.(i) <- Reg.create typ;
           seq1#insert_move r1.(i) r.(i);
           seq2#insert_move r2.(i) r.(i)
         end

--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -47,7 +47,7 @@ parsecmm.mli parsecmm.ml: parsecmm.mly
 lexcmm.ml: lexcmm.mll
 	@$(OCAMLLEX) -q lexcmm.mll
 
-MLCASES=optargs staticalloc bind_tuples is_static
+MLCASES=optargs staticalloc bind_tuples is_static register_typing
 ARGS_is_static=-I $(OTOPDIR)/byterun is_in_static_data.c
 MLCASES_FLAMBDA=is_static_flambda
 ARGS_is_static_flambda=-I $(OTOPDIR)/byterun is_in_static_data.c

--- a/testsuite/tests/asmcomp/register_typing.ml
+++ b/testsuite/tests/asmcomp/register_typing.ml
@@ -1,0 +1,20 @@
+type 'a typ = Int : int typ | Ptr : int list typ
+
+let f (type a) (t : a typ) (p : int list) : a =
+  match t with
+  | Int -> 100
+  | Ptr -> p
+
+let allocate_garbage () =
+  for i = 0 to 100 do
+    ignore (Array.make 200 0.0)
+  done
+
+let g (t : int list typ) x =
+  Gc.minor ();
+  let x = f t ([x; x; x; x; x]) in
+  Gc.minor ();
+  allocate_garbage ();
+  ignore (String.length (String.concat " " (List.map string_of_int x)))
+
+let () = g Ptr 5


### PR DESCRIPTION
It has been known for some time that great care has to be taken when using Obj.magic to ensure that, at join points in the control flow graph, a register "known to hold only immediates" does not end up being used to hold a value that might be a pointer.  If this happens, it will not be registered as a GC root, which can cause it to become invalid.  (The typical fix is something like using None instead of "unit".)

After having fixed a piece of code having that problem this morning it became apparent that the following function, which does not use Obj.magic, suffers from the same problem:

```
type 'a typ = Int : int typ | Ptr : int list typ

let f (type a) (t : a typ) (p : int list) : a =
  match t with
  | Int -> 100
  | Ptr -> p
```

If the function "f" is inlined into another function then the situation above can arise, as exhibited in the test case on this pull request, which segfaults.

The only reasonable solution it would appear at present is to ensure that at join points we respect the register typing.  This may produce slightly worse code in some cases.  For such cases the correct solution to solve this problem is probably the propagation of more information about what values might be held in which identifiers right through from the type checker.

I think this is probably serious enough to warrant putting in 4.03.
