### PR TITLE
[OCamlc] fixes output-complete-object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,6 +272,10 @@
 
 /testsuite/tests/opaque/*/*.mli
 
+/testsuite/tests/output_obj/*.bc.c
+/testsuite/tests/output_obj/*_stub
+/testsuite/tests/output_obj/*_stub
+
 /testsuite/tests/runtime-errors/*.bytecode
 
 /testsuite/tests/self-contained-toplevel/cached_cmi.ml

--- a/Changes
+++ b/Changes
@@ -180,6 +180,8 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- GPR##1332: fix ocamlc handling of "-output-complete-obj"
+
 - MPR#7444, GPR#1138: trigger deprecation warning when a "deprecated"
   attribute is hidden by signature coercion
   (Alain Frisch, report by bmillwood, review by Leo White)

--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,7 @@ utils/config.ml: utils/config.mlp config/Makefile
 	    -e 's|%%CC%%|$(CC)|' \
 	    -e 's|%%CCOMPTYPE%%|$(CCOMPTYPE)|' \
 	    -e 's|%%CC_PROFILE%%|$(CC_PROFILE)|' \
+	    -e 's|%%OUTPUTOBJ%%|$(OUTPUTOBJ)|' \
 	    -e 's|%%EXT_ASM%%|$(EXT_ASM)|' \
 	    -e 's|%%EXT_DLL%%|$(EXT_DLL)|' \
 	    -e 's|%%EXT_EXE%%|$(EXE)|' \

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -617,22 +617,27 @@ let link ppf objfiles output_name =
       raise x
   end else begin
     let basename = Filename.chop_extension output_name in
+    let temps = ref [] in
     let c_file =
-      if !Clflags.output_complete_object
+      if !Clflags.output_complete_object && not (Filename.check_suffix output_name ".c")
       then Filename.temp_file "camlobj" ".c"
-      else basename ^ ".c"
-    and obj_file =
+      else begin
+        let f = basename ^ ".c" in
+        if Sys.file_exists f then raise(Error(File_exists f));
+        f
+      end
+    in
+    let obj_file =
       if !Clflags.output_complete_object
-      then Filename.temp_file "camlobj" Config.ext_obj
+      then (Filename.chop_extension c_file) ^ Config.ext_obj
       else basename ^ Config.ext_obj
     in
-    if Sys.file_exists c_file then raise(Error(File_exists c_file));
-    let temps = ref [] in
     try
       link_bytecode_as_c ppf tolink c_file;
       if not (Filename.check_suffix output_name ".c") then begin
         temps := c_file :: !temps;
-        if Ccomp.compile_file c_file <> 0 then
+        (* -DCAML_INTERNALS because the .c use startup.h *)
+        if Ccomp.compile_file ~output:obj_file ~opt:"-DCAML_INTERNALS" c_file <> 0 then
           raise(Error Custom_runtime);
         if not (Filename.check_suffix output_name Config.ext_obj) ||
            !Clflags.output_complete_object then begin

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -451,7 +451,9 @@ let link_bytecode_as_c ppf tolink outfile =
   begin try
     (* The bytecode *)
     output_string outchan "\
-#ifdef __cplusplus\
+#define CAML_INTERNALS\
+\n\
+\n#ifdef __cplusplus\
 \nextern \"C\" {\
 \n#endif\
 \n#include <caml/mlvalues.h>\
@@ -636,8 +638,7 @@ let link ppf objfiles output_name =
       link_bytecode_as_c ppf tolink c_file;
       if not (Filename.check_suffix output_name ".c") then begin
         temps := c_file :: !temps;
-        (* -DCAML_INTERNALS because the .c use startup.h *)
-        if Ccomp.compile_file ~output:obj_file ~opt:"-DCAML_INTERNALS" c_file <> 0 then
+        if Ccomp.compile_file ~output:obj_file c_file <> 0 then
           raise(Error Custom_runtime);
         if not (Filename.check_suffix output_name Config.ext_obj) ||
            !Clflags.output_complete_object then begin

--- a/testsuite/tests/output_obj/Makefile
+++ b/testsuite/tests/output_obj/Makefile
@@ -20,16 +20,16 @@ compile:
 	@for file in *.ml; do \
 	  printf " ... testing native '$$file'"; \
 	  rm -f log; \
-	  ( $(OCAMLOPT) -w a -output-complete-obj -o $${file}.exe.o $${file} >> log 2>&1 && \
-	    $(CC) $(CFLAGS) $(CPPFLAGS) -I$(CTOPDIR)/byterun -o $${file}_stub $${file}.exe.o -lm -ldl $${file}_stub.c >> log 2>&1 && \
+	  ( $(OCAMLOPT) -w a -output-complete-obj -o $${file}.exe.$(O) $${file} >> log 2>&1 && \
+	    $(CC) $(CFLAGS) $(CPPFLAGS) -I$(CTOPDIR)/byterun -o $${file}_stub $${file}.exe.$(O) $(NATIVECCLIBS) $${file}_stub.c >> log 2>&1 && \
 	    ./$${file}_stub >> log 2>&1 && \
 	    echo " => passed") || (echo " => failed" && cat log) ; \
 	done
 	@for file in *.ml; do \
 	  printf " ... testing byte '$$file'"; \
           rm -f log; \
-	  ( $(OCAMLC) -ccopt "-I$(CTOPDIR)/byterun" -w a -output-complete-obj -o $${file}.bc.o $${file} >> log 2>&1 && \
-	    $(CC) $(CFLAGS) $(CPPFLAGS) -I$(CTOPDIR)/byterun -o $${file}_bc_stub $${file}.bc.o -lm -ldl -lcurses $${file}_stub.c >> log 2>&1 && \
+	  ( $(OCAMLC) -ccopt "-I$(CTOPDIR)/byterun" -w a -output-complete-obj -o $${file}.bc.$(O) $${file} >> log 2>&1 && \
+	    $(CC) $(CFLAGS) $(CPPFLAGS) -I$(CTOPDIR)/byterun -o $${file}_bc_stub $${file}.bc.$(O) $(BYTECCLIBS) $${file}_stub.c >> log 2>&1 && \
 	    ./$${file}_bc_stub >> log 2>&1 && \
 	    echo " => passed") || (echo " => failed" && cat log); \
 	done

--- a/testsuite/tests/output_obj/Makefile
+++ b/testsuite/tests/output_obj/Makefile
@@ -19,18 +19,22 @@ SHOULD_FAIL=
 compile:
 	@for file in *.ml; do \
 	  printf " ... testing native '$$file'"; \
-	  rm -f log; \
-	  ( $(OCAMLOPT) -w a -output-complete-obj -o $${file}.exe.$(O) $${file} >> log 2>&1 && \
-	    $(CC) $(CFLAGS) $(CPPFLAGS) -I$(CTOPDIR)/byterun -o $${file}_stub $${file}.exe.$(O) $(NATIVECCLIBS) $${file}_stub.c >> log 2>&1 && \
-	    ./$${file}_stub >> log 2>&1 && \
-	    echo " => passed") || (echo " => failed" && cat log) ; \
+         if $(BYTECODE_ONLY); then \
+	  echo " => skipped"; \
+	 else \
+	    rm -f log; \
+	    ( $(OCAMLOPT) -w a -output-complete-obj -o $${file}.exe.$(O) $${file} >> log 2>&1 && \
+	      $(MKEXE) -I$(CTOPDIR)/byterun $(OUTPUTEXE)$${file}_stub$(EXE) $${file}.exe.$(O) $(NATIVECCLIBS) $${file}_stub.c >> log 2>&1 && \
+	      ./$${file}_stub$(EXE) >> log 2>&1 && \
+	      echo " => passed") || (echo " => failed" && cat log) ; \
+	 fi \
 	done
 	@for file in *.ml; do \
 	  printf " ... testing byte '$$file'"; \
           rm -f log; \
 	  ( $(OCAMLC) -ccopt "-I$(CTOPDIR)/byterun" -w a -output-complete-obj -o $${file}.bc.$(O) $${file} >> log 2>&1 && \
-	    $(CC) $(CFLAGS) $(CPPFLAGS) -I$(CTOPDIR)/byterun -o $${file}_bc_stub $${file}.bc.$(O) $(BYTECCLIBS) $${file}_stub.c >> log 2>&1 && \
-	    ./$${file}_bc_stub >> log 2>&1 && \
+	    $(MKEXE) -I$(CTOPDIR)/byterun $(OUTPUTEXE)$${file}_bc_stub$(EXE) $${file}.bc.$(O) $(BYTECCLIBS) $${file}_stub.c >> log 2>&1 && \
+	    ./$${file}_bc_stub$(EXE) >> log 2>&1 && \
 	    echo " => passed") || (echo " => failed" && cat log); \
 	done
 	@rm -f log

--- a/testsuite/tests/output_obj/Makefile
+++ b/testsuite/tests/output_obj/Makefile
@@ -1,0 +1,40 @@
+#**************************************************************************
+#*                                                                        *
+#*                                OCaml                                   *
+#*                                                                        *
+#*                 Xavier Clerc, SED, INRIA Rocquencourt                  *
+#*                                                                        *
+#*   Copyright 2010 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+BASEDIR=../..
+SHOULD_FAIL=
+
+compile:
+	@for file in *.ml; do \
+	  printf " ... testing native '$$file'"; \
+	  ( $(OCAMLOPT) -w a -output-complete-obj -o $${file}.exe.o $${file} 2>/dev/null && \
+	    $(CC) $(CFLAGS) $(CPPFLAGS) -I$(CTOPDIR)/byterun -o $${file}_stub $${file}.exe.o -lm -ldl $${file}_stub.c 2>/dev/null && \
+	    ./$${file}_stub 1>/dev/null 2>/dev/null && \
+	    echo " => passed" ) || echo " => failed"; \
+	done
+	@for file in *.ml; do \
+	  printf " ... testing byte '$$file'"; \
+	  ( $(OCAMLC) -ccopt "-I$(CTOPDIR)/byterun" -w a -output-complete-obj -o $${file}.bc.o $${file} 2>/dev/null && \
+	    $(CC) $(CFLAGS) $(CPPFLAGS) -I$(CTOPDIR)/byterun -o $${file}_bc_stub $${file}.bc.o -lm -ldl -lcurses $${file}_stub.c 2>/dev/null && \
+	    ./$${file}_bc_stub 1>/dev/null 2>/dev/null && \
+	    echo " => passed" ) || echo " => failed"; \
+	done
+
+promote:
+
+clean: defaultclean
+	@rm -f ./a.out
+
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/output_obj/Makefile
+++ b/testsuite/tests/output_obj/Makefile
@@ -22,7 +22,7 @@ compile:
          if $(BYTECODE_ONLY); then \
 	  echo " => skipped"; \
 	 else \
-	    rm -f log; \
+	    rm -f log $${file}.exe.$(O) $${file}_stub$(EXE); \
 	    ( $(OCAMLOPT) -w a -output-complete-obj -o $${file}.exe.$(O) $${file} >> log 2>&1 && \
 	      $(MKEXE) -I$(CTOPDIR)/byterun $(OUTPUTEXE)$${file}_stub$(EXE) $${file}.exe.$(O) $(NATIVECCLIBS) $${file}_stub.c >> log 2>&1 && \
 	      ./$${file}_stub$(EXE) >> log 2>&1 && \
@@ -31,7 +31,7 @@ compile:
 	done
 	@for file in *.ml; do \
 	  printf " ... testing byte '$$file'"; \
-          rm -f log; \
+          rm -f log $${file}.bc.$(O) $${file}_bc_stub$(EXE); \
 	  ( $(OCAMLC) -ccopt "-I$(CTOPDIR)/byterun" -w a -output-complete-obj -o $${file}.bc.$(O) $${file} >> log 2>&1 && \
 	    $(MKEXE) -I$(CTOPDIR)/byterun $(OUTPUTEXE)$${file}_bc_stub$(EXE) $${file}.bc.$(O) $(BYTECCLIBS) $${file}_stub.c >> log 2>&1 && \
 	    ./$${file}_bc_stub$(EXE) >> log 2>&1 && \

--- a/testsuite/tests/output_obj/Makefile
+++ b/testsuite/tests/output_obj/Makefile
@@ -19,18 +19,21 @@ SHOULD_FAIL=
 compile:
 	@for file in *.ml; do \
 	  printf " ... testing native '$$file'"; \
-	  ( $(OCAMLOPT) -w a -output-complete-obj -o $${file}.exe.o $${file} 2>/dev/null && \
-	    $(CC) $(CFLAGS) $(CPPFLAGS) -I$(CTOPDIR)/byterun -o $${file}_stub $${file}.exe.o -lm -ldl $${file}_stub.c 2>/dev/null && \
-	    ./$${file}_stub 1>/dev/null 2>/dev/null && \
-	    echo " => passed" ) || echo " => failed"; \
+	  rm -f log; \
+	  ( $(OCAMLOPT) -w a -output-complete-obj -o $${file}.exe.o $${file} >> log 2>&1 && \
+	    $(CC) $(CFLAGS) $(CPPFLAGS) -I$(CTOPDIR)/byterun -o $${file}_stub $${file}.exe.o -lm -ldl $${file}_stub.c >> log 2>&1 && \
+	    ./$${file}_stub >> log 2>&1 && \
+	    echo " => passed") || (echo " => failed" && cat log) ; \
 	done
 	@for file in *.ml; do \
 	  printf " ... testing byte '$$file'"; \
-	  ( $(OCAMLC) -ccopt "-I$(CTOPDIR)/byterun" -w a -output-complete-obj -o $${file}.bc.o $${file} 2>/dev/null && \
-	    $(CC) $(CFLAGS) $(CPPFLAGS) -I$(CTOPDIR)/byterun -o $${file}_bc_stub $${file}.bc.o -lm -ldl -lcurses $${file}_stub.c 2>/dev/null && \
-	    ./$${file}_bc_stub 1>/dev/null 2>/dev/null && \
-	    echo " => passed" ) || echo " => failed"; \
+          rm -f log; \
+	  ( $(OCAMLC) -ccopt "-I$(CTOPDIR)/byterun" -w a -output-complete-obj -o $${file}.bc.o $${file} >> log 2>&1 && \
+	    $(CC) $(CFLAGS) $(CPPFLAGS) -I$(CTOPDIR)/byterun -o $${file}_bc_stub $${file}.bc.o -lm -ldl -lcurses $${file}_stub.c >> log 2>&1 && \
+	    ./$${file}_bc_stub >> log 2>&1 && \
+	    echo " => passed") || (echo " => failed" && cat log); \
 	done
+	@rm -f log
 
 promote:
 

--- a/testsuite/tests/output_obj/test.ml
+++ b/testsuite/tests/output_obj/test.ml
@@ -1,0 +1,1 @@
+let () = Printf.printf "Test!!\n%!"

--- a/testsuite/tests/output_obj/test.ml_stub.c
+++ b/testsuite/tests/output_obj/test.ml_stub.c
@@ -1,0 +1,10 @@
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include <caml/callback.h>
+#include <caml/memory.h>
+
+int main(int argc, char ** argv){
+
+  caml_startup(argv);
+  return 0;
+}

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -87,7 +87,7 @@ let compile_file ?output ?(opt="") name =
                   then (Config.ocamlopt_cflags, Config.ocamlopt_cppflags)
                   else (Config.ocamlc_cflags, Config.ocamlc_cppflags) in
               (String.concat " " [Config.c_compiler; cflags; cppflags]))
-         (match output with | None -> "" | Some o -> "-o " ^ o)
+         (match output with | None -> "" | Some o -> Printf.sprintf "%s %s" Config.c_output_obj o)
          opt
          (if !Clflags.debug && Config.ccomp_type <> "msvc" then "-g" else "")
          (String.concat " " (List.rev !Clflags.all_ccopts))

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -64,7 +64,7 @@ let display_msvc_output file name =
     close_in c;
     Sys.remove file
 
-let compile_file name =
+let compile_file ?output ?(opt="") name =
   let (pipe, file) =
     if Config.ccomp_type = "msvc" && not !Clflags.verbose then
       try
@@ -78,7 +78,7 @@ let compile_file name =
   let exit =
     command
       (Printf.sprintf
-         "%s -c %s %s %s %s %s%s"
+         "%s %s %s -c %s %s %s %s %s%s"
          (match !Clflags.c_compiler with
           | Some cc -> cc
           | None ->
@@ -87,6 +87,8 @@ let compile_file name =
                   then (Config.ocamlopt_cflags, Config.ocamlopt_cppflags)
                   else (Config.ocamlc_cflags, Config.ocamlc_cppflags) in
               (String.concat " " [Config.c_compiler; cflags; cppflags]))
+         (match output with | None -> "" | Some o -> "-o " ^ o)
+         opt
          (if !Clflags.debug && Config.ccomp_type <> "msvc" then "-g" else "")
          (String.concat " " (List.rev !Clflags.all_ccopts))
          (quote_prefixed "-I" (List.rev !Clflags.include_dirs))

--- a/utils/ccomp.mli
+++ b/utils/ccomp.mli
@@ -17,7 +17,7 @@
 
 val command: string -> int
 val run_command: string -> unit
-val compile_file: string -> int
+val compile_file: ?output:string -> ?opt:string -> string -> int
 val create_archive: string -> string list -> int
 val expand_libname: string -> string
 val quote_files: string list -> string

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -28,6 +28,8 @@ val ccomp_type: string
                "msvc" (for Microsoft Visual C++ and MASM) *)
 val c_compiler: string
         (* The compiler to use for compiling C files *)
+val c_output_obj: string
+        (* Name of the option of the C compiler for specifying the output file *)
 val ocamlc_cflags : string
         (* The flags ocamlc should pass to the C compiler *)
 val ocamlc_cppflags : string

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -31,6 +31,7 @@ let standard_library =
 let standard_runtime = "%%BYTERUN%%"
 let ccomp_type = "%%CCOMPTYPE%%"
 let c_compiler = "%%CC%%"
+let c_output_obj = "%%OUTPUTOBJ%%"
 let ocamlc_cflags = "%%OCAMLC_CFLAGS%%"
 let ocamlc_cppflags = "%%OCAMLC_CPPFLAGS%%"
 let ocamlopt_cflags = "%%OCAMLOPT_CFLAGS%%"


### PR DESCRIPTION
  When trying to add support for `--output-complete-obj` for jbuilder [janestreet/jbuilder#23], I was not able to make `--output-complete-obj` work in bytecode mode.  `ocamlc` complains that the temporary files it just created exist. This PR fixes this option and add tests for it.

The support for `--output-complete-obj` has been added in ed60dece81575305b5f1f7394cdda652b65b037a and 19d3bccf48fee6e5e91e65e9f8a5d07c49d2afd4