### PR TITLE
Disable unused-stuff warnings when compiling with -i

### DIFF
--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1783,7 +1783,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
   Typecore.reset_delayed_checks ();
   Env.reset_required_globals ();
   if !Clflags.print_types then (* #7656 *)
-    Warnings.parse_options false "-32-34-37-38";
+    Warnings.parse_options false "-32-34-37-38-60";
   let (str, sg, finalenv) =
     type_structure initial_env ast (Location.in_file sourcefile) in
   let simple_sg = simplify_signature sg in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1782,6 +1782,8 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
   try
   Typecore.reset_delayed_checks ();
   Env.reset_required_globals ();
+  if !Clflags.print_types then (* #7656 *)
+    Warnings.parse_options false "-32-34-37-38";
   let (str, sg, finalenv) =
     type_structure initial_env ast (Location.in_file sourcefile) in
   let simple_sg = simplify_signature sg in


### PR DESCRIPTION
Fixes [MPR#7656](https://caml.inria.fr/mantis/view.php?id=7656).

In #1317, we forced "delayed checks" to run (in order to fix MPR7620) when using `ocamlc -i`.  This was known to  interact badly with "unused stuff" warnings, but it was thought that people would not enable these warnings when calling `ocamlc -i`.  MPR#7656 illustrates that the assumption was wrong.

I think this might deserve to go to 4.06.

(Adding no-change-entry-needed since this is just a tweak on #1317.)