### PR TITLE
Arg.align: allow to change the "alignment" separator

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,6 +47,12 @@ Working version
   (Sébastien Briais, review by Daniel Buenzli, Alain Frisch and
   Gabriel Scherer)
 
+- PR#7515, GPR#1147: Arg.align now optionally uses the tab character '\t' to
+  separate the "unaligned" and "aligned" parts of the documentation string. If
+  tab is not present, then space is used as a fallback. Allows to have spaces in
+  the unaligned part, which is useful for Tuple options.
+  (Nicolas Ojeda Bar, review by Alain Frisch and Gabriel Scherer)
+
 - GPR#1034: Add List.init
   (Richard Degenne, review by David Allsopp, Thomas Braibant, Florian
   Angeletti, Gabriel Scherer, Nathan Moreau, Alain Frisch)
@@ -61,11 +67,6 @@ Working version
 
 - Resurrect tabulation boxes in module Format. Rewrite/extend documentation
   of tabulation boxes.
-- PR#7515, GPR#1147: Arg.align now optionally uses the tab character '\t' to
-  separate the "unaligned" and "aligned" parts of the documentation string. If
-  tab is not present, then space is used as a fallback. Allows to have spaces in the
-  unaligned part, which is useful for Tuple options.
-  (Nicolas Ojeda Bar, review by ...)
 
 ### Compiler user-interface and warnings:
 

--- a/Changes
+++ b/Changes
@@ -61,6 +61,11 @@ Working version
 
 - Resurrect tabulation boxes in module Format. Rewrite/extend documentation
   of tabulation boxes.
+- PR#7515, GPR#1147: Arg.align now optionally uses the tab character '\t' to
+  separate the "unaligned" and "aligned" parts of the documentation string. If
+  tab is not present, then space is used as a fallback. Allows to have spaces in the
+  unaligned part, which is useful for Tuple options.
+  (Nicolas Ojeda Bar, review by ...)
 
 ### Compiler user-interface and warnings:
 

--- a/stdlib/arg.ml
+++ b/stdlib/arg.ml
@@ -313,7 +313,7 @@ let second_word s =
   | n -> loop (n+1)
   | exception Not_found ->
       begin match String.index s ' ' with
-      | n -> loop n
+      | n -> loop (n+1)
       | exception Not_found -> len
       end
 
@@ -324,9 +324,9 @@ let max_arg_len cur (kwd, spec, doc) =
   | _ -> max cur (String.length kwd + second_word doc)
 
 
-let replace_leading_tab s n =
+let replace_leading_tab s =
   let seen = ref false in
-  String.init n (fun i -> match s.[i] with '\t' when not !seen -> seen := true; ' ' | c -> c)
+  String.map (function '\t' when not !seen -> seen := true; ' ' | c -> c) s
 
 let add_padding len ksd =
   match ksd with
@@ -337,16 +337,16 @@ let add_padding len ksd =
   | (kwd, (Symbol _ as spec), msg) ->
       let cutcol = second_word msg in
       let spaces = String.make ((max 0 (len - cutcol)) + 3) ' ' in
-      (kwd, spec, "\n" ^ spaces ^ replace_leading_tab msg (String.length msg))
+      (kwd, spec, "\n" ^ spaces ^ replace_leading_tab msg)
   | (kwd, spec, msg) ->
       let cutcol = second_word msg in
       let kwd_len = String.length kwd in
       let diff = len - kwd_len - cutcol in
       if diff <= 0 then
-        (kwd, spec, replace_leading_tab msg (String.length msg))
+        (kwd, spec, replace_leading_tab msg)
       else
         let spaces = String.make diff ' ' in
-        let prefix = replace_leading_tab msg cutcol in
+        let prefix = String.sub (replace_leading_tab msg) 0 cutcol in
         let suffix = String.sub msg cutcol (String.length msg - cutcol) in
         (kwd, spec, prefix ^ spaces ^ suffix)
 

--- a/stdlib/arg.mli
+++ b/stdlib/arg.mli
@@ -168,14 +168,13 @@ val usage_string : (key * spec * doc) list -> usage_msg -> string
     if provided with the same parameters. *)
 
 val align: ?limit: int -> (key * spec * doc) list -> (key * spec * doc) list
