### PR TITLE
Flambda: Add [Closure_origin.t] to trace inlined functions.

### DIFF
--- a/.depend
+++ b/.depend
@@ -1242,17 +1242,17 @@ middle_end/augment_specialised_args.cmo : middle_end/base_types/variable.cmi \
     middle_end/parameter.cmi utils/misc.cmi middle_end/inlining_cost.cmi \
     middle_end/inline_and_simplify_aux.cmi utils/identifiable.cmi \
     middle_end/flambda_utils.cmi middle_end/flambda.cmi \
-    middle_end/debuginfo.cmi middle_end/base_types/closure_id.cmi \
-    utils/clflags.cmi middle_end/backend_intf.cmi \
-    middle_end/augment_specialised_args.cmi
+    middle_end/debuginfo.cmi middle_end/base_types/closure_origin.cmi \
+    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
+    middle_end/backend_intf.cmi middle_end/augment_specialised_args.cmi
 middle_end/augment_specialised_args.cmx : middle_end/base_types/variable.cmx \
     middle_end/projection.cmx middle_end/pass_wrapper.cmx \
     middle_end/parameter.cmx utils/misc.cmx middle_end/inlining_cost.cmx \
     middle_end/inline_and_simplify_aux.cmx utils/identifiable.cmx \
     middle_end/flambda_utils.cmx middle_end/flambda.cmx \
-    middle_end/debuginfo.cmx middle_end/base_types/closure_id.cmx \
-    utils/clflags.cmx middle_end/backend_intf.cmi \
-    middle_end/augment_specialised_args.cmi
+    middle_end/debuginfo.cmx middle_end/base_types/closure_origin.cmx \
+    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
+    middle_end/backend_intf.cmi middle_end/augment_specialised_args.cmi
 middle_end/augment_specialised_args.cmi : middle_end/base_types/variable.cmi \
     middle_end/projection.cmi middle_end/inlining_cost.cmi \
     middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi
@@ -1269,6 +1269,7 @@ middle_end/closure_conversion.cmo : middle_end/base_types/variable.cmi \
     bytecomp/lambda.cmi typing/ident.cmi middle_end/flambda_utils.cmi \
     middle_end/flambda.cmi middle_end/debuginfo.cmi utils/config.cmi \
     middle_end/base_types/compilation_unit.cmi \
+    middle_end/base_types/closure_origin.cmi \
     middle_end/base_types/closure_id.cmi \
     middle_end/closure_conversion_aux.cmi utils/clflags.cmi \
     middle_end/backend_intf.cmi middle_end/closure_conversion.cmi
@@ -1282,6 +1283,7 @@ middle_end/closure_conversion.cmx : middle_end/base_types/variable.cmx \
     bytecomp/lambda.cmx typing/ident.cmx middle_end/flambda_utils.cmx \
     middle_end/flambda.cmx middle_end/debuginfo.cmx utils/config.cmx \
     middle_end/base_types/compilation_unit.cmx \
+    middle_end/base_types/closure_origin.cmx \
     middle_end/base_types/closure_id.cmx \
     middle_end/closure_conversion_aux.cmx utils/clflags.cmx \
     middle_end/backend_intf.cmi middle_end/closure_conversion.cmi
@@ -1346,6 +1348,7 @@ middle_end/flambda.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
     bytecomp/lambda.cmi utils/identifiable.cmi middle_end/debuginfo.cmi \
     middle_end/base_types/compilation_unit.cmi \
+    middle_end/base_types/closure_origin.cmi \
     middle_end/base_types/closure_id.cmi utils/clflags.cmi \
     parsing/asttypes.cmi middle_end/allocated_const.cmi \
     middle_end/flambda.cmi
@@ -1358,6 +1361,7 @@ middle_end/flambda.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
     bytecomp/lambda.cmx utils/identifiable.cmx middle_end/debuginfo.cmx \
     middle_end/base_types/compilation_unit.cmx \
+    middle_end/base_types/closure_origin.cmx \
     middle_end/base_types/closure_id.cmx utils/clflags.cmx \
     parsing/asttypes.cmi middle_end/allocated_const.cmx \
     middle_end/flambda.cmi
@@ -1369,6 +1373,7 @@ middle_end/flambda.cmi : middle_end/base_types/variable.cmi \
     middle_end/parameter.cmi utils/numbers.cmi \
     middle_end/base_types/mutable_variable.cmi bytecomp/lambda.cmi \
     utils/identifiable.cmi middle_end/debuginfo.cmi \
+    middle_end/base_types/closure_origin.cmi \
     middle_end/base_types/closure_id.cmi parsing/asttypes.cmi \
     middle_end/allocated_const.cmi
 middle_end/flambda_invariants.cmo : middle_end/base_types/variable.cmi \
@@ -1413,6 +1418,7 @@ middle_end/flambda_utils.cmo : middle_end/base_types/variable.cmi \
     utils/misc.cmi middle_end/base_types/linkage_name.cmi bytecomp/lambda.cmi \
     middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
     middle_end/debuginfo.cmi middle_end/base_types/compilation_unit.cmi \
+    middle_end/base_types/closure_origin.cmi \
     middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi \
     middle_end/allocated_const.cmi middle_end/flambda_utils.cmi
 middle_end/flambda_utils.cmx : middle_end/base_types/variable.cmx \
@@ -1424,6 +1430,7 @@ middle_end/flambda_utils.cmx : middle_end/base_types/variable.cmx \
     utils/misc.cmx middle_end/base_types/linkage_name.cmx bytecomp/lambda.cmx \
     middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
     middle_end/debuginfo.cmx middle_end/base_types/compilation_unit.cmx \
+    middle_end/base_types/closure_origin.cmx \
     middle_end/base_types/closure_id.cmx middle_end/backend_intf.cmi \
     middle_end/allocated_const.cmx middle_end/flambda_utils.cmi
 middle_end/flambda_utils.cmi : middle_end/base_types/variable.cmi \
