### PR TITLE
Fix spacetime deadlock

### DIFF
--- a/asmrun/spacetime.c
+++ b/asmrun/spacetime.c
@@ -22,6 +22,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <signal.h>
 #include "caml/config.h"
 #ifdef HAS_UNISTD
 #include <unistd.h>
@@ -187,6 +188,10 @@ static void maybe_reopen_snapshot_channel(void)
 
 extern void caml_spacetime_automatic_save(void);
 
+#ifndef SIGINT
+#define SIGINT -1
+#endif
+
 void caml_spacetime_initialize(void)
 {
   /* Note that this is called very early (even prior to GC initialisation). */
@@ -233,6 +238,8 @@ void caml_spacetime_initialize(void)
         automatic_snapshots = 1;
         open_snapshot_channel();
         if (automatic_snapshots) {
+          // Catch interrupt so that the profile can be completed
+          caml_set_signal_action(SIGINT, 2);
           snapshot_interval = interval / 1e3;
           time = caml_sys_time_unboxed(Val_unit);
           next_snapshot_time = time + snapshot_interval;

--- a/asmrun/spacetime.c
+++ b/asmrun/spacetime.c
@@ -157,6 +157,7 @@ static void open_snapshot_channel(void)
   }
   else {
     snapshot_channel = caml_open_descriptor_out(fd);
+    snapshot_channel->flags |= CHANNEL_FLAG_BLOCKING_WRITE;
     pid_when_snapshot_channel_opened = pid;
     caml_spacetime_write_magic_number_internal(snapshot_channel);
   }
@@ -1064,6 +1065,13 @@ CAMLprim value caml_spacetime_enabled (value v_unit)
   return Val_true;
 }
 
+CAMLprim value caml_channel_for_spacetime (value v_channel)
+{
+  struct channel* channel = Channel(v_channel);
+  channel->flags |= CHANNEL_FLAG_BLOCKING_WRITE;
+  return Val_unit;
+}
+
 #else
 
 /* Functions for when the compiler was not configured with "-spacetime". */
@@ -1092,6 +1100,11 @@ CAMLprim value caml_spacetime_save_event_for_automatic_snapshots
 }
 
 CAMLprim value caml_spacetime_save_trie (value ignored)
+{
+  return Val_unit;
+}
+
+CAMLprim value caml_channel_for_spacetime (value v_channel)
 {
   return Val_unit;
 }

--- a/asmrun/spacetime.c
+++ b/asmrun/spacetime.c
@@ -188,10 +188,6 @@ static void maybe_reopen_snapshot_channel(void)
 
 extern void caml_spacetime_automatic_save(void);
 
