### PR TITLE
EINTR-based signals

### DIFF
--- a/asmrun/signals_asm.c
+++ b/asmrun/signals_asm.c
@@ -96,19 +96,14 @@ DECLARE_SIGNAL_HANDLER(handle_signal)
   signal(sig, handle_signal);
 #endif
   if (sig < 0 || sig >= NSIG) return;
-  if (caml_try_leave_blocking_section_hook ()) {
-    caml_execute_signal(sig, 1);
-    caml_enter_blocking_section_hook();
-  } else {
-    caml_record_signal(sig);
+  caml_record_signal(sig);
   /* Some ports cache [caml_young_limit] in a register.
      Use the signal context to modify that register too, but only if
      we are inside OCaml code (not inside C code). */
 #if defined(CONTEXT_PC) && defined(CONTEXT_YOUNG_LIMIT)
-    if (Is_in_code_area(CONTEXT_PC))
-      CONTEXT_YOUNG_LIMIT = (context_reg) caml_young_limit;
+  if (Is_in_code_area(CONTEXT_PC))
+    CONTEXT_YOUNG_LIMIT = (context_reg) caml_young_limit;
 #endif
-  }
   errno = saved_errno;
 }
 

--- a/byterun/caml/osdeps.h
+++ b/byterun/caml/osdeps.h
@@ -22,22 +22,23 @@
 
 #include "misc.h"
 #include "memory.h"
+#include "io.h"
 
 /* Read at most [n] bytes from file descriptor [fd] into buffer [buf].
    [flags] indicates whether [fd] is a socket
    (bit [CHANNEL_FLAG_FROM_SOCKET] is set in this case, see [io.h]).
    (This distinction matters for Win32, but not for Unix.)
-   Return number of bytes read.
-   In case of error, raises [Sys_error] or [Sys_blocked_io]. */
-extern int caml_read_fd(int fd, int flags, void * buf, int n);
+   Returns error code (0 on success, or positive error code)
+   If successful, stores number of bytes read into *nread. */
+extern io_result caml_read_fd(int fd, int flags, void * buf, int n, int* nread);
 
 /* Write at most [n] bytes from buffer [buf] onto file descriptor [fd].
    [flags] indicates whether [fd] is a socket
    (bit [CHANNEL_FLAG_FROM_SOCKET] is set in this case, see [io.h]).
    (This distinction matters for Win32, but not for Unix.)
-   Return number of bytes written.
-   In case of error, raises [Sys_error] or [Sys_blocked_io]. */
-extern int caml_write_fd(int fd, int flags, void * buf, int n);
+   Return error code (0 on success or positive error code)
+   If successful, stores number of bytes written into *nwritten. */
+extern io_result caml_write_fd(int fd, int flags, void * buf, int n, int* nwritten);
 
 /* Decompose the given path into a list of directories, and add them
    to the given table. */

--- a/byterun/caml/signals.h
+++ b/byterun/caml/signals.h
@@ -51,6 +51,7 @@ CAMLextern void (* volatile caml_async_action_hook)(void);
 
 CAMLextern void caml_enter_blocking_section (void);
 CAMLextern void caml_leave_blocking_section (void);
+CAMLextern void caml_leave_blocking_section_nosig (void);
 
 #ifdef __cplusplus
 }

--- a/byterun/caml/sys.h
+++ b/byterun/caml/sys.h
@@ -26,8 +26,12 @@ extern "C" {
 
 #define NO_ARG Val_int(0)
 
-CAMLextern void caml_sys_error (value);
-CAMLextern void caml_sys_io_error (value);
+CAMLnoreturn_start
+CAMLextern void caml_sys_error (value)
+CAMLnoreturn_end;
+CAMLnoreturn_start
+CAMLextern void caml_sys_io_error (value)
+CAMLnoreturn_end;
 CAMLextern double caml_sys_time_unboxed(value);
 CAMLextern void caml_sys_init (char * exe_name, char ** argv);
 CAMLextern value caml_sys_exit (value);

--- a/byterun/extern.c
+++ b/byterun/extern.c
@@ -684,9 +684,7 @@ CAMLprim value caml_output_value(value vchan, value v, value flags)
   CAMLparam3 (vchan, v, flags);
   struct channel * channel = Channel(vchan);
 
-  Lock(channel);
   caml_output_val(channel, v, flags);
-  Unlock(channel);
   CAMLreturn (Val_unit);
 }
 

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -755,9 +755,7 @@ CAMLprim value caml_input_value(value vchan)
   struct channel * chan = Channel(vchan);
   CAMLlocal1 (res);
 
