### PR TITLE
fix caml_alloc_sprintf invocation in caml_runtime_parameters

### DIFF
--- a/Changes
+++ b/Changes
@@ -458,6 +458,10 @@ Next minor version (4.04.1):
   of call at point correctly.
   (Chunhui He)
 
+- GPR#1072: Fix segfault in Sys.runtime_parameters when exception backtraces
+  are enabled.
+  (Olivier Andrieu)
+
 OCaml 4.04.0 (4 Nov 2016):
 --------------------------
 

--- a/byterun/gc_ctrl.c
+++ b/byterun/gc_ctrl.c
@@ -635,14 +635,14 @@ CAMLprim value caml_runtime_parameters (value unit)
 {
   CAMLassert (unit == Val_unit);
   return caml_alloc_sprintf
-    ("a=%d,b=%s,H=%lu,i=%lu,l=%lu,o=%lu,O=%lu,p=%d,s=%lu,t=%d,v=%lu,w=%d,W=%lu",
-     /* a */ caml_allocation_policy,
+    ("a=%d,b=%d,H=%lu,i=%lu,l=%lu,o=%lu,O=%lu,p=%d,s=%lu,t=%lu,v=%lu,w=%d,W=%lu",
+     /* a */ (int) caml_allocation_policy,
      /* b */ caml_backtrace_active,
      /* h */ /* missing */ /* FIXME add when changed to min_heap_size */
      /* H */ caml_use_huge_pages,
      /* i */ caml_major_heap_increment,
 #ifdef NATIVE_CODE
-     /* l */ 0,
+     /* l */ 0UL,
 #else
      /* l */ caml_max_stack_size,
 #endif


### PR DESCRIPTION
the format string and arguments were mismatched in a couple of places.

Cherry-picked from #1070 .