### PR TITLE
Set close-on-exec flag on Windows in `caml_sys_open`

### DIFF
--- a/Changes
+++ b/Changes
@@ -455,6 +455,10 @@ Working version
   New macro Bytes_val for accessing bytes values.
   (Jeremy Yallop, reviews by Mark Shinwell and Xavier Leroy)
 
+* GPR#1309: open files with the equivalent of O_CLOEXEC on Windows in
+  caml_sys_open to match semantics on Unix.
+  (David Allsopp, report by Andreas Hauptmann)
+
 OCaml 4.05.0 (13 Jul 2017):
 ---------------------------
 

--- a/Changes
+++ b/Changes
@@ -455,8 +455,9 @@ Working version
   New macro Bytes_val for accessing bytes values.
   (Jeremy Yallop, reviews by Mark Shinwell and Xavier Leroy)
 
-* GPR#1309: open files with the equivalent of O_CLOEXEC on Windows in
-  caml_sys_open to match semantics on Unix.
+* GPR#1309: open files with O_CLOEXEC (or equivalent) in caml_sys_open thus
+  unifying the semantics between Unix and Windows and also eliminating race
+  condition on Unix.
   (David Allsopp, report by Andreas Hauptmann)
 
 OCaml 4.05.0 (13 Jul 2017):

--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -182,7 +182,9 @@ CAMLprim value caml_sys_open(value path, value vflags, value vperm)
   int fd, flags, perm;
   char * p;
 
-#ifdef _WIN32
+#if defined(O_CLOEXEC)
+  flags = O_CLOEXEC;
+#elif defined(_WIN32)
   flags = _O_NOINHERIT;
 #else
   flags = 0;
@@ -196,7 +198,8 @@ CAMLprim value caml_sys_open(value path, value vflags, value vperm)
   caml_enter_blocking_section();
   fd = CAML_SYS_OPEN(p, flags, perm);
   /* fcntl on a fd can block (PR#5069)*/
-#if defined(F_SETFD) && defined(FD_CLOEXEC) && !defined(_WIN32)
+#if defined(F_SETFD) && defined(FD_CLOEXEC) && !defined(_WIN32) \
+  && !defined(O_CLOEXEC)
   if (fd != -1)
     fcntl(fd, F_SETFD, FD_CLOEXEC);
 #endif

--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -49,7 +49,6 @@
 #include "caml/debugger.h"
 #include "caml/fail.h"
 #include "caml/gc_ctrl.h"
-#include "caml/instruct.h"
 #include "caml/io.h"
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
@@ -183,15 +182,21 @@ CAMLprim value caml_sys_open(value path, value vflags, value vperm)
   int fd, flags, perm;
   char * p;
 
+#ifdef _WIN32
+  flags = _O_NOINHERIT;
+#else
+  flags = 0;
+#endif
+
   caml_sys_check_path(path);
   p = caml_stat_strdup(String_val(path));
-  flags = caml_convert_flag_list(vflags, sys_open_flags);
+  flags |= caml_convert_flag_list(vflags, sys_open_flags);
   perm = Int_val(vperm);
   /* open on a named FIFO can block (PR#1533) */
   caml_enter_blocking_section();
   fd = CAML_SYS_OPEN(p, flags, perm);
   /* fcntl on a fd can block (PR#5069)*/
-#if defined(F_SETFD) && defined(FD_CLOEXEC)
+#if defined(F_SETFD) && defined(FD_CLOEXEC) && !defined(_WIN32)
   if (fd != -1)
     fcntl(fd, F_SETFD, FD_CLOEXEC);
 #endif


### PR DESCRIPTION
On supporting Unix platform, `Pervasives.open_*` open files with `FD_CLOEXEC`. On Windows, emulate this by calling `SetHandleInformation` to prevent the handle from being inherited.

See https://github.com/janestreet/jbuilder/pull/243 for @fdopen's example of the present behaviour being a nuisance.