### PR TITLE
Fix for bytecode size computation with generic arrays

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -838,6 +838,10 @@ let rec expr_size env = function
       RHS_block (List.length args)
   | Uprim(Pmakearray(Pfloatarray, _), args, _) ->
       RHS_floatblock (List.length args)
+  | Uprim(Pmakearray(Pgenarray, _), _, _) ->
+     (* Pgenarray is excluded from recursive bindings by the
+        check in Translcore.check_recursive_lambda *)
+     RHS_nonrec
   | Uprim (Pduprecord ((Record_regular | Record_inlined _), sz), _, _) ->
       RHS_block sz
   | Uprim (Pduprecord (Record_unboxed _, _), _, _) ->

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -169,6 +169,10 @@ let rec size_of_lambda env = function
       RHS_block (List.length args)
   | Lprim (Pmakearray (Pfloatarray, _), args, _) ->
       RHS_floatblock (List.length args)
+  | Lprim (Pmakearray (Pgenarray, _), _, _) ->
+     (* Pgenarray is excluded from recursive bindings by the
+        check in Translcore.check_recursive_lambda *)
+      RHS_nonrec
   | Lprim (Pduprecord ((Record_regular | Record_inlined _), size), _, _) ->
       RHS_block size
   | Lprim (Pduprecord (Record_unboxed _, _), _, _) ->

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -169,7 +169,6 @@ let rec size_of_lambda env = function
       RHS_block (List.length args)
   | Lprim (Pmakearray (Pfloatarray, _), args, _) ->
       RHS_floatblock (List.length args)
-  | Lprim (Pmakearray (Pgenarray, _), _, _) -> assert false
   | Lprim (Pduprecord ((Record_regular | Record_inlined _), size), _, _) ->
       RHS_block size
   | Lprim (Pduprecord (Record_unboxed _, _), _, _) ->

--- a/testsuite/tests/letrec/generic_array.ml
+++ b/testsuite/tests/letrec/generic_array.ml
@@ -1,0 +1,1 @@
+let rec x = let y = [| |] in ();;

--- a/testsuite/tests/letrec/generic_array.ml
+++ b/testsuite/tests/letrec/generic_array.ml
@@ -1,1 +1,3 @@
 let rec x = let y = [| |] in ();;
+
+let rec x = let y = [| |] in y :: x;;


### PR DESCRIPTION
#995 fixed a bug in which the sizes of values allocated in nested `let rec` bindings were not properly computed, leading to segmentation faults when the generated code was run.

However, the more comprehensive size computation added in that PR exposed a problem with computing the sizes of generic array allocations in bytecode.  Here's the current behaviour in `trunk`:

```ocaml
# let rec x =  let y = [| |] in ();;
Characters 17-18:
  let rec x =  let y = [| |] in ();;
                       ^
Warning 26: unused variable y.
Fatal error: exception File "bytecomp/bytegen.ml", line 172, characters 47-53: Assertion failed
```

In 4.05.0 this problem doesn't appear, because the size computation code doesn't examine the rhs of the binding for `y`.

This PR brings the size computation code for bytecode into line with the [code for native compilation][native-code-size-comp] where generic arrays are involved, treating generic array creation as `nonrec`, i.e. a point through which a cycle doesn't pass.

[native-code-size-comp]: https://github.com/ocaml/ocaml/blob/e286dbd767095808428a7a7ca8bcda70db9fee8f/asmcomp/cmmgen.ml#L837-L855
