### PR TITLE
Fix Windows config/Makefile to remove num library

### DIFF
--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -185,11 +185,7 @@ PACKLD=$(TOOLPREF)ld -r -o # must have a space after '-o'
 
 ############# Configuration for the contributed libraries
 
-OTHERLIBRARIES=win32unix str num win32graph dynlink bigarray systhreads
-
-### Name of the target architecture for the "num" library
-BNG_ARCH=ia32
-BNG_ASM_LEVEL=1
+OTHERLIBRARIES=win32unix str win32graph dynlink bigarray systhreads
 
 ############# for the testsuite makefiles
 #ml let topdir = "" and wintopdir = "";;

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -185,11 +185,7 @@ PACKLD=$(TOOLPREF)ld -r -o # must have a space after '-o'
 
 ############# Configuration for the contributed libraries
 
-OTHERLIBRARIES=win32unix str num win32graph dynlink bigarray systhreads
-
-### Name of the target architecture for the "num" library
-BNG_ARCH=amd64
-BNG_ASM_LEVEL=1
+OTHERLIBRARIES=win32unix str win32graph dynlink bigarray systhreads
 
 ############# for the testsuite makefiles
 #ml let topdir = "" and wintopdir = "";;

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -187,11 +187,7 @@ WITH_OCAMLDOC=ocamldoc
 
 ############# Configuration for the contributed libraries
 
-OTHERLIBRARIES=win32unix systhreads str num win32graph dynlink bigarray
-
-### Name of the target architecture for the "num" library
-BNG_ARCH=generic
-BNG_ASM_LEVEL=0
+OTHERLIBRARIES=win32unix systhreads str win32graph dynlink bigarray
 
 ############# for the testsuite makefiles
 #ml let topdir = "" and wintopdir = "";;

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -190,11 +190,7 @@ WITH_OCAMLDOC=ocamldoc
 
 ############# Configuration for the contributed libraries
 
-OTHERLIBRARIES=win32unix systhreads str num win32graph dynlink bigarray
-
-### Name of the target architecture for the "num" library
-BNG_ARCH=generic
-BNG_ASM_LEVEL=0
+OTHERLIBRARIES=win32unix systhreads str win32graph dynlink bigarray
 
 ############# for the testsuite makefiles
 #ml let topdir = "" and wintopdir = "";;


### PR DESCRIPTION
Amends `config/Makefile.m*` not to build the num library removed in #1178.

@xavierleroy - when the CI fails owing to a transient error, it's better to restart it (via @avsm), rather than ignore it :wink:

I've already tested all 4 ports with this change, though.