### PR TITLE
MPR#7037: fix erroneous Location.input_name setting in Pparse.file

### DIFF
--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -178,7 +178,6 @@ let file_aux ppf ~tool_name inputfile (type a) parse_fun invariant_fun
         (input_value ic : a)
       end else begin
         seek_in ic 0;
-        Location.input_name := inputfile;
         let lexbuf = Lexing.from_channel ic in
         Location.init lexbuf inputfile;
         parse_fun lexbuf

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -164,7 +164,7 @@ let process_file sourcefile =
              None
          | Some (parsetree, typedtree) ->
              let file_module = Ast_analyser.analyse_typed_tree file
-                 !Location.input_name parsetree typedtree
+                 input_file parsetree typedtree
              in
              file_module.Odoc_module.m_top_deps <- Odoc_dep.impl_dependencies parsetree ;
 
@@ -192,7 +192,7 @@ let process_file sourcefile =
        try
          let (ast, signat, input_file) = process_interface_file file in
          let file_module = Sig_analyser.analyse_signature file
-             !Location.input_name ast signat.sig_type
+             input_file ast signat.sig_type
          in
 
          file_module.Odoc_module.m_top_deps <- Odoc_dep.intf_dependencies ast ;


### PR DESCRIPTION
This patch was rotting in [MPR#7037](http://caml.inria.fr/mantis/view.php?id=7037), so I decided to make a pull-request for it. I might have merged it directly, but it is relatively invasive: it affects `Pparse` so there is a risk of other users and tool being affected. Cc: @alainfrisch 

> When reading a serialized-ast file, Pparse.file sets
> Location.input_name to the filename embedded in the AST, and this is
> correct. But before this patch it would also set Location.input_name
> to the filename if this is a regular file, and this is wrong: this
> filename may be a temporary file used for preprocessing (-pp option),
> with a randomly-generated name, while Location.input_name is in fact
> already correctly set to the user-provided source path.
> 
> I needed to fix two lines in ocamldoc/odoc_analyze.ml that
> used !Location.input_file but actually required access to the
> post-processing file (ocamldoc re-opens source files and rereads them
> to detect documentation comments). This is not an invasive change as
> the path to the post-processing file is available at this point in the
> code (as the `input_file` variable).
> 
> This ocamldoc issue was caught thanks to Debian downstream work in bug
> triaging ( mlpost breaks if it is not fixed, see
> https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=802347 ) and package
> maintenance (this bug would not have been found if Debian maintainers
> had not kept the mlpost documentation generator working even after
> non-trivial ocamldoc changes).
