### PR TITLE
Cmm invariants

### DIFF
--- a/.depend
+++ b/.depend
@@ -2027,10 +2027,8 @@ bytecomp/printinstr.cmx : \
     bytecomp/printinstr.cmi
 bytecomp/printinstr.cmi : \
     bytecomp/instruct.cmi
-bytecomp/runtimedef.cmo :
-bytecomp/runtimedef.cmx :
 bytecomp/symtable.cmo : \
-    bytecomp/runtimedef.cmo \
+    lambda/runtimedef.cmi \
     typing/predef.cmi \
     utils/misc.cmi \
     bytecomp/meta.cmi \
@@ -2045,7 +2043,7 @@ bytecomp/symtable.cmo : \
     parsing/asttypes.cmi \
     bytecomp/symtable.cmi
 bytecomp/symtable.cmx : \
-    bytecomp/runtimedef.cmx \
+    lambda/runtimedef.cmx \
     typing/predef.cmx \
     utils/misc.cmx \
     bytecomp/meta.cmx \
@@ -2229,7 +2227,7 @@ asmcomp/asmlibrarian.cmx : \
     asmcomp/asmlibrarian.cmi
 asmcomp/asmlibrarian.cmi :
 asmcomp/asmlink.cmo : \
-    bytecomp/runtimedef.cmo \
+    lambda/runtimedef.cmi \
     utils/profile.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
@@ -2247,7 +2245,7 @@ asmcomp/asmlink.cmo : \
     asmcomp/asmgen.cmi \
     asmcomp/asmlink.cmi
 asmcomp/asmlink.cmx : \
-    bytecomp/runtimedef.cmx \
+    lambda/runtimedef.cmx \
     utils/profile.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
@@ -5791,7 +5789,6 @@ asmcomp/debug/reg_with_debug_info.cmx : \
 asmcomp/debug/reg_with_debug_info.cmi : \
     asmcomp/reg.cmi \
     middle_end/backend_var.cmi
-driver/compdynlink.cmi :
 driver/compenv.cmo : \
     utils/warnings.cmi \
     utils/profile.cmi \
@@ -6126,13 +6123,13 @@ driver/pparse.cmi : \
     parsing/parsetree.cmi
 toplevel/expunge.cmo : \
     bytecomp/symtable.cmi \
-    bytecomp/runtimedef.cmo \
+    lambda/runtimedef.cmi \
     utils/misc.cmi \
     typing/ident.cmi \
     bytecomp/bytesections.cmi
 toplevel/expunge.cmx : \
     bytecomp/symtable.cmx \
-    bytecomp/runtimedef.cmx \
+    lambda/runtimedef.cmx \
     utils/misc.cmx \
     typing/ident.cmx \
     bytecomp/bytesections.cmx
@@ -6342,8 +6339,6 @@ toplevel/trace.cmi : \
     typing/path.cmi \
     parsing/longident.cmi \
     typing/env.cmi
-toplevel/byte/topdirs.cmi : \
-    parsing/longident.cmi
 toplevel/byte/topeval.cmo : \
     utils/warnings.cmi \
     typing/types.cmi \
@@ -6417,20 +6412,11 @@ toplevel/byte/topeval.cmx : \
 toplevel/byte/topeval.cmi : \
     toplevel/topcommon.cmi \
     parsing/parsetree.cmi
-toplevel/byte/toploop.cmi : \
-    utils/warnings.cmi \
-    typing/types.cmi \
-    typing/path.cmi \
-    parsing/parsetree.cmi \
-    typing/outcometree.cmi \
-    parsing/longident.cmi \
-    parsing/location.cmi \
-    typing/env.cmi
 toplevel/byte/topmain.cmo : \
     toplevel/byte/trace.cmi \
-    toplevel/byte/toploop.cmi \
+    toplevel/toploop.cmi \
     toplevel/byte/topeval.cmi \
-    toplevel/byte/topdirs.cmi \
+    toplevel/topdirs.cmi \
     toplevel/topcommon.cmi \
     typing/printtyp.cmi \
     typing/path.cmi \
@@ -6445,9 +6431,9 @@ toplevel/byte/topmain.cmo : \
     toplevel/byte/topmain.cmi
 toplevel/byte/topmain.cmx : \
     toplevel/byte/trace.cmx \
-    toplevel/byte/toploop.cmi \
+    toplevel/toploop.cmx \
     toplevel/byte/topeval.cmx \
