### PR TITLE
Modifications to the native compilation of exception handlers

### DIFF
--- a/.depend
+++ b/.depend
@@ -725,38 +725,38 @@ asmcomp/afl_instrument.cmx : bytecomp/lambda.cmx typing/ident.cmx \
 asmcomp/afl_instrument.cmi : asmcomp/cmm.cmi
 asmcomp/arch.cmo : utils/config.cmi utils/clflags.cmi
 asmcomp/arch.cmx : utils/config.cmx utils/clflags.cmx
-asmcomp/asmgen.cmo : asmcomp/un_anf.cmi bytecomp/translmod.cmi \
-    middle_end/base_types/symbol.cmi asmcomp/split.cmi asmcomp/spill.cmi \
-    asmcomp/selection.cmi asmcomp/scheduling.cmi asmcomp/reload.cmi \
-    asmcomp/reg.cmi utils/profile.cmi asmcomp/proc.cmi asmcomp/printmach.cmi \
-    asmcomp/printlinear.cmi asmcomp/printcmm.cmi asmcomp/printclambda.cmi \
-    typing/primitive.cmi utils/misc.cmi asmcomp/mach.cmi parsing/location.cmi \
-    asmcomp/liveness.cmi asmcomp/linscan.cmi \
-    middle_end/base_types/linkage_name.cmi asmcomp/linearize.cmi \
-    bytecomp/lambda.cmi asmcomp/interval.cmi asmcomp/interf.cmi \
-    typing/ident.cmi asmcomp/flambda_to_clambda.cmi middle_end/flambda.cmi \
-    asmcomp/emitaux.cmi asmcomp/emit.cmi asmcomp/deadcode.cmi \
-    utils/config.cmi asmcomp/compilenv.cmi asmcomp/comballoc.cmi \
-    asmcomp/coloring.cmi asmcomp/cmmgen.cmi asmcomp/cmm.cmi \
-    asmcomp/closure.cmi utils/clflags.cmi asmcomp/clambda.cmi asmcomp/CSE.cmo \
-    asmcomp/build_export_info.cmi asmcomp/debug/available_regs.cmi \
-    asmcomp/asmgen.cmi
-asmcomp/asmgen.cmx : asmcomp/un_anf.cmx bytecomp/translmod.cmx \
-    middle_end/base_types/symbol.cmx asmcomp/split.cmx asmcomp/spill.cmx \
-    asmcomp/selection.cmx asmcomp/scheduling.cmx asmcomp/reload.cmx \
-    asmcomp/reg.cmx utils/profile.cmx asmcomp/proc.cmx asmcomp/printmach.cmx \
-    asmcomp/printlinear.cmx asmcomp/printcmm.cmx asmcomp/printclambda.cmx \
-    typing/primitive.cmx utils/misc.cmx asmcomp/mach.cmx parsing/location.cmx \
-    asmcomp/liveness.cmx asmcomp/linscan.cmx \
-    middle_end/base_types/linkage_name.cmx asmcomp/linearize.cmx \
-    bytecomp/lambda.cmx asmcomp/interval.cmx asmcomp/interf.cmx \
-    typing/ident.cmx asmcomp/flambda_to_clambda.cmx middle_end/flambda.cmx \
-    asmcomp/emitaux.cmx asmcomp/emit.cmx asmcomp/deadcode.cmx \
-    utils/config.cmx asmcomp/compilenv.cmx asmcomp/comballoc.cmx \
-    asmcomp/coloring.cmx asmcomp/cmmgen.cmx asmcomp/cmm.cmx \
-    asmcomp/closure.cmx utils/clflags.cmx asmcomp/clambda.cmx asmcomp/CSE.cmx \
-    asmcomp/build_export_info.cmx asmcomp/debug/available_regs.cmx \
-    asmcomp/asmgen.cmi
+asmcomp/asmgen.cmo : asmcomp/un_anf.cmi asmcomp/trap_analysis.cmi \
+    bytecomp/translmod.cmi middle_end/base_types/symbol.cmi asmcomp/split.cmi \
+    asmcomp/spill.cmi asmcomp/selection.cmi asmcomp/scheduling.cmi \
+    asmcomp/reload.cmi asmcomp/reg.cmi utils/profile.cmi asmcomp/proc.cmi \
+    asmcomp/printmach.cmi asmcomp/printlinear.cmi asmcomp/printcmm.cmi \
+    asmcomp/printclambda.cmi typing/primitive.cmi utils/misc.cmi \
+    asmcomp/mach.cmi parsing/location.cmi asmcomp/liveness.cmi \
+    asmcomp/linscan.cmi middle_end/base_types/linkage_name.cmi \
+    asmcomp/linearize.cmi asmcomp/linear_invariants.cmi bytecomp/lambda.cmi \
+    asmcomp/interval.cmi asmcomp/interf.cmi typing/ident.cmi \
+    asmcomp/flambda_to_clambda.cmi middle_end/flambda.cmi asmcomp/emitaux.cmi \
+    asmcomp/emit.cmi asmcomp/deadcode.cmi utils/config.cmi \
+    asmcomp/compilenv.cmi asmcomp/comballoc.cmi asmcomp/coloring.cmi \
+    asmcomp/cmmgen.cmi asmcomp/cmm.cmi asmcomp/closure.cmi utils/clflags.cmi \
+    asmcomp/clambda.cmi asmcomp/CSE.cmo asmcomp/build_export_info.cmi \
+    asmcomp/debug/available_regs.cmi asmcomp/asmgen.cmi
+asmcomp/asmgen.cmx : asmcomp/un_anf.cmx asmcomp/trap_analysis.cmx \
+    bytecomp/translmod.cmx middle_end/base_types/symbol.cmx asmcomp/split.cmx \
+    asmcomp/spill.cmx asmcomp/selection.cmx asmcomp/scheduling.cmx \
+    asmcomp/reload.cmx asmcomp/reg.cmx utils/profile.cmx asmcomp/proc.cmx \
+    asmcomp/printmach.cmx asmcomp/printlinear.cmx asmcomp/printcmm.cmx \
+    asmcomp/printclambda.cmx typing/primitive.cmx utils/misc.cmx \
+    asmcomp/mach.cmx parsing/location.cmx asmcomp/liveness.cmx \
+    asmcomp/linscan.cmx middle_end/base_types/linkage_name.cmx \
+    asmcomp/linearize.cmx asmcomp/linear_invariants.cmx bytecomp/lambda.cmx \
+    asmcomp/interval.cmx asmcomp/interf.cmx typing/ident.cmx \
+    asmcomp/flambda_to_clambda.cmx middle_end/flambda.cmx asmcomp/emitaux.cmx \
+    asmcomp/emit.cmx asmcomp/deadcode.cmx utils/config.cmx \
+    asmcomp/compilenv.cmx asmcomp/comballoc.cmx asmcomp/coloring.cmx \
+    asmcomp/cmmgen.cmx asmcomp/cmm.cmx asmcomp/closure.cmx utils/clflags.cmx \
+    asmcomp/clambda.cmx asmcomp/CSE.cmx asmcomp/build_export_info.cmx \
+    asmcomp/debug/available_regs.cmx asmcomp/asmgen.cmi
 asmcomp/asmgen.cmi : bytecomp/lambda.cmi typing/ident.cmi \
     middle_end/flambda.cmi asmcomp/cmm.cmi middle_end/backend_intf.cmi
 asmcomp/asmlibrarian.cmo : utils/misc.cmi parsing/location.cmi \
@@ -864,13 +864,13 @@ asmcomp/closure_offsets.cmx : middle_end/base_types/variable.cmx \
 asmcomp/closure_offsets.cmi : middle_end/base_types/var_within_closure.cmi \
     middle_end/flambda.cmi middle_end/base_types/closure_id.cmi
 asmcomp/cmm.cmo : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/debuginfo.cmi parsing/asttypes.cmi asmcomp/arch.cmo \
-    asmcomp/cmm.cmi
+    middle_end/debuginfo.cmi asmcomp/clambda.cmi parsing/asttypes.cmi \
+    asmcomp/arch.cmo asmcomp/cmm.cmi
 asmcomp/cmm.cmx : bytecomp/lambda.cmx typing/ident.cmx \
-    middle_end/debuginfo.cmx parsing/asttypes.cmi asmcomp/arch.cmx \
-    asmcomp/cmm.cmi
+    middle_end/debuginfo.cmx asmcomp/clambda.cmx parsing/asttypes.cmi \
+    asmcomp/arch.cmx asmcomp/cmm.cmi
 asmcomp/cmm.cmi : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/debuginfo.cmi parsing/asttypes.cmi
+    middle_end/debuginfo.cmi asmcomp/clambda.cmi parsing/asttypes.cmi
 asmcomp/cmmgen.cmo : asmcomp/un_anf.cmi typing/types.cmi bytecomp/switch.cmi \
     asmcomp/strmatch.cmi asmcomp/proc.cmi bytecomp/printlambda.cmi \
     typing/primitive.cmi utils/misc.cmi bytecomp/lambda.cmi typing/ident.cmi \
@@ -994,12 +994,12 @@ asmcomp/flambda_to_clambda.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/set_of_closures_id.cmi typing/primitive.cmi \
     middle_end/parameter.cmi utils/numbers.cmi \
     middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    middle_end/base_types/linkage_name.cmi typing/ident.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda.cmi \
+    middle_end/base_types/linkage_name.cmi bytecomp/lambda.cmi \
+    typing/ident.cmi middle_end/flambda_utils.cmi middle_end/flambda.cmi \
     asmcomp/export_info.cmi middle_end/debuginfo.cmi asmcomp/compilenv.cmi \
     asmcomp/closure_offsets.cmi middle_end/base_types/closure_id.cmi \
-    utils/clflags.cmi asmcomp/clambda.cmi middle_end/allocated_const.cmi \
-    asmcomp/flambda_to_clambda.cmi
+    utils/clflags.cmi asmcomp/clambda.cmi parsing/asttypes.cmi \
+    middle_end/allocated_const.cmi asmcomp/flambda_to_clambda.cmi
 asmcomp/flambda_to_clambda.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/var_within_closure.cmx \
     middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
@@ -1007,12 +1007,12 @@ asmcomp/flambda_to_clambda.cmx : middle_end/base_types/variable.cmx \
     middle_end/base_types/set_of_closures_id.cmx typing/primitive.cmx \
     middle_end/parameter.cmx utils/numbers.cmx \
     middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    middle_end/base_types/linkage_name.cmx typing/ident.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda.cmx \
+    middle_end/base_types/linkage_name.cmx bytecomp/lambda.cmx \
+    typing/ident.cmx middle_end/flambda_utils.cmx middle_end/flambda.cmx \
     asmcomp/export_info.cmx middle_end/debuginfo.cmx asmcomp/compilenv.cmx \
     asmcomp/closure_offsets.cmx middle_end/base_types/closure_id.cmx \
-    utils/clflags.cmx asmcomp/clambda.cmx middle_end/allocated_const.cmx \
-    asmcomp/flambda_to_clambda.cmi
+    utils/clflags.cmx asmcomp/clambda.cmx parsing/asttypes.cmi \
+    middle_end/allocated_const.cmx asmcomp/flambda_to_clambda.cmi
 asmcomp/flambda_to_clambda.cmi : middle_end/base_types/symbol.cmi \
     middle_end/flambda.cmi asmcomp/export_info.cmi asmcomp/clambda.cmi
 asmcomp/import_approx.cmo : middle_end/base_types/variable.cmi \
@@ -1043,6 +1043,11 @@ asmcomp/interval.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/mach.cmi \
 asmcomp/interval.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/mach.cmx \
     asmcomp/interval.cmi
 asmcomp/interval.cmi : asmcomp/reg.cmi asmcomp/mach.cmi
+asmcomp/linear_invariants.cmo : asmcomp/printlinear.cmi utils/numbers.cmi \
+    utils/misc.cmi asmcomp/linearize.cmi asmcomp/linear_invariants.cmi
+asmcomp/linear_invariants.cmx : asmcomp/printlinear.cmx utils/numbers.cmx \
+    utils/misc.cmx asmcomp/linearize.cmx asmcomp/linear_invariants.cmi
+asmcomp/linear_invariants.cmi : asmcomp/linearize.cmi
 asmcomp/linearize.cmo : asmcomp/reg.cmi asmcomp/proc.cmi utils/misc.cmi \
     asmcomp/mach.cmi middle_end/debuginfo.cmi utils/config.cmi \
     asmcomp/cmm.cmi asmcomp/linearize.cmi
@@ -1082,11 +1087,11 @@ asmcomp/printclambda.cmx : bytecomp/printlambda.cmx bytecomp/lambda.cmx \
     asmcomp/printclambda.cmi
 asmcomp/printclambda.cmi : asmcomp/clambda.cmi
 asmcomp/printcmm.cmo : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/debuginfo.cmi asmcomp/cmm.cmi parsing/asttypes.cmi \
-    asmcomp/printcmm.cmi
+    middle_end/debuginfo.cmi asmcomp/cmm.cmi asmcomp/clambda.cmi \
+    parsing/asttypes.cmi asmcomp/printcmm.cmi
 asmcomp/printcmm.cmx : bytecomp/lambda.cmx typing/ident.cmx \
-    middle_end/debuginfo.cmx asmcomp/cmm.cmx parsing/asttypes.cmi \
-    asmcomp/printcmm.cmi
+    middle_end/debuginfo.cmx asmcomp/cmm.cmx asmcomp/clambda.cmx \
+    parsing/asttypes.cmi asmcomp/printcmm.cmi
 asmcomp/printcmm.cmi : middle_end/debuginfo.cmi asmcomp/cmm.cmi
 asmcomp/printlinear.cmo : asmcomp/printmach.cmi asmcomp/printcmm.cmi \
     asmcomp/mach.cmi asmcomp/linearize.cmi middle_end/debuginfo.cmi \
@@ -1139,12 +1144,12 @@ asmcomp/scheduling.cmi : asmcomp/linearize.cmi
 asmcomp/selectgen.cmo : utils/tbl.cmi bytecomp/simplif.cmi asmcomp/reg.cmi \
     asmcomp/proc.cmi utils/misc.cmi asmcomp/mach.cmi bytecomp/lambda.cmi \
     typing/ident.cmi middle_end/debuginfo.cmi utils/config.cmi \
-    asmcomp/cmm.cmi parsing/asttypes.cmi asmcomp/arch.cmo \
+    asmcomp/cmm.cmi asmcomp/clambda.cmi parsing/asttypes.cmi asmcomp/arch.cmo \
     asmcomp/selectgen.cmi
 asmcomp/selectgen.cmx : utils/tbl.cmx bytecomp/simplif.cmx asmcomp/reg.cmx \
     asmcomp/proc.cmx utils/misc.cmx asmcomp/mach.cmx bytecomp/lambda.cmx \
     typing/ident.cmx middle_end/debuginfo.cmx utils/config.cmx \
-    asmcomp/cmm.cmx parsing/asttypes.cmi asmcomp/arch.cmx \
+    asmcomp/cmm.cmx asmcomp/clambda.cmx parsing/asttypes.cmi asmcomp/arch.cmx \
     asmcomp/selectgen.cmi
 asmcomp/selectgen.cmi : asmcomp/reg.cmi asmcomp/mach.cmi typing/ident.cmi \
     middle_end/debuginfo.cmi asmcomp/cmm.cmi asmcomp/arch.cmo
@@ -1176,12 +1181,19 @@ asmcomp/split.cmx : asmcomp/reg.cmx utils/misc.cmx asmcomp/mach.cmx \
 asmcomp/split.cmi : asmcomp/mach.cmi
 asmcomp/strmatch.cmo : parsing/location.cmi bytecomp/lambda.cmi \
     typing/ident.cmi middle_end/debuginfo.cmi asmcomp/cmm.cmi \
