### PR TITLE
Don't call getwd if HAS_GETWD is not set

### DIFF
--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -309,7 +309,9 @@ CAMLprim value caml_sys_getcwd(value unit)
 #ifdef HAS_GETCWD
   if (getcwd(buff, sizeof(buff)) == 0) caml_sys_error(NO_ARG);
 #else
-  if (getwd(buff) == 0) caml_sys_error(NO_ARG);
+  #ifdef HAS_GETWD
+    if (getwd(buff) == 0) caml_sys_error(NO_ARG);
+  #endif
 #endif /* HAS_GETCWD */
   return caml_copy_string(buff);
 }


### PR DESCRIPTION
It seems like this is [gated elsewhere](https://github.com/ocaml/ocaml/blob/26183199c077965190057f29b539af527ed432d2/otherlibs/unix/getcwd.c#L43
).

I hit this while trying to [compile the runtime to WebAssembly](https://github.com/sebmarkbage/ocamlrun-wasm) using Emscripten which doesn't have getwd in the default environment.

Keep in mind that this is my first PR and I don't really know what I'm doing. :)