### PR TITLE
Fix tags on zero-sized float arrays

### DIFF
--- a/Changes
+++ b/Changes
@@ -43,6 +43,8 @@ Working version
 - PR#7468: possible GC problem in caml_alloc_sprintf
   (Xavier Leroy, discovery by Olivier Andrieu)
 
+- GPR#1075: Ensure that zero-sized float arrays have zero tags.
+  (Mark Shinwell, Leo White)
 
 
 Next version (4.05.0):

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -96,7 +96,9 @@ let black_closure_header sz = black_block_header Obj.closure_tag sz
 let infix_header ofs = block_header Obj.infix_tag ofs
 let float_header = block_header Obj.double_tag (size_float / size_addr)
 let floatarray_header len =
-      block_header Obj.double_array_tag (len * size_float / size_addr)
+  assert (len >= 0);
+  if len = 0 then block_header 0 0
+  else block_header Obj.double_array_tag (len * size_float / size_addr)
 let string_header len =
       block_header Obj.string_tag ((len + size_addr) / size_addr)
 let boxedint32_header = block_header Obj.custom_tag 2

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -96,6 +96,8 @@ let black_closure_header sz = black_block_header Obj.closure_tag sz
 let infix_header ofs = block_header Obj.infix_tag ofs
 let float_header = block_header Obj.double_tag (size_float / size_addr)
 let floatarray_header len =
+  (* Zero-sized float arrays have tag zero for consistency with
+     [caml_alloc_float_array]. *)
   assert (len >= 0);
   if len = 0 then block_header 0 0
   else block_header Obj.double_array_tag (len * size_float / size_addr)

--- a/byterun/alloc.c
+++ b/byterun/alloc.c
@@ -158,6 +158,9 @@ CAMLprim value caml_alloc_float_array(mlsize_t len)
 {
   mlsize_t wosize = len * Double_wosize;
   value result;
+  /* For consistency with [caml_make_vect], which can't tell whether it should
+     create a float array or not when the size is zero, the tag is set to
+     zero when the size is zero. */
   if (wosize == 0)
     return Atom(0);
   else if (wosize <= Max_young_wosize){

--- a/testsuite/tests/basic-float/zero_sized_float_arrays.ml
+++ b/testsuite/tests/basic-float/zero_sized_float_arrays.ml
@@ -1,0 +1,15 @@
+let non_float_array : int array = [| |]
+
+let float_array : float array = [| |]
+
+let non_float_array_from_runtime : int array =
+  Array.make 0 0
+
+let float_array_from_runtime : float array =
+  Array.make 0 0.0
+
+let () =
+  assert (Pervasives.compare non_float_array non_float_array_from_runtime = 0);
+  assert (Pervasives.compare non_float_array non_float_array_from_runtime = 0);
+  assert (Pervasives.compare float_array float_array_from_runtime = 0);
+  assert (Pervasives.compare float_array float_array_from_runtime = 0)


### PR DESCRIPTION
We have discovered wrong results from `Pervasives.compare` when comparing empty arrays.  In particular some float arrays of zero size have zero tags (as per `caml_alloc_float_array`) and others have `Double_array_tag`.  This causes them to compare as unequal.

This patch should fix that by forcing the tag to be zero in `Cmmgen`.  It is possible that in the future we might want to enhance Flambda's handling of float arrays to deal with this automatically, but we need a minimal fix now.

As an aside, we went on a wild goose chase expecting that zero-sized values for a particular tag are always unique (being the corresponding `Atom`), but in fact that does not appear to be the case even without Flambda.