### PR TITLE
Take PLT-clobbered registers into account at Ialloc

### DIFF
--- a/Changes
+++ b/Changes
@@ -80,6 +80,11 @@ Working version
   to GPR#1250.)
   (Mark Shinwell)
 
+- GPR#1304: Mark registers clobbered by PLT stubs as destroyed across
+  allocations.
+  (Mark Shinwell, Xavier Clerc, report and initial debugging by
+  Valentin Gatien-Baron)
+
 ### Standard library:
 
 - MPR#1771, MPR#7309, GPR#1026: Add update to maps. Allows to update a

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -139,11 +139,6 @@ let mem__imp s =
 let rel_plt s =
   if windows && !Clflags.dlcode then mem__imp s
   else
-    let use_plt =
-      match system with
-      | S_macosx | S_mingw64 | S_cygwin | S_win64 -> false
-      | _ -> !Clflags.dlcode
-    in
     sym (if use_plt then emit_symbol s ^ "@PLT" else emit_symbol s)
 
 let emit_call s = I.call (rel_plt s)

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -143,7 +143,7 @@ let rbp = phys_reg 12
 let rxmm15 = phys_reg 115
 
 let destroyed_by_plt_stub =
-  if win64 then [| |] else [| r10; r11 |]
+  if not X86_proc.use_plt then [| |] else [| r10; r11 |]
 
 let num_destroyed_by_plt_stub = Array.length destroyed_by_plt_stub
 

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -64,9 +64,16 @@ let win64 = Arch.win64
      xmm0 - xmm3: C function arguments
      rbx, rbp, rsi, rdi r12-r15 are preserved by C
      xmm6-xmm15 are preserved by C
-   Note (PR#5707): r11 should not be used for parameter passing, as it
-     can be destroyed by the dynamic loader according to SVR4 ABI.
-     Linux's dynamic loader also destroys r10.
+   Note (PR#5707, GPR#1304): PLT stubs (used for dynamic resolution of symbols
+     on Unix-like platforms) may clobber any register except those used for:
+       1. C parameter passing;
+       2. C return values;
+       3. C callee-saved registers.
+     This translates to the set { r10, r11 }.  These registers hence cannot
+     be used for OCaml parameter passing and must also be marked as
+     destroyed across [Ialloc] (otherwise a call to caml_call_gc@PLT might
+     clobber these two registers before the assembly stub saves them into
+     the GC regs block).
 *)
 
 let max_arguments_for_tailcalls = 10
@@ -129,9 +136,18 @@ let phys_reg n =
 
 let rax = phys_reg 0
 let rdx = phys_reg 4
+let r10 = phys_reg 10
+let r11 = phys_reg 11
 let r13 = phys_reg 9
 let rbp = phys_reg 12
 let rxmm15 = phys_reg 115
+
+let destroyed_by_plt_stub =
+  if win64 then [| |] else [| r10; r11 |]
+
+let num_destroyed_by_plt_stub = Array.length destroyed_by_plt_stub
+
+let destroyed_by_plt_stub_set = Reg.set_of_array destroyed_by_plt_stub
 
 let stack_slot slot ty =
   Reg.at_location ty (Stack slot)
@@ -157,7 +173,8 @@ let calling_conventions first_int last_int first_float last_float make_stack
         end else begin
           loc.(i) <- stack_slot (make_stack !ofs) ty;
           ofs := !ofs + size_int
-        end
+        end;
+        assert (not (Reg.Set.mem loc.(i) destroyed_by_plt_stub_set))
     | Float ->
         if !float <= last_float then begin
           loc.(i) <- phys_reg !float;
@@ -268,6 +285,15 @@ let destroyed_at_c_call =
        100;101;102;103;104;105;106;107;
        108;109;110;111;112;113;114;115])
 
+let destroyed_at_alloc =
+  let regs =
+    if Config.spacetime then
+      [| rax; loc_spacetime_node_hole |]
+    else
+      [| rax |]
+  in
+  Array.concat [regs; destroyed_by_plt_stub]
+
 let destroyed_at_oper = function
     Iop(Icall_ind _ | Icall_imm _ | Iextcall { alloc = true; }) ->
     all_phys_regs
@@ -275,9 +301,8 @@ let destroyed_at_oper = function
   | Iop(Iintop(Idiv | Imod)) | Iop(Iintop_imm((Idiv | Imod), _))
         -> [| rax; rdx |]
   | Iop(Istore(Single, _, _)) -> [| rxmm15 |]
-  | Iop(Ialloc _) when Config.spacetime
-        -> [| rax; loc_spacetime_node_hole |]
-  | Iop(Ialloc _ | Iintop(Imulh | Icomp _) | Iintop_imm((Icomp _), _))
+  | Iop(Ialloc _) -> destroyed_at_alloc
+  | Iop(Iintop(Imulh | Icomp _) | Iintop_imm((Icomp _), _))
         -> [| rax |]
   | Iop (Iintop (Icheckbound _)) when Config.spacetime ->
       [| loc_spacetime_node_hole |]
@@ -309,7 +334,10 @@ let max_register_pressure = function
         if fp then [| 3; 0 |] else  [| 4; 0 |]
   | Iintop(Idiv | Imod) | Iintop_imm((Idiv | Imod), _) ->
     if fp then [| 10; 16 |] else [| 11; 16 |]
