### PR TITLE
generalize -dtimings to show allocation, top heap size

### DIFF
--- a/.depend
+++ b/.depend
@@ -6,11 +6,11 @@ utils/ccomp.cmo : utils/misc.cmi utils/config.cmi utils/clflags.cmi \
 utils/ccomp.cmx : utils/misc.cmx utils/config.cmx utils/clflags.cmx \
     utils/ccomp.cmi
 utils/ccomp.cmi :
-utils/clflags.cmo : utils/numbers.cmi utils/misc.cmi utils/config.cmi \
-    utils/arg_helper.cmi utils/clflags.cmi
-utils/clflags.cmx : utils/numbers.cmx utils/misc.cmx utils/config.cmx \
-    utils/arg_helper.cmx utils/clflags.cmi
-utils/clflags.cmi : utils/misc.cmi
+utils/clflags.cmo : utils/timings.cmi utils/numbers.cmi utils/misc.cmi \
+    utils/config.cmi utils/arg_helper.cmi utils/clflags.cmi
+utils/clflags.cmx : utils/timings.cmx utils/numbers.cmx utils/misc.cmx \
+    utils/config.cmx utils/arg_helper.cmx utils/clflags.cmi
+utils/clflags.cmi : utils/timings.cmi utils/misc.cmi
 utils/config.cmo : utils/config.cmi
 utils/config.cmx : utils/config.cmi
 utils/config.cmi :
@@ -2002,10 +2002,12 @@ middle_end/base_types/variable.cmx : utils/misc.cmx utils/identifiable.cmx \
 middle_end/base_types/variable.cmi : utils/identifiable.cmi typing/ident.cmi \
     middle_end/base_types/compilation_unit.cmi
 driver/compdynlink.cmi :
-driver/compenv.cmo : utils/warnings.cmi utils/misc.cmi parsing/location.cmi \
-    utils/config.cmi utils/clflags.cmi utils/ccomp.cmi driver/compenv.cmi
-driver/compenv.cmx : utils/warnings.cmx utils/misc.cmx parsing/location.cmx \
-    utils/config.cmx utils/clflags.cmx utils/ccomp.cmx driver/compenv.cmi
+driver/compenv.cmo : utils/warnings.cmi utils/timings.cmi utils/misc.cmi \
+    parsing/location.cmi utils/config.cmi utils/clflags.cmi utils/ccomp.cmi \
+    driver/compenv.cmi
+driver/compenv.cmx : utils/warnings.cmx utils/timings.cmx utils/misc.cmx \
+    parsing/location.cmx utils/config.cmx utils/clflags.cmx utils/ccomp.cmx \
+    driver/compenv.cmi
 driver/compenv.cmi :
 driver/compile.cmo : utils/warnings.cmi typing/typemod.cmi \
     typing/typedtree.cmi typing/typecore.cmi bytecomp/translmod.cmi \
@@ -2056,10 +2058,10 @@ driver/main.cmx : utils/warnings.cmx utils/timings.cmx utils/misc.cmx \
     driver/compenv.cmx utils/clflags.cmx bytecomp/bytepackager.cmx \
     bytecomp/bytelink.cmx bytecomp/bytelibrarian.cmx driver/main.cmi
 driver/main.cmi :
-driver/main_args.cmo : utils/warnings.cmi utils/config.cmi utils/clflags.cmi \
-    driver/main_args.cmi
-driver/main_args.cmx : utils/warnings.cmx utils/config.cmx utils/clflags.cmx \
-    driver/main_args.cmi
+driver/main_args.cmo : utils/warnings.cmi utils/timings.cmi utils/config.cmi \
+    utils/clflags.cmi driver/main_args.cmi
+driver/main_args.cmx : utils/warnings.cmx utils/timings.cmx utils/config.cmx \
+    utils/clflags.cmx driver/main_args.cmi
 driver/main_args.cmi :
 driver/optcompile.cmo : utils/warnings.cmi typing/typemod.cmi \
     typing/typedtree.cmi typing/typecore.cmi bytecomp/translmod.cmi \
@@ -2231,13 +2233,15 @@ toplevel/toploop.cmi : utils/warnings.cmi typing/types.cmi typing/path.cmi \
     parsing/parsetree.cmi typing/outcometree.cmi parsing/longident.cmi \
     parsing/location.cmi typing/env.cmi
 toplevel/topmain.cmo : utils/warnings.cmi toplevel/toploop.cmi \
-    toplevel/topdirs.cmi utils/misc.cmi driver/main_args.cmi \
-    parsing/location.cmi utils/config.cmi driver/compplugin.cmi \
-    driver/compenv.cmi utils/clflags.cmi toplevel/topmain.cmi
+    toplevel/topdirs.cmi utils/timings.cmi utils/misc.cmi \
+    driver/main_args.cmi parsing/location.cmi utils/config.cmi \
+    driver/compplugin.cmi driver/compenv.cmi utils/clflags.cmi \
+    toplevel/topmain.cmi
 toplevel/topmain.cmx : utils/warnings.cmx toplevel/toploop.cmx \
-    toplevel/topdirs.cmx utils/misc.cmx driver/main_args.cmx \
-    parsing/location.cmx utils/config.cmx driver/compplugin.cmx \
-    driver/compenv.cmx utils/clflags.cmx toplevel/topmain.cmi
+    toplevel/topdirs.cmx utils/timings.cmx utils/misc.cmx \
+    driver/main_args.cmx parsing/location.cmx utils/config.cmx \
+    driver/compplugin.cmx driver/compenv.cmx utils/clflags.cmx \
+    toplevel/topmain.cmi
 toplevel/topmain.cmi :
 toplevel/topstart.cmo : toplevel/topmain.cmi
 toplevel/topstart.cmx : toplevel/topmain.cmx

--- a/.depend
+++ b/.depend
@@ -6,11 +6,11 @@ utils/ccomp.cmo : utils/misc.cmi utils/config.cmi utils/clflags.cmi \
 utils/ccomp.cmx : utils/misc.cmx utils/config.cmx utils/clflags.cmx \
     utils/ccomp.cmi
 utils/ccomp.cmi :
-utils/clflags.cmo : utils/timings.cmi utils/numbers.cmi utils/misc.cmi \
+utils/clflags.cmo : utils/profile.cmi utils/numbers.cmi utils/misc.cmi \
     utils/config.cmi utils/arg_helper.cmi utils/clflags.cmi
-utils/clflags.cmx : utils/timings.cmx utils/numbers.cmx utils/misc.cmx \
+utils/clflags.cmx : utils/profile.cmx utils/numbers.cmx utils/misc.cmx \
     utils/config.cmx utils/arg_helper.cmx utils/clflags.cmi
-utils/clflags.cmi : utils/timings.cmi utils/misc.cmi
+utils/clflags.cmi : utils/profile.cmi utils/misc.cmi
 utils/config.cmo : utils/config.cmi
 utils/config.cmx : utils/config.cmi
 utils/config.cmi :
@@ -40,9 +40,9 @@ utils/tbl.cmi :
 utils/terminfo.cmo : utils/terminfo.cmi
 utils/terminfo.cmx : utils/terminfo.cmi
 utils/terminfo.cmi :
-utils/timings.cmo : utils/misc.cmi utils/timings.cmi
-utils/timings.cmx : utils/misc.cmx utils/timings.cmi
-utils/timings.cmi :
+utils/profile.cmo : utils/misc.cmi utils/profile.cmi
+utils/profile.cmx : utils/misc.cmx utils/profile.cmi
+utils/profile.cmi :
 utils/warnings.cmo : utils/misc.cmi utils/warnings.cmi
 utils/warnings.cmx : utils/misc.cmx utils/warnings.cmi
 utils/warnings.cmi :
@@ -717,7 +717,7 @@ asmcomp/afl_instrument.cmi : asmcomp/cmm.cmi
 asmcomp/arch.cmo : utils/config.cmi utils/clflags.cmi
 asmcomp/arch.cmx : utils/config.cmx utils/clflags.cmx
 asmcomp/asmgen.cmo : asmcomp/un_anf.cmi bytecomp/translmod.cmi \
