### PR TITLE
Fix for GPR#863

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -1355,8 +1355,8 @@ let make_switch arg cases actions dbg =
       let sym = Compilenv.new_structured_constant ~shared:true c in
       Uconst_ref(sym, Some c) in
     let to_uconst = function
-      | Cconst_int n -> Uconst_int (n lsr 1)
-      | Cconst_pointer n -> Uconst_ptr (n lsr 1)
+      | Cconst_int n -> Uconst_int (n asr 1)
+      | Cconst_pointer n -> Uconst_ptr (n asr 1)
       | Cconst_symbol s -> Uconst_ref (s, None)
       | Cconst_natint n -> const (Uconst_nativeint n)
       | Cconst_float f -> const (Uconst_float f)

--- a/testsuite/tests/asmcomp/Makefile
+++ b/testsuite/tests/asmcomp/Makefile
@@ -52,7 +52,7 @@ lexcmm.ml: lexcmm.mll
 	@$(OCAMLLEX) -q lexcmm.mll
 
 MLCASES=optargs staticalloc bind_tuples is_static register_typing \
-  register_typing_switch
+  register_typing_switch switch_using_array
 ARGS_optargs=-g
 ARGS_is_static=-I $(OTOPDIR)/byterun is_in_static_data.c
 MLCASES_FLAMBDA=is_static_flambda unrolling_flambda unrolling_flambda2 \

--- a/testsuite/tests/asmcomp/switch_using_array.ml
+++ b/testsuite/tests/asmcomp/switch_using_array.ml
@@ -1,0 +1,15 @@
+let test = function
+  | 1 -> `Primary
+  | 2 -> `Secondary
+  | 3 -> `Tertiary
+  | n -> invalid_arg "test"
+
+let to_string = function
+  | `Primary -> "`Primary"
+  | `Secondary -> "`Secondary"
+  | `Tertiary -> "`Tertiary"
+
+let () =
+  assert (to_string (test 1) = "`Primary");
+  assert (to_string (test 2) = "`Secondary");
+  assert (to_string (test 3) = "`Tertiary")


### PR DESCRIPTION
The code for compiling switches to array lookups in #863 is wrong when the constants on the right-hand side of the switch are negative "const int" or "const pointer".  The top bit gets lost.