### PR TITLE
Unboxed calling convention

### DIFF
--- a/asmcomp/clambda.ml
+++ b/asmcomp/clambda.ml
@@ -70,8 +70,9 @@ and ulambda =
 and ufunction = {
   label  : function_label;
   arity  : int;
-  params : (Ident.t * value_kind) list;
-  body   : (ulambda * value_kind);
+  unboxed: fun_unboxing;
+  params : (Ident.t * lfunarg) list;
+  body   : (ulambda * lfunarg);
   dbg    : Debuginfo.t;
   env    : Ident.t option;
 }

--- a/asmcomp/clambda.ml
+++ b/asmcomp/clambda.ml
@@ -21,6 +21,8 @@ open Lambda
 
 type function_label = string
 
+type fun_unboxing = (value_kind list * value_kind) option
+
 type ustructured_constant =
   | Uconst_float of float
   | Uconst_int32 of int32
@@ -39,7 +41,13 @@ and uconstant =
 and ulambda =
     Uvar of Ident.t
   | Uconst of uconstant
-  | Udirect_apply of function_label * ulambda list * Debuginfo.t
+  | Udirect_apply of
+      {
+        label:function_label;
+        args: ulambda list;
+        dbg: Debuginfo.t;
+        unboxed: fun_unboxing;
+      }
   | Ugeneric_apply of ulambda * ulambda list * Debuginfo.t
   | Uclosure of ufunction list * ulambda list
   | Uoffset of ulambda * int
@@ -79,6 +87,7 @@ and ulambda_switch =
 type function_description =
   { fun_label: function_label;          (* Label of direct entry point *)
     fun_arity: int;                     (* Number of arguments *)
+    fun_unboxed: fun_unboxing;
     mutable fun_closed: bool;           (* True if environment not used *)
     mutable fun_inline: (Ident.t list * ulambda) option;
     mutable fun_float_const_prop: bool  (* Can propagate FP consts *)

--- a/asmcomp/clambda.ml
+++ b/asmcomp/clambda.ml
@@ -62,8 +62,8 @@ and ulambda =
 and ufunction = {
   label  : function_label;
   arity  : int;
-  params : Ident.t list;
-  body   : ulambda;
+  params : (Ident.t * value_kind) list;
+  body   : (ulambda * value_kind);
   dbg    : Debuginfo.t;
   env    : Ident.t option;
 }

--- a/asmcomp/clambda.mli
+++ b/asmcomp/clambda.mli
@@ -70,8 +70,9 @@ and ulambda =
 and ufunction = {
   label  : function_label;
   arity  : int;
-  params : (Ident.t * value_kind) list;
-  body   : (ulambda * value_kind);
+  unboxed: fun_unboxing;
+  params : (Ident.t * lfunarg) list;
+  body   : (ulambda * lfunarg);
   dbg    : Debuginfo.t;
   env    : Ident.t option;
 }

--- a/asmcomp/clambda.mli
+++ b/asmcomp/clambda.mli
@@ -21,6 +21,8 @@ open Lambda
 
 type function_label = string
 
+type fun_unboxing = (value_kind list * value_kind) option
+
 type ustructured_constant =
   | Uconst_float of float
   | Uconst_int32 of int32
@@ -39,7 +41,13 @@ and uconstant =
 and ulambda =
     Uvar of Ident.t
   | Uconst of uconstant
-  | Udirect_apply of function_label * ulambda list * Debuginfo.t
+  | Udirect_apply of
+      {
+        label: function_label;
+        args: ulambda list;
+        dbg: Debuginfo.t;
+        unboxed: fun_unboxing;
+      }
   | Ugeneric_apply of ulambda * ulambda list * Debuginfo.t
   | Uclosure of ufunction list * ulambda list
   | Uoffset of ulambda * int
@@ -79,6 +87,7 @@ and ulambda_switch =
 type function_description =
   { fun_label: function_label;          (* Label of direct entry point *)
     fun_arity: int;                     (* Number of arguments *)
+    fun_unboxed: fun_unboxing;
     mutable fun_closed: bool;           (* True if environment not used *)
     mutable fun_inline: (Ident.t list * ulambda) option;
     mutable fun_float_const_prop: bool  (* Can propagate FP consts *)

--- a/asmcomp/clambda.mli
+++ b/asmcomp/clambda.mli
@@ -62,8 +62,8 @@ and ulambda =
 and ufunction = {
   label  : function_label;
   arity  : int;
-  params : Ident.t list;
-  body   : ulambda;
+  params : (Ident.t * value_kind) list;
+  body   : (ulambda * value_kind);
   dbg    : Debuginfo.t;
   env    : Ident.t option;
 }

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2816,10 +2816,11 @@ and transl_letrec env bindings cont =
 
 let transl_function f =
   let body =
+    let body = fst f.body in
     if Config.flambda then
-      Un_anf.apply f.body ~what:f.label
+      Un_anf.apply body ~what:f.label
     else
-      f.body
+      body
   in
   let cmm_body =
     let env = create_env ~environment_param:f.env in
@@ -2828,7 +2829,7 @@ let transl_function f =
     else
       transl env body in
   Cfunction {fun_name = f.label;
-             fun_args = List.map (fun id -> (id, typ_val)) f.params;
+             fun_args = List.map (fun (id, _) -> (id, typ_val)) f.params;
              fun_body = cmm_body;
              fun_fast = !Clflags.optimize_for_speed;
              fun_dbg  = f.dbg}

--- a/asmcomp/flambda_to_clambda.ml
+++ b/asmcomp/flambda_to_clambda.ml
@@ -448,7 +448,7 @@ and to_clambda_direct_apply t func args direct_func dbg env : Clambda.ulambda =
        dropping any side effects.) *)
     if closed then uargs else uargs @ [subst_var env func]
   in
