### PR TITLE
Cmti files: fix duplicate self-reference in imported cmi_crcs list.

### DIFF
--- a/typing/cmt_format.ml
+++ b/typing/cmt_format.ml
@@ -182,7 +182,7 @@ let save_cmt filename modname binary_annots sourcefile initial_env sg =
             cmi_name = modname;
             cmi_sign = sg;
             cmi_flags = flags;
-            cmi_crcs = imports;
+            cmi_crcs = List.filter (fun (n, _) -> n <> modname) imports;
           } in
           Some (output_cmi filename oc cmi)
     in


### PR DESCRIPTION
Currently cmti files store the reference to their own cmi twice in the cmi_crcs list: 

```
> ocamlobjinfo $(opam config var lib)/ocaml/list.cmti
File /Users/dbuenzli/.opam/4.03.0/lib/ocaml/list.cmti
Unit name: List
Interfaces imported:
    ac5f6095cc0a546330ada0df0986a497    List
    999b28e3b7638771c87eebf5a8325e42    Pervasives
    ac5f6095cc0a546330ada0df0986a497    List
    9642e3ed163e46770985ca668738ed5f    CamlinternalFormatBasics
[...]
```

The reason is that the `cmi_crcs` are [written](https://github.com/ocaml/ocaml/blob/93425101e4a97ee891e61fe63ccd0b260668a527/typing/cmt_format.ml#L185) with an `imports` value that already contains the crc for the module. However the `output_cmi` function [assumes](https://github.com/ocaml/ocaml/blob/93425101e4a97ee891e61fe63ccd0b260668a527/typing/cmi_format.ml#L82) `cmi_crcs` doesn't contain the crc for the module itself.

This patch simply remove the crc of the module from `imports` to define the `cmi_crcs` field to output:

```
> _install/bin/ocamlobjinfo stdlib/list.cmti
File stdlib/list.cmti
Unit name: List
Interfaces imported:
    cd293869f2923980325b5f3354992c2d    List
    eef96f967b03d53aceb35ab9ee61e6fc    Pervasives
    cbd5f2d6b649925222e1e9fb63b89db6    CamlinternalFormatBasics
[...]
```
