### PR TITLE
export caml_major_gc_hook in major_gc.h

### DIFF
--- a/byterun/caml/major_gc.h
+++ b/byterun/caml/major_gc.h
@@ -68,6 +68,10 @@ int caml_major_ring_index;
 double caml_major_work_credit;
 extern double caml_gc_clock;
 
+/* [caml_major_gc_hook] is called just between the end of the mark
+   phase and the beginning of the sweep phase of the major GC */
+CAMLextern void (*caml_major_gc_hook)(void);
+
 void caml_init_major_heap (asize_t);           /* size in bytes */
 asize_t caml_clip_heap_chunk_wsz (asize_t wsz);
 void caml_darken (value, value *);


### PR DESCRIPTION
`caml_major_gc_hook` is used by `ocp-memprof` to trigger heap dumps.
