### PR TITLE
Ocamldoc: warning for missed cross-reference opportunities

### DIFF
--- a/Changes
+++ b/Changes
@@ -138,6 +138,10 @@ Next version (4.05.0):
   to solve ocamlbuild+doc usability issue (ocaml/ocamlbuild#79)
   (Gabriel Scherer, review by Florian Angeletti, discussion with Daniel Bünzli)
 
+- GPR#1017: ocamldoc, add an option to detect code fragments that could be
+  transformed into a cross-reference to a known element.
+  (Florian Angeletti, review and suggestion by David Allsopp)
+
 - clarify ocamldoc text parsing error messages
   (Gabriel Scherer)
 

--- a/ocamldoc/odoc_args.ml
+++ b/ocamldoc/odoc_args.ml
@@ -252,6 +252,8 @@ let default_options = Options.list @
        Odoc_global.files := !Odoc_global.files @ [Odoc_global.Text_file s]),
     M.option_text ;
   "-warn-error", Arg.Set Odoc_global.warn_error, M.werr ;
+  "-show-missed-crossref", Arg.Set Odoc_global.show_missed_crossref,
+  M.show_missed_crossref;
   "-hide-warnings", Arg.Clear Odoc_config.print_warnings, M.hide_warnings ;
   "-o", Arg.String (fun s -> Odoc_global.out_file := s), M.out_file ;
   "-d", Arg.String (fun s -> Odoc_global.target_dir := s), M.target_dir ;

--- a/ocamldoc/odoc_global.ml
+++ b/ocamldoc/odoc_global.ml
@@ -28,6 +28,7 @@ let include_dirs = Clflags.include_dirs
 let errors = ref 0
 
 let warn_error = ref false
+let show_missed_crossref = ref false
 
 let pwarning s =
   if !Odoc_config.print_warnings then prerr_endline (Odoc_messages.warning^": "^s);

--- a/ocamldoc/odoc_global.mli
+++ b/ocamldoc/odoc_global.mli
@@ -69,6 +69,9 @@ val errors : int ref
 (** Indicate if a warning is an error. *)
 val warn_error : bool ref
 
+(** Show code fragments that could be transformed into a cross-reference. *)
+val show_missed_crossref: bool ref
+
 (** Print the given warning, adding it to the list of {!errors}
 if {!warn_error} is [true]. *)
 val pwarning : string -> unit

--- a/ocamldoc/odoc_messages.ml
+++ b/ocamldoc/odoc_messages.ml
@@ -39,6 +39,7 @@ let add_load_dir = "<dir> Add the given directory to the search path for custom\
   "\t\tgenerators"
 let load_file = "<file.cm[o|a|xs]> Load file defining a new documentation generator"
 let werr = " Treat ocamldoc warnings as errors"
+let show_missed_crossref = " Show missed cross-reference opportunities"
 let hide_warnings = " do not print ocamldoc warnings"
 let target_dir = "<dir> Generate files in directory <dir>, rather than in current\n"^
   "\t\tdirectory (for man and HTML generators)"
@@ -322,6 +323,12 @@ let cross_value_not_found n = "Value "^n^" not found"
 let cross_type_not_found n = "Type "^n^" not found"
 let cross_recfield_not_found n = Printf.sprintf "Record field %s not found" n
 let cross_const_not_found n = Printf.sprintf "Constructor %s not found" n
+
+let code_could_be_cross_reference n parent =
+  Printf.sprintf "Code element [%s] in %s corresponds to a known \
+                  cross-referenceable element, it might be worthwhile to replace it \
+                  with {!%s}" n parent n
+
 
 let object_end = "object ... end"
 let struct_end = "struct ... end"

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -15,8 +15,8 @@
 
 (** Interface to the Unix system.
 
-    Note: all the functions of this module (except [error_message] and
-    [handle_unix_error]) are liable to raise the [Unix_error]
+    Note: all the functions of this module (except {!error_message} and
+    {!handle_unix_error}) are liable to raise the {!Unix_error}
     exception whenever the underlying system call signals an error. *)
 
 
@@ -112,7 +112,7 @@ val error_message : error -> string
 
 val handle_unix_error : ('a -> 'b) -> 'a -> 'b
 (** [handle_unix_error f x] applies [f] to [x] and returns the result.
-   If the exception [Unix_error] is raised, it prints a message
+   If the exception {!Unix_error} is raised, it prints a message
    describing the error and exits with code 2. *)
 
 
