### PR TITLE
Pervasives.tap

### DIFF
--- a/otherlibs/threads/pervasives.ml
+++ b/otherlibs/threads/pervasives.ml
@@ -42,6 +42,7 @@ exception Exit
 
 external ( |> ) : 'a -> ('a -> 'b) -> 'b = "%revapply"
 external ( @@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
+let tap f x = let _ = f x in x
 
 (* Debugging *)
 

--- a/stdlib/pervasives.ml
+++ b/stdlib/pervasives.ml
@@ -38,6 +38,7 @@ exception Exit
 
 external ( |> ) : 'a -> ('a -> 'b) -> 'b = "%revapply"
 external ( @@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
+let tap f x = let _ = f x in x
 
 (* Debugging *)
 

--- a/stdlib/pervasives.mli
+++ b/stdlib/pervasives.mli
@@ -219,6 +219,10 @@ external ( @@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
    @since 4.01
 *)
 
+val tap : ('a -> _) -> 'a -> 'a
+(** [x |> tap f] discards the result of [f x] and returns [x]
+*)
+
 (** {6 Integer arithmetic} *)
 
 (** Integers are 31 bits wide (or 63 bits on 64-bit processors).


### PR DESCRIPTION
Following the lead of other proposals for making the stdlib a little more
convenient, I've decided to share a tiny function that I end up defining quite
often in my OCaml code.

When writing long `|>` pipelines, it's often useful to insert debugging
statements non intrusively. The `tap` function does exactly that. The name
`tap` is after ruby's similar `.tap` method. I'm open to any names however.

Example of what I mean:

``` ocaml
[ 1 ; 2 ; 3 ; 4 ]
|> List.filter (fun x -> x > 2)
|> tap (fun l -> Printf.printf "Now only %d elements\n" (List.length l))
|> List.iter (Printf.printf "%d\n")
```
