### PR TITLE
use the frame pointer to retrieve caml_last_return_address in the stack overflow handler

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,10 @@ Working version
 
 ### Runtime system:
 
+- #7206: improve Stack overflow backtrace when OCaml is built
+  with --enable-frame-pointers
+  (Olivier Andrieu)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -238,6 +238,12 @@ DECLARE_SIGNAL_HANDLER(segv_handler)
     Caml_state->exception_pointer == (char *) CONTEXT_EXCEPTION_POINTER;
     Caml_state->young_ptr = (value *) CONTEXT_YOUNG_PTR;
 #endif
+#if defined(CONTEXT_FRAME_POINTER)
+    Caml_state->last_return_address =
+              *(((uintnat *) CONTEXT_FRAME_POINTER) + 1);
+    Caml_state->bottom_of_stack     =
+      (char *) (((uintnat *) CONTEXT_FRAME_POINTER) + 2);
+#endif
     caml_raise_stack_overflow();
 #endif
   } else {

--- a/runtime/signals_osdep.h
+++ b/runtime/signals_osdep.h
@@ -32,6 +32,9 @@
   #define CONTEXT_SP (context->uc_mcontext.gregs[REG_RSP])
   #define CONTEXT_YOUNG_PTR (context->uc_mcontext.gregs[REG_R15])
   #define CONTEXT_FAULTING_ADDRESS ((char *)context->uc_mcontext.gregs[REG_CR2])
+  #if defined(WITH_FRAME_POINTERS)
+  #define CONTEXT_FRAME_POINTER (context->uc_mcontext.gregs[REG_RBP])
+  #endif
 
 /****************** AMD64, MacOSX */
 


### PR DESCRIPTION
this should allow for a correct backtrace stashing for the `Stack_overflow` exception when
OCaml is configured with `--with-frame-pointers` (so, only on AMD64/Linux)

addresses partially [PR#7206](https://caml.inria.fr/mantis/view.php?id=7206)

I'm not 100% sure on how OCaml uses the stack — I'd like confirmation whether this is indeed correct !