### PR TITLE
Tweak grammar for extended indexing operators

### DIFF
--- a/Changes
+++ b/Changes
@@ -48,7 +48,7 @@ Release branch for 4.06:
   in class expressions and class type expressions.
   (Alain Frisch, reviews by Thomas Refis and Jacques Garrigue)
 
-- GPR#1064: extended indexing operators, add a new class of
+- GPR#1064, GPR#1392: extended indexing operators, add a new class of
   user-defined indexing operators, obtained by adding at least
   one operator character after the dot symbol to the standard indexing
   operators: e,g ".%()", ".?[]", ".@{}<-"

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -598,7 +598,7 @@ The precedences must be listed from low to high.
 %nonassoc HASH                         /* simple_expr/toplevel_directive */
 %left     HASHOP
 %nonassoc below_DOT
-%nonassoc DOT
+%nonassoc DOT DOTOP
 /* Finally, the first tokens of simple_expr are above everything else. */
 %nonassoc BACKQUOTE BANG BEGIN CHAR FALSE FLOAT INT
           LBRACE LBRACELESS LBRACKET LBRACKETBAR LIDENT LPAREN
@@ -1415,51 +1415,21 @@ expr:
   | simple_expr DOTOP LBRACKET expr RBRACKET LESSMINUS expr
       { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "[]<-")) in
         mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $4; Nolabel, $7]) }
-  | simple_expr DOTOP LBRACKET expr RBRACKET
-      { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "[]")) in
-        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $4]) }
-  | simple_expr DOTOP LBRACKET expr error
-      { unclosed "[" 3 "]" 5 }
   | simple_expr DOTOP LPAREN expr RPAREN LESSMINUS expr
       { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "()<-")) in
         mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $4; Nolabel, $7]) }
-  | simple_expr DOTOP LPAREN expr RPAREN
-      { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "()")) in
-        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $4]) }
-  | simple_expr DOTOP LPAREN expr error
-      { unclosed "(" 3 ")" 5 }
   | simple_expr DOTOP LBRACE expr RBRACE LESSMINUS expr
       { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "{}<-")) in
         mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $4; Nolabel, $7]) }
-  | simple_expr DOTOP LBRACE expr RBRACE
-      { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "{}")) in
-        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $4]) }
-  | simple_expr DOTOP LBRACE expr error
-      { unclosed "{" 3 "}" 5 }
   | simple_expr DOT mod_longident DOTOP LBRACKET expr RBRACKET LESSMINUS expr
       { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3,"." ^ $4 ^ "[]<-")) in
         mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $6; Nolabel, $9]) }
-  | simple_expr DOT mod_longident DOTOP LBRACKET expr RBRACKET
-      { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "[]")) in
-        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $6]) }
-  | simple_expr DOT mod_longident DOTOP LBRACKET expr error
-      { unclosed "[" 5 "]" 7 }
   | simple_expr DOT mod_longident DOTOP LPAREN expr RPAREN LESSMINUS expr
       { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "()<-")) in
         mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $6; Nolabel, $9]) }
-  | simple_expr DOT mod_longident DOTOP LPAREN expr RPAREN
-      { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "()")) in
-        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $6]) }
-  | simple_expr DOT mod_longident DOTOP LPAREN expr error
-      { unclosed "(" 5 ")" 7 }
   | simple_expr DOT mod_longident DOTOP LBRACE expr RBRACE LESSMINUS expr
       { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "{}<-")) in
         mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $6; Nolabel, $9]) }
-  | simple_expr DOT mod_longident DOTOP LBRACE expr RBRACE
-      { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "{}")) in
-        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $6]) }
-  | simple_expr DOT mod_longident DOTOP LBRACE expr error
-      { unclosed "{" 5 "}" 7 }
   | label LESSMINUS expr
       { mkexp(Pexp_setinstvar(mkrhs $1 1, $3)) }
   | ASSERT ext_attributes simple_expr %prec below_HASH
@@ -1516,6 +1486,36 @@ simple_expr:
                          [Nolabel,$1; Nolabel,$4])) }
   | simple_expr DOT LBRACKET seq_expr error
       { unclosed "[" 3 "]" 5 }
