### PR TITLE
Fix Spacetime runtime system compilation with -force-safe-string (MPR#7658)

### DIFF
--- a/Changes
+++ b/Changes
@@ -492,6 +492,10 @@ Release branch for 4.06:
 * GPR#1416: switch the Windows 10 Console to UTF-8 encoding.
   (David Allsopp, reviews by Nicolás Ojeda Bär and Xavier Leroy)
 
+- MPR#7658, GPR#1439: Fix Spacetime runtime system compilation with
+  -force-safe-string
+  (Mark Shinwell)
+
 ### Manual and documentation:
 
 - MPR#6548: remove obsolete limitation in the description of private

--- a/Changes
+++ b/Changes
@@ -494,7 +494,7 @@ Release branch for 4.06:
 
 - MPR#7658, GPR#1439: Fix Spacetime runtime system compilation with
   -force-safe-string
-  (Mark Shinwell)
+  (Mark Shinwell, report by Christoph Spiel, review by Gabriel Scherer)
 
 ### Manual and documentation:
 

--- a/asmrun/spacetime_snapshot.c
+++ b/asmrun/spacetime_snapshot.c
@@ -356,7 +356,7 @@ copy_string_outside_heap(char const *s)
   Field (result, wosize - 1) = 0;
   offset_index = Bsize_wsize (wosize) - 1;
   Byte (result, offset_index) = offset_index - len;
-  memmove(String_val(result), s, len);
+  memmove(Bytes_val(result), s, len);
 
   return result;
 }


### PR DESCRIPTION
This patch fixes compilation of the Spacetime runtime when `-force-safe-string` has been specified to `configure`.