### PR TITLE
Change `value` to be `uintnat`

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -73,7 +73,7 @@ EOF
   $MAKE world.opt
   $MAKE ocamlnat
   (cd testsuite && $MAKE all)
-  [ $XARCH =  "i386" ] ||  (cd testsuite && $MAKE USE_RUNTIME="d" all)
+  (cd testsuite && $MAKE USE_RUNTIME="d" all)
   $MAKE install
   $MAKE manual-pregen
   # check_all_arches checks tries to compile all backends in place,

--- a/Changes
+++ b/Changes
@@ -36,6 +36,10 @@ be mentioned in the 4.06 section below instead of here.)
 
 ### Runtime system:
 
+- GPR#1483: fix GC freelist accounting for chunks larger than the maximum block
+  size.
+  (David Allsopp and Damien Doligez)
+
 ### Tools:
 
 - MPR#7643, GPR#1377: ocamldep, fix an exponential blowup in presence of nested

--- a/Changes
+++ b/Changes
@@ -36,6 +36,10 @@ be mentioned in the 4.06 section below instead of here.)
 
 ### Runtime system:
 
+- GPR#1311: define value as uintnat, though still expose it to user code as
+  intnat.
+  (David Allsopp, review by Xavier Leroy)
+
 - GPR#1483: fix GC freelist accounting for chunks larger than the maximum block
   size.
   (David Allsopp and Damien Doligez)

--- a/asmrun/clambda_checks.c
+++ b/asmrun/clambda_checks.c
@@ -19,6 +19,8 @@
 
 #include <stdio.h>
 
+#define CAML_INTERNALS
+
 #include <caml/mlvalues.h>
 
 value caml_check_value_is_closure(value v, value v_descr)

--- a/byterun/afl.c
+++ b/byterun/afl.c
@@ -17,6 +17,8 @@
 
 #if !defined(HAS_SYS_SHM_H)
 
+#define CAML_INTERNALS
+
 #include "caml/mlvalues.h"
 
 CAMLprim value caml_setup_afl (value unit)

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -38,6 +38,7 @@ typedef size_t asize_t;
 
 #ifdef CAML_INTERNALS
 typedef char * addr;
+#define CAML_UNSIGNED_VALUE
 #endif /* CAML_INTERNALS */
 
 /* Noreturn is preserved for compatibility reasons.
@@ -411,7 +412,13 @@ int caml_runtime_warnings_active(void);
 /* Note: the first argument is in fact a [value] but we don't have this
    type available yet because we can't include [mlvalues.h] in this file.
 */
-extern void caml_set_fields (intnat v, unsigned long, unsigned long);
+#ifdef CAML_UNSIGNED_VALUE
+#define value uintnat
+#else
+#define value intnat
+#endif
+extern void caml_set_fields (value v, unsigned long, unsigned long);
+#undef value
 #endif /* DEBUG */
 
 

