### PR TITLE
Manual tools: fail on unexpected errors or warnings within caml_example

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -44,6 +44,7 @@ EOF
     # we need to redo (small parts of) world.opt afterwards
     make check_all_arches
     make world.opt
+    make manual-pregen
     mkdir external-packages
     cd external-packages
     git clone git://github.com/ocaml/ocamlbuild

--- a/Changes
+++ b/Changes
@@ -39,6 +39,12 @@ Next version (tbd):
   (Laurent Mazare,
    review by Gabriel Scherer, Alain Frisch and Hezekiah M. Carty)
 
+### Manual and documentation:
+- GPR#693: fail on unexpected errors or warnings within caml_example
+  environment.
+  (Florian Angeletti)
+
+
 OCaml 4.04.0:
 -------------
 

--- a/Makefile
+++ b/Makefile
@@ -305,11 +305,10 @@ installoptopt:
 tests: opt.opt
 	cd testsuite; $(MAKE) clean && $(MAKE) all
 
-# Build both the manual latex files from the etex source files
-# and the stdlib ocamldoc documentation.
+# Build the manual latex files from the etex source files
 # (see manual/README.md)
 manual-pregen: opt.opt
-	cd manual; ${MAKE} clean && ${MAKE} pregen
+	cd manual; $(MAKE) clean && $(MAKE) pregen-etex
 
 # The clean target
 

--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,12 @@ installoptopt:
 tests: opt.opt
 	cd testsuite; $(MAKE) clean && $(MAKE) all
 
+# Build both the manual latex files from the etex source files
+# and the stdlib ocamldoc documentation.
+# (see manual/README.md)
+manual-pregen: opt.opt
+	cd manual; ${MAKE} clean && ${MAKE} pregen
+
 # The clean target
 
 clean:: partialclean

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -14,3 +14,9 @@ release:
 .PHONY: tools
 tools:
 	cd tools; ${MAKE} clean; ${MAKE} all
+
+# The pregen target generates the latex files from the .etex files
+# and the ocamldoc documentation for the standard library to ensure
+# that at least this phase of the manual build process is correct
+pregen: tools
+	cd manual; ${MAKE} files

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -15,8 +15,12 @@ release:
 tools:
 	cd tools; ${MAKE} clean; ${MAKE} all
 
-# The pregen target generates the latex files from the .etex files
-# and the ocamldoc documentation for the standard library to ensure
-# that at least this phase of the manual build process is correct
+# The pregen-etex target generates the latex files from the .etex
+# files to ensure that this phase of the manual build process, which
+# may execute OCaml fragments and expect certain outputs, is correct
+pregen-etex: tools
+	cd manual; $(MAKE) etex-files
+
+# pregen builds both .etex files and the documentation of the standard library
 pregen: tools
-	cd manual; ${MAKE} files
+	cd manual; $(MAKE) files

--- a/manual/README.md
+++ b/manual/README.md
@@ -81,9 +81,9 @@ chapters (or sometimes sections) are mapped to a distinct `.etex` file:
     - The runtime system (ocamlrun): `runtime.etex`
     - Native-code compilation (ocamlopt): `native.etex`
     - Lexer and parser generators (ocamllex, ocamlyacc): `lexyacc.etex`
-    - Dependency generator (ocamldep): `ocamldoc.etex`
+    - Dependency generator (ocamldep): `ocamldep.etex`
     - The browser/editor (ocamlbrowser): `browser.etex`
-    - The documentation generator (ocamldoc): `ocamdoc.etex`
+    - The documentation generator (ocamldoc): `ocamldoc.etex`
     - The debugger (ocamldebug): `debugger.etex`
     - Profiling (ocamlprof): `profil.etex`
     - The ocamlbuild compilation manager: `ocamlbuild.etex`
@@ -118,15 +118,39 @@ interpreter and then translates both the input code and the interpreter output
 to latex code, e.g.
 ```latex
 \begin{caml_example}
-let f x = x
+let f x = x;;
 \end{caml_example}
 ```
 Note that the toplevel output can be suppressed by using a `*` suffix:
 ```latex
 \begin{caml_example*}
-let f x = x
+let f x = x;;
 \end{caml_example*}
 ```
