### PR TITLE
Install native versions of tools by default.

### DIFF
--- a/.depend
+++ b/.depend
@@ -52,11 +52,11 @@ parsing/ast_helper.cmx : parsing/parsetree.cmi parsing/longident.cmx \
 parsing/ast_helper.cmi : parsing/parsetree.cmi parsing/longident.cmi \
     parsing/location.cmi parsing/docstrings.cmi parsing/asttypes.cmi
 parsing/ast_invariants.cmo : parsing/syntaxerr.cmi parsing/parsetree.cmi \
-    parsing/longident.cmi parsing/asttypes.cmi parsing/ast_iterator.cmi \
-    parsing/ast_invariants.cmi
+    parsing/longident.cmi parsing/builtin_attributes.cmi parsing/asttypes.cmi \
+    parsing/ast_iterator.cmi parsing/ast_invariants.cmi
 parsing/ast_invariants.cmx : parsing/syntaxerr.cmx parsing/parsetree.cmi \
-    parsing/longident.cmx parsing/asttypes.cmi parsing/ast_iterator.cmx \
-    parsing/ast_invariants.cmi
+    parsing/longident.cmx parsing/builtin_attributes.cmx parsing/asttypes.cmi \
+    parsing/ast_iterator.cmx parsing/ast_invariants.cmi
 parsing/ast_invariants.cmi : parsing/parsetree.cmi
 parsing/ast_iterator.cmo : parsing/parsetree.cmi parsing/location.cmi \
     parsing/ast_iterator.cmi
@@ -892,11 +892,6 @@ asmcomp/deadcode.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/mach.cmi \
 asmcomp/deadcode.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/mach.cmx \
     asmcomp/deadcode.cmi
 asmcomp/deadcode.cmi : asmcomp/mach.cmi
-asmcomp/debuginfo.cmo : parsing/location.cmi bytecomp/lambda.cmi \
-    asmcomp/debuginfo.cmi
-asmcomp/debuginfo.cmx : parsing/location.cmx bytecomp/lambda.cmx \
-    asmcomp/debuginfo.cmi
-asmcomp/debuginfo.cmi : parsing/location.cmi bytecomp/lambda.cmi
 asmcomp/emit.cmo : asmcomp/x86_proc.cmi asmcomp/x86_masm.cmi \
     asmcomp/x86_gas.cmi asmcomp/x86_dsl.cmi asmcomp/x86_ast.cmi \
     asmcomp/reg.cmi asmcomp/proc.cmi utils/misc.cmi asmcomp/mach.cmi \

--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@
 /byterun/caml/version.h
 /byterun/ocamlrun
 /byterun/ocamlrund
