### PR TITLE
Add a kind of finalisation function called without argument

### DIFF
--- a/Changes
+++ b/Changes
@@ -57,6 +57,15 @@ OCaml 4.04.0:
   (Non-exhaustivity warning for pattern matching)
   (Florian Angeletti, review and report by Gabriel Scherer)
 
+### Runtime system:
+
+- PR#7210, GPR#562: Allows to register finalisation function that are
+  called only when a value will never be reachable anymore. The
+  drawbacks compared to the existing one is that the finalisation
+  function is not called with the value as argument. These finalisers
+  are registered with `GC.finalise_last`
+  (François Bobot)
+
 ### Tools:
 
 - MPR#7189: toplevel #show, follow chains of module aliases

--- a/Changes
+++ b/Changes
@@ -64,7 +64,7 @@ OCaml 4.04.0:
   drawbacks compared to the existing one is that the finalisation
   function is not called with the value as argument. These finalisers
   are registered with `GC.finalise_last`
-  (François Bobot)
+  (François Bobot reviewed by Damien Doligez and Leo White)
 
 ### Tools:
 

--- a/asmrun/roots.c
+++ b/asmrun/roots.c
@@ -332,7 +332,7 @@ void caml_oldify_local_roots (void)
   /* Global C roots */
   caml_scan_global_young_roots(&caml_oldify_one);
   /* Finalised values */
-  caml_final_do_young_roots (&caml_oldify_one);
+  caml_final_do_young_roots ();
   /* Hook */
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(&caml_oldify_one);
 }

--- a/asmrun/roots.c
+++ b/asmrun/roots.c
@@ -426,7 +426,7 @@ void caml_do_roots (scanning_action f, int do_globals)
   caml_scan_global_roots(f);
   CAML_INSTR_TIME (tmr, "major_roots/C");
   /* Finalised values */
-  caml_final_do_strong_roots (f);
+  caml_final_do_roots (f);
   CAML_INSTR_TIME (tmr, "major_roots/finalised");
   /* Hook */
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(f);

--- a/asmrun/roots.c
+++ b/asmrun/roots.c
@@ -332,7 +332,7 @@ void caml_oldify_local_roots (void)
   /* Global C roots */
   caml_scan_global_young_roots(&caml_oldify_one);
   /* Finalised values */
-  caml_final_do_young_roots ();
+  caml_final_oldify_young_roots ();
   /* Hook */
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(&caml_oldify_one);
 }

--- a/byterun/caml/compact.h
+++ b/byterun/caml/compact.h
@@ -19,9 +19,11 @@
 
 #include "config.h"
 #include "misc.h"
+#include "mlvalues.h"
 
-extern void caml_compact_heap (void);
-extern void caml_compact_heap_maybe (void);
+void caml_compact_heap (void);
+void caml_compact_heap_maybe (void);
 
+void invert_root (value v, value *p);
 
 #endif /* CAML_COMPACT_H */

--- a/byterun/caml/finalise.h
+++ b/byterun/caml/finalise.h
@@ -22,7 +22,7 @@ void caml_final_update (void);
 void caml_final_do_calls (void);
 void caml_final_do_roots (scanning_action f);
 void caml_final_invert_finalisable_values ();
-void caml_final_do_young_roots ();
+void caml_final_oldify_young_roots ();
 void caml_final_empty_young (void);
 value caml_final_register (value f, value v);
 

--- a/byterun/caml/finalise.h
+++ b/byterun/caml/finalise.h
@@ -21,7 +21,7 @@
 void caml_final_update (void);
 void caml_final_do_calls (void);
 void caml_final_do_strong_roots (scanning_action f);
-void caml_final_do_weak_roots (scanning_action f);
+void caml_final_invert_finalisable_values ();
 void caml_final_do_young_roots ();
 void caml_final_empty_young (void);
 value caml_final_register (value f, value v);

--- a/byterun/caml/finalise.h
+++ b/byterun/caml/finalise.h
@@ -27,5 +27,6 @@ void caml_final_oldify_young_roots ();
 void caml_final_empty_young (void);
 void caml_final_update_minor_roots(void);
 value caml_final_register (value f, value v);
+void caml_final_invariant_check(void);
 
 #endif /* CAML_FINALISE_H */

