### PR TITLE
Add runtime functions for integer arithmetic with checked overflow

### DIFF
--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -124,6 +124,43 @@ CAMLnoreturn_end;
 CAMLextern char * caml_strdup(const char * s);
 CAMLextern char * caml_strconcat(int n, ...); /* n args of const char * type */
 
+/* Integer arithmetic with overflow detection */ 
+
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif  
+
+static inline int caml_addu_overflow(uintnat a, uintnat b, uintnat * res)
+{
+#if __GNUC__ >= 5 || __has_builtin(__builtin_add_overflow)
+  return __builtin_add_overflow(a, b, res);
+#else
+  uintnat c = a + b;
+  *res = c;
+  return c < a;
+#endif
+}
+  
+static inline int caml_subu_overflow(uintnat a, uintnat b, uintnat * res)
+{
+#if __GNUC__ >= 5 || __has_builtin(__builtin_sub_overflow)
+  return __builtin_sub_overflow(a, b, res);
+#else
+  uintnat c = a - b;
+  *res = c;
+  return a < b;
+#endif
+}
+  
+#if __GNUC__ >= 5 || __has_builtin(__builtin_mul_overflow)
+static inline int caml_mulu_overflow(uintnat a, uintnat b, uintnat * res)
+{
+  return __builtin_mul_overflow(a, b, res);
+}
+#else
+extern int caml_mulu_overflow(uintnat a, uintnat b, uintnat * res);
+#endif  
+
 /* Use macros for some system calls being called from OCaml itself.
   These calls can be either traced for security reasons, or changed to
   virtualize the program. */

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -124,6 +124,14 @@ CAMLnoreturn_end;
 CAMLextern char * caml_strdup(const char * s);
 CAMLextern char * caml_strconcat(int n, ...); /* n args of const char * type */
 
+/* Detection of available C built-in functions, the Clang way. */
+
+#ifdef __has_builtin
+#define Caml_has_builtin(x) __has_builtin(x)
+#else
+#define Caml_has_builtin(x) 0
+#endif  
+
 /* Integer arithmetic with overflow detection.
    The functions return 0 if no overflow, 1 if overflow.
    The result of the operation is always stored at [*res].
@@ -131,13 +139,9 @@ CAMLextern char * caml_strconcat(int n, ...); /* n args of const char * type */
    If overflow is reported, this is the exact result modulo 2 to the word size.
 */
 
