### PR TITLE
MPR#7551: manual, make final ";;" potentially optional in caml_example

### DIFF
--- a/Changes
+++ b/Changes
@@ -117,6 +117,10 @@ Working version
   specification "%g" with the ISO C90 description.
   (Florian Angeletti)
 
+- PR#7551, GPR#1194 : make the final ";;" potentially optional in
+  caml_example
+  (Florian Angeletti, suggested by Gabriel Scherer)
+
 - GPR#1187: Minimal documentation for compiler plugins
   (Florian Angeletti)
 

--- a/Changes
+++ b/Changes
@@ -119,7 +119,7 @@ Working version
 
 - PR#7551, GPR#1194 : make the final ";;" potentially optional in
   caml_example
-  (Florian Angeletti, suggested by Gabriel Scherer)
+  (Florian Angeletti, review and suggestion by Gabriel Scherer)
 
 - GPR#1187: Minimal documentation for compiler plugins
   (Florian Angeletti)

--- a/manual/README.md
+++ b/manual/README.md
@@ -164,14 +164,25 @@ and can be used to evaluate OCaml expressions in the toplevel without
 printing anything:
 ```latex
 \begin{caml_eval}
-let pi = 4. *. atan 1.
+let pi = 4. *. atan 1.;;
 \end{caml_eval}
 \begin{caml_example}
-let f x = x +. pi
+let f x = x +. pi;;
 \end{caml_example}
 ```
 Beware that the detection code for these pseudo-environments is quite brittle
 and the environments must start and end at the beginning of the line.
+
+Note that in the tutorial part of manual, the final `;;` is mandatory
+An error will be raised when this final `;;` is missing.
+Such final `;;` is not required in the language extension chapter.
+
+This behavior can be overrided locally by adding an optional
+argument to the environment *before* the expected status argument:
+
+- `[toplevel]` makes the `;;` mandatory
+- `[verbatim]` makes it optional
+
 
 ###Quoting
 The tool `tools/texquote2` provides support for verbatim-like quotes using

--- a/manual/README.md
+++ b/manual/README.md
@@ -125,23 +125,33 @@ The pseudo-environment `caml_example` evaluates its contents using an ocaml
 interpreter and then translates both the input code and the interpreter output
 to latex code, e.g.
 ```latex
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let f x = x;;
 \end{caml_example}
 ```
 Note that the toplevel output can be suppressed by using a `*` suffix:
 ```latex
-\begin{caml_example*}
-let f x = x;;
+\begin{caml_example*}{verbatim}
+let f x = x
 \end{caml_example*}
 ```
+
+The `{verbatim}` or `{toplevel}` argument of the environment corresponds
+to the the mode of the example, two modes are available `toplevel` and
+`verbatim`.
+The `toplevel` mode mimics the appearance and behavior of the toplevel.
+In particular, toplevel examples must end with a double semi-colon `;;`,
+otherwise an error would be raised.
+The `verbatim` does not require a final `;;` and is intended to be
+a lighter mode for code examples.
+
 By default, `caml_tex2` raises an error and stops if the output of one
 the `caml_example` environment contains an unexpected error or warning.
 If such an error or warning is, in fact, expected, it is necessary to
 indicate the expected output status to `caml_tex2` by adding either
 an option to the `caml_example` environment:
 ```latex
-\begin{caml_example}[error]
+\begin{caml_example}{toplevel}[error]
 1 + 2. ;;
 \end{caml_example}
  or for warning
@@ -152,7 +162,7 @@ let f None = None;;
 or an annotation to the concerned phrase:
 
 ```latex
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 1 + 2. [@@expect error] ;;
 let f None = None [@@expect warning 8];;
 3 + 4 [@@expect ok];;
