### PR TITLE
Extending the representation attributes to allow Addr data

### DIFF
--- a/bytecomp/typeopt.ml
+++ b/bytecomp/typeopt.ml
@@ -80,11 +80,16 @@ let classify env ty =
            || Path.same p Predef.path_int64 then Addr
       else begin
         try
-          match (Env.find_type p env).type_kind with
-          | Type_abstract ->
-              Any
-          | Type_record _ | Type_variant _ | Type_open ->
-              Addr
+          let ty = Env.find_type p env in
+          match ty.type_repr with
+          | Asttypes.Repr_immediate -> Int
+          | Asttypes.Repr_address -> Addr
+          | Asttypes.Repr_any ->
+            match ty.type_kind with
+            | Type_abstract ->
+                Any
+            | Type_record _ | Type_variant _ | Type_open ->
+                Addr
         with Not_found ->
           (* This can happen due to e.g. missing -I options,
              causing some .cmi files to be unavailable.

--- a/bytecomp/typeopt.ml
+++ b/bytecomp/typeopt.ml
@@ -82,8 +82,10 @@ let classify env ty =
         try
           let ty = Env.find_type p env in
           match ty.type_repr with
-          | Asttypes.Repr_immediate -> Int
-          | Asttypes.Repr_address -> Addr
+          | Asttypes.Repr_immediate ->
+            Int
+          | Asttypes.Repr_address ->
+            Addr
           | Asttypes.Repr_any ->
             match ty.type_kind with
             | Type_abstract ->

--- a/parsing/asttypes.mli
+++ b/parsing/asttypes.mli
@@ -56,3 +56,7 @@ type variance =
   | Covariant
   | Contravariant
   | Invariant
+
+type type_repr =
+  | Repr_immediate (** Only immediate integers *)
+  | Repr_any (** Not specified *)

--- a/parsing/asttypes.mli
+++ b/parsing/asttypes.mli
@@ -59,4 +59,5 @@ type variance =
 
 type type_repr =
   | Repr_immediate (** Only immediate integers *)
+  | Repr_address (** Only immediate integers or non-float, non-lazy blocks *)
   | Repr_any (** Not specified *)

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -205,12 +205,45 @@ let explicit_arity =
       | _ -> false
     )
 
-let immediate =
-  List.exists
-    (function
-      | ({txt="ocaml.immediate"|"immediate"; _}, _) -> true
-      | _ -> false
-    )
+let type_repr attr =
+  let open Parsetree in
+  let get_repr ({txt;loc}, payload) =
+    let warning txt =
+      Warnings.Attribute_payload
+        (txt, "It must be either 'immediate' or 'address'")
+    in
+    match payload with
+    | PStr [{pstr_desc = Pstr_eval ({pexp_desc},[])}] -> begin
+        match pexp_desc with
+        | Pexp_ident { txt = Longident.Lident "immediate" } ->
+          Repr_immediate
+        | Pexp_ident { txt = Longident.Lident "address" } ->
+          Repr_address
+        | _ ->
+          Location.prerr_warning loc (warning txt);
+          Repr_any
+      end
+    | _ ->
+      Location.prerr_warning loc (warning txt);
+      Repr_any
+  in
+  let find ({txt; _}, _) = match txt with
+  | "immediate" | "ocaml.immediate" | "repr" | "ocaml.repr" -> true
+  | _ -> false
+  in
+  let warn ({txt; loc; _}, _) =
+    let warning = Warnings.Duplicated_attribute txt in
+    Location.prerr_warning loc warning;
+  in
+  match List.find_all find attr with
+  | [] -> Repr_any
+  | ({txt = ("repr" | "ocaml.repr")}, _ as attr) :: rem ->
+    List.iter warn rem;
+    get_repr attr
+  | ({txt = ("immediate" | "ocaml.immediate")}, _) :: rem ->
+    List.iter warn rem;
+    Repr_immediate
+  | _ -> assert false
 
 (* The "ocaml.boxed (default)" and "ocaml.unboxed (default)"
    attributes cannot be input by the user, they are added by the

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -227,23 +227,28 @@ let type_repr attr =
       Location.prerr_warning loc (warning txt);
       Repr_any
   in
-  let find ({txt; _}, _) = match txt with
-  | "immediate" | "ocaml.immediate" | "repr" | "ocaml.repr" -> true
-  | _ -> false
+  let find ({txt; _}, _) =
+    match txt with
+    | "immediate" | "ocaml.immediate" | "repr" | "ocaml.repr" ->
+      true
+    | _ ->
+      false
   in
   let warn ({txt; loc; _}, _) =
     let warning = Warnings.Duplicated_attribute txt in
     Location.prerr_warning loc warning;
   in
   match List.find_all find attr with
-  | [] -> Repr_any
+  | [] ->
+    Repr_any
   | ({txt = ("repr" | "ocaml.repr")}, _ as attr) :: rem ->
     List.iter warn rem;
     get_repr attr
   | ({txt = ("immediate" | "ocaml.immediate")}, _) :: rem ->
     List.iter warn rem;
     Repr_immediate
-  | _ -> assert false
+  | _ ->
+    assert false
 
 (* The "ocaml.boxed (default)" and "ocaml.unboxed (default)"
    attributes cannot be input by the user, they are added by the

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -54,8 +54,7 @@ val emit_external_warnings: Ast_iterator.iterator
 val warn_on_literal_pattern: Parsetree.attributes -> bool
 val explicit_arity: Parsetree.attributes -> bool
 
-
-val immediate: Parsetree.attributes -> bool
+val type_repr : Parsetree.attributes -> Asttypes.type_repr
 
 val has_unboxed: Parsetree.attributes -> bool
 val has_boxed: Parsetree.attributes -> bool

--- a/testsuite/tests/typing-address/Makefile
+++ b/testsuite/tests/typing-address/Makefile
@@ -1,0 +1,18 @@
+#**************************************************************************
+#*                                                                        *
+#*                                OCaml                                   *
+#*                                                                        *
+#*                 Xavier Clerc, SED, INRIA Rocquencourt                  *
+#*                                                                        *
+#*   Copyright 2010 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+BASEDIR=../..
+include $(BASEDIR)/makefiles/Makefile.expect
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/typing-address/address.ml
+++ b/testsuite/tests/typing-address/address.ml
@@ -36,6 +36,7 @@ module A :
     type w = Foo | Bar of int [@@repr(address)]
     type p = q [@@repr(address)]
     and q = T of int
+    type u = int [@@repr(address)]
   end
 |}];;
 
