### PR TITLE
rearrange application args to respect the definition

### DIFF
--- a/manual/manual/cmds/flambda.etex
+++ b/manual/manual/cmds/flambda.etex
@@ -983,7 +983,7 @@ let f x =
     | [] -> 4
     | y::ys -> y - loop' ys inv_0 inv_1
   in
-  Printf.printf "%d\n" (loop' (x + 42) (x + 43) [1; 2; 3])
+  Printf.printf "%d\n" (loop' [1; 2; 3] (x + 42) (x + 43))
 \end{verbatim}
 The allocation of the pair within {\tt f} has been removed.  (Since the
 two closures for {\tt loop'} and {\tt loop2'} are constant they will also be


### PR DESCRIPTION
See mantis id 7322. For reference, the problem is that `loop'` is supposed to take a list as its first arg.

```
let f x =
  let rec loop' xs inv_0 inv_1 =
    match xs with
    | [] -> inv_0 + inv_1
    | x::xs -> x + loop2' xs inv_0 inv_1
  and loop2' ys inv_0 inv_1 =
    match ys with
    | [] -> 4
    | y::ys -> y - loop' ys inv_0 inv_1
  in
  Printf.printf "%d\n" (loop' (x + 42) (x + 43) [1; 2; 3])
```
