### PR TITLE
Export some more functions in C headers

### DIFF
--- a/asmrun/natdynlink.c
+++ b/asmrun/natdynlink.c
@@ -36,8 +36,6 @@ static void *getsym(void *handle, char *module, char *name){
   return sym;
 }
 
-extern char caml_globals_map[];
-
 CAMLprim value caml_natdynlink_getmap(value unit)
 {
   return (value)caml_globals_map;

--- a/asmrun/stack.h
+++ b/asmrun/stack.h
@@ -113,7 +113,10 @@ extern uintnat caml_last_return_address;
 extern value * caml_gc_regs;
 extern char * caml_exception_pointer;
 extern value * caml_globals[];
+extern char caml_globals_map[];
 extern intnat caml_globals_inited;
 extern intnat * caml_frametable[];
+
+CAMLextern frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp);
 
 #endif /* CAML_STACK_H */

--- a/byterun/caml/gc_ctrl.h
+++ b/byterun/caml/gc_ctrl.h
@@ -45,6 +45,8 @@ void caml_init_gc (uintnat minor_size, uintnat major_size, uintnat major_incr,
                    uintnat percent_fr, uintnat percent_m, uintnat window);
 
 
+CAMLextern value caml_gc_stat(value v);
+
 #ifdef DEBUG
 void caml_heap_check (void);
 #endif

--- a/byterun/caml/intext.h
+++ b/byterun/caml/intext.h
@@ -194,6 +194,8 @@ struct code_fragment {
   char digest_computed;
 };
 
+CAMLextern struct code_fragment * caml_extern_find_code(char *addr);
+
 struct ext_table caml_code_fragments_table;
 
 /* </private> */

--- a/byterun/caml/sys.h
+++ b/byterun/caml/sys.h
@@ -22,9 +22,10 @@
 
 CAMLextern void caml_sys_error (value);
 CAMLextern void caml_sys_io_error (value);
-extern double caml_sys_time_unboxed(value);
-extern void caml_sys_init (char * exe_name, char ** argv);
+CAMLextern double caml_sys_time_unboxed(value);
+CAMLextern void caml_sys_init (char * exe_name, char ** argv);
 CAMLextern value caml_sys_exit (value);
+CAMLextern value caml_sys_get_argv(value unit);
 
 extern char * caml_exe_name;
 

--- a/byterun/extern.c
+++ b/byterun/extern.c
@@ -94,7 +94,6 @@ CAMLnoreturn_start
 static void extern_stack_overflow(void)
 CAMLnoreturn_end;
 
-static struct code_fragment * extern_find_code(char *addr);
 static void extern_replay_trail(void);
 static void free_extern_output(void);
 
@@ -574,7 +573,7 @@ static void extern_rec(value v)
     }
     }
   }
-  else if ((cf = extern_find_code((char *) v)) != NULL) {
+  else if ((cf = caml_extern_find_code((char *) v)) != NULL) {
     if ((extern_flags & CLOSURES) == 0)
       extern_invalid_argument("output_value: functional value");
     writecode32(CODE_CODEPOINTER, (char *) v - cf->code_start);
@@ -891,7 +890,7 @@ CAMLexport void caml_serialize_block_float_8(void * data, intnat len)
 
 /* Find where a code pointer comes from */
 
-static struct code_fragment * extern_find_code(char *addr)
+CAMLexport struct code_fragment * caml_extern_find_code(char *addr)
 {
   int i;
   for (i = caml_code_fragments_table.size - 1; i >= 0; i--) {


### PR DESCRIPTION
This PR adds some functions to the C headers, so that they can be used in other files. I think that most of them are in private headers or private sections of public headers, so they should not impact standard C bindings.
