### PR TITLE
Win32unix: fix now totally broken Unix.fstat implemenetation

### DIFF
--- a/Changes
+++ b/Changes
@@ -210,6 +210,9 @@ OCaml 4.04.0:
   of Warning 52 (fragile constant pattern)
   (Gabriel Scherer, William, Adrien Nader, Jacques Garrigue)
 
+- #PR7265, GPR#769: Restore 4.02.3 behaviour of Unix.fstat, if the
+  file descriptor doesn't wrap a regular file (win32unix only)
+  (Andreas Hauptmann, review by David Allsopp)
 
 ### Build system:
 

--- a/otherlibs/win32unix/stat.c
+++ b/otherlibs/win32unix/stat.c
@@ -35,10 +35,14 @@
 #define S_IFLNK (S_IFDIR | S_IFREG)
 #endif
 #ifndef S_IFIFO
-#define S_IFIFO 0
+#ifdef _S_IFIFO
+#define S_IFIFO _S_IFIFO
+#else
+#define S_IFIFO (S_IFREG | S_IFCHR)
+#endif
 #endif
 #ifndef S_IFSOCK
-#define S_IFSOCK 0
+#define S_IFSOCK (S_IFDIR | S_IFCHR)
 #endif
 #ifndef S_IFBLK
 #define S_IFBLK 0
@@ -375,7 +379,7 @@ static value do_fstat(value handle, int use_64)
     }
     break;
   case FILE_TYPE_CHAR:
-    buf.st_mode = _S_IFCHR;
+    buf.st_mode = S_IFCHR;
     break;
   case FILE_TYPE_PIPE:
     {
@@ -384,7 +388,7 @@ static value do_fstat(value handle, int use_64)
         buf.st_mode = S_IFSOCK;
       }
       else {
-        buf.st_mode = _S_IFIFO;
+        buf.st_mode = S_IFIFO;
       }
       if (PeekNamedPipe(h, NULL, 0, NULL, &n_avail, NULL)) {
         buf.st_size = n_avail;

--- a/otherlibs/win32unix/stat.c
+++ b/otherlibs/win32unix/stat.c
@@ -354,24 +354,58 @@ CAMLprim value unix_lstat_64(value path)
   return stat_aux(1, st_ino, &buf);
 }
 
-CAMLprim value unix_fstat(value handle)
+static value do_fstat(value handle, int use_64)
 {
   int ret;
   struct _stat64 buf;
   __int64 st_ino;
-  if (!do_stat(0, 0, NULL, 0, Handle_val(handle), &st_ino, &buf)) {
+  HANDLE h;
+  DWORD ft;
+
+  st_ino = 0;
+  memset(&buf, 0, sizeof buf);
+  buf.st_nlink = 1;
+
+  h = Handle_val(handle);
+  ft = GetFileType(h) & ~FILE_TYPE_REMOTE;
+  switch(ft) {
+  case FILE_TYPE_DISK:
+    if (!safe_do_stat(0, use_64, NULL, 0, Handle_val(handle), &st_ino, &buf)) {
+      uerror("fstat", Nothing);
+    }
+    break;
+  case FILE_TYPE_CHAR:
+    buf.st_mode = _S_IFCHR;
+    break;
+  case FILE_TYPE_PIPE:
+    {
+      DWORD n_avail;
+      if (Descr_kind_val(handle) == KIND_SOCKET) {
+        buf.st_mode = S_IFSOCK;
+      }
+      else {
+        buf.st_mode = _S_IFIFO;
+      }
+      if (PeekNamedPipe(h, NULL, 0, NULL, &n_avail, NULL)) {
+        buf.st_size = n_avail;
+      }
+    }
+    break;
+  case FILE_TYPE_UNKNOWN:
+    unix_error(EBADF, "fstat", Nothing);
+  default:
+    win32_maperr(GetLastError());
     uerror("fstat", Nothing);
   }
-  return stat_aux(0, st_ino, &buf);
+  return stat_aux(use_64, st_ino, &buf);
+}
+
+CAMLprim value unix_fstat(value handle)
+{
+  return do_fstat(handle, 0);
 }
 
 CAMLprim value unix_fstat_64(value handle)
 {
-  int ret;
-  struct _stat64 buf;
-  __int64 st_ino;
-  if (!do_stat(0, 1, NULL, 0, Handle_val(handle), &st_ino, &buf)) {
-    uerror("fstat", Nothing);
-  }
-  return stat_aux(1, st_ino, &buf);
+  return do_fstat(handle, 1);
 }


### PR DESCRIPTION
Unix.fstat was partially broken on Windows since 4.03 (see Mantis #7265 ).
The latest commit made it worse: Now a NULL pointer is passed to `caml_strdup`/`strlen` (which can lead to a segmentation fault, details depend the msvcrt version used).

This commit addresses both issues.

1) `NULL` is not longer passed to caml_strdup

2) If the `Unix.file_descriptor` is of type `FILE_TYPE_DISK`, the new implementation of @dra27 is used.

3) Otherwise a solution similar to `_fstati64` is used. It differs in the following ways:
- The fields `st_dev` and `st_rdev` are not set to `win_CRT_fd_of_filedescr(handle)`. The number of crt file descriptors  is rather small by default and the integer is of limited use. It would also require further changes to prevent descriptor leaks (see Mantis #5258 , this issue was previously ignored).
- the crt solution doesn't distinguish between sockets and pipes, both are reported as  `FILE_TYPE_PIPE`. The OCaml unix library however keeps track of this distinction inside `struct filedescr`.
