### PR TITLE
Some imperative control flow constructions

### DIFF
--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -523,6 +523,7 @@ let check_recursive_lambda idlist lam =
     | Lprim (Pmakearray (Pfloatarray, _), _, _) -> false
     | Lprim (Pmakearray _, args, _) ->
         List.for_all (check idlist) args
+    | Lstaticcatch (lam1, _, lam2)
     | Lsequence (lam1, lam2) -> check idlist lam1 && check idlist lam2
     | Levent (lam, _) -> check idlist lam
     | lam ->

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -455,6 +455,7 @@ type t = {
   local_constraints: type_declaration PathMap.t;
   gadt_instances: (int * TypeSet.t ref) list;
   flags: int;
+  return: Types.type_expr option;
 }
 
 and module_components =
@@ -539,7 +540,8 @@ let empty = {
   summary = Env_empty; local_constraints = PathMap.empty; gadt_instances = [];
   flags = 0;
   functor_args = Ident.empty;
- }
+  return = None;
+}
 
 let in_signature b env =
   let flags =
@@ -857,6 +859,12 @@ let set_unit_name name =
 
 let get_unit_name () =
   !current_unit
+
+let find_return t =
+  t.return
+
+let add_return return t =
+  { t with return = Some return }
 
 (* Lookup by identifier *)
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -456,6 +456,7 @@ type t = {
   gadt_instances: (int * TypeSet.t ref) list;
   flags: int;
   return: Types.type_expr option;
+  break: Types.type_expr option;
 }
 
 and module_components =
@@ -541,6 +542,7 @@ let empty = {
   flags = 0;
   functor_args = Ident.empty;
   return = None;
+  break = None;
 }
 
 let in_signature b env =
@@ -863,8 +865,16 @@ let get_unit_name () =
 let find_return t =
   t.return
 
+let find_break t =
+  t.break
+
 let add_return return t =
-  { t with return = Some return }
+  { t with return = Some return;
+           (* TODO: do that correctly at every point entering a closure *)
+           break = None }
+
+let add_break break t =
+  { t with break = Some break }
 
 (* Lookup by identifier *)
 

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -60,6 +60,7 @@ val without_cmis: ('a -> 'b) -> 'a -> 'b
 
 (* Lookup by paths *)
 
+val find_return: t -> Types.type_expr option
 val find_value: Path.t -> t -> value_description
 val find_type: Path.t -> t -> type_declaration
 val find_type_descrs: Path.t -> t -> type_descriptions
@@ -134,6 +135,7 @@ exception Recmodule
 
 (* Insertion by identifier *)
 
+val add_return: Types.type_expr -> t -> t
 val add_value:
     ?check:(string -> Warnings.t) -> Ident.t -> value_description -> t -> t
 val add_type: check:bool -> Ident.t -> type_declaration -> t -> t

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -136,8 +136,12 @@ exception Recmodule
 
 (* Insertion by identifier *)
 
+type break
+
+val used_break: break -> bool
+
 val add_return: Types.type_expr -> t -> t
-val add_break: Types.type_expr -> t -> t
+val add_break: Types.type_expr -> t -> break * t
 val add_value:
     ?check:(string -> Warnings.t) -> Ident.t -> value_description -> t -> t
 val add_type: check:bool -> Ident.t -> type_declaration -> t -> t

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -61,6 +61,7 @@ val without_cmis: ('a -> 'b) -> 'a -> 'b
 (* Lookup by paths *)
 
 val find_return: t -> Types.type_expr option
+val find_break: t -> Types.type_expr option
 val find_value: Path.t -> t -> value_description
 val find_type: Path.t -> t -> type_declaration
 val find_type_descrs: Path.t -> t -> type_descriptions
@@ -136,6 +137,7 @@ exception Recmodule
 (* Insertion by identifier *)
 
 val add_return: Types.type_expr -> t -> t
+val add_break: Types.type_expr -> t -> t
 val add_value:
     ?check:(string -> Warnings.t) -> Ident.t -> value_description -> t -> t
 val add_type: check:bool -> Ident.t -> type_declaration -> t -> t

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -398,6 +398,9 @@ and expression i ppf x =
       line i ppf "Texp_unreachable"
   | Texp_extension_constructor (li, _) ->
       line i ppf "Texp_extension_constructor %a" fmt_longident li
