### PR TITLE
Add expm1_over_x.

### DIFF
--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -507,6 +507,16 @@ CAMLexport double caml_expm1(double x)
 #endif
 }
 
+CAMLexport double caml_expm1_over_x(double x)
+{
+  double u = exp(x);
+  if (u == 1.)
+    return 1;
+  if (u - 1. == -1.)
+    return -1. / x;
+  return (u - 1.) / log(u);
+}
+
 CAMLexport double caml_log1p(double x)
 {
 #ifdef HAS_C99_FLOAT_OPS
@@ -523,6 +533,11 @@ CAMLexport double caml_log1p(double x)
 CAMLprim value caml_expm1_float(value f)
 {
   return caml_copy_double(caml_expm1(Double_val(f)));
+}
+
+CAMLprim value caml_expm1_over_x_float(value f)
+{
+  return caml_copy_double(caml_expm1_over_x(Double_val(f)));
 }
 
 CAMLprim value caml_log1p_float(value f)

--- a/otherlibs/threads/pervasives.ml
+++ b/otherlibs/threads/pervasives.ml
@@ -119,6 +119,8 @@ external ( ** ) : float -> float -> float = "caml_power_float" "pow"
 external exp : float -> float = "caml_exp_float" "exp" [@@unboxed] [@@noalloc]
 external expm1 : float -> float = "caml_expm1_float" "caml_expm1"
   [@@unboxed] [@@noalloc]
+external expm1_over_x : float -> float =
+  "caml_expm1_over_x_float" "caml_expm1_over_x" [@@unboxed] [@@noalloc]
 external acos : float -> float = "caml_acos_float" "acos"
   [@@unboxed] [@@noalloc]
 external asin : float -> float = "caml_asin_float" "asin"

--- a/stdlib/pervasives.ml
+++ b/stdlib/pervasives.ml
@@ -115,6 +115,8 @@ external ( ** ) : float -> float -> float = "caml_power_float" "pow"
 external exp : float -> float = "caml_exp_float" "exp" [@@unboxed] [@@noalloc]
 external expm1 : float -> float = "caml_expm1_float" "caml_expm1"
   [@@unboxed] [@@noalloc]
+external expm1_over_x : float -> float =
+  "caml_expm1_over_x_float" "caml_expm1_over_x" [@@unboxed] [@@noalloc]
 external acos : float -> float = "caml_acos_float" "acos"
   [@@unboxed] [@@noalloc]
 external asin : float -> float = "caml_asin_float" "asin"

--- a/stdlib/pervasives.mli
+++ b/stdlib/pervasives.mli
@@ -408,8 +408,9 @@ external expm1 : float -> float = "caml_expm1_float" "caml_expm1"
 
 external expm1_over_x : float -> float =
   "caml_expm1_over_x_float" "caml_expm1_over_x" [@@unboxed] [@@noalloc]
-(** [expm1 x] computes [(exp x -. 1.0) / x], giving numerically-accurate
-    results even if [x] is close to [0.0].
+(** [expm1_over_x x] computes [(exp x -. 1.0) / x],
+    giving numerically-accurate results even if [x] is close to [0.0].
+    @since 4.05.0
  *)
 
 external log1p : float -> float = "caml_log1p_float" "caml_log1p"

--- a/stdlib/pervasives.mli
+++ b/stdlib/pervasives.mli
@@ -406,6 +406,12 @@ external expm1 : float -> float = "caml_expm1_float" "caml_expm1"
     @since 3.12.0
 *)
 
+external expm1_over_x : float -> float =
+  "caml_expm1_over_x_float" "caml_expm1_over_x" [@@unboxed] [@@noalloc]
+(** [expm1 x] computes [(exp x -. 1.0) / x], giving numerically-accurate
+    results even if [x] is close to [0.0].
+ *)
+
 external log1p : float -> float = "caml_log1p_float" "caml_log1p"
   [@@unboxed] [@@noalloc]
 (** [log1p x] computes [log(1.0 +. x)] (natural logarithm),


### PR DESCRIPTION
The function `expm1` exists to give accurate values of `exp x - 1` when `x` is small. to avoid the loss of precision from the naive expression `(1+  x + x*x/2 + ...) - 1`.
An implementation is provided in byterun/floats.c.

Using the implementation chosen, one can also get an implementation of the function `(exp x - 1) / x)`.