### PR TITLE
PR#7245: refine warning documentation in the manual

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,6 +47,12 @@ OCaml 4.04.0:
   "transitive" heap size of a value
   (Alain Frisch, review by Marc Shinwell and Damien Doligez)
 
+### Manual:
+
+- PR#7245, GPR#565: clarification to the wording and documentation
+  of Warning 52 (fragile constant pattern)
+  (Gabriel Scherer, William, Adrien Nader, Jacques Garrigue)
+
 ### Build system:
 
 - GPR#324: Compiler developpers only: Adding new primitives to the

--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -139,5 +139,19 @@ version.tex: $(SRC)/VERSION
 	    $(SRC)/VERSION > version.tex
 
 warnings-help.etex: $(SRC)/utils/warnings.ml $(SRC)/ocamlc
+	(echo "% This file is generated from (ocamlc -warn-help)";\
+	 echo "% according to a rule in manual/manual/Makefile.";\
+	 echo "% In particular, the reference to documentation sections";\
+	 echo "% are inserted through the Makefile, which should be updated";\
+	 echo "% when a new warning is documented.";\
+	 echo "%";\
 	$(SRC)/boot/ocamlrun $(SRC)/ocamlc -warn-help \
-	| sed -e 's/^ *\([0-9A-Z][0-9]*\)\(.*\)/\\item[\1] \2/' >$@
+	| sed -e 's/^ *\([0-9A-Z][0-9]*\)\(.*\)/\\item[\1] \2/'\
+	) >$@
+#	sed --inplace is not portable, emulate
+	for i in 52 57; do\
+		sed\
+		  s'/\\item\['$$i'\]/\\item\['$$i' (see \\ref{ss:warn'$$i'})\]/'\
+                  $@ > $@.tmp;\
+		mv $@.tmp $@;\
+	done

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -801,9 +801,9 @@ This section describes and explains in detail some warnings:
 
 >    | Foo "specific value" -> 0
 >          ^^^^^^^^^^^^^^^^
-> Warning 52: the argument of this constructor should not be matched against a
-> constant pattern; the actual value of the argument could change
-> in the future.
+> Warning 52: Code should not depend on the actual values of
+> this constructor's arguments. They are only for information
+> and may change in future versions. (See manual section 8.5)
 \end{verbatim}
 
   In particular, all built-in exceptions with a string argument have

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -797,7 +797,7 @@ This section describes and explains in detail some warnings:
 
   let warning = function
     | Foo "specific value" -> 0
-    | _ _ -> 1
+    | _ -> 1
 
 >    | Foo "specific value" -> 0
 >          ^^^^^^^^^^^^^^^^
@@ -811,10 +811,19 @@ This section describes and explains in detail some warnings:
   example using a string equality inside the right-hand-side instead
   of a literal pattern), as your code would remain fragile. You should
   instead enlarge the scope of the pattern by matching on all possible
-  values. This may require some care: if the scrutinee may return
-  several different cases of the same pattern, or raise distinct
-  instances of the same exception, you may need to modify your code to
-  separate those several cases.
+  values.
+
+\begin{verbatim}
+
+let warning = function
+  | Foo _ -> 0
+  | _ -> 1
+\end{verbatim}
+
+  This may require some care: if the scrutinee may return several
+  different cases of the same pattern, or raise distinct instances of
+  the same exception, you may need to modify your code to separate
+  those several cases.
 
   For example,
 \begin{verbatim}

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -806,6 +806,10 @@ This section describes and explains in detail some warnings:
 > in the future.
 \end{verbatim}
 
+  In particular, all built-in exceptions with a string argument have
+  this attribute set: "Invalid_argument", "Failure", "Sys_error" will
+  all raise this warning if you match for a specific string argument.
+
   If your code raises this warning, you should {\em not} change the
   way you test for the specific string to avoid the warning (for
   example using a string equality inside the right-hand-side instead
@@ -843,6 +847,13 @@ match int_of_string count_str with
     | choice -> (count, choice)
     end
 \end{verbatim}
+
+The only case where that transformation is not possible is if a given
+function call may raises distinct exceptions with the same constructor
+but different string values. In this case, you will have to check for
+specific string values. This is dangerous API design and it should be
+discouraged: it's better to define more precise exception constructors
+than store useful information in strings.
 
 \subsection{Warning 57: Ambiguous or-pattern variables under guard}
 \label{ss:warn57}

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -438,9 +438,9 @@ let message = function
       Printf.sprintf "expected tailcall"
   | Fragile_literal_pattern ->
       Printf.sprintf
-        "the argument of this constructor should not be matched against a\n\
-         constant pattern; the actual value of the argument could change\n\
-         in the future."
+        "Code should not depend on the actual values of\n\
+         this constructor's arguments. They are only for information\n\
+         and may change in future versions. (See manual section 8.5)"
   | Unreachable_case ->
       "this match case is unreachable.\n\
        Consider replacing it with a refutation case '<pat> -> .'"


### PR DESCRIPTION
This pull request implements feedback received on the new section on warning documentation in [PR#7245](http://caml.inria.fr/mantis/view.php?id=7245).

I would appreciate feedback on the portability of the Makefile/shell mixture used [in manual/manual/Makefile](https://github.com/gasche/ocaml/blob/ee65411/manual/manual/Makefile#L148-L155). @damiendoligez (or anyone else having an idea about these things), do you think it will work on other machines that mine?
