### PR TITLE
Fix typo in arm64 assembler directives

### DIFF
--- a/Changes
+++ b/Changes
@@ -28,6 +28,9 @@ Working version
   when using Flambda.
   (Pierre Chambart, review by Mark Shinwell and Leo White)
 
+- GPR#1150: Fix typo in arm64 assembler directives
+  (KC Sivaramakrishnan)
+
 ### Standard library:
 
 - PR#1771, PR#7309, GPR#1026: Add update to maps. Allows to update a

--- a/asmrun/arm64.S
+++ b/asmrun/arm64.S
@@ -254,8 +254,8 @@ caml_alloc3:
     /* Try again */
         b       1b
         CFI_ENDPROC
-        .type   caml_alloc2, %function
-        .size   caml_alloc2, .-caml_alloc2
+        .type   caml_alloc3, %function
+        .size   caml_alloc3, .-caml_alloc3
 
         .align  2
         .globl  caml_allocN


### PR DESCRIPTION
PR fixes a minor typo in the function epilogue of `caml_alloc3` in the arm64 backend. 