### PR TITLE
more -dsource bug fix

### DIFF
--- a/.depend
+++ b/.depend
@@ -48,12 +48,13 @@ utils/warnings.cmx : utils/misc.cmx utils/warnings.cmi
 utils/warnings.cmi :
 parsing/ast_helper.cmo : parsing/parsetree.cmi parsing/longident.cmi \
     parsing/location.cmi parsing/docstrings.cmi parsing/asttypes.cmi \
-    parsing/ast_helper.cmi
+    parsing/syntaxerr.cmi parsing/ast_helper.cmi
 parsing/ast_helper.cmx : parsing/parsetree.cmi parsing/longident.cmx \
     parsing/location.cmx parsing/docstrings.cmx parsing/asttypes.cmi \
-    parsing/ast_helper.cmi
+    parsing/syntaxerr.cmx parsing/ast_helper.cmi
 parsing/ast_helper.cmi : parsing/parsetree.cmi parsing/longident.cmi \
-    parsing/location.cmi parsing/docstrings.cmi parsing/asttypes.cmi
+    parsing/location.cmi parsing/docstrings.cmi \
+    parsing/syntaxerr.cmi parsing/asttypes.cmi
 parsing/ast_invariants.cmo : parsing/syntaxerr.cmi parsing/parsetree.cmi \
     parsing/longident.cmi parsing/builtin_attributes.cmi parsing/asttypes.cmi \
     parsing/ast_iterator.cmi parsing/ast_invariants.cmi
@@ -136,10 +137,10 @@ parsing/parsetree.cmi : parsing/longident.cmi parsing/location.cmi \
     parsing/asttypes.cmi
 parsing/pprintast.cmo : parsing/parsetree.cmi utils/misc.cmi \
     parsing/longident.cmi parsing/location.cmi parsing/asttypes.cmi \
-    parsing/pprintast.cmi
+    parsing/ast_helper.cmi parsing/pprintast.cmi
 parsing/pprintast.cmx : parsing/parsetree.cmi utils/misc.cmx \
     parsing/longident.cmx parsing/location.cmx parsing/asttypes.cmi \
-    parsing/pprintast.cmi
+    parsing/ast_helper.cmx parsing/pprintast.cmi
 parsing/pprintast.cmi : parsing/parsetree.cmi
 parsing/printast.cmo : parsing/parsetree.cmi utils/misc.cmi \
     parsing/longident.cmi parsing/location.cmi parsing/asttypes.cmi \

--- a/Changes
+++ b/Changes
@@ -94,6 +94,8 @@ Next version (4.05.0):
   list in .cmti files + avoid rebuilding cmi_info record when creating
   .cmti files
   (Alain Frisch, report by Daniel Bunzli, review by Jeremie Dimino)
+- GPR#915: fix -dsource (pprintast.ml) bugs
+  (Runhang Li, review by Alain Frisch)
 
 ### Bug fixes
 

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -51,8 +51,8 @@ UTILS=utils/config.cmo utils/misc.cmo \
   utils/targetint.cmo
 
 PARSING=parsing/location.cmo parsing/longident.cmo \
-  parsing/docstrings.cmo parsing/ast_helper.cmo \
-  parsing/syntaxerr.cmo parsing/parser.cmo \
+  parsing/docstrings.cmo parsing/syntaxerr.cmo \
+  parsing/ast_helper.cmo parsing/parser.cmo \
   parsing/lexer.cmo parsing/parse.cmo parsing/printast.cmo \
   parsing/pprintast.cmo \
   parsing/ast_mapper.cmo parsing/ast_iterator.cmo parsing/attr_helper.cmo \

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -41,6 +41,7 @@ OTHEROBJS=\
   ../utils/consistbl.cmo ../utils/warnings.cmo \
   ../utils/terminfo.cmo \
   ../parsing/location.cmo ../parsing/longident.cmo ../parsing/docstrings.cmo \
+  ../parsing/syntaxerr.cmo \
   ../parsing/ast_helper.cmo ../parsing/ast_mapper.cmo \
   ../parsing/ast_iterator.cmo ../parsing/attr_helper.cmo \
   ../parsing/builtin_attributes.cmo \

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -45,7 +45,8 @@ COMPILEROBJS=\
   ../../utils/terminfo.cmo ../../utils/warnings.cmo \
   ../../parsing/asttypes.cmi \
   ../../parsing/location.cmo ../../parsing/longident.cmo \
