### PR TITLE
Display paths using backslashes on Windows

### DIFF
--- a/Makefile.nt
+++ b/Makefile.nt
@@ -373,7 +373,8 @@ otherlibs/dynlink/dynlink.cmxa: otherlibs/dynlink/natdynlink.ml
 
 utils/config.ml: utils/config.mlp config/Makefile
 	@rm -f utils/config.ml
-	sed -e "s|%%LIBDIR%%|$(LIBDIR)|" \
+	# Convert forward-slashes in LIBDIR to backslashes
+	sed -e "s|%%LIBDIR%%|$(shell echo $(LIBDIR)|sed -e 's:/:\\\\\\\\\\\\\\\\:g')|" \
 	    -e "s|%%BYTERUN%%|ocamlrun|" \
 	    -e 's|%%CCOMPTYPE%%|$(CCOMPTYPE)|' \
 	    -e "s|%%BYTECC%%|$(BYTECC) $(BYTECCCOMPOPTS)|" \

--- a/byterun/Makefile.common
+++ b/byterun/Makefile.common
@@ -55,8 +55,14 @@ all:: ocamlruni$(EXE) libcamlruni.$(A)
 endif
 
 ld.conf: ../config/Makefile
+ifeq ($(TOOLCHAIN),cc)
 	echo "$(STUBLIBDIR)" > ld.conf
 	echo "$(LIBDIR)" >> ld.conf
+else
+	# Convert forward-slashes and backslashes and use Windows line-endings
+	echo "$(shell echo $(STUBLIBDIR)|sed -e 's:/:\\\\:g')"| sed -e "s/$$/\r/" > ld.conf
+	echo "$(shell echo $(LIBDIR)| sed -e 's:/:\\\\:g')"| sed -e "s/$$/\r/" >> ld.conf
+endif
 
 # Installation
 


### PR DESCRIPTION
Packaging up myriad OCaml versions ready for native Windows OPAM has finally made me fix a nagging irritation of the last decade or so...!

The premise is simple: while they are supported, professional Windows applications do not use forward-slashes in paths. Period.

This patch:
- Changes the generation of `utils/config.ml` to translate forward-slashes (which are legitimately needed in the Unix-based build system) to back-slashes, meaning that `ocamlc -config` (and `ocamlc -v`) display the default standard library location "correctly".
- Does the same when generating `byterun/ld.conf`
- While there, also sw9tches to Windows line-endings for `ld.conf`

A few minor observations:
- The fact that Windows supports forward-slashes in paths is a fact known only by quite advanced Windows users and Unix users who are forced to target their software to Windows!
- Having the standard library location use back-slashes is a good torture test for poorly written package configure scripts (see, for example, the excellent handling in findlib's `configure` script for how this should be done)
- While there can't be (m)any programmers relying on Notepad.exe, it doesn't process files with Unix line-endings, which is a mild irritation for editing `ld.conf`.
- May I claim a prize for the largest number of backslashes needed in a row in a `Makefile`?
