### PR TITLE
Do not enrich type_decls with incoherent manifests

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,6 +26,9 @@ Working version
   when configured with -no-flat-float-array
   (Jeremy Yallop, report by Gabriel Scherer)
 
+- GPR#1468: Do not enrich type_decls with incoherent manifests
+  (Thomas Refis and Leo White, review by Jacques Garrigue)
+
 - GPR#1583: propagate refined ty_arg to Parmatch checks
   (Thomas Refis, review by Jacques Garrigue)
 

--- a/testsuite/tests/typing-misc/enrich_typedecl.ml
+++ b/testsuite/tests/typing-misc/enrich_typedecl.ml
@@ -1,0 +1,256 @@
+(* TEST
+   * expect
+*)
+
+module rec A : sig
+  type t = int * string
+end = struct
+  type t = A | B
+
+  let f (x : t) =
+    match x with
+    | A -> ()
+    | B -> ()
+end;;
+[%%expect{|
+Line _, characters 6-97:
+  ......struct
+    type t = A | B
+
+    let f (x : t) =
+      match x with
+      | A -> ()
+      | B -> ()
+  end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = A.t = A | B val f : t -> unit end
+       is not included in
+         sig type t = int * string end
+       Type declarations do not match:
+         type t = A.t = A | B
+       is not included in
+         type t = int * string
+|}]
+
+module rec B : sig
+  type 'a t = 'a
+end = struct
+  type 'a t = A of 'a | B
+
+  let f (x : _ t) =
+    match x with
+    | A _ -> ()
+    | B -> ()
+end;;
+[%%expect{|
+Line _, characters 6-110:
+  ......struct
+    type 'a t = A of 'a | B
+
+    let f (x : _ t) =
+      match x with
+      | A _ -> ()
+      | B -> ()
+  end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a B.t = A of 'a | B val f : 'a t -> unit end
+       is not included in
+         sig type 'a t = 'a end
+       Type declarations do not match:
+         type 'a t = 'a B.t = A of 'a | B
+       is not included in
+         type 'a t = 'a
+|}];;
+
+module rec C : sig
+  type 'a t = { x : 'a }
+end = struct
+  type 'a t = A of 'a | B
+
+  let f (x : _ t) =
+    match x with
+    | A _ -> ()
+    | B -> ()
+end;;
+[%%expect{|
+Line _, characters 6-110:
+  ......struct
+    type 'a t = A of 'a | B
+
+    let f (x : _ t) =
+      match x with
+      | A _ -> ()
+      | B -> ()
+  end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a C.t = A of 'a | B val f : 'a t -> unit end
+       is not included in
+         sig type 'a t = { x : 'a; } end
+       Type declarations do not match:
+         type 'a t = 'a C.t = A of 'a | B
+       is not included in
+         type 'a t = { x : 'a; }
+       Their kinds differ.
+|}];;
+
+
+module rec D : sig
+  type 'a t = int
+end = struct
+  type 'a t = A of 'a | B
+
+  let f (x : _ t) =
+    match x with
+    | A _ -> ()
+    | B -> ()
+end;;
+[%%expect{|
+Line _, characters 6-110:
+  ......struct
+    type 'a t = A of 'a | B
+
+    let f (x : _ t) =
+      match x with
+      | A _ -> ()
+      | B -> ()
+  end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a D.t = A of 'a | B val f : 'a t -> unit end
+       is not included in
+         sig type 'a t = int end
+       Type declarations do not match:
+         type 'a t = 'a D.t = A of 'a | B
+       is not included in
+         type 'a t = int
+|}];;
+
+module rec E : sig
+  type 'a t = [> `Foo ] as 'a
+end = struct
+  type 'a t = A of 'a | B
+
+  let f (x : _ t) =
+    match x with
+    | A _ -> ()
+    | B -> ()
+end;;
+[%%expect{|
+Line _, characters 6-110:
+  ......struct
+    type 'a t = A of 'a | B
+
+    let f (x : _ t) =
+      match x with
+      | A _ -> ()
+      | B -> ()
+  end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a E.t = A of 'a | B val f : 'a t -> unit end
+       is not included in
+         sig type 'a t = 'a constraint 'a = [> `Foo ] end
+       Type declarations do not match:
+         type 'a t = 'a E.t = A of 'a | B
+       is not included in
+         type 'a t = 'a constraint 'a = [> `Foo ]
+|}];;
+
+module rec E2 : sig
+  type 'a t = [ `Foo ]
+end = struct
+  type 'a t = A of 'a | B
+
+  let f (x : _ t) =
+    match x with
+    | A _ -> ()
+    | B -> ()
+end;;
+[%%expect{|
+Line _, characters 6-110:
+  ......struct
+    type 'a t = A of 'a | B
+
+    let f (x : _ t) =
+      match x with
+      | A _ -> ()
+      | B -> ()
+  end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a E2.t = A of 'a | B val f : 'a t -> unit end
+       is not included in
+         sig type 'a t = [ `Foo ] end
+       Type declarations do not match:
+         type 'a t = 'a E2.t = A of 'a | B
+       is not included in
+         type 'a t = [ `Foo ]
+|}];;
+
+module rec E3 : sig
+  type 'a t = [< `Foo ] as 'a
+end = struct
+  type 'a t = A of 'a | B
+
+  let f (x : _ t) =
+    match x with
+    | A _ -> ()
+    | B -> ()
+end;;
+[%%expect{|
+Line _, characters 6-110:
+  ......struct
+    type 'a t = A of 'a | B
+
+    let f (x : _ t) =
+      match x with
+      | A _ -> ()
+      | B -> ()
+  end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a E3.t = A of 'a | B val f : 'a t -> unit end
+       is not included in
+         sig type 'a t = 'a constraint 'a = [< `Foo ] end
+       Type declarations do not match:
+         type 'a t = 'a E3.t = A of 'a | B
+       is not included in
+         type 'a t = 'a constraint 'a = [< `Foo ]
+|}];;
+
+
+module rec F : sig
+  type ('a, 'b) t = Foo of 'a
+end = struct
+  type ('a, 'b) t = Foo of 'b
+
+  (* this function typechecks properly, which means that we've added the
+     manisfest. *)
+  let coerce : 'a 'b. ('a, 'b) t -> ('a, 'b) F.t = fun x -> x
+end;;
+[%%expect{|
+Line _, characters 6-201:
+  ......struct
+    type ('a, 'b) t = Foo of 'b
+
+    (* this function typechecks properly, which means that we've added the
+       manisfest. *)
+    let coerce : 'a 'b. ('a, 'b) t -> ('a, 'b) F.t = fun x -> x
+  end..
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type ('a, 'b) t = ('a, 'b) F.t = Foo of 'b
+           val coerce : ('a, 'b) t -> ('a, 'b) F.t
+         end
+       is not included in
+         sig type ('a, 'b) t = Foo of 'a end
+       Type declarations do not match:
+         type ('a, 'b) t = ('a, 'b) F.t = Foo of 'b
+       is not included in
+         type ('a, 'b) t = Foo of 'a
+       The types for field Foo are not equal.
+|}];;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1838,6 +1838,29 @@ let enter_poly env univar_pairs t1 tl1 t2 tl2 f =
 
 let univar_pairs = ref []
 
