### PR TITLE
Declare record type for flambda function parameters

### DIFF
--- a/.depend
+++ b/.depend
@@ -615,9 +615,9 @@ bytecomp/simplif.cmx : utils/warnings.cmx utils/tbl.cmx typing/stypes.cmx \
     bytecomp/simplif.cmi
 bytecomp/simplif.cmi : utils/misc.cmi parsing/location.cmi \
     bytecomp/lambda.cmi typing/ident.cmi
-bytecomp/switch.cmo : bytecomp/switch.cmi
-bytecomp/switch.cmx : bytecomp/switch.cmi
-bytecomp/switch.cmi :
+bytecomp/switch.cmo : parsing/location.cmi bytecomp/switch.cmi
+bytecomp/switch.cmx : parsing/location.cmx bytecomp/switch.cmi
+bytecomp/switch.cmi : parsing/location.cmi
 bytecomp/symtable.cmo : utils/tbl.cmi bytecomp/runtimedef.cmi \
     typing/predef.cmi utils/misc.cmi bytecomp/meta.cmi parsing/location.cmi \
     bytecomp/lambda.cmi typing/ident.cmi bytecomp/dll.cmi utils/config.cmi \
@@ -983,8 +983,9 @@ asmcomp/flambda_to_clambda.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
     middle_end/base_types/static_exception.cmi \
     middle_end/base_types/set_of_closures_id.cmi typing/primitive.cmi \
-    utils/numbers.cmi middle_end/base_types/mutable_variable.cmi \
-    utils/misc.cmi middle_end/base_types/linkage_name.cmi typing/ident.cmi \
+    middle_end/parameter.cmi utils/numbers.cmi \
+    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
+    middle_end/base_types/linkage_name.cmi typing/ident.cmi \
     middle_end/flambda_utils.cmi middle_end/flambda.cmi \
     asmcomp/export_info.cmi middle_end/debuginfo.cmi asmcomp/compilenv.cmi \
     asmcomp/closure_offsets.cmi middle_end/base_types/closure_id.cmi \
@@ -995,8 +996,9 @@ asmcomp/flambda_to_clambda.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
     middle_end/base_types/static_exception.cmx \
     middle_end/base_types/set_of_closures_id.cmx typing/primitive.cmx \
-    utils/numbers.cmx middle_end/base_types/mutable_variable.cmx \
-    utils/misc.cmx middle_end/base_types/linkage_name.cmx typing/ident.cmx \
+    middle_end/parameter.cmx utils/numbers.cmx \
+    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
+    middle_end/base_types/linkage_name.cmx typing/ident.cmx \
     middle_end/flambda_utils.cmx middle_end/flambda.cmx \
     asmcomp/export_info.cmx middle_end/debuginfo.cmx asmcomp/compilenv.cmx \
     asmcomp/closure_offsets.cmx middle_end/base_types/closure_id.cmx \
@@ -1156,13 +1158,14 @@ asmcomp/split.cmo : asmcomp/reg.cmi utils/misc.cmi asmcomp/mach.cmi \
 asmcomp/split.cmx : asmcomp/reg.cmx utils/misc.cmx asmcomp/mach.cmx \
     asmcomp/split.cmi
 asmcomp/split.cmi : asmcomp/mach.cmi
-asmcomp/strmatch.cmo : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/debuginfo.cmi asmcomp/cmm.cmi parsing/asttypes.cmi \
-    asmcomp/arch.cmo asmcomp/strmatch.cmi
-asmcomp/strmatch.cmx : bytecomp/lambda.cmx typing/ident.cmx \
-    middle_end/debuginfo.cmx asmcomp/cmm.cmx parsing/asttypes.cmi \
-    asmcomp/arch.cmx asmcomp/strmatch.cmi
-asmcomp/strmatch.cmi : middle_end/debuginfo.cmi asmcomp/cmm.cmi
+asmcomp/strmatch.cmo : parsing/location.cmi bytecomp/lambda.cmi \
+    typing/ident.cmi middle_end/debuginfo.cmi asmcomp/cmm.cmi \
+    parsing/asttypes.cmi asmcomp/arch.cmo asmcomp/strmatch.cmi
+asmcomp/strmatch.cmx : parsing/location.cmx bytecomp/lambda.cmx \
+    typing/ident.cmx middle_end/debuginfo.cmx asmcomp/cmm.cmx \
+    parsing/asttypes.cmi asmcomp/arch.cmx asmcomp/strmatch.cmi
+asmcomp/strmatch.cmi : parsing/location.cmi middle_end/debuginfo.cmi \
+    asmcomp/cmm.cmi
 asmcomp/un_anf.cmo : bytecomp/semantics_of_primitives.cmi \
     asmcomp/printclambda.cmi utils/misc.cmi bytecomp/lambda.cmi \
     typing/ident.cmi middle_end/debuginfo.cmi utils/clflags.cmi \
@@ -1213,19 +1216,21 @@ middle_end/allocated_const.cmo : middle_end/allocated_const.cmi
 middle_end/allocated_const.cmx : middle_end/allocated_const.cmi
 middle_end/allocated_const.cmi :
 middle_end/augment_specialised_args.cmo : middle_end/base_types/variable.cmi \
-    middle_end/projection.cmi middle_end/pass_wrapper.cmi utils/misc.cmi \
-    middle_end/inlining_cost.cmi middle_end/inline_and_simplify_aux.cmi \
-    utils/identifiable.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi middle_end/debuginfo.cmi \
-    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
-    middle_end/backend_intf.cmi middle_end/augment_specialised_args.cmi
+    middle_end/projection.cmi middle_end/pass_wrapper.cmi \
+    middle_end/parameter.cmi utils/misc.cmi middle_end/inlining_cost.cmi \
+    middle_end/inline_and_simplify_aux.cmi utils/identifiable.cmi \
+    middle_end/flambda_utils.cmi middle_end/flambda.cmi \
+    middle_end/debuginfo.cmi middle_end/base_types/closure_id.cmi \
+    utils/clflags.cmi middle_end/backend_intf.cmi \
+    middle_end/augment_specialised_args.cmi
 middle_end/augment_specialised_args.cmx : middle_end/base_types/variable.cmx \
-    middle_end/projection.cmx middle_end/pass_wrapper.cmx utils/misc.cmx \
-    middle_end/inlining_cost.cmx middle_end/inline_and_simplify_aux.cmx \
-    utils/identifiable.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx middle_end/debuginfo.cmx \
-    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
-    middle_end/backend_intf.cmi middle_end/augment_specialised_args.cmi
+    middle_end/projection.cmx middle_end/pass_wrapper.cmx \
+    middle_end/parameter.cmx utils/misc.cmx middle_end/inlining_cost.cmx \
+    middle_end/inline_and_simplify_aux.cmx utils/identifiable.cmx \
+    middle_end/flambda_utils.cmx middle_end/flambda.cmx \
+    middle_end/debuginfo.cmx middle_end/base_types/closure_id.cmx \
+    utils/clflags.cmx middle_end/backend_intf.cmi \
+    middle_end/augment_specialised_args.cmi
 middle_end/augment_specialised_args.cmi : middle_end/base_types/variable.cmi \
     middle_end/projection.cmi middle_end/inlining_cost.cmi \
     middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi
@@ -1235,12 +1240,12 @@ middle_end/backend_intf.cmi : middle_end/base_types/symbol.cmi \
 middle_end/closure_conversion.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
     middle_end/base_types/static_exception.cmi bytecomp/simplif.cmi \
-    bytecomp/printlambda.cmi typing/predef.cmi utils/numbers.cmi \
-    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    parsing/location.cmi middle_end/base_types/linkage_name.cmi \
-    middle_end/lift_code.cmi bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda.cmi \
-    middle_end/debuginfo.cmi utils/config.cmi \
+    bytecomp/printlambda.cmi typing/predef.cmi middle_end/parameter.cmi \
+    utils/numbers.cmi middle_end/base_types/mutable_variable.cmi \
+    utils/misc.cmi parsing/location.cmi \
+    middle_end/base_types/linkage_name.cmi middle_end/lift_code.cmi \
+    bytecomp/lambda.cmi typing/ident.cmi middle_end/flambda_utils.cmi \
+    middle_end/flambda.cmi middle_end/debuginfo.cmi utils/config.cmi \
     middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/closure_id.cmi \
     middle_end/closure_conversion_aux.cmi utils/clflags.cmi \
@@ -1248,12 +1253,12 @@ middle_end/closure_conversion.cmo : middle_end/base_types/variable.cmi \
 middle_end/closure_conversion.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
     middle_end/base_types/static_exception.cmx bytecomp/simplif.cmx \
-    bytecomp/printlambda.cmx typing/predef.cmx utils/numbers.cmx \
-    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    parsing/location.cmx middle_end/base_types/linkage_name.cmx \
-    middle_end/lift_code.cmx bytecomp/lambda.cmx typing/ident.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda.cmx \
-    middle_end/debuginfo.cmx utils/config.cmx \
+    bytecomp/printlambda.cmx typing/predef.cmx middle_end/parameter.cmx \
+    utils/numbers.cmx middle_end/base_types/mutable_variable.cmx \
+    utils/misc.cmx parsing/location.cmx \
+    middle_end/base_types/linkage_name.cmx middle_end/lift_code.cmx \
+    bytecomp/lambda.cmx typing/ident.cmx middle_end/flambda_utils.cmx \
+    middle_end/flambda.cmx middle_end/debuginfo.cmx utils/config.cmx \
     middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/closure_id.cmx \
     middle_end/closure_conversion_aux.cmx utils/clflags.cmx \
@@ -1315,7 +1320,7 @@ middle_end/flambda.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/static_exception.cmi \
     middle_end/base_types/set_of_closures_origin.cmi \
     middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
-    bytecomp/printlambda.cmi utils/numbers.cmi \
+    bytecomp/printlambda.cmi middle_end/parameter.cmi utils/numbers.cmi \
     middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
     bytecomp/lambda.cmi utils/identifiable.cmi middle_end/debuginfo.cmi \
     middle_end/base_types/compilation_unit.cmi \
@@ -1327,7 +1332,7 @@ middle_end/flambda.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/static_exception.cmx \
     middle_end/base_types/set_of_closures_origin.cmx \
     middle_end/base_types/set_of_closures_id.cmx middle_end/projection.cmx \
-    bytecomp/printlambda.cmx utils/numbers.cmx \
+    bytecomp/printlambda.cmx middle_end/parameter.cmx utils/numbers.cmx \
     middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
     bytecomp/lambda.cmx utils/identifiable.cmx middle_end/debuginfo.cmx \
     middle_end/base_types/compilation_unit.cmx \
@@ -1339,8 +1344,9 @@ middle_end/flambda.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/static_exception.cmi \
     middle_end/base_types/set_of_closures_origin.cmi \
     middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
-    utils/numbers.cmi middle_end/base_types/mutable_variable.cmi \
-    bytecomp/lambda.cmi utils/identifiable.cmi middle_end/debuginfo.cmi \
+    middle_end/parameter.cmi utils/numbers.cmi \
+    middle_end/base_types/mutable_variable.cmi bytecomp/lambda.cmi \
+    utils/identifiable.cmi middle_end/debuginfo.cmi \
     middle_end/base_types/closure_id.cmi parsing/asttypes.cmi \
     middle_end/allocated_const.cmi
 middle_end/flambda_invariants.cmo : middle_end/base_types/variable.cmi \
@@ -1349,7 +1355,7 @@ middle_end/flambda_invariants.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/static_exception.cmi \
     middle_end/base_types/set_of_closures_origin.cmi \
     middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
-    bytecomp/printlambda.cmi utils/numbers.cmi \
+    bytecomp/printlambda.cmi middle_end/parameter.cmi utils/numbers.cmi \
     middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
     bytecomp/lambda.cmi typing/ident.cmi middle_end/flambda_iterators.cmi \
     middle_end/flambda.cmi middle_end/debuginfo.cmi \
@@ -1362,7 +1368,7 @@ middle_end/flambda_invariants.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/static_exception.cmx \
     middle_end/base_types/set_of_closures_origin.cmx \
     middle_end/base_types/set_of_closures_id.cmx middle_end/projection.cmx \
-    bytecomp/printlambda.cmx utils/numbers.cmx \
+    bytecomp/printlambda.cmx middle_end/parameter.cmx utils/numbers.cmx \
     middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
     bytecomp/lambda.cmx typing/ident.cmx middle_end/flambda_iterators.cmx \
     middle_end/flambda.cmx middle_end/debuginfo.cmx \
@@ -1381,10 +1387,10 @@ middle_end/flambda_utils.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/symbol.cmi bytecomp/switch.cmi \
     middle_end/base_types/static_exception.cmi \
     middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
-    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    middle_end/base_types/linkage_name.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/debuginfo.cmi \
-    middle_end/base_types/compilation_unit.cmi \
+    middle_end/parameter.cmi middle_end/base_types/mutable_variable.cmi \
+    utils/misc.cmi middle_end/base_types/linkage_name.cmi \
+    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
+    middle_end/debuginfo.cmi middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi \
     middle_end/allocated_const.cmi middle_end/flambda_utils.cmi
 middle_end/flambda_utils.cmx : middle_end/base_types/variable.cmx \
