### PR TITLE
ocamlc -config: introduce ocaml{c,opt}_cppflags

### DIFF
--- a/Changes
+++ b/Changes
@@ -227,6 +227,14 @@ Release branch for 4.06:
 - GPR#1032: display the output of -dtimings as a hierarchy
   (Valentin Gatien-Baron, review by Gabriel Scherer)
 
+- GPR#1114, GPR#1393, GPR#1429: refine the (ocamlc -config) information
+  on C compilers: the variables `{bytecode,native}_c_compiler` are deprecated
+  (the distinction is now mostly meaningless) in favor of a single
+  `c_compiler` variable combined with `ocaml{c,opt}_cflags`
+  and `ocaml{c,opt}_cppflags`.
+  (Sébastien Hinderer, Jeremy Yallop, Gabriel Scherer, review by
+   Adrien Nader and David Allsopp)
+
 - GPR#1333: turn off warning 40 by default
   (Leo White)
 

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -193,6 +193,7 @@ let print_config oc =
   p_bool "safe_string" safe_string;
   p_bool "default_safe_string" default_safe_string;
   p_bool "flat_float_array" flat_float_array;
+  p_bool "afl_instrument" afl_instrument;
   p_bool "windows_unicode" windows_unicode;
 
   (* print the magic number *)

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -157,12 +157,14 @@ let print_config oc =
   p "standard_library" standard_library;
   p "standard_runtime" standard_runtime;
   p "ccomp_type" ccomp_type;
-  p "bytecomp_c_compiler" bytecomp_c_compiler;
   p "c_compiler" c_compiler;
   p "ocamlc_cflags" ocamlc_cflags;
+  p "ocamlc_cppflags" ocamlc_cppflags;
   p "ocamlopt_cflags" ocamlopt_cflags;
-  p "bytecomp_c_libraries" bytecomp_c_libraries;
+  p "ocamlopt_cppflags" ocamlopt_cppflags;
+  p "bytecomp_c_compiler" bytecomp_c_compiler;
   p "native_c_compiler" native_c_compiler;
+  p "bytecomp_c_libraries" bytecomp_c_libraries;
   p "native_c_libraries" native_c_libraries;
   p "native_pack_linker" native_pack_linker;
   p "ranlib" ranlib;


### PR DESCRIPTION
When I documented the change in #1393 for the beta2 Changes file, I realized that the advice to deprecate `{bytecode,native}_c_compiler` in favor of the newer configuration variables does not really work if the `cppflags` are not exposed.

(cc @shindere, @yallop, @dra27)