### PR TITLE
Aid compatibility with older Microsoft C compilers

### DIFF
--- a/Changes
+++ b/Changes
@@ -155,8 +155,11 @@ Working version
    and validation of OCaml magic numbers.
    (Gabriel Scherer, review by Gabriel Radanne and Damien Doligez)
 
-- #1176: introduce Caml_inline for consistent static inline on all C compilers
-  and remove inconsistent inline in runtime/win32.c.
+- #1176: encourage better compatibility with older Microsoft C compilers by
+  using GCC's -Wdeclaration-after-statement when available. Introduce
+  Caml_inline to stop abuse of the inline keyword on MSVC and to help ensure
+  that only static inline is used in the codebase (erroneous instance in
+  runtime/win32.c removed).
   (David Allsopp, review by Oliver Andrieu and Xavier Leroy)
 
 - #8970: separate value patterns (matching on values) from computation patterns

--- a/Changes
+++ b/Changes
@@ -155,7 +155,8 @@ Working version
    and validation of OCaml magic numbers.
    (Gabriel Scherer, review by Gabriel Radanne and Damien Doligez)
 
-- #1176: introduce Caml_inline for consistent static inline on all C compilers.
+- #1176: introduce Caml_inline for consistent static inline on all C compilers
+  and remove inconsistent inline in runtime/win32.c.
   (David Allsopp, review by Oliver Andrieu and Xavier Leroy)
 
 - #8970: separate value patterns (matching on values) from computation patterns

--- a/Changes
+++ b/Changes
@@ -155,6 +155,9 @@ Working version
    and validation of OCaml magic numbers.
    (Gabriel Scherer, review by Gabriel Radanne and Damien Doligez)
 
+- #1176: introduce Caml_inline for consistent static inline on all C compilers.
+  (David Allsopp, review by Oliver Andrieu and Xavier Leroy)
+
 - #8970: separate value patterns (matching on values) from computation patterns
   (matching on the effects of a copmutation) in the typedtree.
   (Gabriel Scherer, review by Jacques Garrigue and Alain Frisch)

--- a/configure
+++ b/configure
@@ -12461,14 +12461,15 @@ case $ocaml_cv_cc_vendor in #(
   msvc-*) :
     outputobj=-Fo; gcc_warnings="" ;; #(
   *) :
-    outputobj='-o $(EMPTY)'; case 4.11.0+dev0-2019-10-18 in #(
+    outputobj='-o $(EMPTY)'
+  gcc_warnings='-Wall -Wdeclaration-after-statement'
+  case 4.11.0+dev0-2019-10-18 in #(
   *+dev*) :
-    gcc_warnings="-Wall -Werror" ;; #(
+    gcc_warnings="$gcc_warnings -Werror" ;; #(
   *) :
-    gcc_warnings="-Wall"
-   ;;
+     ;;
 esac
- ;;
+   ;;
 esac
 
 # We select high optimization levels, provided we can turn off:

--- a/configure.ac
+++ b/configure.ac
@@ -525,12 +525,12 @@ AS_CASE([$ocaml_cv_cc_vendor],
     [outputobj='-o $(EMPTY)'; gcc_warnings="-qflag=i:i"], # all warnings enabled
   [msvc-*],
     [outputobj=-Fo; gcc_warnings=""],
-  [outputobj='-o $(EMPTY)'; AS_CASE([AC_PACKAGE_VERSION],
+  [outputobj='-o $(EMPTY)'
+  gcc_warnings='-Wall -Wdeclaration-after-statement'
+  AS_CASE([AC_PACKAGE_VERSION],
     [*+dev*],
-      [gcc_warnings="-Wall -Werror"],
-    [gcc_warnings="-Wall"]
-  )]
-)
+      [gcc_warnings="$gcc_warnings -Werror"])
+  ])
 
 # We select high optimization levels, provided we can turn off:
 # - strict type-based aliasing analysis (too risky for the OCaml runtime)

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -31,12 +31,6 @@
 #include <unistd.h>
 #endif
 
-#ifdef __GNUC__
-#define INLINE Caml_inline
-#else
-#define INLINE static
-#endif
-
 typedef int st_retcode;
 
 #define SIGPREEMPTION SIGVTALRM
@@ -71,7 +65,7 @@ static int st_thread_create(st_thread_id * res,
 
 /* Cleanup at thread exit */
 
-INLINE void st_thread_cleanup(void)
+Caml_inline void st_thread_cleanup(void)
 {
   return;
 }
@@ -102,12 +96,12 @@ static int st_tls_newkey(st_tlskey * res)
   return pthread_key_create(res, NULL);
 }
 
