### PR TITLE
Revert "travis: temporarily disable campl4 build broken by GPR#1118"

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -83,17 +83,11 @@ EOF
           OCAML_NATIVE_TOOLS=true &&
         $MAKE all &&
         $MAKE install)
-
-    # camlp4 is temporarily disabled as GPR#1118 changed the parsetree
-    if false
-    then
     git clone git://github.com/ocaml/camlp4
     (cd camlp4 &&
      ./configure --bindir=$PREFIX/bin --libdir=$PREFIX/lib/ocaml \
        --pkgdir=$PREFIX/lib/ocaml && \
       $MAKE && $MAKE install)
-    fi
-
     # git clone git://github.com/ocaml/opam
     # (cd opam && ./configure --prefix $PREFIX &&\
     #   $MAKE lib-ext && $MAKE && $MAKE install)


### PR DESCRIPTION
Camlp4 build was fixed in ocaml/camlp4#123.

This reverts commit 7ebad89109a4ddb09616fb02647297bade14df44. (GPR #1265.)