### PR TITLE
Fix '\r' build problems with newer Cygwin tools

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -136,3 +136,32 @@ testsuite/tests/docstrings/empty.ml text eol=lf
 
 # And w04.ml
 testsuite/tests/warnings/w04.ml text eol=lf
+
+# These are forced to \n to allow the Cygwin testsuite to pass on a
+# Windows-checkout
+testsuite/tests/formatting/margins.ml text eol=lf
+testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml text eol=lf
+testsuite/tests/typing-extension-constructor/test.ml text eol=lf
+testsuite/tests/typing-extensions/extensions.ml text eol=lf
+testsuite/tests/typing-extensions/open_types.ml text eol=lf
+testsuite/tests/typing-objects/Exemples.ml text eol=lf
+testsuite/tests/typing-objects/pr5619_bad.ml text eol=lf
+testsuite/tests/typing-objects/pr6123_bad.ml text eol=lf
+testsuite/tests/typing-objects/pr6907_bad.ml text eol=lf
+testsuite/tests/typing-objects/Tests.ml text eol=lf
+testsuite/tests/typing-pattern_open/pattern_open.ml text eol=lf
+testsuite/tests/typing-private/private.ml text eol=lf
+testsuite/tests/typing-recordarg/recordarg.ml text eol=lf
+testsuite/tests/typing-short-paths/pr5918.ml text eol=lf
+testsuite/tests/typing-sigsubst/sigsubst.ml text eol=lf
+testsuite/tests/typing-typeparam/newtype.ml text eol=lf
+testsuite/tests/typing-unboxed/test.ml text eol=lf
+testsuite/tests/typing-unboxed-types/test.ml text eol=lf
+testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml text eol=lf
+testsuite/tests/typing-warnings/coercions.ml text eol=lf
+testsuite/tests/typing-warnings/exhaustiveness.ml text eol=lf
+testsuite/tests/typing-warnings/pr6872.ml text eol=lf
+testsuite/tests/typing-warnings/pr7085.ml text eol=lf
+testsuite/tests/typing-warnings/pr7115.ml text eol=lf
+testsuite/tests/typing-warnings/records.ml text eol=lf
+testsuite/tests/typing-warnings/unused_types.ml text eol=lf

--- a/Makefile
+++ b/Makefile
@@ -550,8 +550,8 @@ flexdll/Makefile:
 
 .PHONY: flexdll
 flexdll: flexdll/Makefile flexlink
-	$(MAKE) -C flexdll MSVC_DETECT=0 CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false \
-          support
+	$(MAKE) -C flexdll \
+             MSVC_DETECT=0 CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false support
 
 # Bootstrapping flexlink - leaves a bytecode image of flexlink.exe in flexdll/
 .PHONY: flexlink
@@ -579,9 +579,11 @@ flexlink.opt:
 
 .PHONY: install-flexdll
 install-flexdll:
-	cat stdlib/camlheader flexdll/flexlink.exe > "$(INSTALL_BINDIR)/flexlink.exe"
+	cat stdlib/camlheader flexdll/flexlink.exe > \
+	  "$(INSTALL_BINDIR)/flexlink.exe"
 ifneq "$(filter-out mingw,$(TOOLCHAIN))" ""
-	cp flexdll/default$(filter-out _i386,_$(ARCH)).manifest "$(INSTALL_BINDIR)/"
+	cp flexdll/default$(filter-out _i386,_$(ARCH)).manifest \
+    "$(INSTALL_BINDIR)/"
 endif
 	if test -n "$(wildcard flexdll/flexdll_*.$(O))" ; then \
 	  $(MKDIR) "$(INSTALL_FLEXDLL)" ; \
@@ -882,8 +884,8 @@ byterun/primitives:
 
 bytecomp/runtimedef.ml: byterun/primitives byterun/caml/fail.h
 	(echo 'let builtin_exceptions = [|'; \
-	 sed -n -e 's|.*/\* \("[A-Za-z_]*"\) \*/$$|  \1;|p' \
-	     byterun/caml/fail.h; \
+	 cat byterun/caml/fail.h | tr -d '\r' | \
+	 sed -n -e 's|.*/\* \("[A-Za-z_]*"\) \*/$$|  \1;|p'; \
 	 echo '|]'; \
 	 echo 'let builtin_primitives = [|'; \
 	 sed -e 's/.*/  "&";/' byterun/primitives; \

--- a/debugger/show_source.ml
+++ b/debugger/show_source.ml
@@ -23,18 +23,23 @@ open Source
 
 (* Print a line; return the beginning of the next line *)
 let print_line buffer line_number start point before =
-  let next = next_linefeed buffer start
+  let linefeed = next_linefeed buffer start
   and content = buffer_content buffer
   in
     printf "%i " line_number;
-    if point <= next && point >= start then
+    let line_end =
+      if linefeed > 0 && content.[linefeed - 1] = '\r' then
+        linefeed - 1
+      else
+        linefeed in
+    if point <= line_end && point >= start then
       (print_string (String.sub content start (point - start));
        print_string (if before then event_mark_before else event_mark_after);
-       print_string (String.sub content point (next - point)))
+       print_string (String.sub content point (line_end - point)))
     else