@@ -1498,7 +1505,7 @@ middle_end/inline_and_simplify.cmo : utils/warnings.cmi \
     middle_end/inline_and_simplify_aux.cmi typing/ident.cmi \
     middle_end/freshening.cmi middle_end/flambda_utils.cmi \
     middle_end/flambda.cmi middle_end/effect_analysis.cmi \
-    middle_end/debuginfo.cmi utils/config.cmi \
+    middle_end/debuginfo.cmi middle_end/base_types/closure_origin.cmi \
     middle_end/base_types/closure_id.cmi utils/clflags.cmi \
     middle_end/backend_intf.cmi middle_end/allocated_const.cmi \
     middle_end/inline_and_simplify.cmi
@@ -1519,7 +1526,7 @@ middle_end/inline_and_simplify.cmx : utils/warnings.cmx \
     middle_end/inline_and_simplify_aux.cmx typing/ident.cmx \
     middle_end/freshening.cmx middle_end/flambda_utils.cmx \
     middle_end/flambda.cmx middle_end/effect_analysis.cmx \
-    middle_end/debuginfo.cmx utils/config.cmx \
+    middle_end/debuginfo.cmx middle_end/base_types/closure_origin.cmx \
     middle_end/base_types/closure_id.cmx utils/clflags.cmx \
     middle_end/backend_intf.cmi middle_end/allocated_const.cmx \
     middle_end/inline_and_simplify.cmi
@@ -1537,6 +1544,7 @@ middle_end/inline_and_simplify_aux.cmo : middle_end/base_types/variable.cmi \
     middle_end/inlining_stats.cmi middle_end/inlining_cost.cmi \
     middle_end/freshening.cmi middle_end/flambda.cmi middle_end/debuginfo.cmi \
     middle_end/base_types/compilation_unit.cmi \
+    middle_end/base_types/closure_origin.cmi \
     middle_end/base_types/closure_id.cmi utils/clflags.cmi \
     middle_end/backend_intf.cmi middle_end/inline_and_simplify_aux.cmi
 middle_end/inline_and_simplify_aux.cmx : middle_end/base_types/variable.cmx \
@@ -1550,6 +1558,7 @@ middle_end/inline_and_simplify_aux.cmx : middle_end/base_types/variable.cmx \
     middle_end/inlining_stats.cmx middle_end/inlining_cost.cmx \
     middle_end/freshening.cmx middle_end/flambda.cmx middle_end/debuginfo.cmx \
     middle_end/base_types/compilation_unit.cmx \
+    middle_end/base_types/closure_origin.cmx \
     middle_end/base_types/closure_id.cmx utils/clflags.cmx \
     middle_end/backend_intf.cmi middle_end/inline_and_simplify_aux.cmi
 middle_end/inline_and_simplify_aux.cmi : middle_end/base_types/variable.cmi \
@@ -1560,6 +1569,7 @@ middle_end/inline_and_simplify_aux.cmi : middle_end/base_types/variable.cmi \
     middle_end/projection.cmi middle_end/base_types/mutable_variable.cmi \
     middle_end/inlining_stats_types.cmi middle_end/inlining_cost.cmi \
     middle_end/freshening.cmi middle_end/flambda.cmi middle_end/debuginfo.cmi \
+    middle_end/base_types/closure_origin.cmi \
     middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi
 middle_end/inlining_cost.cmo : middle_end/base_types/variable.cmi \
     middle_end/projection.cmi typing/primitive.cmi utils/misc.cmi \
@@ -1770,6 +1780,7 @@ middle_end/remove_unused_arguments.cmo : middle_end/base_types/variable.cmi \
     middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
     middle_end/find_recursive_functions.cmi \
     middle_end/base_types/compilation_unit.cmi \
+    middle_end/base_types/closure_origin.cmi \
     middle_end/base_types/closure_id.cmi utils/clflags.cmi \
     middle_end/remove_unused_arguments.cmi
 middle_end/remove_unused_arguments.cmx : middle_end/base_types/variable.cmx \
@@ -1778,6 +1789,7 @@ middle_end/remove_unused_arguments.cmx : middle_end/base_types/variable.cmx \
     middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
     middle_end/find_recursive_functions.cmx \
     middle_end/base_types/compilation_unit.cmx \
+    middle_end/base_types/closure_origin.cmx \
     middle_end/base_types/closure_id.cmx utils/clflags.cmx \
     middle_end/remove_unused_arguments.cmi
 middle_end/remove_unused_arguments.cmi : middle_end/flambda.cmi \
@@ -1935,6 +1947,15 @@ middle_end/base_types/closure_id.cmx : \
     middle_end/base_types/closure_id.cmi
 middle_end/base_types/closure_id.cmi : \
     middle_end/base_types/closure_element.cmi
+middle_end/base_types/closure_origin.cmo : \
+    middle_end/base_types/closure_id.cmi \
+    middle_end/base_types/closure_origin.cmi
+middle_end/base_types/closure_origin.cmx : \
+    middle_end/base_types/closure_id.cmx \
+    middle_end/base_types/closure_origin.cmi
+middle_end/base_types/closure_origin.cmi : utils/identifiable.cmi \
+    middle_end/base_types/compilation_unit.cmi \
+    middle_end/base_types/closure_id.cmi
 middle_end/base_types/compilation_unit.cmo : utils/misc.cmi \
     middle_end/base_types/linkage_name.cmi utils/identifiable.cmi \
     typing/ident.cmi middle_end/base_types/compilation_unit.cmi
@@ -2233,13 +2254,13 @@ toplevel/opttoploop.cmi : utils/warnings.cmi typing/types.cmi \
 toplevel/opttopmain.cmo : utils/warnings.cmi asmcomp/printmach.cmi \
     toplevel/opttoploop.cmi toplevel/opttopdirs.cmi utils/misc.cmi \
     driver/main_args.cmi parsing/location.cmi utils/config.cmi \
