### PR TITLE
Share a few more equal switch branches

### DIFF
--- a/Changes
+++ b/Changes
@@ -121,6 +121,9 @@ OCaml 4.04.0:
 - GPR#707: Load cross module information during a meet
   (Pierre Chambart, report by Leo White, review by Marc Shinwell)
 
+- GPR#709: Share a few more equal switch branches
+  (Pierre Chambart, review by Gabriel Scherer)
+
 - GPR#712: Small improvements to type-based optimizations for array
   and lazy
   (Alain Frisch, review by Pierre Chambart)

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -314,6 +314,8 @@ let make_key e =
     | Llet (Alias,_k,x,ex,e) -> (* Ignore aliases -> substitute *)
         let ex = tr_rec env ex in
         tr_rec (Ident.add x ex env) e
+    | Llet ((Strict | StrictOpt),_k,x,ex,Lvar v) when Ident.same v x ->
+        tr_rec env ex
     | Llet (str,k,x,ex,e) ->
      (* Because of side effects, keep other lets with normalized names *)
         let ex = tr_rec env ex in


### PR DESCRIPTION
I was surprised to find that in the example:

``` OCaml
type t =
  | Immutable of { cell : int }
  | Mutable of { mutable cell : int }

let cell = function
  | Immutable { cell } -> cell
  | Mutable { cell } -> cell
```

The match branches where not shared. This comes from a small difference between the generated code in both branches:

```
(let (cell/1209 =a (field 0 param/1215)) cell/1209)
(let (cell/1210 =o (field 0 param/1215)) cell/1210)
```

The first one being substituted by Lambda.make_key to

```
(field 0 param/1215)
```

while the other remain unchanged.

This small change simplify `(let (x =o exp) x)` into `x` to enable sharing in this kind of patterns.

CC @maranget 
