### PR TITLE
Fix problem with ocamlopt.opt -plugin

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,16 +8,21 @@ Next version (4.04.1):
 
 ### Bug fixes
 
-- PR#7405, GPR#903: s390x: Fix address of caml_raise_exn in native dynlink modules
+- PR#7405, GPR#903: s390x: Fix address of caml_raise_exn in native
+  dynlink modules
   (Richard Jones, review by Xavier Leroy)
 
-- MPR#7417, GPR#930: ensure 16 byte stack alignment inside caml_allocN on x86-64
-  for ocaml build with WITH_FRAME_POINTERS defined
+- MPR#7417, GPR#930: ensure 16 byte stack alignment inside caml_allocN
+  on x86-64 for ocaml build with WITH_FRAME_POINTERS defined
   (Christoph Cullmann)
 
-- GPR#912: Fix segfault in Unix.create_process on Windows caused by wrong header
-  configuration.
+- GPR#912: Fix segfault in Unix.create_process on Windows caused by
+  wrong header configuration.
   (David Allsopp)
+
+- GPR#980: add dynlink options to ocamlbytecomp.cmxa to allow ocamlopt.opt
+  to load plugins. See http://github.com/OCamlPro/ocamlc-plugins for examples.
+  (Fabrice Le Fessant)
 
 OCaml 4.04.0 (4 Nov 2016):
 --------------------------

--- a/Makefile
+++ b/Makefile
@@ -475,7 +475,7 @@ partialclean::
 # The bytecode compiler compiled with the native-code compiler
 
 compilerlibs/ocamlbytecomp.cmxa: $(BYTECOMP:.cmo=.cmx)
-	$(CAMLOPT) -a -o $@ $(BYTECOMP:.cmo=.cmx)
+	$(CAMLOPT) -a -ccopt "$(NATDYNLINKOPTS)" -o $@ $(BYTECOMP:.cmo=.cmx)
 partialclean::
 	rm -f compilerlibs/ocamlbytecomp.cmxa compilerlibs/ocamlbytecomp.a
 


### PR DESCRIPTION
In 4.04, `ocamlopt.opt` cannot load plugins, whereas `ocamlc.byte`, `ocamlc.opt` and `ocamlopt.byte` work correctly with plugins. This is due to a missing argument when linking `ocamlopt.opt`, whereas `ocamlc.opt` is correctly linked. This PR adds the missing argument.