### PR TITLE
Add a padding word before "data_end" symbols (MPR#6329)

### DIFF
--- a/Changes
+++ b/Changes
@@ -356,7 +356,7 @@ Release branch for 4.06:
 - MPR#6329, GPR#1437: Introduce padding word before "data_end" symbols
   to ensure page table tests work correctly on an immediately preceding
   block of zero size.
-  (Mark Shinwell)
+  (Mark Shinwell, review by Xavier Leroy)
 
 ### Tools:
 

--- a/Changes
+++ b/Changes
@@ -353,6 +353,11 @@ Release branch for 4.06:
   (Xavier Leroy, report by Stéphane Glondu and Ximin Luo,
    review and additional sightings by Mark Shinwell)
 
+- MPR#6329, GPR#1437: Introduce padding word before "data_end" symbols
+  to ensure page table tests work correctly on an immediately preceding
+  block of zero size.
+  (Mark Shinwell)
+
 ### Tools:
 
 - MPR#1956, GPR#973: tools/check-symbol-names checks for globally

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -1060,6 +1060,7 @@ let end_assembly() =
   emit_imp_table();
 
   D.data ();
+  D.qword (const 0);  (* PR#6329 *)
   emit_global_label "data_end";
   D.qword (const 0);
 

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -955,7 +955,7 @@ let end_assembly () =
   `{emit_symbol lbl_end}:\n`;
   let lbl_end = Compilenv.make_symbol (Some "data_end") in
   `	.data\n`;
-  `	.long 0\n`;
+  `	.long 0\n`;  (* PR#6329 *)
   `	.globl	{emit_symbol lbl_end}\n`;
   `{emit_symbol lbl_end}:\n`;
   `	.long	0\n`;

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -955,6 +955,7 @@ let end_assembly () =
   `{emit_symbol lbl_end}:\n`;
   let lbl_end = Compilenv.make_symbol (Some "data_end") in
   `	.data\n`;
+  `	.long 0\n`;
   `	.globl	{emit_symbol lbl_end}\n`;
   `{emit_symbol lbl_end}:\n`;
   `	.long	0\n`;

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -982,6 +982,7 @@ let end_assembly () =
   `{emit_symbol lbl_end}:\n`;
   let lbl_end = Compilenv.make_symbol (Some "data_end") in
   `	.data\n`;
+  `	.long	0\n`;
   `	.globl	{emit_symbol lbl_end}\n`;
   `{emit_symbol lbl_end}:\n`;
   `	.long	0\n`;

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -982,7 +982,7 @@ let end_assembly () =
   `{emit_symbol lbl_end}:\n`;
   let lbl_end = Compilenv.make_symbol (Some "data_end") in
   `	.data\n`;
-  `	.long	0\n`;  (* PR#6329 *)
+  `	.quad	0\n`;  (* PR#6329 *)
   `	.globl	{emit_symbol lbl_end}\n`;
   `{emit_symbol lbl_end}:\n`;
   `	.long	0\n`;

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -982,7 +982,7 @@ let end_assembly () =
   `{emit_symbol lbl_end}:\n`;
   let lbl_end = Compilenv.make_symbol (Some "data_end") in
   `	.data\n`;
-  `	.long	0\n`;
+  `	.long	0\n`;  (* PR#6329 *)
   `	.globl	{emit_symbol lbl_end}\n`;
   `{emit_symbol lbl_end}:\n`;
   `	.long	0\n`;

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -1047,7 +1047,7 @@ let end_assembly() =
   emit_global_label "code_end";
 
   D.data ();
-  D.long (const 0);
+  D.long (const 0);  (* PR#6329 *)
   emit_global_label "data_end";
   D.long (const 0);
 

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -1047,6 +1047,7 @@ let end_assembly() =
   emit_global_label "code_end";
 
   D.data ();
+  D.long (const 0);
   emit_global_label "data_end";
   D.long (const 0);
 

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -1195,7 +1195,7 @@ let end_assembly() =
   emit_string data_space;
   let lbl_end = Compilenv.make_symbol (Some "data_end") in
   declare_global_data lbl_end;
-  `	{emit_string datag}	0\n`;
+  `	{emit_string datag}	0\n`;  (* PR#6329 *)
   `{emit_symbol lbl_end}:\n`;
   `	{emit_string datag}	0\n`;
   (* Emit the frame descriptors *)

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -1195,6 +1195,7 @@ let end_assembly() =
   emit_string data_space;
   let lbl_end = Compilenv.make_symbol (Some "data_end") in
   declare_global_data lbl_end;
+  `	{emit_string datag}	0\n`;
   `{emit_symbol lbl_end}:\n`;
   `	{emit_string datag}	0\n`;
   (* Emit the frame descriptors *)

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -736,7 +736,7 @@ let end_assembly() =
   `	.align	8\n`;
   let lbl_end = Compilenv.make_symbol (Some "data_end") in
   declare_global_data lbl_end;
-  `	.quad	0\n`;
+  `	.quad	0\n`;  (* PR#6329 *)
   `{emit_symbol lbl_end}:\n`;
   `	.quad	0\n`;
   (* Emit the frame descriptors *)

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -736,6 +736,7 @@ let end_assembly() =
   `	.align	8\n`;
   let lbl_end = Compilenv.make_symbol (Some "data_end") in
   declare_global_data lbl_end;
+  `	.quad	0\n`;
   `{emit_symbol lbl_end}:\n`;
   `	.quad	0\n`;
   (* Emit the frame descriptors *)


### PR DESCRIPTION
I think this will fix MPR#6329 by ensuring that if the page table is tested for the address of an empty block immediately before a "data_end" symbol, then there will be a valid result.  The Mantis issue contains the full details of the problem.  I don't believe I have any way of reasonably testing this; the reproduction case involved a binary.