### PR TITLE
Runtime: fixed a couple of use-after-free errors

### DIFF
--- a/byterun/startup.c
+++ b/byterun/startup.c
@@ -319,7 +319,6 @@ CAMLexport void caml_main(char **argv)
   if (fd < 0 && (proc_self_exe = caml_executable_name()) != NULL) {
     exe_name = proc_self_exe;
     fd = caml_attempt_open(&exe_name, &trail, 0);
-    caml_stat_free(proc_self_exe);
   }
 
   if (fd < 0) {

--- a/byterun/startup.c
+++ b/byterun/startup.c
@@ -460,7 +460,6 @@ CAMLexport void caml_startup_code(
   caml_section_table_size = section_table_size;
   /* Initialize system libraries */
   caml_sys_init(exe_name, argv);
-  caml_stat_free(exe_name);
   /* Execute the program */
   caml_debugger(PROGRAM_START);
   res = caml_interprete(caml_start_code, caml_code_size);


### PR DESCRIPTION
Just a couple of trivial mishaps that were introduced in #795. Found this with Valgrind while testing #71.