### PR TITLE
support syntax "S with type _ t = int"

### DIFF
--- a/Changes
+++ b/Changes
@@ -45,6 +45,10 @@ Working version
 - GPR#1253: Private extensible variants
   (Leo White, review by Alain Frisch)
 
+- GPR#1348: accept anonymous type parameters in with constraints,
+  "S with type _ t = int".
+  (Valentin Gatien-Baron, report by Jeremy Yallop)
+
 ### Code generation and optimizations:
 
 - MPR#5324, GPR#375: An alternative Linear Scan register allocator for

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1980,11 +1980,6 @@ optional_type_variable:
 ;
 
 
-type_parameters:
-    /*empty*/                                   { [] }
-  | type_parameter                              { [$1] }
-  | LPAREN type_parameter_list RPAREN           { List.rev $2 }
-;
 type_parameter:
     type_variance type_variable                   { $2, $1 }
 ;
@@ -2148,8 +2143,8 @@ with_constraints:
   | with_constraints AND with_constraint        { $3 :: $1 }
 ;
 with_constraint:
-    TYPE type_parameters label_longident with_type_binder core_type_no_attr
-    constraints
+    TYPE optional_type_parameters label_longident with_type_binder
+    core_type_no_attr constraints
       { Pwith_type
           (mkrhs $3 3,
            (Type.mk (mkrhs (Longident.last $3) 3)
@@ -2160,7 +2155,7 @@ with_constraint:
               ~loc:(symbol_rloc()))) }
     /* used label_longident instead of type_longident to disallow
        functor applications in type path */
-  | TYPE type_parameters label_longident COLONEQUAL core_type_no_attr
+  | TYPE optional_type_parameters label_longident COLONEQUAL core_type_no_attr
       { Pwith_typesubst
          (mkrhs $3 3,
            (Type.mk (mkrhs (Longident.last $3) 3)

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -23,6 +23,14 @@ Error: Multiple definition of the type name t.
        Names must be unique in a given structure or signature.
 |}]
 
+module type Sunderscore = sig
+  type (_, _) t
+end with type (_, 'a) t = int * 'a
+[%%expect {|
+module type Sunderscore = sig type (_, 'a) t = int * 'a end
+|}]
+
+
 (* Valid substitutions in a recursive module may fail due to the ordering of
    the modules. *)
 
@@ -89,6 +97,10 @@ module type S2 = S with type 'a t := (string * 'a) list
 [%%expect {|
 module type S2 =
   sig val map : ('a -> 'b) -> (string * 'a) list -> (string * 'b) list end
+|}]
+module type S3 = S with type _ t := int
+[%%expect {|
+module type S3 = sig val map : ('a -> 'b) -> int -> int end
 |}]
 
 


### PR DESCRIPTION
It's almost certainly an oversight that the parser was rejecting "S with type _ t = int" and "S with type _ t := int", so I'm making it work for consistency.