### PR TITLE
Quoted string and extension nodes: manual clarification

### DIFF
--- a/Changes
+++ b/Changes
@@ -175,6 +175,12 @@ Next version (4.05.0):
   examples to this format.
   (Florian Angeletti)
 
+- GPR#1082: clarify that the use of quoted string for preprocessed
+  foreign quotations still requires the use of an extension node
+  [%foo ...] to mark non-standard interpretation.
+  (Gabriel Scherer, request by Matthew Wahab in GPR#1066,
+   review by Florian Angeletti)
+
 - add a HACKING.adoc file to contain various tips and tricks for
   people hacking on the repository. See also CONTRIBUTING.md for
   advice on sending contributions upstream.

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1923,10 +1923,11 @@ let y = [%extension_constructor Y];;
 
 (Introduced in OCaml 4.02)
 
-Quoted strings provide a different lexical syntax to write string
-literals in OCaml code.  This can be used to embed pieces of foreign
-syntax fragments in OCaml code, to be interpret by a "-ppx" filter or
-just a library.
+Quoted strings "{foo|...|foo}" provide a different lexical syntax to
+write string literals in OCaml code. They are useful to represent
+strings of arbitrary content without escaping -- as long as the
+delimiter you chose (here "|foo}") does not occur in the string
+itself.
 
 \begin{syntax}
 string-literal: ...
@@ -1938,9 +1939,9 @@ quoted-string-id:
 \end{syntax}
 
 The opening delimiter has the form "{id|" where "id" is a (possibly
-  empty) sequence of lowercase letters and underscores.  The
-  corresponding closing delimiter is "|id}" (with the same
-identifier).  Unlike regular OCaml string literals, quoted
+empty) sequence of lowercase letters and underscores.  The
+corresponding closing delimiter is "|id}" (with the same
+identifier). Unlike regular OCaml string literals, quoted
 strings do not interpret any character in a special way.
 
 Example:
@@ -1950,6 +1951,19 @@ String.length {|\"|}         (* returns 2 *)
 String.length {foo|\"|foo}   (* returns 2 *)
 \end{verbatim}
 
+Quoted strings are interesting in particular in conjunction to
+extension nodes "[%foo ...]" (see \ref{s:extension-nodes}) to embed
+foreign syntax fragments to be interpreted by a preprocessor and
+turned into OCaml code: you can use "[%sql {|...|}]" for example to
+represent arbitrary SQL statements -- assuming you have a ppx-rewriter
+that recognizes the "%sql" extension -- without requiring escaping
+quotes.
+
+Note that the non-extension form, for example "{sql|...|sql}", should
+not be used for this purpose, as the user cannot see in the code that
+this string literal has a different semantics than they expect, and
+giving a semantics to a specific delimiter limits the freedom to
+change the delimiter to avoid escaping issues.
 
 \section{Exception cases in pattern matching}\label{s:exception-match}
 


### PR DESCRIPTION
This manual clarification is intended to lift up the misunderstanding
that is the basis for #1066.