### PR TITLE
Ensure that register typing constraints are respected (again)

### DIFF
--- a/Changes
+++ b/Changes
@@ -86,6 +86,9 @@ OCaml 4.04.0:
 
 - PR#7112: Aliased arguments ignored for equality of module types
 
+- GPR#600: (similar to GPR#555) ensure that register typing constraints are
+  respected at N-way join points in the control flow graph (Mark Shinwell)
+
 ### Other libraries:
 
 * GPR#533: Thread library: fixed [Thread.wait_signal] so that it

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -142,15 +142,24 @@ let join_array rs =
   let some_res = ref None in
   for i = 0 to Array.length rs - 1 do
     let (r, _) = rs.(i) in
-    if r <> None then some_res := r
+    match r with
+    | None -> ()
+    | Some r ->
+      match !some_res with
+      | None -> some_res := Some (r, Array.map (fun r -> r.typ) r)
+      | Some (r', types) ->
+        let types =
+          Array.map2 (fun r typ -> Cmm.lub_component r.typ typ) r types
+        in
+        some_res := Some (r', types)
   done;
   match !some_res with
     None -> None
-  | Some template ->
+  | Some (template, types) ->
       let size_res = Array.length template in
       let res = Array.make size_res Reg.dummy in
       for i = 0 to size_res - 1 do
-        res.(i) <- Reg.create template.(i).typ
+        res.(i) <- Reg.create types.(i)
       done;
       for i = 0 to Array.length rs - 1 do
         let (r, s) = rs.(i) in

--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -47,7 +47,8 @@ parsecmm.mli parsecmm.ml: parsecmm.mly
 lexcmm.ml: lexcmm.mll
 	@$(OCAMLLEX) -q lexcmm.mll
 
-MLCASES=optargs staticalloc bind_tuples is_static register_typing
+MLCASES=optargs staticalloc bind_tuples is_static register_typing \
+  register_typing_switch
 ARGS_is_static=-I $(OTOPDIR)/byterun is_in_static_data.c
 MLCASES_FLAMBDA=is_static_flambda unrolling_flambda
 ARGS_is_static_flambda=-I $(OTOPDIR)/byterun is_in_static_data.c

--- a/testsuite/tests/asmcomp/register_typing_switch.ml
+++ b/testsuite/tests/asmcomp/register_typing_switch.ml
@@ -1,0 +1,21 @@
+type 'a typ = Int : int typ | Ptr : int list typ | Int2 : int typ
+
+let f (type a) (t : a typ) (p : int list) : a =
+  match t with
+  | Int -> 100
+  | Ptr -> p
+  | Int2 -> 200
+
+let allocate_garbage () =
+  for i = 0 to 100 do
+    ignore (Array.make 200 0.0)
+  done
+
+let g (t : int list typ) x =
+  Gc.minor ();
+  let x = f t ([x; x; x; x; x]) in
+  Gc.minor ();
+  allocate_garbage ();
+  ignore (String.length (String.concat " " (List.map string_of_int x)))
+
+let () = g Ptr 5


### PR DESCRIPTION
Whilst trying to figure out why the GDB branch is producing wrong code, I noticed that `Selectgen.join_array` suffers from the same problem that was fixed for `Selectgen.join` in #555.  The testcase in this patch segfaults at the moment.  The fix is as for #555.
