### PR TITLE
Pr#7563 module constructor name clash

### DIFF
--- a/Changes
+++ b/Changes
@@ -250,6 +250,11 @@ Working version
   non-labeled argument
   (Jacques Garrigue, report by Stephen Dolan)
 
+- PR#7563, GPR#1210: code generation bug when a module alias and
+  an extension constructor have the same name in the same module
+  (Gabriel Scherer, report by Manuel Fähndrich,
+   review by Jacques Garrigue and Leo White)
+
 - GPR#1199: Pretty-printing formatting cleanup in pprintast
   (Ethan Aubin, suggestion by Gabriel Scherer, review by David Allsopp,
   Florian Angeletti, and Gabriel Scherer)

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -535,7 +535,7 @@ let rec transl_normal_path = function
 (* Translation of value identifiers *)
 
 let transl_path ?(loc=Location.none) env path =
-  transl_normal_path (Env.normalize_path (Some loc) env path)
+  transl_normal_path (Env.normalize_path_prefix (Some loc) env path)
 
 (* Compile a sequence of expressions *)
 

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -532,10 +532,19 @@ let rec transl_normal_path = function
   | Papply _ ->
       fatal_error "Lambda.transl_path"
 
-(* Translation of value identifiers *)
+(* Translation of identifiers *)
 
-let transl_path ?(loc=Location.none) env path =
+let transl_module_path ?(loc=Location.none) env path =
+  transl_normal_path (Env.normalize_path (Some loc) env path)
+
+let transl_value_path ?(loc=Location.none) env path =
   transl_normal_path (Env.normalize_path_prefix (Some loc) env path)
+
+let transl_class_path = transl_value_path
+let transl_extension_path = transl_value_path
+
+(* compatibility alias, deprecated in the .mli *)
+let transl_path = transl_value_path
 
 (* Compile a sequence of expressions *)
 

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -329,6 +329,13 @@ val free_methods: lambda -> IdentSet.t
 
 val transl_normal_path: Path.t -> lambda   (* Path.t is already normal *)
 val transl_path: ?loc:Location.t -> Env.t -> Path.t -> lambda
