### PR TITLE
ocamldep: add -plugin and use compilerlibs to build

### DIFF
--- a/Changes
+++ b/Changes
@@ -141,6 +141,10 @@ Next version (4.05.0):
   spent in subprocesses like preprocessors
   (Valentin Gatien-Baron, review by Gabriel Scherer)
 
+- GPR#1015: add option "-plugin PLUGIN" to ocamldep too. Use compilerlibs
+  to build ocamldep.
+  (Fabrice Le Fessant)
+
 ### Standard library:
 
 - PR#6975, GPR#902: Truncate function added to stdlib Buffer module

--- a/man/ocamldep.m
+++ b/man/ocamldep.m
@@ -155,6 +155,23 @@ Assume that module
 is opened before parsing each of the
 following files.
 .TP
+.BI \-plugin \ plugin
+Dynamically load the code of the given
+.I plugin
+(a .cmo, .cma or .cmxs file) in 
+.BR ocamldep (1).
+The plugin must exist in
+the same kind of code as the tool (
+.BR ocamldep.byte 
+must load bytecode
+plugins, while 
+.BR ocamldep.opt
+must load native code plugins), and
+extension adaptation is done automatically for .cma files (to .cmxs files
+if 
+.BR ocamldep (1)
+is compiled in native code).
+.TP
 .BI \-pp \ command
 Cause
 .BR ocamldep (1)

--- a/manual/manual/cmds/depend.etex
+++ b/manual/manual/cmds/depend.etex
@@ -111,6 +111,14 @@ Output one line per file, regardless of the length.
 Assume that module \var{module} is opened before parsing each of the
 following files.
 
+\item["-plugin" \var{plugin}]
+Dynamically load the code of the given \var{plugin}
+(a ".cmo", ".cma" or ".cmxs" file) in "ocamldep". \var{plugin} must exist in
+the same kind of code as "ocamldep" ("ocamldep.byte" must load bytecode
+plugins, while "ocamldep.opt" must load native code plugins), and
+extension adaptation is done automatically for ".cma" files (to ".cmxs" files
+if "ocamldep" is compiled in native code).
+
 \item["-pp" \var{command}]
 Cause "ocamldep" to call the given \var{command} as a preprocessor
 for each source file.

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -108,14 +108,9 @@ VPATH := $(filter-out -I,$(INCLUDES))
 # The dependency generator
 
 CAMLDEP_OBJ=ocamldep.cmo
-CAMLDEP_IMPORTS=timings.cmo misc.cmo config.cmo identifiable.cmo numbers.cmo \
-  arg_helper.cmo clflags.cmo terminfo.cmo \
-  warnings.cmo location.cmo longident.cmo docstrings.cmo \
-  syntaxerr.cmo ast_helper.cmo parser.cmo lexer.cmo parse.cmo \
-  ccomp.cmo ast_mapper.cmo ast_iterator.cmo \
-  builtin_attributes.cmo ast_invariants.cmo \
-  pparse.cmo compenv.cmo depend.cmo
-
+CAMLDEP_IMPORTS= \
+  ../compilerlibs/ocamlcommon.cma \
+  ../compilerlibs/ocamlbytecomp.cma
 ocamldep: LINKFLAGS += -compat-32
 $(call byte_and_opt,ocamldep,$(CAMLDEP_IMPORTS) $(CAMLDEP_OBJ),)
 ocamldep: depend.cmi

--- a/tools/ocamldep.ml
+++ b/tools/ocamldep.ml
@@ -552,7 +552,7 @@ let _ =
   Clflags.classic := false;
   add_to_list first_include_dirs Filename.current_dir_name;
   Compenv.readenv ppf Before_args;
-  Arg.parse_expand [
+  Clflags.add_arguments __LOC__ [
      "-absname", Arg.Set Location.absname,
         " Show absolute filenames in error messages";
      "-all", Arg.Set all_dependencies,
@@ -586,6 +586,8 @@ let _ =
         " Output one line per file, regardless of the length";
      "-open", Arg.String (add_to_list Clflags.open_modules),
         "<module>  Opens the module <module> before typing";
+     "-plugin", Arg.String Compplugin.load,
+         "<plugin>  Load dynamic plugin <plugin>";
      "-pp", Arg.String(fun s -> Clflags.preprocessor := Some s),
          "<cmd>  Pipe sources through preprocessor <cmd>";
      "-ppx", Arg.String (add_to_list first_ppx),
@@ -606,7 +608,8 @@ let _ =
      "-args0", Arg.Expand Arg.read_arg0,
          "<file> Read additional NUL separated command line arguments from \n\
          \      <file>"
-    ] file_dependencies usage;
+  ];
+  Clflags.parse_arguments file_dependencies usage;
   Compenv.readenv ppf Before_link;
   if !sort_files then sort_files_by_dependencies !files
   else List.iter print_file_dependencies (List.sort compare !files);


### PR DESCRIPTION
This PR simply adds the option `-plugin PLUGIN` to `ocamldep`, as it might be useful to extend `ocamldep` with the same plugins as `ocamlc`.

It also bootstraps the compiler (in a separate commit), so that `ocamlc` can also use the new ability for plugins to define arguments. 