### PR TITLE
Reimplement Sys.rename under Win32 to be more POSIX

### DIFF
--- a/Changes
+++ b/Changes
@@ -140,6 +140,10 @@ Working version
   (Jeremy Yallop, review by Mark Shinwell, Nicolas Ojeda Bar,
   Damien Doligez and Hannes Mehnert)
 
+* In the MSVC and Mingw ports, "Sys.rename src dst" no longer fails if
+  file "dst" exists, but replaces it with file "src", like in the other ports.
+  (Xavier Leroy)
+
 - Resurrect tabulation boxes in module Format. Rewrite/extend documentation
   of tabulation boxes.
 

--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -279,6 +279,13 @@ CAMLprim value caml_sys_remove(value name)
   CAMLreturn(Val_unit);
 }
 
+#ifdef _WIN32
+extern int caml_win32_rename(const char * oldpath, const char * newpath);
+/* This #define is a hack but ensures that CAML_SYS_RENAME
+   resolves to the correct function */
+#define rename caml_win32_rename
+#endif
+
 CAMLprim value caml_sys_rename(value oldname, value newname)
 {
   char * p_old;
@@ -297,6 +304,11 @@ CAMLprim value caml_sys_rename(value oldname, value newname)
     caml_sys_error(NO_ARG);
   return Val_unit;
 }
