### PR TITLE
Fix testing and handling of gethostbyname on non-GNU

### DIFF
--- a/Changes
+++ b/Changes
@@ -521,6 +521,8 @@ Release branch for 4.06:
 
 ### Compiler distribution build system:
 
+- GPR#1410: Fix testing and handling of gethostbyname on non-GNU.
+
 - MPR#6373, GPR#1093: Suppress trigraph warnings from macOS assembler
   (Mark Shinwell)
 

--- a/configure
+++ b/configure
@@ -1519,7 +1519,8 @@ fi
 
 nargs=none
 for i in 5 6; do
-  if sh ./trycompile -DSYS_${system} -DNUM_ARGS=${i} gethostbyname.c; then
+  if sh ./trycompile -Werror -DSYS_${system} -DNUM_ARGS=${i} gethostbyname.c
+  then
       nargs=$i;
       break;
   fi

--- a/otherlibs/unix/gethost.c
+++ b/otherlibs/unix/gethost.c
@@ -111,11 +111,11 @@ CAMLprim value unix_gethostbyaddr(value a)
   caml_leave_blocking_section();
   if (rc != 0) hp = NULL;
 #else
-#ifdef GETHOSTBYADDR_IS_REENTRANT
+#ifndef GETHOSTBYADDR_IS_REENTRANT
   caml_enter_blocking_section();
 #endif
   hp = gethostbyaddr((char *) &adr, 4, AF_INET);
-#ifdef GETHOSTBYADDR_IS_REENTRANT
+#ifndef GETHOSTBYADDR_IS_REENTRANT
   caml_leave_blocking_section();
 #endif
 #endif
@@ -152,11 +152,11 @@ CAMLprim value unix_gethostbyname(value name)
     if (rc != 0) hp = NULL;
   }
 #else
-#ifdef GETHOSTBYNAME_IS_REENTRANT
+#ifndef GETHOSTBYNAME_IS_REENTRANT
   caml_enter_blocking_section();
 #endif
   hp = gethostbyname(hostname);
-#ifdef GETHOSTBYNAME_IS_REENTRANT
+#ifndef GETHOSTBYNAME_IS_REENTRANT
   caml_leave_blocking_section();
 #endif
 #endif


### PR DESCRIPTION
This way mismatched prototypes gets us the desired non-0 exit status.