### PR TITLE
Add -linscan doc to manual

### DIFF
--- a/man/ocamlopt.m
+++ b/man/ocamlopt.m
@@ -360,6 +360,12 @@ setting the
 option ensures that this module will
 always be linked if it is put in a library and this library is linked.
 .TP
+.B \-linscan
+Use linear scan register allocation.  Compiling with this allocator is faster
+than with the usual graph coloring allocator, sometimes quite drastically so for
+long functions and modules. On the other hand, the generated code can be a bit
+slower.
+.TP
 .B \-no-alias-deps
 Do not record dependencies for module aliases.
 .TP

--- a/manual/manual/cmds/unified-options.etex
+++ b/manual/manual/cmds/unified-options.etex
@@ -308,6 +308,14 @@ modules contained in the library.  When compiling a module (option
 always be linked if it is put in a library and this library is linked.
 }%notop
 
+\nat{%
+\item["-linscan"]
+Use linear scan register allocation.  Compiling with this allocator is faster
+than with the usual graph coloring allocator, sometimes quite drastically so for
+long functions and modules. On the other hand, the generated code can be a bit
+slower.
+}%nat
+
 \comp{%
 \item["-make-runtime"]
 Build a custom runtime system (in the file specified by option "-o")


### PR DESCRIPTION
Documentation for the `-linscan` option to `ocamlopt` introduced by #375, as requested by @gasche. Apologies for the lateness, it slipped my mind.