-    utils/timings.cmi middle_end/base_types/symbol.cmi asmcomp/split.cmi \
+    utils/profile.cmi middle_end/base_types/symbol.cmi asmcomp/split.cmi \
     asmcomp/spill.cmi asmcomp/selection.cmi asmcomp/scheduling.cmi \
     asmcomp/reload.cmi asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/printmach.cmi \
     asmcomp/printlinear.cmi asmcomp/printcmm.cmi asmcomp/printclambda.cmi \
@@ -732,7 +732,7 @@ asmcomp/asmgen.cmo : asmcomp/un_anf.cmi bytecomp/translmod.cmi \
     asmcomp/closure.cmi utils/clflags.cmi asmcomp/clambda.cmi asmcomp/CSE.cmo \
     asmcomp/build_export_info.cmi asmcomp/asmgen.cmi
 asmcomp/asmgen.cmx : asmcomp/un_anf.cmx bytecomp/translmod.cmx \
-    utils/timings.cmx middle_end/base_types/symbol.cmx asmcomp/split.cmx \
+    utils/profile.cmx middle_end/base_types/symbol.cmx asmcomp/split.cmx \
     asmcomp/spill.cmx asmcomp/selection.cmx asmcomp/scheduling.cmx \
     asmcomp/reload.cmx asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/printmach.cmx \
     asmcomp/printlinear.cmx asmcomp/printcmm.cmx asmcomp/printclambda.cmx \
@@ -757,19 +757,19 @@ asmcomp/asmlibrarian.cmx : utils/misc.cmx parsing/location.cmx \
     asmcomp/cmx_format.cmi utils/clflags.cmx asmcomp/clambda.cmx \
     utils/ccomp.cmx asmcomp/asmlink.cmx asmcomp/asmlibrarian.cmi
 asmcomp/asmlibrarian.cmi :
-asmcomp/asmlink.cmo : utils/timings.cmi bytecomp/runtimedef.cmi \
+asmcomp/asmlink.cmo : utils/profile.cmi bytecomp/runtimedef.cmi \
     utils/misc.cmi parsing/location.cmi asmcomp/emitaux.cmi asmcomp/emit.cmi \
     utils/consistbl.cmi utils/config.cmi asmcomp/compilenv.cmi \
     asmcomp/cmx_format.cmi asmcomp/cmmgen.cmi utils/clflags.cmi \
     utils/ccomp.cmi asmcomp/asmgen.cmi asmcomp/asmlink.cmi
-asmcomp/asmlink.cmx : utils/timings.cmx bytecomp/runtimedef.cmx \
+asmcomp/asmlink.cmx : utils/profile.cmx bytecomp/runtimedef.cmx \
     utils/misc.cmx parsing/location.cmx asmcomp/emitaux.cmx asmcomp/emit.cmx \
     utils/consistbl.cmx utils/config.cmx asmcomp/compilenv.cmx \
     asmcomp/cmx_format.cmi asmcomp/cmmgen.cmx utils/clflags.cmx \
     utils/ccomp.cmx asmcomp/asmgen.cmx asmcomp/asmlink.cmi
 asmcomp/asmlink.cmi : asmcomp/cmx_format.cmi
 asmcomp/asmpackager.cmo : typing/typemod.cmi bytecomp/translmod.cmi \
-    utils/timings.cmi utils/misc.cmi middle_end/middle_end.cmi \
+    utils/profile.cmi utils/misc.cmi middle_end/middle_end.cmi \
     parsing/location.cmi bytecomp/lambda.cmi typing/ident.cmi \
     asmcomp/export_info_for_pack.cmi asmcomp/export_info.cmi typing/env.cmi \
     utils/config.cmi asmcomp/compilenv.cmi \
@@ -777,7 +777,7 @@ asmcomp/asmpackager.cmo : typing/typemod.cmi bytecomp/translmod.cmi \
     utils/clflags.cmi utils/ccomp.cmi asmcomp/asmlink.cmi asmcomp/asmgen.cmi \
     asmcomp/asmpackager.cmi
 asmcomp/asmpackager.cmx : typing/typemod.cmx bytecomp/translmod.cmx \
-    utils/timings.cmx utils/misc.cmx middle_end/middle_end.cmx \
+    utils/profile.cmx utils/misc.cmx middle_end/middle_end.cmx \
     parsing/location.cmx bytecomp/lambda.cmx typing/ident.cmx \
     asmcomp/export_info_for_pack.cmx asmcomp/export_info.cmx typing/env.cmx \
     utils/config.cmx asmcomp/compilenv.cmx \
@@ -1671,7 +1671,7 @@ middle_end/lift_let_to_initialize_symbol.cmx : \
 middle_end/lift_let_to_initialize_symbol.cmi : middle_end/flambda.cmi \
     middle_end/backend_intf.cmi
 middle_end/middle_end.cmo : utils/warnings.cmi \
-    middle_end/base_types/variable.cmi utils/timings.cmi \
+    middle_end/base_types/variable.cmi utils/profile.cmi \
     middle_end/base_types/symbol.cmi middle_end/share_constants.cmi \
     middle_end/remove_unused_program_constructs.cmi \
     middle_end/remove_unused_closure_vars.cmi middle_end/ref_to_variables.cmi \
@@ -1685,7 +1685,7 @@ middle_end/middle_end.cmo : utils/warnings.cmi \
     middle_end/base_types/closure_id.cmi middle_end/closure_conversion.cmi \
     utils/clflags.cmi middle_end/backend_intf.cmi middle_end/middle_end.cmi
 middle_end/middle_end.cmx : utils/warnings.cmx \
-    middle_end/base_types/variable.cmx utils/timings.cmx \
+    middle_end/base_types/variable.cmx utils/profile.cmx \
     middle_end/base_types/symbol.cmx middle_end/share_constants.cmx \
     middle_end/remove_unused_program_constructs.cmx \
     middle_end/remove_unused_closure_vars.cmx middle_end/ref_to_variables.cmx \
@@ -2002,16 +2002,16 @@ middle_end/base_types/variable.cmx : utils/misc.cmx utils/identifiable.cmx \
 middle_end/base_types/variable.cmi : utils/identifiable.cmi typing/ident.cmi \
     middle_end/base_types/compilation_unit.cmi
 driver/compdynlink.cmi :
-driver/compenv.cmo : utils/warnings.cmi utils/timings.cmi utils/misc.cmi \
+driver/compenv.cmo : utils/warnings.cmi utils/profile.cmi utils/misc.cmi \
     parsing/location.cmi utils/config.cmi utils/clflags.cmi utils/ccomp.cmi \
     driver/compenv.cmi
-driver/compenv.cmx : utils/warnings.cmx utils/timings.cmx utils/misc.cmx \
+driver/compenv.cmx : utils/warnings.cmx utils/profile.cmx utils/misc.cmx \
     parsing/location.cmx utils/config.cmx utils/clflags.cmx utils/ccomp.cmx \
     driver/compenv.cmi
 driver/compenv.cmi :
 driver/compile.cmo : utils/warnings.cmi typing/typemod.cmi \
     typing/typedtree.cmi typing/typecore.cmi bytecomp/translmod.cmi \
-    utils/timings.cmi typing/stypes.cmi bytecomp/simplif.cmi \
+    utils/profile.cmi typing/stypes.cmi bytecomp/simplif.cmi \
     typing/printtyped.cmi typing/printtyp.cmi bytecomp/printlambda.cmi \
     bytecomp/printinstr.cmi parsing/printast.cmi parsing/pprintast.cmi \
     driver/pparse.cmi utils/misc.cmi bytecomp/lambda.cmi \
@@ -2020,7 +2020,7 @@ driver/compile.cmo : utils/warnings.cmi typing/typemod.cmi \
     bytecomp/bytegen.cmi parsing/builtin_attributes.cmi driver/compile.cmi
 driver/compile.cmx : utils/warnings.cmx typing/typemod.cmx \
     typing/typedtree.cmx typing/typecore.cmx bytecomp/translmod.cmx \
-    utils/timings.cmx typing/stypes.cmx bytecomp/simplif.cmx \
+    utils/profile.cmx typing/stypes.cmx bytecomp/simplif.cmx \
     typing/printtyped.cmx typing/printtyp.cmx bytecomp/printlambda.cmx \
     bytecomp/printinstr.cmx parsing/printast.cmx parsing/pprintast.cmx \
     driver/pparse.cmx utils/misc.cmx bytecomp/lambda.cmx \
