### PR TITLE
Fix segfault in Unix.create_process on Windows 10

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,10 @@ Next version (4.04.1):
 - PR#7405, GPR#903: s390x: Fix address of caml_raise_exn in native dynlink modules
   (Richard Jones, review by Xavier Leroy)
 
+- GPR#912: Fix segfault in Unix.create_process on Windows caused by wrong header
+  configuration.
+  (David Allsopp)
+
 OCaml 4.04.0 (4 Nov 2016):
 --------------------------
 

--- a/otherlibs/win32unix/createprocess.c
+++ b/otherlibs/win32unix/createprocess.c
@@ -13,6 +13,8 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
+
 #include <caml/mlvalues.h>
 #include "unixsupport.h"
 #include <windows.h>


### PR DESCRIPTION
#656 didn't add `#define CAML_INTERNALS` to the top of otherlibs/win32unix/createprocess.c which means that its import of `search_exe_in_path` gets a default definition meaning it gets a default return type of `int` instead of `char *` (certainly MSVC emits a warning - I didn't look at gcc).

This appears to be innocuous on Windows 7, but on Windows 10 its causing segfaults (lib-scanf-2 and all the debugger tests failing).

This should probably be pushed to 4.04 as well? (@damiendoligez ?)