### PR TITLE
Enable UTF-8 on Windows 10 Console (Mark #2)

### DIFF
--- a/Changes
+++ b/Changes
@@ -513,7 +513,7 @@ Release branch for 4.06:
 - GPR#1338: Add "-g" for bytecode runtime system compilation
   (Mark Shinwell)
 
-* GPR#1416: switch the Windows 10 Console to UTF-8 encoding.
+* GPR#1416, GPR#1444: switch the Windows 10 Console to UTF-8 encoding.
   (David Allsopp, reviews by Nicolás Ojeda Bär and Xavier Leroy)
 
 - MPR#7658, GPR#1439: Fix Spacetime runtime system compilation with

--- a/byterun/caml/osdeps.h
+++ b/byterun/caml/osdeps.h
@@ -104,6 +104,7 @@ extern int caml_win32_rename(const wchar_t *, const wchar_t *);
 
 extern void caml_probe_win32_version(void);
 extern void caml_setup_win32_terminal(void);
+extern void caml_restore_win32_terminal(void);
 
 /* Windows Unicode support */
 

--- a/byterun/sys.c
+++ b/byterun/sys.c
@@ -154,6 +154,9 @@ CAMLprim value caml_sys_exit(value retcode_v)
   CAML_INSTR_ATEXIT ();
   if (caml_cleanup_on_exit)
     caml_shutdown();
+#ifdef _WIN32
+  caml_restore_win32_terminal();
+#endif
   CAML_SYS_EXIT(retcode);
   return Val_unit;
 }

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -898,8 +898,19 @@ void caml_probe_win32_version(void)
   free(versionInfo);
 }
 
+static UINT startup_codepage = 0;
+
 void caml_setup_win32_terminal(void)
 {
-  if (caml_win32_major >= 10)
-    SetConsoleOutputCP(CP_UTF8);
+  if (caml_win32_major >= 10) {
+    startup_codepage = GetConsoleOutputCP();
+    if (startup_codepage != CP_UTF8)
+      SetConsoleOutputCP(CP_UTF8);
+  }
+}
+
+void caml_restore_win32_terminal(void)
+{
+  if (startup_codepage != 0)
+    SetConsoleOutputCP(startup_codepage);
 }

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -890,10 +890,10 @@ void caml_probe_win32_version(void)
     UINT len = 0;
     VS_FIXEDFILEINFO* vsfi = NULL;
     VerQueryValue(versionInfo, L"\\", (void**)&vsfi, &len);
-    caml_win32_major = HIWORD(vsfi->dwFileVersionMS);
-    caml_win32_minor = LOWORD(vsfi->dwFileVersionMS);
-    caml_win32_build = HIWORD(vsfi->dwFileVersionLS);
-    caml_win32_revision = LOWORD(vsfi->dwFileVersionLS);
+    caml_win32_major = HIWORD(vsfi->dwProductVersionMS);
+    caml_win32_minor = LOWORD(vsfi->dwProductVersionMS);
+    caml_win32_build = HIWORD(vsfi->dwProductVersionLS);
+    caml_win32_revision = LOWORD(vsfi->dwProductVersionLS);
   }
   free(versionInfo);
 }


### PR DESCRIPTION
This GPR started out while trying *finally* to write a blog post about the new Unicode features on Windows which subsequently turned into a case of Dolan's Rabbithole...

This may well want splitting up - and must not be merged as is (the submodule update in 742df2c is not merged upstream). The following things are addressed:

 - `Unix.access` was not upgraded to use char_os in #1200. This is fixed (with test case) in b59395f and must certainly go in 4.06.0
 - There is already trickery in `byterun/Makefile` to allow `OCAML_STDLIB_DIR` to be available in C files when compiling on Windows, but this fails if it contains Unicode code points which don't fit the system locale (so 1252 on my system). The patch in bb1419e uses a little trick with GNU iconv (which is part of the base installation on Cygwin and is only used in the Windows build system, so it should be low/no risk to depend on it) to convert the string to Java format and then translate the escapes from that to be compatible with both cl and mingw (TL;DR, the string gets encoded in C99 \uHHHH format, with surrogates and then the \u is translated to \x which works on older Microsoft C compilers)
 - Most embarrassingly (for me), when #1408 was being split up to create #1416, my testing was clearly insufficient on Windows 10. The console changes in #1416 will only activate if the compiled executable is updated to have a Windows 10/Server 2016 manifest, as the field which was being read from the version information in kernel32.dll is subject to the same shim which affects `GetVersionEx`. The fix is simple in 7e31f50. On the basis that the behaviour of #1416 was agreed, I would consider this a bug-fix for 4.06.0, but please read on
 - Further investigation of `SetConsoleOutputCP` has shown that although cmd's chcp command appears to report that the code page is restored after a process has ended, this isn't the case (Cmd appears to have cached what it thinks the code page is, and doesn't notice). This means that the runtime should restore the code page when it shuts down - this is done in a737357. **This wasn't considered in #1416**. I'd obviously quite like it to go in, but I can see an argument could be that the change in #1416 is presently inactive, so both these commits could be deferred (dra27 makes a pleading face across the channel).
 - I found most of these issues both by compiling OCaml with a PREFIX containing UTF-8 sequences and, as additional torture, even building OCaml in a directory which itself contains UTF-8 sequences. It seems we should do this on AppVeyor. This has led to https://github.com/alainfrisch/flexdll/pull/47. I don't think we should be advertising a release of OCaml which depends on a tool with a faulty UTF-16 encoder, so I think we should be aiming to switch OCaml 4.06.0 to depend on a not-yet-released FlexDLL 0.37 (cc @alainfrisch). 742df2c is a temporary switch to use this patch and points AppVeyor temporarily at my fork of FlexDLL. **That should clearly not be merged.**
 - Passing UTF-8 between appveyor.yml, Cmd and Bash is really painful! 53b9c66, ee9dc6b and 9cd4f9e make minor tweaks so that OCAMLROOT and OCAMLROOT2 can be painlessly dropped with fairly minimal duplication of the constants between those 3 files in 9f4cf36 which then sets up the UTF-8 tortuous builds. The resulting log file in AppVeyor is riddled with :camel:s in a most visually pleasing fashion... it built successfully on my private run of this, so it had better work now...

cc @gasche, @damiendoligez, @nojb
