### PR TITLE
Adding a new field to record `formatter_out_functions` to redefine the meaning of indentation

### DIFF
--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -31,15 +31,15 @@ external int_of_size : size -> int = "%identity"
 
 (* The pretty-printing boxes definition:
    a pretty-printing box is either
-   - hbox: horizontal (no split in the line)
-   - vbox: vertical (the line is splitted at every break hint)
-   - hvbox: horizontal/vertical
+   - hbox: horizontal box (no line splitting)
+   - vbox: vertical box (every break hint splits the line)
+   - hvbox: horizontal/vertical box
      (the box behaves as an horizontal box if it fits on
       the current line, otherwise the box behaves as a vertical box)
-   - hovbox: horizontal or vertical
-     (the box is compacting material, printing as much material on every
-     lines)
-   - box: horizontal or vertical with box enhanced structure
+   - hovbox: horizontal or vertical compacting box
+     (the box is compacting material, printing as much material as possible
+      on every lines)
+   - box: horizontal or vertical compacting box with enhanced box structure
      (the box behaves as an horizontal or vertical box but break hints split
       the line if splitting would move to the left)
 *)
@@ -667,7 +667,6 @@ let pp_rinit state =
   state.pp_space_left <- state.pp_margin;
   pp_open_sys_box state
 
-
 (* Flushing pretty-printer queue. *)
 let pp_flush_queue state b =
   while state.pp_curr_depth > 1 do
@@ -677,7 +676,6 @@ let pp_flush_queue state b =
   advance_left state;
   if b then pp_output_newline state;
   pp_rinit state
-
 
 (*
 
@@ -722,9 +720,14 @@ and pp_open_hovbox state indent = pp_open_box_gen state indent Pp_hovbox
 and pp_open_box state indent = pp_open_box_gen state indent Pp_box
 
 
-(* Printing all queued text.
-   [print_newline] prints a new line after flushing the queue.
-   [print_flush] on flush the queue without adding a newline. *)
+(* Printing queued text.
+
+   [pp_print_flush] prints all pending items in the pretty-printer queue and
+   then flushes the the low level output device of the formatter to effectively
+   display printing material.
+
+   [pp_print_newline] behaves as [pp_print_flush] after printing an additional
+   new line. *)
 let pp_print_newline state () =
   pp_flush_queue state true; state.pp_out_flush ()
 and pp_print_flush state () =
@@ -1294,7 +1297,6 @@ let pp_set_all_formatter_output_functions state
   pp_set_formatter_output_functions state f g;
   state.pp_out_newline <- h;
   state.pp_out_spaces <- i
-
 
 (* Deprecated : subsumed by pp_get_formatter_out_functions *)
 let pp_get_all_formatter_output_functions state () =

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -186,7 +186,8 @@ val print_bool : bool -> unit
 (** {6 Break hints} *)
 
 (** A 'break hint' tells the pretty-printer to output some space or split the
-  line whichever way is more appropriate to the current pretty-printing box splitting rules.
+  line whichever way is more appropriate to the current pretty-printing box
+  splitting rules.
 
   Break hints are used to separate printing items and are mandatory to let
   the pretty-printer correctly split lines and indent items.
@@ -308,8 +309,8 @@ val get_max_indent : unit -> int
 (** {6 Formatting depth: maximum number of pretty-printing boxes allowed before ellipsis} *)
 
 val set_max_boxes : int -> unit
-(** [set_max_boxes max] sets the maximum number of pretty-printing boxes simultaneously
-  open.
+(** [set_max_boxes max] sets the maximum number of pretty-printing boxes
+  simultaneously open.
   Material inside boxes nested deeper is printed as an ellipsis (more
   precisely as the text returned by [get_ellipsis_text ()]).
   Nothing happens if [max] is smaller than 2.
@@ -319,7 +320,8 @@ val get_max_boxes : unit -> int
 (** Returns the maximum number of pretty-printing boxes allowed before ellipsis. *)
 
 val over_max_boxes : unit -> bool
-(** Tests if the maximum number of pretty-printing boxes allowed have already been open. *)
+(** Tests if the maximum number of pretty-printing boxes allowed have already
+    been open.  *)
 
 (** {6 Ellipsis} *)
 
@@ -458,51 +460,72 @@ val set_formatter_output_functions :
 
   The [flush] function is called whenever the pretty-printer is flushed
   (via conversion [%!], or pretty-printing indications [@?] or [@.], or
-  using low level functions [print_flush] or [print_newline]). *)
+  using low level functions [print_flush] or [print_newline]).
+*)
 
 val get_formatter_output_functions :
   unit -> (string -> int -> int -> unit) * (unit -> unit)
 (** Return the current output functions of the pretty-printer. *)
 
-(** {6:meaning Changing the meaning of standard formatter pretty printing} *)
+(** {6:meaning Changing the meaning of formatter ouput} *)
 
 (** The [Format] module is versatile enough to let you completely redefine
-  the meaning of pretty printing: you may provide your own functions to define
+  the meaning of pretty-printing: you may provide your own functions to define
   how to handle indentation, line splitting, and even printing of all the
-  characters that have to be printed! *)
+  characters that have to be printed!
+*)
 
 type formatter_out_functions = {
   out_string : string -> int -> int -> unit;
   out_flush : unit -> unit;
   out_newline : unit -> unit;
   out_spaces : int -> unit;
-} (** @since 4.01.0 *)
+  out_indent : int -> unit;
+}
+(** The set of output functions specific to a formatter:
+- the [out_string] function performs all the pretty-printer string output.
+  It is called with a string [s], a start position [p], and a number of
+  characters [n]; it is supposed to output characters [p] to [p + n - 1] of
+  [s].
+- the [out_flush] function flushes the pretty-printer output device.
+- [out_newline] is called to open a new line when the pretty-printer splits
+  the line.
+- the [out_spaces] function outputs spaces when a break hint leads to spaces
+  instead of a line split. It is called with the number of spaces to output.
+- the [out_indent] function performs new line indentation when the
+  pretty-printer splits the line. It is called with the indentation value of
+  the new line.
+
+  By default:
+- fields [out_string] and [out_flush] are output device specific;
+  (e.g. [Pervasives.output_string] and [Pervasives.flush] for a
+   [Pervasives.out_channel] device, or [Buffer.add_substring] and
+   [Pervasives.ignore] for a [Buffer.t] output device),
+- field [out_newline] is equivalent to [out_string "\n" 0 1];
+- field [out_spaces] is equivalent to [out_string (String.make n ' ') 0 n];
+- field [out_indent] is the same as field [out_spaces].
+*)
 
 val set_formatter_out_functions : formatter_out_functions -> unit
