### PR TITLE
Extend #960 to include ocamldoc -open

### DIFF
--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -50,7 +50,7 @@ let initial_env () =
   let open_mod env m =
     let open Asttypes in
     let lid = {loc = Location.in_file "ocamldoc command line";
-               txt = Longident.Lident m } in
+               txt = Longident.parse m } in
     snd (Typemod.type_open_ Override env lid.loc lid) in
   (* Open the list of modules given as arguments of the "-open" flag
      The list is reversed to open the modules in the left-to-right order *)

--- a/testsuite/tests/tool-ocamldoc-open/Makefile
+++ b/testsuite/tests/tool-ocamldoc-open/Makefile
@@ -33,7 +33,7 @@ alias.odoc: inner.cmi alias.ml
 
 main.odoc: alias.cmi main.ml
 	@$(OCAMLDOC) $(DOCFLAGS) -hide-warnings \
-        -open Alias -open Aliased_inner -dump main.odoc main.ml
+        -open Alias.Container -open Aliased_inner -dump main.odoc main.ml
 
 alias.cmi:inner.cmi
 

--- a/testsuite/tests/tool-ocamldoc-open/alias.ml
+++ b/testsuite/tests/tool-ocamldoc-open/alias.ml
@@ -1,1 +1,3 @@
-module Aliased_inner = Inner
+module Container = struct
+  module Aliased_inner = Inner
+end

--- a/testsuite/tests/tool-ocamldoc-open/doc.reference
+++ b/testsuite/tests/tool-ocamldoc-open/doc.reference
@@ -16,10 +16,19 @@
 
 
 \begin{ocamldoccode}
-{\tt{module }}{\tt{Aliased\_inner}}{\tt{ : }}\end{ocamldoccode}
-\label{module:Alias.Aliased-underscoreinner}\index{Aliased-underscoreinner@\verb`Aliased_inner`}
+{\tt{module }}{\tt{Container}}{\tt{ : }}\end{ocamldoccode}
+\label{module:Alias.Container}\index{Container@\verb`Container`}
 
+\begin{ocamldocsigend}
+
+
+\begin{ocamldoccode}
+{\tt{module }}{\tt{Aliased\_inner}}{\tt{ : }}\end{ocamldoccode}
+\label{module:Alias.Container.Aliased-underscoreinner}\index{Aliased-underscoreinner@\verb`Aliased_inner`}
 {\tt{Inner}}
+
+\end{ocamldocsigend}
+
 
 
 
@@ -48,7 +57,7 @@ type a = int
 
 
 \label{type:Main.t}\begin{ocamldoccode}
-type t = Alias.Aliased_inner.a 
+type t = Alias.Container.Aliased_inner.a 
 \end{ocamldoccode}
 \index{t@\verb`t`}
 \begin{ocamldocdescription}


### PR DESCRIPTION
This very short PR propagates the improvements to the `-open` option introduced in #960 to ocamldoc.
Since this is a very short consistency fix, I will merge this once CI tests pass.