### PR TITLE
Reference manual: fix syntax errors in grammar

### DIFF
--- a/manual/manual/refman/lex.etex
+++ b/manual/manual/refman/lex.etex
@@ -80,8 +80,8 @@ float-literal:
           [("e"||"E") ["+"||"-"] ("0"\ldots"9") { "0"\ldots"9"||"_" }]
         | ["-"] ("0x"||"0X")
           ("0"\ldots"9"||"A"\ldots"F"||"a"\ldots"f")
-          { "0"\ldots"9"||"A"\ldots"F"||"a"\ldots"f"||"_" }\\
-          ["." { "0"\ldots"9"||"A"\ldots"F"||"a"\ldots"f"||"_" }
+          { "0"\ldots"9"||"A"\ldots"F"||"a"\ldots"f"||"_" }
+          ["." { "0"\ldots"9"||"A"\ldots"F"||"a"\ldots"f"||"_" }]
           [("p"||"P") ["+"||"-"] ("0"\ldots"9") { "0"\ldots"9"||"_" }]
 \end{syntax}
 
@@ -151,7 +151,7 @@ string-literal:
 string-character:
           regular-string-char
         | escape-sequence
-        | "\u{" ("0"\ldots"9"||"A"\ldots"F"||"a"\ldots"f")+ "}"
+        | "\u{" {{ "0"\ldots"9"||"A"\ldots"F"||"a"\ldots"f" }} "}"
         | '\' newline { space || tab }
 \end{syntax}
 


### PR DESCRIPTION
Context: I'm working on [DrawGrammar](https://jacquev6.github.io/DrawGrammar/) to make it draw syntax diagrams for OCaml.

There are some irregularities in the reference manual, in "Lexical conventions". This PR fixes them.

Details:
- the `\\` at the end of line 83 has no impact. I've removed it.
- the `[` at the beginning of line 84 is not closed. I've closed it consistently with the definition of decimal floating points literals.
- the `(` and `)+` should be written `{{` and `}}`. I've done that.

Thanks!