### PR TITLE
PR#7405: s390x: Fix address of caml_raise_exn in native dynlink modules.

### DIFF
--- a/Changes
+++ b/Changes
@@ -77,6 +77,9 @@ Next version (4.05.0):
 
 ### Bug fixes
 
+- PR#7405, GPR#903: s390x: Fix address of caml_raise_exn in native dynlink modules
+  (Richard Jones, review by Xavier Leroy)
+
 - GPR#795: remove 256-character limitation on Sys.executable_name
   (Xavier Leroy)
 

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -611,7 +611,7 @@ let emit_instr i =
     | Lraise k ->
         begin match k with
         | Cmm.Raise_withtrace ->
-          `	brasl	%r14, {emit_symbol "caml_raise_exn"}\n`;
+          `	{emit_call "caml_raise_exn"}\n`;
           let lbl = record_frame Reg.Set.empty true i.dbg in
           `{emit_label lbl}:\n`
         | Cmm.Raise_notrace ->


### PR DESCRIPTION
See [PR#7405](https://caml.inria.fr/mantis/view.php?id=7405)

This commit comes from Fedora patch [e732c39340e86939530a087744caa8d8f1247878](https://git.fedorahosted.org/cgit/fedora-ocaml.git/commit/?h=fedora-26-4.04.0&id=e732c39340e86939530a087744caa8d8f1247878).
