### PR TITLE
MPR#6567: add Unix.flush_mapped_file

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,9 +18,9 @@ be mentioned in the 4.06 section below instead of here.)
 
 ### Other libraries:
 
-- MPR#6567: add Unix.flush_mapped_file function to synchronize a
+- MPR#6567, GPR#1432: add Unix.flush_mapped_file function to synchronize a
   memory-mapped file with the corresponding in-memory bigarray.
-  (Christoph Bauer and Xavier Leroy)
+  (Christoph Bauer and Xavier Leroy, review by Anil Madhavapeddy)
 
 ### Compiler user-interface and warnings:
 

--- a/Changes
+++ b/Changes
@@ -18,6 +18,10 @@ be mentioned in the 4.06 section below instead of here.)
 
 ### Other libraries:
 
+- MPR#6567: add Unix.flush_mapped_file function to synchronize a
+  memory-mapped file with the corresponding in-memory bigarray.
+  (Christoph Bauer and Xavier Leroy)
+
 ### Compiler user-interface and warnings:
 
 - GPR#1166: In OCAMLPARAM, an alternative separator can be specified as

--- a/otherlibs/threads/unix.ml
+++ b/otherlibs/threads/unix.ml
@@ -330,6 +330,9 @@ external map_internal:
 let map_file fd ?(pos=0L) kind layout shared dims =
   map_internal fd kind layout shared dims pos
 
