### PR TITLE
display the output of -dtimings as a hierarchy

### DIFF
--- a/.depend
+++ b/.depend
@@ -40,8 +40,8 @@ utils/tbl.cmi :
 utils/terminfo.cmo : utils/terminfo.cmi
 utils/terminfo.cmx : utils/terminfo.cmi
 utils/terminfo.cmi :
-utils/timings.cmo : utils/timings.cmi
-utils/timings.cmx : utils/timings.cmi
+utils/timings.cmo : utils/misc.cmi utils/timings.cmi
+utils/timings.cmx : utils/misc.cmx utils/timings.cmi
 utils/timings.cmi :
 utils/warnings.cmo : utils/misc.cmi utils/warnings.cmi
 utils/warnings.cmx : utils/misc.cmx utils/warnings.cmi
@@ -748,7 +748,7 @@ asmcomp/asmgen.cmx : asmcomp/un_anf.cmx bytecomp/translmod.cmx \
     asmcomp/coloring.cmx asmcomp/cmmgen.cmx asmcomp/cmm.cmx \
     asmcomp/closure.cmx utils/clflags.cmx asmcomp/clambda.cmx asmcomp/CSE.cmx \
     asmcomp/build_export_info.cmx asmcomp/asmgen.cmi
-asmcomp/asmgen.cmi : utils/timings.cmi bytecomp/lambda.cmi typing/ident.cmi \
+asmcomp/asmgen.cmi : bytecomp/lambda.cmi typing/ident.cmi \
     middle_end/flambda.cmi asmcomp/cmm.cmi middle_end/backend_intf.cmi
 asmcomp/asmlibrarian.cmo : utils/misc.cmi parsing/location.cmi \
     asmcomp/export_info.cmi utils/config.cmi asmcomp/compilenv.cmi \
@@ -903,7 +903,7 @@ asmcomp/compilenv.cmx : utils/warnings.cmx middle_end/base_types/symbol.cmx \
     middle_end/base_types/compilation_unit.cmx asmcomp/cmx_format.cmi \
     middle_end/base_types/closure_id.cmx utils/clflags.cmx \
     asmcomp/clambda.cmx asmcomp/compilenv.cmi
-asmcomp/compilenv.cmi : utils/timings.cmi middle_end/base_types/symbol.cmi \
+asmcomp/compilenv.cmi : middle_end/base_types/symbol.cmi \
     middle_end/base_types/set_of_closures_id.cmi \
     middle_end/base_types/linkage_name.cmi typing/ident.cmi \
     middle_end/flambda.cmi asmcomp/export_info.cmi \
@@ -1690,8 +1690,8 @@ middle_end/middle_end.cmx : utils/warnings.cmx \
     middle_end/flambda.cmx middle_end/debuginfo.cmx \
     middle_end/base_types/closure_id.cmx middle_end/closure_conversion.cmx \
     utils/clflags.cmx middle_end/backend_intf.cmi middle_end/middle_end.cmi
-middle_end/middle_end.cmi : utils/timings.cmi bytecomp/lambda.cmi \
-    typing/ident.cmi middle_end/flambda.cmi middle_end/backend_intf.cmi
+middle_end/middle_end.cmi : bytecomp/lambda.cmi typing/ident.cmi \
+    middle_end/flambda.cmi middle_end/backend_intf.cmi
 middle_end/pass_wrapper.cmo : utils/clflags.cmi middle_end/pass_wrapper.cmi
 middle_end/pass_wrapper.cmx : utils/clflags.cmx middle_end/pass_wrapper.cmi
 middle_end/pass_wrapper.cmi :
@@ -2120,34 +2120,34 @@ toplevel/opttopdirs.cmx : utils/warnings.cmx typing/types.cmx \
 toplevel/opttopdirs.cmi : parsing/longident.cmi
 toplevel/opttoploop.cmo : utils/warnings.cmi typing/types.cmi \
     typing/typemod.cmi typing/typedtree.cmi typing/typecore.cmi \
-    bytecomp/translmod.cmi utils/timings.cmi bytecomp/simplif.cmi \
-    asmcomp/proc.cmi typing/printtyped.cmi typing/printtyp.cmi \
-    bytecomp/printlambda.cmi parsing/printast.cmi typing/predef.cmi \
-    parsing/pprintast.cmi driver/pparse.cmi typing/path.cmi \
-    parsing/parsetree.cmi parsing/parse.cmi typing/outcometree.cmi \
-    typing/oprint.cmi utils/misc.cmi middle_end/middle_end.cmi \
-    parsing/longident.cmi parsing/location.cmi parsing/lexer.cmi \
-    bytecomp/lambda.cmi typing/includemod.cmi asmcomp/import_approx.cmi \
-    typing/ident.cmi toplevel/genprintval.cmi typing/env.cmi utils/config.cmi \
-    driver/compmisc.cmi asmcomp/compilenv.cmi driver/compdynlink.cmi \
-    utils/clflags.cmi typing/btype.cmi middle_end/backend_intf.cmi \
-    parsing/asttypes.cmi parsing/ast_helper.cmi asmcomp/asmlink.cmi \
-    asmcomp/asmgen.cmi asmcomp/arch.cmo toplevel/opttoploop.cmi
+    bytecomp/translmod.cmi bytecomp/simplif.cmi asmcomp/proc.cmi \
+    typing/printtyped.cmi typing/printtyp.cmi bytecomp/printlambda.cmi \
+    parsing/printast.cmi typing/predef.cmi parsing/pprintast.cmi \
+    driver/pparse.cmi typing/path.cmi parsing/parsetree.cmi parsing/parse.cmi \
+    typing/outcometree.cmi typing/oprint.cmi utils/misc.cmi \
+    middle_end/middle_end.cmi parsing/longident.cmi parsing/location.cmi \
+    parsing/lexer.cmi bytecomp/lambda.cmi typing/includemod.cmi \
+    asmcomp/import_approx.cmi typing/ident.cmi toplevel/genprintval.cmi \
+    typing/env.cmi utils/config.cmi driver/compmisc.cmi asmcomp/compilenv.cmi \
+    driver/compdynlink.cmi utils/clflags.cmi typing/btype.cmi \
+    middle_end/backend_intf.cmi parsing/asttypes.cmi parsing/ast_helper.cmi \
+    asmcomp/asmlink.cmi asmcomp/asmgen.cmi asmcomp/arch.cmo \
+    toplevel/opttoploop.cmi
 toplevel/opttoploop.cmx : utils/warnings.cmx typing/types.cmx \
     typing/typemod.cmx typing/typedtree.cmx typing/typecore.cmx \
-    bytecomp/translmod.cmx utils/timings.cmx bytecomp/simplif.cmx \
-    asmcomp/proc.cmx typing/printtyped.cmx typing/printtyp.cmx \
-    bytecomp/printlambda.cmx parsing/printast.cmx typing/predef.cmx \
-    parsing/pprintast.cmx driver/pparse.cmx typing/path.cmx \
-    parsing/parsetree.cmi parsing/parse.cmx typing/outcometree.cmi \
-    typing/oprint.cmx utils/misc.cmx middle_end/middle_end.cmx \
-    parsing/longident.cmx parsing/location.cmx parsing/lexer.cmx \
-    bytecomp/lambda.cmx typing/includemod.cmx asmcomp/import_approx.cmx \
-    typing/ident.cmx toplevel/genprintval.cmx typing/env.cmx utils/config.cmx \
-    driver/compmisc.cmx asmcomp/compilenv.cmx driver/compdynlink.cmi \
-    utils/clflags.cmx typing/btype.cmx middle_end/backend_intf.cmi \
-    parsing/asttypes.cmi parsing/ast_helper.cmx asmcomp/asmlink.cmx \
-    asmcomp/asmgen.cmx asmcomp/arch.cmx toplevel/opttoploop.cmi
+    bytecomp/translmod.cmx bytecomp/simplif.cmx asmcomp/proc.cmx \
+    typing/printtyped.cmx typing/printtyp.cmx bytecomp/printlambda.cmx \
+    parsing/printast.cmx typing/predef.cmx parsing/pprintast.cmx \
+    driver/pparse.cmx typing/path.cmx parsing/parsetree.cmi parsing/parse.cmx \
+    typing/outcometree.cmi typing/oprint.cmx utils/misc.cmx \
+    middle_end/middle_end.cmx parsing/longident.cmx parsing/location.cmx \
+    parsing/lexer.cmx bytecomp/lambda.cmx typing/includemod.cmx \
+    asmcomp/import_approx.cmx typing/ident.cmx toplevel/genprintval.cmx \
+    typing/env.cmx utils/config.cmx driver/compmisc.cmx asmcomp/compilenv.cmx \
+    driver/compdynlink.cmi utils/clflags.cmx typing/btype.cmx \
+    middle_end/backend_intf.cmi parsing/asttypes.cmi parsing/ast_helper.cmx \
+    asmcomp/asmlink.cmx asmcomp/asmgen.cmx asmcomp/arch.cmx \
+    toplevel/opttoploop.cmi
 toplevel/opttoploop.cmi : utils/warnings.cmi typing/types.cmi \
     typing/path.cmi parsing/parsetree.cmi typing/outcometree.cmi \
     parsing/longident.cmi parsing/location.cmi typing/env.cmi

--- a/Changes
+++ b/Changes
@@ -41,6 +41,10 @@ Working version
 - MPR#1956, GPR#973: tools/check-symbol-names checks for globally
   linked names not namespaced with caml_
   (Stephen Dolan)
