### PR TITLE
Allow first character of OCAMLPARAM to specify an alternative separator

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,10 @@ be mentioned in the 4.06 section below instead of here.)
 
 ### Compiler user-interface and warnings:
 
+- GPR#1166: In OCAMLPARAM, an alternative separator can be specified as
+  first character (instead of comma) in the set ":|; ,"
+  (Fabrice Le Fessant)
+
 ### Runtime system:
 
 ### Other libraries:

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -122,8 +122,13 @@ development work, not in released packages.
 
 \begin{options}
 \item["OCAMLPARAM" \rm(environment variable)]
-Arguments that will be inserted before or after the arguments from the
-command line.
+A set of arguments that will be inserted before or after the arguments from
+the command line. Arguments are specified in a comma-separated list
+of "name=value" pairs. A "_" is used to specify the position of
+the command line arguments, i.e. "a=x,_,b=y" means that "a=x" should be
+executed before parsing the arguments, and "b=y" after. Finally,
+an alternative separator can be specified as the
+first character of the string, within the set ":|; ,".
 \item["ocaml_compiler_internal_params" \rm(file in the stdlib directory)]
 A mapping of file names to lists of arguments that
 will be added to the command line (and "OCAMLPARAM") arguments.

--- a/manual/manual/cmds/native.etex
+++ b/manual/manual/cmds/native.etex
@@ -135,8 +135,13 @@ development work, not in released packages.
 
 \begin{options}
 \item["OCAMLPARAM" \rm(environment variable)]
-Arguments that will be inserted before or after the arguments from the
-command line.
+A set of arguments that will be inserted before or after the arguments from
+the command line. Arguments are specified in a comma-separated list
+of "name=value" pairs. A "_" is used to specify the position of
+the command line arguments, i.e. "a=x,_,b=y" means that "a=x" should be
+executed before parsing the arguments, and "b=y" after. Finally,
+an alternative separator can be specified as the
+first character of the string, within the set ":|; ,".
 \item["ocaml_compiler_internal_params" \rm(file in the stdlib directory)]
 A mapping of file names to lists of arguments that
 will be added to the command line (and "OCAMLPARAM") arguments.


### PR DESCRIPTION
In the current implementation of `OCAMLPARAM`, there is no way to escape a comma in the arguments (for example, if you want to pass an option to the linker in ccopts). This PR provides such a way, by allowing the user to specify an alternative separator, instead of comma, as first character of `OCAMLPARAM`. The alternative separator must be in ":|; ".

For example, `OCAMLPARAM='x=1,_,y=1'` can also be written `OCAMLPARAM='|x=1|_|y=1'`.

A small bug fix also is included, by adding a `ccopt` option, in addition to `ccopts`.