### PR TITLE
MPR5250: on Cygwin, skip directories when searching bytecode executables in path

### DIFF
--- a/Changes
+++ b/Changes
@@ -628,6 +628,11 @@ Release branch for 4.06:
   (Florian Angeletti, review by Frédéric Bour, Jacques Garrigue,
    Gabriel Radanne and Gabriel Scherer)
 
+- MPR#5250: on Cygwin, when ocamlrun searches the path for a bytecode
+  executable file, skip directories and other non-regular files, like
+  other Unix variants do
+  (Xavier Leroy)
+
 - MPR#5927: Type equality broken for conjunctive polymorphic variant tags
   (Jacques Garrigue, report by Leo White)
 

--- a/byterun/unix.c
+++ b/byterun/unix.c
@@ -161,12 +161,14 @@ caml_stat_string caml_search_in_path(struct ext_table * path, const char * name)
 
 static int cygwin_file_exists(const char * name)
 {
-  int fd;
+  int fd, ret;
+  struct stat st;
   /* Cannot use stat() here because it adds ".exe" implicitly */
   fd = open(name, O_RDONLY);
   if (fd == -1) return 0;
+  ret = fstat(fd, &st);
   close(fd);
-  return 1;
+  return ret == 0 && S_ISREG(st.st_mode);
 }
 
 static caml_stat_string cygwin_search_exe_in_path(struct ext_table * path, const char * name)


### PR DESCRIPTION
During path search, directories and other non-regular files are now skipped under Cygwin, just like they are on other Unix systems.

This fixes the last remaining issue from [MPR 5250](https://caml.inria.fr/mantis/view.php?id=5250)