### PR TITLE
Disable cplugins feature by default

### DIFF
--- a/Changes
+++ b/Changes
@@ -190,6 +190,9 @@ Working version
 - GPR#1203: speed up the manual build by using ocamldoc.opt
   (Gabriel Scherer, review by Florian Angeletti)
 
+- GPR#1242: disable C plugins loading by default
+  (Alexey Egorov)
+
 ### Internal/compiler-libs changes:
 
 - PR#6826, GPR#828, GPR#834: improve compilation time for open

--- a/configure
+++ b/configure
@@ -206,8 +206,10 @@ while : ; do
         native_compiler=false;;
     -flambda|--flambda)
         flambda=true;;
-    -cplugins|--cplugins)
+    -with-cplugins|--with-cplugins)
         with_cplugins=true;;
+    -no-cplugins|--no-cplugins)
+        ;; # Ignored for backward compatibility
     -fPIC|--fPIC)
         with_fpic=true;;
     -safe-string|--safe-string)

--- a/configure
+++ b/configure
@@ -65,7 +65,7 @@ flambda=false
 safe_string=false
 afl_instrument=false
 max_testsuite_dir_retries=0
-with_cplugins=true
+with_cplugins=false
 with_fpic=false
 
 # Try to turn internationalization off, can cause config.guess to malfunction!
@@ -206,8 +206,8 @@ while : ; do
         native_compiler=false;;
     -flambda|--flambda)
         flambda=true;;
-    -no-cplugins|--no-cplugins)
-        with_cplugins=false;;
+    -cplugins|--cplugins)
+        with_cplugins=true;;
     -fPIC|--fPIC)
         with_fpic=true;;
     -safe-string|--safe-string)


### PR DESCRIPTION
This change disables CPLUGINS feature by default.
Added "--with-cplugins" configure parameter.

Motivation:
- Loading shared libraries based on some environment variables is error-prone and should be avoided unless really needed (see CVE-2017-9772 which is introduced by this feature)
- Most users doesn't use this feature (it's not even documented!), so disabling it seems like a more reasonable default.