### PR TITLE
fix PR#7369: Str.regexp raises "Invalid_argument: index out of bounds"

### DIFF
--- a/Changes
+++ b/Changes
@@ -340,6 +340,9 @@ OCaml 4.04.0:
 - PR#7165, GPR#494: uncaught exception on invalid lexer directive
   (Gabriel Scherer, report by KC Sivaramakrishnan using afl-fuzz)
 
+- PR#7369: Str.regexp raises "Invalid_argument: index out of bounds"
+  (Damien Doligez, report by John Whitington)
+
 * GPR#533: Thread library: fixed [Thread.wait_signal] so that it
   converts back the signal number returned by [sigwait] to an
   OS-independent number

--- a/otherlibs/str/str.ml
+++ b/otherlibs/str/str.ml
@@ -248,7 +248,7 @@ let compile fold_case re =
     incr progpos in
   (* Reserve an instruction slot and return its position *)
   let emit_hole () =
-    let p = !progpos in incr progpos; p in
+    let p = !progpos in emit_instr op_CHAR 0; p in
   (* Fill a reserved instruction slot with a GOTO or PUSHBACK instruction *)
   let patch_instr pos opc dest =
     (!prog).(pos) <- (instr opc (displ dest pos)) in


### PR DESCRIPTION
Edge case: when emitting a "hole" instead of an instruction you may still need to extend the array.

Reported by John Whitington: http://caml.inria.fr/mantis/view.php?id=7369
