### PR TITLE
Detection from C as to whether our caller was OCaml

### DIFF
--- a/asmrun/stack.h
+++ b/asmrun/stack.h
@@ -73,6 +73,20 @@
 #define Callback_link(sp) ((struct caml_context *)((sp) + 16))
 #endif
 
+/* Detection as to whether the current C function was called from OCaml. */
+
+#ifdef NATIVE_CODE
+#if defined(SYS_mingw) || defined(SYS_mingw64) || defined(SYS_cygwin)
+#include <intrin.h>
+#pragma intrinsic(_ReturnAddress)
+#define DIRECTLY_CALLED_FROM_OCAML \
+  (_ReturnAddress() == (void*) caml_last_return_address)
+#else
+#define DIRECTLY_CALLED_FROM_OCAML \
+  (__builtin_return_address(0) == (void*) caml_last_return_address)
+#endif
+#endif
+
 /* Structure of OCaml callback contexts */
 
 struct caml_context {


### PR DESCRIPTION
This patch adds a macro that can be used in C functions to determine whether they were directly called from OCaml code.  This is needed for Spacetime instrumentation.

I am pretty sure this is correct for Unix, but I am unsure about Windows.  @alainfrisch : can you comment?  Should we be using the gcc builtin for `SYS_cygwin`?
