### PR TITLE
PR#6676: move overriding class definitions to language reference chapter

### DIFF
--- a/Changes
+++ b/Changes
@@ -62,6 +62,10 @@ Working version
 - PR#6676, GPR#1112: move local opens to tutorial
   (Florian Angeletti)
 
+- PR#6676, GPR#1153: move overriding class definitions to reference
+  manual and tutorial
+  (Florian Angeletti)
+
 - PR#7254, GPR#1096: Rudimentary documentation of ocamlnat
   (Mark Shinwell)
 

--- a/manual/manual/refman/classes.etex
+++ b/manual/manual/refman/classes.etex
@@ -179,11 +179,15 @@ class-expr:
 %END LATEX
 class-field:
       'inherit' class-expr ['as' lowercase-ident]
+   |  'inherit!' class-expr ['as' lowercase-ident]
    |  'val' ['mutable'] inst-var-name [':' typexpr] '=' expr
+   |  'val!' ['mutable'] inst-var-name [':' typexpr] '=' expr
    |  'val' ['mutable'] 'virtual' inst-var-name ':' typexpr
    |  'val' 'virtual' 'mutable' inst-var-name ':' typexpr
    |  'method' ['private'] method-name {parameter} [':' typexpr] '=' expr
+   |  'method!' ['private'] method-name {parameter} [':' typexpr] '=' expr
    |  'method' ['private'] method-name ':' poly-typexpr '=' expr
+   |  'method!' ['private'] method-name ':' poly-typexpr '=' expr
    |  'method' ['private'] 'virtual' method-name ':' poly-typexpr
    |  'method' 'virtual' 'private' method-name ':' poly-typexpr
    |  'constraint' typexpr '=' typexpr
@@ -191,7 +195,6 @@ class-field:
 \end{syntax}
 See also the following language extensions:
 \hyperref[s:locally-abstract]{locally abstract types},
-\hyperref[s:explicit-overriding]{explicit overriding in class definitions},
 \hyperref[s:attributes]{attributes} and
 \hyperref[s:extension-nodes]{extension nodes}.
 
@@ -394,6 +397,21 @@ A method specification is written @'method' ['private'] 'virtual'
 method-name ':' poly-typexpr@.  It specifies whether the method is
 public or private, and gives its type. If the method is intended to be
 polymorphic, the type must be explicitly polymorphic.
+
+\subsubsection*{Explicit overriding}
+
+Since Ocaml 3.12, the keywords @"inherit!"@, @"val!"@ and @"method!"@
+have the same semantics as @"inherit"@, @"val"@ and @"method"@, but
+they additionally require the definition they introduce to be an
+overriding. Namely, @"method!"@ requires @method-name@ to be already
+defined in this class, @"val!"@ requires @inst-var-name@ to be already
+defined in this class, and @"inherit!"@ requires @class-expr@ to
+override some definitions. If no such overriding occurs, an error is
+signaled.
+
+As a side-effect, these 3 keywords avoid the warnings~7
+(method override) and~13 (instance variable override).
+Note that warning~7 is disabled by default.
 
 \subsubsection*{Constraints on type parameters}
 

--- a/manual/manual/refman/classes.etex
+++ b/manual/manual/refman/classes.etex
@@ -402,7 +402,7 @@ polymorphic, the type must be explicitly polymorphic.
 
 Since Ocaml 3.12, the keywords @"inherit!"@, @"val!"@ and @"method!"@
 have the same semantics as @"inherit"@, @"val"@ and @"method"@, but
-they additionally require the definition they introduce to be an
+they additionally require the definition they introduce to be
 overriding. Namely, @"method!"@ requires @method-name@ to be already
 defined in this class, @"val!"@ requires @inst-var-name@ to be already
 defined in this class, and @"inherit!"@ requires @class-expr@ to
@@ -416,7 +416,6 @@ Note that warning~7 is disabled by default.
 \subsubsection*{Constraints on type parameters}
 
 \ikwd{constraint\@\texttt{constraint}}