@@ -54,7 +55,7 @@ module B = struct
   type t = float [@@repr(address)]
 end;;
 [%%expect{|
-Line _, characters 2-31:
+Line _, characters 2-34:
 Error: Types marked with the address attribute must be
        any type wich is neither lazy nor float
 |}];;
@@ -65,7 +66,7 @@ module C = struct
   type s = t [@@repr(address)]
 end;;
 [%%expect{|
-Line _, characters 2-26:
+Line _, characters 2-30:
 Error: Types marked with the address attribute must be
        any type wich is neither lazy nor float
 |}];;
@@ -75,7 +76,7 @@ module D : sig type t [@@repr(address)] end = struct
   type t = float
 end;;
 [%%expect{|
-Line _, characters 42-70:
+Line _, characters 46-73:
 Error: Signature mismatch:
        Modules do not match:
          sig type t = float end
@@ -86,14 +87,14 @@ Error: Signature mismatch:
        is not included in
          type t [@@repr(address)]
        Their internal representations differ:
-       address is not a subrepresentation of any.
+       the type representation cannot be "address".
 |}];;
 
 (* Same as above but with explicit signature *)
 module M_invalid : S = struct type t = float end;;
 module FM_invalid = F (struct type t = float end);;
 [%%expect{|
-Line _, characters 23-49:
+Line _, characters 23-48:
 Error: Signature mismatch:
        Modules do not match: sig type t = float end is not included in S
        Type declarations do not match:
@@ -101,7 +102,7 @@ Error: Signature mismatch:
        is not included in
          type t [@@repr(address)]
        Their internal representations differ:
-       address is not a subrepresentation of any.
+       the type representation cannot be "address".
 |}];;
 
 (* Can't use a non-address type even if mutually recursive *)
@@ -110,7 +111,7 @@ module E = struct
   and s = float
 end;;
 [%%expect{|
-Line _, characters 2-26:
+Line _, characters 2-30:
 Error: Types marked with the address attribute must be
        any type wich is neither lazy nor float
 |}];;

--- a/testsuite/tests/typing-address/address.ml
+++ b/testsuite/tests/typing-address/address.ml
@@ -1,0 +1,116 @@
+module type S = sig type t [@@repr(address)] end;;
+module F (M : S) : S = M;;
+[%%expect{|
+module type S = sig type t [@@repr(address)] end
+module F : functor (M : S) -> S
+|}];;
+
+(* VALID DECLARATIONS *)
+
+module A = struct
+  (* Abstract types can be addresses *)
+  type t [@@repr(address)]
+
+  (* [@@repr(address)] tag here is unnecessary but valid since t has it *)
+  type s = t [@@repr(address)]
+
+  (* Again, valid alias even without tag *)
+  type r = s
+
+  (** Variant types *)
+  type w = Foo | Bar of int [@@repr(address)]
+
+  (* Mutually recursive declarations work as well *)
+  type p = q [@@repr(address)]
+  and q = T of int
+
+  (* Check subtyping: integers are also addresses *)
+  type u = int [@@repr(address)]
+end;;
+[%%expect{|
+module A :
+  sig
+    type t [@@repr(address)]
+    type s = t [@@repr(address)]
+    type r = s
+    type w = Foo | Bar of int [@@repr(address)]
+    type p = q [@@repr(address)]
+    and q = T of int
+  end
+|}];;
+
+(* Valid using an explicit signature *)
+module M_valid : S = struct type t = T of int end;;
+module FM_valid = F (struct type t = T of int end);;
+[%%expect{|
+module M_valid : S
+module FM_valid : S
+|}];;
+
+(* INVALID DECLARATIONS *)
+
+(* Cannot directly declare a non-address type as address *)
+module B = struct
+  type t = float [@@repr(address)]
+end;;
+[%%expect{|
+Line _, characters 2-31:
+Error: Types marked with the address attribute must be
+       any type wich is neither lazy nor float
+|}];;
+
+(* Not guaranteed that t is address, so this is an invalid declaration *)
+module C = struct
+  type t
+  type s = t [@@repr(address)]
+end;;
+[%%expect{|
+Line _, characters 2-26:
+Error: Types marked with the address attribute must be
+       any type wich is neither lazy nor float
+|}];;
+
+(* Can't ascribe to an address type signature with a non-address type *)
+module D : sig type t [@@repr(address)] end = struct
+  type t = float
+end;;
+[%%expect{|
+Line _, characters 42-70:
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = float end
+       is not included in
+         sig type t [@@repr(address)] end
+       Type declarations do not match:
+         type t = float
+       is not included in
+         type t [@@repr(address)]
+       Their internal representations differ:
+       address is not a subrepresentation of any.
+|}];;
+
+(* Same as above but with explicit signature *)
+module M_invalid : S = struct type t = float end;;
+module FM_invalid = F (struct type t = float end);;
+[%%expect{|
+Line _, characters 23-49:
+Error: Signature mismatch:
+       Modules do not match: sig type t = float end is not included in S
+       Type declarations do not match:
+         type t = float
+       is not included in
+         type t [@@repr(address)]
+       Their internal representations differ:
+       address is not a subrepresentation of any.
+|}];;
+
+(* Can't use a non-address type even if mutually recursive *)
+module E = struct
+  type t = s [@@repr(address)]
+  and s = float
+end;;
+[%%expect{|
+Line _, characters 2-26:
+Error: Types marked with the address attribute must be
+       any type wich is neither lazy nor float
+|}];;

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -134,7 +134,7 @@ Error: Signature mismatch:
        is not included in
          type t [@@repr(immediate)]
        Their internal representations differ:
-       immediate is not a subrepresentation of any.
+       "immediate" is not compatible with "address".
 |}];;
 
 (* Same as above but with explicit signature *)
@@ -149,7 +149,7 @@ Error: Signature mismatch:
        is not included in
          type t [@@repr(immediate)]
        Their internal representations differ:
-       immediate is not a subrepresentation of any.
+       "immediate" is not compatible with "address".
 |}];;
 
 (* Can't use a non-immediate type even if mutually recursive *)

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -1,7 +1,7 @@
 module type S = sig type t [@@immediate] end;;
 module F (M : S) : S = M;;
 [%%expect{|
-module type S = sig type t [@@immediate] end
+module type S = sig type t [@@repr(immediate)] end
 module F : functor (M : S) -> S
 |}];;
 
@@ -24,10 +24,10 @@ end;;
 [%%expect{|
 module A :
   sig
-    type t [@@immediate]
-    type s = t [@@immediate]
+    type t [@@repr(immediate)]
+    type s = t [@@repr(immediate)]
     type r = s
-    type p = q [@@immediate]
+    type p = q [@@repr(immediate)]
     and q = int
   end
 |}];;
@@ -39,7 +39,7 @@ module Z = ((Y : X with type t = int) : sig type t [@@immediate] end);;
 [%%expect{|
 module type X = sig type t end
 module Y : sig type t = int end
-module Z : sig type t [@@immediate] end
+module Z : sig type t [@@repr(immediate)] end
 |}];;
 
 (* Valid using an explicit signature *)
@@ -64,7 +64,7 @@ module Bar : sig type t [@@immediate] val x : t ref end = struct
   let x = ref 0
 end;;
 [%%expect{|
-module Bar : sig type t [@@immediate] val x : t ref end
+module Bar : sig type t [@@repr(immediate)] val x : t ref end
 |}];;
 
 let test f =
@@ -128,12 +128,13 @@ Error: Signature mismatch:
        Modules do not match:
          sig type t = string end
        is not included in
-         sig type t [@@immediate] end
+         sig type t [@@repr(immediate)] end
        Type declarations do not match:
          type t = string
        is not included in
-         type t [@@immediate]
-       the first is not an immediate type.
+         type t [@@repr(immediate)]
+       Their internal representations differ:
+       immediate is not a subrepresentation of any.
 |}];;
 
 (* Same as above but with explicit signature *)
