### PR TITLE
Clarify Changes entry for -safe-string C interface change.

### DIFF
--- a/Changes
+++ b/Changes
@@ -390,8 +390,8 @@ Working version
   (Stephen Dolan)
 
 * MPR#7594, GPR#1274: String_val now returns 'const char*', not
-  'char*' when -safe-string is globally enabled.  New macro Bytes_val
-  for accessing bytes values.
+  'char*' when -safe-string is enabled at configure time.
+  New macro Bytes_val for accessing bytes values.
   (Jeremy Yallop, reviews by Mark Shinwell and Xavier Leroy)
 
 OCaml 4.05.0 (13 Jul 2017):


### PR DESCRIPTION
See @damiendoligez's comment here: https://github.com/ocaml/ocaml/pull/1274#issuecomment-321281978.