### PR TITLE
Ocamldoc: fix CSS color declaration

### DIFF
--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -861,7 +861,7 @@ class html =
         ".indextable {border: 1px #ddd solid; border-collapse: collapse}";
         ".indextable td, .indextable th {border: 1px #ddd solid; min-width: 80px}";
         ".indextable td.module {background-color: #eee ;  padding-left: 2px; padding-right: 2px}";
-        ".indextable td.module a {color: 4E6272; text-decoration: none; display: block; width: 100%}";
+        ".indextable td.module a {color: #4E6272; text-decoration: none; display: block; width: 100%}";
         ".indextable td.module a:hover {text-decoration: underline; background-color: transparent}";
         ".deprecated {color: #888; font-style: italic}" ;
 


### PR DESCRIPTION
There is a typo in the generated CSS for link to modules in the index page. CSS colors should start with `#`.

As a consequence, this also makes the default stylesheet valid according to https://jigsaw.w3.org/css-validator.

Of course this changes the look of module lists so here's a preview:
### Before this change

![before](https://cloud.githubusercontent.com/assets/496345/19070513/f6f8c750-8a2b-11e6-89b1-a6a361e3fe9b.png)
### After this change

![after](https://cloud.githubusercontent.com/assets/496345/19070518/fc144e8a-8a2b-11e6-99ca-21cfe77a991d.png)

Thanks!
