### PR TITLE
Losing GADT instances with -principal

### DIFF
--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -1070,3 +1070,29 @@ let f : type a b. (a,b) eq -> (b,int) eq -> a -> b -> _ = fun ab bint a b ->
 [%%expect{|
 val f : ('a, 'b) eq -> ('b, int) eq -> 'a -> 'b -> unit = <fun>
 |}];;
+
+(* More ambiguous *)
+
+type _ i = I : int i
+;;
+
+[%%expect{|
+type _ i = I : int i
+|}]
+
+let bar (type a) (x : a i) y =
+  match x, y with
+  | I, ((_: a) | 0) -> ()
+;;
+
+[%%expect{|
+Line _, characters 17-18:
+Error: This pattern matches values of type int
+       but a pattern was expected which matches values of type a = int
+       This instance of int is ambiguous:
+       it would escape the scope of its equation
+|}, Principal{|
+Line _, characters 17-18:
+Warning 12: this sub-pattern is unused.
+val bar : 'a i -> 'a -> unit = <fun>
+|}]

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -1092,7 +1092,9 @@ Error: This pattern matches values of type int
        This instance of int is ambiguous:
        it would escape the scope of its equation
 |}, Principal{|
-Line _, characters 17-18:
-Warning 12: this sub-pattern is unused.
-val bar : 'a i -> 'a -> unit = <fun>
+Line _, characters 4-19:
+Error: This pattern matches values of type a i * a
+       but a pattern was expected which matches values of type a i * 'a
+       This instance of a is ambiguous:
+       it would escape the scope of its equation
 |}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3867,7 +3867,7 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
           if !Clflags.principal then begin
             end_def ();
             iter_pattern (fun {pat_type=t} -> generalize_structure t) pat;
-            { pat with pat_type = instance env pat.pat_type }
+            { pat with pat_type = instance ext_env pat.pat_type }
           end else pat
         in
         (pat, (ext_env, unpacks)))


### PR DESCRIPTION
In this code:

```ocaml
type _ t = I : int t

let f (type a) (x : a t) y =
  match x, y with
  | I, ((_ : a) | 0) -> ()

```

`f` fails to typecheck for the following reason:

```
Error: This pattern matches values of type int
       but a pattern was expected which matches values of type a = int
       This instance of int is ambiguous:
       it would escape the scope of its equation
```

The error message could be clearer ("this instance of int is ambiguous" is one of the most confusing error messages I ever got from ocaml) but what I think it means is:

> `y` could be either of type `a` or `int`, but I cannot decide which, you need
> to tell me

Indeed, if we annotate `y` at any point to be of type `a`, or annotate `0` to be of type `a` the function is accepted [[1](#bonus)].

This is what is called "ambivalence" in [the paper describing GADT inference](http://gallium.inria.fr/~remy/gadts/Garrigue-Remy:gadts@long2013.pdf).  
All the examples of ambivalence in the paper are of expressions, such as:

```ocaml
if p then (x : a) else 0
```

but it seems that or-patterns allow ambivalence to come from patterns as well.

However if the compiler was called with `-principal` then the function typechecks and is given the following type:
```ocaml
val f : 'a t -> 'a -> unit
```

Here is a rough outline of what happens in both cases (N.B. `ty@level` mean "type at level"):

- **without `-principal`:** When typechecking the pattern, the expected type we use is the type of `x, y` that is: `a@2008 t@2008 * 'b@1005` and the "current level" is `1007`.  
  Typechecking the first branch of the or-pattern unifies `'b@1005` (the expected type) with `a` (which is coming from the annotation), giving `a@1005`.  
  We then go on to the second branch and try to unify `a@1005` (the new expected type) with `int`, we have a local equation saying that `a = int`, but it was introduced at level `1007`, so we can't use it and "fail".

- **with `-principal`:** When typechecking the pattern, the expected type we use is the partially instantiated type of `x, y`: `a@2009 t@2009 * 'b@2009` (we have one more `begin_def` with `-principal` that's why the level is higher).  
  Typechecking the first branch of the or-pattern unifies `'b@2009` (the expected type) with `a` (which is coming from the annotation), giving `a@2009`.  
  We then go on to the second branch and unify `a@2009` (the new expected type) with `int`, we have a local equation saying that `a = int` and it was introduced at level `1007`, so we can use it, and get an ambivalent type `(a | int)@2009` -- where the ambivalence is represented by adding the type to the list of gadt instances in the environment.  
  Up to that point, things are proceeding correctly. We return from `type_pattern` ([typecore.ml:3863](https://github.com/ocaml/ocaml/blob/5a33dc3f2acafc623e01d0cb0005b3d33c2019b2/typing/typecore.ml#L3863)), and continue until we reach line 3870. At this point we take an instance of the type we just computed. The resulting type should still be an ambivalent type, however the environment we use to take that instance is the outer one, i.e. the one without the local constraints, so we never add the instantiated type to the list of gadt instances.  
  So later on, when unifying the type of the pattern with the type of matched expression ([typecore.ml:3863](https://github.com/ocaml/ocaml/blob/5a33dc3f2acafc623e01d0cb0005b3d33c2019b2/typing/typecore.ml#L3863)) we have no problem unifying the unambivalent `a@2008` with `'b@1005`, because we don't have a gadt instance for `a`.


There seem to be two ways to fix the issue:
- when taking an instance of a type, we could always register the instance to the same gadt instance level the initial type was at, regardless of whether there are local equations in scope.  
  (note: I believe that the "are there local equations" check is only here for performance reasons, not for correctness. @garrigue can you confirm?)
- in the particular case where we take the instance of the pattern type, do it in the environment used to typecheck the pattern, not in the outer one.  
  The inner environment still has the equations, and the gadt instance sets are shared between the inner and outer environments, so everything is fine.

I went with the second option, because:
- it works
- it doesn't seem to break anything else (the testsuite still pass)
- it is a one line change

The first option seems potentially more correct to me (but I might be missing something), but I have no idea what the impact on performances of typechecking would have been and the patch would be... well, more than one line.

---
# Bonus

1. Funnily enough, if we annotate `y` to be of type `int`, then the function is rejected with this message:
    ```
    Error: This pattern matches values of type a t * a
           but a pattern was expected which matches values of type a t * int
           Type a is not compatible with type int
    ```
    I believe this to be another bug, cf [MPR#7618](https://caml.inria.fr/mantis/view.php?id=7618).
