### PR TITLE
Ephemeron C API

### DIFF
--- a/Changes
+++ b/Changes
@@ -837,6 +837,13 @@ OCaml 4.07.0 (10 July 2018)
 
 ### Runtime system:
 
+- GPR#515 GPR#676 MPR#7173: Add a public C API for weak arrays and
+  ephemerons. Update the documentation for a 4.03 change: finalisation
+  functions are now run before the erasure of the corresponding
+  values.
+  (François Bobot and Jacques-Henri Jourdan, review by Mark Shinwell,
+   Damien Doligez and Frédéric Bour)
+
 - MPR#6411, GPR#1535: don't compile everything with -static-libgcc on mingw32,
   only dllbigarray.dll and libbigarray.a. Allows the use of C++ libraries which
   raise exceptions.
@@ -2932,14 +2939,6 @@ OCaml 4.04.0 (4 Nov 2016):
   (Florian Angeletti)
 
 ### Debugging and profiling:
-- PR#7173 GPR#515: Add a public C API for weak arrays and ephemerons.
-  Update the documentation for a 4.03 change: finalisation functions
-  are now run before the erasure of the corresponding values.
-  (François Bobot and Jacques-Henri Jourdan, review by Mark Shinwell)
-
-- PR#7203, GPR#534: Add a new primitive caml_alloc_float_array to allocate an
-  array of floats
-  (Thomas Braibant)
 
 - GPR#585: Spacetime, a new memory profiler (Mark Shinwell, Leo White)
 

--- a/Changes
+++ b/Changes
@@ -3443,6 +3443,9 @@ OCaml 4.03.0 (25 Apr 2016):
   now support marshaled data bigger than 4 Gb.
   (Xavier Leroy)
 
+* GPR#22: The undocumented layout of weak arrays has been changed. Finalisation
+  functions are now run before the erasure of the corresponding values.
+
 * GPR#226: select higher levels of optimization for GCC >= 3.4 and Clang
   when compiling the run-time system and C stub code.
   "-std=gnu99 -O2 -fno-strict-aliasing -fwrapv" is used by default.

--- a/Changes
+++ b/Changes
@@ -2932,6 +2932,14 @@ OCaml 4.04.0 (4 Nov 2016):
   (Florian Angeletti)
 
 ### Debugging and profiling:
+- PR#7173 GPR#515: Add a public C API for weak arrays and ephemerons.
+  Update the documentation for a 4.03 change: finalisation functions
+  are now run before the erasure of the corresponding values.
+  (François Bobot and Jacques-Henri Jourdan, review by Mark Shinwell)
+
+- PR#7203, GPR#534: Add a new primitive caml_alloc_float_array to allocate an
+  array of floats
+  (Thomas Braibant)
 
 - GPR#585: Spacetime, a new memory profiler (Mark Shinwell, Leo White)
 

--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -20,33 +20,38 @@
 
 #include "mlvalues.h"
 
-/** It is an error to call these functions not in their defined
-    range. */
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-CAMLextern mlsize_t caml_ephemeron_key_length(value eph);
-/** Return the number of key in the ephemeron. The valid key offset goes
-    from [0] to the predecessor of the returned value. */
+/** The requirements of the functions must be satisfied, it is
+    unspecified what happens if they are not. The debugging runtime
+    could check some of them. */
 
 CAMLextern value caml_ephemeron_create(mlsize_t len);
 /** Create an ephemeron with the given number of keys.
     This function allocates.
  */
 
-CAMLextern int caml_ephemeron_check_key(value eph, mlsize_t offset);
+CAMLextern mlsize_t caml_ephemeron_num_keys(value eph);
+/** Return the number of key in the ephemeron. The valid key offset goes
+    from [0] to the predecessor of the returned value. */
+
+CAMLextern int caml_ephemeron_key_is_set(value eph, mlsize_t offset);
 /** Return 1 if the key in the ephemeron at the given offset is set.
     Otherwise 0. The value [eph] must be an ephemeron and [offset] a
     valid key offset.
-*/
-
-CAMLextern void caml_ephemeron_unset_key(value eph, mlsize_t offset);
-/** Unset the key of the given ephemeron at the given offset. The
-    value [eph] must be an ephemeron and [offset] a valid key offset.
 */
 
 CAMLextern void caml_ephemeron_set_key(value eph, mlsize_t offset, value k);
 /** Set the key of the given ephemeron [eph] at the given offset
     [offset] to the given value [k]. The value [eph] must be an
     ephemeron, [offset] a valid key offset and [k] a block.
+*/
+
+CAMLextern void caml_ephemeron_unset_key(value eph, mlsize_t offset);
+/** Unset the key of the given ephemeron at the given offset. The
+    value [eph] must be an ephemeron and [offset] a valid key offset.
 */
 
 CAMLextern int caml_ephemeron_get_key(value eph, mlsize_t offset, value *key);
@@ -61,7 +66,7 @@ CAMLextern int caml_ephemeron_get_key_copy(value eph, mlsize_t offset,
                                            value *key);
 /** Return 1 if the key in the ephemeron at the given offset is set.
     Otherwise 0. When returning 1, set [*key] to a shallow copy of the
-    pointed value. This function allocates.
+    key. This function allocates.
 
     The value [eph] must be an ephemeron and [offset] a valid key
     offset.
@@ -70,28 +75,29 @@ CAMLextern int caml_ephemeron_get_key_copy(value eph, mlsize_t offset,
 CAMLextern void caml_ephemeron_blit_key(value eph1, mlsize_t off1,
                                         value eph2, mlsize_t off2,
                                         mlsize_t len);
-/** Sets the key of [eph2] with the key of [eph1]. Contrary to using
-    caml_ephemeron_get_key followed by caml_ephemeron_set_key or
-    caml_ephemeron_unset_key, this function does not prevent the
-    incremental GC from erasing the value in its current cycle. The
-    values [eph1] and [eph2] must be ephemerons and the offsets between
-    [off1] and [off1+len] and between [off2] and [off2+offset] must be
-    valid keys of [eph1] and [eph2] respectively.
+/** Fill the given range of keys of [eph2] with the given range of
+    keys of [eph1]. Contrary to using caml_ephemeron_get_key followed
+    by caml_ephemeron_set_key or caml_ephemeron_unset_key, this
+    function does not prevent the incremental GC from erasing the
+    value in its current cycle. The value [eph1] (resp. [eph2]) must
+    be an ephemeron and the offsets between [off1] and [off1+len]
+    (resp. between [off2] and [off2+offset]) must be valid keys of
+    [eph1] (resp. [eph2]).
 */
 
-CAMLextern int caml_ephemeron_check_data(value eph);
+CAMLextern int caml_ephemeron_data_is_set(value eph);
 /** Return 1 if the data in the ephemeron is set.
     Otherwise 0. The value [eph] must be an ephemeron.
-*/
-
-CAMLextern void caml_ephemeron_unset_data(value eph);
-/** Unset the data of the given ephemeron. The value [eph] must be an
-    ephemeron.
 */
 
 CAMLextern void caml_ephemeron_set_data(value eph, value k);
 /** Set the data of the given ephemeron [eph] to the given value
     [k]. The value [eph] must be an ephemeron and [k] a block.
+*/
+
+CAMLextern void caml_ephemeron_unset_data(value eph);
+/** Unset the data of the given ephemeron. The value [eph] must be an
+    ephemeron.
 */
 
 CAMLextern int caml_ephemeron_get_data(value eph, value *data);
@@ -105,24 +111,25 @@ CAMLextern int caml_ephemeron_get_data(value eph, value *data);
 CAMLextern int caml_ephemeron_get_data_copy(value eph, value *data);
 /** Return 1 if the data in the ephemeron at the given offset is set.
     Otherwise 0. When returning 1, set [*data] to a shallow copy of
-    the pointed value. This function allocates.
+    the data. This function allocates.
 
     The value [eph] must be an ephemeron and [offset] a valid key
     offset.
 */
 
 CAMLextern void caml_ephemeron_blit_data(value eph1, value eph2);
-/** Sets the data of [eph2] with the data of [eph1]. Contrary to using
-    caml_ephemeron_get_data followed by caml_ephemeron_set_data or
-    caml_ephemeron_unset_data, this function does not prevent the
-    incremental GC from erasing the value in its current cycle. The
-    values [eph1] and [eph2] must be ephemerons.
+/** Sets the data of [eph2] to be the same as the data of [eph1].
+    Contrary to using caml_ephemeron_get_data followed by
+    caml_ephemeron_set_data or caml_ephemeron_unset_data, this
+    function does not prevent the incremental GC from erasing the
+    value in its current cycle. The values [eph1] and [eph2] must be
+    ephemerons.
 */
 
 
