### PR TITLE
Avoid "internal" deprecation warnings

### DIFF
--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -62,6 +62,13 @@ let rec error_of_extension ext =
 let cat s1 s2 =
   if s2 = "" then s1 else s1 ^ "\n" ^ s2
 
+let partition_deprecated_attrs =
+  List.partition
+    (function
+      | ({txt = "ocaml.deprecated"|"deprecated"; _}, _) -> true
+      | _ -> false
+    )
+
 let rec deprecated_of_attrs = function
   | [] -> None
   | ({txt = "ocaml.deprecated"|"deprecated"; _}, p) :: _ ->

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -32,6 +32,8 @@ val check_deprecated: Location.t -> Parsetree.attributes -> string -> unit
 val check_deprecated_inclusion:
   def:Location.t -> use:Location.t -> Location.t -> Parsetree.attributes ->
   Parsetree.attributes -> string -> unit
+val partition_deprecated_attrs:
+  Parsetree.attributes -> Parsetree.attributes * Parsetree.attributes
 val deprecated_of_attrs: Parsetree.attributes -> string option
 val deprecated_of_sig: Parsetree.signature -> string option
 val deprecated_of_str: Parsetree.structure -> string option

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1211,7 +1211,26 @@ let transl_type_decl env rec_flag sdecl_list =
       fixed_types
     @ sdecl_list
   in
+  (* Remove @@ocaml.deprecated attributes from the type-checked
+     declarations so that references to deprecated types in the
+     current signature/structure does not trigger the deprecation
+     warning.  The attributes will be added back to the final
+     declarations, which will be the ones visible from outside the
+     current signature/structure.
 
+     See MPR#7005
+  *)
+  let sdecl_list, deprecated =
+    List.map
+      (fun sdecl ->
+         let (deprecated, others) =
+           Builtin_attributes.partition_deprecated_attrs sdecl.ptype_attributes
+         in
+         {sdecl with ptype_attributes = others}, deprecated
+      )
+      sdecl_list
+    |> List.split
+  in
   (* Create identifiers. *)
   let id_list =
     List.map (fun sdecl -> Ident.create sdecl.ptype_name.txt) sdecl_list
@@ -1325,10 +1344,16 @@ let transl_type_decl env rec_flag sdecl_list =
   in
   (* Check re-exportation *)
   List.iter2 (check_abbrev final_env) sdecl_list final_decls;
+  (* Restore ocaml.deprecated attributes on returned declarations *)
+  let final_decls =
+    List.map2
+      (fun (_id, decl) attrs -> {decl with type_attributes = attrs @ decl.type_attributes})
+      final_decls deprecated
+  in
   (* Keep original declaration *)
   let final_decls =
     List.map2
-      (fun tdecl (_id2, decl) ->
+      (fun tdecl decl ->
         { tdecl with typ_type = decl }
       ) tdecls final_decls
   in


### PR DESCRIPTION
See https://caml.inria.fr/mantis/view.php?id=7005

Deprecation warnings in a signature are usually intended for clients of the library, not for internal references.  Typically, when a type declaration is marked as deprecated in an .mli file, it is a bit silly to report references to that declaration in the same .mli file.

The current PR changes the handling of deprecation attributes on type declarations.  For now, this is for discussion only, and if this semantics is adopted, it should be generalized to other kinds of declarations that support the deprecated attribute.

The idea is to make deprecation attributes visible only outside the current signature/structure, not for type-checking the rest of the signature/structure.  This is achieved by removing the attribute before type-checking and adding them back to the type-checked declarations that will end up in the synthesized internal module type.  In particular, the type-checking environments used for the rest of the signature/structure and for the declaration itself (for recursive definitions) will not see the attribute.

This gives the following behavior:

````ocaml
module A : sig
  type t = X of t [@@ocaml.deprecated] (* => no warning *)
  val x: t  (* => no warning *)
  module B: sig
    type s = t (* => no warning *)
    val x: t (* => no warning *)

    type u [@@ocaml.deprecated]
  end

  val y: B.u (* => WARNING! *)
end
````

I wanted to get people's opinion on this new interpretation of deprecation warnings.

Note: I guess that those warnings are mostly used on value declarations in signatures, and this change would not impact this case.