### PR TITLE
Eliminate use of cmp in ocamltest

### DIFF
--- a/Changes
+++ b/Changes
@@ -423,7 +423,7 @@ Release branch for 4.06:
   and module type elements
   (Florian Angeletti, review by Yawar Amin and Gabriel Scherer)
 
-- GPR#681: Introduce ocamltest, a new test driver for the
+- GPR#681, GPR#1426: Introduce ocamltest, a new test driver for the
   OCaml compiler testsuite
   (Sébastien Hinderer, review by Damien Doligez)
 

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -776,11 +776,7 @@ let make_bytecode_programs_comparison_tool ocamlsrcdir =
   let ocamlrun = ocamlrun ocamlsrcdir in
   let cmpbyt = cmpbyt ocamlsrcdir in
   let tool_name = ocamlrun ^ " " ^ cmpbyt in
-  {
-    Filecompare.tool_name = tool_name;
-    Filecompare.tool_flags = "";
-    Filecompare.result_of_exitcode = Filecompare.cmp_result_of_exitcode
-  }
+  Filecompare.make_comparison_tool tool_name ""
 
 let native_programs_comparison_tool = Filecompare.default_comparison_tool
 

--- a/ocamltest/filecompare.ml
+++ b/ocamltest/filecompare.ml
@@ -21,11 +21,13 @@ type result =
   | Unexpected_output
   | Error of string * int
 
-type tool = {
-  tool_name : string;
-  tool_flags : string;
-  result_of_exitcode : string -> int -> result
-}
+type tool =
+  |  External of {
+                   tool_name : string;
+                   tool_flags : string;
+                   result_of_exitcode : string -> int -> result
+                }
+  | Internal of int
 
 let cmp_result_of_exitcode commandline = function
   | 0 -> Same
@@ -33,15 +35,16 @@ let cmp_result_of_exitcode commandline = function
   | exit_code -> (Error (commandline, exit_code))
 
 let make_cmp_tool bytes_to_ignore =
-  let i_flag =
-    if bytes_to_ignore <= 0
-    then ""
-    else ("-i " ^ (string_of_int bytes_to_ignore)) in
-  {
-    tool_name = "cmp";
-    tool_flags = "-s " ^ i_flag;
-    result_of_exitcode = cmp_result_of_exitcode
-  }
+  Internal bytes_to_ignore
+
+let make_comparison_tool ?(result_of_exitcode = cmp_result_of_exitcode)
+                         name flags =
+  External
+    {
+      tool_name = name;
+      tool_flags = flags;
+      result_of_exitcode
+    }
 
 let default_comparison_tool = make_cmp_tool 0
 
@@ -53,22 +56,35 @@ type files = {
   output_filename : string;
 }
 
-let unixify_end_of_lines filename =
-  let commandline = "sed -i -e s/\\r$// " ^ filename in
-  let status = Run_command.run_commandline commandline in
-  (status, commandline)
+let read_file bytes_to_ignore filetype fn =
+  let ic = open_in_bin fn in
+  seek_in ic bytes_to_ignore;
+  let drop_cr s =
+    let l = String.length s in
+    if l > 0 && s.[l - 1] = '\r' then String.sub s 0 (l - 1)
+    else raise Exit
+  in
+  let rec loop acc =
+    match input_line ic with
+    | s -> loop (s :: acc)
+    | exception End_of_file ->
+      close_in ic;
+      try
+        if filetype = Text then
+          List.rev_map drop_cr acc
+        else
+          raise Exit
+      with Exit -> List.rev acc
+  in
+  loop []
 
 let compare_files ?(tool = default_comparison_tool) files =
-  let (status, commandline) =
-    if files.filetype = Text && Sys.os_type="Win32"
-    then unixify_end_of_lines files.output_filename
-    else (0, "") in
-  match status with
-    | 0 ->
+  match tool with
+  | External {tool_name; tool_flags; result_of_exitcode} ->
       let commandline = String.concat " "
       [
-        tool.tool_name;
-        tool.tool_flags;
+        tool_name;
+        tool_flags;
         files.reference_filename;
         files.output_filename
       ] in
@@ -78,8 +94,13 @@ let compare_files ?(tool = default_comparison_tool) files =
       let settings = Run_command.settings_of_commandline
         ~stdout_fname:dev_null ~stderr_fname:dev_null commandline in
       let status = Run_command.run settings in
