### PR TITLE
Recognize [@@ocaml.immediate] in addition to [@@immediate]

### DIFF
--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -188,3 +188,10 @@ let explicit_arity =
       | ({txt="ocaml.explicit_arity"|"explicit_arity"; _}, _) -> true
       | _ -> false
     )
+
+let immediate =
+  List.exists
+    (function
+      | ({txt="ocaml.immediate"|"immediate"; _}, _) -> true
+      | _ -> false
+    )

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -23,6 +23,7 @@
    ocaml.explicit_arity (for camlp4/camlp5)
    ocaml.warn_on_literal_pattern
    ocaml.deprecated_mutable
+   ocaml.immediate
 *)
 
 
@@ -45,3 +46,6 @@ val emit_external_warnings: Ast_iterator.iterator
 
 val warn_on_literal_pattern: Parsetree.attributes -> bool
 val explicit_arity: Parsetree.attributes -> bool
+
+
+val immediate: Parsetree.attributes -> bool

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -856,7 +856,7 @@ let rec tree_of_type_decl id decl =
         Public
   in
   let immediate =
-    List.exists (fun (loc, _) -> loc.txt = "immediate") decl.type_attributes
+    Builtin_attributes.immediate decl.type_attributes
   in
     { otype_name = name;
       otype_params = args;

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -898,9 +898,7 @@ let is_hash id =
   String.length s > 0 && s.[0] = '#'
 
 let marked_as_immediate decl =
-  List.exists
-    (fun (loc, _) -> loc.txt = "immediate")
-    decl.type_attributes
+  Builtin_attributes.immediate decl.type_attributes
 
 let compute_immediacy env tdecl =
   match (tdecl.type_kind, tdecl.type_manifest) with


### PR DESCRIPTION
The policy is to always recognize both forms for builtin attributes.
