### PR TITLE
Fix headernt.c & -output-obj Unicode support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,7 +352,6 @@ _ocamltest
 /testsuite/tests/warnings/w58.opt.opt_result
 
 /testsuite/tests/win-unicode/symlink_tests.precheck
-/testsuite/tests/win-unicode/exec_tests.precheck
 
 /testsuite/tools/expect_test
 

--- a/.gitignore
+++ b/.gitignore
@@ -352,6 +352,7 @@ _ocamltest
 /testsuite/tests/warnings/w58.opt.opt_result
 
 /testsuite/tests/win-unicode/symlink_tests.precheck
+/testsuite/tests/win-unicode/exec_tests.precheck
 
 /testsuite/tools/expect_test
 

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -487,7 +487,7 @@ let link_bytecode_as_c ppf tolink outfile =
     Symtable.output_primitive_table outchan;
     (* The entry point *)
     output_string outchan "\
-\nvoid caml_startup(char ** argv)\
+\nvoid caml_startup(charnat ** argv)\
 \n{\
 \n  caml_startup_code(caml_code, sizeof(caml_code),\
 \n                    caml_data, sizeof(caml_data),\
@@ -496,7 +496,7 @@ let link_bytecode_as_c ppf tolink outfile =
 \n                    argv);\
 \n}\
 \n\
-\nvalue caml_startup_exn(char ** argv)\
+\nvalue caml_startup_exn(charnat ** argv)\
 \n{\
 \n  return caml_startup_code_exn(caml_code, sizeof(caml_code),\
 \n                               caml_data, sizeof(caml_data),\
@@ -505,7 +505,7 @@ let link_bytecode_as_c ppf tolink outfile =
 \n                               argv);\
 \n}\
 \n\
-\nvoid caml_startup_pooled(char ** argv)\
+\nvoid caml_startup_pooled(charnat ** argv)\
 \n{\
 \n  caml_startup_code(caml_code, sizeof(caml_code),\
 \n                    caml_data, sizeof(caml_data),\
@@ -514,7 +514,7 @@ let link_bytecode_as_c ppf tolink outfile =
 \n                    argv);\
 \n}\
 \n\
-\nvalue caml_startup_pooled_exn(char ** argv)\
+\nvalue caml_startup_pooled_exn(charnat ** argv)\
 \n{\
 \n  return caml_startup_code_exn(caml_code, sizeof(caml_code),\
 \n                               caml_data, sizeof(caml_data),\

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -158,7 +158,7 @@ else # Windows
 
 camlheader target_camlheader camlheader_ur: headernt.c
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) -I../byterun \
-	          -DRUNTIME_NAME='L"ocamlrun"' $(OUTPUTOBJ)headernt.$(O) $<
+	          -DRUNTIME_NAME='"ocamlrun"' $(OUTPUTOBJ)headernt.$(O) $<
 	$(MKEXE) -o tmpheader.exe headernt.$(O) $(EXTRALIBS)
 	rm -f camlheader.exe
 	mv tmpheader.exe camlheader
@@ -167,14 +167,14 @@ camlheader target_camlheader camlheader_ur: headernt.c
 
 camlheaderd target_camlheaderd: headernt.c
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) -I../byterun \
-	          -DRUNTIME_NAME='L"ocamlrund"' $(OUTPUTOBJ)headernt.$(O) $<
+	          -DRUNTIME_NAME='"ocamlrund"' $(OUTPUTOBJ)headernt.$(O) $<
 	$(MKEXE) -o tmpheader.exe headernt.$(O) $(EXTRALIBS)
 	mv tmpheader.exe camlheaderd
 	cp camlheaderd target_camlheaderd
 
 camlheaderi: headernt.c
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) -I../byterun \
-	          -DRUNTIME_NAME='L"ocamlruni"' $(OUTPUTOBJ)headernt.$(O)
+	          -DRUNTIME_NAME='"ocamlruni"' $(OUTPUTOBJ)headernt.$(O)
 	$(MKEXE) -o tmpheader.exe headernt.$(O) $(EXTRALIBS)
 	mv tmpheader.exe camlheaderi
 

