### PR TITLE
Better error reporting in case of missing 'rec' in let-bindings

### DIFF
--- a/Changes
+++ b/Changes
@@ -27,6 +27,10 @@ be mentioned in the 4.06 section below instead of here.)
 - GPR#1428: give a non dummy location for warning 49 (no cmi found)
   (Valentin Gatien-Baron)
 
+- GPR#1472: Improve error reporting for missing 'rec' in let-bindings
+  (Arthur Charguéraud and Armaël Guéneau, with help from Gabriel Scherer and
+  Frédéric Bour)
+
 ### Code generation and optimizations:
 
 ### Runtime system:

--- a/testsuite/tests/typing-core-bugs/Makefile
+++ b/testsuite/tests/typing-core-bugs/Makefile
@@ -1,0 +1,18 @@
+#########################################################################
+#                                                                       #
+#                                 OCaml                                 #
+#                                                                       #
+#                 Arthur Chargueraud, INRIA                             #
+#                                                                       #
+#   Copyright 2010 Institut National de Recherche en Informatique et    #
+#     en Automatique.                                                   #
+#                                                                       #
+#   All rights reserved.  This file is distributed under the terms of   #
+#   the GNU Lesser General Public License version 2.1, with the         #
+#   special exception on linking described in the file LICENSE.         #
+#                                                                       #
+#########################################################################
+
+BASEDIR=../..
+include $(BASEDIR)/makefiles/Makefile.expect
+include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/typing-core-bugs/example_let_missing_rec.ml
+++ b/testsuite/tests/typing-core-bugs/example_let_missing_rec.ml
@@ -1,0 +1,8 @@
+let facto n =   (* missing [rec] *)
+   if n = 0 then 1 else n * facto (n-1)
+
+[%%expect{|
+Line _, characters 28-33:
+Error: Unbound value facto.
+       Hint: You are probably missing the `rec' keyword on line 1.
+|}]

--- a/testsuite/tests/typing-core-bugs/example_let_missing_rec_loc.ml
+++ b/testsuite/tests/typing-core-bugs/example_let_missing_rec_loc.ml
@@ -1,0 +1,8 @@
+let x = 3 in
+let f x = f x in
+();;
+[%%expect{|
+Line _, characters 10-11:
+Error: Unbound value f.
+       Hint: You are probably missing the `rec' keyword on line 2.
+|}];;