+/byterun/ocamlruni
 /byterun/ld.conf
 /byterun/interp.a.lst
 /byterun/*.[sd]obj
@@ -300,17 +301,24 @@
 /tools/ocamldep.opt
 /tools/ocamldep.bak
 /tools/ocamlprof
+/tools/ocamlprof.opt
 /tools/opnames.ml
 /tools/dumpobj
 /tools/dumpapprox
-/tools/objinfo
+/tools/ocamlobjinfo
+/tools/ocamlobjinfo.opt
 /tools/cvt_emit
+/tools/cvt_emit.opt
 /tools/cvt_emit.bak
 /tools/cvt_emit.ml
+/tools/cvt_emit.opt
 /tools/ocamlcp
+/tools/ocamlcp.opt
 /tools/ocamloptp
+/tools/ocamloptp.opt
 /tools/ocamlmktop
 /tools/primreq
+/tools/primreq.opt
 /tools/ocamldumpobj
 /tools/keywords
 /tools/lexer299.ml
@@ -324,7 +332,9 @@
 /tools/read_cmt
 /tools/read_cmt.opt
 /tools/cmpbyt
+/tools/cmpbyt.opt
 /tools/stripdebug
+/tools/stripdebug.opt
 
 /utils/config.ml
 

--- a/Changes
+++ b/Changes
@@ -73,6 +73,10 @@ OCaml 4.04.0:
 
 ### Build system:
 
+- GPR#512: Installed `ocamlc`, `ocamlopt`, and `ocamllex` are now the
+  native-code versions of the tools, if those versions were built.
+  (Demi Obenour)
+
 - GPR#324: Compiler developpers only: Adding new primitives to the
   standard runtime doesn't require anymore to run `make bootstrap`
   (François Bobot)

--- a/Makefile
+++ b/Makefile
@@ -244,12 +244,16 @@ install:
 	if test -n "$(WITH_OCAMLDOC)"; then (cd ocamldoc; $(MAKE) install); fi
 	if test -n "$(WITH_DEBUGGER)"; then (cd debugger; $(MAKE) install); fi
 	cp config/Makefile $(INSTALL_LIBDIR)/Makefile.config
-	if test -f ocamlopt; then $(MAKE) installopt; fi
+	if test -f ocamlopt; then $(MAKE) installopt; else \
+	   cd $(INSTALL_BINDIR); \
+	   ln -sf ocamlc.byte$(EXE) ocamlc$(EXE); \
+	   ln -sf ocamllex.byte$(EXE) ocamllex$(EXE); \
+	   fi
 
 # Installation of the native-code compiler
 installopt:
 	cd asmrun; $(MAKE) install
-	cp ocamlopt $(INSTALL_BINDIR)/ocamlopt$(EXE)
+	cp ocamlopt $(INSTALL_BINDIR)/ocamlopt.byte$(EXE)
 	cd stdlib; $(MAKE) installopt
 	cp middle_end/*.cmi middle_end/*.cmt middle_end/*.cmti \
 		$(INSTALL_COMPLIBDIR)
@@ -261,13 +265,18 @@ installopt:
 		else :; fi
 	for i in $(OTHERLIBRARIES); \
 	  do (cd otherlibs/$$i; $(MAKE) installopt) || exit $$?; done
-	if test -f ocamlopt.opt ; then $(MAKE) installoptopt; fi
+	if test -f ocamlopt.opt ; then $(MAKE) installoptopt; else \
+	   cd $(INSTALL_BINDIR); ln -sf ocamlopt.byte$(EXE) ocamlopt$(EXE); fi
 	cd tools; $(MAKE) installopt
 
 installoptopt:
 	cp ocamlc.opt $(INSTALL_BINDIR)/ocamlc.opt$(EXE)
 	cp ocamlopt.opt $(INSTALL_BINDIR)/ocamlopt.opt$(EXE)
 	cp lex/ocamllex.opt $(INSTALL_BINDIR)/ocamllex.opt$(EXE)
+	cd $(INSTALL_BINDIR); \
+	   ln -sf ocamlc.opt$(EXE) ocamlc$(EXE); \
+	   ln -sf ocamlopt.opt$(EXE) ocamlopt$(EXE); \
+	   ln -sf ocamllex.opt$(EXE) ocamllex$(EXE)
 	cp utils/*.cmx parsing/*.cmx typing/*.cmx bytecomp/*.cmx \
            driver/*.cmx asmcomp/*.cmx $(INSTALL_COMPLIBDIR)
 	cp compilerlibs/ocamlcommon.cmxa compilerlibs/ocamlcommon.a \
@@ -374,10 +383,7 @@ partialclean::
 ocamlnat: compilerlibs/ocamlcommon.cmxa compilerlibs/ocamloptcomp.cmxa \
     otherlibs/dynlink/dynlink.cmxa compilerlibs/ocamlopttoplevel.cmxa \
     $(OPTTOPLEVELSTART:.cmo=.cmx)
-	$(CAMLOPT) $(LINKFLAGS) -linkall -o ocamlnat \
-	    otherlibs/dynlink/dynlink.cmxa compilerlibs/ocamlcommon.cmxa \
-	    compilerlibs/ocamloptcomp.cmxa compilerlibs/ocamlopttoplevel.cmxa \
-	    $(OPTTOPLEVELSTART:.cmo=.cmx)
+	$(CAMLOPT) $(LINKFLAGS) -linkall -o $@ $^
 
 partialclean::
 	rm -f ocamlnat

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -207,9 +207,11 @@ installbyt:
 	cd byterun ; $(MAKEREC) install
 	cp ocamlc "$(INSTALL_BINDIR)/ocamlc.exe"
 	cp ocaml "$(INSTALL_BINDIR)/ocaml.exe"
+	cp ocamlc "$(INSTALL_BINDIR)/ocamlc.byte.exe"
 	cd stdlib ; $(MAKEREC) install
 	cp lex/ocamllex "$(INSTALL_BINDIR)/ocamllex.exe"
 	cp yacc/ocamlyacc.exe "$(INSTALL_BINDIR)/ocamlyacc.exe"
+	cp lex/ocamllex "$(INSTALL_BINDIR)/ocamllex.byte.exe"
 	cp utils/*.cmi utils/*.cmt utils/*.cmti \
 	   parsing/*.cmi parsing/*.cmt parsing/*.cmti \
 	   typing/*.cmi typing/*.cmt typing/*.cmti \
@@ -256,6 +258,7 @@ install-flexdll:
 installopt:
 	cd asmrun && $(MAKEREC) install
 	cp ocamlopt "$(INSTALL_BINDIR)/ocamlopt.exe"
+	cp ocamlopt "$(INSTALL_BINDIR)/ocamlopt.byte.exe"
 	cd stdlib && $(MAKEREC) installopt
 	cp middle_end/*.cmi middle_end/*.cmt middle_end/*.cmti \
 		"$(INSTALL_COMPLIBDIR)"
@@ -279,6 +282,9 @@ installoptopt:
 	cp ocamlc.opt "$(INSTALL_BINDIR)/ocamlc.opt$(EXE)"
 	cp ocamlopt.opt "$(INSTALL_BINDIR)/ocamlopt.opt$(EXE)"
 	cp lex/ocamllex.opt "$(INSTALL_BINDIR)/ocamllex.opt$(EXE)"
+	cp ocamlc.opt "$(INSTALL_BINDIR)/ocamlc$(EXE)"
+	cp ocamlopt.opt "$(INSTALL_BINDIR)/ocamlopt$(EXE)"
+	cp lex/ocamllex.opt "$(INSTALL_BINDIR)/ocamllex$(EXE)"
 	cp utils/*.cmx parsing/*.cmx typing/*.cmx bytecomp/*.cmx \
            driver/*.cmx asmcomp/*.cmx "$(INSTALL_COMPLIBDIR)"
 	cp compilerlibs/ocamlcommon.cmxa compilerlibs/ocamlcommon.$(A) \

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -17,7 +17,6 @@
 defaultentry:
 
 # The main Makefile, fragments shared between Makefile and Makefile.nt
-
 include config/Makefile
 CAMLRUN ?= boot/ocamlrun
 CAMLYACC ?= boot/ocamlyacc
@@ -213,12 +212,14 @@ PERVASIVES=$(STDLIB_MODULES) outcometree topdirs toploop
 
 
 # The middle end (whose .cma library is currently only used for linking
-# the "objinfo" program, since we cannot depend on the whole native code
+# the "ocamlobjinfo" program, since we cannot depend on the whole native code
 # compiler for "make world" and the list of dependencies for
 # asmcomp/export_info.cmo is long).
 
 compilerlibs/ocamlmiddleend.cma: $(MIDDLE_END)
 	$(CAMLC) -a -o $@ $(MIDDLE_END)
+compilerlibs/ocamlmiddleend.cmxa: $(MIDDLE_END:%.cmo=%.cmx)
+	$(CAMLOPT) -a -o $@ $^
 partialclean::
 	rm -f compilerlibs/ocamlmiddleend.cma
 
@@ -228,17 +229,21 @@ partialclean::
 ocamltools: ocamlc ocamlyacc ocamllex asmcomp/cmx_format.cmi \
             asmcomp/printclambda.cmo compilerlibs/ocamlmiddleend.cma \
             asmcomp/export_info.cmo
-	cd tools ; $(MAKEREC) all
+	+cd tools ; $(MAKEREC) all
 
 ocamltoolsopt: ocamlopt
-	cd tools; $(MAKEREC) opt
+	+cd tools; $(MAKEREC) opt
 
-ocamltoolsopt.opt: ocamlc.opt ocamlyacc ocamllex asmcomp/cmx_format.cmi \
-                   asmcomp/printclambda.cmx
-	cd tools; $(MAKEREC) opt.opt
+ocamltoolsopt.opt: ocamlc.opt ocamlyacc ocamllex.opt asmcomp/cmx_format.cmi \
+                   asmcomp/printclambda.cmx compilerlibs/ocamlmiddleend.cmxa \
+                   asmcomp/export_info.cmx
+	+cd tools; $(MAKEREC) opt.opt
 
 partialclean::
-	cd tools; $(MAKEREC) clean
+	+cd tools; $(MAKEREC) clean
 
 alldepend::
-	cd tools; $(MAKEREC) depend
+	+cd tools; $(MAKEREC) depend
+
+#config/Makefile: configure
+#	./configure $(CONFIGURE_ARGS)

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -99,7 +99,7 @@ OCAMLMKLIB=$(FLEXLINK_PREFIX)$(OCAMLRUN) $(OTOPDIR)/tools/ocamlmklib \
                       $(OTOPDIR)/ocamlopt $(OCFLAGS) $(RUNTIME_VARIANT)"
 OCAMLYACC=$(TOPDIR)/yacc/ocamlyacc$(EXE)
 DUMPOBJ=$(OCAMLRUN) $(OTOPDIR)/tools/dumpobj
-OBJINFO=$(OCAMLRUN) $(OTOPDIR)/tools/objinfo
+OBJINFO=$(OCAMLRUN) $(OTOPDIR)/tools/ocamlobjinfo
 BYTECODE_ONLY=[ "$(ARCH)" = "none" -o "$(ASM)" = "none" ]
 NATIVECODE_ONLY=false
 

--- a/tools/Makefile.nt
+++ b/tools/Makefile.nt
@@ -14,3 +14,8 @@
 #**************************************************************************
 
 include Makefile.shared
+
+ifneq "$(wildcard ../flexdll/Makefile)" ""
+CAMLOPT := OCAML_FLEXLINK="../boot/ocamlrun ../flexdll/flexlink.exe" \
+  $(CAMLOPT)
+endif

--- a/tools/Makefile.shared
+++ b/tools/Makefile.shared
@@ -12,10 +12,67 @@
 #*   special exception on linking described in the file LICENSE.          *
 #*                                                                        *
 #**************************************************************************
-
+MAKEFLAGS := -r -R
 include ../config/Makefile
+INSTALL_BINDIR:=$(DESTDIR)$(BINDIR)
+INSTALL_LIBDIR:=$(DESTDIR)$(LIBDIR)
+INSTALL_COMPLIBDIR:=$(DESTDIR)$(COMPLIBDIR)
+INSTALL_STUBLIBDIR:=$(DESTDIR)$(STUBLIBDIR)
+INSTALL_MANDIR:=$(DESTDIR)$(MANDIR)
+
+ifeq ($(SYSTEM),unix)
+override define shellquote
+$i := $$(subst ",\",$$(subst $$$$,\$$$$,$$(subst `,\`,$i)))#")#
+endef
+$(foreach i,BINDIR LIBDIR COMPLIBDIR STUBLIBDIR MANDIR,$(eval $(shellquote)))
+endif
+
 CAMLRUN ?= ../boot/ocamlrun
 CAMLYACC ?= ../boot/ocamlyacc
+DESTDIR ?=
+# Setup GNU make variables storing per-target source and target,
+# a list of installed tools, and a function to quote a filename for
+# the shell.
+override installed_tools := ocamldep ocamlprof ocamlcp ocamloptp \
+                   ocamlmktop ocamlmklib ocamlobjinfo
+
+install_files :=
+define byte2native
+$(patsubst %.cmo,%.cmx,$(patsubst %.cma,%.cmxa,$1))
+endef
+
+# $1 = target, $2 = OCaml object dependencies, $3 = other dependencies
+# There is a lot of subtle code here.  The multiple layers of expansion
+# are due to `make`'s eval() function, which evaluates the string
+# passed to it as a makefile fragment.  So it is crucial that variables
+# not get expanded too many times.
+define byte_and_opt_
+# This check is defensive programming
+$(and $(filter-out 1,$(words $1)),$(error \
+   cannot build file with whitespace in name))
+$1: $3 $2
+	$$(CAMLC) $$(LINKFLAGS) -I .. -o $$@ $2
+
+$1.opt: $3 $$(call byte2native,$2)
+	$$(CAMLOPT) $$(LINKFLAGS) -I .. -o $$@ $$(call byte2native,$2)
+
+all: $1
+
+opt.opt: $1.opt
+
+ifeq '$(filter $(installed_tools),$1)' '$1'
+install_files += $1
+endif
+clean::
+	rm -f -- $1 $1.opt
+
+endef
+
+# Escape any $ characters in the arguments and eval the result.
+define byte_and_opt
+$(eval $(call \
+ byte_and_opt_,$(subst $$,$$$$,$1),$(subst $$,$$$$,$2),$(subst $$,$$$$,$3)))
+endef
 
 ROOTDIR=..
 
@@ -25,24 +82,20 @@ else
 export OCAML_FLEXLINK:=$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe
 endif
 
-CAMLC=$(CAMLRUN) ../boot/ocamlc -nostdlib -I ../boot -use-prims ../byterun/primitives
+CAMLC=$(CAMLRUN) ../boot/ocamlc -nostdlib -I ../boot -use-prims ../byterun/primitives -I ..
 CAMLOPT=$(CAMLRUN) ../ocamlopt -nostdlib -I ../stdlib
 CAMLLEX=$(CAMLRUN) ../boot/ocamllex
 INCLUDES=-I ../utils -I ../parsing -I ../typing -I ../bytecomp -I ../asmcomp \
          -I ../middle_end -I ../middle_end/base_types -I ../driver \
          -I ../toplevel
-COMPFLAGS= -absname -w +a-4-9-41-42-44-45-48 -strict-sequence -warn-error A -safe-string -strict-formats $(INCLUDES)
+COMPFLAGS= -absname -w +a-4-9-41-42-44-45-48 -strict-sequence -warn-error A \
+ -safe-string -strict-formats $(INCLUDES)
 LINKFLAGS=$(INCLUDES)
-
-all: ocamldep ocamlprof ocamlcp ocamloptp ocamlmktop ocamlmklib dumpobj \
-     objinfo read_cmt stripdebug cmpbyt
+VPATH := $(filter-out -I,$(INCLUDES))
 
 # scrapelabels addlabels
 
-.PHONY: all
-
-opt.opt: ocamldep.opt read_cmt.opt
-.PHONY: opt.opt
+.PHONY: all opt.opt
 
 # The dependency generator
 
@@ -55,13 +108,10 @@ CAMLDEP_IMPORTS=timings.cmo misc.cmo config.cmo identifiable.cmo numbers.cmo \
   builtin_attributes.cmo ast_invariants.cmo \
   pparse.cmo compenv.cmo depend.cmo
 
-ocamldep: $(CAMLDEP_OBJ)
-	$(CAMLC) $(LINKFLAGS) -compat-32 -o ocamldep $(CAMLDEP_IMPORTS) \
-	         $(CAMLDEP_OBJ)
-
-ocamldep.opt: $(CAMLDEP_OBJ:.cmo=.cmx)
-	$(CAMLOPT) $(LINKFLAGS) -o ocamldep.opt $(CAMLDEP_IMPORTS:.cmo=.cmx) \
-	           $(CAMLDEP_OBJ:.cmo=.cmx)
+ocamldep: LINKFLAGS += -compat-32
+$(call byte_and_opt,ocamldep,$(CAMLDEP_IMPORTS) $(CAMLDEP_OBJ),)
+ocamldep: depend.cmi
+ocamldep.opt: depend.cmi
 
 # ocamldep is precious: sometimes we are stuck in the middle of a
 # bootstrap and we need to remake the dependencies
@@ -69,14 +119,6 @@ clean::
 	if test -f ocamldep; then mv -f ocamldep ocamldep.bak; else :; fi
 	rm -f ocamldep.opt
 
-
-INSTALL_BINDIR=$(DESTDIR)$(BINDIR)
-INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
-
-install::
-	cp ocamldep "$(INSTALL_BINDIR)/ocamldep$(EXE)"
-	if test -f ocamldep.opt; then \
-	  cp ocamldep.opt "$(INSTALL_BINDIR)/ocamldep.opt$(EXE)"; else :; fi
 
 # The profiler
 
@@ -86,46 +128,27 @@ CSLPROF_IMPORTS=misc.cmo config.cmo identifiable.cmo numbers.cmo \
   warnings.cmo location.cmo longident.cmo docstrings.cmo \
   syntaxerr.cmo ast_helper.cmo parser.cmo lexer.cmo parse.cmo
 
-ocamlprof: $(CSLPROF) profiling.cmo
-	$(CAMLC) $(LINKFLAGS) -o ocamlprof $(CSLPROF_IMPORTS) $(CSLPROF)
+$(call byte_and_opt,ocamlprof,$(CSLPROF_IMPORTS) profiling.cmo $(CSLPROF),)
 
-ocamlcp: ocamlcp.cmo
-	$(CAMLC) $(LINKFLAGS) -o ocamlcp misc.cmo warnings.cmo config.cmo \
-                 identifiable.cmo numbers.cmo arg_helper.cmo clflags.cmo \
-	         main_args.cmo ocamlcp.cmo
+ocamlcp_cmos = misc.cmo warnings.cmo config.cmo identifiable.cmo numbers.cmo \
+	       arg_helper.cmo clflags.cmo main_args.cmo
 
-ocamloptp: ocamloptp.cmo
-	$(CAMLC) $(LINKFLAGS) -o ocamloptp misc.cmo warnings.cmo config.cmo \
-                 identifiable.cmo numbers.cmo arg_helper.cmo clflags.cmo \
-	         main_args.cmo \
-	         ocamloptp.cmo
+$(call byte_and_opt,ocamlcp,$(ocamlcp_cmos) ocamlcp.cmo,)
+$(call byte_and_opt,ocamloptp,$(ocamlcp_cmos) ocamloptp.cmo,)
 
 opt:: profiling.cmx
 
 install::
-	cp ocamlprof "$(INSTALL_BINDIR)/ocamlprof$(EXE)"
-	cp ocamlcp "$(INSTALL_BINDIR)/ocamlcp$(EXE)"
-	cp ocamloptp "$(INSTALL_BINDIR)/ocamloptp$(EXE)"
-	cp profiling.cmi profiling.cmo "$(INSTALL_LIBDIR)"
+	cp -- profiling.cmi profiling.cmo "$(INSTALL_LIBDIR)"
 
 installopt::
-	cp profiling.cmx profiling.$(O) "$(INSTALL_LIBDIR)"
-
-clean::
-	rm -f ocamlprof ocamlcp ocamloptp
-
+	cp -- profiling.cmx profiling.$(O) "$(INSTALL_LIBDIR)"
 
 # To help building mixed-mode libraries (OCaml + C)
 
-ocamlmklib: ocamlmklibconfig.cmo ocamlmklib.cmo
-	$(CAMLC) $(LINKFLAGS) -o ocamlmklib ocamlmklibconfig.cmo config.cmo \
-	         ocamlmklib.cmo
+$(call byte_and_opt,ocamlmklib,ocamlmklibconfig.cmo config.cmo \
+	         ocamlmklib.cmo,)
 
-install::
-	cp ocamlmklib "$(INSTALL_BINDIR)/ocamlmklib$(EXE)"
-
-clean::
-	rm -f ocamlmklib
 
 ocamlmklibconfig.ml: ../config/Makefile Makefile
 	(echo 'let bindir = "$(BINDIR)"'; \
@@ -146,16 +169,9 @@ clean::
 
 OCAMLMKTOP=ocamlmktop.cmo
 OCAMLMKTOP_IMPORTS=misc.cmo identifiable.cmo numbers.cmo config.cmo \
-             arg_helper.cmo clflags.cmo ccomp.cmo
+		   arg_helper.cmo clflags.cmo ccomp.cmo
 
-ocamlmktop: $(OCAMLMKTOP)
-	$(CAMLC) $(LINKFLAGS) -o ocamlmktop $(OCAMLMKTOP_IMPORTS) $(OCAMLMKTOP)
-
-install::
-	cp ocamlmktop "$(INSTALL_BINDIR)/ocamlmktop$(EXE)"
-
-clean::
-	rm -f ocamlmktop
+$(call byte_and_opt,ocamlmktop,$(OCAMLMKTOP_IMPORTS) $(OCAMLMKTOP),)
 
 # Converter olabl/ocaml 2.99 to ocaml 3
 
@@ -204,6 +220,24 @@ addlabels: addlabels.cmo
 #install::
 #	cp addlabels "$(INSTALL_LIBDIR)"
 
+ifeq ($(UNIX_OR_WIN32),unix)
+LN := ln -sf
+else
+LN := cp -pf
+endif
+
+install::
+	for i in $(install_files); \
+	do \
+	  cp -- "$$i" "$(INSTALL_BINDIR)/$$i.byte$(EXE)" && \
+	  if test -f "$$i".opt; then \
+	    cp -- "$$i.opt" "$(INSTALL_BINDIR)/$$i.opt$(EXE)" && \
+	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
+	  else \
+	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.byte$(EXE)" "$$i$(EXE)"); \
+	  fi; \
+	done
+
 clean::
 	rm -f addlabels
 
@@ -216,6 +250,7 @@ cvt_emit: $(CVT_EMIT)
 
 # cvt_emit is precious: sometimes we are stuck in the middle of a
 # bootstrap and we need to remake the dependencies
+.PRECIOUS: cvt_emit
 clean::
 	if test -f cvt_emit; then mv -f cvt_emit cvt_emit.bak; else :; fi
 
@@ -227,7 +262,6 @@ clean::
 
 beforedepend:: cvt_emit.ml
 
-
 # Reading cmt files
 
 READ_CMT= \
@@ -236,32 +270,17 @@ READ_CMT= \
           \
           cmt2annot.cmo read_cmt.cmo
 
-READ_CMT_OPT1 = $(READ_CMT:.cmo=.cmx)
-READ_CMT_OPT = $(READ_CMT_OPT1:.cma=.cmxa)
+# Reading cmt files
+$(call byte_and_opt,read_cmt,$(READ_CMT),)
 
-read_cmt: $(READ_CMT)
-	$(CAMLC) $(LINKFLAGS) -o read_cmt $(READ_CMT)
-
-read_cmt.opt: $(READ_CMT_OPT)
-	$(CAMLOPT) $(LINKFLAGS) -o read_cmt.opt $(READ_CMT_OPT)
-
-clean::
-	rm -f read_cmt read_cmt.opt
-
-beforedepend::
 
 # The bytecode disassembler
 
 DUMPOBJ=opnames.cmo dumpobj.cmo
 
-dumpobj: $(DUMPOBJ)
-	$(CAMLC) $(LINKFLAGS) -o dumpobj \
-	         misc.cmo identifiable.cmo numbers.cmo \
-                 tbl.cmo config.cmo ident.cmo \
-	         opcodes.cmo bytesections.cmo $(DUMPOBJ)
-
-clean::
-	rm -f dumpobj
+$(call byte_and_opt,dumpobj,misc.cmo identifiable.cmo numbers.cmo tbl.cmo \
+                    config.cmo ident.cmo opcodes.cmo bytesections.cmo \
+		    $(DUMPOBJ),)
 
 opnames.ml: ../byterun/caml/instruct.h
 	unset LC_ALL || : ; \
@@ -306,37 +325,22 @@ OBJINFO=../compilerlibs/ocamlcommon.cma \
         ../asmcomp/export_info.cmo \
         objinfo.cmo
 
-objinfo: objinfo_helper$(EXE) $(OBJINFO)
-	$(CAMLC) -o objinfo $(OBJINFO)
-
-install::
-	cp objinfo "$(INSTALL_BINDIR)/ocamlobjinfo$(EXE)"
-	cp objinfo_helper$(EXE) "$(INSTALL_LIBDIR)/objinfo_helper$(EXE)"
-
-clean::
-	rm -f objinfo objinfo_helper$(EXE)
+$(call byte_and_opt,ocamlobjinfo,$(OBJINFO),objinfo_helper$(EXE))
 
 # Scan object files for required primitives
-
-PRIMREQ=primreq.cmo
-
-primreq: $(PRIMREQ)
-	$(CAMLC) $(LINKFLAGS) -o primreq config.cmo $(PRIMREQ)
+$(call byte_and_opt,primreq,config.cmo primreq.cmo,)
 
 clean::
-	rm -f primreq
+	rm -f "objinfo_helper$(EXE)"
+
 
 # Copy a bytecode executable, stripping debug info
 
-STRIPDEBUG=../compilerlibs/ocamlcommon.cma \
+stripdebug=../compilerlibs/ocamlcommon.cma \
            ../compilerlibs/ocamlbytecomp.cma \
            stripdebug.cmo
 
-stripdebug: $(STRIPDEBUG)
-	$(CAMLC) $(LINKFLAGS) -o stripdebug $(STRIPDEBUG)
-
-clean::
-	rm -f stripdebug
+$(call byte_and_opt,stripdebug,$(stripdebug),)
 
 # Compare two bytecode executables
 
@@ -344,30 +348,25 @@ CMPBYT=../compilerlibs/ocamlcommon.cma \
        ../compilerlibs/ocamlbytecomp.cma \
        cmpbyt.cmo
 
-cmpbyt: $(CMPBYT)
-	$(CAMLC) $(LINKFLAGS) -o cmpbyt $(CMPBYT)
-
-clean::
-	rm -f cmpbyt
+$(call byte_and_opt,cmpbyt,$(CMPBYT),)
 
 ifeq "$(RUNTIMEI)" "true"
 install::
-	cp ocaml-instr-graph ocaml-instr-report $(INSTALL_BINDIR)/
+	cp ocaml-instr-graph ocaml-instr-report "$(INSTALL_BINDIR)/"
 endif
 
 # Common stuff
 
 .SUFFIXES:
-.SUFFIXES: .ml .cmo .mli .cmi .cmx
 
-.ml.cmo:
-	$(CAMLC) -c $(COMPFLAGS) $<
+%.cmo: %.ml
+	$(CAMLC) -c $(COMPFLAGS) - $<
 
-.mli.cmi:
-	$(CAMLC) -c $(COMPFLAGS) $<
+%.cmi: %.mli
+	$(CAMLC) -c $(COMPFLAGS) - $<
 
-.ml.cmx:
-	$(CAMLOPT) $(COMPFLAGS) -c $<
+%.cmx: %.ml
+	$(CAMLOPT) $(COMPFLAGS) -c - $<
 
 clean::
 	rm -f *.cmo *.cmi *.cma *.dll *.so *.lib *.a


### PR DESCRIPTION
Previously, `ocamlc`, `ocamlopt`, `ocamllex`, and `ocamldep` defaulted
to the bytecode versions of the tools.  However, there is normally no
advantage to the bytecode versions if the native-code versions are
available, except in unusual circumstances.  Instead, install the
native-code versions without the `.opt` suffix.  They are still
installed with the `.opt` suffix for backwards compatibility.  Finally,
install the bytecode versions with the `.byte` suffix, and build
native-code versions of tools that are not currently built in native
code.

Also, remove some duplication in tools/Makefile.shared.

Supersedes GPR #512.
