### PR TITLE
PR#6676: manual, move record notation to tutorial

### DIFF
--- a/Changes
+++ b/Changes
@@ -41,7 +41,7 @@ Working version
 ### Manual and documentation:
 
 - PR#6676, GPR#1110: move record notation to tutorial
-  (Florian Angeletti)
+  (Florian Angeletti, review by Gabriel Scherer)
 
 ### Tools:
 

--- a/Changes
+++ b/Changes
@@ -38,6 +38,11 @@ Working version
   a trailing "Error: Some fatal warnings were triggered" message.
   (Valentin Gatien-Baron, review by Alain Frisch)
 
+### Manual and documentation:
+
+- PR#6676, GPR#1110: move record notation to tutorial
+  (Florian Angeletti)
+
 ### Tools:
 
 - GPR#1045: ocamldep, add a "-shared" option to generate dependencies

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -345,7 +345,7 @@ This section describes and explains in detail some warnings:
 
 \subsection{Warning 9: missing fields in a record pattern}
 
-  When pattern matching record, it can be useful to match only few
+  When pattern matching on records, it can be useful to match only few
   fields of a record. Eliding fields can be done either implicitly
   or explicitly by ending the record pattern with "; _".
   However, implicit field elision is at odd with pattern matching

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -343,6 +343,25 @@ command line, and possibly the "-custom" option.
 
 This section describes and explains in detail some warnings:
 
+\subsection{Warning 9: missing fields in a record pattern}
+
+  When pattern matching record, it can be useful to match only few
+  fields of a record. Eliding fields can be done either implicitly
+  or explicitly by ending the record pattern with "; _".
+  However, implicit field elision is at odd with pattern matching
+  exhaustiveness checks.
+  Enabling warning 9 prioritizes exhaustiveness checks over the
+  convenience of implicit field elision and will warn on implicit
+  field elision in record patterns. In particular, this warning can
+  help to spot exhaustive record pattern that may need to be updated
+  after the addition of new fields to a record type.
+
+\begin{verbatim}
+type 'a point = {x='a ;y='a}
+let dx { x } = x (* implicit field elision: trigger warning 9 *)
+let dy { y; _ } = y (* explicit field elision: do not trigger warning 9 *)
+\end{verbatim}
+
 \subsection{Warning 52: fragile constant pattern}
 \label{ss:warn52}
 

--- a/manual/manual/refman/expr.etex
+++ b/manual/manual/refman/expr.etex
@@ -39,10 +39,10 @@ expr:
   | expr '::' expr
   | '[' expr { ';' expr } [';'] ']'
   | '[|' expr { ';' expr } [';'] '|]'
-  | '{' field [':' typexpr] '=' expr%
-    { ';' field [':' typexpr] '=' expr } [';'] '}'
-  | '{' expr 'with' field [':' typexpr] '=' expr%
-    { ';' field [':' typexpr] '=' expr } [';'] '}'
+  | '{' field [':' typexpr] ['=' expr]%
+    { ';' field [':' typexpr] ['=' expr] } [';'] '}'
+  | '{' expr 'with' field [':' typexpr] ['=' expr]%
+    { ';' field [':' typexpr] ['=' expr] } [';'] '}'
   | expr {{ argument }}
   | prefix-symbol expr
   | '-' expr
@@ -108,7 +108,7 @@ parameter:
 \end{syntax}
 See also the following language extensions:
 \hyperref[s:local-opens]{local opens},
-\hyperref[s:record-and-object-notations]{record and object notations},
+\hyperref[s:object-notations]{object notations},
 \hyperref[s:explicit-polymorphic-type]{explicit polymorphic type annotations},
 \hyperref[s-first-class-modules]{first-class modules},
 \hyperref[s:explicit-overriding-open]{overriding in open statements},
@@ -565,10 +565,13 @@ value whose tag is @tag-name@, and whose argument is the value of @expr@.
 
 \subsubsection*{Records}
 