--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -26,6 +26,10 @@
 extern "C" {
 #endif
 
+#ifdef CAML_INTERNALS
+#define CAML_UNSIGNED_VALUE
+#endif
+
 /* Definitions
 
   word: Four bytes on 32 and 16 bit architectures,
@@ -57,7 +61,11 @@ extern "C" {
          This is for use only by the GC.
 */
 
+#ifdef CAML_UNSIGNED_VALUE
+typedef uintnat value;
+#else
 typedef intnat value;
+#endif
 typedef uintnat header_t;
 typedef uintnat mlsize_t;
 typedef unsigned int tag_t;             /* Actually, an unsigned char */
@@ -70,13 +78,22 @@ typedef uintnat mark_t;
 
 /* Conversion macro names are always of the form  "to_from". */
 /* Example: Val_long as in "Val from long" or "Val of long". */
+#ifdef CAML_UNSIGNED_VALUE
+#define Val_long(x)     ((((uintnat)(x) << 1)) + 1)
+#define Long_val(x)     ((intnat) (x) >> 1)
+#else
 #define Val_long(x)     ((intnat) (((uintnat)(x) << 1)) + 1)
 #define Long_val(x)     ((x) >> 1)
+#endif
 #define Max_long (((intnat)1 << (8 * sizeof(value) - 2)) - 1)
 #define Min_long (-((intnat)1 << (8 * sizeof(value) - 2)))
 #define Val_int(x) Val_long(x)
 #define Int_val(x) ((int) Long_val(x))
+#ifdef CAML_UNSIGNED_VALUE
+#define Unsigned_long_val(x) ((x) >> 1)
+#else
 #define Unsigned_long_val(x) ((uintnat)(x) >> 1)
+#endif
 #define Unsigned_int_val(x)  ((int) Unsigned_long_val(x))
 
 /* Structure of the header:

--- a/byterun/compare.c
+++ b/byterun/compare.c
@@ -174,7 +174,7 @@ static intnat do_compare_val(struct compare_stack* stk,
        shift lsb off to avoid overflow in subtraction. */
     if (! Is_in_value_area(v1) || ! Is_in_value_area(v2)) {
       if (v1 == v2) goto next_item;
-      return (v1 >> 1) - (v2 >> 1);
+      return ((intnat)v1 >> 1) - ((intnat)v2 >> 1);
       /* Subtraction above cannot result in UNORDERED */
     }
     t1 = Tag_val(v1);

--- a/byterun/freelist.c
+++ b/byterun/freelist.c
@@ -534,9 +534,13 @@ header_t *caml_fl_merge_block (value bp)
 */
 void caml_fl_add_blocks (value bp)
 {
+  value cur = bp;
   CAMLassert (fl_last != Val_NULL);
   CAMLassert (Next (fl_last) == Val_NULL);
-  caml_fl_cur_wsz += Whsize_bp (bp);
+  do {
+    caml_fl_cur_wsz += Whsize_bp (cur);
+    cur = Field(cur, 0);
+  } while (cur != Val_NULL);
 
   if (bp > fl_last){
     Next (fl_last) = bp;
@@ -547,7 +551,7 @@ void caml_fl_add_blocks (value bp)
       flp [flp_size++] = fl_last;
     }
   }else{
-    value cur, prev;
+    value prev;
 
     prev = Fl_head;
     cur = Next (prev);

--- a/byterun/interp.c
+++ b/byterun/interp.c
@@ -1090,7 +1090,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
         int li = 3, hi = Field(meths,0), mi;
         while (li < hi) {
           mi = ((li+hi) >> 1) | 1;
-          if (accu < Field(meths,mi)) hi = mi-2;
+          if ((intnat)accu < (intnat)Field(meths,mi)) hi = mi-2;
           else li = mi;
         }
         *pc = (li-3)*sizeof(value);
@@ -1112,7 +1112,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       int li = 3, hi = Field(meths,0), mi;
       while (li < hi) {
         mi = ((li+hi) >> 1) | 1;
-        if (accu < Field(meths,mi)) hi = mi-2;
+        if ((intnat)accu < (intnat)Field(meths,mi)) hi = mi-2;
         else li = mi;
       }
       accu = Field (meths, li-1);

--- a/byterun/ints.c
+++ b/byterun/ints.c
@@ -126,7 +126,7 @@ CAMLprim value caml_bswap16(value v)
 
 CAMLprim value caml_int_compare(value v1, value v2)
 {
-  int res = (v1 > v2) - (v1 < v2);
+  int res = ((intnat)v1 > (intnat)v2) - ((intnat)v1 < (intnat)v2);
   return Val_int(res);
 }
 

--- a/byterun/obj.c
+++ b/byterun/obj.c
@@ -207,7 +207,7 @@ CAMLprim value caml_get_public_method (value obj, value tag)
   int li = 3, hi = Field(meths,0), mi;
   while (li < hi) {
     mi = ((li+hi) >> 1) | 1;
-    if (tag < Field(meths,mi)) hi = mi-2;
+    if ((intnat)tag < (intnat)Field(meths,mi)) hi = mi-2;
     else li = mi;
   }
   /* return 0 if tag is not there */
@@ -227,7 +227,7 @@ value caml_cache_public_method (value meths, value tag, value *cache)
   int li = 3, hi = Field(meths,0), mi;
   while (li < hi) {
     mi = ((li+hi) >> 1) | 1;
-    if (tag < Field(meths,mi)) hi = mi-2;
+    if ((intnat)tag < (intnat)Field(meths,mi)) hi = mi-2;
     else li = mi;
   }
   *cache = (li-3)*sizeof(value) + MARK;
@@ -243,7 +243,7 @@ value caml_cache_public_method2 (value *meths, value tag, value *cache)
     int li = 3, hi = meths[0], mi;
     while (li < hi) {
       mi = ((li+hi) >> 1) | 1;
-      if (tag < meths[mi]) hi = mi-2;
+      if ((intnat)tag < (intnat)meths[mi]) hi = mi-2;
       else li = mi;
     }
     *cache = (li-3)*sizeof(value) + MARK;


### PR DESCRIPTION
Historically, value has been treated as a signed integer which might be a pointer. This commit changes it to be an unsigned integer and thus a pointer which might be a signed integer.

This has the benefit that pointer arithmetic assertions always make sense, even if the actual address space spans 0x80000000 or 0x8000000000000000 and only requires annotations in the rarer instances
where value is actually a signed integer. This fixes several instances of invalid pointer assertion code in the debug runtime.

At present, this only comes into play when `CAML_INTERNALS` has been defined. User code may opt for the change by ensuring that `CAML_UNSIGNED_VALUE` has been defined before `caml/mlvalues.h` is included.

/cc @mshinwell, @stedolan