### PR TITLE
Add message about results not matching reference output when test fail

### DIFF
--- a/testsuite/makefiles/Makefile.several
+++ b/testsuite/makefiles/Makefile.several
@@ -108,9 +108,15 @@ run-file:
 	fi \
 	&& \
 	if [ -f $$F.checker ]; then \
-	  DIFF="$(DIFF)" SORT="$(SORT)" sh $$F.checker; \
+	  DIFF="$(DIFF)" SORT="$(SORT)" sh $$F.checker || { \
+	    printf "  Error: output checker failed!\n"; \
+	    exit 1; \
+	  }; \
 	else \
-	  $(DIFF) $$F.reference $$F.result >/dev/null; \
+	  $(DIFF) $$F.reference $$F.result >/dev/null || { \
+	    printf "  Error: results don't match reference output!\n"; \
+	    exit 1; \
+	  }; \
 	fi
 
 .PHONY: promote


### PR DESCRIPTION
When the output of a test does not match the reference output the error message is cryptic. This patch adds an explicit error message to make clear what the error is.
