### PR TITLE
[WIP] Warning for "syntactically dangerous" nested pattern matching

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -24,7 +24,7 @@ include stdlib/StdlibModules
 
 CAMLC=$(CAMLRUN) boot/ocamlc -g -nostdlib -I boot -use-prims byterun/primitives
 CAMLOPT=$(CAMLRUN) ./ocamlopt -g -nostdlib -I stdlib -I otherlibs/dynlink
-COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
+COMPFLAGS=-strict-sequence -principal -absname -w +a-4-9-41-42-44-45-48-62 -warn-error A \
           -bin-annot -safe-string -strict-formats $(INCLUDES)
 LINKFLAGS=
 
@@ -309,4 +309,3 @@ partialclean::
 	rm -f driver/compdynlink.mlbyte
 	rm -f driver/compdynlink.mli
 	rm -f driver/compdynlink.mlopt
-

--- a/debugger/Makefile.shared
+++ b/debugger/Makefile.shared
@@ -18,7 +18,7 @@ CAMLRUN ?= ../boot/ocamlrun
 CAMLYACC ?= ../boot/ocamlyacc
 
 CAMLC=$(CAMLRUN) ../ocamlc -nostdlib -I ../stdlib
-COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A -safe-string -strict-sequence -strict-formats
+COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48-62 -warn-error A -safe-string -strict-sequence -strict-formats
 LINKFLAGS=-linkall -I $(UNIXDIR)
 YACCFLAGS=
 CAMLLEX=$(CAMLRUN) ../boot/ocamllex

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -28,7 +28,7 @@ endif
 
 CAMLC=$(CAMLRUN) ../boot/ocamlc -strict-sequence -nostdlib -I ../boot -use-prims ../byterun/primitives
 CAMLOPT=$(CAMLRUN) ../ocamlopt -nostdlib -I ../stdlib
-COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A -safe-string -strict-sequence -strict-formats -bin-annot
+COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48-62 -warn-error A -safe-string -strict-sequence -strict-formats -bin-annot
 LINKFLAGS=
 YACCFLAGS=-v
 CAMLLEX=$(CAMLRUN) ../boot/ocamllex

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -516,7 +516,7 @@ that are currently defined are ignored. The warnings are as follows.
 \end{options}
 Some warnings are described in more detail in section~\ref{s:comp-warnings}.
 
-The default setting is "-w +a-4-6-7-9-27-29-32..39-41..42-44-45-48-50".
+The default setting is "-w +a-4-6-7-9-27-29-32..39-41..42-44-45-48-50-60-62".
 It is displayed by "ocamlc -help".
 Note that warnings 5 and 10 are not always triggered, depending on
 the internals of the type checker.

--- a/manual/manual/cmds/native.etex
+++ b/manual/manual/cmds/native.etex
@@ -487,7 +487,7 @@ that are currently defined are ignored. The warning are as follows.
 \input{warnings-help.tex}
 \end{options}
 
-The default setting is "-w +a-4-6-7-9-27-29-32..39-41..42-44-45-48-50".
+The default setting is "-w +a-4-6-7-9-27-29-32..39-41..42-44-45-48-50-60-62".
 It is displayed by "ocamlopt -help".
 Note that warnings 5 and 10 are not always triggered, depending on
 the internals of the type checker.
@@ -624,4 +624,3 @@ precision like the bytecode compiler always does.  Floating-point
 results can therefore differ slightly between bytecode and native code.
 
 \end{itemize}
-

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -86,7 +86,7 @@ INCLUDES_NODEP=	-I $(OCAMLSRCDIR)/stdlib \
 
 INCLUDES=$(INCLUDES_DEP) $(INCLUDES_NODEP)
 
-COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A -safe-string -strict-sequence -strict-formats
+COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48-62 -warn-error A -safe-string -strict-sequence -strict-formats
 LINKFLAGS=$(INCLUDES) -nostdlib
 
 CMOFILES= odoc_config.cmo \

