### PR TITLE
Disable CSE for the initialization function

### DIFF
--- a/Changes
+++ b/Changes
@@ -129,6 +129,10 @@ Working version
   Pierre-Marie Pédrot and Paul Steckler, review by Gabriel Scherer
   and Leo White)
 
+- MPR#7630, GPR#1455: Disable CSE for the initialization function
+  (Pierre Chambart, report by Emilio Jesús Gallego Arias,
+   review by Gabriel Scherer and Xavier Leroy)
+
 - GPR#1486: ARM 32-bit port: add support for ARMv8 in 32-bit mode,
   a.k.a. AArch32.
   For this platform, avoid ITE conditional instruction blocks and use

--- a/asmcomp/CSEgen.ml
+++ b/asmcomp/CSEgen.ml
@@ -362,6 +362,10 @@ method private cse n i =
               next = self#cse empty_numbering i.next}
 
 method fundecl f =
-  {f with fun_body = self#cse empty_numbering f.fun_body}
+  (* CSE can trigger bad register allocation behaviors, see MPR#7630 *)
+  if List.mem Cmm.No_CSE f.fun_codegen_options then
+    f
+  else
+    {f with fun_body = self#cse empty_numbering f.fun_body }
 
 end

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -99,6 +99,12 @@ let rec regalloc ppf round fd =
     Reg.reinit(); Liveness.fundecl ppf newfd; regalloc ppf (round + 1) newfd
   end else newfd
 
+let cse fd =
+  if fd.Mach.fun_fast_compile then
+    fd
+  else
+    CSE.fundecl fd
+
 let (++) x f = f x
 
 let compile_fundecl (ppf : formatter) fd_cmm =
@@ -109,7 +115,7 @@ let compile_fundecl (ppf : formatter) fd_cmm =
   ++ pass_dump_if ppf dump_selection "After instruction selection"
   ++ Profile.record ~accumulate:true "comballoc" Comballoc.fundecl
   ++ pass_dump_if ppf dump_combine "After allocation combining"
-  ++ Profile.record ~accumulate:true "cse" CSE.fundecl
+  ++ Profile.record ~accumulate:true "cse" cse
   ++ pass_dump_if ppf dump_cse "After CSE"
   ++ Profile.record ~accumulate:true "liveness" (liveness ppf)
   ++ Profile.record ~accumulate:true "deadcode" Deadcode.fundecl

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -101,7 +101,7 @@ let rec regalloc ppf round fd =
 
 let cse fd =
   (* CSE can trigger bad register allocation behaviors, see MPR#7630 *)
-  if fd.Mach.fun_fast_compile then
+  if fd.Mach.fun_fast_compile && Config.flambda then
     fd
   else
     CSE.fundecl fd

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -100,6 +100,7 @@ let rec regalloc ppf round fd =
   end else newfd
 
 let cse fd =
+  (* CSE can trigger bad register allocation behaviors, see MPR#7630 *)
   if fd.Mach.fun_fast_compile then
     fd
   else

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -101,7 +101,7 @@ let rec regalloc ppf round fd =
 
 let cse fd =
   (* CSE can trigger bad register allocation behaviors, see MPR#7630 *)
-  if fd.Mach.fun_fast_compile && Config.flambda then
+  if List.mem Cmm.No_CSE fd.Mach.fun_codegen_options then
     fd
   else
     CSE.fundecl fd

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -99,13 +99,6 @@ let rec regalloc ppf round fd =
     Reg.reinit(); Liveness.fundecl ppf newfd; regalloc ppf (round + 1) newfd
   end else newfd
 
-let cse fd =
-  (* CSE can trigger bad register allocation behaviors, see MPR#7630 *)
-  if List.mem Cmm.No_CSE fd.Mach.fun_codegen_options then
-    fd
-  else
-    CSE.fundecl fd
-
 let (++) x f = f x
 
 let compile_fundecl (ppf : formatter) fd_cmm =
@@ -116,7 +109,7 @@ let compile_fundecl (ppf : formatter) fd_cmm =
   ++ pass_dump_if ppf dump_selection "After instruction selection"
   ++ Profile.record ~accumulate:true "comballoc" Comballoc.fundecl
   ++ pass_dump_if ppf dump_combine "After allocation combining"
-  ++ Profile.record ~accumulate:true "cse" cse
+  ++ Profile.record ~accumulate:true "cse" CSE.fundecl
   ++ pass_dump_if ppf dump_cse "After CSE"
   ++ Profile.record ~accumulate:true "liveness" (liveness ppf)
   ++ Profile.record ~accumulate:true "deadcode" Deadcode.fundecl

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -175,6 +175,7 @@ type fundecl =
     fun_args: (Ident.t * machtype) list;
     fun_body: expression;
     fun_fast: bool;
+    fun_fast_compile: bool;
     fun_dbg : Debuginfo.t;
   }
 

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -170,12 +170,15 @@ type expression =
   | Cexit of int * expression list
   | Ctrywith of expression * Ident.t * expression
 
+type codegen_option =
+  | Reduce_code_size
+  | No_CSE
+
 type fundecl =
   { fun_name: string;
     fun_args: (Ident.t * machtype) list;
     fun_body: expression;
-    fun_fast: bool;
-    fun_fast_compile: bool;
+    fun_codegen_options : codegen_option list;
     fun_dbg : Debuginfo.t;
   }
 

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -155,6 +155,7 @@ type fundecl =
     fun_args: (Ident.t * machtype) list;
     fun_body: expression;
     fun_fast: bool;
+    fun_fast_compile: bool;
     fun_dbg : Debuginfo.t;
   }
 

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -150,12 +150,15 @@ and expression =
   | Cexit of int * expression list
   | Ctrywith of expression * Ident.t * expression
 
+type codegen_option =
+  | Reduce_code_size
+  | No_CSE
+
 type fundecl =
   { fun_name: string;
     fun_args: (Ident.t * machtype) list;
     fun_body: expression;
-    fun_fast: bool;
-    fun_fast_compile: bool;
+    fun_codegen_options : codegen_option list;
     fun_dbg : Debuginfo.t;
   }
 

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -3090,6 +3090,9 @@ let compunit (ulam, preallocated_blocks, constants) =
   let c1 = [Cfunction {fun_name = Compilenv.make_symbol (Some "entry");
                        fun_args = [];
                        fun_body = init_code; fun_fast = false;
+                       (* This function is often large and run only once.
+                          Compilation time matter more than runtime.
+                          See MPR#7630 *)
                        fun_fast_compile = true;
                        fun_dbg  = Debuginfo.none }] in
   let c2 = emit_constants c1 constants in

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2826,11 +2826,16 @@ let transl_function f =
       Afl_instrument.instrument_function (transl env body)
     else
       transl env body in
+  let fun_codegen_options =
+    if !Clflags.optimize_for_speed then
+      [ Reduce_code_size ]
+    else
+      []
+  in
   Cfunction {fun_name = f.label;
              fun_args = List.map (fun id -> (id, typ_val)) f.params;
              fun_body = cmm_body;
-             fun_fast = !Clflags.optimize_for_speed;
-             fun_fast_compile = false;
+             fun_codegen_options;
              fun_dbg  = f.dbg}
 
 (* Translate all function definitions *)
@@ -3089,11 +3094,16 @@ let compunit (ulam, preallocated_blocks, constants) =
       transl empty_env ulam in
   let c1 = [Cfunction {fun_name = Compilenv.make_symbol (Some "entry");
                        fun_args = [];
-                       fun_body = init_code; fun_fast = false;
+                       fun_body = init_code;
                        (* This function is often large and run only once.
                           Compilation time matter more than runtime.
                           See MPR#7630 *)
-                       fun_fast_compile = true;
+                       fun_codegen_options =
+                         if Config.flambda then [
+                           Reduce_code_size;
+                           No_CSE;
+                         ]
+                         else [ Reduce_code_size ];
                        fun_dbg  = Debuginfo.none }] in
   let c2 = emit_constants c1 constants in
   let c3 = transl_all_functions_and_emit_all_constants c2 in
@@ -3234,8 +3244,7 @@ let send_function arity =
    {fun_name;
     fun_args = fun_args;
     fun_body = body;
-    fun_fast = true;
-    fun_fast_compile = false;
+    fun_codegen_options = [];
     fun_dbg  = Debuginfo.none }
 
 let apply_function arity =
@@ -3246,8 +3255,7 @@ let apply_function arity =
    {fun_name;
     fun_args = List.map (fun id -> (id, typ_val)) all_args;
     fun_body = body;
-    fun_fast = true;
-    fun_fast_compile = false;
+    fun_codegen_options = [];
     fun_dbg  = Debuginfo.none;
    }
 
@@ -3272,8 +3280,7 @@ let tuplify_function arity =
       Cop(Capply typ_val,
           get_field env (Cvar clos) 2 dbg :: access_components 0 @ [Cvar clos],
           dbg);
-    fun_fast = true;
-    fun_fast_compile = false;
+    fun_codegen_options = [];
     fun_dbg  = Debuginfo.none;
    }
 
@@ -3336,8 +3343,7 @@ let final_curry_function arity =
                "_" ^ string_of_int (arity-1);
     fun_args = [last_arg, typ_val; last_clos, typ_val];
     fun_body = curry_fun [] last_clos (arity-1);
-    fun_fast = true;
-    fun_fast_compile = false;
+    fun_codegen_options = [];
     fun_dbg  = Debuginfo.none }
 
 let rec intermediate_curry_functions arity num =
@@ -3367,8 +3373,7 @@ let rec intermediate_curry_functions arity num =
                  Cconst_symbol(name1 ^ "_" ^ string_of_int (num+1));
                  int_const 1; Cvar arg; Cvar clos],
                 dbg);
-      fun_fast = true;
-      fun_fast_compile = false;
+      fun_codegen_options = [];
       fun_dbg  = Debuginfo.none }
     ::
       (if arity <= max_arity_optimized && arity - num > 2 then
@@ -3396,8 +3401,7 @@ let rec intermediate_curry_functions arity num =
                fun_args = direct_args @ [clos, typ_val];
                fun_body = iter (num+1)
                   (List.map (fun (arg,_) -> Cvar arg) direct_args) clos;
-               fun_fast = true;
-               fun_fast_compile = false;
+               fun_codegen_options = [];
                fun_dbg = Debuginfo.none }
           in
           cf :: intermediate_curry_functions arity (num+1)
@@ -3460,8 +3464,7 @@ let entry_point namelist =
   Cfunction {fun_name = "caml_program";
              fun_args = [];
              fun_body = body;
-             fun_fast = false;
-             fun_fast_compile = false;
+             fun_codegen_options = [Reduce_code_size];
              fun_dbg  = Debuginfo.none }
 
 (* Generate the table of globals *)

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2830,6 +2830,7 @@ let transl_function f =
              fun_args = List.map (fun id -> (id, typ_val)) f.params;
              fun_body = cmm_body;
              fun_fast = !Clflags.optimize_for_speed;
+             fun_fast_compile = false;
              fun_dbg  = f.dbg}
 
 (* Translate all function definitions *)
@@ -3089,6 +3090,7 @@ let compunit (ulam, preallocated_blocks, constants) =
   let c1 = [Cfunction {fun_name = Compilenv.make_symbol (Some "entry");
                        fun_args = [];
                        fun_body = init_code; fun_fast = false;
+                       fun_fast_compile = true;
                        fun_dbg  = Debuginfo.none }] in
   let c2 = emit_constants c1 constants in
   let c3 = transl_all_functions_and_emit_all_constants c2 in
@@ -3230,6 +3232,7 @@ let send_function arity =
     fun_args = fun_args;
     fun_body = body;
     fun_fast = true;
+    fun_fast_compile = false;
     fun_dbg  = Debuginfo.none }
 
 let apply_function arity =
