### PR TITLE
Restore 32bit compilation

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -60,8 +60,6 @@ EOF
   i386)
     ./configure --prefix $PREFIX -with-debug-runtime \
       -with-instrumented-runtime $CONFIG_ARG \
-      -cc "gcc -m32" -as "as --32" -aspp "gcc -m32 -c" \
-      -partialld "ld -r -melf_i386" \
       -host i686-pc-linux-gnu
     ;;
   *)

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -74,11 +74,11 @@ EOF
   (cd testsuite && $MAKE all)
   [ $XARCH =  "i386" ] ||  (cd testsuite && $MAKE USE_RUNTIME="d" all)
   $MAKE install
-  # check_all_arches checks tries to compile all backends in place,
-  # we need to redo (small parts of) world.opt afterwards
-  $MAKE check_all_arches
-  $MAKE world.opt
   $MAKE manual-pregen
+  # check_all_arches checks tries to compile all backends in place,
+  # we would need to redo (small parts of) world.opt afterwards to
+  # use the compiler again
+  $MAKE check_all_arches
 }
 
 CheckChangesModified () {

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -42,7 +42,7 @@ esac
 
 BuildAndTest () {
   case $XARCH in
-  i386)
+  x64)
   cat<<EOF
 ------------------------------------------------------------------------
 This test builds the OCaml compiler distribution with your pull request

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -72,7 +72,7 @@ EOF
   $MAKE world.opt
   $MAKE ocamlnat
   (cd testsuite && $MAKE all)
-  (cd testsuite && $MAKE USE_RUNTIME="d" all)
+  [ $XARCH =  "i386" ] ||  (cd testsuite && $MAKE USE_RUNTIME="d" all)
   $MAKE install
   # check_all_arches checks tries to compile all backends in place,
   # we need to redo (small parts of) world.opt afterwards

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ git:
 script: bash -ex .travis-ci.sh
 matrix:
   include:
-  - env: CI_KIND=build XARCH=i386
-  - env: CI_KIND=build XARCH=i386 CONFIG_ARG=-flambda OCAMLRUNPARAM=b,v=0
+  - env: CI_KIND=build XARCH=x64
+  - env: CI_KIND=build XARCH=x64 CONFIG_ARG=-flambda OCAMLRUNPARAM=b,v=0
   - env: CI_KIND=changes
   - env: CI_KIND=tests
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,15 @@ script: bash -ex .travis-ci.sh
 matrix:
   include:
   - env: CI_KIND=build XARCH=i386
+    addons:
+      apt:
+        packages:
+        - gcc:i386
+        - cpp:i386
+        - binutils:i386
+        - binutils-dev:i386
+        - libx11-dev:i386
+        - libc6-dev:i386
   - env: CI_KIND=build XARCH=x64
   - env: CI_KIND=build XARCH=x64 CONFIG_ARG=-flambda OCAMLRUNPARAM=b,v=0
   - env: CI_KIND=changes
@@ -31,4 +40,3 @@ addons:
   apt:
     packages:
     - binutils-dev
-    - gcc-multilib

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ git:
 script: bash -ex .travis-ci.sh
 matrix:
   include:
+  - env: CI_KIND=build XARCH=i386
   - env: CI_KIND=build XARCH=x64
   - env: CI_KIND=build XARCH=x64 CONFIG_ARG=-flambda OCAMLRUNPARAM=b,v=0
   - env: CI_KIND=changes
@@ -30,3 +31,4 @@ addons:
   apt:
     packages:
     - binutils-dev
+    - gcc-multilib

--- a/Changes
+++ b/Changes
@@ -421,10 +421,10 @@ Working version
 
 ### Runtime system:
 
-- GPR#1070: enable gcc typechecking for caml_alloc_sprintf, caml_gc_message.
-  Make caml_gc_message a variadic function. Fix many caml_gc_message format
-  strings.
-  (Olivier Andrieu)
+- GPR#1070, GPR#1295: enable gcc typechecking for caml_alloc_sprintf,
+  caml_gc_message. Make caml_gc_message a variadic function. Fix many
+  caml_gc_message format strings.
+  (Olivier Andrieu, review and 32bit fix by David Allsopp)
 
 - GPR#71: The runtime can now be shut down gracefully by means of the new
   caml_shutdown and caml_startup_pooled functions. The new 'c' flag in

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -243,7 +243,7 @@ machine, you can use the configuration values and run command taken from
 link:.travis.yml[]:
 
 ----
