### PR TITLE
Parser: allow seq_expr inside extended indexing/bigarray operators

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,11 @@ be mentioned in the 4.06 section below instead of here.)
 
 ### Language features:
 
+- GPR#1467: Allow expressions sequences inside extended indexing and bigarray
+  indexing operators, e.g.: e1.![e2; e3; ...], etc.
+  (Nicolas Ojeda Bar, review by Gabriel Radanne, Damien Doligez, Gabriel
+  Scherer)
+
 ### Type system:
 
 - GPR#1370: Fix code duplication in Cmmgen

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1410,24 +1410,24 @@ expr:
   | simple_expr DOT LBRACKET seq_expr RBRACKET LESSMINUS expr
       { mkexp(Pexp_apply(ghexp(Pexp_ident(array_function "String" "set")),
                          [Nolabel,$1; Nolabel,$4; Nolabel,$7])) }
-  | simple_expr DOT LBRACE expr RBRACE LESSMINUS expr
+  | simple_expr DOT LBRACE seq_expr RBRACE LESSMINUS expr
       { bigarray_set $1 $4 $7 }
-  | simple_expr DOTOP LBRACKET expr RBRACKET LESSMINUS expr
+  | simple_expr DOTOP LBRACKET seq_expr RBRACKET LESSMINUS expr
       { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "[]<-")) in
         mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $4; Nolabel, $7]) }
-  | simple_expr DOTOP LPAREN expr RPAREN LESSMINUS expr
+  | simple_expr DOTOP LPAREN seq_expr RPAREN LESSMINUS expr
       { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "()<-")) in
         mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $4; Nolabel, $7]) }
-  | simple_expr DOTOP LBRACE expr RBRACE LESSMINUS expr
+  | simple_expr DOTOP LBRACE seq_expr RBRACE LESSMINUS expr
       { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "{}<-")) in
         mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $4; Nolabel, $7]) }
-  | simple_expr DOT mod_longident DOTOP LBRACKET expr RBRACKET LESSMINUS expr
+  | simple_expr DOT mod_longident DOTOP LBRACKET seq_expr RBRACKET LESSMINUS expr
       { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3,"." ^ $4 ^ "[]<-")) in
         mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $6; Nolabel, $9]) }
-  | simple_expr DOT mod_longident DOTOP LPAREN expr RPAREN LESSMINUS expr
+  | simple_expr DOT mod_longident DOTOP LPAREN seq_expr RPAREN LESSMINUS expr
       { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "()<-")) in
         mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $6; Nolabel, $9]) }
-  | simple_expr DOT mod_longident DOTOP LBRACE expr RBRACE LESSMINUS expr
+  | simple_expr DOT mod_longident DOTOP LBRACE seq_expr RBRACE LESSMINUS expr
       { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "{}<-")) in
         mkexp @@ Pexp_apply(id , [Nolabel, $1; Nolabel, $6; Nolabel, $9]) }
   | label LESSMINUS expr
@@ -1486,37 +1486,37 @@ simple_expr:
                          [Nolabel,$1; Nolabel,$4])) }
   | simple_expr DOT LBRACKET seq_expr error
       { unclosed "[" 3 "]" 5 }
-  | simple_expr DOTOP LBRACKET expr RBRACKET
+  | simple_expr DOTOP LBRACKET seq_expr RBRACKET
       { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "[]")) in
         mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $4]) }
-  | simple_expr DOTOP LBRACKET expr error
+  | simple_expr DOTOP LBRACKET seq_expr error
       { unclosed "[" 3 "]" 5 }
-  | simple_expr DOTOP LPAREN expr RPAREN
+  | simple_expr DOTOP LPAREN seq_expr RPAREN
       { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "()")) in
         mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $4]) }
-  | simple_expr DOTOP LPAREN expr error
+  | simple_expr DOTOP LPAREN seq_expr error
       { unclosed "(" 3 ")" 5 }
-  | simple_expr DOTOP LBRACE expr RBRACE
+  | simple_expr DOTOP LBRACE seq_expr RBRACE
       { let id = mkexp @@ Pexp_ident( ghloc @@ Lident ("." ^ $2 ^ "{}")) in
         mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $4]) }
-  | simple_expr DOTOP LBRACE expr error
+  | simple_expr DOTOP LBRACE seq_expr error
       { unclosed "{" 3 "}" 5 }
-  | simple_expr DOT mod_longident DOTOP LBRACKET expr RBRACKET
+  | simple_expr DOT mod_longident DOTOP LBRACKET seq_expr RBRACKET
       { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "[]")) in
         mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $6]) }
-  | simple_expr DOT mod_longident DOTOP LBRACKET expr error
+  | simple_expr DOT mod_longident DOTOP LBRACKET seq_expr error
       { unclosed "[" 5 "]" 7 }
-  | simple_expr DOT mod_longident DOTOP LPAREN expr RPAREN
+  | simple_expr DOT mod_longident DOTOP LPAREN seq_expr RPAREN
       { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "()")) in
         mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $6]) }
