### PR TITLE
PR#7239: clarify Warning 42 (Disambiguated constructor or label name)

### DIFF
--- a/testsuite/tests/typing-warnings/pr6872.ml.principal.reference
+++ b/testsuite/tests/typing-warnings/pr6872.ml.principal.reference
@@ -10,7 +10,8 @@ The first one was selected. Please disambiguate if this is wrong.
 # Characters 6-7:
   raise A;;
         ^
-Warning 42: this use of A required disambiguation.
+Warning 42: this use of A relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Exception: A.
 # - : a -> unit = <fun>
 # Characters 26-27:
@@ -26,10 +27,12 @@ Error: This pattern matches values of type a
 # Characters 10-11:
   try raise A with A -> 2;;
             ^
-Warning 42: this use of A required disambiguation.
+Warning 42: this use of A relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 17-18:
   try raise A with A -> 2;;
                    ^
-Warning 42: this use of A required disambiguation.
+Warning 42: this use of A relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 - : int = 2
 # 

--- a/testsuite/tests/typing-warnings/pr6872.ml.reference
+++ b/testsuite/tests/typing-warnings/pr6872.ml.reference
@@ -10,21 +10,25 @@ The first one was selected. Please disambiguate if this is wrong.
 # Characters 6-7:
   raise A;;
         ^
-Warning 42: this use of A required disambiguation.
+Warning 42: this use of A relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Exception: A.
 # - : a -> unit = <fun>
 # Characters 26-27:
   function Not_found -> 1 | A -> 2 | _ -> 3;;
                             ^
-Warning 42: this use of A required disambiguation.
+Warning 42: this use of A relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 - : exn -> int = <fun>
 # Characters 10-11:
   try raise A with A -> 2;;
             ^
-Warning 42: this use of A required disambiguation.
+Warning 42: this use of A relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 17-18:
   try raise A with A -> 2;;
                    ^
-Warning 42: this use of A required disambiguation.
+Warning 42: this use of A relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 - : int = 2
 # 

--- a/testsuite/tests/typing-warnings/records.ml.principal.reference
+++ b/testsuite/tests/typing-warnings/records.ml.principal.reference
@@ -4,7 +4,8 @@
 #                 Characters 49-50:
     let f1 (r:t) = r.x (* ok *)
                      ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 89-90:
     let f2 r = ignore (r:t); r.x (* non principal *)
                                ^
@@ -12,15 +13,18 @@ Warning 18: this type-based field disambiguation is not principal.
 Characters 89-90:
     let f2 r = ignore (r:t); r.x (* non principal *)
                                ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 148-149:
       match r with {x; y} -> y + y (* ok *)
                     ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 151-152:
       match r with {x; y} -> y + y (* ok *)
                        ^
-Warning 42: this use of y required disambiguation.
+Warning 42: this use of y relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 148-149:
       match r with {x; y} -> y + y (* ok *)
                     ^
@@ -51,7 +55,8 @@ Error: This pattern matches values of type M1.u
 # Characters 18-21:
   let f (r:M.t) = r.M.x;; (* ok *)
                     ^^^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 val f : M.t -> int = <fun>
 # Characters 18-19:
   let f (r:M.t) = r.x;; (* warning *)
@@ -62,12 +67,14 @@ be selected if the type becomes unknown.
 Characters 18-19:
   let f (r:M.t) = r.x;; (* warning *)
                     ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 val f : M.t -> int = <fun>
 # Characters 8-9:
   let f ({x}:M.t) = x;; (* warning *)
           ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 7-10:
   let f ({x}:M.t) = x;; (* warning *)
          ^^^
@@ -80,7 +87,8 @@ val f : M.t -> int = <fun>
 #         Characters 57-58:
     let f (r:M.t) = r.x
                       ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 30-36:
     open N
     ^^^^^^
@@ -101,7 +109,8 @@ module OK : sig val f : M.t -> int end
 #       Characters 37-38:
     let f {x;z} = x,z
            ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 36-41:
     let f {x;z} = x,z
           ^^^^^
@@ -116,11 +125,13 @@ Error: Some record fields are undefined: y
 #           Characters 90-91:
     let r = {x=3; y=true}
              ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 95-96:
     let r = {x=3; y=true}
                   ^
-Warning 42: this use of y required disambiguation.
+Warning 42: this use of y relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 module OK :
   sig
     type u = { x : int; y : bool; }
