### PR TITLE
Add a non-allocating function to recover the number of allocated minor words

### DIFF
--- a/Changes
+++ b/Changes
@@ -35,6 +35,10 @@ OCaml 4.04.0:
 
 ### Standard library:
 
+- GPR#589: Add a non-allocating function to recover the number of
+  allocated minor words.
+  (Pierre Chambart, review by Damien Doligez and Gabriel Scherer)
+
 - GPR#427: Obj.is_block is now an inlined OCaml function instead of a
   C external.  This should be faster.
   (Demi Obenour)

--- a/byterun/gc_ctrl.c
+++ b/byterun/gc_ctrl.c
@@ -307,6 +307,18 @@ CAMLprim value caml_gc_quick_stat(value v)
   CAMLreturn (res);
 }
 
+double caml_gc_minor_words_unboxed()
+{
+  return (caml_stat_minor_words
+          + (double) (caml_young_alloc_end - caml_young_ptr));
+}
+
+CAMLprim value caml_gc_minor_words(value v)
+{
+  CAMLparam0 ();   /* v is ignored */
+  CAMLreturn(caml_copy_double(caml_gc_minor_words_unboxed()));
+}
+
 CAMLprim value caml_gc_counters(value v)
 {
   CAMLparam0 ();   /* v is ignored */

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -46,6 +46,8 @@ type control = {
 external stat : unit -> stat = "caml_gc_stat"
 external quick_stat : unit -> stat = "caml_gc_quick_stat"
 external counters : unit -> (float * float * float) = "caml_gc_counters"
+external minor_words : unit -> (float [@unboxed])
+  = "caml_gc_minor_words" "caml_gc_minor_words_unboxed" [@@noalloc]
 external get : unit -> control = "caml_gc_get"
 external set : control -> unit = "caml_gc_set"
 external minor : unit -> unit = "caml_gc_minor"

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -170,6 +170,14 @@ external counters : unit -> float * float * float = "caml_gc_counters"
 (** Return [(minor_words, promoted_words, major_words)].  This function
     is as fast as [quick_stat]. *)
 
+external minor_words : unit -> (float [@unboxed])
+  = "caml_gc_minor_words" "caml_gc_minor_words_unboxed" [@@noalloc]
+(** Number of words allocated in the minor heap since the program was
+    started. This number is accurate in byte-code programs, but only an
+    approximation in programs compiled to native code.
+
+    In native code this function does not allocate. *)
+
 external get : unit -> control = "caml_gc_get"
 (** Return the current values of the GC parameters in a [control] record. *)
 

--- a/testsuite/tests/float-unboxing/float_subst_boxed_number.ml
+++ b/testsuite/tests/float-unboxing/float_subst_boxed_number.ml
@@ -126,6 +126,11 @@ let unbox_only_if_useful () =
     r := x  (* use [x] twice to avoid elimination of the let-binding *)
   done
 
+let unbox_minor_words () =
+  for i = 1 to 1000 do
+    ignore (Gc.minor_words () = 0.)
+  done
+
 let () =
   let flambda =
     match Sys.getenv "FLAMBDA" with
@@ -145,4 +150,5 @@ let () =
     check_noalloc "float and int32 record" unbox_record;
   end;
 
+  check_noalloc "Gc.minor_words" unbox_minor_words;
   ()


### PR DESCRIPTION
To test non-allocating functions, it is easier to have a non allocating function.
This uses the recent addition of unboxed externals to avoid allocating the returned float.

Note that this of course allocates in bytecode.
