### PR TITLE
Fix a warning in the tests (use "%lu" for GetLastError())

### DIFF
--- a/testsuite/tests/lib-unix/common/fdstatus.c
+++ b/testsuite/tests/lib-unix/common/fdstatus.c
@@ -22,7 +22,7 @@ void process_fd(char * s)
   } else if (GetLastError() == ERROR_INVALID_HANDLE) {
     printf("closed\n");
   } else {
-    printf("error %d\n", GetLastError());
+    printf("error %lu\n", (unsigned long)(GetLastError()));
   }
 }
 


### PR DESCRIPTION
Spotted in the Appveyor logs:

```
fdstatus.c: In function ‘process_fd’:
fdstatus.c:25:12: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘DWORD {aka long unsigned int}’ [-Wformat=]
     printf("error %d\n", GetLastError());
            ^
```