@@ -789,7 +789,7 @@ val lockf : file_descr -> lock_command -> int -> unit
 
 val kill : int -> int -> unit
 (** [kill pid sig] sends signal number [sig] to the process
-   with id [pid].  On Windows, only the [Sys.sigkill] signal
+   with id [pid].  On Windows, only the {!Sys.sigkill} signal
    is emulated. *)
 
 type sigprocmask_command =

--- a/parsing/ast_mapper.mli
+++ b/parsing/ast_mapper.mli
@@ -113,9 +113,9 @@ val tool_name: unit -> string
     calling it ["ocamlc"], ["ocamlopt"], ["ocamldoc"], ["ocamldep"],
     ["ocaml"], ...  Some global variables that reflect command-line
     options are automatically synchronized between the calling tool
-    and the ppx preprocessor: [Clflags.include_dirs],
-    [Config.load_path], [Clflags.open_modules], [Clflags.for_package],
-    [Clflags.debug]. *)
+    and the ppx preprocessor: {!Clflags.include_dirs},
+    {!Config.load_path}, {!Clflags.open_modules}, {!Clflags.for_package},
+    {!Clflags.debug}. *)
 
 
 val apply: source:string -> target:string -> mapper -> unit
@@ -127,7 +127,7 @@ val apply: source:string -> target:string -> mapper -> unit
 val run_main: (string list -> mapper) -> unit
 (** Entry point to call to implement a standalone -ppx rewriter from a
     mapper, parametrized by the command line arguments.  The current
-    unit name can be obtained from [Location.input_name].  This
+    unit name can be obtained from {!Location.input_name}.  This
     function implements proper error reporting for uncaught
     exceptions. *)
 

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -116,12 +116,12 @@ val parse_argv : ?current: int ref -> string array ->
   (key * spec * doc) list -> anon_fun -> usage_msg -> unit
 (** [Arg.parse_argv ~current args speclist anon_fun usage_msg] parses
   the array [args] as if it were the command line.  It uses and updates
-  the value of [~current] (if given), or [Arg.current].  You must set
+  the value of [~current] (if given), or {!Arg.current}.  You must set
   it before calling [parse_argv].  The initial value of [current]
   is the index of the program name (argument 0) in the array.
-  If an error occurs, [Arg.parse_argv] raises [Arg.Bad] with
+  If an error occurs, [Arg.parse_argv] raises {!Arg.Bad} with
   the error message as argument.  If option [-help] or [--help] is
-  given, [Arg.parse_argv] raises [Arg.Help] with the help message
+  given, [Arg.parse_argv] raises {!Arg.Help} with the help message
   as argument.
 *)
 
@@ -151,13 +151,13 @@ exception Help of string
 exception Bad of string
 (** Functions in [spec] or [anon_fun] can raise [Arg.Bad] with an error
     message to reject invalid arguments.
-    [Arg.Bad] is also raised by [Arg.parse_argv] in case of an error. *)
+    [Arg.Bad] is also raised by {!Arg.parse_argv} in case of an error. *)
 
 val usage : (key * spec * doc) list -> usage_msg -> unit
 (** [Arg.usage speclist usage_msg] prints to standard error
     an error message that includes the list of valid options.  This is
     the same message that {!Arg.parse} prints in case of error.
-    [speclist] and [usage_msg] are the same as for [Arg.parse]. *)
+    [speclist] and [usage_msg] are the same as for {!Arg.parse}. *)
 
 val usage_string : (key * spec * doc) list -> usage_msg -> string
 (** Returns the message that would have been printed by {!Arg.usage},

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -80,7 +80,7 @@ val make_matrix : int -> int -> 'a -> 'a array array
    with the notation [m.(x).(y)].
 
    Raise [Invalid_argument] if [dimx] or [dimy] is negative or
-   greater than [Sys.max_array_length].
+   greater than {!Sys.max_array_length}.
    If the value of [e] is a floating-point number, then the maximum
    size is only [Sys.max_array_length / 2]. *)
 
@@ -93,7 +93,7 @@ val append : 'a array -> 'a array -> 'a array
    concatenation of the arrays [v1] and [v2]. *)
 
 val concat : 'a array list -> 'a array