@@ -1392,10 +1398,10 @@ middle_end/flambda_utils.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/symbol.cmx bytecomp/switch.cmx \
     middle_end/base_types/static_exception.cmx \
     middle_end/base_types/set_of_closures_id.cmx middle_end/projection.cmx \
-    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    middle_end/base_types/linkage_name.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/debuginfo.cmx \
-    middle_end/base_types/compilation_unit.cmx \
+    middle_end/parameter.cmx middle_end/base_types/mutable_variable.cmx \
+    utils/misc.cmx middle_end/base_types/linkage_name.cmx \
+    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
+    middle_end/debuginfo.cmx middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/closure_id.cmx middle_end/backend_intf.cmi \
     middle_end/allocated_const.cmx middle_end/flambda_utils.cmi
 middle_end/flambda_utils.cmi : middle_end/base_types/variable.cmi \
@@ -1403,22 +1409,22 @@ middle_end/flambda_utils.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
     bytecomp/switch.cmi middle_end/base_types/static_exception.cmi \
     middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
-    middle_end/flambda.cmi middle_end/base_types/closure_id.cmi \
-    middle_end/backend_intf.cmi
+    middle_end/parameter.cmi middle_end/flambda.cmi \
+    middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi
 middle_end/freshening.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/symbol.cmi \
     middle_end/base_types/static_exception.cmi middle_end/projection.cmi \
-    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    utils/identifiable.cmi middle_end/flambda_utils.cmi \
+    middle_end/parameter.cmi middle_end/base_types/mutable_variable.cmi \
+    utils/misc.cmi utils/identifiable.cmi middle_end/flambda_utils.cmi \
     middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
     middle_end/base_types/closure_id.cmi middle_end/freshening.cmi
 middle_end/freshening.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/var_within_closure.cmx \
     middle_end/base_types/symbol.cmx \
     middle_end/base_types/static_exception.cmx middle_end/projection.cmx \
-    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    utils/identifiable.cmx middle_end/flambda_utils.cmx \
+    middle_end/parameter.cmx middle_end/base_types/mutable_variable.cmx \
+    utils/misc.cmx utils/identifiable.cmx middle_end/flambda_utils.cmx \
     middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
     middle_end/base_types/closure_id.cmx middle_end/freshening.cmi
 middle_end/freshening.cmi : middle_end/base_types/variable.cmi \
@@ -1429,18 +1435,18 @@ middle_end/freshening.cmi : middle_end/base_types/variable.cmi \
     middle_end/base_types/closure_id.cmi
 middle_end/inconstant_idents.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/symbol.cmi \
-    middle_end/base_types/set_of_closures_id.cmi utils/numbers.cmi \
-    utils/misc.cmi bytecomp/lambda.cmi utils/identifiable.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda.cmi \
-    middle_end/base_types/compilation_unit.cmi \
+    middle_end/base_types/set_of_closures_id.cmi middle_end/parameter.cmi \
+    utils/numbers.cmi utils/misc.cmi bytecomp/lambda.cmi \
+    utils/identifiable.cmi middle_end/flambda_utils.cmi \
+    middle_end/flambda.cmi middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi \
     parsing/asttypes.cmi middle_end/inconstant_idents.cmi
 middle_end/inconstant_idents.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/symbol.cmx \
-    middle_end/base_types/set_of_closures_id.cmx utils/numbers.cmx \
-    utils/misc.cmx bytecomp/lambda.cmx utils/identifiable.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda.cmx \
-    middle_end/base_types/compilation_unit.cmx \
+    middle_end/base_types/set_of_closures_id.cmx middle_end/parameter.cmx \
+    utils/numbers.cmx utils/misc.cmx bytecomp/lambda.cmx \
+    utils/identifiable.cmx middle_end/flambda_utils.cmx \
+    middle_end/flambda.cmx middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/closure_id.cmx middle_end/backend_intf.cmi \
     parsing/asttypes.cmi middle_end/inconstant_idents.cmi
 middle_end/inconstant_idents.cmi : middle_end/base_types/variable.cmi \
@@ -1463,8 +1469,8 @@ middle_end/inline_and_simplify.cmo : utils/warnings.cmi \
     middle_end/simplify_primitives.cmi middle_end/simple_value_approx.cmi \
     middle_end/remove_unused_arguments.cmi \
     middle_end/remove_free_vars_equal_to_args.cmi middle_end/projection.cmi \
-    typing/predef.cmi utils/misc.cmi parsing/location.cmi \
-    middle_end/lift_code.cmi bytecomp/lambda.cmi \
+    typing/predef.cmi middle_end/parameter.cmi utils/misc.cmi \
+    parsing/location.cmi middle_end/lift_code.cmi bytecomp/lambda.cmi \
     middle_end/invariant_params.cmi middle_end/inlining_stats.cmi \
     middle_end/inlining_decision.cmi middle_end/inlining_cost.cmi \
     middle_end/inline_and_simplify_aux.cmi typing/ident.cmi \
@@ -1483,8 +1489,8 @@ middle_end/inline_and_simplify.cmx : utils/warnings.cmx \
     middle_end/simplify_primitives.cmx middle_end/simple_value_approx.cmx \
     middle_end/remove_unused_arguments.cmx \
     middle_end/remove_free_vars_equal_to_args.cmx middle_end/projection.cmx \
-    typing/predef.cmx utils/misc.cmx parsing/location.cmx \
-    middle_end/lift_code.cmx bytecomp/lambda.cmx \
+    typing/predef.cmx middle_end/parameter.cmx utils/misc.cmx \
+    parsing/location.cmx middle_end/lift_code.cmx bytecomp/lambda.cmx \
     middle_end/invariant_params.cmx middle_end/inlining_stats.cmx \
     middle_end/inlining_decision.cmx middle_end/inlining_cost.cmx \
     middle_end/inline_and_simplify_aux.cmx typing/ident.cmx \
@@ -1502,8 +1508,9 @@ middle_end/inline_and_simplify_aux.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/static_exception.cmi \
     middle_end/simple_value_approx.cmi \
     middle_end/base_types/set_of_closures_origin.cmi \
-    middle_end/projection.cmi middle_end/base_types/mutable_variable.cmi \
-    utils/misc.cmi middle_end/inlining_stats.cmi middle_end/inlining_cost.cmi \
+    middle_end/projection.cmi middle_end/parameter.cmi \
+    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
+    middle_end/inlining_stats.cmi middle_end/inlining_cost.cmi \
     middle_end/freshening.cmi middle_end/flambda.cmi middle_end/debuginfo.cmi \
     middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/closure_id.cmi utils/clflags.cmi \
@@ -1514,8 +1521,9 @@ middle_end/inline_and_simplify_aux.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/static_exception.cmx \
     middle_end/simple_value_approx.cmx \
     middle_end/base_types/set_of_closures_origin.cmx \
-    middle_end/projection.cmx middle_end/base_types/mutable_variable.cmx \
-    utils/misc.cmx middle_end/inlining_stats.cmx middle_end/inlining_cost.cmx \
+    middle_end/projection.cmx middle_end/parameter.cmx \
+    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
+    middle_end/inlining_stats.cmx middle_end/inlining_cost.cmx \
     middle_end/freshening.cmx middle_end/flambda.cmx middle_end/debuginfo.cmx \
     middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/closure_id.cmx utils/clflags.cmx \
@@ -1541,20 +1549,20 @@ middle_end/inlining_cost.cmi : middle_end/projection.cmi \
     middle_end/flambda.cmi
 middle_end/inlining_decision.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
-    middle_end/simple_value_approx.cmi utils/misc.cmi bytecomp/lambda.cmi \
-    middle_end/inlining_transforms.cmi middle_end/inlining_stats_types.cmi \
-    middle_end/inlining_cost.cmi middle_end/inline_and_simplify_aux.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda.cmi \
-    middle_end/find_recursive_functions.cmi \
+    middle_end/simple_value_approx.cmi middle_end/parameter.cmi \
+    utils/misc.cmi bytecomp/lambda.cmi middle_end/inlining_transforms.cmi \
+    middle_end/inlining_stats_types.cmi middle_end/inlining_cost.cmi \
+    middle_end/inline_and_simplify_aux.cmi middle_end/flambda_utils.cmi \
+    middle_end/flambda.cmi middle_end/find_recursive_functions.cmi \
     middle_end/base_types/closure_id.cmi utils/clflags.cmi \
     middle_end/inlining_decision.cmi
 middle_end/inlining_decision.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/var_within_closure.cmx \
-    middle_end/simple_value_approx.cmx utils/misc.cmx bytecomp/lambda.cmx \
-    middle_end/inlining_transforms.cmx middle_end/inlining_stats_types.cmx \
-    middle_end/inlining_cost.cmx middle_end/inline_and_simplify_aux.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda.cmx \
-    middle_end/find_recursive_functions.cmx \
+    middle_end/simple_value_approx.cmx middle_end/parameter.cmx \
+    utils/misc.cmx bytecomp/lambda.cmx middle_end/inlining_transforms.cmx \
+    middle_end/inlining_stats_types.cmx middle_end/inlining_cost.cmx \
+    middle_end/inline_and_simplify_aux.cmx middle_end/flambda_utils.cmx \
+    middle_end/flambda.cmx middle_end/find_recursive_functions.cmx \
     middle_end/base_types/closure_id.cmx utils/clflags.cmx \
     middle_end/inlining_decision.cmi
 middle_end/inlining_decision.cmi : middle_end/base_types/variable.cmi \
@@ -1583,20 +1591,20 @@ middle_end/inlining_stats_types.cmx : middle_end/inlining_cost.cmx \
 middle_end/inlining_stats_types.cmi : middle_end/inlining_cost.cmi
 middle_end/inlining_transforms.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
-    middle_end/simple_value_approx.cmi utils/misc.cmi bytecomp/lambda.cmi \
-    middle_end/inlining_cost.cmi middle_end/inline_and_simplify_aux.cmi \
-    middle_end/freshening.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
-    middle_end/base_types/compilation_unit.cmi \
+    middle_end/simple_value_approx.cmi middle_end/parameter.cmi \
+    utils/misc.cmi bytecomp/lambda.cmi middle_end/inlining_cost.cmi \
+    middle_end/inline_and_simplify_aux.cmi middle_end/freshening.cmi \
+    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
+    middle_end/flambda.cmi middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi \
     middle_end/inlining_transforms.cmi
 middle_end/inlining_transforms.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/var_within_closure.cmx \
-    middle_end/simple_value_approx.cmx utils/misc.cmx bytecomp/lambda.cmx \
-    middle_end/inlining_cost.cmx middle_end/inline_and_simplify_aux.cmx \
-    middle_end/freshening.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
-    middle_end/base_types/compilation_unit.cmx \
+    middle_end/simple_value_approx.cmx middle_end/parameter.cmx \
+    utils/misc.cmx bytecomp/lambda.cmx middle_end/inlining_cost.cmx \
+    middle_end/inline_and_simplify_aux.cmx middle_end/freshening.cmx \
+    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
+    middle_end/flambda.cmx middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/closure_id.cmx middle_end/backend_intf.cmi \
     middle_end/inlining_transforms.cmi
 middle_end/inlining_transforms.cmi : middle_end/base_types/variable.cmi \
@@ -1605,15 +1613,17 @@ middle_end/inlining_transforms.cmi : middle_end/base_types/variable.cmi \
     middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi \
     middle_end/debuginfo.cmi middle_end/base_types/closure_id.cmi
 middle_end/invariant_params.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/symbol.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
-    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
-    middle_end/backend_intf.cmi middle_end/invariant_params.cmi
+    middle_end/base_types/symbol.cmi middle_end/parameter.cmi \
+    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
+    middle_end/flambda.cmi middle_end/base_types/closure_id.cmi \
+    utils/clflags.cmi middle_end/backend_intf.cmi \
+    middle_end/invariant_params.cmi
 middle_end/invariant_params.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/symbol.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
-    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
-    middle_end/backend_intf.cmi middle_end/invariant_params.cmi
+    middle_end/base_types/symbol.cmx middle_end/parameter.cmx \
+    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
+    middle_end/flambda.cmx middle_end/base_types/closure_id.cmx \
+    utils/clflags.cmx middle_end/backend_intf.cmi \
+    middle_end/invariant_params.cmi
 middle_end/invariant_params.cmi : middle_end/base_types/variable.cmi \
     middle_end/flambda.cmi middle_end/backend_intf.cmi
 middle_end/lift_code.cmo : middle_end/base_types/variable.cmi \
@@ -1692,6 +1702,12 @@ middle_end/middle_end.cmx : utils/warnings.cmx \
     utils/clflags.cmx middle_end/backend_intf.cmi middle_end/middle_end.cmi
 middle_end/middle_end.cmi : bytecomp/lambda.cmi typing/ident.cmi \
     middle_end/flambda.cmi middle_end/backend_intf.cmi
+middle_end/parameter.cmo : middle_end/base_types/variable.cmi \
+    utils/identifiable.cmi middle_end/parameter.cmi
+middle_end/parameter.cmx : middle_end/base_types/variable.cmx \
+    utils/identifiable.cmx middle_end/parameter.cmi
+middle_end/parameter.cmi : middle_end/base_types/variable.cmi \
+    utils/identifiable.cmi middle_end/base_types/compilation_unit.cmi
 middle_end/pass_wrapper.cmo : utils/clflags.cmi middle_end/pass_wrapper.cmi
 middle_end/pass_wrapper.cmx : utils/clflags.cmx middle_end/pass_wrapper.cmi
 middle_end/pass_wrapper.cmi :
