### PR TITLE
Enable msvc64 asmcomp tests

### DIFF
--- a/asmcomp/amd64/arch.ml
+++ b/asmcomp/amd64/arch.ml
@@ -131,3 +131,8 @@ let print_specific_operation printreg op ppf arg =
                    (Array.sub arg 1 (Array.length arg - 1))
   | Ibswap i ->
       fprintf ppf "bswap_%i %a" i printreg arg.(0)
+
+let win64 =
+  match Config.system with
+  | "win64" | "mingw64" | "cygwin" -> true
+  | _                   -> false

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -988,7 +988,7 @@ let begin_assembly() =
   end;
 
 
-  if !Clflags.dlcode then begin
+  if !Clflags.dlcode || Arch.win64 then begin
     (* from amd64.S; could emit these constants on demand *)
     begin match system with
     | S_macosx -> D.section ["__TEXT";"__literal16"] None ["16byte_literals"]

--- a/testsuite/makefiles/Makefile.common
+++ b/testsuite/makefiles/Makefile.common
@@ -62,9 +62,7 @@ defaultclean:
 	@$(OCAMLRUN) ./codegen -S $*.cmm
 
 .cmm.obj:
-	@$(OCAMLRUN) ./codegen $*.cmm \
-	| grep -v "_caml_\(young_ptr\|young_limit\|extra_params\
-	\|allocN\|raise_exn\|reraise_exn\)" > $*.s
+	@$(OCAMLRUN) ./codegen $*.cmm > $*.s
 	@set -o pipefail ; \
 	$(ASM) $*.obj $*.s | tail -n +2
 

--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -76,7 +76,7 @@ ARGS_integr=-DINT_FLOAT -DFUN=test main.c
 ARGS_arith=mainarith.c
 ARGS_checkbound=-DCHECKBOUND main.c
 ARGS_tagged-fib=-DINT_INT -DFUN=fib main.c
-ARGS_tagged-integr=-DINT_FLOAT -DFUN=test main.c
+ARGS_tagged-integr=-DINT_FLOAT -DFUN=_test main.c
 ARGS_tagged-quicksort=-DSORT -DFUN=quicksort main.c
 ARGS_tagged-tak=-DUNIT_INT -DFUN=takmain main.c
 ARGS_staticalloc=-I $(OTOPDIR)/utils config.cmx
@@ -114,16 +114,11 @@ clean: defaultclean
 
 include $(BASEDIR)/makefiles/Makefile.common
 
-ifeq "$(CCOMPTYPE)-$(ARCH)" "msvc-amd64"
-# these tests are not ported to MSVC64 yet
-SKIP=true
-else
-SKIP=false
-endif
-
 ifeq "$(WITH_SPACETIME)" "true"
 # These tests have not been ported for Spacetime
 SKIP=true
+else
+SKIP=false
 endif
 
 ifeq ($(CCOMPTYPE),msvc)
@@ -150,6 +145,10 @@ tests: $(CASES:=.$(O))
 promote:
 
 arch: $(ARCH).$(O)
+
+amd64.obj: amd64nt.asm
+	@set -o pipefail ; \
+	$(ASM) $@ $^ | tail -n +2
 
 i386.obj: i386nt.asm
 	@set -o pipefail ; \

--- a/testsuite/tests/asmcomp/amd64nt.asm
+++ b/testsuite/tests/asmcomp/amd64nt.asm
@@ -1,0 +1,57 @@
+        .CODE
+
+        PUBLIC  call_gen_code
+        ALIGN  16
+call_gen_code:
+        push    rbx
+        push    rbp
+        push    r12
+        push    r13
+        push    r14
+        push    r15
+        mov     rdi, r10
+        mov     rsi, rax
+        mov     rdx, rbx
+        mov     rcx, rdi
+        mov     r8, rsi
+        call    r10
+        pop     r15
+        pop     r14
+        pop     r13
+        pop     r12
+        pop     rbp
+        pop     rbx
+        ret
+
+        PUBLIC  caml_c_call
+        ALIGN  16
+caml_c_call:
+        jmp     rax
+
+        PUBLIC caml_call_gc
+        PUBLIC caml_alloc1
+        PUBLIC caml_alloc2
+        PUBLIC caml_alloc3
+        PUBLIC caml_allocN
+        PUBLIC caml_raise_exn
+caml_call_gc:
+caml_alloc1:
+caml_alloc2:
+caml_alloc3:
+caml_allocN:
+caml_raise_exn:
+        int     3
+
+        .DATA
+        PUBLIC caml_exception_pointer
+caml_exception_pointer QWORD 0, 0
+
+        PUBLIC  caml_young_ptr
+caml_young_ptr     LABEL QWORD
+        QWORD  0, 0
+
+        PUBLIC  caml_young_limit
+caml_young_limit    LABEL QWORD
+        QWORD  0, 0
+
+        END

