### PR TITLE
[WiP] Match- and try-blocks with mandatory "end"

### DIFF
--- a/Changes
+++ b/Changes
@@ -13,6 +13,13 @@ be mentioned in the 4.06 section below instead of here.)
   (Nicolas Ojeda Bar, review by Gabriel Radanne, Damien Doligez, Gabriel
   Scherer)
 
+- GPR#1480: Add "match" and "try" blocks with mandatory "end" delimiters,
+  distinguished by substituting "as" for the "with" keyword, e.g.
+    match s_opt as
+    | None -> ""
+    | Some s -> s
+    end
+
 ### Type system:
 
 - GPR#1370: Fix code duplication in Cmmgen

--- a/manual/manual/cmds/afl-fuzz.etex
+++ b/manual/manual/cmds/afl-fuzz.etex
@@ -52,9 +52,10 @@ As an example, we fuzz-test the following program, {\tt readline.ml}:
 \begin{verbatim}
 let _ =
   let s = read_line () in
-  match Array.to_list (Array.init (String.length s) (String.get s)) with
+  match Array.to_list (Array.init (String.length s) (String.get s)) as
     ['s'; 'e'; 'c'; 'r'; 'e'; 't'; ' '; 'c'; 'o'; 'd'; 'e'] -> failwith "uh oh"
   | _ -> ()
+  end
 \end{verbatim}
 
 There is a single input (the string ``secret code'') which causes this

--- a/manual/manual/cmds/comp.etex
+++ b/manual/manual/cmds/comp.etex
@@ -389,7 +389,7 @@ let dy { y; _ } = y (* explicit field elision: do not trigger warning 9 *)
   but this means that any code of the form
 \begin{verbatim}
   try ...
-  with Invalid_argument "arrays must have the same length" -> ...
+  as Invalid_argument "arrays must have the same length" -> ... end
 \end{verbatim}
   is now broken and may suffer from uncaught exceptions.
 
@@ -445,21 +445,23 @@ let warning = function
 
   For example,
 \begin{verbatim}
-try (int_of_string count_str, bool_of_string choice_str) with
+try (int_of_string count_str, bool_of_string choice_str) as
   | Failure "int_of_string" -> (0, true)
   | Failure "bool_of_string" -> (-1, false)
+end
 \end{verbatim}
   should be rewritten into more atomic tests. For example,
   using the "exception" patterns documented in Section~\ref{s:exception-match},
   one can write:
 \begin{verbatim}
-match int_of_string count_str with
+match int_of_string count_str as
   | exception (Failure _) -> (0, true)
   | count ->
-    begin match bool_of_string choice_str with
+    match bool_of_string choice_str as
     | exception (Failure _) -> (-1, false)
     | choice -> (count, choice)
     end
+end
 \end{verbatim}
 
 The only case where that transformation is not possible is if a given

--- a/manual/manual/cmds/debugger.etex
+++ b/manual/manual/cmds/debugger.etex
@@ -171,7 +171,7 @@ the source code:
 fun x y z -> \event ...
 \end{alltt}
 \item On each case of a pattern-matching definition (function,
-"match"\ldots"with" construct, "try"\ldots"with" construct):
+"match"\ldots"as"\ldots"end" construct, "try"\ldots"as"\ldots"end" construct):
 \begin{alltt}
 function pat1 -> \event expr1
        | ...

--- a/manual/manual/cmds/flambda.etex
+++ b/manual/manual/cmds/flambda.etex
@@ -544,11 +544,12 @@ place in the compiler currently does this.)
 This function might be written like so:
 \begin{verbatim}
 let rec iter f l =
-  match l with
+  match l as
   | [] -> ()
   | h :: t ->
     f h;
     iter f t
+  end
 \end{verbatim}
 and used like this:
 \begin{verbatim}
