### PR TITLE
Fix MPR#7601 again

### DIFF
--- a/Changes
+++ b/Changes
@@ -54,6 +54,10 @@ Working version
 - MPR#7531, GPR#1162: Erroneous code transformation at partial applications
   (Mark Shinwell)
 
+- MPR#7601, GPR#1320: It seems like a hidden non-generalized type variable
+  remains in some inferred signatures, which leads to strange errors
+  (Jacques Garrigue, report by Mandrikin)
+
 - MP#7617, #7618, GPR#1318: Ambiguous (mistakenly) type escaping the
   scope of its equation
   (Jacques Garrigue, report by Thomas Refix)

--- a/testsuite/tests/typing-modules-bugs/pr7601_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7601_ok.ml
@@ -1,0 +1,22 @@
+(**************************************************************************)
+(*                                                                        *)
+(*  Crude slicer for preprocessing reachability verification tasks        *)
+(*                                                                        *)
+(*  Copyright (C) 2016-2017 Mikhail Mandrykin, ISP RAS                    *)
+(*                                                                        *)
+(**************************************************************************)
+
+module type Analysis = sig
+  type t
+  type 'a maybe_region =
+    [< `Location of t
+    |  `Value of t
+    |  `None ] as 'a
+  val of_var : ?f:string -> string -> [ `Location of _ | `Value of _  | `None ] maybe_region
+end
+
+module Make (Analysis : Analysis) = struct
+  include Analysis
+  let of_var  = of_var ~f:""
+end
+

--- a/testsuite/tests/typing-modules-bugs/pr7601a_ok.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7601a_ok.ml
@@ -1,0 +1,21 @@
+module type Param1 = sig
+  type 'a r = [< `A of int ] as 'a
+  val f : ?a:string -> string -> [ `A of _ ] r
+end
+
+module Make1 (M : Param1) = struct
+  include M
+  let f = f ~a:""
+end
+
+module type Param2 = sig
+  type t
+  type 'a r = [< `A of t ] as 'a
+  val f : ?a:string -> string -> [ `A of _ ] r
+end
+
+module Make2 (M : Param2) = struct
+  include M
+  let f = f ~a:""
+end
+

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2690,7 +2690,7 @@ and unify_row env row1 row2 =
     end;
     (* The following test is not principal... should rather use Tnil *)
     let rm = row_more row in
-    if !trace_gadt_instances && rm.desc = Tnil then () else
+    (*if !trace_gadt_instances && rm.desc = Tnil then () else*)
     if !trace_gadt_instances then
       update_level !env rm.level (newgenty (Tvariant row));
     if row_fixed row then
@@ -2712,6 +2712,10 @@ and unify_row env row1 row2 =
           raise (Unify ((mkvariant [l,f1] true,
                          mkvariant [l,f2] true) :: trace)))
       pairs;
+    if static_row row1 then begin
+      let rm = row_more row1 in
+      if is_Tvar rm then link_type rm (newty2 rm.level Tnil)
+    end
   with exn ->
     log_type rm1; rm1.desc <- md1; log_type rm2; rm2.desc <- md2; raise exn
   end


### PR DESCRIPTION
A new way to fix [MPR#7601](https://caml.inria.fr/mantis/view.php?id=7601), by replacing row variables of static variant types with `Tnil`. Should have no side-effect.

Cf. #1272 for why the previous approach didn't work.