-    toplevel/byte/topdirs.cmi \
+    toplevel/topdirs.cmx \
     toplevel/topcommon.cmx \
     typing/printtyp.cmx \
     typing/path.cmx \

--- a/.depend
+++ b/.depend
@@ -2027,8 +2027,10 @@ bytecomp/printinstr.cmx : \
     bytecomp/printinstr.cmi
 bytecomp/printinstr.cmi : \
     bytecomp/instruct.cmi
+bytecomp/runtimedef.cmo :
+bytecomp/runtimedef.cmx :
 bytecomp/symtable.cmo : \
-    lambda/runtimedef.cmi \
+    bytecomp/runtimedef.cmo \
     typing/predef.cmi \
     utils/misc.cmi \
     bytecomp/meta.cmi \
@@ -2043,7 +2045,7 @@ bytecomp/symtable.cmo : \
     parsing/asttypes.cmi \
     bytecomp/symtable.cmi
 bytecomp/symtable.cmx : \
-    lambda/runtimedef.cmx \
+    bytecomp/runtimedef.cmx \
     typing/predef.cmx \
     utils/misc.cmx \
     bytecomp/meta.cmx \
@@ -2141,6 +2143,7 @@ asmcomp/asmgen.cmo : \
     asmcomp/comballoc.cmi \
     asmcomp/coloring.cmi \
     asmcomp/cmmgen.cmi \
+    asmcomp/cmm_invariants.cmi \
     asmcomp/cmm_helpers.cmi \
     asmcomp/cmm.cmi \
     utils/clflags.cmi \
@@ -2183,6 +2186,7 @@ asmcomp/asmgen.cmx : \
     asmcomp/comballoc.cmx \
     asmcomp/coloring.cmx \
     asmcomp/cmmgen.cmx \
+    asmcomp/cmm_invariants.cmx \
     asmcomp/cmm_helpers.cmx \
     asmcomp/cmm.cmx \
     utils/clflags.cmx \
@@ -2225,7 +2229,7 @@ asmcomp/asmlibrarian.cmx : \
     asmcomp/asmlibrarian.cmi
 asmcomp/asmlibrarian.cmi :
 asmcomp/asmlink.cmo : \
-    lambda/runtimedef.cmi \
+    bytecomp/runtimedef.cmo \
     utils/profile.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
@@ -2243,7 +2247,7 @@ asmcomp/asmlink.cmo : \
     asmcomp/asmgen.cmi \
     asmcomp/asmlink.cmi
 asmcomp/asmlink.cmx : \
-    lambda/runtimedef.cmx \
+    bytecomp/runtimedef.cmx \
     utils/profile.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
@@ -2420,6 +2424,16 @@ asmcomp/cmm_helpers.cmi : \
     middle_end/clambda_primitives.cmi \
     middle_end/clambda.cmi \
     parsing/asttypes.cmi
+asmcomp/cmm_invariants.cmo : \
+    utils/numbers.cmi \
+    asmcomp/cmm.cmi \
+    asmcomp/cmm_invariants.cmi
+asmcomp/cmm_invariants.cmx : \
+    utils/numbers.cmx \
+    asmcomp/cmm.cmx \
+    asmcomp/cmm_invariants.cmi
+asmcomp/cmm_invariants.cmi : \
+    asmcomp/cmm.cmi
 asmcomp/cmmgen.cmo : \
     typing/types.cmi \
     middle_end/printclambda_primitives.cmi \
@@ -5777,6 +5791,7 @@ asmcomp/debug/reg_with_debug_info.cmx : \
 asmcomp/debug/reg_with_debug_info.cmi : \
     asmcomp/reg.cmi \
     middle_end/backend_var.cmi
+driver/compdynlink.cmi :
 driver/compenv.cmo : \
     utils/warnings.cmi \
     utils/profile.cmi \
@@ -6111,13 +6126,13 @@ driver/pparse.cmi : \
     parsing/parsetree.cmi
 toplevel/expunge.cmo : \
     bytecomp/symtable.cmi \
-    lambda/runtimedef.cmi \
+    bytecomp/runtimedef.cmo \
     utils/misc.cmi \
     typing/ident.cmi \
     bytecomp/bytesections.cmi
 toplevel/expunge.cmx : \
     bytecomp/symtable.cmx \
