### PR TITLE
PR#7497: manual, numbered tables of contents

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,10 @@ Working version
   them with "Error (warning ..):", instead of "Warning ..:" and
   a trailing "Error: Some fatal warnings were triggered" message.
   (Valentin Gatien-Baron, review by Alain Frisch)
+### Manual and documentation:
+
+- PR#7497, GPR#1095: manual, enable numbering for table of contents
+  (Florian Angeletti, request by Daniel Bünzli)
 
 ### Tools:
 

--- a/manual/manual/manual.tex
+++ b/manual/manual/manual.tex
@@ -22,7 +22,7 @@
 
 \raggedbottom
 \input{version.tex}
-
+%HEVEA\tocnumber
 %HEVEA\setcounter{cuttingdepth}{1}
 %HEVEA\title{The OCaml system, release \ocamlversion}
 \input{allfiles.tex}


### PR DESCRIPTION
[MPR#7497:](https://caml.inria.fr/mantis/view.php?id=7497)
This one-line PR enables numbered tables of contents in the splitted html version of OCaml manual.
The main motivation is numbered tables of contents make it easier to navigate the manual starting from section numbers. For instance, compare the amount of effort spent finding the section 7.23 (Generative functor) starting from the [numbered manual](http://www.polychoron.fr/ocaml-nonmanual/mpr7497) compared to the [current manual](http://caml.inria.fr/pub/docs/manual-ocaml).

Another point, as noticed by @dbuenzli, is that some warnings refer to the (relatively new) manual section 8.5 for a in-depth explanation. Unfortunately, without a numbered main table of contents, it is not trivial to find this section 8.5 in the manual.