### PR TITLE
ARM 32-bit port: add support for ARMv8 in 32-bit mode, a.k.a. AArch32

### DIFF
--- a/Changes
+++ b/Changes
@@ -89,6 +89,11 @@ Working version
   (Vincent Laviron, with help from Pierre Chambart,
    reviews by Gabriel Scherer and Luc Maranget)
 
+- ARM 32-bit port: add support for ARMv8 in 32-bit mode, a.k.a. AArch32.
+  For this platform, avoid ITE conditional instruction blocks and use
+  simpler IT blocks instead
+  (Xavier Leroy)
+
 ### Runtime system:
 
 - MPR#6411, GPR#1535: don't compile everything with -static-libgcc on mingw32,

--- a/Changes
+++ b/Changes
@@ -89,10 +89,11 @@ Working version
   (Vincent Laviron, with help from Pierre Chambart,
    reviews by Gabriel Scherer and Luc Maranget)
 
-- ARM 32-bit port: add support for ARMv8 in 32-bit mode, a.k.a. AArch32.
+- GPR#1486: ARM 32-bit port: add support for ARMv8 in 32-bit mode,
+  a.k.a. AArch32.
   For this platform, avoid ITE conditional instruction blocks and use
   simpler IT blocks instead
-  (Xavier Leroy)
+  (Xavier Leroy, review by Mark Shinwell)
 
 ### Runtime system:
 

--- a/asmcomp/arm/arch.ml
+++ b/asmcomp/arm/arch.ml
@@ -19,7 +19,7 @@
 open Format
 
 type abi = EABI | EABI_HF
-type arch = ARMv4 | ARMv5 | ARMv5TE | ARMv6 | ARMv6T2 | ARMv7
+type arch = ARMv4 | ARMv5 | ARMv5TE | ARMv6 | ARMv6T2 | ARMv7 | ARMv8
 type fpu = Soft | VFPv2 | VFPv3_D16 | VFPv3
 
 let abi =
@@ -35,6 +35,7 @@ let string_of_arch = function
   | ARMv6   -> "armv6"
   | ARMv6T2 -> "armv6t2"
   | ARMv7   -> "armv7"
+  | ARMv8   -> "armv8"
 
 let string_of_fpu = function
     Soft      -> "soft"
@@ -53,8 +54,10 @@ let (arch, fpu, thumb) =
     | EABI, "armv6"    -> ARMv6,   Soft,      false
     | EABI, "armv6t2"  -> ARMv6T2, Soft,      false
     | EABI, "armv7"    -> ARMv7,   Soft,      false
+    | EABI, "armv8"    -> ARMv8,   Soft,      false
     | EABI, _          -> ARMv4,   Soft,      false
     | EABI_HF, "armv6" -> ARMv6,   VFPv2,     false
+    | EABI_HF, "armv8" -> ARMv8,   VFPv3,     true
     | EABI_HF, _       -> ARMv7,   VFPv3_D16, true
     end in
   (ref def_arch, ref def_fpu, ref def_thumb)
@@ -67,6 +70,7 @@ let farch spec =
            | "armv6"                       -> ARMv6
            | "armv6t2"                     -> ARMv6T2
            | "armv7"                       -> ARMv7
+           | "armv8"                       -> ARMv8
            | spec -> raise (Arg.Bad ("wrong '-farch' option: " ^ spec))
   end
 

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -367,6 +367,34 @@ let emit_load_symbol_addr dst s =
     1
   end
 
