### PR TITLE
Fix x86_64 to arm crosscompiler

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -121,6 +121,9 @@ The `configure` script accepts the following options:
 `-no-ocamldoc`::
         Do not build `ocamldoc`.
 
+`-no-ocamltest`::
+        Do not build `ocamltest`.
+
 `-no-ocamlbuild`::
         Deprecated since 4.03.0, as `ocamlbuild` is now distributed separately
         from the compiler distribution.

--- a/Makefile
+++ b/Makefile
@@ -1106,11 +1106,15 @@ partialclean::
 ifeq "$(UNIX_OR_WIN32)" "unix"
 .PHONY: checkstack
 checkstack:
+ifeq "$(CROSS_COMPILER)" "false"
 	if $(MKEXE) $(OUTPUTEXE)tools/checkstack$(EXE) tools/checkstack.c; \
 	  then tools/checkstack$(EXE); \
 	  else :; \
 	fi
 	rm -f tools/checkstack$(EXE)
+else
+	# skipping checkstack for cross compilation
+endif
 endif
 
 # Lint @since and @deprecated annotations

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ CAMLDEP=$(CAMLRUN) tools/ocamldep
 DEPFLAGS=$(INCLUDES)
 
 OCAMLDOC_OPT=$(WITH_OCAMLDOC:=.opt)
+OCAMLTEST_OPT=$(WITH_OCAMLTEST:=.opt)
 
 UTILS=utils/config.cmo utils/misc.cmo \
   utils/identifiable.cmo utils/numbers.cmo utils/arg_helper.cmo \
@@ -473,15 +474,15 @@ opt.opt:
 	$(MAKE) ocaml
 	$(MAKE) opt-core
 	$(MAKE) ocamlc.opt
-	$(MAKE) otherlibraries $(WITH_DEBUGGER) $(WITH_OCAMLDOC) ocamltest
+	$(MAKE) otherlibraries $(WITH_DEBUGGER) $(WITH_OCAMLDOC) $(WITH_OCAMLTEST)
 	$(MAKE) ocamlopt.opt
 	$(MAKE) otherlibrariesopt
 	$(MAKE) ocamllex.opt ocamltoolsopt ocamltoolsopt.opt $(OCAMLDOC_OPT) \
-	  ocamltest.opt
+	  $(OCAMLTEST_OPT)
 else
 opt.opt: core opt-core ocamlc.opt all ocamlopt.opt ocamllex.opt \
          ocamltoolsopt ocamltoolsopt.opt otherlibrariesopt $(OCAMLDOC_OPT) \
-         ocamltest.opt
+         $(OCAMLTEST_OPT)
 endif
 
 .PHONY: base.opt
@@ -492,8 +493,8 @@ base.opt:
 	$(MAKE) ocaml
 	$(MAKE) opt-core
 	$(MAKE) ocamlc.opt
-	$(MAKE) otherlibraries $(WITH_DEBUGGER) $(WITH_OCAMLDOC) ocamltest
-	$(MAKE) ocamlopt.opt
+	$(MAKE) otherlibraries $(WITH_DEBUGGER) $(WITH_OCAMLDOC) $(WITH_OCAMLTEST)
+	$(MAKE) $(OCAMLTEST_OPT)
 	$(MAKE) otherlibrariesopt
 
 # Core bootstrapping cycle
@@ -524,7 +525,7 @@ coreboot:
 all: runtime
 	$(MAKE) coreall
 	$(MAKE) ocaml
-	$(MAKE) otherlibraries $(WITH_DEBUGGER) $(WITH_OCAMLDOC) ocamltest
+	$(MAKE) otherlibraries $(WITH_DEBUGGER) $(WITH_OCAMLDOC) $(WITH_OCAMLTEST)
 
 # Bootstrap and rebuild the whole system.
 # The compilation of ocaml will fail if the runtime has changed.

--- a/config/auto-aux/runtest
+++ b/config/auto-aux/runtest
@@ -23,4 +23,10 @@ if $verbose; then
 else
   $cmd 2> /dev/null || exit 100
 fi
+
+if $cross_compiler; then
+  # sh exits with 2 code when trying to run executable for foreign platform
+  # that is treated by configure script as "compiler is not ISO C99 compliant"
+  return 255
+fi
 exec ./tst

--- a/configure
+++ b/configure
@@ -53,6 +53,7 @@ with_sharedlibs=true
 partialld="ld -r"
 with_debugger=ocamldebugger
 with_ocamldoc=ocamldoc
+with_ocamltest=ocamltest
 with_frame_pointers=false
 with_spacetime=false
 with_spacetime_call_counts=false
@@ -180,6 +181,8 @@ while : ; do
         with_debugger="";;
     -no-ocamldoc|--no-ocamldoc)
         with_ocamldoc="";;
