### PR TITLE
Correct documentation and behaviour of index_from and rindex_from

### DIFF
--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -234,12 +234,12 @@ let index_opt s c = index_rec_opt s (length s) 0 c
 
 let index_from s i c =
   let l = length s in
-  if i < 0 || i > l then invalid_arg "String.index_from / Bytes.index_from" else
+  if i < 0 || i >= l then invalid_arg "String.index_from / Bytes.index_from" else
   index_rec s l i c
 
 let index_from_opt s i c =
   let l = length s in
-  if i < 0 || i > l then invalid_arg "String.index_from_opt / Bytes.index_from_opt" else
+  if i < 0 || i >= l then invalid_arg "String.index_from_opt / Bytes.index_from_opt" else
   index_rec_opt s l i c
 
 let rec rindex_rec s i c =
@@ -249,7 +249,7 @@ let rec rindex_rec s i c =
 let rindex s c = rindex_rec s (length s - 1) c
 
 let rindex_from s i c =
-  if i < -1 || i >= length s then
+  if i < 0 || i >= length s then
     invalid_arg "String.rindex_from / Bytes.rindex_from"
   else
     rindex_rec s i c
@@ -261,7 +261,7 @@ let rec rindex_rec_opt s i c =
 let rindex_opt s c = rindex_rec_opt s (length s - 1) c
 
 let rindex_from_opt s i c =
-  if i < -1 || i >= length s then
+  if i < 0 || i >= length s then
     invalid_arg "String.rindex_from_opt / Bytes.rindex_from_opt"
   else
     rindex_rec_opt s i c

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -211,7 +211,7 @@ val rindex_opt: bytes -> char -> int option
 
 val index_from : bytes -> int -> char -> int
 (** [index_from s i c] returns the index of the first occurrence of
-    byte [c] in [s] after position [i].  [Bytes.index s c] is
+    byte [c] in [s] starting from position [i].  [Bytes.index s c] is
     equivalent to [Bytes.index_from s 0 c].
 
     Raise [Invalid_argument] if [i] is not a valid position in [s].
@@ -219,7 +219,8 @@ val index_from : bytes -> int -> char -> int
 
 val index_from_opt: bytes -> int -> char -> int option
 (** [index_from _opts i c] returns the index of the first occurrence of
-    byte [c] in [s] after position [i] or [None] if [c] does not occur in [s] after position [i].
+    byte [c] in [s] starting from position [i]
+    or [None] if [c] does not occur in [s] starting from position [i].
     [Bytes.index_opt s c] is equivalent to [Bytes.index_from_opt s 0 c].
 
     Raise [Invalid_argument] if [i] is not a valid position in [s].
@@ -230,7 +231,7 @@ val rindex_from : bytes -> int -> char -> int
     byte [c] in [s] before position [i+1].  [rindex s c] is equivalent
     to [rindex_from s (Bytes.length s - 1) c].
 
-    Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+    Raise [Invalid_argument] if [i] is not a valid position in [s].
     Raise [Not_found] if [c] does not occur in [s] before position [i+1]. *)
 
 val rindex_from_opt: bytes -> int -> char -> int option
@@ -239,7 +240,7 @@ val rindex_from_opt: bytes -> int -> char -> int option
     occur in [s] before position [i+1].  [rindex_opt s c] is equivalent to
     [rindex_from s (Bytes.length s - 1) c].
 
-    Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+    Raise [Invalid_argument] if [i] is not a valid position in [s].
     @since 4.05 *)
 
 val contains : bytes -> char -> bool

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -211,16 +211,16 @@ val rindex_opt: bytes -> char -> int option
 
 val index_from : bytes -> int -> char -> int
 (** [index_from s i c] returns the index of the first occurrence of
-    byte [c] in [s] starting from position [i].  [Bytes.index s c] is
+    byte [c] in [s] at or after position [i].  [Bytes.index s c] is
     equivalent to [Bytes.index_from s 0 c].
 
     Raise [Invalid_argument] if [i] is not a valid position in [s].
-    Raise [Not_found] if [c] does not occur in [s] after position [i]. *)
+    Raise [Not_found] if [c] does not occur in [s] at or after position [i]. *)
 
 val index_from_opt: bytes -> int -> char -> int option
 (** [index_from _opts i c] returns the index of the first occurrence of
-    byte [c] in [s] starting from position [i]
-    or [None] if [c] does not occur in [s] starting from position [i].
+    byte [c] in [s] at or after position [i]
+    or [None] if [c] does not occur in [s] at or after position [i].
     [Bytes.index_opt s c] is equivalent to [Bytes.index_from_opt s 0 c].
 
     Raise [Invalid_argument] if [i] is not a valid position in [s].
@@ -228,16 +228,16 @@ val index_from_opt: bytes -> int -> char -> int option
 
 val rindex_from : bytes -> int -> char -> int
 (** [rindex_from s i c] returns the index of the last occurrence of
-    byte [c] in [s] before position [i+1].  [rindex s c] is equivalent
+    byte [c] in [s] at or before position [i].  [rindex s c] is equivalent
     to [rindex_from s (Bytes.length s - 1) c].
 
     Raise [Invalid_argument] if [i] is not a valid position in [s].
-    Raise [Not_found] if [c] does not occur in [s] before position [i+1]. *)
+    Raise [Not_found] if [c] does not occur in [s] at or before position [i]. *)
 
 val rindex_from_opt: bytes -> int -> char -> int option
 (** [rindex_from_opt s i c] returns the index of the last occurrence
-    of byte [c] in [s] before position [i+1] or [None] if [c] does not
-    occur in [s] before position [i+1].  [rindex_opt s c] is equivalent to
+    of byte [c] in [s] at or before position [i] or [None] if [c] does not
+    occur in [s] at or before position [i].  [rindex_opt s c] is equivalent to
     [rindex_from s (Bytes.length s - 1) c].
 
     Raise [Invalid_argument] if [i] is not a valid position in [s].

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -154,15 +154,16 @@ val rindex_opt: bytes -> char -> int option
 
 val index_from : bytes -> int -> char -> int
 (** [index_from s i c] returns the index of the first occurrence of
-    byte [c] in [s] after position [i].  [Bytes.index s c] is
+    byte [c] in [s] starting from position [i].  [Bytes.index s c] is
     equivalent to [Bytes.index_from s 0 c].
 
     Raise [Invalid_argument] if [i] is not a valid position in [s].
-    Raise [Not_found] if [c] does not occur in [s] after position [i]. *)
+    Raise [Not_found] if [c] does not occur in [s] starting from position [i]. *)
 
 val index_from_opt: bytes -> int -> char -> int option
 (** [index_from _opts i c] returns the index of the first occurrence of
-    byte [c] in [s] after position [i] or [None] if [c] does not occur in [s] after position [i].
+    byte [c] in [s] starting from position [i]
+    or [None] if [c] does not occur in [s] starting from position [i].
     [Bytes.index_opt s c] is equivalent to [Bytes.index_from_opt s 0 c].
 
     Raise [Invalid_argument] if [i] is not a valid position in [s].
@@ -173,7 +174,7 @@ val rindex_from : bytes -> int -> char -> int
     byte [c] in [s] before position [i+1].  [rindex s c] is equivalent
     to [rindex_from s (Bytes.length s - 1) c].
 
-    Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+    Raise [Invalid_argument] if [i] is not a valid position in [s].
     Raise [Not_found] if [c] does not occur in [s] before position [i+1]. *)
 
 val rindex_from_opt: bytes -> int -> char -> int option
