### PR TITLE
Add single-line comments

### DIFF
--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -23,6 +23,7 @@ type error =
   | Illegal_character of char
   | Illegal_escape of string
   | Unterminated_comment of Location.t
+  | Interrupted_line_comment of Location.t
   | Unterminated_string
   | Unterminated_string_in_comment of Location.t * Location.t
   | Keyword_as_label of string

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -608,7 +608,13 @@ and line_comment = parse
                   comment lexbuf;
       }
   | eof
-      { Location.curr lexbuf }
+      { match !comment_start_loc with
+        | [] -> assert false
+        | loc :: _ ->
+          let start = List.hd (List.rev !comment_start_loc) in
+          comment_start_loc := [];
+          raise (Error (Unterminated_comment start, loc))
+      }
   | _
       { store_lexeme lexbuf; line_comment lexbuf }
 


### PR DESCRIPTION
I propose to use `(*)` as a token for single line comments.
This delimiter seems to be a good fit as it already starts a comment but also produce a warning. As such it is unlikely to break existing code (though I didn't check).

In other words:

``` ocaml
code
(* lalala *)
code
```

and:

``` ocaml
code
(*) lalala
code
```

would be equivalent.

This is a superficial feature but I got positive feedbacks from:
- users of Reason, which features single line comment and would benefit from a direct mapping to OCaml.
- adept of literate programming, who benefit from a lighter way to demarcate code and text lines.

So I thought it was worth getting the opinion of the broader community. 
