### PR TITLE
PR#7452: tweak GCC options to try to work around the Skylake/Kaby lake bug

### DIFF
--- a/Changes
+++ b/Changes
@@ -295,6 +295,9 @@ OCaml 4.05.0 (TBD):
 - PR#7377: remove -std=gnu99 for newer gcc versions
   (Damien Doligez, report by ygrek)
 
+- PR#7452: tweak GCC options to try to avoid the Skylake/Kaby lake bug
+  (Damien Doligez, review by ...)
+
 - GPR#693: fail on unexpected errors or warnings within caml_example
   environment.
   (Florian Angeletti)

--- a/Changes
+++ b/Changes
@@ -295,8 +295,9 @@ OCaml 4.05.0 (TBD):
 - PR#7377: remove -std=gnu99 for newer gcc versions
   (Damien Doligez, report by ygrek)
 
-- PR#7452: tweak GCC options to try to avoid the Skylake/Kaby lake bug
-  (Damien Doligez, review by David Allsopp and Xavier Leroy)
+- PR#7452, GPR#1228: tweak GCC options to try to avoid the
+  Skylake/Kaby lake bug
+  (Damien Doligez, review by David Allsopp, Xavier Leroy and Mark Shinwell)
 
 - GPR#693: fail on unexpected errors or warnings within caml_example
   environment.

--- a/Changes
+++ b/Changes
@@ -296,7 +296,7 @@ OCaml 4.05.0 (TBD):
   (Damien Doligez, report by ygrek)
 
 - PR#7452: tweak GCC options to try to avoid the Skylake/Kaby lake bug
-  (Damien Doligez, review by ...)
+  (Damien Doligez, review by David Allsopp and Xavier Leroy)
 
 - GPR#693: fail on unexpected errors or warnings within caml_example
   environment.

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -108,7 +108,9 @@ BYTECC=$(TOOLPREF)gcc -O -mms-bitfields
 BYTECODE_C_COMPILER=$(BYTECC)
 
 ### Additional compile-time options for $(BYTECC).  (For static linking.)
-BYTECCCOMPOPTS=-DCAML_NAME_SPACE -Wall -Wno-unused
+# -fno-tree-vrp is here to try to work around the Skylake/Kaby lake bug,
+# and only works on GCC 4.2 and later.
+BYTECCCOMPOPTS=-DCAML_NAME_SPACE -Wall -Wno-unused -fno-tree-vrp
 
 ### Additional compile-time options for $(BYTECC).  (For debug version.)
 BYTECCDBGCOMPOPTS=-g
@@ -183,7 +185,9 @@ NATIVECC=$(BYTECC)
 NATIVE_C_COMPILER=$(NATIVECC)
 
 ### Additional compile-time options for $(NATIVECC).
-NATIVECCCOMPOPTS=-DCAML_NAME_SPACE -Wall -Wno-unused
+# -fno-tree-vrp is here to try to work around the Skylake/Kaby lake bug,
+# and only works on GCC 4.2 and later.
+NATIVECCCOMPOPTS=-DCAML_NAME_SPACE -Wall -Wno-unused -fno-tree-vrp
 
 ### Additional link-time options for $(NATIVECC)
 NATIVECCLINKOPTS=

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -108,7 +108,9 @@ BYTECC=$(TOOLPREF)gcc -O -mms-bitfields
 BYTECODE_C_COMPILER=$(BYTECC)
 
 ### Additional compile-time options for $(BYTECC).  (For static linking.)
-BYTECCCOMPOPTS=-DCAML_NAME_SPACE -Wall -Wno-unused
+# -fno-tree-vrp is here to try to work around the Skylake/Kaby lake bug,
+# and only works on GCC 4.2 and later.
+BYTECCCOMPOPTS=-DCAML_NAME_SPACE -Wall -Wno-unused -fno-tree-vrp
 
 ### Additional compile-time options for $(BYTECC).  (For debug version.)
 BYTECCDBGCOMPOPTS=-g
@@ -183,7 +185,9 @@ NATIVECC=$(BYTECC)
 NATIVE_C_COMPILER=$(NATIVECC)
 
 ### Additional compile-time options for $(NATIVECC).
-NATIVECCCOMPOPTS=-DCAML_NAME_SPACE -Wall -Wno-unused
+# -fno-tree-vrp is here to try to work around the Skylake/Kaby lake bug,
+# and only works on GCC 4.2 and later.
+NATIVECCCOMPOPTS=-DCAML_NAME_SPACE -Wall -Wno-unused -fno-tree-vrp
 
 ### Additional link-time options for $(NATIVECC)
 NATIVECCLINKOPTS=

--- a/configure
+++ b/configure
@@ -868,7 +868,7 @@ fi
 case "$bytecc,$target" in
     *gcc*,x86_64-*|*gcc*,i686-*)
         if sh ./hasgot -Werror -fno-tree-vrp; then
-            bytecccompopts="$bytecccompopts -fno-tree-vrp"
+            byteccprivatecompopts="$byteccprivatecompopts -fno-tree-vrp"
             inf "Adding -fno-tree-vrp option to work around PR#7452"
         fi;;
 esac

--- a/configure
+++ b/configure
@@ -864,6 +864,16 @@ else
 fi
 
 
+# Try to work around the Skylake/Kaby Lake processor bug.
+case "$bytecc,$target" in
+    *gcc*,x86_64-*|*gcc*,i686-*)
+        if sh ./hasgot -Werror -fno-tree-vrp; then
+            bytecccompopts="$bytecccompopts -fno-tree-vrp"
+            inf "adding -fno-tree-vrp option to work around PR#7452"
+        fi;;
+esac
+
+
 # Configure the native-code compiler
 
 # The NATIVECC make variable defines which compiler and options to use

--- a/configure
+++ b/configure
@@ -869,7 +869,7 @@ case "$bytecc,$target" in
     *gcc*,x86_64-*|*gcc*,i686-*)
         if sh ./hasgot -Werror -fno-tree-vrp; then
             bytecccompopts="$bytecccompopts -fno-tree-vrp"
-            inf "adding -fno-tree-vrp option to work around PR#7452"
+            inf "Adding -fno-tree-vrp option to work around PR#7452"
         fi;;
 esac
 


### PR DESCRIPTION
Pending benchmarks on the performance impact of disabling some gcc optimizations, this PR tries to work around the infamous processor bug described in [PR#7452](https://caml.inria.fr/mantis/view.php?id=7452) and copiously documented on the web:

* http://gallium.inria.fr/blog/intel-skylake-bug/
* https://lists.debian.org/debian-devel/2017/06/msg00308.html
* https://tech.ahrefs.com/skylake-bug-a-detective-story-ab1ad2beddcd