@@ -1717,24 +1733,26 @@ middle_end/ref_to_variables.cmx : middle_end/base_types/variable.cmx \
 middle_end/ref_to_variables.cmi : middle_end/flambda.cmi
 middle_end/remove_free_vars_equal_to_args.cmo : \
     middle_end/base_types/variable.cmi middle_end/pass_wrapper.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda.cmi \
-    middle_end/remove_free_vars_equal_to_args.cmi
+    middle_end/parameter.cmi middle_end/flambda_utils.cmi \
+    middle_end/flambda.cmi middle_end/remove_free_vars_equal_to_args.cmi
 middle_end/remove_free_vars_equal_to_args.cmx : \
     middle_end/base_types/variable.cmx middle_end/pass_wrapper.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda.cmx \
-    middle_end/remove_free_vars_equal_to_args.cmi
+    middle_end/parameter.cmx middle_end/flambda_utils.cmx \
+    middle_end/flambda.cmx middle_end/remove_free_vars_equal_to_args.cmi
 middle_end/remove_free_vars_equal_to_args.cmi : middle_end/flambda.cmi
 middle_end/remove_unused_arguments.cmo : middle_end/base_types/variable.cmi \
-    middle_end/projection.cmi middle_end/invariant_params.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/find_recursive_functions.cmi \
+    middle_end/projection.cmi middle_end/parameter.cmi \
+    middle_end/invariant_params.cmi middle_end/flambda_utils.cmi \
+    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
+    middle_end/find_recursive_functions.cmi \
     middle_end/base_types/compilation_unit.cmi \
     middle_end/base_types/closure_id.cmi utils/clflags.cmi \
     middle_end/remove_unused_arguments.cmi
 middle_end/remove_unused_arguments.cmx : middle_end/base_types/variable.cmx \
-    middle_end/projection.cmx middle_end/invariant_params.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/find_recursive_functions.cmx \
+    middle_end/projection.cmx middle_end/parameter.cmx \
+    middle_end/invariant_params.cmx middle_end/flambda_utils.cmx \
+    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
+    middle_end/find_recursive_functions.cmx \
     middle_end/base_types/compilation_unit.cmx \
     middle_end/base_types/closure_id.cmx utils/clflags.cmx \
     middle_end/remove_unused_arguments.cmi
@@ -1742,15 +1760,15 @@ middle_end/remove_unused_arguments.cmi : middle_end/flambda.cmi \
     middle_end/backend_intf.cmi
 middle_end/remove_unused_closure_vars.cmo : \
     middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
-    middle_end/base_types/closure_id.cmi \
+    middle_end/base_types/var_within_closure.cmi middle_end/parameter.cmi \
+    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
+    middle_end/flambda.cmi middle_end/base_types/closure_id.cmi \
     middle_end/remove_unused_closure_vars.cmi
 middle_end/remove_unused_closure_vars.cmx : \
     middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
-    middle_end/base_types/closure_id.cmx \
+    middle_end/base_types/var_within_closure.cmx middle_end/parameter.cmx \
+    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
+    middle_end/flambda.cmx middle_end/base_types/closure_id.cmx \
     middle_end/remove_unused_closure_vars.cmi
 middle_end/remove_unused_closure_vars.cmi : middle_end/flambda.cmi
 middle_end/remove_unused_program_constructs.cmo : \
@@ -1772,8 +1790,8 @@ middle_end/share_constants.cmi : middle_end/flambda.cmi
 middle_end/simple_value_approx.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    middle_end/base_types/set_of_closures_id.cmi utils/misc.cmi \
-    bytecomp/lambda.cmi middle_end/inlining_cost.cmi \
+    middle_end/base_types/set_of_closures_id.cmi middle_end/parameter.cmi \
+    utils/misc.cmi bytecomp/lambda.cmi middle_end/inlining_cost.cmi \
     middle_end/freshening.cmi middle_end/flambda_utils.cmi \
     middle_end/flambda.cmi middle_end/base_types/export_id.cmi \
     middle_end/effect_analysis.cmi middle_end/base_types/closure_id.cmi \
@@ -1781,8 +1799,8 @@ middle_end/simple_value_approx.cmo : middle_end/base_types/variable.cmi \
 middle_end/simple_value_approx.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/var_within_closure.cmx \
     middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
-    middle_end/base_types/set_of_closures_id.cmx utils/misc.cmx \
-    bytecomp/lambda.cmx middle_end/inlining_cost.cmx \
+    middle_end/base_types/set_of_closures_id.cmx middle_end/parameter.cmx \
+    utils/misc.cmx bytecomp/lambda.cmx middle_end/inlining_cost.cmx \
     middle_end/freshening.cmx middle_end/flambda_utils.cmx \
     middle_end/flambda.cmx middle_end/base_types/export_id.cmx \
     middle_end/effect_analysis.cmx middle_end/base_types/closure_id.cmx \
@@ -2010,11 +2028,11 @@ driver/compile.cmx : utils/warnings.cmx typing/typemod.cmx \
     driver/compmisc.cmx driver/compenv.cmx utils/clflags.cmx \
     bytecomp/bytegen.cmx parsing/builtin_attributes.cmx driver/compile.cmi
 driver/compile.cmi :
-driver/compmisc.cmo : typing/typemod.cmi utils/misc.cmi \
+driver/compmisc.cmo : utils/warnings.cmi typing/typemod.cmi utils/misc.cmi \
     parsing/longident.cmi parsing/location.cmi typing/ident.cmi \
     typing/env.cmi utils/config.cmi driver/compenv.cmi utils/clflags.cmi \
     parsing/asttypes.cmi driver/compmisc.cmi
-driver/compmisc.cmx : typing/typemod.cmx utils/misc.cmx \
+driver/compmisc.cmx : utils/warnings.cmx typing/typemod.cmx utils/misc.cmx \
     parsing/longident.cmx parsing/location.cmx typing/ident.cmx \
     typing/env.cmx utils/config.cmx driver/compenv.cmx utils/clflags.cmx \
     parsing/asttypes.cmi driver/compmisc.cmi

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,7 @@ MIDDLE_END=\
   middle_end/base_types/symbol.cmo \
   middle_end/pass_wrapper.cmo \
   middle_end/allocated_const.cmo \
+  middle_end/parameter.cmo \
   middle_end/projection.cmo \
   middle_end/flambda.cmo \
   middle_end/flambda_iterators.cmo \

--- a/asmcomp/flambda_to_clambda.ml
+++ b/asmcomp/flambda_to_clambda.ml
@@ -511,7 +511,7 @@ and to_clambda_set_of_closures t env
     in
     let env_body, params =
       List.fold_right (fun var (env, params) ->
-          let id, env = Env.add_fresh_ident env var in
+          let id, env = Env.add_fresh_ident env var.Parameter.var in
           env, id :: params)
         function_decl.params (env, [])
     in
@@ -551,7 +551,7 @@ and to_clambda_closed_set_of_closures t env symbol
     in
     let env_body, params =
       List.fold_right (fun var (env, params) ->
-          let id, env = Env.add_fresh_ident env var in
+          let id, env = Env.add_fresh_ident env var.Parameter.var in
           env, id :: params)
         function_decl.params (env, [])
     in

--- a/asmcomp/flambda_to_clambda.ml
+++ b/asmcomp/flambda_to_clambda.ml
@@ -511,7 +511,7 @@ and to_clambda_set_of_closures t env
     in
     let env_body, params =
       List.fold_right (fun var (env, params) ->
-          let id, env = Env.add_fresh_ident env var.Parameter.var in
+          let id, env = Env.add_fresh_ident env (Parameter.var var) in
           env, id :: params)
         function_decl.params (env, [])
     in
@@ -551,7 +551,7 @@ and to_clambda_closed_set_of_closures t env symbol
     in
     let env_body, params =
       List.fold_right (fun var (env, params) ->
-          let id, env = Env.add_fresh_ident env var.Parameter.var in
+          let id, env = Env.add_fresh_ident env (Parameter.var var) in
           env, id :: params)
         function_decl.params (env, [])
     in

--- a/middle_end/augment_specialised_args.ml
+++ b/middle_end/augment_specialised_args.ml
@@ -470,7 +470,8 @@ module Make (T : S) = struct
         Apply {
           func = new_fun_var;
           args =
-            (Parameter.vars wrapper_params) @ spec_args_bound_in_the_wrapper;
+            (Parameter.List.vars wrapper_params) @
+            spec_args_bound_in_the_wrapper;
           kind = Direct (Closure_id.wrap new_fun_var);
           dbg = Debuginfo.none;
           inline = Default_inline;

--- a/middle_end/augment_specialised_args.ml
+++ b/middle_end/augment_specialised_args.ml
@@ -408,17 +408,18 @@ module Make (T : S) = struct
   let rename_function_and_parameters ~fun_var
         ~(function_decl : Flambda.function_declaration) =
     let new_fun_var = Variable.rename fun_var ~append:T.variable_suffix in
+    let params_renaming_list =
+      List.map (fun param ->
+          let new_param = Parameter.rename param ~append:T.variable_suffix in
+          param, new_param)
+        function_decl.params
+    in
+    let renamed_params = List.map snd params_renaming_list in
     let params_renaming =
       Variable.Map.of_list
-        (List.map (fun param ->
-            let new_param = Variable.rename param ~append:T.variable_suffix in
-            param, new_param)
-          (Parameter.vars function_decl.params))
-    in
-    let renamed_params =
-      List.map (fun (param:Parameter.t) : Parameter.t ->
-        { var = Variable.Map.find param.var params_renaming })
-        function_decl.params
+        (List.map (fun (param, new_param) ->
+             Parameter.var param, Parameter.var new_param)
+           params_renaming_list)
     in
     new_fun_var, params_renaming, renamed_params
 
@@ -611,7 +612,7 @@ module Make (T : S) = struct
             for_one_function.new_inner_to_new_outer_vars)
         in
         let new_params =
-          List.map (fun var : Parameter.t -> { var }) new_params
+          List.map Parameter.wrap new_params
         in
         function_decl.params @ new_params
       in

--- a/middle_end/augment_specialised_args.ml
+++ b/middle_end/augment_specialised_args.ml
@@ -246,7 +246,7 @@ module Processed_what_to_specialise = struct
         with
         | exception Not_found -> assert false
         | (function_decl : Flambda.function_declaration) ->
-          let params = Parameter.var_set function_decl.params in
+          let params = Parameter.Set.vars function_decl.params in
           let existing_specialised_args =
             Variable.Map.filter (fun inner_var _spec_to ->
                 Variable.Set.mem inner_var params)
@@ -291,7 +291,7 @@ module Processed_what_to_specialise = struct
           if function_decl.stub then
             Definition.Set.empty
           else
-            let params = Parameter.var_set function_decl.params in
+            let params = Parameter.Set.vars function_decl.params in
             Variable.Map.fold (fun inner_var
                       (spec_to : Flambda.specialised_to) definitions ->
                 if not (Variable.Set.mem inner_var params) then
@@ -373,7 +373,7 @@ let check_invariants ~pass_name ~(set_of_closures : Flambda.set_of_closures)
   if !Clflags.flambda_invariant_checks then begin
     Variable.Map.iter (fun fun_var
               (function_decl : Flambda.function_declaration) ->
-        let params = Parameter.var_set function_decl.params in
+        let params = Parameter.Set.vars function_decl.params in
         Variable.Map.iter (fun inner_var
                     (outer_var : Flambda.specialised_to) ->
               if Variable.Set.mem inner_var params then begin
@@ -433,7 +433,7 @@ module Make (T : S) = struct
        definitions are called the "specialised args bound in the wrapper".
        Note that the domain of [params_renaming] is a (non-strict) superset
        of the "inner vars" of the original specialised args. *)
-    let params = Parameter.var_set function_decl.params in
+    let params = Parameter.Set.vars function_decl.params in
     let new_fun_var, params_renaming, wrapper_params =
       rename_function_and_parameters ~fun_var ~function_decl
     in
@@ -585,7 +585,7 @@ module Make (T : S) = struct
                 assert (Variable.Map.mem projecting_from
                   set_of_closures.specialised_args);
                 assert (Variable.Set.mem projecting_from
-                  (Parameter.var_set function_decl.params));
+                  (Parameter.Set.vars function_decl.params));
                 { var = new_outer_var;
                   projection = Some projection;
                 })

--- a/middle_end/augment_specialised_args.ml
+++ b/middle_end/augment_specialised_args.ml
@@ -246,7 +246,7 @@ module Processed_what_to_specialise = struct
         with
         | exception Not_found -> assert false
         | (function_decl : Flambda.function_declaration) ->
-          let params = Variable.Set.of_list function_decl.params in
+          let params = Parameter.var_set function_decl.params in
           let existing_specialised_args =
             Variable.Map.filter (fun inner_var _spec_to ->
                 Variable.Set.mem inner_var params)
@@ -291,7 +291,7 @@ module Processed_what_to_specialise = struct
           if function_decl.stub then
             Definition.Set.empty
           else
