### PR TITLE
fix fatal error from Parmatch.get_type_path

### DIFF
--- a/Changes
+++ b/Changes
@@ -564,6 +564,9 @@ Release branch for 4.06:
 - MPR#5927: Type equality broken for conjunctive polymorphic variant tags
   (Jacques Garrigue, report by Leo White)
 
+- MPR#6394, GPR#1425: fix fatal_error from Parmatch.get_type_path
+  (Virgile Prevosto, review by David Allsopp and Thomas Refis)
+
 - MPR#6587: only elide Pervasives from printed type paths in unambiguous context
   (Florian Angeletti and Jacques Garrigue)
 

--- a/testsuite/tests/typing-modules/pr6394.ml
+++ b/testsuite/tests/typing-modules/pr6394.ml
@@ -1,0 +1,19 @@
+[@@@ ocaml.warning "+4"]
+module rec X : sig
+  type t = int * bool
+end = struct
+  type t = A | B
+  let f = function A | B -> 0
+end;;
+[%%expect{|
+Line _, characters 6-63:
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = X.t = A | B val f : t -> int end
+       is not included in
+         sig type t = int * bool end
+       Type declarations do not match:
+         type t = X.t = A | B
+       is not included in
+         type t = int * bool
+|}];;

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -127,8 +127,10 @@ let clean_copy ty =
 let get_type_path ty tenv =
   let ty = Ctype.repr (Ctype.expand_head tenv (clean_copy ty)) in
   match ty.desc with
-  | Tconstr (path,_,_) -> path
-  | _ -> fatal_error "Parmatch.get_type_path"
+  | Tconstr (path,_,_) -> Some path
+  | _ -> None
+   (* Same as PR#6394: we have an incoherence due to recursive module. It
+      will result in a type error later on. *)
 
 (*************************************)
 (* Values as patterns pretty printer *)
@@ -670,7 +672,9 @@ let should_extend ext env = match ext with
       | Tpat_construct
           (_, {cstr_tag=(Cstr_constant _|Cstr_block _|Cstr_unboxed)},_) ->
             let path = get_type_path p.pat_type p.pat_env in
-            Path.same path ext
+            (match path with
+             | Some path -> Path.same path ext
+             | None -> false)
       | Tpat_construct
           (_, {cstr_tag=(Cstr_extension _)},_) -> false
       | Tpat_constant _|Tpat_tuple _|Tpat_variant _
@@ -812,8 +816,11 @@ let build_other ext env = match env with
                             {lid with txt="*extension*"})) Ctype.none Env.empty
 | ({pat_desc = Tpat_construct _} as p,_) :: _ ->
     begin match ext with
-    | Some ext when Path.same ext (get_type_path p.pat_type p.pat_env) ->
-        extra_pat
+    | Some ext ->
+        let path =  (get_type_path p.pat_type p.pat_env) in
+        (match path with
+         | Some path when Path.same ext path -> extra_pat
+         | _ -> build_other_constrs env p)
     | _ ->
         build_other_constrs env p
     end
@@ -1886,11 +1893,13 @@ let extendable_path path =
 let rec collect_paths_from_pat r p = match p.pat_desc with
 | Tpat_construct(_, {cstr_tag=(Cstr_constant _|Cstr_block _|Cstr_unboxed)},ps)
   ->
-    let path =  get_type_path p.pat_type p.pat_env in
-    List.fold_left
-      collect_paths_from_pat
-      (if extendable_path path then add_path path r else r)
-      ps
+    (match get_type_path p.pat_type p.pat_env with
+     | Some path ->
+         List.fold_left
+           collect_paths_from_pat
+           (if extendable_path path then add_path path r else r)
+           ps
+     | None -> r)
 | Tpat_any|Tpat_var _|Tpat_constant _| Tpat_variant (_,None,_) -> r
 | Tpat_tuple ps | Tpat_array ps
 | Tpat_construct (_, {cstr_tag=Cstr_extension _}, ps)->

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -124,13 +124,24 @@ let clean_copy ty =
   if ty.level = Btype.generic_level then ty
   else Subst.type_expr Subst.identity ty
 
