### PR TITLE
appveyor: remove the branches specification from the configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,11 +18,6 @@ platform:
 
 image: Visual Studio 2015
 
-branches:
-  only:
-    - trunk
-    - 4.04
-
 # Do a shallow clone of the repo to speed up the build
 clone_depth: 1
 


### PR DESCRIPTION
This has been replaced with a regexp in the Appveyor settings page,
to only build 4.* instead of all branches.