-            let params = Variable.Set.of_list function_decl.params in
+            let params = Parameter.var_set function_decl.params in
             Variable.Map.fold (fun inner_var
                       (spec_to : Flambda.specialised_to) definitions ->
                 if not (Variable.Set.mem inner_var params) then
@@ -373,7 +373,7 @@ let check_invariants ~pass_name ~(set_of_closures : Flambda.set_of_closures)
   if !Clflags.flambda_invariant_checks then begin
     Variable.Map.iter (fun fun_var
               (function_decl : Flambda.function_declaration) ->
-        let params = Variable.Set.of_list function_decl.params in
+        let params = Parameter.var_set function_decl.params in
         Variable.Map.iter (fun inner_var
                     (outer_var : Flambda.specialised_to) ->
               if Variable.Set.mem inner_var params then begin
@@ -413,10 +413,11 @@ module Make (T : S) = struct
         (List.map (fun param ->
             let new_param = Variable.rename param ~append:T.variable_suffix in
             param, new_param)
-          function_decl.params)
+          (Parameter.vars function_decl.params))
     in
     let renamed_params =
-      List.map (fun param -> Variable.Map.find param params_renaming)
+      List.map (fun (param:Parameter.t) : Parameter.t ->
+        { var = Variable.Map.find param.var params_renaming })
         function_decl.params
     in
     new_fun_var, params_renaming, renamed_params
@@ -431,7 +432,7 @@ module Make (T : S) = struct
        definitions are called the "specialised args bound in the wrapper".
        Note that the domain of [params_renaming] is a (non-strict) superset
        of the "inner vars" of the original specialised args. *)
-    let params = Variable.Set.of_list function_decl.params in
+    let params = Parameter.var_set function_decl.params in
     let new_fun_var, params_renaming, wrapper_params =
       rename_function_and_parameters ~fun_var ~function_decl
     in
@@ -467,7 +468,8 @@ module Make (T : S) = struct
       let apply : Flambda.expr =
         Apply {
           func = new_fun_var;
-          args = wrapper_params @ spec_args_bound_in_the_wrapper;
+          args =
+            (Parameter.vars wrapper_params) @ spec_args_bound_in_the_wrapper;
           kind = Direct (Closure_id.wrap new_fun_var);
           dbg = Debuginfo.none;
           inline = Default_inline;
@@ -581,7 +583,7 @@ module Make (T : S) = struct
                 assert (Variable.Map.mem projecting_from
                   set_of_closures.specialised_args);
                 assert (Variable.Set.mem projecting_from
-                  (Variable.Set.of_list function_decl.params));
+                  (Parameter.var_set function_decl.params));
                 { var = new_outer_var;
                   projection = Some projection;
                 })
@@ -607,6 +609,9 @@ module Make (T : S) = struct
         let new_params =
           Variable.Set.elements (Variable.Map.keys
             for_one_function.new_inner_to_new_outer_vars)
+        in
+        let new_params =
+          List.map (fun var : Parameter.t -> { var }) new_params
         in
         function_decl.params @ new_params
       in

--- a/middle_end/closure_conversion.ml
+++ b/middle_end/closure_conversion.ml
@@ -96,7 +96,7 @@ let tupled_function_call_stub original_params unboxed_version
         pos + 1, Flambda.create_let param lam body)
       (0, call) params
   in
-  let tuple_param : Parameter.t = { var = tuple_param_var } in
+  let tuple_param = Parameter.wrap tuple_param_var in
   Flambda.create_function_declaration ~params:[tuple_param]
     ~body ~stub:true ~dbg:Debuginfo.none ~inline:Default_inline
     ~specialise:Default_specialise ~is_a_functor:false
@@ -565,7 +565,7 @@ and close_functions t external_env function_declarations : Flambda.named =
        not marked as stub but certainly should *)
     let stub = Function_decl.stub decl in
     let param_vars = List.map (Env.find_var closure_env) params in
-    let params = List.map (fun var : Parameter.t -> { var }) param_vars in
+    let params = List.map Parameter.wrap param_vars in
     let closure_bound_var = Function_decl.closure_bound_var decl in
     let body = close t closure_env body in
     let fun_decl =

--- a/middle_end/closure_conversion.ml
+++ b/middle_end/closure_conversion.ml
@@ -72,7 +72,7 @@ let add_default_argument_wrappers lam =
     manner from the tuple. *)
 let tupled_function_call_stub original_params unboxed_version
       : Flambda.function_declaration =
-  let tuple_param =
+  let tuple_param_var =
     Variable.rename ~append:"tupled_stub_param" unboxed_version
   in
   let params = List.map (fun p -> Variable.rename p) original_params in
@@ -91,11 +91,12 @@ let tupled_function_call_stub original_params unboxed_version
   let _, body =
     List.fold_left (fun (pos, body) param ->
         let lam : Flambda.named =
-          Prim (Pfield pos, [tuple_param], Debuginfo.none)
+          Prim (Pfield pos, [tuple_param_var], Debuginfo.none)
         in
         pos + 1, Flambda.create_let param lam body)
       (0, call) params
   in
+  let tuple_param : Parameter.t = { var = tuple_param_var } in
   Flambda.create_function_declaration ~params:[tuple_param]
     ~body ~stub:true ~dbg:Debuginfo.none ~inline:Default_inline
     ~specialise:Default_specialise ~is_a_functor:false
@@ -563,7 +564,8 @@ and close_functions t external_env function_declarations : Flambda.named =
        CR-someday pchambart: eta-expansion wrapper for a primitive are
        not marked as stub but certainly should *)
     let stub = Function_decl.stub decl in
-    let params = List.map (Env.find_var closure_env) params in
+    let param_vars = List.map (Env.find_var closure_env) params in
+    let params = List.map (fun var : Parameter.t -> { var }) param_vars in
     let closure_bound_var = Function_decl.closure_bound_var decl in
     let body = close t closure_env body in
     let fun_decl =
@@ -577,7 +579,7 @@ and close_functions t external_env function_declarations : Flambda.named =
     | Tupled ->
       let unboxed_version = Variable.rename closure_bound_var in
       let generic_function_stub =
-        tupled_function_call_stub params unboxed_version
+        tupled_function_call_stub param_vars unboxed_version
       in
       Variable.Map.add unboxed_version fun_decl
         (Variable.Map.add closure_bound_var generic_function_stub map)

--- a/middle_end/flambda.ml
+++ b/middle_end/flambda.ml
@@ -353,8 +353,8 @@ and print_named ppf (named : named) =
     (* lam ppf expr *)
 
 and print_function_declaration ppf var (f : function_declaration) =
-  let param ppf ({ var } : Parameter.t) =
-    Variable.print ppf var
+  let param ppf p =
+    Variable.print ppf (Parameter.var p)
   in
   let params ppf =
     List.iter (fprintf ppf "@ %a" param) in

