### PR TITLE
Possible memory leak.

### DIFF
--- a/ocamltest/run_stubs.c
+++ b/ocamltest/run_stubs.c
@@ -59,7 +59,11 @@ static void logToChannel(void *voidchannel, const char *fmt, va_list ap)
   char *text = malloc(512);
   if (text == NULL) return;
   length = vsnprintf(text, initialTextLength, fmt, ap);
-  if (length <= 0) return;
+  if (length <= 0)
+  {
+    free(text);
+    return;
+  }
   if (length > initialTextLength)
   {
     free(text);


### PR DESCRIPTION
Very minor problem - possible memory leak if `length <= 0` and `text` buffer is allocated, program will not free buffer.