### PR TITLE
Build dylibs, not bundles, on macOS

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,10 @@ Next version (4.05.0):
   and "0 mod <expr>" in the case when <expr> was a non-constant
   evaluating to zero (Mark Shinwell)
 
+- MPR#6927, GPR#988: On macOS, when compiling bytecode stubs, plugins,
+  and shared libraries through -output-obj, generate dylibs instead of
+  bundles. (whitequark)
+
 ### Runtime system:
 
 ### Type system:

--- a/configure
+++ b/configure
@@ -794,13 +794,13 @@ if test $with_sharedlibs = "yes"; then
       mksharedlibrpath="-rpath "
       shared_libraries_supported=true;;
     i[3456]86-*-darwin[89].*)
-      mksharedlib="$bytecc -bundle -flat_namespace -undefined suppress \
+      mksharedlib="$bytecc -shared -flat_namespace -undefined suppress \
                    -read_only_relocs suppress"
       bytecccompopts="$dl_defs $bytecccompopts"
       dl_needs_underscore=false
       shared_libraries_supported=true;;
     *-apple-darwin*)
-      mksharedlib="$bytecc -bundle -flat_namespace -undefined suppress \
+      mksharedlib="$bytecc -shared -flat_namespace -undefined suppress \
                    -Wl,-no_compact_unwind"
       bytecccompopts="$dl_defs $bytecccompopts"
       dl_needs_underscore=false


### PR DESCRIPTION
Generally, OCaml creates dynamic libraries in three cases:
  * when building bytecode stubs (dllX.so);
  * when building a .cmxs plugin;
  * when building a .native.so or even .byte.so.

Right now, this results in DLLs on Windows and ELF shared objects on Linux,
all of which can be dynamically loaded (with dlopen() or equivalent) or
linked against (with the -l linker flag or equivalent). However, on macOS,
this is not the case.

macOS has two kinds of dynamic libraries: "bundles" and "dylibs". Prior to
the version 10.4, there have been significant differences between these,
which I will not describe in this commit because 10.4 has long became
irrelevant. After 10.4, there are only two differences:
  * rpath is handled slightly differently.
  * dylibs can be linked against, with the -l linker flag;

Before this commit, ocamlc/ocamlopt on macOS produce bundles, when using
the .so extension for the output file. After this commit, OCaml on macOS
will produce dylibs, when using the same extension. The rationale is as
follows:
  * For bytecode stubs and plugins, the exact structure of which is essentially
    an implementation detail of the OCaml runtime, nothing will change because
    they can still be dynamically loaded.
  * For .native.so and .byte.so objects, there are two changes:
      1. The objects can be linked against with the -l flag.
      2. The objects can be linked with the -cclib -shared flag, which is
         what ocamlbuild and perhaps other buildsystems pass when building
         a shared object through -output-obj/-output-complete-obj.