### PR TITLE
MPR#7256 build ocaml on Sparc Solaris

### DIFF
--- a/otherlibs/bigarray/mmap_unix.c
+++ b/otherlibs/bigarray/mmap_unix.c
@@ -15,7 +15,7 @@
 
 /* Needed (under Linux at least) to get pwrite's prototype in unistd.h.
    Must be defined before the first system .h is included. */
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 600
 
 #include <stddef.h>
 #include <string.h>


### PR DESCRIPTION
According to http://man7.org/linux/man-pages/man7/feature_test_macros.7.html, defining to 600 might expose more definitions, but I don't actually know its impact to other part of the source base. Please comment.
