### PR TITLE
Fix Spacetime compilation

### DIFF
--- a/Changes
+++ b/Changes
@@ -156,6 +156,10 @@ Next version (4.05.0):
   when the opt target is built but opt.opt target is not.
   (whitequark)
 
+- GPR#984: Fix compilation of compiler distribution when Spacetime
+  enabled
+  (Mark Shinwell)
+
 ### Internal/compiler-libs changes:
 
 - GPR#744, GPR#781: fix duplicate self-reference in imported cmi_crcs

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -1020,7 +1020,7 @@ method emit_fundecl f =
   let env =
     List.fold_right2
       (fun (id, _ty) r env -> env_add id r env)
-      f.Cmm.fun_args rargs env_empty in
+      f.Cmm.fun_args rargs (self#initial_env ()) in
   let spacetime_node_hole, env =
     if not Config.spacetime then None, env
     else begin


### PR DESCRIPTION
The compiler currently doesn't build on trunk with Spacetime enabled due to a classic OO programming error...