### PR TITLE
Adds missing functions to *Labels modules

### DIFF
--- a/Changes
+++ b/Changes
@@ -63,6 +63,11 @@ Next version (4.05.0):
   (Gabriel de Perthuis, with contributions from Alain Frisch, review by
   Hezekiah M. Carty and Simon Cruanes, initial report by Gerd Stolpmann)
 
+- Add missing functions to ArrayLabels, BytesLabels, ListLabels,
+  MoreLabels, StringLabels so they are compatible with non-labeled
+  counterparts.
+  (Roma Sokolov)
+
 ### Manual and documentation:
 
 - add a HACKING.adoc file to contain various tips and tricks for

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -19,24 +19,24 @@ external length : 'a array -> int = "%array_length"
 (** Return the length (number of elements) of the given array. *)
 
 external get : 'a array -> int -> 'a = "%array_safe_get"
-(** [ArrayLabels.get a n] returns the element number [n] of array [a].
+(** [Array.get a n] returns the element number [n] of array [a].
    The first element has number 0.
-   The last element has number [ArrayLabels.length a - 1].
-   You can also write [a.(n)] instead of [ArrayLabels.get a n].
+   The last element has number [Array.length a - 1].
+   You can also write [a.(n)] instead of [Array.get a n].
 
    Raise [Invalid_argument "index out of bounds"]
-   if [n] is outside the range 0 to [(ArrayLabels.length a - 1)]. *)
+   if [n] is outside the range 0 to [(Array.length a - 1)]. *)
 
 external set : 'a array -> int -> 'a -> unit = "%array_safe_set"
-(** [ArrayLabels.set a n x] modifies array [a] in place, replacing
+(** [Array.set a n x] modifies array [a] in place, replacing
    element number [n] with [x].
-   You can also write [a.(n) <- x] instead of [ArrayLabels.set a n x].
+   You can also write [a.(n) <- x] instead of [Array.set a n x].
 
    Raise [Invalid_argument "index out of bounds"]
-   if [n] is outside the range 0 to [ArrayLabels.length a - 1]. *)
+   if [n] is outside the range 0 to [Array.length a - 1]. *)
 
 external make : int -> 'a -> 'a array = "caml_make_vect"
