### PR TITLE
ocamlyacc: output verbose file before failing on --strict.

### DIFF
--- a/yacc/main.c
+++ b/yacc/main.c
@@ -462,6 +462,7 @@ int main(int argc, char **argv)
     lalr();
     make_parser();
     verbose();
+    if (eflag && SRtotal + RRtotal > 0) forbidden_conflicts();
     output();
     done(0);
     /*NOTREACHED*/

--- a/yacc/mkpar.c
+++ b/yacc/mkpar.c
@@ -47,11 +47,7 @@ void make_parser(void)
     find_final_state();
     remove_conflicts();
     unused_rules();
-    if (SRtotal + RRtotal > 0) {
-        total_conflicts();
-        if (eflag)
-            forbidden_conflicts();
-    }
+    if (SRtotal + RRtotal > 0) total_conflicts();
     defreds();
 }
 


### PR DESCRIPTION
This is a follow-up to #598  which added a flag `--strict` to `ocamlyacc` to fail if the grammar contains any conflicts.

Currently using this flag causes `ocamlyacc` to exit before the `.output` file is fully generated, so that the `-v` flag is useless.  The only way to learn about the conflicts is to re-run without `--strict` flag.

Instead, this patch simply delays the check for conflicts so that the `.output` file has a chance to be generated even if there are conflicts.
