### PR TITLE
Manual: alternative html structure for code examples

### DIFF
--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -76,7 +76,7 @@ html: files
 	         -I ../tutorials -I ../../styles -I ../texstuff manual.hva \
 	         -e macros.tex ../manual.tex ; \
 	${HACHA} -tocter manual.html ; \
-
+	cat ../manual.css >> manual.css
 
 info: files
 	cd infoman; rm -f ocaml.info*; \

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -5,20 +5,35 @@
 \newstyle{a:link}{color:\link@color;text-decoration:underline;}
 \newstyle{a:visited}{color:\visited@color;text-decoration:underline;}
 \newstyle{a:hover}{color:black;text-decoration:none;background-color:\hover@color}
+\externalcsstrue % needed due to hevea partial css handling
 %%%
 \newcommand{\input@color}{\htmlcolor{006000}}
 \newcommand{\output@color}{\maroon}
 \newcommand{\machine}{\tt}
 \newenvironment{machineenv}{\begin{alltt}}{\end{alltt}}
-\newcommand{\firstline}{\black\#\input@color\ }
+\newcommand{\firstline}{\ }
 \newcommand{\nextline}{\ \ }
 \newcommand{\@zyva}{\firstline\renewcommand{\?}{\nextline}}
 \newenvironment{camlunder}{\@style{U}}{}
 \newcommand{\caml}{\begin{alltt}\renewcommand{\;}{}\renewcommand{\\}{\char92}\def\<{\begin{camlunder}}\def\>{\end{camlunder}}\activebracefalse}
 \let\?=\@zyva
-\newcommand{\endcaml}{\activebracetrue\end{alltt}}
-\renewcommand{\:}{\renewcommand{\?}{\@zyva}\output@color}
+\newcommand{\endcaml}{\activebracetrue\end{alltt}
+}
+\renewcommand{\:}{\renewcommand{\?}{\@zyva}}
 \newcommand{\var}[1]{\textit{#1}}
+
+% Caml-example environment
+\newcommand{\camlexample}{\@open{div}{class="caml-example"}
+}
+\newcommand{\endcamlexample}{\@close{div}}
+\newcommand{\camlinput}{\@open{div}{class="caml-input"}}
+\newcommand{\endcamlinput}{\@close{div}}
+\newcommand{\camloutput}{\@open{div}{class="caml-output ok"}}
+\newcommand{\endcamloutput}{\@close{div}}
+\newcommand{\camlerror}{\@open{div}{class="caml-output error"}}
+\newcommand{\endcamlerror}{\@close{div}}
+\newcommand{\camlwarn}{\@open{div}{class="caml-output warn"}}
+\newcommand{\endcamlwarn}{\@close{div}}
 
 \newenvironment{library}{}{}
 \newcounter{page}

--- a/manual/manual/manual.css
+++ b/manual/manual/manual.css
@@ -1,0 +1,6 @@
+
+/* Addition to the hevea generated css file */
+div.caml-output {color:maroon;}
+div.caml-input::before{ content:"#"; color:black;}
+div.caml-input {color:#006000;}
+div.caml-example pre {margin:2ex 0px;}

--- a/manual/manual/manual.inf
+++ b/manual/manual/manual.inf
@@ -8,6 +8,14 @@
 \newcommand{\endcaml}{\activebracetrue\end{alltt}}
 \newcommand{\?}{\black\#\blue }
 \renewcommand{\:}{\maroon}
+\def\camlinput{}
+\def\endcamlinput{}
+\def\camloutput{}
+\def\endcamloutput{}
+\def\camlerror{}
+\def\endcamlerror{}
+\def\camlwarn{}
+\def\endcamlwarn{}
 \newcommand{\var}[1]{\textit{#1}}
 
 \newenvironment{library}{}{}

--- a/manual/styles/caml-sl.sty
+++ b/manual/styles/caml-sl.sty
@@ -18,7 +18,6 @@
 
 \def\caml{
     \bgroup
-    \flushleft
     \parindent 0pt
     \parskip 0pt
     \let\do\@makeother\dospecials
@@ -38,6 +37,18 @@
 }
 
 \def\endcaml{
-  \endflushleft
-  \egroup\noindent
+  \egroup
+  \addvspace{\medskipamount}
 }
+
+% Caml-example related command
+\def\camlexample{\begin{flushleft}}
+\def\endcamlexample{\end{flushleft}}
+\def\camlinput{}
+\def\endcamlinput{}
+\def\camloutput{}
+\def\endcamloutput{}
+\def\camlerror{}
+\def\endcamlerror{}
+\def\camlwarn{}
+\def\endcamlwarn{}

--- a/manual/tools/caml_tex2.ml
+++ b/manual/tools/caml_tex2.ml
@@ -4,12 +4,32 @@ open StdLabels
 open Printf
 open Str
 
-let camlbegin = "\\caml\n"
-let camlend = "\\endcaml\n"
-let camlin = "\\\\?\\1"
-let camlout = "\\\\:\\1"
+let camlbegin = "\\caml"
+let camlend = "\\endcaml"
+let camlin = {|\\?\1|}
+let camlout = {|\\:\1|}
 let camlbunderline = "\\<"
 let camleunderline = "\\>"
+
+let start newline out s =
+  Printf.fprintf out "%s%s" camlbegin s;
+  if newline then Printf.fprintf out "\n"
+
+let stop newline out s =
+  Printf.fprintf out "%s%s" camlend s;
+  if newline then Printf.fprintf out "\n"
+
+let code_env ?(newline=true) env out s =
+  Printf.fprintf out "%a%s\n%a"
+    (start false) env s (stop newline) env
+
+let main = "example"
+let input_env = "input"
+let ok_output ="output"
+let error ="error"
+let warning ="warn"
+let phrase_env = ""
+
 
 let camllight = ref "TERM=norepeat ocaml"
 let verbose = ref true
@@ -66,6 +86,12 @@ module Output = struct
     | Error -> Printf.fprintf ppf "an error"
     | Ok -> Printf.fprintf ppf "an ok"
     | Warning n -> Printf.fprintf ppf "a warning %d" n
+
+  (** {2 Related latex environment } *)
+  let env = function
+    | Error -> error
+    | Warning _ -> warning
+    | Ok -> ok_output
 
   (** {2 Exceptions } *)
   exception Parsing_error of kind * string
@@ -232,7 +258,7 @@ let process_file file =
       let global_expected = try Output.expected @@ matched_group 3 !input
             with Not_found -> Output.Ok
       in
-      output_string oc camlbegin;
+      start true oc main;
       let first = ref true in
       let read_phrase () =
         let phrase = Buffer.create 256 in
@@ -294,15 +320,17 @@ let process_file file =
             escape_specials phrase in
         (* Special characters may also appear in output strings -Didier *)
         let output = escape_specials output in
-        let phrase = global_replace ~!"^\\(.\\)" camlin phrase
-        and output = global_replace ~!"^\\(.\\)" camlout output in
-        if not !first then output_string oc "\\;\n";
-        fprintf oc "%s\n" phrase;
-        if not omit_answer then fprintf oc "%s" output;
+        let phrase = global_replace ~!{|^\(.\)|} camlin phrase
+        and output = global_replace ~!{|^\(.\)|} camlout output in
+        start false oc phrase_env;
+        code_env ~newline:omit_answer input_env oc phrase;
+        if not omit_answer then
+          code_env ~newline:false (Output.env status) oc output;
+        stop true oc phrase_env;
         flush oc;
         first := false
       done
-      with End_of_file -> phrase_start:= !phrase_stop; output_string oc camlend
+      with End_of_file -> phrase_start:= !phrase_stop; stop true oc main
     end
     else if string_match ~!"\\\\begin{caml_eval}[ \t]*$" !input 0
     then begin

--- a/manual/tools/caml_tex2.ml
+++ b/manual/tools/caml_tex2.ml
@@ -190,10 +190,11 @@ let read_output () =
     else 0, 0
   in
   let output = Buffer.create 256 in
+  let first_line = ref true in
   while not (string_match ~!".*\"end_of_input\"$" !input 0) do
     if !verbose then prerr_endline !input;
+    if not !first_line then Buffer.add_char output '\n' else first_line:=false;
     Buffer.add_string output !input;
-    Buffer.add_char output '\n';
     input := input_line caml_input;
   done;
   Buffer.contents output, underline
@@ -255,7 +256,7 @@ let process_file file =
               else
                 (Buffer.add_string phrase last_input; global_expected)
             in
-            Buffer.add_string phrase ";;\n";
+            Buffer.add_string phrase ";;";
             Buffer.contents phrase, expected
           end in
         read ()


### PR DESCRIPTION

This pull request proposes to reorganize the html structure of the code examples generated by `manual/tools/caml_tex2`. 

Currently, this html structure tends to be quite chaotic. For instance, the first example in the manual

```OCaml
1+2*3;;
let pi = 4.0 *. atan 1.0;;
let square x = x *. x;;
square (sin pi) +. square (cos pi);;
```

is translated to

```html
<pre><span class="c003">#</span><span class="c002"> 1+2*3;;
<span class="c005">- : int = 7

</span><span class="c003">#</span> let pi = 4.0 *. atan 1.0;;
<span class="c005">val pi : float = 3.14159265358979312

</span><span class="c003">#</span> let square x = x *. x;;
<span class="c005">val square : float -&gt; float = &lt;fun&gt;

</span><span class="c003">#</span> square (sin pi) +. square (cos pi);;
</span><span class="c005">- : float = 1.
</span></pre>
```

Within this example, the nested spans `<span class="c00n">` are mainly linked to the
desired color of the text and not to the structure of the code.
This PR wishes to structure a little more this html output and yields for this example:

```html
<code class="caml-example">
<pre><div class="caml-input"> 1+2*3;;
</div><div class="caml-output ok">- : int = 7
</div></pre>

<pre><div class="caml-input"> let pi = 4.0 *. atan 1.0;;
</div><div class="caml-output ok">val pi : float = 3.14159265358979312
</div></pre>

<pre><div class="caml-input"> let square x = x *. x;;
</div><div class="caml-output ok">val square : float -&gt; float = &lt;fun&gt;
</div></pre>

<pre><div class="caml-input"> square (sin pi) +. square (cos pi);;
</div><div class="caml-output ok">- : float = 1.
</div></pre>

</code>
```

This generated html is longer but has a more regular structure:

- The whole example is wrapped in a `<code class="caml-example">` tag
- Each phrase is wrapped in a `<pre>` tag
- The input and output part of each phrase are also wrapped in a corresponding
`<div>`
- Moreover, the status of the output (i.e. ok, error, or warning) is added to
the class list of the output div.


One of the advantages of this structure is that the original manual style can reproduced by adding few css rules to the hevea generated css while giving more freedom to alternative stylesheet. See for instance ((the button at the top of)) [core examples](http://www.polychoron.fr/ocaml-nonmanual/alternative_caml-example/coreexamples.html) and [advanced examples](http://www.polychoron.fr/ocaml-nonmanual/alternative_caml-example/advexamples.html).
