### PR TITLE
Improve propagation of type annotations in let-bodies

### DIFF
--- a/Changes
+++ b/Changes
@@ -80,6 +80,12 @@ Working version
   to GPR#1250.)
   (Mark Shinwell)
 
+### Type system:
+
+- GPR#1298: improve propagation of type annotations in let-bindings of the form
+    let <pattern> : <type> = <expr>
+  (Gabriel Scherer, request by Alexey Egorov)
+
 ### Standard library:
 
 - MPR#1771, MPR#7309, GPR#1026: Add update to maps. Allows to update a

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1598,7 +1598,8 @@ let_binding_body:
   | pattern_no_exn EQUAL seq_expr
       { ($1, $3) }
   | simple_pattern_not_ident COLON core_type EQUAL seq_expr
-      { (ghpat(Ppat_constraint($1, $3)), $5) }
+      { (ghpat(Ppat_constraint($1, $3)),
+         ghexp(Pexp_constraint($5, $3))) }
 ;
 let_bindings:
     let_binding                                 { $1 }

--- a/testsuite/tests/parsing/attributes.ml
+++ b/testsuite/tests/parsing/attributes.ml
@@ -1,6 +1,6 @@
 [@@@foo]
 
-let (x[@foo]) : unit [@foo] = ()[@foo]
+let ((x[@foo]) : unit [@foo]) = ()[@foo]
   [@@foo]
 
 type t =

--- a/testsuite/tests/parsing/attributes.ml.reference
+++ b/testsuite/tests/parsing/attributes.ml.reference
@@ -2,33 +2,33 @@
   structure_item (attributes.ml[1,0+0]..[1,0+8])
     Pstr_attribute "foo"
     []
-  structure_item (attributes.ml[3,10+0]..[4,49+9])
+  structure_item (attributes.ml[3,10+0]..[4,51+9])
     Pstr_value Nonrec
     [
       <def>
           attribute "foo"
             []
-        pattern (attributes.ml[3,10+4]..[3,10+38]) ghost
+        pattern (attributes.ml[3,10+4]..[3,10+29])
           Ppat_constraint
-          pattern (attributes.ml[3,10+4]..[3,10+13])
+          pattern (attributes.ml[3,10+5]..[3,10+14])
             attribute "foo"
               []
-            Ppat_var "x" (attributes.ml[3,10+5]..[3,10+6])
-          core_type (attributes.ml[3,10+16]..[3,10+20])
+            Ppat_var "x" (attributes.ml[3,10+6]..[3,10+7])
+          core_type (attributes.ml[3,10+17]..[3,10+21])
             attribute "foo"
               []
-            Ptyp_constr "unit" (attributes.ml[3,10+16]..[3,10+20])
+            Ptyp_constr "unit" (attributes.ml[3,10+17]..[3,10+21])
             []
-        expression (attributes.ml[3,10+30]..[3,10+32])
+        expression (attributes.ml[3,10+32]..[3,10+34])
           attribute "foo"
             []
-          Pexp_construct "()" (attributes.ml[3,10+30]..[3,10+32])
+          Pexp_construct "()" (attributes.ml[3,10+32]..[3,10+34])
           None
     ]
