### PR TITLE
configure: optimistically enable native dynlink on recent 32bit darwin hosts

### DIFF
--- a/Changes
+++ b/Changes
@@ -155,6 +155,12 @@ OCaml 4.04.0:
 - GPR#507: More sharing between Unix and Windows makefiles
   (whitequark, review by Alain Frisch)
 
+- GPR#692: optimistically enable native dynlink on recent 32bit darwin hosts
+  (natdynlink is known to not work on darwin{10,11} (OSX 10.6, 10.7),
+   and seems to work on darwin15 (OSX 10.11); please open an issue if
+   you notice that it is broken on darwin{12,13,14})
+  (Gabriel Scherer, report by Maciej Woś)
+
 
 ### Bug fixes:
 

--- a/configure
+++ b/configure
@@ -770,10 +770,16 @@ if test $with_sharedlibs = "yes"; then
     i[3456]86-*-gnu*)             natdynlink=true;;
     x86_64-*-linux*)              natdynlink=true;;
     i[3456]86-*-darwin[89].*)     natdynlink=true;;
-    i[3456]86-*-darwin*)
+    i[3456]86-*-darwin1[01].*)
+      # the 32bit toolchains of darwin{10,11} (OSX 10.6 and 10.7)
+      # are known to break native dynlink
       if test $arch64 == true; then
         natdynlink=true
       fi;;
+    i[3456]86-*-darwin*)
+      # for darwin versions above darwin12 we optimistically enable
+      # native dynlink even on 32bit setups
+      natdynlink=true;;
     x86_64-*-darwin*)             natdynlink=true;;
     s390x*-*-linux*)              natdynlink=true;;
     powerpc*-*-linux*)            natdynlink=true;;


### PR DESCRIPTION
See ocaml/camlp4#108: native dynlink seems to work correctly on recent
OSX machines (Darwin15, OSX 10.11), even on 32 bit setups. 32bit
setups were broken by OSX toolchain changes on darwin{10,11} (10.6,
10.7) so all 32bit darwin versions above darwin9 were pessimistically
disabled.

(Apparently the user demand for 32bit darwin host support is that
core_kernel assumes 32bit machines, at least when used in combination
with js_of_ocaml).