-#define caml_weak_array_length caml_ephemeron_key_length
+#define caml_weak_array_length caml_ephemeron_num_keys
 #define caml_weak_array_create caml_ephemeron_create
-#define caml_weak_array_check caml_ephemeron_check_key
+#define caml_weak_array_check caml_ephemeron_key_is_set
 #define caml_weak_array_unset caml_ephemeron_unset_key
 #define caml_weak_array_set caml_ephemeron_set_key
 #define caml_weak_array_get caml_ephemeron_get_key
@@ -201,5 +208,9 @@ static inline void caml_ephe_clean (value v){
 }
 
 #endif /* CAML_INTERNALS */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CAML_WEAK_H */

--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -140,7 +140,9 @@ extern value caml_ephe_none;
        others       2..:  keys;
 
     A weak pointer is an ephemeron with the data at caml_ephe_none
-    If fields are added, don't forget to update weak.ml [additional_values].
+    If fields are added, don't forget to update weak.ml, [additional_values],
+    and obj.ml, [Ephemeron.additional_values].
+
 
  */
 

--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -18,9 +18,118 @@
 #ifndef CAML_WEAK_H
 #define CAML_WEAK_H
 
-#ifdef CAML_INTERNALS
-
 #include "mlvalues.h"
+
+/** It is an error to call these functions not in their defined
+    range. */
+
+CAMLextern mlsize_t caml_ephemeron_key_length(value eph);
+/** Return the number of key in the ephemeron. The valid key offset goes
+    from [0] to the predecessor of the returned value. */
+
+CAMLextern value caml_ephemeron_create(mlsize_t len);
+/** Create an ephemeron with the given number of keys.
+    This function allocates.
+ */
+
+CAMLextern int caml_ephemeron_check_key(value eph, mlsize_t offset);
+/** Return 1 if the key in the ephemeron at the given offset is set.
+    Otherwise 0. The value [eph] must be an ephemeron and [offset] a
+    valid key offset.
+*/
+
+CAMLextern void caml_ephemeron_unset_key(value eph, mlsize_t offset);
+/** Unset the key of the given ephemeron at the given offset. The
+    value [eph] must be an ephemeron and [offset] a valid key offset.
+*/
+
+CAMLextern void caml_ephemeron_set_key(value eph, mlsize_t offset, value k);
+/** Set the key of the given ephemeron [eph] at the given offset
+    [offset] to the given value [k]. The value [eph] must be an
+    ephemeron, [offset] a valid key offset and [k] a block.
+*/
+
+CAMLextern int caml_ephemeron_get_key(value eph, mlsize_t offset, value *key);
+/** Return 1 if the key in the ephemeron at the given offset is set.
+    Otherwise 0. When returning 1, set [*key] to the pointed value.
+
+    The value [eph] must be an ephemeron and [offset] a valid key
+    offset.
+*/
+
+CAMLextern int caml_ephemeron_get_key_copy(value eph, mlsize_t offset,
+                                           value *key);
+/** Return 1 if the key in the ephemeron at the given offset is set.
+    Otherwise 0. When returning 1, set [*key] to a shallow copy of the
+    pointed value. This function allocates.
+
+    The value [eph] must be an ephemeron and [offset] a valid key
+    offset.
+*/
+
+CAMLextern void caml_ephemeron_blit_key(value eph1, mlsize_t off1,
+                                        value eph2, mlsize_t off2,
+                                        mlsize_t len);
+/** Sets the key of [eph2] with the key of [eph1]. Contrary to using
+    caml_ephemeron_get_key followed by caml_ephemeron_set_key or
+    caml_ephemeron_unset_key, this function does not prevent the
+    incremental GC from erasing the value in its current cycle. The
+    values [eph1] and [eph2] must be ephemerons and the offsets between
+    [off1] and [off1+len] and between [off2] and [off2+offset] must be
+    valid keys of [eph1] and [eph2] respectively.
+*/
+
+CAMLextern int caml_ephemeron_check_data(value eph);
+/** Return 1 if the data in the ephemeron is set.
+    Otherwise 0. The value [eph] must be an ephemeron.
+*/
+
+CAMLextern void caml_ephemeron_unset_data(value eph);
+/** Unset the data of the given ephemeron. The value [eph] must be an
+    ephemeron.
+*/
+
+CAMLextern void caml_ephemeron_set_data(value eph, value k);
+/** Set the data of the given ephemeron [eph] to the given value
+    [k]. The value [eph] must be an ephemeron and [k] a block.
+*/
+
+CAMLextern int caml_ephemeron_get_data(value eph, value *data);
+/** Return 1 if the data in the ephemeron at the given offset is set.
+    Otherwise 0. When returning 1, set [*data] to the pointed value.
+
+    The value [eph] must be an ephemeron and [offset] a valid key
+    offset.
+*/
+
+CAMLextern int caml_ephemeron_get_data_copy(value eph, value *data);
+/** Return 1 if the data in the ephemeron at the given offset is set.
+    Otherwise 0. When returning 1, set [*data] to a shallow copy of
+    the pointed value. This function allocates.
+
+    The value [eph] must be an ephemeron and [offset] a valid key
+    offset.
+*/
+
+CAMLextern void caml_ephemeron_blit_data(value eph1, value eph2);
+/** Sets the data of [eph2] with the data of [eph1]. Contrary to using
+    caml_ephemeron_get_data followed by caml_ephemeron_set_data or
+    caml_ephemeron_unset_data, this function does not prevent the
+    incremental GC from erasing the value in its current cycle. The
+    values [eph1] and [eph2] must be ephemerons.
+*/
+
+
+#define caml_weak_array_length caml_ephemeron_key_length
+#define caml_weak_array_create caml_ephemeron_create
+#define caml_weak_array_check caml_ephemeron_check_key
+#define caml_weak_array_unset caml_ephemeron_unset_key
+#define caml_weak_array_set caml_ephemeron_set_key
+#define caml_weak_array_get caml_ephemeron_get_key
+#define caml_weak_array_get_copy caml_ephemeron_get_key_copy
+#define caml_weak_array_blit caml_ephemeron_blit_key
+
+#ifdef CAML_INTERNALS
 
 extern value caml_ephe_list_head;
 extern value caml_ephe_none;
@@ -32,12 +141,13 @@ extern value caml_ephe_none;
 
     A weak pointer is an ephemeron with the data at caml_ephe_none
     If fields are added, don't forget to update weak.ml [additional_values].
+
  */
 
 #define CAML_EPHE_LINK_OFFSET 0
 #define CAML_EPHE_DATA_OFFSET 1
 #define CAML_EPHE_FIRST_KEY 2
