### PR TITLE
Fix parsing of OCaml code by ocamlyacc

### DIFF
--- a/Changes
+++ b/Changes
@@ -411,6 +411,10 @@ Next major version (4.05.0):
   to solve ocamlbuild+doc usability issue (ocaml/ocamlbuild#79)
   (Gabriel Scherer, review by Florian Angeletti, discussion with Daniel Bünzli)
 
+* GPR#1012: ocamlyacc, fix parsing of raw strings and nested comments, as well
+  as the handling of ' characters in identifiers.
+  (Demi Obenour)
+
 - GPR#1017: ocamldoc, add an option to detect code fragments that could be
   transformed into a cross-reference to a known element.
   (Florian Angeletti, review and suggestion by David Allsopp)

--- a/testsuite/tests/tool-lexyacc/grammar.mly
+++ b/testsuite/tests/tool-lexyacc/grammar.mly
@@ -29,7 +29,8 @@ lexer_definition:
 ;
 header:
     Taction
-        { $1 }
+        { $1 (* '"' test that ocamlyacc can
+                    handle comments correctly"*)" "(*" *) }
   |
         { Location(0,0) }
 ;

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -85,8 +85,6 @@
 #define TEXT 5
 #define TYPE 6
 #define START 7
-#define UNION 8
-#define IDENT 9
 
 /*  symbol classes  */
 

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -229,7 +229,6 @@ extern char *defines_file_name;
 extern char *input_file_name;
 extern char *output_file_name;
 extern char *text_file_name;
-extern char *union_file_name;
 extern char *verbose_file_name;
 extern char *interface_file_name;
 
@@ -240,7 +239,6 @@ extern FILE *defines_file;
 extern FILE *input_file;
 extern FILE *output_file;
 extern FILE *text_file;
-extern FILE *union_file;
 extern FILE *verbose_file;
 extern FILE *interface_file;
 
@@ -252,7 +250,6 @@ extern int ntokens;
 extern int nvars;
 extern int ntags;
 
-extern char unionized;
 extern char line_format[];
 
 extern int   start_symbol;
@@ -335,7 +332,6 @@ extern void no_grammar (void) Noreturn;
 extern void no_space (void) Noreturn;
 extern void open_error (char *filename) Noreturn;
 extern void output (void);
-extern void over_unionized (char *u_cptr) Noreturn;
 extern void prec_redeclared (void);
 extern void polymorphic_entry_point(char *s) Noreturn;
 extern void forbidden_conflicts (void);
@@ -357,7 +353,6 @@ extern void unterminated_action (int a_lineno, char *a_line, char *a_cptr) Noret
 extern void unterminated_comment (int c_lineno, char *c_line, char *c_cptr) Noreturn;
 extern void unterminated_string (int s_lineno, char *s_line, char *s_cptr) Noreturn;
 extern void unterminated_text (int t_lineno, char *t_line, char *t_cptr) Noreturn;
-extern void unterminated_union (int u_lineno, char *u_line, char *u_cptr) Noreturn;
 extern void used_reserved (char *s) Noreturn;
 extern void verbose (void);
 extern void write_section (char **section);

--- a/yacc/error.c
+++ b/yacc/error.c
@@ -109,24 +109,6 @@ void unterminated_text(int t_lineno, char *t_line, char *t_cptr)
 }
 
 
