### PR TITLE
Add natdynlink_hook, a hook called when a module is dynamically loaded

### DIFF
--- a/asmrun/natdynlink.c
+++ b/asmrun/natdynlink.c
@@ -29,6 +29,10 @@
 #include "spacetime.h"
 #endif
 
+#include "caml/hooks.h"
+
+CAMLexport void (*caml_natdynlink_hook)(void* handle, char* unit) = NULL;
+
 #include <stdio.h>
 #include <string.h>
 
@@ -119,6 +123,8 @@ CAMLprim value caml_natdynlink_run(void *handle, value symbol) {
     caml_ext_table_add(&caml_code_fragments_table, cf);
   }
 
+  if( caml_natdynlink_hook != NULL ) caml_natdynlink_hook(handle,unit);
+  
   entrypoint = optsym("__entry");
   if (NULL != entrypoint) result = caml_callback((value)(&entrypoint), 0);
   else result = Val_unit;

--- a/byterun/caml/hooks.h
+++ b/byterun/caml/hooks.h
@@ -1,0 +1,42 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*                    Fabrice Le Fessant, INRIA de Paris                  */
+/*                                                                        */
+/*   Copyright 2016 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#ifndef CAML_HOOKS_H
+#define CAML_HOOKS_H
+
+#include "misc.h"
+#include "memory.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef CAML_INTERNALS
+
+#ifdef NATIVE_CODE
+
+/* executed just before calling the entry point of a dynamically
+   loaded native code module. */
+CAMLextern void (*caml_natdynlink_hook)(void* handle, char* unit);
+
+#endif /* NATIVE_CODE */
+
+#endif /* CAML_INTERNALS */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CAML_HOOKS_H */


### PR DESCRIPTION
This PR adds a hook `natdynlink_hook`, that is called when a native code module is dynamically loaded. It can be used by Memprof and other profiling tools to adapt to such additions.
