### PR TITLE
ocamltest: only test the compilers that have actually been compiled

### DIFF
--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -152,6 +152,7 @@ ocamltest.opt$(EXE): $(native_modules)
 
 ocamltest_config.ml: ocamltest_config.ml.in
 	sed \
+	  -e 's|@@ARCH@@|$(ARCH)|' \
 	  -e 's|@@CPP@@|$(CPP)|' \
 	  -e 's|@@OCAMLCDEFAULTFLAGS@@|$(ocamlcdefaultflags)|' \
 	  -e 's|@@OCAMLOPTDEFAULTFLAGS@@|$(ocamloptdefaultflags)|' \

--- a/ocamltest/builtin_tests.ml
+++ b/ocamltest/builtin_tests.ml
@@ -18,7 +18,14 @@
 open Tests
 open Builtin_actions
 
-let bytecode = {
+let bytecode =
+  let opt_actions =
+  [
+    compile_bytecode_with_native_compiler;
+    check_ocamlc_dot_opt_output;
+    compare_bytecode_programs
+  ] in
+{
   test_name = "bytecode";
   test_run_by_default = true;
   test_actions =
@@ -26,11 +33,8 @@ let bytecode = {
     compile_bytecode_with_bytecode_compiler;
     check_ocamlc_dot_byte_output;
     execute;
-    check_program_output;
-    compile_bytecode_with_native_compiler;
-    check_ocamlc_dot_opt_output;
-    compare_bytecode_programs;
-  ]
+    check_program_output
+  ] @ (if Ocamltest_config.arch<>"none" then opt_actions else [])
 }
 
 let expect = {
@@ -79,7 +83,7 @@ let _ =
   [
     bytecode;
     expect;
-    native;
     script;
     toplevel;
-  ]
+  ];
+  if (Ocamltest_config.arch <> "none") then register native

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -15,6 +15,8 @@
 
 (* The configuration module for ocamltest *)
 
+let arch = "@@ARCH@@"
+
 let c_preprocessor = "@@CPP@@"
 
 let ocamlsrcdir = "@@OCAMLSRCDIR@@"

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -15,6 +15,9 @@
 
 (* Interface for ocamltest's configuration module *)
 
+val arch : string
+(** Architecture for the native compiler, "none" if it is disabled *)
+
 val c_preprocessor : string
 (** Command to use to invoke the C preprocessor *)
 


### PR DESCRIPTION
Before this PR, ocamltest systematically tried to use both native
and bytecode compilers, no matter what had been configured.

So the native tests were tried even when configure was called with
the -no-native-compiler option, leading to expected failures.

This PR fixes this and makes sure the test and actions involving native
compilers are run only when those compilers have actually been compiled.

Should be included in 4.06, too.