### PR TITLE
Expand option

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,12 @@ Next version (tbd):
   rules between Unix and Windows Makefiles
  (Sébastien Hinderer, review by Alain Frisch)
 
+### Standard library:
+
+- GPR#778: Arg: added option Expand that allows to expand a string argument
+  to a string array of new arguments
+  (Bernhard Schommer)
+
 OCaml 4.04.0:
 -------------
 
@@ -607,9 +613,9 @@ OCaml 4.03.0 (25 Apr 2016):
 
 ### Runtime system:
 
-* GPR#442, caml_fill_string, and caml_create_string is deprecated 
-  and will be removed in the future, please use caml_fill_bytes 
-  and caml_create_bytes for migration 
+* GPR#442, caml_fill_string, and caml_create_string is deprecated
+  and will be removed in the future, please use caml_fill_bytes
+  and caml_create_bytes for migration
   (Hongbo Zhang, review by Damien Doligez, Alain Frisch, and Hugo Heuzard)
 
 - PR#3612, PR#92: allow allocating custom block with finalizers

--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -130,11 +130,10 @@ let float_of_string_opt x =
 
 let parse_argv_dynamic ?(current=current) argv speclist anonfun errmsg =
   let argv = ref argv in
-  let l = ref (Array.length !argv) in
   let b = Buffer.create 200 in
   let initpos = !current in
   let stop error =
-    let progname = if initpos < !l then !argv.(initpos) else "(?)" in
+    let progname = if initpos < (Array.length !argv) then !argv.(initpos) else "(?)" in
     begin match error with
       | Unknown "-help" -> ()
       | Unknown "--help" -> ()
@@ -154,7 +153,7 @@ let parse_argv_dynamic ?(current=current) argv speclist anonfun errmsg =
     else raise (Bad (Buffer.contents b))
   in
   incr current;
-  while !current < !l do
+  while !current < (Array.length !argv) do
     let s = !argv.(!current) in
     if String.length s >= 1 && s.[0] = '-' then begin
       let action, follow =
@@ -172,7 +171,7 @@ let parse_argv_dynamic ?(current=current) argv speclist anonfun errmsg =
       let get_arg () =
         match follow with
         | None ->
-          if !current + 1 < !l then !argv.(!current + 1)
+          if !current + 1 < (Array.length !argv) then !argv.(!current + 1)
           else stop (Missing s)
         | Some arg -> arg
       in
@@ -240,7 +239,7 @@ let parse_argv_dynamic ?(current=current) argv speclist anonfun errmsg =
         | Tuple specs ->
             List.iter treat_action specs;
         | Rest f ->
-            while !current < !l - 1 do
+            while !current < (Array.length !argv) - 1 do
               f !argv.(!current + 1);
               consume_arg ();
             done;
@@ -249,9 +248,8 @@ let parse_argv_dynamic ?(current=current) argv speclist anonfun errmsg =
             let newarg = f arg in
             consume_arg ();
             let before = Array.sub !argv 0 (!current + 1)
-            and after = Array.sub !argv (!current + 1) (!l - !current - 1) in
+            and after = Array.sub !argv (!current + 1) ((Array.length !argv) - !current - 1) in
             argv:= Array.concat [before;newarg;after];
-            l := Array.length !argv;
         in
         treat_action action
       with Bad m -> stop (Message m);

