### PR TITLE
Fix infinite unrolling bug, part 2

### DIFF
--- a/Changes
+++ b/Changes
@@ -247,6 +247,8 @@ OCaml 4.04.0:
 - GPR#713: Fix wrong code generation involving lazy values in Flambda mode
   (Mark Shinwell, review by Pierre Chambart and Alain Frisch)
 
+- GPR#721: Fix infinite loop in flambda due to [@@specialise] annotations
+
 ### Internal/compiler-libs changes:
 
 - PR#7200, GPR#539: Improve, fix, and add test for parsing/pprintast.ml

--- a/middle_end/inlining_decision.ml
+++ b/middle_end/inlining_decision.ml
@@ -362,12 +362,12 @@ let specialise env r ~lhs_of_application
        - has useful approximations for some invariant parameters. *)
     if !Clflags.classic_inlining then
       Don't_try_it S.Not_specialised.Classic_mode
+    else if self_call then
+      Don't_try_it S.Not_specialised.Self_call
     else if always_specialise && not (Lazy.force has_no_useful_approxes) then
       Try_it
     else if never_specialise then
       Don't_try_it S.Not_specialised.Annotation
-    else if self_call then
-      Don't_try_it S.Not_specialised.Self_call
     else if remaining_inlining_threshold = T.Never_inline then
       let threshold =
         match inlining_threshold with

--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -51,7 +51,7 @@ lexcmm.ml: lexcmm.mll
 MLCASES=optargs staticalloc bind_tuples is_static register_typing \
   register_typing_switch
 ARGS_is_static=-I $(OTOPDIR)/byterun is_in_static_data.c
-MLCASES_FLAMBDA=is_static_flambda unrolling_flambda
+MLCASES_FLAMBDA=is_static_flambda unrolling_flambda unrolling_flambda2
 ARGS_is_static_flambda=-I $(OTOPDIR)/byterun is_in_static_data.c is_static_flambda_dep.ml
 
 CASES=fib tak quicksort quicksort2 soli \

--- a/testsuite/tests/asmcomp/unrolling_flambda2.ml
+++ b/testsuite/tests/asmcomp/unrolling_flambda2.ml
@@ -1,0 +1,20 @@
+
+type t = { fn : t -> t -> int -> unit -> unit }
+
+let rec foo f b n x =
+  if n < 0 then ()
+  else begin
+    foo f b (n - 1) x;
+    b.fn f b (n - 1) x
+  end
+[@@specialise always]
+
+let rec bar f b n x =
+  if n < 0 then ()
+  else begin
+    bar f b (n - 1) x;
+    f.fn f b (n - 1) x
+  end
+[@@specialise always]
+
+let () = foo {fn = foo} {fn = bar} 10 ()


### PR DESCRIPTION
This PR fixes the same bug as #557 but for `[@specialise]` rather than `[@inline]`. It is not immediately obvious that the same situation can arise for `[@specialise]` but the included test demonstrates it by producing an infinite loop in the compiler before this patch.
