### PR TITLE
Choosing safe-string at configure time

### DIFF
--- a/Changes
+++ b/Changes
@@ -160,6 +160,11 @@ OCaml 4.04.0:
 - GPR#507: More sharing between Unix and Windows makefiles
   (whitequark, review by Alain Frisch)
 
+- GPR#687: "./configure -safe-string" to get a system where
+  "-unsafe-string" is not allowed, thus giving stronger non-local
+  guarantees about immutability of strings
+  (Alain Frisch, review by Hezekiah M. Carty)
+
 
 ### Bug fixes:
 

--- a/Makefile
+++ b/Makefile
@@ -430,6 +430,7 @@ utils/config.ml: utils/config.mlp config/Makefile
 	    -e 's|%%HOST%%|$(HOST)|' \
 	    -e 's|%%TARGET%%|$(TARGET)|' \
 	    -e 's|%%FLAMBDA%%|$(FLAMBDA)|' \
+	    -e 's|%%SAFE_STRING%%|$(SAFE_STRING)|' \
 	    utils/config.mlp > utils/config.ml
 
 partialclean::

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -404,6 +404,7 @@ utils/config.ml: utils/config.mlp config/Makefile
 	    -e 's|%%HOST%%|$(HOST)|' \
 	    -e 's|%%TARGET%%|$(TARGET)|' \
 	    -e 's|%%FLAMBDA%%|$(FLAMBDA)|' \
+	    -e 's|%%SAFE_STRING%%|$(SAFE_STRING)|' \
 	    -e 's|%%FLEXLINK_FLAGS%%|$(FLEXLINK_FLAGS)|' \
 	    utils/config.mlp > utils/config.ml
 

--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -799,9 +799,13 @@ let rec close fenv cenv = function
         | Const_immstring s ->
             str (Uconst_string s)
         | Const_base (Const_string (s, _)) ->
-              (* strings (even literal ones) are mutable! *)
-              (* of course, the empty string is really immutable *)
-            str ~shared:false(*(String.length s = 0)*) (Uconst_string s)
+              (* Strings (even literal ones) must be assumed to be mutable...
+                 except when OCaml has been
+                 configured with -safe-string.  Passing -safe-string at compilation time
+                 is not enough, since the unit could be linked with another one
+                 compiled without -safe-string, and that one could modify our
+                 string literal.  *)
+            str ~shared:Config.safe_string (Uconst_string s)
         | Const_base(Const_float x) -> str (Uconst_float (float_of_string x))
         | Const_base(Const_int32 x) -> str (Uconst_int32 x)
         | Const_base(Const_int64 x) -> str (Uconst_int64 x)

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -86,6 +86,7 @@ ASM_CFI_SUPPORTED=false
 UNIXLIB=win32unix
 GRAPHLIB=win32graph
 FLAMBDA=false
+SAFE_STRING=false
 
 ########## Configuration for the bytecode compiler
 

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -86,6 +86,7 @@ ASM_CFI_SUPPORTED=false
 UNIXLIB=win32unix
 GRAPHLIB=win32graph
 FLAMBDA=false
+SAFE_STRING=false
 
 ########## Configuration for the bytecode compiler
 

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -80,6 +80,7 @@ ASM_CFI_SUPPORTED=false
 UNIXLIB=win32unix
 GRAPHLIB=win32graph
 FLAMBDA=false
+SAFE_STRING=false
 
 ########## Configuration for the bytecode compiler
 

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -79,6 +79,7 @@ ASM_CFI_SUPPORTED=false
 UNIXLIB=win32unix
 GRAPHLIB=win32graph
 FLAMBDA=false
+SAFE_STRING=false
 
 ########## Configuration for the bytecode compiler
 

--- a/configure
+++ b/configure
@@ -53,6 +53,7 @@ native_compiler=true
 TOOLPREF=""
 with_cfi=true
 flambda=false
+safe_string=false
 max_testsuite_dir_retries=0
 with_cplugins=true
 with_fpic=false
@@ -173,6 +174,8 @@ while : ; do
         with_cplugins=false;;
     -fPIC|--fPIC)
         with_fpic=true;;
+    -safe-string|--safe-string)
+        safe_string=true;;
     *) if echo "$1" | grep -q -e '^--\?[a-zA-Z0-9-]\+='; then
          err "configure expects arguments of the form '-prefix /foo/bar'," \
              "not '-prefix=/foo/bar' (note the '=')."
@@ -1851,6 +1854,7 @@ if [ "$ostype" = Cygwin ]; then
   echo "DIFF=diff -q --strip-trailing-cr" >>Makefile
 fi
 echo "FLAMBDA=$flambda" >> Makefile
+echo "SAFE_STRING=$safe_string" >> Makefile
 echo "MAX_TESTSUITE_DIR_RETRIES=$max_testsuite_dir_retries" >> Makefile
 
 
@@ -1934,6 +1938,11 @@ else
   inf "        using flambda middle-end . yes"
   else
   inf "        using flambda middle-end . no"
+  fi
+  if test "$safe_string" = "true"; then
+  inf "        safe strings ............. yes"
+  else
+  inf "        safe strings ............. no"
   fi
 fi
 

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -423,7 +423,9 @@ let mk_S f =
 ;;
 
 let mk_safe_string f =
