### PR TITLE
Add "phantom let" support and provenance tracking to Flambda

### DIFF
--- a/.depend
+++ b/.depend
@@ -431,9 +431,9 @@ typing/typemod.cmo : utils/warnings.cmi typing/typetexp.cmi typing/types.cmi \
     typing/mtype.cmi utils/misc.cmi parsing/longident.cmi \
     parsing/location.cmi typing/includemod.cmi typing/ident.cmi \
     typing/env.cmi typing/ctype.cmi utils/config.cmi typing/cmt_format.cmi \
-    utils/clflags.cmi parsing/builtin_attributes.cmi typing/btype.cmi \
-    parsing/asttypes.cmi parsing/ast_iterator.cmi typing/annot.cmi \
-    typing/typemod.cmi
+    typing/cmi_format.cmi utils/clflags.cmi parsing/builtin_attributes.cmi \
+    typing/btype.cmi parsing/asttypes.cmi parsing/ast_iterator.cmi \
+    typing/annot.cmi typing/typemod.cmi
 typing/typemod.cmx : utils/warnings.cmx typing/typetexp.cmx typing/types.cmx \
     typing/typedtree.cmx typing/typedecl.cmx typing/typecore.cmx \
     typing/typeclass.cmx typing/subst.cmx typing/stypes.cmx \
@@ -441,13 +441,13 @@ typing/typemod.cmx : utils/warnings.cmx typing/typetexp.cmx typing/types.cmx \
     typing/mtype.cmx utils/misc.cmx parsing/longident.cmx \
     parsing/location.cmx typing/includemod.cmx typing/ident.cmx \
     typing/env.cmx typing/ctype.cmx utils/config.cmx typing/cmt_format.cmx \
-    utils/clflags.cmx parsing/builtin_attributes.cmx typing/btype.cmx \
-    parsing/asttypes.cmi parsing/ast_iterator.cmx typing/annot.cmi \
-    typing/typemod.cmi
+    typing/cmi_format.cmx utils/clflags.cmx parsing/builtin_attributes.cmx \
+    typing/btype.cmx parsing/asttypes.cmi parsing/ast_iterator.cmx \
+    typing/annot.cmi typing/typemod.cmi
 typing/typemod.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
     parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
     parsing/location.cmi typing/includemod.cmi typing/ident.cmi \
-    typing/env.cmi parsing/asttypes.cmi
+    typing/env.cmi typing/cmi_format.cmi parsing/asttypes.cmi
 typing/types.cmo : typing/primitive.cmi typing/path.cmi \
     parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
     typing/ident.cmi parsing/asttypes.cmi typing/types.cmi
@@ -1180,17 +1180,19 @@ middle_end/allocated_const.cmi :
 middle_end/augment_specialised_args.cmo : middle_end/base_types/variable.cmi \
     middle_end/projection.cmi middle_end/pass_wrapper.cmi utils/misc.cmi \
     middle_end/inlining_cost.cmi middle_end/inline_and_simplify_aux.cmi \
-    utils/identifiable.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi middle_end/debuginfo.cmi \
-    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
-    middle_end/backend_intf.cmi middle_end/augment_specialised_args.cmi
+    utils/identifiable.cmi middle_end/free_names.cmi \
+    middle_end/flambda_utils.cmi middle_end/flambda.cmi \
+    middle_end/debuginfo.cmi middle_end/base_types/closure_id.cmi \
+    utils/clflags.cmi middle_end/backend_intf.cmi \
+    middle_end/augment_specialised_args.cmi
 middle_end/augment_specialised_args.cmx : middle_end/base_types/variable.cmx \
     middle_end/projection.cmx middle_end/pass_wrapper.cmx utils/misc.cmx \
     middle_end/inlining_cost.cmx middle_end/inline_and_simplify_aux.cmx \
-    utils/identifiable.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx middle_end/debuginfo.cmx \
-    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
-    middle_end/backend_intf.cmi middle_end/augment_specialised_args.cmi
+    utils/identifiable.cmx middle_end/free_names.cmx \
+    middle_end/flambda_utils.cmx middle_end/flambda.cmx \
+    middle_end/debuginfo.cmx middle_end/base_types/closure_id.cmx \
+    utils/clflags.cmx middle_end/backend_intf.cmi \
+    middle_end/augment_specialised_args.cmi
 middle_end/augment_specialised_args.cmi : middle_end/base_types/variable.cmi \
     middle_end/projection.cmi middle_end/inlining_cost.cmi \
     middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi
@@ -1201,11 +1203,12 @@ middle_end/closure_conversion.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
     middle_end/base_types/static_exception.cmi bytecomp/simplif.cmi \
     bytecomp/printlambda.cmi typing/primitive.cmi typing/predef.cmi \
-    utils/numbers.cmi middle_end/base_types/mutable_variable.cmi \
-    utils/misc.cmi parsing/location.cmi \
-    middle_end/base_types/linkage_name.cmi middle_end/lift_code.cmi \
-    bytecomp/lambda.cmi typing/ident.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi middle_end/debuginfo.cmi utils/config.cmi \
+    typing/path.cmi utils/numbers.cmi \
+    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
+    parsing/location.cmi middle_end/base_types/linkage_name.cmi \
+    middle_end/lift_code.cmi bytecomp/lambda.cmi typing/ident.cmi \
+    middle_end/flambda_utils.cmi middle_end/flambda.cmi \
+    middle_end/debuginfo.cmi utils/config.cmi \
     middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/closure_id.cmi \
     middle_end/closure_conversion_aux.cmi utils/clflags.cmi \
@@ -1215,11 +1218,12 @@ middle_end/closure_conversion.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
     middle_end/base_types/static_exception.cmx bytecomp/simplif.cmx \
     bytecomp/printlambda.cmx typing/primitive.cmx typing/predef.cmx \
-    utils/numbers.cmx middle_end/base_types/mutable_variable.cmx \
-    utils/misc.cmx parsing/location.cmx \
-    middle_end/base_types/linkage_name.cmx middle_end/lift_code.cmx \
-    bytecomp/lambda.cmx typing/ident.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx middle_end/debuginfo.cmx utils/config.cmx \
+    typing/path.cmx utils/numbers.cmx \
+    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
+    parsing/location.cmx middle_end/base_types/linkage_name.cmx \
+    middle_end/lift_code.cmx bytecomp/lambda.cmx typing/ident.cmx \
+    middle_end/flambda_utils.cmx middle_end/flambda.cmx \
+    middle_end/debuginfo.cmx utils/config.cmx \
     middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/closure_id.cmx \
     middle_end/closure_conversion_aux.cmx utils/clflags.cmx \
@@ -1230,18 +1234,22 @@ middle_end/closure_conversion.cmi : bytecomp/lambda.cmi typing/ident.cmi \
 middle_end/closure_conversion_aux.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/symbol.cmi \
     middle_end/base_types/static_exception.cmi typing/primitive.cmi \
-    utils/numbers.cmi middle_end/base_types/mutable_variable.cmi \
-    utils/misc.cmi parsing/location.cmi bytecomp/lambda.cmi typing/ident.cmi \
+    typing/path.cmi utils/numbers.cmi \
+    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
+    parsing/location.cmi bytecomp/lambda.cmi typing/ident.cmi \
+    middle_end/base_types/compilation_unit.cmi \
     middle_end/closure_conversion_aux.cmi
 middle_end/closure_conversion_aux.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/symbol.cmx \
     middle_end/base_types/static_exception.cmx typing/primitive.cmx \
-    utils/numbers.cmx middle_end/base_types/mutable_variable.cmx \
-    utils/misc.cmx parsing/location.cmx bytecomp/lambda.cmx typing/ident.cmx \
+    typing/path.cmx utils/numbers.cmx \
+    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
+    parsing/location.cmx bytecomp/lambda.cmx typing/ident.cmx \
+    middle_end/base_types/compilation_unit.cmx \
     middle_end/closure_conversion_aux.cmi
 middle_end/closure_conversion_aux.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi \
+    middle_end/base_types/static_exception.cmi typing/path.cmi \
     middle_end/base_types/mutable_variable.cmi parsing/location.cmi \
     bytecomp/lambda.cmi typing/ident.cmi
 middle_end/debuginfo.cmo : parsing/location.cmi middle_end/debuginfo.cmi
@@ -1282,9 +1290,10 @@ middle_end/flambda.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/static_exception.cmi \
     middle_end/base_types/set_of_closures_origin.cmi \
     middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
-    bytecomp/printlambda.cmi utils/numbers.cmi \
-    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    bytecomp/lambda.cmi utils/identifiable.cmi middle_end/debuginfo.cmi \
+    typing/printtyp.cmi bytecomp/printlambda.cmi typing/path.cmi \
+    utils/numbers.cmi middle_end/base_types/mutable_variable.cmi \
+    utils/misc.cmi bytecomp/lambda.cmi utils/identifiable.cmi \
+    typing/ident.cmi middle_end/free_names.cmi middle_end/debuginfo.cmi \
     middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/closure_id.cmi utils/clflags.cmi \
     parsing/asttypes.cmi middle_end/allocated_const.cmi \
@@ -1294,9 +1303,10 @@ middle_end/flambda.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/static_exception.cmx \
     middle_end/base_types/set_of_closures_origin.cmx \
     middle_end/base_types/set_of_closures_id.cmx middle_end/projection.cmx \
-    bytecomp/printlambda.cmx utils/numbers.cmx \
-    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    bytecomp/lambda.cmx utils/identifiable.cmx middle_end/debuginfo.cmx \
+    typing/printtyp.cmx bytecomp/printlambda.cmx typing/path.cmx \
+    utils/numbers.cmx middle_end/base_types/mutable_variable.cmx \
+    utils/misc.cmx bytecomp/lambda.cmx utils/identifiable.cmx \
+    typing/ident.cmx middle_end/free_names.cmx middle_end/debuginfo.cmx \
     middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/closure_id.cmx utils/clflags.cmx \
     parsing/asttypes.cmi middle_end/allocated_const.cmx \
@@ -1306,10 +1316,11 @@ middle_end/flambda.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/static_exception.cmi \
     middle_end/base_types/set_of_closures_origin.cmi \
     middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
-    utils/numbers.cmi middle_end/base_types/mutable_variable.cmi \
-    bytecomp/lambda.cmi utils/identifiable.cmi middle_end/debuginfo.cmi \
-    middle_end/base_types/closure_id.cmi parsing/asttypes.cmi \
-    middle_end/allocated_const.cmi
+    typing/path.cmi utils/numbers.cmi \
+    middle_end/base_types/mutable_variable.cmi bytecomp/lambda.cmi \
+    utils/identifiable.cmi typing/ident.cmi middle_end/free_names.cmi \
+    middle_end/debuginfo.cmi middle_end/base_types/closure_id.cmi \
+    parsing/asttypes.cmi middle_end/allocated_const.cmi
 middle_end/flambda_invariants.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
