### PR TITLE
Remove spurious semicolons after non-unit expressions

### DIFF
--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1787,7 +1787,7 @@ let rec do_make_string_test_tree loc arg sw delta d =
     bind_sw
       (Lprim
          (prim_string_compare,
-          [arg; Lconst (Const_immstring s)], loc;))
+          [arg; Lconst (Const_immstring s)], loc))
       (fun r ->
         tree_way_test loc r
           (do_make_string_test_tree loc arg lt delta d)

--- a/middle_end/inline_and_simplify_aux.ml
+++ b/middle_end/inline_and_simplify_aux.ml
@@ -293,7 +293,7 @@ module Env = struct
       try
         Set_of_closures_origin.Map.find origin t.actively_unrolling
       with Not_found ->
-        Misc.fatal_error "Unexpected actively unrolled function";
+        Misc.fatal_error "Unexpected actively unrolled function"
     in
     let actively_unrolling =
       Set_of_closures_origin.Map.add origin (unrolling - 1) t.actively_unrolling

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -530,7 +530,7 @@ and comment = parse
     "(*"
       { comment_start_loc := (Location.curr lexbuf) :: !comment_start_loc;
         store_lexeme lexbuf;
-        comment lexbuf;
+        comment lexbuf
       }
   | "*)"
       { match !comment_start_loc with
@@ -538,7 +538,7 @@ and comment = parse
         | [_] -> comment_start_loc := []; Location.curr lexbuf
         | _ :: l -> comment_start_loc := l;
                   store_lexeme lexbuf;
-                  comment lexbuf;
+                  comment lexbuf
        }
   | "\""
       {

--- a/stdlib/camlinternalFormat.ml
+++ b/stdlib/camlinternalFormat.ml
@@ -2040,7 +2040,7 @@ let fmt_ebb_of_string ?legacy_behavior str =
   let invalid_format_message str_ind msg =
     failwith_message
       "invalid format %S: at character number %d, %s"
-      str str_ind msg;
+      str str_ind msg
   in
 
   (* Used when the end of the format (or the current sub-format) was encountered
@@ -2688,14 +2688,14 @@ let fmt_ebb_of_string ?legacy_behavior str =
     let fail_single_percent str_ind =
       failwith_message
         "invalid format %S: '%%' alone is not accepted in character sets, \
-         use %%%% instead at position %d." str str_ind;
+         use %%%% instead at position %d." str str_ind
     in
 
     (* Parse the first character of a char set. *)
     let rec parse_char_set_start str_ind end_ind =
       if str_ind = end_ind then unexpected_end_of_format end_ind;
       let c = str.[str_ind] in
-      parse_char_set_after_char (str_ind + 1) end_ind c;
+      parse_char_set_after_char (str_ind + 1) end_ind c
 
     (* Parse the content of a char set until the first ']'. *)
     and parse_char_set_content str_ind end_ind =
@@ -2705,9 +2705,9 @@ let fmt_ebb_of_string ?legacy_behavior str =
         str_ind + 1
       | '-' ->
         add_char '-';
-        parse_char_set_content (str_ind + 1) end_ind;
+        parse_char_set_content (str_ind + 1) end_ind
       | c ->
-        parse_char_set_after_char (str_ind + 1) end_ind c;
+        parse_char_set_after_char (str_ind + 1) end_ind c
 
     (* Test for range in char set. *)
     and parse_char_set_after_char str_ind end_ind c =
@@ -2838,10 +2838,10 @@ let fmt_ebb_of_string ?legacy_behavior str =
           search_subformat_end (sub_end + 2) end_ind c
         | '}' ->
           (* Error: %(...%}. *)
-          expected_character (str_ind + 1) "character ')'" '}';
+          expected_character (str_ind + 1) "character ')'" '}'
         | ')' ->
           (* Error: %{...%). *)
-          expected_character (str_ind + 1) "character '}'" ')';
+          expected_character (str_ind + 1) "character '}'" ')'
         | _ ->
           search_subformat_end (str_ind + 2) end_ind c
         end
@@ -2931,7 +2931,7 @@ let fmt_ebb_of_string ?legacy_behavior str =
       failwith_message
         "invalid format %S: at character number %d, \
          %s is incompatible with '%c' in sub-format %S"
-        str pct_ind option symb subfmt;
+        str pct_ind option symb subfmt
 
   in parse 0 (String.length str)
 

--- a/tools/cmt2annot.ml
+++ b/tools/cmt2annot.ml
@@ -29,7 +29,7 @@ let bind_variables scope =
                                         Annot.Idef scope))
     | _ -> ()
     end;
-    super.pat sub p;
+    super.pat sub p
   in
   {super with pat}
 

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -187,7 +187,7 @@ let value_description sub v =
     (sub.typ sub v.val_desc)
 
 let module_binding sub mb =
-  let loc = sub.location sub mb.mb_loc; in
+  let loc = sub.location sub mb.mb_loc in
   let attrs = sub.attributes sub mb.mb_attributes in
   Mb.mk ~loc ~attrs
     (map_loc sub mb.mb_name)
@@ -196,7 +196,7 @@ let module_binding sub mb =
 let type_parameter sub (ct, v) = (sub.typ sub ct, v)
 
 let type_declaration sub decl =
-  let loc = sub.location sub decl.typ_loc; in
+  let loc = sub.location sub decl.typ_loc in
   let attrs = sub.attributes sub decl.typ_attributes in
   Type.mk ~loc ~attrs
     ~params:(List.map (type_parameter sub) decl.typ_params)
@@ -223,7 +223,7 @@ let constructor_arguments sub = function
    | Cstr_record l -> Pcstr_record (List.map (sub.label_declaration sub) l)
 
 let constructor_declaration sub cd =
-  let loc = sub.location sub cd.cd_loc; in
+  let loc = sub.location sub cd.cd_loc in
   let attrs = sub.attributes sub cd.cd_attributes in
   Type.constructor ~loc ~attrs
     ~args:(constructor_arguments sub cd.cd_args)
@@ -231,7 +231,7 @@ let constructor_declaration sub cd =
     (map_loc sub cd.cd_name)
 
 let label_declaration sub ld =
-  let loc = sub.location sub ld.ld_loc; in
+  let loc = sub.location sub ld.ld_loc in
   let attrs = sub.attributes sub ld.ld_attributes in
   Type.field ~loc ~attrs
     ~mut:ld.ld_mutable
@@ -247,7 +247,7 @@ let type_extension sub tyext =
     (List.map (sub.extension_constructor sub) tyext.tyext_constructors)
 
 let extension_constructor sub ext =
-  let loc = sub.location sub ext.ext_loc; in
+  let loc = sub.location sub ext.ext_loc in
   let attrs = sub.attributes sub ext.ext_attributes in
   Te.constructor ~loc ~attrs
     (map_loc sub ext.ext_name)
@@ -259,7 +259,7 @@ let extension_constructor sub ext =
     )
 
 let pattern sub pat =
