### PR TITLE
Generate ocaml_compiler_internal_params from ./configure arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,6 +224,7 @@
 /stdlib/labelled-*
 /stdlib/caml
 /stdlib/sys.ml
+/stdlib/ocaml_compiler_internal_params
 
 /testsuite/**/*.result
 /testsuite/**/*.opt_result

--- a/stdlib/Makefile.shared
+++ b/stdlib/Makefile.shared
@@ -64,7 +64,7 @@ INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
 install::
 	cp stdlib.cma std_exit.cmo *.cmi *.cmt *.cmti *.mli *.ml \
-	  camlheader_ur \
+	  camlheader_ur ocaml_compiler_internal_params \
 	  "$(INSTALL_LIBDIR)"
 	cp target_camlheader "$(INSTALL_LIBDIR)/camlheader"
 

--- a/tools/set-default-params
+++ b/tools/set-default-params
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+
+stdlib_dir="`dirname "$0"`/../stdlib"
+config_file="$stdlib_dir/ocaml_compiler_internal_params"
+
+for x in "$@"; do
+    echo "*: $x"
+done > "$config_file"


### PR DESCRIPTION
Allows setting default options by passing arguments to `./configure`, without modifying `./configure` for every option. Default options are entered into `ocaml_compiler_internal_params`. Example:

```
./configure -default-param g=1 -default-param rectypes=1
```
