### PR TITLE
Add extended sequencing operators.

### DIFF
--- a/Changes
+++ b/Changes
@@ -13,6 +13,11 @@ be mentioned in the 4.06 section below instead of here.)
   (Nicolas Ojeda Bar, review by Gabriel Radanne, Damien Doligez, Gabriel
   Scherer)
 
+- GPR#1474: Add a new class of low precedence infix operators obtained by
+  prefixing the semicolon with one or more operator characters, subject to a
+  few constraints.  The operators are user definable, but best suited as
+  statement separators processed by PPX rewriters.
+
 ### Type system:
 
 - GPR#1370: Fix code duplication in Cmmgen

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -2354,3 +2354,21 @@ let dict =
 dict.Dict.%{"one"};;
 let open Dict in dict.%{"two"};;
 \end{caml_example}
+
+\section{Extended sequencing operators \label{s:sequencing-operators}}
+(Introduced in 4.07)
+
+\begin{syntax}
+semi-op-1: ('!'||'$'||'%'||'&'||'*'||'+'||'-'||'/'||':'||'<'||'='||'?'||'@'||'^'||'|'||'~') ;
+semi-op-2: ('!'||'$'||'%'||'&'||'*'||'+'||'-'||'/'||':'||'<'||'='||'>'||'?'||'@'||'^'||'|'||'~') ;
+semi-op: (semi-op-1 || semi-op-2 { semi-op-2 }) ';' ;
+expr: ... | expr semi-op expr ;
+\end{syntax}
+
+This extension provides a class of low-precedence infix operators operators
+suggested for representing sequences of statements. The operators are user
+definable, but best suited as an alternative to ";%ext" for PPX rewriters
+due to the expected need to control evaluation.
+
+These operators are right associative with a precedence just above "if", and
+thus above the bare semicolon.

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -294,6 +294,10 @@ let symbolchar =
   ['!' '$' '%' '&' '*' '+' '-' '.' '/' ':' '<' '=' '>' '?' '@' '^' '|' '~']
 let dotsymbolchar =
   ['!' '$' '%' '&' '*' '+' '-' '/' ':' '=' '>' '?' '@' '^' '|' '~']
+let semisymbolchar1 =
+  ['!' '$' '%' '&' '*' '+' '-' '/' ':' '<' '=' '?' '@' '^' '|' '~']
+let semisymbolchar2 =
+  ['!' '$' '%' '&' '*' '+' '-' '/' ':' '<' '=' '>' '?' '@' '^' '|' '~']
 let decimal_literal =
   ['0'-'9'] ['0'-'9' '_']*
 let hex_digit =
@@ -510,6 +514,8 @@ rule token = parse
             { INFIXOP3(Lexing.lexeme lexbuf) }
   | '#' (symbolchar | '#') +
             { HASHOP(Lexing.lexeme lexbuf) }
+  | (semisymbolchar1 | semisymbolchar2 semisymbolchar2 +) ';'
+            { SEMIOP(Lexing.lexeme lexbuf) }
   | eof { EOF }
   | _
       { raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -516,6 +516,7 @@ let package_type_of_module_type pmty =
 %token RPAREN
 %token SEMI
 %token SEMISEMI
+%token <string> SEMIOP
 %token HASH
 %token <string> HASHOP
 %token SIG
@@ -572,6 +573,7 @@ The precedences must be listed from low to high.
 %nonassoc AND             /* above WITH (module rec A: SIG with ... and ...) */
 %nonassoc THEN                          /* below ELSE (if ... then ...) */
 %nonassoc ELSE                          /* (if ... then ... else ...) */
+%right    SEMIOP                        /* expr (e OP e OP e) */
 %nonassoc LESSMINUS                     /* below COLONEQUAL (lbl <- x := e) */
 %right    COLONEQUAL                    /* expr (e := e := e) */
 %nonassoc AS
@@ -1398,6 +1400,8 @@ expr:
       { mkinfix $1 "&&" $3 }
   | expr COLONEQUAL expr
       { mkinfix $1 ":=" $3 }
+  | expr SEMIOP expr
+      { mkinfix $1 $2 $3 }
   | subtractive expr %prec prec_unary_minus
       { mkuminus $1 $2 }
   | additive expr %prec prec_unary_plus
@@ -2415,6 +2419,7 @@ operator:
   | DOTOP LBRACE RBRACE                         { "."^ $1 ^"{}" }
   | DOTOP LBRACE RBRACE LESSMINUS               { "."^ $1 ^ "{}<-" }
   | HASHOP                                      { $1 }
+  | SEMIOP                                      { $1 }
   | BANG                                        { "!" }
   | PLUS                                        { "+" }
   | PLUSDOT                                     { "+." }

--- a/testsuite/tests/parsing/extended_semicolon.ml
+++ b/testsuite/tests/parsing/extended_semicolon.ml
@@ -1,0 +1,133 @@
+(* State: A virtual bot on an integer grid with an ASCII pen. *)
+
+type world = {
+  dim: int * int;
+  trace: bytes;
+  pos: int * int;
+  vel: int * int;
+  pen: char;
+}
+
+let init (w, h) =
+  {dim = (w, h); trace = Bytes.make (w * h) ' '; pos = (0, 0); vel = (0, 0); pen = '-'}
+
+let dump {dim = (w, h); trace; _} =
+  for y = 0 to h - 1; do
+    print_endline (Bytes.sub_string trace (y * w) w)
+  done
+
+(* State Monad: Control and kinetics. *)
+
+type _ reg =
+  | Pos : (int * int) reg
+  | Vel : (int * int) reg
+  | Pen : char reg
+
+type _ action =
+  | Hold : (unit -> 'a) -> 'a action
+  | Bind : 'a action * ('a -> 'b action) -> 'b action
+  | Put : 'a reg * 'a -> unit action
+  | Get : 'a reg -> 'a action
+  | Step : unit action
+
+(* Monadic return and state handling. *)
+let return x = Hold (fun () -> x)
+let (:=) r x = Put (r, x)
+let get r = Get r
+
+(* Monadic bind and map. *)
+let (>>=) m mf = Bind (m, mf)
+let (>|=) m f = Bind (m, (fun x -> Hold (fun () -> f x)))
+
+(* Statement variants of bind and map. This is an approximation, would normally
+ * be implemented in PPX. *)
+let (>>;) m m' = Bind (m, (fun () -> m'))
+let (>|;) m s = m
+
+(* An alias for ";" which mixes better with the above. Without support from a
+ * PPX the evaluation is closer to plain wrong than an approximation. *)
+let (-;) s v = v
+
+let rec run : type a. a action -> world -> a * world = function
+ | Hold f -> fun world -> (f (), world)
+ | Bind (m, f) -> fun world -> let x, world' = run m world in run (f x) world'
+ | Get Pos -> fun world -> (world.pos, world)
+ | Get Vel -> fun world -> (world.vel, world)
+ | Get Pen -> fun world -> (world.pen, world)
+ | Put (Pos, pos) -> fun world -> ((), {world with pos})
+ | Put (Vel, vel) -> fun world -> ((), {world with vel})
+ | Put (Pen, pen) -> fun world -> ((), {world with pen})
+ | Step -> fun world ->
+    let (w, h), (x, y), (vx, vy) = world.dim, world.pos, world.vel in
+    Bytes.set world.trace (x + w * y) world.pen;
+    let (x', y') = ((x + vx + w) mod w, (y + vy + h) mod h) in
+    ((), {world with pos = (x', y')})
+
+(* Main: Drawing Triangles *)
+
+let rec repeat n m =
+  (* The semicolon operators have higher precedence than conditions, so this
+   * works as intended: *)
+  if n > 0 then
+    m >>;
+    repeat (n - 1) m
+  else
+    assert (n = 0) -;
+    return ()
+
+let draw_triangle n =
+  get Pos >>= fun (xI, yI) ->
+
+  (* The (>>;) operator has lower precedence than (:=). *)
+  Vel := (1, 1) >>;
+  repeat n Step >>;
+  Vel := (1, -1) >>;
+  repeat n Step >>;
+  Vel := (-1, 0) >>;
+  repeat (2 * n) Step >>;
+
+  (* The (>>=) operator has significantly higher precedence than (>>;), but the
+   * following still groups as expected, since (>>;) associates to the right,
+   * and the right hand side of (>>=) will be delimited by the lambda. *)
+  get Pos >>= fun (xF, yF) ->
+  Vel := (0, 0) >>;
+  assert (xF = xI && yF = yI) -; (* Voilà, no parentheses! *)
+  Pos := (0, 0)
+
+let draw_text w s =
+  get Pos >>= fun (x0, _) ->
+  Vel := (1, 0) >>;
+  let rec aux i c =
+    if i = String.length s then
+      return ()
+    else if c > w && s.[i] = ' ' then
+      get Pos >>= fun (_, y) ->
+      Pos := (x0, y + 1) >>;
+      aux (i + 1) 0
+    else
+      Pen := s.[i] >>;
+      Step >>;
+      aux (i + 1) (c + 1) in
+  aux 0 0
+
+let test =
+  Pos := (2, 9) >>;
+  Pen := '-' >>;
+  draw_triangle 8 >>;
+
+  Pos := (4, 6) >>;
+  Pen := '+' >>;
+  draw_triangle 10 >>;
+
+  Pen := '#' >>;
+  Pos := (6, 1) >>;
+  draw_triangle 14 >>;
+
+  Pos := (29, 11) >>;
+  draw_text 10 "These are not three triangles along a third dimension." >|;
+
+  (* If we had a proper rewriter for (>|;) this statement would have been
+   * sequenced into the monad. *)
+  assert true
+
+let () = (72, 19) |> init |> run test |> snd |> dump