@@ -1318,9 +1329,9 @@ middle_end/flambda_invariants.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
     bytecomp/printlambda.cmi utils/numbers.cmi \
     middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    bytecomp/lambda.cmi typing/ident.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/debuginfo.cmi \
-    middle_end/base_types/compilation_unit.cmi \
+    bytecomp/lambda.cmi typing/ident.cmi middle_end/free_names.cmi \
+    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
+    middle_end/debuginfo.cmi middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/closure_id.cmi parsing/asttypes.cmi \
     middle_end/allocated_const.cmi middle_end/flambda_invariants.cmi
 middle_end/flambda_invariants.cmx : middle_end/base_types/variable.cmx \
@@ -1331,9 +1342,9 @@ middle_end/flambda_invariants.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/set_of_closures_id.cmx middle_end/projection.cmx \
     bytecomp/printlambda.cmx utils/numbers.cmx \
     middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    bytecomp/lambda.cmx typing/ident.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/debuginfo.cmx \
-    middle_end/base_types/compilation_unit.cmx \
+    bytecomp/lambda.cmx typing/ident.cmx middle_end/free_names.cmx \
+    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
+    middle_end/debuginfo.cmx middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/closure_id.cmx parsing/asttypes.cmi \
     middle_end/allocated_const.cmx middle_end/flambda_invariants.cmi
 middle_end/flambda_invariants.cmi : middle_end/flambda.cmi
@@ -1345,24 +1356,24 @@ middle_end/flambda_iterators.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/symbol.cmi middle_end/flambda.cmi
 middle_end/flambda_utils.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/symbol.cmi bytecomp/switch.cmi \
-    middle_end/base_types/static_exception.cmi \
+    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
+    bytecomp/switch.cmi middle_end/base_types/static_exception.cmi \
     middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
     middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    middle_end/base_types/linkage_name.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/debuginfo.cmi \
-    middle_end/base_types/compilation_unit.cmi \
+    middle_end/base_types/linkage_name.cmi middle_end/free_names.cmi \
+    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
+    middle_end/debuginfo.cmi middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi \
     middle_end/allocated_const.cmi middle_end/flambda_utils.cmi
 middle_end/flambda_utils.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/symbol.cmx bytecomp/switch.cmx \
-    middle_end/base_types/static_exception.cmx \
+    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
+    bytecomp/switch.cmx middle_end/base_types/static_exception.cmx \
     middle_end/base_types/set_of_closures_id.cmx middle_end/projection.cmx \
     middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    middle_end/base_types/linkage_name.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/debuginfo.cmx \
-    middle_end/base_types/compilation_unit.cmx \
+    middle_end/base_types/linkage_name.cmx middle_end/free_names.cmx \
+    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
+    middle_end/debuginfo.cmx middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/closure_id.cmx middle_end/backend_intf.cmi \
     middle_end/allocated_const.cmx middle_end/flambda_utils.cmi
 middle_end/flambda_utils.cmi : middle_end/base_types/variable.cmi \
@@ -1370,8 +1381,14 @@ middle_end/flambda_utils.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
     bytecomp/switch.cmi middle_end/base_types/static_exception.cmi \
     middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
-    middle_end/flambda.cmi middle_end/base_types/closure_id.cmi \
-    middle_end/backend_intf.cmi
+    typing/path.cmi middle_end/flambda.cmi \
+    middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi
+middle_end/free_names.cmo : middle_end/base_types/variable.cmi \
+    middle_end/base_types/symbol.cmi middle_end/free_names.cmi
+middle_end/free_names.cmx : middle_end/base_types/variable.cmx \
+    middle_end/base_types/symbol.cmx middle_end/free_names.cmi
+middle_end/free_names.cmi : middle_end/base_types/variable.cmi \
+    middle_end/base_types/symbol.cmi
 middle_end/freshening.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/symbol.cmi \
@@ -1435,11 +1452,12 @@ middle_end/inline_and_simplify.cmo : utils/warnings.cmi \
     middle_end/invariant_params.cmi middle_end/inlining_stats.cmi \
     middle_end/inlining_decision.cmi middle_end/inlining_cost.cmi \
     middle_end/inline_and_simplify_aux.cmi typing/ident.cmi \
-    middle_end/freshening.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi middle_end/effect_analysis.cmi \
-    middle_end/debuginfo.cmi middle_end/base_types/closure_id.cmi \
-    utils/clflags.cmi middle_end/backend_intf.cmi \
-    middle_end/allocated_const.cmi middle_end/inline_and_simplify.cmi
+    middle_end/freshening.cmi middle_end/free_names.cmi \
+    middle_end/flambda_utils.cmi middle_end/flambda.cmi \
+    middle_end/effect_analysis.cmi middle_end/debuginfo.cmi \
+    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
+    middle_end/backend_intf.cmi middle_end/allocated_const.cmi \
+    middle_end/inline_and_simplify.cmi
 middle_end/inline_and_simplify.cmx : utils/warnings.cmx \
     middle_end/base_types/variable.cmx \
     middle_end/base_types/var_within_closure.cmx \
@@ -1455,11 +1473,12 @@ middle_end/inline_and_simplify.cmx : utils/warnings.cmx \
     middle_end/invariant_params.cmx middle_end/inlining_stats.cmx \
     middle_end/inlining_decision.cmx middle_end/inlining_cost.cmx \
     middle_end/inline_and_simplify_aux.cmx typing/ident.cmx \
-    middle_end/freshening.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx middle_end/effect_analysis.cmx \
-    middle_end/debuginfo.cmx middle_end/base_types/closure_id.cmx \
-    utils/clflags.cmx middle_end/backend_intf.cmi \
-    middle_end/allocated_const.cmx middle_end/inline_and_simplify.cmi
+    middle_end/freshening.cmx middle_end/free_names.cmx \
+    middle_end/flambda_utils.cmx middle_end/flambda.cmx \
+    middle_end/effect_analysis.cmx middle_end/debuginfo.cmx \
+    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
+    middle_end/backend_intf.cmi middle_end/allocated_const.cmx \
+    middle_end/inline_and_simplify.cmi
 middle_end/inline_and_simplify.cmi : middle_end/base_types/variable.cmi \
     middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi \
     middle_end/backend_intf.cmi
@@ -1471,7 +1490,8 @@ middle_end/inline_and_simplify_aux.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/set_of_closures_origin.cmi \
     middle_end/projection.cmi middle_end/base_types/mutable_variable.cmi \
     utils/misc.cmi middle_end/inlining_stats.cmi middle_end/inlining_cost.cmi \
-    middle_end/freshening.cmi middle_end/flambda.cmi middle_end/debuginfo.cmi \
+    middle_end/freshening.cmi middle_end/free_names.cmi \
+    middle_end/flambda.cmi middle_end/debuginfo.cmi \
     middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/closure_id.cmi utils/clflags.cmi \
     middle_end/backend_intf.cmi middle_end/inline_and_simplify_aux.cmi
@@ -1483,7 +1503,8 @@ middle_end/inline_and_simplify_aux.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/set_of_closures_origin.cmx \
     middle_end/projection.cmx middle_end/base_types/mutable_variable.cmx \
     utils/misc.cmx middle_end/inlining_stats.cmx middle_end/inlining_cost.cmx \
-    middle_end/freshening.cmx middle_end/flambda.cmx middle_end/debuginfo.cmx \
+    middle_end/freshening.cmx middle_end/free_names.cmx \
+    middle_end/flambda.cmx middle_end/debuginfo.cmx \
     middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/closure_id.cmx utils/clflags.cmx \
     middle_end/backend_intf.cmi middle_end/inline_and_simplify_aux.cmi
@@ -1511,8 +1532,8 @@ middle_end/inlining_decision.cmo : middle_end/base_types/variable.cmi \
     middle_end/simple_value_approx.cmi utils/misc.cmi bytecomp/lambda.cmi \
     middle_end/inlining_transforms.cmi middle_end/inlining_stats_types.cmi \
     middle_end/inlining_cost.cmi middle_end/inline_and_simplify_aux.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda.cmi \
-    middle_end/find_recursive_functions.cmi \
+    middle_end/free_names.cmi middle_end/flambda_utils.cmi \
+    middle_end/flambda.cmi middle_end/find_recursive_functions.cmi \
     middle_end/base_types/closure_id.cmi utils/clflags.cmi \
     middle_end/inlining_decision.cmi
 middle_end/inlining_decision.cmx : middle_end/base_types/variable.cmx \
@@ -1520,8 +1541,8 @@ middle_end/inlining_decision.cmx : middle_end/base_types/variable.cmx \
     middle_end/simple_value_approx.cmx utils/misc.cmx bytecomp/lambda.cmx \
     middle_end/inlining_transforms.cmx middle_end/inlining_stats_types.cmx \
     middle_end/inlining_cost.cmx middle_end/inline_and_simplify_aux.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda.cmx \
-    middle_end/find_recursive_functions.cmx \
+    middle_end/free_names.cmx middle_end/flambda_utils.cmx \
+    middle_end/flambda.cmx middle_end/find_recursive_functions.cmx \
     middle_end/base_types/closure_id.cmx utils/clflags.cmx \
     middle_end/inlining_decision.cmi
 middle_end/inlining_decision.cmi : middle_end/base_types/variable.cmi \
@@ -1552,40 +1573,48 @@ middle_end/inlining_transforms.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/simple_value_approx.cmi utils/misc.cmi bytecomp/lambda.cmi \
     middle_end/inlining_cost.cmi middle_end/inline_and_simplify_aux.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi middle_end/inlining_transforms.cmi
+    typing/ident.cmi middle_end/free_names.cmi middle_end/flambda_utils.cmi \
+    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
+    middle_end/base_types/compilation_unit.cmi \
+    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
+    middle_end/inlining_transforms.cmi
 middle_end/inlining_transforms.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/var_within_closure.cmx \
     middle_end/simple_value_approx.cmx utils/misc.cmx bytecomp/lambda.cmx \
     middle_end/inlining_cost.cmx middle_end/inline_and_simplify_aux.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx middle_end/inlining_transforms.cmi
