### PR TITLE
PR#7417: ensure stack stays 16 bytes aligned

### DIFF
--- a/Changes
+++ b/Changes
@@ -120,6 +120,10 @@ Next version (4.05.0):
   (Jeremy Yallop,
    review by Damien Doligez, Alain Frisch, Daniel Bünzli, Fabrice Le Fessant)
 
+- MPR#7417, GPR#930: ensure 16 byte stack alignment inside caml_allocN on x86-64
+  for ocaml build with WITH_FRAME_POINTERS defined
+  (Christoph Cullmann)
+
 Next minor version (4.04.1):
 ----------------------------
 

--- a/asmrun/amd64.S
+++ b/asmrun/amd64.S
@@ -438,12 +438,15 @@ LBL(103):
         CFI_ADJUST(8)
         RECORD_STACK_FRAME(8)
 #ifdef WITH_FRAME_POINTERS
-        /* Do we need 16-byte alignment here ? */
+        /* ensure 16 byte alignment by subq + enter using 16-bytes, PR#7417 */
+        subq    $8, %rsp; CFI_ADJUST (8)
         ENTER_FUNCTION
 #endif
         call    LBL(caml_call_gc)
 #ifdef WITH_FRAME_POINTERS
+        /* ensure 16 byte alignment by leave + addq using 16-bytes PR#7417 */
         LEAVE_FUNCTION
+        addq    $8, %rsp; CFI_ADJUST (-8)
 #endif
         popq    %rax; CFI_ADJUST(-8)       /* recover desired size */
         jmp     LBL(caml_allocN)


### PR DESCRIPTION
See PR#7417

https://caml.inria.fr/mantis/view.php?id=7417

The WITH_FRAME_POINTERS leads to non-16 byte aligned stack addresses.

Try to fix that by manually align like it was done in other locations.

Unit tests seem to work better with that.