--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -38,7 +38,7 @@ type spec =
                                   function with each remaining argument *)
   | Expand of (string -> string array) (* If the remaining arguments to process
                                           are of the form
-                                          [[-foo"; "arg"] @ rest] where "foo" is
+                                          [["-foo"; "arg"] @ rest] where "foo" is
                                           registered as [Expand f], then the
                                           arguments [f "arg" @ rest] are
                                           processed *)

--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -128,8 +128,7 @@ let float_of_string_opt x =
   try Some (float_of_string x)
   with Failure _ -> None
 
-let parse_argv_dynamic ?(current=current) argv speclist anonfun errmsg =
-  let argv = ref argv in
+let parse_and_expand_argv_dynamic ?(current=current) argv speclist anonfun errmsg =
   let b = Buffer.create 200 in
   let initpos = !current in
   let stop error =
@@ -261,6 +260,9 @@ let parse_argv_dynamic ?(current=current) argv speclist anonfun errmsg =
       incr current;
     end;
   done
+
+let parse_argv_dynamic ?(current=current) argv speclist anonfun errmsg =
+  parse_and_expand_argv_dynamic ~current:current (ref argv) speclist anonfun errmsg
 
 
 let parse_argv ?(current=current) argv speclist anonfun errmsg =

--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -129,7 +129,7 @@ let float_of_string_opt x =
   try Some (float_of_string x)
   with Failure _ -> None
 
-let parse_and_expand_argv_dynamic_aux expand current argv speclist anonfun errmsg =
+let parse_and_expand_argv_dynamic_aux allow_expand current argv speclist anonfun errmsg =
   let b = Buffer.create 200 in
   let initpos = !current in
   let stop error =
@@ -244,8 +244,8 @@ let parse_and_expand_argv_dynamic_aux expand current argv speclist anonfun errms
               consume_arg ();
             done;
         | Expand f ->
-            if not expand then
-              raise (Stop (Message ("Expand is not allowed")));
+            if not allow_expand then
+              raise (Invalid_argument "Arg.Expand is is only allowed with Arg.parse_and_expand_argv_dynamic");
             let arg = get_arg () in
             let newarg = f arg in
             consume_arg ();
@@ -264,7 +264,7 @@ let parse_and_expand_argv_dynamic_aux expand current argv speclist anonfun errms
     end;
   done
 
-let parse_and_expand_argv_dynamic ?(current=current) argv speclist anonfun errmsg =
+let parse_and_expand_argv_dynamic current argv speclist anonfun errmsg =
   parse_and_expand_argv_dynamic_aux true current argv speclist anonfun errmsg
 
 let parse_argv_dynamic ?(current=current) argv speclist anonfun errmsg =

--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -36,9 +36,12 @@ type spec =
                                   call the function with the symbol. *)
   | Rest of (string -> unit)   (* Stop interpreting keywords and call the
                                   function with each remaining argument *)
-  | Expand of (string -> string array) (* Call the function with a string
-                                          argument and recursively parse the
-                                          returned array *)
+  | Expand of (string -> string array) (* If the remaining arguments to process
+                                          are of the form
+                                          [[-foo"; "arg"] @ rest] where "foo" is
+                                          registered as [Expand f], then the
+                                          arguments [f "arg" @ rest] are
+                                          processed *)
 
 exception Bad of string
 exception Help of string
@@ -242,9 +245,8 @@ let rec parse_argv_dynamic ?(current=current) argv speclist anonfun errmsg =
             done;
         | Expand f ->
             let arg = get_arg () in
-            let newarg = f arg
-            and newcurr = ref 0 in
-            parse_argv_dynamic ~current:newcurr newarg speclist anonfun errmsg;
+            let newarg = f arg in
+            parse_argv_dynamic ~current:current newarg speclist anonfun errmsg;
             consume_arg ();
         in
         treat_action action

--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -36,7 +36,9 @@ type spec =
                                   call the function with the symbol. *)
   | Rest of (string -> unit)   (* Stop interpreting keywords and call the
                                   function with each remaining argument *)
-  | Expand of (string -> string array)
+  | Expand of (string -> string array) (* Call the function with a string
+                                          argument and recursively parse the
+                                          returned array *)
 
 exception Bad of string
 exception Help of string

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -61,7 +61,7 @@ type spec =
                                    function with each remaining argument *)
   | Expand of (string -> string array) (** If the remaining arguments to process
                                            are of the form
-                                           [[-foo"; "arg"] @ rest] where "foo" is
+                                           [["-foo"; "arg"] @ rest] where "foo" is
                                            registered as [Expand f], then the
                                            arguments [f "arg" @ rest] are
                                            processed *)

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -59,6 +59,7 @@ type spec =
                                    call the function with the symbol *)
   | Rest of (string -> unit)   (** Stop interpreting keywords and call the
                                    function with each remaining argument *)
+  | Expand of (string -> string array)
 (** The concrete type describing the behavior associated
    with a keyword. *)
 

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -131,6 +131,13 @@ val parse_argv_dynamic : ?current:int ref -> string array ->
     See {!Arg.parse_dynamic}.
 *)
 
+val parse_and_expand_argv_dynamic : ?current:int ref -> string array ref ->
+  (key * spec * doc) list ref -> anon_fun -> string -> unit
+(** Same as {!Arg.parse_argv_dynamic}, except that the [argv] argument is a
+    reference and may be updated during the parsing of [Expand] arguments.
+    See {!Arg.parse_argv_dynamic}.
+*)
+
 exception Help of string
 (** Raised by [Arg.parse_argv] when the user asks for help. *)
 

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -132,7 +132,7 @@ val parse_argv_dynamic : ?current:int ref -> string array ->
     See {!Arg.parse_dynamic}.
 *)
 
