### PR TITLE
Eliminate some warnings in the 'let rec' tests.

### DIFF
--- a/testsuite/tests/letrec/allowed.ml
+++ b/testsuite/tests/letrec/allowed.ml
@@ -62,7 +62,7 @@ and y = function
 let rec x = lazy (Lazy.force x + Lazy.force x)
   ;;
 
-let rec x = { x with contents = 3 };;
+let rec x = { x with contents = 3 }  [@ocaml.warning "-23"];;
 
 let rec x = let y = (x; ()) in y;;
 
@@ -75,4 +75,4 @@ let rec deep_cycle : [`Tuple of [`Shared of 'a] array] as 'a
 (* Constructing float arrays was disallowed altogether at one point
    by an overzealous check.  Constructing float arrays in recursive 
    bindings is fine when they don't partake in the recursion. *)
-let rec x = [| 1 |]; 1. in ();;
+let rec _x = let _ = [| 1.0 |] in 1. in ();;


### PR DESCRIPTION
This PR eliminates some warnings from the tests introduced in #556, #1365.  Thanks to @mshinwell for bringing the warnings to my attention.

Additionally, one of the tests is changed to use float arrays (as the comment above the test claims) rather than integer arrays.