### PR TITLE
Skip native tests on bytecode-only systems

### DIFF
--- a/testsuite/tests/lib-dynlink-csharp/Makefile
+++ b/testsuite/tests/lib-dynlink-csharp/Makefile
@@ -30,7 +30,9 @@ all: prepare bytecode bytecode-dll native native-dll
 prepare:
 	@if $(SUPPORTS_SHARED_LIBRARIES); then \
 	   $(OCAMLC) -c plugin.ml && \
-	   $(OCAMLOPT) -o plugin.cmxs -shared plugin.ml; \
+	   if $(BYTECODE_ONLY) ; then : ; else \
+	     $(OCAMLOPT) -o plugin.cmxs -shared plugin.ml; \
+	   fi; \
 	 fi
 
 .PHONY: bytecode

--- a/testsuite/tests/link-test/Makefile
+++ b/testsuite/tests/link-test/Makefile
@@ -14,7 +14,13 @@
 #*                                                                        *
 #**************************************************************************
 
-default: byte native
+default:
+	@$(MAKE) byte
+	@if $(BYTECODE_ONLY) ; then \
+	  echo " ... testing native 'test.reference': => skipped"; \
+	else \
+	  $(MAKE) native; \
+	fi
 
 native:
 	@printf " ... testing native 'test.reference':"


### PR DESCRIPTION
Otherwise this is making [quite a lot](https://buildd.debian.org/status/logs.php?pkg=ocaml) of builds on Debian fail.
