### PR TITLE
Allow -l option to ocamlmklib on MSVC ports

### DIFF
--- a/Changes
+++ b/Changes
@@ -147,6 +147,9 @@ Working version
   a trailing "Error: Some fatal warnings were triggered" message.
   (Valentin Gatien-Baron, review by Alain Frisch)
 
+* GPR#1189: allow MSVC ports to use -l option in ocamlmklib
+  (David Allsopp)
+
 ### Manual and documentation:
 
 - MPR#6548: remove obsolete limitation in the description of private

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -101,6 +101,12 @@ let parse_arguments argv =
     else if s = "-linkall" then
       caml_opts := s :: !caml_opts
     else if starts_with s "-l" then
+      let s =
+        if Config.ccomp_type = "msvc" then
+          String.sub s 2 (String.length s - 2) ^ ".lib"
+        else
+          s
+      in
       c_libs := s :: !c_libs
     else if starts_with s "-L" then
      (c_Lopts := s :: !c_Lopts;


### PR DESCRIPTION
In general (especially for the Windows API), `-lfoo` cannot be used to link libraries because the various drivers assume that libfoo.lib is meant. This patch allows ocamlmklib to mask this difference so that
`-luser32` will refer to `libuser32.a` as normal on MinGW but `user32.lib` on MSVC.

The motivation for this is that ocamlmklib treats `-l` options differently from a manually specified library. So if you have a library requiring you to link against `gdi32.lib` and `user32.lib`, then you get various linker warnings when producing the static stubs library:
```
user32.lib(USER32.dll) : warning LNK4006: __NULL_IMPORT_DESCRIPTOR already defined in gdi32.lib(GDI32.dll); second definition ignored
user32.lib(USER32.dll) : warning LNK4221: no public symbols found; archive member will be inaccessible
```
Though innocuous, these warnings are irritating and arise simply because a .lib file should not be linked with those libraries.