### PR TITLE
Format: Add functions for printing conditionally on line breaks

### DIFF
--- a/Changes
+++ b/Changes
@@ -86,6 +86,11 @@ Working version
   (Sébastien Hinderer, review by Damien Doligez, Gabriel Scherer, David
   Allsopp, Nicolás Ojeda Bär, Vincent Laviron)
 
+- #1229: Add functions to Format module for printing strings conditionally
+  on line breaks.
+  (Josh Berdine, Guillaume Petiot, review by Richard Bonichon, Gabriel Scherer
+  and Vladimir Keleshev)
+
 ### Other libraries:
 
 - #10192: Add support for Unix domain sockets on Windows and use them

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -62,15 +62,18 @@ type box_type = CamlinternalFormatBasics.block_type =
   | Pp_hbox | Pp_vbox | Pp_hvbox | Pp_hovbox | Pp_box | Pp_fits
 
 
+type fits_or_breaks = {
+  fits: string * int * string;   (* when the line is not split *)
+  breaks: string * int * string; (* when the line is split *)
+}
+
+
 (* The pretty-printing tokens definition:
    are either text to print or pretty printing
    elements that drive indentation and line splitting. *)
 type pp_token =
   | Pp_text of string          (* normal text *)
-  | Pp_break of {              (* complete break *)
-      fits: string * int * string;   (* line is not split *)
-      breaks: string * int * string; (* line is split *)
-    }
+  | Pp_break of fits_or_breaks (* complete break *)
   | Pp_tbreak of int * int     (* go to next tabulation *)
   | Pp_stab                    (* set a tabulation *)
   | Pp_begin of int * box_type (* beginning of a box *)
@@ -80,6 +83,16 @@ type pp_token =
   | Pp_newline                 (* to force a newline inside a box *)
   | Pp_if_newline              (* to do something only if this very
                                   line has been broken *)
+  | Pp_string_if_newline of string
+                               (* print a string only if this very
+                                  line has been broken *)
+  | Pp_or_newline of int * int * string * string
+                               (* print a break and the first string if this
+                                  very line has not been broken, otherwise
+                                  print the second string *)
+  | Pp_fits_or_breaks of int * string * int * int * string
+                               (* print a string if the enclosing box fits,
+                                  otherwise print a break and a string *)
   | Pp_open_tag of stag         (* opening a tag name *)
   | Pp_close_tag               (* closing the most recently open tag *)
 
@@ -316,6 +329,33 @@ let pp_skip_token state =
 
 *)
 
+let format_pp_break state size fits breaks =
+  let before, off, _ = breaks in
+  begin match Stack.top_opt state.pp_format_stack with
+  | None -> () (* No open box. *)
+  | Some { box_type; width } ->
+    begin match box_type with
+    | Pp_hovbox ->
+      if size + String.length before > state.pp_space_left
+      then break_new_line state breaks width
+      else break_same_line state fits
+    | Pp_box ->
+      (* Have the line just been broken here ? *)
+      if state.pp_is_new_line then break_same_line state fits else
+      if size + String.length before > state.pp_space_left
+      then break_new_line state breaks width else
+      (* break the line here leads to new indentation ? *)
+      if state.pp_current_indent > state.pp_margin - width + off
+      then break_new_line state breaks width
+      else break_same_line state fits
+    | Pp_hvbox -> break_new_line state breaks width
+    | Pp_fits -> break_same_line state fits
+    | Pp_vbox -> break_new_line state breaks width
+    | Pp_hbox -> break_same_line state fits
+    end
+  end
+
+
 (* Formatting a token with a given size. *)
 let format_pp_token state size = function
 
@@ -384,31 +424,40 @@ let format_pp_token state size = function
     if state.pp_current_indent != state.pp_margin - state.pp_space_left
     then pp_skip_token state
 
+  | Pp_string_if_newline s ->
+    if state.pp_is_new_line
+    then format_string state s
+
   | Pp_break { fits; breaks } ->
