### PR TITLE
Fix parameter invariance analysis (MPR#7291)

### DIFF
--- a/middle_end/invariant_params.ml
+++ b/middle_end/invariant_params.ml
@@ -137,7 +137,7 @@ let function_variable_alias
   in
   let fun_var_bindings = ref Variable.Map.empty in
   Variable.Map.iter (fun _ ( function_decl : Flambda.function_declaration ) ->
-      Flambda_iterators.iter_all_immutable_let_and_let_rec_bindings
+      Flambda_iterators.iter_all_toplevel_immutable_let_and_let_rec_bindings
         ~f:(fun var named ->
            (* CR-soon mshinwell: consider having the body passed to this
               function and using fv calculation instead of used_variables.


### PR DESCRIPTION
The Flambda analysis as to which parameters of recursive functions are invariant appears to be broken in the presence of recursive calls under subfunctions.  I'm not sure why we didn't spot this earlier.

The example from MPR#7291 fails due to this problem.  In that case the parameter `subst` of the following function is being marked as invariant, which is wrong:

```
  let rec term_to_tptp subst (t:term) : T.term = match t with
    | App (id, l) ->
      let fail _ = Conv.failf "no variable allowed in sub-term under %s" id in
      T.app (get_or_create_id id) (List.map (term_to_tptp fail) l)
    | Var v -> subst v
    | True -> T.true_
    | False -> T.false_
    | _ -> Conv.failf "cannot convert `@[%a@]` to term" pp_term t
```

I think this patch fixes the problem; MPR#7291 seems to build ok now.  It keeps track of the free variables mapping as it descends under lambdas, meaning that it can correctly identify variables that actually refer to one of the recursive functions being examined.  There is some trickiness as regards variables that might be aliases to function symbols, as usual: I added an assertion in one place and a comment in another to try to clarify this.

At the moment, the resulting analysis is over-conservative: if there is a recursive call found from a subfunction then the corresponding parameter is deemed to have "any" value flowing to it.  I think this probably suffices for the moment.

We should probably try to get this into 4.04.
