### PR TITLE
add iterators to most containers in stdlib

### DIFF
--- a/otherlibs/threads/Makefile
+++ b/otherlibs/threads/Makefile
@@ -34,7 +34,7 @@ CAML_OBJS=thread.cmo mutex.cmo condition.cmo event.cmo threadUnix.cmo
 LIB=../../stdlib
 
 LIB_OBJS=$(LIB)/camlinternalFormatBasics.cmo pervasives.cmo		\
-  $(LIB)/array.cmo $(LIB)/list.cmo $(LIB)/char.cmo $(LIB)/bytes.cmo	\
+  $(LIB)/iter.cmo $(LIB)/array.cmo $(LIB)/list.cmo $(LIB)/char.cmo $(LIB)/bytes.cmo	\
   $(LIB)/string.cmo $(LIB)/sys.cmo $(LIB)/sort.cmo marshal.cmo		\
   $(LIB)/obj.cmo $(LIB)/int32.cmo $(LIB)/int64.cmo			\
   $(LIB)/nativeint.cmo $(LIB)/lexing.cmo $(LIB)/parsing.cmo		\

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -11,10 +11,10 @@ arrayLabels.cmx : array.cmx arrayLabels.cmi
 arrayLabels.cmi :
 buffer.cmo : sys.cmi string.cmi bytes.cmi buffer.cmi
 buffer.cmx : sys.cmx string.cmx bytes.cmx buffer.cmi
-buffer.cmi :
-bytes.cmo : pervasives.cmi char.cmi bytes.cmi
-bytes.cmx : pervasives.cmx char.cmx bytes.cmi
-bytes.cmi :
+buffer.cmi : iter.cmi
+bytes.cmo : pervasives.cmi list.cmi char.cmi bytes.cmi
+bytes.cmx : pervasives.cmx list.cmx char.cmx bytes.cmi
+bytes.cmi : iter.cmi
 bytesLabels.cmo : bytes.cmi bytesLabels.cmi
 bytesLabels.cmx : bytes.cmx bytesLabels.cmi
 bytesLabels.cmi :
@@ -78,13 +78,16 @@ hashtbl.cmo : sys.cmi string.cmi random.cmi obj.cmi lazy.cmi array.cmi \
     hashtbl.cmi
 hashtbl.cmx : sys.cmx string.cmx random.cmx obj.cmx lazy.cmx array.cmx \
     hashtbl.cmi
-hashtbl.cmi :
+hashtbl.cmi : iter.cmi
 int32.cmo : pervasives.cmi int32.cmi
 int32.cmx : pervasives.cmx int32.cmi
 int32.cmi :
 int64.cmo : pervasives.cmi int64.cmi
 int64.cmx : pervasives.cmx int64.cmi
 int64.cmi :
+iter.cmo : iter.cmi
+iter.cmx : iter.cmi
+iter.cmi :
 lazy.cmo : obj.cmi camlinternalLazy.cmi lazy.cmi
 lazy.cmx : obj.cmx camlinternalLazy.cmx lazy.cmi
 lazy.cmi :
@@ -93,13 +96,13 @@ lexing.cmx : sys.cmx string.cmx bytes.cmx array.cmx lexing.cmi
 lexing.cmi :
 list.cmo : list.cmi
 list.cmx : list.cmi
-list.cmi :
+list.cmi : iter.cmi
 listLabels.cmo : list.cmi listLabels.cmi
 listLabels.cmx : list.cmx listLabels.cmi
 listLabels.cmi :
 map.cmo : map.cmi
 map.cmx : map.cmi
-map.cmi :
+map.cmi : iter.cmi
 marshal.cmo : bytes.cmi marshal.cmi
 marshal.cmx : bytes.cmx marshal.cmi
 marshal.cmi :
@@ -148,7 +151,7 @@ scanf.cmx : string.cmx printf.cmx pervasives.cmx list.cmx \
 scanf.cmi : pervasives.cmi
 set.cmo : list.cmi set.cmi
 set.cmx : list.cmx set.cmi
-set.cmi :
+set.cmi : iter.cmi
 sort.cmo : array.cmi sort.cmi
 sort.cmx : array.cmx sort.cmi
 sort.cmi :
@@ -157,7 +160,7 @@ spacetime.cmx : gc.cmx spacetime.cmi
 spacetime.cmi :
 stack.cmo : list.cmi stack.cmi
 stack.cmx : list.cmx stack.cmi
-stack.cmi :
+stack.cmi : iter.cmi
 stdLabels.cmo : stringLabels.cmi listLabels.cmi bytesLabels.cmi \
     arrayLabels.cmi stdLabels.cmi
 stdLabels.cmx : stringLabels.cmx listLabels.cmx bytesLabels.cmx \
@@ -169,9 +172,9 @@ std_exit.cmx :
 stream.cmo : string.cmi list.cmi lazy.cmi bytes.cmi stream.cmi
 stream.cmx : string.cmx list.cmx lazy.cmx bytes.cmx stream.cmi
 stream.cmi :
