### PR TITLE
Fix selecting wrong README files in Makefile.nt

### DIFF
--- a/Makefile.nt
+++ b/Makefile.nt
@@ -236,8 +236,8 @@ installbyt:
 	fi
 	cp config/Makefile "$(INSTALL_LIBDIR)/Makefile.config"
 	if test -n "$(INSTALL_DISTRIB)"; then \
-	   cp README "$(INSTALL_DISTRIB)/Readme.general.txt"; \
-	   cp README.win32 "$(INSTALL_DISTRIB)/Readme.windows.txt"; \
+	   cp README.adoc "$(INSTALL_DISTRIB)/Readme.general.txt"; \
+	   cp README.win32.adoc "$(INSTALL_DISTRIB)/Readme.windows.txt"; \
 	   cp LICENSE "$(INSTALL_DISTRIB)/License.txt"; \
 	   cp Changes "$(INSTALL_DISTRIB)/Changes.txt"; \
 	fi


### PR DESCRIPTION
As far as I can tell https://github.com/ocaml/ocaml/commit/a6347db592aa5d26b2df5181e3b5ae8384e90ccb (and https://github.com/ocaml/ocaml/commit/73b7f7c2fa7236bb9488ae1b2a68232138069c0a subsequently) inadvertently dropped the .adoc from the README files, meaning they would fail (@whitequark is presumably testing only with INSTALL_DISTRIB="" for cross-compiling?)

Of course, it's slightly strange that the .adoc files get renamed to .txt, but that's a separate matter - at the moment, I think install would fail?
