### PR TITLE
Windows Console Unicode Support

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,6 +36,9 @@ be mentioned in the 4.06 section below instead of here.)
 
 ### Runtime system:
 
+* MPR#6925, GPR#1408: fix UTF-8 related crashes in Windows Console.
+  (David Allsopp, review by Gabriel Scherer)
+
 ### Tools:
 
 - MPR#7643, GPR#1377: ocamldep, fix an exponential blowup in presence of nested

--- a/byterun/caml/io.h
+++ b/byterun/caml/io.h
@@ -58,6 +58,7 @@ enum {
   CHANNEL_FLAG_BLOCKING_WRITE = 2, /* Don't release master lock when writing */
 #endif
   CHANNEL_FLAG_MANAGED_BY_GC = 4,  /* Free and close using GC finalization */
+  CHANNEL_FLAG_CONSOLE = 8,        /* Underlying handle is a Win32 Console */
 };
 
 /* For an output channel:

--- a/byterun/caml/osdeps.h
+++ b/byterun/caml/osdeps.h
@@ -98,6 +98,8 @@ extern char_os * caml_executable_name(void);
 */
 extern char_os *caml_secure_getenv(char_os const *var);
 
+extern int caml_channel_flags(int fd);
+
 #ifdef _WIN32
 
 extern int caml_win32_rename(const wchar_t *, const wchar_t *);

--- a/byterun/io.c
+++ b/byterun/io.c
@@ -78,7 +78,7 @@ CAMLexport struct channel * caml_open_descriptor_in(int fd)
   channel->revealed = 0;
   channel->old_revealed = 0;
   channel->refcount = 0;
-  channel->flags = 0;
+  channel->flags = caml_channel_flags(fd);
   channel->next = caml_all_opened_channels;
   channel->prev = NULL;
   channel->name = NULL;

