### PR TITLE
.gitattributes: disable the 'union' merge driver for Changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,7 +27,12 @@
 # 'union' merge driver just unions textual content in case of conflict
 #   http://krlmlr.github.io/using-gitattributes-to-avoid-merge-conflicts/
 /.mailmap                merge=union
-/Changes                 merge=union
+
+
+# We tried using 'union' for Changes and it did not work:
+# instead of creating Changes conflict it would silently duplicate
+# the lines involved in the conflict, which is arguably worse
+#/Changes                 merge=union
 
 # No header for text files (would be too obtrusive).
 *.md                     ocaml-typo=missing-header


### PR DESCRIPTION
The 'union' merge driver silently duplicates lines instead of raising
a conflict, which turns out to be worse. Example of cleanup commits
include:

- e68642379dda54a1eb2f887b2dbe4192c686461e (#1267)
- dade14d68373241f566c9f94a71d986de5cf8b6e (#1258)