### PR TITLE
Handle specialisation of recursive function that does not always preserve the arguments (MPR#7291)

### DIFF
--- a/Changes
+++ b/Changes
@@ -163,6 +163,10 @@ OCaml 4.04.0:
 - GPR#723 Sort emitted functions according to source location
   (Pierre Chambart, review by Mark Shinwell)
 
+- PR#7291, GPR#780: Handle specialisation of recursive function that does
+  not always preserve the arguments
+  (Pierre Chambart, Mark Shinwell, report by Simon Cruanes)
+
 ### Runtime system:
 
 - PR#7210, GPR#562: Allows to register finalisation function that are

--- a/middle_end/flambda_utils.ml
+++ b/middle_end/flambda_utils.ml
@@ -839,3 +839,27 @@ let projection_to_named (projection : Projection.t) : Flambda.named =
   | Move_within_set_of_closures move -> Move_within_set_of_closures move
   | Field (field_index, var) ->
     Prim (Pfield field_index, [var], Debuginfo.none)
+
+type specialised_to_same_as =
+  | Not_specialised
+  | Specialised_and_aliased_to of Variable.Set.t
+
+let parameters_specialised_to_the_same_variable
+      ~(function_decls : Flambda.function_declarations)
+      ~(specialised_args : Flambda.specialised_to Variable.Map.t) =
+  let specialised_arg_aliasing =
+    (* For each external variable involved in a specialisation, which
+       internal variable(s) it maps to via that specialisation. *)
+    Variable.Map.transpose_keys_and_data_set
+      (Variable.Map.map (fun ({ var; _ } : Flambda.specialised_to) -> var)
+        specialised_args)
+  in
+  Variable.Map.map (fun ({ params; _ } : Flambda.function_declaration) ->
+      List.map (fun param ->
+          match Variable.Map.find param specialised_args with
+          | exception Not_found -> Not_specialised
+          | { var; _ } ->
+            Specialised_and_aliased_to
+              (Variable.Map.find var specialised_arg_aliasing))
+        params)
+    function_decls.funs

--- a/middle_end/flambda_utils.mli
+++ b/middle_end/flambda_utils.mli
@@ -214,3 +214,18 @@ val clean_projections
   -> Flambda.specialised_to Variable.Map.t
 
 val projection_to_named : Projection.t -> Flambda.named
+
+type specialised_to_same_as =
+  | Not_specialised
+  | Specialised_and_aliased_to of Variable.Set.t
+
+(** For each parameter in a given set of function declarations and the usual
+    specialised-args mapping, determine which other parameters are specialised
+    to the same variable as that parameter.
+    The result is presented as a map from [fun_vars] to lists, corresponding
+    componentwise to the usual [params] list in the corresponding function
+    declaration. *)
+val parameters_specialised_to_the_same_variable
+   : function_decls:Flambda.function_declarations
+  -> specialised_args:Flambda.specialised_to Variable.Map.t
+  -> specialised_to_same_as list Variable.Map.t

--- a/middle_end/inlining_transforms.ml
+++ b/middle_end/inlining_transforms.ml
@@ -187,6 +187,19 @@ let inline_by_copying_function_declaration ~env ~r
     ~(invariant_params:Variable.Set.t Variable.Map.t lazy_t)
     ~(specialised_args : Flambda.specialised_to Variable.Map.t)
     ~direct_call_surrogates ~dbg ~simplify =
+
+  let function_decls =
+    (* Rewrite the recursive uses of the closure symbol to simplify
+       the following substitutions *)
+    let make_closure_symbol =
+      let module Backend = (val (E.backend env) : Backend_intf.S) in
+      Backend.closure_symbol
+    in
+    Freshening.rewrite_recursive_calls_with_symbols
+      (Freshening.activate Freshening.empty)
+      ~make_closure_symbol
+      function_decls
+  in
   let original_function_decls = function_decls in
   let specialised_args_set = Variable.Map.keys specialised_args in
   let worth_specialising_args, specialisable_args, args, args_decl =
@@ -265,6 +278,7 @@ let inline_by_copying_function_declaration ~env ~r
           Variable.Map.add internal_var from_closure map,
             (from_closure.var, expr)::for_lets)
     in
+
     let required_functions =
       Flambda_utils.closures_required_by_entry_point ~backend:(E.backend env)
         ~entry_point:closure_id_being_applied
@@ -275,6 +289,28 @@ let inline_by_copying_function_declaration ~env ~r
           Variable.Set.mem func required_functions)
         function_decls.funs
     in
