### PR TITLE
PR#7370: bump magic number (ocamldep segfault)

### DIFF
--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -84,7 +84,7 @@ and cmxa_magic_number =
     "Caml1999Z015"
   else
     "Caml1999Z014"
-and ast_impl_magic_number = "Caml1999M019"
+and ast_impl_magic_number = "Caml1999M020"
 and ast_intf_magic_number = "Caml1999N018"
 and cmxs_magic_number = "Caml2007D002"
 and cmt_magic_number = "Caml2012T008"


### PR DESCRIPTION
The question is: are there any other magic numbers we need to change, and how do we find them?