-(** [ArrayLabels.make n x] returns a fresh array of length [n],
+(** [Array.make n x] returns a fresh array of length [n],
    initialized with [x].
    All the elements of this new array are initially
    physically equal to [x] (in the sense of the [==] predicate).
@@ -49,13 +49,13 @@ external make : int -> 'a -> 'a array = "caml_make_vect"
    size is only [Sys.max_array_length / 2].*)
 
 external create : int -> 'a -> 'a array = "caml_make_vect"
-  [@@ocaml.deprecated "Use ArrayLabels.make instead."]
-(** @deprecated [ArrayLabels.create] is an alias for {!ArrayLabels.make}. *)
+  [@@ocaml.deprecated "Use Array.make instead."]
+(** @deprecated [Array.create] is an alias for {!Array.make}. *)
 
 val init : int -> f:(int -> 'a) -> 'a array
-(** [ArrayLabels.init n f] returns a fresh array of length [n],
+(** [Array.init n f] returns a fresh array of length [n],
    with element number [i] initialized to the result of [f i].
-   In other terms, [ArrayLabels.init n f] tabulates the results of [f]
+   In other terms, [Array.init n f] tabulates the results of [f]
    applied to the integers [0] to [n-1].
 
    Raise [Invalid_argument] if [n < 0] or [n > Sys.max_array_length].
@@ -63,7 +63,7 @@ val init : int -> f:(int -> 'a) -> 'a array
    size is only [Sys.max_array_length / 2].*)
 
 val make_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
-(** [ArrayLabels.make_matrix dimx dimy e] returns a two-dimensional array
+(** [Array.make_matrix dimx dimy e] returns a two-dimensional array
    (an array of arrays) with first dimension [dimx] and
    second dimension [dimy]. All the elements of this new matrix
    are initially physically equal to [e].
@@ -76,32 +76,32 @@ val make_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
    size is only [Sys.max_array_length / 2]. *)
 
 val create_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
-  [@@ocaml.deprecated "Use ArrayLabels.make_matrix instead."]
-(** @deprecated [ArrayLabels.create_matrix] is an alias for
-   {!ArrayLabels.make_matrix}. *)
+  [@@ocaml.deprecated "Use Array.make_matrix instead."]
+(** @deprecated [Array.create_matrix] is an alias for
+   {!Array.make_matrix}. *)
 
 val append : 'a array -> 'a array -> 'a array
-(** [ArrayLabels.append v1 v2] returns a fresh array containing the
+(** [Array.append v1 v2] returns a fresh array containing the
    concatenation of the arrays [v1] and [v2]. *)
 
 val concat : 'a array list -> 'a array
-(** Same as [ArrayLabels.append], but concatenates a list of arrays. *)
+(** Same as [Array.append], but concatenates a list of arrays. *)
 
 val sub : 'a array -> pos:int -> len:int -> 'a array
-(** [ArrayLabels.sub a start len] returns a fresh array of length [len],
+(** [Array.sub a start len] returns a fresh array of length [len],
    containing the elements number [start] to [start + len - 1]
    of array [a].
 
    Raise [Invalid_argument "Array.sub"] if [start] and [len] do not
    designate a valid subarray of [a]; that is, if
-   [start < 0], or [len < 0], or [start + len > ArrayLabels.length a]. *)
+   [start < 0], or [len < 0], or [start + len > Array.length a]. *)
 
 val copy : 'a array -> 'a array
-(** [ArrayLabels.copy a] returns a copy of [a], that is, a fresh array
+(** [Array.copy a] returns a copy of [a], that is, a fresh array
    containing the same elements as [a]. *)
 
 val fill : 'a array -> pos:int -> len:int -> 'a -> unit
-(** [ArrayLabels.fill a ofs len x] modifies the array [a] in place,
+(** [Array.fill a ofs len x] modifies the array [a] in place,
    storing [x] in elements number [ofs] to [ofs + len - 1].
 
    Raise [Invalid_argument "Array.fill"] if [ofs] and [len] do not
@@ -110,7 +110,7 @@ val fill : 'a array -> pos:int -> len:int -> 'a -> unit
 val blit :
   src:'a array -> src_pos:int -> dst:'a array -> dst_pos:int -> len:int ->
     unit
-(** [ArrayLabels.blit v1 o1 v2 o2 len] copies [len] elements
+(** [Array.blit v1 o1 v2 o2 len] copies [len] elements
    from array [v1], starting at element number [o1], to array [v2],
    starting at element number [o2]. It works correctly even if
    [v1] and [v2] are the same array, and the source and
@@ -121,49 +121,70 @@ val blit :
    designate a valid subarray of [v2]. *)
 
 val to_list : 'a array -> 'a list
-(** [ArrayLabels.to_list a] returns the list of all the elements of [a]. *)
+(** [Array.to_list a] returns the list of all the elements of [a]. *)
 
 val of_list : 'a list -> 'a array
-(** [ArrayLabels.of_list l] returns a fresh array containing the elements
+(** [Array.of_list l] returns a fresh array containing the elements
    of [l]. *)
 
 val iter : f:('a -> unit) -> 'a array -> unit
-(** [ArrayLabels.iter f a] applies function [f] in turn to all
+(** [Array.iter f a] applies function [f] in turn to all
    the elements of [a].  It is equivalent to
-   [f a.(0); f a.(1); ...; f a.(ArrayLabels.length a - 1); ()]. *)
+   [f a.(0); f a.(1); ...; f a.(Array.length a - 1); ()]. *)
 
 val map : f:('a -> 'b) -> 'a array -> 'b array
-(** [ArrayLabels.map f a] applies function [f] to all the elements of [a],
+(** [Array.map f a] applies function [f] to all the elements of [a],
    and builds an array with the results returned by [f]:
-   [[| f a.(0); f a.(1); ...; f a.(ArrayLabels.length a - 1) |]]. *)
+   [[| f a.(0); f a.(1); ...; f a.(Array.length a - 1) |]]. *)
 
 val iteri : f:(int -> 'a -> unit) -> 'a array -> unit
-(** Same as {!ArrayLabels.iter}, but the
+(** Same as {!Array.iter}, but the
    function is applied to the index of the element as first argument,
    and the element itself as second argument. *)
 
 val mapi : f:(int -> 'a -> 'b) -> 'a array -> 'b array
-(** Same as {!ArrayLabels.map}, but the
+(** Same as {!Array.map}, but the
    function is applied to the index of the element as first argument,
    and the element itself as second argument. *)
 
 val fold_left : f:('a -> 'b -> 'a) -> init:'a -> 'b array -> 'a
-(** [ArrayLabels.fold_left f x a] computes
+(** [Array.fold_left f x a] computes
    [f (... (f (f x a.(0)) a.(1)) ...) a.(n-1)],
    where [n] is the length of the array [a]. *)
 
 val fold_right : f:('b -> 'a -> 'a) -> 'b array -> init:'a -> 'a
-(** [ArrayLabels.fold_right f a x] computes
+(** [Array.fold_right f a x] computes
    [f a.(0) (f a.(1) ( ... (f a.(n-1) x) ...))],
    where [n] is the length of the array [a]. *)
 
+
+(** {6 Iterators on two arrays} *)
+
+
+val iter2 : f:('a -> 'b -> unit) -> 'a array -> 'b array -> unit
+(** [Array.iter2 f a b] applies function [f] to all the elements of [a]
+   and [b].
+   Raise [Invalid_argument] if the arrays are not the same size.
+   @since 4.03.0 *)
+
+val map2 : f:('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
+(** [Array.map2 f a b] applies function [f] to all the elements of [a]
+   and [b], and builds an array with the results returned by [f]:
+   [[| f a.(0) b.(0); ...; f a.(Array.length a - 1) b.(Array.length b - 1)|]].
+   Raise [Invalid_argument] if the arrays are not the same size.
+   @since 4.03.0 *)
+
+
+(** {6 Array scanning} *)
+
+
 val exists : f:('a -> bool) -> 'a array -> bool
-(** [ArrayLabels.exists p [|a1; ...; an|]] checks if at least one element of
+(** [Array.exists p [|a1; ...; an|]] checks if at least one element of
     the array satisfies the predicate [p]. That is, it returns
     [(p a1) || (p a2) || ... || (p an)]. *)
 
 val for_all : f:('a -> bool) -> 'a array -> bool
-(** [ArrayLabels.for_all p [|a1; ...; an|]] checks if all elements of the array
+(** [Array.for_all p [|a1; ...; an|]] checks if all elements of the array
    satisfy the predicate [p]. That is, it returns
    [(p a1) && (p a2) && ... && (p an)]. *)
 
@@ -172,18 +193,18 @@ val mem : 'a -> set:'a array -> bool
    to an element of [a]. *)
 
 val memq : 'a -> set:'a array -> bool
-(** Same as {!ArrayLabels.mem}, but uses physical equality instead of structural
+(** Same as {!Array.mem}, but uses physical equality instead of structural
    equality to compare list elements. *)
 
 external create_float: int -> float array = "caml_make_float_vect"
-(** [ArrayLabels.create_float n] returns a fresh float array of length [n],
+(** [Array.create_float n] returns a fresh float array of length [n],
     with uninitialized data.
     @since 4.03 *)
 
 val make_float: int -> float array
-  [@@ocaml.deprecated "Use ArrayLabels.create_float instead."]
-(** @deprecated [ArrayLabels.make_float] is an alias for
-    {!ArrayLabels.create_float}. *)
+  [@@ocaml.deprecated "Use Array.create_float instead."]
+(** @deprecated [Array.make_float] is an alias for
+    {!Array.create_float}. *)
 
 
 (** {6 Sorting} *)
@@ -196,9 +217,9 @@ val sort : cmp:('a -> 'a -> int) -> 'a array -> unit
    and a negative integer if the first is smaller (see below for a
    complete specification).  For example, {!Pervasives.compare} is
    a suitable comparison function, provided there are no floating-point
-   NaN values in the data.  After calling [ArrayLabels.sort], the
+   NaN values in the data.  After calling [Array.sort], the
    array is sorted in place in increasing order.
-   [ArrayLabels.sort] is guaranteed to run in constant heap space
+   [Array.sort] is guaranteed to run in constant heap space
    and (at most) logarithmic stack space.
 
    The current implementation uses Heap Sort.  It runs in constant
@@ -210,23 +231,23 @@ val sort : cmp:('a -> 'a -> int) -> 'a array -> unit
 -   [cmp x y] > 0 if and only if [cmp y x] < 0
 -   if [cmp x y] >= 0 and [cmp y z] >= 0 then [cmp x z] >= 0
 
-   When [ArrayLabels.sort] returns, [a] contains the same elements as before,
+   When [Array.sort] returns, [a] contains the same elements as before,
    reordered in such a way that for all i and j valid indices of [a] :
 -   [cmp a.(i) a.(j)] >= 0 if and only if i >= j
 *)
 
 val stable_sort : cmp:('a -> 'a -> int) -> 'a array -> unit
-(** Same as {!ArrayLabels.sort}, but the sorting algorithm is stable (i.e.
+(** Same as {!Array.sort}, but the sorting algorithm is stable (i.e.
    elements that compare equal are kept in their original order) and
    not guaranteed to run in constant heap space.
 
    The current implementation uses Merge Sort. It uses [n/2]
    words of heap space, where [n] is the length of the array.
-   It is usually faster than the current implementation of {!ArrayLabels.sort}.
+   It is usually faster than the current implementation of {!Array.sort}.
 *)
 
 val fast_sort : cmp:('a -> 'a -> int) -> 'a array -> unit
-(** Same as {!ArrayLabels.sort} or {!ArrayLabels.stable_sort}, whichever is
+(** Same as {!Array.sort} or {!Array.stable_sort}, whichever is
     faster on typical input.
 *)
 

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -76,6 +76,16 @@ val sub : bytes -> pos:int -> len:int -> bytes
 val sub_string : bytes -> int -> int -> string
 (** Same as [sub] but return a string instead of a byte sequence. *)
 
+val extend : bytes -> left:int -> right:int -> bytes
+(** [extend s left right] returns a new byte sequence that contains
+    the bytes of [s], with [left] uninitialized bytes prepended and
+    [right] uninitialized bytes appended to it. If [left] or [right]
+    is negative, then bytes are removed (instead of appended) from
+    the corresponding side of [s].
+
+    Raise [Invalid_argument] if the result length is negative or
+    longer than {!Sys.max_string_length} bytes. *)
+
 val fill : bytes -> pos:int -> len:int -> char -> unit
 (** [fill s start len c] modifies [s] in place, replacing [len]
     characters with [c], starting at [start].
@@ -96,10 +106,28 @@ val blit :
     designate a valid range of [src], or if [dstoff] and [len]
     do not designate a valid range of [dst]. *)
 
+val blit_string :
+  src:string -> src_pos:int -> dst:bytes -> dst_pos:int -> len:int
+  -> unit
+(** [blit src srcoff dst dstoff len] copies [len] bytes from string
+    [src], starting at index [srcoff], to byte sequence [dst],
+    starting at index [dstoff].
+
+    Raise [Invalid_argument] if [srcoff] and [len] do not
+    designate a valid range of [src], or if [dstoff] and [len]
+    do not designate a valid range of [dst]. *)
+
 val concat : sep:bytes -> bytes list -> bytes
 (** [concat sep sl] concatenates the list of byte sequences [sl],
     inserting the separator byte sequence [sep] between each, and
     returns the result as a new byte sequence. *)
+
+val cat : bytes -> bytes -> bytes
+(** [cat s1 s2] concatenates [s1] and [s2] and returns the result
+     as new byte sequence.
+
+    Raise [Invalid_argument] if the result is longer than
+    {!Sys.max_string_length} bytes. *)
 
 val iter : f:(char -> unit) -> bytes -> unit
 (** [iter f s] applies function [f] in turn to all the bytes of [s].
@@ -203,22 +231,50 @@ val rcontains_from : bytes -> int -> char -> bool
     position in [s]. *)
 
 val uppercase : bytes -> bytes
+  [@@ocaml.deprecated "Use Bytes.uppercase_ascii instead."]
 (** Return a copy of the argument, with all lowercase letters
-    translated to uppercase, including accented letters of the ISO
-    Latin-1 (8859-1) character set. *)
+   translated to uppercase, including accented letters of the ISO
+   Latin-1 (8859-1) character set.
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val lowercase : bytes -> bytes
+  [@@ocaml.deprecated "Use Bytes.lowercase_ascii instead."]
 (** Return a copy of the argument, with all uppercase letters
-    translated to lowercase, including accented letters of the ISO
-    Latin-1 (8859-1) character set. *)
+   translated to lowercase, including accented letters of the ISO
+   Latin-1 (8859-1) character set.
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val capitalize : bytes -> bytes
-(** Return a copy of the argument, with the first byte set to
-    uppercase. *)
+  [@@ocaml.deprecated "Use Bytes.capitalize_ascii instead."]
+(** Return a copy of the argument, with the first character set to uppercase,
+   using the ISO Latin-1 (8859-1) character set..
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val uncapitalize : bytes -> bytes
-(** Return a copy of the argument, with the first byte set to
-    lowercase. *)
+  [@@ocaml.deprecated "Use Bytes.uncapitalize_ascii instead."]
+(** Return a copy of the argument, with the first character set to lowercase,
+   using the ISO Latin-1 (8859-1) character set..
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
+
+val uppercase_ascii : bytes -> bytes
+(** Return a copy of the argument, with all lowercase letters
+   translated to uppercase, using the US-ASCII character set.
+   @since 4.03.0 *)
+
+val lowercase_ascii : bytes -> bytes
+(** Return a copy of the argument, with all uppercase letters
+   translated to lowercase, using the US-ASCII character set.
+   @since 4.03.0 *)
+
+val capitalize_ascii : bytes -> bytes
+(** Return a copy of the argument, with the first character set to uppercase,
+   using the US-ASCII character set.
+   @since 4.03.0 *)
+
+val uncapitalize_ascii : bytes -> bytes
+(** Return a copy of the argument, with the first character set to lowercase,
+   using the US-ASCII character set.
+   @since 4.03.0 *)
 
 type t = bytes
 (** An alias for the type of byte sequences. *)
@@ -228,6 +284,10 @@ val compare: t -> t -> int
     specification as {!Pervasives.compare}.  Along with the type [t],
     this function [compare] allows the module [Bytes] to be passed as
     argument to the functors {!Set.Make} and {!Map.Make}. *)
+
+val equal: t -> t -> bool
+(** The equality function for byte sequences.
+    @since 4.03.0 *)
 
 (**/**)
 

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -33,6 +33,25 @@ val hd : 'a list -> 'a
 (** Return the first element of the given list. Raise
    [Failure "hd"] if the list is empty. *)
 
+val compare_lengths : 'a list -> 'b list -> int
+(** Compare the lengths of two lists. [compare_lengths l1 l2] is
+   equivalent to [compare (length l1) (length l2)], except that
+   the computation stops after itering on the shortest list.
+   @since 4.05.0
+ *)
+
+val compare_length_with : 'a list -> len:int -> int
+(** Compare the length of a list to an integer. [compare_length_with l n] is
+   equivalent to [compare (length l) n], except that
+   the computation stops after at most [n] iterations on the list.
+   @since 4.05.0
+*)
+
+val cons : 'a -> 'a list -> 'a list
+(** [cons x xs] is [x :: xs]
+    @since 4.03.0
+*)
+
 val tl : 'a list -> 'a list
 (** Return the given list without its first element. Raise
    [Failure "tl"] if the list is empty. *)
@@ -60,8 +79,8 @@ val append : 'a list -> 'a list -> 'a list
    operator is not tail-recursive either. *)
 
 val rev_append : 'a list -> 'a list -> 'a list
-(** [ListLabels.rev_append l1 l2] reverses [l1] and concatenates it to [l2].
-   This is equivalent to {!ListLabels.rev}[ l1 @ l2], but [rev_append] is
+(** [List.rev_append l1 l2] reverses [l1] and concatenates it to [l2].
+   This is equivalent to {!List.rev}[ l1 @ l2], but [rev_append] is
    tail-recursive and more efficient. *)
 
 val concat : 'a list list -> 'a list
@@ -79,40 +98,40 @@ val flatten : 'a list list -> 'a list
 
 
 val iter : f:('a -> unit) -> 'a list -> unit
-(** [ListLabels.iter f [a1; ...; an]] applies function [f] in turn to
+(** [List.iter f [a1; ...; an]] applies function [f] in turn to
    [a1; ...; an]. It is equivalent to
    [begin f a1; f a2; ...; f an; () end]. *)
 
 val iteri : f:(int -> 'a -> unit) -> 'a list -> unit
-(** Same as {!ListLabels.iter}, but the function is applied to the index of
+(** Same as {!List.iter}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
    @since 4.00.0
 *)
 
 val map : f:('a -> 'b) -> 'a list -> 'b list
-(** [ListLabels.map f [a1; ...; an]] applies function [f] to [a1, ..., an],
+(** [List.map f [a1; ...; an]] applies function [f] to [a1, ..., an],
    and builds the list [[f a1; ...; f an]]
    with the results returned by [f].  Not tail-recursive. *)
 
 val mapi : f:(int -> 'a -> 'b) -> 'a list -> 'b list
-(** Same as {!ListLabels.map}, but the function is applied to the index of
+(** Same as {!List.map}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
    @since 4.00.0
 *)
 
 val rev_map : f:('a -> 'b) -> 'a list -> 'b list
-(** [ListLabels.rev_map f l] gives the same result as
-   {!ListLabels.rev}[ (]{!ListLabels.map}[ f l)], but is tail-recursive and
+(** [List.rev_map f l] gives the same result as
+   {!List.rev}[ (]{!List.map}[ f l)], but is tail-recursive and
    more efficient. *)
 
 val fold_left : f:('a -> 'b -> 'a) -> init:'a -> 'b list -> 'a
-(** [ListLabels.fold_left f a [b1; ...; bn]] is
+(** [List.fold_left f a [b1; ...; bn]] is
    [f (... (f (f a b1) b2) ...) bn]. *)
 
 val fold_right : f:('a -> 'b -> 'b) -> 'a list -> init:'b -> 'b
-(** [ListLabels.fold_right f [a1; ...; an] b] is
+(** [List.fold_right f [a1; ...; an] b] is
    [f a1 (f a2 (... (f an b) ...))].  Not tail-recursive. *)
 
 
@@ -120,32 +139,32 @@ val fold_right : f:('a -> 'b -> 'b) -> 'a list -> init:'b -> 'b
 
 
 val iter2 : f:('a -> 'b -> unit) -> 'a list -> 'b list -> unit
-(** [ListLabels.iter2 f [a1; ...; an] [b1; ...; bn]] calls in turn
+(** [List.iter2 f [a1; ...; an] [b1; ...; bn]] calls in turn
    [f a1 b1; ...; f an bn].
    Raise [Invalid_argument] if the two lists are determined
    to have different lengths. *)
 
 val map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
-(** [ListLabels.map2 f [a1; ...; an] [b1; ...; bn]] is
+(** [List.map2 f [a1; ...; an] [b1; ...; bn]] is
    [[f a1 b1; ...; f an bn]].
    Raise [Invalid_argument] if the two lists are determined
    to have different lengths.  Not tail-recursive. *)
 
 val rev_map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
-(** [ListLabels.rev_map2 f l1 l2] gives the same result as
-   {!ListLabels.rev}[ (]{!ListLabels.map2}[ f l1 l2)], but is tail-recursive and
+(** [List.rev_map2 f l1 l2] gives the same result as
+   {!List.rev}[ (]{!List.map2}[ f l1 l2)], but is tail-recursive and
    more efficient. *)
 
 val fold_left2 :
   f:('a -> 'b -> 'c -> 'a) -> init:'a -> 'b list -> 'c list -> 'a
-(** [ListLabels.fold_left2 f a [b1; ...; bn] [c1; ...; cn]] is
+(** [List.fold_left2 f a [b1; ...; bn] [c1; ...; cn]] is
    [f (... (f (f a b1 c1) b2 c2) ...) bn cn].
    Raise [Invalid_argument] if the two lists are determined
    to have different lengths. *)
 
 val fold_right2 :
   f:('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> init:'c -> 'c
-(** [ListLabels.fold_right2 f [a1; ...; an] [b1; ...; bn] c] is
+(** [List.fold_right2 f [a1; ...; an] [b1; ...; bn] c] is
    [f a1 b1 (f a2 b2 (... (f an bn c) ...))].
    Raise [Invalid_argument] if the two lists are determined
    to have different lengths.  Not tail-recursive. *)
@@ -165,12 +184,12 @@ val exists : f:('a -> bool) -> 'a list -> bool
    [(p a1) || (p a2) || ... || (p an)]. *)
 
 val for_all2 : f:('a -> 'b -> bool) -> 'a list -> 'b list -> bool
-(** Same as {!ListLabels.for_all}, but for a two-argument predicate.
+(** Same as {!List.for_all}, but for a two-argument predicate.
    Raise [Invalid_argument] if the two lists are determined
    to have different lengths. *)
 
 val exists2 : f:('a -> 'b -> bool) -> 'a list -> 'b list -> bool
-(** Same as {!ListLabels.exists}, but for a two-argument predicate.
+(** Same as {!List.exists}, but for a two-argument predicate.
    Raise [Invalid_argument] if the two lists are determined
    to have different lengths. *)
 
@@ -179,7 +198,7 @@ val mem : 'a -> set:'a list -> bool
    to an element of [l]. *)
 
 val memq : 'a -> set:'a list -> bool
-(** Same as {!ListLabels.mem}, but uses physical equality instead of structural
+(** Same as {!List.mem}, but uses physical equality instead of structural
    equality to compare list elements. *)
 
 
@@ -205,7 +224,7 @@ val filter : f:('a -> bool) -> 'a list -> 'a list
    in the input list is preserved.  *)
 
 val find_all : f:('a -> bool) -> 'a list -> 'a list
-(** [find_all] is another name for {!ListLabels.filter}. *)
+(** [find_all] is another name for {!List.filter}. *)
 
 val partition : f:('a -> bool) -> 'a list -> 'a list * 'a list
 (** [partition p l] returns a pair of lists [(l1, l2)], where
@@ -237,19 +256,19 @@ val assoc_opt: 'a -> ('a * 'b) list -> 'b option
 *)
 
 val assq : 'a -> ('a * 'b) list -> 'b
-(** Same as {!ListLabels.assoc}, but uses physical equality instead of
+(** Same as {!List.assoc}, but uses physical equality instead of
    structural equality to compare keys. *)
 
 val assq_opt: 'a -> ('a * 'b) list -> 'b option
-(** Same as {!ListLabels.assoc_opt}, but uses physical equality instead of
+(** Same as {!List.assoc_opt}, but uses physical equality instead of
    structural equality to compare keys. *)
 
 val mem_assoc : 'a -> map:('a * 'b) list -> bool
-(** Same as {!ListLabels.assoc}, but simply return true if a binding exists,
+(** Same as {!List.assoc}, but simply return true if a binding exists,
    and false if no bindings exist for the given key. *)
 
 val mem_assq : 'a -> map:('a * 'b) list -> bool
-(** Same as {!ListLabels.mem_assoc}, but uses physical equality instead of
+(** Same as {!List.mem_assoc}, but uses physical equality instead of
    structural equality to compare keys. *)
 
 val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list
@@ -258,7 +277,7 @@ val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list
    Not tail-recursive. *)
 
 val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
-(** Same as {!ListLabels.remove_assoc}, but uses physical equality instead
+(** Same as {!List.remove_assoc}, but uses physical equality instead
    of structural equality to compare keys.  Not tail-recursive. *)
 
 
@@ -290,7 +309,7 @@ val sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
    a complete specification).  For example,
    {!Pervasives.compare} is a suitable comparison function.
    The resulting list is sorted in increasing order.
-   [ListLabels.sort] is guaranteed to run in constant heap space
+   [List.sort] is guaranteed to run in constant heap space
    (in addition to the size of the result list) and logarithmic
    stack space.
 
@@ -299,7 +318,7 @@ val sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
 *)
 
 val stable_sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
-(** Same as {!ListLabels.sort}, but the sorting algorithm is guaranteed to
+(** Same as {!List.sort}, but the sorting algorithm is guaranteed to
    be stable (i.e. elements that compare equal are kept in their
    original order) .
 
@@ -308,11 +327,11 @@ val stable_sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
 *)
 
 val fast_sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
-(** Same as {!ListLabels.sort} or {!ListLabels.stable_sort}, whichever is
+(** Same as {!List.sort} or {!List.stable_sort}, whichever is
     faster on typical input. *)
 
 val sort_uniq : cmp:('a -> 'a -> int) -> 'a list -> 'a list
-(** Same as {!ListLabels.sort}, but also remove duplicates.
+(** Same as {!List.sort}, but also remove duplicates.
     @since 4.02.0 *)
 
 val merge : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> 'a list

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -44,6 +44,7 @@ module Hashtbl : sig
         ('a, 'b) t -> init:'c -> 'c
   val length : ('a, 'b) t -> int
   val randomize : unit -> unit
+  val is_randomized : unit -> bool
   type statistics = Hashtbl.statistics
   val stats : ('a, 'b) t -> statistics
   module type HashedType = Hashtbl.HashedType

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -214,20 +214,50 @@ val rcontains_from : string -> int -> char -> bool
    position in [s]. *)
 
 val uppercase : string -> string
+  [@@ocaml.deprecated "Use String.uppercase_ascii instead."]
 (** Return a copy of the argument, with all lowercase letters
    translated to uppercase, including accented letters of the ISO
-   Latin-1 (8859-1) character set. *)
+   Latin-1 (8859-1) character set.
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val lowercase : string -> string
+  [@@ocaml.deprecated "Use String.lowercase_ascii instead."]
 (** Return a copy of the argument, with all uppercase letters
    translated to lowercase, including accented letters of the ISO
-   Latin-1 (8859-1) character set. *)
+   Latin-1 (8859-1) character set.
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val capitalize : string -> string
-(** Return a copy of the argument, with the first character set to uppercase. *)
+  [@@ocaml.deprecated "Use String.capitalize_ascii instead."]
+(** Return a copy of the argument, with the first character set to uppercase,
+   using the ISO Latin-1 (8859-1) character set..
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
 
 val uncapitalize : string -> string
-(** Return a copy of the argument, with the first character set to lowercase. *)
+  [@@ocaml.deprecated "Use String.uncapitalize_ascii instead."]
+(** Return a copy of the argument, with the first character set to lowercase,
+   using the ISO Latin-1 (8859-1) character set..
+   @deprecated Functions operating on Latin-1 character set are deprecated. *)
+
+val uppercase_ascii : string -> string
+(** Return a copy of the argument, with all lowercase letters
+   translated to uppercase, using the US-ASCII character set.
+   @since 4.03.0 *)
+
+val lowercase_ascii : string -> string
+(** Return a copy of the argument, with all uppercase letters
+   translated to lowercase, using the US-ASCII character set.
+   @since 4.03.0 *)
+
+val capitalize_ascii : string -> string
+(** Return a copy of the argument, with the first character set to uppercase,
+   using the US-ASCII character set.
+   @since 4.03.0 *)
+
+val uncapitalize_ascii : string -> string
+(** Return a copy of the argument, with the first character set to lowercase,
+   using the US-ASCII character set.
+   @since 4.03.0 *)
 
 type t = string
 (** An alias for the type of strings. *)
@@ -237,6 +267,25 @@ val compare: t -> t -> int
     {!Pervasives.compare}.  Along with the type [t], this function [compare]
     allows the module [String] to be passed as argument to the functors
     {!Set.Make} and {!Map.Make}. *)
+
+val equal: t -> t -> bool
+(** The equal function for strings.
+    @since 4.03.0 *)
+
+val split_on_char: sep:char -> string -> string list
+(** [String.split_on_char sep s] returns the list of all (possibly empty)
+    substrings of [s] that are delimited by the [sep] character.
+
+    The function's output is specified by the following invariants:
+
+    - The list is not empty.
+    - Concatenating its elements using [sep] as a separator returns a
+      string equal to the input ([String.concat (String.make 1 sep)
+      (String.split_on_char sep s) = s]).
+    - No string in the result contains the [sep] character.
+
+    @since 4.04.0
+*)
 
 (**/**)
 

--- a/testsuite/tests/lib-stdlabels/Makefile
+++ b/testsuite/tests/lib-stdlabels/Makefile
@@ -1,0 +1,19 @@
+#**************************************************************************
+#*                                                                        *
+#*                                OCaml                                   *
+#*                                                                        *
+#*                 Xavier Clerc, SED, INRIA Rocquencourt                  *
+#*                                                                        *
+#*   Copyright 2010 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+ADD_COMPFLAGS=-nolabels
+BASEDIR=../..
+
+include $(BASEDIR)/makefiles/Makefile.several
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/lib-stdlabels/test_stdlabels.ml
+++ b/testsuite/tests/lib-stdlabels/test_stdlabels.ml
@@ -1,0 +1,40 @@
+module A : module type of Array = ArrayLabels
+module B : module type of Bytes = BytesLabels
+module L : module type of List = ListLabels
+module S : module type of String = StringLabels
+
+module M : module type of Map = MoreLabels.Map
+module Se : module type of Set = MoreLabels.Set
+
+
+(* For  *)
+(* module H : module type of Hashtbl = MoreLabels.Hashtbl *)
+(* we will have following error: *)
+(* Error: Signature mismatch: *)
+(*        ... *)
+(*        Type declarations do not match: *)
+(*          type statistics = Hashtbl.statistics *)
+(*        is not included in *)
+(*          type statistics = { *)
+(*            num_bindings : int; *)
+(*            num_buckets : int; *)
+(*            max_bucket_length : int; *)
+(*            bucket_histogram : int array; *)
+(*          } *)
+(*        Their kinds differ. *)
+(* This is workaround:*)
+module Indirection = struct
+  type t = Hashtbl.statistics = {  num_bindings: int;
+                                   num_buckets: int;
+                                   max_bucket_length: int;
+                                   bucket_histogram: int array}
+end
+module type HS = sig
+  type statistics = Indirection.t
+  include module type of Hashtbl
+                         with type statistics := Indirection.t
+end
+module H : HS = MoreLabels.Hashtbl
+
+let ()  =
+  ()


### PR DESCRIPTION
This fix make it possible to use labeled modules as drop-in replacement with
`open StdLabels`.

Added signatures:

``` ocaml
(* arrayLabels.mli *)
val iter2 : f:('a -> 'b -> unit) -> 'a array -> 'b array -> unit
val map2 : f:('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array

(* bytesLabels.mli *)
val extend : bytes -> left:int -> right:int -> bytes
val blit_string :
val cat : bytes -> bytes -> bytes
val uppercase_ascii : bytes -> bytes
val lowercase_ascii : bytes -> bytes
val capitalize_ascii : bytes -> bytes
val uncapitalize_ascii : bytes -> bytes
val equal: t -> t -> bool

(* listLabels.mli *)
val compare_lengths : 'a list -> 'b list -> int
val compare_length_with : 'a list -> len:int -> int
val cons : 'a -> 'a list -> 'a list

(* moreLabels.Hashtbl *)
val is_randomized : unit -> bool

(* stringLabels.mli *)
val uppercase_ascii : string -> string
val lowercase_ascii : string -> string
val capitalize_ascii : string -> string
val uncapitalize_ascii : string -> string
val equal: t -> t -> bool
val split_on_char: sep:char -> string -> string list
```