+
+    let free_vars, free_vars_for_lets, original_vars =
+      (* Bind all the closures from the original set as free variables
+         in the set. *)
+      Variable.Map.fold (fun fun_var _fun_decl (free_vars, free_vars_for_lets, original_vars) ->
+          let var = Variable.create "closure" in
+          let original_closure : Flambda.named =
+            Move_within_set_of_closures
+              { closure = lhs_of_application;
+                start_from = closure_id_being_applied;
+                move_to = Closure_id.wrap fun_var }
+          in
+          let internal_var =
+            Variable.rename ~append:"_original" fun_var
+          in
+          Variable.Map.add internal_var { Flambda.var; projection = None } free_vars,
+          (var, original_closure) :: free_vars_for_lets,
+          Variable.Map.add fun_var internal_var original_vars)
+        funs
+        (free_vars, free_vars_for_lets, Variable.Map.empty)
+    in
+
     let direct_call_surrogates =
       Closure_id.Map.fold (fun existing surrogate surrogates ->
           let existing = Closure_id.unwrap existing in
@@ -288,12 +324,14 @@ let inline_by_copying_function_declaration ~env ~r
         direct_call_surrogates
         Variable.Map.empty
     in
-    let function_decls =
-      Flambda.update_function_declarations ~funs function_decls
-    in
+
     let all_functions_parameters =
+      let function_decls =
+        Flambda.update_function_declarations ~funs function_decls
+      in
       Flambda_utils.all_functions_parameters function_decls
     in
+
     let specialisable_args =
       Variable.Map.merge (fun param v1 v2 ->
           match v1, v2 with
@@ -330,7 +368,8 @@ let inline_by_copying_function_declaration ~env ~r
                   (Variable.Map.print Variable.print)
                     specialisable_args_with_aliases
                   Flambda.print_function_declarations original_function_decls
-                  Flambda.print_function_declarations function_decls
+                  Flambda.print_function_declarations
+                  (Flambda.update_function_declarations ~funs function_decls)
                   (Variable.Map.print Flambda.print_specialised_to)
                     specialised_args
               | argument_from_the_current_application ->
@@ -339,6 +378,132 @@ let inline_by_copying_function_declaration ~env ~r
               None)
         specialisable_args_with_aliases specialised_args
     in
+
+    let functions_specialised_params =
+      (* For each functions, this is the list of the specialised
+         arguments, and the set of arguments (including other functions)
+         aliased to it. *)
+      let specialised_arg_aliasing =
+        Variable.Map.transpose_keys_and_data_set
+          (Variable.Map.map (fun ({ var }:Flambda.specialised_to) -> var)
+             specialisable_args)
+      in
+      Variable.Map.map (fun ({ params }:Flambda.function_declaration) ->
+        List.map (fun arg ->
+              match Variable.Map.find arg specialisable_args with
+              | exception Not_found ->
+                `Not_specialised
+              | { var } ->
+                `Specialised_and_aliased_to
+                  (Variable.Map.find var specialised_arg_aliasing))
+          params)
+        funs
+    in
+
+    let rewrite_function (fun_decl:Flambda.function_declaration) =
+      (* First rewrite every use of the currently defined closures
+         to the original closure (bound as free variable).
+
+         Then for each call if this is preserving the specialised
+         arguments then replace it by a recursive call.
+
+         In a function like List.map:
+
+         {[
+           let rec specialised_map f l =
+             match l with
+             | [] -> []
+             | h :: t ->
+                 f h :: specialised_map f t
+         ]} ( with [f] a specialised argument )
+
+         The first step turns it into:
+
+         {[
+           let map_original = map in
+           let rec specialised_map f l =
+             match l with
+             | [] -> []
+             | h :: t ->
+                 f h :: map_original f t
+         ]}
+
+         then the second recognize the call to map_original as a call
+         preserving the specialised arguments (here [f]). So it is
+         replaced by [specialised_map f t].
+
+         In the case of map this is not obviously interesting to
+         handle it that way, but this allows to handle situations
+         where there are recursive calls that are not preserving the
+         arguments. In that case the first pass turn it into a correct
+         code, and the second one optimize the benefitial recursive
+         calls.
+      *)
+      let body_substituted =
+        Flambda_utils.toplevel_substitution original_vars fun_decl.body
+      in
+      let body =
+        Flambda_iterators.map_toplevel_expr (fun (expr:Flambda.t) : Flambda.t ->
+          match expr with
+          | Apply apply -> begin
+              match apply.kind with
+              | Indirect ->
+                expr
+              | Direct closure_id -> begin
+                  (* We recognize the potential recursive calls using the
+                     closure id rather than [apply.func] because those can be
+                     aliases to the function (through a symbol for instance)
+                     and not directly the closure variable. *)
+                  let closure_var = Closure_id.unwrap closure_id in
+                  match Variable.Map.find closure_var functions_specialised_params with
+                  | exception Not_found ->
+                    expr
+                  | specialised_params ->
+                    (* This is a call to one of the functions from the
+                       set being specialised *)
+                    let apply_is_preserving_specialised_args =
+                      List.length apply.args = List.length specialised_params &&
+                      List.for_all2 (fun arg param ->
+                        match arg with
+                        | `Not_specialised -> true
+                        | `Specialised_and_aliased_to args ->
+                          (* This is using one of the aliases of param. This
+                             is not necessarilly the exact same variable as
+                             the original parameter when the set contains some
+                             multiply recursive functions. *)
+                          Variable.Set.mem param args)
+                        specialised_params
+                        apply.args
+                    in
+                    if apply_is_preserving_specialised_args then
+                      Flambda.Apply
+                        { apply with func = closure_var;
+                                     kind = Direct closure_id }
+                    else
+                      expr
+                end
+            end
+          | _ -> expr)
+          body_substituted
+      in
+      Flambda.create_function_declaration
+        ~params:fun_decl.params
+        ~stub:fun_decl.stub
+        ~dbg:fun_decl.dbg
+        ~inline:fun_decl.inline
+        ~specialise:fun_decl.specialise
+        ~is_a_functor:fun_decl.is_a_functor
+        ~body
+    in
+
+    let funs =
+      Variable.Map.map rewrite_function funs
+    in
+
+    let function_decls =
+      Flambda.update_function_declarations ~funs function_decls
+    in
+
     let set_of_closures =
       (* This is the new set of closures, with more precise specialisation
          information than the one being copied. *)

--- a/utils/identifiable.ml
+++ b/utils/identifiable.ml
@@ -104,6 +104,17 @@ module Make_map (T : Thing) = struct
   let of_set f set = T_set.fold (fun e map -> add e (f e) map) set empty
 
   let transpose_keys_and_data map = fold (fun k v m -> add v k m) map empty
+  let transpose_keys_and_data_set map =
+    fold (fun k v m ->
+        let set =
+          match find v m with
+          | exception Not_found ->
+            T_set.singleton k
+          | set ->
+            T_set.add k set
+        in
+        add v set m)
+      map empty
 end
 
 module Make_set (T : Thing) = struct
@@ -194,6 +205,7 @@ module type S = sig
     val data : 'a t -> 'a list
     val of_set : (key -> 'a) -> Make_set (T).t -> 'a t
     val transpose_keys_and_data : key t -> key t
+    val transpose_keys_and_data_set : key t -> Set.t t
     val print :
       (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
   end

--- a/utils/identifiable.mli
+++ b/utils/identifiable.mli
@@ -73,6 +73,7 @@ module type S = sig
     val data : 'a t -> 'a list
     val of_set : (key -> 'a) -> Set.t -> 'a t
     val transpose_keys_and_data : key t -> key t
+    val transpose_keys_and_data_set : key t -> Set.t t
     val print :
       (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
   end


### PR DESCRIPTION
This is a followup to https://github.com/ocaml/ocaml/pull/731

The other solution to fixing [MPR#7291](http://caml.inria.fr/mantis/view.php?id=7291) is to drop the requirement from the parameter invariance analysis from being an over-approximation.

This is done by some rewriting of specialised functions before freshening. Every recursive calls that are not obviously preserving the arguments that will be specialised call the original function instead of a recursive call to the specialised version.

This is a bit more complex than originally expected to be able to multiply recursive functions like:

``` OCaml
type a =
  | A of b
  | End

and b =
  | B of a

let rec iter_a f a =
  match a with
  | A b ->
    f ();
    iter_b f b
  | End ->
    ()

and iter_b f b =
  match b with
  | B a ->
    f ();
    iter_a f a


let count a =
  let r = ref 0 in
  let increm () = incr r in
  (iter_a [@specialised]) increm a;
  !r
```

This change is not the most efficient possible: There are 3 added rewritings of the functions.
Some could be eliminated. This is only a first proposal.
