### PR TITLE
Do not build the AFL integration on Android

### DIFF
--- a/byterun/afl.c
+++ b/byterun/afl.c
@@ -1,6 +1,7 @@
 /* Runtime support for afl-fuzz */
 
-#ifdef _WIN32
+/* Android's libc does not implement System V shared memory. */
+#if defined(_WIN32) || defined(__ANDROID__)
 
 #include "caml/mlvalues.h"
 


### PR DESCRIPTION
Android does not implement System V shared memory, and so
compilation fails.