### PR TITLE
Improve error handling while running the testsuite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,6 +241,7 @@ _ocamltest
 /testsuite/**/*.native
 /testsuite/**/program
 /testsuite/**/_log
+/testsuite/failure.stamp
 
 /testsuite/_retries
 

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -39,6 +39,8 @@ else # Windows
   endif
 endif
 
+failstamp := failure.stamp
+
 ocamltest_directory := ../ocamltest
 
 ocamltest_program := $(or \
@@ -97,14 +99,17 @@ new:
 
 .PHONY: new-without-report
 new-without-report: lib tools
-	@for file in `$(find) tests -name ocamltests`; do \
+	@rm -f $(failstamp)
+	@(for file in `$(find) tests -name ocamltests`; do \
 	  dir=`dirname $$file`; \
 	  echo Running tests from \'$$dir\' ... ; \
-	  IFS=$$(printf "\r\n"); while read testfile; do \
+	  (IFS=$$(printf "\r\n"); while read testfile; do \
 	    TERM=dumb OCAMLRUNPARAM= \
-	      $(ocamltest) $$dir/$$testfile; \
-	  done < $$file; \
-	done 2>&1 | tee -a _log
+	      $(ocamltest) $$dir/$$testfile || \
+	      touch $(failstamp); \
+	  done < $$file) || touch $(failstamp); \
+	done || touch $(failstamp)) 2>&1 | tee -a _log
+	@if [ -f $(failstamp) ]; then rm $(failstamp); exit 1; fi
 
 .PHONY: all-%
 all-%: lib tools
@@ -236,6 +241,7 @@ clean:
 	  (cd `dirname $$file` && $(MAKE) BASEDIR=$(BASEDIR) clean); \
 	done
 	$(FIND) . -name '*_ocamltest*' | xargs rm -rf
+	rm -f $(failstamp)
 
 .PHONY: report
 report:


### PR DESCRIPTION
Since the output of ocamltest is piped, it is not possible to access its
exit code, especially under Posix-compliant shells like dash which
do not provide an equivalent to Bash's pipefail option.

This commit thus uses a stamp file which is created when a test fails.
If this file exists after all the tests have been run, an error is
reported.

As a reminder, PR #1280 introduced a bashism. This should have been caught
by Travis which uses dash, a
Posix-compliant shell which does not accept bashisms.

The intent of this PR is to make CI catch such bashisms and fail, so
the expected result is that Travis is broken.

Once this PR has been merged, merging PR #1441 should bring Travis back to
working.