### PR TITLE
Mark certain symbols as .hidden in arm64 codegen, possibly fixes MPR#7585

### DIFF
--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -324,6 +324,7 @@ let emit_literals() =
 
 let emit_load_symbol_addr dst s =
   if (not !Clflags.dlcode) || Compilenv.symbol_in_current_unit s then begin
+    `	.hidden	{emit_symbol s}\n`;
     `	adrp	{emit_reg dst}, {emit_symbol s}\n`;
     `	add	{emit_reg dst}, {emit_reg dst}, #:lo12:{emit_symbol s}\n`
   end else begin
@@ -575,6 +576,7 @@ let emit_instr i =
           `	fmov	{emit_reg i.res.(0)}, #{emit_printf "0x%Lx" f}\n`
         else begin
           let lbl = float_literal f in
+          `	.hidden	{emit_label lbl}\n`;
           `	adrp	{emit_reg reg_tmp1}, {emit_label lbl}\n`;
           `	ldr	{emit_reg i.res.(0)}, [{emit_reg reg_tmp1}, #:lo12:{emit_label lbl}]\n`
         end
@@ -609,6 +611,7 @@ let emit_instr i =
           match addr with
           | Iindexed _ -> i.arg.(0)
           | Ibased(s, ofs) ->
+              `	.hidden	{emit_symbol s}\n`;
               `	adrp	{emit_reg reg_tmp1}, {emit_symbol_offset s ofs}\n`;
               reg_tmp1 in
         begin match size with
@@ -636,6 +639,7 @@ let emit_instr i =
           match addr with
           | Iindexed _ -> i.arg.(1)
           | Ibased(s, ofs) ->
+              `	.hidden	{emit_symbol s}\n`;
               `	adrp	{emit_reg reg_tmp1}, {emit_symbol_offset s ofs}\n`;
               reg_tmp1 in
         begin match size with

--- a/asmcomp/compilenv.ml
+++ b/asmcomp/compilenv.ml
@@ -153,7 +153,6 @@ let make_symbol ?(unitname = current_unit.ui_symbol) idopt =
 
 let symbol_in_current_unit name =
   let prefix = "caml" ^ current_unit.ui_symbol in
-  name = prefix ||
   (let lp = String.length prefix in
    String.length name >= 2 + lp
    && String.sub name 0 lp = prefix


### PR DESCRIPTION
binutils 2.29 arm64 linker is more strict about when to perform pc-relative relocations for global symbols. Specifically, they must be marked as .hidden. ocaml arm64 codegen does not do this, so tests/lib-dynlink-native/ fails as some symbols were not relocated. This patch fixes that by marking (hopefully) the appropriate symbols as .hidden.

This patch builds and tests successfully, but should be reviewed carefully because neither me nor the original author is clear on why exactly it works. See the discussion in https://caml.inria.fr/mantis/view.php?id=7585 for details, and especially the last few comments starting from 0018143.

The change to `symbol_in_current_unit` may also justify renaming that function. (It is only used in the arm64 codegen and nowhere else.)
