### PR TITLE
Fix Ctype.moregeneral's handling of row_name

### DIFF
--- a/Changes
+++ b/Changes
@@ -324,6 +324,8 @@ Next version (4.05.0):
 - GPR#881: short-paths did not apply to some polymorphic variants
   (Valentin Gatien-Baron, review by Leo White)
 
+- GPR#886: Fix Ctype.moregeneral's handling of row_name (Leo White)
+
 - GPR#934: check for integer overflow in Bytes.extend
   (Jeremy Yallop, review by Gabriel Scherer)
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3050,7 +3050,9 @@ and moregen_row inst_nongen type_pairs env row1 row2 =
       raise (Unify [])
   | _ when static_row row1 -> ()
   | _ when may_inst ->
-      let ext = newgenty (Tvariant {row2 with row_fields = r2}) in
+      let ext =
+        newgenty (Tvariant {row2 with row_fields = r2; row_name = None})
+      in
       moregen_occur env rm1.level ext;
       link_type rm1 ext
   | Tconstr _, Tconstr _ ->


### PR DESCRIPTION
The following code:
```ocaml
type t = [ `Foo of float ]

module M : sig
  val baz : t ref
end = struct
  let baz = ref (`Foo 1)
end
```

currently produces the following error:
```ocaml
Error: Signature mismatch:
       Modules do not match:
         sig val baz : t ref end
       is not included in
         sig val baz : t ref end
       Values do not match:
         val baz : t ref
       is not included in
         val baz : t ref
```

which incorrectly gives the inner type of `baz` as `t ref`.

This is due  to `moregeneral` linking the row variable with a type which is not `t` (it is actually the empty variant type) but which is still associated with the name `t`.

With this PR the error is instead given as:
```ocaml
Error: Signature mismatch:
       Modules do not match:
         sig val baz : [ `Foo of int ] ref end
       is not included in
         sig val baz : t ref end
       Values do not match:
         val baz : [ `Foo of int ] ref
       is not included in
         val baz : t ref
```

I've made this PR against 4.04 since it is a very small fix and should be easy for @garrigue to review before the release. But as it only affects the printing of types it can be safely left for 4.05 if that is preferred.