-    driver/compmisc.cmi driver/compenv.cmi utils/clflags.cmi \
-    toplevel/opttopmain.cmi
+    driver/compplugin.cmi driver/compmisc.cmi driver/compenv.cmi \
+    utils/clflags.cmi toplevel/opttopmain.cmi
 toplevel/opttopmain.cmx : utils/warnings.cmx asmcomp/printmach.cmx \
     toplevel/opttoploop.cmx toplevel/opttopdirs.cmx utils/misc.cmx \
     driver/main_args.cmx parsing/location.cmx utils/config.cmx \
-    driver/compmisc.cmx driver/compenv.cmx utils/clflags.cmx \
-    toplevel/opttopmain.cmi
+    driver/compplugin.cmx driver/compmisc.cmx driver/compenv.cmx \
+    utils/clflags.cmx toplevel/opttopmain.cmi
 toplevel/opttopmain.cmi :
 toplevel/opttopstart.cmo : toplevel/opttopmain.cmi
 toplevel/opttopstart.cmx : toplevel/opttopmain.cmx
@@ -2296,13 +2317,13 @@ toplevel/toploop.cmi : utils/warnings.cmi typing/types.cmi typing/path.cmi \
 toplevel/topmain.cmo : utils/warnings.cmi toplevel/toploop.cmi \
     toplevel/topdirs.cmi utils/profile.cmi utils/misc.cmi \
     driver/main_args.cmi parsing/location.cmi utils/config.cmi \
-    driver/compmisc.cmi driver/compenv.cmi utils/clflags.cmi \
-    toplevel/topmain.cmi
+    driver/compplugin.cmi driver/compmisc.cmi driver/compenv.cmi \
+    utils/clflags.cmi toplevel/topmain.cmi
 toplevel/topmain.cmx : utils/warnings.cmx toplevel/toploop.cmx \
     toplevel/topdirs.cmx utils/profile.cmx utils/misc.cmx \
     driver/main_args.cmx parsing/location.cmx utils/config.cmx \
-    driver/compmisc.cmx driver/compenv.cmx utils/clflags.cmx \
-    toplevel/topmain.cmi
+    driver/compplugin.cmx driver/compmisc.cmx driver/compenv.cmx \
+    utils/clflags.cmx toplevel/topmain.cmi
 toplevel/topmain.cmi :
 toplevel/topstart.cmo : toplevel/topmain.cmi
 toplevel/topstart.cmx : toplevel/topmain.cmx

--- a/Changes
+++ b/Changes
@@ -103,6 +103,10 @@ Working version
 
 ### Code generation and optimizations:
 
+- GPR#1340: Add [Closure_origin.t] to trace inlined functions to prevent
+  infinite loops from repeatedly inlining copies of the same function.
+  (Fu Yong Quah)
+
 - GPR#1370: Fix code duplication in Cmmgen
   (Vincent Laviron, with help from Pierre Chambart,
    reviews by Gabriel Scherer and Luc Maranget)

--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,7 @@ MIDDLE_END=\
   middle_end/base_types/set_of_closures_origin.cmo \
   middle_end/base_types/closure_element.cmo \
   middle_end/base_types/closure_id.cmo \
+  middle_end/base_types/closure_origin.cmo \
   middle_end/base_types/var_within_closure.cmo \
   middle_end/base_types/static_exception.cmo \
   middle_end/base_types/export_id.cmo \

--- a/asmcomp/export_info_for_pack.ml
+++ b/asmcomp/export_info_for_pack.ml
@@ -140,7 +140,8 @@ and import_function_declarations_for_pack_aux units pack
           ~stub:function_decl.stub ~dbg:function_decl.dbg
           ~inline:function_decl.inline
           ~specialise:function_decl.specialise
-          ~is_a_functor:function_decl.is_a_functor)
+          ~is_a_functor:function_decl.is_a_functor
+          ~closure_origin:function_decl.closure_origin)
       function_decls.funs
   in
   Flambda.import_function_declarations_for_pack

--- a/asmcomp/import_approx.ml
+++ b/asmcomp/import_approx.ml
@@ -48,7 +48,8 @@ let import_set_of_closures =
             ~body ~stub:function_decl.stub ~dbg:function_decl.dbg
             ~inline:function_decl.inline
             ~specialise:function_decl.specialise
-            ~is_a_functor:function_decl.is_a_functor)
+            ~is_a_functor:function_decl.is_a_functor
+            ~closure_origin:function_decl.closure_origin)
         clos.funs
     in
     Flambda.update_function_declarations clos ~funs

--- a/middle_end/augment_specialised_args.ml
+++ b/middle_end/augment_specialised_args.ml
@@ -542,6 +542,7 @@ module Make (T : S) = struct
         ~inline:Default_inline
         ~specialise:Default_specialise
         ~is_a_functor:false
+        ~closure_origin:function_decl.closure_origin
     in
     new_fun_var, new_function_decl, rewritten_existing_specialised_args,
       benefit
@@ -600,7 +601,7 @@ module Make (T : S) = struct
           specialised_args, None
         else
           let function_decl, new_specialised_args =
-            duplicate_function ~env ~set_of_closures ~fun_var
+            duplicate_function ~env ~set_of_closures ~fun_var ~new_fun_var
           in
           let specialised_args =
             Variable.Map.disjoint_union specialised_args new_specialised_args
@@ -617,6 +618,9 @@ module Make (T : S) = struct
         in
         function_decl.params @ new_params
       in
+      let closure_origin =
+        Closure_origin.create (Closure_id.wrap new_fun_var)
+      in
       let rewritten_function_decl =
         Flambda.create_function_declaration
           ~params:all_params
@@ -626,6 +630,7 @@ module Make (T : S) = struct
           ~inline:function_decl.inline
           ~specialise:function_decl.specialise
           ~is_a_functor:function_decl.is_a_functor
+          ~closure_origin
       in
       let funs, direct_call_surrogates =
         if for_one_function.make_direct_call_surrogates then

--- a/middle_end/augment_specialised_args.mli
+++ b/middle_end/augment_specialised_args.mli
@@ -58,6 +58,7 @@ module Make (T : S) : sig
          env:Inline_and_simplify_aux.Env.t
       -> set_of_closures:Flambda.set_of_closures
       -> fun_var:Variable.t