--- a/byterun/caml/finalise.h
+++ b/byterun/caml/finalise.h
@@ -22,7 +22,7 @@ void caml_final_update (void);
 void caml_final_do_calls (void);
 void caml_final_do_strong_roots (scanning_action f);
 void caml_final_do_weak_roots (scanning_action f);
-void caml_final_do_young_roots (scanning_action f);
+void caml_final_do_young_roots ();
 void caml_final_empty_young (void);
 value caml_final_register (value f, value v);
 

--- a/byterun/caml/finalise.h
+++ b/byterun/caml/finalise.h
@@ -20,7 +20,7 @@
 
 void caml_final_update (void);
 void caml_final_do_calls (void);
-void caml_final_do_strong_roots (scanning_action f);
+void caml_final_do_roots (scanning_action f);
 void caml_final_invert_finalisable_values ();
 void caml_final_do_young_roots ();
 void caml_final_empty_young (void);

--- a/byterun/caml/finalise.h
+++ b/byterun/caml/finalise.h
@@ -25,6 +25,7 @@ void caml_final_do_roots (scanning_action f);
 void caml_final_invert_finalisable_values ();
 void caml_final_oldify_young_roots ();
 void caml_final_empty_young (void);
+void caml_final_update_minor_roots(void);
 value caml_final_register (value f, value v);
 
 #endif /* CAML_FINALISE_H */

--- a/byterun/caml/finalise.h
+++ b/byterun/caml/finalise.h
@@ -18,7 +18,8 @@
 
 #include "roots.h"
 
-void caml_final_update (void);
+void caml_final_update_mark_phase (void);
+void caml_final_update_clean_phase (void);
 void caml_final_do_calls (void);
 void caml_final_do_roots (scanning_action f);
 void caml_final_invert_finalisable_values ();

--- a/byterun/compact.c
+++ b/byterun/compact.c
@@ -26,6 +26,7 @@
 #include "caml/mlvalues.h"
 #include "caml/roots.h"
 #include "caml/weak.h"
+#include "caml/compact.h"
 
 extern uintnat caml_percent_free;                   /* major_gc.c */
 extern void caml_shrink_heap (char *);              /* memory.c */
@@ -108,7 +109,7 @@ static void invert_pointer_at (word *p)
   }
 }
 
-static void invert_root (value v, value *p)
+void invert_root (value v, value *p)
 {
   invert_pointer_at ((word *) p);
 }
@@ -188,7 +189,8 @@ static void do_compaction (void)
        data structures to find its roots.  Fortunately, it doesn't need
        the headers (see above). */
     caml_do_roots (invert_root, 1);
