### PR TITLE
caml.el: use conventional permission statement

### DIFF
--- a/emacs/caml.el
+++ b/emacs/caml.el
@@ -12,9 +12,17 @@
 ;; This file is not part of GNU Emacs.
 
 ;; This file is free software; you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published
-;; by the Free Software Foundation; either version 2, or (at your
-;; option) any later version.  See <http://www.gnu.org/licenses/>.
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 


### PR DESCRIPTION
This helps tools that try to extract the used license.  The text used
before was derived from the permission statement that is usually used
and it was not unreasonable, but `elx-license` [and likely other such tools] would still have
required a special case for just this one package.