### PR TITLE
PR#7504: fix warning 8 with unconstrained records

### DIFF
--- a/Changes
+++ b/Changes
@@ -403,6 +403,9 @@ Next major version (4.05.0):
 - PR#7443, GPR#990: spurious unused open warning with local open in patterns
   (Florian Angeletti, report by Gabriel Scherer)
 
+- PR#7504: fix warning 8 with unconstrained records
+  (Florian Angeletti, report by John Whitington)
+
 - GPR#805, GPR#815, GPR#833: check for integer overflow in String.concat
   (Jeremy Yallop,
    review by Damien Doligez, Alain Frisch, Daniel Bünzli, Fabrice Le Fessant)

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml
@@ -108,3 +108,6 @@ let f x = match x with _ -> () | None -> .;; (* do not warn *)
 (* #7059, all clauses guarded *)
 
 let f x y = match 1 with 1 when x = y -> 1;;
+
+(* #7504, Example with no constraints on a record *)
+let f = function {contents=_}, 0 -> 0;;

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml.reference
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml.reference
@@ -133,4 +133,11 @@ Error: This match case could not be refuted.
 Warning 8: this pattern-matching is not exhaustive.
 All clauses in this pattern-matching are guarded.
 val f : 'a -> 'a -> int = <fun>
+#     Characters 62-91:
+  let f = function {contents=_}, 0 -> 0;;
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(_, 1)
+val f : 'a ref * int -> int = <fun>
 # 

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -137,13 +137,6 @@ let get_type_path ty tenv =
 open Format
 ;;
 
-let pretty_record_elision_mark ppf = function
-  | [] -> () (* should not happen, empty record pattern *)
-  | (_, lbl, _) :: q ->
-      (* we assume that there is no label repetitions here *)
-      if Array.length lbl.lbl_all > 1 + List.length q then
-        fprintf ppf ";@ _@ "
-
 let is_cons = function
 | {cstr_name = "::"} -> true
 | _ -> false
@@ -198,9 +191,17 @@ let rec pretty_val ppf v =
           (function
             | (_,_,{pat_desc=Tpat_any}) -> false (* do not show lbl=_ *)
             | _ -> true) lvs in
-      fprintf ppf "@[{%a%a}@]"
-        pretty_lvals filtered_lvs
-        pretty_record_elision_mark filtered_lvs
+      begin match filtered_lvs with
+      | [] -> fprintf ppf "_"
+      | (_, lbl, _) :: q ->
+          let elision_mark ppf =
+            (* we assume that there is no label repetitions here *)
+             if Array.length lbl.lbl_all > 1 + List.length q then
+               fprintf ppf ";@ _@ "
+             else () in
+          fprintf ppf "@[{%a%t}@]"
+            pretty_lvals filtered_lvs elision_mark
+      end
   | Tpat_array vs ->
       fprintf ppf "@[[| %a |]@]" (pretty_vals " ;") vs
   | Tpat_lazy v ->


### PR DESCRIPTION
[Mantis#7504:](https://caml.inria.fr/mantis/view.php?id=7504)

WIthout this fix, the exhaustiveness check for
```
let f = function {contents=_}, 0 -> 0;;
```
yields an invalid pattern in the warning message
```
Warning 8: this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
({}, 1)
```
due to a mishandled case when there is no constraint on any field of a record in a counter-example.

This fix correct this warning message to 
```
Warning 8: this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
(_, 1)
```