+      -> new_fun_var:Variable.t
       -> Flambda.function_declaration
         * Flambda.specialised_to Variable.Map.t)
     -> set_of_closures:Flambda.set_of_closures

--- a/middle_end/base_types/closure_origin.ml
+++ b/middle_end/base_types/closure_origin.ml
@@ -3,10 +3,10 @@
 (*                                 OCaml                                  *)
 (*                                                                        *)
 (*                       Pierre Chambart, OCamlPro                        *)
-(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*     Mark Shinwell, Leo White and Fu Yong Quah, Jane Street Europe      *)
 (*                                                                        *)
-(*   Copyright 2013--2016 OCamlPro SAS                                    *)
-(*   Copyright 2014--2016 Jane Street Group LLC                           *)
+(*   Copyright 2013--2017 OCamlPro SAS                                    *)
+(*   Copyright 2014--2017 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -16,24 +16,7 @@
 
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
-(** Simplification of Flambda programs combined with function inlining:
-    for the most part a beta-reduction pass.
+include Closure_id
 
-    Readers interested in the inlining strategy should read the
-    [Inlining_decision] module first.
-*)
-val run
-   : never_inline:bool
-  -> backend:(module Backend_intf.S)
-  -> prefixname:string
-  -> round:int
-  -> Flambda.program
-  -> Flambda.program
-
-val duplicate_function
-   : env:Inline_and_simplify_aux.Env.t
-  -> set_of_closures:Flambda.set_of_closures
-  -> fun_var:Variable.t
-  -> new_fun_var:Variable.t
-  -> Flambda.function_declaration
-    * Flambda.specialised_to Variable.Map.t  (* new specialised arguments *)
+let create t = t
+let rename f t = f t

--- a/middle_end/base_types/closure_origin.mli
+++ b/middle_end/base_types/closure_origin.mli
@@ -3,10 +3,10 @@
 (*                                 OCaml                                  *)
 (*                                                                        *)
 (*                       Pierre Chambart, OCamlPro                        *)
-(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*     Mark Shinwell, Leo White and Fu Yong Quah, Jane Street Europe      *)
 (*                                                                        *)
-(*   Copyright 2013--2016 OCamlPro SAS                                    *)
-(*   Copyright 2014--2016 Jane Street Group LLC                           *)
+(*   Copyright 2013--2017 OCamlPro SAS                                    *)
+(*   Copyright 2014--2017 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,26 +14,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+include Identifiable.S
 
-(** Simplification of Flambda programs combined with function inlining:
-    for the most part a beta-reduction pass.
+val create : Closure_id.t -> t
 
-    Readers interested in the inlining strategy should read the
-    [Inlining_decision] module first.
-*)
-val run
-   : never_inline:bool
-  -> backend:(module Backend_intf.S)
-  -> prefixname:string
-  -> round:int
-  -> Flambda.program
-  -> Flambda.program
-
-val duplicate_function
-   : env:Inline_and_simplify_aux.Env.t
-  -> set_of_closures:Flambda.set_of_closures
-  -> fun_var:Variable.t
-  -> new_fun_var:Variable.t
-  -> Flambda.function_declaration
-    * Flambda.specialised_to Variable.Map.t  (* new specialised arguments *)
+val get_compilation_unit : t -> Compilation_unit.t
+val rename : (Closure_id.t -> Closure_id.t) -> t -> t

--- a/middle_end/closure_conversion.ml
+++ b/middle_end/closure_conversion.ml
@@ -69,7 +69,7 @@ let add_default_argument_wrappers lam =
 (** Generate a wrapper ("stub") function that accepts a tuple argument and
     calls another function with arguments extracted in the obvious
     manner from the tuple. *)
-let tupled_function_call_stub original_params unboxed_version
+let tupled_function_call_stub original_params unboxed_version ~closure_bound_var
       : Flambda.function_declaration =
   let tuple_param_var =
     Variable.rename ~append:"tupled_stub_param" unboxed_version
@@ -99,6 +99,7 @@ let tupled_function_call_stub original_params unboxed_version
   Flambda.create_function_declaration ~params:[tuple_param]
     ~body ~stub:true ~dbg:Debuginfo.none ~inline:Default_inline
     ~specialise:Default_specialise ~is_a_functor:false
+    ~closure_origin:(Closure_origin.create (Closure_id.wrap closure_bound_var))
 
 let register_const t (constant:Flambda.constant_defining_value) name
       : Flambda.constant_defining_value_block_field * string =
@@ -573,19 +574,24 @@ and close_functions t external_env function_declarations : Flambda.named =
     let param_vars = List.map (Env.find_var closure_env) params in
     let params = List.map Parameter.wrap param_vars in
     let closure_bound_var = Function_decl.closure_bound_var decl in
+    let unboxed_version = Variable.rename closure_bound_var in
     let body = close t closure_env body in
+    let closure_origin =
+      Closure_origin.create (Closure_id.wrap unboxed_version)
+    in
     let fun_decl =
       Flambda.create_function_declaration ~params ~body ~stub ~dbg
         ~inline:(Function_decl.inline decl)
         ~specialise:(Function_decl.specialise decl)
         ~is_a_functor:(Function_decl.is_a_functor decl)
+        ~closure_origin
     in
     match Function_decl.kind decl with
     | Curried -> Variable.Map.add closure_bound_var fun_decl map
     | Tupled ->
       let unboxed_version = Variable.rename closure_bound_var in
       let generic_function_stub =
-        tupled_function_call_stub param_vars unboxed_version
+        tupled_function_call_stub param_vars unboxed_version ~closure_bound_var
       in
       Variable.Map.add unboxed_version fun_decl
         (Variable.Map.add closure_bound_var generic_function_stub map)

--- a/middle_end/flambda.ml
+++ b/middle_end/flambda.ml
@@ -116,6 +116,7 @@ and function_declarations = {
 }
 
 and function_declaration = {
+  closure_origin: Closure_origin.t;
   params : Parameter.t list;
   body : t;
   free_variables : Variable.Set.t;
@@ -410,13 +411,15 @@ and print_set_of_closures ppf (set_of_closures : set_of_closures) =
     in
     fprintf ppf "@[<2>(set_of_closures id=%a@ %a@ @[<2>free_vars={%a@ }@]@ \
         @[<2>specialised_args={%a})@]@ \
-        @[<2>direct_call_surrogates=%a@]@]"
+        @[<2>direct_call_surrogates=%a@]@ \
+        @[<2>set_of_closures_origin=%a@]@]]"
       Set_of_closures_id.print function_decls.set_of_closures_id
       funs function_decls.funs
       vars free_vars
       spec specialised_args
       (Variable.Map.print Variable.print)
       set_of_closures.direct_call_surrogates
+      Set_of_closures_origin.print function_decls.set_of_closures_origin
 
 and print_const ppf (c : const) =
   match c with
@@ -428,7 +431,8 @@ let print_function_declarations ppf (fd : function_declarations) =
   let funs ppf =
     Variable.Map.iter (print_function_declaration ppf)
   in
-  fprintf ppf "@[<2>(%a)@]" funs fd.funs
+  fprintf ppf "@[<2>(%a)(origin = %a)@]" funs fd.funs
+    Set_of_closures_origin.print fd.set_of_closures_origin
 
 let print ppf flam =
   fprintf ppf "%a@." lam flam
@@ -982,9 +986,39 @@ let free_symbols_program (program : program) =
   loop program.program_body;
   !symbols
 
+let update_body_of_function_declaration (func_decl: function_declaration)
+      ~body : function_declaration =
+  { closure_origin = func_decl.closure_origin;
+    params = func_decl.params;
+    body;
+    free_variables = free_variables body;
+    free_symbols = free_symbols body;
+    stub = func_decl.stub;
+    dbg = func_decl.dbg;
+    inline = func_decl.inline;
+    specialise = func_decl.specialise;
+    is_a_functor = func_decl.is_a_functor;
+  }
+
+let update_function_decl's_params_and_body
+      (func_decl : function_declaration) ~params ~body =
+  { closure_origin = func_decl.closure_origin;
+    params;
+    body;
+    free_variables = free_variables body;
+    free_symbols = free_symbols body;
+    stub = func_decl.stub;
+    dbg = func_decl.dbg;
+    inline = func_decl.inline;
+    specialise = func_decl.specialise;
+    is_a_functor = func_decl.is_a_functor;
+  }
+
+
 let create_function_declaration ~params ~body ~stub ~dbg
       ~(inline : Lambda.inline_attribute)
       ~(specialise : Lambda.specialise_attribute) ~is_a_functor
+      ~closure_origin
       : function_declaration =
   begin match stub, inline with
   | true, (Never_inline | Default_inline)
@@ -1002,7 +1036,8 @@ let create_function_declaration ~params ~body ~stub ~dbg
       "Stubs may not be annotated as [Always_specialise]: %a"
       print body
   end;
-  { params;
+  { closure_origin;
+    params;
     body;
     free_variables = free_variables body;
     free_symbols = free_symbols body;

--- a/middle_end/flambda.mli
+++ b/middle_end/flambda.mli
@@ -300,6 +300,7 @@ and function_declarations = private {
 }
 
 and function_declaration = private {
+  closure_origin: Closure_origin.t;
   params : Parameter.t list;
   body : t;
   (* CR-soon mshinwell: inconsistent naming free_variables/free_vars here and
@@ -553,12 +554,27 @@ val create_function_declaration
   -> inline:Lambda.inline_attribute
   -> specialise:Lambda.specialise_attribute
   -> is_a_functor:bool
+  -> closure_origin:Closure_origin.t
   -> function_declaration
 
 (** Create a set of function declarations given the individual declarations. *)
 val create_function_declarations
    : funs:function_declaration Variable.Map.t
   -> function_declarations
+
+(** Change only the code of a function declaration. *)
+val update_body_of_function_declaration
+   : function_declaration
+  -> body:expr
+  -> function_declaration
+
+(** Change only the code and parameters of a function declaration. *)
+(* CR-soon mshinwell: rename this to match new update function above *)
+val update_function_decl's_params_and_body
+   : function_declaration
+  -> params:Parameter.t list
+  -> body:expr
+  -> function_declaration
 
 (** Create a set of function declarations based on another set of function
     declarations. *)

--- a/middle_end/flambda_iterators.ml
+++ b/middle_end/flambda_iterators.ml
@@ -409,14 +409,8 @@ let map_general ~toplevel f f_named tree =
                   func_decl
                 end else begin
                   done_something := true;
-                  Flambda.create_function_declaration
-                    ~params:func_decl.params
-                    ~body:new_body
-                    ~stub:func_decl.stub
-                    ~dbg:func_decl.dbg
-                    ~inline:func_decl.inline
-                    ~specialise:func_decl.specialise
-                    ~is_a_functor:func_decl.is_a_functor
+                  Flambda.update_body_of_function_declaration
+                    func_decl ~body:new_body
                 end)
               function_decls.funs
           in
@@ -499,14 +493,7 @@ let map_symbols_on_set_of_closures
         if not (body == func_decl.body) then begin
           done_something := true;
         end;
-        Flambda.create_function_declaration
-          ~params:func_decl.params
-          ~body
-          ~stub:func_decl.stub
-          ~dbg:func_decl.dbg
-          ~inline:func_decl.inline
-          ~specialise:func_decl.specialise
-          ~is_a_functor:func_decl.is_a_functor)
+        Flambda.update_body_of_function_declaration func_decl ~body)
       function_decls.funs
   in
   if not !done_something then
@@ -593,13 +580,8 @@ let map_function_bodies (set_of_closures : Flambda.set_of_closures) ~f =
           function_decl
         else begin
           done_something := true;
-          Flambda.create_function_declaration ~body:new_body
-            ~params:function_decl.params
-            ~stub:function_decl.stub
-            ~dbg:function_decl.dbg
-            ~inline:function_decl.inline
-            ~specialise:function_decl.specialise
-            ~is_a_functor:function_decl.is_a_functor
+          Flambda.update_body_of_function_declaration ~body:new_body
+            function_decl
         end)
       set_of_closures.function_decls.funs
   in
@@ -629,13 +611,8 @@ let map_sets_of_closures_of_program (program : Flambda.program)
                 function_decl
               else begin
                 done_something := true;
-                Flambda.create_function_declaration ~body
-                  ~params:function_decl.params
-                  ~stub:function_decl.stub
-                  ~dbg:function_decl.dbg
-                  ~inline:function_decl.inline
-                  ~specialise:function_decl.specialise
-                  ~is_a_functor:function_decl.is_a_functor
+                Flambda.update_body_of_function_declaration ~body
+                  function_decl
               end)
             set_of_closures.function_decls.funs
         in
