### PR TITLE
[ocamldebug] increase the number of default checkpoints

### DIFF
--- a/debugger/debugger_config.ml
+++ b/debugger/debugger_config.ml
@@ -74,7 +74,7 @@ let checkpoint_big_step = ref (~~ "10000")
 let checkpoint_small_step = ref (~~ "1000")
 
 (* Maximum number of checkpoints. *)
-let checkpoint_max_count = ref 15
+let checkpoint_max_count = ref 300
 
 (* Whether to keep checkpoints or not. *)
 let make_checkpoints = ref


### PR DESCRIPTION
Two decades have passed since we set the default process count number. It's almost 2017 today, memory are much cheaper than before.

The default number today cannot even store the checkpoints for a helloworld Infer program (http://fbinfer.com/docs/hello-world.html).

This patch increases the default number to 300 (I'm all for setting it to a higher value).

cc @jeremydubreil @jordwalke