### PR TITLE
Small improvements to type-based optimizations (array, lazy)

### DIFF
--- a/Changes
+++ b/Changes
@@ -121,6 +121,10 @@ OCaml 4.04.0:
 - GPR#707: Load cross module information during a meet
   (Pierre Chambart, report by Leo White, review by Marc Shinwell)
 
+- GPR#712: Small improvements to type-based optimizations for array
+  and lazy
+  (Alain Frisch, review by Pierre Chambart)
+
 ### Tools:
 
 - MPR#7189: toplevel #show, follow chains of module aliases

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -1032,8 +1032,6 @@ and transl_exp0 e =
                  [Lprim(Pmakeblock(Obj.forward_tag, Immutable, None),
                         [transl_exp e], e.exp_loc)],
                  e.exp_loc)
-            Lprim(Pmakeblock(Obj.forward_tag, Immutable, None),
-                [transl_exp e], e.exp_loc)
       (* other cases compile to a lazy block holding a function *)
       | _ ->
          let fn = Lfunction {kind = Curried; params = [Ident.create "param"];

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -1019,6 +1019,8 @@ and transl_exp0 e =
       | Texp_construct (_, {cstr_arity = 0}, _)
         -> transl_exp e
       | Texp_constant(Const_float _) ->
+          (* We don't need to wrap with Popaque: this forward
+             block will never be shortcutted since it points to a float. *)
           Lprim(Pmakeblock(Obj.forward_tag, Immutable, None),
                 [transl_exp e], e.exp_loc)
       | Texp_ident _ ->

--- a/bytecomp/typeopt.ml
+++ b/bytecomp/typeopt.ml
@@ -157,7 +157,7 @@ let value_kind env ty =
 
 
 let lazy_val_requires_forward env ty =
-  let ty = Ctype.repr ty in
+  let ty = scrape_ty env ty in
   match ty.desc with
   (* the following may represent a float/forward/lazy: need a
      forward_tag *)

--- a/bytecomp/typeopt.ml
+++ b/bytecomp/typeopt.ml
@@ -154,3 +154,36 @@ let value_kind env ty =
       Pboxedintval Pnativeint
   | _ ->
       Pgenval
+
+
+let lazy_val_requires_forward env ty =
+  let ty = Ctype.repr ty in
+  match ty.desc with
+  (* the following may represent a float/forward/lazy: need a
+     forward_tag *)
+  | Tvar _ | Tunivar _
+  | Tpoly _ | Tfield _ ->
+      true
+  (* the following cannot be represented as float/forward/lazy:
+     optimize *)
+  | Tarrow _ | Ttuple _ | Tpackage _ | Tobject _ | Tnil | Tvariant _ ->
+      false
+  (* optimize predefined types (excepted float) *)
+  | Tconstr _ when
+      is_base_type env ty Predef.path_int
+      || is_base_type env ty Predef.path_char
+      || is_base_type env ty Predef.path_string
+      || is_base_type env ty Predef.path_bool
+      || is_base_type env ty Predef.path_unit
+      || is_base_type env ty Predef.path_exn
+      || is_base_type env ty Predef.path_array
+      || is_base_type env ty Predef.path_list
+      || is_base_type env ty Predef.path_option
+      || is_base_type env ty Predef.path_nativeint
+      || is_base_type env ty Predef.path_int32
+      || is_base_type env ty Predef.path_int64 ->
+      false
+  | Tconstr _ ->
+      true
+  | Tlink _ | Tsubst _ ->
+      assert false

--- a/bytecomp/typeopt.ml
+++ b/bytecomp/typeopt.ml
@@ -70,6 +70,7 @@ let array_element_kind env ty =
         Pfloatarray
       else if Path.same p Predef.path_string
            || Path.same p Predef.path_bytes
+           || Path.same p Predef.path_lazy_t
            || Path.same p Predef.path_array
            || Path.same p Predef.path_nativeint
            || Path.same p Predef.path_int32

--- a/bytecomp/typeopt.ml
+++ b/bytecomp/typeopt.ml
@@ -158,7 +158,8 @@ let value_kind env ty =
 
 let lazy_val_requires_forward env ty =
   let ty = scrape_ty env ty in
-  match ty.desc with
+  if maybe_pointer_type env ty = Immediate then false
+  else match ty.desc with
   (* the following may represent a float/forward/lazy: need a
      forward_tag *)
   | Tvar _ | Tunivar _
@@ -168,22 +169,17 @@ let lazy_val_requires_forward env ty =
      optimize *)
   | Tarrow _ | Ttuple _ | Tpackage _ | Tobject _ | Tnil | Tvariant _ ->
       false
