### PR TITLE
Fix MPR 7178. Prevent infinite loop in at_exit callbacks.

### DIFF
--- a/stdlib/pervasives.mli
+++ b/stdlib/pervasives.mli
@@ -1124,7 +1124,9 @@ val at_exit : (unit -> unit) -> unit
    will be called when the program executes {!Pervasives.exit},
    or terminates, either normally or because of an uncaught exception.
    The functions are called in 'last in, first out' order:
-   the function most recently added with [at_exit] is called first. *)
+   the function most recently added with [at_exit] is called first. If
+   registered functions try to {!exit}, the last non-zero exit code will
+   define the exit code of the program. *)
 
 (**/**)
 


### PR DESCRIPTION
[Original report](http://caml.inria.fr/mantis/view.php?id=7178). 

From the OCaml Compiler Hacking session @ Citrix. Thanks for hosting. Note, this is done against the `4.03` branch since I didn't manage to make trunk to compile (binaries fail with `Fatal error: unknown C primitive 'caml_alloc_float_array'`)
