### PR TITLE
alloc_sockaddr: Unix domain sockets: use provided address length

### DIFF
--- a/Changes
+++ b/Changes
@@ -216,6 +216,10 @@ Next version (4.05.0):
 - GPR#934: check for integer overflow in Bytes.extend
   (Jeremy Yallop, review by Gabriel Scherer)
 
+- GPR#987: alloc_sockaddr: don't assume a null terminator. It is not inserted
+  on macOS by system calls that fill in a struct sockaddr (e.g. getsockname).
+  (Anton Bachin)
+
 Next minor version (4.04.1):
 ----------------------------
 


### PR DESCRIPTION
macOS (apparently) does not null-terminate Unix domain socket paths returned by `getsockname`. A sufficiently long path would also not be terminated on Linux (see [man page](http://man7.org/linux/man-pages/man7/unix.7.html), section BUGS). The current code in `alloc_sockaddr` assumes that the path is null-terminated. The fix uses the reported length instead of assuming the terminator, and subsumes the special case when the socket is not bound. The fix is based on the BUGS section of the linked man page.

The following code reproduces the problem on my macOS system, with `trunk`:

```ocaml
let () =
  let socket_path = "foobar" in

  let rec repeat = function
    | 0 -> ()
    | n ->
      let fd = Unix.(socket PF_UNIX SOCK_STREAM 0) in
      Unix.(bind fd (ADDR_UNIX socket_path));
      let actual_path =
        match Unix.getsockname fd with
        | Unix.ADDR_UNIX path -> path
        | _ -> assert false
      in
      Unix.close fd;
      Unix.unlink socket_path;
      if actual_path <> socket_path then begin
        prerr_endline actual_path;
        String.iter (fun c -> Printf.eprintf "%02X " (Char.code c)) actual_path;
        prerr_newline ();
        exit 1
      end;
      repeat (n - 1)
  in

  repeat 2

(* ocamlfind opt -linkpkg -package unix repro.ml *)
```

Running it produces outputs such as

```
foobarP(?   
66 6F 6F 62 61 72 50 28 BA 09 01
```

I looked in `testsuite/tests/lib-unix`, but it looks that code needs quite some work to be a proper test suite for the Unix library. I decided not to add tests.
