### PR TITLE
Fix redundant configure clause for openbsd shared lib options

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -113,5 +113,5 @@ using (machine type, etc).
 
 You can also contact the implementors directly at mailto:caml@inria.fr[].
 
-For information on contributing to OCaml, see link:HACKING.md[] and
+For information on contributing to OCaml, see link:HACKING.adoc[] and
 link:CONTRIBUTING.md[].

--- a/configure
+++ b/configure
@@ -734,15 +734,6 @@ if test $with_sharedlibs = "yes"; then
       mksharedlib="$flexlink"
       mkmaindll="$flexlink -maindll"
       shared_libraries_supported=true;;
-    *-*-linux-gnu|*-*-linux|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
-    |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*)
-      sharedcccompopts="-fPIC"
-      mksharedlib="$bytecc -shared"
-      bytecclinkopts="$bytecclinkopts -Wl,-E"
-      byteccrpath="-Wl,-rpath,"
-      mksharedlibrpath="-Wl,-rpath,"
-      natdynlinkopts="-Wl,-E"
-      shared_libraries_supported=true;;
     alpha*-*-osf*)
       case "$bytecc" in
         *gcc*)
@@ -802,17 +793,14 @@ if test $with_sharedlibs = "yes"; then
       bytecccompopts="$dl_defs $bytecccompopts"
       dl_needs_underscore=false
       shared_libraries_supported=true;;
-    m88k-*-openbsd*)
-      shared_libraries_supported=false;;
-    vax-*-openbsd*)
-      shared_libraries_supported=false;;
-    *-*-openbsd*)
+    *-*-linux-gnu|*-*-linux|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
+    |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*)
       sharedcccompopts="-fPIC"
       mksharedlib="$bytecc -shared"
       bytecclinkopts="$bytecclinkopts -Wl,-E"
-      natdynlinkopts="-Wl,-E"
       byteccrpath="-Wl,-rpath,"
       mksharedlibrpath="-Wl,-rpath,"
+      natdynlinkopts="-Wl,-E"
       shared_libraries_supported=true;;
   esac
 fi


### PR DESCRIPTION
The openbsd clause appears twice (see line 738).  This removes the redundant clause.  Also fold in a fix to the README for a broken link on github.
