### PR TITLE
Document that Store_field cannot be used with CAMLlocalN

### DIFF
--- a/Changes
+++ b/Changes
@@ -215,6 +215,9 @@ OCaml 4.04.0:
 - PR#7355: Gc.finalise and lazy values
   (Jeremy Yallop)
 
+- GPR#841: Document that [Store_field] must not be used to populate
+  arrays of values declared using [CAMLlocalN] (Mark Shinwell)
+
 ### Build system:
 
 - GPR#324: Compiler developers: Adding new primitives to the

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -978,6 +978,10 @@ a parameter declared by "CAMLlocal*" to ensure that a garbage
 collection triggered by the evaluation of the other arguments will not
 invalidate the first argument after it is computed.
 
+\paragraph{Use with CAMLlocalN:} Arrays of values declared using
+"CAMLlocalN" must not be written to using "Store_field".
+Use the normal C array syntax instead.
+
 \begin{gcrule} Global variables containing values must be registered
 with the garbage collector using the "caml_register_global_root" function.
 \end{gcrule}


### PR DESCRIPTION
I have wasted at least half a day tracking down a simple but highly subtle bug that was the result of using `Store_field` on a `CAMLlocalN`-allocated block of roots.  In hindsight it is obvious that such a combination is illegal, since it can cause the ref table to point to stale stack locations, but it is subtle enough that an explicit warning in the manual seems sensible.

Thanks to @let-def for help tracking this down.

@damiendoligez OK for 4.04?
