### PR TITLE
Improve consistency of backtraces between flambda and non-flambda modes

### DIFF
--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -154,14 +154,15 @@ let emit_frames a =
     a.efa_data_label (label_debuginfos rs rdbg)
   in
   let emit_frame fd =
+    let fd_debuginfo = Debuginfo.filter_tail_calls fd.fd_debuginfo in
     a.efa_code_label fd.fd_lbl;
-    a.efa_16 (if Debuginfo.is_none fd.fd_debuginfo
+    a.efa_16 (if Debuginfo.is_none fd_debuginfo
               then fd.fd_frame_size
               else fd.fd_frame_size + 1);
     a.efa_16 (List.length fd.fd_live_offset);
     List.iter a.efa_16 fd.fd_live_offset;
     a.efa_align Arch.size_addr;
-    match List.rev fd.fd_debuginfo with
+    match List.rev fd_debuginfo with
     | [] -> ()
     | _ :: _ as rdbg -> emit_debuginfo_label fd.fd_raise rdbg
   in

--- a/byterun/backtrace.c
+++ b/byterun/backtrace.c
@@ -73,7 +73,6 @@ CAMLprim value caml_backtrace_status(value vunit)
 static void print_location(struct caml_loc_info * li, int index)
 {
   char * info;
-  char * inlined;
 
   /* Ignore compiler-inserted raise */
   if (!li->loc_valid && li->loc_is_raise) return;
@@ -90,16 +89,11 @@ static void print_location(struct caml_loc_info * li, int index)
     else
       info = "Called from";
   }
-  if (li->loc_is_inlined) {
-    inlined = " (inlined)";
-  } else {
-    inlined = "";
-  }
   if (! li->loc_valid) {
-    fprintf(stderr, "%s unknown location%s\n", info, inlined);
+    fprintf(stderr, "%s unknown location\n", info);
   } else {
-    fprintf (stderr, "%s file \"%s\"%s, line %d, characters %d-%d\n",
-             info, li->loc_filename, inlined, li->loc_lnum,
+    fprintf (stderr, "%s file \"%s\", line %d, characters %d-%d\n",
+             info, li->loc_filename, li->loc_lnum,
              li->loc_startchr, li->loc_endchr);
   }
 }

--- a/middle_end/debuginfo.ml
+++ b/middle_end/debuginfo.ml
@@ -21,6 +21,7 @@ type item = {
   dinfo_line: int;
   dinfo_char_start: int;
   dinfo_char_end: int;
+  dinfo_is_tail_call: bool;
 }
 
 type t = item list
@@ -52,6 +53,7 @@ let item_from_location loc =
       if loc.loc_end.pos_fname = loc.loc_start.pos_fname
       then loc.loc_end.pos_cnum - loc.loc_start.pos_bol
       else loc.loc_start.pos_cnum - loc.loc_start.pos_bol;
+    dinfo_is_tail_call = false;
   }
 
 let from_location loc =
@@ -72,6 +74,12 @@ let to_location = function
 let inline loc t =
   if loc == Location.none then t
   else (item_from_location loc) :: t
+
+let mark_as_tail_call t =
+  List.map (fun item -> { item with dinfo_is_tail_call = true; }) t
+
+let filter_tail_calls t =
+  List.filter (fun item -> not item.dinfo_is_tail_call) t
 
 let concat dbg1 dbg2 =
   dbg1 @ dbg2

--- a/middle_end/debuginfo.mli
+++ b/middle_end/debuginfo.mli
@@ -17,7 +17,8 @@ type item = private {
   dinfo_file: string;
   dinfo_line: int;
   dinfo_char_start: int;
-  dinfo_char_end: int
+  dinfo_char_end: int;
+  dinfo_is_tail_call: bool;
 }
 
 type t = item list
@@ -33,6 +34,10 @@ val from_location : Location.t -> t
 val to_location : t -> Location.t
 
 val concat: t -> t -> t
+
+val mark_as_tail_call : t -> t
+
+val filter_tail_calls : t -> t
 
 val inline: Location.t -> t -> t
 

--- a/middle_end/inline_and_simplify.ml
+++ b/middle_end/inline_and_simplify.ml
@@ -672,10 +672,7 @@ and simplify_apply env r ~(apply : Flambda.apply) : Flambda.t * R.t =
     Flambda. func = lhs_of_application; args; kind = _; dbg;
     inline = inline_requested; specialise = specialise_requested;
   } = apply in
