### PR TITLE
Performance improvement in print_endline for redirection

### DIFF
--- a/byterun/caml/io.h
+++ b/byterun/caml/io.h
@@ -58,6 +58,7 @@ enum {
   CHANNEL_FLAG_BLOCKING_WRITE = 2, /* Don't release master lock when writing */
 #endif
   CHANNEL_FLAG_MANAGED_BY_GC = 4,  /* Free and close using GC finalization */
+  CHANNEL_FLAG_ISATTY = 8,  /* It is associated to a terminal */
 };
 
 /* For an output channel:

--- a/byterun/io.c
+++ b/byterun/io.c
@@ -78,7 +78,7 @@ CAMLexport struct channel * caml_open_descriptor_in(int fd)
   channel->revealed = 0;
   channel->old_revealed = 0;
   channel->refcount = 0;
-  channel->flags = 0;
+  channel->flags = isatty(fd) ? CHANNEL_FLAG_ISATTY : 0;
   channel->next = caml_all_opened_channels;
   channel->prev = NULL;
   channel->name = NULL;
@@ -585,6 +585,13 @@ CAMLprim value caml_ml_set_binary_mode(value vchannel, value mode)
     caml_sys_error(NO_ARG);
 #endif
   return Val_unit;
+}
+
+CAMLprim value caml_ml_isatty(value vchannel)
+{
+  struct channel * channel = Channel(vchannel);
+  int res = (channel->flags & CHANNEL_FLAG_ISATTY) != 0;
+  return Val_bool(res);
 }
 
 /*

--- a/stdlib/pervasives.ml
+++ b/stdlib/pervasives.ml
@@ -322,6 +322,7 @@ let open_out name =
 let open_out_bin name =
   open_out_gen [Open_wronly; Open_creat; Open_trunc; Open_binary] 0o666 name
 
+external isatty : out_channel -> bool = "caml_ml_isatty"
 external flush : out_channel -> unit = "caml_ml_flush"
 
 external out_channels_list : unit -> out_channel list
@@ -472,9 +473,9 @@ let print_string s = output_string stdout s
 let print_bytes s = output_bytes stdout s
 let print_int i = output_string stdout (string_of_int i)
 let print_float f = output_string stdout (string_of_float f)
-let print_endline s =
-  output_string stdout s; output_char stdout '\n'; flush stdout
-let print_newline () = output_char stdout '\n'; flush stdout
+let print_newline () =
+  output_char stdout '\n'; if isatty stdout then flush stdout else ()
+let print_endline s = output_string stdout s; print_newline ()
 
 (* Output functions on standard error *)
 
@@ -483,9 +484,9 @@ let prerr_string s = output_string stderr s
 let prerr_bytes s = output_bytes stderr s
 let prerr_int i = output_string stderr (string_of_int i)
 let prerr_float f = output_string stderr (string_of_float f)
-let prerr_endline s =
-  output_string stderr s; output_char stderr '\n'; flush stderr
-let prerr_newline () = output_char stderr '\n'; flush stderr
+let prerr_newline () =
+  output_char stderr '\n'; if isatty stderr then flush stderr else ()
+let prerr_endline s = output_string stderr s; prerr_newline ()
 
 (* Input functions on standard input *)
 


### PR DESCRIPTION
This PR inserts checking `isatty` and avoids the calling `caml_ml_flush` in `print_endline`, `print_newline`, `prerr_endline`, and `prerr_newline`.

## Motivation

OCaml's I/O routines is very fast because using not C stdio but the original buffering.
However, the family of `print_endline` are exceptions. They makes I/O would become slow, mainly, in the case that the standard I/O is redirected.

C stdlib checks `isatty` to avoid `fflush` on outputting '\n' for the performance.
It is desirable that OCaml's I/O be revised likewise.

## Details of implementation

Add new flag `CHANNEL_FLAG_ISATTY` into `flags` of `struct channel`, and refer it to reduce the calling `isatty`, because, generally speaking, system calls are slower than normal functions.
(This flag may be useful for other future uses ??)

Thanks.
