### PR TITLE
Fix MPR7253, exit behaviour in case of raising at_exit functions.

### DIFF
--- a/stdlib/pervasives.ml
+++ b/stdlib/pervasives.ml
@@ -508,13 +508,13 @@ let ( ^^ ) (Format (fmt1, str1)) (Format (fmt2, str2)) =
 
 external sys_exit : int -> 'a = "caml_sys_exit"
 
-let exit_function = ref flush_all
+let exit_functions = ref [flush_all]
 
-let at_exit f =
-  let g = !exit_function in
-  exit_function := (fun () -> f(); g())
+let at_exit f = exit_functions := f :: !exit_functions
 
-let do_at_exit () = (!exit_function) ()
+let rec do_at_exit () = match !exit_functions with
+| [] -> ()
+| f :: fs -> exit_functions := fs; f (); do_at_exit ()
 
 let exit retcode =
   do_at_exit ();

--- a/stdlib/pervasives.mli
+++ b/stdlib/pervasives.mli
@@ -1124,7 +1124,9 @@ val at_exit : (unit -> unit) -> unit
    will be called when the program executes {!Pervasives.exit},
    or terminates, either normally or because of an uncaught exception.
    The functions are called in 'last in, first out' order:
-   the function most recently added with [at_exit] is called first. *)
+   the function most recently added with [at_exit] is called first.
+   If the registered function raises an uncaught exception it is given
+   to the handler setup by {!Printexc.set_uncaught_exception_handler}. *)
 
 (**/**)
 

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -143,9 +143,9 @@ val set_uncaught_exception_handler: (exn -> raw_backtrace -> unit) -> unit
     for uncaught exceptions. The default handler prints the exception and
     backtrace on standard error output.
 
-    Note that when [fn] is called all the functions registered with
-    {!Pervasives.at_exit} have already been called. Because of this you must
-    make sure any output channel [fn] writes on is flushed.
+    Note that when [fn] is called all the functions that are registered with
+    {!Pervasives.at_exit} that have not been called yet will be called
+    after the call to [fn].
 
     Also note that exceptions raised by user code in the interactive toplevel
     are not passed to this function as they are caught by the toplevel itself.


### PR DESCRIPTION
Fixes [MPR7253](http://caml.inria.fr/mantis/view.php?id=7253)

Rather than building a closure that captures the list of [at_exit]
functions to call at [exit] we explicitly store them in a mutable
list in LIFO order. We change the [Pervasives.do_at_exit] function
so that it sequentially pops one from the list before executing it.

If the popped function raises, the general uncaught exception mecanism
of [caml_main] kicks in. This eventually leads to the execution of
[Printexc.handle_uncaught_exception'] which reports the uncaught
exception and then calls [Pervasives.do_at_exit] to continue calling
the remaining [at_exit] functions. The latter call is guarded to catch
and report further exception raised by [at_exit] function in a loop,
so that each uncaught expression in [at_exit] functions gets reported.

This changes the semantics of the handler given to
Printexc.set_uncaught_exception_handler. It used to be that handler
would be called after all [at_exit] functions would have been called.
This is no longer the case, it is called before any [at_exit] function
that didn't get executed yet when the uncaught exception was raised.