-#ifndef SIGINT
-#define SIGINT -1
-#endif
-
 void caml_spacetime_initialize(void)
 {
   /* Note that this is called very early (even prior to GC initialisation). */
@@ -238,11 +234,13 @@ void caml_spacetime_initialize(void)
         automatic_snapshots = 1;
         open_snapshot_channel();
         if (automatic_snapshots) {
+#ifdef SIGINT
           /* Catch interrupt so that the profile can be completed.
              We do this by marking the signal as handled without
              specifying an actual handler. This causes the signal
              to be handled by a call to exit. */
           caml_set_signal_action(SIGINT, 2);
+#endif
           snapshot_interval = interval / 1e3;
           time = caml_sys_time_unboxed(Val_unit);
           next_snapshot_time = time + snapshot_interval;

--- a/asmrun/spacetime.c
+++ b/asmrun/spacetime.c
@@ -241,7 +241,7 @@ void caml_spacetime_initialize(void)
           /* Catch interrupt so that the profile can be completed.
              We do this by marking the signal as handled without
              specifying an actual handler. This causes the signal
-             to be handler by a call to exit. */
+             to be handled by a call to exit. */
           caml_set_signal_action(SIGINT, 2);
           snapshot_interval = interval / 1e3;
           time = caml_sys_time_unboxed(Val_unit);

--- a/asmrun/spacetime.c
+++ b/asmrun/spacetime.c
@@ -238,7 +238,10 @@ void caml_spacetime_initialize(void)
         automatic_snapshots = 1;
         open_snapshot_channel();
         if (automatic_snapshots) {
-          // Catch interrupt so that the profile can be completed
+          /* Catch interrupt so that the profile can be completed.
+             We do this by marking the signal as handled without
+             specifying an actual handler. This causes the signal
+             to be handler by a call to exit. */
           caml_set_signal_action(SIGINT, 2);
           snapshot_interval = interval / 1e3;
           time = caml_sys_time_unboxed(Val_unit);
@@ -1072,7 +1075,7 @@ CAMLprim value caml_spacetime_enabled (value v_unit)
   return Val_true;
 }
 
-CAMLprim value caml_channel_for_spacetime (value v_channel)
+CAMLprim value caml_register_channel_for_spacetime (value v_channel)
 {
   struct channel* channel = Channel(v_channel);
   channel->flags |= CHANNEL_FLAG_BLOCKING_WRITE;
@@ -1111,7 +1114,7 @@ CAMLprim value caml_spacetime_save_trie (value ignored)
   return Val_unit;
 }
 
-CAMLprim value caml_channel_for_spacetime (value v_channel)
+CAMLprim value caml_register_channel_for_spacetime (value v_channel)
 {
   return Val_unit;
 }

--- a/byterun/caml/io.h
+++ b/byterun/caml/io.h
@@ -53,7 +53,10 @@ struct channel {
 };
 
 enum {
-  CHANNEL_FLAG_FROM_SOCKET = 1  /* For Windows */
+  CHANNEL_FLAG_FROM_SOCKET = 1,  /* For Windows */
+#if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
+  CHANNEL_FLAG_BLOCKING_WRITE = 2,
+#endif
 };
 
 /* For an output channel:

--- a/byterun/signals.c
+++ b/byterun/signals.c
@@ -160,6 +160,9 @@ void caml_execute_signal(int signal_number, int in_signal_handler)
     = caml_spacetime_finaliser_trie_root;
 #endif
 #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
+  /* Handled action may have no associated handler, which we interpret
+     as meaning the signal should be handled by a call to exit.  This is
+     is used to allow spacetime profiles to be completed on interrupt */
   if (caml_signal_handlers == 0) {
     res = caml_sys_exit(Val_int(2));
   } else {
@@ -363,6 +366,8 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     break;
   case 2:                       /* was Signal_handle */
     #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
+      /* Handled action may have no associated handler
+         which we treat as Signal_default */
       if (caml_signal_handlers == 0) {
         res = Val_int(0);
       } else {

--- a/byterun/signals.c
+++ b/byterun/signals.c
@@ -362,8 +362,21 @@ CAMLprim value caml_install_signal_handler(value signal_number, value action)
     res = Val_int(1);
     break;
   case 2:                       /* was Signal_handle */
+    #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
+      if (caml_signal_handlers == 0) {
+        res = Val_int(0);
+      } else {
+        if (!Is_block(Field(caml_signal_handlers, sig))) {
+          res = Val_int(0);
+        } else {
+          res = caml_alloc_small (1, 0);
+          Field(res, 0) = Field(caml_signal_handlers, sig);
+        }
+      }
+    #else
     res = caml_alloc_small (1, 0);
     Field(res, 0) = Field(caml_signal_handlers, sig);
+    #endif
     break;
   default:                      /* error in caml_set_signal_action */
     caml_sys_error(NO_ARG);

--- a/byterun/signals.c
+++ b/byterun/signals.c
@@ -139,6 +139,7 @@ static value caml_signal_handlers = 0;
 void caml_execute_signal(int signal_number, int in_signal_handler)
 {
   value res;
+  value handler;
 #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
   void* saved_spacetime_trie_node_ptr;
 #endif
@@ -158,10 +159,23 @@ void caml_execute_signal(int signal_number, int in_signal_handler)
   caml_spacetime_trie_node_ptr
     = caml_spacetime_finaliser_trie_root;
 #endif
-  res = caml_callback_exn(
-           Field(caml_signal_handlers, signal_number),
-           Val_int(caml_rev_convert_signal_number(signal_number)));
 #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
+  if (caml_signal_handlers == 0) {
+    res = caml_sys_exit(Val_int(2));
+  } else {
+    handler = Field(caml_signal_handlers, signal_number);
+    if (!Is_block(handler)) {
+      res = caml_sys_exit(Val_int(2));
+    } else {
+#else
+  handler = Field(caml_signal_handlers, signal_number);
+#endif
+    res = caml_callback_exn(
+             handler,
+             Val_int(caml_rev_convert_signal_number(signal_number)));
+#if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
+    }
+  }
   caml_spacetime_trie_node_ptr = saved_spacetime_trie_node_ptr;
 #endif
 #ifdef POSIX_SIGNALS

--- a/byterun/spacetime.c
+++ b/byterun/spacetime.c
@@ -33,3 +33,8 @@ CAMLprim value caml_spacetime_enabled (value v_unit)
 {
   return Val_false;  /* running in bytecode */
 }
+
+CAMLprim value caml_channel_for_spacetime (value v_channel)
+{
+  return Val_unit;
+}

--- a/byterun/spacetime.c
+++ b/byterun/spacetime.c
@@ -34,7 +34,7 @@ CAMLprim value caml_spacetime_enabled (value v_unit)
   return Val_false;  /* running in bytecode */
 }
 
-CAMLprim value caml_channel_for_spacetime (value v_channel)
+CAMLprim value caml_register_channel_for_spacetime (value v_channel)
 {
   return Val_unit;
 }

--- a/byterun/unix.c
+++ b/byterun/unix.c
@@ -49,6 +49,7 @@
 #include "caml/osdeps.h"
 #include "caml/signals.h"
 #include "caml/sys.h"
+#include "caml/io.h"
 
 #ifndef S_ISREG
 #define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
@@ -80,9 +81,18 @@ int caml_write_fd(int fd, int flags, void * buf, int n)
 {
   int retcode;
  again:
+#if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
+  if ((flags & CHANNEL_FLAG_BLOCKING_WRITE)
+      == CHANNEL_FLAG_BLOCKING_WRITE) {
+    retcode = write(fd, buf, n);
+  } else {
+#endif
   caml_enter_blocking_section();
   retcode = write(fd, buf, n);
   caml_leave_blocking_section();
+#if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
+  }
+#endif
   if (retcode == -1) {
     if (errno == EINTR) goto again;
     if ((errno == EAGAIN || errno == EWOULDBLOCK) && n > 1) {

--- a/byterun/unix.c
+++ b/byterun/unix.c
@@ -82,8 +82,7 @@ int caml_write_fd(int fd, int flags, void * buf, int n)
   int retcode;
  again:
 #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
-  if ((flags & CHANNEL_FLAG_BLOCKING_WRITE)
-      == CHANNEL_FLAG_BLOCKING_WRITE) {
+  if (flags & CHANNEL_FLAG_BLOCKING_WRITE) {
     retcode = write(fd, buf, n);
   } else {
 #endif

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -105,9 +105,18 @@ int caml_write_fd(int fd, int flags, void * buf, int n)
 {
   int retcode;
   if ((flags & CHANNEL_FLAG_FROM_SOCKET) == 0) {
+#if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
+  if ((flags & CHANNEL_FLAG_BLOCKING_WRITE)
+      == CHANNEL_FLAG_BLOCKING_WRITE) {
+    retcode = write(fd, buf, n);
+  } else {
+#endif
     caml_enter_blocking_section();
     retcode = write(fd, buf, n);
     caml_leave_blocking_section();
+#if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
+  }
+#endif
     if (retcode == -1) caml_sys_io_error(NO_ARG);
   } else {
     caml_enter_blocking_section();

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -106,8 +106,7 @@ int caml_write_fd(int fd, int flags, void * buf, int n)
   int retcode;
   if ((flags & CHANNEL_FLAG_FROM_SOCKET) == 0) {
 #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
-  if ((flags & CHANNEL_FLAG_BLOCKING_WRITE)
-      == CHANNEL_FLAG_BLOCKING_WRITE) {
+  if (flags & CHANNEL_FLAG_BLOCKING_WRITE) {
     retcode = write(fd, buf, n);
   } else {
 #endif

--- a/stdlib/spacetime.ml
+++ b/stdlib/spacetime.ml
@@ -28,10 +28,15 @@ module Series = struct
     = "caml_spacetime_only_works_for_native_code"
       "caml_spacetime_write_magic_number"
 
+  external channel_for_spacetime : out_channel -> unit
+    = "caml_channel_for_spacetime"
+
   let create ~path =
     if spacetime_enabled () then begin
+      let channel = open_out path in
+      channel_for_spacetime channel;
       let t =
-        { channel = open_out path;
+        { channel = channel;
           closed = false;
         }
       in

--- a/stdlib/spacetime.ml
+++ b/stdlib/spacetime.ml
@@ -28,13 +28,13 @@ module Series = struct
     = "caml_spacetime_only_works_for_native_code"
       "caml_spacetime_write_magic_number"
 
-  external channel_for_spacetime : out_channel -> unit
-    = "caml_channel_for_spacetime"
+  external register_channel_for_spacetime : out_channel -> unit
+    = "caml_register_channel_for_spacetime"
 
   let create ~path =
     if spacetime_enabled () then begin
       let channel = open_out path in
-      channel_for_spacetime channel;
+      register_channel_for_spacetime channel;
       let t =
         { channel = channel;
           closed = false;


### PR DESCRIPTION
This fixes a deadlock in spacetime when a program tries to exit from a signal handler whilst taking a snapshot. It does this by not entering a blocking section whilst writing out a snapshot.

The patch also adds a default handler to exit cleanly on SIGINT when automatic spacetime snapshots are enabled. This is very useful when trying to profile programs that are being OOM killed by the OS as you can simply Ctrl-C before the program is killed.
