### PR TITLE
Test mingw32 in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,21 +34,18 @@ cache:
   - C:\cygwin\var\cache\setup
 
 install:
-  - mkdir "%OCAMLROOT%"
-  - mkdir "%OCAMLROOT%/bin"
   - mkdir "%OCAMLROOT%/bin/flexdll"
   - appveyor DownloadFile "http://alain.frisch.fr/flexdll/flexdll-bin-0.35.zip" -FileName "flexdll.zip"
   - cinst 7zip.commandline
   - 7za x -y flexdll.zip
-  - for %%F in (*.c *.h *.exe *.o *.obj) do copy %%F "%OCAMLROOT%\bin\flexdll"
+  - for %%F in (flexdll.h flexlink.exe flexdll*_msvc64.obj default_amd64.manifest) do copy %%F "%OCAMLROOT%\bin\flexdll"
   # Make sure the Cygwin path comes before the Git one (otherwise
   # cygpath behaves crazily), but after the MSVC one.
-  - set Path=C:\cygwin\bin;%Path%
+  - set Path=C:\cygwin\bin;%OCAMLROOT%\bin\flexdll;%Path%
   - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
-  - '"%CYG_ROOT%\setup-x86.exe" -qgnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P diffutils -P dos2unix -P gcc-core -P make -P ncurses >NUL'
+  - '"%CYG_ROOT%\setup-x86.exe" -qgnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P diffutils -P make >NUL'
   - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
   - call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
-  - set Path=%OCAMLROOT%\bin;%OCAMLROOT%\bin\flexdll;%Path%
 
 build_script:
   - set PFPATH=%PROGRAMFILES%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,18 +48,7 @@ install:
   - call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
 
 build_script:
-  - set PFPATH=%PROGRAMFILES%
-  - set FLEXDLLDIR=%OCAMLROOT%\bin\flexdll
-  - echo VCPATH="`cygpath -p '%Path%'`" > %CYG_ROOT%\tmp\msenv
-  - echo LIB="%LIB%" >> %CYG_ROOT%\tmp\msenv
-  - echo LIBPATH="%LIBPATH%" >> %CYG_ROOT%\tmp\msenv
-  - echo INCLUDE="%INCLUDE%;%FLEXDLLDIR%" >> %CYG_ROOT%\tmp\msenv
-  - echo FLPATH="`cygpath '%FLEXDLLDIR%'`" >> %CYG_ROOT%\tmp\msenv
-  - echo PATH="$VCPATH:$FLPATH:$PATH" >> %CYG_ROOT%\tmp\msenv
-  - echo export PATH LIB LIBPATH INCLUDE >> %CYG_ROOT%\tmp\msenv
-  - echo export OCAMLBUILD_FIND=/usr/bin/find >> %CYG_ROOT%\tmp\msenv
-  - "%CYG_ROOT%/bin/bash -lc \"tr -d '\\r' </tmp/msenv > ~/.msenv64\""
-  - "%CYG_ROOT%/bin/bash -lc \"echo '. ~/.msenv64' >> ~/.bash_profile\""
+  - "%CYG_ROOT%/bin/bash -lc \"echo 'eval $($APPVEYOR_BUILD_FOLDER/tools/msvs-promote-path)' >> ~/.bash_profile\""
   - '%CYG_ROOT%/bin/bash -lc "$APPVEYOR_BUILD_FOLDER/appveyor_build.sh"'
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ environment:
     CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
     CYG_CACHE: C:/cygwin/var/cache/setup
     OCAMLROOT: "%PROGRAMFILES%/OCaml"
+    OCAMLROOT2: "%PROGRAMFILES%/OCaml-mingw32"
 
 cache:
   - C:\cygwin\var\cache\setup
@@ -43,7 +44,7 @@ install:
   # cygpath behaves crazily), but after the MSVC one.
   - set Path=C:\cygwin\bin;%OCAMLROOT%\bin\flexdll;%Path%
   - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