+By default, `caml_tex2` raises an error and stops if the output of one
+the `caml_example` environment contains an unexpected error or warning.
+If such an error or warning is, in fact, expected, it is necessary to
+indicate the expected output status to `caml_tex2` by adding either
+an option to the `caml_example` environment:
+```latex
+\begin{caml_example}[error]
+1 + 2. ;;
+\end{caml_example}
+ or for warning
+\begin{caml_example}[warning=8]
+let f None = None;;
+\end{caml_example}
+```
+or an annotation to the concerned phrase:
+
+```latex
+\begin{caml_example}
+1 + 2. [@@expect error] ;;
+let f None = None [@@expect warning 8];;
+3 + 4 [@@expect ok];;
+\end{caml_example}
+```
+
 The `caml_eval` environment is a companion environment to `caml_example`
 and can be used to evaluate OCaml expressions in the toplevel without
 printing anything:
@@ -148,8 +172,8 @@ environments, `texquote2` translates double quotes `"text"` to
 `\machine{escaped_text}`.
 
 ###BNF grammar notation
-The tool `tools/transf` provides support for BNF grammar notations and a special
-quotation for non-terminal. When transf is used, the environment `syntax` can
+The tool `tools/transf` provides support for BNF grammar notations and special
+quotes for non-terminal. When transf is used, the environment `syntax` can
 be used to describe grammars using BNF notation:
 ```latex
 \begin{syntax}

--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -92,6 +92,12 @@ text: files
 	         -I ../tutorials -I ../../styles -I ../texstuff \
 	         ../manual.inf -e macros.tex ../manual.tex
 
+etex-files: $(FILES)
+	cd refman; $(MAKE) etex-files RELEASEDIR=$(SRC)
+	cd library; $(MAKE) etex-files RELEASEDIR=$(SRC)
+	cd cmds; $(MAKE) etex-files RELEASEDIR=$(SRC)
+	cd tutorials; $(MAKE) etex-files RELEASEDIR=$(SRC)
+
 files: $(FILES)
 	cd refman; $(MAKE) all RELEASEDIR=$(SRC)
 	cd library; $(MAKE) all RELEASEDIR=$(SRC)

--- a/manual/manual/cmds/Makefile
+++ b/manual/manual/cmds/Makefile
@@ -9,7 +9,10 @@ TRANSF=$(OCAMLRUN) ../../tools/transf
 TEXQUOTE=../../tools/texquote2
 FORMAT=../../tools/format-intf
 
+WITH_TRANSF= ocamldoc.tex top.tex intf-c.tex flambda.tex lexyacc.tex debugger.tex
+
 etex-files: $(FILES)
+
 all: $(FILES)
 
 clean::
@@ -24,23 +27,12 @@ clean::
 	&& mv $*.texquote_error.tex $*.tex\
 	|| printf "Failure when generating %s\n" $*.tex
 
-ocamldoc.tex: ocamldoc.etex $(TRANSF)
-	$(TRANSF) < ocamldoc.etex | $(TEXQUOTE) > ocamldoc.tex
-
-top.tex: top.etex $(TRANSF)
-	$(TRANSF) < top.etex | $(TEXQUOTE) > top.tex
-
-intf-c.tex: intf-c.etex $(TRANSF)
-	$(TRANSF) < intf-c.etex | $(TEXQUOTE) > intf-c.tex
-
-flambda.tex: flambda.etex $(TRANSF)
-	$(TRANSF) < flambda.etex | $(TEXQUOTE) > flambda.tex
-
-lexyacc.tex: lexyacc.etex $(TRANSF)
-	$(TRANSF) < lexyacc.etex | $(TEXQUOTE) > lexyacc.tex
-
-debugger.tex: debugger.etex $(TRANSF)
-	$(TRANSF) < debugger.etex | $(TEXQUOTE) > debugger.tex
+$(WITH_TRANSF):%.tex:%.etex
+	@$(TRANSF) < $*.etex > $*.transf_error.tex \
+	&& mv $*.transf_error.tex $*.transf_gen.tex \
+	&& $(TEXQUOTE) < $*.transf_gen.tex > $*.texquote_error.tex \
+	&& mv $*.texquote_error.tex $*.tex \
+	|| printf "Failure when generating %s\n" $*.tex
 
 warnings-help.etex: ../warnings-help.etex
 	cp ../warnings-help.etex .

--- a/manual/manual/cmds/Makefile
+++ b/manual/manual/cmds/Makefile
@@ -19,7 +19,9 @@ clean::
 .SUFFIXES: .tex .etex
 
 .etex.tex:
-	$(TEXQUOTE) < $*.etex > $*.tex
+	@$(TEXQUOTE) < $*.etex > $*.texquote_error.tex\
+	&& mv $*.texquote_error.tex $*.tex\
+	|| printf "Failure when generating %s\n" $*.tex
 
 ocamldoc.tex: ocamldoc.etex $(TRANSF)
 	$(TRANSF) < ocamldoc.etex | $(TEXQUOTE) > ocamldoc.tex

--- a/manual/manual/cmds/Makefile
+++ b/manual/manual/cmds/Makefile
@@ -9,6 +9,7 @@ TRANSF=$(OCAMLRUN) ../../tools/transf
 TEXQUOTE=../../tools/texquote2
 FORMAT=../../tools/format-intf
 
+etex-files: $(FILES)
 all: $(FILES)
 
 clean::

--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -98,7 +98,10 @@ clean:
 .SUFFIXES: .tex .etex .mli
 
 .etex.tex: $(TEXQUOTE)
-	$(TEXQUOTE) < $*.etex > $*.tex
+	@$(TEXQUOTE) < $*.etex > $*.texquote_error.tex\
+	&& cp $*.texquote_error.tex $*.tex\
+	|| printf "Failure when generating %s\n" $*.tex
+
 
 .mli.tex: $(FORMAT)
 	$(FORMAT) $< > $*.tex < $<

--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -49,6 +49,7 @@ CSLDIR=$(RELEASEDIR)
 
 VPATH=.:$(CSLDIR)/stdlib:$(CSLDIR)/parsing:$(CSLDIR)/otherlibs/unix:$(CSLDIR)/otherlibs/str:$(CSLDIR)/otherlibs/num:$(CSLDIR)/otherlibs/graph:$(CSLDIR)/otherlibs/threads:$(CSLDIR)/otherlibs/dynlink:$(CSLDIR)/otherlibs/bigarray
 
+etex-files: $(BLURB)
 all: libs
 	./check-stdlib-modules $(CSLDIR)
 

--- a/manual/manual/refman/Makefile
+++ b/manual/manual/refman/Makefile
@@ -11,6 +11,7 @@ TEXQUOTE=../../tools/texquote2
 
 ALLFILES=$(FILES)
 
+etex-files: $(ALLFILES)
 all: $(ALLFILES)
 
 clean:

--- a/manual/manual/refman/Makefile
+++ b/manual/manual/refman/Makefile
@@ -20,6 +20,11 @@ clean:
 .SUFFIXES: .etex .tex
 
 .etex.tex:
-	$(OCAMLRUN) $(TRANSF) < $*.etex | $(TEXQUOTE) > $*.tex
+	@$(OCAMLRUN) $(TRANSF) < $*.etex > $*.transf_error.tex \
+	&& mv $*.transf_error.tex $*.gen.tex\
+	&& $(TEXQUOTE) < $*.gen.tex  > $*.texquote_error.tex\
+	&& mv $*.texquote_error.tex $*.tex\
+	|| printf "Failure when generating %s\n" $*.tex
+
 
 $(ALLFILES): $(TRANSF) $(TEXQUOTE)

--- a/manual/manual/tutorials/Makefile
+++ b/manual/manual/tutorials/Makefile
@@ -8,6 +8,7 @@ TEXQUOTE=../../tools/texquote2
 
 ALLFILES=$(FILES)
 
+etex-files: $(ALLFILES)
 all: $(ALLFILES)
 
 clean:

--- a/manual/manual/tutorials/Makefile
+++ b/manual/manual/tutorials/Makefile
@@ -17,6 +17,11 @@ clean:
 .SUFFIXES: .etex .tex
 
 .etex.tex:
-	$(CAMLLATEX) -caml "TERM=norepeat $(OCAML)" -n 80 -o - $*.etex | $(TEXQUOTE) > $*.tex
+	@$(CAMLLATEX) -caml "TERM=norepeat $(OCAML)" -n 80 \
+                       -o $*.caml_tex_error.tex $*.etex\
+	&& mv $*.caml_tex_error.tex $*.gen.tex\
+	&& $(TEXQUOTE) < $*.gen.tex > $*.texquote_error.tex\
+	&& mv $*.texquote_error.tex $*.tex\
+	|| printf "Failure when generating %s\n" $*.tex
 
 $(ALLFILES): $(CAMLLATEX) $(TEXQUOTE)

--- a/manual/manual/tutorials/Makefile
+++ b/manual/manual/tutorials/Makefile
@@ -18,7 +18,7 @@ clean:
 .SUFFIXES: .etex .tex
 
 .etex.tex:
-	@$(CAMLLATEX) -caml "TERM=norepeat $(OCAML)" -n 80 \
+	@$(CAMLLATEX) -caml "TERM=norepeat $(OCAML)" -n 80 -v false\
                        -o $*.caml_tex_error.tex $*.etex\
 	&& mv $*.caml_tex_error.tex $*.gen.tex\
 	&& $(TEXQUOTE) < $*.gen.tex > $*.texquote_error.tex\

--- a/manual/manual/tutorials/advexamples.etex
+++ b/manual/manual/tutorials/advexamples.etex
@@ -187,7 +187,10 @@ module Account (M:MONEY) =
     class virtual check_client x =
       let y = if (m 100.)#leq x then x
       else raise (Failure "Insufficient initial deposit") in
-      object (self) initializer self#deposit y end
+      object (self)
+        initializer self#deposit y
+        method virtual deposit: m -> unit
+      end
 
     module Client (B : sig class bank : client_view end) =
       struct

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -39,7 +39,7 @@ the system infers their types from their usage in the
 function. Notice also that integers and floating-point numbers are
 distinct types, with distinct operators: "+" and "*" operate on
 integers, but "+." and "*."  operate on floats.
-\begin{caml_example}
+\begin{caml_example}[error]
 1.0 * 2;;
 \end{caml_example}
 

--- a/manual/manual/tutorials/lablexamples.etex
+++ b/manual/manual/tutorials/lablexamples.etex
@@ -82,7 +82,7 @@ ListLabels.map succ [1;2;3];;
 \end{caml_example}
 But beware that functions like "ListLabels.fold_left" whose result
 type is a type variable will never be considered as totally applied.
-\begin{caml_example}
+\begin{caml_example}[error]
 ListLabels.fold_left ( + ) 0 [1;2;3];;
 \end{caml_example}
 
@@ -92,7 +92,7 @@ are allowed.
 \begin{caml_example}
 let h g = g ~x:3 ~y:2;;
 h f;;
-h ( + );;
+h ( + ) [@@expect error];;
 \end{caml_example}
 Note that when you don't need an argument, you can still use a wildcard
 pattern, but you must prefix it with the label.
@@ -135,7 +135,7 @@ independently.
 \begin{caml_example}
 test ~y:2 ~x:3 () ();;
 test () () ~z:1 ~y:2 ~x:3;;
-(test () ()) ~z:1;;
+(test () ()) ~z:1 [@@expect error];;
 \end{caml_example}
 Here "(test () ())" is already "(0,0,0)" and cannot be further
 applied.
@@ -173,10 +173,10 @@ cannot be inferred as completely as the rest of the language.
 You can see it in the following two examples.
 \begin{caml_example}
 let h' g = g ~y:2 ~x:3;;
-h' f;;
+h' f [@@expect error];;
 let bump_it bump x =
   bump ~step:2 x;;
-bump_it bump 1;;
+bump_it bump 1 [@@expect error];;
 \end{caml_example}
 The first case is simple: "g"  is passed "~y" and then "~x", but "f"
 expects "~x" and then "~y". This is correctly handled if we know the
@@ -484,7 +484,7 @@ let f = function
 let f : abc -> string = f ;;
 \end{caml_example}
 You can avoid such risks by annotating the definition itself.
-\begin{caml_example}
+\begin{caml_example}[error]
 let f : abc -> string = function
   | `As -> "A"
   | #abc -> "other" ;;

