### PR TITLE
Make instruction.next mutable in Mach

### DIFF
--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -59,7 +59,7 @@ type operation =
 
 type instruction =
   { desc: instruction_desc;
-    next: instruction;
+    mutable next: instruction;
     arg: Reg.t array;
     res: Reg.t array;
     dbg: Debuginfo.t;

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -60,7 +60,7 @@ type operation =
 
 type instruction =
   { desc: instruction_desc;
-    next: instruction;
+    mutable next: instruction;
     arg: Reg.t array;
     res: Reg.t array;
     dbg: Debuginfo.t;


### PR DESCRIPTION
Insertion of instrumentation code on Mach is complicated by the use of singly-linked lists, in reverse order, with no means of obtaining a reference to the "next" field (since it is a mutable field in a record).

I propose to make the `next` field in `Mach.instruction` mutable, which makes this task significantly easier.