+    typing/ident.cmx middle_end/free_names.cmx middle_end/flambda_utils.cmx \
+    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
+    middle_end/base_types/compilation_unit.cmx \
+    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
+    middle_end/inlining_transforms.cmi
 middle_end/inlining_transforms.cmi : middle_end/base_types/variable.cmi \
     middle_end/simple_value_approx.cmi bytecomp/lambda.cmi \
     middle_end/inlining_decision_intf.cmi \
     middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi \
     middle_end/debuginfo.cmi middle_end/base_types/closure_id.cmi
 middle_end/invariant_params.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/symbol.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
-    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
-    middle_end/backend_intf.cmi middle_end/invariant_params.cmi
+    middle_end/base_types/symbol.cmi middle_end/free_names.cmi \
+    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
+    middle_end/flambda.cmi middle_end/base_types/closure_id.cmi \
+    utils/clflags.cmi middle_end/backend_intf.cmi \
+    middle_end/invariant_params.cmi
 middle_end/invariant_params.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/symbol.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
-    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
-    middle_end/backend_intf.cmi middle_end/invariant_params.cmi
+    middle_end/base_types/symbol.cmx middle_end/free_names.cmx \
+    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
+    middle_end/flambda.cmx middle_end/base_types/closure_id.cmx \
+    utils/clflags.cmx middle_end/backend_intf.cmi \
+    middle_end/invariant_params.cmi
 middle_end/invariant_params.cmi : middle_end/base_types/variable.cmi \
     middle_end/flambda.cmi middle_end/backend_intf.cmi
 middle_end/lift_code.cmo : middle_end/base_types/variable.cmi \
-    utils/strongly_connected_components.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/base_types/compilation_unit.cmi \
+    utils/strongly_connected_components.cmi middle_end/free_names.cmi \
+    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
+    middle_end/base_types/compilation_unit.cmi utils/clflags.cmi \
     middle_end/lift_code.cmi
 middle_end/lift_code.cmx : middle_end/base_types/variable.cmx \
-    utils/strongly_connected_components.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/base_types/compilation_unit.cmx \
+    utils/strongly_connected_components.cmx middle_end/free_names.cmx \
+    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
+    middle_end/base_types/compilation_unit.cmx utils/clflags.cmx \
     middle_end/lift_code.cmi
 middle_end/lift_code.cmi : middle_end/base_types/variable.cmi \
     middle_end/flambda.cmi
@@ -1595,8 +1624,9 @@ middle_end/lift_constants.cmo : middle_end/base_types/variable.cmi \
     utils/strongly_connected_components.cmi \
     middle_end/simple_value_approx.cmi utils/misc.cmi \
     middle_end/base_types/linkage_name.cmi middle_end/inconstant_idents.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/base_types/compilation_unit.cmi \
+    middle_end/free_names.cmi middle_end/flambda_utils.cmi \
+    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
+    middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi \
     parsing/asttypes.cmi middle_end/allocated_const.cmi \
     middle_end/alias_analysis.cmi middle_end/lift_constants.cmi
@@ -1606,8 +1636,9 @@ middle_end/lift_constants.cmx : middle_end/base_types/variable.cmx \
     utils/strongly_connected_components.cmx \
     middle_end/simple_value_approx.cmx utils/misc.cmx \
     middle_end/base_types/linkage_name.cmx middle_end/inconstant_idents.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/base_types/compilation_unit.cmx \
+    middle_end/free_names.cmx middle_end/flambda_utils.cmx \
+    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
+    middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/closure_id.cmx middle_end/backend_intf.cmi \
     parsing/asttypes.cmi middle_end/allocated_const.cmx \
     middle_end/alias_analysis.cmx middle_end/lift_constants.cmi
@@ -1615,13 +1646,15 @@ middle_end/lift_constants.cmi : middle_end/flambda.cmi \
     middle_end/backend_intf.cmi
 middle_end/lift_let_to_initialize_symbol.cmo : \
     middle_end/base_types/variable.cmi middle_end/base_types/tag.cmi \
-    middle_end/base_types/symbol.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi middle_end/debuginfo.cmi parsing/asttypes.cmi \
+    middle_end/base_types/symbol.cmi utils/misc.cmi middle_end/free_names.cmi \
+    middle_end/flambda_utils.cmi middle_end/flambda.cmi \
+    middle_end/debuginfo.cmi parsing/asttypes.cmi \
     middle_end/lift_let_to_initialize_symbol.cmi
 middle_end/lift_let_to_initialize_symbol.cmx : \
     middle_end/base_types/variable.cmx middle_end/base_types/tag.cmx \
-    middle_end/base_types/symbol.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx middle_end/debuginfo.cmx parsing/asttypes.cmi \
+    middle_end/base_types/symbol.cmx utils/misc.cmx middle_end/free_names.cmx \
+    middle_end/flambda_utils.cmx middle_end/flambda.cmx \
+    middle_end/debuginfo.cmx parsing/asttypes.cmi \
     middle_end/lift_let_to_initialize_symbol.cmi
 middle_end/lift_let_to_initialize_symbol.cmi : middle_end/flambda.cmi \
     middle_end/backend_intf.cmi
@@ -1634,7 +1667,7 @@ middle_end/middle_end.cmo : utils/warnings.cmi \
     middle_end/lift_let_to_initialize_symbol.cmi \
     middle_end/lift_constants.cmi middle_end/lift_code.cmi \
     middle_end/inlining_cost.cmi middle_end/inline_and_simplify.cmi \
-    middle_end/initialize_symbol_to_let_symbol.cmi \
+    middle_end/initialize_symbol_to_let_symbol.cmi typing/ident.cmi \
     middle_end/flambda_iterators.cmi middle_end/flambda_invariants.cmi \
     middle_end/flambda.cmi middle_end/debuginfo.cmi \
     middle_end/base_types/closure_id.cmi middle_end/closure_conversion.cmi \
@@ -1648,7 +1681,7 @@ middle_end/middle_end.cmx : utils/warnings.cmx \
     middle_end/lift_let_to_initialize_symbol.cmx \
     middle_end/lift_constants.cmx middle_end/lift_code.cmx \
     middle_end/inlining_cost.cmx middle_end/inline_and_simplify.cmx \
-    middle_end/initialize_symbol_to_let_symbol.cmx \
+    middle_end/initialize_symbol_to_let_symbol.cmx typing/ident.cmx \
     middle_end/flambda_iterators.cmx middle_end/flambda_invariants.cmx \
     middle_end/flambda.cmx middle_end/debuginfo.cmx \
     middle_end/base_types/closure_id.cmx middle_end/closure_conversion.cmx \
@@ -1669,14 +1702,14 @@ middle_end/projection.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/closure_id.cmi
 middle_end/ref_to_variables.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    bytecomp/lambda.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi parsing/asttypes.cmi \
-    middle_end/ref_to_variables.cmi
+    bytecomp/lambda.cmi middle_end/free_names.cmi \
+    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
+    parsing/asttypes.cmi middle_end/ref_to_variables.cmi
 middle_end/ref_to_variables.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    bytecomp/lambda.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx parsing/asttypes.cmi \
-    middle_end/ref_to_variables.cmi
+    bytecomp/lambda.cmx middle_end/free_names.cmx \
+    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
+    parsing/asttypes.cmi middle_end/ref_to_variables.cmi
 middle_end/ref_to_variables.cmi : middle_end/flambda.cmi
 middle_end/remove_free_vars_equal_to_args.cmo : \
     middle_end/base_types/variable.cmi middle_end/pass_wrapper.cmi \
@@ -1689,15 +1722,17 @@ middle_end/remove_free_vars_equal_to_args.cmx : \
 middle_end/remove_free_vars_equal_to_args.cmi : middle_end/flambda.cmi
 middle_end/remove_unused_arguments.cmo : middle_end/base_types/variable.cmi \
     middle_end/projection.cmi middle_end/invariant_params.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/find_recursive_functions.cmi \
+    middle_end/free_names.cmi middle_end/flambda_utils.cmi \
+    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
+    middle_end/find_recursive_functions.cmi \
     middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/closure_id.cmi utils/clflags.cmi \
     middle_end/remove_unused_arguments.cmi
 middle_end/remove_unused_arguments.cmx : middle_end/base_types/variable.cmx \
     middle_end/projection.cmx middle_end/invariant_params.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/find_recursive_functions.cmx \
+    middle_end/free_names.cmx middle_end/flambda_utils.cmx \
+    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
+    middle_end/find_recursive_functions.cmx \
     middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/closure_id.cmx utils/clflags.cmx \
     middle_end/remove_unused_arguments.cmi
@@ -1705,24 +1740,26 @@ middle_end/remove_unused_arguments.cmi : middle_end/flambda.cmi \
     middle_end/backend_intf.cmi
 middle_end/remove_unused_closure_vars.cmo : \
     middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
-    middle_end/base_types/closure_id.cmi \
-    middle_end/remove_unused_closure_vars.cmi
+    middle_end/base_types/var_within_closure.cmi middle_end/free_names.cmi \
+    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
+    middle_end/flambda.cmi middle_end/base_types/closure_id.cmi \
+    utils/clflags.cmi middle_end/remove_unused_closure_vars.cmi
 middle_end/remove_unused_closure_vars.cmx : \
     middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
-    middle_end/base_types/closure_id.cmx \
-    middle_end/remove_unused_closure_vars.cmi
+    middle_end/base_types/var_within_closure.cmx middle_end/free_names.cmx \
+    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
+    middle_end/flambda.cmx middle_end/base_types/closure_id.cmx \
+    utils/clflags.cmx middle_end/remove_unused_closure_vars.cmi
 middle_end/remove_unused_closure_vars.cmi : middle_end/flambda.cmi
 middle_end/remove_unused_program_constructs.cmo : \
-    middle_end/base_types/symbol.cmi utils/misc.cmi middle_end/flambda.cmi \
-    middle_end/effect_analysis.cmi \
+    middle_end/base_types/symbol.cmi utils/misc.cmi middle_end/free_names.cmi \
+    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
+    middle_end/effect_analysis.cmi utils/clflags.cmi \
     middle_end/remove_unused_program_constructs.cmi
 middle_end/remove_unused_program_constructs.cmx : \
-    middle_end/base_types/symbol.cmx utils/misc.cmx middle_end/flambda.cmx \
-    middle_end/effect_analysis.cmx \
+    middle_end/base_types/symbol.cmx utils/misc.cmx middle_end/free_names.cmx \
+    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
+    middle_end/effect_analysis.cmx utils/clflags.cmx \
     middle_end/remove_unused_program_constructs.cmi
 middle_end/remove_unused_program_constructs.cmi : middle_end/flambda.cmi
 middle_end/semantics_of_primitives.cmo : bytecomp/printlambda.cmi \
