### PR TITLE
Remove trailing semicolon in printed record declaration

### DIFF
--- a/testsuite/tests/tool-ocamldoc-html/type_Linebreaks.reference
+++ b/testsuite/tests/tool-ocamldoc-html/type_Linebreaks.reference
@@ -15,7 +15,7 @@
 <body>
 <code class="code"><span class="keyword">sig</span><br>
 &nbsp;&nbsp;<span class="keyword">type</span>&nbsp;a&nbsp;=&nbsp;<span class="constructor">A</span><br>
-&nbsp;&nbsp;<span class="keyword">type</span>&nbsp;<span class="keywordsign">'</span>a&nbsp;b&nbsp;=&nbsp;{&nbsp;field&nbsp;:&nbsp;<span class="keywordsign">'</span>a;&nbsp;}<br>
+&nbsp;&nbsp;<span class="keyword">type</span>&nbsp;<span class="keywordsign">'</span>a&nbsp;b&nbsp;=&nbsp;{&nbsp;field&nbsp;:&nbsp;<span class="keywordsign">'</span>a&nbsp;}<br>
 &nbsp;&nbsp;<span class="keyword">type</span>&nbsp;c&nbsp;=&nbsp;<span class="constructor">C</span>&nbsp;:&nbsp;<span class="keywordsign">'</span>a&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;<span class="constructor">Linebreaks</span>.c<br>
 &nbsp;&nbsp;<span class="keyword">type</span>&nbsp;s&nbsp;=&nbsp;..<br>
 &nbsp;&nbsp;<span class="keyword">type</span>&nbsp;s&nbsp;+=&nbsp;<span class="constructor">B</span><br>
@@ -23,5 +23,5 @@
 &nbsp;&nbsp;<span class="keyword">module</span>&nbsp;<span class="constructor">S</span>&nbsp;:&nbsp;<span class="keyword">sig</span>&nbsp;<span class="keyword">module</span>&nbsp;<span class="constructor">I</span>&nbsp;:&nbsp;<span class="keyword">sig</span>&nbsp;&nbsp;<span class="keyword">end</span>&nbsp;<span class="keyword">end</span><br>
 &nbsp;&nbsp;<span class="keyword">module</span>&nbsp;<span class="keyword">type</span>&nbsp;s&nbsp;=&nbsp;<span class="keyword">sig</span>&nbsp;&nbsp;<span class="keyword">end</span><br>
 &nbsp;&nbsp;<span class="keyword">class</span>&nbsp;<span class="keyword">type</span>&nbsp;d&nbsp;=&nbsp;<span class="keyword">object</span>&nbsp;&nbsp;<span class="keyword">end</span><br>
-&nbsp;&nbsp;<span class="keyword">exception</span>&nbsp;<span class="constructor">E</span>&nbsp;<span class="keyword">of</span>&nbsp;{&nbsp;inline&nbsp;:&nbsp;int;&nbsp;}<br>
+&nbsp;&nbsp;<span class="keyword">exception</span>&nbsp;<span class="constructor">E</span>&nbsp;<span class="keyword">of</span>&nbsp;{&nbsp;inline&nbsp;:&nbsp;int&nbsp;}<br>
 <span class="keyword">end</span></code></body></html>

--- a/testsuite/tests/tool-ocamldoc/t04.reference
+++ b/testsuite/tests/tool-ocamldoc/t04.reference
@@ -9,7 +9,7 @@
 # Odoc_info.string_of_module_type:
 <[sig  end]>
 # Odoc_info.string_of_module_type ~complete: true :
-<[sig type a = A of { lbl : int; } end]>
+<[sig type a = A of { lbl : int } end]>
 # type T04.A.a:
 # manifest (Odoc_info.string_of_type_expr):
 <[None]>
@@ -18,10 +18,10 @@
 # Odoc_info.string_of_module_type:
 <[sig  end]>
 # Odoc_info.string_of_module_type ~complete: true :
-<[sig exception E of { lbl : int; } end]>
+<[sig exception E of { lbl : int } end]>
 #
 # module T04.E_bis:
 # Odoc_info.string_of_module_type:
 <[sig  end]>
 # Odoc_info.string_of_module_type ~complete: true :
-<[sig exception E of { lbl : int; } end]>
+<[sig exception E of { lbl : int } end]>

--- a/testsuite/tests/typing-gadts/dynamic_frisch.ml
+++ b/testsuite/tests/typing-gadts/dynamic_frisch.ml
@@ -126,9 +126,9 @@ type 'a ty =
   | List : 'a ty -> 'a list ty
   | Pair : ('a ty * 'b ty) -> ('a * 'b) ty
   | Record : 'a record -> 'a ty
-and 'a record = { path : string; fields : 'a field_ list; }
+and 'a record = { path : string; fields : 'a field_ list }
 and 'a field_ = Field : ('a, 'b) field -> 'a field_
