### PR TITLE
Reference manual: fix grammar in Language extensions

### DIFF
--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1779,7 +1779,7 @@ specification: ...
 class-field-spec: ...
    | item-extension
 ;
-class-field:
+class-field: ...
    | item-extension
 ;
 \end{syntax}
@@ -2043,7 +2043,7 @@ float-literal:
      | ["-"] ("0x"||"0X")
        ("0"\ldots"9"||"A"\ldots"F"||"a"\ldots"f")
        { "0"\ldots"9"||"A"\ldots"F"||"a"\ldots"f"||"_" }\\
-       ["." { "0"\ldots"9"||"A"\ldots"F"||"a"\ldots"f"||"_" }
+       ["." { "0"\ldots"9"||"A"\ldots"F"||"a"\ldots"f"||"_" }]
        [("p"||"P") ["+"||"-"] ("0"\ldots"9") { "0"\ldots"9"||"_" }]
        ["g"\ldots"z"||"G"\ldots"Z"]
 ;


### PR DESCRIPTION
Same thing as in #1254. Sorry I missed the language extensions in my first PR.

This time I've verified that all files in [refman](https://github.com/ocaml/ocaml/tree/trunk/manual/manual/refman) are accepted by my tool.