+external flush_mapped_file :
+  ('a, 'b, 'c) CamlinternalBigarray.genarray -> bool -> unit
+     = "caml_unix_flush_mapped_file"
 type access_permission =
     R_OK
   | W_OK

--- a/otherlibs/unix/mmap.c
+++ b/otherlibs/unix/mmap.c
@@ -249,7 +249,6 @@ void caml_unix_flush_file(void * addr, uintnat len, int sync)
 CAMLexport void caml_unix_flush_file(void * addr, uintnat len, int sync)
 {
   caml_invalid_argument("Unix.flush_mapped_file: not supported");
-  return Val_unit;
 }
 
 #endif

--- a/otherlibs/unix/mmap_ba.c
+++ b/otherlibs/unix/mmap_ba.c
@@ -99,16 +99,16 @@ CAMLprim value caml_unix_flush_mapped_file(value vb, value vsync)
   CAMLparam2(vb, vsync);
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   int sync = Bool_val(vsync);
-    
-  if( b->flags & CAML_BA_MAPPED_FILE ) {
-    if( b->proxy == NULL )
+  
+  if (b->flags & CAML_BA_MAPPED_FILE) {
+    if (b->proxy == NULL) {
       caml_unix_flush_file(b->data, caml_ba_byte_size(b), sync);
-    else {
+    } else {
       caml_unix_flush_file(b->proxy->data, b->proxy->size, sync);
     }
   }
-     
-  CAMLreturn( Val_unit );
+  
+  CAMLreturn (Val_unit);
 }
 
 #endif

--- a/otherlibs/unix/mmap_ba.c
+++ b/otherlibs/unix/mmap_ba.c
@@ -89,3 +89,26 @@ ALLOC_FUNCTION(int flags, int num_dims, void * data, intnat * dim)
   for (i = 0; i < num_dims; i++) b->dim[i] = dimcopy[i];
   return res;
 }
+
+#ifndef IN_OCAML_BIGARRAY
+
+CAMLextern void caml_unix_flush_file(void * addr, uintnat len, int sync);
+
+CAMLprim value caml_unix_flush_mapped_file(value vb, value vsync)
+{
+  CAMLparam2(vb, vsync);
+  struct caml_ba_array * b = Caml_ba_array_val(vb);
+  int sync = Bool_val(vsync);
+    
+  if( b->flags & CAML_BA_MAPPED_FILE ) {
+    if( b->proxy == NULL )
+      caml_unix_flush_file(b->data, caml_ba_byte_size(b), sync);
+    else {
+      caml_unix_flush_file(b->proxy->data, b->proxy->size, sync);
+    }
+  }
+     
+  CAMLreturn( Val_unit );
+}
+
+#endif

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -415,6 +415,10 @@ external map_internal:
 let map_file fd ?(pos=0L) kind layout shared dims =
   map_internal fd kind layout shared dims pos
 
+external flush_mapped_file :
+  ('a, 'b, 'c) CamlinternalBigarray.genarray -> bool -> unit
+     = "caml_unix_flush_mapped_file"
+
 type access_permission =
     R_OK
   | W_OK

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -543,6 +543,28 @@ val map_file :
   validation fails.
   @since 4.06.0 *)
 
+val flush_mapped_file :
+  ('a, 'b, 'c) CamlinternalBigarray.genarray -> bool -> unit
+(** Synchronize a memory-mapped file with its in-memory view.
+   Consider a bigarray [b] obtained by {!Unix.map_file} with the [shared]
+   flag set to true.  [flush_mapped_file b sync] causes changes made
+   to the bigarray [b] to be performed on the file as well.  If [sync] is
+   true, [flush_mapped_file] blocks until the file has been fully updated.
+   If [sync] is false, the file update is scheduled but [flush_mapped_file]
+   returns immediately.
+
+   Until [flush_mapped_file] is called, the data modified in [b] can
+   stay in memory and not update the file for arbitrary long amounts
+   of time.  In particular, [flush_mapped_file] must be called before
+   the underlying file descriptor initially passed to {!Unix.map_file}
+   is closed; otherwise, depending on the OS and file system, there is
+   a risk that the changes made to [b] are lost.
+
+   On Windows: the synchronous mode [sync = true] is not supported by the OS
+   and raises [Invalid_argument].  Always use [sync = false].
+   
+   @since 4.07.0 *)
+
 (** {1 Operations on file names} *)
 
 

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -483,6 +483,28 @@ val map_file :
   validation fails.
   @since 4.06.0 *)
 
+val flush_mapped_file :
+  ('a, 'b, 'c) CamlinternalBigarray.genarray -> sync:bool -> unit
+(** Synchronize a memory-mapped file with its in-memory view.
+   Consider a bigarray [b] obtained by {!Unix.map_file} with the [shared]
+   flag set to true.  [flush_mapped_file b ~sync] causes changes made
+   to the bigarray [b] to be performed on the file as well.  If [sync] is
+   true, [flush_mapped_file] blocks until the file has been fully updated.
+   If [sync] is false, the file update is scheduled but [flush_mapped_file]
+   returns immediately.
+
+   Until [flush_mapped_file] is called, the data modified in [b] can
+   stay in memory and not update the file for arbitrary long amounts
+   of time.  In particular, [flush_mapped_file] must be called before
+   the underlying file descriptor initially passed to {!Unix.map_file}
+   is closed; otherwise, depending on the OS and file system, there is
+   a risk that the changes made to [b] are lost.
+
+   On Windows: the synchronous mode [sync = true] is not supported by the OS
+   and raises [Invalid_argument].  Always use [sync = false].
+   
+   @since 4.07.0 *)
+
 (** {1 Operations on file names} *)
 
 

--- a/otherlibs/win32unix/mmap.c
+++ b/otherlibs/win32unix/mmap.c
@@ -181,7 +181,7 @@ void caml_unix_flush_file(void * addr, uintnat len, int sync)
   caml_leave_blocking_section();
   if (! ret)  {
     win32_maperr(GetLastError());
-    uerror("flush_mapped_file", Nothing); 
+    uerror("flush_mapped_file", Nothing);
   }
 }
 

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -308,6 +308,10 @@ external map_internal:
 let map_file fd ?(pos=0L) kind layout shared dims =
   map_internal fd kind layout shared dims pos
 
+external flush_mapped_file :
+  ('a, 'b, 'c) CamlinternalBigarray.genarray -> bool -> unit
+     = "caml_unix_flush_mapped_file"
+
 (* File permissions and ownership *)
 
 type access_permission =

--- a/testsuite/tests/lib-bigarray-file/mapflush.ml
+++ b/testsuite/tests/lib-bigarray-file/mapflush.ml
@@ -1,0 +1,35 @@
+open Printf
+open Bigarray
+
+let mapped_file = Filename.temp_file "bigarray" ".data"
+let reference_file = Filename.temp_file "bigarray" ".ref"
+let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n"
+
+let test () =
+  let oc = open_out_bin reference_file in
+  output_string oc text;
+  close_out oc;
+  let fd =
+   Unix.openfile mapped_file
+                 [Unix.O_RDWR; Unix.O_TRUNC; Unix.O_CREAT] 0o666 in
+  let b =
+    Unix.map_file fd int8_unsigned c_layout true [| String.length text |] in
+  let a =
+    array1_of_genarray b in
+  String.iteri (fun i c -> a.{i} <- Char.code c) text;
+  Unix.flush_mapped_file b (if Sys.os_type = "Unix" then true else false);
+  let rc1 = Sys.command (sprintf "cmp %s %s" mapped_file reference_file) in
+  printf "Test 1: %s\n" (if rc1 = 0 then "success" else "failure");
+  Unix.close fd;
+  let rc2 = Sys.command (sprintf "cmp %s %s" mapped_file reference_file) in
+  printf "Test 2: %s\n" (if rc2 = 0 then "success" else "failure")
+
+  [@@inline never]
+
+let _ =
+  test ();
+  (* Force garbage collection of the mapped bigarrays above, otherwise
+     Win32 doesn't let us erase the file. *)
+  Gc.full_major();
+  Sys.remove mapped_file;
+  Sys.remove reference_file

--- a/testsuite/tests/lib-bigarray-file/mapflush.reference
+++ b/testsuite/tests/lib-bigarray-file/mapflush.reference
@@ -1,0 +1,2 @@
+Test 1: success
+Test 2: success


### PR DESCRIPTION
This function synchronizes a memory-mapped file with the corresponding in-memory bigarray.

This PR reuses the code proposed by Christoph Bauer in [MPR#6567](https://caml.inria.fr/mantis/view.php?id=6567) and adapts it to the new division of labor between Bigarray and Unix, whereas functions for memory-mapped files are now in Unix.