### PR TITLE
Add GPR#247 to Changes

### DIFF
--- a/Changes
+++ b/Changes
@@ -300,6 +300,14 @@ OCaml 4.04.0 (4 Nov 2016):
   are registered with `GC.finalise_last`
   (François Bobot reviewed by Damien Doligez and Leo White)
 
+- GPR#247: In previous OCaml versions, inlining caused stack frames to
+  disappear from stacktraces. This made debugging harder in presence of
+  optimizations, and flambda was going to make this worse. The debugging
+  information produced by the compiler now enables the reconstruction of the
+  original backtrace. Use `Printexc.get_raw_backtrace_next_slot` to traverse
+  the list of inlined stack frames.
+  (Frédéric Bour, review by Mark Shinwell and Xavier Leroy)
+
 - GPR#590: Do not perform compaction if the real overhead is less than expected
   (Thomas Braibant)
 

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -289,6 +289,22 @@ val get_raw_backtrace_next_slot :
     raw_backtrace_slot -> raw_backtrace_slot option
 (** [get_raw_backtrace_next_slot slot] returns the next slot inlined, if any.
 
+    Sample code to iterate over all frames (inlined and non-inlined):
+    {|
+      (* Iterate over inlined frames *)
+      let rec iter_raw_backtrace_slot f slot =
+        f slot;
+        match get_raw_backtrace_next_slot slot with
+        | None -> ()
+        | Some slot' -> iter_raw_backtrace_slot f slot'
+
+      (* Iterate over stack frames *)
+      let iter_raw_backtrace f bt =
+        for i = 0 to raw_backtrace_length bt - 1 do
+          iter_raw_backtrace_slot f (get_raw_backtrace_slot bt i)
+        done
+    |}
+
     @since 4.04.0
 *)
 


### PR DESCRIPTION
I didn't update the changelog in the GPR, so this comes a bit late.

The addition of a small example in `Printexc.mli` was suggested by @gasche to make the primitive easier to understand.