### PR TITLE
PR#7565: expose the origin of universal type variable in error messages 

### DIFF
--- a/Changes
+++ b/Changes
@@ -240,6 +240,10 @@ Working version
 - PR#7543: short-paths printtyp can fail on packed type error messages
   (Florian Angeletti)
 
+- PR#7565: expand object and polymorphic variant types to expose
+  escaping universal type variables in error messages
+  (Florian Angeletti)
+
 - GPR#1155: Fix a race condition with WAIT_NOHANG on Windows
   (Jérémie Dimino and David Allsopp)
 

--- a/testsuite/tests/typing-misc/pr7565.ml
+++ b/testsuite/tests/typing-misc/pr7565.ml
@@ -58,3 +58,33 @@ Error: This expression has type 'b t = < f : 'b -> int >
        but an expression was expected of type t_a = < f : 'a. 'a -> int >
        The universal variable 'a would escape its scope
 |}]
+;;
+
+type y= <n:unit;e:unit;s:unit;t:unit;e':unit;d:unit>
+type x = <i:y;n:y;n':y;e:y;r:y>
+type h = <f:x;a:x;r:x;t:x;o:x;o':x;m:x;a':x;n:x;y:x;f':x;i:x;e:x;l:x;d:x;s:x>
+type t_a = <f: 'a. 'a -> h ; g:h -> unit >
+let f (o:t_a) = o # f 0
+
+let () =
+  let o =
+    object
+      method f _ = assert false
+      method g  _ = ()
+    end
+  in
+  f o;;
+[%%expect{|
+type y = < d : unit; e : unit; e' : unit; n : unit; s : unit; t : unit >
+type x = < e : y; i : y; n : y; n' : y; r : y >
+type h =
+    < a : x; a' : x; d : x; e : x; f : x; f' : x; i : x; l : x; m : x; n :
+      x; o : x; o' : x; r : x; s : x; t : x; y : x >
+type t_a = < f : 'a. 'a -> h; g : h -> unit >
+val f : t_a -> h = <fun>
+Line _, characters 4-5:
+Error: This expression has type < f : 'b -> 'c; g : 'd -> unit >
+       but an expression was expected of type
+         t_a = < f : 'a. 'a -> h; g : h -> unit >
+       The universal variable 'a would escape its scope
+|}];;

--- a/testsuite/tests/typing-misc/pr7565.ml
+++ b/testsuite/tests/typing-misc/pr7565.ml
@@ -1,0 +1,60 @@
+(** Test that object type are expanded in error message, when the error
+     message stems from an escaping universal type variable, cf MPR#7565 *)
+
+type t_a = <f: 'a. 'a -> int >
+let f (o:t_a) = o # f 0
+
+let () =
+  let o =
+    object
+      method f _ = 0
+    end
+  in
+  f o;;
+[%%expect{|
+type t_a = < f : 'a. 'a -> int >
+val f : t_a -> int = <fun>
+Line _, characters 4-5:
+Error: This expression has type < f : 'b -> int >
+       but an expression was expected of type t_a = < f : 'a. 'a -> int >
+       The universal variable 'a would escape its scope
+|}];;
+
+type uv = [ `A of <f: 'a. 'a -> int > ]
+let f (`A o:uv) = o # f 0
+
+let () =
+  let o =
+    `A (object
+      method f _ = 0
+    end)
+  in
+  f o;;
+[%%expect{|
+type uv = [ `A of < f : 'a. 'a -> int > ]
+val f : uv -> int = <fun>
+Line _, characters 4-5:
+Error: This expression has type [> `A of < f : 'b -> int > ]
+       but an expression was expected of type
+         uv = [ `A of < f : 'a. 'a -> int > ]
+       The universal variable 'a would escape its scope
+|}];;
+
+type 'a t = <f:'a -> int>
+let f (o:t_a) = o # f 0
+
+let () =
+  let o: _ t =
+    object
+      method f _ = 0
+    end
+  in
+  f o;;
+[%%expect{|
+type 'a t = < f : 'a -> int >
+val f : t_a -> int = <fun>
+Line _, characters 4-5:
+Error: This expression has type 'b t = < f : 'b -> int >
+       but an expression was expected of type t_a = < f : 'a. 'a -> int >
+       The universal variable 'a would escape its scope
+|}]


### PR DESCRIPTION
[Mantis:7565](https://caml.inria.fr/mantis/view.php?id=7565):

Error message for escaping universal type variables may display universal type variables of which the origin may be unclear to the user. For instance,

```OCaml
type uv = [ `A of <f: 'a. 'a -> int > ]
type 'a v = [ `A of <f: 'a -> int > ]
let f (`A o:uv) = o # f 0
let () = f ( `A (object method f _ = 0 end): _ v);;
```
yields the following error messages:
```
Error: This expression has type 'a v but an expression was expected of type uv
        The universal variable 'a0 would escape its scope 
```
In this error message, the origin of the escaping universal variable `'a0` is not clear. Even more so since the type name `'a0` does not appear directly anywhere in the code.

To make this error easier to read, this PR proposes to expand object and polymorphic variants types whenever they are involved in a escaping universal type variable error message. This expansion transforms the previous error message into:
```
Error: This expression has type 'b v = [ `A of < f : 'b -> int > ]
        but an expression was expected of type
          uv = [ `A of < f : 'a. 'a -> int > ]
        The universal variable 'a would escape its scope
```

The first commit in this PR is a refactoring commit that adds a concrete type for unification conflict explanation in `typing/printtyp.ml`, I can scrap these changes if requested.

The second commit implements the type expansion itself by checking in Printtyp.may_prepare_expansion
if we are currently printing an error message for an escaping universal error and expanding objects and polymorphic variants in this case.