@@ -146,8 +147,9 @@ Error: Signature mismatch:
        Type declarations do not match:
          type t = string
        is not included in
-         type t [@@immediate]
-       the first is not an immediate type.
+         type t [@@repr(immediate)]
+       Their internal representations differ:
+       immediate is not a subrepresentation of any.
 |}];;
 
 (* Can't use a non-immediate type even if mutually recursive *)

--- a/testsuite/tests/typing-unboxed-types/test.ml.reference
+++ b/testsuite/tests/typing-unboxed-types/test.ml.reference
@@ -163,7 +163,7 @@ Error: Signature mismatch:
          type u = { f1 : t; f2 : t; }
        Their internal representations differ:
        the first declaration uses unboxed float representation.
-#     * *           module T : sig type t [@@immediate] end
+#     * *           module T : sig type t [@@repr(immediate)] end
 #   *   type 'a s = S : 'a -> 'a s [@@unboxed]
 # Characters 0-33:
   type t = T : _ s -> t [@@unboxed];;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1099,7 +1099,7 @@ let new_declaration newtype manifest =
     type_newtype_level = newtype;
     type_loc = Location.none;
     type_attributes = [];
-    type_immediate = false;
+    type_repr = Repr_any;
     type_unboxed = unboxed_false_default_false;
   }
 
