### PR TITLE
Make -linkall applicable to single compilation units

### DIFF
--- a/Changes
+++ b/Changes
@@ -313,6 +313,11 @@ Next minor version (4.04.1):
   for ocaml build with WITH_FRAME_POINTERS defined
   (Christoph Cullmann)
 
+- PR#7460, GPR#1011: catch uncaught exception when unknown files are passed
+  as argument (regression in 4.04.0)
+  (Bernhard Schommer, review by Florian Angeletti and Gabriel Scherer,
+   report by Stephen Dolan)
+
 - GPR#912: Fix segfault in Unix.create_process on Windows caused by wrong header
   configuration.
   (David Allsopp)

--- a/Changes
+++ b/Changes
@@ -68,6 +68,12 @@ Next version (4.05.0):
 - PR#7137, GPR#960: "-open" command line flag now accepts a module path
   (not a module name) (Arseniy Alekseyev and Leo White)
 
+- GPR#1009: "ocamlc -c -linkall" and "ocamlopt -c -linkall" can now be used
+  to set the "always link" flag on individual compilation units.  This
+  controls linking with finer granularity than "-a -linkall", which sets
+  the "always link" flag on all units of the given library.
+  (Xavier Leroy)
+
 ### Standard library:
 
 - PR#6975, GPR#902: Truncate function added to stdlib Buffer module

--- a/asmcomp/asmlibrarian.ml
+++ b/asmcomp/asmlibrarian.ml
@@ -38,7 +38,7 @@ let read_info name =
     with Not_found ->
       raise(Error(File_not_found name)) in
   let (info, crc) = Compilenv.read_unit_info filename in
-  info.ui_force_link <- !Clflags.link_everything;
+  info.ui_force_link <- info.ui_force_link || !Clflags.link_everything;
   (* There is no need to keep the approximation in the .cmxa file,
      since the compiler will go looking directly for .cmx files.
      The linker, which is the only one that reads .cmxa files, does not

--- a/asmcomp/compilenv.ml
+++ b/asmcomp/compilenv.ml
@@ -129,7 +129,7 @@ let reset ?packname ~source_provenance:file name =
   current_unit.ui_curry_fun <- [];
   current_unit.ui_apply_fun <- [];
   current_unit.ui_send_fun <- [];
-  current_unit.ui_force_link <- false;
+  current_unit.ui_force_link <- !Clflags.link_everything;
   Hashtbl.clear exported_constants;
   structured_constants := structured_constants_empty;
   current_unit.ui_export_info <- default_ui_export_info;

--- a/bytecomp/bytelibrarian.ml
+++ b/bytecomp/bytelibrarian.ml
@@ -29,7 +29,7 @@ exception Error of error
 let copy_compunit ic oc compunit =
   seek_in ic compunit.cu_pos;
   compunit.cu_pos <- pos_out oc;
-  compunit.cu_force_link <- !Clflags.link_everything;
+  compunit.cu_force_link <- compunit.cu_force_link || !Clflags.link_everything;
   copy_file_chunk ic oc compunit.cu_codesize;
   if compunit.cu_debug > 0 then begin
     seek_in ic compunit.cu_debug;

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -393,7 +393,7 @@ let to_file outchan unit_name objfile ~required_globals code =
       cu_primitives = List.map Primitive.byte_name
                                !Translmod.primitive_declarations;
       cu_required_globals = Ident.Set.elements required_globals;
-      cu_force_link = false;
+      cu_force_link = !Clflags.link_everything;
       cu_debug = pos_debug;
       cu_debugsize = size_debug } in
   init();                               (* Free out_buffer and reloc_info *)

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -129,12 +129,20 @@ let main () =
   try
     readenv ppf Before_args;
     Arg.parse_expand Options.list anonymous usage;