@@ -730,13 +707,8 @@ let map_exprs_at_toplevel_of_program (program : Flambda.program)
               function_decl
             else begin
               done_something := true;
-              Flambda.create_function_declaration ~body
-                ~params:function_decl.params
-                ~stub:function_decl.stub
-                ~dbg:function_decl.dbg
-                ~inline:function_decl.inline
-                ~specialise:function_decl.specialise
-                ~is_a_functor:function_decl.is_a_functor
+              Flambda.update_body_of_function_declaration ~body
+                function_decl
             end)
           set_of_closures.function_decls.funs
       in

--- a/middle_end/flambda_utils.ml
+++ b/middle_end/flambda_utils.ml
@@ -339,6 +339,7 @@ let make_closure_declaration ~id ~body ~params ~stub : Flambda.t =
     Flambda.create_function_declaration ~params:(List.map subst_param params)
       ~body ~stub ~dbg:Debuginfo.none ~inline:Default_inline
       ~specialise:Default_specialise ~is_a_functor:false
+      ~closure_origin:(Closure_origin.create (Closure_id.wrap id))
   in
   assert (Variable.Set.equal (Variable.Set.map subst free_variables)
     function_declaration.free_variables);

--- a/middle_end/freshening.ml
+++ b/middle_end/freshening.ml
@@ -230,9 +230,7 @@ let rewrite_recursive_calls_with_symbols t
                 | e -> e)
               ffun.body
           in
