### PR TITLE
Various `\r` related tweaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -142,6 +142,7 @@ testsuite/tests/docstrings/empty.ml text eol=lf
 testsuite/tests/functors/functors.ml text eol=lf
 testsuite/tests/translprim/module_coercion.ml text eol=lf
 testsuite/tests/warnings/w04.ml text eol=lf
+testsuite/tests/warnings/w32.ml text eol=lf
 
 # These are forced to \n to allow the Cygwin testsuite to pass on a
 # Windows-checkout

--- a/.gitattributes
+++ b/.gitattributes
@@ -147,6 +147,12 @@ testsuite/tests/warnings/w32.ml text eol=lf
 # These are forced to \n to allow the Cygwin testsuite to pass on a
 # Windows-checkout
 testsuite/tests/formatting/margins.ml text eol=lf
+testsuite/tests/letrec-disallowed/disallowed.ml text eol=lf
+testsuite/tests/letrec-disallowed/extension_constructor.ml text eol=lf
+testsuite/tests/letrec-disallowed/float_block.ml text eol=lf
+testsuite/tests/letrec-disallowed/generic_arrays.ml text eol=lf
+testsuite/tests/letrec-disallowed/module_constraints.ml text eol=lf
+testsuite/tests/letrec-disallowed/pr7215.ml text eol=lf
 testsuite/tests/lexing/uchar_esc.ml text eol=lf
 testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml text eol=lf
 testsuite/tests/typing-extension-constructor/test.ml text eol=lf
@@ -175,5 +181,6 @@ testsuite/tests/typing-warnings/pr7085.ml text eol=lf
 testsuite/tests/typing-warnings/pr7115.ml text eol=lf
 testsuite/tests/typing-warnings/pr7261.ml text eol=lf
 testsuite/tests/typing-warnings/pr7297.ml text eol=lf
+testsuite/tests/typing-warnings/pr7553.ml text eol=lf
 testsuite/tests/typing-warnings/records.ml text eol=lf
 testsuite/tests/typing-warnings/unused_types.ml text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -277,6 +277,8 @@ _ocamltest
 /testsuite/tests/lib-threads/*.byt
 
 /testsuite/tests/lib-unix/win-stat/*-file
+/testsuite/tests/lib-unix/win-symlink/link*
+/testsuite/tests/lib-unix/win-symlink/test.txt
 
 /testsuite/tests/opaque/fst/*.mli
 /testsuite/tests/opaque/snd/*.mli

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -102,7 +102,7 @@ new-without-report: lib tools
 	  echo Running tests from \'$$dir\' ... ; \
 	  while read testfile; do \
 	    TERM=dumb OCAMLRUNPARAM= \
-	      $(ocamltest) $$dir/$$testfile; \
+	      $(ocamltest) $$dir/$${testfile/$$'\r'}; \
 	  done < $$file; \
 	done 2>&1 | tee -a _log
 


### PR DESCRIPTION
This GPR largely deals with running the testsuite on a git clone of ocaml where core.autocrlf is true (i.e. the default configuration of Git-for-Windows). The fixes are largely boring, except for the final commit dealing with ocamltest.

ocamltest previously assumed that .reference files would always have Unix line-endings and simply piped all text files through sed to strip any `\r` characters on Windows which obviously fails if the .reference files themselves have `\r` characters.

My solution instead has not been to pre-process the output file (this has the benefit of removing the dependency for sed) but instead to proceed with cmp as before and if the result is different then *on any platform* to compare the files line by line. My first solution just ignored a `\r` character at the end of any line, but I then updated to what I think is a slightly better solution - the first line of each file is analysed and if the last character is `\r` then the last character of each line is dropped **regardless of what it is**. This is on the basis that mixed ending files are probably an error, and this should cause them to be fail noisily.

/cc @shindere