### PR TITLE
Manual: update after the separation of Num

### DIFF
--- a/manual/README.md
+++ b/manual/README.md
@@ -105,7 +105,8 @@ of `unified-options.etex` contains the relevant information.
     - The standard library: `stdlib.etex`
     - The compiler front-end: `compilerlibs.etex`
     - The unix library: Unix system calls: `libunix.etex`
-    - The num library: arbitrary-precision rational arithmetic: `libnum.etex`
+    - The legacy num library: this library has been removed from the core
+      distribution, see `libnum.etex`
     - The str library: regular expressions and string processing: `libstr.etex`
     - The threads library: `libthreads.etex`
     - The graphics library: `libgraph.etex`

--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -29,10 +29,6 @@ MLIS=$(SRC)/stdlib/*.mli \
 	$(SRC)/otherlibs/dynlink/dynlink.mli \
 	$(SRC)/otherlibs/graph/graphics.mli \
 	$(SRC)/otherlibs/graph/graphicsX11.mli \
-	$(SRC)/otherlibs/num/num.mli \
-	$(SRC)/otherlibs/num/arith_status.mli \
-	$(SRC)/otherlibs/num/big_int.mli \
-	$(SRC)/otherlibs/num/ratio.mli \
 	$(SRC)/otherlibs/str/*.mli \
 	$(SRC)/otherlibs/systhreads/*.mli \
 	$(SRC)/otherlibs/unix/*.mli
@@ -71,7 +67,6 @@ html: files
 	-I $(SRC)/otherlibs/bigarray \
 	-I $(SRC)/otherlibs/dynlink \
 	-I $(SRC)/otherlibs/graph \
-	-I $(SRC)/otherlibs/num \
 	-I $(SRC)/otherlibs/str \
 	-I $(SRC)/otherlibs/systhreads \
 	-I $(SRC)/otherlibs/unix \

--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -17,7 +17,6 @@ COMPILER_LIBS_INTF=Asthelper.tex Astmapper.tex Asttypes.tex \
 	$(COMPILER_LIBS_PLUGIN_HOOKS)
 
 OTHERLIB_INTF=Unix.tex UnixLabels.tex Str.tex \
-  Num.tex Arithstatus.tex Bigint.tex \
   Graphics.tex GraphicsX11.tex \
   Thread.tex Mutex.tex Condition.tex Event.tex ThreadUnix.tex \
   Dynlink.tex Bigarray.tex
@@ -35,9 +34,6 @@ MLIS=$(CSLDIR)/stdlib/*.mli \
 	$(CSLDIR)/otherlibs/dynlink/dynlink.mli \
 	$(CSLDIR)/otherlibs/graph/graphics.mli \
 	$(CSLDIR)/otherlibs/graph/graphicsX11.mli \
-	$(CSLDIR)/otherlibs/num/num.mli \
-	$(CSLDIR)/otherlibs/num/arith_status.mli \
-	$(CSLDIR)/otherlibs/num/big_int.mli \
 	$(CSLDIR)/otherlibs/str/*.mli \
 	$(CSLDIR)/otherlibs/systhreads/*.mli \
 	$(CSLDIR)/otherlibs/unix/*.mli
@@ -53,7 +49,7 @@ TEXQUOTE=../../tools/texquote2
 
 CSLDIR=$(RELEASEDIR)
 
-VPATH=.:$(CSLDIR)/stdlib:$(CSLDIR)/parsing:$(CSLDIR)/otherlibs/unix:$(CSLDIR)/otherlibs/str:$(CSLDIR)/otherlibs/num:$(CSLDIR)/otherlibs/graph:$(CSLDIR)/otherlibs/threads:$(CSLDIR)/otherlibs/dynlink:$(CSLDIR)/otherlibs/bigarray
+VPATH=.:$(CSLDIR)/stdlib:$(CSLDIR)/parsing:$(CSLDIR)/otherlibs/unix:$(CSLDIR)/otherlibs/str:$(CSLDIR)/otherlibs/graph:$(CSLDIR)/otherlibs/threads:$(CSLDIR)/otherlibs/dynlink:$(CSLDIR)/otherlibs/bigarray
 
 etex-files: $(BLURB)
 all: libs
@@ -77,7 +73,6 @@ interfaces: $(MLIS)
 	-I $(CSLDIR)/otherlibs/bigarray \
 	-I $(CSLDIR)/otherlibs/dynlink \
 	-I $(CSLDIR)/otherlibs/graph \
-	-I $(CSLDIR)/otherlibs/num \
 	-I $(CSLDIR)/otherlibs/str \
 	-I $(CSLDIR)/otherlibs/systhreads \
 	-I $(CSLDIR)/otherlibs/unix \
@@ -89,8 +84,6 @@ interfaces: $(MLIS)
 	-latex-module-prefix "" \
 	-latex-module-type-prefix "" \
 	-latex-value-prefix ""
-	mv -f Arith_status.tex Arithstatus.tex
-	mv -f Big_int.tex Bigint.tex
 	mv -f Ast_helper.tex Asthelper.tex
 	mv -f Ast_mapper.tex Astmapper.tex
 

--- a/manual/manual/library/libnum.etex
+++ b/manual/manual/library/libnum.etex
@@ -1,10 +1,10 @@
-\chapter{The legacy num library}
-\pdfchapterfold{-3}{The legacy num library}
+\chapter{The num library: arbitrary-precision rational arithmetic}
+\pdfchapterfold{-3}{The num library: arbitrary-precision integer and rational arithmetic}
 %HEVEA\cutname{libnum.html}
 
-The legacy "num" library implemented integer arithmetic and rational
-arithmetic in arbitrary precision. It has been split off from the core
-OCaml distribution starting from the 4.06.0 release and can be found
+The "num" library implements integer arithmetic and rational
+arithmetic in arbitrary precision. It was split off the core
+OCaml distribution starting with the 4.06.0 release, and can now be found
 at \url{https://github.com/ocaml/num}.
 
 New applications that need arbitrary-precision arithmetic should use the

--- a/manual/manual/library/libnum.etex
+++ b/manual/manual/library/libnum.etex
@@ -1,39 +1,14 @@
-\chapter{The num library: arbitrary-precision rational arithmetic}
-\pdfchapterfold{-3}{The num library: arbitrary-precision integer and rational arithmetic}
+\chapter{The legacy num library}
+\pdfchapterfold{-3}{The legacy num library}
 %HEVEA\cutname{libnum.html}
 
-The "num" library implements integer arithmetic and rational
-arithmetic in arbitrary precision.
+The legacy "num" library implemented integer arithmetic and rational
+arithmetic in arbitrary precision. It has been split off from the core
+OCaml distribution starting from the 4.06.0 release and can be found
+at \url{https://github.com/ocaml/num}.
 
-More documentation on the functions provided in this library can be found
-in {\em The CAML Numbers Reference Manual\/} by
-Valérie Ménissier-Morain, technical report 141, INRIA, july 1992
-(available electronically,
-\url{http://hal.inria.fr/docs/00/07/00/27/PDF/RT-0141.pdf}).
-
-Programs that use the "num" library must be linked as follows:
-\begin{alltt}
-        ocamlc \var{other options} nums.cma \var{other files}
-        ocamlopt \var{other options} nums.cmxa \var{other files}
-\end{alltt}
-For interactive use of the "nums" library, do:
-\begin{alltt}
-        ocamlmktop -o mytop nums.cma
-        ./mytop
-\end{alltt}
-or (if dynamic linking of C libraries is supported on your platform),
-start "ocaml" and type "#load \"nums.cma\";;".
-
-\ifouthtml
-\begin{links}
-\item \ahref{libref/Num.html}{Module \texttt{Num}: operation on arbitrary-precision numbers}
-\item \ahref{libref/Big\_int.html}{Module \texttt{Big\_int}: operations on arbitrary-precision integers}
-\item \ahref{libref/Arith\_status.html}{Module \texttt{Arith\_status}: flags that control rational arithmetic}
-\end{links}
-\else
-\input{Num.tex}
-\input{Bigint.tex}
-\input{Arithstatus.tex}
-\fi
-
-
+New applications that need arbitrary-precision arithmetic should use the
+"Zarith" library (\url{https://github.com/ocaml/Zarith}) instead of the "Num"
+library, and older applications that already use "Num" are encouraged to
+switch to "Zarith". "Zarith" delivers much better performance than "Num"
+and has a nicer API.


### PR DESCRIPTION
This PR updates the manual after the separation of Num from the core distribution, cf #1178.
It removes reference to `otherlibs/num` from the manual Makefiles, renames the "num library" to "legacy num library" and replaces the description of the `Num` in `manual/manual/libnum.etex` by a two-lines description along with a link to `https://github.com/ocaml/num` and a paragraph redirecting potential users to `Zarith`.

@xavierleroy , I have copied verbatim your paragraph redirecting users to `Zarith` from  https://github.com/ocaml/num#overview . Is it fine with you? Otherwise, I will paraphrase it.
