### PR TITLE
Merge functions based on partiality rather than Parmatch.irrefutable

### DIFF
--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -1218,16 +1218,16 @@ and transl_apply ?(should_be_tailcall=false) ?(inlined = Default_inline)
      : Lambda.lambda)
 
 and transl_function loc untuplify_fn repr partial param cases =
-  match cases with
+  match cases, partial with
     [{c_lhs=pat; c_guard=None;
       c_rhs={exp_desc = Texp_function { arg_label = _; param = param'; cases;
-        partial = partial'; }} as exp}]
-    when Parmatch.fluid pat ->
+        partial = partial'; }} as exp}], Total
+    when Parmatch.inactive pat ->
       let ((_, params), body) =
         transl_function exp.exp_loc false repr partial' param' cases in
       ((Curried, param :: params),
        Matching.for_function loc None (Lvar param) [pat, body] partial)
-  | {c_lhs={pat_desc = Tpat_tuple pl}} :: _ when untuplify_fn ->
+  | {c_lhs={pat_desc = Tpat_tuple pl}} :: _, _ when untuplify_fn ->
       begin try
         let size = List.length pl in
         let pats_expr_list =

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -2004,23 +2004,20 @@ let irrefutable pat = le_pat pat omega
    trivial computations (tag/equality tests).
    Patterns containing (lazy _) subpatterns are active. *)
 
-let rec inactive pat = match pat with
-| Tpat_lazy _ ->
-    false
-| Tpat_any | Tpat_var _ | Tpat_constant _ | Tpat_variant (_, None, _) ->
-    true
-| Tpat_tuple ps | Tpat_construct (_, _, ps) | Tpat_array ps ->
-    List.for_all (fun p -> inactive p.pat_desc) ps
-| Tpat_alias (p,_,_) | Tpat_variant (_, Some p, _) ->
-    inactive p.pat_desc
-| Tpat_record (ldps,_) ->
-    List.exists (fun (_, _, p) -> inactive p.pat_desc) ldps
-| Tpat_or (p,q,_) ->
-    inactive p.pat_desc && inactive q.pat_desc
-
-(* A `fluid' pattern is both irrefutable and inactive *)
-
-let fluid pat =  irrefutable pat && inactive pat.pat_desc
+let rec inactive pat =
+  match pat.pat_desc with
+  | Tpat_lazy _ ->
+      false
+  | Tpat_any | Tpat_var _ | Tpat_constant _ | Tpat_variant (_, None, _) ->
+      true
+  | Tpat_tuple ps | Tpat_construct (_, _, ps) | Tpat_array ps ->
+      List.for_all (fun p -> inactive p) ps
+  | Tpat_alias (p,_,_) | Tpat_variant (_, Some p, _) ->
+      inactive p
+  | Tpat_record (ldps,_) ->
+      List.exists (fun (_, _, p) -> inactive p) ldps
+  | Tpat_or (p,q,_) ->
+      inactive p && inactive q
 
 
 

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -75,7 +75,7 @@ val check_unused:
 
 (* Irrefutability tests *)
 val irrefutable : pattern -> bool
-val fluid : pattern -> bool
+val inactive : pattern -> bool
 
 (* Ambiguous bindings *)
 val check_ambiguous_bindings : case list -> unit


### PR DESCRIPTION
`translcore.ml` merges together nested functions as long as the parameter is "fluid". This is what gives us a 2 parameter function for things like:

```ocaml
type r = R

let rr = fun R y -> 0
```

but the definition of fluid uses `Parmatch.irrefutable` which does not use type information. So things like:

```ocaml
type 'a t = T : int t | S : string t

let tt : int t -> _ -> _ = fun T y -> 0
```

still gives a function of 1 argument returning a function of 1 argument.

Since the partiality of the match (which does use type information) is already available this patch uses it in place of `Parmatch.irrefutable`. I think this is strictly more accurate and safe.

Note that there are optimizations in later passes (e.g. simplify) that also attempt to merge functions together. However, these can be quite fragile. For instance, the above case was not merged in 4.03, but this was accidentally fixed in 4.04 for `ocamlopt` by removing some debugging events. An example, which is not merged on trunk is `bar` below (unlike `foo` which is always merged):

```ocaml
type 'a foo = A of float * int | C of int * float;;

let foo = fun (A(_, x) | C(x, _)) y -> x + y;;

type 'a bar = A : float * int -> int bar | B : string bar | C : int * float -> int bar;;

let bar : int bar -> _ -> _ = fun (A(_, x) | C(x, _)) y -> x + y;;
```