@@ -172,7 +183,8 @@ Error: The record field NM.y belongs to the type NM.foo = M.foo
 #       Characters 65-66:
     let f r = ignore (r: foo); {r with x = 2; z = 3}
                                        ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 72-73:
     let f r = ignore (r: foo); {r with x = 2; z = 3}
                                               ^
@@ -187,7 +199,8 @@ Error: This record expression is expected to have type M.foo
 #       Characters 66-67:
     let f r = ignore (r: foo); { r with x = 3; a = 4 }
                                         ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 73-74:
     let f r = ignore (r: foo); { r with x = 3; a = 4 }
                                                ^
@@ -196,11 +209,13 @@ Error: This record expression is expected to have type M.foo
 #         Characters 39-40:
     let r = {x=1; y=2}
              ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 44-45:
     let r = {x=1; y=2}
                   ^
-Warning 42: this use of y required disambiguation.
+Warning 42: this use of y relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 67-68:
     let r: other = {x=1; y=2}
                     ^
@@ -225,13 +240,15 @@ class f : t -> object  end
 # Characters 12-13:
   class g = f A;; (* ok *)
               ^
-Warning 42: this use of A required disambiguation.
+Warning 42: this use of A relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 class g : f
 #   class f : 'a -> 'a -> object  end
 # Characters 13-14:
   class g = f (A : t) A;; (* warn with -principal *)
                ^
-Warning 42: this use of A required disambiguation.
+Warning 42: this use of A relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 20-21:
   class g = f (A : t) A;; (* warn with -principal *)
                       ^
@@ -239,12 +256,14 @@ Warning 18: this type-based constructor disambiguation is not principal.
 Characters 20-21:
   class g = f (A : t) A;; (* warn with -principal *)
                       ^
