### PR TITLE
Deprecation warning when checking signature inclusion

### DIFF
--- a/.depend
+++ b/.depend
@@ -205,12 +205,10 @@ typing/env.cmi : utils/warnings.cmi typing/types.cmi typing/subst.cmi \
     typing/path.cmi parsing/longident.cmi parsing/location.cmi \
     typing/ident.cmi utils/consistbl.cmi typing/cmi_format.cmi \
     parsing/asttypes.cmi
-typing/envaux.cmo : typing/types.cmi typing/subst.cmi typing/printtyp.cmi \
-    typing/path.cmi utils/misc.cmi typing/ident.cmi typing/env.cmi \
-    parsing/asttypes.cmi typing/envaux.cmi
-typing/envaux.cmx : typing/types.cmx typing/subst.cmx typing/printtyp.cmx \
-    typing/path.cmx utils/misc.cmx typing/ident.cmx typing/env.cmx \
-    parsing/asttypes.cmi typing/envaux.cmi
+typing/envaux.cmo : typing/subst.cmi typing/printtyp.cmi typing/path.cmi \
+    typing/ident.cmi typing/env.cmi parsing/asttypes.cmi typing/envaux.cmi
+typing/envaux.cmx : typing/subst.cmx typing/printtyp.cmx typing/path.cmx \
+    typing/ident.cmx typing/env.cmx parsing/asttypes.cmi typing/envaux.cmi
 typing/envaux.cmi : typing/subst.cmi typing/path.cmi typing/env.cmi
 typing/ident.cmo : utils/identifiable.cmi typing/ident.cmi
 typing/ident.cmx : utils/identifiable.cmx typing/ident.cmi
@@ -233,13 +231,13 @@ typing/includemod.cmo : typing/types.cmi typing/typedtree.cmi utils/tbl.cmi \
     typing/mtype.cmi utils/misc.cmi parsing/location.cmi \
     typing/includecore.cmi typing/includeclass.cmi typing/ident.cmi \
     typing/env.cmi typing/ctype.cmi typing/cmt_format.cmi utils/clflags.cmi \
-    typing/btype.cmi typing/includemod.cmi
+    parsing/builtin_attributes.cmi typing/btype.cmi typing/includemod.cmi
 typing/includemod.cmx : typing/types.cmx typing/typedtree.cmx utils/tbl.cmx \
     typing/subst.cmx typing/printtyp.cmx typing/primitive.cmx typing/path.cmx \
     typing/mtype.cmx utils/misc.cmx parsing/location.cmx \
     typing/includecore.cmx typing/includeclass.cmx typing/ident.cmx \
     typing/env.cmx typing/ctype.cmx typing/cmt_format.cmx utils/clflags.cmx \
-    typing/btype.cmx typing/includemod.cmi
+    parsing/builtin_attributes.cmx typing/btype.cmx typing/includemod.cmi
 typing/includemod.cmi : typing/types.cmi typing/typedtree.cmi \
     typing/path.cmi parsing/location.cmi typing/includecore.cmi \
     typing/ident.cmi typing/env.cmi typing/ctype.cmi
@@ -284,12 +282,12 @@ typing/predef.cmx : typing/types.cmx typing/path.cmx parsing/parsetree.cmi \
     parsing/location.cmx typing/ident.cmx typing/btype.cmx \
     parsing/asttypes.cmi typing/predef.cmi
 typing/predef.cmi : typing/types.cmi typing/path.cmi typing/ident.cmi
-typing/primitive.cmo : utils/warnings.cmi parsing/parsetree.cmi \
-    typing/outcometree.cmi utils/misc.cmi parsing/location.cmi \
-    parsing/attr_helper.cmi typing/primitive.cmi
-typing/primitive.cmx : utils/warnings.cmx parsing/parsetree.cmi \
-    typing/outcometree.cmi utils/misc.cmx parsing/location.cmx \
-    parsing/attr_helper.cmx typing/primitive.cmi
+typing/primitive.cmo : parsing/parsetree.cmi typing/outcometree.cmi \
+    utils/misc.cmi parsing/location.cmi parsing/attr_helper.cmi \
+    typing/primitive.cmi
+typing/primitive.cmx : parsing/parsetree.cmi typing/outcometree.cmi \
+    utils/misc.cmx parsing/location.cmx parsing/attr_helper.cmx \
+    typing/primitive.cmi
 typing/primitive.cmi : parsing/parsetree.cmi typing/outcometree.cmi \
     parsing/location.cmi
 typing/printtyp.cmo : typing/types.cmi typing/primitive.cmi \
@@ -455,20 +453,18 @@ typing/types.cmx : typing/primitive.cmx typing/path.cmx \
 typing/types.cmi : typing/primitive.cmi typing/path.cmi \
     parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
     typing/ident.cmi parsing/asttypes.cmi
-typing/typetexp.cmo : utils/warnings.cmi typing/types.cmi \
-    typing/typedtree.cmi utils/tbl.cmi typing/printtyp.cmi typing/predef.cmi \
-    typing/path.cmi parsing/parsetree.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi typing/env.cmi \
-    typing/ctype.cmi utils/clflags.cmi parsing/builtin_attributes.cmi \
-    typing/btype.cmi parsing/asttypes.cmi parsing/ast_helper.cmi \
-    typing/typetexp.cmi
-typing/typetexp.cmx : utils/warnings.cmx typing/types.cmx \
-    typing/typedtree.cmx utils/tbl.cmx typing/printtyp.cmx typing/predef.cmx \
-    typing/path.cmx parsing/parsetree.cmi utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx typing/env.cmx \
-    typing/ctype.cmx utils/clflags.cmx parsing/builtin_attributes.cmx \
-    typing/btype.cmx parsing/asttypes.cmi parsing/ast_helper.cmx \
-    typing/typetexp.cmi
+typing/typetexp.cmo : typing/types.cmi typing/typedtree.cmi utils/tbl.cmi \
+    typing/printtyp.cmi typing/predef.cmi typing/path.cmi \
+    parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
+    parsing/location.cmi typing/env.cmi typing/ctype.cmi utils/clflags.cmi \
+    parsing/builtin_attributes.cmi typing/btype.cmi parsing/asttypes.cmi \
+    parsing/ast_helper.cmi typing/typetexp.cmi
+typing/typetexp.cmx : typing/types.cmx typing/typedtree.cmx utils/tbl.cmx \
+    typing/printtyp.cmx typing/predef.cmx typing/path.cmx \
+    parsing/parsetree.cmi utils/misc.cmx parsing/longident.cmx \
+    parsing/location.cmx typing/env.cmx typing/ctype.cmx utils/clflags.cmx \
+    parsing/builtin_attributes.cmx typing/btype.cmx parsing/asttypes.cmi \
+    parsing/ast_helper.cmx typing/typetexp.cmi
 typing/typetexp.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
     parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
     typing/env.cmi parsing/asttypes.cmi

--- a/Changes
+++ b/Changes
@@ -48,7 +48,7 @@ Working version
 
 - MPR#7444, GPR#1138: trigger deprecation warning when a "deprecated"
   attribute is hidden by signature coercion
-  (Alain Frisch, report by bmillwood)
+  (Alain Frisch, report by bmillwood, review by Leo White)
 
 ### Manual and documentation:
 

--- a/Changes
+++ b/Changes
@@ -46,6 +46,10 @@ Working version
   a trailing "Error: Some fatal warnings were triggered" message.
   (Valentin Gatien-Baron, review by Alain Frisch)
 
+- MPR#7444, GPR#1138: trigger deprecation warning when a "deprecated"
+  attribute is hidden by signature coercion
+  (Alain Frisch, report by bmillwood)
+
 ### Manual and documentation:
 
 - PR#6676, GPR#1110: move record notation to tutorial

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -66,9 +66,16 @@ let rec deprecated_of_attrs = function
 let check_deprecated loc attrs s =
   match deprecated_of_attrs attrs with
   | None -> ()
