### PR TITLE
Fix stack size calculation in the presence of threads

### DIFF
--- a/Changes
+++ b/Changes
@@ -163,6 +163,9 @@ Next version (4.05.0):
   (Jeremy Yallop,
    review by Damien Doligez, Alain Frisch, Daniel Bünzli, Fabrice Le Fessant)
 
+- GPR#961: Incorrect stack size reported in the presence of threads
+  (Mark Shinwell, report by Ben Millwood)
+
 Next minor version (4.04.1):
 ----------------------------
 

--- a/byterun/caml/stack.h
+++ b/byterun/caml/stack.h
@@ -121,6 +121,7 @@ extern value * caml_globals[];
 extern char caml_globals_map[];
 extern intnat caml_globals_inited;
 extern intnat * caml_frametable[];
+extern char* caml_system_stack_top;
 
 CAMLextern frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp);
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -472,10 +472,10 @@ CAMLprim value caml_thread_initialize(value unit)   /* ML */
   curr_thread->backtrace_last_exn = Val_unit;
 #ifdef NATIVE_CODE
   curr_thread->exit_buf = &caml_termination_jmpbuf;
-  curr_thread->bottom_of_stack = caml_bottom_of_stack;
+  curr_thread->top_of_stack = caml_system_stack_top;
   {
     char local_var;
-    curr_thread->top_of_stack = &local_var;
+    curr_thread->bottom_of_stack = &local_var;
   }
 #endif
   /* The stack-related fields will be filled in at the next

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -472,6 +472,11 @@ CAMLprim value caml_thread_initialize(value unit)   /* ML */
   curr_thread->backtrace_last_exn = Val_unit;
 #ifdef NATIVE_CODE
   curr_thread->exit_buf = &caml_termination_jmpbuf;
+  curr_thread->bottom_of_stack = caml_bottom_of_stack;
+  {
+    char local_var;
+    curr_thread->top_of_stack = &local_var;
+  }
 #endif
   /* The stack-related fields will be filled in at the next
      caml_enter_blocking_section */


### PR DESCRIPTION
The current stack size calculation is broken in the presence of threads---and is unfortunately troublesome to see in its broken state, since it depends on the value of uninitialised memory.

The problem is that the "top" stack limit (which morally speaking is actually the bottom) is not initialised for the "very first" thread that initially triggers `caml_thread_initialize`.  Its value depends on whatever was in the malloc arena beforehand.  This causes bogus results from the size calculation in due course.

This patch should fix this issue.  To get the size of the "very first" thread's stack it exposes a variable calculated in signals_asm.c, used previously only for stack overflow detection.

@xavierleroy Does this look correct to you?