--- a/middle_end/flambda.ml
+++ b/middle_end/flambda.ml
@@ -116,7 +116,7 @@ and function_declarations = {
 }
 
 and function_declaration = {
-  params : Variable.t list;
+  params : Parameter.t list;
   body : t;
   free_variables : Variable.Set.t;
   free_symbols : Symbol.Set.t;
@@ -353,8 +353,11 @@ and print_named ppf (named : named) =
     (* lam ppf expr *)
 
 and print_function_declaration ppf var (f : function_declaration) =
-  let idents ppf =
-    List.iter (fprintf ppf "@ %a" Variable.print) in
+  let param ppf ({ var } : Parameter.t) =
+    Variable.print ppf var
+  in
+  let params ppf =
+    List.iter (fprintf ppf "@ %a" param) in
   let stub =
     if f.stub then
       " *stub*"
@@ -382,7 +385,7 @@ and print_function_declaration ppf var (f : function_declaration) =
   in
   fprintf ppf "@[<2>(%a%s%s%s%s@ =@ fun@[<2>%a@] ->@ @[<2>%a@])@]@ "
     Variable.print var stub is_a_functor inline specialise
-    idents f.params lam f.body
+    params f.params lam f.body
 
 and print_set_of_closures ppf (set_of_closures : set_of_closures) =
   match set_of_closures with
@@ -1053,7 +1056,7 @@ let create_set_of_closures ~function_decls ~free_vars ~specialised_args
       Variable.Map.fold (fun _fun_var function_decl expected_free_vars ->
           let free_vars =
             Variable.Set.diff function_decl.free_variables
-              (Variable.Set.union (Variable.Set.of_list function_decl.params)
+              (Variable.Set.union (Parameter.var_set function_decl.params)
                 all_fun_vars)
           in
           Variable.Set.union free_vars expected_free_vars)
@@ -1086,7 +1089,7 @@ let create_set_of_closures ~function_decls ~free_vars ~specialised_args
     end;
     let all_params =
       Variable.Map.fold (fun _fun_var function_decl all_params ->
-          Variable.Set.union (Variable.Set.of_list function_decl.params)
+          Variable.Set.union (Parameter.var_set function_decl.params)
             all_params)
         function_decls.funs
         Variable.Set.empty
@@ -1111,7 +1114,7 @@ let create_set_of_closures ~function_decls ~free_vars ~specialised_args
 let used_params function_decl =
   Variable.Set.filter
     (fun param -> Variable.Set.mem param function_decl.free_variables)
-    (Variable.Set.of_list function_decl.params)
+    (Parameter.var_set function_decl.params)
 
 let compare_const (c1:const) (c2:const) =
   match c1, c2 with

--- a/middle_end/flambda.ml
+++ b/middle_end/flambda.ml
@@ -1056,7 +1056,7 @@ let create_set_of_closures ~function_decls ~free_vars ~specialised_args
       Variable.Map.fold (fun _fun_var function_decl expected_free_vars ->
           let free_vars =
             Variable.Set.diff function_decl.free_variables
-              (Variable.Set.union (Parameter.var_set function_decl.params)
+              (Variable.Set.union (Parameter.Set.vars function_decl.params)
                 all_fun_vars)
           in
           Variable.Set.union free_vars expected_free_vars)
@@ -1089,7 +1089,7 @@ let create_set_of_closures ~function_decls ~free_vars ~specialised_args
     end;
     let all_params =
       Variable.Map.fold (fun _fun_var function_decl all_params ->
-          Variable.Set.union (Parameter.var_set function_decl.params)
+          Variable.Set.union (Parameter.Set.vars function_decl.params)
             all_params)
         function_decls.funs
         Variable.Set.empty
@@ -1114,7 +1114,7 @@ let create_set_of_closures ~function_decls ~free_vars ~specialised_args
 let used_params function_decl =
   Variable.Set.filter
     (fun param -> Variable.Set.mem param function_decl.free_variables)
-    (Parameter.var_set function_decl.params)
+    (Parameter.Set.vars function_decl.params)
 
 let compare_const (c1:const) (c2:const) =
   match c1, c2 with

--- a/middle_end/flambda.mli
+++ b/middle_end/flambda.mli
@@ -300,7 +300,7 @@ and function_declarations = private {
 }
 
 and function_declaration = private {
-  params : Variable.t list;
+  params : Parameter.t list;
   body : t;
   (* CR-soon mshinwell: inconsistent naming free_variables/free_vars here and
      above *)
@@ -546,7 +546,7 @@ end
 (** Create a function declaration.  This calculates the free variables and
     symbols occurring in the specified [body]. *)
 val create_function_declaration
-   : params:Variable.t list
+   : params:Parameter.t list
   -> body:t
   -> stub:bool
   -> dbg:Debuginfo.t

--- a/middle_end/flambda_invariants.ml
+++ b/middle_end/flambda_invariants.ml
@@ -303,7 +303,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
             let acceptable_free_variables =
               Variable.Set.union
                 (Variable.Set.union variables_in_closure functions_in_closure)
-                (Variable.Set.of_list params)
+                (Parameter.var_set params)
             in
             let bad =
               Variable.Set.diff free_variables acceptable_free_variables
@@ -315,7 +315,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
             (* Check that parameters are unique across all functions in the
                declaration. *)
             let old_all_params_size = Variable.Set.cardinal all_params in
-            let params = Variable.Set.of_list params in
+            let params = Parameter.var_set params in
             let params_size = Variable.Set.cardinal params in
             let all_params = Variable.Set.union all_params params in
             let all_params_size = Variable.Set.cardinal all_params in

--- a/middle_end/flambda_invariants.ml
+++ b/middle_end/flambda_invariants.ml
@@ -303,7 +303,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
             let acceptable_free_variables =
               Variable.Set.union
                 (Variable.Set.union variables_in_closure functions_in_closure)
-                (Parameter.var_set params)
+                (Parameter.Set.vars params)
             in
             let bad =
               Variable.Set.diff free_variables acceptable_free_variables
@@ -315,7 +315,7 @@ let variable_and_symbol_invariants (program : Flambda.program) =
             (* Check that parameters are unique across all functions in the
                declaration. *)
             let old_all_params_size = Variable.Set.cardinal all_params in
-            let params = Parameter.var_set params in
+            let params = Parameter.Set.vars params in
             let params_size = Variable.Set.cardinal params in
             let all_params = Variable.Set.union all_params params in
             let all_params_size = Variable.Set.cardinal all_params in

--- a/middle_end/flambda_utils.ml
+++ b/middle_end/flambda_utils.ml
@@ -320,7 +320,7 @@ let toplevel_substitution_named sb named =
 
 let make_closure_declaration ~id ~body ~params ~stub : Flambda.t =
   let free_variables = Flambda.free_variables body in
-  let param_set = Variable.Set.of_list params in
+  let param_set = Parameter.var_set params in
   if not (Variable.Set.subset param_set free_variables) then begin
     Misc.fatal_error "Flambda_utils.make_closure_declaration"
   end;
@@ -334,7 +334,7 @@ let make_closure_declaration ~id ~body ~params ~stub : Flambda.t =
      to do something similar to what happens in [Inlining_transforms] now. *)
   let body = toplevel_substitution sb body in
   let subst id = Variable.Map.find id sb in
-  let subst_param var : Parameter.t = { var = subst var } in
+  let subst_param param = Parameter.map_var subst param in
   let function_declaration =
     Flambda.create_function_declaration ~params:(List.map subst_param params)
       ~body ~stub ~dbg:Debuginfo.none ~inline:Default_inline
@@ -856,8 +856,8 @@ let parameters_specialised_to_the_same_variable
         specialised_args)
   in
   Variable.Map.map (fun ({ params; _ } : Flambda.function_declaration) ->
-      List.map (fun (param:Parameter.t) ->
-          match Variable.Map.find param.var specialised_args with
+      List.map (fun param ->
+          match Variable.Map.find (Parameter.var param) specialised_args with
           | exception Not_found -> Not_specialised
           | { var; _ } ->
             Specialised_and_aliased_to

--- a/middle_end/flambda_utils.ml
+++ b/middle_end/flambda_utils.ml
@@ -79,8 +79,6 @@ let compare_const (c1 : Flambda.const) (c2 : Flambda.const) =
   | Char _, _ -> -1
   | _, Char _ -> 1
 
-[@@@ocaml.warning "+9"]
-
 let rec same (l1 : Flambda.t) (l2 : Flambda.t) =
   l1 == l2 || (* it is ok for the string case: if they are physically the same,
                  it is the same original branch *)
@@ -225,8 +223,6 @@ and sameswitch (fs1 : Flambda.switch) (fs2 : Flambda.switch) =
     && Misc.Stdlib.List.equal samecase fs1.consts fs2.consts
     && Misc.Stdlib.List.equal samecase fs1.blocks fs2.blocks
     && Misc.Stdlib.Option.equal same fs1.failaction fs2.failaction
-
-[@@@ocaml.warning "-9"]
 
 let can_be_merged = same
 

--- a/middle_end/flambda_utils.ml
+++ b/middle_end/flambda_utils.ml
@@ -44,7 +44,7 @@ let function_arity (f : Flambda.function_declaration) = List.length f.params
 let variables_bound_by_the_closure cf
       (decls : Flambda.function_declarations) =
   let func = find_declaration cf decls in
-  let params = Parameter.var_set func.params in
+  let params = Parameter.Set.vars func.params in
   let functions = Variable.Map.keys decls.funs in
   Variable.Set.diff
     (Variable.Set.diff func.free_variables params)
@@ -320,7 +320,7 @@ let toplevel_substitution_named sb named =
 
 let make_closure_declaration ~id ~body ~params ~stub : Flambda.t =
   let free_variables = Flambda.free_variables body in
-  let param_set = Parameter.var_set params in
+  let param_set = Parameter.Set.vars params in
   if not (Variable.Set.subset param_set free_variables) then begin
     Misc.fatal_error "Flambda_utils.make_closure_declaration"
   end;
@@ -804,7 +804,7 @@ let closures_required_by_entry_point ~(entry_point : Closure_id.t) ~backend
 
 let all_functions_parameters (function_decls : Flambda.function_declarations) =
   Variable.Map.fold (fun _ ({ params } : Flambda.function_declaration) set ->
-      Variable.Set.union set (Parameter.var_set params))
+      Variable.Set.union set (Parameter.Set.vars params))
     function_decls.funs Variable.Set.empty
 
 let all_free_symbols (function_decls : Flambda.function_declarations) =

--- a/middle_end/flambda_utils.mli
+++ b/middle_end/flambda_utils.mli
@@ -69,7 +69,7 @@ val make_key : Flambda.t -> sharing_key option
 val make_closure_declaration
    : id:Variable.t
   -> body:Flambda.t
-  -> params:Variable.t list
+  -> params:Parameter.t list
   -> stub:bool
   -> Flambda.t
 

--- a/middle_end/freshening.ml
+++ b/middle_end/freshening.ml
@@ -130,6 +130,11 @@ let active_add_variable t id =
   let t = add_sb_var t id id' in
   id', t
 
+let active_add_parameter t param =
+  let param' = Parameter.rename param in
+  let t = add_sb_var t (Parameter.var param) (Parameter.var param') in
+  param', t
+
 let add_variable t id =
   match t with
   | Inactive -> id, t
@@ -138,10 +143,9 @@ let add_variable t id =
      id', Active t
 
 let active_add_parameters' t (params:Parameter.t list) =
-  List.fold_right (fun (id:Parameter.t) (ids, t) ->
-      let id', t = active_add_variable t id.var in
-      let param : Parameter.t = { var = id' } in
-      param :: ids, t)
+  List.fold_right (fun param (params, t) ->
+      let param', t = active_add_parameter t param in
+      param' :: params, t)
     params ([], t)
 
 let add_variables t defs =

--- a/middle_end/freshening.ml
+++ b/middle_end/freshening.ml
@@ -137,10 +137,11 @@ let add_variable t id =
      let id', t = active_add_variable t id in
      id', Active t
 
-let active_add_variables' t ids =
-  List.fold_right (fun id (ids, t) ->
-      let id', t = active_add_variable t id in
-      id' :: ids, t) ids ([], t)
+let active_add_parameters' t (params:Parameter.t list) =
+  List.fold_right (fun (id:Parameter.t) (ids, t) ->
+      let id', t = active_add_variable t id.var in
+      let param : Parameter.t = { var = id' } in
+      param :: ids, t) params ([], t)
 
 let add_variables t defs =
   List.fold_right (fun (id, data) (defs, t) ->
@@ -300,8 +301,8 @@ module Project_var = struct
     | Inactive -> func_decls, subst, t
     | Active subst ->
       let subst_func_decl _fun_id (func_decl : Flambda.function_declaration)
-            subst =
-        let params, subst = active_add_variables' subst func_decl.params in
+          subst =
+        let params, subst = active_add_parameters' subst func_decl.params in
         (* Since all parameters are distinct, even between functions, we can
            just use a single substitution. *)
         let body =

--- a/middle_end/freshening.ml
+++ b/middle_end/freshening.ml
@@ -141,7 +141,8 @@ let active_add_parameters' t (params:Parameter.t list) =
   List.fold_right (fun (id:Parameter.t) (ids, t) ->
       let id', t = active_add_variable t id.var in
       let param : Parameter.t = { var = id' } in
-      param :: ids, t) params ([], t)
+      param :: ids, t)
+    params ([], t)
 
 let add_variables t defs =
   List.fold_right (fun (id, data) (defs, t) ->

--- a/middle_end/inconstant_idents.ml
+++ b/middle_end/inconstant_idents.ml
@@ -439,7 +439,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
             | outer_var ->
               register_implication ~in_nc:(Var outer_var.var)
                 ~implies_in_nc:[Var param])
-          (Parameter.vars ffunc.params);
+          (Parameter.List.vars ffunc.params);
         mark_loop ~toplevel:false [] ffunc.body)
       function_decls.funs
 

--- a/middle_end/inconstant_idents.ml
+++ b/middle_end/inconstant_idents.ml
@@ -439,7 +439,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
             | outer_var ->
               register_implication ~in_nc:(Var outer_var.var)
                 ~implies_in_nc:[Var param])
-          ffunc.params;
+          (Parameter.vars ffunc.params);
         mark_loop ~toplevel:false [] ffunc.body)
       function_decls.funs
 

--- a/middle_end/inline_and_simplify.ml
+++ b/middle_end/inline_and_simplify.ml
@@ -807,8 +807,7 @@ and simplify_partial_application env r ~lhs_of_application
   | Default_specialise -> ()
   end;
   let freshened_params =
-    List.map (fun id -> Variable.rename id.Parameter.var)
-      function_decl.Flambda.params
+    List.map (fun p -> Parameter.rename p) function_decl.Flambda.params
   in
   let applied_args, remaining_args =
     Misc.Stdlib.List.map2_prefix (fun arg id' -> id', arg)
@@ -818,7 +817,7 @@ and simplify_partial_application env r ~lhs_of_application
     let body : Flambda.t =
       Apply {
         func = lhs_of_application;
-        args = freshened_params;
+        args = Parameter.vars freshened_params;
         kind = Direct closure_id_being_applied;
         dbg;
         inline = Default_inline;
@@ -837,8 +836,8 @@ and simplify_partial_application env r ~lhs_of_application
   in
   let with_known_args =
     Flambda_utils.bind
-      ~bindings:(List.map (fun (var, arg) ->
-          var, Flambda.Expr (Var arg)) applied_args)
+      ~bindings:(List.map (fun (param, arg) ->
+          Parameter.var param, Flambda.Expr (Var arg)) applied_args)
       ~body:wrapper_accepting_remaining_args
   in
   simplify env r with_known_args

--- a/middle_end/inline_and_simplify.ml
+++ b/middle_end/inline_and_simplify.ml
@@ -807,7 +807,8 @@ and simplify_partial_application env r ~lhs_of_application
   | Default_specialise -> ()
   end;
   let freshened_params =
-    List.map (fun id -> Variable.rename id) function_decl.Flambda.params
+    List.map (fun id -> Variable.rename id.Parameter.var)
+      function_decl.Flambda.params
   in
   let applied_args, remaining_args =
     Misc.Stdlib.List.map2_prefix (fun arg id' -> id', arg)

--- a/middle_end/inline_and_simplify.ml
+++ b/middle_end/inline_and_simplify.ml
@@ -817,7 +817,7 @@ and simplify_partial_application env r ~lhs_of_application
     let body : Flambda.t =
       Apply {
         func = lhs_of_application;
-        args = Parameter.vars freshened_params;
+        args = Parameter.List.vars freshened_params;
         kind = Direct closure_id_being_applied;
         dbg;
         inline = Default_inline;

--- a/middle_end/inline_and_simplify_aux.ml
+++ b/middle_end/inline_and_simplify_aux.ml
@@ -543,7 +543,7 @@ let prepare_to_simplify_set_of_closures ~env
           match only_for_function_decl with
           | None -> true
           | Some function_decl ->
-            Variable.Set.mem param (Variable.Set.of_list function_decl.params)
+            Variable.Set.mem param (Parameter.var_set function_decl.params)
         in
         if not keep then None
         else
@@ -660,7 +660,7 @@ let populate_closure_approximations
           with Not_found -> (A.value_unknown Other)
         in
         E.add env id approx)
-      env function_decl.params
+      env (Parameter.vars function_decl.params)
   in
   env
 

--- a/middle_end/inline_and_simplify_aux.ml
+++ b/middle_end/inline_and_simplify_aux.ml
@@ -660,7 +660,7 @@ let populate_closure_approximations
           with Not_found -> (A.value_unknown Other)
         in
         E.add env id approx)
-      env (Parameter.vars function_decl.params)
+      env (Parameter.List.vars function_decl.params)
   in
   env
 

--- a/middle_end/inline_and_simplify_aux.ml
+++ b/middle_end/inline_and_simplify_aux.ml
@@ -543,7 +543,7 @@ let prepare_to_simplify_set_of_closures ~env
           match only_for_function_decl with
           | None -> true
           | Some function_decl ->
-            Variable.Set.mem param (Parameter.var_set function_decl.params)
+            Variable.Set.mem param (Parameter.Set.vars function_decl.params)
         in
         if not keep then None
         else

--- a/middle_end/inlining_decision.ml
+++ b/middle_end/inlining_decision.ml
@@ -335,7 +335,7 @@ let specialise env r ~lhs_of_application
          (fun id approx ->
             not ((A.useful approx)
                  && Variable.Map.mem id (Lazy.force invariant_params)))
-         (Parameter.vars function_decl.params) args_approxs)
+         (Parameter.List.vars function_decl.params) args_approxs)
   in
   let always_specialise, never_specialise =
     (* Merge call site annotation and function annotation.

--- a/middle_end/inlining_decision.ml
+++ b/middle_end/inlining_decision.ml
@@ -335,7 +335,7 @@ let specialise env r ~lhs_of_application
          (fun id approx ->
             not ((A.useful approx)
                  && Variable.Map.mem id (Lazy.force invariant_params)))
-         function_decl.params args_approxs)
+         (Parameter.vars function_decl.params) args_approxs)
   in
   let always_specialise, never_specialise =
     (* Merge call site annotation and function annotation.

--- a/middle_end/inlining_transforms.ml
+++ b/middle_end/inlining_transforms.ml
@@ -96,11 +96,7 @@ let copy_of_function's_body_with_freshened_params env
   then
     params, function_decl.body
   else
-    let freshened_params =
-      List.map (fun (p:Parameter.t) : Parameter.t ->
-        { var = Variable.rename p.var })
-        params
-    in
+    let freshened_params = List.map (fun p -> Parameter.rename p) params in
     let subst =
       Variable.Map.of_list
         (List.combine params_var (Parameter.vars freshened_params))

--- a/middle_end/inlining_transforms.ml
+++ b/middle_end/inlining_transforms.ml
@@ -82,6 +82,7 @@ let set_inline_attribute_on_all_apply body inline specialise =
 let copy_of_function's_body_with_freshened_params env
       ~(function_decl : Flambda.function_declaration) =
   let params = function_decl.params in
+  let params_var = Parameter.vars params in
   (* We cannot avoid the substitution in the case where we are inlining
      inside the function itself.  This can happen in two ways: either
      (a) we are inlining the function itself directly inside its declaration;
@@ -90,13 +91,20 @@ let copy_of_function's_body_with_freshened_params env
      original [params] may still be referenced; for (b) we cannot do it
      either since the freshening may already be renaming the parameters for
      the first inlining of the function. *)
-  if E.does_not_bind env params
-    && E.does_not_freshen env params
+  if E.does_not_bind env params_var
+    && E.does_not_freshen env params_var
   then
     params, function_decl.body
   else
-    let freshened_params = List.map (fun var -> Variable.rename var) params in
-    let subst = Variable.Map.of_list (List.combine params freshened_params) in
+    let freshened_params =
+      List.map (fun (p:Parameter.t) : Parameter.t ->
+        { var = Variable.rename p.var })
+        params
+    in
+    let subst =
+      Variable.Map.of_list
+        (List.combine params_var (Parameter.vars freshened_params))
+    in
     let body = Flambda_utils.toplevel_substitution subst function_decl.body in
     freshened_params, body
 
@@ -142,7 +150,8 @@ let inline_by_copying_function_body ~env ~r
   let bindings_for_params_to_args =
     (* Bind the function's parameters to the arguments from the call site. *)
     let args = List.map (fun arg -> Flambda.Expr (Var arg)) args in
-    Flambda_utils.bind ~body ~bindings:(List.combine freshened_params args)
+    Flambda_utils.bind ~body
+      ~bindings:(List.combine (Parameter.vars freshened_params) args)
   in
   (* Add bindings for the variables bound by the closure. *)
   let bindings_for_vars_bound_by_closure_and_params_to_args =
@@ -204,7 +213,7 @@ let inline_by_copying_function_declaration ~env ~r
   let specialised_args_set = Variable.Map.keys specialised_args in
   let worth_specialising_args, specialisable_args, args, args_decl =
     which_function_parameters_can_we_specialise
-      ~params:function_decl.params ~args ~args_approxs
+      ~params:(Parameter.vars function_decl.params) ~args ~args_approxs
       ~invariant_params
       ~specialised_args:specialised_args_set
   in

--- a/middle_end/inlining_transforms.ml
+++ b/middle_end/inlining_transforms.ml
@@ -82,7 +82,7 @@ let set_inline_attribute_on_all_apply body inline specialise =
 let copy_of_function's_body_with_freshened_params env
       ~(function_decl : Flambda.function_declaration) =
   let params = function_decl.params in
-  let param_vars = Parameter.vars params in
+  let param_vars = Parameter.List.vars params in
   (* We cannot avoid the substitution in the case where we are inlining
      inside the function itself.  This can happen in two ways: either
      (a) we are inlining the function itself directly inside its declaration;
@@ -99,7 +99,7 @@ let copy_of_function's_body_with_freshened_params env
     let freshened_params = List.map (fun p -> Parameter.rename p) params in
     let subst =
       Variable.Map.of_list
-        (List.combine param_vars (Parameter.vars freshened_params))
+        (List.combine param_vars (Parameter.List.vars freshened_params))
     in
     let body = Flambda_utils.toplevel_substitution subst function_decl.body in
     freshened_params, body
@@ -147,7 +147,7 @@ let inline_by_copying_function_body ~env ~r
     (* Bind the function's parameters to the arguments from the call site. *)
     let args = List.map (fun arg -> Flambda.Expr (Var arg)) args in
     Flambda_utils.bind ~body
-      ~bindings:(List.combine (Parameter.vars freshened_params) args)
+      ~bindings:(List.combine (Parameter.List.vars freshened_params) args)
   in
   (* Add bindings for the variables bound by the closure. *)
   let bindings_for_vars_bound_by_closure_and_params_to_args =
@@ -209,7 +209,7 @@ let inline_by_copying_function_declaration ~env ~r
   let specialised_args_set = Variable.Map.keys specialised_args in
   let worth_specialising_args, specialisable_args, args, args_decl =
     which_function_parameters_can_we_specialise
-      ~params:(Parameter.vars function_decl.params) ~args ~args_approxs
+      ~params:(Parameter.List.vars function_decl.params) ~args ~args_approxs
       ~invariant_params
       ~specialised_args:specialised_args_set
   in

--- a/middle_end/inlining_transforms.ml
+++ b/middle_end/inlining_transforms.ml
@@ -82,7 +82,7 @@ let set_inline_attribute_on_all_apply body inline specialise =
 let copy_of_function's_body_with_freshened_params env
       ~(function_decl : Flambda.function_declaration) =
   let params = function_decl.params in
-  let params_var = Parameter.vars params in
+  let param_vars = Parameter.vars params in
   (* We cannot avoid the substitution in the case where we are inlining
      inside the function itself.  This can happen in two ways: either
      (a) we are inlining the function itself directly inside its declaration;
@@ -91,15 +91,15 @@ let copy_of_function's_body_with_freshened_params env
      original [params] may still be referenced; for (b) we cannot do it
      either since the freshening may already be renaming the parameters for
      the first inlining of the function. *)
-  if E.does_not_bind env params_var
-    && E.does_not_freshen env params_var
+  if E.does_not_bind env param_vars
+    && E.does_not_freshen env param_vars
   then
     params, function_decl.body
   else
     let freshened_params = List.map (fun p -> Parameter.rename p) params in
     let subst =
       Variable.Map.of_list
-        (List.combine params_var (Parameter.vars freshened_params))
+        (List.combine param_vars (Parameter.vars freshened_params))
     in
     let body = Flambda_utils.toplevel_substitution subst function_decl.body in
     freshened_params, body

--- a/middle_end/invariant_params.ml
+++ b/middle_end/invariant_params.ml
@@ -161,7 +161,7 @@ let analyse_functions ~backend ~param_to_param
   let function_variable_alias = function_variable_alias ~backend decls in
   let param_indexes_by_fun_vars =
     Variable.Map.map (fun (decl : Flambda.function_declaration) ->
-        Array.of_list decl.params)
+      Array.of_list (Parameter.vars decl.params))
       decls.funs
   in
   let find_callee_arg ~callee ~callee_pos =
@@ -200,7 +200,10 @@ let analyse_functions ~backend ~param_to_param
         let new_relation =
           (* We only track dataflow for parameters of functions, not
              arbitrary variables. *)
-          if List.mem caller_arg params then
+          if List.exists
+              (fun ({ var }:Parameter.t) -> Variable.equal var caller_arg)
+              params
+          then
             param_to_param ~caller ~caller_arg ~callee ~callee_arg !relation
           else begin
             used_variable caller_arg;
@@ -252,13 +255,13 @@ let analyse_functions ~backend ~param_to_param
   Variable.Map.iter
     (fun func_var ({ params } : Flambda.function_declaration) ->
        List.iter
-         (fun param ->
-            if Variable.Tbl.mem used_variables param then
+         (fun (param : Parameter.t) ->
+            if Variable.Tbl.mem used_variables param.var then
               relation :=
-                param_to_anywhere ~caller:func_var ~caller_arg:param !relation;
+                param_to_anywhere ~caller:func_var ~caller_arg:param.var !relation;
             if Variable.Tbl.mem escaping_functions func_var then
               relation :=
-                anything_to_param ~callee:func_var ~callee_arg:param !relation)
+                anything_to_param ~callee:func_var ~callee_arg:param.var !relation)
          params)
     decls.funs;
   transitive_closure !relation
@@ -329,7 +332,7 @@ let invariant_params_in_recursion (decls : Flambda.function_declarations)
   in
   let params = Variable.Map.fold (fun _
         ({ params } : Flambda.function_declaration) set ->
-      Variable.Set.union (Variable.Set.of_list params) set)
+      Variable.Set.union (Parameter.var_set params) set)
     decls.funs Variable.Set.empty
   in
   let unchanging = Variable.Set.diff params not_unchanging in
@@ -405,7 +408,7 @@ let unused_arguments (decls : Flambda.function_declarations) ~backend =
               | exception Not_found -> Variable.Set.add param acc
               | Implication _ -> Variable.Set.add param acc
               | Top -> acc)
-           acc decl.Flambda.params)
+           acc (Parameter.vars decl.Flambda.params))
       decls.funs Variable.Set.empty
   in
   if dump then begin

--- a/middle_end/invariant_params.ml
+++ b/middle_end/invariant_params.ml
@@ -161,7 +161,7 @@ let analyse_functions ~backend ~param_to_param
   let function_variable_alias = function_variable_alias ~backend decls in
   let param_indexes_by_fun_vars =
     Variable.Map.map (fun (decl : Flambda.function_declaration) ->
-      Array.of_list (Parameter.vars decl.params))
+      Array.of_list (Parameter.List.vars decl.params))
       decls.funs
   in
   let find_callee_arg ~callee ~callee_pos =
@@ -410,7 +410,7 @@ let unused_arguments (decls : Flambda.function_declarations) ~backend =
               | exception Not_found -> Variable.Set.add param acc
               | Implication _ -> Variable.Set.add param acc
               | Top -> acc)
-           acc (Parameter.vars decl.Flambda.params))
+           acc (Parameter.List.vars decl.Flambda.params))
       decls.funs Variable.Set.empty
   in
   if dump then begin

