### PR TITLE
Upgrade installed Cygwin packages in AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,8 @@ install:
   # Make sure the Cygwin path comes before the Git one (otherwise
   # cygpath behaves crazily), but after the MSVC one.
   - set Path=C:\cygwin\bin;%Path%
-  - '"%CYG_ROOT%\setup-x86.exe" -qnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P diffutils -P dos2unix -P gcc-core -P make -P ncurses >NUL'
+  - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
+  - '"%CYG_ROOT%\setup-x86.exe" -qgnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P diffutils -P dos2unix -P gcc-core -P make -P ncurses >NUL'
   - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
   - call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
   - set Path=%OCAMLROOT%\bin;%OCAMLROOT%\bin\flexdll;%Path%


### PR DESCRIPTION
The Cygwin diffutils packages was updated a few days ago and this is causing a conflict on the AppVeyor CI because the new diff binary depends on an updated Cygwin DLL.

The fix is to add the `-g` parameter to the call to Cygwin's setup which installs diffutils (and other packages). The effect of this switch is to upgrade all existing packages as well (i.e. `sudo apt-get upgrade` / `sudo yum update`). The effect of this is that the Cygwin installation takes noticeably longer, probably owing to having to rebase the entire installation.

Ultimately, this requires the underlying AppVeyor Cygwin installation image to be updated - we can monitor this by looking for early in AppVeyor logs for these lines:

```
%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"
Cygwin Package Information
Package              Version
cygwin               2.5.2-1
"%CYG_ROOT%\setup-x86.exe" -qgnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P diffutils -P dos2unix -P gcc-core -P make -P ncurses >NUL %CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"
Cygwin Package Information
Package              Version
cygwin               2.6.0-1
call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
```

which allows us to see the version of the Cygwin package before and after update.