### PR TITLE
Don't use the page table when scanning closures

### DIFF
--- a/Changes
+++ b/Changes
@@ -166,6 +166,10 @@ Working version
   Mark Shinwell, Thomas Braibant, Stephen Dolan, Pierre Chambart,
   François Bobot, Jacques Garrigue, David Allsopp, and Alain Frisch)
 
+- GPR#1055: Don't use the page table when scanning closures in
+  "no naked pointers" mode
+  (Mark Shinwell)
+
 Next major version (4.05.0):
 ----------------------------
 

--- a/byterun/caml/minor_gc.h
+++ b/byterun/caml/minor_gc.h
@@ -72,6 +72,8 @@ extern void caml_alloc_custom_table (struct caml_custom_table *,
 extern void caml_oldify_one (value, value *);
 extern void caml_oldify_mopup (void);
 
+extern mlsize_t caml_distance_to_closure_environment(value closure);
+
 #define Oldify(p) do{ \
     value __oldify__v__ = *p; \
     if (Is_block (__oldify__v__) && Is_young (__oldify__v__)){ \

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -242,12 +242,7 @@ static inline value* mark_slice_darken(value *gray_vals_ptr, value v, int i,
 #ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
   if (Is_block (child)
         && ! Is_young (child)
-        && Wosize_val (child) > 0  /* Atoms never need to be marked. */
-        /* Closure blocks contain code pointers at offsets that cannot
-           be reliably determined, so we always use the page table when
-           marking such values. */
-        && (!(Tag_val (v) == Closure_tag || Tag_val (v) == Infix_tag) ||
-            Is_in_heap (child))) {
+        && Wosize_val (child) > 0  /* Atoms never need to be marked. */) {
 #else
   if (Is_block (child) && Is_in_heap (child)) {
 #endif
@@ -400,6 +395,12 @@ static void mark_slice (intnat work)
       size = Wosize_hd (hd);
       end = start + work;
       if (Tag_hd (hd) < No_scan_tag){
+#ifdef NATIVE_CODE_AND_NO_NAKED_POINTERS
+        if (Tag_hd(hd) == Closure_tag && start == 0) {
+          start = caml_distance_to_closure_environment(v);
+          end = start + work;
+        }
+#endif
         start = size < start ? size : start;
         end = size < end ? size : end;
         CAMLassert (end >= start);


### PR DESCRIPTION
This is related to #203 , which relates to an overall goal of removing the page table completely when in "no naked pointers" mode (and, in due course, for multicore).  When that goal has been reached I am expecting approximately 5-10% performance improvement over the existing page table mode.

At present it is not possible to scan closures without the page table (or alternatively the code fragments table) because there is an ambiguity between environment entries and `Infix_tag` separators.  This means that the positions of code pointers cannot be determined.  Here is an example of the ambiguity.  The following closure relates to only one function:

`Closure_tag | Code ptr 1 | Arity = 2 | Code ptr 2 | FV1 | FV2 | FV3`

and we suppose the value of the first free variable, when encoded as an OCaml integer, happens to equal `Infix_tag`.  This looks just like the following closure which relates to two closed functions:

`Closure_tag | Code ptr 1 | Arity = 2 | Code ptr 2 | Infix_tag | Code ptr | Arity = 1`

In #203 an attempt was made to add GC headers before the start of functions' instructions to solve this problem.  That proved to be complicated on one architecture and on x86-64 appears to have a surprising penalty -- on the `cpdf` libraries for example code size was increased by 5%.  This is not helped that it is difficult to efficiently pack headers before the start of functions that must be 16 byte aligned, since no assembler directive exists to "align to the next 8-byte boundary that is not a 16-byte boundary".

This patch solves the problem another way, which I think is overall better (benchmarks in progress); it simply uses the bottom bit of the arity field (after having de-tagged it) to indicate whether the corresponding function is the last one in the closure block.  This means that the GC can skip right over all of the code pointers and arities, landing at the start of any environment which may be present.  I claim the performance impact should be minimal since the only place that appears to examine arities is the `caml_apply` family of functions, which now only gain two simple arithmetic instructions.

I mentioned above about the code fragments table, which might provide another solution to this problem, namely by checking every non-immediate member of a closure against it.  However I think in general such tables are fragile and best avoided; indeed, there appear to be at least two different idioms for use of the code fragments table in the compiler code already.  `byterun/extern.c` only checks the table when locating a code pointer, whereas `Is_in_code_area` also checks the page table.  Furthermore, checking of the code fragments table is likely to be slow in the presence of a large number of dynamically-linked objects.