### PR TITLE
Prevent recursive polymorphic variant names

### DIFF
--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -16,3 +16,10 @@ let f (x:'Id_arg) = x;;
 [%%expect{|
 val f : 'Id_arg -> 'Id_arg = <fun>
 |}];;
+
+type 'a id = 'a
+let f (x : [< [`Foo] id]) = ();;
+[%%expect{|
+type 'a id = 'a
+val f : [< [ `Foo ] id ] -> unit = <fun>
+|}];;


### PR DESCRIPTION
The `row_name` field of a polymorphic variant type is used to improve their printing. When a type constructor expands to a polymorphic variant that constructor and its arguments is put in the `row_name` field. However, there is currently no check to ensure that the arguments do not contain the original variant. This means you can get weird recursive types:

```ocaml
# type 'a id = 'a;;
type 'a id = 'a

# let f (x : [< [`Foo] id ]) = ();;
val f : [< 'a id ] -> unit = <fun>
```

The printed type here is clearly incorrect, and this comes from a variant type whose `row_name` field is itself.

This patch fixes the issue by adding a simple occurs check when setting `row_name` during expansion. It doesn't care about contractivity or possibly expanding constructors (as the real occurs check does) because for `row_name` any type which contains the original variant isn't worth using since it will be longer than the original.

Another possible approach would be to set `row_name` at type definition time rather than at type expansion time. That should prevent non-contractive type constructors being used in `row_name` and may give more intuitive results in that only constructors explicitly defined as polymorphic variants would be used in `row_name`.