### PR TITLE
Add stub marker to lambda code

### DIFF
--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -213,6 +213,7 @@ type function_attribute = {
   inline : inline_attribute;
   specialise : specialise_attribute;
   is_a_functor: bool;
+  stub: bool;
 }
 
 type lambda =
@@ -286,7 +287,11 @@ let default_function_attribute = {
   inline = Default_inline;
   specialise = Default_specialise;
   is_a_functor = false;
+  stub = false;
 }
+
+let default_stub_attribute =
+  { default_function_attribute with stub = true }
 
 (* Build sharing keys *)
 (*

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -229,6 +229,7 @@ type function_attribute = {
   inline : inline_attribute;
   specialise : specialise_attribute;
   is_a_functor: bool;
+  stub: bool;
 }
 
 type lambda =
@@ -332,6 +333,7 @@ val commute_comparison : comparison -> comparison
 val negate_comparison : comparison -> comparison
 
 val default_function_attribute : function_attribute
+val default_stub_attribute : function_attribute
 
 (***********************)
 (* For static failures *)

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -412,9 +412,11 @@ let name_of_primitive = function
   | Pint_as_pointer -> "Pint_as_pointer"
   | Popaque -> "Popaque"
 
-let function_attribute ppf { inline; specialise; is_a_functor } =
+let function_attribute ppf { inline; specialise; is_a_functor; stub } =
   if is_a_functor then
     fprintf ppf "is_a_functor@ ";
+  if stub then
+    fprintf ppf "stub@ ";
   begin match inline with
   | Default_inline -> ()
   | Always_inline -> fprintf ppf "always_inline@ "

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -632,8 +632,7 @@ and list_emit_tail_infos is_tail =
    'Some' constructor, only to deconstruct it immediately in the
    function's body. *)
 
-let split_default_wrapper ?(create_wrapper_body = fun lam -> lam)
-      ~id:fun_id ~kind ~params ~body ~attr ~wrapper_attr ~loc () =
+let split_default_wrapper ~id:fun_id ~kind ~params ~body ~attr ~loc =
   let rec aux map = function
     | Llet(Strict, k, id, (Lifthenelse(Lvar optparam, _, _) as def), rest) when
         Ident.name optparam = "*opt*" && List.mem optparam params
@@ -675,9 +674,9 @@ let split_default_wrapper ?(create_wrapper_body = fun lam -> lam)
         (wrapper_body, (inner_id, inner_fun))
   in
   try
-    let wrapper_body, inner = aux [] body in
-    [(fun_id, Lfunction{kind; params; body = create_wrapper_body wrapper_body;
-       attr = wrapper_attr; loc}); inner]
+    let body, inner = aux [] body in
+    let attr = default_stub_attribute in
+    [(fun_id, Lfunction{kind; params; body; attr; loc}); inner]
   with Exit ->
     [(fun_id, Lfunction{kind; params; body; attr; loc})]
 

--- a/bytecomp/simplif.mli
+++ b/bytecomp/simplif.mli
@@ -23,15 +23,12 @@ open Lambda
 val simplify_lambda: string -> lambda -> lambda
 
 val split_default_wrapper
-   : ?create_wrapper_body:(lambda -> lambda)
-  -> id:Ident.t
+   : id:Ident.t
   -> kind:function_kind
   -> params:Ident.t list
   -> body:lambda
   -> attr:function_attribute
-  -> wrapper_attr:function_attribute
   -> loc:Location.t
-  -> unit
   -> (Ident.t * lambda) list
 
 (* To be filled by asmcomp/selectgen.ml *)

--- a/bytecomp/translattribute.ml
+++ b/bytecomp/translattribute.ml
@@ -144,14 +144,14 @@ let get_specialise_attribute l =
 let add_inline_attribute expr loc attributes =
   match expr, get_inline_attribute attributes with
   | expr, Default_inline -> expr
-  | Lfunction({ attr } as funct), inline_attribute ->
+  | Lfunction({ attr = { stub = false } as attr } as funct), inline ->
       begin match attr.inline with
       | Default_inline -> ()
       | Always_inline | Never_inline | Unroll _ ->
           Location.prerr_warning loc
             (Warnings.Duplicated_attribute "inline")
       end;
-      let attr = { attr with inline = inline_attribute } in
+      let attr = { attr with inline } in
       Lfunction { funct with attr = attr }
   | expr, (Always_inline | Never_inline | Unroll _) ->
       Location.prerr_warning loc
@@ -161,14 +161,14 @@ let add_inline_attribute expr loc attributes =
 let add_specialise_attribute expr loc attributes =
   match expr, get_specialise_attribute attributes with
   | expr, Default_specialise -> expr
-  | Lfunction({ attr } as funct), specialise_attribute ->
+  | Lfunction({ attr = { stub = false } as attr } as funct), specialise ->
       begin match attr.specialise with
       | Default_specialise -> ()
       | Always_specialise | Never_specialise ->
           Location.prerr_warning loc
             (Warnings.Duplicated_attribute "specialise")
       end;
-      let attr = { attr with specialise = specialise_attribute } in
+      let attr = { attr with specialise } in
       Lfunction { funct with attr }
   | expr, (Always_specialise | Never_specialise) ->
       Location.prerr_warning loc

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -441,7 +441,7 @@ let transl_primitive loc p env ty path =
       Lfunction{kind = Curried; params = [parm];
                 body = Matching.inline_lazy_force (Lvar parm) Location.none;
                 loc = loc;
-                attr = default_function_attribute }
+                attr = default_stub_attribute }
   | Ploc kind ->
     let lam = lam_of_loc kind loc in
     begin match p.prim_arity with