--- a/testsuite/tests/typing-core-bugs/example_let_missing_rec_mutual.ml
+++ b/testsuite/tests/typing-core-bugs/example_let_missing_rec_mutual.ml
@@ -1,0 +1,9 @@
+let f x = if x < 0 then x else h (x-1)
+and g x = if x < 0 then x else f (x-1)
+and h x = if x < 0 then x else g (x-1)
+
+[%%expect{|
+Line _, characters 31-32:
+Error: Unbound value h.
+       Hint: You are probably missing the `rec' keyword on line 1.
+|}]

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -99,30 +99,35 @@ val add_gadt_instance_chain: t -> int -> type_expr -> unit
 (* ?loc is used to report 'deprecated module' warnings *)
 
 val lookup_value:
-  ?loc:Location.t -> Longident.t -> t -> Path.t * value_description
+  ?loc:Location.t -> ?mark:bool ->
+  Longident.t -> t -> Path.t * value_description
 val lookup_constructor:
-  ?loc:Location.t -> Longident.t -> t -> constructor_description
+  ?loc:Location.t -> ?mark:bool -> Longident.t -> t -> constructor_description
 val lookup_all_constructors:
-  ?loc:Location.t ->
+  ?loc:Location.t -> ?mark:bool ->
   Longident.t -> t -> (constructor_description * (unit -> unit)) list
 val lookup_label:
-  ?loc:Location.t -> Longident.t -> t -> label_description
+  ?loc:Location.t -> ?mark:bool ->
+  Longident.t -> t -> label_description
 val lookup_all_labels:
-  ?loc:Location.t ->
+  ?loc:Location.t -> ?mark:bool ->
   Longident.t -> t -> (label_description * (unit -> unit)) list
 val lookup_type:
-  ?loc:Location.t -> Longident.t -> t -> Path.t
+  ?loc:Location.t -> ?mark:bool -> Longident.t -> t -> Path.t
   (* Since 4.04, this function no longer returns [type_description].
      To obtain it, you should either call [Env.find_type], or replace
      it by [Typetexp.find_type] *)
 val lookup_module:
-  load:bool -> ?loc:Location.t -> Longident.t -> t -> Path.t
+  load:bool -> ?loc:Location.t -> ?mark:bool -> Longident.t -> t -> Path.t
 val lookup_modtype:
-  ?loc:Location.t -> Longident.t -> t -> Path.t * modtype_declaration
+  ?loc:Location.t -> ?mark:bool ->
+  Longident.t -> t -> Path.t * modtype_declaration
 val lookup_class:
-  ?loc:Location.t -> Longident.t -> t -> Path.t * class_declaration
+  ?loc:Location.t -> ?mark:bool ->
+  Longident.t -> t -> Path.t * class_declaration
 val lookup_cltype:
-  ?loc:Location.t -> Longident.t -> t -> Path.t * class_type_declaration
+  ?loc:Location.t -> ?mark:bool ->
+  Longident.t -> t -> Path.t * class_type_declaration
 
 val copy_types: string list -> t -> t
   (* Used only in Typecore.duplicate_ident_types. *)

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -236,7 +236,8 @@ let rc node =
 (* Enter a value in the method environment only *)
 let enter_met_env ?check loc lab kind ty val_env met_env par_env =
   let (id, val_env) =
-    Env.enter_value lab {val_type = ty; val_kind = Val_unbound;
+    Env.enter_value lab {val_type = ty;
+                         val_kind = Val_unbound Val_unbound_instance_variable;
                          val_attributes = [];
                          Types.val_loc = loc} val_env
   in
@@ -244,7 +245,8 @@ let enter_met_env ?check loc lab kind ty val_env met_env par_env =
    Env.add_value ?check id {val_type = ty; val_kind = kind;
                             val_attributes = [];
                             Types.val_loc = loc} met_env,
-   Env.add_value id {val_type = ty; val_kind = Val_unbound;
+   Env.add_value id {val_type = ty;
+                     val_kind = Val_unbound Val_unbound_instance_variable;
                      val_attributes = [];
                      Types.val_loc = loc} par_env)
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1529,7 +1529,8 @@ let type_self_pattern cl_num privty val_env met_env par_env spat =
     List.fold_right
       (fun (id, ty, _name, loc, as_var) (val_env, met_env, par_env) ->
          (Env.add_value id {val_type = ty;
-                            val_kind = Val_unbound;
+                            val_kind =
+                              Val_unbound Val_unbound_instance_variable;
                             val_attributes = [];
                             Types.val_loc = loc;
                            } val_env,
@@ -1541,7 +1542,9 @@ let type_self_pattern cl_num privty val_env met_env par_env spat =
             ~check:(fun s -> if as_var then Warnings.Unused_var s
                              else Warnings.Unused_var_strict s)
             met_env,
-          Env.add_value id {val_type = ty; val_kind = Val_unbound;
+          Env.add_value id {val_type = ty;
+                            val_kind =
+                              Val_unbound Val_unbound_instance_variable;
                             val_attributes = [];
                             Types.val_loc = loc;
                            } par_env))
@@ -2666,7 +2669,7 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
                   Env.lookup_value (Longident.Lident ("self-" ^ cl_num)) env
                 in
                 Texp_ident(path, lid, desc)
-            | Val_unbound ->
+            | Val_unbound Val_unbound_instance_variable ->
                 raise(Error(loc, env, Masked_instance_variable lid.txt))
             (*| Val_prim _ ->
                 let p = Env.normalize_path (Some loc) env path in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1457,13 +1457,13 @@ let add_pattern_variables ?check ?check_as env =
          } env
      )
      pv env,
-   get_ref module_variables)
+   get_ref module_variables, pv)
 
 let type_pattern ~lev env spat scope expected_ty =
   reset_pattern scope true;
   let new_env = ref env in
   let pat = type_pat ~allow_existentials:true ~lev new_env spat expected_ty in
-  let new_env, unpacks =
+  let new_env, unpacks, _ =
     add_pattern_variables !new_env
       ~check:(fun s -> Warnings.Unused_var_strict s)
       ~check_as:(fun s -> Warnings.Unused_var s) in
@@ -1479,8 +1479,8 @@ let type_pattern_list env spatl scope expected_tys allow =
       )
   in
   let patl = List.map2 type_pat spatl expected_tys in
-  let new_env, unpacks = add_pattern_variables !new_env in
-  (patl, new_env, get_ref pattern_force, unpacks)
+  let new_env, unpacks, pv = add_pattern_variables !new_env in
+  (patl, new_env, get_ref pattern_force, unpacks, pv)
 
 let type_class_arg_pattern cl_num val_env met_env l spat =
   reset_pattern None false;
@@ -1508,7 +1508,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
             env))
       !pattern_variables ([], met_env)
   in
-  let val_env, _ = add_pattern_variables val_env in
+  let val_env, _, _ = add_pattern_variables val_env in
   (pat, pv, val_env, met_env)
 
 let type_self_pattern cl_num privty val_env met_env par_env spat =
@@ -4663,7 +4663,7 @@ and type_let ?(check = fun s -> Warnings.Unused_var s)
         | _ -> spat)
       spat_sexp_list in
   let nvs = List.map (fun _ -> newvar ()) spatl in
-  let (pat_list, new_env, force, unpacks) =
+  let (pat_list, new_env, force, unpacks, _pv) =
     type_pattern_list env spatl scope nvs allow in
   let attrs_list = List.map fst spatl in
   let is_recursive = (rec_flag = Recursive) in

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -127,6 +127,7 @@ type error =
   | Illegal_letrec_pat
   | Illegal_letrec_expr
   | Illegal_class_expr
+  | Unbound_value_missing_rec of Longident.t * Location.t
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -104,7 +104,10 @@ and value_kind =
                                         (* Self *)
   | Val_anc of (string * Ident.t) list * string
                                         (* Ancestor *)
-  | Val_unbound                         (* Unbound variable *)
+  | Val_unbound of value_unbound_reason (* Unbound variable *)
+
+and value_unbound_reason =
+  | Val_unbound_instance_variable
 
 (* Variance *)
 

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -108,6 +108,7 @@ and value_kind =
 
 and value_unbound_reason =
   | Val_unbound_instance_variable
+  | Val_unbound_ghost_recursive
 
 (* Variance *)
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -259,7 +259,10 @@ and value_kind =
                                         (* Self *)
   | Val_anc of (string * Ident.t) list * string
                                         (* Ancestor *)
-  | Val_unbound                         (* Unbound variable *)
+  | Val_unbound of value_unbound_reason (* Unbound variable *)
+
+and value_unbound_reason =
+  | Val_unbound_instance_variable
 
 (* Variance *)
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -263,6 +263,7 @@ and value_kind =
 
 and value_unbound_reason =
   | Val_unbound_instance_variable
+  | Val_unbound_ghost_recursive
 
 (* Variance *)
 

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -114,7 +114,7 @@ let rec narrow_unbound_lid_error : 'a. _ -> _ -> _ -> _ -> 'a =
   end;
   raise (Error (loc, env, make_error lid))
 
-let find_component (lookup : ?loc:_ -> _) make_error env loc lid =
+let find_component (lookup : ?loc:_ -> ?mark:_ -> _) make_error env loc lid =
   try
     match lid with
     | Longident.Ldot (Longident.Lident "*predef*", s) ->
@@ -161,7 +161,7 @@ let find_value env loc lid =
   r
 
 let lookup_module ?(load=false) env loc lid =
-  find_component (fun ?loc lid env -> (Env.lookup_module ~load ?loc lid env))
+  find_component (fun ?loc ?mark lid env -> (Env.lookup_module ~load ?loc ?mark lid env))
     (fun lid -> Unbound_module lid) env loc lid
 
 let find_module env loc lid =


### PR DESCRIPTION
This is a first attempt at splitting "easy" and self-contained bits of PR #102 by @charguer, and follows an offline discussion involving @charguer, @gasche, @let-def and myself.
As described in http://chargueraud.org/research/2015/ocaml_errors/ocaml_errors.pdf (section 5, `Message for missing "rec"`), the purpose of the code extracted in this PR is to provide better error reporting for the case of a forgotten `rec` keyword.

In essence, what this PR does is additionally track in the environment "ghost" bindings for the non-recursive let-bindings that have been encountered. Then, in case of an unbound identifier, we additionally check if this identifier is present as a ghost binding in the environment. If this is the case, we display a error message indicating that a `rec` keyword may be missing at the binding site of this identifier.

In Arthur's original patch (and in the first commit of this PR), ghost bindings were implemented by adding a special string marker at the beginning of normal identifier. As this is relatively fragile, I rewrote this mechanism by adding a new kind of "ghost" bindings to typing environments. 

This is my first dive in this part of OCaml's source code, so it is very possible that this patch contains rookie mistakes. I'll be happy to take remarks and criticism :-) .