-  let loc = sub.location sub pat.pat_loc; in
+  let loc = sub.location sub pat.pat_loc in
   (* todo: fix attributes on extras *)
   let attrs = sub.attributes sub pat.pat_attributes in
   let desc =
@@ -319,7 +319,7 @@ let pattern sub pat =
   Pat.mk ~loc ~attrs desc
 
 let exp_extra sub (extra, loc, attrs) sexp =
-  let loc = sub.location sub loc; in
+  let loc = sub.location sub loc in
   let attrs = sub.attributes sub attrs in
   let desc =
     match extra with
@@ -346,14 +346,14 @@ let case sub {c_lhs; c_guard; c_rhs} =
   }
 
 let value_binding sub vb =
-  let loc = sub.location sub vb.vb_loc; in
+  let loc = sub.location sub vb.vb_loc in
   let attrs = sub.attributes sub vb.vb_attributes in
   Vb.mk ~loc ~attrs
     (sub.pat sub vb.vb_pat)
     (sub.expr sub vb.vb_expr)
 
 let expression sub exp =
-  let loc = sub.location sub exp.exp_loc; in
+  let loc = sub.location sub exp.exp_loc in
   let attrs = sub.attributes sub exp.exp_attributes in
   let desc =
     match exp.exp_desc with
@@ -481,7 +481,7 @@ let package_type sub pack =
         (s, sub.typ sub ct)) pack.pack_fields)
 
 let module_type_declaration sub mtd =
-  let loc = sub.location sub mtd.mtd_loc; in
+  let loc = sub.location sub mtd.mtd_loc in
   let attrs = sub.attributes sub mtd.mtd_attributes in
   Mtd.mk ~loc ~attrs
     ?typ:(map_opt (sub.module_type sub) mtd.mtd_type)
@@ -491,7 +491,7 @@ let signature sub sg =
   List.map (sub.signature_item sub) sg.sig_items
 
 let signature_item sub item =
-  let loc = sub.location sub item.sig_loc; in
+  let loc = sub.location sub item.sig_loc in
   let desc =
     match item.sig_desc with
       Tsig_value v ->
