### PR TITLE
`-dtiming` records heap size and allocated words

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -405,6 +405,7 @@ let read_one_param ppf position name v =
     can_discard := v ::!can_discard
 
   | "timings" -> set "timings" [ print_timings ] v
+  | "live-words" -> set "live-words" [ record_max_live_words ] v
 
   | "plugin" -> !load_plugin v
 

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -118,6 +118,7 @@ module Options = Main_args.Make_bytecomp_options (struct
   let _dlambda = set dump_lambda
   let _dinstr = set dump_instr
   let _dtimings = set print_timings
+  let _dlive_words = set record_max_live_words
 
   let _args = Arg.read_arg
   let _args0 = Arg.read_arg0

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -463,6 +463,10 @@ let mk_dtimings f =
   "-dtimings", Arg.Unit f, " Print timings"
 ;;
 
+let mk_dlive_words f =
+  "-dlive-words", Arg.Unit f, " Print maximal heap size"
+;;
+
 let mk_unbox_closures f =
   "-unbox-closures", Arg.Unit f,
   " Pass free variables via specialised arguments rather than closures"
@@ -843,6 +847,7 @@ module type Compiler_options = sig
 
   val _nopervasives : unit -> unit
   val _dtimings : unit -> unit
+  val _dlive_words : unit -> unit
 
   val _args: string -> string array
   val _args0: string -> string array
@@ -1070,6 +1075,7 @@ struct
     mk_dlambda F._dlambda;
     mk_dinstr F._dinstr;
     mk_dtimings F._dtimings;
+    mk_dlive_words F._dlive_words;
 
     mk_args F._args;
     mk_args0 F._args0;
@@ -1263,6 +1269,7 @@ struct
     mk_dinterval F._dinterval;
     mk_dstartup F._dstartup;
     mk_dtimings F._dtimings;
+    mk_dlive_words F._dlive_words;
     mk_dump_pass F._dump_pass;
 
     mk_args F._args;

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -100,6 +100,7 @@ module type Compiler_options = sig
 
   val _nopervasives : unit -> unit
   val _dtimings : unit -> unit
+  val _dlive_words : unit -> unit
 
   val _args: string -> string array
   val _args0: string -> string array

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -225,6 +225,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _dinterval = set dump_interval
   let _dstartup = set keep_startup_file
   let _dtimings = set print_timings
+  let _dlive_words = set record_max_live_words
   let _opaque = set opaque
 
   let _args = Arg.read_arg

--- a/tools/ocamlcp.ml
+++ b/tools/ocamlcp.ml
@@ -126,6 +126,7 @@ module Options = Main_args.Make_bytecomp_options (struct
   let _dflambda = option "-dflambda"
   let _dinstr = option "-dinstr"
   let _dtimings = option "-dtimings"
+  let _dlive_words = option "-dlive-words"
   let _args = Arg.read_arg
   let _args0 = Arg.read_arg0
   let anonymous = process_file

--- a/tools/ocamloptp.ml
+++ b/tools/ocamloptp.ml
@@ -174,6 +174,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _dstartup = option "-dstartup"
   let _dinterval = option "-dinterval"
   let _dtimings = option "-dtimings"
+  let _dlive_words = option "-dlive-words"
   let _opaque = option "-opaque"
 
   let _args = Arg.read_arg

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -125,6 +125,7 @@ let dump_interval = ref false           (* -dinterval *)
 let keep_startup_file = ref false       (* -dstartup *)
 let dump_combine = ref false            (* -dcombine *)
 let print_timings = ref false           (* -dtimings *)
+let record_max_live_words = ref false   (* -dlive-words *)
 
 let native_code = ref false             (* set to true under ocamlopt *)
 

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -183,6 +183,7 @@ val keep_locs : bool ref
 val unsafe_string : bool ref
 val opaque : bool ref
 val print_timings : bool ref
+val record_max_live_words : bool ref
 val flambda_invariant_checks : bool ref
 val unbox_closures : bool ref
 val unbox_closures_factor : int ref

--- a/utils/timings.ml
+++ b/utils/timings.ml
@@ -22,7 +22,12 @@ type times = { start : float; duration : float }
 type hierarchy =
   | E of (string, info) Hashtbl.t
 [@@unboxed]
-and info = { times : times; minor_words : float; hierarchy : hierarchy }
+and info = {
+    times : times;
+    minor_words : float;
+    max_live_words : int option;
+    hierarchy : hierarchy;
+  }
 
 let hierarchy = ref (E (Hashtbl.create 2))
 let reset () = hierarchy := E (Hashtbl.create 2)
@@ -37,12 +42,27 @@ let time_call ?(accumulate = false) name f =
     then
       match Hashtbl.find prev_hierarchy name with
       | exception Not_found -> None, Hashtbl.create 2
-      | { times; minor_words; hierarchy = E table } ->
+      | { times; minor_words; max_live_words; hierarchy = E table } ->
         Hashtbl.remove prev_hierarchy name;
-        Some (times, minor_words), table
+        Some (times, minor_words, max_live_words), table
     else None, Hashtbl.create 2
   in
   hierarchy := E this_table;
+  let max_live_words = ref None in
+  let alarm =
+    if !Clflags.record_max_live_words then
+      let alarm () =
+        let stat = Gc.stat () in
+        match !max_live_words with
+        | None ->
+          max_live_words := Some stat.Gc.live_words
+        | Some live_words ->
+          max_live_words := Some (max live_words stat.Gc.live_words)
+      in
+      Some (Gc.create_alarm alarm)
+    else
+      None
+  in
   let start = cpu_time () in
   let start_minor_words = Gc.minor_words () in
   Misc.try_finally f
@@ -50,16 +70,27 @@ let time_call ?(accumulate = false) name f =
        hierarchy := E prev_hierarchy;
        let end_minor_words = Gc.minor_words () in
        let end_ = cpu_time () in
-       let times, minor_words =
+       (match alarm with
+        | None -> ()
+        | Some alarm ->
+          Gc.delete_alarm alarm);
+       let times, minor_words, max_live_words =
          match this_times_and_minor_words with
          | None ->
            { start; duration = end_ -. start },
-           end_minor_words -. start_minor_words
-         | Some ({ start = initial_start; duration }, previous_minor_words) ->
+           end_minor_words -. start_minor_words,
+           !max_live_words
+         | Some ({ start = initial_start; duration },
+                 previous_minor_words, max_heap) ->
            { start = initial_start; duration = duration +. end_ -. start },
-           previous_minor_words +. end_minor_words -. start_minor_words
+           previous_minor_words +. end_minor_words -. start_minor_words,
+           match !max_live_words, max_heap with
+           | None, v | v, None -> v
+           | Some max_live_words, Some max_heap ->
+             Some (max max_live_words max_heap)
        in
-       Hashtbl.add prev_hierarchy name { times; minor_words; hierarchy = E this_table })
+       Hashtbl.add prev_hierarchy name
+         { times; minor_words; max_live_words; hierarchy = E this_table })
 
 let time ?accumulate pass f x = time_call ?accumulate pass (fun () -> f x)
 
