### PR TITLE
Fix the reduce/reduce conflicts in the grammar

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1811,7 +1811,8 @@ simple_pattern_not_ident:
   | mod_longident DOT simple_delimited_pattern
       { mkpat @@ Ppat_open(mkrhs $1 1, $3) }
   | mod_longident DOT LBRACKET RBRACKET
-    { mkpat @@ Ppat_construct ( mkrhs (Lident "[]") 1, None) }
+    { mkpat @@ Ppat_open(mkrhs $1 1, mkpat @@
+               Ppat_construct ( mkrhs (Lident "[]") 4, None)) }
   | mod_longident DOT LPAREN RPAREN
       { mkpat @@ Ppat_open( mkrhs $1 1, mkpat @@
                  Ppat_construct ( mkrhs (Lident "()") 4, None) ) }

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1751,12 +1751,6 @@ pattern:
       { expecting 3 "pattern" }
   | EXCEPTION ext_attributes pattern %prec prec_constr_appl
       { mkpat_attrs (Ppat_exception $3) $2}
-  | mod_longident DOT LPAREN pattern RPAREN
-    { mkpat @@ Ppat_open (mkrhs $1 1, $4)}
-  | mod_longident DOT LPAREN pattern error
-    {unclosed "(" 3 ")" 5  }
-  | mod_longident DOT LPAREN error
-    { expecting 4 "pattern" }
   | pattern attribute
       { Pat.attr $1 $2 }
   | pattern_gen { $1 }
@@ -1816,6 +1810,8 @@ simple_pattern_not_ident:
       { $1 }
   | mod_longident DOT simple_delimited_pattern
       { mkpat @@ Ppat_open(mkrhs $1 1, $3) }
+  | mod_longident DOT LBRACKET RBRACKET
+    { mkpat @@ Ppat_construct ( mkrhs (Lident "[]") 1, None) }
   | mod_longident DOT LPAREN RPAREN
       { mkpat @@ Ppat_open( mkrhs $1 1, mkpat @@
                  Ppat_construct ( mkrhs (Lident "()") 4, None) ) }
@@ -1847,17 +1843,14 @@ simple_pattern_not_ident:
   | extension
       { mkpat(Ppat_extension $1) }
 ;
+
 simple_delimited_pattern:
   | LBRACE lbl_pattern_list RBRACE
     { let (fields, closed) = $2 in mkpat(Ppat_record(fields, closed)) }
   | LBRACE lbl_pattern_list error
     { unclosed "{" 1 "}" 3 }
-  | LBRACE lbl_pattern_list error
-    { unclosed "{" 1 "}" 3 }
   | LBRACKET pattern_semi_list opt_semi RBRACKET
     { reloc_pat (mktailpat (rhs_loc 4) (List.rev $2)) }
-  | LBRACKET RBRACKET
-    { mkpat @@ Ppat_construct ( mkrhs (Lident "[]") 1, None) }
   | LBRACKET pattern_semi_list opt_semi error
     { unclosed "[" 1 "]" 4 }
   | LBRACKETBAR pattern_semi_list opt_semi BARRBRACKET


### PR DESCRIPTION
This pull request fixes the conflicts in the grammar in the current trunk.  The present status of `parsing/parser.mly` is as follows:

```
boot/ocamlyacc -v -e parsing/parser.mly
1 rule never reduced
126 reduce/reduce conflicts.
```

Happily, the conflicts all have straightforward resolutions.  The changes are as follows:
- The following productions are removed:
  
  ```
  pattern -> mod_longident DOT LPAREN pattern RPAREN
  pattern -> mod_longident DOT LPAREN pattern error
  pattern -> mod_longident DOT LPAREN error
  ```
  
  These productions are redundant because the RHSs can be generated via different routes:
  
  ```
  pattern ->
   pattern_gen ->
     simple_pattern ->
        simple_pattern_not_ident ->
           mod_longident DOT LPAREN pattern RPAREN
  ```
  
  (etc.)
- The following duplication is removed:
  
  ```
  simple_delimited_pattern -> LBRACE lbl_pattern_list error
  simple_delimited_pattern -> LBRACE lbl_pattern_list error
  ```
- The following redundancy
  
  ```
  simple_pattern_not_ident ->
    simple_delimited_pattern ->
       LBRACKET RBRACKET
  simple_pattern_not_ident ->
    constr_longident ->
       LBRACKET RBRACKET
  ```
  
  is replaced by removing the first production and adding a new production for qualified `[]` patterns:
  
  ```
  simple_pattern_not_ident -> mod_longident DOT LBRACKET RBRACKET
  ```
