### PR TITLE
Translate OCAML_STDLIB_DIR correctly on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -463,7 +463,7 @@ Release branch for 4.06:
 ### Runtime system:
 
 * MPR#3771, GPR#153, GPR#1200, GPR#1357, GPR#1362, GPR#1363, GPR#1369, GPR#1398,
-  GPR#1446: Unicode support for the Windows runtime.
+  GPR#1446, GPR#1448: Unicode support for the Windows runtime.
   (ygrek, Nicolas Ojeda Bar, review by Alain Frisch, David Allsopp, Damien
   Doligez)
 

--- a/byterun/Makefile
+++ b/byterun/Makefile
@@ -49,7 +49,17 @@ endif
 # On Windows, OCAML_STDLIB_DIR needs to be defined dynamically
 
 ifeq "$(UNIX_OR_WIN32)" "win32"
-CFLAGS += -DOCAML_STDLIB_DIR='"$(LIBDIR)"'
+# OCAML_STDLIB_DIR needs to arrive in dynlink.c as a string which both gcc and
+# msvc are willing parse without warning. This means we can't pass UTF-8
+# directly since, as far as I can tell, cl can cope, but the pre-processor
+# can't. So the string needs to be directly translated to L"" form. To do this,
+# we take advantage of the fact that Cygwin uses GNU libiconv which includes a
+# Java pseudo-encoding which translates any UTF-8 sequences to \uXXXX (and,
+# unlike the C99 pseudo-encoding, emits two surrogate values when needed, rather
+# than \UXXXXXXXX). The \u is then translated to \x in order to accommodate
+# pre-Visual Studio 2013 compilers where \x is a non-standard alias for \u.
+OCAML_STDLIB_DIR = $(shell echo $(LIBDIR)| iconv -t JAVA | sed -e 's/\\u/\\x/g')
+CFLAGS += -DOCAML_STDLIB_DIR='L"$(OCAML_STDLIB_DIR)"'
 endif
 
 CFLAGS += $(IFLEXDIR)

--- a/byterun/dynlink.c
+++ b/byterun/dynlink.c
@@ -77,7 +77,7 @@ static c_primitive lookup_primitive(char * name)
 
 static char_os * parse_ld_conf(void)
 {
-  char_os * stdlib, * ldconfname, * wconfig, * p, * q, * tofree = NULL;
+  char_os * stdlib, * ldconfname, * wconfig, * p, * q;
   char * config;
 #ifdef _WIN32
   struct _stati64 st;
@@ -88,9 +88,8 @@ static char_os * parse_ld_conf(void)
 
   stdlib = caml_secure_getenv(_T("OCAMLLIB"));
   if (stdlib == NULL) stdlib = caml_secure_getenv(_T("CAMLLIB"));
-  if (stdlib == NULL) stdlib = tofree = caml_stat_strdup_to_os(OCAML_STDLIB_DIR);
+  if (stdlib == NULL) stdlib = OCAML_STDLIB_DIR;
   ldconfname = caml_stat_strconcat_os(3, stdlib, _T("/"), LD_CONF_NAME);
-  if (tofree != NULL) caml_stat_free(tofree);
   if (stat_os(ldconfname, &st) == -1) {
     caml_stat_free(ldconfname);
     return NULL;


### PR DESCRIPTION
See #1444.

Certainly for trunk. I agree with @gasche that describing this as build system change was a bit of a stretch. What is eliminated in byterun/dynlink.c is the copying of the string constant supplied by the build system, because the build system is altered to pass the string as UTF-8 in the first place.

The change eliminates a compiler warning emitted by cl if OCaml is compiled in a directory which includes UTF-8 sequences.