### PR TITLE
Manual: fix link to Ast mapper module

### DIFF
--- a/manual/manual/cmds/unified-options.etex
+++ b/manual/manual/cmds/unified-options.etex
@@ -535,8 +535,10 @@ errors, the intermediate file is deleted afterwards.
 \item["-ppx" \var{command}]
 After parsing, pipe the abstract syntax tree through the preprocessor
 \var{command}. The module "Ast_mapper", described in
-chapter~\ref{Ast-underscoremapper}, implements the external interface
-of a preprocessor.
+\ifouthtml
+chapter~\ref{c:parsinglib}: \ahref{libref/Ast\_mapper.html}{ \texttt{Ast_mapper} }
+\else section~\ref{Ast-underscoremapper}\fi,
+implements the external interface of a preprocessor.
 
 \item["-principal"]
 Check information path during type-checking, to make sure that all


### PR DESCRIPTION
This short PR fixes the link to the ast_mapper module in `ocaml{c,opt}` documentation. The reference `ast-underscoremapper` was unresolved in the html version of the manual due to a subtle difference of structure between the latex and html version of the manual: 
in the latex version, the documentation of modules is directly integrated in the manual structure, whereas this documentation is merely linked to in the html version. 

This PR proposes therefore to use an inner reference in the latex version, and  a link in the html version of the manual.