@@ -2047,25 +2047,25 @@ driver/compplugin.cmi :
 driver/errors.cmo : parsing/location.cmi driver/errors.cmi
 driver/errors.cmx : parsing/location.cmx driver/errors.cmi
 driver/errors.cmi :
-driver/main.cmo : utils/warnings.cmi utils/timings.cmi utils/misc.cmi \
+driver/main.cmo : utils/warnings.cmi utils/profile.cmi utils/misc.cmi \
     driver/main_args.cmi parsing/location.cmi utils/config.cmi \
     driver/compplugin.cmi driver/compmisc.cmi driver/compile.cmi \
     driver/compenv.cmi utils/clflags.cmi bytecomp/bytepackager.cmi \
     bytecomp/bytelink.cmi bytecomp/bytelibrarian.cmi driver/main.cmi
-driver/main.cmx : utils/warnings.cmx utils/timings.cmx utils/misc.cmx \
+driver/main.cmx : utils/warnings.cmx utils/profile.cmx utils/misc.cmx \
     driver/main_args.cmx parsing/location.cmx utils/config.cmx \
     driver/compplugin.cmx driver/compmisc.cmx driver/compile.cmx \
     driver/compenv.cmx utils/clflags.cmx bytecomp/bytepackager.cmx \
     bytecomp/bytelink.cmx bytecomp/bytelibrarian.cmx driver/main.cmi
 driver/main.cmi :
-driver/main_args.cmo : utils/warnings.cmi utils/timings.cmi utils/config.cmi \
+driver/main_args.cmo : utils/warnings.cmi utils/profile.cmi utils/config.cmi \
     utils/clflags.cmi driver/main_args.cmi
-driver/main_args.cmx : utils/warnings.cmx utils/timings.cmx utils/config.cmx \
+driver/main_args.cmx : utils/warnings.cmx utils/profile.cmx utils/config.cmx \
     utils/clflags.cmx driver/main_args.cmi
 driver/main_args.cmi :
 driver/optcompile.cmo : utils/warnings.cmi typing/typemod.cmi \
     typing/typedtree.cmi typing/typecore.cmi bytecomp/translmod.cmi \
-    utils/timings.cmi typing/stypes.cmi bytecomp/simplif.cmi \
+    utils/profile.cmi typing/stypes.cmi bytecomp/simplif.cmi \
     typing/printtyped.cmi typing/printtyp.cmi bytecomp/printlambda.cmi \
     parsing/printast.cmi parsing/pprintast.cmi driver/pparse.cmi \
     utils/misc.cmi middle_end/middle_end.cmi bytecomp/lambda.cmi \
@@ -2074,7 +2074,7 @@ driver/optcompile.cmo : utils/warnings.cmi typing/typemod.cmi \
     parsing/builtin_attributes.cmi asmcomp/asmgen.cmi driver/optcompile.cmi
 driver/optcompile.cmx : utils/warnings.cmx typing/typemod.cmx \
     typing/typedtree.cmx typing/typecore.cmx bytecomp/translmod.cmx \
-    utils/timings.cmx typing/stypes.cmx bytecomp/simplif.cmx \
+    utils/profile.cmx typing/stypes.cmx bytecomp/simplif.cmx \
     typing/printtyped.cmx typing/printtyp.cmx bytecomp/printlambda.cmx \
     parsing/printast.cmx parsing/pprintast.cmx driver/pparse.cmx \
     utils/misc.cmx middle_end/middle_end.cmx bytecomp/lambda.cmx \
@@ -2085,14 +2085,14 @@ driver/optcompile.cmi : middle_end/backend_intf.cmi
 driver/opterrors.cmo : parsing/location.cmi driver/opterrors.cmi
 driver/opterrors.cmx : parsing/location.cmx driver/opterrors.cmi
 driver/opterrors.cmi :
-driver/optmain.cmo : utils/warnings.cmi utils/timings.cmi asmcomp/proc.cmi \
+driver/optmain.cmo : utils/warnings.cmi utils/profile.cmi asmcomp/proc.cmi \
     asmcomp/printmach.cmi driver/optcompile.cmi utils/misc.cmi \
     driver/main_args.cmi parsing/location.cmi asmcomp/import_approx.cmi \
     utils/config.cmi driver/compplugin.cmi driver/compmisc.cmi \
     asmcomp/compilenv.cmi driver/compenv.cmi utils/clflags.cmi \
     middle_end/backend_intf.cmi asmcomp/asmpackager.cmi asmcomp/asmlink.cmi \
     asmcomp/asmlibrarian.cmi asmcomp/arch.cmo driver/optmain.cmi
-driver/optmain.cmx : utils/warnings.cmx utils/timings.cmx asmcomp/proc.cmx \
+driver/optmain.cmx : utils/warnings.cmx utils/profile.cmx asmcomp/proc.cmx \
     asmcomp/printmach.cmx driver/optcompile.cmx utils/misc.cmx \
     driver/main_args.cmx parsing/location.cmx asmcomp/import_approx.cmx \
     utils/config.cmx driver/compplugin.cmx driver/compmisc.cmx \
@@ -2100,11 +2100,11 @@ driver/optmain.cmx : utils/warnings.cmx utils/timings.cmx asmcomp/proc.cmx \
     middle_end/backend_intf.cmi asmcomp/asmpackager.cmx asmcomp/asmlink.cmx \
     asmcomp/asmlibrarian.cmx asmcomp/arch.cmx driver/optmain.cmi
 driver/optmain.cmi :
-driver/pparse.cmo : utils/timings.cmi parsing/parsetree.cmi \
+driver/pparse.cmo : utils/profile.cmi parsing/parsetree.cmi \
     parsing/parse.cmi utils/misc.cmi parsing/location.cmi utils/config.cmi \
     utils/clflags.cmi utils/ccomp.cmi parsing/ast_mapper.cmi \
     parsing/ast_invariants.cmi driver/pparse.cmi
-driver/pparse.cmx : utils/timings.cmx parsing/parsetree.cmi \
+driver/pparse.cmx : utils/profile.cmx parsing/parsetree.cmi \
     parsing/parse.cmx utils/misc.cmx parsing/location.cmx utils/config.cmx \
     utils/clflags.cmx utils/ccomp.cmx parsing/ast_mapper.cmx \
     parsing/ast_invariants.cmx driver/pparse.cmi
@@ -2233,12 +2233,12 @@ toplevel/toploop.cmi : utils/warnings.cmi typing/types.cmi typing/path.cmi \
     parsing/parsetree.cmi typing/outcometree.cmi parsing/longident.cmi \
     parsing/location.cmi typing/env.cmi
 toplevel/topmain.cmo : utils/warnings.cmi toplevel/toploop.cmi \
-    toplevel/topdirs.cmi utils/timings.cmi utils/misc.cmi \
+    toplevel/topdirs.cmi utils/profile.cmi utils/misc.cmi \
     driver/main_args.cmi parsing/location.cmi utils/config.cmi \
     driver/compplugin.cmi driver/compenv.cmi utils/clflags.cmi \
     toplevel/topmain.cmi
 toplevel/topmain.cmx : utils/warnings.cmx toplevel/toploop.cmx \
-    toplevel/topdirs.cmx utils/timings.cmx utils/misc.cmx \
+    toplevel/topdirs.cmx utils/profile.cmx utils/misc.cmx \
     driver/main_args.cmx parsing/location.cmx utils/config.cmx \
     driver/compplugin.cmx driver/compenv.cmx utils/clflags.cmx \
     toplevel/topmain.cmi

--- a/Changes
+++ b/Changes
@@ -112,6 +112,10 @@ Working version
 - PR#6826, GPR#828, GPR#834: improve compilation time for open
   (Alain Frisch, review by Frédéric Bour and Jacques Garrigue)
 
+- PR#7514, GPR#1152: add -dprofile option, similar to -dtimings but
+  also displays memory allocation and consumption
+  (Valentin Gatien-Baron, report by Gabriel Scherer)
+
 - GPR#1032: display the output of -dtimings as a hierarchy
   (Valentin Gatien-Baron, review by Gabriel Scherer)
 

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ OCAMLDOC_OPT=$(WITH_OCAMLDOC:=.opt)
 
 UTILS=utils/config.cmo utils/misc.cmo \
   utils/identifiable.cmo utils/numbers.cmo utils/arg_helper.cmo \