+### Internal/compiler-libs changes:
+
+- GPR#1032: display the output of -dtimings as a hierarchy
+  (Valentin Gatien-Baron, review by Gabriel Scherer)
 
 ### Bug fixes
 

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -104,29 +104,28 @@ let (++) x f = f x
 let compile_fundecl (ppf : formatter) fd_cmm =
   Proc.init ();
   Reg.reset();
-  let build = Compilenv.current_build () in
   fd_cmm
-  ++ Timings.(accumulate_time (Selection build)) Selection.fundecl
+  ++ Timings.time ~accumulate:true "selection" Selection.fundecl
   ++ pass_dump_if ppf dump_selection "After instruction selection"
-  ++ Timings.(accumulate_time (Comballoc build)) Comballoc.fundecl
+  ++ Timings.time ~accumulate:true "comballoc" Comballoc.fundecl
   ++ pass_dump_if ppf dump_combine "After allocation combining"
-  ++ Timings.(accumulate_time (CSE build)) CSE.fundecl
+  ++ Timings.time ~accumulate:true "cse" CSE.fundecl
   ++ pass_dump_if ppf dump_cse "After CSE"
-  ++ Timings.(accumulate_time (Liveness build)) (liveness ppf)
-  ++ Timings.(accumulate_time (Deadcode build)) Deadcode.fundecl
+  ++ Timings.time ~accumulate:true "liveness" (liveness ppf)
+  ++ Timings.time ~accumulate:true "deadcode" Deadcode.fundecl
   ++ pass_dump_if ppf dump_live "Liveness analysis"
-  ++ Timings.(accumulate_time (Spill build)) Spill.fundecl
-  ++ Timings.(accumulate_time (Liveness build)) (liveness ppf)
+  ++ Timings.time ~accumulate:true "spill" Spill.fundecl
+  ++ Timings.time ~accumulate:true "liveness" (liveness ppf)
   ++ pass_dump_if ppf dump_spill "After spilling"
-  ++ Timings.(accumulate_time (Split build)) Split.fundecl
+  ++ Timings.time ~accumulate:true "split" Split.fundecl
   ++ pass_dump_if ppf dump_split "After live range splitting"
-  ++ Timings.(accumulate_time (Liveness build)) (liveness ppf)
-  ++ Timings.(accumulate_time (Regalloc build)) (regalloc ppf 1)
-  ++ Timings.(accumulate_time (Linearize build)) Linearize.fundecl
+  ++ Timings.time ~accumulate:true "liveness" (liveness ppf)
+  ++ Timings.time ~accumulate:true "regalloc" (regalloc ppf 1)
+  ++ Timings.time ~accumulate:true "linearize" Linearize.fundecl
   ++ pass_dump_linear_if ppf dump_linear "Linearized code"
-  ++ Timings.(accumulate_time (Scheduling build)) Scheduling.fundecl
+  ++ Timings.time ~accumulate:true "scheduling" Scheduling.fundecl
   ++ pass_dump_linear_if ppf dump_scheduling "After instruction scheduling"
-  ++ Timings.(accumulate_time (Emit build)) Emit.fundecl
+  ++ Timings.time ~accumulate:true "emit" Emit.fundecl
 
 let compile_phrase ppf p =
   if !dump_cmm then fprintf ppf "%a@." Printcmm.phrase p;
@@ -145,7 +144,7 @@ let compile_genfuns ppf f =
        | _ -> ())
     (Cmmgen.generic_functions true [Compilenv.current_unit_infos ()])
 
-let compile_unit ~source_provenance _output_prefix asm_filename keep_asm
+let compile_unit _output_prefix asm_filename keep_asm
       obj_filename gen =
   let create_asm = keep_asm || not !Emitaux.binary_backend_available in
   Emitaux.create_asm_file := create_asm;
@@ -160,7 +159,7 @@ let compile_unit ~source_provenance _output_prefix asm_filename keep_asm
       raise exn
     end;
     let assemble_result =
-      Timings.(time (Assemble source_provenance))
+      Timings.time "assemble"
         (Proc.assemble_file asm_filename) obj_filename
     in
     if assemble_result <> 0
@@ -174,13 +173,12 @@ let set_export_info (ulambda, prealloc, structured_constants, export) =
   Compilenv.set_export_info export;
   (ulambda, prealloc, structured_constants)
 
-let end_gen_implementation ?toplevel ~source_provenance ppf
+let end_gen_implementation ?toplevel ppf
     (clambda:clambda_and_constants) =
   Emit.begin_assembly ();
   clambda
-  ++ Timings.(time (Cmm source_provenance)) Cmmgen.compunit
-  ++ Timings.(time (Compile_phrases source_provenance))
-       (List.iter (compile_phrase ppf))
+  ++ Timings.time "cmm" Cmmgen.compunit
+  ++ Timings.time "compile_phrases" (List.iter (compile_phrase ppf))
   ++ (fun () -> ());
   (match toplevel with None -> () | Some f -> compile_genfuns ppf f);
 
@@ -197,11 +195,11 @@ let end_gen_implementation ?toplevel ~source_provenance ppf
     );
   Emit.end_assembly ()
 
-let flambda_gen_implementation ?toplevel ~source_provenance ~backend ppf
+let flambda_gen_implementation ?toplevel ~backend ppf
     (program:Flambda.program) =
   let export = Build_export_info.build_export_info ~backend program in
   let (clambda, preallocated, constants) =
-    Timings.time (Flambda_pass ("backend", source_provenance)) (fun () ->
+    Timings.time_call "backend" (fun () ->
       (program, export)
       ++ Flambda_to_clambda.convert
       ++ flambda_raw_clambda_dump_if ppf
@@ -211,7 +209,7 @@ let flambda_gen_implementation ?toplevel ~source_provenance ~backend ppf
                 [Cmmgen.compunit_and_constants]. *)
            Un_anf.apply expr ~what:"init_code", preallocated_blocks,
            structured_constants, exported)
-      ++ set_export_info) ()
+      ++ set_export_info)
   in
   let constants =
     List.map (fun (symbol, definition) ->
@@ -220,10 +218,10 @@ let flambda_gen_implementation ?toplevel ~source_provenance ~backend ppf
           definition })
       (Symbol.Map.bindings constants)
   in
-  end_gen_implementation ?toplevel ~source_provenance ppf
+  end_gen_implementation ?toplevel ppf
     (clambda, preallocated, constants)
 
-let lambda_gen_implementation ?toplevel ~source_provenance ppf
+let lambda_gen_implementation ?toplevel ppf
     (lambda:Lambda.program) =
   let clambda = Closure.intro lambda.main_module_block_size lambda.code in
   let preallocated_block =
@@ -238,29 +236,29 @@ let lambda_gen_implementation ?toplevel ~source_provenance ppf
     clambda, [preallocated_block], []
   in
   raw_clambda_dump_if ppf clambda_and_constants;
-  end_gen_implementation ?toplevel ~source_provenance ppf clambda_and_constants
+  end_gen_implementation ?toplevel ppf clambda_and_constants
 
-let compile_implementation_gen ?toplevel ~source_provenance prefixname
+let compile_implementation_gen ?toplevel prefixname
     ~required_globals ppf gen_implementation program =
   let asmfile =
     if !keep_asm_file || !Emitaux.binary_backend_available
     then prefixname ^ ext_asm
     else Filename.temp_file "camlasm" ext_asm
   in
-  compile_unit ~source_provenance prefixname asmfile !keep_asm_file
+  compile_unit prefixname asmfile !keep_asm_file
       (prefixname ^ ext_obj) (fun () ->
         Ident.Set.iter Compilenv.require_global required_globals;
-        gen_implementation ?toplevel ~source_provenance ppf program)
+        gen_implementation ?toplevel ppf program)
 
-let compile_implementation_clambda ?toplevel ~source_provenance prefixname
+let compile_implementation_clambda ?toplevel prefixname
     ppf (program:Lambda.program) =
-  compile_implementation_gen ?toplevel ~source_provenance prefixname
+  compile_implementation_gen ?toplevel prefixname
     ~required_globals:program.Lambda.required_globals
     ppf lambda_gen_implementation program
 
-let compile_implementation_flambda ?toplevel ~source_provenance prefixname
+let compile_implementation_flambda ?toplevel prefixname
     ~required_globals ~backend ppf (program:Flambda.program) =
-  compile_implementation_gen ?toplevel ~source_provenance prefixname
+  compile_implementation_gen ?toplevel prefixname
     ~required_globals ppf (flambda_gen_implementation ~backend) program
 
 (* Error report *)

--- a/asmcomp/asmgen.mli
+++ b/asmcomp/asmgen.mli
@@ -17,7 +17,6 @@
 
 val compile_implementation_flambda :
     ?toplevel:(string -> bool) ->
-    source_provenance:Timings.source_provenance ->
     string ->
     required_globals:Ident.Set.t ->
     backend:(module Backend_intf.S) ->
@@ -25,7 +24,6 @@ val compile_implementation_flambda :
 
 val compile_implementation_clambda :
     ?toplevel:(string -> bool) ->
-    source_provenance:Timings.source_provenance ->
     string ->
     Format.formatter -> Lambda.program -> unit
 
@@ -38,7 +36,6 @@ val report_error: Format.formatter -> error -> unit
 
 
 val compile_unit:
