### PR TITLE
MPR#7300: heap access in Win32 Unix.sleep

### DIFF
--- a/Changes
+++ b/Changes
@@ -306,6 +306,9 @@ OCaml 4.04.0:
 - PR#7299: remove access to OCaml heap inside blocking section in win32unix
   (David Allsopp, report by Andreas Hauptmann)
 
+- PR#7300: remove access to OCaml heap inside blocking in Unix.sleep on Windows
+  (David Allsopp)
+
 ### Internal/compiler-libs changes:
 
 - PR#7200, GPR#539: Improve, fix, and add test for parsing/pprintast.ml

--- a/otherlibs/win32unix/sleep.c
+++ b/otherlibs/win32unix/sleep.c
@@ -20,8 +20,9 @@
 CAMLprim value unix_sleep(t)
      value t;
 {
+  double d = Double_val(t);
   enter_blocking_section();
-  Sleep(Double_val(t) * 1e3);
+  Sleep(d * 1e3);
   leave_blocking_section();
   return Val_unit;
 }


### PR DESCRIPTION
OCaml heap accessed inside a blocking section.