-  utils/clflags.cmo utils/tbl.cmo utils/timings.cmo \
+  utils/clflags.cmo utils/tbl.cmo utils/profile.cmo \
   utils/terminfo.cmo utils/ccomp.cmo utils/warnings.cmo \
   utils/consistbl.cmo \
   utils/strongly_connected_components.cmo \

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -105,27 +105,27 @@ let compile_fundecl (ppf : formatter) fd_cmm =
   Proc.init ();
   Reg.reset();
   fd_cmm
-  ++ Timings.time ~accumulate:true "selection" Selection.fundecl
+  ++ Profile.record ~accumulate:true "selection" Selection.fundecl
   ++ pass_dump_if ppf dump_selection "After instruction selection"
-  ++ Timings.time ~accumulate:true "comballoc" Comballoc.fundecl
+  ++ Profile.record ~accumulate:true "comballoc" Comballoc.fundecl
   ++ pass_dump_if ppf dump_combine "After allocation combining"
-  ++ Timings.time ~accumulate:true "cse" CSE.fundecl
+  ++ Profile.record ~accumulate:true "cse" CSE.fundecl
   ++ pass_dump_if ppf dump_cse "After CSE"
-  ++ Timings.time ~accumulate:true "liveness" (liveness ppf)
-  ++ Timings.time ~accumulate:true "deadcode" Deadcode.fundecl
+  ++ Profile.record ~accumulate:true "liveness" (liveness ppf)
+  ++ Profile.record ~accumulate:true "deadcode" Deadcode.fundecl
   ++ pass_dump_if ppf dump_live "Liveness analysis"
-  ++ Timings.time ~accumulate:true "spill" Spill.fundecl
-  ++ Timings.time ~accumulate:true "liveness" (liveness ppf)
+  ++ Profile.record ~accumulate:true "spill" Spill.fundecl
+  ++ Profile.record ~accumulate:true "liveness" (liveness ppf)
   ++ pass_dump_if ppf dump_spill "After spilling"
-  ++ Timings.time ~accumulate:true "split" Split.fundecl
+  ++ Profile.record ~accumulate:true "split" Split.fundecl
   ++ pass_dump_if ppf dump_split "After live range splitting"
-  ++ Timings.time ~accumulate:true "liveness" (liveness ppf)
-  ++ Timings.time ~accumulate:true "regalloc" (regalloc ppf 1)
-  ++ Timings.time ~accumulate:true "linearize" Linearize.fundecl
+  ++ Profile.record ~accumulate:true "liveness" (liveness ppf)
+  ++ Profile.record ~accumulate:true "regalloc" (regalloc ppf 1)
+  ++ Profile.record ~accumulate:true "linearize" Linearize.fundecl
   ++ pass_dump_linear_if ppf dump_linear "Linearized code"
-  ++ Timings.time ~accumulate:true "scheduling" Scheduling.fundecl
+  ++ Profile.record ~accumulate:true "scheduling" Scheduling.fundecl
   ++ pass_dump_linear_if ppf dump_scheduling "After instruction scheduling"
-  ++ Timings.time ~accumulate:true "emit" Emit.fundecl
+  ++ Profile.record ~accumulate:true "emit" Emit.fundecl
 
 let compile_phrase ppf p =
   if !dump_cmm then fprintf ppf "%a@." Printcmm.phrase p;
@@ -159,7 +159,7 @@ let compile_unit _output_prefix asm_filename keep_asm
       raise exn
     end;
     let assemble_result =
-      Timings.time "assemble"
+      Profile.record "assemble"
         (Proc.assemble_file asm_filename) obj_filename
     in
     if assemble_result <> 0
@@ -177,8 +177,8 @@ let end_gen_implementation ?toplevel ppf
     (clambda:clambda_and_constants) =
   Emit.begin_assembly ();
   clambda
-  ++ Timings.time "cmm" Cmmgen.compunit
-  ++ Timings.time "compile_phrases" (List.iter (compile_phrase ppf))
+  ++ Profile.record "cmm" Cmmgen.compunit
+  ++ Profile.record "compile_phrases" (List.iter (compile_phrase ppf))
   ++ (fun () -> ());
   (match toplevel with None -> () | Some f -> compile_genfuns ppf f);
 
@@ -199,7 +199,7 @@ let flambda_gen_implementation ?toplevel ~backend ppf
     (program:Flambda.program) =
   let export = Build_export_info.build_export_info ~backend program in
   let (clambda, preallocated, constants) =
