### PR TITLE
Fix stack overflow detection (MPR#7490)

### DIFF
--- a/Changes
+++ b/Changes
@@ -31,6 +31,10 @@ Next version (4.05.0):
 - GPR#891: Use -fno-builtin-memcmp when building runtime with gcc.
   (Leo White)
 
+- PR#7490, GPR#1062: Fix stack overflow detection for Unix-like
+  platforms in the presence of threads.  Fix stack usage calculation
+  in the presence of threads.  (Pierre Chambart, Mark Shinwell)
+
 ### Type system:
 
 - PR#6608, GPR#901: unify record types when overriding all fields

--- a/asmrun/roots.c
+++ b/asmrun/roots.c
@@ -221,6 +221,7 @@ void caml_unregister_frametable(intnat *table) {
 /* Communication with [caml_start_program] and [caml_call_gc]. */
 
 char * caml_top_of_stack;
+size_t caml_stack_size;
 char * caml_bottom_of_stack = NULL; /* no stack initially */
 uintnat caml_last_return_address = 1; /* not in OCaml code initially */
 value * caml_gc_regs;

--- a/byterun/caml/stack.h
+++ b/byterun/caml/stack.h
@@ -122,6 +122,14 @@ extern char caml_globals_map[];
 extern intnat caml_globals_inited;
 extern intnat * caml_frametable[];
 
+/* Size of the stack in bytes for the current thread.  There are two
+   special values:
+
+    0 => this is the main thread, whose size may be dynamic.
+    -1 => stack size unknown (and it's not the main thread)
+*/
+extern size_t caml_stack_size;
+
 CAMLextern frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp);
 
 #endif /* CAML_INTERNALS */

--- a/configure
+++ b/configure
@@ -1584,13 +1584,39 @@ if test "$pthread_wanted" = "yes"; then
     bytecccompopts="$bytecccompopts -D_REENTRANT"
     nativecccompopts="$nativecccompopts -D_REENTRANT"
     case "$target" in
+      *,*-*-darwin*)
+          if sh ./hasgot -i pthread.h $pthread_link pthread_get_stacksize_np;
+          then
+            inf "pthread_get_stacksize_np() found"
+            echo "#define HAS_PTHREAD_GET_STACKSIZE_NP" >> s.h
+          fi
+          if sh ./hasgot -i pthread.h $pthread_link pthread_get_stackaddr_np;
+          then
+            inf "pthread_get_stackaddr_np() found"
+            echo "#define HAS_PTHREAD_GET_STACKADDR_NP" >> s.h
+          fi
+          ;;
       *-*-freebsd*|*-*-dragonfly*)
+          if sh ./hasgot -i pthread.h $pthread_link pthread_attr_get_np; then
+            inf "pthread_attr_get_np() found"
+            echo "#define PTHREAD_GETATTR_NP pthread_attr_get_np" >> s.h
+          fi
           bytecccompopts="$bytecccompopts -D_THREAD_SAFE"
           nativecccompopts="$nativecccompopts -D_THREAD_SAFE";;
       *-*-openbsd*)
+          if sh ./hasgot -i pthread.h $pthread_link pthread_stackseg_np; then
+            inf "pthread_stackseg_np() found"
+            echo "#define HAS_PTHREAD_STACKSEG_NP" >> s.h
+          fi
           bytecccompopts="$bytecccompopts -pthread"
           asppflags="$asppflags -pthread"
           nativecccompopts="$nativecccompopts -pthread";;
+      *)
+          if sh ./hasgot -i pthread.h $pthread_link pthread_getattr_np; then
+            inf "pthread_getattr_np() found"
+            echo "#define PTHREAD_GETATTR_NP pthread_getattr_np" >> s.h
+          fi
+          ;;
     esac
     inf "Options for linking with POSIX threads: $pthread_link"
     if sh ./hasgot $pthread_link sigwait; then

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -391,7 +391,7 @@ static value caml_thread_new_descriptor(value clos)
     /* Create and initialize the termination semaphore */
     mu = caml_threadstatus_new();
     /* Create a descriptor for the new thread */
