### PR TITLE
PR#7543: fix packed module type error reporting

### DIFF
--- a/Changes
+++ b/Changes
@@ -197,6 +197,9 @@ Working version
 - PR#7506: pprintast ignores attributes in tails of a list
   (Alain Frisch, report by Kenichi Asai and Gabriel Scherer)
 
+- PR#7543: short-paths printtyp can fail on packed type error messages
+  (Florian Angeletti)
+
 - GPR#1155: Fix a race condition with WAIT_NOHANG on Windows
   (Jérémie Dimino and David Allsopp)
 

--- a/testsuite/tests/typing-short-paths/pr7543.ml
+++ b/testsuite/tests/typing-short-paths/pr7543.ml
@@ -1,0 +1,9 @@
+(** Test that short-path printtyp does not fail on packed module.
+
+  Packed modules does not respect the arity of type constructor, which can break
+  the path normalization within the short-path code path.
+*)
+module type S = sig type t end;;
+module N = struct type 'a t = 'a end;;
+let f (module M:S with type t = unit) = ();;
+let () = f (module N);;

--- a/testsuite/tests/typing-short-paths/pr7543.ml.reference
+++ b/testsuite/tests/typing-short-paths/pr7543.ml.reference
@@ -1,0 +1,18 @@
+
+# * * * *   module type S = sig type t end
+# module N : sig type 'a t = 'a end
+# val f : (module S with type t = unit) -> unit = <fun>
+# Characters 19-20:
+  let () = f (module N);;
+                     ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a end
+       is not included in
+         sig type t = N.t end
+       Type declarations do not match:
+         type 'a t = 'a
+       is not included in
+         type t = N.t
+       They have different arities.
+# 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -238,10 +238,13 @@ let compose l1 = function
   | Nth n  -> Nth (List.nth l1 n)
 
 let apply_subst s1 tyl =
-  match s1 with
-    Nth n1 -> [List.nth tyl n1]
-  | Map l1 -> List.map (List.nth tyl) l1
-  | Id -> tyl
+  if tyl = [] then []
+  (* cf. PR#7543: Typemod.type_package doesn't respect type constructor arity *)
+  else
+    match s1 with
+      Nth n1 -> [List.nth tyl n1]
+    | Map l1 -> List.map (List.nth tyl) l1
+    | Id -> tyl
 
 type best_path = Paths of Path.t list | Best of Path.t
 
@@ -589,7 +592,7 @@ let rec tree_of_typexp sch ty =
     | Tconstr(p, tyl, _abbrev) ->
         let p', s = best_type_path p in
         let tyl' = apply_subst s tyl in
-        if is_nth s then tree_of_typexp sch (List.hd tyl') else
+        if is_nth s && not (tyl'=[]) then tree_of_typexp sch (List.hd tyl') else
         Otyp_constr (tree_of_path p', tree_of_typlist sch tyl')
     | Tvariant row ->
         let row = row_repr row in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1565,6 +1565,8 @@ let type_package env m p nl =
   let tl' =
     List.map
       (fun name -> Btype.newgenty (Tconstr (mkpath mp name,[],ref Mnil)))
+      (* beware of interactions with Printtyp and short-path:
+         mp.name may have an arity > 0, cf. PR#7534 *)
       nl in
   (* go back to original level *)
   Ctype.end_def ();


### PR DESCRIPTION
[MPR#7543](https://caml.inria.fr/mantis/view.php?id=7543):

`Typemod.type_package` does no respect the arity of type constructor when typing packed module. This broke some of the short-path related functions in the `Printtyp` module that assumed that all type constructors were applied to the right number of type arguments. As a consequence, the following code
failed with an internal compiler exception:

```
module type S = sig type t end;;
module N = struct type 'a t = 'a end;;
let f (module M:S with type t = unit) = ();;
let () = f (module N);;
```
More precisely, `Printtyp` failed when trying to replace ` 'a N.t` with `'a` within the following error
message (where `N.t` is not applied to any argument)
```
 Error: Signature mismatch:
       Modules do not match:
         sig type 'a t = 'a end
       is not included in
         sig type t = N.t end
       Type declarations do not match:
         type 'a t = 'a
       is not included in
         type t = N.t
       They have different arities.
```

This PR implements a minimal fix for this problem by adding additional tests in these short-paths functions to handle correctly the cases where no arguments are provided to a type constructor with an arity strictly superior to `0`.

Note that the whole code path could be made more robust to arity mismatches, but I thought that failing visibly was a superior long-term option.

Similarly, I think that this patch could be cherry-picked safely to 4.05 since it can only improve the robustness of `Printtyp` when `-short-paths` is used (by being equivalent to deactivating short-path locally).