### PR TITLE
Restrict Unix.environment in privileged contexts; add Unix.unsafe_environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,7 +186,6 @@
 /otherlibs/win32unix/chmod.c
 /otherlibs/win32unix/cst2constr.c
 /otherlibs/win32unix/cstringv.c
-/otherlibs/win32unix/envir.c
 /otherlibs/win32unix/execv.c
 /otherlibs/win32unix/execve.c
 /otherlibs/win32unix/execvp.c

--- a/Changes
+++ b/Changes
@@ -46,6 +46,11 @@ Working version
 
 ### Standard library:
 
+- GPR#1217: Restrict Unix.environment in privileged contexts; add
+  Unix.unsafe_environment.
+  (Jeremy Yallop, review by Mark Shinwell, Nicolas Ojeda Bar,
+  Damien Doligez and Hannes Mehnert)
+
 - GRP#1119: Change Set (private) type to inline records.
   (Albin Coquereau)
 

--- a/configure
+++ b/configure
@@ -1503,6 +1503,12 @@ if sh ./hasgot accept4; then
   echo "#define HAS_ACCEPT4" >> s.h
 fi
 
+if sh ./hasgot getauxval; then
+  inf "getauxval() found."
+  echo "#define HAS_GETAUXVAL" >> s.h
+fi
+
+
 # Determine if the debugger is supported
 
 if test -n "$with_debugger"; then

--- a/otherlibs/threads/unix.ml
+++ b/otherlibs/threads/unix.ml
@@ -159,6 +159,7 @@ let handle_unix_error f arg =
     exit 2
 
 external environment : unit -> string array = "unix_environment"
+external unsafe_environment : unit -> string array = "unix_environment_unsafe"
 external getenv: string -> string = "caml_sys_getenv"
 external unsafe_getenv: string -> string = "caml_sys_unsafe_getenv"
 external putenv: string -> string -> unit = "unix_putenv"

--- a/otherlibs/unix/envir.c
+++ b/otherlibs/unix/envir.c
@@ -19,6 +19,9 @@
 #include <unistd.h>
 #endif
 #include <sys/types.h>
