### PR TITLE
Use Git's unzip rather than 7zip on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,10 +42,9 @@ install:
   - mkdir "%OCAMLROOT%/bin/flexdll"
   - appveyor DownloadFile "http://alain.frisch.fr/flexdll/flexdll-bin-0.35.zip" -FileName "flexdll.zip"
   - appveyor DownloadFile "http://alain.frisch.fr/flexdll/flexdll-0.35.tar.gz" -FileName "flexdll.tar.gz"
-  - cinst 7zip.commandline
-  - mkdir flexdll-tmp
-  - cd flexdll-tmp
-  - 7za x -y ..\flexdll.zip
+  - mkdir C:\projects\flexdll-tmp
+  - cd C:\projects\flexdll-tmp
+  - unzip -q /c/projects/ocaml/flexdll.zip
   - for %%F in (flexdll.h flexlink.exe default_amd64.manifest) do copy %%F "%OCAMLROOT%\bin\flexdll"
   - cd ..
   # Make sure the Cygwin path comes before the Git one (otherwise


### PR DESCRIPTION
We've been seeing some AppVeyor failures owing to problems pulling 7zip down from Chocolatey. It's not necessary to use it, as Git's unzip package is already installed, so let's reduce our dependency chain and stop using 7zip entirely.