### PR TITLE
Fix mpr7519

### DIFF
--- a/Changes
+++ b/Changes
@@ -316,6 +316,9 @@ Working version
 - MPR#7513: List.compare_length_with mishandles negative numbers / overflow
   (Fabrice Le Fessant, report by Jeremy Yallop)
 
+- MPR#7519: Incorrect rejection of program due to faux scope escape
+  (Jacques Garrigue, report by Markus Mottl)
+
 - MPR#7540, GPR#1179: Fixed setting of breakpoints within packed modules
   for ocamldebug
   (Hugo Herbelin, review by Gabriel Scherer, Damien Doligez)

--- a/testsuite/tests/typing-modules-bugs/pr7519_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7519_ok.ml
@@ -1,0 +1,18 @@
+module Gen_spec = struct type 't extra = unit end
+
+module type S = sig
+  module Spec : sig type 't extra = unit end
+
+  type t
+  val make : unit -> t Spec.extra
+end (* S *)
+
+module Make () : S with module Spec := Gen_spec = struct
+  type t = int
+  let make () = ()
+end (* Make *)
+
+let () =
+  let module M = Make () in
+  M.make ()
+  (* (M.make () : unit) *)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -658,35 +658,6 @@ let rec generalize_spine ty =
       List.iter generalize_spine tyl
   | _ -> ()
 
-(*
-   Check whether the abbreviation expands to a well-defined type.
-   During the typing of a class, abbreviations for correspondings
-   types expand to non-generic types.
-*)
-let generic_abbrev env path =
-  try
-    let (_, body, _) = Env.find_type_expansion path env in
-    (repr body).level = generic_level
-  with
-    Not_found ->
-      false
-
-let generic_private_abbrev env path =
-  try
-    match Env.find_type path env with
-      {type_kind = Type_abstract;
-       type_private = Private;
-       type_manifest = Some body} ->
-         (repr body).level = generic_level
-    | _ -> false
-  with Not_found -> false
-
-let is_contractive env p =
-  try
-    let decl = Env.find_type p env in
-    in_pervasives p && decl.type_manifest = None || is_datatype decl
-  with Not_found -> false
-
 let forward_try_expand_once = (* Forward declaration *)
   ref (fun _env _ty -> raise Cannot_expand)
 
@@ -1594,6 +1565,35 @@ let full_expand env ty =
       newty2 ty.level (Tobject (fi, ref None))
   | _ ->
       ty
