### PR TITLE
Unix.stat: Raise on overflow of inode number

### DIFF
--- a/Changes
+++ b/Changes
@@ -53,6 +53,9 @@ Working version
   values.
   (Daniel Bünzli, review by Damien Doligez, Max Mouratov)
 
+- Add Unix.LongInode module for stat calls returning 64bit inode numbers
+  (Christopher Zimmermann, review by Gabriel Scherer and Xavier Leroy)
+
 ### Compiler user-interface and warnings:
 
 - GPR#948: the compiler now reports warnings-as-errors by prefixing

--- a/otherlibs/threads/unix.ml
+++ b/otherlibs/threads/unix.ml
@@ -271,6 +271,27 @@ type file_kind =
   | S_FIFO
   | S_SOCK
 
+module LongInode =
+  struct
+    type stats =
+      { st_dev : int32;
+        st_ino : int64;
+        st_kind : file_kind;
+        st_perm : file_perm;
+        st_nlink : int;
+        st_uid : int;
+        st_gid : int;
+        st_rdev : int32;
+        st_size : int64;
+        st_atime : float;
+        st_mtime : float;
+        st_ctime : float;
+      }
+    external stat : string -> stats = "unix_stat_64"
+    external lstat : string -> stats = "unix_lstat_64"
+    external fstat : file_descr -> stats = "unix_fstat_64"
+  end
+
 type stats =
   { st_dev : int;
     st_ino : int;
@@ -285,13 +306,43 @@ type stats =
     st_mtime : float;
     st_ctime : float }
 
-external stat : string -> stats = "unix_stat"
-external lstat : string -> stats = "unix_lstat"
-external fstat : file_descr -> stats = "unix_fstat"
 external isatty : file_descr -> bool = "unix_isatty"
 external unlink : string -> unit = "unix_unlink"
 external rename : string -> string -> unit = "unix_rename"
 external link : string -> string -> unit = "unix_link"
+
+let int_of_32 i =
+  let mask = Int32.shift_left 0xfffffffel (Sys.int_size - 1) in
+  if Int32.equal Int32.zero (Int32.logand mask i)
+  then Int32.to_int i
+  else raise(Unix_error(EOVERFLOW, "stat", ""))
+let int_of_64 i =
+  let mask = Int64.shift_left 0xfffffffffffffffeL (Sys.int_size - 1) in
+  if Int64.equal Int64.zero (Int64.logand mask i)
+  then Int64.to_int i
+  else raise(Unix_error(EOVERFLOW, "stat", ""))
+
+let stat, lstat, fstat =
+  let convert_stat stat = {
+    st_dev   = int_of_32 stat.LongInode.st_dev;
+    st_ino   = int_of_64 stat.LongInode.st_ino;
+    st_kind  = stat.LongInode.st_kind;
+    st_perm  = stat.LongInode.st_perm;
+    st_nlink = stat.LongInode.st_nlink;
+    st_uid   = stat.LongInode.st_uid;
+    st_gid   = stat.LongInode.st_gid;
+    st_rdev  = int_of_32 stat.LongInode.st_dev;
+    st_size  = int_of_64 stat.LongInode.st_size;
+    st_atime = stat.LongInode.st_atime;
+    st_mtime = stat.LongInode.st_mtime;
+    st_ctime = stat.LongInode.st_ctime }
+  in
+  (fun path -> try convert_stat (LongInode.stat path)
+    with Unix_error (e, _, _) -> raise(Unix_error((e, "stat", path)))),
+  (fun path -> try convert_stat (LongInode.lstat path)
+    with Unix_error (e, _, _) -> raise(Unix_error((e, "lstat", path)))),
+  (fun descr -> try convert_stat (LongInode.fstat descr)
+    with Unix_error (e, _, _) -> raise(Unix_error((e, "fstat", ""))))
 
 module LargeFile =
   struct
@@ -313,9 +364,28 @@ module LargeFile =
         st_mtime : float;
         st_ctime : float;
       }
