### PR TITLE
make the CI test for a Changes entry non-optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,4 @@ matrix:
   - env: CI_KIND=changes
   - env: CI_KIND=tests
   allow_failures:
-  - env: CI_KIND=changes
   - env: CI_KIND=tests


### PR DESCRIPTION
Travis CI (Continuous Integration) tests provide feedback to people
contributing patches and pull requests. There has long been a test
checking that the Changes file is modified by the PR (along with
a test checking that the testsuite is modified), but it was marked
optional (`allow_failures`) and not reported in a clear way at all.

(In theory all user-visible or contributor-visible changes should get
a Changes entry. There are some cases of minor changes, or changes
that affect features not present in a released version, where not
having a dedicated changelog entry is ok.)

There are two cases where forgetting to include something in the
Changes has been problematic:
- inline records were originally not part of the 4.03 Changelog
  (we caught the error as I gave a talk on new 4.03 features and
  Alain gently asked why I left inline records out of the discussion)
- recently GPR #674 was forgotten from the Changelog

If we make the Change mandatory in the CI, it is because without it
there is no clear notification than it fails. It does not mean that
having a Changelog entry is now mandatory, and it's just fine to keep
deciding on a case-by-case basis not to have an entry. It's just that
we would make that choice voluntarily, instead of out of distraction.