-#ifndef __has_builtin
-#define __has_builtin(x) 0
-#endif  
-
 static inline int caml_uadd_overflow(uintnat a, uintnat b, uintnat * res)
 {
-#if __GNUC__ >= 5 || __has_builtin(__builtin_add_overflow)
+#if __GNUC__ >= 5 || Caml_has_builtin(__builtin_add_overflow)
   return __builtin_add_overflow(a, b, res);
 #else
   uintnat c = a + b;
@@ -148,7 +152,7 @@ static inline int caml_uadd_overflow(uintnat a, uintnat b, uintnat * res)
   
 static inline int caml_usub_overflow(uintnat a, uintnat b, uintnat * res)
 {
-#if __GNUC__ >= 5 || __has_builtin(__builtin_sub_overflow)
+#if __GNUC__ >= 5 || Caml_has_builtin(__builtin_sub_overflow)
   return __builtin_sub_overflow(a, b, res);
 #else
   uintnat c = a - b;
@@ -157,7 +161,7 @@ static inline int caml_usub_overflow(uintnat a, uintnat b, uintnat * res)
 #endif
 }
   
-#if __GNUC__ >= 5 || __has_builtin(__builtin_mul_overflow)
+#if __GNUC__ >= 5 || Caml_has_builtin(__builtin_mul_overflow)
 static inline int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
 {
   return __builtin_mul_overflow(a, b, res);

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -135,7 +135,7 @@ CAMLextern char * caml_strconcat(int n, ...); /* n args of const char * type */
 #define __has_builtin(x) 0
 #endif  
 
-static inline int caml_addu_overflow(uintnat a, uintnat b, uintnat * res)
+static inline int caml_uadd_overflow(uintnat a, uintnat b, uintnat * res)
 {
 #if __GNUC__ >= 5 || __has_builtin(__builtin_add_overflow)
   return __builtin_add_overflow(a, b, res);
@@ -146,7 +146,7 @@ static inline int caml_addu_overflow(uintnat a, uintnat b, uintnat * res)
 #endif
 }
   
-static inline int caml_subu_overflow(uintnat a, uintnat b, uintnat * res)
+static inline int caml_usub_overflow(uintnat a, uintnat b, uintnat * res)
 {
 #if __GNUC__ >= 5 || __has_builtin(__builtin_sub_overflow)
   return __builtin_sub_overflow(a, b, res);
@@ -158,12 +158,12 @@ static inline int caml_subu_overflow(uintnat a, uintnat b, uintnat * res)
 }
   
 #if __GNUC__ >= 5 || __has_builtin(__builtin_mul_overflow)
-static inline int caml_mulu_overflow(uintnat a, uintnat b, uintnat * res)
+static inline int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
 {
   return __builtin_mul_overflow(a, b, res);
 }
 #else
-extern int caml_mulu_overflow(uintnat a, uintnat b, uintnat * res);
+extern int caml_umul_overflow(uintnat a, uintnat b, uintnat * res);
 #endif  
 
 /* Use macros for some system calls being called from OCaml itself.

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -124,7 +124,12 @@ CAMLnoreturn_end;
 CAMLextern char * caml_strdup(const char * s);
 CAMLextern char * caml_strconcat(int n, ...); /* n args of const char * type */
 
-/* Integer arithmetic with overflow detection */ 
+/* Integer arithmetic with overflow detection.
+   The functions return 0 if no overflow, 1 if overflow.
+   The result of the operation is always stored at [*res].
+   If no overflow is reported, this is the exact result.
+   If overflow is reported, this is the exact result modulo 2 to the word size.
+*/
 
 #ifndef __has_builtin
 #define __has_builtin(x) 0

--- a/byterun/misc.c
+++ b/byterun/misc.c
@@ -222,11 +222,11 @@ CAMLexport int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
                         + LOW_HALF(al * bh) << HALF_SIZE overflows.
      This sum is equal to p = (a * b) modulo word size. */
   uintnat p = a * b;
+  uintnat p1 = al * bh;
+  uintnat p2 = ah * bl;
   *res = p;
   if (ah == 0 && bh == 0) return 0;
   if (ah != 0 && bh != 0) return 1;
-  uintnat p1 = al * bh;
-  uintnat p2 = ah * bl;
   if (HIGH_HALF(p1) != 0 || HIGH_HALF(p2) != 0) return 1;
   p1 <<= HALF_SIZE;
   p2 <<= HALF_SIZE;

--- a/byterun/misc.c
+++ b/byterun/misc.c
@@ -197,7 +197,7 @@ CAMLexport char * caml_strconcat(int n, ...)
 
 /* Integer arithmetic with overflow detection */ 
 
-#if ! (__GNUC__ >= 5 || __has_builtin(__builtin_mul_overflow))
+#if ! (__GNUC__ >= 5 || Caml_has_builtin(__builtin_mul_overflow))
 CAMLexport int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
 {
 #define HALF_SIZE (sizeof(uintnat) * 4)

--- a/byterun/misc.c
+++ b/byterun/misc.c
@@ -198,7 +198,7 @@ CAMLexport char * caml_strconcat(int n, ...)
 /* Integer arithmetic with overflow detection */ 
 
 #if ! (__GNUC__ >= 5 || __has_builtin(__builtin_mul_overflow))
-CAMLexport int caml_mulu_overflow(uintnat a, uintnat b, uintnat * res)
+CAMLexport int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
 {
 #define HALF_SIZE (sizeof(uintnat) * 4)
 #define HALF_MASK (((uintnat)1 << HALF_SIZE) - 1)
@@ -225,6 +225,7 @@ CAMLexport int caml_mulu_overflow(uintnat a, uintnat b, uintnat * res)
   uintnat p2 = ah * bl;
   uintnat p = a * b;
   *res = p;
+  if (ah == 0 && bh == 0) return 0;
   if (ah != 0 && bh != 0) return 1;
   if (HIGH_HALF(p1) != 0 || HIGH_HALF(p2) != 0) return 1;
   p1 <<= HALF_SIZE;

--- a/byterun/misc.c
+++ b/byterun/misc.c
@@ -195,6 +195,50 @@ CAMLexport char * caml_strconcat(int n, ...)
   return res;
 }
 
+/* Integer arithmetic with overflow detection */ 
+
+#if ! (__GNUC__ >= 5 || __has_builtin(__builtin_mul_overflow))
+CAMLexport int caml_mulu_overflow(uintnat a, uintnat b, uintnat * res)
+{
+#define HALF_SIZE (sizeof(uintnat) * 4)
+#define HALF_MASK (((uintnat)1 << HALF_SIZE) - 1)
+#define LOW_HALF(x) ((x) & HALF_MASK)
+#define HIGH_HALF(x) ((x) >> HALF_SIZE)
+  /* Cut in half words */
+  uintnat al = LOW_HALF(a);
+  uintnat ah = HIGH_HALF(a);
+  uintnat bl = LOW_HALF(b);
+  uintnat bh = HIGH_HALF(b);
+  /* Exact product is:
+              al * bl
+           +  ah * bl  << HALF_SIZE
+           +  al * bh  << HALF_SIZE
+           +  ah * bh  << 2*HALF_SIZE
+     Overflow occurs if:
+        ah * bh is not 0, i.e. ah != 0 and bh != 0
+     OR ah * bl has high half != 0
+     OR al * bh has high half != 0
+     OR the sum al * bl + LOW_HALF(ah * bl) << HALF_SIZE
+                        + LOW_HALF(al * bh) << HALF_SIZE overflows.
+     This sum is equal to p = (a * b) modulo word size. */
+  uintnat p1 = al * bh;
+  uintnat p2 = ah * bl;
+  uintnat p = a * b;
+  *res = p;
+  if (ah != 0 && bh != 0) return 1;
+  if (HIGH_HALF(p1) != 0 || HIGH_HALF(p2) != 0) return 1;
+  p1 <<= HALF_SIZE;
+  p2 <<= HALF_SIZE;
+  p1 += p2;
+  if (p < p1 || p1 < p2) return 1; /* overflow in sums */
+  return 0;
+#undef HALF_SIZE
+#undef HALF_MASK
+#undef LOW_HALF
+#undef HIGH_HALF
+}
+#endif
+
 /* Runtime warnings */
 
 uintnat caml_runtime_warnings = 0;

--- a/byterun/misc.c
+++ b/byterun/misc.c
@@ -221,12 +221,12 @@ CAMLexport int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
      OR the sum al * bl + LOW_HALF(ah * bl) << HALF_SIZE
                         + LOW_HALF(al * bh) << HALF_SIZE overflows.
      This sum is equal to p = (a * b) modulo word size. */
-  uintnat p1 = al * bh;
-  uintnat p2 = ah * bl;
   uintnat p = a * b;
   *res = p;
   if (ah == 0 && bh == 0) return 0;
   if (ah != 0 && bh != 0) return 1;
+  uintnat p1 = al * bh;
+  uintnat p2 = ah * bl;
   if (HIGH_HALF(p1) != 0 || HIGH_HALF(p2) != 0) return 1;
   p1 <<= HALF_SIZE;
   p2 <<= HALF_SIZE;

--- a/otherlibs/bigarray/bigarray_stubs.c
+++ b/otherlibs/bigarray/bigarray_stubs.c
@@ -112,10 +112,10 @@ caml_ba_alloc(int flags, int num_dims, void * data, intnat * dim)
   if (data == NULL) {
     num_elts = 1;
     for (i = 0; i < num_dims; i++) {
-      if (caml_mulu_overflow(num_elts, dimcopy[i], &num_elts))
+      if (caml_umul_overflow(num_elts, dimcopy[i], &num_elts))
         caml_raise_out_of_memory();
     }
-    if (caml_mulu_overflow(num_elts,
+    if (caml_umul_overflow(num_elts,
                            caml_ba_element_size[flags & CAML_BA_KIND_MASK],
                            &size))
       caml_raise_out_of_memory();

--- a/otherlibs/bigarray/bigarray_stubs.c
+++ b/otherlibs/bigarray/bigarray_stubs.c
@@ -84,48 +84,6 @@ static struct custom_operations caml_ba_ops = {
   custom_compare_ext_default
 };
 
-/* Multiplication of unsigned longs with overflow detection */
-
-static uintnat
-caml_ba_multov(uintnat a, uintnat b, int * overflow)
-{
-#define HALF_SIZE (sizeof(uintnat) * 4)
-#define HALF_MASK (((uintnat)1 << HALF_SIZE) - 1)
-#define LOW_HALF(x) ((x) & HALF_MASK)
-#define HIGH_HALF(x) ((x) >> HALF_SIZE)
-  /* Cut in half words */
-  uintnat al = LOW_HALF(a);
-  uintnat ah = HIGH_HALF(a);
-  uintnat bl = LOW_HALF(b);
-  uintnat bh = HIGH_HALF(b);
-  /* Exact product is:
-              al * bl
-           +  ah * bl  << HALF_SIZE
-           +  al * bh  << HALF_SIZE
-           +  ah * bh  << 2*HALF_SIZE
-     Overflow occurs if:
-        ah * bh is not 0, i.e. ah != 0 and bh != 0
-     OR ah * bl has high half != 0
-     OR al * bh has high half != 0
-     OR the sum al * bl + LOW_HALF(ah * bl) << HALF_SIZE
-                        + LOW_HALF(al * bh) << HALF_SIZE overflows.
-     This sum is equal to p = (a * b) modulo word size. */
-  uintnat p1 = al * bh;
-  uintnat p2 = ah * bl;
-  uintnat p = a * b;
-  if (ah != 0 && bh != 0) *overflow = 1;
-  if (HIGH_HALF(p1) != 0 || HIGH_HALF(p2) != 0) *overflow = 1;
-  p1 <<= HALF_SIZE;
-  p2 <<= HALF_SIZE;
-  p1 += p2;
-  if (p < p1 || p1 < p2) *overflow = 1; /* overflow in sums */
-  return p;
-#undef HALF_SIZE
-#undef HALF_MASK
-#undef LOW_HALF
-#undef HIGH_HALF
-}
-
 /* Allocation of a big array */
 
 #define CAML_BA_MAX_MEMORY 1024*1024*1024
@@ -142,7 +100,7 @@ CAMLexport value
 caml_ba_alloc(int flags, int num_dims, void * data, intnat * dim)
 {
   uintnat num_elts, asize, size;
-  int overflow, i;
+  int i;
   value res;
   struct caml_ba_array * b;
   intnat dimcopy[CAML_BA_MAX_NUM_DIMS];
@@ -152,15 +110,15 @@ caml_ba_alloc(int flags, int num_dims, void * data, intnat * dim)
   for (i = 0; i < num_dims; i++) dimcopy[i] = dim[i];
   size = 0;
   if (data == NULL) {
-    overflow = 0;
     num_elts = 1;
     for (i = 0; i < num_dims; i++) {
-      num_elts = caml_ba_multov(num_elts, dimcopy[i], &overflow);
+      if (caml_mulu_overflow(num_elts, dimcopy[i], &num_elts))
+        caml_raise_out_of_memory();
     }
-    size = caml_ba_multov(num_elts,
-                          caml_ba_element_size[flags & CAML_BA_KIND_MASK],
-                          &overflow);
-    if (overflow) caml_raise_out_of_memory();
+    if (caml_mulu_overflow(num_elts,
+                           caml_ba_element_size[flags & CAML_BA_KIND_MASK],
+                           &size))
+      caml_raise_out_of_memory();
     data = malloc(size);
     if (data == NULL && size != 0) caml_raise_out_of_memory();
     flags |= CAML_BA_MANAGED;


### PR DESCRIPTION
As suggested in [MPR#7492](https://caml.inria.fr/mantis/view.php?id=7492).  This is a first step towards more safety against overflows in the runtime system.

Currently, addition, subtraction and multiplication are provided at type "uintnat".  The implementation uses GCC / Clang builtins if available, or portable C code otherwise.

Overflow-detecting multiplication was already defined and used in otherlibs/bigarrays/bigarray_stubs.c.  The bigarray code was adapted to use the new runtime functions.