-Warning 42: this use of A required disambiguation.
+Warning 42: this use of A relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 class g : f
 #                       Characters 199-200:
     let y : t = {x = 0}
                  ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 114-120:
     open M  (* this open is unused, it isn't reported as shadowing 'x' *)
     ^^^^^^
@@ -273,7 +292,8 @@ module Shadow2 :
 #                 Characters 167-170:
     let f (u : u) = match u with `Key {loc} -> loc
                                        ^^^
-Warning 42: this use of loc required disambiguation.
+Warning 42: this use of loc relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 module P6235 :
   sig
     type t = { loc : string; }

--- a/testsuite/tests/typing-warnings/records.ml.reference
+++ b/testsuite/tests/typing-warnings/records.ml.reference
@@ -4,19 +4,23 @@
 #                 Characters 49-50:
     let f1 (r:t) = r.x (* ok *)
                      ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 89-90:
     let f2 r = ignore (r:t); r.x (* non principal *)
                                ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 148-149:
       match r with {x; y} -> y + y (* ok *)
                     ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 151-152:
       match r with {x; y} -> y + y (* ok *)
                        ^
-Warning 42: this use of y required disambiguation.
+Warning 42: this use of y relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 148-149:
       match r with {x; y} -> y + y (* ok *)
                     ^
@@ -36,11 +40,13 @@ Error: This expression has type bool but an expression was expected of type
 #               Characters 86-87:
          {x; y} -> y + y
           ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 89-90:
          {x; y} -> y + y
              ^
-Warning 42: this use of y required disambiguation.
+Warning 42: this use of y relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 86-87:
          {x; y} -> y + y
           ^
@@ -50,7 +56,8 @@ module F2 : sig val f : M1.t -> int end
 # Characters 18-21:
   let f (r:M.t) = r.M.x;; (* ok *)
                     ^^^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 val f : M.t -> int = <fun>
 # Characters 18-19:
   let f (r:M.t) = r.x;; (* warning *)
@@ -61,12 +68,14 @@ be selected if the type becomes unknown.
 Characters 18-19:
   let f (r:M.t) = r.x;; (* warning *)
                     ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 val f : M.t -> int = <fun>
 # Characters 8-9:
   let f ({x}:M.t) = x;; (* warning *)
           ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 7-10:
   let f ({x}:M.t) = x;; (* warning *)
          ^^^
@@ -79,7 +88,8 @@ val f : M.t -> int = <fun>
 #         Characters 57-58:
     let f (r:M.t) = r.x
                       ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 30-36:
     open N
     ^^^^^^
@@ -100,7 +110,8 @@ module OK : sig val f : M.t -> int end
 #       Characters 37-38:
     let f {x;z} = x,z
            ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 36-41:
     let f {x;z} = x,z
           ^^^^^
@@ -115,11 +126,13 @@ Error: Some record fields are undefined: y
 #           Characters 90-91:
     let r = {x=3; y=true}
              ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 95-96:
     let r = {x=3; y=true}
                   ^
-Warning 42: this use of y required disambiguation.
+Warning 42: this use of y relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 module OK :
   sig
     type u = { x : int; y : bool; }
@@ -171,7 +184,8 @@ Error: The record field NM.y belongs to the type NM.foo = M.foo
 #       Characters 65-66:
     let f r = ignore (r: foo); {r with x = 2; z = 3}
                                        ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 72-73:
     let f r = ignore (r: foo); {r with x = 2; z = 3}
                                               ^
@@ -186,7 +200,8 @@ Error: This record expression is expected to have type M.foo
 #       Characters 66-67:
     let f r = ignore (r: foo); { r with x = 3; a = 4 }
                                         ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 73-74:
     let f r = ignore (r: foo); { r with x = 3; a = 4 }
                                                ^
@@ -195,11 +210,13 @@ Error: This record expression is expected to have type M.foo
 #         Characters 39-40:
     let r = {x=1; y=2}
              ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 44-45:
     let r = {x=1; y=2}
                   ^
-Warning 42: this use of y required disambiguation.
+Warning 42: this use of y relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 67-68:
     let r: other = {x=1; y=2}
                     ^
@@ -224,22 +241,26 @@ class f : t -> object  end
 # Characters 12-13:
   class g = f A;; (* ok *)
               ^
-Warning 42: this use of A required disambiguation.
+Warning 42: this use of A relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 class g : f
 #   class f : 'a -> 'a -> object  end
 # Characters 13-14:
   class g = f (A : t) A;; (* warn with -principal *)
                ^
-Warning 42: this use of A required disambiguation.
+Warning 42: this use of A relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 20-21:
   class g = f (A : t) A;; (* warn with -principal *)
                       ^
-Warning 42: this use of A required disambiguation.
+Warning 42: this use of A relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 class g : f
 #                       Characters 199-200:
     let y : t = {x = 0}
                  ^
-Warning 42: this use of x required disambiguation.
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Characters 114-120:
     open M  (* this open is unused, it isn't reported as shadowing 'x' *)
     ^^^^^^
@@ -268,7 +289,8 @@ module Shadow2 :
 #                 Characters 167-170:
     let f (u : u) = match u with `Key {loc} -> loc
                                        ^^^
-Warning 42: this use of loc required disambiguation.
+Warning 42: this use of loc relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 module P6235 :
   sig
     type t = { loc : string; }
@@ -279,7 +301,8 @@ module P6235 :
 #                     Characters 220-223:
       |`Key {loc} -> loc
              ^^^
-Warning 42: this use of loc required disambiguation.
+Warning 42: this use of loc relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 module P6235' :
   sig
     type t = { loc : string; }

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -400,7 +400,8 @@ let message = function
       String.concat " " tl ^
       "\nThe first one was selected. Please disambiguate if this is wrong."
   | Disambiguated_name s ->
-      "this use of " ^ s ^ " required disambiguation."
+      "this use of " ^ s ^ " relies on type-directed disambiguation,\n\
+       it will not compile with OCaml 4.00 or earlier."
   | Nonoptional_label s ->
       "the label " ^ s ^ " is not optional."
   | Open_shadow_identifier (kind, s) ->
@@ -547,7 +548,7 @@ let descriptions =
    39, "Unused rec flag.";
    40, "Constructor or label name used out of scope.";
    41, "Ambiguous constructor or label name.";
-   42, "Disambiguated constructor or label name.";
+   42, "Disambiguated constructor or label name (compatibility warning).";
    43, "Nonoptional label applied as optional.";
    44, "Open statement shadows an already defined identifier.";
    45, "Open statement shadows an already defined label or constructor.";


### PR DESCRIPTION
[PR#7239](http://caml.inria.fr/mantis/view.php?id=7239) is a report by Jun Furuse that shows that the wording for warning 42 (the compatibility warning that warns about essential uses of type-directed disambiguation) is confusing. This PR updates the wording from

```
Warning 42: this use of C required disambiguation.
```

to

```
Warning 42: this use of C relies on type-directed disambiguation,
it will not compile with OCaml 4.00 or earlier.
```
