### PR TITLE
warning 25: updated the man page and the behavior a bit

### DIFF
--- a/man/ocamlc.m
+++ b/man/ocamlc.m
@@ -840,7 +840,7 @@ clause.
 \ \ Bad module name: the source file name is not a valid OCaml module name.
 
 25
-\ \ Pattern-matching with all clauses guarded.
+\ \ Deprecated: now part of warning 8.
 
 26
 \ \ Suspicious unused variable: unused variable that is bound with

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -566,9 +566,7 @@ let descriptions =
    23, "Useless record \"with\" clause.";
    24, "Bad module name: the source file name is not a valid OCaml module \
         name.";
-   (* 25, "Pattern-matching with all clauses guarded.  Exhaustiveness cannot \
-      be\n\
-   \    checked.";  (* Now part of warning 8 *) *)
+   25, "Deprecated: now part of warning 8.";
    26, "Suspicious unused variable: unused variable that is bound\n\
    \    with \"let\" or \"as\", and doesn't start with an underscore (\"_\")\n\
    \    character.";

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -44,7 +44,7 @@ type t =
   | Preprocessor of string                  (* 22 *)
   | Useless_record_with                     (* 23 *)
   | Bad_module_name of string               (* 24 *)
-  | All_clauses_guarded                     (* 25 *)
+  | All_clauses_guarded                     (* 8, used to be 25 *)
   | Unused_var of string                    (* 26 *)
   | Unused_var_strict of string             (* 27 *)
   | Wildcard_arg_to_constant_constr         (* 28 *)


### PR DESCRIPTION
The manpage entry of `ocamlc` regarding warning 25 is basically wrong.
I "fixed" the manpage entry and @lpw25 urged me to also add some code which activates warning 8 when people activate warning 25, this seems right to me though perhaps overkill.

@alainfrisch you were the one (in https://github.com/ocaml/ocaml/commit/c610f7379c9ee911a55d95783e3edaffee8a2522 ) to map 25 to 8,  do have any opinion about this PR?

PS: I don't think this requires a Changes entry.