### PR TITLE
Avoid rebuilding cmi_info record when creating .cmti files

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,14 @@ Next version (tbd):
   debugger/
   (Sébastien Hinderer)
 
+### Internal/compiler-libs changes:
+
+- GPR#744, GPR#781: fix duplicate self-reference in imported cmi_crcs
+  list in .cmti files + avoid rebuilding cmi_info record when creating
+  .cmti files
+  (Alain Frisch, report by Daniel Bunzli, review by Jeremie Dimino)
+
+
 OCaml 4.04.0:
 -------------
 

--- a/typing/cmt_format.ml
+++ b/typing/cmt_format.ml
@@ -164,27 +164,13 @@ let record_value_dependency vd1 vd2 =
   if vd1.Types.val_loc <> vd2.Types.val_loc then
     value_deps := (vd1, vd2) :: !value_deps
 
-let save_cmt filename modname binary_annots sourcefile initial_env sg =
+let save_cmt filename modname binary_annots sourcefile initial_env cmi =
   if !Clflags.binary_annotations && not !Clflags.print_types then begin
-    let imports = Env.imports () in
-    let flags =
-      List.concat [
-        if !Clflags.recursive_types then [Cmi_format.Rectypes] else [];
-        if !Clflags.opaque then [Cmi_format.Opaque] else [];
-        ]
-    in
     let oc = open_out_bin filename in
     let this_crc =
-      match sg with
-          None -> None
-        | Some (sg) ->
-          let cmi = {
-            cmi_name = modname;
-            cmi_sign = sg;
-            cmi_flags = flags;
-            cmi_crcs = imports;
-          } in
-          Some (output_cmi filename oc cmi)
+      match cmi with
+      | None -> None
+      | Some cmi -> Some (output_cmi filename oc cmi)
     in
     let source_digest = Misc.may_map Digest.file sourcefile in
     let cmt = {
@@ -199,7 +185,7 @@ let save_cmt filename modname binary_annots sourcefile initial_env sg =
       cmt_source_digest = source_digest;
       cmt_initial_env = if need_to_clear_env then
           keep_only_summary initial_env else initial_env;
-      cmt_imports = List.sort compare imports;
+      cmt_imports = List.sort compare (Env.imports ());
       cmt_interface_digest = this_crc;
       cmt_use_summaries = need_to_clear_env;
     } in

--- a/typing/cmt_format.mli
+++ b/typing/cmt_format.mli
@@ -83,7 +83,7 @@ val read : string -> Cmi_format.cmi_infos option * cmt_infos option
 val read_cmt : string -> cmt_infos
 val read_cmi : string -> Cmi_format.cmi_infos
 
-(** [save_cmt modname filename binary_annots sourcefile initial_env sg]
+(** [save_cmt filename modname binary_annots sourcefile initial_env cmi]
     writes a cmt(i) file.  *)
 val save_cmt :
   string ->  (* filename.cmt to generate *)
@@ -91,8 +91,7 @@ val save_cmt :
   binary_annots ->
   string option ->  (* source file *)
   Env.t -> (* initial env *)
-  Types.signature option -> (* if a .cmi was generated,
-                               the signature saved there *)
+  Cmi_format.cmi_infos option -> (* if a .cmi was generated *)
   unit
 
 (* Miscellaneous functions *)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1926,7 +1926,7 @@ let save_signature_with_imports ~deprecated sg modname filename imports =
         ps_flags = cmi.cmi_flags;
       } in
     save_pers_struct crc ps;
-    sg
+    cmi
   with exn ->
     close_out oc;
     remove_file filename;

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -186,12 +186,12 @@ val get_unit_name: unit -> string
 val read_signature: string -> string -> signature
         (* Arguments: module name, file name. Results: signature. *)
 val save_signature:
-  deprecated:string option -> signature -> string -> string -> signature
+  deprecated:string option -> signature -> string -> string -> Cmi_format.cmi_infos
         (* Arguments: signature, module name, file name. *)
 val save_signature_with_imports:
   deprecated:string option ->
   signature -> string -> string -> (string * Digest.t option) list
-  -> signature
+  -> Cmi_format.cmi_infos
         (* Arguments: signature, module name, file name,
            imported units with their CRCs. *)
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1635,13 +1635,13 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
          case, the inferred signature contains only the last declaration. *)
       if not !Clflags.dont_write_files then begin
         let deprecated = Builtin_attributes.deprecated_of_str ast in
-        let sg =
+        let cmi =
           Env.save_signature ~deprecated
             simple_sg modulename (outputprefix ^ ".cmi")
         in
         Cmt_format.save_cmt  (outputprefix ^ ".cmt") modulename
           (Cmt_format.Implementation str)
-          (Some sourcefile) initial_env (Some sg);
+          (Some sourcefile) initial_env (Some cmi);
       end;
       (str, coercion)
     end
@@ -1722,13 +1722,13 @@ let package_units initial_env objfiles cmifile modulename =
         (Env.imports()) in
     (* Write packaged signature *)
     if not !Clflags.dont_write_files then begin
-      let sg =
+      let cmi =
         Env.save_signature_with_imports ~deprecated:None
           sg modulename
           (prefix ^ ".cmi") imports
       in
       Cmt_format.save_cmt (prefix ^ ".cmt")  modulename
-        (Cmt_format.Packed (sg, objfiles)) None initial_env (Some sg)
+        (Cmt_format.Packed (cmi.Cmi_format.cmi_sign, objfiles)) None initial_env (Some cmi)
     end;
     Tcoerce_none
   end

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -47,7 +47,7 @@ val path_of_module : Typedtree.module_expr -> Path.t option
 
 val save_signature:
   string -> Typedtree.signature -> string -> string ->
-  Env.t -> Types.signature_item list -> unit
+  Env.t -> Cmi_format.cmi_infos -> unit
 
 val package_units:
   Env.t -> string list -> string -> string -> Typedtree.module_coercion


### PR DESCRIPTION
Instead of rebuilding cmi_info in Cmt_format.save_cmt, the record
created in Env.save_signature is kept and passed to that function.  In
addition to simplifying the code, this avoids possible mismatch between
the two records, including:
- Duplicated entry in cmi_crcs for the current unit as noted in #744.
- Missing flags (Unsafe_string/Deprecated were not properly set in
  Cmt_format).

The interface is also stronger, since the signature passed to save_cmt
was supposed to be already mapped by Subst.for_saving but this was not
reflected in the API.
