### PR TITLE
Expose Spacetime.enabled

### DIFF
--- a/Changes
+++ b/Changes
@@ -78,6 +78,9 @@ Next version (4.05.0):
   argument to a string array of new arguments
   (Bernhard Schommer)
 
+- GPR#849: Exposed Spacetime.enabled value
+  (Leo White)
+
 - GPR#885: Option-returning variants of stdlib functions
   (Alain Frisch, review by David Allsopp and Bart Jacobs)
 

--- a/stdlib/spacetime.ml
+++ b/stdlib/spacetime.ml
@@ -15,8 +15,10 @@
 external spacetime_enabled : unit -> bool
   = "caml_spacetime_enabled" [@@noalloc]
 
+let enabled = spacetime_enabled ()
+
 let if_spacetime_enabled f =
-  if spacetime_enabled () then f () else ()
+  if enabled then f () else ()
 
 module Series = struct
   type t = {

--- a/stdlib/spacetime.mli
+++ b/stdlib/spacetime.mli
@@ -50,6 +50,10 @@
     For functions to decode the information recorded by the profiler,
     see the Spacetime offline library in otherlibs/. *)
 
+(** [enabled] is [true] if the compiler is configured with spacetime and [false]
+    otherwise *)
+val enabled : bool
+
 module Series : sig
   (** Type representing a file that will hold a series of heap snapshots
       together with additional information required to interpret those


### PR DESCRIPTION
This adds an `enabled` value to the `Spacetime` module so that people can turn on code for taking snapshots only when using a spacetime configured compiler.

I made the PR against 4.04 as it is a tiny low-risk change with obvious benefit.
