### PR TITLE
fix 'make clean' broken by testsuite/tests/afl-instrumentation

### DIFF
--- a/testsuite/tests/afl-instrumentation/Makefile
+++ b/testsuite/tests/afl-instrumentation/Makefile
@@ -13,3 +13,5 @@ default:
 	fi
 
 include $(BASEDIR)/makefiles/Makefile.common
+
+clean: defaultclean


### PR DESCRIPTION
It seems that `make clean` was broken by #1345 (my mistake!).

The current PR fixes the issue (and I think we should merge it reasonably fast because there is nothing more irritating than `make clean` failing), but two questions remain:

1. How come our CI hasn't caught this? Do we not test `make clean`?
2. Stephen didn't really do anything wrong when preparing his test (except forgetting to test `clean`), but he included `Makefile.common` only and not any of the more specialized `Makefile.{ok,one,several,toplevel,...}` files. Those files all define a `clean:` action that at least do `clean: defaultclean`. Shouldn't `Makefile.common` already do this, and let others overload the rule? 

Re (2), note that *all* the tests that define their own `clean` target (there are 33 of them, and they all only include `Makefile.common`) make it a dependency of `defaultclean`.