### PR TITLE
make short-paths work on more polymorphic variants

### DIFF
--- a/Changes
+++ b/Changes
@@ -235,15 +235,18 @@ Next version (4.05.0):
 - GPR#795: remove 256-character limitation on Sys.executable_name
   (Xavier Leroy)
 
-- GPR#814: fix the Buffer.add_substring bounds check to handle overflow
-  (Jeremy Yallop)
+- GPR#805, GPR#815, GPR#833: check for integer overflow in String.concat
+  (Jeremy Yallop,
+   review by Damien Doligez, Alain Frisch, Daniel Bünzli, Fabrice Le Fessant)
 
 - GPR#810: check for integer overflow in Array.concat
   (Jeremy Yallop)
 
-- GPR#805, GPR#815, GPR#833: check for integer overflow in String.concat
-  (Jeremy Yallop,
-   review by Damien Doligez, Alain Frisch, Daniel Bünzli, Fabrice Le Fessant)
+- GPR#814: fix the Buffer.add_substring bounds check to handle overflow
+  (Jeremy Yallop)
+
+- GPR#881: short-paths did not apply to some polymorphic variants
+  (Valentin Gatien-Baron, review by Leo White and Gabriel Scherer)
 
 - GPR#934: check for integer overflow in Bytes.extend
   (Jeremy Yallop, review by Gabriel Scherer)

--- a/testsuite/tests/typing-short-paths/pr6836.ml.reference
+++ b/testsuite/tests/typing-short-paths/pr6836.ml.reference
@@ -1,7 +1,7 @@
 
 # type t = [ `A | `B ]
 # type 'a u = t
-# val a : [< int u > `A ] = `A
+# val a : [< t > `A ] = `A
 #   type 'a s = 'a
 # val b : [< t > `B ] = `B
 # 

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -212,8 +212,8 @@ and print_simple_out_type ppf =
           Ovar_fields fields ->
             print_list print_row_field (fun ppf -> fprintf ppf "@;<1 -2>| ")
               ppf fields
-        | Ovar_name (id, tyl) ->
-            fprintf ppf "@[%a%a@]" print_typargs tyl print_ident id
+        | Ovar_typ typ ->
+           print_simple_out_type ppf typ
       in
       fprintf ppf "%s[%s@[<hv>@[<hv>%a@]%a ]@]" (if non_gen then "_" else "")
         (if closed then if tags = None then " " else "< "

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -70,7 +70,7 @@ type out_type =
 
 and out_variant =
   | Ovar_fields of (string * bool * out_type list) list
-  | Ovar_name of out_ident * out_type list
+  | Ovar_typ of out_type
 
 type out_class_type =
   | Octy_constr of out_ident * out_type list

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -604,20 +604,15 @@ let rec tree_of_typexp sch ty =
             let (p', s) = best_type_path p in
             let id = tree_of_path p' in
             let args = tree_of_typlist sch (apply_subst s tyl) in
+            let out_variant =
+              if is_nth s then List.hd args else Otyp_constr (id, args) in
             if row.row_closed && all_present then
-              if is_nth s then List.hd args else Otyp_constr (id, args)
+              out_variant
             else
               let non_gen = is_non_gen sch px in
               let tags =
                 if all_present then None else Some (List.map fst present) in
-              let inh =
-                match args with
-                  [Otyp_constr (i, a)] when is_nth s -> Ovar_name (i, a)
-                | _ ->
-                    (* fallback case, should change outcometree... *)
-                    Ovar_name (tree_of_path p, tree_of_typlist sch tyl)
-              in
-              Otyp_variant (non_gen, inh, row.row_closed, tags)
+              Otyp_variant (non_gen, Ovar_typ out_variant, row.row_closed, tags)
         | _ ->
             let non_gen =
               not (row.row_closed && all_present) && is_non_gen sch px in


### PR DESCRIPTION
Compare without and with this change:

```
 $ ocaml -short-paths
        OCaml version 4.03.0+dev11-2015-10-19

 # module B = struct type perms = [ `A | `B ] end;;
 module B : sig type perms = [ `A | `B ] end
 # open B;;
 # let x = lazy (assert false : [< B.perms ]);;
-val x : [< B.perms ] lazy_t = <lazy>
+val x : [< perms ] lazy_t = <lazy>
 # 
```
