### PR TITLE
Private extensible variants

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,6 +26,9 @@ Working version
   and patterns (plus fix printing of (::) in the toplevel)
   (Florian Angeletti, review by Alain Frisch, Gabriel Scherer)
 
+- GPR#1253: Private extensible variants
+  (Leo White, review by Alain Frisch)
+
 ### Code generation and optimizations:
 
 - MPR#5324, GPR#375: An alternative Linear Scan register allocator for

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1970,7 +1970,43 @@ Extensible variant constructors can be declared "private". As with
 regular variants, this prevents them from being constructed directly by
 constructor application while still allowing them to be de-structured in
 pattern-matching.
+\begin{verbatim}
+        module Bool : sig
+          type attr += private Bool of int
+          val bool : bool -> attr
+        end = struct
+          type attr += Bool of int
+          let bool p = if p then Bool 1 else Bool 0
+        end
+\end{verbatim}
 
+\subsection{Private extensible variant types}
+
+(Introduced in OCaml 4.06)
+
+\begin{syntax}
+type-representation:
+          ...
+        | '=' 'private' '..'
+;
+\end{syntax}
+
+Extensible variant types can be declared "private". This prevents new
+constructors from being declared directly, but allows extension
+constructors to be referred to in interfaces.
+\begin{verbatim}
+        module Msg : sig
+          type t = private ..
+          module MkConstr (X : sig type t end) : sig
+            type t += C of X.t
+          end
+        end = struct
+          type t = ..
+          module MkConstr (X : sig type t end) = struct
+            type t += C of X.t
+          end
+        end
+\end{verbatim}
 
 \section{Generative functors}\label{s:generative-functors}
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1926,12 +1926,14 @@ type_kind:
       { (Ptype_variant(List.rev $3), Private, None) }
   | EQUAL DOTDOT
       { (Ptype_open, Public, None) }
+  | EQUAL PRIVATE DOTDOT
+      { (Ptype_open, Private, None) }
   | EQUAL private_flag LBRACE label_declarations RBRACE
       { (Ptype_record $4, $2, None) }
   | EQUAL core_type EQUAL private_flag constructor_declarations
       { (Ptype_variant(List.rev $5), $4, Some $2) }
-  | EQUAL core_type EQUAL DOTDOT
-      { (Ptype_open, Public, Some $2) }
+  | EQUAL core_type EQUAL private_flag DOTDOT
+      { (Ptype_open, $4, Some $2) }
   | EQUAL core_type EQUAL private_flag LBRACE label_declarations RBRACE
       { (Ptype_record $6, $4, Some $2) }
 ;

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -23,6 +23,14 @@ type foo
 type foo += A of int (* Error type is not open *)
 ;;
 
+(* The type must be public to create extension *)
+
+type foo = private ..
+;;
+
+type foo += A of int (* Error type is private *)
+;;
+
 (* The type parameters must match *)
 
 type 'a foo = ..
@@ -31,11 +39,11 @@ type 'a foo = ..
 type ('a, 'b) foo += A of int (* Error: type parameter mismatch *)
 ;;
 
-(* In a signature the type does not have to be open *)
+(* In a signature the type can be private *)
 
 module type S =
 sig
-  type foo
+  type foo = private ..
   type foo += A of float
 end
 ;;
@@ -44,8 +52,8 @@ end
 
 module type S =
 sig
-  type foo = A of int
-  type foo += B of float (* Error foo does not have an extensible type *)
+  type foo
+  type foo += B of float (* Error: foo does not have an extensible type *)
 end
 ;;
 
@@ -164,9 +172,9 @@ type foo += B3 = M.B1  (* Error: rebind private extension *)
 type foo += C = Unknown  (* Error: unbound extension *)
 ;;
 
-(* Extensions can be rebound even if type is closed *)
+(* Extensions can be rebound even if type is private *)
 
-module M : sig type foo type foo += A1 of int end
+module M : sig type foo = private .. type foo += A1 of int end
   = struct type foo = .. type foo += A1 of int end
 
 type M.foo += A2 = M.A1

--- a/testsuite/tests/typing-extensions/extensions.ml.reference
+++ b/testsuite/tests/typing-extensions/extensions.ml.reference
@@ -4,21 +4,26 @@
 #         type foo += A | B of int
 #           val is_a : foo -> bool = <fun>
 #         type foo
-#     Characters 13-21:
+#     Characters 1-21:
   type foo += A of int (* Error type is not open *)
+  ^^^^^^^^^^^^^^^^^^^^
+Error: Type definition foo is not extensible
+#         type foo = private ..
+#     Characters 13-21:
+  type foo += A of int (* Error type is private *)
               ^^^^^^^^