@@ -182,7 +183,7 @@ val rindex_from_opt: bytes -> int -> char -> int option
     occur in [s] before position [i+1].  [rindex_opt s c] is equivalent to
     [rindex_from s (Bytes.length s - 1) c].
 
-    Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+    Raise [Invalid_argument] if [i] is not a valid position in [s].
     @since 4.05 *)
 
 val contains : bytes -> char -> bool

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -154,16 +154,16 @@ val rindex_opt: bytes -> char -> int option
 
 val index_from : bytes -> int -> char -> int
 (** [index_from s i c] returns the index of the first occurrence of
-    byte [c] in [s] starting from position [i].  [Bytes.index s c] is
+    byte [c] in [s] at or after position [i].  [Bytes.index s c] is
     equivalent to [Bytes.index_from s 0 c].
 
     Raise [Invalid_argument] if [i] is not a valid position in [s].
-    Raise [Not_found] if [c] does not occur in [s] starting from position [i]. *)
+    Raise [Not_found] if [c] does not occur in [s] at or after position [i]. *)
 
 val index_from_opt: bytes -> int -> char -> int option
 (** [index_from _opts i c] returns the index of the first occurrence of
-    byte [c] in [s] starting from position [i]
-    or [None] if [c] does not occur in [s] starting from position [i].
+    byte [c] in [s] at or after position [i]
+    or [None] if [c] does not occur in [s] at or after position [i].
     [Bytes.index_opt s c] is equivalent to [Bytes.index_from_opt s 0 c].
 
     Raise [Invalid_argument] if [i] is not a valid position in [s].
@@ -171,11 +171,11 @@ val index_from_opt: bytes -> int -> char -> int option
 
 val rindex_from : bytes -> int -> char -> int
 (** [rindex_from s i c] returns the index of the last occurrence of
-    byte [c] in [s] before position [i+1].  [rindex s c] is equivalent
+    byte [c] in [s] at or before position [i].  [rindex s c] is equivalent
     to [rindex_from s (Bytes.length s - 1) c].
 
     Raise [Invalid_argument] if [i] is not a valid position in [s].
-    Raise [Not_found] if [c] does not occur in [s] before position [i+1]. *)
+    Raise [Not_found] if [c] does not occur in [s] at or before position [i]. *)
 
 val rindex_from_opt: bytes -> int -> char -> int option
 (** [rindex_from_opt s i c] returns the index of the last occurrence

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -201,16 +201,16 @@ val rindex_opt: string -> char -> int option
 
 val index_from : string -> int -> char -> int
 (** [String.index_from s i c] returns the index of the
-   first occurrence of character [c] in string [s] starting from position [i].
+    first occurrence of character [c] in string [s] at or after position [i].
    [String.index s c] is equivalent to [String.index_from s 0 c].
 
    Raise [Invalid_argument] if [i] is not a valid position in [s].
-   Raise [Not_found] if [c] does not occur in [s] starting from position [i]. *)
+   Raise [Not_found] if [c] does not occur in [s] at or after position [i]. *)
 
 val index_from_opt: string -> int -> char -> int option
 (** [String.index_from_opt s i c] returns the index of the
-    first occurrence of character [c] in string [s] starting from position [i]
-    or [None] if [c] does not occur in [s] starting from position [i].
+    first occurrence of character [c] in string [s] at or after position [i]
+    or [None] if [c] does not occur in [s] at or after position [i].
 
     [String.index_opt s c] is equivalent to [String.index_from_opt s 0 c].
     Raise [Invalid_argument] if [i] is not a valid position in [s].
@@ -220,17 +220,17 @@ val index_from_opt: string -> int -> char -> int option
 
 val rindex_from : string -> int -> char -> int
 (** [String.rindex_from s i c] returns the index of the
-   last occurrence of character [c] in string [s] before position [i+1].
+   last occurrence of character [c] in string [s] at or before position [i].
    [String.rindex s c] is equivalent to
    [String.rindex_from s (String.length s - 1) c].
 
    Raise [Invalid_argument] if [i] is not a valid position in [s].
-   Raise [Not_found] if [c] does not occur in [s] before position [i+1]. *)
+   Raise [Not_found] if [c] does not occur in [s] at or before position [i]. *)
 
 val rindex_from_opt: string -> int -> char -> int option
 (** [String.rindex_from_opt s i c] returns the index of the
-   last occurrence of character [c] in string [s] before position [i+1]
-   or [None] if [c] does not occur in [s] before position [i+1].
+   last occurrence of character [c] in string [s] at or before position [i]
+   or [None] if [c] does not occur in [s] at or before position [i].
 
    [String.rindex_opt s c] is equivalent to
    [String.rindex_from_opt s (String.length s - 1) c].

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -201,16 +201,16 @@ val rindex_opt: string -> char -> int option
 
 val index_from : string -> int -> char -> int
 (** [String.index_from s i c] returns the index of the
-   first occurrence of character [c] in string [s] after position [i].
+   first occurrence of character [c] in string [s] starting from position [i].
    [String.index s c] is equivalent to [String.index_from s 0 c].
 
    Raise [Invalid_argument] if [i] is not a valid position in [s].
-   Raise [Not_found] if [c] does not occur in [s] after position [i]. *)
+   Raise [Not_found] if [c] does not occur in [s] starting from position [i]. *)
 
 val index_from_opt: string -> int -> char -> int option
 (** [String.index_from_opt s i c] returns the index of the
-    first occurrence of character [c] in string [s] after position [i]
-    or [None] if [c] does not occur in [s] after position [i].
+    first occurrence of character [c] in string [s] starting from position [i]
+    or [None] if [c] does not occur in [s] starting from position [i].
 
     [String.index_opt s c] is equivalent to [String.index_from_opt s 0 c].
     Raise [Invalid_argument] if [i] is not a valid position in [s].
@@ -224,7 +224,7 @@ val rindex_from : string -> int -> char -> int
    [String.rindex s c] is equivalent to
    [String.rindex_from s (String.length s - 1) c].
 
-   Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+   Raise [Invalid_argument] if [i] is not a valid position in [s].
    Raise [Not_found] if [c] does not occur in [s] before position [i+1]. *)
 
 val rindex_from_opt: string -> int -> char -> int option
