### PR TITLE
Get symbol address from OCaml  (`external "mysymbol"` in expression)

### DIFF
--- a/Changes
+++ b/Changes
@@ -20,6 +20,10 @@ OCaml 4.04.0:
 - GPR#548: empty documentation comments
   (Florian Angeletti)
 
+- GPR#711: `external "mysymbol"` in an expression is a nativeint that
+  is equal to the adress of the symbol "mysymbol"
+  (François Bobot)
+
 
 ### Compiler user-interface and warnings:
 

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -1535,6 +1535,8 @@ let rec transl env e =
       begin match (simplif_primitive prim, args) with
         (Pgetglobal id, []) ->
           Cconst_symbol (Ident.name id)
+      | (Pcsymbol s, []) ->
+          box_int dbg Pnativeint (Cconst_symbol s)
       | (Pmakeblock _, []) ->
           assert false
       | (Pmakeblock(tag, _mut, _kind), args) ->

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -317,6 +317,7 @@ let comp_primitive p args =
   | Psetfloatfield (n, _init) -> Ksetfloatfield n
   | Pduprecord _ -> Kccall("caml_obj_dup", 1)
   | Pccall p -> Kccall(p.prim_name, p.prim_arity)
+  | Pcsymbol s -> Kcsymbol s
   | Pnegint -> Knegint
   | Paddint -> Kaddint
   | Psubint -> Ksubint

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -263,6 +263,8 @@ let emit_instr = function
       if n <= 5
       then (out (opC_CALL1 + n - 1); slot_for_c_prim name)
       else (out opC_CALLN; out_int n; slot_for_c_prim name)
+  | Kcsymbol name ->
+      out opC_SYMBOL; slot_for_c_prim name
   | Knegint -> out opNEGINT  | Kaddint -> out opADDINT
   | Ksubint -> out opSUBINT  | Kmulint -> out opMULINT
   | Kdivint -> out opDIVINT  | Kmodint -> out opMODINT

--- a/bytecomp/instruct.ml
+++ b/bytecomp/instruct.ml
@@ -91,6 +91,7 @@ type instruction =
   | Kraise of raise_kind
   | Kcheck_signals
   | Kccall of string * int
+  | Kcsymbol of string
   | Knegint | Kaddint | Ksubint | Kmulint | Kdivint | Kmodint
   | Kandint | Korint | Kxorint | Klslint | Klsrint | Kasrint
   | Kintcomp of comparison

--- a/bytecomp/instruct.mli
+++ b/bytecomp/instruct.mli
@@ -111,6 +111,7 @@ type instruction =
   | Kraise of raise_kind
   | Kcheck_signals
   | Kccall of string * int
+  | Kcsymbol of string
   | Knegint | Kaddint | Ksubint | Kmulint | Kdivint | Kmodint
   | Kandint | Korint | Kxorint | Klslint | Klsrint | Kasrint
   | Kintcomp of comparison

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -62,6 +62,7 @@ type primitive =
   | Plazyforce
   (* External call *)
   | Pccall of Primitive.description
+  | Pcsymbol of string
   (* Exceptions *)
   | Praise of raise_kind
   (* Boolean operations *)

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -65,6 +65,8 @@ type primitive =
   | Plazyforce
   (* External call *)
   | Pccall of Primitive.description
+  (* Put the address of a symbol into a nativeint *)
+  | Pcsymbol of string
   (* Exceptions *)
   | Praise of raise_kind
   (* Boolean operations *)

--- a/bytecomp/printinstr.ml
+++ b/bytecomp/printinstr.ml
@@ -74,6 +74,8 @@ let instruction ppf = function
   | Kcheck_signals -> fprintf ppf "\tcheck_signals"
   | Kccall(s, n) ->
       fprintf ppf "\tccall %s, %i" s n
+  | Kcsymbol s ->
+      fprintf ppf "\tcsymbol %s" s
   | Knegint -> fprintf ppf "\tnegint"
   | Kaddint -> fprintf ppf "\taddint"
   | Ksubint -> fprintf ppf "\tsubint"

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -162,6 +162,7 @@ let primitive ppf = function
   | Pduprecord (rep, size) -> fprintf ppf "duprecord %a %i" record_rep rep size
   | Plazyforce -> fprintf ppf "force"
   | Pccall p -> fprintf ppf "%s" p.prim_name
