### PR TITLE
Int(32|64).of_string documentation: exceptions and prefixes

### DIFF
--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -131,7 +131,7 @@ external of_string : string -> int32 = "caml_int32_of_string"
    The string is read in decimal (by default) or in hexadecimal,
    octal or binary if the string begins with [0x], [0o] or [0b]
    respectively.
-   Raise [Failure "int_of_string"] if the given string is not
+   Raise [Failure "Int32.of_string"] if the given string is not
    a valid representation of an integer, or if the integer represented
    exceeds the range of integers representable in type [int32]. *)
 

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -131,6 +131,14 @@ external of_string : string -> int32 = "caml_int32_of_string"
    The string is read in decimal (by default, or if the string 
    begins with [0u]) or in hexadecimal, octal or binary if the
    string begins with [0x], [0o] or [0b] respectively.
+
+   The [0u] prefix reads the input as an unsigned integer in the range
+   [[0, 2*Int32.max_int+1]].  If the input exceeds {!Int32.max_int}
+   it is converted to the signed integer
+   [Int32.min_int + input - Int32.max_int - 1].
+
+   The [_] (underscore) character can appear anywhere in the string
+   and is ignored.
    Raise [Failure "Int32.of_string"] if the given string is not
    a valid representation of an integer, or if the integer represented
    exceeds the range of integers representable in type [int32]. *)

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -128,9 +128,9 @@ external to_float : int32 -> float
 
 external of_string : string -> int32 = "caml_int32_of_string"
 (** Convert the given string to a 32-bit integer.
-   The string is read in decimal (by default) or in hexadecimal,
-   octal or binary if the string begins with [0x], [0o] or [0b]
-   respectively.
+   The string is read in decimal (by default, or if the string 
+   begins with [0u]) or in hexadecimal, octal or binary if the
+   string begins with [0x], [0o] or [0b] respectively.
    Raise [Failure "Int32.of_string"] if the given string is not
    a valid representation of an integer, or if the integer represented
    exceeds the range of integers representable in type [int32]. *)

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -153,7 +153,7 @@ external of_string : string -> int64 = "caml_int64_of_string"
    The string is read in decimal (by default) or in hexadecimal,
    octal or binary if the string begins with [0x], [0o] or [0b]
    respectively.
-   Raise [Failure "int_of_string"] if the given string is not
+   Raise [Failure "Int64.of_string"] if the given string is not
    a valid representation of an integer, or if the integer represented
    exceeds the range of integers representable in type [int64]. *)
 

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -150,9 +150,9 @@ external to_nativeint : int64 -> nativeint = "%int64_to_nativeint"
 
 external of_string : string -> int64 = "caml_int64_of_string"
 (** Convert the given string to a 64-bit integer.
-   The string is read in decimal (by default) or in hexadecimal,
-   octal or binary if the string begins with [0x], [0o] or [0b]
-   respectively.
+   The string is read in decimal (by default, or if the string 
+   begins with [0u]) or in hexadecimal, octal or binary if the
+   string begins with [0x], [0o] or [0b] respectively.
    Raise [Failure "Int64.of_string"] if the given string is not
    a valid representation of an integer, or if the integer represented
    exceeds the range of integers representable in type [int64]. *)

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -153,6 +153,14 @@ external of_string : string -> int64 = "caml_int64_of_string"
    The string is read in decimal (by default, or if the string 
    begins with [0u]) or in hexadecimal, octal or binary if the
    string begins with [0x], [0o] or [0b] respectively.
+
+   The [0u] prefix reads the input as an unsigned integer in the range
+   [[0, 2*Int64.max_int+1]].  If the input exceeds {!Int64.max_int}
+   it is converted to the signed integer
+   [Int64.min_int + input - Int64.max_int - 1].
+
+   The [_] (underscore) character can appear anywhere in the string
+   and is ignored.
    Raise [Failure "Int64.of_string"] if the given string is not
    a valid representation of an integer, or if the integer represented
    exceeds the range of integers representable in type [int64]. *)

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -158,10 +158,16 @@ external to_int32 : nativeint -> int32 = "%nativeint_to_int32"
 
 external of_string : string -> nativeint = "caml_nativeint_of_string"
 (** Convert the given string to a native integer.
-   The string is read in decimal (by default) or in hexadecimal,
-   octal or binary if the string begins with [0x], [0o] or [0b]
-   respectively.
-   Raise [Failure "int_of_string"] if the given string is not
+   The string is read in decimal (by default, or if the string 
+   begins with [0u]) or in hexadecimal, octal or binary if the
+   string begins with [0x], [0o] or [0b] respectively.
+
+   The [0u] prefix reads the input as an unsigned integer in the range
+   [[0, 2*Nativeint.max_int+1]].  If the input exceeds {!Nativeint.max_int}
+   it is converted to the signed integer
+   [Int64.min_int + input - Nativeint.max_int - 1].
+
+   Raise [Failure "Nativeint.of_string"] if the given string is not
    a valid representation of an integer, or if the integer represented
    exceeds the range of integers representable in type [nativeint]. *)
 

--- a/stdlib/pervasives.mli
+++ b/stdlib/pervasives.mli
@@ -627,6 +627,12 @@ external int_of_string : string -> int = "caml_int_of_string"
    begins with [0u]), in hexadecimal (if it begins with [0x] or
    [0X]), in octal (if it begins with [0o] or [0O]), or in binary
    (if it begins with [0b] or [0B]).
+
+   The [0u] prefix reads the input as an unsigned integer in the range
+   [[0, 2*max_int+1]].  If the input exceeds {!max_int}
+   it is converted to the signed integer
+   [min_int + input - max_int - 1].
+
    The [_] (underscore) character can appear anywhere in the string
    and is ignored.
    Raise [Failure "int_of_string"] if the given string is not

--- a/stdlib/pervasives.mli
+++ b/stdlib/pervasives.mli
@@ -623,9 +623,10 @@ val string_of_int : int -> string
 
 external int_of_string : string -> int = "caml_int_of_string"
 (** Convert the given string to an integer.
-   The string is read in decimal (by default), in hexadecimal (if it
-   begins with [0x] or [0X]), in octal (if it begins with [0o] or [0O]),
-   or in binary (if it begins with [0b] or [0B]).
+   The string is read in decimal (by default, or if the string 
+   begins with [0u]), in hexadecimal (if it begins with [0x] or
+   [0X]), in octal (if it begins with [0o] or [0O]), or in binary
+   (if it begins with [0b] or [0B]).
    The [_] (underscore) character can appear anywhere in the string
    and is ignored.
    Raise [Failure "int_of_string"] if the given string is not


### PR DESCRIPTION
`Int32.of_string` raises `Failure "Int32.of_string"`, not `Failure "int.of_string"` on failure (and similarly for `Int64.of_string`):

```ocaml
# Int32.of_string "";;
Exception: Failure "Int32.of_string".
```

The `of_string` functions also accept a `0u` prefix, which was previously undocumented:

```ocaml
# Int64.of_string "0u3";;
- : int64 = 3L
```
