### PR TITLE
Support for xlc and bytecode shared libs on AIX.

### DIFF
--- a/Changes
+++ b/Changes
@@ -87,6 +87,12 @@ Working version
 * GPR#1104: remove support for the NeXTStep platform
   (Sébastien Hinderer)
 
+- PR#1130: enable detection of IBM XL C compiler (one need to run configure
+  with "-cc <path to xlc compiler>"). Enable shared library support for
+  bytecode executables on AIX/xlc (tested on AIX 7.1, XL C 12).
+  To enable 64-bit, run both "configure" and "make world" with OBJECT_MODE=64.
+  (Konstantin Romanov, Enrique Naudon)
+
 ### Internal/compiler-libs changes:
 
 - PR#6826, GPR#828, GPR#834: improve compilation time for open

--- a/config/auto-aux/cckind.c
+++ b/config/auto-aux/cckind.c
@@ -25,6 +25,8 @@ icc __INTEL_COMPILER
 clang __clang_major__ __clang_minor__
 #elif defined(__GNUC__) && defined(__GNUC_MINOR__)
 gcc __GNUC__ __GNUC_MINOR__
+#elif defined(__xlc__) && (__xlC__)
+xlc __xlC__ __xlC_ver__
 #else
 unknown
 #endif

--- a/configure
+++ b/configure
@@ -809,6 +809,16 @@ if $with_sharedlibs; then
       mksharedlibrpath="-Wl,-rpath,"
       natdynlinkopts="-Wl,-E"
       shared_libraries_supported=true;;
+    powerpc-*-aix*)
+      case "$ccfamily" in
+        xlc-*)sharedcccompopts="-qpic"
+              mksharedlib="$cc -qmkshrobj -G"
+              mksharedlibrpath="-Wl,-blibpath,"
+              ldflags="$ldflags -brtl -bexpfull"
+              dl_needs_underscore=false
+              rpath="-Wl,-blibpath,"
+              shared_libraries_supported=true;;
+      esac
   esac
 fi
 


### PR DESCRIPTION
This patch made by KONSTANTIN ROMANOV adds support for xlc (IBM C compiler, used on
Linux and AIX) in cckind.cc and enables shared libraries
support in bytecode compiled programs on AIX.

It was tested on Linux/gcc and AIX7.1/xlc 12. By default
configure script uses gcc compiler, so there should be no
impact on Linux/xlc systems. To use xlc one should run
configure with -cc xlc.