-      tool.result_of_exitcode commandline status
-    | _ -> Error (commandline, status)
+      result_of_exitcode commandline status
+  | Internal bytes_to_ignore ->
+      let lines_of = read_file bytes_to_ignore files.filetype in
+      if lines_of files.reference_filename = lines_of files.output_filename then
+        Same
+      else
+        Different
 
 let check_file ?(tool = default_comparison_tool) files =
   if Sys.file_exists files.reference_filename

--- a/ocamltest/filecompare.ml
+++ b/ocamltest/filecompare.ml
@@ -56,9 +56,8 @@ type files = {
   output_filename : string;
 }
 
-let read_file bytes_to_ignore filetype fn =
+let read_text_file fn =
   let ic = open_in_bin fn in
-  seek_in ic bytes_to_ignore;
   let drop_cr s =
     let l = String.length s in
     if l > 0 && s.[l - 1] = '\r' then String.sub s 0 (l - 1)
@@ -69,14 +68,56 @@ let read_file bytes_to_ignore filetype fn =
     | s -> loop (s :: acc)
     | exception End_of_file ->
       close_in ic;
-      try
-        if filetype = Text then
-          List.rev_map drop_cr acc
-        else
-          raise Exit
+      try List.rev_map drop_cr acc
       with Exit -> List.rev acc
   in
   loop []
+
+let compare_text_files file1 file2 =
+  if read_text_file file1 = read_text_file file2 then
+    Same
+  else
+    Different
+
+(* Version of Pervasives.really_input which stops at EOF, rather than raising
+   an exception. *)
+let really_input_up_to ic =
+  let block_size = 8192 in
+  let buf = Bytes.create block_size in
+  let rec read pos =
+    let bytes_read = input ic buf pos (block_size - pos) in
+    let new_pos = pos + bytes_read in
+    if bytes_read = 0 || new_pos = block_size then
+      new_pos
+    else
+      read new_pos
+  in
+  let bytes_read = read 0 in
+  if bytes_read = block_size then
+    buf
+  else
+    Bytes.sub buf 0 bytes_read
+
+let compare_binary_files bytes_to_ignore file1 file2 =
+  let ic1 = open_in_bin file1 in
+  let ic2 = open_in_bin file2 in
+  seek_in ic1 bytes_to_ignore;
+  seek_in ic2 bytes_to_ignore;
+  let rec compare () =
+    let block1 = really_input_up_to ic1 in
+    let block2 = really_input_up_to ic2 in
+    if block1 = block2 then
+      if Bytes.length block1 > 0 then
+        compare ()
+      else
+        Same
+    else
+      Different
+  in
+  let result = compare () in
+  close_in ic1;
+  close_in ic2;
+  result
 
 let compare_files ?(tool = default_comparison_tool) files =
   match tool with
@@ -96,11 +137,13 @@ let compare_files ?(tool = default_comparison_tool) files =
       let status = Run_command.run settings in
       result_of_exitcode commandline status
   | Internal bytes_to_ignore ->
-      let lines_of = read_file bytes_to_ignore files.filetype in
-      if lines_of files.reference_filename = lines_of files.output_filename then
-        Same
-      else
-        Different
+      match files.filetype with
+        | Text ->
+            (* bytes_to_ignore is silently ignored for text files *)
+            compare_text_files files.reference_filename files.output_filename
+        | Binary ->
+            compare_binary_files bytes_to_ignore
+                                 files.reference_filename files.output_filename
 
 let check_file ?(tool = default_comparison_tool) files =
   if Sys.file_exists files.reference_filename

--- a/ocamltest/filecompare.mli
+++ b/ocamltest/filecompare.mli
@@ -21,13 +21,12 @@ type result =
   | Unexpected_output
   | Error of string * int
 
-type tool = {
-  tool_name : string;
-  tool_flags : string;
-  result_of_exitcode : string -> int -> result
-}
+type tool
 
 val make_cmp_tool : int -> tool
+
+val make_comparison_tool :
+  ?result_of_exitcode:(string -> int -> result) -> string -> string -> tool
 
 val default_comparison_tool : tool
 


### PR DESCRIPTION
This splits off the ocamltest changes from #1380.

Note that I also realised that the `\r` processing was previously being done for all files - it's now only done for text files.