-  source_provenance:Timings.source_provenance ->
   string(*prefixname*) ->
   string(*asm file*) -> bool(*keep asm*) ->
   string(*obj file*) -> (unit -> unit) -> unit

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -81,56 +81,55 @@ let check_units members =
 
 let make_package_object ppf members targetobj targetname coercion
       ~backend =
-  let objtemp =
-    if !Clflags.keep_asm_file
-    then Filename.remove_extension targetobj ^ ".pack" ^ Config.ext_obj
-    else
-      (* Put the full name of the module in the temporary file name
-         to avoid collisions with MSVC's link /lib in case of successive
-         packs *)
-      Filename.temp_file (Compilenv.make_symbol (Some "")) Config.ext_obj in
-  let components =
-    List.map
-      (fun m ->
-        match m.pm_kind with
-        | PM_intf -> None
-        | PM_impl _ -> Some(Ident.create_persistent m.pm_name))
-      members in
-  let module_ident = Ident.create_persistent targetname in
-  let source_provenance = Timings.Pack targetname in
-  let prefixname = Filename.remove_extension objtemp in
-  if Config.flambda then begin
-    let size, lam = Translmod.transl_package_flambda components coercion in
-    let flam =
-      Middle_end.middle_end ppf
-        ~source_provenance
-        ~prefixname
-        ~backend
-        ~size
-        ~filename:targetname
-        ~module_ident
-        ~module_initializer:lam
+  Timings.time_call (Printf.sprintf "pack(%s)" targetname) (fun () ->
+    let objtemp =
+      if !Clflags.keep_asm_file
+      then Filename.remove_extension targetobj ^ ".pack" ^ Config.ext_obj
+      else
+        (* Put the full name of the module in the temporary file name
+           to avoid collisions with MSVC's link /lib in case of successive
+           packs *)
+        Filename.temp_file (Compilenv.make_symbol (Some "")) Config.ext_obj in
+    let components =
+      List.map
+        (fun m ->
+          match m.pm_kind with
+          | PM_intf -> None
+          | PM_impl _ -> Some(Ident.create_persistent m.pm_name))
+        members in
+    let module_ident = Ident.create_persistent targetname in
+    let prefixname = Filename.remove_extension objtemp in
+    if Config.flambda then begin
+      let size, lam = Translmod.transl_package_flambda components coercion in
+      let flam =
+        Middle_end.middle_end ppf
+          ~prefixname
+          ~backend
+          ~size
+          ~filename:targetname
+          ~module_ident
+          ~module_initializer:lam
+      in
+      Asmgen.compile_implementation_flambda
+        prefixname ~backend ~required_globals:Ident.Set.empty ppf flam;
+    end else begin
+      let main_module_block_size, code =
+        Translmod.transl_store_package
+          components (Ident.create_persistent targetname) coercion in
+      Asmgen.compile_implementation_clambda
+        prefixname ppf { Lambda.code; main_module_block_size;
+                         module_ident; required_globals = Ident.Set.empty }
+    end;
+    let objfiles =
+      List.map
+        (fun m -> Filename.remove_extension m.pm_file ^ Config.ext_obj)
+        (List.filter (fun m -> m.pm_kind <> PM_intf) members) in
+    let ok =
+      Ccomp.call_linker Ccomp.Partial targetobj (objtemp :: objfiles) ""
     in
-    Asmgen.compile_implementation_flambda ~source_provenance
-      prefixname ~backend ~required_globals:Ident.Set.empty ppf flam;
-  end else begin
-    let main_module_block_size, code =
-      Translmod.transl_store_package
-        components (Ident.create_persistent targetname) coercion in
-    Asmgen.compile_implementation_clambda ~source_provenance
-      prefixname ppf { Lambda.code; main_module_block_size;
-                       module_ident; required_globals = Ident.Set.empty }
-  end;
-  let objfiles =
-    List.map
-      (fun m -> Filename.remove_extension m.pm_file ^ Config.ext_obj)
-      (List.filter (fun m -> m.pm_kind <> PM_intf) members) in
-  let ok =
-    Ccomp.call_linker Ccomp.Partial targetobj (objtemp :: objfiles) ""
-  in
-  remove_file objtemp;
-  if not ok then raise(Error Linking_error)
-
+    remove_file objtemp;
+    if not ok then raise(Error Linking_error)
+  )
 (* Make the .cmx file for the package *)
 
 let get_export_info ui =
@@ -248,8 +247,7 @@ let package_files ppf initial_env files targetcmx ~backend =
   (* Set the name of the current "input" *)
   Location.input_name := targetcmx;
   (* Set the name of the current compunit *)
-  Compilenv.reset ~source_provenance:(Timings.Pack targetname)
-    ?packname:!Clflags.for_package targetname;
+  Compilenv.reset ?packname:!Clflags.for_package targetname;
   try
     let coercion =
       Typemod.package_units initial_env files targetcmi targetname in

--- a/asmcomp/compilenv.ml
+++ b/asmcomp/compilenv.ml
@@ -41,8 +41,6 @@ let imported_sets_of_closures_table =
   (Set_of_closures_id.Tbl.create 10
    : Flambda.function_declarations option Set_of_closures_id.Tbl.t)
 