+(* assumption: [ty] is fully generalized. *)
+let reify_univars env ty =
+  let rec subst_univar vars ty =
+    let ty = repr ty in
+    if ty.level >= lowest_level then begin
+      ty.level <- pivot_level - ty.level;
+      match ty.desc with
+      | Tvar name ->
+          save_desc ty ty.desc;
+          let t = newty2 ty.level (Tunivar name) in
+          vars := t :: !vars;
+          ty.desc <- Tsubst t
+      | _ ->
+          iter_type_expr (subst_univar vars) ty
+    end
+  in
+  let vars = ref [] in
+  subst_univar vars ty;
+  unmark_type ty;
+  let ty = copy ~env ty in
+  cleanup_types ();
+  newty2 ty.level (Tpoly(repr ty, !vars))
+
 
                               (*****************)
                               (*  Unification  *)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -194,6 +194,9 @@ val matches: Env.t -> type_expr -> type_expr -> bool
         (* Same as [moregeneral false], implemented using the two above
            functions and backtracking. Ignore levels *)
 
+val reify_univars : Env.t -> Types.type_expr -> Types.type_expr
+        (* Replaces all the variables of a type by a univar. *)
+
 type class_match_failure =
     CM_Virtual_class
   | CM_Parameter_arity_mismatch of int * int
@@ -290,3 +293,5 @@ val maybe_pointer_type : Env.t -> type_expr -> bool
 val package_subtype :
     (Env.t -> Path.t -> Longident.t list -> type_expr list ->
       Path.t -> Longident.t list -> type_expr list -> bool) ref
+
+val mcomp : Env.t -> type_expr -> type_expr -> unit

--- a/typing/mtype.mli
+++ b/typing/mtype.mli
@@ -38,7 +38,8 @@ val no_code_needed_sig: Env.t -> signature -> bool
         (* Determine whether a module needs no implementation code,
            i.e. consists only of type definitions. *)
 val enrich_modtype: Env.t -> Path.t -> module_type -> module_type
-val enrich_typedecl: Env.t -> Path.t -> type_declaration -> type_declaration
+val enrich_typedecl: Env.t -> Path.t -> Ident.t -> type_declaration ->
+  type_declaration
 val type_paths: Env.t -> Path.t -> module_type -> Path.t list
 val contains_type: Env.t -> module_type -> bool
 val remove_aliases: Env.t -> module_type -> module_type

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -347,24 +347,11 @@ let clean_copy ty =
   if ty.level = Btype.generic_level then ty
   else Subst.type_expr Subst.identity ty
 
-(* As reported in PR#6394 it is possible for recursive modules to add incoherent
-   equations into the environment.
-   So assuming we're working on the same example as in PR#6394, when looking at
-   constructor [A] we end up calling [expand_head] on [t] (the type of [A]) and
-   get [int * bool].
-   This will result in a proper error later on during type checking, meanwhile
-   we need to "survive" and be somewhat aware that we're working on bogus input
-*)
-
-type constructor_type_path =
-  | Ok of Path.t
-  | Inconsistent_environment
-
 let get_constructor_type_path ty tenv =
   let ty = Ctype.repr (Ctype.expand_head tenv (clean_copy ty)) in
   match ty.desc with