@@ -4400,7 +4400,7 @@ let nondep_type_decl env mid id is_covariant decl =
       type_newtype_level = None;
       type_loc = decl.type_loc;
       type_attributes = decl.type_attributes;
-      type_immediate = decl.type_immediate;
+      type_repr = decl.type_repr;
       type_unboxed = decl.type_unboxed;
     }
   with Not_found ->
@@ -4538,7 +4538,9 @@ let maybe_pointer_type env typ =
   | Tconstr(p, _args, _abbrev) ->
     begin try
       let type_decl = Env.find_type p env in
-      not type_decl.type_immediate
+      match type_decl.type_repr with
+      | Repr_immediate -> false
+      | Repr_any -> true
     with Not_found -> true
     (* This can happen due to e.g. missing -I options,
        causing some .cmi files to be unavailable.

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4546,26 +4546,43 @@ let rec get_type_repr env typ =
     end
   | Tvariant row ->
       let row = Btype.row_repr row in
-      let is_direct (_, field) = match field with
-      | Rpresent (Some _) | Reither (false, _, _, _) -> false
-      | _ -> true
+      let is_direct (_, field) =
+        match field with
+          | Rpresent (Some _) | Reither (false, _, _, _) ->
+            false
+          | _ ->
+            true
       in
       if not row.row_closed then Repr_address
+      (* if all labels are devoid of arguments, not a pointer *)
       else if List.for_all is_direct row.row_fields then Repr_immediate
       else Repr_address
   | Tarrow _ | Ttuple _ | Tobject _ | Tfield _
-  | Tnil | Tpackage _ -> Repr_address
-  | Tlink typ | Tpoly (typ, _) -> get_type_repr env typ
-  | Tvar _ | Tunivar _ -> Repr_any
-  | Tsubst _ -> assert false
+  | Tnil | Tpackage _ ->
+    Repr_address
+  | Tlink typ | Tpoly (typ, _) ->
+    get_type_repr env typ
+  | Tvar _ | Tunivar _ ->
+    Repr_any
+  | Tsubst _ ->
+    assert false
 
-let maybe_pointer_type env typ = match get_type_repr env typ with
-| Repr_immediate -> false
-| Repr_address | Repr_any -> true
+let maybe_pointer_type env typ =
+  match get_type_repr env typ with
+  | Repr_immediate ->
+    false
+  | Repr_address | Repr_any ->
+    true
 
-let subtype_repr r1 r2 = match r1, r2 with
-| Repr_any, (Repr_any | Repr_immediate | Repr_address) -> true
-| Repr_address, (Repr_immediate | Repr_address) -> true
-| Repr_address, Repr_any -> false
-| Repr_immediate, Repr_immediate -> true
-| Repr_immediate, (Repr_any | Repr_address) -> false
+let subtype_repr r1 r2 =
+  match r1, r2 with
+  | Repr_any, (Repr_any | Repr_immediate | Repr_address) ->
+    true
+  | Repr_address, (Repr_immediate | Repr_address) ->
+    true
+  | Repr_address, Repr_any ->
+    false
+  | Repr_immediate, Repr_immediate ->
+    true
+  | Repr_immediate, (Repr_any | Repr_address) ->
+    false

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -286,6 +286,12 @@ val reset_reified_var_counter: unit -> unit
 val maybe_pointer_type : Env.t -> type_expr -> bool
        (* True if type is possibly pointer, false if definitely not a pointer *)
 
+val get_type_repr : Env.t -> type_expr -> type_repr
+(** Gives the most precise representation for the given expression *)
+
+val subtype_repr : type_repr -> type_repr -> bool
+(** [subtype_repr r1 r2] checks that [r2] is more constrained than [r1] *)
+
 (* Stubs *)
 val package_subtype :
     (Env.t -> Path.t -> Longident.t list -> type_expr list ->

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -88,7 +88,7 @@ let constructor_args priv cd_args cd_res path rep =
           type_newtype_level = None;
           type_loc = Location.none;
           type_attributes = [];
-          type_immediate = false;
+          type_repr = Repr_any;
           type_unboxed;
         }
       in

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -140,6 +140,11 @@ type type_mismatch =
 
 let report_type_mismatch0 first second decl ppf err =
   let pr fmt = Format.fprintf ppf fmt in
+  let pr_repr = function
+  | Repr_any -> "any"
+  | Repr_immediate -> "immediate"
+  | Repr_address -> "address"
+  in
   match err with
     Arity -> pr "They have different arities"
   | Privacy -> pr "A private type would be revealed"
@@ -167,14 +172,13 @@ let report_type_mismatch0 first second decl ppf err =
       pr "Their internal representations differ:@ %s %s %s"
          (if b then second else first) decl
          "uses unboxed representation"
+  (* Special-casing the 'any' type for readability *)
+  | Repr (r1, Repr_any) ->
+      pr "Their internal representations differ:@ the type representation \
+          cannot be \"%s\"" (pr_repr r1)
   | Repr (r1, r2) ->
-      let pr_repr = function
-      | Repr_any -> "any"
-      | Repr_immediate -> "immediate"
-      | Repr_address -> "address"
-      in
-      pr "Their internal representations differ:@ %s is not a \
-          subrepresentation of %s" (pr_repr r1) (pr_repr r2)
+      pr "Their internal representations differ:@ \"%s\" is not \
+          compatible with \"%s\"" (pr_repr r1) (pr_repr r2)
 
 let report_type_mismatch first second decl ppf =
   List.iter

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -315,11 +315,8 @@ let type_declarations ?(equality = false) ~loc env name decl1 id decl2 =
   (* If attempt to assign a non-immediate type (e.g. string) to a type that
    * must be immediate, then we error *)
   let err =
-    if abstr then match decl1.type_repr, decl2.type_repr with
-    | Repr_any, Repr_immediate -> [Immediate]
-    | Repr_immediate, Repr_any
-    | Repr_immediate, Repr_immediate
-    | Repr_any, Repr_any -> []
+    if abstr && not (Ctype.subtype_repr decl2.type_repr decl1.type_repr) then
+      [Immediate]
     else []
   in
   if err <> [] then err else

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -315,10 +315,11 @@ let type_declarations ?(equality = false) ~loc env name decl1 id decl2 =
   (* If attempt to assign a non-immediate type (e.g. string) to a type that
    * must be immediate, then we error *)
   let err =
-    if abstr &&
-       not decl1.type_immediate &&
-       decl2.type_immediate then
-      [Immediate]
+    if abstr then match decl1.type_repr, decl2.type_repr with
+    | Repr_any, Repr_immediate -> [Immediate]
+    | Repr_immediate, Repr_any
+    | Repr_immediate, Repr_immediate
+    | Repr_any, Repr_any -> []
     else []
   in
   if err <> [] then err else

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -34,7 +34,7 @@ type type_mismatch =
   | Field_missing of bool * Ident.t
   | Record_representation of bool
   | Unboxed_representation of bool
-  | Immediate
+  | Repr of Asttypes.type_repr * Asttypes.type_repr
 
 val value_descriptions:
   loc:Location.t -> Env.t -> string ->

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -520,7 +520,9 @@ and print_out_type_decl kwd ppf td =
   | Asttypes.Public -> ()
   in
   let print_immediate ppf =
-    if td.otype_immediate then fprintf ppf " [%@%@immediate]" else ()
+    match td.otype_repr with
+    | Asttypes.Repr_immediate -> fprintf ppf " [%@%@immediate]"
+    | Asttypes.Repr_any -> ()
   in
   let print_unboxed ppf =
     if td.otype_unboxed then fprintf ppf " [%@%@unboxed]" else ()

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -522,6 +522,7 @@ and print_out_type_decl kwd ppf td =
   let print_immediate ppf =
     match td.otype_repr with
     | Asttypes.Repr_immediate -> fprintf ppf " [%@%@immediate]"
+    | Asttypes.Repr_address -> () (* FIXME *)
     | Asttypes.Repr_any -> ()
   in
   let print_unboxed ppf =

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -521,8 +521,8 @@ and print_out_type_decl kwd ppf td =
   in
   let print_immediate ppf =
     match td.otype_repr with
-    | Asttypes.Repr_immediate -> fprintf ppf " [%@%@immediate]"
-    | Asttypes.Repr_address -> () (* FIXME *)
+    | Asttypes.Repr_immediate -> fprintf ppf " [%@%@repr(immediate)]"
+    | Asttypes.Repr_address -> fprintf ppf " [%@%@repr(address)]"
     | Asttypes.Repr_any -> ()
   in
   let print_unboxed ppf =

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -109,7 +109,7 @@ and out_type_decl =
     otype_params: (string * (bool * bool)) list;
     otype_type: out_type;
     otype_private: Asttypes.private_flag;
-    otype_immediate: bool;
+    otype_repr: Asttypes.type_repr;
     otype_unboxed: bool;
     otype_cstrs: (out_type * out_type) list }
 and out_extension_constructor =

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -124,11 +124,11 @@ let decl_abstr =
    type_variance = [];
    type_newtype_level = None;
    type_attributes = [];
