### PR TITLE
travis: test 'make clean'

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -79,6 +79,8 @@ EOF
   # we would need to redo (small parts of) world.opt afterwards to
   # use the compiler again
   $MAKE check_all_arches
+  # check that the 'clean' target also works
+  $MAKE clean
 }
 
 CheckChangesModified () {


### PR DESCRIPTION
Our CI does not currently test `make clean`, which was recently broken (see #1412).

Note: HACKING.adoc has good information on how to run Travis tests locally -- I used it to check that trunk currently fails the new CI test (#1412 needs to be merged first).