### PR TITLE
Better error when 'open'ing a module aliased to a functor

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,9 @@ Next version (tbd):
 - PR#7315, GPR#736: refine some error locations
   (Gabriel Scherer and Alain Frisch, report by Matej Košík)
 
+- GPR#829: better error when opening a module aliased to a functor
+  (Alain Frisch)
+
 ### Standard library:
 
 - GPR#760: Add a functions List.compare_lengths and

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -78,7 +78,7 @@ let extract_sig_open env loc mty =
     Mty_signature sg -> sg
   | Mty_alias(_, path) ->
       raise(Error(loc, env, Cannot_scrape_alias path))
-  | _ -> raise(Error(loc, env, Structure_expected mty))
+  | mty -> raise(Error(loc, env, Structure_expected mty))
 
 (* Compute the environment after opening a module *)
 


### PR DESCRIPTION
Consider:

``` ocaml
    module F(X : sig end) = struct end
    module G = F
    open G
```

Before this PR:

```
Error: This module is not a structure; it has type (module F)
```

After:

```
Error: This module is not a structure; it has type
       functor (X : sig  end) -> sig  end
```
