### PR TITLE
Fix build of ocamlrund and ocamlruni under Unix

### DIFF
--- a/configure
+++ b/configure
@@ -388,7 +388,7 @@ esac
 # in the OCaml distribution and third-party C source files compiled
 # with ocamlc.
 
-mkexe="\$(CC) \$(CFLAGS) \$(CPPFLAGS)"
+mkexe="\$(CC) \$(CFLAGS) \$(CPPFLAGS) \$(LDFLAGS)"
 mkexedebugflag="-g"
 common_cflags=""
 common_cppflags=""


### PR DESCRIPTION
Because of previous commits these programs were not using LDFLAGS
when built under Linux.

This PR fixes this.