--- a/manual/manual/tutorials/moduleexamples.etex
+++ b/manual/manual/tutorials/moduleexamples.etex
@@ -81,7 +81,7 @@ function is not accessible and the actual representation of priority
 queues is hidden:
 \begin{caml_example}
 module AbstractPrioQueue = (PrioQueue : PRIOQUEUE);;
-AbstractPrioQueue.remove_top;;
+AbstractPrioQueue.remove_top [@@expect error];;
 AbstractPrioQueue.insert AbstractPrioQueue.empty 1 "hello";;
 \end{caml_example}
 The restriction can also be performed during the definition of the
@@ -191,7 +191,7 @@ module type SET =
   end;;
 module WrongSet = (Set : functor(Elt: ORDERED_TYPE) -> SET);;
 module WrongStringSet = WrongSet(OrderedString);;
-WrongStringSet.add "gee" WrongStringSet.empty;;
+WrongStringSet.add "gee" WrongStringSet.empty [@@expect error];;
 \end{caml_example}
 The problem here is that "SET" specifies the type "element"
 abstractly, so that the type equality between "element" in the result
@@ -230,7 +230,7 @@ module NoCaseString =
       OrderedString.compare (String.lowercase_ascii s1) (String.lowercase_ascii s2)
   end;;
 module NoCaseStringSet = AbstractSet(NoCaseString);;
