### PR TITLE
Qualified extended indexing operators

### DIFF
--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -2352,7 +2352,7 @@ type t =  T of string
 [@@ocaml.doc " Attaches to t "]
 \end{verbatim}
 
-\section{Extendend indexing operators \label{s:index-operators} }
+\section{Extended indexing operators \label{s:index-operators} }
 (Introduced in 4.06)
 
 \begin{syntax}
@@ -2362,7 +2362,7 @@ dot-ext:
 ;
 expr:
           ...
-        | expr '.' dot-ext ( '(' expr ')' || '[' expr ']' || '{' expr '}' ) [ '<-' expr ]
+        | expr '.' [module-path '.'] dot-ext ( '(' expr ')' || '[' expr ']' || '{' expr '}' ) [ '<-' expr ]
 ;
 operator-name:
           ...
@@ -2374,22 +2374,21 @@ operator-name:
 This extension provides syntactic sugar for getting and setting elements
 for user-defined indexed types. For instance, we can define python-like
 dictionaries with
-\begin{caml-example}
+\begin{caml_example*}{verbatim}
 module Dict = struct
-
 include Hashtbl
 let ( .%{} ) tabl index = find tabl index
 let ( .%{}<- ) tabl index value = add tabl index value
-end;;
+end
 let dict =
-  let open Dict in
-  let dict = create 10 in
+  let dict = Dict.create 10 in
   let () =
-    dict.%{"one"} <- 1;
+    dict.Dict.%{"one"} <- 1;
+    let open Dict in
     dict.%{"two"} <- 2 in
   dict
-;;
-let () =
-  let open Dict in
-  assert( dict.%{"one"} = 1 );;
-\end{caml-example}
+\end{caml_example*}
+\begin{caml_example}{toplevel}
+dict.Dict.%{"one"};;
+let open Dict in dict.%{"two"};;
+\end{caml_example}

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1436,6 +1436,30 @@ expr:
         mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $4]) }
   | simple_expr DOTOP LBRACE expr error
       { unclosed "{" 3 "}" 5 }
+  | simple_expr DOT mod_longident DOTOP LBRACKET expr RBRACKET LESSMINUS expr
+      { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3,"." ^ $4 ^ "[]<-")) in
+        mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $6; Nolabel, $9]) }
+  | simple_expr DOT mod_longident DOTOP LBRACKET expr RBRACKET
+      { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "[]")) in
+        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $6]) }
+  | simple_expr DOT mod_longident DOTOP LBRACKET expr error
+      { unclosed "[" 5 "]" 7 }
+  | simple_expr DOT mod_longident DOTOP LPAREN expr RPAREN LESSMINUS expr
+      { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "()<-")) in
+        mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $6; Nolabel, $9]) }
+  | simple_expr DOT mod_longident DOTOP LPAREN expr RPAREN
+      { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "()")) in
+        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $6]) }
+  | simple_expr DOT mod_longident DOTOP LPAREN expr error
+      { unclosed "(" 5 ")" 7 }
+  | simple_expr DOT mod_longident DOTOP LBRACE expr RBRACE LESSMINUS expr
+      { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "{}<-")) in
+        mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $6; Nolabel, $9]) }
+  | simple_expr DOT mod_longident DOTOP LBRACE expr RBRACE
+      { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "{}")) in
+        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $6]) }
+  | simple_expr DOT mod_longident DOTOP LBRACE expr error
+      { unclosed "{" 5 "}" 7 }
   | label LESSMINUS expr
       { mkexp(Pexp_setinstvar(mkrhs $1 1, $3)) }
   | ASSERT ext_attributes simple_expr %prec below_HASH

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -7324,15 +7324,19 @@ module Exotic_list = struct
 end
 
 (** Extended index operators *)
-let ( .%[] ) = Hashtbl.find
-let ( .%[] <- ) = Hashtbl.add
-let ( .%() ) = Hashtbl.find
-let ( .%() <- ) = Hashtbl.add
-let ( .%{} ) = Hashtbl.find
-let ( .%{} <- ) = Hashtbl.add
-
-;;
-let h = Hashtbl.create 17 in
-h.%["one"] <- 1;
-h.%("two") <- 2;
-h.%{"three"} <- 3;
+module Indexop = struct
+  module Def = struct
+    let ( .%[] ) = Hashtbl.find
+    let ( .%[] <- ) = Hashtbl.add
+    let ( .%() ) = Hashtbl.find
+    let ( .%() <- ) = Hashtbl.add
+    let ( .%{} ) = Hashtbl.find
+    let ( .%{} <- ) = Hashtbl.add
+  end
+  ;;
+  let h = Hashtbl.create 17 in
+  h.Def.%["one"] <- 1;
+  h.Def.%("two") <- 2;
+  h.Def.%{"three"} <- 3
+  let x,y,z = Def.(h.%["one"], h.%("two"), h.%{"three"})
+end


### PR DESCRIPTION
This PR completes #1064 to add the following syntactic constructions:

* `x.Module.Path.!(y)` ⇒ `Module.Path.(.!()) x y`
* `x.Module.Path.$[t] <- 2` ⇒ `Module.Path.(.$[]<-) x t 2`
* `x.A.B.%{y}` ⇒ `A.B.(.%{})`

and updates (and fixes) the manual and `parsing/pprintast.ml` .