### PR TITLE
allow syntax Functor(val x)

### DIFF
--- a/Changes
+++ b/Changes
@@ -133,7 +133,10 @@ Next version (4.05.0):
 
 ### Bug fixes
 
-- PR#7414/GPR#929: Soundness bug with non-generalized type variable and functors
+- PR#7216, GPR#949: don't require double parens in Functor((val x))
+  (Jacques Garrigue, review by Valentin Gatien-Baron)
+
+- PR#7414, GPR#929: Soundness bug with non-generalized type variable and functors
   (Jacques Garrigue, report by Leo White)
 
 - GPR#795: remove 256-character limitation on Sys.executable_name

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -634,7 +634,8 @@ section~\ref{s:explicit-overriding}.
 \ikwd{with\@\texttt{with}}
 
 (Introduced in OCaml 3.12; pattern syntax and package type inference
-introduced in 4.00; structural comparison of package types introduced in 4.02.)
+introduced in 4.00; structural comparison of package types introduced in 4.02.;
+fewer parens required starting from 4.05)
 
 \begin{syntax}
 typexpr:
@@ -678,6 +679,8 @@ evaluates the core language expression @expr@ to a value, which must
 have type @'module' package-type@, and extracts the module that was
 encapsulated in this value. Again @package-type@ can be omitted if the
 type of @expr@ is known.
+If the module expression is already parenthesized, like the arguments
+of functors are, no additional parens are needed: "Map.Make(val key)".
 
 The pattern @'(' 'module' module-name ':' package-type ')'@ matches a
 package with type @package-type@ and binds it to @module-name@.

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -765,13 +765,20 @@ module_expr:
             (fun acc (n, t) -> mkmod(Pmod_functor(n, t, acc)))
             $5 $3
         in wrap_mod_attrs modexp $2 }
-  | module_expr LPAREN module_expr RPAREN
-      { mkmod(Pmod_apply($1, $3)) }
+  | module_expr paren_module_expr
+      { mkmod(Pmod_apply($1, $2)) }
   | module_expr LPAREN RPAREN
       { mkmod(Pmod_apply($1, mkmod (Pmod_structure []))) }
-  | module_expr LPAREN module_expr error
-      { unclosed "(" 2 ")" 4 }
-  | LPAREN module_expr COLON module_type RPAREN
+  | paren_module_expr
+      { $1 }
+  | module_expr attribute
+      { Mod.attr $1 $2 }
+  | extension
+      { mkmod(Pmod_extension $1) }
+;
+
+paren_module_expr:
+    LPAREN module_expr COLON module_type RPAREN
       { mkmod(Pmod_constraint($2, $4)) }
   | LPAREN module_expr COLON module_type error
       { unclosed "(" 1 ")" 5 }
@@ -801,10 +808,6 @@ module_expr:
       { unclosed "(" 1 ")" 6 }
   | LPAREN VAL attributes expr error
       { unclosed "(" 1 ")" 5 }
-  | module_expr attribute
-      { Mod.attr $1 $2 }
-  | extension
-      { mkmod(Pmod_extension $1) }
 ;
 
 structure:

--- a/testsuite/tests/exotic-syntax/exotic.ml
+++ b/testsuite/tests/exotic-syntax/exotic.ml
@@ -76,6 +76,13 @@ let set_int contents = { contents : int }
 let set_int2 c = { contents : int = c }
 ;;
 
+(* applying a functor to the unpacking of a first-class module *)
+module M() = struct
+  module type String = module type of String
+  let string = (module String : String)
+  module M = Set.Make(val string)
+end ;;
+
 (* More exotic: not even found in the manual (up to version 4.00),
    but used in some programs found in the wild.
 *)


### PR DESCRIPTION
Instead of just `Functor((val x))` right now.