-  structure_item (attributes.ml[6,60+0]..[8,97+7])
+  structure_item (attributes.ml[6,62+0]..[8,99+7])
     Pstr_type Rec
     [
-      type_declaration "t" (attributes.ml[6,60+5]..[6,60+6]) (attributes.ml[6,60+0]..[8,97+7])
+      type_declaration "t" (attributes.ml[6,62+5]..[6,62+6]) (attributes.ml[6,62+0]..[8,99+7])
         attribute "foo"
           []
         ptype_params =
@@ -38,15 +38,15 @@
         ptype_kind =
           Ptype_variant
             [
-              (attributes.ml[7,69+2]..[7,69+27])
-                "Foo" (attributes.ml[7,69+4]..[7,69+7])
+              (attributes.ml[7,71+2]..[7,71+27])
+                "Foo" (attributes.ml[7,71+4]..[7,71+7])
                 attribute "foo"
                   []
                 [
-                  core_type (attributes.ml[7,69+12]..[7,69+13])
+                  core_type (attributes.ml[7,71+12]..[7,71+13])
                     attribute "foo"
                       []
-                    Ptyp_constr "t" (attributes.ml[7,69+12]..[7,69+13])
+                    Ptyp_constr "t" (attributes.ml[7,71+12]..[7,71+13])
                     []
                 ]
                 None
@@ -55,23 +55,23 @@
         ptype_manifest =
           None
     ]
-  structure_item (attributes.ml[10,106+0]..[10,106+8])
+  structure_item (attributes.ml[10,108+0]..[10,108+8])
     Pstr_attribute "foo"
     []
-  structure_item (attributes.ml[13,117+0]..[22,224+7])
+  structure_item (attributes.ml[13,119+0]..[22,226+7])
     Pstr_module
-    "M" (attributes.ml[13,117+7]..[13,117+8])
+    "M" (attributes.ml[13,119+7]..[13,119+8])
       attribute "foo"
         []
-      module_expr (attributes.ml[13,117+11]..[21,214+3])
+      module_expr (attributes.ml[13,119+11]..[21,216+3])
         attribute "foo"
           []
         Pmod_structure
         [
-          structure_item (attributes.ml[14,135+2]..[18,190+11])
+          structure_item (attributes.ml[14,137+2]..[18,192+11])
             Pstr_type Rec
             [
-              type_declaration "t" (attributes.ml[14,135+7]..[14,135+8]) (attributes.ml[14,135+2]..[18,190+11])
+              type_declaration "t" (attributes.ml[14,137+7]..[14,137+8]) (attributes.ml[14,137+2]..[18,192+11])
                 attribute "foo"
                   []
                 attribute "foo"
@@ -83,50 +83,50 @@
                 ptype_kind =
                   Ptype_record
                     [
-                      (attributes.ml[15,148+4]..[15,148+25])
+                      (attributes.ml[15,150+4]..[15,150+25])
                         attribute "foo"
                           []
                         Immutable
-                        "l" (attributes.ml[15,148+4]..[15,148+5])                        core_type (attributes.ml[15,148+9]..[15,148+10])
+                        "l" (attributes.ml[15,150+4]..[15,150+5])                        core_type (attributes.ml[15,150+9]..[15,150+10])
                           attribute "foo"
                             []
-                          Ptyp_constr "t" (attributes.ml[15,148+9]..[15,148+10])
+                          Ptyp_constr "t" (attributes.ml[15,150+9]..[15,150+10])
                           []
                     ]
                 ptype_private = Public
                 ptype_manifest =
                   None
             ]
-          structure_item (attributes.ml[20,203+2]..[20,203+10])
+          structure_item (attributes.ml[20,205+2]..[20,205+10])
             Pstr_attribute "foo"
             []
         ]
-  structure_item (attributes.ml[24,233+0]..[32,357+7])
-    Pstr_modtype "S" (attributes.ml[24,233+12]..[24,233+13])
+  structure_item (attributes.ml[24,235+0]..[32,359+7])
+    Pstr_modtype "S" (attributes.ml[24,235+12]..[24,235+13])
       attribute "foo"
         []
-      module_type (attributes.ml[24,233+16]..[31,347+3])
+      module_type (attributes.ml[24,235+16]..[31,349+3])
         attribute "foo"
           []
         Pmty_signature
         [
-          signature_item (attributes.ml[26,254+2]..[27,322+11])
+          signature_item (attributes.ml[26,256+2]..[27,324+11])
             Psig_include
-            module_type (attributes.ml[26,254+10]..[26,254+61])
+            module_type (attributes.ml[26,256+10]..[26,256+61])
               attribute "foo"
                 []
               Pmty_with
-              module_type (attributes.ml[26,254+11]..[26,254+35])
+              module_type (attributes.ml[26,256+11]..[26,256+35])
                 attribute "foo"
                   []
                 Pmty_typeof
-                module_expr (attributes.ml[26,254+27]..[26,254+28])
+                module_expr (attributes.ml[26,256+27]..[26,256+28])
                   attribute "foo"
                     []
-                  Pmod_ident "M" (attributes.ml[26,254+27]..[26,254+28])
+                  Pmod_ident "M" (attributes.ml[26,256+27]..[26,256+28])
               [
                 Pwith_typesubst
-                  type_declaration "t" (attributes.ml[26,254+53]..[26,254+54]) (attributes.ml[26,254+48]..[26,254+61])
+                  type_declaration "t" (attributes.ml[26,256+53]..[26,256+54]) (attributes.ml[26,256+48]..[26,256+61])
                     ptype_params =
                       []
                     ptype_cstrs =
@@ -136,17 +136,17 @@
                     ptype_private = Public
                     ptype_manifest =
                       Some
-                        core_type (attributes.ml[26,254+58]..[26,254+61])
-                          Ptyp_constr "M.t" (attributes.ml[26,254+58]..[26,254+61])
+                        core_type (attributes.ml[26,256+58]..[26,256+61])
+                          Ptyp_constr "M.t" (attributes.ml[26,256+58]..[26,256+61])
                           []
               ]
               attribute "foo"
                 []
-          signature_item (attributes.ml[29,335+2]..[29,335+10])
+          signature_item (attributes.ml[29,337+2]..[29,337+10])
             Psig_attribute "foo"
             []
         ]
-  structure_item (attributes.ml[34,366+0]..[34,366+8])
+  structure_item (attributes.ml[34,368+0]..[34,368+8])
     Pstr_attribute "foo"
     []
 ]

