### PR TITLE
MPR#7609: use-after-free with ocamldebug and Pervasives.flush_all, continued

### DIFF
--- a/otherlibs/win32unix/channels.c
+++ b/otherlibs/win32unix/channels.c
@@ -50,6 +50,8 @@ CAMLprim value win_inchannel_of_filedescr(value handle)
   fflush(stdin);
 #endif
   chan = caml_open_descriptor_in(win_CRT_fd_of_filedescr(handle));
+  chan->flags |= CHANNEL_FLAG_MANAGED_BY_GC;
+                 /* as in caml_ml_open_descriptor_in() */
   if (Descr_kind_val(handle) == KIND_SOCKET)
     chan->flags |= CHANNEL_FLAG_FROM_SOCKET;
   vchan = caml_alloc_channel(chan);
@@ -64,6 +66,8 @@ CAMLprim value win_outchannel_of_filedescr(value handle)
   struct channel * chan;
 
   chan = caml_open_descriptor_out(win_CRT_fd_of_filedescr(handle));
+  chan->flags |= CHANNEL_FLAG_MANAGED_BY_GC;
+                 /* as in caml_ml_open_descriptor_out() */
   if (Descr_kind_val(handle) == KIND_SOCKET)
     chan->flags |= CHANNEL_FLAG_FROM_SOCKET;
   vchan = caml_alloc_channel(chan);


### PR DESCRIPTION
This is a follow-up to commit 6d9ce26 and to GPR #1361 .

I forgot that the win_{in,out}channel_of_filedescr functions from the
Win32 implementation of the Unix library call caml_open_descriptor_{in,out}
directly, without going through caml_ml_open_descriptor_{in,out} like
the Unix implementation of the Unix library does.

As a consequence the CHANNEL_FLAG_MANAGED_BY_GC flag is not set by
the Win32 implementation.

This commit fixes the Win32 implementation and brings it in sync with
the Unix implementation by setting the CHANNEL_FLAG_MANAGED_BY_GC flag.