### PR TITLE
MPR#7539: manual, fix dead links in the ocamldoc chapter

### DIFF
--- a/Changes
+++ b/Changes
@@ -188,6 +188,9 @@ Next major version (4.05.0):
 - PR#7497, GPR#1095: manual, enable numbering for table of contents
   (Florian Angeletti, request by Daniel Bünzli)
 
+- PR#7539, GPR#1181: manual, update dead links in ocamldoc chapter
+  (Florian Angeletti)
+
 - GPR#633: manpage and manual documentation for the `-opaque` option
   (Konstantin Romanov, Gabriel Scherer, review by Mark Shinwell)
 

--- a/manual/manual/cmds/ocamldoc.etex
+++ b/manual/manual/cmds/ocamldoc.etex
@@ -1030,12 +1030,13 @@ let _ = Odoc_args.extend_html_generator (module Generator : Odoc_gen.Html_functo
 To know which methods to override and/or which methods are available,
 have a look at the different base implementations, depending on the
 kind of generator you are extending~:
+\newcommand\ocamldocsrc[2]{\href{https://github.com/ocaml/ocaml/blob/{\ocamlversion}/ocamldoc/odoc_#1.ml}{#2}}
 \begin{itemize}
-\item for HTML~: \href{http://caml.inria.fr/cgi-bin/viewvc.cgi/ocaml/version/\ocamlversion/ocamldoc/odoc_html.ml?view=markup}{"odoc_html.ml"},
-\item for \LaTeX~: \href{http://caml.inria.fr/cgi-bin/viewvc.cgi/ocaml/version/\ocamlversion/ocamldoc/odoc_latex.ml?view=markup}{"odoc_latex.ml"},
-\item for TeXinfo~: \href{http://caml.inria.fr/cgi-bin/viewvc.cgi/ocaml/version/\ocamlversion/ocamldoc/odoc_texi.ml?view=markup}{"odoc_texi.ml"},
-\item for man pages~: \href{http://caml.inria.fr/cgi-bin/viewvc.cgi/ocaml/version/\ocamlversion/ocamldoc/odoc_man.ml?view=markup}{"odoc_man.ml"},
-\item for graphviz (dot)~: \href{http://caml.inria.fr/cgi-bin/viewvc.cgi/ocaml/version/\ocamlversion/ocamldoc/odoc_dot.ml?view=markup}{"odoc_dot.ml"}.
+\item for HTML~: \ocamldocsrc{html}{"odoc_html.ml"},
+\item for \LaTeX~: \ocamldocsrc{latex}{"odoc_latex.ml"},
+\item for TeXinfo~: \ocamldocsrc{texi}{"odoc_texi.ml"},
+\item for man pages~: \ocamldocsrc{man}{"odoc_man.ml"},
+\item for graphviz (dot)~: \ocamldocsrc{dot}{"odoc_dot.ml"}.
 \end{itemize}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
[MPR:7539](https://caml.inria.fr/mantis/view.php?id=7539)

This short PR fixes few dead links in the ocamldoc chapter of the manual. These links referred directly to the ocamldoc source code and were not valid anymore since the 4.03 release. This PR, as suggested in the mantis ticket, rewrites these links to point towards OCaml's github repository.