### PR TITLE
Ocamldoc: do not ignore "-open" arguments

### DIFF
--- a/Changes
+++ b/Changes
@@ -32,6 +32,8 @@ OCaml 4.04.0:
 
 - GPR#452: Make the output of ocamldep more stable
   (Alain Frisch)
+- GPR#613: make ocamldoc use -open arguments
+  (Florian Angeletti)
 - MPR#7248: have ocamldep interpret -open arguments in left-to-right order
   (Gabriel Scherer, report by Anton Bachin)
 

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -19,7 +19,6 @@
 let print_DEBUG s = print_string s ; print_newline ()
 
 open Config
-open Misc
 open Format
 open Typedtree
 
@@ -33,17 +32,28 @@ let init_path () =
     "" :: List.rev (Config.standard_library :: !Clflags.include_dirs);
   Env.reset_cache ()
 
+
+let open_in env m =
+  try
+    Env.open_pers_signature m env
+  with
+  | Not_found ->
+      Misc.fatal_error @@ Printf.sprintf "cannot open %s.cmi"
+        (String.uncapitalize_ascii m)
+
 (** Return the initial environment in which compilation proceeds. *)
 let initial_env () =
   let initial =
     if !Clflags.unsafe_string then Env.initial_unsafe_string
     else Env.initial_safe_string
   in
-  try
-    if !Clflags.nopervasives then initial else
-    Env.open_pers_signature "Pervasives" initial
-  with Not_found ->
-    fatal_error "cannot open pervasives.cmi"
+  let initial =
+    if !Clflags.nopervasives then
+      initial
+    else
+        open_in initial "Pervasives"
+  in
+  List.fold_left open_in initial (List.rev !Clflags.open_modules)
 
 (** Optionally preprocess a source file *)
 let preprocess sourcefile =

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -33,16 +33,15 @@ let init_path () =
   Env.reset_cache ()
 
 
-let open_in env m =
-  try
-    Env.open_pers_signature m env
-  with
-  | Not_found ->
-      Misc.fatal_error @@ Printf.sprintf "cannot open %s.cmi"
-        (String.uncapitalize_ascii m)
-
 (** Return the initial environment in which compilation proceeds. *)
 let initial_env () =
+  let open_cmi env m =
+    try
+      Env.open_pers_signature m env
+    with
+    | Not_found ->
+        Misc.fatal_error @@ Printf.sprintf "cannot open %s.cmi"
+          (String.uncapitalize_ascii m) in
   let initial =
     if !Clflags.unsafe_string then Env.initial_unsafe_string
     else Env.initial_safe_string
@@ -51,9 +50,9 @@ let initial_env () =
     if !Clflags.nopervasives then
       initial
     else
-        open_in initial "Pervasives"
+        open_cmi initial "Pervasives"
   in
-  List.fold_left open_in initial (List.rev !Clflags.open_modules)
+  List.fold_left open_cmi initial (List.rev !Clflags.open_modules)
 
 (** Optionally preprocess a source file *)
 let preprocess sourcefile =


### PR DESCRIPTION
This pull requests open the module listed as arguments of `-open` in the initial environment of ocamldoc
to mirror the behavior of `ocaml`, `ocamlc` and `ocamldep`.

Without this modification, the "-open" command option has no effect within `ocamldoc`.
