### PR TITLE
Added documentation for the new -args(0) option.

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -726,14 +726,14 @@ let mk_no_strict_formats f =
 
 let mk_args f =
   "-args", Arg.Expand f,
-  "<file> Read additional newline separated command line arguments \n\
+  "<file> Read additional newline separated command line arguments\n\
   \      from <file>"
 ;;
 
 let mk_args0 f =
   "-args0", Arg.Expand f,
-  "<file> Read additional NUL separated command line arguments from \n\
-  \      <file>"
+  "<file> Read additional null character separated command line arguments\n\
+          from <file>"
 ;;
 
 

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -726,13 +726,13 @@ let mk_no_strict_formats f =
 
 let mk_args f =
   "-args", Arg.Expand f,
-  "<file> Read additional newline separated command line arguments\n\
+  "<file> Read additional newline-terminated command line arguments\n\
   \      from <file>"
 ;;
 
 let mk_args0 f =
   "-args0", Arg.Expand f,
-  "<file> Read additional null character separated command line arguments\n\
+  "<file> Read additional null character terminated command line arguments\n\
           from <file>"
 ;;
 

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -136,7 +136,7 @@ interactively.
  Read additional newline separated command line arguments from \var{filename}.
 
 \item["-args0" \var{filename}]
- Read additional NUL separated command line arguments from \var{filename}.
+ Read additional null character separated command line arguments from \var{filename}.
 
 \item["-bin-annot"]
 Dump detailed information about the compilation (types, bindings,

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -133,10 +133,10 @@ The \var{src}".annot" file can be used with the emacs commands given in
 interactively.
 
 \item["-args" \var{filename}]
- Read additional newline separated command line arguments from \var{filename}.
+ Read additional newline-terminated command line arguments from \var{filename}.
 
 \item["-args0" \var{filename}]
- Read additional null character separated command line arguments from \var{filename}.
+ Read additional null character terminated command line arguments from \var{filename}.
 
 \item["-bin-annot"]
 Dump detailed information about the compilation (types, bindings,

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -132,6 +132,12 @@ The \var{src}".annot" file can be used with the emacs commands given in
 "emacs/caml-types.el" to display types and other annotations
 interactively.
 
+\item["-args" \var{filename}]
+ Read additional newline separated command line arguments from \var{filename}.
+
+\item["-args0" \var{filename}]
+ Read additional NUL separated command line arguments from \var{filename}.
+
 \item["-bin-annot"]
 Dump detailed information about the compilation (types, bindings,
 tail-calls, etc) in binary format. The information for file \var{src}".ml"

--- a/manual/manual/cmds/depend.etex
+++ b/manual/manual/cmds/depend.etex
@@ -37,10 +37,10 @@ implicit dependencies.
 Allow falling back on a lexer-based approximation when parsing fails.
 
 \item["-args" \var{filename}]
- Read additional newline separated command line arguments from \var{filename}.
+ Read additional newline-terminated command line arguments from \var{filename}.
 
 \item["-args0" \var{filename}]
- Read additional null character separated command line arguments from \var{filename}.
+ Read additional null character terminated command line arguments from \var{filename}.
 
 \item["-as-map"]
 For the following files, do not include delayed dependencies for

--- a/manual/manual/cmds/depend.etex
+++ b/manual/manual/cmds/depend.etex
@@ -36,6 +36,12 @@ implicit dependencies.
 \item["-allow-approx"]
 Allow falling back on a lexer-based approximation when parsing fails.
 
+\item["-args" \var{filename}]
+ Read additional newline separated command line arguments from \var{filename}.
+
+\item["-args0" \var{filename}]
+ Read additional NUL separated command line arguments from \var{filename}.
+
 \item["-as-map"]
 For the following files, do not include delayed dependencies for
 module aliases.

--- a/manual/manual/cmds/depend.etex
+++ b/manual/manual/cmds/depend.etex
@@ -40,7 +40,7 @@ Allow falling back on a lexer-based approximation when parsing fails.
  Read additional newline separated command line arguments from \var{filename}.
 
 \item["-args0" \var{filename}]
- Read additional NUL separated command line arguments from \var{filename}.
+ Read additional null character separated command line arguments from \var{filename}.
 
 \item["-as-map"]
 For the following files, do not include delayed dependencies for

--- a/manual/manual/cmds/native.etex
+++ b/manual/manual/cmds/native.etex
@@ -120,10 +120,10 @@ The \var{src}".annot" file can be used with the emacs commands given in
 interactively.
 
 \item["-args" \var{filename}]
- Read additional newline separated command line arguments from \var{filename}.
+ Read additional newline-terminated command line arguments from \var{filename}.
 
 \item["-args0" \var{filename}]
- Read additional null character separated command line arguments from \var{filename}.
+ Read additional null character terminated command line arguments from \var{filename}.
 
 \item["-bin-annot"]
 Dump detailed information about the compilation (types, bindings,

--- a/manual/manual/cmds/native.etex
+++ b/manual/manual/cmds/native.etex
@@ -123,7 +123,7 @@ interactively.
  Read additional newline separated command line arguments from \var{filename}.
 
 \item["-args0" \var{filename}]
- Read additional NUL separated command line arguments from \var{filename}.
+ Read additional null character separated command line arguments from \var{filename}.
 
 \item["-bin-annot"]
 Dump detailed information about the compilation (types, bindings,

--- a/manual/manual/cmds/native.etex
+++ b/manual/manual/cmds/native.etex
@@ -119,6 +119,12 @@ The \var{src}".annot" file can be used with the emacs commands given in
 "emacs/caml-types.el" to display types and other annotations
 interactively.
 
+\item["-args" \var{filename}]
+ Read additional newline separated command line arguments from \var{filename}.
+
+\item["-args0" \var{filename}]
+ Read additional NUL separated command line arguments from \var{filename}.
+
 \item["-bin-annot"]
 Dump detailed information about the compilation (types, bindings,
 tail-calls, etc) in binary format. The information for file \var{src}".ml"

--- a/manual/manual/cmds/profil.etex
+++ b/manual/manual/cmds/profil.etex
@@ -102,6 +102,12 @@ The following options are recognized by "ocamlprof":
 
 \begin{options}
 
+\item["-args" \var{filename}]
+ Read additional newline separated command line arguments from \var{filename}.
+
+\item["-args0" \var{filename}]
+ Read additional NUL separated command line arguments from \var{filename}.
+
 \item["-f" \var{dumpfile}]
 Specifies an alternate dump file of profiling information to be read.
 

--- a/manual/manual/cmds/profil.etex
+++ b/manual/manual/cmds/profil.etex
@@ -103,10 +103,10 @@ The following options are recognized by "ocamlprof":
 \begin{options}
 
 \item["-args" \var{filename}]
- Read additional newline separated command line arguments from \var{filename}.
+ Read additional newline-terminated command line arguments from \var{filename}.
 
 \item["-args0" \var{filename}]
- Read additional null character separated command line arguments from \var{filename}.
+ Read additional null character terminated command line arguments from \var{filename}.
 
 \item["-f" \var{dumpfile}]
 Specifies an alternate dump file of profiling information to be read.

--- a/manual/manual/cmds/profil.etex
+++ b/manual/manual/cmds/profil.etex
@@ -106,7 +106,7 @@ The following options are recognized by "ocamlprof":
  Read additional newline separated command line arguments from \var{filename}.
 
 \item["-args0" \var{filename}]
- Read additional NUL separated command line arguments from \var{filename}.
+ Read additional null character separated command line arguments from \var{filename}.
 
 \item["-f" \var{dumpfile}]
 Specifies an alternate dump file of profiling information to be read.

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -181,18 +181,18 @@ val current : int ref
     at the next element. *)
 
 val read_arg: string -> string array
-(** [Arg.read_arg file] reads newline separated command line arguments from
+(** [Arg.read_arg file] reads newline-terminated command line arguments from
     file [file]. *)
 
 val read_arg0: string -> string array
-(** Identical to {!Arg.read_arg} but assumes null character separated command line
+(** Identical to {!Arg.read_arg} but assumes null character terminated command line
     arguments. *)
 
 val write_arg: string -> string array -> unit
-(** [Arg.write_arg file args] writes the arguments [args] newline separated
+(** [Arg.write_arg file args] writes the arguments [args] newline-terminated
     into the file [file]. If the any of the arguments in [args] contains a
     newline, use {!Arg.write_arg0} instead. *)
 
 val write_arg0: string -> string array -> unit
-(** Identical to {!Arg.write_arg} but uses the null character as separator instead
-    of newline. *)
+(** Identical to {!Arg.write_arg} but uses the null character for terminator
+    instead of newline. *)

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -186,12 +186,12 @@ val read_arg: string -> string array
 
 val read_arg0: string -> string array
 (** Identical to {!Arg.read_arg} but assumes NUL terminated command line
-    arguments *)
+    arguments. *)
 
 val write_arg: string -> string array -> unit
 (** [Arg.write_arg file args] writes the arguments [args] newline terminated
     into the file [file]. If the any of the arguments in [args] contains a
-    newline use the function {!Args.write_arg0} instead *)
+    newline use the function {!Arg.write_arg0} instead. *)
 
 val write_arg0: string -> string array -> unit
-(** Identical to {!Arg.write_arg} but uses NUL as terminator instead *)
+(** Identical to {!Arg.write_arg} but uses NUL as terminator instead. *)

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -181,17 +181,18 @@ val current : int ref
     at the next element. *)
 
 val read_arg: string -> string array
-(** [Arg.read_arg file] reads linefeed terminated command line arguments from
+(** [Arg.read_arg file] reads newline separated command line arguments from
     file [file]. *)
 
 val read_arg0: string -> string array
-(** Identical to {!Arg.read_arg} but assumes NUL terminated command line
+(** Identical to {!Arg.read_arg} but assumes null character separated command line
     arguments. *)
 
 val write_arg: string -> string array -> unit
-(** [Arg.write_arg file args] writes the arguments [args] newline terminated
+(** [Arg.write_arg file args] writes the arguments [args] newline separated
     into the file [file]. If the any of the arguments in [args] contains a
-    newline use the function {!Arg.write_arg0} instead. *)
+    newline, use {!Arg.write_arg0} instead. *)
 
 val write_arg0: string -> string array -> unit
-(** Identical to {!Arg.write_arg} but uses NUL as terminator instead. *)
+(** Identical to {!Arg.write_arg} but uses the null character as separator instead
+    of newline. *)


### PR DESCRIPTION
Additionally typos in the documenation of Args.read_arg(0) and Args.write_arg(0) are fixed.
As requeseted in #843.