### PR TITLE
Fix [@@inline] with default parameters in flambda

### DIFF
--- a/Changes
+++ b/Changes
@@ -360,6 +360,8 @@ OCaml 4.04.0:
 - GPR#814: fix the Buffer.add_substring bounds check to handle overflow
   (Jeremy Yallop)
 
+- GPR#880: Fix [@@inline] with default parameters in flambda (Leo White)
+
 ### Internal/compiler-libs changes:
 
 - PR#7200, GPR#539: Improve, fix, and add test for parsing/pprintast.ml

--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -1085,7 +1085,8 @@ and close_functions fenv cenv fun_defs =
       (List.map
          (function
            | (id, Lfunction{kind; params; body; attr; loc}) ->
-               Simplif.split_default_wrapper id kind params body attr loc
+               Simplif.split_default_wrapper ~id ~kind ~params
+                 ~body ~attr ~wrapper_attr:attr ~loc ()
            | _ -> assert false
          )
          fun_defs)

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -644,7 +644,7 @@ and list_emit_tail_infos is_tail =
    function's body. *)
 
 let split_default_wrapper ?(create_wrapper_body = fun lam -> lam)
-      fun_id kind params body attr loc =
+      ~id:fun_id ~kind ~params ~body ~attr ~wrapper_attr ~loc () =
   let rec aux map = function
     | Llet(Strict, k, id, (Lifthenelse(Lvar optparam, _, _) as def), rest) when
         Ident.name optparam = "*opt*" && List.mem optparam params
@@ -688,7 +688,7 @@ let split_default_wrapper ?(create_wrapper_body = fun lam -> lam)
   try
     let wrapper_body, inner = aux [] body in
     [(fun_id, Lfunction{kind; params; body = create_wrapper_body wrapper_body;
-       attr; loc}); inner]
+       attr = wrapper_attr; loc}); inner]
   with Exit ->
     [(fun_id, Lfunction{kind; params; body; attr; loc})]
 

--- a/bytecomp/simplif.mli
+++ b/bytecomp/simplif.mli
@@ -24,12 +24,14 @@ val simplify_lambda: string -> lambda -> lambda
 
 val split_default_wrapper
    : ?create_wrapper_body:(lambda -> lambda)
-  -> Ident.t
-  -> function_kind
-  -> Ident.t list
-  -> lambda
-  -> function_attribute
-  -> Location.t
+  -> id:Ident.t
+  -> kind:function_kind
+  -> params:Ident.t list
+  -> body:lambda
+  -> attr:function_attribute
+  -> wrapper_attr:function_attribute
+  -> loc:Location.t
+  -> unit
   -> (Ident.t * lambda) list
 
 (* To be filled by asmcomp/selectgen.ml *)

--- a/middle_end/closure_conversion.ml
+++ b/middle_end/closure_conversion.ml
@@ -51,8 +51,9 @@ let add_default_argument_wrappers lam =
     | Llet (( Strict | Alias | StrictOpt), _k, id,
         Lfunction {kind; params; body = fbody; attr; loc}, body) ->
       begin match
-        Simplif.split_default_wrapper id kind params fbody attr loc
-          ~create_wrapper_body:stubify
+        Simplif.split_default_wrapper ~id ~kind ~params ~body:fbody
+          ~attr ~wrapper_attr:Lambda.default_function_attribute
+          ~loc ~create_wrapper_body:stubify ()
       with
       | [fun_id, def] -> Llet (Alias, Pgenval, fun_id, def, body)
       | [fun_id, def; inner_fun_id, def_inner] ->
@@ -67,8 +68,9 @@ let add_default_argument_wrappers lam =
             (List.map
                (function
                  | (id, Lambda.Lfunction {kind; params; body; attr; loc}) ->
-                   Simplif.split_default_wrapper id kind params body attr loc
-                     ~create_wrapper_body:stubify
+                   Simplif.split_default_wrapper ~id ~kind ~params ~body
+                     ~attr ~wrapper_attr:Lambda.default_function_attribute
+                     ~loc ~create_wrapper_body:stubify ()
                  | _ -> assert false)
                defs)
         in


### PR DESCRIPTION
Currently, functions with default parameters that are marked `[@@inline]` can cause a compilation error with flamda:

``` ocaml
let foo ?(bar=`Default) () =
  Array.make 5 bar
[@@inline]

let _ = foo ()
```

gives:

```
>> Fatal error: Stubs may not be annotated as [Always_inline] or [Unroll]: (let
                                                             (bar/18
                                                                *(let
                                                                   (cond/19
                                                                    **opt*/17)
                                                                   (if
                                                                    cond/19
                                                                    then begin
                                                                    (let
                                                                    (Pfield/21
                                                                    (field 0<{test.ml:2,14-22}>
                                                                    *opt*/17))
                                                                    Pfield/21)
                                                                    end else begin
                                                                    (let
                                                                    (const_pointer/20
                                                                    Const(-384499551a))
                                                                    const_pointer/20)
                                                                    end))
                                                              apply_funct/22
                                                                *foo_inner/15)
                                                             (apply<>
                                                               apply_funct/22
                                                               bar/18
                                                               param/16))

Fatal error: exception Misc.Fatal_error
```

This is because the `[@@inline]` attribute is copied onto the wrapper function for the default parameter. This patch prevents the attribute from being copied in flambda.

Since it is a bug fix, I've made the PR against 4.04, but since it is a compilation error rather than a miscompilation it can safely be cherry-picked onto trunk instead if people prefer.