-    caml_final_do_weak_roots (invert_root);
+    /* The values to be finalised are not roots but should still be inverted */
+    caml_final_invert_finalisable_values ();
 
     ch = caml_heap_start;
     while (ch != NULL){

--- a/byterun/finalise.c
+++ b/byterun/finalise.c
@@ -168,7 +168,7 @@ void caml_final_do_calls (void)
    This is called by the major GC [caml_darken_all_roots]
    and by the compactor through [caml_do_roots]
 */
-void caml_final_do_strong_roots (scanning_action f)
+void caml_final_do_roots (scanning_action f)
 {
   uintnat i;
   struct to_do *todo;

--- a/byterun/finalise.c
+++ b/byterun/finalise.c
@@ -40,10 +40,12 @@ struct finalisable {
    [young..size) : free space
 
    The element of the finalisable set are moved to the finalising set
-   below when the value are unreachable (for the first time).
+   below when the value are unreachable (for the first or last time).
+
 */
 
 static struct finalisable finalisable_first = {NULL,0,0,0};
+static struct finalisable finalisable_last = {NULL,0,0,0};
 
 struct to_do {
   struct to_do *next;
@@ -80,9 +82,9 @@ static void alloc_to_do (int size)
 }
 
 /* Find white finalisable values, move them to the finalising set, and
-   darken them.
+   darken them (if darken_value is true).
 */
-static void generic_final_update (struct finalisable * final)
+static void generic_final_update (struct finalisable * final, int darken_value)
 {
   uintnat i, j, k;
   uintnat todo_count = 0;
@@ -111,7 +113,14 @@ static void generic_final_update (struct finalisable * final)
       Assert (Is_in_heap (final->table[i].val));
       Assert (Tag_val (final->table[i].val) != Forward_tag);
       if (Is_white_val (final->table[i].val)){
-        to_do_tl->item[k++] = final->table[i];
+        to_do_tl->item[k] = final->table[i];
+        if(!darken_value){
+          /* The value is not darken so the finalisation function
+             is called with unit not with the value */
+          to_do_tl->item[k].val = Val_unit;
+          to_do_tl->item[k].offset = 0;
+        };
+        k++;
       }else{
         final->table[j++] = final->table[i];
       }
@@ -123,16 +132,22 @@ static void generic_final_update (struct finalisable * final)
     }
     final->young = j;
     to_do_tl->size = k;
-    for (i = 0; i < k; i++){
-      /* Note that item may already be dark due to multiple entries in
-         the final table. */
-      caml_darken (to_do_tl->item[i].val, NULL);
+    if(darken_value){
+      for (i = 0; i < k; i++){
+        /* Note that item may already be dark due to multiple entries in
+           the final table. */
+        caml_darken (to_do_tl->item[i].val, NULL);
+      }
     }
   }
 }
 
-void caml_final_update (){
-  generic_final_update(&finalisable_first);
+void caml_final_update_mark_phase (){
+  generic_final_update(&finalisable_first, /* darken_value */ 1);
+}
+
+void caml_final_update_clean_phase (){
+  generic_final_update(&finalisable_last, /* darken_value */ 0);
 }
 
 
@@ -189,6 +204,11 @@ void caml_final_do_roots (scanning_action f, struct finalisable *final)
     Call_action (f, finalisable_first.table[i].fun);
   };
 
+  Assert (finalisable_last.old <= finalisable_last.young);
+  for (i = 0; i < finalisable_last.young; i++){
+    Call_action (f, finalisable_last.table[i].fun);
+  };
+
   for (todo = to_do_hd; todo != NULL; todo = todo->next){
     for (i = 0; i < todo->size; i++){
       Call_action (f, todo->item[i].fun);
@@ -209,6 +229,12 @@ void caml_final_invert_finalisable_values ()
     invert_root(finalisable_first.table[i].val,
                 &finalisable_first.table[i].val);
   };
+
+  CAMLassert (finalisable_last.old <= finalisable_last.young);
+  for (i = 0; i < finalisable_last.young; i++){
+    invert_root(finalisable_last.table[i].val,
+                &finalisable_last.table[i].val);
+  };
 }
 
 /* Call [*f] on the closures and values of the recent set.
@@ -225,6 +251,14 @@ void caml_final_oldify_young_roots ()
     caml_oldify_one(finalisable_first.table[i].val,
                     &finalisable_first.table[i].val);
   }
+
+  Assert (finalisable_last.old <= finalisable_last.young);
+  for (i = finalisable_last.old; i < finalisable_last.young; i++){
+    caml_oldify_one(finalisable_last.table[i].fun,
+                    &finalisable_last.table[i].fun);
+    caml_oldify_one(finalisable_first.table[i].val,
+                    &finalisable_first.table[i].val);
+  }
 }
 
 /* Empty the recent set into the finalisable set.
@@ -234,6 +268,7 @@ void caml_final_oldify_young_roots ()
 void caml_final_empty_young (void)
 {
   finalisable_first.old = finalisable_first.young;
+  finalisable_last.old = finalisable_last.young;
 }
 
 /* Put (f,v) in the recent set. */
@@ -277,6 +312,11 @@ static void generic_final_register (struct finalisable *final, value f, value v)
 
 CAMLprim value caml_final_register (value f, value v){
   generic_final_register(&finalisable_first, f, v);
+  return Val_unit;
+}
+
+CAMLprim value caml_final_register_called_without_value (value f, value v){
+  generic_final_register(&finalisable_last, f, v);
   return Val_unit;
 }
 

--- a/byterun/finalise.c
+++ b/byterun/finalise.c
@@ -98,7 +98,9 @@ static void generic_final_update (struct finalisable * final, int darken_value,
     if (major_collection ?
         Is_white_val (final->table[i].val) :
         Is_young(final->table[i].val) && Hd_val(final->table[i].val) != 0
-        ) ++ todo_count;
+        ){
+      ++ todo_count;
+    }
   }
 
   /** invariant:

--- a/byterun/finalise.c
+++ b/byterun/finalise.c
@@ -20,6 +20,7 @@
 #include "caml/mlvalues.h"
 #include "caml/roots.h"
 #include "caml/signals.h"
+#include "caml/minor_gc.h"
 
 struct final {
   value fun;
@@ -195,14 +196,14 @@ void caml_final_do_weak_roots (scanning_action f)
 /* Call [*f] on the closures and values of the recent set.
    This is called by the minor GC through [caml_oldify_local_roots].
 */
-void caml_final_do_young_roots (scanning_action f)
+void caml_final_do_young_roots ()
 {
   uintnat i;
 
   Assert (old <= young);
   for (i = old; i < young; i++){
-    Call_action (f, final_table[i].fun);
-    Call_action (f, final_table[i].val);
+    caml_oldify_one(final_table[i].fun, &final_table[i].fun);
+    caml_oldify_one(final_table[i].val, &final_table[i].val);
   }
 }
 

--- a/byterun/finalise.c
+++ b/byterun/finalise.c
@@ -214,7 +214,7 @@ void caml_final_invert_finalisable_values ()
 /* Call [*f] on the closures and values of the recent set.
    This is called by the minor GC through [caml_oldify_local_roots].
 */
-void caml_final_do_young_roots ()
+void caml_final_oldify_young_roots ()
 {
   uintnat i;
 

--- a/byterun/gc_ctrl.c
+++ b/byterun/gc_ctrl.c
@@ -213,6 +213,10 @@ static value heap_stats (int returnstats)
     chunk = Chunk_next (chunk);
   }
 
+#ifdef DEBUG
+  caml_final_invariant_check();
+#endif
+
   Assert (heap_chunks == caml_stat_heap_chunks);
   Assert (live_words + free_words + fragments == caml_stat_heap_wsz);
 

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -469,7 +469,7 @@ static void mark_slice (intnat work)
           /* Subphase_mark_main is done.
              Mark finalised values. */
           gray_vals_cur = gray_vals_ptr;
-          caml_final_update ();
+          caml_final_update_mark_phase ();
           gray_vals_ptr = gray_vals_cur;
           if (gray_vals_ptr > gray_vals){
             v = *--gray_vals_ptr;
@@ -481,17 +481,18 @@ static void mark_slice (intnat work)
       }
         break;
       case Subphase_mark_final: {
+        /** The set of unreachable value will not change anymore for
+            this cycle. Start clean phase. */
+        caml_gc_phase = Phase_clean;
+        caml_final_update_clean_phase ();
         if (caml_ephe_list_head != (value) NULL){
           /* Initialise the clean phase. */
-          caml_gc_phase = Phase_clean;
           ephes_to_check = &caml_ephe_list_head;
-          work = 0;
         } else {
-          /* Initialise the sweep phase,
-           shortcut the unneeded clean phase. */
+          /* Initialise the sweep phase. */
           init_sweep_phase();
-          work = 0;
         }
+          work = 0;
       }
         break;
       default: Assert (0);

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -37,7 +37,7 @@
        this interval.
    [caml_young_alloc_start]...[caml_young_alloc_end]
        The allocation arena: newly-allocated blocks are carved from
-       this interval.
+       this interval, starting at [caml_young_alloc_end].
    [caml_young_alloc_mid] is the mid-point of this interval.
    [caml_young_ptr], [caml_young_trigger], [caml_young_limit]
        These pointers are all inside the allocation arena.
@@ -394,6 +394,7 @@ void caml_empty_minor_heap (void)
     ++ caml_stat_minor_collections;
     if (caml_minor_gc_end_hook != NULL) (*caml_minor_gc_end_hook) ();
   }else{
+    /* The minor heap is empty nothing to do. */
     caml_final_empty_young ();
   }
 #ifdef DEBUG

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -365,6 +365,8 @@ void caml_empty_minor_heap (void)
         }
       }
     }