-INLINE void * st_tls_get(st_tlskey k)
+Caml_inline void * st_tls_get(st_tlskey k)
 {
   return pthread_getspecific(k);
 }
 
-INLINE void st_tls_set(st_tlskey k, void * v)
+Caml_inline void st_tls_set(st_tlskey k, void * v)
 {
   pthread_setspecific(k, v);
 }
@@ -153,7 +147,7 @@ static void st_masterlock_release(st_masterlock * m)
 }
 
 CAMLno_tsan  /* This can be called for reading [waiters] without locking. */
-INLINE int st_masterlock_waiters(st_masterlock * m)
+Caml_inline int st_masterlock_waiters(st_masterlock * m)
 {
   return m->waiters;
 }
@@ -167,7 +161,7 @@ INLINE int st_masterlock_waiters(st_masterlock * m)
    off the lock to a waiter we know exists, it's safe, as they'll certainly
    re-wake us later.
 */
-INLINE void st_thread_yield(st_masterlock * m)
+Caml_inline void st_thread_yield(st_masterlock * m)
 {
   pthread_mutex_lock(&m->lock);
   /* We must hold the lock to call this. */
@@ -219,7 +213,7 @@ static int st_mutex_destroy(st_mutex m)
   return rc;
 }
 
-INLINE int st_mutex_lock(st_mutex m)
+Caml_inline int st_mutex_lock(st_mutex m)
 {
   return pthread_mutex_lock(m);
 }
@@ -227,12 +221,12 @@ INLINE int st_mutex_lock(st_mutex m)
 #define PREVIOUSLY_UNLOCKED 0
 #define ALREADY_LOCKED EBUSY
 
-INLINE int st_mutex_trylock(st_mutex m)
+Caml_inline int st_mutex_trylock(st_mutex m)
 {
   return pthread_mutex_trylock(m);
 }
 
-INLINE int st_mutex_unlock(st_mutex m)
+Caml_inline int st_mutex_unlock(st_mutex m)
 {
   return pthread_mutex_unlock(m);
 }
@@ -260,17 +254,17 @@ static int st_condvar_destroy(st_condvar c)
   return rc;
 }
 
-INLINE int st_condvar_signal(st_condvar c)
+Caml_inline int st_condvar_signal(st_condvar c)
 {
   return pthread_cond_signal(c);
 }
 
-INLINE int st_condvar_broadcast(st_condvar c)
+Caml_inline int st_condvar_broadcast(st_condvar c)
 {
   return pthread_cond_broadcast(c);
 }
 
-INLINE int st_condvar_wait(st_condvar c, st_mutex m)
+Caml_inline int st_condvar_wait(st_condvar c, st_mutex m)
 {
   return pthread_cond_wait(c, m);
 }

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -32,9 +32,9 @@
 #endif
 
 #ifdef __GNUC__
-#define INLINE inline
+#define INLINE Caml_inline
 #else
-#define INLINE
+#define INLINE static
 #endif
 
 typedef int st_retcode;
@@ -71,7 +71,7 @@ static int st_thread_create(st_thread_id * res,
 
 /* Cleanup at thread exit */
 
-static INLINE void st_thread_cleanup(void)
+INLINE void st_thread_cleanup(void)
 {
   return;
 }
@@ -102,12 +102,12 @@ static int st_tls_newkey(st_tlskey * res)
   return pthread_key_create(res, NULL);
 }
 
-static INLINE void * st_tls_get(st_tlskey k)
+INLINE void * st_tls_get(st_tlskey k)
 {
   return pthread_getspecific(k);
 }
 
-static INLINE void st_tls_set(st_tlskey k, void * v)
+INLINE void st_tls_set(st_tlskey k, void * v)
 {
   pthread_setspecific(k, v);
 }
@@ -153,7 +153,7 @@ static void st_masterlock_release(st_masterlock * m)
 }
 
 CAMLno_tsan  /* This can be called for reading [waiters] without locking. */
-static INLINE int st_masterlock_waiters(st_masterlock * m)
+INLINE int st_masterlock_waiters(st_masterlock * m)
 {
   return m->waiters;
 }
@@ -167,7 +167,7 @@ static INLINE int st_masterlock_waiters(st_masterlock * m)
    off the lock to a waiter we know exists, it's safe, as they'll certainly
    re-wake us later.
 */
