### PR TITLE
Manual: fix GPR#559, invalid use of transf

### DIFF
--- a/manual/manual/cmds/Makefile
+++ b/manual/manual/cmds/Makefile
@@ -2,7 +2,10 @@ FILES=comp.tex top.tex runtime.tex native.tex lexyacc.tex intf-c.tex \
   depend.tex profil.tex debugger.tex browser.tex ocamldoc.tex \
   warnings-help.tex ocamlbuild.tex flambda.tex
 
-TRANSF=../../tools/transf
+TOPDIR=../../..
+include $(TOPDIR)/Makefile.tools
+
+TRANSF=$(OCAMLRUN) ../../tools/transf
 TEXQUOTE=../../tools/texquote2
 FORMAT=../../tools/format-intf
 

--- a/manual/manual/refman/Makefile
+++ b/manual/manual/refman/Makefile
@@ -2,6 +2,10 @@ FILES= refman.tex lex.tex names.tex values.tex const.tex types.tex \
   patterns.tex expr.tex typedecl.tex modtypes.tex modules.tex compunit.tex \
   exten.tex classes.tex
 
+TOPDIR=../../..
+
+include $(TOPDIR)/Makefile.tools
+
 TRANSF=../../tools/transf
 TEXQUOTE=../../tools/texquote2
 
@@ -16,6 +20,6 @@ clean:
 .SUFFIXES: .etex .tex
 
 .etex.tex:
-	$(TRANSF) < $*.etex | $(TEXQUOTE) > $*.tex
+	$(OCAMLRUN) $(TRANSF) < $*.etex | $(TEXQUOTE) > $*.tex
 
 $(ALLFILES): $(TRANSF) $(TEXQUOTE)


### PR DESCRIPTION
When modifying the manual's Makefiles for #559, I forgot to update the use of the transf tool within the language reference and tools parts. With this error, only empty tex files are generated from the etex source files. 

This PR fixes this faux pas and ensures that the full manual is generated.
