### PR TITLE
String_val: return 'const char *' when -safe-string is globally enabled

### DIFF
--- a/Changes
+++ b/Changes
@@ -360,6 +360,11 @@ Working version
 - GPR#1073: Remove statically allocated compare stack.
   (Stephen Dolan)
 
+* MPR#7594, GPR#1274: String_val now returns 'const char*', not
+  'char*' when -safe-string is globally enabled.  New macro Bytes_val
+  for accessing bytes values.
+  (Jeremy Yallop, reviews by Mark Shinwell and Xavier Leroy)
+
 OCaml 4.05.0 (13 Jul 2017):
 ---------------------------
 

--- a/asmrun/natdynlink.c
+++ b/asmrun/natdynlink.c
@@ -31,7 +31,7 @@
 
 #include "caml/hooks.h"
 
-CAMLexport void (*caml_natdynlink_hook)(void* handle, char* unit) = NULL;
+CAMLexport void (*caml_natdynlink_hook)(void* handle, const char* unit) = NULL;
 
 #include <stdio.h>
 #include <string.h>
@@ -44,7 +44,7 @@ static value Val_handle(void* handle) {
   return res;
 }
 
-static void *getsym(void *handle, char *module, char *name){
+static void *getsym(void *handle, const char *module, const char *name){
   char *fullname = caml_stat_strconcat(3, "caml", module, name);
   void *sym;
   sym = caml_dlsym (handle, fullname);
@@ -103,7 +103,7 @@ CAMLprim value caml_natdynlink_run(value handle_v, value symbol) {
   struct code_fragment * cf;
 
 #define optsym(n) getsym(handle,unit,n)
-  char *unit;
+  const char *unit;
   void (*entrypoint)(void);
 
   unit = String_val(symbol);

--- a/byterun/alloc.c
+++ b/byterun/alloc.c
@@ -127,7 +127,7 @@ CAMLexport value caml_copy_string(char const *s)
 
   len = strlen(s);
   res = caml_alloc_string(len);
-  memmove(String_val(res), s, len);
+  memmove((char *)String_val(res), s, len);
   return res;
 }
 

--- a/byterun/alloc.c
+++ b/byterun/alloc.c
@@ -110,6 +110,14 @@ CAMLexport value caml_alloc_string (mlsize_t len)
   return result;
 }
 
+/* [len] is a number of bytes (chars) */
+CAMLexport value caml_alloc_initialized_string (mlsize_t len, const char *p)
+{
+  value result = caml_alloc_string (len);
+  memcpy((char *)String_val(result), p, len);
+  return result;
+}
+
 /* [len] is a number of words.
    [mem] and [max] are relative (without unit).
 */
@@ -126,8 +134,7 @@ CAMLexport value caml_copy_string(char const *s)
   value res;
 
   len = strlen(s);
-  res = caml_alloc_string(len);
-  memmove((char *)String_val(res), s, len);
+  res = caml_alloc_initialized_string(len, s);
   return res;
 }
 