+  | Texp_return e ->
+      line i ppf "Texp_return";
+      expression i ppf e
 
 and value_description i ppf x =
   line i ppf "value_description %a %a\n" fmt_ident x.val_id fmt_location

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -401,6 +401,9 @@ and expression i ppf x =
   | Texp_return e ->
       line i ppf "Texp_return";
       expression i ppf e
+  | Texp_break e ->
+      line i ppf "Texp_break";
+      option i expression ppf e
 
 and value_description i ppf x =
   line i ppf "value_description %a %a\n" fmt_ident x.val_id fmt_location

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -351,6 +351,8 @@ let expr sub x =
         e
     | Texp_return exp ->
         Texp_return (sub.expr sub exp)
+    | Texp_break exp ->
+        Texp_break (opt (sub.expr sub) exp)
   in
   {x with exp_extra; exp_desc; exp_env}
 

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -349,6 +349,8 @@ let expr sub x =
         Texp_unreachable
     | Texp_extension_constructor _ as e ->
         e
+    | Texp_return exp ->
+        Texp_return (sub.expr sub exp)
   in
   {x with exp_extra; exp_desc; exp_env}
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2452,15 +2452,18 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
         exp_env = env }
   | Pexp_while(scond, sbody) ->
       let cond = type_expect env scond Predef.type_bool in
+      let unit_type = instance_def Predef.type_unit in
       let exp_type =
         match cond.exp_desc with
         | Texp_construct(_, {cstr_name="true"}, _) ->
             instance env ty_expected
         | _ ->
-            instance_def Predef.type_unit
+            unit_type
       in
-      let body_env = Env.add_break exp_type env in
+      let break, body_env = Env.add_break exp_type env in
       let body = type_statement body_env sbody in