@@ -449,7 +449,7 @@ let transl_primitive loc p env ty path =
       | 1 -> (* TODO: we should issue a warning ? *)
         let param = Ident.create "prim" in
         Lfunction{kind = Curried; params = [param];
-                  attr = default_function_attribute;
+                  attr = default_stub_attribute;
                   loc = loc;
                   body = Lprim(Pmakeblock(0, Immutable, None),
                                [lam; Lvar param], loc)}
@@ -460,7 +460,7 @@ let transl_primitive loc p env ty path =
         if n <= 0 then [] else Ident.create "prim" :: make_params (n-1) in
       let params = make_params p.prim_arity in
       Lfunction{ kind = Curried; params;
-                 attr = default_function_attribute;
+                 attr = default_stub_attribute;
                  loc = loc;
                  body = Lprim(prim, List.map (fun id -> Lvar id) params, loc) }
 
@@ -709,14 +709,14 @@ and transl_exp0 e =
         let kind = if public_send then Public else Self in
         let obj = Ident.create "obj" and meth = Ident.create "meth" in
         Lfunction{kind = Curried; params = [obj; meth];
-                  attr = default_function_attribute;
+                  attr = default_stub_attribute;
                   loc = e.exp_loc;
                   body = Lsend(kind, Lvar meth, Lvar obj, [], e.exp_loc)}
       else if p.prim_name = "%sendcache" then
         let obj = Ident.create "obj" and meth = Ident.create "meth" in
         let cache = Ident.create "cache" and pos = Ident.create "pos" in
         Lfunction{kind = Curried; params = [obj; meth; cache; pos];
-                  attr = default_function_attribute;
+                  attr = default_stub_attribute;
                   loc = e.exp_loc;
                   body = Lsend(Cached, Lvar meth, Lvar obj,
                                [Lvar cache; Lvar pos], e.exp_loc)}
@@ -1168,7 +1168,7 @@ and transl_apply ?(should_be_tailcall=false) ?(inlined = Default_inline)
                         loc}
           | lam ->
               Lfunction{kind = Curried; params = [id_arg]; body = lam;
-                        attr = default_function_attribute; loc = loc}
+                        attr = default_stub_attribute; loc = loc}
         in
         List.fold_left
           (fun body (id, lam) -> Llet(Strict, Pgenval, id, lam, body))

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -368,7 +368,8 @@ let rec transl_module cc rootpath mexp =
                   Lfunction{kind = Curried; params = [param];
                             attr = { inline = inline_attribute;
                                      specialise = Default_specialise;
-                                     is_a_functor = true };
+                                     is_a_functor = true;
+                                     stub = false; };
                             loc = loc;
                             body = transl_module Tcoerce_none bodypath body}
               | Tcoerce_functor(ccarg, ccres) ->