-void unterminated_union(int u_lineno, char *u_line, char *u_cptr)
-{
-    fprintf(stderr, "File \"%s\", line %d: unterminated %%union declaration\n",
-            virtual_input_file_name, u_lineno);
-    print_pos(u_line, u_cptr);
-    done(1);
-}
-
-
-void over_unionized(char *u_cptr)
-{
-    fprintf(stderr, "File \"%s\", line %d: too many %%union declarations\n",
-            virtual_input_file_name, lineno);
-    print_pos(line, u_cptr);
-    done(1);
-}
-
-
 void illegal_tag(int t_lineno, char *t_line, char *t_cptr)
 {
     fprintf(stderr, "File \"%s\", line %d: illegal tag\n",

--- a/yacc/main.c
+++ b/yacc/main.c
@@ -56,11 +56,10 @@ char *defines_file_name;
 char *input_file_name = "";
 char *output_file_name;
 char *text_file_name;
-char *union_file_name;
 char *verbose_file_name;
 
 #ifdef HAS_MKSTEMP
-int action_fd = -1, entry_fd = -1, text_fd = -1, union_fd = -1;
+int action_fd = -1, entry_fd = -1, text_fd = -1;
 #endif
 
 FILE *action_file;      /*  a temp file, used to save actions associated    */
@@ -72,9 +71,6 @@ FILE *input_file;       /*  the input file                                  */
 FILE *output_file;      /*  y.tab.c                                         */
 FILE *text_file;        /*  a temp file, used to save text until all        */
                         /*  symbols have been defined                       */
-FILE *union_file;       /*  a temp file, used to save the union             */
-                        /*  definition until all symbol have been           */
-                        /*  defined                                         */
 FILE *verbose_file;     /*  y.output                                        */
 FILE *interface_file;
 
@@ -118,13 +114,10 @@ void done(int k)
        unlink(entry_file_name);
     if (text_fd != -1)
        unlink(text_file_name);
-    if (union_fd != -1)
-       unlink(union_file_name);
 #else
     if (action_file) { fclose(action_file); unlink(action_file_name); }
     if (entry_file) { fclose(entry_file); unlink(entry_file_name); }
     if (text_file) { fclose(text_file); unlink(text_file_name); }
-    if (union_file) { fclose(union_file); unlink(union_file_name); }
 #endif
     if (output_file && k > 0) {
       fclose(output_file); unlink(output_file_name);
@@ -302,32 +295,26 @@ void create_file_names(void)
     if (entry_file_name == 0) no_space();
     text_file_name = MALLOC(i);
     if (text_file_name == 0) no_space();
-    union_file_name = MALLOC(i);
-    if (union_file_name == 0) no_space();
 
     strcpy(action_file_name, tmpdir);
     strcpy(entry_file_name, tmpdir);
     strcpy(text_file_name, tmpdir);
-    strcpy(union_file_name, tmpdir);
 
     if (len && tmpdir[len - 1] != dirsep)
     {
         action_file_name[len] = dirsep;
         entry_file_name[len] = dirsep;
         text_file_name[len] = dirsep;
-        union_file_name[len] = dirsep;
         ++len;
     }
 
     strcpy(action_file_name + len, temp_form);
     strcpy(entry_file_name + len, temp_form);
     strcpy(text_file_name + len, temp_form);
-    strcpy(union_file_name + len, temp_form);
 
     action_file_name[len + 5] = 'a';
     entry_file_name[len + 5] = 'e';
     text_file_name[len + 5] = 't';
-    union_file_name[len + 5] = 'u';
 
 #ifdef HAS_MKSTEMP
     action_fd = mkstemp(action_file_name);
@@ -339,14 +326,10 @@ void create_file_names(void)
     text_fd = mkstemp(text_file_name);
     if (text_fd == -1)
         open_error(text_file_name);
-    union_fd = mkstemp(union_file_name);
-    if (union_fd == -1)
-        open_error(union_file_name);
 #else
     mktemp(action_file_name);
     mktemp(entry_file_name);
     mktemp(text_file_name);
-    mktemp(union_file_name);
 #endif
 
     len = strlen(file_prefix);
@@ -424,13 +407,6 @@ void open_files(void)
         defines_file = fopen(defines_file_name, "w");
         if (defines_file == 0)
             open_error(defines_file_name);
-#ifdef HAS_MKSTEMP
-        union_file = fdopen(union_fd, "w");
-#else
-        union_file = fopen(union_file_name, "w");
-#endif
-        if (union_file ==  0)
-            open_error(union_file_name);
     }
 
     output_file = fopen(output_file_name, "w");

--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -1231,7 +1231,6 @@ void add_symbol(void)
 
 void copy_action(void)
 {
-    push_stack('{');
     register int c;
     register int i, n;
     int depth;
@@ -1242,6 +1241,7 @@ void copy_action(void)
     char *a_line = dup_line();
     char *a_cptr = a_line + (cptr - line);
 
+    push_stack('{');
     if (last_was_action) syntax_error (lineno, line, cptr);
     last_was_action = 1;
 

--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -1282,13 +1282,13 @@ loop:
             goto loop;
         }
     }
-    if (isalpha(c) || c == '_' || c == '$')
+    if (isalpha(c) || c == '_' || c == '$' || In_bitmap(caml_ident_start, c))
     {
         do
         {
             putc(c, f);
             c = *++cptr;
-        } while (isalnum(c) || c == '_' || c == '$');
+        } while (isalnum(c) || c == '_' || c == '$' || c == '\'' || In_bitmap(caml_ident_body, c));
         goto loop;
     }
     if (c == '}' && depth == 1) {


### PR DESCRIPTION
ocamlyacc would missparse certain valid OCaml code.  As shown in [MPR#7454] and [MPR#7455], this can cause valid `.mly` files to be rejected, and for certain invalid files to be compiled to OCaml code that segfaults, without the `.mly` file containing any unsafe functions.

This patch fixes both problems.

[MPR#7454]: https://caml.inria.fr/mantis/view.php?id=7454
[MPR#7455]: https://caml.inria.fr/mantis/view.php?id=7455