### PR TITLE
Improve variable names in Flambda

### DIFF
--- a/middle_end/closure_conversion.ml
+++ b/middle_end/closure_conversion.ml
@@ -122,6 +122,14 @@ let rec eliminate_const_block (const : Lambda.structured_constant)
   | Const_immstring _
   | Const_float_array _ -> Lconst const
 
+let name_expr_with_bound_name bound_name named ~name =
+  match bound_name with
+  | None ->
+      name_expr named ~name
+  | Some bound_name ->
+  let var = Variable.rename bound_name in
+  Flambda.create_let var named (Var var)
+
 let rec close_const t env (const : Lambda.structured_constant)
       : Flambda.named * string =
   match const with
@@ -144,7 +152,8 @@ let rec close_const t env (const : Lambda.structured_constant)
   | Const_block _ ->
     Expr (close t env (eliminate_const_block const)), "const_block"
 
-and close t env (lam : Lambda.lambda) : Flambda.t =
+and close t ?(bound_name:Variable.t option) env (lam : Lambda.lambda)
+      : Flambda.t =
   match lam with
   | Lvar id ->
     begin match Env.find_var_exn env id with
@@ -165,7 +174,7 @@ and close t env (lam : Lambda.lambda) : Flambda.t =
     let defining_expr =
       close_let_bound_expression t var env defining_expr
     in
-    let body = close t (Env.add_var env id var) body in
+    let body = close t (Env.add_var env id var) ?bound_name body in
     Flambda.create_let var defining_expr body
   | Llet (Variable, block_kind, id, defining_expr, body) ->
     let mut_var = Mutable_variable.of_ident id in
@@ -173,7 +182,7 @@ and close t env (lam : Lambda.lambda) : Flambda.t =
     let defining_expr =
       close_let_bound_expression t var env defining_expr
     in
-    let body = close t (Env.add_mutable_var env id mut_var) body in
+    let body = close t (Env.add_mutable_var env id mut_var) ?bound_name body in
     Flambda.create_let var defining_expr
       (Let_mutable
          { var = mut_var;
@@ -289,7 +298,7 @@ and close t env (lam : Lambda.lambda) : Flambda.t =
                 closure_id = Closure_id.wrap closure_bound_var;
               })
               body))
-          (close t env body) function_declarations
+          (close t env ?bound_name body) function_declarations
       in
       Flambda.create_let set_of_closures_var set_of_closures body
     | None ->
@@ -302,7 +311,7 @@ and close t env (lam : Lambda.lambda) : Flambda.t =
             var, close_let_bound_expression t ~let_rec_ident:id var env def)
           defs
       in
-      Let_rec (defs, close t env body)
+      Let_rec (defs, close t env ?bound_name body)
     end
   | Lsend (kind, meth, obj, args, loc) ->
     let meth_var = Variable.create "meth" in
@@ -345,7 +354,7 @@ and close t env (lam : Lambda.lambda) : Flambda.t =
                      are suitable. I had to add a new one for a similar
                      case in the array data types work.
                      mshinwell: deferred CR *)
-                  name_expr ~name:"result"
+                  name_expr_with_bound_name bound_name ~name:"result"
                     (Prim (prim, [numerator; denominator], dbg))))))))
   | Lprim ((Pdivint | Pmodint), _, _) when not !Clflags.fast ->
     Misc.fatal_error "Pdivint / Pmodint must have exactly two arguments"
@@ -419,7 +428,7 @@ and close t env (lam : Lambda.lambda) : Flambda.t =
       ~evaluation_order:`Right_to_left
       ~name:(name ^ "_arg")
       ~create_body:(fun args ->
-        name_expr (Prim (p, args, dbg))
+        name_expr_with_bound_name bound_name (Prim (p, args, dbg))
           ~name)
   | Lswitch (arg, sw) ->
     let scrutinee = Variable.create "switch" in
@@ -529,7 +538,8 @@ and close_functions t external_env function_declarations : Flambda.named =
     in
     let params = List.map (Env.find_var closure_env) params in
     let closure_bound_var = Function_decl.closure_bound_var decl in
-    let body = close t closure_env body in
+    let bound_name = Variable.rename ~append:"_return" closure_bound_var in
+    let body = close t ~bound_name closure_env body in
     let fun_decl =
       Flambda.create_function_declaration ~params ~body ~stub ~dbg
         ~inline:(Function_decl.inline decl)
@@ -603,7 +613,8 @@ and close_let_bound_expression t ?let_rec_ident let_bound_var env
     Expr (Flambda.create_let set_of_closures_var set_of_closures
       (name_expr (Project_closure (project_closure))
         ~name:(Variable.unique_name let_bound_var)))
-  | lam -> Expr (close t env lam)
+  | lam ->
+    Expr (close t ~bound_name:let_bound_var env lam)
 
 let lambda_to_flambda ~backend ~module_ident ~size ~filename lam
       : Flambda.program =
@@ -644,7 +655,7 @@ let lambda_to_flambda ~backend ~module_ident ~size ~filename lam
     Initialize_symbol (
       block_symbol,
       Tag.create_exn 0,
-      [close t Env.empty lam],
+      [close t ~bound_name:(Variable.create "toplevel_module") Env.empty lam],
       Initialize_symbol (
         module_symbol,
         Tag.create_exn 0,

--- a/testsuite/tests/warnings/w55.opt_backend.flambda.opt_reference
+++ b/testsuite/tests/warnings/w55.opt_backend.flambda.opt_reference
@@ -1,6 +1,6 @@
 File "w55.opt_backend.ml", line 12, characters 10-26:
 Warning 55: Cannot inline: [@inlined] attributes may not be used on partial applications
-File "w55.opt_backend.ml", line 8, characters 10-27:
-Warning 55: Cannot inline: [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)
 File "w55.opt_backend.ml", line 18, characters 12-30:
+Warning 55: Cannot inline: [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)
+File "w55.opt_backend.ml", line 8, characters 10-27:
 Warning 55: Cannot inline: [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)


### PR DESCRIPTION
The output of `-dflambda` can be quite confusing. This improves the output by trying to keep the original variable names longer:

```
let r = ref 0
```

without:

```
initialize_symbol
  (Example.camlExample__Pmakeblock_14 0
     (let
       (Pmakeblock_arg/15 Const(33)
        Pmakeblock/13 (makemutable 0 (int)<{example.ml:20,8-14}> Pmakeblock_arg/15))
       Pmakeblock/13))
initialize_symbol
  (Example.camlExample 0
     (let (block_symbol_get_field_0/2 Example.camlExample__Pmakeblock_14.(0))
       block_symbol_get_field_0/2))
End Example.camlExample
```

with:

```
initialize_symbol
  (Example.camlExample__r_14 0
     (let
       (Pmakeblock_arg/15 Const(33)
        r/13 (makemutable 0 (int)<{example.ml:20,8-14}> Pmakeblock_arg/15))
       r/13))
initialize_symbol
  (Example.camlExample 0
     (let (block_symbol_get_field_0/2 Example.camlExample__r_14.(0))
       block_symbol_get_field_0/2))
End Example.camlExample
```
