### PR TITLE
Define Map.update.

### DIFF
--- a/Changes
+++ b/Changes
@@ -83,6 +83,11 @@ Next version (4.05.0):
 
 ### Standard library:
 
+- PR#7309, GPR#1026: Add update to maps. Allows to update a binding in
+  a map or create a new binding if the key had no binding.
+  (Sébastien Briais, review by Daniel Buenzli, Alain Frisch and
+   Gabriel Scherer)
+
 - PR#6975, GPR#902: Truncate function added to stdlib Buffer module
   (Dhruv Makwana, review by Alain Frisch and Gabriel Scherer)
 

--- a/lex/lexgen.ml
+++ b/lex/lexgen.ml
@@ -684,13 +684,10 @@ let env_to_class m =
   let env1 =
     MemMap.fold
       (fun _ (tag,s) r ->
-        try
-          let ss = TagMap.find tag r in
-          let r = TagMap.remove tag r in
-          TagMap.add tag (StateSetSet.add s ss) r
-        with
-        | Not_found ->
-            TagMap.add tag (StateSetSet.add s StateSetSet.empty) r)
+         TagMap.update tag (function
+             | None -> StateSetSet.singleton s
+             | Some ss -> StateSetSet.add s ss
+           ) r)
       m TagMap.empty in
   TagMap.fold
     (fun tag ss r -> MemKey.add {tag=tag ; equiv=ss} r)
@@ -701,14 +698,12 @@ let env_to_class m =
 let inverse_mem_map trans m r =
   TagMap.fold
     (fun tag addr r ->
-      try
-        let otag,s = MemMap.find addr r in
-        assert (tag = otag) ;
-        let r = MemMap.remove addr r in
-        MemMap.add addr (tag,StateSet.add trans s) r
-      with
-      | Not_found ->
-          MemMap.add addr (tag,StateSet.add trans StateSet.empty) r)
+       MemMap.update addr (function
+           | None -> tag, StateSet.singleton trans
+           | Some (otag, s) ->
+               assert (tag = otag);
+               (tag, StateSet.add trans s)
+         ) r)
     m r
 
 let inverse_mem_map_other n (_,m) r = inverse_mem_map (OnChars n) m r

--- a/lex/lexgen.ml
+++ b/lex/lexgen.ml
@@ -685,8 +685,8 @@ let env_to_class m =
     MemMap.fold
       (fun _ (tag,s) r ->
          TagMap.update tag (function
-             | None -> StateSetSet.singleton s
-             | Some ss -> StateSetSet.add s ss
+             | None -> Some (StateSetSet.singleton s)
+             | Some ss -> Some (StateSetSet.add s ss)
            ) r)
       m TagMap.empty in
   TagMap.fold
@@ -699,10 +699,10 @@ let inverse_mem_map trans m r =
   TagMap.fold
     (fun tag addr r ->
        MemMap.update addr (function
-           | None -> tag, StateSet.singleton trans
+           | None -> Some (tag, StateSet.singleton trans)
            | Some (otag, s) ->
                assert (tag = otag);
-               (tag, StateSet.add trans s)
+               Some (tag, StateSet.add trans s)
          ) r)
     m r
 

--- a/stdlib/map.ml
+++ b/stdlib/map.ml
@@ -27,6 +27,7 @@ module type S =
     val is_empty: 'a t -> bool
     val mem:  key -> 'a t -> bool
     val add: key -> 'a -> 'a t -> 'a t
+    val update: key -> ('a option -> 'a) -> 'a t -> 'a t
     val singleton: key -> 'a -> 'a t
     val remove: key -> 'a t -> 'a t
     val merge:
@@ -123,6 +124,21 @@ module Make(Ord: OrderedType) = struct
             if l == ll then m else bal ll v d r
           else
             let rr = add x data r in
+            if r == rr then m else bal l v d rr
+
+    let rec update x f = function
+        Empty ->
+          Node(Empty, x, f None, Empty, 1)
+      | Node(l, v, d, r, h) as m ->
+          let c = Ord.compare x v in
+          if c = 0 then
+            let data = f (Some d) in
+            if d == data then m else Node(l, x, data, r, h)
+          else if c < 0 then
+            let ll = update x f l in
+            if l == ll then m else bal ll v d r
+          else
+            let rr = update x f r in
             if r == rr then m else bal l v d rr
 
     let rec find x = function

--- a/stdlib/map.ml
+++ b/stdlib/map.ml
@@ -27,7 +27,7 @@ module type S =
     val is_empty: 'a t -> bool
     val mem:  key -> 'a t -> bool
     val add: key -> 'a -> 'a t -> 'a t
-    val update: key -> ('a option -> 'a) -> 'a t -> 'a t
+    val update: key -> ('a option -> 'a option) -> 'a t -> 'a t
     val singleton: key -> 'a -> 'a t
     val remove: key -> 'a t -> 'a t
     val merge:
@@ -124,21 +124,6 @@ module Make(Ord: OrderedType) = struct
             if l == ll then m else bal ll v d r
           else
             let rr = add x data r in
-            if r == rr then m else bal l v d rr
-
-    let rec update x f = function
-        Empty ->
-          Node(Empty, x, f None, Empty, 1)
-      | Node(l, v, d, r, h) as m ->
-          let c = Ord.compare x v in
-          if c = 0 then
-            let data = f (Some d) in
-            if d == data then m else Node(l, x, data, r, h)
-          else if c < 0 then
-            let ll = update x f l in
-            if l == ll then m else bal ll v d r
-          else
-            let rr = update x f r in
             if r == rr then m else bal l v d rr
 
     let rec find x = function
@@ -279,6 +264,26 @@ module Make(Ord: OrderedType) = struct
             let ll = remove x l in if l == ll then t else bal ll v d r
           else
             let rr = remove x r in if r == rr then t else bal l v d rr
+
+    let rec update x f = function
+        Empty ->
+          begin match f None with
+          | None -> Empty
+          | Some data -> Node(Empty, x, data, Empty, 1)
+          end
+      | Node(l, v, d, r, h) as m ->
+          let c = Ord.compare x v in
+          if c = 0 then begin
+            match f (Some d) with
+            | None -> merge l r
+            | Some data ->
+                if d == data then m else Node(l, x, data, r, h)
+          end else if c < 0 then
+            let ll = update x f l in
+            if l == ll then m else bal ll v d r
+          else
+            let rr = update x f r in
+            if r == rr then m else bal l v d rr
 
     let rec iter f = function
         Empty -> ()

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -86,6 +86,15 @@ module type S =
        of [x] in [m] disappears.
        @before 4.03 Physical equality was not ensured. *)
 
+    val update: key -> ('a option -> 'a) -> 'a t -> 'a t
+    (** [update x f m] returns a map containing the same bindings as
+        [m], plus a binding of [x] to [f z] where [z] is equal to
+        [find_opt x m].  If [x] was already bound in [m] to a value
+        that is physically equal to [f z], [m] is returned unchanged
+        (the result of the function is then physically equal to
+        [m]). Otherwise, the previous binding of [x] in [m]
+        disappears.  *)
+
     val singleton: key -> 'a -> 'a t
     (** [singleton x y] returns the one-element map that contains a binding [y]
         for [x].

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -86,14 +86,16 @@ module type S =
        of [x] in [m] disappears.
        @before 4.03 Physical equality was not ensured. *)
 
