### PR TITLE
Improve the detection of hashbang support in the configure script

### DIFF
--- a/Changes
+++ b/Changes
@@ -72,6 +72,9 @@ Next version (4.05.0):
 
 ### Compiler distribution build system:
 
+- GPR#927: improve the detection of hashbang support in the configure script
+  (Armaël Guéneau)
+
 - PR#7377: remove -std=gnu99 for newer gcc versions
   (Damien Doligez, report by ygrek)
 

--- a/config/auto-aux/hashbang3
+++ b/config/auto-aux/hashbang3
@@ -1,0 +1,2 @@
+#! /usr/bin/env cat
+exit 1

--- a/configure
+++ b/configure
@@ -1066,7 +1066,7 @@ echo "#define OCAML_STDLIB_DIR \"$libdir\"" >> s.h
 
 # Do #! scripts work?
 
-if (SHELL=/bin/sh; export SHELL; (./hashbang || ./hashbang2) >/dev/null); then
+if (SHELL=/bin/sh; export SHELL; (./hashbang || ./hashbang2 || ./hashbang3) >/dev/null); then
   inf "#! appears to work in shell scripts."
   case "$target" in
     *-*-sunos*|*-*-unicos*)


### PR DESCRIPTION
(hashbang aka shebang)

In particular, this adds support for systems where the `cat` binary isn't
located in /usr/bin/ or /bin/, but can be found using /usr/bin/env.
An example of such a system is [NixOS](https://nixos.org).