### PR TITLE
give a non dummy location to warning 49

### DIFF
--- a/Changes
+++ b/Changes
@@ -24,6 +24,9 @@ be mentioned in the 4.06 section below instead of here.)
   first character (instead of comma) in the set ":|; ,"
   (Fabrice Le Fessant)
 
+- GPR#1428: give a non dummy location for warning 49 (no cmi found)
+  (Valentin Gatien-Baron)
+
 ### Code generation and optimizations:
 
 ### Runtime system:

--- a/testsuite/tests/no-alias-deps/aliases.ml.reference
+++ b/testsuite/tests/no-alias-deps/aliases.ml.reference
@@ -1,5 +1,5 @@
-File "_none_", line 1:
+File "aliases.ml", line 1, characters 12-13:
 Warning 49: no cmi file was found in path for module A
-File "_none_", line 1:
+File "aliases.ml", line 2, characters 12-13:
 Warning 49: no valid cmi file was found in path for module B. b.cmi
 is not a compiled interface


### PR DESCRIPTION
$ cat a.ml
module B = B

Before:
$ ocamlc -no-alias-deps a.ml
File "_none_", line 1:
Warning 49: no cmi file was found in path for module B

After:
$ ocamlc -no-alias-deps a.ml
File "a.ml", line 1, characters 11-12:
Warning 49: no cmi file was found in path for module B