-    Timings.time_call "backend" (fun () ->
+    Profile.record_call "backend" (fun () ->
       (program, export)
       ++ Flambda_to_clambda.convert
       ++ flambda_raw_clambda_dump_if ppf

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -260,7 +260,7 @@ let call_linker_shared file_list output_name =
   then raise(Error Linking_error)
 
 let link_shared ppf objfiles output_name =
-  Timings.time_call output_name (fun () ->
+  Profile.record_call output_name (fun () ->
     let units_tolink = List.fold_right scan_file objfiles [] in
     List.iter
       (fun (info, file_name, crc) -> check_consistency file_name info crc)
@@ -315,7 +315,7 @@ let call_linker file_list startup_file output_name =
 (* Main entry point *)
 
 let link ppf objfiles output_name =
-  Timings.time_call output_name (fun () ->
+  Profile.record_call output_name (fun () ->
     let stdlib =
       if !Clflags.gprofile then "stdlib.p.cmxa" else "stdlib.cmxa" in
     let stdexit =

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -81,7 +81,7 @@ let check_units members =
 
 let make_package_object ppf members targetobj targetname coercion
       ~backend =
-  Timings.time_call (Printf.sprintf "pack(%s)" targetname) (fun () ->
+  Profile.record_call (Printf.sprintf "pack(%s)" targetname) (fun () ->
     let objtemp =
       if !Clflags.keep_asm_file
       then Filename.remove_extension targetobj ^ ".pack" ^ Config.ext_obj

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -404,7 +404,9 @@ let read_one_param ppf position name v =
   | "can-discard" ->
     can_discard := v ::!can_discard
 
-  | "timings" -> set "timings" [ print_timings ] v
+  | "timings" | "profile" ->
+     let if_on = if name = "timings" then [ `Time ] else Timings.all_columns in
+     profile_columns := if check_bool ppf name v then if_on else []
 
   | "plugin" -> !load_plugin v
 

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -405,7 +405,7 @@ let read_one_param ppf position name v =
     can_discard := v ::!can_discard
 
   | "timings" | "profile" ->
-     let if_on = if name = "timings" then [ `Time ] else Timings.all_columns in
+     let if_on = if name = "timings" then [ `Time ] else Profile.all_columns in
      profile_columns := if check_bool ppf name v then if_on else []
 
   | "plugin" -> !load_plugin v

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -118,7 +118,7 @@ module Options = Main_args.Make_bytecomp_options (struct
   let _dlambda = set dump_lambda
   let _dinstr = set dump_instr
   let _dtimings () = profile_columns := [ `Time ]
-  let _dprofile () = profile_columns := Timings.all_columns
+  let _dprofile () = profile_columns := Profile.all_columns
 
   let _args = Arg.read_arg
   let _args0 = Arg.read_arg0
@@ -199,5 +199,5 @@ let main () =
 
 let () =
   main ();
-  Timings.print Format.std_formatter !Clflags.profile_columns;
+  Profile.print Format.std_formatter !Clflags.profile_columns;
   exit 0

--- a/driver/main.ml
+++ b/driver/main.ml
@@ -117,7 +117,8 @@ module Options = Main_args.Make_bytecomp_options (struct
   let _drawlambda = set dump_rawlambda
   let _dlambda = set dump_lambda
   let _dinstr = set dump_instr
-  let _dtimings = set print_timings
+  let _dtimings () = profile_columns := [ `Time ]
+  let _dprofile () = profile_columns := Timings.all_columns
 
   let _args = Arg.read_arg
   let _args0 = Arg.read_arg0
@@ -198,5 +199,5 @@ let main () =
 
 let () =
   main ();
-  if !Clflags.print_timings then Timings.print Format.std_formatter;
+  Timings.print Format.std_formatter !Clflags.profile_columns;
   exit 0

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -460,7 +460,11 @@ let mk_thread f =
 ;;
 
 let mk_dtimings f =
-  "-dtimings", Arg.Unit f, " Print timings"
+  "-dtimings", Arg.Unit f, " Print timings information for each pass";
+;;
+
+let mk_dprofile f =
+  "-dprofile", Arg.Unit f, Timings.options_doc
 ;;
 
 let mk_unbox_closures f =
@@ -843,6 +847,7 @@ module type Compiler_options = sig
 
   val _nopervasives : unit -> unit
   val _dtimings : unit -> unit
+  val _dprofile : unit -> unit
 
   val _args: string -> string array
   val _args0: string -> string array
@@ -1070,6 +1075,7 @@ struct
     mk_dlambda F._dlambda;
     mk_dinstr F._dinstr;
     mk_dtimings F._dtimings;
+    mk_dprofile F._dprofile;
 
     mk_args F._args;
     mk_args0 F._args0;
@@ -1263,6 +1269,7 @@ struct
     mk_dinterval F._dinterval;
     mk_dstartup F._dstartup;
     mk_dtimings F._dtimings;
+    mk_dprofile F._dprofile;
     mk_dump_pass F._dump_pass;
 
     mk_args F._args;

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -464,7 +464,7 @@ let mk_dtimings f =
 ;;
 
 let mk_dprofile f =
-  "-dprofile", Arg.Unit f, Timings.options_doc
+  "-dprofile", Arg.Unit f, Profile.options_doc
 ;;
 
 let mk_unbox_closures f =

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -100,6 +100,7 @@ module type Compiler_options = sig
 
   val _nopervasives : unit -> unit
   val _dtimings : unit -> unit
+  val _dprofile : unit -> unit
 
   val _args: string -> string array
   val _args0: string -> string array

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -225,7 +225,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _dinterval = set dump_interval
   let _dstartup = set keep_startup_file
   let _dtimings () = profile_columns := [ `Time ]
-  let _dprofile () = profile_columns := Timings.all_columns
+  let _dprofile () = profile_columns := Profile.all_columns
   let _opaque = set opaque
 
   let _args = Arg.read_arg
@@ -310,5 +310,5 @@ let main () =
 
 let () =
   main ();
-  Timings.print Format.std_formatter !Clflags.profile_columns;
+  Profile.print Format.std_formatter !Clflags.profile_columns;
   exit 0

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -224,7 +224,8 @@ module Options = Main_args.Make_optcomp_options (struct
   let _dlinear = set dump_linear
   let _dinterval = set dump_interval
   let _dstartup = set keep_startup_file
-  let _dtimings = set print_timings
+  let _dtimings () = profile_columns := [ `Time ]
+  let _dprofile () = profile_columns := Timings.all_columns
   let _opaque = set opaque
 
   let _args = Arg.read_arg
@@ -309,5 +310,5 @@ let main () =
 
 let () =
   main ();
-  if !Clflags.print_timings then Timings.print Format.std_formatter;
+  Timings.print Format.std_formatter !Clflags.profile_columns;
   exit 0

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -38,7 +38,7 @@ let preprocess sourcefile =
   match !Clflags.preprocessor with
     None -> sourcefile
   | Some pp ->
-      Timings.time "-pp"
+      Profile.record "-pp"
         (call_external_preprocessor sourcefile) pp
 
 
@@ -180,13 +180,13 @@ let file_aux ppf ~tool_name inputfile (type a) parse_fun invariant_fun
         seek_in ic 0;
         let lexbuf = Lexing.from_channel ic in
         Location.init lexbuf inputfile;
-        Timings.time_call "parser" (fun () -> parse_fun lexbuf)
+        Profile.record_call "parser" (fun () -> parse_fun lexbuf)
       end
     with x -> close_in ic; raise x
   in
   close_in ic;
   let ast =
-    Timings.time_call "-ppx" (fun () ->
+    Profile.record_call "-ppx" (fun () ->
       apply_rewriters ~restore:false ~tool_name kind ast) in
   if is_ast_file || !Clflags.all_ppx <> [] then invariant_fun ast;
   ast
@@ -230,10 +230,10 @@ module InterfaceHooks = Misc.MakeHooks(struct
   end)
 
 let parse_implementation ppf ~tool_name sourcefile =
-  Timings.time_call "parsing" (fun () ->
+  Profile.record_call "parsing" (fun () ->
     parse_file ~tool_name Ast_invariants.structure
       ImplementationHooks.apply_hooks Structure ppf sourcefile)
 let parse_interface ppf ~tool_name sourcefile =
-  Timings.time_call "parsing" (fun () ->
+  Profile.record_call "parsing" (fun () ->
     parse_file ~tool_name Ast_invariants.signature
       InterfaceHooks.apply_hooks Signature ppf sourcefile)

--- a/middle_end/middle_end.ml
+++ b/middle_end/middle_end.ml
@@ -35,7 +35,7 @@ let middle_end ppf ~prefixname ~backend
     ~filename
     ~module_ident
     ~module_initializer =
-  Timings.time_call "flambda" (fun () ->
+  Profile.record_call "flambda" (fun () ->
     let pass_number = ref 0 in
     let round_number = ref 0 in
     let check flam =
@@ -55,15 +55,15 @@ let middle_end ppf ~prefixname ~backend
           !round_number Flambda.print_program flam;
         Format.eprintf "\n@?"
       end;
-      let flam = Timings.time ~accumulate:true name pass flam in
+      let flam = Profile.record ~accumulate:true name pass flam in
       if !Clflags.flambda_invariant_checks then begin
-        Timings.time ~accumulate:true "check" check flam
+        Profile.record ~accumulate:true "check" check flam
       end;
       flam
     in
-    Timings.time_call ~accumulate:true "middle_end" (fun () ->
+    Profile.record_call ~accumulate:true "middle_end" (fun () ->
       let flam =
-        Timings.time_call ~accumulate:true "closure_conversion" (fun () ->
+        Profile.record_call ~accumulate:true "closure_conversion" (fun () ->
           module_initializer
           |> Closure_conversion.lambda_to_flambda ~backend ~module_ident
                ~size ~filename)

--- a/testsuite/tests/asmcomp/main.ml
+++ b/testsuite/tests/asmcomp/main.ml
@@ -58,10 +58,10 @@ let main() =
      "-dreload", Arg.Set dump_reload, "";
      "-dscheduling", Arg.Set dump_scheduling, "";
      "-dlinear", Arg.Set dump_linear, "";
-     "-dtimings", Arg.Set print_timings, "";
+     "-dtimings", Arg.Unit (fun () -> profile_columns := [ `Time ]), "";
     ] compile_file usage
 
 let () =
   main ();
-  if !Clflags.print_timings then Timings.print Format.std_formatter;
+  Timings.print Format.std_formatter !Clflags.profile_columns;
   exit 0

--- a/testsuite/tests/asmcomp/main.ml
+++ b/testsuite/tests/asmcomp/main.ml
@@ -63,5 +63,5 @@ let main() =
 
 let () =
   main ();
-  Timings.print Format.std_formatter !Clflags.profile_columns;
+  Profile.print Format.std_formatter !Clflags.profile_columns;
   exit 0

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -133,8 +133,8 @@ CSLPROF_IMPORTS=misc.cmo config.cmo identifiable.cmo numbers.cmo \
 
 $(call byte_and_opt,ocamlprof,$(CSLPROF_IMPORTS) profiling.cmo $(CSLPROF),)
 
-ocamlcp_cmos = misc.cmo warnings.cmo config.cmo identifiable.cmo numbers.cmo \
-	       arg_helper.cmo clflags.cmo main_args.cmo
+ocamlcp_cmos = misc.cmo timings.cmo warnings.cmo config.cmo identifiable.cmo \
+               numbers.cmo arg_helper.cmo clflags.cmo main_args.cmo
 
 $(call byte_and_opt,ocamlcp,$(ocamlcp_cmos) ocamlcp.cmo,)
 $(call byte_and_opt,ocamloptp,$(ocamlcp_cmos) ocamloptp.cmo,)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -133,7 +133,7 @@ CSLPROF_IMPORTS=misc.cmo config.cmo identifiable.cmo numbers.cmo \
 
 $(call byte_and_opt,ocamlprof,$(CSLPROF_IMPORTS) profiling.cmo $(CSLPROF),)
 
-ocamlcp_cmos = misc.cmo timings.cmo warnings.cmo config.cmo identifiable.cmo \
+ocamlcp_cmos = misc.cmo profile.cmo warnings.cmo config.cmo identifiable.cmo \
                numbers.cmo arg_helper.cmo clflags.cmo main_args.cmo
 
 $(call byte_and_opt,ocamlcp,$(ocamlcp_cmos) ocamlcp.cmo,)

--- a/tools/ocamlcp.ml
+++ b/tools/ocamlcp.ml
@@ -126,6 +126,7 @@ module Options = Main_args.Make_bytecomp_options (struct
   let _dflambda = option "-dflambda"
   let _dinstr = option "-dinstr"
   let _dtimings = option "-dtimings"
+  let _dprofile = option "-dprofile"
   let _args = Arg.read_arg
   let _args0 = Arg.read_arg0
   let anonymous = process_file

--- a/tools/ocamloptp.ml
+++ b/tools/ocamloptp.ml
@@ -174,6 +174,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _dstartup = option "-dstartup"
   let _dinterval = option "-dinterval"
   let _dtimings = option "-dtimings"
+  let _dprofile = option "-dprofile"
   let _opaque = option "-opaque"
 
   let _args = Arg.read_arg

--- a/toplevel/topmain.ml
+++ b/toplevel/topmain.ml
@@ -145,7 +145,7 @@ module Options = Main_args.Make_bytetop_options (struct
   let _dlambda = set dump_lambda
   let _dflambda = set dump_flambda
   let _dtimings () = profile_columns := [ `Time ]
-  let _dprofile () = profile_columns := Timings.all_columns
+  let _dprofile () = profile_columns := Profile.all_columns
   let _dinstr = set dump_instr
 
   let _args = wrap_expand Arg.read_arg

--- a/toplevel/topmain.ml
+++ b/toplevel/topmain.ml
@@ -144,7 +144,8 @@ module Options = Main_args.Make_bytetop_options (struct
   let _drawlambda = set dump_rawlambda
   let _dlambda = set dump_lambda
   let _dflambda = set dump_flambda
-  let _dtimings = set print_timings
+  let _dtimings () = profile_columns := [ `Time ]
+  let _dprofile () = profile_columns := Timings.all_columns
   let _dinstr = set dump_instr
 
   let _args = wrap_expand Arg.read_arg

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -124,7 +124,7 @@ let dump_linear = ref false             (* -dlinear *)
 let dump_interval = ref false           (* -dinterval *)
 let keep_startup_file = ref false       (* -dstartup *)
 let dump_combine = ref false            (* -dcombine *)
-let print_timings = ref false           (* -dtimings *)
+let profile_columns : Timings.column list ref = ref [] (* -dprofile/-dtimings *)
 
 let native_code = ref false             (* set to true under ocamlopt *)
 

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -124,7 +124,7 @@ let dump_linear = ref false             (* -dlinear *)
 let dump_interval = ref false           (* -dinterval *)
 let keep_startup_file = ref false       (* -dstartup *)
 let dump_combine = ref false            (* -dcombine *)
-let profile_columns : Timings.column list ref = ref [] (* -dprofile/-dtimings *)
+let profile_columns : Profile.column list ref = ref [] (* -dprofile/-dtimings *)
 
 let native_code = ref false             (* set to true under ocamlopt *)
 

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -182,7 +182,7 @@ val keep_docs : bool ref
 val keep_locs : bool ref
 val unsafe_string : bool ref
 val opaque : bool ref
-val profile_columns : Timings.column list ref
+val profile_columns : Profile.column list ref
 val flambda_invariant_checks : bool ref
 val unbox_closures : bool ref
 val unbox_closures_factor : int ref

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -182,7 +182,7 @@ val keep_docs : bool ref
 val keep_locs : bool ref
 val unsafe_string : bool ref
 val opaque : bool ref
-val print_timings : bool ref
+val profile_columns : Timings.column list ref
 val flambda_invariant_checks : bool ref
 val unbox_closures : bool ref
 val unbox_closures_factor : int ref

--- a/utils/profile.mli
+++ b/utils/profile.mli
@@ -18,18 +18,18 @@
 type file = string
 
 val reset : unit -> unit
-(** erase all recorded times *)
+(** erase all recorded profile information *)
 
-val time_call : ?accumulate:bool -> string -> (unit -> 'a) -> 'a
-(** [time_call pass f] calls [f] and records its runtime. *)
+val record_call : ?accumulate:bool -> string -> (unit -> 'a) -> 'a
+(** [record_call pass f] calls [f] and records its profile information. *)
 
-val time : ?accumulate:bool -> string -> ('a -> 'b) -> 'a -> 'b
-(** [time pass f arg] records the runtime of [f arg] *)
+val record : ?accumulate:bool -> string -> ('a -> 'b) -> 'a -> 'b
+(** [record pass f arg] records the profile information of [f arg] *)
 
 type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
 
 val print : Format.formatter -> column list -> unit
-(** Prints all recorded timings to the formatter. *)
+(** Prints the selected recorded profiling information to the formatter. *)
 
 (** Command line flags *)
 

--- a/utils/timings.ml
+++ b/utils/timings.ml
@@ -13,86 +13,321 @@
 (*                                                                        *)
 (**************************************************************************)
 
+[@@@ocaml.warning "+a-18-40-42-48"]
+
 type file = string
 
 external time_include_children: bool -> float = "caml_sys_time_include_children"
 let cpu_time () = time_include_children true
 
-type times = { start : float; duration : float }
+module Measure = struct
+  type t = {
+    time : float;
+    allocated_words : float;
+    top_heap_words : int;
+  }
+  let create () =
+    let stat = Gc.quick_stat () in
+    {
+      time = cpu_time ();
+      allocated_words = stat.minor_words +. stat.major_words;
+      top_heap_words = stat.top_heap_words;
+    }
+  let zero = { time = 0.; allocated_words = 0.; top_heap_words = 0 }
+end
+
+module Measure_diff = struct
+  let timestamp = let r = ref (-1) in fun () -> incr r; !r
+  type t = {
+    timestamp : int;
+    duration : float;
+    allocated_words : float;
+    top_heap_words_increase : int;
+  }
+  let zero () = {
+    timestamp = timestamp ();
+    duration = 0.;
+    allocated_words = 0.;
+    top_heap_words_increase = 0;
+  }
+  let accumulate t (m1 : Measure.t) (m2 : Measure.t) = {
+    timestamp = t.timestamp;
+    duration = t.duration +. (m2.time -. m1.time);
+    allocated_words =
+      t.allocated_words +. (m2.allocated_words -. m1.allocated_words);
+    top_heap_words_increase =
+      t.top_heap_words_increase + (m2.top_heap_words - m1.top_heap_words);
+  }
+  let of_diff m1 m2 =
+    accumulate (zero ()) m1 m2
+end
+
 type hierarchy =
-  | E of (string, times * hierarchy) Hashtbl.t
+  | E of (string, Measure_diff.t * hierarchy) Hashtbl.t
 [@@unboxed]
 
-let hierarchy = ref (E (Hashtbl.create 2))
-let reset () = hierarchy := E (Hashtbl.create 2)
+let create () = E (Hashtbl.create 2)
+let hierarchy = ref (create ())
+let initial_measure = ref None
+let reset () = hierarchy := create (); initial_measure := None
 
 let time_call ?(accumulate = false) name f =
   let E prev_hierarchy = !hierarchy in
-  let this_times, this_table =
-    (* We allow the recording of multiple categories by the same name, for tools like
-       ocamldoc that use the compiler libs but don't care about timings information,
-       and so may record, say, "parsing" multiple times. *)
+  let start_measure = Measure.create () in
+  if !initial_measure = None then initial_measure := Some start_measure;
+  let this_measure_diff, this_table =
+    (* We allow the recording of multiple categories by the same name, for tools
+       like ocamldoc that use the compiler libs but don't care about timings
+       information, and so may record, say, "parsing" multiple times. *)
     if accumulate
     then
       match Hashtbl.find prev_hierarchy name with
-      | exception Not_found -> None, Hashtbl.create 2
-      | times, E table ->
+      | exception Not_found -> Measure_diff.zero (), Hashtbl.create 2
+      | measure_diff, E table ->
         Hashtbl.remove prev_hierarchy name;
-        Some times, table
-    else None, Hashtbl.create 2
+        measure_diff, table
+    else Measure_diff.zero (), Hashtbl.create 2
   in
   hierarchy := E this_table;
-  let start = cpu_time () in
   Misc.try_finally f
     (fun () ->
        hierarchy := E prev_hierarchy;
-       let end_ = cpu_time () in
-       let times =
-         match this_times with
-         | None -> { start; duration = end_ -. start }
-         | Some { start = initial_start; duration } ->
-           { start = initial_start; duration = duration +. end_ -. start }
-       in
-       Hashtbl.add prev_hierarchy name (times, E this_table))
+       let end_measure = Measure.create () in
+       let measure_diff =
+         Measure_diff.accumulate this_measure_diff start_measure end_measure in
+       Hashtbl.add prev_hierarchy name (measure_diff, E this_table))
 
 let time ?accumulate pass f x = time_call ?accumulate pass (fun () -> f x)
 
+type display = {
+  to_string : max:float -> width:int -> string;
+  worth_displaying : max:float -> bool;
+}
+
+let time_display v : display =
+  (* Because indentation is meaningful, and because the durations are
+     the first element of each row, we can't pad them with spaces. *)
+  let to_string_without_unit v ~width = Printf.sprintf "%0*.03f" width v in
+  let to_string ~max:_ ~width =
+    to_string_without_unit v ~width:(width - 1) ^ "s" in
+  let worth_displaying ~max:_ =
+    float_of_string (to_string_without_unit v ~width:0) <> 0. in
+  { to_string; worth_displaying }
+
+let memory_word_display =
+  (* To make memory numbers easily comparable across rows, we choose a single
+     scale for an entire column. To keep the display compact and not overly
+     precise (no one cares about the exact number of bytes), we pick the largest
+     scale we can and we only show 3 digits. Avoiding showing tiny numbers also
+     allows us to avoid displaying passes that barely allocate compared to the
+     rest of the compiler.  *)
+  let bytes_of_words words = words *. float_of_int (Sys.word_size / 8) in
+  let to_string_without_unit v ~width scale =
+    let precision = 3 and precision_power = 1e3 in
+    let v_rescaled = bytes_of_words v /. scale in
+    let v_rounded =
+      floor (v_rescaled *. precision_power +. 0.5) /. precision_power in
+    let v_str = Printf.sprintf "%.*f" precision v_rounded in
+    let index_of_dot = String.index v_str '.' in
+    let v_str_truncated =
+      String.sub v_str 0
+        (if index_of_dot >= precision
+         then index_of_dot
+         else precision + 1)
+    in
+    Printf.sprintf "%*s" width v_str_truncated
+  in
+  let choose_memory_scale =
+    let units = [|"B"; "kB"; "MB"; "GB"|] in
+    fun words ->
+      let bytes = bytes_of_words words in
+      let scale = ref (Array.length units - 1) in
+      while !scale > 0 && bytes < 1024. ** float_of_int !scale do
+        decr scale
+      done;
+      1024. ** float_of_int !scale, units.(!scale)
+  in
+  fun ?previous v : display ->
+    let to_string ~max ~width =
+      let scale, scale_str = choose_memory_scale max in
+      let width = width - String.length scale_str in
+      to_string_without_unit v ~width scale ^ scale_str
+    in
+    let worth_displaying ~max =
+      let scale, _ = choose_memory_scale max in
+      float_of_string (to_string_without_unit v ~width:0 scale) <> 0.
+      && match previous with
+      | None -> true
+      | Some p ->
+         (* This branch is for numbers that represent absolute quantity, rather
+            than differences. It allows us to skip displaying the same absolute
+            quantity many times in a row. *)
+         to_string_without_unit p ~width:0 scale
+         <> to_string_without_unit v ~width:0 scale
+    in
+    { to_string; worth_displaying }
+
 let timings_list (E table) =
   let l = Hashtbl.fold (fun k d l -> (k, d) :: l) table [] in
-  List.sort (fun (pass1, (start1, _)) (pass2, (start2, _)) ->
-    compare (start1, pass1) (start2, pass2)) l
+  List.sort (fun (_, (p1, _)) (_, (p2, _)) ->
+    compare p1.Measure_diff.timestamp p2.Measure_diff.timestamp) l
 
-(* Because indentation is meaningful, and because the durations are
-   the first element of each row, we can't pad them with spaces. *)
-let duration_as_string ~pad duration = Printf.sprintf "%0*.03f" pad duration
+let compute_other_category (E table : hierarchy) (total : Measure_diff.t) =
+  let r = ref total in
+  Hashtbl.iter (fun _pass ((p2 : Measure_diff.t), _) ->
+    let p1 = !r in
+    r := {
+      timestamp = p1.timestamp;
+      duration = p1.duration -. p2.duration;
+      allocated_words = p1.allocated_words -. p2.allocated_words;
+      top_heap_words_increase =
+        p1.top_heap_words_increase - p2.top_heap_words_increase;
+    }
+  ) table;
+  !r
 
-let rec print ppf hierarchy ~total ~nesting =
-  let total_of_children = ref 0. in
+type row = R of string * (float * display) list * row list
+type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
+
+let rec rows_of_hierarchy ~nesting make_row name measure_diff hierarchy env =
+  let rows =
+    rows_of_hierarchy_list
+      ~nesting:(nesting + 1) make_row hierarchy measure_diff env in
+  let values, env =
+    make_row env measure_diff ~toplevel_other:(nesting = 0 && name = "other") in
+  R (name, values, rows), env
+
+and rows_of_hierarchy_list ~nesting make_row hierarchy total env =
   let list = timings_list hierarchy in
-  let max_duration_width =
-    List.fold_left
-      (fun acc (_, (times, _)) ->
-         max acc (String.length (duration_as_string ~pad:0 times.duration)))
-      0 list
+  let list =
+    if list <> [] || nesting = 0
+    then list @ [ "other", (compute_other_category hierarchy total, create ()) ]
+    else []
   in
-  let print_pass ~duration ~pass =
-    let duration_as_string =
-      duration_as_string ~pad:max_duration_width duration in
-    if float_of_string duration_as_string <> 0. then
-      Format.fprintf ppf "%s%ss %s@\n"
-        (String.make (nesting * 2) ' ') duration_as_string pass
-  in
-  List.iter (fun (pass, ({ start = _; duration }, sub_hierarchy)) ->
-    print_pass ~duration ~pass;
-    print ppf sub_hierarchy ~total:duration ~nesting:(nesting + 1);
-    total_of_children := !total_of_children +. duration;
-  ) list;
-  if list <> [] || nesting = 0 then
-    print_pass ~duration:(total -. !total_of_children) ~pass:"other";
-;;
+  let env = ref env in
+  List.map (fun (name, (measure_diff, hierarchy)) ->
+    let a, env' =
+      rows_of_hierarchy ~nesting make_row name measure_diff hierarchy !env in
+    env := env';
+    a
+  ) list
 
-let print ?(total = cpu_time ()) ppf =
-  print ppf !hierarchy ~total ~nesting:0
+let rows_of_hierarchy hierarchy measure_diff initial_measure columns =
+  (* Computing top heap size is a bit complicated: if the compiler applies a
+     list of passes n times (rather than applying pass1 n times, then pass2 n
+     times etc), we only show one row for that pass but what does "top heap
+     size at the end of that pass" even mean?
+     It seems the only sensible answer is to pretend the compiler applied pass1
+     n times, pass2 n times by accumulating all the heap size increases that
+     happened during each pass, and then compute what the heap size would have
+     been. So that's what we do.
+     There's a bit of extra complication, which is that the heap can increase in
+     between measurements. So the heap sizes can be a bit off until the "other"
+     rows account for what's missing. We special case the toplevel "other" row
+     so that any increases that happened before the start of the compilation is
+     correctly reported, as a lot of code may run before the start of the
+     compilation (eg functor applications). *)
+    let make_row prev_top_heap_words (p : Measure_diff.t) ~toplevel_other =
+      let top_heap_words =
+        prev_top_heap_words
+        + p.top_heap_words_increase
+        - if toplevel_other
+          then initial_measure.Measure.top_heap_words
+          else 0
+      in
+      let make value ~f = value, f value in
+      List.map (function
+        | `Time ->
+          make p.duration ~f:time_display
+        | `Alloc ->
+          make p.allocated_words ~f:memory_word_display
+        | `Top_heap ->
+          make (float_of_int p.top_heap_words_increase) ~f:memory_word_display
+        | `Abs_top_heap ->
+          make (float_of_int top_heap_words)
+           ~f:(memory_word_display ~previous:(float_of_int prev_top_heap_words))
+      ) columns,
+      top_heap_words
+  in
+  rows_of_hierarchy_list ~nesting:0 make_row hierarchy measure_diff
+    initial_measure.top_heap_words
+
+let max_by_column ~n_columns rows =
+  let a = Array.make n_columns 0. in
+  let rec loop (R (_, values, rows)) =
+    List.iteri (fun i (v, _) -> a.(i) <- max a.(i) v) values;
+    List.iter loop rows
+  in
+  List.iter loop rows;
+  a
+
+let width_by_column ~n_columns ~display_cell rows =
+  let a = Array.make n_columns 1 in
+  let rec loop (R (_, values, rows)) =
+    List.iteri (fun i cell ->
+      let _, str = display_cell i cell ~width:0 in
+      a.(i) <- max a.(i) (String.length str)
+    ) values;
+    List.iter loop rows;
+  in
+  List.iter loop rows;
+  a
+
+let display_rows ppf rows =
+  let n_columns =
+    match rows with
+    | [] -> 0
+    | R (_, values, _) :: _ -> List.length values
+  in
+  let maxs = max_by_column ~n_columns rows in
+  let display_cell i (_, c) ~width =
+    let display_cell = c.worth_displaying ~max:maxs.(i) in
+    display_cell, if display_cell
+                  then c.to_string ~max:maxs.(i) ~width
+                  else String.make width '-'
+  in
+  let widths = width_by_column ~n_columns ~display_cell rows in
+  let rec loop (R (name, values, rows)) ~indentation =
+    let worth_displaying, cell_strings =
+      values
+      |> List.mapi (fun i cell -> display_cell i cell ~width:widths.(i))
+      |> List.split
+    in
+    if List.exists (fun b -> b) worth_displaying then
+      Format.fprintf ppf "%s%s %s@\n"
+        indentation (String.concat " " cell_strings) name;
+    List.iter (loop ~indentation:("  " ^ indentation)) rows;
+  in
+  List.iter (loop ~indentation:"") rows
+
+let print ppf columns =
+  match columns with
+  | [] -> ()
+  | _ :: _ ->
+     let initial_measure =
+       match !initial_measure with
+       | Some v -> v
+       | None -> Measure.zero
+     in
+     let total = Measure_diff.of_diff Measure.zero (Measure.create ()) in
+     display_rows ppf (rows_of_hierarchy !hierarchy total initial_measure columns)
+
+let column_mapping = [
+  "time", `Time;
+  "alloc", `Alloc;
+  "top-heap", `Top_heap;
+  "absolute-top-heap", `Abs_top_heap;
+]
+
+let column_names = List.map fst column_mapping
+
+let options_doc =
+  Printf.sprintf
+    " Print performance information for each pass\
+   \n    The columns are: %s."
+    (String.concat " " column_names)
+
+let all_columns = List.map snd column_mapping
 
 let generate = "generate"
 let transl = "transl"

--- a/utils/timings.mli
+++ b/utils/timings.mli
@@ -17,8 +17,6 @@
 
 type file = string
 
-val cpu_time : unit -> float
-
 val reset : unit -> unit
 (** erase all recorded times *)
 
@@ -28,8 +26,15 @@ val time_call : ?accumulate:bool -> string -> (unit -> 'a) -> 'a
 val time : ?accumulate:bool -> string -> ('a -> 'b) -> 'a -> 'b
 (** [time pass f arg] records the runtime of [f arg] *)
 
-val print : ?total:float -> Format.formatter -> unit
+type column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap ]
+
+val print : Format.formatter -> column list -> unit
 (** Prints all recorded timings to the formatter. *)
+
+(** Command line flags *)
+
+val options_doc : string
+val all_columns : column list
 
 (** A few pass names that are needed in several places, and shared to
     avoid typos. *)


### PR DESCRIPTION
This is an alternative way of implementing #1137. For now, I simply changed -dtimings to print extra information so we can discuss its format, but we'd need to implement or copy from #1137 extra flags to control whether to show the extra information.

See an example of output below. The five columns are: time of the pass, allocation of that pass, growth of the heap during that pass, and max size of the heap at the end of the pass (rather than the live size), and name of the pass.

As before, useless rows are omitted. When rows have both interesting information and noninteresting information (zero or same as previous element of the column), the latter one is replaced by dashes, which makes it easier to see what's interesting.

The output is kept compact by keeping the numbers short.

The values should be easily comparable because, in a given column, they use the same unit.

Finally, the max heap size that's displayed is not directly what's measured, because for passes that are combined, there's no way to measure (or even define) what that is. For instance, the compiler will run `selection` and `comballoc` on a first input, and then on a second input etc. What does "max heap size at the end of `selection` mean"?
If we simply take the max of all heap sizes at the end of the pass, if `comballoc` causes the heap to grow on the first input, on the second input, we would set the max heap size for `selection` to the same size. So for all passes that run interleaved, we would report the same max heap size.
So instead, I assume that the heap would have grown during the same passes if the compiler had run `selection` on all inputs, then `comballoc` on all inputs etc, and compute what the heap size would have been in this case.

```
$ installed/bin/ocamlopt.byte -g -dtimings -I utils -I parsing -c parsing/pprintast.ml
2.228s  320MB 31.4MB 35.1MB parsing/pprintast.ml
  0.048s 7.40MB ------ ------ parsing
    0.048s 7.40MB ------ ------ parser
  0.888s 96.4MB 9.47MB 13.2MB typing
  0.140s 20.8MB 1.98MB 15.2MB transl
  1.148s  195MB 19.9MB 35.1MB generate
    0.052s 12.5MB ------ ------ cmm
    0.760s  147MB 13.1MB 28.3MB compile_phrases
      0.084s 16.4MB 3.47MB 18.6MB selection
      0.012s 1.87MB ------ ------ comballoc
      0.052s 9.18MB ------ ------ cse
      0.100s 13.1MB ------ ------ liveness
      0.020s 3.84MB ------ ------ deadcode
      0.088s 14.5MB 3.02MB 21.6MB spill
      0.032s 3.48MB ------ ------ split
      0.304s 67.9MB 6.61MB 28.3MB regalloc
      0.004s 1.35MB ------ ------ linearize
      ------ 0.16MB ------ ------ scheduling
      0.016s 4.72MB ------ ------ emit
      0.048s 10.3MB ------ ------ other
    0.100s ------ ------ ------ assemble
    0.236s 36.0MB 6.87MB 35.1MB other
  0.004s 0.36MB ------ ------ other
0.024s 1.94MB 3.75MB ------ other
```

And on a small file:
```
$ installed/bin/ocamlopt.byte -c -dtimings stdlib/marshal.ml
0.036s 3.51MB ------ - stdlib/marshal.ml
  ------ 0.22MB ------ - parsing
    ------ 0.21MB ------ - parser
  0.016s 1.68MB ------ - typing
  ------ 0.16MB ------ - transl
  0.016s 1.07MB ------ - generate
    ------ 0.02MB ------ - cmm
    0.012s 0.75MB ------ - compile_phrases
      0.008s 0.17MB ------ - selection
      ------ 0.01MB ------ - comballoc
      ------ 0.06MB ------ - cse
      ------ 0.06MB ------ - liveness
      ------ 0.02MB ------ - deadcode
      ------ 0.09MB ------ - spill
      ------ 0.02MB ------ - split
      ------ 0.17MB ------ - regalloc
      ------ 0.01MB ------ - linearize
      ------ 0.03MB ------ - emit
      0.004s 0.06MB ------ - other
    0.004s ------ ------ - assemble
    ------ 0.28MB ------ - other
  0.004s 0.36MB ------ - other
0.028s 1.94MB 3.75MB - other
```