@@ -3241,6 +3244,7 @@ let apply_function arity =
     fun_args = List.map (fun id -> (id, typ_val)) all_args;
     fun_body = body;
     fun_fast = true;
+    fun_fast_compile = false;
     fun_dbg  = Debuginfo.none;
    }
 
@@ -3266,6 +3270,7 @@ let tuplify_function arity =
           get_field env (Cvar clos) 2 dbg :: access_components 0 @ [Cvar clos],
           dbg);
     fun_fast = true;
+    fun_fast_compile = false;
     fun_dbg  = Debuginfo.none;
    }
 
@@ -3329,6 +3334,7 @@ let final_curry_function arity =
     fun_args = [last_arg, typ_val; last_clos, typ_val];
     fun_body = curry_fun [] last_clos (arity-1);
     fun_fast = true;
+    fun_fast_compile = false;
     fun_dbg  = Debuginfo.none }
 
 let rec intermediate_curry_functions arity num =
@@ -3359,6 +3365,7 @@ let rec intermediate_curry_functions arity num =
                  int_const 1; Cvar arg; Cvar clos],
                 dbg);
       fun_fast = true;
+      fun_fast_compile = false;
       fun_dbg  = Debuginfo.none }
     ::
       (if arity <= max_arity_optimized && arity - num > 2 then
@@ -3387,6 +3394,7 @@ let rec intermediate_curry_functions arity num =
                fun_body = iter (num+1)
                   (List.map (fun (arg,_) -> Cvar arg) direct_args) clos;
                fun_fast = true;
+               fun_fast_compile = false;
                fun_dbg = Debuginfo.none }
           in
           cf :: intermediate_curry_functions arity (num+1)
