### PR TITLE
Fix emacs mode (raise/failwith/invalid_arg regexp).

### DIFF
--- a/emacs/caml-font.el
+++ b/emacs/caml-font.el
@@ -62,7 +62,7 @@
                            "when" "while" "with")
                          'words))
     . font-lock-constant-face)
-   ("\\<raise\\|failwith\\|invalid_arg\\>"
+   ("\\<\\(raise\\|failwith\\|invalid_arg\\)\\>"
     . font-lock-comment-face)
 ;labels (and open)
    ("\\(\\([~?]\\|\\<\\)[a-z][a-zA-Z0-9_']*:\\)[^:=]"


### PR DESCRIPTION
The regexp for raise, failwith and invalid_arg needed parenthesis, since | precedence is greater than < (or >)  one.
