### PR TITLE
Fix MPR#7414

### DIFF
--- a/Changes
+++ b/Changes
@@ -104,6 +104,9 @@ Next version (4.05.0):
 
 ### Bug fixes
 
+- PR#7414/GPR#929: Soundness bug with non-generalized type variable and functors
+  (Jacques Garrigue, report by Leo White)
+
 - GPR#795: remove 256-character limitation on Sys.executable_name
   (Xavier Leroy)
 

--- a/testsuite/tests/typing-modules-bugs/pr7414_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7414_bad.ml
@@ -1,0 +1,55 @@
+module type T = sig
+  type t
+  val x : t
+  val show : t -> string
+end
+
+module Int = struct
+  type t = int
+  let x = 0
+  let show x = string_of_int x
+end
+
+module String = struct
+  type t = string
+  let x = "Hello"
+  let show x = x
+end
+
+let switch = ref true
+
+module Choose () = struct
+  module Choice =
+    (val if !switch then (module Int : T)
+    else (module String : T))
+  let r = ref (ref [])
+end
+
+module type S = sig
+  module Choice : T
+  val r : Choice.t list ref ref
+end
+
+module Force (X : functor () -> S) = struct end
+
+module M = Choose ()
+
+let () = switch := false
+
+module N = Choose ()
+
+let () = N.r := !M.r
+;;
+
+module Ignore = Force(Choose)
+;; (* fail *)
+
+(* would cause segfault
+module M' = (M : S)
+
+let () = (!M'.r) := [M'.Choice.x]
+
+module N' = (N : S)
+
+let () = List.iter (fun x -> print_string (N'.Choice.show x)) !(!N'.r)
+*)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1383,12 +1383,8 @@ let prefix_idents_and_subst root sub sg =
   let (pl, sub) = prefix_idents root 0 sub sg in
   pl, sub, lazy (subst_signature sub sg)
 
-let set_nongen_level sub path =
-  Subst.set_nongen_level sub (Path.binding_time path - 1)
-
 let prefix_idents_and_subst root sub sg =
-  let sub = set_nongen_level sub root in
-  if sub = set_nongen_level Subst.identity root then
+  if sub = Subst.identity then
     let sgs =
       try
         Hashtbl.find prefixed_sg root
@@ -1506,7 +1502,7 @@ and components_of_module_maker (env, sub, path, mty) =
           (* fcomp_arg and fcomp_res must be prefixed eagerly, because
              they are interpreted in the outer environment *)
           fcomp_arg = may_map (Subst.modtype sub) ty_arg;
-          fcomp_res = Subst.modtype (set_nongen_level sub path) ty_res;
+          fcomp_res = Subst.modtype sub ty_res;
           fcomp_cache = Hashtbl.create 17;
           fcomp_subst_cache = Hashtbl.create 17 }
   | Mty_ident _

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -403,3 +403,20 @@ let remove_aliases env sg =
   (* PathSet.iter (fun p -> Format.eprintf "%a@ " Printtyp.path p) excl;
   Format.eprintf "@."; *)
   remove_aliases env excl sg
+
+
+(* Lower non-generalizable type variables *)
+
+let lower_nongen nglev mty =
+  let open Btype in
+  let it_type_expr it ty =
+    let ty = repr ty in
+    match ty with
+      {desc=Tvar _; level} ->
+        if level < generic_level && level > nglev then set_level ty nglev
+    | _ ->
+        type_iterators.it_type_expr it ty
+  in
+  let it = {type_iterators with it_type_expr} in
+  it.it_module_type it mty;
+  it.it_module_type unmark_iterators mty

--- a/typing/mtype.mli
+++ b/typing/mtype.mli
@@ -42,3 +42,4 @@ val enrich_typedecl: Env.t -> Path.t -> type_declaration -> type_declaration
 val type_paths: Env.t -> Path.t -> module_type -> Path.t list
 val contains_type: Env.t -> module_type -> bool
 val remove_aliases: Env.t -> module_type -> module_type
+val lower_nongen: int -> module_type -> unit

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -544,6 +544,8 @@ let rec tree_of_typexp sch ty =
   let pr_typ () =
     match ty.desc with
     | Tvar _ ->
