### PR TITLE
Assertions cleanup

### DIFF
--- a/asmrun/backtrace_prim.c
+++ b/asmrun/backtrace_prim.c
@@ -70,7 +70,7 @@ frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp)
 }
 
 int caml_alloc_backtrace_buffer(void){
-  Assert(caml_backtrace_pos == 0);
+  CAMLassert(caml_backtrace_pos == 0);
   caml_backtrace_buffer = malloc(BACKTRACE_BUFFER_SIZE
                                  * sizeof(backtrace_slot));
   if (caml_backtrace_buffer == NULL) return -1;
@@ -159,7 +159,7 @@ CAMLprim value caml_get_current_callstack(value max_frames_value)
 
     for (trace_pos = 0; trace_pos < trace_size; trace_pos++) {
       frame_descr * descr = caml_next_frame_descriptor(&pc, &sp);
-      Assert(descr != NULL);
+      CAMLassert(descr != NULL);
       Field(trace, trace_pos) = Val_backtrace_slot((backtrace_slot) descr);
     }
   }

--- a/asmrun/clambda_checks.c
+++ b/asmrun/clambda_checks.c
@@ -17,7 +17,6 @@
 /* Runtime checks to try to catch errors in code generation.
    See flambda_to_clambda.ml for more information. */
 
-#include <assert.h>
 #include <stdio.h>
 
 #include <caml/mlvalues.h>
@@ -46,9 +45,9 @@ value caml_check_value_is_closure(value v, value v_descr)
   }
   if (Tag_val(v) == Infix_tag) {
     v -= Infix_offset_val(v);
-    assert(Tag_val(v) == Closure_tag);
+    CAMLassert(Tag_val(v) == Closure_tag);
   }
-  assert(Wosize_val(v) >= 2);
+  CAMLassert(Wosize_val(v) >= 2);
 
   return orig_v;
 }
@@ -75,7 +74,7 @@ value caml_check_field_access(value v, value pos, value v_descr)
     v -= offset;
     pos += offset / sizeof(value);
   }
