### PR TITLE
Fix ``make install' for the Windows build system

### DIFF
--- a/Changes
+++ b/Changes
@@ -172,6 +172,10 @@ Next version (4.05.0):
   enabled
   (Mark Shinwell)
 
+- GPR#991: On Windows, fix installation when native compiler is not
+  built
+  (Sébastien Hinderer, review by David Allsopp)
+
 - GPR#803: new ocamllex-based tool to extract bytecode compiler
   opcode information from C headers.
   (Nicolas Ojeda Bar)

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -206,9 +206,7 @@ INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 INSTALL_MANDIR=$(DESTDIR)$(MANDIR)
 INSTALL_DISTRIB=$(DESTDIR)$(PREFIX)
 
-install: installbyt installopt
-
-installbyt:
+install:
 	mkdir -p "$(INSTALL_BINDIR)"
 	mkdir -p "$(INSTALL_LIBDIR)"
 	mkdir -p "$(INSTALL_STUBLIBDIR)"
@@ -252,6 +250,11 @@ installbyt:
 	   cp README.win32.adoc "$(INSTALL_DISTRIB)/Readme.windows.txt"; \
 	   cp LICENSE "$(INSTALL_DISTRIB)/License.txt"; \
 	   cp Changes "$(INSTALL_DISTRIB)/Changes.txt"; \
+	fi
+	if test -f ocamlopt; then $(MAKEREC) installopt; else \
+	   cd "$(INSTALL_BINDIR)"; \
+	   cp ocamlc.byte$(EXE) ocamlc$(EXE); \
+	   cp ocamllex.byte$(EXE) ocamllex$(EXE); \
 	fi
 
 install-flexdll:


### PR DESCRIPTION
On Windows, installing worked only when the native compiler was
previously compiled.

I discovered this while working on merging the main build systems but
would prefer this to be fixed before the merge itself.