### PR TITLE
Accept aliases in exception patterns

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,10 @@ Working version
   (Daniel Bünzli, review by Damien Doligez, Alain Frisch, Xavier
   Leroy and Leo White)
 
+- GPR#1283: Accept aliases in exception patterns,
+  i.e. "match ... with ... | exception (E ... as e) -> ..."
+  (Xavier Clerc)
+
 ### Code generation and optimizations:
 
 - MPR#5324, GPR#375: An alternative Linear Scan register allocator for

--- a/testsuite/tests/match-exception/aliases.ml
+++ b/testsuite/tests/match-exception/aliases.ml
@@ -9,7 +9,7 @@ let test_multiple_handlers =
   let print_nat_pred n =
     match nat_pred n with
     | m -> print_int m
-    | exception (Failure _ as f) -> raise f
+    | exception Failure _ as f -> raise f
     | exception Not_found -> () in
   let safe_print_nat_pred n =
     try

--- a/testsuite/tests/match-exception/aliases.ml
+++ b/testsuite/tests/match-exception/aliases.ml
@@ -1,0 +1,23 @@
+(*
+  Test that aliases are accepted.
+*)
+
+let test_multiple_handlers =
+  let nat_pred = function
+    | 0 -> failwith "zero"
+    | n -> pred n in
+  let print_nat_pred n =
+    match nat_pred n with
+    | m -> print_int m
+    | exception (Failure _ as f) -> raise f
+    | exception Not_found -> () in
+  let safe_print_nat_pred n =
+    try
+      print_nat_pred n
+    with e ->
+      print_string (Printexc.to_string e) in
+  for i = 3 downto 0 do
+    safe_print_nat_pred i;
+    print_string " "
+  done
+;;

--- a/testsuite/tests/match-exception/aliases.reference
+++ b/testsuite/tests/match-exception/aliases.reference
@@ -1,0 +1,1 @@
+2 1 0 Failure("zero") 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2165,6 +2165,10 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
         | [] -> List.rev vc, List.rev ec
         | {pc_lhs = {ppat_desc=Ppat_exception p}} as c :: rest ->
             split_cases vc ({c with pc_lhs = p} :: ec) rest
+        | {pc_lhs = {ppat_desc=Ppat_alias ({ppat_desc=Ppat_exception p;},
+                                           aloc)}} as c :: rest ->
+            let ppat_desc = Ppat_alias (p, aloc) in
+            split_cases vc ({c with pc_lhs = {c.pc_lhs with ppat_desc}} :: ec) rest
         | c :: rest ->
             split_cases (c :: vc) ec rest
       in


### PR DESCRIPTION
It is currently not possible to use aliases in exception patterns; for instance
the following code:

    match f 0 with
    | y -> print_int y
    | exception Failure _ as f -> raise f

is refused with the following message:

    Error: Exception patterns must be at the top level of a match case

while the exception pattern is seemingly top level (the alias making it appear
below top level).