### PR TITLE
INSTALL.adoc: explain why configure looks for the curses library.

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -54,6 +54,8 @@ The `configure` script accepts the following options:
 
 `-no-curses`::
         Do not use the curses library.
+        The only use for this is to highlight errors in the toplevel using
+        'standout' mode, e.g. underline, rather than with '^' on a newline.
 
 `-host <hosttype>`::                (default: determined automatically)
         The type of the host machine, in GNU's "configuration name" format


### PR DESCRIPTION
Hint: it is used in the toplevel to highlight errors using something nicer
than a bunch of (slightly-misaligned) '^' on a new line.

NB: $curseslibs ends up in $BYTECCLIBS and we probably link against curses
in the bytecode runtime while we only need it for the toplevel.