### PR TITLE
MPR#7591: frametable not 8-aligned on x86-64 port

### DIFF
--- a/Changes
+++ b/Changes
@@ -331,6 +331,9 @@ Working version
   created by Unix.symlink under Windows.
   (Nicolas Ojeda Bar, review by David Allsopp)
 
+- MPR#7591, GPR#1257: on x86-64, frame table is not 8-aligned
+  (Xavier Leroy, report by Mantis user "voglerr", review by Gabriel Scherer)
+
 - GPR#1223: Fix corruption of the environment when using -short-paths
   with the toplevel.
   (Leo White, review by Alain Frisch)

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -1065,8 +1065,9 @@ let end_assembly() =
 
   D.data ();
   emit_global_label "data_end";
-  D.long (const 0);
+  D.qword (const 0);
 
+  D.align 8;                            (* PR#7591 *)
   emit_global_label "frametable";
 
   let setcnt = ref 0 in


### PR DESCRIPTION
Misalignment was due to the "D.long (const 0)" emitted just before the frametable, which sets the data pointer to 4 mod 8. Looks like someone cut-and-pasted from i386 to amd64 without thinking.

This commit fixes the bug twice (because belt and suspenders and all that) in two obvious ways:
- the data terminator D.long becomes D.qword
- explicit 8-alignment is requested before emitting the frame table.

(Mental note: why is the frame table in the data segment and not in a readonly data segment?)