### PR TITLE
Fix order of arguments with -cclib XXX

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -609,7 +609,7 @@ let process_deferred_actions env =
   let final_output_name = !output_name in
   (* Make sure the intermediate products don't clash with the final one
      when we're invoked like: ocamlopt -o foo bar.c baz.ml. *)
-  output_name := None;
+  if not !compile_only then output_name := None;
   begin
     match final_output_name with
     | None -> ()

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -532,3 +532,104 @@ let get_objfiles ~with_ocamlparam =
     List.rev (!last_objfiles @ !objfiles @ !first_objfiles)
   else
     List.rev !objfiles
+
+
+
+
+
+
+type deferred_action =
+  | ProcessImplementation of string
+  | ProcessInterface of string
+  | ProcessCFile of string
+  | ProcessOtherFile of string
+  | ProcessObjects of string list
+  | ProcessDLLs of string list
+
+let c_object_of_filename name =
+  Filename.chop_suffix (Filename.basename name) ".c" ^ Config.ext_obj
+
+let process_action
+    (ppf, implementation, interface, ocaml_mod_ext, ocaml_lib_ext) action =
+  match action with
+  | ProcessImplementation name ->
+      readenv ppf (Before_compile name);
+      let opref = output_prefix name in
+      implementation ppf name opref;
+      objfiles := (opref ^ ocaml_mod_ext) :: !objfiles
+  | ProcessInterface name ->
+      readenv ppf (Before_compile name);
+      let opref = output_prefix name in
+      interface ppf name opref;
+      if !make_package then objfiles := (opref ^ ".cmi") :: !objfiles
+  | ProcessCFile name ->
+      readenv ppf (Before_compile name);
+      Location.input_name := name;
+      if Ccomp.compile_file name <> 0 then exit 2;
+      ccobjs := c_object_of_filename name :: !ccobjs
+  | ProcessObjects names ->
+      ccobjs := names @ !ccobjs
+  | ProcessDLLs names ->
+      dllibs := names @ !dllibs
+  | ProcessOtherFile name ->
+      if Filename.check_suffix name ocaml_mod_ext
+      || Filename.check_suffix name ocaml_lib_ext then
+        objfiles := name :: !objfiles
+      else if Filename.check_suffix name ".cmi" && !make_package then
+        objfiles := name :: !objfiles
+      else if Filename.check_suffix name Config.ext_obj
+           || Filename.check_suffix name Config.ext_lib then
+        ccobjs := name :: !ccobjs
+      else if not !native_code && Filename.check_suffix name Config.ext_dll then
+        dllibs := name :: !dllibs
+      else
+        raise(Arg.Bad("don't know what to do with " ^ name))
+
+
+let action_of_file name =
+  if Filename.check_suffix name ".ml"
+  || Filename.check_suffix name ".mlt" then
+    ProcessImplementation name
+  else if Filename.check_suffix name !Config.interface_suffix then
+    ProcessInterface name
+  else if Filename.check_suffix name ".c" then
+    ProcessCFile name
+  else
+    ProcessOtherFile name
+
+let deferred_actions = ref []
+let defer action =
+  deferred_actions := action :: !deferred_actions
+
+let anonymous filename = defer (action_of_file filename)
+let impl filename = defer (ProcessImplementation filename)
+let intf filename = defer (ProcessInterface filename)
+
+let process_deferred_actions env =
+  let final_output_name = !output_name in
+  (* Make sure the intermediate products don't clash with the final one
+     when we're invoked like: ocamlopt -o foo bar.c baz.ml. *)
+  output_name := None;
+  begin
+    match final_output_name with
+    | None -> ()
+    | Some output_name ->
+        if !compile_only then begin
+          if List.filter (function
+              | ProcessCFile name -> c_object_of_filename name <> output_name
+              | _ -> false) !deferred_actions <> [] then
+            fatal "Options -c and -o are incompatible when compiling C files";
+
+          if List.length (List.filter (function
+              | ProcessImplementation _
+              | ProcessInterface _
+              | _ -> false) !deferred_actions) > 1 then
+            fatal "Options -c -o are incompatible with compiling multiple files";
+        end;
+  end;
+  if !make_archive && List.exists (function
+      | ProcessOtherFile name -> Filename.check_suffix name ".cmxa"
+      | _ -> false) !deferred_actions then
+    fatal "Option -a cannot be used with .cmxa input files.";
+  List.iter (process_action env) (List.rev !deferred_actions);
+  output_name := final_output_name;

--- a/driver/compenv.mli
+++ b/driver/compenv.mli
@@ -51,3 +51,28 @@ val is_unit_name : string -> bool
 (* [check_unit_name ppf filename name] prints a warning in [filename]
    on [ppf] if [name] should not be used as a module name. *)
 val check_unit_name : Format.formatter -> string -> string -> unit
+
+(* Deferred actions of the compiler, while parsing arguments *)
+
+type deferred_action =
+  | ProcessImplementation of string
+  | ProcessInterface of string
+  | ProcessCFile of string
+  | ProcessOtherFile of string
+  | ProcessObjects of string list
+  | ProcessDLLs of string list
+
+val c_object_of_filename : string -> string
+
+val defer : deferred_action -> unit
+val anonymous : string -> unit
+val impl : string -> unit
+val intf : string -> unit
+
+val process_deferred_actions :
+  Format.formatter *
+  (Format.formatter -> string -> string -> unit) * (* compile implementation *)
+  (Format.formatter -> string -> string -> unit) * (* compile interface *)
+  string * (* ocaml module extension *)
+  string -> (* ocaml library extension *)
+  unit

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -111,7 +111,3 @@ let implementation ppf sourcefile outputprefix =
   with x ->
     Stypes.dump (Some (outputprefix ^ ".annot"));
     raise x
-
-let c_file name =
-  Location.input_name := name;
-  if Ccomp.compile_file name <> 0 then exit 2

--- a/driver/compile.mli
+++ b/driver/compile.mli
@@ -19,4 +19,3 @@ open Format
 
 val interface: formatter -> string -> string -> unit
 val implementation: formatter -> string -> string -> unit
-val c_file: string -> unit

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -13,67 +13,13 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Config
 open Clflags
 open Compenv
-
-let process_interface_file ppf name =
-  let opref = output_prefix name in
-  Compile.interface ppf name opref;
-  if !make_package then objfiles := (opref ^ ".cmi") :: !objfiles
-
-let process_implementation_file ppf name =
-  let opref = output_prefix name in
-  Compile.implementation ppf name opref;
-  objfiles := (opref ^ ".cmo") :: !objfiles
-
-let process_file ppf name =
-  if Filename.check_suffix name ".ml"
-  || Filename.check_suffix name ".mlt" then
-    process_implementation_file ppf name
-  else if Filename.check_suffix name !Config.interface_suffix then
-    process_interface_file ppf name
-  else if Filename.check_suffix name ".cmo"
-       || Filename.check_suffix name ".cma" then
-    objfiles := name :: !objfiles
-  else if Filename.check_suffix name ".cmi" && !make_package then
-    objfiles := name :: !objfiles
-  else if Filename.check_suffix name ext_obj
-       || Filename.check_suffix name ext_lib then
-    ccobjs := name :: !ccobjs
-  else if Filename.check_suffix name ext_dll then
-    dllibs := name :: !dllibs
-  else if Filename.check_suffix name ".c" then begin
-    Compile.c_file name;
-    ccobjs := (Filename.chop_suffix (Filename.basename name) ".c" ^ ext_obj)
-              :: !ccobjs
-  end
-  else
-    raise(Arg.Bad("don't know what to do with " ^ name))
 
 let usage = "Usage: ocamlc <options> <files>\nOptions are:"
 
 (* Error messages to standard error formatter *)
 let ppf = Format.err_formatter
-
-let process_thunks = ref []
-let schedule fn =
-  process_thunks := fn :: !process_thunks
-
-let anonymous filename =
-  schedule (fun () ->
-    readenv ppf (Before_compile filename);
-    process_file ppf filename)
-
-let impl filename =
-  schedule (fun () ->
-    readenv ppf (Before_compile filename);
-    process_implementation_file ppf filename)
-
-let intf filename =
-  schedule (fun () ->
-    readenv ppf (Before_compile filename);
-    process_interface_file ppf filename)
 
 let show_config () =
   Config.print_config stdout;
@@ -89,13 +35,13 @@ module Options = Main_args.Make_bytecomp_options (struct
   let _binannot = set binary_annotations
   let _c = set compile_only
   let _cc s = c_compiler := Some s
-  let _cclib s = schedule (fun () -> ccobjs := Misc.rev_split_words s @ !ccobjs)
+  let _cclib s = Compenv.defer (ProcessObjects (Misc.rev_split_words s))
   let _ccopt s = first_ccopts := s :: !first_ccopts
   let _compat_32 = set bytecode_compatible_32
   let _config = show_config
   let _custom = set custom_runtime
   let _no_check_prims = set no_check_prims
-  let _dllib s = schedule (fun () -> dllibs := Misc.rev_split_words s @ !dllibs)
+  let _dllib s = defer (ProcessDLLs (Misc.rev_split_words s))
   let _dllpath s = dllpaths := !dllpaths @ [s]
   let _for_pack s = for_package := Some s
   let _g = set debug
@@ -179,16 +125,12 @@ let main () =
   try
     readenv ppf Before_args;
     Arg.parse Options.list anonymous usage;
-    if !output_name <> None && !compile_only &&
-          List.length !process_thunks > 1 then
-      fatal "Options -c -o are incompatible with compiling multiple files";
-    let final_output_name = !output_name in
-    if !output_name <> None && not !compile_only then
-      (* We're invoked like: ocamlc -o foo bar.c baz.ml.
-         Make sure the intermediate products don't clash with the final one. *)
-      output_name := None;
-    List.iter (fun f -> f ()) (List.rev !process_thunks);
-    output_name := final_output_name;
+    Compenv.process_deferred_actions
+      (ppf,
+       Compile.implementation,
+       Compile.interface,
+       ".cmo",
+       ".cma");
     readenv ppf Before_link;
     if
       List.length (List.filter (fun x -> !x)

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -63,7 +63,7 @@ let print_if ppf flag printer arg =
 let (++) x f = f x
 let (+++) (x, y) f = (x, f y)
 
-let implementation ppf sourcefile outputprefix ~backend =
+let implementation ~backend ppf sourcefile outputprefix =
   let source_provenance = Timings.File sourcefile in
   Compmisc.init_path true;
   let modulename = module_of_filename ppf sourcefile outputprefix in
@@ -138,6 +138,3 @@ let implementation ppf sourcefile outputprefix ~backend =
     remove_file objfile;
     remove_file cmxfile;
     raise x
-
-let c_file name =
-  if Ccomp.compile_file name <> 0 then exit 2

--- a/driver/optcompile.mli
+++ b/driver/optcompile.mli
@@ -19,11 +19,9 @@ open Format
 
 val interface: formatter -> string -> string -> unit
 
-val implementation
-   : formatter
+val implementation:
+   backend:(module Backend_intf.S)
+   -> formatter
   -> string
   -> string
-  -> backend:(module Backend_intf.S)
   -> unit
-
-val c_file: string -> unit

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -13,7 +13,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Config
 open Clflags
 open Compenv
 
@@ -35,64 +34,7 @@ module Backend = struct
 end
 let backend = (module Backend : Backend_intf.S)
 
-let process_interface_file ppf name =
-  let opref = output_prefix name in
-  Optcompile.interface ppf name opref;
-  if !make_package then objfiles := (opref ^ ".cmi") :: !objfiles
-
-let process_implementation_file ppf name =
-  let opref = output_prefix name in
-  Optcompile.implementation ppf name opref ~backend;
-  objfiles := (opref ^ ".cmx") :: !objfiles
-
-let cmxa_present = ref false;;
-
-let process_file ppf name =
-  if Filename.check_suffix name ".ml"
-  || Filename.check_suffix name ".mlt" then
-    process_implementation_file ppf name
-  else if Filename.check_suffix name !Config.interface_suffix then
-    process_interface_file ppf name
-  else if Filename.check_suffix name ".cmx" then
-    objfiles := name :: !objfiles
-  else if Filename.check_suffix name ".cmxa" then begin
-    cmxa_present := true;
-    objfiles := name :: !objfiles
-  end else if Filename.check_suffix name ".cmi" && !make_package then
-    objfiles := name :: !objfiles
-  else if Filename.check_suffix name ext_obj
-       || Filename.check_suffix name ext_lib then
-    ccobjs := name :: !ccobjs
-  else if Filename.check_suffix name ".c" then begin
-    Optcompile.c_file name;
-    ccobjs := (Filename.chop_suffix (Filename.basename name) ".c" ^ ext_obj)
-              :: !ccobjs
-  end
-  else
-    raise(Arg.Bad("don't know what to do with " ^ name))
-
 let usage = "Usage: ocamlopt <options> <files>\nOptions are:"
-
-(* Error messages to standard error formatter *)
-let ppf = Format.err_formatter
-
-let process_thunks = ref []
-let schedule fn =
-  process_thunks := fn :: !process_thunks
-
-let anonymous filename =
-  schedule (fun () ->
-    readenv ppf (Before_compile filename);
-    process_file ppf filename)
-
-let impl filename =
-  schedule (fun () ->
-    readenv ppf (Before_compile filename);
-    process_implementation_file ppf filename)
-
-let intf filename =
-  schedule (fun () ->
-    readenv ppf (Before_compile filename); process_interface_file ppf filename)
 
 let show_config () =
   Config.print_config stdout;
@@ -109,7 +51,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _binannot = set binary_annotations
   let _c = set compile_only
   let _cc s = c_compiler := Some s
-  let _cclib s = schedule (fun () -> ccobjs := Misc.rev_split_words s @ !ccobjs)
+  let _cclib s = defer (ProcessObjects (Misc.rev_split_words s))
   let _ccopt s = first_ccopts := s :: !first_ccopts
   let _clambda_checks () = clambda_checks := true
   let _compact = clear optimize_for_speed
@@ -290,16 +232,12 @@ let main () =
   try
     readenv ppf Before_args;
     Arg.parse (Arch.command_line_options @ Options.list) anonymous usage;
-    if !output_name <> None && !compile_only &&
-          List.length !process_thunks > 1 then
-      fatal "Options -c -o are incompatible with compiling multiple files";
-    let final_output_name = !output_name in
-    if !output_name <> None && not !compile_only then
-      (* We're invoked like: ocamlopt -o foo bar.c baz.ml.
-         Make sure the intermediate products don't clash with the final one. *)
-      output_name := None;
-    List.iter (fun f -> f ()) (List.rev !process_thunks);
-    output_name := final_output_name;
+    Compenv.process_deferred_actions
+      (ppf,
+       Optcompile.implementation ~backend,
+       Optcompile.interface,
+       ".cmx",
+       ".cma");
     readenv ppf Before_link;
     if
       List.length (List.filter (fun x -> !x)
@@ -308,8 +246,6 @@ let main () =
     then
       fatal "Please specify at most one of -pack, -a, -shared, -c, -output-obj";
     if !make_archive then begin
-      if !cmxa_present then
-        fatal "Option -a cannot be used with .cmxa input files.";
       Compmisc.init_path true;
       let target = extract_output !output_name in
       Asmlibrarian.create_archive (get_objfiles ~with_ocamlparam:false) target;

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -237,7 +237,7 @@ let main () =
        Optcompile.implementation ~backend,
        Optcompile.interface,
        ".cmx",
-       ".cma");
+       ".cmxa");
     readenv ppf Before_link;
     if
       List.length (List.filter (fun x -> !x)


### PR DESCRIPTION
I think the current processing of arguments in 4.04 is completely broken.
Here is a patch to fix most of the problems:
- no error when providing both a library and a file to compile with `-c` and `-o`
- add an error when `-c` and `-o` are used on a C file with `-o` targetting a different name that the one produced by `ocamlc`
- shared code between `main.ml` and `optmain.ml` moved to `compenv.ml`
  @damiendoligez 