--- a/middle_end/invariant_params.ml
+++ b/middle_end/invariant_params.ml
@@ -334,7 +334,7 @@ let invariant_params_in_recursion (decls : Flambda.function_declarations)
   in
   let params = Variable.Map.fold (fun _
         ({ params } : Flambda.function_declaration) set ->
-      Variable.Set.union (Parameter.var_set params) set)
+      Variable.Set.union (Parameter.Set.vars params) set)
     decls.funs Variable.Set.empty
   in
   let unchanging = Variable.Set.diff params not_unchanging in

--- a/middle_end/invariant_params.ml
+++ b/middle_end/invariant_params.ml
@@ -201,7 +201,7 @@ let analyse_functions ~backend ~param_to_param
           (* We only track dataflow for parameters of functions, not
              arbitrary variables. *)
           if List.exists
-              (fun ({ var }:Parameter.t) -> Variable.equal var caller_arg)
+              (fun param -> Variable.equal (Parameter.var param) caller_arg)
               params
           then
             param_to_param ~caller ~caller_arg ~callee ~callee_arg !relation
@@ -256,12 +256,14 @@ let analyse_functions ~backend ~param_to_param
     (fun func_var ({ params } : Flambda.function_declaration) ->
        List.iter
          (fun (param : Parameter.t) ->
-            if Variable.Tbl.mem used_variables param.var then
+            if Variable.Tbl.mem used_variables (Parameter.var param) then
               relation :=
-                param_to_anywhere ~caller:func_var ~caller_arg:param.var !relation;
+                param_to_anywhere ~caller:func_var
+                  ~caller_arg:(Parameter.var param) !relation;
             if Variable.Tbl.mem escaping_functions func_var then
               relation :=
-                anything_to_param ~callee:func_var ~callee_arg:param.var !relation)
+                anything_to_param ~callee:func_var
+                  ~callee_arg:(Parameter.var param) !relation)
          params)
     decls.funs;
   transitive_closure !relation

--- a/middle_end/parameter.ml
+++ b/middle_end/parameter.ml
@@ -41,9 +41,13 @@ include Identifiable.Make (struct
     Variable.output o var
   end)
 
+let wrap var = { var }
+
 let var p = p.var
 let vars = List.map var
 let var_set l = Variable.Set.of_list (vars l)
 
 let rename ?current_compilation_unit ?append p =
   { var = Variable.rename ?current_compilation_unit ?append p.var }
+
+let map_var f { var } = { var = f var }

--- a/middle_end/parameter.ml
+++ b/middle_end/parameter.ml
@@ -51,3 +51,7 @@ let rename ?current_compilation_unit ?append p =
   { var = Variable.rename ?current_compilation_unit ?append p.var }
 
 let map_var f { var } = { var = f var }
+
+module List = struct
+  let vars params = List.map (fun { var } -> var) params
+end

