### PR TITLE
Avoid killing the register allocator with the initialization functions in flambda

### DIFF
--- a/Changes
+++ b/Changes
@@ -96,6 +96,11 @@ Working version
   (Vincent Laviron, with help from Pierre Chambart,
    reviews by Gabriel Scherer and Luc Maranget)
 
+- MPR#7630 GPR#1401: Faster compilation of large modules with Flambda.
+  (Pierre Chambart, report by Emilio Jesús Gallego Arias,
+  Pierre-Marie Pédrot and Paul Steckler, review by Gabriel Scherer
+  and Leo White)
+
 - GPR#1486: ARM 32-bit port: add support for ARMv8 in 32-bit mode,
   a.k.a. AArch32.
   For this platform, avoid ITE conditional instruction blocks and use

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -230,7 +230,7 @@ let lambda_gen_implementation ?toplevel ppf
       symbol = Compilenv.make_symbol None;
       exported = true;
       tag = 0;
-      size = lambda.main_module_block_size;
+      fields = List.init lambda.main_module_block_size (fun _ -> None);
     }
   in
   let clambda_and_constants =

--- a/asmcomp/clambda.ml
+++ b/asmcomp/clambda.ml
@@ -95,11 +95,15 @@ type value_approximation =
 
 (* Preallocated globals *)
 
+type uconstant_block_field =
+  | Uconst_field_ref of string
+  | Uconst_field_int of int
+
 type preallocated_block = {
   symbol : string;
   exported : bool;
   tag : int;
-  size : int;
+  fields : uconstant_block_field option list;
 }
 
 type preallocated_constant = {

--- a/asmcomp/clambda.mli
+++ b/asmcomp/clambda.mli
@@ -100,11 +100,15 @@ val compare_structured_constants:
 val compare_constants:
         uconstant -> uconstant -> int
 
+type uconstant_block_field =
+  | Uconst_field_ref of string
+  | Uconst_field_int of int
+
 type preallocated_block = {
   symbol : string;
   exported : bool;
   tag : int;
-  size : int;
+  fields : uconstant_block_field option list;
 }
 
 type preallocated_constant = {

--- a/middle_end/initialize_symbol_to_let_symbol.mli
+++ b/middle_end/initialize_symbol_to_let_symbol.mli
@@ -16,6 +16,10 @@
 
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
+val constant_field
+   : Flambda.t
+  -> Flambda.constant_defining_value_block_field option
+
 (** Transform Initialize_symbol with only constant fields to
     let_symbol construction. *)
 val run : Flambda.program -> Flambda.program


### PR DESCRIPTION
With flambda, large modules can generate large problems, for the register allocator, where every register is in conflict with every other one. The initialization code is a long sequence of independent assignments from one symbol field to one another. This does not generates any conflict in this form, but the problems appear when CSE shares the various symbol address loading.

This PR propose to sidestep the problem by seriously reducing the size of that code sequence. Usually, in a module, most of the fields are constants (mainly closures). Hence these fields do not requires to be initialized, but can be set to the right value from the beginning. In the stdlib for instance there are never more than 9 fields per module that needs to be initialized.

That should also reduce a bit the code size, but I didn't measure it.

(related mantis PR: https://caml.inria.fr/mantis/view.php?id=7630)