@@ -81,22 +112,33 @@ let rec print ppf hierarchy ~total:(total_time, total_words) ~nesting =
          max acc (String.length (duration_as_string ~pad:0 times.duration)))
       0 list
   in
-  let print_pass ~duration ~words ~pass =
+  let print_max_live_words ppf = function
+    | None ->
+      if !Clflags.record_max_live_words then
+        Format.fprintf ppf " (/)"
+      else
+        ()
+    | Some max_live_words ->
+      Format.fprintf ppf " %iw" max_live_words
+  in
+  let print_pass ~duration ~words ~max_live_words ~pass =
     let duration_as_string =
       duration_as_string ~pad:max_duration_width duration in
     if float_of_string duration_as_string <> 0. then
-      Format.fprintf ppf "%s%ss %gw %s@\n"
-        (String.make (nesting * 2) ' ') duration_as_string words pass
+      Format.fprintf ppf "%s%ss %gw%a %s@\n"
+        (String.make (nesting * 2) ' ') duration_as_string words
+        print_max_live_words max_live_words pass
   in
   List.iter (fun (pass, info) ->
-    print_pass ~duration:info.times.duration ~words:info.minor_words ~pass;
+    print_pass ~duration:info.times.duration ~words:info.minor_words
+      ~max_live_words:info.max_live_words ~pass;
     print ppf info.hierarchy ~total:(info.times.duration, info.minor_words)
       ~nesting:(nesting + 1);
     total_of_children := !total_of_children +. info.times.duration;
   ) list;
   if list <> [] || nesting = 0 then
     print_pass ~duration:(total_time -. !total_of_children)
-      ~words:total_words ~pass:"other";
+      ~words:total_words ~max_live_words:None ~pass:"other";
 ;;
 
 let print ?(total = (cpu_time (), Gc.minor_words ())) ppf =

--- a/utils/timings.mli
+++ b/utils/timings.mli
@@ -28,7 +28,7 @@ val time_call : ?accumulate:bool -> string -> (unit -> 'a) -> 'a
 val time : ?accumulate:bool -> string -> ('a -> 'b) -> 'a -> 'b
 (** [time pass f arg] records the runtime of [f arg] *)
 
-val print : ?total:float -> Format.formatter -> unit
+val print : ?total:(float * float) -> Format.formatter -> unit
 (** Prints all recorded timings to the formatter. *)
 
 (** A few pass names that are needed in several places, and shared to


### PR DESCRIPTION
As requested in https://caml.inria.fr/mantis/view.php?id=7514 this allows to record the maximal size of the heap of the compiler. As this might be expensive (I didn't really check) it is not enabled by default. It is enabled by either the `-dlive-words` or `live-words=1` in OCAMLPARAM.

The heap size is collected just after major collections. Hence some pass might have any information if no major collection finished while it ran (represented as `(/)`).
```
boot/ocamlrun ./ocamlopt -g -nostdlib -I stdlib -I otherlibs/dynlink -strict-sequence -principal -absname -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -safe-string -strict-formats -I utils -I parsing -I typing -I bytecomp -I middle_end -I middle_end/base_types -I asmcomp -I driver -I toplevel -c typing/typedtreeMap.ml
4.072s 4.24902e+07w 4239046w parsing/pprintast.ml
  0.040s 684962w 413551w parsing
    0.040s 684546w 413551w parser
  2.072s 1.72712e+07w 1744949w typing
  0.232s 2.39243e+06w (/) transl
  1.724s 2.21075e+07w 4239046w generate
    0.084s 1.39545e+06w (/) cmm
    1.212s 1.66458e+07w 3101966w compile_phrases
      0.004s 200111w (/) comballoc
      0.056s 1.02222e+06w (/) cse
      0.028s 463950w (/) deadcode
      0.076s 583066w (/) emit
      0.112s 1.49584e+06w (/) liveness
      0.544s 7.66961e+06w (/) regalloc
      0.100s 1.79462e+06w (/) selection
      0.156s 1.73181e+06w (/) spill
      0.052s 362204w (/) split
      0.084s 1.66458e+07w (/) other
    0.120s 72w (/) assemble
    0.308s 2.21075e+07w (/) other
  0.004s 4.24902e+07w (/) other
0.016s 4.26285e+07w (/) other
```

The printing is not very satisfying. I'm wondering which format would keep that easily parsable while being human readable. @sliquister would you object to numbers with a k/M/G suffix ?