### PR TITLE
Correctly update caml_top_of_stack in systhreads

### DIFF
--- a/Changes
+++ b/Changes
@@ -138,6 +138,9 @@ Next version (4.05.0):
   first step towards moving Bigarray to the stdlib
   (Jeremie Dimino)
 
+- GPR#996: correctly update caml_top_of_stack in systhreads
+  (Fabrice Le Fessant)
+
 ### Bytecode debugger (ocamldebug):
 
 - GPR#977: Catch Out_of_range in "list" command

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -169,6 +169,7 @@ static void caml_thread_scan_roots(scanning_action action)
 static inline void caml_thread_save_runtime_state(void)
 {
 #ifdef NATIVE_CODE
+  curr_thread->top_of_stack = caml_top_of_stack;
   curr_thread->bottom_of_stack = caml_bottom_of_stack;
   curr_thread->last_retaddr = caml_last_return_address;
   curr_thread->gc_regs = caml_gc_regs;
@@ -197,6 +198,7 @@ static inline void caml_thread_save_runtime_state(void)
 static inline void caml_thread_restore_runtime_state(void)
 {
 #ifdef NATIVE_CODE
+  caml_top_of_stack = curr_thread->top_of_stack;
   caml_bottom_of_stack= curr_thread->bottom_of_stack;
   caml_last_return_address = curr_thread->last_retaddr;
   caml_gc_regs = curr_thread->gc_regs;
@@ -316,7 +318,9 @@ static uintnat caml_thread_stack_usage(void)
        th != curr_thread;
        th = th->next) {
 #ifdef NATIVE_CODE
-    sz += (value *) th->top_of_stack - (value *) th->bottom_of_stack;
+  if(th->top_of_stack != NULL && th->bottom_of_stack != NULL &&
+     th->top_of_stack > th->bottom_of_stack)
+       sz += (value *) th->top_of_stack - (value *) th->bottom_of_stack;
 #else
     sz += th->stack_high - th->sp;
 #endif


### PR DESCRIPTION
The global variable `caml_top_of_stack` is not correctly updated in the systhreads library. This PR fixes it.

This is a pre-requisite for https://github.com/ocaml/ocaml/pull/697, and related to https://github.com/ocaml/ocaml/pull/961.