-(** Same as [Array.append], but concatenates a list of arrays. *)
+(** Same as {!Array.append}, but concatenates a list of arrays. *)
 
 val sub : 'a array -> int -> int -> 'a array
 (** [Array.sub a start len] returns a fresh array of length [len],

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -71,7 +71,7 @@ val make_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
    with the notation [m.(x).(y)].
 
    Raise [Invalid_argument] if [dimx] or [dimy] is negative or
-   greater than [Sys.max_array_length].
+   greater than {!Sys.max_array_length}.
    If the value of [e] is a floating-point number, then the maximum
    size is only [Sys.max_array_length / 2]. *)
 
@@ -85,7 +85,7 @@ val append : 'a array -> 'a array -> 'a array
    concatenation of the arrays [v1] and [v2]. *)
 
 val concat : 'a array list -> 'a array
-(** Same as [Array.append], but concatenates a list of arrays. *)
+(** Same as {!Array.append}, but concatenates a list of arrays. *)
 
 val sub : 'a array -> pos:int -> len:int -> 'a array
 (** [Array.sub a start len] returns a fresh array of length [len],

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -399,7 +399,7 @@ let bytes_length (s : bytes) =
 
    The caller may not mutate [s] while the string is borrowed (it has
    temporarily given up ownership). This affects concurrent programs,
-   but also higher-order functions: if [String.length] returned
+   but also higher-order functions: if {!String.length} returned
    a closure to be called later, [s] should not be mutated until this
    closure is fully applied and returns ownership.
 *)

--- a/stdlib/ephemeron.mli
+++ b/stdlib/ephemeron.mli
@@ -138,8 +138,8 @@ module K1 : sig
 
   val blit_key : ('k,_) t -> ('k,_) t -> unit
   (** [Ephemeron.K1.blit_key eph1 eph2] sets the key of [eph2] with
-      the key of [eph1]. Contrary to using [Ephemeron.K1.get_key]
-      followed by [Ephemeron.K1.set_key] or [Ephemeon.K1.unset_key]
+      the key of [eph1]. Contrary to using {!Ephemeron.K1.get_key}
+      followed by {!Ephemeron.K1.set_key} or {!Ephemeron.K1.unset_key}
       this function does not prevent the incremental GC from erasing
       the value in its current cycle. *)
 
@@ -172,8 +172,8 @@ module K1 : sig
 
   val blit_data : (_,'d) t -> (_,'d) t -> unit
   (** [Ephemeron.K1.blit_data eph1 eph2] sets the data of [eph2] with
-      the data of [eph1]. Contrary to using [Ephemeron.K1.get_data]
-      followed by [Ephemeron.K1.set_data] or [Ephemeon.K1.unset_data]
+      the data of [eph1]. Contrary to using {!Ephemeron.K1.get_data}
+      followed by {!Ephemeron.K1.set_data} or {!Ephemeron.K1.unset_data}
       this function does not prevent the incremental GC from erasing
       the value in its current cycle. *)
 

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -457,7 +457,7 @@ type formatter
   margin, maximum indentation limit, maximum number of boxes
   simultaneously opened, ellipsis, and so on, are specific to
   each pretty-printer and may be fixed independently.
-  Given a [Pervasives.out_channel] output channel [oc], a new formatter
+  Given a {!Pervasives.out_channel} output channel [oc], a new formatter
   writing to that channel is simply obtained by calling
   [formatter_of_out_channel oc].
   Alternatively, the [make_formatter] function allocates a new
@@ -500,7 +500,7 @@ val make_formatter :
   (string -> int -> int -> unit) -> (unit -> unit) -> formatter
 (** [make_formatter out flush] returns a new formatter that writes according
   to the output function [out], and the flushing function [flush]. For
-  instance, a formatter to the [Pervasives.out_channel] [oc] is returned by
+  instance, a formatter to the {!Pervasives.out_channel} [oc] is returned by
   [make_formatter (Pervasives.output oc) (fun () -> Pervasives.flush oc)]. *)
 
 (** {6 Basic functions to use with formatters} *)
