### PR TITLE
Parser: delay registration of docstring after the mapper is applied

### DIFF
--- a/parsing/docstrings.ml
+++ b/parsing/docstrings.ml
@@ -68,8 +68,10 @@ let docstring body loc =
       ds_attached = Unattached;
       ds_associated = Zero; }
   in
-  docstrings := ds :: !docstrings;
   ds
+
+let register ds =
+  docstrings := ds :: !docstrings
 
 let docstring_body ds = ds.ds_body
 

--- a/parsing/docstrings.mli
+++ b/parsing/docstrings.mli
@@ -29,6 +29,9 @@ type docstring
 (** Create a docstring *)
 val docstring : string -> Location.t -> docstring
 
+(** Register a docstring *)
+val register : docstring -> unit
+
 (** Get the text of a docstring *)
 val docstring_body : docstring -> string
 

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -735,6 +735,7 @@ and skip_hash_bang = parse
           in
           loop lines' docs lexbuf
       | DOCSTRING doc ->
+          Docstrings.register doc;
           add_docstring_comment doc;
           let docs' =
             match docs, lines with


### PR DESCRIPTION
.. so that docstrings filtered out by a lexer preprocessor [1] are correctly ignored. 
[1] eg. https://github.com/janestreet/ppx_optcomp

this is https://github.com/ocaml/ocaml/pull/563 rebased on trunk