@@ -522,14 +522,14 @@ let signature_item sub item =
   Sig.mk ~loc desc
 
 let module_declaration sub md =
-  let loc = sub.location sub md.md_loc; in
+  let loc = sub.location sub md.md_loc in
   let attrs = sub.attributes sub md.md_attributes in
   Md.mk ~loc ~attrs
     (map_loc sub md.md_name)
     (sub.module_type sub md.md_type)
 
 let include_infos f sub incl =
-  let loc = sub.location sub incl.incl_loc; in
+  let loc = sub.location sub incl.incl_loc in
   let attrs = sub.attributes sub incl.incl_attributes in
   Incl.mk ~loc ~attrs
     (f sub incl.incl_mod)
@@ -538,7 +538,7 @@ let include_declaration sub = include_infos sub.module_expr sub
 let include_description sub = include_infos sub.module_type sub
 
 let class_infos f sub ci =
-  let loc = sub.location sub ci.ci_loc; in
+  let loc = sub.location sub ci.ci_loc in
   let attrs = sub.attributes sub ci.ci_attributes in
   Ci.mk ~loc ~attrs
     ~virt:ci.ci_virt
@@ -551,7 +551,7 @@ let class_description sub = class_infos sub.class_type sub
 let class_type_declaration sub = class_infos sub.class_type sub
 
 let module_type sub mty =
-  let loc = sub.location sub mty.mty_loc; in
+  let loc = sub.location sub mty.mty_loc in
   let attrs = sub.attributes sub mty.mty_attributes in
   let desc = match mty.mty_desc with
       Tmty_ident (_path, lid) -> Pmty_ident (map_loc sub lid)
@@ -581,7 +581,7 @@ let with_constraint sub (_path, lid, cstr) =
          map_loc sub lid2)
 
 let module_expr sub mexpr =
-  let loc = sub.location sub mexpr.mod_loc; in
+  let loc = sub.location sub mexpr.mod_loc in
   let attrs = sub.attributes sub mexpr.mod_attributes in
   match mexpr.mod_desc with
       Tmod_constraint (m, _, Tmodtype_implicit, _ ) ->
@@ -607,7 +607,7 @@ let module_expr sub mexpr =
         Mod.mk ~loc ~attrs desc
 
 let class_expr sub cexpr =
-  let loc = sub.location sub cexpr.cl_loc; in
+  let loc = sub.location sub cexpr.cl_loc in
   let attrs = sub.attributes sub cexpr.cl_attributes in
   let desc = match cexpr.cl_desc with
     | Tcl_constraint ( { cl_desc = Tcl_ident (_path, lid, tyl); _ },
@@ -644,7 +644,7 @@ let class_expr sub cexpr =
   Cl.mk ~loc ~attrs desc
 
 let class_type sub ct =
-  let loc = sub.location sub ct.cltyp_loc; in
+  let loc = sub.location sub ct.cltyp_loc in
   let attrs = sub.attributes sub ct.cltyp_attributes in
   let desc = match ct.cltyp_desc with
       Tcty_signature csg -> Pcty_signature (sub.class_signature sub csg)
@@ -664,7 +664,7 @@ let class_signature sub cs =
   }
 
 let class_type_field sub ctf =
-  let loc = sub.location sub ctf.ctf_loc; in
+  let loc = sub.location sub ctf.ctf_loc in
   let attrs = sub.attributes sub ctf.ctf_attributes in
   let desc = match ctf.ctf_desc with
       Tctf_inherit ct -> Pctf_inherit (sub.class_type sub ct)
@@ -679,7 +679,7 @@ let class_type_field sub ctf =
   Ctf.mk ~loc ~attrs desc
 
 let core_type sub ct =
-  let loc = sub.location sub ct.ctyp_loc; in
+  let loc = sub.location sub ct.ctyp_loc in
   let attrs = sub.attributes sub ct.ctyp_attributes in
   let desc = match ct.ctyp_desc with
       Ttyp_any -> Ptyp_any
@@ -735,7 +735,7 @@ and is_self_pat = function
   | _ -> false
 
 let class_field sub cf =
-  let loc = sub.location sub cf.cf_loc; in
+  let loc = sub.location sub cf.cf_loc in
   let attrs = sub.attributes sub cf.cf_attributes in
   let desc = match cf.cf_desc with
       Tcf_inherit (ovf, cl, super, _vals, _meths) ->


### PR DESCRIPTION
Cherry picked from #522.

Will be useful if/when we switch to a stricter semantics for semi-colons in -strict-sequence mode.