### PR TITLE
Improve tools/read_cmt

### DIFF
--- a/Changes
+++ b/Changes
@@ -483,6 +483,9 @@ Next major version (4.05.0):
 - clarify ocamldoc text parsing error messages
   (Gabriel Scherer)
 
+- GPR#1036: ocamlcmt (tools/read_cmt) is installed, converts .cmt to .annot
+  (Fabrice Le Fessant)
+
 ### Compiler distribution build system:
 
 - PR#7377: remove -std=gnu99 for newer gcc versions

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -275,6 +275,13 @@ READ_CMT= \
 # Reading cmt files
 $(call byte_and_opt,read_cmt,$(READ_CMT),)
 
+install::
+	if test -f read_cmt.opt; then \
+		cp read_cmt.opt "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
+	else \
+		cp read_cmt "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
+	fi
+
 
 # The bytecode disassembler
 

--- a/tools/read_cmt.ml
+++ b/tools/read_cmt.ml
@@ -17,20 +17,27 @@ let gen_annot = ref false
 let gen_ml = ref false
 let print_info_arg = ref false
 let target_filename = ref None
+let save_cmt_info = ref false
 
-let arg_list = [
+let arg_list = Arg.align [
   "-o", Arg.String (fun s -> target_filename := Some s),
-    " FILE (or -) : dump to file FILE (or stdout)";
-  "-annot", Arg.Set gen_annot, " : generate the corresponding .annot file";
+    "<file> Dump to file <file> (or stdout if -)";
+  "-annot", Arg.Set gen_annot,
+    " Generate the corresponding .annot file";
+  "-save-cmt-info", Arg.Set save_cmt_info,
+    " Encapsulate additional cmt information in annotations";
   "-src", Arg.Set gen_ml,
-    " : convert .cmt or .cmti back to source code (without comments)";
+    " Convert .cmt or .cmti back to source code (without comments)";
   "-info", Arg.Set print_info_arg, " : print information on the file";
   "-args", Arg.Expand Arg.read_arg,
-    " <file> Read additional newline separated command line arguments \n\
+    "<file> Read additional newline separated command line arguments \n\
     \      from <file>";
   "-args0", Arg.Expand Arg.read_arg0,
     "<file> Read additional NUL separated command line arguments from \n\
     \      <file>";
+  "-I", Arg.String (fun s ->
+    Clflags.include_dirs := s :: !Clflags.include_dirs),
+    "<dir> Add <dir> to the list of include directories";
   ]
 
 let arg_usage =
@@ -39,50 +46,58 @@ let arg_usage =
 let dummy_crc = String.make 32 '-'
 
 let print_info cmt =
+  let oc = match !target_filename with
+    | None -> stdout
+    | Some filename -> open_out filename
+  in
   let open Cmt_format in
-      Printf.printf "module name: %s\n" cmt.cmt_modname;
-      begin match cmt.cmt_annots with
-          Packed (_, list) ->
-            Printf.printf "pack: %s\n" (String.concat " " list)
-        | Implementation _ -> Printf.printf "kind: implementation\n"
-        | Interface _ -> Printf.printf "kind: interface\n"
-        | Partial_implementation _ ->
-            Printf.printf "kind: implementation with errors\n"
-        | Partial_interface _ -> Printf.printf "kind: interface with errors\n"
-      end;
-      Printf.printf "command: %s\n"
-                    (String.concat " " (Array.to_list cmt.cmt_args));
-      begin match cmt.cmt_sourcefile with
-          None -> ()
-        | Some name ->
-          Printf.printf "sourcefile: %s\n" name;
-      end;
-      Printf.printf "build directory: %s\n" cmt.cmt_builddir;
-      List.iter (Printf.printf "load path: %s\n%!") cmt.cmt_loadpath;
-      begin
-      match cmt.cmt_source_digest with
-          None -> ()
-        | Some digest ->
-            Printf.printf "source digest: %s\n" (Digest.to_hex digest);
-      end;
-      begin
-      match cmt.cmt_interface_digest with
-          None -> ()
-        | Some digest ->
-            Printf.printf "interface digest: %s\n" (Digest.to_hex digest);
-      end;
-      List.iter (fun (name, crco) ->
-        let crc =
-          match crco with
-            None -> dummy_crc
-          | Some crc -> Digest.to_hex crc
-        in
-          Printf.printf "import: %s %s\n" name crc;
-      ) (List.sort compare cmt.cmt_imports);
-      Printf.printf "%!";
-      ()
+  Printf.fprintf oc "module name: %s\n" cmt.cmt_modname;
+  begin match cmt.cmt_annots with
+    Packed (_, list) ->
+      Printf.fprintf oc "pack: %s\n" (String.concat " " list)
+  | Implementation _ -> Printf.fprintf oc "kind: implementation\n"
+  | Interface _ -> Printf.fprintf oc "kind: interface\n"
+  | Partial_implementation _ ->
+    Printf.fprintf oc "kind: implementation with errors\n"
+  | Partial_interface _ -> Printf.fprintf oc "kind: interface with errors\n"
+  end;
+  Printf.fprintf oc "command: %s\n"
+    (String.concat " " (Array.to_list cmt.cmt_args));
+  begin match cmt.cmt_sourcefile with
+    None -> ()
+  | Some name ->
+    Printf.fprintf oc "sourcefile: %s\n" name;
+  end;
+  Printf.fprintf oc "build directory: %s\n" cmt.cmt_builddir;
+  List.iter (Printf.fprintf oc "load path: %s\n%!") cmt.cmt_loadpath;
+  begin
+    match cmt.cmt_source_digest with
+      None -> ()
+    | Some digest ->
+      Printf.fprintf oc "source digest: %s\n" (Digest.to_hex digest);
+  end;
+  begin
+    match cmt.cmt_interface_digest with
+      None -> ()
+    | Some digest ->
+      Printf.fprintf oc "interface digest: %s\n" (Digest.to_hex digest);
+  end;
+  List.iter (fun (name, crco) ->
+    let crc =
+      match crco with
+        None -> dummy_crc
+      | Some crc -> Digest.to_hex crc
+    in
+    Printf.fprintf oc "import: %s %s\n" name crc;
+  ) (List.sort compare cmt.cmt_imports);
+  Printf.fprintf oc "%!";
+  begin match !target_filename with
+  | None -> ()
+  | Some _ -> close_out oc
+  end;
+  ()
 
-let _ =
+let main () =
   Clflags.annotations := true;
 
   Arg.parse_expand arg_list  (fun filename ->
@@ -90,9 +105,11 @@ let _ =
       Filename.check_suffix filename ".cmt" ||
         Filename.check_suffix filename ".cmti"
     then begin
-      (*      init_path(); *)
+      Compmisc.init_path false;
       let cmt = Cmt_format.read_cmt filename in
-      if !gen_annot then Cmt2annot.gen_annot !target_filename filename cmt;
+      if !gen_annot then
+        Cmt2annot.gen_annot ~save_cmt_info: !save_cmt_info
+          !target_filename filename cmt;
       if !gen_ml then Cmt2annot.gen_ml !target_filename filename cmt;
       if !print_info_arg || not (!gen_ml || !gen_annot) then print_info cmt;
     end else begin
@@ -101,3 +118,13 @@ let _ =
       Arg.usage arg_list arg_usage
     end
   ) arg_usage
+
+
+let () =
+  try
+    main ()
+  with x ->
+    Printf.eprintf "Exception in main ()\n%!";
+    Location.report_exception Format.err_formatter x;
+    Format.fprintf Format.err_formatter "@.";
+    exit 2


### PR DESCRIPTION
We use `read_cmt` to provide `.annot` files when developing in a version of the compiler for which `merlin` or `ocp-index` are not available. This PR provides some additional features that are needed by our tool.

* Install `read_cmt` as `ocaml_cmt` (in native-code if possible)
* Print cmt info in file when `-o` is specified
* Add an option `-I` for includes
* Catch and print exceptions

