### PR TITLE
Fix PR#7134, following a suggestion of sliquister

### DIFF
--- a/Changes
+++ b/Changes
@@ -241,6 +241,9 @@ OCaml 4.04.0:
 - PR#7112: Aliased arguments ignored for equality of module types
   (Jacques Garrigue, report by Leo White)
 
+- PR#7134: compiler forcing aliases it shouldn't while reporting type errors
+  (Jacques Garrigue, report and suggestion by sliquister)
+
 - PR#7153: document that Unix.SOCK_SEQPACKET is not really usable.
 
 - PR#7257, GPR#583: revert a 4.03 change of behavior on (Unix.sleep 0.),

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -462,11 +462,7 @@ let read_pers_struct check modname filename =
 
 let can_load_cmis = ref true
 let without_cmis f x =
-  if !can_load_cmis then begin
-    can_load_cmis := false;
-    try let r = f x in can_load_cmis := true; r
-    with e -> can_load_cmis := true; raise e
-  end else f x
+  Misc.(protect_refs [R (can_load_cmis, false)] (fun () -> f x))
 
 let find_pers_struct check name =
   if name = "*predef*" then raise Not_found;

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -53,6 +53,9 @@ val run_iter_cont: iter_cont list -> (Path.t * iter_cont) list
 val same_types: t -> t -> bool
 val used_persistent: unit -> Concr.t
 val find_shadowed_types: Path.t -> t -> Path.t list
+val without_cmis: ('a -> 'b) -> 'a -> 'b
+        (* [without_cmis f arg] applies [f] to [arg], but does not
+           allow opening cmis during its execution *)
 
 (* Lookup by paths *)
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -323,6 +323,9 @@ let wrap_printing_env env f =
   set_printing_env env;
   try_finally f (fun () -> set_printing_env Env.empty)
 
+let wrap_printing_env env f =
+  Env.without_cmis (wrap_printing_env env) f
+
 let is_unambiguous path env =
   let l = Env.find_shadowed_types path env in
   List.exists (Path.same path) l || (* concrete paths are ok *)


### PR DESCRIPTION
This fixes [MPR#7134](http://caml.inria.fr/mantis/view.php?id=7134): compiler forcing aliases it shouldn't while reporting type errors.

The idea is just to prevent opening cmis when outputting an error message: if there is an error, it is enough to use the information already in memory.
