### PR TITLE
use parallel build in Travis scripts

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -35,7 +35,15 @@ EOF
     ./configure --prefix $PREFIX -with-debug-runtime \
       -with-instrumented-runtime $CONFIG_ARG
     export PATH=$PREFIX/bin:$PATH
-    make world.opt
+
+    make world.opt -j3
+    # We use a parallel build here with the intent of detecting
+    # changes that break the parallel build -- usually it is because
+    # they forgot to include a "make depend".
+    # On the choice of -j3: travis CI machines have 2 available cores, see
+    #https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
+    # and there seems to be no reliable way to get this value programatically.
+
     make ocamlnat
     make install
     (cd testsuite && make all)


### PR DESCRIPTION
Some commits break parallel make, typically when they forget to include the result of 'make depend' after changing dependencies between OCaml modules. I proposed in #822  to use a parallel build in the Travis Continuous Integration machines to detect and fix those issues earlier -- hopefully directly in the PR that includes the problematic change, although the non-deterministic failure means that there may be some delay.