@@ -3450,6 +3458,7 @@ let entry_point namelist =
              fun_args = [];
              fun_body = body;
              fun_fast = false;
+             fun_fast_compile = false;
              fun_dbg  = Debuginfo.none }
 
 (* Generate the table of globals *)

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2828,9 +2828,9 @@ let transl_function f =
       transl env body in
   let fun_codegen_options =
     if !Clflags.optimize_for_speed then
-      [ Reduce_code_size ]
-    else
       []
+    else
+      [ Reduce_code_size ]
   in
   Cfunction {fun_name = f.label;
              fun_args = List.map (fun id -> (id, typ_val)) f.params;

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -311,7 +311,7 @@ let rec linear i n =
 let fundecl f =
   { fun_name = f.Mach.fun_name;
     fun_body = linear f.Mach.fun_body end_instr;
-    fun_fast = f.Mach.fun_fast;
+    fun_fast = List.mem Cmm.Reduce_code_size f.Mach.fun_codegen_options;
     fun_dbg  = f.Mach.fun_dbg;
     fun_spacetime_shape = f.Mach.fun_spacetime_shape;
   }

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -311,7 +311,7 @@ let rec linear i n =
 let fundecl f =
   { fun_name = f.Mach.fun_name;
     fun_body = linear f.Mach.fun_body end_instr;
-    fun_fast = List.mem Cmm.Reduce_code_size f.Mach.fun_codegen_options;
+    fun_fast = not (List.mem Cmm.Reduce_code_size f.Mach.fun_codegen_options);
     fun_dbg  = f.Mach.fun_dbg;
     fun_spacetime_shape = f.Mach.fun_spacetime_shape;
   }

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -99,6 +99,7 @@ type fundecl =
     fun_args: Reg.t array;
     fun_body: instruction;
     fun_fast: bool;
+    fun_fast_compile: bool;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : spacetime_shape option;
   }

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -98,8 +98,7 @@ type fundecl =
   { fun_name: string;
     fun_args: Reg.t array;
     fun_body: instruction;
-    fun_fast: bool;
-    fun_fast_compile: bool;
+    fun_codegen_options : Cmm.codegen_option list;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : spacetime_shape option;
   }

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -121,6 +121,7 @@ type fundecl =
     fun_args: Reg.t array;
     fun_body: instruction;
     fun_fast: bool;
