### PR TITLE
MPR#7500: Remove Uchar.dump

### DIFF
--- a/Changes
+++ b/Changes
@@ -161,6 +161,9 @@ Next version (4.05.0):
 
 ### Standard library:
 
+* PR#7500, GPR#1081: Remove Uchar.dump
+  (Daniel Bünzli)
+
 - PR#6975, GPR#902: Truncate function added to stdlib Buffer module
   (Dhruv Makwana, review by Alain Frisch and Gabriel Scherer)
 

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -180,9 +180,9 @@ stringLabels.cmi :
 sys.cmo : sys.cmi
 sys.cmx : sys.cmi
 sys.cmi :
-uchar.cmo : printf.cmi pervasives.cmi format.cmi char.cmi uchar.cmi
-uchar.cmx : printf.cmx pervasives.cmx format.cmx char.cmx uchar.cmi
-uchar.cmi : format.cmi
+uchar.cmo : pervasives.cmi char.cmi uchar.cmi
+uchar.cmx : pervasives.cmx char.cmx uchar.cmi
+uchar.cmi :
 weak.cmo : sys.cmi obj.cmi hashtbl.cmi array.cmi weak.cmi
 weak.cmx : sys.cmx obj.cmx hashtbl.cmx array.cmx weak.cmi
 weak.cmi : hashtbl.cmi
@@ -318,7 +318,7 @@ stringLabels.cmo : string.cmi stringLabels.cmi
 stringLabels.p.cmx : string.cmx stringLabels.cmi
 sys.cmo : sys.cmi
 sys.p.cmx : sys.cmi
-uchar.cmo : printf.cmi pervasives.cmi format.cmi char.cmi uchar.cmi
-uchar.p.cmx : printf.cmx pervasives.cmx format.cmx char.cmx uchar.cmi
+uchar.cmo : pervasives.cmi char.cmi uchar.cmi
+uchar.p.cmx : pervasives.cmx char.cmx uchar.cmi
 weak.cmo : sys.cmi obj.cmi hashtbl.cmi array.cmi weak.cmi
 weak.p.cmx : sys.cmx obj.cmx hashtbl.cmx array.cmx weak.cmi

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -33,7 +33,7 @@ CAMLOPT=$(CAMLRUN) $(OPTCOMPILER)
 CAMLDEP=$(CAMLRUN) ../tools/ocamldep
 
 OBJS=camlinternalFormatBasics.cmo pervasives.cmo $(OTHERS)
-OTHERS=list.cmo char.cmo bytes.cmo string.cmo sys.cmo \
+OTHERS=list.cmo char.cmo uchar.cmo bytes.cmo string.cmo sys.cmo \
   sort.cmo marshal.cmo obj.cmo array.cmo \
   int32.cmo int64.cmo nativeint.cmo \
   lexing.cmo parsing.cmo \
@@ -42,7 +42,7 @@ OTHERS=list.cmo char.cmo bytes.cmo string.cmo sys.cmo \
   buffer.cmo camlinternalFormat.cmo printf.cmo \
   arg.cmo printexc.cmo gc.cmo \
   digest.cmo random.cmo hashtbl.cmo weak.cmo \
-  format.cmo uchar.cmo scanf.cmo callback.cmo \
+  format.cmo scanf.cmo callback.cmo \
   camlinternalOO.cmo oo.cmo camlinternalMod.cmo \
   genlex.cmo ephemeron.cmo \
   filename.cmo complex.cmo \

--- a/stdlib/uchar.ml
+++ b/stdlib/uchar.ml
@@ -13,10 +13,12 @@
 (*                                                                        *)
 (**************************************************************************)
 
+external format_int : string -> int -> string = "caml_format_int"
+
 let err_no_pred = "U+0000 has no predecessor"
 let err_no_succ = "U+10FFFF has no successor"
-let err_not_sv i = Printf.sprintf "%X is not an Unicode scalar value" i
-let err_not_latin1 u = Printf.sprintf "U+%04X is not a latin1 character" u
+let err_not_sv i = format_int "%X" i ^ " is not an Unicode scalar value"
+let err_not_latin1 u = "U+" ^ format_int "%04X" u ^ " is not a latin1 character"
 
 type t = int
 
@@ -51,5 +53,3 @@ let unsafe_to_char = Char.unsafe_chr
 let equal : int -> int -> bool = ( = )
 let compare : int -> int -> int = Pervasives.compare
 let hash = to_int
-
-let dump ppf u = Format.fprintf ppf "U+%04X" u

--- a/stdlib/uchar.mli
+++ b/stdlib/uchar.mli
@@ -82,9 +82,3 @@ val compare : t -> t -> int
 
 val hash : t -> int
 (** [hash u] associates a non-negative integer to [u]. *)
-
-val dump : Format.formatter -> t -> unit
-(** [dump ppf u] prints a representation of [u] on [ppf] using
-    only US-ASCII encoded characters according to the Unicode
-    {{:http://www.unicode.org/versions/latest/appA.pdf}notational
-    convention for code points}. *)

--- a/testsuite/tests/lib-uchar/test.ml
+++ b/testsuite/tests/lib-uchar/test.ml
@@ -67,16 +67,6 @@ let test_compare () =
   assert (Uchar.(compare max min) = 1);
   ()
 
-let test_dump () =
-  let str u = Format.asprintf "%a" Uchar.dump u in
-  assert (str Uchar.min = "U+0000");
-  assert (str Uchar.(succ min) = "U+0001");
-  assert (str Uchar.(of_int 0xFFFF) = "U+FFFF");
-  assert (str Uchar.(succ (of_int 0xFFFF)) = "U+10000");
-  assert (str Uchar.(pred max) = "U+10FFFE");
-  assert (str Uchar.max = "U+10FFFF");
-  ()
-
 let tests () =
   test_constants ();
   test_succ ();
@@ -87,7 +77,6 @@ let tests () =
   test_to_char ();
   test_equal ();
   test_compare ();
-  test_dump ();
   ()
 
 let () =


### PR DESCRIPTION
and make the `Uchar` independent from the `Format` and `Printf`
modules. Previously this made it impossible to use the type in the
natural habitat that the `String`, `Bytes` and `Buffer` modules could be.

https://caml.inria.fr/mantis/view.php?id=7500