### PR TITLE
PR#7329, fix "-dsource" for local open in patterns

### DIFF
--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -409,6 +409,14 @@ and simple_pattern ctxt (f:Format.formatter) (x:pattern) : unit =
     | Ppat_exception p ->
         pp f "@[<2>exception@;%a@]" (pattern1 ctxt) p
     | Ppat_extension e -> extension ctxt f e
+    | Ppat_open (lid, p) ->
+        let with_paren =
+        match p.ppat_desc with
+        | Ppat_array _ | Ppat_record _
+        | Ppat_construct (({txt=Lident ("()"|"[]");_}), _) -> false
+        | _ -> true in
+        pp f "@[<2>%a.%a @]" longident_loc lid
+          (paren with_paren @@ pattern1 ctxt) p
     | _ -> paren true (pattern ctxt) f x
 
 and label_exp ctxt f (l,opt,p) =

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7245,3 +7245,12 @@ end and ['a] d () = object
   inherit ['a] c ()
 end;;
 *)
+
+(* PR#7329 Pattern open *)
+let _ =
+  let module M = struct type t = { x : int } end in
+  let f M.(x) = () in
+  let g M.{x} = () in
+  let h = function M.[] | M.[a] | M.(a::q) -> () in
+  let i = function M.[||] | M.[|x|]  -> true | _ -> false in
+  ()


### PR DESCRIPTION
This pull request fixes a bug for the printing of local open in pattern within `parsetree/pprintast.ml`
and adds a corresponding subcase test inside the `testsuite/parsetree` test.
