### PR TITLE
Remove embellishment in HACKING.adoc

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -1,4 +1,4 @@
-= Hacking the compiler 🐫
+= Hacking the compiler
 
 This document is a work-in-progress attempt to provide useful
 information for people willing to inspect or modify the compiler


### PR DESCRIPTION
At the moment, this PR just removes one character (actually two if
counting the leading space) in HACKING.adoc

This is because check-typo complains about this character
and the embellishment it provides didn't seem worth patching check-typo
or anything else just for the sake of preserving this character.

Note that check-typo complains about more than 34 other non-ascii characters:

./typing/HACKING.adoc:6.119: [non-ascii] non-ASCII character(s)
./asmcomp/interval.mli:8.33: [non-ascii] non-ASCII character(s)
./asmcomp/interval.mli:9.16: [non-ascii] non-ASCII character(s)
./asmcomp/linscan.mli:8.33: [non-ascii] non-ASCII character(s)
./asmcomp/linscan.mli:9.16: [non-ascii] non-ASCII character(s)
./asmcomp/linscan.ml:8.33: [non-ascii] non-ASCII character(s)
./asmcomp/linscan.ml:9.16: [non-ascii] non-ASCII character(s)
./asmcomp/interval.ml:8.33: [non-ascii] non-ASCII character(s)
./asmcomp/interval.ml:9.16: [non-ascii] non-ASCII character(s)
./.travis-ci.sh:31.11: [non-ascii] non-ASCII character(s)
./testsuite/tests/tool-toplevel/strings.ml:12.5: [non-ascii] non-ASCII character(s)
./testsuite/tests/tool-toplevel/strings.ml:14.3: [non-ascii] non-ASCII character(s)
./testsuite/tests/lib-bigarray/change_layout.ml:7.30: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/mltest.ml:12.40: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/mltest.ml:13.37: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/mltest.ml:14.35: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/mltest.ml:22.78: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/mltest.ml:23.38: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/mltest.ml:24.46: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/mltest.ml:25.46: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/mltest.ml:26.46: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/mltest.ml:27.62: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/mltest.ml:29.34: [non-ascii] non-ASCII character(s)
WARNING: too many [non-ascii] in this file.  Others will not be reported.
./testsuite/tests/win-unicode/symlink_tests.ml:4.56: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/symlink_tests.ml:5.86: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/symlink_tests.ml:6.88: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/symlink_tests.ml:7.56: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/symlink_tests.ml:8.54: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/exec_tests.ml:3.78: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/exec_tests.ml:4.38: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/exec_tests.ml:5.46: [non-ascii] non-ASCII character(s)
./testsuite/tests/win-unicode/exec_tests.ml:6.46: [non-ascii] non-ASCII character(s)
./tools/lintapidiff.ml:5.35: [non-ascii] non-ASCII character(s)

Mostly this is about non-ascii letters in names of people.

Did we already decide how these characters should be handled?

Do we want to make check-typo more tolerant or rather remove the accents
where possible?