### PR TITLE
Toplevel truncates long strings and prints bytes (replace #454)

### DIFF
--- a/Changes
+++ b/Changes
@@ -147,6 +147,10 @@ Working version
   included by other header files
   (Sébastien Hinderer)
 
+- GPR#1058, MPR#7127, GPR#454: in toplevel, print bytes and strip
+  strings longer than the size specified by the "print_length" directive
+  (Fabrice Le Fessant, initial PR by Junsong Li)
+
 ### Bug fixes
 
 - PR#5927: Type equality broken for conjunctive polymorphic variant tags

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -95,7 +95,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                (* Note: this could be a char or a constant constructor... *)
           else if O.tag arg = Obj.string_tag then
             list :=
-              Oval_string (String.escaped (O.obj arg : string)) :: !list
+              Oval_string ((O.obj arg : string), max_int, Ostr_string) :: !list
           else if O.tag arg = Obj.double_tag then
             list := Oval_float (O.obj arg : float) :: !list
           else
@@ -137,9 +137,6 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
       ( Pident(Ident.create "print_char"),
         Simple (Predef.type_char,
                 (fun x -> Oval_char (O.obj x : char))) );
-      ( Pident(Ident.create "print_string"),
-        Simple (Predef.type_string,
-                (fun x -> Oval_string (O.obj x : string))) );
       ( Pident(Ident.create "print_int32"),
         Simple (Predef.type_int32,
                 (fun x -> Oval_int32 (O.obj x : int32))) );
@@ -301,6 +298,16 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                     Oval_array (List.rev (tree_of_items [] 0))
               else
                 Oval_array []
+
+          | Tconstr(path, [], _)
+              when Path.same path Predef.path_string ->
+            Oval_string ((O.obj obj : string), !printer_steps, Ostr_string)
+
+          | Tconstr (path, [], _)
+              when Path.same path Predef.path_bytes ->
+            let s = Bytes.to_string (O.obj obj : bytes) in
+            Oval_string (s, !printer_steps, Ostr_bytes)
+
           | Tconstr (path, [ty_arg], _)
             when Path.same path Predef.path_lazy_t ->
              let obj_tag = O.tag obj in

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -27,6 +27,10 @@ type out_ident =
   | Oide_dot of out_ident * string
   | Oide_ident of string
 
+type out_string =
+  | Ostr_string
+  | Ostr_bytes
+
 type out_attribute =
   { oattr_name: string }
 
@@ -43,7 +47,7 @@ type out_value =
   | Oval_list of out_value list
   | Oval_printer of (Format.formatter -> unit)
   | Oval_record of (out_ident * out_value) list
-  | Oval_string of string
+  | Oval_string of string * int * out_string (* string, size-to-print, kind *)
   | Oval_stuff of string
   | Oval_tuple of out_value list
   | Oval_variant of string * out_value option


### PR DESCRIPTION
Following a discussion of caml-devel, this PR replaces #454 to:
* print bytes in toplevel, as `Bytes.of_string "....."`
* strip long strings, as `"XXXXXXXXXXXXX"... (* string stripped from 2000000 to 20 chars *)`