+  | Pcsymbol s -> fprintf ppf "%s" s
   | Praise k -> fprintf ppf "%s" (Lambda.raise_kind k)
   | Psequand -> fprintf ppf "&&"
   | Psequor -> fprintf ppf "||"
@@ -311,6 +312,7 @@ let name_of_primitive = function
   | Pduprecord _ -> "Pduprecord"
   | Plazyforce -> "Plazyforce"
   | Pccall _ -> "Pccall"
+  | Pcsymbol _ -> "Pcsymbol"
   | Praise _ -> "Praise"
   | Psequand -> "Psequand"
   | Psequor -> "Psequor"

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -1068,6 +1068,8 @@ and transl_exp0 e =
          }
   | Texp_unreachable ->
       raise (Error (e.exp_loc, Unreachable_reached))
+  | Texp_external s ->
+      Lprim(Pcsymbol s,[], e.exp_loc)
 
 and transl_list expr_list =
   List.map transl_exp expr_list

--- a/byterun/caml/instruct.h
+++ b/byterun/caml/instruct.h
@@ -60,6 +60,7 @@ enum instructions {
   STOP,
   EVENT, BREAK,
   RERAISE, RAISE_NOTRACE,
+  C_SYMBOL,
 FIRST_UNIMPLEMENTED_OP};
 
 #endif /* CAML_INTERNALS */

--- a/byterun/fix_code.c
+++ b/byterun/fix_code.c
@@ -120,7 +120,7 @@ int* caml_init_opcode_nargs(void)
       l[BRANCH] = l[BRANCHIF] = l[BRANCHIFNOT] = l[PUSHTRAP] =
       l[C_CALL1] = l[C_CALL2] = l[C_CALL3] = l[C_CALL4] = l[C_CALL5] =
       l[CONSTINT] = l[PUSHCONSTINT] = l[OFFSETINT] =
-      l[OFFSETREF] = l[OFFSETCLOSURE] = l[PUSHOFFSETCLOSURE] = 1;
+      l[OFFSETREF] = l[OFFSETCLOSURE] = l[PUSHOFFSETCLOSURE] = l[C_SYMBOL] = 1;
 
     /* Instructions with two operands */
     l[APPTERM] = l[CLOSURE] = l[PUSHGETGLOBALFIELD] =

--- a/byterun/interp.c
+++ b/byterun/interp.c
@@ -938,6 +938,11 @@ value caml_interprete(code_t prog, asize_t prog_size)
       Next;
     }
 
+    Instruct(C_SYMBOL):
+      accu = caml_copy_nativeint((intnat) Primitive(*pc));
+      pc++;
+      Next;
+
 /* Integer constants */
 
     Instruct(CONST0):

--- a/middle_end/semantics_of_primitives.ml
+++ b/middle_end/semantics_of_primitives.ml
@@ -36,6 +36,7 @@ let for_primitive (prim : Lambda.primitive) =
     No_effects, No_coeffects
   | Plazyforce
   | Pccall _ -> Arbitrary_effects, Has_coeffects
+  | Pcsymbol _ -> No_effects, No_coeffects
   | Praise _ -> Arbitrary_effects, No_coeffects
   | Pnot
   | Pnegint
@@ -159,6 +160,6 @@ let return_type_of_primitive (prim:Lambda.primitive) =
   | Pfloatfield _
   | Parrayrefu Pfloatarray
   | Parrayrefs Pfloatarray ->
-    Float
+      Float
   | _ ->
     Other

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -133,6 +133,7 @@ module Exp = struct
   let open_ ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_open (a, b, c))
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pexp_extension a)
   let unreachable ?loc ?attrs () = mk ?loc ?attrs Pexp_unreachable
