### PR TITLE
don't attach (**/**) comments to any particular node

### DIFF
--- a/Changes
+++ b/Changes
@@ -423,6 +423,9 @@ OCaml 4.04.0:
   of PR#3963)
   (David Allsopp)
 
+- GPR#872: don't attach (**/**) comments to any particular node
+  (Thomas Refis, review by Leo White)
+
 ### Documentation:
 
 

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -757,13 +757,19 @@ and skip_hash_bang = parse
           Docstrings.register doc;
           add_docstring_comment doc;
           let docs' =
-            match docs, lines with
-            | Initial, (NoLine | NewLine) -> After [doc]
-            | Initial, BlankLine -> Before([], [], [doc])
-            | After a, (NoLine | NewLine) -> After (doc :: a)
-            | After a, BlankLine -> Before (a, [], [doc])
-            | Before(a, f, b), (NoLine | NewLine) -> Before(a, f, doc :: b)
-            | Before(a, f, b), BlankLine -> Before(a, b @ f, [doc])
+            if Docstrings.docstring_body doc = "/*" then
+              match docs with
+              | Initial -> Before([], [doc], [])
+              | After a -> Before (a, [doc], [])
+              | Before(a, f, b) -> Before(a, doc :: b @ f, [])
+            else
+              match docs, lines with
+              | Initial, (NoLine | NewLine) -> After [doc]
+              | Initial, BlankLine -> Before([], [], [doc])
+              | After a, (NoLine | NewLine) -> After (doc :: a)
+              | After a, BlankLine -> Before (a, [], [doc])
+              | Before(a, f, b), (NoLine | NewLine) -> Before(a, f, doc :: b)
+              | Before(a, f, b), BlankLine -> Before(a, b @ f, [doc])
           in
           loop NoLine docs' lexbuf
       | tok ->


### PR DESCRIPTION
IMO ocamldoc stop-comments should never be attached to any AST node, and indeed @lpw25 made the same assumption when writing [doc-ock](ocaml-doc/doc-ock), leading to a bug in odoc (see ocaml-doc/odoc#21).
It then seems to me that the fact that the lexer attaches such comments to some AST node is a bug and that instead of introducing some ad-hoc logic to handle stop-comments in the tools fetching them from the AST, we should just fix the compiler. Both @lpw25 and @dbuenzli seem to agree.

The implementation makes me a little sad but @lpw25 reviewed it, confirmed it was correct and didn't suggest any prettier way to do it.

PS: I consider this patch to be a bugfix, so I was _very_ tempted to make the PR against 4.04 (in particular because it would mean that odoc won't be broken for the next 6 to 9 months), but I am partial so I restrained myself. I would however be happy to resubmit against 4.04 if others agree.