-    parsing/asttypes.cmi asmcomp/arch.cmo asmcomp/strmatch.cmi
+    asmcomp/clambda.cmi parsing/asttypes.cmi asmcomp/arch.cmo \
+    asmcomp/strmatch.cmi
 asmcomp/strmatch.cmx : parsing/location.cmx bytecomp/lambda.cmx \
     typing/ident.cmx middle_end/debuginfo.cmx asmcomp/cmm.cmx \
-    parsing/asttypes.cmi asmcomp/arch.cmx asmcomp/strmatch.cmi
+    asmcomp/clambda.cmx parsing/asttypes.cmi asmcomp/arch.cmx \
+    asmcomp/strmatch.cmi
 asmcomp/strmatch.cmi : parsing/location.cmi middle_end/debuginfo.cmi \
     asmcomp/cmm.cmi
+asmcomp/trap_analysis.cmo : utils/numbers.cmi utils/misc.cmi \
+    asmcomp/mach.cmi bytecomp/lambda.cmi asmcomp/trap_analysis.cmi
+asmcomp/trap_analysis.cmx : utils/numbers.cmx utils/misc.cmx \
+    asmcomp/mach.cmx bytecomp/lambda.cmx asmcomp/trap_analysis.cmi
+asmcomp/trap_analysis.cmi : asmcomp/mach.cmi
 asmcomp/un_anf.cmo : bytecomp/semantics_of_primitives.cmi \
     asmcomp/printclambda.cmi utils/misc.cmi bytecomp/lambda.cmi \
     typing/ident.cmi middle_end/debuginfo.cmi utils/clflags.cmi \

--- a/.depend
+++ b/.depend
@@ -738,9 +738,10 @@ asmcomp/asmgen.cmo : asmcomp/un_anf.cmi asmcomp/trap_analysis.cmi \
     asmcomp/flambda_to_clambda.cmi middle_end/flambda.cmi asmcomp/emitaux.cmi \
     asmcomp/emit.cmi asmcomp/deadcode.cmi utils/config.cmi \
     asmcomp/compilenv.cmi asmcomp/comballoc.cmi asmcomp/coloring.cmi \
-    asmcomp/cmmgen.cmi asmcomp/cmm.cmi asmcomp/closure.cmi utils/clflags.cmi \
-    asmcomp/clambda.cmi asmcomp/CSE.cmo asmcomp/build_export_info.cmi \
-    asmcomp/debug/available_regs.cmi asmcomp/asmgen.cmi
+    asmcomp/cmmgen.cmi asmcomp/cmm_invariants.cmi asmcomp/cmm.cmi \
+    asmcomp/closure.cmi utils/clflags.cmi asmcomp/clambda.cmi asmcomp/CSE.cmo \
+    asmcomp/build_export_info.cmi asmcomp/debug/available_regs.cmi \
+    asmcomp/asmgen.cmi
 asmcomp/asmgen.cmx : asmcomp/un_anf.cmx asmcomp/trap_analysis.cmx \
     bytecomp/translmod.cmx middle_end/base_types/symbol.cmx asmcomp/split.cmx \
     asmcomp/spill.cmx asmcomp/selection.cmx asmcomp/scheduling.cmx \
@@ -754,9 +755,10 @@ asmcomp/asmgen.cmx : asmcomp/un_anf.cmx asmcomp/trap_analysis.cmx \
     asmcomp/flambda_to_clambda.cmx middle_end/flambda.cmx asmcomp/emitaux.cmx \
     asmcomp/emit.cmx asmcomp/deadcode.cmx utils/config.cmx \
     asmcomp/compilenv.cmx asmcomp/comballoc.cmx asmcomp/coloring.cmx \
-    asmcomp/cmmgen.cmx asmcomp/cmm.cmx asmcomp/closure.cmx utils/clflags.cmx \
-    asmcomp/clambda.cmx asmcomp/CSE.cmx asmcomp/build_export_info.cmx \
-    asmcomp/debug/available_regs.cmx asmcomp/asmgen.cmi
+    asmcomp/cmmgen.cmx asmcomp/cmm_invariants.cmx asmcomp/cmm.cmx \
+    asmcomp/closure.cmx utils/clflags.cmx asmcomp/clambda.cmx asmcomp/CSE.cmx \
+    asmcomp/build_export_info.cmx asmcomp/debug/available_regs.cmx \
+    asmcomp/asmgen.cmi
 asmcomp/asmgen.cmi : bytecomp/lambda.cmi typing/ident.cmi \
     middle_end/flambda.cmi asmcomp/cmm.cmi middle_end/backend_intf.cmi
 asmcomp/asmlibrarian.cmo : utils/misc.cmi parsing/location.cmi \
@@ -871,6 +873,11 @@ asmcomp/cmm.cmx : bytecomp/lambda.cmx typing/ident.cmx \
     asmcomp/arch.cmx asmcomp/cmm.cmi
 asmcomp/cmm.cmi : bytecomp/lambda.cmi typing/ident.cmi \
     middle_end/debuginfo.cmi asmcomp/clambda.cmi parsing/asttypes.cmi
+asmcomp/cmm_invariants.cmo : utils/numbers.cmi asmcomp/cmm.cmi \
+    asmcomp/clambda.cmi asmcomp/cmm_invariants.cmi
+asmcomp/cmm_invariants.cmx : utils/numbers.cmx asmcomp/cmm.cmx \
+    asmcomp/clambda.cmx asmcomp/cmm_invariants.cmi
+asmcomp/cmm_invariants.cmi : asmcomp/cmm.cmi
 asmcomp/cmmgen.cmo : asmcomp/un_anf.cmi typing/types.cmi bytecomp/switch.cmi \
     asmcomp/strmatch.cmi asmcomp/proc.cmi bytecomp/printlambda.cmi \
     typing/primitive.cmi utils/misc.cmi bytecomp/lambda.cmi typing/ident.cmi \

--- a/.merlin
+++ b/.merlin
@@ -1,6 +1,9 @@
 S ./asmcomp
 B ./asmcomp
 
+S ./asmcomp/debug
+B ./asmcomp/debug
+
 S ./middle_end
 B ./middle_end
 

--- a/Changes
+++ b/Changes
@@ -12,10 +12,6 @@ Working version
 
 ### Type system:
 
-- GPR#1370: Fix code duplication in Cmmgen
-  (Vincent Laviron, with help from Pierre Chambart,
-   reviews by Gabriel Scherer and Luc Maranget)
-
 ### Standard library:
 
 ### Other libraries:
@@ -48,6 +44,13 @@ Working version
   Florian Angeletti and Gabriel Radanne)
 
 ### Code generation and optimizations:
+
+- GPR#1370: Fix code duplication in Cmmgen
+  (Vincent Laviron, with help from Pierre Chambart,
+   reviews by Gabriel Scherer and Luc Maranget)
+
+- GPR#1482: Adapt and optimize the code generation for try-with blocks
+  (Vincent Laviron, Mark Shinwell and Pierre Chambart)
 
 ### Runtime system:
 

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ ASMCOMP=\
   asmcomp/spacetime_profiling.cmo asmcomp/selection.cmo \
   asmcomp/comballoc.cmo \
   asmcomp/CSEgen.cmo asmcomp/CSE.cmo \
-  asmcomp/trap_analysis.cmo \
+  asmcomp/cmm_invariants.cmo asmcomp/trap_analysis.cmo \
   asmcomp/liveness.cmo \
   asmcomp/spill.cmo asmcomp/split.cmo \
   asmcomp/interf.cmo asmcomp/coloring.cmo \

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,7 @@ ASMCOMP=\
   asmcomp/spacetime_profiling.cmo asmcomp/selection.cmo \
   asmcomp/comballoc.cmo \
   asmcomp/CSEgen.cmo asmcomp/CSE.cmo \
+  asmcomp/trap_analysis.cmo \
   asmcomp/liveness.cmo \
   asmcomp/spill.cmo asmcomp/split.cmo \
   asmcomp/interf.cmo asmcomp/coloring.cmo \
@@ -180,6 +181,7 @@ ASMCOMP=\
   asmcomp/deadcode.cmo \
   asmcomp/printlinear.cmo asmcomp/linearize.cmo \
   asmcomp/debug/available_regs.cmo \
+  asmcomp/linear_invariants.cmo \
   asmcomp/schedgen.cmo asmcomp/scheduling.cmo \
   asmcomp/branch_relaxation_intf.cmo \
   asmcomp/branch_relaxation.cmo \

