### PR TITLE
use sort which is independent of current locale

### DIFF
--- a/Changes
+++ b/Changes
@@ -51,6 +51,10 @@ Next version (4.05.0):
   install-compiler-sources for installation of compiler-libs ml files
   (Hendrik Tews)
 
+- GPR#898: fix locale-dependence of primitive list order,
+  detected through reproducible-builds.org.
+  (Hannes Mehnert, review by Gabriel Scherer and Ximin Luo)
+
 ### Internal/compiler-libs changes:
 
 - GPR#744, GPR#781: fix duplicate self-reference in imported cmi_crcs

--- a/byterun/Makefile.shared
+++ b/byterun/Makefile.shared
@@ -104,9 +104,15 @@ endif
 # Warning: we use "sort | uniq" instead of "sort -u" because in the MSVC
 # port, the "sort" program in the path is Microsoft's and not cygwin's
 
+# Warning: POSIX sort is locale dependent, that's why we set LC_ALL explicitly.
+# Sort is unstable for "is_directory" and "isatty"
+# see http://pubs.opengroup.org/onlinepubs/9699919799/utilities/sort.html:
+# "using sort to process pathnames, it is recommended that LC_ALL .. set to C"
+
+
 primitives : $(PRIMS)
 	sed -n -e "s/CAMLprim value \([a-z0-9_][a-z0-9_]*\).*/\1/p" $(PRIMS) \
-	  | sort | uniq > primitives
+	  | LC_ALL=C sort | uniq > primitives
 
 prims.c : primitives
 	(echo '#define CAML_INTERNALS'; \


### PR DESCRIPTION
According to [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/sort.html), sort is local-dependent.  This leads to an actual problem here, since `​caml_sys_is_directory` and `​caml_s​ys_isatty` are reordered depending on locale.

POSIX says: "When using sort to process pathnames, it is recommended that LC_ALL, or at least LC_CTYPE and LC_COLLATE, are set to POSIX or C in the environment, since pathnames can contain byte sequences that do not form valid characters in some locales, in which case the utility's behavior would be undefined. In the POSIX locale each byte is a valid single-byte character, and therefore this problem is avoided."

This was found via the reproducible automated build - which atm has another issue that the build path is put (over and over) in binaries (..a/.o/.so/.cma/.cmt/.cmti/.cmxs), which should be addressed at another point - see [diffoscope OCaml-4.03](https://tests.reproducible-builds.org/debian/rb-pkg/experimental/amd64/diffoscope-results/ocaml.html) (or download the full [140MB diff](https://tests.reproducible-builds.org/debian/dbdtxt/experimental/amd64/ocaml_4.03.0-5.diffoscope.txt) if you like) for details (or some compiler output, e.g. [findlib](https://tests.reproducible-builds.org/debian/rb-pkg/experimental/amd64/diffoscope-results/findlib.html)).  For the full set of differences between reproducible runs, [look here](https://tests.reproducible-builds.org/debian/index_variations.html).

I have no access to MS Windows (neither MacOSX) equipment

Credits for @infinity0 and @gasche for poking me investigating and submitting a PR here.