### PR TITLE
Let Travis send email notifications for build statuses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,7 @@ addons:
   apt:
     packages:
     - binutils-dev
+
+notifications:
+  email:
+    - ocaml-ci-notifications@inria.fr


### PR DESCRIPTION
The notifications are sent to the dedicated OCaml CI notifications list.

At the moment, the default configuration of both Travis and
AppVeyor is used to decide when to send out notifications.
This can always be fine-tuned later, if desired.