### PR TITLE
Fix testsuite failure with GCC 6.0 due to -Warray-bounds

### DIFF
--- a/testsuite/tests/asmcomp/mainarith.c
+++ b/testsuite/tests/asmcomp/mainarith.c
@@ -91,7 +91,7 @@ void do_test(void)
       INTTEST(R[15], (X - 1));
       INTTEST(R[16], (X - -1));
 
-      INTTEST(R[17], ((intnat) ((char *)R - 8)));
+      INTTEST(R[17], ((intnat) ((uintnat)R - 8)));
       INTTEST(R[18], ((intnat) ((char *)R - Y)));
 
       INTTEST(R[19], (X * 2));


### PR DESCRIPTION
GCC 6 has a warning (`-Warray-bounds`) that detects some cases of array indexing out of bounds (which is undefined behavior).  This triggered on the file `testsuite/tests/asmcomp/mainarith.c`.  This PR changes a cast to fix the tests.
