### PR TITLE
Improve wording of inlining reports

### DIFF
--- a/middle_end/inlining_decision.ml
+++ b/middle_end/inlining_decision.ml
@@ -104,7 +104,7 @@ let inline env r ~lhs_of_application
         | T.Never_inline -> assert false
         | T.Can_inline_if_no_larger_than threshold -> threshold
       in
-      Don't_try_it (S.Not_inlined.Function_obviously_too_large threshold)
+      Don't_try_it (S.Not_inlined.Above_threshold threshold)
     else if not (toplevel && branch_depth = 0)
          && A.all_not_useful (E.find_list_exn env args) then
       (* When all of the arguments to the function being inlined are unknown,
@@ -173,7 +173,7 @@ let inline env r ~lhs_of_application
            should already have been simplified (inside its declaration), so
            we also expect no gain from the code below that permits inlining
            inside the body. *)
-        Don't_try_it S.Not_inlined.Unspecialised
+        Don't_try_it S.Not_inlined.No_useful_approximations
     else begin
       (* There are useful approximations, so we should simplify. *)
       Try_it
@@ -374,7 +374,7 @@ let specialise env r ~lhs_of_application
         | T.Never_inline -> assert false
         | T.Can_inline_if_no_larger_than threshold -> threshold
       in
-      Don't_try_it (S.Not_specialised.Function_obviously_too_large threshold)
+      Don't_try_it (S.Not_specialised.Above_threshold threshold)
     else if not (Var_within_closure.Map.is_empty (Lazy.force bound_vars)) then
       Don't_try_it S.Not_specialised.Not_closed
     else if not (Lazy.force recursive) then

--- a/middle_end/inlining_stats_types.ml
+++ b/middle_end/inlining_stats_types.ml
@@ -73,9 +73,9 @@ end
 module Not_inlined = struct
   type t =
     | Classic_mode
-    | Function_obviously_too_large of int
+    | Above_threshold of int
     | Annotation
-    | Unspecialised
+    | No_useful_approximations
     | Unrolling_depth_exceeded
     | Self_call
     | Without_subfunctions of Wsb.t
@@ -86,19 +86,20 @@ module Not_inlined = struct
     | Classic_mode ->
       Format.pp_print_text ppf
         "This function was prevented from inlining by `-Oclassic'."
-    | Function_obviously_too_large size ->
+    | Above_threshold size ->
       Format.pp_print_text ppf
         "This function was not inlined because \
-         it was obviously too large";
+         it was larger than the current size threshold";
         Format.fprintf ppf "(%i)" size
     | Annotation ->
       Format.pp_print_text ppf
         "This function was not inlined because \
          of an annotation."
-    | Unspecialised ->
+    | No_useful_approximations ->
       Format.pp_print_text ppf
         "This function was not inlined because \
-         its parameters could not be specialised."
+         there was no useful information about any of its parameters, \
+         and it was not particularly small."
     | Unrolling_depth_exceeded ->
       Format.pp_print_text ppf
         "This function was not inlined because \
@@ -118,9 +119,9 @@ module Not_inlined = struct
 
   let calculation ~depth ppf = function
     | Classic_mode
-    | Function_obviously_too_large _
+    | Above_threshold _
     | Annotation
-    | Unspecialised
+    | No_useful_approximations
     | Unrolling_depth_exceeded
     | Self_call -> ()
     | Without_subfunctions wsb ->
@@ -169,7 +170,7 @@ end
 module Not_specialised = struct
   type t =
     | Classic_mode
-    | Function_obviously_too_large of int
+    | Above_threshold of int
     | Annotation
     | Not_recursive
     | Not_closed
@@ -183,10 +184,10 @@ module Not_specialised = struct
       Format.pp_print_text ppf
         "This function was prevented from specialising by \
           `-Oclassic'."
-    | Function_obviously_too_large size ->
+    | Above_threshold size ->
       Format.pp_print_text ppf
         "This function was not specialised because \
-         it was obviously too large";
+         it was larger than the current size threshold";
         Format.fprintf ppf "(%i)" size
     | Annotation ->
       Format.pp_print_text ppf
@@ -220,7 +221,7 @@ module Not_specialised = struct
 
   let calculation ~depth ppf = function
     | Classic_mode
-    | Function_obviously_too_large _
+    | Above_threshold _
     | Annotation
     | Not_recursive
     | Not_closed

--- a/middle_end/inlining_stats_types.mli
+++ b/middle_end/inlining_stats_types.mli
@@ -32,9 +32,9 @@ end
 module Not_inlined : sig
   type t =
     | Classic_mode
-    | Function_obviously_too_large of int
+    | Above_threshold of int
     | Annotation
-    | Unspecialised
+    | No_useful_approximations
     | Unrolling_depth_exceeded
     | Self_call
     | Without_subfunctions of
@@ -57,7 +57,7 @@ end
 module Not_specialised : sig
   type t =
     | Classic_mode
-    | Function_obviously_too_large of int
+    | Above_threshold of int
     | Annotation
     | Not_recursive
     | Not_closed


### PR DESCRIPTION
This is just a couple of changes to the wording of the inlining reports. One message was previously using the word "specialised" when talking about inlining, which seemed to confuse people in relation to our use of "specialised" to refer to copies of recursive functions. The other is changed to explicitly refer to the size threshold, since the phrase "obviously too large" was not particularly informative.