### PR TITLE
Improvements to afl-fuzz support

### DIFF
--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -1,3 +1,17 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                 Stephen Dolan, University of Cambridge                 *)
+(*                                                                        *)
+(*   Copyright 2016 Stephen Dolan.                                        *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
 (* Insert instrumentation for afl-fuzz *)
 
 open Lambda
@@ -72,8 +86,9 @@ let instrument_initialiser c =
   (* Each instrumented module calls caml_setup_afl at
      initialisation, which is a no-op on the second and subsequent
      calls *)
-  with_afl_logging (Csequence
-                (Cop (Cextcall ("caml_setup_afl", typ_int,
-                                false, None),
-                      [Cconst_int 0], Debuginfo.none),
-                 c))
+  with_afl_logging
+    (Csequence
+       (Cop (Cextcall ("caml_setup_afl", typ_int, false, None),
+             [Cconst_int 0],
+             Debuginfo.none),
+        c))

--- a/byterun/afl.c
+++ b/byterun/afl.c
@@ -1,3 +1,17 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*                 Stephen Dolan, University of Cambridge                 */
+/*                                                                        */
+/*   Copyright 2016 Stephen Dolan.                                        */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
 /* Runtime support for afl-fuzz */
 
 #ifdef _WIN32
@@ -5,6 +19,11 @@
 #include "caml/mlvalues.h"
 
 CAMLprim value caml_setup_afl (value unit)
+{
+  return Val_unit;
+}
+
+CAMLprim value caml_reset_afl_instrumentation(value unused)
 {
   return Val_unit;
 }
@@ -17,6 +36,7 @@ CAMLprim value caml_setup_afl (value unit)
 #include <sys/shm.h>
 #include <sys/wait.h>
 #include <stdio.h>
+#include <string.h>
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
 
@@ -77,7 +97,12 @@ CAMLprim value caml_setup_afl(value unit)
   caml_afl_area_ptr[0] = 1;
 
   /* synchronise with afl-fuzz */
-  afl_write(0);
+  uint32_t startup_msg = 0;
+  if (write(FORKSRV_FD_WRITE, &startup_msg, 4) != 4) {
+    /* initial write failed, so assume we're not meant to fork.
+       afl-tmin uses this mode. */
+    return Val_unit;
+  }
   afl_read();
 
   while (1) {
@@ -98,6 +123,7 @@ CAMLprim value caml_setup_afl(value unit)
       /* WUNTRACED means wait until termination or SIGSTOP */
       if (waitpid(child_pid, &status, WUNTRACED) < 0)
         caml_fatal_error("afl-fuzz: waitpid failed");
+
       afl_write((uint32_t)status);
 
       uint32_t was_killed = afl_read();
@@ -108,6 +134,7 @@ CAMLprim value caml_setup_afl(value unit)
              we should wait for it before forking another child */
           if (waitpid(child_pid, &status, 0) < 0)
             caml_fatal_error("afl-fuzz: waitpid failed");
+          break;
         } else {
           kill(child_pid, SIGCONT);
         }
@@ -117,6 +144,15 @@ CAMLprim value caml_setup_afl(value unit)
       }
     }
   }
+}
+
+CAMLprim value caml_reset_afl_instrumentation(value full)
+{
+  if (full != Val_int(0)) {
+    memset(caml_afl_area_ptr, 0, sizeof(afl_area_initial));
+  }
+  caml_afl_prev_loc = 0;
+  return Val_unit;
 }
 
 #endif /* _WIN32 */


### PR DESCRIPTION
Various minor improvements to afl-fuzz instrumentation support.

  - Add missing copyright headers to `afl_instrument.ml` and `afl.c`
  - Fix indentation in `afl_instrument.ml`
  - Support test case minimisation with `afl-tmin`
  - Add a primitive to reset instrumentation (improves results when using afl-fuzz in "persistent" mode, when a single process is re-used to save forking overhead)
  - Fix a bug in handling the error case when `afl-fuzz` kills the program under test before the forkserver notices