--- a/asmcomp/CSEgen.ml
+++ b/asmcomp/CSEgen.ml
@@ -350,15 +350,12 @@ method private cse n i =
   | Iloop(body) ->
       {i with desc = Iloop(self#cse empty_numbering body);
               next = self#cse empty_numbering i.next}
-  | Icatch(rec_flag, handlers, body) ->
-      let aux (nfail, handler) =
-        nfail, self#cse empty_numbering handler
+  | Icatch(rec_flag, is_exn_handler, handlers, body) ->
+      let aux (nfail, trap_stack, handler) =
+        nfail, trap_stack, self#cse empty_numbering handler
       in
-      {i with desc = Icatch(rec_flag, List.map aux handlers, self#cse n body);
-              next = self#cse empty_numbering i.next}
-  | Itrywith(body, handler) ->
-      {i with desc = Itrywith(self#cse n body,
-                              self#cse empty_numbering handler);
+      {i with desc = Icatch(rec_flag, is_exn_handler, List.map aux handlers,
+                self#cse n body);
               next = self#cse empty_numbering i.next}
 
 method fundecl f =

--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -57,8 +57,6 @@ and instrument = function
      Cifthenelse (instrument cond, with_afl_logging t, with_afl_logging f)
   | Cloop e ->
      Cloop (with_afl_logging e)
-  | Ctrywith (e, ex, handler) ->
-     Ctrywith (instrument e, ex, with_afl_logging handler)
   | Cswitch (e, cases, handlers, dbg) ->
      Cswitch (instrument e, cases, Array.map with_afl_logging handlers, dbg)
 
@@ -72,7 +70,7 @@ and instrument = function
      Ccatch (isrec,
              List.map (fun (nfail, ids, e) -> nfail, ids, instrument e) cases,
              instrument body)
-  | Cexit (ex, args) -> Cexit (ex, List.map instrument args)
+  | Cexit (ex, args, conts) -> Cexit (ex, List.map instrument args, conts)
 
   (* these are base cases and have no logging *)
   | Cconst_int _ | Cconst_natint _ | Cconst_float _

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -171,6 +171,13 @@ let emit_Llabel fallthrough lbl =
   if not fallthrough && !fastcode_flag then D.align 4;
   def_label lbl
 
+let load_label_addr s arg =
+  (* CR mshinwell: this needs more testing *)
+  if !Clflags.pic_code then
+    I.lea (mem64_rip NONE (emit_label s)) arg
+  else
+    I.mov (sym (emit_label s)) arg
+
 (* Output a pseudo-register *)
 
 let reg = function
@@ -823,14 +830,20 @@ let emit_instr fallthrough i =
                          ConstLabel lbl))
       done;
       D.text ()
-  | Lsetuptrap lbl ->
-      I.call (label lbl)
-  | Lpushtrap ->
-      cfi_adjust_cfa_offset 8;
-      I.push r14;
-      cfi_adjust_cfa_offset 8;
-      I.mov rsp r14;
-      stack_offset := !stack_offset + 16
+  | Lentertrap ->
+      ()
+  | Ladjust_trap_depth delta ->
+      let delta = 16 * delta in
+      cfi_adjust_cfa_offset delta;
+      stack_offset := !stack_offset + delta
+  | Lpushtrap { handler; } ->
+      cfi_adjust_cfa_offset 16;
+      I.sub (int 16) rsp;
+      stack_offset := !stack_offset + 16;
+      I.mov r14 (mem64 QWORD 0 RSP);
+      load_label_addr handler r14;
+      I.mov r14 (mem64 QWORD 8 RSP);
+      I.mov rsp r14
   | Lpoptrap ->
       I.pop r14;
       cfi_adjust_cfa_offset (-8);
@@ -848,7 +861,8 @@ let emit_instr fallthrough i =
       | Cmm.Raise_notrace ->
           I.mov r14 rsp;
           I.pop r14;
-          I.ret ()
+          I.pop r11;
+          I.jmp r11
       end
 
 let rec emit_all fallthrough i =

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -282,6 +282,8 @@ let float_literals = ref ([] : (int64 * label) list)
 let gotrel_literals = ref ([] : (label * label) list)
 (* Pending symbol literals *)
 let symbol_literals = ref ([] : (string * label) list)
+(* Pending offset computations : (lbl, dst, src) --> lbl: .word dst-(src+N) *)
+let offset_literals = ref ([] : (label * label * label) list)
 (* Total space (in words) occupied by pending literals *)
 let size_literals = ref 0
 
@@ -312,6 +314,13 @@ let symbol_literal s =
     symbol_literals := (s, lbl) :: !symbol_literals;
     lbl
 
+(* Add an offset computation *)
+let offset_literal dst src =
+  let lbl = new_label() in
+  size_literals := !size_literals + 1;
+  offset_literals := (lbl, dst, src) :: !offset_literals;
+  lbl
+
 (* Emit all pending literals *)
 let emit_literals() =
   if !float_literals <> [] then begin
@@ -336,6 +345,17 @@ let emit_literals() =
       !symbol_literals;
     gotrel_literals := [];
     symbol_literals := []
+  end;
+  if !offset_literals <> [] then begin
+    (* Additions using the pc register read a value 4 or 8 bytes greater than
+       the instruction's address, depending on the thumb setting *)
+    let offset = if !thumb then 4 else 8 in
+    `	.align	2\n`;
+    List.iter
+      (fun (lbl, dst, src) ->
+         `{emit_label lbl}:	.word	{emit_label dst}-({emit_label src}+{emit_int offset})\n`)
+      !offset_literals;
+    offset_literals := []
   end;
   size_literals := 0
 
@@ -366,6 +386,16 @@ let emit_load_symbol_addr dst s =
     `	ldr	{emit_reg dst}, {emit_label lbl} @ {emit_symbol s}\n`;
     1
   end
+
+(* Emit code to load the address of a label in the lr register *)
+let emit_load_handler_address handler =
+  (* PIC code *)
+  let lbl_src = new_label() in
+  let lbl_offset = offset_literal handler lbl_src in
+  `	ldr	lr, {emit_label lbl_offset}\n`;
+  `{emit_label lbl_src}:\n`;
+  `	add	lr, pc, lr\n`;
+  2
 
 (* Output the assembly code for an instruction *)
 
@@ -790,15 +820,11 @@ let emit_instr i =
         cfi_adjust_cfa_offset delta;
         stack_offset := !stack_offset + delta; 0
     | Lpushtrap { handler; } ->
-        (* Using lr since :
-           - it was used by the previous version (because of a bl jump)
-           - its position relative to trap_ptr is the same as pc,
-             so the pop instruction in Lraise is correct *)
-        `	ldr	lr, {emit_label handler}\n`;
+        let s = emit_load_handler_address handler in
         stack_offset := !stack_offset + 8;
         `	push	\{trap_ptr, lr}\n`;
         cfi_adjust_cfa_offset 8;
-        `	mov	trap_ptr, sp\n`; 3
+        `	mov	trap_ptr, sp\n`; s + 2
     | Lpoptrap ->
         `	pop	\{trap_ptr, lr}\n`;
         cfi_adjust_cfa_offset (-8);

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -783,13 +783,22 @@ let emit_instr i =
           done;
           2 + Array.length jumptbl
         end
-    | Lsetuptrap lbl ->
-        `	bl	{emit_label lbl}\n`; 1
-    | Lpushtrap ->
+    | Lentertrap ->
+        0
+    | Ladjust_trap_depth delta ->
+        let delta = 8 * delta in
+        cfi_adjust_cfa_offset delta;
+        stack_offset := !stack_offset + delta; 0
+    | Lpushtrap { handler; } ->
+        (* Using lr since :
+           - it was used by the previous version (because of a bl jump)
+           - its position relative to trap_ptr is the same as pc,
+             so the pop instruction in Lraise is correct *)
+        `	ldr	lr, {emit_label handler}\n`;
         stack_offset := !stack_offset + 8;
         `	push	\{trap_ptr, lr}\n`;
         cfi_adjust_cfa_offset 8;
-        `	mov	trap_ptr, sp\n`; 2
+        `	mov	trap_ptr, sp\n`; 3
     | Lpoptrap ->
         `	pop	\{trap_ptr, lr}\n`;
         cfi_adjust_cfa_offset (-8);

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -295,7 +295,7 @@ let max_register_pressure = function
 let op_is_pure = function
   | Icall_ind _ | Icall_imm _ | Itailcall_ind _ | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _)
+  | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _) -> false
   | Ispecific(Ishiftcheckbound _) -> false
   | _ -> true
 

--- a/asmcomp/arm/selection.ml
+++ b/asmcomp/arm/selection.ml
@@ -179,7 +179,7 @@ method select_shift_arith op dbg arithop arithrevop args =
       end
 
 method private iextcall (func, alloc) =
-  Iextcall { func; alloc; label_after = Cmm.new_label (); }
+  Iextcall { func; alloc; label_after = Cmm.new_label (); trap_stack = []; }
 
 method! select_operation op args dbg =
   match (op, args) with

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -489,8 +489,9 @@ module BR = Branch_relaxation.Make (struct
         + begin match lbl1 with None -> 0 | Some _ -> 1 end
         + begin match lbl2 with None -> 0 | Some _ -> 1 end
     | Lswitch jumptbl -> 3 + Array.length jumptbl
-    | Lsetuptrap _ -> 2
-    | Lpushtrap -> 3
+    | Lentertrap -> 0
+    | Ladjust_trap_depth _ -> 0
+    | Lpushtrap _ -> 4
     | Lpoptrap -> 1
     | Lraise k ->
       begin match k with
@@ -845,12 +846,14 @@ let emit_instr i =
             `	.word	{emit_label jumptbl.(j)} - {emit_label lbltbl}\n`
         done
 *)
-    | Lsetuptrap lbl ->
-        let lblnext = new_label() in
-        `	adr	{emit_reg reg_tmp1}, {emit_label lblnext}\n`;
-        `	b	{emit_label lbl}\n`;
-        `{emit_label lblnext}:\n`
-    | Lpushtrap ->
+    | Lentertrap ->
+        ()
+    | Ladjust_trap_depth delta ->
+        let delta = 16 * delta in
+        cfi_adjust_cfa_offset delta;
+        stack_offset := !stack_offset + delta
+    | Lpushtrap { handler; } ->
+        `	adr	{emit_reg reg_tmp1}, {emit_label handler}\n`;
         stack_offset := !stack_offset + 16;
         `	str	{emit_reg reg_trap_ptr}, [sp, -16]!\n`;
         `	str	{emit_reg reg_tmp1}, [sp, #8]\n`;

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -218,7 +218,7 @@ let max_register_pressure = function
 let op_is_pure = function
   | Icall_ind _ | Icall_imm _ | Itailcall_ind _ | Itailcall_imm _
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
-  | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _)
+  | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _) -> false
   | Ispecific(Ishiftcheckbound _) -> false
   | _ -> true
 

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -111,6 +111,7 @@ let compile_fundecl (ppf : formatter) fd_cmm =
   ++ pass_dump_if ppf dump_combine "After allocation combining"
   ++ Profile.record ~accumulate:true "cse" CSE.fundecl
   ++ pass_dump_if ppf dump_cse "After CSE"
+  ++ Profile.record ~accumulate:true "trap_analysis" Trap_analysis.run
   ++ Profile.record ~accumulate:true "liveness" (liveness ppf)
   ++ Profile.record ~accumulate:true "deadcode" Deadcode.fundecl
   ++ pass_dump_if ppf dump_live "Liveness analysis"
@@ -124,7 +125,9 @@ let compile_fundecl (ppf : formatter) fd_cmm =
   ++ Profile.record ~accumulate:true "available_regs" Available_regs.fundecl
   ++ Profile.record ~accumulate:true "linearize" Linearize.fundecl
   ++ pass_dump_linear_if ppf dump_linear "Linearized code"
+  ++ Linear_invariants.check
   ++ Profile.record ~accumulate:true "scheduling" Scheduling.fundecl
+  ++ Linear_invariants.check
   ++ pass_dump_linear_if ppf dump_scheduling "After instruction scheduling"
   ++ Profile.record ~accumulate:true "emit" Emit.fundecl
 

--- a/asmcomp/closure_offsets.ml
+++ b/asmcomp/closure_offsets.ml
@@ -13,7 +13,6 @@
 (*   special exception on linking described in the file LICENSE.          *)
 (*                                                                        *)
 (**************************************************************************)
-
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
 type result = {

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -169,9 +169,9 @@ type expression =
   | Cifthenelse of expression * expression * expression
   | Cswitch of expression * int array * expression array * Debuginfo.t
   | Cloop of expression
-  | Ccatch of rec_flag * (int * Ident.t list * expression) list * expression
-  | Cexit of int * expression list
-  | Ctrywith of expression * Ident.t * expression
+  | Ccatch of Clambda.catch_kind * (int * Ident.t list * expression) list
+      * expression
+  | Cexit of int * expression list * Clambda.trap_action
 
 type fundecl =
   { fun_name: string;
@@ -198,9 +198,6 @@ type data_item =
 type phrase =
     Cfunction of fundecl
   | Cdata of data_item list
-
-let ccatch (i, ids, e1, e2)=
-  Ccatch(Nonrecursive, [i, ids, e2], e1)
 
 let reset () =
   label_counter := 99

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -145,9 +145,9 @@ and expression =
   | Cifthenelse of expression * expression * expression
   | Cswitch of expression * int array * expression array * Debuginfo.t
   | Cloop of expression
-  | Ccatch of rec_flag * (int * Ident.t list * expression) list * expression
-  | Cexit of int * expression list
-  | Ctrywith of expression * Ident.t * expression
+  | Ccatch of Clambda.catch_kind * (int * Ident.t list * expression) list
+      * expression
+  | Cexit of int * expression list * Clambda.trap_action
 
 type fundecl =
   { fun_name: string;
@@ -174,7 +174,5 @@ type data_item =
 type phrase =
     Cfunction of fundecl
   | Cdata of data_item list
-
-val ccatch : int * Ident.t list * expression * expression -> expression
 
 val reset : unit -> unit

--- a/asmcomp/cmm_invariants.ml
+++ b/asmcomp/cmm_invariants.ml
@@ -1,0 +1,227 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Vincent Laviron, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2016 OCamlPro SAS                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "-40"]
+
+module Int = Numbers.Int
+
+(* Check a number of continuation-related invariants *)
+
+module Env : sig
+  type t
+
+  val init : unit -> t
+
+  val check_trap_action : t -> Clambda.trap_action -> unit
+
+  val handler : t -> kind:Clambda.catch_kind -> cont:int -> arg_num:int -> t
+
+  val jump : t -> cont:int -> arg_num:int -> unit
+
+  val report : Format.formatter -> bool
+end = struct
+  type handler_kind = Static | Exception
+
+  type t = {
+    bound_handlers : (handler_kind * int) Int.Map.t;
+  }
+
+  type error =
+    | Unbound_handler of { cont: int }
+    | Mismatching_kind of
+        { cont: int; handler_kind: handler_kind; kind: handler_kind; }
+    | Multiple_handlers of { cont: int; }
+    | Wrong_arguments_number of
+        { cont: int; handler_args: int; jump_args: int; }
+    | Bad_exception_handler of { cont: int; args: int; }
+
+  module Error = struct
+    type t = error
+
+    let compare x y =
+      match x, y with
+      | Mismatching_kind {cont=cont1;_}, Mismatching_kind {cont=cont2;_} ->
+          (* Only report mismatching kinds once per continuation *)
+          cont2 - cont1
+      | _, _ -> Pervasives.compare x y
+  end
+
+  module ErrorSet = Set.Make(Error)
+
+  type persistent_state = {
+    mutable all_handlers : Int.Set.t;
+    mutable errors : ErrorSet.t;
+  }
+
+  let state = {
+    all_handlers = Int.Set.empty;
+    errors = ErrorSet.empty;
+  }
+
+  let record_error error =
+    state.errors <- ErrorSet.add error state.errors
+
+  let unbound_handler cont =
+    record_error (Unbound_handler { cont; })
+
+  let mismatch cont handler_kind kind =
+    record_error (Mismatching_kind { cont; handler_kind; kind; })
+
+  let multiple_handler cont =
+    record_error (Multiple_handlers { cont; })
+
+  let wrong_arguments cont handler_args jump_args =
+    record_error (Wrong_arguments_number { cont; handler_args; jump_args; })
+
+  let bad_exception_handler cont args =
+    record_error (Bad_exception_handler { cont; args; })
+
+  let check_trap_action t (ta: Clambda.trap_action) =
+    let check_trap cont =
+      match Int.Map.find cont t.bound_handlers with
+      | Exception, _ -> ()
+      | Static, _ -> mismatch cont Static Exception
+      | exception Not_found -> unbound_handler cont
+    in
+    match ta with
+    | No_action -> ()
+    | Pop cl | Push cl -> List.iter check_trap cl
+
+  let init () =
+    state.all_handlers <- Int.Set.empty;
+    state.errors <- ErrorSet.empty;
+    {
+      bound_handlers = Int.Map.empty;
+    }
+
+  let handler t ~kind ~cont ~arg_num =
+    if Int.Set.mem cont state.all_handlers then multiple_handler cont;
+    state.all_handlers <- Int.Set.add cont state.all_handlers;
+    let kind = match (kind : Clambda.catch_kind) with
+      | Normal _ -> Static
+      | Exn_handler ->
+        if arg_num <> 1 then bad_exception_handler cont arg_num;
+        Exception
+    in
+    let bound_handlers = Int.Map.add cont (kind, arg_num) t.bound_handlers in
+    { bound_handlers; }
+
+  let jump t ~cont ~arg_num =
+    match Int.Map.find cont t.bound_handlers with
+    | Static, handler_args ->
+      if arg_num <> handler_args then
+        wrong_arguments cont handler_args arg_num
+    | Exception, _ -> mismatch cont Exception Static
+    | exception Not_found -> unbound_handler cont
+
+  let print_handler_kind ppf kind =
+    let str = match kind with
+      | Static -> "static"
+      | Exception -> "exception"
+    in
+    Format.fprintf ppf "%s" str
+
+  let print_error ppf error =
+    match error with
+    | Unbound_handler { cont } ->
+      if Int.Set.mem cont state.all_handlers then
+        Format.fprintf ppf
+          "Continuation %d was used outside the scope of its handler"
+          cont
+      else
+        Format.fprintf ppf
+          "Continuation %d was used but never bound"
+          cont
+    | Mismatching_kind { cont; handler_kind; kind } ->
+      Format.fprintf ppf
+        "Continuation %d was declared as %a but used as %a"
+        cont
+        print_handler_kind handler_kind
+        print_handler_kind kind
+    | Multiple_handlers { cont; } ->
+      Format.fprintf ppf
+        "Continuation %d was declared in more than one handler"
+        cont
+    | Wrong_arguments_number { cont; handler_args; jump_args } ->
+      Format.fprintf ppf
+        "Continuation %d was declared with %d arguments but called with %d"
+        cont
+        handler_args
+        jump_args
+    | Bad_exception_handler { cont; args } ->
+      Format.fprintf ppf
+        "Continuation %d was declared as an exception handler with %d arguments"
+        cont
+        args
+
+  let print_error_newline ppf error =
+    Format.fprintf ppf "%a@." print_error error
+
+  let report ppf =
+    if ErrorSet.is_empty state.errors then false
+    else begin
+      ErrorSet.iter (fun err -> print_error_newline ppf err) state.errors;
+      true
+    end
+end
+
+let rec check env (expr : Cmm.expression) =
+  match expr with
+  | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _
+  | Cconst_pointer _ | Cconst_natpointer _ | Cblockheader _ | Cvar _ ->
+    ()
+  | Clet (_, expr, body) ->
+    check env expr;
+    check env body
+  | Cassign (_, expr) ->
+    check env expr
+  | Ctuple exprs ->
+    List.iter (check env) exprs
+  | Cop (_, args, _) ->
+    List.iter (check env) args
+  | Csequence (expr1, expr2) ->
+    check env expr1;
+    check env expr2
+  | Cifthenelse (test, ifso, ifnot) ->
+    check env test;
+    check env ifso;
+    check env ifnot
+  | Cswitch (body, _, branches, _) ->
+    check env body;
+    Array.iter (check env) branches
+  | Cloop expr ->
+    check env expr
+  | Ccatch (kind, handlers, body) ->
+    let env_extended =
+      List.fold_left
+        (fun env (cont, args, _) ->
+           Env.handler env ~kind ~cont ~arg_num:(List.length args))
+        env
+        handlers
+    in
+    check env_extended body;
+    let env_handler =
+      match kind with
+      | Normal Recursive -> env_extended
+      | Normal Nonrecursive | Exn_handler -> env
+    in
+    List.iter (fun (_, _, handler) -> check env_handler handler) handlers
+  | Cexit (cont, args, ta) ->
+    Env.jump env ~cont ~arg_num:(List.length args);
+    Env.check_trap_action env ta
+
+let run ppf (fundecl : Cmm.fundecl) =
+  let env = Env.init () in
+  check env fundecl.fun_body;
+  Env.report ppf

--- a/asmcomp/cmm_invariants.mli
+++ b/asmcomp/cmm_invariants.mli
@@ -1,0 +1,39 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Vincent Laviron, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2016 OCamlPro SAS                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Check a number of continuation-related invariants *)
+
+(* Currently, this checks that :
+   - Every use of a continuation occurs within the scope of its handler
+   (this includes the Poptrap and Pushtrap instructions, which must
+   refer to a continuation in scope; however, exception stack invariants
+   are checked by Trap_analysis later, not here).
+   - In every function declaration, a given continuation can only be
+   declared in a single handler.
+   - A continuation cannot be declared/used both as an exception continuation
+   and a normal one.
+   - The number of arguments given to continuations makes sense :
+   exception continuation handlers take exactly one argument, and
+   Exit instructions take the same number of arguments as their handler.
+
+   This pass is intended to document what invariants the backend can rely
+   upon, with hope that future changes in earlier passes that break these
+   invariants will document what the new invariants are and update the checks.
+*)
+
+(** [run ppf fundecl] analyses the given function, and returns whether
+    any errors were encountered (with corresponding error messages printed
+    on the given formatter). *)
+
+val run : Format.formatter -> Cmm.fundecl -> bool

--- a/asmcomp/comballoc.ml
+++ b/asmcomp/comballoc.ml
@@ -38,7 +38,7 @@ let rec combine i allocstate =
           let (newnext, newsz) =
             combine i.next (Pending_alloc(i.res.(0), sz)) in
           (instr_cons_debug (Iop(Ialloc {words = newsz; spacetime_index = 0;
-              label_after_call_gc = None; }))
+              label_after_call_gc = None; trap_stack = []; }))
             i.arg i.res i.dbg newnext, 0)
       | Pending_alloc(reg, ofs) ->
           if ofs + sz < Config.max_young_wosize * Arch.size_addr then begin
@@ -50,7 +50,7 @@ let rec combine i allocstate =
             let (newnext, newsz) =
               combine i.next (Pending_alloc(i.res.(0), sz)) in
             (instr_cons_debug (Iop(Ialloc { words = newsz; spacetime_index = 0;
-                label_after_call_gc = None; }))
+                label_after_call_gc = None; trap_stack = []; }))
               i.arg i.res i.dbg newnext, ofs)
           end
       end