-  Udirect_apply (label, uargs, dbg)
+  Udirect_apply {label; args=uargs; dbg; unboxed=None}
 
 (* Describe how to build a runtime closure block that corresponds to the
    given Flambda set of closures.

--- a/asmcomp/flambda_to_clambda.ml
+++ b/asmcomp/flambda_to_clambda.ml
@@ -532,8 +532,8 @@ and to_clambda_set_of_closures t env
     in
     { label = Compilenv.function_label closure_id;
       arity = Flambda_utils.function_arity function_decl;
-      params = params @ [env_var];
-      body = to_clambda t env_body function_decl.body;
+      params = List.map (fun p -> p, Lambda.Pgenval) (params @ [env_var]);
+      body = (to_clambda t env_body function_decl.body, Lambda.Pgenval);
       dbg = function_decl.dbg;
       env = Some env_var;
     }
@@ -572,8 +572,8 @@ and to_clambda_closed_set_of_closures t env symbol
     in
     { label = Compilenv.function_label (Closure_id.wrap id);
       arity = Flambda_utils.function_arity function_decl;
-      params;
-      body = to_clambda t env_body function_decl.body;
+      params = List.map (fun p -> p, Lambda.Pgenval) params;
+      body = (to_clambda t env_body function_decl.body, Lambda.Pgenval);
       dbg = function_decl.dbg;
       env = None;
     }

--- a/asmcomp/flambda_to_clambda.ml
+++ b/asmcomp/flambda_to_clambda.ml
@@ -532,8 +532,9 @@ and to_clambda_set_of_closures t env
     in
     { label = Compilenv.function_label closure_id;
       arity = Flambda_utils.function_arity function_decl;
-      params = List.map (fun p -> p, Lambda.Pgenval) (params @ [env_var]);
-      body = (to_clambda t env_body function_decl.body, Lambda.Pgenval);
+      unboxed = None;
+      params = List.map (fun p -> Lambda.mk_arg p) (params @ [env_var]);
+      body = Lambda.mk_arg (to_clambda t env_body function_decl.body);
       dbg = function_decl.dbg;
       env = Some env_var;
     }
@@ -572,8 +573,9 @@ and to_clambda_closed_set_of_closures t env symbol
     in
     { label = Compilenv.function_label (Closure_id.wrap id);
       arity = Flambda_utils.function_arity function_decl;
-      params = List.map (fun p -> p, Lambda.Pgenval) params;
-      body = (to_clambda t env_body function_decl.body, Lambda.Pgenval);
+      unboxed = None;
+      params = List.map (fun p -> Lambda.mk_arg p) params;
+      body = Lambda.mk_arg (to_clambda t env_body function_decl.body);
       dbg = function_decl.dbg;
       env = None;
     }

--- a/asmcomp/printclambda.ml
+++ b/asmcomp/printclambda.ml
@@ -75,10 +75,19 @@ and lam ppf = function
   | Uvar id ->
       Ident.print ppf id
   | Uconst c -> uconstant ppf c
-  | Udirect_apply(f, largs, _) ->
+  | Udirect_apply{label; args; unboxed; dbg = _} ->
       let lams ppf largs =
-        List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
-      fprintf ppf "@[<2>(apply*@ %s %a)@]" f lams largs
+        List.iter (fun l -> fprintf ppf "@ %a" lam l) largs
+      in
+      let print_unboxed ppf = function
+        | None -> ()
+        | Some (params, res) ->
+            fprintf ppf "[(%s)->%s]"
+              (String.concat "," (List.map value_kind params))
+              (value_kind res)
+      in
+      fprintf ppf "@[<2>(apply*@ %s%a %a)@]"
+        label print_unboxed unboxed lams args
   | Ugeneric_apply(lfun, largs, _) ->
       let lams ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in

--- a/asmcomp/printclambda.ml
+++ b/asmcomp/printclambda.ml
@@ -50,10 +50,13 @@ let rec structured_constant ppf = function
   | Uconst_string s -> fprintf ppf "%S" s
   | Uconst_closure(clos, sym, fv) ->
       let idents ppf =
-        List.iter (fprintf ppf "@ %a" Ident.print)in
+        List.iter
+          (fun (p, ty) -> fprintf ppf "@ %a%s" Ident.print p (value_kind ty))
+      in
       let one_fun ppf f =
-        fprintf ppf "(fun@ %s@ %d@ @[<2>%a@]@ @[<2>%a@])"
-          f.label f.arity idents f.params lam f.body in
+        let (body, ty) = f.body in
+        fprintf ppf "(fun@ %s%s@ %d@ @[<2>%a@]@ @[<2>%a@])"
+          f.label (value_kind ty) f.arity idents f.params lam body in
       let funs ppf =
         List.iter (fprintf ppf "@ %a" one_fun) in
       let sconsts ppf scl =
@@ -82,10 +85,13 @@ and lam ppf = function
       fprintf ppf "@[<2>(apply@ %a%a)@]" lam lfun lams largs
   | Uclosure(clos, fv) ->
       let idents ppf =
-        List.iter (fprintf ppf "@ %a" Ident.print)in
+        List.iter
+          (fun (p, ty) -> fprintf ppf "@ %a%s" Ident.print p (value_kind ty))
+      in
       let one_fun ppf f =
-        fprintf ppf "@[<2>(fun@ %s@ %d @[<2>%a@]@ @[<2>%a@]@])"
-          f.label f.arity idents f.params lam f.body in
+        let (body, ty) = f.body in
+        fprintf ppf "(fun@ %s%s@ %d@ @[<2>%a@]@ @[<2>%a@])"
+          f.label (value_kind ty) f.arity idents f.params lam body in
       let funs ppf =
         List.iter (fprintf ppf "@ %a" one_fun) in
       let lams ppf =

--- a/asmcomp/printclambda.ml
+++ b/asmcomp/printclambda.ml
@@ -32,6 +32,10 @@ let value_kind =
   | Pboxedintval Pint32 -> ":int32"
   | Pboxedintval Pint64 -> ":int64"
 
+let funarg ppf {Lambda.arg_kind; arg_unbox} =
+  fprintf ppf "%s%s" (value_kind arg_kind)
+    (if arg_unbox then "(unbox)" else "")
+
 let rec structured_constant ppf = function
   | Uconst_float x -> fprintf ppf "%F" x
   | Uconst_int32 x -> fprintf ppf "%ldl" x
@@ -51,12 +55,12 @@ let rec structured_constant ppf = function
   | Uconst_closure(clos, sym, fv) ->
       let idents ppf =
         List.iter
-          (fun (p, ty) -> fprintf ppf "@ %a%s" Ident.print p (value_kind ty))
+          (fun (p, ty) -> fprintf ppf "@ %a%a" Ident.print p funarg ty)
       in
       let one_fun ppf f =
         let (body, ty) = f.body in
-        fprintf ppf "(fun@ %s%s@ %d@ @[<2>%a@]@ @[<2>%a@])"
-          f.label (value_kind ty) f.arity idents f.params lam body in
+        fprintf ppf "(fun@ %s%a@ %d@ @[<2>%a@]@ @[<2>%a@])"
+          f.label funarg ty f.arity idents f.params lam body in
       let funs ppf =
         List.iter (fprintf ppf "@ %a" one_fun) in
       let sconsts ppf scl =
@@ -95,12 +99,12 @@ and lam ppf = function
   | Uclosure(clos, fv) ->
       let idents ppf =
         List.iter
-          (fun (p, ty) -> fprintf ppf "@ %a%s" Ident.print p (value_kind ty))
+          (fun (p, ty) -> fprintf ppf "@ %a%a" Ident.print p funarg ty)
       in
       let one_fun ppf f =
         let (body, ty) = f.body in
-        fprintf ppf "(fun@ %s%s@ %d@ @[<2>%a@]@ @[<2>%a@])"
-          f.label (value_kind ty) f.arity idents f.params lam body in
+        fprintf ppf "(fun@ %s%a@ %d@ @[<2>%a@]@ @[<2>%a@])"
+          f.label funarg ty f.arity idents f.params lam body in
       let funs ppf =
         List.iter (fprintf ppf "@ %a" one_fun) in
       let lams ppf =

--- a/asmcomp/un_anf.ml
+++ b/asmcomp/un_anf.ml
@@ -40,7 +40,7 @@ let ignore_primitive (_ : Lambda.primitive) = ()
 let ignore_string (_ : string) = ()
 let ignore_int_array (_ : int array) = ()
 let ignore_ident_list (_ : Ident.t list) = ()
-let ignore_params (_ : (Ident.t * Lambda.value_kind) list) = ()
+let ignore_params (_ : (Ident.t * Lambda.lfunarg) list) = ()
 let ignore_direction_flag (_ : Asttypes.direction_flag) = ()
 let ignore_meth_kind (_ : Lambda.meth_kind) = ()
 
@@ -88,8 +88,9 @@ let make_ident_info (clam : Clambda.ulambda) : ident_info =
       ignore_debuginfo dbg
     | Uclosure (functions, captured_variables) ->
       List.iter loop captured_variables;
-      List.iter (fun (
-        { Clambda. label; arity; params; body; dbg; env; } as clos) ->
+      List.iter
+        (fun ({ Clambda. label; unboxed = _; arity;
+                params; body; dbg; env; } as clos) ->
           (match closure_environment_ident clos with
            | None -> ()
            | Some env_var ->
@@ -258,7 +259,8 @@ let let_bound_vars_that_can_be_moved ident_info (clam : Clambda.ulambda) =
     | Uclosure (functions, captured_variables) ->
       ignore_ulambda_list captured_variables;
       (* Start a new let stack for speed. *)
-      List.iter (fun { Clambda. label; arity; params; body; dbg; env; } ->
+      List.iter
+        (fun { Clambda. label; unboxed = _; arity; params; body; dbg; env; } ->
           ignore_function_label label;
           ignore_int arity;
           ignore_params params;

--- a/asmcomp/un_anf.ml
+++ b/asmcomp/un_anf.ml
@@ -78,7 +78,7 @@ let make_ident_info (clam : Clambda.ulambda) : ident_info =
          of the closures will be traversed when this function is called from
          [Cmmgen.transl_function].) *)
       ignore_uconstant const
-    | Udirect_apply (label, args, dbg) ->
+    | Udirect_apply {label; args; dbg; unboxed = _} ->
       ignore_function_label label;
       List.iter loop args;
       ignore_debuginfo dbg
@@ -245,7 +245,7 @@ let let_bound_vars_that_can_be_moved ident_info (clam : Clambda.ulambda) =
       end
     | Uconst const ->
       ignore_uconstant const
-    | Udirect_apply (label, args, dbg) ->
+    | Udirect_apply {label; args; dbg; unboxed = _} ->
       ignore_function_label label;
       examine_argument_list args;
       (* We don't currently traverse [args]; they should all be variables
@@ -411,9 +411,9 @@ let rec substitute_let_moveable is_let_moveable env (clam : Clambda.ulambda)
           Ident.print id
       end
   | Uconst _ -> clam
-  | Udirect_apply (label, args, dbg) ->
-    let args = substitute_let_moveable_list is_let_moveable env args in
-    Udirect_apply (label, args, dbg)
+  | Udirect_apply ap ->
+    let args = substitute_let_moveable_list is_let_moveable env ap.args in
+    Udirect_apply {ap with args}
   | Ugeneric_apply (func, args, dbg) ->
     let func = substitute_let_moveable is_let_moveable env func in
     let args = substitute_let_moveable_list is_let_moveable env args in
@@ -589,9 +589,9 @@ let rec un_anf_and_moveable ident_info env (clam : Clambda.ulambda)
   | Uconst _ ->
     (* Constant closures are rewritten separately. *)
     clam, Constant
-  | Udirect_apply (label, args, dbg) ->
-    let args = un_anf_list ident_info env args in
-    Udirect_apply (label, args, dbg), Fixed
+  | Udirect_apply ap ->
+    let args = un_anf_list ident_info env ap.args in
+    Udirect_apply {ap with args}, Fixed
   | Ugeneric_apply (func, args, dbg) ->
     let func = un_anf ident_info env func in
     let args = un_anf_list ident_info env args in

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -521,7 +521,7 @@ let rec comp_expr env exp sz cont =
       let lbl = new_label() in
       let fv = IdentSet.elements(free_variables exp) in
       let to_compile =
-        { params = params; body = body; label = lbl;
+        { params = List.map fst params; body = fst body; label = lbl;
           free_vars = fv; num_defs = 1; rec_vars = []; rec_pos = 0 } in
       Stack.push to_compile functions_to_compile;
       comp_args env (List.map (fun n -> Lvar n) fv) sz
@@ -543,7 +543,8 @@ let rec comp_expr env exp sz cont =
           | (_id, Lfunction{params; body}) :: rem ->
               let lbl = new_label() in
               let to_compile =
-                { params = params; body = body; label = lbl; free_vars = fv;
+                { params = List.map fst params; body = fst body; label = lbl;
+                  free_vars = fv;
                   num_defs = ndecl; rec_vars = rec_idents; rec_pos = pos} in
               Stack.push to_compile functions_to_compile;
               lbl :: comp_fun (pos + 1) rem

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -244,10 +244,16 @@ type lambda =
 
 and lfunction =
   { kind: function_kind;
-    params: (Ident.t * value_kind) list;
-    body: (lambda * value_kind);
+    params: (Ident.t * lfunarg) list;
+    body: (lambda * lfunarg);
     attr: function_attribute; (* specified with [@inline] attribute *)
     loc: Location.t; }
+
+and lfunarg =
+  {
+    arg_kind: value_kind;
+    arg_unbox: bool;
+  }
 
 and lambda_apply =
   { ap_func : lambda;
@@ -722,3 +728,6 @@ let merge_inline_attributes attr1 attr2 =
 
 let reset () =
   raise_count := 0
+
+let mk_arg ?(kind = Pgenval) ?(unbox = false) x =
+  x, {arg_kind = kind; arg_unbox = unbox}

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -264,10 +264,16 @@ type lambda =
 
 and lfunction =
   { kind: function_kind;
-    params: (Ident.t * value_kind) list;
-    body: (lambda * value_kind);
+    params: (Ident.t * lfunarg) list;
+    body: (lambda * lfunarg);
     attr: function_attribute; (* specified with [@inline] attribute *)
     loc : Location.t; }
+
+and lfunarg =
+  {
+    arg_kind: value_kind;
+    arg_unbox: bool;
+  }
 
 and lambda_apply =
   { ap_func : lambda;
@@ -375,3 +381,5 @@ val merge_inline_attributes
   -> inline_attribute option
 
 val reset: unit -> unit
+
+val mk_arg: ?kind:value_kind -> ?unbox:bool -> 'a -> 'a * lfunarg

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -264,8 +264,8 @@ type lambda =
 
 and lfunction =
   { kind: function_kind;
-    params: Ident.t list;
-    body: lambda;
+    params: (Ident.t * value_kind) list;
+    body: (lambda * value_kind);
     attr: function_attribute; (* specified with [@inline] attribute *)
     loc : Location.t; }
 

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -60,6 +60,10 @@ let value_kind = function
   | Pfloatval -> "[float]"
   | Pboxedintval bi -> Printf.sprintf "[%s]" (boxed_integer_name bi)
 
+let funarg ppf {arg_kind; arg_unbox} =
+  fprintf ppf "%s%s" (value_kind arg_kind)
+    (if arg_unbox then "(unbox)" else "")
+
 let field_kind = function
   | Pgenval -> "*"
   | Pintval -> "int"
@@ -480,9 +484,9 @@ let rec lam ppf = function
         | Curried ->
             List.iter
               (fun (param, ty) ->
-                 fprintf ppf "@ %a%s"
+                 fprintf ppf "@ %a%a"
                    Ident.print param
-                   (value_kind ty)
+                   funarg ty
               ) params
         | Tupled ->
             fprintf ppf " (";
@@ -490,14 +494,14 @@ let rec lam ppf = function
             List.iter
               (fun (param, ty) ->
                  if !first then first := false else fprintf ppf ",@ ";
-                 fprintf ppf "%a%s"
+                 fprintf ppf "%a%a"
                    Ident.print param
-                   (value_kind ty)
+                   funarg ty
               )
               params;
             fprintf ppf ")" in
-      fprintf ppf "@[<2>(function%s%a@ %a%a)@]"
-        (value_kind ty)
+      fprintf ppf "@[<2>(function%a%a@ %a%a)@]"
+        funarg ty
         pr_params params
         function_attribute attr lam  body
   | Llet(str, k, id, arg, body) ->

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -304,8 +304,9 @@ let simplify_exits lam =
 *)
 
 let beta_reduce params body args =
-  List.fold_left2 (fun l (param, ty) arg -> Llet(Strict, ty, param, arg, l))
-                  body params args
+  List.fold_left2
+    (fun l (param, p) arg -> Llet(Strict, p.arg_kind, param, arg, l))
+    body params args
 
 (* Simplification of lets *)
 
@@ -672,11 +673,16 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~body ~attr ~loc =
                Ident.add id (Lvar new_id) s)
             Ident.empty inner_params new_ids
         in
-        let body = Lambda.subst_lambda subst body, Pgenval in
+        let body = mk_arg (Lambda.subst_lambda subst body) in
         let inner_fun =
-          Lfunction { kind = Curried;
-                      params = List.map (fun id -> id, Pgenval) new_ids;
-                      body; attr; loc; }
+          Lfunction
+            {
+              kind = Curried;
+              params = List.map (fun id -> mk_arg id) new_ids;
+              body;
+              attr;
+              loc;
+            }
         in
         (wrapper_body, (inner_id, inner_fun))
   in

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -304,7 +304,7 @@ let simplify_exits lam =
 *)
 
 let beta_reduce params body args =
-  List.fold_left2 (fun l param arg -> Llet(Strict, Pgenval, param, arg, l))
+  List.fold_left2 (fun l (param, ty) arg -> Llet(Strict, ty, param, arg, l))
                   body params args
 
 (* Simplification of lets *)
@@ -360,11 +360,11 @@ let simplify_lets lam =
   | Lapply{ap_func = Lfunction{kind = Curried; params; body = (body, _)};
            ap_args = args}
     when optimize && List.length params = List.length args ->
-      count bv (beta_reduce (List.map fst params) body args)
+      count bv (beta_reduce params body args)
   | Lapply{ap_func = Lfunction{kind = Tupled; params; body = (body, _)};
            ap_args = [Lprim(Pmakeblock _, args, _)]}
     when optimize && List.length params = List.length args ->
-      count bv (beta_reduce (List.map fst params) body args)
+      count bv (beta_reduce params body args)
   | Lapply{ap_func = l1; ap_args = ll} ->
       count bv l1; List.iter (count bv) ll
   | Lfunction {body = (body, _)} ->
@@ -454,11 +454,11 @@ let simplify_lets lam =
   | Lapply{ap_func = Lfunction{kind = Curried; params; body = (body, _)};
            ap_args = args}
     when optimize && List.length params = List.length args ->
-      simplif (beta_reduce (List.map fst params) body args)
+      simplif (beta_reduce params body args)
   | Lapply{ap_func = Lfunction{kind = Tupled; params; body = (body, _)};
            ap_args = [Lprim(Pmakeblock _, args, _)]}
     when optimize && List.length params = List.length args ->
-      simplif (beta_reduce (List.map fst params) body args)
+      simplif (beta_reduce params body args)
   | Lapply ap -> Lapply {ap with ap_func = simplif ap.ap_func;
                                  ap_args = List.map simplif ap.ap_args}
   | Lfunction{kind; params; body = (l, ty); attr; loc} ->

--- a/bytecomp/simplif.mli
+++ b/bytecomp/simplif.mli
@@ -27,8 +27,8 @@ val simplify_lambda: string -> lambda -> lambda
 val split_default_wrapper
    : id:Ident.t
   -> kind:function_kind
-  -> params:(Ident.t * value_kind) list
-  -> body:(lambda * value_kind)
+  -> params:(Ident.t * lfunarg) list
+  -> body:(lambda * lfunarg)
   -> attr:function_attribute
   -> loc:Location.t
   -> (Ident.t * lambda) list

--- a/bytecomp/simplif.mli
+++ b/bytecomp/simplif.mli
@@ -27,8 +27,8 @@ val simplify_lambda: string -> lambda -> lambda
 val split_default_wrapper
    : id:Ident.t
   -> kind:function_kind
-  -> params:Ident.t list
-  -> body:lambda
+  -> params:(Ident.t * value_kind) list
+  -> body:(lambda * value_kind)
   -> attr:function_attribute
   -> loc:Location.t
   -> (Ident.t * lambda) list

--- a/bytecomp/translattribute.mli
+++ b/bytecomp/translattribute.mli
@@ -29,6 +29,12 @@ val add_inline_attribute
   -> Parsetree.attributes
   -> Lambda.lambda
 
+val add_function_attributes
+   : Lambda.lambda
+  -> Location.t
+  -> Parsetree.attributes
+  -> Lambda.lambda
+
 val get_inline_attribute
    : Parsetree.attributes
   -> Lambda.inline_attribute

--- a/bytecomp/translclass.ml
+++ b/bytecomp/translclass.ml
@@ -29,14 +29,14 @@ exception Error of Location.t * error
 let lfunction params body =
   if params = [] then body
   else
-    let params = List.map (fun id -> id, Pgenval) params in
+    let params = List.map (fun id -> mk_arg id) params in
     match body with
     | Lfunction {kind = Curried; params = params'; body = body'; attr; loc} ->
         Lfunction {kind = Curried; params = params @ params'; body = body'; attr;
                    loc}
     |  _ ->
         Lfunction {kind = Curried; params;
-                   body = (body, Pgenval);
+                   body = mk_arg body;
                    attr = default_function_attribute;
                    loc = Location.none}
 
@@ -176,13 +176,13 @@ let rec build_object_init cl_table obj params inh_init obj_init cl =
       (inh_init,
        let build params rem =
          let param = name_pattern "param" pat in
-         Lfunction {kind = Curried; params = (param, Pgenval)::params;
+         Lfunction {kind = Curried; params = mk_arg param :: params;
                     attr = default_function_attribute;
                     loc = pat.pat_loc;
                     body =
-                      Matching.for_function
-                        pat.pat_loc None (Lvar param) [pat, rem] partial,
-                      Pgenval
+                      mk_arg
+                        (Matching.for_function
+                           pat.pat_loc None (Lvar param) [pat, rem] partial)
                    }
        in
        begin match obj_init with
@@ -433,13 +433,17 @@ let rec transl_class_rebind obj_init cl vf =
       let path, obj_init = transl_class_rebind obj_init cl vf in
       let build params rem =
         let param = name_pattern "param" pat in
-        Lfunction {kind = Curried; params = (param, Pgenval)::params;
-                   attr = default_function_attribute;
-                   loc = pat.pat_loc;
-                   body =
-                     Matching.for_function
-                       pat.pat_loc None (Lvar param) [pat, rem] partial,
-                  Pgenval}
+        Lfunction
+          {
+            kind = Curried;
+            params = mk_arg param :: params;
+            attr = default_function_attribute;
+            loc = pat.pat_loc;
+            body =
+              mk_arg
+                (Matching.for_function
+                   pat.pat_loc None (Lvar param) [pat, rem] partial);
+          }
       in
       (path,
        match obj_init with
@@ -756,8 +760,8 @@ let transl_class ids cl_id pub_meths cl vflag =
     let cl_init = llets (Lfunction{kind = Curried;
                                    attr = default_function_attribute;
                                    loc = Location.none;
-                                   params = [cla, Pgenval];
-                                   body = (cl_init, Pgenval)}) in
+                                   params = [mk_arg cla];
+                                   body = mk_arg cl_init}) in
     Llet(Strict, Pgenval, class_init, cl_init, lam (free_variables cl_init))
   and lbody fv =
     if List.for_all (fun id -> not (IdentSet.mem id fv)) ids then
@@ -778,8 +782,8 @@ let transl_class ids cl_id pub_meths cl vflag =
           [lambda_unit; Lfunction{kind = Curried;
                                   attr = default_function_attribute;
                                   loc = Location.none;
-                                  params = [cla, Pgenval];
-                                  body = cl_init, Pgenval};
+                                  params = [mk_arg cla];
+                                  body = mk_arg cl_init};
            lambda_unit; lenvs],
          Location.none)
   in
@@ -831,10 +835,10 @@ let transl_class ids cl_id pub_meths cl vflag =
   in
   let lclass lam =
     Llet(Strict, Pgenval, class_init,
-         Lfunction{kind = Curried; params = [cla, Pgenval];
+         Lfunction{kind = Curried; params = [mk_arg cla];
                    attr = default_function_attribute;
                    loc = Location.none;
-                   body = def_ids cla cl_init, Pgenval}, lam)
+                   body = mk_arg (def_ids cla cl_init)}, lam)
   and lcache lam =
     if inh_keys = [] then Llet(Alias, Pgenval, cached, Lvar tables, lam) else
     Llet(Strict, Pgenval, cached,
@@ -854,8 +858,8 @@ let transl_class ids cl_id pub_meths cl vflag =
   and lclass_virt () =
     lset cached 0 (Lfunction{kind = Curried; attr = default_function_attribute;
                              loc = Location.none;
-                             params = [cla, Pgenval];
-                             body = def_ids cla cl_init, Pgenval})
+                             params = [mk_arg cla];
+                             body = mk_arg (def_ids cla cl_init)})
   in
   let lupdate_cache =
     if ids = [] then ldirect () else

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -1199,7 +1199,9 @@ and transl_apply ?(should_be_tailcall=false) ?(inlined = Default_inline)
 and transl_function env fun_type loc untuplify_fn repr partial param cases =
   let param_ty, res_ty =
     match Typeopt.is_function_type env fun_type with
-    | None -> assert false
+    | None ->
+        Format.printf "%a%a@." Location.print_loc loc Printtyp.raw_type_expr fun_type;
+        assert false
     | Some (t1, t2) -> t1, t2
   in
   match cases with

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -724,10 +724,6 @@ and transl_exp0 e =
             transl_function e.exp_env e.exp_type e.exp_loc !Clflags.native_code repr partial
               param pl)
       in
-      (* TODO: compute types for parameters/result *)
-      (*let params = List.map (fun id -> id, Pgenval) params in*)
-      (*let body = body, Pgenval in*)
-      (* XXX *)
       let attr = {
         default_function_attribute with
         inline = Translattribute.get_inline_attribute e.exp_attributes;

--- a/middle_end/closure_conversion_aux.ml
+++ b/middle_end/closure_conversion_aux.ml
@@ -105,9 +105,9 @@ module Function_decls = struct
       { let_rec_ident;
         closure_bound_var;
         kind;
-        params;
-        body;
-        free_idents_of_body = Lambda.free_variables body;
+        params = List.map fst params;
+        body = fst body;
+        free_idents_of_body = Lambda.free_variables (fst body);
         attr;
         loc;
       }

--- a/middle_end/closure_conversion_aux.mli
+++ b/middle_end/closure_conversion_aux.mli
@@ -56,8 +56,8 @@ module Function_decls : sig
        : let_rec_ident:Ident.t option
       -> closure_bound_var:Variable.t
       -> kind:Lambda.function_kind
-      -> params:Ident.t list
-      -> body:Lambda.lambda
+      -> params:(Ident.t * Lambda.value_kind) list
+      -> body:(Lambda.lambda * Lambda.value_kind)
       -> attr:Lambda.function_attribute
       -> loc:Location.t
       -> t

--- a/middle_end/closure_conversion_aux.mli
+++ b/middle_end/closure_conversion_aux.mli
@@ -56,8 +56,8 @@ module Function_decls : sig
        : let_rec_ident:Ident.t option
       -> closure_bound_var:Variable.t
       -> kind:Lambda.function_kind
-      -> params:(Ident.t * Lambda.value_kind) list
-      -> body:(Lambda.lambda * Lambda.value_kind)
+      -> params:(Ident.t * Lambda.lfunarg) list
+      -> body:(Lambda.lambda * Lambda.lfunarg)
       -> attr:Lambda.function_attribute
       -> loc:Location.t
       -> t

--- a/testsuite/tests/functors/functors.ml.reference
+++ b/testsuite/tests/functors/functors.ml.reference
@@ -4,26 +4,30 @@
        (module-defn(O) functors.ml(5):48-143
          (function X is_a_functor always_inline
            (let
-             (cow = (function x (apply (field 0 X) x))
-              sheep = (function x (+ 1 (apply cow x))))
+             (cow =
+                (function[int] x[int] (apply (field 0 X) x))
+              sheep =
+                (function[int] x[int] (+ 1 (apply cow x))))
              (makeblock 0 cow sheep))))
      F =
        (module-defn(F) functors.ml(10):145-256
          (function X Y is_a_functor always_inline
            (let
              (cow =
-                (function x
+                (function[int] x[int]
                   (apply (field 0 Y) (apply (field 0 X) x)))
-              sheep = (function x (+ 1 (apply cow x))))
+              sheep =
+                (function[int] x[int] (+ 1 (apply cow x))))
              (makeblock 0 cow sheep))))
      F1/1022 =
        (module-defn(F1/1022) functors.ml(24):380-496
          (function X Y is_a_functor always_inline
            (let
              (cow =
-                (function x
+                (function[int] x[int]
                   (apply (field 0 Y) (apply (field 0 X) x)))
-              sheep = (function x (+ 1 (apply cow x))))
+              sheep =
+                (function[int] x[int] (+ 1 (apply cow x))))
              (makeblock 0 sheep))))
      F2/1029 =
        (module-defn(F2/1029) functors.ml(29):498-648
@@ -32,9 +36,10 @@
              (X =a (makeblock 0 (field 1 X))
               Y =a (makeblock 0 (field 1 Y))
               cow =
-                (function x
+                (function[int] x[int]
                   (apply (field 0 Y) (apply (field 0 X) x)))
-              sheep = (function x (+ 1 (apply cow x))))
+              sheep =
+                (function[int] x[int] (+ 1 (apply cow x))))
              (makeblock 0 sheep))))
      M =
        (module-defn(M) functors.ml(34):650-834
@@ -44,11 +49,12 @@
                 (function X Y is_a_functor always_inline
                   (let
                     (cow =
-                       (function x
+                       (function[int] x[int]
                          (apply (field 0 Y)
                            (apply (field 0 X) x)))
                      sheep =
-                       (function x (+ 1 (apply cow x))))
+                       (function[int] x[int]
+                         (+ 1 (apply cow x))))
                     (makeblock 0 cow sheep)))))
            (makeblock 0
              (function funarg funarg is_a_functor stub

--- a/testsuite/tests/translprim/array_spec.ml.reference-flat
+++ b/testsuite/tests/translprim/array_spec.ml.reference-flat
@@ -5,7 +5,7 @@
      addr_a = (makearray[addr] "a" "b" "c"))
     (seq (array.length[int] int_a) (array.length[float] float_a)
       (array.length[addr] addr_a)
-      (function a (array.length[gen] a))
+      (function[int] a (array.length[gen] a))
       (array.get[int] int_a 0) (array.get[float] float_a 0)
       (array.get[addr] addr_a 0)
       (function a (array.get[gen] a 0))

--- a/testsuite/tests/translprim/comparison_table.ml.reference
+++ b/testsuite/tests/translprim/comparison_table.ml.reference
@@ -1,85 +1,118 @@
 (setglobal Comparison_table!
   (let
-    (gen_cmp = (function x y (caml_compare x y))
-     int_cmp = (function x y (caml_int_compare x y))
+    (gen_cmp =
+       (function[int] x y (caml_compare x y))
+     int_cmp =
+       (function[int] x[int] y[int]
+         (caml_int_compare x y))
      bool_cmp =
-       (function x y (caml_int_compare x y))
+       (function[int] x y (caml_int_compare x y))
      intlike_cmp =
-       (function x y (caml_int_compare x y))
+       (function[int] x y (caml_int_compare x y))
      float_cmp =
-       (function x y (caml_float_compare x y))
+       (function[int] x[float] y[float]
+         (caml_float_compare x y))
      string_cmp =
-       (function x y (caml_string_compare x y))
+       (function[int] x y (caml_string_compare x y))
      int32_cmp =
-       (function x y (caml_int32_compare x y))
+       (function[int] x[int32] y[int32]
+         (caml_int32_compare x y))
      int64_cmp =
-       (function x y (caml_int64_compare x y))
+       (function[int] x[int64] y[int64]
+         (caml_int64_compare x y))
      nativeint_cmp =
-       (function x y (caml_nativeint_compare x y))
+       (function[int] x[nativeint] y[nativeint]
+         (caml_nativeint_compare x y))
      gen_eq = (function x y (caml_equal x y))
-     int_eq = (function x y (== x y))
+     int_eq = (function x[int] y[int] (== x y))
      bool_eq = (function x y (== x y))
      intlike_eq = (function x y (== x y))
-     float_eq = (function x y (==. x y))
+     float_eq =
+       (function x[float] y[float] (==. x y))
      string_eq =
        (function x y (caml_string_equal x y))
-     int32_eq = (function x y (Int32.== x y))
-     int64_eq = (function x y (Int64.== x y))
+     int32_eq =
+       (function x[int32] y[int32] (Int32.== x y))
+     int64_eq =
+       (function x[int64] y[int64] (Int64.== x y))
      nativeint_eq =
-       (function x y (Nativeint.== x y))
+       (function x[nativeint] y[nativeint]
+         (Nativeint.== x y))
      gen_ne = (function x y (caml_notequal x y))
-     int_ne = (function x y (!= x y))
+     int_ne = (function x[int] y[int] (!= x y))
      bool_ne = (function x y (!= x y))
      intlike_ne = (function x y (!= x y))
-     float_ne = (function x y (!=. x y))
+     float_ne =
+       (function x[float] y[float] (!=. x y))
      string_ne =
        (function x y (caml_string_notequal x y))
-     int32_ne = (function x y (Int32.!= x y))
-     int64_ne = (function x y (Int64.!= x y))
+     int32_ne =
+       (function x[int32] y[int32] (Int32.!= x y))
+     int64_ne =
+       (function x[int64] y[int64] (Int64.!= x y))
      nativeint_ne =
-       (function x y (Nativeint.!= x y))
+       (function x[nativeint] y[nativeint]
+         (Nativeint.!= x y))
      gen_lt = (function x y (caml_lessthan x y))
-     int_lt = (function x y (< x y))
+     int_lt = (function x[int] y[int] (< x y))
      bool_lt = (function x y (< x y))
      intlike_lt = (function x y (< x y))
-     float_lt = (function x y (<. x y))
+     float_lt =
+       (function x[float] y[float] (<. x y))
      string_lt =
        (function x y (caml_string_lessthan x y))
-     int32_lt = (function x y (Int32.< x y))
-     int64_lt = (function x y (Int64.< x y))
-     nativeint_lt = (function x y (Nativeint.< x y))
+     int32_lt =
+       (function x[int32] y[int32] (Int32.< x y))
+     int64_lt =
+       (function x[int64] y[int64] (Int64.< x y))
+     nativeint_lt =
+       (function x[nativeint] y[nativeint]
+         (Nativeint.< x y))
      gen_gt = (function x y (caml_greaterthan x y))
-     int_gt = (function x y (> x y))
+     int_gt = (function x[int] y[int] (> x y))
      bool_gt = (function x y (> x y))
      intlike_gt = (function x y (> x y))
-     float_gt = (function x y (>. x y))
+     float_gt =
+       (function x[float] y[float] (>. x y))
      string_gt =
        (function x y (caml_string_greaterthan x y))
-     int32_gt = (function x y (Int32.> x y))
-     int64_gt = (function x y (Int64.> x y))
-     nativeint_gt = (function x y (Nativeint.> x y))
+     int32_gt =
+       (function x[int32] y[int32] (Int32.> x y))
+     int64_gt =
+       (function x[int64] y[int64] (Int64.> x y))
+     nativeint_gt =
+       (function x[nativeint] y[nativeint]
+         (Nativeint.> x y))
      gen_le = (function x y (caml_lessequal x y))
-     int_le = (function x y (<= x y))
+     int_le = (function x[int] y[int] (<= x y))
      bool_le = (function x y (<= x y))
      intlike_le = (function x y (<= x y))
-     float_le = (function x y (<=. x y))
+     float_le =
+       (function x[float] y[float] (<=. x y))
      string_le =
        (function x y (caml_string_lessequal x y))
-     int32_le = (function x y (Int32.<= x y))
-     int64_le = (function x y (Int64.<= x y))
+     int32_le =
+       (function x[int32] y[int32] (Int32.<= x y))
+     int64_le =
+       (function x[int64] y[int64] (Int64.<= x y))
      nativeint_le =
-       (function x y (Nativeint.<= x y))
+       (function x[nativeint] y[nativeint]
+         (Nativeint.<= x y))
      gen_ge = (function x y (caml_greaterequal x y))
-     int_ge = (function x y (>= x y))
+     int_ge = (function x[int] y[int] (>= x y))
      bool_ge = (function x y (>= x y))
      intlike_ge = (function x y (>= x y))
-     float_ge = (function x y (>=. x y))
+     float_ge =
+       (function x[float] y[float] (>=. x y))
      string_ge =
        (function x y (caml_string_greaterequal x y))
-     int32_ge = (function x y (Int32.>= x y))
-     int64_ge = (function x y (Int64.>= x y))
+     int32_ge =
+       (function x[int32] y[int32] (Int32.>= x y))
+     int64_ge =
+       (function x[int64] y[int64] (Int64.>= x y))
      nativeint_ge =
-       (function x y (Nativeint.>= x y))
+       (function x[nativeint] y[nativeint]
+         (Nativeint.>= x y))
      eta_gen_cmp =
        (function prim prim stub (caml_compare prim prim))
      eta_int_cmp =

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -39,8 +39,9 @@ let scrape_ty env ty =
 let scrape env ty =
   (scrape_ty env ty).desc
 
-let is_function_type env ty =
+let rec is_function_type env ty =
   match scrape env ty with
+  | Tpoly (ty, _) -> is_function_type env ty
   | Tarrow (_, lhs, rhs, _) -> Some (lhs, rhs)
   | _ -> None
 

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -45,6 +45,13 @@ let rec is_function_type env ty =
   | Tarrow (_, lhs, rhs, _) -> Some (lhs, rhs)
   | _ -> None
 
+let rec is_tuple_type env ty =
+  match scrape env ty with
+  | Tpoly (ty, _) -> is_tuple_type env ty
+  | Ttuple l -> Some l
+  | _ -> None
+
+
 let is_base_type env ty base_ty_path =
   match scrape env ty with
   | Tconstr(p, _, _) -> Path.same p base_ty_path

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -17,6 +17,8 @@
 
 val is_function_type :
       Env.t -> Types.type_expr -> (Types.type_expr * Types.type_expr) option
+val is_tuple_type :
+      Env.t -> Types.type_expr -> Types.type_expr list option
 val is_base_type : Env.t -> Types.type_expr -> Path.t -> bool
 
 val maybe_pointer_type : Env.t -> Types.type_expr


### PR DESCRIPTION
This is a very early WIP, inspired from https://caml.inria.fr/mantis/view.php?id=5894 .  For discussion only, for now.

Currently, ocamlopt will always use the boxed representation for floats (and boxed integers) across function calls. This can be a major cause of inefficiency for numerical code, and little can be done through manual optimization, except inlining everything and turning recursive functions into while loops.

This PR keeps track of an approximation of the type for function parameters and result, from the Typedtree and through lambda+clambda.  When a function takes or return a float, it will generate two cmm functions: one with the usual calling convention, the other taking/returning unboxed floats.  The unboxed version is used in case of a known direct call to the function (inserting boxing/unboxing on the call site, if needed).  

With this approach, no boxing should be caused by crossing function boundaries when using first-order and monomorphic code (without higher-order functions).   This would not avoid boxing for highly abstracted code, but at least this provides a way to write modular numerical code that doesn't allocate like crazy.

Contrary to MPR#5894; no effort is made to predict if using the unboxing calling convention will avoid any boxing or avoid adding more boxing.  This is coherent with the current treatment of let-binding (incl for references turned into mutable variables): whenever the bound value is tracked to be of type float, we use the unboxed binding scheme.

Currenlty, the function is compiled twice.  We could avoid that by considering the generic function to be a simple wrapper around the unboxed one.  This would reduce the code size.  There would be no need try to inline such wrapper, since inlining could only happen when calling a known function, and in that case one would call the unboxed version directly.  There would still be an extra function call, but I suspect this would not impact performance too much in practice, at least for performance-critical code (that would likely not use higher-order numerical functions anyway).

Currently this PR only deals with float, but extending the treatment to unboxed integers will be trivial.

I know that flambda guys had plans to deal with this topic at some point, but (i) I haven't heard about anything on this front recently; (ii) the work done here might be useful for flambda as well; (iii) not everyone is ready to jump to flambda; (iv) this PR is a rather low-hanging fruit.


TODO:

 - [ ] Extend to boxed integers.
 - [ ] Evaluate the cost of turning the "generic" function into a simple wrapper around the "unboxed" function (so as to contain increase in code size).
 - [ ] More realistic benchmarks.
 - [ ] Non-regression tests.