-  | Ialloc _ | Iintop(Icomp _) | Iintop_imm((Icomp _), _) ->
+  | Ialloc _ ->
+    if fp then [| 11 - num_destroyed_by_plt_stub; 16 |]
+    else [| 12 - num_destroyed_by_plt_stub; 16 |]
+  | Iintop(Icomp _) | Iintop_imm((Icomp _), _) ->
     if fp then [| 11; 16 |] else [| 12; 16 |]
   | Istore(Single, _, _) ->
     if fp then [| 12; 15 |] else [| 13; 15 |]

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -99,12 +99,22 @@ let phys_reg n =
   if n < 100 then hard_int_reg.(n) else hard_float_reg.(n - 100)
 
 let reg_x15 = phys_reg 15
+let reg_x16 = phys_reg 26
+let reg_x17 = phys_reg 27
 let reg_d7 = phys_reg 107
 
 let stack_slot slot ty =
   Reg.at_location ty (Stack slot)
 
 let loc_spacetime_node_hole = Reg.dummy  (* Spacetime unsupported *)
+
+(* cf. "Procedure Call Standard for the ARM 64-Bit Architecture"
+   (ARM IHI 0055B) page 14 and also section 5.3.1.1. *)
+let destroyed_by_plt_stub = [| reg_x16; reg_x17 |]
+
+let num_destroyed_by_plt_stub = Array.length destroyed_by_plt_stub
+
+let destroyed_by_plt_stub_set = Reg.set_of_array destroyed_by_plt_stub
 
 (* Calling conventions *)
 
@@ -123,7 +133,8 @@ let calling_conventions
         end else begin
           loc.(i) <- stack_slot (make_stack !ofs) ty;
           ofs := !ofs + size_int
-        end
+        end;
+        assert (not (Reg.Set.mem loc.(i) destroyed_by_plt_stub_set))
     | Float ->
         if !float <= last_float then begin
           loc.(i) <- phys_reg !float;
@@ -185,13 +196,16 @@ let destroyed_at_c_call =
      116;117;118;119;120;121;122;123;
      124;125;126;127;128;129;130;131])
 
+let destroyed_at_alloc =
+  Array.concat [[| reg_x15 |]; destroyed_by_plt_stub]
+
 let destroyed_at_oper = function
   | Iop(Icall_ind _ | Icall_imm _) | Iop(Iextcall { alloc = true; }) ->
       all_phys_regs
   | Iop(Iextcall { alloc = false; }) ->
       destroyed_at_c_call
   | Iop(Ialloc _) ->
-      [| reg_x15 |]
+      destroyed_at_alloc
   | Iop(Iintoffloat | Ifloatofint | Iload(Single, _) | Istore(Single, _, _)) ->
       [| reg_d7 |]            (* d7 / s7 destroyed *)
   | _ -> [||]
@@ -207,7 +221,7 @@ let safe_register_pressure = function
 
 let max_register_pressure = function
   | Iextcall _ -> [| 10; 8 |]
-  | Ialloc _ -> [| 25; 32 |]
+  | Ialloc _ -> [| 25 - num_destroyed_by_plt_stub; 32 |]
   | Iintoffloat | Ifloatofint
   | Iload(Single, _) | Istore(Single, _, _) -> [| 26; 31 |]
   | _ -> [| 26; 32 |]

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -219,7 +219,6 @@ let string_of_rounding = function
   | RoundTruncate -> "roundsd.trunc"
   | RoundNearest -> "roundsd.near"
 
-
 (* These hooks can be used to insert optimization passes on
    the assembly code. *)
 let assembler_passes = ref ([] : (asm_program -> asm_program) list)
@@ -232,6 +231,11 @@ let masm =
   match system with
   | S_win32 | S_win64 -> true
   | _ -> false
+
+let use_plt =
+  match system with
+  | S_macosx | S_mingw64 | S_cygwin | S_win64 -> false
+  | _ -> !Clflags.dlcode
 
 (* Shall we use an external assembler command ?
    If [binary_content] contains some data, we can directly

--- a/asmcomp/x86_proc.mli
+++ b/asmcomp/x86_proc.mli
@@ -81,6 +81,9 @@ val system: system
 val masm: bool
 val windows:bool
 
+(** Whether calls need to go via the PLT. *)
+val use_plt : bool
+
 (** Support for plumbing a binary code emitter *)
 
 val register_internal_assembler: (asm_program -> string -> unit) -> unit


### PR DESCRIPTION
Calls in dynamically-linked libraries on Unix-like platforms are indirect jumps through the PLT (procedure linkage table).  In the usual case of lazy symbol binding the PLT entries initially point at stubs which invoke the dynamic linker to resolve the relevant symbol.  The PLT entry is overwritten with the jump target once it has been resolved.  (This latter step happens at startup if non-lazy binding is in effect.)

I believe the PLT stubs may clobber those registers which are none of: (a) C argument registers; (b) C return value registers; (c) C callee-save registers.  On x86-64 this set comprises `r10` and `r11`.  The backend has correctly avoided these for the passing of arguments for some time.  However these registers must also be avoided between OCaml code and the assembly code in `caml_call_gc` which saves registers into the `caml_gc_regs` block, since `caml_call_gc` itself may be called via the PLT.  Otherwise what happens is that any live values in `r10` and/or `r11` might be clobbered by the PLT stub and then saved into the `caml_gc_regs` block.

This bug was responsible for a number of obscure segfaults which @sliquister did a fine job of investigating.  Such failures are obscure: the first allocation in a given dynamic library to trigger a GC needs to have something live across it in `r10` and/or `r11`.