### PR TITLE
Fix maximum weak bucket size

### DIFF
--- a/stdlib/weak.ml
+++ b/stdlib/weak.ml
@@ -200,7 +200,7 @@ module Make (H : Hashtbl.HashedType) : (S with type data = H.t) = struct
     let sz = length bucket in
     let rec loop i =
       if i >= sz then begin
-        let newsz = min (3 * sz / 2 + 3) (Sys.max_array_length - 1) in
+        let newsz = min (3 * sz / 2 + 3) (Sys.max_array_length - additional_values) in
         if newsz <= sz then failwith "Weak.Make: hash bucket cannot grow more";
         let newbucket = weak_create newsz in
         let newhashes = Array.make newsz 0 in


### PR DESCRIPTION
Ephemeron buckets need 2 extra fields (rather than 1 in the old weak table) in
each bucket, as can be seen in [`caml_ephe_create`](https://github.com/ocaml/ocaml/blob/trunk/byterun/weak.c#L67). Thus the
actual max bucket size should be `Sys.max_array_length - 2` instead of
`Sys.max_array_length - 1`.

Seen with @alainfrisch.
