### PR TITLE
Fix building of debug runtime on Windows

### DIFF
--- a/byterun/Makefile.nt
+++ b/byterun/Makefile.nt
@@ -45,8 +45,9 @@ libcamlrund.$(A): $(DOBJS)
 %.$(O): %.c
 	$(CC) $(CFLAGS) $(BYTECCCOMPOPTS) -c $<
 
+# It is imperative that there is no space after $(NAME_OBJ_FLAG)
 %.$(DBGO): %.c
-	$(CC) $(CFLAGS) $(BYTECCDBGCOMPOPTS) -c -o $@ $<
+	$(CC) $(DFLAGS) $(BYTECCDBGCOMPOPTS) -c $(NAME_OBJ_FLAG)$@ $<
 
 .depend.nt: .depend
 	rm -f .depend.win32

--- a/byterun/Makefile.nt
+++ b/byterun/Makefile.nt
@@ -16,6 +16,7 @@
 include Makefile.common
 
 CFLAGS=-DOCAML_STDLIB_DIR='"$(LIBDIR)"' $(IFLEXDIR)
+DFLAGS=$(CFLAGS) -DDEBUG
 
 ifdef BOOTSTRAPPING_FLEXLINK
 MAKE_OCAMLRUN=$(MKEXE_BOOT)
@@ -33,7 +34,7 @@ ocamlrun$(EXE): libcamlrun.$(A) prims.$(O)
 	         $(call SYSLIB,ws2_32) $(EXTRALIBS))
 
 ocamlrund$(EXE): libcamlrund.$(A) prims.$(O) main.$(O)
-	$(MKEXE) -o ocamlrund$(EXE) $(BYTECCDBGCOMPOPTS) prims.$(O) \
+	$(MKEXE) -o ocamlrund$(EXE) prims.$(O) \
 	         $(call SYSLIB,ws2_32) $(EXTRALIBS) libcamlrund.$(A)
 
 libcamlrun.$(A): $(OBJS)
@@ -60,7 +61,10 @@ libcamlrund.$(A): $(DOBJS)
 	echo " caml/freelist.h caml/minor_gc.h caml/osdeps.h caml/signals.h"\
 	  >> .depend.win32
 	cat .depend >> .depend.win32
-	sed -e '/\.d\.o/q' -e 's/^\(.*\)\.o:/\1.$$(O) \1.$$(DBGO):/' \
+	sed -ne '/\.pic\.o/q' \
+	    -e 's/^\(.*\)\.d\.o:/\1.$$(DBGO):/' \
+	    -e 's/^\(.*\)\.o:/\1.$$(O):/' \
+	    -e p \
 	    .depend.win32 > .depend.nt
 	rm -f .depend.win32
 

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -100,6 +100,9 @@ BYTECC=$(TOOLPREF)gcc
 ### Additional compile-time options for $(BYTECC).  (For static linking.)
 BYTECCCOMPOPTS=-O -mms-bitfields -Wall -Wno-unused
 
+### Flag to use to rename object files.  (for debug version.)
+NAME_OBJ_FLAG=-o
+
 ### Additional link-time options for $(BYTECC).  (For static linking.)
 BYTECCLINKOPTS=
 

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -100,6 +100,9 @@ BYTECC=$(TOOLPREF)gcc
 ### Additional compile-time options for $(BYTECC).  (For static linking.)
 BYTECCCOMPOPTS=-O -mms-bitfields -Wall -Wno-unused
 
+### Additional compile-time options for $(BYTECC).  (For debug version.)
+BYTECCDBGCOMPOPTS=-g
+
 ### Flag to use to rename object files.  (for debug version.)
 NAME_OBJ_FLAG=-o
 

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -100,6 +100,9 @@ BYTECC=$(TOOLPREF)gcc
 ### Additional compile-time options for $(BYTECC).  (For static linking.)
 BYTECCCOMPOPTS=-O -mms-bitfields -Wall -Wno-unused
 
+### Flag to use to rename object files.  (for debug version.)
+NAME_OBJ_FLAG=-o
+
 ### Additional link-time options for $(BYTECC).  (For static linking.)
 BYTECCLINKOPTS=
 

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -100,6 +100,9 @@ BYTECC=$(TOOLPREF)gcc
 ### Additional compile-time options for $(BYTECC).  (For static linking.)
 BYTECCCOMPOPTS=-O -mms-bitfields -Wall -Wno-unused
 
+### Additional compile-time options for $(BYTECC).  (For debug version.)
+BYTECCDBGCOMPOPTS=-g
+
 ### Flag to use to rename object files.  (for debug version.)
 NAME_OBJ_FLAG=-o
 

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -94,6 +94,9 @@ BYTECC=cl -nologo -D_CRT_SECURE_NO_DEPRECATE
 ### Additional compile-time options for $(BYTECC).  (For static linking.)
 BYTECCCOMPOPTS=-O2 -Gy- -MD
 
+### Additional compile-time options for $(BYTECC).  (For debug version.)
+BYTECCDBGCOMPOPTS=-Zi
+
 ### Flag to use to rename object files.  (for debug version.)
 NAME_OBJ_FLAG=-Fo
 

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -94,6 +94,9 @@ BYTECC=cl -nologo -D_CRT_SECURE_NO_DEPRECATE
 ### Additional compile-time options for $(BYTECC).  (For static linking.)
 BYTECCCOMPOPTS=-O2 -Gy- -MD
 
+### Flag to use to rename object files.  (for debug version.)
+NAME_OBJ_FLAG=-Fo
+
 ### Additional link-time options for $(BYTECC).  (For static linking.)
 BYTECCLINKOPTS=
 

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -94,7 +94,7 @@ BYTECC=cl -nologo -D_CRT_SECURE_NO_DEPRECATE
 BYTECCCOMPOPTS=-O2 -Gy- -MD
 
 ### Additional compile-time options for $(BYTECC).  (For debug version.)
-BYTECCDBGCOMPOPTS=-DDEBUG -Zi -W3 -Wp64
+BYTECCDBGCOMPOPTS=-Zi
 
 ### Flag to use to rename object files.  (for debug version.)
 NAME_OBJ_FLAG=-Fo

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -96,6 +96,9 @@ BYTECCCOMPOPTS=-O2 -Gy- -MD
 ### Additional compile-time options for $(BYTECC).  (For debug version.)
 BYTECCDBGCOMPOPTS=-DDEBUG -Zi -W3 -Wp64
 
+### Flag to use to rename object files.  (for debug version.)
+NAME_OBJ_FLAG=-Fo
+
 ### Additional link-time options for $(BYTECC).  (For static linking.)
 BYTECCLINKOPTS=
 


### PR DESCRIPTION
This fixes the building of `ocamlrund.exe` and `libcamlrun.a`/`libcamlrun.lib` on Windows. To me, each argument for putting this in 4.04 is as strong an argument for putting in trunk instead:
- The debug runtime is not compiled by default, and the changes (almost) only touch that build path. (The alteration to `byterun/.depend.nt` compilation is pretty trivial).
- Although this fixes a broken build system (msvc/msvc64 haven't built since 4.02.2), it's not clear to me that the result is strictly usable. For example, I'm fairly sure that the msvc ports should be installing a .pdb file for ocamlrund.exe (and using the `/Fd` option to cl to ensure that it has a sensible name).
- It looks as though compiling libasmrund just got forgotten about when that was added (?), and that isn't here.

FWIW, I'd fix the build system for 4.04 and then aim to improve the debugging support on Windows for 4.05.
