### PR TITLE
Manual: build fix

### DIFF
--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -754,8 +754,8 @@ an array of floating-point numbers.)
 \item
 "caml_copy_string_array("\var{p}")" allocates an array of strings or byte
 sequences, copied from the pointer to a string array \var{p}
-(a \verb"char **").  \var{p} must be NULL-terminated.
-\item "caml_alloc_float_array ("\var{n}"")" allocates an array of floating point
+(a "char **").  \var{p} must be NULL-terminated.
+\item "caml_alloc_float_array("\var{n}")" allocates an array of floating point
   numbers of size \var{n}. The array initially contains uninitialized values.
 \end{itemize}
 

--- a/ocamldoc/odoc_to_text.ml
+++ b/ocamldoc/odoc_to_text.ml
@@ -228,7 +228,8 @@ class virtual to_text =
 
     method normal_cstr_args ?par m_name = function
       | Cstr_tuple l -> self#normal_type_list ?par m_name " * " l
-      | Cstr_record _ -> "{...}" (* TODO *)
+      | Cstr_record r -> self#relative_idents m_name
+                            (Odoc_str.string_of_record r)
 
     (** Get a string for a list of class or class type type parameters
        where all idents are relative. *)
@@ -335,22 +336,20 @@ class virtual to_text =
       Format.fprintf Format.str_formatter "@[<hov 2>exception %s" s_name ;
       (match e.ex_args, e.ex_ret with
          Cstr_tuple [], None -> ()
-       | Cstr_tuple l, None ->
-           Format.fprintf Format.str_formatter " %s@ %s"
-             "of"
-             (self#normal_type_list ~par: false father " * " l)
        | Cstr_tuple [], Some r ->
            Format.fprintf Format.str_formatter " %s@ %s"
              ":"
              (self#normal_type father r)
-       | Cstr_tuple l, Some r ->
+       | args, None ->
+           Format.fprintf Format.str_formatter " %s@ %s"
+             "of"
+             (self#normal_cstr_args ~par:false father args)
+       | args, Some r ->
            Format.fprintf Format.str_formatter " %s@ %s@ %s@ %s"
              ":"
-             (self#normal_type_list ~par: false father " * " l)
+             (self#normal_cstr_args ~par:false father args)
              "->"
              (self#normal_type father r)
-       | Cstr_record _, _ ->
-           assert false
       );
       (match e.ex_alias with
          None -> ()

--- a/testsuite/tests/tool-ocamldoc-2/inline_records.mli
+++ b/testsuite/tests/tool-ocamldoc-2/inline_records.mli
@@ -1,0 +1,14 @@
+(**
+  This test focuses on the printing of documentation for inline record
+  within the latex generator.
+*)    
+
+
+(** A simple record type for reference *)
+type r = {lbl: int (** Field documentation *);
+          more:int list (** More documentation *) }
+
+
+(** A sum type with an inline record *)
+type t = C of {lbl: int (** Field documentation *); 
+               more:int list (** More documentation *) }

--- a/testsuite/tests/tool-ocamldoc-2/inline_records.reference
+++ b/testsuite/tests/tool-ocamldoc-2/inline_records.reference
@@ -1,0 +1,66 @@
+\documentclass[11pt]{article} 
+\usepackage[latin1]{inputenc} 
+\usepackage[T1]{fontenc} 
+\usepackage{textcomp}
+\usepackage{fullpage} 
+\usepackage{url} 
+\usepackage{ocamldoc}
+\begin{document}
+\tableofcontents
+\section{Module {\tt{Inline\_records}} : This test focuses on the printing of documentation for inline record
+  within the latex generator.}
+\label{Inline-underscorerecords}\index{Inline-underscorerecords@\verb`Inline_records`}
+
+
+
+
+\ocamldocvspace{0.5cm}
+
+
+
+\label{TYPInline-underscorerecords.r}\begin{ocamldoccode}
+type r = {\char123}
+  lbl : int ;
+\end{ocamldoccode}
+\begin{ocamldoccomment}
+Field documentation
+
+
+\end{ocamldoccomment}
+\begin{ocamldoccode}
+  more : int list ;
+\end{ocamldoccode}
+\begin{ocamldoccomment}
+More documentation
+
+
+\end{ocamldoccomment}
+\begin{ocamldoccode}
+{\char125}
+\end{ocamldoccode}
+\index{r@\verb`r`}
+\begin{ocamldocdescription}
+A simple record type for reference
+
+
+\end{ocamldocdescription}
+
+
+
+
+\label{TYPInline-underscorerecords.t}\begin{ocamldoccode}
+type t =
+  | C of {\char123}
+   lbl : int;
+   more : int list;
+{\char125}
+\end{ocamldoccode}
+\index{t@\verb`t`}
+\begin{ocamldocdescription}
+A sum type with an inline record
+
+
+\end{ocamldocdescription}
+
+
+\end{document}

--- a/testsuite/tests/tool-ocamldoc/t04.ml
+++ b/testsuite/tests/tool-ocamldoc/t04.ml
@@ -1,0 +1,24 @@
+(** Testing display of inline record.
+
+   @test_types_display
+ *)
+
+
+module A = struct
+  type a = A of {lbl:int}
+
+end
+
+module type E = sig
+  exception E of {lbl:int}
+
+end
+
+(* Note: inline record within structure are currently broken
+
+module E_bis= struct
+  exception E of {lbl:int}
+
+end
+
+*)

--- a/testsuite/tests/tool-ocamldoc/t04.reference
+++ b/testsuite/tests/tool-ocamldoc/t04.reference
@@ -1,0 +1,21 @@
+#
+# module T04:
+# Odoc_info.string_of_module_type:
+<[sig  end]>
+# Odoc_info.string_of_module_type ~complete: true :
+<[sig  end]>
+#
+# module T04.A:
+# Odoc_info.string_of_module_type:
+<[sig  end]>
+# Odoc_info.string_of_module_type ~complete: true :
+<[sig type a = A of { lbl : int; } end]>
+# type T04.A.a:
+# manifest (Odoc_info.string_of_type_expr):
+<[None]>
+#
+# module type T04.E:
+# Odoc_info.string_of_module_type:
+<[sig  end]>
+# Odoc_info.string_of_module_type ~complete: true :
+<[sig exception E of { lbl : int; } end]>


### PR DESCRIPTION
This PR makes the manual build again:
- The first commit fixes a problem with an odd number of `"` inside `cmds/intf-c.etex`
- The second commit fixes an assertion failure within ocamldoc. However, I am worried that I have
  no idea why this assertion failure was triggered in the first place.