-string.cmo : pervasives.cmi bytes.cmi string.cmi
-string.cmx : pervasives.cmx bytes.cmx string.cmi
-string.cmi :
+string.cmo : pervasives.cmi list.cmi bytes.cmi string.cmi
+string.cmx : pervasives.cmx list.cmx bytes.cmx string.cmi
+string.cmi : iter.cmi
 stringLabels.cmo : string.cmi stringLabels.cmi
 stringLabels.cmx : string.cmx stringLabels.cmi
 stringLabels.cmi :
@@ -194,8 +197,8 @@ arrayLabels.cmo : array.cmi arrayLabels.cmi
 arrayLabels.p.cmx : array.cmx arrayLabels.cmi
 buffer.cmo : sys.cmi string.cmi bytes.cmi buffer.cmi
 buffer.p.cmx : sys.cmx string.cmx bytes.cmx buffer.cmi
-bytes.cmo : pervasives.cmi char.cmi bytes.cmi
-bytes.p.cmx : pervasives.cmx char.cmx bytes.cmi
+bytes.cmo : pervasives.cmi list.cmi char.cmi bytes.cmi
+bytes.p.cmx : pervasives.cmx list.cmx char.cmx bytes.cmi
 bytesLabels.cmo : bytes.cmi bytesLabels.cmi
 bytesLabels.p.cmx : bytes.cmx bytesLabels.cmi
 callback.cmo : obj.cmi callback.cmi
@@ -308,8 +311,8 @@ std_exit.cmo :
 std_exit.cmx :
 stream.cmo : string.cmi list.cmi lazy.cmi bytes.cmi stream.cmi
 stream.p.cmx : string.cmx list.cmx lazy.cmx bytes.cmx stream.cmi
-string.cmo : pervasives.cmi bytes.cmi string.cmi
-string.p.cmx : pervasives.cmx bytes.cmx string.cmi
+string.cmo : pervasives.cmi list.cmi bytes.cmi string.cmi
+string.p.cmx : pervasives.cmx list.cmx bytes.cmx string.cmi
 stringLabels.cmo : string.cmi stringLabels.cmi
 stringLabels.p.cmx : string.cmx stringLabels.cmi
 sys.cmo : sys.cmi

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -33,7 +33,7 @@ CAMLOPT=$(CAMLRUN) $(OPTCOMPILER)
 CAMLDEP=$(CAMLRUN) ../tools/ocamldep
 
 OBJS=camlinternalFormatBasics.cmo pervasives.cmo $(OTHERS)
-OTHERS=list.cmo char.cmo bytes.cmo string.cmo sys.cmo \
+OTHERS=iter.cmo list.cmo char.cmo bytes.cmo string.cmo sys.cmo \
   sort.cmo marshal.cmo obj.cmo array.cmo \
   int32.cmo int64.cmo nativeint.cmo \
   lexing.cmo parsing.cmo \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -42,6 +42,7 @@ STDLIB_MODULES=\
   hashtbl \
   int32 \
   int64 \
+  iter \
   lazy \
   lexing \
   list \

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -292,3 +292,38 @@ let stable_sort cmp a =
 
 
 let fast_sort = stable_sort
+
+(** {6 Iterators} *)
+
+let to_iter a =
+  let next i =
+    if i < length a
+    then
+      let x = unsafe_get a i in
+      Iter.Yield (x, i+1)
+    else Iter.Done
+  in Iter.Sequence (0, next)
+
+let to_iteri a =
+  let next i =
+    if i < length a
+    then
+      let x = unsafe_get a i in
+      Iter.Yield ((i,x), i+1)
+    else Iter.Done
+  in Iter.Sequence (0, next)
+
+let of_rev_list = function
+    [] -> [||]
+  | hd::tl as l ->
+      let len = list_length 0 l in
+      let a = create len hd in
+      let rec fill i = function
+          [] -> a
+        | hd::tl -> unsafe_set a i hd; fill (i-1) tl
+      in
+      fill (len-1) tl
+
+let of_iter i =
+  let l = Iter.fold_left (fun acc x -> x::acc) [] i in
+  of_rev_list l

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -256,6 +256,20 @@ val fast_sort : ('a -> 'a -> int) -> 'a array -> unit
 *)
 
 
