### PR TITLE
Don't warn on mutation of 0 size blocks (MPR#7616)

### DIFF
--- a/Changes
+++ b/Changes
@@ -124,6 +124,9 @@ Working version
   reference symbols (even locally-defined ones) through the GOT.
   (Mark Shinwell, review by Xavier Leroy)
 
+- MPR#7616, GPR#1339: don't warn on mutation of zero size blocks.
+  (Leo White)
+
 ### Standard library:
 
 - MPR#1771, MPR#7309, GPR#1026: Add update to maps. Allows to update a

--- a/middle_end/inline_and_simplify.ml
+++ b/middle_end/inline_and_simplify.ml
@@ -1023,7 +1023,7 @@ and simplify_named env r (tree : Flambda.named) : Flambda.named * R.t =
       | (Parraysetu kind | Parraysets kind),
         [_block; _field; _value],
         [block_approx; _field_approx; value_approx] ->
-        if A.is_definitely_immutable block_approx then begin
+        if A.warn_on_mutation block_approx then begin
           Location.prerr_warning (Debuginfo.to_location dbg)
             Warnings.Assignment_to_non_mutable_value
         end;
@@ -1050,7 +1050,7 @@ and simplify_named env r (tree : Flambda.named) : Flambda.named * R.t =
         in
         Prim (prim, args, dbg), ret r (A.value_unknown Other)
       | Psetfield _, _block::_, block_approx::_ ->
-        if A.is_definitely_immutable block_approx then begin
+        if A.warn_on_mutation block_approx then begin
           Location.prerr_warning (Debuginfo.to_location dbg)
             Warnings.Assignment_to_non_mutable_value
         end;

--- a/middle_end/simple_value_approx.ml
+++ b/middle_end/simple_value_approx.ml
@@ -488,10 +488,11 @@ let useful t =
 
 let all_not_useful ts = List.for_all (fun t -> not (useful t)) ts
 
-let is_definitely_immutable t =
+let warn_on_mutation t =
   match t.descr with
+  | Value_block(_, fields) -> Array.length fields > 0
   | Value_string { contents = Some _ }
-  | Value_block _ | Value_int _ | Value_char _ | Value_constptr _
+  | Value_int _ | Value_char _ | Value_constptr _
   | Value_set_of_closures _ | Value_float _ | Value_boxed_int _
   | Value_closure _ -> true
   | Value_string { contents = None } | Value_float_array _

--- a/middle_end/simple_value_approx.mli
+++ b/middle_end/simple_value_approx.mli
@@ -282,10 +282,10 @@ val useful : t -> bool
 (** Whether all approximations in the given list do *not* satisfy [useful]. *)
 val all_not_useful : t list -> bool
 
-(** A value is certainly immutable if its approximation is known and not bottom.
+(** Whether to warn on attempts to mutate a value.
     It must have been resolved (it cannot be [Value_extern] or
     [Value_symbol]).  (See comment above for further explanation.) *)
-val is_definitely_immutable : t -> bool
+val warn_on_mutation : t -> bool
 
 type simplification_summary =
   | Nothing_done


### PR DESCRIPTION
This PR should fix [MPR#7616](https://caml.inria.fr/mantis/view.php?id=7616). It stops warning 59 from triggering on mutations of zero size blocks, since that is how zero size arrays are represented. I also renamed a function to better represent its meaning and use.

To be honest, the best fix would be just to get rid of warning 59, since it will always be possible for it to trigger on perfectly reasonable type-safe code. But in the meantime this gets rid of a particularly egregious case.