### PR TITLE
Manual, remove dangling reference

### DIFF
--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -519,9 +519,6 @@ This syntax can be very useful when defining recursive functions involving
 GADTs, see the section~\ref{s:gadts} for a more detailed explanation.
 
 The same feature is provided for method definitions.
-The @'method!'@ form combines this extension with the
-``explicit overriding'' extension described in
-section~\ref{s:explicit-overriding}.
 
 \section{First-class modules}\label{s-first-class-modules}
 \ikwd{module\@\texttt{module}}


### PR DESCRIPTION
This small PR removes a forgotten dangling reference to the explicitly overriding method definition that was moved to the tutorial part of the manual.