### PR TITLE
Manual(4.04): `;%ext` infix extension node

### DIFF
--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1829,7 +1829,9 @@ end
 \section{Extension nodes}\label{s:extension-nodes}
 
 (Introduced in OCaml 4.02,
-infix notations for constructs other than expressions added in 4.03)
+infix notations for constructs other than expressions added in 4.03,
+infix notation (e1 ;\%ext e2) added in 4.04.
+)
 
 Extension nodes are generic placeholders in the syntax tree. They are
 rejected by the type-checker and are intended to be ``expanded'' by external
@@ -1897,6 +1899,7 @@ Examples:
 \begin{verbatim}
 let%foo x = 2 in x + 1     === [%foo let x = 2 in x + 1]
 begin%foo ... end          === [%foo begin ... end]
+x ;%foo 2                  === [%foo x; 2]
 module%foo M = ..          === [%%foo module M = ... ]
 val%foo x : t              === [%%foo: val x : t]
 \end{verbatim}


### PR DESCRIPTION
This PR adds an example to the 4.04 manual concerning the new infix extension construct `;%ext`
```
x ;%ext y ≡ [%ext x; y]
``` 
since I was not sure that this notation may be easily inferred from the other examples.

Similarly, this PR adds a note at the start of the `extension nodes` section to indicate that this notation was introduced in 4.04.