### PR TITLE
Manual bookkeeping: add the spacetime module to the manual

### DIFF
--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -8,7 +8,7 @@ STDLIB_INTF=Arg.tex Array.tex ArrayLabels.tex Char.tex Complex.tex \
   Parsing.tex Printexc.tex Printf.tex Queue.tex Random.tex Scanf.tex \
   Set.tex Sort.tex Stack.tex Stream.tex String.tex StringLabels.tex Sys.tex \
   Weak.tex Callback.tex Buffer.tex StdLabels.tex \
-  Bytes.tex BytesLabels.tex
+  Bytes.tex BytesLabels.tex Spacetime.tex
 
 COMPILER_LIBS_INTF=Asthelper.tex Astmapper.tex Asttypes.tex \
 	Lexer.tex Location.tex Longident.tex Parse.tex Pprintast.tex Printast.tex

--- a/manual/manual/library/stdlib.etex
+++ b/manual/manual/library/stdlib.etex
@@ -91,6 +91,7 @@ be called from C \\
 "Filename" & p.~\pageref{Filename} & operations on file names \\
 "Gc" & p.~\pageref{Gc} & memory management control and statistics \\
 "Printexc" & p.~\pageref{Printexc} & a catch-all exception handler \\
+"Spacetime" & p.~\pageref{Spacetime} & memory profiler \\
 "Sys" & p.~\pageref{Sys} & system interface \\
 \end{tabular}
 \end{latexonly}
@@ -131,6 +132,7 @@ be called from C \\
 \item \ahref{libref/Scanf.html}{Module \texttt{Scanf}: formatted input functions}
 \item \ahref{libref/Set.html}{Module \texttt{Set}: sets over ordered types}
 \item \ahref{libref/Sort.html}{(deprecated)}
+\item \ahref{libref/Spacetime.html}{Module \texttt{Spacetime}: memory profiler}
 \item \ahref{libref/Stack.html}{Module \texttt{Stack}: last-in first-out stacks}
 \item \ahref{libref/StdLabels.html}{Module \texttt{StdLabels}: Include modules \texttt{Array}, \texttt{List} and \texttt{String} with labels}
 \item \ahref{libref/Stream.html}{Module \texttt{Stream}: streams and parsers}
@@ -173,6 +175,7 @@ be called from C \\
 \input{Scanf.tex}
 \input{Set.tex}
 \input{Sort.tex}
+\input{Spacetime.tex}
 \input{Stack.tex}
 \input{StdLabels.tex}
 \input{Stream.tex}


### PR DESCRIPTION
According to the manual exhaustivity check for the stdlib, the `Spacetime` module was missing from the manual. This PR fixes this point.