-  | Some "" -> Location.prerr_warning loc (Warnings.Deprecated s)
-  | Some txt ->
-      Location.prerr_warning loc (Warnings.Deprecated (s ^ "\n" ^ txt))
+  | Some "" -> Location.deprecated loc s
+  | Some txt -> Location.deprecated loc (s ^ "\n" ^ txt)
+
+let check_deprecated_inclusion ~def ~use loc attrs1 attrs2 s =
+  match deprecated_of_attrs attrs1, deprecated_of_attrs attrs2 with
+  | None, _ | Some _, Some _ -> ()
+  | Some "", None ->
+      Location.deprecated ~def ~use loc s
+  | Some txt, None ->
+      Location.deprecated ~def ~use loc (s ^ "\n" ^ txt)
 
 let rec check_deprecated_mutable loc attrs s =
   match attrs with
@@ -79,9 +86,7 @@ let rec check_deprecated_mutable loc attrs s =
         | Some txt -> "\n" ^ txt
         | None -> ""
       in
-      Location.prerr_warning loc
-        (Warnings.Deprecated (Printf.sprintf "mutating field %s%s"
-           s txt))
+      Location.deprecated loc (Printf.sprintf "mutating field %s%s" s txt)
   | _ :: tl -> check_deprecated_mutable loc tl s
 
 let rec deprecated_of_sig = function

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -38,6 +38,9 @@ val deprecated_of_str: Parsetree.structure -> string option
 
 val check_deprecated_mutable:
     Location.t -> Parsetree.attributes -> string -> unit
+val check_deprecated_mutable_inclusion:
+  def:Location.t -> use:Location.t -> Location.t -> Parsetree.attributes ->
+  Parsetree.attributes -> string -> unit
 
 val error_of_extension: Parsetree.extension -> Location.error
 

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -29,6 +29,9 @@
 
 
 val check_deprecated: Location.t -> Parsetree.attributes -> string -> unit
+val check_deprecated_inclusion:
+  def:Location.t -> use:Location.t -> Location.t -> Parsetree.attributes ->
+  Parsetree.attributes -> string -> unit
 val deprecated_of_attrs: Parsetree.attributes -> string option
 val deprecated_of_sig: Parsetree.signature -> string option
 val deprecated_of_str: Parsetree.structure -> string option

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -222,9 +222,7 @@ let escaped_newlines = ref false
 (* Warn about Latin-1 characters used in idents *)
 
 let warn_latin1 lexbuf =
-  Location.prerr_warning (Location.curr lexbuf)
-    (Warnings.Deprecated "ISO-Latin1 characters in identifiers")
-;;
+  Location.deprecated (Location.curr lexbuf)"ISO-Latin1 characters in identifiers"
 
 let handle_docstrings = ref true
 let comment_list = ref []

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -17,7 +17,7 @@
 
 open Format
 
