### PR TITLE
Remove useless comment

### DIFF
--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -14,16 +14,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(***********************************************************************)
-(**                                                                   **)
-(**               WARNING WARNING WARNING                             **)
-(**                                                                   **)
-(** When you change this file, you must make the parallel change      **)
-(** in config.mlbuild                                                 **)
-(**                                                                   **)
-(***********************************************************************)
-
-
 (* The main OCaml version string has moved to ../VERSION *)
 let version = Sys.ocaml_version
 


### PR DESCRIPTION
The comment in `utils/config.mlp` made sense when `ocamlbuild` was part of OCaml, but not anymore.
