### PR TITLE
fix flexdll bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -577,7 +577,7 @@ flexlink: flexdll/Makefile
 	cd stdlib && cp stdlib.cma std_exit.cmo *.cmi ../boot
 	$(MAKE) -C flexdll MSVC_DETECT=0 TOOLCHAIN=$(TOOLCHAIN) \
 	  OCAML_CONFIG_FILE=../config/Makefile \
-	  TOOLPREF=$(TOOLPREF) CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false \
+	  CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false \
 	  OCAMLOPT="../boot/ocamlrun ../boot/ocamlc -I ../boot" \
 	  flexlink.exe
 	$(MAKE) -C byterun clean
@@ -589,7 +589,7 @@ flexlink.opt:
 	mv flexlink.exe flexlink && \
 	$(MAKE) OCAML_FLEXLINK="../boot/ocamlrun ./flexlink" MSVC_DETECT=0 \
 	           OCAML_CONFIG_FILE=../config/Makefile \
-	           TOOLCHAIN=$(TOOLCHAIN) TOOLPREF=$(TOOLPREF) \
+	           TOOLCHAIN=$(TOOLCHAIN) \
 	           OCAMLOPT="../ocamlopt.opt -I ../stdlib" flexlink.exe && \
 	mv flexlink.exe flexlink.opt && \
 	mv flexlink flexlink.exe

--- a/Makefile
+++ b/Makefile
@@ -575,8 +575,7 @@ flexlink: flexdll/Makefile
 	cp byterun/ocamlrun$(EXE) boot/ocamlrun$(EXE)
 	$(MAKE) -C stdlib COMPILER=../boot/ocamlc stdlib.cma std_exit.cmo
 	cd stdlib && cp stdlib.cma std_exit.cmo *.cmi ../boot
-	$(MAKE) -C flexdll MSVC_DETECT=0 TOOLCHAIN=$(TOOLCHAIN) \
-	  OCAML_CONFIG_FILE=../config/Makefile \
+	$(MAKE) -C flexdll MSVC_DETECT=0 OCAML_CONFIG_FILE=../config/Makefile \
 	  CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false \
 	  OCAMLOPT="../boot/ocamlrun ../boot/ocamlc -I ../boot" \
 	  flexlink.exe
@@ -589,7 +588,6 @@ flexlink.opt:
 	mv flexlink.exe flexlink && \
 	$(MAKE) OCAML_FLEXLINK="../boot/ocamlrun ./flexlink" MSVC_DETECT=0 \
 	           OCAML_CONFIG_FILE=../config/Makefile \
-	           TOOLCHAIN=$(TOOLCHAIN) \
 	           OCAMLOPT="../ocamlopt.opt -I ../stdlib" flexlink.exe && \
 	mv flexlink.exe flexlink.opt && \
 	mv flexlink flexlink.exe

--- a/Makefile
+++ b/Makefile
@@ -565,6 +565,7 @@ flexdll/Makefile:
 .PHONY: flexdll
 flexdll: flexdll/Makefile flexlink
 	$(MAKE) -C flexdll \
+	     OCAML_CONFIG_FILE=../config/Makefile \
              MSVC_DETECT=0 CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false support
 
 # Bootstrapping flexlink - leaves a bytecode image of flexlink.exe in flexdll/
@@ -575,6 +576,7 @@ flexlink: flexdll/Makefile
 	$(MAKE) -C stdlib COMPILER=../boot/ocamlc stdlib.cma std_exit.cmo
 	cd stdlib && cp stdlib.cma std_exit.cmo *.cmi ../boot
 	$(MAKE) -C flexdll MSVC_DETECT=0 TOOLCHAIN=$(TOOLCHAIN) \
+	  OCAML_CONFIG_FILE=../config/Makefile \
 	  TOOLPREF=$(TOOLPREF) CHAINS=$(FLEXDLL_CHAIN) NATDYNLINK=false \
 	  OCAMLOPT="../boot/ocamlrun ../boot/ocamlc -I ../boot" \
 	  flexlink.exe
@@ -586,6 +588,7 @@ flexlink.opt:
 	cd flexdll && \
 	mv flexlink.exe flexlink && \
 	$(MAKE) OCAML_FLEXLINK="../boot/ocamlrun ./flexlink" MSVC_DETECT=0 \
+	           OCAML_CONFIG_FILE=../config/Makefile \
 	           TOOLCHAIN=$(TOOLCHAIN) TOOLPREF=$(TOOLPREF) \
 	           OCAMLOPT="../ocamlopt.opt -I ../stdlib" flexlink.exe && \
 	mv flexlink.exe flexlink.opt && \

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -326,12 +326,15 @@ done in one of three ways:
 OCaml is then compiled as normal for the port you require, except that before
 compiling `world`, you must compile `flexdll`, i.e.:
 
-  make flexdll world [bootstrap] opt opt.opt install
+  make flexdll world [bootstrap] opt opt.opt flexlink.opt install
 
  * You should ignore the error messages that say ocamlopt was not found.
  * `make install` will install FlexDLL by placing `flexlink.exe`
    (and the default manifest file for the Microsoft port) in `bin/` and the
    FlexDLL object files in `lib/`.
+ * If you don't include `make flexlink.opt`, `flexlink.exe` will be a
+   bytecode program.  `make install` always installs the "best"
+   `flexlink.exe` (i.e. there is never a `flexlink.opt.exe` installed).
  * If you have populated `flexdll/`, you *must* run
    `make flexdll`.  If you wish to revert to using an externally
    installed FlexDLL, you must erase the contents of `flexdll/` before

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -328,12 +328,10 @@ compiling `world`, you must compile `flexdll`, i.e.:
 
   make flexdll world [bootstrap] opt opt.opt install
 
+ * You should ignore the error messages that say ocamlopt was not found.
  * `make install` will install FlexDLL by placing `flexlink.exe`
    (and the default manifest file for the Microsoft port) in `bin/` and the
    FlexDLL object files in `lib/`.
- * If you don't include `make opt.opt`, `flexlink.exe` will be a
-   bytecode program.  `make install` always installs the "best"
-   `flexlink.exe` (i.e. there is never a `flexlink.opt.exe` installed).
  * If you have populated `flexdll/`, you *must* run
    `make flexdll`.  If you wish to revert to using an externally
    installed FlexDLL, you must erase the contents of `flexdll/` before


### PR DESCRIPTION
Make it possible to bootstrap `flexdll` on a machine that doesn't already have `ocamlopt` installed.

Remove a false sentence from `README.win32.adoc` (about flexlink.opt).
