### PR TITLE
MPR#7443: fix spurious "unused open" warnings in presence of local open in patterns

### DIFF
--- a/Changes
+++ b/Changes
@@ -205,6 +205,9 @@ Next version (4.05.0):
 - PR#7437: typing assert failure with nonrec priv
   (Jacques Garrigue, report by Anil Madhavapeddy)
 
+- PR#7443, GPR#990: spurious unused open warning with local open in patterns
+  (Florian Angeletti, report by Gabriel Scherer)
+
 - GPR#795: remove 256-character limitation on Sys.executable_name
   (Xavier Leroy)
 

--- a/testsuite/tests/warnings/w33.ml
+++ b/testsuite/tests/warnings/w33.ml
@@ -1,0 +1,16 @@
+(** Test unused opens, in particular in presence of
+     pattern open *)
+
+module M = struct end
+module N = struct type t = A | B end
+module R = struct type r = {x: int} end
+
+let f M.(x) = x (* useless open *)
+let g N.(A|B) = () (* used open *)
+let h R.{x} = R.{x}
+
+open N (* used open *)
+let i (A|B) = B
+
+open! M (* open! also deactivates unused open warning *)
+open M (* useless open *)

--- a/testsuite/tests/warnings/w33.reference
+++ b/testsuite/tests/warnings/w33.reference
@@ -1,0 +1,4 @@
+File "w33.ml", line 8, characters 6-11:
+Warning 33: unused open M.
+File "w33.ml", line 16, characters 0-6:
+Warning 33: unused open M.

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1853,7 +1853,7 @@ let contains_gadt env p =
         with Not_found -> ()
         end; iter_ppat (loop env) p
       | Ppat_open (lid,sub_p) ->
-        let _, new_env = !type_open Asttypes.Fresh env p.ppat_loc lid in
+        let _, new_env = !type_open Asttypes.Override env p.ppat_loc lid in
         loop new_env sub_p
     | _ -> iter_ppat (loop env) p
   in


### PR DESCRIPTION
This PR removes spurious warnings about `unused open` in presence of local open in pattern.
These spurious warnings appeared due to `Typecore.contain_gadt` erroneously (and accidentally) invoking the use tracking mechanism of `type_open`.