--- a/middle_end/parameter.ml
+++ b/middle_end/parameter.ml
@@ -44,3 +44,6 @@ include Identifiable.Make (struct
 let var p = p.var
 let vars = List.map var
 let var_set l = Variable.Set.of_list (vars l)
+
+let rename ?current_compilation_unit ?append p =
+  { var = Variable.rename ?current_compilation_unit ?append p.var }

--- a/middle_end/parameter.ml
+++ b/middle_end/parameter.ml
@@ -27,8 +27,6 @@ type parameter = {
 let wrap var = { var }
 
 let var p = p.var
-let vars = List.map var
-let var_set l = Variable.Set.of_list (vars l)
 
 module M =
   Identifiable.Make (struct
@@ -57,7 +55,7 @@ module Map = M.Map
 module Tbl = M.Tbl
 module Set = struct
   include M.Set
-  let vars = var_set
+  let vars l = Variable.Set.of_list (List.map var l)
 end
 
 let rename ?current_compilation_unit ?append p =

--- a/middle_end/parameter.ml
+++ b/middle_end/parameter.ml
@@ -1,0 +1,46 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2016 OCamlPro SAS                                    *)
+(*   Copyright 2014--2016 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+
+[@@@ocaml.warning "+9"]
+
+type t = {
+  var : Variable.t;
+}
+
+include Identifiable.Make (struct
+  type nonrec t = t
+
+  let compare { var = var1 } { var = var2 } =
+    Variable.compare var1 var2
+
+  let equal { var = var1 } { var = var2 } =
+    Variable.equal var1 var2
+
+  let hash { var } =
+    Variable.hash var
+
+  let print ppf { var } =
+    Variable.print ppf var
+
+  let output o { var } =
+    Variable.output o var
+  end)
+
+let var p = p.var
+let vars = List.map var
+let var_set l = Variable.Set.of_list (vars l)

--- a/middle_end/parameter.ml
+++ b/middle_end/parameter.ml
@@ -17,35 +17,48 @@
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
 [@@@ocaml.warning "+9"]
+(* Warning 9 is enabled to ensure correct update of each function when
+   a field is added to type parameter *)
 
-type t = {
+type parameter = {
   var : Variable.t;
 }
-
-include Identifiable.Make (struct
-  type nonrec t = t
-
-  let compare { var = var1 } { var = var2 } =
-    Variable.compare var1 var2
-
-  let equal { var = var1 } { var = var2 } =
-    Variable.equal var1 var2
-
-  let hash { var } =
-    Variable.hash var
-
-  let print ppf { var } =
-    Variable.print ppf var
-
-  let output o { var } =
-    Variable.output o var
-  end)
 
 let wrap var = { var }
 
 let var p = p.var
 let vars = List.map var
 let var_set l = Variable.Set.of_list (vars l)
+
+module M =
+  Identifiable.Make (struct
+    type t = parameter
+
+    let compare { var = var1 } { var = var2 } =
+      Variable.compare var1 var2
+
+    let equal { var = var1 } { var = var2 } =
+      Variable.equal var1 var2
+
+    let hash { var } =
+      Variable.hash var
+
+    let print ppf { var } =
+      Variable.print ppf var
+
+    let output o { var } =
+      Variable.output o var
+  end)
+
+module T = M.T
+include T
+
+module Map = M.Map
+module Tbl = M.Tbl
+module Set = struct
+  include M.Set
+  let vars = var_set
+end
 
 let rename ?current_compilation_unit ?append p =
   { var = Variable.rename ?current_compilation_unit ?append p.var }

--- a/middle_end/parameter.mli
+++ b/middle_end/parameter.mli
@@ -1,0 +1,27 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2016 OCamlPro SAS                                    *)
+(*   Copyright 2014--2016 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+
+type t = {
+  var : Variable.t;
+}
+
+val var : t -> Variable.t
+val vars : t list -> Variable.t list
+val var_set : t list -> Variable.Set.t
+
+include Identifiable.S with type t := t

--- a/middle_end/parameter.mli
+++ b/middle_end/parameter.mli
@@ -16,9 +16,13 @@
 
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
-type t = {
-  var : Variable.t;
-}
+(** [Parameter.t] carries a unique [Variable.t] used as function parameter.
+    It can also carries annotation on the usage of the variable *)
+
+type t
+
+(** Make a parameter from a variable with default attributes *)
+val wrap : Variable.t -> t
 
 val var : t -> Variable.t
 val vars : t list -> Variable.t list
@@ -30,5 +34,7 @@ val rename
   -> ?append:string
   -> t
   -> t
+
+val map_var : (Variable.t -> Variable.t) -> t -> t
 
 include Identifiable.S with type t := t

--- a/middle_end/parameter.mli
+++ b/middle_end/parameter.mli
@@ -26,7 +26,6 @@ type parameter = t
 val wrap : Variable.t -> t
 
 val var : t -> Variable.t
-val var_set : t list -> Variable.Set.t
 
 (** Rename the inner variable of the parameter *)
 val rename

--- a/middle_end/parameter.mli
+++ b/middle_end/parameter.mli
@@ -17,9 +17,10 @@
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
 (** [Parameter.t] carries a unique [Variable.t] used as function parameter.
-    It can also carries annotation on the usage of the variable *)
+    It can also carry annotations about the usage of the variable. *)
 
 type t
+type parameter = t
 
 (** Make a parameter from a variable with default attributes *)
 val wrap : Variable.t -> t
@@ -36,7 +37,16 @@ val rename
 
 val map_var : (Variable.t -> Variable.t) -> t -> t
 
+module T : Identifiable.Thing with type t = t
+
+module Set : sig
+  include Identifiable.Set with module T := T
+  val vars : parameter list -> Variable.Set.t
+end
+
 include Identifiable.S with type t := t
+                        and module T := T
+                        and module Set := Set
 
 module List : sig
   (** extract variables from a list of parameters, preserving the order *)

--- a/middle_end/parameter.mli
+++ b/middle_end/parameter.mli
@@ -24,4 +24,11 @@ val var : t -> Variable.t
 val vars : t list -> Variable.t list
 val var_set : t list -> Variable.Set.t
 
+(** Rename the inner variable of the parameter *)
+val rename
+   : ?current_compilation_unit:Compilation_unit.t
+  -> ?append:string
+  -> t
+  -> t
+
 include Identifiable.S with type t := t

--- a/middle_end/parameter.mli
+++ b/middle_end/parameter.mli
@@ -25,7 +25,6 @@ type t
 val wrap : Variable.t -> t
 
 val var : t -> Variable.t
-val vars : t list -> Variable.t list
 val var_set : t list -> Variable.Set.t
 
 (** Rename the inner variable of the parameter *)
@@ -38,3 +37,8 @@ val rename
 val map_var : (Variable.t -> Variable.t) -> t -> t
 
 include Identifiable.S with type t := t
+
+module List : sig
+  (** extract variables from a list of parameters, preserving the order *)
+  val vars : t list -> Variable.t list
+end

--- a/middle_end/remove_free_vars_equal_to_args.ml
+++ b/middle_end/remove_free_vars_equal_to_args.ml
@@ -38,7 +38,7 @@ let rewrite_one_function_decl ~(function_decl : Flambda.function_declaration)
             Variable.Set.fold (fun free_var subst ->
                 Variable.Map.add free_var param subst)
               set subst)
-      Variable.Map.empty (Parameter.vars function_decl.params)
+      Variable.Map.empty (Parameter.List.vars function_decl.params)
   in
   if Variable.Map.is_empty params_for_equal_free_vars then
     function_decl

--- a/middle_end/remove_free_vars_equal_to_args.ml
+++ b/middle_end/remove_free_vars_equal_to_args.ml
@@ -38,7 +38,7 @@ let rewrite_one_function_decl ~(function_decl : Flambda.function_declaration)
             Variable.Set.fold (fun free_var subst ->
                 Variable.Map.add free_var param subst)
               set subst)
-      Variable.Map.empty function_decl.params
+      Variable.Map.empty (Parameter.vars function_decl.params)
   in
   if Variable.Map.is_empty params_for_equal_free_vars then
     function_decl

--- a/middle_end/remove_unused_arguments.ml
+++ b/middle_end/remove_unused_arguments.ml
@@ -86,7 +86,7 @@ let make_stub unused var (fun_decl : Flambda.function_declaration)
   let body : Flambda.t =
     Apply {
       func = renamed;
-      args = Parameter.vars args;
+      args = Parameter.List.vars args;
       kind;
       dbg = fun_decl.dbg;
       inline = Default_inline;

--- a/middle_end/remove_unused_arguments.ml
+++ b/middle_end/remove_unused_arguments.ml
@@ -25,15 +25,15 @@ let rename_var var =
 
 let remove_params unused (fun_decl: Flambda.function_declaration) =
   let unused_params, used_params =
-    List.partition (fun v -> Variable.Set.mem v.Parameter.var unused)
+    List.partition (fun v -> Variable.Set.mem (Parameter.var v) unused)
       fun_decl.params
   in
   let unused_params = List.filter (fun v ->
-      Variable.Set.mem v.Parameter.var fun_decl.free_variables) unused_params
+      Variable.Set.mem (Parameter.var v) fun_decl.free_variables) unused_params
   in
   let body =
-    List.fold_left (fun body (param:Parameter.t) ->
-        Flambda.create_let param.var (Const (Const_pointer 0)) body)
+    List.fold_left (fun body param ->
+        Flambda.create_let (Parameter.var param) (Const (Const_pointer 0)) body)
       fun_decl.body
       unused_params
   in
@@ -48,11 +48,11 @@ let make_stub unused var (fun_decl : Flambda.function_declaration)
     List.map (fun param -> param, Parameter.rename param) fun_decl.params
   in
   let used_args' =
-    List.filter (fun ((param:Parameter.t), _) ->
-      not (Variable.Set.mem param.var unused)) args'
+    List.filter (fun (param, _) ->
+      not (Variable.Set.mem (Parameter.var param) unused)) args'
   in
   let args'_var =
-    List.map (fun (p1, p2) -> p1.Parameter.var, p2.Parameter.var) args'
+    List.map (fun (p1, p2) -> Parameter.var p1, Parameter.var p2) args'
   in
   let args_renaming = Variable.Map.of_list args'_var in
   let additional_specialised_args =
@@ -124,7 +124,7 @@ let separate_unused_arguments ~only_specialised
     let funs, additional_specialised_args =
       Variable.Map.fold (fun fun_id (fun_decl : Flambda.function_declaration)
                           (funs, additional_specialised_args) ->
-          if List.exists (fun v -> Variable.Set.mem v.Parameter.var unused)
+          if List.exists (fun v -> Variable.Set.mem (Parameter.var v) unused)
               fun_decl.params
           then begin
             let stub, renamed_fun_id, additional_specialised_args =

--- a/middle_end/remove_unused_arguments.ml
+++ b/middle_end/remove_unused_arguments.ml
@@ -109,7 +109,7 @@ let separate_unused_arguments ~only_specialised
         if decl.stub then
           acc
         else
-          Variable.Set.union acc (Parameter.var_set decl.Flambda.params))
+          Variable.Set.union acc (Parameter.Set.vars decl.Flambda.params))
       function_decls.funs Variable.Set.empty
   in
   let unused = Variable.Set.inter non_stub_arguments unused in

--- a/middle_end/remove_unused_arguments.ml
+++ b/middle_end/remove_unused_arguments.ml
@@ -25,14 +25,15 @@ let rename_var var =
 
 let remove_params unused (fun_decl: Flambda.function_declaration) =
   let unused_params, used_params =
-    List.partition (fun v -> Variable.Set.mem v unused) fun_decl.params
+    List.partition (fun v -> Variable.Set.mem v.Parameter.var unused)
+      fun_decl.params
   in
   let unused_params = List.filter (fun v ->
-      Variable.Set.mem v fun_decl.free_variables) unused_params
+      Variable.Set.mem v.Parameter.var fun_decl.free_variables) unused_params
   in
   let body =
-    List.fold_left (fun body var ->
-        Flambda.create_let var (Const (Const_pointer 0)) body)
+    List.fold_left (fun body (param:Parameter.t) ->
+        Flambda.create_let param.var (Const (Const_pointer 0)) body)
       fun_decl.body
       unused_params
   in
@@ -43,13 +44,20 @@ let remove_params unused (fun_decl: Flambda.function_declaration) =
 let make_stub unused var (fun_decl : Flambda.function_declaration)
     ~specialised_args ~additional_specialised_args =
   let renamed = rename_var var in
+  let rename_param (param:Parameter.t) : Parameter.t =
+    { var = rename_var param.var }
+  in
   let args' =
-    List.map (fun var -> var, rename_var var) fun_decl.params
+    List.map (fun param -> param, rename_param param) fun_decl.params
   in
   let used_args' =
-    List.filter (fun (var, _) -> not (Variable.Set.mem var unused)) args'
+    List.filter (fun ((param:Parameter.t), _) ->
+      not (Variable.Set.mem param.var unused)) args'
   in
-  let args_renaming = Variable.Map.of_list args' in
+  let args'_var =
+    List.map (fun (p1, p2) -> p1.Parameter.var, p2.Parameter.var) args'
+  in
+  let args_renaming = Variable.Map.of_list args'_var in
   let additional_specialised_args =
     List.fold_left (fun additional_specialised_args (original_arg,arg) ->
         match Variable.Map.find original_arg specialised_args with
@@ -74,14 +82,14 @@ let make_stub unused var (fun_decl : Flambda.function_declaration)
               }
           in
           Variable.Map.add arg outer_var additional_specialised_args)
-      additional_specialised_args args'
+      additional_specialised_args args'_var
   in
   let args = List.map (fun (_, var) -> var) used_args' in
   let kind = Flambda.Direct (Closure_id.wrap renamed) in
   let body : Flambda.t =
     Apply {
       func = renamed;
-      args;
+      args = Parameter.vars args;
       kind;
       dbg = fun_decl.dbg;
       inline = Default_inline;
@@ -104,7 +112,7 @@ let separate_unused_arguments ~only_specialised
         if decl.stub then
           acc
         else
-          Variable.Set.union acc (Variable.Set.of_list decl.Flambda.params))
+          Variable.Set.union acc (Parameter.var_set decl.Flambda.params))
       function_decls.funs Variable.Set.empty
   in
   let unused = Variable.Set.inter non_stub_arguments unused in
