### PR TITLE
Expose Unix.is_inet6_addr

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,8 @@ be mentioned in the 4.06 section below instead of here.)
 
 ### Other libraries:
 
+- Expose Unix.is_inet6_addr
+
 ### Manual and documentation:
 
 ### Tools:

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -1183,6 +1183,10 @@ val getgrgid : int -> group_entry
 type inet_addr
 (** The abstract type of Internet addresses. *)
 
+val is_inet6_addr : inet_addr -> bool
+(** Return [true] if the given Internet address represents
+    a IPv6 address, [false] if it represents a IPv4 address. *)
+
 val inet_addr_of_string : string -> inet_addr
 (** Conversion from the printable representation of an Internet
     address to its internal representation.  The argument string

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -977,6 +977,10 @@ val getgrgid : int -> group_entry
 type inet_addr = Unix.inet_addr
 (** The abstract type of Internet addresses. *)
 
+val is_inet6_addr : inet_addr -> bool
+(** Return [true] if the given Internet address represents
+    a IPv6 address, [false] if it represents a IPv4 address. *)
+
 val inet_addr_of_string : string -> inet_addr
 (** Conversion from the printable representation of an Internet
     address to its internal representation.  The argument string


### PR DESCRIPTION
There is a missing link in the following chain of event when one wants to bind a socket to a local address:
```
let open_socket ~bind_addr ~max_conn port =
  let bind_addr_inet =
    Unix.inet_addr_of_string bind_addr
  in
  let bind_addr = Unix.ADDR_INET(bind_addr_inet, port) in
  (* PF_INET or PF_INET6 ?? *)
  let sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
  Unix.setsockopt sock Unix.SO_REUSEADDR true ;
  Unix.setsockopt sock Unix.TCP_NODELAY true;
  Unix.bind sock bind_addr;
  Unix.listen sock max_conn ;
  sock
```

With the proposed patch, this code would change to:
```
let open_socket ~bind_addr ~max_conn port =
  let bind_addr_inet =
    Unix.inet_addr_of_string bind_addr
  in
  let bind_addr = Unix.ADDR_INET(bind_addr_inet, port) in
  let domain =
    if Unix.is_inet6_addr bind_addr then Unix.PF_INET6 else Unix.PF_INET
  in
  let sock = Unix.socket domain Unix.SOCK_STREAM 0 in
  Unix.setsockopt sock Unix.SO_REUSEADDR true ;
  Unix.setsockopt sock Unix.TCP_NODELAY true;
  Unix.bind sock bind_addr;
  Unix.listen sock max_conn ;
  sock
```