### PR TITLE
Get rid of Makefile.nt in the yacc directory.

### DIFF
--- a/yacc/Makefile
+++ b/yacc/Makefile
@@ -20,6 +20,12 @@ include ../config/Makefile
 CC=$(BYTECC)
 CFLAGS=-DNDEBUG $(BYTECCCOMPOPTS)
 
+ifeq "$(TOOLCHAIN)" "mingw"
+  CFLAGS += -DNO_UNIX
+else ifeq "$(TOOLCHAIN)" "msvc"
+  CFLAGS += -DNO_UNIX
+endif
+
 OBJS= closure.$(O) error.$(O) lalr.$(O) lr0.$(O) main.$(O) \
   mkpar.$(O) output.$(O) reader.$(O) \
   skeleton.$(O) symtab.$(O) verbose.$(O) warshall.$(O)
@@ -49,3 +55,9 @@ skeleton.$(O): defs.h
 symtab.$(O): defs.h
 verbose.$(O): defs.h
 warshall.$(O): defs.h
+
+# The following rule is similar to make's default one, except that it
+# also works for .obj files.
+
+%.$(O): %.c
+	$(CC) $(CFLAGS) -c $<

--- a/yacc/Makefile.nt
+++ b/yacc/Makefile.nt
@@ -14,6 +14,3 @@
 #**************************************************************************
 
 include Makefile
-
-%.$(O): %.c
-	$(BYTECC) -DNDEBUG -DNO_UNIX $(BYTECCCOMPOPTS) -c $<


### PR DESCRIPTION
The Makefile has been changed so that it also works on Windows.

As a consequence, in OCaml's main Makefile.nt, building things in the
yacc directory can now be done by invoking $(MAKE) rather than
$(MAKEREC).
