### PR TITLE
Add Buffer.add_utf_{8,16be,16le}_uchar and Uchar.{bom,rep}

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,10 @@ Working version
   them with "Error (warning ..):", instead of "Warning ..:" and
   a trailing "Error: Some fatal warnings were triggered" message.
   (Valentin Gatien-Baron, review by Alain Frisch)
+- GPR#XXX: Add Buffer.add_utf_{8,16le,16be}_uchar to encode Uchar.t
+  values to the corresponding UTF-X transformation formats in Buffer.t
+  values.
+  (Daniel Bünzli, review by Damien Doligez, Max Mouratov)
 
 ### Tools:
 

--- a/Changes
+++ b/Changes
@@ -37,7 +37,11 @@ Working version
   them with "Error (warning ..):", instead of "Warning ..:" and
   a trailing "Error: Some fatal warnings were triggered" message.
   (Valentin Gatien-Baron, review by Alain Frisch)
-- GPR#XXX: Add Buffer.add_utf_{8,16le,16be}_uchar to encode Uchar.t
+
+- GRP#1091 Add the Uchar.{bom,rep} constants.
+  (Daniel Bünzli, Alain Frisch)
+
+- GPR#1091: Add Buffer.add_utf_{8,16le,16be}_uchar to encode Uchar.t
   values to the corresponding UTF-X transformation formats in Buffer.t
   values.
   (Daniel Bünzli, review by Damien Doligez, Max Mouratov)

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -9,9 +9,9 @@ array.cmi :
 arrayLabels.cmo : array.cmi arrayLabels.cmi
 arrayLabels.cmx : array.cmx arrayLabels.cmi
 arrayLabels.cmi :
-buffer.cmo : sys.cmi string.cmi bytes.cmi buffer.cmi
-buffer.cmx : sys.cmx string.cmx bytes.cmx buffer.cmi
-buffer.cmi :
+buffer.cmo : sys.cmi string.cmi bytes.cmi buffer.cmi uchar.cmi
+buffer.cmx : sys.cmx string.cmx bytes.cmx buffer.cmi uchar.cmi
+buffer.cmi : uchar.cmi
 bytes.cmo : pervasives.cmi char.cmi bytes.cmi
 bytes.cmx : pervasives.cmx char.cmx bytes.cmi
 bytes.cmi :
@@ -194,8 +194,8 @@ array.cmo : array.cmi
 array.p.cmx : array.cmi
 arrayLabels.cmo : array.cmi arrayLabels.cmi
 arrayLabels.p.cmx : array.cmx arrayLabels.cmi
-buffer.cmo : sys.cmi string.cmi bytes.cmi buffer.cmi
-buffer.p.cmx : sys.cmx string.cmx bytes.cmx buffer.cmi
+buffer.cmo : sys.cmi string.cmi bytes.cmi buffer.cmi uchar.cmi
+buffer.p.cmx : sys.cmx string.cmx bytes.cmx buffer.cmi uchar.cmi
 bytes.cmo : pervasives.cmi char.cmi bytes.cmi
 bytes.p.cmx : pervasives.cmx char.cmx bytes.cmi
 bytesLabels.cmo : bytes.cmi bytesLabels.cmi

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -85,6 +85,26 @@ val reset : t -> unit
 val add_char : t -> char -> unit
 (** [add_char b c] appends the character [c] at the end of buffer [b]. *)
 
