### PR TITLE
typos ('middle_end' directory)

### DIFF
--- a/middle_end/alias_analysis.ml
+++ b/middle_end/alias_analysis.ml
@@ -144,7 +144,7 @@ and fetch_symbol_field
       | fields ->
         begin match List.nth fields field with
         | None ->
-          Misc.fatal_errorf "constant field access to an inconstant %a"
+          Misc.fatal_errorf "Constant field access to an inconstant %a"
             Symbol.print sym
         | Some v ->
           fetch_variable definitions v ~the_dead_constant

--- a/middle_end/augment_specialised_args.ml
+++ b/middle_end/augment_specialised_args.ml
@@ -159,7 +159,7 @@ module Processed_what_to_specialise = struct
        of closures (corresponding to another new specialised argument),
        we should re-use its "new outer var" to avoid duplication of
        projection definitions.  Likewise if the definition is just
-       [Existing_inner_free_var], in in which case we can use the
+       [Existing_inner_free_var], in which case we can use the
        corresponding existing outer free variable. *)
     let new_outer_var, t =
       let existing_outer_var =

--- a/middle_end/backend_intf.mli
+++ b/middle_end/backend_intf.mli
@@ -39,7 +39,7 @@ module type S = sig
   (** [true] iff the target architecture is big endian. *)
   val big_endian : bool
 
-  (** The maximum number of arguments that is is reasonable for a function
+  (** The maximum number of arguments that is reasonable for a function
       to have.  This should be fewer than the threshold that causes non-self
       tail call optimization to be inhibited (in particular, if it would
       entail passing arguments on the stack; see [Selectgen]). *)

--- a/middle_end/base_types/set_of_closures_id.mli
+++ b/middle_end/base_types/set_of_closures_id.mli
@@ -17,7 +17,7 @@
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
 (** An identifier, unique across the whole program, that identifies a set
-    of a closures (viz. [Set_of_closures]). *)
+    of closures (viz. [Set_of_closures]). *)
 
 include Identifiable.S
 

--- a/middle_end/closure_conversion.ml
+++ b/middle_end/closure_conversion.ml
@@ -421,7 +421,7 @@ and close t ?debuginfo env (lam : Lambda.lambda) : Flambda.t =
        blocks being made (with [Pmakeblock]).  This information can be used
        by the simplification pass to increase the likelihood of eliminating
        the allocation, since some field accesses can be tracked back to known
