### PR TITLE
Use dash instead of bash on the Travis CI machines.

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -15,6 +15,8 @@
 
 PREFIX=~/local
 
+MAKE=make SHELL=dash
+
 BuildAndTest () {
   case $XARCH in
   i386)
@@ -35,37 +37,37 @@ EOF
     ./configure --prefix $PREFIX -with-debug-runtime \
       -with-instrumented-runtime $CONFIG_ARG
     export PATH=$PREFIX/bin:$PATH
-    make world.opt
-    make ocamlnat
-    (cd testsuite && make all)
-    (cd testsuite && make USE_RUNTIME="d" all)
-    make install
+    $MAKE world.opt
+    $MAKE ocamlnat
+    (cd testsuite && $MAKE all)
+    (cd testsuite && $MAKE USE_RUNTIME="d" all)
+    $MAKE install
     # check_all_arches checks tries to compile all backends in place,
     # we need to redo (small parts of) world.opt afterwards
-    make check_all_arches
-    make world.opt
-    make manual-pregen
+    $MAKE check_all_arches
+    $MAKE world.opt
+    $MAKE manual-pregen
     mkdir external-packages
     cd external-packages
     git clone git://github.com/ocaml/ocamlbuild
     mkdir ocamlbuild-install
     (cd ocamlbuild &&
-        make -f configure.make Makefile.config src/ocamlbuild_config.ml \
+        $MAKE -f configure.make Makefile.config src/ocamlbuild_config.ml \
           OCAMLBUILD_PREFIX=$PREFIX \
           OCAMLBUILD_BINDIR=$PREFIX/bin \
           OCAMLBUILD_LIBDIR=$PREFIX/lib \
           OCAML_NATIVE=true \
           OCAML_NATIVE_TOOLS=true &&
-        make all &&
-        make install)
+        $MAKE all &&
+        $MAKE install)
     git clone git://github.com/ocaml/camlp4
     (cd camlp4 &&
      ./configure --bindir=$PREFIX/bin --libdir=$PREFIX/lib/ocaml \
        --pkgdir=$PREFIX/lib/ocaml && \
-      make && make install)
+      $MAKE && $MAKE install)
     # git clone git://github.com/ocaml/opam
     # (cd opam && ./configure --prefix $PREFIX &&\
-    #   make lib-ext && make && make install)
+    #   $MAKE lib-ext && $MAKE && $MAKE install)
     # git config --global user.email "some@name.com"
     # git config --global user.name "Some Name"
     # opam init -y -a git://github.com/ocaml/opam-repository


### PR DESCRIPTION
On some Linux server machines, /bin/sh points to the "dash" shell,
a minimalistic shell implementation that does not support many
bash-isms. This means that Makefiles that work on developer machines
(typically using bash or other rich shells) may silently break in
other environments. Using a minimalistic shell implementation in
testing should help catch non-portable Make rules.