+    fun_fast_compile: bool;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : spacetime_shape option;
   }

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -120,8 +120,7 @@ type fundecl =
   { fun_name: string;
     fun_args: Reg.t array;
     fun_body: instruction;
-    fun_fast: bool;
-    fun_fast_compile: bool;
+    fun_codegen_options : Cmm.codegen_option list;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : spacetime_shape option;
   }

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -130,6 +130,7 @@ method fundecl f =
   let new_body = self#reload f.fun_body in
   ({fun_name = f.fun_name; fun_args = f.fun_args;
     fun_body = new_body; fun_fast = f.fun_fast;
+    fun_fast_compile = f.fun_fast_compile;
     fun_dbg  = f.fun_dbg; fun_spacetime_shape = f.fun_spacetime_shape},
    redo_regalloc)
 end

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -129,8 +129,7 @@ method fundecl f =
   redo_regalloc <- false;
   let new_body = self#reload f.fun_body in
   ({fun_name = f.fun_name; fun_args = f.fun_args;
-    fun_body = new_body; fun_fast = f.fun_fast;
-    fun_fast_compile = f.fun_fast_compile;
+    fun_body = new_body; fun_codegen_options = f.fun_codegen_options;
     fun_dbg  = f.fun_dbg; fun_spacetime_shape = f.fun_spacetime_shape},
    redo_regalloc)
 end

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -1217,6 +1217,7 @@ method emit_fundecl f =
     fun_body = body;
     fun_fast = f.Cmm.fun_fast;
     fun_dbg  = f.Cmm.fun_dbg;
