### PR TITLE
String.split

### DIFF
--- a/Changes
+++ b/Changes
@@ -109,6 +109,9 @@ OCaml 4.04.0:
   array of floats
   (Thomas Braibant)
 
+- GPR#626: String.split
+  (Alain Frisch)
+
 ### Manual:
 
 - PR#7245, GPR#565: clarification to the wording and documentation

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -127,6 +127,17 @@ type t = string
 let compare (x: t) (y: t) = Pervasives.compare x y
 external equal : string -> string -> bool = "caml_string_equal"
 
+let split sep s =
+  let r = ref [] in
+  let j = ref (length s) in
+  for i = length s - 1 downto 0 do
+    if unsafe_get s i = sep then begin
+      r := sub s (i + 1) (!j - i - 1) :: !r;
+      j := i
+    end
+  done;
+  sub s 0 !j :: !r
+
 (* Deprecated functions implemented via other deprecated functions *)
 [@@@ocaml.warning "-3"]
 let uppercase s =

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -282,6 +282,21 @@ val equal: t -> t -> bool
 (** The equal function for strings.
     @since 4.03.0 *)
 
+val split: char -> string -> string list
+(** [String.split sep s] returns the list of all (possibly empty)
+    substrings of [s] that are delimited by the [sep] character.
+
+    The function's output is specified by the following invariants:
+
+    - The list is not empty.
+    - Concatenating its elements using [sep] as a separator returns a
+      string equal to the input ([String.concat (String.make 1 sep)
+      (String.split sep s) = s]).
+    - No string in the result contains the [sep] character.
+
+    @since 4.04.0
+*)
+
 (**/**)
 
 (* The following is for system use only. Do not call directly. *)

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -21,3 +21,18 @@ let raw_string = build_string char 256 [];;
 let ref_string = build_string reference 256 [];;
 
 if String.escaped raw_string <> ref_string then failwith "test:String.escaped";;
+
+
+let check_split sep s =
+  let l = String.split sep s in
+  assert(List.length l > 0);
+  assert(String.concat (String.make 1 sep) (String.split sep s) = s);
+  List.iter (String.iter (fun c -> assert (c <> sep))) l
+;;
+
+let () =
+  let s = " abc def " in
+  for i = 0 to String.length s do
+    check_split ' ' (String.sub s 0 i)
+  done
+;;


### PR DESCRIPTION
Not wanting to reopen old wounds (#10), but `String.split` would be a really useful addition to the stdlib.

I propose to add a form where the separator is a single character.  Compared to a version with a string delimiter, the advantages of this simpler version are:
- A self-explanatory type: no need to introduce labelled arguments to disambiguate between two string arguments.
- A total function that never fails, no special support for the empty separator.
- Higher-level specification: no need to specify the matching algorithm to specify the behavior when the separator overlaps with itself (nor to introduce two variants for left-to-right and right-to-left traversal).

It's worth noting that both JaneStreet Core and ExtLib/Batteries expose a similar feature. ExtLib's [String.nsplit] has a string separator, but I could not find a single use of it with a long separator ( https://github.com/search?l=ocaml&p=4&q=%22String.nsplit%22&ref=searchresults&type=Code&utf8=%E2%9C%93 ).

Also, a similar function is implemented multiple times in the compiler code base:
- Misc.Stdlib.String.split.
- Misc.split.
- Dumpobj.read_primitive_table
- Dll.split
- Primitives.split_string (in debugger), although this seems to be dead code

Not talking about ocamldoc's `split_string` interesting implementation (it supports multiple character separator, but this shows what people can actually write...).

See also http://rosettacode.org/wiki/Tokenize_a_string#OCaml : several inefficient and uselessly complex implementations.
