### PR TITLE
Turn local exceptions into jumps

### DIFF
--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -141,6 +141,9 @@ type primitive =
   (* Inhibition of optimisation *)
   | Popaque
 
+  (* Marker for static exception *)
+  | Pstatic_exn of Location.t
+
 and comparison =
     Ceq | Cneq | Clt | Cgt | Cle | Cge
 

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -147,6 +147,9 @@ type primitive =
   (* Inhibition of optimisation *)
   | Popaque
 
+  (* Marker for static exception *)
+  | Pstatic_exn of Location.t
+
 and comparison =
     Ceq | Cneq | Clt | Cgt | Cle | Cge
 

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -294,6 +294,7 @@ let primitive ppf = function
   | Pbbswap(bi) -> print_boxed_integer "bswap" ppf bi
   | Pint_as_pointer -> fprintf ppf "int_as_pointer"
   | Popaque -> fprintf ppf "opaque"
+  | Pstatic_exn _ -> fprintf ppf "static_exn"
 
 let name_of_primitive = function
   | Pidentity -> "Pidentity"
@@ -390,6 +391,7 @@ let name_of_primitive = function
   | Pbbswap _ -> "Pbbswap"
   | Pint_as_pointer -> "Pint_as_pointer"
   | Popaque -> "Popaque"
+  | Pstatic_exn _ -> "Pstatic_exn"
 
 let function_attribute ppf { inline; specialise; is_a_functor } =
   if is_a_functor then

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -982,9 +982,14 @@ and transl_exp0 e =
            !transl_module Tcoerce_none None modl,
            transl_exp body)
   | Texp_letexception(cd, body) ->
-      Llet(Strict, Pgenval,
-           cd.ext_id, transl_extension_constructor e.exp_env None cd,
-           transl_exp body)
+      let exn = transl_extension_constructor e.exp_env None cd  in
+      let r = Llet(Strict, Pgenval, cd.ext_id, exn, transl_exp body) in
+      if Attr_helper.has_no_payload_attribute ["static"; "ocaml.static"]
+          cd.ext_attributes
+      || Attr_helper.has_no_payload_attribute ["static"; "ocaml.static"]
+           e.exp_attributes
+      then Lprim(Pstatic_exn e.exp_loc, [r])
+      else r
   | Texp_pack modl ->
       !transl_module Tcoerce_none None modl
   | Texp_assert {exp_desc=Texp_construct(_, {cstr_name="false"}, _)} ->

--- a/middle_end/semantics_of_primitives.ml
+++ b/middle_end/semantics_of_primitives.ml
@@ -37,6 +37,7 @@ let for_primitive (prim : Lambda.primitive) =
   | Plazyforce
   | Pccall _ -> Arbitrary_effects, Has_coeffects
   | Praise _ -> Arbitrary_effects, No_coeffects
+  | Pstatic_exn _
   | Pnot
   | Pnegint
   | Paddint

