### PR TITLE
Remove support code for Cash

### DIFF
--- a/byterun/caml/compatibility.h
+++ b/byterun/caml/compatibility.h
@@ -194,7 +194,6 @@
 #define really_putblock caml_really_putblock
 #define seek_out caml_seek_out /*SP*/
 #define pos_out caml_pos_out /*SP*/
-#define do_read caml_do_read
 #define refill caml_refill
 #define getword caml_getword
 #define getblock caml_getblock
@@ -202,7 +201,6 @@
 #define seek_in caml_seek_in /*SP*/
 #define pos_in caml_pos_in /*SP*/
 #define input_scan_line caml_input_scan_line /*SP*/
-#define finalize_channel caml_finalize_channel
 #define alloc_channel caml_alloc_channel
 /*#define Val_file_offset caml_Val_file_offset   *** done in io.h as needed */
 /*#define File_offset_val caml_File_offset_val   *** done in io.h as needed */

--- a/byterun/caml/io.h
+++ b/byterun/caml/io.h
@@ -44,9 +44,7 @@ struct channel {
   char * max;                   /* Logical end of the buffer (for input) */
   void * mutex;                 /* Placeholder for mutex (for systhreads) */
   struct channel * next, * prev;/* Double chaining of channels (flush_all) */
-  int revealed;                 /* For Cash only */
-  int old_revealed;             /* For Cash only */
-  int refcount;                 /* For flush_all and for Cash */
+  int refcount;                 /* For flush_all */
   int flags;                    /* Bitfield */
   char buff[IO_BUFFER_SIZE];    /* The buffer itself */
   char * name;                  /* Optional name (to report fd leaks) */

--- a/byterun/io.c
+++ b/byterun/io.c
@@ -75,8 +75,6 @@ CAMLexport struct channel * caml_open_descriptor_in(int fd)
   channel->curr = channel->max = channel->buff;
   channel->end = channel->buff + IO_BUFFER_SIZE;
   channel->mutex = NULL;
-  channel->revealed = 0;
-  channel->old_revealed = 0;
   channel->refcount = 0;
   channel->flags = 0;
   channel->next = caml_all_opened_channels;
@@ -250,12 +248,6 @@ CAMLexport file_offset caml_pos_out(struct channel *channel)
 
 /* Input */
 
-/* caml_do_read is exported for Cash */
-CAMLexport int caml_do_read(int fd, char *p, unsigned int n)
-{
-  return caml_read_fd(fd, 0, p, n);
-}
-
 CAMLexport unsigned char caml_refill(struct channel *channel)
 {
   int n;
@@ -390,8 +382,7 @@ CAMLexport intnat caml_input_scan_line(struct channel *channel)
    objects into a heap-allocated object.  Perform locking
    and unlocking around the I/O operations. */
 
-/* FIXME CAMLexport, but not in io.h  exported for Cash ? */
-CAMLexport void caml_finalize_channel(value vchan)
+static void finalize_channel(value vchan)
 {
   struct channel * chan = Channel(vchan);
   if (--chan->refcount > 0) return;
@@ -441,7 +432,7 @@ static intnat hash_channel(value vchan)
 
 static struct custom_operations channel_operations = {
   "_chan",
-  caml_finalize_channel,
+  finalize_channel,
   compare_channel,
   hash_channel,
   custom_serialize_default,


### PR DESCRIPTION
I've begun working on a patch to fix [PR7503](https://caml.inria.fr/mantis/view.php?id=7503), which involves refactoring the locking and interrupting logic in `io.c`.

That patch isn't ready yet. This is the first, trivial part: removing some dead code that exists only to support Cash.

The Cash [homepage is still up](http://pauillac.inria.fr/cash/), but states "The current version is Cash 0.20, released on the last week of 2002 Aug.". The links to source code are broken (it lived on a now-dead INRIA FTP server), but given that it requires "Objective Caml 3.05 or higher" I'm doubtful that it would still build. (It's also listed on the [Caml Hump](http://caml.inria.fr/cgi-bin/hump.en.cgi?contrib=86), but that links to the same homepage)