### PR TITLE
Optimize some constant string operations

### DIFF
--- a/Changes
+++ b/Changes
@@ -118,6 +118,10 @@ OCaml 4.04.0:
 - GPR#602: Do not generate dummy code to force module linking
   (Pierre Chambart, reviewed by Jacques Garrigue)
 
+- GPR#703: Optimize some constant string operations when the "-safe-string"
+  configure time option is enabled.
+  (Pierre Chambart)
+
 - GPR#707: Load cross module information during a meet
   (Pierre Chambart, report by Leo White, review by Marc Shinwell)
 

--- a/middle_end/simple_value_approx.ml
+++ b/middle_end/simple_value_approx.ml
@@ -783,3 +783,14 @@ let float_array_as_constant (t:value_float_array) : float list option =
         | Value_extern _ | Value_boxed_int _ | Value_symbol _)
         -> None)
       contents (Some [])
+
+let check_approx_for_string t : string option =
+  match t.descr with
+  | Value_string { contents } -> contents
+  | Value_float _
+  | Value_unresolved _
+  | Value_unknown _ | Value_float_array _
+  | Value_bottom | Value_block _ | Value_int _ | Value_char _
+  | Value_constptr _ | Value_set_of_closures _ | Value_closure _
+  | Value_extern _ | Value_boxed_int _ | Value_symbol _ ->
+      None

--- a/middle_end/simple_value_approx.mli
+++ b/middle_end/simple_value_approx.mli
@@ -409,3 +409,6 @@ val check_approx_for_float : t -> float option
 
 (** Returns the value if it can be proved to be a constant float array *)
 val float_array_as_constant : value_float_array -> float list option
+
+(** Returns the value if it can be proved to be a constant string *)
+val check_approx_for_string : t -> string option

--- a/middle_end/simplify_primitives.ml
+++ b/middle_end/simplify_primitives.ml
@@ -126,7 +126,6 @@ let primitive (p : Lambda.primitive) (args, approxs) expr dbg ~size_int
       | Pasrint when shift_precond -> S.const_int_expr expr (x asr y)
       | Pintcomp cmp -> S.const_comparison_expr expr cmp x y
       | Pisout -> S.const_bool_expr expr (y > x || y < 0)
-      (* [Psequand] and [Psequor] have special simplification rules, above. *)
       | _ -> expr, A.value_unknown Other, C.Benefit.zero
       end
     | [Value_constptr x] ->

--- a/middle_end/simplify_primitives.ml
+++ b/middle_end/simplify_primitives.ml
@@ -197,7 +197,8 @@ let primitive (p : Lambda.primitive) (args, approxs) expr dbg ~size_int
        (Value_int x | Value_constptr x)] when x >= 0 && x < size ->
         begin match p with
         | Pstringrefu
-        | Pstringrefs -> S.const_char_expr expr s.[x]
+        | Pstringrefs ->
+          S.const_char_expr (Prim(Pstringrefu, args, dbg)) s.[x]
         | _ -> expr, A.value_unknown Other, C.Benefit.zero
         end
     | [Value_string { size; contents = None };

--- a/middle_end/simplify_primitives.ml
+++ b/middle_end/simplify_primitives.ml
@@ -128,6 +128,11 @@ let primitive (p : Lambda.primitive) (args, approxs) expr dbg ~size_int
       | Pisout -> S.const_bool_expr expr (y > x || y < 0)
       | _ -> expr, A.value_unknown Other, C.Benefit.zero
       end
+    | [Value_char x; Value_char y] ->
+      begin match p with
+      | Pintcomp cmp -> S.const_comparison_expr expr cmp x y
+      | _ -> expr, A.value_unknown Other, C.Benefit.zero
+      end
     | [Value_constptr x] ->
       begin match p with
       (* [Pidentity] should probably never appear, but is here for

--- a/middle_end/simplify_primitives.ml
+++ b/middle_end/simplify_primitives.ml
@@ -71,6 +71,8 @@ let primitive (p : Lambda.primitive) (args, approxs) expr dbg ~size_int
       expr, approx, C.Benefit.zero
   | Pintcomp Ceq when phys_equal approxs ->
     S.const_bool_expr expr true
+  | Pintcomp Cneq when phys_equal approxs ->
+    S.const_bool_expr expr false
     (* N.B. Having [not (phys_equal approxs)] would not on its own tell us
        anything about whether the two values concerned are unequal.  To judge
        that, it would be necessary to prove that the approximations are


### PR DESCRIPTION
Since https://github.com/ocaml/ocaml/pull/687 some constant string operations can be simplified.
This currently propose eliminating string switch when the argument is a constant string ( @yallop thinks that this can matter for Ctypes ). This also tweaks a few things to improve char lookup.

Notice that this kind of change makes using `Bytes.unsafe_to_string` more unsafe.

I can add various other cases (`Pervasives.(^)`, String.equal, String.compare, int_of_string, string_of_int, ...) if someone consider that useful .
