### PR TITLE
MPR#7333: Ocamldoc, use first sentence as a short description for text files in global overviews

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,13 @@ Next version (tbd):
 - PR#7315, GPR#736: refine some error locations
   (Gabriel Scherer and Alain Frisch, report by Matej Košík)
 
+
+### Tools:
+
+- PR#7333: ocamldoc, use the first sentence of text file as
+  a short description in overviews.
+  (Florian Angeletti)
+
 ### Compiler distribution build system:
 
 - GPR#729: Make sure ocamlnat is built with a $(EXE) extension, merge

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -231,10 +231,7 @@ let process_file sourcefile =
             raise (Failure (Odoc_messages.text_parse_error l c s))
         in
          let m_info =
-        (* use the first sentence of the text as a short description for
-           the whole file *)
-          let i_desc = Some (Odoc_misc.first_sentence_of_text txt) in
-          Some Odoc_types.{dummy_info with i_desc} in
+          Some Odoc_types.{dummy_info with i_desc= Some txt } in
         let m =
           {
             Odoc_module.m_name = mod_name ;
@@ -242,8 +239,7 @@ let process_file sourcefile =
             Odoc_module.m_info;
             Odoc_module.m_is_interface = true ;
             Odoc_module.m_file = file ;
-            Odoc_module.m_kind = Odoc_module.Module_struct
-              [Odoc_module.Element_module_comment txt] ;
+            Odoc_module.m_kind = Odoc_module.Module_struct [] ;
             Odoc_module.m_loc =
               { Odoc_types.loc_impl = None ;
                 Odoc_types.loc_inter = Some (Location.in_file file) } ;

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -230,11 +230,16 @@ let process_file sourcefile =
           with Odoc_text.Text_syntax (l, c, s) ->
             raise (Failure (Odoc_messages.text_parse_error l c s))
         in
+         let m_info =
+        (* use the first sentence of the text as a short description for
+           the whole file *)
+          let i_desc = Some (Odoc_misc.first_sentence_of_text txt) in
+          Some Odoc_types.{dummy_info with i_desc} in
         let m =
           {
             Odoc_module.m_name = mod_name ;
             Odoc_module.m_type = Types.Mty_signature [] ;
-            Odoc_module.m_info = None ;
+            Odoc_module.m_info;
             Odoc_module.m_is_interface = true ;
             Odoc_module.m_file = file ;
             Odoc_module.m_kind = Odoc_module.Module_struct

--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -2560,7 +2560,10 @@ class html =
           );
         bs b "</h1>\n";
 
-        if not modu.m_text_only then self#html_of_module b ~with_link: false modu;
+        if not modu.m_text_only then
+          self#html_of_module b ~with_link: false modu
+        else
+          self#html_of_info ~indent:false b modu.m_info;
 
         (* parameters for functors *)
         self#html_of_module_parameter_list b

--- a/ocamldoc/odoc_latex.ml
+++ b/ocamldoc/odoc_latex.ml
@@ -1209,20 +1209,13 @@ class latex =
     method generate_for_top_module fmt m =
       let (first_t, rest_t) = self#first_and_rest_of_info m.m_info in
       let text =
-        if m.m_text_only then
-          [ Title (1, None, [Raw m.m_name]  @
-                   (match first_t with
-                     [] -> []
-                   | t -> (Raw " : ") :: t)
-                  ) ;
-          ]
-        else
-          [ Title (1, None,
-                   [ Raw (Odoc_messages.modul^" ") ; Code m.m_name ] @
-                   (match first_t with
-                     [] -> []
-                   | t -> (Raw " : ") :: t)) ;
-          ]
+        let title =
+          if m.m_text_only then [Raw m.m_name]
+          else [ Raw (Odoc_messages.modul^" ") ; Code m.m_name ] in
+        let subtitle = match first_t with
+          | [] -> []
+          | t -> (Raw " : ") :: t in
+        [ Title (1, None, title @ subtitle ) ]
       in
       self#latex_of_text fmt text;
       self#latex_for_module_label fmt m;

--- a/testsuite/tests/tool-ocamldoc-2/Makefile
+++ b/testsuite/tests/tool-ocamldoc-2/Makefile
@@ -33,11 +33,12 @@ default:
 	fi
 
 .PHONY: run
-run: *.ml *.mli
-	@for file in *.mli *.ml; do \
+run: *.ml *.mli *.txt
+	@for file in *.mli *.ml *.txt; do \
 	  printf " ... testing '$$file'"; \
 	  F="`basename $$file .mli`"; \
 	  F="`basename $$F .ml`"; \
+	  F="`basename $$F .txt`"; \
 	  $(OCAMLDOC) $(DOCFLAGS) -hide-warnings -latex $ \
 	              -o $$F.result $$file; \
 	  $(DIFF) $$F.reference $$F.result >/dev/null \

--- a/testsuite/tests/tool-ocamldoc-2/short_description.reference
+++ b/testsuite/tests/tool-ocamldoc-2/short_description.reference
@@ -12,14 +12,10 @@
 
 
 
-
-
-
-Short global description in text mode
-
-
 This file tests that documentation in text mode are given
 a short description in the global description of modules.
+
+
 
 
 \end{document}

--- a/testsuite/tests/tool-ocamldoc-2/short_description.reference
+++ b/testsuite/tests/tool-ocamldoc-2/short_description.reference
@@ -1,0 +1,25 @@
+\documentclass[11pt]{article} 
+\usepackage[latin1]{inputenc} 
+\usepackage[T1]{fontenc} 
+\usepackage{textcomp}
+\usepackage{fullpage} 
+\usepackage{url} 
+\usepackage{ocamldoc}
+\begin{document}
+\tableofcontents
+\section{Short\_description : Short global description in text mode}
+\label{Short-underscoredescription}\index{Short-underscoredescription@\verb`Short_description`}
+
+
+
+
+
+
+Short global description in text mode
+
+
+This file tests that documentation in text mode are given
+a short description in the global description of modules.
+
+
+\end{document}

--- a/testsuite/tests/tool-ocamldoc-2/short_description.txt
+++ b/testsuite/tests/tool-ocamldoc-2/short_description.txt
@@ -1,0 +1,4 @@
+Short global description in text mode
+
+This file tests that documentation in text mode are given
+a short description in the global description of modules.


### PR DESCRIPTION
[MPR#7333:](http://caml.inria.fr/mantis/view.php?id=7333)
In global overviews, ocamldoc uses the first sentence of documentation comments as a short description
of the content of the module/file for `.mli` and `.ml` files, but not for simple text file. As suggested in the linked mantis ticket, this pull request fixes this asymmetry and uses the first sentence of a text file as a short description of this file in global overviews.
