### PR TITLE
Allow creation of empty .cmxa files on macOS (PR#6550)

### DIFF
--- a/Changes
+++ b/Changes
@@ -418,6 +418,9 @@ Next major version (4.05.0):
   matches the bytecode compiler and Flambda.
   (Mark Shinwell, report by Jeremy Yallop, review by Frédéric Bour)
 
+- PR#6550, GPR#1094: Allow creation of empty .cmxa files on macOS
+  (Mark Shinwell)
+
 - PR#6594, GPR#955: Remove "Istore_symbol" specific operation on x86-64.
   This is more robust and in particular avoids assembly failures on Win64.
   (Mark Shinwell, review by Xavier Leroy, testing by David Allsopp and


### PR DESCRIPTION
In the event that a user attempts to create an empty .cmxa file on macOS, the "ar" utility fails with an error, complaining about trying to create an empty .a file.  Fixing this is useful since it provides consistent cross-platform behaviour and less opportunity for special cases in users' build systems (for example if the presence of archive members is conditional).

I tried to make this atomic by creating a temporary file first, but lo and behold, the "ar" utility has an error for that too: you can't run "ar rc" if the file already exists and isn't a valid archive as far as I can tell.  So this isn't atomic, but it's not really any worse than the existing two-step ar/ranlib process.