-(** Align the documentation strings by inserting spaces at the first
-    space, according to the length of the keyword.  Use a
-    space as the first character in a doc string if you want to
-    align the whole string.  The doc strings corresponding to
-    [Symbol] arguments are aligned on the next line.
-    @param limit options with keyword and message longer than
-    [limit] will not be used to compute the alignment.
-*)
+(** Align the documentation strings by inserting spaces at the first alignment
+    separator (tab or, if tab is not found, space), according to the length of
+    the keyword.  Use a alignment separator as the first character in a doc
+    string if you want to align the whole string.  The doc strings corresponding
+    to [Symbol] arguments are aligned on the next line.
+    @param limit options with keyword and message longer than [limit] will not
+    be used to compute the alignment. *)
 
 val current : int ref
 (** Position (in {!Sys.argv}) of the argument being processed.  You can

--- a/testsuite/tests/lib-arg/testarg.ml
+++ b/testsuite/tests/lib-arg/testarg.ml
@@ -187,3 +187,18 @@ let test_expand spec argv reference =
 
 test_expand (expand1@spec) args1 expected1;;
 test_expand (expand2@spec) args2 expected2;;
+
+let test_align () =
+  let spec =
+    [
+      "-foo", Arg.String ignore, "FOO Do foo with FOO";
+      "-bar", Arg.Tuple [Arg.String ignore; Arg.String ignore], "FOO BAR\tDo bar with FOO and BAR";
+      "-cha", Arg.Unit ignore, " Another option";
+      "-sym", Arg.Symbol (["a"; "b"], ignore), "\ty\tfoo";
+      "-sym2", Arg.Symbol (["a"; "b"], ignore), "x bar";
+    ]
+  in
+  print_endline (Arg.usage_string (Arg.align spec) "")
+;;
+
+test_align ();;

--- a/testsuite/tests/lib-arg/testarg.reference
+++ b/testsuite/tests/lib-arg/testarg.reference
@@ -1,0 +1,11 @@
+
+  -foo FOO     Do foo with FOO
+  -bar FOO BAR Do bar with FOO and BAR
+  -cha         Another option
+  -sym {a|b}
+               y	foo
+  -sym2 {a|b}
+             x bar
+  -help        Display this list of options
+  --help       Display this list of options
+


### PR DESCRIPTION
> Follow-up to [MPR#7515](https://caml.inria.fr/mantis/view.php?id=7515).

### Issue addressed by this pull request

When using the `Arg` module, the function `align` can be used to align the documentation string of each command-line option.  Currently this function in fact only aligns the part of the documentation string following the first `' '` character.  Concretely, this means that if

```ocaml
let spec =
  [
    "-foo", Arg.String f, "FOO Do foo with FOO";
    "-foobar", Arg.String g, "FOOBAR Do foobar with FOOBAR";
  ]
```
then `align spec` is displayed as
```
  -foo FOO               Do foo with FOO
  -foobar FOOBAR         Do foobar with FOOBAR
```
which is nice and good.

The issue is that this precludes having spaces in the initial, *unaligned* part of the documentation string.  But it turns out that for arguments of type `Tuple` one would like to have such spaces, so as to obtain

```
  -foobar FOO BAR        Do foobar with FOO and BAR
  -gamma GAMMA           Do gamma with GAMMA
```

instead of 

```
  -foobar FOO            BAR Do foobar with FOO and BAR
  -gamma GAMMA           Do gamma with GAMMA
```

### The proposed solution

A very simple solution is offered in this PR.  A new function `set_alignment_separator : char -> unit`
is added to `Arg` allowing to set the character used to break the *unaligned* and *aligned* parts of the documentation string.  Initially this character is the space `' '`.  We can then do

```ocaml
let spec =
  [
    "-foobar", Arg.Tuple [Arg.String f; Arg.String g], "FOO BAR~Do foobar with FOO and BAR";
    "-gamma", Arg.String h, "GAMMA~Do gamma with GAMMA"
  ]

let () =
  Arg.set_alignment_separator '~'
```

to produce the desired output.