### PR TITLE
Fix MPR#7601

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,10 @@ Working 4.05.x branch
 - MPR#7591, GPR#1257: on x86-64, frame table is not 8-aligned
   (Xavier Leroy, report by Mantis user "voglerr", review by Gabriel Scherer)
 
+- MPR#7601, GPR#1272: It seems like a hidden non-generalized type variable
+  remains in some inferred signatures, which leads to strange errors.
+  (Jacques Garrigue, report by Mandrikin)
+
 - GPR#1271: Don't generate Ialloc instructions for closures that exceed
   Max_young_wosize; instead allocate them on the major heap.  (Related
   to GPR#1250.)

--- a/testsuite/tests/typing-modules-bugs/pr7601_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7601_ok.ml
@@ -1,0 +1,22 @@
+(**************************************************************************)
+(*                                                                        *)
+(*  Crude slicer for preprocessing reachability verification tasks        *)
+(*                                                                        *)
+(*  Copyright (C) 2016-2017 Mikhail Mandrykin, ISP RAS                    *)
+(*                                                                        *)
+(**************************************************************************)
+
+module type Analysis = sig
+  type t
+  type 'a maybe_region =
+    [< `Location of t
+    |  `Value of t
+    |  `None ] as 'a
+  val of_var : ?f:string -> string -> [ `Location of _ | `Value of _  | `None ] maybe_region
+end
+
+module Make (Analysis : Analysis) = struct
+  include Analysis
+  let of_var  = of_var ~f:""
+end
+

--- a/testsuite/tests/typing-modules-bugs/pr7601a_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7601a_ok.ml
@@ -1,0 +1,21 @@
+module type Param1 = sig
+  type 'a r = [< `A of int ] as 'a
+  val f : ?a:string -> string -> [ `A of _ ] r
+end
+
+module Make1 (M : Param1) = struct
+  include M
+  let f = f ~a:""
+end
+
+module type Param2 = sig
+  type t
+  type 'a r = [< `A of t ] as 'a
+  val f : ?a:string -> string -> [ `A of _ ] r
+end
+
+module Make2 (M : Param2) = struct
+  include M
+  let f = f ~a:""
+end
+

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -961,7 +961,8 @@ let extension_constructor id ppf ext =
 (* Print a value declaration *)
 
 let tree_of_value_description id decl =
-  (* Format.eprintf "@[%a@]@." raw_type_expr decl.val_type; *)
+  (* Format.eprintf "@[<2>%s :@ %a@]@." (ident_name id)
+    raw_type_expr decl.val_type; *)
   let id = Ident.name id in
   let ty = tree_of_type_scheme decl.val_type in
   let vd =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1097,6 +1097,7 @@ let rec type_module ?(alias=false) sttn funct_body anchor env smod =
   | Pmod_structure sstr ->
       let (str, sg, _finalenv) =
         type_structure funct_body anchor env sstr smod.pmod_loc in
+      let sg = Subst.signature Subst.identity sg in
       let md =
         rm { mod_desc = Tmod_structure str;
              mod_type = Mty_signature sg;


### PR DESCRIPTION
This is a tentative fix to [MPR#7601](https://caml.inria.fr/mantis/view.php?id=7601).

It work by creating a fresh copy of the signature after closing each (module) structure.

It is trivial, but there is a drawback: the size of cmi's seems to increase by about 20% when there are is no mli (tested on ocamldoc, no change when there is a mli).

If it is acceptable, it reflects the idea that, for principality, type information is assumed to be given when one leaves a structure.

A more economical solution is to do that in the `-principal` case only, not lowering levels in the non-principal case.