+val add_utf_8_uchar : t -> Uchar.t -> unit
+(** [add_utf_8_uchar b u] appends the {{:https://tools.ietf.org/html/rfc3629}
+    UTF-8} encoding of [u] at the end of buffer [b].
+
+    @since 4.06.0 *)
+
+val add_utf_16le_uchar : t -> Uchar.t -> unit
+(** [add_utf_16le_uchar b u] appends the
+    {{:https://tools.ietf.org/html/rfc2781}UTF-16LE} encoding of [u]
+    at the end of buffer [b].
+
+    @since 4.06.0 *)
+
+val add_utf_16be_uchar : t -> Uchar.t -> unit
+(** [add_utf_16be_uchar b u] appends the
+    {{:https://tools.ietf.org/html/rfc2781}UTF-16BE} encoding of [u]
+    at the end of buffer [b].
+
+    @since 4.06.0 *)
+
 val add_string : t -> string -> unit
 (** [add_string b s] appends the string [s] at the end of buffer [b]. *)
 

--- a/stdlib/uchar.ml
+++ b/stdlib/uchar.ml
@@ -27,6 +27,9 @@ let max = 0x10FFFF
 let lo_bound = 0xD7FF
 let hi_bound = 0xE000
 
+let bom = 0xFEFF
+let rep = 0xFFFD
+
 let succ u =
   if u = lo_bound then hi_bound else
   if u = max then invalid_arg err_no_succ else

--- a/stdlib/uchar.mli
+++ b/stdlib/uchar.mli
@@ -31,6 +31,16 @@ val min : t
 val max : t
 (** [max] is U+10FFFF. *)
 
+val bom : t
+(** [bom] is U+FEFF, the
+    {{:http://unicode.org/glossary/#byte_order_mark}byte order mark} (BOM)
+    character. *)
+
+val rep : t
+(** [rep] is U+FFFD, the
+    {{:http://unicode.org/glossary/#replacement_character}replacement}
+    character. *)
+
 val succ : t -> t
 (** [succ u] is the scalar value after [u] in the set of Unicode scalar
     values.

--- a/testsuite/tests/lib-buffer/test.reference
+++ b/testsuite/tests/lib-buffer/test.reference
@@ -4,3 +4,6 @@ Buffer truncate: large passed
 Buffer truncate: in-range passed
 Buffer reset: non-zero passed
 Buffer reset: zero passed
+Buffer add_utf_8_uchar: test against spec passed
+Buffer add_utf_16be_uchar: test against spec passed
+Buffer add_utf_16le_uchar: test against spec passed

--- a/testsuite/tests/lib-uchar/test.ml
+++ b/testsuite/tests/lib-uchar/test.ml
@@ -4,6 +4,8 @@ let assert_raise_invalid_argument f v =
 let test_constants () =
   assert (Uchar.(to_int min) = 0x0000);
   assert (Uchar.(to_int max) = 0x10FFFF);
+  assert (Uchar.(to_int bom) = 0xFEFF);
+  assert (Uchar.(to_int rep) = 0xFFFD);
   ()
 
 let test_succ () =


### PR DESCRIPTION
This PR builds on #80 to further improve OCaml's standard library support for Unicode.

It provides the stdlib with the ability to *encode* `Uchar.t` values to the main Unicode transformation formats (see [here](http://erratique.ch/software/uucp/doc/Uucp#serializing) for more background) in `Buffer.t` values.  These functions correspond exactly to the functionality provided by the [`Uutf.Buffer`](http://erratique.ch/software/uutf/doc/Uutf.Buffer.html) module.

This [comment](https://github.com/ocaml/ocaml/pull/1091#issuecomment-285425929) by Alain Frisch also prompted to add the `Uchar.{bom,rep}` constants to the proposal. `Uchar.bom` is the [byte order mark](http://unicode.org/glossary/#byte_order_mark), it needs to be encoded at that beginning of `UTF-16` byte streams to denote the stream's endianness. `Uchar.rep` is the [replacement character](http://unicode.org/glossary/#replacement_character) that can be used for mentioning decode errors in a best-effort recode or untranslatable data when transcoding from another standard. Both constants are also available in `Uutf` [here](http://erratique.ch/software/uutf/doc/Uutf#ucharcsts).

Here are a few arguments for inclusion and design clarifications.

1. Akin to the rationale made for the introduction of `Uchar.t`, the UTF-X encoding schemes are nowadays cast in stone and are a non-moving part of standard (in contrast to say Unicode normalization or character properties). They only define a way to serialize the integers denoted by `Uchar.t` values to standard byte sequences.
1. Providing them in the standard library can make them more efficient: bulk byte addition to the buffer vs. repeated `Buffer.add_char` (no measurements were performed though).
1. The code increase is reasonable. The functions are exhaustively tested against a model of the encodings in the test suite. They seem unlikely to be a maintenance burden in the future.
1. It seems good that users of the OCaml system do not have to add a dependency on a third-party library to serialize values of a type of the stdlib in another type of the stlib, to formats used pervasively in the computing world.
1. Exhaustiveness w.r.t. Unicode standard would have called for functions to encode to UTF-32LE and UTF-32BE formats. I personally never had or saw any usage of these encodings on disk or on wires (they are very wasteful) and thus would rather see their presence as API cruft.
1. I would of course like to upstream at a certain point corresponding [decoding](http://erratique.ch/software/uutf/doc/Uutf.String.html) functionality for the `String` and `Bytes` module. However the design for this is less self-evident than these functions (e.g. inversion of control, error reporting) and the mentioned decoding API sports optional arguments and polyvars which is still unclear whether allowed in the base and supposedly non-labelled stdlib. This can wait a little bit more for now (e.g. effects could communicate `` `Malformed`` byte sequences: it would avoid boxing the `Uchar.t` values and provide the client with an error handling mecanism that supports both fail stop and best-effort decoding resumption).
1. In light of 6., some might see providing only *encoding* and not *decoding* as being absurd and dismiss the proposal until both are provided. My only arguments to counter this are 2., 4. and the fact that as far as the `Uchar.t` and `Buffer.t` types are concerned a decoding API proposal should not have any impact on the signature of the functions that are provided in this PR.