+
+#ifdef _WIN32
+/* End of rename hack */
+#undef rename
+#endif
 
 CAMLprim value caml_sys_chdir(value dirname)
 {

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -730,8 +730,17 @@ char *caml_secure_getenv (char const *var)
 
 int caml_win32_rename(const char * oldpath, const char * newpath)
 {
-  if (MoveFileEx(oldpath, newpath, MOVEFILE_REPLACE_EXISTING))
+  /* MOVEFILE_REPLACE_EXISTING: to be closer to POSIX
+     MOVEFILE_COPY_ALLOWED: MoveFile performs a copy if old and new
+       paths are on different devices, so we do the same here for
+       compatibility with the old rename()-based implementation.
+     MOVEFILE_WRITE_THROUGH: not sure it's useful; affects only
+       the case where a copy is done. */
+  if (MoveFileEx(oldpath, newpath,
+                 MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH |
+                 MOVEFILE_COPY_ALLOWED)) {
     return 0;
+  }
   /* Modest attempt at mapping Win32 error codes to POSIX error codes.
      The __dosmaperr() function from the CRT does a better job but is
      generally not accessible. */

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -738,8 +738,8 @@ int caml_win32_rename(const char * oldpath, const char * newpath)
   switch (GetLastError()) {
   case ERROR_FILE_NOT_FOUND: case ERROR_PATH_NOT_FOUND:
     errno = ENOENT; break;
-  case ERROR_ACCESS_DENIED: case ERROR_WRITE_PROTEXT: case ERROR_CANNOT_MAKE:
-    errno = EACCESS; break;
+  case ERROR_ACCESS_DENIED: case ERROR_WRITE_PROTECT: case ERROR_CANNOT_MAKE:
+    errno = EACCES; break;
   case ERROR_CURRENT_DIRECTORY: case ERROR_BUSY:
     errno = EBUSY; break;
   case ERROR_NOT_SAME_DEVICE:

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -557,7 +557,12 @@ val unlink : string -> unit
 *)
 
 val rename : string -> string -> unit
-(** [rename old new] changes the name of a file from [old] to [new]. *)
+(** [rename old new] changes the name of a file from [old] to [new],
+    moving it between directories if needed.  If [new] already
+    exists, its contents will be replaced with those of [old].
+    Depending on the operating system, the metadata (permissions,
+    owner, etc) of [new] can either be preserved or be replaced by
+    those of [old].  *)
 
 val link : string -> string -> unit
 (** [link source dest] creates a hard link named [dest] to the file

--- a/otherlibs/win32unix/rename.c
+++ b/otherlibs/win32unix/rename.c
@@ -19,25 +19,11 @@
 
 CAMLprim value unix_rename(value path1, value path2)
 {
-  static int supports_MoveFileEx = -1; /* don't know yet */
-  BOOL ok;
-
   caml_unix_check_path(path1, "rename");
   caml_unix_check_path(path2, "rename");
-  if (supports_MoveFileEx < 0) {
-    OSVERSIONINFO VersionInfo;
-    VersionInfo.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-    supports_MoveFileEx =
-      (GetVersionEx(&VersionInfo) != 0)
-      && (VersionInfo.dwPlatformId == VER_PLATFORM_WIN32_NT);
-  }
-  if (supports_MoveFileEx > 0)
-    ok = MoveFileEx(String_val(path1), String_val(path2),
-                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH |
-                    MOVEFILE_COPY_ALLOWED);
-  else
-    ok = MoveFile(String_val(path1), String_val(path2));
-  if (! ok) {
+  if (! MoveFileEx(String_val(path1), String_val(path2),
+                   MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH |
+                   MOVEFILE_COPY_ALLOWED)) {
     win32_maperr(GetLastError());
     uerror("rename", path1);
   }

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -45,8 +45,9 @@ external remove : string -> unit = "caml_sys_remove"
 external rename : string -> string -> unit = "caml_sys_rename"
 (** Rename a file. The first argument is the old name and the
    second is the new name. If there is already another file
-   under the new name, [rename] may replace it, or raise an
-   exception, depending on your operating system. *)
+   under the new name, [rename] will delete it before the rename,
+   effectively replacing its contents.
+   @since 4.06 concerning the "replace existing file" behavior *)
 
 external getenv : string -> string = "caml_sys_getenv"
 (** Return the value associated to a variable in the process

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -43,10 +43,13 @@ external remove : string -> unit = "caml_sys_remove"
 (** Remove the given file name from the file system. *)
 
 external rename : string -> string -> unit = "caml_sys_rename"
-(** Rename a file. The first argument is the old name and the
-   second is the new name. If there is already another file
-   under the new name, [rename] will delete it before the rename,
-   effectively replacing its contents.
+(** Rename a file.  [rename oldpath newpath] renames the file
+    called [oldpath], giving it [newpath] as its new name,
+    moving it between directories if needed.  If [newpath] already
+    exists, its contents will be replaced with those of [oldpath].
+    Depending on the operating system, the metadata (permissions,
+    owner, etc) of [newpath] can either be preserved or be replaced by
+    those of [oldpath].
    @since 4.06 concerning the "replace existing file" behavior *)
 
 external getenv : string -> string = "caml_sys_getenv"

--- a/testsuite/tests/lib-sys/Makefile
+++ b/testsuite/tests/lib-sys/Makefile
@@ -1,0 +1,21 @@
+#**************************************************************************
+#*                                                                        *
+#*                                OCaml                                   *
+#*                                                                        *
+#*                 Xavier Clerc, SED, INRIA Rocquencourt                  *
+#*                                                                        *
+#*   Copyright 2010 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+BASEDIR=../..
+include $(BASEDIR)/makefiles/Makefile.several
+include $(BASEDIR)/makefiles/Makefile.common
+
+# Not really generated sources but temp files that need cleaning
+GENERATED_SOURCES=file1.dat file2.dat

--- a/testsuite/tests/lib-sys/rename.ml
+++ b/testsuite/tests/lib-sys/rename.ml
@@ -1,0 +1,52 @@
+(* Test the Sys.rename function *)
+
+let writefile filename contents =
+  let oc = open_out_bin filename in
+  output_string oc contents;
+  close_out oc
+
+let readfile filename =
+  let ic = open_in_bin filename in
+  let sz = in_channel_length ic in
+  let contents = really_input_string ic sz in
+  close_in ic;
+  contents
+
+let safe_remove filename =
+  try Sys.remove filename with Sys_error _ -> ()
+
+let testrename f1 f2 contents =
+  try
+    Sys.rename f1 f2;
+    if readfile f2 <> contents then print_string "wrong contents!"
+    else if Sys.file_exists f1 then print_string "initial file still exists!"
+    else print_string "passed"
+  with Sys_error msg ->
+    print_string "Sys_error exception: "; print_string msg
+
+let testfailure f1 f2 =
+  try
+    Sys.rename f1 f2; print_string "should fail but doesn't!"
+  with Sys_error _ ->
+    print_string "fails as expected"
+
+let _ =
+  let f1 = "file1.dat" and f2 = "file2.dat" in
+  safe_remove f1; safe_remove f2;
+  print_string "Rename to nonexisting file: ";
+  writefile f1 "abc";
+  testrename f1 f2 "abc";
+  print_newline();
+  print_string "Rename to existing file: ";
+  writefile f1 "def";
+  writefile f2 "xyz";
+  testrename f1 f2 "def";
+  print_newline();
+  print_string "Renaming a nonexisting file: ";
+  testfailure f1 f2;
+  print_newline();
+  print_string "Renaming to a nonexisting directory: ";
+  writefile f1 "abc";
+  testfailure f1 (Filename.concat "nosuchdir" f2);
+  print_newline();
+  safe_remove f1; safe_remove f2

--- a/testsuite/tests/lib-sys/rename.reference
+++ b/testsuite/tests/lib-sys/rename.reference
@@ -1,0 +1,4 @@
+Rename to nonexisting file: passed
+Rename to existing file: passed
+Renaming a nonexisting file: fails as expected
+Renaming to a nonexisting directory: fails as expected

--- a/testsuite/tests/lib-unix/common/rename.ml
+++ b/testsuite/tests/lib-unix/common/rename.ml
@@ -1,0 +1,52 @@
+(* Test the Unix.rename function *)
+
+let writefile filename contents =
+  let oc = open_out_bin filename in
+  output_string oc contents;
+  close_out oc
+
+let readfile filename =
+  let ic = open_in_bin filename in
+  let sz = in_channel_length ic in
+  let contents = really_input_string ic sz in
+  close_in ic;
+  contents
+
+let safe_remove filename =
+  try Sys.remove filename with Sys_error _ -> ()
+
+let testrename f1 f2 contents =
+  try
+    Unix.rename f1 f2;
+    if readfile f2 <> contents then print_string "wrong contents!"
+    else if Sys.file_exists f1 then print_string "initial file still exists!"
+    else print_string "passed"
+  with Unix.Unix_error(err, _, _) ->
+    print_string "Unix_error exception: "; print_string (Unix.error_message err)
+
+let testfailure f1 f2 =
+  try
+    Unix.rename f1 f2; print_string "should fail but doesn't!"
+  with Unix.Unix_error _ ->
+    print_string "fails as expected"
+
+let _ =
+  let f1 = "file1.dat" and f2 = "file2.dat" in
+  safe_remove f1; safe_remove f2;
+  print_string "Rename to nonexisting file: ";
+  writefile f1 "abc";
+  testrename f1 f2 "abc";
+  print_newline();
+  print_string "Rename to existing file: ";
+  writefile f1 "def";
+  writefile f2 "xyz";
+  testrename f1 f2 "def";
+  print_newline();
+  print_string "Renaming a nonexisting file: ";
+  testfailure f1 f2;
+  print_newline();
+  print_string "Renaming to a nonexisting directory: ";
+  writefile f1 "abc";
+  testfailure f1 (Filename.concat "nosuchdir" f2);
+  print_newline();
+  safe_remove f1; safe_remove f2

--- a/testsuite/tests/lib-unix/common/rename.reference
+++ b/testsuite/tests/lib-unix/common/rename.reference
@@ -1,0 +1,4 @@
+Rename to nonexisting file: passed
+Rename to existing file: passed
+Renaming a nonexisting file: fails as expected
+Renaming to a nonexisting directory: fails as expected


### PR DESCRIPTION
Currently, in the MSVC and Mingw ports of OCaml, `Sys.rename src dst` fails if a file named `dst` already exists.  This is unlike the other ports, where `dst` is replaced by `src` in this case.  This PR reimplements `Sys.rename` on top of the `MoveFileEx` Win32 system call so that the destination file, if it exists already, is replaced by the source file.

The "replace existing file" behavior is more useful especially in cases where one wants to prepare data in a temporary file with a unique name, then give it its final name, which can match an existing file.  See [MPR 4991](https://caml.inria.fr/mantis/view.php?id=4991) and [MPR 7472](https://caml.inria.fr/mantis/view.php?id=7472) for possible uses within the OCaml compiler itself.

The "replace existing file" behavior is even more useful if it is guaranteed to be atomic.  POSIX gives such guarantees for the `rename` function, but MSDN gives no atomicity guarantees for `MoveFileEx` nor for `ReplaceFile`.  It is believed that `MoveFileEx` is atomic on a journaling file system such as NTFS and if no copy of contents is requested.  Same beliefs for `ReplaceFile`, except that the latter is not really usable because it expects the destination name to exist already, and fails otherwise.  In the end we cannot guarantee atomicity of `Sys.rename` but we've made a best effort.