### PR TITLE
MPR#248: unique names for weak type variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -213,6 +213,10 @@ Working version
 
 ### Bug fixes
 
+- PR#248: unique names for weak type variables
+  (Florian Angeletti, review by Frédéric Bour, Jacques Garrigue,
+   Gabriel Radanne and Gabriel Scherer)
+
 - PR#5927: Type equality broken for conjunctive polymorphic variant tags
   (Jacques Garrigue, report by Leo White)
 

--- a/testsuite/tests/printing-types/Makefile
+++ b/testsuite/tests/printing-types/Makefile
@@ -1,0 +1,3 @@
+BASEDIR=../..
+include $(BASEDIR)/makefiles/Makefile.toplevel
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/printing-types/pr248.ml
+++ b/testsuite/tests/printing-types/pr248.ml
@@ -1,0 +1,13 @@
+(** Test that weak variables keep their names long enough *)
+
+let f y = fun x -> x
+let blah = f 0
+let splash () = blah (failwith "coucou")
+let blurp = f 0;;
+
+blah 1;;
+
+let g = f ();;
+
+g (fun x -> x);;
+let h = g (f ());;

--- a/testsuite/tests/printing-types/pr248.ml.reference
+++ b/testsuite/tests/printing-types/pr248.ml.reference
@@ -1,0 +1,10 @@
+
+#           val f : 'a -> 'b -> 'b = <fun>
+val blah : '_weak1 -> '_weak1 = <fun>
+val splash : unit -> '_weak1 = <fun>
+val blurp : '_weak2 -> '_weak2 = <fun>
+#   - : int = 1
+#   val g : '_weak3 -> '_weak3 = <fun>
+#   - : '_weak4 -> '_weak4 = <fun>
+# val h : '_weak4 -> '_weak4 = <fun>
+# 