@@ -564,11 +565,12 @@ specialised:
 let run xs =
   let rec iter' f l =
     (* The compiler knows: f holds the same value as foo throughout iter'. *)
-    match l with
+    match l as
     | [] -> ()
     | h :: t ->
       f h;
       iter' f t
+    end
   in
   iter' print_int (List.rev xs)
 \end{verbatim}
@@ -579,11 +581,12 @@ means that the body of {\tt iter'} may be simplified:
 let run xs =
   let rec iter' f l =
     (* The compiler knows: f holds the same value as foo throughout iter'. *)
-    match l with
+    match l as
     | [] -> ()
     | h :: t ->
       print_int h;  (* this is now a direct call *)
       iter' f t
+    end
   in
   iter' print_int (List.rev xs)
 \end{verbatim}
@@ -592,11 +595,12 @@ The call to {\tt print\_int} can indeed be inlined:
 let run xs =
   let rec iter' f l =
     (* The compiler knows: f holds the same value as foo throughout iter'. *)
-    match l with
+    match l as
     | [] -> ()
     | h :: t ->
       print_endline (string_of_int h);
       iter' f t
+    end
   in
   iter' print_int (List.rev xs)
 \end{verbatim}
@@ -604,11 +608,12 @@ The unused specialised argument {\tt f} may now be removed, leaving:
 \begin{verbatim}
 let run xs =
   let rec iter' l =
-    match l with
+    match l as
     | [] -> ()
     | h :: t ->
       print_endline (string_of_int h);
       iter' t
+    end
   in
   iter' (List.rev xs)
 \end{verbatim}
@@ -617,13 +622,14 @@ let run xs =
 detect invariance in cases such as the following.
 \begin{verbatim}
 let rec iter_swap f g l =
-  match l with
+  match l as
   | [] -> ()
   | 0 :: t ->
     iter_swap g f l
   | h :: t ->
     f h;
     iter_swap f g t
+  end
 \end{verbatim}
 
 \subsection{Assessment of specialisation benefit}
@@ -959,13 +965,15 @@ being invariant and always the pair formed by adding {\tt 42} and {\tt 43}
 to the argument {\tt x} of the function {\tt f}.
 \begin{verbatim}
 let rec loop inv xs =
-  match xs with
+  match xs as
   | [] -> fst inv + snd inv
   | x::xs -> x + loop2 xs inv
+  end
 and loop2 ys inv =
-  match ys with
+  match ys as
   | [] -> 4
   | y::ys -> y - loop inv ys
+  end
 
 let f x =
   Printf.printf "%d\n" (loop (x + 42, x + 43) [1; 2; 3])
@@ -975,13 +983,15 @@ arguments will be added.  After some simplification one obtains:
 \begin{verbatim}
 let f x =
   let rec loop' xs inv_0 inv_1 =
-    match xs with
+    match xs as
     | [] -> inv_0 + inv_1
     | x::xs -> x + loop2' xs inv_0 inv_1
+    end
   and loop2' ys inv_0 inv_1 =
-    match ys with
+    match ys as
     | [] -> 4
     | y::ys -> y - loop' ys inv_0 inv_1
+    end
   in
   Printf.printf "%d\n" (loop' [1; 2; 3] (x + 42) (x + 43))
 \end{verbatim}
@@ -1085,7 +1095,7 @@ too large to inline.
 \begin{verbatim}
 let foo c =
   let rec bar zs fv =
-    match zs with
+    match zs as
     | [] -> []
     | z::zs ->
       let rec baz f = function
@@ -1093,6 +1103,7 @@ let foo c =
         | a::l -> let r = fv + ((f [@inlined never]) a) in r :: baz f l
       in
       (map2 (fun y -> z + y) [z; 2; 3; 4]) @ bar zs fv
+    end
   in
   Printf.printf "%d" (List.length (bar [1; 2; 3; 4] c))
 \end{verbatim}

--- a/manual/manual/cmds/lexyacc.etex
+++ b/manual/manual/cmds/lexyacc.etex
@@ -667,8 +667,9 @@ Here is the main program, that combines the parser with the lexer:
               let result = Parser.main Lexer.token lexbuf in
                 print_int result; print_newline(); flush stdout
             done
-          with Lexer.Eof ->
+          as Lexer.Eof ->
             exit 0
+          end
 \end{verbatim}
 To compile everything, execute:
 \begin{verbatim}
@@ -716,8 +717,9 @@ rule token = parse
   ['A'-'Z' 'a'-'z'] ['A'-'Z' 'a'-'z' '0'-'9' '_'] * as id
                { try
                    Hashtbl.find keyword_table id
-                 with Not_found ->
-                   IDENT id }
+                 as Not_found ->
+                   IDENT id
+                 end }
 \end{verbatim}
 
 \item[ocamllex: Position memory overflow, too many bindings]

--- a/manual/manual/cmds/profil.etex
+++ b/manual/manual/cmds/profil.etex
@@ -45,7 +45,7 @@ both {\bf then} branch and {\bf else} branch
 the loop body
 \item["m"] {\bf match} branches: a count point is set at the beginning of the
 body of each branch
-\item["t"] {\bf try \ldots with \ldots} branches: a count point is set at the
+\item["t"] {\bf try \ldots as \ldots end} branches: a count point is set at the
 beginning of the body of each branch
 \end{options}
 

--- a/manual/manual/refman/expr.etex
+++ b/manual/manual/refman/expr.etex
@@ -58,9 +58,11 @@ expr:
   | 'while' expr 'do' expr 'done'
   | 'for' value-name '=' expr ( 'to' || 'downto' ) expr 'do' expr 'done'
   | expr ';' expr
+  | 'match' expr 'as' pattern-matching 'end'
   | 'match' expr 'with' pattern-matching
   | 'function' pattern-matching
   | 'fun' {{ parameter }} [ ':' typexpr ] '->' expr
+  | 'try' expr 'as' pattern-matching 'end'
   | 'try' expr 'with' pattern-matching
   | 'let' ['rec'] let-binding { 'and' let-binding } 'in' expr
   | 'new' class-path
@@ -308,7 +310,7 @@ expr@ is equivalent to
 \begin{center}
 @"fun" "?" lab ":" ident '->'
   "let" pattern '='
-    "match" ident "with" "Some" ident "->" ident '|' "None" '->' expr_0
+    "match" ident "as" "Some" ident "->" ident '|' "None" '->' expr_0 "end"
   "in" expr@
 \end{center}
 where @ident@
@@ -453,9 +455,10 @@ The @"else" expr_3@ part can be omitted, in which case it defaults to
 The expression
 $$\begin{array}{rlll}
 \token{match} & \textsl{expr} \\
-\token{with} & \textsl{pattern}_1 & \token{->} & \textsl{expr}_1 \\
-\token{|}     & \ldots \\
-\token{|}     & \textsl{pattern}_n & \token{->} & \textsl{expr}_n
+\token{as} & \textsl{pattern}_1 & \token{->} & \textsl{expr}_1 \\
+\token{|}  & \ldots \\
+\token{|}  & \textsl{pattern}_n & \token{->} & \textsl{expr}_n \\
+\token{end}
 \end{array}$$
 matches the value of @expr@ against the patterns @pattern_1@ to
 @pattern_n@. If the matching against @pattern_i@ succeeds, the
@@ -530,9 +533,10 @@ value @'()'@.
 The expression
 $$\begin{array}{rlll}
 \token{try~} & \textsl{expr} \\
-\token{with} & \textsl{pattern}_1 & \token{->} & \textsl{expr}_1 \\
+\token{as} & \textsl{pattern}_1 & \token{->} & \textsl{expr}_1 \\
 \token{|}   & \ldots \\
-\token{|}   & \textsl{pattern}_n & \token{->} & \textsl{expr}_n
+\token{|}   & \textsl{pattern}_n & \token{->} & \textsl{expr}_n \\
+\token{end}
 \end{array}$$
 evaluates the expression @expr@ and returns its value if the
 evaluation of @expr@ does not raise any exception. If the evaluation

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -166,11 +166,12 @@ definition is:
                  = struct
                      type t = Leaf of string | Node of ASet.t
                      let compare t1 t2 =
-                       match (t1, t2) with
+                       match (t1, t2) as
                          (Leaf s1, Leaf s2) -> Pervasives.compare s1 s2
                        | (Leaf _, Node _) -> 1
                        | (Node _, Leaf _) -> -1
                        | (Node n1, Node n2) -> ASet.compare n1 n2
+                       end
                    end
         and ASet : Set.S with type elt = A.t
                  = Set.Make(A)
@@ -623,7 +624,7 @@ arguments, for instance:
 \begin{verbatim}
         module Device =
           (val (try Hashtbl.find devices (parse_cmdline())
-                with Not_found -> eprintf "Unknown device %s\n"; exit 2)
+                as Not_found -> eprintf "Unknown device %s\n"; exit 2 end)
            : DEVICE)
 \end{verbatim}
 Alternatively, the selection can be performed within a function:
@@ -733,13 +734,14 @@ then pretty-prints the value into a string:
         open Typ
         let rec to_string: 'a. 'a Typ.typ -> 'a -> string =
           fun (type s) t x ->
-            match t with
+            match t as
             | Int eq -> string_of_int (TypEq.apply eq x)
             | String eq -> Printf.sprintf "%S" (TypEq.apply eq x)
             | Pair p ->
                 let module P = (val p : PAIR with type t = s) in
                 let (x1, x2) = TypEq.apply P.eq x in
                 Printf.sprintf "(%s,%s)" (to_string P.t1 x1) (to_string P.t2 x2)
+            end
 \end{verbatim}
 
 Note that this function uses an explicit polymorphic annotation to obtain
@@ -1121,10 +1123,11 @@ For instance, the following program types correctly.
 \begin{verbatim}
         let rec sum : type a. a term -> _ = fun x ->
           let y =
-            match x with
+            match x as
             | Int n -> n
             | Add   -> 0
             | App(f,x) -> sum f + sum x
+            end
           in y + 1
         val sum : 'a term -> int = <fun>
 \end{verbatim}
@@ -1206,12 +1209,13 @@ then pretty-prints the value as a string:
 
         let rec to_string: type t. t typ -> t -> string =
           fun t x ->
-          match t with
+          match t as
           | Int -> string_of_int x
           | String -> Printf.sprintf "%S" x
           | Pair(t1,t2) ->
               let (x1, x2) = x in
               Printf.sprintf "(%s,%s)" (to_string t1 x1) (to_string t2 x2)
+          end
 \end{verbatim}
 
 Another frequent application of GADTs is equality witnesses.
@@ -1230,23 +1234,25 @@ to implement dynamic types.
 \begin{verbatim}
         let rec eq_type : type a b. a typ -> b typ -> (a,b) eq option =
           fun a b ->
-          match a, b with
+          match a, b as
           | Int, Int -> Some Eq
           | String, String -> Some Eq
           | Pair(a1,a2), Pair(b1,b2) ->
-              begin match eq_type a1 b1, eq_type a2 b2 with
+              match eq_type a1 b1, eq_type a2 b2 as
               | Some Eq, Some Eq -> Some Eq
               | _ -> None
               end
           | _ -> None
+          end
 
         type dyn = Dyn : 'a typ * 'a -> dyn
 
         let get_dyn : type a. a typ -> dyn -> a option =
           fun a (Dyn(b,x)) ->
-          match eq_type a b with
+          match eq_type a b as
           | None -> None
           | Some Eq -> Some x
+          end
 \end{verbatim}
 
 \paragraph{Existential type names in error messages}%
@@ -1278,9 +1284,10 @@ type ('arg,'result,'aux) fn =
   | Fun: ('a ->'b) -> ('a,'b,unit) fn
   | Mem1: ('a ->'b) * 'a * 'b -> ('a, 'b, 'a * 'b) fn
  let apply: ('arg,'result, _ ) fn -> 'arg -> 'result = fun f x ->
-  match f with
+  match f as
   | Fun f -> f x
   | Mem1 (f,y,fy) -> if x = y then fy else f x
+  end
 \end{caml_example}
 \item "$n" (n a number) is an internally generated existential %$
 which could not be named using one of the previous schemes.
@@ -1844,7 +1851,7 @@ change the delimiter to avoid escaping issues.
 (Introduced in OCaml 4.02)
 
 A new form of exception patterns is allowed, only as a toplevel
-pattern under a "match"..."with" pattern-matching (other occurrences
+pattern under a "match"..."as" pattern-matching (other occurrences
 are rejected by the type-checker).
 
 \begin{syntax}
@@ -1858,9 +1865,9 @@ as opposed to regular ``value cases''.  Exception cases are applied
 when the evaluation of the matched expression raises an exception.
 The exception value is then matched against all the exception cases
 and re-raised if none of them accept the exception (as for a
-"try"..."with" block).  Since the bodies of all exception and value
+"try"\ldots"as"\ldots"end" block).  Since the bodies of all exception and value
 cases is outside the scope of the exception handler, they are all
-considered to be in tail-position: if the "match"..."with" block
+considered to be in tail-position: if the "match"\ldots"as"\ldots"end" block
 itself is in tail position in the current function, any function call
 in tail position in one of the case bodies results in an actual tail
 call.

--- a/manual/manual/tutorials/advexamples.etex
+++ b/manual/manual/tutorials/advexamples.etex
@@ -387,7 +387,7 @@ class ['a] stack =
   object
     val mutable l = ([] : 'a list)
     method push x = l <- x::l
-    method pop = match l with [] -> raise Empty | a::l' -> l <- l'; a
+    method pop = match l as [] -> raise Empty | a::l' -> l <- l'; a end
     method clear = l <- []
     method length = List.length l
   end;;
@@ -509,15 +509,17 @@ module type SET =
 module Set : SET =
   struct
     let rec merge l1 l2 =
-      match l1 with
+      match l1 as
         [] -> l2
       | h1 :: t1 ->
-          match l2 with
+          match l2 as
             [] -> l1
           | h2 :: t2 ->
               if h1 < h2 then h1 :: merge t1 l2
               else if h1 > h2 then h2 :: merge l1 t2
               else merge t1 l2
+          end
+      end
     type 'a tag = 'a list
     class ['a] c =
       object (_ : 'b)

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -84,13 +84,15 @@ shape as list expressions, with identifier representing unspecified
 parts of the list. As an example, here is insertion sort on a list:
 \begin{caml_example}{toplevel}
 let rec sort lst =
-  match lst with
+  match lst as
     [] -> []
   | head :: tail -> insert head (sort tail)
+  end
 and insert elt lst =
-  match lst with
+  match lst as
     [] -> [elt]
   | head :: tail -> if elt <= head then elt :: lst else head :: insert elt tail
+  end
 ;;
 sort l;;
 \end{caml_example}
@@ -148,9 +150,10 @@ functionals, is predefined because it is often useful, but there is
 nothing magic with it: it can easily be defined as follows.
 \begin{caml_example}{toplevel}
 let rec map f l =
-  match l with
+  match l as
     [] -> []
-  | hd :: tl -> f hd :: map f tl;;
+  | hd :: tl -> f hd :: map f tl
+  end;;
 \end{caml_example}
 
 \section{Records and variants}
@@ -170,8 +173,9 @@ add_ratio {num=1; denom=3} {num=2; denom=5};;
 Record fields can also be accessed through pattern-matching:
 \begin{caml_example}{toplevel}
 let integer_part r =
-  match r with
-    {num=num; denom=denom} -> num / denom;;
+  match r as
+    {num=num; denom=denom} -> num / denom
+  end;;
 \end{caml_example}
 Since there is only one case in this pattern matching, it
 is safe to expand directly the argument "r" in a record pattern:
@@ -229,7 +233,7 @@ To define arithmetic operations for the "number" type, we use
 pattern-matching on the two numbers involved:
 \begin{caml_example}{toplevel}
 let add_num n1 n2 =
-  match (n1, n2) with
+  match (n1, n2) as
     (Int i1, Int i2) ->
       (* Check for overflow of integer addition *)
       if sign_int i1 = sign_int i2 && sign_int (i1 + i2) <> sign_int i1
@@ -239,7 +243,8 @@ let add_num n1 n2 =
   | (Float f1, Int i2) -> Float(f1 +. float i2)
   | (Float f1, Float f2) -> Float(f1 +. f2)
   | (Error, _) -> Error
-  | (_, Error) -> Error;;
+  | (_, Error) -> Error
+  end;;
 add_num (Int 123) (Float 3.14159);;
 \end{caml_example}
 
@@ -271,17 +276,19 @@ instance, here are functions performing lookup and insertion in
 ordered binary trees (elements increase from left to right):
 \begin{caml_example}{toplevel}
 let rec member x btree =
-  match btree with
+  match btree as
     Empty -> false
   | Node(y, left, right) ->
       if x = y then true else
-      if x < y then member x left else member x right;;
+      if x < y then member x left else member x right
+  end;;
 let rec insert x btree =
-  match btree with
+  match btree as
     Empty -> Node(x, Empty, Empty)
   | Node(y, left, right) ->
       if x <= y then Node(y, insert x left, right)
-                else Node(y, left, insert x right);;
+                else Node(y, left, insert x right)
+  end;;
 \end{caml_example}
 
 \section{Imperative features}
@@ -381,9 +388,10 @@ signal the case where an empty list is given.
 \begin{caml_example}{toplevel}
 exception Empty_list;;
 let head l =
-  match l with
+  match l as
     [] -> raise Empty_list
-  | hd :: tl -> hd;;
+  | hd :: tl -> hd
+  end;;
 head [1;2];;
 head [];;
 \end{caml_example}
@@ -398,20 +406,21 @@ List.assoc 1 [(0, "zero"); (1, "one")];;
 List.assoc 2 [(0, "zero"); (1, "one")];;
 \end{caml_example}
 
-Exceptions can be trapped with the "try"\ldots"with" construct:
+Exceptions can be trapped with the "try"\ldots"as"\ldots"end" construct:
 \begin{caml_example}{toplevel}
 let name_of_binary_digit digit =
   try
     List.assoc digit [0, "zero"; 1, "one"]
-  with Not_found ->
-    "not a binary digit";;
+  as Not_found ->
+    "not a binary digit"
+  end;;
 name_of_binary_digit 0;;
 name_of_binary_digit (-1);;
 \end{caml_example}
 
 The "with" part is actually a regular pattern-matching on the
 exception value. Thus, several exceptions can be caught by one
-"try"\ldots"with" construct. Also, finalization can be performed by
+"try"\ldots"as"\ldots"end" construct. Also, finalization can be performed by
 trapping all exceptions, performing the finalization, then raising
 again the exception:
 \begin{caml_example}{toplevel}
@@ -422,9 +431,10 @@ let temporarily_set_reference ref newval funct =
     let res = funct () in
     ref := oldval;
     res
-  with x ->
+  as x ->
     ref := oldval;
-    raise x;;
+    raise x
+  end;;
 \end{caml_example}
 
 \section{Symbolic processing of expressions}
@@ -451,14 +461,15 @@ the environment is represented as an association list.
 \begin{caml_example}{toplevel}
 exception Unbound_variable of string;;
 let rec eval env exp =
-  match exp with
+  match exp as
     Const c -> c
   | Var v ->
-      (try List.assoc v env with Not_found -> raise (Unbound_variable v))
+      try List.assoc v env as Not_found -> raise (Unbound_variable v) end
   | Sum(f, g) -> eval env f +. eval env g
   | Diff(f, g) -> eval env f -. eval env g
   | Prod(f, g) -> eval env f *. eval env g
-  | Quot(f, g) -> eval env f /. eval env g;;
+  | Quot(f, g) -> eval env f /. eval env g
+  end;;
 eval [("x", 1.0); ("y", 3.14)] (Prod(Sum(Var "x", Const 2.0), Var "y"));;
 \end{caml_example}
 
@@ -466,7 +477,7 @@ Now for a real symbolic processing, we define the derivative of an
 expression with respect to a variable "dv":
 \begin{caml_example}{toplevel}
 let rec deriv exp dv =
-  match exp with
+  match exp as
     Const c -> Const 0.0
   | Var v -> if v = dv then Const 1.0 else Const 0.0
   | Sum(f, g) -> Sum(deriv f dv, deriv g dv)
@@ -474,6 +485,7 @@ let rec deriv exp dv =
   | Prod(f, g) -> Sum(Prod(f, deriv g dv), Prod(deriv f dv, g))
   | Quot(f, g) -> Quot(Diff(Prod(deriv f dv, g), Prod(f, deriv g dv)),
                        Prod(g, g))
+  end
 ;;
 deriv (Quot(Const 1.0, Var "x")) "x";;
 \end{caml_example}
@@ -501,7 +513,7 @@ let print_expr exp =
   let close_paren prec op_prec =
     if prec > op_prec then print_string ")" in
   let rec print prec exp =     (* prec is the current precedence *)
-    match exp with
+    match exp as
       Const c -> print_float c
     | Var v -> print_string v
     | Sum(f, g) ->
@@ -520,6 +532,7 @@ let print_expr exp =
         open_paren prec 2;
         print 2 f; print_string " / "; print 3 g;
         close_paren prec 2
+    end
   in print 0 exp;;
 let e = Sum(Prod(Const 2.0, Var "x"), Const 1.0);;
 print_expr e; print_newline ();;

--- a/manual/manual/tutorials/lablexamples.etex
+++ b/manual/manual/tutorials/lablexamples.etex
@@ -147,9 +147,10 @@ provide different behaviors when an argument is present or not.
 
 \begin{caml_example}{toplevel}
 let bump ?step x =
-  match step with
+  match step as
   | None -> x * 2
   | Some y -> x + y
+  end
 ;;
 \end{caml_example}
 

--- a/manual/manual/tutorials/moduleexamples.etex
+++ b/manual/manual/tutorials/moduleexamples.etex
@@ -23,12 +23,13 @@ module PrioQueue =
     type 'a queue = Empty | Node of priority * 'a * 'a queue * 'a queue
     let empty = Empty
     let rec insert queue prio elt =
-      match queue with
+      match queue as
         Empty -> Node(prio, elt, Empty, Empty)
       | Node(p, e, left, right) ->
           if prio <= p
           then Node(prio, elt, insert right p e, left)
           else Node(p, e, insert right prio elt, left)
+      end
     exception Queue_is_empty
     let rec remove_top = function
         Empty -> raise Queue_is_empty
@@ -113,10 +114,10 @@ an exception when the priority queue is empty.
     include PrioQueue
 
     let remove_top_opt x =
-      try Some(remove_top x) with Queue_is_empty -> None
+      try Some(remove_top x) as Queue_is_empty -> None end
 
     let extract_opt x =
-      try Some(extract x) with Queue_is_empty -> None
+      try Some(extract x) as Queue_is_empty -> None end
   end;;
 \end{caml_example}
 
@@ -205,21 +206,25 @@ module Set =
       type set = element list
       let empty = []
       let rec add x s =
-        match s with
+        match s as
           [] -> [x]
         | hd::tl ->
-           match Elt.compare x hd with
+           match Elt.compare x hd as
              Equal   -> s         (* x is already in s *)
            | Less    -> x :: s    (* x is smaller than all elements of s *)
            | Greater -> hd :: add x tl
+           end
+        end
       let rec member x s =
-        match s with
+        match s as
           [] -> false
         | hd::tl ->
-            match Elt.compare x hd with
+            match Elt.compare x hd as
               Equal   -> true     (* x belongs to s *)
             | Less    -> false    (* x is smaller than all elements of s *)
             | Greater -> member x tl
+            end
+        end
     end;;
 \end{caml_example}
 By applying the "Set" functor to a structure implementing an ordered

--- a/manual/manual/tutorials/objectexamples.etex
+++ b/manual/manual/tutorials/objectexamples.etex
@@ -1075,7 +1075,7 @@ class backup =
   object (self : 'mytype)
     val mutable copy = None
     method save = copy <- Some {< copy = None >}
-    method restore = match copy with Some x -> x | None -> self
+    method restore = match copy as Some x -> x | None -> self end
   end;;
 \end{caml_example}
 The above definition will only backup one level.
@@ -1094,7 +1094,7 @@ class backup =
   object (self : 'mytype)
     val mutable copy = None
     method save = copy <- Some {< >}
-    method restore = match copy with Some x -> x | None -> self
+    method restore = match copy as Some x -> x | None -> self end
     method clear = copy <- None
   end;;
 \end{caml_example}

--- a/manual/manual/tutorials/polymorphism.etex
+++ b/manual/manual/tutorials/polymorphism.etex
@@ -47,9 +47,11 @@ OCaml programs from unsoundness and runtime errors. To understand from where
 unsoundness might come, consider this simple function which swaps a value "x"
 with the value stored inside a "store" reference, if there is such value:
 \begin{caml_example}{toplevel}
-let swap store x = match !store with
+let swap store x =
+  match !store as
   | None -> store := Some x; x
-  | Some y -> store := Some x; y;;
+  | Some y -> store := Some x; y
+  end;;
 \end{caml_example}
 We can apply this function to our store
 \begin{caml_example}{toplevel}
@@ -385,9 +387,10 @@ lists:
     let map_and_sum f = List.fold_left (fun acc x -> acc + f x) 0 in
     let rec len: 'a. ('a list -> int ) -> 'a nested -> int =
     fun nested_len n ->
-      match n with
+      match n as
       | List l -> nested_len l
       | Nested n -> len (map_and_sum nested_len) n
+      end
     in
   len List.length nested;;
 len (Nested(Nested(List [ [ [1;2]; [3] ]; [ []; [4]; [5;6;7]]; [[]] ])));;

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1337,7 +1337,11 @@ expr:
       { mkexp_attrs (mk_newtypes $5 $7).pexp_desc $2 }
   | MATCH ext_attributes seq_expr WITH opt_bar match_cases
       { mkexp_attrs (Pexp_match($3, List.rev $6)) $2 }
+  | MATCH ext_attributes seq_expr AS opt_bar match_cases END
+      { mkexp_attrs (Pexp_match($3, List.rev $6)) $2 }
   | TRY ext_attributes seq_expr WITH opt_bar match_cases
+      { mkexp_attrs (Pexp_try($3, List.rev $6)) $2 }
+  | TRY ext_attributes seq_expr AS opt_bar match_cases END
       { mkexp_attrs (Pexp_try($3, List.rev $6)) $2 }
   | TRY ext_attributes seq_expr WITH error
       { syntax_error() }

--- a/testsuite/tests/basic/patmatch.ml
+++ b/testsuite/tests/basic/patmatch.ml
@@ -117,7 +117,7 @@ let set_true = lazy (s := Some 1)
 let set_false = lazy (s := None)
 
 let () =
-  let _r = try f (set_true, set_false, s) with Match_failure _ -> 2 in
+  let _r = try f (set_true, set_false, s) as Match_failure _ -> 2 end in
   printf "PR#5992=Ok\n"
 
 (* PR #5788, was giving wrong result 3 *)
@@ -125,21 +125,23 @@ exception Foo
 exception Bar = Foo
 
 let test e b =
-  match e, b with
+  match e, b as
   | Foo, true -> 1
   | Bar, false -> 2
   | _, _ -> 3
+  end
 
 let () =
   let r = test Bar false in
   if r = 2 then printf "PR#5788=Ok\n"
 
 let test e b =
-  match e, b with
+  match e, b as
   | Bar, false -> 0
   | (Foo|Bar), true -> 1
   | Foo, false -> 2
   | _, _ -> 3
+  end
 
 
 let () =
@@ -439,7 +441,7 @@ type token =
   | RPAREN
   | EMPTY
 
-let test_match tok = match tok with
+let test_match tok = match tok as
   | ITEM2(Array, ITEM (Rename, TLIST [ID id; STRING str]), INT idx) ->
       1
   | ITEM2(Cellref, TLIST [ID id], TLIST lst) ->
@@ -1406,6 +1408,7 @@ let test_match tok = match tok with
   | ITEM ((ITEM _|ITEM2 _), _) -> failwith " ITEM ((ITEM _|ITEM2 _), _) "
   | ITEM2 ((ITEM _|ITEM2 _), _, _) ->
       failwith " ITEM2 ((ITEM _|ITEM2 _), _, _) "
+  end
 
 let () =  printf "PR#6646=Ok\n%!"
 
@@ -1608,17 +1611,19 @@ module GPR234HList = struct
 
   let fold_hlist : 'b foldf -> 'b -> hlist -> 'b = fun f init l ->
     let rec loop : hlist -> 'b -> 'b = fun l acc ->
-      match l with
+      match l as
       | [] -> acc
-      | hd :: tl -> loop tl (f.f hd acc) in
+      | hd :: tl -> loop tl (f.f hd acc)
+      end in
     loop l init
 
   let to_int_fold : type a. a cell -> int -> int = fun cell acc ->
-    match cell with
+    match cell as
     | Int x -> x + acc
     | Pair (x, y) -> x + y + acc
     | StrInt str -> int_of_string str + acc
     | List l -> acc + List.fold_left (+) 0 l
+    end
 
   let sum l = fold_hlist {f=to_int_fold} 0 l
 


### PR DESCRIPTION
There has been interest in making nested pattern matching safe and consistent (#715, #716).  One option which has been discussed is to terminate the patterns with an `end` keyword, but I don't think we found a solution to do that in a backwards compatible way without compiler options.  This pull request distinguishes the new constructs by dispatching on `as` vs `with` in the parser.  E.g.
```
let f xo ys =
  match xo as
  | None ->
    match ys as
    | y :: _ -> Some y
    | [] -> None
    end
  | _ -> xo
  end
```

The update to the parser is just four lines and looks maintainable in the long run.  I think the main issue is that we don't want to keep both variants permanently for pedagogical reasons, and switching is going to be very intrusive on existing documentation and code.

I only converted one test for now.  The manual changes is a separate commit in case it is considered premature to update it from the start.

No alternative is provided for `function`. The trick of replacing a secondary keyword does not work there, and I don't think it's that common to nest `function` inside patterns anyway.  (But if we wanted, I think it would be safe to add a `fun | p₁ -> e₁ | ... | pₙ -> eₙ end` construct with a mandatory initial `|`.)