### PR TITLE
Fix "-keep-docs" option in ocamlopt manpage

### DIFF
--- a/Changes
+++ b/Changes
@@ -132,6 +132,9 @@ Working version
 - GPR#1187: Minimal documentation for compiler plugins
   (Florian Angeletti)
 
+- GPR#1220: Fix "-keep-docs" option in ocamlopt manpage
+  (Etienne Millon)
+
 ### Tools:
 
 - GPR#1078: add a subcommand "-depend" to "ocamlc" and "ocamlopt",

--- a/man/ocamlopt.m
+++ b/man/ocamlopt.m
@@ -333,7 +333,7 @@ Recognize file names ending with
 .I string
 as interface files (instead of the default .mli).
 .TP
-.B \-keep-locs
+.B \-keep-docs
 Keep documentation strings in generated .cmi files.
 .TP
 .B \-keep-locs


### PR DESCRIPTION
It was a duplicate of `-keep-locs` below.

Thanks!