### PR TITLE
Unix.environment on Windows: use _wenviron

### DIFF
--- a/Changes
+++ b/Changes
@@ -424,8 +424,8 @@ Release branch for 4.06:
 
 ### Runtime system:
 
-* MPR#3771, GPR#153, GPR#1200, GPR#1357, GPR#1362, GPR#1363, GPR#1398: Unicode
-  support for the Windows runtime.
+* MPR#3771, GPR#153, GPR#1200, GPR#1357, GPR#1362, GPR#1363, GPR#1369, GPR#1398:
+  Unicode support for the Windows runtime.
   (ygrek, Nicolas Ojeda Bar, review by Alain Frisch, David Allsopp, Damien
   Doligez)
 

--- a/otherlibs/win32unix/envir.c
+++ b/otherlibs/win32unix/envir.c
@@ -21,23 +21,14 @@
 #include <caml/osdeps.h>
 
 #include <Windows.h>
+#include <stdlib.h>
 
 CAMLprim value unix_environment(value unit)
 {
-  CAMLparam0();
-  CAMLlocal2(v, result);
-  wchar_t * envp, * p;
-  int size, i;
-
   /* Win32 doesn't have a notion of setuid bit, so accessing environ is safe. */
-  envp = GetEnvironmentStrings();
-  for (p = envp, size = 0; *p; p += wcslen(p) + 1) size++;
-  result = caml_alloc(size, 0);
-  for (p = envp, i = 0; *p; p += wcslen(p) + 1) {
-    v = caml_copy_string_of_utf16(p);
-    Store_field(result, i ++, v);
+  if (_wenviron != NULL) {
+    return caml_alloc_array((void *)caml_copy_string_of_utf16, (const char**)_wenviron);
+  } else {
+    return Atom(0);
   }
-  FreeEnvironmentStrings(envp);
-
-  CAMLreturn(result);
 }

--- a/testsuite/tests/lib-unix/win-env/Makefile
+++ b/testsuite/tests/lib-unix/win-env/Makefile
@@ -1,0 +1,18 @@
+BASEDIR=../../..
+LIBRARIES=unix
+ADD_COMPFLAGS= \
+	-I $(OTOPDIR)/otherlibs/$(UNIXLIBVAR)unix \
+	-strict-sequence -safe-string -w A -warn-error A
+LD_PATH=$(TOPDIR)/otherlibs/$(UNIXLIBVAR)unix
+C_FILES=stubs
+
+.PHONY: test
+test:
+	@if echo 'let () = exit (if Sys.win32 then 0 else 1)' | $(OCAML) -stdin; then \
+	  $(MAKE) check; \
+	else \
+	  $(MAKE) SKIP=true C_FILES= run-all; \
+	fi
+
+include $(BASEDIR)/makefiles/Makefile.several
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/lib-unix/win-env/stubs.c
+++ b/testsuite/tests/lib-unix/win-env/stubs.c
@@ -1,0 +1,20 @@
+#define CAML_INTERNALS
+
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/fail.h>
+#include <caml/osdeps.h>
+
+#include <windows.h>
+
+CAMLprim value caml_SetEnvironmentVariable(value s1, value s2)
+{
+  WCHAR *w1, *w2;
+  w1 = caml_stat_strdup_to_utf16(String_val(s1));
+  w2 = caml_stat_strdup_to_utf16(String_val(s2));
+  SetEnvironmentVariableW(w1, w2);
+  caml_stat_free(w1);
+  caml_stat_free(w2);
+  return Val_unit;
+}

--- a/testsuite/tests/lib-unix/win-env/test_env.ml
+++ b/testsuite/tests/lib-unix/win-env/test_env.ml
@@ -1,0 +1,30 @@
+external set_environment_variable: string -> string -> unit = "caml_SetEnvironmentVariable"
+
+let find_env s =
+  let env = Unix.environment () in
+  let rec loop i =
+    if i >= Array.length env then
+      None
+    else begin
+      let e = env.(i) in
+      let pos = String.index e '=' in
+      if String.sub e 0 pos = s then
+        Some (String.sub e (pos+1) (String.length e - pos - 1))
+      else
+        loop (i+1)
+    end
+  in
+  loop 0
+
+let print title = function
+  | None ->
+      Printf.printf "%s -> None\n%!" title
+  | Some s ->
+      Printf.printf "%s -> Some %S\n%!" title s
+
+let foo = "FOO"
+
+let () =
+  set_environment_variable foo "BAR";
+  print "Sys.getenv FOO" (Sys.getenv_opt foo);
+  print "Unix.environment FOO" (find_env foo)

--- a/testsuite/tests/lib-unix/win-env/test_env.reference
+++ b/testsuite/tests/lib-unix/win-env/test_env.reference
@@ -1,0 +1,2 @@
+Sys.getenv FOO -> None
+Unix.environment FOO -> None

--- a/testsuite/tests/lib-unix/win-env/test_env2.ml
+++ b/testsuite/tests/lib-unix/win-env/test_env2.ml
@@ -1,0 +1,17 @@
+(* This test is disabled (see test_env2.precheck) as it fails due to MPR#4499:
+   the Windows POSIX environment does not get updated when using the native
+   Windows API SetEnvironmentVariable. *)
+
+external set_environment_variable: string -> string -> unit = "caml_SetEnvironmentVariable"
+
+let print title = function
+  | None ->
+      Printf.printf "%s -> None\n%!" title
+  | Some s ->
+      Printf.printf "%s -> Some %S\n%!" title s
+
+let foo = "FOO"
+
+let () =
+  set_environment_variable foo "BAR";
+  print "Sys.getenv FOO" (Sys.getenv_opt foo)

--- a/testsuite/tests/lib-unix/win-env/test_env2.precheck
+++ b/testsuite/tests/lib-unix/win-env/test_env2.precheck
@@ -1,0 +1,4 @@
+# test_env2.ml disabled because it fails due to the fact that
+# Windows POSIX environment is not updated when using the native
+# API SetEnvironmentVariable (see MPR#4499)
+exit 1

--- a/testsuite/tests/lib-unix/win-env/test_env2.reference
+++ b/testsuite/tests/lib-unix/win-env/test_env2.reference
@@ -1,0 +1,1 @@
+Sys.getenv FOO -> Some "BAR"

--- a/testsuite/tests/win-unicode/mltest.reference
+++ b/testsuite/tests/win-unicode/mltest.reference
@@ -321,12 +321,16 @@ Sys.file_exists "你好" ... false
 
 Unix.putenv "été" "верблюды" ... OK
 Sys.getenv "été" ... "верблюды"
+Unix.environment "été" ... "верблюды"
 Unix.putenv "simple" "骆驼" ... OK
 Sys.getenv "simple" ... "骆驼"
+Unix.environment "simple" ... "骆驼"
 Unix.putenv "sœur" "קעמל" ... OK
 Sys.getenv "sœur" ... "קעמל"
+Unix.environment "sœur" ... "קעמל"
 Unix.putenv "你好" "اونٹ" ... OK
 Sys.getenv "你好" ... "اونٹ"
+Unix.environment "你好" ... "اونٹ"
 
 #16. Testing test_open_process_in
 ============================
@@ -339,4 +343,4 @@ Unix.open_process_in ... ... "верблюды" "骆驼" "קעמל" "اونٹ" "
 Unix.open_process_full ... "OCAML_UTF8_VAR0=верблюды" "OCAML_UTF8_VAR1=骆驼" "OCAML_UTF8_VAR2=קעמל" "OCAML_UTF8_VAR3=اونٹ" ... "OCAML_UTF8_VAR0=верблюды" "OCAML_UTF8_VAR1=骆驼" "OCAML_UTF8_VAR2=קעמל" "OCAML_UTF8_VAR3=اونٹ"
 
 
-*** ALL TESTS DONE (203/203 OK) ***
+*** ALL TESTS DONE (207/207 OK) ***


### PR DESCRIPTION
One more rebase fix following #1200.

The existing `Unix.environment` in `trunk` uses the native Win32 API `GetEnvironmentStrings` which works OK except that its result can sometimes get out of sync with the result of the "POSIX" API `_wgetenv` used for `Unix.{get,put}env` (see [MPR#4499](https://caml.inria.fr/mantis/view.php?id=4499) for details).

The mixup ocurred because at some point we had switched to using the native Win32 API in all three functions but later decided to leave that change for later.

This patch reverts `Unix.environment` to read from the global variable `_wenviron`, similar to the analogous implementation for Unix.