### PR TITLE
Remove ability to run OCaml code in a Unix signal handler

### DIFF
--- a/asmrun/signals_asm.c
+++ b/asmrun/signals_asm.c
@@ -96,19 +96,14 @@ DECLARE_SIGNAL_HANDLER(handle_signal)
   signal(sig, handle_signal);
 #endif
   if (sig < 0 || sig >= NSIG) return;
-  if (caml_try_leave_blocking_section_hook ()) {
-    caml_execute_signal(sig, 1);
-    caml_enter_blocking_section_hook();
-  } else {
-    caml_record_signal(sig);
+  caml_record_signal(sig);
   /* Some ports cache [caml_young_limit] in a register.
      Use the signal context to modify that register too, but only if
      we are inside OCaml code (not inside C code). */
 #if defined(CONTEXT_PC) && defined(CONTEXT_YOUNG_LIMIT)
-    if (Is_in_code_area(CONTEXT_PC))
-      CONTEXT_YOUNG_LIMIT = (context_reg) caml_young_limit;
+  if (Is_in_code_area(CONTEXT_PC))
+    CONTEXT_YOUNG_LIMIT = (context_reg) caml_young_limit;
 #endif
-  }
   errno = saved_errno;
 }
 

--- a/byterun/caml/signals.h
+++ b/byterun/caml/signals.h
@@ -37,7 +37,7 @@ void caml_request_major_slice (void);
 void caml_request_minor_gc (void);
 CAMLextern int caml_convert_signal_number (int);
 CAMLextern int caml_rev_convert_signal_number (int);
-void caml_execute_signal(int signal_number, int in_signal_handler);
+void caml_execute_signal(int signal_number);
 void caml_record_signal(int signal_number);
 void caml_process_pending_signals(void);
 void caml_process_event(void);

--- a/byterun/signals.c
+++ b/byterun/signals.c
@@ -55,7 +55,7 @@ void caml_process_pending_signals(void)
     for (i = 0; i < NSIG; i++) {
       if (caml_pending_signals[i]) {
         caml_pending_signals[i] = 0;
-        caml_execute_signal(i, 0);
+        caml_execute_signal(i);
       }
     }
   }
@@ -136,7 +136,7 @@ CAMLexport void caml_leave_blocking_section(void)
 
 static value caml_signal_handlers = 0;
 
-void caml_execute_signal(int signal_number, int in_signal_handler)
+void caml_execute_signal(int signal_number)
 {
   value res;
   value handler;
@@ -182,14 +182,8 @@ void caml_execute_signal(int signal_number, int in_signal_handler)
   caml_spacetime_trie_node_ptr = saved_spacetime_trie_node_ptr;
 #endif
 #ifdef POSIX_SIGNALS
-  if (! in_signal_handler) {
-    /* Restore the original signal mask */
-    sigprocmask(SIG_SETMASK, &sigs, NULL);
-  } else if (Is_exception_result(res)) {
-    /* Restore the original signal mask and unblock the signal itself */
-    sigdelset(&sigs, signal_number);
-    sigprocmask(SIG_SETMASK, &sigs, NULL);
-  }
+  /* Restore the original signal mask */
+  sigprocmask(SIG_SETMASK, &sigs, NULL);
 #endif
   if (Is_exception_result(res)) caml_raise(Extract_exception(res));
 }

--- a/byterun/signals_byt.c
+++ b/byterun/signals_byt.c
@@ -60,12 +60,7 @@ static void handle_signal(int signal_number)
   signal(signal_number, handle_signal);
 #endif
   if (signal_number < 0 || signal_number >= NSIG) return;
-  if (caml_try_leave_blocking_section_hook()) {
-    caml_execute_signal(signal_number, 1);
-    caml_enter_blocking_section_hook();
-  }else{
-    caml_record_signal(signal_number);
-  }
+  caml_record_signal(signal_number);
   errno = saved_errno;
 }
 


### PR DESCRIPTION
(This branch is for discussion, not immediate merging. It contains a breaking change)

If a signal arrives during a blocking section, the runtime will try to execute the signal handler (arbitrary OCaml code) directly inside the Unix signal handling context. This is unsafe, and I'd like to see it removed, but first I'd like to understand the uses of this feature.

The issue is that only a very small [whitelisted set of functions](http://man7.org/linux/man-pages/man7/signal-safety.7.html) can safely be called from a Unix signal handler. In particular, it is not safe to call `malloc` from a Unix signal handler (`malloc` can safely be called from multiple threads, but if a signal handler interrupts `malloc` and itself calls `malloc`, then per-thread datastructures will be corrupted).

It is essentially impossible to know that a piece of OCaml code does not call malloc. Obviously, code which allocates may call `malloc`. However, merely writing a reference may call `malloc`, if [the `ref_table` overflows](https://github.com/ocaml/ocaml/blob/65523392f0211d6e991fb5066f8ec14447f4df63/byterun/caml/minor_gc.h#L86). Writing an immediate value like `None` into a reference may call `malloc`, if the value that was previously there needs to be darkened and [the grey stack overflows](https://github.com/ocaml/ocaml/blob/65523392f0211d6e991fb5066f8ec14447f4df63/byterun/major_gc.c#L178). Even throwing an exception may call `malloc` [to allocate space for the backtrace](https://github.com/ocaml/ocaml/blob/65523392f0211d6e991fb5066f8ec14447f4df63/asmrun/backtrace_prim.c#L93).

So, the current approach is fundamentally unsafe. Is it relied upon?