### PR TITLE
Overhaul AppVeyor scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -44,7 +44,9 @@ README*                  ocaml-typo=missing-header
 /Changes                 ocaml-typo=non-ascii,missing-header
 /INSTALL                 ocaml-typo=missing-header
 /LICENSE                 ocaml-typo=long-line,very-long-line,missing-header
-/appveyor.yml            ocaml-typo=long-line,very-long-line
+# appveyor_build.cmd only has missing-header because dra27 too lazy to update
+# check-typo to interpret Cmd-style comments!
+/appveyor_build.cmd      ocaml-typo=long-line,very-long-line,missing-header
 
 
 asmcomp/*/emit.mlp       ocaml-typo=tab,long-line,unused-prop

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,42 +34,12 @@ cache:
   - C:\cygwin64\var\cache\setup
 
 install:
-  - mkdir "%OCAMLROOT%/bin/flexdll"
-  - appveyor DownloadFile "http://alain.frisch.fr/flexdll/flexdll-bin-0.35.zip" -FileName "flexdll.zip"
-  - appveyor DownloadFile "http://alain.frisch.fr/flexdll/flexdll-0.35.tar.gz" -FileName "flexdll.tar.gz"
-  - mkdir C:\projects\flexdll-tmp
-  - cd C:\projects\flexdll-tmp
-  - unzip -q /c/projects/ocaml/flexdll.zip
-  - for %%F in (flexdll.h flexlink.exe default_amd64.manifest) do copy %%F "%OCAMLROOT%\bin\flexdll"
-  - cd ..
-  # Make sure the Cygwin path comes before the Git one (otherwise
-  # cygpath behaves crazily), but after the MSVC one.
-  - set Path=C:\cygwin64\bin;%OCAMLROOT%\bin\flexdll;%Path%
-  - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
-  - '"%CYG_ROOT%\setup-x86_64.exe" -qgnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P diffutils -P make -P mingw64-i686-gcc-core >NUL'
-  - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
-  - set OCAML_PREV_PATH=%PATH%
-  - set OCAML_PREV_LIB=%LIB%
-  - set OCAML_PREV_INCLUDE=%INCLUDE%
-  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
+# This is a hangover from monitoring effects of MPR#7452
+  - wmic cpu get name
+  - call "%APPVEYOR_BUILD_FOLDER%\appveyor_build.cmd" install
 
 build_script:
-  - "%CYG_ROOT%/bin/bash -lc \"echo 'eval $($APPVEYOR_BUILD_FOLDER/tools/msvs-promote-path)' >> ~/.bash_profile\""
-  - '%CYG_ROOT%/bin/bash -lc "$APPVEYOR_BUILD_FOLDER/appveyor_build.sh"'
-  - set PATH=%OCAML_PREV_PATH%
-  - set LIB=%OCAML_PREV_LIB%
-  - set INCLUDE=%OCAML_PREV_INCLUDE%
-  - call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86
-  - '%CYG_ROOT%/bin/bash -lc "$APPVEYOR_BUILD_FOLDER/appveyor_build.sh msvc32-only"'
+  - call "%APPVEYOR_BUILD_FOLDER%\appveyor_build.cmd" build
 
 test_script:
-  - set PATH=%OCAML_PREV_PATH%
-  - set LIB=%OCAML_PREV_LIB%
-  - set INCLUDE=%OCAML_PREV_INCLUDE%
-  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
-  - '%APPVEYOR_BUILD_FOLDER%\ocamlc.opt -version'
-  - set CAML_LD_LIBRARY_PATH=%OCAMLROOT%/lib/stublibs
-  - '%CYG_ROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && make tests"'
-  - '%CYG_ROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER/../build-mingw32 && make tests"'
-  - '%CYG_ROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && make install"'
-  - '%CYG_ROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER/../build-mingw32 && make install"'
+  - call "%APPVEYOR_BUILD_FOLDER%\appveyor_build.cmd" test

--- a/appveyor_build.cmd
+++ b/appveyor_build.cmd
@@ -37,6 +37,16 @@ set INCLUDE=%OCAML_PREV_INCLUDE%
 goto :EOF
 
 :install
+rem Temporarily initialise the submodule in the main (msvc64) build
+git submodule update --init flexdll
+git worktree add ..\build-mingw32 -b appveyor-build-mingw32
+cd ..\build-mingw32
+git submodule update --init flexdll
+git worktree add ..\build-msvc32 -b appveyor-build-msvc32
+rem Temporarily initialise the submodule in the msvc32 build
+cd ..\build-msvc32
+git submodule update --init flexdll
+
 rem appveyor DownloadFile "http://alain.frisch.fr/flexdll/flexdll-0.35.tar.gz" -FileName "flexdll.tar.gz" || exit /b 1
 appveyor DownloadFile "http://alain.frisch.fr/flexdll/flexdll-bin-0.35.zip" -FileName "flexdll.zip" || exit /b 1
 rem flexdll.zip is processed here, rather than in appveyor_build.sh because the

--- a/appveyor_build.cmd
+++ b/appveyor_build.cmd
@@ -36,6 +36,25 @@ set LIB=%OCAML_PREV_LIB%
 set INCLUDE=%OCAML_PREV_INCLUDE%
 goto :EOF
 
+:CheckPackage
+"%CYG_ROOT%\bin\bash.exe" -lc "cygcheck -dc %1" | findstr %1 > nul
+if %ERRORLEVEL% equ 1 (
+  echo Cygwin package %1 will be installed
+  set CYGWIN_INSTALL_PACKAGES=%CYGWIN_INSTALL_PACKAGES%,%1
+)
+goto :EOF
+
+:UpgradeCygwin
+if "%CYGWIN_INSTALL_PACKAGES%" neq "" "%CYG_ROOT%\setup-x86_64.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --packages %CYGWIN_INSTALL_PACKAGES:~1% > nul
+for %%P in (%CYGWIN_COMMANDS%) do "%CYG_ROOT%\bin\%%P.exe" --version > nul || set CYGWIN_UPGRADE_REQUIRED=1
+"%CYG_ROOT%\bin\bash.exe" -lc "cygcheck -dc %CYGWIN_PACKAGES%"
+if %CYGWIN_UPGRADE_REQUIRED% equ 1 (
+  echo Cygwin package upgrade required - please go and drink coffee
+  "%CYG_ROOT%\setup-x86_64.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --upgrade-also > nul
+  "%CYG_ROOT%\bin\bash.exe" -lc "cygcheck -dc %CYGWIN_PACKAGES%"
+)
+goto :EOF
+
 :install
 rem Temporarily initialise the submodule in the main (msvc64) build
 git submodule update --init flexdll
@@ -59,9 +78,21 @@ cd "%APPVEYOR_BUILD_FOLDER%\..\flexdll" && unzip -q flexdll.zip
 rem Make sure the Cygwin path comes before the Git one (otherwise cygpath
 rem gets confused as to which root it's in).
 set Path=C:\cygwin64\bin;%OCAMLROOT%\bin\flexdll;%Path%
-"%CYG_ROOT%\bin\bash.exe" -lc "cygcheck -dc cygwin"
-"%CYG_ROOT%\setup-x86_64.exe" -qgnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P diffutils -P make -P mingw64-i686-gcc-core >NUL || exit /b 1
-"%CYG_ROOT%\bin\bash.exe" -lc "cygcheck -dc cygwin"
+
+rem CYGWIN_PACKAGES is the list of required Cygwin packages (cygwin is included
+rem in the list just so that the Cygwin version is always displayed on the log).
+rem CYGWIN_COMMANDS is a corresponding command to run with --version to test
+rem whether the package works. This is used to verify whether the installation
+rem needs upgrading.
+set CYGWIN_PACKAGES=cygwin make diffutils mingw64-i686-gcc-core
+set CYGWIN_COMMANDS=cygcheck make diff i686-w64-mingw32-gcc
+
+set CYGWIN_INSTALL_PACKAGES=
+set CYGWIN_UPGRADE_REQUIRED=0
+
+for %%P in (%CYGWIN_PACKAGES%) do call :CheckPackage %%P
+call :UpgradeCygwin
+
 "%CYG_ROOT%\bin\bash.exe" -lec "$APPVEYOR_BUILD_FOLDER/appveyor_build.sh install" || exit /b 1
 
 call :SaveVars

--- a/appveyor_build.cmd
+++ b/appveyor_build.cmd
@@ -1,0 +1,78 @@
+@rem ***********************************************************************
+@rem *                                                                     *
+@rem *                                 OCaml                               *
+@rem *                                                                     *
+@rem *                 David Allsopp, OCaml Labs, Cambridge.               *
+@rem *                                                                     *
+@rem *   Copyright 2017 MetaStack Solutions Ltd.                           *
+@rem *                                                                     *
+@rem *   All rights reserved.  This file is distributed under the terms of *
+@rem *   the GNU Lesser General Public License version 2.1, with the       *
+@rem *   special exception on linking described in the file LICENSE.       *
+@rem *                                                                     *
+@rem ***********************************************************************
+
+@rem BE CAREFUL ALTERING THIS FILE TO ENSURE THAT ERRORS PROPAGATE
+@rem IF A COMMAND SHOULD FAIL IT PROBABLY NEEDS TO END WITH
+@rem   || exit /b 1
+@rem BASICALLY, DO THE TESTING IN BASH...
+
+@rem Do not call setlocal!
+@echo off
+
+goto %1
+
+goto :EOF
+
+:SaveVars
+set OCAML_PREV_PATH=%PATH%
+set OCAML_PREV_LIB=%LIB%
+set OCAML_PREV_INCLUDE=%INCLUDE%
+goto :EOF
+
+:RestoreVars
+set PATH=%OCAML_PREV_PATH%
+set LIB=%OCAML_PREV_LIB%
+set INCLUDE=%OCAML_PREV_INCLUDE%
+goto :EOF
+
+:install
+rem appveyor DownloadFile "http://alain.frisch.fr/flexdll/flexdll-0.35.tar.gz" -FileName "flexdll.tar.gz" || exit /b 1
+appveyor DownloadFile "http://alain.frisch.fr/flexdll/flexdll-bin-0.35.zip" -FileName "flexdll.zip" || exit /b 1
+rem flexdll.zip is processed here, rather than in appveyor_build.sh because the
+rem unzip command comes from MSYS2 (via Git for Windows) and it has to be
+rem invoked via cmd /c in a bash script which is weird(er).
+mkdir "%APPVEYOR_BUILD_FOLDER%\..\flexdll"
+move flexdll.zip "%APPVEYOR_BUILD_FOLDER%\..\flexdll"
+cd "%APPVEYOR_BUILD_FOLDER%\..\flexdll" && unzip -q flexdll.zip
+
+rem Make sure the Cygwin path comes before the Git one (otherwise cygpath
+rem gets confused as to which root it's in).
+set Path=C:\cygwin64\bin;%OCAMLROOT%\bin\flexdll;%Path%
+"%CYG_ROOT%\bin\bash.exe" -lc "cygcheck -dc cygwin"
+"%CYG_ROOT%\setup-x86_64.exe" -qgnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P diffutils -P make -P mingw64-i686-gcc-core >NUL || exit /b 1
+"%CYG_ROOT%\bin\bash.exe" -lc "cygcheck -dc cygwin"
+"%CYG_ROOT%\bin\bash.exe" -lec "$APPVEYOR_BUILD_FOLDER/appveyor_build.sh install" || exit /b 1
+
+call :SaveVars
+goto :EOF
+
+:build
+rem Run the msvc64 and mingw32 builds
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
+"%CYG_ROOT%\bin\bash.exe" -lec "$APPVEYOR_BUILD_FOLDER/appveyor_build.sh" || exit /b 1
+
+rem Reconfigure the environment and run the msvc32 partial build
+call :RestoreVars
+call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86
+"%CYG_ROOT%\bin\bash.exe" -lec "$APPVEYOR_BUILD_FOLDER/appveyor_build.sh msvc32-only" || exit /b 1
+goto :EOF
+
+:test
+rem Reconfigure the environment for the msvc64 build
+call :RestoreVars
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
+"%APPVEYOR_BUILD_FOLDER%\ocamlc.opt" -version || exit /b 1
+set CAML_LD_LIBRARY_PATH=%OCAMLROOT%/lib/stublibs
+"%CYG_ROOT%\bin\bash.exe" -lec "$APPVEYOR_BUILD_FOLDER/appveyor_build.sh test" || exit /b 1
+goto :EOF

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -52,8 +52,7 @@ case "$1" in
     echo "Edit config/Makefile to set PREFIX=$PREFIX"
     sed -e "s|PREFIX=.*|PREFIX=$PREFIX|" -e "/^ *CFLAGS *=/s/\r\?$/ -WX\0/" config/Makefile.msvc > config/Makefile
 
-    # Temporarily initialise the submodule in the msvc32 build
-    git submodule update --init flexdll
+    # Temporarily bootstrap flexdll
     run "make flexdll" make flexdll
     run "make world" make world
     run "make runtimeopt" make runtimeopt
@@ -70,14 +69,6 @@ case "$1" in
   *)
     cd $APPVEYOR_BUILD_FOLDER
 
-    git worktree add ../build-mingw32 -b appveyor-build-mingw32
-    git worktree add ../build-msvc32 -b appveyor-build-msvc32
-
-    cd ../build-mingw32
-    git submodule update --init flexdll
-
-    cd $APPVEYOR_BUILD_FOLDER
-
     # tar -xzf flexdll.tar.gz
     # cd flexdll-0.35
     # make MSVC_DETECT=0 CHAINS=msvc64 support
@@ -91,8 +82,7 @@ case "$1" in
     sed -e "s|PREFIX=.*|PREFIX=$PREFIX|" -e "/^ *CFLAGS *=/s/\r\?$/ -WX\0/" config/Makefile.msvc64 > config/Makefile
     #run "Content of config/Makefile" cat config/Makefile
 
-    # Temporarily initialise the submodule in the main (msvc64) build
-    git submodule update --init flexdll
+    # Temporarily bootstrap flexdll
     run "make flexdll" make flexdll
     run "make world" make world
     run "make bootstrap" make bootstrap


### PR DESCRIPTION
This has acquired a new urgency, as a Cygwin change in the last 36 hours appears to have broken git (again) - as it happens, I was already working on something, so here it is.

This fixes/changes:
 1. Command Processor escaping is hard enough without having to deal with an illogical format like YAML as well - I've moved all the command processing from `appveyor.yml` into a new `appveyor_build.cmd` file. A price of this is that cmd has no equivalent to bash's `set -e`, but I've also moved as much logic into `appveyor_build.sh` as possible (which is now executed with `-e`) and peppered appropriate commands with `|| exit /b 1`. TL;DR Modifications to `appveyor_build.cmd` and `appveyor.yml` should now be very rare - changes are more likely to be in `appveyor_build.sh` and so in a slightly more familiar script.
 2. Use Git-for-Windows instead of Cygwin's git to set-up the worktrees and initialise the submodules. At the time, it was easier to do that in the bash script, but it's now come back to bite us.
 3. All the packages we need are actually pre-installed these days - I've completely overhauled the logic for Cygwin packages so that setup is only executed if needed. I've also added a test so that the full package upgrade is only run if a package which was installed is not working (this would be the case if we were installing, for example, fresh copies of Cygwin's gcc since they need Cygwin 2.9 and AppVeyor is still shipping 2.7)
  4. While it's far from optimal, I shaved a few minutes off the build by running the mingw32 build in parallel with the msvc64 build. The build log is displayed as before - if the msvc64 build fails, then nothing is reported about msvc32 (for now) and if similarly if the mingw32 fails, then msvc64 will complete (if possible) before that error is displayed.

There is more tidying which could profitably be done in `appveyor_build.sh`, but I'm leaving that alone for now partly because I've had enough CI golf for one weekend and also because it will need updating when we have a working binary release of flexdll 0.36 and want to remove some of the temporary submodule initialisations.

I have run various tests on my personal fork [breaking the compiler](https://ci.appveyor.com/project/dra27/ocaml/build/1.0.99), [breaking the testsuite](https://ci.appveyor.com/project/dra27/ocaml/build/1.0.100), [breaking msvc64 builds](https://ci.appveyor.com/project/dra27/ocaml/build/1.0.111) and [breaking mingw32 builds](https://ci.appveyor.com/project/dra27/ocaml/build/1.0.129) in order to provide a little confidence that AppVeyor doesn't suddenly start passing everything...