### PR TITLE
MPR#7639: configure warnings on Mac OS X High Sierra (10.13)

### DIFF
--- a/Changes
+++ b/Changes
@@ -453,6 +453,11 @@ Release branch for 4.06:
 - GPR#1278: discover presence of <sys/shm.h> during configure for afl runtime
   (Hannes Mehnert)
 
+- MPR#1639, GPR#1371: fix configure script for correct detection of
+  int64 alignment on Mac OS X 10.13 (High Sierra) and above; fix bug in
+  configure script relating to such detection.
+  (Mark Shinwell, report by John Whitington, review by Xavier Leroy)
+
 ### Internal/compiler-libs changes:
 
 - MPR#6826, GPR#828, GPR#834: improve compilation time for open

--- a/config/auto-aux/int64align.c
+++ b/config/auto-aux/int64align.c
@@ -19,18 +19,18 @@
 #include "m.h"
 
 #if defined(ARCH_INT64_TYPE)
-typedef ARCH_INT64_TYPE int64_t;
+typedef ARCH_INT64_TYPE myint64_t;
 #elif SIZEOF_LONG == 8
-typedef long int64_t;
+typedef long myint64_t;
 #elif SIZEOF_LONGLONG == 8
-typedef long long int64_t;
+typedef long long myint64_t;
 #else
 #error "No 64-bit integer type available"
 #endif
 
-volatile int64_t foo;
+volatile myint64_t foo;
 
-void access_int64(volatile int64_t *p)
+void access_int64(volatile myint64_t *p)
 {
   foo = *p;
 }
@@ -51,8 +51,8 @@ int main(void)
   signal(SIGBUS, sig_handler);
 #endif
   if(setjmp(failure) == 0) {
-    access_int64((volatile int64_t *) n);
-    access_int64((volatile int64_t *) (n+1));
+    access_int64((volatile myint64_t *) n);
+    access_int64((volatile myint64_t *) (n+1));
     res = 0;
   } else {
     res = 1;

--- a/configure
+++ b/configure
@@ -752,7 +752,7 @@ case "$target" in
              "64-bit integers. I'm going to assume this architecture has\n" \
              "alignment constraints. That's a safe bet: OCaml will work\n" \
              "even if this architecture has actually no alignment\n" \
-             "constraints." \
+             "constraints."
          echo "#define ARCH_ALIGN_INT64" >> m.h;;
     esac
 esac


### PR DESCRIPTION
It seems that on OS X 10.13 a `typedef` from a header file comes into scope for the `int64align.c` test (used during `configure`) which defines `int64_t` as `long long`.  We try to redefine it as `long` and an error occurs.  (This behaviour is only seen once the XCode tools have been installed.)  I don't know why this didn't happen on previous versions---although the previous versions do still define it as `long long` in the corresponding header file.

Since we are planning to replace the `configure` infrastructure anyway I propose the fix in this pull request.  It seems rather unlikely that Intel will introduce architectural constraints on integer alignment in the short term.

There was also a semi-related bug in `configure` with a stray backslash.

Incidentally, this is not related to MPR#7591 / GPR#1257.  The alignment warnings from the linker there are a new introduction which I believe to be due to preparations for a new dynamic loader which forbids misaligned references into the data section.  There are some more details here: <http://docs.huihoo.com/apple/wwdc/2017/413_app_startup_time_past_present_and_future.pdf>.  For the moment I don't _think_ we need to do anything (any problems with this will show up as linker warnings in any case).

Tested on OS X 10.13 including running the testsuite.

@xavierleroy If you dislike the fix in this pull request, my branch is available for you to push to.