### PR TITLE
Use linscan and disable CSE for the intialization function

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -80,7 +80,7 @@ let rec regalloc ppf round fd =
     fatal_error(fd.Mach.fun_name ^
                 ": function too complex, cannot complete register allocation");
   dump_if ppf dump_live "Liveness analysis" fd;
-  if !use_linscan then begin
+  if !use_linscan || fd.Mach.fun_fast_compile then begin
     (* Linear Scan *)
     Interval.build_intervals fd;
     if !dump_interval then Printmach.intervals ppf ();
@@ -99,6 +99,12 @@ let rec regalloc ppf round fd =
     Reg.reinit(); Liveness.fundecl ppf newfd; regalloc ppf (round + 1) newfd
   end else newfd
 
+let cse fd =
+  if fd.Mach.fun_fast_compile then
+    fd
+  else
+    CSE.fundecl fd
+
 let (++) x f = f x
 
 let compile_fundecl (ppf : formatter) fd_cmm =
@@ -109,7 +115,7 @@ let compile_fundecl (ppf : formatter) fd_cmm =
   ++ pass_dump_if ppf dump_selection "After instruction selection"
   ++ Profile.record ~accumulate:true "comballoc" Comballoc.fundecl
   ++ pass_dump_if ppf dump_combine "After allocation combining"
-  ++ Profile.record ~accumulate:true "cse" CSE.fundecl
+  ++ Profile.record ~accumulate:true "cse" cse
   ++ pass_dump_if ppf dump_cse "After CSE"
   ++ Profile.record ~accumulate:true "liveness" (liveness ppf)
   ++ Profile.record ~accumulate:true "deadcode" Deadcode.fundecl

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -178,6 +178,7 @@ type fundecl =
     fun_args: (Ident.t * machtype) list;
     fun_body: expression;
     fun_fast: bool;
+    fun_fast_compile: bool;
     fun_dbg : Debuginfo.t;
   }
 

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -154,6 +154,7 @@ type fundecl =
     fun_args: (Ident.t * machtype) list;
     fun_body: expression;
     fun_fast: bool;
+    fun_fast_compile: bool;
     fun_dbg : Debuginfo.t;
   }
 

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2807,6 +2807,7 @@ let transl_function f =
              fun_args = List.map (fun id -> (id, typ_val)) f.params;
              fun_body = cmm_body;
              fun_fast = !Clflags.optimize_for_speed;
+             fun_fast_compile = false;
              fun_dbg  = f.dbg}
 
 (* Translate all function definitions *)
@@ -3060,6 +3061,7 @@ let compunit (ulam, preallocated_blocks, constants) =
   let c1 = [Cfunction {fun_name = Compilenv.make_symbol (Some "entry");
                        fun_args = [];
                        fun_body = init_code; fun_fast = false;
+                       fun_fast_compile = true;
                        fun_dbg  = Debuginfo.none }] in
   let c2 = emit_constants c1 constants in
   let c3 = transl_all_functions_and_emit_all_constants c2 in
@@ -3201,6 +3203,7 @@ let send_function arity =
     fun_args = fun_args;
     fun_body = body;
     fun_fast = true;
+    fun_fast_compile = false;
     fun_dbg  = Debuginfo.none }
 
 let apply_function arity =
@@ -3212,6 +3215,7 @@ let apply_function arity =
     fun_args = List.map (fun id -> (id, typ_val)) all_args;
     fun_body = body;
     fun_fast = true;
+    fun_fast_compile = false;
     fun_dbg  = Debuginfo.none;
    }
 
@@ -3237,6 +3241,7 @@ let tuplify_function arity =
           get_field env (Cvar clos) 2 dbg :: access_components 0 @ [Cvar clos],
           dbg);
     fun_fast = true;
+    fun_fast_compile = false;
     fun_dbg  = Debuginfo.none;
    }
 
@@ -3300,6 +3305,7 @@ let final_curry_function arity =
     fun_args = [last_arg, typ_val; last_clos, typ_val];
     fun_body = curry_fun [] last_clos (arity-1);
     fun_fast = true;
+    fun_fast_compile = false;
     fun_dbg  = Debuginfo.none }
 
 let rec intermediate_curry_functions arity num =
@@ -3330,6 +3336,7 @@ let rec intermediate_curry_functions arity num =
                  int_const 1; Cvar arg; Cvar clos],
                 dbg);
       fun_fast = true;
+      fun_fast_compile = false;
       fun_dbg  = Debuginfo.none }
     ::
       (if arity <= max_arity_optimized && arity - num > 2 then
@@ -3358,6 +3365,7 @@ let rec intermediate_curry_functions arity num =
                fun_body = iter (num+1)
                   (List.map (fun (arg,_) -> Cvar arg) direct_args) clos;
                fun_fast = true;
+               fun_fast_compile = false;
                fun_dbg = Debuginfo.none }
           in
           cf :: intermediate_curry_functions arity (num+1)
@@ -3421,6 +3429,7 @@ let entry_point namelist =
              fun_args = [];
              fun_body = body;
              fun_fast = false;
+             fun_fast_compile = false;
              fun_dbg  = Debuginfo.none }
 
 (* Generate the table of globals *)

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -97,6 +97,7 @@ type fundecl =
     fun_args: Reg.t array;
     fun_body: instruction;
     fun_fast: bool;
+    fun_fast_compile: bool;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : spacetime_shape option;
   }

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -119,6 +119,7 @@ type fundecl =
     fun_args: Reg.t array;
     fun_body: instruction;
     fun_fast: bool;
+    fun_fast_compile: bool;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : spacetime_shape option;
   }

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -130,6 +130,7 @@ method fundecl f =
   let new_body = self#reload f.fun_body in
   ({fun_name = f.fun_name; fun_args = f.fun_args;
     fun_body = new_body; fun_fast = f.fun_fast;
+    fun_fast_compile = f.fun_fast_compile;
     fun_dbg  = f.fun_dbg; fun_spacetime_shape = f.fun_spacetime_shape},
    redo_regalloc)
 end

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -1217,6 +1217,7 @@ method emit_fundecl f =
     fun_body = body;
     fun_fast = f.Cmm.fun_fast;
     fun_dbg  = f.Cmm.fun_dbg;
+    fun_fast_compile = f.Cmm.fun_fast_compile;
     fun_spacetime_shape;
   }
 

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -473,5 +473,6 @@ let fundecl f =
     fun_body = new_body;
     fun_fast = f.fun_fast;
     fun_dbg  = f.fun_dbg;
+    fun_fast_compile = f.fun_fast_compile;
     fun_spacetime_shape = f.fun_spacetime_shape;
   }

--- a/asmcomp/split.ml
+++ b/asmcomp/split.ml
@@ -223,5 +223,6 @@ let fundecl f =
     fun_body = new_body;
     fun_fast = f.fun_fast;
     fun_dbg  = f.fun_dbg;
+    fun_fast_compile = f.fun_fast_compile;
     fun_spacetime_shape = f.fun_spacetime_shape;
   }


### PR DESCRIPTION
The initialization function runs only once and can be extremely large. It might be a sensible trade-of to disable the costly optimizations on it. This function was already compile with the equivalent of -compact, disabling some allocation optimization for reduced code size.

This allows compiling some over-sized Coq-generated files without using too much memory or time with flambda.