-    lambda/runtimedef.cmx \
+    bytecomp/runtimedef.cmx \
     utils/misc.cmx \
     typing/ident.cmx \
     bytecomp/bytesections.cmx
@@ -6327,6 +6342,8 @@ toplevel/trace.cmi : \
     typing/path.cmi \
     parsing/longident.cmi \
     typing/env.cmi
+toplevel/byte/topdirs.cmi : \
+    parsing/longident.cmi
 toplevel/byte/topeval.cmo : \
     utils/warnings.cmi \
     typing/types.cmi \
@@ -6400,11 +6417,20 @@ toplevel/byte/topeval.cmx : \
 toplevel/byte/topeval.cmi : \
     toplevel/topcommon.cmi \
     parsing/parsetree.cmi
+toplevel/byte/toploop.cmi : \
+    utils/warnings.cmi \
+    typing/types.cmi \
+    typing/path.cmi \
+    parsing/parsetree.cmi \
+    typing/outcometree.cmi \
+    parsing/longident.cmi \
+    parsing/location.cmi \
+    typing/env.cmi
 toplevel/byte/topmain.cmo : \
     toplevel/byte/trace.cmi \
-    toplevel/toploop.cmi \
+    toplevel/byte/toploop.cmi \
     toplevel/byte/topeval.cmi \
-    toplevel/topdirs.cmi \
+    toplevel/byte/topdirs.cmi \
     toplevel/topcommon.cmi \
     typing/printtyp.cmi \
     typing/path.cmi \
@@ -6419,9 +6445,9 @@ toplevel/byte/topmain.cmo : \
     toplevel/byte/topmain.cmi
 toplevel/byte/topmain.cmx : \
     toplevel/byte/trace.cmx \
-    toplevel/toploop.cmx \
+    toplevel/byte/toploop.cmi \
     toplevel/byte/topeval.cmx \
-    toplevel/topdirs.cmx \
+    toplevel/byte/topdirs.cmi \
     toplevel/topcommon.cmx \
     typing/printtyp.cmx \
     typing/path.cmx \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         sudo apt-get update -y && sudo apt-get install -y gcc-multilib gfortran-multilib
     - name: configure tree
       run: |
-        XARCH=i386 CONFIG_ARG='--disable-stdlib-manpages --disable-shared' bash -xe tools/ci/actions/runner.sh configure
+        XARCH=i386 CONFIG_ARG='--disable-stdlib-manpages --disable-shared --enable-cmm-invariants' bash -xe tools/ci/actions/runner.sh configure
     - name: Build
       run: |
         bash -xe tools/ci/actions/runner.sh build
@@ -55,7 +55,7 @@ jobs:
         MAKE_ARG=-j make distclean
     - name: configure tree
       run: |
-        MAKE_ARG=-j XARCH=x64 CONFIG_ARG='--enable-flambda --enable-dependency-generation' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure
+        MAKE_ARG=-j XARCH=x64 CONFIG_ARG='--enable-flambda --enable-cmm-invariants --enable-dependency-generation' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure
     - name: Build
       run: |
         MAKE_ARG=-j OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh build

--- a/Changes
+++ b/Changes
@@ -109,7 +109,7 @@ Working version
 
 - #1400: Add an optional invariants check on Cmm, which can be activated
   with the -dcmm-invariants flag
-  (Vincent Laviron)
+  (Vincent Laviron, with help from Sebastien Hinderer, review by Stephen Dolan)
 
 ### Type system:
 

--- a/Changes
+++ b/Changes
@@ -109,7 +109,8 @@ Working version
 
 - #1400: Add an optional invariants check on Cmm, which can be activated
   with the -dcmm-invariants flag
-  (Vincent Laviron, with help from Sebastien Hinderer, review by Stephen Dolan)
+  (Vincent Laviron, with help from Sebastien Hinderer, review by Stephen Dolan
+   and David Allsopp)
 
 ### Type system:
 

--- a/Changes
+++ b/Changes
@@ -107,6 +107,10 @@ Working version
 - #10349: Fix destroyed_at_c_call on RISC-V
   (Mark Shinwell, review by Nicolás Ojeda Bär)
 
+- #1400: Add an optional invariants check on Cmm, which can be activated
+  with the -dcmm-invariants flag
+  (Vincent Laviron)
+
 ### Type system:
 
 * #10081: Typecheck `x |> f` and `f @@ x` as `(f x)`

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -234,6 +234,7 @@ TARGET=@target@
 HOST=@host@
 FLAMBDA=@flambda@
 WITH_FLAMBDA_INVARIANTS=@flambda_invariants@
