### PR TITLE
Clarify documentation for Format.out_indent

### DIFF
--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -687,8 +687,8 @@ type formatter_out_functions = {
    {!Pervasives.out_channel} device, or [Buffer.add_substring] and
    {!Pervasives.ignore} for a [Buffer.t] output device),
 - field [out_newline] is equivalent to [out_string "\n" 0 1];
-- field [out_spaces] is equivalent to [out_string (String.make n ' ') 0 n];
-- field [out_indent] is the same as field [out_spaces].
+- fields [out_spaces] and [out_indent] are equivalent to
+  [out_string (String.make n ' ') 0 n].
   @since 4.01.0
 *)
 


### PR DESCRIPTION
This is a (tiny) follow-up to #615.

In that PR a new field `out_indent` was introduced in the `formatter_out_functions` record type in `Format`, used for indentation.  This function used to be identical with the `out_spaces` field. This breaks code in two cases:

1) one builds the record completely by hand because the new field will be missing, or
2) one builds the record with `{... with ...}` because the new field may end up with an incorrect value.

The second case is more problematic because it is a "silent" bug.

I propose a fix for this second case by making the default `out_indent` reference `out_spaces`, so that any update to `out_spaces` will also affect `out_indent`.

(surprised that this was not done in the original PR, I wonder if I am missing something obvious...)

@rbonichon @pierreweis 