+(** {6 Iterators} *)
+
+val to_iter : 'a array -> 'a Iter.t
+(** Iterate on the array, in increasing order
+    @since NEXT_RELEASE *)
+
+val to_iteri : 'a array -> (int * 'a) Iter.t
+(** Iterate on the array, in increasing order, yielding indices along elements
+    @since NEXT_RELEASE *)
+
+val of_iter : 'a Iter.t -> 'a array
+(** Create an array from the generator
+    @since NEXT_RELEASE *)
+
 (**/**)
 (** {6 Undocumented functions} *)
 

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -136,3 +136,22 @@ val truncate : t -> int -> unit
 (** [truncate b len] truncates the length of [b] to [len]
   Note: the internal byte sequence is not shortened.
   Raise [Invalid_argument] if [len < 0] or [len > length b]. *)
+
+(** {6 Iterators} *)
+
+val to_iter : t -> char Iter.t
+(** Iterate on the buffer, in increasing order
+    @since NEXT_RELEASE *)
+
+val to_iteri : t -> (int * char) Iter.t
+(** Iterate on the buffer, in increasing order, yielding indices along chars
+    @since NEXT_RELEASE *)
+
+val add_iter : t -> char Iter.t -> unit
+(** Add chars to the buffer
+    @since NEXT_RELEASE *)
+
+val of_iter : char Iter.t -> t
+(** Create a buffer from the generator
+    @since NEXT_RELEASE *)
+

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -140,11 +140,13 @@ val truncate : t -> int -> unit
 (** {6 Iterators} *)
 
 val to_iter : t -> char Iter.t
-(** Iterate on the buffer, in increasing order
+(** Iterate on the buffer, in increasing order.
+    Modification of the buffer during iteration is undefined behavior.
     @since NEXT_RELEASE *)
 
 val to_iteri : t -> (int * char) Iter.t
-(** Iterate on the buffer, in increasing order, yielding indices along chars
+(** Iterate on the buffer, in increasing order, yielding indices along chars.
+    Modification of the buffer during iteration is undefined behavior.
     @since NEXT_RELEASE *)
 
 val add_iter : t -> char Iter.t -> unit

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -327,3 +327,41 @@ let lowercase s = map Char.lowercase s
 
 let capitalize s = apply1 Char.uppercase s
 let uncapitalize s = apply1 Char.lowercase s
+
+(** {6 Iterators} *)
+
+let to_iter s =
+  let next i =
+    if i = length s then Iter.Done
+    else
+      let x = get s i in
+      Iter.Yield (x, i+1)
+  in
+  Iter.Sequence (0, next)
+
+let to_iteri s =
+  let next i =
+    if i = length s then Iter.Done
+    else
+      let x = get s i in
+      Iter.Yield ((i,x), i+1)
+  in
+  Iter.Sequence (0, next)
+
+let of_iter i =
+  let n = ref 0 in
+  let buf = ref (make 256 '\000') in
+  let resize () =
+    (* resize *)
+    let new_buf = make (2 * length !buf) '\000' in
+    blit !buf 0 new_buf 0 !n;
+    buf := new_buf
+  in
+  Iter.iter
+    (fun c ->
+       if !n = length !buf then resize();
+       set !buf !n c;
+       incr n)
+    i;
+  sub !buf 0 !n
+

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -447,6 +447,21 @@ let s = Bytes.of_string "hello"
     [string] type for this purpose.
 *)
 
+(** {6 Iterators} *)
+
+val to_iter : t -> char Iter.t
+(** Iterate on the string , in increasing index order. Modifications of the
+    string during iteration will be reflected in the iterator.
+    @since NEXT_RELEASE *)
+
+val to_iteri : t -> (int * char) Iter.t
+(** Iterate on the string, in increasing order, yielding indices along chars
+    @since NEXT_RELEASE *)
+
+val of_iter : char Iter.t -> t
+(** Create a string from the generator
+    @since NEXT_RELEASE *)
+
 (**/**)
 
 (* The following is for system use only. Do not call directly. *)

--- a/stdlib/ephemeron.ml
+++ b/stdlib/ephemeron.ml
@@ -21,7 +21,24 @@ module type SeededS = sig
 end
 
 module type S = sig
-  include Hashtbl.S
+  type key
+  type 'a t
+  val create : int -> 'a t
+  val clear : 'a t -> unit
+  val reset : 'a t -> unit
+  val copy : 'a t -> 'a t
+  val add : 'a t -> key -> 'a -> unit
+  val remove : 'a t -> key -> unit
+  val find : 'a t -> key -> 'a
+  val find_opt : 'a t -> key -> 'a option
+  val find_all : 'a t -> key -> 'a list
+  val replace : 'a t -> key -> 'a -> unit
+  val mem : 'a t -> key -> bool
+  val iter : (key -> 'a -> unit) -> 'a t -> unit
+  val filter_map_inplace: (key -> 'a -> 'a option) -> 'a t -> unit
+  val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+  val length : 'a t -> int
+  val stats: 'a t -> Hashtbl.statistics
   val clean: 'a t -> unit
   val stats_alive: 'a t -> Hashtbl.statistics
     (** same as {!stats} but only count the alive bindings *)

--- a/stdlib/ephemeron.mli
+++ b/stdlib/ephemeron.mli
@@ -76,7 +76,26 @@ module type S = sig
       Use [filter_map_inplace] in this case.
   *)
 
-  include Hashtbl.S
+  (** See {!Hashtbl.S} for more details *)
+
+  type key
+  type 'a t
+  val create : int -> 'a t
+  val clear : 'a t -> unit
+  val reset : 'a t -> unit
+  val copy : 'a t -> 'a t
+  val add : 'a t -> key -> 'a -> unit
+  val remove : 'a t -> key -> unit
+  val find : 'a t -> key -> 'a
+  val find_opt : 'a t -> key -> 'a option
+  val find_all : 'a t -> key -> 'a list
+  val replace : 'a t -> key -> 'a -> unit
+  val mem : 'a t -> key -> bool
+  val iter : (key -> 'a -> unit) -> 'a t -> unit
+  val filter_map_inplace: (key -> 'a -> 'a option) -> 'a t -> unit
+  val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+  val length : 'a t -> int
+  val stats: 'a t -> Hashtbl.statistics
 
   val clean: 'a t -> unit
   (** remove all dead bindings. Done automatically during automatic resizing. *)

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -354,6 +354,35 @@ let stats h =
     max_bucket_length = mbl;
     bucket_histogram = histo }
 