-    Compenv.process_deferred_actions
-      (ppf,
-       Compile.implementation,
-       Compile.interface,
-       ".cmo",
-       ".cma");
+    begin try
+      Compenv.process_deferred_actions
+        (ppf,
+         Compile.implementation,
+         Compile.interface,
+         ".cmo",
+         ".cma");
+    with Arg.Bad msg ->
+      begin
+        prerr_endline msg;
+        Arg.usage Options.list usage;
+        exit 2
+      end
+    end;
     readenv ppf Before_link;
     if
       List.length (List.filter (fun x -> !x)

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -236,15 +236,24 @@ let main () =
   let ppf = Format.err_formatter in
   try
     readenv ppf Before_args;
-    Arg.parse_expand (Arch.command_line_options @ Options.list) anonymous usage;
+    let spec = Arch.command_line_options @ Options.list in
+    Arg.parse_expand spec anonymous usage;
     if !gprofile && not Config.profiling then
       fatal "Profiling with \"gprof\" is not supported on this platform.";
-    Compenv.process_deferred_actions
-      (ppf,
-       Optcompile.implementation ~backend,
-       Optcompile.interface,
-       ".cmx",
-       ".cmxa");
+    begin try
+      Compenv.process_deferred_actions
+        (ppf,
+         Optcompile.implementation ~backend,
+         Optcompile.interface,
+         ".cmx",
+         ".cmxa");
+    with Arg.Bad msg ->
+      begin
+        prerr_endline msg;
+        Arg.usage spec usage;
+        exit 2
+      end
+    end;
     readenv ppf Before_link;
     if
       List.length (List.filter (fun x -> !x)

--- a/man/ocamlc.m
+++ b/man/ocamlc.m
@@ -425,6 +425,12 @@ setting the
 .B \-linkall
 option forces all subsequent links of programs involving that library
 to link all the modules contained in the library.
+When compiling a module (option
+.BR \-c ),
+setting the
+.B \-linkall
+option ensures that this module will
+always be linked if it is put in a library and this library is linked.
 .TP
 .B \-make\-runtime
 Build a custom runtime system (in the file specified by option

--- a/man/ocamlopt.m
+++ b/man/ocamlopt.m
@@ -326,6 +326,12 @@ flag), setting the
 flag forces all
 subsequent links of programs involving that library to link all the
 modules contained in the library.
+When compiling a module (option
+.BR \-c ),
+setting the
+.B \-linkall
+option ensures that this module will
+always be linked if it is put in a library and this library is linked.
 .TP
 .B \-no-alias-deps
 Do not record dependencies for module aliases.

--- a/manual/manual/cmds/unified-options.etex
+++ b/manual/manual/cmds/unified-options.etex
@@ -288,7 +288,9 @@ Force all modules contained in libraries to be linked in. If this
 flag is not given, unreferenced modules are not linked in. When
 building a library (option "-a"), setting the "-linkall" option forces all
 subsequent links of programs involving that library to link all the
-modules contained in the library.
+modules contained in the library.  When compiling a module (option
+"-c"), setting the "-linkall" option ensures that this module will
+always be linked if it is put in a library and this library is linked.
 }%notop
 
 \comp{%

--- a/testsuite/tests/tool-command-line/Makefile
+++ b/testsuite/tests/tool-command-line/Makefile
@@ -1,0 +1,40 @@
+#**************************************************************************
+#*                                                                        *
+#*                                OCaml                                   *
+#*                                                                        *
+#*                          Bernhard Schommer                             *
+#*                                                                        *
+#*   Copyright 2010 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+BASEDIR=../..
+
+
+default:
+	@$(OCAMLOPT) unknown-file  2>&1 | grep "don't know what to do with unknown-file"\
+	> unknown-file.opt.result || true
+	@$(OCAMLC) unknown-file 2>&1 | grep "don't know what to do with unknown-file" \
+	> unknown-file.byte.result  || true
+	@for file in *.opt.reference; do \
+	  printf " ... testing '$$file':"; \
+	  $(DIFF) $$file `basename $$file reference`result >/dev/null \
+          && echo " => passed" || echo " => failed"; \
+	done
+	@for file in *.byte.reference; do \
+	  printf " ... testing '$$file':"; \
+	  $(DIFF) $$file `basename $$file reference`result >/dev/null \
+          && echo " => passed" || echo " => failed"; \
+	done
+
+promote: defaultpromote
+
+clean: defaultclean
+	@rm -f *.result
+
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/tool-command-line/unknown-file.byte.reference
+++ b/testsuite/tests/tool-command-line/unknown-file.byte.reference
@@ -1,0 +1,1 @@
+don't know what to do with unknown-file

--- a/testsuite/tests/tool-command-line/unknown-file.opt.reference
+++ b/testsuite/tests/tool-command-line/unknown-file.opt.reference
@@ -1,0 +1,1 @@
+don't know what to do with unknown-file


### PR DESCRIPTION
The `-linkall` option of ocamlc/ocamlopt was introduced a long time ago to deactivate the link-time optimization of libraries, whereas objects (.cmo/.cmx) contained in libraries (.cma/.cmxa) are not linked if none of their definitions is referenced.

At link-time, `-linkall` causes all objects of all libraries to be linked and included in the final executable.

At library construction time (`-a` option), `-linkall` causes the "always link" flag to be put on all objects in the library, so that when the library is linked, all its objects are linked.

The present pull request extends this behavior to single objects / compilation units.  Compiling with `-c -linkall` causes the production of an object file with the "always link" flag set.  When put in a library, this object retains its "always link" flag, even if `-linkall` is not given at library construction time and the other objects in the library do not have the "always link" flag.  

This new behavior can be useful for libraries that contain one compilation unit that performs important initializations (e.g. for a mixed OCaml/C library, initializing global data structures on the C side) and other units that don't:
* Not using `-linkall` anywhere in the library build can cause data structures to remain uninitialized, see https://caml.inria.fr/mantis/view.php?id=7459 for an example of this bug.
* Building the library with `-a -linkall` causes all units to be linked all the time, which can be costly in code size. 
* Compiling the first unit with `-c -linkall` and building the library without `-linkall` ensures that the initialization is always performed, but the rest of the library is linked only when actually used.

This pull request just introduces the mechanism.  If it is judged favorably, we'll see about using it to make some of the otherlibs/ more robust w.r.t. initialization.