-   type_immediate = false;
+   type_repr = Asttypes.Repr_any;
    type_unboxed = unboxed_false_default_false;
   }
 
-let decl_abstr_imm = {decl_abstr with type_immediate = true}
+let decl_abstr_imm = {decl_abstr with type_repr = Asttypes.Repr_immediate}
 
 let cstr id args =
   {
@@ -150,11 +150,11 @@ let common_initial_env add_type add_extension empty_env =
   let decl_bool =
     {decl_abstr with
      type_kind = Type_variant([cstr ident_false []; cstr ident_true []]);
-     type_immediate = true}
+     type_repr = Asttypes.Repr_immediate}
   and decl_unit =
     {decl_abstr with
      type_kind = Type_variant([cstr ident_void []]);
-     type_immediate = true}
+     type_repr = Asttypes.Repr_immediate}
   and decl_exn =
     {decl_abstr with
      type_kind = Type_open}

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -129,6 +129,7 @@ let decl_abstr =
   }
 
 let decl_abstr_imm = {decl_abstr with type_repr = Asttypes.Repr_immediate}
+let decl_abstr_addr = {decl_abstr with type_repr = Asttypes.Repr_address}
 
 let cstr id args =
   {
@@ -156,17 +157,17 @@ let common_initial_env add_type add_extension empty_env =
      type_kind = Type_variant([cstr ident_void []]);
      type_repr = Asttypes.Repr_immediate}
   and decl_exn =
