### PR TITLE
Changing the display of fatal warnings

### DIFF
--- a/Changes
+++ b/Changes
@@ -45,6 +45,12 @@ Working version
 
 - GPR#1032: display the output of -dtimings as a hierarchy
   (Valentin Gatien-Baron, review by Gabriel Scherer)
+### Compiler user-interface and warnings:
+
+- GPR#948: the compiler now reports warnings-as-errors by prefixing
+  them with "Error (warning ..):", instead of "Warning ..:" and
+  a trailing "Error: Some fatal warnings were triggered" message.
+  (Valentin Gatien-Baron, review by Alain Frisch)
 
 ### Bug fixes
 

--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -133,13 +133,11 @@ module Sig_analyser = Odoc_sig.Analyser (Odoc_comments.Basic_info_retriever)
 (** Handle an error. *)
 
 let process_error exn =
-  match Location.error_of_exn exn with
-  | Some err ->
-      fprintf Format.err_formatter "@[%a@]@." Location.report_error err
-  | None ->
-      fprintf Format.err_formatter
-        "Compilation error(%s). Use the OCaml compiler to get more details.@."
-        (Printexc.to_string exn)
+  try Location.report_exception Format.err_formatter exn
+  with exn ->
+    fprintf Format.err_formatter
+      "Compilation error(%s). Use the OCaml compiler to get more details.@."
+      (Printexc.to_string exn)
 
 (** Process the given file, according to its extension. Return the Module.t created, if any.*)
 let process_file sourcefile =

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -804,9 +804,10 @@ end
 
 let ppx_context = PpxContext.make
 
-let ext_of_exn exn =
+let extension_of_exn exn =
   match error_of_exn exn with
