### PR TITLE
WIP: Hide bound variables marked with [@ocaml.private] from signatures

### DIFF
--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -3023,7 +3023,7 @@ let assign_pat opt nraise catch_ids loc pat lam =
   | _ ->
     (* pattern idents will be bound in staticcatch (let body), so we
        refresh them here to guarantee binders  uniqueness *)
-    let pat_ids = pat_bound_idents pat in
+    let pat_ids = pat_bound_idents ~with_private:true pat in
     let fresh_ids = List.map (fun id -> id, Ident.rename id) pat_ids in
     (fresh_ids, alpha_pat fresh_ids pat, lam) :: acc
   in
@@ -3058,7 +3058,7 @@ let for_let loc param pat body =
   | _ ->
       let opt = ref false in
       let nraise = next_raise_count () in
-      let catch_ids = pat_bound_idents pat in
+      let catch_ids = pat_bound_idents ~with_private:true pat in
       let bind = map_return (assign_pat opt nraise catch_ids loc pat) param in
       if !opt then Lstaticcatch(bind, (nraise, catch_ids), body)
       else simple_for_let loc param pat body

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -460,7 +460,9 @@ and transl_structure loc fields cc rootpath final_env = function
           in
           Lsequence(transl_exp expr, body), size
       | Tstr_value(rec_flag, pat_expr_list) ->
-          let ext_fields = rev_let_bound_idents pat_expr_list @ fields in
+          let ext_fields =
+            rev_let_bound_idents ~with_private:false pat_expr_list @ fields
+          in
           let body, size =
             transl_structure loc ext_fields cc rootpath final_env rem
           in
@@ -626,7 +628,7 @@ let rec defined_idents = function
     match item.str_desc with
     | Tstr_eval _ -> defined_idents rem
     | Tstr_value(_rec_flag, pat_expr_list) ->
-      let_bound_idents pat_expr_list @ defined_idents rem
+      let_bound_idents ~with_private:false pat_expr_list @ defined_idents rem
     | Tstr_primitive _ -> defined_idents rem
     | Tstr_type _ -> defined_idents rem
     | Tstr_typext tyext ->
@@ -652,7 +654,11 @@ let rec more_idents = function
   | item :: rem ->
     match item.str_desc with
     | Tstr_eval _ -> more_idents rem
-    | Tstr_value _ -> more_idents rem
+    | Tstr_value(_, pat_expr_list) ->
+        let l = let_bound_idents ~with_private:true pat_expr_list in
+        let public = let_bound_idents ~with_private:false pat_expr_list in
+        let l = List.filter (fun id -> not (List.memq id public)) l in
+        l @ more_idents rem
     | Tstr_primitive _ -> more_idents rem
     | Tstr_type _ -> more_idents rem
     | Tstr_typext _ -> more_idents rem
@@ -677,7 +683,7 @@ and all_idents = function
     match item.str_desc with
     | Tstr_eval _ -> all_idents rem
     | Tstr_value(_rec_flag, pat_expr_list) ->
-      let_bound_idents pat_expr_list @ all_idents rem
+      let_bound_idents ~with_private:true pat_expr_list @ all_idents rem
     | Tstr_primitive _ -> all_idents rem
     | Tstr_type _ -> all_idents rem
     | Tstr_typext tyext ->
@@ -734,7 +740,7 @@ let transl_store_structure glob map prims str =
             Lsequence(subst_lambda subst (transl_exp expr),
                       transl_store rootpath subst rem)
         | Tstr_value(rec_flag, pat_expr_list) ->
-            let ids = let_bound_idents pat_expr_list in
+            let ids = let_bound_idents ~with_private:true pat_expr_list in
             let lam =
               transl_let rec_flag pat_expr_list (store_idents Location.none ids)
             in
@@ -1038,7 +1044,7 @@ let transl_toplevel_item item =
          in a Lsequence returning unit. *)
       transl_exp expr
   | Tstr_value(rec_flag, pat_expr_list) ->
-      let idents = let_bound_idents pat_expr_list in
+      let idents = let_bound_idents ~with_private:true (* !!! *) pat_expr_list in
       transl_let rec_flag pat_expr_list
         (make_sequence toploop_setvalue_id idents)
   | Tstr_typext(tyext) ->

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -182,6 +182,13 @@ let warn_on_literal_pattern =
       | _ -> false
     )
 
