### PR TITLE
MPR#7646: ocamldoc, generate TOC for module pages

### DIFF
--- a/Changes
+++ b/Changes
@@ -29,6 +29,8 @@ be mentioned in the 4.06 section below instead of here.)
 - MPR#7635: ocamldoc, add an identifier to module and module type elements
   (Florian Angeletti, review by Yawar Amin and Gabriel Scherer)
 
+- MPR#7646: ocamldoc, add a table of contents to each module page (Yawar Amin)
+
 ### Compiler distribution build system
 
 ### Internal/compiler-libs changes:

--- a/ocamldoc/odoc_html.ml
+++ b/ocamldoc/odoc_html.ml
@@ -1455,10 +1455,10 @@ class html =
 
     (** Print a summary of the given module element to the given buffer.
         This summary is used in the module table of contents. *)
-    method html_summary_of_module_element b _ ele =
+    method html_summary_of_module_element b ele =
       (* Write the first sentence of the item's description. *)
       let write_info = function
-      | Some info -> bs b " "; self#html_of_info_summary b info
+      | Some info -> bs b " - "; self#html_of_info_summary b info
       | None -> () in
 
       bs b {|<li class="|};
@@ -1481,13 +1481,13 @@ class html =
 
         write_info mt.mt_info
       | Element_included_module im ->
-        bp b {|includedmodule">%s|} (Name.simple im.im_name);
+        bp b {|includedmodule">include %s|} (Name.simple im.im_name);
         write_info im.im_info
       | Element_class c ->
         let name = c.cl_name in
         bp
           b
-          {|class"><a href="#%s">%s</a>|}
+          {|class"><a href="#%s">class %s</a>|}
           (Naming.type_target (type_from_name name))
           (Name.simple name);
 
@@ -1496,7 +1496,7 @@ class html =
         let name = ct.clt_name in
         bp
           b
-          {|classtype"><a href="#%s">%s</a>|}
+          {|classtype"><a href="#%s">class type %s</a>|}
           (Naming.type_target (type_from_name name))
           (Name.simple name);
 
@@ -1504,18 +1504,18 @@ class html =
       | Element_value v ->
         bp
           b
-          {|val"><a href="#%s">%s</a>|}
+          {|val"><a href="#%s">val %s</a>|}
           (Naming.value_target v)
           (Name.simple v.val_name);
 
         write_info v.val_info
       | Element_type_extension te ->
-        bp b {|typeextension">%s|} (Name.simple te.te_type_name);
+        bp b {|typeextension">type %s|} (Name.simple te.te_type_name);
         write_info te.te_info
       | Element_exception e ->
         bp
           b
-          {|exception"><a href="#%s">%s</a>|}
+          {|exception"><a href="#%s">exception %s</a>|}
           (Naming.exception_target e)
           (Name.simple e.ex_name);
 
@@ -1523,7 +1523,7 @@ class html =
       | Element_type t ->
         bp
           b
-          {|type"><a href="#%s">%s</a>|}
+          {|type"><a href="#%s">type %s</a>|}
           (Naming.type_target t)
           (Name.simple t.ty_name);
 
@@ -1532,7 +1532,7 @@ class html =
       We'll never reach this case since we've filtered out module
       comments before calling this
       *)
-      | Element_module_comment _ -> bs b {|unknown">|}
+      | Element_module_comment _ -> ()
       end;
 
       bs b {|</li>
@@ -2755,7 +2755,7 @@ class html =
         module_elements
           (* We don't care about module comments in the TOC *)
           |> List.filter (function Element_module_comment _ -> false | _ -> true)
-          |> List.iter (self#html_summary_of_module_element b modu.m_name);
+          |> List.iter (self#html_summary_of_module_element b);
 
         bs b {|</ul>
 </details>

--- a/testsuite/tests/tool-ocamldoc-html/Documentation_tags.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Documentation_tags.reference
@@ -20,6 +20,13 @@
 <p>Test the html rendering of ocamldoc documentation tags</p>
 </div>
 </div>
+
+<details class="info toc"><summary>Contents</summary>
+<ul>
+<li class="val"><a href="#VALheterological">val heterological</a> - <span class="deprecated"></span></li>
+<li class="val"><a href="#VALnoop">val noop</a> - </li>
+</ul>
+</details>
 <hr width="100%">
 
 <pre><span id="VALheterological"><span class="keyword">val</span> heterological</span> : <code class="type">unit</code></pre><div class="info ">

--- a/testsuite/tests/tool-ocamldoc-html/Documentation_tags.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Documentation_tags.reference
@@ -28,11 +28,6 @@
 </ul>
 </details>
 <hr width="100%">
-<ul class="toc">
-<li class="val"><a href="#VALheterological">val heterological</a> - <span class="deprecated"></span></li>
-<li class="val"><a href="#VALnoop">val noop</a> - </li>
-</ul>
-<hr width="100%">
 
 <pre><span id="VALheterological"><span class="keyword">val</span> heterological</span> : <code class="type">unit</code></pre><div class="info ">
 <div class="info-deprecated">

--- a/testsuite/tests/tool-ocamldoc-html/Documentation_tags.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Documentation_tags.reference
@@ -29,8 +29,8 @@
 </details>
 <hr width="100%">
 <ul class="toc">
-<li class="val"><a href="#VALheterological">heterological</a> <span class="deprecated"></span></li>
-<li class="val"><a href="#VALnoop">noop</a> </li>
+<li class="val"><a href="#VALheterological">val heterological</a> - <span class="deprecated"></span></li>
+<li class="val"><a href="#VALnoop">val noop</a> - </li>
 </ul>
 <hr width="100%">
 

--- a/testsuite/tests/tool-ocamldoc-html/Documentation_tags.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Documentation_tags.reference
@@ -28,6 +28,11 @@
 </ul>
 </details>
 <hr width="100%">
+<ul class="toc">
+<li class="val"><a href="#VALheterological">heterological</a> <span class="deprecated"></span></li>
+<li class="val"><a href="#VALnoop">noop</a> </li>
+</ul>
+<hr width="100%">
 
 <pre><span id="VALheterological"><span class="keyword">val</span> heterological</span> : <code class="type">unit</code></pre><div class="info ">
 <div class="info-deprecated">

--- a/testsuite/tests/tool-ocamldoc-html/Inline_records.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Inline_records.reference
@@ -23,6 +23,26 @@
   within the latex generator.</p>
 </div>
 </div>
+
+<details class="info toc"><summary>Contents</summary>
+<ul>
+<li class="exception"><a href="#EXCEPTIONSimple">exception Simple</a> - A nice exception
+</li>
+<li class="type"><a href="#TYPEext">type ext</a> - An open sum type
+</li>
+<li class="type"><a href="#TYPEr">type r</a> - A simple record type for reference
+</li>
+<li class="type"><a href="#TYPEt">type t</a> - A sum type with one inline record
+</li>
+<li class="type"><a href="#TYPEs">type s</a> - A sum type with two inline records
+</li>
+<li class="type"><a href="#TYPEany">type any</a> - A gadt constructor
+</li>
+<li class="exception"><a href="#EXCEPTIONError">exception Error</a></li>
+<li class="typeextension">type ext - Two new constructors for ext
+</li>
+</ul>
+</details>
 <hr width="100%">
 
 <pre><span id="EXCEPTIONSimple"><span class="keyword">exception</span> Simple</span></pre>

--- a/testsuite/tests/tool-ocamldoc-html/Inline_records.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Inline_records.reference
@@ -45,20 +45,20 @@
 </details>
 <hr width="100%">
 <ul class="toc">
-<li class="exception"><a href="#EXCEPTIONSimple">Simple</a> A nice exception
+<li class="exception"><a href="#EXCEPTIONSimple">exception Simple</a> - A nice exception
 </li>
-<li class="type"><a href="#TYPEext">ext</a> An open sum type
+<li class="type"><a href="#TYPEext">type ext</a> - An open sum type
 </li>
-<li class="type"><a href="#TYPEr">r</a> A simple record type for reference
+<li class="type"><a href="#TYPEr">type r</a> - A simple record type for reference
 </li>
-<li class="type"><a href="#TYPEt">t</a> A sum type with one inline record
+<li class="type"><a href="#TYPEt">type t</a> - A sum type with one inline record
 </li>
-<li class="type"><a href="#TYPEs">s</a> A sum type with two inline records
+<li class="type"><a href="#TYPEs">type s</a> - A sum type with two inline records
 </li>
-<li class="type"><a href="#TYPEany">any</a> A gadt constructor
+<li class="type"><a href="#TYPEany">type any</a> - A gadt constructor
 </li>
-<li class="exception"><a href="#EXCEPTIONError">Error</a></li>
-<li class="typeextension">ext Two new constructors for ext
+<li class="exception"><a href="#EXCEPTIONError">exception Error</a></li>
+<li class="typeextension">type ext - Two new constructors for ext
 </li>
 </ul>
 <hr width="100%">

--- a/testsuite/tests/tool-ocamldoc-html/Inline_records.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Inline_records.reference
@@ -44,24 +44,6 @@
 </ul>
 </details>
 <hr width="100%">
-<ul class="toc">
-<li class="exception"><a href="#EXCEPTIONSimple">exception Simple</a> - A nice exception
-</li>
-<li class="type"><a href="#TYPEext">type ext</a> - An open sum type
-</li>
-<li class="type"><a href="#TYPEr">type r</a> - A simple record type for reference
-</li>
-<li class="type"><a href="#TYPEt">type t</a> - A sum type with one inline record
-</li>
-<li class="type"><a href="#TYPEs">type s</a> - A sum type with two inline records
-</li>
-<li class="type"><a href="#TYPEany">type any</a> - A gadt constructor
-</li>
-<li class="exception"><a href="#EXCEPTIONError">exception Error</a></li>
-<li class="typeextension">type ext - Two new constructors for ext
-</li>
-</ul>
-<hr width="100%">
 
 <pre><span id="EXCEPTIONSimple"><span class="keyword">exception</span> Simple</span></pre>
 <div class="info ">

--- a/testsuite/tests/tool-ocamldoc-html/Inline_records.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Inline_records.reference
@@ -44,6 +44,24 @@
 </ul>
 </details>
 <hr width="100%">
+<ul class="toc">
+<li class="exception"><a href="#EXCEPTIONSimple">Simple</a> A nice exception
+</li>
+<li class="type"><a href="#TYPEext">ext</a> An open sum type
+</li>
+<li class="type"><a href="#TYPEr">r</a> A simple record type for reference
+</li>
+<li class="type"><a href="#TYPEt">t</a> A sum type with one inline record
+</li>
+<li class="type"><a href="#TYPEs">s</a> A sum type with two inline records
+</li>
+<li class="type"><a href="#TYPEany">any</a> A gadt constructor
+</li>
+<li class="exception"><a href="#EXCEPTIONError">Error</a></li>
+<li class="typeextension">ext Two new constructors for ext
+</li>
+</ul>
+<hr width="100%">
 
 <pre><span id="EXCEPTIONSimple"><span class="keyword">exception</span> Simple</span></pre>
 <div class="info ">

--- a/testsuite/tests/tool-ocamldoc-html/Item_ids.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Item_ids.reference
@@ -26,6 +26,20 @@
 <p>Check that all toplevel items are given a unique id.</p>
 </div>
 </div>
+
+<details class="info toc"><summary>Contents</summary>
+<ul>
+<li class="exception"><a href="#EXCEPTIONEx">exception Ex</a></li>
+<li class="type"><a href="#TYPEt">type t</a></li>
+<li class="val"><a href="#VALx">val x</a></li>
+<li class="type"><a href="#TYPEext">type ext</a></li>
+<li class="typeextension">type ext</li>
+<li class="class"><a href="#TYPEc">class c</a></li>
+<li class="classtype"><a href="#TYPEct">class type ct</a></li>
+<li class="module"><a href="#MODULEM">module M</a></li>
+<li class="moduletype"><a href="#MODULETYPEs">module type s</a></li>
+</ul>
+</details>
 <hr width="100%">
 
 <pre><span id="EXCEPTIONEx"><span class="keyword">exception</span> Ex</span></pre>

--- a/testsuite/tests/tool-ocamldoc-html/Item_ids.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Item_ids.reference
@@ -41,18 +41,6 @@
 </ul>
 </details>
 <hr width="100%">
-<ul class="toc">
-<li class="exception"><a href="#EXCEPTIONEx">exception Ex</a></li>
-<li class="type"><a href="#TYPEt">type t</a></li>
-<li class="val"><a href="#VALx">val x</a></li>
-<li class="type"><a href="#TYPEext">type ext</a></li>
-<li class="typeextension">type ext</li>
-<li class="class"><a href="#TYPEc">class c</a></li>
-<li class="classtype"><a href="#TYPEct">class type ct</a></li>
-<li class="module"><a href="#MODULEM">module M</a></li>
-<li class="moduletype"><a href="#MODULETYPEs">module type s</a></li>
-</ul>
-<hr width="100%">
 
 <pre><span id="EXCEPTIONEx"><span class="keyword">exception</span> Ex</span></pre>
 

--- a/testsuite/tests/tool-ocamldoc-html/Item_ids.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Item_ids.reference
@@ -41,6 +41,18 @@
 </ul>
 </details>
 <hr width="100%">
+<ul class="toc">
+<li class="exception"><a href="#EXCEPTIONEx">exception Ex</a></li>
+<li class="type"><a href="#TYPEt">type t</a></li>
+<li class="val"><a href="#VALx">val x</a></li>
+<li class="type"><a href="#TYPEext">type ext</a></li>
+<li class="typeextension">type ext</li>
+<li class="class"><a href="#TYPEc">class c</a></li>
+<li class="classtype"><a href="#TYPEct">class type ct</a></li>
+<li class="module"><a href="#MODULEM">module M</a></li>
+<li class="moduletype"><a href="#MODULETYPEs">module type s</a></li>
+</ul>
+<hr width="100%">
 
 <pre><span id="EXCEPTIONEx"><span class="keyword">exception</span> Ex</span></pre>
 

--- a/testsuite/tests/tool-ocamldoc-html/Linebreaks.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Linebreaks.reference
@@ -64,19 +64,6 @@
 </ul>
 </details>
 <hr width="100%">
-<ul class="toc">
-<li class="type"><a href="#TYPEa">type a</a></li>
-<li class="type"><a href="#TYPEb">type b</a></li>
-<li class="type"><a href="#TYPEc">type c</a></li>
-<li class="type"><a href="#TYPEs">type s</a></li>
-<li class="typeextension">type s</li>
-<li class="val"><a href="#VALx">val x</a></li>
-<li class="module"><a href="#MODULES">module S</a></li>
-<li class="moduletype"><a href="#MODULETYPEs">module type s</a></li>
-<li class="classtype"><a href="#TYPEd">class type d</a></li>
-<li class="exception"><a href="#EXCEPTIONE">exception E</a></li>
-</ul>
-<hr width="100%">
 
 <pre><code><span id="TYPEa"><span class="keyword">type</span> <code class="type"></code>a</span> = </code></pre><table class="typetable">
 <tr>

--- a/testsuite/tests/tool-ocamldoc-html/Linebreaks.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Linebreaks.reference
@@ -64,6 +64,19 @@
 </ul>
 </details>
 <hr width="100%">
+<ul class="toc">
+<li class="type"><a href="#TYPEa">type a</a></li>
+<li class="type"><a href="#TYPEb">type b</a></li>
+<li class="type"><a href="#TYPEc">type c</a></li>
+<li class="type"><a href="#TYPEs">type s</a></li>
+<li class="typeextension">type s</li>
+<li class="val"><a href="#VALx">val x</a></li>
+<li class="module"><a href="#MODULES">module S</a></li>
+<li class="moduletype"><a href="#MODULETYPEs">module type s</a></li>
+<li class="classtype"><a href="#TYPEd">class type d</a></li>
+<li class="exception"><a href="#EXCEPTIONE">exception E</a></li>
+</ul>
+<hr width="100%">
 
 <pre><code><span id="TYPEa"><span class="keyword">type</span> <code class="type"></code>a</span> = </code></pre><table class="typetable">
 <tr>

--- a/testsuite/tests/tool-ocamldoc-html/Linebreaks.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Linebreaks.reference
@@ -48,6 +48,21 @@
 </ul>
 </div>
 </div>
+
+<details class="info toc"><summary>Contents</summary>
+<ul>
+<li class="type"><a href="#TYPEa">type a</a></li>
+<li class="type"><a href="#TYPEb">type b</a></li>
+<li class="type"><a href="#TYPEc">type c</a></li>
+<li class="type"><a href="#TYPEs">type s</a></li>
+<li class="typeextension">type s</li>
+<li class="val"><a href="#VALx">val x</a></li>
+<li class="module"><a href="#MODULES">module S</a></li>
+<li class="moduletype"><a href="#MODULETYPEs">module type s</a></li>
+<li class="classtype"><a href="#TYPEd">class type d</a></li>
+<li class="exception"><a href="#EXCEPTIONE">exception E</a></li>
+</ul>
+</details>
 <hr width="100%">
 
 <pre><code><span id="TYPEa"><span class="keyword">type</span> <code class="type"></code>a</span> = </code></pre><table class="typetable">

--- a/testsuite/tests/tool-ocamldoc-html/Loop.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Loop.reference
@@ -14,7 +14,14 @@
 &nbsp;</div>
 <h1>Module <a href="type_Loop.html">Loop</a></h1>
 
-<pre><span id="MODULELoop"><span class="keyword">module</span> Loop</span>: <code class="code"><span class="keyword">sig</span></code> <a href="Loop.html">..</a> <code class="code"><span class="keyword">end</span></code></pre><hr width="100%">
+<pre><span id="MODULELoop"><span class="keyword">module</span> Loop</span>: <code class="code"><span class="keyword">sig</span></code> <a href="Loop.html">..</a> <code class="code"><span class="keyword">end</span></code></pre>
+<details class="info toc"><summary>Contents</summary>
+<ul>
+<li class="module"><a href="#MODULEA">module A</a></li>
+<li class="module"><a href="#MODULEB">module B</a></li>
+</ul>
+</details>
+<hr width="100%">
 
 <pre><span id="MODULEA"><span class="keyword">module</span> <a href="Loop.A.html">A</a></span>: <code class="type"><a href="Loop.B.html">B</a></code></pre>
 <pre><span id="MODULEB"><span class="keyword">module</span> <a href="Loop.B.html">B</a></span>: <code class="type"><a href="Loop.A.html">A</a></code></pre></body></html>

--- a/testsuite/tests/tool-ocamldoc-html/Module_whitespace.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Module_whitespace.reference
@@ -14,7 +14,13 @@
 &nbsp;</div>
 <h1>Module <a href="type_Module_whitespace.html">Module_whitespace</a></h1>
 
-<pre><span id="MODULEModule_whitespace"><span class="keyword">module</span> Module_whitespace</span>: <code class="code"><span class="keyword">sig</span></code> <a href="Module_whitespace.html">..</a> <code class="code"><span class="keyword">end</span></code></pre><hr width="100%">
+<pre><span id="MODULEModule_whitespace"><span class="keyword">module</span> Module_whitespace</span>: <code class="code"><span class="keyword">sig</span></code> <a href="Module_whitespace.html">..</a> <code class="code"><span class="keyword">end</span></code></pre>
+<details class="info toc"><summary>Contents</summary>
+<ul>
+<li class="module"><a href="#MODULEM">module M</a></li>
+</ul>
+</details>
+<hr width="100%">
 
 <pre><span id="MODULEM"><span class="keyword">module</span> <a href="Module_whitespace.M.html">M</a></span>: <code class="type">Set.Make</code><code class="code">(</code><code class="code"><span class="keyword">sig</span></code></pre><div class="sig_block">
 <pre><span id="TYPEt"><span class="keyword">type</span> <code class="type"></code>t</span> = <code class="type">int</code> </pre>

--- a/testsuite/tests/tool-ocamldoc-html/No_preamble.reference
+++ b/testsuite/tests/tool-ocamldoc-html/No_preamble.reference
@@ -15,7 +15,14 @@
 &nbsp;</div>
 <h1>Module <a href="type_No_preamble.html">No_preamble</a></h1>
 
-<pre><span id="MODULENo_preamble"><span class="keyword">module</span> No_preamble</span>: <code class="code"><span class="keyword">sig</span></code> <a href="No_preamble.html">..</a> <code class="code"><span class="keyword">end</span></code></pre><hr width="100%">
+<pre><span id="MODULENo_preamble"><span class="keyword">module</span> No_preamble</span>: <code class="code"><span class="keyword">sig</span></code> <a href="No_preamble.html">..</a> <code class="code"><span class="keyword">end</span></code></pre>
+<details class="info toc"><summary>Contents</summary>
+<ul>
+<li class="val"><a href="#VALx">val x</a> - This is a documentation comment for <code class="code">x</code>, not a module preamble.
+</li>
+</ul>
+</details>
+<hr width="100%">
 
 <pre><span id="VALx"><span class="keyword">val</span> x</span> : <code class="type">unit</code></pre><div class="info ">
 <div class="info-desc">

--- a/testsuite/tests/tool-ocamldoc-html/Paragraph.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Paragraph.reference
@@ -59,17 +59,12 @@
 </ul>
 </details>
 <hr width="100%">
-<ul class="toc">
-<li class="type"><a href="#TYPEt">type t</a> - And cross-reference <a href="Paragraph.html#TYPEt"><code class="code"><span class="constructor">Paragraph</span>.t</code></a>.
-</li>
-</ul>
-<hr width="100%">
 
 <pre><span id="TYPEt"><span class="keyword">type</span> <code class="type"></code>t</span> </pre>
 <div class="info ">
 <div class="info-desc">
 <p>And cross-reference <a href="Paragraph.html#TYPEt"><code class="code"><span class="constructor">Paragraph</span>.t</code></a>.
-
+   
 <table class="indextable module-list">
 <tr><td class="module"><a href="Paragraph.html">Paragraph</a></td><td><div class="info">
 <p>This file tests the generation of paragraph within module comments.</p>

--- a/testsuite/tests/tool-ocamldoc-html/Paragraph.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Paragraph.reference
@@ -51,13 +51,20 @@
 <li><b>Version:</b> : 1</li>
 </ul>
 </div>
+
+<details class="info toc"><summary>Contents</summary>
+<ul>
+<li class="type"><a href="#TYPEt">type t</a> - And cross-reference <a href="Paragraph.html#TYPEt"><code class="code"><span class="constructor">Paragraph</span>.t</code></a>.
+</li>
+</ul>
+</details>
 <hr width="100%">
 
 <pre><span id="TYPEt"><span class="keyword">type</span> <code class="type"></code>t</span> </pre>
 <div class="info ">
 <div class="info-desc">
 <p>And cross-reference <a href="Paragraph.html#TYPEt"><code class="code"><span class="constructor">Paragraph</span>.t</code></a>.
-   
+
 <table class="indextable module-list">
 <tr><td class="module"><a href="Paragraph.html">Paragraph</a></td><td><div class="info">
 <p>This file tests the generation of paragraph within module comments.</p>

--- a/testsuite/tests/tool-ocamldoc-html/Paragraph.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Paragraph.reference
@@ -59,6 +59,11 @@
 </ul>
 </details>
 <hr width="100%">
+<ul class="toc">
+<li class="type"><a href="#TYPEt">t</a> And cross-reference <a href="Paragraph.html#TYPEt"><code class="code"><span class="constructor">Paragraph</span>.t</code></a>.
+</li>
+</ul>
+<hr width="100%">
 
 <pre><span id="TYPEt"><span class="keyword">type</span> <code class="type"></code>t</span> </pre>
 <div class="info ">

--- a/testsuite/tests/tool-ocamldoc-html/Paragraph.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Paragraph.reference
@@ -60,7 +60,7 @@
 </details>
 <hr width="100%">
 <ul class="toc">
-<li class="type"><a href="#TYPEt">t</a> And cross-reference <a href="Paragraph.html#TYPEt"><code class="code"><span class="constructor">Paragraph</span>.t</code></a>.
+<li class="type"><a href="#TYPEt">type t</a> - And cross-reference <a href="Paragraph.html#TYPEt"><code class="code"><span class="constructor">Paragraph</span>.t</code></a>.
 </li>
 </ul>
 <hr width="100%">

--- a/testsuite/tests/tool-ocamldoc-html/Variants.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Variants.reference
@@ -40,19 +40,19 @@
 </details>
 <hr width="100%">
 <ul class="toc">
-<li class="type"><a href="#TYPEs">s</a></li>
-<li class="type"><a href="#TYPEt">t</a></li>
-<li class="type"><a href="#TYPEu">u</a> Some documentation for u
+<li class="type"><a href="#TYPEs">type s</a></li>
+<li class="type"><a href="#TYPEt">type t</a></li>
+<li class="type"><a href="#TYPEu">type u</a> - Some documentation for u
 </li>
-<li class="type"><a href="#TYPEw">w</a> With records
+<li class="type"><a href="#TYPEw">type w</a> - With records
 </li>
-<li class="type"><a href="#TYPEz">z</a> With args
+<li class="type"><a href="#TYPEz">type z</a> - With args
 </li>
-<li class="type"><a href="#TYPEa">a</a> Gadt notation
+<li class="type"><a href="#TYPEa">type a</a> - Gadt notation
 </li>
-<li class="type"><a href="#TYPEb">b</a> Lonely constructor
+<li class="type"><a href="#TYPEb">type b</a> - Lonely constructor
 </li>
-<li class="type"><a href="#TYPEno_documentation">no_documentation</a></li>
+<li class="type"><a href="#TYPEno_documentation">type no_documentation</a></li>
 </ul>
 <hr width="100%">
 

--- a/testsuite/tests/tool-ocamldoc-html/Variants.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Variants.reference
@@ -39,6 +39,22 @@
 </ul>
 </details>
 <hr width="100%">
+<ul class="toc">
+<li class="type"><a href="#TYPEs">s</a></li>
+<li class="type"><a href="#TYPEt">t</a></li>
+<li class="type"><a href="#TYPEu">u</a> Some documentation for u
+</li>
+<li class="type"><a href="#TYPEw">w</a> With records
+</li>
+<li class="type"><a href="#TYPEz">z</a> With args
+</li>
+<li class="type"><a href="#TYPEa">a</a> Gadt notation
+</li>
+<li class="type"><a href="#TYPEb">b</a> Lonely constructor
+</li>
+<li class="type"><a href="#TYPEno_documentation">no_documentation</a></li>
+</ul>
+<hr width="100%">
 
 <pre><code><span id="TYPEs"><span class="keyword">type</span> <code class="type"></code>s</span> = </code></pre><table class="typetable">
 <tr>

--- a/testsuite/tests/tool-ocamldoc-html/Variants.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Variants.reference
@@ -39,22 +39,6 @@
 </ul>
 </details>
 <hr width="100%">
-<ul class="toc">
-<li class="type"><a href="#TYPEs">type s</a></li>
-<li class="type"><a href="#TYPEt">type t</a></li>
-<li class="type"><a href="#TYPEu">type u</a> - Some documentation for u
-</li>
-<li class="type"><a href="#TYPEw">type w</a> - With records
-</li>
-<li class="type"><a href="#TYPEz">type z</a> - With args
-</li>
-<li class="type"><a href="#TYPEa">type a</a> - Gadt notation
-</li>
-<li class="type"><a href="#TYPEb">type b</a> - Lonely constructor
-</li>
-<li class="type"><a href="#TYPEno_documentation">type no_documentation</a></li>
-</ul>
-<hr width="100%">
 
 <pre><code><span id="TYPEs"><span class="keyword">type</span> <code class="type"></code>s</span> = </code></pre><table class="typetable">
 <tr>

--- a/testsuite/tests/tool-ocamldoc-html/Variants.reference
+++ b/testsuite/tests/tool-ocamldoc-html/Variants.reference
@@ -20,6 +20,24 @@
 <p>This test is here to check the latex code generated for variants</p>
 </div>
 </div>
+
+<details class="info toc"><summary>Contents</summary>
+<ul>
+<li class="type"><a href="#TYPEs">type s</a></li>
+<li class="type"><a href="#TYPEt">type t</a></li>
+<li class="type"><a href="#TYPEu">type u</a> - Some documentation for u
+</li>
+<li class="type"><a href="#TYPEw">type w</a> - With records
+</li>
+<li class="type"><a href="#TYPEz">type z</a> - With args
+</li>
+<li class="type"><a href="#TYPEa">type a</a> - Gadt notation
+</li>
+<li class="type"><a href="#TYPEb">type b</a> - Lonely constructor
+</li>
+<li class="type"><a href="#TYPEno_documentation">type no_documentation</a></li>
+</ul>
+</details>
 <hr width="100%">
 
 <pre><code><span id="TYPEs"><span class="keyword">type</span> <code class="type"></code>s</span> = </code></pre><table class="typetable">


### PR DESCRIPTION
https://caml.inria.fr/mantis/view.php?id=7646 :

Generate a table of contents in each module page, listing each module member (except for module-level docstrings).

Add a new method `html_summary_of_module_element` in the `Odoc_html.Generator.html` class, to generate a summary of each element suitable to put in the table of contents. Factor out some minor common code for reuse in both the TOC and the main documentation.