### PR TITLE
Optimize immutable float records

### DIFF
--- a/asmcomp/import_approx.ml
+++ b/asmcomp/import_approx.ml
@@ -104,7 +104,11 @@ let rec import_ex ex =
     | Unknown_or_mutable ->
       A.value_mutable_float_array ~size:float_array.size
     | Contents contents ->
-      A.value_immutable_float_array contents
+      A.value_immutable_float_array
+        (Array.map (function
+           | None -> A.value_any_float
+           | Some f -> A.value_float f)
+           contents)
     end
   | Export_info.Value_boxed_int (t, i) -> A.value_boxed_int t i
   | Value_string { size; contents } ->

--- a/middle_end/inline_and_simplify.ml
+++ b/middle_end/inline_and_simplify.ml
@@ -185,7 +185,7 @@ let approx_for_allocated_const (const : Allocated_const.t) =
   | Float_array a -> A.value_mutable_float_array ~size:(List.length a)
   | Immutable_float_array a ->
       A.value_immutable_float_array
-        (Array.map (fun x -> Some x) (Array.of_list a))
+        (Array.map A.value_float (Array.of_list a))
 
 (* Determine whether a given closure ID corresponds directly to a variable
    (bound to a closure) in the given environment.  This happens when the body

--- a/middle_end/lift_constants.ml
+++ b/middle_end/lift_constants.ml
@@ -379,14 +379,9 @@ let translate_definition_and_resolve_alias inconstants
                Duplicate Pfloatarray %a with unknown symbol: %a"
               Variable.print var
               Alias_analysis.print_constant_defining_value definition
-          | Value_float_array { contents = Contents float_array } ->
+          | Value_float_array value_float_array ->
             let contents =
-              Array.fold_right (fun elt acc ->
-                  match acc, elt with
-                  | None, _ | _, None -> None
-                  | Some acc, Some f ->
-                    Some (f :: acc))
-                float_array (Some [])
+              Simple_value_approx.float_array_as_constant value_float_array
             in
             begin match contents with
             | None ->

--- a/middle_end/simple_value_approx.mli
+++ b/middle_end/simple_value_approx.mli
@@ -30,15 +30,6 @@ type value_string = {
   size : int;
 }
 
-type value_float_array_contents =
-  | Contents of float option array
-  | Unknown_or_mutable
-
-type value_float_array = {
-  contents : value_float_array_contents;
-  size : int;
-}
-
 type unknown_because_of =
   | Unresolved_symbol of Symbol.t
   | Other
@@ -162,6 +153,15 @@ and value_set_of_closures = private {
   direct_call_surrogates : Closure_id.t Closure_id.Map.t;
 }
 
+and value_float_array_contents =
+  | Contents of t array
+  | Unknown_or_mutable
+
+and value_float_array = {
+  contents : value_float_array_contents;
+  size : int;
+}
+
 (** Extraction of the description of approximation(s). *)
 val descr : t -> descr
 val descrs : t list -> descr list
@@ -195,7 +195,7 @@ val value_char : char -> t
 val value_float : float -> t
 val value_any_float : t
 val value_mutable_float_array : size:int -> t
-val value_immutable_float_array : float option array -> t
+val value_immutable_float_array : t array -> t
 val value_string : int -> string option -> t
 val value_boxed_int : 'i boxed_int -> 'i -> t
 val value_constptr : int -> t
@@ -406,3 +406,6 @@ val check_approx_for_closure_allowing_unresolved
 
 (** Returns the value if it can be proved to be a constant float *)
 val check_approx_for_float : t -> float option
+
+(** Returns the value if it can be proved to be a constant float array *)
+val float_array_as_constant : value_float_array -> float list option

--- a/middle_end/simplify_primitives.ml
+++ b/middle_end/simplify_primitives.ml
@@ -66,8 +66,7 @@ let primitive (p : Lambda.primitive) (args, approxs) expr dbg ~size_int
       expr, approx, C.Benefit.zero
   | Pmakearray (Pfloatarray, Immutable) ->
       let approx =
-        A.value_immutable_float_array
-          (Array.of_list (List.map A.check_approx_for_float approxs))
+        A.value_immutable_float_array (Array.of_list approxs)
       in
       expr, approx, C.Benefit.zero
   | Pintcomp Ceq when phys_equal approxs ->
@@ -212,8 +211,8 @@ let primitive (p : Lambda.primitive) (args, approxs) expr dbg ~size_int
         | Pfloatfield i ->
           begin match contents with
           | A.Contents a when i >= 0 && i < size ->
-            begin match a.(i) with
-            | None -> expr, A.value_any_float, C.Benefit.zero
+            begin match A.check_approx_for_float a.(i) with
+            | None -> expr, a.(i), C.Benefit.zero
             | Some v -> S.const_float_expr expr v
             end
           | Contents _ | Unknown_or_mutable ->

--- a/testsuite/tests/float-unboxing/float_subst_boxed_number.ml
+++ b/testsuite/tests/float-unboxing/float_subst_boxed_number.ml
@@ -76,7 +76,8 @@ let unbox_classify_float () =
   for i = 1 to 1000 do
     assert (classify_float !x = FP_normal);
     x := !x +. 1.
-  done
+  done;
+  ignore (Sys.opaque_identity !x)
 
 let unbox_compare_float () =
   let module M = struct type sf = { mutable x: float; y: float; } end in
@@ -84,12 +85,13 @@ let unbox_compare_float () =
   for i = 1 to 1000 do
     assert (compare x.M.x x.M.y >= 0);
     x.M.x <- x.M.x +. 1.
-  done
-
+  done;
+  ignore (Sys.opaque_identity x.M.x)
 
 let unbox_float_refs () =
   let r = ref nan in
-  for i = 1 to 1000 do r := !r +. float i done
+  for i = 1 to 1000 do r := !r +. float i done;
+  ignore (Sys.opaque_identity !r)
 
 let unbox_let_float () =
   let r = ref 0. in
@@ -98,7 +100,8 @@ let unbox_let_float () =
       if i mod 2 = 0 then nan else float i
     in
     r := !r +. (y *. 2.)
-  done
+  done;
+  ignore (Sys.opaque_identity !r)
 
 type block =
   { mutable float : float;
@@ -122,7 +125,9 @@ let unbox_record_1 float int32 =
       if i mod 2 = 0 then Int32.max_int else Int32.of_int i
     in
     block.int32 <- Int32.(add block.int32 (mul y_int32 2l))
-  done
+  done;
+  ignore (Sys.opaque_identity block.float);
+  ignore (Sys.opaque_identity block.int32)
   [@@inline never]
   (* Prevent inlining to test that the type is effectively used *)
 
@@ -139,7 +144,8 @@ let unbox_only_if_useful () =
     in
     r := x; (* would force boxing if the let binding above were unboxed *)
     r := x  (* use [x] twice to avoid elimination of the let-binding *)
-  done
+  done;
+  ignore (Sys.opaque_identity !r)
 
 let () =
   let flambda =

--- a/testsuite/tests/float-unboxing/float_subst_boxed_number.ml
+++ b/testsuite/tests/float-unboxing/float_subst_boxed_number.ml
@@ -147,6 +147,15 @@ let unbox_only_if_useful () =
   done;
   ignore (Sys.opaque_identity !r)
 
+let eliminate_intermediate_float_record () =
+  let r = ref 0. in
+  for n = 1 to 1000 do
+    let open Complex in
+    let c = { re = float n; im = 0. } in
+    r := !r +. (norm [@inlined]) ((add [@inlined]) c i);
+  done;
+  ignore (Sys.opaque_identity !r)
+
 let () =
   let flambda =
     match Sys.getenv "FLAMBDA" with
@@ -164,6 +173,8 @@ let () =
 
   if flambda then begin
     check_noalloc "float and int32 record" unbox_record;
+    check_noalloc "eliminate intermediate immutable float record"
+      eliminate_intermediate_float_record;
   end;
 
   ()


### PR DESCRIPTION
In particular, this allows to write non (or at least less) allocating code using the Complex module or fixed size vectors. For instance in this code the angle function allocates only the return float

```
  type t = { x : float; y : float }
  let dot v1 v2 = v1.x *. v2.x +. v1.y *. v2.y [@@inline]
  let sq x = x *. x [@@inline]
  let norm v = sqrt (sq v.x +. sq v.y) [@@inline]
  let scale s v = { x = s *. v.x; y = s *. v.y } [@@inline]
  let normalized v = scale (1. /. norm v) v [@@inline]
  let angle v1 v2 =
    acos (dot (normalized v1) (normalized v2))
```

The only change is to allow immutable float records to propagate the complete approximation of their content, in particular the alias informations.
