### PR TITLE
MPR#7609: use-after-free with ocamldebug and Pervasives.flush_all

### DIFF
--- a/Changes
+++ b/Changes
@@ -527,7 +527,7 @@ Release branch for 4.06:
 
 - MPR#7609: use-after-free memory corruption if a program debugged
   under ocamldebug calls Pervasives.flush_all
-  (Xavier Leroy, report by Paul Steckler)
+  (Xavier Leroy, report by Paul Steckler, review by Gabriel Scherer)
 
 - GPR#1155: Fix a race condition with WAIT_NOHANG on Windows
   (Jérémie Dimino and David Allsopp)

--- a/Changes
+++ b/Changes
@@ -525,6 +525,10 @@ Release branch for 4.06:
 - MPR#7591, GPR#1257: on x86-64, frame table is not 8-aligned
   (Xavier Leroy, report by Mantis user "voglerr", review by Gabriel Scherer)
 
+- MPR#7609: use-after-free memory corruption if a program debugged
+  under ocamldebug calls Pervasives.flush_all
+  (Xavier Leroy, report by Paul Steckler)
+
 - GPR#1155: Fix a race condition with WAIT_NOHANG on Windows
   (Jérémie Dimino and David Allsopp)
 

--- a/byterun/caml/io.h
+++ b/byterun/caml/io.h
@@ -55,8 +55,9 @@ struct channel {
 enum {
   CHANNEL_FLAG_FROM_SOCKET = 1,  /* For Windows */
 #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
-  CHANNEL_FLAG_BLOCKING_WRITE = 2,
+  CHANNEL_FLAG_BLOCKING_WRITE = 2, /* Don't release master lock when writing */
 #endif
+  CHANNEL_FLAG_MANAGED_BY_GC = 4,  /* Free and close using GC finalization */
 };
 
 /* For an output channel:

--- a/byterun/debugger.c
+++ b/byterun/debugger.c
@@ -131,6 +131,7 @@ static void open_connection(void)
 #endif
   dbg_in = caml_open_descriptor_in(dbg_socket);
   dbg_out = caml_open_descriptor_out(dbg_socket);
+  dbg_out->refcount++; /* prevent deallocation at finalization, MPR#7609 */
   if (!caml_debugger_in_use) caml_putword(dbg_out, -1); /* first connection */
 #ifdef _WIN32
   caml_putword(dbg_out, _getpid());

--- a/byterun/debugger.c
+++ b/byterun/debugger.c
@@ -131,7 +131,6 @@ static void open_connection(void)
 #endif
   dbg_in = caml_open_descriptor_in(dbg_socket);
   dbg_out = caml_open_descriptor_out(dbg_socket);
-  dbg_out->refcount++; /* prevent deallocation at finalization, MPR#7609 */
   if (!caml_debugger_in_use) caml_putword(dbg_out, -1); /* first connection */
 #ifdef _WIN32
   caml_putword(dbg_out, _getpid());
@@ -144,7 +143,6 @@ static void open_connection(void)
 static void close_connection(void)
 {
   caml_close_channel(dbg_in);
-  dbg_out->refcount--;
   caml_close_channel(dbg_out);
   dbg_socket = -1;              /* was closed by caml_close_channel */
 }

--- a/byterun/debugger.c
+++ b/byterun/debugger.c
@@ -144,6 +144,7 @@ static void open_connection(void)
 static void close_connection(void)
 {
   caml_close_channel(dbg_in);
+  dbg_out->refcount--;
   caml_close_channel(dbg_out);
   dbg_socket = -1;              /* was closed by caml_close_channel */
 }


### PR DESCRIPTION
This commit makes sure that the "dbg_out" channel used to send data from the debugged program back to ocamldebug cannot be freed early by finalization.

[MPR#7609](https://caml.inria.fr/mantis/view.php?id=7609) shows a scenario where this happens:

* Debugged program starts, opens an out channel "dbg_out" to send data to ocamldebug via the debugging socket.
* Channel is created by caml_open_descriptor_in with refcount = 0 and is inserted in the doubly-linked list caml_all_opened_channels.
* Later, debugged program calls Pervasives.flush_all, which calls caml_ml_out_channels_list.
* caml_ml_out_channels_list wraps dbg_out in a Caml custom object of type "out_channel".  dbg_out->refcount is increased to 1.
* Later, a GC finalizes this Caml custom object.  dbg_out->refcount is decreased to 0 and the dbg_out structure is freed via caml_stat_free().
* Subsequent interactions with ocamldebug access the now-freed dbg_out structure.  Disaster ensues.

The fix is just to increase the refcount of dbg_out to signal that it is "held" by the debugger interface.

No such fix is needed for dbg_in or other channels allocated from C using caml_open_descriptor_in, because those input channels are skipped by caml_ml_out_channels_list and never re-wrapped as Caml custom objects.
