### PR TITLE
Fix MPR7241: Pattern matching with mutable and lazy patterns is unsound

### DIFF
--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -136,17 +136,17 @@ let register_name r =
 
 let sym32 ?ofs s = mem_sym ?ofs DWORD (emit_symbol s)
 
-let reg = function
-  | { loc = Reg r } -> register_name r
-  | { loc = Stack(Incoming n | Outgoing n) } when n < 0 ->
+let reg r = match r.Reg.loc,r.Reg.typ with
+  | Reg r,_ -> register_name r
+  | Stack(Incoming n | Outgoing n),_ when n < 0 ->
       sym32 "caml_extra_params" ~ofs:(n + 64)
-  | { loc = Stack s; typ = Float } as r ->
+  | Stack s, Float ->
       let ofs = slot_offset s (register_class r) in
       mem32 REAL8 ofs RSP
-  | { loc = Stack s } as r ->
+  | Stack s,_ ->
       let ofs = slot_offset s (register_class r) in
       mem32 DWORD ofs RSP
-  | { loc = Unknown } ->
+  | Unknown,_ ->
       fatal_error "Emit_i386.reg"
 
 (* Output a reference to the lower 8 bits or lower 16 bits of a register *)

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -2707,19 +2707,11 @@ let arg_to_var arg cls = match arg with
   The main compilation function.
    Input:
       repr=used for inserting debug events
-      mut= true <=> some field in pattern is mutable and there is are
-        guard or lazy patterns
       partial=exhaustiveness information from Parmatch
       ctx=a context
       m=a pattern matching
 
    Output: a lambda term, a jump summary {..., exit number -> context, .. }
-*)
-
-(*
-  The "mut" argument is here to solve PR #7241. When mut is true
-  all context information is cancelled while returning jump sumaries.
-  Cf. the "mut" argument of ctx_combine, and ctx_rshift.
 *)
 
 let rec compile_match repr partial ctx m = match m with
@@ -2840,10 +2832,8 @@ and compile_no_test divide up_ctx repr partial ctx to_match =
    Notice that those sides effects can be performed at any moment
    'a priori' (multithreading, guards, lazy patterns, signal handlers...).
    So we sub-optimise in case of mutable patterns.
-
 LM:
    Lazy pattern was PR#5992, initial patch by lpw25.
-   I have  generalized the patch, so as to also find mutable fields.
 *)
 
 let find_in_pat pred =

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -2887,20 +2887,23 @@ let is_mutable p = find_in_pat have_mutable_field p
 *)
 
 let check_partial is_mutable is_lazy pat_act_list partial =
-  let mut =
-    List.exists (fun (pats, _) -> is_mutable pats) pat_act_list
-      &&
-    List.exists
-      (fun (pats, lam) -> is_guarded lam || is_lazy pats)
-      pat_act_list in
-  let partial = match partial with
-  | Partial -> Partial
-  | Total ->
-      if
-        mut
-      then Partial
-      else Total in
-  partial,mut
+  match pat_act_list with
+  | [] -> Partial,false (* Also partial, nothing mutable *)
+  | _::_ ->
+      let mut =
+        List.exists (fun (pats, _) -> is_mutable pats) pat_act_list
+          &&
+        List.exists
+          (fun (pats, lam) -> is_guarded lam || is_lazy pats)
+          pat_act_list in
+      let partial = match partial with
+      | Partial -> Partial
+      | Total ->
+          if
+            mut || (match pat_act_list with [] -> true | _::_ -> false)
+          then Partial
+          else Total in
+      partial,mut
 
 let check_partial_list =
   check_partial (List.exists is_mutable) (List.exists is_lazy)

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -2949,9 +2949,10 @@ let check_total warn loc total lambda i handler_fun =
   end
 
 (* Warn for "extra" match failure *)
-let check_warn partial pat_act_list = match partial,pat_act_list with
-| Total,_::_ -> true
-| _,_ -> false
+let check_warn no_opt partial pat_act_list =
+  match partial,pat_act_list,no_opt  with
+  | Total,_::_,true -> true
+  | _,_,_ -> false
 
 let compile_matching loc repr handler_fun arg pat_act_list partial0 =
   let partial,no_opt = check_partial pat_act_list partial0 in
@@ -2964,7 +2965,7 @@ let compile_matching loc repr handler_fun arg pat_act_list partial0 =
           default = [[[omega]],raise_num]} in
       begin try
         let (lambda, total) = compile_match no_opt repr partial (start_ctx 1) pm in