@@ -1741,18 +1778,20 @@ middle_end/simple_value_approx.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
     utils/misc.cmi bytecomp/lambda.cmi middle_end/inlining_cost.cmi \
-    middle_end/freshening.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi middle_end/base_types/export_id.cmi \
-    middle_end/effect_analysis.cmi middle_end/base_types/closure_id.cmi \
-    middle_end/allocated_const.cmi middle_end/simple_value_approx.cmi
+    middle_end/freshening.cmi middle_end/free_names.cmi \
+    middle_end/flambda_utils.cmi middle_end/flambda.cmi \
+    middle_end/base_types/export_id.cmi middle_end/effect_analysis.cmi \
+    middle_end/base_types/closure_id.cmi middle_end/allocated_const.cmi \
+    middle_end/simple_value_approx.cmi
 middle_end/simple_value_approx.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/var_within_closure.cmx \
     middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
     utils/misc.cmx bytecomp/lambda.cmx middle_end/inlining_cost.cmx \
-    middle_end/freshening.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx middle_end/base_types/export_id.cmx \
-    middle_end/effect_analysis.cmx middle_end/base_types/closure_id.cmx \
-    middle_end/allocated_const.cmx middle_end/simple_value_approx.cmi
+    middle_end/freshening.cmx middle_end/free_names.cmx \
+    middle_end/flambda_utils.cmx middle_end/flambda.cmx \
+    middle_end/base_types/export_id.cmx middle_end/effect_analysis.cmx \
+    middle_end/base_types/closure_id.cmx middle_end/allocated_const.cmx \
+    middle_end/simple_value_approx.cmi
 middle_end/simple_value_approx.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -159,6 +159,7 @@ MIDDLE_END=\
   middle_end/semantics_of_primitives.cmo \
   middle_end/allocated_const.cmo \
   middle_end/projection.cmo \
+  middle_end/free_names.cmo \
   middle_end/flambda.cmo \
   middle_end/flambda_iterators.cmo \
   middle_end/flambda_utils.cmo \

--- a/asmcomp/export_info_for_pack.ml
+++ b/asmcomp/export_info_for_pack.ml
@@ -100,7 +100,8 @@ let import_function_declarations_for_pack units pack
           ~stub:function_decl.stub ~dbg:function_decl.dbg
           ~inline:function_decl.inline
           ~specialise:function_decl.specialise
-          ~is_a_functor:function_decl.is_a_functor)
+          ~is_a_functor:function_decl.is_a_functor
+          ~module_path:function_decl.module_path)
       function_decls.funs
   in
   Flambda.update_function_declarations function_decls ~funs

--- a/asmcomp/import_approx.ml
+++ b/asmcomp/import_approx.ml
@@ -31,24 +31,22 @@ let import_set_of_closures =
         clos.funs Symbol.Map.empty
     in
     let sym_map = sym_to_fun_var_map clos in
-    let f_named (named : Flambda.named) =
-      match named with
-      | Symbol sym ->
-        begin try Flambda.Expr (Var (Symbol.Map.find sym sym_map)) with
-        | Not_found -> named
-        end
-      | named -> named
+    let sym_to_fun_var sym =
+      try Some (Symbol.Map.find sym sym_map)
+      with Not_found -> None
     in
     let funs =
       Variable.Map.map (fun (function_decl : Flambda.function_declaration) ->
           let body =
-            Flambda_iterators.map_toplevel_named f_named function_decl.body
+            Flambda_iterators.map_toplevel_symbols_to_vars function_decl.body
+              ~f:sym_to_fun_var
           in
           Flambda.create_function_declaration ~params:function_decl.params
             ~body ~stub:function_decl.stub ~dbg:function_decl.dbg
             ~inline:function_decl.inline
             ~specialise:function_decl.specialise
-            ~is_a_functor:function_decl.is_a_functor)
+            ~is_a_functor:function_decl.is_a_functor
+            ~module_path:function_decl.module_path)
         clos.funs
     in
     Flambda.update_function_declarations clos ~funs

--- a/middle_end/augment_specialised_args.ml
+++ b/middle_end/augment_specialised_args.ml
@@ -377,8 +377,11 @@ let check_invariants ~pass_name ~(set_of_closures : Flambda.set_of_closures)
         Variable.Map.iter (fun inner_var
                     (outer_var : Flambda.specialised_to) ->
               if Variable.Set.mem inner_var params then begin
+                let free_variables =
+                  Free_names.all_free_variables function_decl.free_names
+                in
                 assert (not (Variable.Set.mem outer_var.var
-                  function_decl.free_variables));
+                  free_variables));
                 match outer_var.projection with
                 | None -> ()
                 | Some projection ->
@@ -538,6 +541,7 @@ module Make (T : S) = struct
         ~inline:Default_inline
         ~specialise:Default_specialise
         ~is_a_functor:false
+        ~module_path:function_decl.module_path
     in
     new_fun_var, new_function_decl, rewritten_existing_specialised_args,
       benefit
@@ -619,6 +623,7 @@ module Make (T : S) = struct
           ~inline:function_decl.inline
           ~specialise:function_decl.specialise
           ~is_a_functor:function_decl.is_a_functor
+          ~module_path:function_decl.module_path
       in
       let funs, direct_call_surrogates =
         if for_one_function.make_direct_call_surrogates then

--- a/middle_end/base_types/closure_element.mli
+++ b/middle_end/base_types/closure_element.mli
@@ -27,6 +27,8 @@ val unwrap_set : Set.t -> Variable.Set.t
 val in_compilation_unit : t -> Compilation_unit.t -> bool
 val get_compilation_unit : t -> Compilation_unit.t
 
+val base_name : t -> string
+
 val unique_name : t -> string
 
 val output_full : out_channel -> t -> unit

--- a/middle_end/base_types/compilation_unit.ml
+++ b/middle_end/base_types/compilation_unit.ml
@@ -20,6 +20,7 @@ type t = {
   id : Ident.t;
   linkage_name : Linkage_name.t;
   hash : int;
+  is_startup : bool;
 }
 
 let string_for_printing t = Ident.name t.id
@@ -58,7 +59,7 @@ let create (id : Ident.t) linkage_name =
   if not (Ident.persistent id) then begin
     Misc.fatal_error "Compilation_unit.create with non-persistent Ident.t"
   end;
-  { id; linkage_name; hash = Hashtbl.hash id.name }
+  { id; linkage_name; hash = Hashtbl.hash id.name; is_startup = false; }
 
 let get_persistent_ident cu = cu.id
 let get_linkage_name cu = cu.linkage_name
@@ -71,3 +72,13 @@ let get_current_exn () =
   | Some current -> current
   | None -> Misc.fatal_error "Compilation_unit.get_current_exn"
 let get_current_id_exn () = get_persistent_ident (get_current_exn ())
+
+let startup =
+  lazy ({
+    id = Ident.create_persistent "*startup*";
+    linkage_name = Linkage_name.create "caml_startup";
+    hash = Hashtbl.hash "*startup*";
+    is_startup = true;
+  })
+
+let is_startup t = t.is_startup

--- a/middle_end/base_types/compilation_unit.mli
+++ b/middle_end/base_types/compilation_unit.mli
@@ -31,3 +31,10 @@ val get_current_exn : unit -> t
 val get_current_id_exn : unit -> Ident.t
 
 val string_for_printing : t -> string
+
+(** The unique compilation unit corresponding to the startup file.
+    This can be used for constructing [Symbol.t]s for, e.g. "caml_program",
+    "caml_curry*", etc.
+*)
+val startup : t Lazy.t
+val is_startup : t -> bool

--- a/middle_end/base_types/symbol.mli
+++ b/middle_end/base_types/symbol.mli
@@ -28,6 +28,8 @@
 
 include Identifiable.S
 
+type symbol = t
+
 val create : Compilation_unit.t -> Linkage_name.t -> t
 (* Create the symbol without prefixing with the compilation unit.
    Used for predefined exceptions *)

--- a/middle_end/base_types/variable.mli
+++ b/middle_end/base_types/variable.mli
@@ -28,7 +28,12 @@
 
 include Identifiable.S
 
-val create : ?current_compilation_unit:Compilation_unit.t -> string -> t
+val create
+   : ?original_ident:Ident.t
+  -> ?current_compilation_unit:Compilation_unit.t
+  -> string
+  -> t
+
 val create_with_same_name_as_ident : Ident.t -> t
 
 val clambda_name : t -> string
@@ -42,7 +47,12 @@ val rename
 
 val in_compilation_unit : t -> Compilation_unit.t -> bool
 
+val base_name : t -> string
 val unique_name : t -> string
+
+(** Returns any identifier as found in the [Lambda] code that exactly
+    corresponds to the given variable. *)
+val original_ident : t -> Ident.t option
 
 val get_compilation_unit : t -> Compilation_unit.t
 

--- a/middle_end/closure_conversion_aux.mli
+++ b/middle_end/closure_conversion_aux.mli
@@ -42,7 +42,11 @@ module Env : sig
   val find_global : t -> int -> Symbol.t
 
   val at_toplevel : t -> bool
+  (* XXX not_at_toplevel should take a function name  / etc *)
   val not_at_toplevel : t -> t
