### PR TITLE
Fix -nostdlib option to ocaml

### DIFF
--- a/Changes
+++ b/Changes
@@ -252,6 +252,11 @@ Working version
   calls over the lifetime of a program when using Spacetime profiling
   (Mark Shinwell)
 
+### Toplevel:
+
+- GPR#1041: -nostdlib no longer ignored by toplevel.
+  (David Allsopp, review by Xavier Leroy)
+
 ### Compiler distribution build system
 
 - MPR#6373, GPR#1093: Suppress trigraph warnings from macOS assembler

--- a/toplevel/opttopmain.ml
+++ b/toplevel/opttopmain.ml
@@ -254,4 +254,5 @@ let main () =
     | Arg.Help msg -> Format.fprintf Format.std_formatter "%s%!" msg; exit 0
   end;
   if not (prepare Format.err_formatter) then exit 2;
+  Compmisc.init_path true;
   Opttoploop.loop Format.std_formatter

--- a/toplevel/topmain.ml
+++ b/toplevel/topmain.ml
@@ -168,4 +168,5 @@ let main () =
   end;
   Compenv.readenv ppf Before_link;
   if not (prepare ppf) then exit 2;
+  Compmisc.init_path false;
   Toploop.loop Format.std_formatter


### PR DESCRIPTION
Search path was initialised before options were parsed, meaning that
-nostdlib had no effect.