--- a/ocamldoc/Makefile.nt
+++ b/ocamldoc/Makefile.nt
@@ -72,7 +72,7 @@ INCLUDES_NODEP=	-I $(OCAMLSRCDIR)/stdlib \
 
 INCLUDES=$(INCLUDES_DEP) $(INCLUDES_NODEP)
 
-COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A -safe-string -strict-sequence -strict-formats
+COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48-62 -warn-error A -safe-string -strict-sequence -strict-formats
 LINKFLAGS=$(INCLUDES) -nostdlib
 
 CMOFILES= odoc_config.cmo \

--- a/otherlibs/Makefile
+++ b/otherlibs/Makefile
@@ -33,7 +33,7 @@ CFLAGS=-I$(ROOTDIR)/byterun $(SHAREDCCCOMPOPTS) $(EXTRACFLAGS)
 
 # Compilation options
 CC=$(BYTECC)
-COMPFLAGS=-absname -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats $(EXTRACAMLFLAGS)
+COMPFLAGS=-absname -w +a-4-9-41-42-44-45-48-62 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats $(EXTRACAMLFLAGS)
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS=-O3
 else

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -26,7 +26,7 @@ OCAMLC    = $(CAMLRUN) $(ROOTDIR)/ocamlc -nostdlib -I $(ROOTDIR)/stdlib
 OCAMLOPT  = $(CAMLRUN) $(ROOTDIR)/ocamlopt -nostdlib -I $(ROOTDIR)/stdlib
 
 INCLUDES=-I ../../utils -I ../../typing -I ../../bytecomp -I ../../asmcomp
-COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -bin-annot -g -I ../../stdlib -warn-error A \
+COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48-62 -bin-annot -g -I ../../stdlib -warn-error A \
    -safe-string -strict-sequence -strict-formats
 ifeq "$(FLAMBDA)" "true"
 OPTCOMPFLAGS=-O3

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -76,6 +76,11 @@ let ghsig d = Sig.mk ~loc:(symbol_gloc()) d
 let mkinfix arg1 name arg2 =
   mkexp(Pexp_apply(mkoperator name 2, [Nolabel, arg1; Nolabel, arg2]))
 
+let delimited_attr = (mknoloc "ocaml.delimited", PStr [])
+
+let delimited e =
+  {e with pexp_attributes = delimited_attr :: e.pexp_attributes}
+
 let neg_string f =
   if String.length f > 0 && f.[0] = '-'
   then String.sub f 1 (String.length f - 1)
@@ -1477,11 +1482,11 @@ simple_expr:
   | name_tag %prec prec_constant_constructor
       { mkexp(Pexp_variant($1, None)) }
   | LPAREN seq_expr RPAREN
-      { reloc_exp $2 }
+      { delimited (reloc_exp $2) }
   | LPAREN seq_expr error
       { unclosed "(" 1 ")" 3 }
   | BEGIN ext_attributes seq_expr END
-      { wrap_exp_attrs (reloc_exp $3) $2 (* check location *) }
+      { wrap_exp_attrs (delimited (reloc_exp $3)) $2 (* check location *) }
   | BEGIN ext_attributes END
       { mkexp_attrs (Pexp_construct (mkloc (Lident "()") (symbol_rloc ()),
                                None)) $2 }

--- a/stdlib/Makefile.shared
+++ b/stdlib/Makefile.shared
@@ -20,7 +20,7 @@ TARGET_BINDIR ?= $(BINDIR)
 
 COMPILER=../ocamlc
 CAMLC=$(CAMLRUN) $(COMPILER)
-COMPFLAGS=-strict-sequence -absname -w +a-4-9-41-42-44-45-48 \
+COMPFLAGS=-strict-sequence -absname -w +a-4-9-41-42-44-45-48-62 \
           -g -warn-error A -bin-annot -nostdlib \
           -safe-string -strict-formats
 ifeq "$(FLAMBDA)" "true"

