### PR TITLE
PR#7331: ocamldoc, avoid self-alias induced infinite loop

### DIFF
--- a/Changes
+++ b/Changes
@@ -359,7 +359,7 @@ Next version (4.05.0):
 
 - PR#7331: ocamldoc, avoid infinite loop in presence of self alias,
   i.e. module rec M:sig end = M
-  (Florian Angeletti)
+  (Florian Angeletti, review Gabriel Scherer)
 
 - PR#7346, GPR#966: Fix evaluation order problem whereby expressions could
   be incorrectly re-ordered when compiling with Flambda.  This also fixes one

--- a/Changes
+++ b/Changes
@@ -357,6 +357,10 @@ Next version (4.05.0):
 - PR#7216, GPR#949: don't require double parens in Functor((val x))
   (Jacques Garrigue, review by Valentin Gatien-Baron)
 
+- PR#7331: ocamldoc, avoid infinite loop in presence of self alias,
+  i.e. module rec M:sig end = M
+  (Florian Angeletti)
+
 - PR#7346, GPR#966: Fix evaluation order problem whereby expressions could
   be incorrectly re-ordered when compiling with Flambda.  This also fixes one
   example of evaluation order in the native code compiler not matching the

--- a/ocamldoc/odoc_module.ml
+++ b/ocamldoc/odoc_module.ml
@@ -219,37 +219,47 @@ let included_modules l =
     []
     l
 
+module S = Misc.StringSet
+
 (** Returns the list of elements of a module.
-   @param trans indicates if, for aliased modules, we must perform a transitive search.*)
-let rec module_elements ?(trans=true) m =
+   @param trans indicates if, for aliased modules, we must perform a transitive search.
+   @param visited is used to guard against aliases loop
+     (e.g [module rec M:sig end=M] induced loop.
+
+**)
+let rec module_elements ?(visited=S.empty) ?(trans=true) m =
   let rec iter_kind = function
       Module_struct l ->
-        print_DEBUG "Odoc_module.module_element: Module_struct";
+        print_DEBUG "Odoc_module.module_elements: Module_struct";
         l
     | Module_alias ma ->
-        print_DEBUG "Odoc_module.module_element: Module_alias";
+        print_DEBUG "Odoc_module.module_elements: Module_alias";
         if trans then
           match ma.ma_module with
             None -> []
