### PR TITLE
fix quoting inside ocamlmktop (win32)

### DIFF
--- a/tools/ocamlmktop.ml
+++ b/tools/ocamlmktop.ml
@@ -16,7 +16,17 @@
 let _ =
   let args = Ccomp.quote_files (List.tl (Array.to_list Sys.argv)) in
   let ocamlmktop = Sys.executable_name in
-  let ocamlc = Filename.(quote (concat (dirname ocamlmktop) "ocamlc")) in
-  exit(Sys.command(ocamlc ^ " -I +compiler-libs -linkall ocamlcommon.cma \
-                    ocamlbytecomp.cma ocamltoplevel.cma "
-                   ^ args ^ " topstart.cmo"))
+  (* On Windows Sys.command calls system() which in turn calls 'cmd.exe /c'.
+     cmd.exe has special quoting rules (see 'cmd.exe /?' for details).
+     Short version: if the string passed to cmd.exe starts with '"',
+     the first and last '"' are removed *)
+  let ocamlc,extra_quote =
+    if Sys.win32 then "ocamlc.exe","\"" else "ocamlc",""
+  in
+  let ocamlc = Filename.(quote (concat (dirname ocamlmktop) ocamlc)) in
+  let cmdline =
+    extra_quote ^ ocamlc ^ " -I +compiler-libs -linkall ocamlcommon.cma " ^
+    "ocamlbytecomp.cma ocamltoplevel.cma " ^ args ^ " topstart.cmo" ^
+    extra_quote
+  in
+  exit(Sys.command cmdline)


### PR DESCRIPTION
The quoting is currently wrong (win32 only, since 5f968b00ff11ac327aa4cb893a4e1b5b825f2393). If the first expression is quoted, the whole expression must be put in quotes ...
See eg https://www.borngeek.com/2011/03/22/calls-to-system-in-windows/ or https://stackoverflow.com/questions/2642551/windows-c-system-call-with-spaces-in-command

Also `ocamlc.exe` is used in order to be independend of `$PATHEXT`.
