### PR TITLE
Distinguish root and heap values in Lambda.Initialization

### DIFF
--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -109,8 +109,8 @@ let prim_size prim args =
   | Pfield _ -> 1
   | Psetfield(_f, isptr, init) ->
     begin match init with
-    | Initialization -> 1  (* never causes a write barrier hit *)
-    | Assignment ->
+    | Root_initialization -> 1  (* never causes a write barrier hit *)
+    | Assignment | Heap_initialization ->
       match isptr with
       | Pointer -> 4
       | Immediate -> 1

--- a/asmcomp/flambda_to_clambda.ml
+++ b/asmcomp/flambda_to_clambda.ml
@@ -571,7 +571,7 @@ let to_clambda_initialize_symbol t env symbol fields : Clambda.ulambda =
   let build_setfield (index, field) : Clambda.ulambda =
     (* Note that this will never cause a write barrier hit, owing to
        the [Initialization]. *)
-    Uprim (Psetfield (index, Pointer, Initialization),
+    Uprim (Psetfield (index, Pointer, Root_initialization),
       [to_clambda_symbol env symbol; field],
       Debuginfo.none)
   in

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -70,7 +70,8 @@ let operation d = function
   | Cstore (c, init) ->
     let init =
       match init with
-      | Lambda.Initialization -> "(init)"
+      | Lambda.Heap_initialization -> "(heap-init)"
+      | Lambda.Root_initialization -> "(root-init)"
       | Lambda.Assignment -> ""
     in
     Printf.sprintf "store %s%s" (chunk c) init

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -304,7 +304,8 @@ method select_operation op args _dbg =
       let (addr, eloc) = self#select_addressing chunk arg1 in
       let is_assign =
         match init with
-        | Lambda.Initialization -> false
+        | Lambda.Root_initialization -> false
+        | Lambda.Heap_initialization -> false
         | Lambda.Assignment -> true
       in
       if chunk = Word_int || chunk = Word_val then begin

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -39,8 +39,9 @@ type immediate_or_pointer =
   | Pointer
 
 type initialization_or_assignment =
-  | Initialization
   | Assignment
+  | Heap_initialization
+  | Root_initialization
 
 type is_safe =
   | Safe

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -39,11 +39,14 @@ type immediate_or_pointer =
   | Pointer
 
 type initialization_or_assignment =
-  (* CR-someday mshinwell: For multicore, perhaps it might be necessary to
-     split [Initialization] into two cases, depending on whether the place
-     being initialized is in the heap or not. *)
-  | Initialization
   | Assignment
+  (* Initialization of in heap values, like [caml_initialize] C primitive.  The
+     field should not have been read before and initialization should happen
+     only once. *)
+  | Heap_initialization
+  (* Initialization of roots only. Compiles to a simple store.
+     No checks are done to preserve GC invariants.  *)
+  | Root_initialization
 
 type is_safe =
   | Safe

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -151,7 +151,8 @@ let primitive ppf = function
       in
       let init =
         match init with
-        | Initialization -> "(init)"
+        | Heap_initialization -> "(heap-init)"
+        | Root_initialization -> "(root-init)"
         | Assignment -> ""
       in
       fprintf ppf "setfield_%s%s %i" instr init n
@@ -159,7 +160,8 @@ let primitive ppf = function
   | Psetfloatfield (n, init) ->
       let init =
         match init with
-        | Initialization -> "(init)"
+        | Heap_initialization -> "(heap-init)"
+        | Root_initialization -> "(root-init)"
         | Assignment -> ""
       in
       fprintf ppf "setfloatfield%s %i" init n

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -925,7 +925,7 @@ let transl_store_structure glob map prims str =
     try
       let (pos, cc) = Ident.find_same id map in
       let init_val = apply_coercion loc Alias cc (Lvar id) in
-      Lprim(Psetfield(pos, Pointer, Initialization),
+      Lprim(Psetfield(pos, Pointer, Root_initialization),
             [Lprim(Pgetglobal glob, [], loc); init_val],
             loc)
     with Not_found ->
@@ -953,7 +953,7 @@ let transl_store_structure glob map prims str =
     List.fold_right (add_ident may_coerce) idlist subst
 
   and store_primitive (pos, prim) cont =
-    Lsequence(Lprim(Psetfield(pos, Pointer, Initialization),
+    Lsequence(Lprim(Psetfield(pos, Pointer, Root_initialization),
                     [Lprim(Pgetglobal glob, [], Location.none);
                      transl_primitive Location.none
                        prim.pc_desc prim.pc_env prim.pc_type None],
@@ -1209,7 +1209,7 @@ let transl_store_package component_names target_name coercion =
       (List.length component_names,
        make_sequence
          (fun pos id ->
-           Lprim(Psetfield(pos, Pointer, Initialization),
+           Lprim(Psetfield(pos, Pointer, Root_initialization),
                  [Lprim(Pgetglobal target_name, [], Location.none);
                   get_component id],
                  Location.none))
@@ -1226,7 +1226,7 @@ let transl_store_package component_names target_name coercion =
              apply_coercion Location.none Strict coercion components,
              make_sequence
                (fun pos _id ->
-                 Lprim(Psetfield(pos, Pointer, Initialization),
+                 Lprim(Psetfield(pos, Pointer, Root_initialization),
                        [Lprim(Pgetglobal target_name, [], Location.none);
                         Lprim(Pfield pos, [Lvar blk], Location.none)],
                        Location.none))

--- a/bytecomp/translobj.ml
+++ b/bytecomp/translobj.ml
@@ -140,7 +140,7 @@ let transl_store_label_init glob size f arg =
     if !method_count = 0 then (size, expr) else
     (size+1,
      Lsequence(
-     Lprim(Psetfield(size, Pointer, Initialization),
+     Lprim(Psetfield(size, Pointer, Root_initialization),
            [Lprim(Pgetglobal glob, [], Location.none);
             Lprim (Pccall prim_makearray,
                    [int !method_count; int 0],

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -630,7 +630,7 @@ CAMLexport void caml_adjust_gc_speed (mlsize_t res, mlsize_t max)
 /* PR#6084 workaround: define it as a weak symbol */
 CAMLexport CAMLweakdef void caml_initialize (value *fp, value val)
 {
-  CAMLassert(Is_in_heap(fp));
+  CAMLassert(Is_in_heap_or_young(fp));
   *fp = val;
   if (Is_block (val) && Is_young (val)) {
     add_to_ref_table (&caml_ref_table, fp);

--- a/middle_end/inlining_cost.ml
+++ b/middle_end/inlining_cost.ml
@@ -27,8 +27,8 @@ let prim_size (prim : Lambda.primitive) args =
   | Pfield _ -> 1
   | Psetfield (_, isptr, init) ->
     begin match init with
-    | Initialization -> 1  (* never causes a write barrier hit *)
-    | Assignment ->
+    | Root_initialization -> 1  (* never causes a write barrier hit *)
+    | Assignment | Heap_initialization ->
       match isptr with
       | Pointer -> 4
       | Immediate -> 1


### PR DESCRIPTION
Flambda introduced a distinction between assignment and initialization in Psetfield.
What was really meant was "initialization of roots", as these only require a cheap store compared to a call to `caml_modify`.

However, a more general notion of field initialization would be less "error-prone" and still useful for the middle-end.

This patch propose to distinguish `In_heap` and `Root` initializations.
`In_heap` being equivalent to `caml_initialize`, `Root` being a simple store.

The backend doesn't have any use for `In_heap` (it is not produced by the frontend anyway).
The intention is that the middle-end could benefit from the distinction between arbitrary mutations and simple delayed initialization on otherwise pure values. (We briefly discussed that with @chambart and @mshinwell).

My latest port of TRMC also makes use of it.
## Other remarks

`Initialization In_heap` is compiled to a call to `caml_initialize`.

The primitive didn't check if the field was in the minor heap or not. That made it many times slower (8x on a simple loop benchmark doing alloc + init on my machine) than `caml_modify`.
Not adding the field to the remembered set if in minor heap seems correct though.

The last patch inline this check... It is provided more for information and I plan to remove before merging. I saw a negligible benefit in my benchmark (I guess my Intel CPU did some smartness seeing many calls `caml_initialize`). Slightly better was hand tuned code using %r15...