+
+(*
+   Check whether the abbreviation expands to a well-defined type.
+   During the typing of a class, abbreviations for correspondings
+   types expand to non-generic types.
+*)
+let generic_abbrev env path =
+  try
+    let (_, body, _) = Env.find_type_expansion path env in
+    (repr body).level = generic_level
+  with
+    Not_found ->
+      false
+
+let generic_private_abbrev env path =
+  try
+    match Env.find_type path env with
+      {type_kind = Type_abstract;
+       type_private = Private;
+       type_manifest = Some body} ->
+         (repr body).level = generic_level
+    | _ -> false
+  with Not_found -> false
+
+let is_contractive env p =
+  try
+    let decl = Env.find_type p env in
+    in_pervasives p && decl.type_manifest = None || is_datatype decl
+  with Not_found -> false
 
 
                               (*****************)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -728,7 +728,7 @@ let rec normalize_package_path env p =
           normalize_package_path env (Path.Pdot (p1', s, n))
       | _ -> p
 
-let rec update_level env level ty =
+let rec update_level env level expand ty =
   let ty = repr ty in
   if ty.level > level then begin
     begin match Env.gadt_instance_level env ty with
@@ -741,35 +741,30 @@ let rec update_level env level ty =
         begin try
           (* if is_newtype env p then raise Cannot_expand; *)
           link_type ty (!forward_try_expand_once env ty);
-          update_level env level ty
+          update_level env level expand ty
         with Cannot_expand ->
           (* +++ Levels should be restored... *)
           (* Format.printf "update_level: %i < %i@." level (get_level env p); *)
           if level < get_level env p then raise (Unify [(ty, newvar2 level)]);
-          iter_type_expr (update_level env level) ty
+          iter_type_expr (update_level env level expand) ty
         end
-    | Tconstr(p, _tl, _abbrev) when generic_abbrev env p ->
-        let snap = snapshot () in
+    | Tconstr(_, _ :: _, _) when expand ->
         begin try
-          set_level ty level;
-          iter_type_expr (update_level env level) ty
-        with Unify _ -> try
-          backtrack snap;
           link_type ty (!forward_try_expand_once env ty);
-          update_level env level ty
+          update_level env level expand ty
         with Cannot_expand ->
           set_level ty level;
-          iter_type_expr (update_level env level) ty
+          iter_type_expr (update_level env level expand) ty
         end          
     | Tpackage (p, nl, tl) when level < Path.binding_time p ->
         let p' = normalize_package_path env p in
         if Path.same p p' then raise (Unify [(ty, newvar2 level)]);
         log_type ty; ty.desc <- Tpackage (p', nl, tl);
-        update_level env level ty
+        update_level env level expand ty
     | Tobject(_, ({contents=Some(p, _tl)} as nm))
       when level < get_level env p ->
         set_name nm None;
-        update_level env level ty
+        update_level env level expand ty
     | Tvariant row ->
         let row = row_repr row in
         begin match row.row_name with
@@ -779,14 +774,27 @@ let rec update_level env level ty =
         | _ -> ()
         end;
         set_level ty level;
-        iter_type_expr (update_level env level) ty
+        iter_type_expr (update_level env level expand) ty
     | Tfield(lab, _, ty1, _)
       when lab = dummy_method && (repr ty1).level > level ->
         raise (Unify [(ty1, newvar2 level)])
     | _ ->
         set_level ty level;
         (* XXX what about abbreviations in Tconstr ? *)
-        iter_type_expr (update_level env level) ty
+        iter_type_expr (update_level env level expand) ty
+  end
+
+(* First try without expanding, then expand everything,
+   to avoid combinatorial blow-up *)
+let update_level env level ty =
+  let ty = repr ty in
+  if ty.level > level then begin
+    let snap = snapshot () in
+    try
+      update_level env level false ty
+    with Unify _ ->
+      backtrack snap;
+      update_level env level true ty
   end
 
 (* Generalize and lower levels of contravariant branches simultaneously *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2800,7 +2800,7 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
       let (id, new_env) = Env.enter_module name.txt modl.mod_type env in
       Ctype.init_def(Ident.current_time());
       Typetexp.widen context;
-      let body = type_expect new_env sbody (correct_levels ty_expected) in
+      let body = type_expect new_env sbody ty_expected in
       (* go back to original level *)
       end_def ();
       (* Unification of body.exp_type with the fresh variable ty
@@ -2808,12 +2808,15 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
          i.e. if generative types rooted at id show up in the
          type body.exp_type.  Thus, this unification enforces the
          scoping condition on "let module". *)
+      (* Note that this code will only be reached if ty_expected
+         is a generic type variable, otherwise the error will occur
+         above in type_expect *)
       begin try
         Ctype.unify_var new_env ty body.exp_type
       with Unify _ ->
         raise(Error(loc, env, Scoping_let_module(name.txt, body.exp_type)))
       end;
-      rue {
+      re {
         exp_desc = Texp_letmodule(id, name, modl, body);
         exp_loc = loc; exp_extra = [];
         exp_type = ty;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2800,7 +2800,7 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
       let (id, new_env) = Env.enter_module name.txt modl.mod_type env in
       Ctype.init_def(Ident.current_time());
       Typetexp.widen context;
-      let body = type_expect new_env sbody ty_expected in
+      let body = type_expect new_env sbody (correct_levels ty_expected) in
       (* go back to original level *)
       end_def ();
       (* Unification of body.exp_type with the fresh variable ty
@@ -2809,11 +2809,11 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
          type body.exp_type.  Thus, this unification enforces the
          scoping condition on "let module". *)
       begin try
-        Ctype.unify_var new_env ty body.exp_type
+        Ctype.unify_var new_env ty body.exp_type;
       with Unify _ ->
         raise(Error(loc, env, Scoping_let_module(name.txt, body.exp_type)))
       end;
-      re {
+      rue {
         exp_desc = Texp_letmodule(id, name, modl, body);
         exp_loc = loc; exp_extra = [];
         exp_type = ty;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2809,7 +2809,7 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
          type body.exp_type.  Thus, this unification enforces the
          scoping condition on "let module". *)
       begin try
-        Ctype.unify_var new_env ty body.exp_type;
+        Ctype.unify_var new_env ty body.exp_type
       with Unify _ ->
         raise(Error(loc, env, Scoping_let_module(name.txt, body.exp_type)))
       end;


### PR DESCRIPTION
Fix [MPR#7519](https://caml.inria.fr/mantis/view.php?id=7519).

Change `Ctype.update_level` so that it tries to expand all abbreviations if the old approach of only expanding invalid type constructors didn't work. Requires taking a snapshot first.