### PR TITLE
MPR#7652: Restore accidentally hidden functions in misc.h

### DIFF
--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -351,6 +351,10 @@ extern void caml_ext_table_clear(struct ext_table * tbl, int free_entries);
 
 CAMLextern int caml_read_directory(char_os * dirname, struct ext_table * contents);
 
+/* Deprecated aliases */
+#define caml_aligned_malloc caml_stat_alloc_aligned_noexc
+#define caml_strdup caml_stat_strdup
+#define caml_strconcat caml_stat_strconcat
 
 #ifdef CAML_INTERNALS
 
@@ -366,11 +370,6 @@ void caml_gc_message (int, char *, ...)
 /* Runtime warnings */
 extern uintnat caml_runtime_warnings;
 int caml_runtime_warnings_active(void);
-
-/* Deprecated aliases */
-#define caml_aligned_malloc caml_stat_alloc_aligned_noexc
-#define caml_strdup caml_stat_strdup
-#define caml_strconcat caml_stat_strconcat
 
 #ifdef DEBUG
 #ifdef ARCH_SIXTYFOUR


### PR DESCRIPTION
These compatibility aliases were accidentally moved into CAML_INTERNALS in #71.

Fixes [MPR#7652](https://caml.inria.fr/mantis/view.php?id=7652).