### PR TITLE
PR#7172: ocamlc -config: add int_size, word_size, natdynlink, ext_exe

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,6 +36,10 @@ Next version (4.05.0):
    and Damien Doligez, discussion with Alain Frisch and Xavier Leroy,
    feature request from the Coq team)
 
+- PR#7172, GPR#970: add extra (ocamlc -config) options
+  int_size, word_size, ext_exe
+  (Gabriel Scherer, request by Daniel Buenzli)
+
 - GPR#829: better error when opening a module aliased to a functor
   (Alain Frisch)
 

--- a/Makefile
+++ b/Makefile
@@ -423,6 +423,7 @@ utils/config.ml: utils/config.mlp config/Makefile
 	    -e 's|%%ARCH%%|$(ARCH)|' \
 	    -e 's|%%MODEL%%|$(MODEL)|' \
 	    -e 's|%%SYSTEM%%|$(SYSTEM)|' \
+	    -e 's|%%EXT_EXE%%|$(EXE)|' \
 	    -e 's|%%EXT_OBJ%%|.o|' \
 	    -e 's|%%EXT_ASM%%|.s|' \
 	    -e 's|%%EXT_LIB%%|.a|' \

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -387,6 +387,7 @@ utils/config.ml: utils/config.mlp config/Makefile
 	    -e "s|%%ARCH%%|$(ARCH)|" \
 	    -e "s|%%MODEL%%|$(MODEL)|" \
 	    -e "s|%%SYSTEM%%|$(SYSTEM)|" \
+	    -e "s|%%EXT_EXE%%|$(EXE)|" \
 	    -e "s|%%EXT_OBJ%%|.$(O)|" \
 	    -e "s|%%EXT_ASM%%|.$(S)|" \
 	    -e "s|%%EXT_LIB%%|.$(A)|" \

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -109,6 +109,7 @@ let libunwind_link_flags = "%%LIBUNWIND_LINK_FLAGS%%"
 let profinfo = %%WITH_PROFINFO%%
 let profinfo_width = %%PROFINFO_WIDTH%%
 
+let ext_exe = "%%EXT_EXE%%"
 let ext_obj = "%%EXT_OBJ%%"
 let ext_asm = "%%EXT_ASM%%"
 let ext_lib = "%%EXT_LIB%%"
@@ -127,6 +128,7 @@ let systhread_supported = %%SYSTHREAD_SUPPORT%%;;
 
 let print_config oc =
   let p name valu = Printf.fprintf oc "%s: %s\n" name valu in
+  let p_int name valu = Printf.fprintf oc "%s: %d\n" name valu in
   let p_bool name valu = Printf.fprintf oc "%s: %B\n" name valu in
   p "version" version;
   p "standard_library_default" standard_library_default;
@@ -142,10 +144,13 @@ let print_config oc =
   p "cc_profile" cc_profile;
   p "architecture" architecture;
   p "model" model;
+  p_int "int_size" Sys.int_size;
+  p_int "word_size" Sys.word_size;
   p "system" system;
   p "asm" asm;
   p_bool "asm_cfi_supported" asm_cfi_supported;
   p_bool "with_frame_pointers" with_frame_pointers;
+  p "ext_exe" ext_exe;
   p "ext_obj" ext_obj;
   p "ext_asm" ext_asm;
   p "ext_lib" ext_lib;


### PR DESCRIPTION
See [MPR#7172](https://caml.inria.fr/mantis/view.php?id=7172#c16992).

Among the options that @dbuenzli asked, one that is not included is "nativecomp", which he specified as "whether native compilation is available". First, I'm not completely sure how to implement that (there is no obvious makefile variable I can reuse), and second it is unclear to me that we actually can give it a specification: `config.mlp` tells about how the compiler distribution was *configured* to be built, but not about what was actually *installed* on the user machine, so while I can say if native-compilation was disabled at configure-time, if I say `true` at config-time you still have to check that `ocamlopt` is actually installed to be sure.