### PR TITLE
Fix usage warnings with no mli file

### DIFF
--- a/Changes
+++ b/Changes
@@ -86,6 +86,9 @@ Working version
   first character (instead of comma) in the set ":|; ,"
   (Fabrice Le Fessant)
 
+- GPR#1358: Fix usage warnings with no mli file
+  (Leo White, review by Alain Frisch)
+
 - GPR#1428: give a non dummy location for warning 49 (no cmi found)
   (Valentin Gatien-Baron)
 

--- a/testsuite/tests/warnings/deprecated_module_assigment.ml
+++ b/testsuite/tests/warnings/deprecated_module_assigment.ml
@@ -10,7 +10,7 @@ module Y : sig val x : int end = X
 
 module Z : sig val x : int [@@deprecated "..."] end = X
 
-module F(A : sig val x : int end) = struct end
+module F(A : sig val x : int end) = struct let _ = A.x end
 
 module B = F(X)
 

--- a/testsuite/tests/warnings/w32.ml
+++ b/testsuite/tests/warnings/w32.ml
@@ -45,3 +45,10 @@ module M = struct
   let j x = x
   and[@warning "+32"] k x = x
 end
+
+(* unused values in functor argument *)
+module F (X : sig val x : int end) = struct end
+
+module G (X : sig val x : int end) = X
+
+module H (X : sig val x : int end) = X

--- a/testsuite/tests/warnings/w32.mli
+++ b/testsuite/tests/warnings/w32.mli
@@ -7,3 +7,10 @@ val g : 'a -> 'a
 val n : 'a -> 'a
 
 val o : 'a -> 'a
+
+(* value in functor argument *)
+module F (X : sig val x : int end) : sig end
+
+module G (X : sig val x : int end) : sig end
+
+module H (X : sig val x : int end) : sig val x : int end

--- a/testsuite/tests/warnings/w32.reference
+++ b/testsuite/tests/warnings/w32.reference
@@ -24,3 +24,7 @@ File "w32.ml", line 46, characters 22-23:
 Warning 32: unused value k.
 File "w32.ml", line 39, characters 0-174:
 Warning 60: unused module M.
+File "w32.ml", line 50, characters 18-29:
+Warning 32: unused value x.
+File "w32.ml", line 52, characters 18-29:
+Warning 32: unused value x.