+  let external_ ?loc ?attrs s = mk ?loc ?attrs (Pexp_external s)
 
   let case lhs ?guard rhs =
     {

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -163,6 +163,7 @@ module Exp:
                -> expression
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> expression
     val unreachable: ?loc:loc -> ?attrs:attrs -> unit -> expression
+    val external_: ?loc:loc -> ?attrs:attrs -> string -> expression
 
     val case: pattern -> ?guard:expression -> expression -> case
   end

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -369,6 +369,7 @@ module E = struct
         iter_loc sub lid; sub.expr sub e
     | Pexp_extension x -> sub.extension sub x
     | Pexp_unreachable -> ()
+    | Pexp_external _ -> ()
 end
 
 module P = struct

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -385,6 +385,7 @@ module E = struct
         open_ ~loc ~attrs ovf (map_loc sub lid) (sub.expr sub e)
     | Pexp_extension x -> extension ~loc ~attrs (sub.extension sub x)
     | Pexp_unreachable -> unreachable ~loc ~attrs ()
+    | Pexp_external s -> external_ ~loc ~attrs s
 end
 
 module P = struct

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -271,6 +271,7 @@ let rec add_expr bv exp =
       end
   | Pexp_extension e -> handle_extension e
   | Pexp_unreachable -> ()
+  | Pexp_external _ -> ()
 
 and add_cases bv cases =
   List.iter (add_case bv) cases

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -608,6 +608,7 @@ conflicts.
 The precedences must be listed from low to high.
 */
 
+%nonassoc EXTERNAL
 %nonassoc IN
 %nonassoc below_SEMI
 %nonassoc SEMI                          /* below EQUAL ({lbl=...; lbl=...}) */
@@ -1465,7 +1466,9 @@ expr:
   | expr attribute
       { Exp.attr $1 $2 }
   | UNDERSCORE
-     { not_expecting 1 "wildcard \"_\"" }
+      { not_expecting 1 "wildcard \"_\"" }
+  | EXTERNAL STRING
+      { mkexp (Pexp_external (fst $2)) }
 ;
 simple_expr:
     val_longident

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -349,6 +349,8 @@ and expression_desc =
         (* [%id] *)
   | Pexp_unreachable
         (* . *)
+  | Pexp_external of string
+        (* external "..." *)
 
 and case =   (* (P -> E) or (P when E0 -> E) *)
     {

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -376,6 +376,8 @@ and expression i ppf x =
       payload i ppf arg
   | Pexp_unreachable ->
       line i ppf "Pexp_unreachable"
+  | Pexp_external s ->
+      line i ppf "Pexp_external %s" s
 
 and value_description i ppf x =
   line i ppf "value_description %a %a\n" fmt_string_loc

--- a/testsuite/tests/external-in-expr/Makefile
+++ b/testsuite/tests/external-in-expr/Makefile
@@ -1,0 +1,22 @@
+#**************************************************************************
+#*                                                                        *
+#*                                OCaml                                   *
+#*                                                                        *
+#*                 Xavier Clerc, SED, INRIA Rocquencourt                  *
+#*                                                                        *
+#*   Copyright 2010 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+BASEDIR=../..
+#MODULES=
+MAIN_MODULE=external_in_expr
+C_FILES=external_in_exprprim
+
+include $(BASEDIR)/makefiles/Makefile.one
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/external-in-expr/external_in_expr.ml
+++ b/testsuite/tests/external-in-expr/external_in_expr.ml
@@ -1,0 +1,53 @@
+
+
+(** {2 Check that the address is the same from ocaml and from C} *)
+external get_foobar_global: unit -> nativeint = "get_foobar_global"
+
+external get_var_global: unit -> (nativeint [@unboxed]) =
+  "get_var_global_boxed" "get_var_global" [@@noalloc]
+
+let () =
+  Printf.printf "foobar same address: %b\n%!"
+    ((external "foobar") =  (get_foobar_global ()))
+
+let () =
+  Printf.printf "var_global same address: %b\n%!"
+    ((external "var_global") = (get_var_global ()))
+
+(** {2 Check that the computation is the same} *)
+
+external run_one: nativeint -> Obj.t -> Obj.t = "run_one"
+(** apply the function with the given address to the given value and
+    return its result *)
+
+external foobar: int -> int = "foobar"
+
+let foobar_dyn (x:int) : int =
+  Obj.obj (run_one (external "foobar") (Obj.repr x))
+
+let () =
+  Printf.printf "foobar same computation: %b\n%!"
+    ((foobar 1) = (foobar_dyn 1))
+
+(** {2 Check that the computation is the same with unboxing} *)
+
+(** Here we suppose that there is only one C function [foobar_unboxed]
+    provided by the user *)
+
+external run_one_unbox: nativeint -> Obj.t -> Obj.t = "run_one_unbox"
+(** apply the function with the given address to the given value (must
+    be an int) and return its result (must be an int) *)
+
+external foobar_native: (int [@untagged]) -> (int [@untagged]) =
+  "shouldnotbecalled" "foobar_unboxed" [@@noalloc]
+
+let foobar_unboxed (x:int) : int =
+  match Sys.backend_type with
+  | Sys.Native -> foobar_native x
+  | Sys.Bytecode ->
+      Obj.obj (run_one_unbox (external "foobar_unboxed") (Obj.repr x))
+  | Sys.Other _ -> assert false
+
+let () =
+  Printf.printf "foobar unboxed result: %i\n%!"
+    (foobar_unboxed 1)

--- a/testsuite/tests/external-in-expr/external_in_expr.reference
+++ b/testsuite/tests/external-in-expr/external_in_expr.reference
@@ -1,0 +1,4 @@
+foobar same address: true
+var_global same address: true
+foobar same computation: true
+foobar unboxed result: 3

--- a/testsuite/tests/external-in-expr/external_in_exprprim.c
+++ b/testsuite/tests/external-in-expr/external_in_exprprim.c
@@ -1,0 +1,56 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                OCaml                                   */
+/*                                                                        */
+/*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1995 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#include "caml/mlvalues.h"
+#include "caml/alloc.h"
+
+intnat var_global = 42;
+
+value foobar(value i){
+  return Val_long(2+(Long_val(i)));
+}
+
+intnat foobar_unboxed(intnat i){
+  return 2+i;
+}
+
+
+typedef value (*run_one1)(value);
+
+value run_one(value f, value arg1){
+  return ((run_one1) (Nativeint_val(f)))(arg1);
+}
+
+typedef intnat (*run_one_unbox1)(intnat);
+
+value run_one_unbox(value f, value arg1){
+  return (Val_long (((run_one_unbox1) (Nativeint_val(f)))(Long_val(arg1))));
+}
+
+value get_foobar_global(value unit){
+  return caml_copy_nativeint((intnat) &foobar);
+}
+
+value get_var_global_boxed(value unit){
+  return caml_copy_nativeint((intnat) &var_global);
+}
+
+intnat get_var_global(value unit){
+  return (intnat) &var_global;
+}
+
+void shouldnotbecalled(void){
+  exit(1);
+}

--- a/tools/ocamlprof.ml
+++ b/tools/ocamlprof.ml
@@ -301,6 +301,7 @@ and rw_exp iflag sexp =
   | Pexp_pack (smod) -> rewrite_mod iflag smod
   | Pexp_extension _ -> ()
   | Pexp_unreachable -> ()
+  | Pexp_external _ -> ()
 
 and rewrite_ifbody iflag ghost sifbody =
   if !instr_if && not ghost then

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -396,6 +396,8 @@ and expression i ppf x =
       line i ppf "Texp_unreachable"
   | Texp_extension_constructor (li, _) ->
       line i ppf "Texp_extension_constructor %a" fmt_longident li
+  | Texp_external s ->
+      line i ppf "Texp_external %s" s
 
 and value_description i ppf x =
   line i ppf "value_description %a %a\n" fmt_ident x.val_id fmt_location

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -347,6 +347,8 @@ let expr sub x =
         Texp_unreachable
     | Texp_extension_constructor _ as e ->
         e
+    | Texp_external _ as e ->
+        e
   in
   {x with exp_extra; exp_desc; exp_env}
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -174,6 +174,7 @@ let iter_expression f e =
     | Pexp_object { pcstr_fields = fs } -> List.iter class_field fs
     | Pexp_pack me -> module_expr me
     | Pexp_unreachable -> ()
+    | Pexp_external _ -> ()
 
   and case {pc_lhs = _; pc_guard; pc_rhs} =
     may expr pc_guard;
@@ -2988,6 +2989,14 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
            exp_type = instance env ty_expected;
            exp_attributes = sexp.pexp_attributes;
            exp_env = env }
+  | Pexp_external s ->
+      rue {
+        exp_desc = Texp_external s;
+        exp_loc = loc; exp_extra = [];
+        exp_type = instance_def Predef.type_nativeint;
+        exp_attributes = sexp.pexp_attributes;
+        exp_env = env }
+
 
 and type_function ?in_function loc attrs env ty_expected l caselist =
   let (loc_fun, ty_fun) =

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -113,6 +113,7 @@ and expression_desc =
   | Texp_pack of module_expr
   | Texp_unreachable
   | Texp_extension_constructor of Longident.t loc * Path.t
+  | Texp_external of string
 
 and meth =
     Tmeth_name of string

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -225,6 +225,7 @@ and expression_desc =
   | Texp_pack of module_expr
   | Texp_unreachable
   | Texp_extension_constructor of Longident.t loc * Path.t
+  | Texp_external of string
 
 and meth =
     Tmeth_name of string

--- a/typing/typedtreeIter.ml
+++ b/typing/typedtreeIter.ml
@@ -359,6 +359,8 @@ module MakeIterator(Iter : IteratorArgument) : sig
             ()
         | Texp_extension_constructor _ ->
             ()
+        | Texp_external _ ->
+            ()
       end;
       Iter.leave_expression exp;
 

--- a/typing/typedtreeMap.ml
+++ b/typing/typedtreeMap.ml
@@ -388,7 +388,10 @@ module MakeMap(Map : MapArgument) = struct
         | Texp_unreachable ->
           Texp_unreachable
         | Texp_extension_constructor _ as e ->
-          e
+            e
+        | Texp_external _ as e ->
+            e
+
     in
     let exp_extra = List.map map_exp_extra exp.exp_extra in
     Map.leave_expression {

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -468,6 +468,8 @@ let expression sub exp =
                         PStr [ Str.eval ~loc
                                  (Exp.construct ~loc (map_loc sub lid) None)
                              ])
+    | Texp_external s ->
+        Pexp_external s
   in
   List.fold_right (exp_extra sub) exp.exp_extra
     (Exp.mk ~loc ~attrs desc)


### PR DESCRIPTION
The first goal of this work was to eliminate the need to write boilerplate code for the bytecode case when creating stubs. The introduction of `[@unboxed]` and `[@untagged]` makes these boilerplate even more annoying since one can directly use a usual C function by doing all the unboxing in the OCaml side in native mode.

If one want to do the same thing for the bytecode case the OCaml bytecode interpreter must be able to do all the possible unboxing (exponential number of cases) and better for any arity. This requires a library such as [libffi](https://github.com/libffi/libffi/) which is a dependency too big for the OCaml interpreter. Moreover it is easier to manage such dependency in an external package (opam, depext, conf-libffi, explicit dependency to this feature).

However such library (ppx+a stub) needs one important feature, to get the address of the C-function. This PR allows just that: it adds in the expression grammar the possibility to write `external "mysymbol"`, "mysymbol" being a constant string. The expression is of type `nativeint`.

The library ppx could then produce from:

``` ocaml
external foobar: (int [@untagged]) -> (int [@untagged]) = "foobar_unboxed" [@@noalloc]
```

the code:

``` ocaml
external foobar_native: (int [@untagged]) -> (int [@untagged]) =
  "shouldnotbecalled" "foobar_unboxed" [@@noalloc]


let foobar (x:int) : int =
  match Sys.backend_type with
  | Sys.Native -> foobar_native x
  | Sys.Bytecode ->
      Obj.obj (run_one_unbox (external "foobar_unboxed") (Obj.repr x))
  | Sys.Other _ -> assert false
```

That use the function `run_one_unbox` defined in the library stubs.

``` ocaml
external run_one_unbox: nativeint -> Obj.t -> Obj.t = "run_one_unbox"
(** apply the function with the given address to the given value (must
    be an int) and return its result (must be an int) *)
```

and

``` C
typedef intnat (*run_one_unbox1)(intnat);

value run_one_unbox(value f, value arg1){
  return (Val_long (((run_one_unbox1) (Nativeint_val(f)))(Long_val(arg1))));
}
```

Using libffi the library could define the more useful:

``` ocaml
external ffi: nativeint -> prototype -> Obj.t array  -> Obj.t = "ffi"
```

I'm not proposing to maintain such library, but @yallop from ocaml-ctypes seems interested ocamllabs/ocaml-ctypes#416

Bonus: With #652 one could modify directly from OCaml C globals.
