### PR TITLE
fixed position of last optional last semicolumn in sequence

### DIFF
--- a/Changes
+++ b/Changes
@@ -566,7 +566,8 @@ Release branch for 4.06:
   (Leo White, review by Alain Frisch and Gabriel Scherer)
 
 - MPR#7619, GPR#1387: position of the optional last semi-column not included
-  in the position of the expression (same behavior than for lists)
+  in the position of the expression (same behavior as for lists)
+  (Christophe Raffalli, review by Gabriel Scherer)
 
 ### Runtime system:
 

--- a/Changes
+++ b/Changes
@@ -565,6 +565,9 @@ Release branch for 4.06:
 - GPR#1308: Only treat pure patterns as inactive
   (Leo White, review by Alain Frisch and Gabriel Scherer)
 
+- MPR#7619, GPR#1387: position of the optional last semi-column not included
+  in the position of the expression (same behavior than for lists)
+
 ### Runtime system:
 
 * MPR#3771, GPR#153, GPR#1200, GPR#1357, GPR#1362, GPR#1363: Unicode support for
@@ -590,7 +593,7 @@ Release branch for 4.06:
 - GPR#1073: Remove statically allocated compare stack.
   (Stephen Dolan)
 
-- GPR#1086: in Sys.getcwd, just fail instead of calling getwd() 
+- GPR#1086: in Sys.getcwd, just fail instead of calling getwd()
   if HAS_GETCWD is not set.
   (Report and first fix by Sebastian Markbåge, final fix by Xavier Leroy,
    review by MarK Shinwell)

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1267,7 +1267,7 @@ and_class_type_declaration:
 
 seq_expr:
   | expr        %prec below_SEMI  { $1 }
-  | expr SEMI                     { reloc_exp $1 }
+  | expr SEMI                     { $1 }
   | expr SEMI seq_expr            { mkexp(Pexp_sequence($1, $3)) }
   | expr SEMI PERCENT attr_id seq_expr
       { let seq = mkexp(Pexp_sequence ($1, $5)) in

--- a/testsuite/tests/backtrace/pr6920_why_swallow.byte.reference
+++ b/testsuite/tests/backtrace/pr6920_why_swallow.byte.reference
@@ -1,4 +1,4 @@
 Fatal error: exception Pervasives.Exit
 Raised at file "pr6920_why_swallow.ml", line 1, characters 41-45
-Called from file "pr6920_why_swallow.ml", line 4, characters 4-14
+Called from file "pr6920_why_swallow.ml", line 4, characters 4-13
 Called from file "pr6920_why_swallow.ml", line 11, characters 2-6

--- a/testsuite/tests/backtrace/pr6920_why_swallow.native.reference
+++ b/testsuite/tests/backtrace/pr6920_why_swallow.native.reference
@@ -1,4 +1,4 @@
 Fatal error: exception Pervasives.Exit
 Raised at file "pr6920_why_swallow.ml", line 1, characters 35-45
-Called from file "pr6920_why_swallow.ml", line 4, characters 4-14
+Called from file "pr6920_why_swallow.ml", line 4, characters 4-13
 Called from file "pr6920_why_swallow.ml", line 11, characters 2-6


### PR DESCRIPTION
This fixes MPR#7619, removing just one word.
It treats position of optional last semicolmun in sequence as in list.