### PR TITLE
Remove superfluous return statement

### DIFF
--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -308,7 +308,6 @@ CAMLprim value caml_float_of_string(value vs)
  error:
   if (buf != parse_buffer) caml_stat_free(buf);
   caml_failwith("float_of_string");
-  return Val_unit; /* not reached */
 }
 
 CAMLprim value caml_int_of_float(value f)


### PR DESCRIPTION
I don't think `return Val_unit` is necessary.  The function declaration of `caml_failwith` already tells the compiler that it does not return.