### PR TITLE
caml_sys_isatty: detect Cygwin/MSYS for better -color heuristic

### DIFF
--- a/Changes
+++ b/Changes
@@ -20,6 +20,11 @@ Working version
 
 ### Other libraries:
 
+* GPR#1406: Unix.isatty now returns true in the native Windows ports when the
+  passed a file descriptor connected to Cygwin's terminal. In particular,
+  compiler colors for the native Windows ports now work under Cygwin.
+  (Nicolas Ojeda Bar, review by Gabriel Scherer)
+
 ### Compiler user-interface and warnings:
 
 - GPR#1166: In OCAMLPARAM, an alternative separator can be specified as

--- a/Changes
+++ b/Changes
@@ -23,7 +23,7 @@ Working version
 * GPR#1406: Unix.isatty now returns true in the native Windows ports when the
   passed a file descriptor connected to Cygwin's terminal. In particular,
   compiler colors for the native Windows ports now work under Cygwin.
-  (Nicolas Ojeda Bar, review by Gabriel Scherer)
+  (Nicolas Ojeda Bar, review by Gabriel Scherer and Xavier Leroy)
 
 ### Compiler user-interface and warnings:
 

--- a/Changes
+++ b/Changes
@@ -20,7 +20,7 @@ Working version
 
 ### Other libraries:
 
-* GPR#1406: Unix.isatty now returns true in the native Windows ports when the
+* GPR#1406: Unix.isatty now returns true in the native Windows ports when
   passed a file descriptor connected to a Cygwin PTY. In particular, compiler
   colors for the native Windows ports now work under Cygwin/MSYS2.
   (Nicolas Ojeda Bar, review by Gabriel Scherer, David Allsopp, Xavier Leroy)

--- a/Changes
+++ b/Changes
@@ -21,8 +21,8 @@ Working version
 ### Other libraries:
 
 * GPR#1406: Unix.isatty now returns true in the native Windows ports when the
-  passed a file descriptor connected to Cygwin's terminal. In particular,
-  compiler colors for the native Windows ports now work under Cygwin.
+  passed a file descriptor connected to a Cygwin PTY. In particular, compiler
+  colors for the native Windows ports now work under Cygwin/MSYS2.
   (Nicolas Ojeda Bar, review by Gabriel Scherer and Xavier Leroy)
 
 ### Compiler user-interface and warnings:

--- a/Changes
+++ b/Changes
@@ -23,7 +23,7 @@ Working version
 * GPR#1406: Unix.isatty now returns true in the native Windows ports when the
   passed a file descriptor connected to a Cygwin PTY. In particular, compiler
   colors for the native Windows ports now work under Cygwin/MSYS2.
-  (Nicolas Ojeda Bar, review by Gabriel Scherer and Xavier Leroy)
+  (Nicolas Ojeda Bar, review by Gabriel Scherer, David Allsopp, Xavier Leroy)
 
 ### Compiler user-interface and warnings:
 

--- a/byterun/caml/osdeps.h
+++ b/byterun/caml/osdeps.h
@@ -136,7 +136,7 @@ extern char* caml_stat_strdup_of_utf16(const wchar_t *s);
 */
 extern value caml_copy_string_of_utf16(const wchar_t *s);
 
-extern int caml_win32_detect_msys_tty(int fd);
+extern int caml_win32_isatty(int fd);
 
 #endif /* _WIN32 */
 

--- a/byterun/caml/osdeps.h
+++ b/byterun/caml/osdeps.h
@@ -136,6 +136,8 @@ extern char* caml_stat_strdup_of_utf16(const wchar_t *s);
 */
 extern value caml_copy_string_of_utf16(const wchar_t *s);
 
+extern int caml_win32_detect_msys_tty(int fd);
+
 #endif /* _WIN32 */
 
 #endif /* CAML_INTERNALS */

--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -27,7 +27,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #ifdef _WIN32
-#include <io.h> /* for isatty */
 #include <direct.h> /* for _wchdir and _wgetcwd */
 #else
 #include <sys/wait.h>
@@ -619,7 +618,7 @@ CAMLprim value caml_sys_isatty(value chan)
 
   fd = (Channel(chan))->fd;
 #ifdef _WIN32
-  ret = Val_bool(_isatty(fd) || caml_win32_detect_msys_tty(fd));
+  ret = Val_bool(caml_win32_isatty(fd));
         /* https://msdn.microsoft.com/en-us/library/f4s0ddew.aspx */
 #else
   ret = Val_bool(isatty(fd));

--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -619,7 +619,7 @@ CAMLprim value caml_sys_isatty(value chan)
 
   fd = (Channel(chan))->fd;
 #ifdef _WIN32