-  assert(Long_val(pos) >= 0);
+  CAMLassert(Long_val(pos) >= 0);
   if (Long_val(pos) >= Wosize_val(v)) {
     fprintf(stderr,
       "Access to field %" ARCH_INT64_PRINTF_FORMAT

--- a/asmrun/fail.c
+++ b/asmrun/fail.c
@@ -100,7 +100,7 @@ void caml_raise_with_args(value tag, int nargs, value args[])
   value bucket;
   int i;
 
-  Assert(1 + nargs <= Max_young_wosize);
+  CAMLassert(1 + nargs <= Max_young_wosize);
   bucket = caml_alloc_small (1 + nargs, 0);
   Field(bucket, 0) = tag;
   for (i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];

--- a/asmrun/roots.c
+++ b/asmrun/roots.c
@@ -116,7 +116,7 @@ static void init_frame_descriptors(link *new_frametables)
   intnat tblsize, increase, i;
   link *tail = NULL;
 
-  Assert(new_frametables);
+  CAMLassert(new_frametables);
 
   tail = frametables_list_tail(new_frametables);
   increase = count_descriptors(new_frametables);

--- a/asmrun/spacetime.c
+++ b/asmrun/spacetime.c
@@ -374,7 +374,7 @@ void save_trie (struct channel *chan, double time_override,
     thr = thr->next;
     num_marshalled++;
   }
-  Assert(num_marshalled == num_per_threads); */
+  CAMLassert(num_marshalled == num_per_threads); */
   caml_extern_allow_out_of_heap = 0;
 
   Unlock(chan);
@@ -403,23 +403,23 @@ c_node_type caml_spacetime_classify_c_node(c_node* node)
 
 c_node* caml_spacetime_c_node_of_stored_pointer(value node_stored)
 {
-  Assert(node_stored == Val_unit || Is_c_node(node_stored));
+  CAMLassert(node_stored == Val_unit || Is_c_node(node_stored));
   return (node_stored == Val_unit) ? NULL : (c_node*) Hp_val(node_stored);
 }
 
 c_node* caml_spacetime_c_node_of_stored_pointer_not_null(
       value node_stored)
 {
-  Assert(Is_c_node(node_stored));
+  CAMLassert(Is_c_node(node_stored));
   return (c_node*) Hp_val(node_stored);
 }
 
 value caml_spacetime_stored_pointer_of_c_node(c_node* c_node)
 {
   value node;
-  Assert(c_node != NULL);
+  CAMLassert(c_node != NULL);
   node = Val_hp(c_node);
-  Assert(Is_c_node(node));
+  CAMLassert(Is_c_node(node));
   return node;
 }
 
@@ -435,7 +435,7 @@ static value allocate_uninitialized_ocaml_node(int size_including_header)
   void* node;
   uintnat size;
 
-  Assert(size_including_header >= 3);
+  CAMLassert(size_including_header >= 3);
   node = caml_stat_alloc(sizeof(uintnat) * size_including_header);
 
   size = size_including_header * sizeof(value);
@@ -444,14 +444,14 @@ static value allocate_uninitialized_ocaml_node(int size_including_header)
   if (end_of_free_node_block - start_of_free_node_block < size) {
     reinitialise_free_node_block();
     node = (void*) start_of_free_node_block;
-    Assert(end_of_free_node_block - start_of_free_node_block >= size);
+    CAMLassert(end_of_free_node_block - start_of_free_node_block >= size);
   }
 
   start_of_free_node_block += size;
 
   /* We don't currently rely on [uintnat] alignment, but we do need some
      alignment, so just be sure. */
-  Assert (((uintnat) node) % sizeof(uintnat) == 0);
+  CAMLassert (((uintnat) node) % sizeof(uintnat) == 0);
   return Val_hp(node);
 }
 
@@ -470,7 +470,7 @@ static value find_tail_node(value node, void* callee)
   pc = Encode_node_pc(callee);
 
   do {
-    Assert(Is_ocaml_node(node));
+    CAMLassert(Is_ocaml_node(node));
     if (Node_pc(node) == pc) {
       found = node;
     }
@@ -496,7 +496,7 @@ CAMLprim value caml_spacetime_allocate_node(
      that tail called the current function.  (Such a value is necessary to
      be able to find the start of the caller's node, and hence its tail
      chain, so we as a tail-called callee can link ourselves in.) */
-  Assert(Is_tail_caller_node_encoded(node));
+  CAMLassert(Is_tail_caller_node_encoded(node));
 
   if (node != Val_unit) {
     value tail_node;
@@ -516,7 +516,7 @@ CAMLprim value caml_spacetime_allocate_node(
   node = allocate_uninitialized_ocaml_node(size_including_header);
   Hd_val(node) =
     Make_header(size_including_header - 1, OCaml_node_tag, Caml_black);
-  Assert((((uintnat) pc) % 1) == 0);
+  CAMLassert((((uintnat) pc) % 1) == 0);
   Node_pc(node) = Encode_node_pc(pc);
   /* If the callee was tail called, then the tail link field will link this
      new node into an existing tail chain.  Otherwise, it is initialized with
@@ -554,12 +554,12 @@ static c_node* allocate_c_node(void)
   if (end_of_free_node_block - start_of_free_node_block < sizeof(c_node)) {
     reinitialise_free_node_block();
     node = (c_node*) start_of_free_node_block;
-    Assert(end_of_free_node_block - start_of_free_node_block
+    CAMLassert(end_of_free_node_block - start_of_free_node_block
       >= sizeof(c_node));
   }
   start_of_free_node_block += sizeof(c_node);
 
-  Assert((sizeof(c_node) % sizeof(uintnat)) == 0);
+  CAMLassert((sizeof(c_node) % sizeof(uintnat)) == 0);
 
   /* CR-soon mshinwell: remove this and pad the structure properly */
   for (index = 0; index < sizeof(c_node) / sizeof(value); index++) {
@@ -605,12 +605,12 @@ CAMLprim value* caml_spacetime_indirect_node_hole_ptr
   encoded_callee = Encode_c_node_pc_for_call(callee);
 
   while (*node_hole != Val_unit) {
-    Assert(((uintnat) *node_hole) % sizeof(value) == 0);
+    CAMLassert(((uintnat) *node_hole) % sizeof(value) == 0);
 
     c_node = caml_spacetime_c_node_of_stored_pointer_not_null(*node_hole);
 
-    Assert(c_node != NULL);
-    Assert(caml_spacetime_classify_c_node(c_node) == CALL);
+    CAMLassert(c_node != NULL);
+    CAMLassert(caml_spacetime_classify_c_node(c_node) == CALL);
 
     if (c_node->pc == encoded_callee) {
       last_indirect_node_hole_ptr_result = &(c_node->data.callee_node);
@@ -634,8 +634,8 @@ CAMLprim value* caml_spacetime_indirect_node_hole_ptr
 
   *node_hole = caml_spacetime_stored_pointer_of_c_node(c_node);
 
-  Assert(((uintnat) *node_hole) % sizeof(value) == 0);
-  Assert(*node_hole != Val_unit);
+  CAMLassert(((uintnat) *node_hole) % sizeof(value) == 0);
+  CAMLassert(*node_hole != Val_unit);
 
   last_indirect_node_hole_ptr_result = &(c_node->data.callee_node);
 
@@ -785,7 +785,7 @@ static NOINLINE void* find_trie_node_from_libunwind(int for_allocation,
   for (frame = frames->size - 1; frame >= innermost_frame; frame--) {
     c_node_type expected_type;
     void* pc = frames->contents[frame];
-    Assert (pc != (void*) caml_last_return_address);
+    CAMLassert (pc != (void*) caml_last_return_address);
 
     if (!for_allocation) {
       expected_type = CALL;
@@ -813,8 +813,8 @@ static NOINLINE void* find_trie_node_from_libunwind(int for_allocation,
       int found = 0;
 
       node = caml_spacetime_c_node_of_stored_pointer_not_null(*node_hole);
-      Assert(node != NULL);
-      Assert(node->next == Val_unit
+      CAMLassert(node != NULL);
+      CAMLassert(node->next == Val_unit
         || (((uintnat) (node->next)) % sizeof(value) == 0));
 
       prev = NULL;
@@ -830,7 +830,7 @@ static NOINLINE void* find_trie_node_from_libunwind(int for_allocation,
         }
       }
       if (!found) {
-        Assert(prev != NULL);
+        CAMLassert(prev != NULL);
         node = allocate_c_node();
         node->pc = (expected_type == CALL ? Encode_c_node_pc_for_call(pc)
           : Encode_c_node_pc_for_alloc_point(pc));
@@ -841,10 +841,10 @@ static NOINLINE void* find_trie_node_from_libunwind(int for_allocation,
       }
     }
 
-    Assert(node != NULL);
+    CAMLassert(node != NULL);
 
-    Assert(caml_spacetime_classify_c_node(node) == expected_type);
-    Assert(pc_inside_c_node_matches(node, pc));
+    CAMLassert(caml_spacetime_classify_c_node(node) == expected_type);
+    CAMLassert(pc_inside_c_node_matches(node, pc));
     node_hole = &node->data.callee_node;
   }
 
@@ -876,14 +876,14 @@ static NOINLINE void* find_trie_node_from_libunwind(int for_allocation,
   }
 
   if (for_allocation) {
-    Assert(caml_spacetime_classify_c_node(node) == ALLOCATION);
-    Assert(caml_spacetime_c_node_of_stored_pointer(node->next) != node);
-    Assert(Profinfo_hd(node->data.allocation.profinfo) > 0);
+    CAMLassert(caml_spacetime_classify_c_node(node) == ALLOCATION);
+    CAMLassert(caml_spacetime_c_node_of_stored_pointer(node->next) != node);
+    CAMLassert(Profinfo_hd(node->data.allocation.profinfo) > 0);
     node->data.allocation.count =
       Val_long(Long_val(node->data.allocation.count) + (1 + wosize));
   }
 
-  Assert(node->next != (value) NULL);
+  CAMLassert(node->next != (value) NULL);
 
   return for_allocation ? (void*) node : (void*) node_hole;
 #else
@@ -927,7 +927,7 @@ void caml_spacetime_c_to_ocaml(void* ocaml_entry_point,
     node = allocate_uninitialized_ocaml_node(size_including_header);
     Hd_val(node) =
       Make_header(size_including_header - 1, OCaml_node_tag, Caml_black);
-    Assert((((uintnat) identifying_pc_for_caml_start_program) % 1) == 0);
+    CAMLassert((((uintnat) identifying_pc_for_caml_start_program) % 1) == 0);
     Node_pc(node) = Encode_node_pc(identifying_pc_for_caml_start_program);
     Tail_link(node) = node;
     Indirect_pc_linked_list(node, Node_num_header_words) = Val_unit;
@@ -938,14 +938,14 @@ void caml_spacetime_c_to_ocaml(void* ocaml_entry_point,
     /* If there is a node here already, it should never be an initialized
        (but as yet unused) tail call point, since calls from OCaml into C
        are never tail calls (and no C -> C call is marked as tail). */
-    Assert(!Is_tail_caller_node_encoded(node));
+    CAMLassert(!Is_tail_caller_node_encoded(node));
   }
 
-  Assert(Is_ocaml_node(node));
-  Assert(Decode_node_pc(Node_pc(node))
+  CAMLassert(Is_ocaml_node(node));
+  CAMLassert(Decode_node_pc(Node_pc(node))
     == identifying_pc_for_caml_start_program);
-  Assert(Tail_link(node) == node);
-  Assert(Wosize_val(node) == Node_num_header_words + Indirect_num_fields);
+  CAMLassert(Tail_link(node) == node);
+  CAMLassert(Wosize_val(node) == Node_num_header_words + Indirect_num_fields);
 
   /* Search the node to find the node hole corresponding to the indirect
      call to the OCaml function. */
@@ -954,7 +954,7 @@ void caml_spacetime_c_to_ocaml(void* ocaml_entry_point,
       ocaml_entry_point,
       &Indirect_pc_linked_list(node, Node_num_header_words),
       Val_unit);
-  Assert(*caml_spacetime_trie_node_ptr == Val_unit
+  CAMLassert(*caml_spacetime_trie_node_ptr == Val_unit
     || Is_ocaml_node(*caml_spacetime_trie_node_ptr));
 }
 
@@ -986,7 +986,7 @@ CAMLprim uintnat caml_spacetime_generate_profinfo (void* profinfo_words,
      (which already has to be done in the OCaml-generated code run before
      this function). */
   node = (value) profinfo_words;
-  Assert(Alloc_point_profinfo(node, 0) == Val_unit);
+  CAMLassert(Alloc_point_profinfo(node, 0) == Val_unit);
 
   /* The profinfo value is stored shifted to reduce the number of
      instructions required on the OCaml side.  It also enables us to use
@@ -995,11 +995,11 @@ CAMLprim uintnat caml_spacetime_generate_profinfo (void* profinfo_words,
   profinfo = Make_header_with_profinfo(
     index_within_node, Infix_tag, Caml_black, profinfo);
 
-  Assert(!Is_block(profinfo));
+  CAMLassert(!Is_block(profinfo));
   Alloc_point_profinfo(node, 0) = profinfo;
   /* The count is set to zero by the initialisation when the node was
      created (see above). */
-  Assert(Alloc_point_count(node, 0) == Val_long(0));
+  CAMLassert(Alloc_point_count(node, 0) == Val_long(0));
 
   /* Add the new allocation point into the linked list of all allocation
      points. */
@@ -1007,7 +1007,7 @@ CAMLprim uintnat caml_spacetime_generate_profinfo (void* profinfo_words,
     Alloc_point_next_ptr(node, 0) = (value) &caml_all_allocation_points->count;
   }
   else {
-    Assert(Alloc_point_next_ptr(node, 0) == Val_unit);
+    CAMLassert(Alloc_point_next_ptr(node, 0) == Val_unit);
   }
   caml_all_allocation_points = (allocation_point*) node;
 

--- a/asmrun/spacetime_offline.c
+++ b/asmrun/spacetime_offline.c
@@ -48,7 +48,7 @@
 c_node* caml_spacetime_offline_c_node_of_stored_pointer_not_null
           (value node_stored)
 {
-  Assert(Is_c_node(node_stored));
+  CAMLassert(Is_c_node(node_stored));
   return (c_node*) Hp_val(node_stored);
 }
 
@@ -60,8 +60,8 @@ c_node_type caml_spacetime_offline_classify_c_node(c_node* node)
 CAMLprim value caml_spacetime_compare_node(
       value node1, value node2)
 {
-  Assert(!Is_in_value_area(node1));
-  Assert(!Is_in_value_area(node2));
+  CAMLassert(!Is_in_value_area(node1));
+  CAMLassert(!Is_in_value_area(node2));
 
   if (node1 == node2) {
     return Val_long(0);
@@ -85,19 +85,19 @@ CAMLprim value caml_spacetime_node_num_header_words(value unit)
 
 CAMLprim value caml_spacetime_is_ocaml_node(value node)
 {
-  Assert(Is_ocaml_node(node) || Is_c_node(node));
+  CAMLassert(Is_ocaml_node(node) || Is_c_node(node));
   return Val_bool(Is_ocaml_node(node));
 }
 
 CAMLprim value caml_spacetime_ocaml_function_identifier(value node)
 {
-  Assert(Is_ocaml_node(node));
+  CAMLassert(Is_ocaml_node(node));
   return caml_copy_int64((uint64_t) Decode_node_pc(Node_pc(node)));
 }
 
 CAMLprim value caml_spacetime_ocaml_tail_chain(value node)
 {
-  Assert(Is_ocaml_node(node));
+  CAMLassert(Is_ocaml_node(node));
   return Tail_link(node);
 }
 
@@ -107,7 +107,7 @@ CAMLprim value caml_spacetime_classify_direct_call_point
   uintnat field;
   value callee_node;
 
-  Assert(Is_ocaml_node(node));
+  CAMLassert(Is_ocaml_node(node));
 
   field = Long_val(offset);
 
@@ -134,7 +134,7 @@ CAMLprim value caml_spacetime_ocaml_allocation_point_count
       (value node, value offset)
 {
   value count = Alloc_point_count(node, Long_val(offset));
-  Assert(!Is_block(count));
+  CAMLassert(!Is_block(count));
   return count;
 }
 
@@ -148,22 +148,22 @@ CAMLprim value caml_spacetime_ocaml_indirect_call_point_callees
       (value node, value offset)
 {
   value callees = Indirect_pc_linked_list(node, Long_val(offset));
-  Assert(Is_block(callees));
-  Assert(Is_c_node(callees));
+  CAMLassert(Is_block(callees));
+  CAMLassert(Is_c_node(callees));
   return callees;
 }
 
 CAMLprim value caml_spacetime_c_node_is_call(value node)
 {
   c_node* c_node;
-  Assert(node != (value) NULL);
-  Assert(Is_c_node(node));
+  CAMLassert(node != (value) NULL);
+  CAMLassert(Is_c_node(node));
   c_node = caml_spacetime_offline_c_node_of_stored_pointer_not_null(node);
   switch (caml_spacetime_offline_classify_c_node(c_node)) {
     case CALL: return Val_true;
     case ALLOCATION: return Val_false;
   }
-  Assert(0);
+  CAMLassert(0);
   return Val_unit;  /* silence compiler warning */
 }
 
@@ -171,18 +171,18 @@ CAMLprim value caml_spacetime_c_node_next(value node)
 {
   c_node* c_node;
 
-  Assert(node != (value) NULL);
-  Assert(Is_c_node(node));
+  CAMLassert(node != (value) NULL);
+  CAMLassert(Is_c_node(node));
   c_node = caml_spacetime_offline_c_node_of_stored_pointer_not_null(node);
-  Assert(c_node->next == Val_unit || Is_c_node(c_node->next));
+  CAMLassert(c_node->next == Val_unit || Is_c_node(c_node->next));
   return c_node->next;
 }
 
 CAMLprim value caml_spacetime_c_node_call_site(value node)
 {
   c_node* c_node;
-  Assert(node != (value) NULL);
-  Assert(Is_c_node(node));
+  CAMLassert(node != (value) NULL);
+  CAMLassert(Is_c_node(node));
   c_node = caml_spacetime_offline_c_node_of_stored_pointer_not_null(node);
   return caml_copy_int64((uint64_t) Decode_c_node_pc(c_node->pc));
 }
@@ -190,10 +190,10 @@ CAMLprim value caml_spacetime_c_node_call_site(value node)
 CAMLprim value caml_spacetime_c_node_callee_node(value node)
 {
   c_node* c_node;
-  Assert(node != (value) NULL);
-  Assert(Is_c_node(node));
+  CAMLassert(node != (value) NULL);
+  CAMLassert(Is_c_node(node));
   c_node = caml_spacetime_offline_c_node_of_stored_pointer_not_null(node);
-  Assert(caml_spacetime_offline_classify_c_node(c_node) == CALL);
+  CAMLassert(caml_spacetime_offline_classify_c_node(c_node) == CALL);
   /* This might be an uninitialised tail call point: for example if an OCaml
      callee was indirectly called but the callee wasn't instrumented (e.g. a
      leaf function that doesn't allocate). */
@@ -206,22 +206,22 @@ CAMLprim value caml_spacetime_c_node_callee_node(value node)
 CAMLprim value caml_spacetime_c_node_profinfo(value node)
 {
   c_node* c_node;
-  Assert(node != (value) NULL);
-  Assert(Is_c_node(node));
+  CAMLassert(node != (value) NULL);
+  CAMLassert(Is_c_node(node));
   c_node = caml_spacetime_offline_c_node_of_stored_pointer_not_null(node);
-  Assert(caml_spacetime_offline_classify_c_node(c_node) == ALLOCATION);
-  Assert(!Is_block(c_node->data.allocation.profinfo));
+  CAMLassert(caml_spacetime_offline_classify_c_node(c_node) == ALLOCATION);
+  CAMLassert(!Is_block(c_node->data.allocation.profinfo));
   return Val_long(Profinfo_hd(c_node->data.allocation.profinfo));
 }
 
 CAMLprim value caml_spacetime_c_node_allocation_count(value node)
 {
   c_node* c_node;
-  Assert(node != (value) NULL);
-  Assert(Is_c_node(node));
+  CAMLassert(node != (value) NULL);
+  CAMLassert(Is_c_node(node));
   c_node = caml_spacetime_offline_c_node_of_stored_pointer_not_null(node);
-  Assert(caml_spacetime_offline_classify_c_node(c_node) == ALLOCATION);
-  Assert(!Is_block(c_node->data.allocation.count));
+  CAMLassert(caml_spacetime_offline_classify_c_node(c_node) == ALLOCATION);
+  CAMLassert(!Is_block(c_node->data.allocation.count));
   return c_node->data.allocation.count;
 }
 

--- a/asmrun/spacetime_snapshot.c
+++ b/asmrun/spacetime_snapshot.c
@@ -88,7 +88,7 @@ static value allocate_outside_heap_with_tag(mlsize_t size_in_bytes, tag_t tag)
   /* CR-soon mshinwell: this function should live somewhere else */
   header_t* block;
 
-  Assert(size_in_bytes % sizeof(value) == 0);
+  CAMLassert(size_in_bytes % sizeof(value) == 0);
   block = caml_stat_alloc(sizeof(header_t) + size_in_bytes);
   *block = Make_header(size_in_bytes / sizeof(value), tag, Caml_black);
   return (value) &block[1];
@@ -96,7 +96,7 @@ static value allocate_outside_heap_with_tag(mlsize_t size_in_bytes, tag_t tag)
 
 static value allocate_outside_heap(mlsize_t size_in_bytes)
 {
-  Assert(size_in_bytes > 0);
+  CAMLassert(size_in_bytes > 0);
   return allocate_outside_heap_with_tag(size_in_bytes, 0);
 }
 
@@ -138,7 +138,7 @@ static value get_total_allocations(void)
     Field(v_total, 2) = v_total_allocations;
     v_total_allocations = v_total;
 
-    Assert (total->next == Val_unit
+    CAMLassert (total->next == Val_unit
       || (Is_block(total->next) && Tag_val(total->next) == Infix_tag));
     if (total->next == Val_unit) {
       total = NULL;
@@ -217,7 +217,7 @@ static value take_snapshot(double time_override, int use_time_override)
             words_scanned += Whsize_hd(hd);
             if (profinfo > 0 && profinfo < PROFINFO_MASK) {
               words_scanned_with_profinfo += Whsize_hd(hd);
-              Assert (raw_entries[profinfo].num_blocks >= 0);
+              CAMLassert (raw_entries[profinfo].num_blocks >= 0);
               if (raw_entries[profinfo].num_blocks == 0) {
                 num_distinct_profinfos++;
               }
@@ -229,7 +229,7 @@ static value take_snapshot(double time_override, int use_time_override)
           break;
       }
       hp += Bhsize_hd (hd);
-      Assert (hp <= limit);
+      CAMLassert (hp <= limit);
     }
 
     chunk = Chunk_next (chunk);
@@ -241,9 +241,9 @@ static value take_snapshot(double time_override, int use_time_override)
     entries = (snapshot_entries*) v_entries;
     target_index = 0;
     for (index = 0; index <= PROFINFO_MASK; index++) {
-      Assert(raw_entries[index].num_blocks >= 0);
+      CAMLassert(raw_entries[index].num_blocks >= 0);
       if (raw_entries[index].num_blocks > 0) {
-        Assert(target_index < num_distinct_profinfos);
+        CAMLassert(target_index < num_distinct_profinfos);
         entries->entries[target_index].profinfo = Val_long(index);
         entries->entries[target_index].num_blocks
           = Val_long(raw_entries[index].num_blocks);
@@ -256,7 +256,7 @@ static value take_snapshot(double time_override, int use_time_override)
     v_entries = Atom(0);
   }
 
-  Assert(sizeof(double) == sizeof(value));
+  CAMLassert(sizeof(double) == sizeof(value));
   v_time = allocate_outside_heap_with_tag(sizeof(double), Double_tag);
   Double_field(v_time, 0) = time;
 
@@ -497,7 +497,7 @@ static void add_unit_to_shape_table(uint64_t *unit_table, value *list)
           break;
 
         default:
-          Assert(0);
+          CAMLassert(0);
           abort();  /* silence compiler warning */
       }
 
@@ -569,7 +569,6 @@ value caml_spacetime_shape_table(void)
 static value spacetime_disabled()
 {
   caml_failwith("Spacetime profiling not enabled");
-  Assert(0);  /* unreachable */
 }
 
 CAMLprim value caml_spacetime_take_snapshot(value ignored)

--- a/byterun/alloc.c
+++ b/byterun/alloc.c
@@ -36,8 +36,8 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
   value result;
   mlsize_t i;
 
-  Assert (tag < 256);
-  Assert (tag != Infix_tag);
+  CAMLassert (tag < 256);
+  CAMLassert (tag != Infix_tag);
   if (wosize == 0){
     result = Atom (tag);
   }else if (wosize <= Max_young_wosize){
@@ -59,9 +59,9 @@ CAMLexport value caml_alloc_small (mlsize_t wosize, tag_t tag)
 {
   value result;
 
-  Assert (wosize > 0);
-  Assert (wosize <= Max_young_wosize);
-  Assert (tag < 256);
+  CAMLassert (wosize > 0);
+  CAMLassert (wosize <= Max_young_wosize);
+  CAMLassert (tag < 256);
   Alloc_small (result, wosize, tag);
   return result;
 }
@@ -75,9 +75,9 @@ CAMLexport value caml_alloc_small_with_my_or_given_profinfo (mlsize_t wosize,
   else {
     value result;
 
-    Assert (wosize > 0);
-    Assert (wosize <= Max_young_wosize);
-    Assert (tag < 256);
+    CAMLassert (wosize > 0);
+    CAMLassert (wosize <= Max_young_wosize);
+    CAMLassert (tag < 256);
     Alloc_small_with_profinfo (result, wosize, tag, profinfo);
     return result;
   }
@@ -223,8 +223,8 @@ CAMLprim value caml_update_dummy(value dummy, value newval)
 
   size = Wosize_val(newval);
   tag = Tag_val (newval);
-  Assert (size == Wosize_val(dummy));
-  Assert (tag < No_scan_tag || tag == Double_array_tag);
+  CAMLassert (size == Wosize_val(dummy));
+  CAMLassert (tag < No_scan_tag || tag == Double_array_tag);
 
   Tag_val(dummy) = tag;
   if (tag == Double_array_tag){

--- a/byterun/array.c
+++ b/byterun/array.c
@@ -335,7 +335,7 @@ static value caml_array_gather(intnat num_arrays,
              lengths[i] * sizeof(double));
       pos += lengths[i];
     }
-    Assert(pos == size);
+    CAMLassert(pos == size);
   }
   else if (size > Max_wosize) {
     /* Array of values, too big. */
@@ -351,7 +351,7 @@ static value caml_array_gather(intnat num_arrays,
              lengths[i] * sizeof(value));
       pos += lengths[i];
     }
-    Assert(pos == size);
+    CAMLassert(pos == size);
   } else {
     /* Array of values, must be allocated in old generation and filled
        using caml_initialize. */
@@ -363,7 +363,7 @@ static value caml_array_gather(intnat num_arrays,
         caml_initialize(&Field(res, pos), *src);
       }
     }
-    Assert(pos == size);
+    CAMLassert(pos == size);
 
     /* Many caml_initialize in a row can create a lot of old-to-young
        refs.  Give the minor GC a chance to run if it needs to. */

--- a/byterun/backtrace_prim.c
+++ b/byterun/backtrace_prim.c
@@ -162,7 +162,7 @@ static struct ev_info *process_debug_events(code_t code_start, value events_heap
     }
   }
 
-  Assert(j == *num_events);
+  CAMLassert(j == *num_events);
 
   qsort(events, *num_events, sizeof(struct ev_info), cmp_ev_info);
 
@@ -218,7 +218,7 @@ CAMLprim value caml_remove_debug_info(code_t start)
 }
 
 int caml_alloc_backtrace_buffer(void){
-  Assert(caml_backtrace_pos == 0);
+  CAMLassert(caml_backtrace_pos == 0);
   caml_backtrace_buffer = malloc(BACKTRACE_BUFFER_SIZE * sizeof(code_t));
   if (caml_backtrace_buffer == NULL) return -1;
   return 0;
@@ -310,7 +310,7 @@ CAMLprim value caml_get_current_callstack(value max_frames_value)
 
     for (trace_pos = 0; trace_pos < trace_size; trace_pos++) {
       code_t p = caml_next_frame_pointer(&sp, &trsp);
-      Assert(p != NULL);
+      CAMLassert(p != NULL);
       Field(trace, trace_pos) = Val_backtrace_slot(p);
     }
   }
@@ -333,7 +333,7 @@ static void read_main_debug_info(struct debug_info *di)
   struct channel *chan;
   struct exec_trailer trail;
 
-  Assert(di->already_read == 0);
+  CAMLassert(di->already_read == 0);
   di->already_read = 1;
 
   if (caml_cds_file != NULL) {

--- a/byterun/callback.c
+++ b/byterun/callback.c
@@ -69,7 +69,7 @@ CAMLexport value caml_callbackN_exn(value closure, int narg, value args[])
   opcode_t local_callback_code[7];
 #endif
 
-  Assert(narg + 4 <= 256);
+  CAMLassert(narg + 4 <= 256);
 
   caml_extern_sp -= narg + 4;
   for (i = 0; i < narg; i++) caml_extern_sp[i] = args[i]; /* arguments */

--- a/byterun/caml/address_class.h
+++ b/byterun/caml/address_class.h
@@ -26,7 +26,7 @@
    it might belong to. */
 
 #define Is_young(val) \
-  (Assert (Is_block (val)), \
+  (CAMLassert (Is_block (val)), \
    (addr)(val) < (addr)caml_young_end && (addr)(val) > (addr)caml_young_start)
 
 #define Is_in_heap(a) (Classify_addr(a) & In_heap)

--- a/byterun/caml/gc.h
+++ b/byterun/caml/gc.h
@@ -40,7 +40,7 @@
 
 /* This depends on the layout of the header.  See [mlvalues.h]. */
 #define Make_header(wosize, tag, color)                                       \
-      (/*Assert ((wosize) <= Max_wosize),*/                                   \
+      (/*CAMLassert ((wosize) <= Max_wosize),*/                                   \
        ((header_t) (((header_t) (wosize) << 10)                               \
                     + (color)                                                 \
                     + (tag_t) (tag)))                                         \

--- a/byterun/caml/minor_gc.h
+++ b/byterun/caml/minor_gc.h
@@ -99,7 +99,7 @@ static inline void add_to_ephe_ref_table (struct caml_ephe_ref_table *tbl,
   ephe_ref = tbl->ptr++;
   ephe_ref->ephe = ar;
   ephe_ref->offset = offset;
-  Assert(ephe_ref->offset < Wosize_val(ephe_ref->ephe));
+  CAMLassert(ephe_ref->offset < Wosize_val(ephe_ref->ephe));
 }
 
 static inline void add_to_custom_table (struct caml_custom_table *tbl, value v,

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -341,10 +341,6 @@ extern void caml_set_fields (intnat v, unsigned long, unsigned long);
 #endif /* DEBUG */
 
 
-#ifndef CAML_AVOID_CONFLICTS
-#define Assert CAMLassert
-#endif
-
 /* snprintf emulation for Win32 */
 
 #if defined(_WIN32) && !defined(_UCRT)

--- a/byterun/caml/weak.h
+++ b/byterun/caml/weak.h
@@ -46,7 +46,7 @@ static inline void caml_ephe_clean (value v){
   int release_data = 0;
   mlsize_t size, i;
   header_t hd;
-                                    Assert(caml_gc_phase == Phase_clean);
+                                    CAMLassert(caml_gc_phase == Phase_clean);
 
   hd = Hd_val (v);
   size = Wosize_hd (hd);
@@ -82,7 +82,7 @@ static inline void caml_ephe_clean (value v){
         Field (v, 1) = caml_ephe_none;
       } else {
         /* The mark phase must have marked it */
-        Assert( !(Is_block (child) && Is_in_heap (child)
+        CAMLassert( !(Is_block (child) && Is_in_heap (child)
                   && Is_white_val (child)) );
       }
   }

--- a/byterun/compact.c
+++ b/byterun/compact.c
@@ -66,7 +66,7 @@ typedef uintnat word;
 static void invert_pointer_at (word *p)
 {
   word q = *p;
-                                            Assert (Ecolor ((intnat) p) == 0);
+                                            CAMLassert (Ecolor ((intnat) p) == 0);
 
   /* Use Ecolor (q) == 0 instead of Is_block (q) because q could be an
      inverted pointer for an infix header (with Ecolor == 2). */
@@ -88,7 +88,7 @@ static void invert_pointer_at (word *p)
         word *hp = (word *) Hp_val (val);
 
         while (Ecolor (*hp) == 0) hp = (word *) *hp;
-                                                   Assert (Ecolor (*hp) == 3);
+                                                   CAMLassert (Ecolor (*hp) == 3);
         if (Tag_ehd (*hp) == Closure_tag){
           /* This is the first infix found in this block. */
           /* Save original header. */
@@ -98,7 +98,7 @@ static void invert_pointer_at (word *p)
           /* Change block header's tag to Infix_tag, and change its size
              to point to the infix list. */
           *hp = Make_ehd (Wosize_bhsize (q - val), Infix_tag, 3, (uintnat) 0);
-        }else{                            Assert (Tag_ehd (*hp) == Infix_tag);
+        }else{                            CAMLassert (Tag_ehd (*hp) == Infix_tag);
           /* Point the last of this infix list to the current first infix
              list of the block. */
           *p = (word) &Field (val, Wosize_ehd (*hp)) | 1;
@@ -147,7 +147,7 @@ static char *compact_allocate (mlsize_t size)
   }
   chunk = compact_fl;
   while (Chunk_size (chunk) - Chunk_alloc (chunk) < size){
-    chunk = Chunk_next (chunk);                         Assert (chunk != NULL);
+    chunk = Chunk_next (chunk);                         CAMLassert (chunk != NULL);
   }
   adr = chunk + Chunk_alloc (chunk);
   Chunk_alloc (chunk) += size;
@@ -157,7 +157,7 @@ static char *compact_allocate (mlsize_t size)
 static void do_compaction (void)
 {
   char *ch, *chend;
-                                          Assert (caml_gc_phase == Phase_idle);
+                                          CAMLassert (caml_gc_phase == Phase_idle);
   caml_gc_message (0x10, "Compacting heap...\n", 0);
 
 #ifdef DEBUG
@@ -178,7 +178,7 @@ static void do_compaction (void)
         if (Is_blue_hd (hd)){
           /* Free object.  Give it a string tag. */
           Hd_hp (p) = Make_ehd (sz, String_tag, 3, (uintnat) 0);
-        }else{                                      Assert (Is_white_hd (hd));
+        }else{                                      CAMLassert (Is_white_hd (hd));
           /* Live object.  Keep its tag. */
           Hd_hp (p) = Make_ehd (sz, Tag_hd (hd), 3, Profinfo_hd (hd));
         }
@@ -287,7 +287,7 @@ static void do_compaction (void)
           if (t == Infix_tag){
             /* Get the original header of this block. */
             infixes = p + sz;
-            q = *infixes;                             Assert (Ecolor (q) == 2);
+            q = *infixes;                             CAMLassert (Ecolor (q) == 2);
             while (Ecolor (q) != 3) q = * (word *) (q & ~(uintnat)3);
             sz = Whsize_ehd (q);
             t = Tag_ehd (q);
@@ -314,7 +314,7 @@ static void do_compaction (void)
                 next = * (word *) q;
                 * (word *) q = (word) Val_hp ((word *) newadr + (infixes - p));
                 q = next;
-              }                    Assert (Ecolor (q) == 1 || Ecolor (q) == 3);
+              }                    CAMLassert (Ecolor (q) == 1 || Ecolor (q) == 3);
               /* No need to preserve any profinfo value on the [Infix_tag]
                  headers; the Spacetime profiling heap snapshot code doesn't
                  look at them. */
@@ -323,9 +323,9 @@ static void do_compaction (void)
             }
           }
           p += sz;
-        }else{                                        Assert (Ecolor (q) == 3);
+        }else{                                        CAMLassert (Ecolor (q) == 3);
           /* This is guaranteed only if caml_compact_heap was called after a
-             nonincremental major GC:       Assert (Tag_ehd (q) == String_tag);
+             nonincremental major GC:       CAMLassert (Tag_ehd (q) == String_tag);
           */
           /* No pointers to the header and no infix header:
              the object was free. */
@@ -355,7 +355,7 @@ static void do_compaction (void)
           memmove (newadr, p, sz);
           p += Wsize_bsize (sz);
         }else{
-          Assert (Color_hd (q) == Caml_blue);
+          CAMLassert (Color_hd (q) == Caml_blue);
           p += Whsize_hd (q);
         }
       }
@@ -489,9 +489,9 @@ void caml_compact_heap (void)
       caml_stat_top_heap_wsz = caml_stat_heap_wsz;
     }
     do_compaction ();
-    Assert (caml_stat_heap_chunks == 1);
-    Assert (Chunk_next (caml_heap_start) == NULL);
-    Assert (caml_stat_heap_wsz == Wsize_bsize (Chunk_size (chunk)));
+    CAMLassert (caml_stat_heap_chunks == 1);
+    CAMLassert (Chunk_next (caml_heap_start) == NULL);
+    CAMLassert (caml_stat_heap_wsz == Wsize_bsize (Chunk_size (chunk)));
     CAML_INSTR_TIME (tmr, "compact/recompact");
   }
 }
@@ -507,7 +507,7 @@ void caml_compact_heap_maybe (void)
      We compact the heap if FP > caml_percent_max
   */
   float fw, fp;
-                                          Assert (caml_gc_phase == Phase_idle);
+                                          CAMLassert (caml_gc_phase == Phase_idle);
   if (caml_percent_max >= 1000000) return;
   if (caml_stat_major_collections < 3) return;
   if (caml_stat_heap_wsz <= 2 * caml_clip_heap_chunk_wsz (0)) return;

--- a/byterun/custom.c
+++ b/byterun/custom.c
@@ -60,8 +60,8 @@ CAMLexport void caml_register_custom_operations(struct custom_operations * ops)
 {
   struct custom_operations_list * l =
     caml_stat_alloc(sizeof(struct custom_operations_list));
-  Assert(ops->identifier != NULL);
-  Assert(ops->deserialize != NULL);
+  CAMLassert(ops->identifier != NULL);
+  CAMLassert(ops->deserialize != NULL);
   l->ops = ops;
   l->next = custom_ops_table;
   custom_ops_table = l;

--- a/byterun/debugger.c
+++ b/byterun/debugger.c
@@ -302,20 +302,20 @@ void caml_debugger(enum event_kind event)
     switch(caml_getch(dbg_in)) {
     case REQ_SET_EVENT:
       pos = caml_getword(dbg_in);
-      Assert (pos >= 0);
-      Assert (pos < caml_code_size);
+      CAMLassert (pos >= 0);
+      CAMLassert (pos < caml_code_size);
       caml_set_instruction(caml_start_code + pos / sizeof(opcode_t), EVENT);
       break;
     case REQ_SET_BREAKPOINT:
       pos = caml_getword(dbg_in);
-      Assert (pos >= 0);
-      Assert (pos < caml_code_size);
+      CAMLassert (pos >= 0);
+      CAMLassert (pos < caml_code_size);
       caml_set_instruction(caml_start_code + pos / sizeof(opcode_t), BREAK);
       break;
     case REQ_RESET_INSTR:
       pos = caml_getword(dbg_in);
-      Assert (pos >= 0);
-      Assert (pos < caml_code_size);
+      CAMLassert (pos >= 0);
+      CAMLassert (pos < caml_code_size);
       pos = pos / sizeof(opcode_t);
       caml_set_instruction(caml_start_code + pos, caml_saved_code[pos]);
       break;

--- a/byterun/fail.c
+++ b/byterun/fail.c
@@ -65,7 +65,7 @@ CAMLexport void caml_raise_with_args(value tag, int nargs, value args[])
   value bucket;
   int i;
 
-  Assert(1 + nargs <= Max_young_wosize);
+  CAMLassert(1 + nargs <= Max_young_wosize);
   bucket = caml_alloc_small (1 + nargs, 0);
   Field(bucket, 0) = tag;
   for (i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];

--- a/byterun/finalise.c
+++ b/byterun/finalise.c
@@ -81,7 +81,7 @@ static void alloc_to_do (int size)
     to_do_hd = result;
     to_do_tl = result;
   }else{
-    Assert (to_do_tl->next == NULL);
+    CAMLassert (to_do_tl->next == NULL);
     to_do_tl->next = result;
     to_do_tl = result;
   }
@@ -95,10 +95,10 @@ static void generic_final_update (struct finalisable * final, int darken_value)
   uintnat i, j, k;
   uintnat todo_count = 0;
 
-  Assert (final->old <= final->young);
+  CAMLassert (final->old <= final->young);
   for (i = 0; i < final->old; i++){
-    Assert (Is_block (final->table[i].val));
-    Assert (Is_in_heap (final->table[i].val));
+    CAMLassert (Is_block (final->table[i].val));
+    CAMLassert (Is_in_heap (final->table[i].val));
     if (Is_white_val (final->table[i].val)){
       ++ todo_count;
     }
@@ -117,9 +117,9 @@ static void generic_final_update (struct finalisable * final, int darken_value)
     alloc_to_do (todo_count);
     j = k = 0;
     for (i = 0; i < final->old; i++){
-      Assert (Is_block (final->table[i].val));
-      Assert (Is_in_heap (final->table[i].val));
-      Assert (Tag_val (final->table[i].val) != Forward_tag);
+      CAMLassert (Is_block (final->table[i].val));
+      CAMLassert (Is_in_heap (final->table[i].val));
+      CAMLassert (Tag_val (final->table[i].val) != Forward_tag);
       if(Is_white_val (final->table[i].val)){
         /** dead */
         to_do_tl->item[k] = final->table[i];
@@ -187,7 +187,7 @@ void caml_final_do_calls (void)
         if (to_do_hd == NULL) to_do_tl = NULL;
       }
       if (to_do_hd == NULL) break;
-      Assert (to_do_hd->size > 0);
+      CAMLassert (to_do_hd->size > 0);
       -- to_do_hd->size;
       f = to_do_hd->item[to_do_hd->size];
       running_finalisation_function = 1;
@@ -223,12 +223,12 @@ void caml_final_do_roots (scanning_action f)
   uintnat i;
   struct to_do *todo;
 
-  Assert (finalisable_first.old <= finalisable_first.young);
+  CAMLassert (finalisable_first.old <= finalisable_first.young);
   for (i = 0; i < finalisable_first.young; i++){
     Call_action (f, finalisable_first.table[i].fun);
   };
 
-  Assert (finalisable_last.old <= finalisable_last.young);
+  CAMLassert (finalisable_last.old <= finalisable_last.young);
   for (i = 0; i < finalisable_last.young; i++){
     Call_action (f, finalisable_last.table[i].fun);
   };
@@ -268,7 +268,7 @@ void caml_final_oldify_young_roots ()
 {
   uintnat i;
 
-  Assert (finalisable_first.old <= finalisable_first.young);
+  CAMLassert (finalisable_first.old <= finalisable_first.young);
   for (i = finalisable_first.old; i < finalisable_first.young; i++){
     caml_oldify_one(finalisable_first.table[i].fun,
                     &finalisable_first.table[i].fun);
@@ -276,7 +276,7 @@ void caml_final_oldify_young_roots ()
                     &finalisable_first.table[i].val);
   }
 
-  Assert (finalisable_last.old <= finalisable_last.young);
+  CAMLassert (finalisable_last.old <= finalisable_last.young);
   for (i = finalisable_last.old; i < finalisable_last.young; i++){
     caml_oldify_one(finalisable_last.table[i].fun,
                     &finalisable_last.table[i].fun);
@@ -289,10 +289,10 @@ static void generic_final_minor_update (struct finalisable * final)
   uintnat i, j, k;
   uintnat todo_count = 0;
 
-  Assert (final->old <= final->young);
+  CAMLassert (final->old <= final->young);
   for (i = final->old; i < final->young; i++){
-    Assert (Is_block (final->table[i].val));
-    Assert (Is_in_heap_or_young (final->table[i].val));
+    CAMLassert (Is_block (final->table[i].val));
+    CAMLassert (Is_in_heap_or_young (final->table[i].val));
     if (Is_young(final->table[i].val) && Hd_val(final->table[i].val) != 0){
       ++ todo_count;
     }
@@ -311,9 +311,9 @@ static void generic_final_minor_update (struct finalisable * final)
     k = 0;
     j = final->old;
     for (i = final->old; i < final->young; i++){
-      Assert (Is_block (final->table[i].val));
-      Assert (Is_in_heap_or_young (final->table[i].val));
-      Assert (Tag_val (final->table[i].val) != Forward_tag);
+      CAMLassert (Is_block (final->table[i].val));
+      CAMLassert (Is_in_heap_or_young (final->table[i].val));
+      CAMLassert (Tag_val (final->table[i].val) != Forward_tag);
       if(Is_young(final->table[j].val) && Hd_val(final->table[i].val) != 0){
         /** dead */
         to_do_tl->item[k] = final->table[i];
@@ -334,8 +334,8 @@ static void generic_final_minor_update (struct finalisable * final)
 
   /** update the minor value to the copied major value */
   for (i = final->old; i < final->young; i++){
-    Assert (Is_block (final->table[i].val));
-    Assert (Is_in_heap_or_young (final->table[i].val));
+    CAMLassert (Is_block (final->table[i].val));
+    CAMLassert (Is_in_heap_or_young (final->table[i].val));
     if (Is_young(final->table[i].val)) {
       CAMLassert (Hd_val(final->table[i].val) == 0);
       final->table[i].val = Field(final->table[i].val,0);
@@ -343,7 +343,7 @@ static void generic_final_minor_update (struct finalisable * final)
   }
 
   /** check invariant */
-  Assert (final->old <= final->young);
+  CAMLassert (final->old <= final->young);
   for (i = 0; i < final->young; i++){
     CAMLassert( Is_in_heap(final->table[i].val) );
   };
@@ -379,14 +379,14 @@ static void generic_final_register (struct finalisable *final, value f, value v)
       || Tag_val (v) == Forward_tag) {
     caml_invalid_argument ("Gc.finalise");
   }
-  Assert (final->old <= final->young);
+  CAMLassert (final->old <= final->young);
 
   if (final->young >= final->size){
     if (final->table == NULL){
       uintnat new_size = 30;
       final->table = caml_stat_alloc (new_size * sizeof (struct final));
-      Assert (final->old == 0);
-      Assert (final->young == 0);
+      CAMLassert (final->old == 0);
+      CAMLassert (final->young == 0);
       final->size = new_size;
     }else{
       uintnat new_size = final->size * 2;
@@ -395,7 +395,7 @@ static void generic_final_register (struct finalisable *final, value f, value v)
       final->size = new_size;
     }
   }
-  Assert (final->young < final->size);
+  CAMLassert (final->young < final->size);
   final->table[final->young].fun = f;
   if (Tag_val (v) == Infix_tag){
     final->table[final->young].offset = Infix_offset_val (v);

--- a/byterun/fix_code.c
+++ b/byterun/fix_code.c
@@ -163,7 +163,7 @@ void caml_thread_code (code_t code, asize_t len)
       p += l[instr];
     }
   }
-  Assert(p == code + len);
+  CAMLassert(p == code + len);
 }
 
 #else

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -48,7 +48,7 @@ CAMLexport double caml_Double_val(value val)
 {
   union { value v[2]; double d; } buffer;
 
-  Assert(sizeof(double) == 2 * sizeof(value));
+  CAMLassert(sizeof(double) == 2 * sizeof(value));
   buffer.v[0] = Field(val, 0);
   buffer.v[1] = Field(val, 1);
   return buffer.d;
@@ -58,7 +58,7 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
 {
   union { value v[2]; double d; } buffer;
 
-  Assert(sizeof(double) == 2 * sizeof(value));
+  CAMLassert(sizeof(double) == 2 * sizeof(value));
   buffer.d = dbl;
   Field(val, 0) = buffer.v[0];
   Field(val, 1) = buffer.v[1];

--- a/byterun/freelist.c
+++ b/byterun/freelist.c
@@ -82,25 +82,25 @@ static void fl_check (void)
   cur = Next (prev);
   while (cur != Val_NULL){
     size_found += Whsize_bp (cur);
-    Assert (Is_in_heap (cur));
+    CAMLassert (Is_in_heap (cur));
     if (cur == fl_prev) prev_found = 1;
     if (policy == Policy_first_fit && Wosize_bp (cur) > sz){
       sz = Wosize_bp (cur);
       if (flp_found < flp_size){
-        Assert (Next (flp[flp_found]) == cur);
+        CAMLassert (Next (flp[flp_found]) == cur);
         ++ flp_found;
       }else{
-        Assert (beyond == Val_NULL || cur >= Next (beyond));
+        CAMLassert (beyond == Val_NULL || cur >= Next (beyond));
       }
     }
     if (cur == caml_fl_merge) merge_found = 1;
     prev = cur;
     cur = Next (prev);
   }
-  if (policy == Policy_next_fit) Assert (prev_found || fl_prev == Fl_head);
-  if (policy == Policy_first_fit) Assert (flp_found == flp_size);
-  Assert (merge_found || caml_fl_merge == Fl_head);
-  Assert (size_found == caml_fl_cur_wsz);
+  if (policy == Policy_next_fit) CAMLassert (prev_found || fl_prev == Fl_head);
+  if (policy == Policy_first_fit) CAMLassert (flp_found == flp_size);
+  CAMLassert (merge_found || caml_fl_merge == Fl_head);
+  CAMLassert (size_found == caml_fl_cur_wsz);
 }
 
 #endif
@@ -123,11 +123,11 @@ static header_t *allocate_block (mlsize_t wh_sz, int flpi, value prev,
                                  value cur)
 {
   header_t h = Hd_bp (cur);
-                                             Assert (Whsize_hd (h) >= wh_sz);
+                                             CAMLassert (Whsize_hd (h) >= wh_sz);
   if (Wosize_hd (h) < wh_sz + 1){                        /* Cases 0 and 1. */
     caml_fl_cur_wsz -= Whsize_hd (h);
     Next (prev) = Next (cur);
-                  Assert (Is_in_heap (Next (prev)) || Next (prev) == Val_NULL);
+                  CAMLassert (Is_in_heap (Next (prev)) || Next (prev) == Val_NULL);
     if (caml_fl_merge == cur) caml_fl_merge = prev;
 #ifdef DEBUG
     fl_last = Val_NULL;
@@ -191,8 +191,8 @@ header_t *caml_fl_allocate (mlsize_t wo_sz)
   header_t *result;
   int i;
   mlsize_t sz, prevsz;
-                                  Assert (sizeof (char *) == sizeof (value));
-                                  Assert (wo_sz >= 1);
+                                  CAMLassert (sizeof (char *) == sizeof (value));
+                                  CAMLassert (wo_sz >= 1);
 #ifdef CAML_INSTR
   if (wo_sz < 10){
     ++instr_size[wo_sz];
@@ -205,11 +205,11 @@ header_t *caml_fl_allocate (mlsize_t wo_sz)
 
   switch (policy){
   case Policy_next_fit:
-                                  Assert (fl_prev != Val_NULL);
+                                  CAMLassert (fl_prev != Val_NULL);
     /* Search from [fl_prev] to the end of the list. */
     prev = fl_prev;
     cur = Next (prev);
-    while (cur != Val_NULL){                         Assert (Is_in_heap (cur));
+    while (cur != Val_NULL){                         CAMLassert (Is_in_heap (cur));
       if (Wosize_bp (cur) >= wo_sz){
         return allocate_block (Whsize_wosize (wo_sz), 0, prev, cur);
       }
@@ -299,10 +299,10 @@ header_t *caml_fl_allocate (mlsize_t wo_sz)
       prev = flp[flp_size - 1];
     }
     prevsz = Wosize_bp (Next (flp[FLP_MAX-1]));
-    Assert (prevsz < wo_sz);
+    CAMLassert (prevsz < wo_sz);
     cur = Next (prev);
     while (cur != Val_NULL){
-      Assert (Is_in_heap (cur));
+      CAMLassert (Is_in_heap (cur));
       sz = Wosize_bp (cur);
       if (sz < prevsz){
         beyond = cur;
@@ -317,7 +317,7 @@ header_t *caml_fl_allocate (mlsize_t wo_sz)
 
   update_flp: /* (i, sz) */
     /* The block at [i] was removed or reduced.  Update the table. */
-    Assert (0 <= i && i < flp_size + 1);
+    CAMLassert (0 <= i && i < flp_size + 1);
     if (i < flp_size){
       if (i > 0){
         prevsz = Wosize_bp (Next (flp[i-1]));
@@ -344,7 +344,7 @@ header_t *caml_fl_allocate (mlsize_t wo_sz)
             buf[j++] = prev;
             prevsz = sz;
             if (sz >= oldsz){
-              Assert (sz == oldsz);
+              CAMLassert (sz == oldsz);
               break;
             }
           }
@@ -380,7 +380,7 @@ header_t *caml_fl_allocate (mlsize_t wo_sz)
   break;
 
   default:
-    Assert (0);   /* unknown policy */
+    CAMLassert (0);   /* unknown policy */
     break;
   }
   return NULL;  /* NOT REACHED */
@@ -434,7 +434,7 @@ void caml_fl_reset (void)
     truncate_flp (Fl_head);
     break;
   default:
-    Assert (0);
+    CAMLassert (0);
     break;
   }
   caml_fl_cur_wsz = 0;
@@ -459,8 +459,8 @@ header_t *caml_fl_merge_block (value bp)
   cur = Next (prev);
   /* The sweep code makes sure that this is the right place to insert
      this block: */
-  Assert (prev < bp || prev == Fl_head);
-  Assert (cur > bp || cur == Val_NULL);
+  CAMLassert (prev < bp || prev == Fl_head);
+  CAMLassert (cur > bp || cur == Val_NULL);
 
   if (policy == Policy_first_fit) truncate_flp (prev);
 
@@ -505,7 +505,7 @@ header_t *caml_fl_merge_block (value bp)
 #ifdef DEBUG
     Hd_val (bp) = Debug_free_major;
 #endif
-    Assert (caml_fl_merge == prev);
+    CAMLassert (caml_fl_merge == prev);
   }else if (Wosize_hd (hd) != 0){
     Hd_val (bp) = Bluehd_hd (hd);
     Next (bp) = cur;
@@ -533,8 +533,8 @@ header_t *caml_fl_merge_block (value bp)
 */
 void caml_fl_add_blocks (value bp)
 {
-                                                   Assert (fl_last != Val_NULL);
-                                            Assert (Next (fl_last) == Val_NULL);
+                                                   CAMLassert (fl_last != Val_NULL);
+                                            CAMLassert (Next (fl_last) == Val_NULL);
   caml_fl_cur_wsz += Whsize_bp (bp);
 
   if (bp > fl_last){
@@ -551,12 +551,12 @@ void caml_fl_add_blocks (value bp)
     prev = Fl_head;
     cur = Next (prev);
     while (cur != Val_NULL && cur < bp){
-      Assert (prev < bp || prev == Fl_head);
+      CAMLassert (prev < bp || prev == Fl_head);
       /* XXX TODO: extend flp on the fly */
       prev = cur;
       cur = Next (prev);
-    }                                  Assert (prev < bp || prev == Fl_head);
-                                       Assert (cur > bp || cur == Val_NULL);
+    }                                  CAMLassert (prev < bp || prev == Fl_head);
+                                       CAMLassert (cur > bp || cur == Val_NULL);
     Next (Field (bp, 1)) = cur;
     Next (prev) = bp;
     /* When inserting blocks between [caml_fl_merge] and [caml_gc_sweep_hp],

--- a/byterun/gc_ctrl.c
+++ b/byterun/gc_ctrl.c
@@ -64,25 +64,25 @@ extern uintnat caml_allocation_policy;    /*        see freelist.c */
 /* Check that [v]'s header looks good.  [v] must be a block in the heap. */
 static void check_head (value v)
 {
-  Assert (Is_block (v));
-  Assert (Is_in_heap (v));
+  CAMLassert (Is_block (v));
+  CAMLassert (Is_in_heap (v));
 
-  Assert (Wosize_val (v) != 0);
-  Assert (Color_hd (Hd_val (v)) != Caml_blue);
-  Assert (Is_in_heap (v));
+  CAMLassert (Wosize_val (v) != 0);
+  CAMLassert (Color_hd (Hd_val (v)) != Caml_blue);
+  CAMLassert (Is_in_heap (v));
   if (Tag_val (v) == Infix_tag){
     int offset = Wsize_bsize (Infix_offset_val (v));
     value trueval = Val_op (&Field (v, -offset));
-    Assert (Tag_val (trueval) == Closure_tag);
-    Assert (Wosize_val (trueval) > offset);
-    Assert (Is_in_heap (&Field (trueval, Wosize_val (trueval) - 1)));
+    CAMLassert (Tag_val (trueval) == Closure_tag);
+    CAMLassert (Wosize_val (trueval) > offset);
+    CAMLassert (Is_in_heap (&Field (trueval, Wosize_val (trueval) - 1)));
   }else{
-    Assert (Is_in_heap (&Field (v, Wosize_val (v) - 1)));
+    CAMLassert (Is_in_heap (&Field (v, Wosize_val (v) - 1)));
   }
   if (Tag_val (v) ==  Double_tag){
-    Assert (Wosize_val (v) == Double_wosize);
+    CAMLassert (Wosize_val (v) == Double_wosize);
   }else if (Tag_val (v) == Double_array_tag){
-    Assert (Wosize_val (v) % Double_wosize == 0);
+    CAMLassert (Wosize_val (v) % Double_wosize == 0);
   }
 }
 
@@ -98,26 +98,26 @@ static void check_block (header_t *hp)
   case String_tag:
     break;
   case Double_tag:
-    Assert (Wosize_val (v) == Double_wosize);
+    CAMLassert (Wosize_val (v) == Double_wosize);
     break;
   case Double_array_tag:
-    Assert (Wosize_val (v) % Double_wosize == 0);
+    CAMLassert (Wosize_val (v) % Double_wosize == 0);
     break;
   case Custom_tag:
-    Assert (!Is_in_heap (Custom_ops_val (v)));
+    CAMLassert (!Is_in_heap (Custom_ops_val (v)));
     break;
 
   case Infix_tag:
-    Assert (0);
+    CAMLassert (0);
     break;
 
   default:
-    Assert (Tag_hp (hp) < No_scan_tag);
+    CAMLassert (Tag_hp (hp) < No_scan_tag);
     for (i = 0; i < Wosize_hp (hp); i++){
       f = Field (v, i);
       if (Is_block (f) && Is_in_heap (f)){
         check_head (f);
-        Assert (Color_val (f) != Caml_blue);
+        CAMLassert (Color_val (f) != Caml_blue);
       }
     }
   }
@@ -155,14 +155,14 @@ static value heap_stats (int returnstats)
     cur_hp = (header_t *) chunk;
     while (cur_hp < (header_t *) chunk_end){
       cur_hd = Hd_hp (cur_hp);
-      Assert (Next (cur_hp) <= (header_t *) chunk_end);
+      CAMLassert (Next (cur_hp) <= (header_t *) chunk_end);
       switch (Color_hd (cur_hd)){
       case Caml_white:
         if (Wosize_hd (cur_hd) == 0){
           ++ fragments;
-          Assert (prev_hp == NULL
-                  || Color_hp (prev_hp) != Caml_blue
-                  || cur_hp == (header_t *) caml_gc_sweep_hp);
+          CAMLassert (prev_hp == NULL
+                      || Color_hp (prev_hp) != Caml_blue
+                      || cur_hp == (header_t *) caml_gc_sweep_hp);
         }else{
           if (caml_gc_phase == Phase_sweep
               && cur_hp >= (header_t *) caml_gc_sweep_hp){
@@ -181,7 +181,7 @@ static value heap_stats (int returnstats)
         }
         break;
       case Caml_gray: case Caml_black:
-        Assert (Wosize_hd (cur_hd) > 0);
+        CAMLassert (Wosize_hd (cur_hd) > 0);
         ++ live_blocks;
         live_words += Whsize_hd (cur_hd);
 #ifdef DEBUG
@@ -189,21 +189,23 @@ static value heap_stats (int returnstats)
 #endif
         break;
       case Caml_blue:
-        Assert (Wosize_hd (cur_hd) > 0);
+        CAMLassert (Wosize_hd (cur_hd) > 0);
         ++ free_blocks;
         free_words += Whsize_hd (cur_hd);
         if (Whsize_hd (cur_hd) > largest_free){
           largest_free = Whsize_hd (cur_hd);
         }
         /* not true any more with big heap chunks
-        Assert (prev_hp == NULL
-                || (Color_hp (prev_hp) != Caml_blue && Wosize_hp (prev_hp) > 0)
-                || cur_hp == caml_gc_sweep_hp);
-        Assert (Next (cur_hp) == chunk_end
-                || (Color_hp (Next (cur_hp)) != Caml_blue
-                    && Wosize_hp (Next (cur_hp)) > 0)
-                || (Whsize_hd (cur_hd) + Wosize_hp (Next (cur_hp)) > Max_wosize)
-                || Next (cur_hp) == caml_gc_sweep_hp);
+        CAMLassert (prev_hp == NULL
+                    || (Color_hp (prev_hp) != Caml_blue
+                        && Wosize_hp (prev_hp) > 0)
+                    || cur_hp == caml_gc_sweep_hp);
+        CAMLassert (Next (cur_hp) == chunk_end
+                    || (Color_hp (Next (cur_hp)) != Caml_blue 
+                       && Wosize_hp (Next (cur_hp)) > 0)
+                    || (Whsize_hd (cur_hd) + Wosize_hp (Next (cur_hp))
+                       > Max_wosize)
+                    || Next (cur_hp) == caml_gc_sweep_hp);
         */
         break;
       }
@@ -211,7 +213,7 @@ static value heap_stats (int returnstats)
       prev_hp = cur_hp;
 #endif
       cur_hp = Next (cur_hp);
-    }                             Assert (cur_hp == (header_t *) chunk_end);
+    }                           CAMLassert (cur_hp == (header_t *) chunk_end);
     chunk = Chunk_next (chunk);
   }
 
@@ -219,8 +221,8 @@ static value heap_stats (int returnstats)
   caml_final_invariant_check();
 #endif
 
-  Assert (heap_chunks == caml_stat_heap_chunks);
-  Assert (live_words + free_words + fragments == caml_stat_heap_wsz);
+  CAMLassert (heap_chunks == caml_stat_heap_chunks);
+  CAMLassert (live_words + free_words + fragments == caml_stat_heap_wsz);
 
   if (returnstats){
     CAMLlocal1 (res);
@@ -270,7 +272,7 @@ CAMLprim value caml_gc_stat(value v)
 {
   value result;
   CAML_INSTR_SETUP (tmr, "");
-  Assert (v == Val_unit);
+  CAMLassert (v == Val_unit);
   result = heap_stats (1);
   CAML_INSTR_TIME (tmr, "explicit/gc_stat");
   return result;
@@ -464,7 +466,7 @@ CAMLprim value caml_gc_set(value v)
 CAMLprim value caml_gc_minor(value v)
 {
   CAML_INSTR_SETUP (tmr, "");
-  Assert (v == Val_unit);
+  CAMLassert (v == Val_unit);
   caml_request_minor_gc ();
   caml_gc_dispatch ();
   CAML_INSTR_TIME (tmr, "explicit/gc_minor");
@@ -489,7 +491,7 @@ static void test_and_compact (void)
 CAMLprim value caml_gc_major(value v)
 {
   CAML_INSTR_SETUP (tmr, "");
-  Assert (v == Val_unit);
+  CAMLassert (v == Val_unit);
   caml_gc_message (0x1, "Major GC cycle requested\n", 0);
   caml_empty_minor_heap ();
   caml_finish_major_cycle ();
@@ -502,7 +504,7 @@ CAMLprim value caml_gc_major(value v)
 CAMLprim value caml_gc_full_major(value v)
 {
   CAML_INSTR_SETUP (tmr, "");
-  Assert (v == Val_unit);
+  CAMLassert (v == Val_unit);
   caml_gc_message (0x1, "Full major GC cycle requested\n", 0);
   caml_empty_minor_heap ();
   caml_finish_major_cycle ();
@@ -518,7 +520,7 @@ CAMLprim value caml_gc_full_major(value v)
 CAMLprim value caml_gc_major_slice (value v)
 {
   CAML_INSTR_SETUP (tmr, "");
-  Assert (Is_long (v));
+  CAMLassert (Is_long (v));
   caml_major_collection_slice (Long_val (v));
   CAML_INSTR_TIME (tmr, "explicit/gc_major_slice");
   return Val_long (0);
@@ -527,7 +529,7 @@ CAMLprim value caml_gc_major_slice (value v)
 CAMLprim value caml_gc_compaction(value v)
 {
   CAML_INSTR_SETUP (tmr, "");
-  Assert (v == Val_unit);
+  CAMLassert (v == Val_unit);
   caml_gc_message (0x10, "Heap compaction requested\n", 0);
   caml_empty_minor_heap ();
   caml_finish_major_cycle ();

--- a/byterun/globroots.c
+++ b/byterun/globroots.c
@@ -61,7 +61,7 @@ static int random_level(void)
      "less random" than the most significant bits with a modulus of 2^m,
      so consume most significant bits first */
   while ((r & 0xC0000000U) == 0xC0000000U) { level++; r = r << 2; }
-  Assert(level < NUM_LEVELS);
+  CAMLassert(level < NUM_LEVELS);
   return level;
 }
 
@@ -74,7 +74,7 @@ static void caml_insert_global_root(struct global_root_list * rootlist,
   struct global_root * e, * f;
   int i, new_level;
 
-  Assert(0 <= rootlist->level && rootlist->level < NUM_LEVELS);
+  CAMLassert(0 <= rootlist->level && rootlist->level < NUM_LEVELS);
 
   /* Init "cursor" to list head */
   e = (struct global_root *) rootlist;
@@ -115,7 +115,7 @@ static void caml_delete_global_root(struct global_root_list * rootlist,
   struct global_root * e, * f;
   int i;
 
-  Assert(0 <= rootlist->level && rootlist->level < NUM_LEVELS);
+  CAMLassert(0 <= rootlist->level && rootlist->level < NUM_LEVELS);
 
   /* Init "cursor" to list head */
   e = (struct global_root *) rootlist;
@@ -163,7 +163,7 @@ static void caml_empty_global_roots(struct global_root_list * rootlist)
   struct global_root * gr, * next;
   int i;
 
-  Assert(0 <= rootlist->level && rootlist->level < NUM_LEVELS);
+  CAMLassert(0 <= rootlist->level && rootlist->level < NUM_LEVELS);
 
   for (gr = rootlist->forward[0]; gr != NULL; /**/) {
     next = gr->forward[0];
@@ -187,7 +187,7 @@ struct global_root_list caml_global_roots_old = { NULL, { NULL, }, 0 };
 
 CAMLexport void caml_register_global_root(value *r)
 {
-  Assert (((intnat) r & 3) == 0);  /* compact.c demands this (for now) */
+  CAMLassert (((intnat) r & 3) == 0);  /* compact.c demands this (for now) */
   caml_insert_global_root(&caml_global_roots, r);
 }
 
@@ -203,7 +203,7 @@ CAMLexport void caml_remove_global_root(value *r)
 CAMLexport void caml_register_generational_global_root(value *r)
 {
   value v = *r;
-  Assert (((intnat) r & 3) == 0);  /* compact.c demands this (for now) */
+  CAMLassert (((intnat) r & 3) == 0);  /* compact.c demands this (for now) */
   if (Is_block(v)) {
     if (Is_young(v))
       caml_insert_global_root(&caml_global_roots_young, r);

--- a/byterun/hash.c
+++ b/byterun/hash.c
@@ -320,7 +320,7 @@ static void hash_aux(value obj)
   /* Pointers into the heap are well-structured blocks. So are atoms.
      We can inspect the block contents. */
 
-  Assert (Is_block (obj));
+  CAMLassert (Is_block (obj));
   if (Is_in_value_area(obj)) {
     tag = Tag_val(obj);
     switch (tag) {

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -140,7 +140,7 @@ static void intern_init(void * src, void * input)
   /* This is asserted at the beginning of demarshaling primitives.
      If it fails, it probably means that an exception was raised
      without calling intern_cleanup() during the previous demarshaling. */
-  Assert (intern_input == NULL && intern_obj_table == NULL \
+  CAMLassert (intern_input == NULL && intern_obj_table == NULL \
      && intern_extra_block == NULL && intern_block == 0);
   intern_src = src;
   intern_input = input;
@@ -369,7 +369,7 @@ static void intern_rec(value *dest)
         intern_dest += 1 + size;
         /* For objects, we need to freshen the oid */
         if (tag == Object_tag) {
-          Assert(size >= 2);
+          CAMLassert(size >= 2);
           /* Request to read rest of the elements of the block */
           ReadItems(&Field(v, 2), size - 2);
           /* Request freshing OID */
@@ -424,9 +424,9 @@ static void intern_rec(value *dest)
       case CODE_SHARED8:
         ofs = read8u();
       read_shared:
-        Assert (ofs > 0);
-        Assert (ofs <= obj_counter);
-        Assert (intern_obj_table != NULL);
+        CAMLassert (ofs > 0);
+        CAMLassert (ofs <= obj_counter);
+        CAMLassert (intern_obj_table != NULL);
         v = intern_obj_table[obj_counter - ofs];
         break;
       case CODE_SHARED16:
@@ -552,7 +552,7 @@ static void intern_rec(value *dest)
   *dest = v;
   break;
   default:
-    Assert(0);
+    CAMLassert(0);
   }
   }
   /* We are done. Cleanup the stack and leave the function */
@@ -565,7 +565,7 @@ static void intern_alloc(mlsize_t whsize, mlsize_t num_objects,
   mlsize_t wosize;
 
   if (whsize == 0) {
-    Assert (intern_extra_block == NULL && intern_block == 0
+    CAMLassert (intern_extra_block == NULL && intern_block == 0
          && intern_obj_table == NULL);
     return;
   }
@@ -582,7 +582,7 @@ static void intern_alloc(mlsize_t whsize, mlsize_t num_objects,
     intern_color =
       outside_heap ? Caml_black : caml_allocation_color(intern_extra_block);
     intern_dest = (header_t *) intern_extra_block;
-    Assert (intern_block == 0);
+    CAMLassert (intern_block == 0);
   } else {
     /* this is a specialised version of caml_alloc from alloc.c */
     if (wosize == 0){
@@ -592,7 +592,7 @@ static void intern_alloc(mlsize_t whsize, mlsize_t num_objects,
     }else{
       intern_block = caml_alloc_shr_no_raise (wosize, String_tag);
       /* do not do the urgent_gc check here because it might darken
-         intern_block into gray and break the Assert 3 lines down */
+         intern_block into gray and break the intern_color assertion below */
       if (intern_block == 0) {
         intern_cleanup();
         caml_raise_out_of_memory();
@@ -600,9 +600,9 @@ static void intern_alloc(mlsize_t whsize, mlsize_t num_objects,
     }
     intern_header = Hd_val(intern_block);
     intern_color = Color_hd(intern_header);
-    Assert (intern_color == Caml_white || intern_color == Caml_black);
+    CAMLassert (intern_color == Caml_white || intern_color == Caml_black);
     intern_dest = (header_t *) Hp_val(intern_block);
-    Assert (intern_extra_block == NULL);
+    CAMLassert (intern_extra_block == NULL);
   }
   obj_counter = 0;
   if (num_objects > 0) {
@@ -612,7 +612,7 @@ static void intern_alloc(mlsize_t whsize, mlsize_t num_objects,
       caml_raise_out_of_memory();
     }
   } else
-    Assert(intern_obj_table == NULL);
+    CAMLassert(intern_obj_table == NULL);
 }
 
 static void intern_add_to_heap(mlsize_t whsize)
@@ -623,8 +623,8 @@ static void intern_add_to_heap(mlsize_t whsize)
     asize_t request = Chunk_size (intern_extra_block);
     header_t * end_extra_block =
       (header_t *) intern_extra_block + Wsize_bsize(request);
-    Assert(intern_block == 0);
-    Assert(intern_dest <= end_extra_block);
+    CAMLassert(intern_block == 0);
+    CAMLassert(intern_dest <= end_extra_block);
     if (intern_dest < end_extra_block){
       caml_make_free_blocks ((value *) intern_dest,
                              end_extra_block - intern_dest, 0, Caml_white);

--- a/byterun/interp.c
+++ b/byterun/interp.c
@@ -267,8 +267,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
 #ifdef DEBUG
  next_instr:
   if (caml_icount-- == 0) caml_stop_here ();
-  Assert(sp >= caml_stack_low);
-  Assert(sp <= caml_stack_high);
+  CAMLassert(sp >= caml_stack_low);
+  CAMLassert(sp <= caml_stack_high);
 #endif
   goto *(void *)(jumptbl_base + *pc++); /* Jump to the first instruction */
 #else
@@ -285,8 +285,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
       caml_trace_accu_sp_file(accu,sp,prog,prog_size,stdout);
       fflush(stdout);
     };
-    Assert(sp >= caml_stack_low);
-    Assert(sp <= caml_stack_high);
+    CAMLassert(sp >= caml_stack_low);
+    CAMLassert(sp <= caml_stack_high);
 #endif
     curr_instr = *pc++;
 
@@ -801,11 +801,11 @@ value caml_interprete(code_t prog, asize_t prog_size)
       uint32_t sizes = *pc++;
       if (Is_block(accu)) {
         intnat index = Tag_val(accu);
-        Assert ((uintnat) index < (sizes >> 16));
+        CAMLassert ((uintnat) index < (sizes >> 16));
         pc += pc[(sizes & 0xFFFF) + index];
       } else {
         intnat index = Long_val(accu);
-        Assert ((uintnat) index < (sizes & 0xFFFF)) ;
+        CAMLassert ((uintnat) index < (sizes & 0xFFFF)) ;
         pc += pc[index];
       }
       Next;
@@ -1155,8 +1155,8 @@ void caml_prepare_bytecode(code_t prog, asize_t prog_size) {
   /* other implementations of the interpreter (such as an hypothetical
      JIT translator) might want to do something with a bytecode before
      running it */
-  Assert(prog);
-  Assert(prog_size>0);
+  CAMLassert(prog);
+  CAMLassert(prog_size>0);
   /* actually, the threading of the bytecode might be done here */
 }
 
@@ -1164,6 +1164,6 @@ void caml_release_bytecode(code_t prog, asize_t prog_size) {
   /* other implementations of the interpreter (such as an hypothetical
      JIT translator) might want to know when a bytecode is removed */
   /* check that we have a program */
-  Assert(prog);
-  Assert(prog_size>0);
+  CAMLassert(prog);
+  CAMLassert(prog_size>0);
 }

--- a/byterun/io.c
+++ b/byterun/io.c
@@ -100,7 +100,7 @@ CAMLexport struct channel * caml_open_descriptor_out(int fd)
 static void unlink_channel(struct channel *channel)
 {
   if (channel->prev == NULL) {
-    Assert (channel == caml_all_opened_channels);
+    CAMLassert (channel == caml_all_opened_channels);
     caml_all_opened_channels = caml_all_opened_channels->next;
     if (caml_all_opened_channels != NULL)
       caml_all_opened_channels->prev = NULL;

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -123,7 +123,7 @@ static void realloc_gray_vals (void)
 {
   value *new;
 
-  Assert (gray_vals_cur == gray_vals_end);
+  CAMLassert (gray_vals_cur == gray_vals_end);
   if (gray_vals_size < caml_stat_heap_wsz / 32){
     caml_gc_message (0x08, "Growing gray_vals to %"
                            ARCH_INTNAT_PRINTF_FORMAT "uk bytes\n",
@@ -185,8 +185,8 @@ void caml_darken (value v, value *p /* not used */)
 
 static void start_cycle (void)
 {
-  Assert (caml_gc_phase == Phase_idle);
-  Assert (gray_vals_cur == gray_vals);
+  CAMLassert (caml_gc_phase == Phase_idle);
+  CAMLassert (gray_vals_cur == gray_vals);
   caml_gc_message (0x01, "Starting new major GC cycle\n", 0);
   caml_darken_all_roots_start ();
   caml_gc_phase = Phase_mark;
@@ -303,7 +303,7 @@ static value* mark_ephe_aux (value *gray_vals_ptr, intnat *work,
 
   v = *ephes_to_check;
   hd = Hd_val(v);
-  Assert(Tag_val (v) == Abstract_tag);
+  CAMLassert(Tag_val (v) == Abstract_tag);
   data = Field(v,CAML_EPHE_DATA_OFFSET);
   if ( data != caml_ephe_none &&
        Is_block (data) && Is_in_heap (data) && Is_white_val (data)){
@@ -395,7 +395,7 @@ static void mark_slice (intnat work)
     }
     if (v != 0){
       hd = Hd_val(v);
-      Assert (Is_gray_hd (hd));
+      CAMLassert (Is_gray_hd (hd));
       size = Wosize_hd (hd);
       end = start + work;
       if (Tag_hd (hd) < No_scan_tag){
@@ -440,7 +440,7 @@ static void mark_slice (intnat work)
         }
       }else{
         if (Is_gray_val (Val_hp (markhp))){
-          Assert (gray_vals_ptr == gray_vals);
+          CAMLassert (gray_vals_ptr == gray_vals);
           CAMLassert (v == 0 && start == 0);
           v = Val_hp (markhp);
         }
@@ -497,7 +497,7 @@ static void mark_slice (intnat work)
           work = 0;
       }
         break;
-      default: Assert (0);
+      default: CAMLassert (0);
       }
     }
   }
@@ -560,11 +560,11 @@ static void sweep_slice (intnat work)
         caml_fl_merge = Bp_hp (hp);
         break;
       default:          /* gray or black */
-        Assert (Color_hd (hd) == Caml_black);
+        CAMLassert (Color_hd (hd) == Caml_black);
         Hd_hp (hp) = Whitehd_hd (hd);
         break;
       }
-      Assert (caml_gc_sweep_hp <= limit);
+      CAMLassert (caml_gc_sweep_hp <= limit);
     }else{
       chunk = Chunk_next (chunk);
       if (chunk == NULL){
@@ -774,7 +774,7 @@ void caml_major_collection_slice (intnat howmuch)
     clean_slice (computed_work);
     caml_gc_message (0x02, "%%", 0);
   }else{
-    Assert (caml_gc_phase == Phase_sweep);
+    CAMLassert (caml_gc_phase == Phase_sweep);
     CAML_INSTR_INT ("major/work/sweep#", computed_work);
     sweep_slice (computed_work);
     CAML_INSTR_TIME (tmr, "major/sweep");
@@ -818,9 +818,9 @@ void caml_finish_major_cycle (void)
   if (caml_gc_phase == Phase_idle) start_cycle ();
   while (caml_gc_phase == Phase_mark) mark_slice (LONG_MAX);
   while (caml_gc_phase == Phase_clean) clean_slice (LONG_MAX);
-  Assert (caml_gc_phase == Phase_sweep);
+  CAMLassert (caml_gc_phase == Phase_sweep);
   while (caml_gc_phase == Phase_sweep) sweep_slice (LONG_MAX);
-  Assert (caml_gc_phase == Phase_idle);
+  CAMLassert (caml_gc_phase == Phase_idle);
   caml_stat_major_words += caml_allocated_words;
   caml_allocated_words = 0;
 }
@@ -856,7 +856,7 @@ void caml_init_major_heap (asize_t heap_size)
 
   caml_stat_heap_wsz = caml_clip_heap_chunk_wsz (Wsize_bsize (heap_size));
   caml_stat_top_heap_wsz = caml_stat_heap_wsz;
-  Assert (Bsize_wsize (caml_stat_heap_wsz) % Page_size == 0);
+  CAMLassert (Bsize_wsize (caml_stat_heap_wsz) % Page_size == 0);
   caml_heap_start =
     (char *) caml_alloc_for_heap (Bsize_wsize (caml_stat_heap_wsz));
   if (caml_heap_start == NULL)

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -157,7 +157,7 @@ static int caml_page_table_modify(uintnat page, int toclear, int toset)
 {
   uintnat h;
 
-  Assert ((page & ~Page_mask) == 0);
+  CAMLassert ((page & ~Page_mask) == 0);
 
   /* Resize to keep load factor below 1/2 */
   if (caml_page_table.occupancy * 2 >= caml_page_table.size) {
@@ -373,7 +373,7 @@ static value *expand_heap (mlsize_t request)
   value *mem, *hp, *prev;
   asize_t over_request, malloc_request, remain;
 
-  Assert (request <= Max_wosize);
+  CAMLassert (request <= Max_wosize);
   over_request = request + request / 100 * caml_percent_free;
   malloc_request = caml_clip_heap_chunk_wsz (over_request);
   mem = (value *) caml_alloc_for_heap (Bsize_wsize (malloc_request));
@@ -407,7 +407,7 @@ static value *expand_heap (mlsize_t request)
       Hd_hp (hp) = Make_header_allocated_here (0, 0, Caml_white);
     }
   }
-  Assert (Wosize_hp (mem) >= request);
+  CAMLassert (Wosize_hp (mem) >= request);
   if (caml_add_to_heap ((char *) mem) != 0){
     caml_free_for_heap ((char *) mem);
     return NULL;
@@ -464,7 +464,7 @@ color_t caml_allocation_color (void *hp)
       || (caml_gc_phase == Phase_sweep && (addr)hp >= (addr)caml_gc_sweep_hp)){
     return Caml_black;
   }else{
-    Assert (caml_gc_phase == Phase_idle
+    CAMLassert (caml_gc_phase == Phase_idle
             || (caml_gc_phase == Phase_sweep
                 && (addr)hp < (addr)caml_gc_sweep_hp));
     return Caml_white;
@@ -498,19 +498,19 @@ static inline value caml_alloc_shr_aux (mlsize_t wosize, tag_t tag,
     hp = caml_fl_allocate (wosize);
   }
 
-  Assert (Is_in_heap (Val_hp (hp)));
+  CAMLassert (Is_in_heap (Val_hp (hp)));
 
   /* Inline expansion of caml_allocation_color. */
   if (caml_gc_phase == Phase_mark || caml_gc_phase == Phase_clean
       || (caml_gc_phase == Phase_sweep && (addr)hp >= (addr)caml_gc_sweep_hp)){
     Hd_hp (hp) = Make_header_with_profinfo (wosize, tag, Caml_black, profinfo);
   }else{
-    Assert (caml_gc_phase == Phase_idle
+    CAMLassert (caml_gc_phase == Phase_idle
             || (caml_gc_phase == Phase_sweep
                 && (addr)hp < (addr)caml_gc_sweep_hp));
     Hd_hp (hp) = Make_header_with_profinfo (wosize, tag, Caml_white, profinfo);
   }
-  Assert (Hd_hp (hp)
+  CAMLassert (Hd_hp (hp)
     == Make_header_with_profinfo (wosize, tag, caml_allocation_color (hp),
                                   profinfo));
   caml_allocated_words += Whsize_wosize (wosize);

--- a/byterun/meta.c
+++ b/byterun/meta.c
@@ -90,7 +90,7 @@ CAMLprim value caml_static_release_bytecode(value prog, value len)
 
   if (!cf) {
       /* [cf] Not matched with a caml_reify_bytecode call; impossible. */
-      Assert (0);
+      CAMLassert (0);
   } else {
       caml_ext_table_remove(&caml_code_fragments_table, cf);
   }

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -133,9 +133,9 @@ void caml_set_minor_heap_size (asize_t bsz)
   char *new_heap;
   void *new_heap_base;
 
-  Assert (bsz >= Bsize_wsize(Minor_heap_min));
-  Assert (bsz <= Bsize_wsize(Minor_heap_max));
-  Assert (bsz % sizeof (value) == 0);
+  CAMLassert (bsz >= Bsize_wsize(Minor_heap_min));
+  CAMLassert (bsz <= Bsize_wsize(Minor_heap_max));
+  CAMLassert (bsz % sizeof (value) == 0);
   if (caml_young_ptr != caml_young_alloc_end){
     CAML_INSTR_INT ("force_minor/set_minor_heap_size@", 1);
     caml_requested_minor_gc = 0;
@@ -183,7 +183,7 @@ void caml_oldify_one (value v, value *p)
 
  tail_call:
   if (Is_block (v) && Is_young (v)){
-    Assert ((value *) Hp_val (v) >= caml_young_ptr);
+    CAMLassert ((value *) Hp_val (v) >= caml_young_ptr);
     hd = Hd_val (v);
     if (hd == 0){         /* If already forwarded */
       *p = Field (v, 0);  /*  then forward pointer is first field. */
@@ -203,7 +203,7 @@ void caml_oldify_one (value v, value *p)
           Field (result, 1) = oldify_todo_list;    /* Add this block */
           oldify_todo_list = v;                    /*  to the "to do" list. */
         }else{
-          Assert (sz == 1);
+          CAMLassert (sz == 1);
           p = &Field (result, 0);
           v = field0;
           goto tail_call;
@@ -224,7 +224,7 @@ void caml_oldify_one (value v, value *p)
         tag_t ft = 0;
         int vv = 1;
 
-        Assert (tag == Forward_tag);
+        CAMLassert (tag == Forward_tag);
         if (Is_block (f)){
           if (Is_young (f)){
             vv = 1;
@@ -238,7 +238,7 @@ void caml_oldify_one (value v, value *p)
         }
         if (!vv || ft == Forward_tag || ft == Lazy_tag || ft == Double_tag){
           /* Do not short-circuit the pointer.  Copy as a normal block. */
-          Assert (Wosize_hd (hd) == 1);
+          CAMLassert (Wosize_hd (hd) == 1);
           result = caml_alloc_shr_preserving_profinfo (1, Forward_tag, hd);
           *p = result;
           Hd_val (v) = 0;             /* Set (GC) forward flag */
@@ -285,7 +285,7 @@ void caml_oldify_mopup (void)
 
   while (oldify_todo_list != 0){
     v = oldify_todo_list;                /* Get the head. */
-    Assert (Hd_val (v) == 0);            /* It must be forwarded. */
+    CAMLassert (Hd_val (v) == 0);            /* It must be forwarded. */
     new_v = Field (v, 0);                /* Follow forward pointer. */
     oldify_todo_list = Field (new_v, 1); /* Remove from list. */
 
@@ -360,7 +360,7 @@ void caml_empty_minor_heap (void)
           if (Hd_val (*key) == 0){ /* Value copied to major heap */
             *key = Field (*key, 0);
           }else{ /* Value not copied so it's dead */
-            Assert(!ephe_check_alive_data(re));
+            CAMLassert(!ephe_check_alive_data(re));
             *key = caml_ephe_none;
             Field(re->ephe,1) = caml_ephe_none;
           }
@@ -488,9 +488,9 @@ static void realloc_generic_table
 (struct generic_table *tbl, asize_t element_size,
  char * msg_intr_int, char *msg_threshold, char *msg_growing, char *msg_error)
 {
-                                            Assert (tbl->ptr == tbl->limit);
-                                            Assert (tbl->limit <= tbl->end);
-                                      Assert (tbl->limit >= tbl->threshold);
+                                            CAMLassert (tbl->ptr == tbl->limit);
+                                            CAMLassert (tbl->limit <= tbl->end);
+                                      CAMLassert (tbl->limit >= tbl->threshold);
 
   if (tbl->base == NULL){
     alloc_generic_table (tbl, caml_minor_heap_wsz / 8, 256,

--- a/byterun/misc.c
+++ b/byterun/misc.c
@@ -85,7 +85,7 @@ char *caml_aligned_malloc (asize_t size, int modulo, void **block)
 {
   char *raw_mem;
   uintnat aligned_mem;
-                                                  Assert (modulo < Page_size);
+                                                  CAMLassert (modulo < Page_size);
   raw_mem = (char *) malloc (size + Page_size);
   if (raw_mem == NULL) return NULL;
   *block = raw_mem;

--- a/byterun/parsing.c
+++ b/byterun/parsing.c
@@ -288,7 +288,7 @@ CAMLprim value caml_parse_engine(struct parser_tables *tables,
     goto loop;
 
   default:                      /* Should not happen */
-    Assert(0);
+    CAMLassert(0);
     return RAISE_PARSE_ERROR;   /* Keeps gcc -Wall happy */
   }
 

--- a/byterun/signals.c
+++ b/byterun/signals.c
@@ -85,13 +85,13 @@ static intnat volatile caml_async_signal_mode = 0;
 
 static void caml_enter_blocking_section_default(void)
 {
-  Assert (caml_async_signal_mode == 0);
+  CAMLassert (caml_async_signal_mode == 0);
   caml_async_signal_mode = 1;
 }
 
 static void caml_leave_blocking_section_default(void)
 {
-  Assert (caml_async_signal_mode == 1);
+  CAMLassert (caml_async_signal_mode == 1);
   caml_async_signal_mode = 0;
 }
 

--- a/byterun/spacetime.c
+++ b/byterun/spacetime.c
@@ -12,7 +12,6 @@
 /*                                                                        */
 /**************************************************************************/
 
-#include <assert.h>
 #include "caml/fail.h"
 #include "caml/mlvalues.h"
 
@@ -21,7 +20,6 @@ int caml_ensure_spacetime_dot_o_is_included = 42;
 CAMLprim value caml_spacetime_only_works_for_native_code(value foo, ...)
 {
   caml_failwith("Spacetime profiling only works for native code");
-  assert(0);  /* unreachable */
 }
 
 uintnat caml_spacetime_my_profinfo (void)

--- a/byterun/stacks.c
+++ b/byterun/stacks.c
@@ -53,7 +53,7 @@ void caml_realloc_stack(asize_t required_space)
   value * new_low, * new_high, * new_sp;
   value * p;
 
-  Assert(caml_extern_sp >= caml_stack_low);
+  CAMLassert(caml_extern_sp >= caml_stack_low);
   size = caml_stack_high - caml_stack_low;
   do {
     if (size >= caml_max_stack_size) caml_raise_stack_overflow();

--- a/byterun/str.c
+++ b/byterun/str.c
@@ -32,7 +32,7 @@ CAMLexport mlsize_t caml_string_length(value s)
 {
   mlsize_t temp;
   temp = Bosize_val(s) - 1;
-  Assert (Byte (s, temp - Byte (s, temp)) == 0);
+  CAMLassert (Byte (s, temp - Byte (s, temp)) == 0);
   return temp - Byte (s, temp);
 }
 
@@ -41,7 +41,7 @@ CAMLprim value caml_ml_string_length(value s)
 {
   mlsize_t temp;
   temp = Bosize_val(s) - 1;
-  Assert (Byte (s, temp - Byte (s, temp)) == 0);
+  CAMLassert (Byte (s, temp - Byte (s, temp)) == 0);
   return Val_long(temp - Byte (s, temp));
 }
 

--- a/byterun/terminfo.c
+++ b/byterun/terminfo.c
@@ -64,7 +64,7 @@ CAMLprim value caml_terminfo_setup (value vchan)
     standout = tgetstr ("so", &area_p);
     standend = tgetstr ("se", &area_p);
   }
-  Assert (area_p <= area + 1024);
+  CAMLassert (area_p <= area + 1024);
   if (num_lines == -1 || up == NULL || down == NULL
       || standout == NULL || standend == NULL){
     return Bad_term;

--- a/byterun/weak.c
+++ b/byterun/weak.c
@@ -36,23 +36,27 @@ value caml_ephe_none = (value) &ephe_dummy;
     Outside minor and major heap, x must be black.
 */
 static inline int Is_Dead_during_clean(value x){
-  Assert (x != caml_ephe_none); Assert (caml_gc_phase == Phase_clean);
+  CAMLassert (x != caml_ephe_none);
+  CAMLassert (caml_gc_phase == Phase_clean);
   return Is_block (x) && !Is_young (x) && Is_white_val(x);
 }
 /** The minor heap doesn't have to be marked, outside they should
     already be black
 */
 static inline int Must_be_Marked_during_mark(value x){
-  Assert (x != caml_ephe_none); Assert (caml_gc_phase == Phase_mark);
+  CAMLassert (x != caml_ephe_none);
+  CAMLassert (caml_gc_phase == Phase_mark);
   return Is_block (x) && !Is_young (x);
 }
 #else
 static inline int Is_Dead_during_clean(value x){
-  Assert (x != caml_ephe_none); Assert (caml_gc_phase == Phase_clean);
+  CAMLassert (x != caml_ephe_none);
+  CAMLassert (caml_gc_phase == Phase_clean);
   return Is_block (x) && Is_in_heap (x) && Is_white_val(x);
 }
 static inline int Must_be_Marked_during_mark(value x){
-  Assert (x != caml_ephe_none); Assert (caml_gc_phase == Phase_mark);
+  CAMLassert (x != caml_ephe_none); 
+  CAMLassert (caml_gc_phase == Phase_mark);
   return Is_block (x) && Is_in_heap (x);
 }
 #endif
@@ -115,7 +119,7 @@ CAMLprim value caml_weak_create (value len)
    that is going to disappear is dead and so should trigger a cleaning
  */
 static void do_check_key_clean(value ar, mlsize_t offset){
-                                   Assert ( offset >= 2);
+                                   CAMLassert ( offset >= 2);
   if (caml_gc_phase == Phase_clean){
     value elt = Field (ar, offset);
     if (elt != caml_ephe_none && Is_Dead_during_clean(elt)){
@@ -158,7 +162,7 @@ static void do_set (value ar, mlsize_t offset, value v)
 CAMLprim value caml_ephe_set_key (value ar, value n, value el)
 {
   mlsize_t offset = Long_val (n) + 2;
-                                                   Assert (Is_in_heap (ar));
+                                                   CAMLassert (Is_in_heap (ar));
   if (offset < 2 || offset >= Wosize_val (ar)){
     caml_invalid_argument ("Weak.set");
   }
@@ -170,7 +174,7 @@ CAMLprim value caml_ephe_set_key (value ar, value n, value el)
 CAMLprim value caml_ephe_unset_key (value ar, value n)
 {
   mlsize_t offset = Long_val (n) + 2;
-                                                   Assert (Is_in_heap (ar));
+                                                   CAMLassert (Is_in_heap (ar));
   if (offset < 2 || offset >= Wosize_val (ar)){
     caml_invalid_argument ("Weak.set");
   }
@@ -182,13 +186,13 @@ CAMLprim value caml_ephe_unset_key (value ar, value n)
 value caml_ephe_set_key_option (value ar, value n, value el)
 {
   mlsize_t offset = Long_val (n) + 2;
-                                                   Assert (Is_in_heap (ar));
+                                                   CAMLassert (Is_in_heap (ar));
   if (offset < 2 || offset >= Wosize_val (ar)){
     caml_invalid_argument ("Weak.set");
   }
   do_check_key_clean(ar,offset);
   if (el != None_val && Is_block (el)){
-                                              Assert (Wosize_val (el) == 1);
+                                              CAMLassert (Wosize_val (el) == 1);
     do_set (ar, offset, Field (el, 0));
   }else{
     Field (ar, offset) = caml_ephe_none;
@@ -202,7 +206,7 @@ CAMLprim value caml_weak_set (value ar, value n, value el){
 
 CAMLprim value caml_ephe_set_data (value ar, value el)
 {
-                                                   Assert (Is_in_heap (ar));
+                                                   CAMLassert (Is_in_heap (ar));
   if (caml_gc_phase == Phase_clean){
     /* During this phase since we don't know which ephemeron have been
        cleaned we always need to check it. */
@@ -214,7 +218,7 @@ CAMLprim value caml_ephe_set_data (value ar, value el)
 
 CAMLprim value caml_ephe_unset_data (value ar)
 {
-                                                   Assert (Is_in_heap (ar));
+                                                   CAMLassert (Is_in_heap (ar));
   Field (ar, CAML_EPHE_DATA_OFFSET) = caml_ephe_none;
   return Val_unit;
 }
@@ -224,7 +228,7 @@ CAMLprim value caml_ephe_get_key (value ar, value n)
   CAMLparam2 (ar, n);
   mlsize_t offset = Long_val (n) + 2;
   CAMLlocal2 (res, elt);
-                                                   Assert (Is_in_heap (ar));
+                                                   CAMLassert (Is_in_heap (ar));
   if (offset < 2 || offset >= Wosize_val (ar)){
     caml_invalid_argument ("Weak.get_key");
   }
@@ -250,7 +254,7 @@ CAMLprim value caml_ephe_get_data (value ar)
   CAMLparam1 (ar);
   mlsize_t offset = 1;
   CAMLlocal2 (res, elt);
-                                                   Assert (Is_in_heap (ar));
+                                                   CAMLassert (Is_in_heap (ar));
   elt = Field (ar, offset);
   if(caml_gc_phase == Phase_clean) caml_ephe_clean(ar);
   if (elt == caml_ephe_none){
@@ -271,7 +275,7 @@ CAMLprim value caml_ephe_get_key_copy (value ar, value n)
   mlsize_t offset = Long_val (n) + 2;
   CAMLlocal2 (res, elt);
   value v;  /* Caution: this is NOT a local root. */
-                                                   Assert (Is_in_heap (ar));
+                                                   CAMLassert (Is_in_heap (ar));
   if (offset < 1 || offset >= Wosize_val (ar)){
     caml_invalid_argument ("Weak.get_copy");
   }
@@ -318,7 +322,7 @@ CAMLprim value caml_ephe_get_data_copy (value ar)
   mlsize_t offset = 1;
   CAMLlocal2 (res, elt);
   value v;  /* Caution: this is NOT a local root. */
-                                                   Assert (Is_in_heap (ar));
+                                                   CAMLassert (Is_in_heap (ar));
 
   v = Field (ar, offset);
   if (caml_gc_phase == Phase_clean) caml_ephe_clean(ar);
@@ -357,7 +361,7 @@ CAMLprim value caml_ephe_get_data_copy (value ar)
 CAMLprim value caml_ephe_check_key (value ar, value n)
 {
   mlsize_t offset = Long_val (n) + 2;
-                                                   Assert (Is_in_heap (ar));
+                                                   CAMLassert (Is_in_heap (ar));
   if (offset < 2 || offset >= Wosize_val (ar)){
     caml_invalid_argument ("Weak.check");
   }
@@ -382,8 +386,8 @@ CAMLprim value caml_ephe_blit_key (value ars, value ofs,
   mlsize_t offset_d = Long_val (ofd) + 2;
   mlsize_t length = Long_val (len);
   long i;
-                                                   Assert (Is_in_heap (ars));
-                                                   Assert (Is_in_heap (ard));
+                                                   CAMLassert (Is_in_heap (ars));
+                                                   CAMLassert (Is_in_heap (ard));
   if (offset_s < 1 || offset_s + length > Wosize_val (ars)){
     caml_invalid_argument ("Weak.blit");
   }

--- a/otherlibs/bigarray/bigarray_stubs.c
+++ b/otherlibs/bigarray/bigarray_stubs.c
@@ -105,8 +105,8 @@ caml_ba_alloc(int flags, int num_dims, void * data, intnat * dim)
   struct caml_ba_array * b;
   intnat dimcopy[CAML_BA_MAX_NUM_DIMS];
 
-  Assert(num_dims >= 0 && num_dims <= CAML_BA_MAX_NUM_DIMS);
-  Assert((flags & CAML_BA_KIND_MASK) <= CAML_BA_CHAR);
+  CAMLassert(num_dims >= 0 && num_dims <= CAML_BA_MAX_NUM_DIMS);
+  CAMLassert((flags & CAML_BA_KIND_MASK) <= CAML_BA_CHAR);
   for (i = 0; i < num_dims; i++) dimcopy[i] = dim[i];
   size = 0;
   if (data == NULL) {
@@ -144,7 +144,7 @@ CAMLexport value caml_ba_alloc_dims(int flags, int num_dims, void * data, ...)
   int i;
   value res;
 
-  Assert(num_dims <= CAML_BA_MAX_NUM_DIMS);
+  CAMLassert(num_dims <= CAML_BA_MAX_NUM_DIMS);
   va_start(ap, data);
   for (i = 0; i < num_dims; i++) dim[i] = va_arg(ap, intnat);
   va_end(ap);
@@ -230,7 +230,7 @@ value caml_ba_get_N(value vb, value * vind, int nind)
   /* Perform read */
   switch ((b->flags) & CAML_BA_KIND_MASK) {
   default:
-    Assert(0);
+    CAMLassert(0);
   case CAML_BA_FLOAT32:
     return caml_copy_double(((float *) b->data)[offset]);
   case CAML_BA_FLOAT64:
@@ -399,7 +399,7 @@ static value caml_ba_set_aux(value vb, value * vind, intnat nind, value newval)
   /* Perform write */
   switch (b->flags & CAML_BA_KIND_MASK) {
   default:
-    Assert(0);
+    CAMLassert(0);
   case CAML_BA_FLOAT32:
     ((float *) b->data)[offset] = Double_val(newval); break;
   case CAML_BA_FLOAT64:
@@ -732,7 +732,7 @@ static int caml_ba_compare(value v1, value v2)
   case CAML_BA_NATIVE_INT:
     DO_INTEGER_COMPARISON(intnat);
   default:
-    Assert(0);
+    CAMLassert(0);
     return 0;                   /* should not happen */
   }
 #undef DO_INTEGER_COMPARISON
@@ -898,7 +898,7 @@ static void caml_ba_serialize(value v,
   }
   /* Compute required size in OCaml heap.  Assumes struct caml_ba_array
      is exactly 4 + num_dims words */
-  Assert(SIZEOF_BA_ARRAY == 4 * sizeof(value));
+  CAMLassert(SIZEOF_BA_ARRAY == 4 * sizeof(value));
   *wsize_32 = (4 + b->num_dims) * 4;
   *wsize_64 = (4 + b->num_dims) * 8;
 }
@@ -1175,7 +1175,7 @@ CAMLprim value caml_ba_fill(value vb, value vinit)
 
   switch (b->flags & CAML_BA_KIND_MASK) {
   default:
-    Assert(0);
+    CAMLassert(0);
   case CAML_BA_FLOAT32: {
     float init = Double_val(vinit);
     float * p;

--- a/otherlibs/threads/scheduler.c
+++ b/otherlibs/threads/scheduler.c
@@ -523,7 +523,7 @@ static void check_callback(void)
 
 value thread_yield(value unit)        /* ML */
 {
-  Assert(curr_thread != NULL);
+  CAMLassert(curr_thread != NULL);
   Assign(curr_thread->retval, Val_unit);
   return schedule_thread();
 }
@@ -534,7 +534,7 @@ static void thread_reschedule(void)
 {
   value accu;
 
-  Assert(curr_thread != NULL);
+  CAMLassert(curr_thread != NULL);
   /* Pop accu from event frame, making it look like a C_CALL frame
      followed by a RETURN frame */
   accu = *caml_extern_sp++;
@@ -558,7 +558,7 @@ value thread_request_reschedule(value unit)    /* ML */
 
 value thread_sleep(value unit)        /* ML */
 {
-  Assert(curr_thread != NULL);
+  CAMLassert(curr_thread != NULL);
   check_callback();
   curr_thread->status = SUSPENDED;
   return schedule_thread();
@@ -673,7 +673,7 @@ value thread_outchan_ready(value vchan, value vsize) /* ML */
 value thread_delay(value time)          /* ML */
 {
   double date = timeofday() + Double_val(time);
-  Assert(curr_thread != NULL);
+  CAMLassert(curr_thread != NULL);
   check_callback();
   curr_thread->status = BLOCKED_DELAY;
   Assign(curr_thread->delay, caml_copy_double(date));
@@ -685,7 +685,7 @@ value thread_delay(value time)          /* ML */
 value thread_join(value th)          /* ML */
 {
   check_callback();
-  Assert(curr_thread != NULL);
+  CAMLassert(curr_thread != NULL);
   if (((caml_thread_t)th)->status == KILLED) return Val_unit;
   curr_thread->status = BLOCKED_JOIN;
   Assign(curr_thread->joining, th);
@@ -696,7 +696,7 @@ value thread_join(value th)          /* ML */
 
 value thread_wait_pid(value pid)          /* ML */
 {
-  Assert(curr_thread != NULL);
+  CAMLassert(curr_thread != NULL);
   check_callback();
   curr_thread->status = BLOCKED_WAIT;
   curr_thread->waitpid = pid;
@@ -725,7 +725,7 @@ value thread_wakeup(value thread)     /* ML */
 
 value thread_self(value unit)         /* ML */
 {
-  Assert(curr_thread != NULL);
+  CAMLassert(curr_thread != NULL);
   return (value) curr_thread;
 }
 


### PR DESCRIPTION
Replace a few occurrences of assert and many occurrences of Assert
by CAMLassert.

For multi-line assertions, an effort has been made to keep the code
both aligned correctly and beyond the 80-characters-per-line limit.
Sighted input would be welcome to make sure this has actually been achieved.

Also, in byterun/caml/weak.h, function caml_ephe_clean, does
anybody know why the assertions have not been aligned with

  header_t hd; ?

Does this need to be preserved or changed?

Similar question for byterun/compact.c, byterun/minor_gc.c, byterun/misc.c and
byterun/freelist.c.

In this file, does the big comment with all the assertions in it
need to be preserved?

In byterun/intern.c, see the comment saying: "do not do the urgent_gc
check here because it might darken intern_block into gray and break
the Assert 3 lines down.": maybe "3 lines down" could be replaced by "below"?