### PR TITLE
Turn off warning 40 by default

### DIFF
--- a/Changes
+++ b/Changes
@@ -219,6 +219,8 @@ Working version
 - MPR#7624: handle warning attributes placed on let bindings
   (Xavier Clerc, report by dinosaure, review by Alain Frisch)
 
+- GPR#1333: turn off warning 40 by default
+  (Leo White)
 
 ### Other libraries:
 

--- a/man/ocamlc.m
+++ b/man/ocamlc.m
@@ -986,7 +986,7 @@ mentioned here corresponds to the empty set.
 
 .IP
 The default setting is
-.BR \-w\ +a\-4\-6\-7\-9\-27\-29\-32..39\-40\-41\-42\-44\-45\-48\-50\-60 .
+.BR \-w\ +a\-4\-6\-7\-9\-27\-29\-32..42\-44\-45\-48\-50\-60 .
 Note that warnings
 .BR 5 \ and \ 10
 are not always triggered, depending on the internals of the type checker.

--- a/man/ocamlc.m
+++ b/man/ocamlc.m
@@ -986,7 +986,7 @@ mentioned here corresponds to the empty set.
 
 .IP
 The default setting is
-.BR \-w\ +a\-4\-6\-7\-9\-27\-29\-32..39\-41\-42\-44\-45\-48\-50\-60 .
+.BR \-w\ +a\-4\-6\-7\-9\-27\-29\-32..39\-40\-41\-42\-44\-45\-48\-50\-60 .
 Note that warnings
 .BR 5 \ and \ 10
 are not always triggered, depending on the internals of the type checker.

--- a/manual/manual/cmds/unified-options.etex
+++ b/manual/manual/cmds/unified-options.etex
@@ -745,7 +745,7 @@ that are currently defined are ignored. The warnings are as follows.
 \input{warnings-help.tex}
 \end{options}
 
-The default setting is "-w +a-4-6-7-9-27-29-32..39-40-41..42-44-45-48-50-60".
+The default setting is "-w +a-4-6-7-9-27-29-32..42-44-45-48-50-60".
 It is displayed by {\machine\ocamlx\ -help}.
 Note that warnings 5 and 10 are not always triggered, depending on
 the internals of the type checker.

--- a/manual/manual/cmds/unified-options.etex
+++ b/manual/manual/cmds/unified-options.etex
@@ -745,7 +745,7 @@ that are currently defined are ignored. The warnings are as follows.
 \input{warnings-help.tex}
 \end{options}
 
-The default setting is "-w +a-4-6-7-9-27-29-32..39-41..42-44-45-48-50".
+The default setting is "-w +a-4-6-7-9-27-29-32..39-40-41..42-44-45-48-50-60".
 It is displayed by {\machine\ocamlx\ -help}.
 Note that warnings 5 and 10 are not always triggered, depending on
 the internals of the type checker.

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -297,7 +297,7 @@ let parse_options errflag s =
   current := {error; active}
 
 (* If you change these, don't forget to change them in man/ocamlc.m *)
-let defaults_w = "+a-4-6-7-9-27-29-32..39-40-41..42-44-45-48-50-60";;
+let defaults_w = "+a-4-6-7-9-27-29-32..42-44-45-48-50-60";;
 let defaults_warn_error = "-a+31";;
 
 let () = parse_options false defaults_w;;

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -297,7 +297,7 @@ let parse_options errflag s =
   current := {error; active}
 
 (* If you change these, don't forget to change them in man/ocamlc.m *)
-let defaults_w = "+a-4-6-7-9-27-29-32..39-41..42-44-45-48-50-60";;
+let defaults_w = "+a-4-6-7-9-27-29-32..39-40-41..42-44-45-48-50-60";;
 let defaults_warn_error = "-a+31";;
 
 let () = parse_options false defaults_w;;


### PR DESCRIPTION
Warning 40 was added due to my concerns about record/constructor disambiguation confusing people when the feature was created. At this point it seems pretty clear that in practice people don't find the mix of lexical scoping and type-based lookup that confusing, and in particular the benefits of turning off warning 40 outweigh the costs.

Most OCaml users seem to turn this warning off. Indeed it is the only difference between the default warnings of jbuilder and the default warnings of the compiler. Also libraries like Base rely on warning 40 being disabled for some of their interfaces.

As such it seems like a good idea to disable this warning by default. Since I was the only person arguing for its inclusion in the first place I don't expect there to be much resistance to the change :-).