### PR TITLE
Fixed erroneous comments

### DIFF
--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -85,7 +85,7 @@ val max_int : nativeint
    or 2{^63} - 1 on a 64-bit platform. *)
 
 val min_int : nativeint
-(** The greatest representable native integer,
+(** The smallest representable native integer,
    either -2{^31} on a 32-bit platform,
    or -2{^63} on a 64-bit platform. *)
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -130,7 +130,7 @@ val no_overflow_add: int -> int -> bool
         (* [no_overflow_add n1 n2] returns [true] if the computation of
            [n1 + n2] does not overflow. *)
 val no_overflow_sub: int -> int -> bool
-        (* [no_overflow_add n1 n2] returns [true] if the computation of
+        (* [no_overflow_sub n1 n2] returns [true] if the computation of
            [n1 - n2] does not overflow. *)
 val no_overflow_mul: int -> int -> bool
         (* [no_overflow_mul n1 n2] returns [true] if the computation of
@@ -160,8 +160,8 @@ val search_substring: string -> string -> int -> int
            does not occur. *)
 
 val replace_substring: before:string -> after:string -> string -> string
-        (* [search_substring ~before ~after str] replaces all
-           occurences of [before] with [after] in [str] and returns
+        (* [replace_substring ~before ~after str] replaces all
+           occurrences of [before] with [after] in [str] and returns
            the resulting string. *)
 
 val rev_split_words: string -> string list

--- a/utils/targetint.mli
+++ b/utils/targetint.mli
@@ -82,7 +82,7 @@ val max_int : t
     or 2{^63} - 1 on a 64-bit platform. *)
 
 val min_int : t
-(** The greatest representable target integer,
+(** The smallest representable target integer,
    either -2{^31} on a 32-bit platform,
    or -2{^63} on a 64-bit platform. *)
 


### PR DESCRIPTION
This fixes a few crude non-grammatical errors in user-facing comments.

Cherry-picked from the stale #817.