### PR TITLE
Add Filename.extension.

### DIFF
--- a/Changes
+++ b/Changes
@@ -112,6 +112,10 @@ OCaml 4.04.0:
 - GPR#626: String.split
   (Alain Frisch)
 
+- GPR#669: Filename.extension and Filename.remove_extension
+  (Alain Frisch, request by Edgar Aroutiounian, review by Daniel Bunzli
+  and Damien Doligez)
+
 ### Manual:
 
 - PR#7245, GPR#565: clarification to the wording and documentation

--- a/asmcomp/asmlibrarian.ml
+++ b/asmcomp/asmlibrarian.ml
@@ -47,7 +47,7 @@ let read_info name =
   (Filename.chop_suffix filename ".cmx" ^ ext_obj, (info, crc))
 
 let create_archive file_list lib_name =
-  let archive_name = chop_extension_if_any lib_name ^ ext_lib in
+  let archive_name = Filename.remove_extension lib_name ^ ext_lib in
   let outchan = open_out_bin lib_name in
   try
     output_string outchan cmxa_magic_number;

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -82,7 +82,7 @@ let make_package_object ppf members targetobj targetname coercion
       ~backend =
   let objtemp =
     if !Clflags.keep_asm_file
-    then chop_extension_if_any targetobj ^ ".pack" ^ Config.ext_obj
+    then Filename.remove_extension targetobj ^ ".pack" ^ Config.ext_obj
     else
       (* Put the full name of the module in the temporary file name
          to avoid collisions with MSVC's link /lib in case of successive
@@ -97,7 +97,7 @@ let make_package_object ppf members targetobj targetname coercion
       members in
   let module_ident = Ident.create_persistent targetname in
   let source_provenance = Timings.Pack targetname in
-  let prefixname = chop_extension_if_any objtemp in
+  let prefixname = Filename.remove_extension objtemp in
   if Config.flambda then begin
     let size, lam = Translmod.transl_package_flambda components coercion in
     let flam =
@@ -122,7 +122,7 @@ let make_package_object ppf members targetobj targetname coercion
   end;
   let objfiles =
     List.map
-      (fun m -> chop_extension_if_any m.pm_file ^ Config.ext_obj)
+      (fun m -> Filename.remove_extension m.pm_file ^ Config.ext_obj)
       (List.filter (fun m -> m.pm_kind <> PM_intf) members) in
   let ok =
     Ccomp.call_linker Ccomp.Partial targetobj (objtemp :: objfiles) ""
@@ -242,7 +242,7 @@ let package_files ppf initial_env files targetcmx ~backend =
       files in
   let prefix = chop_extensions targetcmx in
   let targetcmi = prefix ^ ".cmi" in
-  let targetobj = chop_extension_if_any targetcmx ^ Config.ext_obj in
+  let targetobj = Filename.remove_extension targetcmx ^ Config.ext_obj in
   let targetname = String.capitalize_ascii(Filename.basename prefix) in
   (* Set the name of the current "input" *)
   Location.input_name := targetcmx;

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -20,7 +20,7 @@ let output_prefix name =
     match !output_name with
     | None -> name
     | Some n -> if !compile_only then (output_name := None; n) else name in
-  Misc.chop_extension_if_any oname
+  Filename.remove_extension oname
 
 let print_version_and_library compiler =
   Printf.printf "The OCaml %s, version " compiler;

--- a/experimental/frisch/nomli.ml
+++ b/experimental/frisch/nomli.ml
@@ -99,7 +99,7 @@ and typ x : Parsetree.core_type =
 let mli_of_ml ppf sourcefile =
   Location.input_name := sourcefile;
   Compmisc.init_path false;
-  let file = chop_extension_if_any sourcefile in
+  let file = Filename.remove_extension sourcefile in
   let modulename = String.capitalize(Filename.basename file) in
   Env.set_unit_name modulename;
   let inputfile = Pparse.preprocess sourcefile in
@@ -111,4 +111,3 @@ let mli_of_ml ppf sourcefile =
 
 let () =
   mli_of_ml Format.err_formatter Sys.argv.(1)
-

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -199,12 +199,31 @@ let chop_suffix name suff =
   let n = String.length name - String.length suff in
   if n < 0 then invalid_arg "Filename.chop_suffix" else String.sub name 0 n
 
-let chop_extension name =
+let extension_len name =
+  let rec check i0 i =
+    if i < 0 || is_dir_sep name i then 0
+    else if name.[i] = '.' then check i0 (i - 1)
+    else String.length name - i0
+  in
   let rec search_dot i =
-    if i < 0 || is_dir_sep name i then invalid_arg "Filename.chop_extension"
-    else if name.[i] = '.' then String.sub name 0 i
-    else search_dot (i - 1) in
+    if i < 0 || is_dir_sep name i then 0
+    else if name.[i] = '.' then check i (i - 1)
+    else search_dot (i - 1)
+  in
   search_dot (String.length name - 1)
+
+let extension name =
+  let l = extension_len name in
+  if l = 0 then "" else String.sub name (String.length name - l) l
+
+let chop_extension name =
+  let l = extension_len name in
+  if l = 0 then invalid_arg "Filename.chop_extension"
+  else String.sub name 0 (String.length name - l)
+
+let remove_extension name =
+  let l = extension_len name in
+  if l = 0 then name else String.sub name 0 (String.length name - l)
 
 external open_desc: string -> open_flag list -> int -> int = "caml_sys_open"
 external close_desc: int -> unit = "caml_sys_close"

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -49,13 +49,37 @@ val chop_suffix : string -> string -> string
    the filename [name]. The behavior is undefined if [name] does not
    end with the suffix [suff]. *)
 
