### PR TITLE
PR#6676: manual, move local and overriding opens to tutorial 

### DIFF
--- a/Changes
+++ b/Changes
@@ -51,6 +51,9 @@ Working version
 - PR#6676, GPR#1110: move record notation to tutorial
   (Florian Angeletti, review by Gabriel Scherer)
 
+- PR#6676, GPR#1112: move local opens to tutorial
+  (Florian Angeletti)
+
 - PR#7254, GPR#1096: Rudimentary documentation of ocamlnat
   (Mark Shinwell)
 

--- a/manual/manual/refman/expr.etex
+++ b/manual/manual/refman/expr.etex
@@ -75,7 +75,12 @@ expr:
   | 'lazy' expr
   | 'let' 'module' module-name { '(' module-name ':' module-type ')' }
     [ ':' module-type ] \\ '=' module-expr 'in' expr
-
+  | "let" "open" module-path "in" expr
+  | module-path '.(' expr ')'
+  | module-path '.[' expr ']'
+  | module-path '.[|' expr '|]'
+  | module-path '.{' expr '}'
+  | module-path '.{<' expr '>}'
 ;
 %BEGIN LATEX
 \end{syntax} \begin{syntax}
@@ -107,7 +112,6 @@ parameter:
   | '?' label-name ':' '(' pattern [':' typexpr] ['=' expr] ')'
 \end{syntax}
 See also the following language extensions:
-\hyperref[s:local-opens]{local opens},
 \hyperref[s:object-notations]{object notations},
 \hyperref[s:explicit-polymorphic-type]{explicit polymorphic type annotations},
 \hyperref[s-first-class-modules]{first-class modules},
@@ -959,5 +963,21 @@ It then returns the value of @expr@.  For example:
           StringSet.elements
             (List.fold_right StringSet.add string_list StringSet.empty)
 \end{verbatim}
+
+\subsubsection*{Local opens}
+\ikwd{let\@\texttt{let}}
+\ikwd{module\@\texttt{open}}
+
+The expressions @"let" "open" module-path "in" expr@ and
+@module-path'.('expr')'@ are strictly equivalent. These
+constructions locally open the module referred to by the module path
+@module-path@ in the respective scope of the expression @expr@.
+
+When the body of a local open expression is delimited by
+@'[' ']'@,  @'[|' '|]'@,  or @'{' '}'@, the parentheses can be omitted.
+For expression, parentheses can also be omitted for @'{<' '>}'@.
+For example, @module-path'.['expr']'@ is equivalent to
+@module-path'.(['expr'])'@, and @module-path'.[|' expr '|]'@ is
+equivalent to @module-path'.([|' expr '|])'@.
 
 %% \newpage

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -379,61 +379,31 @@ Similarly to abstract types, the variance of type parameters
 is not inferred, and must be given explicitly.
 
 
-\section{Local opens}
+\section{Local opens for patterns}
 \ikwd{let\@\texttt{let}}
 \ikwd{open\@\texttt{open}} \label{s:local-opens}
 
-(Introduced in OCaml 3.12, extended to patterns in 4.04)
+(Introduced in OCaml 4.04)
 
 \begin{syntax}
-expr:
-       ...
-     | "let" "open" module-path "in" expr
-     | module-path '.(' expr ')'
-;
 pattern:
        ...
      | module-path '.(' pattern ')'
-\end{syntax}
-
-The expressions
-@"let" "open" module-path "in" expr@
-and
-@module-path'.('expr')'@ are strictly equivalent. On the pattern side,
-only the pattern @module-path'.('pattern')'@ is available. These
-constructions locally open the module referred to by the module path
-@module-path@ in the respective scope of the expression @expr@ or
-pattern @pattern@.
-
-Restricting opening to the scope of a single expression or pattern
-instead of a whole structure allows one to benefit from shorter syntax
-to refer to components of the opened module, without polluting the
-global scope. Also, this can make the code easier to read (the open
-statement is closer to where it is used) and to refactor (because the
-code fragment is more self-contained).
-
-\paragraph{Local opens for delimited expressions or patterns} (Introduced in OCaml 4.02)
-
-\begin{syntax}
-expr:
-       ...
-     | module-path '.[' expr ']'
-     | module-path '.[|' expr '|]'
-     | module-path '.{' expr '}'
-     | module-path '.{<' expr '>}'
-;
-pattern:
-       ...
      | module-path '.[' pattern ']'
      | module-path '.[|' pattern '|]'
      | module-path '.{' pattern '}'
+
 \end{syntax}
 
-When the body of a local open expression or pattern is delimited by
+For patterns, local opens are limited to the
+@module-path'.('pattern')'@ construction. This
+construction locally open the module referred to by the module path
+@module-path@ in the scope of the pattern @pattern@.
+
+When the body of a local open pattern is delimited by
 @'[' ']'@,  @'[|' '|]'@,  or @'{' '}'@, the parentheses can be omitted.
-For expression, parentheses can also be omitted for @'{<' '>}'@.
-For example, @module-path'.['expr']'@ is equivalent to
-@module-path'.(['expr'])'@, and @module-path'.[|' pattern '|]'@ is
+For example, @module-path'.['pattern']'@ is equivalent to
+@module-path'.(['pattern'])'@, and @module-path'.[|' pattern '|]'@ is
 equivalent to @module-path'.([|' pattern '|])'@.
 
 \section{Object copy short notations} \label{s:object-notations}

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -243,6 +243,18 @@ let add_num n1 n2 =
 add_num (Int 123) (Float 3.14159);;
 \end{caml_example}
 
