### PR TITLE
Fix instrumented runtime with spacetime

### DIFF
--- a/asmrun/spacetime_snapshot.c
+++ b/asmrun/spacetime_snapshot.c
@@ -404,6 +404,7 @@ value caml_spacetime_frame_table(void)
   /* Flatten the frame table into a single associative list. */
 
   value list = Val_long(0);  /* the empty list */
+  uintnat i;
 
   if (!caml_debug_info_available()) {
     return list;
@@ -413,7 +414,7 @@ value caml_spacetime_frame_table(void)
     caml_init_frame_descriptors();
   }
 
-  for (uintnat i = 0; i <= caml_frame_descriptors_mask; i++) {
+  for (i = 0; i <= caml_frame_descriptors_mask; i++) {
     frame_descr* descr = caml_frame_descriptors[i];
     if (descr != NULL) {
       value location, return_address, pair, new_list_element, location_list;


### PR DESCRIPTION
This fixes compilation of the instrumented runtime when spacetime is enabled
