### PR TITLE
Fix implicit function declaration warning in bytern/fix_code.c.

### DIFF
--- a/byterun/fix_code.c
+++ b/byterun/fix_code.c
@@ -21,6 +21,8 @@
 
 #ifdef HAS_UNISTD
 #include <unistd.h>
+#else
+#include <io.h>
 #endif
 
 #include "caml/debugger.h"


### PR DESCRIPTION
The read function was not declared on systems where unistd.h is not
available.