### PR TITLE
Toplevel: remove plugin option

### DIFF
--- a/Changes
+++ b/Changes
@@ -384,6 +384,9 @@ Release branch for 4.06:
 
 ### Toplevel:
 
+- MPR#7570: remove unusable -plugin option from the toplevel
+  (Florian Angeletti)
+
 - GPR#1041: -nostdlib no longer ignored by toplevel.
   (David Allsopp, review by Xavier Leroy)
 

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -871,7 +871,6 @@ module type Toplevel_options = sig
   val _no_version : unit -> unit
   val _noprompt : unit -> unit
   val _nopromptcont : unit -> unit
-  val _plugin : string -> unit
   val _stdin : unit -> unit
   val _args : string -> string array
   val _args0 : string -> string array
@@ -1113,7 +1112,6 @@ struct
     mk_nostdlib F._nostdlib;
     mk_open F._open;
     mk_ppx F._ppx;
-    mk_plugin F._plugin;
     mk_principal F._principal;
     mk_no_principal F._no_principal;
     mk_rectypes F._rectypes;
@@ -1326,7 +1324,6 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_o2 F._o2;
     mk_o3 F._o3;
     mk_open F._open;
-    mk_plugin F._plugin;
     mk_ppx F._ppx;
     mk_principal F._principal;
     mk_no_principal F._no_principal;

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -114,7 +114,6 @@ module type Toplevel_options = sig
   val _no_version : unit -> unit
   val _noprompt : unit -> unit
   val _nopromptcont : unit -> unit
-  val _plugin : string -> unit
   val _stdin : unit -> unit
   val _args: string -> string array
   val _args0: string -> string array

--- a/man/ocaml.m
+++ b/man/ocaml.m
@@ -142,11 +142,6 @@ Opens the given module before starting the toplevel. If several
 options are given, they are processed in order, just as if
 the statements open! module1;; ... open! moduleN;; were input.
 .TP
-.BI \-plugin \ plugin
-Dynamically load the code of the given
-.I plugin
-(a .cmo or .cma file) in the toplevel.
-.TP
 .BI \-ppx \ command
 After parsing, pipe the abstract syntax tree through the preprocessor
 .IR command .

--- a/toplevel/opttopmain.ml
+++ b/toplevel/opttopmain.ml
@@ -237,7 +237,6 @@ module Options = Main_args.Make_opttop_options (struct
   let _safe_string = clear unsafe_string
   let _unsafe_string = set unsafe_string
   let _open s = open_modules := s :: !open_modules
-  let _plugin p = Compplugin.load p
 
   let _args = wrap_expand Arg.read_arg
   let _args0 = wrap_expand Arg.read_arg0

--- a/toplevel/topmain.ml
+++ b/toplevel/topmain.ml
@@ -115,7 +115,6 @@ module Options = Main_args.Make_bytetop_options (struct
   let _nopromptcont = set nopromptcont
   let _nostdlib = set no_std_include
   let _open s = open_modules := s :: !open_modules
-  let _plugin p = Compplugin.load p
   let _ppx s = first_ppx := s :: !first_ppx
   let _principal = set principal
   let _no_principal = clear principal


### PR DESCRIPTION
[MPR7570](https://caml.inria.fr/mantis/view.php?id=7570):
This PR removes the non-functional `-plugin` option from the toplevels, since the option does not work at all currently and should not be exposed to users.