### PR TITLE
Sort emitted functions according to source location

### DIFF
--- a/Changes
+++ b/Changes
@@ -125,6 +125,9 @@ OCaml 4.04.0:
   and lazy
   (Alain Frisch, review by Pierre Chambart)
 
+- GPR#723 Sort emitted functions according to source location
+  (Pierre Chambart, review by Marc Shinwell)
+
 ### Tools:
 
 - MPR#7189: toplevel #show, follow chains of module aliases


### PR DESCRIPTION
Jane Street reported some unpredictable performance changes with flambda. It was supposed that it might be related to some locality problems. Effectively the order of function emission is basically random (based on the order of the hash of symbol names). This prevent such problems by fixing it to the order of the source definitions.

We probably want some feedback from Jane Street on this for the performance assessment, but this is already a win for cmm readability and diffability.