@@ -604,7 +604,7 @@ val fprintf : formatter -> ('a, formatter, unit) format -> 'a
 
   The format [fmt] is a character string which contains three types of
   objects: plain characters and conversion specifications as specified in
-  the [Printf] module, and pretty-printing indications specific to the
+  the {!Printf} module, and pretty-printing indications specific to the
   [Format] module.
 
   The pretty-printing indication characters are introduced by

--- a/stdlib/genlex.mli
+++ b/stdlib/genlex.mli
@@ -67,7 +67,7 @@ val make_lexer : string list -> char Stream.t -> token Stream.t
    belongs to this list, and as [Ident s] otherwise.
    A special character [s] is returned as [Kwd s] if [s]
    belongs to this list, and cause a lexical error (exception
-   [Stream.Error] with the offending lexeme as its parameter) otherwise.
+   {!Stream.Error} with the offending lexeme as its parameter) otherwise.
    Blanks and newlines are skipped. Comments delimited by [(*] and [*)]
-   are skipped as well, and can be nested. A [Stream.Failure] exception
+   are skipped as well, and can be nested. A {!Stream.Failure} exception
    is raised if end of stream is unexpectedly reached.*)

--- a/stdlib/lazy.mli
+++ b/stdlib/lazy.mli
@@ -48,7 +48,7 @@ external force : 'a t -> 'a = "%lazy_force"
    If [x] has already been forced, [Lazy.force x] returns the
    same value again without recomputing it.  If it raised an exception,
    the same exception is raised again.
-   Raise [Undefined] if the forcing of [x] tries to force [x] itself
+   Raise {!Undefined} if the forcing of [x] tries to force [x] itself
    recursively.
 *)
 
@@ -56,10 +56,10 @@ val force_val : 'a t -> 'a
 (** [force_val x] forces the suspension [x] and returns its
     result.  If [x] has already been forced, [force_val x]
     returns the same value again without recomputing it.
-    Raise [Undefined] if the forcing of [x] tries to force [x] itself
+    Raise {!Undefined} if the forcing of [x] tries to force [x] itself
     recursively.
     If the computation of [x] raises an exception, it is unspecified
-    whether [force_val x] raises the same exception or [Undefined].
+    whether [force_val x] raises the same exception or {!Undefined}.
 *)
 
 val from_fun : (unit -> 'a) -> 'a t

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -50,7 +50,7 @@ external field : t -> int -> t = "%obj_field"
 
     For experts only:
     [set_field] et al can be made safe by first wrapping the block in
-    [Sys.opaque_identity], so any information about its contents will not
+    {!Sys.opaque_identity}, so any information about its contents will not
     be propagated.
 *)
 external set_field : t -> int -> t -> unit = "%obj_set_field"

