### PR TITLE
Fix MacOS test unwind_test

### DIFF
--- a/testsuite/tests/unwind/Makefile
+++ b/testsuite/tests/unwind/Makefile
@@ -31,7 +31,7 @@ unwind_test:
 	@$(OCAMLOPT) -c -opaque mylib.mli
 	@$(OCAMLOPT) -c driver.ml
 	@$(OCAMLOPT) -c mylib.ml
-	@$(OCAMLOPT) -c stack_walker.c
+	@$(OCAMLOPT) -ccopt -I -ccopt $(CTOPDIR)/byterun -c stack_walker.c
 	@$(OCAMLOPT) -cclib -Wl,-keep_dwarf_unwind -o unwind_test mylib.cmx \
 	             driver.cmx stack_walker.o
 


### PR DESCRIPTION
The error was `stack_walker.c:4:10: fatal error: 'caml/callback.h' file not found`