### PR TITLE
Win64 stack overflow detection

### DIFF
--- a/Changes
+++ b/Changes
@@ -190,6 +190,9 @@ Working version
 
 ### Runtime system:
 
+- GPR#938: Stack overflow detection on 64-bit Windows
+  (Olivier Andrieu)
+
 - GPR#71: The runtime can now be shut down gracefully by means of the new
   caml_shutdown and caml_startup_pooled functions. The new 'c' flag in
   OCAMLRUNPARAM enables shutting the runtime properly on process exit.

--- a/asmrun/amd64.S
+++ b/asmrun/amd64.S
@@ -260,9 +260,12 @@
    /* Calls from OCaml to C must reserve 32 bytes of extra stack space */
 #  define PREPARE_FOR_C_CALL subq $32, %rsp; CFI_ADJUST(32)
 #  define CLEANUP_AFTER_C_CALL addq $32, %rsp; CFI_ADJUST(-32)
+   /* Stack probing mustn't be larger than the page size */
+#  define STACK_PROBE_SIZE $4096
 #else
 #  define PREPARE_FOR_C_CALL
 #  define CLEANUP_AFTER_C_CALL
+#  define STACK_PROBE_SIZE $32768
 #endif
 
         .text
@@ -278,13 +281,11 @@ FUNCTION(G(caml_call_gc))
         CFI_STARTPROC
         RECORD_STACK_FRAME(0)
 LBL(caml_call_gc):
-#if !defined(SYS_mingw64) && !defined(SYS_cygwin)
     /* Touch the stack to trigger a recoverable segfault
        if insufficient space remains */
-        subq    $32768, %rsp
+        subq    STACK_PROBE_SIZE, %rsp
         movq    %rax, 0(%rsp)
-        addq    $32768, %rsp
-#endif
+        addq    STACK_PROBE_SIZE, %rsp
     /* Build array of registers, save it into caml_gc_regs */
 #ifdef WITH_FRAME_POINTERS
         ENTER_FUNCTION          ;
@@ -467,13 +468,11 @@ LBL(caml_c_call):
         STORE_VAR(%r13, caml_spacetime_trie_node_ptr)
 #endif
         subq    $8, %rsp; CFI_ADJUST(8) /* equivalent to pushq %r12 */
-#if !defined(SYS_mingw64) && !defined(SYS_cygwin)
     /* Touch the stack to trigger a recoverable segfault
        if insufficient space remains */
-        subq    $32768, %rsp
+        subq    STACK_PROBE_SIZE, %rsp
         movq    %rax, 0(%rsp)
-        addq    $32768, %rsp
-#endif
+        addq    STACK_PROBE_SIZE, %rsp
     /* Make the exception handler and alloc ptr available to the C code */
         STORE_VAR(%r15, caml_young_ptr)
         STORE_VAR(%r14, caml_exception_pointer)

--- a/asmrun/signals_asm.c
+++ b/asmrun/signals_asm.c
@@ -285,7 +285,7 @@ void caml_init_signals(void)
     if (sigaltstack(&stk, NULL) == 0) { sigaction(SIGSEGV, &act, NULL); }
   }
 #endif
-#if defined(_WIN32) && !defined(_WIN64)
+#if defined(_WIN32)
   caml_win32_overflow_detection();
 #endif
 }

--- a/asmrun/signals_asm.c
+++ b/asmrun/signals_asm.c
@@ -285,7 +285,4 @@ void caml_init_signals(void)
     if (sigaltstack(&stk, NULL) == 0) { sigaction(SIGSEGV, &act, NULL); }
   }
 #endif
-#if defined(_WIN32)
-  caml_win32_overflow_detection();
-#endif
 }

--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -92,6 +92,9 @@ void (*caml_termination_hook)(void *) = NULL;
 extern value caml_start_program (void);
 extern void caml_init_ieee_floats (void);
 extern void caml_init_signals (void);
+#ifdef _WIN32
+extern void caml_win32_overflow_detection (void);
+#endif
 
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
 
@@ -133,6 +136,9 @@ value caml_startup_common(char **argv, int pooling)
                 caml_init_max_percent_free, caml_init_major_window);
   init_static();
   caml_init_signals();
+#ifdef _WIN32
+  caml_win32_overflow_detection();
+#endif
   caml_init_backtrace();
   caml_debugger_init (); /* force debugger.o stub to be linked */
   exe_name = argv[0];

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -526,7 +526,7 @@ static void caml_reset_stack (void *faulting_address)
 CAMLextern int caml_is_in_code(void *);
 
 static LONG CALLBACK
