### PR TITLE
Add profiling hooks on systhreads

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,6 +26,10 @@ Next version (4.05.0):
   passed to the new functions are handled by the garbage collector.
   (Gabriel Scherer, review by Mark Shinwell, request by Immanuel Litzroth)
 
+- GPR#697: add hooks to monitor the activity of system threads, and
+  allow performance/memory profiling.
+  (Fabrice Le Fessant)
+
 ### Type system:
 
 - PR#6608, GPR#901: unify record types when overriding all fields

--- a/byterun/caml/hooks.h
+++ b/byterun/caml/hooks.h
@@ -13,6 +13,9 @@
 /*                                                                        */
 /**************************************************************************/
 
+/* Hooks in the OCaml runtime. Warning: these functions/hooks are
+   experimental, and might change in the future. */
+
 #ifndef CAML_HOOKS_H
 #define CAML_HOOKS_H
 
@@ -32,6 +35,53 @@ extern "C" {
 CAMLextern void (*caml_natdynlink_hook)(void* handle, char* unit);
 
 #endif /* NATIVE_CODE */
+
+
+/* Hooks to profile systhreads. */
+
+/* [caml_st_root_scan_hook(thread_id,bottom,retaddr)] is called before
+  scanning the stack of a thread. It is called with [thread_id] equal
+  to zero at the end. */
+
+#define CAML_ST_ROOT_SCAN_HOOK(thread_id,bottom,retaddr) \
+  if( caml_st_root_scan_hook != NULL ) \
+    caml_st_root_scan_hook(thread_id,bottom,retaddr)
+CAMLextern void (*caml_st_root_scan_hook)(value thread_id,
+                                          char* bottom,
+                                          uintnat retaddr);
+/*
+  [caml_st_change_hook(thread_id, action)] is called everytime an action
+  is performed on a thread. The following actions are detected:
+ CAML_HOOK_ST_INIT: corresponding thread is the first thread of the
+    system. All preceeding OCaml code was executed by it !
+ CAML_HOOK_ST_REINIT: corresponding thread is the first thread after a fork.
+ CAML_HOOK_ST_YIELD: corresponding thread is blocked until scheduled again.
+ CAML_HOOK_ST_SCHEDULE: corresponding thread is being scheduled.
+ CAML_HOOK_ST_STOP: corresponding thread is being terminated. It will
+    NEVER execute again.
+ CAML_HOOK_ST_REGISTER: corresponding thread is declared as a C thread.
+    It should be scheduled just after.
+ CAML_HOOK_ST_UNREGISTER: corresponding thread is unregistered. It will
+    not interact with the OCaml runtime, unless it is registered again, 
+    but under a different identifier.
+ CAML_HOOK_ST_CREATE: corresponding thread is being created. It is not
+    scheduled yet, i.e. another thread is still executing.
+
+Note that we always hold the master lock when [caml_st_change_hook] is
+called, but it is unsafe to allocate OCaml data or to assume that the
+thread is completely initialized.
+ */
+#define CAML_HOOK_ST_INIT       0
+#define CAML_HOOK_ST_YIELD      1
+#define CAML_HOOK_ST_SCHEDULE   2
+#define CAML_HOOK_ST_STOP       3
+#define CAML_HOOK_ST_REINIT     4
+#define CAML_HOOK_ST_REGISTER   5
+#define CAML_HOOK_ST_UNREGISTER 6
+#define CAML_HOOK_ST_CREATE     7
+#define CAML_ST_CHANGE_HOOK(thread_id, change) \
+  if( caml_st_change_hook != NULL ) caml_st_change_hook(thread_id, change)
+CAMLextern void (*caml_st_change_hook)(value thread_id, int change);
 
 #endif /* CAML_INTERNALS */
 

--- a/byterun/caml/roots.h
+++ b/byterun/caml/roots.h
@@ -28,14 +28,14 @@ void caml_darken_all_roots_start (void);
 intnat caml_darken_all_roots_slice (intnat);
 void caml_do_roots (scanning_action, int);
 extern uintnat caml_incremental_roots_count;
-#ifndef NATIVE_CODE
-CAMLextern void caml_do_local_roots (scanning_action, value *, value *,
-                                     struct caml__roots_block *);
-#else
+#ifdef NATIVE_CODE
 CAMLextern void caml_do_local_roots(scanning_action f, char * bottom_of_stack,
                                     uintnat last_retaddr, value * gc_regs,
                                     struct caml__roots_block * local_roots);
-#endif
+#else
+CAMLextern void caml_do_local_roots (scanning_action, value *, value *,
+                                     struct caml__roots_block *);
+#endif /* NATIVE_CODE */
 
 CAMLextern void (*caml_scan_roots_hook) (scanning_action);
 

--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -58,6 +58,7 @@
 #include "caml/stacks.h"
 #include "caml/sys.h"
 #include "caml/version.h"
+#include "caml/roots.h"
 
 static char * error_message(void)
 {
@@ -635,3 +636,9 @@ void caml_cplugins_init(char * exe_name, char **argv)
 }
 
 #endif /* CAML_WITH_CPLUGINS */
+
+/* Hooks to profile systhreads */
+CAMLexport void (*caml_st_root_scan_hook)(value thread_id,
+                                          char* bottom,
+                                          uintnat retaddr) = NULL;
+CAMLexport void (*caml_st_change_hook)(value thread_id, int change) = NULL;


### PR DESCRIPTION
This PR adds hooks on systhreads to be able to monitor their behavior. The hooks are defined in the standard runtime, to be always available, but only used when system threads are being used. 

There are 2 kinds of hooks:
- the first hook is called when scanning threads roots, providing the thread being scanned before its local roots are scanned
- the second hook is called everytime a thread change happens, i.e. when a thread is created, is scheduled or yield.