--- a/testsuite/tests/parsing/extensions.ml
+++ b/testsuite/tests/parsing/extensions.ml
@@ -1,18 +1,18 @@
 
 [%%foo let x = 1 in x]
-let [%foo 2+1] : [%foo bar.baz] = [%foo "foo"]
+let ([%foo 2+1] : [%foo bar.baz]) = [%foo "foo"]
 
 [%%foo module M = [%bar] ]
-let [%foo let () = () ] : [%foo type t = t ] = [%foo class c = object end]
+let ([%foo let () = () ] : [%foo type t = t ]) = [%foo class c = object end]
 
 [%%foo: 'a list]
-let [%foo: [`Foo] ] : [%foo: t -> t ] = [%foo: < foo : t > ]
+let ([%foo: [`Foo] ] : [%foo: t -> t ]) = [%foo: < foo : t > ]
 
 [%%foo? _ ]
 [%%foo? Some y when y > 0]
-let [%foo? (Bar x | Baz x) ] : [%foo? #bar ] = [%foo? { x }]
+let ([%foo? (Bar x | Baz x) ] : [%foo? #bar ]) = [%foo? { x }]
 
 [%%foo: module M : [%baz]]
-let [%foo: include S with type t = t ]
-  : [%foo: val x : t  val y : t]
+let ([%foo: include S with type t = t ]
+    : [%foo: val x : t  val y : t])
   = [%foo: type t = t ]

--- a/testsuite/tests/parsing/extensions.ml.reference
+++ b/testsuite/tests/parsing/extensions.ml.reference
@@ -16,90 +16,90 @@
           expression (extensions.ml[2,1+20]..[2,1+21])
             Pexp_ident "x" (extensions.ml[2,1+20]..[2,1+21])
     ]
-  structure_item (extensions.ml[3,24+0]..[3,24+46])
+  structure_item (extensions.ml[3,24+0]..[3,24+48])
     Pstr_value Nonrec
     [
       <def>
-        pattern (extensions.ml[3,24+4]..[3,24+46]) ghost
+        pattern (extensions.ml[3,24+4]..[3,24+33])
           Ppat_constraint
-          pattern (extensions.ml[3,24+4]..[3,24+14])
+          pattern (extensions.ml[3,24+5]..[3,24+15])
             Ppat_extension "foo"
             [
-              structure_item (extensions.ml[3,24+10]..[3,24+13])
+              structure_item (extensions.ml[3,24+11]..[3,24+14])
                 Pstr_eval
-                expression (extensions.ml[3,24+10]..[3,24+13])
+                expression (extensions.ml[3,24+11]..[3,24+14])
                   Pexp_apply
-                  expression (extensions.ml[3,24+11]..[3,24+12])
-                    Pexp_ident "+" (extensions.ml[3,24+11]..[3,24+12])
+                  expression (extensions.ml[3,24+12]..[3,24+13])
+                    Pexp_ident "+" (extensions.ml[3,24+12]..[3,24+13])
                   [
                     <arg>
                     Nolabel
-                      expression (extensions.ml[3,24+10]..[3,24+11])
+                      expression (extensions.ml[3,24+11]..[3,24+12])
                         Pexp_constant PConst_int (2,None)
                     <arg>
                     Nolabel
-                      expression (extensions.ml[3,24+12]..[3,24+13])
+                      expression (extensions.ml[3,24+13]..[3,24+14])
                         Pexp_constant PConst_int (1,None)
                   ]
             ]
-          core_type (extensions.ml[3,24+17]..[3,24+31])
+          core_type (extensions.ml[3,24+18]..[3,24+32])
             Ptyp_extension "foo"
             [
-              structure_item (extensions.ml[3,24+23]..[3,24+30])
+              structure_item (extensions.ml[3,24+24]..[3,24+31])
                 Pstr_eval
-                expression (extensions.ml[3,24+23]..[3,24+30])
+                expression (extensions.ml[3,24+24]..[3,24+31])
                   Pexp_field
-                  expression (extensions.ml[3,24+23]..[3,24+26])
-                    Pexp_ident "bar" (extensions.ml[3,24+23]..[3,24+26])
-                  "baz" (extensions.ml[3,24+27]..[3,24+30])
+                  expression (extensions.ml[3,24+24]..[3,24+27])
+                    Pexp_ident "bar" (extensions.ml[3,24+24]..[3,24+27])
+                  "baz" (extensions.ml[3,24+28]..[3,24+31])
             ]
-        expression (extensions.ml[3,24+34]..[3,24+46])
+        expression (extensions.ml[3,24+36]..[3,24+48])
           Pexp_extension "foo"
           [
-            structure_item (extensions.ml[3,24+40]..[3,24+45])
+            structure_item (extensions.ml[3,24+42]..[3,24+47])
               Pstr_eval
-              expression (extensions.ml[3,24+40]..[3,24+45])
+              expression (extensions.ml[3,24+42]..[3,24+47])
                 Pexp_constant PConst_string("foo",None)
           ]
     ]
-  structure_item (extensions.ml[5,72+0]..[5,72+26])
+  structure_item (extensions.ml[5,74+0]..[5,74+26])
     Pstr_extension "foo"
     [
-      structure_item (extensions.ml[5,72+7]..[5,72+24])
+      structure_item (extensions.ml[5,74+7]..[5,74+24])
         Pstr_module
-        "M" (extensions.ml[5,72+14]..[5,72+15])
-          module_expr (extensions.ml[5,72+18]..[5,72+24])
+        "M" (extensions.ml[5,74+14]..[5,74+15])
+          module_expr (extensions.ml[5,74+18]..[5,74+24])
             Pmod_extension "bar"
             []
     ]
-  structure_item (extensions.ml[6,99+0]..[6,99+74])
+  structure_item (extensions.ml[6,101+0]..[6,101+76])
     Pstr_value Nonrec
     [
       <def>
-        pattern (extensions.ml[6,99+4]..[6,99+74]) ghost
+        pattern (extensions.ml[6,101+4]..[6,101+46])
           Ppat_constraint
-          pattern (extensions.ml[6,99+4]..[6,99+23])
+          pattern (extensions.ml[6,101+5]..[6,101+24])
             Ppat_extension "foo"
             [
-              structure_item (extensions.ml[6,99+10]..[6,99+21])
+              structure_item (extensions.ml[6,101+11]..[6,101+22])
                 Pstr_value Nonrec
                 [
                   <def>
-                    pattern (extensions.ml[6,99+14]..[6,99+16])
-                      Ppat_construct "()" (extensions.ml[6,99+14]..[6,99+16])
+                    pattern (extensions.ml[6,101+15]..[6,101+17])
+                      Ppat_construct "()" (extensions.ml[6,101+15]..[6,101+17])
                       None
-                    expression (extensions.ml[6,99+19]..[6,99+21])
-                      Pexp_construct "()" (extensions.ml[6,99+19]..[6,99+21])
+                    expression (extensions.ml[6,101+20]..[6,101+22])
+                      Pexp_construct "()" (extensions.ml[6,101+20]..[6,101+22])
                       None
                 ]
             ]
-          core_type (extensions.ml[6,99+26]..[6,99+44])
+          core_type (extensions.ml[6,101+27]..[6,101+45])
             Ptyp_extension "foo"
             [
-              structure_item (extensions.ml[6,99+32]..[6,99+42])
+              structure_item (extensions.ml[6,101+33]..[6,101+43])
                 Pstr_type Rec
                 [
-                  type_declaration "t" (extensions.ml[6,99+37]..[6,99+38]) (extensions.ml[6,99+32]..[6,99+42])
+                  type_declaration "t" (extensions.ml[6,101+38]..[6,101+39]) (extensions.ml[6,101+33]..[6,101+43])
                     ptype_params =
                       []
                     ptype_cstrs =
@@ -109,163 +109,163 @@
                     ptype_private = Public
                     ptype_manifest =
                       Some
-                        core_type (extensions.ml[6,99+41]..[6,99+42])
-                          Ptyp_constr "t" (extensions.ml[6,99+41]..[6,99+42])
+                        core_type (extensions.ml[6,101+42]..[6,101+43])
+                          Ptyp_constr "t" (extensions.ml[6,101+42]..[6,101+43])
                           []
                 ]
             ]
-        expression (extensions.ml[6,99+47]..[6,99+74])
+        expression (extensions.ml[6,101+49]..[6,101+76])
           Pexp_extension "foo"
           [
-            structure_item (extensions.ml[6,99+53]..[6,99+73])
+            structure_item (extensions.ml[6,101+55]..[6,101+75])
               Pstr_class
               [
-                class_declaration (extensions.ml[6,99+53]..[6,99+73])
+                class_declaration (extensions.ml[6,101+55]..[6,101+75])
                   pci_virt = Concrete
                   pci_params =
                     []
-                  pci_name = "c" (extensions.ml[6,99+59]..[6,99+60])
+                  pci_name = "c" (extensions.ml[6,101+61]..[6,101+62])
                   pci_expr =
-                    class_expr (extensions.ml[6,99+63]..[6,99+73])
+                    class_expr (extensions.ml[6,101+65]..[6,101+75])
                       Pcl_structure
                       class_structure
-                        pattern (extensions.ml[6,99+69]..[6,99+69]) ghost
+                        pattern (extensions.ml[6,101+71]..[6,101+71]) ghost
                           Ppat_any
                         []
               ]
           ]
     ]
-  structure_item (extensions.ml[8,175+0]..[8,175+16])
+  structure_item (extensions.ml[8,179+0]..[8,179+16])
     Pstr_extension "foo"
-    core_type (extensions.ml[8,175+8]..[8,175+15])
-      Ptyp_constr "list" (extensions.ml[8,175+11]..[8,175+15])
+    core_type (extensions.ml[8,179+8]..[8,179+15])
+      Ptyp_constr "list" (extensions.ml[8,179+11]..[8,179+15])
       [
-        core_type (extensions.ml[8,175+8]..[8,175+10])
+        core_type (extensions.ml[8,179+8]..[8,179+10])
           Ptyp_var a
       ]
-  structure_item (extensions.ml[9,192+0]..[9,192+60])
+  structure_item (extensions.ml[9,196+0]..[9,196+62])
     Pstr_value Nonrec
     [
       <def>
-        pattern (extensions.ml[9,192+4]..[9,192+60]) ghost
+        pattern (extensions.ml[9,196+4]..[9,196+39])
           Ppat_constraint
-          pattern (extensions.ml[9,192+4]..[9,192+19])
+          pattern (extensions.ml[9,196+5]..[9,196+20])
             Ppat_extension "foo"
-            core_type (extensions.ml[9,192+11]..[9,192+17])
+            core_type (extensions.ml[9,196+12]..[9,196+18])
               Ptyp_variant closed=Closed
               [
                 Rtag "Foo" true
                   []
               ]
               None
-          core_type (extensions.ml[9,192+22]..[9,192+37])
+          core_type (extensions.ml[9,196+23]..[9,196+38])
             Ptyp_extension "foo"
-            core_type (extensions.ml[9,192+29]..[9,192+35])
+            core_type (extensions.ml[9,196+30]..[9,196+36])
               Ptyp_arrow
               Nolabel
-              core_type (extensions.ml[9,192+29]..[9,192+30])
-                Ptyp_constr "t" (extensions.ml[9,192+29]..[9,192+30])
+              core_type (extensions.ml[9,196+30]..[9,196+31])
+                Ptyp_constr "t" (extensions.ml[9,196+30]..[9,196+31])
                 []
-              core_type (extensions.ml[9,192+34]..[9,192+35])
-                Ptyp_constr "t" (extensions.ml[9,192+34]..[9,192+35])
+              core_type (extensions.ml[9,196+35]..[9,196+36])
+                Ptyp_constr "t" (extensions.ml[9,196+35]..[9,196+36])
                 []
-        expression (extensions.ml[9,192+40]..[9,192+60])
+        expression (extensions.ml[9,196+42]..[9,196+62])
           Pexp_extension "foo"
-          core_type (extensions.ml[9,192+47]..[9,192+58])
+          core_type (extensions.ml[9,196+49]..[9,196+60])
             Ptyp_object Closed
               method foo
-                core_type (extensions.ml[9,192+55]..[9,192+56])
-                  Ptyp_constr "t" (extensions.ml[9,192+55]..[9,192+56])
+                core_type (extensions.ml[9,196+57]..[9,196+58])
+                  Ptyp_constr "t" (extensions.ml[9,196+57]..[9,196+58])
                   []
     ]
-  structure_item (extensions.ml[11,254+0]..[11,254+11])
+  structure_item (extensions.ml[11,260+0]..[11,260+11])
     Pstr_extension "foo"
-    pattern (extensions.ml[11,254+8]..[11,254+9])
+    pattern (extensions.ml[11,260+8]..[11,260+9])
       Ppat_any
-  structure_item (extensions.ml[12,266+0]..[12,266+26])
+  structure_item (extensions.ml[12,272+0]..[12,272+26])
     Pstr_extension "foo"
-    pattern (extensions.ml[12,266+8]..[12,266+14])
-      Ppat_construct "Some" (extensions.ml[12,266+8]..[12,266+12])
+    pattern (extensions.ml[12,272+8]..[12,272+14])
+      Ppat_construct "Some" (extensions.ml[12,272+8]..[12,272+12])
       Some
-        pattern (extensions.ml[12,266+13]..[12,266+14])
-          Ppat_var "y" (extensions.ml[12,266+13]..[12,266+14])
+        pattern (extensions.ml[12,272+13]..[12,272+14])
+          Ppat_var "y" (extensions.ml[12,272+13]..[12,272+14])
     <when>
-      expression (extensions.ml[12,266+20]..[12,266+25])
+      expression (extensions.ml[12,272+20]..[12,272+25])
         Pexp_apply
-        expression (extensions.ml[12,266+22]..[12,266+23])
-          Pexp_ident ">" (extensions.ml[12,266+22]..[12,266+23])
+        expression (extensions.ml[12,272+22]..[12,272+23])
+          Pexp_ident ">" (extensions.ml[12,272+22]..[12,272+23])
         [
           <arg>
           Nolabel
-            expression (extensions.ml[12,266+20]..[12,266+21])
-              Pexp_ident "y" (extensions.ml[12,266+20]..[12,266+21])
+            expression (extensions.ml[12,272+20]..[12,272+21])
+              Pexp_ident "y" (extensions.ml[12,272+20]..[12,272+21])
           <arg>
           Nolabel
-            expression (extensions.ml[12,266+24]..[12,266+25])
+            expression (extensions.ml[12,272+24]..[12,272+25])
               Pexp_constant PConst_int (0,None)
         ]
-  structure_item (extensions.ml[13,293+0]..[13,293+60])
+  structure_item (extensions.ml[13,299+0]..[13,299+62])
     Pstr_value Nonrec
     [
       <def>
-        pattern (extensions.ml[13,293+4]..[13,293+60]) ghost
+        pattern (extensions.ml[13,299+4]..[13,299+46])
           Ppat_constraint
-          pattern (extensions.ml[13,293+4]..[13,293+28])
+          pattern (extensions.ml[13,299+5]..[13,299+29])
             Ppat_extension "foo"
-            pattern (extensions.ml[13,293+11]..[13,293+26])
+            pattern (extensions.ml[13,299+12]..[13,299+27])
               Ppat_or
-              pattern (extensions.ml[13,293+12]..[13,293+17])
-                Ppat_construct "Bar" (extensions.ml[13,293+12]..[13,293+15])
+              pattern (extensions.ml[13,299+13]..[13,299+18])
+                Ppat_construct "Bar" (extensions.ml[13,299+13]..[13,299+16])
                 Some
-                  pattern (extensions.ml[13,293+16]..[13,293+17])
-                    Ppat_var "x" (extensions.ml[13,293+16]..[13,293+17])
-              pattern (extensions.ml[13,293+20]..[13,293+25])
-                Ppat_construct "Baz" (extensions.ml[13,293+20]..[13,293+23])
+                  pattern (extensions.ml[13,299+17]..[13,299+18])
+                    Ppat_var "x" (extensions.ml[13,299+17]..[13,299+18])
+              pattern (extensions.ml[13,299+21]..[13,299+26])
+                Ppat_construct "Baz" (extensions.ml[13,299+21]..[13,299+24])
                 Some
-                  pattern (extensions.ml[13,293+24]..[13,293+25])
-                    Ppat_var "x" (extensions.ml[13,293+24]..[13,293+25])
-          core_type (extensions.ml[13,293+31]..[13,293+44])
+                  pattern (extensions.ml[13,299+25]..[13,299+26])
+                    Ppat_var "x" (extensions.ml[13,299+25]..[13,299+26])
+          core_type (extensions.ml[13,299+32]..[13,299+45])
             Ptyp_extension "foo"
-            pattern (extensions.ml[13,293+38]..[13,293+42])
+            pattern (extensions.ml[13,299+39]..[13,299+43])
               Ppat_type
-              "bar" (extensions.ml[13,293+39]..[13,293+42])
-        expression (extensions.ml[13,293+47]..[13,293+60])
+              "bar" (extensions.ml[13,299+40]..[13,299+43])
+        expression (extensions.ml[13,299+49]..[13,299+62])
           Pexp_extension "foo"
-          pattern (extensions.ml[13,293+54]..[13,293+59])
+          pattern (extensions.ml[13,299+56]..[13,299+61])
             Ppat_record Closed
             [
-              "x" (extensions.ml[13,293+56]..[13,293+57])
-                pattern (extensions.ml[13,293+56]..[13,293+57])
-                  Ppat_var "x" (extensions.ml[13,293+56]..[13,293+57])
+              "x" (extensions.ml[13,299+58]..[13,299+59])
+                pattern (extensions.ml[13,299+58]..[13,299+59])
+                  Ppat_var "x" (extensions.ml[13,299+58]..[13,299+59])
             ]
     ]
-  structure_item (extensions.ml[15,355+0]..[15,355+26])
+  structure_item (extensions.ml[15,363+0]..[15,363+26])
     Pstr_extension "foo"
     [
-      signature_item (extensions.ml[15,355+8]..[15,355+25])
-        Psig_module "M" (extensions.ml[15,355+15]..[15,355+16])
-        module_type (extensions.ml[15,355+19]..[15,355+25])
+      signature_item (extensions.ml[15,363+8]..[15,363+25])
+        Psig_module "M" (extensions.ml[15,363+15]..[15,363+16])
+        module_type (extensions.ml[15,363+19]..[15,363+25])
           Pmod_extension "baz"
           []
     ]
-  structure_item (extensions.ml[16,382+0]..[18,454+23])
+  structure_item (extensions.ml[16,390+0]..[18,466+23])
     Pstr_value Nonrec
     [
       <def>
-        pattern (extensions.ml[16,382+4]..[18,454+23]) ghost
+        pattern (extensions.ml[16,390+4]..[17,430+35])
           Ppat_constraint
-          pattern (extensions.ml[16,382+4]..[16,382+38])
+          pattern (extensions.ml[16,390+5]..[16,390+39])
             Ppat_extension "foo"
             [
-              signature_item (extensions.ml[16,382+11]..[16,382+36])
+              signature_item (extensions.ml[16,390+12]..[16,390+37])
                 Psig_include
-                module_type (extensions.ml[16,382+19]..[16,382+36])
+                module_type (extensions.ml[16,390+20]..[16,390+37])
                   Pmty_with
-                  module_type (extensions.ml[16,382+19]..[16,382+20])
-                    Pmty_ident "S" (extensions.ml[16,382+19]..[16,382+20])
+                  module_type (extensions.ml[16,390+20]..[16,390+21])
+                    Pmty_ident "S" (extensions.ml[16,390+20]..[16,390+21])
                   [
-                    Pwith_type "t" (extensions.ml[16,382+31]..[16,382+32])
-                      type_declaration "t" (extensions.ml[16,382+31]..[16,382+32]) (extensions.ml[16,382+26]..[16,382+36])
+                    Pwith_type "t" (extensions.ml[16,390+32]..[16,390+33])
+                      type_declaration "t" (extensions.ml[16,390+32]..[16,390+33]) (extensions.ml[16,390+27]..[16,390+37])
                         ptype_params =
                           []
                         ptype_cstrs =
@@ -275,36 +275,36 @@
                         ptype_private = Public
                         ptype_manifest =
                           Some
-                            core_type (extensions.ml[16,382+35]..[16,382+36])
-                              Ptyp_constr "t" (extensions.ml[16,382+35]..[16,382+36])
+                            core_type (extensions.ml[16,390+36]..[16,390+37])
+                              Ptyp_constr "t" (extensions.ml[16,390+36]..[16,390+37])
                               []
                   ]
             ]
-          core_type (extensions.ml[17,421+4]..[17,421+32])
+          core_type (extensions.ml[17,430+6]..[17,430+34])
             Ptyp_extension "foo"
             [
-              signature_item (extensions.ml[17,421+11]..[17,421+20])
+              signature_item (extensions.ml[17,430+13]..[17,430+22])
                 Psig_value
-                value_description "x" (extensions.ml[17,421+15]..[17,421+16]) (extensions.ml[17,421+11]..[17,421+20])
-                  core_type (extensions.ml[17,421+19]..[17,421+20])
-                    Ptyp_constr "t" (extensions.ml[17,421+19]..[17,421+20])
+                value_description "x" (extensions.ml[17,430+17]..[17,430+18]) (extensions.ml[17,430+13]..[17,430+22])
+                  core_type (extensions.ml[17,430+21]..[17,430+22])
+                    Ptyp_constr "t" (extensions.ml[17,430+21]..[17,430+22])
                     []
                   []
-              signature_item (extensions.ml[17,421+22]..[17,421+31])
+              signature_item (extensions.ml[17,430+24]..[17,430+33])
                 Psig_value
-                value_description "y" (extensions.ml[17,421+26]..[17,421+27]) (extensions.ml[17,421+22]..[17,421+31])
-                  core_type (extensions.ml[17,421+30]..[17,421+31])
-                    Ptyp_constr "t" (extensions.ml[17,421+30]..[17,421+31])
+                value_description "y" (extensions.ml[17,430+28]..[17,430+29]) (extensions.ml[17,430+24]..[17,430+33])
+                  core_type (extensions.ml[17,430+32]..[17,430+33])
+                    Ptyp_constr "t" (extensions.ml[17,430+32]..[17,430+33])
                     []
                   []
             ]
-        expression (extensions.ml[18,454+4]..[18,454+23])
+        expression (extensions.ml[18,466+4]..[18,466+23])
           Pexp_extension "foo"
           [
-            signature_item (extensions.ml[18,454+11]..[18,454+21])
+            signature_item (extensions.ml[18,466+11]..[18,466+21])
               Psig_type Rec
               [
-                type_declaration "t" (extensions.ml[18,454+16]..[18,454+17]) (extensions.ml[18,454+11]..[18,454+21])
+                type_declaration "t" (extensions.ml[18,466+16]..[18,466+17]) (extensions.ml[18,466+11]..[18,466+21])
                   ptype_params =
                     []
                   ptype_cstrs =
@@ -314,8 +314,8 @@
                   ptype_private = Public
                   ptype_manifest =
                     Some
-                      core_type (extensions.ml[18,454+20]..[18,454+21])
-                        Ptyp_constr "t" (extensions.ml[18,454+20]..[18,454+21])
+                      core_type (extensions.ml[18,466+20]..[18,466+21])
+                        Ptyp_constr "t" (extensions.ml[18,466+20]..[18,466+21])
                         []
               ]
           ]

--- a/testsuite/tests/typing-gadts/annotation-propagation.ml
+++ b/testsuite/tests/typing-gadts/annotation-propagation.ml
@@ -1,0 +1,42 @@
+type _ t = T : int t;;
+[%%expect{|
+type _ t = T : int t
+|}];;
+
+let f : type a . a t * a -> unit = fun t ->
+  let x : int = match t with T, n -> n in
+  ignore (x + 1)
+;;
+[%%expect{|
+val f : 'a t * 'a -> unit = <fun>
+|}];;
+
+let f : type a . a t * a -> unit = fun t ->
+  let (_ as x) : int = match t with T, n -> n in
+  ignore (x + 1)
+;;
+[%%expect{|
+val f : 'a t * 'a -> unit = <fun>
+|}];;
+
+let f : type a . a t * a -> unit = fun t ->
+  let x : type b . int = match t with T, n -> n in
+  ignore (x + 1)
+;;
+[%%expect{|
+val f : 'a t * 'a -> unit = <fun>
+|}];;
+
+(** ideally we would like this test to also pass under -principal,
+    but this requires fixing several hurdles with the current
+    type-checking of polymorphic annotations. *)
+let f : type a . a t * a -> unit = fun t ->
+  let x : 'b . int = match t with T, n -> n in
+  ignore (x + 1)
+;;
+[%%expect{|
+val f : 'a t * 'a -> unit = <fun>
+|}, Principal{|
+Line _, characters 42-43:
+Error: This expression has type a but an expression was expected of type int
+|}];;


### PR DESCRIPTION
cc @garrigue, @alainfrisch.

Previously the form

    let <var> : <type> = <expr>

would desugar into

    let <var> = (<expr> : <type>)
but the more complex

    let <pattern> : <type> = <expr>

would only become

    let (<pattern> : <type>) = <expr>

Losing the coercion on the body of the definition means that sometimes
GADT pattern-matching complains that an annotation
(to disambiguate types) is required. See the caml-list thread

    strange type error with -principal
    Alexey Egorov, Friday 18 Aug 2017
    https://sympa.inria.fr/sympa/arc/caml-list/2017-08/msg00048.html

After this change,

    let <pattern> : <type> = <expr>

desugars into

    let (<pattern> : <type>) = (<expr> : <type>)

which better preserves this annotation.

The duplication of the annotated might seem worrisome, but note that
such a duplication was already present in the desugaring of another
related form,

    let x : type <vars> . <type> = <expr>

Finally, we would have liked to also handle the related form

    let x : <tyvars> . <type> = <expr>

but desugaring by copying the polymorphic type (<tyvars> . <type>)
does not work: for example, it seems to break the type-checking of
polymorphic recursion. More changes to the type-checker would be
required to accept this.