+  | simple_expr DOTOP LBRACKET expr RBRACKET
+      { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "[]")) in
+        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $4]) }
+  | simple_expr DOTOP LBRACKET expr error
+      { unclosed "[" 3 "]" 5 }
+  | simple_expr DOTOP LPAREN expr RPAREN
+      { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "()")) in
+        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $4]) }
+  | simple_expr DOTOP LPAREN expr error
+      { unclosed "(" 3 ")" 5 }
+  | simple_expr DOTOP LBRACE expr RBRACE
+      { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "{}")) in
+        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $4]) }
+  | simple_expr DOTOP LBRACE expr error
+      { unclosed "{" 3 "}" 5 }
+  | simple_expr DOT mod_longident DOTOP LBRACKET expr RBRACKET
+      { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "[]")) in
+        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $6]) }
+  | simple_expr DOT mod_longident DOTOP LBRACKET expr error
+      { unclosed "[" 5 "]" 7 }
+  | simple_expr DOT mod_longident DOTOP LPAREN expr RPAREN
+      { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "()")) in
+        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $6]) }
+  | simple_expr DOT mod_longident DOTOP LPAREN expr error
+      { unclosed "(" 5 ")" 7 }
+  | simple_expr DOT mod_longident DOTOP LBRACE expr RBRACE
+      { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "{}")) in
+        mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $6]) }
+  | simple_expr DOT mod_longident DOTOP LBRACE expr error
+      { unclosed "{" 5 "}" 7 }
   | simple_expr DOT LBRACE expr RBRACE
       { bigarray_get $1 $4 }
   | simple_expr DOT LBRACE expr_comma_list error

--- a/testsuite/tests/parsing/extended_indexoperators.ml
+++ b/testsuite/tests/parsing/extended_indexoperators.ml
@@ -11,4 +11,13 @@ let h = Hashtbl.create 17
 ;;
   h.@("One") <- 1
 ; assert (h.@{"One"} = 1)
+; print_int h.@{"One"}
 ; assert (h.?["Two"] = None)
+
+
+(* from GPR#1392 *)
+let ( #? ) x y = (x, y);;
+let ( .%() ) x y = x.(y);;
+let x = [| 0 |];;
+let _ = 1 #? x.(0);;
+let _ = 1 #? x.%(0);;

--- a/testsuite/tests/parsing/extended_indexoperators.ml.reference
+++ b/testsuite/tests/parsing/extended_indexoperators.ml.reference
@@ -79,9 +79,9 @@
                 Pexp_constant PConst_int (17,None)
           ]
     ]
-  structure_item (extended_indexoperators.ml[12,226+2]..[14,270+28])
+  structure_item (extended_indexoperators.ml[12,226+2]..[15,293+28])
     Pstr_eval
-    expression (extended_indexoperators.ml[12,226+2]..[14,270+28])
+    expression (extended_indexoperators.ml[12,226+2]..[15,293+28])
       Pexp_sequence
       expression (extended_indexoperators.ml[12,226+2]..[12,226+17])
         Pexp_apply
@@ -101,7 +101,7 @@
             expression (extended_indexoperators.ml[12,226+16]..[12,226+17])
               Pexp_constant PConst_int (1,None)
         ]
-      expression (extended_indexoperators.ml[13,244+2]..[14,270+28])
+      expression (extended_indexoperators.ml[13,244+2]..[15,293+28])
         Pexp_sequence
         expression (extended_indexoperators.ml[13,244+2]..[13,244+25])
           Pexp_assert
@@ -131,34 +131,197 @@
                 expression (extended_indexoperators.ml[13,244+23]..[13,244+24])
                   Pexp_constant PConst_int (1,None)
             ]
-        expression (extended_indexoperators.ml[14,270+2]..[14,270+28])
-          Pexp_assert
-          expression (extended_indexoperators.ml[14,270+9]..[14,270+28])
+        expression (extended_indexoperators.ml[14,270+2]..[15,293+28])
+          Pexp_sequence
+          expression (extended_indexoperators.ml[14,270+2]..[14,270+22])
             Pexp_apply
-            expression (extended_indexoperators.ml[14,270+21]..[14,270+22])
-              Pexp_ident "=" (extended_indexoperators.ml[14,270+21]..[14,270+22])
+            expression (extended_indexoperators.ml[14,270+2]..[14,270+11])
+              Pexp_ident "print_int" (extended_indexoperators.ml[14,270+2]..[14,270+11])
             [
               <arg>
               Nolabel
-                expression (extended_indexoperators.ml[14,270+10]..[14,270+20])
+                expression (extended_indexoperators.ml[14,270+12]..[14,270+22])
                   Pexp_apply
-                  expression (extended_indexoperators.ml[14,270+10]..[14,270+20])
-                    Pexp_ident ".?[]" (extended_indexoperators.ml[14,270+10]..[14,270+20]) ghost
+                  expression (extended_indexoperators.ml[14,270+12]..[14,270+22])
+                    Pexp_ident ".@{}" (extended_indexoperators.ml[14,270+12]..[14,270+22]) ghost
                   [
                     <arg>
                     Nolabel
-                      expression (extended_indexoperators.ml[14,270+10]..[14,270+11])
-                        Pexp_ident "h" (extended_indexoperators.ml[14,270+10]..[14,270+11])
+                      expression (extended_indexoperators.ml[14,270+12]..[14,270+13])
+                        Pexp_ident "h" (extended_indexoperators.ml[14,270+12]..[14,270+13])
                     <arg>
                     Nolabel
-                      expression (extended_indexoperators.ml[14,270+14]..[14,270+19])
-                        Pexp_constant PConst_string("Two",None)
+                      expression (extended_indexoperators.ml[14,270+16]..[14,270+21])
+                        Pexp_constant PConst_string("One",None)
                   ]
-              <arg>
-              Nolabel
-                expression (extended_indexoperators.ml[14,270+23]..[14,270+27])
-                  Pexp_construct "None" (extended_indexoperators.ml[14,270+23]..[14,270+27])
-                  None
             ]