-  ret = Val_bool(_isatty(fd));
+  ret = Val_bool(_isatty(fd) || caml_win32_detect_msys_tty(fd));
         /* https://msdn.microsoft.com/en-us/library/f4s0ddew.aspx */
 #else
   ret = Val_bool(isatty(fd));

--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -619,7 +619,6 @@ CAMLprim value caml_sys_isatty(value chan)
   fd = (Channel(chan))->fd;
 #ifdef _WIN32
   ret = Val_bool(caml_win32_isatty(fd));
-        /* https://msdn.microsoft.com/en-us/library/f4s0ddew.aspx */
 #else
   ret = Val_bool(isatty(fd));
 #endif

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -942,7 +942,8 @@ static int caml_win32_is_cygwin_pty(HANDLE hFile)
   if (pGetFileInformationByHandleEx == NULL)
     return 0;
 
-  /* get pipe name */
+  /* Get pipe name. GetFileInformationByHandleEx does not NULL-terminate the string, so reduce
+     the buffer size to allow for adding one. */
   if (! pGetFileInformationByHandleEx(hFile, FileNameInfo, buffer, sizeof(buffer) - sizeof(WCHAR)))
     return 0;
 

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -933,13 +933,13 @@ CAMLexport int caml_win32_detect_msys_tty(int fd)
   if (! GetFileInformationByHandleEx(h, FileNameInfo, buffer, sizeof(buffer) - sizeof(WCHAR)))
     return 0;
 
-  nameinfo->FileName[nameinfo->FileNameLength / sizeof(WCHAR)] = 0;
+  nameinfo->FileName[nameinfo->FileNameLength / sizeof(WCHAR)] = L'\0';
 
   /* check if this could be a msys pty pipe ('msys-XXXX-ptyN-XX')
      or a cygwin pty pipe ('cygwin-XXXX-ptyN-XX') */
-  if ((!wcsstr(nameinfo->FileName, L"msys-") &&
-       !wcsstr(nameinfo->FileName, L"cygwin-")) || !wcsstr(nameinfo->FileName, L"-pty"))
-    return 0;
+  if ((wcsstr(nameinfo->FileName, L"msys-") ||
+       wcsstr(nameinfo->FileName, L"cygwin-")) && wcsstr(nameinfo->FileName, L"-pty"))
+    return 1;
 
-  return 1;
+  return 0;
 }

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -968,7 +968,12 @@ CAMLexport int caml_win32_isatty(int fd)
 {
   DWORD lpMode;
   HANDLE hFile = (HANDLE)_get_osfhandle(fd);
-  return (hFile != INVALID_HANDLE_VALUE &&
-          GetFileType(hFile) == FILE_TYPE_CHAR &&
-          GetConsoleMode(hFile, &lpMode)) || caml_win32_ismsystty(hFile);
+
+  if (hFile == INVALID_HANDLE_VALUE)
+    return 0;
+
+  if (GetFileType(hFile) == FILE_TYPE_CHAR && GetConsoleMode(hFile, &lpMode))
+    return 1;
+
+  return caml_win32_ismsystty(hFile);
 }

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -931,9 +931,9 @@ static int caml_win32_is_cygwin_pty(HANDLE hFile)
 {
   char buffer[1024];
   FILE_NAME_INFO * nameinfo = (FILE_NAME_INFO *) buffer;
-  static tGetFileInformationByHandleEx pGetFileInformationByHandleEx = NULL;
+  static tGetFileInformationByHandleEx pGetFileInformationByHandleEx = INVALID_HANDLE_VALUE;
 
-  if (pGetFileInformationByHandleEx == NULL)
+  if (pGetFileInformationByHandleEx == INVALID_HANDLE_VALUE)
     pGetFileInformationByHandleEx =
       (tGetFileInformationByHandleEx)GetProcAddress(GetModuleHandle(L"KERNEL32.DLL"),
                                                     "GetFileInformationByHandleEx");

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -921,7 +921,6 @@ void caml_restore_win32_terminal(void)
 }
 
 /* Detect if a named pipe corresponds to a Cygwin/MSYS pty: see
-
    https://github.com/mirror/newlib-cygwin/blob/00e9bf2/winsup/cygwin/dtable.cc#L932
 */
 typedef

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -931,7 +931,7 @@ BOOL (WINAPI *tGetFileInformationByHandleEx)(
   DWORD                     dwBufferSize
 );
 