-          Flambda.create_function_declaration ~params:ffun.params
-            ~body ~stub:ffun.stub ~dbg:ffun.dbg ~inline:ffun.inline
-            ~specialise:ffun.specialise ~is_a_functor:ffun.is_a_functor)
+          Flambda.update_body_of_function_declaration ffun ~body)
           function_declarations.funs
       in
       Flambda.update_function_declarations function_declarations ~funs
@@ -314,10 +312,11 @@ module Project_var = struct
           Flambda_utils.toplevel_substitution subst.sb_var func_decl.body
         in
         let function_decl =
-          Flambda.create_function_declaration ~params
-            ~body ~stub:func_decl.stub ~dbg:func_decl.dbg
+          Flambda.create_function_declaration ~params ~body
+            ~stub:func_decl.stub ~dbg:func_decl.dbg
             ~inline:func_decl.inline ~specialise:func_decl.specialise
             ~is_a_functor:func_decl.is_a_functor
+            ~closure_origin:func_decl.closure_origin
         in
         function_decl, subst
       in

--- a/middle_end/inline_and_simplify.ml
+++ b/middle_end/inline_and_simplify.ml
@@ -598,7 +598,10 @@ and simplify_set_of_closures original_env r
         ~inline_inside:
           (Inlining_decision.should_inline_inside_declaration function_decl)
         ~dbg:function_decl.dbg
-        ~f:(fun body_env -> simplify body_env r function_decl.body)
+        ~f:(fun body_env ->
+          assert (E.inside_set_of_closures_declaration
+            function_decls.set_of_closures_origin body_env);
+          simplify body_env r function_decl.body)
     in
     let inline : Lambda.inline_attribute =
       match function_decl.inline with
@@ -626,6 +629,7 @@ and simplify_set_of_closures original_env r
         ~body ~stub:function_decl.stub ~dbg:function_decl.dbg
         ~inline ~specialise:function_decl.specialise
         ~is_a_functor:function_decl.is_a_functor
+        ~closure_origin:function_decl.closure_origin
     in
     let used_params' = Flambda.used_params function_decl in
     Variable.Map.add fun_var function_decl funs,
@@ -1384,7 +1388,7 @@ and simplify_list env r l =
     else h' :: t', approxs, r
 
 and duplicate_function ~env ~(set_of_closures : Flambda.set_of_closures)
-      ~fun_var =
+      ~fun_var ~new_fun_var =
   let function_decl =
     match Variable.Map.find fun_var set_of_closures.function_decls.funs with
     | exception Not_found ->
@@ -1417,6 +1421,8 @@ and duplicate_function ~env ~(set_of_closures : Flambda.set_of_closures)
       ~inline_inside:false
       ~dbg:function_decl.dbg
       ~f:(fun body_env ->
+        assert (E.inside_set_of_closures_declaration
+          function_decls.set_of_closures_origin body_env);
         simplify body_env (R.create ()) function_decl.body)
   in
   let function_decl =
@@ -1424,6 +1430,7 @@ and duplicate_function ~env ~(set_of_closures : Flambda.set_of_closures)
       ~body ~stub:function_decl.stub ~dbg:function_decl.dbg
       ~inline:function_decl.inline ~specialise:function_decl.specialise
       ~is_a_functor:function_decl.is_a_functor
+      ~closure_origin:(Closure_origin.create (Closure_id.wrap new_fun_var))
   in
   function_decl, specialised_args
 

--- a/middle_end/inline_and_simplify_aux.ml
+++ b/middle_end/inline_and_simplify_aux.ml
@@ -37,7 +37,7 @@ module Env = struct
     never_inline_inside_closures : bool;
     never_inline_outside_closures : bool;
     unroll_counts : int Set_of_closures_origin.Map.t;