-static INLINE void st_thread_yield(st_masterlock * m)
+INLINE void st_thread_yield(st_masterlock * m)
 {
   pthread_mutex_lock(&m->lock);
   /* We must hold the lock to call this. */
@@ -219,7 +219,7 @@ static int st_mutex_destroy(st_mutex m)
   return rc;
 }
 
-static INLINE int st_mutex_lock(st_mutex m)
+INLINE int st_mutex_lock(st_mutex m)
 {
   return pthread_mutex_lock(m);
 }
@@ -227,12 +227,12 @@ static INLINE int st_mutex_lock(st_mutex m)
 #define PREVIOUSLY_UNLOCKED 0
 #define ALREADY_LOCKED EBUSY
 
-static INLINE int st_mutex_trylock(st_mutex m)
+INLINE int st_mutex_trylock(st_mutex m)
 {
   return pthread_mutex_trylock(m);
 }
 
-static INLINE int st_mutex_unlock(st_mutex m)
+INLINE int st_mutex_unlock(st_mutex m)
 {
   return pthread_mutex_unlock(m);
 }
@@ -260,17 +260,17 @@ static int st_condvar_destroy(st_condvar c)
   return rc;
 }
 
-static INLINE int st_condvar_signal(st_condvar c)
+INLINE int st_condvar_signal(st_condvar c)
 {
   return pthread_cond_signal(c);
 }
 
-static INLINE int st_condvar_broadcast(st_condvar c)
+INLINE int st_condvar_broadcast(st_condvar c)
 {
   return pthread_cond_broadcast(c);
 }
 
-static INLINE int st_condvar_wait(st_condvar c, st_mutex m)
+INLINE int st_condvar_wait(st_condvar c, st_mutex m)
 {
   return pthread_cond_wait(c, m);
 }

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -172,7 +172,7 @@ static void caml_thread_scan_roots(scanning_action action)
 
 /* Saving and restoring runtime state in curr_thread */
 
-static inline void caml_thread_save_runtime_state(void)
+Caml_inline void caml_thread_save_runtime_state(void)
 {
 #ifdef NATIVE_CODE
   curr_thread->top_of_stack = Caml_state->top_of_stack;
@@ -201,7 +201,7 @@ static inline void caml_thread_save_runtime_state(void)
   curr_thread->memprof_suspended = caml_memprof_suspended;
 }
 
-static inline void caml_thread_restore_runtime_state(void)
+Caml_inline void caml_thread_restore_runtime_state(void)
 {
 #ifdef NATIVE_CODE
   Caml_state->top_of_stack = curr_thread->top_of_stack;

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -24,8 +24,6 @@
 
 #include <caml/osdeps.h>
 
-#define INLINE __inline
-
 #if 1
 #define TRACE(x)
 #define TRACE1(x,y)
@@ -112,12 +110,12 @@ static DWORD st_tls_newkey(st_tlskey * res)
     return 0;
 }
 
-static INLINE void * st_tls_get(st_tlskey k)
+Caml_inline void * st_tls_get(st_tlskey k)
 {
   return TlsGetValue(k);
 }
 
-static INLINE void st_tls_set(st_tlskey k, void * v)
+Caml_inline void st_tls_set(st_tlskey k, void * v)
 {
   TlsSetValue(k, v);
 }
@@ -133,27 +131,27 @@ static void st_masterlock_init(st_masterlock * m)
   EnterCriticalSection(m);
 }
 
-static INLINE void st_masterlock_acquire(st_masterlock * m)
+Caml_inline void st_masterlock_acquire(st_masterlock * m)
 {
   TRACE("st_masterlock_acquire");
   EnterCriticalSection(m);
   TRACE("st_masterlock_acquire (done)");
 }
 
-static INLINE void st_masterlock_release(st_masterlock * m)
+Caml_inline void st_masterlock_release(st_masterlock * m)
 {
   LeaveCriticalSection(m);
   TRACE("st_masterlock_released");
 }
 
-static INLINE int st_masterlock_waiters(st_masterlock * m)
+Caml_inline int st_masterlock_waiters(st_masterlock * m)
 {
   return 1;                     /* info not maintained */
 }
 
 /* Scheduling hints */
 
-static INLINE void st_thread_yield(st_masterlock * m)
+Caml_inline void st_thread_yield(st_masterlock * m)
 {
   LeaveCriticalSection(m);
   Sleep(0);
@@ -180,7 +178,7 @@ static DWORD st_mutex_destroy(st_mutex m)
   return 0;
 }
 
