### PR TITLE
Improve comparisons to Array.length

### DIFF
--- a/testsuite/tests/basic-more/array_length_test.ml
+++ b/testsuite/tests/basic-more/array_length_test.ml
@@ -1,0 +1,61 @@
+
+let identity x = Sys.opaque_identity x
+  [@@inline never]
+
+let a0 = Array.make 0 0
+let a3 = Array.make 3 3
+let a5 = Array.make 5 5
+let a7 = Array.make 7 7
+
+let test_compare comparison =
+  let [@inline never] test_0 a =
+    assert(
+      (comparison (Array.length a) 0) =
+      (comparison (Array.length a) (identity 0)));
+    assert(
+      (comparison 0 (Array.length a)) =
+      (comparison (identity 0) (Array.length a)))
+  in
+
+  let [@inline never] test_5 a =
+    assert(
+      (comparison (Array.length a) 5) =
+      (comparison (Array.length a) (identity 5)));
+    assert(
+      (comparison 5 (Array.length a)) =
+      (comparison (identity 5) (Array.length a)))
+  in
+
+  let [@inline never] test_min_5 a =
+    assert(
+      (comparison (Array.length a) (-5)) =
+      (comparison (Array.length a) (identity (-5))));
+    assert(
+      (comparison (-5) (Array.length a)) =
+      (comparison (identity (-5)) (Array.length a)))
+  in
+
+  test_0 a0;
+  test_0 a3;
+  test_0 a5;
+  test_0 a7;
+
+  test_5 a0;
+  test_5 a3;
+  test_5 a5;
+  test_5 a7;
+
+  test_min_5 a0;
+  test_min_5 a3;
+  test_min_5 a5;
+  test_min_5 a7
+  [@@inline]
+
+let () =
+  test_compare (=);
+  test_compare (<);
+  test_compare (>);
+  test_compare (<=);
+  test_compare (>=);
+  print_endline "OK"
+

--- a/testsuite/tests/basic-more/array_length_test.reference
+++ b/testsuite/tests/basic-more/array_length_test.reference
@@ -1,0 +1,3 @@
+OK
+
+All tests succeeded.


### PR DESCRIPTION
When comparing the size of an array, the generated code has to extract the size (shift), tag it (or) and compare it. When the value to compare to is a constant we can instead transform the constant instead.

This allows to gain an instruction:

`Array.length a < 5` is compiled to (on amd64)

``` asm
    andq    $-1024, %rax
    cmpq    $5120, %rax
```

instead of

``` asm
    shrq    $9, %rax
    orq     $1, %rax
    cmpq    $11, %rax
```

This was considered to avoid differences with the specifically optimized checkbound construction.

Notice that something similar can also be done for some non constant comparisons (but not equality). I will take some time to add this to this patch if this kind of change is accepted
