### PR TITLE
afl-fuzz instrumentation fix for classes

### DIFF
--- a/Changes
+++ b/Changes
@@ -686,6 +686,9 @@ Release branch for 4.06:
 - GPR#1308: Only treat pure patterns as inactive
   (Leo White, review by Alain Frisch and Gabriel Scherer)
 
+- MPR#7612, GPR#1345: afl-instrumentation bugfix for classes.
+  (Stephen Dolan, review by Gabriel Scherer and David Allsopp)
+
 - MPR#7619, GPR#1387: position of the optional last semi-column not included
   in the position of the expression (same behavior as for lists)
   (Christophe Raffalli, review by Gabriel Scherer)

--- a/testsuite/tests/afl-instrumentation/Makefile
+++ b/testsuite/tests/afl-instrumentation/Makefile
@@ -1,0 +1,15 @@
+BASEDIR=../..
+
+default:
+	@printf " ... testing 'afl_instrumentation':"
+	@if ! which afl-showmap > /dev/null; then \
+	  echo " => skipped (afl-showmap unavailable)"; \
+	else \
+	  if OCAMLOPT='$(OCAMLOPT)' ./test.sh > /dev/null; then \
+	    echo " => passed"; \
+	  else \
+	    echo " => failed"; \
+	  fi \
+	fi
+
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/afl-instrumentation/harness.ml
+++ b/testsuite/tests/afl-instrumentation/harness.ml
@@ -1,0 +1,22 @@
+external reset_instrumentation : bool -> unit = "caml_reset_afl_instrumentation"
+external sys_exit : int -> 'a = "caml_sys_exit"
+
+let name n =
+  fst (Test.tests.(int_of_string n - 1))
+let run n =
+  snd (Test.tests.(int_of_string n - 1)) ()
+
+let orig_random = Random.get_state ()
+
+let () =
+  (* Random.set_state orig_random; *)
+  reset_instrumentation true;
+  begin
+    match Sys.argv with
+    | [| _; "len" |] -> print_int (Array.length Test.tests); print_newline (); flush stdout
+    | [| _; "name"; n |] -> print_string (name n); flush stdout
+    | [| _; "1"; n |] -> run n
+    | [| _; "2"; n |] -> run n; (* Random.set_state orig_random;  *)reset_instrumentation false; run n
+    | _ -> failwith "error"
+  end;
+  sys_exit 0

--- a/testsuite/tests/afl-instrumentation/test.ml
+++ b/testsuite/tests/afl-instrumentation/test.ml
@@ -1,0 +1,73 @@
+let opaque = Sys.opaque_identity
+
+let lists n =
+  let l = opaque [n; n; n] in
+  match List.rev l with
+  | [a; b; c] when a = n && b = n && c = n -> ()
+  | _ -> assert false
+
+let fresh_exception x =
+  opaque @@
+    let module M = struct
+        exception E of int
+        let throw () = raise (E x)
+      end in
+    try
+      M.throw ()
+    with
+      M.E n -> assert (n = x)
+
+let obj_with_closure x =
+  opaque (object method foo = x end)
+
+let r = ref 42
+let state () =
+  incr r;
+  if !r > 43 then print_string "woo" else ()
+
+let classes (x : int) =
+  opaque @@
+    let module M = struct
+        class a = object
+          method foo = x
+        end
+        class c = object
+          inherit a
+        end
+      end in
+    let o = new M.c in
+    assert (o#foo = x)
+
+
+class c_global = object
+  method foo = 42
+end
+let obj_ordering () = opaque @@
+  (* Object IDs change, but should be in the same relative order *)
+  let a = new c_global in
+  let b = new c_global in
+  if a < b then print_string "a" else print_string "b"
+
+let random () = opaque @@
+  (* as long as there's no self_init, this should be deterministic *)
+  if Random.int 100 < 50 then print_string "a" else print_string "b";
+  if Random.int 100 < 50 then print_string "a" else print_string "b";
+  if Random.int 100 < 50 then print_string "a" else print_string "b";
+  if Random.int 100 < 50 then print_string "a" else print_string "b";
+  if Random.int 100 < 50 then print_string "a" else print_string "b";
+  if Random.int 100 < 50 then print_string "a" else print_string "b";
+  if Random.int 100 < 50 then print_string "a" else print_string "b";
+  if Random.int 100 < 50 then print_string "a" else print_string "b";
+  if Random.int 100 < 50 then print_string "a" else print_string "b"
+
+let tests =
+  [| ("lists", fun () -> lists 42);
+     ("manylists", fun () -> for i = 1 to 10 do lists 42 done);
+     ("exceptions", fun () -> fresh_exception 100);
+     ("objects", fun () -> ignore (obj_with_closure 42));
+     (* ("state", state); *) (* this one should fail *)
+     ("classes", fun () -> classes 42);
+     ("obj_ordering", obj_ordering);
+     (* ("random", random); *)
+  |]
+  

--- a/testsuite/tests/afl-instrumentation/test.sh
+++ b/testsuite/tests/afl-instrumentation/test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+$OCAMLOPT -c -afl-instrument test.ml
+$OCAMLOPT -afl-inst-ratio 0 test.cmx harness.ml -o test
+
+NTESTS=`./test len`
+failures=''
+echo "running $NTESTS tests..."
+for t in `seq 1 $NTESTS`; do
+  printf "%14s: " `./test name $t`
+  # when run twice, the instrumentation output should double
+  afl-showmap -q -o output-1 -- ./test 1 $t
+  afl-showmap -q -o output-2 -- ./test 2 $t
+  # see afl-showmap.c for what the numbers mean
+  cat output-1 | sed '
+    s/:6/:7/; s/:5/:6/;
+    s/:4/:5/; s/:3/:4/;
+    s/:2/:4/; s/:1/:2/;
+  ' > output-2-predicted
+  if cmp -s output-2-predicted output-2; then
+    echo "passed."
+  else
+    echo "failed:"
+    paste output-2 output-1
+    failures=1
+  fi
+done
+
+if [ -z "$failures" ]; then echo "all tests passed"; else exit 1; fi
+
+rm -f {test,harness}.{cmi,cmx,o} test output-{1,2,2-predicted}


### PR DESCRIPTION
[MPR#7612](https://caml.inria.fr/mantis/view.php?id=7612) reports a bug in the afl-fuzz instrumentation produced by OCaml 4.05: the instrumentation output differs across multiple iterations of a deterministic program that uses objects.

The issue turns out to be the caching that objects use to lazily initialise the class data structures. At runtime, evaluating the expression `object end` checks a mutable field of its auto-generated class table to see whether it has already been initialised, and if not, initialises the class.

This means that instrumented programs can have different behaviour even on identical inputs, since a different code path is taken the second time an object creation expression is evaluated.

This patch fixes the issue in a very simple way: when compiling with afl-fuzz instrumentation, the class table cache is disabled and unconditionally regenerated every time an object is created.

This is a little tricky to test. I've written some tests and made them available in the [ocaml-afl-persistent repository](https://github.com/stedolan/ocaml-afl-persistent/tree/master/test), which run various code snippets first once and then twice with afl instrumentation enabled, checking that the instrumentation output from the double run is twice that from the single run. (Since these tests depend on some tools shipped as part of afl-fuzz, I don't think it's appropriate to put them in the OCaml test suite)