### PR TITLE
Let ocamltest use other runtime variants

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -18,7 +18,8 @@ NO_PRINT=`$(MAKE) empty --no-print-directory >/dev/null 2>&1 \
 	  && echo --no-print-directory`
 
 FIND=find
-include ../config/Makefile
+TOPDIR := ..
+include $(TOPDIR)/Makefile.tools
 
 ifeq "$(UNIX_OR_WIN32)" "unix"
   ifeq "$(SYSTEM)" "cygwin"
@@ -104,7 +105,7 @@ new-without-report: lib tools
 	  dir=`dirname $$file`; \
 	  echo Running tests from \'$$dir\' ... ; \
 	  (IFS=$$(printf "\r\n"); while read testfile; do \
-	    TERM=dumb OCAMLRUNPARAM= \
+	    TERM=dumb \
 	      $(ocamltest) $$dir/$$testfile || \
 	      touch $(failstamp); \
 	  done < $$file) || touch $(failstamp); \


### PR DESCRIPTION
Before this PR, ocamltest was not able to run either the debug or the
instrumented runtime.

In particular, when Travis was running the testsuite with the debug-runtime
by setting the USE_RUNTIME environment variable, the tests that had
already been migrated to be run by ocamltest were still run with the
"normal" runtime, so the test was actually not testing anything new in that
case.

This PR fixes this and makes sure ocamltest runs the runtime variants
properly when instructed to do so.

The first commit of the PR which gets rid of the UNIXLIBVAR build variable
in the testsuite is not directly related but it does improve the
readability of the makefiles and looks really harmless.