### PR TITLE
Fix an overflow bug in String.concat

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,6 +47,10 @@ Next version (tbd):
   environment.
   (Florian Angeletti)
 
+### Bug fixes:
+- GPR#805: check for integer overflow in String.concat and Bytes.concat
+  (Jeremy Yallop)
+
 
 OCaml 4.04.0:
 -------------


### PR DESCRIPTION
[tl;dr: `String.concat` can segfault due to overflow; this PR fixes the bug and makes the function faster.]
### The Description of the Bug

This PR fixes a bug from last century in the `String.concat` function, which catenates a list of strings:

``` ocaml
String.concat "," ["a"; "b"; "c"]
~>
"a,b,c"
```

and whose [description](https://github.com/ocaml/ocaml/blob/bf6261c2b7058a2ac2c471839d48acb1c77c22fd/stdlib/string.mli#L123-L128) includes the following:

```
Raise [Invalid_argument] if the result is longer than
{!Sys.max_string_length} bytes. *)
```

Unfortunately, computing the length of the output string may overflow an `int`, in which case the result is not the `Invalid_argument` exception but an out-of-bounds write.  This situation is perhaps unlikely on a modern 64-bit platform, but on what the configure script [calls](https://github.com/ocaml/ocaml/blob/bf6261c2b7058a2ac2c471839d48acb1c77c22fd/configure#L562) "a regular 32 bit architecture" the bug can be triggered with a single large string and a list of moderate length.
### The Example

Here's an example to illustrate the problem.  The idea is to create a list containing multiple references to a single large string of length `Sys.max_string_length`, or `16777211`.  The number of entries in the list is carefully chosen so that computing their sum wraps around past `max_int` (`1073741823`) and `min_int`, all the way past zero again to give a number between zero and  `Sys.max_string_length` -- i.e. a valid length for a string but significantly less than the combined lengths of the members of the list.

``` ocaml
let big = String.make Sys.max_string_length 'x'

let push x l = l := x :: !l
let (+=) a b = a := !a + b

let sz, l = ref 0, ref []

let () = begin
  while !sz >= 0 do push big l; sz += Sys.max_string_length done;
  while !sz <= 0 do push big l; sz += Sys.max_string_length done;
end

let _ = String.concat "" !l
```

Here's the unfortunate result of compiling and running the program:

```
Segmentation fault (core dumped)
```
### The Proposed Fix

The fix is simple, in principle: the [code that computes the size of the result string](https://github.com/ocaml/ocaml/blob/bf6261c2b7058a2ac2c471839d48acb1c77c22fd/stdlib/string.ml#L51-L53) must be extended with a check that the sum does not overflow an `int`.  In general overflow is only detectable during the computation; by the time the final result is computed it may be too late, as the example above shows.

Here is the current code for computing the size of the result string:

``` ocaml
let num = ref 0 and len = ref 0 in
List.iter (fun s -> incr num; len := !len + length s) l;
(!len + length sep * (!num - 1))
```

Naively adding an overflow check to each iteration (i.e. to the function passed to `List.iter`) slows things down slightly, as we might expect:

**Effect on performance of adding an overflow check**

| List length: | 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128 | 256 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Current code (ns): | 13.08 | 20.44 | 23.72 | 39.31 | 83.46 | 141.42 | 266.81 | 505.84 | 994.86 |
| With overflow check (ns): | 13.82 | 19.94 | 27.07 | 43.77 | 83.76 | 157.16 | 300.61 | 578.60 | 1119.99 |

In mitigation, it seems unlikely that computing the size of the result in `String.concat` is a significant bottleneck in most OCaml programs.

Still, it's a shame to slow things down unnecessarily.  So this PR takes advantage of some optimization opportunities to make the size computation faster (while adding in the overflow check, of course).  Instead of calling `List.iter` with a closure we might compute the size in a simple loop implemented as a recursive function with an accumulator.  And we can then unroll the loop so as not to perform the overflow check every iteration.  The unrolling uses the following observation: since `Sys.max_string_length` is significantly smaller than `max_int`, if adding `String.length s` to `size` causes an overflow, then we can add quite a few more string lengths to `size` before it becomes positive again.

Here's a comparison of the performance of the existing size computation and the implementation in this PR:

**Performance of current implementation vs this PR**

| List length: | 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128 | 256 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Current code (ns): | 13.08 | 20.44 | 23.72 | 39.31 | 83.46 | 141.42 | 266.81 | 505.84 | 994.86 |
| New implementation (ns): | 3.70 | 5.04 | 8.51 | 14.70 | 27.15 | 53.66 | 112.77 | 215.85 | 419.42 |

With flambda the gap narrows a bit:

**Performance of current implementation vs this PR (flambda)**

| List length: | 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128 | 256 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Current code (ns): | 8.49 | 10.79 | 15.74 | 25.84 | 48.46 | 93.41 | 183.54 | 357.02 | 711.02 |
| New implementation (ns): | 4.29 | 5.25 | 8.43 | 15.74 | 27.38 | 52.16 | 108.34 | 209.81 | 419.05 |
### A final note

This PR fixes a bug in `String.concat` and `Bytes.concat`.  The `Array.concat` function has a similar problem, which I'll address in a separate PR.