+WITH_CMM_INVARIANTS=@cmm_invariants@
 FORCE_SAFE_STRING=@force_safe_string@
 DEFAULT_SAFE_STRING=@default_safe_string@
 WINDOWS_UNICODE=@windows_unicode@

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -30,6 +30,16 @@ type error =
 
 exception Error of error
 
+let cmm_invariants ppf fd_cmm =
+  let print_fundecl =
+    if !Clflags.dump_cmm then Printcmm.fundecl
+    else fun ppf fdecl -> Format.fprintf ppf "%s" fdecl.fun_name
+  in
+  if !Clflags.cmm_invariants && Cmm_invariants.run ppf fd_cmm then
+    Misc.fatal_errorf "Cmm invariants failed on following fundecl:@.%a@."
+      print_fundecl fd_cmm;
+  fd_cmm
+
 let liveness phrase = Liveness.fundecl phrase; phrase
 
 let dump_if ppf flag message phrase =
@@ -127,6 +137,7 @@ let compile_fundecl ~ppf_dump fd_cmm =
   Proc.init ();
   Reg.reset();
   fd_cmm
+  ++ Profile.record ~accumulate:true "cmm_invariants" (cmm_invariants ppf_dump)
   ++ Profile.record ~accumulate:true "selection" Selection.fundecl
   ++ pass_dump_if ppf_dump dump_selection "After instruction selection"
   ++ Profile.record ~accumulate:true "comballoc" Comballoc.fundecl

--- a/asmcomp/cmm_invariants.ml
+++ b/asmcomp/cmm_invariants.ml
@@ -1,0 +1,180 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Vincent Laviron, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2017 OCamlPro SAS                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "-40"]
+
+module Int = Numbers.Int
+
+(* Check a number of continuation-related invariants *)
+
+module Env : sig
+  type t
+
+  val init : unit -> t
+
+  val handler : t -> cont:int -> arg_num:int -> t
+
+  val jump : t -> cont:int -> arg_num:int -> unit
+
+  val report : Format.formatter -> bool
+end = struct
+  type t = {
+    bound_handlers : int Int.Map.t;
+  }
+
+  type error =
+    | Unbound_handler of { cont: int }
+    | Multiple_handlers of { cont: int; }
+    | Wrong_arguments_number of
+        { cont: int; handler_args: int; jump_args: int; }
+
+  module Error = struct
+    type t = error
+
+    let compare = Stdlib.compare
+  end
+
+  module ErrorSet = Set.Make(Error)
+
+  type persistent_state = {
+    mutable all_handlers : Int.Set.t;
+    mutable errors : ErrorSet.t;
+  }
+
+  let state = {
+    all_handlers = Int.Set.empty;
+    errors = ErrorSet.empty;
+  }
+
+  let record_error error =
+    state.errors <- ErrorSet.add error state.errors
+
+  let unbound_handler cont =
+    record_error (Unbound_handler { cont; })
+
+  let multiple_handler cont =
+    record_error (Multiple_handlers { cont; })
+
+  let wrong_arguments cont handler_args jump_args =
+    record_error (Wrong_arguments_number { cont; handler_args; jump_args; })
+
+  let init () =
+    state.all_handlers <- Int.Set.empty;
+    state.errors <- ErrorSet.empty;
+    {
+      bound_handlers = Int.Map.empty;
+    }
+
+  let handler t ~cont ~arg_num =
+    if Int.Set.mem cont state.all_handlers then multiple_handler cont;
+    state.all_handlers <- Int.Set.add cont state.all_handlers;
+    let bound_handlers = Int.Map.add cont arg_num t.bound_handlers in
+    { bound_handlers; }
+
+  let jump t ~cont ~arg_num =
+    match Int.Map.find cont t.bound_handlers with
+    | handler_args ->
+      if arg_num <> handler_args then
+        wrong_arguments cont handler_args arg_num
+    | exception Not_found -> unbound_handler cont
+
+  let print_error ppf error =
+    match error with
+    | Unbound_handler { cont } ->
+      if Int.Set.mem cont state.all_handlers then
+        Format.fprintf ppf
+          "Continuation %d was used outside the scope of its handler"
+          cont
+      else
+        Format.fprintf ppf
+          "Continuation %d was used but never bound"
+          cont
+    | Multiple_handlers { cont; } ->
+      Format.fprintf ppf
+        "Continuation %d was declared in more than one handler"
+        cont
+    | Wrong_arguments_number { cont; handler_args; jump_args } ->
+      Format.fprintf ppf
+        "Continuation %d was declared with %d arguments but called with %d"
+        cont
+        handler_args
+        jump_args
+
+  let print_error_newline ppf error =
+    Format.fprintf ppf "%a@." print_error error
+
+  let report ppf =
+    if ErrorSet.is_empty state.errors then false
+    else begin
+      ErrorSet.iter (fun err -> print_error_newline ppf err) state.errors;
+      true
+    end
+end
+
+let rec check env (expr : Cmm.expression) =
+  match expr with
+  | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _
+  | Cvar _ ->
+    ()
+  | Clet (_, expr, body)
+  | Clet_mut (_, _, expr, body) ->
+    check env expr;
+    check env body
+  | Cphantom_let (_, _, expr) ->
+    check env expr
+  | Cassign (_, expr) ->
+    check env expr
+  | Ctuple exprs ->
+    List.iter (check env) exprs
+  | Cop (_, args, _) ->
+    List.iter (check env) args;
+  | Csequence (expr1, expr2) ->
+    check env expr1;
+    check env expr2
+  | Cifthenelse (test, _, ifso, _, ifnot, _) ->
+    check env test;
+    check env ifso;
+    check env ifnot
+  | Cswitch (body, _, branches, _) ->
+    check env body;
+    Array.iter (fun (expr, _) -> check env expr) branches
+  | Ccatch (rec_flag, handlers, body) ->
+    let env_extended =
+      List.fold_left
+        (fun env (cont, args, _, _) ->
+           Env.handler env ~cont ~arg_num:(List.length args))
+        env
+        handlers
+    in
+    check env_extended body;
+    let env_handler =
+      match rec_flag with
+      | Recursive -> env_extended
+      | Nonrecursive -> env
+    in
+    List.iter (fun (_, _, handler, _) -> check env_handler handler) handlers
+  | Cexit (cont, args) ->
+    Env.jump env ~cont ~arg_num:(List.length args)
+  | Ctrywith (body, _, handler, _) ->
+    (* Jumping from inside a trywith body to outside isn't very nice,
+       but it's handled correctly by Linearize, as it happens
+       when compiling match ... with exception ..., for instance, so it is
+       not reported as an error. *)
+    check env body;
+    check env handler
+
+let run ppf (fundecl : Cmm.fundecl) =
+  let env = Env.init () in
+  check env fundecl.fun_body;
+  Env.report ppf

