### PR TITLE
Include safe_string option with -config output

### DIFF
--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -163,6 +163,7 @@ let print_config oc =
   p "target" target;
   p_bool "flambda" flambda;
   p_bool "spacetime" spacetime;
+  p_bool "safe_string" safe_string;
 
   (* print the magic number *)
   p "exec_magic_number" exec_magic_number;


### PR DESCRIPTION
Currently, the only way a shell script can determine if -safe-string is the default is by examining the output of ocamlc/ocamlopt -help!
