### PR TITLE
fix GPR#673 issue: ref_table shouldn't point to minor heap

### DIFF
--- a/Changes
+++ b/Changes
@@ -227,6 +227,9 @@ Next version (4.05.0):
   `Ovar_name of out_ident * out_type list` becomes `Ovar_type of out_type`.
   (Valentin Gatien-Baron)
 
+- GPR#673: distinguish initialization of block fields from mutation in lambda.
+  (Frédéric Bour, review by Xavier Leroy, Stephen Dolan and Mark Shinwell)
+
 ### Bug fixes
 
 - PR#5115: protect all byterun/fail.c functions against

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -632,7 +632,7 @@ CAMLexport CAMLweakdef void caml_initialize (value *fp, value val)
 {
   CAMLassert(Is_in_heap_or_young(fp));
   *fp = val;
-  if (Is_block (val) && Is_young (val)) {
+  if (!Is_young((value)fp) && Is_block (val) && Is_young (val)) {
     add_to_ref_table (&caml_ref_table, fp);
   }
 }


### PR DESCRIPTION
This fix the issue pointed by @stedolan and @damiendoligez: caml_initialize shouldn't store refs to minor heap in ref_table.