--- a/asmcomp/cmm_invariants.mli
+++ b/asmcomp/cmm_invariants.mli
@@ -1,0 +1,36 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Vincent Laviron, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2017 OCamlPro SAS                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Check a number of continuation-related invariants *)
+
+(* Currently, this checks that :
+   - Every use of a continuation occurs within the scope of its handler
+   - Exit instructions take the same number of arguments as their handler.
+   - In every function declaration, a given continuation can only be
+   declared in a single handler.
+
+   This is intended to document what invariants the backend can rely upon.
+   The first two would trigger errors later, and the last one, while
+   harmless for now, is not that hard to ensure, could be useful for
+   future work on the backend, and helped detect a code duplication bug.
+
+   These invariants are not checked by default, but the check can be turned
+   on with the -dcmm-invariants compilation flag.
+*)
+
+(** [run ppf fundecl] analyses the given function, and returns whether
+    any errors were encountered (with corresponding error messages printed
+    on the given formatter). *)
+
+val run : Format.formatter -> Cmm.fundecl -> bool

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -136,6 +136,7 @@ ASMCOMP=\
   asmcomp/cmmgen_state.cmo \
   asmcomp/cmm_helpers.cmo \
   asmcomp/cmmgen.cmo \
+  asmcomp/cmm_invariants.cmo \
   asmcomp/interval.cmo \
   asmcomp/printmach.cmo asmcomp/selectgen.cmo \
   asmcomp/selection.cmo \

--- a/configure
+++ b/configure
@@ -759,6 +759,7 @@ afl
 function_sections
 flat_float_array
 windows_unicode
+cmm_invariants
 flambda_invariants
 flambda
 frame_pointers