+#ifdef HAS_GETAUXVAL
+#include <sys/auxv.h>
+#endif
 
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
@@ -36,7 +39,12 @@ CAMLprim value unix_environment_unsafe(value unit)
 
 static char **secure_environ(void)
 {
-#if defined(HAS_ISSETUGID)
+#ifdef HAS_GETAUXVAL
+  if (!getauxval(AT_SECURE))
+    return environ;
+  else
+   return NULL;
+#elif defined(HAS_ISSETUGID)
   if (!issetugid ())
     return environ;
   else

--- a/otherlibs/unix/envir.c
+++ b/otherlibs/unix/envir.c
@@ -28,6 +28,15 @@
 extern char ** environ;
 #endif
 
+CAMLprim value unix_environment_unsafe(value unit)
+{
+  if (environ != NULL) {
+    return caml_copy_string_array((const char**)environ);
+  } else {
+    return Atom(0);
+  }
+}
+
 static char **secure_environ(void)
 {
 #if defined(HAS_ISSETUGID)

--- a/otherlibs/unix/envir.c
+++ b/otherlibs/unix/envir.c
@@ -13,17 +13,41 @@
 /*                                                                        */
 /**************************************************************************/
 
+#include "caml/config.h"
+
+#ifdef HAS_UNISTD
+#include <unistd.h>
+#endif
+#include <sys/types.h>
+
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
+#include "unixsupport.h"
 
 #ifndef _WIN32
 extern char ** environ;
 #endif
 
+static char **secure_environ(void)
+{
+#if defined(HAS_ISSETUGID)
+  if (!issetugid ())
+    return environ;
+  else
+    return NULL;
+#else
+  if (geteuid () == getuid () && getegid () == getgid ())
+    return environ;
+  else
+    return NULL;
+#endif
+}
+
 CAMLprim value unix_environment(value unit)
 {
-  if (environ != NULL) {
-    return caml_copy_string_array((const char**)environ);
+  char **e = secure_environ();
+  if (e != NULL) {
+    return caml_copy_string_array((const char**)e);
   } else {
     return Atom(0);
   }

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -186,6 +186,7 @@ let handle_unix_error f arg =
     exit 2
 
 external environment : unit -> string array = "unix_environment"
+external unsafe_environment : unit -> string array = "unix_environment_unsafe"
 external getenv: string -> string = "caml_sys_getenv"
 external unsafe_getenv: string -> string = "caml_sys_unsafe_getenv"
 external putenv: string -> string -> unit = "unix_putenv"

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -124,6 +124,15 @@ val environment : unit -> string array
     with the format ``variable=value''.  The returned array
     is empty if the process has special privileges. *)
 
+val unsafe_environment : unit -> string array
+(** Return the process environment, as an array of strings with the
+    format ``variable=value''.  Unlike {!environment}, this function
+    returns a populated array even if the process has special
+    privileges.  See the documentation for {!unsafe_getenv} for more
+    details.
+
+    @since 4.06.0 *)
+
 val getenv : string -> string
 (** Return the value associated to a variable in the process
    environment, unless the process has special privileges.

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -121,7 +121,8 @@ val handle_unix_error : ('a -> 'b) -> 'a -> 'b
 
 val environment : unit -> string array
 (** Return the process environment, as an array of strings
-    with the format ``variable=value''. *)
+    with the format ``variable=value''.  The returned array
+    is empty if the process has special privileges. *)
 
 val getenv : string -> string
 (** Return the value associated to a variable in the process

--- a/otherlibs/win32unix/Makefile
+++ b/otherlibs/win32unix/Makefile
@@ -19,7 +19,7 @@
 
 # Files in this directory
 WIN_FILES = accept.c bind.c channels.c close.c \
-  close_on.c connect.c createprocess.c dup.c dup2.c errmsg.c \
+  close_on.c connect.c createprocess.c dup.c dup2.c errmsg.c envir.c \
   getpeername.c getpid.c getsockname.c gettimeofday.c \
   link.c listen.c lockf.c lseek.c nonblock.c \
   mkdir.c mmap.c open.c pipe.c read.c readlink.c rename.c \
@@ -30,7 +30,7 @@ WIN_FILES = accept.c bind.c channels.c close.c \
 
 # Files from the ../unix directory
 UNIX_FILES = access.c addrofstr.c chdir.c chmod.c cst2constr.c \
-  cstringv.c envir.c execv.c execve.c execvp.c \
+  cstringv.c execv.c execve.c execvp.c \
   exit.c getaddrinfo.c getcwd.c gethost.c gethostname.c \
   getnameinfo.c getproto.c \
   getserv.c gmtime.c mmap_ba.c putenv.c rmdir.c \

--- a/otherlibs/win32unix/envir.c
+++ b/otherlibs/win32unix/envir.c
@@ -13,47 +13,14 @@
 /*                                                                        */
 /**************************************************************************/
 
-#include <caml/config.h>
-
-#ifdef HAS_UNISTD
-#include <unistd.h>
-#endif
-#include <sys/types.h>
-
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 
-extern char ** environ;
-
-CAMLprim value unix_environment_unsafe(value unit)
-{
-  if (environ != NULL) {
-    return caml_copy_string_array((const char**)environ);
-  } else {
-    return Atom(0);
-  }
-}
-
-static char **secure_environ(void)
-{
-#if defined(HAS_ISSETUGID)
-  if (!issetugid ())
-    return environ;
-  else
-    return NULL;
-#else
-  if (geteuid () == getuid () && getegid () == getgid ())
-    return environ;
-  else
-    return NULL;
-#endif
-}
-
 CAMLprim value unix_environment(value unit)
 {
-  char **e = secure_environ();
-  if (e != NULL) {
-    return caml_copy_string_array((const char**)e);
+  /* Win32 doesn't have a notion of setuid bit, so accessing environ is safe. */
+  if (environ != NULL) {
+    return caml_copy_string_array((const char**)environ);
   } else {
     return Atom(0);
   }

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -121,7 +121,8 @@ let handle_unix_error f arg =
     exit 2
 
 external environment : unit -> string array = "unix_environment"
-external unsafe_environment : unit -> string array = "unix_environment_unsafe"
+(* On Win32 environment access is always considered safe. *)
+let unsafe_environment = environment
 external getenv: string -> string = "caml_sys_getenv"
 external unsafe_getenv: string -> string = "caml_sys_unsafe_getenv"
 external putenv: string -> string -> unit = "unix_putenv"

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -121,6 +121,7 @@ let handle_unix_error f arg =
     exit 2
 
 external environment : unit -> string array = "unix_environment"
+external unsafe_environment : unit -> string array = "unix_environment_unsafe"
 external getenv: string -> string = "caml_sys_getenv"
 external unsafe_getenv: string -> string = "caml_sys_unsafe_getenv"
 external putenv: string -> string -> unit = "unix_putenv"


### PR DESCRIPTION
Background / related:
* Mantis issue: [local privilege escalation issue with ocaml binaries](https://caml.inria.fr/mantis/view.php?id=7557)
* Commit: [Add Unix.unsafe_getenv.](b38b008d88)
* PR: [Some tweaks for MPR#7557](https://github.com/ocaml/ocaml/pull/1213)