--- a/stdlib/headernt.c
+++ b/stdlib/headernt.c
@@ -31,7 +31,7 @@
 #endif
 #endif
 
-wchar_t * default_runtime_name = RUNTIME_NAME;
+char * default_runtime_name = RUNTIME_NAME;
 
 static
 #if _MSC_VER >= 1200
@@ -46,10 +46,10 @@ unsigned long read_size(const char * const ptr)
          ((unsigned long) p[2] << 8) | p[3];
 }
 
-static __inline wchar_t * read_runtime_path(HANDLE h)
+static __inline char * read_runtime_path(HANDLE h)
 {
   char buffer[TRAILER_SIZE];
-  static wchar_t runtime_path[MAX_PATH];
+  static char runtime_path[MAX_PATH];
   DWORD nread;
   int num_sections, path_size, i;
   long ofs;
@@ -87,6 +87,12 @@ static BOOL WINAPI ctrl_handler(DWORD event)
     return FALSE;
 }
 
+#if WINDOWS_UNICODE
+#define CP CP_UTF8
+#else
+#define CP CP_THREAD_ACP
+#endif
+
 #define msg_and_length(msg) msg , (sizeof(msg) - 1)
 
 static __inline void __declspec(noreturn) run_runtime(wchar_t * runtime,
@@ -101,9 +107,9 @@ static __inline void __declspec(noreturn) run_runtime(wchar_t * runtime,
     char runtime_cp[MAX_PATH];
     DWORD numwritten;
     errh = GetStdHandle(STD_ERROR_HANDLE);
-    WideCharToMultiByte(CP_UTF8, 0, runtime, -1, runtime_cp, sizeof(runtime_cp), NULL, NULL);
+    WideCharToMultiByte(CP, 0, runtime, -1, runtime_cp, sizeof(runtime_cp), NULL, NULL);
     WriteFile(errh, msg_and_length("Cannot exec "), &numwritten, NULL);
-    WriteFile(errh, msg_and_length(runtime_cp), &numwritten, NULL);
+    WriteFile(errh, runtime_cp, strlen(runtime_cp), &numwritten, NULL);
     WriteFile(errh, msg_and_length("\r\n"), &numwritten, NULL);
     ExitProcess(2);
 #if _MSC_VER >= 1200
@@ -127,6 +133,7 @@ static __inline void __declspec(noreturn) run_runtime(wchar_t * runtime,
     char runtime_cp[MAX_PATH];
     DWORD numwritten;
     errh = GetStdHandle(STD_ERROR_HANDLE);
+    WideCharToMultiByte(CP, 0, runtime, -1, runtime_cp, sizeof(runtime_cp), NULL, NULL);
     WriteFile(errh, msg_and_length("Cannot exec "), &numwritten, NULL);
     WriteFile(errh, runtime_cp, strlen(runtime_cp), &numwritten, NULL);
     WriteFile(errh, msg_and_length("\r\n"), &numwritten, NULL);
@@ -149,7 +156,8 @@ int wmain(void)
 {
   wchar_t truename[MAX_PATH];
   wchar_t * cmdline = GetCommandLine();
-  wchar_t * runtime_path;
+  char * runtime_path;
+  wchar_t wruntime_path[MAX_PATH];
   HANDLE h;
 
   GetModuleFileName(NULL, truename, sizeof(truename)/sizeof(wchar_t));
@@ -161,8 +169,8 @@ int wmain(void)
     char truename_cp[MAX_PATH];
     DWORD numwritten;
     errh = GetStdHandle(STD_ERROR_HANDLE);
-    WideCharToMultiByte(CP_UTF8, 0, truename, -1, truename_cp, sizeof(truename_cp), NULL, NULL);
-    WriteFile(errh, msg_and_length(truename_cp), &numwritten, NULL);
+    WideCharToMultiByte(CP, 0, truename, -1, truename_cp, sizeof(truename_cp), NULL, NULL);
+    WriteFile(errh, truename_cp, strlen(truename_cp), &numwritten, NULL);
     WriteFile(errh, msg_and_length(" not found or is not a bytecode"
                                    " executable file\r\n"),
               &numwritten, NULL);
@@ -172,7 +180,8 @@ int wmain(void)
 #endif
   }
   CloseHandle(h);
-  run_runtime(runtime_path , cmdline);
+  MultiByteToWideChar(CP, 0, runtime_path, -1, wruntime_path, sizeof(wruntime_path)/sizeof(wchar_t));
+  run_runtime(wruntime_path , cmdline);
 #if _MSC_VER >= 1200
     __assume(0); /* Not reached */
 #endif

--- a/stdlib/headernt.c
+++ b/stdlib/headernt.c
@@ -93,7 +93,18 @@ static BOOL WINAPI ctrl_handler(DWORD event)
 #define CP CP_THREAD_ACP
 #endif
 
-#define msg_and_length(msg) msg , (sizeof(msg) - 1)
+static void write_console(HANDLE hOut, WCHAR *wstr)
+{
+  DWORD consoleMode, numwritten, len;
+  static char str[MAX_PATH];
+
+  if (GetConsoleMode(hOut, &consoleMode) != 0) { /* The output stream is a Console */
+    WriteConsole(hOut, wstr, wcslen(wstr), &numwritten, NULL);
+  } else { /* The output stream is redirected */
+    len = WideCharToMultiByte(CP, 0, wstr, wcslen(wstr), str, sizeof(str), NULL, NULL);
+    WriteFile(hOut, str, len, &numwritten, NULL);
+  }
+}
 
 static __inline void __declspec(noreturn) run_runtime(wchar_t * runtime,
          wchar_t * const cmdline)
@@ -104,13 +115,10 @@ static __inline void __declspec(noreturn) run_runtime(wchar_t * runtime,
   DWORD retcode;
   if (SearchPath(NULL, runtime, L".exe", sizeof(path)/sizeof(wchar_t), path, &runtime) == 0) {
     HANDLE errh;
-    char runtime_cp[MAX_PATH];
-    DWORD numwritten;
     errh = GetStdHandle(STD_ERROR_HANDLE);
-    WideCharToMultiByte(CP, 0, runtime, -1, runtime_cp, sizeof(runtime_cp), NULL, NULL);
-    WriteFile(errh, msg_and_length("Cannot exec "), &numwritten, NULL);
-    WriteFile(errh, runtime_cp, strlen(runtime_cp), &numwritten, NULL);
-    WriteFile(errh, msg_and_length("\r\n"), &numwritten, NULL);
+    write_console(errh, L"Cannot exec ");
+    write_console(errh, runtime);
+    write_console(errh, L"\r\n");
     ExitProcess(2);
 #if _MSC_VER >= 1200
     __assume(0); /* Not reached */
@@ -130,13 +138,10 @@ static __inline void __declspec(noreturn) run_runtime(wchar_t * runtime,
   if (!CreateProcess(path, cmdline, NULL, NULL, TRUE, 0, NULL, NULL,
                      &stinfo, &procinfo)) {
     HANDLE errh;
-    char runtime_cp[MAX_PATH];
-    DWORD numwritten;
     errh = GetStdHandle(STD_ERROR_HANDLE);
-    WideCharToMultiByte(CP, 0, runtime, -1, runtime_cp, sizeof(runtime_cp), NULL, NULL);
-    WriteFile(errh, msg_and_length("Cannot exec "), &numwritten, NULL);
-    WriteFile(errh, runtime_cp, strlen(runtime_cp), &numwritten, NULL);
-    WriteFile(errh, msg_and_length("\r\n"), &numwritten, NULL);
+    write_console(errh, L"Cannot exec ");
+    write_console(errh, runtime);
+    write_console(errh, L"\r\n");
     ExitProcess(2);
 #if _MSC_VER >= 1200
     __assume(0); /* Not reached */
@@ -166,14 +171,9 @@ int wmain(void)
   if (h == INVALID_HANDLE_VALUE ||
       (runtime_path = read_runtime_path(h)) == NULL) {
     HANDLE errh;
-    char truename_cp[MAX_PATH];
-    DWORD numwritten;
     errh = GetStdHandle(STD_ERROR_HANDLE);
-    WideCharToMultiByte(CP, 0, truename, -1, truename_cp, sizeof(truename_cp), NULL, NULL);
-    WriteFile(errh, truename_cp, strlen(truename_cp), &numwritten, NULL);
-    WriteFile(errh, msg_and_length(" not found or is not a bytecode"
-                                   " executable file\r\n"),
-              &numwritten, NULL);
+    write_console(errh, truename);
+    write_console(errh, L" not found or is not a bytecode executable file\r\n");
     ExitProcess(2);
 #if _MSC_VER >= 1200
     __assume(0); /* Not reached */

--- a/testsuite/tests/win-unicode/Makefile
+++ b/testsuite/tests/win-unicode/Makefile
@@ -9,7 +9,7 @@ C_FILES=mkfiles
 .PHONY: test
 test:
 	@if echo 'let () = exit (if Config.windows_unicode then 0 else 1)' | $(OCAML) -I $(OTOPDIR)/utils config.cmo -stdin; then \
-	  $(MAKE) printargv.exe printenv.exe symlink_tests.precheck exec_tests.precheck && \
+	  $(MAKE) printargv.exe printenv.exe symlink_tests.precheck && \
 	  $(MAKE) check; \
 	else \
 	  $(MAKE) SKIP=true C_FILES= run-all; \
@@ -18,10 +18,6 @@ test:
 .PHONY: symlink_tests.precheck
 symlink_tests.precheck:
 	@echo 'echo "let () = exit (if Unix.has_symlink () then 0 else 1)" | $(OCAML) $(ADD_COMPFLAGS) unix.cma -stdin' > $@
-
-.PHONY: exec_tests.precheck
-exec_tests.precheck:
-	@echo 'exit 1' > $@
 
 include $(BASEDIR)/makefiles/Makefile.several
 include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/win-unicode/Makefile
+++ b/testsuite/tests/win-unicode/Makefile
@@ -9,7 +9,7 @@ C_FILES=mkfiles
 .PHONY: test
 test:
 	@if echo 'let () = exit (if Config.windows_unicode then 0 else 1)' | $(OCAML) -I $(OTOPDIR)/utils config.cmo -stdin; then \
-	  $(MAKE) printargv.exe printenv.exe symlink_tests.precheck && \
+	  $(MAKE) printargv.exe printenv.exe symlink_tests.precheck exec_tests.precheck && \
 	  $(MAKE) check; \
 	else \
 	  $(MAKE) SKIP=true C_FILES= run-all; \

--- a/testsuite/tests/win-unicode/exec_tests.precheck
+++ b/testsuite/tests/win-unicode/exec_tests.precheck
@@ -1,0 +1,3 @@
+# exec_tests.ml disabled because it fails non-deterministically (at least under CI)
+# seems to be a problem redirecting handles
+exit 1


### PR DESCRIPTION
This is a follow-up to #1200.  It does three things:

- Fixes a bad rebase of `read_runtime_path` of `headernt.c`
- Fixes the C signature of the `argv` argument in the C file generated by `-output-obj`
- Uses `WriteConsole` in `headernt.c` to properly print Unicode pathnames in error messages.

Together with #1357 this should fix the remaining Windows testsuite errors.

/cc @dra27 