### PR TITLE
Fix Spacetime under Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -61,6 +61,10 @@ Working version
 - GPR#1431: remove ocamlrun dependencies on curses/terminfo/termcap C library
   (Xavier Leroy, review by Daniel Bünzli)
 
+- GPR#1478: The Spacetime profiler now works under Windows (but it is not yet
+  able to collect profiling information from C stubs).
+  (Nicolas Ojeda Bar, review by Xavier Leroy, Mark Shinwell)
+
 ### Tools:
 
 - MPR#7643, GPR#1377: ocamldep, fix an exponential blowup in presence of nested

--- a/asmrun/Makefile
+++ b/asmrun/Makefile
@@ -53,6 +53,10 @@ ifeq "$(TOOLCHAIN)" "msvc"
 DFLAGS = $(CFLAGS) -DDEBUG
 PFLAGS=$(CFLAGS) -DPROFILING $(NATIVECCPROFOPTS)
 ASMOBJS=$(ARCH)nt.$(O)
+ASMFLAGS=
+ifeq ($(WITH_SPACETIME),true)
+ASMFLAGS=/DWITH_SPACETIME
+endif
 else
 DFLAGS = $(CFLAGS) -g -DDEBUG
 PFLAGS=$(CFLAGS) -pg -DPROFILING $(NATIVECCPROFOPTS)
@@ -163,10 +167,10 @@ $(LINKEDFILES): %.c: ../byterun/%.c
 	$(ASPP) $(ASPPFLAGS) $(SHAREDCCCOMPOPTS) -o $@ $<
 
 %.obj: %.asm
-	$(ASM)$@ $<
+	$(ASM)$@ $(ASMFLAGS) $<
 
 %.pic.obj: %.asm
-	$(ASM)$@ $<
+	$(ASM)$@ $(ASMFLAGS) $<
 
 .PHONY: clean
 clean:

--- a/asmrun/amd64.S
+++ b/asmrun/amd64.S
@@ -268,6 +268,20 @@
 #  define STACK_PROBE_SIZE $32768
 #endif
 
+/* Registers holding arguments of C functions. */
+
+#if defined(SYS_mingw64) || defined(SYS_cygwin)
+#define C_ARG_1 %rcx
+#define C_ARG_2 %rdx
+#define C_ARG_3 %r8
+#define C_ARG_4 %r9
+#else
+#define C_ARG_1 %rdi
+#define C_ARG_2 %rsi
+#define C_ARG_3 %rdx
+#define C_ARG_4 %rcx
+#endif
+
         .text
 
         .globl  G(caml_system__code_begin)
@@ -508,8 +522,8 @@ LBL(caml_start_program):
         pushq   %rdi; CFI_ADJUST (8)
         pushq   %rsi; CFI_ADJUST (8)
         /* No need to push %r12: it's callee-save. */
-        movq    %r12, %rdi
-        LEA_VAR(caml_start_program, %rsi)
+        movq    %r12, C_ARG_1
+        LEA_VAR(caml_start_program, C_ARG_2)
         call    GCALL(caml_spacetime_c_to_ocaml)
         popq    %rsi; CFI_ADJUST (-8)
         popq    %rdi; CFI_ADJUST (-8)
@@ -556,20 +570,6 @@ LBL(108):
         orq     $2, %rax
         jmp     LBL(109)
 CFI_ENDPROC
-
-/* Registers holding arguments of C functions. */
-
-#if defined(SYS_mingw64) || defined(SYS_cygwin)
-#define C_ARG_1 %rcx
-#define C_ARG_2 %rdx
-#define C_ARG_3 %r8
-#define C_ARG_4 %r9
-#else
-#define C_ARG_1 %rdi
-#define C_ARG_2 %rsi
-#define C_ARG_3 %rdx
-#define C_ARG_4 %rcx
-#endif
 
 /* Raise an exception from OCaml */
 

--- a/asmrun/amd64nt.asm
+++ b/asmrun/amd64nt.asm
@@ -34,6 +34,10 @@
         EXTRN  caml_backtrace_pos: DWORD
         EXTRN  caml_backtrace_active: DWORD
         EXTRN  caml_stash_backtrace: NEAR
+IFDEF WITH_SPACETIME
+        EXTRN  caml_spacetime_trie_node_ptr: QWORD
+        EXTRN  caml_spacetime_c_to_ocaml: NEAR
+ENDIF
 
         .CODE
 
