### PR TITLE
Add Int8 and Int16 modules to Numbers

### DIFF
--- a/utils/numbers.ml
+++ b/utils/numbers.ml
@@ -33,6 +33,39 @@ module Int = struct
     if n < 0 then Set.empty else Set.add n (zero_to_n (n-1))
 end
 
+module Int8 = struct
+  type t = int
+
+  let zero = 0
+  let one = 1
+
+  let of_int_exn i =
+    if i < -(1 lsl 8) || i > ((1 lsl 8) - 1) then
+      Misc.fatal_errorf "Int8.of_int_exn: %d is out of range" i
+    else
+      i
+
+  let to_int i = i
+end
+
+module Int16 = struct
+  type t = int
+
+  let of_int_exn i =
+    if i < -(1 lsl 16) || i > ((1 lsl 16) - 1) then
+      Misc.fatal_errorf "Int16.of_int_exn: %d is out of range" i
+    else
+      i
+
+  let of_int64_exn i =
+    if Int64.compare i 0xFFFFL >= 0 then
+      Misc.fatal_errorf "Int16.of_int64_exn: %Ld is out of range" i
+    else
+      Int64.to_int i
+
+  let to_int t = t
+end
+
 module Float = struct
   type t = float
 

--- a/utils/numbers.ml
+++ b/utils/numbers.ml
@@ -40,7 +40,7 @@ module Int8 = struct
   let one = 1
 
   let of_int_exn i =
-    if i < -(1 lsl 8) || i > ((1 lsl 8) - 1) then
+    if i < -(1 lsl 7) || i > ((1 lsl 7) - 1) then
       Misc.fatal_errorf "Int8.of_int_exn: %d is out of range" i
     else
       i
@@ -52,13 +52,18 @@ module Int16 = struct
   type t = int
 
   let of_int_exn i =
-    if i < -(1 lsl 16) || i > ((1 lsl 16) - 1) then
+    if i < -(1 lsl 15) || i > ((1 lsl 15) - 1) then
       Misc.fatal_errorf "Int16.of_int_exn: %d is out of range" i
     else
       i
 
+  let lower_int64 = Int64.neg (Int64.shift_left Int64.one 15)
+  let upper_int64 = Int64.sub (Int64.shift_left Int64.one 15) Int64.one
+
   let of_int64_exn i =
-    if Int64.compare i 0xFFFFL >= 0 then
+    if Int64.compare i lower_int64 < 0
+        || Int64.compare i upper_int64 > 0
+    then
       Misc.fatal_errorf "Int16.of_int64_exn: %Ld is out of range" i
     else
       Int64.to_int i

--- a/utils/numbers.mli
+++ b/utils/numbers.mli
@@ -14,13 +14,32 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Modules about numbers that satisfy {!Identifiable.S}. *)
+(** Modules about numbers, some of which satisfy {!Identifiable.S}. *)
 
 module Int : sig
   include Identifiable.S with type t = int
 
   (** [zero_to_n n] is the set of numbers \{0, ..., n\} (inclusive). *)
   val zero_to_n : int -> Set.t
+end
+
+module Int8 : sig
+  type t
+
+  val zero : t
+  val one : t
+
+  val of_int_exn : int -> t
+  val to_int : t -> int
+end
+
+module Int16 : sig
+  type t
+
+  val of_int_exn : int -> t
+  val of_int64_exn : Int64.t -> t
+
+  val to_int : t -> int
 end
 
 module Float : Identifiable.S with type t = float


### PR DESCRIPTION
This patch adds basic `Int8` and `Int16` modules to the `Numbers` module, which is internal to the compiler.  These are needed by the forthcoming DWARF library.
