### PR TITLE
Implement find_ceil

### DIFF
--- a/stdlib/map.ml
+++ b/stdlib/map.ml
@@ -47,6 +47,7 @@ module type S =
     val choose: 'a t -> (key * 'a)
     val split: key -> 'a t -> 'a t * 'a option * 'a t
     val find: key -> 'a t -> 'a
+    val find_ceil: key -> 'a t -> key * 'a
     val map: ('a -> 'b) -> 'a t -> 'b t
     val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
   end
@@ -124,6 +125,25 @@ module Make(Ord: OrderedType) = struct
           let c = Ord.compare x v in
           if c = 0 then d
           else find x (if c < 0 then l else r)
+
+    let rec get_ceil x = function
+        Empty -> None
+      | Node(l, v, d, r, _) ->
+          let c = Ord.compare x v in
+          if c = 0 then
+            Some (v, d)
+          else if c > 0 then
+            get_ceil x r
+          else match get_ceil x l with
+              None -> Some (v, d)
+            | r -> r
+
+      let find_ceil x m =
+        match get_ceil x m with
+          None ->
+            raise Not_found
+        | Some (v, d) ->
+            (v, d)
 
     let rec mem x = function
         Empty ->

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -212,6 +212,11 @@ module type S =
     (** [find x m] returns the current binding of [x] in [m],
        or raises [Not_found] if no such binding exists. *)
 
+    val find_ceil: key -> 'a t -> key * 'a
+    (** [find x m] returns the binding of [m] with the lowest
+       key [k] such that [k] is greater or equal to [x], or raises
+       [Not_found] if [x] is greater than all the keys in [m]. *)
+
     val map: ('a -> 'b) -> 'a t -> 'b t
     (** [map f m] returns a map with same domain as [m], where the
        associated value [a] of all bindings of [m] has been

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -133,6 +133,7 @@ module Map : sig
       val choose: 'a t -> (key * 'a)
       val split: key -> 'a t -> 'a t * 'a option * 'a t
       val find : key -> 'a t -> 'a
+      val find_ceil : key -> 'a t -> key * 'a
       val map : f:('a -> 'b) -> 'a t -> 'b t
       val mapi : f:(key -> 'a -> 'b) -> 'a t -> 'b t
   end

--- a/testsuite/tests/lib-set/testmap.ml
+++ b/testsuite/tests/lib-set/testmap.ml
@@ -101,6 +101,20 @@ let test x v s1 s2 =
      with Not_found ->
        M.is_empty s1);
 
+  checkbool "find_ceil"
+    (let (l, p, r) = M.split x s1 in
+    if p = None && M.is_empty r then
+      try
+        let _ = M.find_ceil x s1 in
+        false
+      with Not_found ->
+        true
+    else
+      let (k, v) = M.find_ceil x s1 in
+      match p with
+        None -> (k, v) = M.min_binding r
+      | Some v1 -> (k, v) = (x, v1));
+
   check "split"
     (let (l, p, r) = M.split x s1 in
      fun i ->


### PR DESCRIPTION
In a map, finds a binding where the key is the ceiling for a given key.

Addresses #665.