-Error: Cannot extend type definition foo
+Error: Cannot extend private type definition foo
 #         type 'a foo = ..
 #     Characters 1-30:
   type ('a, 'b) foo += A of int (* Error: type parameter mismatch *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This extension does not match the definition of type foo
        They have different arities.
-#                 module type S = sig type foo type foo += A of float end
-#                 Characters 84-106:
-    type foo += B of float (* Error foo does not have an extensible type *)
+#                 module type S = sig type foo = private .. type foo += A of float end
+#                 Characters 73-95:
+    type foo += B of float (* Error: foo does not have an extensible type *)
     ^^^^^^^^^^^^^^^^^^^^^^
-Error: Type foo is not extensible
+Error: Type definition foo is not extensible
 #         type foo = ..
 #                     module M :
   sig
@@ -75,7 +80,7 @@ Error: The constructor M.B1 is private
   type foo += C = Unknown  (* Error: unbound extension *)
                   ^^^^^^^
 Error: Unbound constructor Unknown
-#                       module M : sig type foo type foo += A1 of int end
+#                       module M : sig type foo = private .. type foo += A1 of int end
 type M.foo += A2 of int
 type 'a foo = ..
 #     type 'a foo1 = 'a foo = ..

--- a/testsuite/tests/typing-extensions/msg.ml
+++ b/testsuite/tests/typing-extensions/msg.ml
@@ -2,7 +2,7 @@
 
 module Msg : sig
 
-  type 'a tag
+  type 'a tag = private ..
 
   type result = Result : 'a tag * 'a -> result
 

--- a/testsuite/tests/typing-extensions/msg.ml.reference
+++ b/testsuite/tests/typing-extensions/msg.ml.reference
@@ -1,7 +1,7 @@
 
 #                                                                                                                                                                                                                             module Msg :
   sig
-    type 'a tag
+    type 'a tag = private ..
     type result = Result : 'a tag * 'a -> result
     val write : 'a tag -> 'a -> unit
     val read : unit -> result

--- a/testsuite/tests/typing-extensions/open_types.ml
+++ b/testsuite/tests/typing-extensions/open_types.ml
@@ -52,15 +52,7 @@ type ('a, 'b) foo = ..
 type ('a, 'b) bar = ('a, 'a) foo = .. (* Error: constraints do not match *)
 ;;
 
-(* Private abstract types cannot be open *)
-
-type foo = ..
-;;
-
-type bar = private foo = .. (* ERROR: Private abstract types cannot be open *)
-;;
-
-(* Check that signatures can hide open-ness *)
+(* Check that signatures can hide exstensibility *)
 
 module M = struct type foo = .. end
 ;;
@@ -74,7 +66,7 @@ module M_S = (M : S)
 type M_S.foo += Foo (* ERROR: Cannot extend a type that isn't "open" *)
 ;;
 
-(* Check that signatures cannot add open-ness *)
+(* Check that signatures cannot add extensibility *)
 
 module M = struct type foo end
 ;;
@@ -84,6 +76,32 @@ module type S = sig type foo = .. end
 
 module M_S = (M : S) (* ERROR: Signatures are not compatible *)
 ;;
+
+(* Check that signatures can make exstensibility private *)
+
+module M = struct type foo = .. end
+;;
+
+module type S = sig type foo = private .. end
+;;
+
+module M_S = (M : S)
+;;
+
+type M_S.foo += Foo (* ERROR: Cannot extend a private extensible type *)
+;;
+
+(* Check that signatures cannot make private extensibility public *)
+
+module M = struct type foo = private .. end
+;;
+
+module type S = sig type foo = .. end
+;;
+
+module M_S = (M : S) (* ERROR: Signatures are not compatible *)
+;;
+
 
 (* Check that signatures maintain variances *)
 

--- a/testsuite/tests/typing-extensions/open_types.ml.reference
+++ b/testsuite/tests/typing-extensions/open_types.ml.reference
@@ -9,10 +9,10 @@
 #     module M_S : S
 #         type foo = ..
 #     type bar = foo
-#     Characters 13-23:
+#     Characters 1-23:
   type bar += Bar of int (* Error: type is not open *)
-              ^^^^^^^^^^
-Error: Cannot extend type definition bar
+  ^^^^^^^^^^^^^^^^^^^^^^
+Error: Type definition bar is not extensible
 #     Characters 1-20:
   type baz = bar = .. (* Error: type kinds don't match *)
   ^^^^^^^^^^^^^^^^^^^
@@ -31,18 +31,13 @@ Error: This variant or record definition does not match that of type 'a foo
 Error: This variant or record definition does not match that of type
          ('a, 'a) foo
        Their constraints differ.
-#         type foo = ..
-#     Characters 24-25:
-  type bar = private foo = .. (* ERROR: Private abstract types cannot be open *)
-                         ^
-Error: Syntax error
 #         module M : sig type foo = .. end
 #     module type S = sig type foo end
 #     module M_S : S
-#     Characters 17-20:
+#     Characters 1-20:
   type M_S.foo += Foo (* ERROR: Cannot extend a type that isn't "open" *)
-                  ^^^
-Error: Cannot extend type definition M_S.foo
+  ^^^^^^^^^^^^^^^^^^^
+Error: Type definition M_S.foo is not extensible
 #         module M : sig type foo end
 #     module type S = sig type foo = .. end
 #     Characters 15-16:
@@ -55,7 +50,29 @@ Error: Signature mismatch:
        is not included in
          type foo = ..
        Their kinds differ.
-#         module M : sig type +'a foo = .. type 'a bar = 'a foo = .. end
+#         module M : sig type foo = .. end
+#     module type S = sig type foo = private .. end
+#     module M_S : S
+#     Characters 17-20:
+  type M_S.foo += Foo (* ERROR: Cannot extend a private extensible type *)
+                  ^^^
+Error: Cannot extend private type definition M_S.foo
+#         module M : sig type foo = private .. end
+#     module type S = sig type foo = .. end
+#     Characters 15-16:
+  module M_S = (M : S) (* ERROR: Signatures are not compatible *)
+                ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type foo = M.foo = private .. end
+       is not included in
+         S
+       Type declarations do not match:
+         type foo = M.foo = private ..
+       is not included in
+         type foo = ..
+       A private type would be revealed.
+#           module M : sig type +'a foo = .. type 'a bar = 'a foo = .. end
 #     module type S = sig type 'a foo = .. type 'a bar = 'a foo = .. end
 #     Characters 15-16:
   module M_S = (M : S) (* ERROR: Signatures are not compatible *)

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -540,7 +540,8 @@ and print_out_type_decl kwd ppf td =
         print_private td.otype_private
         (print_list print_out_constr (fun ppf -> fprintf ppf "@ | ")) constrs
   | Otyp_open ->
-      fprintf ppf " = .."
+      fprintf ppf " =%a .."
+        print_private td.otype_private
   | ty ->
       fprintf ppf " =%a@;<1 2>%a"
         print_private td.otype_private

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -895,7 +895,7 @@ let rec tree_of_type_decl id decl =
         decl.type_private
     | Type_open ->
         tree_of_manifest Otyp_open,
-        Public
+        decl.type_private
   in
   let immediate =
     Builtin_attributes.immediate decl.type_attributes

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -80,7 +80,7 @@ type error =
   | Null_arity_external
   | Missing_native_external
   | Unbound_type_var of type_expr * type_declaration
-  | Not_open_type of Path.t
+  | Cannot_extend_private_type of Path.t
   | Not_extensible_type of Path.t
   | Extension_mismatch of Path.t * Includecore.type_mismatch list
   | Rebind_wrong_type of Longident.t * Env.t * (type_expr * type_expr) list


### PR DESCRIPTION
Currently, in signatures, extensible variant constructors can be declared for types of abstract kind:

```ocaml
module type S = sig
  type t
  type t += Foo
end
```

This is a useful feature allowing constructors to be created by functors without exposing the underlying extensiblity. See the `msg.ml` example in the testsuite for a nice example of this. However, it also allows nonsensical signatures to be created:

```ocaml
module type S = sig
  type int += A_new_number
end
```

This doesn't cause any soundness issues but it does cause difficulties for the compiler. For example:

```ocaml
# module F (X : sig type int += A_new_number end) = struct
    let f = function
      | X.A_new_number | 0 -> true
      | _ -> false
  end;;
Fatal error: exception File "typing/parmatch.ml", line 109, characters 6-12: Assertion failed
```

It also makes changes like #792 unnecessarily difficult. In general it is quite awkward to support having constructors available for arbitrary types.

This PR adds a notion of "private" extensible variant type:

```ocaml
module type S = sig
  type t = private ..
  type t += Foo
end
```

which are visibly extensible but cannot actually be extended. This allows us to make it illegal to extend a type which is not known to be extensible:

```ocaml
module type S = sig
  type t
  type t += Foo
end;;
      Characters 31-44:
    type t += Foo
    ^^^^^^^^^^^^^
Error: Type definition t is not extensible
```

and so avoid the various problems described above whilst still allowing the use cases previously supported with extensions to abstract types.

This change is not backwards compatible, however extending abstract types is a little used and undocumented feature so I doubt that there will be much disruption.