### PR TITLE
Fix function label: UnixLabels.sendto_substring s/bug/buf

### DIFF
--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -1040,7 +1040,7 @@ val sendto :
 (** Send data over an unconnected socket. *)
 
 val sendto_substring :
-  file_descr -> bug:string -> pos:int -> len:int -> mode:msg_flag list
+  file_descr -> buf:string -> pos:int -> len:int -> mode:msg_flag list
   -> sockaddr -> int
 (** Same as [sendto], but take the data from a string instead of a
     byte sequence. *)


### PR DESCRIPTION
A label called `~bug` is likely a typo, I noticed this while working on https://github.com/ocaml/ocaml/pull/916

Since this changes the actual interface should I add a ChangeLog entry too?