### PR TITLE
Fix handling of Printexc.raise_with_backtrace under partial application

### DIFF
--- a/Changes
+++ b/Changes
@@ -184,6 +184,9 @@ Working version
   (Nicolás Ojeda Bär, report by Alain Frisch, review by David Allsopp, Xavier
   Leroy)
 
+- MPR#7666, GPR#1465: fix partial application of Printexc.raise_with_backtrace.
+  (Nicolás Ojeda Bär)
+
 4.06 maintenance branch
 -----------------------
 

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -687,6 +687,20 @@ and transl_exp0 e =
                   loc = e.exp_loc;
                   body = Lsend(Cached, Lvar meth, Lvar obj,
                                [Lvar cache; Lvar pos], e.exp_loc)}
+      else if p.prim_name = "%raise_with_backtrace" then
+        let exn = Ident.create "exn" and bt = Ident.create "bt" in
+        let kind = Curried in
+        let params = [exn; bt] in
+        let attr = default_stub_attribute in
+        let loc = e.exp_loc in
+        let body =
+          event_before e (Lsequence(Lprim(Pccall prim_restore_raw_backtrace,
+                                          [Lvar exn; Lvar bt], e.exp_loc),
+                                    Lprim(Praise Raise_reraise,
+                                          [event_after e (Lvar exn)],
+                                          e.exp_loc)))
+        in
+        Lfunction{kind; params; attr; loc; body}
       else
         transl_primitive e.exp_loc p e.exp_env e.exp_type (Some path)
   | Texp_ident(_, _, {val_kind = Val_anc _}) ->

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -776,9 +776,9 @@ and transl_exp0 e =
         Llet(Strict, Pgenval, vexn, texn2,
              event_before e begin
                Lsequence(
-                 wrap  (Lprim (Pccall prim_restore_raw_backtrace,
-                               [Lvar vexn;bt],
-                               e.exp_loc)),
+                 Lprim (Pccall prim_restore_raw_backtrace,
+                        [Lvar vexn;bt],
+                        e.exp_loc),
                  wrap0 (Lprim(Praise Raise_reraise,
                               [event_after texn1 (Lvar vexn)],
                               e.exp_loc))

--- a/testsuite/tests/backtrace/raw_backtrace.byte.reference
+++ b/testsuite/tests/backtrace/raw_backtrace.byte.reference
@@ -10,10 +10,10 @@ Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 16, characters 4-11
 Re-raised at file "raw_backtrace.ml", line 18, characters 68-71
-Called from file "raw_backtrace.ml", line 33, characters 11-23
+Called from file "raw_backtrace.ml", line 44, characters 11-23
 Uncaught exception Raw_backtrace.Error("c")
 Raised at file "raw_backtrace.ml", line 19, characters 26-37
-Called from file "raw_backtrace.ml", line 33, characters 11-23
+Called from file "raw_backtrace.ml", line 44, characters 11-23
 Uncaught exception Raw_backtrace.Error("d")
 Raised at file "raw_backtrace.ml", line 7, characters 21-32
 Called from file "raw_backtrace.ml", line 7, characters 42-53
@@ -22,7 +22,7 @@ Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 16, characters 4-11
-Called from file "raw_backtrace.ml", line 33, characters 11-23
+Called from file "raw_backtrace.ml", line 44, characters 11-23
 e
 Uncaught exception Raw_backtrace.Error("e")
 Raised at file "raw_backtrace.ml", line 7, characters 21-32
@@ -33,7 +33,7 @@ Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 16, characters 4-11
 Re-raised at file "raw_backtrace.ml", line 25, characters 39-42
-Called from file "raw_backtrace.ml", line 33, characters 11-23
+Called from file "raw_backtrace.ml", line 44, characters 11-23
 f
 Uncaught exception Raw_backtrace.Localized(_)
 Raised at file "raw_backtrace.ml", line 7, characters 21-32
@@ -44,6 +44,28 @@ Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 16, characters 4-11
 Re-raised at file "raw_backtrace.ml", line 29, characters 39-54
-Called from file "raw_backtrace.ml", line 33, characters 11-23
+Called from file "raw_backtrace.ml", line 44, characters 11-23
+g
+Uncaught exception Raw_backtrace.Error("g")
+Raised at file "raw_backtrace.ml", line 7, characters 21-32
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 16, characters 4-11
+Re-raised at file "raw_backtrace.ml", line 34, characters 17-46
+Called from file "raw_backtrace.ml", line 44, characters 11-23
+h
+Uncaught exception Raw_backtrace.Localized(_)
+Raised at file "raw_backtrace.ml", line 7, characters 21-32
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 16, characters 4-11
+Re-raised at file "raw_backtrace.ml", line 39, characters 17-46
+Called from file "raw_backtrace.ml", line 44, characters 11-23
 Uncaught exception Invalid_argument("index out of bounds")
-Raised by primitive operation at file "raw_backtrace.ml", line 33, characters 14-22
+Raised by primitive operation at file "raw_backtrace.ml", line 44, characters 14-22

--- a/testsuite/tests/backtrace/raw_backtrace.ml
+++ b/testsuite/tests/backtrace/raw_backtrace.ml
@@ -27,6 +27,17 @@ let g msg =
          let bt = Printexc.get_raw_backtrace () in
          print_string "f"; print_newline ();
          Printexc.raise_with_backtrace (Localized exn) bt
+     | Error "g" as exn ->
+         let bt = Printexc.get_raw_backtrace () in
+         print_string "g"; print_newline ();
+         ignore (exception_raised_internally ());
+         let f = Printexc.raise_with_backtrace exn in
+         f bt
+     | Error "h" as exn ->
+         let bt = Printexc.get_raw_backtrace () in
+         print_string "h"; print_newline ();
+         let f = Printexc.raise_with_backtrace (Localized exn) in
+         f bt
 
 let backtrace args =
   try
@@ -56,4 +67,6 @@ let _ =
   run [| "d" |];
   run [| "e" |];
   run [| "f" |];
+  run [| "g" |];
+  run [| "h" |];
   run [| |]

--- a/testsuite/tests/backtrace/raw_backtrace.native.reference
+++ b/testsuite/tests/backtrace/raw_backtrace.native.reference
@@ -10,10 +10,10 @@ Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 16, characters 4-11
 Re-raised at file "raw_backtrace.ml", line 18, characters 62-71
-Called from file "raw_backtrace.ml", line 33, characters 11-23
+Called from file "raw_backtrace.ml", line 44, characters 11-23
 Uncaught exception Raw_backtrace.Error("c")
 Raised at file "raw_backtrace.ml", line 19, characters 20-37
-Called from file "raw_backtrace.ml", line 33, characters 11-23
+Called from file "raw_backtrace.ml", line 44, characters 11-23
 Uncaught exception Raw_backtrace.Error("d")
 Raised at file "raw_backtrace.ml", line 7, characters 16-32
 Called from file "raw_backtrace.ml", line 7, characters 42-53
@@ -22,7 +22,7 @@ Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 16, characters 4-11
-Called from file "raw_backtrace.ml", line 33, characters 11-23
+Called from file "raw_backtrace.ml", line 44, characters 11-23
 e
 Uncaught exception Raw_backtrace.Error("e")
 Raised at file "raw_backtrace.ml", line 7, characters 16-32
@@ -33,7 +33,7 @@ Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 16, characters 4-11
 Re-raised at file "raw_backtrace.ml", line 25, characters 9-45
-Called from file "raw_backtrace.ml", line 33, characters 11-23
+Called from file "raw_backtrace.ml", line 44, characters 11-23
 f
 Uncaught exception Raw_backtrace.Localized(_)
 Raised at file "raw_backtrace.ml", line 7, characters 16-32
@@ -44,6 +44,32 @@ Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 7, characters 42-53
 Called from file "raw_backtrace.ml", line 16, characters 4-11
 Re-raised at file "raw_backtrace.ml", line 29, characters 9-57
-Called from file "raw_backtrace.ml", line 33, characters 11-23
+Called from file "raw_backtrace.ml", line 44, characters 11-23
+g
+Uncaught exception Raw_backtrace.Error("g")
+Raised at file "raw_backtrace.ml", line 7, characters 16-32
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 16, characters 4-11
+Re-raised at file "raw_backtrace.ml" (inlined), line 34, characters 17-46
+Called from file "raw_backtrace.ml" (inlined), line 34, characters 17-50
+Called from file "raw_backtrace.ml", line 35, characters 9-13
+Called from file "raw_backtrace.ml", line 44, characters 11-23
+h
+Uncaught exception Raw_backtrace.Localized(_)
+Raised at file "raw_backtrace.ml", line 7, characters 16-32
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 7, characters 42-53
+Called from file "raw_backtrace.ml", line 16, characters 4-11
+Re-raised at file "raw_backtrace.ml" (inlined), line 39, characters 17-46
+Called from file "raw_backtrace.ml" (inlined), line 39, characters 17-62
+Called from file "raw_backtrace.ml", line 40, characters 9-13
+Called from file "raw_backtrace.ml", line 44, characters 11-23
 Uncaught exception Invalid_argument("index out of bounds")
-Raised by primitive operation at file "raw_backtrace.ml", line 33, characters 14-22
+Raised by primitive operation at file "raw_backtrace.ml", line 44, characters 14-22


### PR DESCRIPTION
See [MPR#7666](https://caml.inria.fr/mantis/view.php?id=7666) and #378.  The case of the primitive `%raise_with_backtrace` being partially applied was not being handled, which would end up being considered as a (partially-applied) C primitive and fail.

This PR adds the missing case and a corresponding test.