### PR TITLE
minor heap runs from caml_young_start included…

### DIFF
--- a/byterun/caml/address_class.h
+++ b/byterun/caml/address_class.h
@@ -27,7 +27,7 @@
 
 #define Is_young(val) \
   (Assert (Is_block (val)), \
-   (addr)(val) < (addr)caml_young_end && (addr)(val) > (addr)caml_young_start)
+   (addr)(val) < (addr)caml_young_end && (addr)(val) >= (addr)caml_young_start)
 
 #define Is_in_heap(a) (Classify_addr(a) & In_heap)
 


### PR DESCRIPTION
… to caml_young_end excluded

Note that when `addr` is defined as `char *`, the macro `Is_young` invokes undefined behavior “when it returns false”. The problem would be much less acute if `addr` were defined as the C99 & later type `uintptr_t`, which is intended for this sort of use on platforms where it makes sense. The conversion from pointer to integer is implementation-defined but the intent of the standard is expressed in C11 [footnote 67](http://port70.net/~nsz/c/c11/n1570.html#note67).