-    descr = caml_alloc_small(4, 0);
+    descr = caml_alloc_small(3, 0);
     Ident(descr) = Val_long(thread_next_ident);
     Start_closure(descr) = clos;
     Terminated(descr) = mu;

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -422,3 +422,17 @@ value caml_wait_signal(value sigs) /* ML */
   caml_invalid_argument("Thread.wait_signal not implemented");
   return Val_int(0);            /* not reached */
 }
+
+void st_determine_thread_stack_size(void** top_of_stack, size_t* stack_size)
+{
+#ifdef _WIN64
+  *top_of_stack = (void*) __readgsqword(offsetof(NT_TIB64, StackBase));
+#endif
+#ifdef _WIN32
+  *top_of_stack = (void*) __readfsdword(offsetof(NT_TIB, StackBase));
+#endif
+
+  /* The stack size is only needed for the Unix-style stack overflow
+     detection code. */
+  *stack_size = -1;
+}


### PR DESCRIPTION
Mantis 7490, using a small but yet highly involved example, demonstrates that the current detection of stack overflow is broken when the fault happens in a thread.  This turns out to be caused by two problems:
1. It is necessary to assign an alternate stack to be used for the execution of signal handlers associated with a signal delivered to a specific thread, even though the setting of which handler is to be executed is process-wide.  At least on Linux, signals arising from processor faults (e.g. `SIGSEGV`) will be delivered to the thread that caused them.
2. When the example in MPR#7490 is operating correctly, there are multiple invocations of the OCaml signal handler for SIGSEGV, until sufficient stack space has been recovered for the exception handler to run without causing another signal.  At least on my system what eventually happens is that a segfault arises in a runtime function outputting a string.  That signal shouldn't terminate the program because `caml_c_call` should have faulted before calling that C function (which in turn should have triggered another invocation of the signal handler and more unwinding).  Unfortunately it wasn't faulting because the guard page size for the thread stack wasn't large enough.  This patch now makes it match up with `caml_c_call`.

The `segv_handler` needs to know what size the current stack is; a new variable is introduced for this.  Unfortunately determination of the size of a thread stack is troublesome.  One approach is to initialise a pthread attributes block and then query it before it is passed to `pthread_create`, hoping that the creation function doesn't mess with the size.  However the threading of the resulting size to the correct place in `st_stubs.c` is awkward and it won't work for threads registered with the OCaml runtime but not created by it.  Instead we use platform-dependent methods to determine the thread stack size after creation; this has the nice side effect of giving us a more accurate top-of-stack value as well.  At present, if C code registers a thread when the stack depth is deeper than it will be when some OCaml code running in that thread causes a segfault, then the stack overflow detection code may have a completely wrong top-of-stack value.  (This problem also appears to exist for e.g. `caml_startup` but this patch doesn't address that.  This could be fixed using similar code but there are some intricacies, e.g. needing to use `__libc_stack_end` rather than the pthreads function on glibc since it's the main thread.)

The means of determining stack base and size should work at least on Linux, FreeBSD, OpenBSD and macOS.  I haven't yet tested on all these platforms but will do so.  The code for doing this was inspired by some from the Chromium project [*] although it was written afresh.

This patch should also fix the stack size calculation in the presence of threads, subsuming GPR#961.  It is currently based on 4.05 but may be more appropriate for trunk.  Hopefully it will fix complaints about the stack overflow check seemingly not working correctly (there's been some such at Jane Street and I think this threads problem is probably the underlying reason).

As an aside, we are executing potentially non-async-signal-safe functions (cf. `man 7 signal`) in the signal handler, but it's unclear how to do better as noted in the patch.

[*] https://chromium.googlesource.com/experimental/chromium/blink/+/master/Source/platform/heap/StackFrameDepth.cpp