### PR TITLE
Fix optimisation of switches to lookup tables

### DIFF
--- a/Changes
+++ b/Changes
@@ -55,6 +55,11 @@ Next version (4.05.0):
   (Stephen Dolan, review by Alain Frisch, Pierre Chambart, Mark
   Shinwell, Gabriel Scherer and Damien Doligez)
 
+- GPR#863, GPR#1068, GPR#1069: Optimise matches with constant
+  results to lookup tables.
+  (Stephen Dolan, review by Gabriel Scherer, Pierre Chambart,
+  Mark Shinwell, and bug report by Gabriel Scherer)
+
 ### Runtime system:
 
 - MPR#385, GPR#953: Add caml_startup_exn

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -1351,32 +1351,7 @@ let transl_isout h arg dbg = tag_int (Cop(Ccmpa Clt, [h ; arg], dbg)) dbg
 (* Build an actual switch (ie jump table) *)
 
 let make_switch arg cases actions dbg =
-  let is_const = function
-    | Cconst_int n
-    | Cconst_pointer n -> (n land 1) = 1
-    | Cconst_natint _
-    | Cconst_float _
-    | Cconst_symbol _ -> true
-    | _ -> false in
-  if Array.for_all is_const actions then
-    let const c =
-      let sym = Compilenv.new_structured_constant ~shared:true c in
-      Uconst_ref(sym, Some c) in
-    let to_uconst = function
-      | Cconst_int n -> Uconst_int (n lsr 1)
-      | Cconst_pointer n -> Uconst_ptr (n lsr 1)
-      | Cconst_symbol s -> Uconst_ref (s, None)
-      | Cconst_natint n -> const (Uconst_nativeint n)
-      | Cconst_float f -> const (Uconst_float f)
-      | _ -> assert false in
-    let const_actions = Array.map to_uconst actions in
-    let table = Compilenv.new_structured_constant ~shared:true
-      (Uconst_block (0,
-        Array.to_list (Array.map (fun act ->
-          const_actions.(act)) cases))) in
-    addr_array_ref (Cconst_symbol table) (tag_int arg dbg) dbg
-  else
-    Cswitch (arg,cases,actions,dbg)
+  Cswitch (arg,cases,actions,dbg)
 
 module SArgBlocks =
 struct

