### PR TITLE
PR#7507: updated description for printf "%g"

### DIFF
--- a/Changes
+++ b/Changes
@@ -87,6 +87,10 @@ Working version
 - PR#7254, GPR#1096: Rudimentary documentation of ocamlnat
   (Mark Shinwell)
 
+- PR#7507: Align the description of the printf conversion
+  specification "%g" with the ISO C90 description.
+  (Florian Angeletti)
+
 ### Tools:
 
 - GPR#1045: ocamldep, add a "-shared" option to generate dependencies

--- a/stdlib/printf.mli
+++ b/stdlib/printf.mli
@@ -56,7 +56,10 @@ val fprintf : out_channel -> ('a, out_channel, unit) format -> 'a
    - [e] or [E]: convert a floating-point argument to decimal notation,
      in the style [d.ddd e+-dd] (mantissa and exponent).
    - [g] or [G]: convert a floating-point argument to decimal notation,
-     in style [f] or [e], [E] (whichever is more compact).
+     in style [f] or [e], [E] (whichever is more compact). Moreover,
+     any trailing zeros are removed from the fractional part of the result
+     and the decimal-point character is removed if there is no fractional
+     part remaining.
    - [h] or [H]: convert a floating-point argument to hexadecimal notation,
      in the style [0xh.hhhh e+-dd] (hexadecimal mantissa, exponent in
      decimal and denotes a power of 2).


### PR DESCRIPTION
[Mantis:7507](https://caml.inria.fr/mantis/view.php?id=7507):

This PR aligns the description of the `printf `conversion specification `%g` with the ISO C90 description by mentioning the removal of trailing zeros and decimal-point character, e.g.

```OCaml
# Printf.printf "%g" 1. ;;
1- : unit = ()
```