-CI_KIND=build XARCH=i386 bash -ex .travis-ci.sh
+CI_KIND=build XARCH=x64 bash -ex .travis-ci.sh
 ----
 
 The scripts support two other kinds of tests (values of the

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -44,7 +44,7 @@ if [[ $1 = "msvc32-only" ]] ; then
 
   PREFIX="C:/Program Files/OCaml-msmvc32"
   echo "Edit config/Makefile to set PREFIX=$PREFIX"
-  sed -e "s|PREFIX=.*|PREFIX=$PREFIX|" -e "/\(BYTE\|NATIVE\)CCCOMPOPTS=./s/\r\?$/ -WX\0/" config/Makefile.msvc > config/Makefile
+  sed -e "s|PREFIX=.*|PREFIX=$PREFIX|" -e "/^ *CFLAGS *=/s/\r\?$/ -WX\0/" config/Makefile.msvc > config/Makefile
 
   run "make world" make world
   run "make runtimeopt" make runtimeopt
@@ -73,7 +73,7 @@ cp config/m-nt.h byterun/caml/m.h
 cp config/s-nt.h byterun/caml/s.h
 
 echo "Edit config/Makefile to set PREFIX=$PREFIX"
-sed -e "s|PREFIX=.*|PREFIX=$PREFIX|" -e "/\(BYTE\|NATIVE\)CCCOMPOPTS=./s/\r\?$/ -WX\0/" config/Makefile.msvc64 > config/Makefile
+sed -e "s|PREFIX=.*|PREFIX=$PREFIX|" -e "/^ *CFLAGS *=/s/\r\?$/ -WX\0/" config/Makefile.msvc64 > config/Makefile
 #run "Content of config/Makefile" cat config/Makefile
 
 run "make world" make world
@@ -88,7 +88,7 @@ cp config/s-nt.h byterun/caml/s.h
 
 PREFIX="C:/Program Files/OCaml-mingw32"
 echo "Edit config/Makefile to set PREFIX=$PREFIX"
-sed -e "s|PREFIX=.*|PREFIX=$PREFIX|" -e "/\(BYTE\|NATIVE\)CCCOMPOPTS=./s/\r\?$/ -Werror\0/" config/Makefile.mingw > config/Makefile
+sed -e "s|PREFIX=.*|PREFIX=$PREFIX|" -e "/^ *CFLAGS *=/s/\r\?$/ -Werror\0/" config/Makefile.mingw > config/Makefile
 #run "Content of config/Makefile" cat config/Makefile
 
 run "make flexdll" make flexdll

--- a/byterun/caml/config.h
+++ b/byterun/caml/config.h
@@ -33,6 +33,10 @@
 #include <stdint.h>
 #endif
 
+#ifndef ARCH_SIZET_PRINTF_FORMAT
+#define ARCH_SIZET_PRINTF_FORMAT "z"
+#endif
+
 /* Types for 32-bit integers, 64-bit integers, and
    native integers (as wide as a pointer type) */
 

--- a/byterun/gc_ctrl.c
+++ b/byterun/gc_ctrl.c
@@ -461,7 +461,7 @@ CAMLprim value caml_gc_set(value v)
   newminwsz = norm_minsize (Long_val (Field (v, 0)));
   if (newminwsz != caml_minor_heap_wsz){
     caml_gc_message (0x20, "New minor heap size: %"
-                     ARCH_INTNAT_PRINTF_FORMAT "uk words\n", newminwsz / 1024);
+                     ARCH_SIZET_PRINTF_FORMAT "uk words\n", newminwsz / 1024);
     caml_set_minor_heap_size (Bsize_wsize (newminwsz));
   }
   CAML_INSTR_TIME (tmr, "explicit/gc_set");
@@ -603,7 +603,7 @@ void caml_init_gc (uintnat minor_size, uintnat major_size,
   caml_init_major_heap (major_heap_size);
   caml_major_window = norm_window (window);
   caml_gc_message (0x20, "Initial minor heap size: %"
-                   ARCH_INTNAT_PRINTF_FORMAT "uk words\n",
+                   ARCH_SIZET_PRINTF_FORMAT "uk words\n",
                    caml_minor_heap_wsz / 1024);
   caml_gc_message (0x20, "Initial major heap size: %"
                    ARCH_INTNAT_PRINTF_FORMAT "uk bytes\n",
@@ -647,10 +647,11 @@ extern int caml_parser_trace;
 CAMLprim value caml_runtime_parameters (value unit)
 {
 #define F_Z ARCH_INTNAT_PRINTF_FORMAT
+#define F_S ARCH_SIZET_PRINTF_FORMAT
 
   CAMLassert (unit == Val_unit);
   return caml_alloc_sprintf
-    ("a=%d,b=%d,H=%"F_Z"u,i=%"F_Z"u,l=%"F_Z"u,o=%"F_Z"u,O=%"F_Z"u,p=%d,s=%"F_Z"u,t=%"F_Z"u,v=%"F_Z"u,w=%d,W=%"F_Z"u",
+    ("a=%d,b=%d,H=%"F_Z"u,i=%"F_Z"u,l=%"F_Z"u,o=%"F_Z"u,O=%"F_Z"u,p=%d,s=%"F_S"u,t=%"F_Z"u,v=%"F_Z"u,w=%d,W=%"F_Z"u",
      /* a */ (int) caml_allocation_policy,
      /* b */ caml_backtrace_active,
      /* h */ /* missing */ /* FIXME add when changed to min_heap_size */
@@ -672,6 +673,7 @@ CAMLprim value caml_runtime_parameters (value unit)
      /* W */ caml_runtime_warnings
      );
 #undef F_Z
+#undef F_S
 }
 
 /* Control runtime warnings */

--- a/config/m-nt.h
+++ b/config/m-nt.h
@@ -41,6 +41,11 @@
 #define ARCH_UINT64_TYPE unsigned __int64
 #endif
 #define ARCH_INT64_PRINTF_FORMAT "I64"
+#if _MSC_VER >= 1800
+#define ARCH_SIZET_PRINTF_FORMAT "z"
+#else
+#define ARCH_SIZET_PRINTF_FORMAT "I"
+#endif
 
 #if defined(_MSC_VER) && !defined(__cplusplus)
 #define inline __inline

--- a/yacc/main.c
+++ b/yacc/main.c
@@ -100,9 +100,6 @@ char *nullable;
 #if !defined(HAS_MKSTEMP)
 extern char *mktemp(char *);
 #endif
-#ifdef _WIN32
-extern char *getenv(const char *);
-#endif
 
 
 void done(int k)


### PR DESCRIPTION
This PR addresses various shortcomings of our CI:
 - x86 Linux is now tested on Travis
 - Recent (good) changes to the Windows build system mean that AppVeyor was no longer running with C warnings as errors
 - An old issue in ocamlyacc's definition of `getenv` on Windows fixed to eliminate an error
 - Breakage caused by need for `z` printf specifier in #1070 on 32-bit platforms dealt with