### PR TITLE
PR#7350: ocamldoc, viewport metadata for html

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,10 @@ Next version (tbd):
   a short description in overviews.
   (Florian Angeletti)
 
+- PR#7350: ocamldoc, add viewport metadata to generated html
+  pages
+  (Florian Angeletti, request by Daniel Bünzli)
+
 ### Compiler distribution build system:
 
 - GPR#729: Make sure ocamlnat is built with a $(EXE) extension, merge

--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -781,10 +781,14 @@ class html =
 
     val mutable doctype =
       "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n"
-    method character_encoding () =
-      Printf.sprintf
+    method character_encoding b =
+      bp b
         "<meta content=\"text/html; charset=%s\" http-equiv=\"Content-Type\">\n"
         !charset
+
+    method meta b =
+      self#character_encoding b;
+      bs b "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
 
     (** The default style options. *)
     val mutable default_style_options =
@@ -1023,7 +1027,7 @@ class html =
         in
         bs b "<head>\n";
         bs b style;
-        bs b (self#character_encoding ()) ;
+        self#meta b;
         bs b "<link rel=\"Start\" href=\"";
         bs b self#index;
         bs b "\">\n" ;

--- a/testsuite/tests/tool-ocamldoc-html/Inline_records.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Inline_records.reference
@@ -3,6 +3,7 @@
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">
 <meta content="text/html; charset=iso-8859-1" http-equiv="Content-Type">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="Start" href="index.html">
 <link rel="Up" href="index.html">
 <link title="Index of types" rel=Appendix href="index_types.html">

--- a/testsuite/tests/tool-ocamldoc-html/Linebreaks.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Linebreaks.reference
@@ -3,6 +3,7 @@
 <head>
 <link rel="stylesheet" href="style.css" type="text/css">
 <meta content="text/html; charset=iso-8859-1" http-equiv="Content-Type">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="Start" href="index.html">
 <link rel="Up" href="index.html">
 <link title="Index of types" rel=Appendix href="index_types.html">

--- a/testsuite/tests/tool-ocamldoc-html/type_Linebreaks.reference
+++ b/testsuite/tests/tool-ocamldoc-html/type_Linebreaks.reference
@@ -1,6 +1,7 @@
 <html><head>
 <link rel="stylesheet" href="style.css" type="text/css">
 <meta content="text/html; charset=iso-8859-1" http-equiv="Content-Type">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="Start" href="index.html">
 <link title="Index of types" rel=Appendix href="index_types.html">
 <link title="Index of extensions" rel=Appendix href="index_extensions.html">


### PR DESCRIPTION
This short PR adds viewport metadata to the html generated by ocamldoc. This should improve styling possibilities for the generated html for mobile devices. Furthermore, even the default ocamldoc style seems to render better with this metadata added: see for instance (on a mobile device) [Bigarray with metadata](http://www.polychoron.fr/ocamldoc/viewport/Bigarray.html) and [without](http://caml.inria.fr/pub/docs/manual-ocaml/libref/Bigarray.html).
