### PR TITLE
add labels to BytesLabels.sub_string

### DIFF
--- a/Changes
+++ b/Changes
@@ -1661,6 +1661,8 @@ OCaml 4.04.0 (4 Nov 2016):
 
 - GPR#880: Fix [@@inline] with default parameters in flambda (Leo White)
 
+* GPR#1353: add labels to BytesLabels.sub_string (Jacques Garrigue)
+
 ### Internal/compiler-libs changes:
 
 - PR#7200, GPR#539: Improve, fix, and add test for parsing/pprintast.ml

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -73,7 +73,7 @@ val sub : bytes -> pos:int -> len:int -> bytes
     Raise [Invalid_argument] if [start] and [len] do not designate a
     valid range of [s]. *)
 
-val sub_string : bytes -> int -> int -> string
+val sub_string : bytes -> pos:int -> len:int -> string
 (** Same as [sub] but return a string instead of a byte sequence. *)
 
 val extend : bytes -> left:int -> right:int -> bytes


### PR DESCRIPTION
`BytesLabels.sub_string` lacks the labels of `StringLabels.sub`
Add them to make transition to `-safe-string` easier.

I view this as a bug fix, discovered when porting `labltk` and `lablgtk` to the 4.06 branch.