### PR TITLE
Add caml_ext_table_clear

### DIFF
--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -138,6 +138,7 @@ extern void caml_ext_table_init(struct ext_table * tbl, int init_capa);
 extern int caml_ext_table_add(struct ext_table * tbl, void * data);
 extern void caml_ext_table_remove(struct ext_table * tbl, void * data);
 extern void caml_ext_table_free(struct ext_table * tbl, int free_entries);
+extern void caml_ext_table_clear(struct ext_table * tbl, int free_entries);
 
 /* GC flags and messages */
 

--- a/byterun/misc.c
+++ b/byterun/misc.c
@@ -139,11 +139,18 @@ void caml_ext_table_remove(struct ext_table * tbl, void * data)
   }
 }
 
-void caml_ext_table_free(struct ext_table * tbl, int free_entries)
+void caml_ext_table_clear(struct ext_table * tbl, int free_entries)
 {
   int i;
-  if (free_entries)
+  if (free_entries) {
     for (i = 0; i < tbl->size; i++) caml_stat_free(tbl->contents[i]);
+  }
+  tbl->size = 0;
+}
+
+void caml_ext_table_free(struct ext_table * tbl, int free_entries)
+{
+  caml_ext_table_clear(tbl, free_entries);
   caml_stat_free(tbl->contents);
 }
 


### PR DESCRIPTION
This patch adds a new function, `caml_ext_table_clear`, which is like `caml_ext_table_remove` but does not free the table.  It is subsequently available for re-use.