+          expression (extended_indexoperators.ml[15,293+2]..[15,293+28])
+            Pexp_assert
+            expression (extended_indexoperators.ml[15,293+9]..[15,293+28])
+              Pexp_apply
+              expression (extended_indexoperators.ml[15,293+21]..[15,293+22])
+                Pexp_ident "=" (extended_indexoperators.ml[15,293+21]..[15,293+22])
+              [
+                <arg>
+                Nolabel
+                  expression (extended_indexoperators.ml[15,293+10]..[15,293+20])
+                    Pexp_apply
+                    expression (extended_indexoperators.ml[15,293+10]..[15,293+20])
+                      Pexp_ident ".?[]" (extended_indexoperators.ml[15,293+10]..[15,293+20]) ghost
+                    [
+                      <arg>
+                      Nolabel
+                        expression (extended_indexoperators.ml[15,293+10]..[15,293+11])
+                          Pexp_ident "h" (extended_indexoperators.ml[15,293+10]..[15,293+11])
+                      <arg>
+                      Nolabel
+                        expression (extended_indexoperators.ml[15,293+14]..[15,293+19])
+                          Pexp_constant PConst_string("Two",None)
+                    ]
+                <arg>
+                Nolabel
+                  expression (extended_indexoperators.ml[15,293+23]..[15,293+27])
+                    Pexp_construct "None" (extended_indexoperators.ml[15,293+23]..[15,293+27])
+                    None
+              ]
+  structure_item (extended_indexoperators.ml[19,344+0]..[19,344+23])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_indexoperators.ml[19,344+4]..[19,344+10])
+          Ppat_var "#?" (extended_indexoperators.ml[19,344+4]..[19,344+10])
+        expression (extended_indexoperators.ml[19,344+11]..[19,344+23]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_indexoperators.ml[19,344+11]..[19,344+12])
+            Ppat_var "x" (extended_indexoperators.ml[19,344+11]..[19,344+12])
+          expression (extended_indexoperators.ml[19,344+13]..[19,344+23]) ghost
+            Pexp_fun
+            Nolabel
+            None
+            pattern (extended_indexoperators.ml[19,344+13]..[19,344+14])
+              Ppat_var "y" (extended_indexoperators.ml[19,344+13]..[19,344+14])
+            expression (extended_indexoperators.ml[19,344+17]..[19,344+23])
+              Pexp_tuple
+              [
+                expression (extended_indexoperators.ml[19,344+18]..[19,344+19])
+                  Pexp_ident "x" (extended_indexoperators.ml[19,344+18]..[19,344+19])
+                expression (extended_indexoperators.ml[19,344+21]..[19,344+22])
+                  Pexp_ident "y" (extended_indexoperators.ml[19,344+21]..[19,344+22])
+              ]
+    ]
+  structure_item (extended_indexoperators.ml[20,370+0]..[20,370+24])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_indexoperators.ml[20,370+4]..[20,370+12])
+          Ppat_var ".%()" (extended_indexoperators.ml[20,370+4]..[20,370+12])
+        expression (extended_indexoperators.ml[20,370+13]..[20,370+24]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_indexoperators.ml[20,370+13]..[20,370+14])
+            Ppat_var "x" (extended_indexoperators.ml[20,370+13]..[20,370+14])
+          expression (extended_indexoperators.ml[20,370+15]..[20,370+24]) ghost
+            Pexp_fun
+            Nolabel
+            None
+            pattern (extended_indexoperators.ml[20,370+15]..[20,370+16])
+              Ppat_var "y" (extended_indexoperators.ml[20,370+15]..[20,370+16])
+            expression (extended_indexoperators.ml[20,370+19]..[20,370+24])
+              Pexp_apply
+              expression (extended_indexoperators.ml[20,370+19]..[20,370+24]) ghost
+                Pexp_ident "Array.get" (extended_indexoperators.ml[20,370+19]..[20,370+24]) ghost
+              [
+                <arg>
+                Nolabel
+                  expression (extended_indexoperators.ml[20,370+19]..[20,370+20])
+                    Pexp_ident "x" (extended_indexoperators.ml[20,370+19]..[20,370+20])
+                <arg>
+                Nolabel
+                  expression (extended_indexoperators.ml[20,370+22]..[20,370+23])
+                    Pexp_ident "y" (extended_indexoperators.ml[20,370+22]..[20,370+23])
+              ]
+    ]
+  structure_item (extended_indexoperators.ml[21,397+0]..[21,397+15])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_indexoperators.ml[21,397+4]..[21,397+5])
+          Ppat_var "x" (extended_indexoperators.ml[21,397+4]..[21,397+5])
+        expression (extended_indexoperators.ml[21,397+8]..[21,397+15])
+          Pexp_array
+          [
+            expression (extended_indexoperators.ml[21,397+11]..[21,397+12])
+              Pexp_constant PConst_int (0,None)
+          ]
+    ]
+  structure_item (extended_indexoperators.ml[22,415+0]..[22,415+18])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_indexoperators.ml[22,415+4]..[22,415+5])
+          Ppat_any
+        expression (extended_indexoperators.ml[22,415+8]..[22,415+18])
+          Pexp_apply
+          expression (extended_indexoperators.ml[22,415+10]..[22,415+12])
+            Pexp_ident "#?" (extended_indexoperators.ml[22,415+10]..[22,415+12])
+          [
+            <arg>
+            Nolabel
+              expression (extended_indexoperators.ml[22,415+8]..[22,415+9])
+                Pexp_constant PConst_int (1,None)
+            <arg>
+            Nolabel
+              expression (extended_indexoperators.ml[22,415+13]..[22,415+18])
+                Pexp_apply
+                expression (extended_indexoperators.ml[22,415+13]..[22,415+18]) ghost
+                  Pexp_ident "Array.get" (extended_indexoperators.ml[22,415+13]..[22,415+18]) ghost
+                [
+                  <arg>
+                  Nolabel
+                    expression (extended_indexoperators.ml[22,415+13]..[22,415+14])
+                      Pexp_ident "x" (extended_indexoperators.ml[22,415+13]..[22,415+14])
+                  <arg>
+                  Nolabel
+                    expression (extended_indexoperators.ml[22,415+16]..[22,415+17])
+                      Pexp_constant PConst_int (0,None)
+                ]
+          ]
+    ]
+  structure_item (extended_indexoperators.ml[23,436+0]..[23,436+19])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_indexoperators.ml[23,436+4]..[23,436+5])
+          Ppat_any
+        expression (extended_indexoperators.ml[23,436+8]..[23,436+19])
+          Pexp_apply
+          expression (extended_indexoperators.ml[23,436+10]..[23,436+12])
+            Pexp_ident "#?" (extended_indexoperators.ml[23,436+10]..[23,436+12])
+          [
+            <arg>
+            Nolabel
+              expression (extended_indexoperators.ml[23,436+8]..[23,436+9])
+                Pexp_constant PConst_int (1,None)
+            <arg>
+            Nolabel
+              expression (extended_indexoperators.ml[23,436+13]..[23,436+19])
+                Pexp_apply
+                expression (extended_indexoperators.ml[23,436+13]..[23,436+19])
+                  Pexp_ident ".%()" (extended_indexoperators.ml[23,436+13]..[23,436+19]) ghost
+                [
+                  <arg>
+                  Nolabel
+                    expression (extended_indexoperators.ml[23,436+13]..[23,436+14])
+                      Pexp_ident "x" (extended_indexoperators.ml[23,436+13]..[23,436+14])
+                  <arg>
+                  Nolabel
+                    expression (extended_indexoperators.ml[23,436+17]..[23,436+18])
+                      Pexp_constant PConst_int (0,None)
+                ]
+          ]
+    ]
 ]
 


### PR DESCRIPTION
As I tried to use the extended indexing operators introduced by https://github.com/ocaml/ocaml/pull/1064,
I noticed that they cannot be used as the regular ones. For example,
the following expression fails with a syntax error:

    print_int a.%{i}

This PR is an attempt to fix this issue by:

- moving the rules for read accesses from `expr` to `simple_expr`
  (thus being uniform with regular arrays);
- setting a precedence for `DOTOP` as the previous step created
  conflicts.

My understanding of the grammar being limited (at best), feedback
and comments are more than welcome.