-    let before, off, _ = breaks in
-    begin match Stack.top_opt state.pp_format_stack with
-    | None -> () (* No open box. *)
-    | Some { box_type; width } ->
-      begin match box_type with
-      | Pp_hovbox ->
-        if size + String.length before > state.pp_space_left
-        then break_new_line state breaks width
-        else break_same_line state fits
-      | Pp_box ->
-        (* Have the line just been broken here ? *)
-        if state.pp_is_new_line then break_same_line state fits else
-        if size + String.length before > state.pp_space_left
-          then break_new_line state breaks width else
-        (* break the line here leads to new indentation ? *)
-        if state.pp_current_indent > state.pp_margin - width + off
-        then break_new_line state breaks width
-        else break_same_line state fits
-      | Pp_hvbox -> break_new_line state breaks width
-      | Pp_fits -> break_same_line state fits
-      | Pp_vbox -> break_new_line state breaks width
-      | Pp_hbox -> break_same_line state fits
-      end
-    end
+    format_pp_break state size fits breaks
+
+
+  | Pp_or_newline (n, off, fits, breaks) ->
+    if state.pp_is_new_line
+    then format_string state breaks
+    else format_pp_break state size ("", n, fits) ("", off, breaks)
+
+  | Pp_fits_or_breaks (level, fits, n, off, breaks) ->
+     let check_level level { box_type= ty; width } =
+       if level < 0 then level
+       else if ty = Pp_fits then
+         begin
+           if level = 0 then format_string state fits ;
+           level - 1
+         end
+       else
+         begin
+           if off > min_int then
+             begin
+               if size + n + String.length breaks >= state.pp_space_left
+               then break_new_line state ("", off, "") width
+               else break_same_line state ("", n, "")
+             end;
+           format_string state breaks;
+           - 1
+         end
+     in
+     ignore (Stack.fold check_level level state.pp_format_stack)
 
    | Pp_open_tag tag_name ->
      let marker = state.pp_mark_open_tag tag_name in
@@ -482,7 +531,8 @@ let set_size state ty =
       initialize_scan_stack state.pp_scan_stack
     else
       match queue_elem.token with
-      | Pp_break _ | Pp_tbreak (_, _) ->
+      | Pp_break _ | Pp_tbreak (_, _)
+      | Pp_or_newline _ | Pp_fits_or_breaks _ ->
         if ty then begin
           queue_elem.size <- Size.of_int (state.pp_right_total + size);
           Stack.pop_opt state.pp_scan_stack |> ignore
@@ -493,7 +543,8 @@ let set_size state ty =
           Stack.pop_opt state.pp_scan_stack |> ignore
         end
       | Pp_text _ | Pp_stab | Pp_tbegin _ | Pp_tend | Pp_end
-      | Pp_newline | Pp_if_newline | Pp_open_tag _ | Pp_close_tag ->
+      | Pp_newline | Pp_if_newline | Pp_string_if_newline _
+      | Pp_open_tag _ | Pp_close_tag ->
         () (* scan_push is only used for breaks and boxes. *)
 
 
@@ -700,6 +751,15 @@ let pp_print_custom_break state ~fits ~breaks =
     let elem = { size; token; length } in
     scan_push state true elem
 
