### PR TITLE
MPR#7642: on ARMv4 and ARMv5, wrong register allocation for integer multiply

### DIFF
--- a/Changes
+++ b/Changes
@@ -336,6 +336,9 @@ Release branch for 4.06:
 - MPR#7631, GPR#1355: "-linscan" option crashes ocamlopt
   (Xavier Clerc, report by Paul Steckler)
 
+- MPR#7642: on ARMv4 and ARMv5, wrong register allocation for integer multiply
+  (Xavier Leroy, report by Stéphane Glondu and Mantis user "infinity0")
+
 ### Tools:
 
 - MPR#1956, GPR#973: tools/check-symbol-names checks for globally

--- a/Changes
+++ b/Changes
@@ -338,9 +338,9 @@ Release branch for 4.06:
 
 - MPR#7642, GPR#1411: ARM port: wrong register allocation for integer
   multiply on ARMv4 and ARMv5; possible wrong register allocation for
-  floating-point multiply and add on VFD and for floating-point
+  floating-point multiply and add on VFP and for floating-point
   negation and absolute value on soft FP emulation.
-  (Xavier Leroy, report by Stéphane Glondu and Mantis user "infinity0",
+  (Xavier Leroy, report by Stéphane Glondu and Ximin Luo,
    review and additional sightings by Mark Shinwell)
 
 ### Tools:

--- a/Changes
+++ b/Changes
@@ -336,8 +336,12 @@ Release branch for 4.06:
 - MPR#7631, GPR#1355: "-linscan" option crashes ocamlopt
   (Xavier Clerc, report by Paul Steckler)
 
-- MPR#7642: on ARMv4 and ARMv5, wrong register allocation for integer multiply
-  (Xavier Leroy, report by Stéphane Glondu and Mantis user "infinity0")
+- MPR#7642, GPR#1411: ARM port: wrong register allocation for integer
+  multiply on ARMv4 and ARMv5; possible wrong register allocation for
+  floating-point multiply and add on VFD and for floating-point
+  negation and absolute value on soft FP emulation.
+  (Xavier Leroy, report by Stéphane Glondu and Mantis user "infinity0",
+   review and additional sightings by Mark Shinwell)
 
 ### Tools:
 

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -609,6 +609,7 @@ let emit_instr i =
         let instr = name_for_int_operation op in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, #{emit_int n}\n`; 1
     | Lop(Iabsf | Inegf as op) when !fpu = Soft ->
+        assert (i.res.(0).loc = i.arg.(0).loc);
         let instr = (match op with
                        Iabsf -> "bic"
                      | Inegf -> "eor"
@@ -638,6 +639,7 @@ let emit_instr i =
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
         1
     | Lop(Ispecific(Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf as op)) ->
+        assert (i.res.(0).loc = i.arg.(0).loc);
         let instr = (match op with
                        Imuladdf    -> "fmacd"
                      | Inegmuladdf -> "fnmacd"

--- a/asmcomp/arm/reload.ml
+++ b/asmcomp/arm/reload.ml
@@ -13,7 +13,33 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Arch
+open Mach
+
 (* Reloading for the ARM *)
 
+class reload = object
+
+inherit Reloadgen.reload_generic as super
+
+method! reload_operation op arg res =
+  match op with
+  | Iintop Imul | Ispecific Imuladd ->
+      (* On ARM v4 and v5, module [Selection] adds a second, dummy
+         result to multiplication instructions (mul and muladd).  This
+         second result is the same pseudoregister as the first
+         argument to the multiplication.  As shown in MPR#7642,
+         reloading must maintain this invariant.  Otherwise, the second
+         result and the first argument can end up in different registers,
+         and the second result can be used later, even though
+         it is not initialized. *)
+      let ((arg', res') as argres') = super#reload_operation op arg res in
+      if Array.length res' >= 2 then res'.(1) <- arg'.(0);
+      argres'
+  | _ ->
+      super#reload_operation op arg res
+
+end
+
 let fundecl f =
-  (new Reloadgen.reload_generic)#fundecl f
+  (new reload)#fundecl f

--- a/asmcomp/arm/reload.ml
+++ b/asmcomp/arm/reload.ml
@@ -37,7 +37,7 @@ method! reload_operation op arg res =
       if Array.length res' >= 2 then res'.(1) <- arg'.(0);
       argres'
   | Ispecific(Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf) ->
-      (* VFD float multiply-add instructions are "two-address" in the
+      (* VFP float multiply-add instructions are "two-address" in the
          sense that they must have [arg.(0) = res.(0)].
          Preserve this invariant. *)
       (arg', [|arg'.(0)|])


### PR DESCRIPTION
Consider the ARM integer multiply and multiply-accumulate instructions:
```
         mul rd, rm, rs
         mla rd, rm, rs, ra
```
Before ARMv6, the destination register rd must be different from the
first argument register rm.  Otherwise, undefined behavior could occur,
and actually the assembler refuses the instructions.

In asmcomp/arm/selection.ml, this constraint rd <> rm is cleverly
expressed by pretending that the first argument to the multiply
is also an additional result.  Hence, for `X <- Y * Z`, selection produces
```
        (X, Y) <- Y * Z
```
Then, register allocation knows not to put pseudoregisters X and Y in
the same register.

The problem, exhibited in [MPR#7642](https://caml.inria.fr/mantis/view.php?id=7642), is that this invariant "second result
of multiply is first argument" is not preserved by the reloading phase.
Assume that on the first round of register allocation, Y was spilled to
stack.  Then, reloading takes place and produces two different
pseudo-registers Y1 and Y2 for uses of Y before and after the multiply:
```
        // use Y1
        (X, Y2) <- Y1 * Z
        // use Y2
```
The second round of register allocation gladly puts Y1 and Y2 in different
registers or stack locations.  Uses of Y2 after the multiply therefore
use the wrong value of Y, because Y2 was never initialized to begin with!

This commit fixes the issue by adding a special reloading rule for multiply
and multiply-accumulate instructions that have 2 results.  The special
rule ensures that the first argument and the second result are reloaded
to the same pseudoregister.  (E.g. that Y1=Y2 in the example above.)
This way, the invariant "second result of multiply is first argument"
is preserved all the way to assembly code emission.

In the original report (MPR#7642) the problem is tied to

1. generation of position-independent code (PIC)
2. the "armel" (soft-FP ABI) Debian port as opposed to the "armhf" (hard-FP EABI) port.

Both factors are mostly unrelated.  PIC changes register availability
and therefore produces a different register allocation than non-PIC.
The PIC register allocation happens to trigger the bug on function
Cmmgen.udivmod from the OCaml sources.

Concerning "armel" vs "armhf", "armhf" is available for ARMv6 and above,
hence will never run into the bug.  "armel", on the other hand, still
defaults to ARMv4T.  Configuring OCaml for, say, armv7l-unknown-linux-gnueabi
(ARMv7 + soft-FP EABI) would avoid the bug as well.  It shows up in
Debian's armel only because they configure for arm-unknown-linux-gnueabi,
which is their ARMv4T base line.