### PR TITLE
Erroneous code transformation at partial applications (MPR#7531)

### DIFF
--- a/Changes
+++ b/Changes
@@ -37,6 +37,9 @@ Working version
   (Markus Mottl, review by Alain Frisch, Xavier Leroy, Gabriel Scherer,
   Mark Shinwell and Leo White)
 
+- MPR#7531, GPR#1162: Erroneous code transformation at partial applications
+  (Mark Shinwell) 
+
 ### Standard library:
 
 - GRP#1119: Change Set (private) type to inline records.

--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -843,7 +843,7 @@ let rec close fenv cenv = function
             direct_apply ~loc ~attribute fundesc funct ufunct uargs in
           (app, strengthen_approx app approx_res)
 
-      | ((ufunct, Value_closure(fundesc, _approx_res)), uargs)
+      | ((ufunct, (Value_closure(fundesc, _) as fapprox)), uargs)
           when nargs < fundesc.fun_arity ->
         let first_args = List.map (fun arg ->
           (Ident.create "arg", arg) ) uargs in
@@ -862,6 +862,7 @@ let rec close fenv cenv = function
           @ (List.map (fun arg -> Lvar arg ) final_args)
         in
         let funct_var = Ident.create "funct" in
+        let fenv = Tbl.add funct_var fapprox fenv in
         let (new_fun, approx) = close fenv cenv
           (Lfunction{
                kind = Curried;

--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -825,7 +825,7 @@ let rec close fenv cenv = function
   | Lfunction _ as funct ->
       close_one_function fenv cenv (Ident.create "fun") funct
 
-    (* We convert [f a] to [let a' = a in fun b c -> f a' b c]
+    (* We convert [f a] to [let a' = a in let f' = f in fun b c -> f' a' b c]
        when fun_arity > nargs *)
   | Lapply{ap_func = funct; ap_args = args; ap_loc = loc;
         ap_inlined = attribute} ->
@@ -843,7 +843,7 @@ let rec close fenv cenv = function
             direct_apply ~loc ~attribute fundesc funct ufunct uargs in
           (app, strengthen_approx app approx_res)
 
-      | ((_ufunct, Value_closure(fundesc, _approx_res)), uargs)
+      | ((ufunct, Value_closure(fundesc, _approx_res)), uargs)
           when nargs < fundesc.fun_arity ->
         let first_args = List.map (fun arg ->
           (Ident.create "arg", arg) ) uargs in
@@ -861,20 +861,24 @@ let rec close fenv cenv = function
           (List.map (fun (arg1, _arg2) -> Lvar arg1) first_args)
           @ (List.map (fun arg -> Lvar arg ) final_args)
         in
+        let funct_var = Ident.create "funct" in
         let (new_fun, approx) = close fenv cenv
           (Lfunction{
                kind = Curried;
                params = final_args;
                body = Lapply{ap_should_be_tailcall=false;
                              ap_loc=loc;
-                             ap_func=funct;
+                             ap_func=(Lvar funct_var);
                              ap_args=internal_args;
                              ap_inlined=Default_inline;
                              ap_specialised=Default_specialise};
                loc;
                attr = default_function_attribute})
         in
-        let new_fun = iter first_args new_fun in
+        let new_fun =
+          iter first_args
+            (Ulet (Immutable, Pgenval, funct_var, ufunct, new_fun))
+        in
         warning_if_forced_inline ~loc ~attribute "Partial application";
         (new_fun, approx)
 

--- a/testsuite/tests/basic/eval_order_4.ml
+++ b/testsuite/tests/basic/eval_order_4.ml
@@ -1,0 +1,17 @@
+(* PR#7531 *)
+
+let f =
+  (let _i = print_endline "first"
+   in fun q -> fun i -> "") (print_endline "x")
+
+let _ =
+  let k = 
+    (let _i = print_int 1 
+     in fun q -> fun i -> "") () 
+  in k (print_int 0)
+
+let () =
+  print_endline "foo";
+  ignore ((f ()) : string);
+  ignore ((f ()) : string);
+  print_endline "bar"

--- a/testsuite/tests/basic/eval_order_4.reference
+++ b/testsuite/tests/basic/eval_order_4.reference
@@ -1,0 +1,4 @@
+x
+first
+10foo
+bar


### PR DESCRIPTION
Effects may be incorrectly pushed under lambdas that are generated at partial application sites when using the Closure path of the native code compiler.  The test case here is a slightly more elaborate version of [MPR#7531](https://caml.inria.fr/mantis/view.php?id=7531); it checks for non-duplication of an effect as well as ensuring that the function component of an application gets evaluated after the argument.

This should probably go on 4.05 as well.