### PR TITLE
[ocamldebug] Catch out_of_range in "list" command

### DIFF
--- a/Changes
+++ b/Changes
@@ -53,7 +53,7 @@ Next version (4.05.0):
   This can be tested with ocamlopt -config
   (Sébastien Hinderer)
 
-- PR#7137, GPR#960: "-open" command line flag now accepts a module path 
+- PR#7137, GPR#960: "-open" command line flag now accepts a module path
   (not a module name) (Arseniy Alekseyev and Leo White)
 
 ### Standard library:
@@ -101,6 +101,9 @@ Next version (4.05.0):
 * PR#7342, GPR#797: fix Unix.read on pipes with no data left on Windows
   it previously raised an EPIPE error, it now returns 0 like other OSes
   (Jonathan Protzenko)
+
+### Debugger:
+- GPR#977: Catch Out_of_range in "list" command (Yunxing)
 
 ### Tools:
 

--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -791,7 +791,10 @@ let instr_list _ppf lexbuf =
         | Not_found -> error ("No source file for " ^ mdle ^ ".") in
       let point =
         if column <> -1 then
-          (point_of_coord buffer line 1) + column
+          try
+            (point_of_coord buffer line 1) + column
+          with Out_of_range ->
+            -1
         else
           -1 in
         let beginning =


### PR DESCRIPTION
If you type list at a step where the source info is not available, ocamldebug could crash
due to the uncaught exception. This patch catches the exception and returns an user friendly
error message instead.