### PR TITLE
Fix pprintast for infix operators starting with #

### DIFF
--- a/Changes
+++ b/Changes
@@ -271,6 +271,10 @@ Working version
   (Ethan Aubin, suggestion by Gabriel Scherer, review by David Allsopp,
   Florian Angeletti, and Gabriel Scherer)
 
+- Fix pprintast for #... infix operators
+  (Alain Frisch, report by Omar Chebib)
+
+
 ### Runtime system:
 
 - GPR#71: The runtime can now be shut down gracefully by means of the new

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -30,7 +30,7 @@ open Ast_helper
 
 let prefix_symbols  = [ '!'; '?'; '~' ] ;;
 let infix_symbols = [ '='; '<'; '>'; '@'; '^'; '|'; '&'; '+'; '-'; '*'; '/';
-                      '$'; '%' ]
+                      '$'; '%'; '#' ]
 (* type fixity = Infix| Prefix  *)
 let special_infix_strings =
   ["asr"; "land"; "lor"; "lsl"; "lsr"; "lxor"; "mod"; "or"; ":="; "!=" ]

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7294,3 +7294,7 @@ let f = function _::(_::_ [@foo]) -> () | _ -> ();;
 function {contents=contents[@foo]} -> ();;
 fun contents -> {contents=contents[@foo]};;
 ((); (((); ())[@foo]));;
+
+(* https://github.com/LexiFi/gen_js_api/issues/61 *)
+
+let () = foo##.bar := ();;


### PR DESCRIPTION
OCaml now accepts binary infix operators starting with #, but pprintast.ml was not aware of it, resulting in incorrect printing of these operators.  See https://github.com/LexiFi/gen_js_api/issues/61