### PR TITLE
MPR#7373: fix ocamlmklib when FlexDLL bootstrapped

### DIFF
--- a/Changes
+++ b/Changes
@@ -17,6 +17,13 @@ Next minor version (4.04.1):
 - PR#7369: Str.regexp raises "Invalid_argument: index out of bounds"
   (Damien Doligez, report by John Whitington)
 
+- PR#7373, GPR#1023: Fix ocamlmklib with bootstrapped FlexDLL. Bootstrapped
+  FlexDLL objects are now installed to a subdirectory flexdll of the Standard
+  Library which allows the compilers to pick them up explicitly and also
+  ocamlmklib to include them without unnecessarily adding the entire Standard
+  Library.
+  (David Allsopp)
+
 - PR#7385, GPR#1057: fix incorrect timestamps returned by Unix.stat on Windows
   when either TZ is set or system date is in DST.
   (David Allsopp, report and initial fix by Nicolás Ojeda Bär, review and

--- a/Changes
+++ b/Changes
@@ -12,6 +12,12 @@ Next minor version (4.04.1):
   with constructors without arguments.
   (Florian Angeletti, report by Xavier Leroy)
 
+### Build system:
+- PR#7373, GPR#1023: New flexlink target in Makefile.nt to bootstrap the
+  flexlink binary only, rather than the flexlink binary and the FlexDLL C
+  objects.
+  (David Allsopp)
+
 ### Bug fixes
 
 - PR#7369: Str.regexp raises "Invalid_argument: index out of bounds"

--- a/Makefile
+++ b/Makefile
@@ -438,6 +438,7 @@ utils/config.ml: utils/config.mlp config/Makefile
 	    -e 's|%%TARGET%%|$(TARGET)|' \
 	    -e 's|%%FLAMBDA%%|$(FLAMBDA)|' \
 	    -e 's|%%SAFE_STRING%%|$(SAFE_STRING)|' \
+	    -e 's|%%FLEXDLL_DIR%%||' \
 	    utils/config.mlp > utils/config.ml
 
 partialclean::

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -24,9 +24,11 @@ defaultentry:
 FLEXDLL_SUBMODULE_PRESENT:=$(wildcard flexdll/Makefile)
 ifeq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
   BOOT_FLEXLINK_CMD=
+  FLEXDLL_DIR=
 else
   BOOT_FLEXLINK_CMD=FLEXLINK_CMD="../boot/ocamlrun ../flexdll/flexlink.exe"
   CAMLOPT:=OCAML_FLEXLINK="boot/ocamlrun flexdll/flexlink.exe" $(CAMLOPT)
+  FLEXDLL_DIR="+flexdll"
 endif
 
 # FlexDLL sources missing error messages
@@ -198,6 +200,7 @@ INSTALL_COMPLIBDIR=$(DESTDIR)$(COMPLIBDIR)
 INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 INSTALL_MANDIR=$(DESTDIR)$(MANDIR)
 INSTALL_DISTRIB=$(DESTDIR)$(PREFIX)
+INSTALL_FLEXDLL=$(INSTALL_LIBDIR)/flexdll
 
 install: installbyt installopt
 
@@ -255,7 +258,8 @@ install-flexdll:
 	   $(if $(filter-out mingw,$(TOOLCHAIN)),\
 	     flexdll/default$(filter-out _i386,_$(ARCH)).manifest) \
 	   "$(INSTALL_BINDIR)/"
-	cp flexdll/flexdll_*.$(O) "$(INSTALL_LIBDIR)"
+	mkdir -p "$(INSTALL_FLEXDLL)"
+	cp flexdll/flexdll_*.$(O) "$(INSTALL_FLEXDLL)"
 
 # Installation of the native-code compiler
 installopt:
@@ -422,6 +426,7 @@ utils/config.ml: utils/config.mlp config/Makefile
 	    -e 's|%%FLAMBDA%%|$(FLAMBDA)|' \
 	    -e 's|%%SAFE_STRING%%|$(SAFE_STRING)|' \
 	    -e 's|%%FLEXLINK_FLAGS%%|$(subst \,\\,$(FLEXLINK_FLAGS))|' \
+	    -e 's|%%FLEXDLL_DIR%%|$(FLEXDLL_DIR)|' \
 	    utils/config.mlp > utils/config.ml
 
 partialclean::

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -413,15 +413,15 @@ utils/config.ml: utils/config.mlp config/Makefile
 	    -e 's|%%PROFINFO_WIDTH%%|$(PROFINFO_WIDTH)|' \
 	    -e 's|%%LIBUNWIND_AVAILABLE%%|false|' \
 	    -e 's|%%LIBUNWIND_LINK_FLAGS%%||' \
-	    -e 's|%%MKDLL%%|$(MKDLL)|' \
-	    -e 's|%%MKEXE%%|$(MKEXE)|' \
-	    -e 's|%%MKMAINDLL%%|$(MKMAINDLL)|' \
+	    -e 's|%%MKDLL%%|$(subst \,\\,$(MKDLL))|' \
+	    -e 's|%%MKEXE%%|$(subst \,\\,$(MKEXE))|' \
+	    -e 's|%%MKMAINDLL%%|$(subst \,\\,$(MKMAINDLL))|' \
 	    -e 's|%%CC_PROFILE%%||' \
 	    -e 's|%%HOST%%|$(HOST)|' \
 	    -e 's|%%TARGET%%|$(TARGET)|' \
 	    -e 's|%%FLAMBDA%%|$(FLAMBDA)|' \
 	    -e 's|%%SAFE_STRING%%|$(SAFE_STRING)|' \
-	    -e 's|%%FLEXLINK_FLAGS%%|$(FLEXLINK_FLAGS)|' \
+	    -e 's|%%FLEXLINK_FLAGS%%|$(subst \,\\,$(FLEXLINK_FLAGS))|' \
 	    utils/config.mlp > utils/config.ml
 
 partialclean::

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -192,8 +192,7 @@ opt:
 # Native-code versions of the tools
 # If the submodule is initialised, then opt.opt will build a native flexlink
 opt.opt: core opt-core ocamlc.opt all ocamlopt.opt ocamllex.opt \
-         ocamltoolsopt ocamltoolsopt.opt otherlibrariesopt $(OCAMLDOC_OPT) \
-         $(if $(wildcard flexdll/Makefile),flexlink.opt)
+         ocamltoolsopt ocamltoolsopt.opt otherlibrariesopt $(OCAMLDOC_OPT)
 
 # Complete build using fast compilers
 world.opt: coldstart opt.opt

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -28,7 +28,11 @@ ifeq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
 else
   BOOT_FLEXLINK_CMD=FLEXLINK_CMD="../boot/ocamlrun ../flexdll/flexlink.exe"
   CAMLOPT:=OCAML_FLEXLINK="boot/ocamlrun flexdll/flexlink.exe" $(CAMLOPT)
-  FLEXDLL_DIR="+flexdll"
+  ifeq "$(wildcard flexdll/flexdll_*.$(O))$(filter flexdll,$(MAKECMDGOALS))" ""
+    FLEXDLL_DIR=
+  else
+    FLEXDLL_DIR="+flexdll"
+  endif
 endif
 
 # FlexDLL sources missing error messages
@@ -49,8 +53,12 @@ flexdll/Makefile:
 	fi
 	@false
 
-# Bootstrapping FlexDLL - leaves a bytecode image of flexlink.exe in flexdll/
-flexdll: flexdll/Makefile
+flexdll: flexdll/Makefile flexlink
+	$(MAKECMD) -C flexdll MSVC_DETECT=0 CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false \
+             support
+
+# Bootstrapping flexlink - leaves a bytecode image of flexlink.exe in flexdll/
+flexlink: flexdll/Makefile
 	cd byterun && $(MAKEREC) BOOTSTRAPPING_FLEXLINK=yes ocamlrun$(EXE)
 	cp byterun/ocamlrun.exe boot/ocamlrun.exe
 	cd stdlib && $(MAKEREC) COMPILER=../boot/ocamlc stdlib.cma std_exit.cmo
@@ -59,7 +67,7 @@ flexdll: flexdll/Makefile
 	 $(MAKECMD) MSVC_DETECT=0 TOOLCHAIN=$(TOOLCHAIN) TOOLPREF=$(TOOLPREF) \
 	            CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false \
 	            OCAMLOPT="../boot/ocamlrun ../boot/ocamlc -I ../boot" \
-	            flexlink.exe support
+	            flexlink.exe
 	cd byterun && $(MAKEREC) clean
 	$(MAKEREC) partialclean
 
@@ -258,8 +266,10 @@ install-flexdll:
 	   $(if $(filter-out mingw,$(TOOLCHAIN)),\
 	     flexdll/default$(filter-out _i386,_$(ARCH)).manifest) \
 	   "$(INSTALL_BINDIR)/"
-	mkdir -p "$(INSTALL_FLEXDLL)"
-	cp flexdll/flexdll_*.$(O) "$(INSTALL_FLEXDLL)"
+	if test -n "$(wildcard flexdll/flexdll_*.$(O))" ; then \
+	  mkdir -p "$(INSTALL_FLEXDLL)" ; \
+	  cp flexdll/flexdll_*.$(O) "$(INSTALL_FLEXDLL)" ; \
+	fi
 
 # Installation of the native-code compiler
 installopt:

--- a/Makefile.nt
+++ b/Makefile.nt
@@ -258,13 +258,10 @@ installbyt:
 	fi
 
 install-flexdll:
-# The $(if ...) installs the correct .manifest file for MSVC and MSVC64
-# (GNU make doesn't have ifeq as a function, hence slightly convoluted use of
-#  filter-out)
-	cp flexdll/flexlink.exe \
-	   $(if $(filter-out mingw,$(TOOLCHAIN)),\
-	     flexdll/default$(filter-out _i386,_$(ARCH)).manifest) \
-	   "$(INSTALL_BINDIR)/"
+	cat stdlib/camlheader flexdll/flexlink.exe > "$(INSTALL_BINDIR)/flexlink.exe"
+ifneq "$(filter-out mingw,$(TOOLCHAIN))" ""
+	cp flexdll/default$(filter-out _i386,_$(ARCH)).manifest "$(INSTALL_BINDIR)/"
+endif
 	if test -n "$(wildcard flexdll/flexdll_*.$(O))" ; then \
 	  mkdir -p "$(INSTALL_FLEXDLL)" ; \
 	  cp flexdll/flexdll_*.$(O) "$(INSTALL_FLEXDLL)" ; \

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -29,7 +29,9 @@ let init_path ?(dir="") native =
     else
       !Clflags.include_dirs
   in
-  let dirs = !last_include_dirs @ dirs @ !first_include_dirs in
+  let dirs =
+    !last_include_dirs @ dirs @ Config.flexdll_dirs @ !first_include_dirs
+  in
   let exp_dirs =
     List.map (Misc.expand_directory Config.standard_library) dirs in
   Config.load_path := dir ::

--- a/tools/Makefile.shared
+++ b/tools/Makefile.shared
@@ -147,7 +147,7 @@ installopt::
 
 # To help building mixed-mode libraries (OCaml + C)
 
-$(call byte_and_opt,ocamlmklib,ocamlmklibconfig.cmo config.cmo \
+$(call byte_and_opt,ocamlmklib,ocamlmklibconfig.cmo config.cmo misc.cmo \
 	         ocamlmklib.cmo,)
 
 

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -242,11 +242,27 @@ let transl_path s =
         in Bytes.to_string (aux 0)
     | _ -> s
 
+let flexdll_dirs =
+  let dirs =
+    let expand = Misc.expand_directory Config.standard_library in
+    List.map expand Config.flexdll_dirs
+  in
+  let f dir =
+    let dir =
+      if String.contains dir ' ' then
+        "\"" ^ dir ^ "\""
+      else
+        dir
+    in
+      "-L" ^ dir
+  in
+  List.map f dirs
+
 let build_libs () =
   if !c_objs <> [] then begin
     if !dynlink then begin
       let retcode = command
-          (Printf.sprintf "%s %s -o %s %s %s %s %s %s"
+          (Printf.sprintf "%s %s -o %s %s %s %s %s %s %s"
              Config.mkdll
              (if !debug then "-g" else "")
              (prepostfix "dll" !output_c Config.ext_dll)
@@ -255,6 +271,7 @@ let build_libs () =
              (String.concat " " !ld_opts)
              (make_rpath mksharedlibrpath)
              (String.concat " " !c_libs)
+             (String.concat " " flexdll_dirs)
           )
       in
       if retcode <> 0 then if !failsafe then dynlink := false else exit 2

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -128,6 +128,9 @@ val default_executable_name: string
 val systhread_supported : bool
         (* Whether the system thread library is implemented *)
 
+val flexdll_dirs : string list
+        (* Directories needed for the FlexDLL objects *)
+
 val host : string
         (* Whether the compiler is a cross-compiler *)
 

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -131,6 +131,8 @@ let default_executable_name =
 
 let systhread_supported = %%SYSTHREAD_SUPPORT%%;;
 
+let flexdll_dirs = [%%FLEXDLL_DIR%%];;
+
 let print_config oc =
   let p name valu = Printf.fprintf oc "%s: %s\n" name valu in
   let p_bool name valu = Printf.fprintf oc "%s: %B\n" name valu in


### PR DESCRIPTION
Discussion in the [Mantis ticket](https://caml.inria.fr/mantis/view.php?id=7373).

The original problem is that when FlexDLL is bootstrapped, the runtime object files were installed to OCaml's lib directory which is fine for the compilers because, unless compiling with `-nostdlib`, these are always included. It doesn't work for ocamlmklib which doesn't include this directory by default. The effect was that ocamlmklib couldn't compile DLLs.

Rather than having ocamlmklib add the whole stdlib directory, this fix installs the FlexDLL object files to the `flexdll` subdirectory of lib. The compiler drivers automatically add `-I +flexdll` (always - so this indirectly improves the `-nostdlib` case as well) in a manner similar to how `+threads` and `+vmthreads` are added. ocamlmklib also adds an option along the lines of `-L+flexdll`, allowing DLLs to be compiled.

As a tacked on bonus, the `flexdll` bootstrapping target is also split into two so it's now possible to put pre-compiled FlexDLL object files separately (and add the appropriate -L{path} to `FLEXLINK_FLAGS`) but bootstrap just the flexlink executable as part of the build process.