-type t = {
+type t = Warnings.loc = {
   loc_start: Lexing.position;
   loc_end: Lexing.position;
   loc_ghost: bool;
@@ -140,3 +140,5 @@ val default_error_reporter : formatter -> error -> unit
 
 val report_exception: formatter -> exn -> unit
 (** Reraise the exception if it is unknown. *)
+
+val deprecated: ?def:t -> ?use:t -> t -> string -> unit

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -56,7 +56,7 @@ val init : int -> f:(int -> char) -> string
    Raise [Invalid_argument] if [n < 0] or [n > ]{!Sys.max_string_length}.
    @since 4.02.0 *)
 
-val copy : string -> string
+val copy : string -> string  [@@ocaml.deprecated]
 (** Return a copy of the given string. *)
 
 val sub : string -> pos:int -> len:int -> string

--- a/testsuite/tests/warnings/deprecated_module_assigment.ml
+++ b/testsuite/tests/warnings/deprecated_module_assigment.ml
@@ -6,6 +6,8 @@ end
 
 module Y : sig val x : int end = X
 
+module Z : sig val x : int [@@deprecated "..."] end = X
+
 module F(A : sig val x : int end) = struct end
 
 module B = F(X)

--- a/testsuite/tests/warnings/deprecated_module_assigment.ml
+++ b/testsuite/tests/warnings/deprecated_module_assigment.ml
@@ -1,0 +1,11 @@
+module X : sig
+  val x : int [@@deprecated "DEPRECATED"]
+end = struct
+  let x = 7
+end
+
+module Y : sig val x : int end = X
+
+module F(A : sig val x : int end) = struct end
+
+module B = F(X)

--- a/testsuite/tests/warnings/deprecated_module_assigment.ml
+++ b/testsuite/tests/warnings/deprecated_module_assigment.ml
@@ -1,3 +1,5 @@
+(* Values *)
+
 module X : sig
   val x : int [@@deprecated "DEPRECATED"]
 end = struct
@@ -16,3 +18,61 @@ module B = F(X)
 
 module XX = struct let x = 7 end
 module YY : sig val x : int [@@deprecated "..."] end = XX
+
+
+(* Constructors *)
+
+module CSTR : sig type t = A | B end = struct type t = A [@deprecated] | B end
+
+module CSTR1 = struct
+  type t = A [@deprecated] | B
+  type s = t = A | B
+end
+
+
+(* Fields *)
+
+module FIELD :
+sig type t = {mutable x: int} end =
+struct type t = {mutable x: int [@deprecated_mutable]} end
+
+module FIELD1 = struct
+  type t = {mutable x: int [@deprecated_mutable]}
+  type s = t = {mutable x: int}
+end
+
+(* Types *)
+
+module TYPE : sig type t = int end = struct type t = int [@@deprecated] end
+
+(* Class, class types *)
+
+module CL :
+sig class c : object end end =
+struct class c = object end [@@deprecated "FOO"] end
+
+module CLT :
+sig class type c = object end end =
+struct class type c = object end [@@deprecated "FOO"] end
+
+
+(* Module types *)
+
+module MT :
+sig module type S = sig end end =
+struct module type S = sig end [@@deprecated "FOO"] end
+
+module MT_OK :
+sig module type S = sig end [@@deprecated] end =
+struct module type S = sig end [@@deprecated "FOO"] end
+
+
+(* Modules *)
+
+module MD :
+sig module M : sig end end =
+struct module M = struct end [@@deprecated "FOO"] end
+
+module MD_OK :
+sig module M : sig end [@@deprecated] end =
+struct module M = struct end [@@deprecated "FOO"] end

--- a/testsuite/tests/warnings/deprecated_module_assigment.ml
+++ b/testsuite/tests/warnings/deprecated_module_assigment.ml
@@ -11,3 +11,8 @@ module Z : sig val x : int [@@deprecated "..."] end = X
 module F(A : sig val x : int end) = struct end
 
 module B = F(X)
+
+
+
+module XX = struct let x = 7 end
+module YY : sig val x : int [@@deprecated "..."] end = XX

--- a/testsuite/tests/warnings/deprecated_module_assigment.reference
+++ b/testsuite/tests/warnings/deprecated_module_assigment.reference
@@ -1,14 +1,72 @@
-File "deprecated_module_assigment.ml", line 7, characters 33-34:
+File "deprecated_module_assigment.ml", line 9, characters 33-34:
 Warning 3: deprecated: x
 DEPRECATED
-  File "deprecated_module_assigment.ml", line 2, characters 2-41:
+  File "deprecated_module_assigment.ml", line 4, characters 2-41:
   Definition
-  File "deprecated_module_assigment.ml", line 7, characters 15-26:
+  File "deprecated_module_assigment.ml", line 9, characters 15-26:
   Expected signature
-File "deprecated_module_assigment.ml", line 13, characters 13-14:
+File "deprecated_module_assigment.ml", line 15, characters 13-14:
 Warning 3: deprecated: x
 DEPRECATED
-  File "deprecated_module_assigment.ml", line 2, characters 2-41:
+  File "deprecated_module_assigment.ml", line 4, characters 2-41:
   Definition
-  File "deprecated_module_assigment.ml", line 11, characters 17-28:
+  File "deprecated_module_assigment.ml", line 13, characters 17-28:
+  Expected signature
+File "deprecated_module_assigment.ml", line 25, characters 39-78:
+Warning 3: deprecated: A
+  File "deprecated_module_assigment.ml", line 25, characters 55-70:
+  Definition
+  File "deprecated_module_assigment.ml", line 25, characters 27-28:
+  Expected signature
+File "deprecated_module_assigment.ml", line 29, characters 2-20:
+Warning 3: deprecated: A
+  File "deprecated_module_assigment.ml", line 28, characters 11-26:
+  Definition
+  File "deprecated_module_assigment.ml", line 29, characters 15-16:
+  Expected signature
+File "deprecated_module_assigment.ml", line 37, characters 0-58:
+Warning 3: deprecated: mutating field x
+  File "deprecated_module_assigment.ml", line 37, characters 17-53:
+  Definition
+  File "deprecated_module_assigment.ml", line 36, characters 14-28:
+  Expected signature
+File "deprecated_module_assigment.ml", line 41, characters 2-31:
+Warning 3: deprecated: mutating field x
+  File "deprecated_module_assigment.ml", line 40, characters 12-48:
+  Definition
+  File "deprecated_module_assigment.ml", line 41, characters 16-30:
+  Expected signature
+File "deprecated_module_assigment.ml", line 46, characters 37-75:
+Warning 3: deprecated: t
+  File "deprecated_module_assigment.ml", line 46, characters 44-71:
+  Definition
+  File "deprecated_module_assigment.ml", line 46, characters 18-30:
+  Expected signature
+File "deprecated_module_assigment.ml", line 52, characters 0-52:
+Warning 3: deprecated: c
+FOO
+  File "deprecated_module_assigment.ml", line 52, characters 7-48:
+  Definition
+  File "deprecated_module_assigment.ml", line 51, characters 4-24:
+  Expected signature
+File "deprecated_module_assigment.ml", line 56, characters 0-57:
+Warning 3: deprecated: c
+FOO
+  File "deprecated_module_assigment.ml", line 56, characters 7-53:
+  Definition
+  File "deprecated_module_assigment.ml", line 55, characters 4-29:
+  Expected signature
+File "deprecated_module_assigment.ml", line 63, characters 0-55:
+Warning 3: deprecated: S
+FOO
+  File "deprecated_module_assigment.ml", line 63, characters 7-51:
+  Definition
+  File "deprecated_module_assigment.ml", line 62, characters 4-27:
+  Expected signature
+File "deprecated_module_assigment.ml", line 74, characters 0-53:
+Warning 3: deprecated: M
+FOO
+  File "deprecated_module_assigment.ml", line 74, characters 7-49:
+  Definition
+  File "deprecated_module_assigment.ml", line 73, characters 4-22:
   Expected signature

--- a/testsuite/tests/warnings/deprecated_module_assigment.reference
+++ b/testsuite/tests/warnings/deprecated_module_assigment.reference
@@ -5,10 +5,10 @@ DEPRECATED
   Definition
   File "deprecated_module_assigment.ml", line 7, characters 15-26:
   Expected signature
-File "deprecated_module_assigment.ml", line 11, characters 13-14:
+File "deprecated_module_assigment.ml", line 13, characters 13-14:
 Warning 3: deprecated: x
 DEPRECATED
   File "deprecated_module_assigment.ml", line 2, characters 2-41:
   Definition
-  File "deprecated_module_assigment.ml", line 9, characters 17-28:
+  File "deprecated_module_assigment.ml", line 11, characters 17-28:
   Expected signature

--- a/testsuite/tests/warnings/deprecated_module_assigment.reference
+++ b/testsuite/tests/warnings/deprecated_module_assigment.reference
@@ -1,0 +1,14 @@
+File "deprecated_module_assigment.ml", line 7, characters 33-34:
+Warning 3: deprecated: x
+DEPRECATED
+  File "deprecated_module_assigment.ml", line 2, characters 2-41:
+  Definition
+  File "deprecated_module_assigment.ml", line 7, characters 15-26:
+  Expected signature
+File "deprecated_module_assigment.ml", line 11, characters 13-14:
+Warning 3: deprecated: x
+DEPRECATED
+  File "deprecated_module_assigment.ml", line 2, characters 2-41:
+  Definition
+  File "deprecated_module_assigment.ml", line 9, characters 17-28:
+  Expected signature

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1059,7 +1059,8 @@ let rec lookup_module_descr_aux ?loc lid env =
       let {md_type=mty2} = find_module p2 env in
       begin match get_components desc1 with
         Functor_comps f ->
-          Misc.may (!check_modtype_inclusion ~loc:(match loc with Some l -> l | None -> Location.none) env mty2 p2) f.fcomp_arg;
+          let loc = match loc with Some l -> l | None -> Location.none in
+          Misc.may (!check_modtype_inclusion ~loc env mty2 p2) f.fcomp_arg;
           (Papply(p1, p2), !components_of_functor_appl' f env p1 p2)
       | Structure_comps _ ->
           raise Not_found
@@ -1123,7 +1124,8 @@ and lookup_module ~load ?loc lid env : Path.t =
       let p = Papply(p1, p2) in
       begin match get_components desc1 with
         Functor_comps f ->
-          Misc.may (!check_modtype_inclusion ~loc:(match loc with Some l -> l | None -> Location.none) env mty2 p2) f.fcomp_arg;
+          let loc = match loc with Some l -> l | None -> Location.none in
+          Misc.may (!check_modtype_inclusion ~loc env mty2 p2) f.fcomp_arg;
           p
       | Structure_comps _ ->
           raise Not_found

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -538,8 +538,8 @@ let components_of_functor_appl' =
           functor_components -> t -> Path.t -> Path.t -> module_components)
 let check_modtype_inclusion =
   (* to be filled with Includemod.check_modtype_inclusion *)
-  ref ((fun _env _mty1 _path1 _mty2 -> assert false) :
-          t -> module_type -> Path.t -> module_type -> unit)
+  ref ((fun ~loc:_ _env _mty1 _path1 _mty2 -> assert false) :
+          loc:Location.t -> t -> module_type -> Path.t -> module_type -> unit)
 let strengthen =
   (* to be filled with Mtype.strengthen *)
   ref ((fun ~aliasable:_ _env _mty _path -> assert false) :
@@ -1026,9 +1026,7 @@ let report_deprecated ?loc p deprecated =
   match loc, deprecated with
   | Some loc, Some txt ->
       let txt = if txt = "" then "" else "\n" ^ txt in
-      Location.prerr_warning loc
-        (Warnings.Deprecated (Printf.sprintf "module %s%s"
-                                (Path.name p) txt))
+      Location.deprecated loc (Printf.sprintf "module %s%s" (Path.name p) txt)
   | _ -> ()
 
 let mark_module_used env name loc =
@@ -1061,7 +1059,7 @@ let rec lookup_module_descr_aux ?loc lid env =
       let {md_type=mty2} = find_module p2 env in
       begin match get_components desc1 with
         Functor_comps f ->
-          Misc.may (!check_modtype_inclusion env mty2 p2) f.fcomp_arg;
+          Misc.may (!check_modtype_inclusion ~loc:(match loc with Some l -> l | None -> Location.none) env mty2 p2) f.fcomp_arg;
           (Papply(p1, p2), !components_of_functor_appl' f env p1 p2)
       | Structure_comps _ ->
           raise Not_found
@@ -1125,7 +1123,7 @@ and lookup_module ~load ?loc lid env : Path.t =
       let p = Papply(p1, p2) in
       begin match get_components desc1 with
         Functor_comps f ->
-          Misc.may (!check_modtype_inclusion env mty2 p2) f.fcomp_arg;
+          Misc.may (!check_modtype_inclusion ~loc:(match loc with Some l -> l | None -> Location.none) env mty2 p2) f.fcomp_arg;
           p
       | Structure_comps _ ->
           raise Not_found

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -268,7 +268,7 @@ val set_type_used_callback:
 
 (* Forward declaration to break mutual recursion with Includemod. *)
 val check_modtype_inclusion:
-      (t -> module_type -> Path.t -> module_type -> unit) ref
+      (loc:Location.t -> t -> module_type -> Path.t -> module_type -> unit) ref
 (* Forward declaration to break mutual recursion with Typecore. *)
 val add_delayed_check_forward: ((unit -> unit) -> unit) ref
 (* Forward declaration to break mutual recursion with Mtype. *)

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -27,7 +27,6 @@ let class_type_declarations ~loc env cty1 cty2 =
     loc
     cty1.clty_attributes cty2.clty_attributes
     (Path.last cty1.clty_path);
-
   Ctype.match_class_declarations env
     cty1.clty_params cty1.clty_type
     cty2.clty_params cty2.clty_type

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -20,12 +20,26 @@ open Types
 let class_types env cty1 cty2 =
   Ctype.match_class_types env cty1 cty2
 
-let class_type_declarations env cty1 cty2 =
+let class_type_declarations ~loc env cty1 cty2 =
+  Builtin_attributes.check_deprecated_inclusion
+    ~def:cty1.clty_loc
+    ~use:cty2.clty_loc
+    loc
+    cty1.clty_attributes cty2.clty_attributes
+    (Path.last cty1.clty_path);
+
   Ctype.match_class_declarations env
     cty1.clty_params cty1.clty_type
     cty2.clty_params cty2.clty_type
 
-let class_declarations env cty1 cty2 =
+let class_declarations ~loc env cty1 cty2 =
+  Builtin_attributes.check_deprecated_inclusion
+    ~def:cty1.cty_loc
+    ~use:cty2.cty_loc
+    loc
+    cty1.cty_attributes cty2.cty_attributes
+    (Path.last cty1.cty_path);
+
   match cty1.cty_new, cty2.cty_new with
     None, Some _ ->
       [Ctype.CM_Virtual_class]

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -32,14 +32,7 @@ let class_type_declarations ~loc env cty1 cty2 =
     cty1.clty_params cty1.clty_type
     cty2.clty_params cty2.clty_type
 
-let class_declarations ~loc env cty1 cty2 =
-  Builtin_attributes.check_deprecated_inclusion
-    ~def:cty1.cty_loc
-    ~use:cty2.cty_loc
-    loc
-    cty1.cty_attributes cty2.cty_attributes
-    (Path.last cty1.cty_path);
-
+let class_declarations env cty1 cty2 =
   match cty1.cty_new, cty2.cty_new with
     None, Some _ ->
       [Ctype.CM_Virtual_class]

--- a/typing/includeclass.mli
+++ b/typing/includeclass.mli
@@ -26,7 +26,6 @@ val class_type_declarations:
   Env.t -> class_type_declaration -> class_type_declaration ->
   class_match_failure list
 val class_declarations:
-  loc:Location.t ->
   Env.t -> class_declaration -> class_declaration ->
   class_match_failure list
 

--- a/typing/includeclass.mli
+++ b/typing/includeclass.mli
@@ -22,10 +22,12 @@ open Format
 val class_types:
         Env.t -> class_type -> class_type -> class_match_failure list
 val class_type_declarations:
-        Env.t -> class_type_declaration -> class_type_declaration ->
-        class_match_failure list
+  loc:Location.t ->
+  Env.t -> class_type_declaration -> class_type_declaration ->
+  class_match_failure list
 val class_declarations:
-        Env.t -> class_declaration -> class_declaration ->
-        class_match_failure list
+  loc:Location.t ->
+  Env.t -> class_declaration -> class_declaration ->
+  class_match_failure list
 
 val report_error: formatter -> class_match_failure list -> unit

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -175,7 +175,7 @@ let report_type_mismatch first second decl ppf =
       if err = Manifest then () else
       Format.fprintf ppf "@ %a." (report_type_mismatch0 first second decl) err)
 
-let rec compare_constructor_arguments env cstr params1 params2 arg1 arg2 =
+let rec compare_constructor_arguments ~loc env cstr params1 params2 arg1 arg2 =
   match arg1, arg2 with
   | Types.Cstr_tuple arg1, Types.Cstr_tuple arg2 ->
       if List.length arg1 <> List.length arg2 then [Field_arity cstr]
@@ -184,7 +184,7 @@ let rec compare_constructor_arguments env cstr params1 params2 arg1 arg2 =
         Ctype.equal env true (params1 @ arg1) (params2 @ arg2)
       then [] else [Field_type cstr]
   | Types.Cstr_record l1, Types.Cstr_record l2 ->
-      compare_records env params1 params2 0 l1 l2
+      compare_records env ~loc params1 params2 0 l1 l2
   | _ -> [Field_type cstr]
 
 and compare_variants ~loc env params1 params2 n
@@ -209,13 +209,13 @@ and compare_variants ~loc env params1 params2 n
           match cd1.cd_res, cd2.cd_res with
           | Some r1, Some r2 ->
               if Ctype.equal env true [r1] [r2] then
-                compare_constructor_arguments env cd1.cd_id [r1] [r2]
+                compare_constructor_arguments ~loc env cd1.cd_id [r1] [r2]
                   cd1.cd_args cd2.cd_args
               else [Field_type cd1.cd_id]
           | Some _, None | None, Some _ ->
               [Field_type cd1.cd_id]
           | _ ->
-              compare_constructor_arguments env cd1.cd_id
+              compare_constructor_arguments ~loc env cd1.cd_id
                 params1 params2 cd1.cd_args cd2.cd_args
         in
         if r <> [] then r
@@ -223,21 +223,33 @@ and compare_variants ~loc env params1 params2 n
       end
 
 
-and compare_records env params1 params2 n labels1 labels2 =
+and compare_records ~loc env params1 params2 n
+    (labels1 : Types.label_declaration list)
+    (labels2 : Types.label_declaration list) =
   match labels1, labels2 with
     [], []           -> []
   | [], l::_ -> [Field_missing (true, l.Types.ld_id)]
   | l::_, [] -> [Field_missing (false, l.Types.ld_id)]
-  | {Types.ld_id=lab1; ld_mutable=mut1; ld_type=arg1}::rem1,
-    {Types.ld_id=lab2; ld_mutable=mut2; ld_type=arg2}::rem2 ->
-      if Ident.name lab1 <> Ident.name lab2
-      then [Field_names (n, lab1, lab2)]
-      else if mut1 <> mut2 then [Field_mutable lab1] else
-      if Ctype.equal env true (arg1::params1)
-                              (arg2::params2)
-      then (* add arguments to the parameters, cf. PR#7378 *)
-        compare_records env (arg1::params1) (arg2::params2) (n+1) rem1 rem2
-      else [Field_type lab1]
+  | ld1::rem1, ld2::rem2 ->
+      if Ident.name ld1.ld_id <> Ident.name ld2.ld_id
+      then [Field_names (n, ld1.ld_id, ld2.ld_id)]
+      else if ld1.ld_mutable <> ld2.ld_mutable then [Field_mutable ld1.ld_id] else begin
+        Builtin_attributes.check_deprecated_mutable_inclusion
+          ~def:ld1.ld_loc
+          ~use:ld2.ld_loc
+          loc
+          ld1.ld_attributes ld2.ld_attributes
+          (Ident.name ld1.ld_id);
+
+        if Ctype.equal env true (ld1.ld_type::params1)(ld2.ld_type::params2)
+        then (* add arguments to the parameters, cf. PR#7378 *)
+          compare_records ~loc env
+            (ld1.ld_type::params1) (ld2.ld_type::params2)
+            (n+1)
+            rem1 rem2
+        else
+          [Field_type ld1.ld_id]
+      end
 
 let type_declarations ?(equality = false) ~loc env name decl1 id decl2 =
   if decl1.type_arity <> decl2.type_arity then [Arity] else
@@ -287,7 +299,7 @@ let type_declarations ?(equality = false) ~loc env name decl1 id decl2 =
         if equality then mark cstrs2 Env.Positive (Ident.name id) decl2;
         compare_variants ~loc env decl1.type_params decl2.type_params 1 cstrs1 cstrs2
     | (Type_record(labels1,rep1), Type_record(labels2,rep2)) ->
-        let err = compare_records env decl1.type_params decl2.type_params
+        let err = compare_records ~loc env decl1.type_params decl2.type_params
             1 labels1 labels2 in
         if err <> [] || rep1 = rep2 then err else
         [Record_representation (rep2 = Record_float)]
@@ -327,7 +339,7 @@ let type_declarations ?(equality = false) ~loc env name decl1 id decl2 =
 
 (* Inclusion between extension constructors *)
 
-let extension_constructors env id ext1 ext2 =
+let extension_constructors ~loc env id ext1 ext2 =
   let usage =
     if ext1.ext_private = Private || ext2.ext_private = Public
     then Env.Positive else Env.Privatize
@@ -343,7 +355,7 @@ let extension_constructors env id ext1 ext2 =
        (ty1 :: ext1.ext_type_params)
        (ty2 :: ext2.ext_type_params)
   then
-    if compare_constructor_arguments env (Ident.create "")
+    if compare_constructor_arguments ~loc env (Ident.create "")
         ext1.ext_type_params ext2.ext_type_params
         ext1.ext_args ext2.ext_args = [] then
       if match ext1.ext_ret_type, ext2.ext_ret_type with

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -252,6 +252,13 @@ and compare_records ~loc env params1 params2 n
       end
 
 let type_declarations ?(equality = false) ~loc env name decl1 id decl2 =
+  Builtin_attributes.check_deprecated_inclusion
+    ~def:decl1.type_loc
+    ~use:decl2.type_loc
+    loc
+    decl1.type_attributes decl2.type_attributes
+    name;
+
   if decl1.type_arity <> decl2.type_arity then [Arity] else
   if not (private_flags decl1 decl2) then [Privacy] else
   let err = match (decl1.type_manifest, decl2.type_manifest) with

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -204,7 +204,6 @@ and compare_variants ~loc env params1 params2 n
           loc
           cd1.cd_attributes cd2.cd_attributes
           (Ident.name cd1.cd_id);
-
         let r =
           match cd1.cd_res, cd2.cd_res with
           | Some r1, Some r2 ->
@@ -240,7 +239,6 @@ and compare_records ~loc env params1 params2 n
           loc
           ld1.ld_attributes ld2.ld_attributes
           (Ident.name ld1.ld_id);
-
         if Ctype.equal env true (ld1.ld_type::params1)(ld2.ld_type::params2)
         then (* add arguments to the parameters, cf. PR#7378 *)
           compare_records ~loc env
@@ -258,7 +256,6 @@ let type_declarations ?(equality = false) ~loc env name decl1 id decl2 =
     loc
     decl1.type_attributes decl2.type_attributes
     name;
-
   if decl1.type_arity <> decl2.type_arity then [Arity] else
   if not (private_flags decl1 decl2) then [Privacy] else
   let err = match (decl1.type_manifest, decl2.type_manifest) with

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -24,7 +24,15 @@ open Typedtree
 
 exception Dont_match
 
-let value_descriptions env vd1 vd2 =
+let value_descriptions ~loc env name
+    (vd1 : Types.value_description)
+    (vd2 : Types.value_description) =
+  Builtin_attributes.check_deprecated_inclusion
+    ~def:vd1.val_loc
+    ~use:vd2.val_loc
+    loc
+    vd1.val_attributes vd2.val_attributes
+    name;
   if Ctype.moregeneral env true vd1.val_type vd2.val_type then begin
     match (vd1.val_kind, vd2.val_kind) with
         (Val_prim p1, Val_prim p2) ->

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -41,9 +41,11 @@ val value_descriptions:
   value_description -> value_description -> module_coercion
 
 val type_declarations:
-    ?equality:bool ->
-      Env.t -> string ->
-        type_declaration -> Ident.t -> type_declaration -> type_mismatch list
+  ?equality:bool ->
+  loc:Location.t ->
+  Env.t -> string ->
+  type_declaration -> Ident.t -> type_declaration -> type_mismatch list
+
 val extension_constructors:
     Env.t -> Ident.t -> extension_constructor -> extension_constructor -> bool
 (*

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -37,7 +37,9 @@ type type_mismatch =
   | Immediate
 
 val value_descriptions:
-    Env.t -> value_description -> value_description -> module_coercion
+  loc:Location.t -> Env.t -> string ->
+  value_description -> value_description -> module_coercion
+
 val type_declarations:
     ?equality:bool ->
       Env.t -> string ->

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -47,7 +47,9 @@ val type_declarations:
   type_declaration -> Ident.t -> type_declaration -> type_mismatch list
 
 val extension_constructors:
-    Env.t -> Ident.t -> extension_constructor -> extension_constructor -> bool
+  loc:Location.t ->
+  Env.t -> Ident.t ->
+  extension_constructor -> extension_constructor -> bool
 (*
 val class_types:
         Env.t -> class_type -> class_type -> bool

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -75,9 +75,9 @@ let type_declarations ~loc env ?(old_env=env) cxt subst id decl1 decl2 =
 
 (* Inclusion between extension constructors *)
 
-let extension_constructors env cxt subst id ext1 ext2 =
+let extension_constructors ~loc env cxt subst id ext1 ext2 =
   let ext2 = Subst.extension_constructor subst ext2 in
-  if Includecore.extension_constructors env id ext1 ext2
+  if Includecore.extension_constructors ~loc env id ext1 ext2
   then ()
   else raise(Error[cxt, env, Extension_constructors(id, ext1, ext2)])
 
@@ -408,7 +408,7 @@ and signature_components ~loc old_env env cxt subst paired =
       comps_rec rem
   | (Sig_typext(id1, ext1, _), Sig_typext(_id2, ext2, _), pos)
     :: rem ->
-      extension_constructors env cxt subst id1 ext1 ext2;
+      extension_constructors ~loc env cxt subst id1 ext1 ext2;
       (pos, Tcoerce_none) :: comps_rec rem
   | (Sig_module(id1, mty1, _), Sig_module(_id2, mty2, _), pos) :: rem ->
       let p1 = Pident id1 in

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -53,10 +53,16 @@ exception Error of error list
 
 (* Inclusion between value descriptions *)
 
-let value_descriptions env cxt subst id vd1 vd2 =
+let value_descriptions ~loc env cxt subst id vd1 vd2 =
   Cmt_format.record_value_dependency vd1 vd2;
   Env.mark_value_used env (Ident.name id) vd1;
   let vd2 = Subst.value_description subst vd2 in
+  Builtin_attributes.check_deprecated_inclusion
+    ~def:vd1.val_loc
+    ~use:vd2.val_loc
+    loc
+    vd1.val_attributes vd2.val_attributes
+    (Ident.name id);
   try
     Includecore.value_descriptions env vd1 vd2
   with Includecore.Dont_match ->
@@ -211,9 +217,9 @@ let simplify_structure_coercion cc id_pos_list =
    Return the restriction that transforms a value of the smaller type
    into a value of the bigger type. *)
 
-let rec modtypes env cxt subst mty1 mty2 =
+let rec modtypes ~loc env cxt subst mty1 mty2 =
   try
-    try_modtypes env cxt subst mty1 mty2
+    try_modtypes ~loc env cxt subst mty1 mty2
   with
     Dont_match ->
       raise(Error[cxt, env, Module_types(mty1, Subst.modtype subst mty2)])
@@ -225,7 +231,7 @@ let rec modtypes env cxt subst mty1 mty2 =
           raise(Error((cxt, env, Module_types(mty1, Subst.modtype subst mty2))
                       :: reasons))
 
-and try_modtypes env cxt subst mty1 mty2 =
+and try_modtypes ~loc env cxt subst mty1 mty2 =
   match (mty1, mty2) with
   | (Mty_alias(pres1, p1), Mty_alias(pres2, p2)) -> begin
       if Env.is_functor_arg p2 env then
@@ -259,28 +265,28 @@ and try_modtypes env cxt subst mty1 mty2 =
         Mtype.strengthen ~aliasable:true env
           (expand_module_alias env cxt p1) p1
       in
-      let cc = modtypes env cxt subst mty1 mty2 in
+      let cc = modtypes ~loc env cxt subst mty1 mty2 in
       match pres1 with
       | Mta_present -> cc
       | Mta_absent -> Tcoerce_alias (p1, cc)
     end
   | (Mty_ident p1, _) when may_expand_module_path env p1 ->
-      try_modtypes env cxt subst (expand_module_path env cxt p1) mty2
+      try_modtypes ~loc env cxt subst (expand_module_path env cxt p1) mty2
   | (_, Mty_ident _) ->
-      try_modtypes2 env cxt mty1 (Subst.modtype subst mty2)
+      try_modtypes2 ~loc env cxt mty1 (Subst.modtype subst mty2)
   | (Mty_signature sig1, Mty_signature sig2) ->
-      signatures env cxt subst sig1 sig2
+      signatures ~loc env cxt subst sig1 sig2
   | (Mty_functor(param1, None, res1), Mty_functor(_param2, None, res2)) ->
-      begin match modtypes env (Body param1::cxt) subst res1 res2 with
+      begin match modtypes ~loc env (Body param1::cxt) subst res1 res2 with
         Tcoerce_none -> Tcoerce_none
       | cc -> Tcoerce_functor (Tcoerce_none, cc)
       end
   | (Mty_functor(param1, Some arg1, res1),
      Mty_functor(param2, Some arg2, res2)) ->
       let arg2' = Subst.modtype subst arg2 in
-      let cc_arg = modtypes env (Arg param1::cxt) Subst.identity arg2' arg1 in
+      let cc_arg = modtypes ~loc env (Arg param1::cxt) Subst.identity arg2' arg1 in
       let cc_res =
-        modtypes (Env.add_module param1 arg2' env) (Body param1::cxt)
+        modtypes ~loc (Env.add_module param1 arg2' env) (Body param1::cxt)
           (Subst.add_module param2 (Pident param1) subst) res1 res2 in
       begin match (cc_arg, cc_res) with
           (Tcoerce_none, Tcoerce_none) -> Tcoerce_none
@@ -289,7 +295,7 @@ and try_modtypes env cxt subst mty1 mty2 =
   | (_, _) ->
       raise Dont_match
 
-and try_modtypes2 env cxt mty1 mty2 =
+and try_modtypes2 ~loc env cxt mty1 mty2 =
   (* mty2 is an identifier *)
   match (mty1, mty2) with
     (Mty_ident p1, Mty_ident p2)
@@ -297,13 +303,13 @@ and try_modtypes2 env cxt mty1 mty2 =
                    (Env.normalize_path_prefix None env p2) ->
       Tcoerce_none
   | (_, Mty_ident p2) when may_expand_module_path env p2 ->
-      try_modtypes env cxt Subst.identity mty1 (expand_module_path env cxt p2)
+      try_modtypes ~loc env cxt Subst.identity mty1 (expand_module_path env cxt p2)
   | (_, _) ->
       raise Dont_match
 
 (* Inclusion between signatures *)
 
-and signatures env cxt subst sig1 sig2 =
+and signatures ~loc env cxt subst sig1 sig2 =
   (* Environment used to check inclusion of components *)
   let new_env =
     Env.add_signature sig1 (Env.in_signature true env) in
@@ -342,7 +348,8 @@ and signatures env cxt subst sig1 sig2 =
         begin match unpaired with
             [] ->
               let cc =
-                signature_components env new_env cxt subst (List.rev paired)
+                signature_components ~loc env new_env cxt subst
+                  (List.rev paired)
               in
               if len1 = len2 then (* see PR#5098 *)
                 simplify_structure_coercion cc id_pos_list
@@ -390,12 +397,12 @@ and signatures env cxt subst sig1 sig2 =
 
 (* Inclusion between signature components *)
 
-and signature_components old_env env cxt subst paired =
-  let comps_rec rem = signature_components old_env env cxt subst rem in
+and signature_components ~loc old_env env cxt subst paired =
+  let comps_rec rem = signature_components ~loc old_env env cxt subst rem in
   match paired with
     [] -> []
   | (Sig_value(id1, valdecl1), Sig_value(_id2, valdecl2), pos) :: rem ->
-      let cc = value_descriptions env cxt subst id1 valdecl1 valdecl2 in
+      let cc = value_descriptions ~loc env cxt subst id1 valdecl1 valdecl2 in
       begin match valdecl2.val_kind with
         Val_prim _ -> comps_rec rem
       | _ -> (pos, cc) :: comps_rec rem
@@ -411,12 +418,12 @@ and signature_components old_env env cxt subst paired =
       let p1 = Pident id1 in
       Env.mark_module_used env (Ident.name id1) mty1.md_loc;
       let cc =
-        modtypes env (Module id1::cxt) subst
+        modtypes ~loc env (Module id1::cxt) subst
           (Mtype.strengthen ~aliasable:true env mty1.md_type p1) mty2.md_type
       in
       (pos, cc) :: comps_rec rem
   | (Sig_modtype(id1, info1), Sig_modtype(_id2, info2), _pos) :: rem ->
-      modtype_infos env cxt subst id1 info1 info2;
+      modtype_infos ~loc env cxt subst id1 info1 info2;
       comps_rec rem
   | (Sig_class(id1, decl1, _), Sig_class(_id2, decl2, _), pos) :: rem ->
       class_declarations ~old_env env cxt subst id1 decl1 decl2;
@@ -430,7 +437,7 @@ and signature_components old_env env cxt subst paired =
 
 (* Inclusion between module type specifications *)
 
-and modtype_infos env cxt subst id info1 info2 =
+and modtype_infos ~loc env cxt subst id info1 info2 =
   let info2 = Subst.modtype_declaration subst info2 in
   let cxt' = Modtype id :: cxt in
   try
@@ -438,16 +445,16 @@ and modtype_infos env cxt subst id info1 info2 =
       (None, None) -> ()
     | (Some _, None) -> ()
     | (Some mty1, Some mty2) ->
-        check_modtype_equiv env cxt' mty1 mty2
+        check_modtype_equiv ~loc env cxt' mty1 mty2
     | (None, Some mty2) ->
-        check_modtype_equiv env cxt' (Mty_ident(Pident id)) mty2
+        check_modtype_equiv ~loc env cxt' (Mty_ident(Pident id)) mty2
   with Error reasons ->
     raise(Error((cxt, env, Modtype_infos(id, info1, info2)) :: reasons))
 
-and check_modtype_equiv env cxt mty1 mty2 =
+and check_modtype_equiv ~loc env cxt mty1 mty2 =
   match
-    (modtypes env cxt Subst.identity mty1 mty2,
-     modtypes env cxt Subst.identity mty2 mty1)
+    (modtypes ~loc env cxt Subst.identity mty1 mty2,
+     modtypes ~loc env cxt Subst.identity mty2 mty1)
   with
     (Tcoerce_none, Tcoerce_none) -> ()
   | (_c1, _c2) ->
@@ -465,10 +472,10 @@ let can_alias env path =
   in
   no_apply path && not (Env.is_functor_arg path env)
 
-let check_modtype_inclusion env mty1 path1 mty2 =
+let check_modtype_inclusion ~loc env mty1 path1 mty2 =
   try
     let aliasable = can_alias env path1 in
-    ignore(modtypes env [] Subst.identity
+    ignore(modtypes ~loc env [] Subst.identity
                     (Mtype.strengthen ~aliasable env mty1 path1) mty2)
   with Error _ ->
     raise Not_found
@@ -480,15 +487,17 @@ let _ = Env.check_modtype_inclusion := check_modtype_inclusion
 
 let compunit env impl_name impl_sig intf_name intf_sig =
   try
-    signatures env [] Subst.identity impl_sig intf_sig
+    signatures ~loc:(Location.in_file impl_name) env [] Subst.identity
+      impl_sig intf_sig
   with Error reasons ->
     raise(Error(([], Env.empty,Interface_mismatch(impl_name, intf_name))
                 :: reasons))
 
 (* Hide the context and substitution parameters to the outside world *)
 
-let modtypes env mty1 mty2 = modtypes env [] Subst.identity mty1 mty2
-let signatures env sig1 sig2 = signatures env [] Subst.identity sig1 sig2
+let modtypes ~loc env mty1 mty2 = modtypes ~loc env [] Subst.identity mty1 mty2
+let signatures env sig1 sig2 =
+  signatures ~loc:Location.none env [] Subst.identity sig1 sig2
 let type_declarations env id decl1 decl2 =
   type_declarations env [] Subst.identity id decl1 decl2
 

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -83,17 +83,17 @@ let extension_constructors ~loc env cxt subst id ext1 ext2 =
 
 (* Inclusion between class declarations *)
 
-let class_type_declarations ~old_env env cxt subst id decl1 decl2 =
+let class_type_declarations ~loc ~old_env env cxt subst id decl1 decl2 =
   let decl2 = Subst.cltype_declaration subst decl2 in
-  match Includeclass.class_type_declarations env decl1 decl2 with
+  match Includeclass.class_type_declarations ~loc env decl1 decl2 with
     []     -> ()
   | reason ->
       raise(Error[cxt, old_env,
                   Class_type_declarations(id, decl1, decl2, reason)])
 
-let class_declarations ~old_env env cxt subst id decl1 decl2 =
+let class_declarations ~loc ~old_env env cxt subst id decl1 decl2 =
   let decl2 = Subst.class_declaration subst decl2 in
-  match Includeclass.class_declarations env decl1 decl2 with
+  match Includeclass.class_declarations ~loc env decl1 decl2 with
     []     -> ()
   | reason ->
       raise(Error[cxt, old_env, Class_declarations(id, decl1, decl2, reason)])
@@ -422,11 +422,11 @@ and signature_components ~loc old_env env cxt subst paired =
       modtype_infos ~loc env cxt subst id1 info1 info2;
       comps_rec rem
   | (Sig_class(id1, decl1, _), Sig_class(_id2, decl2, _), pos) :: rem ->
-      class_declarations ~old_env env cxt subst id1 decl1 decl2;
+      class_declarations ~loc ~old_env env cxt subst id1 decl1 decl2;
       (pos, Tcoerce_none) :: comps_rec rem
   | (Sig_class_type(id1, info1, _),
      Sig_class_type(_id2, info2, _), _pos) :: rem ->
-      class_type_declarations ~old_env env cxt subst id1 info1 info2;
+      class_type_declarations ~loc ~old_env env cxt subst id1 info1 info2;
       comps_rec rem
   | _ ->
       assert false

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -91,9 +91,9 @@ let class_type_declarations ~loc ~old_env env cxt subst id decl1 decl2 =
       raise(Error[cxt, old_env,
                   Class_type_declarations(id, decl1, decl2, reason)])
 
-let class_declarations ~loc ~old_env env cxt subst id decl1 decl2 =
+let class_declarations ~old_env env cxt subst id decl1 decl2 =
   let decl2 = Subst.class_declaration subst decl2 in
-  match Includeclass.class_declarations ~loc env decl1 decl2 with
+  match Includeclass.class_declarations env decl1 decl2 with
     []     -> ()
   | reason ->
       raise(Error[cxt, old_env, Class_declarations(id, decl1, decl2, reason)])
@@ -417,7 +417,7 @@ and signature_components ~loc old_env env cxt subst paired =
       modtype_infos ~loc env cxt subst id1 info1 info2;
       comps_rec rem
   | (Sig_class(id1, decl1, _), Sig_class(_id2, decl2, _), pos) :: rem ->
-      class_declarations ~loc ~old_env env cxt subst id1 decl1 decl2;
+      class_declarations ~old_env env cxt subst id1 decl1 decl2;
       (pos, Tcoerce_none) :: comps_rec rem
   | (Sig_class_type(id1, info1, _),
      Sig_class_type(_id2, info2, _), _pos) :: rem ->

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -433,7 +433,6 @@ and module_declarations ~loc env cxt subst id1 md1 md2 =
     loc
     md1.md_attributes md2.md_attributes
     (Ident.name id1);
-
   let p1 = Pident id1 in
   Env.mark_module_used env (Ident.name id1) md1.md_loc;
   modtypes ~loc env (Module id1::cxt) subst
@@ -448,7 +447,6 @@ and modtype_infos ~loc env cxt subst id info1 info2 =
     loc
     info1.mtd_attributes info2.mtd_attributes
     (Ident.name id);
-
   let info2 = Subst.modtype_declaration subst info2 in
   let cxt' = Modtype id :: cxt in
   try

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -57,14 +57,8 @@ let value_descriptions ~loc env cxt subst id vd1 vd2 =
   Cmt_format.record_value_dependency vd1 vd2;
   Env.mark_value_used env (Ident.name id) vd1;
   let vd2 = Subst.value_description subst vd2 in
-  Builtin_attributes.check_deprecated_inclusion
-    ~def:vd1.val_loc
-    ~use:vd2.val_loc
-    loc
-    vd1.val_attributes vd2.val_attributes
-    (Ident.name id);
   try
-    Includecore.value_descriptions env vd1 vd2
+    Includecore.value_descriptions ~loc env (Ident.name id) vd1 vd2
   with Includecore.Dont_match ->
     raise(Error[cxt, env, Value_descriptions(id, vd1, vd2)])
 

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -64,10 +64,12 @@ let value_descriptions ~loc env cxt subst id vd1 vd2 =
 
 (* Inclusion between type declarations *)
 
-let type_declarations env ?(old_env=env) cxt subst id decl1 decl2 =
+let type_declarations ~loc env ?(old_env=env) cxt subst id decl1 decl2 =
   Env.mark_type_used env (Ident.name id) decl1;
   let decl2 = Subst.type_declaration subst decl2 in
-  let err = Includecore.type_declarations env (Ident.name id) decl1 id decl2 in
+  let err =
+    Includecore.type_declarations ~loc env (Ident.name id) decl1 id decl2
+  in
   if err <> [] then
     raise(Error[cxt, old_env, Type_declarations(id, decl1, decl2, err)])
 
@@ -402,7 +404,7 @@ and signature_components ~loc old_env env cxt subst paired =
       | _ -> (pos, cc) :: comps_rec rem
       end
   | (Sig_type(id1, tydecl1, _), Sig_type(_id2, tydecl2, _), _pos) :: rem ->
-      type_declarations ~old_env env cxt subst id1 tydecl1 tydecl2;
+      type_declarations ~loc ~old_env env cxt subst id1 tydecl1 tydecl2;
       comps_rec rem
   | (Sig_typext(id1, ext1, _), Sig_typext(_id2, ext2, _), pos)
     :: rem ->
@@ -492,8 +494,8 @@ let compunit env impl_name impl_sig intf_name intf_sig =
 let modtypes ~loc env mty1 mty2 = modtypes ~loc env [] Subst.identity mty1 mty2
 let signatures env sig1 sig2 =
   signatures ~loc:Location.none env [] Subst.identity sig1 sig2
-let type_declarations env id decl1 decl2 =
-  type_declarations env [] Subst.identity id decl1 decl2
+let type_declarations ~loc env id decl1 decl2 =
+  type_declarations ~loc env [] Subst.identity id decl1 decl2
 
 (*
 let modtypes env m1 m2 =

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -19,7 +19,7 @@ open Typedtree
 open Types
 open Format
 
-val modtypes: Env.t -> module_type -> module_type -> module_coercion
+val modtypes: loc:Location.t -> Env.t -> module_type -> module_type -> module_coercion
 val signatures: Env.t -> signature -> signature -> module_coercion
 val compunit:
       Env.t -> string -> signature -> string -> signature -> module_coercion

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -19,12 +19,19 @@ open Typedtree
 open Types
 open Format
 
-val modtypes: loc:Location.t -> Env.t -> module_type -> module_type -> module_coercion
+val modtypes:
+  loc:Location.t -> Env.t ->
+  module_type -> module_type -> module_coercion
+
 val signatures: Env.t -> signature -> signature -> module_coercion
+
 val compunit:
       Env.t -> string -> signature -> string -> signature -> module_coercion
+
 val type_declarations:
-      Env.t -> Ident.t -> type_declaration -> type_declaration -> unit
+  loc:Location.t -> Env.t ->
+  Ident.t -> type_declaration -> type_declaration -> unit
+
 val print_coercion: formatter -> module_coercion -> unit
 
 type symptom =

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -110,13 +110,11 @@ let parse_declaration valdecl ~native_repr_args ~native_repr_res =
      explicit now (GPR#167): *)
   let old_style_noalloc = old_style_noalloc || old_style_float in
   if old_style_float then
-    Location.prerr_warning valdecl.pval_loc
-      (Warnings.Deprecated "[@@unboxed] + [@@noalloc] should be used instead \
-                            of \"float\"")
+    Location.deprecated valdecl.pval_loc
+      "[@@unboxed] + [@@noalloc] should be used instead of \"float\""
   else if old_style_noalloc then
-    Location.prerr_warning valdecl.pval_loc
-      (Warnings.Deprecated "[@@noalloc] should be used instead of \
-                            \"noalloc\"");
+    Location.deprecated valdecl.pval_loc
+      "[@@noalloc] should be used instead of \"noalloc\"";
   if native_name = "" &&
      not (List.for_all is_ocaml_repr native_repr_args &&
           is_ocaml_repr native_repr_res) then

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1747,8 +1747,7 @@ let transl_with_constraint env id row_path orig_decl sdecl =
   in
   if arity_ok && orig_decl.type_kind <> Type_abstract
   && sdecl.ptype_private = Private then
-    Location.prerr_warning sdecl.ptype_loc
-      (Warnings.Deprecated "spurious use of private");
+    Location.deprecated sdecl.ptype_loc "spurious use of private";
   let type_kind, type_unboxed =
     if arity_ok && man <> None then
       orig_decl.type_kind, orig_decl.type_unboxed

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -620,7 +620,7 @@ let check_coherence env loc id decl =
               else if not (Ctype.equal env false args decl.type_params)
               then [Includecore.Constraint]
               else
-                Includecore.type_declarations ~equality:true env
+                Includecore.type_declarations ~loc ~equality:true env
                   (Path.last path)
                   decl'
                   id

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -132,7 +132,7 @@ let check_type_decl env loc id row_id newdecl decl rs rem =
     | Some id -> Env.add_type ~check:false id newdecl env
   in
   let env = if rs = Trec_not then env else add_rec_types env rem in
-  Includemod.type_declarations env id newdecl decl;
+  Includemod.type_declarations ~loc env id newdecl decl;
   Typedecl.check_coherence env loc id newdecl
 
 let update_rec_next rs rem =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -227,14 +227,14 @@ let merge_constraint initial_env loc sg constr =
         let path, md' = Typetexp.find_module initial_env loc lid'.txt in
         let md'' = {md' with md_type = Mtype.remove_aliases env md'.md_type} in
         let newmd = Mtype.strengthen_decl ~aliasable:false env md'' path in
-        ignore(Includemod.modtypes env newmd.md_type md.md_type);
+        ignore(Includemod.modtypes ~loc env newmd.md_type md.md_type);
         (Pident id, lid, Twith_module (path, lid')),
         Sig_module(id, newmd, rs) :: rem
     | (Sig_module(id, md, rs) :: rem, [s], Pwith_modsubst (_, lid'))
       when Ident.name id = s ->
         let path, md' = Typetexp.find_module initial_env loc lid'.txt in
         let newmd = Mtype.strengthen_decl ~aliasable:false env md' path in
-        ignore(Includemod.modtypes env newmd.md_type md.md_type);
+        ignore(Includemod.modtypes ~loc env newmd.md_type md.md_type);
         real_id := Some id;
         (Pident id, lid, Twith_modsubst (path, lid')),
         update_rec_next rs rem
@@ -972,7 +972,7 @@ let check_recmodule_inclusion env bindings =
         and mty_actual' = subst_and_strengthen env s id mty_actual in
         let coercion =
           try
-            Includemod.modtypes env mty_actual' mty_decl'
+            Includemod.modtypes ~loc:modl.mod_loc env mty_actual' mty_decl'
           with Includemod.Error msg ->
             raise(Error(modl.mod_loc, env, Not_included msg)) in
         let modl' =
@@ -1047,7 +1047,7 @@ let package_subtype env p1 nl1 tl1 p2 nl2 tl2 =
     modtype_of_package env Location.none p nl tl
   in
   let mty1 = mkmty p1 nl1 tl1 and mty2 = mkmty p2 nl2 tl2 in
-  try Includemod.modtypes env mty1 mty2 = Tcoerce_none
+  try Includemod.modtypes ~loc:Location.none env mty1 mty2 = Tcoerce_none
   with Includemod.Error _msg -> false
     (* raise(Error(Location.none, env, Not_included msg)) *)
 
@@ -1056,7 +1056,7 @@ let () = Ctype.package_subtype := package_subtype
 let wrap_constraint env arg mty explicit =
   let coercion =
     try
-      Includemod.modtypes env arg.mod_type mty
+      Includemod.modtypes ~loc:arg.mod_loc env arg.mod_type mty
     with Includemod.Error msg ->
       raise(Error(arg.mod_loc, env, Not_included msg)) in
   { mod_desc = Tmod_constraint(arg, mty, explicit, coercion);
@@ -1142,7 +1142,7 @@ let rec type_module ?(alias=false) sttn funct_body anchor env smod =
           end;
           let coercion =
             try
-              Includemod.modtypes env arg.mod_type mty_param
+              Includemod.modtypes ~loc:sarg.pmod_loc env arg.mod_type mty_param
             with Includemod.Error msg ->
               raise(Error(sarg.pmod_loc, env, Not_included msg)) in
           let mty_appl =

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -394,8 +394,8 @@ let rec transl_type env policy styp =
                     check (Env.find_type path env)
                 | _ -> raise Not_found
           in check decl;
-          Location.prerr_warning styp.ptyp_loc
-            (Warnings.Deprecated "old syntax for polymorphic variant type");
+          Location.deprecated styp.ptyp_loc
+            "old syntax for polymorphic variant type";
           (path, decl,true)
         with Not_found -> try
           let lid2 =

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -20,10 +20,16 @@
    - manual/manual/cmds/native.etex
 *)
 
+type loc = {
+  loc_start: Lexing.position;
+  loc_end: Lexing.position;
+  loc_ghost: bool;
+}
+
 type t =
   | Comment_start                           (*  1 *)
   | Comment_not_end                         (*  2 *)
-  | Deprecated of string                    (*  3 *)
+  | Deprecated of string * loc * loc        (*  3 *)
   | Fragile_match of string                 (*  4 *)
   | Partial_application                     (*  5 *)
   | Labels_omitted of string list           (*  6 *)
@@ -280,7 +286,7 @@ let () = parse_options true defaults_warn_error;;
 let message = function
   | Comment_start -> "this is the start of a comment."
   | Comment_not_end -> "this is not the end of a comment."
-  | Deprecated s ->
+  | Deprecated (s, _, _) ->
       (* Reduce \r\n to \n:
            - Prevents any \r characters being printed on Unix when processing
              Windows sources
@@ -489,12 +495,21 @@ let message = function
       "Type constraints do not apply to GADT cases of variant types."
 ;;
 
+let sub_locs = function
+  | Deprecated (_, def, use) ->
+      [
+        def, "Definition";
+        use, "Expected signature";
+      ]
+  | _ -> []
+
 let nerrors = ref 0;;
 
 type reporting_information =
   { number : int
   ; message : string
   ; is_error : bool
+  ; sub_locs : (loc * string) list;
   }
 
 let report w =
@@ -502,7 +517,9 @@ let report w =
   | false -> `Inactive
   | true ->
      if is_error w then incr nerrors;
-    `Active { number = number w; message = message w; is_error = is_error w }
+     `Active { number = number w; message = message w; is_error = is_error w;
+               sub_locs = sub_locs w;
+             }
 ;;
 
 exception Errors;;

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -13,10 +13,16 @@
 (*                                                                        *)
 (**************************************************************************)
 
+type loc = {
+  loc_start: Lexing.position;
+  loc_end: Lexing.position;
+  loc_ghost: bool;
+}
+
 type t =
   | Comment_start                           (*  1 *)
   | Comment_not_end                         (*  2 *)
-  | Deprecated of string                    (*  3 *)
+  | Deprecated of string * loc * loc        (*  3 *)
   | Fragile_match of string                 (*  4 *)
   | Partial_application                     (*  5 *)
   | Labels_omitted of string list           (*  6 *)
@@ -90,6 +96,7 @@ type reporting_information =
   { number : int
   ; message : string
   ; is_error : bool
+  ; sub_locs : (loc * string) list;
   }
 
 val report : t -> [ `Active of reporting_information | `Inactive ]


### PR DESCRIPTION
https://caml.inria.fr/mantis/view.php?id=7444

Deprecation warning (3) is currently only reported when directly
accessing a component marked with the deprecated attribute; but it is
missed when we coerce the signature containing the deprecated component
to a signature without the attribute.

This PR adds the required machinery to detect such cases
and report the same warning. An alternative design could be
to introduce a new warning for that purpose. Do people believe one
should reuse the existing warning, or introduce a new one?

Another design choice is that only the presence of the deprecated attribute is checked.  Changing the payload of the attribute does not trigger the warning.

Some of the new machinery could be used for other purposes:

  - During the inclusion check, keep the location that would used in
    the error message if the check fails.

  - Warnings can now hold extra "sub-locations" (and associated
    messages).

One case of a missing attribute was found on StringLabels.copy (after
bootstrapping the compiler).

All kinds of deprecated attributes are supported (on values, types, constructors, class/class types, module/module types; and also the "deprecated_mutable" attribute on record labels).
