### PR TITLE
Update intf-c.etex

### DIFF
--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -879,7 +879,8 @@ All the macros described in this section are declared in the
 \begin{gcrule}
 A function that has parameters or local variables of type "value" must
 begin with a call to one of the "CAMLparam" macros and return with
-"CAMLreturn", "CAMLreturn0", or "CAMLreturnT".
+"CAMLreturn", "CAMLreturn0", or "CAMLreturnT".  In particular, CAMLlocal
+\emph{must} be bracketed by CAMLparam and CAMLreturn macros.
 \end{gcrule}
 
 There are six "CAMLparam" macros: "CAMLparam0" to "CAMLparam5", which


### PR DESCRIPTION
(re-posting from https://github.com/ocaml/ocaml-manual/pull/15)

Hey folks, CC @damiendoligez

Some of us have been hacking on the OCaml/C interface, and an unfortunate `CAMLlocal1(foo); CAMLparam1(bar);` (instead of `CAMLparam1(bar); CAMLlocal1(foo);`) led to a hard-to-trace segfault in the GC code. The valiant hero who debugged the code suggested the sentence (in the diff) be added to the manual. Any thoughts?

I'm happy to commit this myself on the svn repository if someone deems the addition worthwhile!

Ideally, there would be some macro trickery to generate a compiler error for these cases. Probably something like:

```
// in CAMLparam:
#ifdef CAML_AFTER_PARAM
#error "A call to CAMLparam was not followed by a call to CAMLreturn"
#define CAML_AFTER_PARAM
#endif

// in CAMLlocal
#ifndef CAML_AFTER_PARAM
#error "A call to CAMLlocal was not preceded by a call to CAMLparam
#endif

// in CAMLreturn
#ifndef CAML_AFTER_PARAM
#error "A call to CAMLreturn was not preceded by a call to CAMLparam"
#elif
#undef CAML_AFTER_PARAM
#endif
```

Not very classy, and not perfect, but might help. Comments welcome!

Cheers,

Jonathan
