### PR TITLE
Tidy up clean targets

### DIFF
--- a/Makefile.nt
+++ b/Makefile.nt
@@ -742,7 +742,8 @@ alldepend:: depend
 
 distclean:
 	$(MAKEREC) clean
-	rm -f asmrun/.depend.nt byterun/.depend.nt
+	rm -f asmrun/.depend.nt byterun/.depend.nt otherlibs/bigarray/.depend.nt  \
+		    otherlibs/str/.depend.nt
 	rm -f boot/ocamlrun boot/ocamlrun.exe boot/camlheader boot/ocamlyacc \
 	      boot/*.cm* boot/libcamlrun.a
 	rm -f config/Makefile config/m.h config/s.h

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -224,7 +224,7 @@ compilerlibs/ocamlmiddleend.cma: $(MIDDLE_END)
 compilerlibs/ocamlmiddleend.cmxa: $(MIDDLE_END:%.cmo=%.cmx)
 	$(CAMLOPT) -a -o $@ $^
 partialclean::
-	rm -f compilerlibs/ocamlmiddleend.cma
+	rm -f compilerlibs/ocamlmiddleend.cma compilerlibs/ocamlmiddleend.cmxa compilerlibs/ocamlmiddleend.$(A)
 
 
 # Tools


### PR DESCRIPTION
Four files left behind by `make [dist]clean`
