### PR TITLE
API changes for multicore

### DIFF
--- a/Changes
+++ b/Changes
@@ -249,6 +249,9 @@ Working version
 - GPR#938, GPR#1170: Stack overflow detection on 64-bit Windows
   (Olivier Andrieu)
 
+- GPR#1003: C API additions to support multicore.
+  (Stephen Dolan, review by Mark Shinwell and Damien Doligez)
+
 Next major version (4.05.0):
 ----------------------------
 

--- a/byterun/alloc.c
+++ b/byterun/alloc.c
@@ -85,6 +85,84 @@ CAMLexport value caml_alloc_small_with_my_or_given_profinfo (mlsize_t wosize,
   }
 }
 
+static inline value alloc_fixed(mlsize_t wosize, tag_t tag, value* vals)
+{
+  value result;
+  mlsize_t i;
+#undef Setup_for_gc
+#define Setup_for_gc CAMLparamN(vals, wosize)
+#undef Restore_after_gc
+#define Restore_after_gc CAMLdrop
+  Alloc_small (result, wosize, tag);
+#undef Setup_for_gc
+#define Setup_for_gc
+#undef Restore_after_gc
+#define Restore_after_gc
+  for (i = 0; i < wosize; i++) {
+    Field(result, i) = vals[i];
+  }
+  return result;
+}
+
+CAMLexport value caml_alloc_1 (tag_t tag, value a)
+{
+  value v[1] = {a};
+  return alloc_fixed(1, tag, v);
+}
+
+CAMLexport value caml_alloc_2 (tag_t tag, value a, value b)
+{
+  value v[2] = {a, b};
+  return alloc_fixed(2, tag, v);
+}
+
+CAMLexport value caml_alloc_3 (tag_t tag, value a, value b, value c)
+{
+  value v[3] = {a, b, c};
+  return alloc_fixed(3, tag, v);
+}
+
+CAMLexport value caml_alloc_4 (tag_t tag, value a, value b, value c, value d)
+{
+  value v[4] = {a, b, c, d};
+  return alloc_fixed(4, tag, v);
+}
+
+CAMLexport value caml_alloc_5 (tag_t tag, value a, value b, value c, value d,
+                               value e)
+{
+  value v[5] = {a, b, c, d, e};
+  return alloc_fixed(5, tag, v);
+}
+
+CAMLexport value caml_alloc_6 (tag_t tag, value a, value b, value c, value d,
+                               value e, value f)
+{
+  value v[6] = {a, b, c, d, e, f};
+  return alloc_fixed(6, tag, v);
+}
+
+CAMLexport value caml_alloc_7 (tag_t tag, value a, value b, value c, value d,
+                               value e, value f, value g)
+{
+  value v[7] = {a, b, c, d, e, f, g};
+  return alloc_fixed(7, tag, v);
+}
+
+CAMLexport value caml_alloc_8 (tag_t tag, value a, value b, value c, value d,
+                               value e, value f, value g, value h)
+{
+  value v[8] = {a, b, c, d, e, f, g, h};
+  return alloc_fixed(8, tag, v);
+}
+
+CAMLexport value caml_alloc_9 (tag_t tag, value a, value b, value c, value d,
+                               value e, value f, value g, value h, value i)
+{
+  value v[9] = {a, b, c, d, e, f, g, h, i};
+  return alloc_fixed(9, tag, v);
+}
+
 /* [n] is a number of words (fields) */
 CAMLexport value caml_alloc_tuple(mlsize_t n)
 {

--- a/byterun/callback.c
+++ b/byterun/callback.c
@@ -254,8 +254,8 @@ CAMLexport caml_root caml_named_root(char const *name)
 
 CAMLexport value* caml_named_value(char const* name)
 {
-  extern value* caml__root_as_ptr(caml_root r);
-  return caml__root_as_ptr(caml_named_root(name));
+  extern value* caml_deprecated_root_as_ptr(caml_root r);
+  return caml_deprecated_root_as_ptr(caml_named_root(name));
 }
 
 CAMLexport void caml_iterate_named_roots(caml_named_action f)

--- a/byterun/caml/alloc.h
+++ b/byterun/caml/alloc.h
@@ -17,17 +17,29 @@
 #define CAML_ALLOC_H
 
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "misc.h"
 #include "mlvalues.h"
+#include "memory.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 CAMLextern value caml_alloc (mlsize_t wosize, tag_t);
+CAMLextern value caml_alloc_1(tag_t, value);
+CAMLextern value caml_alloc_2(tag_t, value, value);
+CAMLextern value caml_alloc_3(tag_t, value, value, value);
+CAMLextern value caml_alloc_4(tag_t, value, value, value, value);
+CAMLextern value caml_alloc_5(tag_t, value, value, value, value,
+                              value);
+CAMLextern value caml_alloc_6(tag_t, value, value, value, value,
+                              value, value);
+CAMLextern value caml_alloc_7(tag_t, value, value, value, value,
+                              value, value, value);
+CAMLextern value caml_alloc_8(tag_t, value, value, value, value,
+                              value, value, value, value);
+CAMLextern value caml_alloc_9(tag_t, value, value, value, value,
+                              value, value, value, value, value);
 CAMLextern value caml_alloc_small (mlsize_t wosize, tag_t);
 CAMLextern value caml_alloc_tuple (mlsize_t wosize);
 CAMLextern value caml_alloc_float_array (mlsize_t len);
@@ -58,12 +70,15 @@ CAMLextern int caml_convert_flag_list (value, int *);
 /* Convenience functions to deal with unboxable types. */
 static inline value caml_alloc_unboxed (value arg) { return arg; }
 static inline value caml_alloc_boxed (value arg) {
-  value result = caml_alloc_small (1, 0);
-  Field (result, 0) = arg;
-  return result;
+  return caml_alloc_1(0, arg);
 }
 static inline value caml_field_unboxed (value arg) { return arg; }
-static inline value caml_field_boxed (value arg) { return Field (arg, 0); }
+static inline value caml_field_boxed (value arg) {
+  CAMLparam1(arg);
+  CAMLlocal1(v);
+  caml_read_field(arg, 0, &v);
+  CAMLreturn (v);
+}
 
 /* Unannotated unboxable types are boxed by default. (may change in the
    future) */

--- a/byterun/caml/callback.h
+++ b/byterun/caml/callback.h
@@ -18,10 +18,8 @@
 #ifndef CAML_CALLBACK_H
 #define CAML_CALLBACK_H
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "mlvalues.h"
+#include "memory.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,9 +41,13 @@ CAMLextern value caml_callbackN_exn (value closure, int narg, value args[]);
 #define Is_exception_result(v) (((v) & 3) == 2)
 #define Extract_exception(v) ((v) & ~3)
 
+#if CAML_API_VERSION < 405
 CAMLextern value * caml_named_value (char const * name);
-typedef void (*caml_named_action) (value*, char *);
-CAMLextern void caml_iterate_named_values(caml_named_action f);
+#endif
+
+CAMLextern caml_root caml_named_root (char const * name);
+typedef void (*caml_named_action) (caml_root, char *);
+CAMLextern void caml_iterate_named_roots(caml_named_action f);
 
 CAMLextern void caml_main (char ** argv);
 CAMLextern void caml_startup (char ** argv);

--- a/byterun/caml/callback.h
+++ b/byterun/caml/callback.h
@@ -41,7 +41,7 @@ CAMLextern value caml_callbackN_exn (value closure, int narg, value args[]);
 #define Is_exception_result(v) (((v) & 3) == 2)
 #define Extract_exception(v) ((v) & ~3)
 
-#if CAML_API_VERSION < 405
+#if CAML_API_VERSION < 406
 CAMLextern value * caml_named_value (char const * name);
 #endif
 

--- a/byterun/caml/compatibility.h
+++ b/byterun/caml/compatibility.h
@@ -18,11 +18,19 @@
 #ifndef CAML_COMPATIBILITY_H
 #define CAML_COMPATIBILITY_H
 
+#ifndef CAML_API_VERSION
+#define CAML_API_VERSION 100
+#endif
+
+#if CAML_API_VERSION >= 400 && !defined(CAML_NAME_SPACE)
+#define CAML_NAME_SPACE
+#endif
+
+#ifndef CAML_NAME_SPACE
+
 /* internal global variables renamed between 4.02.1 and 4.03.0 */
 #define caml_stat_top_heap_size Bsize_wsize(caml_stat_top_heap_wsz)
 #define caml_stat_heap_size Bsize_wsize(caml_stat_heap_wsz)
-
-#ifndef CAML_NAME_SPACE
 
 /*
    #define --> CAMLextern  (defined with CAMLexport or CAMLprim)

--- a/byterun/caml/config.h
+++ b/byterun/caml/config.h
@@ -25,9 +25,7 @@
 #undef SUPPORT_DYNAMIC_LINKING
 #endif
 
-#ifndef CAML_NAME_SPACE
 #include "compatibility.h"
-#endif
 
 #ifdef HAS_STDINT_H
 #include <stdint.h>

--- a/byterun/caml/custom.h
+++ b/byterun/caml/custom.h
@@ -17,9 +17,6 @@
 #define CAML_CUSTOM_H
 
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "mlvalues.h"
 
 struct custom_operations {

--- a/byterun/caml/fail.h
+++ b/byterun/caml/fail.h
@@ -20,9 +20,6 @@
 #include <setjmp.h>
 #endif /* CAML_INTERNALS */
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "misc.h"
 #include "mlvalues.h"
 

--- a/byterun/caml/intext.h
+++ b/byterun/caml/intext.h
@@ -18,9 +18,6 @@
 #ifndef CAML_INTEXT_H
 #define CAML_INTEXT_H
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "misc.h"
 #include "mlvalues.h"
 

--- a/byterun/caml/memory.h
+++ b/byterun/caml/memory.h
@@ -47,7 +47,7 @@ CAMLextern value caml_alloc_shr_no_raise (mlsize_t wosize, tag_t);
 CAMLextern void caml_adjust_gc_speed (mlsize_t, mlsize_t);
 CAMLextern void caml_alloc_dependent_memory (mlsize_t bsz);
 CAMLextern void caml_free_dependent_memory (mlsize_t bsz);
-#if CAML_API_VERSION < 405
+#if CAML_API_VERSION < 406
 CAMLextern void caml_modify (value *, value);
 CAMLextern void caml_initialize (value *, value);
 #endif
@@ -543,7 +543,7 @@ CAMLextern struct caml__roots_block *caml_local_roots;  /* defined in roots.c */
 #endif /* CAML_API_VERSION < 400 */
 
 
-#if CAML_API_VERSION < 405
+#if CAML_API_VERSION < 406
 
 /* [caml_register_global_root] registers a global C variable as a memory root
    for the duration of the program, or until [caml_remove_global_root] is
@@ -585,7 +585,7 @@ CAMLextern void caml_remove_generational_global_root (value *);
 
 CAMLextern void caml_modify_generational_global_root(value *r, value newval);
 
-#endif /* CAML_API_VERSION < 405 */
+#endif /* CAML_API_VERSION < 406 */
 
 
 typedef struct caml_root_private* caml_root;

--- a/byterun/caml/memory.h
+++ b/byterun/caml/memory.h
@@ -208,9 +208,11 @@ int caml_page_table_initialize(mlsize_t bytesize);
   if (caml_young_ptr < caml_young_trigger){ \
     caml_young_ptr += Whsize_wosize (wosize); \
     CAML_INSTR_INT ("force_minor/alloc_small@", 1); \
-    Setup_for_gc; \
-    caml_gc_dispatch (); \
-    Restore_after_gc; \
+    { \
+      Setup_for_gc; \
+      caml_gc_dispatch (); \
+      Restore_after_gc; \
+    } \
     caml_young_ptr -= Whsize_wosize (wosize); \
   } \
   Hd_hp (caml_young_ptr) = \

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -18,9 +18,6 @@
 #ifndef CAML_MISC_H
 #define CAML_MISC_H
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "config.h"
 
 /* Standard definitions */

--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -183,7 +183,7 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 /* Pointer to the first field. */
 #define Op_val(x) ((value *) (x))
 /* Fields are numbered from 0. */
-#if CAML_API_VERSION < 405
+#if CAML_API_VERSION < 406
 #define Field(x, i) (((value *)(x)) [i])           /* Also an l-value. */
 #endif
 

--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -16,9 +16,6 @@
 #ifndef CAML_MLVALUES_H
 #define CAML_MLVALUES_H
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "config.h"
 #include "misc.h"
 
@@ -186,7 +183,24 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 /* Pointer to the first field. */
 #define Op_val(x) ((value *) (x))
 /* Fields are numbered from 0. */
+#if CAML_API_VERSION < 405
 #define Field(x, i) (((value *)(x)) [i])           /* Also an l-value. */
+#endif
+
+static inline void caml_read_field (value obj, mlsize_t f, value* ret)
+{
+  *ret = Op_val(obj)[f];
+}
+
+static inline value Field_imm (value obj, mlsize_t f)
+{
+  return Op_val(obj)[f];
+}
+
+#define Int_field(x, i) Int_val(Op_val(x)[i])
+#define Long_field(x, i) Long_val(Op_val(x)[i])
+#define Bool_field(x, i) Bool_val(Op_val(x)[i])
+
 
 typedef int32_t opcode_t;
 typedef opcode_t * code_t;
@@ -214,8 +228,8 @@ typedef opcode_t * code_t;
 
 /* Another special case: objects */
 #define Object_tag 248
-#define Class_val(val) Field((val), 0)
-#define Oid_val(val) Long_val(Field((val), 1))
+#define Class_val(val) Field_imm((val), 0)
+#define Oid_val(val) Long_val(Field_imm((val), 1))
 CAMLextern value caml_get_public_method (value obj, value tag);
 /* Called as:
    caml_callback(caml_get_public_method(obj, caml_hash_variant(name)), obj) */
@@ -288,7 +302,7 @@ CAMLextern int caml_is_double_array (value);   /* 0 is false, 1 is true */
    the GC; therefore, they must not contain any [value].
    See [custom.h] for operations on method suites. */
 #define Custom_tag 255
-#define Data_custom_val(v) ((void *) &Field((v), 1))
+#define Data_custom_val(v) ((void *) &Op_val(v)[1])
 struct custom_operations;       /* defined in [custom.h] */
 
 /* Int32.t, Int64.t and Nativeint.t are represented as custom blocks. */

--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -187,12 +187,17 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 #define Field(x, i) (((value *)(x)) [i])           /* Also an l-value. */
 #endif
 
+/* The result of [caml_read_field] must be stored in a variable
+   which has already been declared with CAMLlocalN/CAMLparamN.
+
+   To help ensure this, [caml_read_field] takes the address of such
+   a variable as a parameter, rather than directly returning a value. */
 static inline void caml_read_field (value obj, mlsize_t f, value* ret)
 {
   *ret = Op_val(obj)[f];
 }
 
-static inline value Field_imm (value obj, mlsize_t f)
+static inline value Field_immut (value obj, mlsize_t f)
 {
   return Op_val(obj)[f];
 }
@@ -228,8 +233,8 @@ typedef opcode_t * code_t;
 
 /* Another special case: objects */
 #define Object_tag 248
-#define Class_val(val) Field_imm((val), 0)
-#define Oid_val(val) Long_val(Field_imm((val), 1))
+#define Class_val(val) Field_immut((val), 0)
+#define Oid_val(val) Long_val(Field_immut((val), 1))
 CAMLextern value caml_get_public_method (value obj, value tag);
 /* Called as:
    caml_callback(caml_get_public_method(obj, caml_hash_variant(name)), obj) */

--- a/byterun/caml/signals.h
+++ b/byterun/caml/signals.h
@@ -16,9 +16,6 @@
 #ifndef CAML_SIGNALS_H
 #define CAML_SIGNALS_H
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "misc.h"
 #include "mlvalues.h"
 

--- a/byterun/globroots.c
+++ b/byterun/globroots.c
@@ -298,7 +298,7 @@ struct caml_root_private {
 
 /* It would be better if caml_roots used the generational API,
    but they can't if they are to support the caml_named_value call,
-   which raw value pointers */
+   which returns raw value pointers */
 
 CAMLexport caml_root caml_create_root(value v)
 {
@@ -325,7 +325,7 @@ CAMLexport void caml_modify_root(caml_root r, value v)
 }
 
 /* used only for backward compatibility with caml_named_value in callback.c */
-CAMLexport value* caml__root_as_ptr(caml_root r)
+CAMLexport value* caml_deprecated_root_as_ptr(caml_root r)
 {
   return &r->val;
 }

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -640,6 +640,11 @@ CAMLexport CAMLweakdef void caml_initialize (value *fp, value val)
   }
 }
 