+
+  val entering_module_definition : t -> path:Path.t -> t
+  val current_module_path : t -> Path.t
 end
 
 (** Used to represent information about a set of function declarations

--- a/middle_end/debuginfo.ml
+++ b/middle_end/debuginfo.ml
@@ -94,3 +94,20 @@ let compare dbg1 dbg2 =
       loop ds1 ds2
   in
   loop (List.rev dbg1) (List.rev dbg2)
+
+let rec print_compact ppf t =
+  let print_item item =
+    Format.fprintf ppf "%a:%i"
+      Location.print_filename item.dinfo_file
+      item.dinfo_line;
+    if item.dinfo_char_start >= 0 then begin
+      Format.fprintf ppf ",%i--%i" item.dinfo_char_start item.dinfo_char_end
+    end
+  in
+  match t with
+  | [] -> ()
+  | [item] -> print_item item
+  | item::t ->
+    print_item item;
+    Format.fprintf ppf ";";
+    print_compact ppf t

--- a/middle_end/debuginfo.mli
+++ b/middle_end/debuginfo.mli
@@ -37,3 +37,5 @@ val concat: t -> t -> t
 val inline: Location.t -> t -> t
 
 val compare : t -> t -> int
+
+val print_compact : Format.formatter -> t -> unit

--- a/middle_end/extract_projections.ml
+++ b/middle_end/extract_projections.ml
@@ -97,8 +97,8 @@ let rec analyse_expr ~which_variables expr =
     | Assign { new_value; _ } ->
       check_free_variable new_value
     | If_then_else (var, _, _)
-    | Switch (var, _)
-    | String_switch (var, _, _) ->
+    | Switch (_, var, _)
+    | String_switch (_, var, _, _) ->
       check_free_variable var
     | Static_raise (_, args) ->
       List.iter check_free_variable args

--- a/middle_end/flambda_iterators.mli
+++ b/middle_end/flambda_iterators.mli
@@ -99,15 +99,19 @@ val iter_all_immutable_let_and_let_rec_bindings
    : Flambda.t
   -> f:(Variable.t -> Flambda.named -> unit)
   -> unit
-
+(* CR mshinwell: these now miss "debug_only" lets *)
 val iter_all_toplevel_immutable_let_and_let_rec_bindings
    : Flambda.t
-  -> f:(Variable.t -> Flambda.named -> unit)
+  -> f:(Variable.t
+    -> Flambda.named
+    -> provenance:Flambda.let_provenance option
+    -> unit)
   -> unit
 
+(* CR mshinwell: wrong name?  Not really "toplevel" *)
 val iter_exprs_at_toplevel_of_program
    : Flambda.program
-  -> f:(Flambda.t -> unit)
+  -> f:(Flambda.t -> under_lifted_set_of_closures:bool -> unit)
   -> unit
 
 val iter_named_of_program
@@ -141,22 +145,16 @@ val map_named
   -> Flambda.t
   -> Flambda.t
 
+(** This function may rewrite the defining expression of a phantom let. *)
 val map_toplevel
    : (Flambda.t -> Flambda.t)
   -> (Flambda.named -> Flambda.named)
+  -> (Flambda.defining_expr_of_phantom_let
+    -> Flambda.defining_expr_of_phantom_let)
   -> Flambda.t
   -> Flambda.t
 
-val map_toplevel_expr
-   : (Flambda.t -> Flambda.t)
-  -> Flambda.t
-  -> Flambda.t
-
-val map_toplevel_named
-   : (Flambda.named -> Flambda.named)
-  -> Flambda.t
-  -> Flambda.t
-
+(** This function may rewrite the defining expression of a phantom let. *)
 val map_symbols
    : Flambda.t
   -> f:(Symbol.t -> Symbol.t)
@@ -167,12 +165,23 @@ val map_symbols_on_set_of_closures
   -> f:(Symbol.t -> Symbol.t)
   -> Flambda.set_of_closures
 
+(** This function may rewrite the defining expression of a phantom let. *)
+val map_toplevel_symbols_to_vars
+   : Flambda.t
+  -> f:(Symbol.t -> Variable.t option)
+  -> Flambda.t
+
 val map_toplevel_sets_of_closures
    : Flambda.t
   -> f:(Flambda.set_of_closures -> Flambda.set_of_closures)
   -> Flambda.t
 
 val map_apply
+   : Flambda.t
+  -> f:(Flambda.apply -> Flambda.apply)
+  -> Flambda.t
+
+val map_toplevel_apply
    : Flambda.t
   -> f:(Flambda.apply -> Flambda.apply)
   -> Flambda.t
@@ -212,9 +221,17 @@ val map_named_of_program
   -> f:(Variable.t -> Flambda.named -> Flambda.named)
   -> Flambda.program
 
+val map_phantom_of_program
+   : Flambda.program
+  -> f:(Flambda.defining_expr_of_phantom_let
+    -> Flambda.defining_expr_of_phantom_let)
+  -> Flambda.program
+
 val map_all_immutable_let_and_let_rec_bindings
    : Flambda.t
-  -> f:(Variable.t -> Flambda.named -> Flambda.named)
+  -> f:(Variable.t
+      -> Flambda.named
+      -> Flambda.named)
   -> Flambda.t
 
 val fold_function_decls_ignoring_stubs

--- a/middle_end/flambda_utils.mli
+++ b/middle_end/flambda_utils.mli
@@ -71,6 +71,7 @@ val make_closure_declaration
   -> body:Flambda.t
   -> params:Variable.t list
   -> stub:bool
+  -> module_path:Path.t
   -> Flambda.t
 
 val toplevel_substitution
@@ -87,17 +88,23 @@ val toplevel_substitution_named
     [Immutable] [Let] expressions the given [(var, expr)] pairs around the
     body. *)
 val bind
-   : bindings:(Variable.t * Flambda.named) list
+   : ?provenance:Flambda.let_provenance
+  -> bindings:(Variable.t * Flambda.named) list
   -> body:Flambda.t
+  -> unit
   -> Flambda.t
 
-val name_expr : Flambda.named -> name:string -> Flambda.t
+val name_expr
+   : ?provenance:Flambda.let_provenance
+  -> Flambda.named
+  -> name:string
+  -> Flambda.t
 
 val compare_const : Flambda.const -> Flambda.const -> int
 
 val initialize_symbols
    : Flambda.program
-  -> (Symbol.t * Tag.t * Flambda.t list) list
+  -> (Symbol.t * Flambda.symbol_provenance option * Tag.t * Flambda.t list) list
 
 val imported_symbols : Flambda.program -> Symbol.Set.t
 
@@ -214,3 +221,9 @@ val clean_projections
   -> Flambda.specialised_to Variable.Map.t
 
 val projection_to_named : Projection.t -> Flambda.named
+
+(** Turn a [named], intended to be the defining expression of a [Let],
+    into a phantom let defining expression. *)
+val phantomize_defining_expr
+   : Flambda.named
+  -> Flambda.defining_expr_of_phantom_let

--- a/middle_end/free_names.ml
+++ b/middle_end/free_names.ml
@@ -1,0 +1,100 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2016 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type t = {
+  mutable free_variables : Variable.Set.t;
+  mutable free_phantom_variables : Variable.Set.t;
+  mutable free_symbols : Symbol.Set.t;
+  mutable free_phantom_symbols : Symbol.Set.t;
+}
+
+type free_names = t
+
+let is_free_variable t var = Variable.Set.mem var t.free_variables
+let is_free_phantom_variable t var =
+  Variable.Set.mem var t.free_phantom_variables
+
+let free_variables t = t.free_variables
+let free_phantom_variables t = t.free_phantom_variables
+let all_free_variables t =
+  Variable.Set.union (free_variables t) (free_phantom_variables t)
+
+let free_symbols t = t.free_symbols
+let free_phantom_symbols t = t.free_phantom_symbols
+let all_free_symbols t =
+  Symbol.Set.union (free_symbols t) (free_phantom_symbols t)
+
+let subset t1 t2 =
+  Variable.Set.subset t1.free_variables t2.free_variables
+    && Variable.Set.subset t1.free_phantom_variables t2.free_phantom_variables
+    && Symbol.Set.subset t1.free_symbols t2.free_symbols
+    && Symbol.Set.subset t1.free_phantom_symbols t2.free_phantom_symbols
+
+let print ppf t =
+  Format.fprintf ppf "{ free_variables = %a;@ free_phantom_variables = %a;@ \
+      free_symbols = %a;@ free_phantom_symbols = %a; }"
+    Variable.Set.print t.free_variables
+    Variable.Set.print t.free_phantom_variables
+    Symbol.Set.print t.free_symbols
+    Symbol.Set.print t.free_phantom_symbols
+
+module Mutable = struct
+  type nonrec t = t
+
+  let create () =
+    { free_variables = Variable.Set.empty;
+      free_phantom_variables = Variable.Set.empty;
+      free_symbols = Symbol.Set.empty;
+      free_phantom_symbols = Symbol.Set.empty;
+    }
+
+  let free_variable t var =
+    t.free_variables <- Variable.Set.add var t.free_variables
+
+  let free_phantom_variable t var =
+    t.free_phantom_variables <- Variable.Set.add var t.free_phantom_variables
+
+  let free_symbol t sym =
+    t.free_symbols <- Symbol.Set.add sym t.free_symbols
+
+  let free_symbols t syms =
+    t.free_symbols <- Symbol.Set.union syms t.free_symbols
+
+  let free_phantom_symbol t sym =
+    t.free_phantom_symbols <- Symbol.Set.add sym t.free_phantom_symbols
+
+  let union_free_symbols_only t t' =
+    t.free_symbols <- Symbol.Set.union t.free_symbols t'.free_symbols;
+    t.free_phantom_symbols
+      <- Symbol.Set.union t.free_phantom_symbols t'.free_phantom_symbols
+
+  let union t t' =
+    t.free_variables
+      <- Variable.Set.union t.free_variables t'.free_variables;
+    t.free_phantom_variables
+      <- Variable.Set.union t.free_phantom_variables t'.free_phantom_variables;
+    union_free_symbols_only t t'
+
+  let bound_variables t bound_vars =
+    t.free_variables <- Variable.Set.diff t.free_variables bound_vars;
+    t.free_phantom_variables
+      <- Variable.Set.diff t.free_phantom_variables bound_vars
+
+  let freeze t =
+    { free_variables = t.free_variables;
+      free_phantom_variables = t.free_phantom_variables;
+      free_symbols = t.free_symbols;
+      free_phantom_symbols = t.free_phantom_symbols;
+    }
+end

