### PR TITLE
Add Debuginfo.print_compact

### DIFF
--- a/middle_end/debuginfo.ml
+++ b/middle_end/debuginfo.ml
@@ -94,3 +94,20 @@ let compare dbg1 dbg2 =
       loop ds1 ds2
   in
   loop (List.rev dbg1) (List.rev dbg2)
+
+let rec print_compact ppf t =
+  let print_item item =
+    Format.fprintf ppf "%a:%i"
+      Location.print_filename item.dinfo_file
+      item.dinfo_line;
+    if item.dinfo_char_start >= 0 then begin
+      Format.fprintf ppf ",%i--%i" item.dinfo_char_start item.dinfo_char_end
+    end
+  in
+  match t with
+  | [] -> ()
+  | [item] -> print_item item
+  | item::t ->
+    print_item item;
+    Format.fprintf ppf ";";
+    print_compact ppf t

--- a/middle_end/debuginfo.mli
+++ b/middle_end/debuginfo.mli
@@ -37,3 +37,5 @@ val concat: t -> t -> t
 val inline: Location.t -> t -> t
 
 val compare : t -> t -> int
+
+val print_compact : Format.formatter -> t -> unit


### PR DESCRIPTION
This pull requests adds `Debuginfo.print_compact`, which is analogous to `Location.print_compact`.
