### PR TITLE
When cross-compiling, install host ocamlrun, not build ocamlrun

### DIFF
--- a/byterun/Makefile.shared
+++ b/byterun/Makefile.shared
@@ -58,7 +58,7 @@ INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
 
 install::
-	cp $(CAMLRUN)$(EXE) "$(INSTALL_BINDIR)/ocamlrun$(EXE)"
+	cp ocamlrun$(EXE) "$(INSTALL_BINDIR)/ocamlrun$(EXE)"
 	cp libcamlrun.$(A) "$(INSTALL_LIBDIR)/libcamlrun.$(A)"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) libcamlrun.$(A)
 	if test -d "$(INSTALL_LIBDIR)/caml"; then : ; \


### PR DESCRIPTION
Typically, $(CAMLRUN) just points to .../byterun/ocamlrun, and so
this change makes no difference. When cross-compiling, $(CAMLRUN)
points to the "build" ocamlrun (since $(CAMLRUN) is used by the build
system to run the bootstrapped compiler), but we want to install the "host"
(or "target", as the build system currently lacks the distinction) ocamlrun
such that the installed bytecode executables are actually runnable.