### PR TITLE
Spellchecker hints and type-directed disambiguation for extensible variants

### DIFF
--- a/Changes
+++ b/Changes
@@ -34,7 +34,7 @@ Working version
 
     GPR#1154: enable spellchecker hints and type-directed
     disambiguation for extensible sum type constructors
-    (Florian Angeletti)
+    (Florian Angeletti, review by Alain Frisch, Gabriel Scherer and Leo White)
 
 ### Standard library:
 

--- a/Changes
+++ b/Changes
@@ -30,6 +30,11 @@ Working version
 
 - GPR#1150: Fix typo in arm64 assembler directives
   (KC Sivaramakrishnan)
+### Type system:
+
+    GPR#1154: enable spellchecker hints and type-directed
+    disambiguation for extensible sum type constructors
+    (Florian Angeletti)
 
 ### Standard library:
 

--- a/testsuite/tests/typing-extensions/disambiguation.ml
+++ b/testsuite/tests/typing-extensions/disambiguation.ml
@@ -35,3 +35,26 @@ open M.N;;
 type exn += Foo;;
 
 let x : r = Foo;;
+
+;; (** Closed open extensible type support *)
+
+module M : sig
+  type t
+  type t += Aleph
+end = struct
+  type t = ..
+  type t += Aleph
+end;;
+open M;;
+
+type exn += Aleph
+;;
+let x : t = Aleph;;
+
+;;
+
+module F(X: sig type t = .. end ) = struct type X.t+= Beth end
+module X = struct type t = .. end
+module FX = F(X) open FX
+type exn += Beth;;
+let x : X.t = Beth;;

--- a/testsuite/tests/typing-extensions/disambiguation.ml
+++ b/testsuite/tests/typing-extensions/disambiguation.ml
@@ -21,3 +21,17 @@ let g: t = N.Gamm ;;
 
 raise Not_Found;;
 
+type r = ..;;
+module M = struct
+  type t = r = ..
+  type s = t = ..
+  module N = struct
+    type u = s = ..
+    type u += Foo
+  end
+end
+open M.N;;
+
+type exn += Foo;;
+
+let x : r = Foo;;

--- a/testsuite/tests/typing-extensions/disambiguation.ml
+++ b/testsuite/tests/typing-extensions/disambiguation.ml
@@ -1,0 +1,23 @@
+(** Test type-directed disambiguation and spellchecker hints *)
+
+type t = ..
+type t += Alpha
+
+module M = struct
+  type w = ..
+  type w += Alpha | Beta ;;
+end;;
+
+module F(X:sig end) = struct type t += Gamma end;;
+module X = struct end;;
+
+let x: t = Alha;;
+open M;;
+let y : w = Alha;;
+let z: t = Alpha;;
+
+module N = F(X);;
+let g: t = N.Gamm ;;
+
+raise Not_Found;;
+

--- a/testsuite/tests/typing-extensions/disambiguation.ml.reference
+++ b/testsuite/tests/typing-extensions/disambiguation.ml.reference
@@ -1,0 +1,38 @@
+
+#                 type t = ..
+type t += Alpha
+module M : sig type w = .. type w += Alpha | Beta  end
+#   module F : functor (X : sig  end) -> sig type t += Gamma end
+# module X : sig  end
+#   Characters 12-16:
+  let x: t = Alha;;
+             ^^^^
+Error: This variant expression is expected to have type t
+       The constructor Alha does not belong to type t
+Hint: Did you mean Alpha?
+# # Characters 12-16:
+  let y : w = Alha;;
+              ^^^^
+Error: This variant expression is expected to have type M.w
+       The constructor Alha does not belong to type M.w
+Hint: Did you mean Alpha?
+# Characters 11-16:
+  let z: t = Alpha;;
+             ^^^^^
+Warning 40: Alpha was selected from type t.
+It is not visible in the current scope, and will not 
+be selected if the type becomes unknown.
+val z : t = <extension>
+#   module N : sig type t += Gamma end
+# Characters 11-17:
+  let g: t = N.Gamm ;;
+             ^^^^^^
+Error: Unbound constructor N.Gamm
+Hint: Did you mean Gamma?
+#   Characters 7-16:
+  raise Not_Found;;
+        ^^^^^^^^^
+Error: This variant expression is expected to have type exn
+       The constructor Not_Found does not belong to type exn
+Hint: Did you mean Not_found?
+#   

--- a/testsuite/tests/typing-extensions/disambiguation.ml.reference
+++ b/testsuite/tests/typing-extensions/disambiguation.ml.reference
@@ -35,4 +35,19 @@ Hint: Did you mean Gamma?
 Error: This variant expression is expected to have type exn
        The constructor Not_Found does not belong to type exn
 Hint: Did you mean Not_found?
-#   
+#   type r = ..
+#                 module M :
+  sig
+    type t = r = ..
+    type s = t = ..
+    module N : sig type u = s = .. type u += Foo end
+  end
+#   type exn += Foo
+#   Characters 13-16:
+  let x : r = Foo;;
+              ^^^
+Warning 40: Foo was selected from type r.
+It is not visible in the current scope, and will not 
+be selected if the type becomes unknown.
+val x : r = M.N.Foo
+# 

--- a/testsuite/tests/typing-extensions/disambiguation.ml.reference
+++ b/testsuite/tests/typing-extensions/disambiguation.ml.reference
@@ -50,4 +50,24 @@ Warning 40: Foo was selected from type r.
 It is not visible in the current scope, and will not 
 be selected if the type becomes unknown.
 val x : r = M.N.Foo