+CAMLexport CAMLweakdef void caml_initialize_field (value obj, mlsize_t f, value val)
+{
+  caml_initialize(&Field(obj, f), val);
+}
+
 /* You must use [caml_modify] to change a field of an existing shared block,
    unless you are sure the value being overwritten is not a shared block and
    the value being written is not a young block. */
@@ -689,6 +694,10 @@ CAMLexport CAMLweakdef void caml_modify (value *fp, value val)
   }
 }
 
+CAMLexport CAMLweakdef void caml_modify_field (value obj, mlsize_t f, value val)
+{
+  caml_modify(&Field(obj, f), val);
+}
 
 /* Global memory pool.
 

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -13,6 +13,7 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_API_VERSION 405
 #include <string.h>
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
@@ -46,13 +47,13 @@ static value convert_addrinfo(struct addrinfo * a)
   memcpy(&sa.s_gen, a->ai_addr, len);
   vaddr = alloc_sockaddr(&sa, len, -1);
   vcanonname = caml_copy_string(a->ai_canonname == NULL ? "" : a->ai_canonname);
-  vres = caml_alloc_small(5, 0);
-  Field(vres, 0) = cst_to_constr(a->ai_family, socket_domain_table, 3, 0);
-  Field(vres, 1) = cst_to_constr(a->ai_socktype, socket_type_table, 4, 0);
-  Field(vres, 2) = Val_int(a->ai_protocol);
-  Field(vres, 3) = vaddr;
-  Field(vres, 4) = vcanonname;
-  CAMLreturn(vres);
+  vres = caml_alloc_5(0,
+    cst_to_constr(a->ai_family, socket_domain_table, 3, 0),
+    cst_to_constr(a->ai_socktype, socket_type_table, 4, 0),
+    Val_int(a->ai_protocol),
+    vaddr,
+    vcanonname);
+  CAMLreturn (vres);
 }
 
 CAMLprim value unix_getaddrinfo(value vnode, value vserv, value vopts)
@@ -82,18 +83,18 @@ CAMLprim value unix_getaddrinfo(value vnode, value vserv, value vopts)
   /* Parse options, set hints */
   memset(&hints, 0, sizeof(hints));
   hints.ai_family = PF_UNSPEC;