-    {decl_abstr with
+    {decl_abstr_addr with
      type_kind = Type_open}
   and decl_array =
     let tvar = newgenvar() in
-    {decl_abstr with
+    {decl_abstr_addr with
      type_params = [tvar];
      type_arity = 1;
      type_variance = [Variance.full]}
   and decl_list =
     let tvar = newgenvar() in
-    {decl_abstr with
+    {decl_abstr_addr with
      type_params = [tvar];
      type_arity = 1;
      type_kind =
@@ -174,7 +175,7 @@ let common_initial_env add_type add_extension empty_env =
      type_variance = [Variance.covariant]}
   and decl_option =
     let tvar = newgenvar() in
-    {decl_abstr with
+    {decl_abstr_addr with
      type_params = [tvar];
      type_arity = 1;
      type_kind = Type_variant([cstr ident_none []; cstr ident_some [tvar]]);
@@ -214,9 +215,9 @@ let common_initial_env add_type add_extension empty_env =
                          [newgenty (Ttuple[type_string; type_int; type_int])] (
   add_extension ident_undefined_recursive_module
                          [newgenty (Ttuple[type_string; type_int; type_int])] (
-  add_type ident_int64 decl_abstr (
-  add_type ident_int32 decl_abstr (
-  add_type ident_nativeint decl_abstr (
+  add_type ident_int64 decl_abstr_addr (
+  add_type ident_int32 decl_abstr_addr (
+  add_type ident_nativeint decl_abstr_addr (
   add_type ident_lazy_t decl_lazy_t (
   add_type ident_option decl_option (
   add_type ident_list decl_list (
@@ -225,7 +226,7 @@ let common_initial_env add_type add_extension empty_env =
   add_type ident_unit decl_unit (
   add_type ident_bool decl_bool (
   add_type ident_float decl_abstr (
-  add_type ident_string decl_abstr (
+  add_type ident_string decl_abstr_addr (
   add_type ident_char decl_abstr_imm (
   add_type ident_int decl_abstr_imm (
   add_type ident_extension_constructor decl_abstr (
@@ -233,8 +234,8 @@ let common_initial_env add_type add_extension empty_env =
 
 let build_initial_env add_type add_exception empty_env =
   let common = common_initial_env add_type add_exception empty_env in
-  let safe_string = add_type ident_bytes decl_abstr common in
-  let decl_bytes_unsafe = {decl_abstr with type_manifest = Some type_string} in
+  let safe_string = add_type ident_bytes decl_abstr_addr common in
+  let decl_bytes_unsafe = {decl_abstr_addr with type_manifest = Some type_string} in
   let unsafe_string = add_type ident_bytes decl_bytes_unsafe common in
   (safe_string, unsafe_string)
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -897,14 +897,15 @@ let rec tree_of_type_decl id decl =
         tree_of_manifest Otyp_open,
         Public
   in
-  let immediate =
-    Builtin_attributes.immediate decl.type_attributes
+  let repr =
+    if Builtin_attributes.immediate decl.type_attributes then Repr_immediate
+    else Repr_any
   in
     { otype_name = name;
       otype_params = args;
       otype_type = ty;
       otype_private = priv;
-      otype_immediate = immediate;
+      otype_repr = repr;
       otype_unboxed = decl.type_unboxed.unboxed;
       otype_cstrs = constraints }
 
@@ -1199,7 +1200,7 @@ let dummy =
     type_private = Public; type_manifest = None; type_variance = [];
     type_newtype_level = None; type_loc = Location.none;
     type_attributes = [];
-    type_immediate = false;
+    type_repr = Repr_any;
     type_unboxed = unboxed_false_default_false;
   }
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -897,10 +897,7 @@ let rec tree_of_type_decl id decl =
         tree_of_manifest Otyp_open,
         Public
   in
-  let repr =
-    if Builtin_attributes.immediate decl.type_attributes then Repr_immediate
-    else Repr_any
-  in
+  let repr = Builtin_attributes.type_repr decl.type_attributes in
     { otype_name = name;
       otype_params = args;
       otype_type = ty;

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -262,7 +262,7 @@ let type_declaration s decl =
       type_newtype_level = None;
       type_loc = loc s decl.type_loc;
       type_attributes = attrs s decl.type_attributes;
-      type_immediate = decl.type_immediate;
+      type_repr = decl.type_repr;
       type_unboxed = decl.type_unboxed;
     }
   in

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1259,7 +1259,7 @@ let temp_abbrev loc env id arity =
        type_newtype_level = None;
        type_loc = loc;
        type_attributes = []; (* or keep attrs from the class decl? *)
-       type_immediate = false;
+       type_repr = Repr_any;
        type_unboxed = unboxed_false_default_false;
       }
       env
@@ -1507,7 +1507,7 @@ let class_infos define_class kind
      type_newtype_level = None;
      type_loc = cl.pci_loc;
      type_attributes = []; (* or keep attrs from cl? *)
-     type_immediate = false;
+     type_repr = Repr_any;
      type_unboxed = unboxed_false_default_false;
     }
   in
@@ -1526,7 +1526,7 @@ let class_infos define_class kind
      type_newtype_level = None;
      type_loc = cl.pci_loc;
      type_attributes = []; (* or keep attrs from cl? *)
-     type_immediate = false;
+     type_repr = Repr_any;
      type_unboxed = unboxed_false_default_false;
     }
   in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2924,7 +2924,7 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
         type_newtype_level = Some (level, level);
         type_loc = loc;
         type_attributes = [];
-        type_immediate = false;
+        type_repr = Repr_any;
         type_unboxed = unboxed_false_default_false;
       }
       in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1102,7 +1102,7 @@ let is_hash id =
   let s = Ident.name id in
   String.length s > 0 && s.[0] = '#'
 
-let marked_as_immediate decl =
+let type_repr_attr decl =
   Builtin_attributes.type_repr decl.type_attributes
 
 let compute_immediacy env tdecl =
@@ -1122,7 +1122,7 @@ let compute_immediacy env tdecl =
     else
       Repr_immediate
   | (Type_abstract, Some(typ)) -> Ctype.get_type_repr env typ
-  | (Type_abstract, None) -> marked_as_immediate tdecl
+  | (Type_abstract, None) -> type_repr_attr tdecl
   | _ -> Repr_any
 
 (* Computes the fixpoint for the variance and immediacy of type declarations *)
@@ -1130,8 +1130,8 @@ let compute_immediacy env tdecl =
 let rec compute_properties_fixpoint env decls required variances immediacies =
   let new_decls =
     List.map2
-      (fun (id, decl) (variance, immediacy) ->
-         id, {decl with type_variance = variance; type_repr = immediacy})
+      (fun (id, decl) (variance, repr) ->
+         id, {decl with type_variance = variance; type_repr = repr})
       decls (List.combine variances immediacies)
   in
   let new_env =
@@ -1162,7 +1162,7 @@ let rec compute_properties_fixpoint env decls required variances immediacies =
       prerr_endline "")
       new_decls; *)
     List.iter (fun (_, decl) ->
-      let repr = marked_as_immediate decl in
+      let repr = type_repr_attr decl in
       if not (Ctype.subtype_repr repr decl.type_repr) then
         raise (Error (decl.type_loc, Bad_repr_attribute repr))
       else ())

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1103,8 +1103,7 @@ let is_hash id =
   String.length s > 0 && s.[0] = '#'
 
 let marked_as_immediate decl =
-  if Builtin_attributes.immediate decl.type_attributes then Repr_immediate
-  else Repr_any
+  Builtin_attributes.type_repr decl.type_attributes
 
 let compute_immediacy env tdecl =
   let from_pointer b = if b then Repr_any else Repr_immediate in

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -95,7 +95,7 @@ type error =
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
   | Deep_unbox_or_untag_attribute of native_repr_kind
-  | Bad_immediate_attribute
+  | Bad_repr_attribute
   | Bad_unboxed_attribute of string
   | Wrong_unboxed_type_float
   | Boxed_and_unboxed

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -95,7 +95,7 @@ type error =
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
   | Deep_unbox_or_untag_attribute of native_repr_kind
-  | Bad_repr_attribute
+  | Bad_repr_attribute of Asttypes.type_repr
   | Bad_unboxed_attribute of string
   | Wrong_unboxed_type_float
   | Boxed_and_unboxed

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -187,7 +187,7 @@ let merge_constraint initial_env loc sg constr =
             type_loc = sdecl.ptype_loc;
             type_newtype_level = None;
             type_attributes = [];
-            type_immediate = false;
+            type_repr = Repr_any;
             type_unboxed = unboxed_false_default_false;
           }
         and id_row = Ident.create (s^"#row") in

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -148,7 +148,7 @@ type type_declaration =
     type_newtype_level: (int * int) option;
     type_loc: Location.t;
     type_attributes: Parsetree.attributes;
-    type_immediate: bool;
+    type_repr: Asttypes.type_repr;
     type_unboxed: unboxed_status;
  }
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -294,7 +294,7 @@ type type_declaration =
     (* definition level * expansion level *)
     type_loc: Location.t;
     type_attributes: Parsetree.attributes;
-    type_immediate: bool; (* true iff type should not be a pointer *)
+    type_repr: type_repr;
     type_unboxed: unboxed_status;
   }
 


### PR DESCRIPTION
Following [Mantis#7485](https://caml.inria.fr/mantis/view.php?id=7485), this PR extends the `[@@ocaml.immediate]` attribute with a generic `ocaml.repr(X)` attribute. In its current form, this new attribute can take the two following values:
- `immediate`, in which case it is equivalent to the old `ocaml.immediate` attribute;
- `address`, which means it is neither a float nor a lazy value (an `Addr` in Typeopt parlance).

This allows to ensure a few static optimizations by the compiler, e.g. regarding array accesses.

It provides a generic infrastructure for further extension of this mechanism to handle i.e. statically-known floats and whatnot. This has not been done yet as I don't know about all the potential optimization cases.

As requested per the contribution guidelines, I've added a few tests adapted from the immediate case. I did not add documentation yet, not knowing whether the attribute name and arguments would be accepted as-is. Also, I don't know what the guidelines are regarding bootstrap. This PR requires a bootstrap phase in the first two commits, but I find it a pity to store binary data in the repository, thus I didn't do it. I'd rather push a bootstrap commit when this PR is agreed on and before merge. Once again, correct me if that's wrong.
