### PR TITLE
[WIP] Implement responsefiles support PR7050

### DIFF
--- a/driver/main.ml
+++ b/driver/main.ml
@@ -178,7 +178,8 @@ end)
 let main () =
   try
     readenv ppf Before_args;
-    Arg.parse Options.list anonymous usage;
+    let args = Arg.expandargv Sys.argv in
+    Arg.parse_argv args Options.list anonymous usage;
     if !output_name <> None && !compile_only &&
           List.length !process_thunks > 1 then
       fatal "Options -c -o are incompatible with compiling multiple files";

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -159,3 +159,16 @@ val current : int ref
     {!Arg.parse} uses the initial value of {!Arg.current} as the index of
     argument 0 (the program name) and starts parsing arguments
     at the next element. *)
+
+val expandargv : string array -> string array
+(** [Arg.expandargv argv] looks for arguments that begin with the character
+    @ and interpretes them as response files. The contents of the response
+    file are interpreted as additional command line options. Options in
+    repsonsefiles are separated by whitespace. A whitespace character may be
+    included in an option by surrounding the entier option in either single or
+    double quotes. Any character may be included by prefixing the character to
+    be included with a backslash. *)
+
+val writeargv : string array -> string -> unit
+(** [Arg.writeargv argv file] writes each member of argv in file handling
+    quoting compatible to [Arg.expandargv] separated by whitespaces *)

--- a/testsuite/tests/lib-arg/argv
+++ b/testsuite/tests/lib-arg/argv
@@ -1,0 +1,2 @@
+test1 "white space" 'white space' "double\" quote" "new
+line" "tab	ulator" @argv2

--- a/testsuite/tests/lib-arg/argv2
+++ b/testsuite/tests/lib-arg/argv2
@@ -1,0 +1,1 @@
+testargv2

--- a/testsuite/tests/lib-arg/testarg.ml
+++ b/testsuite/tests/lib-arg/testarg.ml
@@ -119,5 +119,79 @@ let test argv =
   check r_float 2.72 "Set_float";
 ;;
 
+let check r v msg = if r <> v then error msg;;
+
+let test_expand argv eargv =
+  let argv = Arg.expandargv argv in
+  let size = Array.length argv
+  and esize = Array.length eargv in
+  let msg = Printf.sprintf "expandargv lenght %d %d" size esize in
+  check size esize msg;
+  let msg a b= Printf.sprintf "expandargv options: found:%s expected:%s" a b in
+  Array.iter2 (fun a b -> check a b (msg a b)) argv eargv;
+;;
+
 test args1;;
 test args2;;
+
+test_expand args1 args1;;
+test_expand args2 args2;;
+
+let args3 =
+  [|"prog";
+    "anon1";
+    "-u";
+    "-b=true";
+    "-s";
+    "anon2";
+    "-c";
+    "-str=foo";
+    "-sstr=bar";
+    "-i=19";
+    "-si=42";
+    "-f=3.14";
+    "-sf=2.72";
+    "anon3";
+    "-t"; "false"; "gee"; "1436";
+    "-sym=c";
+    "anon4";
+    "-rest"; "r1"; "r2";
+    "@non-exist";|]
+;;
+
+test_expand args3 args3;;
+
+let args4 =
+  [|"test1";
+    "white space";
+    "white space";
+    "double\" quote";
+    "new\nline";
+    "tab\tulator";
+    "testargv2";|];;
+
+test_expand [|"@argv"|] args4;;
+
+let safe_remove f =
+  try Sys.remove f with _ -> ();
+;;
+
+let test_writeargv argv f =
+  safe_remove f;
+  Arg.writeargv argv f;
+  test_expand [|"@"^f|] argv;
+  safe_remove f;
+;;
+
+let args5 =
+  [| "white space";
+     "new\nline";
+     "tab\tulator";
+     "vertical\012line feed"
+   |];;
+
+test_writeargv args1 "args1";;
+test_writeargv args2 "args2";;
+test_writeargv args3 "args3";;
+test_writeargv args4 "args4";;
+test_writeargv args5 "args5";;


### PR DESCRIPTION
This is a first implementation of support for giving arguments via response file as `@file`. The quoting conventions are the ones of the gnu tools. The implementation itself is a variation of the patch attached to the original mantis issue [http://caml.inria.fr/mantis/view.php?id=7050](mantis). 
The functionality is implemented via two new functions in the Arg module.