@@ -166,23 +176,12 @@ printing anything:
 \begin{caml_eval}
 let pi = 4. *. atan 1.;;
 \end{caml_eval}
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let f x = x +. pi;;
 \end{caml_example}
 ```
 Beware that the detection code for these pseudo-environments is quite brittle
 and the environments must start and end at the beginning of the line.
-
-Note that in the tutorial part of manual, the final `;;` is mandatory
-An error will be raised when this final `;;` is missing.
-Such final `;;` is not required in the language extension chapter.
-
-This behavior can be overrided locally by adding an optional
-argument to the environment *before* the expected status argument:
-
-- `[toplevel]` makes the `;;` mandatory
-- `[verbatim]` makes it optional
-
 
 ###Quoting
 The tool `tools/texquote2` provides support for verbatim-like quotes using

--- a/manual/manual/refman/Makefile
+++ b/manual/manual/refman/Makefile
@@ -6,7 +6,8 @@ TOPDIR=../../..
 
 include $(TOPDIR)/Makefile.tools
 
-CAMLLATEX= $(OCAMLRUN) ../../tools/caml-tex2
+CAMLLATEX= $(OCAMLRUN) ../../tools/caml-tex2 -caml "TERM=norepeat $(OCAML)" \
+-n 80 -v false -implicit-stop
 TRANSF=../../tools/transf
 TEXQUOTE=../../tools/texquote2
 
@@ -22,8 +23,7 @@ clean:
 .SUFFIXES: .etex .tex
 
 exten.tex:exten.etex
-	@$(CAMLLATEX) -caml "TERM=norepeat $(OCAML)" -n 80 -v false \
-                       -o $*.caml_tex_error.tex $*.etex \
+	@$(CAMLLATEX) -o $*.caml_tex_error.tex $*.etex \
 	&& mv $*.caml_tex_error.tex $*.gen.tex \
 	&& $(OCAMLRUN) $(TRANSF) < $*.gen.tex > $*.transf_error.tex \
 	&& mv $*.transf_error.tex $*.gen.tex\

--- a/manual/manual/refman/Makefile
+++ b/manual/manual/refman/Makefile
@@ -7,7 +7,7 @@ TOPDIR=../../..
 include $(TOPDIR)/Makefile.tools
 
 CAMLLATEX= $(OCAMLRUN) ../../tools/caml-tex2 -caml "TERM=norepeat $(OCAML)" \
--n 80 -v false -implicit-stop
+-n 80 -v false
 TRANSF=../../tools/transf
 TEXQUOTE=../../tools/texquote2
 

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -458,8 +458,8 @@ actually be unified with "int".
 
 The other application is to ensure that some definition is sufficiently
 polymorphic:
-\begin{caml_example}[error]
-let id: 'a. 'a -> 'a = fun x -> x + 1;;
+\begin{caml_example}{verbatim}[error]
+let id: 'a. 'a -> 'a = fun x -> x + 1
 \end{caml_example}
 
 \section{Locally abstract types}
@@ -863,7 +863,7 @@ parameters.
 
 A natural application of destructive substitution is merging two
 signatures sharing a type name.
-\begin{caml_example*}
+\begin{caml_example*}{verbatim}
         module type Printable = sig
           type t
           val print : Format.formatter -> t -> unit
@@ -875,26 +875,26 @@ signatures sharing a type name.
         module type PrintableComparable = sig
           include Printable
           include Comparable with type t := t
-        end;;
+        end
 \end{caml_example*}
 
 One can also use this to completely remove a field:
-\begin{caml_example}
-module type S = Comparable with type t := int;;
+\begin{caml_example}{verbatim}
+module type S = Comparable with type t := int
 \end{caml_example}
 or to rename one:
-\begin{caml_example}
+\begin{caml_example}{verbatim}
 module type S = sig
   type u
   include Comparable with type t := u
-end;;
+end
 \end{caml_example}
 
 Note that you can also remove manifest types, by substituting with the
 same type.
-\begin{caml_example}
+\begin{caml_example}{verbatim}
 module type ComparableInt = Comparable with type t = int ;;
-module type CompareInt = ComparableInt with type t := int ;;
+module type CompareInt = ComparableInt with type t := int
 \end{caml_example}
 
 \section{Type-level module aliases}
@@ -929,8 +929,8 @@ satisfying the above constraints,
 \begin{caml_eval}
 module P = struct end
 \end{caml_eval}
-\begin{caml_example*}
-module N = P;;
+\begin{caml_example*}{verbatim}
+module N = P
 \end{caml_example*}
 has type
 \caml
@@ -1287,27 +1287,26 @@ compiler generates these names according to the following nomenclature:
 \item First, types whose name starts with a "$" are existentials.
 \item "$Constr_'a" denotes an existential type introduced for the type
 variable "'a" of the GADT constructor "Constr":
-\begin{caml_example}[error]
+\begin{caml_example}{verbatim}[error]
 type any = Any : 'name -> any
-let escape (Any x) = x;;
+let escape (Any x) = x
 \end{caml_example}
 \item "$Constr" denotes an existential type introduced for an anonymous %$
 type variable in the GADT constructor "Constr":
-\begin{caml_example}[error]
+\begin{caml_example}{verbatim}[error]
 type any = Any : _ -> any
-let escape (Any x) = x;;
+let escape (Any x) = x
 \end{caml_example}
 \item "$'a" if the existential variable was unified with the type %$
 variable "'a" during typing:
-\begin{caml_example}[error]
+\begin{caml_example}{verbatim}[error]
 type ('arg,'result,'aux) fn =
   | Fun: ('a ->'b) -> ('a,'b,unit) fn
   | Mem1: ('a ->'b) * 'a * 'b -> ('a, 'b, 'a * 'b) fn
-
  let apply: ('arg,'result, _ ) fn -> 'arg -> 'result = fun f x ->
   match f with
   | Fun f -> f x
-  | Mem1 (f,y,fy) -> if x = y then fy else f x;;
+  | Mem1 (f,y,fy) -> if x = y then fy else f x
 \end{caml_example}
 \item "$n" (n a number) is an internally generated existential %$
 which could not be named using one of the previous schemes.
@@ -1808,13 +1807,13 @@ Some extension nodes are understood by the compiler itself:
     constructor slot.
 \end{itemize}
 
-\begin{caml_example*}
+\begin{caml_example*}{verbatim}
 type t = ..
 type t += X of int | Y of string
 let x = [%extension_constructor X]
-let y = [%extension_constructor Y];;
+let y = [%extension_constructor Y]
 \end{caml_example*}
-\begin{caml_example}
+\begin{caml_example}{toplevel}
  x <> y;;
 \end{caml_example}
 

--- a/manual/manual/tutorials/advexamples.etex
+++ b/manual/manual/tutorials/advexamples.etex
@@ -52,7 +52,7 @@ module Euro : MONEY =
       end
   end;;
 \end{caml_eval}
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let euro = new Euro.c;;
 let zero = euro 0.;;
 let neg x = x#times (-1.);;
@@ -67,7 +67,7 @@ class account =
 let c = new account in c # deposit (euro 100.); c # withdraw (euro 50.);;
 \end{caml_example}
 We now refine this definition with a method to compute interest.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class account_with_interests =
   object (self)
     inherit account
@@ -81,7 +81,7 @@ that will manage monthly or yearly updates of the account.
 We should soon fix a bug in the current definition: the deposit method can
 be used for withdrawing money by depositing negative amounts. We can
 fix this directly:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class safe_account =
   object
     inherit account
@@ -89,7 +89,7 @@ class safe_account =
   end;;
 \end{caml_example}
 However, the bug might be fixed more safely by  the following definition:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class safe_account =
   object
     inherit account as unsafe
@@ -104,7 +104,7 @@ the method "deposit".
 To keep track of operations, we extend the class with a mutable field
 "history" and a private method "trace" to add an operation in the
 log. Then each method to be traced is redefined.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type 'a operation = Deposit of 'a | Retrieval of 'a;;
 class account_with_history =
   object (self)
@@ -120,7 +120,7 @@ class account_with_history =
 One may wish to open an account and simultaneously deposit some initial
 amount. Although the initial implementation did not address this
 requirement, it can be achieved by using an initializer.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class account_with_deposit x =
   object
     inherit account_with_history
@@ -128,7 +128,7 @@ class account_with_deposit x =
   end;;
 \end{caml_example}
 A better alternative is:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class account_with_deposit x =
   object (self)
     inherit account_with_history
@@ -138,20 +138,20 @@ class account_with_deposit x =
 Indeed, the latter is safer since the call to "deposit" will automatically
 benefit from safety checks and from the trace.
 Let's test it:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let ccp = new account_with_deposit (euro 100.) in
 let _balance = ccp#withdraw (euro 50.) in
 ccp#history;;
 \end{caml_example}
 Closing an account can be done with the following polymorphic function:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let close c = c#withdraw c#balance;;
 \end{caml_example}
 Of course, this applies to all sorts of accounts.
 
 Finally, we gather several versions of the account into a module "Account"
 abstracted over some currency.
-\begin{caml_example*}
+\begin{caml_example*}{toplevel}
 let today () = (01,01,2000) (* an approximation *)
 module Account (M:MONEY) =
   struct
@@ -215,7 +215,7 @@ the same code can be used to provide accounts in different currencies.
 The class "bank" is the {\em real} implementation of the bank account (it
 could have been inlined). This is the one that will be used for further
 extensions, refinements, etc.  Conversely, the client will only be given the client view.
-\begin{caml_example*}
+\begin{caml_example*}{toplevel}
 module Euro_account = Account(Euro);;
 module Client = Euro_account.Client (Euro_account);;
 new Client.account (new Euro.c 100.);;
@@ -236,7 +236,7 @@ It is important to provide the client's view as a functor
 specialization of the "bank".
 The functor "Client" may remain unchanged and be passed
 the new definition to initialize a client's view of the extended account.
-\begin{caml_example*}
+\begin{caml_example*}{toplevel}
 module Investment_account (M : MONEY) =
   struct
     type m = M.c
@@ -261,7 +261,7 @@ new Client.account (new Euro.c 100.);;
 \end{caml_eval}
 The functor "Client" may also be redefined when some new features of the
 account can be given to the client.
-\begin{caml_example*}
+\begin{caml_example*}{toplevel}
 module Internet_account (M : MONEY) =
   struct
     type m = M.c
@@ -313,7 +313,7 @@ We show here how to do it for strings.
 \label{module:string}
 
 A naive definition of strings as objects could be:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ostring s =
   object
      method get n = String.get s n
@@ -325,7 +325,7 @@ However, the method "escaped" returns an object of the class "ostring",
 and not an object of the current class. Hence, if the class is further
 extended, the method "escaped" will only return an object of the parent
 class.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class sub_string s =
   object
      inherit ostring s
@@ -335,7 +335,7 @@ class sub_string s =
 As seen in section \ref{ss:binary-methods}, the solution is to use
 functional update instead. We need to create an instance variable
 containing the representation "s" of the string.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class better_string s =
   object
      val repr = s
@@ -353,7 +353,7 @@ In order to concatenate a string with another string of the same class,
 one must be able to access the instance variable externally. Thus, a method
 "repr" returning s must be defined. Here is the correct definition of
 strings:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ostring s =
   object (self : 'mytype)
      val repr = s
@@ -367,7 +367,7 @@ class ostring s =
 \end{caml_example}
 Another constructor of the class string can be defined to return a new
 string of a given length:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class cstring n = ostring (String.make n ' ');;
 \end{caml_example}
 Here, exposing the representation of strings is probably harmless.  We do
@@ -381,7 +381,7 @@ There is sometimes an alternative between using modules or classes for
 parametric data types.
 Indeed, there are situations when the two approaches are quite similar.
 For instance, a stack can be  straightforwardly implemented as a class:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 exception Empty;;
 class ['a] stack =
   object
@@ -400,7 +400,7 @@ argument that will be passed to the method "fold".
 %The intuition is that method "fold" should be polymorphic, i.e. of type
 %"All ('a) ('b -> 'a -> 'b) -> 'b -> 'b".
 A naive approach is to make "'b" an extra parameter of class "stack":
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ['a, 'b] stack2 =
   object
     inherit ['a] stack
@@ -409,7 +409,7 @@ class ['a, 'b] stack2 =
 \end{caml_example}
 However, the method "fold" of a given object can only be
 applied to functions that all have the same type:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let s = new stack2;;
 s#fold ( + ) 0;;
 s;;
@@ -421,7 +421,7 @@ universally quantified, giving "fold" the polymorphic type
 "Forall 'b. ('b -> 'a -> 'b) -> 'b -> 'b".
 An explicit type declaration on the method "fold" is required, since
 the type checker cannot infer the polymorphic type by itself.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ['a] stack3 =
   object
     inherit ['a] stack
@@ -440,7 +440,7 @@ class ['a] stack3 =
 
 A simplified version of object-oriented hash tables should have the
 following class type.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class type ['a, 'b] hash_table =
   object
     method find : 'a -> 'b
@@ -449,7 +449,7 @@ class type ['a, 'b] hash_table =
 \end{caml_example}
 A simple implementation, which is quite reasonable for small hash tables is
 to use an association list:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ['a, 'b] small_hashtbl : ['a, 'b] hash_table =
   object
     val mutable table = []
@@ -459,7 +459,7 @@ class ['a, 'b] small_hashtbl : ['a, 'b] hash_table =
 \end{caml_example}
 A better implementation, and one that scales up better, is to use a
 true hash table\ldots\ whose elements are small hash tables!
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ['a, 'b] hashtbl size : ['a, 'b] hash_table =
   object (self)
     val table = Array.init size (fun i -> new small_hashtbl)
@@ -492,7 +492,7 @@ parametric in the type of elements, the method "tag" has a parametric type
 the module definition but abstract in its signature.
 From outside, it will then be guaranteed that two objects with a method "tag"
 of the same type will share the same representation.
-\begin{caml_example*}
+\begin{caml_example*}{toplevel}
 module type SET =
   sig
     type 'a tag
@@ -544,7 +544,7 @@ classes that recursively interact with one another.
 
 The class "observer"  has a distinguished method "notify" that requires
 two arguments, a subject and an event to execute an action.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class virtual ['subject, 'event] observer =
   object
     method virtual notify : 'subject ->  'event -> unit
@@ -553,7 +553,7 @@ class virtual ['subject, 'event] observer =
 The class "subject" remembers a list of observers in an instance variable,
 and has a distinguished method "notify_observers" to broadcast the message
 "notify" to all observers with a particular event "e".
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ['observer, 'event] subject =
   object (self)
     val mutable observers = ([]:'observer list)
@@ -565,7 +565,7 @@ class ['observer, 'event] subject =
 The difficulty usually lies  in defining instances of the pattern above
 by inheritance. This can be done in a natural and obvious manner in
 OCaml, as shown on the following example manipulating windows.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type event = Raise | Resize | Move;;
 let string_of_event = function
     Raise -> "Raise" | Resize -> "Resize" | Move -> "Move";;
@@ -586,12 +586,12 @@ class ['subject] window_observer =
   end;;
 \end{caml_example}
 As can be expected, the type of "window" is recursive.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let window = new window_subject;;
 \end{caml_example}
 However, the two classes of "window_subject" and "window_observer" are not
 mutually recursive.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let window_observer = new window_observer;;
 window#add_observer window_observer;;
 window#move 1;;
@@ -600,7 +600,7 @@ window#move 1;;
 Classes "window_observer" and "window_subject" can still be extended by
 inheritance. For instance, one may enrich the "subject" with new
 behaviors and refine the behavior of the observer.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ['observer] richer_window_subject =
   object (self)
     inherit ['observer] window_subject
@@ -617,7 +617,7 @@ class ['subject] richer_window_observer =
   end;;
 \end{caml_example}
 We can also create a different kind of observer:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ['subject] trace_observer =
   object
     inherit ['subject, event] observer
@@ -627,7 +627,7 @@ class ['subject] trace_observer =
   end;;
 \end{caml_example}
 and attach several observers to the same object:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let window = new richer_window_subject;;
 window#add_observer (new richer_window_observer);;
 window#add_observer (new trace_observer);;

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -27,7 +27,7 @@ by ";;" in response to the "#" prompt, and the system compiles them
 on the fly, executes them, and prints the outcome of evaluation.
 Phrases are either simple expressions, or "let" definitions of
 identifiers (either values or functions).
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 1+2*3;;
 let pi = 4.0 *. atan 1.0;;
 let square x = x *. x;;
@@ -39,12 +39,12 @@ the system infers their types from their usage in the
 function. Notice also that integers and floating-point numbers are
 distinct types, with distinct operators: "+" and "*" operate on
 integers, but "+." and "*."  operate on floats.
-\begin{caml_example}[error]
+\begin{caml_example}{toplevel}[error]
 1.0 * 2;;
 \end{caml_example}
 
 Recursive functions are defined with the "let rec" binding:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let rec fib n =
   if n < 2 then n else fib (n-1) + fib (n-2);;
 fib 10;;
@@ -55,7 +55,7 @@ fib 10;;
 
 In addition to integers and floating-point numbers, OCaml offers the
 usual basic data types: booleans, characters, and immutable character strings.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 (1 < 2) = false;;
 'a';;
 "Hello world";;
@@ -68,7 +68,7 @@ Lists are either given in extension as a bracketed list of
 semicolon-separated elements, or built from the empty list "[]"
 (pronounce ``nil'') by adding elements in front using the "::"
 (``cons'') operator.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let l = ["is"; "a"; "tale"; "told"; "etc."];;
 "Life" :: l;;
 \end{caml_example}
@@ -82,7 +82,7 @@ As with most OCaml data structures, inspecting and destructuring lists
 is performed by pattern-matching. List patterns have the exact same
 shape as list expressions, with identifier representing unspecified
 parts of the list. As an example, here is insertion sort on a list:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let rec sort lst =
   match lst with
     [] -> []
@@ -102,7 +102,7 @@ given type. The reason why "sort" can apply to lists of any type is
 that the comparisons ("=", "<=", etc.) are {\em polymorphic} in OCaml:
 they operate between any two values of the same type. This makes
 "sort" itself polymorphic over all list types.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 sort [6;2;5;3];;
 sort [3.14; 2.718];;
 \end{caml_example}
@@ -123,13 +123,13 @@ sense are supported and can be passed around freely just as any other
 piece of data. For instance, here is a "deriv" function that takes any
 float function as argument and returns an approximation of its
 derivative function:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let deriv f dx = function x -> (f (x +. dx) -. f x) /. dx;;
 let sin' = deriv sin 1e-6;;
 sin' pi;;
 \end{caml_example}
 Even function composition is definable:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let compose f g = function x -> f (g x);;
 let cos2 = compose square cos;;
 \end{caml_example}
@@ -140,13 +140,13 @@ especially useful to provide iterators or similar generic operations
 over a data structure. For instance, the standard OCaml library
 provides a "List.map" functional that applies a given function to each
 element of a list, and returns the list of the results:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 List.map (function n -> n * 2 + 1) [0;1;2;3;4];;
 \end{caml_example}
 This functional, along with a number of other list and array
 functionals, is predefined because it is often useful, but there is
 nothing magic with it: it can easily be defined as follows.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let rec map f l =
   match l with
     [] -> []
@@ -160,7 +160,7 @@ let rec map f l =
 User-defined data structures include records and variants. Both are
 defined with the "type" declaration. Here, we declare a record type to
 represent rational numbers.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type ratio = {num: int; denom: int};;
 let add_ratio r1 r2 =
   {num = r1.num * r2.denom + r2.num * r1.denom;
@@ -168,36 +168,36 @@ let add_ratio r1 r2 =
 add_ratio {num=1; denom=3} {num=2; denom=5};;
 \end{caml_example}
 Record fields can also be accessed through pattern-matching:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let integer_part r =
   match r with
     {num=num; denom=denom} -> num / denom;;
 \end{caml_example}
 Since there is only one case in this pattern matching, it
 is safe to expand directly the argument "r" in a record pattern:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let integer_part {num=num; denom=denom} = num / denom;;
 \end{caml_example}
 Unneeded fields can be omitted:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let get_denom {denom=denom} = denom;;
 \end{caml_example}
 Optionally, missing fields can be made explicit by ending the list of
 fields with a trailing wildcard "_"::
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let get_num {num=num; _ } = num;;
 \end{caml_example}
 When both sides of the "=" sign are the same, it is possible to avoid
 repeating the field name by eliding the "=field" part:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let integer_part {num; denom} = num / denom;;
 \end{caml_example}
 This short notation for fields also works when constructing records:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let ratio num denom = {num; denom};;
 \end{caml_example}
 At last, it is possible to update few fields of a record at once:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
   let integer_product integer ratio = { ratio with num = integer * ratio.num };;
 \end{caml_example}
 With this functional update notation, the record on the left-hand side
@@ -211,7 +211,7 @@ inspecting them by pattern-matching. Constructor names are capitalized
 to distinguish them from variable names (which must start with a
 lowercase letter). For instance, here is a variant
 type for doing mixed arithmetic (integers and floats):
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type number = Int of int | Float of float | Error;;
 \end{caml_example}
 This declaration expresses that a value of type "number" is either an
@@ -220,14 +220,14 @@ the result of an invalid operation (e.g. a division by zero).
 
 Enumerated types are a special case of variant types, where all
 alternatives are constants:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type sign = Positive | Negative;;
 let sign_int n = if n >= 0 then Positive else Negative;;
 \end{caml_example}
 
 To define arithmetic operations for the "number" type, we use
 pattern-matching on the two numbers involved:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let add_num n1 n2 =
   match (n1, n2) with
     (Int i1, Int i2) ->
@@ -246,18 +246,18 @@ add_num (Int 123) (Float 3.14159);;
 Another interesting example of variant type is the built-in
 "'a option" type which represents either a value of type "'a" or an
 absence of value:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type 'a option = Some of 'a | None;;
 \end{caml_example}
 This type is particularly useful when defining function that can
 fail in common situations, for instance
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let safe_square_root x = if x > 0. then Some(sqrt x) else None;;
 \end{caml_example}
 
 The most common usage of variant types is to describe recursive data
 structures. Consider for example the type of binary trees:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type 'a btree = Empty | Node of 'a * 'a btree * 'a btree;;
 \end{caml_example}
 This definition reads as follows: a binary tree containing values of
@@ -269,7 +269,7 @@ Operations on binary trees are naturally expressed as recursive functions
 following the same structure as the type definition itself. For
 instance, here are functions performing lookup and insertion in
 ordered binary trees (elements increase from left to right):
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let rec member x btree =
   match btree with
     Empty -> false
@@ -294,7 +294,7 @@ as arrays. Arrays are either given in extension between "[|" and "|]"
 brackets, or allocated and initialized with the "Array.make"
 function, then filled up later by assignments. For instance, the
 function below sums two vectors (represented as float arrays) componentwise.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let add_vect v1 v2 =
   let len = min (Array.length v1) (Array.length v2) in
   let res = Array.make len 0.0 in
@@ -307,7 +307,7 @@ add_vect [| 1.0; 2.0 |] [| 3.0; 4.0 |];;
 
 Record fields can also be modified by assignment, provided they are
 declared "mutable" in the definition of the record type:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type mutable_point = { mutable x: float; mutable y: float };;
 let translate p dx dy =
   p.x <- p.x +. dx; p.y <- p.y +. dy;;
@@ -324,7 +324,7 @@ indirection cells (or one-element arrays), with operators "!" to fetch
 the current contents of the reference and ":=" to assign the contents.
 Variables can then be emulated by "let"-binding a reference. For
 instance, here is an in-place insertion sort over arrays:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let insertion_sort a =
   for i = 1 to Array.length a - 1 do
     let val_i = a.(i) in
@@ -341,7 +341,7 @@ References are also useful to write functions that maintain a current
 state between two calls to the function. For instance, the following
 pseudo-random number generator keeps the last returned number in a
 reference:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let current_rand = ref 0;;
 let random () =
   current_rand := !current_rand * 25713 + 1345;
@@ -350,7 +350,7 @@ let random () =
 
 Again, there is nothing magical with references: they are implemented as
 a single-field mutable record, as follows.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type 'a ref = { mutable contents: 'a };;
 let ( ! ) r = r.contents;;
 let ( := ) r newval = r.contents <- newval;;
@@ -361,7 +361,7 @@ a data structure, keeping its polymorphism.  Without user-provided
 type annotations, this is not allowed, as polymorphism is only
 introduced on a global level.  However, you can give explicitly
 polymorphic types to record fields.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type idref = { mutable id: 'a. 'a -> 'a };;
 let r = {id = fun x -> x};;
 let g s = (s.id 1, s.id true);;
@@ -378,7 +378,7 @@ control structure. Exceptions are declared with the "exception"
 construct, and signalled with the "raise" operator. For instance, the
 function below for taking the head of a list uses an exception  to
 signal the case where an empty list is given.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 exception Empty_list;;
 let head l =
   match l with
@@ -393,13 +393,13 @@ where the library functions cannot complete normally. For instance,
 the "List.assoc" function, which returns the data associated with a
 given key in a list of (key, data) pairs, raises the predefined
 exception "Not_found" when the key does not appear in the list:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 List.assoc 1 [(0, "zero"); (1, "one")];;
 List.assoc 2 [(0, "zero"); (1, "one")];;
 \end{caml_example}
 
 Exceptions can be trapped with the "try"\ldots"with" construct:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let name_of_binary_digit digit =
   try
     List.assoc digit [0, "zero"; 1, "one"]
@@ -414,7 +414,7 @@ exception value. Thus, several exceptions can be caught by one
 "try"\ldots"with" construct. Also, finalization can be performed by
 trapping all exceptions, performing the finalization, then raising
 again the exception:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let temporarily_set_reference ref newval funct =
   let oldval = !ref in
   try
@@ -434,7 +434,7 @@ We finish this introduction with a more complete example
 representative of the use of OCaml for symbolic processing: formal
 manipulations of arithmetic expressions containing variables. The
 following variant type describes the expressions we shall manipulate:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type expression =
     Const of float
   | Var of string
@@ -448,7 +448,7 @@ type expression =
 We first define a function to evaluate an expression given an
 environment that maps variable names to their values. For simplicity,
 the environment is represented as an association list.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 exception Unbound_variable of string;;
 let rec eval env exp =
   match exp with
@@ -464,7 +464,7 @@ eval [("x", 1.0); ("y", 3.14)] (Prod(Sum(Var "x", Const 2.0), Var "y"));;
 
 Now for a real symbolic processing, we define the derivative of an
 expression with respect to a variable "dv":
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let rec deriv exp dv =
   match exp with
     Const c -> Const 0.0
@@ -493,7 +493,7 @@ rules (i.e. "*" binds tighter than "+") to avoid printing unnecessary
 parentheses. To this end, we maintain the current operator precedence
 and print parentheses around an operator only if its precedence is
 less than the current precedence.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let print_expr exp =
   (* Local function definitions *)
   let open_paren prec op_prec =
@@ -576,7 +576,7 @@ print_expr (deriv e "x"); print_newline ();;
 %% %#load"camlp4o.cma";;
 %% %\end{caml_example}
 %% %Then we are ready to define our parser.
-%% \begin{caml_example}
+%% \begin{caml_example}{toplevel}
 %% let rec parse_expr = parser
 %%     [< e1 = parse_mult; e = parse_more_adds e1 >] -> e
 %% and parse_more_adds e1 = parser

--- a/manual/manual/tutorials/lablexamples.etex
+++ b/manual/manual/tutorials/lablexamples.etex
@@ -15,7 +15,7 @@ If you have a look at modules ending in "Labels" in the standard
 library, you will see that function types have annotations you did not
 have in the functions you defined yourself.
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 ListLabels.map;;
 StringLabels.sub;;
 \end{caml_example}
@@ -26,7 +26,7 @@ flexibility to function application.
 You can give such names to arguments in your programs, by prefixing them
 with a tilde "~".
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let f ~x ~y = x - y;;
 let x = 3 and y = 2 in f ~x ~y;;
 \end{caml_example}
@@ -35,7 +35,7 @@ When you want to use distinct names for the variable and the label
 appearing in the type, you can use a naming label of the form
 "~name:". This also applies when the argument is not a variable.
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let f ~x:x1 ~y:y1 = x1 - y1;;
 f ~x:3 ~y:2;;
 \end{caml_example}
@@ -54,7 +54,7 @@ This allows commuting arguments in applications. One can also
 partially apply a function on any argument, creating a new function of
 the remaining parameters.
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let f ~x ~y = x - y;;
 f ~y:2 ~x:3;;
 ListLabels.fold_left;;
@@ -66,7 +66,7 @@ If several arguments of a function bear the same label (or no label),
 they will not commute among themselves, and order matters. But they
 can still commute with other arguments.
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let hline ~x:x1 ~x:x2 ~y = (x1, x2, y);;
 hline ~x:3 ~y:2 ~x:5;;
 \end{caml_example}
@@ -76,27 +76,27 @@ application is total (omitting all optional arguments), labels may be
 omitted.
 In practice, many applications are total, so that labels can often be
 omitted.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 f 3 2;;
 ListLabels.map succ [1;2;3];;
 \end{caml_example}
 But beware that functions like "ListLabels.fold_left" whose result
 type is a type variable will never be considered as totally applied.
-\begin{caml_example}[error]
+\begin{caml_example}{toplevel}[error]
 ListLabels.fold_left ( + ) 0 [1;2;3];;
 \end{caml_example}
 
 When a function is passed as an argument to a higher-order function,
 labels must match in both types. Neither adding nor removing labels
 are allowed.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let h g = g ~x:3 ~y:2;;
 h f;;
 h ( + ) [@@expect error];;
 \end{caml_example}
 Note that when you don't need an argument, you can still use a wildcard
 pattern, but you must prefix it with the label.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 h (fun ~x:_ ~y -> y+1);;
 \end{caml_example}
 
@@ -108,7 +108,7 @@ tilde "~" of non-optional ones, and the label is also prefixed by "?"
 in the function type.
 Default values may be given for such optional parameters.
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let bump ?(step = 1) x = x + step;;
 bump 2;;
 bump ~step:3 2;;
@@ -122,7 +122,7 @@ Note that if that argument is labeled, you will only be able to
 eliminate optional arguments through the special case for total
 applications.
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let test ?(x = 0) ?(y = 0) () ?(z = 0) () = (x, y, z);;
 test ();;
 test ~x:2 () ~z:3 ();;
@@ -132,7 +132,7 @@ Optional parameters may also commute with non-optional or unlabeled
 ones, as long as they are applied simultaneously. By nature, optional
 arguments do not commute with unlabeled arguments applied
 independently.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 test ~y:2 ~x:3 () ();;
 test () () ~z:1 ~y:2 ~x:3;;
 (test () ()) ~z:1 [@@expect error];;
@@ -145,7 +145,7 @@ you do not give a default value, you have access to their internal
 representation, "type 'a option = None | Some of 'a". You can then
 provide different behaviors when an argument is present or not.
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let bump ?step x =
   match step with
   | None -> x * 2
@@ -158,7 +158,7 @@ call to another. This can be done by prefixing the applied argument
 with "?". This question mark disables the wrapping of optional
 argument in an option type.
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let test2 ?x ?y () = test ?x ?y () ();;
 test2 ?x:None;;
 \end{caml_example}
@@ -171,7 +171,7 @@ applications, labels and optional arguments have the pitfall that they
 cannot be inferred as completely as the rest of the language.
 
 You can see it in the following two examples.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let h' g = g ~y:2 ~x:3;;
 h' f [@@expect error];;
 let bump_it bump x =
@@ -203,7 +203,7 @@ order.
 
 The right way to solve this problem for optional parameters is to add
 a type annotation to the argument "bump".
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let bump_it (bump : ?step:int -> int -> int) x =
   bump ~step:2 x;;
 bump_it bump 1;;
@@ -220,7 +220,7 @@ parameters, the compiler will attempt to transform the argument to
 have it match the expected type, by passing "None" for all optional
 parameters.
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let twice f (x : int) = f(f x);;
 twice bump 2;;
 \end{caml_example}
@@ -334,7 +334,7 @@ type will be inferred independently for each of its uses.
 
 In programs, polymorphic variants work like usual ones. You just have
 to prefix their names with a backquote character "`".
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 [`On; `Off];;
 `Number 1;;
 let f = function `On -> 1 | `Off -> 0 | `Number n -> n;;
