### PR TITLE
Fix mpr7620

### DIFF
--- a/Changes
+++ b/Changes
@@ -54,6 +54,9 @@ Working version
 - MPR#7531, GPR#1162: Erroneous code transformation at partial applications
   (Mark Shinwell)
 
+- MPR#7620, GPR#1317: Typecore.force_delayed_checks does not run with -i option
+  (Jacques Garrigue, report by Jun Furuse)
+
 * GPR#659: Remove support for SPARC native code generation
   (Mark Shinwell)
 

--- a/testsuite/tests/typing-ocamlc-i/Makefile
+++ b/testsuite/tests/typing-ocamlc-i/Makefile
@@ -4,7 +4,7 @@ SOURCES = pr7620_bad.ml
 
 all: 
 	@printf " ... testing '$(SOURCES)'"
-	@$(OCAMLC) $(ADD_COMPFLAGS) -i 2>&1 > /dev/null \
+	$(OCAMLC) -i $(SOURCES) 2>&1 > /dev/null \
 	 && echo " => failed" || echo " => passed"
 
 clean: defaultclean

--- a/testsuite/tests/typing-ocamlc-i/Makefile
+++ b/testsuite/tests/typing-ocamlc-i/Makefile
@@ -1,0 +1,15 @@
+# Check ocamlc -i
+
+SOURCES = pr7620_bad.ml
+
+all: 
+	@printf " ... testing '$(SOURCES)'"
+	@$(OCAMLC) $(ADD_COMPFLAGS) -i 2>&1 > /dev/null \
+	 && echo " => failed" || echo " => passed"
+
+clean: defaultclean
+	@rm -f *~
+
+BASEDIR=../..
+include $(BASEDIR)/makefiles/Makefile.common
+

--- a/testsuite/tests/typing-ocamlc-i/Makefile
+++ b/testsuite/tests/typing-ocamlc-i/Makefile
@@ -4,7 +4,7 @@ SOURCES = pr7620_bad.ml
 
 all: 
 	@printf " ... testing '$(SOURCES)'"
-	$(OCAMLC) -i $(SOURCES) 2>&1 > /dev/null \
+	@$(OCAMLC) -i $(SOURCES) 2> /dev/null \
 	 && echo " => failed" || echo " => passed"
 
 clean: defaultclean

--- a/testsuite/tests/typing-ocamlc-i/pr7620_bad.ml
+++ b/testsuite/tests/typing-ocamlc-i/pr7620_bad.ml
@@ -1,0 +1,3 @@
+let t = 
+  (function `A | `B -> () : 'a) (`A : [`A]);
+  (failwith "dummy" : 'a) (* to know how 'a is unified *)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1607,6 +1607,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
     type_structure initial_env ast (Location.in_file sourcefile) in
   let simple_sg = simplify_signature sg in
   if !Clflags.print_types then begin
+    Typecore.force_delayed_checks ();
     Printtyp.wrap_printing_env initial_env
       (fun () -> fprintf std_formatter "%a@." Printtyp.signature simple_sg);
     (str, Tcoerce_none)   (* result is ignored by Compile.implementation *)


### PR DESCRIPTION
Call `Typecore.force_delayed_checks` before printing the signature for `ocamlc -i`

Cf [MPR#7620](https://caml.inria.fr/mantis/view.php?id=7620).