### PR TITLE
Prevent repeated warnings with recursive modules

### DIFF
--- a/Changes
+++ b/Changes
@@ -426,6 +426,9 @@ Working version
 - MPR#7543: short-paths printtyp can fail on packed type error messages
   (Florian Angeletti)
 
+- MPR#7553, GPR#1191: Prevent repeated warnings with recursive modules.
+  (Leo White, review by Josh Berdine and Alain Frisch)
+
 - MPR#7563, GPR#1210: code generation bug when a module alias and
   an extension constructor have the same name in the same module
   (Gabriel Scherer, report by Manuel Fähndrich,

--- a/testsuite/tests/typing-warnings/pr7553.ml
+++ b/testsuite/tests/typing-warnings/pr7553.ml
@@ -1,0 +1,20 @@
+module A = struct type foo end;;
+
+module rec B : sig
+  open A
+  type bar = Bar of foo
+end = B;;
+
+module rec C : sig
+  open A
+end = C;;
+
+module rec D : sig
+  module M : module type of struct
+    module X : sig end = struct
+      open A
+      let None = None
+    end
+  end
+end = D;;
+

--- a/testsuite/tests/typing-warnings/pr7553.ml.reference
+++ b/testsuite/tests/typing-warnings/pr7553.ml.reference
@@ -1,0 +1,20 @@
+
+# module A : sig type foo end
+#         module rec B : sig type bar = Bar of A.foo end
+#       Characters 22-28:
+    open A
+    ^^^^^^
+Warning 33: unused open A.
+module rec C : sig  end
+#                 Characters 110-114:
+        let None = None
+            ^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Some _
+Characters 93-99:
+        open A
+        ^^^^^^
+Warning 33: unused open A.
+module rec D : sig module M : sig module X : sig  end end end
+#   

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -427,6 +427,10 @@ and approx_modtype_info env sinfo =
    mtd_loc = sinfo.pmtd_loc;
   }
 
+let approx_modtype env smty =
+  Warnings.without_warnings
+    (fun () -> approx_modtype env smty)
+
 (* Additional validity checks on type definitions arising from
    recursive modules *)
 
@@ -818,7 +822,10 @@ and transl_recmodule_modtypes env sdecls =
       ids sdecls
   in
   let env0 = make_env init in
-  let dcl1 = transition env0 init in
+  let dcl1 =
+    Warnings.without_warnings
+      (fun () -> transition env0 init)
+  in
   let env1 = make_env2 dcl1 in
   check_recmod_typedecls env1 sdecls dcl1;
   let dcl2 = transition env1 dcl1 in

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -212,12 +212,17 @@ let current =
       error = Array.make (last_warning_number + 1) false;
     }
 
+let disabled = ref false
+
+let without_warnings f =
+  Misc.protect_refs [Misc.R(disabled, true)] f
+
 let backup () = !current
 
 let restore x = current := x
 
-let is_active x = (!current).active.(number x);;
-let is_error x = (!current).error.(number x);;
+let is_active x = not !disabled && (!current).active.(number x);;
+let is_error x = not !disabled && (!current).error.(number x);;
 
 let parse_opt error active flags s =
   let set i = flags.(i) <- true in

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -86,6 +86,8 @@ type t =
 
 val parse_options : bool -> string -> unit;;
 
+val without_warnings : (unit -> 'a) -> 'a
+
 val is_active : t -> bool;;
 val is_error : t -> bool;;
 


### PR DESCRIPTION
This fixes [PR#7553](https://caml.inria.fr/mantis/view.php?id=7553) and similar issues with recursive modules where warnings are reported multiple times.