### PR TITLE
Travis tests: use a more robust search for no-change-needed lines based on merge-base.

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #**************************************************************************
 #*                                                                        *
 #*                                 OCaml                                  *
@@ -20,8 +21,8 @@ MAKE=make SHELL=dash
 # TRAVIS_COMMIT_RANGE has the form   <commit1>...<commit2>
 # TRAVIS_CUR_HEAD is <commit1>
 # TRAVIS_PR_HEAD is <commit2>
-TRAVIS_CUR_HEAD=$(echo $TRAVIS_COMMIT_RANGE | sed 's!\.\.\..*!!')
-TRAVIS_PR_HEAD=$(echo $TRAVIS_COMMIT_RANGE | sed 's![^.]*\.\.\.!!')
+TRAVIS_CUR_HEAD=${TRAVIS_COMMIT_RANGE%%...*}
+TRAVIS_PR_HEAD=${TRAVIS_COMMIT_RANGE##*...}
 TRAVIS_MERGE_BASE=$(git merge-base $TRAVIS_CUR_HEAD $TRAVIS_PR_HEAD)
 
 BuildAndTest () {

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -111,7 +111,7 @@ EOF
 }
 
 CheckNoChangesMessage () {
-  if test -n "$(git log --grep="[Nn]o [Cc]hange.* needed" --max-count=1 ${TRAVIS_CUR_HEAD}..${TRAVIS_PR_HEAD})"
+  if test -n "$(git log --grep="[Nn]o [Cc]hange.* needed" --max-count=1 ${TRAVIS_MERGE_BASE}..${TRAVIS_PR_HEAD})"
   then echo pass
   elif test -n "$(curl https://api.github.com/repos/$TRAVIS_REPO_SLUG/issues/$TRAVIS_PULL_REQUEST/labels \
        | grep 'no-change-entry-needed')"
@@ -140,7 +140,7 @@ does *not* imply that your change is appropriately tested.
 ------------------------------------------------------------------------
 EOF
   # check that at least a file in testsuite/ has been modified
-  git diff $TRAVIS_COMMIT_RANGE --name-only --exit-code testsuite > /dev/null \
+  git diff $TRAVIS_MERGE_BASE..$TRAVIS_PR_HEAD --name-only --exit-code testsuite > /dev/null \
   && exit 1 || echo pass
 }
 

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -21,6 +21,17 @@ MAKE=make SHELL=dash
 # TRAVIS_COMMIT_RANGE has the form   <commit1>...<commit2>
 # TRAVIS_CUR_HEAD is <commit1>
 # TRAVIS_PR_HEAD is <commit2>
+#
+# The following diagram illustrates the relationship between
+# the commits:
+#
+#      (trunk)         (pr branch)
+#  TRAVIS_CUR_HEAD   TRAVIS_PR_HEAD
+#        |            /
+#        …           …
+#        |          /
+#  TRAVIS_MERGE_BASE
+#
 TRAVIS_CUR_HEAD=${TRAVIS_COMMIT_RANGE%%...*}
 TRAVIS_PR_HEAD=${TRAVIS_COMMIT_RANGE##*...}
 TRAVIS_MERGE_BASE=$(git merge-base $TRAVIS_CUR_HEAD $TRAVIS_PR_HEAD)


### PR DESCRIPTION
[tl;dr:  CI wrongly accepts some prs which have neither a `Changes` entry nor a 'no change needed' opt-out.]

### The meaning of `...`: `git log` vs `git diff`

One amusing quirk of `git` is that a commit range with three dots (`<commit>...<commit>`) means two quite different things depending on whether the range is used as an argument to `git diff` or as an argument to `git log`.

With `git diff`, `A...B` means "all the changes up to `A` since `A` and `B` diverged:

     git diff [--options] <commit>...<commit> [--] [<path>...]
       This form is to view the changes on the branch containing
       and up to the second <commit>, starting at a common ancestor
       of both <commit>. "git diff A...B" is equivalent to "git diff
       $(git-merge-base A B) B". You can omit any one of <commit>,
       which has the same effect as using HEAD instead.

With `git log`, `A...B` means "symmetric difference", i.e. all the changes in the union of the histories of `A` and `B`, but not in the intersection:

       A similar notation r1...r2 is called symmetric difference of r1
       and r2 and is defined as r1 r2 --not $(git merge-base --all r1
       r2). It is the set of commits that are reachable from either
       one of r1 (left side) or r2 (right side) but not from both.

### The `$TRAVIS_COMMIT_RANGE` variable

The `TRAVIS_COMMIT_RANGE` environment variable is a string of the form `A...B`, where `A` is the head commit of the target branch (typically `trunk`) and `B` is the head commit of the PR branch.  Consequently, `git diff $TRAVIS_COMMIT_RANGE` displays the changes proposed in the PR, but `git log $TRAVIS_COMMIT_RANGE` displays something quite different: a list of the commits in the PR together with the commits that have occurred on the target branch since the PR branch was created.

### The `.travis-ci.sh` script and the check for 'no change needed'

The following line in `.travis-ci.sh` is intended to check whether any commit message in the PR contains a string 'no change needed', or similar.

    if test -n "$(git log --grep="[Nn]o [Cc]hange.* needed" --max-count=1 $TRAVIS_COMMIT_RANGE)"

However, under the `git log` interpretation of the `...` notation in `$TRAVIS_COMMIT_RANGE`, this line actually searches both the commits in the PR and the commits to `trunk` since the PR branch was created.  A recent commit to `trunk` with 'no change needed' in the commit message can therefore lead to the Travis tests accepting PRs without either `Changes` entries or 'no change needed' in the commit messages.  #1215 ([Travis logs](https://travis-ci.org/ocaml/ocaml/jobs/247918986)) is a recent example of exactly this situation.



### This PR: `merge-base` and `..`

This PR attempts a more robust search based on a clunkier but more explicit specification of the commit range using `merge-base` and the double-dot range notation (`A..B`).

