### PR TITLE
Enable AppVeyor for 4.05 branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ platform:
 branches:
   only:
     - trunk
+    - 4.05
 
 # Do a shallow clone of the repo to speed up the build
 clone_depth: 1


### PR DESCRIPTION
This is primarily to enable automatic tracking of the branch, rather than pull requests, since 4.05 is supposed to be updated by being cherry picked.

It also provides a quick check for pull requests which can be temporarily targeted to 4.05 just to check the CI and then retargeted to trunk (assuming clean merge, obviously).