### PR TITLE
Stdlib: New functions Map.find_after and Map.find_before

### DIFF
--- a/stdlib/map.ml
+++ b/stdlib/map.ml
@@ -47,10 +47,10 @@ module type S =
     val choose: 'a t -> (key * 'a)
     val split: key -> 'a t -> 'a t * 'a option * 'a t
     val find: key -> 'a t -> 'a
-    val map: ('a -> 'b) -> 'a t -> 'b t
-    val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
     val find_after : (key -> 'a -> bool) -> key -> 'a t -> key * 'a
     val find_before : (key -> 'a -> bool) -> key -> 'a t -> key * 'a
+    val map: ('a -> 'b) -> 'a t -> 'b t
+    val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
   end
 
 module Make(Ord: OrderedType) = struct
@@ -367,7 +367,7 @@ module Make(Ord: OrderedType) = struct
         function
         | Empty ->
             None
-        | Node(l, v, d, r, h) ->
+        | Node(l, v, d, r, _) ->
             if iterating then (
               match recurse true l with
                 | Some _ as found -> found
@@ -394,7 +394,7 @@ module Make(Ord: OrderedType) = struct
         function
         | Empty ->
             None
-        | Node(l, v, d, r, h) ->
+        | Node(l, v, d, r, _) ->
             if iterating then (
               match recurse true r with
                 | Some _ as found -> found

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -212,6 +212,24 @@ module type S =
     (** [find x m] returns the current binding of [x] in [m],
        or raises [Not_found] if no such binding exists. *)
 
+    val find_after : (key -> 'a -> bool) -> key -> 'a t -> key * 'a
+    (** [find_after f x m] calls [f] for bindings with keys greater than
+        or equal to [x] in the order of ascending keys, and returns the
+        first binding [(key,data)] for which [f key data] is true. If there
+        are no such bindings or if [f] never returns true, the function
+        will raise [Not_found].
+        @since 4.03.1
+     *)
+
+    val find_before : (key -> 'a -> bool) -> key -> 'a t -> key * 'a
+    (** [find_before f x m] calls [f] for bindings with keys less than
+        or equal to [x] in the order of descending keys, and returns the
+        first binding [(key,data)] for which [f key data] is true. If there
+        are no such bindings or if [f] never returns true, the function
+        will raise [Not_found].
+        @since 4.03.1
+     *)
+
     val map: ('a -> 'b) -> 'a t -> 'b t
     (** [map f m] returns a map with same domain as [m], where the
        associated value [a] of all bindings of [m] has been
@@ -222,7 +240,6 @@ module type S =
     val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
     (** Same as {!Map.S.map}, but the function receives as arguments both the
        key and the associated value for each binding of the map. *)
-
 
   end
 (** Output signature of the functor {!Map.Make}. *)

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -133,6 +133,8 @@ module Map : sig
       val choose: 'a t -> (key * 'a)
       val split: key -> 'a t -> 'a t * 'a option * 'a t
       val find : key -> 'a t -> 'a
+      val find_after : f:(key -> 'a -> bool) -> key -> 'a t -> key * 'a
+      val find_before : f:(key -> 'a -> bool) -> key -> 'a t -> key * 'a
       val map : f:('a -> 'b) -> 'a t -> 'b t
       val mapi : f:(key -> 'a -> 'b) -> 'a t -> 'b t
   end

--- a/testsuite/tests/lib-set/testmap.ml
+++ b/testsuite/tests/lib-set/testmap.ml
@@ -106,7 +106,40 @@ let test x v s1 s2 =
      fun i ->
        if i < x then img i l = img i s1
        else if i > x then img i r = img i s1
-       else p = img i s1)
+       else p = img i s1);
+
+  checkbool "find_after1"
+    (try
+       let i, _ = M.find_after (fun _ _ -> true) x s1 in
+       not (M.exists (fun k _ -> k >= x && k < i) s1)
+     with Not_found ->
+       M.is_empty s1 || x > fst(M.max_binding s1)
+    );
+
+  checkbool "find_after2"
+    (try
+       let i, _ = M.find_after (fun k _ -> k > x) x s1 in
+       not (M.exists (fun k _ -> k > x && k < i) s1)
+     with Not_found ->
+       M.is_empty s1 || x >= fst(M.max_binding s1)
+    );
+
+  checkbool "find_before1"
+    (try
+       let i, _ = M.find_before (fun _ _ -> true) x s1 in
+       not (M.exists (fun k _ -> k <= x && k > i) s1)
+     with Not_found ->
+       M.is_empty s1 || x < fst(M.min_binding s1)
+    );
+
+  checkbool "find_before2"
+    (try
+       let i, _ = M.find_before (fun k _ -> k < x) x s1 in
+       not (M.exists (fun k _ -> k < x && k > i) s1)
+     with Not_found ->
+       M.is_empty s1 || x <= fst(M.min_binding s1)
+    )
+     
 
 let rkey() = Random.int 10
 


### PR DESCRIPTION
This implements the suggestion of http://caml.inria.fr/mantis/view.php?id=7277

I'm going here with Alain's idea of iterating over the successors/predecessors of the key until the callback function returns true.
