### PR TITLE
Detect integer overflow in Array.concat

### DIFF
--- a/Changes
+++ b/Changes
@@ -50,7 +50,10 @@ Next version (tbd):
   (Xavier Leroy)
 
 - GPR#814: fix the Buffer.add_substring bounds check to handle overflow
-   (Jeremy Yallop)
+  (Jeremy Yallop)
+
+- GPR#810: check for integer overflow in Array.concat
+  (Jeremy Yallop)
 
 
 OCaml 4.04.0:

--- a/byterun/array.c
+++ b/byterun/array.c
@@ -26,6 +26,8 @@
 /* Why is caml/spacetime.h included conditionnally sometimes and not here ? */
 #include "caml/spacetime.h"
 
+static const mlsize_t mlsize_t_max = -1;
+
 /* returns number of elements (either fields or floats) */
 CAMLexport mlsize_t caml_array_length(value array)
 {
@@ -314,6 +316,7 @@ static value caml_array_gather(intnat num_arrays,
   size = 0;
   isfloat = 0;
   for (i = 0; i < num_arrays; i++) {
+    if (mlsize_t_max - lengths[i] < size) caml_invalid_argument("Array.concat");
     size += lengths[i];
     if (Tag_val(arrays[i]) == Double_array_tag) isfloat = 1;
   }
@@ -323,8 +326,8 @@ static value caml_array_gather(intnat num_arrays,
   }
   else if (isfloat) {
     /* This is an array of floats.  We can use memcpy directly. */
+    if (size > Max_wosize/Double_wosize) caml_invalid_argument("Array.concat");
     wsize = size * Double_wosize;
-    if (wsize > Max_wosize) caml_invalid_argument("Array.concat");
     res = caml_alloc(wsize, Double_array_tag);
     for (i = 0, pos = 0; i < num_arrays; i++) {
       memcpy((double *)res + pos,


### PR DESCRIPTION
This pull request is part of an occasional series on bounds checking and integer overflow.  (Previous installments: #250, #805.)
### Description

The code used to calculate the size of the output array in `Array.concat` doesn't detect integer overflow.  Consequently, passing a single (moderately-sized) list with multiple references to a large array can lead to out-of-bounds writes.
### Demonstration

Here's a program that demonstrates the problem on a 32-bit platform.

``` ocaml
open Int32

let big = Array.make Sys.max_array_length ()

let push x l = l := x :: !l
let (+=) a b = a := add !a b

let sz, l = ref zero, ref []

let () = begin
  while !sz >= zero do push big l; sz += of_int Sys.max_array_length done;
  while !sz <= zero do push big l; sz += of_int Sys.max_array_length done;
end

let _ = Array.concat !l
```

And here's the result of compiling and running the program:

```
$ ocamlopt ~/arrayconcat.ml
$ ./a.out
Segmentation fault (core dumped)
```

Here's what happens with the addition of this patch:

```
$ ocamlopt ~/arrayconcat.ml
$ ./a.out 
Fatal error: exception Invalid_argument("Array.concat")
```
