### PR TITLE
Fix the way the ocamldoc bytecode executable is called under Windows.

### DIFF
--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -63,7 +63,7 @@ ifeq "$(UNIX_OR_WIN32)" "unix"
     OCAMLDOC_RUN=$(OCAMLRUN) ./$(OCAMLDOC)
   endif
 else # Windows
-  OCAMLDOC_RUN = PATH="$$PATH":"$(abspath $(ROOTDIR))/otherlibs/$(UNIXLIB)":"$(abspath $(ROOTDIR))/otherlibs/str" $(OCAMLRUN) ./$(OCAMLDOC)
+  OCAMLDOC_RUN = CAML_LD_LIBRARY_PATH="../otherlibs/win32unix;../otherlibs/str" $(OCAMLRUN) ./$(OCAMLDOC)
 endif
 
 OCAMLDOC_OPT=$(OCAMLDOC).opt


### PR DESCRIPTION
This is a follow-up to PR #808. More specifically, it fixes the problem
reported by @alainfrisch at
https://github.com/ocaml/ocaml/pull/808#issuecomment-257364340

Many thanks to him for having both reported the issue and suggested a fix.