-  ../../parsing/docstrings.cmo ../../parsing/ast_helper.cmo \
+  ../../parsing/docstrings.cmo ../../parsing/syntaxerr.cmo \
+  ../../parsing/ast_helper.cmo \
   ../../parsing/ast_mapper.cmo ../../parsing/ast_iterator.cmo \
   ../../parsing/attr_helper.cmo \
   ../../parsing/builtin_attributes.cmo \

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -75,6 +75,13 @@ module Typ :
     val force_poly: core_type -> core_type
 
     val varify_constructors: str list -> core_type -> core_type
+    (** [varify_constructors newtypes te] is type expression [te], of which
+        any of nullary type constructor [tc] is replaced by type variable of
+        the same name, if [tc]'s name appears in [newtypes].
+        Raise [Syntaxerr.Variable_in_scope] if any type variable inside [te]
+        appears in [newtypes].
+        @since 4.05
+     *)
   end
 
 (** Patterns *)

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -73,6 +73,8 @@ module Typ :
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> core_type
 
     val force_poly: core_type -> core_type
+
+    val varify_constructors: str list -> core_type -> core_type
   end
 
 (** Patterns *)

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -219,56 +219,6 @@ let exp_of_label lbl pos =
 let pat_of_label lbl pos =
   mkpat (Ppat_var (mkrhs (Longident.last lbl) pos))
 