--- a/byterun/io.c
+++ b/byterun/io.c
@@ -349,6 +349,14 @@ CAMLexport intnat caml_input_scan_line(struct channel *channel)
 {
   char * p;
   int n;
+  int min_buffer = 0;
+
+  /* For a Windows Console, caml_fd_read will fail for a request of fewer than
+     4 bytes. */
+#ifdef _WIN32
+  if (channel->flags & CHANNEL_FLAG_CONSOLE)
+    min_buffer = 3;
+#endif
 
   p = channel->curr;
   do {
@@ -363,7 +371,7 @@ CAMLexport intnat caml_input_scan_line(struct channel *channel)
         channel->max -= n;
         p -= n;
       }
-      if (channel->max >= channel->end) {
+      if (channel->max >= channel->end - min_buffer) {
         /* Buffer is full, no room to read more characters from the input.
            Return the number of characters in the buffer, with negative
            sign to indicate that no newline was encountered. */

--- a/byterun/unix.c
+++ b/byterun/unix.c
@@ -428,3 +428,8 @@ char *caml_secure_getenv (char const *var)
     return NULL;
 #endif
 }
+
+int caml_channel_flags(int fd)
+{
+  return 0;
+}

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -111,16 +111,14 @@ int caml_write_fd(int fd, int flags, void * buf, int n)
   int retcode;
   if ((flags & CHANNEL_FLAG_FROM_SOCKET) == 0) {
 #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
-  if (flags & CHANNEL_FLAG_BLOCKING_WRITE) {
-    retcode = write(fd, buf, n);
-  } else {
+    if (!(flags & CHANNEL_FLAG_BLOCKING_WRITE))
 #endif
     caml_enter_blocking_section();
     retcode = write(fd, buf, n);
-    caml_leave_blocking_section();
 #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
-  }
+    if (!(flags & CHANNEL_FLAG_BLOCKING_WRITE))
 #endif
+    caml_leave_blocking_section();
     if (retcode == -1) caml_sys_io_error(NO_ARG);
   } else {
     caml_enter_blocking_section();


### PR DESCRIPTION
The explanation of this is slightly picky, so please bear with me. This is a continuation of #1398, but it picks up a few other bugs on the way.

On normal OSes, you don't have to worry so much about your terminal - the caller tells you about the terminal, and you just send appropriate output to it. Not quite the case on Windows, especially if you want Unicode characters to display correctly.

At a minimum, I would like the change in byterun/sys.c to call `SetConsoleOutputCP(CP_UTF8);` to be included in 4.06.0 (if the change in byterun/win32.c is **not** included, then it is necessary to guard that call with a check that we're running on Windows 10). I think the entire change is safe, especially as it only affects input/output from/to keyboards/screens, and not redirections.

It seems to me that having gone to the (serious) trouble of adding proper handling for UTF-8 through the runtime on Windows, that it's a PR (in the "public relations") disaster to have the toplevel displaying raw UTF-8 sequences when it the Unix toplevel now gets to display proper strings.

The primary goal is to ensure that the Windows console is set to interpret UTF-8 text and display the correct Unicode characters. This can be achieved from the console by executing `chcp 65001` but it has some important caveats:

 - Prior to Windows 10, the underlying WriteConsole API call contains a bug. This is tracked in [MPR#6925](https://caml.inria.fr/mantis/view.php?id=6925). I have included a fix in `caml_write_fd` which detects that the fd is a console and on the appropriate version of Windows, manually writes the output.
 - Prior to Windows 10 1607, there is a bug when running the UTF-8 codepage which crashes applications which attempt to read Unicode characters entered by the user. This can be seen in the toplevel of OCaml by trying to put UTF-8 directly into a string - it simply segfaults if you're running `chcp 65001`. The fact that OCaml now supports Unicode filenames, and so forth, means this is something users are more likely to do (run in `chcp 65001`, I mean). I therefore include a fix in `caml_read_fd` which similarly upon detection that fd is a console, reads Windows wide-characters directly and then calls the Windows functions to translate those sequences to UTF-8 as the official result of read.

There is also some weirdness in that prior to Windows 10 1607, the "raster fonts" mode of the console (which was the default prior to Windows 10 **1507/RTM**) cannot ever display Unicode characters and can cause all kinds of crashes for any process trying to do so. For this reason, all the shims back off completely if the console has not been set to a truetype font. This means in the specific case of raster fonts selected and code page 65001 selected that ocamlrun will crash if presented with Unicode input from the console (but that's the same as anything - even cmd.exe displays an error prior to 1607 if you try to echo a string containing extended characters).

Obviously, this has the potential to alter both the way input and output are processed. I will stress here: **this only happens when writing to consoles, it will never affect redirection to files**. This is therefore a much lower-risk change than it may appear.

The behaviour, as with many of these things, depends on `WINDOWS_UNICODE` in `config/Makefile`.

If `WINDOWS_UNICODE` is 1, then:
 - The runtime will always select CP_UTF8 for output
 - For versions prior to Windows 10, it will use the output shim so that UTF-8 is processed correctly
 - For all versions, it uses the input shim to read UTF-8 correctly

If `WINDOWS_UNICODE` is 0, then:
 - The runtime does **not** alter the codepage for output
 - For versions prior to Windows 10, the output shim is used **only if the user has already selected CP_UTF8** (e.g. by running `chcp 65001`). This fixes MPR#6925
 - If the user has selected CP_UTF8, the input shim is used. I don't know if the crash associated with this is recorded in Mantis, but it fixes that too.

There are some semantic changes to `caml_read_fd` and `caml_write_fd` when dealing with console handles, but I believe these are either within spec, or not relevant:
 1. caml_write_fd will not write more than 1KiB to the console at once (that's within spec)
 2. caml_read_fd will often read considerably less than requested (and never more than 4KiB), because it must allow for converting the characters read to UTF-8 sequences
 3. caml_read_fd will fail if asked to read less than 4 bytes from a console

The caml_write_fd change should have no particular effect, unless a program is very badly coded to assume the write always succeeds. The caml_read_fd change results in a subtle change to caml_ml_input_line to prevent it from every trying to request too few bytes - all the other uses of caml_read_fd are to fill channel buffers completely, so will work.