### PR TITLE
Fix Flambda introduction of mutable variables

### DIFF
--- a/middle_end/flambda_utils.mli
+++ b/middle_end/flambda_utils.mli
@@ -229,3 +229,8 @@ val parameters_specialised_to_the_same_variable
    : function_decls:Flambda.function_declarations
   -> specialised_args:Flambda.specialised_to Variable.Map.t
   -> specialised_to_same_as list Variable.Map.t
+
+(** Remove all obvious aliases ("let x = y", transitively) to the variables
+    [to_variables] by substituting out uses and replacing defining expressions
+    of aliasing [Let]s with dummy values. *)
+val eliminate_aliases : Flambda.t -> to_variables:Variable.Set.t -> Flambda.t

--- a/middle_end/middle_end.ml
+++ b/middle_end/middle_end.ml
@@ -86,13 +86,13 @@ let middle_end ppf ~source_provenance ~prefixname ~backend
       +-+ ("lift_lets 1", Lift_code.lift_lets)
       +-+ ("Lift_constants", Lift_constants.lift_constants ~backend)
       +-+ ("Share_constants", Share_constants.share_constants)
+      +-+ ("Ref_to_variables",
+           Ref_to_variables.eliminate_ref)
       +-+ ("Lift_let_to_initialize_symbol",
            Lift_let_to_initialize_symbol.lift ~backend)
       +-+ ("Inline_and_simplify",
            Inline_and_simplify.run ~never_inline:false ~backend
              ~prefixname ~round)
-      +-+ ("Ref_to_variables",
-           Ref_to_variables.eliminate_ref)
       +-+ ("Remove_unused_closure_vars 2",
            Remove_unused_closure_vars.remove_unused_closure_variables
              ~remove_direct_call_surrogates:false)
@@ -113,6 +113,8 @@ let middle_end ppf ~source_provenance ~prefixname ~backend
         +-+ ("Share_constants", Share_constants.share_constants)
         +-+ ("Remove_unused_program_constructs",
              Remove_unused_program_constructs.remove_unused_program_constructs)
+        +-+ ("Ref_to_variables",
+             Ref_to_variables.eliminate_ref)
         +-+ ("Lift_let_to_initialize_symbol",
              Lift_let_to_initialize_symbol.lift ~backend)
         +-+ ("lift_lets 2", Lift_code.lift_lets)
@@ -126,8 +128,6 @@ let middle_end ppf ~source_provenance ~prefixname ~backend
              Remove_unused_closure_vars.remove_unused_closure_variables
               ~remove_direct_call_surrogates:false)
         +-+ ("lift_lets 3", Lift_code.lift_lets)
-        +-+ ("Ref_to_variables",
-             Ref_to_variables.eliminate_ref)
         +-+ ("Inline_and_simplify noinline",
              Inline_and_simplify.run ~never_inline:true ~backend
               ~prefixname ~round)

--- a/middle_end/ref_to_variables.ml
+++ b/middle_end/ref_to_variables.ml
@@ -105,6 +105,11 @@ let variables_containing_ref (flam:Flambda.t) =
   !map
 
 let eliminate_ref_of_expr flam =
+  let variables_containing_ref = variables_containing_ref flam in
+  let flam =
+    Flambda_utils.eliminate_aliases flam
+      ~to_variables:(Variable.Map.keys variables_containing_ref)
+  in
   let variables_not_used_as_local_reference =
     variables_not_used_as_local_reference flam
   in
@@ -112,7 +117,7 @@ let eliminate_ref_of_expr flam =
     Variable.Map.filter
       (fun v _ ->
         not (Variable.Set.mem v variables_not_used_as_local_reference))
-      (variables_containing_ref flam)
+      variables_containing_ref
   in
   if Variable.Map.cardinal convertible_variables = 0 then flam
   else


### PR DESCRIPTION
(From the caml-list thread "Why is some code compiled with 4.04.0 or 4.05.0 running 2.3 times slower than the same code compiled with 4.03.0?")

It looks like Flambda's `Ref_to_variables` pass has been broken for some time.  This has only come to light because of a change introduced in 4.04 to disable the `Simplif` equivalent of this transformation.

The example from the mailing list is thus:
```
open Bigarray

let _ = 
  let m, n, rep = 100, 100, 1000 in
  let cr m n = Array2.create float64 fortran_layout m n in
  let a = cr m n in
  let c = cr m m in
  let rz = ref 0.0 in
  let x = ref 0.0 in
  for r = 1 to rep do
    for i = 1 to m do
      for j = 1 to n do
	a.{i,j} <- !rz;
	rz := !rz +. 123.45;
      done
    done;
    for i = 1 to m do
      for j = 1 to m do
	x := 0.0;
	for k = 1 to n do
	  x := !x +. a.{i,k} *. a.{k,i}
	done;
	c.{i,j} <- !x
      done
    done
  done
```

The conversion of `x` and `rz` to local mutables fails to happen.  I think this is because the `Ref_to_variables` pass runs too late and the reference cells have already been lifted to toplevel `Initialize_symbol`.  As such, we fail to spot the references.

Moving `Ref_to_variables` earlier would solve the problem, but unfortunately that means having it before `Inline_and_simplify`, so it needs to cope with direct aliases in order to correctly see what to transform.  I've added a slightly rudimentary way of it doing that, which seems to solve the problem.

@chambart What do you think about all this?  We need to make a decision about 4.04---this regression may be bad enough to fix before the release.  The safest thing may be to re-introduce the pass on `Lambda`.

As an aside, even since 4.03 there has been a performance regression in this code: the arrays having been lifted to toplevel `Initialize_symbol` declarations, we end up loading the symbol address and then dereferencing every time around the loop.  However I think a fix for that can wait.