+(** {6 Iterators} *)
+
+let to_iter tbl =
+  (* state: index * next bucket to traverse *)
+  let next (i, buck) = match buck with
+    | Empty ->
+        if i = Array.length tbl.data
+        then Iter.Done
+        else Iter.Skip (i+1, tbl.data.(i))
+    | Cons {key; data; next} ->
+        Iter.Yield ((key, data), (i,next))
+  in
+  Iter.Sequence ((0,Empty), next)
+
+let to_iter_keys m = Iter.map fst (to_iter m)
+
+let to_iter_values m = Iter.map snd (to_iter m)
+
+let add_iter tbl i =
+  Iter.iter (fun (k,v) -> add tbl k v) i
+
+let replace_iter tbl i =
+  Iter.iter (fun (k,v) -> replace tbl k v) i
+
+let of_iter i =
+  let tbl = create 16 in
+  replace_iter tbl i;
+  tbl
+
 (* Functorial interface *)
 
 module type HashedType =
@@ -374,22 +403,33 @@ module type S =
   sig
     type key
     type 'a t
-    val create: int -> 'a t
+    val create : int -> 'a t
     val clear : 'a t -> unit
     val reset : 'a t -> unit
-    val copy: 'a t -> 'a t
-    val add: 'a t -> key -> 'a -> unit
-    val remove: 'a t -> key -> unit
-    val find: 'a t -> key -> 'a
+    val copy : 'a t -> 'a t
+    val add : 'a t -> key -> 'a -> unit
+    val remove : 'a t -> key -> unit
+    val find : 'a t -> key -> 'a
     val find_opt: 'a t -> key -> 'a option
-    val find_all: 'a t -> key -> 'a list
+    val find_all : 'a t -> key -> 'a list
     val replace : 'a t -> key -> 'a -> unit
     val mem : 'a t -> key -> bool
-    val iter: (key -> 'a -> unit) -> 'a t -> unit
+    val iter : (key -> 'a -> unit) -> 'a t -> unit
     val filter_map_inplace: (key -> 'a -> 'a option) -> 'a t -> unit
-    val fold: (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
-    val length: 'a t -> int
+    val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+    val length : 'a t -> int
     val stats: 'a t -> statistics
+  end
+
+module type FULL =
+  sig
+    include S
+    val to_iter : 'a t -> (key * 'a) Iter.t
+    val to_iter_keys : _ t -> key Iter.t
+    val to_iter_values : 'a t -> 'a Iter.t
+    val add_iter : 'a t -> (key * 'a) Iter.t -> unit
+    val replace_iter : 'a t -> (key * 'a) Iter.t -> unit
+    val of_iter : (key * 'a) Iter.t -> 'a t
   end
 
 module type SeededS =
@@ -414,7 +454,18 @@ module type SeededS =
     val stats: 'a t -> statistics
   end
 
-module MakeSeeded(H: SeededHashedType): (SeededS with type key = H.t) =
+module type SeededSFull =
+  sig
+    include SeededS
+    val to_iter : 'a t -> (key * 'a) Iter.t
+    val to_iter_keys : _ t -> key Iter.t
+    val to_iter_values : 'a t -> 'a Iter.t
+    val add_iter : 'a t -> (key * 'a) Iter.t -> unit
+    val replace_iter : 'a t -> (key * 'a) Iter.t -> unit
+    val of_iter : (key * 'a) Iter.t -> 'a t
+  end
+
+module MakeSeeded(H: SeededHashedType): (SeededSFull with type key = H.t) =
   struct
     type key = H.t
     type 'a hashtbl = (key, 'a) t
@@ -531,9 +582,15 @@ module MakeSeeded(H: SeededHashedType): (SeededS with type key = H.t) =
     let fold = fold
     let length = length
     let stats = stats
+    let to_iter = to_iter
+    let to_iter_keys = to_iter_keys
+    let to_iter_values = to_iter_values
+    let add_iter = add_iter
+    let replace_iter = replace_iter
+    let of_iter = of_iter
   end
 
-module Make(H: HashedType): (S with type key = H.t) =
+module Make(H: HashedType): (FULL with type key = H.t) =
   struct
     include MakeSeeded(struct
         type t = H.t

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -403,7 +403,7 @@ module type S =
   sig
     type key
     type 'a t
-    val create : int -> 'a t
+    val create: int -> 'a t
     val clear : 'a t -> unit
     val reset : 'a t -> unit
     val copy : 'a t -> 'a t

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -215,6 +215,36 @@ val stats : ('a, 'b) t -> statistics
    buckets by size.
    @since 4.00.0 *)
 
