### PR TITLE
In Sys.getcwd, don't call getwd if HAS_GETWD is not set (follow-up to #1086)

### DIFF
--- a/Changes
+++ b/Changes
@@ -609,6 +609,9 @@ Release branch for 4.06:
 - GPR#1073: Remove statically allocated compare stack.
   (Stephen Dolan)
 
+- GPR#1086: in Sys.getcwd, don't call getwd() if HAS_GETWD is not set
+  (report and first fix by Sebastian Markbåge, final fix by Xavier Leroy)
+
 - GPR#1269: Remove 50ms delay at exit for programs using threads
   (Valentin Gatien-Baron, review by Stephen Dolan)
 

--- a/Changes
+++ b/Changes
@@ -609,8 +609,10 @@ Release branch for 4.06:
 - GPR#1073: Remove statically allocated compare stack.
   (Stephen Dolan)
 
-- GPR#1086: in Sys.getcwd, don't call getwd() if HAS_GETWD is not set
-  (report and first fix by Sebastian Markbåge, final fix by Xavier Leroy)
+- GPR#1086: in Sys.getcwd, just fail instead of calling getwd() 
+  if HAS_GETCWD is not set.
+  (Report and first fix by Sebastian Markbåge, final fix by Xavier Leroy,
+   review by MarK Shinwell)
 
 - GPR#1269: Remove 50ms delay at exit for programs using threads
   (Valentin Gatien-Baron, review by Stephen Dolan)

--- a/asmrun/spacetime.c
+++ b/asmrun/spacetime.c
@@ -217,7 +217,7 @@ void caml_spacetime_initialize(void)
     sscanf(ap_interval, "%u", &interval);
     if (interval != 0) {
       double time;
-      char cwd[4096];
+      char* cwd;
       char* user_specified_automatic_snapshot_dir;
       int dir_ok = 1;
 
@@ -225,17 +225,29 @@ void caml_spacetime_initialize(void)
         caml_secure_getenv("OCAML_SPACETIME_SNAPSHOT_DIR");
 
       if (user_specified_automatic_snapshot_dir == NULL) {
-#ifdef HAS_GETCWD
-        if (getcwd(cwd, sizeof(cwd)) == NULL) {
+#if defined(HAS_GETCWD)
+        cwd = (char*) malloc(PATH_MAX);
+        if (cwd == NULL) {
+          fprintf(stderr, "Out of memory for [getcwd]\n");
+          abort();
+        }
+        if (getcwd(cwd, PATH_MAX) == NULL) {
           dir_ok = 0;
         }
-#else
+#elif defined(HAS_GETWD)
+        cwd = (char*) malloc(PATH_MAX);
+        if (cwd == NULL) {
+          fprintf(stderr, "Out of memory for [getwd]\n");
+          abort();
+        }
         if (getwd(cwd) == NULL) {
           dir_ok = 0;
         }
+#else
+        dir_ok = 0;
 #endif
         if (dir_ok) {
-          automatic_snapshot_dir = strdup(cwd);
+          automatic_snapshot_dir = cwd;
         }
       }
       else {

--- a/asmrun/spacetime.c
+++ b/asmrun/spacetime.c
@@ -234,15 +234,6 @@ void caml_spacetime_initialize(void)
         if (getcwd(cwd, PATH_MAX) == NULL) {
           dir_ok = 0;
         }
-#elif defined(HAS_GETWD)
-        cwd = (char*) malloc(PATH_MAX);
-        if (cwd == NULL) {
-          fprintf(stderr, "Out of memory for [getwd]\n");
-          abort();
-        }
-        if (getwd(cwd) == NULL) {
-          dir_ok = 0;
-        }
 #else
         dir_ok = 0;
 #endif

--- a/asmrun/spacetime.c
+++ b/asmrun/spacetime.c
@@ -217,7 +217,7 @@ void caml_spacetime_initialize(void)
     sscanf(ap_interval, "%u", &interval);
     if (interval != 0) {
       double time;
-      char* cwd;
+      char cwd[4096];
       char* user_specified_automatic_snapshot_dir;
       int dir_ok = 1;
 
@@ -226,12 +226,7 @@ void caml_spacetime_initialize(void)
 
       if (user_specified_automatic_snapshot_dir == NULL) {
 #if defined(HAS_GETCWD)
-        cwd = (char*) malloc(PATH_MAX);
-        if (cwd == NULL) {
-          fprintf(stderr, "Out of memory for [getcwd]\n");
-          abort();
-        }
-        if (getcwd(cwd, PATH_MAX) == NULL) {
+        if (getcwd(cwd, sizeof(cwd)) == NULL) {
           dir_ok = 0;
         }
 #else

--- a/asmrun/spacetime.c
+++ b/asmrun/spacetime.c
@@ -233,7 +233,7 @@ void caml_spacetime_initialize(void)
         dir_ok = 0;
 #endif
         if (dir_ok) {
-          automatic_snapshot_dir = cwd;
+          automatic_snapshot_dir = strdup(cwd);
         }
       }
       else {

--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -321,7 +321,7 @@ CAMLprim value caml_sys_getcwd(value unit)
 #ifdef HAS_GETCWD
   ret = getcwd_os(buff, sizeof(buff)/sizeof(*buff));
 #else
-  ret = getwd(buff);
+  caml_invalid_argument("Sys.getcwd not implemented");
 #endif /* HAS_GETCWD */
   if (ret == 0) caml_sys_error(NO_ARG);
   return caml_copy_string_of_os(buff);

--- a/config/s-templ.h
+++ b/config/s-templ.h
@@ -92,10 +92,8 @@
 /* Define HAS_MKFIFO if the library provides the mkfifo() function. */
 
 #define HAS_GETCWD
-#define HAS_GETWD
 
 /* Define HAS_GETCWD if the library provides the getcwd() function. */
-/* Define HAS_GETWD if the library provides the getwd() function. */
 
 #define HAS_GETPRIORITY
 

--- a/configure
+++ b/configure
@@ -1305,11 +1305,6 @@ if sh ./hasgot getcwd; then
   echo "#define HAS_GETCWD" >> s.h
 fi
 
-if sh ./hasgot getwd; then
-  inf "getwd() found."
-  echo "#define HAS_GETWD" >> s.h
-fi
-
 if sh ./hasgot getpriority setpriority; then
   inf "getpriority() found."
   echo "#define HAS_GETPRIORITY" >> s.h


### PR DESCRIPTION
This is a proper fix for the bug reported in #1086 but incorrectly fixed there.  
