### PR TITLE
Initialize systhreads when C threads are registered with the runtime.

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -451,10 +451,10 @@ static void caml_thread_reinitialize(void)
 
 /* Initialize the thread machinery */
 
-CAMLprim value caml_thread_initialize(value unit)   /* ML */
+static void st_thread_initialize(void)
 {
   /* Protect against repeated initialization (PR#1325) */
-  if (curr_thread != NULL) return Val_unit;
+  if (curr_thread != NULL) return;
   /* OS-specific initialization */
   st_initialize();
   /* Initialize and acquire the master lock */
@@ -495,6 +495,12 @@ CAMLprim value caml_thread_initialize(value unit)   /* ML */
   /* Set up fork() to reinitialize the thread machinery in the child
      (PR#4577) */
   st_atfork(caml_thread_reinitialize);
+}
+
+
+CAMLprim value caml_thread_initialize(value unit)   /* ML */
+{
+  st_thread_initialize();
   return Val_unit;
 }
 
@@ -604,6 +610,8 @@ CAMLexport int caml_c_thread_register(void)
   caml_thread_t th;
   st_retcode err;
 
+  /* Initialize thread */
+  st_thread_initialize();
   /* Already registered? */
   if (st_tls_get(thread_descriptor_key) != NULL) return 0;
   /* Create a thread info block */


### PR DESCRIPTION
# Summary

The systhreads scheduler is initialized (by `caml_thread_initialize`) when linking against the threads library **and** the OCaml code refers to the thread module. The initialization ensures that acquiring the runtime acquires the runtime master lock. If the OCaml code does not refer to the `Thread` module, the initialization code is never run, and the master lock is not initialized. This PR initializes (if not already initialized) the systhreads scheduler when adding C threads are registered from C.

# Example

Normally, if the OCaml code refers to the `Thread` module, the initialization code is run. There are scenarios where the OCaml code does not refer to the `Thread` module but the runtime still needs to be locked. This happens when the OCaml functions are expected to be called from a multi-threaded C program. For example, consider this simple ocaml program that registers a callback. 

```
$ cat caml_stubs.ml
let _ = Callback.register "ocaml_string_of_int" string_of_int
```

For the sake of example, let's compile this program with `-threads`.

```
$ ocamlbuild -tag thread -package unix caml_stubs.native
Finished, 4 targets (4 cached) in 00:00:00.
```
Since `caml_stubs.ml` does not refer to the `Thread` module, the initialization code is not run. In fact, the module is not even linked. 

```
$ nm caml_stubs.native | grep "caml_thread"
$
```

Calling `ocaml_string_to_int` concurrently from multiple C threads is incorrect as the runtime is not protected by the master lock. 

Simply referring to the `Thread` module runs the initialization code:

```
$ cat caml_stubs.ml
let _ = Thread.self (* Refer to Thread module *)
let _ = Callback.register "ocaml_string_of_int" string_of_int
$ ocamlbuild -tag thread -package unix caml_stubs.native
Finished, 4 targets (0 cached) in 00:00:00.
$ nm caml_stubs.native | grep "caml_thread_initialize"
0000000100031eb0 T _caml_thread_initialize
$ lldb caml_stubs.native 
(lldb) target create "caml_stubs.native"
Current executable set to 'caml_stubs.native' (x86_64).
(lldb) break set --name caml_thread_initialize 
Breakpoint 1: where = caml_stubs.native`caml_thread_initialize, address = 0x0000000100031eb0
(lldb) r
Process 86473 launched: '/Users/kc/research/repos/code-snippets/ocaml-thread-crash/caml_stubs.native' (x86_64)
Process 86473 stopped
* thread #1: tid = 0x1de433, 0x0000000100031eb0 caml_stubs.native`caml_thread_initialize, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
    frame #0: 0x0000000100031eb0 caml_stubs.native`caml_thread_initialize
caml_stubs.native`caml_thread_initialize:
->  0x100031eb0 <+0>:  cmpq   $0x0, 0x54a98(%rip)
    0x100031eb8 <+8>:  jne    0x100032037               ; <+391>
    0x100031ebe <+14>: pushq  %rbp
    0x100031ebf <+15>: movq   %rsp, %rbp
(lldb) bt
* thread #1: tid = 0x1de433, 0x0000000100031eb0 caml_stubs.native`caml_thread_initialize, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
  * frame #0: 0x0000000100031eb0 caml_stubs.native`caml_thread_initialize
    frame #1: 0x000000010000372e caml_stubs.native`camlThread__entry + 254
    frame #2: 0x0000000100000959 caml_stubs.native`caml_program + 393
    frame #3: 0x0000000100055c68 caml_stubs.native`caml_start_program + 92
    frame #4: 0x000000010003a3e8 caml_stubs.native`caml_main + 488
    frame #5: 0x000000010003a43c caml_stubs.native`main + 12
    frame #6: 0x00007fffdacb7255 libdyld.dylib`start + 1
(lldb) 
```

# Fix

OCaml already expects any additional application threads created in C be registered using `caml_c_thread_register`, if it plans to callback into OCaml. The fix is to initialize the systhread scheduler in `caml_c_thread_register`, if it already wasn't. The initialization code is protected against [duplicate initializations](https://github.com/ocaml/ocaml/blob/trunk/otherlibs/systhreads/st_stubs.c#L456-L457) so this is safe and efficient. 