-NoCaseStringSet.add "FOO" AbstractStringSet.empty;;
+NoCaseStringSet.add "FOO" AbstractStringSet.empty [@@expect error];;
 \end{caml_example}
 Note that the two types "AbstractStringSet.set" and
 "NoCaseStringSet.set" are not compatible, and values of these

--- a/manual/manual/tutorials/objectexamples.etex
+++ b/manual/manual/tutorials/objectexamples.etex
@@ -246,7 +246,7 @@ class my_int =
   object (self)
     method n = 1
     method register = ints := self :: !ints
-  end;;
+  end [@@expect error];;
 \end{caml_example}
 You can ignore the first two lines of the error message. What matters
 is the last one: putting self into an external reference would make it
@@ -347,7 +347,7 @@ class restricted_point x_init =
     method bump = self#move 1
   end;;
 let p = new restricted_point 0;;
-p#move 10;;
+p#move 10 [@@expect error] ;;
 p#bump;;
 \end{caml_example}
 Note that this is not the same thing as private and protected methods
@@ -514,7 +514,7 @@ in the order they are introduced.
 
 Reference cells can be implemented as objects.
 The naive definition fails to typecheck:
-\begin{caml_example}
+\begin{caml_example}[error]
 class oref x_init =
   object
     val mutable x = x_init
