### PR TITLE
Fix `make alldepend`: don't build dependencies for num

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -968,7 +968,7 @@ clean::
 	$(MAKE) -C byterun clean
 	rm -f stdlib/libcamlrun.$(A)
 
-otherlibs_all := bigarray dynlink graph num raw_spacetime_lib \
+otherlibs_all := bigarray dynlink graph raw_spacetime_lib \
   str systhreads threads unix win32graph win32unix
 subdirs := asmrun byterun debugger lex ocamldoc stdlib tools \
   $(addprefix otherlibs/, $(otherlibs_all))


### PR DESCRIPTION
This is a follow-up to PR #1178