--- a/testsuite/tests/basic/switch_opts.ml
+++ b/testsuite/tests/basic/switch_opts.ml
@@ -1,0 +1,62 @@
+(* Test for optimisation of jump tables to arrays of constants *)
+
+let p = Printf.printf
+
+type test =
+  Test : 'b * 'a * ('b -> 'a) -> test
+
+type t = A | B | C
+
+(* These test functions need to have at least three cases.
+   Functions with fewer cases don't trigger the optimisation,
+   as they are compiled to if-then-else, not switch *)
+let testcases = [
+  Test (3, 3, function 1 -> 1 | 2 -> 2 | 3 -> 3 | _ -> 0);
+  Test (3, -3, function 1 -> 1 | 2 -> 2 | 3 -> -3 | _ -> 0);
+  Test (3, min_int, function 1 -> 1 | 2 -> 2 | 3 -> min_int | _ -> 0);
+  Test (3, max_int, function 1 -> 1 | 2 -> 2 | 3 -> max_int | _ -> 0);
+  Test (3, 3., function 1 -> 1. | 2 -> 2. | 3 -> 3. | _ -> 0.);
+  Test (3, ""^"c"^"", function 1 -> "a" | 2 -> "b" | 3 -> "c" | _ -> "");
+  Test (3, List.rev [3;2;1], function 1 -> [] | 2 -> [42] | 3 -> [1;2;3] | _ -> [415]);
+
+  Test (C, 3, function A -> 1 | B -> 2 | C -> 3);
+  Test (C, -3, function A -> 1 | B -> 2 | C -> -3);
+  Test (C, min_int, function A -> 1 | B -> 2 | C -> min_int);
+  Test (C, max_int, function A -> 1 | B -> 2 | C -> max_int);
+  Test (C, 3., function A -> 1. | B -> 2. | C -> 3.);
+  Test (C, "c", function A -> "a" | B -> "b" | C -> "c");
+  Test (C, List.rev [3;2;1], function A -> [] | B -> [42] | C -> [1;2;3]);
+
+  Test (42, 42, function
+  | 1 -> 1 | 2 -> 2 | 3 -> 3 | 4 -> 4 | 5 -> 5 | 6 -> 6 | 7 -> 7 | 8 -> 8
+  | 9 -> 9 | 10 -> 10 | 11 -> 11 | 12 -> 12 | 13 -> 13 | 14 -> 14 | 15 -> 15
+  | 16 -> 16 | 17 -> 17 | 18 -> 18 | 19 -> 19 | 20 -> 20 | 21 -> 21 | 22 -> 22
+  | 23 -> 23 | 24 -> 24 | 25 -> 25 | 26 -> 26 | 27 -> 27 | 28 -> 28 | 29 -> 29
+  | 30 -> 30 | 31 -> 31 | 32 -> 32 | 33 -> 33 | 34 -> 34 | 35 -> 35 | 36 -> 36
+  | 37 -> 37 | 38 -> 38 | 39 -> 39 | 40 -> 40 | 41 -> 41 | 42 -> 42 | 43 -> 43
+  | 44 -> 44 | 45 -> 45 | 46 -> 46 | 47 -> 47 | 48 -> 48 | 49 -> 49 | 50 -> 50
+  | 51 -> 51 | 52 -> 52 | 53 -> 53 | 54 -> 54 | 55 -> 55 | 56 -> 56 | 57 -> 57
+  | 58 -> 58 | 59 -> 59 | 60 -> 60 | 61 -> 61 | 62 -> 62 | 63 -> 63 | 64 -> 64
+  | 65 -> 65 | 66 -> 66 | 67 -> 67 | 68 -> 68 | 69 -> 69 | 70 -> 70 | 71 -> 71
+  | 72 -> 72 | 73 -> 73 | 74 -> 74 | 75 -> 75 | 76 -> 76 | 77 -> 77 | 78 -> 78
+  | 79 -> 79 | 80 -> 80 | 81 -> 81 | 82 -> 82 | 83 -> 83 | 84 -> 84 | 85 -> 85
+  | 86 -> 86 | 87 -> 87 | 88 -> 88 | 89 -> 89 | 90 -> 90 | 91 -> 91 | 92 -> 92
+  | 93 -> 93 | 94 -> 94 | 95 -> 95 | 96 -> 96 | 97 -> 97 | 98 -> 98 | 99 -> 99
+  | _ -> 0);
+
+  Test (3, `Tertiary, function
+  | 1 -> `Primary
+  | 2 -> `Secondary
+  | 3 -> `Tertiary
+  | n -> invalid_arg "test")
+  ]
+
+let passes = ref 0
+let run_test (Test (a, b, f)) =
+  assert (f a = b);
+  incr passes
+
+let () =
+  List.iter run_test testcases;
+  Printf.printf "%d tests passed\n" !passes
+

--- a/testsuite/tests/basic/switch_opts.ml
+++ b/testsuite/tests/basic/switch_opts.ml
@@ -16,7 +16,8 @@ let testcases = [
   Test (3, min_int, function 1 -> 1 | 2 -> 2 | 3 -> min_int | _ -> 0);
   Test (3, max_int, function 1 -> 1 | 2 -> 2 | 3 -> max_int | _ -> 0);
   Test (3, 3., function 1 -> 1. | 2 -> 2. | 3 -> 3. | _ -> 0.);
-  Test (3, ""^"c"^"", function 1 -> "a" | 2 -> "b" | 3 -> "c" | _ -> "");
+  Test (3, Sys.opaque_identity "c" ^ Sys.opaque_identity "c",
+        function 1 -> "a" | 2 -> "b" | 3 -> "cc" | _ -> "");
   Test (3, List.rev [3;2;1], function 1 -> [] | 2 -> [42] | 3 -> [1;2;3] | _ -> [415]);
 
   Test (C, 3, function A -> 1 | B -> 2 | C -> 3);

--- a/testsuite/tests/basic/switch_opts.reference
+++ b/testsuite/tests/basic/switch_opts.reference
@@ -1,0 +1,1 @@
+16 tests passed


### PR DESCRIPTION
This pull request is remarkably similar to #863, but:
  - removes misguided buggy bit-twiddling
  - adds tests