@@ -235,7 +235,7 @@ val rindex_from_opt: string -> int -> char -> int option
    [String.rindex_opt s c] is equivalent to
    [String.rindex_from_opt s (String.length s - 1) c].
 
-   Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+   Raise [Invalid_argument] if [i] is not a valid position in [s].
 
     @since 4.05
 *)

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -155,16 +155,16 @@ val rindex_opt: string -> char -> int option
 
 val index_from : string -> int -> char -> int
 (** [String.index_from s i c] returns the index of the
-   first occurrence of character [c] in string [s] starting from position [i].
+   first occurrence of character [c] in string [s] at or after position [i].
    [String.index s c] is equivalent to [String.index_from s 0 c].
 
    Raise [Invalid_argument] if [i] is not a valid position in [s].
-   Raise [Not_found] if [c] does not occur in [s] starting from position [i]. *)
+   Raise [Not_found] if [c] does not occur in [s] at or after position [i]. *)
 
 val index_from_opt: string -> int -> char -> int option
 (** [String.index_from_opt s i c] returns the index of the
-    first occurrence of character [c] in string [s] starting from position [i]
-    or [None] if [c] does not occur in [s] starting from position [i].
+    first occurrence of character [c] in string [s] at or after position [i]
+    or [None] if [c] does not occur in [s] at or after position [i].
 
     [String.index_opt s c] is equivalent to [String.index_from_opt s 0 c].
     Raise [Invalid_argument] if [i] is not a valid position in [s].
@@ -174,17 +174,17 @@ val index_from_opt: string -> int -> char -> int option
 
 val rindex_from : string -> int -> char -> int
 (** [String.rindex_from s i c] returns the index of the
-   last occurrence of character [c] in string [s] before position [i+1].
+   last occurrence of character [c] in string [s] at or before position [i].
    [String.rindex s c] is equivalent to
    [String.rindex_from s (String.length s - 1) c].
 
    Raise [Invalid_argument] if [i] is not a valid position in [s].
-   Raise [Not_found] if [c] does not occur in [s] before position [i+1]. *)
+   Raise [Not_found] if [c] does not occur in [s] at or before position [i]. *)
 
 val rindex_from_opt: string -> int -> char -> int option
 (** [String.rindex_from_opt s i c] returns the index of the
-   last occurrence of character [c] in string [s] before position [i+1]
-   or [None] if [c] does not occur in [s] before position [i+1].
+   last occurrence of character [c] in string [s] at or before position [i]
+   or [None] if [c] does not occur in [s] at or before position [i].
 
    [String.rindex_opt s c] is equivalent to
    [String.rindex_from_opt s (String.length s - 1) c].

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -155,16 +155,16 @@ val rindex_opt: string -> char -> int option
 
 val index_from : string -> int -> char -> int
 (** [String.index_from s i c] returns the index of the
-   first occurrence of character [c] in string [s] after position [i].
+   first occurrence of character [c] in string [s] starting from position [i].
    [String.index s c] is equivalent to [String.index_from s 0 c].
 
    Raise [Invalid_argument] if [i] is not a valid position in [s].
-   Raise [Not_found] if [c] does not occur in [s] after position [i]. *)
+   Raise [Not_found] if [c] does not occur in [s] starting from position [i]. *)
 
 val index_from_opt: string -> int -> char -> int option
 (** [String.index_from_opt s i c] returns the index of the
-    first occurrence of character [c] in string [s] after position [i]
-    or [None] if [c] does not occur in [s] after position [i].
+    first occurrence of character [c] in string [s] starting from position [i]
+    or [None] if [c] does not occur in [s] starting from position [i].
 
     [String.index_opt s c] is equivalent to [String.index_from_opt s 0 c].
     Raise [Invalid_argument] if [i] is not a valid position in [s].
@@ -178,7 +178,7 @@ val rindex_from : string -> int -> char -> int
    [String.rindex s c] is equivalent to
    [String.rindex_from s (String.length s - 1) c].
 
-   Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+   Raise [Invalid_argument] if [i] is not a valid position in [s].
    Raise [Not_found] if [c] does not occur in [s] before position [i+1]. *)
 
 val rindex_from_opt: string -> int -> char -> int option
@@ -189,7 +189,7 @@ val rindex_from_opt: string -> int -> char -> int option
    [String.rindex_opt s c] is equivalent to
    [String.rindex_from_opt s (String.length s - 1) c].
 
-   Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+   Raise [Invalid_argument] if [i] is not a valid position in [s].
 
     @since 4.05
 *)


### PR DESCRIPTION
According to the documentation of `index_from` (in `String`, `Bytes`, `StringLabels` and `BytesLabels`), `index_from s i c` looks for the first occurrence of `c` _after_ position `i`. In reality, position `i` itself is included, so it's not strictly _after_.

Then it says it will raise `Invalid_argument` if `i` is not a valid position. This is indeed what should happen, but when `i = length s` (which is an invalid position), it raises `Not_found` instead.

The documentation of `rindex_from` says `rindex_from s i c` will raise `Invalid_argument` if `i+1` is not a valid position. This not what happens (`i = length s - 1` raises `Not_found`), but I think the correct thing to do is raising `Invalid_argument` if `i` itself is not a valid position.

I corrected the documentation (which is safe I think), and changed the behaviour by raising `Invalid_argument` instead of `Not_found` when necessary (which can be a problem if people relied on this).