### PR TITLE
make string_of_float and float_of_string locale-independent

### DIFF
--- a/Changes
+++ b/Changes
@@ -62,6 +62,9 @@ Working version
 - Resurrect tabulation boxes in module Format. Rewrite/extend documentation
   of tabulation boxes.
 
+- GPR#1185: make float_of_string and string_of_float locale-independent
+  (ygrek)
+
 ### Compiler user-interface and warnings:
 
 - GPR#896: "-compat-32" is now taken into account when building .cmo/.cma

--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -126,6 +126,7 @@ value caml_startup_common(char **argv, int pooling)
 #endif
   caml_init_frame_descriptors();
   caml_init_ieee_floats();
+  caml_init_locale();
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();
 #endif

--- a/byterun/caml/startup_aux.h
+++ b/byterun/caml/startup_aux.h
@@ -20,6 +20,9 @@
 
 #include "config.h"
 
+extern void caml_init_locale(void);
+extern void caml_free_locale(void);
+
 extern void caml_init_atom_table (void);
 
 extern uintnat caml_init_percent_free;

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -91,7 +91,7 @@ void caml_init_locale(void)
   if (0 == caml_locale)
   {
     caml_locale = duplocale(LC_GLOBAL_LOCALE);
-    caml_locale = newlocale(LC_ALL,"C",caml_locale);
+    caml_locale = newlocale(LC_NUMERIC_MASK,"C",caml_locale);
   }
 #endif
 }

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -17,6 +17,12 @@
 
 /* The interface of this file is in "caml/mlvalues.h" and "caml/alloc.h" */
 
+/* Needed for uselocale */
+#define _XOPEN_SOURCE 700
+
+/* Needed for strtod_l */
+#define _GNU_SOURCE
+
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -31,6 +37,10 @@
 #include "caml/misc.h"
 #include "caml/reverse.h"
 #include "caml/stacks.h"
+
+#ifdef HAS_LOCALE
+#include <locale.h>
+#endif
 
 #ifdef _MSC_VER
 #include <float.h>
@@ -66,6 +76,34 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
 
 #endif
 
