### PR TITLE
Fix bootstrapping flexlink

### DIFF
--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -20,6 +20,12 @@ include $(ROOTDIR)/config/Makefile
 CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 CAMLYACC ?= $(ROOTDIR)/boot/ocamlyacc
 
+ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
+export OCAML_FLEXLINK:=
+else
+export OCAML_FLEXLINK:=$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe
+endif
+
 LIBS = -nostdlib -I $(ROOTDIR)/stdlib -I $(ROOTDIR)/otherlibs/$(UNIXLIB)
 
 CAMLC=$(CAMLRUN) $(ROOTDIR)/ocamlc $(LIBS)


### PR DESCRIPTION
https://github.com/ocaml/ocaml/commit/5c4c41ba10639fbaad61dc747afc965c8348d01e accidentally broke building otherlibs/systhreads with a
bootstrapped flexlink.