-The expression @'{' field_1 '=' expr_1 ';' \ldots ';' field_n '='
-expr_n '}'@ evaluates to the record value
+The expression @'{' field_1 ['=' expr_1] ';' \ldots ';' field_n ['='
+expr_n ']}'@ evaluates to the record value
 $\{ field_1 = v_1; \ldots; field_n = v_n \}$
 where $v_i$ is the value of @expr_i@ for \fromoneto{i}{n}.
+A single identifier @field_k@ stands for @field_k '=' field_k@,
+and a qualified identifier @module-path '.' field_k@ stands for
+@module-path '.' field_k '=' field_k@.
 The fields @field_1@ to @field_n@ must all belong to the same record
 type; each field of this record type must appear exactly
 once in the record expression, though they can appear in any
@@ -579,12 +582,15 @@ specified. Optional type constraints can be added after each field
 to force the type of @field_k@ to be compatible with @typexpr_k@.
 
 The expression
-@"{" expr "with" field_1 "=" expr_1 ";" \ldots ";" field_n "=" expr_n "}"@
+@"{" expr "with" field_1 ["=" expr_1] ";" \ldots ";" field_n ["=" expr_n] "}"@
 builds a fresh record with fields @field_1 \ldots field_n@ equal to
 @expr_1 \ldots expr_n@, and all other fields having the same value as
 in the record @expr@.  In other terms, it returns a shallow copy of
 the record @expr@, except for the fields @field_1 \ldots field_n@,
-which are initialized to @expr_1 \ldots expr_n@. As previously, it is
+which are initialized to @expr_1 \ldots expr_n@. As previously,
+single identifier @field_k@ stands for @field_k '=' field_k@,
+a qualified identifier @module-path '.' field_k@ stands for
+@module-path '.' field_k '=' field_k@ and it is
 possible to add an optional type constraint on each field being updated
 with
 @"{" expr "with" field_1 ':' typexpr_1 "=" expr_1 ";" %

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -436,38 +436,21 @@ For example, @module-path'.['expr']'@ is equivalent to
 @module-path'.(['expr'])'@, and @module-path'.[|' pattern '|]'@ is
 equivalent to @module-path'.([|' pattern '|])'@.
 
-\section{Record and object notations} \label{s:record-and-object-notations}
+\section{Object copy short notations} \label{s:object-notations}
 \ikwd{with\@\texttt{with}}
 
-(Introduced in OCaml 3.12, object copy notation added in Ocaml 4.03)
+(Introduced in OCaml 4.03)
 
 \begin{syntax}
-pattern:
-    ...
-  | '{' field ['=' pattern] { ';' field ['=' pattern] } [';' '_' ] [';'] '}'
-;
 expr:
      ...
-  | '{' field ['=' expr] { ';' field ['=' expr] } [';'] '}'
-  | '{' expr 'with' field ['=' expr] { ';' field ['=' expr] } [';'] '}'
   | '{' '<' expr 'with' field ['=' expr] { ';' field ['=' expr] } [';'] '>' '}'
-
 \end{syntax}
 
-In a record pattern, a record construction expression or an object copy expression,
+In an object copy expression,
 a single identifier @id@ stands for @id '=' id@, and a qualified identifier
 @module-path '.' id@ stands for @module-path '.' id '=' id@.
-For example, assuming the record type
-\begin{verbatim}
-          type point = { x: float; y: float }
-\end{verbatim}
-has been declared, the following expressions are equivalent:
-\begin{verbatim}
-          let x = 1. and y = 2. in { x = x; y = y },
-          let x = 1. and y = 2. in { x; y },
-          let x = 1. and y = 2. in { x = x; y }
-\end{verbatim}
-On the object side, all following methods are equivalent:
+For example, all following methods are equivalent:
 \begin{verbatim}
           object
             val x=0. val y=0. val z=0.
@@ -476,29 +459,6 @@ On the object side, all following methods are equivalent:
             method f_2 x y = {< x=x ; y = y >}
           end
 \end{verbatim}
-Likewise, the following functions are equivalent:
-\begin{verbatim}
-          fun {x = x; y = y} -> x +. y
-          fun {x; y} -> x +. y
-\end{verbatim}
-
-Optionally, a record pattern can be terminated by @';' '_'@ to convey the
-fact that not all fields of the record type are listed in the record
-pattern and that it is intentional.  By default, the compiler ignores
-the @';' '_'@ annotation.  If warning 9 is turned on,
-the compiler will warn when a record pattern fails to list all fields of
-the corresponding record type and is not terminated by @';' '_'@.
-Continuing the "point" example above,
-\begin{verbatim}
-          fun {x} -> x +. 1.
-\end{verbatim}
-\noindent will warn if warning 9 is on, while
-\begin{verbatim}
-          fun {x; _} -> x +. 1.
-\end{verbatim}
-\noindent will not warn.  This warning can help spot program points where
-record patterns may need to be modified after new fields are added to a
-record type.
 
 \section{Explicit polymorphic type annotations} \label{s:explicit-polymorphic-type}
 \ikwd{let\@\texttt{let}}

--- a/manual/manual/refman/patterns.etex
+++ b/manual/manual/refman/patterns.etex
@@ -15,8 +15,8 @@ pattern:
   | "`"tag-name pattern
   | "#"typeconstr
   | pattern {{ ',' pattern }}
-  | '{' field [':' typexpr] '=' pattern%
-    { ';' field [':' typexpr] '=' pattern } [ ';' ] '}'
+  | '{' field [':' typexpr] ['=' pattern]%
+    { ';' field [':' typexpr] ['=' pattern] } [';' '_' ] [ ';' ] '}'
   | '[' pattern { ';' pattern } [ ';' ] ']'
   | pattern '::' pattern
   | '[|' pattern { ';' pattern } [ ';' ] '|]'
@@ -141,16 +141,23 @@ is, the pattern matches the tuple values $(v_1, \ldots, v_n)$ such that
 
 \subsubsection*{Record patterns}
 
-The pattern @"{" field_1 "=" pattern_1 ";" \ldots ";" field_n "="
-pattern_n "}"@ matches records that define at least the fields
+The pattern @"{" field_1 ["=" pattern_1] ";" \ldots ";" field_n ["="
+pattern_n] "}"@ matches records that define at least the fields
 @field_1@ through @field_n@, and such that the value associated to
 @field_i@ matches the pattern @pattern_i@, for \fromoneto{i}{n}.
+A single identifier @field_k@ stands for @field_k '=' field_k @,
+and a single qualified identifier @module-path '.' field_k@ stands
+for @module-path '.' field_k '=' field_k @.
 The record value can define more fields than @field_1@ \ldots
 @field_n@; the values associated to these extra fields are not taken
-into account for matching. Optional type constraints can be added field
-by field with @"{" field_1 ":" typexpr_1 "=" pattern_1 ";"%
+into account for matching. Optionally, a record pattern can be terminated
+by @';' '_'@ to convey the fact that not all fields of the record type are
+listed in the record pattern and that it is intentional.
+Optional type constraints can be added field by field with
+@"{" field_1 ":" typexpr_1 "=" pattern_1 ";"%
 \ldots ";"field_n ":" typexpr_n "=" pattern_n "}"@ to force the type
 of @field_k@ to be compatible with @typexpr_k@.
+
 
 \subsubsection*{Array patterns}
 

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -167,6 +167,42 @@ let add_ratio r1 r2 =
    denom = r1.denom * r2.denom};;
 add_ratio {num=1; denom=3} {num=2; denom=5};;
 \end{caml_example}