@@ -61,6 +65,9 @@ L105:
     ; Save caml_young_ptr, caml_exception_pointer
         mov     caml_young_ptr, r15
         mov     caml_exception_pointer, r14
+IFDEF WITH_SPACETIME
+        mov     caml_spacetime_trie_node_ptr, r13
+ENDIF
     ; Build array of registers, save it into caml_gc_regs
         push    rbp
         push    r11
@@ -212,6 +219,11 @@ caml_c_call:
         pop     r12
         mov     caml_last_return_address, r12
         mov     caml_bottom_of_stack, rsp
+IFDEF WITH_SPACETIME
+    ; Record the trie node hole pointer that corresponds to
+    ; [caml_last_return_address]
+        mov     caml_spacetime_trie_node_ptr, r13
+ENDIF
     ; Touch the stack to trigger a recoverable segfault
     ; if insufficient space remains
         sub     rsp, 01000h
@@ -258,10 +270,29 @@ caml_start_program:
     ; Common code for caml_start_program and caml_callback*
 L106:
     ; Build a callback link
+IFDEF WITH_SPACETIME
+        push    caml_spacetime_trie_node_ptr
+ELSE
         sub     rsp, 8  ; stack 16-aligned
+ENDIF
         push    caml_gc_regs
         push    caml_last_return_address
         push    caml_bottom_of_stack
+IFDEF WITH_SPACETIME
+    ; Save arguments to caml_callback
+        push    rax
+        push    rbx
+        push    rdi
+        push    rsi
+    ; No need to push r12: it is callee-save.
+        mov     rcx, r12
+        lea     rdx, caml_start_program
+        call    caml_spacetime_c_to_ocaml
+        pop     rsi
+        pop     rdi
+        pop     rbx
+        pop     rax
+ENDIF
     ; Setup alloc ptr and exception ptr
         mov     r15, caml_young_ptr
         mov     r14, caml_exception_pointer
@@ -270,6 +301,9 @@ L106:
         push    r13
         push    r14
         mov     r14, rsp
+IFDEF WITH_SPACETIME
+        mov     r13, caml_spacetime_trie_node_ptr
+ENDIF
     ; Call the OCaml code
         call    r12
 L107:
@@ -284,7 +318,11 @@ L109:
         pop     caml_bottom_of_stack
         pop     caml_last_return_address
         pop     caml_gc_regs
+IFDEF WITH_SPACETIME
+        pop     caml_spacetime_trie_node_ptr
+ELSE
         add     rsp, 8
+ENDIF
     ; Restore callee-save registers.
         movapd  xmm6, OWORD PTR [rsp + 0*16]
         movapd  xmm7, OWORD PTR [rsp + 1*16]
@@ -471,6 +509,19 @@ caml_system__frametable LABEL QWORD
         WORD    -1          ; negative frame size => use callback link
         WORD    0           ; no roots here
         ALIGN   8
+
+IFDEF WITH_SPACETIME
+        .DATA
+        PUBLIC  caml_system__spacetime_shapes
+        ALIGN   8
+caml_system__spacetime_shapes LABEL QWORD
+        QWORD   caml_start_program
+        QWORD   2         ; indirect call point to OCaml code
+        QWORD   L107      ; in caml_start_program / caml_callback*
+        QWORD   0         ; end of shapes in caml_start_program
+        QWORD   0         ; end of shape table
+        ALIGN   8
+ENDIF
 
         PUBLIC  caml_negf_mask
         ALIGN   16

--- a/otherlibs/raw_spacetime_lib/raw_spacetime_lib.ml
+++ b/otherlibs/raw_spacetime_lib/raw_spacetime_lib.ml
@@ -596,7 +596,7 @@ module Heap_snapshot = struct
         (Array.of_list (List.rev snapshots)), List.rev events
 
     let read ~path =
-      let chn = open_in path in
+      let chn = open_in_bin path in
       let magic_number : int = Marshal.from_channel chn in
       let magic_number_base = magic_number land 0xffff_ffff in
       let version_number = (magic_number lsr 32) land 0xffff in


### PR DESCRIPTION
This PR adapts Spacetime so it can be used under Windows.

- Adapt `spacetime.c` to Unicode changes, fix compilation under `msvc`, etc.
- **Use the right calling convention in `amd64.S` when calling `caml_spacetime_c_to_ocaml`**
- Make the necessary Spacetime-related modifications to `amd64nt.asm` (used by `msvc`)
- Use binary mode to read profiles in `raw_spacetime_lib`

Thanks @mshinwell for help debugging!