### PR TITLE
Fix PR#7070: Use simplified signature in generalizable check

### DIFF
--- a/Changes
+++ b/Changes
@@ -106,6 +106,10 @@ Working version
 - PR#6934: nonrec misbehaves with GADTs
   (Jacques Garrigue, report by Markus Mottl)
 
+- PR#7070, GPR#1139: Unexported values can cause non-generalisable variables
+  error
+  (Leo White)
+
 - PR#7261: Warn on type constraints in GADT declarations
   (Jacques Garrigue, report by Fabrice Le Botlan)
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1629,11 +1629,11 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
         (Cmt_format.Implementation str) (Some sourcefile) initial_env None;
       (str, coercion)
     end else begin
-      check_nongen_schemes finalenv sg;
-      normalize_signature finalenv simple_sg;
       let coercion =
         Includemod.compunit initial_env sourcefile sg
                             "(inferred signature)" simple_sg in
+      check_nongen_schemes finalenv simple_sg;
+      normalize_signature finalenv simple_sg;
       Typecore.force_delayed_checks ();
       (* See comment above. Here the target signature contains all
          the value being exported. We can still capture unused


### PR DESCRIPTION
This fixes [PR#7070](https://caml.inria.fr/mantis/view.php?id=7070) by calling `check_nongen_scheme` after the signature has been simplified.