-  | Some error -> extension_of_error error
+  | Some (`Ok error) -> extension_of_error error
+  | Some `Already_displayed -> { loc = Location.none; txt = "ocaml.error" }, PStr []
   | None -> raise exn
 
 
@@ -824,7 +825,7 @@ let apply_lazy ~source ~target mapper =
         let mapper = mapper () in
         mapper.structure mapper ast
       with exn ->
-        [{pstr_desc = Pstr_extension (ext_of_exn exn, []);
+        [{pstr_desc = Pstr_extension (extension_of_exn exn, []);
           pstr_loc  = Location.none}]
     in
     let fields = PpxContext.update_cookies fields in
@@ -843,7 +844,7 @@ let apply_lazy ~source ~target mapper =
         let mapper = mapper () in
         mapper.signature mapper ast
       with exn ->
-        [{psig_desc = Psig_extension (ext_of_exn exn, []);
+        [{psig_desc = Psig_extension (extension_of_exn exn, []);
           psig_loc  = Location.none}]
     in
     let fields = PpxContext.update_cookies fields in

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -39,6 +39,7 @@ let rec error_of_extension ext =
       | [] -> []
     in
     begin match p with
+    | PStr [] -> raise Location.Already_displayed_error
     | PStr({pstr_desc=Pstr_eval
               ({pexp_desc=Pexp_constant(Pconst_string(msg,_))}, _)}::
            {pstr_desc=Pstr_eval

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -287,7 +287,7 @@ let warning_prefix = "Warning"
 
 let print_error_prefix ppf =
   setup_colors ();
-  fprintf ppf "@{<error>%s@}:" error_prefix;
+  fprintf ppf "@{<error>%s@}" error_prefix;
 ;;
 
 let print_compact ppf loc =
@@ -302,18 +302,22 @@ let print_compact ppf loc =
 ;;
 
 let print_error ppf loc =
-  print ppf loc;
-  print_error_prefix ppf
+  fprintf ppf "%a%t:" print loc print_error_prefix;
 ;;
 
 let print_error_cur_file ppf () = print_error ppf (in_file !input_name);;
 
 let default_warning_printer loc ppf w =
-  if Warnings.is_active w then begin
+  match Warnings.report w with
+  | `Inactive -> ()
+  | `Active { Warnings. number; message; is_error } ->
     setup_colors ();
     print ppf loc;
-    fprintf ppf "@{<warning>%s@} %a@." warning_prefix Warnings.print w
-  end
+    if is_error
+    then
+      fprintf ppf "%t (%s %d): %s@." print_error_prefix
+           (String.uncapitalize_ascii warning_prefix) number message
+    else fprintf ppf "@{<warning>%s@} %d: %s@." warning_prefix number message
 ;;
 
 let warning_printer = ref default_warning_printer ;;
@@ -379,15 +383,20 @@ let error_of_exn : (exn -> error option) list ref = ref []
 
 let register_error_of_exn f = error_of_exn := f :: !error_of_exn
 
+exception Already_displayed_error = Warnings.Errors
+
 let error_of_exn exn =
-  let rec loop = function
-    | [] -> None
-    | f :: rest ->
-        match f exn with
-        | Some _ as r -> r
-        | None -> loop rest
-  in
-  loop !error_of_exn
+  match exn with
+  | Already_displayed_error -> Some `Already_displayed
+  | _ ->
+     let rec loop = function
+       | [] -> None
+       | f :: rest ->
+          match f exn with
+          | Some error -> Some (`Ok error)
+          | None -> loop rest
+     in
+     loop !error_of_exn
 
 let rec default_error_reporter ppf ({loc; msg; sub; if_highlight} as err) =
   let highlighted =
@@ -403,7 +412,7 @@ let rec default_error_reporter ppf ({loc; msg; sub; if_highlight} as err) =
   if highlighted then
     Format.pp_print_string ppf if_highlight
   else begin
-    fprintf ppf "%a%t %s" print loc print_error_prefix msg;
+    fprintf ppf "%a %s" print_error loc msg;
     List.iter (Format.fprintf ppf "@\n@[<2>%a@]" default_error_reporter) sub
   end
 
@@ -425,16 +434,12 @@ let () =
       | Sys_error msg ->
           Some (errorf ~loc:(in_file !input_name)
                 "I/O error: %s" msg)
-      | Warnings.Errors n ->
-          Some
-            (errorf ~loc:(in_file !input_name)
-             "Some fatal warnings were triggered (%d occurrences)" n)
 
       | Misc.HookExnWrapper {error = e; hook_name;
                              hook_info={Misc.sourcefile}} ->
           let sub = match error_of_exn e with
-            | None -> error (Printexc.to_string e)
-            | Some err -> err
+            | None | Some `Already_displayed -> error (Printexc.to_string e)
+            | Some (`Ok err) -> err
           in
           Some
             (errorf ~loc:(in_file sourcefile)
@@ -446,12 +451,12 @@ let () =
 external reraise : exn -> 'a = "%reraise"
 
 let rec report_exception_rec n ppf exn =
-  try match error_of_exn exn with
-  | Some err ->
-      fprintf ppf "@[%a@]@." report_error err
-  | None -> reraise exn
-  with exn when n > 0 ->
-    report_exception_rec (n-1) ppf exn
+  try
+    match error_of_exn exn with
+    | None -> reraise exn
+    | Some `Already_displayed -> ()
+    | Some (`Ok err) -> fprintf ppf "@[%a@]@." report_error err
+  with exn when n > 0 -> report_exception_rec (n-1) ppf exn
 
 let report_exception ppf exn = report_exception_rec 5 ppf exn
 

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -272,20 +272,22 @@ let print_loc ppf loc =
   end
 ;;
 
-let print ppf loc =
+let default_printer ppf loc =
   setup_colors ();
   if loc.loc_start.pos_fname = "//toplevel//"
   && highlight_locations ppf [loc] then ()
   else fprintf ppf "@{<loc>%a@}%s@." print_loc loc msg_colon
 ;;
 
+let printer = ref default_printer
+let print ppf loc = !printer ppf loc
+
 let error_prefix = "Error"
 let warning_prefix = "Warning"
 
-let print_error_prefix ppf () =
+let print_error_prefix ppf =
   setup_colors ();
   fprintf ppf "@{<error>%s@}:" error_prefix;
-  ()
 ;;
 
 let print_compact ppf loc =
@@ -301,7 +303,7 @@ let print_compact ppf loc =
 
 let print_error ppf loc =
   print ppf loc;
-  print_error_prefix ppf ()
+  print_error_prefix ppf
 ;;
 
 let print_error_cur_file ppf () = print_error ppf (in_file !input_name);;
@@ -401,7 +403,7 @@ let rec default_error_reporter ppf ({loc; msg; sub; if_highlight} as err) =
   if highlighted then
     Format.pp_print_string ppf if_highlight
   else begin
-    fprintf ppf "%a%a %s" print loc print_error_prefix () msg;
+    fprintf ppf "%a%t %s" print loc print_error_prefix msg;
     List.iter (Format.fprintf ppf "@\n@[<2>%a@]" default_error_reporter) sub
   end
 

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -105,6 +105,7 @@ type error =
     if_highlight: string; (* alternative message if locations are highlighted *)
   }
 
+exception Already_displayed_error
 exception Error of error
 
 val error: ?loc:t -> ?sub:error list -> ?if_highlight:string -> string -> error
@@ -119,7 +120,7 @@ val error_of_printer: t -> (formatter -> 'a -> unit) -> 'a -> error
 
 val error_of_printer_file: (formatter -> 'a -> unit) -> 'a -> error
 
-val error_of_exn: exn -> error option
+val error_of_exn: exn -> [ `Ok of error | `Already_displayed ] option
 
 val register_error_of_exn: (exn -> error option) -> unit
 (** Each compiler module which defines a custom type of exception

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -63,6 +63,9 @@ val prerr_warning: t -> Warnings.t -> unit
 val echo_eof: unit -> unit
 val reset: unit -> unit
 
+val default_printer : formatter -> t -> unit
+val printer : (formatter -> t -> unit) ref
+
 val warning_printer : (t -> formatter -> Warnings.t -> unit) ref
 (** Hook for intercepting warnings. *)
 
@@ -92,7 +95,7 @@ val show_filename: string -> string
 
 val absname: bool ref
 
-(* Support for located errors *)
+(** Support for located errors *)
 
 type error =
   {
@@ -103,9 +106,6 @@ type error =
   }
 
 exception Error of error
-
-val print_error_prefix: formatter -> unit -> unit
-  (* print the prefix "Error:" possibly with style *)
 
 val error: ?loc:t -> ?sub:error list -> ?if_highlight:string -> string -> error
 
@@ -122,12 +122,12 @@ val error_of_printer_file: (formatter -> 'a -> unit) -> 'a -> error
 val error_of_exn: exn -> error option
 
 val register_error_of_exn: (exn -> error option) -> unit
-  (* Each compiler module which defines a custom type of exception
-     which can surface as a user-visible error should register
-     a "printer" for this exception using [register_error_of_exn].
-     The result of the printer is an [error] value containing
-     a location, a message, and optionally sub-messages (each of them
-     being located as well). *)
+(** Each compiler module which defines a custom type of exception
+    which can surface as a user-visible error should register
+    a "printer" for this exception using [register_error_of_exn].
+    The result of the printer is an [error] value containing
+    a location, a message, and optionally sub-messages (each of them
+    being located as well). *)
 
 val report_error: formatter -> error -> unit
 
@@ -138,4 +138,4 @@ val default_error_reporter : formatter -> error -> unit
 (** Original error reporter for use in hooks. *)
 
 val report_exception: formatter -> exn -> unit
-  (* Reraise the exception if it is unknown. *)
+(** Reraise the exception if it is unknown. *)

--- a/testsuite/tests/messages/precise_locations.ml
+++ b/testsuite/tests/messages/precise_locations.ml
@@ -40,18 +40,14 @@ Foo ();;
 [%%expect{|
 type t = Foo of unit | Bar
 Line _, characters 0-6:
-Warning 3: deprecated: Foo
-Line _:
-Error: Some fatal warnings were triggered (1 occurrences)
+Error (warning 3): deprecated: Foo
 |}];;
 function
 Foo _ -> () | Bar -> ();;
 (* "Foo _", the whole construct is deprecated *)
 [%%expect{|
 Line _, characters 0-5:
-Warning 3: deprecated: Foo
-Line _:
-Error: Some fatal warnings were triggered (1 occurrences)
+Error (warning 3): deprecated: Foo
 |}];;
 
 
@@ -70,9 +66,7 @@ end);;
    on "open List" as whole rather than "List" *)
 [%%expect{|
 Line _, characters 0-9:
-Warning 33: unused open List.
-Line _:
-Error: Some fatal warnings were triggered (1 occurrences)
+Error (warning 33): unused open List.
 |}];;
 
 type unknown += Foo;;

--- a/testsuite/tests/parsetree/test.ml
+++ b/testsuite/tests/parsetree/test.ml
@@ -7,15 +7,7 @@ let diff =
   | _ -> "diff -u"
 
 let report_err exn =
-  match exn with
-    | Sys_error msg ->
-        Format.printf "@[I/O error:@ %s@]@." msg
-    | x ->
-        match Location.error_of_exn x with
-        | Some err ->
-            Format.printf "@[%a@]@."
-              Location.report_error err
-        | None -> raise x
+  Location.report_exception Format.std_formatter exn
 
 let remove_locs =
   let open Ast_mapper in

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -138,23 +138,10 @@ module Compiler_messages = struct
       Format.fprintf ppf ", characters %d-%d" startchar endchar;
     Format.fprintf ppf ":@."
 
-  let rec error_reporter ppf ({loc; msg; sub; if_highlight=_} : Location.error)=
-    print_loc ppf loc;
-    Format.fprintf ppf "%a %s" Location.print_error_prefix () msg;
-    List.iter sub ~f:(fun err ->
-      Format.fprintf ppf "@\n@[<2>%a@]" error_reporter err)
-
-  let warning_printer loc ppf w =
-    if Warnings.is_active w then begin
-      print_loc ppf loc;
-      Format.fprintf ppf "Warning %a@." Warnings.print w
-    end
-
   let capture ppf ~f =
     Misc.protect_refs
-      [ R (Location.formatter_for_warnings , ppf            )
-      ; R (Location.warning_printer        , warning_printer)
-      ; R (Location.error_reporter         , error_reporter )
+      [ R (Location.formatter_for_warnings , ppf)
+      ; R (Location.printer                , print_loc)
       ]
       f
 end

--- a/tools/ocamldep.ml
+++ b/tools/ocamldep.ml
@@ -221,15 +221,7 @@ let print_raw_dependencies source_file deps =
 
 let report_err exn =
   error_occurred := true;
-  match exn with
-    | Sys_error msg ->
-        Format.fprintf Format.err_formatter "@[I/O error:@ %s@]@." msg
-    | x ->
-        match Location.error_of_exn x with
-        | Some err ->
-            Format.fprintf Format.err_formatter "@[%a@]@."
-              Location.report_error err
-        | None -> raise x
+  Location.report_exception Format.err_formatter exn
 
 let tool_name = "ocamldep"
 

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -488,11 +488,8 @@ let message = function
 let nerrors = ref 0;;
 
 let print ppf w =
-  let msg = message w in
-  let num = number w in
-  Format.fprintf ppf "%d: %s" num msg;
-  Format.pp_print_flush ppf ();
-  if (!current).error.(num) then incr nerrors
+  Format.fprintf ppf "%d: %s@?" (number w) (message w);
+  if is_error w then incr nerrors
 ;;
 
 exception Errors of int;;

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -487,21 +487,29 @@ let message = function
 
 let nerrors = ref 0;;
 
-let print ppf w =
-  Format.fprintf ppf "%d: %s@?" (number w) (message w);
-  if is_error w then incr nerrors
+type reporting_information =
+  { number : int
+  ; message : string
+  ; is_error : bool
+  }
+
+let report w =
+  match is_active w with
+  | false -> `Inactive
+  | true ->
+     if is_error w then incr nerrors;
+    `Active { number = number w; message = message w; is_error = is_error w }
 ;;
 
-exception Errors of int;;
+exception Errors;;
 
 let reset_fatal () =
   nerrors := 0
 
 let check_fatal () =
   if !nerrors > 0 then begin
-    let e = Errors !nerrors in
     nerrors := 0;
-    raise e;
+    raise Errors;
   end;
 ;;
 

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -13,8 +13,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Format
-
 type t =
   | Comment_start                           (*  1 *)
   | Comment_not_end                         (*  2 *)
@@ -87,9 +85,15 @@ val is_error : t -> bool;;
 val defaults_w : string;;
 val defaults_warn_error : string;;
 
-val print : formatter -> t -> unit;;
+type reporting_information =
+  { number : int
+  ; message : string
+  ; is_error : bool
+  }
 
-exception Errors of int;;
+val report : t -> [ `Active of reporting_information | `Inactive ]
+
+exception Errors;;
 
 val check_fatal : unit -> unit;;
 val reset_fatal: unit -> unit


### PR DESCRIPTION
This pull request changes the display of warnings that are errors, for instance from:

```
File "a.ml", line 1, characters 6-7:
Warning 27: unused variable x.
File "tmp.ml", line 1:
Error: Some fatal warnings were triggered (1 occurrences)
```

to

```
File "a.ml", line 1, characters 6-7:
Error: Warning 27: unused variable x.
```

The main motivation is that the message about fatal warnings has a location that does not respect the line directives in the source file, which is my case means random filenames show up in errors.

This change also means one can tell from the output what warnings are errors, which could be useful either for people or for parsing the output.

Finally, it makes for a shorter error message in the common case where the code is not full of warnings.