-
+#define CAML_EPHE_MAX_WOSIZE (Max_wosize - CAML_EPHE_FIRST_KEY)
 
 /* In the header, in order to let major_gc.c
    and weak.c see the body of the function */

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -254,9 +254,9 @@ CAMLprim value caml_ephe_get_data (value ar)
 {
   CAMLparam1 (ar);
   CAMLlocal2 (res, elt);
-  CAMLassert (Is_in_heap (ar));
-  elt = Field (ar, CAML_EPHE_DATA_OFFSET);
+                                                   Assert (Is_in_heap (ar));
   if(caml_gc_phase == Phase_clean) caml_ephe_clean(ar);
+  elt = Field (ar, CAML_EPHE_DATA_OFFSET);
   if (elt == caml_ephe_none){
     res = None_val;
   }else{
@@ -319,20 +319,19 @@ CAMLprim value caml_weak_get_copy (value ar, value n){
 CAMLprim value caml_ephe_get_data_copy (value ar)
 {
   CAMLparam1 (ar);
-  mlsize_t offset = CAML_EPHE_DATA_OFFSET;
   CAMLlocal2 (res, elt);
   value v;  /* Caution: this is NOT a local root. */
   CAMLassert (Is_in_heap (ar));
 
-  v = Field (ar, offset);
   if (caml_gc_phase == Phase_clean) caml_ephe_clean(ar);
+  v = Field (ar, CAML_EPHE_DATA_OFFSET);
   if (v == caml_ephe_none) CAMLreturn (None_val);
   /** Don't copy custom_block #7279 */
   if (Is_block (v) && Is_in_heap_or_young(v) && Tag_val(v) != Custom_tag ) {
     elt = caml_alloc (Wosize_val (v), Tag_val (v));
           /* The GC may erase or move v during this call to caml_alloc. */
-    v = Field (ar, offset);
     if (caml_gc_phase == Phase_clean) caml_ephe_clean(ar);
+    v = Field (ar, CAML_EPHE_DATA_OFFSET);
     if (v == caml_ephe_none) CAMLreturn (None_val);
     if (Tag_val (v) < No_scan_tag){
       mlsize_t i;

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -31,11 +31,29 @@ value caml_ephe_list_head = 0;
 static value ephe_dummy = 0;
 value caml_ephe_none = (value) &ephe_dummy;
 
+#define CAMLassert_valid_ephemeron(eph) do{                                 \
+    CAMLassert (Is_in_heap (eph));                                          \
+    CAMLassert (Tag_val(eph) == Abstract_tag);                              \
+    CAMLassert (CAML_EPHE_FIRST_KEY <= Wosize_val (eph));                   \
+}while(0)
+
+#define CAMLassert_valid_offset(eph,offset) do{                             \
+    CAMLassert_valid_ephemeron(eph);                                        \
+    CAMLassert (0 <= offset);                                               \
+    CAMLassert (offset < Wosize_val (eph) - CAML_EPHE_FIRST_KEY);           \
+}while(0)
+
+CAMLexport mlsize_t caml_ephemeron_key_length(value eph)
+{
+  return Wosize_val (eph) - CAML_EPHE_FIRST_KEY;
+}
+
 #if defined (NATIVE_CODE) && defined (NO_NAKED_POINTERS)
 /** The minor heap is considered alive.
     Outside minor and major heap, x must be black.
 */
-static inline int Is_Dead_during_clean(value x){
+static inline int Is_Dead_during_clean(value x)
+{
   CAMLassert (x != caml_ephe_none);
   CAMLassert (caml_gc_phase == Phase_clean);
   return Is_block (x) && !Is_young (x) && Is_white_val(x);
@@ -43,32 +61,35 @@ static inline int Is_Dead_during_clean(value x){
 /** The minor heap doesn't have to be marked, outside they should
     already be black
 */
-static inline int Must_be_Marked_during_mark(value x){
+static inline int Must_be_Marked_during_mark(value x)
+{
   CAMLassert (x != caml_ephe_none);
   CAMLassert (caml_gc_phase == Phase_mark);
   return Is_block (x) && !Is_young (x);
 }
 #else
-static inline int Is_Dead_during_clean(value x){
+static inline int Is_Dead_during_clean(value x)
+{
   CAMLassert (x != caml_ephe_none);
   CAMLassert (caml_gc_phase == Phase_clean);
   return Is_block (x) && Is_in_heap (x) && Is_white_val(x);
 }
-static inline int Must_be_Marked_during_mark(value x){
+static inline int Must_be_Marked_during_mark(value x)
+{
   CAMLassert (x != caml_ephe_none);
   CAMLassert (caml_gc_phase == Phase_mark);
   return Is_block (x) && Is_in_heap (x);
 }
 #endif
 
-
 /* [len] is a value that represents a number of words (fields) */
-CAMLprim value caml_ephe_create (value len)
+CAMLexport value caml_ephemeron_create (mlsize_t len)
 {
   mlsize_t size, i;
   value res;
 
-  size = Long_val (len) + CAML_EPHE_FIRST_KEY;
+  CAMLassert(len <= CAML_EPHE_MAX_WOSIZE);
+  size = len + CAML_EPHE_FIRST_KEY;
   if (size < CAML_EPHE_FIRST_KEY || size > Max_wosize)
     caml_invalid_argument ("Weak.create");
   res = caml_alloc_shr (size, Abstract_tag);
@@ -76,6 +97,14 @@ CAMLprim value caml_ephe_create (value len)
   Field (res, CAML_EPHE_LINK_OFFSET) = caml_ephe_list_head;
   caml_ephe_list_head = res;
   return res;
+}
+
+CAMLprim value caml_ephe_create (value len)
+{
+  intnat size = Long_val(len);
+  if (size < 0 || size > CAML_EPHE_MAX_WOSIZE)
+    caml_invalid_argument ("Weak.create");
+  return caml_ephemeron_create(size);
 }
 
 CAMLprim value caml_weak_create (value len)
@@ -119,7 +148,8 @@ CAMLprim value caml_weak_create (value len)
 /* If we are in Phase_clean we need to check if the key
    that is going to disappear is dead and so should trigger a cleaning
  */
-static void do_check_key_clean(value ar, mlsize_t offset){
+static void do_check_key_clean(value ar, mlsize_t offset)
+{
   CAMLassert (offset >= CAML_EPHE_FIRST_KEY);
   if (caml_gc_phase == Phase_clean){
     value elt = Field (ar, offset);
@@ -132,7 +162,8 @@ static void do_check_key_clean(value ar, mlsize_t offset){
 
 /* If we are in Phase_clean we need to do as if the key is empty when
    it will be cleaned during this phase */
-static inline int is_ephe_key_none(value ar, mlsize_t offset){
+static inline int is_ephe_key_none(value ar, mlsize_t offset)
+{
   value elt = Field (ar, offset);
   if (elt == caml_ephe_none){
     return 1;
@@ -145,11 +176,21 @@ static inline int is_ephe_key_none(value ar, mlsize_t offset){
   }
 }
 
+/** The offset starts here at 0 */
+static inline mlsize_t raise_if_invalid_offset(value ar, value n,
+                                               char* msg)
+{
+  intnat offset = Long_val (n);
+  if (offset < 0 || offset >= Wosize_val (ar) - CAML_EPHE_FIRST_KEY){
+    caml_invalid_argument (msg);
+  }
+  return offset;
+}
 
 static void do_set (value ar, mlsize_t offset, value v)
 {
   if (Is_block (v) && Is_young (v)){
-    /* modified version of Modify */
+    /* modified version of caml_modify */
     value old = Field (ar, offset);
     Field (ar, offset) = v;
     if (!(Is_block (old) && Is_young (old))){
@@ -160,211 +201,273 @@ static void do_set (value ar, mlsize_t offset, value v)
   }
 }
 
-CAMLprim value caml_ephe_set_key (value ar, value n, value el)
+CAMLexport void caml_ephemeron_set_key(value ar, mlsize_t offset, value k)
 {
-  mlsize_t offset = Long_val (n) + CAML_EPHE_FIRST_KEY;
+  CAMLassert_valid_offset(ar,offset);
   CAMLassert (Is_in_heap (ar));
+
+  offset += CAML_EPHE_FIRST_KEY;
   if (offset < CAML_EPHE_FIRST_KEY || offset >= Wosize_val (ar)){
     caml_invalid_argument ("Weak.set");
   }
   do_check_key_clean(ar,offset);
-  do_set (ar, offset, el);
+  do_set (ar, offset, k);
+}
+
+CAMLprim value caml_ephe_set_key (value ar, value n, value el)
+{
+  mlsize_t offset = raise_if_invalid_offset(ar,n,"Weak.set");
+
+  caml_ephemeron_set_key(ar,offset,el);
   return Val_unit;
 }
 
-CAMLprim value caml_ephe_unset_key (value ar, value n)
+CAMLexport void caml_ephemeron_unset_key(value ar, mlsize_t offset)
 {
-  mlsize_t offset = Long_val (n) + CAML_EPHE_FIRST_KEY;
+  CAMLassert_valid_offset(ar,offset);
   CAMLassert (Is_in_heap (ar));
+
+  offset += CAML_EPHE_FIRST_KEY;
   if (offset < CAML_EPHE_FIRST_KEY || offset >= Wosize_val (ar)){
     caml_invalid_argument ("Weak.set");
   }
   do_check_key_clean(ar,offset);
   Field (ar, offset) = caml_ephe_none;
+}
+
+CAMLprim value caml_ephe_unset_key (value ar, value n)
+{
+  mlsize_t offset = raise_if_invalid_offset (ar,n,"Weak.set");
+
+  caml_ephemeron_unset_key(ar,offset);
   return Val_unit;
 }
 
 value caml_ephe_set_key_option (value ar, value n, value el)
 {
-  mlsize_t offset = Long_val (n) + CAML_EPHE_FIRST_KEY;
-  CAMLassert (Is_in_heap (ar));
-  if (offset < CAML_EPHE_FIRST_KEY || offset >= Wosize_val (ar)){
-    caml_invalid_argument ("Weak.set");
-  }
-  do_check_key_clean(ar,offset);
-  if (el != None_val && Is_block (el)){
+  if (Is_block (el)){
     CAMLassert (Wosize_val (el) == 1);
-    do_set (ar, offset, Field (el, 0));
+    caml_ephe_set_key(ar,n,Field (el, 0));
   }else{
-    Field (ar, offset) = caml_ephe_none;
+    CAMLassert (el == None_val);
+    caml_ephe_unset_key(ar,n);
   }
   return Val_unit;
 }
 
-CAMLprim value caml_weak_set (value ar, value n, value el){
+CAMLprim value caml_weak_set (value ar, value n, value el)
+{
   return caml_ephe_set_key_option(ar,n,el);
 }
 
-CAMLprim value caml_ephe_set_data (value ar, value el)
+CAMLexport void caml_ephemeron_set_data (value ar, value el)
 {
-  CAMLassert (Is_in_heap (ar));
+  CAMLassert_valid_ephemeron(ar);
+
   if (caml_gc_phase == Phase_clean){
     /* During this phase since we don't know which ephemeron have been
        cleaned we always need to check it. */
     caml_ephe_clean(ar);
   };
   do_set (ar, CAML_EPHE_DATA_OFFSET, el);
+}
+
+CAMLprim value caml_ephe_set_data (value ar, value el)
+{
+  caml_ephemeron_set_data (ar, el);
   return Val_unit;
+}
+
+CAMLexport void caml_ephemeron_unset_data (value ar)
+{
+  CAMLassert_valid_ephemeron(ar);
+
+  Field (ar, CAML_EPHE_DATA_OFFSET) = caml_ephe_none;
 }
 
 CAMLprim value caml_ephe_unset_data (value ar)
 {
-  CAMLassert (Is_in_heap (ar));
-  Field (ar, CAML_EPHE_DATA_OFFSET) = caml_ephe_none;
+  caml_ephemeron_unset_data (ar);
   return Val_unit;
 }
 
-CAMLprim value caml_ephe_get_key (value ar, value n)
+static value optionalize(int status, value *x)
 {
-  CAMLparam2 (ar, n);
-  mlsize_t offset = Long_val (n) + CAML_EPHE_FIRST_KEY;
-  CAMLlocal2 (res, elt);
-  CAMLassert (Is_in_heap (ar));
-  if (offset < CAML_EPHE_FIRST_KEY || offset >= Wosize_val (ar)){
-    caml_invalid_argument ("Weak.get_key");
-  }
-  if (is_ephe_key_none(ar, offset)){
+  CAMLparam0();
+  CAMLlocal2(res,v);
+  if(status) {
+    v = *x;
+    res = caml_alloc_small (1, Some_tag);
+    Field (res, 0) = v;
+  } else {
     res = None_val;
+  }
+  CAMLreturn(res);
+}
+
+CAMLexport int caml_ephemeron_get_key (value ar, mlsize_t offset, value *key)
+{
+  value elt;
+  CAMLassert_valid_offset(ar,offset);
+
+  offset += CAML_EPHE_FIRST_KEY;
+
+  if (is_ephe_key_none(ar, offset)){
+    return 0;
   }else{
     elt = Field (ar, offset);
     if (caml_gc_phase == Phase_mark && Must_be_Marked_during_mark(elt)){
       caml_darken (elt, NULL);
     }
-    res = caml_alloc_small (1, Some_tag);
-    Field (res, 0) = elt;
+    *key = elt;
+    return 1;
   }
-  CAMLreturn (res);
 }
 
-CAMLprim value caml_weak_get (value ar, value n){
+CAMLprim value caml_ephe_get_key (value ar, value n)
+{
+  mlsize_t offset = raise_if_invalid_offset (ar,n,"Weak.get_key");
+
+  value data;
+  return optionalize(caml_ephemeron_get_key(ar,offset,&data),&data);
+}
+
+CAMLprim value caml_weak_get (value ar, value n)
+{
   return caml_ephe_get_key(ar, n);
 }
 
-CAMLprim value caml_ephe_get_data (value ar)
+CAMLexport int caml_ephemeron_get_data (value ar, value *data)
 {
-  CAMLparam1 (ar);
-  CAMLlocal2 (res, elt);
-                                                   Assert (Is_in_heap (ar));
+  value elt;
+  CAMLassert_valid_ephemeron(ar);
+
   if(caml_gc_phase == Phase_clean) caml_ephe_clean(ar);
   elt = Field (ar, CAML_EPHE_DATA_OFFSET);
   if (elt == caml_ephe_none){
-    res = None_val;
+    return 0;
   }else{
     if (caml_gc_phase == Phase_mark && Must_be_Marked_during_mark(elt)){
       caml_darken (elt, NULL);
     }
-    res = caml_alloc_small (1, Some_tag);
-    Field (res, 0) = elt;
+    *data = elt;
+    return 1;
   }
-  CAMLreturn (res);
 }
 
-CAMLprim value caml_ephe_get_key_copy (value ar, value n)
+CAMLprim value caml_ephe_get_data (value ar)
 {
-  CAMLparam2 (ar, n);
-  mlsize_t offset = Long_val (n) + CAML_EPHE_FIRST_KEY;
-  CAMLlocal2 (res, elt);
-  value v;  /* Caution: this is NOT a local root. */
-  CAMLassert (Is_in_heap (ar));
-  if (offset < CAML_EPHE_FIRST_KEY || offset >= Wosize_val (ar)){
-    caml_invalid_argument ("Weak.get_copy");
-  }
+  value data;
+  return optionalize(caml_ephemeron_get_data(ar,&data),&data);
+}
 
-  if (is_ephe_key_none(ar, offset)) CAMLreturn (None_val);
+
+static inline void copy_value(value src, value dst)
+{
+  if (Tag_val (src) < No_scan_tag){
+    mlsize_t i;
+    for (i = 0; i < Wosize_val (src); i++){
+      value f = Field (src, i);
+      if (caml_gc_phase == Phase_mark && Must_be_Marked_during_mark(f)){
+        caml_darken (f, NULL);
+      }
+      caml_modify (&Field (dst, i), f);
+    }
+  }else{
+    memmove (Bp_val (dst), Bp_val (src), Bosize_val (src));
+  }
+}
+
+CAMLexport int caml_ephemeron_get_key_copy(value ar, mlsize_t offset,
+                                           value *key)
+{
+  CAMLparam1(ar);
+  value elt,v; /* Caution: they are NOT a local root. */
+  CAMLassert_valid_offset(ar,offset);
+
+  offset += CAML_EPHE_FIRST_KEY;
+
+  if (is_ephe_key_none(ar, offset)) CAMLreturn(0);
   v = Field (ar, offset);
   /** Don't copy custom_block #7279 */
   if (Is_block (v) && Is_in_heap_or_young(v) && Tag_val(v) != Custom_tag ) {
     elt = caml_alloc (Wosize_val (v), Tag_val (v));
           /* The GC may erase or move v during this call to caml_alloc. */
+    if (is_ephe_key_none(ar, offset)) CAMLreturn(0);
     v = Field (ar, offset);
-    if (is_ephe_key_none(ar, offset)) CAMLreturn (None_val);
-    if (Tag_val (v) < No_scan_tag){
-      mlsize_t i;
-      for (i = 0; i < Wosize_val (v); i++){
-        value f = Field (v, i);
-        if (caml_gc_phase == Phase_mark && Must_be_Marked_during_mark(f)){
-          caml_darken (f, NULL);
-        }
-        Modify (&Field (elt, i), f);
-      }
-    }else{
-      memmove (Bp_val (elt), Bp_val (v), Bosize_val (v));
-    }
+    copy_value(v,elt);
+    *key = elt;
+    CAMLreturn(1);
   }else{
     if ( caml_gc_phase == Phase_mark && Must_be_Marked_during_mark(v) ){
       caml_darken (v, NULL);
     };
-    elt = v;
+    *key = v;
+    CAMLreturn(1);
   }
-  res = caml_alloc_small (1, Some_tag);
-  Field (res, 0) = elt;
-
-  CAMLreturn (res);
 }
 
-CAMLprim value caml_weak_get_copy (value ar, value n){
+CAMLprim value caml_ephe_get_key_copy (value ar, value n)
+{
+  mlsize_t offset = raise_if_invalid_offset (ar,n,"Weak.get_copy");
+
+  value key;
+  return optionalize(caml_ephemeron_get_key_copy(ar, offset, &key), &key);
+}
+
+CAMLprim value caml_weak_get_copy (value ar, value n)
+{
   return caml_ephe_get_key_copy(ar,n);
 }
 
-CAMLprim value caml_ephe_get_data_copy (value ar)
+CAMLexport int caml_ephemeron_get_data_copy (value ar, value *data)
 {
   CAMLparam1 (ar);
-  CAMLlocal2 (res, elt);
-  value v;  /* Caution: this is NOT a local root. */
-  CAMLassert (Is_in_heap (ar));
+  value elt,v; /* Caution: they are NOT a local root. */
+  CAMLassert_valid_ephemeron(ar);
 
   if (caml_gc_phase == Phase_clean) caml_ephe_clean(ar);
   v = Field (ar, CAML_EPHE_DATA_OFFSET);
-  if (v == caml_ephe_none) CAMLreturn (None_val);
+  if (v == caml_ephe_none) CAMLreturn(0);
   /** Don't copy custom_block #7279 */
   if (Is_block (v) && Is_in_heap_or_young(v) && Tag_val(v) != Custom_tag ) {
     elt = caml_alloc (Wosize_val (v), Tag_val (v));
           /* The GC may erase or move v during this call to caml_alloc. */
     if (caml_gc_phase == Phase_clean) caml_ephe_clean(ar);
     v = Field (ar, CAML_EPHE_DATA_OFFSET);
-    if (v == caml_ephe_none) CAMLreturn (None_val);
-    if (Tag_val (v) < No_scan_tag){
-      mlsize_t i;
-      for (i = 0; i < Wosize_val (v); i++){
-        value f = Field (v, i);
-        if (caml_gc_phase == Phase_mark && Must_be_Marked_during_mark(f)){
-          caml_darken (f, NULL);
-        }
-        Modify (&Field (elt, i), f);
-      }
-    }else{
-      memmove (Bp_val (elt), Bp_val (v), Bosize_val (v));
-    }
+    if (v == caml_ephe_none) CAMLreturn(0);
+    copy_value(v,elt);
+    *data=elt;
+    CAMLreturn(1);
   }else{
     if ( caml_gc_phase == Phase_mark && Must_be_Marked_during_mark(v) ){
       caml_darken (v, NULL);
     };
-    elt = v;
+    *data = v;
+    CAMLreturn(1);
   }
-  res = caml_alloc_small (1, Some_tag);
-  Field (res, 0) = elt;
+}
 
-  CAMLreturn (res);
+
+CAMLprim value caml_ephe_get_data_copy (value ar)
+{
+  value data;
+  return optionalize(caml_ephemeron_get_data_copy(ar,&data),&data);
+}
+
+CAMLexport int caml_ephemeron_check_key(value ar, mlsize_t offset)
+{
+  CAMLassert_valid_offset(ar,offset);
+
+  offset += CAML_EPHE_FIRST_KEY;
+  return !is_ephe_key_none(ar, offset);
 }
 
 CAMLprim value caml_ephe_check_key (value ar, value n)
 {
-  mlsize_t offset = Long_val (n) + CAML_EPHE_FIRST_KEY;
-  CAMLassert (Is_in_heap (ar));
-  if (offset < CAML_EPHE_FIRST_KEY || offset >= Wosize_val (ar)){
-    caml_invalid_argument ("Weak.check");
-  }
-  return Val_bool (!is_ephe_key_none(ar, offset));
+  mlsize_t offset = raise_if_invalid_offset(ar, n, "Weak.check");
+
+  return Val_bool (caml_ephemeron_check_key(ar, offset));
 }
 
 CAMLprim value caml_weak_check (value ar, value n)
@@ -372,27 +475,35 @@ CAMLprim value caml_weak_check (value ar, value n)
   return caml_ephe_check_key(ar,n);
 }
 
-CAMLprim value caml_ephe_check_data (value ar)
+CAMLexport int caml_ephemeron_check_data (value ar)
 {
+  CAMLassert_valid_ephemeron(ar);
+
   if(caml_gc_phase == Phase_clean) caml_ephe_clean(ar);
-  return Val_bool (Field (ar, CAML_EPHE_DATA_OFFSET) != caml_ephe_none);
+  return Field (ar, CAML_EPHE_DATA_OFFSET) != caml_ephe_none;
 }
 
-CAMLprim value caml_ephe_blit_key (value ars, value ofs,
-                               value ard, value ofd, value len)
+CAMLprim value caml_ephe_check_data (value ar)
 {
-  mlsize_t offset_s = Long_val (ofs) + CAML_EPHE_FIRST_KEY;
-  mlsize_t offset_d = Long_val (ofd) + CAML_EPHE_FIRST_KEY;
-  mlsize_t length = Long_val (len);
-  long i;
-  CAMLassert (Is_in_heap (ars));
-  CAMLassert (Is_in_heap (ard));
-  if (offset_s < CAML_EPHE_FIRST_KEY || offset_s + length > Wosize_val (ars)){
-    caml_invalid_argument ("Weak.blit");
-  }
-  if (offset_d < CAML_EPHE_FIRST_KEY || offset_d + length > Wosize_val (ard)){
-    caml_invalid_argument ("Weak.blit");
-  }
+  return Val_bool (caml_ephemeron_check_data(ar));
+}
+
+CAMLexport void caml_ephemeron_blit_key(value ars, mlsize_t offset_s,
+                                        value ard, mlsize_t offset_d,
+                                        mlsize_t length)
+{
+  if (length == 0) return;
+  intnat i; /** intnat because the second for-loop stops with i == -1 */
+  CAMLassert_valid_offset(ars,offset_s);
+  CAMLassert_valid_offset(ard,offset_d);
+  CAMLassert(length <= Wosize_val(ars) - CAML_EPHE_FIRST_KEY);
+  CAMLassert(length <= Wosize_val(ard) - CAML_EPHE_FIRST_KEY);
+  CAMLassert(offset_s <= Wosize_val(ars) - CAML_EPHE_FIRST_KEY - length);
+  CAMLassert(offset_d <= Wosize_val(ard) - CAML_EPHE_FIRST_KEY - length);
+
+  offset_s += CAML_EPHE_FIRST_KEY;
+  offset_d += CAML_EPHE_FIRST_KEY;
+
   if (caml_gc_phase == Phase_clean){
     caml_ephe_clean(ars);
     caml_ephe_clean(ard);
@@ -406,16 +517,17 @@ CAMLprim value caml_ephe_blit_key (value ars, value ofs,
       do_set (ard, offset_d + i,  Field (ars, offset_s + i));
     }
   }
-  return Val_unit;
 }
 
-CAMLprim value caml_ephe_blit_data (value ars, value ard)
+CAMLprim value caml_ephe_blit_key (value ars, value ofs,
+                                   value ard, value ofd, value len)
 {
-  if(caml_gc_phase == Phase_clean) {
-    caml_ephe_clean(ars);
-    caml_ephe_clean(ard);
-  };
-  do_set (ard, CAML_EPHE_DATA_OFFSET, Field (ars, CAML_EPHE_DATA_OFFSET));
+  if (Long_val(len) == 0) return Val_unit;
+  mlsize_t offset_s = raise_if_invalid_offset(ars, ofs, "Weak.blit");
+  mlsize_t offset_d = raise_if_invalid_offset(ard, ofd, "Weak.blit");
+  mlsize_t length = Long_val (len);
+
+  caml_ephemeron_blit_key(ars,offset_s,ard,offset_d,length);
   return Val_unit;
 }
 
@@ -423,4 +535,22 @@ CAMLprim value caml_weak_blit (value ars, value ofs,
                       value ard, value ofd, value len)
 {
   return caml_ephe_blit_key (ars, ofs, ard, ofd, len);
+}
+
+CAMLexport void caml_ephemeron_blit_data (value ars, value ard)
+{
+  CAMLassert_valid_ephemeron(ars);
+  CAMLassert_valid_ephemeron(ard);
+
+  if(caml_gc_phase == Phase_clean) {
+    caml_ephe_clean(ars);
+    caml_ephe_clean(ard);
+  };
+  do_set (ard, CAML_EPHE_DATA_OFFSET, Field (ars, CAML_EPHE_DATA_OFFSET));
+}
+
+CAMLprim value caml_ephe_blit_data (value ars, value ard)
+{
+  caml_ephemeron_blit_data(ars, ard);
+  return Val_unit;
 }

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -91,7 +91,7 @@ static inline int Must_be_Marked_during_mark(value x)
 }
 #endif
 
-/* [len] is a value that represents a number of words (fields) */
+/* [len] is a number of words (fields) */
 CAMLexport value caml_ephemeron_create (mlsize_t len)
 {
   mlsize_t size, i;
@@ -545,7 +545,7 @@ CAMLprim value caml_ephe_blit_key (value ars, value ofs,
 {
   if (Long_val(len) == 0) return Val_unit;
 
-  caml_ephemeron_blit_key(ars, Long_val(ofs), ard, Long_val(ofd), Long_val(len));
+  caml_ephemeron_blit_key(ars,Long_val(ofs),ard,Long_val(ofd),Long_val(len));
   return Val_unit;
 }
 

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -91,6 +91,7 @@ module Ephemeron = struct
 
   type t (** ephemeron *)
 
+   (** To change in sync with weak.h *)
   let additional_values = 2
   let max_ephe_length = Sys.max_array_length - additional_values
 
@@ -133,19 +134,12 @@ module Ephemeron = struct
 
   external blit_key : t -> int -> t -> int -> int -> unit
     = "caml_ephe_blit_key"
+
   let blit_key e1 o1 e2 o2 l =
-    let msg = "Obj.Ephemeron.blit_key" in
-    if l < 0 then invalid_arg msg;
-    if l = 0 then ()
-    else begin
-      raise_if_invalid_offset e1 o1 msg;
-      raise_if_invalid_offset e2 o2 msg;
-      let len1 = length e1 in let len2 = length e2 in
-      if not (l <= len1 && l <= len2 &&
-              o1 <= len1 - l && o2 <= len2 - l) then
-        invalid_arg msg;
-      blit_key e1 o1 e2 o2 l
-    end
+    if l < 0 || o1 < 0 || o1 > length e1 - l
+       || o2 < 0 || o2 > length e2 - l
+    then invalid_arg "Obj.Ephemeron.blit_key"
+    else if l <> 0 then blit_key e1 o1 e2 o2 l
 
   external get_data: t -> obj_t option = "caml_ephe_get_data"
   external get_data_copy: t -> obj_t option = "caml_ephe_get_data_copy"

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -149,4 +149,7 @@ module Ephemeron: sig
 
   val blit_data : t -> t -> unit
   (** Same as {!Ephemeron.K1.blit_data} *)
+
+  val max_ephe_length: int
+  (** Maximum length of an ephemeron *)
 end

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -109,7 +109,10 @@ module Ephemeron: sig
 
   val create: int -> t
   (** [create n] returns an ephemeron with [n] keys.
-      All the keys and the data are initially empty *)
+      All the keys and the data are initially empty.
+      The argument [n] must be between zero
+      and {!max_ephe_length} (limits included).
+  *)
 
   val length: t -> int
   (** return the number of keys *)
@@ -151,5 +154,6 @@ module Ephemeron: sig
   (** Same as {!Ephemeron.K1.blit_data} *)
 
   val max_ephe_length: int
-  (** Maximum length of an ephemeron *)
+  (** Maximum length of an ephemeron, ie the maximum number of keys an
+      ephemeron could contain *)
 end

--- a/stdlib/weak.ml
+++ b/stdlib/weak.ml
@@ -33,18 +33,24 @@ let raise_if_invalid_offset e o msg =
   if not (0 <= o && o < length e) then
     invalid_arg(msg)
 
-external set : 'a t -> int -> 'a option -> unit = "caml_weak_set"
+external set' : 'a t -> int -> 'a -> unit = "caml_ephe_set_key"
+external unset : 'a t -> int -> unit = "caml_ephe_unset_key"
 let set e o x =
   raise_if_invalid_offset e o "Weak.set";
-  set e o x
+  match x with
+  | None -> unset e o
+  | Some x -> set' e o x
+
 external get : 'a t -> int -> 'a option = "caml_weak_get"
 let get e o =
   raise_if_invalid_offset e o "Weak.get";
   get e o
+
 external get_copy : 'a t -> int -> 'a option = "caml_weak_get_copy"
 let get_copy e o =
   raise_if_invalid_offset e o "Weak.get_copy";
   get_copy e o
+
 external check : 'a t -> int -> bool = "caml_weak_check"
 let check e o =
   raise_if_invalid_offset e o "Weak.check";
@@ -54,21 +60,13 @@ external blit : 'a t -> int -> 'a t -> int -> int -> unit = "caml_weak_blit"
 
 (* blit: src srcoff dst dstoff len *)
 let blit e1 o1 e2 o2 l =
-  let msg = "Weak.blit" in
-  if l < 0 then invalid_arg msg;
-  if l = 0 then ()
-  else begin
-    raise_if_invalid_offset e1 o1 msg;
-    raise_if_invalid_offset e2 o2 msg;
-    let len1 = length e1 in let len2 = length e2 in
-    if not (l <= len1 && l <= len2 &&
-            o1 <= len1 - l && o2 <= len2 - l) then
-      invalid_arg msg;
-    blit e1 o1 e2 o2 l
-  end
+  if l < 0 || o1 < 0 || o1 > length e1 - l
+     || o2 < 0 || o2 > length e2 - l
+  then invalid_arg "Weak.blit"
+  else if l <> 0 then blit e1 o1 e2 o2 l
 
 let fill ar ofs len x =
-  if ofs < 0 || len < 0 || ofs + len > length ar
+  if ofs < 0 || len < 0 || ofs > length ar - len
   then raise (Invalid_argument "Weak.fill")
   else begin
     for i = ofs to (ofs + len - 1) do

--- a/stdlib/weak.mli
+++ b/stdlib/weak.mli
@@ -22,8 +22,10 @@ type 'a t
 (** The type of arrays of weak pointers (weak arrays).  A weak
    pointer is a value that the garbage collector may erase whenever
    the value is not used any more (through normal pointers) by the
-   program.  Note that finalisation functions are run after the
-   weak pointers are erased.
+   program.  Note that finalisation functions are run before the
+   weak pointers are erased, because the finalisation functions
+   can make values alive again (before 4.03 the finalisation
+   functions were run before).
 
    A weak pointer is said to be full if it points to a value,
    empty if the value was erased by the GC.

--- a/stdlib/weak.mli
+++ b/stdlib/weak.mli
@@ -25,7 +25,7 @@ type 'a t
    program.  Note that finalisation functions are run before the
    weak pointers are erased, because the finalisation functions
    can make values alive again (before 4.03 the finalisation
-   functions were run before).
+   functions were run after).
 
    A weak pointer is said to be full if it points to a value,
    empty if the value was erased by the GC.
@@ -40,7 +40,8 @@ type 'a t
 val create : int -> 'a t
 (** [Weak.create n] returns a new weak array of length [n].
    All the pointers are initially empty.  Raise [Invalid_argument]
-   if [n] is negative or greater than {!Sys.max_array_length}[-1].*)
+   if [n] is not comprised between zero and
+   {!Obj.Ephemeron.max_ephe_length} (limits included).*)
 
 val length : 'a t -> int
 (** [Weak.length ar] returns the length (number of elements) of

--- a/testsuite/tests/ephe-c-api/Makefile
+++ b/testsuite/tests/ephe-c-api/Makefile
@@ -1,0 +1,7 @@
+BASEDIR=../..
+MODULES=
+MAIN_MODULE=test
+C_FILES=stubs
+
+include $(BASEDIR)/makefiles/Makefile.one
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/ephe-c-api/stubs.c
+++ b/testsuite/tests/ephe-c-api/stubs.c
@@ -1,0 +1,325 @@
+#include<stdio.h>
+#include "caml/alloc.h"
+#include "caml/memory.h"
+#include "caml/weak.h"
+
+/* C version of ephetest.ml */
+
+void is_true(const char* test, const char* s, int b) {
+  if(b) printf("%s %s: OK\n", test, s);
+  else printf("%s %s: FAIL\n", test, s);
+}
+
+void is_false(const char* test, const char* s, int b) {
+  is_true(test, s, !b);
+}
+
+void is_data_value(const char* test, value eph, intnat v) {
+  CAMLparam1(eph);
+  CAMLlocal1(x);
+
+  if(caml_ephemeron_get_data_copy(eph, &x))
+    if(Long_val(Field(x, 0)) == v) printf("%s data set: OK\n", test);
+    else printf("%s data set: FAIL(bad value %li)\n", test,
+                (long int)Long_val(Field(x, 0)));
+  else
+    printf("%s data set: FAIL\n", test);
+
+  CAMLreturn0;
+}
+
+void is_key_value(const char* test, value eph, intnat v) {
+  CAMLparam1(eph);
+  CAMLlocal1(x);
+
+  if(caml_ephemeron_get_key_copy(eph, 0, &x))
+    if(Long_val(Field(x, 0)) == v) printf("%s key set: OK\n", test);
+    else printf("%s key set: FAIL(bad value %li)\n", test,
+                (long int)Long_val(Field(x, 0)));
+  else
+    printf("%s key unset: FAIL\n", test);
+
+  CAMLreturn0;
+}
+
+void is_key_unset(const char* test, value eph) {
+  is_false(test, "key unset", caml_ephemeron_check_key(eph, 0));
+}
+
+void is_data_unset(const char* test, value eph) {
+  is_false(test, "data unset", caml_ephemeron_check_data(eph));
+}
+
+extern value caml_gc_minor(value);
+extern value caml_gc_full_major(value);
+
+CAMLprim value test1(value ra, value rb) {
+  CAMLparam2(ra, rb);
+  CAMLlocal1(eph);
+  value x;
+
+  const char* test = "test1";
+  caml_gc_minor(Val_unit);
+  caml_gc_full_major(Val_unit);
+  eph = caml_ephemeron_create(1);
+  caml_ephemeron_set_key(eph, 0, Field(ra, 0));
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = Val_long(42);
+  caml_ephemeron_set_data(eph, x);
+  is_key_value(test, eph, 1);
+  is_data_value(test, eph, 42);
+  caml_gc_minor(Val_unit);
+  is_key_value(test, eph, 1);
+  is_data_value(test, eph, 42);
+  caml_gc_full_major(Val_unit);
+  is_key_value(test, eph, 1);
+  is_data_value(test, eph, 42);
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = Val_long(12);
+  caml_modify(&Field(ra, 0), x);
+  caml_gc_full_major(Val_unit);
+  is_key_unset(test, eph);
+  is_data_unset(test, eph);
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value test2(value ra, value rb) {
+  CAMLparam2(ra, rb);
+  CAMLlocal1(eph);
+  value x;
+
+  const char* test = "test2";
+  caml_gc_minor(Val_unit);
+  caml_gc_full_major(Val_unit);
+  eph = caml_ephemeron_create(1);
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = Val_long(125);
+  caml_ephemeron_set_key(eph, 0, x);
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = Val_long(42);
+  caml_ephemeron_set_data(eph, x);
+  is_key_value(test, eph, 125);
+  is_data_value(test, eph, 42);
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = Val_long(13);
+  caml_modify(&Field(ra, 0), x);
+  caml_gc_minor(Val_unit);
+  is_key_unset(test, eph);
+  is_data_unset(test, eph);
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value test3(value ra, value rb) {
+  CAMLparam2(ra, rb);
+  CAMLlocal1(eph);
+  value x;
+
+  const char* test = "test3";
+  caml_gc_minor(Val_unit);
+  caml_gc_full_major(Val_unit);
+  eph = caml_ephemeron_create(1);
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = Val_long(125);
+  caml_ephemeron_set_key(eph, 0, x);
+  caml_ephemeron_set_data(eph, Field(ra, 0));
+  is_key_value(test, eph, 125);
+  is_data_value(test, eph, 13);
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = Val_long(14);
+  caml_modify(&Field(ra, 0), x);
+  caml_gc_minor(Val_unit);
+  is_key_unset(test, eph);
+  is_data_unset(test, eph);
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value test4(value ra, value rb) {
+  CAMLparam2(ra, rb);
+  CAMLlocal2(eph, y);
+  value x;
+
+  const char* test = "test4";
+  caml_gc_minor(Val_unit);
+  caml_gc_full_major(Val_unit);
+  eph = caml_ephemeron_create(1);
+  y = caml_alloc(1, 0);
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = y;
+  caml_modify(&Field(y, 0), Val_long(3));
+  caml_modify(&Field(rb, 0), x);
+  y = Val_unit;
+  caml_ephemeron_set_key(eph, 0, Field(Field(rb, 0), 0));
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = Val_long(43);
+  caml_ephemeron_set_data(eph, x);
+  is_key_value(test, eph, 3);
+  is_data_value(test, eph, 43);
+  caml_gc_minor(Val_unit);
+  caml_gc_minor(Val_unit);
+  is_key_value(test, eph, 3);
+  is_data_value(test, eph, 43);
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value test5(value ra, value rb) {
+  CAMLparam2(ra, rb);
+  CAMLlocal2(eph, y);
+  value x;
+
+  const char* test = "test5";
+  caml_gc_minor(Val_unit);
+  caml_gc_full_major(Val_unit);
+  eph = caml_ephemeron_create(1);
+  y = caml_alloc(1, 0);
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = y;
+  caml_modify(&Field(y, 0), Val_long(3));
+  caml_modify(&Field(rb, 0), x);
+  y = Val_unit;
+  caml_ephemeron_set_key(eph, 0, Field(Field(rb, 0), 0));
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = Val_long(43);
+  caml_ephemeron_set_data(eph, x);
+  is_key_value(test, eph, 3);
+  is_data_value(test, eph, 43);
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = Val_long(4);
+  caml_modify(&Field(rb, 0), x);
+  caml_gc_minor(Val_unit);
+  caml_gc_minor(Val_unit);
+  is_key_unset(test, eph);
+  is_data_unset(test, eph);
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value test6(value ra, value rb) {
+  CAMLparam2(ra, rb);
+  CAMLlocal2(eph, y);
+  value x;
+
+  const char* test = "test6";
+  caml_gc_minor(Val_unit);
+  caml_gc_full_major(Val_unit);
+  eph = caml_ephemeron_create(1);
+  y = caml_alloc(1, 0);
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = y;
+  caml_modify(&Field(y, 0), Val_long(3));
+  caml_modify(&Field(rb, 0), x);
+  y = Val_unit;
+  caml_ephemeron_set_key(eph, 0, Field(Field(rb, 0), 0));
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = Field(Field(rb, 0), 0);
+  caml_ephemeron_set_data(eph, x);
+  caml_gc_minor(Val_unit);
+  is_key_value(test, eph, 3);
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = Val_long(4);
+  caml_modify(&Field(rb, 0), x);
+  caml_gc_full_major(Val_unit);
+  is_key_unset(test, eph);
+  is_data_unset(test, eph);
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value test7(value ra, value rb) {
+  CAMLparam2(ra, rb);
+  CAMLlocal4(eph, weak, y, rc);
+  value x;
+
+  const char* test = "test7";
+  caml_gc_minor(Val_unit);
+  caml_gc_full_major(Val_unit);
+  x = caml_alloc_small(1, 0);
+  Field(x, 0) = Val_long(42);
+  caml_modify(&Field(ra, 0), x);
+  weak = caml_weak_array_create(1);
+  y = caml_ephemeron_create(1);
+  eph = caml_alloc_small(1, 0);
+  Field(eph, 0) = y;
+  y = Val_unit;
+  rc = caml_alloc_small(1, 0);
+  Field(rc, 0) = Field(eph, 0);
+  caml_weak_array_set(weak, 0, Field(rc, 0));
+  caml_ephemeron_set_key(Field(eph, 0), 0, Field(ra, 0));
+  caml_ephemeron_set_data(Field(eph, 0), Field(rc, 0));
+  caml_gc_minor(Val_unit);
+  is_true(test, "before", caml_weak_array_check(weak, 0));
+  caml_modify(&Field(eph, 0), caml_ephemeron_create(1));
+  caml_modify(&Field(rc, 0), Val_unit);
+  caml_gc_full_major(Val_unit);
+  caml_gc_full_major(Val_unit);
+  caml_gc_full_major(Val_unit);
+  is_false(test, "after", caml_weak_array_check(weak, 0));
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value test8(value ra, value rb) {
+  CAMLparam2(ra, rb);
+  CAMLlocal3(x, y, z);
+
+  const char* test = "test8";
+
+  x = caml_ephemeron_create(15);
+  z = caml_ephemeron_create(3);
+  is_true(test, "eph length=15", caml_ephemeron_key_length(x) == 15);
+  is_true(test, "eph length=3", caml_ephemeron_key_length(z) == 3);
+
+  is_false(test, "eph get empty nonull", caml_ephemeron_get_key(x, 5, &y));
+  is_false(test, "eph get copy empty nonnull", caml_ephemeron_get_key_copy(x, 5, &y));
+  caml_ephemeron_set_key(x, 5, ra);
+  is_true(test, "eph get nonull", caml_ephemeron_get_key(x, 5, &y));
+  is_true(test, "eph get eq", y == ra);
+  is_true(test, "eph get copy nonnull", caml_ephemeron_get_key_copy(x, 5, &y));
+  is_true(test, "eph get copy eq", y != ra);
+  caml_ephemeron_blit_key(x, 4, z, 0, 3);
+  caml_ephemeron_unset_key(x, 5);
+  is_false(test, "eph get unset nonull", caml_ephemeron_get_key(x, 5, &y));
+  is_false(test, "eph get copy unset nonnull", caml_ephemeron_get_key_copy(x, 5, &y));
+  is_true(test, "eph get nonull z", caml_ephemeron_get_key(z, 1, &y));
+  is_true(test, "eph get eq z", y == ra);
+  is_false(test, "eph get empty z", caml_ephemeron_get_key(z, 0, &y));
+
+  is_false(test, "eph get data empty nonull", caml_ephemeron_get_data(x, &y));
+  is_false(test, "eph get data copy empty nonnull", caml_ephemeron_get_data_copy(x, &y));
+  caml_ephemeron_set_data(x, ra);
+  is_true(test, "eph get data nonull", caml_ephemeron_get_data(x, &y));
+  is_true(test, "eph get data eq", y == ra);
+  is_true(test, "eph get data copy nonnull", caml_ephemeron_get_data_copy(x, &y));
+  is_true(test, "eph get data copy eq", y != ra);
+  caml_ephemeron_blit_data(x, z);
+  caml_ephemeron_unset_data(x);
+  is_false(test, "eph get data unset nonull", caml_ephemeron_get_data(x, &y));
+  is_false(test, "eph get data copy unset nonnull", caml_ephemeron_get_data_copy(x, &y));
+  is_true(test, "eph get nonull z", caml_ephemeron_get_data(z, &y));
+  is_true(test, "eph get eq z", y == ra);
+
+  x = caml_weak_array_create(15);
+  z = caml_weak_array_create(3);
+  is_true(test, "eph length=15", caml_weak_array_length(x) == 15);
+  is_true(test, "eph length=3", caml_weak_array_length(z) == 3);
+
+  is_false(test, "eph get empty nonull", caml_weak_array_get(x, 5, &y));
+  is_false(test, "eph get copy empty nonnull", caml_weak_array_get_copy(x, 5, &y));
+  caml_weak_array_set(x, 5, ra);
+  is_true(test, "eph get nonull", caml_weak_array_get(x, 5, &y));
+  is_true(test, "eph get eq", y == ra);
+  is_true(test, "eph get copy nonnull", caml_weak_array_get_copy(x, 5, &y));
+  is_true(test, "eph get copy eq", y != ra);
+  caml_weak_array_blit(x, 4, z, 0, 3);
+  caml_weak_array_unset(x, 5);
+  is_false(test, "eph get unset nonull", caml_weak_array_get(x, 5, &y));
+  is_false(test, "eph get copy unset nonnull", caml_weak_array_get_copy(x, 5, &y));
+  is_true(test, "eph get nonull z", caml_weak_array_get(z, 1, &y));
+  is_true(test, "eph get eq z", y == ra);
+  is_false(test, "eph get empty z", caml_weak_array_get(z, 0, &y));
+
+  CAMLreturn(Val_unit);
+}

--- a/testsuite/tests/ephe-c-api/stubs.c
+++ b/testsuite/tests/ephe-c-api/stubs.c
@@ -43,11 +43,11 @@ void is_key_value(const char* test, value eph, intnat v) {
 }
 
 void is_key_unset(const char* test, value eph) {
-  is_false(test, "key unset", caml_ephemeron_check_key(eph, 0));
+  is_false(test, "key unset", caml_ephemeron_key_is_set(eph, 0));
 }
 
 void is_data_unset(const char* test, value eph) {
-  is_false(test, "data unset", caml_ephemeron_check_data(eph));
+  is_false(test, "data unset", caml_ephemeron_data_is_set(eph));
 }
 
 extern value caml_gc_minor(value);
@@ -269,8 +269,8 @@ CAMLprim value test8(value ra, value rb) {
 
   x = caml_ephemeron_create(15);
   z = caml_ephemeron_create(3);
-  is_true(test, "eph length=15", caml_ephemeron_key_length(x) == 15);
-  is_true(test, "eph length=3", caml_ephemeron_key_length(z) == 3);
+  is_true(test, "eph length=15", caml_ephemeron_num_keys(x) == 15);
+  is_true(test, "eph length=3", caml_ephemeron_num_keys(z) == 3);
 
   is_false(test, "eph get empty nonull", caml_ephemeron_get_key(x, 5, &y));
   is_false(test, "eph get copy empty nonnull", caml_ephemeron_get_key_copy(x, 5, &y));

--- a/testsuite/tests/ephe-c-api/test.ml
+++ b/testsuite/tests/ephe-c-api/test.ml
@@ -1,0 +1,20 @@
+(* C version of ephetest.ml *)
+
+let make_ra () = ref (ref 1) [@@inline never]
+let make_rb () = ref (ref (ref 2)) [@@inline never]
+
+let ra = make_ra ()
+let rb = make_rb ()
+
+external test1 : int ref ref -> int ref ref ref -> unit = "test1"
+external test2 : int ref ref -> int ref ref ref -> unit = "test2"
+external test3 : int ref ref -> int ref ref ref -> unit = "test3"
+external test4 : int ref ref -> int ref ref ref -> unit = "test4"
+external test5 : int ref ref -> int ref ref ref -> unit = "test5"
+external test6 : int ref ref -> int ref ref ref -> unit = "test6"
+external test7 : int ref ref -> int ref ref ref -> unit = "test7"
+external test8 : int ref ref -> int ref ref ref -> unit = "test8"
+
+let () =
+  test1 ra rb;  test2 ra rb;  test3 ra rb;  test4 ra rb;  test5 ra rb;
+  test6 ra rb;  test7 ra rb; test8 ra rb

--- a/testsuite/tests/ephe-c-api/test.reference
+++ b/testsuite/tests/ephe-c-api/test.reference
@@ -1,0 +1,65 @@
+test1 key set: OK
+test1 data set: OK
+test1 key set: OK
+test1 data set: OK
+test1 key set: OK
+test1 data set: OK
+test1 key unset: OK
+test1 data unset: OK
+test2 key set: OK
+test2 data set: OK
+test2 key unset: OK
+test2 data unset: OK
+test3 key set: OK
+test3 data set: OK
+test3 key unset: OK
+test3 data unset: OK
+test4 key set: OK
+test4 data set: OK
+test4 key set: OK
+test4 data set: OK
+test5 key set: OK
+test5 data set: OK
+test5 key unset: OK
+test5 data unset: OK
+test6 key set: OK
+test6 key unset: OK
+test6 data unset: OK
+test7 before: OK
+test7 after: OK
+test8 eph length=15: OK
+test8 eph length=3: OK
+test8 eph get empty nonull: OK
+test8 eph get copy empty nonnull: OK
+test8 eph get nonull: OK
+test8 eph get eq: OK
+test8 eph get copy nonnull: OK
+test8 eph get copy eq: OK
+test8 eph get unset nonull: OK
+test8 eph get copy unset nonnull: OK
+test8 eph get nonull z: OK
+test8 eph get eq z: OK
+test8 eph get empty z: OK
+test8 eph get data empty nonull: OK
+test8 eph get data copy empty nonnull: OK
+test8 eph get data nonull: OK
+test8 eph get data eq: OK
+test8 eph get data copy nonnull: OK
+test8 eph get data copy eq: OK
+test8 eph get data unset nonull: OK
+test8 eph get data copy unset nonnull: OK
+test8 eph get nonull z: OK
+test8 eph get eq z: OK
+test8 eph length=15: OK
+test8 eph length=3: OK
+test8 eph get empty nonull: OK
+test8 eph get copy empty nonnull: OK
+test8 eph get nonull: OK
+test8 eph get eq: OK
+test8 eph get copy nonnull: OK
+test8 eph get copy eq: OK
+test8 eph get unset nonull: OK
+test8 eph get copy unset nonnull: OK
+test8 eph get nonull z: OK
+test8 eph get eq z: OK
+test8 eph get empty z: OK


### PR DESCRIPTION
Follow up of #515 (which contained only change for 4.03), fix [#7173](http://caml.inria.fr/mantis/view.php?id=7173).
- C API for ephemerons and weak pointers
- Implement the OCaml primitive using these functions
- Exceptions are managed in the ocaml side
- Primitives that do not allocate are marked as noalloc