-static int caml_win32_ismsystty(int fd)
+static int caml_win32_ismsystty(HANDLE hFile)
 {
   char buffer[1024];
   FILE_NAME_INFO * nameinfo = (FILE_NAME_INFO *) buffer;
@@ -939,8 +939,7 @@ static int caml_win32_ismsystty(int fd)
   tGetFileInformationByHandleEx pGetFileInformationByHandleEx;
 
   /* check if fd is a pipe */
-  HANDLE h = (HANDLE) _get_osfhandle(fd);
-  if (GetFileType(h) != FILE_TYPE_PIPE)
+  if (GetFileType(hFile) != FILE_TYPE_PIPE)
     return 0;
 
   hModKernel32 = GetModuleHandle(L"KERNEL32.DLL");
@@ -951,7 +950,7 @@ static int caml_win32_ismsystty(int fd)
     return 0;
 
   /* get pipe name */
-  if (! pGetFileInformationByHandleEx(h, FileNameInfo, buffer, sizeof(buffer) - sizeof(WCHAR)))
+  if (! pGetFileInformationByHandleEx(hFile, FileNameInfo, buffer, sizeof(buffer) - sizeof(WCHAR)))
     return 0;
 
   nameinfo->FileName[nameinfo->FileNameLength / sizeof(WCHAR)] = L'\0';
@@ -971,5 +970,5 @@ CAMLexport int caml_win32_isatty(int fd)
   HANDLE hFile = (HANDLE)_get_osfhandle(fd);
   return (hFile != INVALID_HANDLE_VALUE &&
           GetFileType(hFile) == FILE_TYPE_CHAR &&
-          GetConsoleMode(hFile, &lpMode)) || caml_win32_ismsystty(fd);
+          GetConsoleMode(hFile, &lpMode)) || caml_win32_ismsystty(hFile);
 }

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -967,5 +967,9 @@ static int caml_win32_ismsystty(int fd)
 
 CAMLexport int caml_win32_isatty(int fd)
 {
-  return _isatty(fd) || caml_win32_ismsystty(fd);
+  DWORD lpMode;
+  HANDLE hFile = (HANDLE)_get_osfhandle(fd);
+  return (hFile != INVALID_HANDLE_VALUE &&
+          GetFileType(hFile) == FILE_TYPE_CHAR &&
+          GetConsoleMode(hFile, &lpMode)) || caml_win32_ismsystty(fd);
 }

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -919,7 +919,7 @@ void caml_restore_win32_terminal(void)
 
    https://github.com/mirror/newlib-cygwin/blob/master/winsup/cygwin/dtable.cc#L932
 */
-CAMLexport int caml_win32_detect_msys_tty(int fd)
+static int caml_win32_ismsystty(int fd)
 {
   char buffer[1024];
   FILE_NAME_INFO * nameinfo = (FILE_NAME_INFO *) buffer;
@@ -942,4 +942,9 @@ CAMLexport int caml_win32_detect_msys_tty(int fd)
     return 1;
 
   return 0;
+}
+
+CAMLexport int caml_win32_isatty(int fd)
+{
+  return _isatty(fd) || caml_win32_ismsystty(fd);
 }

--- a/otherlibs/win32unix/isatty.c
+++ b/otherlibs/win32unix/isatty.c
@@ -12,13 +12,12 @@
 /*                                                                        */
 /**************************************************************************/
 
+#define CAML_INTERNALS
+
 #include <caml/mlvalues.h>
-#include "unixsupport.h"
+#include <caml/osdeps.h>
 
 CAMLprim value unix_isatty(value fd)
 {
-  DWORD lpMode;
-  HANDLE hFile = Handle_val(fd);
-  return (Val_bool((GetFileType(hFile) == FILE_TYPE_CHAR)
-                   && GetConsoleMode(hFile, &lpMode)));
+  return Val_bool(caml_win32_isatty(Int_val(fd)));
 }

--- a/otherlibs/win32unix/isatty.c
+++ b/otherlibs/win32unix/isatty.c
@@ -16,8 +16,9 @@
 
 #include <caml/mlvalues.h>
 #include <caml/osdeps.h>
+#include "unixsupport.h"
 
 CAMLprim value unix_isatty(value fd)
 {
-  return Val_bool(caml_win32_isatty(Int_val(fd)));
+  return Val_bool(caml_win32_isatty(win_CRT_fd_of_filedescr(fd)));
 }


### PR DESCRIPTION
This PR improves the heuristic used to decide whether to use colors for warnings & errors by detecting the case when the native Windows port of OCaml is being used under Cygwin (which I would guess is fairly common).

@dra27 will know if we need to add some `#ifdef` to deal with the case of Windows XP and other strange creatures that may have trouble with `GetFileInformationByHandleEx`.

Of course, feel free to ignore this PR until after 4.06!