### PR TITLE
Cross compiler should use host ocamlrun for hashbang scripts

### DIFF
--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -127,7 +127,7 @@ CAMLHEADERS =\
 ifeq "$(HASHBANGSCRIPTS)" "true"
 $(CAMLHEADERS): ../config/Makefile
 	for suff in '' d i; do \
-	  echo '#!$(BINDIR)/ocamlrun'$$suff > camlheader$$suff && \
+	  echo '#!$(CAMLRUN)'$$suff > camlheader$$suff && \
 	  echo '#!$(TARGET_BINDIR)/ocamlrun'$$suff >target_camlheader$$suff; \
 	done && \
 	echo '#!' | tr -d '\012' > camlheader_ur;


### PR DESCRIPTION
I could not build a cross compiler since f3650d5. Hashbang scripts in `BINDIR` used `ocamlrun` from `BINDIR`. Because since that commit, it has always been ocamlrun built for cross compiler target architecture it couldn't be run on the host.

I believe that the change in f3650d5 was correct because one of the products when building a cross compiler should be ocamlrun which can execute bytecode on the target.

I cannot anticipate impact of this change on the whole build system. It's mainly because I can't grok the difference in purpose of `TARGET_BINDIR` and `BINDIR` and likewise `target_camlheader` and `camlheader`. Intuitively `target*` are supposed to be used on target architectures whereas the latter are to be used on the host if cross compiling.

If the assumption above is true, I should make sure that target `ocamlrun` is always installed in `TARGET_BINDIR` and maybe revert this change and install `ocamlrun` from the host (e.g. `CAMLRUN`) in `BINDIR`.

@shindere has made changes in this area so I guess it should be reviewed by them.

Any input is appreciated.

## TODO

- [ ] `changes` entry [if needed]
- [ ] documentation. I believe that such subtleties should be documented somewhere but I have no idea where (?)

### Failing test

The following test fails, but I'm pretty sure it's not related to my change:
`tests/unwind/unwind_test`