### PR TITLE
Add filename to system frametable for amd64

### DIFF
--- a/asmrun/amd64.S
+++ b/asmrun/amd64.S
@@ -677,6 +677,9 @@ G(caml_system__frametable):
         .value  -1          /* negative frame size => use callback link */
         .value  0           /* no roots here */
         .align  EIGHT_ALIGN
+        .quad   16
+        .quad   0
+        .string "amd64.S"
 
 #if defined(SYS_macosx)
         .literal16


### PR DESCRIPTION
This patch enables the system frametable on amd64 to be used for resolving the location of `caml_start_program`.  This is needed for Spacetime.  I have not yet replicated this across all backends since we currently only support amd64 for instrumentation.

This will make it clear in the main Spacetime patch that the changes to amd64.S are a no-op when Spacetime is not enabled.
