### PR TITLE
Fix infinite unrolling bug

### DIFF
--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -49,7 +49,7 @@ lexcmm.ml: lexcmm.mll
 
 MLCASES=optargs staticalloc bind_tuples is_static
 ARGS_is_static=-I $(OTOPDIR)/byterun is_in_static_data.c
-MLCASES_FLAMBDA=is_static_flambda
+MLCASES_FLAMBDA=is_static_flambda unrolling_flambda
 ARGS_is_static_flambda=-I $(OTOPDIR)/byterun is_in_static_data.c
 
 CASES=fib tak quicksort quicksort2 soli \

--- a/testsuite/tests/asmcomp/unrolling_flambda.ml
+++ b/testsuite/tests/asmcomp/unrolling_flambda.ml
@@ -1,0 +1,7 @@
+
+let rec f x =
+  if x > 0 then f (x - 1)
+  else 0
+[@@inline]
+
+let _ = f 0


### PR DESCRIPTION
This fixes an infinte loop that the inliner can get in with code like:

``` ocaml
let rec f x =
  f (x + 1)
[@@inline]

let _ = f 0
```

This is a rather embarrassing reproduction case that I neglected to re-test after adding support for unrolling.

Since `-Oclassic` mode involves essentially annotating all small functions with `[@inline]` this loop is most likely to appear when running under that mode.

The bug causes a stack overflow in the compiler rather than miscompilation, so it could safely be left 4.04. However the fix is small, and the bug is common enough to appear when compiling Janestreet's open source code in `-Oclassic` mode. So I made the PR against 4.03.
