### PR TITLE
Check for integer overflow in Bytes.extend

### DIFF
--- a/Changes
+++ b/Changes
@@ -199,6 +199,9 @@ Next version (4.05.0):
   by zero.
   (Jeremy Yallop)
 
+- GPR#934: check for integer overflow in Bytes.extend
+  (Jeremy Yallop, review by Gabriel Scherer)
+
 Next minor version (4.04.1):
 ----------------------------
 

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -72,8 +72,16 @@ let sub s ofs len =
 
 let sub_string b ofs len = unsafe_to_string (sub b ofs len)
 
+(* addition with an overflow check *)
+let (++) a b =
+  let c = a + b in
+  match a < 0, b < 0, c < 0 with
+  | true , true , false
+  | false, false, true  -> invalid_arg "Bytes.extend" (* overflow *)
+  | _ -> c
+
 let extend s left right =
-  let len = length s + left + right in
+  let len = length s ++ left ++ right in
   let r = create len in
   let (srcoff, dstoff) = if left < 0 then -left, 0 else 0, left in
   let cpylen = min (length s - srcoff) (len - dstoff) in

--- a/testsuite/tests/lib-bytes/Makefile
+++ b/testsuite/tests/lib-bytes/Makefile
@@ -1,0 +1,19 @@
+#**************************************************************************
+#*                                                                        *
+#*                                OCaml                                   *
+#*                                                                        *
+#*                 Xavier Clerc, SED, INRIA Rocquencourt                  *
+#*                                                                        *
+#*   Copyright 2010 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+BASEDIR=../..
+MODULES=testing
+include $(BASEDIR)/makefiles/Makefile.several
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/lib-bytes/test_bytes.ml
+++ b/testsuite/tests/lib-bytes/test_bytes.ml
@@ -1,0 +1,116 @@
+let test_raises_invalid_argument f x =
+  ignore
+    (Testing.test_raises_exc_p (function Invalid_argument _ -> true | _ -> false)
+         f x)
+
+let () =
+  let abcde = Bytes.of_string "abcde" in
+  let open Bytes in
+  begin
+    (*
+           abcde
+    ?????     
+    *)
+    Testing.test
+      (length (extend abcde 7 (-7)) = 5); 
+
+    (*
+    abcde
+           ?????
+    *)
+    Testing.test
+      (length (extend abcde (-7) 7) = 5);
+
+    (*
+      abcde
+      abcde
+    *)
+    Testing.test
+      (let r = extend abcde 0 0 in
+       length r = 5
+       && r.[0] = 'a' && r.[1] = 'b' && r.[2] = 'c' && r.[3] = 'd' && r.[4] = 'e'
+       && r != abcde);
+
+    (*
+      abcde
+    ??abc
+    *)
+    Testing.test
+      (let r = extend abcde 2 (-2) in
+       length r = 5 && r.[2] = 'a' && r.[3] = 'b' && r.[4] = 'c');
+
+    (*
+      abcde
+       bcd
+    *)
+    Testing.test
+      (let r = extend abcde (-1) (-1) in
+       length r = 3 && r.[0] = 'b' && r.[1] = 'c' && r.[2] = 'd');
+
+    (*
+      abcde
+         de??
+    *)
+    Testing.test
+      (let r = extend abcde (-3) 2 in
+       length r = 4 && r.[0] = 'd' && r.[1] = 'e');
+
+    (*
+      abcde
+      abc
+    *)
+    Testing.test
+      (let r = extend abcde 0 (-2) in
+       length r = 3 && r.[0] = 'a' && r.[1] = 'b' && r.[2] = 'c');
+
+    (*
+      abcde
+        cde
+    *)
+    Testing.test
+      (let r = extend abcde (-2) 0 in
+       length r = 3 && r.[0] = 'c' && r.[1] = 'd' && r.[2] = 'e');
+
+    (*
+      abcde
+      abcde??
+    *)
+    Testing.test
+      (let r = extend abcde 0 2 in
+       length r = 7
+       && r.[0] = 'a' && r.[1] = 'b' && r.[2] = 'c' && r.[3] = 'd' && r.[4] = 'e');
+
+    (*
+        abcde
+      ??abcde
+    *)
+    Testing.test
+      (let r = extend abcde 2 0 in
+       length r = 7
+       && r.[2] = 'a' && r.[3] = 'b' && r.[4] = 'c' && r.[5] = 'd' && r.[6] = 'e');
+
+    (*
+       abcde
+      ?abcde?
+    *)
+    Testing.test
+      (let r = extend abcde 1 1 in
+       length r = 7
+       && r.[1] = 'a' && r.[2] = 'b' && r.[3] = 'c' && r.[4] = 'd' && r.[5] = 'e');
+
+    (* length + left + right < 0 *)
+    test_raises_invalid_argument
+      (fun () -> extend abcde (-3) (-3)) ();
+
+    (* length + left > max_int *)
+    test_raises_invalid_argument
+      (fun () -> extend abcde max_int 0) ();
+
+    (* length + right > max_int *)
+    test_raises_invalid_argument
+      (fun () -> extend abcde 0 max_int) ();
+
+    (* length + left + right > max_int *)
+    test_raises_invalid_argument
+      (fun () -> extend abcde max_int max_int) ();
+  end

--- a/testsuite/tests/lib-bytes/test_bytes.reference
+++ b/testsuite/tests/lib-bytes/test_bytes.reference
@@ -1,0 +1,2 @@
+ 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
+All tests succeeded.


### PR DESCRIPTION
Current behaviour:

```ocaml
# Bytes.extend "abc" max_int max_int;;
- : bytes = "\000"
```

With this fix:

```ocaml
# Bytes.extend "abc" max_int max_int;;
Exception: Invalid_argument "Bytes.extend".
```