### PR TITLE
Makefile cleanup

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -198,8 +198,15 @@ for guidance on how to edit the generated files by hand.
 
 2. From the top directory, do:
 
+        make world.opt
++
+if your platform is supported by the native-code compiler (as reported during
+   the auto-configuration), or
+
         make world
 +
+if not.
+
 This builds the OCaml bytecode compiler for the first time.  This phase is
 fairly verbose; consider redirecting the output to a file:
 
@@ -226,38 +233,7 @@ best thing to do is to try a second bootstrapping phase: just do
 `make bootstrap` again.  It will either crash almost immediately, or
 re-re-compile everything correctly and reach the fix-point.
 
-4. If your platform is supported by the native-code compiler (as reported during
-   the auto-configuration), you can now build the native-code compiler.  From
-   the top directory, do:
-
-        make opt
-+
-or:
-
-        make opt > log.opt 2>&1     # in sh
-        make opt >& log.opt         # in csh
-
-5. anchor:step-5[] Compile fast versions of the OCaml compilers, by compiling
-   them with the native-code compiler (you will have only compiled them to
-   bytecode in steps 2-4).  Just do:
-
-        make opt.opt
-+
-Later, you can compile your programs to bytecode using ocamlc.opt instead of
-ocamlc, and to native-code using ocamlopt.opt instead of ocamlopt.  The ".opt"
-compilers should run faster than the normal compilers, especially on large input
-files, but they may take longer to start due to increased code size.  If
-compilation times are an issue on your programs, try the ".opt" compilers to see
-if they make a significant difference.
-+
-An alternative, and faster approach to steps 2 to 5 is
-
-        make world.opt          # to build using native-code compilers
-+
-The result is equivalent to `make world opt opt.opt`, but this may fail if
-anything goes wrong in native-code generation.
-
-6. You can now install the OCaml system. This will create the following commands
+4. You can now install the OCaml system. This will create the following commands
    (in the binary directory selected during autoconfiguration):
 +
 [width="70%",frame="topbot",cols="25%,75%"]
@@ -277,20 +253,17 @@ anything goes wrong in native-code generation.
 | `ocamlcp`    | the bytecode compiler in profiling mode
 |===============================================================================
 +
-and also, if you built them during <<step-5,step 5>>: `ocamlc.opt`,
-`ocamlopt.opt`, `ocamllex.opt`, `ocamldep.opt` and `ocamldoc.opt`
-+
 From the top directory, become superuser and do:
 
         umask 022       # make sure to give read & execute permission to all
         make install
 
-7. Installation is complete. Time to clean up. From the toplevel directory,
+5. Installation is complete. Time to clean up. From the toplevel directory,
    do:
 
         make clean
 
-8. (Optional) The `emacs/` subdirectory contains Emacs-Lisp files for an OCaml
+6. (Optional) The `emacs/` subdirectory contains Emacs-Lisp files for an OCaml
    editing mode and an interface for the debugger.  To install these files,
    change to the `emacs/` subdirectory and do:
 
@@ -303,7 +276,7 @@ or
 In the latter case, the destination directory defaults to the
 `site-lisp` directory of your Emacs installation.
 
-9. After installation, do *not* strip the `ocamldebug` and `ocamlbrowser`
+7. After installation, do *not* strip the `ocamldebug` and `ocamlbrowser`
    executables. These are mixed-mode executables (containing both compiled C
    code and OCaml bytecode) and stripping erases the bytecode!  Other
    executables such as `ocamlrun` can safely be stripped.

--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ RUNTOP=./byterun/ocamlrun ./ocaml \
   -noinit $(TOPFLAGS) \
   -I otherlibs/$(UNIXLIB)
 NATRUNTOP=./ocamlnat$(EXE) -nostdlib -I stdlib -noinit $(TOPFLAGS)
-ifeq "UNIX_OR_WIN32" "unix"
+ifeq "$(UNIX_OR_WIN32)" "unix"
 EXTRAPATH=
 else
 EXTRAPATH = PATH="otherlibs/win32unix:$(PATH)"
@@ -788,7 +788,9 @@ partialclean::
 
 .PHONY: runtop
 runtop:
