### PR TITLE
Fix gethost.c C const warning when using compile-time -safe-string

### DIFF
--- a/Changes
+++ b/Changes
@@ -606,9 +606,9 @@ Release branch for 4.06:
 - GPR#1269: Remove 50ms delay at exit for programs using threads
   (Valentin Gatien-Baron, review by Stephen Dolan)
 
-* MPR#7594, GPR#1274: String_val now returns 'const char*', not
-  'char*' when -safe-string is enabled at configure time.
-  New macro Bytes_val for accessing bytes values.
+* MPR#7594, GPR#1274, GPR#1368: String_val now returns 'const char*', not
+  'char*' when -safe-string is enabled at configure time.  New macro Bytes_val
+  for accessing bytes values.
   (Jeremy Yallop, reviews by Mark Shinwell and Xavier Leroy)
 
 * GPR#1309: open files with O_CLOEXEC (or equivalent) in caml_sys_open thus

--- a/otherlibs/unix/gethost.c
+++ b/otherlibs/unix/gethost.c
@@ -135,11 +135,7 @@ CAMLprim value unix_gethostbyname(value name)
 
   if (! caml_string_is_c_safe(name)) caml_raise_not_found();
 
-#if HAS_GETHOSTBYNAME_R || GETHOSTBYNAME_IS_REENTRANT
   hostname = caml_stat_strdup(String_val(name));
-#else
-  hostname = String_val(name);
-#endif
 
 #if HAS_GETHOSTBYNAME_R == 5
   {
@@ -165,9 +161,7 @@ CAMLprim value unix_gethostbyname(value name)
 #endif
 #endif
 
-#if HAS_GETHOSTBYNAME_R || GETHOSTBYNAME_IS_REENTRANT
   caml_stat_free(hostname);
-#endif
 
   if (hp == (struct hostent *) NULL) caml_raise_not_found();
   return alloc_host_entry(hp);


### PR DESCRIPTION
When using compile-time `-safe-string` (#687), `String_val` returns a `const char *` (#1274), but `caml_stat_strdup` returns a `char *`, so both branches of the `#if` below are not compatible.  I fixed it always copying the string. Is this the canonical way to do this ?