-    inlining_counts : int Closure_id.Map.t;
+    inlining_counts : int Closure_origin.Map.t;
     actively_unrolling : int Set_of_closures_origin.Map.t;
     closure_depth : int;
     inlining_stats_closure_stack : Inlining_stats.Closure_stack.t;
@@ -59,7 +59,7 @@ module Env = struct
       never_inline_inside_closures = false;
       never_inline_outside_closures = false;
       unroll_counts = Set_of_closures_origin.Map.empty;
-      inlining_counts = Closure_id.Map.empty;
+      inlining_counts = Closure_origin.Map.empty;
       actively_unrolling = Set_of_closures_origin.Map.empty;
       closure_depth = 0;
       inlining_stats_closure_stack =
@@ -225,7 +225,7 @@ module Env = struct
   let activate_freshening t =
     { t with freshening = Freshening.activate t.freshening }
 
-  let enter_set_of_closures_declaration origin t =
+  let enter_set_of_closures_declaration t origin =
     { t with
       current_functions =
         Set_of_closures_origin.Set.add origin t.current_functions; }
@@ -327,7 +327,7 @@ module Env = struct
   let inlining_allowed t id =
     let inlining_count =
       try
-        Closure_id.Map.find id t.inlining_counts
+        Closure_origin.Map.find id t.inlining_counts
       with Not_found ->
         max 1 (Clflags.Int_arg_helper.get
                  ~key:t.round !Clflags.inline_max_unroll)
@@ -337,13 +337,13 @@ module Env = struct
   let inside_inlined_function t id =
     let inlining_count =
       try
-        Closure_id.Map.find id t.inlining_counts
+        Closure_origin.Map.find id t.inlining_counts
       with Not_found ->
         max 1 (Clflags.Int_arg_helper.get
                  ~key:t.round !Clflags.inline_max_unroll)
     in
     let inlining_counts =
-      Closure_id.Map.add id (inlining_count - 1) t.inlining_counts
+      Closure_origin.Map.add id (inlining_count - 1) t.inlining_counts
     in
     { t with inlining_counts }
 
@@ -608,8 +608,8 @@ let prepare_to_simplify_set_of_closures ~env
       Closure_id.Map.empty
   in
   let env =
-    E.enter_set_of_closures_declaration
-      function_decls.set_of_closures_origin env
+    E.enter_set_of_closures_declaration env
+      function_decls.set_of_closures_origin
   in
   (* we use the previous closure for evaluating the functions *)
   let internal_value_set_of_closures =

--- a/middle_end/inline_and_simplify_aux.mli
+++ b/middle_end/inline_and_simplify_aux.mli
@@ -128,12 +128,6 @@ module Env : sig
       variables from outer scopes that are not accessible. *)
   val local : t -> t
 
-  (** Note that the inliner is descending into a function body from the given
-      set of closures.  A set of such descents is maintained. *)
-  (* CR-someday mshinwell: consider changing name to remove "declaration".
-     Also, isn't this the inlining stack?  Maybe we can use that instead. *)
-  val enter_set_of_closures_declaration : Set_of_closures_origin.t -> t -> t
-
   (** Determine whether the inliner is currently inside a function body from
       the given set of closures.  This is used to detect whether a given
       function call refers to a function which exists somewhere on the current
@@ -200,11 +194,11 @@ module Env : sig
 
   (** Whether it is permissible to inline a call to a function in the given
       environment. *)
-  val inlining_allowed : t -> Closure_id.t -> bool
+  val inlining_allowed : t -> Closure_origin.t -> bool
 
   (** Whether the given environment is currently being used to rewrite the
       body of an inlined function. *)
-  val inside_inlined_function : t -> Closure_id.t -> t
+  val inside_inlined_function : t -> Closure_origin.t -> t
 
   (** If collecting inlining statistics, record that the inliner is about to
       descend into [closure_id].  This information enables us to produce a

--- a/middle_end/inlining_decision.ml
+++ b/middle_end/inlining_decision.ml
@@ -87,7 +87,7 @@ let inline env r ~lhs_of_application
       Try_it
     else if self_call then
       Don't_try_it S.Not_inlined.Self_call
-    else if not (E.inlining_allowed env closure_id_being_applied) then
+    else if not (E.inlining_allowed env function_decl.closure_origin) then
       Don't_try_it S.Not_inlined.Unrolling_depth_exceeded
     else if only_use_of_function || always_inline then
       Try_it
@@ -222,7 +222,7 @@ let inline env r ~lhs_of_application
            recursive to avoid having to check whether or not it is recursive *)
         E.inside_unrolled_function env function_decls.set_of_closures_origin
       in
-      let env = E.inside_inlined_function env closure_id_being_applied in
+      let env = E.inside_inlined_function env function_decl.closure_origin in
       let env =
         if E.inlining_level env = 0
            (* If the function was considered for inlining without considering

--- a/middle_end/inlining_transforms.ml
+++ b/middle_end/inlining_transforms.ml
@@ -481,14 +481,7 @@ let inline_by_copying_function_declaration ~env ~r
             | _ -> expr)
           body_substituted
       in
-      Flambda.create_function_declaration
-        ~params:fun_decl.params
-        ~stub:fun_decl.stub
-        ~dbg:fun_decl.dbg
-        ~inline:fun_decl.inline
-        ~specialise:fun_decl.specialise
-        ~is_a_functor:fun_decl.is_a_functor
-        ~body
+      Flambda.update_body_of_function_declaration ~body fun_decl
     in
     let funs =
       Variable.Map.map rewrite_function function_decls.funs

--- a/middle_end/lift_constants.ml
+++ b/middle_end/lift_constants.ml
@@ -676,14 +676,7 @@ let introduce_free_variables_in_set_of_closures
              end else begin
                done_something := true;
                let body = Flambda_utils.toplevel_substitution subst body in
-               Flambda.create_function_declaration
-                 ~params:func_decl.params
-                 ~body
-                 ~stub:func_decl.stub
-                 ~dbg:func_decl.dbg
-                 ~inline:func_decl.inline
-                 ~specialise:func_decl.specialise
-                 ~is_a_functor:func_decl.is_a_functor
+               Flambda.update_body_of_function_declaration func_decl ~body
              end)
           function_decls.funs)
   in

