### PR TITLE
Fix MPR#7617 and #7618

### DIFF
--- a/Changes
+++ b/Changes
@@ -54,6 +54,10 @@ Working version
 - MPR#7531, GPR#1162: Erroneous code transformation at partial applications
   (Mark Shinwell)
 
+- MP#7617, #7618, GPR#1318: Ambiguous (mistakenly) type escaping the
+  scope of its equation
+  (Jacques Garrigue, report by Thomas Refix)
+
 * GPR#659: Remove support for SPARC native code generation
   (Mark Shinwell)
 

--- a/testsuite/tests/typing-gadts/pr6690.ml
+++ b/testsuite/tests/typing-gadts/pr6690.ml
@@ -35,11 +35,12 @@ type 'a local_visit_action
 type ('a, 'result, 'visit_action) context =
     Local : ('a, 'a * insert, 'a local_visit_action) context
   | Global : ('a, 'a, 'a visit_action) context
-Line _, characters 4-10:
-Error: This pattern matches values of type ($1, $1, visit_action) context
-       but a pattern was expected which matches values of type
+Line _, characters 4-9:
+Error: This pattern matches values of type
          ($0, $0 * insert, visit_action) context
-       Type $1 is not compatible with type $0
+       but a pattern was expected which matches values of type
+         ('a, 'b, visit_action) context
+       The type constructor $0 would escape its scope
 |}];;
 
 let vexpr (type visit_action)
@@ -56,11 +57,12 @@ Error: This pattern matches values of type
          ($'a, $'a * insert, visit_action) context
        The type constructor $'a would escape its scope
 |}, Principal{|
-Line _, characters 4-10:
-Error: This pattern matches values of type ($1, $1, visit_action) context
-       but a pattern was expected which matches values of type
+Line _, characters 4-9:
+Error: This pattern matches values of type
          ($0, $0 * insert, visit_action) context
-       Type $1 is not compatible with type $0
+       but a pattern was expected which matches values of type
+         ('a, 'result, visit_action) context
+       The type constructor $0 would escape its scope
 |}];;
 
 let vexpr (type result) (type visit_action)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3840,7 +3840,6 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
       [{pc_lhs}] when is_var pc_lhs -> false
     | _ -> true in
   if propagate then begin_def (); (* propagation of the argument *)
-  let ty_arg' = newvar () in
   let pattern_force = ref [] in
 (*  Format.printf "@[%i %i@ %a@]@." lev (get_current_level())
     Printtyp.raw_type_expr ty_arg; *)
@@ -3867,15 +3866,19 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
           if !Clflags.principal then begin
             end_def ();
             iter_pattern (fun {pat_type=t} -> generalize_structure t) pat;
-            { pat with pat_type = instance env pat.pat_type }
+            { pat with pat_type = instance ext_env pat.pat_type }
           end else pat
         in
         (pat, (ext_env, unpacks)))
       caselist in
-  (* Unify cases (delayed to keep it order-free) *)
-  let patl = List.map fst pat_env_list in
-  List.iter (fun pat -> unify_pat env pat ty_arg') patl;
+  (* If there are polymorphics variants, then unify cases
+     (delayed to keep it order-free) *)
+  let unify_pats sch =
+    List.iter (fun (pat, (ext_env, _)) ->
+      unify_pat ext_env pat (instance ext_env sch)) pat_env_list in
+  if contains_polyvars then unify_pats (newvar ());
   (* Check for polymorphic variants to close *)
+  let patl = List.map fst pat_env_list in
   if List.exists has_variants patl then begin
     Parmatch.pressure_variants env patl;
     List.iter (iter_pattern finalize_variant) patl
@@ -3883,15 +3886,14 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
   (* `Contaminating' unifications start here *)
   List.iter (fun f -> f()) !pattern_force;
   (* Post-processing and generalization *)
-  let unify_pats ty = List.iter (fun pat -> unify_pat env pat ty) patl in
+  if propagate || erase_either then unify_pats ty_arg;
   if propagate then begin
     List.iter
       (iter_pattern (fun {pat_type=t} -> unify_var env t (newvar()))) patl;
-    unify_pats (instance env ty_arg);
     end_def ();
     List.iter (iter_pattern (fun {pat_type=t} -> generalize t)) patl;
-  end
-  else if erase_either then unify_pats (instance env ty_arg);
+  end;
+  (*else if erase_either then unify_pats (instance env ty_arg)*)
   (* type bodies *)
   let in_function = if List.length caselist = 1 then in_function else None in
   let cases =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3893,7 +3893,6 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
     end_def ();
     List.iter (iter_pattern (fun {pat_type=t} -> generalize t)) patl;
   end;
-  (*else if erase_either then unify_pats (instance env ty_arg)*)
   (* type bodies *)
   let in_function = if List.length caselist = 1 then in_function else None in
   let cases =


### PR DESCRIPTION
Only unify pattern-matching branches together when there is a polymorphic variant constructor in the pattern. Otherwise, be more laxist, and allow different case to be different instances.

Cf [MPR#7617](https://caml.inria.fr/mantis/view.php?id=7617).

(the branch name is wrong...)