-(** [set_formatter_out_functions f]
-  Redirect the pretty-printer output to the functions [f.out_string]
-  and [f.out_flush] as described in
-  [set_formatter_output_functions]. In addition, the pretty-printer function
-  that outputs a newline is set to the function [f.out_newline] and
-  the function that outputs indentation spaces is set to the function
-  [f.out_spaces].
+(** [set_formatter_out_functions out_funs]
+  Set all the pretty-printer output functions to those of argument
+  [out_funs],
 
   This way, you can change the meaning of indentation (which can be
   something else than just printing space characters) and the meaning of new
   lines opening (which can be connected to any other action needed by the
-  application at hand). The two functions [f.out_spaces] and [f.out_newline]
-  are normally connected to [f.out_string] and [f.out_flush]: respective
-  default values for [f.out_space] and [f.out_newline] are
-  [f.out_string (String.make n ' ') 0 n] and [f.out_string "\n" 0 1].
-  @since 4.01.0 *)
+  application at hand).
+*)
+
 
 val get_formatter_out_functions : unit -> formatter_out_functions
 (** Return the current output functions of the pretty-printer,
   including line splitting and indentation functions. Useful to record the
   current setting and restore it afterwards.
-  @since 4.01.0 *)
+*)
 
-(** {6:tagsmeaning Changing the meaning of printing semantic tags} *)
+
+(** {6:tagsmeaning Changing the semantic tags operations} *)
 
 type formatter_tag_functions = {
   mark_open_tag : tag -> string;
@@ -611,7 +634,8 @@ val formatter_of_out_functions :
   formatter_out_functions -> formatter
 (** [formatter_of_out_functions out_funs] returns a new formatter that writes
   according to the set of output functions [out_funs].
-  See definition of type {!formatter_out_functions} for the meaning of argument [out_funs].
+  See definition of type {!formatter_out_functions} for the meaning of argument
+  [out_funs].
   @since 4.04.0
 *)
 

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -147,6 +147,9 @@ module Compiler_messages = struct
 end
 
 let collect_formatters buf pps ~f =
+  let ppb = Format.formatter_of_buffer buf in
+  let out_functions = Format.pp_get_formatter_out_functions ppb () in
+
   List.iter (fun pp -> Format.pp_print_flush pp ()) pps;
   let save =
     List.map (fun pp -> Format.pp_get_formatter_out_functions pp ()) pps
@@ -157,13 +160,6 @@ let collect_formatters buf pps ~f =
          Format.pp_print_flush pp ();
          Format.pp_set_formatter_out_functions pp out_functions)
       pps save
-  in
-  let out_string str ofs len = Buffer.add_substring buf str ofs len
-  and out_flush = ignore
-  and out_newline () = Buffer.add_char buf '\n'
-  and out_spaces n = for i = 1 to n do Buffer.add_char buf ' ' done in
-  let out_functions =
-    { Format.out_string; out_flush; out_newline; out_spaces }
   in
   List.iter
     (fun pp -> Format.pp_set_formatter_out_functions pp out_functions)


### PR DESCRIPTION
All output of the pretty-printer were abstracted in record `formatter_out_functions` except for indentation which was linked to output spaces. Indentation could be more complex than simply adding spaces at begining of lines.
The expected impact to existing software should be minimal.

Documentation has been update and carefully checked.
