### PR TITLE
use `malloc`+`fatal_error` instead of `caml_stat_alloc` in `alloc_generic_table`

### DIFF
--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -85,8 +85,8 @@ static void alloc_generic_table (struct generic_table *tbl, asize_t sz,
 
   tbl->size = sz;
   tbl->reserve = rsv;
-  new_table = (void *) caml_stat_alloc ((tbl->size + tbl->reserve)
-                                        * element_size);
+  new_table = (void *) malloc((tbl->size + tbl->reserve) * element_size);
+  if (new_table == NULL) caml_fatal_error ("Fatal error: not enough memory\n");
   if (tbl->base != NULL) caml_stat_free (tbl->base);
   tbl->base = new_table;
   tbl->ptr = tbl->base;


### PR DESCRIPTION
The runtime uses `caml_stat_alloc` as a `malloc` wrapper when building the linked list of frametables and the table of old-to-young references. `caml_stats_alloc` raises an OCaml exception if malloc fails ; it seems ill-advised to try to re-enter OCaml code if those GC datastructures are improperly set up.

This `caml_stat_alloc_no_raise` simply calls `caml_fatal_error` when `malloc` fails.
