### PR TITLE
Fix MPR#7520

### DIFF
--- a/Changes
+++ b/Changes
@@ -54,6 +54,9 @@ Working version
   when using Flambda.
   (Pierre Chambart, review by Mark Shinwell and Leo White)
 
+- MPR#7520, GPR#1328: Odd behaviour of refutation cases with polymorphic variant
+  (Jacques Garrigue, report by Leo White)
+
 - MPR#7531, GPR#1162: Erroneous code transformation at partial applications
   (Mark Shinwell)
 

--- a/testsuite/tests/typing-gadts/pr7520.ml
+++ b/testsuite/tests/typing-gadts/pr7520.ml
@@ -1,0 +1,26 @@
+type ('a, 'b) eq = Refl : ('a, 'a) eq
+type empty = (int, string) eq;;
+[%%expect{|
+type ('a, 'b) eq = Refl : ('a, 'a) eq
+type empty = (int, string) eq
+|}]
+
+let f = function `Foo (_ : empty) -> .;;
+[%%expect{|
+val f : [< `Foo of empty ] -> 'a = <fun>
+|}]
+
+let f : [< `Foo of empty] -> int = function `Foo (_ : empty) -> .;;
+[%%expect{|
+val f : [< `Foo of empty ] -> int = <fun>
+|}]
+
+let f : [`Foo of empty] -> int = function `Foo (_ : empty) -> .;;
+[%%expect{|
+val f : [ `Foo of empty ] -> int = <fun>
+|}]
+
+let f : [< `Foo of empty] -> int = function `Foo (_ : empty) -> . | _ -> .;;
+[%%expect{|
+val f : [ `Foo of empty ] -> int = <fun>
+|}]

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1719,6 +1719,18 @@ module Conv = struct
     let constrs = Hashtbl.create 7 in
     let labels = Hashtbl.create 7 in
     let rec loop pat =
+      match pat.pat_extra with (* cf PR#7520 *)
+        (extra, _, _) :: extras ->
+          let pat = {pat with pat_extra = extras} in
+          begin match extra with
+            Tpat_constraint ctyp ->
+              let mapper = Untypeast.(default_mapper.typ default_mapper) in
+              mkpat (Ppat_constraint (loop pat, mapper ctyp))
+          | Tpat_open (_, lid, _) ->
+              mkpat (Ppat_open (lid, loop pat))
+          | _ -> loop pat
+          end
+      | [] ->
       match pat.pat_desc with
         Tpat_or (pa,pb,_) ->
           mkpat (Ppat_or (loop pa, loop pb))


### PR DESCRIPTION
Fix [MPR#7520](https://caml.inria.fr/mantis/view.php?id=7520) (Odd behaviour of refutation cases with polymorphic variants) by rebuilding type annotations (and local opens) in the reconstructed pattern.
Uses `Untypeast.default_mapper` for this.