### PR TITLE
Add optional delimiters around match/try/function cases.

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1366,16 +1366,22 @@ expr:
       { mkexp_attrs (Pexp_letexception($4, $6)) $3 }
   | LET OPEN override_flag ext_attributes mod_longident IN seq_expr
       { mkexp_attrs (Pexp_open($3, mkrhs $5 5, $7)) $4 }
-  | FUNCTION ext_attributes opt_bar match_cases
-      { mkexp_attrs (Pexp_function(List.rev $4)) $2 }
   | FUN ext_attributes labeled_simple_pattern fun_def
       { let (l,o,p) = $3 in
         mkexp_attrs (Pexp_fun(l, o, p, $4)) $2 }
   | FUN ext_attributes LPAREN TYPE lident_list RPAREN fun_def
       { mkexp_attrs (mk_newtypes $5 $7).pexp_desc $2 }
-  | MATCH ext_attributes seq_expr WITH opt_bar match_cases
+  | FUNCTION ext_attributes match_cases
+      { mkexp_attrs (Pexp_function(List.rev $3)) $2 }
+  | FUNCTION ext_attributes LBRACKET match_cases RBRACKET
+      { mkexp_attrs (Pexp_function(List.rev $4)) $2 }
+  | MATCH ext_attributes seq_expr WITH match_cases
+      { mkexp_attrs (Pexp_match($3, List.rev $5)) $2 }
+  | MATCH ext_attributes seq_expr WITH LBRACKET match_cases RBRACKET
       { mkexp_attrs (Pexp_match($3, List.rev $6)) $2 }
-  | TRY ext_attributes seq_expr WITH opt_bar match_cases
+  | TRY ext_attributes seq_expr WITH match_cases
+      { mkexp_attrs (Pexp_try($3, List.rev $5)) $2 }
+  | TRY ext_attributes seq_expr WITH LBRACKET match_cases RBRACKET
       { mkexp_attrs (Pexp_try($3, List.rev $6)) $2 }
   | TRY ext_attributes seq_expr WITH error
       { syntax_error() }
@@ -1659,9 +1665,11 @@ strict_binding:
       { mk_newtypes $3 $5 }
 ;
 match_cases:
-    match_case { [$1] }
+        match_case { [$1] }
+  | BAR match_case { [$2] }
   | match_cases BAR match_case { $3 :: $1 }
 ;
+
 match_case:
     pattern MINUSGREATER seq_expr
       { Exp.case $1 $3 }


### PR DESCRIPTION
[Since there was some support for [this suggestion](https://github.com/ocaml/ocaml/pull/715#issuecomment-235288570) (thanks @alainfrisch, @gasche, @dbuenzli, @bobzhang!) under #715, I've opened a PR for further discussion.]

This PR adds optional delimiters around the cases in `try`, `match`, and `function` expressions.  As an alternative to the current syntax:

``` ocaml
match e with
  C₁ -> e₁
| C₂ -> e₂
```

this change gives you the option of writing your code like this:

``` ocaml
match e with
[ C₁ -> e₁
| C₂ -> e₂ ]
```
### What problem does this solve?

There is currently a kind of ambiguity in the syntax for nested matches.  In the following example, the case for `C₂` actually belongs to the inner `match`, despite the indentation: 

``` ocaml
match e with
  C₁ -> match e₁ with
            C₃ -> e₃
          | C₄ -> e₄
| C₂ -> e₂
```

Of course, this is not strictly an ambiguity in the grammar.  But it is a potential pitfall.  Fortunately, there is a straightforward workaround --- you can surround inner matches with `begin` and `end` or with parentheses:

``` ocaml
match e with
  C₁ -> begin match e₁ with
            C₃ -> e₃
          | C₄ -> e₄
        end
| C₂ -> e₂
```

But this is a little heavy, and suggests a shortcoming in the current syntax, since the delimiters go _around_ the `match` expression; they are not part of the expression itself.

With the new syntax the delimiters are part of the syntax of the expression, and the nested `match` may be written like this:

``` ocaml
match e with
[ C₁ -> match e₁ with
        [ C₃ -> e₃
        | C₄ -> e₄ ]
| C₂ -> e₂ ]
```

A warning along the lines of @alainfrisch's proposal in #716 for nested `match` expressions without delimiters would work well with this change as an additional help for avoiding the problem.
### What about the optional initial `|`?

Following @gasche's suggestion, this change supports an optional `|` before the first case:

``` ocaml
match e with [
 | C₁ -> e₁
 | C₂ -> e₂
]
```

This has the advantage of making the cases easier to edit, since there is no special initial case.
### What should the delimiters be?

This change currently uses brackets (`[` ... `]`) to delimit cases.  But the syntax would equally well support parentheses (`(` ... `)`) or even braces (`{` ... `}`). On balance I think the arguments are in favour of brackets.
#### Advantages of brackets
- Experience suggests that having a variety of delimiters (rather than using parentheses everywhere) makes code easier to read.  Some Lisp-family languages, such as Racket, support brackets as an alternative to parentheses for this reason.
- Parentheses are already used to enclose sub-expressions and sub-patterns in OCaml.  But a set of cases is not very much like either of these, since it can only be used as part of a larger construct, not in isolation.  So using different delimiters seems appropriate.
- There is already some experience with using brackets in the revised syntax.
- As @dbuenzli [points out](https://github.com/ocaml/ocaml/pull/715#issuecomment-235435688), brackets are reminiscent of the syntax for polymorphic variant types.
#### Advantages of alternative delimiters
- Parentheses have the advantage that `(|` is not a token, so there is no need for a space between `(` and the optional opening `|`.
- Braces are familiar from the `switch` statement in C-family languages, and from Reason.
