### PR TITLE
Clarify Sys.executable_name behavior

### DIFF
--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -27,7 +27,9 @@ val argv : string array
    given to the program. *)
 
 val executable_name : string
-(** The name of the file containing the executable currently running. *)
+(** The name of the file containing the executable currently running.
+    The path may be relative or absolute depending on the platform and
+    whether the program was compiled to bytecode or a native executable. *)
 
 external file_exists : string -> bool = "caml_sys_file_exists"
 (** Test if a file with the given name exists. *)

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -28,8 +28,9 @@ val argv : string array
 
 val executable_name : string
 (** The name of the file containing the executable currently running.
-    The path may be relative or absolute depending on the platform and
-    whether the program was compiled to bytecode or a native executable. *)
+    This name may be absolute or relative to the current directory, depending
+    on the platform and whether the program was compiled to bytecode or a native
+    executable. *)
 
 external file_exists : string -> bool = "caml_sys_file_exists"
 (** Test if a file with the given name exists. *)


### PR DESCRIPTION
We had a bug based on differences on the result of `Sys.executable_name` on OSX and Linux. The behavior also differs based on whether the program was compiled with `ocamlopt` and `ocamlc`. I'm using OCaml 4.04.2 in both locations.

Linux (Ubuntu 16.04.3):
```
ubuntu@ip-172-31-7-122:/tmp/executable-name$ cat test.ml
print_endline Sys.executable_name
ubuntu@ip-172-31-7-122:/tmp/executable-name$ ocamlc test.ml -o test
ubuntu@ip-172-31-7-122:/tmp/executable-name$ ./test
./test
ubuntu@ip-172-31-7-122:/tmp/executable-name$ ocamlopt test.ml -o test
ubuntu@ip-172-31-7-122:/tmp/executable-name$ ./test
/tmp/executable-name/test
```

OSX (Sierra 10.12.6):

```
~/Documents/ocaml/executable-name
$ ocamlc test.ml -o test

~/Documents/ocaml/executable-name
$ ./test
./test

~/Documents/ocaml/executable-name
$ ocamlopt test.ml -o test

~/Documents/ocaml/executable-name
$ ./test
./test
```

This PR updates the documentation to be explicit that this path may be relative or absolute.