### PR TITLE
Ocamldoc, latex backend: labels for exception

### DIFF
--- a/Changes
+++ b/Changes
@@ -423,6 +423,10 @@ Release branch for 4.06:
   calls over the lifetime of a program when using Spacetime profiling
   (Mark Shinwell)
 
+- GPR#1457, ocamldoc: restore label for exception in the latex backend
+  (omitted since 4.04.0)
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Toplevel:
 
 - MPR#7570: remove unusable -plugin option from the toplevel

--- a/ocamldoc/odoc_latex.ml
+++ b/ocamldoc/odoc_latex.ml
@@ -745,6 +745,7 @@ class latex =
                 );
               [CodePre (flush2 ())]
         in
+        Latex ( self#make_label (self#exception_label e.ex_name) ) ::
        merge_codepre (l @ s ) @
       [Latex ("\\index{"^(self#label s_name)^"@\\verb`"^(self#label ~no_:false s_name)^"`}\n")]
        @ (self#text_of_info e.ex_info) in

--- a/testsuite/tests/tool-ocamldoc-2/extensible_variant.ml
+++ b/testsuite/tests/tool-ocamldoc-2/extensible_variant.ml
@@ -1,8 +1,11 @@
-(** Testing display of extensible variant types.
+(** Testing display of extensible variant types and exceptions.
 
    @test_types_display
  *)
 
+(** Also check reference for {!M.A}, {!M.B}, {!M.C} and {!E} *)
+
+(** Extensible type *)
 type e = ..
 
 module M = struct
@@ -18,3 +21,5 @@ module type MT = sig
   | B (** B doc *)
   | C (** C doc *)
 end
+
+exception E

--- a/testsuite/tests/tool-ocamldoc-2/extensible_variant.reference
+++ b/testsuite/tests/tool-ocamldoc-2/extensible_variant.reference
@@ -7,7 +7,7 @@
 \usepackage{ocamldoc}
 \begin{document}
 \tableofcontents
-\section{Module {\tt{Extensible\_variant}} : Testing display of extensible variant types.}
+\section{Module {\tt{Extensible\_variant}} : Testing display of extensible variant types and exceptions.}
 \label{Extensible-underscorevariant}\index{Extensible-underscorevariant@\verb`Extensible_variant`}
 
 
@@ -17,10 +17,19 @@
 
 
 
+Also check reference for {\tt{Extensible\_variant.M.A}}[\ref{extension:Extensible-underscorevariant.M.A}], {\tt{Extensible\_variant.M.B}}[\ref{extension:Extensible-underscorevariant.M.B}], {\tt{Extensible\_variant.M.C}}[\ref{extension:Extensible-underscorevariant.M.C}] and {\tt{Extensible\_variant.E}}[\ref{exception:Extensible-underscorevariant.E}]
+
+
+
 \label{TYPExtensible-underscorevariant.e}\begin{ocamldoccode}
 type e = ..
 \end{ocamldoccode}
 \index{e@\verb`e`}
+\begin{ocamldocdescription}
+Extensible type
+
+
+\end{ocamldocdescription}
 
 
 
@@ -103,6 +112,14 @@ C doc
 \end{ocamldocsigend}
 
 
+
+
+
+
+\label{exception:Extensible-underscorevariant.E}\begin{ocamldoccode}
+exception E
+\end{ocamldoccode}
+\index{E@\verb`E`}
 
 
 \end{document}

--- a/testsuite/tests/tool-ocamldoc-2/inline_records.reference
+++ b/testsuite/tests/tool-ocamldoc-2/inline_records.reference
@@ -18,7 +18,7 @@
 
 
 
-\begin{ocamldoccode}
+\label{exception:Inline-underscorerecords.Simple}\begin{ocamldoccode}
 exception Simple
 \end{ocamldoccode}
 \index{Simple@\verb`Simple`}
@@ -31,7 +31,7 @@ A nice exception
 
 
 
-\begin{ocamldoccode}
+\label{exception:Inline-underscorerecords.Less}\begin{ocamldoccode}
 exception Less of int
 \end{ocamldoccode}
 \index{Less@\verb`Less`}
@@ -210,7 +210,7 @@ A gadt constructor
 
 
 
-\begin{ocamldoccode}
+\label{exception:Inline-underscorerecords.Error}\begin{ocamldoccode}
 exception Error of {\char123}  name : string ;
 \end{ocamldoccode}
 \begin{ocamldoccomment}

--- a/testsuite/tests/tool-ocamldoc-2/inline_records_bis.reference
+++ b/testsuite/tests/tool-ocamldoc-2/inline_records_bis.reference
@@ -18,7 +18,7 @@
 
 
 
-\begin{ocamldoccode}
+\label{exception:Inline-underscorerecords-underscorebis.Simple}\begin{ocamldoccode}
 exception Simple
 \end{ocamldoccode}
 \index{Simple@\verb`Simple`}
@@ -31,7 +31,7 @@ A nice exception
 
 
 
-\begin{ocamldoccode}
+\label{exception:Inline-underscorerecords-underscorebis.Less}\begin{ocamldoccode}
 exception Less of int
 \end{ocamldoccode}
 \index{Less@\verb`Less`}
@@ -210,7 +210,7 @@ A gadt constructor
 
 
 
-\begin{ocamldoccode}
+\label{exception:Inline-underscorerecords-underscorebis.Error}\begin{ocamldoccode}
 exception Error of {\char123}  name : string ;
 \end{ocamldoccode}
 \begin{ocamldoccomment}


### PR DESCRIPTION
This brief PR restores the label for exceptions in the latex backend of ocamldoc (which fixes a handful of missing reference warnings in the latex version of the manual).