### PR TITLE
MPR#7604: minor Ephemeron documentation fixes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -88,6 +88,7 @@ Andreas Hauptmann <andreashauptmann@t-online.de> fdopen <andreashauptmann@t-onli
 Andreas Hauptmann <andreashauptmann@t-online.de> <fdopen@users.noreply.github.com>
 Hendrik Tews <hendrik@askra.de>
 Hugo Heuzard <hugo.heuzard@gmail.com>
+Miod Vallat <miod@mantis>
 
 # These contributors prefer to be referred to pseudonymously
 whitequark <whitequark@whitequark.org>

--- a/Changes
+++ b/Changes
@@ -188,6 +188,9 @@ Working version
   caml_example
   (Florian Angeletti, review and suggestion by Gabriel Scherer)
 
+- MPR#7604: Minor Ephemeron documentation fixes
+  (Miod Vallat, review by Florian Angeletti)
+
 - GPR#1187: Minimal documentation for compiler plugins
   (Florian Angeletti)
   

--- a/stdlib/ephemeron.mli
+++ b/stdlib/ephemeron.mli
@@ -15,14 +15,12 @@
 
 (** Ephemerons and weak hash table *)
 
-(** Ephemerons and weak hash table
-
-    Ephemerons and weak hash table are useful when one wants to cache
+(** Ephemerons and weak hash table are useful when one wants to cache
     or memorize the computation of a function, as long as the
     arguments and the function are used, without creating memory leaks
     by continuously keeping old computation results that are not
     useful anymore because one argument or the function is freed. An
-    implementation using {Hashtbl.t} is not suitable because all
+    implementation using {!Hashtbl.t} is not suitable because all
     associations would keep in memory the arguments and the result.
 
     Ephemerons can also be used for "adding" a field to an arbitrary


### PR DESCRIPTION
Submitted on behalf of Miod Vallat, see [MPR#7604](https://caml.inria.fr/mantis/view.php?id=7604).

This patch fixes two issues within the documentation comments of `ephemeron.mli` .
First, it removes a repetition of the module preamble at the start of the main body of the documentation.
Second, it adds back a missing `!` inside a cross-reference to `Hashtbl.t`.