### PR TITLE
Ocamldep: -shared option

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,12 @@ Working version
 
 (Changes that can break existing programs are marked with a "*")
 
+### Tools:
+
+- GPR#1045: ocamldep, add a "-shared" option to generate dependencies
+  for native plugin files (i.e. .cmxs files)
+  (Florian Angeletti, suggestion by Sébastien Hinderer)
+
 ### Bug fixes
 
 - PR#7468: possible GC problem in caml_alloc_sprintf

--- a/man/ocamldep.m
+++ b/man/ocamldep.m
@@ -166,6 +166,10 @@ as a preprocessor for each source file.
 Pipe abstract syntax tree through preprocessor
 .IR command .
 .TP
+.B \-shared
+Generate dependencies for native plugin files (.cmxs) in addition to
+native compiled files (.cmx).
+.TP
 .B \-slash
 Under Unix, this option does nothing.
 .TP

--- a/manual/manual/cmds/depend.etex
+++ b/manual/manual/cmds/depend.etex
@@ -118,6 +118,10 @@ for each source file.
 \item["-ppx" \var{command}]
 Pipe abstract syntax trees through preprocessor \var{command}.
 
+\item["-shared"]
+Generate dependencies for native plugin files (.cmxs) in addition to
+native compiled files (.cmx).
+
 \item["-slash"]
 Under Windows, use a forward slash (/) as the path separator instead
 of the usual backward slash ($\backslash$).  Under Unix, this option does

--- a/ocamldoc/.depend
+++ b/ocamldoc/.depend
@@ -1,11 +1,3 @@
-generators/odoc_literate.cmo : odoc_info.cmi odoc_html.cmo odoc_gen.cmi \
-    odoc_args.cmi
-generators/odoc_literate.cmx : odoc_info.cmx odoc_html.cmx odoc_gen.cmx \
-    odoc_args.cmx
-generators/odoc_todo.cmo : odoc_module.cmo odoc_info.cmi odoc_html.cmo \
-    odoc_gen.cmi odoc_args.cmi
-generators/odoc_todo.cmx : odoc_module.cmx odoc_info.cmx odoc_html.cmx \
-    odoc_gen.cmx odoc_args.cmx
 odoc.cmo : odoc_messages.cmo odoc_info.cmi odoc_global.cmi odoc_gen.cmi \
     odoc_config.cmi odoc_args.cmi odoc_analyse.cmi
 odoc.cmx : odoc_messages.cmx odoc_info.cmx odoc_global.cmx odoc_gen.cmx \
@@ -272,3 +264,15 @@ odoc_value.cmo : ../typing/types.cmi ../typing/printtyp.cmi odoc_types.cmi \
     odoc_parameter.cmo odoc_name.cmi odoc_misc.cmi ../parsing/asttypes.cmi
 odoc_value.cmx : ../typing/types.cmx ../typing/printtyp.cmx odoc_types.cmx \
     odoc_parameter.cmx odoc_name.cmx odoc_misc.cmx ../parsing/asttypes.cmi
+generators/odoc_literate.cmo : odoc_info.cmi odoc_html.cmo odoc_gen.cmi \
+    odoc_args.cmi
+generators/odoc_literate.cmx : odoc_info.cmx odoc_html.cmx odoc_gen.cmx \
+    odoc_args.cmx
+generators/odoc_literate.cmxs : odoc_info.cmx odoc_html.cmx odoc_gen.cmx \
+    odoc_args.cmx
+generators/odoc_todo.cmo : odoc_module.cmo odoc_info.cmi odoc_html.cmo \
+    odoc_gen.cmi odoc_args.cmi
+generators/odoc_todo.cmx : odoc_module.cmx odoc_info.cmx odoc_html.cmx \
+    odoc_gen.cmx odoc_args.cmx
+generators/odoc_todo.cmxs : odoc_module.cmx odoc_info.cmx odoc_html.cmx \
+    odoc_gen.cmx odoc_args.cmx

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -424,6 +424,7 @@ depend:
 	$(OCAMLLEX) odoc_lexer.mll
 	$(OCAMLLEX) odoc_ocamlhtml.mll
 	$(OCAMLLEX) odoc_see_lexer.mll
-	$(OCAMLDEP) $(INCLUDES_DEP) *.mll *.mly *.ml *.mli generators/*.ml > .depend
+	$(OCAMLDEP) $(INCLUDES_DEP) *.mll *.mly *.ml *.mli > .depend
+	$(OCAMLDEP) $(INCLUDES_DEP) -shared generators/*.ml >> .depend
 
 include .depend


### PR DESCRIPTION
This short PR introduces a new ocamldep option: `-shared`. When this option is enabled, ocamldep generates dependencies for plugin files in complement of the classical `.cmx` targets (if native dependencies are enabled).

The second commit of this PR uses this new option to update ocamldoc makefile (see #1031).