### PR TITLE
Avoid formatter flushes inside exported printers in Location

### DIFF
--- a/Changes
+++ b/Changes
@@ -292,6 +292,9 @@ Working version
   included by other header files
   (Sébastien Hinderer)
 
+- GPR#1281: avoid formatter flushes inside exported printers in Location
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Bug fixes
 
 - MPR#248, GPR#1225: unique names for weak type variables

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -136,7 +136,7 @@ module Compiler_messages = struct
     Format.fprintf ppf "Line _";
     if startchar >= 0 then
       Format.fprintf ppf ", characters %d-%d" startchar endchar;
-    Format.fprintf ppf ":@."
+    Format.fprintf ppf ":@,"
 
   let capture ppf ~f =
     Misc.protect_refs


### PR DESCRIPTION
This PR proposes to amend the exported printers in the `Location` module to make them more conservative in their use of formatter flushes (`@.`) and forced new lines (`@\n`).

In particular, the default location printer `Location.printer` currently ends with a formatter flush (`@.`). This makes this printer impossible to use with a non-flat box layout since the formatter flush will break the layout.
((and yes this situation can happen: I ended up copying the code of `Location.print_loc` to avoid this specific issue in the current version of #1120))

To avoid this issue, this PR replaces formatter flushes (`@.`) by simple break hints (`@,`) inside a vertical box whenever the flush was used as a newline. Similarly, forced newlines (`@\n`) are replaced by simple break hints also enclosed by a vertical box.

The current formatting of error messages and warning messages is mostly preserved by this change. One exception stems from the `@[<2>…@]` boxes in `Location.default_error_reporter` that were abruptly closed by a formatter flush before this patch and should now be closed in due time.