+Record fields can also be accessed through pattern-matching:
+\begin{caml_example}
+let integer_part r =
+  match r with
+    {num=num; denom=denom} -> num / denom;;
+\end{caml_example}
+Since there is only one case in this pattern matching, it
+is safe to expand directly the argument "r" in a record pattern:
+\begin{caml_example}
+let integer_part {num=num; denom=denom} = num / denom;;
+\end{caml_example}
+When both sides of the "=" sign are the same, it is possible to avoid
+repeating the field name by eliding the "=field" part:
+\begin{caml_example}
+let integer_part {num; denom} = num / denom;;
+\end{caml_example}
+Similarly, unneeded fields can be omitted
+\begin{caml_example}
+let get_denom {denom} = denom;;
+\end{caml_example}
+Optionally, missing fields can be made explicit by ending the list of
+fields with a trailing wildcard "_"::
+\begin{caml_example}
+let get_num {num; _ } = num;;
+\end{caml_example}
+The short notation for fields also works when constructing records:
+\begin{caml_example}
+let ratio num denom = {num; denom};;
+\end{caml_example}
+At last, it is possible to update few fields of a record at once:
+\begin{caml_example}
+  let integer_product integer ratio = { ratio with num = integer * ratio.num };;
+\end{caml_example}
+With this functional update notation, the record on the left-hand side
+of "with" is copied except for the fields on the right-hand side which
+are updated.
 
 The declaration of a variant type lists all possible shapes for values
 of that type. Each case is identified by a name, called a constructor,

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -178,21 +178,21 @@ is safe to expand directly the argument "r" in a record pattern:
 \begin{caml_example}
 let integer_part {num=num; denom=denom} = num / denom;;
 \end{caml_example}
+Unneeded fields can be omitted:
+\begin{caml_example}
+let get_denom {denom=denom} = denom;;
+\end{caml_example}
+Optionally, missing fields can be made explicit by ending the list of
+fields with a trailing wildcard "_"::
+\begin{caml_example}
+let get_num {num=num; _ } = num;;
+\end{caml_example}
 When both sides of the "=" sign are the same, it is possible to avoid
 repeating the field name by eliding the "=field" part:
 \begin{caml_example}
 let integer_part {num; denom} = num / denom;;
 \end{caml_example}
-Similarly, unneeded fields can be omitted
-\begin{caml_example}
-let get_denom {denom} = denom;;
-\end{caml_example}
-Optionally, missing fields can be made explicit by ending the list of
-fields with a trailing wildcard "_"::
-\begin{caml_example}
-let get_num {num; _ } = num;;
-\end{caml_example}
-The short notation for fields also works when constructing records:
+This short notation for fields also works when constructing records:
 \begin{caml_example}
 let ratio num denom = {num; denom};;
 \end{caml_example}


### PR DESCRIPTION
This PR proposes to move the description of the various record notations  —record patterns, field punning, functional update— to the tutorial section rather than the extension chapter since they are an important part of how OCaml is used in the wild; and the current introduction of record types feels very dry.

To complete the move, the description of the grammar of these notations in section 7.7, formerly record and object notations, has been dispatched to the language reference chapter. Similarly, the related warning 9 is now detailed in the section 8.5 which is dedicated to warning explanations.

