### PR TITLE
ocamldoc: keep using relative instead of absolute source file names

### DIFF
--- a/Changes
+++ b/Changes
@@ -120,6 +120,10 @@ Next version (4.05.0):
   (Etienne Millon, review by Gabriel Scherer, Florian Angeletti and
   Daniel Bünzli)
 
+- GPR#986: ocamldoc, use relative paths in error message
+  to solve ocamlbuild+doc usability issue (ocaml/ocamlbuild#79)
+  (Gabriel Scherer, review by Florian Angeletti, discussion with Daniel Bünzli)
+
 - clarify ocamldoc text parsing error messages
   (Gabriel Scherer)
 

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -1867,21 +1867,7 @@ module Analyser =
      let analyse_typed_tree source_file input_file
          (parsetree : Parsetree.structure) (typedtree : typedtree) =
        let (tree_structure, _) = typedtree in
-       let complete_source_file =
-         try
-           let curdir = Sys.getcwd () in
-           let (dirname, basename) = (Filename.dirname source_file, Filename.basename source_file) in
-           Sys.chdir dirname ;
-           let complete = Filename.concat (Sys.getcwd ()) basename in
-           Sys.chdir curdir ;
-           complete
-         with
-           Sys_error s ->
-             prerr_endline s ;
-             incr Odoc_global.errors ;
-             source_file
-       in
-       prepare_file complete_source_file input_file;
+       prepare_file source_file input_file;
        (* We create the t_module for this file. *)
        let mod_name = String.capitalize_ascii (Filename.basename (Filename.chop_extension source_file)) in
        let (len,info_opt) = My_ir.first_special !file_name !file in

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -1619,21 +1619,7 @@ module Analyser =
 
     let analyse_signature source_file input_file
         (ast : Parsetree.signature) (signat : Types.signature) =
-      let complete_source_file =
-        try
-          let curdir = Sys.getcwd () in
-          let (dirname, basename) = (Filename.dirname source_file, Filename.basename source_file) in
-          Sys.chdir dirname ;
-          let complete = Filename.concat (Sys.getcwd ()) basename in
-          Sys.chdir curdir ;
-          complete
-        with
-          Sys_error s ->
-            prerr_endline s ;
-            incr Odoc_global.errors ;
-            source_file
-      in
-      prepare_file complete_source_file input_file;
+      prepare_file source_file input_file;
       (* We create the t_module for this file. *)
       let mod_name = String.capitalize_ascii
           (Filename.basename (try Filename.chop_extension source_file with _ -> source_file))


### PR DESCRIPTION
The fact that ocamldoc uses absolute file paths in its error messages
creates a usability problem for ocamlbuild users that see the path of
the files in _build instead of the path of the files in the source
project. See <https://github.com/ocaml/ocamlbuild/issues/79>:

    cd /tmp
    mkdir repro; cd repro
    echo "(** hey {ol {1 bla}} *)" > a.mli
    echo "A" > doc.odocl
    ocamlbuild doc.docdir/index.html

raises the error message:

>     File "/tmp/repro/_build/a.mli", line 0, character 11:
>     Error parsing text:
>     hey {ol {1 bla}}
>                ^

and then people jump to the reported error site from their editor, and
then they are editing temporary _build files and it is a mess.

After the patch is applied, we get the following error message instead:

>     File "a.mli", line 0, character 11:
>     Error parsing text:
>     hey {ol {1 bla}}
>                ^

The code that is removed by the patch is also a mess, of undocumented
assumptions. It is careful to Sys.chdir to the argument's directory,
and to capture a long name there and Sys.chdir back. This would make
perfect sense if other parts of ocamldoc were also using 'chdir' and
one could therefore not trust relative paths. But these were the only
two places using 'chdir', so the present change actually establishes
the property that relative paths can be trusted.

I am not imaginative enough to have a sense of what can go wrong as
we turn those absolute paths into relative paths. I looked at the
blame information, this code comes from the very first ocamldoc
commits by Maxence in 2002. My guess would be that early prototypes
used 'chdir' more agressively (maybe to call the typechecker as an
external command?), making absolute paths useful.