-
 The construct @'constraint' typexpr_1 '=' typexpr_2@ forces the two
 type expressions to be equals. This is typically used to specify type
 parameters: in that way they can be bound to specific type

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1006,34 +1006,6 @@ you use @'Mylib.A'@, only @'Mylib_A'@ will be linked in, not
 %name the interface @'Mylib.mli'@, but this would require that all
 %clients are compiled with the @'-no-alias-deps'@ flag.
 
-\section{Explicit overriding in class definitions}\label{s:explicit-overriding}
-\ikwd{method.\@\texttt{method\char33}}
-\ikwd{val.\@\texttt{val\char33}}
-\ikwd{inherit.\@\texttt{inherit\char33}}
-
-(Introduced in OCaml 3.12)
-
-\begin{syntax}
-class-field:
-      ...
-   |  'inherit!' class-expr ['as' lowercase-ident]
-   |  'val!' ['mutable'] inst-var-name [':' typexpr] '=' expr
-   |  'method!' ['private'] method-name {parameter} [':' typexpr] '=' expr
-   |  'method!' ['private'] method-name ':' poly-typexpr '=' expr
-\end{syntax}
-
-The keywords @"inherit!"@, @"val!"@ and @"method!"@ have the same semantics
-as @"inherit"@, @"val"@ and @"method"@, but they additionally require the
-definition they introduce to be an overriding. Namely, @"method!"@
-requires @method-name@ to be already defined in this class, @"val!"@
-requires @inst-var-name@ to be already defined in this class, and
-@"inherit!"@ requires @class-expr@ to override some definitions.
-If no such overriding occurs, an error is signaled.
-
-As a side-effect, these 3 keywords avoid the warnings~7
-(method override) and~13 (instance variable override).
-Note that warning~7 is disabled by default.
-
 \section{Overriding in open statements}\label{s:explicit-overriding-open}
 \ikwd{open.\@\texttt{open\char33}}
 

--- a/manual/manual/tutorials/objectexamples.etex
+++ b/manual/manual/tutorials/objectexamples.etex
@@ -493,7 +493,7 @@ class printable_colored_point y c =
     val c = c
     method color = c
     inherit printable_point y as super
-    method print =
+    method! print =
       print_string "(";
       super#print;
       print_string ", ";
@@ -507,6 +507,27 @@ A private method that has been hidden in the parent class is no longer
 visible, and is thus not overridden. Since initializers are treated as
 private methods, all initializers along the class hierarchy are evaluated,
 in the order they are introduced.
+
+Note that for clarity's sake, the method "print" is explicitly marked as
+overriding another definition by annotating the "method" keyword with
+an exclamation mark "!". If the method "print" were not overriding the
+"print" method of "printable_point", the compiler would raise an error:
+\begin{caml_example}[error]
+  object
+    method! m = ()
+  end;;
+\end{caml_example}
+
+This explicit overriding annotation also works
+for "val" and "inherit":
+\begin{caml_example}
+class another_printable_colored_point y c c' =
+  object (self)
+  inherit printable_point y
+  inherit! printable_colored_point y c
+  val! c = c'
+  end;;
+\end{caml_example}
 
 \section{Parameterized classes}
 \pdfsection{Parameterized classes}
@@ -677,7 +698,7 @@ Here is an example of method overriding.
 class intlist_rev l =
   object
     inherit intlist l
-    method fold f accu = List.fold_left f accu (List.rev l)
+    method! fold f accu = List.fold_left f accu (List.rev l)
   end;;
 \end{caml_example*}
 The following idiom separates description and definition.


### PR DESCRIPTION
This PR moves the description of overriding class definitions —`val!`, `method!` and `inherit!` — from the extension chapter to the language reference chapter, and add two short paragraphs  in the object chapter of the tutorial. Since this language extension has a small syntactic footprint and a clearer semantic compared to the `open!` variant, I think it makes sense to integrate it in the already quite extensive description of the object system.