### PR TITLE
Compile the toplevel files with -opaque.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,7 +368,7 @@ partialclean::
 # The toplevel
 
 compilerlibs/ocamltoplevel.cma: $(TOPLEVEL)
-	$(CAMLC) -a -o $@ $(TOPLEVEL)
+	$(CAMLC) -a -opaque -o $@ $(TOPLEVEL)
 partialclean::
 	rm -f compilerlibs/ocamltoplevel.cma
 

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -347,7 +347,7 @@ partialclean::
 # The toplevel
 
 compilerlibs/ocamltoplevel.cma: $(TOPLEVEL)
-  $(CAMLC) -a -opaque -o $@ $(TOPLEVEL)
+	$(CAMLC) -a -opaque -o $@ $(TOPLEVEL)
 partialclean::
 	rm -f compilerlibs/ocamltoplevel.cma
 

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -347,7 +347,7 @@ partialclean::
 # The toplevel
 
 compilerlibs/ocamltoplevel.cma: $(TOPLEVEL)
-	$(CAMLC) -a -o $@ $(TOPLEVEL)
+  $(CAMLC) -a -opaque -o $@ $(TOPLEVEL)
 partialclean::
 	rm -f compilerlibs/ocamltoplevel.cma
 


### PR DESCRIPTION
For example ocamlfind, camlp4 complain about topdirs.cmi and toploop.cmi not being compiled with -opaque.