@@ -119,7 +127,8 @@ let separate_unused_arguments ~only_specialised
     let funs, additional_specialised_args =
       Variable.Map.fold (fun fun_id (fun_decl : Flambda.function_declaration)
                           (funs, additional_specialised_args) ->
-          if List.exists (fun v -> Variable.Set.mem v unused) fun_decl.params
+          if List.exists (fun v -> Variable.Set.mem v.Parameter.var unused)
+              fun_decl.params
           then begin
             let stub, renamed_fun_id, additional_specialised_args =
               make_stub unused fun_id fun_decl

--- a/middle_end/remove_unused_arguments.ml
+++ b/middle_end/remove_unused_arguments.ml
@@ -44,11 +44,8 @@ let remove_params unused (fun_decl: Flambda.function_declaration) =
 let make_stub unused var (fun_decl : Flambda.function_declaration)
     ~specialised_args ~additional_specialised_args =
   let renamed = rename_var var in
-  let rename_param (param:Parameter.t) : Parameter.t =
-    { var = rename_var param.var }
-  in
   let args' =
-    List.map (fun param -> param, rename_param param) fun_decl.params
+    List.map (fun param -> param, Parameter.rename param) fun_decl.params
   in
   let used_args' =
     List.filter (fun ((param:Parameter.t), _) ->

--- a/middle_end/remove_unused_closure_vars.ml
+++ b/middle_end/remove_unused_closure_vars.ml
@@ -93,7 +93,7 @@ let remove_unused_closure_variables ~remove_direct_call_surrogates program =
         (* Remove specialised args that are used by removed functions *)
         let all_remaining_arguments =
           Variable.Map.fold (fun _ { Flambda.params } set ->
-              Variable.Set.union set (Parameter.var_set params))
+              Variable.Set.union set (Parameter.Set.vars params))
             funs Variable.Set.empty
         in
         Variable.Map.filter (fun arg _ ->

--- a/middle_end/remove_unused_closure_vars.ml
+++ b/middle_end/remove_unused_closure_vars.ml
@@ -93,7 +93,7 @@ let remove_unused_closure_variables ~remove_direct_call_surrogates program =
         (* Remove specialised args that are used by removed functions *)
         let all_remaining_arguments =
           Variable.Map.fold (fun _ { Flambda.params } set ->
-              Variable.Set.union set (Variable.Set.of_list params))
+              Variable.Set.union set (Parameter.var_set params))
             funs Variable.Set.empty
         in
         Variable.Map.filter (fun arg _ ->

--- a/middle_end/simple_value_approx.ml
+++ b/middle_end/simple_value_approx.ml
@@ -243,7 +243,7 @@ let create_value_set_of_closures
     lazy (
       let functions = Variable.Map.keys function_decls.funs in
       Variable.Map.map (fun (function_decl : Flambda.function_declaration) ->
-          let params = Parameter.var_set function_decl.params in
+          let params = Parameter.Set.vars function_decl.params in
           let free_vars =
             Variable.Set.diff
               (Variable.Set.diff function_decl.free_variables params)

--- a/middle_end/simple_value_approx.ml
+++ b/middle_end/simple_value_approx.ml
@@ -243,7 +243,7 @@ let create_value_set_of_closures
     lazy (
       let functions = Variable.Map.keys function_decls.funs in
       Variable.Map.map (fun (function_decl : Flambda.function_declaration) ->
-          let params = Variable.Set.of_list function_decl.params in
+          let params = Parameter.var_set function_decl.params in
           let free_vars =
             Variable.Set.diff
               (Variable.Set.diff function_decl.free_variables params)

--- a/utils/identifiable.ml
+++ b/utils/identifiable.ml
@@ -14,9 +14,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Stdlib_map = Map
-module Stdlib_set = Set
-
 module type Thing = sig
   type t
 
@@ -25,6 +22,65 @@ module type Thing = sig
 
   val output : out_channel -> t -> unit
   val print : Format.formatter -> t -> unit
+end
+
+module type Set = sig
+  module T : Set.OrderedType
+  include Set.S
+    with type elt = T.t
+     and type t = Set.Make (T).t
+
+  val output : out_channel -> t -> unit
+  val print : Format.formatter -> t -> unit
+  val to_string : t -> string
+  val of_list : elt list -> t
+  val map : (elt -> elt) -> t -> t
+end
+
+module type Map = sig
+  module T : Map.OrderedType
+  include Map.S
+    with type key = T.t
+     and type 'a t = 'a Map.Make (T).t
+
+  val filter_map : 'a t -> f:(key -> 'a -> 'b option) -> 'b t
+  val of_list : (key * 'a) list -> 'a t
+
+  val disjoint_union : ?eq:('a -> 'a -> bool) -> ?print:(Format.formatter -> 'a -> unit) -> 'a t -> 'a t -> 'a t
+
+  val union_right : 'a t -> 'a t -> 'a t
+
+  val union_left : 'a t -> 'a t -> 'a t
+
+  val union_merge : ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+  val rename : key t -> key -> key
+  val map_keys : (key -> key) -> 'a t -> 'a t
+  val keys : 'a t -> Set.Make(T).t
+  val data : 'a t -> 'a list
+  val of_set : (key -> 'a) -> Set.Make(T).t -> 'a t
+  val transpose_keys_and_data : key t -> key t
+  val transpose_keys_and_data_set : key t -> Set.Make(T).t t
+  val print :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+end
+
+module type Tbl = sig
+  module T : sig
+    type t
+    include Map.OrderedType with type t := t
+    include Hashtbl.HashedType with type t := t
+  end
+  include Hashtbl.S
+    with type key = T.t
+     and type 'a t = 'a Hashtbl.Make (T).t
+
+  val to_list : 'a t -> (T.t * 'a) list
+  val of_list : (T.t * 'a) list -> 'a t
+
+  val to_map : 'a t -> 'a Map.Make(T).t
+  val of_map : 'a Map.Make(T).t -> 'a t
+  val memoize : 'a t -> (key -> 'a) -> key -> 'a
+  val map : 'a t -> ('a -> 'b) -> 'b t
 end
 
 module Pair (A : Thing) (B : Thing) : Thing with type t = A.t * B.t = struct
@@ -183,53 +239,9 @@ module type S = sig
   module T : Thing with type t = t
   include Thing with type t := T.t
 
-  module Set : sig
-    include Stdlib_set.S
-      with type elt = T.t
-      and type t = Make_set (T).t
-
-    val output : out_channel -> t -> unit
-    val print : Format.formatter -> t -> unit
-    val to_string : t -> string
-    val of_list : elt list -> t
-    val map : (elt -> elt) -> t -> t
-  end
-
-  module Map : sig
-    include Stdlib_map.S
-      with type key = T.t
-      and type 'a t = 'a Make_map (T).t
-
-    val filter_map : 'a t -> f:(key -> 'a -> 'b option) -> 'b t
-    val of_list : (key * 'a) list -> 'a t
-    val disjoint_union : ?eq:('a -> 'a -> bool) -> ?print:(Format.formatter -> 'a -> unit) -> 'a t -> 'a t -> 'a t
-    val union_right : 'a t -> 'a t -> 'a t
-    val union_left : 'a t -> 'a t -> 'a t
-    val union_merge : ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
-    val rename : key t -> key -> key
-    val map_keys : (key -> key) -> 'a t -> 'a t
-    val keys : 'a t -> Make_set (T).t
-    val data : 'a t -> 'a list
-    val of_set : (key -> 'a) -> Make_set (T).t -> 'a t
-    val transpose_keys_and_data : key t -> key t
-    val transpose_keys_and_data_set : key t -> Set.t t
-    val print :
-      (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
-  end
-
-  module Tbl : sig
-    include Hashtbl.S
-      with type key = T.t
-      and type 'a t = 'a Hashtbl.Make (T).t
-
-    val to_list : 'a t -> (T.t * 'a) list
-    val of_list : (T.t * 'a) list -> 'a t
-
-    val to_map : 'a t -> 'a Make_map (T).t
-    val of_map : 'a Make_map (T).t -> 'a t
-    val memoize : 'a t -> (key -> 'a) -> key -> 'a
-    val map : 'a t -> ('a -> 'b) -> 'b t
-  end
+  module Set : Set with module T := T
+  module Map : Map with module T := T
+  module Tbl : Tbl with module T := T
 end
 
 module Make (T : Thing) = struct

--- a/utils/identifiable.mli
+++ b/utils/identifiable.mli
@@ -28,69 +28,80 @@ end
 
 module Pair : functor (A : Thing) (B : Thing) -> Thing with type t = A.t * B.t
 
+module type Set = sig
+  module T : Set.OrderedType
+  include Set.S
+    with type elt = T.t
+     and type t = Set.Make (T).t
+
+  val output : out_channel -> t -> unit
+  val print : Format.formatter -> t -> unit
+  val to_string : t -> string
+  val of_list : elt list -> t
+  val map : (elt -> elt) -> t -> t
+end
+
+module type Map = sig
+  module T : Map.OrderedType
+  include Map.S
+    with type key = T.t
+     and type 'a t = 'a Map.Make (T).t
+
+  val filter_map : 'a t -> f:(key -> 'a -> 'b option) -> 'b t
+  val of_list : (key * 'a) list -> 'a t
+
+  (** [disjoint_union m1 m2] contains all bindings from [m1] and
+      [m2]. If some binding is present in both and the associated
+      value is not equal, a Fatal_error is raised *)
+  val disjoint_union : ?eq:('a -> 'a -> bool) -> ?print:(Format.formatter -> 'a -> unit) -> 'a t -> 'a t -> 'a t
+
+  (** [union_right m1 m2] contains all bindings from [m1] and [m2]. If
+      some binding is present in both, the one from [m2] is taken *)
+  val union_right : 'a t -> 'a t -> 'a t
+
+  (** [union_left m1 m2 = union_right m2 m1] *)
+  val union_left : 'a t -> 'a t -> 'a t
+
+  val union_merge : ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+  val rename : key t -> key -> key
+  val map_keys : (key -> key) -> 'a t -> 'a t
+  val keys : 'a t -> Set.Make(T).t
+  val data : 'a t -> 'a list
+  val of_set : (key -> 'a) -> Set.Make(T).t -> 'a t
+  val transpose_keys_and_data : key t -> key t
+  val transpose_keys_and_data_set : key t -> Set.Make(T).t t
+  val print :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+end
+
+module type Tbl = sig
+  module T : sig
+    type t
+    include Map.OrderedType with type t := t
+    include Hashtbl.HashedType with type t := t
+  end
+  include Hashtbl.S
+    with type key = T.t
+     and type 'a t = 'a Hashtbl.Make (T).t
+
+  val to_list : 'a t -> (T.t * 'a) list
+  val of_list : (T.t * 'a) list -> 'a t
+
+  val to_map : 'a t -> 'a Map.Make(T).t
+  val of_map : 'a Map.Make(T).t -> 'a t
+  val memoize : 'a t -> (key -> 'a) -> key -> 'a
+  val map : 'a t -> ('a -> 'b) -> 'b t
+end
+
 module type S = sig
   type t
 
   module T : Thing with type t = t
   include Thing with type t := T.t
 
-  module Set : sig
-    include Set.S
-      with type elt = T.t
-      and type t = Set.Make (T).t
-
-    val output : out_channel -> t -> unit
-    val print : Format.formatter -> t -> unit
-    val to_string : t -> string
-    val of_list : elt list -> t
-    val map : (elt -> elt) -> t -> t
-  end
-
-  module Map : sig
-    include Map.S
-      with type key = T.t
-      and type 'a t = 'a Map.Make (T).t
-
-    val filter_map : 'a t -> f:(key -> 'a -> 'b option) -> 'b t
-    val of_list : (key * 'a) list -> 'a t
-
-    (** [disjoint_union m1 m2] contains all bindings from [m1] and
-        [m2]. If some binding is present in both and the associated
-        value is not equal, a Fatal_error is raised *)
-    val disjoint_union : ?eq:('a -> 'a -> bool) -> ?print:(Format.formatter -> 'a -> unit) -> 'a t -> 'a t -> 'a t
-
-    (** [union_right m1 m2] contains all bindings from [m1] and [m2]. If
-        some binding is present in both, the one from [m2] is taken *)
-    val union_right : 'a t -> 'a t -> 'a t
-
-    (** [union_left m1 m2 = union_right m2 m1] *)
-    val union_left : 'a t -> 'a t -> 'a t
-
-    val union_merge : ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
-    val rename : key t -> key -> key
-    val map_keys : (key -> key) -> 'a t -> 'a t
-    val keys : 'a t -> Set.t
-    val data : 'a t -> 'a list
-    val of_set : (key -> 'a) -> Set.t -> 'a t
-    val transpose_keys_and_data : key t -> key t
-    val transpose_keys_and_data_set : key t -> Set.t t
-    val print :
-      (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
-  end
-
-  module Tbl : sig
-    include Hashtbl.S
-      with type key = T.t
-      and type 'a t = 'a Hashtbl.Make (T).t
-
-    val to_list : 'a t -> (T.t * 'a) list
-    val of_list : (T.t * 'a) list -> 'a t
-
-    val to_map : 'a t -> 'a Map.t
-    val of_map : 'a Map.t -> 'a t
-    val memoize : 'a t -> (key -> 'a) -> key -> 'a
-    val map : 'a t -> ('a -> 'b) -> 'b t
-  end
+  module Set : Set with module T := T
+  module Map : Map with module T := T
+  module Tbl : Tbl with module T := T
 end
 
 module Make (T : Thing) : S with type t := T.t


### PR DESCRIPTION
This will simplify two future patches adding informations to functions parameters

* Per parameter inline annotations
* Function type propagation (in particular for unboxing)