### PR TITLE
Manual: minimal documentation for compiler plugins

### DIFF
--- a/Changes
+++ b/Changes
@@ -103,6 +103,9 @@ Working version
   specification "%g" with the ISO C90 description.
   (Florian Angeletti)
 
+- GPR#1187: Minimal documentation for compiler plugins
+  (Florian Angeletti)
+
 ### Tools:
 
 - GPR#1045: ocamldep, add a "-shared" option to generate dependencies

--- a/bytecomp/simplif.mli
+++ b/bytecomp/simplif.mli
@@ -13,6 +13,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Lambda simplification and lambda plugin hooks *)
+
 (* Elimination of useless Llet(Alias) bindings.
    Transformation of let-bound references into variables.
    Simplification over staticraise/staticcatch constructs.

--- a/driver/pparse.mli
+++ b/driver/pparse.mli
@@ -13,6 +13,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Driver for the parser, external preprocessors and ast plugin hooks *)
+
 open Format
 
 type error =

--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -18,6 +18,8 @@ OCAMLDOC=$(SRC)/byterun/ocamlrun $(SRC)/ocamldoc/ocamldoc -hide Pervasives
 MLIS=$(SRC)/stdlib/*.mli \
 	$(SRC)/utils/*.mli \
 	$(SRC)/parsing/*.mli \
+	$(SRC)/driver/pparse.mli \
+	$(SRC)/typing/typemod.mli \
 	$(SRC)/otherlibs/bigarray/bigarray.mli \
 	$(SRC)/otherlibs/dynlink/dynlink.mli \
 	$(SRC)/otherlibs/graph/graphics.mli \
@@ -63,6 +65,8 @@ html: files
 	-I $(SRC)/stdlib  \
 	-I $(SRC)/utils  \
 	-I $(SRC)/parsing \
+	-I $(SRC)/driver \
+	-I $(SRC)/typing \
 	-I $(SRC)/otherlibs/bigarray \
 	-I $(SRC)/otherlibs/dynlink \
 	-I $(SRC)/otherlibs/graph \

--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -20,6 +20,7 @@ MLIS=$(SRC)/stdlib/*.mli \
 	$(SRC)/parsing/*.mli \
 	$(SRC)/driver/pparse.mli \
 	$(SRC)/typing/typemod.mli \
+	$(SRC)/bytecomp/simplif.mli \
 	$(SRC)/otherlibs/bigarray/bigarray.mli \
 	$(SRC)/otherlibs/dynlink/dynlink.mli \
 	$(SRC)/otherlibs/graph/graphics.mli \
@@ -67,6 +68,7 @@ html: files
 	-I $(SRC)/parsing \
 	-I $(SRC)/driver \
 	-I $(SRC)/typing \
+	-I $(SRC)/bytecomp \
 	-I $(SRC)/otherlibs/bigarray \
 	-I $(SRC)/otherlibs/dynlink \
 	-I $(SRC)/otherlibs/graph \

--- a/manual/manual/allfiles.etex
+++ b/manual/manual/allfiles.etex
@@ -75,6 +75,7 @@ and as a
 \input{flambda.tex}
 \input{spacetime.tex}
 \input{afl-fuzz.tex}
+\input{plugins}
 
 \part{The OCaml library}
 \label{p:library}

--- a/manual/manual/cmds/Makefile
+++ b/manual/manual/cmds/Makefile
@@ -1,7 +1,7 @@
 FILES=comp.tex top.tex runtime.tex native.tex lexyacc.tex intf-c.tex \
   depend.tex profil.tex debugger.tex browser.tex ocamldoc.tex \
   warnings-help.tex ocamlbuild.tex flambda.tex spacetime.tex \
-  afl-fuzz.tex unified-options.tex
+  afl-fuzz.tex plugins.tex unified-options.tex
 
 TOPDIR=../../..
 include $(TOPDIR)/Makefile.tools

--- a/manual/manual/cmds/plugins.etex
+++ b/manual/manual/cmds/plugins.etex
@@ -1,4 +1,4 @@
-\chapter{Compiler plugins}
+\chapter{Compiler plugins\label{c:plugins}}
 \pdfchapterfold{-9}{Compiler plugind}
 %HEVEA\cutname{plugins.html}
 
@@ -12,12 +12,17 @@ is still in flux and breaking changes may happen in the future. Plugins features
 are based on the compiler library API. In complement, new hooks have been added to
 the compiler to increase its flexibility.
 
-In particular, hooks are available to transform the parsed abstract syntax tree,
-providing similar functionality to extension point based preprocessors.
-Other hooks are available to analyze the typed tree after the type-checking phase
-of the compiler. Since the typed tree relies on numerous invariants that play a
-vital part in ulterior phases of the compiler, it is not possible however to
-transform the typed tree.
+In particular, hooks are available in the
+\ifouthtml\ahref{libref/Pparse.html}{\texttt{Pparse} module}
+\else\texttt{Pparse} module (see section~\ref{Pparse})\fi
+to transform the parsed abstract syntax tree, providing similar functionality
+to extension point based preprocessors.
+Other hooks are available to analyze the typed tree in the
+\ifouthtml\ahref{libref/Typemod.html}{\texttt{Typemod} module}
+\else\texttt{Typemod} module (see section~\ref{Typemod})\fi
+after the type-checking phase of the compiler. Since the typed tree relies
+on numerous invariants that play a vital part in ulterior phases of the
+compiler, it is not possible however to transform the typed tree.
 
 Plugins are dynamically loaded and need to be compiled in the same mode (i.e.
 native or bytecode) that the tool they extend.

--- a/manual/manual/cmds/plugins.etex
+++ b/manual/manual/cmds/plugins.etex
@@ -27,6 +27,10 @@ Similarly, the intermediary lambda representation can be modified by using the
 hooks provided in the
 \ifouthtml\ahref{libref/Simplif.html}{\texttt{Simplif} module}
 \else\texttt{Simplif} module (see section~\ref{Simplif})\fi.
+A plugin can also add new options to a tool through the
+"Clflags.add_arguments" function (see
+\ifouthtml\ahref{libref/Clflags.html}{\texttt{Clflags} module}
+\else\texttt{Clflags} module (see section~\ref{Clflags})\fi).
 
 Plugins are dynamically loaded and need to be compiled in the same mode (i.e.
 native or bytecode) that the tool they extend.

--- a/manual/manual/cmds/plugins.etex
+++ b/manual/manual/cmds/plugins.etex
@@ -23,6 +23,10 @@ Other hooks are available to analyze the typed tree in the
 after the type-checking phase of the compiler. Since the typed tree relies
 on numerous invariants that play a vital part in ulterior phases of the
 compiler, it is not possible however to transform the typed tree.
+Similarly, the intermediary lambda representation can be modified by using the
+hooks provided in the
+\ifouthtml\ahref{libref/Simplif.html}{\texttt{Simplif} module}
+\else\texttt{Simplif} module (see section~\ref{Simplif})\fi.
 
 Plugins are dynamically loaded and need to be compiled in the same mode (i.e.
 native or bytecode) that the tool they extend.

--- a/manual/manual/cmds/plugins.etex
+++ b/manual/manual/cmds/plugins.etex
@@ -1,0 +1,75 @@
+\chapter{Compiler plugins}
+\pdfchapterfold{-9}{Compiler plugind}
+%HEVEA\cutname{plugins.html}
+
+\section{Overview}
+
+Starting from OCaml 4.03, it is possible to extend the native and bytecode compilers
+with plugins using the "-plugin" command line option of both tools.
+This possibility is also available for "ocamldep" for OCaml version ulterior to 4.05.
+Beware however that plugins are an advanced feature of which the design
+is still in flux and breaking changes may happen in the future. Plugins features
+are based on the compiler library API. In complement, new hooks have been added to
+the compiler to increase its flexibility.
+
+In particular, hooks are available to transform the parsed abstract syntax tree,
+providing similar functionality to extension point based preprocessors.
+Other hooks are available to analyze the typed tree after the type-checking phase
+of the compiler. Since the typed tree relies on numerous invariants that play a
+vital part in ulterior phases of the compiler, it is not possible however to
+transform the typed tree.
+
+Plugins are dynamically loaded and need to be compiled in the same mode (i.e.
+native or bytecode) that the tool they extend.
+
+\section{Basic example}
+
+As an illustration, we shall build a simple "Hello world" plugin that adds
+a simple statement "print_endline \"Hello from:$sourcefile\"" to a compiled file.
+
+The simplest way to implement this feature is to modify the abstract syntax
+tree. We will therefore add an hooks to the "Pparse.ImplementationHooks".
+Since the proposed modification is very basic, we could implement the hook
+directly. However, for the sake of this illustration, we use the "Ast_mapper"
+structure that provides a better path to build more interesting plugins.
+
+The first step is to build the AST fragment corresponding to the
+evaluation of "print_endline":
+\begin{verbatim}
+  let print_endline name =
+    let open Ast_helper in
+    let print_endline = Exp.ident
+    @@ Location.mknoloc @@Longident.Lident "print_endline" in
+    let hello = Exp.constant @@ Const.string @@ "Hello from: " ^ name in
+    Str.eval @@ Exp.apply print_endline [Asttypes.Nolabel, hello]
+\end{verbatim}%
+Then, we can construct an ast mapper that adds this fragment to the parsed
+ast tree.
+\begin{verbatim}
+let add_hello name (mapper:Ast_mapper.mapper) structure =
+  let default = Ast_mapper.default_mapper in
+  (print_ensline name) :: (default.structure default structure)
+
+let ast_mapper name =
+  { Ast_mapper.default_mapper with structure = add_hello name }
+\end{verbatim}%
+%
+Once this AST mapped constructed, we need to convert it to a hook and adds this
+hooks to the "Pparse.ImplementationsHooks".
+\begin{verbatim}
+let transform hook_info structure =
+        let astm = ast_mapper hook_info.Misc.sourcefile in
+        astm.structure astm structure
+
+let () = Pparse.ImplementationHooks.add_hook "Hello world hook" transform
+\end{verbatim}
+%
+The resulting simplistic plugin can then be compiled with
+\begin{verbatim}
+$ ocamlopt -I +compiler-libs -shared plugin.ml -o plugin.cmxs
+\end{verbatim}
+%
+Compiling other files with this plugin enabled is then as simple as
+\begin{verbatim}
+$ ocamlopt -plugin plugin.cmxs test.ml -o test
+\end{verbatim}

--- a/manual/manual/cmds/plugins.etex
+++ b/manual/manual/cmds/plugins.etex
@@ -48,14 +48,14 @@ ast tree.
 \begin{verbatim}
 let add_hello name (mapper:Ast_mapper.mapper) structure =
   let default = Ast_mapper.default_mapper in
-  (print_ensline name) :: (default.structure default structure)
+  (print_endline name) :: (default.structure default structure)
 
 let ast_mapper name =
   { Ast_mapper.default_mapper with structure = add_hello name }
 \end{verbatim}%
 %
-Once this AST mapped constructed, we need to convert it to a hook and adds this
-hooks to the "Pparse.ImplementationsHooks".
+Once this AST mapper is constructed, we need to convert it to a hook and adds this
+hook to the "Pparse.ImplementationsHooks".
 \begin{verbatim}
 let transform hook_info structure =
         let astm = ast_mapper hook_info.Misc.sourcefile in

--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -30,6 +30,7 @@ MLIS=$(CSLDIR)/stdlib/*.mli \
 	$(CSLDIR)/parsing/*.mli \
 	$(CSLDIR)/driver/pparse.mli \
 	$(CSLDIR)/typing/typemod.mli \
+	$(CSLDIR)/bytecomp/simplif.mli \
 	$(CSLDIR)/otherlibs/bigarray/bigarray.mli \
 	$(CSLDIR)/otherlibs/dynlink/dynlink.mli \
 	$(CSLDIR)/otherlibs/graph/graphics.mli \
@@ -67,6 +68,7 @@ $(INTF): $(MLIS)
 	-I $(CSLDIR)/parsing \
 	-I $(CSLDIR)/typing \
 	-I $(CSLDIR)/driver \
+	-I $(CSLDIR)/bytecomp \
 	-I $(CSLDIR)/otherlibs/bigarray \
 	-I $(CSLDIR)/otherlibs/dynlink \
 	-I $(CSLDIR)/otherlibs/graph \

--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -10,8 +10,11 @@ STDLIB_INTF=Arg.tex Array.tex ArrayLabels.tex Char.tex Complex.tex \
   Weak.tex Callback.tex Buffer.tex StdLabels.tex \
   Bytes.tex BytesLabels.tex Spacetime.tex
 
+COMPILER_LIBS_PLUGIN_HOOKS=Pparse.tex Typemod.tex
+
 COMPILER_LIBS_INTF=Asthelper.tex Astmapper.tex Asttypes.tex \
-	Lexer.tex Location.tex Longident.tex Parse.tex Pprintast.tex Printast.tex
+	Lexer.tex Location.tex Longident.tex Parse.tex Pprintast.tex Printast.tex \
+	$(COMPILER_LIBS_PLUGIN_HOOKS)
 
 OTHERLIB_INTF=Unix.tex UnixLabels.tex Str.tex \
   Num.tex Arithstatus.tex Bigint.tex \
@@ -25,6 +28,8 @@ INTF=$(CORE_INTF) $(STDLIB_INTF) $(COMPILER_LIBS_INTF) $(OTHERLIB_INTF)
 MLIS=$(CSLDIR)/stdlib/*.mli \
 	$(CSLDIR)/utils/*.mli \
 	$(CSLDIR)/parsing/*.mli \
+	$(CSLDIR)/driver/pparse.mli \
+	$(CSLDIR)/typing/typemod.mli \
 	$(CSLDIR)/otherlibs/bigarray/bigarray.mli \
 	$(CSLDIR)/otherlibs/dynlink/dynlink.mli \
 	$(CSLDIR)/otherlibs/graph/graphics.mli \
@@ -60,6 +65,8 @@ $(INTF): $(MLIS)
 	-I $(CSLDIR)/utils \
 	-I $(CSLDIR)/stdlib \
 	-I $(CSLDIR)/parsing \
+	-I $(CSLDIR)/typing \
+	-I $(CSLDIR)/driver \
 	-I $(CSLDIR)/otherlibs/bigarray \
 	-I $(CSLDIR)/otherlibs/dynlink \
 	-I $(CSLDIR)/otherlibs/graph \

--- a/manual/manual/library/compilerlibs.etex
+++ b/manual/manual/library/compilerlibs.etex
@@ -63,8 +63,10 @@ The following modules provides hooks for compiler plugins:
 \item \ahref{libref/Pparse.html}{Module \texttt{Pparse}: OCaml parser driver}
 \item \ahref{libref/Typemod.html}{Module \texttt{Typemod}:
 OCaml module type checking}
+\item \ahref{libref/Simplif.html}{Module \texttt{Simplif}: Lambda simplification}
 \end{links}
 \else
 \input{Pparse.tex}
 \input{Typemod.tex}
+\input{Simplif.tex}
 \fi

--- a/manual/manual/library/compilerlibs.etex
+++ b/manual/manual/library/compilerlibs.etex
@@ -5,7 +5,8 @@ This chapter describes the OCaml front-end, which declares the abstract
 syntax tree used by the compiler, provides a way to parse, print
 and pretty-print OCaml code, and ultimately allows to write abstract
 syntax tree preprocessors invoked via the {\tt -ppx} flag (see chapters~\ref{c:camlc}
-and~\ref{c:nativecomp}).
+and~\ref{c:nativecomp}) and plugins invoked via the {\tt -plugin} flag
+(see chapter~\ref{c:plugins}).
 
 It is important to note that the exported front-end interface follows the evolution of the OCaml language and implementation, and thus does not provide {\bf any} backwards compatibility guarantees.
 
@@ -56,3 +57,14 @@ type\\*"#load \"compiler-libs/ocamlcommon.cma\";;".
 % \input{Printast.tex}
 \fi
 
+\ifouthtml
+The following modules provides hooks for compiler plugins:
+\begin{links}
+\item \ahref{libref/Pparse.html}{Module \texttt{Pparse}: OCaml parser driver}
+\item \ahref{libref/Typemod.html}{Module \texttt{Typemod}:
+OCaml module type checking}
+\end{links}
+\else
+\input{Pparse.tex}
+\input{Typemod.tex}
+\fi

--- a/manual/manual/library/compilerlibs.etex
+++ b/manual/manual/library/compilerlibs.etex
@@ -64,9 +64,11 @@ The following modules provides hooks for compiler plugins:
 \item \ahref{libref/Typemod.html}{Module \texttt{Typemod}:
 OCaml module type checking}
 \item \ahref{libref/Simplif.html}{Module \texttt{Simplif}: Lambda simplification}
+\item \ahref{libref/Clflags.html}{Module \texttt{Clflags}: command line flags}
 \end{links}
 \else
 \input{Pparse.tex}
 \input{Typemod.tex}
 \input{Simplif.tex}
+\input{Clflags.tex}
 \fi

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Type-checking of the module language *)
+(** Type-checking of the module language and typed ast plugin hooks *)
 
 open Types
 open Format

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -13,6 +13,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Command line flags *)
+
 (** Optimization parameters represented as ints indexed by round number. *)
 module Int_arg_helper : sig
   type parsed

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -298,9 +298,9 @@ val delete_eol_spaces : string -> string
 
 
 
-(** {2 Hook machinery} *)
+(** {2 Hook machinery}
 
-(* Hooks machinery:
+    Hooks machinery:
    [add_hook name f] will register a function that will be called on the
     argument of a later call to [apply_hooks]. Hooks are applied in the
     lexicographical order of their names.


### PR DESCRIPTION
This PR adds a new chapter to the tool part of the manual in order to provide some minimal documentation on the new plugins infrastrucutre (beyond the laconic mention in the man pages).

Currently, the proposed documentation only contains a brief description of the available hooks in the compiler and a basic "hello world" plugin. This is still a very basic starting point, so I am open to any improvement propositions. 