-       field values. ,*)
+       field values. *)
     let name = Printlambda.name_of_primitive p in
     Lift_code.lifting_helper (close_list t env args)
       ~evaluation_order:`Right_to_left

--- a/middle_end/closure_conversion_aux.mli
+++ b/middle_end/closure_conversion_aux.mli
@@ -73,7 +73,7 @@ module Function_decls : sig
     val is_a_functor : t -> bool
 
     (* [primitive_wrapper t] is [None] iff [t] is not a wrapper for a function
-       with default optionnal arguments. Otherwise it is [Some body], where
+       with default optional arguments. Otherwise it is [Some body], where
        [body] is the body of the wrapper. *)
     val primitive_wrapper : t -> Lambda.lambda option
 

--- a/middle_end/flambda.mli
+++ b/middle_end/flambda.mli
@@ -249,7 +249,7 @@ and set_of_closures = private {
       [let rec f a b c = f a 1 2 in], [a] -> [x] would still be a valid
       specialised argument because all recursive calls maintain the invariant.
 
-      This information is used for optimisation purposes, if such a binding is
+      This information is used for optimization purposes, if such a binding is
       known, it is possible to specialise the body of the function according
       to its parameter. This is usually introduced when specialising a
       recursive function, for instance.
@@ -434,7 +434,7 @@ val free_variables_named
   -> named
   -> Variable.Set.t
 
-(** Compute _all_ variables occuring inside an expression. *)
+(** Compute _all_ variables occurring inside an expression. *)
 val used_variables
    : ?ignore_uses_as_callee:unit
   -> ?ignore_uses_as_argument:unit

--- a/middle_end/flambda_invariants.ml
+++ b/middle_end/flambda_invariants.ml
@@ -362,7 +362,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
       (* CR-someday pchambart: Ignore it to avoid the warning: get rid of that
          when the case is settled *)
       ignore (Set_of_closures_free_vars_map_has_wrong_range bad_free_vars);
-      (* Check that free variables variables are not bound somewhere
+      (* Check that free variables are not bound somewhere
          else in the program *)
       declare_variables (Variable.Map.keys free_vars);
       (* Check that every "specialised arg" is a parameter of one of the

--- a/middle_end/inconstant_idents.ml
+++ b/middle_end/inconstant_idents.ml
@@ -49,7 +49,7 @@
 
 (* CR-someday lwhite: I think this pass could be combined with
    alias_analysis and other parts of lift_constants into a single
-   type-based anaylsis which infers a "type" for each variable that is
+   type-based analysis which infers a "type" for each variable that is
    either an allocated_constant expression or "not constant".  Recursion
    would be handled with unification variables. *)
 
@@ -216,7 +216,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
 
   (* First loop: iterates on the tree to mark dependencies.
 
-     curr is the variables or closures to wich we add constraints like
+     curr is the variables or closures to which we add constraints like
      '... in NC => curr in NC' or 'curr in NC'
 
      It can be empty when no constraint can be added like in the toplevel

--- a/middle_end/inline_and_simplify.ml
+++ b/middle_end/inline_and_simplify.ml
@@ -422,7 +422,7 @@ let simplify_move_within_set_of_closures env r
 
    If the function is declared outside of the alpha renamed part, there is
    no need for renaming in the [Ffunction] and [Project_var].
-   This is not usualy the case, except when the closure declaration is a
+   This is not usually the case, except when the closure declaration is a
    symbol.
 
    What ensures that this information is available at [Project_var]
@@ -554,7 +554,7 @@ let rec simplify_project_var env r ~(project_var : Flambda.project_var)
    will be introduced in the current scope for [y_1] each time.
 
 
-   If the function where a recursive one comming from another compilation
+   If the function where a recursive one coming from another compilation
    unit, the code already went through [Flambdasym] that could have
    replaced the function variable by the symbol identifying the function
    (this occur if the function contains only constants in its closure).
@@ -1617,7 +1617,7 @@ let run ~never_inline ~backend ~prefixname ~round program =
   let result = Flambda_utils.introduce_needed_import_symbols result in
   if not (Static_exception.Set.is_empty (R.used_static_exceptions r))
   then begin
-    Misc.fatal_error (Format.asprintf "remaining static exceptions: %a@.%a@."
+    Misc.fatal_error (Format.asprintf "Remaining static exceptions: %a@.%a@."
       Static_exception.Set.print (R.used_static_exceptions r)
       Flambda.print_program result)
   end;

--- a/middle_end/inline_and_simplify_aux.mli
+++ b/middle_end/inline_and_simplify_aux.mli
@@ -172,7 +172,7 @@ module Env : sig
   val inlining_level : t -> int
 
   (** Mark that this environment is used to rewrite code for inlining. This is
-      used by the inlining heuristics to decide wether to continue.
+      used by the inlining heuristics to decide whether to continue.
       Unconditionally inlined does not take this into account. *)
   val inlining_level_up : t -> t
 

--- a/middle_end/inlining_decision.ml
+++ b/middle_end/inlining_decision.ml
@@ -119,7 +119,7 @@ let inline env r ~lhs_of_application
 
           We may need to think a bit about that. I can't see a lot of
           meaningful examples right now, but there are some cases where some
-          optimisation can happen even if we don't know anything about the
+          optimization can happen even if we don't know anything about the
           shape of the arguments.
 
           For instance
@@ -251,7 +251,7 @@ let inline env r ~lhs_of_application
       else if num_direct_applications_seen < 1 then begin
       (* Inlining the body of the function did not appear sufficiently
          beneficial; however, it may become so if we inline within the body
-         first.  We try that next, unless it is known that there are were
+         first.  We try that next, unless it is known that there were
          no direct applications in the simplified body computed above, meaning
          no opportunities for inlining. *)
         Original (S.Not_inlined.Without_subfunctions wsb)

--- a/middle_end/inlining_transforms.ml
+++ b/middle_end/inlining_transforms.ml
@@ -198,7 +198,7 @@ let inline_by_copying_function_declaration ~env ~r
   in
   (* Arguments of functions that are not directly called but are
      aliased to arguments of a directly called one may need to be
-     marked as specialiased. *)
+     marked as specialised. *)
   let specialisable_args_with_aliases =
     Variable.Map.fold (fun arg outside_var map ->
         match Variable.Map.find arg (Lazy.force invariant_params) with

--- a/middle_end/invariant_params.ml
+++ b/middle_end/invariant_params.ml
@@ -278,7 +278,7 @@ let analyse_functions ~backend ~param_to_param
      let rec f x = ...
      and g y = f x
 
-   We record [(f, x) <- Top] when some unknown values can flow to a the
+   We record [(f, x) <- Top] when some unknown values can flow to the
    [y] parameter.
 
      let rec f x = f 1

--- a/middle_end/remove_free_vars_equal_to_args.ml
+++ b/middle_end/remove_free_vars_equal_to_args.ml
@@ -34,7 +34,7 @@ let rewrite_one_function_decl ~(function_decl : Flambda.function_declaration)
             (* No free variables equal to the param *)
             subst
           | set ->
-            (* Replace the free variables equal to an parameter *)
+            (* Replace the free variables equal to a parameter *)
             Variable.Set.fold (fun free_var subst ->
                 Variable.Map.add free_var param subst)
               set subst)

--- a/middle_end/unbox_specialised_args.ml
+++ b/middle_end/unbox_specialised_args.ml
@@ -63,7 +63,7 @@ module Transform = struct
                 (* If for function [f] we would extract a projection expression
                    [e] from some specialised argument [x] of [f], and we know
                    from [Invariant_params] that a specialised argument [y] of
-                   another function [g] flows to [x], we will add add [e] with
+                   another function [g] flows to [x], we will add [e] with
                    [y] substituted for [x] throughout as a newly-specialised
                    argument for [g].  This should help reduce the number of
                    simplification rounds required for mutually-recursive


### PR DESCRIPTION
This is 'GPR #461 - The Return'
( Not sure why this PR was not accepted but anyway ...)

Only typos found in the 'middle_end' directory are concerned.

However (for the record and/or for a possible use) here are the '(*' and '(**'
that seem suspicious/inconsistent (well , at least for me ...)
- '(*' instead of '(**' :

flambda_utils.mli           : L61
freshening.mli              : L114
inline_and_simplify_aux.mli : L84
inlining_stats_types.mli    : L19
middle_end.mli              : L19
- '(**' instead of '(*' :

flambda.ml                : L187
flambda.ml                : L755
flambda.mli               : L101
simple_value_approx.mli   : L148
base_types/closure_id.mli : L19
