### PR TITLE
Add String/Bytes to/from char convenience methods

### DIFF
--- a/Changes
+++ b/Changes
@@ -87,6 +87,9 @@ OCaml 4.04.0:
 - GPR#669: Filename.extension and Filename.remove_extension
   (Alain Frisch, request by Edgar Aroutiounian, review by Daniel Bunzli
   and Damien Doligez)
+  
+- GPR#727: String.to_char_list, String.of_char_list, String.of_char
+  (Spencer williams)
 
 
 ### Code generation and optimizations:

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -255,6 +255,26 @@ let rcontains_from s i c =
   else
     try ignore (rindex_rec s i c); true with Not_found -> false
 
+let of_char c = make 1 c
+
+let split_at i s =
+    if i < 0 || i >= length s then
+        invalid_arg "String.split_at / Bytes.split_at"
+    else
+        ((sub s 0 i), (sub s i ((length s) - i)))
+
+let rec to_char_list s =
+    match length s with
+    | 0 -> []
+    | 1 -> [(get s 0)]
+    | _ -> 
+        let (first, rest) = split_at 1 s in
+        (get first 0) :: to_char_list rest
+
+let rec of_char_list = function
+    | [] -> empty
+    | next::rest -> cat (of_char next) (of_char_list rest)
+
 
 type t = bytes
 

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -232,6 +232,22 @@ val rcontains_from : bytes -> int -> char -> bool
     Raise [Invalid_argument] if [stop < 0] or [stop+1] is not a valid
     position in [s]. *)
 
+val of_char : char -> bytes
+(** [of_char c] creates a byte sequence of length 1 containing the char [c] *)
+
+val split_at : int -> bytes -> (bytes * bytes)
+(** [split_at index s] returns a pair of the substring of [s] up to the index 
+    [i], and the substring from index [i] to the end of the string.
+
+    Raise [Invalid_argument] if [i] is not a valid position in [s]. *)
+
+val to_char_list : bytes -> char list
+(** [to_char_list s] returns a list of the characters in [s] *)
+
+val of_char_list : char list -> bytes
+(** [of_char_list c] returns a byte sequence comprised of the characters in [c] 
+    or an empty byte sequence if [c] is empty *)
+
 val uppercase : bytes -> bytes
   [@@ocaml.deprecated "Use Bytes.uppercase_ascii instead."]
 (** Return a copy of the argument, with all lowercase letters

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -113,6 +113,15 @@ let contains_from s i c =
 let rcontains_from s i c =
   B.rcontains_from (bos s) i c
 
+let of_char c = 
+  B.of_char c |> bts
+let split_at i s =
+  (B.split_at i (bos s)) |> (fun (a, b) -> ((bts a), (bts b)))
+let to_char_list s =
+  B.to_char_list (bos s)
+let of_char_list c =
+  B.of_char_list c |> bts
+
 let uppercase_ascii s =
   B.uppercase_ascii (bos s) |> bts
 let lowercase_ascii s =

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -223,6 +223,22 @@ val rcontains_from : string -> int -> char -> bool
    Raise [Invalid_argument] if [stop < 0] or [stop+1] is not a valid
    position in [s]. *)
 
+val of_char : char -> string
+(** [of_char c] creates a string of length 1 containing the char [c] *)
+
+val split_at : int -> string -> (string * string)
+(** [split_at index s] returns a pair of the substring of [s] up to the index 
+    [i], and the substring from index [i] to the end of the string.
+
+    Raise [Invalid_argument] if [i] is not a valid position in [s]. *)
+
+val to_char_list : string -> char list
+(** [to_char_list s] returns a list of the characters in [s] *)
+
+val of_char_list : char list -> string
+(** [of_char_list c] returns a string comprised of the characters in [c] or an
+    empty byte sequence if [c] is empty *)
+
 val uppercase : string -> string
   [@@ocaml.deprecated "Use String.uppercase_ascii instead."]
 (** Return a copy of the argument, with all lowercase letters

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -36,3 +36,8 @@ let () =
     check_split ' ' (String.sub s 0 i)
   done
 ;;
+
+assert ((String.of_char 'a') = "a");;
+assert ((String.split_at 1 "test") = ("t", "est"));;
+assert ((String.to_char_list "test") = ['t';'e';'s';'t']);;
+assert ((String.of_char_list ['t';'e';'s';'t']) = "test");;


### PR DESCRIPTION
I find it's useful at times to be able to destructure and pattern-match strings by converting them to char-lists and then converting them back.

I've written `of_char_list` and `to_char_list` countless times since I don't always want to pull in all of Core or Batteries just for these two functions (both implement it under different names). `of_char` is a related convenience method that I've written often in similar cases, though it could be dropped in favor of just using `of_char_list` with a single-element list.

I've also added `String.split_at index s`, mostly in service of writing `String.to_char_list`. I'm not 100% sold on its general-purpose utility outside of that, although I could see cases like stripping prefixes off of things like URLs with known protocols.

```
String.of_char 'a' = "a"
String.of_char_list ['a';'b';'c'] = "abc"
String.to_char_list "abc" = ['a';'b';'c']
```