-    val update: key -> ('a option -> 'a) -> 'a t -> 'a t
+    val update: key -> ('a option -> 'a option) -> 'a t -> 'a t
     (** [update x f m] returns a map containing the same bindings as
-        [m], plus a binding of [x] to [f z] where [z] is equal to
-        [find_opt x m].  If [x] was already bound in [m] to a value
-        that is physically equal to [f z], [m] is returned unchanged
-        (the result of the function is then physically equal to
-        [m]). Otherwise, the previous binding of [x] in [m]
-        disappears.  *)
+        [m], except for the binding of [x]. Depending on the value of
+        [y] where [y] is [f (find_opt x m)], the binding of [x] is
+        added, removed or updated. If [y] is [None], the binding is
+        removed if it exists; otherwise, if [y] is [Some z] then [x]
+        is associated to [z] in the resulting map.  If [x] was already
+        bound in [m] to a value that is physically equal to [z], [m]
+        is returned unchanged (the result of the function is then
+        physically equal to [m]).  *)
 
     val singleton: key -> 'a -> 'a t
     (** [singleton x y] returns the one-element map that contains a binding [y]

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -115,6 +115,7 @@ module Map : sig
       val is_empty: 'a t -> bool
       val mem : key -> 'a t -> bool
       val add : key:key -> data:'a -> 'a t -> 'a t
+      val update: key:key -> f:('a option -> 'a) -> 'a t -> 'a t
       val singleton: key -> 'a -> 'a t
       val remove : key -> 'a t -> 'a t
       val merge:

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -115,7 +115,7 @@ module Map : sig
       val is_empty: 'a t -> bool
       val mem : key -> 'a t -> bool
       val add : key:key -> data:'a -> 'a t -> 'a t
-      val update: key:key -> f:('a option -> 'a) -> 'a t -> 'a t
+      val update: key:key -> f:('a option -> 'a option) -> 'a t -> 'a t
       val singleton: key -> 'a -> 'a t
       val remove : key -> 'a t -> 'a t
       val merge:

--- a/testsuite/tests/basic/maps.ml
+++ b/testsuite/tests/basic/maps.ml
@@ -27,5 +27,45 @@ let () =
   print_endline "Union+concat (with Map.union)";
   let f3 _ l r = if l = r then None else Some (l ^ r) in
   show (IntMap.union f3 m1 m2);
-
   ()
+
+let show m = IntMap.iter (fun k v -> Printf.printf "%d -> %d\n" k v) m
+
+let update x f m =
+  let yp = IntMap.find_opt x m in
+  let y = f yp in
+  match yp, y with
+  | _, None -> IntMap.remove x m
+  | None, Some z -> IntMap.add x z m
+  | Some zp, Some z -> if zp == z then m else IntMap.add x z m
+
+let () =
+  print_endline "Update";
+  let rec init m  = function
+    | -1 -> m
+    | n -> init (IntMap.add n n m) (n - 1)
+  in
+  let n = 9 in
+  let m = init IntMap.empty n in
+  for i = 0 to n + 1 do
+    for j = 0 to n + 1 do
+      List.iter (function (k, f) ->
+          let m1 = update i f m in
+          let m2 = IntMap.update i f m in
+          if not (IntMap.equal ( = ) m1 m2 && ((m1 == m) = (m2 == m))) then begin
+            Printf.printf "ERROR: %s: %d -> %d\n" k i j;
+            print_endline "expected result:";
+            show m1;
+            print_endline "result:";
+            show m2;
+          end
+        )
+      [
+        "replace",                          (function None -> None   | Some _ -> Some j);
+        "delete if exists, bind otherwise", (function None -> Some j | Some _ -> None);
+        "delete",                           (function None -> None   | Some _ -> None);
+        "insert",                           (function None -> Some j | Some _ -> Some j);
+      ]
+    done;
+  done;
+;;

--- a/testsuite/tests/basic/maps.reference
+++ b/testsuite/tests/basic/maps.reference
@@ -8,3 +8,4 @@ Union+concat (with Map.union)
 0 AB
 3 X1
 5 X2
+Update

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml.reference
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml.reference
@@ -82,7 +82,7 @@ module type MapT =
     val is_empty : 'a t -> bool
     val mem : key -> 'a t -> bool
     val add : key -> 'a -> 'a t -> 'a t
-    val update : key -> ('a option -> 'a) -> 'a t -> 'a t
+    val update : key -> ('a option -> 'a option) -> 'a t -> 'a t
     val singleton : key -> 'a -> 'a t
     val remove : key -> 'a t -> 'a t
     val merge :
@@ -129,7 +129,7 @@ module SSMap :
     val is_empty : 'a t -> bool
     val mem : key -> 'a t -> bool
     val add : key -> 'a -> 'a t -> 'a t
-    val update : key -> ('a option -> 'a) -> 'a t -> 'a t
+    val update : key -> ('a option -> 'a option) -> 'a t -> 'a t
     val singleton : key -> 'a -> 'a t
     val remove : key -> 'a t -> 'a t
     val merge :

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml.reference
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml.reference
@@ -82,6 +82,7 @@ module type MapT =
     val is_empty : 'a t -> bool
     val mem : key -> 'a t -> bool
     val add : key -> 'a -> 'a t -> 'a t
+    val update : key -> ('a option -> 'a) -> 'a t -> 'a t
     val singleton : key -> 'a -> 'a t
     val remove : key -> 'a t -> 'a t
     val merge :
@@ -128,6 +129,7 @@ module SSMap :
     val is_empty : 'a t -> bool
     val mem : key -> 'a t -> bool
     val add : key -> 'a -> 'a t -> 'a t
+    val update : key -> ('a option -> 'a) -> 'a t -> 'a t
     val singleton : key -> 'a -> 'a t
     val remove : key -> 'a t -> 'a t
     val merge :

--- a/testsuite/tests/typing-short-paths/short-paths.ml.reference
+++ b/testsuite/tests/typing-short-paths/short-paths.ml.reference
@@ -20,7 +20,7 @@
             val is_empty : 'a t -> bool
             val mem : key -> 'a t -> bool
             val add : key -> 'a -> 'a t -> 'a t
-            val update : key -> ('a option -> 'a) -> 'a t -> 'a t
+            val update : key -> ('a option -> 'a option) -> 'a t -> 'a t
             val singleton : key -> 'a -> 'a t
             val remove : key -> 'a t -> 'a t
             val merge :

--- a/testsuite/tests/typing-short-paths/short-paths.ml.reference
+++ b/testsuite/tests/typing-short-paths/short-paths.ml.reference
@@ -20,6 +20,7 @@
             val is_empty : 'a t -> bool
             val mem : key -> 'a t -> bool
             val add : key -> 'a -> 'a t -> 'a t
+            val update : key -> ('a option -> 'a) -> 'a t -> 'a t
             val singleton : key -> 'a -> 'a t
             val remove : key -> 'a t -> 'a t
             val merge :


### PR DESCRIPTION
The following pattern seems frequent:

`
try Map.add key map (f (Map.find key map))
with Not_found -> Map.add key map default
`

It can be implemented more efficiently when having access to the concrete representation of maps to avoid to traverse twice the tree. This PR implements one possible solution to this problem and illustrates this by replacing two such patterns.


EDIT: Cf https://caml.inria.fr/mantis/view.php?id=7309 -- AF