--- a/middle_end/remove_free_vars_equal_to_args.ml
+++ b/middle_end/remove_free_vars_equal_to_args.ml
@@ -48,14 +48,7 @@ let rewrite_one_function_decl ~(function_decl : Flambda.function_declaration)
         params_for_equal_free_vars
         function_decl.body
     in
-    Flambda.create_function_declaration
-      ~params:function_decl.params
-      ~body:body
-      ~stub:function_decl.stub
-      ~dbg:function_decl.dbg
-      ~inline:function_decl.inline
-      ~specialise:function_decl.specialise
-      ~is_a_functor:function_decl.is_a_functor
+    Flambda.update_body_of_function_declaration ~body function_decl
 
 let rewrite_one_set_of_closures (set_of_closures : Flambda.set_of_closures) =
   let back_free_vars =

--- a/middle_end/remove_unused_arguments.ml
+++ b/middle_end/remove_unused_arguments.ml
@@ -23,7 +23,8 @@ let rename_var var =
   Variable.rename var
     ~current_compilation_unit:(Compilation_unit.get_current_exn ())
 
-let remove_params unused (fun_decl: Flambda.function_declaration) =
+let remove_params unused (fun_decl: Flambda.function_declaration)
+      ~new_fun_var =
   let unused_params, used_params =
     List.partition (fun v -> Variable.Set.mem (Parameter.var v) unused)
       fun_decl.params
@@ -40,6 +41,7 @@ let remove_params unused (fun_decl: Flambda.function_declaration) =
   Flambda.create_function_declaration ~params:used_params ~body
     ~stub:fun_decl.stub ~dbg:fun_decl.dbg ~inline:fun_decl.inline
     ~specialise:fun_decl.specialise ~is_a_functor:fun_decl.is_a_functor
+    ~closure_origin:(Closure_origin.create (Closure_id.wrap new_fun_var))
 
 let make_stub unused var (fun_decl : Flambda.function_declaration)
     ~specialised_args ~additional_specialised_args =
@@ -97,6 +99,7 @@ let make_stub unused var (fun_decl : Flambda.function_declaration)
     Flambda.create_function_declaration ~params:(List.map snd args') ~body
       ~stub:true ~dbg:fun_decl.dbg ~inline:Default_inline
       ~specialise:Default_specialise ~is_a_functor:fun_decl.is_a_functor
+      ~closure_origin:fun_decl.closure_origin
   in
   function_decl, renamed, additional_specialised_args
 
@@ -132,7 +135,9 @@ let separate_unused_arguments ~only_specialised
                 ~specialised_args:set_of_closures.specialised_args
                 ~additional_specialised_args
             in
-            let cleaned = remove_params unused fun_decl in
+            let cleaned =
+              remove_params unused fun_decl ~new_fun_var:renamed_fun_id
+            in
             Variable.Map.add fun_id stub
               (Variable.Map.add renamed_fun_id cleaned funs),
             additional_specialised_args

--- a/middle_end/unbox_closures.mli
+++ b/middle_end/unbox_closures.mli
@@ -26,6 +26,7 @@ val rewrite_set_of_closures
        env:Inline_and_simplify_aux.Env.t
     -> set_of_closures:Flambda.set_of_closures
     -> fun_var:Variable.t
+    -> new_fun_var:Variable.t
     -> Flambda.function_declaration
       * Flambda.specialised_to Variable.Map.t)
   -> set_of_closures:Flambda.set_of_closures

--- a/middle_end/unbox_specialised_args.mli
+++ b/middle_end/unbox_specialised_args.mli
@@ -43,6 +43,7 @@ val rewrite_set_of_closures
        env:Inline_and_simplify_aux.Env.t
     -> set_of_closures:Flambda.set_of_closures
     -> fun_var:Variable.t
+    -> new_fun_var:Variable.t
     -> Flambda.function_declaration
       * Flambda.specialised_to Variable.Map.t)
   -> set_of_closures:Flambda.set_of_closures

--- a/testsuite/tests/warnings/w55.opt_backend.flambda.opt_reference
+++ b/testsuite/tests/warnings/w55.opt_backend.flambda.opt_reference
@@ -1,6 +1,6 @@
 File "w55.opt_backend.ml", line 12, characters 10-26:
 Warning 55: Cannot inline: [@inlined] attributes may not be used on partial applications
-File "w55.opt_backend.ml", line 8, characters 10-27:
-Warning 55: Cannot inline: [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)
 File "w55.opt_backend.ml", line 18, characters 12-30:
+Warning 55: Cannot inline: [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)
+File "w55.opt_backend.ml", line 8, characters 10-27:
 Warning 55: Cannot inline: [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)


### PR DESCRIPTION
Adds a `Closure_origin.t` analogous to `Set_of_closures_origin.t` to prevent infinite loops from repeatedly inlining copies of the same function. This happens very rarely, and it is quite fragile, so I don't have a reproduction case that works with current trunk. A variation of an earlier version of the compiler looped forever on the following code:

```ocaml
(* a.ml *)

type 'a cont = 'a -> unit
type 'a t = {mutable f : exn cont -> unit cont -> 'a cont -> unit}

let next {f} throw e k = f throw e k

let rec fold f v s throw k =
  next s throw
    (fun () -> k v)
    (fun v' -> f v v' throw (fun v'' -> fold f v'' s throw k))
[@@specialize never]

let iter f s throw k = fold (fun () v throw k -> f v throw k) () s throw k
```

```ocaml
(* b.ml *)
open A

let to_buffer buffer s throw k =
  iter (fun b _ k -> k ()) s throw (fun () -> k buffer)
```