### PR TITLE
Fix missing clean rule in testsuite

### DIFF
--- a/testsuite/tests/afl-instrumentation/Makefile
+++ b/testsuite/tests/afl-instrumentation/Makefile
@@ -12,4 +12,7 @@ default:
 	  fi \
 	fi
 
+.PHONY: clean
+clean:
+
 include $(BASEDIR)/makefiles/Makefile.common


### PR DESCRIPTION
Since `makefiles/Makefile.common` only defines a `defaultclean` rule and no `clean` rules, the Makefile of the afl-instrumentation test was missing a clean rule.