-	$(MAKE) core
+	$(MAKE) coldstart
+	$(MAKE) ocamlc
+	$(MAKE) otherlibraries
 	$(MAKE) ocaml
 	@rlwrap --help 2>/dev/null && $(EXTRAPATH) rlwrap $(RUNTOP) ||\
 	  $(EXTRAPATH) $(RUNTOP)
@@ -1080,9 +1082,10 @@ checkstack:
 ifeq "$(UNIX_OR_WIN32)" "unix"
 	if $(MKEXE) $(OUTPUTEXE)tools/checkstack$(EXE) tools/checkstack.c; \
 	  then tools/checkstack$(EXE); \
-	  else :; \
 	fi
 	rm -f tools/checkstack$(EXE)
+else
+	@
 endif
 
 # Lint @since and @deprecated annotations

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,18 @@
 # The main Makefile
 
 # Hard bootstrap how-to:
-# (only necessary in some cases, for example if you remove some primitive)
+# (only necessary if you remove or rename some primitive)
 #
-# make coreboot     [old system -- you were in a stable state]
-# <change the source>
-# make clean runtime coreall
-# <debug your changes>
-# make clean runtime coreall
+# make core     [old system -- you were in a stable state]
+# make coreboot [optional -- check state stability]
+# <add new primitives and remove uses of old primitives>
+# make clean && make core
+# if the above fails:
+#     <debug your changes>
+#     make clean && make core
+# make coreboot [intermediate state with both old and new primitives]
+# <remove old primitives>
+# make clean && make runtime && make coreall
 # make coreboot [new system -- now in a stable state]
 
 include config/Makefile

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -188,7 +188,7 @@ the top-level of the OCaml distribution by running:
 
   eval $(tools/msvs-promote-path)
 
-If you forget to do this, `make world` will fail relatively
+If you forget to do this, `make world.opt` will fail relatively
 quickly as it will be unable to link `ocamlrun`.
 
 Now run:
@@ -210,7 +210,8 @@ which indicates where to install everything.
 
 Finally, use `make` to build the system, e.g.
 
-        make world bootstrap opt opt.opt install
+        make world.opt
+        make install
 
 After installing, it is not necessary to keep the Cygwin installation (although
 you may require it to build additional third party libraries and tools).  You
@@ -281,7 +282,8 @@ which indicates where to install everything.
 
 Finally, use `make` to build the system, e.g.
 
-        make world bootstrap opt opt.opt install
+        make world.opt
+        make install
 
 After installing, you will need to ensure that `ocamlopt` (or `ocamlc -custom`)
 can access the C compiler.  You can do this either by using OCaml from Cygwin's
@@ -327,7 +329,10 @@ done in one of three ways:
 OCaml is then compiled as normal for the port you require, except that before
 compiling `world`, you must compile `flexdll`, i.e.:
 
-  make flexdll world [bootstrap] opt opt.opt flexlink.opt install
+  make flexdll
+  make world.opt
+  make flexlink.opt
+  make install
 
  * You should ignore the error messages that say ocamlopt was not found.
  * `make install` will install FlexDLL by placing `flexlink.exe`

--- a/tools/ci-build
+++ b/tools/ci-build
@@ -218,13 +218,11 @@ case $configure in
   *) error "internal error";;
 esac
 
-$make $jobs core
-$make $jobs coreboot
-$make $jobs world
 if $make_native; then
-  $make $jobs opt
-  $make $jobs opt.opt
+  $make $jobs world.opt
   if $check_make_alldepend; then $make alldepend; fi
+else
+  $make $jobs world
 fi
 if $dorebase; then
     # temporary solution to the cygwin fork problem

--- a/tools/ci-build
+++ b/tools/ci-build
@@ -218,7 +218,6 @@ case $configure in
   *) error "internal error";;
 esac
 
-$make $jobs coldstart
 $make $jobs core
 $make $jobs coreboot
 $make $jobs world


### PR DESCRIPTION
main Makefile:
* remove some dicrepancies between Unix and Windows
* fix hard-bootstrap instructions
* remove obsolete targets `package-macosx` and `base.opt`
* various clean-ups

cc @garrigue : is `base.opt` really obsolete?