### PR TITLE
Fix for PR7447: incorrect code generation for nested recursive bindings

### DIFF
--- a/Changes
+++ b/Changes
@@ -448,6 +448,9 @@ Next version (4.05.0):
   (Jeremy Yallop,
    review by Damien Doligez, Alain Frisch, Daniel Bünzli, Fabrice Le Fessant)
 
+- PR#7447, GPR#995: incorrect code generation for nested recursive bindings
+  (Leo White and Jeremy Yallop, report by Stephen Dolan)
+
 - GPR#810: check for integer overflow in Array.concat
   (Jeremy Yallop)
 

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -787,7 +787,12 @@ let rec expr_size env = function
       RHS_block (fundecls_size fundecls + List.length clos_vars)
   | Ulet(_str, _kind, id, exp, body) ->
       expr_size (Ident.add id (expr_size env exp) env) body
-  | Uletrec(_bindings, body) ->
+  | Uletrec(bindings, body) ->
+      let env =
+        List.fold_right
+          (fun (id, exp) env -> Ident.add id (expr_size env exp) env)
+          bindings env
+      in
       expr_size env body
   | Uprim(Pmakeblock _, args, _) ->
       RHS_block (List.length args)

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -142,7 +142,9 @@ let rec check_recordwith_updates id e =
   | _ -> false
 ;;
 
-let rec size_of_lambda = function
+let rec size_of_lambda env = function
+  | Lvar id ->
+      begin try Ident.find_same id env with Not_found -> RHS_nonrec end
   | Lfunction{params} as funct ->
       RHS_function (1 + IdentSet.cardinal(free_variables funct),
                     List.length params)
@@ -154,8 +156,14 @@ let rec size_of_lambda = function
       | Record_float -> RHS_floatblock size
       | Record_extension -> RHS_block (size + 1)
       end
-  | Llet(_str, _k, _id, _arg, body) -> size_of_lambda body
-  | Lletrec(_bindings, body) -> size_of_lambda body
+  | Llet(_str, _k, id, arg, body) ->
+      size_of_lambda (Ident.add id (size_of_lambda env arg) env) body
+  | Lletrec(bindings, body) ->
+      let env = List.fold_right
+        (fun (id, e) env -> Ident.add id (size_of_lambda env e) env)
+        bindings env
+      in
+      size_of_lambda env body
   | Lprim(Pmakeblock _, args, _) -> RHS_block (List.length args)
   | Lprim (Pmakearray ((Paddrarray|Pintarray), _), args, _) ->
       RHS_block (List.length args)
@@ -169,8 +177,8 @@ let rec size_of_lambda = function
   | Lprim (Pduprecord (Record_extension, size), _, _) ->
       RHS_block (size + 1)
   | Lprim (Pduprecord (Record_float, size), _, _) -> RHS_floatblock size
-  | Levent (lam, _) -> size_of_lambda lam
-  | Lsequence (_lam, lam') -> size_of_lambda lam'
+  | Levent (lam, _) -> size_of_lambda env lam
+  | Lsequence (_lam, lam') -> size_of_lambda env lam'
   | _ -> RHS_nonrec
 
 (**** Merging consecutive events ****)
@@ -543,7 +551,7 @@ let rec comp_expr env exp sz cont =
                        (add_pop ndecl cont)))
       end else begin
         let decl_size =
-          List.map (fun (id, exp) -> (id, exp, size_of_lambda exp)) decl in
+          List.map (fun (id, exp) -> (id, exp, size_of_lambda Ident.empty exp)) decl in
         let rec comp_init new_env sz = function
           | [] -> comp_nonrec new_env sz ndecl decl_size
           | (id, _exp, RHS_floatblock blocksize) :: rem ->

--- a/testsuite/tests/letrec/nested.ml
+++ b/testsuite/tests/letrec/nested.ml
@@ -1,0 +1,7 @@
+(* Mantis PR7447 *)
+
+let rec r = (let rec x = `A r and y = fun () -> x in y)
+
+let (`A x) = r () 
+
+let _ = x ()


### PR DESCRIPTION
Here's the original example, from the [issue](https://caml.inria.fr/mantis/view.php?id=7447) reported by @stedolan:

```ocaml
        # let rec r = (let rec x = `A r and y = fun () -> x in y);;
        val r : unit -> [> `A of 'a ] as 'a = <fun>
        # let (`A x) = r () in x ();;
        Segmentation fault
```

@lpw25 analysed the problem and provided a patch for native code compilation (b4e7849), included in this PR.  The PR also adds a fix for bytecode compilation (6488c54) that brings `Bytegen.size_of_lambda` more into line with `Cmmgen.expr_size` by adding an environment to keep track of nested recursive bindings.  With these two patches both the native code and bytecode compilers produce code for the example that runs without crashing.

I'm not very familiar with the workings of code generation and so I'd appreciate a review of this code by someone who is.