+    -no-ocamltest|--no-ocamltest)
+        with_ocamltest="";;
     -no-ocamlbuild|--no-ocamlbuild)
         ;; # ignored for backward compatibility
     -with-frame-pointers|--with-frame-pointers)
@@ -2114,6 +2117,7 @@ config RUNTIMED "${debugruntime}"
 config RUNTIMEI "${with_instrumented_runtime}"
 config WITH_DEBUGGER "${with_debugger}"
 config WITH_OCAMLDOC "${with_ocamldoc}"
+config WITH_OCAMLTEST "${with_ocamltest}"
 config ASM_CFI_SUPPORTED "$asm_cfi_supported"
 config WITH_FRAME_POINTERS "$with_frame_pointers"
 config WITH_SPACETIME "$with_spacetime"

--- a/configure
+++ b/configure
@@ -368,6 +368,7 @@ if [ x"$host" = x"$target" ]; then
 else
   cross_compiler=true
 fi
+config CROSS_COMPILER "$cross_compiler"
 
 # Do we have gcc?
 
@@ -579,7 +580,7 @@ esac
 
 # Configure compiler options to use in further tests.
 
-export cclibs ldflags
+export cclibs ldflags cross_compiler
 
 # Check C compiler.
 
@@ -667,7 +668,8 @@ if test "$?" -eq 0; then
 else
   # For cross-compilation, runtest always fails: add special handling.
   case "$target" in
-    i686-*-mingw*) inf "OK, this is a regular 32 bit architecture."
+    i686-*-mingw*|arm-linux-gnueabi*)
+                   inf "OK, this is a regular 32 bit architecture."
                    echo "#undef ARCH_SIXTYFOUR" >> m.h
                    set 4 4 4 2 8
                    arch64=false;;
@@ -977,7 +979,7 @@ case "$target" in
   powerpc-*-openbsd*)           arch=power; model=ppc; system=bsd_elf;;
   s390x*-*-linux*)              arch=s390x; model=z10; system=elf;;
   armv6*-*-linux-gnueabihf)     arch=arm; model=armv6; system=linux_eabihf;;
-  arm*-*-linux-gnueabihf)       arch=arm; system=linux_eabihf;;
+  arm*-linux-gnueabihf)         arch=arm; system=linux_eabihf;;
   armv7*-*-linux-gnueabi)       arch=arm; model=armv7; system=linux_eabi;;
   armv6t2*-*-linux-gnueabi)     arch=arm; model=armv6t2; system=linux_eabi;;
   armv6*-*-linux-gnueabi)       arch=arm; model=armv6; system=linux_eabi;;

--- a/configure
+++ b/configure
@@ -621,6 +621,7 @@ if $cross_compiler; then
           "sources ($ocaml_source_version)."
     else
       config CAMLRUN "`./searchpath -p ocamlrun`"
+      config OCAMLRUN "`./searchpath -p ocamlrun`"
     fi
   fi
 
@@ -633,6 +634,7 @@ if $cross_compiler; then
           "successfully."
     else
       config CAMLYACC "`./searchpath -p ocamlyacc`"
+      config OCAMLYACC "`./searchpath -p ocamlyacc`"
     fi
   fi
 


### PR DESCRIPTION
Hi, I've tried to build a cross compiler from x86_64 to arm
(I actually want to write programs for my orangepie), but I found some blocking bugs:(
I've tried to fix them, in this PR.

Unfortunately, ocamltest don't work for cross compilation because
it tries to run newly built ocamlrun binary that can not be run
if host and target arch differs.
Here are the commands I used:
```
./configure -host x86_64-linux-gnu -target arm-linux-gnueabihf -prefix /opt/ocamlarm -target-bindir '$(PREFIX)/bin' -verbose -no-ocamltest
make world
make opt
```
I've checked that `ocamlrun ./ocamlopt -o hello hello_world.ml`
successfully compiles and runs on my arm machine.

Unfortunately, *.opt binaries are gettig compiled for target system,
so I can't run them on host machine to produce executable for target.
I think this can be fixed with changing line 56 from
`CAMLOPT=$(CAMLRUN) ./ocamlopt -g -nostdlib -I stdlib -I otherlibs/dynlink`
to something like:
```
ifeq "$(CROSS_COMPILER)" "true"
CAMLOPT=$(shell config/auto-aux/searchpath -p ocamlopt) -g -nostdlib -I stdlib -I otherlibs/dynlink
else
CAMLOPT=$(CAMLRUN) ./ocamlopt -g -nostdlib -I stdlib -I otherlibs/dynlink
endif
```
but I'm not sure its a good idea.

Please, consider this PR - I'm looking forward to fix it:)
