### PR TITLE
Reordered size checks in caml_make_vect for better performance

### DIFF
--- a/Changes
+++ b/Changes
@@ -31,6 +31,12 @@ Working version
 - GPR#1150: Fix typo in arm64 assembler directives
   (KC Sivaramakrishnan)
 
+- GPR#1143: tweaked several allocation functions in the runtime by
+  checking for likely conditions before unlikely ones and eliminating
+  some redundant checks.
+  (Markus Mottl, review by Alain Frisch, Xavier Leroy, Gabriel Scherer,
+  Mark Shinwell and Leo White)
+
 ### Standard library:
 
 - GRP#1119: Change Set (private) type to inline records.

--- a/byterun/array.c
+++ b/byterun/array.c
@@ -149,12 +149,13 @@ CAMLprim value caml_make_float_vect(value len)
 {
   mlsize_t wosize = Long_val(len) * Double_wosize;
   value result;
-  if (wosize == 0)
-    return Atom(0);
-  else if (wosize <= Max_young_wosize){
+  if (wosize <= Max_young_wosize){
+    if (wosize == 0)
+      return Atom(0);
+    else
 #define Setup_for_gc
 #define Restore_after_gc
-    Alloc_small (result, wosize, Double_array_tag);
+      Alloc_small (result, wosize, Double_array_tag);
 #undef Setup_for_gc
 #undef Restore_after_gc
   }else if (wosize > Max_wosize)
@@ -190,13 +191,13 @@ CAMLprim value caml_make_vect(value len, value init)
       Store_double_field(res, i, d);
     }
   } else {
-    if (size > Max_wosize) caml_invalid_argument("Array.make");
     if (size <= Max_young_wosize) {
       uintnat profinfo;
       Get_my_profinfo_with_cached_backtrace(profinfo, size);
       res = caml_alloc_small_with_my_or_given_profinfo(size, 0, profinfo);
       for (i = 0; i < size; i++) Field(res, i) = init;
     }
+    else if (size > Max_wosize) caml_invalid_argument("Array.make");
     else if (Is_block(init) && Is_young(init)) {
       /* We don't want to create so many major-to-minor references,
          so [init] is moved to the major heap by doing a minor GC. */
@@ -337,10 +338,6 @@ static value caml_array_gather(intnat num_arrays,
     }
     CAMLassert(pos == size);
   }
-  else if (size > Max_wosize) {
-    /* Array of values, too big. */
-    caml_invalid_argument("Array.concat");
-  }
   else if (size <= Max_young_wosize) {
     /* Array of values, small enough to fit in young generation.
        We can use memcpy directly. */
@@ -352,6 +349,10 @@ static value caml_array_gather(intnat num_arrays,
       pos += lengths[i];
     }
     CAMLassert(pos == size);
+  }
+  else if (size > Max_wosize) {
+    /* Array of values, too big. */
+    caml_invalid_argument("Array.concat");
   } else {
     /* Array of values, must be allocated in old generation and filled
        using caml_initialize. */

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -570,7 +570,7 @@ static void intern_alloc(mlsize_t whsize, mlsize_t num_objects,
     return;
   }
   wosize = Wosize_whsize(whsize);
-  if (wosize > Max_wosize || outside_heap) {
+  if (outside_heap || wosize > Max_wosize) {
     /* Round desired size up to next page */
     asize_t request =
       ((Bsize_wsize(whsize) + Page_size - 1) >> Page_log) << Page_log;
@@ -585,10 +585,12 @@ static void intern_alloc(mlsize_t whsize, mlsize_t num_objects,
     CAMLassert (intern_block == 0);
   } else {
     /* this is a specialised version of caml_alloc from alloc.c */
-    if (wosize == 0){
-      intern_block = Atom (String_tag);
-    }else if (wosize <= Max_young_wosize){
-      intern_block = caml_alloc_small (wosize, String_tag);
+    if (wosize <= Max_young_wosize){
+      if (wosize == 0){
+        intern_block = Atom (String_tag);
+      } else {
+        intern_block = caml_alloc_small (wosize, String_tag);
+      }
     }else{
       intern_block = caml_alloc_shr_no_raise (wosize, String_tag);
       /* do not do the urgent_gc check here because it might darken


### PR DESCRIPTION
`size <= Max_young_wosize` always implies `size <= Max_wosize`.  Checking for the former first should improve performance, because it is by far the more likely case and we can thus avoid an additional branch in the majority of cases.