### PR TITLE
Fixes for README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,23 +3,22 @@
 == Overview
 
 OCaml is an implementation of the ML language, based on the Caml Light
-dialect extended with a complete class-based object system and a
-powerful module system in the style of Standard ML.
+dialect extended with a complete class-based object system and a powerful
+module system in the style of Standard ML.
 
 OCaml comprises two compilers. One generates bytecode which is then
-interpreted by a C program. This compiler runs quickly, generates
-compact code with moderate memory requirements, and is portable to
-essentially any 32 or 64 bit Unix platform. Performance of generated
-programs is quite good for a bytecoded implementation.  This compiler
-can be used either as a standalone, batch-oriented compiler that
-produces standalone programs, or as an interactive, toplevel-based
-system.
+interpreted by a C program. This compiler runs quickly, generates compact
+code with moderate memory requirements, and is portable to essentially any
+32 or 64 bit Unix platform. Performance of generated programs is quite good
+for a bytecoded implementation.  This compiler can be used either as a
+standalone, batch-oriented compiler that produces standalone programs, or as
+an interactive, toplevel-based system.
 
-The other compiler generates high-performance native code for a number
-of processors. Compilation takes longer and generates bigger code, but
-the generated programs deliver excellent performance, while retaining
-the moderate memory requirements of the bytecode compiler. The
-native-code compiler currently runs on the following platforms:
+The other compiler generates high-performance native code for a number of
+processors. Compilation takes longer and generates bigger code, but the
+generated programs deliver excellent performance, while retaining the
+moderate memory requirements of the bytecode compiler. The native-code
+compiler currently runs on the following platforms:
 
 Tier 1 (actively used and maintained by the core OCaml team):
 
@@ -36,13 +35,13 @@ PowerPC::            NetBSD
 ARM::                NetBSD
 SPARC::              Solaris, Linux, NetBSD
 
-Other operating systems for the processors above have not been tested,
-but the compiler may work under other operating systems with little work.
+Other operating systems for the processors above have not been tested, but
+the compiler may work under other operating systems with little work.
 
-Before the introduction of objects, OCaml was known as Caml Special
-Light. OCaml is almost upwards compatible with Caml Special Light,
-except for a few additional reserved keywords that have forced some
-renaming of standard library functions.
+Before the introduction of objects, OCaml was known as Caml Special Light.
+OCaml is almost upwards compatible with Caml Special Light, except for a few
+additional reserved keywords that have forced some renaming of standard
+library functions.
 
 == Contents
 
@@ -89,11 +88,11 @@ renaming of standard library functions.
 
 == Copyright
 
-All files marked "Copyright INRIA" in this distribution are copyright
-1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006,
-2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Institut
-National de Recherche en Informatique et en Automatique (INRIA) and
-distributed under the conditions stated in file LICENSE.
+All files marked "Copyright INRIA" in this distribution are copyright 1996,
+1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008,
+2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Institut National de
+Recherche en Informatique et en Automatique (INRIA) and distributed under
+the conditions stated in file LICENSE.
 
 == Installation
 
@@ -103,8 +102,8 @@ link:README.win32.adoc[].
 
 == Documentation
 
-The OCaml manual is distributed in HTML, PDF, Postscript, DVI, and
-Emacs Info files.  It is available at
+The OCaml manual is distributed in HTML, PDF, Postscript, DVI, and Emacs
+Info files.  It is available at
 
 http://caml.inria.fr/
 
@@ -119,11 +118,11 @@ http://caml.inria.fr/
 
 == Keeping in Touch with the Caml Community
 
-There exists a mailing list of users of the OCaml implementations
-developed at INRIA. The purpose of this list is to share
-experience, exchange ideas (and even code), and report on applications
-of the OCaml language. Messages can be written in English or in
-French. The list has more than 1000 subscribers.
+There exists a mailing list of users of the OCaml implementations developed
+at INRIA. The purpose of this list is to share experience, exchange ideas
+(and even code), and report on applications of the OCaml language. Messages
+can be written in English or in French. The list has more than 1000
+subscribers.
 
 Messages to the list should be sent to:
 
@@ -135,20 +134,20 @@ https://sympa.inria.fr/sympa/subscribe/caml-list
 
 Archives of the list are available on the Web site above.
 
-The Usenet news `groups comp.lang.ml` and `comp.lang.functional`
-also contains discussions about the ML family of programming languages,
-including OCaml.
+The Usenet news `groups comp.lang.ml` and `comp.lang.functional` also
+contains discussions about the ML family of programming languages, including
+OCaml.
 
 The IRC channel `#ocaml` on https://freenode.net/[Freenode] also has several
 hundred users and welcomes questions.
 
 == Bug Reports and User Feedback
 
-Please report bugs using the Web interface to the bug-tracking system
-at http://caml.inria.fr/bin/caml-bugs
+Please report bugs using the Web interface to the bug-tracking system at
+http://caml.inria.fr/bin/caml-bugs
 
-To be effective, bug reports should include a complete program
-(preferably small) that exhibits the unexpected behavior, and the
-configuration you are using (machine type, etc).
+To be effective, bug reports should include a complete program (preferably
+small) that exhibits the unexpected behavior, and the configuration you are
+using (machine type, etc).
 
 You can also contact the implementors directly at mailto:caml@inria.fr[].

--- a/README.adoc
+++ b/README.adoc
@@ -45,8 +45,6 @@ library functions.
 
 == Contents
 
-  appveyor.yml::          configuration for appveyor CI
-  appveyor_build.sh::     appveyor CI script
   Changes::               what's new with each release
   configure::             configure script
   CONTRIBUTING.md::       how to contribute to OCaml