@@ -637,7 +637,7 @@ does not work in practice.
 let l = new intlist [1; 2; 3];;
 l#fold (fun x y -> x+y) 0;;
 l;;
-l#fold (fun s x -> s ^ string_of_int x ^ " ") "";;
+l#fold (fun s x -> s ^ string_of_int x ^ " ") "" [@@expect error];;
 \end{caml_example}
 Our iterator works, as shows its first use for summation. However,
 since objects themselves are not polymorphic (only their constructors
@@ -700,7 +700,7 @@ type is known at the call site.  Otherwise, the method will be assumed
 to be monomorphic, and given an incompatible type.
 \begin{caml_example}
 let sum lst = lst#fold (fun x y -> x+y) 0;;
-sum l;;
+sum l [@@expect error];;
 \end{caml_example}
 The workaround is easy: you should put a type constraint on the
 parameter.
@@ -765,7 +765,7 @@ let l = [p; (colored_point_to_point q)];;
 An object of type "t" can be seen as an object of type "t'"
 only if "t" is a subtype of "t'". For instance, a point cannot be
 seen as a colored point.
-\begin{caml_example}
+\begin{caml_example}[error]
 (p : point :> colored_point);;
 \end{caml_example}
 Indeed, narrowing coercions without runtime checks would be unsafe.
@@ -873,7 +873,7 @@ Indeed, the type of self cannot be closed: this would prevent any
 further extension of the class. Therefore, a type error is generated
 when the unification of this type with another type would result in a
 closed object type.
-\begin{caml_example}
+\begin{caml_example}[error]
 class c = object method m = 1 end
 and d = object (self)
   inherit c

--- a/manual/tools/caml_tex2.ml
+++ b/manual/tools/caml_tex2.ml
@@ -113,7 +113,7 @@ module Output = struct
 
   let status s = match catch_warning s, catch_error s with
     | Some w, _ -> w
-    | _, Some e -> e
+    | None, Some e -> e
     | None, None -> Ok
 
   (** {2 Parsing caml_example options } *)
@@ -142,15 +142,15 @@ module Output = struct
   let expected s =
     match parse_warning s, parse_error s with
     | Some w, _ -> w
-    | _, Some e -> e
+    | None, Some e -> e
     | None, None -> raise (Parsing_error (Option,s))
 
   (** Parse the local (i.e. phrase-wide) expected status output *)
   let local_expected s =
     match parse_local_warning s, parse_error s, parse_ok s with
     | Some w, _, _ -> w
-    | _, Some e, _ -> e
-    | _, _, Some ok -> ok
+    | None, Some e, _ -> e
+    | None, None, Some ok -> ok
     | None, None, None -> raise (Parsing_error (Annotation,s))
 
 end

--- a/manual/tools/caml_tex2.ml
+++ b/manual/tools/caml_tex2.ml
@@ -45,7 +45,12 @@ module Output = struct
     | Warning of int
     | Error
 
-  type kind = Annotation | Option
+  type kind =
+    | Annotation (** Local annotation: [ [@@expect (*annotation*) ] ]*)
+    | Option (** Global environment option:
+                 [\begin{caml_example}[option[=value]]
+                 ...
+                 \end{caml_example}] *)
 
   (** Pretty printer for status *)
   let pp_status ppf = function

--- a/manual/tools/caml_tex2.ml
+++ b/manual/tools/caml_tex2.ml
@@ -34,6 +34,127 @@ let (~!) =
       memo := (key, data) :: !memo;
       data
 
+(** The Output module deals with the analysis and classification
+    of the interpreter output and the parsing of status-related options
+    or annotations for the caml_example environment *)
+module Output = struct
+
+  (** Interpreter output status *)
+  type status =
+    | Ok
+    | Warning of int
+    | Error
+
+  type kind = Annotation | Option
+
+  (** Pretty printer for status *)
+  let pp_status ppf = function
+    | Error -> Printf.fprintf ppf "error"
+    | Ok -> Printf.fprintf ppf "ok"
+    | Warning n -> Printf.fprintf ppf "warning %d" n
+
+  (** Pretty printer for status preceded with an undefined determinant *)
+  let pp_a_status ppf = function
+    | Error -> Printf.fprintf ppf "an error"
+    | Ok -> Printf.fprintf ppf "an ok"
+    | Warning n -> Printf.fprintf ppf "a warning %d" n
+
+  (** {2 Exceptions } *)
+  exception Parsing_error of kind * string
+  type unexpected_report = {source:string; expected:status; got:status}
+  exception Unexpected_status of unexpected_report
+
+  let print_unexpected {source; expected; got} =
+    if expected = Ok then
+      Printf.eprintf
+        "Error when evaluating a caml_example environment in %s:\n\
+         unexpected %a.\n\
+         If %a status was expected, add an [@@expect %a] annotation.\n"
+        source
+        pp_status got
+        pp_a_status got
+        pp_status got
+    else
+      Printf.eprintf
+        "Error when evaluating a guarded caml_example environment in %s:\n \
+         %a status was expected, got %a status.\n\
+         If %a states was in fact expected, change the status annotation to\
+         [@@expect %a].\n"
+        source
+        pp_a_status expected
+        pp_a_status got
+        pp_a_status got
+        pp_status got;
+    flush stderr
+
+  let print_parsing_error k s =
+    match k with
+    | Option ->
+        Printf.eprintf
+          "Unknown caml_example option: [%s].\n\
+           Supported options are \"ok\",\"error\", or \"warning=n\" (with n \
+           a warning number).\n" s
+    | Annotation ->
+        Printf.eprintf
+          "Unknown caml_example phrase annotation: [@@expect %s].\n\
+           Supported annotations are [@@expect ok], [@@expect error],\n\
+           and [@@expect warning n] (with n a warning number).\n" s
+
+
+  (** {2 Output analysis} *)
+  let catch_error s =
+    if string_match ~!{|Error:|} s 0 then Some Error else None
+
+  let catch_warning s =
+    if string_match ~!{|Warning \([0-9]+\):|} s 0 then
+      Some (Warning (int_of_string @@ matched_group 1 s))
+    else
+      None
+
+  let status s = match catch_warning s, catch_error s with
+    | Some w, _ -> w
+    | _, Some e -> e
+    | None, None -> Ok
+
+  (** {2 Parsing caml_example options } *)
+
+  (** Parse [warning=n] options for caml_example options *)
+  let parse_warning s =
+    if string_match ~!{|warning=\([0-9]+\)|} s 0 then
+      Some (Warning (int_of_string @@ matched_group 1 s))
+    else
+      None
+
+  (** Parse [warning n] annotations *)
+  let parse_local_warning s =
+    if string_match ~!{|warning \([0-9]+\)|} s 0 then
+      Some (Warning (int_of_string @@ matched_group 1 s))
+    else
+      None
+
+  let parse_error s =
+    if s="error" then Some Error else None
+
+  let parse_ok s =
+    if s = "ok" then Some Ok else None
+
+  (** Parse the environment-wide expected status output *)
+  let expected s =
+    match parse_warning s, parse_error s with
+    | Some w, _ -> w
+    | _, Some e -> e
+    | None, None -> raise (Parsing_error (Option,s))
+
+  (** Parse the local (i.e. phrase-wide) expected status output *)
+  let local_expected s =
+    match parse_local_warning s, parse_error s, parse_ok s with
+    | Some w, _, _ -> w
+    | _, Some e, _ -> e
+    | _, _, Some ok -> ok
+    | None, None, None -> raise (Parsing_error (Annotation,s))
+
+end
+
 let caml_input, caml_output =
   let cmd = !camllight ^ " 2>&1" in
   try Unix.open_process cmd with _ -> failwith "Cannot start toplevel"
@@ -83,34 +204,52 @@ let process_file file =
     with _ -> failwith "Cannot open output file" in
   try while true do
     let input = ref (input_line ic) in
-    if string_match ~!"\\\\begin{caml_example\\(\\*?\\)}[ \t]*$"
+    if string_match
+        ~!"\\\\begin{caml_example\\(\\*?\\)}[ \t]*\\(\\[\\(.*\\)\\]\\)?[ \t]*$"
         !input 0
     then begin
       let omit_answer = matched_group 1 !input = "*" in
+      let global_expected = try Output.expected @@ matched_group 3 !input
+            with Not_found -> Output.Ok
+      in
       output_string oc camlbegin;
       let first = ref true in
       let read_phrase () =
         let phrase = Buffer.create 256 in
-        while
-          let input = input_line ic in
+        let rec read () =
+          let input =  input_line ic in
           if string_match ~!"\\\\end{caml_example\\*?}[ \t]*$"
               input 0
           then raise End_of_file;
           if Buffer.length phrase > 0 then Buffer.add_char phrase '\n';
-          Buffer.add_string phrase input;
-          not (string_match ~!".*;;[ \t]*$" input 0)
-        do
-          ()
-        done;
-        Buffer.contents phrase
+          let stop = string_match ~!"\\(.*\\)[ \t]*;;[ \t]*$" input 0 in
+          if not stop then (
+            Buffer.add_string phrase input; read ()
+          )
+          else
+            let last_input = matched_group 1 input in
+            let expected =
+              if string_match ~!{|\(.*\)\[@@expect \(.*\)\]|} last_input 0 then
+                ( Buffer.add_string phrase (matched_group 1 last_input);
+                  Output.local_expected @@ matched_group 2 last_input )
+              else
+                (Buffer.add_string phrase last_input; global_expected)
+            in
+            Buffer.add_string phrase ";;\n";
+            Buffer.contents phrase, expected in
+        read ()
       in
       try while true do
-        let phrase = read_phrase () in
+        let phrase, expected = read_phrase () in
         fprintf caml_output "%s\n" phrase;
         flush caml_output;
         output_string caml_output "\"end_of_input\";;\n";
         flush caml_output;
         let output, (b, e) = read_output () in
+        let status = Output.status output in
+        if status <> expected then
+          raise (Output.Unexpected_status
+                   {Output.got=status; expected; source=file} );
         let phrase =
           if b < e then begin
             let start = String.sub phrase ~pos:0 ~len:b
@@ -154,7 +293,12 @@ let process_file file =
       flush oc
     end
   done with
-    End_of_file -> close_in ic; close_out oc
+  |  End_of_file -> close_in ic; close_out oc
+  | Output.Unexpected_status r ->
+          ( Output.print_unexpected r; close_in ic; close_out oc; exit 1 )
+  | Output.Parsing_error (k,s) ->
+      ( Output.print_parsing_error k s;
+        close_in ic; close_out oc; exit 1 )
 
 let _ =
   if !outfile <> "-" && !outfile <> "" then begin
@@ -162,4 +306,3 @@ let _ =
     with _ -> failwith "Cannot open output file"
   end;
   List.iter process_file (List.rev !files)
-


### PR DESCRIPTION
This pull request proposes to modify the manual tools `caml_tex2` to make it fails on unexpected errors or warnings within a `caml_example` environment. This change would make easier to notice new warnings or errors triggering on the code examples within the manual (like the few recent cases of deprecated warning or the quite hidden warning
in `advexamples.etex` corrected within this PR). Combined with the new use of in-tree,
this change would also make safer the potential use of the `caml_example` in the Langage extensions chapter. 

In more detail, the second commit of this pull request makes the following code

``` latex
\begin{caml_example}
1.0 * 2 ;;
\end{caml_example}
```

fail with

```
Error when evaluating a caml_example environment in filename.etex:
unexpected error.
If an error status was expected, add an [@@expect error] annotation.
```

As explained by the error message above, if the error or warning was intended, it
is necessary to annotate the example either with an attribute:

``` latex
\begin{caml_example}
1 + 2. [@@expect error] ;;
let f None = None [@@expect warning 8];;
3 + 4 (*optional ok attribute) [@@expect ok];; 
\end{caml_example}
```

or with a global latex environment option, e.g.

``` latex
\begin{caml_example}[error]
1 + 2.;;
3. + 4;;
\end{caml_example}
```

or for an intended warning

``` latex
\begin{caml_example}[warning=8]
let f None = ();;
\end{caml_example}
```

Both annotations can be combined if needed

``` latex
\begin{caml_example}[error]
1 + 2.;;
3. + 4;;
5 +6 [@@expect ok];;
\end{caml_example}
```

(The existing source files for the manual has been added the needed annotations.)

Moreover, to make this change useful, the first commit in this PR alters the build process of the manual to make the compilation of the manual fails in case of problems when generating the latex files from the ".etex" source files. Without this modifications, the manual build process had a tendency to "silently" generate empty tex files and then go on with the build process. This should no longer be the case. 
