### PR TITLE
fix speculative usage of <sys/shm.h> in AFL runtime

### DIFF
--- a/Changes
+++ b/Changes
@@ -264,6 +264,9 @@ Working version
 - GPR#1275: correct configure test for Spacetime availability
   (Mark Shinwell)
 
+- GPR#1278: discover presence of <sys/shm.h> during configure for afl runtime
+  (Hannes Mehnert)
+
 ### Internal/compiler-libs changes:
 
 - MPR#6826, GPR#828, GPR#834: improve compilation time for open

--- a/byterun/afl.c
+++ b/byterun/afl.c
@@ -13,9 +13,9 @@
 /**************************************************************************/
 
 /* Runtime support for afl-fuzz */
+#include "caml/config.h"
 
-/* Android's libc does not implement System V shared memory. */
-#if defined(_WIN32) || defined(__ANDROID__)
+#if !defined(HAS_SYS_SHM_H)
 
 #include "caml/mlvalues.h"
 
@@ -159,4 +159,4 @@ CAMLprim value caml_reset_afl_instrumentation(value full)
   return Val_unit;
 }
 
-#endif /* _WIN32 */
+#endif /* HAS_SYS_SHM_H */

--- a/configure
+++ b/configure
@@ -1541,6 +1541,10 @@ if sh ./hasgot getauxval; then
   echo "#define HAS_GETAUXVAL" >> s.h
 fi
 
+if sh ./hasgot -i sys/shm.h; then
+  inf "sys/shm.h found."
+  echo "#define HAS_SYS_SHM_H" >> s.h
+fi
 
 # Determine if the debugger is supported
 


### PR DESCRIPTION
Instead of relying on a blacklist `(_WIN32 || __ANDROID__)` of systems not
providing `<sys/shm.h>`, figure out its presence in `./configure`.  This fixes
the build with a minimal libc, such as ocaml-freestanding.

Further discussion in https://github.com/mirage/ocaml-freestanding/pull/23#issuecomment-315325175

I don't think a Changes entry is necessary for this, please let me know if you disagree and I'll add one.  @stedolan I hope this change is fine with you.

//cc @mato @avsm