### PR TITLE
Per type warn 4

### DIFF
--- a/testsuite/tests/warnings/w04.ml
+++ b/testsuite/tests/warnings/w04.ml
@@ -10,3 +10,22 @@ type t = A | B
 let g x = match x with
 | A -> 0
 | _ -> 1
+
+type u = C | D [@@ ocaml.warning "-4"]
+(* should not warn. *)
+let h x = match x with
+| C -> 0
+| _ -> 1
+
+[@@@ocaml.warning "-4"]
+
+type v = F | G [@@ ocaml.warning "+4"]
+
+let k x = match x with
+| F -> 0
+| _ -> 1
+
+(* should not warn. *)
+let l x = match x with
+| A -> 0
+| _ -> 1

--- a/testsuite/tests/warnings/w04.ml
+++ b/testsuite/tests/warnings/w04.ml
@@ -29,3 +29,15 @@ let k x = match x with
 let l x = match x with
 | A -> 0
 | _ -> 1
+
+[@@@ocaml.warning "--4"]
+(* should not warn. *)
+let m x = match x with
+| F -> 0
+| _ -> 1
+
+[@@@ocaml.warning "++4"]
+(*should warn. *)
+let n x = match x with
+| C -> 0
+| _ -> 1

--- a/testsuite/tests/warnings/w04.reference
+++ b/testsuite/tests/warnings/w04.reference
@@ -1,3 +1,6 @@
 File "w04.ml", line 10, characters 10-40:
 Warning 4: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type t.
+File "w04.ml", line 24, characters 10-40:
+Warning 4: this pattern-matching is fragile.
+It will remain exhaustive when constructors are added to type v.

--- a/testsuite/tests/warnings/w04.reference
+++ b/testsuite/tests/warnings/w04.reference
@@ -4,3 +4,6 @@ It will remain exhaustive when constructors are added to type t.
 File "w04.ml", line 24, characters 10-40:
 Warning 4: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type v.
+File "w04.ml", line 41, characters 10-40:
+Warning 4: this pattern-matching is fragile.
+It will remain exhaustive when constructors are added to type u.

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1878,9 +1878,14 @@ let extendable_path path =
 
 let warn_fragile_type ty env =
   let _,_,decl = Ctype.extract_concrete_typedecl env ty in
-  Builtin_attributes.with_warning_attribute
-    decl.Types.type_attributes
-    (fun () -> Warnings.(is_active (Fragile_match "")))
+  let warn = Warnings.Fragile_match "" in
+  match Warnings.status warn with
+    | Warnings.Always -> true
+    | Warnings.Never -> false
+    | Warnings.Implicit | Warnings.Explicit ->
+        Builtin_attributes.with_warning_attribute
+          decl.Types.type_attributes
+          (fun () -> Warnings.(is_active warn))
 
 let rec collect_paths_from_pat r p = match p.pat_desc with
 | Tpat_construct(_, {cstr_tag=(Cstr_constant _|Cstr_block _|Cstr_unboxed)},ps)

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -807,7 +807,7 @@ let build_other ext env = match env with
 | ({pat_desc = Tpat_construct _} as p,_) :: _ ->
     begin match ext with
     | Some ext ->
-        let path =  (get_type_path p.pat_type p.pat_env) in
+        let path = (get_type_path p.pat_type p.pat_env) in
         (match path with
          | Some path when Path.same ext path -> extra_pat
          | _ -> build_other_constrs env p)
@@ -1880,24 +1880,24 @@ let warn_fragile_type ty env =
   let _,_,decl = Ctype.extract_concrete_typedecl env ty in
   let warn = Warnings.Fragile_match "" in
   match Warnings.status warn with
-    | Warnings.Always -> true
-    | Warnings.Never -> false
-    | Warnings.Implicit | Warnings.Explicit ->
-        Builtin_attributes.with_warning_attribute
-          decl.Types.type_attributes
-          (fun () -> Warnings.(is_active warn))
+  | Warnings.Always -> true
+  | Warnings.Never -> false
+  | Warnings.Implicit | Warnings.Explicit ->
+      Builtin_attributes.with_warning_attribute
+        decl.Types.type_attributes
+        (fun () -> Warnings.(is_active warn))
 
 let rec collect_paths_from_pat r p = match p.pat_desc with
 | Tpat_construct(_, {cstr_tag=(Cstr_constant _|Cstr_block _|Cstr_unboxed)},ps)
   ->
