### PR TITLE
Remove superfluous spaces around equals in config/Makefile.*

### DIFF
--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -109,12 +109,12 @@ AFL_INSTRUMENT=false
 ########## Configuration for the bytecode compiler
 
 ### Which C compiler to use for the bytecode interpreter.
-CC = $(TOOLPREF)gcc
-CFLAGS = -O -mms-bitfields -Wall -Wno-unused -fno-tree-vrp
+CC=$(TOOLPREF)gcc
+CFLAGS=-O -mms-bitfields -Wall -Wno-unused -fno-tree-vrp
 # -fno-tree-vrp is here to try to work around the Skylake/Kaby lake bug,
 # and only works on GCC 4.2 and later.
-CPPFLAGS = -DCAML_NAME_SPACE -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=$(WINDOWS_UNICODE)
-OCAMLC_CFLAGS = -O -mms-bitfields
+CPPFLAGS=-DCAML_NAME_SPACE -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=$(WINDOWS_UNICODE)
+OCAMLC_CFLAGS=-O -mms-bitfields
 
 BYTECCDBGCOMPOPTS=-g
 

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -109,12 +109,12 @@ AFL_INSTRUMENT=false
 ########## Configuration for the bytecode compiler
 
 ### Which C compiler to use for the bytecode interpreter.
-CC = $(TOOLPREF)gcc
-CFLAGS = -O -mms-bitfields -Wall -Wno-unused -fno-tree-vrp
+CC=$(TOOLPREF)gcc
+CFLAGS=-O -mms-bitfields -Wall -Wno-unused -fno-tree-vrp
 # -fno-tree-vrp is here to try to work around the Skylake/Kaby lake bug,
 # and only works on GCC 4.2 and later.
-CPPFLAGS = -DCAML_NAME_SPACE -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=$(WINDOWS_UNICODE)
-OCAMLC_CFLAGS = -O -mms-bitfields
+CPPFLAGS=-DCAML_NAME_SPACE -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=$(WINDOWS_UNICODE)
+OCAMLC_CFLAGS=-O -mms-bitfields
 
 BYTECCDBGCOMPOPTS=-g
 
@@ -182,7 +182,7 @@ MODEL=default
 ### Name of operating system family for the native-code compiler.
 SYSTEM=mingw64
 
-OCAMLOPT_CFLAGS = -O -mms-bitfields
+OCAMLOPT_CFLAGS=-O -mms-bitfields
 
 ### Build partially-linked object file
 PACKLD=$(TOOLPREF)ld -r -o # must have a space after '-o'

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -102,11 +102,11 @@ AFL_INSTRUMENT=false
 ########## Configuration for the bytecode compiler
 
 ### Which C compiler to use for the bytecode interpreter.
-CC = cl
-CFLAGS = -nologo -O2 -Gy- -MD
-CPPFLAGS = -D_CRT_SECURE_NO_DEPRECATE -DCAML_NAME_SPACE -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=$(WINDOWS_UNICODE)
-OCAMLC_CFLAGS = -nologo -O2 -Gy- -MD
-OCAMLC_CPPFLAGS = -D_CRT_SECURE_NO_DEPRECATE
+CC=cl
+CFLAGS=-nologo -O2 -Gy- -MD
+CPPFLAGS=-D_CRT_SECURE_NO_DEPRECATE -DCAML_NAME_SPACE -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=$(WINDOWS_UNICODE)
+OCAMLC_CFLAGS=-nologo -O2 -Gy- -MD
+OCAMLC_CPPFLAGS=-D_CRT_SECURE_NO_DEPRECATE
 BYTECCDBGCOMPOPTS=-Zi
 
 LDFLAGS=/ENTRY:wmainCRTStartup
@@ -177,8 +177,8 @@ MODEL=default
 ### Name of operating system family for the native-code compiler.
 SYSTEM=win32
 
-OCAMLOPT_CFLAGS = -nologo -O2 -Gy- -MD
-OCAMLOPT_CPPFLAGS = -D_CRT_SECURE_NO_DEPRECATE
+OCAMLOPT_CFLAGS=-nologo -O2 -Gy- -MD
+OCAMLOPT_CPPFLAGS=-D_CRT_SECURE_NO_DEPRECATE
 
 ### Build partially-linked object file
 PACKLD=link -lib -nologo -out:# there must be no space after this '-out:'

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -101,11 +101,11 @@ AFL_INSTRUMENT=false
 ########## Configuration for the bytecode compiler
 
 ### Which C compiler to use for the bytecode interpreter.
-CC = cl
-CFLAGS = -nologo -O2 -Gy- -MD
-CPPFLAGS = -D_CRT_SECURE_NO_DEPRECATE -DCAML_NAME_SPACE -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=$(WINDOWS_UNICODE)
-OCAMLC_CFLAGS = -nologo -O2 -Gy- -MD
-OCAMLC_CPPFLAGS = -D_CRT_SECURE_NO_DEPRECATE
+CC=cl
+CFLAGS=-nologo -O2 -Gy- -MD
+CPPFLAGS=-D_CRT_SECURE_NO_DEPRECATE -DCAML_NAME_SPACE -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=$(WINDOWS_UNICODE)
+OCAMLC_CFLAGS=-nologo -O2 -Gy- -MD
+OCAMLC_CPPFLAGS=-D_CRT_SECURE_NO_DEPRECATE
 
 BYTECCDBGCOMPOPTS=-Zi
 
@@ -180,8 +180,8 @@ MODEL=default
 ### Name of operating system family for the native-code compiler.
 SYSTEM=win64
 
-OCAMLOPT_CFLAGS = -nologo -O2 -Gy- -MD
-OCAMLOPT_CPPFLAGS = -D_CRT_SECURE_NO_DEPRECATE
+OCAMLOPT_CFLAGS=-nologo -O2 -Gy- -MD
+OCAMLOPT_CPPFLAGS=-D_CRT_SECURE_NO_DEPRECATE
 
 ### Build partially-linked object file
 PACKLD=link -lib -nologo -machine:AMD64 -out:# must have no space after '-out:'


### PR DESCRIPTION
Commit f2d5d60 unintentionnaly introduced spaces aroudn a few =
in the config/Makefile.* files.

The present commit gets rid of them.