### PR TITLE
Replace @ocaml.warnerror by @ocaml.warning in Str

### DIFF
--- a/otherlibs/str/str.ml
+++ b/otherlibs/str/str.ml
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* In this module, [@ocaml.warnerror "-3"] is used in several places
+(* In this module, [@ocaml.warning "-3"] is used in several places
    that use deprecated functions to preserve legacy behavior.
    It overrides -w @3 given on the command line. *)
 
@@ -96,7 +96,7 @@ module Charset =
     let fold_case s =
       (let r = make_empty() in
        iter (fun c -> add r (Char.lowercase c); add r (Char.uppercase c)) s;
-       r)[@ocaml.warnerror "-3"]
+       r)[@ocaml.warning "-3"]
 
   end
 
@@ -219,7 +219,7 @@ let charclass_of_regexp fold_case re =
 let fold_case_table =
   (let t = Bytes.create 256 in
    for i = 0 to 255 do Bytes.set t i (Char.lowercase(Char.chr i)) done;
-   Bytes.to_string t)[@ocaml.warnerror "-3"]
+   Bytes.to_string t)[@ocaml.warning "-3"]
 
 module StringMap =
   Map.Make(struct type t = string let compare (x:t) y = compare x y end)
@@ -276,7 +276,7 @@ let compile fold_case re =
     Char c ->
       if fold_case then
         emit_instr op_CHARNORM (Char.code (Char.lowercase c))
-          [@ocaml.warnerror "-3"]
+          [@ocaml.warning "-3"]
       else
         emit_instr op_CHAR (Char.code c)
   | String s ->
@@ -285,7 +285,7 @@ let compile fold_case re =
       | 1 ->
         if fold_case then
           emit_instr op_CHARNORM (Char.code (Char.lowercase s.[0]))
-            [@ocaml.warnerror "-3"]
+            [@ocaml.warning "-3"]
         else
           emit_instr op_CHAR (Char.code s.[0])
       | _ ->
@@ -299,7 +299,7 @@ let compile fold_case re =
         with Not_found ->
           if fold_case then
             emit_instr op_STRINGNORM (cpool_index (String.lowercase s))
-              [@ocaml.warnerror "-3"]
+              [@ocaml.warning "-3"]
           else
             emit_instr op_STRING (cpool_index s)
       end


### PR DESCRIPTION
This PR fixes the warnings in `Str` (use of `Char.lowercase`) by replacing the `@ocaml.warnerror` by an `@ocaml.warning` annotation. The reason for the use of `@ocaml.warnerror` in the first place instead of `@ocaml.warning` might have been discussed somewhere, but I probably missed that discussion. That's the problem with the current process, i.e. having long discussions on Github, but almost no comments in the code, the result is that we lose a lot of valuable information, unless we find a way to go from a commit number in `git blame` to the corresponding PR discussion on Github, probably archived somewhere else for perennity.