+Another interesting example of variant type is the built-in
+"'a option" type which represents either a value of type "'a" or an
+absence of value:
+\begin{caml_example}
+type 'a option = Some of 'a | None;;
+\end{caml_example}
+This type is particularly useful when defining function that can
+fail in common situations, for instance
+\begin{caml_example}
+let safe_square_root x = if x > 0. then Some(sqrt x) else None;;
+\end{caml_example}
+
 The most common usage of variant types is to describe recursive data
 structures. Consider for example the type of binary trees:
 \begin{caml_example}

--- a/manual/manual/tutorials/moduleexamples.etex
+++ b/manual/manual/tutorials/moduleexamples.etex
@@ -53,6 +53,33 @@ inside the structure "PrioQueue" and "PrioQueue.queue" is the type
 PrioQueue.insert PrioQueue.empty 1 "hello";;
 \end{caml_example}
 
+Another possibility is to open the module, which brings all
+identifiers defined inside the module in the scope of the current
+structure.
+
+\begin{caml_example}
+  open PrioQueue;;
+  insert empty 1 "hello";;
+\end{caml_example}
+
+It is also possible to copy the components of a module inside
+another module by using an "include" statement. This can be
+particularly useful to extend existing modules. As an illustration,
+we could add functions that returns an optional value rather than
+an exception when the priority queue is empty.
+\begin{caml_example}
+  module PrioQueueOpt =
+  struct
+    include PrioQueue
+
+    let remove_top_opt x =
+      try Some(remove_top x) with Queue_is_empty -> None
+
+    let extract_opt x =
+      try Some(extract x) with Queue_is_empty -> None
+  end;;
+\end{caml_example}
+
 \section{Signatures}
 \pdfsection{Signatures}
 
@@ -93,6 +120,20 @@ An alternate syntax is provided for the above:
 \begin{verbatim}
 module PrioQueue : PRIOQUEUE = struct ... end;;
 \end{verbatim}
+
+Like for modules, it is possible to include a signature to copy
+its components inside the current signature. For instance, we
+can extend the PRIOQUEUE signature with the "extract_opt"
+function:
+
+\begin{caml_example}
+module type PRIOQUEUE_WITH_OPT =
+  sig
+    include PRIOQUEUE
+    val extract_opt : 'a queue -> (int * 'a * 'a queue) option
+  end;;
+\end{caml_example}
+
 
 \section{Functors}
 \pdfsection{Functors}

--- a/manual/manual/tutorials/moduleexamples.etex
+++ b/manual/manual/tutorials/moduleexamples.etex
@@ -62,6 +62,46 @@ structure.
   insert empty 1 "hello";;
 \end{caml_example}
 
+Opening a module enables lighter access to its components, at the
+cost of making it harder to identify in which module a identifier
+has been defined. In particular, opened modules can shadow
+identifiers present in the current scope, potentially leading
+to confusing errors:
+
+\begin{caml_example}
+  let empty = []
+  open PrioQueue;;
+  let x = 1 :: empty [@@expect error];;
+\end{caml_example}
+
+
+A partial solution to this conundrum is to open modules locally,
+making the components of the module available only in the
+concerned expression. This can also make the code easier to read
+-- the open statement is closer to where it is used-- and to refactor
+-- the code fragment is more self-contained.
+Two constructions are available for this purpose:
+\begin{caml_example}
+  let open PrioQueue in
+  insert empty 1 "hello";;
+\end{caml_example}
+and
+\begin{caml_example}
+  PrioQueue.(insert empty 1 "hello");;
+\end{caml_example}
+In the second form, when the body of a local open is itself delimited
+by parentheses, braces or bracket, the parentheses of the local open
+can be omitted. For instance,
+\begin{caml_example}
+  PrioQueue.[empty] = PrioQueue.([empty]);;
+  PrioQueue.[|empty|] = PrioQueue.([|empty|]);;
+   PrioQueue.{ contents = empty } = PrioQueue.({ contents = empty });;
+\end{caml_example}
+becomes
+\begin{caml_example}
+  PrioQueue.[insert empty 1 "hello"];;
+\end{caml_example}
+
 It is also possible to copy the components of a module inside
 another module by using an "include" statement. This can be
 particularly useful to extend existing modules. As an illustration,


### PR DESCRIPTION
The aim of this PR is to move the description of local and overriding opens to the tutorial section of
the manual —with the exception of the local open in patterns construction introduced only few months ago— in order to decrease a little the distance between OCaml as described in the tutorial, and existing OCaml idioms.

As a preliminary step, the first commit in this PR introduces the built-in option types: the option type was useful to build meaningful examples in the module section and was already used without any description in ulterior sections of the manual.

Similarly, the second commit adds a short description and an example for the simple `open` and `include` statements, that were neither described nor used in the tutorial before.

Finally, the third and fourth commits extends the description of the `open` statement to include both local and overriding opens and move the grammar description from the language extension section to the corresponding language section.