### PR TITLE
Fix hash table performance problem in Emitaux (PR#7456)

### DIFF
--- a/Changes
+++ b/Changes
@@ -405,6 +405,9 @@ Next major version (4.05.0):
 
 - PR#7504: fix warning 8 with unconstrained records
   (Florian Angeletti, report by John Whitington)
+- PR#7456, GPR#1092: fix slow compilation on source files containing a lot
+  of similar debugging information location entries
+  (Mark Shinwell)
 
 - GPR#805, GPR#815, GPR#833: check for integer overflow in String.concat
   (Jeremy Yallop,

--- a/Changes
+++ b/Changes
@@ -405,6 +405,7 @@ Next major version (4.05.0):
 
 - PR#7504: fix warning 8 with unconstrained records
   (Florian Angeletti, report by John Whitington)
+
 - PR#7456, GPR#1092: fix slow compilation on source files containing a lot
   of similar debugging information location entries
   (Mark Shinwell)

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -143,10 +143,21 @@ let emit_frames a =
       Hashtbl.add filenames name lbl;
       lbl
   in
-  let debuginfos = Hashtbl.create 7 in
+  let module Label_table =
+    Hashtbl.Make (struct
+      type t = bool * Debuginfo.t
+
+      let equal ((rs1 : bool), dbg1) (rs2, dbg2) =
+        rs1 = rs2 && Debuginfo.compare dbg1 dbg2 = 0
+
+      let hash (rs, dbg) =
+        Hashtbl.hash (rs, Debuginfo.hash dbg)
+    end)
+  in
+  let debuginfos = Label_table.create 7 in
   let rec label_debuginfos rs rdbg =
     let key = (rs, rdbg) in
-    try fst (Hashtbl.find debuginfos key)
+    try fst (Label_table.find debuginfos key)
     with Not_found ->
       let lbl = Cmm.new_label () in
       let next =
@@ -155,7 +166,7 @@ let emit_frames a =
         | _ :: [] -> None
         | _ :: ((_ :: _) as rdbg') -> Some (label_debuginfos false rdbg')
       in
-      Hashtbl.add debuginfos key (lbl, next);
+      Label_table.add debuginfos key (lbl, next);
       lbl
   in
   let emit_debuginfo_label rs rdbg =
@@ -204,7 +215,7 @@ let emit_frames a =
   in
   a.efa_word (List.length !frame_descriptors);
   List.iter emit_frame !frame_descriptors;
-  Hashtbl.iter emit_debuginfo debuginfos;
+  Label_table.iter emit_debuginfo debuginfos;
   Hashtbl.iter emit_filename filenames;
   frame_descriptors := []
 

--- a/middle_end/debuginfo.ml
+++ b/middle_end/debuginfo.ml
@@ -95,6 +95,9 @@ let compare dbg1 dbg2 =
   in
   loop (List.rev dbg1) (List.rev dbg2)
 
+let hash t =
+  List.fold_left (fun hash item -> Hashtbl.hash (hash, item)) 0 t
+
 let rec print_compact ppf t =
   let print_item item =
     Format.fprintf ppf "%a:%i"

--- a/middle_end/debuginfo.ml
+++ b/middle_end/debuginfo.ml
@@ -76,6 +76,11 @@ let inline loc t =
 let concat dbg1 dbg2 =
   dbg1 @ dbg2
 
+(* CR-someday afrisch: FWIW, the current compare function does not seem very
+   good, since it reverses the two lists. I don't know how long the lists are,
+   nor if the specific currently implemented ordering is useful in other
+   contexts, but if one wants to use Map, a more efficient comparison should
+   be considered. *)
 let compare dbg1 dbg2 =
   let rec loop ds1 ds2 =
     match ds1, ds2 with

--- a/middle_end/debuginfo.mli
+++ b/middle_end/debuginfo.mli
@@ -38,4 +38,6 @@ val inline: Location.t -> t -> t
 
 val compare : t -> t -> int
 
+val hash : t -> int
+
 val print_compact : Format.formatter -> t -> unit


### PR DESCRIPTION
The default parameters for `Hashtbl.hash` are insufficient to hash `Debuginfo.t` values in any reasonable manner.  On the example from PR#7456, which has nearly 300,000 such values in the linearized code, there are a lot of hash collisions and about 30 seconds is taken on a fast machine inside `label_debuginfos`.

This patch adds a proper hash function which removes the performance regression (introduced between 4.03 and 4.04).