--- a/byterun/callback.c
+++ b/byterun/callback.c
@@ -219,7 +219,7 @@ static unsigned int hash_value_name(char const *name)
 CAMLprim value caml_register_named_value(value vname, value val)
 {
   struct named_value * nv;
-  char * name = String_val(vname);
+  const char * name = String_val(vname);
   size_t namelen = strlen(name);
   unsigned int h = hash_value_name(name);
 

--- a/byterun/caml/alloc.h
+++ b/byterun/caml/alloc.h
@@ -32,6 +32,7 @@ CAMLextern value caml_alloc_small (mlsize_t wosize, tag_t);
 CAMLextern value caml_alloc_tuple (mlsize_t wosize);
 CAMLextern value caml_alloc_float_array (mlsize_t len);
 CAMLextern value caml_alloc_string (mlsize_t len);  /* len in bytes (chars) */
+CAMLextern value caml_alloc_initialized_string (mlsize_t len, const char *);
 CAMLextern value caml_copy_string (char const *);
 CAMLextern value caml_copy_string_array (char const **);
 CAMLextern value caml_copy_double (double);

--- a/byterun/caml/hooks.h
+++ b/byterun/caml/hooks.h
@@ -29,7 +29,7 @@ extern "C" {
 
 /* executed just before calling the entry point of a dynamically
    loaded native code module. */
-CAMLextern void (*caml_natdynlink_hook)(void* handle, char* unit);
+CAMLextern void (*caml_natdynlink_hook)(void* handle, const char* unit);
 
 #endif /* NATIVE_CODE */
 

--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -257,6 +257,7 @@ CAMLextern value caml_hash_variant(char const * tag);
 #else
 #define String_val(x) ((char *) Bp_val(x))
 #endif
+#define Bytes_val(x) ((unsigned char *) Bp_val(x))
 CAMLextern mlsize_t caml_string_length (value);   /* size in bytes */
 CAMLextern int caml_string_is_c_safe (value);
   /* true if string contains no '\0' null characters */

--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -252,7 +252,11 @@ CAMLextern value caml_hash_variant(char const * tag);
 
 /* Strings. */
 #define String_tag 252
+#ifdef CAML_SAFE_STRING
+#define String_val(x) ((const char *) Bp_val(x))
+#else
 #define String_val(x) ((char *) Bp_val(x))
+#endif
 CAMLextern mlsize_t caml_string_length (value);   /* size in bytes */
 CAMLextern int caml_string_is_c_safe (value);
   /* true if string contains no '\0' null characters */

--- a/byterun/caml/osdeps.h
+++ b/byterun/caml/osdeps.h
@@ -45,13 +45,13 @@ extern caml_stat_string caml_decompose_path(struct ext_table * tbl, char * path)
 
 /* Search the given file in the given list of directories.
    If not found, return a copy of [name]. */
-extern caml_stat_string caml_search_in_path(struct ext_table * path, char * name);
+extern caml_stat_string caml_search_in_path(struct ext_table * path, const char * name);
 
 /* Same, but search an executable name in the system path for executables. */
-CAMLextern caml_stat_string caml_search_exe_in_path(char * name);
+CAMLextern caml_stat_string caml_search_exe_in_path(const char * name);
 
 /* Same, but search a shared library in the given path. */
-extern caml_stat_string caml_search_dll_in_path(struct ext_table * path, char * name);
+extern caml_stat_string caml_search_dll_in_path(struct ext_table * path, const char * name);
 
 /* Open a shared library and return a handle on it.
    If [for_execution] is true, perform full symbol resolution and
@@ -69,9 +69,9 @@ extern void caml_dlclose(void * handle);
 
 /* Look up the given symbol in the given shared library.
    Return [NULL] if not found, or symbol value if found. */
-extern void * caml_dlsym(void * handle, char * name);
+extern void * caml_dlsym(void * handle, const char * name);
 
-extern void * caml_globalsym(char * name);
+extern void * caml_globalsym(const char * name);
 
 /* Return an error message describing the most recent dynlink failure. */
 extern char * caml_dlerror(void);

--- a/byterun/extern.c
+++ b/byterun/extern.c
@@ -332,17 +332,17 @@ static inline void write(int c)
   *extern_ptr++ = c;
 }
 
-static void writeblock(char * data, intnat len)
+static void writeblock(const char * data, intnat len)
 {
   if (extern_ptr + len > extern_limit) grow_extern_output(len);
   memcpy(extern_ptr, data, len);
   extern_ptr += len;
 }
 
-static inline void writeblock_float8(double * data, intnat ndoubles)
+static inline void writeblock_float8(const double * data, intnat ndoubles)
 {
 #if ARCH_FLOAT_ENDIANNESS == 0x01234567 || ARCH_FLOAT_ENDIANNESS == 0x76543210
-  writeblock((char *) data, ndoubles * 8);
+  writeblock((const char *) data, ndoubles * 8);
 #else
   caml_serialize_block_float_8(data, ndoubles);
 #endif
@@ -588,7 +588,7 @@ static void extern_rec(value v)
     if ((extern_flags & CLOSURES) == 0)
       extern_invalid_argument("output_value: functional value");
     writecode32(CODE_CODEPOINTER, (char *) v - cf->code_start);
-    writeblock((char *) cf->digest, 16);
+    writeblock((const char *)cf->digest, 16);
   } else {
     extern_invalid_argument("output_value: abstract value (outside heap)");
   }

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -261,7 +261,8 @@ static int caml_float_of_hex(const char * s, double * res)
 CAMLprim value caml_float_of_string(value vs)
 {
   char parse_buffer[64];
-  char * buf, * src, * dst, * end;
+  char * buf, * dst, * end;
+  const char *src;
   mlsize_t len;
   int sign;
   double d;

--- a/byterun/intern.c
+++ b/byterun/intern.c
@@ -400,7 +400,7 @@ static void intern_rec(value *dest)
       Field(v, size - 1) = 0;
       ofs_ind = Bsize_wsize(size) - 1;
       Byte(v, ofs_ind) = ofs_ind - len;
-      readblock(String_val(v), len);
+      readblock((char *)String_val(v), len);
     } else {
       switch(code) {
       case CODE_INT8:

--- a/byterun/ints.c
+++ b/byterun/ints.c
@@ -25,10 +25,10 @@
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
 
-static char * parse_sign_and_base(char * p,
-                                  /*out*/ int * base,
-                                  /*out*/ int * signedness,
-                                  /*out*/ int * sign)
+static const char * parse_sign_and_base(const char * p,
+                                        /*out*/ int * base,
+                                        /*out*/ int * signedness,
+                                        /*out*/ int * sign)
 {
   *sign = 1;
   if (*p == '-') {
@@ -71,7 +71,7 @@ static int parse_digit(char c)
 
 static intnat parse_intnat(value s, int nbits, const char *errmsg)
 {
-  char * p;
+  const char * p;
   uintnat res, threshold;
   int sign, base, signedness, d;
 
@@ -565,7 +565,7 @@ CAMLprim value caml_int64_format(value fmt, value arg)
 
 CAMLprim value caml_int64_of_string(value s)
 {
-  char * p;
+  const char * p;
   uint64_t res, threshold;
   int sign, base, signedness, d;
 

--- a/byterun/printexc.c
+++ b/byterun/printexc.c
@@ -40,7 +40,7 @@ static void add_char(struct stringbuf *buf, char c)
   if (buf->ptr < buf->end) *(buf->ptr++) = c;
 }
 
-static void add_string(struct stringbuf *buf, char *s)
+static void add_string(struct stringbuf *buf, const char *s)
 {
   int len = strlen(s);
   if (buf->ptr + len > buf->end) len = buf->end - buf->ptr;

--- a/byterun/str.c
+++ b/byterun/str.c
@@ -398,8 +398,7 @@ CAMLexport value caml_alloc_sprintf(const char * format, ...)
     /* All output characters were written to buf, including the
        terminating '\0'.  Allocate a Caml string with length "n"
        as computed by vsnprintf, and copy the output of vsnprintf into it. */
-    res = caml_alloc_string(n);
-    memcpy((char *)String_val(res), buf, n);
+    res = caml_alloc_initialized_string(n, buf);
   } else {
     /* PR#7568: if the format is in the Caml heap, the following
        caml_alloc_string could move or free the format.  To prevent

--- a/byterun/str.c
+++ b/byterun/str.c
@@ -399,7 +399,7 @@ CAMLexport value caml_alloc_sprintf(const char * format, ...)
        terminating '\0'.  Allocate a Caml string with length "n"
        as computed by vsnprintf, and copy the output of vsnprintf into it. */
     res = caml_alloc_string(n);
-    memcpy(String_val(res), buf, n);
+    memcpy((char *)String_val(res), buf, n);
   } else {
     /* PR#7568: if the format is in the Caml heap, the following
        caml_alloc_string could move or free the format.  To prevent
@@ -411,7 +411,7 @@ CAMLexport value caml_alloc_sprintf(const char * format, ...)
        Note that caml_alloc_string left room for a '\0' at position n,
        so the size passed to vsnprintf is n+1. */
     va_start(args, format);
-    vsnprintf(String_val(res), n + 1, saved_format, args);
+    vsnprintf((char *)String_val(res), n + 1, saved_format, args);
     va_end(args);
     caml_stat_free(saved_format);
   }

--- a/byterun/unix.c
+++ b/byterun/unix.c
@@ -131,9 +131,10 @@ caml_stat_string caml_decompose_path(struct ext_table * tbl, char * path)
   return p;
 }
 
-caml_stat_string caml_search_in_path(struct ext_table * path, char * name)
+caml_stat_string caml_search_in_path(struct ext_table * path, const char * name)
 {
-  char * p, * dir, * fullname;
+  const char * p;
+  char * dir, * fullname;
   int i;
   struct stat st;
 
@@ -195,7 +196,7 @@ static caml_stat_string cygwin_search_exe_in_path(struct ext_table * path, char 
 
 #endif
 
-caml_stat_string caml_search_exe_in_path(char * name)
+caml_stat_string caml_search_exe_in_path(const char * name)
 {
   struct ext_table path;
   char * tofree;
@@ -213,7 +214,7 @@ caml_stat_string caml_search_exe_in_path(char * name)
   return res;
 }
 
-caml_stat_string caml_search_dll_in_path(struct ext_table * path, char * name)
+caml_stat_string caml_search_dll_in_path(struct ext_table * path, const char * name)
 {
   caml_stat_string dllname;
   caml_stat_string res;
@@ -240,7 +241,7 @@ void caml_dlclose(void * handle)
   flexdll_dlclose(handle);
 }
 
-void * caml_dlsym(void * handle, char * name)
+void * caml_dlsym(void * handle, const char * name)
 {
   return flexdll_dlsym(handle, name);
 }
@@ -276,7 +277,7 @@ void caml_dlclose(void * handle)
   dlclose(handle);
 }
 
-void * caml_dlsym(void * handle, char * name)
+void * caml_dlsym(void * handle, const char * name)
 {
 #ifdef DL_NEEDS_UNDERSCORE
   char _name[1000] = "_";
@@ -286,7 +287,7 @@ void * caml_dlsym(void * handle, char * name)
   return dlsym(handle, name);
 }
 
-void * caml_globalsym(char * name)
+void * caml_globalsym(const char * name)
 {
 #ifdef RTLD_DEFAULT
   return caml_dlsym(RTLD_DEFAULT, name);

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -146,9 +146,10 @@ caml_stat_string caml_decompose_path(struct ext_table * tbl, char * path)
   return p;
 }
 
-caml_stat_string caml_search_in_path(struct ext_table * path, char * name)
+caml_stat_string caml_search_in_path(struct ext_table * path, const char * name)
 {
-  char * p, * dir, * fullname;
+  char * dir, * fullname;
+  const char * p;
   int i;
   struct stat st;
 
@@ -170,7 +171,7 @@ caml_stat_string caml_search_in_path(struct ext_table * path, char * name)
   return caml_stat_strdup(name);
 }
 
-CAMLexport caml_stat_string caml_search_exe_in_path(char * name)
+CAMLexport caml_stat_string caml_search_exe_in_path(const char * name)
 {
   char * fullname, * filepart;
   size_t fullnamelen;
@@ -199,7 +200,7 @@ CAMLexport caml_stat_string caml_search_exe_in_path(char * name)
   }
 }
 
-caml_stat_string caml_search_dll_in_path(struct ext_table * path, char * name)
+caml_stat_string caml_search_dll_in_path(struct ext_table * path, const char * name)
 {
   caml_stat_string dllname;
   caml_stat_string res;
@@ -230,12 +231,12 @@ void caml_dlclose(void * handle)
   flexdll_dlclose(handle);
 }
 
-void * caml_dlsym(void * handle, char * name)
+void * caml_dlsym(void * handle, const char * name)
 {
   return flexdll_dlsym(handle, name);
 }
 
-void * caml_globalsym(char * name)
+void * caml_globalsym(const char * name)
 {
   return flexdll_dlsym(flexdll_dlopen(NULL,0), name);
 }
@@ -256,12 +257,12 @@ void caml_dlclose(void * handle)
 {
 }
 
-void * caml_dlsym(void * handle, char * name)
+void * caml_dlsym(void * handle, const char * name)
 {
   return NULL;
 }
 
-void * caml_globalsym(char * name)
+void * caml_globalsym(const char * name)
 {
   return NULL;
 }

--- a/configure
+++ b/configure
@@ -2017,6 +2017,10 @@ if $with_fpic; then
   echo "#define CAML_WITH_FPIC" >> m.h
 fi
 
+if $safe_string; then
+  echo "#define CAML_SAFE_STRING" >> m.h
+fi
+
 # Finish generated files
 
 cclibs="$cclibs $mathlib"

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -767,6 +767,10 @@ satisfy the GC constraints.
 "caml_alloc_string("\var{n}")" returns a byte sequence (or string) value of
 length \var{n} bytes. The sequence initially contains uninitialized bytes.
 \item
+"caml_alloc_initialized_string("\var{n}", "\var{p}")" returns a byte sequence
+(or string) value of length \var{n} bytes.  The value is initialized from the
+\var{n} bytes starting at address \var{p}.
+\item
 "caml_copy_string("\var{s}")" returns a string or byte sequence value
 containing a copy of the null-terminated C string \var{s} (a "char *").
 \item

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -704,11 +704,13 @@ $\hbox{"string_length"}(v)-1$.
 or byte sequence \var{v}, with type "unsigned char". Bytes are
 numbered from 0 to $\hbox{"string_length"}(v)-1$.
 \item "String_val("\var{v}")" returns a pointer to the first byte of the string
-or byte sequence \var{v}, with type "char *". This pointer is a valid C
-string: there is a
-null byte after the last byte in the string. However, OCaml
-strings and byte sequences can contain embedded null bytes, which will confuse
-the usual C functions over strings.
+\var{v}, with type "char *" or, when OCaml is configured with "-safe-string",
+with type "const char *".
+This pointer is a valid C string: there is a null byte after the last
+byte in the string. However, OCaml strings can contain embedded null bytes,
+which will confuse the usual C functions over strings.
+\item "Bytes_val("\var{v}")" returns a pointer to the first byte of the
+byte sequence \var{v}, with type "unsigned char *".
 \item "Double_val("\var{v}")" returns the floating-point number contained in
 value \var{v}, with type "double".
 \item "Double_field("\var{v}", "\var{n}")" returns

--- a/otherlibs/graph/libgraph.h
+++ b/otherlibs/graph/libgraph.h
@@ -77,7 +77,7 @@ extern int caml_gr_bits_per_pixel;
 #endif
 
 CAMLnoreturn_start
-extern void caml_gr_fail(char *fmt, char *arg)
+extern void caml_gr_fail(const char *fmt, const char *arg)
 CAMLnoreturn_end;
 
 extern void caml_gr_check_open(void);

--- a/otherlibs/graph/open.c
+++ b/otherlibs/graph/open.c
@@ -51,7 +51,8 @@ value caml_gr_clear_graph(void);
 value caml_gr_open_graph(value arg)
 {
   char display_name[256], geometry_spec[64];
-  char * p, * q;
+  const char * p;
+  char * q;
   XSizeHints hints;
   int ret;
   XEvent event;
@@ -366,7 +367,7 @@ value caml_gr_sigio_handler(void)
 
 static value * graphic_failure_exn = NULL;
 
-void caml_gr_fail(char *fmt, char *arg)
+void caml_gr_fail(const char *fmt, const char *arg)
 {
   char buffer[1024];
 

--- a/otherlibs/graph/text.c
+++ b/otherlibs/graph/text.c
@@ -18,7 +18,7 @@
 
 XFontStruct * caml_gr_font = NULL;
 
-static void caml_gr_get_font(char *fontname)
+static void caml_gr_get_font(const char *fontname)
 {
   XFontStruct * font = XLoadQueryFont(caml_gr_display, fontname);
   if (font == NULL) caml_gr_fail("cannot find font %s", fontname);
@@ -40,7 +40,7 @@ value caml_gr_set_text_size (value sz)
   return Val_unit;
 }
 
-static void caml_gr_draw_text(char *txt, int len)
+static void caml_gr_draw_text(const char *txt, int len)
 {
   if (caml_gr_font == NULL) caml_gr_get_font(DEFAULT_FONT);
   if (caml_gr_remember_modeflag)

--- a/otherlibs/str/strstubs.c
+++ b/otherlibs/str/strstubs.c
@@ -286,18 +286,18 @@ static value re_match(value re,
     case ACCEPT:
       goto accept;
     case SIMPLEOPT: {
-      char * set = String_val(Field(cpool, Arg(instr)));
+      const char * set = String_val(Field(cpool, Arg(instr)));
       if (txt < endtxt && In_bitset(set, *txt, c)) txt++;
       break;
     }
     case SIMPLESTAR: {
-      char * set = String_val(Field(cpool, Arg(instr)));
+      const char * set = String_val(Field(cpool, Arg(instr)));
       while (txt < endtxt && In_bitset(set, *txt, c))
         txt++;
       break;
     }
     case SIMPLEPLUS: {
-      char * set = String_val(Field(cpool, Arg(instr)));
+      const char * set = String_val(Field(cpool, Arg(instr)));
       if (txt == endtxt) goto prefix_match;
       if (! In_bitset(set, *txt, c)) goto backtrack;
       txt++;
@@ -483,7 +483,8 @@ CAMLprim value re_replacement_text(value repl, value groups, value orig)
   CAMLparam3(repl, groups, orig);
   CAMLlocal1(res);
   mlsize_t start, end, len, n;
-  char * p, * q;
+  const char * p;
+  char * q;
   int c;
 
   len = 0;
@@ -517,7 +518,7 @@ CAMLprim value re_replacement_text(value repl, value groups, value orig)
   }
   res = caml_alloc_string(len);
   p = String_val(repl);
-  q = String_val(res);
+  q = (char *)String_val(res);
   n = caml_string_length(repl);
   while (n > 0) {
     c = *p++; n--;

--- a/otherlibs/unix/cstringv.c
+++ b/otherlibs/unix/cstringv.c
@@ -28,7 +28,7 @@ char ** cstringvect(value arg, char * cmdname)
     if (! caml_string_is_c_safe(Field(arg, i)))
       unix_error(EINVAL, cmdname, Field(arg, i));
   res = (char **) caml_stat_alloc((size + 1) * sizeof(char *));
-  for (i = 0; i < size; i++) res[i] = String_val(Field(arg, i));
+  for (i = 0; i < size; i++) res[i] = (char *)String_val(Field(arg, i));
   res[size] = NULL;
   return res;
 }

--- a/otherlibs/unix/execvp.c
+++ b/otherlibs/unix/execvp.c
@@ -37,7 +37,7 @@ CAMLprim value unix_execvp(value path, value args)
 
 CAMLprim value unix_execvpe(value path, value args, value env)
 {
-  char * exefile;
+  const char * exefile;
   char ** argv;
   char ** envp;
   caml_unix_check_path(path, "execvpe");
@@ -45,7 +45,7 @@ CAMLprim value unix_execvpe(value path, value args, value env)
   argv = cstringvect(args, "execvpe");
   envp = cstringvect(env, "execvpe");
   (void) execve(exefile, argv, envp);
-  caml_stat_free(exefile);
+  caml_stat_free((char *)exefile);
   caml_stat_free((char *) argv);
   caml_stat_free((char *) envp);
   uerror("execvpe", path);

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -35,8 +35,7 @@ CAMLexport value alloc_inet_addr(struct in_addr * a)
   /* Use a string rather than an abstract block so that it can be
      marshaled safely.  Remember that a is in network byte order,
      hence is marshaled in an endian-independent manner. */
-  res = caml_alloc_string(4);
-  memcpy((char *)String_val(res), a, 4);
+  res = caml_alloc_initialized_string(4, (char *)a);
   return res;
 }
 
@@ -45,8 +44,7 @@ CAMLexport value alloc_inet_addr(struct in_addr * a)
 CAMLexport value alloc_inet6_addr(struct in6_addr * a)
 {
   value res;
-  res = caml_alloc_string(16);
-  memcpy((char *)String_val(res), a, 16);
+  res = caml_alloc_initialized_string(16, (char *)a);
   return res;
 }
 
@@ -117,8 +115,7 @@ value alloc_sockaddr(union sock_addr_union * adr /*in*/,
       mlsize_t path_length =
         strnlen(adr->s_unix.sun_path,
                 adr_len - offsetof(struct sockaddr_un, sun_path));
-      n = caml_alloc_string(path_length);
-      memmove((char *)String_val(n), adr->s_unix.sun_path, path_length);
+      n = caml_alloc_initialized_string(path_length, (char *)adr->s_unix.sun_path);
       Begin_root (n);
         res = caml_alloc_small(1, 0);
         Field(res,0) = n;

--- a/otherlibs/unix/socketaddr.c
+++ b/otherlibs/unix/socketaddr.c
@@ -36,7 +36,7 @@ CAMLexport value alloc_inet_addr(struct in_addr * a)
      marshaled safely.  Remember that a is in network byte order,
      hence is marshaled in an endian-independent manner. */
   res = caml_alloc_string(4);
-  memcpy(String_val(res), a, 4);
+  memcpy((char *)String_val(res), a, 4);
   return res;
 }
 
@@ -46,7 +46,7 @@ CAMLexport value alloc_inet6_addr(struct in6_addr * a)
 {
   value res;
   res = caml_alloc_string(16);
-  memcpy(String_val(res), a, 16);
+  memcpy((char *)String_val(res), a, 16);
   return res;
 }
 
@@ -118,7 +118,7 @@ value alloc_sockaddr(union sock_addr_union * adr /*in*/,
         strnlen(adr->s_unix.sun_path,
                 adr_len - offsetof(struct sockaddr_un, sun_path));
       n = caml_alloc_string(path_length);
-      memmove(String_val(n), adr->s_unix.sun_path, path_length);
+      memmove((char *)String_val(n), adr->s_unix.sun_path, path_length);
       Begin_root (n);
         res = caml_alloc_small(1, 0);
         Field(res,0) = n;

--- a/otherlibs/unix/unixsupport.c
+++ b/otherlibs/unix/unixsupport.c
@@ -285,7 +285,7 @@ extern int code_of_unix_error (value error)
   }
 }
 
-void unix_error(int errcode, char *cmdname, value cmdarg)
+void unix_error(int errcode, const char *cmdname, value cmdarg)
 {
   value res;
   value name = Val_unit, err = Val_unit, arg = Val_unit;
@@ -309,12 +309,12 @@ void unix_error(int errcode, char *cmdname, value cmdarg)
   caml_raise(res);
 }
 
-void uerror(char *cmdname, value cmdarg)
+void uerror(const char *cmdname, value cmdarg)
 {
   unix_error(errno, cmdname, cmdarg);
 }
 
-void caml_unix_check_path(value path, char * cmdname)
+void caml_unix_check_path(value path, const char * cmdname)
 {
   if (! caml_string_is_c_safe(path)) unix_error(ENOENT, cmdname, path);
 }

--- a/otherlibs/unix/unixsupport.h
+++ b/otherlibs/unix/unixsupport.h
@@ -30,14 +30,14 @@ extern value unix_error_of_code (int errcode);
 extern int code_of_unix_error (value error);
 
 CAMLnoreturn_start
-extern void unix_error (int errcode, char * cmdname, value arg)
+extern void unix_error (int errcode, const char * cmdname, value arg)
 CAMLnoreturn_end;
 
 CAMLnoreturn_start
-extern void uerror (char * cmdname, value arg)
+extern void uerror (const char * cmdname, value arg)
 CAMLnoreturn_end;
 
-extern void caml_unix_check_path(value path, char * cmdname);
+extern void caml_unix_check_path(value path, const char * cmdname);
 
 #define UNIX_BUFFER_SIZE 65536
 

--- a/otherlibs/win32unix/unixsupport.c
+++ b/otherlibs/win32unix/unixsupport.c
@@ -280,7 +280,7 @@ value unix_error_of_code (int errcode)
   return err;
 }
 
-void unix_error(int errcode, char *cmdname, value cmdarg)
+void unix_error(int errcode, const char *cmdname, value cmdarg)
 {
   value res;
   value name = Val_unit, err = Val_unit, arg = Val_unit;
@@ -305,12 +305,12 @@ void unix_error(int errcode, char *cmdname, value cmdarg)
   caml_raise(res);
 }
 
-void uerror(char * cmdname, value cmdarg)
+void uerror(const char * cmdname, value cmdarg)
 {
   unix_error(errno, cmdname, cmdarg);
 }
 
-void caml_unix_check_path(value path, char * cmdname)
+void caml_unix_check_path(value path, const char * cmdname)
 {
   if (! caml_string_is_c_safe(path)) unix_error(ENOENT, cmdname, path);
 }

--- a/otherlibs/win32unix/unixsupport.h
+++ b/otherlibs/win32unix/unixsupport.h
@@ -61,14 +61,14 @@ extern void win32_maperr(DWORD errcode);
 extern value unix_error_of_code (int errcode);
 
 CAMLnoreturn_start
-extern void unix_error (int errcode, char * cmdname, value arg)
+extern void unix_error (int errcode, const char * cmdname, value arg)
 CAMLnoreturn_end;
 
 CAMLnoreturn_start
-extern void uerror (char * cmdname, value arg)
+extern void uerror (const char * cmdname, value arg)
 CAMLnoreturn_end;
 
-extern void caml_unix_check_path(value path, char * cmdname);
+extern void caml_unix_check_path(value path, const char * cmdname);
 extern value unix_freeze_buffer (value);
 extern char ** cstringvect(value arg, char * cmdname);
 


### PR DESCRIPTION
(There is some discussion about this change in [Mantis PR 7594](https://caml.inria.fr/mantis/view.php?id=7594).)

#### Background & motivation

Since #687 it's possible to enable `-safe-string` globally at configure time.  #1252 makes configure-time `-safe-string` the default.

At present, `-safe-string` only affects OCaml code; C stubs that mutate OCaml strings will continue to compile without error. This may lead to subtle bugs, not least since the compiler now takes string immutability into account during optimizations (see, e.g., #703).

#### This change

This PR updates `String_val` to return `const char *` when `-safe-string` is enabled.  (When `-safe-string` is not enabled the type of `String_val` is unchanged.)  With typical settings, attempts to modify the result of `String_val` will result in a compiler warning, like this:

```
bar.c: In function ‘foo’:
/usr/lib/ocaml/caml/mlvalues.h:256:23: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 #define String_val(x) ((const char *) Bp_val(x))
                       ^
bar.c:6:13: note: in expansion of macro ‘String_val’
   char *p = String_val(s);
             ^~~~~~~~~~
```

This PR also adds a new macro `Bytes_val`, for accessing `bytes` values via `unsigned char *`.  Additionally, the types of several public functions have additional `const` qualifiers.

#### Compatibility
The change to `String_val` is slightly backwards-incompatible (but probably less so than defaulting to `-safe-string` (#1252)).  I ran some tests on `opam-repository`: of the 134 packages that use `Safe_string`, 4 will not compile with this patch if the compiler is configured with `-safe-string`.  ([More details in Mantis PR 7594](https://caml.inria.fr/mantis/view.php?id=7594#c18135).)
