### PR TITLE
Do not delete unused closures in un_anf.ml

### DIFF
--- a/Changes
+++ b/Changes
@@ -356,6 +356,9 @@ Next version (4.05.0):
   on macOS by system calls that fill in a struct sockaddr (e.g. getsockname).
   (Anton Bachin)
 
+- GPR#998: Do not delete unused closures in un_anf.ml.
+  (Leo White)
+
 - GPR#1019: Fix fatal error in Flambda mode "[functions] does not map set of
   closures ID" (Pierre Chambart, code review by Mark Shinwell and Leo White)
 

--- a/asmcomp/un_anf.ml
+++ b/asmcomp/un_anf.ml
@@ -524,7 +524,7 @@ and substitute_let_moveable_array is_let_moveable env clams =
 (* We say that an expression is "moveable" iff it has neither effects nor
    coeffects.  (See semantics_of_primitives.mli.)
 *)
-type moveable = Fixed | Constant | Moveable | Moveable_not_into_loops
+type moveable = Fixed | Constant | Moveable
 
 let both_moveable a b =
   match a, b with
@@ -532,17 +532,10 @@ let both_moveable a b =
   | Constant, Moveable
   | Moveable, Constant
   | Moveable, Moveable -> Moveable
-  | Moveable_not_into_loops, Constant
-  | Moveable_not_into_loops, Moveable
-  | Constant, Moveable_not_into_loops
-  | Moveable, Moveable_not_into_loops
-  | Moveable_not_into_loops, Moveable_not_into_loops -> Moveable_not_into_loops
   | Constant, Fixed
   | Moveable, Fixed
-  | Moveable_not_into_loops, Fixed
   | Fixed, Constant
   | Fixed, Moveable
-  | Fixed, Moveable_not_into_loops
   | Fixed, Fixed -> Fixed
 
 let primitive_moveable (prim : Lambda.primitive)
@@ -570,17 +563,7 @@ let primitive_moveable (prim : Lambda.primitive)
     | Arbitrary_effects, No_coeffects
     | Arbitrary_effects, Has_coeffects -> Fixed
 
-type moveable_for_env = Constant | Moveable | Moveable_not_into_loops
-
-(** Called when we are entering a loop or body of a function (which may be
-    called multiple times).  The environment is rewritten such that
-    identifiers previously moveable, but not into loops, are now fixed. *)
-let going_into_loop env =
-  Ident.Map.filter_map env ~f:(fun _var ((moveable : moveable_for_env), def) ->
-    match moveable with
-    | Constant -> Some (Constant, def)
-    | Moveable -> Some (Moveable, def)
-    | Moveable_not_into_loops -> None)
+type moveable_for_env = Constant | Moveable
 
 (** Eliminate, through substitution, [let]-bindings of linear variables with
     moveable defining expressions. *)
@@ -591,7 +574,6 @@ let rec un_anf_and_moveable ident_info env (clam : Clambda.ulambda)
     begin match Ident.Map.find id env with
     | Constant, def -> def, Constant
     | Moveable, def -> def, Moveable
-    | Moveable_not_into_loops, def -> def, Moveable_not_into_loops
     | exception Not_found ->
       let moveable : moveable =
         if Ident.Set.mem id ident_info.assigned then
@@ -615,15 +597,14 @@ let rec un_anf_and_moveable ident_info env (clam : Clambda.ulambda)
     let functions =
       List.map (fun (ufunction : Clambda.ufunction) ->
           { ufunction with
-            body = un_anf ident_info (going_into_loop env) ufunction.body;
+            body = un_anf ident_info env ufunction.body;
           })
         functions
     in
-    let variables_bound_by_the_closure, moveable =
-      un_anf_list_and_moveable ident_info env variables_bound_by_the_closure
+    let variables_bound_by_the_closure =
+      un_anf_list ident_info env variables_bound_by_the_closure
     in
-    Uclosure (functions, variables_bound_by_the_closure),
-      both_moveable moveable Moveable_not_into_loops
+    Uclosure (functions, variables_bound_by_the_closure), Fixed
   | Uoffset (clam, n) ->
     let clam, moveable = un_anf_and_moveable ident_info env clam in
     Uoffset (clam, n), both_moveable Moveable moveable
@@ -635,7 +616,7 @@ let rec un_anf_and_moveable ident_info env (clam : Clambda.ulambda)
     let is_used = Ident.Set.mem id ident_info.used in
     let is_assigned = Ident.Set.mem id ident_info.assigned in
     begin match def_moveable, is_linear, is_used, is_assigned with
-    | (Constant | Moveable | Moveable_not_into_loops), _, false, _ ->
+    | (Constant | Moveable), _, false, _ ->
       (* A moveable expression that is never used may be eliminated. *)
       un_anf_and_moveable ident_info env body
     | Constant, _, true, false
@@ -648,19 +629,13 @@ let rec un_anf_and_moveable ident_info env (clam : Clambda.ulambda)
         match def_moveable with
         | Moveable -> Moveable
         | Constant -> Constant
-        | Moveable_not_into_loops -> Moveable_not_into_loops
         | Fixed -> assert false
       in
       let env = Ident.Map.add id (def_moveable, def) env in
       un_anf_and_moveable ident_info env body
