### PR TITLE
Use -fno-builtin-memcmp with gcc

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,6 +26,9 @@ Next version (4.05.0):
   passed to the new functions are handled by the garbage collector.
   (Gabriel Scherer, review by Mark Shinwell, request by Immanuel Litzroth)
 
+- GPR#891: Use -fno-builtin-memcmp when building runtime with gcc.
+  (Leo White)
+
 ### Type system:
 
 - PR#6608, GPR#901: unify record types when overriding all fields

--- a/configure
+++ b/configure
@@ -393,7 +393,8 @@ case "$ccfamily" in
     bytecccompopts="-std=gnu99 -O";
     byteccprivatecompopts="$gcc_warnings";;
   gcc-4-*)
-    bytecccompopts="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv";
+    bytecccompopts="-std=gnu99 -O2 -fno-strict-aliasing -fwrapv \
+-fno-builtin-memcmp";
     byteccprivatecompopts="$gcc_warnings";;
   gcc-*)
     bytecccompopts="-O2 -fno-strict-aliasing -fwrapv";


### PR DESCRIPTION
The gcc builtin version of memcmp is actually significantly slower than the function implementation in glib:

  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=43052

For this reason gcc disabled its builtin version after 4.5, but for earlier versions of gcc you need to do `-fno-builtin-memcmp` to turn it off, which is what this PR does.