+#   #               module M : sig type t type t += Aleph end
+# #     type exn += Aleph
+# Characters 12-17:
+  let x : t = Aleph;;
+              ^^^^^
+Warning 40: Aleph was selected from type M.t.
+It is not visible in the current scope, and will not 
+be selected if the type becomes unknown.
+val x : M.t = <abstr>
+#   #         module F : functor (X : sig type t = .. end) -> sig type X.t += Beth end
+module X : sig type t = .. end
+module FX : sig type X.t += Beth end
+type exn += Beth
+# Characters 14-18:
+  let x : X.t = Beth;;
+                ^^^^
+Warning 40: Beth was selected from type X.t.
+It is not visible in the current scope, and will not 
+be selected if the type becomes unknown.
+val x : X.t = <extension>
 # 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1474,14 +1474,17 @@ let expand_head env ty =
 let _ = forward_try_expand_once := try_expand_safe
 
 
-(* Expand until we find a non-abstract type declaration *)
+(* Expand until we find either a non-abstract type declaration or
+   an abstract type declaration associated with visible extension
+   constructors *)
 
 let rec extract_concrete_typedecl env ty =
   let ty = repr ty in
   match ty.desc with
     Tconstr (p, _, _) ->
       let decl = Env.find_type p env in
-      if decl.type_kind <> Type_abstract then (p, p, decl) else
+      if decl.type_kind <> Type_abstract
+      || Env.has_extension_constructors env p then (p, p, decl) else
       let ty =
         try try_expand_once env ty with Cannot_expand -> raise Not_found
       in

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1635,11 +1635,6 @@ and components_of_module_maker (env, sub, path, mty) =
             let decl' = Subst.type_declaration sub decl in
             let constructors =
               List.map snd (Datarepr.constructors_of_type path decl') in
-            let ext_constructors =
-              constructors
-              |> List.filter
-                (function {Types.cstr_tag = Cstr_extension _; _ } -> true
-                | _ -> false ) in
             let labels =
               List.map snd (Datarepr.labels_of_type path decl') in
             c.comp_types <-
@@ -1651,11 +1646,6 @@ and components_of_module_maker (env, sub, path, mty) =
                 c.comp_constrs <-
                   add_to_tbl descr.cstr_name descr c.comp_constrs)
               constructors;
-            List.iter
-              (fun descr ->
-                 c.comp_ext_constrs <-
-                   add_ext_constrs c.comp_ext_constrs descr)
-              ext_constructors;
             List.iter
               (fun descr ->
                 c.comp_labels <-

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -88,6 +88,8 @@ val reset_required_globals: unit -> unit
 val get_required_globals: unit -> Ident.t list
 val add_required_global: Ident.t -> unit
 
+val has_extension_constructors: t -> Path.t -> bool
+
 val has_local_constraints: t -> bool
 val add_gadt_instance_level: int -> t -> t
 val gadt_instance_level: t -> type_expr -> int option

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -331,6 +331,10 @@ let extract_concrete_variant env ty =
   match extract_concrete_typedecl env ty with
     (p0, p, {type_kind=Type_variant cstrs}) -> (p0, p, cstrs)
   | (p0, p, {type_kind=Type_open}) -> (p0, p, [])
+  | (p0, p, {type_kind=Type_abstract}) ->
+      if Env.has_extension_constructors env p then
+        (p0,p,[])
+      else raise Not_found
   | _ -> raise Not_found
 
 let extract_label_names env ty =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -331,10 +331,8 @@ let extract_concrete_variant env ty =
   match extract_concrete_typedecl env ty with
     (p0, p, {type_kind=Type_variant cstrs}) -> (p0, p, cstrs)
   | (p0, p, {type_kind=Type_open}) -> (p0, p, [])
-  | (p0, p, {type_kind=Type_abstract}) ->
-      if Env.has_extension_constructors env p then
-        (p0,p,[])
-      else raise Not_found
+  | (p0, p, {type_kind=Type_abstract})
+    when Env.has_extension_constructors env p -> (p0,p,[])
   | _ -> raise Not_found
 
 let extract_label_names env ty =


### PR DESCRIPTION
This PR proposes to enable spellchecher hints and type-directed disambiguation for extensible variant sum types. For instance, with this PR using `Not_Found` rather than `Not_found` triggers a spellchecking hints:

``` OCaml  
raise Not_Found;;
        ^^^^^^^^^
Error: This variant expression is expected to have type exn
       The constructor Not_Found does not belong to type exn
Hint: Did you mean Not_found?
```
Simultaneously, it becomes possible to use type-directed disambiguation. Consequently the following code,
```OCaml
module M = struct
  type w = ..
  type w += Alpha | Beta ;;
end
open M
type t = ..
type t += Alpha
let x : M.w = Alpha 
```
which currently raises the quite misleading error 
```
Error: This variant expression is expected to have type M.w
       The constructor Alpha does not belong to type M.w
```
compiles once this PR applied.


In term of implementation, before this patch, the separate definitions of the extensible variant type and its constructors hindered the type-directed and spellchecking mechanism for extension constructors.

To work around these separate definitions, this PR adds a new field `extension_constructors` to the `Env.t` type. This new field tracks the extension constructors associated to a given type path. This field is then used to complete the description of the type provided by `Env.find_full_type`, which is sufficient to enable the missing features.