-    | Moveable_not_into_loops, true, true, false
-        (* We can't delete the [let] binding in this case because we don't
-           know whether the variable was substituted for its definition
-           (in the case of its linear use not being inside a loop) or not.
-           We could extend the code to cope with this case. *)
-    | (Constant | Moveable | Moveable_not_into_loops), _, _, true
+    | (Constant | Moveable), _, _, true
         (* Constant or Moveable but assigned. *)
-    | (Moveable | Moveable_not_into_loops), false, _, _
+    | Moveable, false, _, _
         (* Moveable but not used linearly. *)
     | Fixed, _, _, _ ->
       let body, body_moveable = un_anf_and_moveable ident_info env body in
@@ -721,14 +696,13 @@ let rec un_anf_and_moveable ident_info env (clam : Clambda.ulambda)
     let e2 = un_anf ident_info env e2 in
     Usequence (e1, e2), Fixed
   | Uwhile (cond, body) ->
-    let env = going_into_loop env in
     let cond = un_anf ident_info env cond in
     let body = un_anf ident_info env body in
     Uwhile (cond, body), Fixed
   | Ufor (id, low, high, direction, body) ->
     let low = un_anf ident_info env low in
     let high = un_anf ident_info env high in
-    let body = un_anf ident_info (going_into_loop env) body in
+    let body = un_anf ident_info env body in
     Ufor (id, low, high, direction, body), Fixed
   | Uassign (id, expr) ->
     let expr = un_anf ident_info env expr in

--- a/testsuite/tests/flambda/Makefile
+++ b/testsuite/tests/flambda/Makefile
@@ -1,0 +1,21 @@
+#**************************************************************************
+#*                                                                        *
+#*                                OCaml                                   *
+#*                                                                        *
+#*                 Xavier Clerc, SED, INRIA Rocquencourt                  *
+#*                                                                        *
+#*   Copyright 2010 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+BASEDIR=../..
+
+ADD_OPTFLAGS=-unbox-closures
+
+include $(BASEDIR)/makefiles/Makefile.several
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/flambda/gpr998.ml
+++ b/testsuite/tests/flambda/gpr998.ml
@@ -1,0 +1,39 @@
+(* This test attempts to check that unused closures are not deleted
+   during conversion from flambda to clambda. The idea is that there is
+   a direct call to [foo] in [bar] even though the closure for [foo] is
+   not used. This requires [bar] to be have a specialised parameter that
+   would be [foo]'s closure were there any calls to [bar], and for [bar]
+   to not be deleted even though there are no calls to it. Creating such
+   a situation is difficult, and the fact that the following code does so
+   is very fragile. This means two things:
+
+     1. This code only tests the appropriate property on amd64
+        architectures. Since the code conversion from flambda to
+        clambda is architecture independent, this should be fine
+        as long as the test is run on such an architecture as part
+        of CI.
+
+    2. It is likely that future changes to flambda will silently cause
+       this test to stop testing the desired property. It would be worth
+       periodically examining the flambda output for the code to check
+       that this test is still worth using.
+*)
+
+let main x =
+  let[@inline never] inner () =
+    let[@inline never] foo y () () () () () () () = x + y in
+    let x1, x2, x3 = x + 1, x + 2, x + 3 in
+    let bar p y () () () =
+      if p then foo y () () () () () () ()
+      else x1 + x2 + x3
+    in
+    let[@inline never] baz0 y () () () () () () () =
+      let y1 = y + 1 in
+      let[@inline never] baz1 () () () () () =
+        bar false y1 () () ()
+      in
+      baz1 () () () () ()
+    in
+    baz0 1 () () () () () () ()
+  in
+  inner ()


### PR DESCRIPTION
The following code:
```
let main x =
  let[@inline never] inner () =
    let[@inline never] foo y () () () () () () () = x + y in
    let x1, x2, x3 = x + 1, x + 2, x + 3 in
    let bar p y () () () =
      if p then foo y () () () () () () ()
      else x1 + x2 + x3
    in
    let[@inline never] baz0 y () () () () () () () =
      let y1 = y + 1 in
      let[@inline never] baz1 () () () () () =
        bar false y1 () () ()
      in
      baz1 () () () () ()
    in
    baz0 1 () () () () () () ()
  in
  inner ()
```
compiled using flambda and `-unbox-closures` will produce an error from the system linker:
```
bar.o: In function `camlBar__bar_152':
:(.text+0x144): undefined reference to `camlBar__foo_13'
collect2: ld returned 1 exit status
File "caml_startup", line 1:
Error: Error during linking
```

(The bug is actually architecture dependent: on architectures other than amd64 you'll need to adjust the number of `()` in the above code to get the error).

The issue is the following snippet from `un_anf.ml`:
```
| (Constant | Moveable | Moveable_not_into_loops), _, false, _ ->
       (* A moveable expression that is never used may be eliminated. *)
       un_anf_and_moveable ident_info env body
```
which allows unused closures (the only thing that still produces `Moveable_not_into_loops`) to be deleted. However, it is not in general safe to delete closure expressions from `clambda` code.

The fix is simply to take the `Moveable_not_into_loops` case out of that pattern. However, after the fix `Moveable_not_into_loops` is functionally identical to `Fixed`, so the PR goes further and removes `Moveable_not_into_loops` entirely.