@@ -77,18 +77,16 @@ let rec combine i allocstate =
       let newbody = combine_restart body in
       (instr_cons (Iloop(newbody)) i.arg i.res i.next,
        allocated_size allocstate)
-  | Icatch(rec_flag, handlers, body) ->
+  | Icatch(rec_flag, is_exn_handler, handlers, body) ->
       let (newbody, sz) = combine body allocstate in
       let newhandlers =
-        List.map (fun (io, handler) -> io, combine_restart handler) handlers in
+        List.map (fun (io, trap_stack, handler) ->
+            io, trap_stack, combine_restart handler)
+          handlers
+      in
       let newnext = combine_restart i.next in
-      (instr_cons (Icatch(rec_flag, newhandlers, newbody))
+      (instr_cons (Icatch(rec_flag, is_exn_handler, newhandlers, newbody))
          i.arg i.res newnext, sz)
-  | Itrywith(body, handler) ->
-      let (newbody, sz) = combine body allocstate in
-      let newhandler = combine_restart handler in
-      let newnext = combine_restart i.next in
-      (instr_cons (Itrywith(newbody, newhandler)) i.arg i.res newnext, sz)
 
 and combine_restart i =
   let (newi, _) = combine i No_alloc in newi

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -857,9 +857,14 @@ let emit_instr fallthrough i =
         D.long (ConstLabel (emit_label jumptbl.(i)))
       done;
       D.text ()
-  | Lsetuptrap lbl ->
-      I.call (label lbl)
-  | Lpushtrap ->
+  | Lentertrap ->
+      ()
+  | Ladjust_trap_depth delta ->
+      let delta = trap_frame_size * delta in
+      cfi_adjust_cfa_offset delta;
+      stack_offset := !stack_offset + delta
+  | Lpushtrap { handler; } ->
+      I.push (label handler);
       if trap_frame_size > 8 then
         I.sub (int (trap_frame_size - 8)) esp;
       I.push (sym32 "caml_exception_pointer");
@@ -881,7 +886,8 @@ let emit_instr fallthrough i =
           I.pop (sym32 "caml_exception_pointer");
           if trap_frame_size > 8 then
             I.add (int (trap_frame_size - 8)) esp;
-          I.ret ()
+          I.pop ebx;
+          I.jmp ebx
       end
 
 let rec emit_all fallthrough i =

--- a/asmcomp/interval.ml
+++ b/asmcomp/interval.ml
@@ -107,7 +107,7 @@ let insert_destroyed_at_oper intervals instr pos =
   if Array.length destroyed > 0 then
     update_interval_position_by_array intervals destroyed pos Result
 
-let insert_destroyed_at_raise intervals pos =
+let _insert_destroyed_at_raise intervals pos =
   let destroyed = Proc.destroyed_at_raise in
   if Array.length destroyed > 0 then
     update_interval_position_by_array intervals destroyed pos Result
@@ -115,6 +115,8 @@ let insert_destroyed_at_raise intervals pos =
 (* Build all intervals.
    The intervals will be expanded by one step at the start and end
    of a basic block. *)
+
+(* CR mshinwell: This code needs fixing for the push/poptrap stuff. *)
 
 let build_intervals fd =
   let intervals = Array.init
@@ -152,20 +154,20 @@ let build_intervals fd =
         insert_destroyed_at_oper intervals i !pos;
         walk_instruction body;
         walk_instruction i.next
-    | Icatch(_, handlers, body) ->
+    | Icatch(_, _, handlers, body) ->
         insert_destroyed_at_oper intervals i !pos;
-        List.iter (fun (_, i) -> walk_instruction i) handlers;
+        List.iter (fun (_, _, i) -> walk_instruction i) handlers;
         walk_instruction body;
         walk_instruction i.next
     | Iexit _ ->
         insert_destroyed_at_oper intervals i !pos;
         walk_instruction i.next
-    | Itrywith(body, handler) ->
+(*    | Itrywith(body, handler) ->
         insert_destroyed_at_oper intervals i !pos;
         walk_instruction body;
         insert_destroyed_at_raise intervals !pos;
         walk_instruction handler;
-        walk_instruction i.next
+        walk_instruction i.next *)
     | Iraise _ ->
         walk_instruction i.next
     end in

--- a/asmcomp/linear_invariants.ml
+++ b/asmcomp/linear_invariants.ml
@@ -1,0 +1,107 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2016 OCamlPro SAS                                          *)
+(*   Copyright 2016 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+
+module Int = Numbers.Int
+
+type state = {
+  trap_depth : int;
+  trap_depth_at_labels : int Int.Map.t;
+}
+
+let record_trap_depth_at_label ~state ~insn ~label =
+  match Int.Map.find label state.trap_depth_at_labels with
+  | exception Not_found ->
+    let trap_depth_at_labels =
+      Int.Map.add label state.trap_depth state.trap_depth_at_labels
+    in
+    { state with trap_depth_at_labels; }
+  | existing_trap_depth ->
+    if state.trap_depth = existing_trap_depth then
+      state
+    else
+      Misc.fatal_errorf "Conflicting trap depths for label %d (already have \
+          %d but the following instruction has depth %d):@;%a"
+        label
+        existing_trap_depth
+        state.trap_depth
+        Printlinear.instr insn
+
+let record_trap_depth_at_label_opt ~state ~insn ~label =
+  match label with
+  | None -> state
+  | Some label -> record_trap_depth_at_label ~state ~insn ~label
+
+let check_instruction (insn : Linearize.instruction) ~state =
+  assert (state.trap_depth >= 0);
+  if state.trap_depth <> insn.trap_depth then begin
+    Misc.fatal_errorf "Trap depth %d expected on instruction:@;%a"
+      state.trap_depth
+      Printlinear.instr insn
+  end;
+  match insn.desc with
+  | Lend | Lop _ | Lreloadretaddr | Lraise _ | Lentertrap -> state
+  | Lreturn ->
+    if state.trap_depth <> 0 then begin
+      Misc.fatal_error "Trap depth must be zero at Lreturn"
+    end;
+    state
+  | Llabel label | Lbranch label | Lcondbranch (_, label) ->
+    record_trap_depth_at_label ~state ~insn ~label
+  | Lcondbranch3 (label1, label2, label3) ->
+    let state = record_trap_depth_at_label_opt ~state ~insn ~label:label1 in
+    let state = record_trap_depth_at_label_opt ~state ~insn ~label:label2 in
+    record_trap_depth_at_label_opt ~state ~insn ~label:label3
+  | Lswitch labels ->
+    Array.fold_left (fun state label ->
+        record_trap_depth_at_label ~state ~insn ~label)
+      state
+      labels
+  | Ladjust_trap_depth delta ->
+    let trap_depth = state.trap_depth + delta in
+    if trap_depth >= 0 then
+      { state with trap_depth; }
+    else
+      Misc.fatal_errorf "Ladjust_trap_depth %d moves the trap depth %d \
+          below zero"
+        delta
+        state.trap_depth
+  | Lpushtrap { handler; } ->
+    let state = record_trap_depth_at_label ~state ~insn ~label:handler in
+    let trap_depth = state.trap_depth + 1 in
+    { state with trap_depth; }
+  | Lpoptrap ->
+    let trap_depth = state.trap_depth - 1 in
+    if trap_depth >= 0 then
+      { state with trap_depth; }
+    else
+      Misc.fatal_errorf "Lpoptrap moves the trap depth below zero"
+
+let rec check_instructions (insn : Linearize.instruction) ~state =
+  let state = check_instruction insn ~state in
+  if not (insn.next == insn) then begin
+    check_instructions insn.next ~state
+  end
+
+let check (fundecl : Linearize.fundecl) =
+  let state =
+    { trap_depth = 0;
+      trap_depth_at_labels = Int.Map.empty;
+    }
+  in
+  check_instructions fundecl.fun_body ~state;
+  fundecl

--- a/asmcomp/linear_invariants.mli
+++ b/asmcomp/linear_invariants.mli
@@ -2,10 +2,11 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
-(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
-(*     en Automatique.                                                    *)
+(*   Copyright 2016 OCamlPro SAS                                          *)
+(*   Copyright 2016 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -13,14 +14,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Lambda
+(** Invariant checks on code produced by [Linearize]. *)
 
-open Format
-
-val trap_action: formatter -> trap_action -> unit
-val structured_constant: formatter -> structured_constant -> unit
-val lambda: formatter -> lambda -> unit
-val program: formatter -> program -> unit
-val primitive: formatter -> primitive -> unit
-val name_of_primitive : primitive -> string
-val value_kind : value_kind -> string
+val check : Linearize.fundecl -> Linearize.fundecl

--- a/asmcomp/linearize.mli
+++ b/asmcomp/linearize.mli
@@ -23,7 +23,9 @@ type instruction =
     arg: Reg.t array;
     res: Reg.t array;
     dbg: Debuginfo.t;
-    live: Reg.Set.t }
+    live: Reg.Set.t;
+    trap_depth: int;
+  }
 
 and instruction_desc =
     Lend
@@ -35,8 +37,9 @@ and instruction_desc =
   | Lcondbranch of Mach.test * label
   | Lcondbranch3 of label option * label option * label option
   | Lswitch of label array
-  | Lsetuptrap of label
-  | Lpushtrap
+  | Ladjust_trap_depth of int
+  | Lentertrap
+  | Lpushtrap of { handler : label; }
   | Lpoptrap
   | Lraise of Cmm.raise_kind
 

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -486,8 +486,9 @@ module BR = Branch_relaxation.Make (struct
         + (if lbl1 = None then 0 else 1)
         + (if lbl2 = None then 0 else 1)
     | Lswitch _ -> size 7 (5 + tocload_size()) (5 + tocload_size())
-    | Lsetuptrap _ -> size 1 2 2
-    | Lpushtrap -> size 4 5 5
+    | Lentertrap -> size 0 (tocload_size()) (tocload_size())
+    | Ladjust_trap_depth _ -> 0
+    | Lpushtrap _ -> size 5 (4 + tocload_size()) (4 + tocload_size())
     | Lpoptrap -> 2
     | Lraise _ -> 6
 
@@ -914,24 +915,26 @@ let emit_instr i =
           done;
           emit_string code_space
         end
-    | Lsetuptrap lbl ->
-        `	bl	{emit_label lbl}\n`;
+    | Lentertrap ->
         begin match abi with
         | ELF32 -> ()
         | ELF64v1 | ELF64v2 -> emit_reload_toc()
         end
-    | Lpushtrap ->
+    | Ladjust_trap_depth delta ->
+        adjust_stack_offset (trap_size * delta)
+    | Lpushtrap { handler; } ->
         begin match abi with
         | ELF32 ->
-          `	mflr	0\n`;
-          `	stwu    0, -16(1)\n`;
+          `	addis	11, 0, {emit_upper emit_label handler}\n`;
+          `	addi	11, 11, {emit_lower emit_label handler}\n`;
+          `	stwu    11, -16(1)\n`;
           adjust_stack_offset 16;
           `	stw	29, 4(1)\n`;
           `	mr	29, 1\n`
         | ELF64v1 | ELF64v2 ->
-          `	mflr	0\n`;
-          `	addi	1, 1, -32\n`;
-          adjust_stack_offset 32;
+          `	addi	1, 1, {emit_int (-trap_size)}\n`;
+          adjust_stack_offset trap_size;
+          emit_tocload emit_gpr 0 (TocLabel handler);
           `	std     0, {emit_int trap_handler_offset}(1)\n`;
           `	std	29, {emit_int trap_previous_offset}(1)\n`;
           `	mr	29, 1\n`

--- a/asmcomp/printclambda.ml
+++ b/asmcomp/printclambda.ml
@@ -32,6 +32,19 @@ let value_kind =
   | Pboxedintval Pint32 -> ":int32"
   | Pboxedintval Pint64 -> ":int64"
 
+let conts ppf = function
+  | [] -> fprintf ppf "(none)"
+  | [c] -> fprintf ppf "%d" c
+  | hd :: tl ->
+      fprintf ppf "[%d" hd;
+      List.iter (fun c -> fprintf ppf ",%d" c) tl;
+      fprintf ppf "]"
+
+let trap_action ppf = function
+  | No_action -> ()
+  | Pop cl -> fprintf ppf "{pop %a} " conts cl
+  | Push cl -> fprintf ppf "{push %a} " conts cl
+
 let rec structured_constant ppf = function
   | Uconst_float x -> fprintf ppf "%F" x
   | Uconst_int32 x -> fprintf ppf "%ldl" x
@@ -150,24 +163,30 @@ and lam ppf = function
         end in
       fprintf ppf
         "@[<1>(switch %a@ @[<v 0>%a@])@]" lam larg switch sw
-  | Ustaticfail (i, ls)  ->
+  | Ustaticfail (i, ls, ta) ->
       let lams ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
-      fprintf ppf "@[<2>(exit@ %d%a)@]" i lams ls;
-  | Ucatch(i, vars, lbody, lhandler) ->
-      fprintf ppf "@[<2>(catch@ %a@;<1 -1>with (%d%a)@ %a)@]"
-        lam lbody i
-        (fun ppf vars -> match vars with
-          | [] -> ()
-          | _ ->
-              List.iter
-                (fun x -> fprintf ppf " %a" Ident.print x)
-                vars)
-        vars
-        lam lhandler
-  | Utrywith(lbody, param, lhandler) ->
-      fprintf ppf "@[<2>(try@ %a@;<1 -1>with %a@ %a)@]"
-        lam lbody Ident.print param lam lhandler
+      fprintf ppf "@[<2>(exit@ %a%d%a)@]" trap_action ta i lams ls;
+  | Ucatch(kind, handlers, lbody) ->
+      let print_handler ppf (cont, params, lhandler) =
+        fprintf ppf "@[<2>(%d%a)@ %a@]"
+          cont
+          (fun ppf vars -> match vars with
+             | [] -> ()
+             | _ ->
+                 List.iter
+                   (fun x -> fprintf ppf " %a" Ident.print x)
+                   vars)
+          params
+          lam lhandler
+      in
+      fprintf ppf "@[<2>(catch%s@ %a@;<1 -1>with %a)@]"
+        (match kind with
+          | Normal Asttypes.Nonrecursive -> ""
+          | Normal Asttypes.Recursive -> "_rec"
+          | Exn_handler -> "_exn")
+        lam lbody
+        (Format.pp_print_list print_handler) handlers
   | Uifthenelse(lcond, lif, lelse) ->
       fprintf ppf "@[<2>(if@ %a@ %a@ %a)@]" lam lcond lam lif lam lelse
   | Usequence(l1, l2) ->

--- a/asmcomp/printclambda.mli
+++ b/asmcomp/printclambda.mli
@@ -16,6 +16,7 @@
 open Clambda
 open Format
 
+val trap_action: formatter -> trap_action -> unit
 val clambda: formatter -> ulambda -> unit
 val approx: formatter -> value_approximation -> unit
 val structured_constant: formatter -> ustructured_constant -> unit

--- a/asmcomp/printlinear.ml
+++ b/asmcomp/printlinear.ml
@@ -24,12 +24,13 @@ let label ppf l =
   Format.fprintf ppf "L%i" l
 
 let instr ppf i =
+  fprintf ppf "[%2d] " i.trap_depth;
   begin match i.desc with
   | Lend -> ()
   | Lop op ->
       begin match op with
       | Ialloc _ | Icall_ind _ | Icall_imm _ | Iextcall _ ->
-          fprintf ppf "@[<1>{%a}@]@," regsetaddr i.live
+          fprintf ppf "@[<1>{%a}@]@,     " regsetaddr i.live
       | _ -> ()
       end;
       operation op i.arg ppf i.res
@@ -57,10 +58,12 @@ let instr ppf i =
        fprintf ppf "case %i: goto %a" i label lblv.(i)
       done;
       fprintf ppf "@,endswitch"
-  | Lsetuptrap lbl ->
-      fprintf ppf "setup trap %a" label lbl
-  | Lpushtrap ->
-      fprintf ppf "push trap"
+  | Lentertrap ->
+      fprintf ppf "enter trap"
+  | Ladjust_trap_depth i ->
+      fprintf ppf "adjust trap depth by %d" i
+  | Lpushtrap { handler; } ->
+      fprintf ppf "push trap L%d" handler
   | Lpoptrap ->
       fprintf ppf "pop trap"
   | Lraise k ->

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -67,6 +67,15 @@ let regsetaddr ppf s =
       | _ -> ())
     s
 
+let print_trap_stack ppf trap_stack =
+  match trap_stack with
+  | [] -> Format.fprintf ppf "[no traps]"
+  | trap_stack ->
+    Format.fprintf ppf "[traps %a]"
+      (Format.pp_print_list ~pp_sep:(fun ppf () -> Format.fprintf ppf "; ")
+        Format.pp_print_int)
+      trap_stack
+
 let intcomp = function
   | Isigned c -> Printf.sprintf " %ss " (Printcmm.comparison c)
   | Iunsigned c -> Printf.sprintf " %su " (Printcmm.comparison c)
@@ -88,10 +97,12 @@ let intop = function
   | Ilsr -> " >>u "
   | Iasr -> " >>s "
   | Icomp cmp -> intcomp cmp
-  | Icheckbound { label_after_error; spacetime_index; } ->
-    if not Config.spacetime then " check > "
+  | Icheckbound { label_after_error; spacetime_index; trap_stack } ->
+    if not Config.spacetime then
+      Format.asprintf " check%a > " print_trap_stack trap_stack
     else
-      Printf.sprintf "check[lbl=%s,index=%d] > "
+      Format.asprintf "check%a[lbl=%s,index=%d] > "
+        print_trap_stack trap_stack
         begin
           match label_after_error with
           | None -> ""
@@ -123,12 +134,15 @@ let operation op arg ppf res =
   | Iconst_int n -> fprintf ppf "%s" (Nativeint.to_string n)
   | Iconst_float f -> fprintf ppf "%F" (Int64.float_of_bits f)
   | Iconst_symbol s -> fprintf ppf "\"%s\"" s
-  | Icall_ind _ -> fprintf ppf "call %a" regs arg
-  | Icall_imm { func; _ } -> fprintf ppf "call \"%s\" %a" func regs arg
+  | Icall_ind { trap_stack; _ } ->
+    fprintf ppf "call%a %a" print_trap_stack trap_stack regs arg
+  | Icall_imm { func; trap_stack; _ } ->
+    fprintf ppf "call%a \"%s\" %a" print_trap_stack trap_stack func regs arg
   | Itailcall_ind _ -> fprintf ppf "tailcall %a" regs arg
   | Itailcall_imm { func; } -> fprintf ppf "tailcall \"%s\" %a" func regs arg
-  | Iextcall { func; alloc; _ } ->
-      fprintf ppf "extcall \"%s\" %a%s" func regs arg
+  | Iextcall { func; alloc; trap_stack; _ } ->
+      fprintf ppf "extcall%a \"%s\" %a%s" print_trap_stack trap_stack
+        func regs arg
       (if alloc then "" else " (noalloc)")
   | Istackoffset n ->
       fprintf ppf "offset stack %i" n
@@ -208,11 +222,14 @@ let rec instr ppf i =
       fprintf ppf "@,endswitch"
   | Iloop(body) ->
       fprintf ppf "@[<v 2>loop@,%a@;<0 -2>endloop@]" instr body
-  | Icatch(flag, handlers, body) ->
-      fprintf ppf "@[<v 2>catch%a@,%a@;<0 -2>with"
+  | Icatch(flag, is_exn_handler, handlers, body) ->
+      fprintf ppf "@[<v 2>catch%s%a@,%a@;<0 -2>with"
+        (if is_exn_handler then "_exn" else "")
         Printcmm.rec_flag flag instr body;
-      let h (nfail, handler) =
-        fprintf ppf "(%d)@,%a@;" nfail instr handler in
+      let h (nfail, trap_stack, handler) =
+        fprintf ppf "(%d%a)@,%a@;" nfail print_trap_stack trap_stack
+          instr handler
+      in
       let rec aux = function
         | [] -> ()
         | [v] -> h v
@@ -221,14 +238,13 @@ let rec instr ppf i =
             fprintf ppf "@ and";
             aux t
       in
-      aux handlers
-  | Iexit i ->
-      fprintf ppf "exit(%d)" i
-  | Itrywith(body, handler) ->
-      fprintf ppf "@[<v 2>try@,%a@;<0 -2>with@,%a@;<0 -2>endtry@]"
-             instr body instr handler
-  | Iraise k ->
-      fprintf ppf "%a %a" Printcmm.raise_kind k reg i.arg.(0)
+      aux handlers;
+      fprintf ppf "@]"
+  | Iexit (i, ta) ->
+      fprintf ppf "exit%a(%d)" Printclambda.trap_action ta i
+  | Iraise (k, trap_stack) ->
+      fprintf ppf "%a%a %a" Printcmm.raise_kind k
+        print_trap_stack trap_stack reg i.arg.(0)
   end;
   if not (Debuginfo.is_none i.dbg) then
     fprintf ppf "%s" (Debuginfo.to_string i.dbg);

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -112,18 +112,17 @@ method private reload i =
           (self#reload i.next))
   | Iloop body ->
       instr_cons (Iloop(self#reload body)) [||] [||] (self#reload i.next)
-  | Icatch(rec_flag, handlers, body) ->
+  | Icatch(rec_flag, is_exn_handler, handlers, body) ->
       let new_handlers = List.map
-          (fun (nfail, handler) -> nfail, self#reload handler)
+          (fun (nfail, trap_stack, handler) ->
+            nfail, trap_stack, self#reload handler)
           handlers in
       instr_cons
-        (Icatch(rec_flag, new_handlers, self#reload body)) [||] [||]
+        (Icatch(rec_flag, is_exn_handler, new_handlers, self#reload body))
+        [||] [||]
         (self#reload i.next)
-  | Iexit i ->
-      instr_cons (Iexit i) [||] [||] dummy_instr
-  | Itrywith(body, handler) ->
-      instr_cons (Itrywith(self#reload body, self#reload handler)) [||] [||]
-        (self#reload i.next)
+  | Iexit (i, ta) ->
+      instr_cons (Iexit (i, ta)) [||] [||] dummy_instr
 
 method fundecl f =
   redo_regalloc <- false;

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -594,11 +594,16 @@ let emit_instr i =
           `	.long	{emit_label jumptbl.(i)} - {emit_label lbl}\n`
         done;
         emit_string code_space
-    | Lsetuptrap lbl ->
-        `	brasl	%r14, {emit_label lbl}\n`;
-    | Lpushtrap ->
+    | Lentertrap ->
+        ()
+    | Ladjust_trap_depth delta ->
+        let delta = 16 * delta in
+        emit_stack_adjust delta;
+        stack_offset := !stack_offset + delta
+    | Lpushtrap { handler; } ->
         stack_offset := !stack_offset + 16;
         emit_stack_adjust 16;
+        `	larl	%r14, {emit_label handler}\n`;
         `	stg	%r14, 0(%r15)\n`;
         `	stg	%r13, {emit_int size_addr}(%r15)\n`;
         `	lgr	%r13, %r15\n`

--- a/asmcomp/schedgen.ml
+++ b/asmcomp/schedgen.ml
@@ -360,8 +360,10 @@ method schedule_fundecl f =
   let rec schedule i try_nesting =
     match i.desc with
     | Lend -> i
-    | Lpushtrap -> { i with next = schedule i.next (try_nesting + 1) }
+    | Lpushtrap _ -> { i with next = schedule i.next (try_nesting + 1) }
     | Lpoptrap -> { i with next = schedule i.next (try_nesting - 1) }
+    | Ladjust_trap_depth delta ->
+      { i with next = schedule i.next (try_nesting + delta) }
     | _ ->
         if self#instr_in_basic_block i try_nesting then begin
           clear_code_dag();

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -301,8 +301,8 @@ method is_simple_expr = function
       | Cabsf | Caddf | Csubf | Cmulf | Cdivf | Cfloatofint | Cintoffloat
       | Ccmpf _ | Ccheckbound -> List.for_all self#is_simple_expr args
       end
-  | Cassign _ | Cifthenelse _ | Cswitch _ | Cloop _ | Ccatch _ | Cexit _
-  | Ctrywith _ -> false
+  | Cassign _ | Cifthenelse _ | Cswitch _ | Cloop _ | Ccatch _
+  | Cexit _ -> false
 
 (* Analyses the effects and coeffects of an expression.  This is used across
    a whole list of expressions with a view to determining which expressions
@@ -345,7 +345,7 @@ method effects_of exp =
         EC.none
     in
     EC.join from_op (EC.join_list_map args self#effects_of)
-  | Cassign _ | Cswitch _ | Cloop _ | Ccatch _ | Cexit _ | Ctrywith _ ->
+  | Cassign _ | Cswitch _ | Cloop _ | Ccatch _ | Cexit _ ->
     EC.arbitrary
 
 (* Says whether an integer constant is a suitable immediate argument *)
@@ -380,7 +380,7 @@ method mark_instr = function
       self#mark_call (* caml_alloc*, caml_garbage_collection *)
   | Iop (Iintop (Icheckbound _) | Iintop_imm(Icheckbound _, _)) ->
       self#mark_c_tailcall (* caml_ml_array_bound_error *)
-  | Iraise raise_kind ->
+  | Iraise (raise_kind, _) ->
     begin match raise_kind with
       | Cmm.Raise_notrace -> ()
       | Cmm.Raise_withtrace ->
@@ -389,35 +389,35 @@ method mark_instr = function
              #mark_c_tailcall to get a good stack backtrace *)
           self#mark_call
     end
-  | Itrywith _ ->
-    self#mark_call
   | _ -> ()
 
 (* Default instruction selection for operators *)
 
 method select_allocation words =
-  Ialloc { words; spacetime_index = 0; label_after_call_gc = None; }
+  Ialloc { words; spacetime_index = 0; label_after_call_gc = None;
+    trap_stack = []; }
 method select_allocation_args _env = [| |]
 
 method select_checkbound () =
-  Icheckbound { spacetime_index = 0; label_after_error = None; }
+  Icheckbound { spacetime_index = 0; label_after_error = None;
+    trap_stack = []; }
 method select_checkbound_extra_args () = []
 
 method select_operation op args _dbg =
   match (op, args) with
   | (Capply _, Cconst_symbol func :: rem) ->
     let label_after = Cmm.new_label () in
-    (Icall_imm { func; label_after; }, rem)
+    (Icall_imm { func; label_after; trap_stack = []; }, rem)
   | (Capply _, _) ->
     let label_after = Cmm.new_label () in
-    (Icall_ind { label_after; }, args)
+    (Icall_ind { label_after; trap_stack = []; }, args)
   | (Cextcall(func, _ty, alloc, label_after), _) ->
     let label_after =
       match label_after with
       | None -> Cmm.new_label ()
       | Some label_after -> label_after
     in
-    Iextcall { func; alloc; label_after; }, args
+    Iextcall { func; alloc; label_after; trap_stack = []; }, args
   | (Cload (chunk, _mut), [arg]) ->
       let (addr, eloc) = self#select_addressing chunk arg in
       (Iload(chunk, addr), [eloc])
@@ -686,7 +686,7 @@ method emit_expr (env:environment) exp =
       | Some r1 ->
           let rd = [|Proc.loc_exn_bucket|] in
           self#insert (Iop Imove) r1 rd;
-          self#insert_debug (Iraise k) dbg rd [||];
+          self#insert_debug (Iraise (k, [])) dbg rd [||];
           None
       end
   | Cop(Ccmpf _, _, _) ->
@@ -743,7 +743,8 @@ method emit_expr (env:environment) exp =
               let rd = self#regs_for typ_val in
               let size = size_expr env (Ctuple new_args) in
               let op =
-                Ialloc { words = size; spacetime_index; label_after_call_gc; }
+                Ialloc { words = size; spacetime_index; label_after_call_gc;
+                  trap_stack = []; }
               in
               let args = self#select_allocation_args env in
               self#insert_debug (Iop op) dbg args rd;
@@ -788,7 +789,8 @@ method emit_expr (env:environment) exp =
       Some [||]
   | Ccatch(_, [], e1) ->
       self#emit_expr env e1
-  | Ccatch(rec_flag, handlers, body) ->
+  | Ccatch(kind, handlers, body) ->
+      assert (kind <> Clambda.Exn_handler || List.length handlers = 1);
       let handlers =
         List.map (fun (nfail, ids, e2) ->
             let rs =
@@ -815,16 +817,30 @@ method emit_expr (env:environment) exp =
           List.fold_left (fun env (id, r) -> env_add id r env)
             env (List.combine ids rs)
         in
-        let (r, s) = self#emit_sequence new_env e2 in
+        let (r, s) =
+          self#emit_sequence new_env e2 ~at_start:(fun seq ->
+            match kind with
+            | Clambda.Normal _ -> ()
+            | Clambda.Exn_handler ->
+              seq#insert_moves [| Proc.loc_exn_bucket |] (Array.concat rs))
+        in
         (nfail, (r, s))
       in
       let l = List.map translate_one_handler handlers in
       let a = Array.of_list ((r_body, s_body) :: List.map snd l) in
       let r = join_array a in
-      let aux (nfail, (_r, s)) = (nfail, s#extract) in
-      self#insert (Icatch (rec_flag, List.map aux l, s_body#extract)) [||] [||];
+      let aux (nfail, (_r, s)) = (nfail, [], s#extract) in
+      let rec_flag, is_exn_handler =
+        match kind with
+        | Clambda.Normal Asttypes.Nonrecursive -> Cmm.Nonrecursive, false
+        | Clambda.Normal Asttypes.Recursive -> Cmm.Recursive, false
+        | Clambda.Exn_handler -> Cmm.Nonrecursive, true
+      in
+      self#insert
+        (Icatch (rec_flag, is_exn_handler, List.map aux l, s_body#extract))
+        [||] [||];
       r
-  | Cexit (nfail,args) ->
+  | Cexit (nfail,args,ta) ->
       begin match self#emit_parts_list env args with
         None -> None
       | Some (simple_list, ext_env) ->
@@ -843,23 +859,16 @@ method emit_expr (env:environment) exp =
           Array.iter (fun reg -> assert(reg.typ <> Addr)) src;
           self#insert_moves src tmp_regs ;
           self#insert_moves tmp_regs (Array.concat dest_args) ;
-          self#insert (Iexit nfail) [||] [||];
+          self#insert (Iexit (nfail, ta)) [||] [||];
           None
       end
-  | Ctrywith(e1, v, e2) ->
-      let (r1, s1) = self#emit_sequence env e1 in
-      let rv = self#regs_for typ_val in
-      let (r2, s2) = self#emit_sequence (env_add v rv env) e2 in
-      let r = join r1 s1 r2 s2 in
-      self#insert
-        (Itrywith(s1#extract,
-                  instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv
-                             (s2#extract)))
-        [||] [||];
-      r
 
-method private emit_sequence (env:environment) exp =
+method private emit_sequence ?at_start (env:environment) exp =
   let s = {< instr_seq = dummy_instr >} in
+  begin match at_start with
+  | None -> ()
+  | Some f -> f s
+  end;
   let r = s#emit_expr env exp in
   (r, s)
 
@@ -1120,9 +1129,10 @@ method emit_tail (env:environment) exp =
             (Iswitch(index, Array.map (self#emit_tail_sequence env) ecases))
             rsel [||]
       end
-  | Ccatch(_, [], e1) ->
+  | Ccatch(Clambda.Normal Asttypes.Nonrecursive, [], e1) ->
       self#emit_tail env e1
-  | Ccatch(rec_flag, handlers, e1) ->
+  | Ccatch(kind, handlers, e1) ->
+      assert (kind <> Clambda.Exn_handler || List.length handlers = 1);
       let handlers =
         List.map (fun (nfail, ids, e2) ->
             let rs =
@@ -1142,29 +1152,31 @@ method emit_tail (env:environment) exp =
           List.fold_left
             (fun env (id,r) -> env_add id r env)
             env (List.combine ids rs) in
-        nfail, self#emit_tail_sequence new_env e2
+        nfail, [],
+          self#emit_tail_sequence new_env e2 ~at_start:(fun seq ->
+            match kind with
+            | Clambda.Normal _ -> ()
+            | Clambda.Exn_handler ->
+              seq#insert_moves [| Proc.loc_exn_bucket |] (Array.concat rs))
       in
-      self#insert (Icatch(rec_flag, List.map aux handlers, s_body)) [||] [||]
-  | Ctrywith(e1, v, e2) ->
-      let (opt_r1, s1) = self#emit_sequence env e1 in
-      let rv = self#regs_for typ_val in
-      let s2 = self#emit_tail_sequence (env_add v rv env) e2 in
+      let rec_flag, is_exn_handler =
+        match kind with
+        | Clambda.Normal Asttypes.Nonrecursive -> Cmm.Nonrecursive, false
+        | Clambda.Normal Asttypes.Recursive -> Cmm.Recursive, false
+        | Clambda.Exn_handler -> Cmm.Nonrecursive, true
+      in
       self#insert
-        (Itrywith(s1#extract,
-                  instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv s2))
-        [||] [||];
-      begin match opt_r1 with
-        None -> ()
-      | Some r1 ->
-          let loc = Proc.loc_results r1 in
-          self#insert_moves r1 loc;
-          self#insert Ireturn loc [||]
-      end
+        (Icatch(rec_flag, is_exn_handler, List.map aux handlers, s_body))
+        [||] [||]
   | _ ->
       self#emit_return env exp
 
-method private emit_tail_sequence env exp =
+method private emit_tail_sequence ?at_start env exp =
   let s = {< instr_seq = dummy_instr >} in
+  begin match at_start with
+  | None -> ()
+  | Some f -> f s
+  end;
   s#emit_tail env exp;
   s#extract
 

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -389,6 +389,9 @@ method mark_instr = function
              #mark_c_tailcall to get a good stack backtrace *)
           self#mark_call
     end
+  | Icatch (_, true, _, _) ->
+    (* Exception handler *)
+    self#mark_call
   | _ -> ()
 
 (* Default instruction selection for operators *)

--- a/asmcomp/spacetime_profiling.ml
+++ b/asmcomp/spacetime_profiling.ml
@@ -372,6 +372,7 @@ class virtual instruction_selection = object (self)
         words;
         label_after_call_gc = Some label;
         spacetime_index = index;
+        trap_stack = [];
       }
     end else begin
       super#select_allocation words
@@ -400,6 +401,7 @@ class virtual instruction_selection = object (self)
       Mach.Icheckbound {
         label_after_error = Some label;
         spacetime_index = index;
+        trap_stack = [];
       }
     end else begin
       super#select_checkbound ()

--- a/asmcomp/strmatch.ml
+++ b/asmcomp/strmatch.ml
@@ -375,10 +375,11 @@ module Make(I:I) = struct
 (* Module entry point *)
 
     let catch arg k = match arg with
-    | Cexit (_e,[]) ->  k arg
+    | Cexit (_e,[],_) ->  k arg
     | _ ->
         let e =  next_raise_count () in
-        ccatch (e,[],k (Cexit (e,[])),arg)
+        Ccatch (Clambda.Normal Asttypes.Nonrecursive,
+          [e, [], arg], k (Cexit (e,[],Clambda.No_action)))
 
     let compile dbg str default cases =
 (* We do not attempt to really optimise default=None *)

--- a/asmcomp/trap_analysis.ml
+++ b/asmcomp/trap_analysis.ml
@@ -1,0 +1,273 @@
+
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2016 OCamlPro SAS                                          *)
+(*   Copyright 2016 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+
+module Int = Numbers.Int
+
+(* The following invariant is relied upon (and checked to a reasonable
+   extent): all applications of a given continuation must be at the same
+   trap depth.
+*)
+
+let rec trap_stacks (insn : Mach.instruction) ~stack ~stacks_at_exit
+      : Mach.instruction * ((bool * Mach.trap_stack) Int.Map.t) =
+  let print_stack ppf stack =
+    Format.fprintf ppf "%a"
+      (Format.pp_print_list ~pp_sep:(fun ppf () -> Format.fprintf ppf "; ")
+        (fun ppf cont -> Format.fprintf ppf "%d" cont))
+      stack
+  in
+  let print_is_exn ppf is_exn =
+    Format.fprintf ppf "%s" (if is_exn then "exn" else "normal")
+  in
+  let add_stack ~cont ~is_exn ~stack ~stacks_at_exit =
+    match Int.Map.find cont stacks_at_exit with
+    | exception Not_found ->
+      Int.Map.add cont (is_exn, stack) stacks_at_exit
+    | is_exn', stack' ->
+      if stack <> stack' then begin
+        Misc.fatal_errorf "Iexit points for continuation %d disagree on \
+            the trap stack: existing = %a new = %a"
+          cont
+          print_stack stack'
+          print_stack stack
+      end;
+      if is_exn <> is_exn' then begin
+        Misc.fatal_errorf "Iexit points for continuation %d disagree on \
+            the continuation kind: existing = %a new = %a"
+          cont
+          print_is_exn is_exn'
+          print_is_exn is_exn
+      end;
+      stacks_at_exit
+  in
+  let register_raise ~stack ~stacks_at_exit =
+    match stack with
+    | [] -> stacks_at_exit  (* raise to toplevel handler *)
+    | cont::_ -> add_stack ~cont ~is_exn:true ~stack ~stacks_at_exit
+  in
+  match insn.Mach.desc with
+  | Iend ->
+    insn, stacks_at_exit
+  | Ireturn ->
+    begin match stack with
+    | [] -> insn, stacks_at_exit
+    | _ -> Misc.fatal_error "Trap depth at Ireturn is non-zero"
+    end
+  | Iop op ->
+    let desc, stacks_at_exit =
+      match op with
+      | Icall_ind call ->
+        let stacks_at_exit = register_raise ~stack ~stacks_at_exit in
+        Mach.Iop (Icall_ind ({ call with trap_stack = stack; })),
+          stacks_at_exit
+      | Icall_imm call ->
+        let stacks_at_exit = register_raise ~stack ~stacks_at_exit in
+        Mach.Iop (Icall_imm ({ call with trap_stack = stack; })),
+          stacks_at_exit
+      | Iextcall call ->
+        let stacks_at_exit = register_raise ~stack ~stacks_at_exit in
+        Mach.Iop (Iextcall ({ call with trap_stack = stack; })),
+          stacks_at_exit
+      | Iintop (Icheckbound check) ->
+        let stacks_at_exit = register_raise ~stack ~stacks_at_exit in
+        Mach.Iop (Iintop (Icheckbound ({ check with trap_stack = stack; }))),
+          stacks_at_exit
+      | Iintop_imm (Icheckbound check, i) ->
+        let stacks_at_exit = register_raise ~stack ~stacks_at_exit in
+        Mach.Iop (Iintop_imm (
+            Icheckbound { check with trap_stack = stack; }, i)),
+          stacks_at_exit
+      | Ialloc alloc ->
+        let stacks_at_exit = register_raise ~stack ~stacks_at_exit in
+        Mach.Iop (Ialloc ({ alloc with trap_stack = stack; })),
+          stacks_at_exit
+      | _ -> Mach.Iop op, stacks_at_exit
+    in
+    let next, stacks_at_exit =
+      trap_stacks insn.Mach.next ~stack ~stacks_at_exit
+    in
+    { insn with
+      desc;
+      next; }, stacks_at_exit
+  | Iraise (kind, _) ->
+    let stacks_at_exit = register_raise ~stack ~stacks_at_exit in
+    let next, stacks_at_exit =
+      trap_stacks insn.Mach.next ~stack ~stacks_at_exit
+    in
+    { insn with desc = Iraise (kind, stack); next; }, stacks_at_exit
+  | Iifthenelse (cond, ifso, ifnot) ->
+    let ifso, stacks_at_exit = trap_stacks ifso ~stack ~stacks_at_exit in
+    let ifnot, stacks_at_exit = trap_stacks ifnot ~stack ~stacks_at_exit in
+    let next, stacks_at_exit =
+      trap_stacks insn.Mach.next ~stack ~stacks_at_exit
+    in
+    { insn with
+      desc = Iifthenelse (cond, ifso, ifnot);
+      next;
+    }, stacks_at_exit
+  | Iswitch (cases, insns) ->
+    let stacks_at_exit = ref stacks_at_exit in
+    let new_insns = Array.copy insns in
+    for case = 0 to Array.length insns - 1 do
+      let new_insn, new_stacks_at_exit =
+        trap_stacks insns.(case) ~stack ~stacks_at_exit:!stacks_at_exit
+      in
+      new_insns.(case) <- new_insn;
+      stacks_at_exit := new_stacks_at_exit
+    done;
+    let next, stacks_at_exit =
+      trap_stacks insn.Mach.next ~stack ~stacks_at_exit:!stacks_at_exit
+    in
+    { insn with
+      desc = Iswitch (cases, new_insns);
+      next;
+    }, stacks_at_exit
+  | Iloop body ->
+    let body, stacks_at_exit = trap_stacks body ~stack ~stacks_at_exit in
+    let next, stacks_at_exit =
+      trap_stacks insn.Mach.next ~stack ~stacks_at_exit
+    in
+    { insn with
+      desc = Iloop body;
+      next;
+    }, stacks_at_exit
+  | Icatch (rec_flag, is_exn_handler, handlers, body) ->
+    assert (not is_exn_handler || List.length handlers = 1);
+    let body, stacks_at_exit = trap_stacks body ~stack ~stacks_at_exit in
+    let handlers =
+      let handlers =
+        List.map (fun (cont, _trap_stack, handler) ->
+            cont, handler)
+          handlers
+      in
+      Int.Map.of_list handlers
+    in
+    let handlers_with_uses, handlers_without_uses =
+      Int.Map.partition (fun cont _handler ->
+          Int.Map.mem cont stacks_at_exit)
+        handlers
+    in
+    let rec process_handlers ~stacks_at_exit ~handlers_with_uses
+          ~handlers_without_uses ~output_handlers =
+      (* By the invariant above, there is no need to compute a fixpoint. *)
+      if Int.Map.is_empty handlers_with_uses then begin
+        output_handlers, stacks_at_exit
+      end else
+        let cont, handler = Int.Map.min_binding handlers_with_uses in
+        let handlers_with_uses = Int.Map.remove cont handlers_with_uses in
+        match Int.Map.find cont stacks_at_exit with
+        | exception Not_found -> assert false
+        | (is_exn, stack) ->
+          (* [handler] is a continuation that is used.  It is called (via
+             exit or raise) when the given [stack] of exception handlers are
+             in scope. *)
+          if is_exn <> is_exn_handler then begin
+            Misc.fatal_errorf "Continuation %d is an exception handler \
+                but is called via Iexit"
+              cont
+          end;
+          let stack =
+            if not is_exn_handler then
+              stack
+            else
+              match stack with
+              | _::stack -> stack
+              | [] ->
+                Misc.fatal_errorf "Continuation %d is an exception handler \
+                    whose trap-stack-at-start is empty"
+                  cont
+          in
+          let handler, stacks_at_exit =
+            trap_stacks handler ~stack ~stacks_at_exit
+          in
+          let new_handlers_with_uses, handlers_without_uses =
+            Int.Map.partition (fun cont _handler ->
+                Int.Map.mem cont stacks_at_exit)
+              handlers_without_uses
+          in
+          let handlers_with_uses =
+            Int.Map.disjoint_union handlers_with_uses new_handlers_with_uses
+          in
+          process_handlers ~stacks_at_exit ~handlers_with_uses
+            ~handlers_without_uses
+            ~output_handlers:((cont, stack, handler) :: output_handlers)
+    in
+    let handlers, stacks_at_exit =
+      process_handlers ~stacks_at_exit ~handlers_with_uses
+        ~handlers_without_uses ~output_handlers:[]
+    in
+    let next, stacks_at_exit =
+      trap_stacks insn.Mach.next ~stack ~stacks_at_exit
+    in
+    begin match handlers with
+    | [] ->
+      { insn with
+        desc = Icatch (Nonrecursive, false, [], body);
+        next;
+      }
+    , stacks_at_exit
+    | handlers ->
+      { insn with
+        desc = Icatch (rec_flag, is_exn_handler, handlers, body);
+        next;
+      }, stacks_at_exit
+    end
+  | Iexit (cont, ta) ->
+    let stack, stacks_at_exit =
+      match ta with
+      | No_action -> stack, stacks_at_exit
+      | Push cl ->
+        let push (stack, stacks_at_exit) cont =
+          let stack = cont :: stack in
+          (* CR vlaviron: This add_stack is necessary because we don't remove
+             Pop/Push annotations for unreachable handlers, which means that
+             we can't remove exception handlers (otherwise we would get errors
+             in Linearize.find_exit_label), and since we can't remove the handler
+             we need to know its trap stack even if there is no raise. *)
+          stack, add_stack ~cont ~is_exn:true ~stack ~stacks_at_exit
+        in
+        List.fold_left push (stack, stacks_at_exit) cl
+      | Pop cl ->
+        let pop (stack, stacks_at_exit) cont =
+          match stack with
+          | [] ->
+            Misc.fatal_errorf "Tried to poptrap %d but trap stack is empty" cont
+          | cont' :: stack ->
+            if cont = cont' then
+              stack, stacks_at_exit
+            else
+              Misc.fatal_errorf "Tried to poptrap %d but trap stack has %d \
+                  at the top"
+                cont cont'
+        in
+        List.fold_left pop (stack, stacks_at_exit) cl
+    in
+    let stacks_at_exit = add_stack ~cont ~is_exn:false ~stack ~stacks_at_exit in
+    let next, stacks_at_exit =
+      trap_stacks insn.Mach.next ~stack ~stacks_at_exit
+    in
+    { insn with next; }, stacks_at_exit
+
+let run (fundecl : Mach.fundecl) =
+  let fun_body, _stacks_at_exit =
+    trap_stacks fundecl.fun_body ~stack:[] ~stacks_at_exit:Int.Map.empty
+  in
+  { fundecl with
+    fun_body;
+  }

--- a/asmcomp/trap_analysis.mli
+++ b/asmcomp/trap_analysis.mli
@@ -2,10 +2,11 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
-(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
-(*     en Automatique.                                                    *)
+(*   Copyright 2016 OCamlPro SAS                                          *)
+(*   Copyright 2016 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -13,14 +14,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Lambda
+(** Fill in the [trap_stack] members of Mach instructions by calculating
+    which exception handlers are in scope for each instruction.
 
-open Format
+    This pass also removes unused [Icatch] handlers.
+*)
 
-val trap_action: formatter -> trap_action -> unit
-val structured_constant: formatter -> structured_constant -> unit
-val lambda: formatter -> lambda -> unit
-val program: formatter -> program -> unit
-val primitive: formatter -> primitive -> unit
-val name_of_primitive : primitive -> string
-val value_kind : value_kind -> string
+val run : Mach.fundecl -> Mach.fundecl

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -276,7 +276,7 @@ let find_raise_label i =
 
 (* Will the translation of l lead to a jump to label ? *)
 let code_as_jump l sz = match l with
-| Lstaticraise (i,[]) ->
+| Lstaticraise (i,[],No_action) ->
     let label,size,tb = find_raise_label i in
     if sz = size && tb == !try_blocks then
       Some label
@@ -715,7 +715,7 @@ let rec comp_expr env exp sz cont =
         end in
       sz_static_raises := List.tl !sz_static_raises ;
       r
-  | Lstaticraise (i, args) ->
+  | Lstaticraise (i, args, _ta) ->
       let cont = discard_dead_code cont in
       let label,size,tb = find_raise_label i in
       let cont = branch_to label cont in
@@ -731,7 +731,7 @@ let rec comp_expr env exp sz cont =
           comp_expr env arg sz cont
       | _ -> comp_exit_args env args sz size cont
       end
-  | Ltrywith(body, id, handler) ->
+  | Ltrywith(body, _c, id, handler) ->
       let (branch1, cont1) = make_branch cont in
       let lbl_handler = new_label() in
       let body_cont =

--- a/bytecomp/instruct.ml
+++ b/bytecomp/instruct.ml
@@ -18,7 +18,9 @@ open Lambda
 type compilation_env =
   { ce_stack: int Ident.tbl;
     ce_heap: int Ident.tbl;
-    ce_rec: int Ident.tbl }
+    ce_rec: int Ident.tbl;
+    ce_static_raises: (int * int) Numbers.Int.Map.t;
+  }
 
 type debug_event =
   { mutable ev_pos: int;                (* Position in bytecode *)

--- a/bytecomp/instruct.mli
+++ b/bytecomp/instruct.mli
@@ -22,7 +22,10 @@ open Lambda
 type compilation_env =
   { ce_stack: int Ident.tbl; (* Positions of variables in the stack *)
     ce_heap: int Ident.tbl;  (* Structure of the heap-allocated env *)
-    ce_rec: int Ident.tbl }  (* Functions bound by the same let rec *)
+    ce_rec: int Ident.tbl;   (* Functions bound by the same let rec *)
+    ce_static_raises: (int * int) Numbers.Int.Map.t;
+                             (* staticraise number to label and size *)
+  }
 
 (* The ce_stack component gives locations of variables residing
    in the stack. The locations are offsets w.r.t. the origin of the

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -237,6 +237,18 @@ type function_attribute = {
   stub: bool;
 }
 
+type trap_action =
+  | No_action
+  | Pop of int list
+(* Trap actions annotate static raise constructs.
+   No_action means that the raise is under the same trywith context as its
+   handler, Pop l means that the raise is nested within the
+   trywith blocks in l (the head of l being the deepest such block).
+   Pop refers to the operaions Kpoptrap and Lpoptrap (respectively in
+   bytecode and native code) that have to be inserted before the jump.
+   Some optimizations that move code around are only legal on No_action
+   static raises. *)
+
 type lambda =
     Lvar of Ident.t
   | Lconst of structured_constant
@@ -250,9 +262,9 @@ type lambda =
    strings are pairwise distinct *)
   | Lstringswitch of
       lambda * (string * lambda) list * lambda option * Location.t
-  | Lstaticraise of int * lambda list
+  | Lstaticraise of int * lambda list * trap_action
   | Lstaticcatch of lambda * (int * Ident.t list) * lambda
-  | Ltrywith of lambda * Ident.t * lambda
+  | Ltrywith of lambda * int * Ident.t * lambda
   | Lifthenelse of lambda * lambda * lambda
   | Lsequence of lambda * lambda
   | Lwhile of lambda * lambda

--- a/middle_end/effect_analysis.ml
+++ b/middle_end/effect_analysis.ml
@@ -42,7 +42,7 @@ let rec no_effects (flam : Flambda.t) =
     List.for_all (fun (_, lam) -> no_effects lam) sw
       && Misc.Stdlib.Option.value_default no_effects def
         ~default:true
-  | Static_catch (_, _, body, _) | Try_with (body, _, _) ->
+  | Static_catch (_, _, body, _) | Try_with (body, _, _, _) ->
     (* If there is a [raise] in [body], the whole [Try_with] may have an
        effect, so there is no need to test the handler. *)
     no_effects body

--- a/middle_end/extract_projections.ml
+++ b/middle_end/extract_projections.ml
@@ -100,7 +100,7 @@ let rec analyse_expr ~which_variables expr =
     | Switch (var, _)
     | String_switch (var, _, _) ->
       check_free_variable var
-    | Static_raise (_, args) ->
+    | Static_raise (_, args, _) ->
       List.iter check_free_variable args
     | For { from_value; to_value; _ } ->
       check_free_variable from_value;

--- a/middle_end/flambda.mli
+++ b/middle_end/flambda.mli
@@ -87,6 +87,12 @@ type specialised_to = {
       either the [free_vars] or the [specialised_args]. *)
 }
 
+(** Trap actions that decorate jumps *)
+type trap_action =
+  | No_action
+  | Pop of Static_exception.t list
+  | Push of Static_exception.t list
+
 (** Flambda terms are partitioned in a pseudo-ANF manner; many terms are
     required to be [let]-bound.  This in particular ensures there is always
     a variable name for an expression that may be lifted out (for example
@@ -106,9 +112,9 @@ type t =
   | Switch of Variable.t * switch
   | String_switch of Variable.t * (string * t) list * t option
   (** Restrictions on [Lambda.Lstringswitch] also apply to [String_switch]. *)
-  | Static_raise of Static_exception.t * Variable.t list
+  | Static_raise of Static_exception.t * Variable.t list * trap_action
   | Static_catch of Static_exception.t * Variable.t list * t * t
-  | Try_with of t * Variable.t * t
+  | Try_with of t * Static_exception.t * Variable.t * t
   | While of t * t
   | For of for_loop
   | Proved_unreachable

--- a/middle_end/flambda_iterators.ml
+++ b/middle_end/flambda_iterators.ml
@@ -37,7 +37,7 @@ let apply_on_subexpressions f f_named (flam : Flambda.t) =
     Misc.may f def
   | Static_catch (_,_,f1,f2) ->
     f f1; f f2;
-  | Try_with (f1,_,f2) ->
+  | Try_with (f1,_,_,f2) ->
     f f1; f f2
   | If_then_else (_,f1, f2) ->
     f f1;f f2
@@ -131,13 +131,13 @@ let map_subexpressions f f_named (tree:Flambda.t) : Flambda.t =
       tree
     else
       Static_catch (i, vars, new_body, new_handler)
-  | Try_with(body, id, handler) ->
+  | Try_with(body, cont, id, handler) ->
     let new_body = f body in
     let new_handler = f handler in
     if body == new_body && handler == new_handler then
       tree
     else
-      Try_with(new_body, id, new_handler)
+      Try_with(new_body, cont, id, new_handler)
   | If_then_else(arg, ifso, ifnot) ->
     let new_ifso = f ifso in
     let new_ifnot = f ifnot in
@@ -355,13 +355,13 @@ let map_general ~toplevel f f_named tree =
             tree
           else
             Static_catch (i, vars, new_body, new_handler)
-        | Try_with(body, id, handler) ->
+        | Try_with(body, cont, id, handler) ->
           let new_body = aux body in
           let new_handler = aux handler in
           if new_body == body && new_handler == handler then
             tree
           else
-            Try_with (new_body, id, new_handler)
+            Try_with (new_body, cont, id, new_handler)
         | If_then_else (arg, ifso, ifnot) ->
           let new_ifso = aux ifso in
           let new_ifnot = aux ifnot in

--- a/middle_end/inconstant_idents.ml
+++ b/middle_end/inconstant_idents.ml
@@ -246,7 +246,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
        bound variables as in NC also *)
     | Assign _ ->
       mark_curr curr
-    | Try_with (f1,id,f2) ->
+    | Try_with (f1,_,id,f2) ->
       mark_curr [Var id];
       mark_curr curr;
       mark_loop ~toplevel [] f1;
@@ -273,7 +273,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
       mark_curr [Var f1];
       mark_loop ~toplevel [] f2;
       mark_loop ~toplevel [] f3
-    | Static_raise (_,l) ->
+    | Static_raise (_,l,_) ->
       mark_curr curr;
       List.iter (fun v -> mark_var v curr) l
     | Apply ({func; args; _ }) ->

--- a/middle_end/inlining_cost.ml
+++ b/middle_end/inlining_cost.ml
@@ -106,7 +106,7 @@ let lambda_smaller' lam ~than:threshold =
     | Static_raise _ -> ()
     | Static_catch (_, _, body, handler) ->
       incr size; lambda_size body; lambda_size handler
-    | Try_with (body, _, handler) ->
+    | Try_with (body, _, _, handler) ->
       size := !size + 8; lambda_size body; lambda_size handler
     | If_then_else (_, ifso, ifnot) ->
       size := !size + 2;

--- a/middle_end/ref_to_variables.ml
+++ b/middle_end/ref_to_variables.ml
@@ -73,7 +73,7 @@ let variables_not_used_as_local_reference (tree:Flambda.t) =
     | Static_catch (_, _, body, handler) ->
       loop body;
       loop handler
-    | Try_with (body, _, handler) ->
+    | Try_with (body, _, _, handler) ->
       loop body;
       loop handler
     | While (cond, body) ->
@@ -83,7 +83,7 @@ let variables_not_used_as_local_reference (tree:Flambda.t) =
       set := Variable.Set.add from_value !set;
       set := Variable.Set.add to_value !set;
       loop body
-    | Static_raise (_, args) ->
+    | Static_raise (_, args, _) ->
       set := Variable.Set.union (Variable.Set.of_list args) !set
     | Proved_unreachable | Apply _ | Send _ | Assign _ ->
       set := Variable.Set.union !set (Flambda.free_variables flam)

--- a/testsuite/tests/asmgen/Makefile
+++ b/testsuite/tests/asmgen/Makefile
@@ -55,7 +55,7 @@ lexcmm.ml: lexcmm.mll
 
 CASES=fib tak quicksort quicksort2 soli \
       arith checkbound tagged-fib tagged-integr tagged-quicksort tagged-tak \
-      catch-try catch-rec even-odd even-odd-spill pgcd
+      catch-try catch-rec even-odd even-odd-spill pgcd deep-exit
 ARGS_fib=-DINT_INT -DFUN=fib main.c
 ARGS_tak=-DUNIT_INT -DFUN=takmain main.c
 ARGS_quicksort=-DSORT -DFUN=quicksort main.c
@@ -73,6 +73,8 @@ ARGS_catch-rec=-DINT_INT -DFUN=catch_fact main.c
 ARGS_even-odd=-DINT_INT -DFUN=is_even main.c
 ARGS_even-odd-spill=-DINT_INT -DFUN=is_even main.c
 ARGS_pgcd=-DINT_INT -DFUN=pgcd_30030 main.c
+#ARGS_double-exit=-DINT_INT -DFUN=double_exit main.c
+ARGS_deep-exit=-DINT_INT -DFUN=deep_exit main.c
 
 skips:
 	@for c in $(CASES); do \

--- a/testsuite/tests/asmgen/deep-exit.cmm
+++ b/testsuite/tests/asmgen/deep-exit.cmm
@@ -1,0 +1,10 @@
+
+(function "deep_exit" (b:val)
+  (catch
+    (try
+      (try
+        (if (and b 1) (exit l (raise_notrace 1))
+          1a)
+      with vartwo 123)
+     with var 456)
+   with (l x) x))

--- a/testsuite/tests/asmgen/double-exit.cmm
+++ b/testsuite/tests/asmgen/double-exit.cmm
@@ -1,0 +1,17 @@
+(* This program makes the invariant in trap_analysis fail.
+   The decision has been taken to consider this program broken, rather
+   than fix trap_analysis, but the program is left for reference. *)
+
+(function "double_exit" (b:val)
+  (let
+    x
+      (catch
+        (if (and b 1) (exit l 1a)
+          3a)
+      with (l x) x)
+    (try
+      (catch
+        (if (and b 1) (exit l 1a)
+          3a)
+      with (l x) x)
+     with var 456)))

--- a/testsuite/tests/asmgen/main.ml
+++ b/testsuite/tests/asmgen/main.ml
@@ -13,8 +13,9 @@ let compile_file filename =
   lb.Lexing.lex_curr_p <- { lb.Lexing.lex_curr_p with pos_fname = filename };
   try
     while true do
-      Asmgen.compile_phrase Format.std_formatter
-                            (Parsecmm.phrase Lexcmm.token lb)
+      let phrase = Parsecmm.phrase Lexcmm.token lb in
+      let phrase = Parsecmmaux.adjust_traps_at_exit phrase in
+      Asmgen.compile_phrase Format.std_formatter phrase
     done
   with
       End_of_file ->

--- a/testsuite/tests/asmgen/parsecmmaux.ml
+++ b/testsuite/tests/asmgen/parsecmmaux.ml
@@ -2,6 +2,9 @@
 
 type error =
     Unbound of string
+  | Undefined_continuation of int
+  | Wrong_stack_at_poptrap of (int * int option)
+  | Inconsistent_stacks of int
 
 exception Error of error
 
@@ -38,6 +41,113 @@ let find_label s =
 let report_error = function
     Unbound s ->
       prerr_string "Unbound identifier "; prerr_string s; prerr_endline "."
+  | Undefined_continuation i ->
+      prerr_string "Exit "; prerr_int i; prerr_endline " with no matching handler."
+  | Wrong_stack_at_poptrap (i, None) ->
+      prerr_string "Poptrap "; prerr_int i; prerr_endline " on empty stack."
+  | Wrong_stack_at_poptrap (i, Some j) ->
+      prerr_string "Poptrap "; prerr_int i;
+      prerr_string " with stack top "; prerr_int j;
+      prerr_endline "."
+  | Inconsistent_stacks i ->
+      prerr_string "Exit "; prerr_int i;
+      prerr_endline " and its handler have incompatible stacks."
 
 let debuginfo ?(loc=Location.symbol_rloc ()) () =
   Debuginfo.(from_location loc)
+
+let nodebuginfo () =
+  Debuginfo.(from_location Location.none)
+
+let adjust_traps exit_stack handler_stack
+  : int list =
+  let rec diff_stack exit_stack handler_stack =
+    match exit_stack, handler_stack with
+    | stack, [] -> stack
+    | conte :: stacke, conth :: stackh
+      when conte = conth -> diff_stack stacke stackh
+    | _, _ ->
+      raise (Error (Inconsistent_stacks 0))
+  in
+  let diff_stack =
+    List.rev (diff_stack (List.rev exit_stack) (List.rev handler_stack))
+  in
+  diff_stack
+
+let rec adjust_traps_expr env stack (expr : Cmm.expression)
+  : Cmm.expression * int list =
+  match expr with
+  | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _
+  | Cconst_pointer _ | Cconst_natpointer _ | Cblockheader _ | Cvar _ ->
+    expr, stack
+  | Clet (id, def, body) ->
+    let def, stack = adjust_traps_expr env stack def in
+    let body, stack = adjust_traps_expr env stack body in
+    Clet (id, def, body), stack
+  | Cassign (id, expr) ->
+    let expr, stack = adjust_traps_expr env stack expr in
+    Cassign (id, expr), stack
+  | Ctuple exprs ->
+    Ctuple (adjust_traps_expr_list env stack exprs), stack
+  | Cop (op, exprs, dbg) ->
+    Cop (op, adjust_traps_expr_list env stack exprs, dbg), stack
+  | Csequence (expr1, expr2) ->
+    let expr1, stack = adjust_traps_expr env stack expr1 in
+    let expr2, stack = adjust_traps_expr env stack expr2 in
+    Csequence (expr1, expr2), stack
+  | Cifthenelse (cond, ifso, ifnot) ->
+    let cond, stack = adjust_traps_expr env stack cond in
+    let ifso, stack_so = adjust_traps_expr env stack ifso in
+    let ifnot, stack_not = adjust_traps_expr env stack ifnot in
+    assert (stack_so = stack_not);
+    Cifthenelse (cond, ifso, ifnot), stack_so
+  | Cswitch (expr, ints, exprs, dbg) ->
+    let expr, stack = adjust_traps_expr env stack expr in
+    let exprs =
+      Array.of_list (adjust_traps_expr_list env stack (Array.to_list exprs))
+    in
+    Cswitch (expr, ints, exprs, dbg), stack
+  | Cloop expr ->
+    let expr, stack = adjust_traps_expr env stack expr in
+    Cloop expr, stack
+  | Ccatch (kind, handlers, body) ->
+    let body_env =
+      (List.map (fun (cont, _, _) -> (cont, stack)) handlers) @ env
+    in
+    let handlers_env = match kind with
+      | Normal Recursive -> body_env
+      | Normal Nonrecursive | Exn_handler -> env
+    in
+    let handlers =
+      List.map (fun (cont, params, body) ->
+          (cont, params, fst (adjust_traps_expr handlers_env stack body)))
+        handlers
+    in
+    let body, stack = adjust_traps_expr body_env stack body in
+    Ccatch (kind, handlers, body), stack
+  | Cexit (cont, exprs, _) ->
+    let exprs = adjust_traps_expr_list env stack exprs in
+    let handler_stack =
+      match List.assoc cont env with
+      | stack -> stack
+      | exception Not_found -> raise (Error (Undefined_continuation cont))
+    in
+    match adjust_traps stack handler_stack with
+    | [] -> Cexit (cont, exprs, No_action), stack
+    | to_pop -> Cexit (cont, exprs, Pop to_pop), stack
+    | exception (Error (Inconsistent_stacks _)) ->
+      raise (Error (Inconsistent_stacks cont))
+
+and adjust_traps_expr_list env stack (exprs : Cmm.expression list) =
+  match exprs with
+  | [] -> []
+  | expr :: rest ->
+    let expr, _stack = adjust_traps_expr env stack expr in
+    expr :: (adjust_traps_expr_list env stack rest)
+
+let adjust_traps_at_exit (phrase: Cmm.phrase) : Cmm.phrase =
+  match phrase with
+  | Cfunction fundecl ->
+    let fun_body, _stack = adjust_traps_expr [] [] fundecl.fun_body in
+    Cfunction { fundecl with fun_body; }
+  | Cdata data -> phrase

--- a/testsuite/tests/asmgen/parsecmmaux.mli
+++ b/testsuite/tests/asmgen/parsecmmaux.mli
@@ -10,7 +10,12 @@ val debuginfo: ?loc:Location.t -> unit -> Debuginfo.t
 
 type error =
     Unbound of string
+  | Undefined_continuation of int
+  | Wrong_stack_at_poptrap of (int * int option)
+  | Inconsistent_stacks of int
 
 exception Error of error
 
 val report_error: error -> unit
+
+val adjust_traps_at_exit: Cmm.phrase -> Cmm.phrase

--- a/testsuite/tests/asmgen/quicksort.cmm
+++ b/testsuite/tests/asmgen/quicksort.cmm
@@ -21,16 +21,16 @@
         (while (< i j)
           (catch
               (while 1
-                (if (>= i hi) exit [])
-                (if (> (addraref a i) pivot) exit [])
+                (if (>= i hi) (exit l1) [])
+                (if (> (addraref a i) pivot) (exit l1) [])
                 (assign i (+ i 1)))
-           with [])
+           with (l1) [])
           (catch
               (while 1
-                (if (<= j lo) exit [])
-                (if (< (addraref a j) pivot) exit [])
+                (if (<= j lo) (exit l2) [])
+                (if (< (addraref a j) pivot) (exit l2) [])
                 (assign j (- j 1)))
-           with [])
+           with (l2) [])
           (if (< i j)
               (let temp (addraref a i)
                    (addraset a i (addraref a j))

--- a/testsuite/tests/asmgen/quicksort2.cmm
+++ b/testsuite/tests/asmgen/quicksort2.cmm
@@ -24,16 +24,16 @@
         (while (< i j)
           (catch
             (while 1
-              (if (>= i hi) exit [])
-              (if (> (app cmp (intaref a i) pivot int) 0) exit [])
+              (if (>= i hi) (exit l1) [])
+              (if (> (app cmp (intaref a i) pivot int) 0) (exit l1) [])
               (assign i (+ i 1)))
-            with [])
+            with (l1) [])
           (catch
             (while 1
-              (if (<= j lo) exit [])
-              (if (< (app cmp (intaref a j) pivot int) 0) exit [])
+              (if (<= j lo) (exit l2) [])
+              (if (< (app cmp (intaref a j) pivot int) 0) (exit l2) [])
               (assign j (- j 1)))
-           with [])
+           with (l2) [])
           (if (< i j)
               (let temp (intaref a i)
                    (intaset a i (intaref a j))

--- a/testsuite/tests/asmgen/tagged-quicksort.cmm
+++ b/testsuite/tests/asmgen/tagged-quicksort.cmm
@@ -21,16 +21,16 @@
         (while (< i j)
           (catch
               (while 1
-                (if (>= i hi) exit [])
-                (if (> (addraref a (>>s i 1)) pivot) exit [])
+                (if (>= i hi) (exit l1) [])
+                (if (> (addraref a (>>s i 1)) pivot) (exit l1) [])
                 (assign i (+ i 2)))
-           with [])
+           with (l1) [])
           (catch
               (while 1
-                (if (<= j lo) exit [])
-                (if (< (addraref a (>>s j 1)) pivot) exit [])
+                (if (<= j lo) (exit l2) [])
+                (if (< (addraref a (>>s j 1)) pivot) (exit l2) [])
                 (assign j (- j 2)))
-           with [])
+           with (l2) [])
           (if (< i j)
               (let temp (addraref a (>>s i 1))
                    (addraset a (>>s i 1) (addraref a (>>s j 1)))

--- a/testsuite/tests/lib-dynlink-native/Makefile
+++ b/testsuite/tests/lib-dynlink-native/Makefile
@@ -35,7 +35,7 @@ all: compile run
 PLUGINS=plugin.so plugin2.so sub/plugin.so sub/plugin3.so plugin4.so \
         mypack.so packed1.so packed1_client.so pack_client.so plugin_ref.so \
         plugin_high_arity.so plugin_ext.so plugin_simple.so bug.so \
-        plugin_thread.so plugin4_unix.so a.so b.so c.so
+        plugin_thread.so plugin4_unix.so a.so b.so c.so plugin_exn.so
 
 ADD_COMPFLAGS=-thread
 
@@ -45,7 +45,7 @@ compile: $(PLUGINS) main$(EXE) mylib.so
 .PHONY: run
 run:
 	@printf " ... testing 'main'"
-	@./main$(EXE) plugin.so plugin2.so plugin_thread.so > result
+	@./main$(EXE) plugin.so plugin2.so plugin_thread.so plugin_exn.so > result
 	@$(DIFF) reference result >/dev/null \
 	&& echo " => passed" || echo " => failed"
 

--- a/testsuite/tests/lib-dynlink-native/api.ml
+++ b/testsuite/tests/lib-dynlink-native/api.ml
@@ -11,6 +11,11 @@ let reg_mod name =
 
 let cbs = ref []
 
+let exn_handler = ref ((fun exn -> raise exn) : exn -> unit)
+
+let set_exn_handler f = exn_handler := f
+let restore_exn_handler () = exn_handler := (fun exn -> raise exn)
+
 let add_cb f = cbs := f :: !cbs
 let runall () = List.iter (fun f -> f ()) !cbs
 

--- a/testsuite/tests/lib-dynlink-native/main.ml
+++ b/testsuite/tests/lib-dynlink-native/main.ml
@@ -27,6 +27,6 @@ let ()  =
     let ic = open_in_bin "marshal.data" in
     let l = (Marshal.from_channel ic : (unit -> unit) list) in
     close_in ic;
-    List.iter (fun f -> f()) l
+    List.iter (fun f -> try f() with exn -> !Api.exn_handler exn) l
   with Failure s ->
     Printf.printf "Failure: %s\n" s

--- a/testsuite/tests/lib-dynlink-native/plugin_exn.ml
+++ b/testsuite/tests/lib-dynlink-native/plugin_exn.ml
@@ -1,0 +1,23 @@
+exception Plugin_exception
+
+let () =
+  Api.reg_mod "Plugin_exn";
+  let handle_exception = function
+  | Plugin_exception ->
+    begin
+      print_endline "Caught Plugin_exception";
+      Api.restore_exn_handler ()
+    end
+  | exn ->
+    begin
+      Api.restore_exn_handler ();
+      raise exn
+    end
+  in
+  let cb () =
+    Api.set_exn_handler handle_exception;
+    print_endline "Raising Plugin_exception";
+    raise Plugin_exception
+  in
+  Api.add_cb cb;
+  print_endline "Plugin_exn loaded"

--- a/testsuite/tests/lib-dynlink-native/reference
+++ b/testsuite/tests/lib-dynlink-native/reference
@@ -25,6 +25,11 @@ Thread
 Thread
 Thread
 Thread
+Loading plugin_exn.so
+Registering module Plugin_exn
+Plugin_exn loaded
+Raising Plugin_exception
+Caught Plugin_exception
 Callback from plugin2
 Callback from plugin
 Callback from main


### PR DESCRIPTION
# Overview

This pull request is extracted from the ongoing flambda branch, and contains two main features:
- A change to the representation of try-with constructs from Clambda onwards
- A change to the compilation of catch handlers (including exception handlers) that aims at improving
performance in the exception case

# Removal of Trywith constructs

This pull request replaces the `Utrywith` construct from Clambda, and replaces it with a more generalized `Ucatch` construct, and `Upushtrap` and `Upoptrap` to denote entering and exiting a try-with body.

The pushtrap/poptrap approach was already used late in the compilation chain, the reason for trying to push it as early as Clambda is that the ongoing work on flambda has shown the necessity to break the trywith blocks to do some optimizations, and reconstructing trywith blocks at the end of the middle-end is not always possible.

It would have been feasible to retain both the trywith and traps based constructs, but we feel this would only lead to more maintaining load (as some paths in the backend are only taken when flambda is enabled or disabled), and translation of a trywith construct to catch and traps is fairly straightforward (with a special case for exit/staticfail from within a trywith block to outside it; the logic that was present in the `Iexit` case in `linearize.ml` has been moved earlier to compensate).

To address the safety problems that such a change implies, three invariants checking modules have been added:
- `Cmm_invariants` checks a few continuations-related invariants (on both catch/exit continuations and trap continuations) on the cmm representation. This was already proposed in a separate pull request (#1400), but this pull request extends the invariants with trap-related ones and makes the invariant checks mandatory.
- `Trap_analysis` annotates mach instructions with trap stack information. Since no pushtrap/poptrap instructions will be added by the backend, it also checks consistency on trap stacks at exit points. This should address the problems noted in an earlier discussion of the feature about the exception edges of the control flow graph not being explicit enough.
- `Linear_invariants` checks again consistency of trap depths on the linear representation, in particular that extra exit instructions added during the transformation from mach are consistent with the rest of the program.

# Changes to the compilation of catch constructs

When compiling a catch handler to linear instructions, the previous choice was to put the handler(s) first, then the actual body, with an extra jump statement to the body code added before the handlers.
This pull request inverts the order, so writes the body first, then the handlers, and of course adds an extra jump at the end of the body to the following code.

This was motivated by a suspicion that the use of `call` and `return` x86 instructions to respectively branch into the body and go back to the handler interfered with the prediction of returns that was done in the processor, causing branch misses. With this patch, going to the body is a simple fallthrough, going to the handler in the `raise` case is a `pop` followed by a `jmp`, and additional work is done at the beginning of the body to compute and store the address of the handler on the stack.

To give an idea of how much time this could save, we ran the following micro-benchmark:

```ocaml
let test_gen () =
  let count = ref 0 in
  fun () ->
    incr count;
    !count land 1 = 0

let test1 = test_gen ()

let test2 = test_gen ()

let do_it n =
  let f () =
    try if test1 () then raise Not_found else ()
    with Not_found when test2 () -> ()
  in
  for i = 1 to n do
    try f () with Not_found -> ()
  done

let _ =
  let default = 100_000 in
  let n =
    if Array.length Sys.argv > 1
    then
      try int_of_string Sys.argv.(1)
      with _ -> default
    else default
  in
  do_it n
```

through the following commands:

`$ ./ocamlopt.opt -o microbench microbench.ml`
`$ perf stat ./microbench 1000000000`

and we got the following results:
On trunk:

```

 Performance counter stats for './microbench 1000000000':

       9936.470484      task-clock (msec)         #    1.000 CPUs utilized          
                35      context-switches          #    0.004 K/sec                  
                 3      cpu-migrations            #    0.000 K/sec                  
                98      page-faults               #    0.010 K/sec                  
    34,612,388,085      cycles                    #    3.483 GHz                    
    46,758,631,959      instructions              #    1.35  insn per cycle         
     7,751,627,648      branches                  #  780.119 M/sec                  
       750,012,504      branch-misses             #    9.68% of all branches        

       9.937585757 seconds time elapsed
```

With this patch:

```

 Performance counter stats for './microbench 1000000000':

       4475.919299      task-clock (msec)         #    1.000 CPUs utilized          
                12      context-switches          #    0.003 K/sec                  
                 2      cpu-migrations            #    0.000 K/sec                  
                97      page-faults               #    0.022 K/sec                  
    15,382,062,427      cycles                    #    3.437 GHz                    
    49,754,449,689      instructions              #    3.23  insn per cycle         
     6,500,840,769      branches                  # 1452.403 M/sec                  
            21,738      branch-misses             #    0.00% of all branches        

       4.477019523 seconds time elapsed
```

The huge gains in execution time can be linked to the big difference in branch-misses, with roughly one branch-miss for every raise in the program.

Tests done on more complex programs are of course much less impressive but still show improvement, and more serious benchmarking is being done using the flambda benchmarks infrastructure. Results will be linked to in this thread once they are available.

In addition to the benchmarking, testing of the patched emitters has been done on all of the supported architectures. More precisely, amd64, arm, arm64, and power were tested on real hardware (by running the whole testsuite), i386 was tested on amd64 by configuring the compiler to produce 32-bits code, and s390x was tested through qemu (some of the lib-threads tests did not finish, likely due to the qemu scheduler, but after disabling them other tests passed fine).

# About separating the patches

While the two changes were described separately, they are submitted in a single pull request because they correspond to the exceptions-related changes in the flambda branch that are not dependent on the middle-end. We would definitely prefer to merge them together, rather than separately, and we have not tested the impact of one part without the other.