### PR TITLE
Remove some dead preprocessor lines

### DIFF
--- a/byterun/weak.c
+++ b/byterun/weak.c
@@ -219,10 +219,6 @@ CAMLprim value caml_ephe_unset_data (value ar)
   return Val_unit;
 }
 
-
-#define Setup_for_gc
-#define Restore_after_gc
-
 CAMLprim value caml_ephe_get_key (value ar, value n)
 {
   CAMLparam2 (ar, n);
@@ -268,9 +264,6 @@ CAMLprim value caml_ephe_get_data (value ar)
   }
   CAMLreturn (res);
 }
-
-#undef Setup_for_gc
-#undef Restore_after_gc
 
 CAMLprim value caml_ephe_get_key_copy (value ar, value n)
 {


### PR DESCRIPTION
These lines in `weak.c` have no effect - they're for changing the behaviour of the `Alloc_small` macro, which this file doesn't use.