+/*
+ OCaml runtime itself doesn't call setlocale, i.e. it is using
+ standard "C" locale by default, but it is possible that
+ thirt-party code loaded into process does.
+*/
+#ifdef HAS_LOCALE
+locale_t caml_locale = 0;
+#endif
+
+void caml_init_locale(void)
+{
+#ifdef HAS_LOCALE
+  if (0 == caml_locale)
+  {
+    caml_locale = duplocale(LC_GLOBAL_LOCALE);
+    caml_locale = newlocale(LC_ALL,"C",caml_locale);
+  }
+#endif
+}
+
+void caml_free_locale(void)
+{
+#ifdef HAS_LOCALE
+  if (0 != caml_locale) freelocale(caml_locale);
+  caml_locale = 0;
+#endif
+}
+
 CAMLexport value caml_copy_double(double d)
 {
   value res;
@@ -87,7 +125,13 @@ CAMLprim value caml_format_float(value fmt, value arg)
 #ifdef HAS_BROKEN_PRINTF
   if (isfinite(d)) {
 #endif
+#ifdef HAS_LOCALE
+    locale_t saved_locale = uselocale(caml_locale);
+#endif
     res = caml_alloc_sprintf(String_val(fmt), d);
+#ifdef HAS_LOCALE
+    uselocale(saved_locale);
+#endif
 #ifdef HAS_BROKEN_PRINTF
   } else {
     if (isnan(d)) {
@@ -287,8 +331,18 @@ CAMLprim value caml_float_of_string(value vs)
   }
   *dst = 0;
   if (dst == buf) goto error;
+#ifdef HAS_STRTOD_L
+  d = strtod_l((const char *) buf, &end, caml_locale);
+#else
+#ifdef HAS_LOCALE
+  locale_t saved_locale = uselocale(caml_locale);
+#endif
   /* Convert using strtod */
   d = strtod((const char *) buf, &end);
+#ifdef HAS_LOCALE
+  uselocale(saved_locale);
+#endif
+#endif /* HAS_STRTOD_L */
   if (end != dst) goto error;
   if (buf != parse_buffer) caml_stat_free(buf);
   return caml_copy_double(d);

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -79,7 +79,7 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
 /*
  OCaml runtime itself doesn't call setlocale, i.e. it is using
  standard "C" locale by default, but it is possible that
- thirt-party code loaded into process does.
+ third-party code loaded into process does.
 */
 #ifdef HAS_LOCALE
 
@@ -99,21 +99,20 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
 
 #endif
 
-locale_t caml_locale = 0;
+locale_t caml_locale = (locale_t)0;
 
 #endif
 
 void caml_init_locale(void)
 {
 #ifdef HAS_LOCALE
-  if (0 == caml_locale)
+  if ((locale_t)0 == caml_locale)
   {
 #ifdef _MSC_VER
     _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
     caml_locale = _create_locale(LC_NUMERIC, "C");
 #else
-    caml_locale = duplocale(LC_GLOBAL_LOCALE);
-    caml_locale = newlocale(LC_NUMERIC_MASK,"C",caml_locale);
+    caml_locale = newlocale(LC_NUMERIC_MASK,"C",(locale_t)0);
 #endif
   }
 #endif
@@ -122,8 +121,8 @@ void caml_init_locale(void)
 void caml_free_locale(void)
 {
 #ifdef HAS_LOCALE
-  if (0 != caml_locale) freelocale(caml_locale);
-  caml_locale = 0;
+  if ((locale_t)0 != caml_locale) freelocale(caml_locale);
+  caml_locale = (locale_t)0;
 #endif
 }
 

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -38,10 +38,10 @@
 #include "caml/reverse.h"
 #include "caml/stacks.h"
 
-#ifdef HAS_LOCALE
+#if defined(HAS_LOCALE) || defined(__MINGW32__)
 #include <locale.h>
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(_MSC_VER)
 #ifndef locale_t
 #define locale_t _locale_t
 #endif
@@ -96,30 +96,29 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
 */
 #ifdef HAS_LOCALE
 locale_t caml_locale = (locale_t)0;
+#endif
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 /* there is no analogue to uselocale in MSVC so just set locale for thread */
 #define USE_LOCALE setlocale(LC_NUMERIC,"C")
 #define RESTORE_LOCALE do {} while(0)
-#else
+#elif defined(HAS_LOCALE)
 #define USE_LOCALE locale_t saved_locale = uselocale(caml_locale)
 #define RESTORE_LOCALE uselocale(saved_locale)
-#endif
-
 #else
-
 #define USE_LOCALE do {} while(0)
 #define RESTORE_LOCALE do {} while(0)
-
 #endif
 
 void caml_init_locale(void)
 {
+#if defined(_MSC_VER) || defined(__MINGW32__)
+  _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+#endif
 #ifdef HAS_LOCALE
   if ((locale_t)0 == caml_locale)
   {
-#if defined(_MSC_VER) || defined(__MINGW32__)
-    _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+#if defined(_MSC_VER)
     caml_locale = _create_locale(LC_NUMERIC, "C");
 #else
     caml_locale = newlocale(LC_NUMERIC_MASK,"C",(locale_t)0);

--- a/byterun/startup.c
+++ b/byterun/startup.c
@@ -300,6 +300,7 @@ CAMLexport void caml_main(char **argv)
   /* Machine-dependent initialization of the floating-point hardware
      so that it behaves as much as possible as specified in IEEE */
   caml_init_ieee_floats();
+  caml_init_locale();
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();
 #endif
@@ -424,6 +425,7 @@ CAMLexport value caml_startup_code_exn(
     return Val_unit;
 
   caml_init_ieee_floats();
+  caml_init_locale();
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();
 #endif

--- a/byterun/startup_aux.c
+++ b/byterun/startup_aux.c
@@ -157,6 +157,7 @@ CAMLexport void caml_shutdown(void)
 
   do_at_exit();
   caml_finalise_heap();
+  caml_free_locale();
 #ifndef NATIVE_CODE
   caml_free_shared_libs();
 #endif

--- a/config/s-nt.h
+++ b/config/s-nt.h
@@ -29,8 +29,10 @@
 #define HAS_GETHOSTNAME
 #define HAS_MKTIME
 #define HAS_PUTENV
+#ifndef __MINGW32__
 #define HAS_LOCALE
 #define HAS_STRTOD_L
+#endif
 #define HAS_BROKEN_PRINTF
 #define HAS_IPV6
 #define HAS_NICE

--- a/config/s-nt.h
+++ b/config/s-nt.h
@@ -30,6 +30,7 @@
 #define HAS_MKTIME
 #define HAS_PUTENV
 #define HAS_LOCALE
+#define HAS_STRTOD_L
 #define HAS_BROKEN_PRINTF
 #define HAS_IPV6
 #define HAS_NICE

--- a/config/s-templ.h
+++ b/config/s-templ.h
@@ -197,7 +197,11 @@
 #define HAS_LOCALE
 
 /* Define HAS_LOCALE if you have the include file <locale.h> and the
-   setlocale() function. */
+   uselocale() function. */
+
+#define HAS_STRTOD_L
+
+/* Define HAS_STRTOD_L if you have strtod_l */
 
 #define HAS_MMAP
 

--- a/configure
+++ b/configure
@@ -1388,7 +1388,7 @@ if sh ./hasgot putenv; then
   echo "#define HAS_PUTENV" >> s.h
 fi
 
-if sh ./hasgot -i locale.h && sh ./hasgot newlocale duplocale freelocale uselocale; then
+if sh ./hasgot -i locale.h && sh ./hasgot newlocale freelocale uselocale; then
   inf "newlocale() and <locale.h> found."
   echo "#define HAS_LOCALE" >> s.h
 fi

--- a/configure
+++ b/configure
@@ -1388,9 +1388,14 @@ if sh ./hasgot putenv; then
   echo "#define HAS_PUTENV" >> s.h
 fi
 
-if sh ./hasgot -i locale.h && sh ./hasgot setlocale; then
-  inf "setlocale() and <locale.h> found."
+if sh ./hasgot -i locale.h && sh ./hasgot newlocale duplocale freelocale uselocale; then
+  inf "newlocale() and <locale.h> found."
   echo "#define HAS_LOCALE" >> s.h
+fi
+
+if sh ./hasgot strtod_l; then
+  inf "strtod_l() found."
+  echo "#define HAS_STRTOD_L" >> s.h
 fi
 
 

--- a/testsuite/tests/locale/Makefile
+++ b/testsuite/tests/locale/Makefile
@@ -1,0 +1,9 @@
+BASEDIR=../..
+MODULES=
+MAIN_MODULE=test
+C_FILES=stubs
+
+include $(BASEDIR)/makefiles/Makefile.one
+include $(BASEDIR)/makefiles/Makefile.common
+
+NATIVECODE_ONLY=true

--- a/testsuite/tests/locale/stubs.c
+++ b/testsuite/tests/locale/stubs.c
@@ -1,0 +1,8 @@
+#include <caml/mlvalues.h>
+#include <locale.h>
+
+value ml_setlocale(value v_locale)
+{
+  setlocale(LC_ALL,String_val(v_locale));
+  return Val_unit;
+}

--- a/testsuite/tests/locale/test.ml
+++ b/testsuite/tests/locale/test.ml
@@ -1,0 +1,24 @@
+
+external setlocale : string -> unit = "ml_setlocale"
+
+let show f = try string_of_float @@ f () with exn -> Printf.sprintf "exn %s" (Printexc.to_string exn)
+let pr fmt = Printf.ksprintf print_endline fmt
+
+let () =
+  let s = "12345.6789" in
+  let f = 1.23 in
+  let test () =
+    pr "  print 1.23 : %s" (show @@ fun () -> f);
+    pr "  parse %S : %s" s (show @@ fun () -> float_of_string s);
+    pr "  roundtrip 1.23 : %s" (show @@ fun () -> float_of_string @@ string_of_float f);
+  in
+  pr "locale from environment";
+  setlocale "";
+  test ();
+  pr "locale nl_NL";
+  setlocale "nl_NL";
+  test ();
+  pr "locale POSIX";
+  setlocale "C";
+  test ();
+  ()

--- a/testsuite/tests/locale/test.reference
+++ b/testsuite/tests/locale/test.reference
@@ -1,0 +1,12 @@
+locale from environment
+  print 1.23 : 1.23
+  parse "12345.6789" : 12345.6789
+  roundtrip 1.23 : 1.23
+locale nl_NL
+  print 1.23 : 1.23
+  parse "12345.6789" : 12345.6789
+  roundtrip 1.23 : 1.23
+locale POSIX
+  print 1.23 : 1.23
+  parse "12345.6789" : 12345.6789
+  roundtrip 1.23 : 1.23


### PR DESCRIPTION
Problem:

see https://caml.inria.fr/mantis/view.php?id=6701 and https://github.com/mjambon/yojson/issues/13

Solution:

1. Use `uselocale` around calls to `vsnprintf`.
2. Use `strtod_l` if available. If not available - use `uselocale` around calls to `strtod`.

Possible improvement - use `vsnprintf_l` if available.

Test output for 4.04.1 : 
```
locale from environment
  print 1.23 : 1.23
  parse "12345.6789" : 12345.6789
  roundtrip 1.23 : 1.23
locale nl_NL
  print 1.23 : 1,23
  parse "12345.6789" : exn Failure("float_of_string")
  roundtrip 1.23 : 1,23
locale POSIX
  print 1.23 : 1.23
  parse "12345.6789" : 12345.6789
  roundtrip 1.23 : 1.23
```

With this patch : 
```
$ ./q.locale 
locale from environment
  print 1.23 : 1.23
  parse "12345.6789" : 12345.6789
  roundtrip 1.23 : 1.23
locale nl_NL
  print 1.23 : 1.23
  parse "12345.6789" : 12345.6789
  roundtrip 1.23 : 1.23
locale POSIX
  print 1.23 : 1.23
  parse "12345.6789" : 12345.6789
  roundtrip 1.23 : 1.23
```

Speed overhead of `uselocale` around `vsnprintf` (x86_64, glibc).
Test program : 
```
let () =
  for _ = 1 to 1_000_000 do
    ignore @@ Printf.sprintf "%f %f" 123456.789 (-8888.8888)
  done
```

```
$ sudo perf stat ./speed.4.04.1 |& grep instructions
     9,684,761,712      instructions              #    1.72  insn per cycle         
$ sudo perf stat ./speed.locale |& grep instructions
     9,780,738,205      instructions              #    1.73  insn per cycle         
```

i.e. each call to `vsnprintf` (~4800 instructions) bears additional cost of ~48 insns for two `uselocale` calls, i.e. 1% slowdown for every `%f` conversion in `Printf.printf`.