-  (* optimize predefined types (excepted float) *)
-  | Tconstr _ when
-      is_base_type env ty Predef.path_int
-      || is_base_type env ty Predef.path_char
-      || is_base_type env ty Predef.path_string
-      || is_base_type env ty Predef.path_bool
-      || is_base_type env ty Predef.path_unit
-      || is_base_type env ty Predef.path_exn
-      || is_base_type env ty Predef.path_array
-      || is_base_type env ty Predef.path_list
-      || is_base_type env ty Predef.path_option
-      || is_base_type env ty Predef.path_nativeint
-      || is_base_type env ty Predef.path_int32
-      || is_base_type env ty Predef.path_int64 ->
-      false
+
+  (* optimize predefined types (excepted float);
+     immediate types (int, bool, unit, char) have been dealt with already *)
   | Tconstr _ ->
-      true
+      not (is_base_type env ty Predef.path_string
+           || is_base_type env ty Predef.path_exn
+           || is_base_type env ty Predef.path_array
+           || is_base_type env ty Predef.path_list
+           || is_base_type env ty Predef.path_option
+           || is_base_type env ty Predef.path_nativeint
+           || is_base_type env ty Predef.path_int32
+           || is_base_type env ty Predef.path_int64)
   | Tlink _ | Tsubst _ ->
       assert false

--- a/bytecomp/typeopt.ml
+++ b/bytecomp/typeopt.ml
@@ -69,6 +69,7 @@ let array_element_kind env ty =
       if Path.same p Predef.path_float then
         Pfloatarray
       else if Path.same p Predef.path_string
+           || Path.same p Predef.path_bytes
            || Path.same p Predef.path_array
            || Path.same p Predef.path_nativeint
            || Path.same p Predef.path_int32
@@ -174,6 +175,7 @@ let lazy_val_requires_forward env ty =
      immediate types (int, bool, unit, char) have been dealt with already *)
   | Tconstr _ ->
       not (is_base_type env ty Predef.path_string
+           || is_base_type env ty Predef.path_bytes
            || is_base_type env ty Predef.path_exn
            || is_base_type env ty Predef.path_array
            || is_base_type env ty Predef.path_list

--- a/bytecomp/typeopt.ml
+++ b/bytecomp/typeopt.ml
@@ -30,7 +30,7 @@ let scrape_ty env ty =
         | None -> ty
         | Some ty2 -> ty2
         end
-      | _ -> desc
+      | _ -> ty
       | exception Not_found -> ty
       end
   | _ -> ty

--- a/bytecomp/typeopt.mli
+++ b/bytecomp/typeopt.mli
@@ -18,7 +18,6 @@
 val is_function_type :
       Env.t -> Types.type_expr -> (Types.type_expr * Types.type_expr) option
 val is_base_type : Env.t -> Types.type_expr -> Path.t -> bool
-val has_base_type : Typedtree.expression -> Path.t -> bool
 
 val maybe_pointer_type : Env.t -> Types.type_expr
   -> Lambda.immediate_or_pointer

--- a/bytecomp/typeopt.mli
+++ b/bytecomp/typeopt.mli
@@ -30,3 +30,7 @@ val array_pattern_kind : Typedtree.pattern -> Lambda.array_kind
 val bigarray_type_kind_and_layout :
       Env.t -> Types.type_expr -> Lambda.bigarray_kind * Lambda.bigarray_layout
 val value_kind : Env.t -> Types.type_expr -> Lambda.value_kind
+
+val lazy_val_requires_forward : Env.t -> Types.type_expr -> bool
+  (** Whether a forward block is needed for a lazy thunk on a value, i.e.
+      if the value can be represented as a float/forward/lazy *)


### PR DESCRIPTION
This PR improves the type-based optimization logic for array and lazy.

For arrays: this is about knowing that the array cannot hold floats, or can only hold ints. Improvements brought by the PR:
- Arrays on `_ Lazy.t` or `bytes` (in `-safe-string`mode) are now properly detected to never hold floats.
- Reuse the machinery introduced for the `@@immediate` attribute, which detects more arrays as holding only ints (closed polymorphic variants with only constant constructors, or abstract types marked with the attribute).

For lazy: this is about knowing that `lazy x` can be compiled just as `x` without introducing a forward block.  The forward block is needed only if `x` can be a float or lazy value.  Improvements:
- Detect `bytes` (in `-safe-string`mode).
- Expand abbreviations.
- Reuse the machinery for the `@@immediate` attribute.
- Logic moved to `Typeopt` (where it really belongs) instead of `Translcore`.
- Share this logic with the one for arrays (the only difference being the case of the `lazy_t` abstract type):  this brings the more clever support for concrete data types (records, sums) which are known to be neither floats nor lazy values, and will also better interact with #606.
