### PR TITLE
Stdlib, documentation: format margin and maximum indentation are coupled

### DIFF
--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -311,6 +311,10 @@ val set_margin : int -> unit
   Nothing happens if [d] is smaller than 2.
   If [d] is too large, the right margin is set to the maximum
   admissible value (which is greater than [10 ^ 9]).
+  If [d] is less than the current maximum indentation limit, the
+  maximum indentation limit is decreased while trying to preserve
+  a minimal ratio [max_indent/margin>=50%] and if possible
+  the current difference [margin - max_indent].
 *)
 
 val get_margin : unit -> int
@@ -327,6 +331,9 @@ val set_max_indent : int -> unit
   Nothing happens if [d] is smaller than 2.
   If [d] is too large, the limit is set to the maximum
   admissible value (which is greater than [10 ^ 9]).
+
+  If [d] is greater or equal than the current margin, it is ignored,
+  and the current maximum indentation limit is kept.
 *)
 
 val get_max_indent : unit -> int


### PR DESCRIPTION
This PR (partially related to [Mantis#7528](https://caml.inria.fr/mantis/view.php?id=7528)) documents the fact that the margin and maximum indentation limit of a `Format.formatter` are coupled (by the following inequality `0 ≤ max_indent < margin`).

In particular, call to `Format.pp_set_margin` can decrease the value of maximum indentation limit and reciprocally calls to `Format.pp_set_max_indent` with values greater than the current margin are simply ignored.

Note that the currently implementation can lead to somewhat surprising memory effect and I am not sure that this is the most user-friendly choice. For this reason, I am not marking this PR as an answer to [mantis#7528](https://caml.inria.fr/mantis/view.php?id=7528). Nevertheless, the current coupling ought to be documented at the very least.