### PR TITLE
.travis-ci.sh: make git commit manipulation more robust for branch builds.

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -32,9 +32,13 @@ MAKE=make SHELL=dash
 #        |          /
 #  TRAVIS_MERGE_BASE
 #
+echo TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE
 TRAVIS_CUR_HEAD=${TRAVIS_COMMIT_RANGE%%...*}
 TRAVIS_PR_HEAD=${TRAVIS_COMMIT_RANGE##*...}
-TRAVIS_MERGE_BASE=$(git merge-base $TRAVIS_CUR_HEAD $TRAVIS_PR_HEAD)
+case $TRAVIS_EVENT_TYPE in
+   # If this is not a pull request then TRAVIS_COMMIT_RANGE may be empty.
+   pull_request) TRAVIS_MERGE_BASE=$(git merge-base $TRAVIS_CUR_HEAD $TRAVIS_PR_HEAD);;
+esac
 
 BuildAndTest () {
   case $XARCH in


### PR DESCRIPTION
For Travis builds triggered by pushes to branches, [`$TRAVIS_COMMIT_RANGE` may be empty](https://github.com/travis-ci/travis-ci/issues/5133).  At present, `.travis-ci.sh` assumes that `$TRAVIS_COMMIT_RANGE` is non-empty, so branch builds fail.

For example, https://github.com/ocaml/ocaml/pull/1245 has two Travis builds
* [one for the branch](https://travis-ci.org/ocaml/ocaml/builds/253690201?utm_source=github_status&utm_medium=notification), which fails
* [one for the pull request](https://travis-ci.org/ocaml/ocaml/builds/253691654?utm_source=github_status&utm_medium=notification), which succeeds

This pr adds a guard to prevent `git merge-base` from being run on branch builds.