-  for (/*nothing*/; Is_block(vopts); vopts = Field(vopts, 1)) {
-    v = Field(vopts, 0);
+  for (/*nothing*/; Is_block(vopts); vopts = Field_imm(vopts, 1)) {
+    v = Field_imm(vopts, 0);
     if (Is_block(v))
       switch (Tag_val(v)) {
       case 0:                   /* AI_FAMILY of socket_domain */
-        hints.ai_family = socket_domain_table[Int_val(Field(v, 0))];
+        hints.ai_family = socket_domain_table[Int_val(Field_imm(v, 0))];
         break;
       case 1:                   /* AI_SOCKTYPE of socket_type */
-        hints.ai_socktype = socket_type_table[Int_val(Field(v, 0))];
+        hints.ai_socktype = socket_type_table[Int_val(Field_imm(v, 0))];
         break;
       case 2:                   /* AI_PROTOCOL of int */
-        hints.ai_protocol = Int_val(Field(v, 0));
+        hints.ai_protocol = Int_val(Field_imm(v, 0));
         break;
       }
     else
@@ -117,10 +118,7 @@ CAMLprim value unix_getaddrinfo(value vnode, value vserv, value vopts)
   if (retcode == 0) {
     for (r = res; r != NULL; r = r->ai_next) {
       e = convert_addrinfo(r);
-      v = caml_alloc_small(2, 0);
-      Field(v, 0) = e;
-      Field(v, 1) = vres;
-      vres = v;
+      vres = caml_alloc_2(0, e, vres);
     }
     freeaddrinfo(res);
   }

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -83,18 +83,18 @@ CAMLprim value unix_getaddrinfo(value vnode, value vserv, value vopts)
   /* Parse options, set hints */
   memset(&hints, 0, sizeof(hints));
   hints.ai_family = PF_UNSPEC;
-  for (/*nothing*/; Is_block(vopts); vopts = Field_imm(vopts, 1)) {
-    v = Field_imm(vopts, 0);
+  for (/*nothing*/; Is_block(vopts); vopts = Field_immut(vopts, 1)) {
+    v = Field_immut(vopts, 0);
     if (Is_block(v))
       switch (Tag_val(v)) {
       case 0:                   /* AI_FAMILY of socket_domain */
-        hints.ai_family = socket_domain_table[Int_val(Field_imm(v, 0))];
+        hints.ai_family = socket_domain_table[Int_val(Field_immut(v, 0))];
         break;
       case 1:                   /* AI_SOCKTYPE of socket_type */
-        hints.ai_socktype = socket_type_table[Int_val(Field_imm(v, 0))];
+        hints.ai_socktype = socket_type_table[Int_val(Field_immut(v, 0))];
         break;
       case 2:                   /* AI_PROTOCOL of int */
-        hints.ai_protocol = Int_val(Field_imm(v, 0));
+        hints.ai_protocol = Int_val(Field_immut(v, 0));
         break;
       }
     else

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -13,7 +13,7 @@
 /*                                                                        */
 /**************************************************************************/
 
-#define CAML_API_VERSION 405
+#define CAML_API_VERSION 406
 #include <string.h>
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>


### PR DESCRIPTION
The [multicore branch](https://github.com/ocamllabs/ocaml-multicore) requires several changes to OCaml's C API, affecting those functions which expose raw pointers into mutable parts the OCaml heap (which is not a safe thing to do on multicore).

While multicore can't support the current OCaml API, it's quite easy for trunk OCaml to support the multicore API. This patch adds support for the multicore API (while maintaining support for the existing one), so that we can begin porting libraries that use C stubs to work on multicore without breaking compatibility with trunk.

## Changes

The most invasive changes are to field access, since multicore does not support the `Field` macro. Fields are initialised, read, and modified using the new functions `caml_initialise_field`, `caml_read_field` and `caml_modify_field`, with `Field_imm` available as a convenience for fields known to be immutable. The changes are described in depth on [the multicore wiki](https://github.com/ocamllabs/ocaml-multicore/wiki/C-API-changes).

The other API changes are to global roots and values registered for callbacks. The new API for global roots uses an opaque type `caml_root` instead of `value*`, while the new API for registered values also works with `caml_root` instead of `value*`.

The second commit in this patch gives an example of the changes necessary in C bindings. I picked `unix/getaddrinfo.c` as an example at random, but there are many more examples in the [recent commits on the multicore branch](https://github.com/ocamllabs/ocaml-multicore/commits). In general, the changes are easy but tedious.

## Compatibility

By default, both the current API and the multicore API are exposed, since there are no conflicting names between them. To check for compatibility with multicore and avoid use of deprecated features, this patch introduces the macro `CAML_API_VERSION`. C stubs can define this macro to a version of OCaml, to check that they are not using features deprecated in that version. (The macro serves only to disable features: it has more the flavour of "use strict" (in perl / javascript / others) rather than glibc's feature flags).

Only two levels of `CAML_API_VERSION` currently have any effect:

  - `#define CAML_API_VERSION 400` (or above) implies `CAML_NAME_SPACE`, so that old aliases like `alloc` for `caml_alloc` are not defined, and disables the old `Begin_root` / `End_root` macros.

  - `#define CAML_API_VERSION 405` (or above) disables the current API for accessing fields in favour of the one introduced by this patch. Bindings which work with `CAML_API_VERSION=405` should also work on multicore.

Projects with C bindings can define `CAML_API_VERSION` at the top of each file, but it may be simpler to add `-DCAML_API_VERSION=xxx` to the C compiler flags.

Eventually, I'd like to see the OCaml headers print a warning if `CAML_API_VERSION` is not defined to some recent version, which would give us a path to removal of old features (such as `Begin_root` / `End_root`, which have now been deprecated for longer than they were supported).

## Docs

This patch shouldn't be merged until I've updated the "Interfacing with C" section of the manual, but I'd like to get feedback about the proposed design beforehand.