### PR TITLE
Ocamldoc: no -title, no empty <h1> in html

### DIFF
--- a/Changes
+++ b/Changes
@@ -48,6 +48,10 @@ Working version
   linked names not namespaced with caml_
   (Stephen Dolan)
 
+- PR#6928: ocamldoc, do not introduce an empty <h1> in index.html when
+  no -title has been provided
+  (Pierre Boutillier)
+
 ### Compiler distribution build system
 
 - GPR#558: enable shared library and natdynlink support on more Linux

--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -2618,15 +2618,20 @@ class html =
       try
         let chanout = open_out (Filename.concat !Global.target_dir self#index) in
         let b = new_buf () in
-        let title = match !Global.title with None -> "" | Some t -> self#escape t in
         bs b doctype ;
         bs b "<html>\n";
         self#print_header b self#title;
         bs b "<body>\n";
 
-        bs b "<h1>";
-        bs b title;
-        bs b "</h1>\n" ;
+        (
+        match !Global.title with
+        | None -> ()
+        | Some t ->
+            bs b "<h1>";
+            bs b (self#escape t);
+            bs b "</h1>\n"
+        );
+
         let info = Odoc_info.apply_opt
             (Odoc_info.info_of_comment_file module_list)
             !Odoc_info.Global.intro_file


### PR DESCRIPTION
PR#6928 discussion contains 2 points: 
- Do not generate an empty intro `<h1>` when ocamldoc is launched without `-title`.  
> [this] does seem like an unconditional improvement
 @Octachron

This is what this patch implements.

- Do not introduce a `<h1>` with the content of `-title` at all when `-intro` is specified to respect `-intro` documentation:
> Use content of file as ocamldoc text to use as introduction (HTML, LATEX and TeXinfo only). __For HTML, the file is used to create the whole index.html file__

I have no dog in this fight... (Maybe, the mistake is just in the description of `-intro`)