### PR TITLE
Fix typo in docs of module Marshal

### DIFF
--- a/stdlib/marshal.mli
+++ b/stdlib/marshal.mli
@@ -29,7 +29,7 @@
    the [Marshal.from_*] functions is given as ['a], but this is
    misleading: the returned OCaml value does not possess type ['a]
    for all ['a]; it has one, unique type which cannot be determined
-   at compile-type.  The programmer should explicitly give the expected
+   at compile-time.  The programmer should explicitly give the expected
    type of the returned value, using the following syntax:
    - [(Marshal.from_channel chan : type)].
    Anything can happen at run-time if the object in the file does not


### PR DESCRIPTION
I hope this doesn't need an entry in the changelog.