### PR TITLE
Propagation of static_raise argument approximation.

### DIFF
--- a/middle_end/inline_and_simplify_aux.mli
+++ b/middle_end/inline_and_simplify_aux.mli
@@ -291,17 +291,31 @@ module Result : sig
       simplification algorithm. *)
   val meet_approx : t -> Env.t -> Simple_value_approx.t -> t
 
-  (** All static exceptions for which [use_staticfail] has been called on
-      the given result structure. *)
+  (** Check that [use_static_exception] has been called on the given
+      result structure. *)
+  val is_used_static_exception : t -> Static_exception.t -> bool
+
+  (** All static exceptions for which [use_static_exception] has been
+      called on the given result structure. O(n*log(n)) Used only for
+      debugging purpose. *)
   val used_static_exceptions : t -> Static_exception.Set.t
 
-  (** Mark that the given static exception has been used. *)
-  val use_static_exception : t -> Static_exception.t -> t
+  (** Check that there is no static catch in scope *)
+  val no_defined_static_exceptions : t -> bool
+
+  (** Mark that the given static exception has been used and provide
+      an approximation for the arguments. *)
+  val use_static_exception
+    : t
+    -> Env.t
+    -> Static_exception.t
+    -> Simple_value_approx.t list
+    -> t
 
   (** Mark that we are moving up out of the scope of a static-catch block
       that catches the given static exception identifier.  This has the effect
       of removing the identifier from the [used_staticfail] set. *)
-  val exit_scope_catch : t -> Static_exception.t -> t
+  val exit_scope_catch : t -> Static_exception.t -> t * Simple_value_approx.t list
 
   (** The benefit to be gained by inlining the subexpression whose
       simplification yielded the given result structure. *)


### PR DESCRIPTION
In a more continuation oriented flambda, the handling of static exceptions should be better handled by Inline_and_simplify. This allows to replace a let by a static exception without too much drawback.
