### PR TITLE
Tentative fix for MPR#7624

### DIFF
--- a/Changes
+++ b/Changes
@@ -202,7 +202,7 @@ Working version
   (Xavier Leroy, from a suggestion by Gerd Stolpmann)
 
 - MPR#7624: handle warning attributes placed on let bindings
-  (Xavier Clerc, report by dinosaure)
+  (Xavier Clerc, report by dinosaure, review by Alain Frisch)
 
 
 ### Other libraries:

--- a/Changes
+++ b/Changes
@@ -201,6 +201,9 @@ Working version
   of ocamlc and a run of ocamlopt.
   (Xavier Leroy, from a suggestion by Gerd Stolpmann)
 
+- MPR#7624: handle warning attributes placed on let bindings
+  (Xavier Clerc, report by dinosaure)
+
 
 ### Other libraries:
 

--- a/testsuite/tests/warnings/Makefile
+++ b/testsuite/tests/warnings/Makefile
@@ -19,6 +19,7 @@ FLAGS=-w A
 run-all:
 	@$(OCAMLC) $(FLAGS) -c deprecated_module.mli
 	@$(OCAMLC) $(FLAGS) -c module_without_cmx.mli
+	@$(OCAMLC) $(FLAGS) -c w32.mli
 	@$(OCAMLC) $(FLAGS) -c w60.mli
 	@for file in *.ml; do \
 	  printf " ... testing '$$file':"; \

--- a/testsuite/tests/warnings/w32.ml
+++ b/testsuite/tests/warnings/w32.ml
@@ -32,3 +32,16 @@ and[@warning "-39"] t x = x
 
 let[@warning "-39"] rec u x = x
 and v x = v x
+
+
+(* disabled then re-enabled warnings *)
+
+module M = struct
+  [@@@warning "-32"]
+  let f x = x
+  let[@warning "+32"] g x = x
+  let[@warning "+32"] h x = x
+  and i x = x
+  let j x = x
+  and[@warning "+32"] k x = x
+end

--- a/testsuite/tests/warnings/w32.ml
+++ b/testsuite/tests/warnings/w32.ml
@@ -5,3 +5,30 @@ let[@warning "-32"] f x = x
 let g x = x
 
 let h x = x
+
+
+(* multiple bindings *)
+
+let[@warning "-32"] i x = x
+and j x = x
+
+let k x = x
+and[@warning "-32"] l x = x
+
+let[@warning "-32"] m x = x
+and n x = x
+
+let o x = x
+and[@warning "-32"] p x = x
+
+
+(* recursive bindings *)
+
+let[@warning "-32"] rec q x = x
+and r x = x
+
+let[@warning "-32"] rec s x = x
+and[@warning "-39"] t x = x
+
+let[@warning "-39"] rec u x = x
+and v x = v x

--- a/testsuite/tests/warnings/w32.ml
+++ b/testsuite/tests/warnings/w32.ml
@@ -1,0 +1,7 @@
+(* from MPR#7624 *)
+
+let[@warning "-32"] f x = x
+
+let g x = x
+
+let h x = x

--- a/testsuite/tests/warnings/w32.mli
+++ b/testsuite/tests/warnings/w32.mli
@@ -1,3 +1,9 @@
 (* from MPR#7624 *)
 
 val g : 'a -> 'a
+
+
+(* multiple bindings *)
+val n : 'a -> 'a
+
+val o : 'a -> 'a

--- a/testsuite/tests/warnings/w32.mli
+++ b/testsuite/tests/warnings/w32.mli
@@ -1,0 +1,3 @@
+(* from MPR#7624 *)
+
+val g : 'a -> 'a

--- a/testsuite/tests/warnings/w32.reference
+++ b/testsuite/tests/warnings/w32.reference
@@ -1,2 +1,18 @@
+File "w32.ml", line 27, characters 24-25:
+Warning 39: unused rec flag.
+File "w32.ml", line 30, characters 24-25:
+Warning 39: unused rec flag.
 File "w32.ml", line 7, characters 4-5:
 Warning 32: unused value h.
+File "w32.ml", line 13, characters 4-5:
+Warning 32: unused value j.
+File "w32.ml", line 15, characters 4-5:
+Warning 32: unused value k.
+File "w32.ml", line 28, characters 4-5:
+Warning 32: unused value r.
+File "w32.ml", line 31, characters 20-21:
+Warning 32: unused value t.
+File "w32.ml", line 33, characters 24-25:
+Warning 32: unused value u.
+File "w32.ml", line 34, characters 4-5:
+Warning 32: unused value v.

--- a/testsuite/tests/warnings/w32.reference
+++ b/testsuite/tests/warnings/w32.reference
@@ -16,3 +16,11 @@ File "w32.ml", line 33, characters 24-25:
 Warning 32: unused value u.
 File "w32.ml", line 34, characters 4-5:
 Warning 32: unused value v.
+File "w32.ml", line 42, characters 22-23:
+Warning 32: unused value g.
+File "w32.ml", line 43, characters 22-23:
+Warning 32: unused value h.
+File "w32.ml", line 46, characters 22-23:
+Warning 32: unused value k.
+File "w32.ml", line 39, characters 0-174:
+Warning 60: unused module M.

--- a/testsuite/tests/warnings/w32.reference
+++ b/testsuite/tests/warnings/w32.reference
@@ -1,0 +1,2 @@
+File "w32.ml", line 7, characters 4-5:
+Warning 32: unused value h.

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4057,7 +4057,7 @@ and type_let ?(check = fun s -> Warnings.Unused_var s)
 
   let current_slot = ref None in
   let rec_needed = ref false in
-  let warn_unused =
+  let warn_about_unused_bindings =
     List.exists
       (fun attrs ->
          Builtin_attributes.warning_scope ~ppwarning:false attrs (fun () ->
@@ -4085,7 +4085,7 @@ and type_let ?(check = fun s -> Warnings.Unused_var s)
     List.map2
       (fun attrs pat ->
          Builtin_attributes.warning_scope ~ppwarning:false attrs (fun () ->
-           if not warn_unused then pat, None
+           if not warn_about_unused_bindings then pat, None
            else
              let some_used = ref false in
              (* has one of the identifier of this pattern been used? *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4058,8 +4058,12 @@ and type_let ?(check = fun s -> Warnings.Unused_var s)
   let current_slot = ref None in
   let rec_needed = ref false in
   let warn_unused =
-    Warnings.is_active (check "") || Warnings.is_active (check_strict "") ||
-    (is_recursive && (Warnings.is_active Warnings.Unused_rec_flag))
+    List.exists
+      (fun attrs ->
+         Builtin_attributes.warning_scope ~ppwarning:false attrs (fun () ->
+           Warnings.is_active (check "") || Warnings.is_active (check_strict "") ||
+           (is_recursive && (Warnings.is_active Warnings.Unused_rec_flag))))
+      attrs_list
   in
   let pat_slot_list =
     (* Algorithm to detect unused declarations in recursive bindings:


### PR DESCRIPTION
In `Typecore`, the `warn_unused` value now depends on the attributes
of the related pattern. It seems enough / safe, but review and comments
would be greatly appreciated.

[MPR #7624](https://caml.inria.fr/mantis/view.php?id=7624)