-    caml_UnhandledExceptionFilter (EXCEPTION_POINTERS* exn_info)
+    caml_stack_overflow_VEH (EXCEPTION_POINTERS* exn_info)
 {
   DWORD code   = exn_info->ExceptionRecord->ExceptionCode;
   CONTEXT *ctx = exn_info->ContextRecord;
@@ -555,7 +555,7 @@ static LONG CALLBACK
 
 void caml_win32_overflow_detection()
 {
-  SetUnhandledExceptionFilter (caml_UnhandledExceptionFilter);
+  AddVectoredExceptionHandler(1, caml_stack_overflow_VEH);
 }
 
 #endif

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -521,7 +521,16 @@ static void caml_reset_stack (void *faulting_address)
   caml_raise_stack_overflow();
 }
 
-CAMLextern int caml_is_in_code(void *);
+/* Do not use the macro from address_class.h here. */
+#undef Is_in_code_area
+#define Is_in_code_area(pc) \
+ ( ((char *)(pc) >= caml_code_area_start && \
+    (char *)(pc) <= caml_code_area_end)     \
+|| ((char *)(pc) >= &caml_system__code_begin && \
+    (char *)(pc) <= &caml_system__code_end)     \
+|| (Classify_addr(pc) & In_code_area) )
+extern char caml_system__code_begin, caml_system__code_end;
+
 
 #ifndef _WIN64
 static LONG CALLBACK

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -587,7 +587,7 @@ static LONG CALLBACK
 }
 #endif /* _WIN64 */
 
-void caml_win32_overflow_detection()
+void caml_win32_overflow_detection(void)
 {
   AddVectoredExceptionHandler(1, caml_stack_overflow_VEH);
 }

--- a/manual/manual/cmds/native.etex
+++ b/manual/manual/cmds/native.etex
@@ -189,12 +189,9 @@ is handled in one of the following ways, depending on the
 platform used:
 \begin{itemize}
 \item By raising a "Stack_overflow" exception, like the bytecode
-  compiler does.  (IA32/Linux, AMD64/Linux, PowerPC/MacOSX, MS Windows
-  32-bit ports).
+  compiler does.  (IA32/Linux, AMD64/Linux, PowerPC/MacOSX, MS Windows).
 \item By aborting the program on a ``segmentation fault'' signal.
 (All other Unix systems.)
-\item By terminating the program silently.
-(MS Windows 64 bits).
 \end{itemize}
 
 \item On IA32 processors only (Intel and AMD x86 processors in 32-bit

--- a/testsuite/tests/runtime-errors/Makefile
+++ b/testsuite/tests/runtime-errors/Makefile
@@ -30,8 +30,9 @@ compile:
 	    $(OCAMLOPT) -w a -o $$F.native$(EXE) $$f; \
 	  fi; \
 	done
+	$(if $(findstring win32,$(UNIX_OR_WIN32)),:, \
 	@grep -q HAS_STACK_OVERFLOW_DETECTION $(TOPDIR)/byterun/caml/s.h \
-	  || rm -f stackoverflow.native$(EXE)
+	  || rm -f stackoverflow.native$(EXE))
 
 # Cygwin doesn't allow the stack limit to be changed - the 4096 is
 # intended to be larger than the its default stack size. The logic

--- a/testsuite/tests/runtime-errors/stackoverflow.bytecode.reference
+++ b/testsuite/tests/runtime-errors/stackoverflow.bytecode.reference
@@ -2,3 +2,7 @@ x = 20000
 x = 10000
 x = 0
 Stack overflow caught
+x = 20000
+x = 10000
+x = 0
+second Stack overflow caught

--- a/testsuite/tests/runtime-errors/stackoverflow.ml
+++ b/testsuite/tests/runtime-errors/stackoverflow.ml
@@ -9,7 +9,15 @@ let rec f x =
       raise Stack_overflow
 
 let _ =
+ begin
   try
     ignore(f 0)
   with Stack_overflow ->
     print_string "Stack overflow caught"; print_newline()
+ end ;
+ begin
+  try
+    ignore(f 0)
+  with Stack_overflow ->
+    print_string "second Stack overflow caught"; print_newline()
+ end

--- a/testsuite/tests/runtime-errors/stackoverflow.native.reference
+++ b/testsuite/tests/runtime-errors/stackoverflow.native.reference
@@ -2,3 +2,7 @@ x = 20000
 x = 10000
 x = 0
 Stack overflow caught
+x = 20000
+x = 10000
+x = 0
+second Stack overflow caught


### PR DESCRIPTION
This branch enables stack overflow detection for native code on Windows 64. There are mainly two changes compared to the existing Win32 code:
- use a different Win32 API to register the exception handler ; the previous one (`SetUnhandledExceptionFilter`) wasn't working anymore with recent MSVC CRT ;
- adapt the context manipulation in the exception handler for 64 bits

I'm not too sure about the backtrace stashing mechanism: `caml_last_return_address` and `caml_bottom_of_stack` have not been updated so it seems the backtrace may be incorrect. But the Unix equivalent in signals_asm.c ought to have the same issue and it does not bypass the stashing …