@@ -357,7 +357,7 @@ variant types, that is types that cannot be refined. This is
 also the case for type abbreviations. Such types do not contain "<" or
 ">", but just an enumeration of the tags and their associated types,
 just like in a normal datatype definition.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type 'a vlist = [`Nil | `Cons of 'a * 'a vlist];;
 let rec map f : 'a vlist -> 'b vlist = function
   | `Nil -> `Nil
@@ -370,7 +370,7 @@ let rec map f : 'a vlist -> 'b vlist = function
 Type-checking polymorphic variants is a subtle thing, and some
 expressions may result in more complex type information.
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let f = function `A -> `C | `B -> `D | x -> x;;
 f `E;;
 \end{caml_example}
@@ -381,7 +381,7 @@ returned as is, input and return types are identical. The notation "as
 'a" denotes such type sharing. If we apply "f" to yet another tag
 "`E", it gets added to the list.
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let f1 = function `A x -> x = 1 | `B -> true | `C -> false
 let f2 = function `A x -> x = "a" | `B -> true ;;
 let f x = f1 x && f2 x;;
@@ -398,7 +398,7 @@ Even if a value has a fixed variant type, one can still give it a
 larger type through coercions. Coercions are normally written with
 both the source type and the destination type, but in simple cases the
 source type may be omitted.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type 'a wlist = [`Nil | `Cons of 'a * 'a wlist | `Snoc of 'a wlist * 'a];;
 let wlist_of_vlist  l = (l : 'a vlist :> 'a wlist);;
 let open_vlist l = (l : 'a vlist :> [> 'a vlist]);;