+(** {6 Iterators} *)
+
+val to_iter : ('a,'b) t -> ('a * 'b) Iter.t
+(** Iterate on the whole table, in unspecified order.
+
+    The behavior is not defined if the hash table is modified
+    during the iteration.
+
+    @since NEXT_RELEASE *)
+
+val to_iter_keys : ('a,_) t -> 'a Iter.t
+(** Iterate on 'as, in ascending order
+    @since NEXT_RELEASE *)
+
+val to_iter_values : (_,'b) t -> 'b Iter.t
+(** Iterate on values, in ascending order of their corresponding 'a
+    @since NEXT_RELEASE *)
+
+val add_iter : ('a,'b) t -> ('a * 'b) Iter.t -> unit
+(** Add the given bindings to the table, using {!add}
+    @since NEXT_RELEASE *)
+
+val replace_iter : ('a,'b) t -> ('a * 'b) Iter.t -> unit
+(** Add the given bindings to the table, using {!replace}
+    @since NEXT_RELEASE *)
+
+val of_iter : ('a * 'b) Iter.t -> ('a, 'b) t
+(** Build a table from the given bindings
+    @since NEXT_RELEASE *)
+
 (** {6 Functorial interface} *)
 
 (** The functorial interface allows the use of specific comparison
@@ -291,9 +321,20 @@ module type S =
     val length : 'a t -> int
     val stats: 'a t -> statistics
   end
-(** The output signature of the functor {!Hashtbl.Make}. *)
+(** The core output signature of the functor {!Hashtbl.Make}. *)
 
-module Make (H : HashedType) : S with type key = H.t
+module type FULL =
+  sig
+    include S
+    val to_iter : 'a t -> (key * 'a) Iter.t
+    val to_iter_keys : _ t -> key Iter.t
+    val to_iter_values : 'a t -> 'a Iter.t
+    val add_iter : 'a t -> (key * 'a) Iter.t -> unit
+    val replace_iter : 'a t -> (key * 'a) Iter.t -> unit
+    val of_iter : (key * 'a) Iter.t -> 'a t
+  end
+
+module Make (H : HashedType) : FULL with type key = H.t
 (** Functor building an implementation of the hashtable structure.
     The functor [Hashtbl.Make] returns a structure containing
     a type [key] of keys and a type ['a t] of hash tables
@@ -344,10 +385,23 @@ module type SeededS =
     val length : 'a t -> int
     val stats: 'a t -> statistics
   end
-(** The output signature of the functor {!Hashtbl.MakeSeeded}.
+(** The core output signature of the functor {!Hashtbl.MakeSeeded}.
     @since 4.00.0 *)
 
-module MakeSeeded (H : SeededHashedType) : SeededS with type key = H.t
+module type SeededSFull =
+  sig
+    include SeededS
+    val to_iter : 'a t -> (key * 'a) Iter.t
+    val to_iter_keys : _ t -> key Iter.t
+    val to_iter_values : 'a t -> 'a Iter.t
+    val add_iter : 'a t -> (key * 'a) Iter.t -> unit
+    val replace_iter : 'a t -> (key * 'a) Iter.t -> unit
+    val of_iter : (key * 'a) Iter.t -> 'a t
+  end
+(** The full output signature of the functor {!Hashtbl.MakeSeeded}.
+    @since NEXT_RELEASE *)
+
+module MakeSeeded (H : SeededHashedType) : SeededSFull with type key = H.t
 (** Functor building an implementation of the hashtable structure.
     The functor [Hashtbl.MakeSeeded] returns a structure containing
     a type [key] of keys and a type ['a t] of hash tables

--- a/stdlib/iter.ml
+++ b/stdlib/iter.ml
@@ -1,0 +1,106 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                 Simon Cruanes                                          *)
+(*                                                                        *)
+(*   Copyright 2001 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Module [Iter]: functional iterators *)
+
+type ('a, 's) step =
+  | Done
+  | Skip of 's
+  | Yield of 'a * 's
+
+type +_ t =
+  | Sequence : 's * ('s -> ('a,'s) step) -> 'a t
+
+let empty = Sequence ((), (fun _ -> Done))
+
+let return x =
+  let next = function
+    | true -> Done
+    | false -> Yield (x, true)
+  in
+  Sequence (false, next)
+
+let map f (Sequence (state, next)) =
+  let next' s = match next s with
+    | Done -> Done
+    | Skip s -> Skip s
+    | Yield (x, s') -> Yield (f x, s')
+  in
+  Sequence (state, next')
+
+let filter_map f (Sequence (state, next)) =
+  let next' s = match next s with
+    | Done -> Done
+    | Skip s -> Skip s
+    | Yield (x, s') ->
+        match f x with
+          | None -> Skip s'
+          | Some y -> Yield (y, s')
+  in
+  Sequence (state, next')
+
+let filter f (Sequence (state, next)) =
+  let next' s = match next s with
+    | Done -> Done
+    | Skip _ as res -> res
+    | Yield (x, _) as res when f x -> res
+    | Yield (_, s') -> Skip s'
+  in
+  Sequence (state, next')
+
+type ('a, 'b, 'top_st) flat_map_state =
+    FMS :
+      { top: 'top_st;
+        sub: 'sub_st;
+        sub_next: 'sub_st -> ('b, 'sub_st) step
+      } -> ('a, 'b, 'top_st) flat_map_state
+
+let flat_map f (Sequence (state, next)) =
+  let next' (FMS { top; sub; sub_next}) =
+    match sub_next sub with
+      | Skip sub' -> Skip (FMS {top; sub=sub'; sub_next})
+      | Done ->
+          begin match next top with
+            | Done -> Done
+            | Skip top' -> Skip (FMS {top=top'; sub; sub_next})
+            | Yield (x, top') ->
+                let Sequence (sub, sub_next) = f x in
+                Skip (FMS { top=top'; sub; sub_next; })
+          end
+      | Yield (x, sub') ->
+          Yield (x, FMS {top; sub=sub'; sub_next})
+  in
+  let s0 = FMS {top=state; sub=(); sub_next=(fun _ -> Done) } in
+  Sequence (s0, next')
+
+let fold_left f acc (Sequence (state,next)) =
+  let rec aux f acc state = match next state with
+    | Done -> acc
+    | Skip state' -> aux f acc state'
+    | Yield (x, state') ->
+        let acc = f acc x in
+        aux f acc state'
+  in
+  aux f acc state
+
+let iter f (Sequence (state,next)) =
+  let rec aux state = match next state with
+    | Done -> ()
+    | Skip state' -> aux state'
+    | Yield (x, state') ->
+        f x;
+        aux state'
+  in
+  aux state

--- a/stdlib/iter.ml
+++ b/stdlib/iter.ml
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                 Simon Cruanes                                          *)
 (*                                                                        *)
-(*   Copyright 2001 Institut National de Recherche en Informatique et     *)
+(*   Copyright 2017 Institut National de Recherche en Informatique et     *)
 (*     en Automatique.                                                    *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)

--- a/stdlib/iter.mli
+++ b/stdlib/iter.mli
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                 Simon Cruanes                                          *)
 (*                                                                        *)
-(*   Copyright 2001 Institut National de Recherche en Informatique et     *)
+(*   Copyright 2017 Institut National de Recherche en Informatique et     *)
 (*     en Automatique.                                                    *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)

--- a/stdlib/iter.mli
+++ b/stdlib/iter.mli
@@ -2,9 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                 Simon Cruanes                                          *)
 (*                                                                        *)
-(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*   Copyright 2001 Institut National de Recherche en Informatique et     *)
 (*     en Automatique.                                                    *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
@@ -13,44 +13,30 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type 'a t = { mutable c : 'a list; mutable len : int; }
+(* Module [Iter]: functional iterators *)
 
-exception Empty
+(** @since NEXT_RELEASE *)
 
-let create () = { c = []; len = 0; }
+type ('a, 's) step =
+  | Done
+  | Skip of 's
+  | Yield of 'a * 's
 
-let clear s = s.c <- []; s.len <- 0
+type +_ t =
+  | Sequence : 's * ('s -> ('a,'s) step) -> 'a t
 
-let copy s = { c = s.c; len = s.len; }
+val empty : 'a t
 
-let push x s = s.c <- x :: s.c; s.len <- s.len + 1
+val return : 'a -> 'a t
 
-let pop s =
-  match s.c with
-  | hd::tl -> s.c <- tl; s.len <- s.len - 1; hd
-  | []     -> raise Empty
+val map : ('a -> 'b) -> 'a t -> 'b t
 
-let top s =
-  match s.c with
-  | hd::_ -> hd
-  | []     -> raise Empty
+val filter : ('a -> bool) -> 'a t -> 'a t
 
-let is_empty s = (s.c = [])
+val filter_map : ('a -> 'b option) -> 'a t -> 'b t
 
-let length s = s.len
+val flat_map : ('a -> 'b t) -> 'a t -> 'b t
 
-let iter f s = List.iter f s.c
+val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
 
-let fold f acc s = List.fold_left f acc s.c
-
-(** {6 Iterators} *)
-
-let to_iter s = List.to_iter s.c
-
-let add_iter q i = Iter.iter (fun x -> push x q) i
-
-let of_iter g =
-  let s = create() in
-  add_iter s g;
-  s
-
+val iter : ('a -> unit) -> 'a t -> unit

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -466,3 +466,25 @@ let rec compare_length_with l n =
   | _, 0 -> 1
   | _ :: l, n -> compare_length_with l (n-1)
 ;;
+
+(** {6 Iterators} *)
+
+let to_iter l =
+  let next = function
+    | [] -> Iter.Done
+    | x :: tail -> Iter.Yield (x, tail)
+  in Iter.Sequence (l, next)
+
+let of_iter (Iter.Sequence (state,next)) =
+  let rec direct depth state : _ list =
+    if depth=0
+    then
+      let i' = Iter.Sequence (state, next) in
+      Iter.fold_left (fun acc x -> x::acc) [] i'
+      |> rev (* tailrec *)
+    else match next state with
+      | Iter.Done -> []
+      | Iter.Skip state' -> direct depth state'
+      | Iter.Yield (x, state') -> x :: direct (depth-1) state'
+  in
+  direct 500 state

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -338,3 +338,13 @@ val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
     before the elements of [l2].
     Not tail-recursive (sum of the lengths of the arguments).
 *)
+
+(** {6 Iterators} *)
+
+val to_iter : 'a list -> 'a Iter.t
+(** Iterate on the list
+    @since NEXT_RELEASE *)
+
+val of_iter : 'a Iter.t -> 'a list
+(** Create a list from the iterator
+    @since NEXT_RELEASE *)

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -283,7 +283,24 @@ module type S =
     (** Same as {!Map.S.map}, but the function receives as arguments both the
        key and the associated value for each binding of the map. *)
 
+    (** {6 Iterators} *)
 
+    val to_iter : 'a t -> (key * 'a) Iter.t
+    (** Iterate on the whole map, in ascending order
+        @since NEXT_RELEASE *)
+
+    val to_iter_at : key -> 'a t -> (key * 'a) Iter.t
+    (** [to_iter_at k m] iterates on a subset of the bindings of [m],
+        in ascending order, from key [k] or above.
+        @since NEXT_RELEASE *)
+
+    val add_iter : 'a t -> (key * 'a) Iter.t -> 'a t
+    (** Add the given bindings to the map, in order.
+        @since NEXT_RELEASE *)
+
+    val of_iter : (key * 'a) Iter.t -> 'a t
+    (** Build a map from the given bindings
+        @since NEXT_RELEASE *)
   end
 (** Output signature of the functor {!Map.Make}. *)
 

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -47,6 +47,12 @@ module Hashtbl : sig
   val is_randomized : unit -> bool
   type statistics = Hashtbl.statistics
   val stats : ('a, 'b) t -> statistics
+  val to_iter : ('a,'b) t -> ('a * 'b) Iter.t
+  val to_iter_keys : ('a,_) t -> 'a Iter.t
+  val to_iter_values : (_,'b) t -> 'b Iter.t
+  val add_iter : ('a,'b) t -> ('a * 'b) Iter.t -> unit
+  val replace_iter : ('a,'b) t -> ('a * 'b) Iter.t -> unit
+  val of_iter : ('a * 'b) Iter.t -> ('a, 'b) t
   module type HashedType = Hashtbl.HashedType
   module type SeededHashedType = Hashtbl.SeededHashedType
   module type S =
@@ -147,6 +153,10 @@ module Map : sig
       val find_last_opt : f:(key -> bool) -> 'a t -> (key * 'a) option
       val map : f:('a -> 'b) -> 'a t -> 'b t
       val mapi : f:(key -> 'a -> 'b) -> 'a t -> 'b t
+      val to_iter : 'a t -> (key * 'a) Iter.t
+      val to_iter_at : key -> 'a t -> (key * 'a) Iter.t
+      val add_iter : 'a t -> (key * 'a) Iter.t -> 'a t
+      val of_iter : (key * 'a) Iter.t -> 'a t
   end
   module Make : functor (Ord : OrderedType) -> S with type key = Ord.t
 end
@@ -192,6 +202,10 @@ module Set : sig
       val find_last: f:(elt -> bool) -> t -> elt
       val find_last_opt: f:(elt -> bool) -> t -> elt option
       val of_list: elt list -> t
+      val to_iter_at : elt -> t -> elt Iter.t
+      val to_iter : t -> elt Iter.t
+      val add_iter : t -> elt Iter.t -> t
+      val of_iter : elt Iter.t -> t
     end
   module Make : functor (Ord : OrderedType) -> S with type elt = Ord.t
 end

--- a/stdlib/queue.ml
+++ b/stdlib/queue.ml
@@ -130,3 +130,20 @@ let transfer q1 q2 =
       last.next <- q1.first;
       q2.last <- q1.last;
       clear q1
+
+(** {6 Iterators} *)
+
+let to_iter q =
+  let next = function
+    | Nil -> Iter.Done
+    | Cons { content=x; next; } -> Iter.Yield (x, next)
+  in
+  Iter.Sequence (q.first, next)
+
+let add_iter q i = Iter.iter (fun x -> push x q) i
+
+let of_iter g =
+  let q = create() in
+  add_iter q g;
+  q
+

--- a/stdlib/queue.mli
+++ b/stdlib/queue.mli
@@ -80,3 +80,20 @@ val transfer : 'a t -> 'a t -> unit
    the queue [q2], then clears [q1]. It is equivalent to the
    sequence [iter (fun x -> add x q2) q1; clear q1], but runs
    in constant time. *)
+
+(** {6 Iterators} *)
+
+val to_iter : 'a t -> 'a Iter.t
+(** Iterate on the queue, in front-to-back order.
+    The behavior is not defined if the queue is modified
+    during the iteration.
+    @since NEXT_RELEASE *)
+
+val add_iter : 'a t -> 'a Iter.t -> unit
+(** Add the elements from the generator to the end of the queue
+    @since NEXT_RELEASE *)
+
+val of_iter : 'a Iter.t -> 'a t
+(** Create an array from the generator
+    @since NEXT_RELEASE *)
+

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -258,6 +258,25 @@ module type S =
         This is usually more efficient than folding [add] over the list,
         except perhaps for lists with many duplicated elements.
         @since 4.02.0 *)
+
+    (** {6 Iterators} *)
+
+    val to_iter_at : elt -> t -> elt Iter.t
+    (** [to_iter_at x s] iterates on a subset of the elements of [s]
+        in ascending order, from [x] or above.
+        @since NEXT_RELEASE *)
+
+    val to_iter : t -> elt Iter.t
+    (** Iterate on the whole set, in ascending order
+        @since NEXT_RELEASE *)
+
+    val add_iter : t -> elt Iter.t -> t
+    (** Add the given elements to the set, in order.
+        @since NEXT_RELEASE *)
+
+    val of_iter : elt Iter.t -> t
+    (** Build a set from the given bindings
+        @since NEXT_RELEASE *)
   end
 (** Output signature of the functor {!Set.Make}. *)
 

--- a/stdlib/stack.mli
+++ b/stdlib/stack.mli
@@ -61,3 +61,19 @@ val fold : ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b
     where [x1] is the top of the stack, [x2] the second element,
     and [xn] the bottom element. The stack is unchanged.
     @since 4.03 *)
+
+(** {6 Iterators} *)
+
+val to_iter : 'a t -> 'a Iter.t
+(** Iterate on the stack, top to bottom.
+    It is safe to modify the stack during iteration.
+    @since NEXT_RELEASE *)
+
+val add_iter : 'a t -> 'a Iter.t -> unit
+(** Add the elements from the iterator on the top of the stack.
+    @since NEXT_RELEASE *)
+
+val of_iter : 'a Iter.t -> 'a t
+(** Create a stack from the iterator
+    @since NEXT_RELEASE *)
+

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -224,3 +224,12 @@ let capitalize s =
   B.capitalize (bos s) |> bts
 let uncapitalize s =
   B.uncapitalize (bos s) |> bts
+
+(** {6 Iterators} *)
+
+let to_iter s = bos s |> B.to_iter
+
+let to_iteri s = bos s |> B.to_iteri
+
+let of_iter g = B.of_iter g |> bts
+

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -333,6 +333,20 @@ val split_on_char: char -> string -> string list
     @since 4.04.0
 *)
 
+(** {6 Iterators} *)
+
+val to_iter : t -> char Iter.t
+(** Iterate on the string , in increasing order
+    @since NEXT_RELEASE *)
+
+val to_iteri : t -> (int * char) Iter.t
+(** Iterate on the string, in increasing order, yielding indices along chars
+    @since NEXT_RELEASE *)
+
+val of_iter : char Iter.t -> t
+(** Create a string from the generator
+    @since NEXT_RELEASE *)
+
 (**/**)
 
 (* The following is for system use only. Do not call directly. *)


### PR DESCRIPTION
Following the new guidelines, here is the first of a series of proposals to improve and extend the stdlib.

I think iterators should be available in the stdlib for several of the reasons mentionned in the guidelines:
- "they cannot easily be implemented externally": if I don't have access to the internals of `Map`, `Stack` or `Hashtbl`, I cannot implement proper iterators on them;
- "they facilitate communication between independent external libraries": having iterators makes it easier to transfer data between various data structures by just providing two functions (from/to). 
## Testing

There are no tests right now, because it's not clear to me how to test those. I already have some tests using [qtest](https://github.com/vincent-hugot/iTeML), but that relies on 3rd party tools. I think tests using expect/result files are overkill, so we probably should have a small unit/random testing lib in the compiler? I will obviously upgrade this PR once the proper way of testing becomes clear. 
## The iterator type

I have been involved in discussions with Janestreet, @dbuenzli and others to try to agree on a common iterator type (batteries/extlib have `Enum`, JST has `Core.Sequence`, I use `sequence`, etc.). We did not reach an agreement, in parts because of performance considerations related to flambda. I still think the solution I propose, `type 'a gen = unit -> 'a option`, is the best tradeoff:
- it is simple, and easy to implement;
- it is structural, making compatibility between libraries trivial (just declare it; no need for a `result`/`bytes` compatibility package);
- it looks a lot like iterators in many other languages, including python, java, C#, rust, etc. and therefore should be familiar to many programmers;
- there already is an extensive [library of combinators](https://github.com/c-cube/gen/) for it, demonstrating that it is indeed possible to implement many operations on it;
- it has good performance, even with flambda (see benchmark results for 4.03 and 4.03+flambda below); the much faster iterators (sequence and fold) are less expressive, and cannot express `zip`, `merge`, `map2` and the likes. In contrast, `gen` can be used for consuming an iterator step by step.

**edit**: the current proposal no longer uses `gen`, but instead uses the same type as `Core.Sequence`, which should make interoperability with `Core` possible. It has the advantages of being explicit, purely functional, and likely to be optimized by flambda in the future.

https://github.com/c-cube/iterators_bench/blob/master/res_4.03
https://github.com/c-cube/iterators_bench/blob/master/res_4.03_flambda
## Other planned proposals:

(as a mere preview ;)
- a module for options (map, flat_map, etc. really "fill obvious gaps", as in, they are useful in every single OCaml program).
- ideally, I'd like a module `IO` in which channel-related functions could go, but they already belong in pervasives, so this ship probably has sailed. Nevertheless, I'd like to add some functions that promote a safe handling of resources, in the vein of `val with_file_in : string -> (in_channel -> 'a) -> 'a` (taking care of always closing the file); also, some idiom to iterate on the lines in a channel, read a whole channel into a string, and other basics that get reinvented hundreds of times in the community.