-  "-safe-string", Arg.Unit f, " Make strings immutable"
+  "-safe-string", Arg.Unit f,
+  if Config.safe_string then " Make strings immutable (default)"
+  else " Make strings immutable"
 ;;
 
 let mk_shared f =
@@ -476,7 +478,14 @@ let mk_unsafe f =
 ;;
 
 let mk_unsafe_string f =
-  "-unsafe-string", Arg.Unit f, " Make strings mutable (default)"
+  if Config.safe_string then
+    let err () =
+      raise (Arg.Bad "OCaml has been configured with -safe-string: \
+                      -unsafe-string is not available")
+    in
+    "-unsafe-string", Arg.Unit err, " (option not available)"
+  else
+    "-unsafe-string", Arg.Unit f, " Make strings mutable (default)"
 ;;
 
 let mk_use_runtime f =

--- a/middle_end/closure_conversion.ml
+++ b/middle_end/closure_conversion.ml
@@ -126,7 +126,9 @@ let rec close_const t env (const : Lambda.structured_constant)
   match const with
   | Const_base (Const_int c) -> Const (Int c), "int"
   | Const_base (Const_char c) -> Const (Char c), "char"
-  | Const_base (Const_string (s, _)) -> Allocated_const (String s), "string"
+  | Const_base (Const_string (s, _)) ->
+    if Config.safe_string then Allocated_const (Immutable_string s), "immstring"
+    else Allocated_const (String s), "string"
   | Const_base (Const_float c) ->
     Allocated_const (Float (float_of_string c)), "float"
   | Const_base (Const_int32 c) -> Allocated_const (Int32 c), "int32"

--- a/typing/cmi_format.ml
+++ b/typing/cmi_format.ml
@@ -17,6 +17,7 @@ type pers_flags =
   | Rectypes
   | Deprecated of string
   | Opaque
+  | Unsafe_string
 
 type error =
     Not_an_interface of string

--- a/typing/cmi_format.mli
+++ b/typing/cmi_format.mli
@@ -17,6 +17,7 @@ type pers_flags =
   | Rectypes
   | Deprecated of string
   | Opaque
+  | Unsafe_string
 
 type cmi_infos = {
     cmi_name : string;

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -229,6 +229,7 @@ type error =
   | Illegal_renaming of string * string * string
   | Inconsistent_import of string * string * string
   | Need_recursive_types of string * string
+  | Depend_on_unsafe_string_unit of string * string
   | Missing_module of Location.t * Path.t * Path.t
   | Illegal_value_name of Location.t * string
 

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -153,7 +153,7 @@ let runtime_variant = ref "";;      (* -runtime-variant *)
 
 let keep_docs = ref false              (* -keep-docs *)
 let keep_locs = ref false              (* -keep-locs *)
-let unsafe_string = ref true;;         (* -safe-string / -unsafe-string *)
+let unsafe_string = ref (not Config.safe_string)    (* -safe-string / -unsafe-string *)
 
 let classic_inlining = ref false       (* -Oclassic *)
 let inlining_report = ref false    (* -inlining-report *)

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -138,3 +138,6 @@ val print_config : out_channel -> unit;;
 
 val flambda : bool
         (* Whether the compiler was configured for flambda *)
+
+val safe_string: bool
+        (* Whether the compiler was configured with -safe-string *)

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -68,6 +68,7 @@ let mkdll, mkexe, mkmaindll =
     "%%MKDLL%%", "%%MKEXE%%", "%%MKMAINDLL%%"
 
 let flambda = %%FLAMBDA%%
+let safe_string = %%SAFE_STRING%%
 
 let exec_magic_number = "Caml1999X011"
 and cmi_magic_number = "Caml1999I020"


### PR DESCRIPTION
This PR adds a `-safe-string` flag to `./configure`.  When the system is compiled in this mode, the compile-time option `-safe-string` is implied, and `-unsafe-string` is ignored (printing a warning on stderr).  This is to serve two goals:
- Facilitate the detection of packages that are not ready for `-safe-string` (e.g. through an OPAM switch).
- Start supporting optimizations that depend on immutable strings, and which can be broken by any linked unit that has not been compiled with `-safe-string`.  In particular, this PR enables sharing of string literals in a given compilation unit.

Hopefully, this will give extra incentive to the community to move to `-safe-string`.

In addition to the configure flag, this PR also records in `.cmi` file the safe/unsafe_string status.  Currently, this is only used to fail when opening a `.cmi` file compiled in unsafe-string mode in a compiled _configured_ in safe-string mode.  This is not bullet proof as explained in the corresponding commit message.  (We don't even check that the implementation is compiled in -safe-string when its interface is; we should probably do that.)  A simple stronger alternative would be to use different magic numbers (as for flambda .cmx files), but the proliferation of different magic number for each version of OCaml become tedious (magic number are not really suited to encode orthogonal flags).  One could also have a flag stored in .cmi and "inherited" automatically.  But anyway, this is rather minor and only to protect people from their own mistake (forgetting to recompile a library already compiled in unsafe-string mode when switching to a compiler configured with safe-string ).

(This is related to http://caml.inria.fr/mantis/view.php?id=7113.)
