### PR TITLE
Fix AppVeyor build

### DIFF
--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -82,7 +82,7 @@ run "make opt.opt" make opt.opt
 cd ../build-mingw32
 
 cp config/m-nt.h byterun/caml/m.h
-cp config/s-nt.h caml/byterun/s.h
+cp config/s-nt.h byterun/caml/s.h
 
 PREFIX="C:/Program Files/OCaml-mingw32"
 echo "Edit config/Makefile to set PREFIX=$PREFIX"


### PR DESCRIPTION
Typo in 40fcbb5f0a70171193891c863a325f31291f16f7