-  Lock(chan);
   res = caml_input_val(chan);
-  Unlock(chan);
   CAMLreturn (res);
 }
 
@@ -769,9 +767,7 @@ CAMLprim value caml_input_value_to_outside_heap(value vchan)
   struct channel * chan = Channel(vchan);
   CAMLlocal1 (res);
 
-  Lock(chan);
   res = caml_input_val_core(chan, 1);
-  Unlock(chan);
   CAMLreturn (res);
 }
 

--- a/byterun/md5.c
+++ b/byterun/md5.c
@@ -45,7 +45,6 @@ CAMLexport value caml_md5_channel(struct channel *chan, intnat toread)
   intnat read;
   char buffer[4096];
 
-  Lock(chan);
   caml_MD5Init(&ctx);
   if (toread < 0){
     while (1){
@@ -64,7 +63,6 @@ CAMLexport value caml_md5_channel(struct channel *chan, intnat toread)
   }
   res = caml_alloc_string(16);
   caml_MD5Final(&Byte_u(res, 0), &ctx);
-  Unlock(chan);
   CAMLreturn (res);
 }
 

--- a/byterun/signals.c
+++ b/byterun/signals.c
@@ -111,23 +111,24 @@ CAMLexport int (*caml_try_leave_blocking_section_hook)(void) =
 
 CAMLexport void caml_enter_blocking_section(void)
 {
-  while (1){
-    /* Process all pending signals now */
-    caml_process_pending_signals();
-    caml_enter_blocking_section_hook ();
-    /* Check again for pending signals.
-       If none, done; otherwise, try again */
-    if (! caml_signals_are_pending) break;
-    caml_leave_blocking_section_hook ();
-  }
+  caml_enter_blocking_section_hook ();
 }
 
-CAMLexport void caml_leave_blocking_section(void)
+CAMLexport void caml_leave_blocking_section_nosig(void)
 {
   int saved_errno;
   /* Save the value of errno (PR#5982). */
   saved_errno = errno;
   caml_leave_blocking_section_hook ();
+  errno = saved_errno;
+}
+
+CAMLexport void caml_leave_blocking_section(void)
+{
+  int saved_errno;
+  caml_leave_blocking_section_nosig();
+  /* Save the value of errno (PR#5982). */
+  saved_errno = errno;
   caml_process_pending_signals();
   errno = saved_errno;
 }

--- a/byterun/signals_byt.c
+++ b/byterun/signals_byt.c
@@ -60,12 +60,7 @@ static void handle_signal(int signal_number)
   signal(signal_number, handle_signal);
 #endif
   if (signal_number < 0 || signal_number >= NSIG) return;
-  if (caml_try_leave_blocking_section_hook()) {
-    caml_execute_signal(signal_number, 1);
-    caml_enter_blocking_section_hook();
-  }else{
-    caml_record_signal(signal_number);
-  }
+  caml_record_signal(signal_number);
   errno = saved_errno;
 }
 