@@ -900,6 +901,7 @@ enable_installing_bytecode_programs
 enable_native_compiler
 enable_flambda
 enable_flambda_invariants
+enable_cmm_invariants
 with_target_bindir
 enable_reserved_header_bits
 enable_stdlib_manpages
@@ -1575,6 +1577,7 @@ Optional Features:
   --enable-flambda        enable flambda optimizations
   --enable-flambda-invariants
                           enable invariants checks in flambda
+  --enable-cmm-invariants enable invariants checks in Cmm
   --enable-reserved-header-bits=BITS
                           reserve BITS (between 0 and 31) bits in block
                           headers for profiling info
@@ -2932,6 +2935,7 @@ VERSION=4.13.0+dev0-2020-10-19
 
 
 
+
 ## Generated files
 
 ac_config_files="$ac_config_files Makefile.build_config"
@@ -3235,6 +3239,12 @@ fi
 # Check whether --enable-flambda-invariants was given.
 if test "${enable_flambda_invariants+set}" = set; then :
   enableval=$enable_flambda_invariants;
+fi
+
+
+# Check whether --enable-cmm-invariants was given.
+if test "${enable_cmm_invariants+set}" = set; then :
+  enableval=$enable_cmm_invariants;
 fi
 
 
@@ -17108,6 +17118,12 @@ fi
 else
   flambda=false
   flambda_invariants=false
+fi
+
+if test x"$enable_cmm_invariants" = "xyes"; then :
+  cmm_invariants=true
+else
+  cmm_invariants=false
 fi
 
 if test x"$enable_flat_float_array" = "xno"; then :

--- a/configure.ac
+++ b/configure.ac
@@ -156,6 +156,7 @@ AC_SUBST([profinfo_width])
 AC_SUBST([frame_pointers])
 AC_SUBST([flambda])
 AC_SUBST([flambda_invariants])
+AC_SUBST([cmm_invariants])
 AC_SUBST([windows_unicode])
 AC_SUBST([flat_float_array])
 AC_SUBST([function_sections])