--- a/testsuite/tests/parsing/extended_semicolon.ml.reference
+++ b/testsuite/tests/parsing/extended_semicolon.ml.reference
@@ -1,0 +1,2454 @@
+[
+  structure_item (extended_semicolon.ml[3,66+0]..[9,164+1])
+    Pstr_type Rec
+    [
+      type_declaration "world" (extended_semicolon.ml[3,66+5]..[3,66+10]) (extended_semicolon.ml[3,66+0]..[9,164+1])
+        ptype_params =
+          []
+        ptype_cstrs =
+          []
+        ptype_kind =
+          Ptype_record
+            [
+              (extended_semicolon.ml[4,81+2]..[4,81+17])
+                Immutable
+                "dim" (extended_semicolon.ml[4,81+2]..[4,81+5])                core_type (extended_semicolon.ml[4,81+7]..[4,81+16])
+                  Ptyp_tuple
+                  [
+                    core_type (extended_semicolon.ml[4,81+7]..[4,81+10])
+                      Ptyp_constr "int" (extended_semicolon.ml[4,81+7]..[4,81+10])
+                      []
+                    core_type (extended_semicolon.ml[4,81+13]..[4,81+16])
+                      Ptyp_constr "int" (extended_semicolon.ml[4,81+13]..[4,81+16])
+                      []
+                  ]
+              (extended_semicolon.ml[5,99+2]..[5,99+15])
+                Immutable
+                "trace" (extended_semicolon.ml[5,99+2]..[5,99+7])                core_type (extended_semicolon.ml[5,99+9]..[5,99+14])
+                  Ptyp_constr "bytes" (extended_semicolon.ml[5,99+9]..[5,99+14])
+                  []
+              (extended_semicolon.ml[6,115+2]..[6,115+17])
+                Immutable
+                "pos" (extended_semicolon.ml[6,115+2]..[6,115+5])                core_type (extended_semicolon.ml[6,115+7]..[6,115+16])
+                  Ptyp_tuple
+                  [
+                    core_type (extended_semicolon.ml[6,115+7]..[6,115+10])
+                      Ptyp_constr "int" (extended_semicolon.ml[6,115+7]..[6,115+10])
+                      []
+                    core_type (extended_semicolon.ml[6,115+13]..[6,115+16])
+                      Ptyp_constr "int" (extended_semicolon.ml[6,115+13]..[6,115+16])
+                      []
+                  ]
+              (extended_semicolon.ml[7,133+2]..[7,133+17])
+                Immutable
+                "vel" (extended_semicolon.ml[7,133+2]..[7,133+5])                core_type (extended_semicolon.ml[7,133+7]..[7,133+16])
+                  Ptyp_tuple
+                  [
+                    core_type (extended_semicolon.ml[7,133+7]..[7,133+10])
+                      Ptyp_constr "int" (extended_semicolon.ml[7,133+7]..[7,133+10])
+                      []
+                    core_type (extended_semicolon.ml[7,133+13]..[7,133+16])
+                      Ptyp_constr "int" (extended_semicolon.ml[7,133+13]..[7,133+16])
+                      []
+                  ]
+              (extended_semicolon.ml[8,151+2]..[8,151+12])
+                Immutable
+                "pen" (extended_semicolon.ml[8,151+2]..[8,151+5])                core_type (extended_semicolon.ml[8,151+7]..[8,151+11])
+                  Ptyp_constr "char" (extended_semicolon.ml[8,151+7]..[8,151+11])
+                  []
+            ]
+        ptype_private = Public
+        ptype_manifest =
+          None
+    ]
+  structure_item (extended_semicolon.ml[11,167+0]..[12,185+87])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_semicolon.ml[11,167+4]..[11,167+8])
+          Ppat_var "init" (extended_semicolon.ml[11,167+4]..[11,167+8])
+        expression (extended_semicolon.ml[11,167+9]..[12,185+87]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_semicolon.ml[11,167+9]..[11,167+15])
+            Ppat_tuple
+            [
+              pattern (extended_semicolon.ml[11,167+10]..[11,167+11])
+                Ppat_var "w" (extended_semicolon.ml[11,167+10]..[11,167+11])
+              pattern (extended_semicolon.ml[11,167+13]..[11,167+14])
+                Ppat_var "h" (extended_semicolon.ml[11,167+13]..[11,167+14])
+            ]
+          expression (extended_semicolon.ml[12,185+2]..[12,185+87])
+            Pexp_record
+            [
+              "dim" (extended_semicolon.ml[12,185+3]..[12,185+6])
+                expression (extended_semicolon.ml[12,185+9]..[12,185+15])
+                  Pexp_tuple
+                  [
+                    expression (extended_semicolon.ml[12,185+10]..[12,185+11])
+                      Pexp_ident "w" (extended_semicolon.ml[12,185+10]..[12,185+11])
+                    expression (extended_semicolon.ml[12,185+13]..[12,185+14])
+                      Pexp_ident "h" (extended_semicolon.ml[12,185+13]..[12,185+14])
+                  ]
+              "trace" (extended_semicolon.ml[12,185+17]..[12,185+22])
+                expression (extended_semicolon.ml[12,185+25]..[12,185+47])
+                  Pexp_apply
+                  expression (extended_semicolon.ml[12,185+25]..[12,185+35])
+                    Pexp_ident "Bytes.make" (extended_semicolon.ml[12,185+25]..[12,185+35])
+                  [
+                    <arg>
+                    Nolabel
+                      expression (extended_semicolon.ml[12,185+36]..[12,185+43])
+                        Pexp_apply
+                        expression (extended_semicolon.ml[12,185+39]..[12,185+40])
+                          Pexp_ident "*" (extended_semicolon.ml[12,185+39]..[12,185+40])
+                        [
+                          <arg>
+                          Nolabel
+                            expression (extended_semicolon.ml[12,185+37]..[12,185+38])
+                              Pexp_ident "w" (extended_semicolon.ml[12,185+37]..[12,185+38])
+                          <arg>
+                          Nolabel
+                            expression (extended_semicolon.ml[12,185+41]..[12,185+42])
+                              Pexp_ident "h" (extended_semicolon.ml[12,185+41]..[12,185+42])
+                        ]
+                    <arg>
+                    Nolabel
+                      expression (extended_semicolon.ml[12,185+44]..[12,185+47])
+                        Pexp_constant PConst_char 20
+                  ]
+              "pos" (extended_semicolon.ml[12,185+49]..[12,185+52])
+                expression (extended_semicolon.ml[12,185+55]..[12,185+61])
+                  Pexp_tuple
+                  [
+                    expression (extended_semicolon.ml[12,185+56]..[12,185+57])
+                      Pexp_constant PConst_int (0,None)
+                    expression (extended_semicolon.ml[12,185+59]..[12,185+60])
+                      Pexp_constant PConst_int (0,None)
+                  ]
+              "vel" (extended_semicolon.ml[12,185+63]..[12,185+66])
+                expression (extended_semicolon.ml[12,185+69]..[12,185+75])
+                  Pexp_tuple
+                  [
+                    expression (extended_semicolon.ml[12,185+70]..[12,185+71])
+                      Pexp_constant PConst_int (0,None)
+                    expression (extended_semicolon.ml[12,185+73]..[12,185+74])
+                      Pexp_constant PConst_int (0,None)
+                  ]
+              "pen" (extended_semicolon.ml[12,185+77]..[12,185+80])
+                expression (extended_semicolon.ml[12,185+83]..[12,185+86])
+                  Pexp_constant PConst_char 2d
+            ]
+            None
+    ]
+  structure_item (extended_semicolon.ml[14,274+0]..[17,388+6])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_semicolon.ml[14,274+4]..[14,274+8])
+          Ppat_var "dump" (extended_semicolon.ml[14,274+4]..[14,274+8])
+        expression (extended_semicolon.ml[14,274+9]..[17,388+6]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_semicolon.ml[14,274+9]..[14,274+33])
+            Ppat_record Open
+            [
+              "dim" (extended_semicolon.ml[14,274+10]..[14,274+13])
+                pattern (extended_semicolon.ml[14,274+16]..[14,274+22])
+                  Ppat_tuple
+                  [
+                    pattern (extended_semicolon.ml[14,274+17]..[14,274+18])
+                      Ppat_var "w" (extended_semicolon.ml[14,274+17]..[14,274+18])
+                    pattern (extended_semicolon.ml[14,274+20]..[14,274+21])
+                      Ppat_var "h" (extended_semicolon.ml[14,274+20]..[14,274+21])
+                  ]
+              "trace" (extended_semicolon.ml[14,274+24]..[14,274+29])
+                pattern (extended_semicolon.ml[14,274+24]..[14,274+29])
+                  Ppat_var "trace" (extended_semicolon.ml[14,274+24]..[14,274+29])
+            ]
+          expression (extended_semicolon.ml[15,310+2]..[17,388+6])
+            Pexp_for Up
+            pattern (extended_semicolon.ml[15,310+6]..[15,310+7])
+              Ppat_var "y" (extended_semicolon.ml[15,310+6]..[15,310+7])
+            expression (extended_semicolon.ml[15,310+10]..[15,310+11])
+              Pexp_constant PConst_int (0,None)
+            expression (extended_semicolon.ml[15,310+15]..[15,310+20])
+              Pexp_apply
+              expression (extended_semicolon.ml[15,310+17]..[15,310+18])
+                Pexp_ident "-" (extended_semicolon.ml[15,310+17]..[15,310+18])
+              [
+                <arg>
+                Nolabel
+                  expression (extended_semicolon.ml[15,310+15]..[15,310+16])
+                    Pexp_ident "h" (extended_semicolon.ml[15,310+15]..[15,310+16])
+                <arg>
+                Nolabel
+                  expression (extended_semicolon.ml[15,310+19]..[15,310+20])
+                    Pexp_constant PConst_int (1,None)
+              ]
+            expression (extended_semicolon.ml[16,335+4]..[16,335+52])
+              Pexp_apply
+              expression (extended_semicolon.ml[16,335+4]..[16,335+17])
+                Pexp_ident "print_endline" (extended_semicolon.ml[16,335+4]..[16,335+17])
+              [
+                <arg>
+                Nolabel
+                  expression (extended_semicolon.ml[16,335+18]..[16,335+52])
+                    Pexp_apply
+                    expression (extended_semicolon.ml[16,335+19]..[16,335+35])
+                      Pexp_ident "Bytes.sub_string" (extended_semicolon.ml[16,335+19]..[16,335+35])
+                    [
+                      <arg>
+                      Nolabel
+                        expression (extended_semicolon.ml[16,335+36]..[16,335+41])
+                          Pexp_ident "trace" (extended_semicolon.ml[16,335+36]..[16,335+41])
+                      <arg>
+                      Nolabel
+                        expression (extended_semicolon.ml[16,335+42]..[16,335+49])
+                          Pexp_apply
+                          expression (extended_semicolon.ml[16,335+45]..[16,335+46])
+                            Pexp_ident "*" (extended_semicolon.ml[16,335+45]..[16,335+46])
+                          [
+                            <arg>
+                            Nolabel
+                              expression (extended_semicolon.ml[16,335+43]..[16,335+44])
+                                Pexp_ident "y" (extended_semicolon.ml[16,335+43]..[16,335+44])
+                            <arg>
+                            Nolabel
+                              expression (extended_semicolon.ml[16,335+47]..[16,335+48])
+                                Pexp_ident "w" (extended_semicolon.ml[16,335+47]..[16,335+48])
+                          ]
+                      <arg>
+                      Nolabel
+                        expression (extended_semicolon.ml[16,335+50]..[16,335+51])
+                          Pexp_ident "w" (extended_semicolon.ml[16,335+50]..[16,335+51])
+                    ]
+              ]
+    ]
+  structure_item (extended_semicolon.ml[21,438+0]..[24,503+18])
+    Pstr_type Rec
+    [
+      type_declaration "reg" (extended_semicolon.ml[21,438+7]..[21,438+10]) (extended_semicolon.ml[21,438+0]..[24,503+18])
+        ptype_params =
+          [
+            core_type (extended_semicolon.ml[21,438+5]..[21,438+6])
+              Ptyp_any
+          ]
+        ptype_cstrs =
+          []
+        ptype_kind =
+          Ptype_variant
+            [
+              (extended_semicolon.ml[22,451+2]..[22,451+25])
+                "Pos" (extended_semicolon.ml[22,451+4]..[22,451+7])
+                []
+                Some
+                  core_type (extended_semicolon.ml[22,451+10]..[22,451+25])
+                    Ptyp_constr "reg" (extended_semicolon.ml[22,451+22]..[22,451+25])
+                    [
+                      core_type (extended_semicolon.ml[22,451+11]..[22,451+20])
+                        Ptyp_tuple
+                        [
+                          core_type (extended_semicolon.ml[22,451+11]..[22,451+14])
+                            Ptyp_constr "int" (extended_semicolon.ml[22,451+11]..[22,451+14])
+                            []
+                          core_type (extended_semicolon.ml[22,451+17]..[22,451+20])
+                            Ptyp_constr "int" (extended_semicolon.ml[22,451+17]..[22,451+20])
+                            []
+                        ]
+                    ]
+              (extended_semicolon.ml[23,477+2]..[23,477+25])
+                "Vel" (extended_semicolon.ml[23,477+4]..[23,477+7])
+                []
+                Some
+                  core_type (extended_semicolon.ml[23,477+10]..[23,477+25])
+                    Ptyp_constr "reg" (extended_semicolon.ml[23,477+22]..[23,477+25])
+                    [
+                      core_type (extended_semicolon.ml[23,477+11]..[23,477+20])
+                        Ptyp_tuple
+                        [
+                          core_type (extended_semicolon.ml[23,477+11]..[23,477+14])
+                            Ptyp_constr "int" (extended_semicolon.ml[23,477+11]..[23,477+14])
+                            []
+                          core_type (extended_semicolon.ml[23,477+17]..[23,477+20])
+                            Ptyp_constr "int" (extended_semicolon.ml[23,477+17]..[23,477+20])
+                            []
+                        ]
+                    ]
+              (extended_semicolon.ml[24,503+2]..[24,503+18])
+                "Pen" (extended_semicolon.ml[24,503+4]..[24,503+7])
+                []
+                Some
+                  core_type (extended_semicolon.ml[24,503+10]..[24,503+18])
+                    Ptyp_constr "reg" (extended_semicolon.ml[24,503+15]..[24,503+18])
+                    [
+                      core_type (extended_semicolon.ml[24,503+10]..[24,503+14])
+                        Ptyp_constr "char" (extended_semicolon.ml[24,503+10]..[24,503+14])
+                        []
+                    ]
+            ]
+        ptype_private = Public
+        ptype_manifest =
+          None
+    ]
+  structure_item (extended_semicolon.ml[26,523+0]..[31,697+22])
+    Pstr_type Rec
+    [
+      type_declaration "action" (extended_semicolon.ml[26,523+7]..[26,523+13]) (extended_semicolon.ml[26,523+0]..[31,697+22])
+        ptype_params =
+          [
+            core_type (extended_semicolon.ml[26,523+5]..[26,523+6])
+              Ptyp_any
+          ]
+        ptype_cstrs =
+          []
+        ptype_kind =
+          Ptype_variant
+            [
+              (extended_semicolon.ml[27,539+2]..[27,539+36])
+                "Hold" (extended_semicolon.ml[27,539+4]..[27,539+8])
+                [
+                  core_type (extended_semicolon.ml[27,539+12]..[27,539+22])
+                    Ptyp_arrow
+                    Nolabel
+                    core_type (extended_semicolon.ml[27,539+12]..[27,539+16])
+                      Ptyp_constr "unit" (extended_semicolon.ml[27,539+12]..[27,539+16])
+                      []
+                    core_type (extended_semicolon.ml[27,539+20]..[27,539+22])
+                      Ptyp_var a
+                ]
+                Some
+                  core_type (extended_semicolon.ml[27,539+27]..[27,539+36])
+                    Ptyp_constr "action" (extended_semicolon.ml[27,539+30]..[27,539+36])
+                    [
+                      core_type (extended_semicolon.ml[27,539+27]..[27,539+29])
+                        Ptyp_var a
+                    ]
+              (extended_semicolon.ml[28,576+2]..[28,576+53])
+                "Bind" (extended_semicolon.ml[28,576+4]..[28,576+8])
+                [
+                  core_type (extended_semicolon.ml[28,576+11]..[28,576+20])
+                    Ptyp_constr "action" (extended_semicolon.ml[28,576+14]..[28,576+20])
+                    [
+                      core_type (extended_semicolon.ml[28,576+11]..[28,576+13])
+                        Ptyp_var a
+                    ]
+                  core_type (extended_semicolon.ml[28,576+24]..[28,576+39])
+                    Ptyp_arrow
+                    Nolabel
+                    core_type (extended_semicolon.ml[28,576+24]..[28,576+26])
+                      Ptyp_var a
+                    core_type (extended_semicolon.ml[28,576+30]..[28,576+39])
+                      Ptyp_constr "action" (extended_semicolon.ml[28,576+33]..[28,576+39])
+                      [
+                        core_type (extended_semicolon.ml[28,576+30]..[28,576+32])
+                          Ptyp_var b
+                      ]
+                ]
+                Some
+                  core_type (extended_semicolon.ml[28,576+44]..[28,576+53])
+                    Ptyp_constr "action" (extended_semicolon.ml[28,576+47]..[28,576+53])
+                    [
+                      core_type (extended_semicolon.ml[28,576+44]..[28,576+46])
+                        Ptyp_var b
+                    ]
+              (extended_semicolon.ml[29,630+2]..[29,630+36])
+                "Put" (extended_semicolon.ml[29,630+4]..[29,630+7])
+                [
+                  core_type (extended_semicolon.ml[29,630+10]..[29,630+16])
+                    Ptyp_constr "reg" (extended_semicolon.ml[29,630+13]..[29,630+16])
+                    [
+                      core_type (extended_semicolon.ml[29,630+10]..[29,630+12])
+                        Ptyp_var a
+                    ]
+                  core_type (extended_semicolon.ml[29,630+19]..[29,630+21])
+                    Ptyp_var a
+                ]
+                Some
+                  core_type (extended_semicolon.ml[29,630+25]..[29,630+36])
+                    Ptyp_constr "action" (extended_semicolon.ml[29,630+30]..[29,630+36])
+                    [
+                      core_type (extended_semicolon.ml[29,630+25]..[29,630+29])
+                        Ptyp_constr "unit" (extended_semicolon.ml[29,630+25]..[29,630+29])
+                        []
+                    ]
+              (extended_semicolon.ml[30,667+2]..[30,667+29])
+                "Get" (extended_semicolon.ml[30,667+4]..[30,667+7])
+                [
+                  core_type (extended_semicolon.ml[30,667+10]..[30,667+16])
+                    Ptyp_constr "reg" (extended_semicolon.ml[30,667+13]..[30,667+16])
+                    [
+                      core_type (extended_semicolon.ml[30,667+10]..[30,667+12])
+                        Ptyp_var a
+                    ]
+                ]
+                Some
+                  core_type (extended_semicolon.ml[30,667+20]..[30,667+29])
+                    Ptyp_constr "action" (extended_semicolon.ml[30,667+23]..[30,667+29])
+                    [
+                      core_type (extended_semicolon.ml[30,667+20]..[30,667+22])
+                        Ptyp_var a
+                    ]
+              (extended_semicolon.ml[31,697+2]..[31,697+22])
+                "Step" (extended_semicolon.ml[31,697+4]..[31,697+8])
+                []
+                Some
+                  core_type (extended_semicolon.ml[31,697+11]..[31,697+22])
+                    Ptyp_constr "action" (extended_semicolon.ml[31,697+16]..[31,697+22])
+                    [
+                      core_type (extended_semicolon.ml[31,697+11]..[31,697+15])
+                        Ptyp_constr "unit" (extended_semicolon.ml[31,697+11]..[31,697+15])
+                        []
+                    ]
+            ]
+        ptype_private = Public
+        ptype_manifest =
+          None
+    ]
+  structure_item (extended_semicolon.ml[34,762+0]..[34,762+33])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_semicolon.ml[34,762+4]..[34,762+10])
+          Ppat_var "return" (extended_semicolon.ml[34,762+4]..[34,762+10])
+        expression (extended_semicolon.ml[34,762+11]..[34,762+33]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_semicolon.ml[34,762+11]..[34,762+12])
+            Ppat_var "x" (extended_semicolon.ml[34,762+11]..[34,762+12])
+          expression (extended_semicolon.ml[34,762+15]..[34,762+33])
+            Pexp_construct "Hold" (extended_semicolon.ml[34,762+15]..[34,762+19])
+            Some
+              expression (extended_semicolon.ml[34,762+20]..[34,762+33])
+                Pexp_fun
+                Nolabel
+                None
+                pattern (extended_semicolon.ml[34,762+25]..[34,762+27])
+                  Ppat_construct "()" (extended_semicolon.ml[34,762+25]..[34,762+27])
+                  None
+                expression (extended_semicolon.ml[34,762+31]..[34,762+32])
+                  Pexp_ident "x" (extended_semicolon.ml[34,762+31]..[34,762+32])
+    ]
+  structure_item (extended_semicolon.ml[35,796+0]..[35,796+25])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_semicolon.ml[35,796+4]..[35,796+8])
+          Ppat_var ":=" (extended_semicolon.ml[35,796+4]..[35,796+8])
+        expression (extended_semicolon.ml[35,796+9]..[35,796+25]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_semicolon.ml[35,796+9]..[35,796+10])
+            Ppat_var "r" (extended_semicolon.ml[35,796+9]..[35,796+10])
+          expression (extended_semicolon.ml[35,796+11]..[35,796+25]) ghost
+            Pexp_fun
+            Nolabel
+            None
+            pattern (extended_semicolon.ml[35,796+11]..[35,796+12])
+              Ppat_var "x" (extended_semicolon.ml[35,796+11]..[35,796+12])
+            expression (extended_semicolon.ml[35,796+15]..[35,796+25])
+              Pexp_construct "Put" (extended_semicolon.ml[35,796+15]..[35,796+18])
+              Some
+                expression (extended_semicolon.ml[35,796+19]..[35,796+25])
+                  Pexp_tuple
+                  [
+                    expression (extended_semicolon.ml[35,796+20]..[35,796+21])
+                      Pexp_ident "r" (extended_semicolon.ml[35,796+20]..[35,796+21])
+                    expression (extended_semicolon.ml[35,796+23]..[35,796+24])
+                      Pexp_ident "x" (extended_semicolon.ml[35,796+23]..[35,796+24])
+                  ]
+    ]
+  structure_item (extended_semicolon.ml[36,822+0]..[36,822+17])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_semicolon.ml[36,822+4]..[36,822+7])
+          Ppat_var "get" (extended_semicolon.ml[36,822+4]..[36,822+7])
+        expression (extended_semicolon.ml[36,822+8]..[36,822+17]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_semicolon.ml[36,822+8]..[36,822+9])
+            Ppat_var "r" (extended_semicolon.ml[36,822+8]..[36,822+9])
+          expression (extended_semicolon.ml[36,822+12]..[36,822+17])
+            Pexp_construct "Get" (extended_semicolon.ml[36,822+12]..[36,822+15])
+            Some
+              expression (extended_semicolon.ml[36,822+16]..[36,822+17])
+                Pexp_ident "r" (extended_semicolon.ml[36,822+16]..[36,822+17])
+    ]
+  structure_item (extended_semicolon.ml[39,869+0]..[39,869+29])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_semicolon.ml[39,869+4]..[39,869+9])
+          Ppat_var ">>=" (extended_semicolon.ml[39,869+4]..[39,869+9])
+        expression (extended_semicolon.ml[39,869+10]..[39,869+29]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_semicolon.ml[39,869+10]..[39,869+11])
+            Ppat_var "m" (extended_semicolon.ml[39,869+10]..[39,869+11])
+          expression (extended_semicolon.ml[39,869+12]..[39,869+29]) ghost
+            Pexp_fun
+            Nolabel
+            None
+            pattern (extended_semicolon.ml[39,869+12]..[39,869+14])
+              Ppat_var "mf" (extended_semicolon.ml[39,869+12]..[39,869+14])
+            expression (extended_semicolon.ml[39,869+17]..[39,869+29])
+              Pexp_construct "Bind" (extended_semicolon.ml[39,869+17]..[39,869+21])
+              Some
+                expression (extended_semicolon.ml[39,869+22]..[39,869+29])
+                  Pexp_tuple
+                  [
+                    expression (extended_semicolon.ml[39,869+23]..[39,869+24])
+                      Pexp_ident "m" (extended_semicolon.ml[39,869+23]..[39,869+24])
+                    expression (extended_semicolon.ml[39,869+26]..[39,869+28])
+                      Pexp_ident "mf" (extended_semicolon.ml[39,869+26]..[39,869+28])
+                  ]
+    ]
+  structure_item (extended_semicolon.ml[40,899+0]..[40,899+57])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_semicolon.ml[40,899+4]..[40,899+9])
+          Ppat_var ">|=" (extended_semicolon.ml[40,899+4]..[40,899+9])
+        expression (extended_semicolon.ml[40,899+10]..[40,899+57]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_semicolon.ml[40,899+10]..[40,899+11])
+            Ppat_var "m" (extended_semicolon.ml[40,899+10]..[40,899+11])
+          expression (extended_semicolon.ml[40,899+12]..[40,899+57]) ghost
+            Pexp_fun
+            Nolabel
+            None
+            pattern (extended_semicolon.ml[40,899+12]..[40,899+13])
+              Ppat_var "f" (extended_semicolon.ml[40,899+12]..[40,899+13])
+            expression (extended_semicolon.ml[40,899+16]..[40,899+57])
+              Pexp_construct "Bind" (extended_semicolon.ml[40,899+16]..[40,899+20])
+              Some
+                expression (extended_semicolon.ml[40,899+21]..[40,899+57])
+                  Pexp_tuple
+                  [
+                    expression (extended_semicolon.ml[40,899+22]..[40,899+23])
+                      Pexp_ident "m" (extended_semicolon.ml[40,899+22]..[40,899+23])
+                    expression (extended_semicolon.ml[40,899+25]..[40,899+56])
+                      Pexp_fun
+                      Nolabel
+                      None
+                      pattern (extended_semicolon.ml[40,899+30]..[40,899+31])
+                        Ppat_var "x" (extended_semicolon.ml[40,899+30]..[40,899+31])
+                      expression (extended_semicolon.ml[40,899+35]..[40,899+55])
+                        Pexp_construct "Hold" (extended_semicolon.ml[40,899+35]..[40,899+39])
+                        Some
+                          expression (extended_semicolon.ml[40,899+40]..[40,899+55])
+                            Pexp_fun
+                            Nolabel
+                            None
+                            pattern (extended_semicolon.ml[40,899+45]..[40,899+47])
+                              Ppat_construct "()" (extended_semicolon.ml[40,899+45]..[40,899+47])
+                              None
+                            expression (extended_semicolon.ml[40,899+51]..[40,899+54])
+                              Pexp_apply
+                              expression (extended_semicolon.ml[40,899+51]..[40,899+52])
+                                Pexp_ident "f" (extended_semicolon.ml[40,899+51]..[40,899+52])
+                              [
+                                <arg>
+                                Nolabel
+                                  expression (extended_semicolon.ml[40,899+53]..[40,899+54])
+                                    Pexp_ident "x" (extended_semicolon.ml[40,899+53]..[40,899+54])
+                              ]
+                  ]
+    ]
+  structure_item (extended_semicolon.ml[44,1067+0]..[44,1067+41])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_semicolon.ml[44,1067+4]..[44,1067+9])
+          Ppat_var ">>;" (extended_semicolon.ml[44,1067+4]..[44,1067+9])
+        expression (extended_semicolon.ml[44,1067+10]..[44,1067+41]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_semicolon.ml[44,1067+10]..[44,1067+11])
+            Ppat_var "m" (extended_semicolon.ml[44,1067+10]..[44,1067+11])
+          expression (extended_semicolon.ml[44,1067+12]..[44,1067+41]) ghost
+            Pexp_fun
+            Nolabel
+            None
+            pattern (extended_semicolon.ml[44,1067+12]..[44,1067+14])
+              Ppat_var "m'" (extended_semicolon.ml[44,1067+12]..[44,1067+14])
+            expression (extended_semicolon.ml[44,1067+17]..[44,1067+41])
+              Pexp_construct "Bind" (extended_semicolon.ml[44,1067+17]..[44,1067+21])
+              Some
+                expression (extended_semicolon.ml[44,1067+22]..[44,1067+41])
+                  Pexp_tuple
+                  [
+                    expression (extended_semicolon.ml[44,1067+23]..[44,1067+24])
+                      Pexp_ident "m" (extended_semicolon.ml[44,1067+23]..[44,1067+24])
+                    expression (extended_semicolon.ml[44,1067+26]..[44,1067+40])
+                      Pexp_fun
+                      Nolabel
+                      None
+                      pattern (extended_semicolon.ml[44,1067+31]..[44,1067+33])
+                        Ppat_construct "()" (extended_semicolon.ml[44,1067+31]..[44,1067+33])
+                        None
+                      expression (extended_semicolon.ml[44,1067+37]..[44,1067+39])
+                        Pexp_ident "m'" (extended_semicolon.ml[44,1067+37]..[44,1067+39])
+                  ]
+    ]
+  structure_item (extended_semicolon.ml[45,1109+0]..[45,1109+17])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_semicolon.ml[45,1109+4]..[45,1109+9])
+          Ppat_var ">|;" (extended_semicolon.ml[45,1109+4]..[45,1109+9])
+        expression (extended_semicolon.ml[45,1109+10]..[45,1109+17]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_semicolon.ml[45,1109+10]..[45,1109+11])
+            Ppat_var "m" (extended_semicolon.ml[45,1109+10]..[45,1109+11])
+          expression (extended_semicolon.ml[45,1109+12]..[45,1109+17]) ghost
+            Pexp_fun
+            Nolabel
+            None
+            pattern (extended_semicolon.ml[45,1109+12]..[45,1109+13])
+              Ppat_var "s" (extended_semicolon.ml[45,1109+12]..[45,1109+13])
+            expression (extended_semicolon.ml[45,1109+16]..[45,1109+17])
+              Pexp_ident "m" (extended_semicolon.ml[45,1109+16]..[45,1109+17])
+    ]
+  structure_item (extended_semicolon.ml[49,1279+0]..[49,1279+16])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_semicolon.ml[49,1279+4]..[49,1279+8])
+          Ppat_var "-;" (extended_semicolon.ml[49,1279+4]..[49,1279+8])
+        expression (extended_semicolon.ml[49,1279+9]..[49,1279+16]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_semicolon.ml[49,1279+9]..[49,1279+10])
+            Ppat_var "s" (extended_semicolon.ml[49,1279+9]..[49,1279+10])
+          expression (extended_semicolon.ml[49,1279+11]..[49,1279+16]) ghost
+            Pexp_fun
+            Nolabel
+            None
+            pattern (extended_semicolon.ml[49,1279+11]..[49,1279+12])
+              Ppat_var "v" (extended_semicolon.ml[49,1279+11]..[49,1279+12])
+            expression (extended_semicolon.ml[49,1279+15]..[49,1279+16])
+              Pexp_ident "v" (extended_semicolon.ml[49,1279+15]..[49,1279+16])
+    ]
+  structure_item (extended_semicolon.ml[51,1297+0]..[64,1995+37])
+    Pstr_value Rec
+    [
+      <def>
+        pattern (extended_semicolon.ml[51,1297+8]..[64,1995+37]) ghost
+          Ppat_constraint
+          pattern (extended_semicolon.ml[51,1297+8]..[51,1297+11])
+            Ppat_var "run" (extended_semicolon.ml[51,1297+8]..[51,1297+11])
+          core_type (extended_semicolon.ml[51,1297+8]..[64,1995+37]) ghost
+            Ptyp_poly 'a
+            core_type (extended_semicolon.ml[51,1297+22]..[51,1297+52])
+              Ptyp_arrow
+              Nolabel
+              core_type (extended_semicolon.ml[51,1297+22]..[51,1297+30])
+                Ptyp_constr "action" (extended_semicolon.ml[51,1297+24]..[51,1297+30])
+                [
+                  core_type (extended_semicolon.ml[51,1297+22]..[51,1297+23])
+                    Ptyp_var a
+                ]
+              core_type (extended_semicolon.ml[51,1297+34]..[51,1297+52])
+                Ptyp_arrow
+                Nolabel
+                core_type (extended_semicolon.ml[51,1297+34]..[51,1297+39])
+                  Ptyp_constr "world" (extended_semicolon.ml[51,1297+34]..[51,1297+39])
+                  []
+                core_type (extended_semicolon.ml[51,1297+43]..[51,1297+52])
+                  Ptyp_tuple
+                  [
+                    core_type (extended_semicolon.ml[51,1297+43]..[51,1297+44])
+                      Ptyp_var a
+                    core_type (extended_semicolon.ml[51,1297+47]..[51,1297+52])
+                      Ptyp_constr "world" (extended_semicolon.ml[51,1297+47]..[51,1297+52])
+                      []
+                  ]
+        expression (extended_semicolon.ml[51,1297+8]..[64,1995+37])
+          Pexp_newtype "a"
+          expression (extended_semicolon.ml[51,1297+8]..[64,1995+37])
+            Pexp_constraint
+            expression (extended_semicolon.ml[51,1297+55]..[64,1995+37])
+              Pexp_function
+              [
+                <case>
+                  pattern (extended_semicolon.ml[52,1361+3]..[52,1361+9])
+                    Ppat_construct "Hold" (extended_semicolon.ml[52,1361+3]..[52,1361+7])
+                    Some
+                      pattern (extended_semicolon.ml[52,1361+8]..[52,1361+9])
+                        Ppat_var "f" (extended_semicolon.ml[52,1361+8]..[52,1361+9])
+                  expression (extended_semicolon.ml[52,1361+13]..[52,1361+39])
+                    Pexp_fun
+                    Nolabel
+                    None
+                    pattern (extended_semicolon.ml[52,1361+17]..[52,1361+22])
+                      Ppat_var "world" (extended_semicolon.ml[52,1361+17]..[52,1361+22])
+                    expression (extended_semicolon.ml[52,1361+26]..[52,1361+39])
+                      Pexp_tuple
+                      [
+                        expression (extended_semicolon.ml[52,1361+27]..[52,1361+31])
+                          Pexp_apply
+                          expression (extended_semicolon.ml[52,1361+27]..[52,1361+28])
+                            Pexp_ident "f" (extended_semicolon.ml[52,1361+27]..[52,1361+28])
+                          [
+                            <arg>
+                            Nolabel
+                              expression (extended_semicolon.ml[52,1361+29]..[52,1361+31])
+                                Pexp_construct "()" (extended_semicolon.ml[52,1361+29]..[52,1361+31])
+                                None
+                          ]
+                        expression (extended_semicolon.ml[52,1361+33]..[52,1361+38])
+                          Pexp_ident "world" (extended_semicolon.ml[52,1361+33]..[52,1361+38])
+                      ]
+                <case>
+                  pattern (extended_semicolon.ml[53,1401+3]..[53,1401+14])
+                    Ppat_construct "Bind" (extended_semicolon.ml[53,1401+3]..[53,1401+7])
+                    Some
+                      pattern (extended_semicolon.ml[53,1401+8]..[53,1401+14])
+                        Ppat_tuple
+                        [
+                          pattern (extended_semicolon.ml[53,1401+9]..[53,1401+10])
+                            Ppat_var "m" (extended_semicolon.ml[53,1401+9]..[53,1401+10])
+                          pattern (extended_semicolon.ml[53,1401+12]..[53,1401+13])
+                            Ppat_var "f" (extended_semicolon.ml[53,1401+12]..[53,1401+13])
+                        ]
+                  expression (extended_semicolon.ml[53,1401+18]..[53,1401+78])
+                    Pexp_fun
+                    Nolabel
+                    None
+                    pattern (extended_semicolon.ml[53,1401+22]..[53,1401+27])
+                      Ppat_var "world" (extended_semicolon.ml[53,1401+22]..[53,1401+27])
+                    expression (extended_semicolon.ml[53,1401+31]..[53,1401+78])
+                      Pexp_let Nonrec
+                      [
+                        <def>
+                          pattern (extended_semicolon.ml[53,1401+35]..[53,1401+44])
+                            Ppat_tuple
+                            [
+                              pattern (extended_semicolon.ml[53,1401+35]..[53,1401+36])
+                                Ppat_var "x" (extended_semicolon.ml[53,1401+35]..[53,1401+36])
+                              pattern (extended_semicolon.ml[53,1401+38]..[53,1401+44])
+                                Ppat_var "world'" (extended_semicolon.ml[53,1401+38]..[53,1401+44])
+                            ]
+                          expression (extended_semicolon.ml[53,1401+47]..[53,1401+58])
+                            Pexp_apply
+                            expression (extended_semicolon.ml[53,1401+47]..[53,1401+50])
+                              Pexp_ident "run" (extended_semicolon.ml[53,1401+47]..[53,1401+50])
+                            [
+                              <arg>
+                              Nolabel
+                                expression (extended_semicolon.ml[53,1401+51]..[53,1401+52])
+                                  Pexp_ident "m" (extended_semicolon.ml[53,1401+51]..[53,1401+52])
+                              <arg>
+                              Nolabel
+                                expression (extended_semicolon.ml[53,1401+53]..[53,1401+58])
+                                  Pexp_ident "world" (extended_semicolon.ml[53,1401+53]..[53,1401+58])
+                            ]
+                      ]
+                      expression (extended_semicolon.ml[53,1401+62]..[53,1401+78])
+                        Pexp_apply
+                        expression (extended_semicolon.ml[53,1401+62]..[53,1401+65])
+                          Pexp_ident "run" (extended_semicolon.ml[53,1401+62]..[53,1401+65])
+                        [
+                          <arg>
+                          Nolabel
+                            expression (extended_semicolon.ml[53,1401+66]..[53,1401+71])
+                              Pexp_apply
+                              expression (extended_semicolon.ml[53,1401+67]..[53,1401+68])
+                                Pexp_ident "f" (extended_semicolon.ml[53,1401+67]..[53,1401+68])
+                              [
+                                <arg>
+                                Nolabel
+                                  expression (extended_semicolon.ml[53,1401+69]..[53,1401+70])
+                                    Pexp_ident "x" (extended_semicolon.ml[53,1401+69]..[53,1401+70])
+                              ]
+                          <arg>
+                          Nolabel
+                            expression (extended_semicolon.ml[53,1401+72]..[53,1401+78])
+                              Pexp_ident "world'" (extended_semicolon.ml[53,1401+72]..[53,1401+78])
+                        ]
+                <case>
+                  pattern (extended_semicolon.ml[54,1480+3]..[54,1480+10])
+                    Ppat_construct "Get" (extended_semicolon.ml[54,1480+3]..[54,1480+6])
+                    Some
+                      pattern (extended_semicolon.ml[54,1480+7]..[54,1480+10])
+                        Ppat_construct "Pos" (extended_semicolon.ml[54,1480+7]..[54,1480+10])
+                        None
+                  expression (extended_semicolon.ml[54,1480+14]..[54,1480+45])
+                    Pexp_fun
+                    Nolabel
+                    None
+                    pattern (extended_semicolon.ml[54,1480+18]..[54,1480+23])
+                      Ppat_var "world" (extended_semicolon.ml[54,1480+18]..[54,1480+23])
+                    expression (extended_semicolon.ml[54,1480+27]..[54,1480+45])
+                      Pexp_tuple
+                      [
+                        expression (extended_semicolon.ml[54,1480+28]..[54,1480+37])
+                          Pexp_field
+                          expression (extended_semicolon.ml[54,1480+28]..[54,1480+33])
+                            Pexp_ident "world" (extended_semicolon.ml[54,1480+28]..[54,1480+33])
+                          "pos" (extended_semicolon.ml[54,1480+34]..[54,1480+37])
+                        expression (extended_semicolon.ml[54,1480+39]..[54,1480+44])
+                          Pexp_ident "world" (extended_semicolon.ml[54,1480+39]..[54,1480+44])
+                      ]
+                <case>
+                  pattern (extended_semicolon.ml[55,1526+3]..[55,1526+10])
+                    Ppat_construct "Get" (extended_semicolon.ml[55,1526+3]..[55,1526+6])
+                    Some
+                      pattern (extended_semicolon.ml[55,1526+7]..[55,1526+10])
+                        Ppat_construct "Vel" (extended_semicolon.ml[55,1526+7]..[55,1526+10])
+                        None
+                  expression (extended_semicolon.ml[55,1526+14]..[55,1526+45])
+                    Pexp_fun
+                    Nolabel
+                    None
+                    pattern (extended_semicolon.ml[55,1526+18]..[55,1526+23])
+                      Ppat_var "world" (extended_semicolon.ml[55,1526+18]..[55,1526+23])
+                    expression (extended_semicolon.ml[55,1526+27]..[55,1526+45])
+                      Pexp_tuple
+                      [
+                        expression (extended_semicolon.ml[55,1526+28]..[55,1526+37])
+                          Pexp_field
+                          expression (extended_semicolon.ml[55,1526+28]..[55,1526+33])
+                            Pexp_ident "world" (extended_semicolon.ml[55,1526+28]..[55,1526+33])
+                          "vel" (extended_semicolon.ml[55,1526+34]..[55,1526+37])
+                        expression (extended_semicolon.ml[55,1526+39]..[55,1526+44])
+                          Pexp_ident "world" (extended_semicolon.ml[55,1526+39]..[55,1526+44])
+                      ]
+                <case>
+                  pattern (extended_semicolon.ml[56,1572+3]..[56,1572+10])
+                    Ppat_construct "Get" (extended_semicolon.ml[56,1572+3]..[56,1572+6])
+                    Some
+                      pattern (extended_semicolon.ml[56,1572+7]..[56,1572+10])
+                        Ppat_construct "Pen" (extended_semicolon.ml[56,1572+7]..[56,1572+10])
+                        None
+                  expression (extended_semicolon.ml[56,1572+14]..[56,1572+45])
+                    Pexp_fun
+                    Nolabel
+                    None
+                    pattern (extended_semicolon.ml[56,1572+18]..[56,1572+23])
+                      Ppat_var "world" (extended_semicolon.ml[56,1572+18]..[56,1572+23])
+                    expression (extended_semicolon.ml[56,1572+27]..[56,1572+45])
+                      Pexp_tuple
+                      [
+                        expression (extended_semicolon.ml[56,1572+28]..[56,1572+37])
+                          Pexp_field
+                          expression (extended_semicolon.ml[56,1572+28]..[56,1572+33])
+                            Pexp_ident "world" (extended_semicolon.ml[56,1572+28]..[56,1572+33])
+                          "pen" (extended_semicolon.ml[56,1572+34]..[56,1572+37])
+                        expression (extended_semicolon.ml[56,1572+39]..[56,1572+44])
+                          Pexp_ident "world" (extended_semicolon.ml[56,1572+39]..[56,1572+44])
+                      ]
+                <case>
+                  pattern (extended_semicolon.ml[57,1618+3]..[57,1618+17])
+                    Ppat_construct "Put" (extended_semicolon.ml[57,1618+3]..[57,1618+6])
+                    Some
+                      pattern (extended_semicolon.ml[57,1618+7]..[57,1618+17])
+                        Ppat_tuple
+                        [
+                          pattern (extended_semicolon.ml[57,1618+8]..[57,1618+11])
+                            Ppat_construct "Pos" (extended_semicolon.ml[57,1618+8]..[57,1618+11])
+                            None
+                          pattern (extended_semicolon.ml[57,1618+13]..[57,1618+16])
+                            Ppat_var "pos" (extended_semicolon.ml[57,1618+13]..[57,1618+16])
+                        ]
+                  expression (extended_semicolon.ml[57,1618+21]..[57,1618+56])
+                    Pexp_fun
+                    Nolabel
+                    None
+                    pattern (extended_semicolon.ml[57,1618+25]..[57,1618+30])
+                      Ppat_var "world" (extended_semicolon.ml[57,1618+25]..[57,1618+30])
+                    expression (extended_semicolon.ml[57,1618+34]..[57,1618+56])
+                      Pexp_tuple
+                      [
+                        expression (extended_semicolon.ml[57,1618+35]..[57,1618+37])
+                          Pexp_construct "()" (extended_semicolon.ml[57,1618+35]..[57,1618+37])
+                          None
+                        expression (extended_semicolon.ml[57,1618+39]..[57,1618+55])
+                          Pexp_record
+                          [
+                            "pos" (extended_semicolon.ml[57,1618+51]..[57,1618+54])
+                              expression (extended_semicolon.ml[57,1618+51]..[57,1618+54])
+                                Pexp_ident "pos" (extended_semicolon.ml[57,1618+51]..[57,1618+54])
+                          ]
+                          Some
+                            expression (extended_semicolon.ml[57,1618+40]..[57,1618+45])
+                              Pexp_ident "world" (extended_semicolon.ml[57,1618+40]..[57,1618+45])
+                      ]
+                <case>
+                  pattern (extended_semicolon.ml[58,1675+3]..[58,1675+17])
+                    Ppat_construct "Put" (extended_semicolon.ml[58,1675+3]..[58,1675+6])
+                    Some
+                      pattern (extended_semicolon.ml[58,1675+7]..[58,1675+17])
+                        Ppat_tuple
+                        [
+                          pattern (extended_semicolon.ml[58,1675+8]..[58,1675+11])
+                            Ppat_construct "Vel" (extended_semicolon.ml[58,1675+8]..[58,1675+11])
+                            None
+                          pattern (extended_semicolon.ml[58,1675+13]..[58,1675+16])
+                            Ppat_var "vel" (extended_semicolon.ml[58,1675+13]..[58,1675+16])
+                        ]
+                  expression (extended_semicolon.ml[58,1675+21]..[58,1675+56])
+                    Pexp_fun
+                    Nolabel
+                    None
+                    pattern (extended_semicolon.ml[58,1675+25]..[58,1675+30])
+                      Ppat_var "world" (extended_semicolon.ml[58,1675+25]..[58,1675+30])
+                    expression (extended_semicolon.ml[58,1675+34]..[58,1675+56])
+                      Pexp_tuple
+                      [
+                        expression (extended_semicolon.ml[58,1675+35]..[58,1675+37])
+                          Pexp_construct "()" (extended_semicolon.ml[58,1675+35]..[58,1675+37])
+                          None
+                        expression (extended_semicolon.ml[58,1675+39]..[58,1675+55])
+                          Pexp_record
+                          [
+                            "vel" (extended_semicolon.ml[58,1675+51]..[58,1675+54])
+                              expression (extended_semicolon.ml[58,1675+51]..[58,1675+54])
+                                Pexp_ident "vel" (extended_semicolon.ml[58,1675+51]..[58,1675+54])
+                          ]
+                          Some
+                            expression (extended_semicolon.ml[58,1675+40]..[58,1675+45])
+                              Pexp_ident "world" (extended_semicolon.ml[58,1675+40]..[58,1675+45])
+                      ]
+                <case>
+                  pattern (extended_semicolon.ml[59,1732+3]..[59,1732+17])
+                    Ppat_construct "Put" (extended_semicolon.ml[59,1732+3]..[59,1732+6])
+                    Some
+                      pattern (extended_semicolon.ml[59,1732+7]..[59,1732+17])
+                        Ppat_tuple
+                        [
+                          pattern (extended_semicolon.ml[59,1732+8]..[59,1732+11])
+                            Ppat_construct "Pen" (extended_semicolon.ml[59,1732+8]..[59,1732+11])
+                            None
+                          pattern (extended_semicolon.ml[59,1732+13]..[59,1732+16])
+                            Ppat_var "pen" (extended_semicolon.ml[59,1732+13]..[59,1732+16])
+                        ]
+                  expression (extended_semicolon.ml[59,1732+21]..[59,1732+56])
+                    Pexp_fun
+                    Nolabel
+                    None
+                    pattern (extended_semicolon.ml[59,1732+25]..[59,1732+30])
+                      Ppat_var "world" (extended_semicolon.ml[59,1732+25]..[59,1732+30])
+                    expression (extended_semicolon.ml[59,1732+34]..[59,1732+56])
+                      Pexp_tuple
+                      [
+                        expression (extended_semicolon.ml[59,1732+35]..[59,1732+37])
+                          Pexp_construct "()" (extended_semicolon.ml[59,1732+35]..[59,1732+37])
+                          None
+                        expression (extended_semicolon.ml[59,1732+39]..[59,1732+55])
+                          Pexp_record
+                          [
+                            "pen" (extended_semicolon.ml[59,1732+51]..[59,1732+54])
+                              expression (extended_semicolon.ml[59,1732+51]..[59,1732+54])
+                                Pexp_ident "pen" (extended_semicolon.ml[59,1732+51]..[59,1732+54])
+                          ]
+                          Some
+                            expression (extended_semicolon.ml[59,1732+40]..[59,1732+45])
+                              Pexp_ident "world" (extended_semicolon.ml[59,1732+40]..[59,1732+45])
+                      ]
+                <case>
+                  pattern (extended_semicolon.ml[60,1789+3]..[60,1789+7])
+                    Ppat_construct "Step" (extended_semicolon.ml[60,1789+3]..[60,1789+7])
+                    None
+                  expression (extended_semicolon.ml[60,1789+11]..[64,1995+37])
+                    Pexp_fun
+                    Nolabel
+                    None
+                    pattern (extended_semicolon.ml[60,1789+15]..[60,1789+20])
+                      Ppat_var "world" (extended_semicolon.ml[60,1789+15]..[60,1789+20])
+                    expression (extended_semicolon.ml[61,1813+4]..[64,1995+37])
+                      Pexp_let Nonrec
+                      [
+                        <def>
+                          pattern (extended_semicolon.ml[61,1813+8]..[61,1813+32])
+                            Ppat_tuple
+                            [
+                              pattern (extended_semicolon.ml[61,1813+8]..[61,1813+14])
+                                Ppat_tuple
+                                [
+                                  pattern (extended_semicolon.ml[61,1813+9]..[61,1813+10])
+                                    Ppat_var "w" (extended_semicolon.ml[61,1813+9]..[61,1813+10])
+                                  pattern (extended_semicolon.ml[61,1813+12]..[61,1813+13])
+                                    Ppat_var "h" (extended_semicolon.ml[61,1813+12]..[61,1813+13])
+                                ]
+                              pattern (extended_semicolon.ml[61,1813+16]..[61,1813+22])
+                                Ppat_tuple
+                                [
+                                  pattern (extended_semicolon.ml[61,1813+17]..[61,1813+18])
+                                    Ppat_var "x" (extended_semicolon.ml[61,1813+17]..[61,1813+18])
+                                  pattern (extended_semicolon.ml[61,1813+20]..[61,1813+21])
+                                    Ppat_var "y" (extended_semicolon.ml[61,1813+20]..[61,1813+21])
+                                ]
+                              pattern (extended_semicolon.ml[61,1813+24]..[61,1813+32])
+                                Ppat_tuple
+                                [
+                                  pattern (extended_semicolon.ml[61,1813+25]..[61,1813+27])
+                                    Ppat_var "vx" (extended_semicolon.ml[61,1813+25]..[61,1813+27])
+                                  pattern (extended_semicolon.ml[61,1813+29]..[61,1813+31])
+                                    Ppat_var "vy" (extended_semicolon.ml[61,1813+29]..[61,1813+31])
+                                ]
+                            ]
+                          expression (extended_semicolon.ml[61,1813+35]..[61,1813+66])
+                            Pexp_tuple
+                            [
+                              expression (extended_semicolon.ml[61,1813+35]..[61,1813+44])
+                                Pexp_field
+                                expression (extended_semicolon.ml[61,1813+35]..[61,1813+40])
+                                  Pexp_ident "world" (extended_semicolon.ml[61,1813+35]..[61,1813+40])
+                                "dim" (extended_semicolon.ml[61,1813+41]..[61,1813+44])
+                              expression (extended_semicolon.ml[61,1813+46]..[61,1813+55])
+                                Pexp_field
+                                expression (extended_semicolon.ml[61,1813+46]..[61,1813+51])
+                                  Pexp_ident "world" (extended_semicolon.ml[61,1813+46]..[61,1813+51])
+                                "pos" (extended_semicolon.ml[61,1813+52]..[61,1813+55])
+                              expression (extended_semicolon.ml[61,1813+57]..[61,1813+66])
+                                Pexp_field
+                                expression (extended_semicolon.ml[61,1813+57]..[61,1813+62])
+                                  Pexp_ident "world" (extended_semicolon.ml[61,1813+57]..[61,1813+62])
+                                "vel" (extended_semicolon.ml[61,1813+63]..[61,1813+66])
+                            ]
+                      ]
+                      expression (extended_semicolon.ml[62,1883+4]..[64,1995+37])
+                        Pexp_sequence
+                        expression (extended_semicolon.ml[62,1883+4]..[62,1883+47])
+                          Pexp_apply
+                          expression (extended_semicolon.ml[62,1883+4]..[62,1883+13])
+                            Pexp_ident "Bytes.set" (extended_semicolon.ml[62,1883+4]..[62,1883+13])
+                          [
+                            <arg>
+                            Nolabel
+                              expression (extended_semicolon.ml[62,1883+14]..[62,1883+25])
+                                Pexp_field
+                                expression (extended_semicolon.ml[62,1883+14]..[62,1883+19])
+                                  Pexp_ident "world" (extended_semicolon.ml[62,1883+14]..[62,1883+19])
+                                "trace" (extended_semicolon.ml[62,1883+20]..[62,1883+25])
+                            <arg>
+                            Nolabel
+                              expression (extended_semicolon.ml[62,1883+26]..[62,1883+37])
+                                Pexp_apply
+                                expression (extended_semicolon.ml[62,1883+29]..[62,1883+30])
+                                  Pexp_ident "+" (extended_semicolon.ml[62,1883+29]..[62,1883+30])
+                                [
+                                  <arg>
+                                  Nolabel
+                                    expression (extended_semicolon.ml[62,1883+27]..[62,1883+28])
+                                      Pexp_ident "x" (extended_semicolon.ml[62,1883+27]..[62,1883+28])
+                                  <arg>
+                                  Nolabel
+                                    expression (extended_semicolon.ml[62,1883+31]..[62,1883+36])
+                                      Pexp_apply
+                                      expression (extended_semicolon.ml[62,1883+33]..[62,1883+34])
+                                        Pexp_ident "*" (extended_semicolon.ml[62,1883+33]..[62,1883+34])
+                                      [
+                                        <arg>
+                                        Nolabel
+                                          expression (extended_semicolon.ml[62,1883+31]..[62,1883+32])
+                                            Pexp_ident "w" (extended_semicolon.ml[62,1883+31]..[62,1883+32])
+                                        <arg>
+                                        Nolabel
+                                          expression (extended_semicolon.ml[62,1883+35]..[62,1883+36])
+                                            Pexp_ident "y" (extended_semicolon.ml[62,1883+35]..[62,1883+36])
+                                      ]
+                                ]
+                            <arg>
+                            Nolabel
+                              expression (extended_semicolon.ml[62,1883+38]..[62,1883+47])
+                                Pexp_field
+                                expression (extended_semicolon.ml[62,1883+38]..[62,1883+43])
+                                  Pexp_ident "world" (extended_semicolon.ml[62,1883+38]..[62,1883+43])
+                                "pen" (extended_semicolon.ml[62,1883+44]..[62,1883+47])
+                          ]
+                        expression (extended_semicolon.ml[63,1932+4]..[64,1995+37])
+                          Pexp_let Nonrec
+                          [
+                            <def>
+                              pattern (extended_semicolon.ml[63,1932+8]..[63,1932+16])
+                                Ppat_tuple
+                                [
+                                  pattern (extended_semicolon.ml[63,1932+9]..[63,1932+11])
+                                    Ppat_var "x'" (extended_semicolon.ml[63,1932+9]..[63,1932+11])
+                                  pattern (extended_semicolon.ml[63,1932+13]..[63,1932+15])
+                                    Ppat_var "y'" (extended_semicolon.ml[63,1932+13]..[63,1932+15])
+                                ]
+                              expression (extended_semicolon.ml[63,1932+19]..[63,1932+59])
+                                Pexp_tuple
+                                [
+                                  expression (extended_semicolon.ml[63,1932+20]..[63,1932+38])
+                                    Pexp_apply
+                                    expression (extended_semicolon.ml[63,1932+33]..[63,1932+36])
+                                      Pexp_ident "mod" (extended_semicolon.ml[63,1932+33]..[63,1932+36])
+                                    [
+                                      <arg>
+                                      Nolabel
+                                        expression (extended_semicolon.ml[63,1932+20]..[63,1932+32])
+                                          Pexp_apply
+                                          expression (extended_semicolon.ml[63,1932+28]..[63,1932+29])
+                                            Pexp_ident "+" (extended_semicolon.ml[63,1932+28]..[63,1932+29])
+                                          [
+                                            <arg>
+                                            Nolabel
+                                              expression (extended_semicolon.ml[63,1932+21]..[63,1932+27])
+                                                Pexp_apply
+                                                expression (extended_semicolon.ml[63,1932+23]..[63,1932+24])
+                                                  Pexp_ident "+" (extended_semicolon.ml[63,1932+23]..[63,1932+24])
+                                                [
+                                                  <arg>
+                                                  Nolabel
+                                                    expression (extended_semicolon.ml[63,1932+21]..[63,1932+22])
+                                                      Pexp_ident "x" (extended_semicolon.ml[63,1932+21]..[63,1932+22])
+                                                  <arg>
+                                                  Nolabel
+                                                    expression (extended_semicolon.ml[63,1932+25]..[63,1932+27])
+                                                      Pexp_ident "vx" (extended_semicolon.ml[63,1932+25]..[63,1932+27])
+                                                ]
+                                            <arg>
+                                            Nolabel
+                                              expression (extended_semicolon.ml[63,1932+30]..[63,1932+31])
+                                                Pexp_ident "w" (extended_semicolon.ml[63,1932+30]..[63,1932+31])
+                                          ]
+                                      <arg>
+                                      Nolabel
+                                        expression (extended_semicolon.ml[63,1932+37]..[63,1932+38])
+                                          Pexp_ident "w" (extended_semicolon.ml[63,1932+37]..[63,1932+38])
+                                    ]
+                                  expression (extended_semicolon.ml[63,1932+40]..[63,1932+58])
+                                    Pexp_apply
+                                    expression (extended_semicolon.ml[63,1932+53]..[63,1932+56])
+                                      Pexp_ident "mod" (extended_semicolon.ml[63,1932+53]..[63,1932+56])
+                                    [
+                                      <arg>
+                                      Nolabel
+                                        expression (extended_semicolon.ml[63,1932+40]..[63,1932+52])
+                                          Pexp_apply
+                                          expression (extended_semicolon.ml[63,1932+48]..[63,1932+49])
+                                            Pexp_ident "+" (extended_semicolon.ml[63,1932+48]..[63,1932+49])
+                                          [
+                                            <arg>
+                                            Nolabel
+                                              expression (extended_semicolon.ml[63,1932+41]..[63,1932+47])
+                                                Pexp_apply
+                                                expression (extended_semicolon.ml[63,1932+43]..[63,1932+44])
+                                                  Pexp_ident "+" (extended_semicolon.ml[63,1932+43]..[63,1932+44])
+                                                [
+                                                  <arg>
+                                                  Nolabel
+                                                    expression (extended_semicolon.ml[63,1932+41]..[63,1932+42])
+                                                      Pexp_ident "y" (extended_semicolon.ml[63,1932+41]..[63,1932+42])
+                                                  <arg>
+                                                  Nolabel
+                                                    expression (extended_semicolon.ml[63,1932+45]..[63,1932+47])
+                                                      Pexp_ident "vy" (extended_semicolon.ml[63,1932+45]..[63,1932+47])
+                                                ]
+                                            <arg>
+                                            Nolabel
+                                              expression (extended_semicolon.ml[63,1932+50]..[63,1932+51])
+                                                Pexp_ident "h" (extended_semicolon.ml[63,1932+50]..[63,1932+51])
+                                          ]
+                                      <arg>
+                                      Nolabel
+                                        expression (extended_semicolon.ml[63,1932+57]..[63,1932+58])
+                                          Pexp_ident "h" (extended_semicolon.ml[63,1932+57]..[63,1932+58])
+                                    ]
+                                ]
+                          ]
+                          expression (extended_semicolon.ml[64,1995+4]..[64,1995+37])
+                            Pexp_tuple
+                            [
+                              expression (extended_semicolon.ml[64,1995+5]..[64,1995+7])
+                                Pexp_construct "()" (extended_semicolon.ml[64,1995+5]..[64,1995+7])
+                                None
+                              expression (extended_semicolon.ml[64,1995+9]..[64,1995+36])
+                                Pexp_record
+                                [
+                                  "pos" (extended_semicolon.ml[64,1995+21]..[64,1995+24])
+                                    expression (extended_semicolon.ml[64,1995+27]..[64,1995+35])
+                                      Pexp_tuple
+                                      [
+                                        expression (extended_semicolon.ml[64,1995+28]..[64,1995+30])
+                                          Pexp_ident "x'" (extended_semicolon.ml[64,1995+28]..[64,1995+30])
+                                        expression (extended_semicolon.ml[64,1995+32]..[64,1995+34])
+                                          Pexp_ident "y'" (extended_semicolon.ml[64,1995+32]..[64,1995+34])
+                                      ]
+                                ]
+                                Some
+                                  expression (extended_semicolon.ml[64,1995+10]..[64,1995+15])
+                                    Pexp_ident "world" (extended_semicolon.ml[64,1995+10]..[64,1995+15])
+                            ]
+              ]
+            core_type (extended_semicolon.ml[51,1297+22]..[51,1297+52])
+              Ptyp_arrow
+              Nolabel
+              core_type (extended_semicolon.ml[51,1297+22]..[51,1297+30])
+                Ptyp_constr "action" (extended_semicolon.ml[51,1297+24]..[51,1297+30])
+                [
+                  core_type (extended_semicolon.ml[51,1297+22]..[51,1297+23])
+                    Ptyp_constr "a" (extended_semicolon.ml[51,1297+22]..[51,1297+23])
+                    []
+                ]
+              core_type (extended_semicolon.ml[51,1297+34]..[51,1297+52])
+                Ptyp_arrow
+                Nolabel
+                core_type (extended_semicolon.ml[51,1297+34]..[51,1297+39])
+                  Ptyp_constr "world" (extended_semicolon.ml[51,1297+34]..[51,1297+39])
+                  []
+                core_type (extended_semicolon.ml[51,1297+43]..[51,1297+52])
+                  Ptyp_tuple
+                  [
+                    core_type (extended_semicolon.ml[51,1297+43]..[51,1297+44])
+                      Ptyp_constr "a" (extended_semicolon.ml[51,1297+43]..[51,1297+44])
+                      []
+                    core_type (extended_semicolon.ml[51,1297+47]..[51,1297+52])
+                      Ptyp_constr "world" (extended_semicolon.ml[51,1297+47]..[51,1297+52])
+                      []
+                  ]
+    ]
+  structure_item (extended_semicolon.ml[68,2065+0]..[76,2266+13])
+    Pstr_value Rec
+    [
+      <def>
+        pattern (extended_semicolon.ml[68,2065+8]..[68,2065+14])
+          Ppat_var "repeat" (extended_semicolon.ml[68,2065+8]..[68,2065+14])
+        expression (extended_semicolon.ml[68,2065+15]..[76,2266+13]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_semicolon.ml[68,2065+15]..[68,2065+16])
+            Ppat_var "n" (extended_semicolon.ml[68,2065+15]..[68,2065+16])
+          expression (extended_semicolon.ml[68,2065+17]..[76,2266+13]) ghost
+            Pexp_fun
+            Nolabel
+            None
+            pattern (extended_semicolon.ml[68,2065+17]..[68,2065+18])
+              Ppat_var "m" (extended_semicolon.ml[68,2065+17]..[68,2065+18])
+            expression (extended_semicolon.ml[71,2190+2]..[76,2266+13])
+              Pexp_ifthenelse
+              expression (extended_semicolon.ml[71,2190+5]..[71,2190+10])
+                Pexp_apply
+                expression (extended_semicolon.ml[71,2190+7]..[71,2190+8])
+                  Pexp_ident ">" (extended_semicolon.ml[71,2190+7]..[71,2190+8])
+                [
+                  <arg>
+                  Nolabel
+                    expression (extended_semicolon.ml[71,2190+5]..[71,2190+6])
+                      Pexp_ident "n" (extended_semicolon.ml[71,2190+5]..[71,2190+6])
+                  <arg>
+                  Nolabel
+                    expression (extended_semicolon.ml[71,2190+9]..[71,2190+10])
+                      Pexp_constant PConst_int (0,None)
+                ]
+              expression (extended_semicolon.ml[72,2206+4]..[73,2216+20])
+                Pexp_apply
+                expression (extended_semicolon.ml[72,2206+6]..[72,2206+9])
+                  Pexp_ident ">>;" (extended_semicolon.ml[72,2206+6]..[72,2206+9])
+                [
+                  <arg>
+                  Nolabel
+                    expression (extended_semicolon.ml[72,2206+4]..[72,2206+5])
+                      Pexp_ident "m" (extended_semicolon.ml[72,2206+4]..[72,2206+5])
+                  <arg>
+                  Nolabel
+                    expression (extended_semicolon.ml[73,2216+4]..[73,2216+20])
+                      Pexp_apply
+                      expression (extended_semicolon.ml[73,2216+4]..[73,2216+10])
+                        Pexp_ident "repeat" (extended_semicolon.ml[73,2216+4]..[73,2216+10])
+                      [
+                        <arg>
+                        Nolabel
+                          expression (extended_semicolon.ml[73,2216+11]..[73,2216+18])
+                            Pexp_apply
+                            expression (extended_semicolon.ml[73,2216+14]..[73,2216+15])
+                              Pexp_ident "-" (extended_semicolon.ml[73,2216+14]..[73,2216+15])
+                            [
+                              <arg>
+                              Nolabel
+                                expression (extended_semicolon.ml[73,2216+12]..[73,2216+13])
+                                  Pexp_ident "n" (extended_semicolon.ml[73,2216+12]..[73,2216+13])
+                              <arg>
+                              Nolabel
+                                expression (extended_semicolon.ml[73,2216+16]..[73,2216+17])
+                                  Pexp_constant PConst_int (1,None)
+                            ]
+                        <arg>
+                        Nolabel
+                          expression (extended_semicolon.ml[73,2216+19]..[73,2216+20])
+                            Pexp_ident "m" (extended_semicolon.ml[73,2216+19]..[73,2216+20])
+                      ]
+                ]
+              Some
+                expression (extended_semicolon.ml[75,2244+4]..[76,2266+13])
+                  Pexp_apply
+                  expression (extended_semicolon.ml[75,2244+19]..[75,2244+21])
+                    Pexp_ident "-;" (extended_semicolon.ml[75,2244+19]..[75,2244+21])
+                  [
+                    <arg>
+                    Nolabel
+                      expression (extended_semicolon.ml[75,2244+4]..[75,2244+18])
+                        Pexp_assert
+                        expression (extended_semicolon.ml[75,2244+11]..[75,2244+18])
+                          Pexp_apply
+                          expression (extended_semicolon.ml[75,2244+14]..[75,2244+15])
+                            Pexp_ident "=" (extended_semicolon.ml[75,2244+14]..[75,2244+15])
+                          [
+                            <arg>
+                            Nolabel
+                              expression (extended_semicolon.ml[75,2244+12]..[75,2244+13])
+                                Pexp_ident "n" (extended_semicolon.ml[75,2244+12]..[75,2244+13])
+                            <arg>
+                            Nolabel
+                              expression (extended_semicolon.ml[75,2244+16]..[75,2244+17])
+                                Pexp_constant PConst_int (0,None)
+                          ]
+                    <arg>
+                    Nolabel
+                      expression (extended_semicolon.ml[76,2266+4]..[76,2266+13])
+                        Pexp_apply
+                        expression (extended_semicolon.ml[76,2266+4]..[76,2266+10])
+                          Pexp_ident "return" (extended_semicolon.ml[76,2266+4]..[76,2266+10])
+                        [
+                          <arg>
+                          Nolabel
+                            expression (extended_semicolon.ml[76,2266+11]..[76,2266+13])
+                              Pexp_construct "()" (extended_semicolon.ml[76,2266+11]..[76,2266+13])
+                              None
+                        ]
+                  ]
+    ]
+  structure_item (extended_semicolon.ml[78,2281+0]..[95,2867+15])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_semicolon.ml[78,2281+4]..[78,2281+17])
+          Ppat_var "draw_triangle" (extended_semicolon.ml[78,2281+4]..[78,2281+17])
+        expression (extended_semicolon.ml[78,2281+18]..[95,2867+15]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_semicolon.ml[78,2281+18]..[78,2281+19])
+            Ppat_var "n" (extended_semicolon.ml[78,2281+18]..[78,2281+19])
+          expression (extended_semicolon.ml[79,2303+2]..[95,2867+15])
+            Pexp_apply
+            expression (extended_semicolon.ml[79,2303+10]..[79,2303+13])
+              Pexp_ident ">>=" (extended_semicolon.ml[79,2303+10]..[79,2303+13])
+            [
+              <arg>
+              Nolabel
+                expression (extended_semicolon.ml[79,2303+2]..[79,2303+9])
+                  Pexp_apply
+                  expression (extended_semicolon.ml[79,2303+2]..[79,2303+5])
+                    Pexp_ident "get" (extended_semicolon.ml[79,2303+2]..[79,2303+5])
+                  [
+                    <arg>
+                    Nolabel
+                      expression (extended_semicolon.ml[79,2303+6]..[79,2303+9])
+                        Pexp_construct "Pos" (extended_semicolon.ml[79,2303+6]..[79,2303+9])
+                        None
+                  ]
+              <arg>
+              Nolabel
+                expression (extended_semicolon.ml[79,2303+14]..[95,2867+15])
+                  Pexp_fun
+                  Nolabel
+                  None
+                  pattern (extended_semicolon.ml[79,2303+18]..[79,2303+26])
+                    Ppat_tuple
+                    [
+                      pattern (extended_semicolon.ml[79,2303+19]..[79,2303+21])
+                        Ppat_var "xI" (extended_semicolon.ml[79,2303+19]..[79,2303+21])
+                      pattern (extended_semicolon.ml[79,2303+23]..[79,2303+25])
+                        Ppat_var "yI" (extended_semicolon.ml[79,2303+23]..[79,2303+25])
+                    ]
+                  expression (extended_semicolon.ml[82,2393+2]..[95,2867+15])
+                    Pexp_apply
+                    expression (extended_semicolon.ml[82,2393+16]..[82,2393+19])
+                      Pexp_ident ">>;" (extended_semicolon.ml[82,2393+16]..[82,2393+19])
+                    [
+                      <arg>
+                      Nolabel
+                        expression (extended_semicolon.ml[82,2393+2]..[82,2393+15])
+                          Pexp_apply
+                          expression (extended_semicolon.ml[82,2393+6]..[82,2393+8])
+                            Pexp_ident ":=" (extended_semicolon.ml[82,2393+6]..[82,2393+8])
+                          [
+                            <arg>
+                            Nolabel
+                              expression (extended_semicolon.ml[82,2393+2]..[82,2393+5])
+                                Pexp_construct "Vel" (extended_semicolon.ml[82,2393+2]..[82,2393+5])
+                                None
+                            <arg>
+                            Nolabel
+                              expression (extended_semicolon.ml[82,2393+9]..[82,2393+15])
+                                Pexp_tuple
+                                [
+                                  expression (extended_semicolon.ml[82,2393+10]..[82,2393+11])
+                                    Pexp_constant PConst_int (1,None)
+                                  expression (extended_semicolon.ml[82,2393+13]..[82,2393+14])
+                                    Pexp_constant PConst_int (1,None)
+                                ]
+                          ]
+                      <arg>
+                      Nolabel
+                        expression (extended_semicolon.ml[83,2413+2]..[95,2867+15])
+                          Pexp_apply
+                          expression (extended_semicolon.ml[83,2413+16]..[83,2413+19])
+                            Pexp_ident ">>;" (extended_semicolon.ml[83,2413+16]..[83,2413+19])
+                          [
+                            <arg>
+                            Nolabel
+                              expression (extended_semicolon.ml[83,2413+2]..[83,2413+15])
+                                Pexp_apply
+                                expression (extended_semicolon.ml[83,2413+2]..[83,2413+8])
+                                  Pexp_ident "repeat" (extended_semicolon.ml[83,2413+2]..[83,2413+8])
+                                [
+                                  <arg>
+                                  Nolabel
+                                    expression (extended_semicolon.ml[83,2413+9]..[83,2413+10])
+                                      Pexp_ident "n" (extended_semicolon.ml[83,2413+9]..[83,2413+10])
+                                  <arg>
+                                  Nolabel
+                                    expression (extended_semicolon.ml[83,2413+11]..[83,2413+15])
+                                      Pexp_construct "Step" (extended_semicolon.ml[83,2413+11]..[83,2413+15])
+                                      None
+                                ]
+                            <arg>
+                            Nolabel
+                              expression (extended_semicolon.ml[84,2433+2]..[95,2867+15])
+                                Pexp_apply
+                                expression (extended_semicolon.ml[84,2433+17]..[84,2433+20])
+                                  Pexp_ident ">>;" (extended_semicolon.ml[84,2433+17]..[84,2433+20])
+                                [
+                                  <arg>
+                                  Nolabel
+                                    expression (extended_semicolon.ml[84,2433+2]..[84,2433+16])
+                                      Pexp_apply
+                                      expression (extended_semicolon.ml[84,2433+6]..[84,2433+8])
+                                        Pexp_ident ":=" (extended_semicolon.ml[84,2433+6]..[84,2433+8])
+                                      [
+                                        <arg>
+                                        Nolabel
+                                          expression (extended_semicolon.ml[84,2433+2]..[84,2433+5])
+                                            Pexp_construct "Vel" (extended_semicolon.ml[84,2433+2]..[84,2433+5])
+                                            None
+                                        <arg>
+                                        Nolabel
+                                          expression (extended_semicolon.ml[84,2433+9]..[84,2433+16])
+                                            Pexp_tuple
+                                            [
+                                              expression (extended_semicolon.ml[84,2433+10]..[84,2433+11])
+                                                Pexp_constant PConst_int (1,None)
+                                              expression (extended_semicolon.ml[84,2433+13]..[84,2433+15])
+                                                Pexp_constant PConst_int (-1,None)
+                                            ]
+                                      ]
+                                  <arg>
+                                  Nolabel
+                                    expression (extended_semicolon.ml[85,2454+2]..[95,2867+15])
+                                      Pexp_apply
+                                      expression (extended_semicolon.ml[85,2454+16]..[85,2454+19])
+                                        Pexp_ident ">>;" (extended_semicolon.ml[85,2454+16]..[85,2454+19])
+                                      [
+                                        <arg>
+                                        Nolabel
+                                          expression (extended_semicolon.ml[85,2454+2]..[85,2454+15])
+                                            Pexp_apply
+                                            expression (extended_semicolon.ml[85,2454+2]..[85,2454+8])
+                                              Pexp_ident "repeat" (extended_semicolon.ml[85,2454+2]..[85,2454+8])
+                                            [
+                                              <arg>
+                                              Nolabel
+                                                expression (extended_semicolon.ml[85,2454+9]..[85,2454+10])
+                                                  Pexp_ident "n" (extended_semicolon.ml[85,2454+9]..[85,2454+10])
+                                              <arg>
+                                              Nolabel
+                                                expression (extended_semicolon.ml[85,2454+11]..[85,2454+15])
+                                                  Pexp_construct "Step" (extended_semicolon.ml[85,2454+11]..[85,2454+15])
+                                                  None
+                                            ]
+                                        <arg>
+                                        Nolabel
+                                          expression (extended_semicolon.ml[86,2474+2]..[95,2867+15])
+                                            Pexp_apply
+                                            expression (extended_semicolon.ml[86,2474+17]..[86,2474+20])
+                                              Pexp_ident ">>;" (extended_semicolon.ml[86,2474+17]..[86,2474+20])
+                                            [
+                                              <arg>
+                                              Nolabel
+                                                expression (extended_semicolon.ml[86,2474+2]..[86,2474+16])
+                                                  Pexp_apply
+                                                  expression (extended_semicolon.ml[86,2474+6]..[86,2474+8])
+                                                    Pexp_ident ":=" (extended_semicolon.ml[86,2474+6]..[86,2474+8])
+                                                  [
+                                                    <arg>
+                                                    Nolabel
+                                                      expression (extended_semicolon.ml[86,2474+2]..[86,2474+5])
+                                                        Pexp_construct "Vel" (extended_semicolon.ml[86,2474+2]..[86,2474+5])
+                                                        None
+                                                    <arg>
+                                                    Nolabel
+                                                      expression (extended_semicolon.ml[86,2474+9]..[86,2474+16])
+                                                        Pexp_tuple
+                                                        [
+                                                          expression (extended_semicolon.ml[86,2474+10]..[86,2474+12])
+                                                            Pexp_constant PConst_int (-1,None)
+                                                          expression (extended_semicolon.ml[86,2474+14]..[86,2474+15])
+                                                            Pexp_constant PConst_int (0,None)
+                                                        ]
+                                                  ]
+                                              <arg>
+                                              Nolabel
+                                                expression (extended_semicolon.ml[87,2495+2]..[95,2867+15])
+                                                  Pexp_apply
+                                                  expression (extended_semicolon.ml[87,2495+22]..[87,2495+25])
+                                                    Pexp_ident ">>;" (extended_semicolon.ml[87,2495+22]..[87,2495+25])
+                                                  [
+                                                    <arg>
+                                                    Nolabel
+                                                      expression (extended_semicolon.ml[87,2495+2]..[87,2495+21])
+                                                        Pexp_apply
+                                                        expression (extended_semicolon.ml[87,2495+2]..[87,2495+8])
+                                                          Pexp_ident "repeat" (extended_semicolon.ml[87,2495+2]..[87,2495+8])
+                                                        [
+                                                          <arg>
+                                                          Nolabel
+                                                            expression (extended_semicolon.ml[87,2495+9]..[87,2495+16])
+                                                              Pexp_apply
+                                                              expression (extended_semicolon.ml[87,2495+12]..[87,2495+13])
+                                                                Pexp_ident "*" (extended_semicolon.ml[87,2495+12]..[87,2495+13])
+                                                              [
+                                                                <arg>
+                                                                Nolabel
+                                                                  expression (extended_semicolon.ml[87,2495+10]..[87,2495+11])
+                                                                    Pexp_constant PConst_int (2,None)
+                                                                <arg>
+                                                                Nolabel
+                                                                  expression (extended_semicolon.ml[87,2495+14]..[87,2495+15])
+                                                                    Pexp_ident "n" (extended_semicolon.ml[87,2495+14]..[87,2495+15])
+                                                              ]
+                                                          <arg>
+                                                          Nolabel
+                                                            expression (extended_semicolon.ml[87,2495+17]..[87,2495+21])
+                                                              Pexp_construct "Step" (extended_semicolon.ml[87,2495+17]..[87,2495+21])
+                                                              None
+                                                        ]
+                                                    <arg>
+                                                    Nolabel
+                                                      expression (extended_semicolon.ml[92,2754+2]..[95,2867+15])
+                                                        Pexp_apply
+                                                        expression (extended_semicolon.ml[92,2754+10]..[92,2754+13])
+                                                          Pexp_ident ">>=" (extended_semicolon.ml[92,2754+10]..[92,2754+13])
+                                                        [
+                                                          <arg>
+                                                          Nolabel
+                                                            expression (extended_semicolon.ml[92,2754+2]..[92,2754+9])
+                                                              Pexp_apply
+                                                              expression (extended_semicolon.ml[92,2754+2]..[92,2754+5])
+                                                                Pexp_ident "get" (extended_semicolon.ml[92,2754+2]..[92,2754+5])
+                                                              [
+                                                                <arg>
+                                                                Nolabel
+                                                                  expression (extended_semicolon.ml[92,2754+6]..[92,2754+9])
+                                                                    Pexp_construct "Pos" (extended_semicolon.ml[92,2754+6]..[92,2754+9])
+                                                                    None
+                                                              ]
+                                                          <arg>
+                                                          Nolabel
+                                                            expression (extended_semicolon.ml[92,2754+14]..[95,2867+15])
+                                                              Pexp_fun
+                                                              Nolabel
+                                                              None
+                                                              pattern (extended_semicolon.ml[92,2754+18]..[92,2754+26])
+                                                                Ppat_tuple
+                                                                [
+                                                                  pattern (extended_semicolon.ml[92,2754+19]..[92,2754+21])
+                                                                    Ppat_var "xF" (extended_semicolon.ml[92,2754+19]..[92,2754+21])
+                                                                  pattern (extended_semicolon.ml[92,2754+23]..[92,2754+25])
+                                                                    Ppat_var "yF" (extended_semicolon.ml[92,2754+23]..[92,2754+25])
+                                                                ]
+                                                              expression (extended_semicolon.ml[93,2784+2]..[95,2867+15])
+                                                                Pexp_apply
+                                                                expression (extended_semicolon.ml[93,2784+16]..[93,2784+19])
+                                                                  Pexp_ident ">>;" (extended_semicolon.ml[93,2784+16]..[93,2784+19])
+                                                                [
+                                                                  <arg>
+                                                                  Nolabel
+                                                                    expression (extended_semicolon.ml[93,2784+2]..[93,2784+15])
+                                                                      Pexp_apply
+                                                                      expression (extended_semicolon.ml[93,2784+6]..[93,2784+8])
+Pexp_ident ":=" (extended_semicolon.ml[93,2784+6]..[93,2784+8])
+                                                                      [
+<arg>
+Nolabel
+  expression (extended_semicolon.ml[93,2784+2]..[93,2784+5])
+    Pexp_construct "Vel" (extended_semicolon.ml[93,2784+2]..[93,2784+5])
+    None
+<arg>
+Nolabel
+  expression (extended_semicolon.ml[93,2784+9]..[93,2784+15])
+    Pexp_tuple
+    [
+      expression (extended_semicolon.ml[93,2784+10]..[93,2784+11])
+        Pexp_constant PConst_int (0,None)
+      expression (extended_semicolon.ml[93,2784+13]..[93,2784+14])
+        Pexp_constant PConst_int (0,None)
+    ]
+                                                                      ]
+                                                                  <arg>
+                                                                  Nolabel
+                                                                    expression (extended_semicolon.ml[94,2804+2]..[95,2867+15])
+                                                                      Pexp_apply
+                                                                      expression (extended_semicolon.ml[94,2804+30]..[94,2804+32])
+Pexp_ident "-;" (extended_semicolon.ml[94,2804+30]..[94,2804+32])
+                                                                      [
+<arg>
+Nolabel
+  expression (extended_semicolon.ml[94,2804+2]..[94,2804+29])
+    Pexp_assert
+    expression (extended_semicolon.ml[94,2804+9]..[94,2804+29])
+      Pexp_apply
+      expression (extended_semicolon.ml[94,2804+18]..[94,2804+20])
+        Pexp_ident "&&" (extended_semicolon.ml[94,2804+18]..[94,2804+20])
+      [
+        <arg>
+        Nolabel
+          expression (extended_semicolon.ml[94,2804+10]..[94,2804+17])
+            Pexp_apply
+            expression (extended_semicolon.ml[94,2804+13]..[94,2804+14])
+              Pexp_ident "=" (extended_semicolon.ml[94,2804+13]..[94,2804+14])
+            [
+              <arg>
+              Nolabel
+                expression (extended_semicolon.ml[94,2804+10]..[94,2804+12])
+                  Pexp_ident "xF" (extended_semicolon.ml[94,2804+10]..[94,2804+12])
+              <arg>
+              Nolabel
+                expression (extended_semicolon.ml[94,2804+15]..[94,2804+17])
+                  Pexp_ident "xI" (extended_semicolon.ml[94,2804+15]..[94,2804+17])
+            ]
+        <arg>
+        Nolabel
+          expression (extended_semicolon.ml[94,2804+21]..[94,2804+28])
+            Pexp_apply
+            expression (extended_semicolon.ml[94,2804+24]..[94,2804+25])
+              Pexp_ident "=" (extended_semicolon.ml[94,2804+24]..[94,2804+25])
+            [
+              <arg>
+              Nolabel
+                expression (extended_semicolon.ml[94,2804+21]..[94,2804+23])
+                  Pexp_ident "yF" (extended_semicolon.ml[94,2804+21]..[94,2804+23])
+              <arg>
+              Nolabel
+                expression (extended_semicolon.ml[94,2804+26]..[94,2804+28])
+                  Pexp_ident "yI" (extended_semicolon.ml[94,2804+26]..[94,2804+28])
+            ]
+      ]
+<arg>
+Nolabel
+  expression (extended_semicolon.ml[95,2867+2]..[95,2867+15])
+    Pexp_apply
+    expression (extended_semicolon.ml[95,2867+6]..[95,2867+8])
+      Pexp_ident ":=" (extended_semicolon.ml[95,2867+6]..[95,2867+8])
+    [
+      <arg>
+      Nolabel
+        expression (extended_semicolon.ml[95,2867+2]..[95,2867+5])
+          Pexp_construct "Pos" (extended_semicolon.ml[95,2867+2]..[95,2867+5])
+          None
+      <arg>
+      Nolabel
+        expression (extended_semicolon.ml[95,2867+9]..[95,2867+15])
+          Pexp_tuple
+          [
+            expression (extended_semicolon.ml[95,2867+10]..[95,2867+11])
+              Pexp_constant PConst_int (0,None)
+            expression (extended_semicolon.ml[95,2867+13]..[95,2867+14])
+              Pexp_constant PConst_int (0,None)
+          ]
+    ]
+                                                                      ]
+                                                                ]
+                                                        ]
+                                                  ]
+                                            ]
+                                      ]
+                                ]
+                          ]
+                    ]
+            ]
+    ]
+  structure_item (extended_semicolon.ml[97,2884+0]..[111,3216+9])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_semicolon.ml[97,2884+4]..[97,2884+13])
+          Ppat_var "draw_text" (extended_semicolon.ml[97,2884+4]..[97,2884+13])
+        expression (extended_semicolon.ml[97,2884+14]..[111,3216+9]) ghost
+          Pexp_fun
+          Nolabel
+          None
+          pattern (extended_semicolon.ml[97,2884+14]..[97,2884+15])
+            Ppat_var "w" (extended_semicolon.ml[97,2884+14]..[97,2884+15])
+          expression (extended_semicolon.ml[97,2884+16]..[111,3216+9]) ghost
+            Pexp_fun
+            Nolabel
+            None
+            pattern (extended_semicolon.ml[97,2884+16]..[97,2884+17])
+              Ppat_var "s" (extended_semicolon.ml[97,2884+16]..[97,2884+17])
+            expression (extended_semicolon.ml[98,2904+2]..[111,3216+9])
+              Pexp_apply
+              expression (extended_semicolon.ml[98,2904+10]..[98,2904+13])
+                Pexp_ident ">>=" (extended_semicolon.ml[98,2904+10]..[98,2904+13])
+              [
+                <arg>
+                Nolabel
+                  expression (extended_semicolon.ml[98,2904+2]..[98,2904+9])
+                    Pexp_apply
+                    expression (extended_semicolon.ml[98,2904+2]..[98,2904+5])
+                      Pexp_ident "get" (extended_semicolon.ml[98,2904+2]..[98,2904+5])
+                    [
+                      <arg>
+                      Nolabel
+                        expression (extended_semicolon.ml[98,2904+6]..[98,2904+9])
+                          Pexp_construct "Pos" (extended_semicolon.ml[98,2904+6]..[98,2904+9])
+                          None
+                    ]
+                <arg>
+                Nolabel
+                  expression (extended_semicolon.ml[98,2904+14]..[111,3216+9])
+                    Pexp_fun
+                    Nolabel
+                    None
+                    pattern (extended_semicolon.ml[98,2904+18]..[98,2904+25])
+                      Ppat_tuple
+                      [
+                        pattern (extended_semicolon.ml[98,2904+19]..[98,2904+21])
+                          Ppat_var "x0" (extended_semicolon.ml[98,2904+19]..[98,2904+21])
+                        pattern (extended_semicolon.ml[98,2904+23]..[98,2904+24])
+                          Ppat_any
+                      ]
+                    expression (extended_semicolon.ml[99,2933+2]..[111,3216+9])
+                      Pexp_apply
+                      expression (extended_semicolon.ml[99,2933+16]..[99,2933+19])
+                        Pexp_ident ">>;" (extended_semicolon.ml[99,2933+16]..[99,2933+19])
+                      [
+                        <arg>
+                        Nolabel
+                          expression (extended_semicolon.ml[99,2933+2]..[99,2933+15])
+                            Pexp_apply
+                            expression (extended_semicolon.ml[99,2933+6]..[99,2933+8])
+                              Pexp_ident ":=" (extended_semicolon.ml[99,2933+6]..[99,2933+8])
+                            [
+                              <arg>
+                              Nolabel
+                                expression (extended_semicolon.ml[99,2933+2]..[99,2933+5])
+                                  Pexp_construct "Vel" (extended_semicolon.ml[99,2933+2]..[99,2933+5])
+                                  None
+                              <arg>
+                              Nolabel
+                                expression (extended_semicolon.ml[99,2933+9]..[99,2933+15])
+                                  Pexp_tuple
+                                  [
+                                    expression (extended_semicolon.ml[99,2933+10]..[99,2933+11])
+                                      Pexp_constant PConst_int (1,None)
+                                    expression (extended_semicolon.ml[99,2933+13]..[99,2933+14])
+                                      Pexp_constant PConst_int (0,None)
+                                  ]
+                            ]
+                        <arg>
+                        Nolabel
+                          expression (extended_semicolon.ml[100,2953+2]..[111,3216+9])
+                            Pexp_let Rec
+                            [
+                              <def>
+                                pattern (extended_semicolon.ml[100,2953+10]..[100,2953+13])
+                                  Ppat_var "aux" (extended_semicolon.ml[100,2953+10]..[100,2953+13])
+                                expression (extended_semicolon.ml[100,2953+14]..[110,3187+25]) ghost
+                                  Pexp_fun
+                                  Nolabel
+                                  None
+                                  pattern (extended_semicolon.ml[100,2953+14]..[100,2953+15])
+                                    Ppat_var "i" (extended_semicolon.ml[100,2953+14]..[100,2953+15])
+                                  expression (extended_semicolon.ml[100,2953+16]..[110,3187+25]) ghost
+                                    Pexp_fun
+                                    Nolabel
+                                    None
+                                    pattern (extended_semicolon.ml[100,2953+16]..[100,2953+17])
+                                      Ppat_var "c" (extended_semicolon.ml[100,2953+16]..[100,2953+17])
+                                    expression (extended_semicolon.ml[101,2973+4]..[110,3187+25])
+                                      Pexp_ifthenelse
+                                      expression (extended_semicolon.ml[101,2973+7]..[101,2973+26])
+                                        Pexp_apply
+                                        expression (extended_semicolon.ml[101,2973+9]..[101,2973+10])
+                                          Pexp_ident "=" (extended_semicolon.ml[101,2973+9]..[101,2973+10])
+                                        [
+                                          <arg>
+                                          Nolabel
+                                            expression (extended_semicolon.ml[101,2973+7]..[101,2973+8])
+                                              Pexp_ident "i" (extended_semicolon.ml[101,2973+7]..[101,2973+8])
+                                          <arg>
+                                          Nolabel
+                                            expression (extended_semicolon.ml[101,2973+11]..[101,2973+26])
+                                              Pexp_apply
+                                              expression (extended_semicolon.ml[101,2973+11]..[101,2973+24])
+                                                Pexp_ident "String.length" (extended_semicolon.ml[101,2973+11]..[101,2973+24])
+                                              [
+                                                <arg>
+                                                Nolabel
+                                                  expression (extended_semicolon.ml[101,2973+25]..[101,2973+26])
+                                                    Pexp_ident "s" (extended_semicolon.ml[101,2973+25]..[101,2973+26])
+                                              ]
+                                        ]
+                                      expression (extended_semicolon.ml[102,3005+6]..[102,3005+15])
+                                        Pexp_apply
+                                        expression (extended_semicolon.ml[102,3005+6]..[102,3005+12])
+                                          Pexp_ident "return" (extended_semicolon.ml[102,3005+6]..[102,3005+12])
+                                        [
+                                          <arg>
+                                          Nolabel
+                                            expression (extended_semicolon.ml[102,3005+13]..[102,3005+15])
+                                              Pexp_construct "()" (extended_semicolon.ml[102,3005+13]..[102,3005+15])
+                                              None
+                                        ]
+                                      Some
+                                        expression (extended_semicolon.ml[103,3021+9]..[110,3187+25])
+                                          Pexp_ifthenelse
+                                          expression (extended_semicolon.ml[103,3021+12]..[103,3021+32])
+                                            Pexp_apply
+                                            expression (extended_semicolon.ml[103,3021+18]..[103,3021+20])
+                                              Pexp_ident "&&" (extended_semicolon.ml[103,3021+18]..[103,3021+20])
+                                            [
+                                              <arg>
+                                              Nolabel
+                                                expression (extended_semicolon.ml[103,3021+12]..[103,3021+17])
+                                                  Pexp_apply
+                                                  expression (extended_semicolon.ml[103,3021+14]..[103,3021+15])
+                                                    Pexp_ident ">" (extended_semicolon.ml[103,3021+14]..[103,3021+15])
+                                                  [
+                                                    <arg>
+                                                    Nolabel
+                                                      expression (extended_semicolon.ml[103,3021+12]..[103,3021+13])
+                                                        Pexp_ident "c" (extended_semicolon.ml[103,3021+12]..[103,3021+13])
+                                                    <arg>
+                                                    Nolabel
+                                                      expression (extended_semicolon.ml[103,3021+16]..[103,3021+17])
+                                                        Pexp_ident "w" (extended_semicolon.ml[103,3021+16]..[103,3021+17])
+                                                  ]
+                                              <arg>
+                                              Nolabel
+                                                expression (extended_semicolon.ml[103,3021+21]..[103,3021+32])
+                                                  Pexp_apply
+                                                  expression (extended_semicolon.ml[103,3021+27]..[103,3021+28])
+                                                    Pexp_ident "=" (extended_semicolon.ml[103,3021+27]..[103,3021+28])
+                                                  [
+                                                    <arg>
+                                                    Nolabel
+                                                      expression (extended_semicolon.ml[103,3021+21]..[103,3021+26])
+                                                        Pexp_apply
+                                                        expression (extended_semicolon.ml[103,3021+21]..[103,3021+26]) ghost
+                                                          Pexp_ident "String.get" (extended_semicolon.ml[103,3021+21]..[103,3021+26]) ghost
+                                                        [
+                                                          <arg>
+                                                          Nolabel
+                                                            expression (extended_semicolon.ml[103,3021+21]..[103,3021+22])
+                                                              Pexp_ident "s" (extended_semicolon.ml[103,3021+21]..[103,3021+22])
+                                                          <arg>
+                                                          Nolabel
+                                                            expression (extended_semicolon.ml[103,3021+24]..[103,3021+25])
+                                                              Pexp_ident "i" (extended_semicolon.ml[103,3021+24]..[103,3021+25])
+                                                        ]
+                                                    <arg>
+                                                    Nolabel
+                                                      expression (extended_semicolon.ml[103,3021+29]..[103,3021+32])
+                                                        Pexp_constant PConst_char 20
+                                                  ]
+                                            ]
+                                          expression (extended_semicolon.ml[104,3059+6]..[106,3120+19])
+                                            Pexp_apply
+                                            expression (extended_semicolon.ml[104,3059+14]..[104,3059+17])
+                                              Pexp_ident ">>=" (extended_semicolon.ml[104,3059+14]..[104,3059+17])
+                                            [
+                                              <arg>
+                                              Nolabel
+                                                expression (extended_semicolon.ml[104,3059+6]..[104,3059+13])
+                                                  Pexp_apply
+                                                  expression (extended_semicolon.ml[104,3059+6]..[104,3059+9])
+                                                    Pexp_ident "get" (extended_semicolon.ml[104,3059+6]..[104,3059+9])
+                                                  [
+                                                    <arg>
+                                                    Nolabel
+                                                      expression (extended_semicolon.ml[104,3059+10]..[104,3059+13])
+                                                        Pexp_construct "Pos" (extended_semicolon.ml[104,3059+10]..[104,3059+13])
+                                                        None
+                                                  ]
+                                              <arg>
+                                              Nolabel
+                                                expression (extended_semicolon.ml[104,3059+18]..[106,3120+19])
+                                                  Pexp_fun
+                                                  Nolabel
+                                                  None
+                                                  pattern (extended_semicolon.ml[104,3059+22]..[104,3059+28])
+                                                    Ppat_tuple
+                                                    [
+                                                      pattern (extended_semicolon.ml[104,3059+23]..[104,3059+24])
+                                                        Ppat_any
+                                                      pattern (extended_semicolon.ml[104,3059+26]..[104,3059+27])
+                                                        Ppat_var "y" (extended_semicolon.ml[104,3059+26]..[104,3059+27])
+                                                    ]
+                                                  expression (extended_semicolon.ml[105,3091+6]..[106,3120+19])
+                                                    Pexp_apply
+                                                    expression (extended_semicolon.ml[105,3091+25]..[105,3091+28])
+                                                      Pexp_ident ">>;" (extended_semicolon.ml[105,3091+25]..[105,3091+28])
+                                                    [
+                                                      <arg>
+                                                      Nolabel
+                                                        expression (extended_semicolon.ml[105,3091+6]..[105,3091+24])
+                                                          Pexp_apply
+                                                          expression (extended_semicolon.ml[105,3091+10]..[105,3091+12])
+                                                            Pexp_ident ":=" (extended_semicolon.ml[105,3091+10]..[105,3091+12])
+                                                          [
+                                                            <arg>
+                                                            Nolabel
+                                                              expression (extended_semicolon.ml[105,3091+6]..[105,3091+9])
+                                                                Pexp_construct "Pos" (extended_semicolon.ml[105,3091+6]..[105,3091+9])
+                                                                None
+                                                            <arg>
+                                                            Nolabel
+                                                              expression (extended_semicolon.ml[105,3091+13]..[105,3091+24])
+                                                                Pexp_tuple
+                                                                [
+                                                                  expression (extended_semicolon.ml[105,3091+14]..[105,3091+16])
+                                                                    Pexp_ident "x0" (extended_semicolon.ml[105,3091+14]..[105,3091+16])
+                                                                  expression (extended_semicolon.ml[105,3091+18]..[105,3091+23])
+                                                                    Pexp_apply
+                                                                    expression (extended_semicolon.ml[105,3091+20]..[105,3091+21])
+                                                                      Pexp_ident "+" (extended_semicolon.ml[105,3091+20]..[105,3091+21])
+                                                                    [
+                                                                      <arg>
+                                                                      Nolabel
+expression (extended_semicolon.ml[105,3091+18]..[105,3091+19])
+  Pexp_ident "y" (extended_semicolon.ml[105,3091+18]..[105,3091+19])
+                                                                      <arg>
+                                                                      Nolabel
+expression (extended_semicolon.ml[105,3091+22]..[105,3091+23])
+  Pexp_constant PConst_int (1,None)
+                                                                    ]
+                                                                ]
+                                                          ]
+                                                      <arg>
+                                                      Nolabel
+                                                        expression (extended_semicolon.ml[106,3120+6]..[106,3120+19])
+                                                          Pexp_apply
+                                                          expression (extended_semicolon.ml[106,3120+6]..[106,3120+9])
+                                                            Pexp_ident "aux" (extended_semicolon.ml[106,3120+6]..[106,3120+9])
+                                                          [
+                                                            <arg>
+                                                            Nolabel
+                                                              expression (extended_semicolon.ml[106,3120+10]..[106,3120+17])
+                                                                Pexp_apply
+                                                                expression (extended_semicolon.ml[106,3120+13]..[106,3120+14])
+                                                                  Pexp_ident "+" (extended_semicolon.ml[106,3120+13]..[106,3120+14])
+                                                                [
+                                                                  <arg>
+                                                                  Nolabel
+                                                                    expression (extended_semicolon.ml[106,3120+11]..[106,3120+12])
+                                                                      Pexp_ident "i" (extended_semicolon.ml[106,3120+11]..[106,3120+12])
+                                                                  <arg>
+                                                                  Nolabel
+                                                                    expression (extended_semicolon.ml[106,3120+15]..[106,3120+16])
+                                                                      Pexp_constant PConst_int (1,None)
+                                                                ]
+                                                            <arg>
+                                                            Nolabel
+                                                              expression (extended_semicolon.ml[106,3120+18]..[106,3120+19])
+                                                                Pexp_constant PConst_int (0,None)
+                                                          ]
+                                                    ]
+                                            ]
+                                          Some
+                                            expression (extended_semicolon.ml[108,3149+6]..[110,3187+25])
+                                              Pexp_apply
+                                              expression (extended_semicolon.ml[108,3149+19]..[108,3149+22])
+                                                Pexp_ident ">>;" (extended_semicolon.ml[108,3149+19]..[108,3149+22])
+                                              [
+                                                <arg>
+                                                Nolabel
+                                                  expression (extended_semicolon.ml[108,3149+6]..[108,3149+18])
+                                                    Pexp_apply
+                                                    expression (extended_semicolon.ml[108,3149+10]..[108,3149+12])
+                                                      Pexp_ident ":=" (extended_semicolon.ml[108,3149+10]..[108,3149+12])
+                                                    [
+                                                      <arg>
+                                                      Nolabel
+                                                        expression (extended_semicolon.ml[108,3149+6]..[108,3149+9])
+                                                          Pexp_construct "Pen" (extended_semicolon.ml[108,3149+6]..[108,3149+9])
+                                                          None
+                                                      <arg>
+                                                      Nolabel
+                                                        expression (extended_semicolon.ml[108,3149+13]..[108,3149+18])
+                                                          Pexp_apply
+                                                          expression (extended_semicolon.ml[108,3149+13]..[108,3149+18]) ghost
+                                                            Pexp_ident "String.get" (extended_semicolon.ml[108,3149+13]..[108,3149+18]) ghost
+                                                          [
+                                                            <arg>
+                                                            Nolabel
+                                                              expression (extended_semicolon.ml[108,3149+13]..[108,3149+14])
+                                                                Pexp_ident "s" (extended_semicolon.ml[108,3149+13]..[108,3149+14])
+                                                            <arg>
+                                                            Nolabel
+                                                              expression (extended_semicolon.ml[108,3149+16]..[108,3149+17])
+                                                                Pexp_ident "i" (extended_semicolon.ml[108,3149+16]..[108,3149+17])
+                                                          ]
+                                                    ]
+                                                <arg>
+                                                Nolabel
+                                                  expression (extended_semicolon.ml[109,3172+6]..[110,3187+25])
+                                                    Pexp_apply
+                                                    expression (extended_semicolon.ml[109,3172+11]..[109,3172+14])
+                                                      Pexp_ident ">>;" (extended_semicolon.ml[109,3172+11]..[109,3172+14])
+                                                    [
+                                                      <arg>
+                                                      Nolabel
+                                                        expression (extended_semicolon.ml[109,3172+6]..[109,3172+10])
+                                                          Pexp_construct "Step" (extended_semicolon.ml[109,3172+6]..[109,3172+10])
+                                                          None
+                                                      <arg>
+                                                      Nolabel
+                                                        expression (extended_semicolon.ml[110,3187+6]..[110,3187+25])
+                                                          Pexp_apply
+                                                          expression (extended_semicolon.ml[110,3187+6]..[110,3187+9])
+                                                            Pexp_ident "aux" (extended_semicolon.ml[110,3187+6]..[110,3187+9])
+                                                          [
+                                                            <arg>
+                                                            Nolabel
+                                                              expression (extended_semicolon.ml[110,3187+10]..[110,3187+17])
+                                                                Pexp_apply
+                                                                expression (extended_semicolon.ml[110,3187+13]..[110,3187+14])
+                                                                  Pexp_ident "+" (extended_semicolon.ml[110,3187+13]..[110,3187+14])
+                                                                [
+                                                                  <arg>
+                                                                  Nolabel
+                                                                    expression (extended_semicolon.ml[110,3187+11]..[110,3187+12])
+                                                                      Pexp_ident "i" (extended_semicolon.ml[110,3187+11]..[110,3187+12])
+                                                                  <arg>
+                                                                  Nolabel
+                                                                    expression (extended_semicolon.ml[110,3187+15]..[110,3187+16])
+                                                                      Pexp_constant PConst_int (1,None)
+                                                                ]
+                                                            <arg>
+                                                            Nolabel
+                                                              expression (extended_semicolon.ml[110,3187+18]..[110,3187+25])
+                                                                Pexp_apply
+                                                                expression (extended_semicolon.ml[110,3187+21]..[110,3187+22])
+                                                                  Pexp_ident "+" (extended_semicolon.ml[110,3187+21]..[110,3187+22])
+                                                                [
+                                                                  <arg>
+                                                                  Nolabel
+                                                                    expression (extended_semicolon.ml[110,3187+19]..[110,3187+20])
+                                                                      Pexp_ident "c" (extended_semicolon.ml[110,3187+19]..[110,3187+20])
+                                                                  <arg>
+                                                                  Nolabel
+                                                                    expression (extended_semicolon.ml[110,3187+23]..[110,3187+24])
+                                                                      Pexp_constant PConst_int (1,None)
+                                                                ]
+                                                          ]
+                                                    ]
+                                              ]
+                            ]
+                            expression (extended_semicolon.ml[111,3216+2]..[111,3216+9])
+                              Pexp_apply
+                              expression (extended_semicolon.ml[111,3216+2]..[111,3216+5])
+                                Pexp_ident "aux" (extended_semicolon.ml[111,3216+2]..[111,3216+5])
+                              [
+                                <arg>
+                                Nolabel
+                                  expression (extended_semicolon.ml[111,3216+6]..[111,3216+7])
+                                    Pexp_constant PConst_int (0,None)
+                                <arg>
+                                Nolabel
+                                  expression (extended_semicolon.ml[111,3216+8]..[111,3216+9])
+                                    Pexp_constant PConst_int (0,None)
+                              ]
+                      ]
+              ]
+    ]
+  structure_item (extended_semicolon.ml[113,3227+0]..[131,3627+13])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_semicolon.ml[113,3227+4]..[113,3227+8])
+          Ppat_var "test" (extended_semicolon.ml[113,3227+4]..[113,3227+8])
+        expression (extended_semicolon.ml[114,3238+2]..[131,3627+13])
+          Pexp_apply
+          expression (extended_semicolon.ml[114,3238+16]..[114,3238+19])
+            Pexp_ident ">>;" (extended_semicolon.ml[114,3238+16]..[114,3238+19])
+          [
+            <arg>
+            Nolabel
+              expression (extended_semicolon.ml[114,3238+2]..[114,3238+15])
+                Pexp_apply
+                expression (extended_semicolon.ml[114,3238+6]..[114,3238+8])
+                  Pexp_ident ":=" (extended_semicolon.ml[114,3238+6]..[114,3238+8])
+                [
+                  <arg>
+                  Nolabel
+                    expression (extended_semicolon.ml[114,3238+2]..[114,3238+5])
+                      Pexp_construct "Pos" (extended_semicolon.ml[114,3238+2]..[114,3238+5])
+                      None
+                  <arg>
+                  Nolabel
+                    expression (extended_semicolon.ml[114,3238+9]..[114,3238+15])
+                      Pexp_tuple
+                      [
+                        expression (extended_semicolon.ml[114,3238+10]..[114,3238+11])
+                          Pexp_constant PConst_int (2,None)
+                        expression (extended_semicolon.ml[114,3238+13]..[114,3238+14])
+                          Pexp_constant PConst_int (9,None)
+                      ]
+                ]
+            <arg>
+            Nolabel
+              expression (extended_semicolon.ml[115,3258+2]..[131,3627+13])
+                Pexp_apply
+                expression (extended_semicolon.ml[115,3258+13]..[115,3258+16])
+                  Pexp_ident ">>;" (extended_semicolon.ml[115,3258+13]..[115,3258+16])
+                [
+                  <arg>
+                  Nolabel
+                    expression (extended_semicolon.ml[115,3258+2]..[115,3258+12])
+                      Pexp_apply
+                      expression (extended_semicolon.ml[115,3258+6]..[115,3258+8])
+                        Pexp_ident ":=" (extended_semicolon.ml[115,3258+6]..[115,3258+8])
+                      [
+                        <arg>
+                        Nolabel
+                          expression (extended_semicolon.ml[115,3258+2]..[115,3258+5])
+                            Pexp_construct "Pen" (extended_semicolon.ml[115,3258+2]..[115,3258+5])
+                            None
+                        <arg>
+                        Nolabel
+                          expression (extended_semicolon.ml[115,3258+9]..[115,3258+12])
+                            Pexp_constant PConst_char 2d
+                      ]
+                  <arg>
+                  Nolabel
+                    expression (extended_semicolon.ml[116,3275+2]..[131,3627+13])
+                      Pexp_apply
+                      expression (extended_semicolon.ml[116,3275+18]..[116,3275+21])
+                        Pexp_ident ">>;" (extended_semicolon.ml[116,3275+18]..[116,3275+21])
+                      [
+                        <arg>
+                        Nolabel
+                          expression (extended_semicolon.ml[116,3275+2]..[116,3275+17])
+                            Pexp_apply
+                            expression (extended_semicolon.ml[116,3275+2]..[116,3275+15])
+                              Pexp_ident "draw_triangle" (extended_semicolon.ml[116,3275+2]..[116,3275+15])
+                            [
+                              <arg>
+                              Nolabel
+                                expression (extended_semicolon.ml[116,3275+16]..[116,3275+17])
+                                  Pexp_constant PConst_int (8,None)
+                            ]
+                        <arg>
+                        Nolabel
+                          expression (extended_semicolon.ml[118,3298+2]..[131,3627+13])
+                            Pexp_apply
+                            expression (extended_semicolon.ml[118,3298+16]..[118,3298+19])
+                              Pexp_ident ">>;" (extended_semicolon.ml[118,3298+16]..[118,3298+19])
+                            [
+                              <arg>
+                              Nolabel
+                                expression (extended_semicolon.ml[118,3298+2]..[118,3298+15])
+                                  Pexp_apply
+                                  expression (extended_semicolon.ml[118,3298+6]..[118,3298+8])
+                                    Pexp_ident ":=" (extended_semicolon.ml[118,3298+6]..[118,3298+8])
+                                  [
+                                    <arg>
+                                    Nolabel
+                                      expression (extended_semicolon.ml[118,3298+2]..[118,3298+5])
+                                        Pexp_construct "Pos" (extended_semicolon.ml[118,3298+2]..[118,3298+5])
+                                        None
+                                    <arg>
+                                    Nolabel
+                                      expression (extended_semicolon.ml[118,3298+9]..[118,3298+15])
+                                        Pexp_tuple
+                                        [
+                                          expression (extended_semicolon.ml[118,3298+10]..[118,3298+11])
+                                            Pexp_constant PConst_int (4,None)
+                                          expression (extended_semicolon.ml[118,3298+13]..[118,3298+14])
+                                            Pexp_constant PConst_int (6,None)
+                                        ]
+                                  ]
+                              <arg>
+                              Nolabel
+                                expression (extended_semicolon.ml[119,3318+2]..[131,3627+13])
+                                  Pexp_apply
+                                  expression (extended_semicolon.ml[119,3318+13]..[119,3318+16])
+                                    Pexp_ident ">>;" (extended_semicolon.ml[119,3318+13]..[119,3318+16])
+                                  [
+                                    <arg>
+                                    Nolabel
+                                      expression (extended_semicolon.ml[119,3318+2]..[119,3318+12])
+                                        Pexp_apply
+                                        expression (extended_semicolon.ml[119,3318+6]..[119,3318+8])
+                                          Pexp_ident ":=" (extended_semicolon.ml[119,3318+6]..[119,3318+8])
+                                        [
+                                          <arg>
+                                          Nolabel
+                                            expression (extended_semicolon.ml[119,3318+2]..[119,3318+5])
+                                              Pexp_construct "Pen" (extended_semicolon.ml[119,3318+2]..[119,3318+5])
+                                              None
+                                          <arg>
+                                          Nolabel
+                                            expression (extended_semicolon.ml[119,3318+9]..[119,3318+12])
+                                              Pexp_constant PConst_char 2b
+                                        ]
+                                    <arg>
+                                    Nolabel
+                                      expression (extended_semicolon.ml[120,3335+2]..[131,3627+13])
+                                        Pexp_apply
+                                        expression (extended_semicolon.ml[120,3335+19]..[120,3335+22])
+                                          Pexp_ident ">>;" (extended_semicolon.ml[120,3335+19]..[120,3335+22])
+                                        [
+                                          <arg>
+                                          Nolabel
+                                            expression (extended_semicolon.ml[120,3335+2]..[120,3335+18])
+                                              Pexp_apply
+                                              expression (extended_semicolon.ml[120,3335+2]..[120,3335+15])
+                                                Pexp_ident "draw_triangle" (extended_semicolon.ml[120,3335+2]..[120,3335+15])
+                                              [
+                                                <arg>
+                                                Nolabel
+                                                  expression (extended_semicolon.ml[120,3335+16]..[120,3335+18])
+                                                    Pexp_constant PConst_int (10,None)
+                                              ]
+                                          <arg>
+                                          Nolabel
+                                            expression (extended_semicolon.ml[122,3359+2]..[131,3627+13])
+                                              Pexp_apply
+                                              expression (extended_semicolon.ml[122,3359+13]..[122,3359+16])
+                                                Pexp_ident ">>;" (extended_semicolon.ml[122,3359+13]..[122,3359+16])
+                                              [
+                                                <arg>
+                                                Nolabel
+                                                  expression (extended_semicolon.ml[122,3359+2]..[122,3359+12])
+                                                    Pexp_apply
+                                                    expression (extended_semicolon.ml[122,3359+6]..[122,3359+8])
+                                                      Pexp_ident ":=" (extended_semicolon.ml[122,3359+6]..[122,3359+8])
+                                                    [
+                                                      <arg>
+                                                      Nolabel
+                                                        expression (extended_semicolon.ml[122,3359+2]..[122,3359+5])
+                                                          Pexp_construct "Pen" (extended_semicolon.ml[122,3359+2]..[122,3359+5])
+                                                          None
+                                                      <arg>
+                                                      Nolabel
+                                                        expression (extended_semicolon.ml[122,3359+9]..[122,3359+12])
+                                                          Pexp_constant PConst_char 23
+                                                    ]
+                                                <arg>
+                                                Nolabel
+                                                  expression (extended_semicolon.ml[123,3376+2]..[131,3627+13])
+                                                    Pexp_apply
+                                                    expression (extended_semicolon.ml[123,3376+16]..[123,3376+19])
+                                                      Pexp_ident ">>;" (extended_semicolon.ml[123,3376+16]..[123,3376+19])
+                                                    [
+                                                      <arg>
+                                                      Nolabel
+                                                        expression (extended_semicolon.ml[123,3376+2]..[123,3376+15])
+                                                          Pexp_apply
+                                                          expression (extended_semicolon.ml[123,3376+6]..[123,3376+8])
+                                                            Pexp_ident ":=" (extended_semicolon.ml[123,3376+6]..[123,3376+8])
+                                                          [
+                                                            <arg>
+                                                            Nolabel
+                                                              expression (extended_semicolon.ml[123,3376+2]..[123,3376+5])
+                                                                Pexp_construct "Pos" (extended_semicolon.ml[123,3376+2]..[123,3376+5])
+                                                                None
+                                                            <arg>
+                                                            Nolabel
+                                                              expression (extended_semicolon.ml[123,3376+9]..[123,3376+15])
+                                                                Pexp_tuple
+                                                                [
+                                                                  expression (extended_semicolon.ml[123,3376+10]..[123,3376+11])
+                                                                    Pexp_constant PConst_int (6,None)
+                                                                  expression (extended_semicolon.ml[123,3376+13]..[123,3376+14])
+                                                                    Pexp_constant PConst_int (1,None)
+                                                                ]
+                                                          ]
+                                                      <arg>
+                                                      Nolabel
+                                                        expression (extended_semicolon.ml[124,3396+2]..[131,3627+13])
+                                                          Pexp_apply
+                                                          expression (extended_semicolon.ml[124,3396+19]..[124,3396+22])
+                                                            Pexp_ident ">>;" (extended_semicolon.ml[124,3396+19]..[124,3396+22])
+                                                          [
+                                                            <arg>
+                                                            Nolabel
+                                                              expression (extended_semicolon.ml[124,3396+2]..[124,3396+18])
+                                                                Pexp_apply
+                                                                expression (extended_semicolon.ml[124,3396+2]..[124,3396+15])
+                                                                  Pexp_ident "draw_triangle" (extended_semicolon.ml[124,3396+2]..[124,3396+15])
+                                                                [
+                                                                  <arg>
+                                                                  Nolabel
+                                                                    expression (extended_semicolon.ml[124,3396+16]..[124,3396+18])
+                                                                      Pexp_constant PConst_int (14,None)
+                                                                ]
+                                                            <arg>
+                                                            Nolabel
+                                                              expression (extended_semicolon.ml[126,3420+2]..[131,3627+13])
+                                                                Pexp_apply
+                                                                expression (extended_semicolon.ml[126,3420+18]..[126,3420+21])
+                                                                  Pexp_ident ">>;" (extended_semicolon.ml[126,3420+18]..[126,3420+21])
+                                                                [
+                                                                  <arg>
+                                                                  Nolabel
+                                                                    expression (extended_semicolon.ml[126,3420+2]..[126,3420+17])
+                                                                      Pexp_apply
+                                                                      expression (extended_semicolon.ml[126,3420+6]..[126,3420+8])
+Pexp_ident ":=" (extended_semicolon.ml[126,3420+6]..[126,3420+8])
+                                                                      [
+<arg>
+Nolabel
+  expression (extended_semicolon.ml[126,3420+2]..[126,3420+5])
+    Pexp_construct "Pos" (extended_semicolon.ml[126,3420+2]..[126,3420+5])
+    None
+<arg>
+Nolabel
+  expression (extended_semicolon.ml[126,3420+9]..[126,3420+17])
+    Pexp_tuple
+    [
+      expression (extended_semicolon.ml[126,3420+10]..[126,3420+12])
+        Pexp_constant PConst_int (29,None)
+      expression (extended_semicolon.ml[126,3420+14]..[126,3420+16])
+        Pexp_constant PConst_int (11,None)
+    ]
+                                                                      ]
+                                                                  <arg>
+                                                                  Nolabel
+                                                                    expression (extended_semicolon.ml[127,3442+2]..[131,3627+13])
+                                                                      Pexp_apply
+                                                                      expression (extended_semicolon.ml[127,3442+72]..[127,3442+75])
+Pexp_ident ">|;" (extended_semicolon.ml[127,3442+72]..[127,3442+75])
+                                                                      [
+<arg>
+Nolabel
+  expression (extended_semicolon.ml[127,3442+2]..[127,3442+71])
+    Pexp_apply
+    expression (extended_semicolon.ml[127,3442+2]..[127,3442+11])
+      Pexp_ident "draw_text" (extended_semicolon.ml[127,3442+2]..[127,3442+11])
+    [
+      <arg>
+      Nolabel
+        expression (extended_semicolon.ml[127,3442+12]..[127,3442+14])
+          Pexp_constant PConst_int (10,None)
+      <arg>
+      Nolabel
+        expression (extended_semicolon.ml[127,3442+15]..[127,3442+71])
+          Pexp_constant PConst_string("These are not three triangles along a third dimension.",None)
+    ]
+<arg>
+Nolabel
+  expression (extended_semicolon.ml[131,3627+2]..[131,3627+13])
+    Pexp_assert
+    expression (extended_semicolon.ml[131,3627+9]..[131,3627+13])
+      Pexp_construct "true" (extended_semicolon.ml[131,3627+9]..[131,3627+13])
+      None
+                                                                      ]
+                                                                ]
+                                                          ]
+                                                    ]
+                                              ]
+                                        ]
+                                  ]
+                            ]
+                      ]
+                ]
+          ]
+    ]
+  structure_item (extended_semicolon.ml[133,3642+0]..[133,3642+52])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (extended_semicolon.ml[133,3642+4]..[133,3642+6])
+          Ppat_construct "()" (extended_semicolon.ml[133,3642+4]..[133,3642+6])
+          None
+        expression (extended_semicolon.ml[133,3642+9]..[133,3642+52])
+          Pexp_apply
+          expression (extended_semicolon.ml[133,3642+45]..[133,3642+47])
+            Pexp_ident "|>" (extended_semicolon.ml[133,3642+45]..[133,3642+47])
+          [
+            <arg>
+            Nolabel
+              expression (extended_semicolon.ml[133,3642+9]..[133,3642+44])
+                Pexp_apply
+                expression (extended_semicolon.ml[133,3642+38]..[133,3642+40])
+                  Pexp_ident "|>" (extended_semicolon.ml[133,3642+38]..[133,3642+40])
+                [
+                  <arg>
+                  Nolabel
+                    expression (extended_semicolon.ml[133,3642+9]..[133,3642+37])
+                      Pexp_apply
+                      expression (extended_semicolon.ml[133,3642+26]..[133,3642+28])
+                        Pexp_ident "|>" (extended_semicolon.ml[133,3642+26]..[133,3642+28])
+                      [
+                        <arg>
+                        Nolabel
+                          expression (extended_semicolon.ml[133,3642+9]..[133,3642+25])
+                            Pexp_apply
+                            expression (extended_semicolon.ml[133,3642+18]..[133,3642+20])
+                              Pexp_ident "|>" (extended_semicolon.ml[133,3642+18]..[133,3642+20])
+                            [
+                              <arg>
+                              Nolabel
+                                expression (extended_semicolon.ml[133,3642+9]..[133,3642+17])
+                                  Pexp_tuple
+                                  [
+                                    expression (extended_semicolon.ml[133,3642+10]..[133,3642+12])
+                                      Pexp_constant PConst_int (72,None)
+                                    expression (extended_semicolon.ml[133,3642+14]..[133,3642+16])
+                                      Pexp_constant PConst_int (19,None)
+                                  ]
+                              <arg>
+                              Nolabel
+                                expression (extended_semicolon.ml[133,3642+21]..[133,3642+25])
+                                  Pexp_ident "init" (extended_semicolon.ml[133,3642+21]..[133,3642+25])
+                            ]
+                        <arg>
+                        Nolabel
+                          expression (extended_semicolon.ml[133,3642+29]..[133,3642+37])
+                            Pexp_apply
+                            expression (extended_semicolon.ml[133,3642+29]..[133,3642+32])
+                              Pexp_ident "run" (extended_semicolon.ml[133,3642+29]..[133,3642+32])
+                            [
+                              <arg>
+                              Nolabel
+                                expression (extended_semicolon.ml[133,3642+33]..[133,3642+37])
+                                  Pexp_ident "test" (extended_semicolon.ml[133,3642+33]..[133,3642+37])
+                            ]
+                      ]
+                  <arg>
+                  Nolabel
+                    expression (extended_semicolon.ml[133,3642+41]..[133,3642+44])
+                      Pexp_ident "snd" (extended_semicolon.ml[133,3642+41]..[133,3642+44])
+                ]
+            <arg>
+            Nolabel
+              expression (extended_semicolon.ml[133,3642+48]..[133,3642+52])
+                Pexp_ident "dump" (extended_semicolon.ml[133,3642+48]..[133,3642+52])
+          ]
+    ]
+]
+


