### PR TITLE
Expose function to map from Lambda's structured constants to Obj.t.

### DIFF
--- a/bytecomp/symtable.mli
+++ b/bytecomp/symtable.mli
@@ -29,6 +29,7 @@ val output_primitive_names: out_channel -> unit
 val output_primitive_table: out_channel -> unit
 val data_global_map: unit -> Obj.t
 val data_primitive_names: unit -> string
+val transl_const: Lambda.structured_constant -> Obj.t
 
 (* Functions for the toplevel *)
 


### PR DESCRIPTION
Useful for the js_of_ocaml compiler, which currently maintains a local copy:

https://github.com/ocsigen/js_of_ocaml/blob/master/compiler/lib/util.cppo.ml#L458

cc @hhugo