@@ -406,7 +406,7 @@ fun x -> (x :> [`A|`B|`C]);;
 \end{caml_example}
 
 You may also selectively coerce values through pattern matching.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let split_cases = function
   | `Nil | `Cons _ as x -> `A x
   | `Snoc _ as x -> `B x
@@ -417,7 +417,7 @@ alias-pattern, the alias is given a type containing only the tags
 enumerated in the or-pattern. This allows for many useful idioms, like
 incremental definition of functions.
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let num x = `Num x
 let eval1 eval (`Num x) = x
 let rec eval x = eval1 eval x ;;
@@ -437,13 +437,13 @@ type myvariant = [`Tag1 of int | `Tag2 of bool];;
 \end{caml_eval}
 
 Such abbreviations may be used alone,
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let f = function
   | #myvariant -> "myvariant"
   | `Tag3 -> "Tag3";;
 \end{caml_example}
 or combined with with aliases.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let g1 = function `Tag1 _ -> "Tag1" | `Tag2 _ -> "Tag2";;
 let g = function
   | #myvariant as x -> g1 x
@@ -476,7 +476,7 @@ programs you are probably better off with core language variants.
 Beware also that some idioms make trivial errors very hard to find.
 For instance, the following code is probably wrong but the compiler
 has no way to see it.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type abc = [`A | `B | `C] ;;
 let f = function
   | `As -> "A"
@@ -484,7 +484,7 @@ let f = function
 let f : abc -> string = f ;;
 \end{caml_example}
 You can avoid such risks by annotating the definition itself.
-\begin{caml_example}[error]
+\begin{caml_example}{toplevel}[error]
 let f : abc -> string = function
   | `As -> "A"
   | #abc -> "other" ;;

