### PR TITLE
fix make -j again and fix make depend for ocamldoc

### DIFF
--- a/ocamldoc/.depend
+++ b/ocamldoc/.depend
@@ -1,10 +1,10 @@
 generators/odoc_literate.cmo : odoc_info.cmi odoc_html.cmo odoc_gen.cmi \
     odoc_args.cmi
-generators/odoc_literate.cmx : odoc_info.cmx odoc_html.cmx odoc_gen.cmx \
+generators/odoc_literate.cmxs : odoc_info.cmx odoc_html.cmx odoc_gen.cmx \
     odoc_args.cmx
 generators/odoc_todo.cmo : odoc_module.cmo odoc_info.cmi odoc_html.cmo \
     odoc_gen.cmi odoc_args.cmi
-generators/odoc_todo.cmx : odoc_module.cmx odoc_info.cmx odoc_html.cmx \
+generators/odoc_todo.cmxs : odoc_module.cmx odoc_info.cmx odoc_html.cmx \
     odoc_gen.cmx odoc_args.cmx
 odoc.cmo : odoc_messages.cmo odoc_info.cmi odoc_global.cmi odoc_gen.cmi \
     odoc_config.cmi odoc_args.cmi odoc_analyse.cmi

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -424,6 +424,7 @@ depend:
 	$(OCAMLLEX) odoc_lexer.mll
 	$(OCAMLLEX) odoc_ocamlhtml.mll
 	$(OCAMLLEX) odoc_see_lexer.mll
-	$(OCAMLDEP) $(INCLUDES_DEP) *.mll *.mly *.ml *.mli generators/*.ml > .depend
+	$(OCAMLDEP) $(INCLUDES_DEP) *.mll *.mly *.ml *.mli > .depend
+	$(OCAMLDEP) $(INCLUDES_DEP) generators/*.ml | sed -e 's/\.cmx : /.cmxs : /' >> .depend
 
 include .depend


### PR DESCRIPTION
In 928a7a965984ee096bfeb1c3511ff618ec99b074 the fix for
make depend in ocamldoc was wrong, therefore make alldepend
breaks parallel compilation.