### PR TITLE
Support -fvisibility=hidden

### DIFF
--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -52,8 +52,8 @@ typedef char * addr;
 */
 #ifdef __GNUC__
   /* Works only in GCC 2.5 and later */
-  #define CAMLnoreturn_start
-  #define CAMLnoreturn_end __attribute__ ((noreturn))
+  #define CAMLnoreturn_start __attribute__ ((noreturn))
+  #define CAMLnoreturn_end
   #define Noreturn __attribute__ ((noreturn))
 #elif _MSC_VER >= 1500
   #define CAMLnoreturn_start __declspec(noreturn)

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -68,7 +68,11 @@ typedef char * addr;
 
 
 /* Export control (to mark primitives and to handle Windows DLL) */
-
+#ifdef __cplusplus
+# define CAMLextern extern "C"
+#else
+# define CAMLextern extern
+#endif
 #if defined _WIN32 || defined __CYGWIN__
 # ifdef __GNUC__
 #  define CAMLexport __attribute__((dllexport))
@@ -80,8 +84,11 @@ typedef char * addr;
 #else
 # define CAMLexport
 #endif
-#define CAMLprim CAMLexport
-#define CAMLextern extern
+#ifdef __cplusplus
+# define CAMLprim extern "C" CAMLexport
+#else
+# define CAMLprim CAMLexport
+#endif
 
 /* Weak function definitions that can be overridden by external libs */
 /* Conservatively restricted to ELF and MacOSX platforms */

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -69,8 +69,18 @@ typedef char * addr;
 
 /* Export control (to mark primitives and to handle Windows DLL) */
 
-#define CAMLexport
-#define CAMLprim
+#if defined _WIN32 || defined __CYGWIN__
+# ifdef __GNUC__
+#  define CAMLexport __attribute__((dllexport))
+# else
+#  define CAMLexport __declspec((dllexport)
+# endif
+#elif defined __GNUC__
+# define CAMLexport __attribute__((visibility("default")))
+#else
+# define CAMLexport
+#endif
+#define CAMLprim CAMLexport
 #define CAMLextern extern
 
 /* Weak function definitions that can be overridden by external libs */

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -69,15 +69,23 @@ typedef char * addr;
 
 /* Export control (to mark primitives and to handle Windows DLL) */
 #ifdef __cplusplus
-# define CAMLextern extern "C"
+# define CAMLextern extern "C" CAMLexport
 #else
-# define CAMLextern extern
+# define CAMLextern extern CAMLexport
 #endif
 #if defined _WIN32 || defined __CYGWIN__
-# ifdef __GNUC__
-#  define CAMLexport __attribute__((dllexport))
+# ifdef CAML_CORE
+#  ifdef __GNUC__
+#   define CAMLexport __attribute__((dllexport))
+#  else
+#   define CAMLexport __declspec((dllexport)
+#  endif
 # else
-#  define CAMLexport __declspec((dllexport)
+#  ifdef __GNUC__
+#   define CAMLexport __attribute__((dllimport))
+#  else
+#   define CAMLexport __declspec((dllimport))
+#  endif
 # endif
 #elif defined __GNUC__
 # define CAMLexport __attribute__((visibility("default")))
@@ -117,24 +125,20 @@ extern caml_timing_hook caml_finalise_begin_hook, caml_finalise_end_hook;
 #define CAMLassert(x) \
   ((x) ? (void) 0 : caml_failed_assert ( #x , __FILE__, __LINE__))
 CAMLnoreturn_start
-CAMLextern int caml_failed_assert (char *, char *, int)
-CAMLnoreturn_end;
+CAMLextern int caml_failed_assert (char *, char *, int);
 #else
 #define CAMLassert(x) ((void) 0)
 #endif
 
 CAMLnoreturn_start
-CAMLextern void caml_fatal_error (char *msg)
-CAMLnoreturn_end;
+CAMLextern void caml_fatal_error (char *msg);
 
 CAMLnoreturn_start
-CAMLextern void caml_fatal_error_arg (char *fmt, char *arg)
-CAMLnoreturn_end;
+CAMLextern void caml_fatal_error_arg (char *fmt, char *arg);
 
 CAMLnoreturn_start
 CAMLextern void caml_fatal_error_arg2 (char *fmt1, char *arg1,
-                                       char *fmt2, char *arg2)
-CAMLnoreturn_end;
+                                       char *fmt2, char *arg2);
 
 /* Detection of available C built-in functions, the Clang way. */
 
@@ -179,7 +183,7 @@ static inline int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
   return __builtin_mul_overflow(a, b, res);
 }
 #else
-extern int caml_umul_overflow(uintnat a, uintnat b, uintnat * res);
+CAMLextern int caml_umul_overflow(uintnat a, uintnat b, uintnat * res);
 #endif
 
 /* Use macros for some system calls being called from OCaml itself.

--- a/configure
+++ b/configure
@@ -418,7 +418,7 @@ case "$ccfamily" in
     common_cflags="-O";;
 esac
 
-internal_cppflags="-DCAML_NAME_SPACE $internal_cppflags"
+internal_cppflags="-DCAML_NAME_SPACE -DCAML_CORE $internal_cppflags"
 
 # Adjust according to target
 


### PR DESCRIPTION
CAMLprim and CAMLexport currently expand to nothing, but it can be
made to export the associated declaration even when
-fvisibility=hidden is used.

Also, eliminate the need for CAMLnoreturn_end by moving its
expansion to that of CAMLnoreturn_start.