### PR TITLE
Aarch64 - enable large immediate offset

### DIFF
--- a/Changes
+++ b/Changes
@@ -44,6 +44,9 @@ Working version
 - MPR#7531, GPR#1162: Erroneous code transformation at partial applications
   (Mark Shinwell)
 
+- GPR#1250: illegal ARM64 assembly code generated for large combined allocations
+  (report and initial fix by Steve Walk, review and final fix by Xavier Leroy)
+
 ### Standard library:
 
 - GPR#1217: Restrict Unix.environment in privileged contexts; add

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -518,10 +518,18 @@ let assembly_code_for_allocation ?label_after_call_gc i ~n ~far =
   if !fastcode_flag then begin
     let lbl_redo = new_label() in
     let lbl_call_gc = new_label() in
-    `{emit_label lbl_redo}:`;
-    `	sub	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int n}\n`;
-    `	cmp	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_limit}\n`;
-    `	add	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
+    if n > 4096 then begin
+      `{emit_label lbl_redo}:`;
+      emit_intconst reg_tmp1 (Nativeint.of_int n);
+      ` sub     {emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, {emit_reg reg_tmp1}\n`;
+      ` cmp     {emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_limit}\n`;
+      ` add     {emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
+    end else begin
+      `{emit_label lbl_redo}:`;
+      ` sub     {emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int n}\n`;
+      ` cmp     {emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_limit}\n`;
+      ` add     {emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
+    end;
     if not far then begin
       `	b.lo	{emit_label lbl_call_gc}\n`
     end else begin

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -439,8 +439,10 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Iload (size, addr)) | Lop (Istore (size, addr, _)) ->
       let based = match addr with Iindexed _ -> 0 | Ibased _ -> 1 in
       based + begin match size with Single -> 2 | _ -> 1 end
-    | Lop (Ialloc _) when !fastcode_flag -> 4
-    | Lop (Ispecific (Ifar_alloc _)) when !fastcode_flag -> 5
+    | Lop (Ialloc {words = num_words}) when !fastcode_flag ->
+      if num_words <= 0xFFF then 4 else 5
+    | Lop (Ispecific (Ifar_alloc {words = num_words})) when !fastcode_flag ->
+      if num_words <= 0xFFF then 5 else 6
     | Lop (Ialloc { words = num_words; _ })
     | Lop (Ispecific (Ifar_alloc { words = num_words; _ })) ->
       begin match num_words with
@@ -518,18 +520,15 @@ let assembly_code_for_allocation ?label_after_call_gc i ~n ~far =
   if !fastcode_flag then begin
     let lbl_redo = new_label() in
     let lbl_call_gc = new_label() in
-    if n > 4096 then begin
-      `{emit_label lbl_redo}:`;
-      emit_intconst reg_tmp1 (Nativeint.of_int n);
-      ` sub     {emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, {emit_reg reg_tmp1}\n`;
-      ` cmp     {emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_limit}\n`;
-      ` add     {emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
-    end else begin
-      `{emit_label lbl_redo}:`;
-      ` sub     {emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int n}\n`;
-      ` cmp     {emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_limit}\n`;
-      ` add     {emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
-    end;
+    assert (n < 0x1_000_000);
+    let nl = n land 0xFFF and nh = n land 0xFFF_000 in
+    `{emit_label lbl_redo}:`;
+    if nh <> 0 then
+      `	sub	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int nh}\n`;
+    if nl <> 0 then
+      `	sub	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_ptr}, #{emit_int nl}\n`;
+    `	cmp	{emit_reg reg_alloc_ptr}, {emit_reg reg_alloc_limit}\n`;
+    `	add	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, #8\n`;
     if not far then begin
       `	b.lo	{emit_label lbl_call_gc}\n`
     end else begin


### PR DESCRIPTION
Facebook is using ocaml version 4.03 in their hhvm project.  Recently they hit a limit in the
ocaml code generation for ARM64.  This blocked building hhvm on ARM64 hosts.

The error signature is given blow, but it hit a unique sequence of instructions.  ocaml
was trying to generate an invalid immediate offset in a subtract instruction.  This change
will use one of the temporary registers if the value is too large.

The testsuite was run before/after this change.  No difference in the output was seen.

Since this is a limit problem, I'm not sure how to create a small test case.

hhvm/third-party/ocaml/build/bin/ocamlopt.opt -c -g -w A -w -3-4-6-29-35-44-48-50-52 -I parser -I fsnotify_linux      -I watchman -I server -I ast -I hhbc -I hhi -I watchman_event_watcher -I typing -I libancillary -I dfind -I recorder -I deps -I heap -I s     earch -I find -I decl -I format -I utils -I ide_rpc -I debug -I client -I hackfmt -I globals -I diff -I stubs -I naming -I monitor -I proc     s -I socket -I options -I injection/default_injector -I utils/process -I utils/collections -I utils/errors -I utils/hh_json -I utils/lint      -I utils/hg -I utils/disk -I hackfmt/error -I hackfmt/line_splitter -I hackfmt/debug -I third-party/avl -I third-party/inotify -I third-pa     rty/core -I parser/coroutine -I parser/schema -o parser/full_fidelity_validated_syntax.cmx parser/full_fidelity_validated_syntax.ml
/tmp/camlasmc2926f.s: Assembler messages:
/tmp/camlasmc2926f.s:38621: Error: immediate out of range  //<<---
 File "parser/full_fidelity_validated_syntax.ml", line 1:
Error: Assembler error, input left in file /tmp/camlasmc2926f.s
Command exited with code 2.

`38617         add     x6, x6, #:lo12:camlFull_fidelity_validated_syntax__invalidate_list_with_6322`
`38618         str     x6, [x7, #16]`
`38619         str     x13, [x7, #24]`
`38620         str     x11, [x7, #32]`
`38621 .L4580: sub     x27, x27, #8728`  //<<---
`38622         cmp     x27, x28 `
`38623         add     x0, x27, #8`
`38624         b.lo    .L4581`
`38625         str     x0, [sp, #96]`
`38626         movz    x6, #17, lsl #16 `
parser/full_fidelity_validated_syntax.s