--- a/manual/manual/tutorials/moduleexamples.etex
+++ b/manual/manual/tutorials/moduleexamples.etex
@@ -16,7 +16,7 @@ is introduced by the "struct"\ldots"end" construct, which contains an
 arbitrary sequence of definitions. The structure is usually given a
 name with the "module" binding. Here is for instance a structure
 packaging together a type of priority queues and their operations:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 module PrioQueue =
   struct
     type priority = int
@@ -49,7 +49,7 @@ Outside the structure, its components can be referred to using the
 For instance, "PrioQueue.insert" is the function "insert" defined
 inside the structure "PrioQueue" and "PrioQueue.queue" is the type
 "queue" defined in "PrioQueue".
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 PrioQueue.insert PrioQueue.empty 1 "hello";;
 \end{caml_example}
 
@@ -57,7 +57,7 @@ Another possibility is to open the module, which brings all
 identifiers defined inside the module in the scope of the current
 structure.
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
   open PrioQueue;;
   insert empty 1 "hello";;
 \end{caml_example}
@@ -68,7 +68,7 @@ has been defined. In particular, opened modules can shadow
 identifiers present in the current scope, potentially leading
 to confusing errors:
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
   let empty = []
   open PrioQueue;;
   let x = 1 :: empty [@@expect error];;
@@ -81,24 +81,24 @@ concerned expression. This can also make the code easier to read
 -- the open statement is closer to where it is used-- and to refactor
 -- the code fragment is more self-contained.
 Two constructions are available for this purpose:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
   let open PrioQueue in
   insert empty 1 "hello";;
 \end{caml_example}
 and
-\begin{caml_example}
+\begin{caml_example}{toplevel}
   PrioQueue.(insert empty 1 "hello");;
 \end{caml_example}
 In the second form, when the body of a local open is itself delimited
 by parentheses, braces or bracket, the parentheses of the local open
 can be omitted. For instance,
-\begin{caml_example}
+\begin{caml_example}{toplevel}
   PrioQueue.[empty] = PrioQueue.([empty]);;
   PrioQueue.[|empty|] = PrioQueue.([|empty|]);;
    PrioQueue.{ contents = empty } = PrioQueue.({ contents = empty });;
 \end{caml_example}
 becomes
-\begin{caml_example}
+\begin{caml_example}{toplevel}
   PrioQueue.[insert empty 1 "hello"];;
 \end{caml_example}
 
@@ -107,7 +107,7 @@ another module by using an "include" statement. This can be
 particularly useful to extend existing modules. As an illustration,
 we could add functions that returns an optional value rather than
 an exception when the priority queue is empty.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
   module PrioQueueOpt =
   struct
     include PrioQueue
@@ -131,7 +131,7 @@ restricted type. For instance, the signature below specifies the three
 priority queue operations "empty", "insert" and "extract", but not the
 auxiliary function "remove_top". Similarly, it makes the "queue" type
 abstract (by not providing its actual representation as a concrete type).
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 module type PRIOQUEUE =
   sig
     type priority = int         (* still concrete *)
@@ -146,7 +146,7 @@ Restricting the "PrioQueue" structure by this signature results in
 another view of the "PrioQueue" structure where the "remove_top"
 function is not accessible and the actual representation of priority
 queues is hidden:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 module AbstractPrioQueue = (PrioQueue : PRIOQUEUE);;
 AbstractPrioQueue.remove_top [@@expect error];;
 AbstractPrioQueue.insert AbstractPrioQueue.empty 1 "hello";;
@@ -166,7 +166,7 @@ its components inside the current signature. For instance, we
 can extend the PRIOQUEUE signature with the "extract_opt"
 function:
 
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 module type PRIOQUEUE_WITH_OPT =
   sig
     include PRIOQUEUE
@@ -191,7 +191,7 @@ For instance, here is a structure implementing sets as sorted lists,
 parameterized by a structure providing the type of the set elements
 and an ordering function over this type (used to keep the sets
 sorted):
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 type comparison = Less | Equal | Greater;;
 module type ORDERED_TYPE =
   sig
@@ -224,7 +224,7 @@ module Set =
 \end{caml_example}
 By applying the "Set" functor to a structure implementing an ordered
 type, we obtain set operations for this type:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 module OrderedString =
   struct
     type t = string
@@ -243,7 +243,7 @@ structure will not rely on sets being lists, and we can switch later
 to another, more efficient representation of sets without breaking
 their code. This can be achieved by restricting "Set" by a suitable
 functor signature:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 module type SETFUNCTOR =
   functor (Elt: ORDERED_TYPE) ->
     sig
@@ -261,7 +261,7 @@ AbstractStringSet.add "gee" AbstractStringSet.empty;;
 In an attempt to write the type constraint above more elegantly,
 one may wish to name the signature of the structure
 returned by the functor, then use that signature in the constraint:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 module type SET =
   sig
     type element
@@ -285,7 +285,7 @@ impossible above since "SET" is defined in a context where "Elt" does
 not exist. To overcome this difficulty, OCaml provides a
 "with type" construct over signatures that allows enriching a signature
 with extra type equalities:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 module AbstractSet2 =
   (Set : functor(Elt: ORDERED_TYPE) -> (SET with type element = Elt.t));;
 \end{caml_example}
