### PR TITLE
Fix Stdlib.Arg: do no repeat usage_msg thrice

### DIFF
--- a/Changes
+++ b/Changes
@@ -92,6 +92,9 @@ Next version (4.05.0):
   counterparts.
   (Roma Sokolov)
 
+- GPR#999: Arg, do not repeat thrice usage_msg when reporting an error
+  (Florian Angeletti)
+
 ### Manual and documentation:
 
 - GPR#939: activate the caml_example environment in the language

--- a/Changes
+++ b/Changes
@@ -93,7 +93,7 @@ Next version (4.05.0):
   (Roma Sokolov)
 
 - GPR#999: Arg, do not repeat thrice usage_msg when reporting an error
-  (Florian Angeletti)
+  (Florian Angeletti, review by Gabriel Scherer)
 
 ### Manual and documentation:
 

--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -130,14 +130,13 @@ let float_of_string_opt x =
   with Failure _ -> None
 
 let parse_and_expand_argv_dynamic_aux allow_expand current argv speclist anonfun errmsg =
-  let b = Buffer.create 200 in
   let initpos = !current in
   let convert_error error =
     (* convert an internal error to a Bad/Help exception
        *or* add the program name as a prefix and the usage message as a suffix
        to an user-raised Bad exception.
     *)
-    let () = Buffer.clear b in
+    let b = Buffer.create 200 in
     let progname = if initpos < (Array.length !argv) then !argv.(initpos) else "(?)" in
     begin match error with
       | Unknown "-help" -> ()

--- a/testsuite/tests/lib-arg/Makefile
+++ b/testsuite/tests/lib-arg/Makefile
@@ -14,7 +14,6 @@
 #**************************************************************************
 
 BASEDIR=../..
-MAIN_MODULE=testarg
 
-include $(BASEDIR)/makefiles/Makefile.one
+include $(BASEDIR)/makefiles/Makefile.several
 include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/lib-arg/testerror.ml
+++ b/testsuite/tests/lib-arg/testerror.ml
@@ -6,8 +6,8 @@ let usage= "Arg module testing"
 let test total i (spec,anon,argv) =
   let argv = Array.of_list ("testerror" :: argv) in
   try Arg.parse_argv ~current:(ref 0) argv spec anon usage with
