### PR TITLE
Graphics.close_graph crashes 64-bit Windows ports

### DIFF
--- a/Changes
+++ b/Changes
@@ -190,6 +190,10 @@ OCaml 4.04.0:
   OS-independent number
   (Jérémie Dimino)
 
+- GPR#678: Graphics.close_graph crashes 64-bit Windows ports (re-implementation
+  of PR#3963)
+  (David Allsopp)
+
 ### Documentation:
 
 - PR#7243: warn users against using WinZip to unpack the source archive

--- a/otherlibs/win32graph/open.c
+++ b/otherlibs/win32graph/open.c
@@ -104,7 +104,6 @@ static LRESULT CALLBACK GraphicsWndProc(HWND hwnd,UINT msg,WPARAM wParam,
                 // End application
         case WM_DESTROY:
                 ResetForClose(hwnd);
-                gr_check_open();
                 break;
         }
         caml_gr_handle_event(msg, wParam, lParam);


### PR DESCRIPTION
A fix for [MPR3963](http://caml.inria.fr/mantis/view.php?id=3963) was added in b147d078 (released in 4.01.0) by @damiendoligez. As far as I can see, this fix never worked: I think it's fundamentally broken and on the 32-bit Windows ports it doesn't work and on the 64-bit Windows ports, it causes `Graphics.close_graph` to bring down the runtime.

I believe the original intention was that closing the graphics window (via the X button) should result in any calls to `Graphics.wait_next_event` terminating with: 

``` ocaml
Graphics.Graphic_failure "graphic screen not opened"
```

but this is done by causing WM_DESTROY to raise an OCaml exception - but the window handler is in a non-OCaml thread, so it cannot possibly raise OCaml exceptions?
