### PR TITLE
Move the ref_to_variables pass to a later position

### DIFF
--- a/middle_end/middle_end.ml
+++ b/middle_end/middle_end.ml
@@ -91,11 +91,11 @@ let middle_end ppf ~source_provenance ~prefixname ~backend
       +-+ ("Inline_and_simplify",
            Inline_and_simplify.run ~never_inline:false ~backend
              ~prefixname ~round)
-      +-+ ("Ref_to_variables",
-           Ref_to_variables.eliminate_ref)
       +-+ ("Remove_unused_closure_vars 2",
            Remove_unused_closure_vars.remove_unused_closure_variables
              ~remove_direct_call_surrogates:false)
+      +-+ ("Ref_to_variables",
+           Ref_to_variables.eliminate_ref)
       +-+ ("Initialize_symbol_to_let_symbol",
            Initialize_symbol_to_let_symbol.run)
     in
@@ -126,14 +126,14 @@ let middle_end ppf ~source_provenance ~prefixname ~backend
              Remove_unused_closure_vars.remove_unused_closure_variables
               ~remove_direct_call_surrogates:false)
         +-+ ("lift_lets 3", Lift_code.lift_lets)
-        +-+ ("Ref_to_variables",
-             Ref_to_variables.eliminate_ref)
         +-+ ("Inline_and_simplify noinline",
              Inline_and_simplify.run ~never_inline:true ~backend
               ~prefixname ~round)
         +-+ ("Remove_unused_closure_vars 3",
              Remove_unused_closure_vars.remove_unused_closure_variables
               ~remove_direct_call_surrogates:false)
+        +-+ ("Ref_to_variables",
+             Ref_to_variables.eliminate_ref)
         +-+ ("Initialize_symbol_to_let_symbol",
              Initialize_symbol_to_let_symbol.run)
         |> loop


### PR DESCRIPTION
The ordering of the last few phases of an flambda round is:

- Ref_to_variables
- Inline_and_simplify noinline
- Remove_unused_closure_vars 3

The transformation done by ref_to_variables does not produce anything which can be simplified -- dealing as it does with mutable things -- nor can it affect which closure vars are used. However, both inline_and_simplify and remove_unused_closure_vars can make more variables suitable for turning to references -- inline_and_simplify removes aliases and unused definitions whilst remove_unused_closure_vars can remove unused functions which might include escaping references to potential mutable variables.

So this PR to moves the ref_to_variables pass after those two passes. A similar change is made for `-Oclassic`.