### PR TITLE
Reject conflicts in parsing/parser.mly

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -29,7 +29,7 @@ COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-41-42-44-45-48 -warn-er
           -bin-annot -safe-string -strict-formats $(INCLUDES)
 LINKFLAGS=
 
-YACCFLAGS=-v -e
+YACCFLAGS=-v --strict
 CAMLLEX=$(CAMLRUN) boot/ocamllex
 CAMLDEP=$(CAMLRUN) tools/ocamldep
 DEPFLAGS=$(INCLUDES)

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -29,7 +29,7 @@ COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-41-42-44-45-48 -warn-er
           -bin-annot -safe-string -strict-formats $(INCLUDES)
 LINKFLAGS=
 
-YACCFLAGS=-v
+YACCFLAGS=-v -e
 CAMLLEX=$(CAMLRUN) boot/ocamllex
 CAMLDEP=$(CAMLRUN) tools/ocamldep
 DEPFLAGS=$(INCLUDES)

--- a/man/ocamlyacc.m
+++ b/man/ocamlyacc.m
@@ -79,6 +79,9 @@ instead of the default naming convention.
 .B \-q
 This option has no effect.
 .TP
+.B \-e
+Reject grammars with conflicts.
+.TP
 .B \-v
 Generate a description of the parsing tables and a report on conflicts
 resulting from ambiguities in the grammar. The description is put in

--- a/man/ocamlyacc.m
+++ b/man/ocamlyacc.m
@@ -79,7 +79,7 @@ instead of the default naming convention.
 .B \-q
 This option has no effect.
 .TP
-.B \-e
+.B \--strict
 Reject grammars with conflicts.
 .TP
 .B \-v

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -210,6 +210,7 @@ extern char tflag;
 extern char vflag;
 extern char qflag;
 extern char sflag;
+extern char eflag;
 extern char big_endian;
 
 extern char *myname;
@@ -335,6 +336,7 @@ extern void output (void);
 extern void over_unionized (char *u_cptr) Noreturn;
 extern void prec_redeclared (void);
 extern void polymorphic_entry_point(char *s) Noreturn;
+extern void forbidden_conflicts (void);
 extern void reader (void);
 extern void reflexive_transitive_closure (unsigned int *R, int n);
 extern void reprec_warning (char *s);

--- a/yacc/error.c
+++ b/yacc/error.c
@@ -317,7 +317,7 @@ void polymorphic_entry_point(char *s)
 void forbidden_conflicts(void)
 {
     fprintf(stderr,
-            "%s: the grammar has conflicts, but -e was specified\n",
+            "%s: the grammar has conflicts, but --strict was specified\n",
             myname);
     done(1);
 }

--- a/yacc/error.c
+++ b/yacc/error.c
@@ -313,3 +313,11 @@ void polymorphic_entry_point(char *s)
             myname, s);
     done(1);
 }
+
+void forbidden_conflicts(void)
+{
+    fprintf(stderr,
+            "%s: the grammar has conflicts, but -e was specified\n",
+            myname);
+    done(1);
+}

--- a/yacc/main.c
+++ b/yacc/main.c
@@ -161,7 +161,7 @@ void set_signals(void)
 
 void usage(void)
 {
-    fprintf(stderr, "usage: %s [-v] [-e] [-q] [-b file_prefix] filename\n",
+    fprintf(stderr, "usage: %s [-v] [--strict] [-q] [-b file_prefix] filename\n",
             myname);
     exit(1);
 }
@@ -185,6 +185,10 @@ void getargs(int argc, char **argv)
             return;
 
         case '-':
+            if (!strcmp (argv[i], "--strict")){
+              eflag = 1;
+              goto end_of_option;
+            }
             ++i;
             goto no_more_options;
 
@@ -212,10 +216,6 @@ void getargs(int argc, char **argv)
                 file_prefix = argv[i];
             else
                 usage();
-            continue;
-
-        case 'e':
-            eflag = 1;
             continue;
 
         default:

--- a/yacc/main.c
+++ b/yacc/main.c
@@ -30,6 +30,7 @@ char rflag;
 char tflag;
 char vflag;
 char qflag;
+char eflag;
 char sflag;
 char big_endian;
 
@@ -160,7 +161,7 @@ void set_signals(void)
 
 void usage(void)
 {
-    fprintf(stderr, "usage: %s [-v] [-q] [-b file_prefix] filename\n",
+    fprintf(stderr, "usage: %s [-v] [-e] [-q] [-b file_prefix] filename\n",
             myname);
     exit(1);
 }
@@ -211,6 +212,10 @@ void getargs(int argc, char **argv)
                 file_prefix = argv[i];
             else
                 usage();
+            continue;
+
+        case 'e':
+            eflag = 1;
             continue;
 
         default:

--- a/yacc/mkpar.c
+++ b/yacc/mkpar.c
@@ -47,7 +47,11 @@ void make_parser(void)
     find_final_state();
     remove_conflicts();
     unused_rules();
-    if (SRtotal + RRtotal > 0) total_conflicts();
+    if (SRtotal + RRtotal > 0) {
+        total_conflicts();
+        if (eflag)
+            forbidden_conflicts();
+    }
     defreds();
 }
 


### PR DESCRIPTION
In current ocaml `trunk` the grammar in `parsing/parser.mly` has a number of reduce/reduce conflicts:

```
boot/ocamlyacc -v -e parsing/parser.mly
1 rule never reduced
126 reduce/reduce conflicts.
```

Unfortunately, it's currently quite easy to inadvertently introduce conflicts, since they're not treated as errors.

This pull request
- adds a new option, `-e` to `ocamlyacc` that treats a conflict in a grammar as a fatal error, and
- updates the Makefile to pass `-e` when compiling `parsing/parser.mly`.

Consequently, this PR intentionally breaks the build, which should now fail at the point where the parser is compiled. 