--- a/stdlib/pervasives.mli
+++ b/stdlib/pervasives.mli
@@ -1078,12 +1078,12 @@ type ('a,'b) result = Ok of 'a | Error of 'b
 
     - ['b] is the type of input source for formatted input functions and the
       type of output target for formatted output functions.
-      For [printf]-style functions from module [Printf], ['b] is typically
+      For [printf]-style functions from module {!Printf}, ['b] is typically
       [out_channel];
-      for [printf]-style functions from module [Format], ['b] is typically
-      [Format.formatter];
-      for [scanf]-style functions from module [Scanf], ['b] is typically
-      [Scanf.Scanning.in_channel].
+      for [printf]-style functions from module {!Format}, ['b] is typically
+      {!Format.formatter};
+      for [scanf]-style functions from module {!Scanf}, ['b] is typically
+      {!Scanf.Scanning.in_channel}.
 
       Type argument ['b] is also the type of the first argument given to
       user's defined printing functions for [%a] and [%t] conversions,

--- a/stdlib/queue.mli
+++ b/stdlib/queue.mli
@@ -41,14 +41,14 @@ val push : 'a -> 'a t -> unit
 
 val take : 'a t -> 'a
 (** [take q] removes and returns the first element in queue [q],
-   or raises [Empty] if the queue is empty. *)
+   or raises {!Empty} if the queue is empty. *)
 
 val pop : 'a t -> 'a
 (** [pop] is a synonym for [take]. *)
 
 val peek : 'a t -> 'a
 (** [peek q] returns the first element in queue [q], without removing
-   it from the queue, or raises [Empty] if the queue is empty. *)
+   it from the queue, or raises {!Empty} if the queue is empty. *)
 
 val top : 'a t -> 'a
 (** [top] is a synonym for [peek]. *)

--- a/stdlib/random.mli
+++ b/stdlib/random.mli
@@ -66,7 +66,7 @@ val bool : unit -> bool
 
 (** {6 Advanced functions} *)
 
-(** The functions from module [State] manipulate the current state
+(** The functions from module {!State} manipulate the current state
     of the random generator explicitly.
     This allows using one or several deterministic PRNGs,
     even in a multi-threaded program, without interference from

--- a/stdlib/scanf.mli
+++ b/stdlib/scanf.mli
@@ -19,7 +19,7 @@
 
 (** {7 Functional input with format strings} *)
 
-(** The module [Scanf] provides formatted input functions or {e scanners}.
+(** The module {!Scanf} provides formatted input functions or {e scanners}.
 
     The formatted input functions can read from any kind of input, including
     strings, files, or anything that can return characters. The more general
@@ -86,12 +86,12 @@
 module Scanning : sig
 
 type in_channel
-(** The notion of input channel for the [Scanf] module:
+(** The notion of input channel for the {!Scanf} module:
    those channels provide all the machinery necessary to read from any source
-   of characters, including a [!Pervasives.in_channel] value.
-   A [Scanf.Scanning.in_channel] value is also called a {i formatted input
+   of characters, including a {!Pervasives.in_channel} value.
+   A Scanf.Scanning.in_channel value is also called a {i formatted input
    channel} or equivalently a {i scanning buffer}.
-   The type [Scanning.scanbuf] below is an alias for [Scanning.in_channel].
+   The type {!Scanning.scanbuf} below is an alias for [Scanning.in_channel].
    @since 3.12.0
 *)
 
@@ -108,12 +108,12 @@ type scanbuf = in_channel
 *)
 
 val stdin : in_channel
-(** The standard input notion for the [Scanf] module.
-    [Scanning.stdin] is the [Scanning.in_channel] formatted input channel
-    attached to [!Pervasives.stdin].
+(** The standard input notion for the {!Scanf} module.
+    [Scanning.stdin] is the {!Scanning.in_channel} formatted input channel
+    attached to {!Pervasives.stdin}.
 
     Note: in the interactive system, when input is read from
-    [!Pervasives.stdin], the newline character that triggers evaluation is
+    {!Pervasives.stdin}, the newline character that triggers evaluation is
     part of the input; thus, the scanning specifications must properly skip
     this additional newline character (for instance, simply add a ['\n'] as
     the last character of the format string).
@@ -126,7 +126,7 @@ type file_name = string
 *)
 
 val open_in : file_name -> in_channel
-(** [Scanning.open_in fname] returns a [!Scanning.in_channel] formatted input
+(** [Scanning.open_in fname] returns a {!Scanning.in_channel} formatted input
     channel for bufferized reading in text mode from file [fname].
 
     Note:
@@ -138,32 +138,32 @@ val open_in : file_name -> in_channel
 *)
 
 val open_in_bin : file_name -> in_channel
-(** [Scanning.open_in_bin fname] returns a [!Scanning.in_channel] formatted
+(** [Scanning.open_in_bin fname] returns a {!Scanning.in_channel} formatted
     input channel for bufferized reading in binary mode from file [fname].
     @since 3.12.0
 *)
 
 val close_in : in_channel -> unit
-(** Closes the [!Pervasives.in_channel] associated with the given
-  [!Scanning.in_channel] formatted input channel.
+(** Closes the {!Pervasives.in_channel} associated with the given
+  {!Scanning.in_channel} formatted input channel.
   @since 3.12.0
 *)
 
 val from_file : file_name -> in_channel
-(** An alias for [!Scanning.open_in] above. *)
+(** An alias for {!Scanning.open_in} above. *)
 
 val from_file_bin : string -> in_channel
-(** An alias for [!Scanning.open_in_bin] above. *)
+(** An alias for {!Scanning.open_in_bin} above. *)
 
 val from_string : string -> in_channel
-(** [Scanning.from_string s] returns a [!Scanning.in_channel] formatted
+(** [Scanning.from_string s] returns a {!Scanning.in_channel} formatted
     input channel which reads from the given string.
     Reading starts from the first character in the string.
     The end-of-input condition is set when the end of the string is reached.
 *)
 
 val from_function : (unit -> char) -> in_channel
-(** [Scanning.from_function f] returns a [!Scanning.in_channel] formatted
+(** [Scanning.from_function f] returns a {!Scanning.in_channel} formatted
     input channel with the given function as its reading method.
 
     When scanning needs one more character, the given function is called.
@@ -173,32 +173,32 @@ val from_function : (unit -> char) -> in_channel
 *)
 
 val from_channel : Pervasives.in_channel -> in_channel
-(** [Scanning.from_channel ic] returns a [!Scanning.in_channel] formatted
-    input channel which reads from the regular [!Pervasives.in_channel] input
+(** [Scanning.from_channel ic] returns a {!Scanning.in_channel} formatted
+    input channel which reads from the regular {!Pervasives.in_channel} input
     channel [ic] argument.
     Reading starts at current reading position of [ic].
 *)
 
 val end_of_input : in_channel -> bool
 (** [Scanning.end_of_input ic] tests the end-of-input condition of the given
-    [!Scanning.in_channel] formatted input channel.
+    {!Scanning.in_channel} formatted input channel.
 *)
 
 val beginning_of_input : in_channel -> bool
 (** [Scanning.beginning_of_input ic] tests the beginning of input condition
-    of the given [!Scanning.in_channel] formatted input channel.
+    of the given {!Scanning.in_channel} formatted input channel.
 *)
 
 val name_of_input : in_channel -> string
 (** [Scanning.name_of_input ic] returns the name of the character source
-    for the given [!Scanning.in_channel] formatted input channel.
+    for the given {!Scanning.in_channel} formatted input channel.
     @since 3.09.0
 *)
 
 val stdib : in_channel
   [@@ocaml.deprecated "Use Scanf.Scanning.stdin instead."]
-(** A deprecated alias for [!Scanning.stdin], the scanning buffer reading from
-    [!Pervasives.stdin].
+(** A deprecated alias for {!Scanning.stdin}, the scanning buffer reading from
+    {!Pervasives.stdin}.
 *)
 
 end
@@ -213,11 +213,11 @@ type ('a, 'b, 'c, 'd) scanner =
     precisely, if [scan] is some formatted input function, then [scan
     ic fmt f] applies [f] to all the arguments specified by format
     string [fmt], when [scan] has read those arguments from the
-    [!Scanning.in_channel] formatted input channel [ic].
+    {!Scanning.in_channel} formatted input channel [ic].
 
-    For instance, the [!Scanf.scanf] function below has type
+    For instance, the {!Scanf.scanf} function below has type
     [('a, 'b, 'c, 'd) scanner], since it is a formatted input function that
-    reads from [!Scanning.stdin]: [scanf fmt f] applies [f] to the arguments
+    reads from {!Scanning.stdin}: [scanf fmt f] applies [f] to the arguments
     specified by [fmt], reading those arguments from [!Pervasives.stdin] as
     expected.
 
@@ -240,7 +240,7 @@ exception Scan_failure of string
 val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
 
 (** [bscanf ic fmt r1 ... rN f] reads characters from the
-    [!Scanning.in_channel] formatted input channel [ic] and converts them to
+    {!Scanning.in_channel} formatted input channel [ic] and converts them to
     values according to format string [fmt].
     As a final step, receiver function [f] is applied to the values read and
     gives the result of the [bscanf] call.
@@ -410,7 +410,7 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
     - the [scanf] facility is not intended for heavy duty lexical
     analysis and parsing. If it appears not expressive enough for your
     needs, several alternative exists: regular expressions (module
-    [Str]), stream parsers, [ocamllex]-generated lexers,
+    {!Str}), stream parsers, [ocamllex]-generated lexers,
     [ocamlyacc]-generated parsers.
 *)
 
@@ -434,11 +434,11 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
     For instance, format ["%s@%%"] reads a string up to the next [%]
     character, and format ["%s@%@"] reads a string up to the next [@].
     - The scanning indications introduce slight differences in the syntax of
-    [Scanf] format strings, compared to those used for the [Printf]
+    {!Scanf} format strings, compared to those used for the {!Printf}
     module. However, the scanning indications are similar to those used in
-    the [Format] module; hence, when producing formatted text to be scanned
-    by [!Scanf.bscanf], it is wise to use printing functions from the
-    [Format] module (or, if you need to use functions from [Printf], banish
+    the {!Format} module; hence, when producing formatted text to be scanned
+    by {!Scanf.bscanf}, it is wise to use printing functions from the
+    {!Format} module (or, if you need to use functions from {!Printf}, banish
     or carefully double check the format strings that contain ['@']
     characters).
 *)
@@ -448,7 +448,7 @@ val bscanf : Scanning.in_channel -> ('a, 'b, 'c, 'd) scanner
 (** Scanners may raise the following exceptions when the input cannot be read
     according to the format string:
 
-    - Raise [Scanf.Scan_failure] if the input does not match the format.
+    - Raise {!Scanf.Scan_failure} if the input does not match the format.
 
     - Raise [Failure] if a conversion to a number is not possible.
 
@@ -471,7 +471,7 @@ val sscanf : string -> ('a, 'b, 'c, 'd) scanner
 
 val scanf : ('a, 'b, 'c, 'd) scanner
 (** Same as {!Scanf.bscanf}, but reads from the predefined formatted input
-    channel {!Scanf.Scanning.stdin} that is connected to [!Pervasives.stdin].
+    channel {!Scanf.Scanning.stdin} that is connected to {!Pervasives.stdin}.
 *)
 
 val kscanf :
@@ -498,7 +498,7 @@ val bscanf_format :
 (** [bscanf_format ic fmt f] reads a format string token from the formatted
     input channel [ic], according to the given format string [fmt], and
     applies [f] to the resulting format string value.
-    Raise [Scan_failure] if the format string value read does not have the
+    Raise {!Scan_failure} if the format string value read does not have the
     same type as [fmt].
     @since 3.09.0
 *)
@@ -515,7 +515,7 @@ val format_from_string :
     ('a, 'b, 'c, 'd, 'e, 'f) format6 -> ('a, 'b, 'c, 'd, 'e, 'f) format6
 (** [format_from_string s fmt] converts a string argument to a format string,
     according to the given format string [fmt].
-    Raise [Scan_failure] if [s], considered as a format string, does not
+    Raise {!Scan_failure} if [s], considered as a format string, does not
     have the same type as [fmt].
     @since 3.10.0
 *)
@@ -529,7 +529,7 @@ val unescaped : string -> string
 
     Always return a copy of the argument, even if there is no escape sequence
     in the argument.
-    Raise [Scan_failure] if [s] is not properly escaped (i.e. [s] has invalid
+    Raise {!Scan_failure} if [s] is not properly escaped (i.e. [s] has invalid
     escape sequences or special characters that are not properly escaped).
     For instance, [String.unescaped "\""] will fail.
     @since 4.00.0
@@ -541,15 +541,15 @@ val fscanf : Pervasives.in_channel -> ('a, 'b, 'c, 'd) scanner
   [@@ocaml.deprecated "Use Scanning.from_channel then Scanf.bscanf."]
 (** @deprecated [Scanf.fscanf] is error prone and deprecated since 4.03.0.
 
-    This function violates the following invariant of the [Scanf] module:
-    To preserve scanning semantics, all scanning functions defined in [Scanf]
-    must read from a user defined [Scanning.in_channel] formatted input
+    This function violates the following invariant of the {!Scanf} module:
+    To preserve scanning semantics, all scanning functions defined in {!Scanf}
+    must read from a user defined {!Scanning.in_channel} formatted input
     channel.
 
-    If you need to read from a [!Pervasives.in_channel] input channel
-    [ic], simply define a [!Scanning.in_channel] formatted input channel as in
+    If you need to read from a {!Pervasives.in_channel} input channel
+    [ic], simply define a {!Scanning.in_channel} formatted input channel as in
     [let ib = Scanning.from_channel ic],
-    then use [!Scanf.bscanf ib] as usual.
+    then use [Scanf.bscanf ib] as usual.
 *)
 
 val kfscanf :

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -22,7 +22,7 @@
    reasonably efficient: insertion and membership take time
    logarithmic in the size of the set, for instance.
 
-   The [Make] functor constructs implementations for any type, given a
+   The {!Make} functor constructs implementations for any type, given a
    [compare] function.
    For instance:
    {[

--- a/stdlib/spacetime.mli
+++ b/stdlib/spacetime.mli
@@ -62,7 +62,7 @@ module Series : sig
   (** [save_event] writes an event, which is an arbitrary string, into the
       given series file.  This may be used for identifying particular points
       during program execution when analysing the profile.
-      The optional [time] parameter is as for [Snapshot.take].
+      The optional [time] parameter is as for {!Snapshot.take}.
   *)
   val save_event : ?time:float -> t -> event_name:string -> unit
 
@@ -70,7 +70,7 @@ module Series : sig
       interpeting the snapshots that [series] contains and then closes the
       [series] file. This function must be called to produce a valid series
       file.
-      The optional [time] parameter is as for [Snapshot.take].
+      The optional [time] parameter is as for {!Snapshot.take}.
   *)
   val save_and_close : ?time:float -> t -> unit
 end
@@ -81,7 +81,7 @@ module Snapshot : sig
       result to the [series] file.  This function triggers a minor GC but does
       not allocate any memory itself.
       If the optional [time] is specified, it will be used instead of the
-      result of [Sys.time] as the timestamp of the snapshot.  Such [time]s
+      result of {!Sys.time} as the timestamp of the snapshot.  Such [time]s
       should start from zero and be monotonically increasing.  This parameter
       is intended to be used so that snapshots can be correlated against wall
       clock time (which is not supported in the standard library) rather than
@@ -90,6 +90,6 @@ module Snapshot : sig
   val take : ?time:float -> Series.t -> unit
 end
 
-(** Like [Series.save_event], but writes to the automatic snapshot file.
+(** Like {!Series.save_event}, but writes to the automatic snapshot file.
     This function is a no-op if OCAML_SPACETIME_INTERVAL was not set. *)
 val save_event_for_automatic_snapshots : event_name:string -> unit

--- a/stdlib/stack.mli
+++ b/stdlib/stack.mli
@@ -33,11 +33,11 @@ val push : 'a -> 'a t -> unit
 
 val pop : 'a t -> 'a
 (** [pop s] removes and returns the topmost element in stack [s],
-   or raises [Empty] if the stack is empty. *)
+   or raises {!Empty} if the stack is empty. *)
 
 val top : 'a t -> 'a
 (** [top s] returns the topmost element in stack [s],
-   or raises [Empty] if the stack is empty. *)
+   or raises {!Empty} if the stack is empty. *)
 
 val clear : 'a t -> unit
 (** Discard all elements from a stack. *)

--- a/stdlib/stream.mli
+++ b/stdlib/stream.mli
@@ -67,10 +67,10 @@ val iter : ('a -> unit) -> 'a t -> unit
 
 val next : 'a t -> 'a
 (** Return the first element of the stream and remove it from the
-   stream. Raise Stream.Failure if the stream is empty. *)
+   stream. Raise {!Stream.Failure} if the stream is empty. *)
 
 val empty : 'a t -> unit
-(** Return [()] if the stream is empty, else raise [Stream.Failure]. *)
+(** Return [()] if the stream is empty, else raise {!Stream.Failure}. *)
 
 
 (** {6 Useful functions} *)

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -322,7 +322,7 @@ exception HookExnWrapper of
 
 val raise_direct_hook_exn: exn -> 'a
   (** A hook can use [raise_unwrapped_hook_exn] to raise an exception that will
-      not be wrapped into a [HookExnWrapper]. *)
+      not be wrapped into a {!HookExnWrapper}. *)
 
 module type HookSig = sig
   type t

--- a/utils/numbers.mli
+++ b/utils/numbers.mli
@@ -14,7 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Modules about numbers that satisfy [Identifiable.S]. *)
+(** Modules about numbers that satisfy {!Identifiable.S}. *)
 
 module Int : sig
   include Identifiable.S with type t = int


### PR DESCRIPTION
Following a discussion with @dra27 in #1016, this PR proposes to add an option to ocamldoc to identify missed cross-reference  opportunities. 

More precisely, with the `-warn-missed-cross` option enabled, code fragments of the form `[path]` that correspond to a known element and could therefore be replaced by `{!path}` trigger a warning.

To decrease the false positive rate, the current patch does not trigger the warning if:
* the identifier is the same as the parent of the current element, e.g
```OCaml
val f: unit -> unit
(** [f] does not trigger the missed cross-reference warning *) 
```
* the path of the identifier is a suffix of the path of the parent element,
```OCaml
val f: unit -> unit
(** [Grand_parent.Parent.f] also does not trigger the missed cross-reference warning *) 
```

The second commit in this PR replaces few occurences of this warning by cross-references.
Note that even with the implemented heuristic, the warning is unfortunately too noisy to be activated by default.