+        (*let lev =
+          if is_non_gen sch ty then "/" ^ string_of_int ty.level else "" in*)
         Otyp_var (is_non_gen sch ty, name_of_type ty)
     | Tarrow(l, ty1, ty2, _) ->
         let pr_arrow l ty1 ty2 =

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -24,12 +24,11 @@ type t =
   { types: (Ident.t, Path.t) Tbl.t;
     modules: (Ident.t, Path.t) Tbl.t;
     modtypes: (Ident.t, module_type) Tbl.t;
-    for_saving: bool;
-    nongen_level: int }
+    for_saving: bool }
 
 let identity =
   { types = Tbl.empty; modules = Tbl.empty; modtypes = Tbl.empty;
-    for_saving = false; nongen_level = generic_level }
+    for_saving = false }
 
 let add_type id p s = { s with types = Tbl.add id p s.types }
 
@@ -38,8 +37,6 @@ let add_module id p s = { s with modules = Tbl.add id p s.modules }
 let add_modtype id ty s = { s with modtypes = Tbl.add id ty s.modtypes }
 
 let for_saving s = { s with for_saving = true }
-
-let set_nongen_level s lev = { s with nongen_level = lev }
 
 let loc s x =
   if s.for_saving && not !Clflags.keep_locs then Location.none else x
@@ -128,11 +125,7 @@ let rec typexp s ty =
           else newty2 ty.level desc
         in
         save_desc ty desc; ty.desc <- Tsubst ty'; ty'
-      else begin (* when adding a module to the environment *)
-        if ty.level < generic_level then
-          ty.level <- min ty.level s.nongen_level;
-        ty
-      end
+      else ty
   | Tsubst ty ->
       ty
 (* cannot do it, since it would omit subsitution
@@ -436,5 +429,4 @@ let compose s1 s2 =
   { types = merge_tbls (type_path s2) s1.types s2.types;
     modules = merge_tbls (module_path s2) s1.modules s2.modules;
     modtypes = merge_tbls (modtype s2) s1.modtypes s2.modtypes;
-    for_saving = s1.for_saving || s2.for_saving;
-    nongen_level = min s1.nongen_level s2.nongen_level }
+    for_saving = s1.for_saving || s2.for_saving }

--- a/typing/subst.mli
+++ b/typing/subst.mli
@@ -36,7 +36,6 @@ val identity: t
 val add_type: Ident.t -> Path.t -> t -> t
 val add_module: Ident.t -> Path.t -> t -> t
 val add_modtype: Ident.t -> module_type -> t -> t
-val set_nongen_level: t -> int -> t
 val for_saving: t -> t
 val reset_for_saving: unit -> unit
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1291,6 +1291,9 @@ and type_structure ?(toplevel = false) funct_body anchor env sstr scope =
             md_loc = pmb_loc;
           }
         in
+        ignore Subst.(modtype
+                        (set_nongen_level identity (Ident.binding_time id - 1))
+                        md.md_type);
         let newenv = Env.enter_module_declaration id md env in
         Tstr_module {mb_id=id; mb_name=name; mb_expr=modl;
                      mb_attributes=attrs;  mb_loc=pmb_loc;

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1291,9 +1291,8 @@ and type_structure ?(toplevel = false) funct_body anchor env sstr scope =
             md_loc = pmb_loc;
           }
         in
-        ignore Subst.(modtype
-                        (set_nongen_level identity (Ident.binding_time id - 1))
-                        md.md_type);
+        (*prerr_endline (Ident.unique_toplevel_name id);*)
+        Mtype.lower_nongen (Ident.binding_time id - 1) md.md_type;
         let newenv = Env.enter_module_declaration id md env in
         Tstr_module {mb_id=id; mb_name=name; mb_expr=modl;
                      mb_attributes=attrs;  mb_loc=pmb_loc;


### PR DESCRIPTION
Fix [MPR#7414](https://caml.inria.fr/mantis/view.php?id=7414).
The problem was that non-generalizable variable lowering, introduced in 4.04 for modules, didn't work for functors.
The first attempt uses Subst.modtype for its side-effect.