### PR TITLE
Added a function [Genarray.change_layout].

### DIFF
--- a/otherlibs/bigarray/bigarray.ml
+++ b/otherlibs/bigarray/bigarray.ml
@@ -110,7 +110,9 @@ module Genarray = struct
 
   external kind: ('a, 'b, 'c) t -> ('a, 'b) kind = "caml_ba_kind"
   external layout: ('a, 'b, 'c) t -> 'c layout = "caml_ba_layout"
-
+  external change_layout: ('a, 'b, 'c) t -> 'd layout -> ('a, 'b, 'd) t
+     = "caml_ba_change_layout"
+ 
   let size_in_bytes arr =
     (kind_size_in_bytes (kind arr)) * (Array.fold_left ( * ) 1 (dims arr))
 

--- a/otherlibs/bigarray/bigarray.mli
+++ b/otherlibs/bigarray/bigarray.mli
@@ -292,7 +292,9 @@ module Genarray :
   (** [Genarray.change_layout a layout] returns a bigarray with the
       specified [layout], sharing the data with [a] (and hence having
       the same dimensions as [a]). No copying of elements is involved: the
-      new array and the original array share the same storage space. *)
+      new array and the original array share the same storage space.
+      The dimensions are reversed, such that [get v [| a; b |]] in
+      C layout becomes [get v [| b+1; a+1 |]] in Fortran layout. *)
    
   val size_in_bytes : ('a, 'b, 'c) t -> int
   (** [size_in_bytes a] is the number of elements in [a] multiplied

--- a/otherlibs/bigarray/bigarray.mli
+++ b/otherlibs/bigarray/bigarray.mli
@@ -287,7 +287,13 @@ module Genarray :
 
   external layout: ('a, 'b, 'c) t -> 'c layout = "caml_ba_layout"
   (** Return the layout of the given big array. *)
-
+  
+  external change_layout: ('a, 'b, 'c) t -> 'd layout -> ('a, 'b, 'd) t = "caml_ba_change_layout"
+  (** [Genarray.change_layout a layout] returns a bigarray with the
+      specified [layout], sharing the data with [a] (and hence having
+      the same dimensions as [a]). No copying of elements is involved: the
+      new array and the original array share the same storage space. *)
+   
   val size_in_bytes : ('a, 'b, 'c) t -> int
   (** [size_in_bytes a] is the number of elements in [a] multiplied
     by [a]'s {!kind_size_in_bytes}.

--- a/otherlibs/bigarray/bigarray_stubs.c
+++ b/otherlibs/bigarray/bigarray_stubs.c
@@ -1090,7 +1090,7 @@ CAMLprim value caml_ba_change_layout(value vb, value vlayout)
     /* change the flags to reflect the new layout */
     int flags = (b->flags & CAML_BA_KIND_MASK) | Caml_ba_layout_val(vlayout);
     /* reverse the dimensions */
-    intnat new_dim[b->num_dims];
+    intnat new_dim[CAML_BA_MAX_NUM_DIMS];
     unsigned int i;
     for(i = 0; i < b->num_dims; i++) new_dim[i] = b->dim[b->num_dims - i - 1];
     res = caml_ba_alloc(flags, b->num_dims, b->data, new_dim);

--- a/otherlibs/bigarray/bigarray_stubs.c
+++ b/otherlibs/bigarray/bigarray_stubs.c
@@ -1085,23 +1085,24 @@ CAMLprim value caml_ba_change_layout(value vb, value vlayout)
   CAMLparam2 (vb, vlayout);
   CAMLlocal1 (res);
   #define b ((struct caml_ba_array *) Caml_ba_array_val(vb))
-  unsigned int i;
-  intnat new_dim[b->num_dims];
-  /* change the flags to reflect the new layout */
-  int flags = (b->flags & CAML_BA_KIND_MASK) | Caml_ba_layout_val(vlayout);
-  /* if the layout is different, reverse the dimensions */
+  /* if the layout is different, change the flags and reverse the dimensions */
   if (Caml_ba_layout_val(vlayout) != (b->flags & CAML_BA_LAYOUT_MASK)) {
-    for(i=0;i<b->num_dims;i++) new_dim[i] = b->dim[b->num_dims-i-1];
+    /* change the flags to reflect the new layout */
+    int flags = (b->flags & CAML_BA_KIND_MASK) | Caml_ba_layout_val(vlayout);
+    /* reverse the dimensions */
+    intnat new_dim[b->num_dims];
+    unsigned int i;
+    for(i = 0; i < b->num_dims; i++) new_dim[i] = b->dim[b->num_dims - i - 1];
     res = caml_ba_alloc(flags, b->num_dims, b->data, new_dim);
+    caml_ba_update_proxy(b, Caml_ba_array_val(res));
+    CAMLreturn(res);
   } else {
-    res = caml_ba_alloc(flags, b->num_dims, b->data, b->dim);
+  /* otherwise, do nothing */  
+  CAMLreturn(vb);
   }
-  /* Create or update proxy in case of managed bigarray */
-  caml_ba_update_proxy(b, Caml_ba_array_val(res));
-  /* Return result */
-  CAMLreturn (res);
   #undef b
 }
+
 
 /* Extracting a sub-array of same number of dimensions */
 

--- a/otherlibs/bigarray/bigarray_stubs.c
+++ b/otherlibs/bigarray/bigarray_stubs.c
@@ -1077,7 +1077,25 @@ CAMLprim value caml_ba_slice(value vb, value vind)
 
   #undef b
 }
+    
+/* Changing the layout of an array (memory is shared) */    
 
+CAMLprim value caml_ba_change_layout(value vb, value vlayout)
+{
+  CAMLparam2 (vb, vlayout);
+  CAMLlocal1 (res);
+  #define b ((struct caml_ba_array *) Caml_ba_array_val(vb))
+  /* change to the desired layout */
+  int flags = (b->flags & CAML_BA_KIND_MASK) | Caml_ba_layout_val(vlayout);
+  /* Allocate an OCaml bigarray to hold the result */
+  res = caml_ba_alloc(flags, b->num_dims, b->data, b->dim);
+  /* Create or update proxy in case of managed bigarray */
+  caml_ba_update_proxy(b, Caml_ba_array_val(res));
+  /* Return result */
+  CAMLreturn (res);
+  #undef b
+}
+ 
 /* Extracting a sub-array of same number of dimensions */
 
 CAMLprim value caml_ba_sub(value vb, value vofs, value vlen)

--- a/otherlibs/bigarray/bigarray_stubs.c
+++ b/otherlibs/bigarray/bigarray_stubs.c
@@ -1085,17 +1085,24 @@ CAMLprim value caml_ba_change_layout(value vb, value vlayout)
   CAMLparam2 (vb, vlayout);
   CAMLlocal1 (res);
   #define b ((struct caml_ba_array *) Caml_ba_array_val(vb))
-  /* change to the desired layout */
+  unsigned int i;
+  intnat new_dim[b->num_dims];
+  /* change the flags to reflect the new layout */
   int flags = (b->flags & CAML_BA_KIND_MASK) | Caml_ba_layout_val(vlayout);
-  /* Allocate an OCaml bigarray to hold the result */
-  res = caml_ba_alloc(flags, b->num_dims, b->data, b->dim);
+  /* if the layout is different, reverse the dimensions */
+  if (Caml_ba_layout_val(vlayout) != (b->flags & CAML_BA_LAYOUT_MASK)) {
+    for(i=0;i<b->num_dims;i++) new_dim[i] = b->dim[b->num_dims-i-1];
+    res = caml_ba_alloc(flags, b->num_dims, b->data, new_dim);
+  } else {
+    res = caml_ba_alloc(flags, b->num_dims, b->data, b->dim);
+  }
   /* Create or update proxy in case of managed bigarray */
   caml_ba_update_proxy(b, Caml_ba_array_val(res));
   /* Return result */
   CAMLreturn (res);
   #undef b
 }
- 
+
 /* Extracting a sub-array of same number of dimensions */
 
 CAMLprim value caml_ba_sub(value vb, value vofs, value vlen)


### PR DESCRIPTION
This small addition enables sharing of bigarrays between libraries that assume different layouts (currently impossible without copying data!). Examples include using lacaml vectors (Fortran) in gsl routines (C). Cf. previous ticket on Mantis: http://caml.inria.fr/mantis/print_bug_page.php?bug_id=4834
