### PR TITLE
Fix configure comment about raw_spacetime_lib

### DIFF
--- a/configure
+++ b/configure
@@ -1184,7 +1184,7 @@ echo "GRAPHLIB=$graphlib" >> Makefile
 
 otherlibraries="$unixlib str num dynlink bigarray"
 
-# Spacetime profiling is only available for native code on 64-bit targets.
+# Spacetime profiling is only available for 64-bit targets.
 
 case "$native_compiler" in
     true)


### PR DESCRIPTION
According to the code, $arch64 is true for all 64-bit platforms not just native ones.

Also otherlibs/raw_spacetime_lib/raw_spacetime_lib.mli says "For 64-bit targets only" without reference to native or bytecode architectures.