### PR TITLE
PR#6597:  manual, forward references to languages extensions

### DIFF
--- a/Changes
+++ b/Changes
@@ -94,6 +94,10 @@ Next version (4.05.0):
 
 ### Manual and documentation:
 
+- PR#6597, GPR#1030: add forward references to language extensions
+  that extend non-terminal symbols in the language reference section.
+  (Florian Angeletti, review by Gabriel Scherer)
+
 - GPR#939: activate the caml_example environment in the language
   extensions section of the manual. Convert some existing code
   examples to this format.

--- a/manual/manual/refman/classes.etex
+++ b/manual/manual/refman/classes.etex
@@ -37,6 +37,9 @@ class-field-spec:
    |  'method' 'virtual' 'private' method-name ':' poly-typexpr
    |  'constraint' typexpr '=' typexpr
 \end{syntax}
+See also the following language extensions:
+\hyperref[s:attributes]{attributes} and
+\hyperref[s:extension-nodes]{extension nodes}.
 
 \subsubsection*{Simple class expressions}
 
@@ -186,6 +189,11 @@ class-field:
    |  'constraint' typexpr '=' typexpr
    |  'initializer' expr
 \end{syntax}
+See also the following language extensions:
+\hyperref[s:locally-abstract]{locally abstract types},
+\hyperref[s:explicit-overriding]{explicit overriding in class definitions},
+\hyperref[s:attributes]{attributes} and
+\hyperref[s:extension-nodes]{extension nodes}.
 
 \subsubsection*{Simple class expressions}
 

--- a/manual/manual/refman/const.etex
+++ b/manual/manual/refman/const.etex
@@ -22,6 +22,10 @@ constant:
   | "[|""|]"
   | "`"tag-name
 \end{syntax}
+See also the following language extensions:
+\hyperref[s:ext-integer]{integer literals for types \texttt{int32}, \texttt{int64}
+and \texttt{nativeint}}, \hyperref[s:quoted-strings]{quoted strings}
+and \hyperref[s:extension-literals]{extension literals}.
 
 The syntactic class of constants comprises literals from the four
 base types (integers, floating-point numbers, characters, character

--- a/manual/manual/refman/expr.etex
+++ b/manual/manual/refman/expr.etex
@@ -106,6 +106,16 @@ parameter:
   | '?' label-name ':' pattern
   | '?' label-name ':' '(' pattern [':' typexpr] ['=' expr] ')'
 \end{syntax}
+See also the following language extensions:
+\hyperref[s:local-opens]{local opens},
+\hyperref[s:record-and-object-notations]{record and object notations},
+\hyperref[s:explicit-polymorphic-type]{explicit polymorphic type annotations},
+\hyperref[s-first-class-modules]{first-class modules},
+\hyperref[s:explicit-overriding-open]{overriding in open statements},
+\hyperref[s:bigarray-access]{syntax for Bigarray access},
+\hyperref[s:attributes]{attributes},
+\hyperref[s:extension-nodes]{extension nodes} and
+\hyperref[s:local-exceptions]{local exceptions}.
 
 The table below shows the relative precedences and associativity of
 operators and non-closed constructions. The constructions with higher

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -7,7 +7,7 @@ that are implemented in OCaml, but not described in the
 OCaml reference manual.
 
 \section{Integer literals for types \texttt{int32}, \texttt{int64}
-         and \texttt{nativeint}}
+         and \texttt{nativeint}} \label{s:ext-integer}
 
 (Introduced in Objective Caml 3.07)
 
@@ -2108,7 +2108,7 @@ infix-symbol:
 Operator names starting with a "#" character and containing more than
 one "#" character are reserved for extensions.
 
-\subsection{Extension literals}
+\subsection{Extension literals} \label{s:extension-literals}
 (Introduced in OCaml 4.03)
 \begin{syntax}
 float-literal:

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -381,7 +381,7 @@ is not inferred, and must be given explicitly.
 
 \section{Local opens}
 \ikwd{let\@\texttt{let}}
-\ikwd{open\@\texttt{open}}
+\ikwd{open\@\texttt{open}} \label{s:local-opens}
 
 (Introduced in OCaml 3.12, extended to patterns in 4.04)
 

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -204,7 +204,7 @@ function component of a safe module is applied during this computation
 Note that, in the @specification@ case, the @module-type@s must be
 parenthesized if they use the @'with' mod-constraint@ construct.
 
-\section{Private types}
+\section{Private types}\label{s:private-types}
 \ikwd{private\@\texttt{private}}
 
 Private type declarations in module signatures, of the form
@@ -2139,7 +2139,7 @@ int-literal:
 Int and float literals followed by an one-letter identifier in the
 range @["g".."z"||"G".."Z"]@ are extension-only literals.
 
-\section{Inline records}
+\section{Inline records} \label{s:inline-records}
 (Introduced in OCaml 4.03)
 \begin{syntax}
   constr-args:

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -537,7 +537,7 @@ let id: 'a. 'a -> 'a = fun x -> x + 1;;
 
 \section{Locally abstract types}
 \ikwd{type\@\texttt{type}}
-\ikwd{fun\@\texttt{fun}}
+\ikwd{fun\@\texttt{fun}} \label{s:locally-abstract}
 
 (Introduced in OCaml 3.12, short syntax added in 4.03)
 

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -857,7 +857,7 @@ Note that this function uses an explicit polymorphic annotation to obtain
 polymorphic recursion.
 \fi
 
-\section{Recovering the type of a module}
+\section{Recovering the type of a module} \label{s:module-type-of}
 
 \ikwd{module\@\texttt{module}}
 \ikwd{type\@\texttt{type}}
