### PR TITLE
Update docs for Visual Studio 2017

### DIFF
--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -74,8 +74,8 @@ instructions on how to build FlexDLL from sources, including how to bootstrap
 FlexDLL and OCaml are given <<seflexdll,later in this document>>.  Unless you
 bootstrap FlexDLL, you will need to ensure that the directory to which you
 install FlexDLL is included in your `PATH` environment variable. Note: if you
-use Visual Studio 2015, the binary distribution of FlexDLL will not work and
-you must build it from sources.
+use Visual Studio 2015 or Visual Studio 2017, the binary distribution of
+FlexDLL will not work and you must build it from sources.
 
 The base bytecode system (ocamlc, ocaml, ocamllex, ocamlyacc, ...) of all three
 ports runs without any additional tools.
@@ -101,6 +101,7 @@ Visual C/C++ Compiler.
 | Visual Studio 2012 | 17.00.x.x    | 32/64-bit               |
 | Visual Studio 2013 | 18.00.x.x    | 32/64-bit               |
 | Visual Studio 2015 | 19.00.x.x    | 32/64-bit               |
+| Visual Studio 2017 | 19.10.x.x    | 32/64-bit               |
 |=====
 
 [[vs1]]
@@ -138,9 +139,9 @@ for 32-bit or:
 
 for 64-bit. For Visual Studio 2005-2013, you need to use one of the shortcuts in
 the "Visual Studio Tools" program group under the main program group for the
-version of Visual Studio you installed. For Visual Studio 2015, you need to use
-the shortcuts in the "Windows Desktop Command Prompts" group under the
-"Visual Studio Tools" group.
+version of Visual Studio you installed. For Visual Studio 2015 and 2017, you
+need to use the shortcuts in the "Windows Desktop Command Prompts" (2015) or
+"VC" (2017) group under the "Visual Studio Tools" group.
 
 Unlike `SetEnv` for the Windows SDK, the architecture is selected by using a
 different shortcut, rather than by running a command.
@@ -154,7 +155,7 @@ work with OCaml.
 
 For Visual Studio 2012 and 2013, both x86 and x64 Command Prompt shortcuts
 indicate if they are the "Native Tools" or "Cross Tools" versions. Visual Studio
-2015 makes the shortcuts even clearer by including the full name of the
+2015 and 2017 make the shortcuts even clearer by including the full name of the
 architecture.
 
 You cannot at present use a cross-compiler to compile 64-bit OCaml on 32-bit


### PR DESCRIPTION
There's a new release of Visual Studio - which fortunately requires no change to OCaml beyond a few alterations to the docs.