### PR TITLE
Types corresponding to the compiler's target machine

### DIFF
--- a/.depend
+++ b/.depend
@@ -31,6 +31,9 @@ utils/strongly_connected_components.cmo : utils/numbers.cmi utils/misc.cmi \
 utils/strongly_connected_components.cmx : utils/numbers.cmx utils/misc.cmx \
     utils/identifiable.cmx utils/strongly_connected_components.cmi
 utils/strongly_connected_components.cmi : utils/identifiable.cmi
+utils/target_system.cmo : utils/misc.cmi utils/target_system.cmi
+utils/target_system.cmx : utils/misc.cmx utils/target_system.cmi
+utils/target_system.cmi :
 utils/tbl.cmo : utils/tbl.cmi
 utils/tbl.cmx : utils/tbl.cmi
 utils/tbl.cmi :

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -42,7 +42,7 @@ OCAMLDOC_OPT=$(WITH_OCAMLDOC:=.opt)
 INCLUDES=-I utils -I parsing -I typing -I bytecomp -I middle_end \
         -I middle_end/base_types -I asmcomp -I driver -I toplevel
 
-UTILS=utils/config.cmo utils/misc.cmo \
+UTILS=utils/config.cmo utils/misc.cmo utils/target_system.cmo \
   utils/identifiable.cmo utils/numbers.cmo utils/arg_helper.cmo \
   utils/clflags.cmo utils/tbl.cmo utils/timings.cmo \
   utils/terminfo.cmo utils/ccomp.cmo utils/warnings.cmo \

--- a/utils/target_system.ml
+++ b/utils/target_system.ml
@@ -1,0 +1,46 @@
+module Address = struct
+  type t =
+    | Int32 of Int32.t
+    | Int64 of Int64.t
+
+  type word_size = Four | Eight
+
+  let word_size () =
+    match Sys.word_size with
+    | 32 -> Four
+    | 64 -> Eight
+    | bits -> Misc.fatal_errorf "Unknown word size %d" bits
+
+  let zero () =
+    match word_size () with
+    | Four -> Int32 Int32.zero
+    | Eight -> Int64 Int64.zero
+
+  let all_ones () =
+    match word_size () with
+    | Four -> Int32 Int32.minus_one
+    | Eight -> Int64 Int64.minus_one
+
+  let thirty_two_bit_bounds =
+    Int64.of_int32 Int32.min_int,
+      Int64.of_int32 Int32.max_int
+
+  let of_int_exn i =
+    let min, max =
+      match word_size () with
+      | Four -> thirty_two_bit_bounds
+      | Eight -> Int64.min_int, Int64.max_int
+    in
+    let i' = Int64.of_int i in
+    if Int64.compare i' min < 0 || Int64.compare i' max > 0 then
+      Misc.fatal_errorf "Target_system.Address.of_int_exn: 0x%Ld out of range"
+        i'
+    else
+      match word_size () with
+      | Four -> Int32 (Int32.of_int i)
+      | Eight -> Int64 i'
+
+  let to_int64 = function
+    | Int32 i -> Int64.of_int32 i
+    | Int64 i -> i
+end

--- a/utils/target_system.ml
+++ b/utils/target_system.ml
@@ -1,3 +1,17 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2015--2016 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
 module Address = struct
   type t =
     | Int32 of Int32.t

--- a/utils/target_system.mli
+++ b/utils/target_system.mli
@@ -1,0 +1,35 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2015--2016 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Basic types corresponding to the compiler's target machine.
+    We provide for the future potential of the compiler's target being
+    selected at runtime. *)
+
+module Address : sig
+  (** Addresses on the target. *)
+
+  type t = private
+    | Int32 of Int32.t
+    | Int64 of Int64.t
+
+  val zero : unit -> t
+
+  val all_ones : unit -> t
+
+  type word_size = Four | Eight
+  val word_size : unit -> word_size
+
+  val of_int_exn : int -> t
+  val to_int64 : t -> Int64.t
+end


### PR DESCRIPTION
This pull request provides a module that is intended to be used when code needs to manipulate values of the same width as the compiler's target machine.  I think an abstraction like this will be needed for full cross compilation support; in the meanwhile, it is needed by the forthcoming `Asm_directives` pull request.