-    external stat : string -> stats = "unix_stat_64"
-    external lstat : string -> stats = "unix_lstat_64"
-    external fstat : file_descr -> stats = "unix_fstat_64"
+
+    let stat, lstat, fstat =
+      let convert_stat stat = {
+        st_dev   = int_of_32 stat.LongInode.st_dev;
+        st_ino   = int_of_64 stat.LongInode.st_ino;
+        st_kind  = stat.LongInode.st_kind;
+        st_perm  = stat.LongInode.st_perm;
+        st_nlink = stat.LongInode.st_nlink;
+        st_uid   = stat.LongInode.st_uid;
+        st_gid   = stat.LongInode.st_gid;
+        st_rdev  = int_of_32 stat.LongInode.st_dev;
+        st_size  = stat.LongInode.st_size;
+        st_atime = stat.LongInode.st_atime;
+        st_mtime = stat.LongInode.st_mtime;
+        st_ctime = stat.LongInode.st_ctime }
+      in
+      (fun path -> try convert_stat (LongInode.stat path)
+        with Unix_error (e, _, _) -> raise(Unix_error((e, "stat", path)))),
+      (fun path -> try convert_stat (LongInode.lstat path)
+        with Unix_error (e, _, _) -> raise(Unix_error((e, "lstat", path)))),
+      (fun descr -> try convert_stat (LongInode.fstat descr)
+        with Unix_error (e, _, _) -> raise(Unix_error((e, "fstat", ""))))
   end
 
 type map_file_impl =

--- a/otherlibs/unix/stat.c
+++ b/otherlibs/unix/stat.c
@@ -39,18 +39,15 @@
 #define S_IFBLK 0
 #endif
 
-#ifndef EOVERFLOW
-#define EOVERFLOW ERANGE
-#endif
-
 static int file_kind_table[] = {
   S_IFREG, S_IFDIR, S_IFCHR, S_IFBLK, S_IFLNK, S_IFIFO, S_IFSOCK
 };
 
-static value stat_aux(int use_64, struct stat *buf)
+static value stat_aux(struct stat *buf)
 {
   CAMLparam0();
-  CAMLlocal5(atime, mtime, ctime, offset, v);
+  CAMLlocal5(size, ino, dev, rdev, v);
+  CAMLlocal3(atime, mtime, ctime);
 
   #include "nanosecond_stat.h"
   atime = caml_copy_double((double) buf->st_atime
@@ -60,75 +57,25 @@ static value stat_aux(int use_64, struct stat *buf)
   ctime = caml_copy_double((double) buf->st_ctime
                            + (NSEC(buf, c) / 1000000000.0));
   #undef NSEC
-  offset = use_64 ? Val_file_offset(buf->st_size) : Val_int (buf->st_size);
+  dev = caml_copy_int32(buf->st_dev);
+  rdev = caml_copy_int32(buf->st_rdev);
+  ino = caml_copy_int64(buf->st_ino);
+  size = caml_copy_int64(buf->st_size);
   v = caml_alloc_small(12, 0);
-  Field (v, 0) = Val_int (buf->st_dev);
-  Field (v, 1) = Val_int (buf->st_ino);
+  Field (v, 0) = dev;
+  Field (v, 1) = ino;
   Field (v, 2) = cst_to_constr(buf->st_mode & S_IFMT, file_kind_table,
                                sizeof(file_kind_table) / sizeof(int), 0);
   Field (v, 3) = Val_int (buf->st_mode & 07777);
   Field (v, 4) = Val_int (buf->st_nlink);
   Field (v, 5) = Val_int (buf->st_uid);
   Field (v, 6) = Val_int (buf->st_gid);
-  Field (v, 7) = Val_int (buf->st_rdev);
-  Field (v, 8) = offset;
+  Field (v, 7) = rdev;
+  Field (v, 8) = size;
   Field (v, 9) = atime;
   Field (v, 10) = mtime;
   Field (v, 11) = ctime;
   CAMLreturn(v);
-}
-
-CAMLprim value unix_stat(value path)
-{
-  CAMLparam1(path);
-  int ret;
-  struct stat buf;
-  char * p;
-  caml_unix_check_path(path, "stat");
-  p = caml_stat_strdup(String_val(path));
-  caml_enter_blocking_section();
-  ret = stat(p, &buf);
-  caml_leave_blocking_section();
-  caml_stat_free(p);
-  if (ret == -1) uerror("stat", path);
-  if (buf.st_size > Max_long && (buf.st_mode & S_IFMT) == S_IFREG)
-    unix_error(EOVERFLOW, "stat", path);
-  CAMLreturn(stat_aux(0, &buf));
-}
-
-CAMLprim value unix_lstat(value path)
-{
-  CAMLparam1(path);
-  int ret;
-  struct stat buf;
-  char * p;
-  caml_unix_check_path(path, "lstat");
-  p = caml_stat_strdup(String_val(path));
-  caml_enter_blocking_section();
-#ifdef HAS_SYMLINK
-  ret = lstat(p, &buf);
-#else
-  ret = stat(p, &buf);
-#endif
-  caml_leave_blocking_section();
-  caml_stat_free(p);
-  if (ret == -1) uerror("lstat", path);
-  if (buf.st_size > Max_long && (buf.st_mode & S_IFMT) == S_IFREG)
-    unix_error(EOVERFLOW, "lstat", path);
-  CAMLreturn(stat_aux(0, &buf));
-}
-
-CAMLprim value unix_fstat(value fd)
-{
-  int ret;
-  struct stat buf;
-  caml_enter_blocking_section();
-  ret = fstat(Int_val(fd), &buf);
-  caml_leave_blocking_section();
-  if (ret == -1) uerror("fstat", Nothing);
-  if (buf.st_size > Max_long && (buf.st_mode & S_IFMT) == S_IFREG)
-    unix_error(EOVERFLOW, "fstat", Nothing);
-  return stat_aux(0, &buf);
 }
 
 CAMLprim value unix_stat_64(value path)
@@ -144,7 +91,7 @@ CAMLprim value unix_stat_64(value path)
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1) uerror("stat", path);
-  CAMLreturn(stat_aux(1, &buf));
+  CAMLreturn(stat_aux(&buf));
 }
 
 CAMLprim value unix_lstat_64(value path)