@@ -140,6 +138,10 @@ OCaml.
 
 The IRC channel `#ocaml` on https://freenode.net/[Freenode] also has several
 hundred users and welcomes questions.
+
+The OCaml Community website is
+
+http://ocaml.org/
 
 == Bug Reports and User Feedback
 

--- a/README.adoc
+++ b/README.adoc
@@ -46,26 +46,41 @@ renaming of standard library functions.
 
 == Contents
 
+  appveyor.yml::          configuration for appveyor CI
+  appveyor_build.sh::     appveyor CI script
   Changes::               what's new with each release
+  configure::             configure script
+  CONTRIBUTING.md::       how to contribute to OCaml
   INSTALL.adoc::          instructions for installation
   LICENSE::               license and copyright notice
   Makefile::              main Makefile
+  Makefile.nt::           MS Windows Makefile
+  Makefile.shared::       common Makefile
+  Makefile.tools::        used by manual/ and testsuite/ Makefiles
   README.adoc::           this file
   README.win32.adoc::     info on the MS Windows ports of OCaml
+  VERSION::               version string
   asmcomp/::              native-code compiler and linker
   asmrun/::               native-code runtime library
   boot/::                 bootstrap compiler
   bytecomp/::             bytecode compiler and linker
   byterun/::              bytecode interpreter and runtime system
+  compilerlibs/::         the OCaml compiler as a library
   config/::               autoconfiguration stuff
   debugger/::             source-level replay debugger
   driver/::               driver code for the compilers
   emacs/::                editing mode and debugger interface for GNU Emacs
+  experimental/::         experiments not built by default
+  flexdll/::              empty (see README.win32.adoc)
   lex/::                  lexer generator
+  man/::                  man pages
+  manual/::               system to generate the manual
+  middle_end/::           the flambda optimisation phase
   ocamldoc/::             documentation generator
   otherlibs/::            several external libraries
   parsing/::              syntax analysis
   stdlib/::               standard library
+  testsuite/::            tests
   tools/::                various utilities
   toplevel/::             interactive system
   typing/::               typechecking

--- a/README.adoc
+++ b/README.adoc
@@ -106,7 +106,7 @@ Info files.  It is available at
 http://caml.inria.fr/
 
 The community also maintains the Web site http://ocaml.org, with tutorials
-and other useful informations for OCaml users.
+and other useful information for OCaml users.
 
 == Availability
 

--- a/README.adoc
+++ b/README.adoc
@@ -151,3 +151,5 @@ small) that exhibits the unexpected behavior, and the configuration you are
 using (machine type, etc).
 
 You can also contact the implementors directly at mailto:caml@inria.fr[].
+
+For information on contributing to OCaml, see the file CONTRIBUTING.md.

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = README =
 
-== OVERVIEW
+== Overview
 
 OCaml is an implementation of the ML language, based on the Caml Light
 dialect extended with a complete class-based object system and a
@@ -44,14 +44,14 @@ Light. OCaml is almost upwards compatible with Caml Special Light,
 except for a few additional reserved keywords that have forced some
 renaming of standard library functions.
 
-== CONTENTS
+== Contents
 
   Changes::               what's new with each release
   INSTALL.adoc::          instructions for installation
   LICENSE::               license and copyright notice
   Makefile::              main Makefile
   README.adoc::           this file
-  README.win32.adoc::     infos on the MS Windows ports of OCaml
+  README.win32.adoc::     info on the MS Windows ports of OCaml
   asmcomp/::              native-code compiler and linker
   asmrun/::               native-code runtime library
   boot/::                 bootstrap compiler
@@ -72,21 +72,21 @@ renaming of standard library functions.
   utils/::                utility libraries
   yacc/::                 parser generator
 
-== COPYRIGHT
+== Copyright
 
 All files marked "Copyright INRIA" in this distribution are copyright
 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006,
-2007, 2008, 2009, 2010, 2011, 2012 Institut National de Recherche en
-Informatique et en Automatique (INRIA) and distributed under the
-conditions stated in file LICENSE.
+2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Institut
+National de Recherche en Informatique et en Automatique (INRIA) and
+distributed under the conditions stated in file LICENSE.
 
-== INSTALLATION
+== Installation
 
 See the file INSTALL for installation instructions on machines running Unix,
 Linux, OS X and Cygwin.  For native Microsoft Windows, see
 link:README.win32.adoc[].
 
-== DOCUMENTATION
+== Documentation
 
 The OCaml manual is distributed in HTML, PDF, Postscript, DVI, and
 Emacs Info files.  It is available at
@@ -96,13 +96,13 @@ http://caml.inria.fr/
 The community also maintains the Web site http://ocaml.org, with tutorials
 and other useful informations for OCaml users.
 
-== AVAILABILITY
+== Availability
 
 The complete OCaml distribution can be accessed at
 
 http://caml.inria.fr/
 
-== KEEPING IN TOUCH WITH THE CAML COMMUNITY
+== Keeping in Touch with the Caml Community
 
 There exists a mailing list of users of the OCaml implementations
 developed at INRIA. The purpose of this list is to share
@@ -127,7 +127,7 @@ including OCaml.
 The IRC channel `#ocaml` on https://freenode.net/[Freenode] also has several
 hundred users and welcomes questions.
 
-== BUG REPORTS AND USER FEEDBACK
+== Bug Reports and User Feedback
 
 Please report bugs using the Web interface to the bug-tracking system
 at http://caml.inria.fr/bin/caml-bugs


### PR DESCRIPTION
As per the discussion in #543.

Decision on moving the "Contents" section into CONTRIBUTING.md or starting a separate HACKING.md postponed.