-        let warn = check_warn partial0 pat_act_list in
+        let warn = check_warn no_opt partial0 pat_act_list in
         check_total warn loc total lambda raise_num handler_fun
       with
       | Unused -> assert false (* ; handler_fun() *)
@@ -3145,7 +3146,7 @@ let for_tupled_function loc paraml pats_act_list partial0 =
   try
     let (lambda, total) = compile_match no_opt None partial
         (start_ctx (List.length paraml)) pm in
-    let warn = check_warn partial0 pats_act_list in
+    let warn = check_warn no_opt partial0 pats_act_list in
     check_total warn loc total lambda raise_num (partial_function loc)
   with
   | Unused -> partial_function loc ()
@@ -3253,7 +3254,7 @@ let do_for_multiple_match loc paraml pat_act_list partial0 =
       List.fold_right2 (bind Strict) idl paraml
         (match partial with
         | Partial ->
-            let warn = check_warn  partial0 pat_act_list in
+            let warn = check_warn no_opt partial0 pat_act_list in
             check_total warn loc total lam raise_num (partial_function loc)
         | Total ->
             assert (jumps_is_empty total) ;
@@ -3262,7 +3263,7 @@ let do_for_multiple_match loc paraml pat_act_list partial0 =
       let (lambda, total) = compile_match no_opt None partial (start_ctx 1) pm1 in
       begin match partial with
       | Partial ->
-          let warn = check_warn partial0 pat_act_list in
+          let warn = check_warn no_opt partial0 pat_act_list in
           check_total warn loc total lambda raise_num (partial_function loc)
       | Total ->
           assert (jumps_is_empty total) ;

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1659,7 +1659,7 @@ let make_record_matching no_opt loc all_labels def = function
           let str =
             match lbl.lbl_mut with
               Immutable -> Alias,mut
-            | Mutable -> StrictOpt,no_opt && true in
+            | Mutable -> StrictOpt,no_opt in
           (access, str) :: make_args(pos + 1)
         end in
       let nfields = Array.length all_labels in
@@ -2909,7 +2909,7 @@ let may_call p = find_in_pat may_call_pat p
    it will activate de-optimization of mutable accesses.
 *)
 
-let check_partial is_mutable may_call pat_act_list partial =
+let do_check_partial is_mutable may_call pat_act_list partial =
   match pat_act_list with
   | [] -> Partial,false (* Always partial *)
   | _::_ ->
@@ -2921,16 +2921,13 @@ let check_partial is_mutable may_call pat_act_list partial =
           pat_act_list in
       let partial = match partial with
       | Partial -> Partial
-      | Total ->
-          if
-            mut || (match pat_act_list with [] -> true | _::_ -> false)
-          then Partial
-          else Total in
+      | Total ->  if mut then Partial else Total in
       partial,mut
 
 let check_partial_list =
-  check_partial (List.exists is_mutable) (List.exists may_call)
-let check_partial = check_partial is_mutable may_call
+  do_check_partial (List.exists is_mutable) (List.exists may_call)
+
+let check_partial = do_check_partial is_mutable may_call
 
 (* have toplevel handler when appropriate *)
 

--- a/bytecomp/matching.mli
+++ b/bytecomp/matching.mli
@@ -23,10 +23,21 @@ open Lambda
 val for_function:
         Location.t -> int ref option -> lambda -> (pattern * lambda) list ->
         partial -> lambda
+
+(* By contrast with other entry points, for_trywith does not take
+   a Location.t value as first parameter. Namely, this location is
+   used only when PM compilation changes exhautivity from Total to Partial
+   The location is used at compile time for warning and at runtime,
+   as an argument to the Match_failure exception.
+
+   All this does not apply to try .. with .., as unmatched exceptions are
+   always re-raised silently. *)
+
 val for_trywith:
         lambda -> (pattern * lambda) list -> lambda
 val for_let:
         Location.t -> lambda -> pattern -> lambda -> lambda
+
 val for_multiple_match:
         Location.t -> lambda list -> (pattern * lambda) list -> partial ->
         lambda

