### PR TITLE
[WIP] Private modules

### DIFF
--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -188,3 +188,10 @@ let explicit_arity =
       | ({txt="ocaml.explicit_arity"|"explicit_arity"; _}, _) -> true
       | _ -> false
     )
+
+let is_private =
+  List.exists
+    (function
+      | ({txt="ocaml.private"|"private"; _}, _) -> true
+      | _ -> false
+    )

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -43,5 +43,7 @@ val with_warning_attribute: Parsetree.attributes -> (unit -> 'a) -> 'a
 
 val emit_external_warnings: Ast_iterator.iterator
 
+val is_private: Parsetree.attributes -> bool
+
 val warn_on_literal_pattern: Parsetree.attributes -> bool
 val explicit_arity: Parsetree.attributes -> bool

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -56,6 +56,7 @@ type error =
     Cannot_apply of module_type
   | Not_included of Includemod.error list
   | Cannot_eliminate_dependency of module_type
+  | Cannot_eliminate_private_module of Ident.t * signature
   | Signature_expected
   | Structure_expected of module_type
   | With_no_component of Longident.t


### PR DESCRIPTION
This is a variant of #682, and also for discussion only.

This is about marking module declarations as private, so that they are visible in the rest of the current structure, but not exposed in the signature (in particular, there is a check that types declared in the private module can be eliminated).  The syntax in the PR is currently:

``` ocaml
module[@private] X = ....
```

Private let bindings from #682 can be encoded by picking a fresh name:

``` ocaml
let (x[@private]) = ...

===>

module[@private] Foo1234 = struct let x = ... end
open Foo1234
```
