### PR TITLE
Bigarray storage tweak

### DIFF
--- a/Changes
+++ b/Changes
@@ -130,7 +130,7 @@ Working version
   OCAMLRUNPARAM enables shutting the runtime properly on process exit.
   (Max Mouratov, review and discussion by Damien Doligez, Gabriel Scherer,
   Mark Shinwell, Thomas Braibant, Stephen Dolan, Pierre Chambart,
-  François Bobot, Jacques Garrigue, and David Allsopp)
+  François Bobot, Jacques Garrigue, David Allsopp, and Alain Frisch)
 
 Next major version (4.05.0):
 ----------------------------

--- a/byterun/bigarray.c
+++ b/byterun/bigarray.c
@@ -85,7 +85,7 @@ CAMLexport struct custom_operations caml_ba_ops = {
 
 /* [caml_ba_alloc] will allocate a new bigarray object in the heap.
    If [data] is NULL, the memory for the contents is also allocated
-   (with [caml_stat_alloc]) by [caml_ba_alloc].
+   (with [malloc]) by [caml_ba_alloc].
    [data] cannot point into the OCaml heap.
    [dim] may point into an object in the OCaml heap.
 */
@@ -112,7 +112,7 @@ caml_ba_alloc(int flags, int num_dims, void * data, intnat * dim)
                            caml_ba_element_size[flags & CAML_BA_KIND_MASK],
                            &size))
       caml_raise_out_of_memory();
-    data = caml_stat_alloc_noexc(size);
+    data = malloc(size);
     if (data == NULL && size != 0) caml_raise_out_of_memory();
     flags |= CAML_BA_MANAGED;
   }
@@ -156,11 +156,11 @@ CAMLexport void caml_ba_finalize(value v)
     break;
   case CAML_BA_MANAGED:
     if (b->proxy == NULL) {
-      caml_stat_free(b->data);
+      free(b->data);
     } else {
       if (-- b->proxy->refcount == 0) {
-        caml_stat_free(b->proxy->data);
-        caml_stat_free(b->proxy);
+        free(b->proxy->data);
+        free(b->proxy);
       }
     }
     break;
@@ -455,7 +455,7 @@ CAMLexport uintnat caml_ba_deserialize(void * dst)
     caml_deserialize_error("input_value: bad bigarray kind");
   elt_size = caml_ba_element_size[b->flags & CAML_BA_KIND_MASK];
   /* Allocate room for data */
-  b->data = caml_stat_alloc_noexc(elt_size * num_elts);
+  b->data = malloc(elt_size * num_elts);
   if (b->data == NULL)
     caml_deserialize_error("input_value: out of memory for bigarray");
   /* Read data */

--- a/otherlibs/bigarray/bigarray_stubs.c
+++ b/otherlibs/bigarray/bigarray_stubs.c
@@ -520,7 +520,8 @@ static void caml_ba_update_proxy(struct caml_ba_array * b1,
     ++ b1->proxy->refcount;
   } else {
     /* Otherwise, create proxy and attach it to both b1 and b2 */
-    proxy = caml_stat_alloc(sizeof(struct caml_ba_proxy));
+    proxy = malloc(sizeof(struct caml_ba_proxy));
+    if (proxy == NULL) caml_raise_out_of_memory();
     proxy->refcount = 2;      /* original array + sub array */
     proxy->data = b1->data;
     proxy->size =

--- a/otherlibs/unix/mmap_ba.c
+++ b/otherlibs/unix/mmap_ba.c
@@ -46,7 +46,7 @@ static void caml_ba_mapped_finalize(value v)
   } else {
     if (-- b->proxy->refcount == 0) {
       UNMAP_FILE_FUNCTION(b->proxy->data, b->proxy->size);
-      caml_stat_free(b->proxy);
+      free(b->proxy);
     }
   }
 }


### PR DESCRIPTION
In comments to the recently merged #71 @alainfrisch [pointed out](https://github.com/ocaml/ocaml/pull/71#issuecomment-289053912) that perhaps it'd suffice to use plain `malloc` and `free` inside Bigarray instead of the more complicated `caml_stat_*`. I have validated his suggestion, and this patch implements it. 

No separate Changes entry is needed, as it's merely a fixup to #71.