### PR DESCRIPTION
(This is quite a subtle change, I'd appreciate nitpicking about locking, signal handling and error checking. It's still incomplete at the moment, but I'd like some discussion. Apologies about the length, but the fallout outside `io.c` is fairly minimal, and the changes within are mostly mechanical.)

Currently, OCaml signal handlers for signals arriving during IO are run directly from the Unix signal handler, which has a number of problems (see discussion on #1107 for details). Additionally, they may be run while holding channels' locks, which causes the deadlocks/crashes detailed in [MPR#7503](https://caml.inria.fr/mantis/view.php?id=7503).

Nowadays, a better solution is available: by relying on blocking system calls to return `EINTR` when interrupted by a signal, we can do the OCaml signal handling outside of the Unix signal handler. (The old BSD systems that couldn't return EINTR are thankfully thin on the ground now).

This patch rewrites the error-handling logic for IO channels in this style, which makes signal handling much more robust. I need to do a lot more testing, but one program whose behaviour improves is this:

```ocaml
let counter = ref 0
let () =
      Sys.set_signal Sys.sigint (Sys.Signal_handle (fun _ ->
        incr counter;
        Printf.printf "\nsignalled %d times\n%!" !counter;
        if Random.int 10 = 0 then Gc.full_major ()));
      while true; do
        print_string "\r";
        flush stdout;
      done
```

This program does allocation, I/O, GC and compaction from a signal handler. (I killed it after handling ~500k signals successfully. Trunk sometimes manages 1).

The biggest code changes are in `io.c`, where code like this:
```c
Lock(chan);
operation_that_might_fail();
Unlock(chan);
```
becomes this:
```c
Lock(chan);
do{
  err = operation_that_might_fail();
} while (check_retry(chan, err));
Unlock(chan);
```
The old `operation_that_might_fail` possibly raises exceptions or invokes signal handlers, but these have to contend with the channel possibly being locked (and possibly being left in an inconsistent state if forcibly unlocked), the signal handler possibly trying to re-enter channel code (and deadlocking if it needs the same lock), or the signal handler causing GC which makes finalisers run under an unknown collection of channel locks.

The new `operation_that_might_fail` returns an error code, and if the error code is nonzero then `check_retry` unlocks the channel, handles the error or signal, and retries the operation (if it was interrupted by a signal). The code is longer, but the error paths are easier to understand.

Some details:

## Low-level I/O

The low-level IO functions `caml_read_fd` and `caml_write_fd` now return an error code instead of raising exceptions, and never run signal handlers themselves (returning `EINTR` if a signal was triggered).

Similarly, there are new functions `caml_try_putblock` and `caml_try_getblock` in `io.h` which return error codes. These low-level operations expect their channel arguments to be locked, but the higher-level operations no longer do (Holding the channel locks across any operation which may allocate, or across `caml_leave_blocking_section`, causes [deadlocks](https://caml.inria.fr/mantis/view.php?id=7503), so explicitly taking those locks is not something most code should do).

## Blocking sections

`caml_enter_blocking_section` no longer runs signal handlers, because this caused a race condition in every IO operation:

```c
CAMLparam1(vchannel);
struct channel * chan = Channel(vchannel);
Lock(chan);
caml_enter_blocking_section();
err = caml_read_fd(fd, &chan->buff, len, &nread);
```

In code like the above, if `caml_enter_blocking_section` runs a signal handler, then if the signal handler uses the same channel a deadlock arises when the signal handler tries to `Lock(chan)`.

I think there is no need for `caml_enter_blocking_section` to run signal handlers: it is not a blocking operation, and it comes at the end of normal OCaml code in which signals were regularly polled.

`caml_leave_blocking_section` still checks for signals, but there is a new version `caml_leave_blocking_section_nosig` which does not, for use in `caml_read_fd` and other low-level IO functions that return explicit `EINTR`.

## Atomicity

I tried to maintain the same atomicity guarantees that currently exist. In particular, `caml_really_{get,put}block` (which may be implemented as multiple calls to `read` / `write` internally) are atomic with respect to systhreads if not interrupted, since they hold the channel lock for the duration of the call.

These functions are *not* atomic if interrupted by a signal. In particular, if a signal handler writes to a channel, the signal handler's output may appear anywhere in the output stream.

## To do

  - [ ] Spacetime support (Spacetime does some slightly complicated things with channel locking)
  - [ ] Windows support
  - [ ] Atomic test-and-clear of caml_pending_signals
  - [ ] Remove the now-unneeded mechanism for unlocking channels on exceptions