-          | Some (Mod m) -> module_elements m
+          | Some (Mod m') ->
+              if m'.m_name = m.m_name || S.mem m'.m_name visited then
+                []
+              else
+                module_elements ~visited:(S.add m'.m_name visited) m'
           | Some (Modtype mt) -> module_type_elements mt
         else
           []
     | Module_functor (_, k)
     | Module_apply (k, _) ->
-        print_DEBUG "Odoc_module.module_element: Module_functor ou Module_apply";
+        print_DEBUG "Odoc_module.module_elements: Module_functor ou Module_apply";
         iter_kind k
     | Module_with (tk,_) ->
-        print_DEBUG "Odoc_module.module_element: Module_with";
+        print_DEBUG "Odoc_module.module_elements: Module_with";
         module_type_elements ~trans: trans
           { mt_name = "" ; mt_info = None ; mt_type = None ;
             mt_is_interface = false ; mt_file = "" ; mt_kind = Some tk ;
             mt_loc = Odoc_types.dummy_loc ;
           }
     | Module_constraint (k, _tk) ->
-        print_DEBUG "Odoc_module.module_element: Module_constraint";
+        print_DEBUG "Odoc_module.module_elements: Module_constraint";
       (* FIXME : use k or tk ? *)
-        module_elements ~trans: trans
+        module_elements ~visited ~trans: trans
           { m_name = "" ;
             m_info = None ;
             m_type = Types.Mty_signature [] ;
@@ -293,6 +303,11 @@ and module_type_elements ?(trans=true) mt =
   | Some (Module_type_typeof _) -> []
   in
   iter_kind mt.mt_kind
+
+(** Returns the list of elements of a module.
+   @param trans indicates if, for aliased modules, we must perform a transitive search.
+*)
+let module_elements ?(trans=true) m =  module_elements ~trans m
 
 (** Returns the list of values of a module.
   @param trans indicates if, for aliased modules, we must perform a transitive search.*)
@@ -459,20 +474,22 @@ let rec module_type_is_functor mt =
 
 (** The module is a functor if is defined as a functor or if it is an alias for a functor. *)
 let module_is_functor m =
-  let rec iter = function
+  let rec iter visited = function
       Module_functor _ -> true
     | Module_alias ma ->
         (
-         match ma.ma_module with
-           None -> false
-         | Some (Mod mo) -> iter mo.m_kind
-         | Some (Modtype mt) -> module_type_is_functor mt
+          not (ma.ma_name = m.m_name || S.mem ma.ma_name visited)
+          &&
+          match ma.ma_module with
+            None -> false
+          | Some (Mod mo) -> iter (S.add ma.ma_name visited) mo.m_kind
+          | Some (Modtype mt) -> module_type_is_functor mt
         )
     | Module_constraint (k, _) ->
-        iter k
+        iter visited k
     | _ -> false
   in
-  iter m.m_kind
+  iter S.empty m.m_kind
 
 (** Returns the list of values of a module type.
   @param trans indicates if, for aliased modules, we must perform a transitive search.*)

--- a/testsuite/tests/tool-ocamldoc-2/loop.ml
+++ b/testsuite/tests/tool-ocamldoc-2/loop.ml
@@ -1,0 +1,3 @@
+
+module rec A : sig type t end = B and B : sig type t = A.t end = A;;
+

--- a/testsuite/tests/tool-ocamldoc-2/loop.reference
+++ b/testsuite/tests/tool-ocamldoc-2/loop.reference
@@ -1,0 +1,36 @@
+\documentclass[11pt]{article} 
+\usepackage[latin1]{inputenc} 
+\usepackage[T1]{fontenc} 
+\usepackage{textcomp}
+\usepackage{fullpage} 
+\usepackage{url} 
+\usepackage{ocamldoc}
+\begin{document}
+\tableofcontents
+\section{Module {\tt{Loop}}}
+\label{Loop}\index{Loop@\verb`Loop`}
+
+
+\ocamldocvspace{0.5cm}
+
+
+
+\begin{ocamldoccode}
+{\tt{module }}{\tt{A}}{\tt{ : }}\end{ocamldoccode}
+\label{Loop.A}\index{A@\verb`A`}
+
+{\tt{B}}
+
+
+
+
+
+\begin{ocamldoccode}
+{\tt{module }}{\tt{B}}{\tt{ : }}\end{ocamldoccode}
+\label{Loop.B}\index{B@\verb`B`}
+
+{\tt{A}}
+
+
+
+\end{document}

--- a/testsuite/tests/tool-ocamldoc-html/Loop.ml
+++ b/testsuite/tests/tool-ocamldoc-html/Loop.ml
@@ -1,0 +1,3 @@
+
+module rec A : sig type t end = B and B : sig type t = A.t end = A;;
+

--- a/testsuite/tests/tool-ocamldoc-html/Loop.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Loop.reference
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<link rel="stylesheet" href="style.css" type="text/css">
+<meta content="text/html; charset=iso-8859-1" http-equiv="Content-Type">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="Start" href="index.html">
+<link rel="Up" href="index.html">
+<link title="Index of modules" rel=Appendix href="index_modules.html">
+<link title="Loop" rel="Chapter" href="Loop.html"><title>Loop</title>
+</head>
+<body>
+<div class="navbar">&nbsp;<a class="up" href="index.html" title="Index">Up</a>
+&nbsp;</div>
+<h1>Module <a href="type_Loop.html">Loop</a></h1>
+
+<pre><span class="keyword">module</span> Loop: <code class="code"><span class="keyword">sig</span></code> <a href="Loop.html">..</a> <code class="code"><span class="keyword">end</span></code></pre><hr width="100%">
+
+<pre><span class="keyword">module</span> <a href="Loop.A.html">A</a>: <code class="type"><a href="Loop.B.html">B</a></code></pre>
+<pre><span class="keyword">module</span> <a href="Loop.B.html">B</a>: <code class="type"><a href="Loop.A.html">A</a></code></pre></body></html>

--- a/testsuite/tests/tool-ocamldoc-html/Makefile
+++ b/testsuite/tests/tool-ocamldoc-html/Makefile
@@ -34,6 +34,7 @@ default:
 
 .PHONY: run
 run: *.mli *.ml
+# Note that we strip both .ml and .mli extensions
 	@for file in *.ml *.mli; do \
 	  printf " ... testing '$$file'"; \
 	  F="`basename $$file .mli`"; \
@@ -45,7 +46,7 @@ run: *.mli *.ml
 	  && echo " => passed" || echo " => failed"; \
 	done;\
 # For linebreaks.mli, we also compare type_Linebreaks.html and not only
-# themain html file
+# the main html file
 	@cp type_Linebreaks.html type_Linebreaks.result;\
 	printf " ... testing 'type_Linebreak.html'";\
 	$(DIFF) type_Linebreaks.reference type_Linebreaks.result\

--- a/testsuite/tests/tool-ocamldoc-html/Makefile
+++ b/testsuite/tests/tool-ocamldoc-html/Makefile
@@ -33,10 +33,11 @@ default:
 	fi
 
 .PHONY: run
-run: *.mli
-	@for file in *.mli; do \
+run: *.mli *.ml
+	@for file in *.ml *.mli; do \
 	  printf " ... testing '$$file'"; \
 	  F="`basename $$file .mli`"; \
+	  F="`basename $$F .ml`"; \
 	  $(OCAMLDOC) $(DOCFLAGS) -colorize-code -hide-warnings -html $ \
 	              -o index $$file; \
 	  cp $$F.html $$F.result; \

--- a/testsuite/tests/tool-ocamldoc/t05.ml
+++ b/testsuite/tests/tool-ocamldoc/t05.ml
@@ -1,0 +1,3 @@
+
+module rec A : sig type t end = B and B : sig type t = A.t end = A;;
+

--- a/testsuite/tests/tool-ocamldoc/t05.reference
+++ b/testsuite/tests/tool-ocamldoc/t05.reference
@@ -1,0 +1,6 @@
+#
+# module T05:
+#
+# module T05.A:
+#
+# module T05.B:


### PR DESCRIPTION
[MPR#7331](https://caml.inria.fr/mantis/view.php?id=7331):
This PR fixes an infinite loop within ocamldoc in presence of alias loops in module definitions:
```(* a.ml *)
module rec A: sig 
(** Aphasia *)
type t end
= B
and B:sig type t= A.t end = A
```
Note that the fix is partial: more complex cycles may still trigger infinite loops. Moreover, the generated documentation is useless, since ocamldoc ignores documentation comments in signature constraints (i.e. `Aphasia` is not picked up by ocamldoc).

However, since this infinite loop is triggered for valid OCaml code, I would argue that this partial fix should go into 4.05, without waiting for a more complete (and complex) solution.