-let check_variable vl loc v =
-  if List.mem v vl then
-    raise Syntaxerr.(Error(Variable_in_scope(loc,v)))
-
-let varify_constructors var_names t =
-  let var_names = List.map (fun v -> v.txt) var_names in
-  let rec loop t =
-    let desc =
-      match t.ptyp_desc with
-      | Ptyp_any -> Ptyp_any
-      | Ptyp_var x ->
-          check_variable var_names t.ptyp_loc x;
-          Ptyp_var x
-      | Ptyp_arrow (label,core_type,core_type') ->
-          Ptyp_arrow(label, loop core_type, loop core_type')
-      | Ptyp_tuple lst -> Ptyp_tuple (List.map loop lst)
-      | Ptyp_constr( { txt = Lident s }, []) when List.mem s var_names ->
-          Ptyp_var s
-      | Ptyp_constr(longident, lst) ->
-          Ptyp_constr(longident, List.map loop lst)
-      | Ptyp_object (lst, o) ->
-          Ptyp_object
-            (List.map (fun (s, attrs, t) -> (s, attrs, loop t)) lst, o)
-      | Ptyp_class (longident, lst) ->
-          Ptyp_class (longident, List.map loop lst)
-      | Ptyp_alias(core_type, string) ->
-          check_variable var_names t.ptyp_loc string;
-          Ptyp_alias(loop core_type, string)
-      | Ptyp_variant(row_field_list, flag, lbl_lst_option) ->
-          Ptyp_variant(List.map loop_row_field row_field_list,
-                       flag, lbl_lst_option)
-      | Ptyp_poly(string_lst, core_type) ->
-        List.iter (fun v ->
-          check_variable var_names t.ptyp_loc v.txt) string_lst;
-          Ptyp_poly(string_lst, loop core_type)
-      | Ptyp_package(longident,lst) ->
-          Ptyp_package(longident,List.map (fun (n,typ) -> (n,loop typ) ) lst)
-      | Ptyp_extension (s, arg) ->
-          Ptyp_extension (s, arg)
-    in
-    {t with ptyp_desc = desc}
-  and loop_row_field  =
-    function
-      | Rtag(label,attrs,flag,lst) ->
-          Rtag(label,attrs,flag,List.map loop lst)
-      | Rinherit t ->
-          Rinherit (loop t)
-  in
-  loop t
-
 let mk_newtypes newtypes exp =
   List.fold_right (fun newtype exp -> mkexp (Pexp_newtype (newtype, exp)))
     newtypes exp
@@ -276,7 +226,7 @@ let mk_newtypes newtypes exp =
 let wrap_type_annotation newtypes core_type body =
   let exp = mkexp(Pexp_constraint(body,core_type)) in
   let exp = mk_newtypes newtypes exp in
-  (exp, ghtyp(Ptyp_poly(newtypes,varify_constructors newtypes core_type)))
+  (exp, ghtyp(Ptyp_poly(newtypes, Typ.varify_constructors newtypes core_type)))
 
 let wrap_exp_attrs body (ext, attrs) =
   (* todo: keep exact location for the entire attribute *)

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -839,7 +839,7 @@ and class_field ctxt f x =
            | Pexp_poly (e, Some ct) ->
                pp f "%s :@;%a=@;%a"
                  s.txt (core_type ctxt) ct (expression ctxt) e
-           | Pexp_poly (e,None) -> bind e
+           | Pexp_poly (e, None) -> bind e
            | _ -> bind e) e
         (item_attributes ctxt) x.pcf_attributes
   | Pcf_constraint (ct1, ct2) ->
@@ -1093,9 +1093,11 @@ and binding ctxt f {pvb_pat=p; pvb_expr=x; _} =
             pp f "(%a@;:@;%a)@;=@;%a" (simple_pattern ctxt) p
               (core_type ctxt) ty (expression ctxt) x
         end
+(*
     | Pexp_constraint (e,t1),Ppat_var {txt;_} ->
       pp f "%a@;:@ %a@;=@;%a" protect_ident txt
         (core_type ctxt) t1 (expression ctxt) e
+*)
     | (_, Ppat_var _) ->
         pp f "%a@ %a" (simple_pattern ctxt) p pp_print_pexp_function x
     | _ ->

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7238,13 +7238,11 @@ class id = [%exp]
 let _ = fun (x : < x : int >) y z -> (y :> 'a), (x :> 'a), (z :> 'a);;
 (* - : (< x : int > as 'a) -> 'a -> 'a * 'a = <fun> *)
 
-(*
 class ['a] c () = object
   method f = (new c (): int c)
 end and ['a] d () = object
   inherit ['a] c ()
 end;;
-*)
 
 (* PR#7329 Pattern open *)
 let _ =
@@ -7254,3 +7252,8 @@ let _ =
   let h = function M.[] | M.[a] | M.(a::q) -> () in
   let i = function M.[||] | M.[|x|]  -> true | _ -> false in
   ()
+
+class ['a] c () = object
+  constraint 'a = < .. > -> unit
+  method m  = (fun x -> () : 'a)
+end

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7257,3 +7257,9 @@ class ['a] c () = object
   constraint 'a = < .. > -> unit
   method m  = (fun x -> () : 'a)
 end
+
+let f: type a'.a' = assert false
+let foo : type a' b'. a' -> b' = fun a -> assert false
+let foo : type t' . t' = fun (type t') -> (assert false : t')
+let foo : 't . 't = fun (type t) -> (assert false : t)
+let foo : type a' b' c' t. a' -> b' -> c' -> t = fun a b c -> assert false


### PR DESCRIPTION
This PR is a follow-up of https://github.com/ocaml/ocaml/pull/539, which aims to fix two more corner case `-dsource`([pprintast.ml](https://github.com/ocaml/ocaml/blob/trunk/parsing/pprintast.ml)) bugs. 

Cf. [Mantis 7200](https://caml.inria.fr/mantis/view.php?id=7200)

### Bug 1: GADT exp

Parse tree of `let f: type a'.a' = assert false` is incorrectly printed to `let f : 'a' . 'a' = fun (type a') -> (assert false : a')`. This bug happens since `a'` is a valid new type name according to [lexing rule](https://github.com/ocaml/ocaml/blob/trunk/parsing/lexer.mll#L340)

**Solution**: _really_ pretty-print GADT let-expression by restoring the desugared GADT let-expression. After this PR, the above example will have output `let f : type a'.a' = assert false`

### Bug 2: Polymorphic method

Parse tree of

```OCaml
class ['a] c () = object
  constraint 'a = < .. > -> unit
  method m  = (fun x -> () : 'a)
end
```

is incorrectly printed to

```OCaml
class ['a] c () =
  object constraint 'a = < .. > -> unit method m : 'a = fun x  -> () end
```

This is wrong because now two classes have different signatures. The input has signatures

```OCaml
class ['a] c : unit ->
  object constraint 'a = (< .. > as 'b) -> unit method m : 'b -> unit end
```

but the output has
```OCaml
class ['a] c :
    unit -> object constraint 'a = (< .. > as 'b) -> unit method m : 'a end
```

**Solution**: delete the part that incorrectly optimizes pretty-printing in this situation.

```diff
-    | Pexp_constraint (e,t1),Ppat_var {txt;_} ->
-      pp f "%a@;:@ %a@;=@;%a" protect_ident txt
-        (core_type ctxt) t1 (expression ctxt) e
```

cc @alainfrisch 