--- a/testsuite/tests/asmcomp/i386nt.asm
+++ b/testsuite/tests/asmcomp/i386nt.asm
@@ -47,19 +47,25 @@ _caml_c_call:
         PUBLIC  _caml_alloc1
         PUBLIC  _caml_alloc2
         PUBLIC  _caml_alloc3
+        PUBLIC  _caml_allocN
+        PUBLIC  _caml_extra_params
+        PUBLIC  _caml_raise_exn
 _caml_call_gc:
 _caml_alloc:
 _caml_alloc1:
 _caml_alloc2:
 _caml_alloc3:
+_caml_allocN:
+_caml_extra_params:
+_caml_raise_exn:
         int     3
 
         .DATA
         PUBLIC  _caml_exception_pointer
 _caml_exception_pointer dword 0
-        PUBLIC  _young_ptr
-_young_ptr      dword 0
-        PUBLIC  _young_limit
-_young_limit    dword 0
+        PUBLIC  _caml_young_ptr
+_caml_young_ptr      dword 0
+        PUBLIC  _caml_young_limit
+_caml_young_limit    dword 0
 
         END

--- a/testsuite/tests/asmcomp/quicksort2.cmm
+++ b/testsuite/tests/asmcomp/quicksort2.cmm
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(function "cmp" (i: int j: int)
+(function "_cmp" (i: int j: int)
   (- i j))
 
 (function "quick" (lo: int hi: int a: val cmp: val)
@@ -47,4 +47,4 @@
     []))
 
 (function "quicksort" (lo: int hi: int a: val)
-  (app "quick" lo hi a "cmp" unit))
+  (app "quick" lo hi a "_cmp" unit))

--- a/testsuite/tests/asmcomp/tagged-integr.cmm
+++ b/testsuite/tests/asmcomp/tagged-integr.cmm
@@ -36,10 +36,10 @@
     (store float "res_integr" ( *f (load float s) (load float h)))
     "res_integr"))
 
-("low": skip 8)
-("hi": skip 8)
+("_low": skip 8)
+("_hi": skip 8)
 
-(function "test" (n: int)
-  (store float "low" 0.0)
-  (store float "hi" 1.0)
-  (load float (app "integr" "square" "low" "hi" n val)))
+(function "_test" (n: int)
+  (store float "_low" 0.0)
+  (store float "_hi" 1.0)
+  (load float (app "integr" "square" "_low" "_hi" n val)))


### PR DESCRIPTION
So for some reason I decided to port tests/asmcomp to msvc64 this evening. It was interesting, because I've never written any assembler before (and indeed, arguably, I still haven't...).

The first commit corrects a grim hack **I** added in 4.03.0 which allowed the msvc32 version of these tests to work - i386nt.asm had become stale and I should have fixed that, rather than resorting to hacking the assembler output.

This GPR includes a fix which is already part of #955 (and the fix in #955 is neater, so it should be merged first and the middle commit here removed).

There is a problem which seems to arise because of symbols not being decorated in the amd64 backend - ml64 is very fussy about names and I had to rename some symbols in cmm files. Is that OK - or is this is a sign of a (presumably) hidden problem with the msvc64 backend?

Another thing - why do we not run the programs compiled from the .cmm files? I ask because all of these seem to segfault as soon as they enter the OCaml portion (i.e. some can display usage instructions, but that comes from main.c). The mingw64 examples segfault too, so I'm guessing that something about amd64.S is wrong and therefore (presumably) my translation in amd64nt.asm. Presumably it is informative to run these programs too?

/cc @xavierleroy, @mshinwell 