+    fun_fast_compile = f.Cmm.fun_fast_compile;
     fun_spacetime_shape;
   }
 

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -1215,9 +1215,8 @@ method emit_fundecl f =
   { fun_name = f.Cmm.fun_name;
     fun_args = loc_arg;
     fun_body = body;
-    fun_fast = f.Cmm.fun_fast;
+    fun_codegen_options = f.Cmm.fun_codegen_options;
     fun_dbg  = f.Cmm.fun_dbg;
-    fun_fast_compile = f.Cmm.fun_fast_compile;
     fun_spacetime_shape;
   }
 

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -471,8 +471,7 @@ let fundecl f =
   { fun_name = f.fun_name;
     fun_args = f.fun_args;
     fun_body = new_body;
-    fun_fast = f.fun_fast;
+    fun_codegen_options = f.fun_codegen_options;
     fun_dbg  = f.fun_dbg;
-    fun_fast_compile = f.fun_fast_compile;
     fun_spacetime_shape = f.fun_spacetime_shape;
   }

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -473,5 +473,6 @@ let fundecl f =
     fun_body = new_body;
     fun_fast = f.fun_fast;
     fun_dbg  = f.fun_dbg;
+    fun_fast_compile = f.fun_fast_compile;
     fun_spacetime_shape = f.fun_spacetime_shape;
   }

--- a/asmcomp/split.ml
+++ b/asmcomp/split.ml
@@ -223,5 +223,6 @@ let fundecl f =
     fun_body = new_body;
     fun_fast = f.fun_fast;
     fun_dbg  = f.fun_dbg;
+    fun_fast_compile = f.fun_fast_compile;
     fun_spacetime_shape = f.fun_spacetime_shape;
   }

--- a/asmcomp/split.ml
+++ b/asmcomp/split.ml
@@ -221,8 +221,7 @@ let fundecl f =
   { fun_name = f.fun_name;
     fun_args = new_args;
     fun_body = new_body;
-    fun_fast = f.fun_fast;
+    fun_codegen_options = f.fun_codegen_options;
     fun_dbg  = f.fun_dbg;
-    fun_fast_compile = f.fun_fast_compile;
     fun_spacetime_shape = f.fun_spacetime_shape;
   }

--- a/testsuite/tests/asmgen/parsecmm.mly
+++ b/testsuite/tests/asmgen/parsecmm.mly
@@ -146,8 +146,13 @@ phrase:
 fundecl:
     LPAREN FUNCTION fun_name LPAREN params RPAREN sequence RPAREN
       { List.iter (fun (id, ty) -> unbind_ident id) $5;
-        {fun_name = $3; fun_args = $5; fun_body = $7; fun_fast = true;
-         fun_fast_compile = true;
+        {fun_name = $3; fun_args = $5; fun_body = $7;
+         fun_codegen_options =
+           if Config.flambda then [
+             Reduce_code_size;
+             No_CSE;
+           ]
+           else [ Reduce_code_size ];
          fun_dbg = debuginfo ()} }
 ;
 fun_name:

--- a/testsuite/tests/asmgen/parsecmm.mly
+++ b/testsuite/tests/asmgen/parsecmm.mly
@@ -147,6 +147,7 @@ fundecl:
     LPAREN FUNCTION fun_name LPAREN params RPAREN sequence RPAREN
       { List.iter (fun (id, ty) -> unbind_ident id) $5;
         {fun_name = $3; fun_args = $5; fun_body = $7; fun_fast = true;
+         fun_fast_compile = true;
          fun_dbg = debuginfo ()} }
 ;
 fun_name:


### PR DESCRIPTION
This is #1453 with only the CSE change. This is sufficient for compiling the reported problematic files of https://caml.inria.fr/mantis/view.php?id=7630 with flambda with a few hundreds MB of ram while it took ~10GB without this patch.