### PR TITLE
Change factor estimation equation in Flambda manual

### DIFF
--- a/manual/manual/cmds/flambda.etex
+++ b/manual/manual/cmds/flambda.etex
@@ -445,7 +445,7 @@ compensate for the fact that the current point in the code, if under some
 number of conditional branches, may be cold.  (Flambda does not currently
 compute hot and cold paths.)  The factor---the estimated probability that
 the inliner really is on a {\em hot} path---is calculated as
-$(\frac{1}{1 + f})^{d}$, where $f$ is set by
+$\frac{1}{(1 + f)^{d}}$, where $f$ is set by
 {\tt -inline-branch-factor} and $d$ is the nesting depth of branches
 at the current point.  As the inliner descends into more deeply-nested
 branches, the benefit of inlining thus lessens.


### PR DESCRIPTION
Currently, the equation is rendered as (1/1 + f)<sup>d</sup>.
I'm not certain if this will correctly render in HTML (apologies, but I don't have the capacity to check at the moment), but hopefully this PR will suffice.