-let sourcefile = ref None
-
 module CstMap =
   Map.Make(struct
     type t = Clambda.ustructured_constant
@@ -116,11 +114,10 @@ let make_symbol ?(unitname = current_unit.ui_symbol) idopt =
 let current_unit_linkage_name () =
   Linkage_name.create (make_symbol ~unitname:current_unit.ui_symbol None)
 
-let reset ?packname ~source_provenance:file name =
+let reset ?packname name =
   Hashtbl.clear global_infos_table;
   Set_of_closures_id.Tbl.clear imported_sets_of_closures_table;
   let symbol = symbolname_for_pack packname name in
-  sourcefile := Some file;
   current_unit.ui_name <- name;
   current_unit.ui_symbol <- symbol;
   current_unit.ui_defines <- [symbol];
@@ -147,11 +144,6 @@ let current_unit_infos () =
 
 let current_unit_name () =
   current_unit.ui_name
-
-let current_build () =
-  match !sourcefile with
-  | None -> assert false
-  | Some v -> v
 
 let make_symbol ?(unitname = current_unit.ui_symbol) idopt =
   let prefix = "caml" ^ unitname in

--- a/asmcomp/compilenv.mli
+++ b/asmcomp/compilenv.mli
@@ -29,8 +29,7 @@ val imported_sets_of_closures_table
   : Flambda.function_declarations option Set_of_closures_id.Tbl.t
         (* flambda-only *)
 
-val reset: ?packname:string -> source_provenance:Timings.source_provenance ->
-        string -> unit
+val reset: ?packname:string -> string -> unit
         (* Reset the environment and record the name of the unit being
            compiled (arg).  Optional argument is [-for-pack] prefix. *)
 
@@ -47,10 +46,6 @@ val current_unit_name: unit -> string
 val current_unit_linkage_name: unit -> Linkage_name.t
         (* Return the linkage_name of the unit being compiled.
            flambda-only *)
-
-val current_build: unit -> Timings.source_provenance
-        (* Return the kind of build source being compiled. If it is a
-           file compilation it also provides the filename. *)
 
 val current_unit: unit -> Compilation_unit.t
         (* flambda-only *)

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -27,33 +27,35 @@ open Compenv
 let tool_name = "ocamlc"
 
 let interface ppf sourcefile outputprefix =
-  Compmisc.init_path false;
-  let modulename = module_of_filename ppf sourcefile outputprefix in
-  Env.set_unit_name modulename;
-  let initial_env = Compmisc.initial_env () in
-  let ast = Pparse.parse_interface ~tool_name ppf sourcefile in
+  Timings.time_call sourcefile (fun () ->
+    Compmisc.init_path false;
+    let modulename = module_of_filename ppf sourcefile outputprefix in
+    Env.set_unit_name modulename;
+    let initial_env = Compmisc.initial_env () in
+    let ast = Pparse.parse_interface ~tool_name ppf sourcefile in
 
-  if !Clflags.dump_parsetree then fprintf ppf "%a@." Printast.interface ast;
-  if !Clflags.dump_source then fprintf ppf "%a@." Pprintast.signature ast;
-  Timings.(time_call (Typing sourcefile)) (fun () ->
-    let tsg = Typemod.type_interface sourcefile initial_env ast in
-    if !Clflags.dump_typedtree then fprintf ppf "%a@." Printtyped.interface tsg;
-    let sg = tsg.sig_type in
-    if !Clflags.print_types then
-      Printtyp.wrap_printing_env initial_env (fun () ->
-          fprintf std_formatter "%a@."
-            Printtyp.signature (Typemod.simplify_signature sg));
-    ignore (Includemod.signatures initial_env sg sg);
-    Typecore.force_delayed_checks ();
-    Warnings.check_fatal ();
-    if not !Clflags.print_types then begin
-      let deprecated = Builtin_attributes.deprecated_of_sig ast in
-      let sg =
-        Env.save_signature ~deprecated sg modulename (outputprefix ^ ".cmi")
-      in
-      Typemod.save_signature modulename tsg outputprefix sourcefile
-        initial_env sg ;
-    end
+    if !Clflags.dump_parsetree then fprintf ppf "%a@." Printast.interface ast;
+    if !Clflags.dump_source then fprintf ppf "%a@." Pprintast.signature ast;
+    Timings.(time_call typing) (fun () ->
+      let tsg = Typemod.type_interface sourcefile initial_env ast in
+      if !Clflags.dump_typedtree then fprintf ppf "%a@." Printtyped.interface tsg;
+      let sg = tsg.sig_type in
+      if !Clflags.print_types then
+        Printtyp.wrap_printing_env initial_env (fun () ->
+            fprintf std_formatter "%a@."
+              Printtyp.signature (Typemod.simplify_signature sg));
+      ignore (Includemod.signatures initial_env sg sg);
+      Typecore.force_delayed_checks ();
+      Warnings.check_fatal ();
+      if not !Clflags.print_types then begin
+        let deprecated = Builtin_attributes.deprecated_of_sig ast in
+        let sg =
+          Env.save_signature ~deprecated sg modulename (outputprefix ^ ".cmi")
+        in
+        Typemod.save_signature modulename tsg outputprefix sourcefile
+          initial_env sg ;
+      end
+    )
   )
 
 (* Compile a .ml file *)
@@ -65,51 +67,53 @@ let print_if ppf flag printer arg =
 let (++) x f = f x
 
 let implementation ppf sourcefile outputprefix =
-  Compmisc.init_path false;
-  let modulename = module_of_filename ppf sourcefile outputprefix in
-  Env.set_unit_name modulename;
-  let env = Compmisc.initial_env() in
-  try
-    let (typedtree, coercion) =
-      Pparse.parse_implementation ~tool_name ppf sourcefile
-      ++ print_if ppf Clflags.dump_parsetree Printast.implementation
-      ++ print_if ppf Clflags.dump_source Pprintast.structure
-      ++ Timings.(time (Typing sourcefile))
-          (Typemod.type_implementation sourcefile outputprefix modulename env)
-      ++ print_if ppf Clflags.dump_typedtree
-        Printtyped.implementation_with_coercion
-   in
-    if !Clflags.print_types then begin
-      Warnings.check_fatal ();
-      Stypes.dump (Some (outputprefix ^ ".annot"))
-    end else begin
-      let bytecode, required_globals =
-        (typedtree, coercion)
-        ++ Timings.(time (Transl sourcefile))
-            (Translmod.transl_implementation modulename)
-        ++ Timings.(accumulate_time (Generate sourcefile))
-            (fun { Lambda.code = lambda; required_globals } ->
-              print_if ppf Clflags.dump_rawlambda Printlambda.lambda lambda
-              ++ Simplif.simplify_lambda sourcefile
-              ++ print_if ppf Clflags.dump_lambda Printlambda.lambda
-              ++ Bytegen.compile_implementation modulename
-              ++ print_if ppf Clflags.dump_instr Printinstr.instrlist
-              ++ fun bytecode -> bytecode, required_globals)
-      in
-      let objfile = outputprefix ^ ".cmo" in
-      let oc = open_out_bin objfile in
-      try
-        bytecode
-        ++ Timings.(accumulate_time (Generate sourcefile))
-            (Emitcode.to_file oc modulename objfile ~required_globals);
+  Timings.time_call sourcefile (fun () ->
+    Compmisc.init_path false;
+    let modulename = module_of_filename ppf sourcefile outputprefix in
+    Env.set_unit_name modulename;
+    let env = Compmisc.initial_env() in
+    try
+      let (typedtree, coercion) =
+        Pparse.parse_implementation ~tool_name ppf sourcefile
+        ++ print_if ppf Clflags.dump_parsetree Printast.implementation
+        ++ print_if ppf Clflags.dump_source Pprintast.structure
+        ++ Timings.(time typing)
+            (Typemod.type_implementation sourcefile outputprefix modulename env)
+        ++ print_if ppf Clflags.dump_typedtree
+          Printtyped.implementation_with_coercion
+     in
+      if !Clflags.print_types then begin
         Warnings.check_fatal ();
-        close_out oc;
         Stypes.dump (Some (outputprefix ^ ".annot"))
-      with x ->
-        close_out oc;
-        remove_file objfile;
-        raise x
-    end
-  with x ->
-    Stypes.dump (Some (outputprefix ^ ".annot"));
-    raise x
+      end else begin
+        let bytecode, required_globals =
+          (typedtree, coercion)
+          ++ Timings.(time transl)
+              (Translmod.transl_implementation modulename)
+          ++ Timings.(time ~accumulate:true generate)
+              (fun { Lambda.code = lambda; required_globals } ->
+                print_if ppf Clflags.dump_rawlambda Printlambda.lambda lambda
+                ++ Simplif.simplify_lambda sourcefile
+                ++ print_if ppf Clflags.dump_lambda Printlambda.lambda
+                ++ Bytegen.compile_implementation modulename
+                ++ print_if ppf Clflags.dump_instr Printinstr.instrlist
+                ++ fun bytecode -> bytecode, required_globals)
+        in
+        let objfile = outputprefix ^ ".cmo" in
+        let oc = open_out_bin objfile in
+        try
+          bytecode
+          ++ Timings.(time ~accumulate:true generate)
+              (Emitcode.to_file oc modulename objfile ~required_globals);
+          Warnings.check_fatal ();
+          close_out oc;
+          Stypes.dump (Some (outputprefix ^ ".annot"))
+        with x ->
+          close_out oc;
+          remove_file objfile;
+          raise x
+      end
+    with x ->
+      Stypes.dump (Some (outputprefix ^ ".annot"));
+      raise x
+  )

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -195,7 +195,7 @@ let main () =
     Location.report_exception ppf x;
     exit 2
 
-let _ =
-  Timings.(time All) main ();
+let () =
+  main ();
   if !Clflags.print_timings then Timings.print Format.std_formatter;
   exit 0

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -28,32 +28,34 @@ open Compenv
 let tool_name = "ocamlopt"
 
 let interface ppf sourcefile outputprefix =
-  Compmisc.init_path false;
-  let modulename = module_of_filename ppf sourcefile outputprefix in
-  Env.set_unit_name modulename;
-  let initial_env = Compmisc.initial_env () in
-  let ast = Pparse.parse_interface ~tool_name ppf sourcefile in
-  if !Clflags.dump_parsetree then fprintf ppf "%a@." Printast.interface ast;
-  if !Clflags.dump_source then fprintf ppf "%a@." Pprintast.signature ast;
-  Timings.(time_call (Typing sourcefile)) (fun () ->
-    let tsg = Typemod.type_interface sourcefile initial_env ast in
-    if !Clflags.dump_typedtree then fprintf ppf "%a@." Printtyped.interface tsg;
-    let sg = tsg.sig_type in
-    if !Clflags.print_types then
-      Printtyp.wrap_printing_env initial_env (fun () ->
-          fprintf std_formatter "%a@."
-            Printtyp.signature (Typemod.simplify_signature sg));
-    ignore (Includemod.signatures initial_env sg sg);
-    Typecore.force_delayed_checks ();
-    Warnings.check_fatal ();
-    if not !Clflags.print_types then begin
-      let deprecated = Builtin_attributes.deprecated_of_sig ast in
-      let sg =
-        Env.save_signature ~deprecated sg modulename (outputprefix ^ ".cmi")
-      in
-      Typemod.save_signature modulename tsg outputprefix sourcefile
-        initial_env sg ;
-    end
+  Timings.time_call sourcefile (fun () ->
+    Compmisc.init_path false;
+    let modulename = module_of_filename ppf sourcefile outputprefix in
+    Env.set_unit_name modulename;
+    let initial_env = Compmisc.initial_env () in
+    let ast = Pparse.parse_interface ~tool_name ppf sourcefile in
+    if !Clflags.dump_parsetree then fprintf ppf "%a@." Printast.interface ast;
+    if !Clflags.dump_source then fprintf ppf "%a@." Pprintast.signature ast;
+    Timings.(time_call typing) (fun () ->
+      let tsg = Typemod.type_interface sourcefile initial_env ast in
+      if !Clflags.dump_typedtree then fprintf ppf "%a@." Printtyped.interface tsg;
+      let sg = tsg.sig_type in
+      if !Clflags.print_types then
+        Printtyp.wrap_printing_env initial_env (fun () ->
+            fprintf std_formatter "%a@."
+              Printtyp.signature (Typemod.simplify_signature sg));
+      ignore (Includemod.signatures initial_env sg sg);
+      Typecore.force_delayed_checks ();
+      Warnings.check_fatal ();
+      if not !Clflags.print_types then begin
+        let deprecated = Builtin_attributes.deprecated_of_sig ast in
+        let sg =
+          Env.save_signature ~deprecated sg modulename (outputprefix ^ ".cmi")
+        in
+        Typemod.save_signature modulename tsg outputprefix sourcefile
+          initial_env sg ;
+      end
+    )
   )
 
 (* Compile a .ml file *)
@@ -66,77 +68,78 @@ let (++) x f = f x
 let (+++) (x, y) f = (x, f y)
 
 let implementation ~backend ppf sourcefile outputprefix =
-  let source_provenance = Timings.File sourcefile in
-  Compmisc.init_path true;
-  let modulename = module_of_filename ppf sourcefile outputprefix in
-  Env.set_unit_name modulename;
-  let env = Compmisc.initial_env() in
-  Compilenv.reset ~source_provenance ?packname:!Clflags.for_package modulename;
-  let cmxfile = outputprefix ^ ".cmx" in
-  let objfile = outputprefix ^ ext_obj in
-  let comp ast =
-    let (typedtree, coercion) =
-      ast
-      ++ print_if ppf Clflags.dump_parsetree Printast.implementation
-      ++ print_if ppf Clflags.dump_source Pprintast.structure
-      ++ Timings.(time (Typing sourcefile))
-          (Typemod.type_implementation sourcefile outputprefix modulename env)
-      ++ print_if ppf Clflags.dump_typedtree
-          Printtyped.implementation_with_coercion
-    in
-    if not !Clflags.print_types then begin
-      if Config.flambda then begin
-        if !Clflags.classic_inlining then begin
-          Clflags.default_simplify_rounds := 1;
+  Timings.time_call sourcefile (fun () ->
+    Compmisc.init_path true;
+    let modulename = module_of_filename ppf sourcefile outputprefix in
+    Env.set_unit_name modulename;
+    let env = Compmisc.initial_env() in
+    Compilenv.reset ?packname:!Clflags.for_package modulename;
+    let cmxfile = outputprefix ^ ".cmx" in
+    let objfile = outputprefix ^ ext_obj in
+    let comp ast =
+      let (typedtree, coercion) =
+        ast
+        ++ print_if ppf Clflags.dump_parsetree Printast.implementation
+        ++ print_if ppf Clflags.dump_source Pprintast.structure
+        ++ Timings.(time typing)
+            (Typemod.type_implementation sourcefile outputprefix modulename env)
+        ++ print_if ppf Clflags.dump_typedtree
+            Printtyped.implementation_with_coercion
+      in
+      if not !Clflags.print_types then begin
+        if Config.flambda then begin
+          if !Clflags.classic_inlining then begin
+            Clflags.default_simplify_rounds := 1;
+            Clflags.use_inlining_arguments_set Clflags.classic_arguments;
+            Clflags.unbox_free_vars_of_closures := false;
+            Clflags.unbox_specialised_args := false
+          end;
+          (typedtree, coercion)
+          ++ Timings.(time transl)
+              (Translmod.transl_implementation_flambda modulename)
+          ++ Timings.(time generate)
+            (fun { Lambda.module_ident; main_module_block_size;
+                   required_globals; code } ->
+            ((module_ident, main_module_block_size), code)
+            +++ print_if ppf Clflags.dump_rawlambda Printlambda.lambda
+            +++ Simplif.simplify_lambda sourcefile
+            +++ print_if ppf Clflags.dump_lambda Printlambda.lambda
+            ++ (fun ((module_ident, size), lam) ->
+                Middle_end.middle_end ppf
+                  ~prefixname:outputprefix
+                  ~size
+                  ~filename:sourcefile
+                  ~module_ident
+                  ~backend
+                  ~module_initializer:lam)
+            ++ Asmgen.compile_implementation_flambda
+              outputprefix ~required_globals ~backend ppf;
+            Compilenv.save_unit_info cmxfile)
+        end
+        else begin
           Clflags.use_inlining_arguments_set Clflags.classic_arguments;
-          Clflags.unbox_free_vars_of_closures := false;
-          Clflags.unbox_specialised_args := false
-        end;
-        (typedtree, coercion)
-        ++ Timings.(time (Timings.Transl sourcefile)
-            (Translmod.transl_implementation_flambda modulename))
-        ++ Timings.time (Timings.Generate sourcefile)
-          (fun { Lambda.module_ident; main_module_block_size;
-                 required_globals; code } ->
-          ((module_ident, main_module_block_size), code)
-          +++ print_if ppf Clflags.dump_rawlambda Printlambda.lambda
-          +++ Simplif.simplify_lambda sourcefile
-          +++ print_if ppf Clflags.dump_lambda Printlambda.lambda
-          ++ (fun ((module_ident, size), lam) ->
-              Middle_end.middle_end ppf ~source_provenance
-                ~prefixname:outputprefix
-                ~size
-                ~filename:sourcefile
-                ~module_ident
-                ~backend
-                ~module_initializer:lam)
-          ++ Asmgen.compile_implementation_flambda ~source_provenance
-            outputprefix ~required_globals ~backend ppf;
-          Compilenv.save_unit_info cmxfile)
-      end
-      else begin
-        Clflags.use_inlining_arguments_set Clflags.classic_arguments;
-        (typedtree, coercion)
-        ++ Timings.(time (Transl sourcefile))
-            (Translmod.transl_store_implementation modulename)
-        ++ print_if ppf Clflags.dump_rawlambda Printlambda.program
-        ++ Timings.(time (Generate sourcefile))
-            (fun program ->
-              { program with
-                Lambda.code = Simplif.simplify_lambda sourcefile
-                  program.Lambda.code }
-              ++ print_if ppf Clflags.dump_lambda Printlambda.program
-              ++ Asmgen.compile_implementation_clambda ~source_provenance
-                outputprefix ppf;
-              Compilenv.save_unit_info cmxfile)
-      end
-    end;
-    Warnings.check_fatal ();
-    Stypes.dump (Some (outputprefix ^ ".annot"))
-  in
-  try comp (Pparse.parse_implementation ~tool_name ppf sourcefile)
-  with x ->
-    Stypes.dump (Some (outputprefix ^ ".annot"));
-    remove_file objfile;
-    remove_file cmxfile;
-    raise x
+          (typedtree, coercion)
+          ++ Timings.(time transl)
+              (Translmod.transl_store_implementation modulename)
+          ++ print_if ppf Clflags.dump_rawlambda Printlambda.program
+          ++ Timings.(time generate)
+              (fun program ->
+                { program with
+                  Lambda.code = Simplif.simplify_lambda sourcefile
+                    program.Lambda.code }
+                ++ print_if ppf Clflags.dump_lambda Printlambda.program
+                ++ Asmgen.compile_implementation_clambda
+                  outputprefix ppf;
+                Compilenv.save_unit_info cmxfile)
+        end
+      end;
+      Warnings.check_fatal ();
+      Stypes.dump (Some (outputprefix ^ ".annot"))
+    in
+    try comp (Pparse.parse_implementation ~tool_name ppf sourcefile)
+    with x ->
+      Stypes.dump (Some (outputprefix ^ ".annot"));
+      remove_file objfile;
+      remove_file cmxfile;
+      raise x
+  )

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -306,7 +306,7 @@ let main () =
       Location.report_exception ppf x;
       exit 2
 
-let _ =
-  Timings.(time All) main ();
+let () =
+  main ();
   if !Clflags.print_timings then Timings.print Format.std_formatter;
   exit 0

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -38,7 +38,7 @@ let preprocess sourcefile =
   match !Clflags.preprocessor with
     None -> sourcefile
   | Some pp ->
-      Timings.(time (Dash_pp sourcefile))
+      Timings.time "-pp"
         (call_external_preprocessor sourcefile) pp
 
 
@@ -166,7 +166,6 @@ let parse (type a) (kind : a ast_kind) lexbuf : a =
 let file_aux ppf ~tool_name inputfile (type a) parse_fun invariant_fun
              (kind : a ast_kind) =
   let ast_magic = magic_of_kind kind in
-  let source_file = !Location.input_name in
   let (ic, is_ast_file) = open_and_check_magic inputfile ast_magic in
   let ast =
     try
@@ -182,14 +181,13 @@ let file_aux ppf ~tool_name inputfile (type a) parse_fun invariant_fun
         Location.input_name := inputfile;
         let lexbuf = Lexing.from_channel ic in
         Location.init lexbuf inputfile;
-        Timings.(time_call (Parser source_file)) (fun () ->
-          parse_fun lexbuf)
+        Timings.time_call "parser" (fun () -> parse_fun lexbuf)
       end
     with x -> close_in ic; raise x
   in
   close_in ic;
   let ast =
-    Timings.(time_call (Dash_ppx source_file)) (fun () ->
+    Timings.time_call "-ppx" (fun () ->
       apply_rewriters ~restore:false ~tool_name kind ast) in
   if is_ast_file || !Clflags.all_ppx <> [] then invariant_fun ast;
   ast
@@ -233,10 +231,10 @@ module InterfaceHooks = Misc.MakeHooks(struct
   end)
 
 let parse_implementation ppf ~tool_name sourcefile =
-  Timings.(time_call (Parsing sourcefile)) (fun () ->
+  Timings.time_call "parsing" (fun () ->
     parse_file ~tool_name Ast_invariants.structure
       ImplementationHooks.apply_hooks Structure ppf sourcefile)
 let parse_interface ppf ~tool_name sourcefile =
-  Timings.(time_call (Parsing sourcefile)) (fun () ->
+  Timings.time_call "parsing" (fun () ->
     parse_file ~tool_name Ast_invariants.signature
       InterfaceHooks.apply_hooks Signature ppf sourcefile)

--- a/middle_end/middle_end.ml
+++ b/middle_end/middle_end.ml
@@ -30,154 +30,149 @@ let _dump_function_sizes flam ~backend =
           | None -> assert false)
         set_of_closures.function_decls.funs)
 
-let middle_end ppf ~source_provenance ~prefixname ~backend
+let middle_end ppf ~prefixname ~backend
     ~size
     ~filename
     ~module_ident
     ~module_initializer =
-  let pass_number = ref 0 in
-  let round_number = ref 0 in
-  let check flam =
-    if !Clflags.flambda_invariant_checks then begin
-      try Flambda_invariants.check_exn flam
-      with exn ->
-        Misc.fatal_errorf "After Flambda pass %d, round %d:@.%s:@.%a"
-          !pass_number !round_number (Printexc.to_string exn)
-          Flambda.print_program flam
-    end
-  in
-  let (+-+) flam (name, pass) =
-    incr pass_number;
-    if !Clflags.dump_flambda_verbose then begin
-      Format.fprintf ppf "@.PASS: %s@." name;
-      Format.fprintf ppf "Before pass %d, round %d:@ %a@." !pass_number
-        !round_number Flambda.print_program flam;
-      Format.eprintf "\n@?"
-    end;
-    let timing_pass = (Timings.Flambda_pass (name, source_provenance)) in
-    let flam = Timings.accumulate_time timing_pass pass flam in
-    if !Clflags.flambda_invariant_checks then begin
-      Timings.accumulate_time (Flambda_pass ("check", source_provenance))
-        check flam
-    end;
-    flam
-  in
-  Timings.accumulate_time
-    (Flambda_pass ("middle_end", source_provenance)) (fun () ->
-    let flam =
-      let timing_pass =
-        Timings.Flambda_pass ("closure_conversion", source_provenance)
-      in
-      Timings.accumulate_time timing_pass (fun () ->
+  Timings.time_call "flambda" (fun () ->
+    let pass_number = ref 0 in
+    let round_number = ref 0 in
+    let check flam =
+      if !Clflags.flambda_invariant_checks then begin
+        try Flambda_invariants.check_exn flam
+        with exn ->
+          Misc.fatal_errorf "After Flambda pass %d, round %d:@.%s:@.%a"
+            !pass_number !round_number (Printexc.to_string exn)
+            Flambda.print_program flam
+      end
+    in
+    let (+-+) flam (name, pass) =
+      incr pass_number;
+      if !Clflags.dump_flambda_verbose then begin
+        Format.fprintf ppf "@.PASS: %s@." name;
+        Format.fprintf ppf "Before pass %d, round %d:@ %a@." !pass_number
+          !round_number Flambda.print_program flam;
+        Format.eprintf "\n@?"
+      end;
+      let flam = Timings.time ~accumulate:true name pass flam in
+      if !Clflags.flambda_invariant_checks then begin
+        Timings.time ~accumulate:true "check" check flam
+      end;
+      flam
+    in
+    Timings.time_call ~accumulate:true "middle_end" (fun () ->
+      let flam =
+        Timings.time_call ~accumulate:true "closure_conversion" (fun () ->
           module_initializer
           |> Closure_conversion.lambda_to_flambda ~backend ~module_ident
-                ~size ~filename)
-        ()
-    in
-    if !Clflags.dump_rawflambda
-    then
-      Format.fprintf ppf "After closure conversion:@ %a@."
-        Flambda.print_program flam;
-    check flam;
-    let fast_mode flam =
-      pass_number := 0;
-      let round = 0 in
-      flam
-      +-+ ("lift_lets 1", Lift_code.lift_lets)
-      +-+ ("Lift_constants", Lift_constants.lift_constants ~backend)
-      +-+ ("Share_constants", Share_constants.share_constants)
-      +-+ ("Lift_let_to_initialize_symbol",
-           Lift_let_to_initialize_symbol.lift ~backend)
-      +-+ ("Inline_and_simplify",
-           Inline_and_simplify.run ~never_inline:false ~backend
-             ~prefixname ~round)
-      +-+ ("Remove_unused_closure_vars 2",
-           Remove_unused_closure_vars.remove_unused_closure_variables
-             ~remove_direct_call_surrogates:false)
-      +-+ ("Ref_to_variables",
-           Ref_to_variables.eliminate_ref)
-      +-+ ("Initialize_symbol_to_let_symbol",
-           Initialize_symbol_to_let_symbol.run)
-    in
-    let rec loop flam =
-      pass_number := 0;
-      let round = !round_number in
-      incr round_number;
-      if !round_number > (Clflags.rounds ()) then flam
-      else
+               ~size ~filename)
+      in
+      if !Clflags.dump_rawflambda
+      then
+        Format.fprintf ppf "After closure conversion:@ %a@."
+          Flambda.print_program flam;
+      check flam;
+      let fast_mode flam =
+        pass_number := 0;
+        let round = 0 in
         flam
-        (* Beware: [Lift_constants] must be run before any pass that might
-           duplicate strings. *)
         +-+ ("lift_lets 1", Lift_code.lift_lets)
         +-+ ("Lift_constants", Lift_constants.lift_constants ~backend)
         +-+ ("Share_constants", Share_constants.share_constants)
-        +-+ ("Remove_unused_program_constructs",
-             Remove_unused_program_constructs.remove_unused_program_constructs)
         +-+ ("Lift_let_to_initialize_symbol",
              Lift_let_to_initialize_symbol.lift ~backend)
-        +-+ ("lift_lets 2", Lift_code.lift_lets)
-        +-+ ("Remove_unused_closure_vars 1",
-             Remove_unused_closure_vars.remove_unused_closure_variables
-              ~remove_direct_call_surrogates:false)
         +-+ ("Inline_and_simplify",
              Inline_and_simplify.run ~never_inline:false ~backend
                ~prefixname ~round)
         +-+ ("Remove_unused_closure_vars 2",
              Remove_unused_closure_vars.remove_unused_closure_variables
-              ~remove_direct_call_surrogates:false)
-        +-+ ("lift_lets 3", Lift_code.lift_lets)
-        +-+ ("Inline_and_simplify noinline",
-             Inline_and_simplify.run ~never_inline:true ~backend
-              ~prefixname ~round)
-        +-+ ("Remove_unused_closure_vars 3",
-             Remove_unused_closure_vars.remove_unused_closure_variables
-              ~remove_direct_call_surrogates:false)
+               ~remove_direct_call_surrogates:false)
         +-+ ("Ref_to_variables",
              Ref_to_variables.eliminate_ref)
         +-+ ("Initialize_symbol_to_let_symbol",
              Initialize_symbol_to_let_symbol.run)
-        |> loop
-    in
-    let back_end flam =
-      flam
-      +-+ ("Remove_unused_closure_vars",
-           Remove_unused_closure_vars.remove_unused_closure_variables
-             ~remove_direct_call_surrogates:true)
-      +-+ ("Lift_constants", Lift_constants.lift_constants ~backend)
-      +-+ ("Share_constants", Share_constants.share_constants)
-      +-+ ("Remove_unused_program_constructs",
-        Remove_unused_program_constructs.remove_unused_program_constructs)
-    in
-    let flam =
-      if !Clflags.classic_inlining then
-        fast_mode flam
-      else
-        loop flam
-    in
-    let flam = back_end flam in
-    (* Check that there aren't any unused "always inline" attributes. *)
-    Flambda_iterators.iter_apply_on_program flam ~f:(fun apply ->
-        match apply.inline with
-        | Default_inline | Never_inline -> ()
-        | Always_inline ->
-          (* CR-someday mshinwell: consider a different error message if
-             this triggers as a result of the propagation of a user's
-             attribute into the second part of an over application
-             (inline_and_simplify.ml line 710). *)
-          Location.prerr_warning (Debuginfo.to_location apply.dbg)
-            (Warnings.Inlining_impossible "[@inlined] attribute was not \
-              used on this function application (the optimizer did not \
-              know what function was being applied)")
-        | Unroll _ ->
-          Location.prerr_warning (Debuginfo.to_location apply.dbg)
-            (Warnings.Inlining_impossible "[@unroll] attribute was not \
-              used on this function application (the optimizer did not \
-              know what function was being applied)"));
-    if !Clflags.dump_flambda
-    then
-      Format.fprintf ppf "End of middle end:@ %a@."
-        Flambda.print_program flam;
-    check flam;
-    (* CR-someday mshinwell: add -d... option for this *)
-    (* dump_function_sizes flam ~backend; *)
-    flam) ();
+      in
+      let rec loop flam =
+        pass_number := 0;
+        let round = !round_number in
+        incr round_number;
+        if !round_number > (Clflags.rounds ()) then flam
+        else
+          flam
+          (* Beware: [Lift_constants] must be run before any pass that might
+             duplicate strings. *)
+          +-+ ("lift_lets 1", Lift_code.lift_lets)
+          +-+ ("Lift_constants", Lift_constants.lift_constants ~backend)
+          +-+ ("Share_constants", Share_constants.share_constants)
+          +-+ ("Remove_unused_program_constructs",
+               Remove_unused_program_constructs.remove_unused_program_constructs)
+          +-+ ("Lift_let_to_initialize_symbol",
+               Lift_let_to_initialize_symbol.lift ~backend)
+          +-+ ("lift_lets 2", Lift_code.lift_lets)
+          +-+ ("Remove_unused_closure_vars 1",
+               Remove_unused_closure_vars.remove_unused_closure_variables
+                ~remove_direct_call_surrogates:false)
+          +-+ ("Inline_and_simplify",
+               Inline_and_simplify.run ~never_inline:false ~backend
+                 ~prefixname ~round)
+          +-+ ("Remove_unused_closure_vars 2",
+               Remove_unused_closure_vars.remove_unused_closure_variables
+                ~remove_direct_call_surrogates:false)
+          +-+ ("lift_lets 3", Lift_code.lift_lets)
+          +-+ ("Inline_and_simplify noinline",
+               Inline_and_simplify.run ~never_inline:true ~backend
+                ~prefixname ~round)
+          +-+ ("Remove_unused_closure_vars 3",
+               Remove_unused_closure_vars.remove_unused_closure_variables
+                ~remove_direct_call_surrogates:false)
+          +-+ ("Ref_to_variables",
+               Ref_to_variables.eliminate_ref)
+          +-+ ("Initialize_symbol_to_let_symbol",
+               Initialize_symbol_to_let_symbol.run)
+          |> loop
+      in
+      let back_end flam =
+        flam
+        +-+ ("Remove_unused_closure_vars",
+             Remove_unused_closure_vars.remove_unused_closure_variables
+               ~remove_direct_call_surrogates:true)
+        +-+ ("Lift_constants", Lift_constants.lift_constants ~backend)
+        +-+ ("Share_constants", Share_constants.share_constants)
+        +-+ ("Remove_unused_program_constructs",
+          Remove_unused_program_constructs.remove_unused_program_constructs)
+      in
+      let flam =
+        if !Clflags.classic_inlining then
+          fast_mode flam
+        else
+          loop flam
+      in
+      let flam = back_end flam in
+      (* Check that there aren't any unused "always inline" attributes. *)
+      Flambda_iterators.iter_apply_on_program flam ~f:(fun apply ->
+          match apply.inline with
+          | Default_inline | Never_inline -> ()
+          | Always_inline ->
+            (* CR-someday mshinwell: consider a different error message if
+               this triggers as a result of the propagation of a user's
+               attribute into the second part of an over application
+               (inline_and_simplify.ml line 710). *)
+            Location.prerr_warning (Debuginfo.to_location apply.dbg)
+              (Warnings.Inlining_impossible "[@inlined] attribute was not \
+                used on this function application (the optimizer did not \
+                know what function was being applied)")
+          | Unroll _ ->
+            Location.prerr_warning (Debuginfo.to_location apply.dbg)
+              (Warnings.Inlining_impossible "[@unroll] attribute was not \
+                used on this function application (the optimizer did not \
+                know what function was being applied)"));
+      if !Clflags.dump_flambda
+      then
+        Format.fprintf ppf "End of middle end:@ %a@."
+          Flambda.print_program flam;
+      check flam;
+      (* CR-someday mshinwell: add -d... option for this *)
+      (* dump_function_sizes flam ~backend; *)
+      flam)
+  )

--- a/middle_end/middle_end.mli
+++ b/middle_end/middle_end.mli
@@ -20,7 +20,6 @@
 
 val middle_end
    : Format.formatter
-  -> source_provenance:Timings.source_provenance
   -> prefixname:string
   -> backend:(module Backend_intf.S)
   -> size:int

--- a/testsuite/tests/asmcomp/main.ml
+++ b/testsuite/tests/asmcomp/main.ml
@@ -7,7 +7,7 @@ let compile_file filename =
     Emitaux.output_channel := open_out out_name
   end; (* otherwise, stdout *)
   Clflags.dlcode := false;
-  Compilenv.reset ~source_provenance:(Timings.File filename) "test";
+  Compilenv.reset "test";
   Emit.begin_assembly();
   let ic = open_in filename in
   let lb = Lexing.from_channel ic in
@@ -61,6 +61,7 @@ let main() =
      "-dtimings", Arg.Set print_timings, "";
     ] compile_file usage
 
-let _ = (*Printexc.catch*) Timings.(time All) main ();
+let () =
+  main ();
   if !Clflags.print_timings then Timings.print Format.std_formatter;
   exit 0

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -220,15 +220,14 @@ let load_lambda ppf ~module_ident ~required_globals lam size =
   in
   let fn = Filename.chop_extension dll in
   if not Config.flambda then
-    Asmgen.compile_implementation_clambda ~source_provenance:Timings.Toplevel
+    Asmgen.compile_implementation_clambda
       ~toplevel:need_symbol fn ppf
       { Lambda.code=slam ; main_module_block_size=size;
         module_ident; required_globals }
   else
-    Asmgen.compile_implementation_flambda ~source_provenance:Timings.Toplevel
+    Asmgen.compile_implementation_flambda
       ~required_globals ~backend ~toplevel:need_symbol fn ppf
-      (Middle_end.middle_end ppf
-         ~source_provenance:Timings.Toplevel ~prefixname:"" ~backend ~size
+      (Middle_end.middle_end ppf ~prefixname:"" ~backend ~size
          ~module_ident ~module_initializer:slam ~filename:"toplevel");
   Asmlink.call_linker_shared [fn ^ ext_obj] dll;
   Sys.remove (fn ^ ext_obj);
@@ -281,8 +280,7 @@ let execute_phrase print_outcome ppf phr =
       let oldenv = !toplevel_env in
       incr phrase_seqid;
       phrase_name := Printf.sprintf "TOP%i" !phrase_seqid;
-      Compilenv.reset ~source_provenance:Timings.Toplevel
-        ?packname:None !phrase_name;
+      Compilenv.reset ?packname:None !phrase_name;
       Typecore.reset_delayed_checks ();
       let sstr, rewritten =
         match sstr with

--- a/utils/timings.ml
+++ b/utils/timings.ml
@@ -15,144 +15,85 @@
 
 type file = string
 
-type source_provenance =
-  | File of file
-  | Pack of string
-  | Startup
-  | Toplevel
-
-type compiler_pass =
-  | All
-  | Parsing of file
-  | Parser of file
-  | Dash_pp of file
-  | Dash_ppx of file
-  | Typing of file
-  | Transl of file
-  | Generate of file
-  | Assemble of source_provenance
-  | Clambda of source_provenance
-  | Cmm of source_provenance
-  | Compile_phrases of source_provenance
-  | Selection of source_provenance
-  | Comballoc of source_provenance
-  | CSE of source_provenance
-  | Liveness of source_provenance
-  | Deadcode of source_provenance
-  | Spill of source_provenance
-  | Split of source_provenance
-  | Regalloc of source_provenance
-  | Linearize of source_provenance
-  | Scheduling of source_provenance
-  | Emit of source_provenance
-  | Flambda_pass of string * source_provenance
-
-let timings : (compiler_pass, float * float option) Hashtbl.t =
-  Hashtbl.create 20
-
 external time_include_children: bool -> float = "caml_sys_time_include_children"
 let cpu_time () = time_include_children true
 
-let reset () = Hashtbl.clear timings
+type times = { start : float; duration : float }
+type hierarchy =
+  | E of (string, times * hierarchy) Hashtbl.t
+[@@unboxed]
 
-let start pass =
-  (* Cannot assert it is not here: a source file can be compiled
-     multiple times on the same command line *)
-  (* assert(not (Hashtbl.mem timings pass)); *)
-  let time = cpu_time () in
-  Hashtbl.add timings pass (time, None)
+let hierarchy = ref (E (Hashtbl.create 2))
+let reset () = hierarchy := E (Hashtbl.create 2)
 
-let stop pass =
-  assert(Hashtbl.mem timings pass);
-  let time = cpu_time () in
-  let (start, stop) = Hashtbl.find timings pass in
-  assert(stop = None);
-  Hashtbl.replace timings pass (start, Some (time -. start))
-
-let time_call pass f =
-  start pass;
-  let r = f () in
-  stop pass;
-  r
-
-let time pass f x = time_call pass (fun () -> f x)
-
-let restart pass =
-  let previous_duration =
-    match Hashtbl.find timings pass with
-    | exception Not_found -> 0.
-    | (_, Some duration) -> duration
-    | _, None -> assert false
+let time_call ?(accumulate = false) name f =
+  let E prev_hierarchy = !hierarchy in
+  let this_times, this_table =
+    (* We allow the recording of multiple categories by the same name, for tools like
+       ocamldoc that use the compiler libs but don't care about timings information,
+       and so may record, say, "parsing" multiple times. *)
+    if accumulate
+    then
+      match Hashtbl.find prev_hierarchy name with
+      | exception Not_found -> None, Hashtbl.create 2
+      | times, E table ->
+        Hashtbl.remove prev_hierarchy name;
+        Some times, table
+    else None, Hashtbl.create 2
   in
-  let time = cpu_time () in
-  Hashtbl.replace timings pass (time, Some previous_duration)
+  hierarchy := E this_table;
+  let start = cpu_time () in
+  Misc.try_finally f
+    (fun () ->
+       hierarchy := E prev_hierarchy;
+       let end_ = cpu_time () in
+       let times =
+         match this_times with
+         | None -> { start; duration = end_ -. start }
+         | Some { start = initial_start; duration } ->
+           { start = initial_start; duration = duration +. end_ -. start }
+       in
+       Hashtbl.add prev_hierarchy name (times, E this_table))
 
-let accumulate pass =
-  let time = cpu_time () in
-  match Hashtbl.find timings pass with
-  | exception Not_found -> assert false
-  | _, None -> assert false
-  | (start, Some duration) ->
-    let duration = duration +. (time -. start) in
-    Hashtbl.replace timings pass (start, Some duration)
+let time ?accumulate pass f x = time_call ?accumulate pass (fun () -> f x)
 
-let accumulate_time pass f x =
-  restart pass;
-  let r = f x in
-  accumulate pass;
-  r
-
-let get pass =
-  match Hashtbl.find timings pass with
-  | _start, Some duration -> Some duration
-  | _, None -> None
-  | exception Not_found -> None
-
-let kind_name = function
-  | File f -> Printf.sprintf "sourcefile(%s)" f
-  | Pack p -> Printf.sprintf "pack(%s)" p
-  | Startup -> "startup"
-  | Toplevel  -> "toplevel"
-
-let pass_name = function
-  | All -> "all"
-  | Parsing file -> Printf.sprintf "parsing(%s)" file
-  | Parser file -> Printf.sprintf "parser(%s)" file
-  | Dash_pp file -> Printf.sprintf "-pp(%s)" file
-  | Dash_ppx file -> Printf.sprintf "-ppx(%s)" file
-  | Typing file -> Printf.sprintf "typing(%s)" file
-  | Transl file -> Printf.sprintf "transl(%s)" file
-  | Generate file -> Printf.sprintf "generate(%s)" file
-  | Assemble k -> Printf.sprintf "assemble(%s)" (kind_name k)
-  | Clambda k -> Printf.sprintf "clambda(%s)" (kind_name k)
-  | Cmm k -> Printf.sprintf "cmm(%s)" (kind_name k)
-  | Compile_phrases k -> Printf.sprintf "compile_phrases(%s)" (kind_name k)
-  | Selection k -> Printf.sprintf "selection(%s)" (kind_name k)
-  | Comballoc k -> Printf.sprintf "comballoc(%s)" (kind_name k)
-  | CSE k -> Printf.sprintf "cse(%s)" (kind_name k)
-  | Liveness k -> Printf.sprintf "liveness(%s)" (kind_name k)
-  | Deadcode k -> Printf.sprintf "deadcode(%s)" (kind_name k)
-  | Spill k -> Printf.sprintf "spill(%s)" (kind_name k)
-  | Split k -> Printf.sprintf "split(%s)" (kind_name k)
-  | Regalloc k -> Printf.sprintf "regalloc(%s)" (kind_name k)
-  | Linearize k -> Printf.sprintf "linearize(%s)" (kind_name k)
-  | Scheduling k -> Printf.sprintf "scheduling(%s)" (kind_name k)
-  | Emit k -> Printf.sprintf "emit(%s)" (kind_name k)
-  | Flambda_pass (pass, file) ->
-    Printf.sprintf "flambda(%s)(%s)" pass (kind_name file)
-
-let timings_list () =
-  let l = Hashtbl.fold (fun pass times l -> (pass, times) :: l) timings [] in
+let timings_list (E table) =
+  let l = Hashtbl.fold (fun k d l -> (k, d) :: l) table [] in
   List.sort (fun (pass1, (start1, _)) (pass2, (start2, _)) ->
     compare (start1, pass1) (start2, pass2)) l
 
-let print ppf =
-  let current_time = cpu_time () in
-  List.iter (fun (pass, (start, stop)) ->
-      match stop with
-      | Some duration ->
-        Format.fprintf ppf "%s: %.03fs@." (pass_name pass) duration
-      | None ->
-        Format.fprintf ppf "%s: running for %.03fs@." (pass_name pass)
-          (current_time -. start))
-    (timings_list ())
+(* Because indentation is meaningful, and because the durations are
+   the first element of each row, we can't pad them with spaces. *)
+let duration_as_string ~pad duration = Printf.sprintf "%0*.03f" pad duration
+
+let rec print ppf hierarchy ~total ~nesting =
+  let total_of_children = ref 0. in
+  let list = timings_list hierarchy in
+  let max_duration_width =
+    List.fold_left
+      (fun acc (_, (times, _)) ->
+         max acc (String.length (duration_as_string ~pad:0 times.duration)))
+      0 list
+  in
+  let print_pass ~duration ~pass =
+    let duration_as_string =
+      duration_as_string ~pad:max_duration_width duration in
+    if float_of_string duration_as_string <> 0. then
+      Format.fprintf ppf "%s%ss %s@\n"
+        (String.make (nesting * 2) ' ') duration_as_string pass
+  in
+  List.iter (fun (pass, ({ start = _; duration }, sub_hierarchy)) ->
+    print_pass ~duration ~pass;
+    print ppf sub_hierarchy ~total:duration ~nesting:(nesting + 1);
+    total_of_children := !total_of_children +. duration;
+  ) list;
+  if list <> [] || nesting = 0 then
+    print_pass ~duration:(total -. !total_of_children) ~pass:"other";
+;;
+
+let print ?(total = cpu_time ()) ppf =
+  print ppf !hierarchy ~total ~nesting:0
+
+let generate = "generate"
+let transl = "transl"
+let typing = "typing"

--- a/utils/timings.mli
+++ b/utils/timings.mli
@@ -17,52 +17,23 @@
 
 type file = string
 
-type source_provenance =
-  | File of file
-  | Pack of string
-  | Startup
-  | Toplevel
-
-type compiler_pass =
-  | All
-  | Parsing of file
-  | Parser of file
-  | Dash_pp of file
-  | Dash_ppx of file
-  | Typing of file
-  | Transl of file
-  | Generate of file
-  | Assemble of source_provenance
-  | Clambda of source_provenance
-  | Cmm of source_provenance
-  | Compile_phrases of source_provenance
-  | Selection of source_provenance
-  | Comballoc of source_provenance
-  | CSE of source_provenance
-  | Liveness of source_provenance
-  | Deadcode of source_provenance
-  | Spill of source_provenance
-  | Split of source_provenance
-  | Regalloc of source_provenance
-  | Linearize of source_provenance
-  | Scheduling of source_provenance
-  | Emit of source_provenance
-  | Flambda_pass of string * source_provenance
+val cpu_time : unit -> float
 
 val reset : unit -> unit
 (** erase all recorded times *)
 
-val get : compiler_pass -> float option
-(** returns the runtime in seconds of a completed pass *)
-
-val time_call : compiler_pass -> (unit -> 'a) -> 'a
+val time_call : ?accumulate:bool -> string -> (unit -> 'a) -> 'a
 (** [time_call pass f] calls [f] and records its runtime. *)
 
-val time : compiler_pass -> ('a -> 'b) -> 'a -> 'b
+val time : ?accumulate:bool -> string -> ('a -> 'b) -> 'a -> 'b
 (** [time pass f arg] records the runtime of [f arg] *)
 
-val accumulate_time : compiler_pass -> ('a -> 'b) -> 'a -> 'b
-(** Like time for passes that can run multiple times *)
-
-val print : Format.formatter -> unit
+val print : ?total:float -> Format.formatter -> unit
 (** Prints all recorded timings to the formatter. *)
+
+(** A few pass names that are needed in several places, and shared to
+    avoid typos. *)
+
+val generate : string
+val transl : string
+val typing : string


### PR DESCRIPTION
As briefly mentioned in https://github.com/ocaml/ocaml/pull/1027, this pull request changes the output of -dtimings from something like this:

```
all: 2.236s
parsing(hg.ml): 0.064s
-pp(hg.ml): 0.054s
-ppx(hg.ml): 0.000s
typing(hg.ml): 1.533s
transl(hg.ml): 0.220s
generate(sourcefile(hg.ml)): 0.418s
cmm(sourcefile(hg.ml)): 0.012s
compile_phrases(sourcefile(hg.ml)): 0.233s
selection(sourcefile(hg.ml)): 0.032s
comballoc(sourcefile(hg.ml)): 0.001s
cse(sourcefile(hg.ml)): 0.016s
deadcode(sourcefile(hg.ml)): 0.009s
spill(sourcefile(hg.ml)): 0.021s
split(sourcefile(hg.ml)): 0.013s
liveness(sourcefile(hg.ml)): 0.019s
regalloc(sourcefile(hg.ml)): 0.096s
linearize(sourcefile(hg.ml)): 0.000s
scheduling(sourcefile(hg.ml)): 0.000s
emit(sourcefile(hg.ml)): 0.019s
assemble(sourcefile(hg.ml)): 0.071s
```

to:

```
/: 2.236s
/parsing(hg.ml): 0.064s
/parsing/-pp(hg.ml): 0.054s
/parsing/-ppx(hg.ml): 0.000s
/typing(hg.ml): 1.533s
/transl(hg.ml): 0.220s
/generate(sourcefile(hg.ml)): 0.418s
/generate/cmm(sourcefile(hg.ml)): 0.012s
/generate/compile_phrases(sourcefile(hg.ml)): 0.233s
/generate/selection(sourcefile(hg.ml)): 0.032s
/generate/comballoc(sourcefile(hg.ml)): 0.001s
/generate/cse(sourcefile(hg.ml)): 0.016s
/generate/deadcode(sourcefile(hg.ml)): 0.009s
/generate/spill(sourcefile(hg.ml)): 0.021s
/generate/split(sourcefile(hg.ml)): 0.013s
/generate/liveness(sourcefile(hg.ml)): 0.019s
/generate/regalloc(sourcefile(hg.ml)): 0.096s
/generate/linearize(sourcefile(hg.ml)): 0.000s
/generate/scheduling(sourcefile(hg.ml)): 0.000s
/generate/emit(sourcefile(hg.ml)): 0.019s
/generate/assemble(sourcefile(hg.ml)): 0.071s
```

It makes parsing the output simpler, since one doesn't need to know that, say, cmm is part of generate.
The hierarchy in the output is reflected in the types, I don't know if that's really necessary. 

While I was looking at some outputs, I noticed that when linking, there were subcategories of /generate but not /generate itself, so I added /generate (I'll also point out the the call to the linker ends up in / right now, it may be worth splitting it into a separate category at some point).
