### PR TITLE
Fix broken bounds check in Buffer.add_substring

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,6 +47,10 @@ Next version (tbd):
   environment.
   (Florian Angeletti)
 
+### Bugs
+
+ - GPR#814: fix the Buffer.add_substring bounds check to handle overflow
+   (Jeremy Yallop)
 
 OCaml 4.04.0:
 -------------

--- a/stdlib/buffer.ml
+++ b/stdlib/buffer.ml
@@ -81,7 +81,7 @@ let add_char b c =
   b.position <- pos + 1
 
 let add_substring b s offset len =
-  if offset < 0 || len < 0 || offset + len > String.length s
+  if offset < 0 || len < 0 || offset > String.length s - len
   then invalid_arg "Buffer.add_substring/add_subbytes";
   let new_position = b.position + len in
   if new_position > b.length then resize b len;


### PR DESCRIPTION
This pull request is part of an occasional series on bounds checking and integer overflow. (Previous installments: #250, #805, #810.)
### Summary

The bounds check in `Buffer.add_substring` does not handle overflow correctly.
### Symptoms

Out-of-bounds writes may be caught and reported only by a second check in `Bytes.blit_string`:

``` ocaml
# let b = Buffer.create 2;;
val b : Buffer.t = <abstr>
# Buffer.add_string b "ab";;
- : unit = ()
# Buffer.add_substring  b "cde" 3 max_int;;
Exception: Invalid_argument "Bytes.blit_string".
```

There is an infinite loop in `Buffer.resize`:

``` ocaml
# let b = Buffer.create 2;;
val b : Buffer.t = <abstr>
# Buffer.add_substring  b "abc" 3 max_int;;
```
### Post-fix

Both situations above are correctly detected and reported:

``` ocaml
# let b = Buffer.create 2;;
val b : Buffer.t = <abstr>
# Buffer.add_string b "ab";;
- : unit = ()
# Buffer.add_substring  b "cde" 3 max_int;;
Exception: Invalid_argument "Buffer.add_substring/add_subbytes".
```

``` ocaml
# let b = Buffer.create 2;;
val b : Buffer.t = <abstr>
# Buffer.add_substring  b "abc" 3 max_int;;
Exception: Invalid_argument "Buffer.add_substring/add_subbytes".
```
