### PR TITLE
In otherlibs/num: fix make warning about ignored `depend' target.

### DIFF
--- a/otherlibs/num/Makefile.shared
+++ b/otherlibs/num/Makefile.shared
@@ -29,9 +29,3 @@ clean::
 
 bng.$(O): bng.h bng_digit.c \
        bng_amd64.c bng_ia32.c bng_ppc.c bng_sparc.c
-
-depend:
-	$(CC) -MM $(CFLAGS) *.c > .depend
-	$(CAMLRUN) ../../tools/ocamldep -slash *.mli *.ml >> .depend
-
-include .depend


### PR DESCRIPTION
The `depend' target defined in Makefile.shared was ignored on Unix and
Windows, because it is also defined in Makefile and Makefile.nt.

The definition in Makefile.shared is an exact copy of the one in Makefile.

This commit also removes the "include .depend" directive from
Makefile.shared because this inclusion is handled in a system-dependent
way in Makefile and Makefile.nt.
