### PR TITLE
cmpbyt: return 1 rather than 2 to report file difference.

### DIFF
--- a/tools/cmpbyt.ml
+++ b/tools/cmpbyt.ml
@@ -84,4 +84,4 @@ let _ =
     eprintf "Usage: cmpbyt <file 1> <file 2>\n";
     exit 2
   end;
-  if cmpbyt Sys.argv.(1) Sys.argv.(2) then exit 0 else exit 2
+  if cmpbyt Sys.argv.(1) Sys.argv.(2) then exit 0 else exit 1


### PR DESCRIPTION
cmpbyt was returning 2 to report both an error in the way it is
called (wrong number of command-line arguments) and the fact that
its two arguments are different programs. This patch fixes this and makes
cmpbyt's behaviour similar to the one of the cmp Unix command, i.e.
returning 0 to report file similarity, 1 to report file difference
and 2 for real errors.