-  | Arg.Bad s-> Printf.printf "(%d/%d) Bad:%s\n" (i+1) total s
-  | Arg.Help s -> Printf.printf "(%d/%d) Help:%s\n" (i+1) total s
+  | Arg.Bad s-> Printf.printf "(%d/%d) Bad:\n%s\n" (i+1) total s
+  | Arg.Help s -> Printf.printf "(%d/%d) Help:\n%s\n" (i+1) total s
 
 
 let tests = [

--- a/testsuite/tests/lib-arg/testerror.ml
+++ b/testsuite/tests/lib-arg/testerror.ml
@@ -1,0 +1,41 @@
+(** Test that the right message errors are emitted by Arg *)
+
+
+let usage= "Arg module testing"
+
+let test total i (spec,anon,argv) =
+  let argv = Array.of_list ("testerror" :: argv) in
+  try Arg.parse_argv ~current:(ref 0) argv spec anon usage with
+  | Arg.Bad s-> Printf.printf "(%d/%d) Bad:%s\n" (i+1) total s
+  | Arg.Help s -> Printf.printf "(%d/%d) Help:%s\n" (i+1) total s
+
+
+let tests = [
+(** missing argument error *)
+  ["-s",  Arg.String ignore, "missing arg"], ignore, ["-s"]
+
+(** No argument expected *)
+; ["-set",  Arg.Set (ref false), "no argument expected"], ignore, ["-set=true"]
+
+(** help message *)
+; [], ignore, ["-help" ]
+
+(** wrong argument type *)
+; ["-int", Arg.Int ignore, "wrong argument type" ], ignore, ["-int"; "not_an_int" ]
+
+(** unknown option *)
+; [], ignore, [ "-an-unknown-option" ]
+
+(** user-error in anon fun *)
+; [], (fun _ -> raise @@ Arg.Bad("User-raised error")), [ "argument" ]
+
+(** user-error in anon fun *)
+; ["-error",
+   Arg.Unit (fun () -> raise @@ Arg.Bad("User-raised error bis")),
+   "user raised error"]
+, ignore, [ "-error" ]
+]
+
+let () =
+  let n = List.length tests in
+  List.iteri (test n) tests

--- a/testsuite/tests/lib-arg/testerror.reference
+++ b/testsuite/tests/lib-arg/testerror.reference
@@ -1,36 +1,43 @@
-(1/7) Bad:testerror: option '-s' needs an argument.
+(1/7) Bad:
+testerror: option '-s' needs an argument.
 Arg module testing
   -s missing arg
   -help  Display this list of options
   --help  Display this list of options
 
-(2/7) Bad:testerror: wrong argument 'true'; option '-set=true' expects no argument.
+(2/7) Bad:
+testerror: wrong argument 'true'; option '-set=true' expects no argument.
 Arg module testing
   -set no argument expected
   -help  Display this list of options
   --help  Display this list of options
 
-(3/7) Help:Arg module testing
+(3/7) Help:
+Arg module testing
   -help  Display this list of options
   --help  Display this list of options
 
-(4/7) Bad:testerror: wrong argument 'not_an_int'; option '-int' expects an integer.
+(4/7) Bad:
+testerror: wrong argument 'not_an_int'; option '-int' expects an integer.
 Arg module testing
   -int wrong argument type
   -help  Display this list of options
   --help  Display this list of options
 
-(5/7) Bad:testerror: unknown option '-an-unknown-option'.
+(5/7) Bad:
+testerror: unknown option '-an-unknown-option'.
 Arg module testing
   -help  Display this list of options
   --help  Display this list of options
 
-(6/7) Bad:testerror: User-raised error.
+(6/7) Bad:
+testerror: User-raised error.
 Arg module testing
   -help  Display this list of options
   --help  Display this list of options
 
-(7/7) Bad:testerror: User-raised error bis.
+(7/7) Bad:
+testerror: User-raised error bis.
 Arg module testing
   -error user raised error
   -help  Display this list of options

--- a/testsuite/tests/lib-arg/testerror.reference
+++ b/testsuite/tests/lib-arg/testerror.reference
@@ -1,0 +1,38 @@
+(1/7) Bad:testerror: option '-s' needs an argument.
+Arg module testing
+  -s missing arg
+  -help  Display this list of options
+  --help  Display this list of options
+
+(2/7) Bad:testerror: wrong argument 'true'; option '-set=true' expects no argument.
+Arg module testing
+  -set no argument expected
+  -help  Display this list of options
+  --help  Display this list of options
+
+(3/7) Help:Arg module testing
+  -help  Display this list of options
+  --help  Display this list of options
+
+(4/7) Bad:testerror: wrong argument 'not_an_int'; option '-int' expects an integer.
+Arg module testing
+  -int wrong argument type
+  -help  Display this list of options
+  --help  Display this list of options
+
+(5/7) Bad:testerror: unknown option '-an-unknown-option'.
+Arg module testing
+  -help  Display this list of options
+  --help  Display this list of options
+
+(6/7) Bad:testerror: User-raised error.
+Arg module testing
+  -help  Display this list of options
+  --help  Display this list of options
+
+(7/7) Bad:testerror: User-raised error bis.
+Arg module testing
+  -error user raised error
+  -help  Display this list of options
+  --help  Display this list of options
+


### PR DESCRIPTION
Currently, when reporting an error during the parsing of argument, the parsing functions in Arg repeat the usage_msg thrice (and the error message twice). For instance, invoking `ocamllex -o` yields
```
ocamllex: option '-o' needs an argument.
usage: ocamllex [options] sourcefile
  -ml  Output code that does not use the Lexing module built-in automata interpreter
  -o  <file>  Set output file name to <file>
  -q  Do not display informational messages
  -v  Print version and exit
  -version  Print version and exit
  -vnum  Print version number and exit
  -help  Display this list of options
  --help  Display this list of options
ocamllex: ocamllex: option '-o' needs an argument.
usage: ocamllex [options] sourcefile
  -ml  Output code that does not use the Lexing module built-in automata interpreter
  -o  <file>  Set output file name to <file>
  -q  Do not display informational messages
  -v  Print version and exit
  -version  Print version and exit
  -vnum  Print version number and exit
  -help  Display this list of options
  --help  Display this list of options
.
usage: ocamllex [options] sourcefile
  -ml  Output code that does not use the Lexing module built-in automata interpreter
  -o  <file>  Set output file name to <file>
  -q  Do not display informational messages
  -v  Print version and exit
  -version  Print version and exit
  -vnum  Print version number and exit
  -help  Display this list of options
  --help  Display this list of options
```
This PR fixes this problem by avoiding long-ranged side-effect when constructing error messages in `Arg.parse_and_expand_argv_dynamic_aux`.  Similarly, this PR also suppresses the repetition of the program name by not prefixing already constructed error messages with the program name.
when reporting error.