### PR TITLE
Fix the stack overflow in the stack overflow handler on Windows!

### DIFF
--- a/Changes
+++ b/Changes
@@ -394,8 +394,8 @@ Working version
   Mark Shinwell, Thomas Braibant, Stephen Dolan, Pierre Chambart,
   François Bobot, Jacques Garrigue, David Allsopp, and Alain Frisch)
 
-- GPR#938, GPR#1170: Stack overflow detection on 64-bit Windows
-  (Olivier Andrieu)
+- GPR#938, GPR#1170, GPR#1289: Stack overflow detection on 64-bit Windows
+  (Olivier Andrieu, tweaked by David Allsopp)
 
 - GPR#1073: Remove statically allocated compare stack.
   (Stephen Dolan)

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -499,7 +499,7 @@ void caml_signal_thread(void * lpParam)
  * quickly.
  */
 
-static uintnat win32_alt_stack[0x80];
+static uintnat win32_alt_stack[0x100];
 
 static void caml_reset_stack (void *faulting_address)
 {

--- a/testsuite/tests/runtime-errors/stackoverflow.ml
+++ b/testsuite/tests/runtime-errors/stackoverflow.ml
@@ -15,6 +15,8 @@ let _ =
   with Stack_overflow ->
     print_string "Stack overflow caught"; print_newline()
  end ;
+ (* GPR#1289 *)
+ Printexc.record_backtrace true;
  begin
   try
     ignore(f 0)


### PR DESCRIPTION
#1070 has revealed a slight flaw in #938 in that the native code stack overflow test is failing. My investigations have determined that the most likely cause of this is that `win32_alt_stack` declared in `byterun/win32.c` is in certain circumstances not large enough.

This GPR is arriving in two bits, just so that I can get more AppVeyor logs - the first commit being added alters the stack overflow test to record backtraces for the second run. On AppVeyor and on my Windows 10 1703 machines, this is sufficient to cause the native code executable to segfault. Interestingly, on Windows Server 2016 instances running on Azure and also on my Windows 10 1511 box, the same binary works successfully. I'm making slightly hand-wavy assertions that this is a mixture of ASLR and possibly code injecty things (Windows Defender et al) causing this. win32_alt_stack does not have a guard page, so I believe I'm correct that if it overruns, we're just looking at chaos - hence the strange fact that #1070 appears to have triggered it. On machines where it fails, it seems to fail with both msvc32 and msvc64 but not with mingw32 or mingw64. I've been testing VS 2015 and VS 2017, so I'm guessing it's just down to the different runtimes possibly needing a teensy bit more stack between the exception handler completing and `caml_raise_exception` restoring the old one.

As far as I can tell, just doubling the size of `win32_alt_stack` is enough to mitigate this.