-  - '"%CYG_ROOT%\setup-x86.exe" -qgnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P diffutils -P make >NUL'
+  - '"%CYG_ROOT%\setup-x86.exe" -qgnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P diffutils -P make -P mingw64-i686-gcc-core >NUL'
   - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
   - call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
 
@@ -55,4 +56,6 @@ test_script:
   - '%APPVEYOR_BUILD_FOLDER%\ocamlc.opt -version'
   - set CAML_LD_LIBRARY_PATH=%OCAMLROOT%/lib/stublibs
   - '%CYG_ROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && make tests"'
+  - '%CYG_ROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER/../build-mingw32 && make tests"'
   - '%CYG_ROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && make install"'
+  - '%CYG_ROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER/../build-mingw32 && make install"'

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -29,6 +29,14 @@ function run {
 
 cd $APPVEYOR_BUILD_FOLDER
 
+git worktree add ../build-mingw32 -b appveyor-build-mingw32
+
+cd ../build-mingw32
+
+git submodule update --init flexdll
+
+cd $APPVEYOR_BUILD_FOLDER
+
 cp config/m-nt.h config/m.h
 cp config/s-nt.h config/s.h
 cp config/Makefile.msvc64 config/Makefile
@@ -42,3 +50,17 @@ run "make world" make world
 run "make bootstrap" make bootstrap
 run "make opt" make opt
 run "make opt.opt" make opt.opt
+
+cd ../build-mingw32
+
+cp config/m-nt.h config/m.h
+cp config/s-nt.h config/s.h
+cp config/Makefile.mingw config/Makefile
+
+PREFIX="C:/Program Files/OCaml-mingw32"
+echo "Edit config/Makefile to set PREFIX=$PREFIX"
+sed -i -e "s|PREFIX=.*|PREFIX=$PREFIX|" config/Makefile
+#run "Content of config/Makefile" cat config/Makefile
+
+run "make flexdll" make flexdll
+run "make world.opt" make world.opt

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -31,13 +31,11 @@ cd $APPVEYOR_BUILD_FOLDER
 
 cp config/m-nt.h config/m.h
 cp config/s-nt.h config/s.h
-#cp config/Makefile.msvc config/Makefile
 cp config/Makefile.msvc64 config/Makefile
 
 PREFIX="C:/Program Files/OCaml"
-echo "Edit config/Makefile so set PREFIX=$PREFIX"
-cp config/Makefile config/Makefile.bak
-sed -e "s|PREFIX=.*|PREFIX=$PREFIX|" config/Makefile.bak > config/Makefile
+echo "Edit config/Makefile to set PREFIX=$PREFIX"
+sed -i -e "s|PREFIX=.*|PREFIX=$PREFIX|" config/Makefile
 #run "Content of config/Makefile" cat config/Makefile
 
 run "make world" make world

--- a/testsuite/tests/lib-dynlink-csharp/Makefile
+++ b/testsuite/tests/lib-dynlink-csharp/Makefile
@@ -14,7 +14,8 @@
 #**************************************************************************
 
 BASEDIR=../..
-CSC_COMMAND=csc
+# Only run this test for TOOLCHAIN=msvc
+CSC_COMMAND=$(filter csc,$(subst msvc,csc,$(TOOLCHAIN)))
 CSC=$(CSC_COMMAND) $(CSC_FLAGS)
 
 COMPFLAGS=-I $(OTOPDIR)/otherlibs/bigarray -I $(OTOPDIR)/otherlibs/dynlink \


### PR DESCRIPTION
The primary purpose of this GPR is to add mingw32 testing to the CI. Various points:

 - The two builds take roughly the same as the flambda Travis test :smile:
 - It means that Windows is tested in both 32 and 64-bit variants
 - mingw32 means that the oldest (and least featured) msvcrt.dll is tested against - see #861
 - Using the two builds allows the FlexDLL bootstrap mode to be tested