### PR TITLE
Make use of the [@@immediate] information when checking [@@unboxed]

### DIFF
--- a/Changes
+++ b/Changes
@@ -16,6 +16,10 @@ Working version
   (Vincent Laviron, with help from Pierre Chambart,
    reviews by Gabriel Scherer and Luc Maranget)
 
+- GPR#1469: Use the information from [@@immediate] annotations when
+  computing whether a type can be [@@unboxed]
+  (Damien Doligez, report by Stephan Muenzel, review by ...)
+
 - GPR#1516: Allow float array construction in recursive bindings
   when configured with -no-flat-float-array
   (Jeremy Yallop, report by Gabriel Scherer)

--- a/testsuite/tests/typing-unboxed-types/test.ml
+++ b/testsuite/tests/typing-unboxed-types/test.ml
@@ -162,9 +162,11 @@ type ('a, 'p) t = private 'a s
 type 'a packed = T : ('a, _) t -> 'a packed [@@unboxed]
 ;;
 
-
 (* MPR#7682 *)
-
 type f = {field: 'a. 'a list} [@@unboxed];;
 let g = Array.make 10 { field=[] };;
 let h = g.(5);;
+
+(* Using [@@immediate] information (GPR#1469) *)
+type 'a t [@@immediate];;
+type u = U : 'a t -> u [@@unboxed];;

--- a/testsuite/tests/typing-unboxed-types/test.ml.reference-flat
+++ b/testsuite/tests/typing-unboxed-types/test.ml.reference-flat
@@ -203,9 +203,11 @@ Error: This type cannot be unboxed because
 #             type 'a s
 type ('a, 'p) t = private 'a s
 type 'a packed = T : ('a, 'b) t -> 'a packed [@@unboxed]
-#         type f = { field : 'a. 'a list; } [@@unboxed]
+#     type f = { field : 'a. 'a list; } [@@unboxed]
 # val g : f array =
   [|{field = []}; {field = []}; {field = []}; {field = []}; {field = []};
     {field = []}; {field = []}; {field = []}; {field = []}; {field = []}|]
 # val h : f = {field = []}
+#     type 'a t [@@immediate]
+# type u = U : 'a t -> u [@@unboxed]
 # 

--- a/testsuite/tests/typing-unboxed-types/test.ml.reference-noflat
+++ b/testsuite/tests/typing-unboxed-types/test.ml.reference-noflat
@@ -169,9 +169,11 @@ and _ t = T : 'a -> 'a s t
 #             type 'a s
 type ('a, 'p) t = private 'a s
 type 'a packed = T : ('a, 'b) t -> 'a packed [@@unboxed]
-#         type f = { field : 'a. 'a list; } [@@unboxed]
+#     type f = { field : 'a. 'a list; } [@@unboxed]
 # val g : f array =
   [|{field = []}; {field = []}; {field = []}; {field = []}; {field = []};
     {field = []}; {field = []}; {field = []}; {field = []}; {field = []}|]
 # val h : f = {field = []}
+#     type 'a t [@@immediate]
+# type u = U : 'a t -> u [@@unboxed]
 # 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -132,6 +132,7 @@ let rec get_unboxed_type_representation env ty fuel =
   | Tconstr (p, args, _) ->
     begin match Env.find_type p env with
     | exception Not_found -> Some ty
+    | {type_immediate = true; _} -> Some Predef.type_int
     | {type_unboxed = {unboxed = false}} -> Some ty
     | {type_params; type_kind =
          Type_record ([{ld_type = ty2; _}], _)


### PR DESCRIPTION
When checking whether the `[@@unboxed]` annotation on a type is acceptable, we can make use of the information given by `[@@immediate]` annotations on other types.

Suggested by Stephan Muenzel.

See also [MPR#7511](https://caml.inria.fr/mantis/view.php?id=7511) [GPR#606](https://github.com/ocaml/ocaml/pull/606) [GPR#1133](https://github.com/ocaml/ocaml/pull/1133).
