### PR TITLE
MPR#7323 fix ocamllex -ml, works with -safe-string option

### DIFF
--- a/Changes
+++ b/Changes
@@ -162,6 +162,9 @@ OCaml 4.04.0:
 
 ### Tools:
 
+- MPR#7323: ocamllex -ml work with (-safe-string)
+  (Hongbo Zhang)
+  
 - MPR#7189: toplevel #show, follow chains of module aliases
   (Gabriel Scherer, report by Daniel Bünzli, review by Thomas Refis)
 

--- a/lex/outputbis.ml
+++ b/lex/outputbis.ml
@@ -44,7 +44,7 @@ let output_auto_defs oc has_refill =
 \n    end\
 \n  end else begin\
 \n    let i = lexbuf.Lexing.lex_curr_pos in\
-\n    let c = lexbuf.Lexing.lex_buffer.[i] in\
+\n    let c = Bytes.get lexbuf.Lexing.lex_buffer i in\
 \n    lexbuf.Lexing.lex_curr_pos <- i+1 ;\
 \n    state lexbuf k (Char.code c)\
 \n  end\
@@ -61,7 +61,7 @@ let output_auto_defs oc has_refill =
 \n    end\
 \n  end else begin\
 \n    let i = lexbuf.Lexing.lex_curr_pos in\
-\n    let c = lexbuf.Lexing.lex_buffer.[i] in\
+\n    let c = Bytes.get lexbuf.Lexing.lex_buffer i in\
 \n    lexbuf.Lexing.lex_curr_pos <- i+1 ;\
 \n    Char.code c\
 \n  end\


### PR DESCRIPTION
It is a low-risk fix, would be nice to get this into OCaml 4.04 (CC @gasche , @damiendoligez )
