### PR TITLE
One more Windows Unicode PR: do not use %S

### DIFF
--- a/Changes
+++ b/Changes
@@ -404,10 +404,10 @@ Release branch for 4.06:
 
 ### Runtime system:
 
-* MPR#3771, GPR#153, GPR#1200, GPR#1357, GPR#1362, GPR#1363: Unicode support for
-  the Windows runtime.
-  (ygrek, Clement Franchini, Nicolas Ojeda Bar, review by Alain Frisch, David
-  Allsopp, Damien Doligez)
+* MPR#3771, GPR#153, GPR#1200, GPR#1357, GPR#1362, GPR#1363, GPR#1398: Unicode
+  support for the Windows runtime.
+  (ygrek, Nicolas Ojeda Bar, review by Alain Frisch, David Allsopp, Damien
+  Doligez)
 
 - GPR#1070, GPR#1295: enable gcc typechecking for caml_alloc_sprintf,
   caml_gc_message. Make caml_gc_message a variadic function. Fix many

--- a/byterun/caml/config.h
+++ b/byterun/caml/config.h
@@ -37,14 +37,6 @@
 #define ARCH_SIZET_PRINTF_FORMAT "z"
 #endif
 
-/* Types for Windows wide strings */
-
-#ifdef _WIN32
-#define ARCH_CHARNATSTR_PRINTF_FORMAT "S"
-#else
-#define ARCH_CHARNATSTR_PRINTF_FORMAT "s"
-#endif
-
 /* Types for 32-bit integers, 64-bit integers, and
    native integers (as wide as a pointer type) */
 

--- a/byterun/dynlink.c
+++ b/byterun/dynlink.c
@@ -127,11 +127,13 @@ static char_os * parse_ld_conf(void)
 static void open_shared_lib(char_os * name)
 {
   char_os * realname;
+  char * u8;
   void * handle;
 
   realname = caml_search_dll_in_path(&caml_shared_libs_path, name);
-  caml_gc_message(0x100, "Loading shared library %"
-                  ARCH_CHARNATSTR_PRINTF_FORMAT "\n", realname);
+  u8 = caml_stat_strdup_of_os(realname);
+  caml_gc_message(0x100, "Loading shared library %s\n", u8);
+  caml_stat_free(u8);
   caml_enter_blocking_section();
   handle = caml_dlopen(realname, 1, 1);
   caml_leave_blocking_section();

--- a/byterun/startup.c
+++ b/byterun/startup.c
@@ -94,11 +94,12 @@ int caml_attempt_open(char_os **name, struct exec_trailer *trail,
   char_os * truename;
   int fd;
   int err;
-  char buf [2];
+  char buf [2], * u8;
 
   truename = caml_search_exe_in_path(*name);
-  caml_gc_message(0x100, "Opening bytecode executable %"
-                  ARCH_CHARNATSTR_PRINTF_FORMAT "\n", truename);
+  u8 = caml_stat_strdup_of_os(truename);
+  caml_gc_message(0x100, "Opening bytecode executable %s\n", u8);
+  caml_stat_free(u8);
   fd = open_os(truename, O_RDONLY | O_BINARY);
   if (fd == -1) {
     caml_stat_free(truename);

--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -634,6 +634,7 @@ static struct cplugin_context cplugin_context;
 void caml_load_plugin(char_os *plugin)
 {
   void* dll_handle = NULL;
+  char* u8;
 
   dll_handle = caml_dlopen(plugin, DLL_EXECUTABLE, DLL_NOT_GLOBAL);
   if( dll_handle != NULL ){
@@ -646,8 +647,10 @@ void caml_load_plugin(char_os *plugin)
      caml_dlclose(dll_handle);
    }
   } else {
+   u8 = caml_stat_strdup_of_os(plugin);
    fprintf(stderr, "Cannot load C plugin %s\nReason: %s\n",
-           caml_stat_strdup_of_os(plugin), caml_dlerror());
+           u8, caml_dlerror());
+   caml_stat_free(u8);
   }
 }
 

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -149,6 +149,7 @@ wchar_t * caml_decompose_path(struct ext_table * tbl, wchar_t * path)
 wchar_t * caml_search_in_path(struct ext_table * path, const wchar_t * name)
 {
   wchar_t * dir, * fullname;
+  char * u8;
   const wchar_t * p;
   int i;
   struct _stati64 st;
@@ -161,19 +162,24 @@ wchar_t * caml_search_in_path(struct ext_table * path, const wchar_t * name)
     if (dir[0] == 0) continue;
          /* not sure what empty path components mean under Windows */
     fullname = caml_stat_wcsconcat(3, dir, L"\\", name);
-    caml_gc_message(0x100, "Searching %" ARCH_CHARNATSTR_PRINTF_FORMAT "\n", fullname);
+    u8 = caml_stat_strdup_of_utf16(fullname);
+    caml_gc_message(0x100, "Searching %s\n", u8);
+    caml_stat_free(u8);
     if (_wstati64(fullname, &st) == 0 && S_ISREG(st.st_mode))
       return fullname;
     caml_stat_free(fullname);
   }
  not_found:
-  caml_gc_message(0x100, "%" ARCH_CHARNATSTR_PRINTF_FORMAT " not found in search path\n", name);
+  u8 = caml_stat_strdup_of_utf16(name);
+  caml_gc_message(0x100, "%s not found in search path\n", u8);
+  caml_stat_free(u8);
   return caml_stat_wcsdup(name);
 }
 
 CAMLexport wchar_t * caml_search_exe_in_path(const wchar_t * name)
 {
   wchar_t * fullname, * filepart;
+  char * u8;
   size_t fullnamelen;
   DWORD retcode;
 
@@ -188,7 +194,9 @@ CAMLexport wchar_t * caml_search_exe_in_path(const wchar_t * name)
                          fullname,
                          &filepart);
     if (retcode == 0) {
-      caml_gc_message(0x100, "%" ARCH_CHARNATSTR_PRINTF_FORMAT " not found in search path\n", name);
+      u8 = caml_stat_strdup_of_utf16(name);
+      caml_gc_message(0x100, "%s not found in search path\n", u8);
+      caml_stat_free(u8);
       caml_stat_free(fullname);
       return caml_stat_strdup_os(name);
     }


