### PR TITLE
Clean up trailing whitespace in .ml and .mli files

### DIFF
--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -1021,7 +1021,7 @@ and transl_exp0 e =
       | `Constant_or_function ->
         (* a constant expr of type <> float gets compiled as itself *)
          transl_exp e
-      | `Float -> 
+      | `Float ->
           (* We don't need to wrap with Popaque: this forward
              block will never be shortcutted since it points to a float. *)
           Lprim(Pmakeblock(Obj.forward_tag, Immutable, None),

--- a/manual/tools/latexmacros.ml
+++ b/manual/tools/latexmacros.ml
@@ -90,7 +90,7 @@ def_macro "\\var" [Print "<i>"; Print_arg; Print "</i>"];
 def_macro "\\optvar" [Print "[<i>"; Print_arg; Print "</i>]"];
 def_macro "\\nth" [Print "<i>"; Print_arg;
                    Print "</i><sub>"; Print_arg; Print "</sub>"];
-def_macro "\\nmth" [Print "<i>"; Print_arg; 
+def_macro "\\nmth" [Print "<i>"; Print_arg;
                     Print "</i><sub>"; Print_arg;
                     Print "</sub><sup>"; Print_arg;
                     Print "</sup>"];

--- a/otherlibs/graph/graphics.mli
+++ b/otherlibs/graph/graphics.mli
@@ -48,7 +48,7 @@ external size_y : unit -> int = "caml_gr_size_y"
 (** Return the size of the graphics window. Coordinates of the screen
    pixels range over [0 .. size_x()-1] and [0 .. size_y()-1].
    Drawings outside of this rectangle are clipped, without causing
-   an error. The origin (0,0) is at the lower left corner. 
+   an error. The origin (0,0) is at the lower left corner.
    Some implementation (e.g. X Windows) represent coordinates by
    16-bit integers, hence wrong clipping may occur with coordinates
    below [-32768] or above [32676]. *)

--- a/otherlibs/threads/unix.ml
+++ b/otherlibs/threads/unix.ml
@@ -573,7 +573,7 @@ type msg_flag =
   | MSG_DONTROUTE
   | MSG_PEEK
 
-external _socket : 
+external _socket :
   ?cloexec: bool -> socket_domain -> socket_type -> int -> file_descr
   = "unix_socket"
 external _socketpair :
@@ -1072,7 +1072,7 @@ let open_process cmd =
   with e ->
     close_in inchan;
     close in_write;
-    raise e    
+    raise e
 
 let open_process_full cmd env =
   let (in_read, in_write) = pipe ~cloexec:true () in
@@ -1101,7 +1101,7 @@ let open_process_full cmd env =
   with e ->
     close_in inchan;
     close in_write;
-    raise e    
+    raise e
 
 let find_proc_id fun_name proc =
   try

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -260,7 +260,7 @@ let execvpe_ml name args env =
          which looks up the PATH environment variable whether SUID or not. *)
 
 let execvpe name args env =
-  try  
+  try
     execvpe_c name args env
   with Unix_error(ENOSYS, _, _) ->
     execvpe_ml name args env
@@ -597,7 +597,7 @@ type msg_flag =
   | MSG_DONTROUTE
   | MSG_PEEK
 
-external socket : 
+external socket :
   ?cloexec: bool -> socket_domain -> socket_type -> int -> file_descr
   = "unix_socket"
 external socketpair :
@@ -1086,7 +1086,7 @@ let open_process_full cmd env =
     with e ->
       close out_read; close out_write;
       close in_read; close in_write;
-      close err_read; close err_write; 
+      close err_read; close err_write;
       raise e
   end;
   close out_read;

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -646,7 +646,7 @@ val set_close_on_exec : file_descr -> unit
    to the private file and can do bad things with it.  Hence, it is
    highly recommended to set all file descriptors ``close-on-exec'',
    except in the very few cases where a file descriptor actually needs
-   to be transmitted to another program.  
+   to be transmitted to another program.
 
    The best way to set a file descriptor ``close-on-exec'' is to create
    it in this state.  To this end, the [openfile] function has

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -128,7 +128,7 @@ external to_float : int32 -> float
 
 external of_string : string -> int32 = "caml_int32_of_string"
 (** Convert the given string to a 32-bit integer.
-   The string is read in decimal (by default, or if the string 
+   The string is read in decimal (by default, or if the string
    begins with [0u]) or in hexadecimal, octal or binary if the
    string begins with [0x], [0o] or [0b] respectively.
 

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -150,7 +150,7 @@ external to_nativeint : int64 -> nativeint = "%int64_to_nativeint"
 
 external of_string : string -> int64 = "caml_int64_of_string"
 (** Convert the given string to a 64-bit integer.
-   The string is read in decimal (by default, or if the string 
+   The string is read in decimal (by default, or if the string
    begins with [0u]) or in hexadecimal, octal or binary if the
    string begins with [0x], [0o] or [0b] respectively.
 

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -158,7 +158,7 @@ external to_int32 : nativeint -> int32 = "%nativeint_to_int32"
 
 external of_string : string -> nativeint = "caml_nativeint_of_string"
 (** Convert the given string to a native integer.
-   The string is read in decimal (by default, or if the string 
+   The string is read in decimal (by default, or if the string
    begins with [0u]) or in hexadecimal, octal or binary if the
    string begins with [0x], [0o] or [0b] respectively.
 

--- a/stdlib/pervasives.mli
+++ b/stdlib/pervasives.mli
@@ -623,7 +623,7 @@ val string_of_int : int -> string
 
 external int_of_string : string -> int = "caml_int_of_string"
 (** Convert the given string to an integer.
-   The string is read in decimal (by default, or if the string 
+   The string is read in decimal (by default, or if the string
    begins with [0u]), in hexadecimal (if it begins with [0x] or
    [0X]), in octal (if it begins with [0o] or [0O]), or in binary
    (if it begins with [0b] or [0B]).

--- a/testsuite/tests/afl-instrumentation/test.ml
+++ b/testsuite/tests/afl-instrumentation/test.ml
@@ -70,4 +70,4 @@ let tests =
      ("obj_ordering", obj_ordering);
      (* ("random", random); *)
   |]
-  
+

--- a/testsuite/tests/basic/eval_order_4.ml
+++ b/testsuite/tests/basic/eval_order_4.ml
@@ -5,9 +5,9 @@ let f =
    in fun q -> fun i -> "") (print_endline "x")
 
 let _ =
-  let k = 
-    (let _i = print_int 1 
-     in fun q -> fun i -> "") () 
+  let k =
+    (let _i = print_int 1
+     in fun q -> fun i -> "") ()
   in k (print_int 0)
 
 let () =

--- a/testsuite/tests/letrec-disallowed/disallowed.ml
+++ b/testsuite/tests/letrec-disallowed/disallowed.ml
@@ -106,7 +106,7 @@ and y = let module M = struct let x = x end in (module M : T)
 let rec x =
   match let _ = y in raise Not_found with
     _ -> "x"
-  | exception Not_found -> "z" 
+  | exception Not_found -> "z"
 and y = match x with
   z -> ("y", z);;
 

--- a/testsuite/tests/letrec-disallowed/disallowed.ml.reference
+++ b/testsuite/tests/letrec-disallowed/disallowed.ml.reference
@@ -121,6 +121,6 @@ Error: This kind of expression is not allowed as right-hand side of `let rec'
 #             Characters 15-98:
   ..match let _ = y in raise Not_found with
       _ -> "x"