+let private_decl =
+  List.exists
+    (function
+      | ({txt="ocaml.private"|"private"; _}, _) -> true
+      | _ -> false
+    )
+
 let explicit_arity =
   List.exists
     (function

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -43,5 +43,7 @@ val with_warning_attribute: Parsetree.attributes -> (unit -> 'a) -> 'a
 
 val emit_external_warnings: Ast_iterator.iterator
 
+val private_decl: Parsetree.attributes -> bool
+
 val warn_on_literal_pattern: Parsetree.attributes -> bool
 val explicit_arity: Parsetree.attributes -> bool

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -2077,7 +2077,8 @@ let check_partial_gadt pred loc casel =
 
 module IdSet = Set.Make(Ident)
 
-let pattern_vars p = IdSet.of_list (Typedtree.pat_bound_idents p)
+let pattern_vars p =
+  IdSet.of_list (Typedtree.pat_bound_idents ~with_private:true p)
 
 (* Row for ambiguous variable search,
    unseen is the traditional pattern row,

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1153,7 +1153,7 @@ and class_expr cl_num val_env met_env scl =
              ((id', id_loc, expr)
               :: vals,
               Env.add_value id' desc met_env))
-          (let_bound_idents_with_loc defs)
+          (let_bound_idents_with_loc ~with_private:true defs)
           ([], met_env)
       in
       let cl = class_expr cl_num val_env met_env scl' in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4013,7 +4013,7 @@ and type_let ?(check = fun s -> Warnings.Unused_var s)
                       some_used := true
                 )
             )
-            (Typedtree.pat_bound_idents pat);
+            (Typedtree.pat_bound_idents ~with_private:true pat);
           pat, Some slot
         )
       pat_list

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -628,11 +628,11 @@ and 'a class_infos =
 val iter_pattern_desc: (pattern -> unit) -> pattern_desc -> unit
 val map_pattern_desc: (pattern -> pattern) -> pattern_desc -> pattern_desc
 
-val let_bound_idents: value_binding list -> Ident.t list
-val rev_let_bound_idents: value_binding list -> Ident.t list
+val let_bound_idents: with_private:bool -> value_binding list -> Ident.t list
+val rev_let_bound_idents: with_private:bool -> value_binding list -> Ident.t list
 
 val let_bound_idents_with_loc:
-    value_binding list -> (Ident.t * string loc) list
+    with_private:bool -> value_binding list -> (Ident.t * string loc) list
 
 (** Alpha conversion of patterns *)
 val alpha_pat: (Ident.t * Ident.t) list -> pattern -> pattern
@@ -640,4 +640,4 @@ val alpha_pat: (Ident.t * Ident.t) list -> pattern -> pattern
 val mknoloc: 'a -> 'a Asttypes.loc
 val mkloc: 'a -> Location.t -> 'a Asttypes.loc
 
-val pat_bound_idents: pattern -> Ident.t list
+val pat_bound_idents: with_private:bool -> pattern -> Ident.t list

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1233,8 +1233,9 @@ and type_structure ?(toplevel = false) funct_body anchor env sstr scope =
         (* Note: Env.find_value does not trigger the value_used event. Values
            will be marked as being used during the signature inclusion test. *)
         Tstr_value(rec_flag, defs),
-        List.map (fun id -> Sig_value(id, Env.find_value (Pident id) newenv))
-          (let_bound_idents defs),
+        List.map
+          (fun id -> Sig_value(id, Env.find_value (Pident id) newenv))
+          (let_bound_idents ~with_private:false defs),
         newenv
     | Pstr_primitive sdesc ->
         let (desc, newenv) = Typedecl.transl_value_decl env loc sdesc in


### PR DESCRIPTION
Not ready for merge!

This is a first proposal to address http://caml.inria.fr/mantis/view.php?id=5764 by providing a way to specify that some non-local let-bound pattern variables should not be exposed in their structure.  This is done by detecting a special attribute on pattern variables (the lhs is used in case of or-patterns):
For instance in

``` ocaml

  module M = struct
      let x[@ocaml.private], y = 1, 2
  end
```

outside `M`, only `y` exists.

This is not really intended for end-users and more for ppx or other code generators that need to insert declarations for internal uses which should not be exposed in inferred signatures.  (See https://github.com/LexiFi/landmarks/issues/2 for a recent case where such a feature would have been useful.)

This PR is to discuss the general idea.

The current implementation is not very satisfactory, because it parses the attribute potentially multiple times.  A better approach would probably to add to the `Tstr_value` constructor an explicit list of "public" identifiers, rather than recover it from analyzing its patterns.  The logic to parse the attribute would then be nicely located in `Typemod`.

What to do in the toplevel is not completely clear.  Should private identifiers be usable by later phrases?  