@@ -915,6 +915,7 @@ it to represent sets internally in a different way.
 \ikwd{with\@\texttt{with}}
 \ikwd{module\@\texttt{module}}
 \ikwd{type\@\texttt{type}}
+\label{s:signature-substitution}
 
 (Introduced in OCaml 3.12)
 

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -436,7 +436,7 @@ For example, @module-path'.['expr']'@ is equivalent to
 @module-path'.(['expr'])'@, and @module-path'.[|' pattern '|]'@ is
 equivalent to @module-path'.([|' pattern '|])'@.
 
-\section{Record and object notations}
+\section{Record and object notations} \label{s:record-and-object-notations}
 \ikwd{with\@\texttt{with}}
 
 (Introduced in OCaml 3.12, object copy notation added in Ocaml 4.03)
@@ -500,7 +500,7 @@ Continuing the "point" example above,
 record patterns may need to be modified after new fields are added to a
 record type.
 
-\section{Explicit polymorphic type annotations}
+\section{Explicit polymorphic type annotations} \label{s:explicit-polymorphic-type}
 \ikwd{let\@\texttt{let}}
 
 (Introduced in OCaml 3.12)
@@ -2186,7 +2186,7 @@ let invalid = function
 
 \section{Local exceptions}
 \ikwd{let\@\texttt{let}}
-\ikwd{exception\@\texttt{exception}}
+\ikwd{exception\@\texttt{exception}} \label{s:local-exceptions}
 
 (Introduced in OCaml 4.04)
 

--- a/manual/manual/refman/lex.etex
+++ b/manual/manual/refman/lex.etex
@@ -211,6 +211,8 @@ operator-char:
         '/' || ':' || '<' || '=' || '>' || '?' || '@' ||
         '^' || '|' || '~'
 \end{syntax}
+See also the following language extension:
+\hyperref[s:ext-ops]{extension operators}.
 
 Sequences of ``operator characters'', such as "<=>" or "!!",
 are read as a single token from the @infix-symbol@ or @prefix-symbol@

--- a/manual/manual/refman/modtypes.etex
+++ b/manual/manual/refman/modtypes.etex
@@ -51,6 +51,13 @@ specification:
         | 'open' module-path
         | 'include' module-type
 \end{syntax}
+See also the following language extensions:
+\hyperref[s:module-type-of]{recovering the type of a module},
+\hyperref[s:signature-substitution]{substitution inside a signature},
+\hyperref[s:module-alias]{type-level module aliases},
+\hyperref[s:attributes]{attributes},
+\hyperref[s:extension-nodes]{extension nodes} and
+\hyperref[s:generative-functors]{generative functors}.
 
 \subsection{Simple module types}
 

--- a/manual/manual/refman/modules.etex
+++ b/manual/manual/refman/modules.etex
@@ -45,6 +45,13 @@ definition:
         | 'open' module-path
         | 'include' module-expr
 \end{syntax}
+See also the following language extensions:
+\hyperref[s-recursive-modules]{recursive modules},
+\hyperref[s-first-class-modules]{first-class modules},
+\hyperref[s:explicit-overriding-open]{overriding in open statements},
+\hyperref[s:attributes]{attributes},
+\hyperref[s:extension-nodes]{extension nodes} and
+\hyperref[s:generative-functors]{generative functors}.
 
 \subsection{Simple module expressions}
 

--- a/manual/manual/refman/patterns.etex
+++ b/manual/manual/refman/patterns.etex
@@ -22,6 +22,12 @@ pattern:
   | '[|' pattern { ';' pattern } [ ';' ] '|]'
   | char-literal '..' char-literal
 \end{syntax}
+See also the following language extensions: \hyperref[s:lazypat]{lazy patterns},
+\hyperref[s:local-opens]{local opens},
+\hyperref[s-first-class-modules]{first-class modules},
+\hyperref[s:attributes]{attributes},
+\hyperref[s:extension-nodes]{extension nodes} and
+\hyperref[s:exception-match]{exception cases in pattern matching}.
 
 The table below shows the relative precedences and associativity of
 operators and non-closed pattern constructions. The constructions with

--- a/manual/manual/refman/typedecl.etex
+++ b/manual/manual/refman/typedecl.etex
@@ -60,6 +60,13 @@ type-constraint:
 \end{syntax}
 \ikwd{mutable\@\texttt{mutable}}
 \ikwd{constraint\@\texttt{constraint}}
+See also the following language extensions:
+\hyperref[s:private-types]{private types},
+\hyperref[s:gadts]{generalized algebraic datatypes},
+\hyperref[s:attributes]{attributes},
+\hyperref[s:extension-nodes]{extension nodes},
+\hyperref[s:extensible-variants]{extensible variant types} and
+\hyperref[s:inline-records]{inline records}.
 
 Type definitions are introduced by the "type" keyword, and
 consist in one or several simple definitions, possibly mutually

--- a/manual/manual/refman/types.etex
+++ b/manual/manual/refman/types.etex
@@ -28,6 +28,10 @@ poly-typexpr:
 method-type:
     method-name ':' poly-typexpr
 \end{syntax}
+See also the following language extensions:
+\hyperref[s-first-class-modules]{first-class modules},
+\hyperref[s:attributes]{attributes} and
+\hyperref[s:extension-nodes]{extension nodes}.
 
 The table below shows the relative precedences and associativity of
 operators and non-closed type constructions. The constructions with


### PR DESCRIPTION
[PR#6597](https://caml.inria.fr/mantis/view.php?id=6597)

This PR adds some forward references to language extensions inside the main language reference section,
with the aim to decrease −at least a little− the fragmentation of the description of the grammar of current OCaml.

More precisely, after each description of non-terminal symbols, this PR references all language extensions
that extends these symbols.

These references are added as plain text rather than footnotes to give them some amount of visibility.     