-    | exception Not_found -> "z".
+    | exception Not_found -> "z"
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 #   

--- a/testsuite/tests/letrec-disallowed/pr7231.ml
+++ b/testsuite/tests/letrec-disallowed/pr7231.ml
@@ -1,1 +1,1 @@
-let rec r = let rec x () = r and y () = x () in y () in r "oops";; 
+let rec r = let rec x () = r and y () = x () in y () in r "oops";;

--- a/testsuite/tests/letrec-disallowed/pr7231.ml.reference
+++ b/testsuite/tests/letrec-disallowed/pr7231.ml.reference
@@ -1,10 +1,10 @@
 
 # Characters 58-64:
-  let rec r = let rec x () = r and y () = x () in y () in r "oops";; 
+  let rec r = let rec x () = r and y () = x () in y () in r "oops";;
                                                             ^^^^^^
 Warning 20: this argument will not be used by the function.
 Characters 12-52:
-  let rec r = let rec x () = r and y () = x () in y () in r "oops";; 
+  let rec r = let rec x () = r and y () = x () in y () in r "oops";;
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 # 

--- a/testsuite/tests/letrec-disallowed/unboxed.ml
+++ b/testsuite/tests/letrec-disallowed/unboxed.ml
@@ -3,4 +3,4 @@ let rec x = {x = y} and y = 3L;;
 
 type r = A of r [@@unboxed];;
 let rec y = A y;;
