### PR TITLE
Avoid overflow when checking for an oversized result String/Bytes.concat

### DIFF
--- a/Changes
+++ b/Changes
@@ -50,7 +50,10 @@ Next version (tbd):
   (Xavier Leroy)
 
 - GPR#814: fix the Buffer.add_substring bounds check to handle overflow
-   (Jeremy Yallop)
+  (Jeremy Yallop)
+
+- GPR#805, GPR#815: fix check for oversized result in String/Bytes.concat
+  (Jeremy Yallop, Damien Doligez, Alain Frisch)
 
 
 OCaml 4.04.0:

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -12,8 +12,8 @@ arrayLabels.cmi :
 buffer.cmo : sys.cmi string.cmi bytes.cmi buffer.cmi
 buffer.cmx : sys.cmx string.cmx bytes.cmx buffer.cmi
 buffer.cmi :
-bytes.cmo : pervasives.cmi list.cmi char.cmi bytes.cmi
-bytes.cmx : pervasives.cmx list.cmx char.cmx bytes.cmi
+bytes.cmo : sys.cmi pervasives.cmi list.cmi char.cmi bytes.cmi
+bytes.cmx : sys.cmx pervasives.cmx list.cmx char.cmx bytes.cmi
 bytes.cmi :
 bytesLabels.cmo : bytes.cmi bytesLabels.cmi
 bytesLabels.cmx : bytes.cmx bytesLabels.cmi
@@ -194,8 +194,8 @@ arrayLabels.cmo : array.cmi arrayLabels.cmi
 arrayLabels.p.cmx : array.cmx arrayLabels.cmi
 buffer.cmo : sys.cmi string.cmi bytes.cmi buffer.cmi
 buffer.p.cmx : sys.cmx string.cmx bytes.cmx buffer.cmi
-bytes.cmo : pervasives.cmi list.cmi char.cmi bytes.cmi
-bytes.p.cmx : pervasives.cmx list.cmx char.cmx bytes.cmi
+bytes.cmo : sys.cmi pervasives.cmi list.cmi char.cmi bytes.cmi
+bytes.p.cmx : sys.cmx pervasives.cmx list.cmx char.cmx bytes.cmi
 bytesLabels.cmo : bytes.cmi bytesLabels.cmi
 bytesLabels.p.cmx : bytes.cmx bytesLabels.cmi
 callback.cmo : obj.cmi callback.cmi

--- a/stdlib/Makefile.shared
+++ b/stdlib/Makefile.shared
@@ -33,7 +33,7 @@ CAMLOPT=$(CAMLRUN) $(OPTCOMPILER)
 CAMLDEP=$(CAMLRUN) ../tools/ocamldep
 
 OBJS=camlinternalFormatBasics.cmo pervasives.cmo $(OTHERS)
-OTHERS=list.cmo char.cmo bytes.cmo string.cmo sys.cmo \
+OTHERS=list.cmo char.cmo sys.cmo bytes.cmo string.cmo \
   sort.cmo marshal.cmo obj.cmo array.cmo \
   int32.cmo int64.cmo nativeint.cmo \
   lexing.cmo parsing.cmo \

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -97,31 +97,35 @@ let iter f a =
 let iteri f a =
   for i = 0 to length a - 1 do f i (unsafe_get a i) done
 
-let concat sep l =
-  match l with
-    [] -> empty
+let rec sum_lengths acc seplen = function
+  | [] -> assert false
+  | hd :: [] ->
+      let new_acc = length hd + acc in
+      if new_acc < acc then invalid_arg "Bytes.concat" (* overflow *)
+      else new_acc
   | hd :: tl ->
-      let len = ref (length hd) in
-      let sep_len = length sep in
-      List.iter
-        (fun s ->
-           let old_len = !len in
-           len := old_len + sep_len + length s;
-           if !len < old_len then invalid_arg "Bytes.concat"  (* overflow *)
-        )
-        tl;
-      if !len > Sys.max_string_length then invalid_arg "Bytes.concat";
-      let r = create !len in
-      unsafe_blit hd 0 r 0 (length hd);
-      let pos = ref(length hd) in
-      List.iter
-        (fun s ->
-          unsafe_blit sep 0 r !pos sep_len;
-          pos := !pos + sep_len;
-          unsafe_blit s 0 r !pos (length s);
-          pos := !pos + length s)
-        tl;
-      r
+      let new_acc = length hd + seplen + acc in
+      if new_acc < acc then invalid_arg "Bytes.concat" (* overflow *)
+      else sum_lengths new_acc seplen tl
+
+let rec unsafe_blits dst pos sep seplen = function
+  | [] -> assert false
+  | hd :: tl ->
+      let len_hd = length hd in
+      unsafe_blit hd 0 dst pos len_hd;
+      if tl == [] then dst
+      else begin
+        unsafe_blit sep 0 dst (pos + len_hd) seplen;
+        unsafe_blits dst (pos + len_hd + seplen) sep seplen tl
+      end
+
+let concat sep = function
+  | [] -> empty
+  | l ->
+      let seplen = length sep in
+      let len = sum_lengths 0 seplen l in
+      if len > Sys.max_string_length then invalid_arg "Bytes.concat";
+      unsafe_blits (create len) 0 sep seplen l
 
 let cat s1 s2 =
   let l1 = length s1 in

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -44,31 +44,35 @@ let fill =
 let blit =
   B.blit_string
 