-val parse_and_expand_argv_dynamic : ?current:int ref -> string array ref ->
+val parse_and_expand_argv_dynamic : int ref -> string array ref ->
   (key * spec * doc) list ref -> anon_fun -> string -> unit
 (** Same as {!Arg.parse_argv_dynamic}, except that the [argv] argument is a
     reference and may be updated during the parsing of [Expand] arguments.

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -59,9 +59,12 @@ type spec =
                                    call the function with the symbol *)
   | Rest of (string -> unit)   (** Stop interpreting keywords and call the
                                    function with each remaining argument *)
-  | Expand of (string -> string array) (** Call the function with a string
-                                           argument and recursively parse the
-                                           returned array *)
+  | Expand of (string -> string array) (** If the remaining arguments to process
+                                           are of the form
+                                           [[-foo"; "arg"] @ rest] where "foo" is
+                                           registered as [Expand f], then the
+                                           arguments [f "arg" @ rest] are
+                                           processed *)
 (** The concrete type describing the behavior associated
    with a keyword. *)
 

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -59,7 +59,9 @@ type spec =
                                    call the function with the symbol *)
   | Rest of (string -> unit)   (** Stop interpreting keywords and call the
                                    function with each remaining argument *)
-  | Expand of (string -> string array)
+  | Expand of (string -> string array) (** Call the function with a string
+                                           argument and recursively parse the
+                                           returned array *)
 (** The concrete type describing the behavior associated
    with a keyword. *)
 

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -64,7 +64,8 @@ type spec =
                                            [["-foo"; "arg"] @ rest] where "foo" is
                                            registered as [Expand f], then the
                                            arguments [f "arg" @ rest] are
-                                           processed *)
+                                           processed. Only allowed in
+                                           [parse_and_expand_argv_dynamic]. *)
 (** The concrete type describing the behavior associated
    with a keyword. *)
 

--- a/testsuite/tests/lib-arg/testarg.ml
+++ b/testsuite/tests/lib-arg/testarg.ml
@@ -89,7 +89,7 @@ let test spec argv =
   r_int := 0;
   r_float := 0.0;
   accum := [];
-  Arg.parse_and_expand_argv_dynamic ~current argv (ref spec) f_anon "usage";
+  Arg.parse_and_expand_argv_dynamic current argv (ref spec) f_anon "usage";
   let result = List.rev !accum in
   let reference = [
       "anon(anon1)";

--- a/testsuite/tests/lib-arg/testarg.ml
+++ b/testsuite/tests/lib-arg/testarg.ml
@@ -81,7 +81,7 @@ let args2 = [|
 let error s = Printf.printf "error (%s)\n" s;;
 let check r v msg = if !r <> v then error msg;;
 
-let test argv =
+let test spec argv =
   current := 0;
   r_set := false;
   r_clear := true;
@@ -119,5 +119,22 @@ let test argv =
   check r_float 2.72 "Set_float";
 ;;
 
-test args1;;
-test args2;;
+let test_arg = test spec;;
+
+test_arg args1;;
+test_arg args2;;
+
+let f_expand r msg arg s =
+  if s <> r then error msg;
+  arg;
+;;
+
+let expand1 = Arg.[
+  "-expand", Expand (f_expand "expand_arg1" "Expand" args1), "Expand (1)";
+];;
+let expand2 = Arg.[
+  "-expand", Expand (f_expand "expand_arg2" "Expand" args2), "Expand (1)";
+];;
+
+test (expand1@spec) [|"prog";"-expand";"expand_arg1"|];;
+test (expand2@spec) [|"prog";"-expand";"expand_arg2"|];;

--- a/testsuite/tests/lib-arg/testarg.ml
+++ b/testsuite/tests/lib-arg/testarg.ml
@@ -129,11 +129,17 @@ let f_expand r msg arg s =
   arg;
 ;;
 
-let expand1 = Arg.[
-  "-expand", Expand (f_expand "expand_arg1" "Expand" args1), "Expand (1)";
+let expand1 =
+  let l = Array.length args1  - 1 in
+  let args = Array.sub args1 1 l in
+  Arg.[
+  "-expand", Expand (f_expand "expand_arg1" "Expand" args), "Expand (1)";
 ];;
-let expand2 = Arg.[
-  "-expand", Expand (f_expand "expand_arg2" "Expand" args2), "Expand (1)";
+let expand2 =
+  let l = Array.length args2  - 1 in
+  let args = Array.sub args2 1 l in
+  Arg.[
+  "-expand", Expand (f_expand "expand_arg2" "Expand" args), "Expand (1)";
 ];;
 
 test (expand1@spec) [|"prog";"-expand";"expand_arg1"|];;


### PR DESCRIPTION
This PR adds a new spec for the `Arg` parser: `Expand of (string -> string array)` which takes a function as arguments and parses the returned `string array` recursively with the same set of specs.

This implements the approach mentioned by @xavierleroy in #748.