-static INLINE DWORD st_mutex_lock(st_mutex m)
+Caml_inline DWORD st_mutex_lock(st_mutex m)
 {
   TRACE1("st_mutex_lock", m);
   EnterCriticalSection(m);
@@ -193,7 +191,7 @@ static INLINE DWORD st_mutex_lock(st_mutex m)
 #define PREVIOUSLY_UNLOCKED 0
 #define ALREADY_LOCKED (1<<29)
 
-static INLINE DWORD st_mutex_trylock(st_mutex m)
+Caml_inline DWORD st_mutex_trylock(st_mutex m)
 {
   TRACE1("st_mutex_trylock", m);
   if (TryEnterCriticalSection(m)) {
@@ -205,7 +203,7 @@ static INLINE DWORD st_mutex_trylock(st_mutex m)
   }
 }
 
-static INLINE DWORD st_mutex_unlock(st_mutex m)
+Caml_inline DWORD st_mutex_unlock(st_mutex m)
 {
   TRACE1("st_mutex_unlock", m);
   LeaveCriticalSection(m);

--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -64,14 +64,14 @@ CAMLextern value caml_alloc_final (mlsize_t wosize,
 CAMLextern int caml_convert_flag_list (value, int *);
 
 /* Convenience functions to deal with unboxable types. */
-static inline value caml_alloc_unboxed (value arg) { return arg; }
-static inline value caml_alloc_boxed (value arg) {
+Caml_inline value caml_alloc_unboxed (value arg) { return arg; }
+Caml_inline value caml_alloc_boxed (value arg) {
   value result = caml_alloc_small (1, 0);
   Field (result, 0) = arg;
   return result;
 }
-static inline value caml_field_unboxed (value arg) { return arg; }
-static inline value caml_field_boxed (value arg) { return Field (arg, 0); }
+Caml_inline value caml_field_unboxed (value arg) { return arg; }
+Caml_inline value caml_field_boxed (value arg) { return Field (arg, 0); }
 
 /* Unannotated unboxable types are boxed by default. (may change in the
    future) */

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -34,7 +34,9 @@
 #endif
 
 #if defined(_MSC_VER) && !defined(__cplusplus)
-#define inline __inline
+#define Caml_inline static __inline
+#else
+#define Caml_inline static inline
 #endif
 
 #include "s.h"

--- a/runtime/caml/freelist.h
+++ b/runtime/caml/freelist.h
@@ -37,29 +37,29 @@ extern void (*caml_fl_p_make_free_blocks)
 extern void (*caml_fl_p_check) (void);
 #endif
 
-static inline header_t *caml_fl_allocate (mlsize_t wo_sz)
+Caml_inline header_t *caml_fl_allocate (mlsize_t wo_sz)
   { return (*caml_fl_p_allocate) (wo_sz); }
 
-static inline void caml_fl_init_merge (void)
+Caml_inline void caml_fl_init_merge (void)
   { (*caml_fl_p_init_merge) (); }
 
-static inline void caml_fl_reset (void)
+Caml_inline void caml_fl_reset (void)
   { (*caml_fl_p_reset) (); }
 
-static inline header_t *caml_fl_merge_block (value bp, char *limit)
+Caml_inline header_t *caml_fl_merge_block (value bp, char *limit)
   { return (*caml_fl_p_merge_block) (bp, limit); }
 
-static inline void caml_fl_add_blocks (value bp)
+Caml_inline void caml_fl_add_blocks (value bp)
   { (*caml_fl_p_add_blocks) (bp); }
 
-static inline void caml_make_free_blocks
+Caml_inline void caml_make_free_blocks
   (value *p, mlsize_t size, int do_merge, int color)
   { (*caml_fl_p_make_free_blocks) (p, size, do_merge, color); }
 
 extern void caml_set_allocation_policy (intnat);
 
 #ifdef DEBUG
-static inline void caml_fl_check (void)
+Caml_inline void caml_fl_check (void)
   { (*caml_fl_p_check) (); }
 #endif
 

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -94,7 +94,7 @@ void caml_alloc_minor_tables (void);
     } \
   }while(0)
 
-static inline void add_to_ref_table (struct caml_ref_table *tbl, value *p)
+Caml_inline void add_to_ref_table (struct caml_ref_table *tbl, value *p)
 {
   if (tbl->ptr >= tbl->limit){
     CAMLassert (tbl->ptr == tbl->limit);
@@ -103,7 +103,7 @@ static inline void add_to_ref_table (struct caml_ref_table *tbl, value *p)
   *tbl->ptr++ = p;
 }
 
-static inline void add_to_ephe_ref_table (struct caml_ephe_ref_table *tbl,
+Caml_inline void add_to_ephe_ref_table (struct caml_ephe_ref_table *tbl,
                                           value ar, mlsize_t offset)
 {
   struct caml_ephe_ref_elt *ephe_ref;
@@ -117,7 +117,7 @@ static inline void add_to_ephe_ref_table (struct caml_ephe_ref_table *tbl,
   CAMLassert(ephe_ref->offset < Wosize_val(ephe_ref->ephe));
 }
 
-static inline void add_to_custom_table (struct caml_custom_table *tbl, value v,
+Caml_inline void add_to_custom_table (struct caml_custom_table *tbl, value v,
                                         mlsize_t mem, mlsize_t max)
 {
   struct caml_custom_elt *elt;

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -214,7 +214,7 @@ CAMLnoreturn_end;
    If overflow is reported, this is the exact result modulo 2 to the word size.
 */
 
-static inline int caml_uadd_overflow(uintnat a, uintnat b, uintnat * res)
+Caml_inline int caml_uadd_overflow(uintnat a, uintnat b, uintnat * res)
 {
 #if __GNUC__ >= 5 || Caml_has_builtin(__builtin_add_overflow)
   return __builtin_add_overflow(a, b, res);
@@ -225,7 +225,7 @@ static inline int caml_uadd_overflow(uintnat a, uintnat b, uintnat * res)
 #endif
 }
 
-static inline int caml_usub_overflow(uintnat a, uintnat b, uintnat * res)
+Caml_inline int caml_usub_overflow(uintnat a, uintnat b, uintnat * res)
 {
 #if __GNUC__ >= 5 || Caml_has_builtin(__builtin_sub_overflow)
   return __builtin_sub_overflow(a, b, res);
@@ -237,7 +237,7 @@ static inline int caml_usub_overflow(uintnat a, uintnat b, uintnat * res)
 }
 
 #if __GNUC__ >= 5 || Caml_has_builtin(__builtin_mul_overflow)
-static inline int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
+Caml_inline int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
 {
   return __builtin_mul_overflow(a, b, res);
 }

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -312,14 +312,14 @@ CAMLextern void caml_Store_double_val (value,double);
   #define Double_field(v,i) Double_flat_field(v,i)
   #define Store_double_field(v,i,d) Store_double_flat_field(v,i,d)
 #else
-  static inline double Double_field (value v, mlsize_t i) {
+  Caml_inline double Double_field (value v, mlsize_t i) {
     if (Tag_val (v) == Double_array_tag){
       return Double_flat_field (v, i);
     }else{
       return Double_array_field (v, i);
     }
   }
-  static inline void Store_double_field (value v, mlsize_t i, double d) {
+  Caml_inline void Store_double_field (value v, mlsize_t i, double d) {
     if (Tag_val (v) == Double_array_tag){
       Store_double_flat_field (v, i, d);
     }else{

--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -161,7 +161,7 @@ extern value caml_ephe_none;
 
 /* In the header, in order to let major_gc.c
    and weak.c see the body of the function */
-static inline void caml_ephe_clean (value v){
+Caml_inline void caml_ephe_clean (value v){
   value child;
   int release_data = 0;
   mlsize_t size, i;

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -309,17 +309,17 @@ static void extern_stack_overflow(void)
 
 /* Conversion to big-endian */
 
-static inline void store16(char * dst, int n)
+Caml_inline void store16(char * dst, int n)
 {
   dst[0] = n >> 8;  dst[1] = n;
 }
 
-static inline void store32(char * dst, intnat n)
+Caml_inline void store32(char * dst, intnat n)
 {
   dst[0] = n >> 24;  dst[1] = n >> 16;  dst[2] = n >> 8;  dst[3] = n;
 }
 
-static inline void store64(char * dst, int64_t n)
+Caml_inline void store64(char * dst, int64_t n)
 {
   dst[0] = n >> 56;  dst[1] = n >> 48;  dst[2] = n >> 40;  dst[3] = n >> 32;
   dst[4] = n >> 24;  dst[5] = n >> 16;  dst[6] = n >> 8;   dst[7] = n;
@@ -327,7 +327,7 @@ static inline void store64(char * dst, int64_t n)
 
 /* Write characters, integers, and blocks in the output buffer */
 
-static inline void write(int c)
+Caml_inline void write(int c)
 {
   if (extern_ptr >= extern_limit) grow_extern_output(1);
   *extern_ptr++ = c;
@@ -340,7 +340,7 @@ static void writeblock(const char * data, intnat len)
   extern_ptr += len;
 }
 
-static inline void writeblock_float8(const double * data, intnat ndoubles)
+Caml_inline void writeblock_float8(const double * data, intnat ndoubles)
 {
 #if ARCH_FLOAT_ENDIANNESS == 0x01234567 || ARCH_FLOAT_ENDIANNESS == 0x76543210
   writeblock((const char *) data, ndoubles * 8);

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -105,7 +105,7 @@ static void check_global_data_param(char const *exception_name, char const *msg)
   }
 }
 
-static inline value caml_get_failwith_tag (char const *msg)
+Caml_inline value caml_get_failwith_tag (char const *msg)
 {
   check_global_data_param("Failure", msg);
   return Field(caml_global_data, FAILURE_EXN);
@@ -124,7 +124,7 @@ CAMLexport void caml_failwith_value (value msg)
   CAMLnoreturn;
 }
 
-static inline value caml_get_invalid_argument_tag (char const *msg)
+Caml_inline value caml_get_invalid_argument_tag (char const *msg)
 {
   check_global_data_param("Invalid_argument", msg);
   return Field(caml_global_data, INVALID_EXN);

--- a/runtime/freelist.c
+++ b/runtime/freelist.c
@@ -50,7 +50,7 @@ value caml_fl_merge = Val_NULL;  /* Current insertion pointer.  Managed
 #define Next_small(v) Field ((v), 0)
 
 /* Next in memory order */
-static inline value Next_in_mem (value v) {
+Caml_inline value Next_in_mem (value v) {
   return (value) &Field ((v), Whsize_val (v));
 }
 
@@ -894,7 +894,7 @@ typedef struct large_free_block {
   struct large_free_block *next;
 } large_free_block;
 
-static inline mlsize_t bf_large_wosize (struct large_free_block *n) {
+Caml_inline mlsize_t bf_large_wosize (struct large_free_block *n) {
   return Wosize_val((value)(n));
 }
 
@@ -913,7 +913,7 @@ static struct large_free_block *bf_large_least;
 #include <strings.h>
 #elif defined(HAS_BITSCANFORWARD)
 #include <intrin.h>
-static inline int ffs (int x)
+Caml_inline int ffs (int x)
 {
   unsigned long index;
   unsigned char result;
@@ -921,7 +921,7 @@ static inline int ffs (int x)
   return result ? (int) index + 1 : 0;
 }
 #else
-static inline int ffs (int x)
+Caml_inline int ffs (int x)
 {
   /* adapted from Hacker's Delight */
   int bnz, b0, b1, b2, b3, b4;
@@ -938,11 +938,11 @@ static inline int ffs (int x)
 #endif /* HAS_FFS or HAS_BITSCANFORWARD */
 
 /* Indexing starts at 1 because that's the minimum block size. */
-static inline void set_map (int index)
+Caml_inline void set_map (int index)
 {
   bf_small_map |= (1 << (index - 1));
 }
-static inline void unset_map (int index)
+Caml_inline void unset_map (int index)
 {
   bf_small_map &= ~(1 << (index - 1));
 }

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -77,27 +77,27 @@ CAMLnoreturn_end;
 
 static void intern_free_stack(void);
 
-static inline unsigned char read8u(void)
+Caml_inline unsigned char read8u(void)
 { return *intern_src++; }
 
-static inline signed char read8s(void)
+Caml_inline signed char read8s(void)
 { return *intern_src++; }
 
-static inline uint16_t read16u(void)
+Caml_inline uint16_t read16u(void)
 {
   uint16_t res = (intern_src[0] << 8) + intern_src[1];
   intern_src += 2;
   return res;
 }
 
-static inline int16_t read16s(void)
+Caml_inline int16_t read16s(void)
 {
   int16_t res = (intern_src[0] << 8) + intern_src[1];
   intern_src += 2;
   return res;
 }
 
-static inline uint32_t read32u(void)
+Caml_inline uint32_t read32u(void)
 {
   uint32_t res =
     ((uint32_t)(intern_src[0]) << 24) + (intern_src[1] << 16)
@@ -106,7 +106,7 @@ static inline uint32_t read32u(void)
   return res;
 }
 
-static inline int32_t read32s(void)
+Caml_inline int32_t read32s(void)
 {
   int32_t res =
     ((uint32_t)(intern_src[0]) << 24) + (intern_src[1] << 16)
@@ -132,7 +132,7 @@ static uintnat read64u(void)
 }
 #endif
 
-static inline void readblock(void * dest, intnat len)
+Caml_inline void readblock(void * dest, intnat len)
 {
   memcpy(dest, intern_src, len);
   intern_src += len;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -41,7 +41,7 @@
 #endif
 
 #ifdef _MSC_VER
-static inline double fmin(double a, double b) {
+Caml_inline double fmin(double a, double b) {
   return (a < b) ? a : b;
 }
 #endif
@@ -233,9 +233,9 @@ static void init_sweep_phase(void)
 }
 
 /* auxiliary function of mark_slice */
-static inline value* mark_slice_darken(value *gray_vals_ptr,
-                                       value v, mlsize_t i,
-                                       int in_ephemeron, int *slice_pointers)
+Caml_inline value* mark_slice_darken(value *gray_vals_ptr,
+                                     value v, mlsize_t i,
+                                     int in_ephemeron, int *slice_pointers)
 {
   value child;
   header_t chd;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -623,6 +623,7 @@ void caml_major_collection_slice (intnat howmuch)
   double p, dp, filt_p, spend;
   intnat computed_work;
   int i;
+  CAML_INSTR_DECLARE (tmr);
   /*
      Free memory at the start of the GC cycle (garbage + free list) (assumed):
                  FM = Caml_state->stat_heap_wsz * caml_percent_free
@@ -682,7 +683,8 @@ void caml_major_collection_slice (intnat howmuch)
   */
 
   if (caml_major_slice_begin_hook != NULL) (*caml_major_slice_begin_hook) ();
-  CAML_INSTR_SETUP (tmr, "major");
+  CAML_INSTR_ALLOC (tmr);
+  CAML_INSTR_START (tmr, "major");
 
   p = (double) caml_allocated_words * 3.0 * (100 + caml_percent_free)
       / Caml_state->stat_heap_wsz / caml_percent_free / 2.0;

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -467,8 +467,8 @@ color_t caml_allocation_color (void *hp)
   }
 }
 
-static inline value caml_alloc_shr_aux (mlsize_t wosize, tag_t tag, int track,
-                                        int raise_oom, uintnat profinfo)
+Caml_inline value caml_alloc_shr_aux (mlsize_t wosize, tag_t tag, int track,
+                                      int raise_oom, uintnat profinfo)
 {
   header_t *hp;
   value *new_block;

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -293,9 +293,9 @@ static int realloc_trackst(void) {
   return 1;
 }
 
-static inline uintnat new_tracked(uintnat n_samples, uintnat wosize,
-                                  int is_unmarshalled, int is_young,
-                                  value block, value user_data)
+Caml_inline uintnat new_tracked(uintnat n_samples, uintnat wosize,
+                                int is_unmarshalled, int is_young,
+                                value block, value user_data)
 {
   struct tracked *t;
   trackst.len++;
@@ -332,7 +332,7 @@ static void mark_deleted(uintnat t_idx)
 /* The return value is an exception or [Val_unit] iff [*t_idx] is set to
    [Invalid_index]. In this case, the entry is deleted.
    Otherwise, the return value is a [Some(...)] block. */
-static inline value run_callback_exn(uintnat *t_idx, value cb, value param) {
+Caml_inline value run_callback_exn(uintnat *t_idx, value cb, value param) {
   struct tracked* t = &trackst.entries[*t_idx];
   value res;
   CAMLassert(!t->callback_running && t->idx_ptr == NULL);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -274,7 +274,7 @@ void caml_oldify_one (value v, value *p)
 }
 
 /* Test if the ephemeron is alive, everything outside minor heap is alive */
-static inline int ephe_check_alive_data(struct caml_ephe_ref_elt *re){
+Caml_inline int ephe_check_alive_data(struct caml_ephe_ref_elt *re){
   mlsize_t i;
   value child;
   for (i = CAML_EPHE_FIRST_KEY; i < Wosize_val(re->ephe); i++){

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -351,11 +351,13 @@ void caml_empty_minor_heap (void)
   struct caml_custom_elt *elt;
   uintnat prev_alloc_words;
   struct caml_ephe_ref_elt *re;
+  CAML_INSTR_DECLARE (tmr);
 
   if (Caml_state->young_ptr != Caml_state->young_alloc_end){
     CAMLassert_young_header(*(header_t*)Caml_state->young_ptr);
     if (caml_minor_gc_begin_hook != NULL) (*caml_minor_gc_begin_hook) ();
-    CAML_INSTR_SETUP (tmr, "minor");
+    CAML_INSTR_ALLOC (tmr);
+    CAML_INSTR_START (tmr, "minor");
     prev_alloc_words = caml_allocated_words;
     Caml_state->in_minor_collection = 1;
     caml_gc_message (0x02, "<");

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -325,7 +325,7 @@ exception:
 }
 
 CAMLno_tsan /* The access to [caml_something_to_do] is not synchronized. */
-static inline value process_pending_actions_with_root_exn(value extra_root)
+Caml_inline value process_pending_actions_with_root_exn(value extra_root)
 {
   if (caml_something_to_do) {
     CAMLparam1(extra_root);

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -61,7 +61,7 @@ CAMLexport mlsize_t caml_ephemeron_num_keys(value eph)
 /** The minor heap is considered alive. */
 #if defined (NATIVE_CODE) && defined (NO_NAKED_POINTERS)
 /** Outside minor and major heap, x must be black. */
-static inline int Is_Dead_during_clean(value x)
+Caml_inline int Is_Dead_during_clean(value x)
 {
   CAMLassert (x != caml_ephe_none);
   CAMLassert (caml_gc_phase == Phase_clean);
@@ -70,20 +70,20 @@ static inline int Is_Dead_during_clean(value x)
 /** The minor heap doesn't have to be marked, outside they should
     already be black
 */
-static inline int Must_be_Marked_during_mark(value x)
+Caml_inline int Must_be_Marked_during_mark(value x)
 {
   CAMLassert (x != caml_ephe_none);
   CAMLassert (caml_gc_phase == Phase_mark);
   return Is_block (x) && !Is_young (x);
 }
 #else
-static inline int Is_Dead_during_clean(value x)
+Caml_inline int Is_Dead_during_clean(value x)
 {
   CAMLassert (x != caml_ephe_none);
   CAMLassert (caml_gc_phase == Phase_clean);
   return Is_block (x) && Is_in_heap (x) && Is_white_val(x);
 }
-static inline int Must_be_Marked_during_mark(value x)
+Caml_inline int Must_be_Marked_during_mark(value x)
 {
   CAMLassert (x != caml_ephe_none);
   CAMLassert (caml_gc_phase == Phase_mark);
@@ -170,7 +170,7 @@ static void do_check_key_clean(value ar, mlsize_t offset)
 
 /* If we are in Phase_clean we need to do as if the key is empty when
    it will be cleaned during this phase */
-static inline int is_ephe_key_none(value ar, mlsize_t offset)
+Caml_inline int is_ephe_key_none(value ar, mlsize_t offset)
 {
   value elt = Field (ar, offset);
   if (elt == caml_ephe_none){
@@ -355,7 +355,7 @@ CAMLprim value caml_ephe_get_data (value ar)
 }
 
 
-static inline void copy_value(value src, value dst)
+Caml_inline void copy_value(value src, value dst)
 {
   if (Tag_val (src) < No_scan_tag){
     mlsize_t i;

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -888,7 +888,7 @@ CAMLexport value caml_copy_string_of_utf16(const wchar_t *s)
   return v;
 }
 
-CAMLexport inline wchar_t* caml_stat_strdup_to_utf16(const char *s)
+CAMLexport wchar_t* caml_stat_strdup_to_utf16(const char *s)
 {
   wchar_t * ws;
   int retcode;


### PR DESCRIPTION
In other projects, it is useful to be able to tell GCC to run with `--std=c89` in order to write C code which is compatible with Microsoft's C compiler, but this disables the `inline` keyword, as that's officially only part of C99.

This GPR proposes altering the headers to use GCC's `__inline__` keyword, which is always available in GCC, and introduces a test in configure which adds a definition for `__inline__` if the C compiler does not support it.

I think that this "trick" using `--std=c89` to force compatibility with MSVC is a safe thing to do, but I'd very much appreciate input from someone who really gets the differences in semantics between -fgnu89-inline (which is also enabled by using `--std=c89`) and C99 inline.