### PR TITLE
Supply a Git pre-commit hook for tools/check-typo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -56,16 +56,16 @@ README*                  ocaml-typo=missing-header
 asmcomp/*/emit.mlp       ocaml-typo=tab,long-line,unused-prop
 asmcomp/power/NOTES.md   ocaml-typo=missing-header
 
-config/gnu               ocaml-typo=prune
+/config/gnu              ocaml-typo=prune
 
 emacs/*.el               ocaml-typo=long-line,unused-prop
 emacs/caml.el            ocaml-typo=long-line,unused-prop,missing-header
 emacs/COPYING            ocaml-typo=tab,non-printing,missing-header
 emacs/ocamltags.in       ocaml-typo=non-printing
 
-experimental             ocaml-typo=prune
+/experimental            ocaml-typo=prune
 
-manual                   ocaml-typo=prune
+/manual                  ocaml-typo=prune
 
 ocamldoc/Changes.txt     ocaml-typo=missing-header
 ocamldoc/ocamldoc.sty    ocaml-typo=missing-header

--- a/.gitattributes
+++ b/.gitattributes
@@ -135,6 +135,7 @@ tools/make-package-macosx text eol=lf
 tools/ocaml-objcopy-macosx text eol=lf
 tools/ocamlmktop.tpl text eol=lf
 tools/ocamlsize text eol=lf
+tools/pre-commit-githook text eol=lf
 
 # These two are cat scripts, so may not actually require this
 config/auto-aux/sharpbang text eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
   - env: CI_KIND=build XARCH=x64 CONFIG_ARG=-flambda OCAMLRUNPARAM=b,v=0
   - env: CI_KIND=changes
   - env: CI_KIND=manual
+  - env: CI_KIND=check-typo
   - env: CI_KIND=tests
   allow_failures:
   - env: CI_KIND=tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,9 @@ columns, not use tab characters (spaces only), and not use non-ASCII
 characters. These typographical rules can be checked with the script
 `tools/check-typo`.
 
+If you are working from a Git clone, you can automate this process by
+copying the file `tools/pre-commit-githook` to `.git/hooks/pre-commit`.
+
 Otherwise, there are no strongly enforced guidelines specific to the
 compiler -- and, as a result, the style may differ in the different
 parts of the compiler. The general [OCaml Programming

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -117,6 +117,7 @@ done
 OCAML_CT_CAT=${OCAML_CT_CAT:-cat}
 OCAML_CT_LS_FILES=${OCAML_CT_LS_FILES:-git ls-files}
 OCAML_CT_HEAD=${OCAML_CT_HEAD:-HEAD}
+OCAML_CT_AWK=${OCAML_CT_AWK:-awk}
 if [ -z "${OCAML_CT_GIT_INDEX+x}" ] ; then
   OCAML_CT_GIT_INDEX=
 else
@@ -190,7 +191,7 @@ IGNORE_DIRS="
     esac
 
     ($OCAML_CT_CAT "$OCAML_CT_PREFIX$f" | tr -d '\r'; echo) \
-    | awk -v rules="$rules" -v svnrules="$svnrules" -v file="$f" \
+    | $OCAML_CT_AWK -v rules="$rules" -v svnrules="$svnrules" -v file="$f" \
       '
         function is_err(name) {
           return (("," rules svnrules ",") !~ ("[, ]" name "[, ]"));

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -91,7 +91,7 @@ export LC_ALL=C
 # Special case for recursive call from the find command (see IGNORE_DIRS).
 case "$1" in
   --check-prune)
-    case `git check-attr ocaml-typo "$2" 2>/dev/null` in
+    case `git check-attr $OCAML_CT_CA_FLAG ocaml-typo "$2" 2>/dev/null` in
       *prune*) echo "INFO: pruned directory $2 (ocaml-typo=prune)" >&2; exit 0;;
       *) exit 3;;
     esac;;
@@ -112,6 +112,8 @@ while : ; do
     *) break;;
   esac
 done
+
+OCAML_CT_CAT=${OCAML_CT_CAT:-cat}
 
 IGNORE_DIRS="
   -name .git -prune -o
@@ -149,7 +151,8 @@ IGNORE_DIRS="
       EMPTY=`git hash-object -t tree /dev/null`
       git diff-tree --numstat $EMPTY HEAD -- "$f" | grep -q "^-[[:blank:]]-" \
         && continue
-      svnrules=`git check-attr ocaml-typo "$f" | sed -e 's/.*: //'`
+      svnrules=`git check-attr $OCAML_CT_CA_FLAG ocaml-typo "$f" \
+                  | sed -e 's/.*: //'`
       case $svnrules in unspecified) svnrules= ;; esac
     fi
     rules="$userrules"
@@ -169,14 +172,15 @@ IGNORE_DIRS="
         # requires the entire line to match. This specifically detects the
         # presence of lines containing malformed UTF-8. It may be tested using
         # https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
-        if LC_ALL=en_US.UTF8 grep -qaxv '.*' "$f" ; then
+        if $OCAML_CT_CAT "$OCAML_CT_PREFIX$f" \
+             | LC_ALL=en_US.UTF8 grep -qaxv '.*' ; then
           echo File "$f" is not correctly encoded in UTF-8
           exit 2
         fi
         ;;
     esac
 
-    (cat "$f" | tr -d '\r'; echo) \
+    ($OCAML_CT_CAT "$OCAML_CT_PREFIX$f" | tr -d '\r'; echo) \
     | awk -v rules="$rules" -v svnrules="$svnrules" -v file="$f" \
       '
         function is_err(name) {

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -91,7 +91,8 @@ export LC_ALL=C
 # Special case for recursive call from the find command (see IGNORE_DIRS).
 case "$1" in
   --check-prune)
-    case `git check-attr $OCAML_CT_CA_FLAG ocaml-typo "$2" 2>/dev/null` in
+    case `env $OCAML_CT_GIT_INDEX git check-attr $OCAML_CT_CA_FLAG \
+                                                 ocaml-typo "$2" 2>/dev/null` in
       *prune*) echo "INFO: pruned directory $2 (ocaml-typo=prune)" >&2; exit 0;;
       *) exit 3;;
     esac;;
@@ -114,6 +115,13 @@ while : ; do
 done
 
 OCAML_CT_CAT=${OCAML_CT_CAT:-cat}
+OCAML_CT_LS_FILES=${OCAML_CT_LS_FILES:-git ls-files}
+OCAML_CT_HEAD=${OCAML_CT_HEAD:-HEAD}
+if [ -z "${OCAML_CT_GIT_INDEX+x}" ] ; then
+  OCAML_CT_GIT_INDEX=
+else
+  OCAML_CT_GIT_INDEX="GIT_INDEX_FILE=$OCAML_CT_GIT_INDEX"
+fi
 
 IGNORE_DIRS="
   -name .git -prune -o
@@ -126,7 +134,7 @@ IGNORE_DIRS="
   esac
 ) | (
   while read f; do
-    case `git ls-files "$f" 2>&1` in
+    case `$OCAML_CT_LS_FILES "$f" 2>&1` in
       "") is_svn=false;;
       *) is_svn=true;;
     esac
@@ -149,9 +157,10 @@ IGNORE_DIRS="
       #    the documentation for the --numstat option. Commands designated as
       #    "plumbing" commands in git have stable output intended for parsing)
       EMPTY=`git hash-object -t tree /dev/null`
-      git diff-tree --numstat $EMPTY HEAD -- "$f" | grep -q "^-[[:blank:]]-" \
-        && continue
-      svnrules=`git check-attr $OCAML_CT_CA_FLAG ocaml-typo "$f" \
+      git diff-tree --numstat $EMPTY $OCAML_CT_HEAD -- "$f" \
+        | grep -q "^-[[:blank:]]-" && continue
+      svnrules=`env $OCAML_CT_GIT_INDEX git check-attr $OCAML_CT_CA_FLAG \
+                                                       ocaml-typo "$f" \
                   | sed -e 's/.*: //'`
       case $svnrules in unspecified) svnrules= ;; esac
     fi

--- a/tools/ci/inria/extra-checks
+++ b/tools/ci/inria/extra-checks
@@ -226,3 +226,11 @@ TSAN_OPTIONS="die_after_fork=0" $run_testsuite
 # # Build the system (bytecode only) and test
 # make $jobs world
 # $run_testsuite
+
+#########################################################################
+
+# Ensure that the repo still passes the check-typo script
+if [ ! -x tools/check-typo ] ; then
+  error "tools/check-typo does not appear to be executable?"
+fi
+tools/check-typo

--- a/tools/ci/travis/travis-ci.sh
+++ b/tools/ci/travis/travis-ci.sh
@@ -186,7 +186,7 @@ CheckTypoTree () {
   do
     if not_pruned $path ; then
       echo "Checking $1: $path"
-      if ! tools/check-typo $path ; then
+      if ! tools/check-typo ./$path ; then
         touch check-typo-failed
       fi
     else

--- a/tools/ci/travis/travis-ci.sh
+++ b/tools/ci/travis/travis-ci.sh
@@ -163,7 +163,8 @@ CheckTypoTree () {
   export OCAML_CT_CAT="git cat-file --textconv"
   export OCAML_CT_PREFIX="$1:"
   GIT_INDEX_FILE=tmp-index git read-tree --reset -i $1
-  git diff-tree --no-commit-id --name-only -r $1 | (while IFS= read -r path
+  git diff-tree --diff-filter=d --no-commit-id --name-only -r $1 \
+    | (while IFS= read -r path
   do
     echo "Checking $1: $path"
     if ! tools/check-typo $path ; then

--- a/tools/ci/travis/travis-ci.sh
+++ b/tools/ci/travis/travis-ci.sh
@@ -182,10 +182,14 @@ CheckTypoAllCommits () {
   rm -f check-typo-failed
   if test -z "$TRAVIS_COMMIT_RANGE"
   then CheckTypo $TRAVIS_COMMIT
-  else for commit in $(git rev-list $TRAVIS_COMMIT_RANGE --reverse)
-       do
-         CheckTypo $commit
-       done
+  else
+    if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]
+    then TRAVIS_COMMIT_RANGE=$TRAVIS_BRANCH..$TRAVIS_PULL_REQUEST_SHA
+    fi
+    for commit in $(git rev-list $TRAVIS_COMMIT_RANGE --reverse)
+      do
+        CheckTypo $commit
+      done
   fi
   echo complete
   if [ -e check-typo-failed ]

--- a/tools/pre-commit-githook
+++ b/tools/pre-commit-githook
@@ -50,7 +50,7 @@ ERRORS=0
 export OCAML_CT_PREFIX=:
 export OCAML_CT_CAT="git cat-file --textconv"
 export OCAML_CT_CA_FLAG=--cached
-git diff --staged --name-only | (while IFS= read -r path
+git diff --diff-filter=d --staged --name-only | (while IFS= read -r path
 do
   if ! tools/check-typo $path ; then
     ERRORS=1

--- a/tools/pre-commit-githook
+++ b/tools/pre-commit-githook
@@ -1,0 +1,49 @@
+#!/bin/sh
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*                David Allsopp, MetaStack Solutions Ltd.                 *
+#*                                                                        *
+#*   Copyright 2017 MetaStack Solutions Ltd.                              *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+# For what it's worth, allow for empty trees!
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+  against=HEAD
+else
+  # Initial commit: diff against an empty tree object
+  against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Git's built-in mechanism for whitespace is neater than ours, so do it first.
+# The strange construction below creates a list of files which have either
+# white-at-eol or white-at-eof included in ocaml-typo in .gitattributes and by
+# prefixing the names with :! causes git diff-index to skip over them.
+FILES=$(git diff-index --cached --name-only $against \
+          | xargs git check-attr --cached ocaml-typo \
+          | sed -ne 's/\(.*\): ocaml-typo:.*[ ,]white-at-eo[fl]\(,\|$\)/:!\1/p')
+if ! git diff-index --check --cached $against -- $FILES ; then
+  exit 1
+fi
+
+# Now run check-typo over all the files in the index
+ERRORS=0
+export OCAML_CT_PREFIX=:
+export OCAML_CT_CAT="git cat-file --textconv"
+export OCAML_CT_CA_FLAG=--cached
+git diff --staged --name-only | (while IFS= read -r path
+do
+  if ! tools/check-typo $path ; then
+    ERRORS=1
+  fi
+done; exit $ERRORS)

--- a/tools/pre-commit-githook
+++ b/tools/pre-commit-githook
@@ -70,7 +70,7 @@ export OCAML_CT_CAT="git cat-file --textconv"
 export OCAML_CT_CA_FLAG=--cached
 git diff --diff-filter=d --staged --name-only | (while IFS= read -r path
 do
-  if not_pruned $path && ! tools/check-typo $path ; then
+  if not_pruned $path && ! tools/check-typo ./$path ; then
     ERRORS=1
   fi
 done; exit $ERRORS)

--- a/tools/pre-commit-githook
+++ b/tools/pre-commit-githook
@@ -45,6 +45,24 @@ if ! git diff-index --check --cached $against -- $FILES ; then
   exit 1
 fi
 
+# Test to see if any part of the directory name has been marked prune
+not_pruned () {
+  DIR=$(dirname "$1")
+  if [ "$DIR" = "." ] ; then
+    return 0
+  else
+    case ",$(git check-attr ocaml-typo "$DIR" | sed -e 's/.*: //')," in
+      ,prune,)
+      return 1
+      ;;
+      *)
+
+      not_pruned $DIR
+      return $?
+    esac
+  fi
+}
+
 # Now run check-typo over all the files in the index
 ERRORS=0
 export OCAML_CT_PREFIX=:
@@ -52,7 +70,7 @@ export OCAML_CT_CAT="git cat-file --textconv"
 export OCAML_CT_CA_FLAG=--cached
 git diff --diff-filter=d --staged --name-only | (while IFS= read -r path
 do
-  if ! tools/check-typo $path ; then
+  if not_pruned $path && ! tools/check-typo $path ; then
     ERRORS=1
   fi
 done; exit $ERRORS)

--- a/tools/pre-commit-githook
+++ b/tools/pre-commit-githook
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #**************************************************************************
 #*                                                                        *
 #*                                 OCaml                                  *
@@ -24,6 +24,15 @@ fi
 
 # Redirect output to stderr.
 exec 1>&2
+
+# Check to see if the script's been updated
+if git ls-files --error-unmatch tools/pre-commit-githook >/dev/null 2>&1 ; then
+  if ! diff -q <(git cat-file --textconv HEAD:tools/pre-commit-githook) "$0" \
+       >/dev/null 2>&1 ; then
+    echo "Note: tools/pre-commit-githook differs from .git/hooks/pre-commit"
+    echo "You may wish to upgrade your local githook"
+  fi
+fi
 
 # Git's built-in mechanism for whitespace is neater than ours, so do it first.
 # The strange construction below creates a list of files which have either


### PR DESCRIPTION
This GPR provides a pre-commit script which can be used as a Githook to automate the use of `tools/check-typo` when developing.

I have ensured that `tools/check-typo` operates on the *index* and not the *working tree* (you can test this by adding a long line or a tab character to a file, doing `git add -u`, correcting the file in your working tree and then running `git commit`) but I haven't checked that the other sections of the script read the "correct" version of .gitattributes and so forth. This is something which should be addressed if this is generalised to the CI (which should really check each commit in turn on a pull request).