### PR TITLE
Make assertions nonexpansive

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,10 @@ Working version
 
 ### Language features:
 
+- GPR#1142: Mark assertions nonexpansive, so that 'assert false'
+  can be used as a placeholder for a polymorphic function.
+  (Stephen Dolan)
+
 ### Code generation and optimizations:
 
 - PR#5324, GPR#375: An alternative Linear Scan register allocator for

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1499,3 +1499,13 @@ val f :
 type t = { x : 'a. ([< `Foo of int & float ] as 'a) -> unit; }
 val f : t -> t = <fun>
 |}]
+
+(* GPR#1142 *)
+
+module M () = struct
+  let f : 'a -> 'a = assert false
+  let g : 'a -> 'a = raise Not_found
+end
+[%%expect{|
+module M : functor () -> sig val f : 'a -> 'a val g : 'a -> 'a end
+|}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1616,6 +1616,8 @@ let rec is_nonexpansive exp =
       is_nonexpansive_mod mexp && is_nonexpansive e
   | Texp_pack mexp ->
       is_nonexpansive_mod mexp
+  | Texp_assert exp ->
+      is_nonexpansive exp
   | _ -> false
 
 and is_nonexpansive_mod mexp =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1616,8 +1616,16 @@ let rec is_nonexpansive exp =
       is_nonexpansive_mod mexp && is_nonexpansive e
   | Texp_pack mexp ->
       is_nonexpansive_mod mexp
+  (* Computations which raise exceptions are nonexpansive, since (raise e) is equivalent
+     to (raise e; diverge), and a nonexpansive "diverge" can be produced using lazy values
+     or the relaxed value restriction. See GPR#1142 *)
   | Texp_assert exp ->
       is_nonexpansive exp
+  | Texp_apply (
+      { exp_desc = Texp_ident (_, _, {val_kind =
+             Val_prim {Primitive.prim_name = "%raise"}}) },
+      [Nolabel, Some e]) ->
+     is_nonexpansive e
   | _ -> false
 
 and is_nonexpansive_mod mexp =


### PR DESCRIPTION
Currently, while `assert false` has polymorphic type, its type does not generalise:

 ```
let f  (type a) :  a -> a list = assert false
=>
val f : '_a -> '_a list
```

```
let f : type a . a -> a list = assert false
=>
Error: This definition has type 'a -> 'a list which is less general than
         'a0. 'a0 -> 'a0 list
```

I ran into this issue when I was prototyping some polymorphic code, and got errors when I wrote `assert false` as a placeholder for an implementation.

I think it's sound to mark `assert e` as a nonexpansive expression whenever `e` is. With this patch, both of the definitions above typecheck with type scheme `'a -> 'a list`.