--- a/middle_end/free_names.mli
+++ b/middle_end/free_names.mli
@@ -1,0 +1,61 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2016 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Tracking of sets of free variables and symbols. *)
+
+type t
+type free_names = t
+
+val is_free_variable : t -> Variable.t -> bool
+val is_free_phantom_variable : t -> Variable.t -> bool
+
+val free_variables : t -> Variable.Set.t
+(* CR mshinwell: The name is misleading.  It should be "variables used
+   in phantom context". *)
+val free_phantom_variables : t -> Variable.Set.t
+
+(** Both the normal and phantom free variables in the set. *)
+val all_free_variables : t -> Variable.Set.t
+
+val free_symbols : t -> Symbol.Set.t
+(* CR mshinwell: clarify whether a symbol in free_phantom_symbols may occur
+   in free_symbols *)
+val free_phantom_symbols : t -> Symbol.Set.t
+
+(** Both the normal and phantom free symbols in the set. *)
+val all_free_symbols : t -> Symbol.Set.t
+
+val subset : t -> t -> bool
+
+val print : Format.formatter -> t -> unit
+
+module Mutable : sig
+  type t
+
+  val create : unit -> t
+
+  val free_variable : t -> Variable.t -> unit
+  val free_phantom_variable : t -> Variable.t -> unit
+
+  val free_symbol : t -> Symbol.t -> unit
+  val free_symbols : t -> Symbol.Set.t -> unit
+  val free_phantom_symbol : t -> Symbol.t -> unit
+
+  val union : t -> free_names -> unit
+  val union_free_symbols_only : t -> free_names -> unit
+
+  val bound_variables : t -> Variable.Set.t -> unit
+
+  val freeze : t -> free_names
+end

--- a/middle_end/freshening.ml
+++ b/middle_end/freshening.ml
@@ -147,6 +147,11 @@ let add_variables t defs =
       let id', t = add_variable t id in
       (id', data) :: defs, t) defs ([], t)
 
+let add_variables3 t defs =
+  List.fold_right (fun (id, data1, data2) (defs, t) ->
+      let id', t = add_variable t id in
+      (id', data1, data2) :: defs, t) defs ([], t)
+
 let add_variables' t ids =
   List.fold_right (fun id (ids, t) ->
       let id', t = add_variable t id in
@@ -214,19 +219,18 @@ let rewrite_recursive_calls_with_symbols t
       let funs =
         Variable.Map.map (fun (ffun : Flambda.function_declaration) ->
           let body =
-            Flambda_iterators.map_toplevel_named
-              (* CR-someday pchambart: This may be worth deep substituting
-                 below the closures, but that means that we need to take care
-                 of functions' free variables. *)
-              (function
-                | Symbol sym when Symbol.Map.mem sym closure_symbols ->
-                  Expr (Var (Symbol.Map.find sym closure_symbols))
-                | e -> e)
-              ffun.body
+            (* CR-someday pchambart: This may be worth deep substituting
+               below the closures, but that means that we need to take care
+               of functions' free variables. *)
+            Flambda_iterators.map_toplevel_symbols_to_vars ffun.body
+              ~f:(fun sym ->
+                try Some (Symbol.Map.find sym closure_symbols)
+                with Not_found -> None)
           in
           Flambda.create_function_declaration ~params:ffun.params
             ~body ~stub:ffun.stub ~dbg:ffun.dbg ~inline:ffun.inline
-            ~specialise:ffun.specialise ~is_a_functor:ffun.is_a_functor)
+            ~specialise:ffun.specialise ~is_a_functor:ffun.is_a_functor
+            ~module_path:ffun.module_path)
           function_declarations.funs
       in
       Flambda.update_function_declarations function_declarations ~funs
@@ -312,6 +316,7 @@ module Project_var = struct
             ~body ~stub:func_decl.stub ~dbg:func_decl.dbg
             ~inline:func_decl.inline ~specialise:func_decl.specialise
             ~is_a_functor:func_decl.is_a_functor
+            ~module_path:func_decl.module_path
         in
         function_decl, subst
       in

--- a/middle_end/freshening.mli
+++ b/middle_end/freshening.mli
@@ -60,6 +60,13 @@ val add_variables
   -> (Variable.t * 'a) list
   -> (Variable.t * 'a) list * t
 
+(** Like [add_variables], but passes through the second and third components
+    of the input list unchanged. *)
+val add_variables3
+   : t
+  -> (Variable.t * 'a * 'b) list
+  -> (Variable.t * 'a * 'b) list * t
+
 (** Like [add_variable], but for mutable variables. *)
 val add_mutable_variable : t -> Mutable_variable.t -> Mutable_variable.t * t
 

--- a/middle_end/initialize_symbol_to_let_symbol.ml
+++ b/middle_end/initialize_symbol_to_let_symbol.ml
@@ -16,14 +16,14 @@
 
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
-let constant_field (expr:Flambda.t)
-  : Flambda.constant_defining_value_block_field option =
+let constant_field (expr : Flambda.t)
+      : Flambda.constant_defining_value_block_field option =
   match expr with
-  | Let { var; defining_expr = Const c; body = Var var' ; _ } ->
+  | Let { var; defining_expr = Normal (Const c); body = Var var' ; _ } ->
     assert(Variable.equal var var');
     (* This must be true since var is the only variable in scope *)
     Some (Flambda.Const c)
-  | Let { var; defining_expr = Symbol s; body = Var var' ; _ } ->
+  | Let { var; defining_expr = Normal (Symbol s); body = Var var' ; _ } ->
     assert(Variable.equal var var');
     Some (Flambda.Symbol s)
   | _ ->
@@ -31,18 +31,18 @@ let constant_field (expr:Flambda.t)
 
 let rec loop (program : Flambda.program_body) : Flambda.program_body =
   match program with
-  | Initialize_symbol (symbol, tag, fields, program) ->
+  | Initialize_symbol (symbol, provenance, tag, fields, program) ->
     let constant_fields = List.map constant_field fields in
     begin
       match Misc.Stdlib.List.some_if_all_elements_are_some constant_fields
     with
     | None ->
-      Initialize_symbol (symbol, tag, fields, loop program)
+      Initialize_symbol (symbol, provenance, tag, fields, loop program)
     | Some fields ->
-      Let_symbol (symbol, Block (tag, fields), loop program)
+      Let_symbol (symbol, provenance, Block (tag, fields), loop program)
     end
-  | Let_symbol (symbol, const, program) ->
-    Let_symbol (symbol, const, loop program)
+  | Let_symbol (symbol, provenance, const, program) ->
+    Let_symbol (symbol, provenance, const, loop program)
   | Let_rec_symbol (defs, program) ->
     Let_rec_symbol (defs, loop program)
   | Effect (expr, program) ->

--- a/middle_end/inline_and_simplify_aux.ml
+++ b/middle_end/inline_and_simplify_aux.ml
@@ -679,7 +679,10 @@ let prepare_to_simplify_closure ~(function_decl : Flambda.function_declaration)
         | None -> env
         | Some projection ->
           let from = Projection.projecting_from projection in
-          if Variable.Set.mem from function_decl.free_variables then
+          let free_variables =
+            Free_names.free_variables function_decl.free_names
+          in
+          if Variable.Set.mem from free_variables then
             E.add_projection env ~projection ~bound_to:inner_var
           else
             env)

--- a/middle_end/inlining_decision.ml
+++ b/middle_end/inlining_decision.ml
@@ -140,6 +140,9 @@ let inline env r ~lhs_of_application
           let benefit = Inlining_cost.Benefit.zero in
           let benefit = Inlining_cost.Benefit.remove_call benefit in
           let benefit =
+            let free_variables =
+              Free_names.free_variables function_decl.free_names
+            in
             Variable.Set.fold (fun v acc ->
                 try
                   let t =
@@ -152,7 +155,7 @@ let inline env r ~lhs_of_application
                     else acc
                   | None -> acc
                 with Not_found -> acc)
-              function_decl.free_variables benefit
+              free_variables benefit
           in
           W.create_estimate
             ~original_size:Inlining_cost.direct_call_size

--- a/middle_end/invariant_params.ml
+++ b/middle_end/invariant_params.ml
@@ -138,7 +138,7 @@ let function_variable_alias
   let fun_var_bindings = ref Variable.Map.empty in
   Variable.Map.iter (fun _ ( function_decl : Flambda.function_declaration ) ->
       Flambda_iterators.iter_all_toplevel_immutable_let_and_let_rec_bindings
-        ~f:(fun var named ->
+        ~f:(fun var named ~provenance:_ ->
            (* CR-soon mshinwell: consider having the body passed to this
               function and using fv calculation instead of used_variables.
               Need to be careful of "let rec" *)
@@ -241,13 +241,17 @@ let analyse_functions ~backend ~param_to_param
       Flambda_iterators.iter (check_expr ~caller)
         (fun (_ : Flambda.named) -> ())
         decl.body;
+      let free_variables =
+        Free_names.free_variables
+          (Flambda.free_names_expr ~ignore_uses_as_callee:()
+             ~ignore_uses_as_argument:() decl.body)
+      in
       Variable.Set.iter
         (fun var -> escaping_function var; used_variable var)
         (* CR-soon mshinwell: we should avoid recomputing this, cache in
            [function_declaration].  See also comment on
            [only_via_symbols] in [Flambda_utils]. *)
-        (Flambda.free_variables ~ignore_uses_as_callee:()
-           ~ignore_uses_as_argument:() decl.body))
+        free_variables)
     decls.funs;
   Variable.Map.iter
     (fun func_var ({ params } : Flambda.function_declaration) ->

--- a/middle_end/lift_let_to_initialize_symbol.ml
+++ b/middle_end/lift_let_to_initialize_symbol.ml
@@ -17,21 +17,28 @@
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
 type ('a, 'b) kind =
-  | Initialisation of (Symbol.t * Tag.t * Flambda.t list)
-  | Effect of 'b
+  | Initialisation of
+      (Symbol.t * Flambda.symbol_provenance option * Tag.t * Flambda.t list)
 
-let should_copy (named:Flambda.named) =
-  match named with
-  | Symbol _ | Read_symbol_field _ | Const _ -> true
-  | _ -> false
+let should_copy (defining_expr : Flambda.defining_expr_of_let) =
+  match defining_expr with
+  | Normal named ->
+    begin match named with
+    | Symbol _ | Read_symbol_field _ | Const _ -> true
+    | _ -> false
+    end
+  | Phantom _ -> true
 
 type extracted =
-  | Expr of Variable.t * Flambda.t
-  | Exprs of Variable.t list * Flambda.t
+  | Expr of Variable.t * Flambda.t * Flambda.symbol_provenance option
+  | Exprs of Variable.t list * Flambda.t * Flambda.symbol_provenance option
   | Block of Variable.t * Tag.t * Variable.t list
+      * Flambda.symbol_provenance option
 
 type accumulated = {
-  copied_lets : (Variable.t * Flambda.named) list;
+  copied_lets :
+    (Variable.t * (Flambda.defining_expr_of_let
+      * Flambda.let_provenance option)) list;
   extracted_lets : extracted list;
   terminator : Flambda.expr;
 }
@@ -39,44 +46,93 @@ type accumulated = {
 let rec accumulate ~substitution ~copied_lets ~extracted_lets
       (expr : Flambda.t) =
   match expr with
-  | Let { var; body = Var var'; _ } | Let_rec ([var, _], Var var')
+  | Let { var; body = Var var'; _ }
+  | Let_rec { vars_and_defining_exprs = [var, _, _]; body = Var var'; }
     when Variable.equal var var' ->
     { copied_lets; extracted_lets;
       terminator = Flambda_utils.toplevel_substitution substitution expr;
     }
   (* If the pattern is what lifting let_rec generates, prevent it from being
      lifted again. *)
-  | Let_rec (defs,
-             Let { var; body = Var var';
-                   defining_expr = Prim (Pmakeblock _, fields, _); })
+  | Let_rec {
+      vars_and_defining_exprs = defs;
+      body = Let { var; body = Var var';
+        defining_expr = Normal (Prim (Pmakeblock _, fields, _)); }; }
     when
       Variable.equal var var'
       && List.for_all (fun field ->
-          List.exists (fun (def_var, _) -> Variable.equal def_var field) defs)
-      fields ->
+          List.exists (fun (def_var, _, _) -> Variable.equal def_var field)
+            defs)
+        fields ->
     { copied_lets; extracted_lets;
       terminator = Flambda_utils.toplevel_substitution substitution expr;
     }
-  | Let { var; defining_expr = Expr (Var alias); body; _ }
-  | Let_rec ([var, Expr (Var alias)], body) ->
+  | Let { var; defining_expr = Normal (Expr (Var alias)); body; provenance }
+  | Let_rec { vars_and_defining_exprs = [var, Expr (Var alias), provenance];
+      body; } ->
     let alias =
       match Variable.Map.find alias substitution with
       | exception Not_found -> alias
       | original_alias -> original_alias
+    in
+    (* We can end up with situations such as:
+        currentstamp/116[=currentstamp/1330]
+          (makemutable 0 (int)<{typing/ident.ml:25,19-24}>
+            Pmakeblock_arg/115)
+        currentstamp/113[=currentstamp/1330]
+            <path `Ident', typing/ident.ml:27,4--10>
+          *currentstamp/116[=currentstamp/1330]
+       where provenance information is only attached to the final "Expr"
+       binding.  (It is not duplicated on the other bindings as this can cause
+       duplicate variables to appear in the debugger in the case where these
+       bindings do not get lifted.)  If we are going to lift, then we ensure
+       that any provenance information is pushed onto the lifted binding
+       itself. *)
+    let extracted_lets =
+      match provenance with
+      | None -> extracted_lets
+      | Some provenance ->
+        match Variable.original_ident var with
+        | None -> extracted_lets
+        | Some original_ident ->
+          let provenance =
+            let provenance : Flambda.symbol_provenance =
+              { original_ident;
+                module_path = provenance.module_path;
+                location = provenance.location;
+              }
+            in
+            Some provenance
+          in
+          List.map (fun defn ->
+              match defn with
+              | Expr (var', defining_expr, None)
+                  when Variable.equal alias var' ->
+                Expr (var', defining_expr, provenance)
+              | Exprs (vars, defining_expr, None)
+                  when List.exists (Variable.equal alias) vars ->
+                Exprs (vars, defining_expr, provenance)
+              | Expr _ | Exprs _ | Block _ -> defn)
+            extracted_lets
     in
     accumulate
       ~substitution:(Variable.Map.add var alias substitution)
       ~copied_lets
       ~extracted_lets
       body
-  | Let { var; defining_expr = named; body; _ }
-  | Let_rec ([var, named], body)
+  | Let { var; defining_expr = named; body; provenance; _ }
     when should_copy named ->
       accumulate body
         ~substitution
-        ~copied_lets:((var, named)::copied_lets)
+        ~copied_lets:((var, (named, provenance))::copied_lets)
         ~extracted_lets
-  | Let { var; defining_expr = named; body; _ } ->
+  | Let_rec { vars_and_defining_exprs = [var, named, provenance]; body; _ }
+    when should_copy (Normal named) ->
+      accumulate body
+        ~substitution
+        ~copied_lets:((var, (Flambda.Normal named, provenance))::copied_lets)
+        ~extracted_lets
+  | Let { var; defining_expr = Normal named; body; provenance; _ } ->
     let extracted =
       let renamed = Variable.rename var in
       match named with
@@ -88,69 +144,142 @@ let rec accumulate ~substitution ~copied_lets ~extracted_lets
               with Not_found -> v)
             args
         in
-        Block (var, tag, args)
+        let provenance =
+          match provenance with
+          | None -> None
+          | Some provenance ->
+            match Variable.original_ident var with
+            | None -> None
+            | Some original_ident ->
+              let provenance : Flambda.symbol_provenance =
+                { original_ident;
+                  module_path = provenance.module_path;
+                  location = provenance.location;
+                }
+              in
+              Some provenance
+        in
+        Block (var, tag, args, provenance)
       | named ->
+        let symbol_provenance : Flambda.symbol_provenance option =
+          match provenance with
+          | None -> None
+          | Some provenance ->
+            match Variable.original_ident var with
+            | None -> None
+            | Some original_ident ->
+              let provenance : Flambda.symbol_provenance =
+                { original_ident;
+                  module_path = provenance.module_path;
+                  location = provenance.location;
+                }
+              in
+              Some provenance
+        in
         let expr =
           Flambda_utils.toplevel_substitution substitution
-            (Flambda.create_let renamed named (Var renamed))
+            (Flambda.create_let renamed named (Var renamed) ?provenance)
         in
-        Expr (var, expr)
+        Expr (var, expr, symbol_provenance)
     in
     accumulate body
       ~substitution
       ~copied_lets
       ~extracted_lets:(extracted::extracted_lets)
-  | Let_rec ([var, named], body) ->
+  | Let_rec { vars_and_defining_exprs = [var, named, provenance]; body; } ->
     let renamed = Variable.rename var in
     let def_substitution = Variable.Map.add var renamed substitution in
     let expr =
       Flambda_utils.toplevel_substitution def_substitution
-        (Let_rec ([renamed, named], Var renamed))
+        (Let_rec {
+          vars_and_defining_exprs = [renamed, named, provenance];
+          body = Var renamed;
+        })
     in
-    let extracted = Expr (var, expr) in
+    let symbol_provenance : Flambda.symbol_provenance option =
+      match provenance with
+      | None -> None
+      | Some provenance ->
+        match Variable.original_ident var with
+        | None -> None
+        | Some original_ident ->
+          let provenance : Flambda.symbol_provenance =
+            { original_ident;
+              module_path = provenance.module_path;
+              location = provenance.location;
+            }
+          in
+          Some provenance
+    in
+    let extracted = Expr (var, expr, symbol_provenance) in
     accumulate body
       ~substitution
       ~copied_lets
       ~extracted_lets:(extracted::extracted_lets)
-  | Let_rec (defs, body) ->
+  | Let_rec { vars_and_defining_exprs = defs; body; } ->
     let renamed_defs, def_substitution =
-      List.fold_right (fun (var, def) (acc, substitution) ->
+      List.fold_right (fun (var, def, provenance) (acc, substitution) ->
           let new_var = Variable.rename var in
-          (new_var, def) :: acc,
-          Variable.Map.add var new_var substitution)
+          (new_var, def, provenance) :: acc,
+            Variable.Map.add var new_var substitution)
         defs ([], substitution)
     in
     let extracted =
       let expr =
         Flambda_utils.toplevel_substitution def_substitution
-          (Let_rec (renamed_defs,
-                    Flambda_utils.name_expr ~name:"lifted_let_rec_block"
-                      (Prim (Pmakeblock (0, Immutable, None),
-                             List.map fst renamed_defs,
-                             Debuginfo.none))))
+          (Let_rec {
+            vars_and_defining_exprs = renamed_defs;
+            body =
+              Flambda_utils.name_expr ~name:"lifted_let_rec_block"
+                (Prim (Pmakeblock (0, Immutable, None),
+                  List.map (fun (new_var, _, _) -> new_var) renamed_defs,
+                  Debuginfo.none));
+          })
       in
-      Exprs (List.map fst defs, expr)
+      let provenance : Flambda.symbol_provenance option =
+        match renamed_defs with
+        | (var, _, provenance)::_ ->
+          begin match provenance with
+          | None -> None
+          | Some provenance ->
+            match Variable.original_ident var with
+            | None -> None
+            | Some original_ident ->
+              Some { Flambda.
+                original_ident;
+                module_path = provenance.module_path;
+                location = provenance.location;
+              }
+          end
+        | [] -> Misc.fatal_error "Let_rec with no bindings"
+      in
+      Exprs (List.map (fun (var, _, _) -> var) defs, expr, provenance)
     in
     accumulate body
       ~substitution
       ~copied_lets
       ~extracted_lets:(extracted::extracted_lets)
   | _ ->
-  { copied_lets;
-    extracted_lets;
-    terminator = Flambda_utils.toplevel_substitution substitution expr;
-  }
+    { copied_lets;
+      extracted_lets;
+      terminator = Flambda_utils.toplevel_substitution substitution expr;
+    }
 
 let rebuild_expr
       ~(extracted_definitions : (Symbol.t * int list) Variable.Map.t)
-      ~(copied_definitions : Flambda.named Variable.Map.t)
+      ~(copied_definitions
+        : (Flambda.defining_expr_of_let * Flambda.let_provenance option)
+            Variable.Map.t)
       ~(substitute : bool)
       (expr : Flambda.t) =
   let expr_with_read_symbols =
     Flambda_utils.substitute_read_symbol_field_for_variables
       extracted_definitions expr
   in
-  let free_variables = Flambda.free_variables expr_with_read_symbols in
+  let free_variables =
+    Free_names.all_free_variables
+      (Flambda.free_names_expr expr_with_read_symbols)
+  in
   let substitution =
     if substitute then
       Variable.Map.of_set (fun x -> Variable.rename x) free_variables
@@ -162,18 +291,19 @@ let rebuild_expr
       expr_with_read_symbols
   in
   Variable.Map.fold (fun var declaration body ->
-      let definition = Variable.Map.find var copied_definitions in
-      Flambda.create_let declaration definition body)
+      let definition, provenance = Variable.Map.find var copied_definitions in
+      Flambda.create_let' ?provenance declaration definition body)
     substitution expr_with_read_symbols
 
-let rebuild (used_variables:Variable.Set.t) (accumulated:accumulated) =
+let rebuild (accumulated : accumulated) =
   let copied_definitions = Variable.Map.of_list accumulated.copied_lets in
   let accumulated_extracted_lets =
     List.map (fun decl ->
         match decl with
-        | Block (var, _, _) | Expr (var, _) ->
+        | Block (var, _, _, _)
+        | Expr (var, _, _) ->
           Flambda_utils.make_variable_symbol var, decl
-        | Exprs (vars, _) ->
+        | Exprs (vars, _, _) ->
           Flambda_utils.make_variables_symbol vars, decl)
       accumulated.extracted_lets
   in
@@ -191,11 +321,11 @@ let rebuild (used_variables:Variable.Set.t) (accumulated:accumulated) =
          field of the field 0 of the symbol. *)
     List.fold_left (fun map (symbol, decl) ->
         match decl with
-        | Block (var, _tag, _fields) ->
+        | Block (var, _tag, _fields, _provenance) ->
           Variable.Map.add var (symbol, []) map
-        | Expr (var, _expr) ->
+        | Expr (var, _expr, _provenance) ->
           Variable.Map.add var (symbol, [0]) map
-        | Exprs (vars, _expr) ->
+        | Exprs (vars, _expr, _provenance) ->
           let map, _ =
             List.fold_left (fun (map, field) var ->
                 Variable.Map.add var (symbol, [field; 0]) map,
@@ -208,32 +338,33 @@ let rebuild (used_variables:Variable.Set.t) (accumulated:accumulated) =
   let extracted =
     List.map (fun (symbol, decl) ->
         match decl with
-        | Expr (var, decl) ->
+        | Expr (_var, decl, provenance) ->
           let expr =
             rebuild_expr ~extracted_definitions ~copied_definitions
               ~substitute:true decl
           in
-          if Variable.Set.mem var used_variables then
-            Initialisation
-              (symbol,
-               Tag.create_exn 0,
-               [expr])
-          else
-            Effect expr
-        | Exprs (_vars, decl) ->
+          (* This [Initialisation] will be turned into an [Effect]
+             (by [Remove_unused_program_constructs]) if it turns out that
+             the [symbol] is not referenced. *)
+          Initialisation
+            (symbol,
+             provenance,
+             Tag.create_exn 0,
+             [expr])
+        | Exprs (_vars, decl, provenance) ->
           let expr =
             rebuild_expr ~extracted_definitions ~copied_definitions
               ~substitute:true decl
           in
-          Initialisation (symbol, Tag.create_exn 0, [expr])
-        | Block (_var, tag, fields) ->
+          Initialisation (symbol, provenance, Tag.create_exn 0, [expr])
+        | Block (_var, tag, fields, provenance) ->
           let fields =
             List.map (fun var ->
                 rebuild_expr ~extracted_definitions ~copied_definitions
                   ~substitute:true (Var var))
               fields
           in
-          Initialisation (symbol, tag, fields))
+          Initialisation (symbol, provenance, tag, fields))
       accumulated_extracted_lets
   in
   let terminator =
@@ -251,42 +382,41 @@ let introduce_symbols expr =
       ~substitution:Variable.Map.empty
       ~copied_lets:[] ~extracted_lets:[]
   in
-  let used_variables = Flambda.used_variables expr in
-  let extracted, terminator = rebuild used_variables accumulated in
-  extracted, terminator
+  rebuild accumulated
 
 let add_extracted introduced program =
   List.fold_right (fun extracted program ->
       match extracted with
-      | Initialisation (symbol, tag, def) ->
-        Flambda.Initialize_symbol (symbol, tag, def, program)
-      | Effect effect ->
-        Flambda.Effect (effect, program))
+      | Initialisation (symbol, provenance, tag, def) ->
+        Flambda.Initialize_symbol (symbol, provenance, tag, def, program)
+      (* | Effect effect ->
+        Flambda.Effect (effect, program) *))
     introduced program
 
 let rec split_program (program : Flambda.program_body) : Flambda.program_body =
   match program with
   | End s -> End s
-  | Let_symbol (s, def, program) ->
-    Let_symbol (s, def, split_program program)
+  | Let_symbol (s, provenance, def, program) ->
+    Let_symbol (s, provenance, def, split_program program)
   | Let_rec_symbol (defs, program) ->
     Let_rec_symbol (defs, split_program program)
   | Effect (expr, program) ->
     let program = split_program program in
     let introduced, expr = introduce_symbols expr in
     add_extracted introduced (Flambda.Effect (expr, program))
-  | Initialize_symbol (symbol, tag, ((_::_::_) as fields), program) ->
+  | Initialize_symbol (symbol, provenance, tag, ((_::_::_) as fields),
+      program) ->
     (* CR-someday pchambart: currently the only initialize_symbol with more
        than 1 field is the module block. This could evolve, in that case
        this pattern should be handled properly. *)
-    Initialize_symbol (symbol, tag, fields, split_program program)
-  | Initialize_symbol (sym, tag, [], program) ->
-    Let_symbol (sym, Block (tag, []), split_program program)
-  | Initialize_symbol (symbol, tag, [field], program) ->
+    Initialize_symbol (symbol, provenance, tag, fields, split_program program)
+  | Initialize_symbol (sym, provenance, tag, [], program) ->
+    Let_symbol (sym, provenance, Block (tag, []), split_program program)
+  | Initialize_symbol (symbol, provenance, tag, [field], program) ->
     let program = split_program program in
     let introduced, field = introduce_symbols field in
     add_extracted introduced
-      (Flambda.Initialize_symbol (symbol, tag, [field], program))
+      (Flambda.Initialize_symbol (symbol, provenance, tag, [field], program))
 
 let lift ~backend:_ (program : Flambda.program) =
   { program with

--- a/middle_end/middle_end.ml
+++ b/middle_end/middle_end.ml
@@ -35,6 +35,8 @@ let middle_end ppf ~source_provenance ~prefixname ~backend
     ~filename
     ~module_ident
     ~module_initializer =
+  let dummy = Ident.create "dummy" in
+  Flambda.ident_stamp_before_flambda := dummy.stamp;
   let pass_number = ref 0 in
   let round_number = ref 0 in
   let check flam =

--- a/middle_end/remove_free_vars_equal_to_args.ml
+++ b/middle_end/remove_free_vars_equal_to_args.ml
@@ -56,6 +56,7 @@ let rewrite_one_function_decl ~(function_decl : Flambda.function_declaration)
       ~inline:function_decl.inline
       ~specialise:function_decl.specialise
       ~is_a_functor:function_decl.is_a_functor
+      ~module_path:function_decl.module_path
 
 let rewrite_one_set_of_closures (set_of_closures : Flambda.set_of_closures) =
   let back_free_vars =

--- a/middle_end/remove_unused_arguments.ml
+++ b/middle_end/remove_unused_arguments.ml
@@ -27,18 +27,22 @@ let remove_params unused (fun_decl: Flambda.function_declaration) =
   let unused_params, used_params =
     List.partition (fun v -> Variable.Set.mem v unused) fun_decl.params
   in
-  let unused_params = List.filter (fun v ->
-      Variable.Set.mem v fun_decl.free_variables) unused_params
+  let unused_params =
+    List.filter (fun var ->
+        Variable.Set.mem var
+          (Free_names.all_free_variables fun_decl.free_names))
+      unused_params
   in
   let body =
     List.fold_left (fun body var ->
-        Flambda.create_let var (Const (Const_pointer 0)) body)
+        Flambda.create_let var (Expr Proved_unreachable) body)
       fun_decl.body
       unused_params
   in
   Flambda.create_function_declaration ~params:used_params ~body
     ~stub:fun_decl.stub ~dbg:fun_decl.dbg ~inline:fun_decl.inline
     ~specialise:fun_decl.specialise ~is_a_functor:fun_decl.is_a_functor
+    ~module_path:fun_decl.module_path
 
 let make_stub unused var (fun_decl : Flambda.function_declaration)
     ~specialised_args ~additional_specialised_args =
@@ -92,6 +96,7 @@ let make_stub unused var (fun_decl : Flambda.function_declaration)
     Flambda.create_function_declaration ~params:(List.map snd args') ~body
       ~stub:true ~dbg:fun_decl.dbg ~inline:Default_inline
       ~specialise:Default_specialise ~is_a_functor:fun_decl.is_a_functor
+      ~module_path:fun_decl.module_path
   in
   function_decl, renamed, additional_specialised_args
 

--- a/middle_end/simple_value_approx.mli
+++ b/middle_end/simple_value_approx.mli
@@ -421,3 +421,8 @@ type switch_branch_selection =
 (** Check that the branch is compatible with the approximation *)
 val potentially_taken_const_switch_branch : t -> int -> switch_branch_selection
 val potentially_taken_block_switch_branch : t -> int -> switch_branch_selection
+
+val phantomize
+   : t
+  -> is_present_in_env:(Variable.t -> bool)
+  -> Flambda.defining_expr_of_phantom_let


### PR DESCRIPTION
This pull request deals with the addition of a new construction called "phantom let" to Flambda.  Phantom lets behave like normal lets except that they do not generate any code at runtime.  They are used as a way of encoding optimised-out parts of the program entirely within the language rather than using some kind of out-of-band mechanism.

This patch also adds support to Flambda for _provenance tracking_: identifying which variables in the Flambda code came from which variables (equipped with full module paths and locations of definitions) in the source program.  The tracking back to original `Ident.t` values is necessary so that their original stamps can be retrieved; these are used for lookup of types in `.cmt` files in libmonda.  The propagation of location information is required so that variables that do not have unique names can be properly disambiguated in the debugger.  This location information keeps track of inlined-out frames.

In order for it to compile this pull request has a couple of stubs on the Lambda side and a version of `Flambda_to_clambda` that does not deal with phantom lets.  This will be added via a subsequent pull request that adds support for them in Clambda and beyond.

Code in this pull request scrapes Lambda expressions for location information.  It would probably be better in future to equip `Llet` with the necessary location information.  There will be another pull request coming in due course in this area, so let's save any discussion on this point for later.

Phantom lets only permit certain kinds of defining expressions for simplicity.  @lpw25 suggested this might be a mistake (we may still gain more information about an optimised-out piece of code if it were subsequently inlined), but I think this should stay as-is for the moment.  It's probably actually good enough in any case.

When the simplifier determines that a let binding is no longer required it will become eligible for phantomisation.  This uses both the structure of the redundant defining expression together with its approximation to try to construct a phantom let which will later be describable in DWARF.  The backend support permits the description in DWARF (using "implicit pointers") of structured values that have been optimised out even in the case where such values may reference values that were not optimised out.  For example, the structure of a pair may be described in the following manner: the pair was optimised out, but it had size 2 and tag 0, and its contents were the parameters `x` and `y` of the function, which may be found in some particular registers (also described).  At runtime, the debugger will reconstitute the structured value in the address space of the debugger (not the address space of the target program), and the libmonda library's value printers will be able to move seamlessly through the value, unaware that in fact part of it doesn't exist in the target program.

Once case that is not currently supported in the backend is the description of projections from variables known to represent blocks where those variables may in turn be phantom.  This problem, together with the fact that we end up generating aliases in the DWARF information between phantom lets (e.g `phantom_let x = y` where `y` is phantom), is planned to be solved in the future by making `Inline_and_simplify` simplify the defining expressions of phantom lets using the techniques it uses for normal lets.  This will eliminate aliases and enable us to avoid the case that is unsupported in the backend.  (The reason it is unsupported is due to restrictions in the DWARF language.)

Along the way this patch introduces a new module `Free_names` for tracking of the various free name sets that we now have.  There are some other minor cleanups (e.g. a record type for `Let_rec`).

@chambart is on the hook to review this one :)
