### PR TITLE
A few modifications to OCAMLPARAM

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -522,5 +522,8 @@ let readenv ppf position =
   all_ccopts := !last_ccopts @ !first_ccopts;
   all_ppx := !last_ppx @ !first_ppx
 
-let get_objfiles () =
-  List.rev (!last_objfiles @ !objfiles @ !first_objfiles)
+let get_objfiles ~with_ocamlparam =
+  if with_ocamlparam then
+    List.rev (!last_objfiles @ !objfiles @ !first_objfiles)
+  else
+    List.rev !objfiles

--- a/driver/compenv.mli
+++ b/driver/compenv.mli
@@ -32,6 +32,8 @@ val implicit_modules : string list ref
 
 (* return the list of objfiles, after OCAMLPARAM and List.rev *)
 val get_objfiles : with_ocamlparam:bool -> string list
+val last_objfiles : string list ref
+val first_objfiles : string list ref
 
 type filename = string
 

--- a/driver/compenv.mli
+++ b/driver/compenv.mli
@@ -31,7 +31,7 @@ val last_include_dirs : string list ref
 val implicit_modules : string list ref
 
 (* return the list of objfiles, after OCAMLPARAM and List.rev *)
-val get_objfiles : unit -> string list
+val get_objfiles : with_ocamlparam:bool -> string list
 
 type filename = string
 

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -27,10 +27,9 @@ let init_path ?(dir="") native =
     else if !Clflags.use_vmthreads && not native then
       "+vmthreads" :: !Clflags.include_dirs
     else
-      !last_include_dirs @
-      !Clflags.include_dirs @
-      !first_include_dirs
+      !Clflags.include_dirs
   in
+  let dirs = !last_include_dirs @ dirs @ !first_include_dirs in
   let exp_dirs =
     List.map (Misc.expand_directory Config.standard_library) dirs in
   Config.load_path := dir ::

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -182,14 +182,14 @@ let main () =
     if !make_archive then begin
       Compmisc.init_path false;
 
-      Bytelibrarian.create_archive ppf  (Compenv.get_objfiles ())
+      Bytelibrarian.create_archive ppf  (Compenv.get_objfiles ~with_ocamlparam:false)
                                    (extract_output !output_name);
       Warnings.check_fatal ();
     end
     else if !make_package then begin
       Compmisc.init_path false;
       let extracted_output = extract_output !output_name in
-      let revd = get_objfiles () in
+      let revd = get_objfiles ~with_ocamlparam:false in
       Bytepackager.package_files ppf (Compmisc.initial_env ())
         revd (extracted_output);
       Warnings.check_fatal ();
@@ -212,7 +212,7 @@ let main () =
           default_output !output_name
       in
       Compmisc.init_path false;
-      Bytelink.link ppf (get_objfiles ()) target;
+      Bytelink.link ppf (get_objfiles ~with_ocamlparam:true) target;
       Warnings.check_fatal ();
     end;
   with x ->

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -293,20 +293,20 @@ let main () =
         fatal "Option -a cannot be used with .cmxa input files.";
       Compmisc.init_path true;
       let target = extract_output !output_name in
-      Asmlibrarian.create_archive (get_objfiles ()) target;
+      Asmlibrarian.create_archive (get_objfiles ~with_ocamlparam:false) target;
       Warnings.check_fatal ();
     end
     else if !make_package then begin
       Compmisc.init_path true;
       let target = extract_output !output_name in
       Asmpackager.package_files ppf (Compmisc.initial_env ())
-        (get_objfiles ()) target ~backend;
+        (get_objfiles ~with_ocamlparam:false) target ~backend;
       Warnings.check_fatal ();
     end
     else if !shared then begin
       Compmisc.init_path true;
       let target = extract_output !output_name in
-      Asmlink.link_shared ppf (get_objfiles ()) target;
+      Asmlink.link_shared ppf (get_objfiles ~with_ocamlparam:false) target;
       Warnings.check_fatal ();
     end
     else if not !compile_only && !objfiles <> [] then begin
@@ -326,7 +326,7 @@ let main () =
           default_output !output_name
       in
       Compmisc.init_path true;
-      Asmlink.link ppf (get_objfiles ()) target;
+      Asmlink.link ppf (get_objfiles ~with_ocamlparam:true) target;
       Warnings.check_fatal ();
     end;
   with x ->

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -495,7 +495,9 @@ let set_paths () =
      but keep the directories that user code linked in with ocamlmktop
      may have added to load_path. *)
   load_path := !load_path @ [Filename.concat Config.standard_library "camlp4"];
-  load_path := "" :: (List.rev !Clflags.include_dirs @ !load_path);
+  load_path := "" :: List.rev (!Compenv.last_include_dirs @
+                               !Clflags.include_dirs @
+                               !Compenv.first_include_dirs) @ !load_path;
   Dll.add_path !load_path
 
 let initialize_toplevel_env () =

--- a/toplevel/topmain.ml
+++ b/toplevel/topmain.ml
@@ -25,7 +25,11 @@ let prepare ppf =
   Toploop.set_paths ();
   try
     let res =
-      List.for_all (Topdirs.load_file ppf) (List.rev !preload_objects) in
+      let objects =
+        List.rev (!preload_objects @ !first_objfiles)
+      in
+      List.for_all (Topdirs.load_file ppf) objects
+    in
     !Toploop.toplevel_startup_hook ();
     res
   with x ->


### PR DESCRIPTION
Hello, 

In this PR, I propose (for discussion) two modifications in the behavior of OCAMLPARAM:
1.  Do not use cmo/cmx and cma/cmxa provided in OCAMLPARAM to build archive, package and shared libraries. (210d7ae)
2.  Use them in toplevels (7ace5aa)
3.  Fix something that looked like a bug: the include directory of OCAMLPARAM was not used when threads were present. (bc968d4)

I am not aware of the original purpose of this experimental feature, but I am trying to use it to instrument code (in the same spirit as the "bisect" tool) of arbitrary ocaml sources without modification the build infrastructure. 

The modification "1" prevents multiple include of same objects when archive are built and used in the same build. But there's a drawback: the archives that are produced are not self-contained anymore, they depend on the objects that were in OCAMLPARAM during the build.
