### PR TITLE
Fix some globally-visible names, and add a tool for them

### DIFF
--- a/Changes
+++ b/Changes
@@ -38,6 +38,10 @@ Working version
   for native plugin files (i.e. .cmxs files)
   (Florian Angeletti, suggestion by Sébastien Hinderer)
 
+- MPR#1956, GPR#973: tools/check-symbol-names checks for globally
+  linked names not namespaced with caml_
+  (Stephen Dolan)
+
 ### Bug fixes
 
 - PR#7468: possible GC problem in caml_alloc_sprintf

--- a/byterun/backtrace_prim.c
+++ b/byterun/backtrace_prim.c
@@ -109,7 +109,7 @@ static int cmp_ev_info(const void *a, const void *b)
   return 0;
 }
 
-struct ev_info *process_debug_events(code_t code_start, value events_heap,
+static struct ev_info *process_debug_events(code_t code_start, value events_heap,
                                      mlsize_t *num_events)
 {
   CAMLparam1(events_heap);
@@ -324,7 +324,7 @@ CAMLprim value caml_get_current_callstack(value max_frames_value)
 #define O_BINARY 0
 #endif
 
-void read_main_debug_info(struct debug_info *di)
+static void read_main_debug_info(struct debug_info *di)
 {
   CAMLparam0();
   CAMLlocal3(events, evl, l);

--- a/byterun/caml/compact.h
+++ b/byterun/caml/compact.h
@@ -24,7 +24,7 @@
 
 void caml_compact_heap (void);
 void caml_compact_heap_maybe (void);
-void invert_root (value v, value *p);
+void caml_invert_root (value v, value *p);
 
 #endif /* CAML_INTERNALS */
 

--- a/byterun/compact.c
+++ b/byterun/compact.c
@@ -117,7 +117,7 @@ static void invert_pointer_at (word *p)
   }
 }
 
-void invert_root (value v, value *p)
+void caml_invert_root (value v, value *p)
 {
   invert_pointer_at ((word *) p);
 }
@@ -196,7 +196,7 @@ static void do_compaction (void)
     /* Invert roots first because the threads library needs some heap
        data structures to find its roots.  Fortunately, it doesn't need
        the headers (see above). */
-    caml_do_roots (invert_root, 1);
+    caml_do_roots (caml_invert_root, 1);
     /* The values to be finalised are not roots but should still be inverted */
     caml_final_invert_finalisable_values ();
 

--- a/byterun/finalise.c
+++ b/byterun/finalise.c
@@ -241,7 +241,7 @@ void caml_final_do_roots (scanning_action f)
   }
 }
 
-/* Call invert_root on the values of the finalisable set. This is called
+/* Call caml_invert_root on the values of the finalisable set. This is called
    directly by the compactor.
 */
 void caml_final_invert_finalisable_values ()
@@ -250,13 +250,13 @@ void caml_final_invert_finalisable_values ()
 
   CAMLassert (finalisable_first.old <= finalisable_first.young);
   for (i = 0; i < finalisable_first.young; i++){
-    invert_root(finalisable_first.table[i].val,
+    caml_invert_root(finalisable_first.table[i].val,
                 &finalisable_first.table[i].val);
   };
 
   CAMLassert (finalisable_last.old <= finalisable_last.young);
   for (i = 0; i < finalisable_last.young; i++){
-    invert_root(finalisable_last.table[i].val,
+    caml_invert_root(finalisable_last.table[i].val,
                 &finalisable_last.table[i].val);
   };
 }

--- a/byterun/spacetime.c
+++ b/byterun/spacetime.c
@@ -16,7 +16,7 @@
 #include "caml/fail.h"
 #include "caml/mlvalues.h"
 
-int ensure_spacetime_dot_o_is_included = 42;
+int caml_ensure_spacetime_dot_o_is_included = 42;
 
 CAMLprim value caml_spacetime_only_works_for_native_code(value foo, ...)
 {

--- a/byterun/startup.c
+++ b/byterun/startup.c
@@ -271,7 +271,7 @@ extern void caml_install_invalid_parameter_handler();
 
 #endif
 
-extern int ensure_spacetime_dot_o_is_included;
+extern int caml_ensure_spacetime_dot_o_is_included;
 
 /* Main entry point when loading code from a file */
 
@@ -284,7 +284,7 @@ CAMLexport void caml_main(char **argv)
   char * shared_lib_path, * shared_libs, * req_prims;
   char * exe_name, * proc_self_exe;
 
-  ensure_spacetime_dot_o_is_included++;
+  caml_ensure_spacetime_dot_o_is_included++;
 
   /* Machine-dependent initialization of the floating-point hardware
      so that it behaves as much as possible as specified in IEEE */

--- a/tools/check-symbol-names
+++ b/tools/check-symbol-names
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -o pipefail
+
+[ -z "$@" ] && { echo "Usage: $0 libfoo.a" 1>&2; exit 2; }
+
+nm -A -P "$@" | awk '
+# ignore caml_foo, camlFoo_bar, _caml_foo, _camlFoo_bar
+$2 ~ /^(_?caml[_A-Z])/ { next }
+# ignore local and undefined symbols
+$3 ~ /^[rbdtsU]$/ { next }
+# ignore "main", which should be externally linked
+$2 ~ /^_?main$/ { next }
+# print the rest
+{ found=1; print $1 " " $2 " " $3 }
+# fail if there were any results
+END { exit found ? 1 : 0 }
+'
+exit $?


### PR DESCRIPTION
[PR#1956](https://caml.inria.fr/mantis/view.php?id=1956) is about externally-linked names not prefixed with `caml_`, which can break other software. Since that issue was created, a couple more have snuck in (e.g. `invert_root` in `compare.c`).

This commit fixes those names, and adds `tools/check-symbol-names` to check for others. It may be a good idea to add:

    tools/check-symbol-names byterun/libcamlrun.a

as a step in the build, but I'll leave that step for someone else.

(The only remaining offending symbol (i.e. externally visible, not prefixed with "caml", and not "main") is `ensure_spacetime_dot_o_is_included`, whose function I don't really understand (despite the descriptive name). Does anyone know why this is necessary? @mshinwell?)