### PR TITLE
MPR#7299: heap access in Win32 Unix

### DIFF
--- a/Changes
+++ b/Changes
@@ -268,6 +268,9 @@ OCaml 4.04.0:
 
 - GPR#721: Fix infinite loop in flambda due to [@@specialise] annotations
 
+- PR#7299: remove access to OCaml heap inside blocking section in win32unix
+  (David Allsopp, report by Andreas Hauptmann)
+
 ### Internal/compiler-libs changes:
 
 - PR#7200, GPR#539: Improve, fix, and add test for parsing/pprintast.ml

--- a/otherlibs/win32unix/readlink.c
+++ b/otherlibs/win32unix/readlink.c
@@ -26,18 +26,22 @@ CAMLprim value unix_readlink(value opath)
   CAMLparam1(opath);
   CAMLlocal1(result);
   HANDLE h;
-  char* path = String_val(opath);
+  char* path;
   DWORD attributes;
+  caml_unix_check_path(opath, "readlink");
+  path = caml_strdup(String_val(opath));
 
   caml_enter_blocking_section();
   attributes = GetFileAttributes(path);
   caml_leave_blocking_section();
 
   if (attributes == INVALID_FILE_ATTRIBUTES) {
+    caml_stat_free(path);
     win32_maperr(GetLastError());
     uerror("readlink", opath);
   }
   else if (!(attributes & FILE_ATTRIBUTE_REPARSE_POINT)) {
+    caml_stat_free(path);
     errno = EINVAL;
     uerror("readlink", opath);
   }
@@ -51,6 +55,7 @@ CAMLprim value unix_readlink(value opath)
                         FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
                         NULL)) == INVALID_HANDLE_VALUE) {
       caml_leave_blocking_section();
+      caml_stat_free(path);
       errno = ENOENT;
       uerror("readlink", opath);
     }
@@ -58,6 +63,8 @@ CAMLprim value unix_readlink(value opath)
       char buffer[16384];
       DWORD read;
       REPARSE_DATA_BUFFER* point;
+
+      caml_stat_free(path);
 
       if (DeviceIoControl(h, FSCTL_GET_REPARSE_POINT, NULL, 0, buffer, 16384, &read, NULL)) {
         caml_leave_blocking_section();

--- a/otherlibs/win32unix/symlink.c
+++ b/otherlibs/win32unix/symlink.c
@@ -29,11 +29,15 @@ typedef BOOLEAN (WINAPI *LPFN_CREATESYMBOLICLINK) (LPTSTR, LPTSTR, DWORD);
 static LPFN_CREATESYMBOLICLINK pCreateSymbolicLink = NULL;
 static int no_symlink = 0;
 
-CAMLprim value unix_symlink(value to_dir, value source, value dest)
+CAMLprim value unix_symlink(value to_dir, value osource, value odest)
 {
-  CAMLparam3(to_dir, source, dest);
+  CAMLparam3(to_dir, osource, odest);
   DWORD flags = (Bool_val(to_dir) ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0);
   BOOLEAN result;
+  LPTSTR source;
+  LPTSTR dest;
+  caml_unix_check_path(osource, "symlink");
+  caml_unix_check_path(odest, "symlink");
 
 again:
   if (no_symlink) {
@@ -46,13 +50,20 @@ again:
     goto again;
   }
 
+  /* Copy source and dest outside the OCaml heap */
+  source = caml_strdup(String_val(osource));
+  dest = caml_strdup(String_val(odest));
+
   caml_enter_blocking_section();
-  result = pCreateSymbolicLink(String_val(dest), String_val(source), flags);
+  result = pCreateSymbolicLink(dest, source, flags);
   caml_leave_blocking_section();
+
+  caml_stat_free(source);
+  caml_stat_free(dest);
 
   if (!result) {
     win32_maperr(GetLastError());
-    uerror("symlink", dest);
+    uerror("symlink", odest);
   }
 
   CAMLreturn(Val_unit);
@@ -76,7 +87,7 @@ CAMLprim value unix_has_symlink(value unit)
 
       if (!GetTokenInformation(hProcess, TokenPrivileges, NULL, 0, &length)) {
         if (GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
-          TOKEN_PRIVILEGES* privileges = (TOKEN_PRIVILEGES*)malloc(length);
+          TOKEN_PRIVILEGES* privileges = (TOKEN_PRIVILEGES*)caml_stat_alloc(length);
           if (GetTokenInformation(hProcess,
                                   TokenPrivileges,
                                   privileges,
@@ -91,7 +102,7 @@ CAMLprim value unix_has_symlink(value unit)
             }
           }
 
-          free(privileges);
+          caml_stat_free(privileges);
         }
       }
     }


### PR DESCRIPTION
Copy strings outside the heap before entering blocking sections.
readlink, symlink and lstat were also missing caml_unix_check_path
validation calls.