-let get_type_path ty tenv =
+(* As reported in PR#6394 it is possible for recursive modules to add incoherent
+   equations into the environment.
+   So assuming we're working on the same example as in PR#6394, when looking at
+   constructor [A] we end up calling [expand_head] on [t] (the type of [A]) and
+   get [int * bool].
+   This will result in a proper error later on during type checking, meanwhile
+   we need to "survive" and be somewhat aware that we're working on bogus input
+*)
+
+type constructor_type_path =
+  | Ok of Path.t
+  | Inconsistent_environment
+
+let get_constructor_type_path ty tenv =
   let ty = Ctype.repr (Ctype.expand_head tenv (clean_copy ty)) in
   match ty.desc with
-  | Tconstr (path,_,_) -> Some path
-  | _ -> None
-   (* Same as PR#6394: we have an incoherence due to recursive module. It
-      will result in a type error later on. *)
+  | Tconstr (path,_,_) -> Ok path
+  | _ -> Inconsistent_environment
 
 (*************************************)
 (* Values as patterns pretty printer *)
@@ -671,10 +682,13 @@ let should_extend ext env = match ext with
       begin match p.pat_desc with
       | Tpat_construct
           (_, {cstr_tag=(Cstr_constant _|Cstr_block _|Cstr_unboxed)},_) ->
-            let path = get_type_path p.pat_type p.pat_env in
-            (match path with
-             | Some path -> Path.same path ext
-             | None -> false)
+            (match get_constructor_type_path p.pat_type p.pat_env with
+             | Ok path -> Path.same path ext
+             | Inconsistent_environment ->
+               (* returning [true] here could result in more computations being
+                  done to check exhaustivity. Which is clearly not necessary
+                  since the code doesn't typecheck anyway. *)
+               false)
       | Tpat_construct
           (_, {cstr_tag=(Cstr_extension _)},_) -> false
       | Tpat_constant _|Tpat_tuple _|Tpat_variant _
@@ -817,9 +831,8 @@ let build_other ext env = match env with
 | ({pat_desc = Tpat_construct _} as p,_) :: _ ->
     begin match ext with
     | Some ext ->
-        let path =  (get_type_path p.pat_type p.pat_env) in
-        (match path with
-         | Some path when Path.same ext path -> extra_pat
+        (match get_constructor_type_path p.pat_type p.pat_env with
+         | Ok path when Path.same ext path -> extra_pat
          | _ -> build_other_constrs env p)
     | _ ->
         build_other_constrs env p
@@ -1893,13 +1906,17 @@ let extendable_path path =
 let rec collect_paths_from_pat r p = match p.pat_desc with
 | Tpat_construct(_, {cstr_tag=(Cstr_constant _|Cstr_block _|Cstr_unboxed)},ps)
   ->
-    (match get_type_path p.pat_type p.pat_env with
-     | Some path ->
+    (match get_constructor_type_path p.pat_type p.pat_env with
+     | Ok path ->
          List.fold_left
            collect_paths_from_pat
            (if extendable_path path then add_path path r else r)
            ps
-     | None -> r)
+     | Inconsistent_environment ->
+       (* no need to recurse on the constructor arguments: since we know the
+          code won't typecheck anyway, whatever we might compute would be
+          useless anyway. *)
+       r)
 | Tpat_any|Tpat_var _|Tpat_constant _| Tpat_variant (_,None,_) -> r
 | Tpat_tuple ps | Tpat_array ps
 | Tpat_construct (_, {cstr_tag=Cstr_extension _}, ps)->


### PR DESCRIPTION
I am extracting a fix @vprevosto proposed in another GPR he submitted a few releases ago that hasn't been merged yet.

This is a fix for MPR#6394, however I chose to insert the changelog entry with this GPR as key and title because it's less obvious (from its title) to see how MPR is related.
But I'd be happy to change that.

Also, I took the liberty of rewriting a tiny bit Virgile's patch and adding some comments, I hope no one will mind.

All the commits should be squashed before merging.