-  | simple_expr DOT mod_longident DOTOP LPAREN expr error
+  | simple_expr DOT mod_longident DOTOP LPAREN seq_expr error
       { unclosed "(" 5 ")" 7 }
-  | simple_expr DOT mod_longident DOTOP LBRACE expr RBRACE
+  | simple_expr DOT mod_longident DOTOP LBRACE seq_expr RBRACE
       { let id = mkexp @@ Pexp_ident( ghloc @@ Ldot($3, "." ^ $4 ^ "{}")) in
         mkexp @@ Pexp_apply(id, [Nolabel, $1; Nolabel, $6]) }
-  | simple_expr DOT mod_longident DOTOP LBRACE expr error
+  | simple_expr DOT mod_longident DOTOP LBRACE seq_expr error
       { unclosed "{" 5 "}" 7 }
-  | simple_expr DOT LBRACE expr RBRACE
+  | simple_expr DOT LBRACE seq_expr RBRACE
       { bigarray_get $1 $4 }
   | simple_expr DOT LBRACE expr_comma_list error
       { unclosed "{" 3 "}" 5 }

--- a/testsuite/tests/parsing/extended_indexoperators.ml
+++ b/testsuite/tests/parsing/extended_indexoperators.ml
@@ -21,3 +21,7 @@ let ( .%() ) x y = x.(y);;
 let x = [| 0 |];;
 let _ = 1 #? x.(0);;
 let _ = 1 #? x.%(0);;
+
+(* form GPR#1467 *)
+let _ = x.%((); (); 0)
+let _ = x.%(print_endline "hello"; 0)

--- a/testsuite/tests/parsing/extended_indexoperators.ml.reference
+++ b/testsuite/tests/parsing/extended_indexoperators.ml.reference
@@ -323,5 +323,69 @@
                 ]
           ]
     ]
+  structure_item (extended_indexoperators.ml[26,479+0]..[26,479+22])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_indexoperators.ml[26,479+4]..[26,479+5])
+          Ppat_any
+        expression (extended_indexoperators.ml[26,479+8]..[26,479+22])
+          Pexp_apply
+          expression (extended_indexoperators.ml[26,479+8]..[26,479+22])
+            Pexp_ident ".%()" (extended_indexoperators.ml[26,479+8]..[26,479+22]) ghost
+          [
+            <arg>
+            Nolabel
+              expression (extended_indexoperators.ml[26,479+8]..[26,479+9])
+                Pexp_ident "x" (extended_indexoperators.ml[26,479+8]..[26,479+9])
+            <arg>
+            Nolabel
+              expression (extended_indexoperators.ml[26,479+12]..[26,479+21])
+                Pexp_sequence
+                expression (extended_indexoperators.ml[26,479+12]..[26,479+14])
+                  Pexp_construct "()" (extended_indexoperators.ml[26,479+12]..[26,479+14])
+                  None
+                expression (extended_indexoperators.ml[26,479+16]..[26,479+21])
+                  Pexp_sequence
+                  expression (extended_indexoperators.ml[26,479+16]..[26,479+18])
+                    Pexp_construct "()" (extended_indexoperators.ml[26,479+16]..[26,479+18])
+                    None
+                  expression (extended_indexoperators.ml[26,479+20]..[26,479+21])
+                    Pexp_constant PConst_int (0,None)
+          ]
+    ]
+  structure_item (extended_indexoperators.ml[27,502+0]..[27,502+37])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_indexoperators.ml[27,502+4]..[27,502+5])
+          Ppat_any
+        expression (extended_indexoperators.ml[27,502+8]..[27,502+37])
+          Pexp_apply
+          expression (extended_indexoperators.ml[27,502+8]..[27,502+37])
+            Pexp_ident ".%()" (extended_indexoperators.ml[27,502+8]..[27,502+37]) ghost
+          [
+            <arg>
+            Nolabel
+              expression (extended_indexoperators.ml[27,502+8]..[27,502+9])
+                Pexp_ident "x" (extended_indexoperators.ml[27,502+8]..[27,502+9])
+            <arg>
+            Nolabel
+              expression (extended_indexoperators.ml[27,502+12]..[27,502+36])
+                Pexp_sequence
+                expression (extended_indexoperators.ml[27,502+12]..[27,502+33])
+                  Pexp_apply
+                  expression (extended_indexoperators.ml[27,502+12]..[27,502+25])
+                    Pexp_ident "print_endline" (extended_indexoperators.ml[27,502+12]..[27,502+25])
+                  [
+                    <arg>
+                    Nolabel
+                      expression (extended_indexoperators.ml[27,502+26]..[27,502+33])
+                        Pexp_constant PConst_string("hello",None)
+                  ]
+                expression (extended_indexoperators.ml[27,502+35]..[27,502+36])
+                  Pexp_constant PConst_int (0,None)
+          ]
+    ]
 ]
 


### PR DESCRIPTION
By analogy with the case of array and string indexing operators, the PR changes the parser so that the thing used inside extended indexing/bigarray operators is allowed to be a `seq_expr` instead of simply an `expr`. While this "feature" is surely not used much, the intent here is to keep the concrete syntax as uniform as possible.