@@ -315,6 +316,10 @@ AC_ARG_ENABLE([flambda],
 AC_ARG_ENABLE([flambda-invariants],
   [AS_HELP_STRING([--enable-flambda-invariants],
     [enable invariants checks in flambda])])
+
+AC_ARG_ENABLE([cmm-invariants],
+  [AS_HELP_STRING([--enable-cmm-invariants],
+    [enable invariants checks in Cmm])])
 
 AC_ARG_WITH([target-bindir],
   [AS_HELP_STRING([--with-target-bindir],
@@ -1774,6 +1779,10 @@ AS_IF([test x"$enable_flambda" = "xyes"],
     [flambda_invariants=false])],
   [flambda=false
   flambda_invariants=false])
+
+AS_IF([test x"$enable_cmm_invariants" = "xyes"],
+  [cmm_invariants=true],
+  [cmm_invariants=false])
 
 AS_IF([test x"$enable_flat_float_array" = "xno"],
   [flat_float_array=false],

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -371,6 +371,8 @@ let read_one_param ppf position name v =
       set "flambda-verbose" [ dump_flambda_verbose ] v
   | "flambda-invariants" ->
       set "flambda-invariants" [ flambda_invariant_checks ] v
+  | "cmm-invariants" ->
+      set "cmm-invariants" [ cmm_invariants ] v
   | "linscan" ->
       set "linscan" [ use_linscan ] v
   | "insn-sched" -> set "insn-sched" [ insn_sched ] v

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -779,6 +779,10 @@ let mk_dcamlprimc f =
   "-dcamlprimc", Arg.Unit f, " (undocumented)"
 ;;
 
+let mk_dcmm_invariants f =
+  "-dcmm-invariants", Arg.Unit f, " Extra sanity checks on Cmm"
+;;
+
 let mk_dcmm f =
   "-dcmm", Arg.Unit f, " (undocumented)"
 ;;
@@ -1087,6 +1091,7 @@ module type Optcommon_options = sig
   val _dflambda_verbose : unit -> unit
   val _drawclambda : unit -> unit
   val _dclambda : unit -> unit
+  val _dcmm_invariants : unit -> unit
   val _dcmm : unit -> unit
   val _dsel : unit -> unit
   val _dcombine : unit -> unit
@@ -1445,6 +1450,7 @@ struct
     mk_dlambda F._dlambda;
     mk_drawclambda F._drawclambda;
     mk_dclambda F._dclambda;
+    mk_dcmm_invariants F._dcmm_invariants;
     mk_dflambda F._dflambda;
     mk_drawflambda F._drawflambda;
     mk_dflambda_invariants F._dflambda_invariants;
@@ -1555,6 +1561,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_drawlambda F._drawlambda;
     mk_drawclambda F._drawclambda;
     mk_dclambda F._dclambda;
+    mk_dcmm_invariants F._dcmm_invariants;
     mk_drawflambda F._drawflambda;
     mk_dflambda F._dflambda;
     mk_dcmm F._dcmm;
@@ -1739,6 +1746,7 @@ module Default = struct
     let _davail () = dump_avail := true
     let _dclambda = set dump_clambda
     let _dcmm = set dump_cmm
+    let _dcmm_invariants = set cmm_invariants
     let _dcombine = set dump_combine
     let _dcse = set dump_cse
     let _dflambda = set dump_flambda

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -203,6 +203,7 @@ module type Optcommon_options = sig
   val _dflambda_verbose : unit -> unit
   val _drawclambda : unit -> unit
   val _dclambda : unit -> unit
+  val _dcmm_invariants : unit -> unit
   val _dcmm : unit -> unit
   val _dsel : unit -> unit
   val _dcombine : unit -> unit

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -270,6 +270,7 @@ let _ =
     arch64;
     has_symlink;
     setup_build_env;
+    setup_simple_build_env;
     run;
     script;
     check_program_output;

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -703,7 +703,10 @@ let run_codegen log env =
     flags env;
     "-S " ^ testfile
   ] in
-  let expected_exit_status = 0 in
+  let expected_exit_status =
+    Actions_helpers.exit_status_of_variable env
+      Ocaml_variables.codegen_exit_status
+  in
   let exit_status =
     Actions_helpers.run_cmd
       ~environment:default_ocaml_env
@@ -713,12 +716,15 @@ let run_codegen log env =
       log env commandline in
   if exit_status=expected_exit_status
   then begin
-    let finalise =
-       if Ocamltest_config.ccomptype="msvc"
-      then finalise_codegen_msvc
-      else finalise_codegen_cc
-    in
-    finalise testfile_basename log env
+    if exit_status=0
+    then begin
+      let finalise =
+        if Ocamltest_config.ccomptype="msvc"
+        then finalise_codegen_msvc
+        else finalise_codegen_cc
+      in
+      finalise testfile_basename log env
+    end else (Result.pass, env)
   end else begin
     let reason =
       (Actions_helpers.mkreason

--- a/ocamltest/ocaml_variables.ml
+++ b/ocamltest/ocaml_variables.ml
@@ -62,6 +62,9 @@ let caml_ld_library_path =
     ("ld_library_path",
       "List of paths to lookup for loading dynamic libraries")
 
+let codegen_exit_status = make ("codegen_exit_status",
+  "Expected exit status of codegen")
+
 let compare_programs = make ("compare_programs",
   "Set to \"false\" to disable program comparison")
 
@@ -240,6 +243,7 @@ let _ = List.iter register_variable
     bytecc_libs;
     c_preprocessor;
     caml_ld_library_path;
+    codegen_exit_status;
     compare_programs;
     compiler_directory_suffix;
     compiler_reference;

--- a/ocamltest/ocaml_variables.mli
+++ b/ocamltest/ocaml_variables.mli
@@ -32,6 +32,8 @@ val cc : Variables.t
 
 val caml_ld_library_path : Variables.t
 
+val codegen_exit_status : Variables.t
+
 val compare_programs : Variables.t
 
 val compiler_directory_suffix : Variables.t

--- a/testsuite/tests/asmgen/invariants.cmm
+++ b/testsuite/tests/asmgen/invariants.cmm
@@ -1,6 +1,7 @@
 (* TEST
-* codegen
-codegen_expected_exit_status = "2"
+* setup-simple-build-env
+** codegen
+codegen_exit_status = "2"
 *)
 
 (*

--- a/testsuite/tests/asmgen/invariants.cmm
+++ b/testsuite/tests/asmgen/invariants.cmm
@@ -1,0 +1,23 @@
+(* TEST
+* cmm-invariants
+** codegen
+codegen_expected_exit_status = "2"
+*)
+
+(*
+This test is here to ensure that the Cmm invariant checks
+correctly catch broken Cmm programs.
+*)
+
+(function "bad_continuations" (x:int)
+  (* Bad arity *)
+  (catch
+    (exit cont 0)
+   with (cont) 1)
+  (* Multiple handler definition *)
+  (catch
+    (exit cont 0)
+   with (cont y:int) y)
+  (* Exit out of scope of its handler *)
+  (exit cont 0)
+)

--- a/testsuite/tests/asmgen/invariants.cmm
+++ b/testsuite/tests/asmgen/invariants.cmm
@@ -1,6 +1,5 @@
 (* TEST
-* cmm-invariants
-** codegen
+* codegen
 codegen_expected_exit_status = "2"
 *)
 

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -22,6 +22,7 @@ let compile_file filename =
     Emitaux.output_channel := open_out out_name
   end; (* otherwise, stdout *)
   Compilenv.reset "test";
+  Clflags.cmm_invariants := true;
   Emit.begin_assembly();
   let ic = open_in filename in
   let lb = Lexing.from_channel ic in

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -58,6 +58,7 @@ config.ml: config.mlp $(ROOTDIR)/Makefile.config Makefile
 	    $(call SUBST_STRING,EXT_OBJ) \
 	    $(call SUBST,FLAMBDA) \
 	    $(call SUBST,WITH_FLAMBDA_INVARIANTS) \
+	    $(call SUBST,WITH_CMM_INVARIANTS) \
 	    $(call SUBST_STRING,FLEXLINK_FLAGS) \
 	    $(call SUBST_QUOTE,FLEXDLL_DIR) \
 	    $(call SUBST,HOST) \

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -139,6 +139,7 @@ let native_code = ref false             (* set to true under ocamlopt *)
 
 let force_slash = ref false             (* for ocamldep *)
 let clambda_checks = ref false          (* -clambda-checks *)
+let cmm_invariants = ref false          (* -dcmm-invariants *)
 
 let flambda_invariant_checks =
   ref Config.with_flambda_invariants    (* -flambda-(no-)invariants *)

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -139,7 +139,8 @@ let native_code = ref false             (* set to true under ocamlopt *)
 
 let force_slash = ref false             (* for ocamldep *)
 let clambda_checks = ref false          (* -clambda-checks *)
-let cmm_invariants = ref false          (* -dcmm-invariants *)
+let cmm_invariants =
+  ref Config.with_cmm_invariants        (* -dcmm-invariants *)
 
 let flambda_invariant_checks =
   ref Config.with_flambda_invariants    (* -flambda-(no-)invariants *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -201,6 +201,7 @@ val default_unbox_closures_factor : int
 val unbox_free_vars_of_closures : bool ref
 val unbox_specialised_args : bool ref
 val clambda_checks : bool ref
+val cmm_invariants : bool ref
 val default_inline_max_depth : int
 val inline_max_depth : Int_arg_helper.parsed ref
 val remove_unused_arguments : bool ref

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -211,6 +211,9 @@ val flambda : bool
 val with_flambda_invariants : bool
 (** Whether the invariants checks for flambda are enabled *)
 
+val with_cmm_invariants : bool
+(** Whether the invariants checks for Cmm are enabled *)
+
 val profinfo : bool
 (** Whether the compiler was configured for profiling *)
 

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -79,6 +79,7 @@ let mkdll, mkexe, mkmaindll =
 
 let flambda = %%FLAMBDA%%
 let with_flambda_invariants = %%WITH_FLAMBDA_INVARIANTS%%
+let with_cmm_invariants = %%WITH_CMM_INVARIANTS%%
 let safe_string = %%FORCE_SAFE_STRING%%
 let default_safe_string = %%DEFAULT_SAFE_STRING%%
 let windows_unicode = %%WINDOWS_UNICODE%% != 0


### PR DESCRIPTION
This pull request adds an optional sanity check on the Cmm intermediate representation.

The main feature is that this check does not allow two Ccatch handlers (nested or not) to bind the same continuation in the same Cmm.fundecl structure. The first commit patches Closure to generate new continuations in places where it may duplicate code, which removes the main source of duplicate continuations.

The motivation for this additional check is not only that it is easier to reason about code when continuation identifiers are unique, but also that current work on flambda requires some changes to the backend, which are simpler if we can rely on this invariant.

The checks are disabled by default and can be activated with the `-dcmm-invariants` compilation flag, but as long as #1370 is merged I wouldn't mind reversing the default or making it non-optional.