### PR TITLE
Do not perform compaction if the real overhead is less than expected

### DIFF
--- a/byterun/compact.c
+++ b/byterun/compact.c
@@ -528,9 +528,9 @@ void caml_compact_heap_maybe (void)
                             ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
                      (uintnat) fp);
     if (fp >= caml_percent_max)
-      {
-         caml_gc_message (0x200, "Compacting heap.\n", 0);
          caml_compact_heap ();
-      }
+    else 
+         caml_gc_message (0x200, "Automatic compaction aborted.\n", 0);
+         
   }
 }

--- a/byterun/compact.c
+++ b/byterun/compact.c
@@ -511,6 +511,9 @@ void caml_compact_heap_maybe (void)
   caml_gc_message (0x200, "FL size at phase change = %"
                           ARCH_INTNAT_PRINTF_FORMAT "u words\n",
                    (uintnat) caml_fl_wsz_at_phase_change);
+  caml_gc_message (0x200, "FL current size = %"
+                          ARCH_INTNAT_PRINTF_FORMAT "u words\n",
+                   (uintnat) caml_fl_cur_wsz);                
   caml_gc_message (0x200, "Estimated overhead = %"
                           ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
                    (uintnat) fp);
@@ -524,7 +527,7 @@ void caml_compact_heap_maybe (void)
     caml_gc_message (0x200, "Measured overhead: %"
                             ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
                      (uintnat) fp);
-
-    caml_compact_heap ();
+    if (fp >= caml_percent_max)
+      caml_compact_heap ();
   }
 }

--- a/byterun/compact.c
+++ b/byterun/compact.c
@@ -528,6 +528,9 @@ void caml_compact_heap_maybe (void)
                             ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
                      (uintnat) fp);
     if (fp >= caml_percent_max)
-      caml_compact_heap ();
+      {
+         caml_gc_message (0x200, "Compacting heap.\n", 0);
+         caml_compact_heap ();
+      }
   }
 }


### PR DESCRIPTION
The automatic compaction is triggered when the estimated overhead reach `caml_percent_max`. The automatic compaction starts by finishing the current major cycle, which has the side effect of computing a better estimate for the overhead. 

This pull request makes sure that we do not perform compaction if the measured overhead is actually smaller than `caml_percent_max`. This pull-request is a fix for some behaviors we see where the estimated overhead is several orders of magnitude bigger than the measured overhead, but does not try to address why this measure is off by such a factor.