+    /* Update the OCaml finalise_last values */
+    caml_final_update_minor_roots();
     /* Run custom block finalisation of dead minor values */
     for (elt = caml_custom_table.base; elt < caml_custom_table.ptr; elt++){
       value v = elt->block;

--- a/byterun/roots.c
+++ b/byterun/roots.c
@@ -55,7 +55,7 @@ void caml_oldify_local_roots (void)
   /* Global C roots */
   caml_scan_global_young_roots(&caml_oldify_one);
   /* Finalised values */
-  caml_final_do_young_roots ();
+  caml_final_oldify_young_roots ();
   /* Hook */
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(&caml_oldify_one);
 }

--- a/byterun/roots.c
+++ b/byterun/roots.c
@@ -55,7 +55,7 @@ void caml_oldify_local_roots (void)
   /* Global C roots */
   caml_scan_global_young_roots(&caml_oldify_one);
   /* Finalised values */
-  caml_final_do_young_roots (&caml_oldify_one);
+  caml_final_do_young_roots ();
   /* Hook */
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(&caml_oldify_one);
 }

--- a/byterun/roots.c
+++ b/byterun/roots.c
@@ -89,7 +89,7 @@ void caml_do_roots (scanning_action f, int do_globals)
   caml_scan_global_roots(f);
   CAML_INSTR_TIME (tmr, "major_roots/C");
   /* Finalised values */