-    (match get_type_path p.pat_type p.pat_env with
-     | Some path ->
-         List.fold_left
-           collect_paths_from_pat
-           (if extendable_path path && warn_fragile_type p.pat_type p.pat_env
-            then add_path path r else r)
-           ps
-     | None -> r)
+    let r =
+      match get_type_path p.pat_type p.pat_env with
+      | Some path
+        when extendable_path path && warn_fragile_type p.pat_type p.pat_env ->
+          add_path path r
+      | _ -> r
+    in
+    List.fold_left collect_paths_from_pat r ps
 | Tpat_any|Tpat_var _|Tpat_constant _| Tpat_variant (_,None,_) -> r
 | Tpat_tuple ps | Tpat_array ps
 | Tpat_construct (_, {cstr_tag=Cstr_extension _}, ps)->

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -219,21 +219,21 @@ let is_active x = (!current).active.(number x);;
 let status x =
   let n = number x in
   match (!current).active.(n), (!current).flexible.(n) with
-    | true, false -> Always
-    | true, true -> Implicit
-    | false, true -> Explicit
-    | false, false -> Never
+  | true, false -> Always
+  | true, true -> Implicit
+  | false, true -> Explicit
+  | false, false -> Never
 ;;
 
 let is_error x = (!current).error.(number x);;
 
 let parse_opt error active flexible flags s =
   let set i = flags.(i) <- true; flexible.(i) <- true in
-  let set_strict i = flags.(i) <- true; flexible.(i) <- false in
+  let set_rigid i = flags.(i) <- true; flexible.(i) <- false in
   let clear i = flags.(i) <- false; flexible.(i) <- true in
-  let clear_strict i = flags.(i) <- false; flexible.(i) <- false in
+  let clear_rigid i = flags.(i) <- false; flexible.(i) <- false in
   let set_all i = active.(i) <- true; error.(i) <- true; flexible.(i) <- true in
-  let set_all_strict i =
+  let set_all_rigid i =
     active.(i) <- true; error.(i) <- true; flexible.(i) <- false
   in
   let error () = raise (Arg.Bad "Ill-formed list of warnings") in
@@ -264,15 +264,15 @@ let parse_opt error active flexible flags s =
        loop (i+1)
     | '+' ->
         need_char i;
-        if s.[i+1] = '+' then loop_letter_num set_strict (i+2)
+        if s.[i+1] = '+' then loop_letter_num set_rigid (i+2)
         else loop_letter_num set (i+1)
     | '-' ->
         need_char i;
-        if s.[i+1] = '-' then loop_letter_num clear_strict (i+2)
+        if s.[i+1] = '-' then loop_letter_num clear_rigid (i+2)
         else loop_letter_num clear (i+1)
     | '@' ->
         need_char i;
-        if s.[i+1] = '@' then loop_letter_num set_all_strict (i+2)
+        if s.[i+1] = '@' then loop_letter_num set_all_rigid (i+2)
         else loop_letter_num set_all (i+1)
     | _ -> error ()
   and loop_letter_num myset i =

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -78,9 +78,24 @@ type t =
   | Constraint_on_gadt                      (* 62 *)
 ;;
 
+(* For warnings that can be enabled by attributes on external declarations,
+    the status indicates whether we should follow the current state of the
+    warning or the one given by those external declarations.
+
+    An example of such warning is Fragile_match, which can be (de)activated on a
+    per-type basis. See PR#7310 for an extended discussion.
+*)
+type status =
+  | Always (* warning always active. *)
+  | Implicit (* warning active, but external declarations may deactivate it.*)
+  | Explicit (* warning not active, external declaration may activate it.*)
+  | Never (* warning never active. *)
+;;
+
 val parse_options : bool -> string -> unit;;
 
 val is_active : t -> bool;;
+val status : t -> status;;
 val is_error : t -> bool;;
 
 val defaults_w : string;;


### PR DESCRIPTION
This MR allows to enable (or disable) warning 4 (fragile pattern-matching) on a per-type basis instead of globally. More specifically, if an attribute `ocaml.warning` with a payload containing `+4` (resp `-4`) is associated to the definition of a sum type `t`, this attribute will be honored for any pattern-matching over a value of type `t`, regardless of the status of warning 4 at that point.

The rationale behind that is that writing non-fragile pattern-matching is pretty cumbersome and leads to code that is difficult to read (as a matter of fact, even the OCaml compiler disables it for its own compilation). On the other hand, knowing which patterns are fragile is extremely useful when one is adding a constructor, but only if only the patterns of the type being extended are reported (otherwise, there will very likely be too much noise from fragile matching over irrelevant types), which is exactly what this PR allows.

Additionally, the fragile matching detection code is now called on every matching, which uncovered an existing issue (just launch current ocamlc -w +4 over the code of PR #6394 to see it happen). This is fixed in the second commit of the series. 