### PR TITLE
Testsuite tweaks

### DIFF
--- a/testsuite/makefiles/Makefile.common
+++ b/testsuite/makefiles/Makefile.common
@@ -71,6 +71,7 @@ defaultclean:
 .S.o:
 	@$(ASPP) $(ASPPFLAGS) -DSYS_$(SYSTEM) -DMODEL_$(MODEL) -o $*.o $*.S
 
+.PRECIOUS: %.s
 .s.o:
 	@$(ASPP) $(ASPPFLAGS) -DSYS_$(SYSTEM) -o $*.o $*.s
 

--- a/testsuite/tests/lib-unix/Makefile
+++ b/testsuite/tests/lib-unix/Makefile
@@ -29,5 +29,8 @@ include $(BASEDIR)/makefiles/Makefile.several
 include $(BASEDIR)/makefiles/Makefile.common
 
 %.exe: %.c
-	@$(BYTECC) $(if $(filter msvc,$(CCOMPTYPE)),/Fe$*.exe,-o $*.exe) $*.c
-
+ifeq ($(CCOMPTYPE),msvc)
+	@set -o pipefail ; $(BYTECC) /Fe$*.exe $*.c | tail -n +2
+else
+	@$(BYTECC) -o $*.exe $*.c
+endif

--- a/testsuite/tests/lib-unix/Makefile
+++ b/testsuite/tests/lib-unix/Makefile
@@ -23,7 +23,7 @@ ADD_BYTERUN_FLAGS="-I $(OTOPDIR)/otherlibs/win32unix"
 endif
 
 default: reflector.exe fdstatus.exe cmdline_prog.exe
-	$(MAKE) check
+	@$(MAKE) check
 
 include $(BASEDIR)/makefiles/Makefile.several
 include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/lib-unix/cloexec.ml
+++ b/testsuite/tests/lib-unix/cloexec.ml
@@ -6,7 +6,11 @@
 let string_of_fd (fd: Unix.file_descr) : string =
   match Sys.os_type with
   | "Unix" | "Cygwin" ->  string_of_int (Obj.magic fd : int)
-  | "Win32"           ->  Int32.to_string (Obj.magic fd : int32)
+  | "Win32" ->
+      if Sys.word_size = 32 then
+        Int32.to_string (Obj.magic fd : int32)
+      else
+        Int64.to_string (Obj.magic fd : int64)
   | _ -> assert false
 
 let _ =
@@ -33,7 +37,7 @@ let _ =
     try Unix.(socketpair ~cloexec:true PF_UNIX SOCK_STREAM 0)
     with Invalid_argument _ -> (p2, p2') in
 
-  let fds = [| f0;f1;f2; d0;d1;d2; 
+  let fds = [| f0;f1;f2; d0;d1;d2;
                p0;p0';p1;p1';p2;p2';
                s0;s1;s2;
                x0;x0';x1;x1';x2;x2' |] in
@@ -45,4 +49,3 @@ let _ =
   ignore (Unix.waitpid [] pid);
   Array.iter (fun fd -> try Unix.close fd with Unix.Unix_error _ -> ()) fds;
   Sys.remove "tmp.txt"
-

--- a/testsuite/tests/lib-unix/fdstatus.c
+++ b/testsuite/tests/lib-unix/fdstatus.c
@@ -16,7 +16,11 @@ void process_fd(char * s)
   HANDLE h;
   DWORD flags;
 
+#ifdef _WIN64
+  h = (HANDLE) _atoi64(s);
+#else
   h = (HANDLE) atoi(s);
+#endif
   if (GetHandleInformation(h, &flags)) {
     printf("open\n");
   } else if (GetLastError() == ERROR_INVALID_HANDLE) {

--- a/testsuite/tests/tool-command-line/Makefile
+++ b/testsuite/tests/tool-command-line/Makefile
@@ -17,7 +17,7 @@ BASEDIR=../..
 
 
 default:
-	$(MAKE) byte
+	@$(MAKE) byte
 	@if $(BYTECODE_ONLY); then $(MAKE) opt-skipped ; else \
           $(MAKE) opt; \
         fi


### PR DESCRIPTION
A few minor tweaks to the testsuite only:

 - On non-MSVC builds of tests/asmcomp, don't remove the intermediate .s files (the only reason for this is to reduce the difference in the logs between mingw and msvc)
 - A few missing `@` symbols (again, tidying the log output)
 - The new lib-unix tests needed the Microsoft C compiler's tedious echoing of the file its compiling suppressed (this is already done in ocamlc/ocamlopt and elsewhere in the testsuite)
 - Fixed a 64/32-bit error on the Windows ports in the lib-unix cloexec test

Popping this through AppVeyor/Travis/Inria - can be merged next week

cc @damiendoligez 