+(* To format a string, only in case the line has just been broken. *)
+let pp_print_string_if_newline state s =
+  if state.pp_curr_depth < state.pp_max_boxes then
+    let length = String.length s in
+    let size = Size.zero in
+    let token = Pp_string_if_newline s in
+    enqueue_advance state { size; token; length }
+
+
 (* Printing break hints:
    A break hint indicates where a box may be broken.
    If line is broken then offset is added to the indentation of the current
@@ -707,6 +767,26 @@ let pp_print_custom_break state ~fits ~breaks =
 let pp_print_break state width offset =
   pp_print_custom_break state
     ~fits:("", width, "") ~breaks:("", offset, "")
+
+
+(* To format a break and the first string, only in case the line has not just
+   been broken, or the second string, in case the line has just been broken. *)
+let pp_print_or_newline state width offset fits breaks =
+  if state.pp_curr_depth < state.pp_max_boxes then
+    let size = Size.of_int (- state.pp_right_total) in
+    let token = Pp_or_newline (width, offset, fits, breaks) in
+    let width = width + String.length fits in
+    scan_push state true { size; token; length= width }
+
+
+(* To format a string if the enclosing box fits, and otherwise to format a
+   break and a string. *)
+let pp_print_fits_or_breaks state ?(level = 0) fits nspaces offset breaks =
+  if state.pp_curr_depth < state.pp_max_boxes then
+    let size = Size.of_int (- state.pp_right_total) in
+    let token = Pp_fits_or_breaks (level, fits, nspaces, offset, breaks) in
+    let length = String.length fits in
+    scan_push state true { size; token; length }
 
 
 (* Print a space :

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -359,6 +359,22 @@ val print_if_newline : unit -> unit
   command.
 *)
 
+val pp_print_string_if_newline : formatter -> string -> unit
+(** Similar to [print_if_newline] followed by [print_string] except that the
+  length of the string does not contribute to the width of the enclosing
+  box. *)
+
+val pp_print_or_newline : formatter -> int -> int -> string -> string -> unit
+(** Print a full break hint and the first string if the preceding line has
+  not just been split. Otherwise, print the second string. *)
+
+val pp_print_fits_or_breaks :
+  formatter -> ?level:int -> string -> int -> int -> string -> unit
+(** [pp_print_fits_or_breaks fmt ?level fits nspaces offset breaks] prints
+  [fits] if the enclosing boxes fits on one line ([level] being the depth of
+  boxes that are checked in the stack). Otherwise, prints a break as per
+  [print_break nspaces offset] followed by [breaks]. *)
+
 (** {1 Pretty-printing termination} *)
 
 val pp_print_flush : formatter -> unit -> unit

--- a/testsuite/tests/lib-format/gpr1229.ml
+++ b/testsuite/tests/lib-format/gpr1229.ml
@@ -1,0 +1,92 @@
+(* TEST *)
+
+(*
+A test file for Format.print_string_if_newline,
+print_or_newline and print_fits_or_breaks.
+*)
+
+let set_margin n =
+  Format.set_margin n;
+  Format.set_max_indent (n - 1)
+
+open Format;;
+
+let print_string_if_newline = pp_print_string_if_newline std_formatter
+let print_or_newline = pp_print_or_newline std_formatter
+let print_fits_or_breaks = pp_print_fits_or_breaks std_formatter
+
+let test_print_string_if_newline m =
+  let case ~first =
+    print_space ();
+    if first
+    then print_string_if_newline "| "
+    else print_string "| ";
+    print_string "Foooo -> foooo"
+  in
+  print_string "margin = ";
+  print_int m;
+  print_newline ();
+  set_margin m;
+  open_hvbox 2;
+  print_string "let foo = function";
+  case ~first:true;
+  case ~first:false;
+  close_box ();
+  print_newline ()
+;;
+
+test_print_string_if_newline 15;;
+test_print_string_if_newline 55;;
+
+print_newline ();;
+
+let test_print_or_newline m =
+  let sep ~first =
+    print_space ();
+    if first
+    then print_or_newline 0 0 "" "  (* breaks *) "
+    else print_or_newline 0 0 "; " "; (* breaks *) "
+  in
+  print_string "margin = ";
+  print_int m;
+  print_newline ();
+  set_margin m;
+  open_hvbox 0;
+  print_string "let foo ="; print_space ();
+  print_string "[";
+  sep ~first:true;
+  print_string "0"; sep ~first:false;
+  print_string "0"; sep ~first:false;
+  print_string "0"; sep ~first:false;
+  print_string "0"; sep ~first:false;
+  print_string "0"; sep ~first:false;
+  print_string "0";
+  print_space ();
+  print_string "]";
+  close_box ();
+  print_newline ()
+;;
+
+test_print_or_newline 20;;
+test_print_or_newline 60;;
+
+print_newline ();;
+
+let test_print_fits_or_breaks m =
+  print_string "margin = ";
+  print_int m;
+  print_newline ();
+  set_margin m;
+  open_hvbox 0;
+  print_fits_or_breaks "" 0 0 "( ";
+  print_string "a";
+  for i = 1 to 10 do
+    print_space (); print_string "+ a"
+  done;
+  print_fits_or_breaks "" 0 1 " )";
+  close_box ();
+  print_newline ()
+;;
+
+test_print_fits_or_breaks 15;;
+test_print_fits_or_breaks 50;;

--- a/testsuite/tests/lib-format/gpr1229.reference
+++ b/testsuite/tests/lib-format/gpr1229.reference
@@ -1,0 +1,34 @@
+margin = 15
+let foo = function
+  | Foooo -> foooo
+  | Foooo -> foooo
+margin = 55
+let foo = function Foooo -> foooo | Foooo -> foooo
+
+margin = 20
+let foo =
+[
+  (* breaks *) 0
+; (* breaks *) 0
+; (* breaks *) 0
+; (* breaks *) 0
+; (* breaks *) 0
+; (* breaks *) 0
+]
+margin = 60
+let foo = [ 0 ; 0 ; 0 ; 0 ; 0 ; 0 ]
+
+margin = 15
+( a
++ a
++ a
++ a
++ a
++ a
++ a
++ a
++ a
++ a
++ a )
+margin = 50
+a + a + a + a + a + a + a + a + a + a + a


### PR DESCRIPTION
This PR adds a few functions to format conditionally on whether lines are broken. These are very limited so that they can be implemented without changing the internal algorithms or invariants of the Format module. In particular, the conditionally formatted material can only be strings, not the result of other formatting, so that their length can be computed before knowing whether boxes break.

In its current form this PR duplicates a bunch of code in order to make a less invasive diff. If the added functionality and overall approach is supported, I am happy to refactor to avoid duplicating code.

See [format.mli](https://github.com/ocaml/ocaml/compare/trunk...jberdine:cond_format?expand=1#diff-ecd205ea92ba9c2fdfd17d570a7ef7b0) for the high-level summary of the added functionality.