-  caml_final_do_strong_roots (f);
+  caml_final_do_roots (f);
   CAML_INSTR_TIME (tmr, "major_roots/finalised");
   /* Hook */
   if (caml_scan_roots_hook != NULL) (*caml_scan_roots_hook)(f);

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -92,6 +92,8 @@ let allocated_bytes () =
 
 
 external finalise : ('a -> unit) -> 'a -> unit = "caml_final_register"
+external finalise_last : (unit -> unit) -> 'a -> unit =
+  "caml_final_register_called_without_value"
 external finalise_release : unit -> unit = "caml_final_release"
 
 

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -303,6 +303,19 @@ val finalise : ('a -> unit) -> 'a -> unit
    heap-allocated and non-constant except when the length argument is [0].
 *)
 
+val finalise_last : (unit -> unit) -> 'a -> unit
+(** same as {!finalise} except the value is not given as argument. So
+    you can't use the given value for the computation of the
+    finalisation function. The benefit is that the function is called
+    after the value is unreachable for the last time instead of the
+    first time. So contrary to {!finalise} the value will never be
+    reachable again or used again. In particular every weak pointers
+    and ephemerons that contained this value as key or data is unset
+    before running the finalisation function. Moreover the
+    finalisation function attached with `GC.finalise` are always
+    called before the finalisation function attached with `GC.finalise_last`.
+*)
+
 val finalise_release : unit -> unit
 (** A finalisation function may call [finalise_release] to tell the
     GC that it can launch the next finalisation function without waiting

--- a/testsuite/tests/misc/finaliser.ml
+++ b/testsuite/tests/misc/finaliser.ml
@@ -10,7 +10,7 @@ let debug = false
 let gc_print where _ =
   if debug then
     let stat = Gc.quick_stat () in
-    Printf.printf "minor: %i major: %i %s\n"
+    Printf.printf "minor: %i major: %i %s\n%!"
       stat.Gc.minor_collections
       stat.Gc.major_collections
       where
@@ -22,27 +22,35 @@ let () =
   gc_print "[Before]" ();
   let rec aux n =
     if n < k then begin
-      r.(n mod m) <- (Array.make m' 1);
+      r.(n mod m) <- (Array.make m' n);
       begin match n mod m with
       | 0 ->
+          (** finalise first major *)
           gc_print (Printf.sprintf "[Create %i first]" n) ();
           Gc.finalise (gc_print (Printf.sprintf "[Finalise %i first]" n)) r.(0)
       | 1 ->
+          (** finalise last major *)
           gc_print (Printf.sprintf "[Create %i last]" n) ();
           Gc.finalise_last
-            (gc_print (Printf.sprintf "[Finalise %i last]" n)) r.(0)
+            (gc_print (Printf.sprintf "[Finalise %i last]" n)) r.(1)
       | 2 ->
-          (** minor heap *)
+          (** finalise first minor *)
           let m = ref 1 in
           gc_print (Printf.sprintf "[Create %i first minor]" n) ();
           Gc.finalise
             (gc_print (Printf.sprintf "[Finalise %i first minor]" n)) m
       | 3 ->
-          (** minor heap *)
+          (** finalise last minor *)
           let m = ref 1 in
           gc_print (Printf.sprintf "[Create %i last minor]" n) ();
           Gc.finalise_last
             (gc_print (Printf.sprintf "[Finalise %i last minor]" n)) m
+      | 4 ->
+          (** finalise first-last major *)
+          gc_print (Printf.sprintf "[Create %i first]" n) ();
+          Gc.finalise (gc_print (Printf.sprintf "[Finalise %i first]" n)) r.(4);
+          Gc.finalise_last
+            (gc_print (Printf.sprintf "[Finalise %i first]" n)) r.(4)
       | _ -> ()
       end;
       aux (n + 1)

--- a/testsuite/tests/misc/finaliser.ml
+++ b/testsuite/tests/misc/finaliser.ml
@@ -1,0 +1,60 @@
+
+
+let m = 1000
+let m' = 100
+let k = m*10
+
+(** the printing are not stable between ocamlc and ocamlopt *)
+let debug = false
+
+let gc_print where _ =
+  if debug then
+    let stat = Gc.quick_stat () in
+    Printf.printf "minor: %i major: %i %s\n"
+      stat.Gc.minor_collections
+      stat.Gc.major_collections
+      where
+
+let r = Array.init m (fun _ -> Array.create m 1)
+
+
+let () =
+  gc_print "[Before]" ();
+  let rec aux n =
+    if n < k then begin
+      r.(n mod m) <- (Array.create m' 1);
+      begin match n mod m with
+      | 0 ->
+          gc_print (Printf.sprintf "[Create %i first]" n) ();
+          Gc.finalise (gc_print (Printf.sprintf "[Finalise %i first]" n)) r.(0)
+      | 1 ->
+          gc_print (Printf.sprintf "[Create %i last]" n) ();
+          Gc.finalise_last
+            (gc_print (Printf.sprintf "[Finalise %i last]" n)) r.(0)
+      | 2 ->
+          (** minor heap *)
+          let m = ref 1 in
+          gc_print (Printf.sprintf "[Create %i first minor]" n) ();
+          Gc.finalise
+            (gc_print (Printf.sprintf "[Finalise %i first minor]" n)) m
+      | 3 ->
+          (** minor heap *)
+          let m = ref 1 in
+          gc_print (Printf.sprintf "[Create %i last minor]" n) ();
+          Gc.finalise_last
+            (gc_print (Printf.sprintf "[Finalise %i last minor]" n)) m
+      | _ -> ()
+      end;
+      aux (n + 1)
+    end
+  in
+  aux 0;
+  gc_print "[Full major]" ();
+  Gc.full_major ();
+  gc_print "[Second full major]" ();
+  Gc.full_major ();
+  gc_print "[Third full major]" ();
+  Gc.full_major ();
+  ()
+
+let () = flush stdout

--- a/testsuite/tests/misc/finaliser.ml
+++ b/testsuite/tests/misc/finaliser.ml
@@ -15,14 +15,14 @@ let gc_print where _ =
       stat.Gc.major_collections
       where
 
-let r = Array.init m (fun _ -> Array.create m 1)
+let r = Array.init m (fun _ -> Array.make m 1)
 
 
 let () =
   gc_print "[Before]" ();
   let rec aux n =
     if n < k then begin
-      r.(n mod m) <- (Array.create m' 1);
+      r.(n mod m) <- (Array.make m' 1);
       begin match n mod m with
       | 0 ->
           gc_print (Printf.sprintf "[Create %i first]" n) ();


### PR DESCRIPTION
The advantage is that this kind of finalization functions are called after the value being unreachable for the last time instead of the first time (GC.finalise). [MPR#7210](http://caml.inria.fr/mantis/view.php?id=7210)

```
Gc.finalise_unit: (unit -> unit) -> 'a -> unit
```

Tests are not provided because there are no tests for `GC.finalise` and I must understand which kind of tests should be done.