--- a/testsuite/tests/warnings/w60.ml
+++ b/testsuite/tests/warnings/w60.ml
@@ -1,0 +1,107 @@
+(* bad *)
+let f1 () =
+  let exception[@static] E in
+  E
+
+
+(* ok *)
+let f2 () =
+  let exception[@static] E in
+  try raise E
+  with E -> ()
+
+
+(* ok *)
+let f3 () =
+  let exception[@static] E in
+  fun () ->
+    try raise E
+    with E -> ()
+
+
+(* bad *)
+let f4 () =
+  let exception[@static] E in
+  try
+    fun () -> raise E
+  with E -> fun () -> ()
+
+
+(* ok *)
+let f5 i =
+  let exception[@static] E in
+  let exception[@static] F in
+  let exception[@static] G of int * int in
+  fun () ->
+    try
+      if i = 1 then raise E
+      else if i = 2 then raise Exit
+      else if i = 3 then raise Not_found
+      else if i = 4 then raise F
+      else if i = 5 then raise (G (40, 2))
+      else i
+    with E | F | Exit -> 0
+       | Not_found -> 1
+       | G (x, y) -> x + y
+
+
+(* ok *)
+let f6 x =
+  let exception[@static] Ret of bool * int in
+  let r = ref 0 in
+  try
+    for _i = 1 to 10000 do
+      r := !r + x;
+      if !r > 1000 then raise (Ret (true, !r));
+
+      r := !r + x;
+      if !r > 1000 then raise (Ret (false, !r));
+    done;
+    !r
+  with
+  | Ret (true, x) -> x
+  | Ret (false, x) -> x
+
+
+(* ok *)
+let f7 x =
+  let exception[@static] Ret of bool * int in
+  let exception[@static] Foo in
+  let r = ref 0 in
+  try
+    for _i = 1 to 10000 do
+      r := !r + x;
+      if !r > 1000 then raise (Ret (true, !r));
+
+      r := !r + x;
+      if !r > 1000 then raise (Ret (false, !r));
+
+      if !r = 200 then raise Foo;
+      if !r = 100 then raise Exit;
+    done;
+    !r
+  with
+  | Ret (true, x) -> x
+  | Ret (false, x) -> -x
+  | Foo | Exit -> 42
+
+
+let f8 x =
+  let exception[@static] Foo in (* ok *)
+  let exception[@static] Ret of bool * int in (* bad *)
+  let r = ref 0 in
+  try
+    for _i = 1 to 10000 do
+      r := !r + x;
+      if !r > 1000 then raise (Ret (true, !r));
+
+      r := !r + x;
+      if !r > 1000 then raise (Ret (false, !r));
+
+      if !r = 200 then raise Foo;
+      if !r = 100 then raise Exit;
+    done;
+    !r
+  with
+  | Ret (true, x) -> x
+  | Foo | Exit -> 42

--- a/testsuite/tests/warnings/w60.reference
+++ b/testsuite/tests/warnings/w60.reference
@@ -1,0 +1,6 @@
+File "w60.ml", line 91, characters 2-381:
+Warning 60: this exception is not static
+File "w60.ml", line 24, characters 2-82:
+Warning 60: this exception is not static
+File "w60.ml", line 3, characters 2-33:
+Warning 60: this exception is not static

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -80,6 +80,7 @@ type t =
   | Ambiguous_pattern of string list        (* 57 *)
   | No_cmx_file of string                   (* 58 *)
   | Assignment_to_non_mutable_value         (* 59 *)
+  | Exception_not_static                    (* 60 *)
 ;;
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
@@ -148,9 +149,10 @@ let number = function
   | Ambiguous_pattern _ -> 57
   | No_cmx_file _ -> 58
   | Assignment_to_non_mutable_value -> 59
+  | Exception_not_static -> 60
 ;;
 
-let last_warning_number = 59
+let last_warning_number = 60
 ;;
 
 (* Must be the max number returned by the [number] function. *)
@@ -472,6 +474,8 @@ let message = function
       "A potential assignment to a non-mutable value was detected \n\
         in this source file.  Such assignments may generate incorrect code \n\
         when using Flambda."
+  | Exception_not_static ->
+      "this exception is not static"
 ;;
 
 let nerrors = ref 0;;
@@ -571,6 +575,7 @@ let descriptions =
    57, "Ambiguous or-pattern variables under guard";
    58, "Missing cmx file";
    59, "Assignment to non-mutable value";
+   60, "Local exception marked with @static is not static."
   ]
 ;;
 

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -75,6 +75,7 @@ type t =
   | Ambiguous_pattern of string list        (* 57 *)
   | No_cmx_file of string                   (* 58 *)
   | Assignment_to_non_mutable_value         (* 59 *)
+  | Exception_not_static                    (* 60 *)
 ;;
 
 val parse_options : bool -> string -> unit;;


### PR DESCRIPTION
This is a rebased version of #260, following the addition of local exceptions (without the optimization) in #301.  (I prefer to open a new PR since the discussion in #260 included parts about local exception themselves.)

The current version is still based on reverse engineering exception matching at the lambda level.
