### PR TITLE
Keep possibly-effectful expressions when optimizing multiplication by zero

### DIFF
--- a/Changes
+++ b/Changes
@@ -163,6 +163,10 @@ Next version (4.05.0):
   (Jeremy Yallop,
    review by Damien Doligez, Alain Frisch, Daniel Bünzli, Fabrice Le Fessant)
 
+- GPR#956 Keep possibly-effectful expressions when optimizing multiplication
+  by zero.
+  (Jeremy Yallop)
+
 Next minor version (4.04.1):
 ----------------------------
 

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -156,8 +156,7 @@ and mult_power2 c n dbg = lsl_int c (Cconst_int (Misc.log2 n)) dbg
 
 let rec mul_int c1 c2 dbg =
   match (c1, c2) with
-  | (_, Cconst_int 0) | (Cconst_int 0, _) ->
-      Cconst_int 0
+  | (c, Cconst_int 0) | (Cconst_int 0, c) -> Csequence (c, Cconst_int 0)
   | (c, Cconst_int 1) | (Cconst_int 1, c) ->
       c
   | (c, Cconst_int(-1)) | (Cconst_int(-1), c) ->


### PR DESCRIPTION
Here's a test program:

```ocaml
let () = Printf.printf "%d\n" (0 * (print_endline "erk"; 1))
```

Output before this PR:
```
0
```
Output after this PR:
```
erk
0
```