@@ -376,7 +377,8 @@ let rec transl_module cc rootpath mexp =
                   Lfunction{kind = Curried; params = [param'];
                             attr = { inline = inline_attribute;
                                      specialise = Default_specialise;
-                                     is_a_functor = true };
+                                     is_a_functor = true;
+                                     stub = false; };
                             loc = loc;
                             body = Llet(Alias, Pgenval, param,
                                         apply_coercion loc Alias ccarg

--- a/middle_end/closure_conversion_aux.ml
+++ b/middle_end/closure_conversion_aux.ml
@@ -82,8 +82,6 @@ module Env = struct
   let not_at_toplevel t = { t with at_toplevel = false; }
 end
 
-let stub_hack_prim_name = "*stub*"
-
 module Function_decls = struct
   module Function_decl = struct
     type t = {
@@ -93,14 +91,12 @@ module Function_decls = struct
       params : Ident.t list;
       body : Lambda.lambda;
       free_idents_of_body : IdentSet.t;
-      inline : Lambda.inline_attribute;
-      specialise : Lambda.specialise_attribute;
-      is_a_functor : bool;
+      attr : Lambda.function_attribute;
       loc : Location.t;
     }
 
-    let create ~let_rec_ident ~closure_bound_var ~kind ~params ~body ~inline
-        ~specialise ~is_a_functor ~loc =
+    let create ~let_rec_ident ~closure_bound_var ~kind ~params ~body
+        ~attr ~loc =
       let let_rec_ident =
         match let_rec_ident with
         | None -> Ident.create "unnamed_function"
@@ -112,9 +108,7 @@ module Function_decls = struct
         params;
         body;
         free_idents_of_body = Lambda.free_variables body;
-        inline;
-        specialise;
-        is_a_functor;
+        attr;
         loc;
       }
 
@@ -124,16 +118,12 @@ module Function_decls = struct
     let params t = t.params
     let body t = t.body
     let free_idents t = t.free_idents_of_body
-    let inline t = t.inline
-    let specialise t = t.specialise
-    let is_a_functor t = t.is_a_functor
+    let inline t = t.attr.inline
+    let specialise t = t.attr.specialise
+    let is_a_functor t = t.attr.is_a_functor
+    let stub t = t.attr.stub
     let loc t = t.loc
 
-    let primitive_wrapper t =
-      match t.body with
-      | Lprim (Pccall { Primitive. prim_name; }, [body], _)
-        when prim_name = stub_hack_prim_name -> Some body
-      | _ -> None
   end
 
   type t = {

--- a/middle_end/closure_conversion_aux.mli
+++ b/middle_end/closure_conversion_aux.mli
@@ -58,9 +58,7 @@ module Function_decls : sig
       -> kind:Lambda.function_kind
       -> params:Ident.t list
       -> body:Lambda.lambda
-      -> inline:Lambda.inline_attribute
-      -> specialise:Lambda.specialise_attribute
-      -> is_a_functor:bool
+      -> attr:Lambda.function_attribute
       -> loc:Location.t
       -> t
 
@@ -72,12 +70,8 @@ module Function_decls : sig
     val inline : t -> Lambda.inline_attribute
     val specialise : t -> Lambda.specialise_attribute
     val is_a_functor : t -> bool
+    val stub : t -> bool
     val loc : t -> Location.t
-
-    (* [primitive_wrapper t] is [None] iff [t] is not a wrapper for a function
-       with default optional arguments. Otherwise it is [Some body], where
-       [body] is the body of the wrapper. *)
-    val primitive_wrapper : t -> Lambda.lambda option
 
     (* Like [all_free_idents], but for just one function. *)
     val free_idents : t -> Lambda.IdentSet.t
@@ -98,5 +92,3 @@ module Function_decls : sig
      It also contains the globals bindings of the provided environment. *)
   val closure_env_without_parameters : Env.t -> t -> Env.t
 end
-
-val stub_hack_prim_name : string

--- a/testsuite/tests/translprim/array_spec.ml.reference
+++ b/testsuite/tests/translprim/array_spec.ml.reference
@@ -22,60 +22,60 @@
       (function a x (array.unsafe_set[gen] a 0 x))
       (let
         (eta_gen_len =
-           (function prim (array.length[gen] prim))
+           (function prim stub (array.length[gen] prim))
          eta_gen_safe_get =
-           (function prim prim
+           (function prim prim stub
              (array.get[gen] prim prim))
          eta_gen_unsafe_get =
-           (function prim prim
+           (function prim prim stub
              (array.unsafe_get[gen] prim prim))
          eta_gen_safe_set =
-           (function prim prim prim
+           (function prim prim prim stub
              (array.set[gen] prim prim prim))
          eta_gen_unsafe_set =
-           (function prim prim prim
+           (function prim prim prim stub
              (array.unsafe_set[gen] prim prim prim))
          eta_int_len =
-           (function prim (array.length[int] prim))
+           (function prim stub (array.length[int] prim))
          eta_int_safe_get =
-           (function prim prim
+           (function prim prim stub
              (array.get[int] prim prim))
          eta_int_unsafe_get =
-           (function prim prim
+           (function prim prim stub
              (array.unsafe_get[int] prim prim))
          eta_int_safe_set =
-           (function prim prim prim
+           (function prim prim prim stub
              (array.set[int] prim prim prim))
          eta_int_unsafe_set =
-           (function prim prim prim
+           (function prim prim prim stub
              (array.unsafe_set[int] prim prim prim))
          eta_float_len =
-           (function prim (array.length[float] prim))
+           (function prim stub (array.length[float] prim))
          eta_float_safe_get =
-           (function prim prim
+           (function prim prim stub
              (array.get[float] prim prim))
          eta_float_unsafe_get =
-           (function prim prim
+           (function prim prim stub
              (array.unsafe_get[float] prim prim))
          eta_float_safe_set =
-           (function prim prim prim
+           (function prim prim prim stub
              (array.set[float] prim prim prim))
          eta_float_unsafe_set =
-           (function prim prim prim
+           (function prim prim prim stub
              (array.unsafe_set[float] prim prim prim))
          eta_addr_len =
-           (function prim (array.length[addr] prim))
+           (function prim stub (array.length[addr] prim))
          eta_addr_safe_get =
-           (function prim prim
+           (function prim prim stub
              (array.get[addr] prim prim))
          eta_addr_unsafe_get =
-           (function prim prim
+           (function prim prim stub
              (array.unsafe_get[addr] prim prim))
          eta_addr_safe_set =
-           (function prim prim prim
+           (function prim prim prim stub
              (array.set[addr] prim prim prim))
          eta_addr_unsafe_set =
-           (function prim prim prim
+           (function prim prim prim stub
              (array.unsafe_set[addr] prim prim prim)))
         (makeblock 0 int_a float_a addr_a eta_gen_len
           eta_gen_safe_get eta_gen_unsafe_get eta_gen_safe_set

--- a/testsuite/tests/translprim/comparison_table.ml.reference
+++ b/testsuite/tests/translprim/comparison_table.ml.reference
@@ -81,139 +81,150 @@
      nativeint_ge =
        (function x y (Nativeint.>= x y))
      eta_gen_cmp =
-       (function prim prim (caml_compare prim prim))
+       (function prim prim stub (caml_compare prim prim))
      eta_int_cmp =
-       (function prim prim (caml_int_compare prim prim))
+       (function prim prim stub
+         (caml_int_compare prim prim))
      eta_bool_cmp =
-       (function prim prim (caml_int_compare prim prim))
+       (function prim prim stub
+         (caml_int_compare prim prim))
      eta_intlike_cmp =
-       (function prim prim (caml_int_compare prim prim))
+       (function prim prim stub
+         (caml_int_compare prim prim))
      eta_float_cmp =
-       (function prim prim
+       (function prim prim stub
          (caml_float_compare prim prim))
      eta_string_cmp =
-       (function prim prim
+       (function prim prim stub
          (caml_string_compare prim prim))
      eta_int32_cmp =
-       (function prim prim
+       (function prim prim stub
          (caml_int32_compare prim prim))
      eta_int64_cmp =
-       (function prim prim
+       (function prim prim stub
          (caml_int64_compare prim prim))
      eta_nativeint_cmp =
-       (function prim prim
+       (function prim prim stub
          (caml_nativeint_compare prim prim))
      eta_gen_eq =
-       (function prim prim (caml_equal prim prim))
+       (function prim prim stub (caml_equal prim prim))
      eta_int_eq =
-       (function prim prim (== prim prim))
+       (function prim prim stub (== prim prim))
      eta_bool_eq =
-       (function prim prim (== prim prim))
+       (function prim prim stub (== prim prim))
      eta_intlike_eq =
-       (function prim prim (== prim prim))
+       (function prim prim stub (== prim prim))
      eta_float_eq =
-       (function prim prim (==. prim prim))
+       (function prim prim stub (==. prim prim))
      eta_string_eq =
-       (function prim prim (caml_string_equal prim prim))
+       (function prim prim stub
+         (caml_string_equal prim prim))
      eta_int32_eq =
-       (function prim prim (Int32.== prim prim))
+       (function prim prim stub (Int32.== prim prim))
      eta_int64_eq =
-       (function prim prim (Int64.== prim prim))
+       (function prim prim stub (Int64.== prim prim))
      eta_nativeint_eq =
-       (function prim prim (Nativeint.== prim prim))
+       (function prim prim stub (Nativeint.== prim prim))
      eta_gen_ne =
-       (function prim prim (caml_notequal prim prim))
+       (function prim prim stub
+         (caml_notequal prim prim))
      eta_int_ne =
-       (function prim prim (!= prim prim))
+       (function prim prim stub (!= prim prim))
      eta_bool_ne =
-       (function prim prim (!= prim prim))
+       (function prim prim stub (!= prim prim))
      eta_intlike_ne =
-       (function prim prim (!= prim prim))
+       (function prim prim stub (!= prim prim))
      eta_float_ne =
-       (function prim prim (!=. prim prim))
+       (function prim prim stub (!=. prim prim))
      eta_string_ne =
-       (function prim prim
+       (function prim prim stub
          (caml_string_notequal prim prim))
      eta_int32_ne =
-       (function prim prim (Int32.!= prim prim))
+       (function prim prim stub (Int32.!= prim prim))
      eta_int64_ne =
-       (function prim prim (Int64.!= prim prim))
+       (function prim prim stub (Int64.!= prim prim))
      eta_nativeint_ne =
-       (function prim prim (Nativeint.!= prim prim))
+       (function prim prim stub (Nativeint.!= prim prim))
      eta_gen_lt =
-       (function prim prim (caml_lessthan prim prim))
-     eta_int_lt = (function prim prim (< prim prim))
+       (function prim prim stub
+         (caml_lessthan prim prim))
+     eta_int_lt =
+       (function prim prim stub (< prim prim))
      eta_bool_lt =
-       (function prim prim (< prim prim))
+       (function prim prim stub (< prim prim))
      eta_intlike_lt =
-       (function prim prim (< prim prim))
+       (function prim prim stub (< prim prim))
      eta_float_lt =
-       (function prim prim (<. prim prim))
+       (function prim prim stub (<. prim prim))
      eta_string_lt =
-       (function prim prim
+       (function prim prim stub
          (caml_string_lessthan prim prim))
      eta_int32_lt =
-       (function prim prim (Int32.< prim prim))
+       (function prim prim stub (Int32.< prim prim))
      eta_int64_lt =
-       (function prim prim (Int64.< prim prim))
+       (function prim prim stub (Int64.< prim prim))
      eta_nativeint_lt =
-       (function prim prim (Nativeint.< prim prim))
+       (function prim prim stub (Nativeint.< prim prim))
      eta_gen_gt =
-       (function prim prim (caml_greaterthan prim prim))
-     eta_int_gt = (function prim prim (> prim prim))
+       (function prim prim stub
+         (caml_greaterthan prim prim))
+     eta_int_gt =
+       (function prim prim stub (> prim prim))
      eta_bool_gt =
-       (function prim prim (> prim prim))
+       (function prim prim stub (> prim prim))
      eta_intlike_gt =
-       (function prim prim (> prim prim))
+       (function prim prim stub (> prim prim))
      eta_float_gt =
-       (function prim prim (>. prim prim))
+       (function prim prim stub (>. prim prim))
      eta_string_gt =
-       (function prim prim
+       (function prim prim stub
          (caml_string_greaterthan prim prim))
      eta_int32_gt =
-       (function prim prim (Int32.> prim prim))
+       (function prim prim stub (Int32.> prim prim))
      eta_int64_gt =
-       (function prim prim (Int64.> prim prim))
+       (function prim prim stub (Int64.> prim prim))
      eta_nativeint_gt =
-       (function prim prim (Nativeint.> prim prim))
+       (function prim prim stub (Nativeint.> prim prim))
      eta_gen_le =
-       (function prim prim (caml_lessequal prim prim))
+       (function prim prim stub
+         (caml_lessequal prim prim))
      eta_int_le =
-       (function prim prim (<= prim prim))
+       (function prim prim stub (<= prim prim))
      eta_bool_le =
-       (function prim prim (<= prim prim))
+       (function prim prim stub (<= prim prim))
      eta_intlike_le =
-       (function prim prim (<= prim prim))
+       (function prim prim stub (<= prim prim))
      eta_float_le =
-       (function prim prim (<=. prim prim))
+       (function prim prim stub (<=. prim prim))
      eta_string_le =
-       (function prim prim
+       (function prim prim stub
          (caml_string_lessequal prim prim))
      eta_int32_le =
-       (function prim prim (Int32.<= prim prim))
+       (function prim prim stub (Int32.<= prim prim))
      eta_int64_le =
-       (function prim prim (Int64.<= prim prim))
+       (function prim prim stub (Int64.<= prim prim))
      eta_nativeint_le =
-       (function prim prim (Nativeint.<= prim prim))
+       (function prim prim stub (Nativeint.<= prim prim))
      eta_gen_ge =
-       (function prim prim (caml_greaterequal prim prim))
+       (function prim prim stub
+         (caml_greaterequal prim prim))
      eta_int_ge =
-       (function prim prim (>= prim prim))
+       (function prim prim stub (>= prim prim))
      eta_bool_ge =
-       (function prim prim (>= prim prim))
+       (function prim prim stub (>= prim prim))
      eta_intlike_ge =
-       (function prim prim (>= prim prim))
+       (function prim prim stub (>= prim prim))
      eta_float_ge =
-       (function prim prim (>=. prim prim))
+       (function prim prim stub (>=. prim prim))
      eta_string_ge =
-       (function prim prim
+       (function prim prim stub
          (caml_string_greaterequal prim prim))
      eta_int32_ge =
-       (function prim prim (Int32.>= prim prim))
+       (function prim prim stub (Int32.>= prim prim))
      eta_int64_ge =
-       (function prim prim (Int64.>= prim prim))
+       (function prim prim stub (Int64.>= prim prim))
      eta_nativeint_ge =
-       (function prim prim (Nativeint.>= prim prim))
+       (function prim prim stub (Nativeint.>= prim prim))
      int_vec = [0: [0: 1 1] [0: [0: 1 2] [0: [0: 2 1] 0a]]]
      bool_vec = [0: [0: 0a 0a] [0: [0: 0a 1a] [0: [0: 1a 0a] 0a]]]
      intlike_vec = [0: [0: 0a 0a] [0: [0: 0a 1a] [0: [0: 1a 0a] 0a]]]

--- a/testsuite/tests/translprim/module_coercion.ml.reference
+++ b/testsuite/tests/translprim/module_coercion.ml.reference
@@ -1,104 +1,115 @@
 (setglobal Module_coercion!
   (let (M = (makeblock 0))
     (makeblock 0 M
-      (makeblock 0 (function prim (array.length[int] prim))
-        (function prim prim (array.get[int] prim prim))
-        (function prim prim
+      (makeblock 0 (function prim stub (array.length[int] prim))
+        (function prim prim stub
+          (array.get[int] prim prim))
+        (function prim prim stub
           (array.unsafe_get[int] prim prim))
-        (function prim prim prim
+        (function prim prim prim stub
           (array.set[int] prim prim prim))
-        (function prim prim prim
+        (function prim prim prim stub
           (array.unsafe_set[int] prim prim prim))
-        (function prim prim (caml_int_compare prim prim))
-        (function prim prim (== prim prim))
-        (function prim prim (!= prim prim))
-        (function prim prim (< prim prim))
-        (function prim prim (> prim prim))
-        (function prim prim (<= prim prim))
-        (function prim prim (>= prim prim)))
-      (makeblock 0 (function prim (array.length[float] prim))
-        (function prim prim (array.get[float] prim prim))
-        (function prim prim
+        (function prim prim stub
+          (caml_int_compare prim prim))
+        (function prim prim stub (== prim prim))
+        (function prim prim stub (!= prim prim))
+        (function prim prim stub (< prim prim))
+        (function prim prim stub (> prim prim))
+        (function prim prim stub (<= prim prim))
+        (function prim prim stub (>= prim prim)))
+      (makeblock 0 (function prim stub (array.length[float] prim))
+        (function prim prim stub
+          (array.get[float] prim prim))
+        (function prim prim stub
           (array.unsafe_get[float] prim prim))
-        (function prim prim prim
+        (function prim prim prim stub
           (array.set[float] prim prim prim))
-        (function prim prim prim
+        (function prim prim prim stub
           (array.unsafe_set[float] prim prim prim))
-        (function prim prim
+        (function prim prim stub
           (caml_float_compare prim prim))
-        (function prim prim (==. prim prim))
-        (function prim prim (!=. prim prim))
-        (function prim prim (<. prim prim))
-        (function prim prim (>. prim prim))
-        (function prim prim (<=. prim prim))
-        (function prim prim (>=. prim prim)))
-      (makeblock 0 (function prim (array.length[addr] prim))
-        (function prim prim (array.get[addr] prim prim))
-        (function prim prim
+        (function prim prim stub (==. prim prim))
+        (function prim prim stub (!=. prim prim))
+        (function prim prim stub (<. prim prim))
+        (function prim prim stub (>. prim prim))
+        (function prim prim stub (<=. prim prim))
+        (function prim prim stub (>=. prim prim)))
+      (makeblock 0 (function prim stub (array.length[addr] prim))
+        (function prim prim stub
+          (array.get[addr] prim prim))
+        (function prim prim stub
           (array.unsafe_get[addr] prim prim))
-        (function prim prim prim
+        (function prim prim prim stub
           (array.set[addr] prim prim prim))
-        (function prim prim prim
+        (function prim prim prim stub
           (array.unsafe_set[addr] prim prim prim))
-        (function prim prim
+        (function prim prim stub
           (caml_string_compare prim prim))
-        (function prim prim
+        (function prim prim stub
           (caml_string_equal prim prim))
-        (function prim prim
+        (function prim prim stub
           (caml_string_notequal prim prim))
-        (function prim prim
+        (function prim prim stub
           (caml_string_lessthan prim prim))
-        (function prim prim
+        (function prim prim stub
           (caml_string_greaterthan prim prim))
-        (function prim prim
+        (function prim prim stub
           (caml_string_lessequal prim prim))
-        (function prim prim
+        (function prim prim stub
           (caml_string_greaterequal prim prim)))
-      (makeblock 0 (function prim (array.length[addr] prim))
-        (function prim prim (array.get[addr] prim prim))
-        (function prim prim
+      (makeblock 0 (function prim stub (array.length[addr] prim))
+        (function prim prim stub
+          (array.get[addr] prim prim))
+        (function prim prim stub
           (array.unsafe_get[addr] prim prim))
-        (function prim prim prim
+        (function prim prim prim stub
           (array.set[addr] prim prim prim))
-        (function prim prim prim
+        (function prim prim prim stub
           (array.unsafe_set[addr] prim prim prim))
-        (function prim prim
+        (function prim prim stub
           (caml_int32_compare prim prim))
-        (function prim prim (Int32.== prim prim))
-        (function prim prim (Int32.!= prim prim))
-        (function prim prim (Int32.< prim prim))
-        (function prim prim (Int32.> prim prim))
-        (function prim prim (Int32.<= prim prim))
-        (function prim prim (Int32.>= prim prim)))
-      (makeblock 0 (function prim (array.length[addr] prim))
-        (function prim prim (array.get[addr] prim prim))
-        (function prim prim
+        (function prim prim stub (Int32.== prim prim))
+        (function prim prim stub (Int32.!= prim prim))
+        (function prim prim stub (Int32.< prim prim))
+        (function prim prim stub (Int32.> prim prim))
+        (function prim prim stub (Int32.<= prim prim))
+        (function prim prim stub (Int32.>= prim prim)))
+      (makeblock 0 (function prim stub (array.length[addr] prim))
+        (function prim prim stub
+          (array.get[addr] prim prim))
+        (function prim prim stub
           (array.unsafe_get[addr] prim prim))
-        (function prim prim prim
+        (function prim prim prim stub
           (array.set[addr] prim prim prim))
-        (function prim prim prim
+        (function prim prim prim stub
           (array.unsafe_set[addr] prim prim prim))
-        (function prim prim
+        (function prim prim stub
           (caml_int64_compare prim prim))
-        (function prim prim (Int64.== prim prim))
-        (function prim prim (Int64.!= prim prim))
-        (function prim prim (Int64.< prim prim))
-        (function prim prim (Int64.> prim prim))
-        (function prim prim (Int64.<= prim prim))
-        (function prim prim (Int64.>= prim prim)))
-      (makeblock 0 (function prim (array.length[addr] prim))
-        (function prim prim (array.get[addr] prim prim))
-        (function prim prim
+        (function prim prim stub (Int64.== prim prim))
+        (function prim prim stub (Int64.!= prim prim))
+        (function prim prim stub (Int64.< prim prim))
+        (function prim prim stub (Int64.> prim prim))
+        (function prim prim stub (Int64.<= prim prim))
+        (function prim prim stub (Int64.>= prim prim)))
+      (makeblock 0 (function prim stub (array.length[addr] prim))
+        (function prim prim stub
+          (array.get[addr] prim prim))
+        (function prim prim stub
           (array.unsafe_get[addr] prim prim))
-        (function prim prim prim
+        (function prim prim prim stub
           (array.set[addr] prim prim prim))
-        (function prim prim prim
+        (function prim prim prim stub
           (array.unsafe_set[addr] prim prim prim))
-        (function prim prim
+        (function prim prim stub
           (caml_nativeint_compare prim prim))
-        (function prim prim (Nativeint.== prim prim))
-        (function prim prim (Nativeint.!= prim prim))
-        (function prim prim (Nativeint.< prim prim))
-        (function prim prim (Nativeint.> prim prim))
-        (function prim prim (Nativeint.<= prim prim))
-        (function prim prim (Nativeint.>= prim prim))))))
+        (function prim prim stub
+          (Nativeint.== prim prim))
+        (function prim prim stub
+          (Nativeint.!= prim prim))
+        (function prim prim stub (Nativeint.< prim prim))
+        (function prim prim stub (Nativeint.> prim prim))
+        (function prim prim stub
+          (Nativeint.<= prim prim))
+        (function prim prim stub
+          (Nativeint.>= prim prim))))))


### PR DESCRIPTION
When Flambda has to create small functions for things like partial applications, it marks these functions as "stub" functions. This changes the heuristics for inlining them, and can produce much better code. 

However, lambda also creates such functions and they are not currently marked as "stub" since lambda code has no such notion. This PR fixes that deficiency. It adds a `stub` field to the `function_attribute` type in `lambda.ml` and uses it to mark the small wrapper functions produced by lambda.

`closure.ml` is also updated to always inline such functions much as flambda does -- although since they're all tiny this change is basically a no-op.

The addition of "stub" to lambda also allows to remove a horrible hack around the treatment of "default argument wrappers" in `closure_conversion.ml`.

The following program demonstrates the benefit of this PR. It produces much better code with this change, as without it the partial applications of labelled functions get in the way of the inlining heuristics:

```
type 'a t =
    F :
      { init : unit -> 's
      ; cond : 's -> bool
      ; step : 's -> ('a -> unit) -> unit
      ; freeze : 's -> 'a t } -> 'a t

let[@inline] fold  ~init ~f (F t)=
  let s = t.init () in
  let acc = ref init in
  while t.cond s do
    t.step s (fun a -> acc := f !acc a)
  done;
  !acc

let[@inline] rec of_array a ~i =
  let[@inline] init () = ref i in
  let[@inline] cond s = !s < Array.length a in
  let[@inline] step s f = f a.(!s); incr s in
  let[@inline] freeze s = of_array a ~i:!s in
  F { init; cond; step; freeze }

let of_array = of_array ~i:0

let[@inline] rec map ~f t =
  match t with
  | F t ->
    let[@inline] step s g = t.step s ((fun a -> g (f a)) [@inline]) in
    F { step;
        init = t.init;
        cond = t.cond;
        freeze = fun s -> (map[@inlined never]) ~f (t.freeze s)
      }

let[@inline] filter t ~f =
  match t with
  | F t ->
    let[@inline] step s g = t.step s ((fun a -> if f a then g a) [@inline]) in
    F { t with step }

let main a =
  of_array a
  |> map ~f:((+) 1)
  |> filter ~f:(fun x -> x mod 2 = 0)
  |> fold ~init:0 ~f:(+)
```