### PR TITLE
Fix the -use-runtime option.

### DIFF
--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -318,7 +318,7 @@ let link_bytecode ppf tolink exec_name standalone =
     Bytesections.init_record outchan;
     (* The path to the bytecode interpreter (in use_runtime mode) *)
     if String.length !Clflags.use_runtime > 0 then begin
-      output_string outchan ("#!" ^ (make_absolute !Clflags.use_runtime));
+      output_string outchan (make_absolute !Clflags.use_runtime);
       output_char outchan '\n';
       Bytesections.record outchan "RNTM"
     end;


### PR DESCRIPTION
This option was broken, as can be seen by using it to compile the
following helloworld.ml program:

let _ = Printf.printf "Hello, world!\n%!"

Then from OCaml's toplevel source directory, compile as follows:

./ocamlc.opt -use-runtime ${HOME}/src/ocaml/byterun/ocamlrun \
  -nostdlib -I stdlib -o helloworld.byte helloworld.ml

And do:

head -1 helloworld.byte

See the double #! at the beginning of the line.

The first one comes from the "header" file which is included and is
correct (it would be a different header on Windows).

The second one is hard-coded and should be removed, this is what
this patch does.
