### PR TITLE
Add extension function for filename, add reverse function for string

### DIFF
--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -207,6 +207,12 @@ let chop_extension name =
     else search_dot (i - 1) in
   search_dot (String.length name - 1)
 
+let extension name =
+  try
+    let dot_spot = String.rindex name '.' in
+    String.sub name dot_spot (String.length name - dot_spot)
+  with Not_found -> ""
+
 external open_desc: string -> open_flag list -> int -> int = "caml_sys_open"
 external close_desc: int -> unit = "caml_sys_close"
 

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -140,4 +140,9 @@ val quote : string -> string
     Warning: under Windows, the output is only suitable for use
     with programs that follow the standard Windows quoting
     conventions.
- *)
+*)
+
+val extension : string -> string
+(** Get the extension of a file if there is one, includes the . when
+    there is an extension. Gives back empty string is no extension
+    found. *)

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -127,6 +127,10 @@ type t = string
 let compare (x: t) (y: t) = Pervasives.compare x y
 external equal : string -> string -> bool = "caml_string_equal"
 
+let reverse s =
+  let len = length s in
+  init len (fun spot -> unsafe_get s (len - spot - 1))
+
 (* Deprecated functions implemented via other deprecated functions *)
 [@@@ocaml.warning "-3"]
 let uppercase s =

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -282,6 +282,9 @@ val equal: t -> t -> bool
 (** The equal function for strings.
     @since 4.03.0 *)
 
+val reverse: t -> t
+(** Get a new reversed string *)
+
 (**/**)
 
 (* The following is for system use only. Do not call directly. *)


### PR DESCRIPTION
Missing functions from stdlib that I think are useful enough to add.

Added `String.reverse` and `Filename.extension`
