### PR TITLE
Test for ccfamily for preprocessed as.

### DIFF
--- a/Changes
+++ b/Changes
@@ -89,6 +89,9 @@ Next version (4.05.0):
 
 ### Compiler distribution build system:
 
+- GPR#919: use clang as preprocessor assembler if clang is used as compiler
+  (Bernhard Schommer)
+
 - GPR#927: improve the detection of hashbang support in the configure script
   (Armaël Guéneau)
 

--- a/configure
+++ b/configure
@@ -1015,7 +1015,14 @@ case "$arch,$system" in
                   aspp="${TOOLPREF}cc -c";;
   amd64,*|arm,*|arm64,*|i386,*|power,bsd*|sparc,*)
                   as="${TOOLPREF}as"
-                  aspp="${TOOLPREF}gcc -c";;
+                  case "$ccfamily" in
+                      clang-*)
+                          aspp="${TOOLPREF}clang -c"
+                          ;;
+                      *)
+                          aspp="${TOOLPREF}gcc -c"
+                          ;;
+                  esac;;
 esac
 
 if test -n "$asoption"; then as="$asoption"; fi


### PR DESCRIPTION
If clang is used instead of gcc to compile ocaml gcc is still
used as assembler preprocessor.