-      print_string (String.sub content start (next - start));
+      print_string (String.sub content start (line_end - start));
     print_newline ();
-    next
+    linefeed
 
 (* Tell Emacs we are nowhere in the source. *)
 let show_no_point () =

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -195,7 +195,7 @@ stdlib.p.cmxa: $(OBJS:.cmo=.p.cmx)
 	$(CAMLOPT) -a -o $@ $^
 
 sys.ml: sys.mlp ../VERSION
-	sed -e "s|%%VERSION%%|`sed -e 1q ../VERSION`|" sys.mlp >sys.ml
+	sed -e "s|%%VERSION%%|`sed -e 1q ../VERSION | tr -d '\r'`|" sys.mlp > $@
 
 .PHONY: clean
 clean::

--- a/testsuite/tests/tool-debugger/find-artifacts/Makefile
+++ b/testsuite/tests/tool-debugger/find-artifacts/Makefile
@@ -53,7 +53,7 @@ run:
 	             program.byte$(EXE) >$(MAIN_MODULE).raw.result 2>&1 \
 	 && sed -e '/Debugger version/d' -e '/^Time:/d' \
 	        -e '/Breakpoint [0-9]* at [0-9]*:/d' -e '$$d' \
-	        $(MAIN_MODULE).raw.result >$(MAIN_MODULE).result \
+	        $(MAIN_MODULE).raw.result | tr -d '\r' >$(MAIN_MODULE).result \
 	 && $(DIFF) $(MAIN_MODULE).reference $(MAIN_MODULE).result >/dev/null \
 	 && echo " => passed" || echo " => failed"
 

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -159,7 +159,7 @@ IGNORE_DIRS="
       ocamldoc/*|*/ocamldoc/*) rules="long-line,$rules";;
     esac
 
-    (cat "$f"; echo) \
+    (cat "$f" | tr -d '\r'; echo) \
     | awk -v rules="$rules" -v svnrules="$svnrules" -v file="$f" \
       '
         function err(name, msg) {

--- a/tools/make-version-header.sh
+++ b/tools/make-version-header.sh
@@ -32,8 +32,8 @@
 # be used.
 
 case $# in
-  0) version="`ocamlc -v | sed -n -e 's/.*version //p'`";;
-  1) version="`sed -e 1q $1`";;
+  0) version="`ocamlc -v | tr -d '\r' | sed -n -e 's/.*version //p'`";;
+  1) version="`sed -e 1q $1 | tr -d '\r'`";;
   *) echo "usage: make-version-header.sh [version-file]" >&2
      exit 2;;
 esac

--- a/yacc/Makefile
+++ b/yacc/Makefile
@@ -36,7 +36,7 @@ ocamlyacc$(EXE): $(OBJS)
 	$(MKEXE) -o ocamlyacc$(EXE) $(OBJS) $(EXTRALIBS)
 
 version.h : ../VERSION
-	echo "#define OCAML_VERSION \"`sed -e 1q ../VERSION`\"" >version.h
+	echo "#define OCAML_VERSION \"`sed -e 1q $^ | tr -d '\r'`\"" > $@
 
 clean:
 	rm -f *.$(O) ocamlyacc$(EXE) *~ version.h


### PR DESCRIPTION
On 20 Feb 2017, Cygwin's awk, grep and sed packages were updated so that they no longer silently treat `\r\n` as `\n` (a switch to more POSIX-like behaviour). This means that files accessed using binary mounts (which includes `/cygdrive`) can now end up with extra `\r` characters which in a few places breaks our builds.

This does not affect OCaml built from a sources tarball, because those are assembled on Unix but it does affect Git clones using Git-for-Windows.

The three fixes:
 - The debugger now strips `\r` when displaying source lines from files (this affects ocamldebug on Unix platforms, including the two Cygwin ports, when faced with an ML file with Windows line-endings). This was arguably a display bug even before the Cygwin tools were updated. It's fixed here as, when combined with the Cygwin tools change, the debugger tests are also affected.
 - In a number of processing places in the build system where sed is used, the output (or, in some cases, the input) is pre-processed with `tr -d '\r'` to get rid of any Windows line-endings. As far as I can tell, using `tr d '\r'` is POSIXly correct.
 - When building the Cygwin ports from a **Git-for-Windows** clone, there are a number of extra tests which fail because of Windows line-endings. I think that at some point in the coming months, the discrepancy in the lexer over the handling of line-endings should be fixed once and for all (in a nutshell, I think we should stop allowing character references in locations which span newlines and instead only provide these for emacs, etc. via a command-line option). However, that's a lot of work, so for the time being I've altered the .gitattributes for the affected tests.

The benefit for me, and for new CI coming soon to an Azure cloud near you, is that I can parallel test branches in all 6 Windows ports at once without having to faff with multiple versions of Git, etc.