@@ -303,7 +303,7 @@ illustrate. Consider an ordering over character strings that is
 different from the standard ordering implemented in the
 "OrderedString" structure. For instance, we compare strings without
 distinguishing upper and lower case.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 module NoCaseString =
   struct
     type t = string

--- a/manual/manual/tutorials/objectexamples.etex
+++ b/manual/manual/tutorials/objectexamples.etex
@@ -52,7 +52,7 @@ The class "point" below defines one instance variable "x" and two methods
 "get_x" and "move". The initial value of the instance variable is "0".
 The variable "x" is declared mutable, so the method "move" can change
 its value.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class point =
   object
     val mutable x = 0
@@ -62,7 +62,7 @@ class point =
 \end{caml_example}
 
 We now create a new point "p", instance of the "point" class.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let p = new point;;
 \end{caml_example}
 Note that the type of "p" is "point". This is an abbreviation
@@ -71,7 +71,7 @@ object type "<get_x : int; move : int -> unit>", listing the methods
 of class "point" along with their types.
 
 We now invoke some methods to "p":
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 p#get_x;;
 p#move 3;;
 p#get_x;;
@@ -81,7 +81,7 @@ The evaluation of the body of a class only takes place at object
 creation time.  Therefore, in the following example, the instance
 variable "x" is initialized to different values for two different
 objects.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let x0 = ref 0;;
 class point =
   object
@@ -95,7 +95,7 @@ new point#get_x;;
 
 The class "point" can also be abstracted over the initial values of
 the "x" coordinate.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class point = fun x_init ->
   object
     val mutable x = x_init
@@ -105,7 +105,7 @@ class point = fun x_init ->
 \end{caml_example}
 Like in function definitions, the definition above can be
 abbreviated as:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class point x_init =
   object
     val mutable x = x_init
@@ -115,7 +115,7 @@ class point x_init =
 \end{caml_example}
 An instance of the class "point" is now a function that expects an
 initial parameter to create a point object:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 new point;;
 let p = new point 7;;
 \end{caml_example}
@@ -123,7 +123,7 @@ The parameter "x_init" is, of course, visible in the whole body of the
 definition, including methods. For instance, the method "get_offset"
 in the class below returns the position of the object relative to its
 initial position.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class point x_init =
   object
     val mutable x = x_init
@@ -134,7 +134,7 @@ class point x_init =
 \end{caml_example}
 %Instance variables can only be used inside methods. For instance it would
 %not be possible to define
-%\begin{caml_example}
+%\begin{caml_example}{toplevel}
 %class point x_init =
 %  object
 %    val mutable x = x_init
@@ -147,7 +147,7 @@ Expressions can be evaluated and bound before defining the object body
 of the class. This is useful to enforce invariants. For instance,
 points can be automatically adjusted to the nearest point on a grid,
 as follows:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class adjusted_point x_init =
   let origin = (x_init / 10) * 10 in
   object
@@ -161,12 +161,12 @@ class adjusted_point x_init =
 on the grid.) In fact, the same effect could here be obtained by
 calling the definition of class "point" with the value of the
 "origin".
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class adjusted_point x_init =  point ((x_init / 10) * 10);;
 \end{caml_example}
 An alternate solution would have been to define the adjustment in
 a special allocation function:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let new_adjusted_point x_init = new point ((x_init / 10) * 10);;
 \end{caml_example}
 However, the former pattern is generally more appropriate, since
@@ -189,7 +189,7 @@ without going through a class.
 The syntax is exactly the same as for class expressions, but the
 result is a single object rather than a class. All the constructs
 described in the rest of this section also apply to immediate objects.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let p =
   object
     val mutable x = 0
@@ -204,7 +204,7 @@ p#get_x;;
 Unlike classes, which cannot be defined inside an expression,
 immediate objects can appear anywhere, using variables from their
 environment.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let minmax x y =
   if x < y then object method min = x method max = y end
   else object method min = y method max = x end;;
@@ -223,7 +223,7 @@ A method or an initializer can send messages to self (that is,
 the current object).  For that, self must be explicitly bound, here to
 the variable "s" ("s" could be any identifier, even though we will
 often choose the name "self".)
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class printable_point x_init =
   object (s)
     val mutable x = x_init
@@ -240,7 +240,7 @@ particular, when the class "printable_point" is inherited, the variable
 
 A common problem with self is that, as its type may be extended in
 subclasses, you cannot fix it in advance. Here is a simple example.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let ints = ref [];;
 class my_int =
   object (self)
@@ -255,7 +255,7 @@ We will see in section \ref{ss:using-coercions} a workaround to this
 problem.
 Note however that, since immediate objects are not extensible, the
 problem does not occur with them.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let my_int =
   object (self)
     method n = 1
@@ -272,7 +272,7 @@ is constructed. It is also possible to evaluate an expression
 immediately after the object has been built. Such code is written as
 an anonymous hidden method called an initializer. Therefore, it can
 access self and the instance variables.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class printable_point x_init =
   let origin = (x_init / 10) * 10 in
   object (self)
@@ -300,7 +300,7 @@ subclasses. A class containing virtual methods must be flagged
 "virtual", and cannot be instantiated (that is, no object of this class
 can be created). It still defines type abbreviations (treating virtual methods
 as other methods.)
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class virtual abstract_point x_init =
   object (self)
     method virtual get_x : int
@@ -318,7 +318,7 @@ class point x_init =
 
 Instance variables can also be declared as virtual, with the same effect
 as with methods.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class virtual abstract_point2 =
   object
     val mutable virtual x : int
@@ -338,7 +338,7 @@ class point2 x_init =
 
 Private methods are methods that do not appear in object interfaces.
 They can only be invoked from other methods of the same object.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class restricted_point x_init =
   object (self)
     val mutable x = x_init
@@ -362,7 +362,7 @@ Private methods are inherited (they are by default visible in subclasses),
 unless they are hidden by signature matching, as described below.
 
 Private methods can be made public in a subclass.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class point_again x =
   object (self)
     inherit restricted_point x
@@ -375,7 +375,7 @@ annotation, this makes the method public, keeping the original
 definition.
 
 An alternative definition is
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class point_again x =
   object (self : < move : _; ..> )
     inherit restricted_point x
@@ -388,7 +388,7 @@ One could think that a private method should remain private in a subclass.
 However, since the method is visible in a subclass, it is always possible
 to pick its code and define a method of the same name that runs that
 code, so yet another (heavier) solution would be:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class point_again x =
   object
     inherit restricted_point x as super
@@ -409,7 +409,7 @@ appear in this order "method private virtual".
 Class interfaces are inferred from class definitions.  They may also
 be defined directly and used to restrict the type of a class.  Like class
 declarations, they also define a new type abbreviation.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class type restricted_point_type =
   object
     method get_x : int
@@ -421,16 +421,16 @@ In addition to program documentation, class interfaces can be used to
 constrain the type of a class. Both concrete instance variables and concrete
 private methods can be hidden by a class type constraint. Public
 methods and virtual members, however, cannot.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class restricted_point' x = (restricted_point x : restricted_point_type);;
 \end{caml_example}
 Or, equivalently:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class restricted_point' = (restricted_point : int -> restricted_point_type);;
 \end{caml_example}
 The interface of a class can also be specified in a module
 signature, and used to restrict the inferred signature of a module.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 module type POINT = sig
   class restricted_point' : int ->
     object
@@ -451,7 +451,7 @@ We illustrate inheritance by defining a class of colored points that
 inherits from the class of points.  This class has all instance
 variables and all methods of class "point", plus a new instance
 variable "c" and a new method "color".
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class colored_point x (c : string) =
   object
     inherit point x
@@ -466,12 +466,12 @@ no method "color". However, the function "get_x" below is a generic
 function applying method "get_x" to any object "p" that has this
 method (and possibly some others, which are represented by an ellipsis
 in the type). Thus, it applies to both points and colored points.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let get_succ_x p = p#get_x + 1;;
 get_succ_x p + get_succ_x p';;
 \end{caml_example}
 Methods need not be declared previously, as shown by the example:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let set_x p = p#set_x;;
 let incr p = set_x p (get_succ_x p);;
 \end{caml_example}
@@ -487,7 +487,7 @@ Previous definitions of a method can be reused by binding the related
 ancestor. Below, "super" is bound to the ancestor "printable_point".
 The name "super" is a pseudo value identifier that can only be used to
 invoke a super-class method, as in "super#print".
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class printable_colored_point y c =
   object (self)
     val c = c
@@ -512,7 +512,7 @@ Note that for clarity's sake, the method "print" is explicitly marked as
 overriding another definition by annotating the "method" keyword with
 an exclamation mark "!". If the method "print" were not overriding the
 "print" method of "printable_point", the compiler would raise an error:
-\begin{caml_example}[error]
+\begin{caml_example}{toplevel}[error]
   object
     method! m = ()
   end;;
