### PR TITLE
toplevel: doc for #show mentions categories above while they're below.

### DIFF
--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -621,7 +621,7 @@ let () =
     {
       section = section_env;
       doc = "Print the signatures of components \
-             from any of the above categories.";
+             from any of the categories below.";
     }
 
 let _ = add_directive "trace"


### PR DESCRIPTION
The toplevel output for #help seems to be sorted and looks like:

  #show <ident>
    Print the signatures of components from any of the above categories.
  #show_class <ident>
    Print the signature of the corresponding class.
  #show_class_type <ident>
  [...]

Thus the documentation for #show needs to say that the categories are
below, not above. The code is effectful and has the specific #show_*
directives before the general #show one. That's why I expect there is
some kind of sorting done at runtime.