+[@@ocaml.deprecated "use transl_{module,value,extension,class}_path instead"]
+
+val transl_module_path: ?loc:Location.t -> Env.t -> Path.t -> lambda
+val transl_value_path: ?loc:Location.t -> Env.t -> Path.t -> lambda
+val transl_extension_path: ?loc:Location.t -> Env.t -> Path.t -> lambda
+val transl_class_path: ?loc:Location.t -> Env.t -> Path.t -> lambda
+
 val make_sequence: ('a -> lambda) -> 'a list -> lambda
 
 val subst_lambda: lambda Ident.tbl -> lambda -> lambda

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -2335,9 +2335,8 @@ let combine_constructor loc arg ex_pat cstr partial ctx def
             let tests =
               List.fold_right
                 (fun (path, act) rem ->
-                   Lifthenelse(Lprim(Pintcomp Ceq,
-                                     [Lvar tag;
-                                      transl_path ex_pat.pat_env path], loc),
+                   let ext = transl_extension_path ex_pat.pat_env path in
+                   Lifthenelse(Lprim(Pintcomp Ceq, [Lvar tag; ext], loc),
                                act, rem))
                 nonconsts
                 default
@@ -2346,8 +2345,8 @@ let combine_constructor loc arg ex_pat cstr partial ctx def
       in
         List.fold_right
           (fun (path, act) rem ->
-             Lifthenelse(Lprim(Pintcomp Ceq,
-                               [arg; transl_path ex_pat.pat_env path], loc),
+             let ext = transl_extension_path ex_pat.pat_env path in
+             Lifthenelse(Lprim(Pintcomp Ceq, [arg; ext], loc),
                          act, rem))
           consts
           nonconst_lambda

--- a/bytecomp/translclass.ml
+++ b/bytecomp/translclass.ml
@@ -268,7 +268,7 @@ let rec build_class_init cla cstr super inh_init cl_init msubst top cl =
     Tcl_ident ( path, _, _) ->
       begin match inh_init with
         (obj_init, _path')::inh_init ->
-          let lpath = transl_path ~loc:cl.cl_loc cl.cl_env path in
+          let lpath = transl_class_path ~loc:cl.cl_loc cl.cl_env path in
           (inh_init,
            Llet (Strict, Pgenval, obj_init,
                  mkappl(Lprim(Pfield 1, [lpath], Location.none), Lvar cla ::

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -64,7 +64,7 @@ let transl_extension_constructor env path ext =
          Lprim (prim_fresh_oo_id, [Lconst (Const_base (Const_int 0))], loc)],
         loc)
   | Text_rebind(path, _lid) ->
-      transl_path ~loc env path
+      transl_extension_path ~loc env path
 
 (* Translation of primitives *)
 
@@ -733,7 +733,7 @@ and transl_exp0 e =
   | Texp_ident(_, _, {val_kind = Val_anc _}) ->
       raise(Error(e.exp_loc, Free_super_var))
   | Texp_ident(path, _, {val_kind = Val_reg | Val_self _}) ->
-      transl_path ~loc:e.exp_loc e.exp_env path
+      transl_value_path ~loc:e.exp_loc e.exp_env path
   | Texp_ident _ -> fatal_error "Translcore.transl_exp: bad Texp_ident"
   | Texp_constant cst ->
       Lconst(Const_base cst)
@@ -888,13 +888,13 @@ and transl_exp0 e =
           end
       | Cstr_extension(path, is_const) ->
           if is_const then
-            transl_path e.exp_env path
+            transl_extension_path e.exp_env path
           else
             Lprim(Pmakeblock(0, Immutable, Some (Pgenval :: shape)),
-                  transl_path e.exp_env path :: ll, e.exp_loc)
+                  transl_extension_path e.exp_env path :: ll, e.exp_loc)
       end
   | Texp_extension_constructor (_, path) ->
-      transl_path e.exp_env path
+      transl_extension_path e.exp_env path
   | Texp_variant(l, arg) ->
       let tag = Btype.hash_variant l in
       begin match arg with
@@ -1008,7 +1008,7 @@ and transl_exp0 e =
   | Texp_new (cl, {Location.loc=loc}, _) ->
       Lapply{ap_should_be_tailcall=false;
              ap_loc=loc;
-             ap_func=Lprim(Pfield 0, [transl_path ~loc e.exp_env cl], loc);
+             ap_func=Lprim(Pfield 0, [transl_class_path ~loc e.exp_env cl], loc);
              ap_args=[lambda_unit];
              ap_inlined=Default_inline;
              ap_specialised=Default_specialise}
@@ -1353,7 +1353,7 @@ and transl_record loc env fields repres opt_init_expr =
               | Tconstr(p, _, _) -> p
               | _ -> assert false
             in
-            let slot = transl_path env path in
+            let slot = transl_extension_path env path in
             Lprim(Pmakeblock(0, mut, Some (Pgenval :: shape)), slot :: ll, loc)
     in
     begin match opt_init_expr with

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -354,7 +354,7 @@ let rec transl_module cc rootpath mexp =
       match mexp.mod_desc with
         Tmod_ident (path,_) ->
           apply_coercion loc Strict cc
-            (transl_path ~loc mexp.mod_env path)
+            (transl_module_path ~loc mexp.mod_env path)
       | Tmod_structure str ->
           fst (transl_struct loc [] cc rootpath str)
       | Tmod_functor(param, _, _, body) ->

--- a/testsuite/tests/typing-multifile/Makefile
+++ b/testsuite/tests/typing-multifile/Makefile
@@ -16,7 +16,7 @@
 BASEDIR=../..
 GENERATED= a.ml b.ml c.ml d.mli e.ml
 
-default: pr7325 pr6372
+default: pr7325 pr6372 pr7563
 
 pr7325:
 	@printf " ... testing pr7325:"
@@ -32,6 +32,15 @@ pr6372:
 	@echo "open D;; let f (C {f}) = ()" > e.ml
 	@$(OCAMLC) -c d.mli e.ml \
 	  && echo " => passed" || echo " => failed"
+
+pr7563:
+	@printf " ... testing pr7563:"
+	@echo "module A = struct end" > f.ml
+	@echo "module Alias = A" >> f.ml
+	@echo "exception Alias" >> f.ml
+	@echo "let alias = Alias" >> f.ml
+	@echo "exit (if F.Alias = F.alias then 0 else 1)" > g.ml
+	@$(OCAMLC) f.ml g.ml -o test && ./test && echo " => passed" || echo " => failed"
 
 clean: defaultclean
 	@rm -f $(GENERATED)


### PR DESCRIPTION
Original report in [PR#7563](https://caml.inria.fr/mantis/view.php?id=7563).

A repro case for the bug is the following:

f.ml:

```
module A = struct end
module Alias = A
exception Alias
let alias = Alias
```

g.ml:
```
print_endline (string_of_bool (F.Alias = F.alias))
```

This should print `true`, but on OCaml between 4.02.0 and the current trunk it prints `false`. This is because `F.Alias` is compiled by calling `transl_path`, which uses `Env.normalize_path` which, if I understand correctly, normalizes the whole path as if it was a module path -- but the last component is actually a constructor name! Using `normalize_path_prefix` avoid this, but not being familiar with the codebase I'm not sure that it is correct. @garrigue?
