### PR TITLE
Fix XSS in ocamldoc

### DIFF
--- a/Changes
+++ b/Changes
@@ -93,6 +93,10 @@ Next version (4.05.0):
   a short description in overviews.
   (Florian Angeletti)
 
+- GPR#848: ocamldoc, escape link targets in HTML output
+  (Etienne Millon, review by Gabriel Scherer, Florian Angeletti and
+  Daniel Bünzli)
+
 - clarify ocamldoc text parsing error messages
   (Gabriel Scherer)
 

--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -441,7 +441,7 @@ class virtual text =
 
     method html_of_Link b s t =
       bs b "<a href=\"";
-      bs b s ;
+      bs b (self#escape s);
       bs b "\">";
       self#html_of_text b t;
       bs b "</a>"


### PR DESCRIPTION
It is possible to craft comments that can expand to unfiltered HTML fragments.

For example, the following program:

``` ocaml
(** {{: "><script>alert(1)</script>"} } *)
let n = 0
```

Would generate a HTML file containing:

``` html
<a href=" "><script>alert(1)</script>""> </a>
```

Using this technique it is possible to leak cookies to a third party.

The fix is not perfect since it does not generate usable documentation, but the generated HTML is harmless.

Note that input like `{{: javascript:alert(1)} }` will still run arbitrary JS but requires human interaction.