--- a/testsuite/tests/warnings/w32b.ml
+++ b/testsuite/tests/warnings/w32b.ml
@@ -1,0 +1,3 @@
+
+(* Check that [t] is considered unused without an .mli file (see GPR#1358) *)
+module Q (M : sig type t end) = struct end

--- a/testsuite/tests/warnings/w32b.reference
+++ b/testsuite/tests/warnings/w32b.reference
@@ -1,0 +1,2 @@
+File "w32b.ml", line 3, characters 18-24:
+Warning 34: unused type t.

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -265,20 +265,19 @@ open Format
 val report_error: formatter -> error -> unit
 
 
-val mark_value_used: t -> string -> value_description -> unit
-val mark_module_used: t -> string -> Location.t -> unit
-val mark_type_used: t -> string -> type_declaration -> unit
+val mark_value_used: string -> value_description -> unit
+val mark_module_used: string -> Location.t -> unit
+val mark_type_used: string -> type_declaration -> unit
 
 type constructor_usage = Positive | Pattern | Privatize
 val mark_constructor_used:
-    constructor_usage -> t -> string -> type_declaration -> string -> unit
+    constructor_usage -> string -> type_declaration -> string -> unit
 val mark_constructor:
     constructor_usage -> t -> string -> constructor_description -> unit
 val mark_extension_used:
-    constructor_usage -> t -> extension_constructor -> string -> unit
+    constructor_usage -> extension_constructor -> string -> unit
 
 val in_signature: bool -> t -> t
-val implicit_coercion: t -> t
 
 val is_in_signature: t -> bool
 

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -43,12 +43,11 @@ val value_descriptions:
 val type_declarations:
   ?equality:bool ->
   loc:Location.t ->
-  Env.t -> string ->
+  Env.t -> mark:bool -> string ->
   type_declaration -> Ident.t -> type_declaration -> type_mismatch list
 
 val extension_constructors:
-  loc:Location.t ->
-  Env.t -> Ident.t ->
+  loc:Location.t -> Env.t -> mark:bool -> Ident.t ->
   extension_constructor -> extension_constructor -> bool
 (*
 val class_types:

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -19,8 +19,20 @@ open Typedtree
 open Types
 open Format
 
+(** Type describing which arguments of an inclusion to consider as used
+    for the usage warnings. [Mark_both] is the default. *)
+type mark =
+  | Mark_both
+      (** Mark definitions used from both arguments *)
+  | Mark_positive
+      (** Mark definitions used from the positive (first) argument *)
+  | Mark_negative
+      (** Mark definitions used from the negative (second) argument *)
+  | Mark_neither
+      (** Do not mark definitions used from either argument *)
+
 val modtypes:
-  loc:Location.t -> Env.t ->
+  loc:Location.t -> Env.t -> ?mark:mark ->
   module_type -> module_type -> module_coercion
 
 val check_modtype_inclusion :
@@ -29,13 +41,15 @@ val check_modtype_inclusion :
     functor application F(M) is well typed, where mty2 is the type of
     the argument of F and path1/mty1 is the path/unstrenghened type of M. *)
 
-val signatures: Env.t -> signature -> signature -> module_coercion
+val signatures: Env.t -> ?mark:mark ->
+  signature -> signature -> module_coercion
 
 val compunit:
-      Env.t -> string -> signature -> string -> signature -> module_coercion
+      Env.t -> ?mark:mark -> string -> signature ->
+      string -> signature -> module_coercion
 
 val type_declarations:
-  loc:Location.t -> Env.t ->
+  loc:Location.t -> Env.t -> ?mark:mark ->
   Ident.t -> type_declaration -> type_declaration -> unit
 
 val print_coercion: formatter -> module_coercion -> unit

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -684,7 +684,7 @@ end) = struct
 
   let lookup_from_type env tpath lid =
     let descrs = get_descrs (Env.find_type_descrs tpath env) in
-    Env.mark_type_used env (Path.last tpath) (Env.find_type tpath env);
+    Env.mark_type_used (Path.last tpath) (Env.find_type tpath env);
     match lid.txt with
       Longident.Lident s -> begin
         try
@@ -4867,7 +4867,7 @@ and type_let ?(check = fun s -> Warnings.Unused_var s)
                          slot := (name, vd) :: !slot; rec_needed := true
                        | None ->
                          List.iter
-                           (fun (name, vd) -> Env.mark_value_used env name vd)
+                           (fun (name, vd) -> Env.mark_value_used name vd)
                            (get_ref slot);
                          used := true;
                          some_used := true

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -687,6 +687,7 @@ let check_coherence env loc id decl =
               then [Includecore.Constraint]
               else
                 Includecore.type_declarations ~loc ~equality:true env
+                  ~mark:true
                   (Path.last path)
                   decl'
                   id
@@ -1310,7 +1311,7 @@ let transl_type_decl env rec_flag sdecl_list =
              match !current_slot with
              | Some slot -> slot := (name, td) :: !slot
              | None ->
-                 List.iter (fun (name, d) -> Env.mark_type_used env name d)
+                 List.iter (fun (name, d) -> Env.mark_type_used name d)
                    (get_ref slot);
                  old_callback ()
           );
@@ -1799,7 +1800,7 @@ let transl_value_decl env loc valdecl =
 (* Translate a "with" constraint -- much simplified version of
     transl_type_decl. *)
 let transl_with_constraint env id row_path orig_decl sdecl =
-  Env.mark_type_used env (Ident.name id) orig_decl;
+  Env.mark_type_used (Ident.name id) orig_decl;
   reset_type_variables();
   Ctype.begin_def();
   let tparams = make_params env sdecl.ptype_params in


### PR DESCRIPTION
The following `.ml` file:

```ocaml
module Q (M : sig type t end) = struct end
```

with the following `.mli` file:

```ocaml
module Q : functor (M : sig type t end) -> sig  end
```

helpfully emits the warning:

```ocaml
File "unused.ml", line 1, characters 18-24:
Warning 34: unused type t.
```

However, if the `.mli` file is removed then the warning disappears, even though this is the `.mli` file that `ocamlc -i` generates for the `.ml` file.

The problem comes from the inclusion check between the module and its interface. An inclusion check like:

```ocaml
Includemod.modtypes ~loc env a b
```

will mark the definitions occurring positively (covariantly) in `a` and negatively (contravariantly) in `b`. In most cases this is correct, but when checking an `.ml` file against its interface we only really want to mark the definitions occurring positively in `a`.

There already exists `Env.implicit_coercion` which is used for dealing with implicit coercions. However, this disables all marking in an inclusion, not just the negative marking.

This PR removes `Env.implicit_coercion` and adds parameters to the `Includemod` functions with type:

```ocaml
(** Type describing which arguments of an inclusion to consider as used
    for the usage warnings. [Mark_both] is the default. *)
type mark =
  | Mark_both
      (** Mark definitions used from both arguments *)
  | Mark_positive
      (** Mark definitions used from the positive (first) argument *)
  | Mark_negative
      (** Mark definitions used from the negative (second) argument *)
  | Mark_neither
      (** Do not mark definitions used from either argument *)
```

`Mark_both` is used for most inclusions, `Mark_neither` is used for implicit coercions, and `Mark_positive` is used when checking an `.ml` file against its interface. (`Mark_negative` is used within `Includemod` and is exposed in the interface for completeness).