### PR TITLE
Ocamldoc: test and consistency fix for "-open" option

### DIFF
--- a/testsuite/tests/tool-ocamldoc-open/Makefile
+++ b/testsuite/tests/tool-ocamldoc-open/Makefile
@@ -1,0 +1,40 @@
+BASEDIR=../..
+COMPFLAGS=-I $(OTOPDIR)/ocamldoc
+LD_PATH=$(TOPDIR)/otherlibs/$(UNIXLIBVAR)unix:$(TOPDIR)/otherlibs/str
+DOCFLAGS=-I $(OTOPDIR)/stdlib $(COMPFLAGS)
+
+SRC= main.ml alias.ml inner.ml
+ODOCS=$(SRC:%.ml=%.odoc)
+
+.PHONY: doc
+
+doc: $(ODOCS)
+	@printf " ... testing ocamldoc '-open' option";\
+	$(OCAMLDOC) $(DOCFLAGS) -hide-warnings \
+         -load alias.odoc -load inner.odoc \
+         -load main.odoc -latex -o doc.result ;\
+	$(DIFF) doc.result doc.reference > /dev/null \
+	&& echo " => passed" || echo " => failed";
+
+inner.odoc: inner.ml
+	@$(OCAMLDOC) $(DOCFLAGS) -hide-warnings \
+        -dump inner.odoc inner.ml
+
+alias.odoc: inner.cmi alias.ml
+	@$(OCAMLDOC) $(DOCFLAGS) -hide-warnings \
+        -dump alias.odoc alias.ml
+
+main.odoc: alias.cmi main.ml
+	@$(OCAMLDOC) $(DOCFLAGS) -hide-warnings \
+        -open Alias -open Aliased_inner -dump main.odoc main.ml
+
+alias.cmi:inner.cmi
+
+.PHONY: promote
+promote: defaultpromote
+
+.PHONY: clean
+clean: defaultclean
+	@rm -f *.odoc *.toc *.sty *.aux *.log *.result
+
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/tool-ocamldoc-open/Readme
+++ b/testsuite/tests/tool-ocamldoc-open/Readme
@@ -1,0 +1,12 @@
+This test focuses on ocamldoc "-open" command line option.
+It ensures that the modules passed as argument to this "-open" option
+are opened in the initial environment of ocamldoc.
+
+More precisely, it checks that
+
+* both cmi files and inner modules can be opened
+* modules are opened in the left-to-right order
+
+The test builds a latex documentation file for the three modules
+"Main", "Alias" and "Inner". Changes to ocamldoc latex output might
+trigger spurious errors in this test.

--- a/testsuite/tests/tool-ocamldoc-open/alias.ml
+++ b/testsuite/tests/tool-ocamldoc-open/alias.ml
@@ -1,0 +1,1 @@
+module Aliased_inner = Inner

--- a/testsuite/tests/tool-ocamldoc-open/doc.reference
+++ b/testsuite/tests/tool-ocamldoc-open/doc.reference
@@ -1,0 +1,61 @@
+\documentclass[11pt]{article} 
+\usepackage[latin1]{inputenc} 
+\usepackage[T1]{fontenc} 
+\usepackage{textcomp}
+\usepackage{fullpage} 
+\usepackage{url} 
+\usepackage{ocamldoc}
+\begin{document}
+\tableofcontents
+\section{Module {\tt{Alias}}}
+\label{module:Alias}\index{Alias@\verb`Alias`}
+
+
+\ocamldocvspace{0.5cm}
+
+
+
+\begin{ocamldoccode}
+{\tt{module }}{\tt{Aliased\_inner}}{\tt{ : }}\end{ocamldoccode}
+\label{module:Alias.Aliased-underscoreinner}\index{Aliased-underscoreinner@\verb`Aliased_inner`}
+
+{\tt{Inner}}
+
+
+
+\section{Module {\tt{Inner}}}
+\label{module:Inner}\index{Inner@\verb`Inner`}
+
+
+\ocamldocvspace{0.5cm}
+
+
+
+\label{type:Inner.a}\begin{ocamldoccode}
+type a = int 
+\end{ocamldoccode}
+\index{a@\verb`a`}
+
+
+\section{Module {\tt{Main}} : Documentation test}
+\label{module:Main}\index{Main@\verb`Main`}
+
+
+
+
+\ocamldocvspace{0.5cm}
+
+
+
+\label{type:Main.t}\begin{ocamldoccode}
+type t = Alias.Aliased_inner.a 
+\end{ocamldoccode}
+\index{t@\verb`t`}
+\begin{ocamldocdescription}
+Alias to type Inner.a
+
+
+\end{ocamldocdescription}
+
+
+\end{document}

--- a/testsuite/tests/tool-ocamldoc-open/inner.ml
+++ b/testsuite/tests/tool-ocamldoc-open/inner.ml
@@ -1,0 +1,2 @@
+
+type a = int

--- a/testsuite/tests/tool-ocamldoc-open/main.ml
+++ b/testsuite/tests/tool-ocamldoc-open/main.ml
@@ -1,0 +1,5 @@
+
+(** Documentation test *)
+
+type t = a
+(** Alias to type Inner.a *)


### PR DESCRIPTION
This pull requestion is a continuation of #613 that adds a test for ocamldoc "-open" command line option and fixes two consistencies issues in the previous PR:
- First, tests on Clflags.nopervasives are dropped: the nopervasives flag is not currently supported by ocamldoc
- Second, "-open" works now also for inner modules and not only cmi files, matching the behavior of the other tools in this respect.