--- a/testsuite/tests/typing-gadts/omega07.ml
+++ b/testsuite/tests/typing-gadts/omega07.ml
@@ -898,11 +898,11 @@ val _0 : ((zero, int, 'a) rcons, int) lam = Var Zero
 val suc :
   (('a, 'b, (suc, int -> int, 'c) rcons) rcons, int) lam ->
   (('a, 'b, (suc, int -> int, 'c) rcons) rcons, int) lam = <fun>
-val _1 : ((zero, int, (suc, int -> int, '_a) rcons) rcons, int) lam =
+val _1 : ((zero, int, (suc, int -> int, '_weak1) rcons) rcons, int) lam =
   App (Shift (Var Suc), Var Zero)
-val _2 : ((zero, int, (suc, int -> int, '_a) rcons) rcons, int) lam =
+val _2 : ((zero, int, (suc, int -> int, '_weak2) rcons) rcons, int) lam =
   App (Shift (Var Suc), App (Shift (Var Suc), Var Zero))
-val _3 : ((zero, int, (suc, int -> int, '_a) rcons) rcons, int) lam =
+val _3 : ((zero, int, (suc, int -> int, '_weak3) rcons) rcons, int) lam =
   App (Shift (Var Suc),
    App (Shift (Var Suc), App (Shift (Var Suc), Var Zero)))
 val add :
@@ -916,7 +916,8 @@ val double :
   Abs (<poly>,
    App (App (Shift (Shift (Shift (Var Add))), Var <poly>), Var <poly>))
 val ex3 :
-  ((zero, int, (suc, int -> int, (add, int -> int -> int, '_a) rcons) rcons)
+  ((zero, int,
+    (suc, int -> int, (add, int -> int -> int, '_weak4) rcons) rcons)
    rcons, int)
   lam =
   App

--- a/testsuite/tests/typing-gadts/unify_mb.ml
+++ b/testsuite/tests/typing-gadts/unify_mb.ml
@@ -232,10 +232,10 @@ let t' = subst' d t
 [%%expect{|
 val s : 'a succ succ succ term = Fork (Var FZ, Fork (Var (FS (FS FZ)), Leaf))
 val t : 'a succ succ term = Fork (Var (FS FZ), Var (FS FZ))
-val d : '_a succ succ succ ealist =
+val d : '_weak1 succ succ succ ealist =
   EAlist (Asnoc (Asnoc (Anil, Fork (Var FZ, Leaf), FZ), Var FZ, FZ))
-val s' : '_a succ succ succ term =
+val s' : '_weak1 succ succ succ term =
   Fork (Fork (Var FZ, Leaf), Fork (Var FZ, Leaf))
-val t' : '_a succ succ succ term =
+val t' : '_weak1 succ succ succ term =
   Fork (Fork (Var FZ, Leaf), Fork (Var FZ, Leaf))
 |}];;

--- a/testsuite/tests/typing-objects/Tests.ml.principal.reference
+++ b/testsuite/tests/typing-objects/Tests.ml.principal.reference
@@ -50,14 +50,14 @@ Error: The abbreviation c is used with parameters bool c
     constraint 'b = 'a * < x : 'b > * 'c * 'd
     method f : 'a -> 'b -> unit
   end
-#     val x : '_a list ref = {contents = []}
+#     val x : '_weak1 list ref = {contents = []}
 #     Characters 0-50:
   class ['a] c () = object
     method f = (x : 'a)
   end..
 Error: The type of this class,
        class ['a] c :
-         unit -> object constraint 'a = '_b list ref method f : 'a end,
+         unit -> object constraint 'a = '_weak1 list ref method f : 'a end,
        contains type variables that cannot be generalized
 #       Characters 21-53:
   type 'a c = <f : 'a c; g : 'a d>
@@ -265,7 +265,7 @@ Error: Type int -> bool is not a subtype of int -> int
        Type bool is not a subtype of int 
 # - : <  > -> <  > = <fun>
 # - : < .. > -> <  > = <fun>
-#   val x : '_a list ref = {contents = []}
+#   val x : '_weak2 list ref = {contents = []}
 #   module F : functor (X : sig  end) -> sig type t = int end
 # - : < m : int > list ref = {contents = []}
 #   type 'a t

--- a/testsuite/tests/typing-objects/Tests.ml.reference
+++ b/testsuite/tests/typing-objects/Tests.ml.reference
@@ -50,14 +50,14 @@ Error: The abbreviation c is used with parameters bool c
     constraint 'b = 'a * < x : 'b > * 'c * 'd
     method f : 'a -> 'b -> unit
   end
-#     val x : '_a list ref = {contents = []}
+#     val x : '_weak1 list ref = {contents = []}
 #     Characters 0-50:
   class ['a] c () = object
     method f = (x : 'a)
   end..
 Error: The type of this class,
        class ['a] c :
-         unit -> object constraint 'a = '_b list ref method f : 'a end,
+         unit -> object constraint 'a = '_weak1 list ref method f : 'a end,
        contains type variables that cannot be generalized
 #       Characters 21-53:
   type 'a c = <f : 'a c; g : 'a d>
@@ -265,7 +265,7 @@ Error: Type int -> bool is not a subtype of int -> int
        Type bool is not a subtype of int 
 # - : <  > -> <  > = <fun>
 # - : < .. > -> <  > = <fun>
-#   val x : '_a list ref = {contents = []}
+#   val x : '_weak2 list ref = {contents = []}
 #   module F : functor (X : sig  end) -> sig type t = int end
 # - : < m : int > list ref = {contents = []}
 #   type 'a t

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1459,8 +1459,9 @@ let x = f 3;;
 [%%expect{|
 type (+'a, -'b) foo = private int
 val f : int -> ('a, 'a) foo = <fun>
-val x : ('_a, '_a) foo = 3
+val x : ('_weak1, '_weak1) foo = 3
 |}]
+
 
 (* PR#7344*)
 let rec f : unit -> < m: 'a. 'a -> 'a> = fun () ->


### PR DESCRIPTION
[MPR#248](https://caml.inria.fr/mantis/view.php?id=248):
This PR proposes to store separately the name given to weak type variable when printing them and to only forget those name once the associated weak type variable have been attributed a non weak type.
With this modification, in a given toplevel phrase or signature, each weak type variable is given an unique name. In other words, the types of
```OCaml
let mk _ x = x
let f = mk ()
let g = mk ();;
let h = f;;
```
are printed with this PR as
```OCaml
val f:'_a ->'_a
val g:'_b ->'_b (* and not '_a -> '_a as previously *)
val h:'_a -> '_a
 ```
and adding in the toplevel
```OCaml
let x = f 1;;
f;;
let i = mk ();;
```
yields
```OCaml
val x:int=1
val f: int -> int
val i: '_a -> '_a
```
Note that one disadvantage of remembering the names of weak type variables is that this deprives non weak type variables from using these names. Personally, I believe that adding a `w` prefix to the name of weak type varibles could favorably resolve this tension: the `_` prefix can be hard to see and replacing it with `_w` by convention would mitigate this issue. Another issue is that currently, the number of weak variable names kept in memory is unbounded. I am not sure if it can matter in practice.