--- a/tools/Makefile.shared
+++ b/tools/Makefile.shared
@@ -88,7 +88,7 @@ CAMLLEX=$(CAMLRUN) ../boot/ocamllex
 INCLUDES=-I ../utils -I ../parsing -I ../typing -I ../bytecomp -I ../asmcomp \
          -I ../middle_end -I ../middle_end/base_types -I ../driver \
          -I ../toplevel
-COMPFLAGS= -absname -w +a-4-9-41-42-44-45-48 -strict-sequence -warn-error A \
+COMPFLAGS= -absname -w +a-4-9-41-42-44-45-48-62 -strict-sequence -warn-error A \
  -safe-string -strict-formats $(INCLUDES)
 LINKFLAGS=$(INCLUDES)
 VPATH := $(filter-out -I,$(INCLUDES))

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -82,6 +82,7 @@ type t =
   | Assignment_to_non_mutable_value         (* 59 *)
   | Unused_module of string                 (* 60 *)
   | Unboxable_type_in_prim_decl of string   (* 61 *)
+  | Pattern_matching_should_be_delimited    (* 62 *)
 ;;
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
@@ -152,9 +153,10 @@ let number = function
   | Assignment_to_non_mutable_value -> 59
   | Unused_module _ -> 60
   | Unboxable_type_in_prim_decl _ -> 61
+  | Pattern_matching_should_be_delimited -> 62
 ;;
 
-let last_warning_number = 60
+let last_warning_number = 62
 ;;
 
 (* Must be the max number returned by the [number] function. *)
@@ -483,6 +485,9 @@ let message = function
          unboxable. The representation of such types may change in future\n\
          versions. You should annotate the declaration of %s with [@@boxed]\n\
          or [@@unboxed]." t t
+  | Pattern_matching_should_be_delimited ->
+      "This nested pattern matching should be delimited \
+       with begin...end or (...)."
 ;;
 
 let nerrors = ref 0;;

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -271,7 +271,7 @@ let parse_options errflag s =
   current := {error; active}
 
 (* If you change these, don't forget to change them in man/ocamlc.m *)
-let defaults_w = "+a-4-6-7-9-27-29-32..39-41..42-44-45-48-50-60";;
+let defaults_w = "+a-4-6-7-9-27-29-32..39-41..42-44-45-48-50-60-62";;
 let defaults_warn_error = "-a+31";;
 
 let () = parse_options false defaults_w;;

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -77,6 +77,7 @@ type t =
   | Assignment_to_non_mutable_value         (* 59 *)
   | Unused_module of string                 (* 60 *)
   | Unboxable_type_in_prim_decl of string   (* 61 *)
+  | Pattern_matching_should_be_delimited    (* 62 *)
 ;;
 
 val parse_options : bool -> string -> unit;;


### PR DESCRIPTION
Follow up to #715 .

This is to address a common concern with OCaml syntax, namely the lack of a closing token for the pattern matching constructs.  We want to detect cases such as:

``` ocaml
  let f = function
     | A -> ...
     | B x ->
           match x with
           | A -> ...
           | B x -> ...
           | C -> ...
     | C -> ...
```

The compiler considers that the final clause belongs to the nested pattern matching while the intent of the programmer is that it should belong to the outermost one.  This situation can typically arise after moving pattern matching clauses, e.g. starting from the valid:

``` ocaml
  let f = function
     | A -> ...
     | C -> ...
     | B x ->
           match x with
           | A -> ...
           | B x -> ...
           | C -> ...
```

This PR adds a warning that would fire on the two cases above, telling the user that the inner pattern matching should be delimited (by parentheses or `begin...end`).  This is done by keeping in the Parsetree the info about which sub-expressions are delimited (using an attribute) and checking for nested pattern matchings by traversing the Parsetree before type-checking (reusing an existing traversal).

As discussed in #715, this could be complemented/combined with another criteria based on badly aligned patterns in a given pattern matching, which would also indicate a suspicious case.  This would be to really detect bad cases, while the current PR is more about encouraging a more robust style where nested pattern matching are explicitly delimited (even when not required because they are in the last clause of the surrounding pattern matching).