-              
+

--- a/testsuite/tests/letrec/allowed.ml
+++ b/testsuite/tests/letrec/allowed.ml
@@ -45,7 +45,7 @@ and y = fun () -> ignore x
 
 let rec x = { contents = y }
 and y = fun () -> ignore x;;
-               
+
 let r = ref (fun () -> ())
 let rec x = fun () -> r := x;;
 
@@ -73,6 +73,6 @@ let rec deep_cycle : [`Tuple of [`Shared of 'a] array] as 'a
   = `Tuple [| `Shared deep_cycle |];;
 
 (* Constructing float arrays was disallowed altogether at one point
-   by an overzealous check.  Constructing float arrays in recursive 
+   by an overzealous check.  Constructing float arrays in recursive
    bindings is fine when they don't partake in the recursion. *)
 let rec _x = let _ = [| 1.0 |] in 1. in ();;

--- a/testsuite/tests/letrec/nested.ml
+++ b/testsuite/tests/letrec/nested.ml
@@ -2,6 +2,6 @@
 
 let rec r = (let rec x = `A r and y = fun () -> x in y)
 
-let (`A x) = r () 
+let (`A x) = r ()
 
 let _ = x ()

--- a/testsuite/tests/lib-buffer/test.ml
+++ b/testsuite/tests/lib-buffer/test.ml
@@ -44,9 +44,9 @@ let validate f str msg =
 let () = print_string "Standard Library: Module Buffer\n"
 ;;
 
-let truncate_neg : unit = 
+let truncate_neg : unit =
   let msg =  "truncate: negative" in
-  try 
+  try
     Buffer.truncate buf (-1);
     failed msg
   with
@@ -63,7 +63,7 @@ let truncate_large : unit =
 ;;
 
 let truncate_correct : unit =
-  let n' = n - 1 
+  let n' = n - 1
   and msg =  "truncate: in-range" in
   try
     Buffer.truncate buf n';

--- a/testsuite/tests/lib-bytes/test_bytes.ml
+++ b/testsuite/tests/lib-bytes/test_bytes.ml
@@ -16,10 +16,10 @@ let () =
   begin
     (*
            abcde
-    ?????     
+    ?????
     *)
     Testing.test
-      (length (extend abcde 7 (-7)) = 5); 
+      (length (extend abcde 7 (-7)) = 5);
 
     (*
     abcde

--- a/testsuite/tests/lib-unix/common/dup2.ml
+++ b/testsuite/tests/lib-unix/common/dup2.ml
@@ -21,4 +21,4 @@ let _ =
   cat "./tmp.txt";
   Sys.remove "./tmp.txt"
 
-    
+

--- a/testsuite/tests/lib-unix/common/redirections.ml
+++ b/testsuite/tests/lib-unix/common/redirections.ml
@@ -82,7 +82,7 @@ let test_open_process_full () =
       (refl ^ " o 123 i2o e 456 i2e v XVAR")
       [|"XVAR=xvar"|] in
   output_string i "aa\nbbbb\n"; close_out i;
-  for _i = 1 to 3 do 
+  for _i = 1 to 3 do
     out Unix.stdout (input_line o ^ "\n")
   done;
   for _i = 1 to 2 do
@@ -94,7 +94,7 @@ let test_open_process_full () =
 
 let _ =
   (* The following 'close' makes things more difficult.
-     Under Unix it works fine, but under Win32 create_process 
+     Under Unix it works fine, but under Win32 create_process
      gives an error if one of the standard handles is closed. *)
   (* Unix.close Unix.stdin; *)
   out Unix.stdout "** create_process\n";

--- a/testsuite/tests/tool-ocamldoc-2/level_0.mli
+++ b/testsuite/tests/tool-ocamldoc-2/level_0.mli
@@ -1,15 +1,15 @@
-(** Test for level 0 headings 
- 
-  {1 Level 1} 
-   
+(** Test for level 0 headings
+
+  {1 Level 1}
+
    Standard heading levels start at 1.
 
   {0 Level 0}
   A level 0 heading is guaranted to be at the same level that
   the main heading of the module.
 
-  This setup allows users to start their standard heading at level 1 rather 
-  than 2, without losing the ability to add global level heading, 
+  This setup allows users to start their standard heading at level 1 rather
+  than 2, without losing the ability to add global level heading,
   when, if ever, such heading is warranted
 
  *)

--- a/testsuite/tests/tool-ocamldoc-2/level_0.reference
+++ b/testsuite/tests/tool-ocamldoc-2/level_0.reference
@@ -7,13 +7,13 @@
 \usepackage{ocamldoc}
 \begin{document}
 \tableofcontents
-\section{Module {\tt{Level\_0}} : Test for level 0 headings }
+\section{Module {\tt{Level\_0}} : Test for level 0 headings}
 \label{Level-underscore0}\index{Level-underscore0@\verb`Level_0`}
 
 
 
   \subsection*{Level 1}
- 
+
 
 
    Standard heading levels start at 1.
@@ -25,8 +25,8 @@
   the main heading of the module.
 
 
-  This setup allows users to start their standard heading at level 1 rather 
-  than 2, without losing the ability to add global level heading, 
+  This setup allows users to start their standard heading at level 1 rather
+  than 2, without losing the ability to add global level heading,
   when, if ever, such heading is warranted
 
 

--- a/testsuite/tests/tool-ocamldoc-html/Documentation_tags.mli
+++ b/testsuite/tests/tool-ocamldoc-html/Documentation_tags.mli
@@ -1,10 +1,10 @@
 (** Test the html rendering of ocamldoc documentation tags *)
 
 val heterological: unit
-(** 
+(**
  @author yes
  @param no No description
- @param neither see no description  
+ @param neither see no description
  @deprecated since the start of time
  @return ()
  @see "Documentation_tags.mli" Self reference

--- a/testsuite/tests/typing-modules/pr7348.ml
+++ b/testsuite/tests/typing-modules/pr7348.ml
@@ -29,7 +29,7 @@ module A : sig end = struct
     let x : < foo: int; ..> = X.x
   end
 
-  module N = F(M)                
+  module N = F(M)
   let _ = (N.x = M.x)
 end;;
 [%%expect{|

--- a/testsuite/tests/typing-ocamlc-i/pr7620_bad.ml
+++ b/testsuite/tests/typing-ocamlc-i/pr7620_bad.ml
@@ -1,3 +1,3 @@
-let t = 
+let t =
   (function `A | `B -> () : 'a) (`A : [`A]);
   (failwith "dummy" : 'a) (* to know how 'a is unified *)

--- a/testsuite/tests/warnings/w04.ml
+++ b/testsuite/tests/warnings/w04.ml
@@ -2,7 +2,7 @@
 
 type expr = E of int [@@unboxed]
 
-      
+
 let f x = match x with (E e) -> e
 
 type t = A | B

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -209,7 +209,7 @@ let proxy ty =
 
 (**** Utilities for fixed row private types ****)
 
-let row_of_type t = 
+let row_of_type t =
   match (repr t).desc with
     Tobject(t,_) ->
       let rec get_row t =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -726,7 +726,7 @@ let rec update_level env level expand ty =
         with Cannot_expand ->
           set_level ty level;
           iter_type_expr (update_level env level expand) ty
-        end          
+        end
     | Tpackage (p, nl, tl) when level < Path.binding_time p ->
         let p' = normalize_package_path env p in
         if Path.same p p' then raise (Unify [(ty, newvar2 level)]);

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -792,7 +792,7 @@ let complete_constrs p all_tags =
   let constrs = get_variant_constructors p.pat_env c.cstr_res in
   let others =
     List.filter
-      (fun cnstr -> ConstructorTagHashtbl.mem not_tags cnstr.cstr_tag) 
+      (fun cnstr -> ConstructorTagHashtbl.mem not_tags cnstr.cstr_tag)
       constrs in
   let const, nonconst =
     List.partition (fun cnstr -> cnstr.cstr_arity = 0) others in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1766,7 +1766,7 @@ struct
     val empty : t
     (** No variables are accessed in an expression; it might be a
         constant or a global identifier *)
-      
+
     val unguarded : t -> Ident.t list
     (** The list of identifiers that are used in an unguarded context *)
 
@@ -1801,14 +1801,14 @@ struct
         x y
 
     let single id access = M.add id access M.empty
-  
+
     let empty = M.empty
 
     let list_matching p t =
       let r = ref [] in
       M.iter (fun id v -> if p v then r := id :: !r) t;
       !r
-    
+
     let unguarded =
       list_matching (function Unguarded | Dereferenced -> true | _ -> false)
 
@@ -1824,7 +1824,7 @@ struct
     let empty = Ident.empty
 
     let join x y =
-      let r = 
+      let r =
       Ident.fold_all
         (fun id v tbl ->
            let v' = try Ident.find_same id tbl with Not_found -> Use.empty in
@@ -1928,7 +1928,7 @@ struct
   type sd = Static | Dynamic
 
   let rec classify_expression : Typedtree.expression -> sd =
-    fun exp -> match exp.exp_desc with 
+    fun exp -> match exp.exp_desc with
       | Texp_let (_, _, e)
       | Texp_letmodule (_, _, _, e)
       | Texp_sequence (_, e)
@@ -1987,7 +1987,7 @@ struct
                 (join
                    (inspect (expression env e1))
                    (inspect (expression env e2)))
-                (* The body is evaluated, but not used, and not available 
+                (* The body is evaluated, but not used, and not available
                    for inclusion in another value *)
                 (discard (expression env e3)))
 
@@ -2229,7 +2229,7 @@ struct
         else Use.discard ty (* as in 'let' *)
       in
       let vars = pattern_variables c_lhs in
-      let env = 
+      let env =
         List.fold_left
           (fun env id -> Ident.add id ty env)
           env
@@ -2242,7 +2242,7 @@ struct
     fun rec_flag env bindings ->
       match rec_flag with
       | Recursive ->
-          (* Approximation: 
+          (* Approximation:
                 let rec y =
                   let rec x1 = e1
                       and x2 = e2
@@ -2301,7 +2301,7 @@ struct
     let ty = expression (build_unguarded_env idlist) expr in
     match Use.unguarded ty, Use.dependent ty, classify_expression expr with
     | _ :: _, _, _ (* The expression inspects rec-bound variables *)
-    | _, _ :: _, Dynamic -> (* The expression depends on rec-bound variables 
+    | _, _ :: _, Dynamic -> (* The expression depends on rec-bound variables
                                and its size is unknown *)
         raise(Error(expr.exp_loc, env, Illegal_letrec_expr))
     | [], _, Static (* The expression has known size *)
@@ -4860,7 +4860,7 @@ and type_let ?(check = fun s -> Warnings.Unused_var s)
       l spat_sexp_list
   in
   if is_recursive then
-    List.iter 
+    List.iter
       (fun {vb_pat=pat} -> match pat.pat_desc with
            Tpat_var _ -> ()
          | Tpat_alias ({pat_desc=Tpat_any}, _, _) -> ()

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -326,12 +326,12 @@ and constructor_tag =
   | Cstr_extension of Path.t * bool     (* Extension constructor
                                            true if a constant false if a block*)
 
-let equal_tag t1 t2 = 
+let equal_tag t1 t2 =
   match (t1, t2) with
   | Cstr_constant i1, Cstr_constant i2 -> i2 = i1
   | Cstr_block i1, Cstr_block i2 -> i2 = i1
   | Cstr_unboxed, Cstr_unboxed -> true
-  | Cstr_extension (path1, b1), Cstr_extension (path2, b2) -> 
+  | Cstr_extension (path1, b1), Cstr_extension (path2, b2) ->
       Path.same path1 path2 && b1 = b2
   | (Cstr_constant _|Cstr_block _|Cstr_unboxed|Cstr_extension _), _ -> false
 


### PR DESCRIPTION
This is the result of running `sed -i 's/[[:space:]]*$//'` on all .ml and .mli files (I also needed to update a few tests).