### PR TITLE
Fix FlexDLL bootstrap when system flexlink found

### DIFF
--- a/Makefile.nt
+++ b/Makefile.nt
@@ -615,7 +615,7 @@ alldepend::
 runtimeopt: makeruntimeopt stdlib/libasmrun.$(A)
 
 makeruntimeopt:
-	cd asmrun ; $(MAKEREC) all
+	cd asmrun ; $(MAKEREC) $(BOOT_FLEXLINK_CMD) all
 stdlib/libasmrun.$(A): asmrun/libasmrun.$(A)
 	cp asmrun/libasmrun.$(A) stdlib/libasmrun.$(A)
 clean::


### PR DESCRIPTION
Building the native runtime could accidentally pick up the wrong include
directory for flexdll.h.

Background in https://sympa.inria.fr/sympa/arc/caml-list/2016-06/msg00123.html