--- a/testsuite/tests/basic/patmatch.compilers.reference
+++ b/testsuite/tests/basic/patmatch.compilers.reference
@@ -1,0 +1,8 @@
+File "patmatch.ml", line 113, characters 8-90:
+Warning 63: this pattern-matching operates on mutable data and may not be exhaustive.
+File "patmatch.ml", line 1886, characters 12-136:
+Warning 63: this pattern-matching operates on mutable data and may not be exhaustive.
+File "patmatch.ml", line 1894, characters 12-127:
+Warning 63: this pattern-matching operates on mutable data and may not be exhaustive.
+File "patmatch.ml", line 1902, characters 12-136:
+Warning 63: this pattern-matching operates on mutable data and may not be exhaustive.

--- a/testsuite/tests/basic/patmatch.ml
+++ b/testsuite/tests/basic/patmatch.ml
@@ -1874,3 +1874,39 @@ module MPR7761 = struct
     let () = printf "PR#7661-E=Ok\n%!"
   end
 end
+
+module PR7241 = struct
+
+  type u = {a: bool; mutable b: int option}
+
+  let tst f =
+    try  let _ = f {a=true; b=Some 5} in assert false
+    with Match_failure _ -> ()
+
+  let f x = match x with
+    {a=false} -> 0
+  | {b=None} -> 1
+  | {b=Some z}  when (x.b <- None; false) -> z
+  | {a=true; b=Some y} -> y
+
+  let () = tst f
+
+  let f x = match x with
+    {a=false} -> 0
+  | {b=None} -> 1
+  | _  when (x.b <- None; false) -> 2
+  | {a=true; b=Some y} -> y
+
+  let () = tst f
+
+  let f x = match x with
+    {a=false} -> 0
+  | {b=None} -> 1
+  | {b=Some 5}  when (x.b <- None; false) -> 2
+  | {a=true; b=Some y} -> y
+
+  let () = tst f
+
+  let () = printf "PR#7241=Ok\n%!"
+end
+

--- a/testsuite/tests/basic/patmatch.reference
+++ b/testsuite/tests/basic/patmatch.reference
@@ -151,3 +151,4 @@ g A Y X -> '_'
 f A Z Y -> '_'
 g A Z Y -> '_'
 PR#7661-E=Ok
+PR#7241=Ok

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -89,6 +89,7 @@ type t =
   | Unused_module of string                 (* 60 *)
   | Unboxable_type_in_prim_decl of string   (* 61 *)
   | Constraint_on_gadt                      (* 62 *)
+  | Partial_match_extra                     (* 63 *)
 ;;
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
@@ -160,9 +161,10 @@ let number = function
   | Unused_module _ -> 60
   | Unboxable_type_in_prim_decl _ -> 61
   | Constraint_on_gadt -> 62
+  | Partial_match_extra -> 63
 ;;
 
-let last_warning_number = 62
+let last_warning_number = 63
 ;;
 
 (* Must be the max number returned by the [number] function. *)
@@ -347,6 +349,8 @@ let message = function
   | Partial_match s ->
       "this pattern-matching is not exhaustive.\n\
        Here is an example of a case that is not matched:\n" ^ s
+  | Partial_match_extra ->
+      "this pattern-matching operates on mutable data and may not be exhaustive."
   | Non_closed_record_pattern s ->
       "the following labels are not bound in this record pattern:\n" ^ s ^
       "\nEither bind these labels explicitly or add '; _' to the pattern."
@@ -636,7 +640,8 @@ let descriptions =
    59, "Assignment to non-mutable value";
    60, "Unused module declaration";
    61, "Unboxable type in primitive declaration";
-   62, "Type constraint on GADT type declaration"
+   62, "Type constraint on GADT type declaration";
+   63, "Extra partial match, matching may fail when subject value is mutated";
   ]
 ;;
 

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -82,6 +82,7 @@ type t =
   | Unused_module of string                 (* 60 *)
   | Unboxable_type_in_prim_decl of string   (* 61 *)
   | Constraint_on_gadt                      (* 62 *)
+  | Partial_match_extra                     (* 63 *)
 ;;
 
 val parse_options : bool -> string -> unit;;


### PR DESCRIPTION
Correct [PR#7241](https://caml.inria.fr/mantis/view.php?id=7241) --- side effect in guard segfaults because of PM compiler assuming that subject value does not change.

Correction consists in avoiding remembering what was matched. More precisely the compiler "forgets" what it learned during matching. This is performed by the various "rshift" functions.

Correction applies when
1. Some pattern has a mutable field.
2. And there is a guard or a lazy pattern.

Caveats
  PM may now fail (with Match_failure) although no warning has been given (better than segfault),
  see example in test suite.
  Suboptimal, one may think confining the memory erasure to mutable subterms.