@@ -164,7 +111,7 @@ CAMLprim value unix_lstat_64(value path)
   caml_leave_blocking_section();
   caml_stat_free(p);
   if (ret == -1) uerror("lstat", path);
-  CAMLreturn(stat_aux(1, &buf));
+  CAMLreturn(stat_aux(&buf));
 }
 
 CAMLprim value unix_fstat_64(value fd)
@@ -175,5 +122,5 @@ CAMLprim value unix_fstat_64(value fd)
   ret = fstat(Int_val(fd), &buf);
   caml_leave_blocking_section();
   if (ret == -1) uerror("fstat", Nothing);
-  return stat_aux(1, &buf);
+  return stat_aux(&buf);
 }

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -393,6 +393,30 @@ type file_kind =
   | S_FIFO                      (** Named pipe *)
   | S_SOCK                      (** Socket *)
 
+(** {6 Stat calls for 64 bit inodes} *)
+
+module LongInode :
+  sig
+    type stats =
+      { st_dev : int32;             (** Device number *)
+        st_ino : int64;             (** Inode number *)
+        st_kind : file_kind;        (** Kind of the file *)
+        st_perm : file_perm;        (** Access rights *)
+        st_nlink : int;             (** Number of links *)
+        st_uid : int;               (** User id of the owner *)
+        st_gid : int;               (** Group ID of the file's group *)
+        st_rdev : int32;            (** Device minor number *)
+        st_size : int64;            (** Size in bytes *)
+        st_atime : float;           (** Last access time *)
+        st_mtime : float;           (** Last modification time *)
+        st_ctime : float;           (** Last status change time *)
+      }
+
+    val stat : string -> stats
+    val lstat : string -> stats
+    val fstat : file_descr -> stats
+  end
+
 type stats =
   { st_dev : int;               (** Device number *)
     st_ino : int;               (** Inode number *)

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -348,6 +348,30 @@ type file_kind = Unix.file_kind =
   | S_FIFO                      (** Named pipe *)
   | S_SOCK                      (** Socket *)
 
+(** {6 Stat calls for 64 bit inodes} *)
+
+module LongInode :
+  sig
+    type stats =
+      { st_dev : int32;             (** Device number *)
+        st_ino : int64;             (** Inode number *)
+        st_kind : file_kind;        (** Kind of the file *)
+        st_perm : file_perm;        (** Access rights *)
+        st_nlink : int;             (** Number of links *)
+        st_uid : int;               (** User id of the owner *)
+        st_gid : int;               (** Group ID of the file's group *)
+        st_rdev : int32;            (** Device minor number *)
+        st_size : int64;            (** Size in bytes *)
+        st_atime : float;           (** Last access time *)
+        st_mtime : float;           (** Last modification time *)
+        st_ctime : float;           (** Last status change time *)
+      }
+
+    val stat : string -> stats
+    val lstat : string -> stats
+    val fstat : file_descr -> stats
+  end
+
 type stats = Unix.stats =
   { st_dev : int;               (** Device number *)
     st_ino : int;               (** Inode number *)

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -239,6 +239,27 @@ type file_kind =
   | S_FIFO
   | S_SOCK
 
+module LongInode =
+  struct
+    type stats =
+      { st_dev : int32;
+        st_ino : int64;
+        st_kind : file_kind;
+        st_perm : file_perm;
+        st_nlink : int;
+        st_uid : int;
+        st_gid : int;
+        st_rdev : int32;
+        st_size : int64;
+        st_atime : float;
+        st_mtime : float;
+        st_ctime : float;
+      }
+    external stat : string -> stats = "unix_stat_64"
+    external lstat : string -> stats = "unix_lstat_64"
+    external fstat : file_descr -> stats = "unix_fstat_64"
+  end
+
 type stats =
   { st_dev : int;
     st_ino : int;
@@ -253,17 +274,47 @@ type stats =
     st_mtime : float;
     st_ctime : float }
 
-external stat : string -> stats = "unix_stat"
-external lstat : string -> stats = "unix_lstat"
-external fstat : file_descr -> stats = "unix_fstat"
-let isatty fd =
-  match (fstat fd).st_kind with S_CHR -> true | _ -> false
-
 (* Operations on file names *)
 
 external unlink : string -> unit = "unix_unlink"
 external rename : string -> string -> unit = "unix_rename"
 external link : string -> string -> unit = "unix_link"
+
+let int_of_32 i =
+  let mask = Int32.shift_left 0xfffffffel (Sys.int_size - 1) in
+  if Int32.equal Int32.zero (Int32.logand mask i)
+  then Int32.to_int i
+  else raise(Unix_error(EOVERFLOW, "stat", ""))
+let int_of_64 i =
+  let mask = Int64.shift_left 0xfffffffffffffffeL (Sys.int_size - 1) in
+  if Int64.equal Int64.zero (Int64.logand mask i)
+  then Int64.to_int i
+  else raise(Unix_error(EOVERFLOW, "stat", ""))
+
+let stat, lstat, fstat =
+  let convert_stat stat = {
+    st_dev   = int_of_32 stat.LongInode.st_dev;
+    st_ino   = int_of_64 stat.LongInode.st_ino;
+    st_kind  = stat.LongInode.st_kind;
+    st_perm  = stat.LongInode.st_perm;
+    st_nlink = stat.LongInode.st_nlink;
+    st_uid   = stat.LongInode.st_uid;
+    st_gid   = stat.LongInode.st_gid;
+    st_rdev  = int_of_32 stat.LongInode.st_dev;
+    st_size  = int_of_64 stat.LongInode.st_size;
+    st_atime = stat.LongInode.st_atime;
+    st_mtime = stat.LongInode.st_mtime;
+    st_ctime = stat.LongInode.st_ctime }
+  in
+  (fun path -> try convert_stat (LongInode.stat path)
+    with Unix_error (e, _, _) -> raise(Unix_error((e, "stat", path)))),
+  (fun path -> try convert_stat (LongInode.lstat path)
+    with Unix_error (e, _, _) -> raise(Unix_error((e, "lstat", path)))),
+  (fun descr -> try convert_stat (LongInode.fstat descr)
+    with Unix_error (e, _, _) -> raise(Unix_error((e, "fstat", ""))))
+
+let isatty fd =
+  match (fstat fd).st_kind with S_CHR -> true | _ -> false
 
 (* Operations on large files *)
 
@@ -289,9 +340,28 @@ module LargeFile =
         st_mtime : float;
         st_ctime : float;
       }
-    external stat : string -> stats = "unix_stat_64"
-    external lstat : string -> stats = "unix_lstat_64"
-    external fstat : file_descr -> stats = "unix_fstat_64"
+
+    let stat, lstat, fstat =
+      let convert_stat stat = {
+        st_dev   = int_of_32 stat.LongInode.st_dev;
+        st_ino   = int_of_64 stat.LongInode.st_ino;
+        st_kind  = stat.LongInode.st_kind;
+        st_perm  = stat.LongInode.st_perm;
+        st_nlink = stat.LongInode.st_nlink;
+        st_uid   = stat.LongInode.st_uid;
+        st_gid   = stat.LongInode.st_gid;
+        st_rdev  = int_of_32 stat.LongInode.st_dev;
+        st_size  = stat.LongInode.st_size;
+        st_atime = stat.LongInode.st_atime;
+        st_mtime = stat.LongInode.st_mtime;
+        st_ctime = stat.LongInode.st_ctime }
+      in
+      (fun path -> try convert_stat (LongInode.stat path)
+        with Unix_error (e, _, _) -> raise(Unix_error((e, "stat", path)))),
+      (fun path -> try convert_stat (LongInode.lstat path)
+        with Unix_error (e, _, _) -> raise(Unix_error((e, "lstat", path)))),
+      (fun descr -> try convert_stat (LongInode.fstat descr)
+        with Unix_error (e, _, _) -> raise(Unix_error((e, "fstat", ""))))
   end
 
 (* Mapping files into memory *)


### PR DESCRIPTION
There are filesystems out there supporting 64bit inodes numbers. Even 32bit inode numbers may overflow on our 31bit ints.