@@ -520,7 +520,7 @@ an exclamation mark "!". If the method "print" were not overriding the
 
 This explicit overriding annotation also works
 for "val" and "inherit":
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class another_printable_colored_point y c c' =
   object (self)
   inherit printable_point y
@@ -535,7 +535,7 @@ class another_printable_colored_point y c c' =
 
 Reference cells can be implemented as objects.
 The naive definition fails to typecheck:
-\begin{caml_example}[error]
+\begin{caml_example}{toplevel}[error]
 class oref x_init =
   object
     val mutable x = x_init
@@ -548,7 +548,7 @@ The reason is that at least one of the methods has a polymorphic type
 either the class should be parametric, or the method type should be
 constrained to a monomorphic type.  A monomorphic instance of the class could
 be defined by:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class oref (x_init:int) =
   object
     val mutable x = x_init
@@ -558,7 +558,7 @@ class oref (x_init:int) =
 \end{caml_example}
 Note that since immediate objects do not define a class type, they have
 no such restriction.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let new_oref x_init =
   object
     val mutable x = x_init
@@ -570,7 +570,7 @@ On the other hand, a class for polymorphic references must explicitly
 list the type parameters in its declaration. Class type parameters are
 listed between "[" and "]". The type parameters must also be
 bound somewhere in the class body by a type constraint.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ['a] oref x_init =
   object
     val mutable x = (x_init : 'a)
@@ -582,7 +582,7 @@ let r = new oref 1 in r#set 2; (r#get);;
 The type parameter in the declaration may actually be constrained in the
 body of the class definition. In the class type, the actual value of
 the type parameter is displayed in the "constraint" clause.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ['a] oref_succ (x_init:'a) =
   object
     val mutable x = x_init + 1
@@ -594,7 +594,7 @@ Let us consider a more complex example: define a circle, whose center
 may be any kind of point.  We put an additional type
 constraint in method "move", since no free variables must remain
 unaccounted for by the class type parameters.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ['a] circle (c : 'a) =
   object
     val mutable center = c
@@ -612,7 +612,7 @@ object belonging to a subclass of class "point". It actually expands to
 alternate definition of "circle", which has slightly stronger
 constraints on its argument, as we now expect "center" to have a
 method "get_x".
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ['a] circle (c : 'a) =
   object
     constraint 'a = #point
@@ -627,7 +627,7 @@ The class "colored_circle" is a specialized version of class
 "#colored_point", and adds a method "color". Note that when specializing a
 parameterized class, the instance of type parameter must always be
 explicitly given. It is again written between "[" and "]".
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ['a] colored_circle c =
   object
     constraint 'a = #colored_point
@@ -644,7 +644,7 @@ While parameterized classes may be polymorphic in their contents, they
 are not enough to allow polymorphism of method use.
 
 A classical example is defining an iterator.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 List.fold_left;;
 class ['a] intlist (l : int list) =
   object
@@ -654,7 +654,7 @@ class ['a] intlist (l : int list) =
 \end{caml_example}
 At first look, we seem to have a polymorphic iterator, however this
 does not work in practice.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let l = new intlist [1; 2; 3];;
 l#fold (fun x y -> x+y) 0;;
 l;;
@@ -669,7 +669,7 @@ The problem here is that quantification was wrongly located: it is
 not the class we want to be polymorphic, but the "fold" method.
 This can be achieved by giving an explicitly polymorphic type in the
 method definition.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class intlist (l : int list) =
   object
     method empty = (l = [])
@@ -694,7 +694,7 @@ cannot choose between those two types, and must be helped.
 However, the type can be completely omitted in the class definition if
 it is already known, through inheritance or type constraints on self.
 Here is an example of method overriding.
-\begin{caml_example*}
+\begin{caml_example*}{toplevel}
 class intlist_rev l =
   object
     inherit intlist l
@@ -702,7 +702,7 @@ class intlist_rev l =
   end;;
 \end{caml_example*}
 The following idiom separates description and definition.
-\begin{caml_example*}
+\begin{caml_example*}{toplevel}
 class type ['a] iterator =
   object method fold : ('b -> 'a -> 'b) -> 'b -> 'b end;;
 class intlist l =
@@ -719,18 +719,18 @@ methods, but you should be aware of some limitations of type
 inference.  Namely, a polymorphic method can only be called if its
 type is known at the call site.  Otherwise, the method will be assumed
 to be monomorphic, and given an incompatible type.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let sum lst = lst#fold (fun x y -> x+y) 0;;
 sum l [@@expect error];;
 \end{caml_example}
 The workaround is easy: you should put a type constraint on the
 parameter.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let sum (lst : _ #iterator) = lst#fold (fun x y -> x+y) 0;;
 \end{caml_example}
 Of course the constraint may also be an explicit method type.
 Only occurences of quantified variables are required.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let sum lst =
   (lst : < fold : 'a. ('a -> _ -> 'a) -> 'a -> 'a; .. >)#fold (+) 0;;
 \end{caml_example}
@@ -739,7 +739,7 @@ Another use of polymorphic methods is to allow some form of implicit
 subtyping in method arguments. We have already seen in section
 \ref{ss:inheritance} how some functions may be polymorphic in the
 class of their argument. This can be extended to methods.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class type point0 = object method get_x : int end;;
 class distance_point x =
   object
@@ -754,7 +754,7 @@ Note here the special syntax "(#point0 as 'a)" we have to use to
 quantify the extensible part of "#point0". As for the variable binder,
 it can be omitted in class specifications. If you want polymorphism
 inside object field it must be quantified independently.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class multi_poly =
   object
     method m1 : 'a. (< n1 : 'b. 'b -> 'b; .. > as 'a) -> _ =
@@ -778,7 +778,7 @@ domain and the codomain of the type coercion must be given.
 We have seen that points and colored points have incompatible types.
 For instance, they cannot be mixed in the same list. However, a
 colored point can be coerced to a point, hiding its "color" method:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let colored_point_to_point cp = (cp : colored_point :> point);;
 let p = new point 3 and q = new colored_point 4 "blue";;
 let l = [p; (colored_point_to_point q)];;
@@ -786,7 +786,7 @@ let l = [p; (colored_point_to_point q)];;
 An object of type "t" can be seen as an object of type "t'"
 only if "t" is a subtype of "t'". For instance, a point cannot be
 seen as a colored point.
-\begin{caml_example}[error]
+\begin{caml_example}{toplevel}[error]
 (p : point :> colored_point);;
 \end{caml_example}
 Indeed, narrowing coercions without runtime checks would be unsafe.
@@ -803,43 +803,43 @@ colored points would remain unchanged and thus still be a subtype of
 points.
 % Conversely, the class "int_comparable" inherits from class
 %"comparable", but type "int_comparable" is not a subtype of "comparable".
-%\begin{caml_example}
+%\begin{caml_example}{toplevel}
 %function x -> (x : int_comparable :> comparable);;
 %\end{caml_example}
 
 The domain of a coercion can often be omitted. For instance, one can
 define:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let to_point cp = (cp :> point);;
 \end{caml_example}
 In this case, the function "colored_point_to_point" is an instance of the
 function "to_point". This is not always true, however. The fully
 explicit coercion  is more precise and is sometimes  unavoidable.
 Consider, for example, the following class:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class c0 = object method m = {< >} method n = 0 end;;
 \end{caml_example}
 The object type "c0" is an abbreviation for "<m : 'a; n : int> as 'a".
 Consider now the type declaration:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class type c1 =  object method m : c1 end;;
 \end{caml_example}
 The object type "c1" is an abbreviation for the type "<m : 'a> as 'a".
 The coercion from an object of type "c0" to an object of type "c1" is
 correct:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 fun (x:c0) -> (x : c0 :> c1);;
 \end{caml_example}
 %%% FIXME come up with a better example.
 % However, the domain of the coercion cannot be omitted here:
-% \begin{caml_example}
+% \begin{caml_example}{toplevel}
 % fun (x:c0) -> (x :> c1);;
 % \end{caml_example}
 However, the domain of the coercion cannot always be omitted.
 In that case, the solution is to use the explicit form.
 %
 Sometimes, a change in the class-type definition can also solve the problem
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class type c2 = object ('a) method m : 'a end;;
 fun (x:c0) -> (x :> c2);;
 \end{caml_example}
@@ -852,7 +852,7 @@ allows leaving the domain implicit in most cases when coercing form a
 subclass to its superclass.
 %
 The type of a coercion can always be seen as below:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let to_c1 x = (x :> c1);;
 let to_c2 x = (x :> c2);;
 \end{caml_example}
@@ -872,7 +872,7 @@ parameterless classes the coercion "(_ :> c)" is always more general than
 "(_ : #c :> c)".
 %If a class type exposes the type of self through one of its parameters, this
 %is no longer true. Here is a counter-example.
-%\begin{caml_example}
+%\begin{caml_example}{toplevel}
 %class type ['a] c = object ('a) method m : 'a end;;
 %let to_c x = (x :> _ c);;
 %\end{caml_example}
@@ -883,7 +883,7 @@ class "c" while defining class "c". The problem is due to the type
 abbreviation not being completely defined yet, and so its subtypes are not
 clearly known.  Then, a coercion "(_ :> c)" or "(_ : #c :> c)" is taken to be
 the identity function, as in
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 function x -> (x :> 'a);;
 \end{caml_example}
 As a consequence, if the coercion is applied to "self", as in the
@@ -894,7 +894,7 @@ Indeed, the type of self cannot be closed: this would prevent any
 further extension of the class. Therefore, a type error is generated
 when the unification of this type with another type would result in a
 closed object type.
-\begin{caml_example}[error]
+\begin{caml_example}{toplevel}[error]
 class c = object method m = 1 end
 and d = object (self)
   inherit c
@@ -905,12 +905,12 @@ end;;
 However, the most common instance of this problem, coercing self to
 its current class, is detected as a special case by the type checker,
 and properly typed.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class c = object (self) method m = (self :> c) end;;
 \end{caml_example}
 This allows the following idiom, keeping a list of all objects
 belonging to a class or its subclasses:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let all_c = ref [];;
 class c (m : int) =
   object (self)
@@ -920,7 +920,7 @@ class c (m : int) =
 \end{caml_example}
 This idiom can in turn be used to retrieve an object whose type has
 been weakened:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let rec lookup_obj obj = function [] -> raise Not_found
   | obj' :: l ->
      if (obj :> < >) = (obj' :> < >) then obj' else lookup_obj obj l ;;
@@ -933,7 +933,7 @@ of type "c".
 \medskip
 The previous coercion problem can often be avoided by first
 defining the abbreviation, using a class type:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class type c' = object method m : int end;;
 class c : c' = object method m = 1 end
 and d = object (self)
@@ -945,12 +945,12 @@ end;;
 It is also possible to use a virtual class. Inheriting from this class
 simultaneously forces all methods of "c" to have the same
 type as the methods of "c'".
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class virtual c' = object method virtual m : int end;;
 class c = object (self) inherit c' method m = 1 end;;
 \end{caml_example}
 One could think of defining the type abbreviation directly:
-\begin{caml_example*}
+\begin{caml_example*}{toplevel}
 type c' = <m : int>;;
 \end{caml_example*}
 However, the abbreviation "#c'" cannot be defined directly in a similar way.
@@ -958,7 +958,7 @@ It can only be defined by a class or a class-type definition.
 This is because a "#"-abbreviation carries an implicit anonymous
 variable ".." that cannot be explicitly named.
 The closer you get to it is:
-\begin{caml_example*}
+\begin{caml_example*}{toplevel}
 type 'a c'_class = 'a constraint 'a = < m : int; .. >;;
 \end{caml_example*}
 with an extra type variable capturing the open object type.
@@ -971,7 +971,7 @@ It is possible to write a version of class "point" without assignments
 on the instance variables. The override construct "{< ... >}" returns a copy of
 ``self'' (that is, the current object), possibly changing the value of
 some instance variables.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class functional_point y =
   object
     val x = y
@@ -989,7 +989,7 @@ and "'a" appears inside the type of the method "move".
 
 The above definition of "functional_point" is not equivalent
 to the following:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class bad_functional_point y =
   object
     val x = y
@@ -1022,7 +1022,7 @@ A deeper assignment (for example if the instance variable is a reference cell)
 will of course affect both the original and the copy.
 
 The type of "Oo.copy" is the following:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 Oo.copy;;
 \end{caml_example}
 The keyword "as" in that type binds the type variable "'a" to
@@ -1031,7 +1031,7 @@ any methods (represented by the ellipsis), and returns an object of
 the same type. The type of "Oo.copy" is different from type "< .. > ->
 < .. >" as each ellipsis represents a different set of methods.
 Ellipsis actually behaves as a type variable.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let p = new point 5;;
 let q = Oo.copy p;;
 q#move 7; (p#get_x, q#get_x);;
@@ -1042,7 +1042,7 @@ method "copy" with body "{< >}" has been defined in the class of "p".
 Objects can be compared using the generic comparison functions "=" and "<>".
 Two objects are equal if and only if they are physically equal. In
 particular, an object and its copy are not equal.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let q = Oo.copy p;;
 p = q, p = p;;
 \end{caml_example}
@@ -1055,7 +1055,7 @@ two objects have been created and it is not affected by mutation of fields.
 Cloning and override have a non empty intersection.
 They are interchangeable when used within an object and without
 overriding any field:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class copy =
   object
     method copy = {< >}
@@ -1070,7 +1070,7 @@ only the "Oo.copy" primitive can be used externally.
 
 Cloning can also be used to provide facilities for saving and
 restoring the state of objects.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class backup =
   object (self : 'mytype)
     val mutable copy = None
@@ -1080,7 +1080,7 @@ class backup =
 \end{caml_example}
 The above definition will only backup one level.
 The backup facility can be added to any class by using multiple inheritance.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ['a] backup_ref x = object inherit ['a] oref x inherit backup end;;
 let rec get p n = if n = 0 then p # get else get (p # restore) (n-1);;
 let p = new backup_ref 0  in
@@ -1089,7 +1089,7 @@ p # save; p # set 1; p # save; p # set 2;
 \end{caml_example}
 We can define a variant of backup that retains all copies. (We also
 add a method "clear" to manually erase all copies.)
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class backup =
   object (self : 'mytype)
     val mutable copy = None
@@ -1098,7 +1098,7 @@ class backup =
     method clear = copy <- None
   end;;
 \end{caml_example}
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class ['a] backup_ref x = object inherit ['a] oref x inherit backup end;;
 let p = new backup_ref 0  in
 p # save; p # set 1; p # save; p # set 2;
@@ -1113,7 +1113,7 @@ p # save; p # set 1; p # save; p # set 2;
 
 Recursive classes can be used to define objects whose types are
 mutually recursive.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class window =
   object
     val mutable top_widget = (None : widget option)
@@ -1139,7 +1139,7 @@ binary method "leq" of type "'a -> bool" where the type variable "'a"
 is bound to the type of self. Therefore, "#comparable" expands to "<
 leq : 'a -> bool; .. > as 'a".  We see here that the binder "as" also
 allows writing recursive types.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class virtual comparable =
   object (_ : 'a)
     method virtual leq : 'a -> bool
@@ -1151,7 +1151,7 @@ more operations. We have to use a type constraint on the class parameter "x"
 because the primitive "<=" is a polymorphic function in
 OCaml.  The "inherit" clause ensures that the type of objects
 of this class is an instance of "#comparable".
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class money (x : float) =
   object
     inherit comparable
@@ -1171,7 +1171,7 @@ call to method "leq" on "m" with an argument that does not have a method
 "value", which would be an error.
 
 Similarly, the type "money2" below is not a subtype of type "money".
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class money2 x =
   object
     inherit money x
@@ -1185,13 +1185,13 @@ will return the minimum of any two objects whose type unifies with
 #comparable -> #comparable", as the abbreviation "#comparable" hides a
 type variable (an ellipsis). Each occurrence of this abbreviation
 generates a new variable.
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 let min (x : #comparable) y =
   if x#leq y then x else y;;
 \end{caml_example}
 This function can be applied to objects of type "money"
 or "money2".
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 (min (new money  1.3) (new money 3.1))#value;;
 (min (new money2 5.0) (new money2 3.14))#value;;
 \end{caml_example}
@@ -1207,7 +1207,7 @@ the "times" method would return an object of class "money2" but not of class
 
 The class "money" could naturally carry another binary method. Here is a
 direct definition:
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class money x =
   object (self : 'a)
     val repr = x
@@ -1231,7 +1231,7 @@ the representation can easily be hidden inside objects by removing the method
 "value" as well. However, this is not possible as soon as some binary
 method requires access to the representation of objects of the same
 class (other than self).
-\begin{caml_example}
+\begin{caml_example}{toplevel}
 class safe_money x =
   object (self : 'a)
     val repr = x
@@ -1243,7 +1243,7 @@ Here, the representation of the object is known only to a particular object.
 To make it available to other objects of the same class, we are forced to
 make it available to the whole world. However we can easily restrict the
 visibility of the representation using the module system.
-\begin{caml_example*}
+\begin{caml_example*}{toplevel}
 module type MONEY =
   sig
     type t


### PR DESCRIPTION
[MPR#7551](https://caml.inria.fr/mantis/view.php?id=7551): 
This PR makes it possible to omit the final `;;` in a caml_example environment.
By default, this final `;;` is still mandatory and a new command line option `-implicit-stop` makes it optional globally.

This global setting can be overrided locally by adding an optional argument to the environment:

- `[toplevel]` makes the final `;;` mandatory
- `[verbatim]` makes it optional

This new optional argument must precedes the expected status argument:
```
\begin{caml_example*}[verbatim][error]
1 + 2.
\end{caml_example}
```
The tutorial part of the manual is configured to use the globally mandatory `;;` mode for the sake of consistency whereas the language extension section uses the new optional `;;` mode.