### PR TITLE
caml-types.el: Fix missing format argument

### DIFF
--- a/Changes
+++ b/Changes
@@ -289,6 +289,10 @@ Next minor version (4.04.1):
   to load plugins. See http://github.com/OCamlPro/ocamlc-plugins for examples.
   (Fabrice Le Fessant, review by David Allsopp)
 
+- GPR#992: caml-types.el: Fix missing format argument, so that it can show kind
+  of call at point correctly.
+  (Chunhui He)
+
 OCaml 4.04.0 (4 Nov 2016):
 --------------------------
 

--- a/emacs/caml-types.el
+++ b/emacs/caml-types.el
@@ -221,7 +221,7 @@ See `caml-types-location-re' for annotation file format."
               (right (caml-types-get-pos target-buf (elt node 1)))
               (kind (cdr (assoc "call" (elt node 2)))))
           (move-overlay caml-types-expr-ovl left right target-buf)
-          (caml-types-feedback kind)))))
+          (caml-types-feedback kind "%s call")))))
     (if (and (= arg 4)
              (not (window-live-p (get-buffer-window caml-types-buffer))))
         (display-buffer caml-types-buffer))


### PR DESCRIPTION
Fixes: 5fa4e02 ("caml-types.el: Extract the feedback logic to a separate function.")