-let concat sep l =
-  match l with
-  | [] -> ""
+let rec sum_lengths acc seplen = function
+  | [] -> assert false
+  | hd :: [] ->
+      let new_acc = length hd + acc in
+      if new_acc < acc then invalid_arg "String.concat" (* overflow *)
+      else new_acc
   | hd :: tl ->
-      let len = ref (length hd) in
-      let sep_len = length sep in
-      List.iter
-        (fun s ->
-           let old_len = !len in
-           len := old_len + sep_len + length s;
-           if !len < old_len then invalid_arg "String.concat"  (* overflow *)
-        )
-        tl;
-      if !len > Sys.max_string_length then invalid_arg "String.concat";
-      let r = Bytes.create !len in
-      unsafe_blit hd 0 r 0 (length hd);
-      let pos = ref(length hd) in
-      List.iter
-        (fun s ->
-          unsafe_blit sep 0 r !pos sep_len;
-          pos := !pos + sep_len;
-          unsafe_blit s 0 r !pos (length s);
-          pos := !pos + length s)
-        tl;
-      Bytes.unsafe_to_string r
+      let new_acc = length hd + seplen + acc in
+      if new_acc < acc then invalid_arg "String.concat" (* overflow *)
+      else sum_lengths new_acc seplen tl
+
+let rec unsafe_blits dst pos sep seplen = function
+  | [] -> assert false
+  | hd :: tl ->
+      let len_hd = length hd in
+      unsafe_blit hd 0 dst pos len_hd;
+      if tl == [] then bts dst
+      else begin
+        unsafe_blit sep 0 dst (pos + len_hd) seplen;
+        unsafe_blits dst (pos + len_hd + seplen) sep seplen tl
+      end
+
+let concat sep = function
+  | [] -> ""
+  | l ->
+      let seplen = length sep in
+      let len = sum_lengths 0 seplen l in
+      if len > Sys.max_string_length then invalid_arg "String.concat";
+      unsafe_blits (B.create len) 0 sep seplen l
 
 let iter f s =
   B.iter f (bos s)

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -48,15 +48,23 @@ let concat sep l =
   match l with
   | [] -> ""
   | hd :: tl ->
-      let num = ref 0 and len = ref 0 in
-      List.iter (fun s -> incr num; len := !len + length s) l;
-      let r = B.create (!len + length sep * (!num - 1)) in
+      let len = ref (length hd) in
+      let sep_len = length sep in
+      List.iter
+        (fun s ->
+           let old_len = !len in
+           len := old_len + sep_len + length s;
+           if !len < old_len then invalid_arg "String.concat"  (* overflow *)
+        )
+        tl;
+      if !len > Sys.max_string_length then invalid_arg "String.concat";
+      let r = Bytes.create !len in
       unsafe_blit hd 0 r 0 (length hd);
       let pos = ref(length hd) in
       List.iter
         (fun s ->
-          unsafe_blit sep 0 r !pos (length sep);
-          pos := !pos + length sep;
+          unsafe_blit sep 0 r !pos sep_len;
+          pos := !pos + sep_len;
           unsafe_blit s 0 r !pos (length s);
           pos := !pos + length s)
         tl;

--- a/testsuite/tests/lib-string/test_string.ml
+++ b/testsuite/tests/lib-string/test_string.ml
@@ -36,3 +36,17 @@ let () =
     check_split ' ' (String.sub s 0 i)
   done
 ;;
+
+(* GPR#805/815 *)
+
+let ()  =
+  if Sys.word_size = 32 then begin
+    let big = String.make Sys.max_string_length 'x' in
+    let push x l = l := x :: !l in
+    let (+=) a b = a := !a + b in
+    let sz, l = ref 0, ref [] in
+    while !sz >= 0 do push big l; sz += Sys.max_string_length done;
+    while !sz <= 0 do push big l; sz += Sys.max_string_length done;
+    try ignore (String.concat "" !l); assert false
+    with Invalid_argument _ -> ()
+  end


### PR DESCRIPTION
Follow up to #805.

String and Bytes now depend on Sys (for max_string_length).  One could avoid that by copying the code which computes this constant.  Actually, it would make sense to have String and Byte expose a `max_length` value, but this is another story.