+(* Emit instructions that set [rd] to 1 if integer condition [cmp] holds
+   and set [rd] to 0 otherwise. *)
+
+let emit_set_condition cmp rd =
+  let compthen = name_for_comparison cmp in
+  let compelse = name_for_comparison (negate_integer_comparison cmp) in
+  if !arch < ARMv8 || not !thumb then begin
+    `	ite	{emit_string compthen}\n`;
+    `	mov{emit_string	compthen}	{emit_reg rd}, #1\n`;
+    `	mov{emit_string compelse}	{emit_reg rd}, #0\n`;
+    3
+  end else begin
+    (* T32 mode in ARMv8 deprecates general ITE blocks
+       and favors IT blocks containing only one 16-bit instruction.
+       mov <reg>, #<imm> is 16 bits if <reg> is R0...R7 and <imm> is 0 or 1. *)
+    let temp =
+      match rd.loc with
+      | Reg r when r < 8 -> rd  (* can assign rd directly *)
+      | _ -> phys_reg 3  (* use r3 as temporary *) in
+    `	it	{emit_string compthen}\n`;
+    `	mov{emit_string	compthen}	{emit_reg temp}, #1\n`;
+    `	it	{emit_string compelse}\n`;
+    `	mov{emit_string compelse}	{emit_reg temp}, #0\n`;
+    if temp.loc = rd.loc then 4 else begin
+      `	movs	{emit_reg rd}, {emit_reg temp}\n`; 5
+    end
+  end
+
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
@@ -572,19 +600,11 @@ let emit_instr i =
           1 + ninstr
         end
     | Lop(Iintop(Icomp cmp)) ->
-        let compthen = name_for_comparison cmp in
-        let compelse = name_for_comparison (negate_integer_comparison cmp) in
         `	cmp	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
-        `	ite	{emit_string compthen}\n`;
-        `	mov{emit_string	compthen}	{emit_reg i.res.(0)}, #1\n`;
-        `	mov{emit_string compelse}	{emit_reg i.res.(0)}, #0\n`; 4
+        emit_set_condition cmp i.res.(0) + 1
     | Lop(Iintop_imm(Icomp cmp, n)) ->
-        let compthen = name_for_comparison cmp in
-        let compelse = name_for_comparison (negate_integer_comparison cmp) in
         `	cmp	{emit_reg i.arg.(0)}, #{emit_int n}\n`;
-        `	ite	{emit_string compthen}\n`;
-        `	mov{emit_string	compthen}	{emit_reg i.res.(0)}, #1\n`;
-        `	mov{emit_string compelse}	{emit_reg i.res.(0)}, #0\n`; 4
+        emit_set_condition cmp i.res.(0) + 1
     | Lop(Iintop (Icheckbound { label_after_error; } )) ->
         let lbl = bound_error_label ?label:label_after_error i.dbg in
         `	cmp	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
@@ -929,6 +949,7 @@ let begin_assembly() =
   | ARMv6   -> `	.arch	armv6\n`
   | ARMv6T2 -> `	.arch	armv6t2\n`
   | ARMv7   -> `	.arch	armv7-a\n`
+  | ARMv8   -> `	.arch	armv8-a\n`
   end;
   begin match !fpu with
     Soft      -> `	.fpu	softvfp\n`

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -381,7 +381,8 @@ let emit_set_condition cmp rd =
   end else begin
     (* T32 mode in ARMv8 deprecates general ITE blocks
        and favors IT blocks containing only one 16-bit instruction.
-       mov <reg>, #<imm> is 16 bits if <reg> is R0...R7 and <imm> is 0 or 1. *)
+       mov <reg>, #<imm> is 16 bits if <reg> is R0...R7
+                                   and <imm> fits in 8 bits. *)
     let temp =
       match rd.loc with
       | Reg r when r < 8 -> rd  (* can assign rd directly *)
@@ -601,10 +602,10 @@ let emit_instr i =
         end
     | Lop(Iintop(Icomp cmp)) ->
         `	cmp	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
-        emit_set_condition cmp i.res.(0) + 1
+        1 + emit_set_condition cmp i.res.(0)
     | Lop(Iintop_imm(Icomp cmp, n)) ->
         `	cmp	{emit_reg i.arg.(0)}, #{emit_int n}\n`;
-        emit_set_condition cmp i.res.(0) + 1
+        1 + emit_set_condition cmp i.res.(0)
     | Lop(Iintop (Icheckbound { label_after_error; } )) ->
         let lbl = bound_error_label ?label:label_after_error i.dbg in
         `	cmp	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -265,6 +265,9 @@ let destroyed_at_oper = function
       [| phys_reg 3; phys_reg 8 |]  (* r3 and r12 destroyed *)
   | Iop(Iintop Imulh) when !arch < ARMv6 ->
       [| phys_reg 8 |]              (* r12 destroyed *)
+  | Iop(Iintop (Icomp _) | Iintop_imm(Icomp _, _))
+    when !arch >= ARMv8 && !thumb ->
+      [| phys_reg 3 |]  (* r3 destroyed *)
   | Iop(Iintoffloat | Ifloatofint | Iload(Single, _) | Istore(Single, _, _)) ->
       [| phys_reg 107 |]            (* d7 (s14-s15) destroyed *)
   | _ -> [||]

--- a/configure
+++ b/configure
@@ -977,7 +977,9 @@ case "$target" in
   powerpc-*-openbsd*)           arch=power; model=ppc; system=bsd_elf;;
   s390x*-*-linux*)              arch=s390x; model=z10; system=elf;;
   armv6*-*-linux-gnueabihf)     arch=arm; model=armv6; system=linux_eabihf;;
-  arm*-*-linux-gnueabihf)       arch=arm; system=linux_eabihf;;
+  armv7*-*-linux-gnueabihf)     arch=arm; model=armv7; system=linux_eabihf;;
+  armv8*-*-linux-gnueabihf)     arch=arm; model=armv8; system=linux_eabihf;;
+  armv8*-*-linux-gnueabi)       arch=arm; model=armv8; system=linux_eabi;;
   armv7*-*-linux-gnueabi)       arch=arm; model=armv7; system=linux_eabi;;
   armv6t2*-*-linux-gnueabi)     arch=arm; model=armv6t2; system=linux_eabi;;
   armv6*-*-linux-gnueabi)       arch=arm; model=armv6; system=linux_eabi;;


### PR DESCRIPTION
ARMv8, the latest and greatest ARM architecture, has two modes: AArch64 in 64 bits and AArch32 in 32 bits.  AArch32 is almost identical to ARMv7, the previous, 32-bit-only incarnation of ARM.  However, some conditional instructions are marked as "deprecated" and cause an assembler warning.  Quoting from an ARMv8 manual:

> In conjunction with the reduction of conditionality in the A64 instruction set, and to facilitate higher performance implementations of the architecture in the future, ARMv8 deprecates some uses of the T32 IT instruction. All uses of IT that apply to other than a single subsequent 16-bit instruction from a restricted set are deprecated, as are explicit references to R15 (i.e. PC) within that single 16-bit instruction. This permits the non-deprecated forms of IT and subsequent instruction to be treated by the processor as a single 32-bit conditional instruction. The restricted set of 16-bit instructions which are not deprecated when used in conjunction with IT are as follows: [...]

This pull request updates the ARM 32 bit port of OCaml as follows:
* Add a new architecture variant `Archi.ARMv8`
* Recognize it in `configure`
* Adapt code generation for condition operators to not use `ITE` blocks on ARMv8/Thumb2 and use `IT` blocks from the restricted set of instructions that are not deprecated.

Side note: the ARM cases in `configure` are a bit of a mess but this will be dealt with as part of a future cleanup of `configure`.