### PR DESCRIPTION
This PR adds a new class of low precedence operators suitable as statement separators.  E.g. a rewriter may set up the following aliases:

* `e1 -; e2` as `e1; e2`
* `e1 >|; e2` as `e1 >|= fun () -> e2`
* `e1 >>; e2` as `e1 >>= fun () -> e2`

which could be used in an Lwt context: 
```ocaml
open Lwt.Infix

let rec test l n =
  Lwt_io.printlf "Entering level %d." l >>;
  begin
    if l > 5 || !n > 20 then
      Lwt_io.printl "Sleeping." >>;
      Lwt_unix.sleep (Random.float 1.0)
    else
      n := !n + 1 -;
      test (l + 1) n <&> test (l + 1) n >|;
      n := !n - 1
  end >>;
  Lwt_io.printlf "Leaving level %d." l
```
I might have gone slightly overboard with the `extended_semicolon.ml` test, so that provides a more elaborate example.

## Syntax

The operators are composed of a semicolon prefixed by one or more operator characters, except for a few constraints due to conflicts with existing syntax.  The period is excluded from the operator characters here, since both `..` and `.` may occur before `;;` and at least the latter before `;`.  The `>;` operator also had to be excluded, since `>` works as a delimiter in type expressions, and may thus precede both `;` and `;;`.  I'm not sure if this covers everything, so we should give this point some though before merging (with a "-" bullet in the change log).

The precedence level is just above `if`, as opposed to `;`, which is just below.  This level was chosen to prevent a prefixed  `let` expression from affecting the grouping of statements under `then` or `else`, as discussed to length in #715 and related threads.  I believe the `-;` operator suggested above provides a more well-behaved alternative to `;` for those who are okay with the heavier notation.

## Related

* [Discourse discussion about `>>` in lwt](https://discuss.ocaml.org/t/operator-in-lwt/296).
* ocsigen/lwt#307 discusses `;%lwt` and ocsigen/lwt#495 proposes to remove `>>`.