-and ('a, 'b) field = { label : string; field_type : 'b ty; get : 'a -> 'b; }
+and ('a, 'b) field = { label : string; field_type : 'b ty; get : 'a -> 'b }
 type variant =
     VInt of int
   | VString of string
@@ -199,7 +199,7 @@ and ('a, 'builder) record = {
   path : string;
   fields : ('a, 'builder) field list;
   create_builder : unit -> 'builder;
-  of_builder : 'builder -> 'a;
+  of_builder : 'builder -> 'a
 }
 and ('a, 'builder) field =
     Field : ('a, 'builder, 'b) field_ -> ('a, 'builder) field
@@ -207,7 +207,7 @@ and ('a, 'builder, 'b) field_ = {
   label : string;
   field_type : 'b ty;
   get : 'a -> 'b;
-  set : 'builder -> 'b -> unit;
+  set : 'builder -> 'b -> unit
 }
 val devariantize : 't ty -> variant -> 't = <fun>
 |}];;
@@ -239,7 +239,7 @@ let my_record =
   Record {path = "My_module.my_record"; fields; create_builder; of_builder}
 ;;
 [%%expect{|
-type my_record = { a : int; b : string list; }
+type my_record = { a : int; b : string list }
 val my_record : my_record ty =
   Record
    {path = "My_module.my_record";
@@ -319,7 +319,7 @@ type (_, _) ty =
 and ('a, 'e, 'b) ty_sum = {
   sum_proj : 'a -> string * 'e ty_dyn option;
   sum_cases : (string * ('e, 'b) ty_case) list;
-  sum_inj : 'c. ('b, 'c) ty_sel * 'c -> 'a;
+  sum_inj : 'c. ('b, 'c) ty_sel * 'c -> 'a
 }
 and 'e ty_dyn = Tdyn : ('a, 'e) ty * 'a -> 'e ty_dyn
 and (_, _) ty_sel =

--- a/testsuite/tests/typing-gadts/pr5997.ml
+++ b/testsuite/tests/typing-gadts/pr5997.ml
@@ -37,8 +37,8 @@ end;;
 
 match M.comp with | Diff -> false;;
 [%%expect{|
-module U : sig type t = { x : int; } end
-module M : sig type t = { x : int; } val comp : (U.t, t) comp end
+module U : sig type t = { x : int } end
+module M : sig type t = { x : int } val comp : (U.t, t) comp end
 Line _, characters 0-33:
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:

--- a/testsuite/tests/typing-gadts/pr7269.ml
+++ b/testsuite/tests/typing-gadts/pr7269.ml
@@ -59,7 +59,7 @@ module M :
   sig
     type s
     type elim = {
-      ex : 'a. ([< `Conj of int & s | `Other of string ] as 'a) -> unit;
+      ex : 'a. ([< `Conj of int & s | `Other of string ] as 'a) -> unit
     }
     val e : elim -> unit
   end

--- a/testsuite/tests/typing-gadts/pr7432.ml
+++ b/testsuite/tests/typing-gadts/pr7432.ml
@@ -8,7 +8,7 @@ let eql : (s, t) eql = Refl;;
 type (_, _) eql = Refl : ('a, 'a) eql
 type s = x:int -> y:float -> unit
 type t = y:int -> x:float -> unit
-type silly = { silly : 'a. 'a; }
+type silly = { silly : 'a. 'a }
 val eql : (s, t) eql = Refl
 |}]
 

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -202,7 +202,7 @@ end;;
 module PR6403 :
   sig
     type (_, _) eq = Refl : ('a, 'a) eq
-    type empty = { bottom : 'a. 'a; }
+    type empty = { bottom : 'a. 'a }
     type ('a, 'b) sum = Left of 'a | Right of 'b
     val notequal : ((int, bool) eq, empty) sum -> empty
   end
@@ -882,7 +882,7 @@ let f : type a. a ty -> a t -> int = fun x y ->
   | {left=TA; right=D z} -> z
 ;; (* fail *)
 [%%expect{|
-type ('a, 'b) pair = { right : 'a; left : 'b; }
+type ('a, 'b) pair = { right : 'a; left : 'b }
 Line _, characters 25-32:
 Error: This pattern matches values of type 'a array
        but a pattern was expected which matches values of type a
@@ -900,7 +900,7 @@ let f : type a. a ty -> a t -> int = fun x y ->
   | {left=TA; right=D z} -> z
 ;; (* ok *)
 [%%expect{|
-type ('a, 'b) pair = { left : 'a; right : 'b; }
+type ('a, 'b) pair = { left : 'a; right : 'b }
 Line _, characters 2-244:
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:

--- a/testsuite/tests/typing-gadts/yallop_bugs.ml
+++ b/testsuite/tests/typing-gadts/yallop_bugs.ml
@@ -62,7 +62,7 @@ let check : type s . (s t, s) pair -> bool = function
   | {fst = IntLit ; snd =  6} -> false
 ;;
 [%%expect{|
-type ('a, 'b) pair = { fst : 'a; snd : 'b; }
+type ('a, 'b) pair = { fst : 'a; snd : 'b }
 Line _, characters 45-134:
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml.reference
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml.reference
@@ -11,7 +11,7 @@ Error: The type of this packed module contains variables:
 (module S with type t = 'a)
 # val f : (module S with type t = 'a) -> 'a = <fun>
 # - : int = 1
-#   type 'a s = { s : (module S with type t = 'a); }
+#   type 'a s = { s : (module S with type t = 'a) }
 # - : int s = {s = <module>}
 # Characters 9-19:
   let f {s=(module M)} = M.x;; (* Error *)
@@ -19,7 +19,7 @@ Error: The type of this packed module contains variables:
 Error: The type of this packed module contains variables:
 (module S with type t = 'a)
 # val f : 'a s -> 'a = <fun>
-#   type s = { s : (module S with type t = int); }
+#   type s = { s : (module S with type t = int) }
 # val f : s -> int = <fun>
 # val f : s -> s -> int = <fun>
 #   module type S = sig val x : int end

--- a/testsuite/tests/typing-misc/pr7228.ml
+++ b/testsuite/tests/typing-misc/pr7228.ml
@@ -1,7 +1,7 @@
 type t = A of {mutable x: int};;
 fun (A r) -> r.x <- 42;;
 [%%expect{|
-type t = A of { mutable x : int; }
+type t = A of { mutable x : int }
 - : t -> unit = <fun>
 |}];;
 
@@ -9,7 +9,7 @@ type t = A of { mutable x : int; }
 type t = private A of {mutable x: int};;
 fun (A r) -> r.x <- 42;;
 [%%expect{|
-type t = private A of { mutable x : int; }
+type t = private A of { mutable x : int }
 Line _, characters 15-16:
 Error: Cannot assign field x of the private type t.A
 |}];;

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -2,7 +2,7 @@
 type t = {x:int;y:int};;
 {x=3;z=2};;
 [%%expect{|
-type t = { x : int; y : int; }
+type t = { x : int; y : int }
 Line _, characters 5-6:
 Error: Unbound record field z
 |}];;
@@ -24,7 +24,7 @@ Error: The record field contents belongs to the type 'a ref
 type u = private {mutable u:int};;
 {u=3};;
 [%%expect{|
-type u = private { mutable u : int; }
+type u = private { mutable u : int }
 Line _, characters 0-5:
 Error: Cannot create values of the private type u
 |}];;
@@ -39,7 +39,7 @@ module M = struct
   type t = {x: int; y: int}
 end;;
 [%%expect{|
-module M : sig type t = { x : int; y : int; } end
+module M : sig type t = { x : int; y : int } end
 |}];;
 
 let f {M.x; y} = x+y;;
@@ -55,7 +55,7 @@ val z : int = 3
 type foo = { mutable y:int };;
 let f (r: int) = r.y <- 3;;
 [%%expect{|
-type foo = { mutable y : int; }
+type foo = { mutable y : int }
 Line _, characters 17-18:
 Error: This expression has type int but an expression was expected of type
          foo
@@ -66,8 +66,8 @@ type foo = { y: int; z: int };;
 type bar = { x: int };;
 let f (r: bar) = ({ r with z = 3 } : foo)
 [%%expect{|
-type foo = { y : int; z : int; }
-type bar = { x : int; }
+type foo = { y : int; z : int }
+type bar = { x : int }
 Line _, characters 20-21:
 Error: This expression has type bar but an expression was expected of type
          foo
@@ -76,7 +76,7 @@ Error: This expression has type bar but an expression was expected of type
 type foo = { x: int };;
 let r : foo = { ZZZ.x = 2 };;
 [%%expect{|
-type foo = { x : int; }
+type foo = { x : int }
 Line _, characters 16-21:
 Error: Unbound module ZZZ
 |}];;
@@ -106,7 +106,7 @@ type ('a, 'b) t = { fst : 'a; snd : 'b };;
 let with_fst r fst = { r with fst };;
 with_fst { fst=""; snd="" } 2;;
 [%%expect{|
-type ('a, 'b) t = { fst : 'a; snd : 'b; }
+type ('a, 'b) t = { fst : 'a; snd : 'b }
 val with_fst : ('a, 'b) t -> 'c -> ('c, 'b) t = <fun>
 - : (int, string) t = {fst = 2; snd = ""}
 |}];;

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -215,7 +215,7 @@ include C;;
 [%%expect{|
 module type Complex =
   sig
-    type t = Complex.t = { re : float; im : float; }
+    type t = Complex.t = { re : float; im : float }
     val zero : t
     val one : t
     val i : t
@@ -238,7 +238,7 @@ module type Complex =
 module M : sig module C : Complex end
 module C = Complex
 - : float = 1.
-type t = Complex.t = { re : float; im : float; }
+type t = Complex.t = { re : float; im : float }
 val zero : t = {re = 0.; im = 0.}
 val one : t = {re = 1.; im = 0.}
 val i : t = {re = 0.; im = 1.}

--- a/testsuite/tests/typing-pattern_open/pattern_open.ml.reference
+++ b/testsuite/tests/typing-pattern_open/pattern_open.ml.reference
@@ -1,8 +1,8 @@
 
 #                 val pp : ('a, out_channel, unit) format -> 'a = <fun>
 type 'a box = B of 'a
-module M : sig type c = C type t = { x : c box; } end
-#             module N : sig type d = D val d : d type t = { x : d box; } end
+module M : sig type c = C type t = { x : c box } end
+#             module N : sig type d = D val d : d type t = { x : d box } end
 #   val f : M.t -> 'a -> M.c * 'a = <fun>
 #   val g : int -> int -> int = <fun>
 #         val g : M.c list -> M.c list = <fun>
@@ -11,15 +11,15 @@ module M : sig type c = C type t = { x : c box; } end
 #   #     #               module L :
   sig
     type _ c = C : unit c
-    type t = { t : unit c; }
-    type r = { r : unit c; }
+    type t = { t : unit c }
+    type r = { r : unit c }
     val x : unit -> unit
   end
 #             module K :
   sig
     type _ c = C : unit c
-    type t = { t : unit c; }
-    type r = { r : unit c; }
+    type t = { t : unit c }
+    type r = { r : unit c }
     val x : unit -> unit
   end
 #               Right value K.x
@@ -29,7 +29,7 @@ module M : sig type c = C type t = { x : c box; } end
       sig
         module Boolean :
           sig
-            type t = { b : bool; }
+            type t = { b : bool }
             type wrong = false | true
             val print : unit -> unit
           end

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -11,8 +11,8 @@ type 'a fold = { fold : 'b. f:('b -> 'a -> 'b) -> init:'b -> 'b };;
 let f l = { fold = List.fold_left l };;
 (f [1;2;3]).fold ~f:(+) ~init:0;;
 [%%expect {|
-type 'a t = { t : 'a; }
-type 'a fold = { fold : 'b. f:('b -> 'a -> 'b) -> init:'b -> 'b; }
+type 'a t = { t : 'a }
+type 'a fold = { fold : 'b. f:('b -> 'a -> 'b) -> init:'b -> 'b }
 val f : 'a list -> 'a fold = <fun>
 - : int = 6
 |}];;
@@ -589,7 +589,7 @@ type record = { r: < id: 'a. 'a -> 'a > } ;;
 fun x -> x.r#id;;
 fun {r=x} -> x#id;;
 [%%expect {|
-type record = { r : < id : 'a. 'a -> 'a >; }
+type record = { r : < id : 'a. 'a -> 'a > }
 - : record -> 'a -> 'a = <fun>
 - : record -> 'a -> 'a = <fun>
 |}];;
@@ -730,7 +730,7 @@ type bad2 = {mutable bad2 : 'a. 'a option ref option};;
 let bad2 = {bad2 = None};;
 bad2.bad2 <- Some (ref None);;
 [%%expect {|
-type bad = { bad : 'a. 'a option ref; }
+type bad = { bad : 'a. 'a option ref }
 Line _, characters 17-25:
 Error: This field value has type 'b option ref which is less general than
          'a. 'a option ref
@@ -803,7 +803,7 @@ end
 type t = {f : 'a 'b. ('b -> (#ct as 'a) -> 'b) -> 'b};;
 [%%expect {|
 class type ct = object ('a) method fold : ('b -> 'a -> 'b) -> 'b -> 'b end
-type t = { f : 'a 'b. ('b -> (#ct as 'a) -> 'b) -> 'b; }
+type t = { f : 'a 'b. ('b -> (#ct as 'a) -> 'b) -> 'b }
 |}];;
 
 (* PR#1663 *)
@@ -1254,9 +1254,9 @@ let zero = {f = `Int 0} ;;
 type t = {f: 'a. [< `Int of int] as 'a}
 let zero = {f = `Int 0} ;; (* fails *)
 [%%expect {|
-type t = { f : 'a. [> `B of 'a | `Int of int ] as 'a; }
+type t = { f : 'a. [> `B of 'a | `Int of int ] as 'a }
 val zero : t = {f = `Int 0}
-type t = { f : 'a. [< `Int of int ] as 'a; }
+type t = { f : 'a. [< `Int of int ] as 'a }
 Line _, characters 16-22:
 Error: This expression has type [> `Int of int ]
        but an expression was expected of type [< `Int of int ]
@@ -1296,7 +1296,7 @@ val transf_alist : (int -> t) -> ('a * t) list -> ('a * t) list = <fun>
 type t = {f: 'a. ('a list -> int) Lazy.t}
 let l : t = { f = lazy (raise Not_found)};;
 [%%expect {|
-type t = { f : 'a. ('a list -> int) Lazy.t; }
+type t = { f : 'a. ('a list -> int) Lazy.t }
 val l : t = {f = <lazy>}
 |}];;
 
@@ -1305,7 +1305,7 @@ type t = {f: 'a. 'a -> unit};;
 let f ?x y = () in {f};;
 let f ?x y = y in {f};; (* fail *)
 [%%expect {|
-type t = { f : 'a. 'a -> unit; }
+type t = { f : 'a. 'a -> unit }
 - : t = {f = <fun>}
 Line _, characters 19-20:
 Error: This field value has type unit -> unit which is less general than
@@ -1496,7 +1496,7 @@ let f t = { x = t.x };;
 val f :
   < m : 'a. ([< `Foo of int & float ] as 'a) -> unit > ->
   < m : 'b. ([< `Foo of int & float ] as 'b) -> unit > = <fun>
-type t = { x : 'a. ([< `Foo of int & float ] as 'a) -> unit; }
+type t = { x : 'a. ([< `Foo of int & float ] as 'a) -> unit }
 val f : t -> t = <fun>
 |}]
 

--- a/testsuite/tests/typing-recordarg/recordarg.ml.reference
+++ b/testsuite/tests/typing-recordarg/recordarg.ml.reference
@@ -1,5 +1,5 @@
 
-# type t = A of { x : int; mutable y : int; }
+# type t = A of { x : int; mutable y : int }
 # Characters 14-15:
   let f (A r) = r;;  (* -> escape *)
                 ^
@@ -12,20 +12,20 @@ Error: This form is not allowed as the type of the inlined record could escape.
                 ^
 Error: The field a is not part of the record argument for the t.A constructor
 # val f : unit -> t = <fun>
-#   type _ t = A : { x : 'a; y : 'b; } -> 'a t
+#   type _ t = A : { x : 'a; y : 'b } -> 'a t
 # val f : 'a t -> 'a t = <fun>
 # val f : 'a t -> 'a t = <fun>
 #               module M :
   sig
-    type 'a t = A of { x : 'a; } | B : { u : 'b; } -> unit t
-    exception Foo of { x : int; }
+    type 'a t = A of { x : 'a } | B : { u : 'b } -> unit t
+    exception Foo of { x : int }
   end
 #                           module N :
   sig
-    type 'b t = 'b M.t = A of { x : 'b; } | B : { u : 'bla; } -> unit t
-    exception Foo of { x : int; }
+    type 'b t = 'b M.t = A of { x : 'b } | B : { u : 'bla } -> unit t
+    exception Foo of { x : int }
   end
-#     module type S = sig exception A of { x : int; } end
+#     module type S = sig exception A of { x : int } end
 #       Characters 65-74:
     module A = (val X.x)
                ^^^^^^^^^
@@ -41,19 +41,19 @@ Error: Multiple definition of the extension constructor name A.
               ^
 Error: Multiple definition of the extension constructor name A.
        Names must be unique in a given structure or signature.
-#         module M1 : sig exception A of { x : int; } end
+#         module M1 : sig exception A of { x : int } end
 #         Characters 34-44:
     include M1
     ^^^^^^^^^^
 Error: Multiple definition of the extension constructor name A.
        Names must be unique in a given structure or signature.
-#         module type S1 = sig exception A of { x : int; } end
+#         module type S1 = sig exception A of { x : int } end
 #         Characters 36-46:
     include S1
     ^^^^^^^^^^
 Error: Multiple definition of the extension constructor name A.
        Names must be unique in a given structure or signature.
-#       module M : sig exception A of { x : int; } end
+#       module M : sig exception A of { x : int } end
 #       module X1 : sig type t = .. end
 #     module X2 : sig type t = .. end
 #       Characters 62-63:
@@ -62,6 +62,6 @@ Error: Multiple definition of the extension constructor name A.
 Error: Multiple definition of the extension constructor name A.
        Names must be unique in a given structure or signature.
 #         type _ c = C : [ `A ] c
-type t = T : { x : [< `A ] c; } -> t
+type t = T : { x : [< `A ] c } -> t
 # val f : t -> unit = <fun>
 # 

--- a/testsuite/tests/typing-unboxed-types/test.ml.reference
+++ b/testsuite/tests/typing-unboxed-types/test.ml.reference
@@ -1,9 +1,9 @@
 
 #       type t1 = A of string [@@unboxed]
 #       - : bool = true
-#     type t2 = { f : string; } [@@unboxed]
+#     type t2 = { f : string } [@@unboxed]
 #       - : bool = true
-#     type t3 = B of { g : string; } [@@unboxed]
+#     type t3 = B of { g : string } [@@unboxed]
 #       - : bool = true
 #     Characters 29-58:
   type t4 = C [@@ocaml.unboxed];;  (* no argument *)
@@ -76,13 +76,13 @@ Error: Signature mismatch:
   end..
 Error: Signature mismatch:
        Modules do not match:
-         sig type t = { f : string; } [@@unboxed] end
+         sig type t = { f : string } [@@unboxed] end
        is not included in
-         sig type t = { f : string; } end
+         sig type t = { f : string } end
        Type declarations do not match:
-         type t = { f : string; } [@@unboxed]
+         type t = { f : string } [@@unboxed]
        is not included in
-         type t = { f : string; }
+         type t = { f : string }
        Their internal representations differ:
        the first declaration uses unboxed representation.
 #           Characters 66-102:
@@ -91,13 +91,13 @@ Error: Signature mismatch:
   end..
 Error: Signature mismatch:
        Modules do not match:
-         sig type t = { f : string; } end
+         sig type t = { f : string } end
        is not included in
-         sig type t = { f : string; } [@@unboxed] end
+         sig type t = { f : string } [@@unboxed] end
        Type declarations do not match:
-         type t = { f : string; }
+         type t = { f : string }
        is not included in
-         type t = { f : string; } [@@unboxed]
+         type t = { f : string } [@@unboxed]
        Their internal representations differ:
        the second declaration uses unboxed representation.
 #           Characters 53-112:
@@ -106,13 +106,13 @@ Error: Signature mismatch:
   end..
 Error: Signature mismatch:
        Modules do not match:
-         sig type t = A of { f : string; } [@@unboxed] end
+         sig type t = A of { f : string } [@@unboxed] end
        is not included in
-         sig type t = A of { f : string; } end
+         sig type t = A of { f : string } end
        Type declarations do not match:
-         type t = A of { f : string; } [@@unboxed]
+         type t = A of { f : string } [@@unboxed]
        is not included in
-         type t = A of { f : string; }
+         type t = A of { f : string }
        Their internal representations differ:
        the first declaration uses unboxed representation.
 #           Characters 71-112:
@@ -121,13 +121,13 @@ Error: Signature mismatch:
   end..
 Error: Signature mismatch:
        Modules do not match:
-         sig type t = A of { f : string; } end
+         sig type t = A of { f : string } end
        is not included in
-         sig type t = A of { f : string; } [@@unboxed] end
+         sig type t = A of { f : string } [@@unboxed] end
        Type declarations do not match:
-         type t = A of { f : string; }
+         type t = A of { f : string }
        is not included in
-         type t = A of { f : string; } [@@unboxed]
+         type t = A of { f : string } [@@unboxed]
        Their internal representations differ:
        the second declaration uses unboxed representation.
 #       type t11 = L of float [@@unboxed]
@@ -153,9 +153,9 @@ Error: This type cannot be unboxed because
 Error: Signature mismatch:
        ...
        Type declarations do not match:
-         type u = { f1 : t; f2 : t; }
+         type u = { f1 : t; f2 : t }
        is not included in
-         type u = { f1 : t; f2 : t; }
+         type u = { f1 : t; f2 : t }
        Their internal representations differ:
        the first declaration uses unboxed float representation.
 #     * *           module T : sig type t [@@immediate] end

--- a/testsuite/tests/typing-warnings/exhaustiveness.ml.reference
+++ b/testsuite/tests/typing-warnings/exhaustiveness.ml.reference
@@ -56,7 +56,7 @@ Here is an example of a case that is not matched:
 Some A
 val f : int t option -> int = <fun>
 #         type 'a box = Box of 'a
-type 'a pair = { left : 'a; right : 'a; }
+type 'a pair = { left : 'a; right : 'a }
 #   Characters 50-69:
   let f : (int t box pair * bool) option -> unit = function None -> ();;
                                                    ^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-warnings/records.ml.principal.reference
+++ b/testsuite/tests/typing-warnings/records.ml.principal.reference
@@ -1,6 +1,6 @@
 
 #         module M1 :
-  sig type t = { x : int; y : int; } type u = { x : bool; y : bool; } end
+  sig type t = { x : int; y : int } type u = { x : bool; y : bool } end
 #                 Characters 49-50:
     let f1 (r:t) = r.x (* ok *)
                      ^
@@ -51,7 +51,7 @@ Characters 85-91:
          ^^^^^^
 Error: This pattern matches values of type M1.u
        but a pattern was expected which matches values of type M1.t
-#           module M : sig type t = { x : int; } type u = { x : bool; } end
+#           module M : sig type t = { x : int } type u = { x : bool } end
 # Characters 18-21:
   let f (r:M.t) = r.M.x;; (* ok *)
                     ^^^
@@ -82,8 +82,8 @@ Warning 40: this record of type M.t contains fields that are
 not visible in the current scope: x.
 They will not be selected if the type becomes unknown.
 val f : M.t -> int = <fun>
-#       module M : sig type t = { x : int; y : int; } end
-#     module N : sig type u = { x : bool; y : bool; } end
+#       module M : sig type t = { x : int; y : int } end
+#     module N : sig type u = { x : bool; y : bool } end
 #         Characters 57-58:
     let f (r:M.t) = r.x
                       ^
@@ -96,15 +96,15 @@ Warning 33: unused open N.
 module OK : sig val f : M.t -> int end
 #           module M :
   sig
-    type t = { x : int; }
-    module N : sig type s = t = { x : int; } end
-    type u = { x : bool; }
+    type t = { x : int }
+    module N : sig type s = t = { x : int } end
+    type u = { x : bool }
   end
 #       module OK : sig val f : M.t -> int end
 #           module M :
   sig
-    type u = { x : bool; y : int; z : char; }
-    type t = { x : int; y : bool; }
+    type u = { x : bool; y : int; z : char }
+    type t = { x : int; y : bool }
   end
 #       Characters 37-38:
     let f {x;z} = x,z
@@ -134,8 +134,8 @@ Warning 42: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 module OK :
   sig
-    type u = { x : int; y : bool; }
-    type t = { x : bool; y : int; z : char; }
+    type u = { x : int; y : bool }
+    type t = { x : bool; y : int; z : char }
     val r : u
   end
 #               Characters 111-112:
@@ -143,8 +143,8 @@ module OK :
                         ^
 Error: This record expression is expected to have type bar
        The field y does not belong to type bar
-#   module M : sig type foo = { x : int; y : int; } end
-# module N : sig type bar = { x : int; y : int; } end
+#   module M : sig type foo = { x : int; y : int } end
+# module N : sig type bar = { x : int; y : int } end
 # Characters 19-22:
   let r = { M.x = 3; N.y = 4; };; (* error: different definitions *)
                      ^^^
@@ -152,13 +152,13 @@ Error: The record field N.y belongs to the type N.bar
        but is mixed here with fields of type M.foo
 #     module MN :
   sig
-    type foo = M.foo = { x : int; y : int; }
-    type bar = N.bar = { x : int; y : int; }
+    type foo = M.foo = { x : int; y : int }
+    type bar = N.bar = { x : int; y : int }
   end
 module NM :
   sig
-    type bar = N.bar = { x : int; y : int; }
-    type foo = M.foo = { x : int; y : int; }
+    type bar = N.bar = { x : int; y : int }
+    type foo = M.foo = { x : int; y : int }
   end
 # Characters 8-28:
   let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
@@ -177,8 +177,8 @@ Error: The record field NM.y belongs to the type NM.foo = M.foo
        but is mixed here with fields of type MN.bar = N.bar
 #             module M :
   sig
-    type foo = { x : int; y : int; }
-    type bar = { x : int; y : int; z : int; }
+    type foo = { x : int; y : int }
+    type bar = { x : int; y : int; z : int }
   end
 #       Characters 65-66:
     let f r = ignore (r: foo); {r with x = 2; z = 3}
@@ -192,9 +192,9 @@ Error: This record expression is expected to have type M.foo
        The field z does not belong to type M.foo
 #       module M :
   sig
-    type foo = M.foo = { x : int; y : int; }
-    type bar = M.bar = { x : int; y : int; z : int; }
-    type other = { a : int; b : int; }
+    type foo = M.foo = { x : int; y : int }
+    type bar = M.bar = { x : int; y : int; z : int }
+    type other = { a : int; b : int }
   end
 #       Characters 66-67:
     let f r = ignore (r: foo); { r with x = 3; a = 4 }
@@ -221,8 +221,8 @@ Characters 67-68:
                     ^
 Error: This record expression is expected to have type M.other
        The field x does not belong to type M.other
-#     module A : sig type t = { x : int; } end
-module B : sig type t = { x : int; } end
+#     module A : sig type t = { x : int } end
+module B : sig type t = { x : int } end
 # Characters 20-23:
   let f (r : B.t) = r.A.x;; (* fail *)
                       ^^^
@@ -270,8 +270,8 @@ Characters 114-120:
 Warning 33: unused open M.
 module Shadow1 :
   sig
-    type t = { x : int; }
-    module M : sig type s = { x : string; } end
+    type t = { x : int }
+    module M : sig type s = { x : string } end
     val y : t
   end
 #               Characters 97-103:
@@ -285,8 +285,8 @@ Warning 41: these field labels belong to several types: M.s t
 The first one was selected. Please disambiguate if this is wrong.
 module Shadow2 :
   sig
-    type t = { x : int; }
-    module M : sig type s = { x : string; } end
+    type t = { x : int }
+    module M : sig type s = { x : string } end
     val y : M.s
   end
 #                 Characters 167-170:
@@ -296,8 +296,8 @@ Warning 42: this use of loc relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 module P6235 :
   sig
-    type t = { loc : string; }
-    type v = { loc : string; x : int; }
+    type t = { loc : string }
+    type v = { loc : string; x : int }
     type u = [ `Key of t ]
     val f : u -> string
   end

--- a/testsuite/tests/typing-warnings/records.ml.reference
+++ b/testsuite/tests/typing-warnings/records.ml.reference
@@ -1,6 +1,6 @@
 
 #         module M1 :
-  sig type t = { x : int; y : int; } type u = { x : bool; y : bool; } end
+  sig type t = { x : int; y : int } type u = { x : bool; y : bool } end
 #                 Characters 49-50:
     let f1 (r:t) = r.x (* ok *)
                      ^
@@ -52,7 +52,7 @@ Characters 86-87:
           ^
 Warning 27: unused variable x.
 module F2 : sig val f : M1.t -> int end
-#           module M : sig type t = { x : int; } type u = { x : bool; } end
+#           module M : sig type t = { x : int } type u = { x : bool } end
 # Characters 18-21:
   let f (r:M.t) = r.M.x;; (* ok *)
                     ^^^
@@ -83,8 +83,8 @@ Warning 40: this record of type M.t contains fields that are
 not visible in the current scope: x.
 They will not be selected if the type becomes unknown.
 val f : M.t -> int = <fun>
-#       module M : sig type t = { x : int; y : int; } end
-#     module N : sig type u = { x : bool; y : bool; } end
+#       module M : sig type t = { x : int; y : int } end
+#     module N : sig type u = { x : bool; y : bool } end
 #         Characters 57-58:
     let f (r:M.t) = r.x
                       ^
@@ -97,15 +97,15 @@ Warning 33: unused open N.
 module OK : sig val f : M.t -> int end
 #           module M :
   sig
-    type t = { x : int; }
-    module N : sig type s = t = { x : int; } end
-    type u = { x : bool; }
+    type t = { x : int }
+    module N : sig type s = t = { x : int } end
+    type u = { x : bool }
   end
 #       module OK : sig val f : M.t -> int end
 #           module M :
   sig
-    type u = { x : bool; y : int; z : char; }
-    type t = { x : int; y : bool; }
+    type u = { x : bool; y : int; z : char }
+    type t = { x : int; y : bool }
   end
 #       Characters 37-38:
     let f {x;z} = x,z
@@ -135,8 +135,8 @@ Warning 42: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 module OK :
   sig
-    type u = { x : int; y : bool; }
-    type t = { x : bool; y : int; z : char; }
+    type u = { x : int; y : bool }
+    type t = { x : bool; y : int; z : char }
     val r : u
   end
 #               Characters 111-112:
@@ -144,8 +144,8 @@ module OK :
                         ^
 Error: This record expression is expected to have type bar
        The field y does not belong to type bar
-#   module M : sig type foo = { x : int; y : int; } end
-# module N : sig type bar = { x : int; y : int; } end
+#   module M : sig type foo = { x : int; y : int } end
+# module N : sig type bar = { x : int; y : int } end
 # Characters 19-22:
   let r = { M.x = 3; N.y = 4; };; (* error: different definitions *)
                      ^^^
@@ -153,13 +153,13 @@ Error: The record field N.y belongs to the type N.bar
        but is mixed here with fields of type M.foo
 #     module MN :
   sig
-    type foo = M.foo = { x : int; y : int; }
-    type bar = N.bar = { x : int; y : int; }
+    type foo = M.foo = { x : int; y : int }
+    type bar = N.bar = { x : int; y : int }
   end
 module NM :
   sig
-    type bar = N.bar = { x : int; y : int; }
-    type foo = M.foo = { x : int; y : int; }
+    type bar = N.bar = { x : int; y : int }
+    type foo = M.foo = { x : int; y : int }
   end
 # Characters 8-28:
   let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
@@ -178,8 +178,8 @@ Error: The record field NM.y belongs to the type NM.foo = M.foo
        but is mixed here with fields of type MN.bar = N.bar
 #             module M :
   sig
-    type foo = { x : int; y : int; }
-    type bar = { x : int; y : int; z : int; }
+    type foo = { x : int; y : int }
+    type bar = { x : int; y : int; z : int }
   end
 #       Characters 65-66:
     let f r = ignore (r: foo); {r with x = 2; z = 3}
@@ -193,9 +193,9 @@ Error: This record expression is expected to have type M.foo
        The field z does not belong to type M.foo
 #       module M :
   sig
-    type foo = M.foo = { x : int; y : int; }
-    type bar = M.bar = { x : int; y : int; z : int; }
-    type other = { a : int; b : int; }
+    type foo = M.foo = { x : int; y : int }
+    type bar = M.bar = { x : int; y : int; z : int }
+    type other = { a : int; b : int }
   end
 #       Characters 66-67:
     let f r = ignore (r: foo); { r with x = 3; a = 4 }
@@ -222,8 +222,8 @@ Characters 67-68:
                     ^
 Error: This record expression is expected to have type M.other
        The field x does not belong to type M.other
-#     module A : sig type t = { x : int; } end
-module B : sig type t = { x : int; } end
+#     module A : sig type t = { x : int } end
+module B : sig type t = { x : int } end
 # Characters 20-23:
   let f (r : B.t) = r.A.x;; (* fail *)
                       ^^^
@@ -267,8 +267,8 @@ Characters 114-120:
 Warning 33: unused open M.
 module Shadow1 :
   sig
-    type t = { x : int; }
-    module M : sig type s = { x : string; } end
+    type t = { x : int }
+    module M : sig type s = { x : string } end
     val y : t
   end
 #               Characters 97-103:
@@ -282,8 +282,8 @@ Warning 41: these field labels belong to several types: M.s t
 The first one was selected. Please disambiguate if this is wrong.
 module Shadow2 :
   sig
-    type t = { x : int; }
-    module M : sig type s = { x : string; } end
+    type t = { x : int }
+    module M : sig type s = { x : string } end
     val y : M.s
   end
 #                 Characters 167-170:
@@ -293,8 +293,8 @@ Warning 42: this use of loc relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 module P6235 :
   sig
-    type t = { loc : string; }
-    type v = { loc : string; x : int; }
+    type t = { loc : string }
+    type v = { loc : string; x : int }
     type u = [ `Key of t ]
     val f : u -> string
   end
@@ -305,8 +305,8 @@ Warning 42: this use of loc relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 module P6235' :
   sig
-    type t = { loc : string; }
-    type v = { loc : string; x : int; }
+    type t = { loc : string }
+    type v = { loc : string; x : int }
     type u = [ `Key of t ]
     val f : u -> string
   end

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -159,11 +159,6 @@ let out_value = ref print_out_value
 
 (* Types *)
 
-let rec print_list_init pr sep ppf =
-  function
-    [] -> ()
-  | a :: l -> sep ppf; pr ppf a; print_list_init pr sep ppf l
-
 let rec print_list pr sep ppf =
   function
     [] -> ()
@@ -258,8 +253,8 @@ and print_simple_out_type ppf =
   | Otyp_attribute (t, attr) ->
       fprintf ppf "@[<1>(%a [@@%s])@]" print_out_type t attr.oattr_name
 and print_record_decl ppf lbls =
-  fprintf ppf "{%a@;<1 -2>}"
-    (print_list_init print_out_label (fun ppf -> fprintf ppf "@ ")) lbls
+  fprintf ppf "{@ %a@;<1 -2>}"
+    (print_list print_out_label (fun ppf -> fprintf ppf ";@ ")) lbls
 and print_fields rest ppf =
   function
     [] ->
@@ -305,7 +300,7 @@ and print_typargs ppf =
       pp_close_box ppf ();
       pp_print_space ppf ()
 and print_out_label ppf (name, mut, arg) =
-  fprintf ppf "@[<2>%s%s :@ %a@];" (if mut then "mutable " else "") name
+  fprintf ppf "@[<2>%s%s :@ %a@]" (if mut then "mutable " else "") name
     print_out_type arg
 
 let out_type = ref print_out_type


### PR DESCRIPTION
This micro PR removes the trailing semicolon at the end of record definition when printing outcome trees
(i.e. inside the toplevel or error messages).

In other words,
```OCaml
(* before: *)
type my_record = { a : int; b : string list; }
```
becomes
```OCaml
(* after this PR: *)
type my_record = { a : int; b : string list }
```