### PR TITLE
Use _mkgmtime64 instead of _mktime64 to implement Windows Unix.stat

### DIFF
--- a/otherlibs/win32unix/stat.c
+++ b/otherlibs/win32unix/stat.c
@@ -118,11 +118,9 @@ static value stat_aux(int use_64, __int64 st_ino, struct _stat64 *buf)
 static int convert_time(FILETIME* time, __time64_t* result, __time64_t def)
 {
   SYSTEMTIME sys;
-  FILETIME local;
 
   if (time->dwLowDateTime || time->dwHighDateTime) {
-    if (!FileTimeToLocalFileTime(time, &local) ||
-        !FileTimeToSystemTime(&local, &sys))
+    if (!FileTimeToSystemTime(time, &sys))
     {
       win32_maperr(GetLastError());
       return 0;
@@ -132,7 +130,7 @@ static int convert_time(FILETIME* time, __time64_t* result, __time64_t def)
       struct tm stamp = {sys.wSecond, sys.wMinute, sys.wHour,
                          sys.wDay, sys.wMonth - 1, sys.wYear - 1900,
                          0, 0, 0};
-      *result = _mktime64(&stamp);
+      *result = _mkgmtime64(&stamp);
     }
   }
   else {


### PR DESCRIPTION
(Continued from Mantis [MPR #7835](http://caml.inria.fr/mantis/view.php?id=7385))
## The problem

`Unix.stat` on Windows returns time stamps which depend on the DST setting of the computer.
## How to reproduce

Given an existing file `FILE`, simply do

```
$ ocaml unix.cma
> Unix.stat "FILE";;
```

then change your Windows DST setting and retry.  The resulting timestamps should have changed by `3600.` (1 hour).
## Some information learned so far

Windows `Unix.stat` time stamps are [currently computed as follows](https://github.com/ocaml/ocaml/blob/trunk/otherlibs/win32unix/stat.c#L118-L143):
1. time stamp is computed in a Windows-specific type ([`FILETIME`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284%28v=vs.85%29.aspx), a 64bit value)
2. map to the local time zone (using [`FileTimeToLocalFileTime`](FileTimeToLocalFileTime))
3. map to "structured" date type ([`SYSTEMTIME`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724950%28v=vs.85%29.aspx), similar to `tm` structure, using [`FileTimeToSystemTime`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724280%28v=vs.85%29.aspx))
4. map to corresponding `tm` structure "by hand"
5. map with [`_mktime64`](https://msdn.microsoft.com/en-us/library/d1y53h2a.aspx) (takes a `tm` structure in local time zone)

It looks like the problematic step is 4. -> 5. Indeed, the `tm` structure has a field `tm_isdst`, supposed to be set to `0`, `1`, or `-1` according to whether DST is inactive, active, or should be taken from the OS. Since the output of `FileTimeToLocalFileTime` takes the DST setting from the OS, one should probably set this field to `-1` to compensate (incidentally, this field [is always set to `-1`](https://github.com/ocaml/ocaml/blob/trunk/otherlibs/unix/gmtime.c#L78) in the Un*x implementation of `Unix.mktime`).

Currently, this field is set to `0` instead. So I hoped this was the culprit. However, passing `-1` does not seem to have any effect.  This behavior is still a mystery.

Also relevant:
- [File Times](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724290%28v=vs.85%29.aspx)
- [Retrieving the Last-Write Time](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724926%28v=vs.85%29.aspx)
## Proposed solution

Sidestepping the conversion to local time by using the Windows function [`_mkgmtime64`](https://msdn.microsoft.com/en-us/library/2093ets1%28v=vs.140%29.aspx).  This is an avatar of the non-standard GNU C function [`timegm`](http://man7.org/linux/man-pages/man3/timegm.3.html). The resulting time stamps seem to be correct and invariant under DST changes.

**While this change seems to solve the issue, the source of the problem is not yet fully understood.  Any comments on the problem and/or the solution, as well as confirmation of the problem would be greatly appreciated!**
