### PR TITLE
Documentation: fix minor issues within Format

### DIFF
--- a/Changes
+++ b/Changes
@@ -89,6 +89,12 @@ Working version
   the unaligned part, which is useful for Tuple options.
   (Nicolas Ojeda Bar, review by Alain Frisch and Gabriel Scherer)
 
+* GPR#615: Format, add symbolic formatters that output symbolic
+  pretty-printing items. New fields have been added to the
+  formatter_out_functions record, thus this change will break any code building
+  such record from scratch.
+  (Richard Bonichon and Pierre Weiss, review by Alain Frisch)
+
 * GPR#943: Fixed the divergence of the Pervasives module between the stdlib
   and threads implementations.  In rare circumstances this can change the
   behavior of existing applications: the implementation of Pervasives.close_out

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -762,7 +762,7 @@ val formatter_of_out_functions :
   See definition of type {!formatter_out_functions} for the meaning of argument
   [out_funs].
 
-  @since 4.04.0
+  @since 4.06.0
 *)
 
 (** {7 Symbolic pretty-printing} *)

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -801,34 +801,34 @@ type symbolic_output_item =
   - [Output_spaces n]: symbolic command to output [n] spaces.
   - [Output_indent i]: symbolic indentation of size [i].
 
-  @since 4.04.0
+  @since 4.06.0
 *)
 
 type symbolic_output_buffer
 (**
   The output buffer of a symbolic pretty-printer.
 
-  @since 4.04.0
+  @since 4.06.0
 *)
 
 val make_symbolic_output_buffer : unit -> symbolic_output_buffer
 (** [make_symbolic_output_buffer ()] returns a fresh buffer for
   symbolic output.
 
-  @since 4.04.0
+  @since 4.06.0
 *)
 
 val clear_symbolic_output_buffer : symbolic_output_buffer -> unit
 (** [clear_symbolic_output_buffer sob] resets buffer [sob].
 
-  @since 4.04.0
+  @since 4.06.0
 *)
 
 val get_symbolic_output_buffer :
   symbolic_output_buffer -> symbolic_output_item list
 (** [get_symbolic_output_buffer sob] returns the contents of buffer [sob].
 
-  @since 4.04.0
+  @since 4.06.0
 *)
 
 val flush_symbolic_output_buffer :
@@ -839,7 +839,7 @@ val flush_symbolic_output_buffer :
   [let items = get_symbolic_output_buffer sob in
    clear_symbolic_output_buffer sob; items]
 
-  @since 4.04.0
+  @since 4.06.0
 *)
 
 val add_symbolic_output_item :
@@ -851,7 +851,7 @@ val formatter_of_symbolic_output_buffer : symbolic_output_buffer -> formatter
 (** [formatter_of_symbolic_output_buffer sob] returns a symbolic formatter
   that outputs to [symbolic_output_buffer] [sob].
 
-  @since 4.04.0
+  @since 4.06.0
 *)
 
 (** {6 Basic functions for formatters} *)

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -788,20 +788,16 @@ val formatter_of_out_functions :
 *)
 
 type symbolic_output_item =
-  | Output_flush
-  | Output_newline
+  | Output_flush (** symbolic flush command *)
+  | Output_newline (** symbolic newline command *)
   | Output_string of string
+  (** [Output_string s]: symbolic output for string [s]*)
   | Output_spaces of int
+  (** [Output_spaces n]: symbolic command to output [n] spaces *)
   | Output_indent of int
-(**
-  The output items that symbolic pretty-printers will produce:
-  - [Output_flush]: symbolic flush command.
-  - [Output_newline]: symbolic newline command.
-  - [Output_string s]: symbolic output for string [s].
-  - [Output_spaces n]: symbolic command to output [n] spaces.
-  - [Output_indent i]: symbolic indentation of size [i].
-
-  @since 4.06.0
+  (** [Output_indent i]: symbolic indentation of size [i] *)
+(** Items produced by symbolic pretty-printers
+    @since 4.06.0
 *)
 
 type symbolic_output_buffer


### PR DESCRIPTION
This PR fixes a handful of minor issues with the documentation of the Format module:

- some `@since` metadata were referring to 4.04 instead of 4.06
- The documentation comment for `symbolic_output_item` was wrongly attached to the `Output_indent` constructor, and was detailing each constructors in a list.
- There were no Changes entry associated with #615, even though it introduces a breaking change.

@pierreweis, @rbonichon: Do you wish to make any amendments to these fixes?