-val chop_extension : string -> string
-(** Return the given file name without its extension. The extension
-   is the shortest suffix starting with a period and not including
-   a directory separator, [.xyz] for instance.
+val extension : string -> string
+(** [extension name] is the shortest suffix [ext] of [name0] where:
 
-   Raise [Invalid_argument] if the given name does not contain
-   an extension. *)
+    - [name0] is the longest suffix of [name] that does not
+      contain a directory separator;
+    - [ext] starts with a period;
+    - [ext] is preceded by at least one non-period character
+      in [name0].
+
+    If such a suffix does not exist, [extension name] is the empty
+    string.
+
+    @since 4.04
+*)
+
+val remove_extension : string -> string
+(** Return the given file name without its extension, as defined
+    in {!Filename.extension}. If the extension is empty, the function
+    returns the given file name.
+
+    The following invariant holds for any file name [s]:
+
+    [remove_extension s ^ extension s = s]
+
+    @since 4.04
+*)
+
+val chop_extension : string -> string
+(** Same as {!Filename.remove_extension}, but raise [Invalid_argument]
+    if the given name has an empty extension. *)
+
 
 val basename : string -> string
 (** Split a file name into directory name / base file name.

--- a/testsuite/tests/lib-filename/Makefile
+++ b/testsuite/tests/lib-filename/Makefile
@@ -1,0 +1,18 @@
+#**************************************************************************
+#*                                                                        *
+#*                                OCaml                                   *
+#*                                                                        *
+#*                 Xavier Clerc, SED, INRIA Rocquencourt                  *
+#*                                                                        *
+#*   Copyright 2010 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+BASEDIR=../..
+include $(BASEDIR)/makefiles/Makefile.several
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/lib-filename/extension.ml
+++ b/testsuite/tests/lib-filename/extension.ml
@@ -1,0 +1,14 @@
+let () =
+  let test f e =
+    assert(Filename.extension f = e);
+    assert(Filename.extension ("foo/" ^ f) = e);
+    assert(f = Filename.remove_extension f ^ Filename.extension f)
+  in
+  test "" "";
+  test "foo" "";
+  test "foo.txt" ".txt";
+  test "foo.txt.gz" ".gz";
+  test ".foo" "";
+  test "." "";
+  test ".." "";
+  test "foo..txt" ".txt"

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1592,7 +1592,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
     (str, Tcoerce_none)   (* result is ignored by Compile.implementation *)
   end else begin
     let sourceintf =
-      Misc.chop_extension_if_any sourcefile ^ !Config.interface_suffix in
+      Filename.remove_extension sourcefile ^ !Config.interface_suffix in
     if Sys.file_exists sourceintf then begin
       let intf_file =
         try
@@ -1687,7 +1687,7 @@ let package_units initial_env objfiles cmifile modulename =
   Ident.reinit();
   let sg = package_signatures Subst.identity units in
   (* See if explicit interface is provided *)
-  let prefix = chop_extension_if_any cmifile in
+  let prefix = Filename.remove_extension cmifile in
   let mlifile = prefix ^ !Config.interface_suffix in
   if Sys.file_exists mlifile then begin
     if not (Sys.file_exists cmifile) then begin

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -309,9 +309,6 @@ end
 
 (* String operations *)
 
-let chop_extension_if_any fname =
-  try Filename.chop_extension fname with Invalid_argument _ -> fname
-
 let chop_extensions file =
   let dirname = Filename.dirname file and basename = Filename.basename file in
   try

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -155,10 +155,6 @@ module Int_literal_converter : sig
   val nativeint : string -> nativeint
 end
 
-val chop_extension_if_any: string -> string
-        (* Like Filename.chop_extension but returns the initial file
-           name if it has no extension *)
-
 val chop_extensions: string -> string
         (* Return the given file name without its extensions. The extensions
            is the longest suffix starting with a period and not including


### PR DESCRIPTION
Follow up to #609, #610.

The definition implemented here was suggested by Daniel Bünzli. It considers that ".", "..", ".foo" all have an empty extension.

This PR also fixes `chop_extension` to align with this definition and adds `chop_extension_if_any` which behaves as `chop_extension` but does not fail when the extension is empty (note: there is already
such a function in `Misc`, it should be replaced by this new one).
