### PR TITLE
PR#6548, manual: remove comment on obsolete limitation of private type abbreviations

### DIFF
--- a/Changes
+++ b/Changes
@@ -74,6 +74,10 @@ Working version
 
 ### Manual and documentation:
 
+- PR#6548: remove obsolete limitation in the description of private
+  type abbreviations
+  (Florian Angeletti, suggestion by Leo White)
+
 - PR#6676, GPR#1110: move record notation to tutorial
   (Florian Angeletti, review by Gabriel Scherer)
 

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -276,9 +276,6 @@ declares a type that is distinct from its implementation type @typexpr@.
 However, coercions from the type to @typexpr@ are permitted.
 Moreover, the compiler ``knows'' the implementation type and can take
 advantage of this knowledge to perform type-directed optimizations.
-For ambiguity reasons, @typexpr@ cannot be an object or polymorphic
-variant type, but a similar behaviour can be obtained through private
-row types.
 
 The following example uses a private type abbreviation to define a
 module of nonnegative integers:


### PR DESCRIPTION
[Mantis:6548](https://caml.inria.fr/mantis/view.php?id=6548#c12094):

This PR implements a suggestion by @lpw25 to remove a comment on an obsolete limitation of private type abbreviations, that could not be of the form
```OCaml
type t = private <x:int> and u = private [`A]
```
before OCaml 4.02. 