-  | Tconstr (path,_,_) -> Ok path
-  | _ -> Inconsistent_environment
+  | Tconstr (path,_,_) -> path
+  | _ -> assert false
 
 (****************************)
 (* Utilities for matching   *)
@@ -842,13 +829,8 @@ let should_extend ext env = match ext with
       begin match p.pat_desc with
       | Tpat_construct
           (_, {cstr_tag=(Cstr_constant _|Cstr_block _|Cstr_unboxed)},_) ->
-            (match get_constructor_type_path p.pat_type p.pat_env with
-             | Ok path -> Path.same path ext
-             | Inconsistent_environment ->
-               (* returning [true] here could result in more computations being
-                  done to check exhaustivity. Which is clearly not necessary
-                  since the code doesn't typecheck anyway. *)
-               false)
+            let path = get_constructor_type_path p.pat_type p.pat_env in
+            Path.same path ext
       | Tpat_construct
           (_, {cstr_tag=(Cstr_extension _)},_) -> false
       | Tpat_constant _|Tpat_tuple _|Tpat_variant _
@@ -994,9 +976,10 @@ let build_other ext env = match env with
 | ({pat_desc = Tpat_construct _} as p,_) :: _ ->
     begin match ext with
     | Some ext ->
-        (match get_constructor_type_path p.pat_type p.pat_env with
-         | Ok path when Path.same ext path -> extra_pat
-         | _ -> build_other_constrs env p)
+        if Path.same ext (get_constructor_type_path p.pat_type p.pat_env) then
+          extra_pat
+        else
+          build_other_constrs env p
     | _ ->
         build_other_constrs env p
     end
@@ -2025,17 +2008,11 @@ let extendable_path path =
 let rec collect_paths_from_pat r p = match p.pat_desc with
 | Tpat_construct(_, {cstr_tag=(Cstr_constant _|Cstr_block _|Cstr_unboxed)},ps)
   ->
-    (match get_constructor_type_path p.pat_type p.pat_env with
-     | Ok path ->
-         List.fold_left
-           collect_paths_from_pat
-           (if extendable_path path then add_path path r else r)
-           ps
-     | Inconsistent_environment ->
-       (* no need to recurse on the constructor arguments: since we know the
-          code won't typecheck anyway, whatever we might compute would be
-          useless anyway. *)
-       r)
+    let path = get_constructor_type_path p.pat_type p.pat_env in
+    List.fold_left
+      collect_paths_from_pat
+      (if extendable_path path then add_path path r else r)
+      ps
 | Tpat_any|Tpat_var _|Tpat_constant _| Tpat_variant (_,None,_) -> r
 | Tpat_tuple ps | Tpat_array ps
 | Tpat_construct (_, {cstr_tag=Cstr_extension _}, ps)->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -659,8 +659,7 @@ let rec expand_path env p =
     Some {type_manifest = Some ty} ->
       begin match repr ty with
         {desc=Tconstr(p,_,_)} -> expand_path env p
-      | _ -> p
-         (* PR#6394: recursive module may introduce incoherent manifest *)
+      | _ -> assert false
       end
   | _ ->
       let p' = Env.normalize_path None env p in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1111,7 +1111,7 @@ let enrich_type_decls anchor decls oldenv newenv =
           let id = info.typ_id in
           let info' =
             Mtype.enrich_typedecl oldenv (Pdot(p, Ident.name id, nopos))
-              info.typ_type
+              id info.typ_type
           in
             Env.add_type ~check:true id info' e)
         oldenv decls


### PR DESCRIPTION
Follow up to: [MPR#6394](https://caml.inria.fr/mantis/view.php?id=6394), [GPR#1425](https://github.com/ocaml/ocaml/pull/1425).

As discussed in the MPR and GPR linked above, recursive module can add inconsistent equations in the environment. The two previous PRs updated parts of the codebase, which were previously relying on the fact that the environment is consistent, to keep working even when that's not the case.
For one of these, the change raised the question of what to do when the environment is inconsistent, and whether it was safe to keep going (were other parts of the codebase really going to catch the issue afterward?).

This GPR proposes to handle the issue differently by preventing the addition of inconsistent equations to the environment in the first place, and reverting to the old attitude of "if the environment is inconsistent, there is a bug in the compiler, let's crash now".

A few remarks:
- Some (weak) coherence check was already present before, I simply extended it.
- If the check fails, we do not fail right away, we simply do not add the guilty equation to the environment. This behavior was already present before, and while I'd be inclined to change it, I'll leave that as future work.
- I reverted the previous patch which made the compiler more resilient to inconsistent environment. This means that the compiler might fail again if something other than recursive module adds inconsistent equations. I think this is a good thing: I'd rather know this is going on and make the conscious decision of supporting or rejecting it, rather than silently accepting it.