### PR TITLE
Re-assigning events of a pack of modules to the individual modules of the pack

### DIFF
--- a/Changes
+++ b/Changes
@@ -253,6 +253,10 @@ Working version
 - PR#7506: pprintast ignores attributes in tails of a list
   (Alain Frisch, report by Kenichi Asai and Gabriel Scherer)
 
+- PR#7540, GPR#1179: Fixing setting of breakpoints in packed modules
+  for ocamldebug
+  (Hugo Herbelin, review by Gabriel Scherer, Damien Doligez)
+
 - PR#7543: short-paths printtyp can fail on packed type error messages
   (Florian Angeletti)
 


### PR DESCRIPTION
Hi, I wrote the attached lines to fix [https://caml.inria.fr/mantis/view.php?id=7540](https://caml.inria.fr/mantis/view.php?id=7540). This seems to work in my experiments but I don't know well enough the global layout ocamldebug to be sure that this is the right fix. Best.