### PR TITLE
PR#7488: wrong Latex output for variant types

### DIFF
--- a/Changes
+++ b/Changes
@@ -192,6 +192,10 @@ Next version (4.05.0):
   a short description in overviews.
   (Florian Angeletti)
 
+- PR#7488: ocamldoc, wrong Latex output for variant types
+  with constructors without arguments.
+  (Florian Angeletti, report by Xavier Leroy)
+
 - GPR#848: ocamldoc, escape link targets in HTML output
   (Etienne Millon, review by Gabriel Scherer, Florian Angeletti and
   Daniel Bünzli)

--- a/ocamldoc/odoc_latex.ml
+++ b/ocamldoc/odoc_latex.ml
@@ -700,17 +700,17 @@ class latex =
                    p fmt2 "@[<h 6>  | %s" (Name.simple x.xt_name);
                    let l = self#latex_of_cstr_args f father (x.xt_args, x.xt_ret) in
                    let c =
-                     begin match x.xt_alias with
-                     | None -> ()
+                     match x.xt_alias with
+                     | None -> []
                      | Some xa ->
                          p fmt2 " = %s"
                            (
                              match xa.xa_xt with
                              | None -> xa.xa_name
                              | Some x -> x.xt_name
-                           )
-                     end;
-                       [CodePre (flush2 ())] in
+                           );
+                         [CodePre (flush2 ())]
+                   in
                     Latex (self#make_label (self#extension_label x.xt_name)) :: l @ c
                     @ (match x.xt_text with
                       None -> []
@@ -744,16 +744,17 @@ class latex =
         p fmt2 "@[<hov 2>exception %s" s_name;
         let l = self#latex_of_cstr_args f father (e.ex_args, e.ex_ret) in
         let s =
-          (match e.ex_alias with
-             None -> ()
-           | Some ea ->
-               Format.fprintf fmt " = %s"
-                 (
-                   match ea.ea_ex with
-                     None -> ea.ea_name
-                   | Some e -> e.ex_name
-                 )
-          ); [CodePre (flush2 ())] in
+          match e.ex_alias with
+            None -> []
+          | Some ea ->
+              Format.fprintf fmt " = %s"
+                (
+                  match ea.ea_ex with
+                    None -> ea.ea_name
+                  | Some e -> e.ex_name
+                );
+              [CodePre (flush2 ())]
+        in
        merge_codepre (l @ s ) @
       [Latex ("\\index{"^(self#label s_name)^"@\\verb`"^(self#label ~no_:false s_name)^"`}\n")]
        @ (self#text_of_info e.ex_info) in

--- a/ocamldoc/odoc_latex.ml
+++ b/ocamldoc/odoc_latex.ml
@@ -571,11 +571,13 @@ class latex =
           p fmt " of@ %s"
             (self#normal_cstr_args ~par:false mod_name l);
           [CodePre (flush())]
-      | Cstr_tuple _ as l, Some r ->
-          p fmt " :@ %s@ %s@ %s"
-            (self#normal_cstr_args ~par:false mod_name l)
-            "->"
-            (self#normal_type mod_name r);
+      | Cstr_tuple t as l, Some r ->
+          let res = self#normal_type mod_name r in
+          if t = [] then
+            p fmt " :@ %s" res
+          else
+            p fmt " :@ %s -> %s" (self#normal_cstr_args ~par:false mod_name l) res
+          ;
           [CodePre (flush())]
       | Cstr_record l, None ->
           p fmt " of@ ";

--- a/ocamldoc/odoc_latex.ml
+++ b/ocamldoc/odoc_latex.ml
@@ -566,7 +566,7 @@ class latex =
 
     method latex_of_cstr_args ( (fmt,flush) as f) mod_name (args, ret) =
       match args, ret with
-      | Cstr_tuple [], None -> []
+      | Cstr_tuple [], None -> [CodePre(flush())]
       | Cstr_tuple _ as l, None ->
           p fmt " of@ %s"
             (self#normal_cstr_args ~par:false mod_name l);

--- a/testsuite/tests/tool-ocamldoc-2/inline_records.reference
+++ b/testsuite/tests/tool-ocamldoc-2/inline_records.reference
@@ -33,7 +33,6 @@ A nice exception
 
 \begin{ocamldoccode}
 exception Less of int
-
 \end{ocamldoccode}
 \index{Less@\verb`Less`}
 \begin{ocamldocdescription}
@@ -221,7 +220,6 @@ Error field documentation {\tt{name:string}}
 \end{ocamldoccomment}
 \begin{ocamldoccode}
 {\char125}
-
 \end{ocamldoccode}
 \index{Error@\verb`Error`}
 
@@ -241,7 +239,6 @@ Field documentation for {\tt{E}} in ext
 \end{ocamldoccomment}
 \begin{ocamldoccode}
 {\char125}
-
 \end{ocamldoccode}
 \begin{ocamldoccomment}
 Constructor E documentation
@@ -258,7 +255,6 @@ Some field documentations for {\tt{F}}
 \end{ocamldoccomment}
 \begin{ocamldoccode}
 {\char125}
-
 \end{ocamldoccode}
 \begin{ocamldoccomment}
 Constructor F documentation
@@ -275,7 +271,6 @@ The last and least field documentation
 \end{ocamldoccomment}
 \begin{ocamldoccode}
 {\char125}
-
 \end{ocamldoccode}
 \begin{ocamldoccomment}
 Constructor G documentation

--- a/testsuite/tests/tool-ocamldoc-2/inline_records_bis.reference
+++ b/testsuite/tests/tool-ocamldoc-2/inline_records_bis.reference
@@ -33,7 +33,6 @@ A nice exception
 
 \begin{ocamldoccode}
 exception Less of int
-
 \end{ocamldoccode}
 \index{Less@\verb`Less`}
 \begin{ocamldocdescription}
@@ -221,7 +220,6 @@ Error field documentation {\tt{name:string}}
 \end{ocamldoccomment}
 \begin{ocamldoccode}
 {\char125}
-
 \end{ocamldoccode}
 \index{Error@\verb`Error`}
 
@@ -241,7 +239,6 @@ Field documentation for {\tt{E}} in ext
 \end{ocamldoccomment}
 \begin{ocamldoccode}
 {\char125}
-
 \end{ocamldoccode}
 \begin{ocamldoccomment}
 Constructor E documentation
@@ -258,7 +255,6 @@ Some field documentations for {\tt{F}}
 \end{ocamldoccomment}
 \begin{ocamldoccode}
 {\char125}
-
 \end{ocamldoccode}
 \begin{ocamldoccomment}
 Constructor F documentation
@@ -275,7 +271,6 @@ The last and least field documentation
 \end{ocamldoccomment}
 \begin{ocamldoccode}
 {\char125}
-
 \end{ocamldoccode}
 \begin{ocamldoccomment}
 Constructor G documentation

--- a/testsuite/tests/tool-ocamldoc-2/variants.mli
+++ b/testsuite/tests/tool-ocamldoc-2/variants.mli
@@ -1,0 +1,38 @@
+(** This test is here to check the latex code generated for variants *)
+
+type s = A | B (** only B is documented here *) | C
+
+type t =
+  | A
+    (** doc for A *)
+  | B
+  (** doc for B *)
+
+(** Some documentation for u*)
+type u =
+| A (** doc for A *) | B of unit (** doc for B *)
+
+
+(** With records *)
+type w =
+| A of { x: int }
+    (** doc for A *)
+| B of { y:int }
+    (** doc for B *)
+
+(** With args *)
+type z =
+| A of int
+    (** doc for A *)
+| B of int
+    (** doc for B *)
+
+(** Gadt notation *)
+type a =
+    A: a (** doc for A*)
+
+(** Lonely constructor *)
+type b =
+  B (** doc for B *)
+
+type no_documentation = A | B | C

--- a/testsuite/tests/tool-ocamldoc-2/variants.reference
+++ b/testsuite/tests/tool-ocamldoc-2/variants.reference
@@ -1,0 +1,190 @@
+\documentclass[11pt]{article} 
+\usepackage[latin1]{inputenc} 
+\usepackage[T1]{fontenc} 
+\usepackage{textcomp}
+\usepackage{fullpage} 
+\usepackage{url} 
+\usepackage{ocamldoc}
+\begin{document}
+\tableofcontents
+\section{Module {\tt{Variants}} : This test is here to check the latex code generated for variants}
+\label{Variants}\index{Variants@\verb`Variants`}
+
+
+
+
+\ocamldocvspace{0.5cm}
+
+
+
+\label{TYPVariants.s}\begin{ocamldoccode}
+type s =
+  | A
+  | B
+\end{ocamldoccode}
+\begin{ocamldoccomment}
+only B is documented here
+
+
+\end{ocamldoccomment}
+\begin{ocamldoccode}
+  | C
+\end{ocamldoccode}
+\index{s@\verb`s`}
+
+
+
+
+\label{TYPVariants.t}\begin{ocamldoccode}
+type t =
+  | A
+\end{ocamldoccode}
+\begin{ocamldoccomment}
+doc for A
+
+
+\end{ocamldoccomment}
+\begin{ocamldoccode}
+  | B
+\end{ocamldoccode}
+\begin{ocamldoccomment}
+doc for B
+
+
+\end{ocamldoccomment}
+\index{t@\verb`t`}
+
+
+
+
+\label{TYPVariants.u}\begin{ocamldoccode}
+type u =
+  | A
+\end{ocamldoccode}
+\begin{ocamldoccomment}
+doc for A
+
+
+\end{ocamldoccomment}
+\begin{ocamldoccode}
+  | B of unit
+\end{ocamldoccode}
+\begin{ocamldoccomment}
+doc for B
+
+
+\end{ocamldoccomment}
+\index{u@\verb`u`}
+\begin{ocamldocdescription}
+Some documentation for u
+
+
+\end{ocamldocdescription}
+
+
+
+
+\label{TYPVariants.w}\begin{ocamldoccode}
+type w =
+  | A of {\char123}  x : int ;
+{\char125}
+\end{ocamldoccode}
+\begin{ocamldoccomment}
+doc for A
+
+
+\end{ocamldoccomment}
+\begin{ocamldoccode}
+  | B of {\char123}  y : int ;
+{\char125}
+\end{ocamldoccode}
+\begin{ocamldoccomment}
+doc for B
+
+
+\end{ocamldoccomment}
+\index{w@\verb`w`}
+\begin{ocamldocdescription}
+With records
+
+
+\end{ocamldocdescription}
+
+
+
+
+\label{TYPVariants.z}\begin{ocamldoccode}
+type z =
+  | A of int
+\end{ocamldoccode}
+\begin{ocamldoccomment}
+doc for A
+
+
+\end{ocamldoccomment}
+\begin{ocamldoccode}
+  | B of int
+\end{ocamldoccode}
+\begin{ocamldoccomment}
+doc for B
+
+
+\end{ocamldoccomment}
+\index{z@\verb`z`}
+\begin{ocamldocdescription}
+With args
+
+
+\end{ocamldocdescription}
+
+
+
+
+\label{TYPVariants.a}\begin{ocamldoccode}
+type a =
+  | A : a
+\end{ocamldoccode}
+\begin{ocamldoccomment}
+doc for A
+
+
+\end{ocamldoccomment}
+\index{a@\verb`a`}
+\begin{ocamldocdescription}
+Gadt notation
+
+
+\end{ocamldocdescription}
+
+
+
+
+\label{TYPVariants.b}\begin{ocamldoccode}
+type b =
+  | B
+\end{ocamldoccode}
+\begin{ocamldoccomment}
+doc for B
+
+
+\end{ocamldoccomment}
+\index{b@\verb`b`}
+\begin{ocamldocdescription}
+Lonely constructor
+
+
+\end{ocamldocdescription}
+
+
+
+
+\label{TYPVariants.no-underscoredocumentation}\begin{ocamldoccode}
+type no_documentation =
+  | A
+  | B
+  | C
+\end{ocamldoccode}
+\index{no-underscoredocumentation@\verb`no_documentation`}
+
+
+\end{document}

--- a/testsuite/tests/tool-ocamldoc-html/Variants.mli
+++ b/testsuite/tests/tool-ocamldoc-html/Variants.mli
@@ -1,0 +1,38 @@
+(** This test is here to check the latex code generated for variants *)
+
+type s = A | B (** only B is documented here *) | C
+
+type t =
+  | A
+    (** doc for A *)
+  | B
+  (** doc for B *)
+
+(** Some documentation for u*)
+type u =
+| A (** doc for A *) | B of unit (** doc for B *)
+
+
+(** With records *)
+type w =
+| A of { x: int }
+    (** doc for A *)
+| B of { y:int }
+    (** doc for B *)
+
+(** With args *)
+type z =
+| A of int
+    (** doc for A *)
+| B of int
+    (** doc for B *)
+
+(** Gadt notation *)
+type a =
+    A: a (** doc for A*)
+
+(** Lonely constructor *)
+type b =
+  B (** doc for B *)
+
+type no_documentation = A | B | C

--- a/testsuite/tests/tool-ocamldoc-html/Variants.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Variants.reference
@@ -1,0 +1,232 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<link rel="stylesheet" href="style.css" type="text/css">
+<meta content="text/html; charset=iso-8859-1" http-equiv="Content-Type">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="Start" href="index.html">
+<link rel="Up" href="index.html">
+<link title="Index of types" rel=Appendix href="index_types.html">
+<link title="Index of modules" rel=Appendix href="index_modules.html">
+<link title="Variants" rel="Chapter" href="Variants.html"><title>Variants</title>
+</head>
+<body>
+<div class="navbar">&nbsp;<a class="up" href="index.html" title="Index">Up</a>
+&nbsp;</div>
+<h1>Module <a href="type_Variants.html">Variants</a></h1>
+
+<pre><span class="keyword">module</span> Variants: <code class="code"><span class="keyword">sig</span></code> <a href="Variants.html">..</a> <code class="code"><span class="keyword">end</span></code></pre><div class="info module top">
+This test is here to check the latex code generated for variants<br>
+</div>
+<hr width="100%">
+
+<pre><code><span id="TYPEs"><span class="keyword">type</span> <code class="type"></code>s</span> = </code></pre><table class="typetable">
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTs.A"><span class="constructor">A</span></span></code></td>
+
+</tr>
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTs.B"><span class="constructor">B</span></span></code></td>
+<td class="typefieldcomment" align="left" valign="top" ><code>(*</code></td><td class="typefieldcomment" align="left" valign="top" ><div class="info ">
+only B is documented here<br>
+</div>
+</td><td class="typefieldcomment" align="left" valign="bottom" ><code>*)</code></td>
+</tr>
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTs.C"><span class="constructor">C</span></span></code></td>
+
+</tr></table>
+
+
+
+<pre><code><span id="TYPEt"><span class="keyword">type</span> <code class="type"></code>t</span> = </code></pre><table class="typetable">
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTt.A"><span class="constructor">A</span></span></code></td>
+<td class="typefieldcomment" align="left" valign="top" ><code>(*</code></td><td class="typefieldcomment" align="left" valign="top" ><div class="info ">
+doc for A<br>
+</div>
+</td><td class="typefieldcomment" align="left" valign="bottom" ><code>*)</code></td>
+</tr>
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTt.B"><span class="constructor">B</span></span></code></td>
+<td class="typefieldcomment" align="left" valign="top" ><code>(*</code></td><td class="typefieldcomment" align="left" valign="top" ><div class="info ">
+doc for B<br>
+</div>
+</td><td class="typefieldcomment" align="left" valign="bottom" ><code>*)</code></td>
+</tr></table>
+
+
+
+<pre><code><span id="TYPEu"><span class="keyword">type</span> <code class="type"></code>u</span> = </code></pre><table class="typetable">
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTu.A"><span class="constructor">A</span></span></code></td>
+<td class="typefieldcomment" align="left" valign="top" ><code>(*</code></td><td class="typefieldcomment" align="left" valign="top" ><div class="info ">
+doc for A<br>
+</div>
+</td><td class="typefieldcomment" align="left" valign="bottom" ><code>*)</code></td>
+</tr>
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTu.B"><span class="constructor">B</span></span> <span class="keyword">of</span> <code class="type">unit</code></code></td>
+<td class="typefieldcomment" align="left" valign="top" ><code>(*</code></td><td class="typefieldcomment" align="left" valign="top" ><div class="info ">
+doc for B<br>
+</div>
+</td><td class="typefieldcomment" align="left" valign="bottom" ><code>*)</code></td>
+</tr></table>
+
+<div class="info ">
+Some documentation for u<br>
+</div>
+
+
+<pre><code><span id="TYPEw"><span class="keyword">type</span> <code class="type"></code>w</span> = </code></pre><table class="typetable">
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTw.A"><span class="constructor">A</span></span> <span class="keyword">of</span> <code>{</code><table class="typetable">
+<tr>
+<td align="left" valign="top" >
+<code>&nbsp;&nbsp;</code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTVariants.A.x">x</span>&nbsp;: <code class="type">int</code>;</code></td>
+
+</tr></table>
+}
+</code></td>
+<td class="typefieldcomment" align="left" valign="top" ><code>(*</code></td><td class="typefieldcomment" align="left" valign="top" ><div class="info ">
+doc for A<br>
+</div>
+</td><td class="typefieldcomment" align="left" valign="bottom" ><code>*)</code></td>
+</tr>
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTw.B"><span class="constructor">B</span></span> <span class="keyword">of</span> <code>{</code><table class="typetable">
+<tr>
+<td align="left" valign="top" >
+<code>&nbsp;&nbsp;</code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTVariants.B.y">y</span>&nbsp;: <code class="type">int</code>;</code></td>
+
+</tr></table>
+}
+</code></td>
+<td class="typefieldcomment" align="left" valign="top" ><code>(*</code></td><td class="typefieldcomment" align="left" valign="top" ><div class="info ">
+doc for B<br>
+</div>
+</td><td class="typefieldcomment" align="left" valign="bottom" ><code>*)</code></td>
+</tr></table>
+
+<div class="info ">
+With records<br>
+</div>
+
+
+<pre><code><span id="TYPEz"><span class="keyword">type</span> <code class="type"></code>z</span> = </code></pre><table class="typetable">
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTz.A"><span class="constructor">A</span></span> <span class="keyword">of</span> <code class="type">int</code></code></td>
+<td class="typefieldcomment" align="left" valign="top" ><code>(*</code></td><td class="typefieldcomment" align="left" valign="top" ><div class="info ">
+doc for A<br>
+</div>
+</td><td class="typefieldcomment" align="left" valign="bottom" ><code>*)</code></td>
+</tr>
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTz.B"><span class="constructor">B</span></span> <span class="keyword">of</span> <code class="type">int</code></code></td>
+<td class="typefieldcomment" align="left" valign="top" ><code>(*</code></td><td class="typefieldcomment" align="left" valign="top" ><div class="info ">
+doc for B<br>
+</div>
+</td><td class="typefieldcomment" align="left" valign="bottom" ><code>*)</code></td>
+</tr></table>
+
+<div class="info ">
+With args<br>
+</div>
+
+
+<pre><code><span id="TYPEa"><span class="keyword">type</span> <code class="type"></code>a</span> = </code></pre><table class="typetable">
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTa.A"><span class="constructor">A</span></span> <span class="keyword">:</span> <code class="type"><a href="Variants.html#TYPEa">a</a></code></code></td>
+<td class="typefieldcomment" align="left" valign="top" ><code>(*</code></td><td class="typefieldcomment" align="left" valign="top" ><div class="info ">
+doc for A<br>
+</div>
+</td><td class="typefieldcomment" align="left" valign="bottom" ><code>*)</code></td>
+</tr></table>
+
+<div class="info ">
+Gadt notation<br>
+</div>
+
+
+<pre><code><span id="TYPEb"><span class="keyword">type</span> <code class="type"></code>b</span> = </code></pre><table class="typetable">
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTb.B"><span class="constructor">B</span></span></code></td>
+<td class="typefieldcomment" align="left" valign="top" ><code>(*</code></td><td class="typefieldcomment" align="left" valign="top" ><div class="info ">
+doc for B<br>
+</div>
+</td><td class="typefieldcomment" align="left" valign="bottom" ><code>*)</code></td>
+</tr></table>
+
+<div class="info ">
+Lonely constructor<br>
+</div>
+
+
+<pre><code><span id="TYPEno_documentation"><span class="keyword">type</span> <code class="type"></code>no_documentation</span> = </code></pre><table class="typetable">
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTno_documentation.A"><span class="constructor">A</span></span></code></td>
+
+</tr>
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTno_documentation.B"><span class="constructor">B</span></span></code></td>
+
+</tr>
+<tr>
+<td align="left" valign="top" >
+<code><span class="keyword">|</span></code></td>
+<td align="left" valign="top" >
+<code><span id="TYPEELTno_documentation.C"><span class="constructor">C</span></span></code></td>
+
+</tr></table>
+
+
+</body></html>


### PR DESCRIPTION
[MPR#7488:](https://caml.inria.fr/mantis/view.php?id=7488)
This PR fixes three problems with the latex code generated for constructors without arguments: first, 
due to a missing flush, the constructor name could end up generated outside of any ocamldoc code environement (or not at all), second  there were some spurious newlines after extension constructor, third gadt constructor types were printed with a leading array,  i.e `A: -> a` rather than `A:a`.