### PR TITLE
Fix unboxed types check

### DIFF
--- a/testsuite/tests/typing-unboxed-types/test.ml
+++ b/testsuite/tests/typing-unboxed-types/test.ml
@@ -154,3 +154,10 @@ type 'a t = T : 'a s -> 'a t [@@unboxed];;
 type _ s = S : 'a t -> _ s  [@@unboxed]
  and _ t = T : 'a -> 'a s t
 ;;
+
+
+(* Another corner case *)
+type 'a s
+type ('a, 'p) t = private 'a s
+type 'a packed = T : ('a, _) t -> 'a packed [@@unboxed]
+;;

--- a/testsuite/tests/typing-unboxed-types/test.ml.reference-flat
+++ b/testsuite/tests/typing-unboxed-types/test.ml.reference-flat
@@ -200,4 +200,7 @@ Error: This type cannot be unboxed because
 Error: This type cannot be unboxed because
        it might contain both float and non-float values.
        You should annotate it with [@@ocaml.boxed].
+#             type 'a s
+type ('a, 'p) t = private 'a s
+type 'a packed = T : ('a, 'b) t -> 'a packed [@@unboxed]
 # 

--- a/testsuite/tests/typing-unboxed-types/test.ml.reference-noflat
+++ b/testsuite/tests/typing-unboxed-types/test.ml.reference-noflat
@@ -166,4 +166,7 @@ Error: Signature mismatch:
 #     type 'a t = T : 'a s -> 'a t [@@unboxed]
 #           type _ s = S : 'a t -> 'b s [@@unboxed]
 and _ t = T : 'a -> 'a s t
+#             type 'a s
+type ('a, 'p) t = private 'a s
+type 'a packed = T : ('a, 'b) t -> 'a packed [@@unboxed]
 # 


### PR DESCRIPTION
Currently the following definitions give an error:

```ocaml
type 'a s
+type ('a, 'p) t = 'a s
+type 'a packed = T : ('a, _) t -> 'a packed [@@unboxed]
```

because the compiler thinks that the `'a` might be an existential type variable. There is supposed to be a check that sees that `'a` is in fact a parameter of the `packed` type, however the check is using the wrong copies of the parameters and so can never succeed. This patch fixes the problem by using the appropriate copies of the parameters.