### PR DESCRIPTION
This PR addresses the following small issue left over from #1200. In that PR there are a handful of uses of the `printf` format specifier `%S` to print wide strings (`wchar_t *`), mostly in calls to `caml_gc_message` to print filename arguments (see e.g. [here](https://github.com/ocaml/ocaml/blob/trunk/byterun/startup.c#L100) and [here](https://github.com/ocaml/ocaml/blob/trunk/byterun/dynlink.c#L133)).

The specifier `%S` is both [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fprintf.html) and conforms to the [Unix specification](http://pubs.opengroup.org/onlinepubs/007908799/xsh/fprintf.html).  Unfortunately it is effectively broken under Windows (in spite of ["supporting"](https://msdn.microsoft.com/en-us/library/aa272865(v=vs.60).aspx) it).  The details are a little long but see this [post](https://stackoverflow.com/questions/10882277/properly-print-utf8-characters-in-windows-console) for some good pointers.

Hence we would like to get rid of the `%S` specifiers.  The only issue is that if we convert the wide strings into usual strings with our existing functions then we must not forget to `free` them, etc. Also it would be nicer not to allocate when printing GC debug messages.

This PR defines a function `win_utf8_string_of_utf16` in `win32.c` which converts as needed but uses a fixed-length statically-allocated buffer to store the resulting UTF-8 string.  This is not an issue because in each use of the function the result of doing the conversion does not need to be stored anywhere (and possible truncation is OK).

We also use this function for some arguments to `caml_fatal_error_arg` which were being "leaked" (just before the program ends).

Together with this change, we also add a call to `SetConsoleOutputCP` in the different `caml_{main,startup*}` functions so that, under Windows with Unicode mode enabled, the console code page is set to UTF-8, saving the user from having to do it.  This helps to print things correctly on the Windows Console (e.g. if you run your programs from the Command Prompt).

Lastly, and for the record, as far as I know, the most "native" solution to these printing issues would be to use the Windows call `WriteConsole` (like we do in `headernt.c`) to print wide strings, which would not require us to do any conversion. However, it is not straightforward to integrate this function in our `printf`-based functions `caml_gc_message`, `caml_fatal_error_arg`, and `caml_fatal_error_arg2`.

@dra27 