-  let dbg =
-    if E.in_tail_position env then dbg
-    else E.add_inlined_debuginfo env ~dbg
-  in
+  let dbg = E.add_inlined_debuginfo env ~dbg in
   simplify_free_variable env lhs_of_application
     ~f:(fun env lhs_of_application lhs_of_application_approx ->
       simplify_free_variables env args ~f:(fun env args args_approxs ->

--- a/middle_end/inline_and_simplify_aux.mli
+++ b/middle_end/inline_and_simplify_aux.mli
@@ -125,7 +125,9 @@ module Env : sig
       from the given environment.  However, the freshening activation state
       is preserved.  This function is used when rewriting inside a function
       declaration, to avoid (due to a compiler bug) accidental use of
-      variables from outer scopes that are not accessible. *)
+      variables from outer scopes that are not accessible.
+      This function resets the "in tail position" flag to [true].
+  *)
   val local : t -> t
 
   (** Note that the inliner is descending into a function body from the given
@@ -266,6 +268,14 @@ module Env : sig
 
   (** Appends the locations of inlined call-sites to the [~dbg] argument *)
   val add_inlined_debuginfo : t -> dbg:Debuginfo.t -> Debuginfo.t
+
+  (** Returns [true] if the environment corresponds syntactically to tail
+      position. *)
+  val in_tail_position : t -> bool
+
+  (** Note that the current environment no longer corresponds to tail
+      position. *)
+  val set_not_in_tail_position : t -> t
 end
 
 module Result : sig

--- a/middle_end/inlining_transforms.ml
+++ b/middle_end/inlining_transforms.ml
@@ -174,7 +174,10 @@ let inline_by_copying_function_body ~env ~r
       bindings_for_vars_bound_by_closure_and_params_to_args
   in
   let env = E.activate_freshening (E.set_never_inline env) in
-  let env = E.set_inline_debuginfo ~dbg env in
+  let env =
+    if E.in_tail_position env then env
+    else E.set_inline_debuginfo ~dbg env
+  in
   simplify env r expr
 
 let inline_by_copying_function_declaration ~env ~r

--- a/middle_end/inlining_transforms.ml
+++ b/middle_end/inlining_transforms.ml
@@ -174,10 +174,13 @@ let inline_by_copying_function_body ~env ~r
       bindings_for_vars_bound_by_closure_and_params_to_args
   in
   let env = E.activate_freshening (E.set_never_inline env) in
-  let env =
-    if E.in_tail_position env then env
-    else E.set_inline_debuginfo ~dbg env
+  let dbg =
+    if E.in_tail_position env then
+      Debuginfo.mark_as_tail_call dbg
+    else
+      dbg
   in
+  let env = E.set_inline_debuginfo ~dbg env in
   simplify env r expr
 
 let inline_by_copying_function_declaration ~env ~r

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -132,9 +132,8 @@ let format_backtrace_slot pos slot =
       else
         Some (sprintf "%s unknown location" (info false))
   | Known_location l ->
-      Some (sprintf "%s file \"%s\"%s, line %d, characters %d-%d"
+      Some (sprintf "%s file \"%s\", line %d, characters %d-%d"
               (info l.is_raise) l.filename
-              (if l.is_inline then " (inlined)" else "")
               l.line_number l.start_char l.end_char)
 
 let print_exception_backtrace outchan backtrace =


### PR DESCRIPTION
Backtraces on 4.04 are currently rather inconsistent between flambda and non-flambda modes.  This causes a significant amount of trouble when using expect-tests or similar to check the output of programs.

It is proposed (after discussion with @let-def who wrote the inlined frames support) in this pull request to do the following:
1. Remove the "(inlined)" annotations on printed backtraces.  This should remove a significant source of inconsistency.  The annotations don't seem that useful: in particular, if people want to debug the inliner, they should use the inlining reports instead.
2. Stop adding inlined frames for function calls that are syntactically in tail-position during the middle end.  This subtlety is probably the cause of rather a lot of inconsistency (of a particularly problematic nature since it actually changes the number of frames in the backtrace): flambda is far more likely to inline such calls.  Not having frames for tail calls should match up with general expectations about backtraces.

This probably won't remove all of the inconsistencies, but should bring things significantly closer together than they are now.

This is work in progress, although should be finished soon.  @let-def is going to contribute the equivalent code for `Closure`.
