### PR TITLE
synchronize {Pervasives,Int64}.float_of_bits declarations

### DIFF
--- a/stdlib/pervasives.ml
+++ b/stdlib/pervasives.ml
@@ -159,7 +159,9 @@ external float : int -> float = "%floatofint"
 external float_of_int : int -> float = "%floatofint"
 external truncate : float -> int = "%intoffloat"
 external int_of_float : float -> int = "%intoffloat"
-external float_of_bits : int64 -> float = "caml_int64_float_of_bits"
+external float_of_bits : int64 -> float
+  = "caml_int64_float_of_bits" "caml_int64_float_of_bits_unboxed"
+  [@@unboxed] [@@noalloc]
 let infinity =
   float_of_bits 0x7F_F0_00_00_00_00_00_00L
 let neg_infinity =


### PR DESCRIPTION
That way the `float_of_bits` calls in `Pervasives` can use the unboxed version.

Looks like an oversight from #277 