### PR TITLE
Improve compilation of short-circuit operators

### DIFF
--- a/Changes
+++ b/Changes
@@ -68,13 +68,17 @@ Working version
   attributes on such functors; mark functor coercion veneers as
   stubs.
   (Mark Shinwell, review by Pierre Chambart and Leo White)
+
+- GPR#1215: Improve compilation of short-circuit operators
+  (Leo White, review by Frédéric Bour and Mark Shinwell)
+
+- GPR#1250: illegal ARM64 assembly code generated for large combined allocations
+  (report and initial fix by Steve Walk, review and final fix by Xavier Leroy)
+
 - GPR#1271: Don't generate Ialloc instructions for closures that exceed
   Max_young_wosize; instead allocate them on the major heap.  (Related
   to GPR#1250.)
   (Mark Shinwell)
-
-- GPR#1250: illegal ARM64 assembly code generated for large combined allocations
-  (report and initial fix by Steve Walk, review and final fix by Xavier Leroy)
 
 ### Standard library:
 

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -262,12 +262,44 @@ let untag_int i dbg =
   | Cop(Cor, [c; Cconst_int 1], _) -> Cop(Casr, [c; Cconst_int 1], dbg)
   | c -> Cop(Casr, [c; Cconst_int 1], dbg)
 
-let if_then_else (cond, ifso, ifnot) =
+(* Approximation of the "then" and "else" continuations in [transl_if] *)
+type then_else_approx =
+  | Cond (* then => true, else => false *)
+  | NotCond (* then => false, else => true *)
+  | Unknown
+
+let invert_then_else = function
+  | Cond -> NotCond
+  | NotCond -> Cond
+  | Unknown -> Unknown
+
+let mk_if_then_else cond ifso ifnot =
   match cond with
   | Cconst_int 0 -> ifnot
   | Cconst_int 1 -> ifso
   | _ ->
     Cifthenelse(cond, ifso, ifnot)
+
+let mk_not dbg cmm =
+  match cmm with
+  | Cop(Caddi, [Cop(Clsl, [c; Cconst_int 1], _); Cconst_int 1], _) -> begin
+      match c with
+      | Cop(Ccmpi cmp, [c1; c2], dbg') ->
+          tag_int (Cop(Ccmpi (negate_comparison cmp), [c1; c2], dbg')) dbg
+      | Cop(Ccmpa cmp, [c1; c2], dbg') ->
+          tag_int (Cop(Ccmpa (negate_comparison cmp), [c1; c2], dbg')) dbg
+      | Cop(Ccmpf cmp, [c1; c2], dbg') ->
+          tag_int (Cop(Ccmpf (negate_comparison cmp), [c1; c2], dbg')) dbg
+      | _ ->
+        (* 0 -> 3, 1 -> 1 *)
+        Cop(Csubi, [Cconst_int 3; Cop(Clsl, [c; Cconst_int 1], dbg)], dbg)
+    end
+  | Cconst_int 3 -> Cconst_int 1
+  | Cconst_int 1 -> Cconst_int 3
+  | c ->
+      (* 1 -> 3, 3 -> 1 *)
+      Cop(Csubi, [Cconst_int 4; c], dbg)
+
 
 (* Turning integer divisions into multiply-high then shift.
    The [division_parameters] function is used in module Emit for
@@ -1828,43 +1860,10 @@ let rec transl env e =
       ccatch(nfail, ids, transl env body, transl env handler)
   | Utrywith(body, exn, handler) ->
       Ctrywith(transl env body, exn, transl env handler)
-  | Uifthenelse(Uprim(Pnot, [arg], _), ifso, ifnot) ->
-      transl env (Uifthenelse(arg, ifnot, ifso))
-  | Uifthenelse(cond, ifso, Ustaticfail (nfail, [])) ->
-      let dbg = Debuginfo.none in
-      exit_if_false dbg env cond (transl env ifso) nfail
-  | Uifthenelse(cond, Ustaticfail (nfail, []), ifnot) ->
-      let dbg = Debuginfo.none in
-      exit_if_true dbg env cond nfail (transl env ifnot)
-  | Uifthenelse(Uprim(Psequand, _, dbg) as cond, ifso, ifnot) ->
-      let raise_num = next_raise_count () in
-      make_catch
-        raise_num
-        (exit_if_false dbg env cond (transl env ifso) raise_num)
-        (transl env ifnot)
-  | Uifthenelse(Uprim(Psequor, _, dbg) as cond, ifso, ifnot) ->
-      let raise_num = next_raise_count () in
-      make_catch
-        raise_num
-        (exit_if_true dbg env cond raise_num (transl env ifnot))
-        (transl env ifso)
-  | Uifthenelse (Uifthenelse (cond, condso, condnot), ifso, ifnot) ->
-      let dbg = Debuginfo.none in
-      let num_true = next_raise_count () in
-      make_catch
-        num_true
-        (make_catch2
-           (fun shared_false ->
-             if_then_else
-               (test_bool dbg (transl env cond),
-                exit_if_true dbg env condso num_true shared_false,
-                exit_if_true dbg env condnot num_true shared_false))
-           (transl env ifnot))
-        (transl env ifso)
   | Uifthenelse(cond, ifso, ifnot) ->
       let dbg = Debuginfo.none in
-      if_then_else(test_bool dbg (transl env cond), transl env ifso,
-        transl env ifnot)
+      transl_if dbg env cond Unknown
+        (transl env ifso) (transl env ifnot)
   | Usequence(exp1, exp2) ->
       Csequence(remove_unit(transl env exp1), transl env exp2)
   | Uwhile(cond, body) ->
@@ -1873,8 +1872,9 @@ let rec transl env e =
       return_unit
         (ccatch
            (raise_num, [],
-            Cloop(exit_if_false dbg env cond
-                    (remove_unit(transl env body)) raise_num),
+            Cloop(transl_if dbg env cond Unknown
+                    (remove_unit(transl env body))
+                    (Cexit (raise_num,[]))),
             Ctuple []))
   | Ufor(id, low, high, dir, body) ->
       let dbg = Debuginfo.none in
@@ -2052,7 +2052,8 @@ and transl_prim_1 env p arg dbg =
       end
   (* Boolean operations *)
   | Pnot ->
-      Cop(Csubi, [Cconst_int 4; transl env arg], dbg) (* 1 -> 3, 3 -> 1 *)
+      transl_if dbg env arg NotCond
+        (Cconst_pointer 1) (Cconst_pointer 3)
   (* Test integer/block *)
   | Pisint ->
       tag_int(Cop(Cand, [transl env arg; Cconst_int 1], dbg)) dbg
@@ -2113,15 +2114,14 @@ and transl_prim_2 env p arg1 arg2 dbg =
 
   (* Boolean operations *)
   | Psequand ->
-      if_then_else(test_bool dbg (transl env arg1),
-        transl env arg2, Cconst_int 1)
+      transl_sequand dbg env arg1 arg2 Cond
+        (Cconst_pointer 3) (Cconst_pointer 1)
       (* let id = Ident.create "res1" in
       Clet(id, transl env arg1,
            Cifthenelse(test_bool dbg (Cvar id), transl env arg2, Cvar id)) *)
   | Psequor ->
-      if_then_else(test_bool dbg (transl env arg1),
-        Cconst_int 3, transl env arg2)
-
+      transl_sequor dbg env arg1 arg2 Cond
+        (Cconst_pointer 3) (Cconst_pointer 1)
   (* Integer operations *)
   | Paddint ->
       decr_int(add_int (transl env arg1) (transl env arg2) dbg) dbg
@@ -2631,88 +2631,75 @@ and make_catch ncatch body handler = match body with
 | Cexit (nexit,[]) when nexit=ncatch -> handler
 | _ ->  ccatch (ncatch, [], body, handler)
 
-and make_catch2 mk_body handler = match handler with
-| Cexit (_,[])|Ctuple []|Cconst_int _|Cconst_pointer _ ->
-    mk_body handler
-| _ ->
+and is_shareable_cont exp =
+  match exp with
+  | Cexit (_,[]) -> true
+  | _ -> false
+
+and make_shareable_cont mk exp =
+  if is_shareable_cont exp then mk exp
+  else begin
     let nfail = next_raise_count () in
     make_catch
       nfail
-      (mk_body (Cexit (nfail,[])))
-      handler
+      (mk (Cexit (nfail,[])))
+      exp
+  end
 
-and exit_if_true dbg env cond nfail otherwise =
+and transl_if dbg env cond approx then_ else_ =
   match cond with
-  | Uconst (Uconst_ptr 0) -> otherwise
-  | Uconst (Uconst_ptr 1) -> Cexit (nfail,[])
-  | Uifthenelse (arg1, Uconst (Uconst_ptr 1), arg2)
-  | Uprim(Psequor, [arg1; arg2], _) ->
-      (* CR-someday pchambart: Since Uifthenelse does not have a debuginfo,
-         this pattern cannot be written to propagate the Psequor operation
-         location. Should it do that ?
-         This also applies to the following pattern for Psequand and the
-         instances in exit_if_false *)
-      exit_if_true dbg env arg1 nfail
-        (exit_if_true dbg env arg2 nfail otherwise)
-  | Uifthenelse (_, _, Uconst (Uconst_ptr 0))
-  | Uprim(Psequand, _, _) ->
-      begin match otherwise with
-      | Cexit (raise_num,[]) ->
-          exit_if_false dbg env cond (Cexit (nfail,[])) raise_num
-      | _ ->
-          let raise_num = next_raise_count () in
-          make_catch
-            raise_num
-            (exit_if_false dbg env cond (Cexit (nfail,[])) raise_num)
-            otherwise
-      end
-  | Uprim(Pnot, [arg], _) ->
-      exit_if_false dbg env arg otherwise nfail
-  | Uifthenelse (cond, ifso, ifnot) ->
-      make_catch2
-        (fun shared ->
-          if_then_else
-            (test_bool dbg (transl env cond),
-             exit_if_true dbg env ifso nfail shared,
-             exit_if_true dbg env ifnot nfail shared))
-        otherwise
-  | _ ->
-      if_then_else(test_bool dbg (transl env cond),
-        Cexit (nfail, []), otherwise)
-
-and exit_if_false dbg env cond otherwise nfail =
-  match cond with
-  | Uconst (Uconst_ptr 0) -> Cexit (nfail,[])
-  | Uconst (Uconst_ptr 1) -> otherwise
+  | Uconst (Uconst_ptr 0) -> else_
+  | Uconst (Uconst_ptr 1) -> then_
   | Uifthenelse (arg1, arg2, Uconst (Uconst_ptr 0))
   | Uprim(Psequand, [arg1; arg2], _) ->
-      exit_if_false dbg env arg1
-        (exit_if_false dbg env arg2 otherwise nfail) nfail
-  | Uifthenelse (_, Uconst (Uconst_ptr 1), _)
-  | Uprim(Psequor, _, _) ->
-      begin match otherwise with
-      | Cexit (raise_num,[]) ->
-          exit_if_true dbg env cond raise_num (Cexit (nfail,[]))
-      | _ ->
-          let raise_num = next_raise_count () in
-          make_catch
-            raise_num
-            (exit_if_true dbg env cond raise_num (Cexit (nfail,[])))
-            otherwise
-      end
+      transl_sequand dbg env arg1 arg2 approx then_ else_
+  | Uifthenelse (arg1, Uconst (Uconst_ptr 1), arg2)
+  | Uprim(Psequor, [arg1; arg2], _) ->
+      transl_sequor dbg env arg1 arg2 approx then_ else_
   | Uprim(Pnot, [arg], _) ->
-      exit_if_true dbg env arg nfail otherwise
+      transl_if dbg env arg (invert_then_else approx) else_ then_
+  | Uifthenelse (Uconst (Uconst_ptr 1), ifso, _) ->
+      transl_if dbg env ifso approx then_ else_
+  | Uifthenelse (Uconst (Uconst_ptr 0), _, ifnot) ->
+      transl_if dbg env ifnot approx then_ else_
   | Uifthenelse (cond, ifso, ifnot) ->
-      make_catch2
-        (fun shared ->
-          if_then_else
-            (test_bool dbg (transl env cond),
-             exit_if_false dbg env ifso shared nfail,
-             exit_if_false dbg env ifnot shared nfail))
-        otherwise
-  | _ ->
-      if_then_else (test_bool dbg (transl env cond), otherwise,
-        Cexit (nfail, []))
+      make_shareable_cont
+        (fun shareable_then ->
+           make_shareable_cont
+             (fun shareable_else ->
+                mk_if_then_else
+                  (test_bool dbg (transl env cond))
+                  (transl_if dbg env ifso approx
+                     shareable_then shareable_else)
+                  (transl_if dbg env ifnot approx
+                     shareable_then shareable_else))
+             else_)
+        then_
+  | _ -> begin
+      match approx with
+      | Cond ->
+          transl env cond
+      | NotCond ->
+          mk_not dbg (transl env cond)
+      | Unknown ->
+          mk_if_then_else (test_bool dbg (transl env cond)) then_ else_
+    end
+
+and transl_sequand dbg env arg1 arg2 approx then_ else_ =
+  make_shareable_cont
+    (fun shareable_else ->
+       transl_if dbg env arg1 Unknown
+         (transl_if dbg env arg2 approx then_ shareable_else)
+         shareable_else)
+    else_
+
+and transl_sequor dbg env arg1 arg2 approx then_ else_ =
+  make_shareable_cont
+    (fun shareable_then ->
+       transl_if dbg env arg1 Unknown
+         shareable_then
+         (transl_if dbg env arg2 approx shareable_then else_))
+    then_
 
 and transl_switch loc env arg index cases = match Array.length cases with
 | 0 -> fatal_error "Cmmgen.transl_switch"

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -262,15 +262,19 @@ let untag_int i dbg =
   | Cop(Cor, [c; Cconst_int 1], _) -> Cop(Casr, [c; Cconst_int 1], dbg)
   | c -> Cop(Casr, [c; Cconst_int 1], dbg)
 
-(* Approximation of the "then" and "else" continuations in [transl_if] *)
-type then_else_approx =
-  | Cond (* then => true, else => false *)
-  | NotCond (* then => false, else => true *)
+(* Description of the "then" and "else" continuations in [transl_if]. If
+   the "then" continuation is true and the "else" continuation is false then
+   we can use the condition directly as the result. Similarly, if the "then"
+   continuation is false and the "else" continuation is true then we can use
+   the negation of the condition directly as the result. *)
+type then_else =
+  | Then_true_else_false
+  | Then_false_else_true
   | Unknown
 
 let invert_then_else = function
-  | Cond -> NotCond
-  | NotCond -> Cond
+  | Then_true_else_false -> Then_false_else_true
+  | Then_false_else_true -> Then_true_else_false
   | Unknown -> Unknown
 
 let mk_if_then_else cond ifso ifnot =
@@ -2052,7 +2056,7 @@ and transl_prim_1 env p arg dbg =
       end
   (* Boolean operations *)
   | Pnot ->
-      transl_if env arg dbg NotCond
+      transl_if env arg dbg Then_false_else_true
         (Cconst_pointer 1) (Cconst_pointer 3)
   (* Test integer/block *)
   | Pisint ->
@@ -2115,14 +2119,14 @@ and transl_prim_2 env p arg1 arg2 dbg =
   (* Boolean operations *)
   | Psequand ->
       let dbg' = Debuginfo.none in
-      transl_sequand env arg1 dbg arg2 dbg' Cond
+      transl_sequand env arg1 dbg arg2 dbg' Then_true_else_false
         (Cconst_pointer 3) (Cconst_pointer 1)
       (* let id = Ident.create "res1" in
       Clet(id, transl env arg1,
            Cifthenelse(test_bool dbg (Cvar id), transl env arg2, Cvar id)) *)
   | Psequor ->
       let dbg' = Debuginfo.none in
-      transl_sequor env arg1 dbg arg2 dbg' Cond
+      transl_sequor env arg1 dbg arg2 dbg' Then_true_else_false
         (Cconst_pointer 3) (Cconst_pointer 1)
   (* Integer operations *)
   | Paddint ->
@@ -2683,9 +2687,9 @@ and transl_if env cond dbg approx then_ else_ =
         then_
   | _ -> begin
       match approx with
-      | Cond ->
+      | Then_true_else_false ->
           transl env cond
-      | NotCond ->
+      | Then_false_else_true ->
           mk_not dbg (transl env cond)
       | Unknown ->
           mk_if_then_else (test_bool dbg (transl env cond)) then_ else_

--- a/middle_end/closure_conversion.ml
+++ b/middle_end/closure_conversion.ml
@@ -395,7 +395,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let arg2 = close t env arg2 in
     let const_true = Variable.create "const_true" in
     let cond = Variable.create "cond_sequor" in
-    Flambda.create_let const_true (Const (Int 1))
+    Flambda.create_let const_true (Const (Const_pointer 1))
       (Flambda.create_let cond (Expr arg1)
         (If_then_else (cond, Var const_true, arg2)))
   | Lprim (Psequand, [arg1; arg2], _) ->
@@ -403,7 +403,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
     let arg2 = close t env arg2 in
     let const_false = Variable.create "const_false" in
     let cond = Variable.create "cond_sequand" in
-    Flambda.create_let const_false (Const (Int 0))
+    Flambda.create_let const_false (Const (Const_pointer 0))
       (Flambda.create_let cond (Expr arg1)
         (If_then_else (cond, arg2, Var const_false)))
   | Lprim ((Psequand | Psequor), _, _) ->


### PR DESCRIPTION
The compiler optimises short-circuit operations in if conditions. For example:

```ocaml
let foo x y =
  if (x > 4 && not (x < 10)) || (y > 3 && not (y < 9)) then
    x
  else
    0
```

gets compiled to the following code (from `-dlinear`):

```
camlFoo__foo_1002:
  if x/29[%rax] <=s 9 goto L101
  if x/29[%rax] >=s 21 goto L100
  L101:
  if y/30[%rbx] <=s 7 goto L102
  if y/30[%rbx] >=s 19 goto L100
  L102:
  I/31[%rax] := 1
  return R/0[%rax]
  L100:
  return R/0[%rax]
```

However, these optimisations are not applied for short-circuit operators outside of if conditions. For example:

```ocaml
let bar x y =
  (x > 4 && not (x < 10)) || (y > 3 && not (y < 9))
```

gets compiled to:

```
camlFoo__bar_1005:
  if x/29[%rax] <=s 9 goto L107
  I/31[%rax] := x/29[%rax] <s 21
  I/32[%rax] := I/31[%rax]  * 2 + 1
  I/33[%rdi] := 4
  I/34[%rdi] := I/34[%rdi] - I/32[%rax]
  goto L106
  L107:
  I/35[%rdi] := 1
  L106:
  if I/34[%rdi] ==s 1 goto L105
  I/41[%rax] := 3
  return R/0[%rax]
  L105:
  if y/30[%rbx] <=s 7 goto L104
  I/37[%rax] := y/30[%rbx] <s 19
  I/38[%rbx] := I/37[%rax]  * 2 + 1
  I/39[%rax] := 4
  I/40[%rax] := I/40[%rax] - I/38[%rbx]
  return R/0[%rax]
  L104:
  I/36[%rax] := 1
  return R/0[%rax]
```

This PR tidies up these optimisations and applies them to all short-circuit operations (and `not`). `foo` is compiled as before, but `bar` is now compiled to:

```
camlFoo__bar_1005:
  if x/29[%rax] <=s 9 goto L105
  if x/29[%rax] >=s 21 goto L104
  L105:
  if y/30[%rbx] <=s 7 goto L106
  I/31[%rax] := y/30[%rbx] >=s 19
  I/32[%rax] := I/31[%rax]  * 2 + 1
  return R/0[%rax]
  L106:
  V/33[%rax] := 1
  return R/0[%rax]
  L104:
  V/34[%rax] := 3
  return R/0[%rax]
```

With flambda turned on these optimisations were broken both inside and outside of if conditions. For example, the `foo` function above would produce:

```
camlFoo__foo_7:
  x_10/29[%rdi] := R/0[%rax]
  if x_10/29[%rdi] <=s 9 goto L103
  I/31[%rax] := x_10/29[%rdi] <s 21
  I/32[%rax] := I/31[%rax]  * 2 + 1
  I/33[%rsi] := 4
  I/34[%rsi] := I/34[%rsi] - I/32[%rax]
  goto L102
  L103:
  I/35[%rsi] := 1
  L102:
  if I/34[%rsi] !=s 1 goto L100
  if y_9/30[%rbx] <=s 7 goto L101
  if y_9/30[%rbx] >=s 19 goto L100
  I/37[%rax] := 1
  return R/0[%rax]
  L101:
  I/36[%rax] := 1
  return R/0[%rax]
  L100:
  R/0[%rax] := x_10/29[%rdi]
  return R/0[%rax]
```

with this PR it produces the same code as the non-flambda compiler.