### PR TITLE
PR#6587: avoid ambiguous pervasives prefix elision in printed type names

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,6 +47,7 @@ Working version
 - PR#6676, GPR#1110: move record notation to tutorial
   (Florian Angeletti, review by Gabriel Scherer)
 
+
 ### Tools:
 
 - GPR#1045: ocamldep, add a "-shared" option to generate dependencies
@@ -88,6 +89,10 @@ Working version
 
 - PR#5927: Type equality broken for conjunctive polymorphic variant tags
   (Jacques Garrigue, report by Leo White)
+
+- PR#6587: only elide Pervasives from printed type paths in
+  unambiguous context
+  (Florian Angeletti)
 
 - PR#7261: Warn on type constraints in GADT declarations
   (Jacques Garrigue, report by Fabrice Le Botlan)

--- a/testsuite/tests/typing-warnings/pr6587.ml
+++ b/testsuite/tests/typing-warnings/pr6587.ml
@@ -1,0 +1,13 @@
+
+module A: sig val f: fpclass -> fpclass end =
+  struct
+    let f _ = FP_normal
+  end;;
+
+type fpclass = A ;;
+
+module B: sig val f: fpclass -> fpclass end =
+  struct
+    let f A = FP_normal
+  end
+    ;;

--- a/testsuite/tests/typing-warnings/pr6587.ml.reference
+++ b/testsuite/tests/typing-warnings/pr6587.ml.reference
@@ -1,0 +1,17 @@
+
+#         module A : sig val f : fpclass -> fpclass end
+#   type fpclass = A
+#           Characters 49-85:
+  ..struct
+      let f A = FP_normal
+    end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : fpclass -> Pervasives.fpclass end
+       is not included in
+         sig val f : fpclass -> fpclass end
+       Values do not match:
+         val f : fpclass -> Pervasives.fpclass
+       is not included in
+         val f : fpclass -> fpclass
+# 


### PR DESCRIPTION
The purpose of this PR is to be more cautious when eliding the `Pervasives.` prefix from printed type names in order to avoid using the same printed name for two different types.

For instance, consider a file `a.ml` consisting of
```OCaml
(* a.ml *)
type fpclass = R
module A: sig val f: fpclass -> fpclass end = struct let f R = FP_normal end;;
```
Currently, it raises the following error messages:
```
Error: Signature mismatch: 
       Modules do not match
         sig val f : fpclass -> fpclass end                                            
       is not included in
         sig val f : fpclass -> fpclass end
       Values do not match:
         val f : fpclass -> fpclass
       is not included in
         val f : fpclass -> fpclass
```
where the printed type name `fpclass` means either `A.fpclass` or `Pervasives.fpclass` due to the hard coded elision of the `Pervasives .` prefix in [printtyp](typing/printtyp.ml).

This PR proposes to perform this elision of the `Pervasives.` prefix only when `t` is mapped to `Pervasives.t` in the current printing environment. With this changes, the previous error messages becomes
```
Error: Signature mismatch:
       Modules do not match:
         sig val f : fpclass -> Pervasives.fpclass end
       is not included in
         sig val f : fpclass -> fpclass end
       Values do not match:
         val f : fpclass -> Pervasives.fpclass
       is not included in
         val f : fpclass -> fpclass
```
where the two types `A.fpclass` and `Pervasives.fpclass` are clearly distincts.

N.B: I fully agree that redefining `Pervasives` types is a bad idea, but I would argue that punishing a bad idea with a non-understandable type error is an even worse idea.