### PR TITLE
Propagate to Lambda type information for function parameters and return

### DIFF
--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -863,7 +863,8 @@ let rec close fenv cenv = function
         let (new_fun, approx) = close fenv cenv
           (Lfunction{
                kind = Curried;
-               params = final_args;
+               return = Pgenval;
+               params = List.map (fun v -> v, Pgenval) final_args;
                body = Lapply{ap_should_be_tailcall=false;
                              ap_loc=loc;
                              ap_func=funct;
@@ -1099,9 +1100,9 @@ and close_functions fenv cenv fun_defs =
     List.flatten
       (List.map
          (function
-           | (id, Lfunction{kind; params; body; attr; loc}) ->
+           | (id, Lfunction{kind; params; return; body; attr; loc}) ->
                Simplif.split_default_wrapper ~id ~kind ~params
-                 ~body ~attr ~loc
+                 ~body ~attr ~loc ~return
            | _ -> assert false
          )
          fun_defs)
@@ -1157,6 +1158,7 @@ and close_functions fenv cenv fun_defs =
   let useless_env = ref initially_closed in
   (* Translate each function definition *)
   let clos_fundef (id, params, body, fundesc, dbg) env_pos =
+    let params = List.map (fun (id, _typ) -> id) params in
     let env_param = Ident.create "env" in
     let cenv_fv =
       build_closure_env env_param (fv_pos - env_pos) fv in

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -507,7 +507,7 @@ let rec comp_expr env exp sz cont =
       let lbl = new_label() in
       let fv = IdentSet.elements(free_variables exp) in
       let to_compile =
-        { params = params; body = body; label = lbl;
+        { params = List.map fst params; body = body; label = lbl;
           free_vars = fv; num_defs = 1; rec_vars = []; rec_pos = 0 } in
       Stack.push to_compile functions_to_compile;
       comp_args env (List.map (fun n -> Lvar n) fv) sz
@@ -529,8 +529,9 @@ let rec comp_expr env exp sz cont =
           | (_id, Lfunction{params; body}) :: rem ->
               let lbl = new_label() in
               let to_compile =
-                { params = params; body = body; label = lbl; free_vars = fv;
-                  num_defs = ndecl; rec_vars = rec_idents; rec_pos = pos} in
+                { params = List.map fst params; body = body; label = lbl;
+                  free_vars = fv; num_defs = ndecl; rec_vars = rec_idents;
+                  rec_pos = pos} in
               Stack.push to_compile functions_to_compile;
               lbl :: comp_fun (pos + 1) rem
           | _ -> assert false in

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -262,7 +262,8 @@ type lambda =
 
 and lfunction =
   { kind: function_kind;
-    params: Ident.t list;
+    params: (Ident.t * value_kind) list;
+    return: value_kind;
     body: lambda;
     attr: function_attribute; (* specified with [@inline] attribute *)
     loc : Location.t; }

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -54,11 +54,17 @@ let boxed_integer_name = function
   | Pint32 -> "int32"
   | Pint64 -> "int64"
 
-let value_kind = function
-  | Pgenval -> ""
-  | Pintval -> "[int]"
-  | Pfloatval -> "[float]"
-  | Pboxedintval bi -> Printf.sprintf "[%s]" (boxed_integer_name bi)
+let value_kind ppf = function
+  | Pgenval -> ()
+  | Pintval -> fprintf ppf "[int]"
+  | Pfloatval -> fprintf ppf "[float]"
+  | Pboxedintval bi -> fprintf ppf "[%s]" (boxed_integer_name bi)
+
+let return_kind ppf = function
+  | Pgenval -> ()
+  | Pintval -> fprintf ppf ": int@ "
+  | Pfloatval -> fprintf ppf ": float@ "
+  | Pboxedintval bi -> fprintf ppf ": %s@ " (boxed_integer_name bi)
 
 let field_kind = function
   | Pgenval -> "*"
@@ -458,34 +464,36 @@ let rec lam ppf = function
         apply_tailcall_attribute ap.ap_should_be_tailcall
         apply_inlined_attribute ap.ap_inlined
         apply_specialised_attribute ap.ap_specialised
-  | Lfunction{kind; params; body; attr} ->
+  | Lfunction{kind; params; return; body; attr} ->
       let pr_params ppf params =
         match kind with
         | Curried ->
-            List.iter (fun param -> fprintf ppf "@ %a" Ident.print param) params
+            List.iter (fun (param, k) ->
+                fprintf ppf "@ %a%a" Ident.print param value_kind k) params
         | Tupled ->
             fprintf ppf " (";
             let first = ref true in
             List.iter
-              (fun param ->
+              (fun (param, k) ->
                 if !first then first := false else fprintf ppf ",@ ";
-                Ident.print ppf param)
+                Ident.print ppf param;
+                value_kind ppf k)
               params;
             fprintf ppf ")" in
-      fprintf ppf "@[<2>(function%a@ %a%a)@]" pr_params params
-        function_attribute attr lam body
+      fprintf ppf "@[<2>(function%a@ %a%a%a)@]" pr_params params
+        function_attribute attr return_kind return lam body
   | Llet(str, k, id, arg, body) ->
       let kind = function
           Alias -> "a" | Strict -> "" | StrictOpt -> "o" | Variable -> "v"
       in
       let rec letbody = function
         | Llet(str, k, id, arg, body) ->
-            fprintf ppf "@ @[<2>%a =%s%s@ %a@]"
-              Ident.print id (kind str) (value_kind k) lam arg;
+            fprintf ppf "@ @[<2>%a =%s%a@ %a@]"
+              Ident.print id (kind str) value_kind k lam arg;
             letbody body
         | expr -> expr in
-      fprintf ppf "@[<2>(let@ @[<hv 1>(@[<2>%a =%s%s@ %a@]"
-        Ident.print id (kind str) (value_kind k) lam arg;
+      fprintf ppf "@[<2>(let@ @[<hv 1>(@[<2>%a =%s%a@ %a@]"
+        Ident.print id (kind str) value_kind k lam arg;
       let expr = letbody body in
       fprintf ppf ")@]@ %a)@]" lam expr
   | Lletrec(id_arg_list, body) ->

--- a/bytecomp/printlambda.mli
+++ b/bytecomp/printlambda.mli
@@ -22,4 +22,5 @@ val lambda: formatter -> lambda -> unit
 val program: formatter -> program -> unit
 val primitive: formatter -> primitive -> unit
 val name_of_primitive : primitive -> string
-val value_kind : value_kind -> string
+val value_kind : formatter -> value_kind -> unit
+val array_kind : array_kind -> string

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -457,13 +457,18 @@ let simplify_lets lam =
       simplif (beta_reduce params body args)
   | Lapply ap -> Lapply {ap with ap_func = simplif ap.ap_func;
                                  ap_args = List.map simplif ap.ap_args}
-  | Lfunction{kind; params; return; body = l; attr; loc} ->
+  | Lfunction{kind; params; return=return1; body = l; attr; loc} ->
       begin match simplif l with
-        Lfunction{kind=Curried; params=params'; return; body; attr; loc}
+        Lfunction{kind=Curried; params=params'; return=return2; body; attr; loc}
         when kind = Curried && optimize ->
+          (* The return type is the type of the value returned after
+             applying all the parameters to the function. The return
+             type of the merged function taking [params @ params'] as
+             parameters is the type returned after applying [params']. *)
+          let return = return2 in
           Lfunction{kind; params = params @ params'; return; body; attr; loc}
       | body ->
-          Lfunction{kind; params; return; body; attr; loc}
+          Lfunction{kind; params; return = return1; body; attr; loc}
       end
   | Llet(_str, _k, v, Lvar w, l2) when optimize ->
       Hashtbl.add subst v (simplif (Lvar w));

--- a/bytecomp/simplif.mli
+++ b/bytecomp/simplif.mli
@@ -25,7 +25,8 @@ val simplify_lambda: string -> lambda -> lambda
 val split_default_wrapper
    : id:Ident.t
   -> kind:function_kind
-  -> params:Ident.t list
+  -> params:(Ident.t * Lambda.value_kind) list
+  -> return:Lambda.value_kind
   -> body:lambda
   -> attr:function_attribute
   -> loc:Location.t

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -1166,16 +1166,17 @@ and transl_apply ?(should_be_tailcall=false) ?(inlined = Default_inline)
         and id_arg = Ident.create "param" in
         let body =
           match build_apply handle ((Lvar id_arg, optional)::args') l with
-            Lfunction{kind = Curried; params = ids; body = lam; attr; loc} ->
+            Lfunction{kind = Curried; params = ids; return;
+                      body = lam; attr; loc} ->
               Lfunction{kind = Curried;
                         params = (id_arg, Pgenval)::ids;
-                        return = Pgenval;
+                        return;
                         body = lam; attr;
                         loc}
-          | Levent(Lfunction{kind = Curried; params = ids;
+          | Levent(Lfunction{kind = Curried; params = ids; return;
                              body = lam; attr; loc}, _) ->
               Lfunction{kind = Curried; params = (id_arg, Pgenval)::ids;
-                        return = Pgenval;
+                        return;
                         body = lam; attr;
                         loc}
           | lam ->

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -441,7 +441,7 @@ let transl_primitive loc p env ty path =
       Lfunction{kind = Curried; params = [parm, Pgenval]; return = Pgenval;
                 body = Matching.inline_lazy_force (Lvar parm) Location.none;
                 loc = loc;
-                attr = default_function_attribute }
+                attr = default_stub_attribute }
   | Ploc kind ->
     let lam = lam_of_loc kind loc in
     begin match p.prim_arity with
@@ -449,7 +449,7 @@ let transl_primitive loc p env ty path =
       | 1 -> (* TODO: we should issue a warning ? *)
         let param = Ident.create "prim" in
         Lfunction{kind = Curried; params = [param, Pgenval]; return = Pgenval;
-                  attr = default_function_attribute;
+                  attr = default_stub_attribute;
                   loc = loc;
                   body = Lprim(Pmakeblock(0, Immutable, None),
                                [lam; Lvar param], loc)}
@@ -462,7 +462,7 @@ let transl_primitive loc p env ty path =
       let params = make_params p.prim_arity in
       let body = Lprim(prim, List.map (fun (id, _) -> Lvar id) params, loc) in
       Lfunction{ kind = Curried; params; return = Pgenval;
-                 attr = default_function_attribute;
+                 attr = default_stub_attribute;
                  loc = loc;
                  body }
 
@@ -711,7 +711,7 @@ and transl_exp0 e =
         let kind = if public_send then Public else Self in
         let obj = Ident.create "obj" and meth = Ident.create "meth" in
         Lfunction{kind = Curried; params = [obj, Pgenval; meth, Pgenval];
-                  return = Pgenval; attr = default_function_attribute;
+                  return = Pgenval; attr = default_stub_attribute;
                   loc = e.exp_loc;
                   body = Lsend(kind, Lvar meth, Lvar obj, [], e.exp_loc)}
       else if p.prim_name = "%sendcache" then
@@ -721,7 +721,7 @@ and transl_exp0 e =
                   params = [obj, Pgenval; meth, Pgenval;
                             cache, Pgenval; pos, Pgenval];
                   return = Pgenval;
-                  attr = default_function_attribute;
+                  attr = default_stub_attribute;
                   loc = e.exp_loc;
                   body = Lsend(Cached, Lvar meth, Lvar obj,
                                [Lvar cache; Lvar pos], e.exp_loc)}
@@ -1181,7 +1181,7 @@ and transl_apply ?(should_be_tailcall=false) ?(inlined = Default_inline)
           | lam ->
               Lfunction{kind = Curried; params = [id_arg, Pgenval];
                         return = Pgenval; body = lam;
-                        attr = default_function_attribute; loc = loc}
+                        attr = default_stub_attribute; loc = loc}
         in
         List.fold_left
           (fun body (id, lam) -> Llet(Strict, Pgenval, id, lam, body))

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -76,7 +76,7 @@ let rec apply_coercion loc strict restr arg =
   | Tcoerce_functor(cc_arg, cc_res) ->
       let param = Ident.create "funarg" in
       name_lambda strict arg (fun id ->
-        Lfunction{kind = Curried; params = [param];
+        Lfunction{kind = Curried; params = [param, Pgenval]; return = Pgenval;
                   attr = { default_function_attribute with
                            is_a_functor = true };
                   loc = loc;
@@ -365,7 +365,8 @@ let rec transl_module cc rootpath mexp =
           oo_wrap mexp.mod_env true
             (function
               | Tcoerce_none ->
-                  Lfunction{kind = Curried; params = [param];
+                  Lfunction{kind = Curried; params = [param, Pgenval];
+                            return = Pgenval;
                             attr = { inline = inline_attribute;
                                      specialise = Default_specialise;
                                      is_a_functor = true;
@@ -374,7 +375,8 @@ let rec transl_module cc rootpath mexp =
                             body = transl_module Tcoerce_none bodypath body}
               | Tcoerce_functor(ccarg, ccres) ->
                   let param' = Ident.create "funarg" in
-                  Lfunction{kind = Curried; params = [param'];
+                  Lfunction{kind = Curried; params = [param', Pgenval];
+                            return = Pgenval;
                             attr = { inline = inline_attribute;
                                      specialise = Default_specialise;
                                      is_a_functor = true;

--- a/bytecomp/typeopt.ml
+++ b/bytecomp/typeopt.ml
@@ -167,6 +167,10 @@ let value_kind env ty =
   | _ ->
       Pgenval
 
+let function_return_value_kind env ty =
+  match is_function_type env ty with
+  | Some (_lhs, rhs) -> value_kind env rhs
+  | None -> Pgenval
 
 let lazy_val_requires_forward env ty =
   match classify env ty with

--- a/bytecomp/typeopt.ml
+++ b/bytecomp/typeopt.ml
@@ -176,3 +176,7 @@ let lazy_val_requires_forward env ty =
   match classify env ty with
   | Any | Float | Lazy -> true
   | Addr | Int -> false
+
+let value_kind_union k1 k2 =
+  if k1 = k2 then k1
+  else Pgenval

--- a/bytecomp/typeopt.mli
+++ b/bytecomp/typeopt.mli
@@ -29,6 +29,7 @@ val array_pattern_kind : Typedtree.pattern -> Lambda.array_kind
 val bigarray_type_kind_and_layout :
       Env.t -> Types.type_expr -> Lambda.bigarray_kind * Lambda.bigarray_layout
 val value_kind : Env.t -> Types.type_expr -> Lambda.value_kind
+val function_return_value_kind : Env.t -> Types.type_expr -> Lambda.value_kind
 
 val lazy_val_requires_forward : Env.t -> Types.type_expr -> bool
   (** Whether a forward block is needed for a lazy thunk on a value, i.e.

--- a/bytecomp/typeopt.mli
+++ b/bytecomp/typeopt.mli
@@ -34,3 +34,8 @@ val function_return_value_kind : Env.t -> Types.type_expr -> Lambda.value_kind
 val lazy_val_requires_forward : Env.t -> Types.type_expr -> bool
   (** Whether a forward block is needed for a lazy thunk on a value, i.e.
       if the value can be represented as a float/forward/lazy *)
+
+val value_kind_union :
+      Lambda.value_kind -> Lambda.value_kind -> Lambda.value_kind
+  (** [value_kind_union k1 k2] is a value_kind at least as general as
+      [k1] and [k2] *)

--- a/middle_end/closure_conversion.ml
+++ b/middle_end/closure_conversion.ml
@@ -41,7 +41,7 @@ let add_default_argument_wrappers lam =
         Lfunction {kind; params; body = fbody; attr; loc}, body) ->
       begin match
         Simplif.split_default_wrapper ~id ~kind ~params
-          ~body:fbody ~attr ~loc
+          ~body:fbody ~return:Pgenval ~attr ~loc
       with
       | [fun_id, def] -> Llet (Alias, Pgenval, fun_id, def, body)
       | [fun_id, def; inner_fun_id, def_inner] ->
@@ -57,7 +57,7 @@ let add_default_argument_wrappers lam =
                (function
                  | (id, Lambda.Lfunction {kind; params; body; attr; loc}) ->
                    Simplif.split_default_wrapper ~id ~kind ~params ~body
-                     ~attr ~loc
+                     ~return:Pgenval ~attr ~loc
                  | _ -> assert false)
                defs)
         in
@@ -205,7 +205,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let set_of_closures =
       let decl =
         Function_decl.create ~let_rec_ident:None ~closure_bound_var ~kind
-          ~params ~body ~attr ~loc
+          ~params:(List.map fst params) ~body ~attr ~loc
       in
       close_functions t env (Function_decls.create [decl])
     in
@@ -251,7 +251,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
             in
             let function_declaration =
               Function_decl.create ~let_rec_ident:(Some let_rec_ident)
-                ~closure_bound_var ~kind ~params ~body
+                ~closure_bound_var ~kind ~params:(List.map fst params) ~body
                 ~attr ~loc
             in
             Some function_declaration
@@ -621,8 +621,8 @@ and close_let_bound_expression t ?let_rec_ident let_bound_var env
        names. *)
     let closure_bound_var = Variable.rename let_bound_var in
     let decl =
-      Function_decl.create ~let_rec_ident ~closure_bound_var ~kind ~params
-        ~body ~attr ~loc
+      Function_decl.create ~let_rec_ident ~closure_bound_var ~kind
+        ~params:(List.map fst params) ~body ~attr ~loc
     in
     let set_of_closures_var =
       Variable.rename let_bound_var ~append:"_set_of_closures"

--- a/middle_end/flambda.ml
+++ b/middle_end/flambda.ml
@@ -240,7 +240,7 @@ let rec lam ppf (flam : t) =
     let print_kind ppf (kind : Lambda.value_kind) =
       match kind with
       | Pgenval -> ()
-      | _ -> Format.fprintf ppf " %s" (Printlambda.value_kind kind)
+      | _ -> Format.fprintf ppf " %a" Printlambda.value_kind kind
     in
     fprintf ppf "@[<2>(let_mutable%a@ @[<2>%a@ %a@]@ %a)@]"
       print_kind contents_kind

--- a/testsuite/tests/translprim/array_spec.ml.reference
+++ b/testsuite/tests/translprim/array_spec.ml.reference
@@ -5,7 +5,7 @@
      addr_a = (makearray[addr] "a" "b" "c"))
     (seq (array.length[int] int_a) (array.length[float] float_a)
       (array.length[addr] addr_a)
-      (function a (array.length[gen] a))
+      (function a : int (array.length[gen] a))
       (array.get[int] int_a 0) (array.get[float] float_a 0)
       (array.get[addr] addr_a 0)
       (function a (array.get[gen] a 0))

--- a/testsuite/tests/translprim/comparison_table.ml.reference
+++ b/testsuite/tests/translprim/comparison_table.ml.reference
@@ -1,85 +1,118 @@
 (setglobal Comparison_table!
   (let
-    (gen_cmp = (function x y (caml_compare x y))
-     int_cmp = (function x y (caml_int_compare x y))
+    (gen_cmp =
+       (function x y : int (caml_compare x y))
+     int_cmp =
+       (function x[int] y[int] : int
+         (caml_int_compare x y))
      bool_cmp =
-       (function x y (caml_int_compare x y))
+       (function x y : int (caml_int_compare x y))
      intlike_cmp =
-       (function x y (caml_int_compare x y))
+       (function x y : int (caml_int_compare x y))
      float_cmp =
-       (function x y (caml_float_compare x y))
+       (function x[float] y[float] : int
+         (caml_float_compare x y))
      string_cmp =
-       (function x y (caml_string_compare x y))
+       (function x y : int (caml_string_compare x y))
      int32_cmp =
-       (function x y (caml_int32_compare x y))
+       (function x[int32] y[int32] : int
+         (caml_int32_compare x y))
      int64_cmp =
-       (function x y (caml_int64_compare x y))
+       (function x[int64] y[int64] : int
+         (caml_int64_compare x y))
      nativeint_cmp =
-       (function x y (caml_nativeint_compare x y))
+       (function x[nativeint] y[nativeint] : int
+         (caml_nativeint_compare x y))
      gen_eq = (function x y (caml_equal x y))
-     int_eq = (function x y (== x y))
+     int_eq = (function x[int] y[int] (== x y))
      bool_eq = (function x y (== x y))
      intlike_eq = (function x y (== x y))
-     float_eq = (function x y (==. x y))
+     float_eq =
+       (function x[float] y[float] (==. x y))
      string_eq =
        (function x y (caml_string_equal x y))
-     int32_eq = (function x y (Int32.== x y))
-     int64_eq = (function x y (Int64.== x y))
+     int32_eq =
+       (function x[int32] y[int32] (Int32.== x y))
+     int64_eq =
+       (function x[int64] y[int64] (Int64.== x y))
      nativeint_eq =
-       (function x y (Nativeint.== x y))
+       (function x[nativeint] y[nativeint]
+         (Nativeint.== x y))
      gen_ne = (function x y (caml_notequal x y))
-     int_ne = (function x y (!= x y))
+     int_ne = (function x[int] y[int] (!= x y))
      bool_ne = (function x y (!= x y))
      intlike_ne = (function x y (!= x y))
-     float_ne = (function x y (!=. x y))
+     float_ne =
+       (function x[float] y[float] (!=. x y))
      string_ne =
        (function x y (caml_string_notequal x y))
-     int32_ne = (function x y (Int32.!= x y))
-     int64_ne = (function x y (Int64.!= x y))
+     int32_ne =
+       (function x[int32] y[int32] (Int32.!= x y))
+     int64_ne =
+       (function x[int64] y[int64] (Int64.!= x y))
      nativeint_ne =
-       (function x y (Nativeint.!= x y))
+       (function x[nativeint] y[nativeint]
+         (Nativeint.!= x y))
      gen_lt = (function x y (caml_lessthan x y))
-     int_lt = (function x y (< x y))
+     int_lt = (function x[int] y[int] (< x y))
      bool_lt = (function x y (< x y))
      intlike_lt = (function x y (< x y))
-     float_lt = (function x y (<. x y))
+     float_lt =
+       (function x[float] y[float] (<. x y))
      string_lt =
        (function x y (caml_string_lessthan x y))
-     int32_lt = (function x y (Int32.< x y))
-     int64_lt = (function x y (Int64.< x y))
-     nativeint_lt = (function x y (Nativeint.< x y))
+     int32_lt =
+       (function x[int32] y[int32] (Int32.< x y))
+     int64_lt =
+       (function x[int64] y[int64] (Int64.< x y))
+     nativeint_lt =
+       (function x[nativeint] y[nativeint]
+         (Nativeint.< x y))
      gen_gt = (function x y (caml_greaterthan x y))
-     int_gt = (function x y (> x y))
+     int_gt = (function x[int] y[int] (> x y))
      bool_gt = (function x y (> x y))
      intlike_gt = (function x y (> x y))
-     float_gt = (function x y (>. x y))
+     float_gt =
+       (function x[float] y[float] (>. x y))
      string_gt =
        (function x y (caml_string_greaterthan x y))
-     int32_gt = (function x y (Int32.> x y))
-     int64_gt = (function x y (Int64.> x y))
-     nativeint_gt = (function x y (Nativeint.> x y))
+     int32_gt =
+       (function x[int32] y[int32] (Int32.> x y))
+     int64_gt =
+       (function x[int64] y[int64] (Int64.> x y))
+     nativeint_gt =
+       (function x[nativeint] y[nativeint]
+         (Nativeint.> x y))
      gen_le = (function x y (caml_lessequal x y))
-     int_le = (function x y (<= x y))
+     int_le = (function x[int] y[int] (<= x y))
      bool_le = (function x y (<= x y))
      intlike_le = (function x y (<= x y))
-     float_le = (function x y (<=. x y))
+     float_le =
+       (function x[float] y[float] (<=. x y))
      string_le =
        (function x y (caml_string_lessequal x y))
-     int32_le = (function x y (Int32.<= x y))
-     int64_le = (function x y (Int64.<= x y))
+     int32_le =
+       (function x[int32] y[int32] (Int32.<= x y))
+     int64_le =
+       (function x[int64] y[int64] (Int64.<= x y))
      nativeint_le =
-       (function x y (Nativeint.<= x y))
+       (function x[nativeint] y[nativeint]
+         (Nativeint.<= x y))
      gen_ge = (function x y (caml_greaterequal x y))
-     int_ge = (function x y (>= x y))
+     int_ge = (function x[int] y[int] (>= x y))
      bool_ge = (function x y (>= x y))
      intlike_ge = (function x y (>= x y))
-     float_ge = (function x y (>=. x y))
+     float_ge =
+       (function x[float] y[float] (>=. x y))
      string_ge =
        (function x y (caml_string_greaterequal x y))
-     int32_ge = (function x y (Int32.>= x y))
-     int64_ge = (function x y (Int64.>= x y))
+     int32_ge =
+       (function x[int32] y[int32] (Int32.>= x y))
+     int64_ge =
+       (function x[int64] y[int64] (Int64.>= x y))
      nativeint_ge =
-       (function x y (Nativeint.>= x y))
+       (function x[nativeint] y[nativeint]
+         (Nativeint.>= x y))
      eta_gen_cmp =
        (function prim prim stub (caml_compare prim prim))
      eta_int_cmp =


### PR DESCRIPTION
Type information about function parameter and return can be useful for various optimizations on flambda and clambda. In particular it helps function parameter unboxing and post-inlining primitive specialization.

@alainfrisch you might be concerned by that.