+      if not (Env.used_break break) then
+        unify env exp_type unit_type;
       rue {
         exp_desc = Texp_while(cond, body);
         exp_loc = loc; exp_extra = [];

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2935,7 +2935,9 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
       let (id, new_env) = Env.enter_type name decl env in
       Ctype.init_def(Ident.current_time());
 
-      let body = type_exp new_env sbody in
+      let return_type = newvar () in
+      let new_env = Env.add_return return_type new_env in
+      let body = type_expect new_env sbody return_type in
       (* Replace every instance of this type constructor in the resulting
          type. *)
       let seen = Hashtbl.create 8 in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2852,6 +2852,7 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
       let ty = newgenvar () in
       let to_unify = Predef.type_lazy_t ty in
       unify_exp_types loc env to_unify ty_expected;
+      let env = Env.add_return ty env in
       let arg = type_expect env e ty in
       re {
         exp_desc = Texp_lazy arg;

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -114,6 +114,7 @@ and expression_desc =
   | Texp_pack of module_expr
   | Texp_unreachable
   | Texp_extension_constructor of Longident.t loc * Path.t
+  | Texp_return of expression
 
 and meth =
     Tmeth_name of string

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -115,6 +115,7 @@ and expression_desc =
   | Texp_unreachable
   | Texp_extension_constructor of Longident.t loc * Path.t
   | Texp_return of expression
+  | Texp_break of expression option
 
 and meth =
     Tmeth_name of string

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -229,6 +229,7 @@ and expression_desc =
   | Texp_pack of module_expr
   | Texp_unreachable
   | Texp_extension_constructor of Longident.t loc * Path.t
+  | Texp_return of expression
 
 and meth =
     Tmeth_name of string

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -230,6 +230,7 @@ and expression_desc =
   | Texp_unreachable
   | Texp_extension_constructor of Longident.t loc * Path.t
   | Texp_return of expression
+  | Texp_break of expression option
 
 and meth =
     Tmeth_name of string

--- a/typing/typedtreeIter.ml
+++ b/typing/typedtreeIter.ml
@@ -359,6 +359,8 @@ module MakeIterator(Iter : IteratorArgument) : sig
             ()
         | Texp_extension_constructor _ ->
             ()
+        | Texp_return exp ->
+            iter_expression exp
       end;
       Iter.leave_expression exp;
 

--- a/typing/typedtreeIter.ml
+++ b/typing/typedtreeIter.ml
@@ -249,7 +249,8 @@ module MakeIterator(Iter : IteratorArgument) : sig
       end;
       Iter.leave_pattern pat
 
-    and option f x = match x with None -> () | Some e -> f e
+    and option : 'a. ('a -> unit) -> 'a option -> unit =
+      fun f x -> match x with None -> () | Some e -> f e
 
     and iter_expression exp =
       Iter.enter_expression exp;
@@ -361,6 +362,8 @@ module MakeIterator(Iter : IteratorArgument) : sig
             ()
         | Texp_return exp ->
             iter_expression exp
+        | Texp_break exp ->
+            option iter_expression exp
       end;
       Iter.leave_expression exp;
 

--- a/typing/typedtreeMap.ml
+++ b/typing/typedtreeMap.ml
@@ -389,6 +389,8 @@ module MakeMap(Map : MapArgument) = struct
           Texp_unreachable
         | Texp_extension_constructor _ as e ->
           e
+        | Texp_return exp ->
+          Texp_return (map_expression exp)
     in
     let exp_extra = List.map map_exp_extra exp.exp_extra in
     Map.leave_expression {

--- a/typing/typedtreeMap.ml
+++ b/typing/typedtreeMap.ml
@@ -391,6 +391,8 @@ module MakeMap(Map : MapArgument) = struct
           e
         | Texp_return exp ->
           Texp_return (map_expression exp)
+        | Texp_break exp ->
+          Texp_break (Misc.may_map map_expression exp)
     in
     let exp_extra = List.map map_exp_extra exp.exp_extra in
     Map.leave_expression {

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -474,6 +474,14 @@ let expression sub exp =
     | Texp_return exp ->
         Pexp_extension ({ txt = "ocaml.return"; loc },
                         PStr [ Str.eval ~loc (sub.expr sub exp) ])
+    | Texp_break exp ->
+        let payload =
+          match exp with
+          | None -> []
+          | Some exp -> [ Str.eval ~loc (sub.expr sub exp) ]
+        in
+        Pexp_extension ({ txt = "ocaml.break"; loc },
+                        PStr payload)
   in
   List.fold_right (exp_extra sub) exp.exp_extra
     (Exp.mk ~loc ~attrs desc)

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -471,6 +471,9 @@ let expression sub exp =
                         PStr [ Str.eval ~loc
                                  (Exp.construct ~loc (map_loc sub lid) None)
                              ])
+    | Texp_return exp ->
+        Pexp_extension ({ txt = "ocaml.return"; loc },
+                        PStr [ Str.eval ~loc (sub.expr sub exp) ])
   in
   List.fold_right (exp_extra sub) exp.exp_extra
     (Exp.mk ~loc ~attrs desc)


### PR DESCRIPTION
This was inspired by some discussions with an OCaml old-timer whose identity won't be disclosed for obvious reasons.

This is certainly not something I would suggest for integration. I made it obvious by the complete lack of additional syntax: It is exposed as `[% ]` extensions.

There are two proposed new keywords: return and break

* return jumps to the end of the current function i.e. the last fun/function/lazy or method keyword
  return can take an argument. With no argument the function is expected to return a value of type
  unit, otherwise it returns the argument.
* break jumps to the end of the current while loop.
  If the loop does not terminate by default (while true) and there is a break inside, the loop returns
  the type of the argument of break. Otherwise break takes no argument

For instance

```OCaml
let pgcd a b =
  let a = ref a in
  let b = ref b in
  while true do
    if !b = 0 then [%break !a];
    let c = !a mod !b in
    a := !b;
    b := c
  done
```
A complete lack of imagination is behind this example. I do not claim that this is any better than the recursive version. It only exposes the syntax. 
There are some situations I encountered where it would have improved the code quality, but they wouldn't fit in a PR. It usually involves some dataflow analysis.

This is I think better than situations where you would need something like
```OCaml
let continue = ref true in
while !continue do
  ...
  if cond then continue := false
  else
     ...
done
```

Which can be rewritten
```OCaml
while true do
  ...
  if cond then [%break];
  ...
done
```
For instance the classic do-while loop is lighter to write.

Return could be useful in different kind of situations. It could shine
for instance with complex error checking inside functions:

```OCaml
let f arg =
  if error_condition_1 then [%return (Error a)];
  if error_condition_2 then [%return (Error b)];
  if error_condition_3 then [%return (Error c)];
  ...
  Ok result
```

As a funny side effect you can encode break using it:

```OCaml
(fun (type t) ->
   while true do
     [%return x]
   done)
```

Also this can make some kinds of ppx simpler and more efficient

Problems:
* This may obviously not feel like the OCaml way
* there are no syntax space left (unless we want to use some combination of keywords like) 'try in method'

Implementation details:
* This is not implemented for objects yet
* break for while only
* Errors are ugly
* syntax...

Also, please. Please don't take it too seriously...

PS: this does not reflect my employer, clients, or anybody's opinions !