### PR TITLE
Fix install of symlinks with installopt but without installoptopt

### DIFF
--- a/Changes
+++ b/Changes
@@ -98,6 +98,10 @@ Next version (4.05.0):
   detected through reproducible-builds.org.
   (Hannes Mehnert, review by Gabriel Scherer and Ximin Luo)
 
+- GPR#932: install ocaml{c,lex}->ocaml{c,lex}.byte symlink correctly
+  when the opt target is built but opt.opt target is not.
+  (whitequark)
+
 ### Internal/compiler-libs changes:
 
 - GPR#744, GPR#781: fix duplicate self-reference in imported cmi_crcs

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ install:
 	   cd $(INSTALL_BINDIR); \
 	   ln -sf ocamlc.byte$(EXE) ocamlc$(EXE); \
 	   ln -sf ocamllex.byte$(EXE) ocamllex$(EXE); \
-	   fi
+	fi
 
 # Installation of the native-code compiler
 installopt:
@@ -275,7 +275,11 @@ installopt:
 	for i in $(OTHERLIBRARIES); \
 	  do (cd otherlibs/$$i; $(MAKE) installopt) || exit $$?; done
 	if test -f ocamlopt.opt ; then $(MAKE) installoptopt; else \
-	   cd $(INSTALL_BINDIR); ln -sf ocamlopt.byte$(EXE) ocamlopt$(EXE); fi
+	   cd $(INSTALL_BINDIR); \
+	   ln -sf ocamlc.byte$(EXE) ocamlc$(EXE); \
+	   ln -sf ocamlopt.byte$(EXE) ocamlopt$(EXE); \
+	   ln -sf ocamllex.byte$(EXE) ocamllex$(EXE); \
+	fi
 	cd tools; $(MAKE) installopt
 
 installoptopt:


### PR DESCRIPTION
Since the `ocamlc -> ocamlc.byte` symlink is not installed when ocamlopt exists, building ocamlopt, but not *.opt compilers, results in no ocamlc symlink being installed at all. Since ln -sf is already used everywhere, just make the code less clever, and let the symlink be overwritten when appropriate.