### PR TITLE
Make expect tests more usable

### DIFF
--- a/testsuite/makefiles/Makefile.expect
+++ b/testsuite/makefiles/Makefile.expect
@@ -24,6 +24,12 @@ default:
 	  echo " => passed" || echo " => failed"; \
 	done
 
+# Builds everything needed to run an expect test
+.PHONY: deps
+deps:
+	@$(MAKE) -C $(OTOPDIR) coldstart ocaml ocamlc
+	@$(MAKE) -C $(OTOPDIR)/testsuite/tools expect_test$(EXE)
+
 .PHONY: promote
 promote:
 	@for file in *.corrected; do \

--- a/testsuite/tools/Makefile
+++ b/testsuite/tools/Makefile
@@ -21,7 +21,7 @@ LIBRARIES=../../compilerlibs/ocamlcommon \
           ../../compilerlibs/ocamlbytecomp \
           ../../compilerlibs/ocamltoplevel
 
-$(PROG): $(MAIN).cmo
+$(PROG): $(MAIN).cmo $(LIBRARIES:=.cma)
 	$(OCAMLC) -linkall -o $(PROG) $(LIBRARIES:=.cma) $(MAIN).cmo
 
 include $(BASEDIR)/makefiles/Makefile.common


### PR DESCRIPTION
One big problem with expect tests right now is that the rule building the expect tests runner declares almost none of its dependencies, forcing people to clean to run such tests when they change the compiler. The first commit fixes this.

Another problem, though maybe it's because I don't understand the makefiles, is that there seems to be no way to just run a test without first knowing everything the test will need and building them. Of course, one can overapproximate by building world or something, but that's slower than necessary. So the second commit introduces a phony target to build what's necessary to run an expect test and no more.
Once `configure` has been called, one can run a test like this: `make -C testsuite/tests/typing-sigsubst DIFF="diff -u" deps default`. This command takes 1min the first time, .2s when changing the test, 2s when changing typemod.ml, 3.5s when changing parser.mly.
Using `make world && make -C testsuite tools && make -C testsuite/tests/typing-sigsubst DIFF="diff -u" default` takes 2min the first time, the last call to `make` takes .15s when changing the test, and the whole command takes 10s when changing typemod.ml, and 20s when changing parser.mly.