### PR TITLE
MPR#7281: fix .TH macros in generated manpages

### DIFF
--- a/Changes
+++ b/Changes
@@ -147,6 +147,9 @@ Working version
 - MPR#7254, GPR#1096: Rudimentary documentation of ocamlnat
   (Mark Shinwell)
 
+- MPR#7281, GPR#1259: fix .TH macros in generated manpages
+  (Olaf Hering)
+
 - MPR#7507: Align the description of the printf conversion
   specification "%g" with the ISO C90 description.
   (Florian Angeletti)

--- a/ocamldoc/odoc_man.ml
+++ b/ocamldoc/odoc_man.ml
@@ -874,7 +874,7 @@ class man =
         let b = new_buf () in
         bs b (".TH \""^cl.cl_name^"\" ");
         bs b !man_section ;
-        bs b (" source: "^Odoc_misc.current_date^" ");
+        bs b (" "^Odoc_misc.current_date^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
 
@@ -932,7 +932,7 @@ class man =
         let b = new_buf () in
         bs b (".TH \""^ct.clt_name^"\" ");
         bs b !man_section ;
-        bs b (" source: "^Odoc_misc.current_date^" ");
+        bs b (" "^Odoc_misc.current_date^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
 
@@ -1024,7 +1024,7 @@ class man =
         let b = new_buf () in
         bs b (".TH \""^mt.mt_name^"\" ");
         bs b !man_section ;
-        bs b (" source: "^Odoc_misc.current_date^" ");
+        bs b (" "^Odoc_misc.current_date^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
 
@@ -1106,7 +1106,7 @@ class man =
         let b = new_buf () in
         bs b (".TH \""^m.m_name^"\" ");
         bs b !man_section ;
-        bs b (" source: "^Odoc_misc.current_date^" ");
+        bs b (" "^Odoc_misc.current_date^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
 
@@ -1212,7 +1212,7 @@ class man =
         let b = new_buf () in
         bs b (".TH \""^name^"\" ");
         bs b !man_section ;
-        bs b (" source: "^Odoc_misc.current_date^" ");
+        bs b (" "^Odoc_misc.current_date^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
         bs b ".SH NAME\n";


### PR DESCRIPTION
The troff .TH macro takes up to three extra args, according to the
groff documentation at gnu.org. ocamldoc inserts a fourth argument
"source:". Remove the extra argument. Fixes commit a87c3f20e
("Enable ocamldoc to build reproducible manpages")

Without this change the header/footer of each ocaml manpage is
broken. Example: the date should be in the middle of footer,
instead of the left side. The string "source:" should not be shown
at all. No other manpage has such string.

Signed-off-by: Olaf Hering <olaf@aepfle.de>