### PR TITLE
Treat negated float comparisons more directly

### DIFF
--- a/Changes
+++ b/Changes
@@ -98,6 +98,9 @@ Working version
   simpler IT blocks instead
   (Xavier Leroy, review by Mark Shinwell)
 
+- GPR#1487: Treat negated float comparisons more directly
+  (Leo White, review by Xavier Leroy)
+
 ### Runtime system:
 
 - MPR#6411, GPR#1535: don't compile everything with -static-libgcc on mingw32,

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -385,7 +385,7 @@ let output_test_zero arg =
 
 (* Output a floating-point compare and branch *)
 
-let emit_float_test cmp neg i lbl =
+let emit_float_test cmp i lbl =
   (* Effect of comisd on flags and conditional branches:
                      ZF PF CF  cond. branches taken
         unordered     1  1  1  je, jb, jbe, jp
@@ -395,33 +395,41 @@ let emit_float_test cmp neg i lbl =
      If FP traps are on (they are off by default),
      comisd traps on QNaN and SNaN but ucomisd traps on SNaN only.
   *)
-  match (cmp, neg) with
-  | (Ceq, false) | (Cne, true) ->
+  match cmp with
+  | CFeq ->
       let next = new_label() in
       I.ucomisd (arg i 1) (arg i 0);
       I.jp (label next);          (* skip if unordered *)
       I.je lbl;                   (* branch taken if x=y *)
       def_label next
-  | (Cne, false) | (Ceq, true) ->
+  | CFneq ->
       I.ucomisd (arg i 1) (arg i 0);
       I.jp lbl;                   (* branch taken if unordered *)
       I.jne lbl                   (* branch taken if x<y or x>y *)
-  | (Clt, _) ->
+  | CFlt ->
       I.comisd (arg i 0) (arg i 1);
-      if not neg then I.ja lbl    (* branch taken if y>x i.e. x<y *)
-      else            I.jbe lbl   (* taken if unordered or y<=x i.e. !(x<y) *)
-  | (Cle, _) ->
+      I.ja lbl                    (* branch taken if y>x i.e. x<y *)
+  | CFnlt ->
+      I.comisd (arg i 0) (arg i 1);
+      I.jbe lbl                   (* taken if unordered or y<=x i.e. !(x<y) *)
+  | CFle ->
       I.comisd (arg i 0) (arg i 1);(* swap compare *)
-      if not neg then I.jae lbl   (* branch taken if y>=x i.e. x<=y *)
-      else            I.jb lbl    (* taken if unordered or y<x i.e. !(x<=y) *)
-  | (Cgt, _) ->
+      I.jae lbl                    (* branch taken if y>=x i.e. x<=y *)
+  | CFnle ->
+      I.comisd (arg i 0) (arg i 1);(* swap compare *)
+      I.jb lbl                     (* taken if unordered or y<x i.e. !(x<=y) *)
+  | CFgt ->
       I.comisd (arg i 1) (arg i 0);
-      if not neg then I.ja lbl    (* branch taken if x>y *)
-      else            I.jbe lbl   (* taken if unordered or x<=y i.e. !(x>y) *)
-  | (Cge, _) ->
+      I.ja lbl                     (* branch taken if x>y *)
+  | CFngt ->
+      I.comisd (arg i 1) (arg i 0);
+      I.jbe lbl                    (* taken if unordered or x<=y i.e. !(x>y) *)
+  | CFge ->
       I.comisd (arg i 1) (arg i 0);(* swap compare *)
-      if not neg then I.jae lbl   (* branch taken if x>=y *)
-      else            I.jb lbl    (* taken if unordered or x<y i.e. !(x>=y) *)
+      I.jae lbl                    (* branch taken if x>=y *)
+  | CFnge ->
+      I.comisd (arg i 1) (arg i 0);(* swap compare *)
+      I.jb lbl                     (* taken if unordered or x<y i.e. !(x>=y) *)
 
 (* Deallocate the stack frame before a return or tail call *)
 
@@ -770,8 +778,8 @@ let emit_instr fallthrough i =
       | Iinttest_imm(cmp, n) ->
           I.cmp (int n) (arg i 0);
           I.j (cond cmp) lbl
-      | Ifloattest(cmp, neg) ->
-          emit_float_test cmp neg i lbl
+      | Ifloattest cmp ->
+          emit_float_test cmp i lbl
       | Ioddtest ->
           I.test (int 1) (arg8 i 0);
           I.jne lbl

--- a/asmcomp/amd64/reload.ml
+++ b/asmcomp/amd64/reload.ml
@@ -107,13 +107,13 @@ method! reload_test tst arg =
       if stackp arg.(0) && stackp arg.(1)
       then [| self#makereg arg.(0); arg.(1) |]
       else arg
-  | Ifloattest((Clt|Cle), _) ->
+  | Ifloattest (CFlt | CFnlt | CFle | CFnle) ->
       (* Cf. emit.mlp: we swap arguments in this case *)
       (* First argument can be on stack, second must be in register *)
       if stackp arg.(1)
       then [| arg.(0); self#makereg arg.(1) |]
       else arg
-  | Ifloattest((Ceq|Cne|Cgt|Cge), _) ->
+  | Ifloattest (CFeq | CFneq | CFgt | CFngt | CFge | CFnge) ->
       (* Second argument can be on stack, first must be in register *)
       if stackp arg.(0)
       then [| self#makereg arg.(0); arg.(1) |]

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -165,8 +165,8 @@ let emit_call_bound_error bd =
 (* Negate a comparison *)
 
 let negate_integer_comparison = function
-    Isigned cmp   -> Isigned(negate_comparison cmp)
-  | Iunsigned cmp -> Iunsigned(negate_comparison cmp)
+  | Isigned cmp   -> Isigned(negate_integer_comparison cmp)
+  | Iunsigned cmp -> Iunsigned(negate_integer_comparison cmp)
 
 (* Names of various instructions *)
 
@@ -726,18 +726,20 @@ let emit_instr i =
             `	cmp	{emit_reg i.arg.(0)}, #{emit_int n}\n`;
             let comp = name_for_comparison cmp in
             `	b{emit_string comp}	{emit_label lbl}\n`; 2
-        | Ifloattest(cmp, neg) ->
-            let comp = (match (cmp, neg) with
-                          (Ceq, false) | (Cne, true) -> "eq"
-                        | (Cne, false) | (Ceq, true) -> "ne"
-                        | (Clt, false) -> "cc"
-                        | (Clt, true)  -> "cs"
-                        | (Cle, false) -> "ls"
-                        | (Cle, true)  -> "hi"
-                        | (Cgt, false) -> "gt"
-                        | (Cgt, true)  -> "le"
-                        | (Cge, false) -> "ge"
-                        | (Cge, true)  -> "lt") in
+        | Ifloattest cmp ->
+            let comp =
+              match cmp with
+              | CFeq -> "eq"
+              | CFneq -> "ne"
+              | CFlt -> "cc"
+              | CFnlt -> "cs"
+              | CFle -> "ls"
+              | CFnle -> "hi"
+              | CFgt -> "gt"
+              | CFngt -> "le"
+              | CFge -> "ge"
+              | CFnge -> "lt"
+            in
             `	fcmpd	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
             `	fmstat\n`;
             `	b{emit_string comp}	{emit_label lbl}\n`; 3

--- a/asmcomp/arm/selection.ml
+++ b/asmcomp/arm/selection.ml
@@ -240,16 +240,19 @@ method private select_operation_softfp op args dbg =
   | (Cfloatofint, args) -> (self#iextcall("__aeabi_i2d", false), args)
   | (Cintoffloat, args) -> (self#iextcall("__aeabi_d2iz", false), args)
   | (Ccmpf comp, args) ->
-      let func = (match comp with
-                    Cne    (* there's no __aeabi_dcmpne *)
-                  | Ceq -> "__aeabi_dcmpeq"
-                  | Clt -> "__aeabi_dcmplt"
-                  | Cle -> "__aeabi_dcmple"
-                  | Cgt -> "__aeabi_dcmpgt"
-                  | Cge -> "__aeabi_dcmpge") in
-      let comp = (match comp with
-                    Cne -> Ceq (* eq 0 => false *)
-                  | _   -> Cne (* ne 0 => true *)) in
+      let comp, func =
+        match comp with
+        | CFeq -> Cne, "__aeabi_dcmpeq"
+        | CFneq -> Ceq, "__aeabi_dcmpeq"
+        | CFlt -> Cne, "__aeabi_dcmplt"
+        | CFnlt -> Ceq, "__aeabi_dcmplt"
+        | CFle -> Cne, "__aeabi_dcmple"
+        | CFnle -> Ceq, "__aeabi_dcmple"
+        | CFgt -> Cne, "__aeabi_dcmpgt"
+        | CFngt -> Ceq, "__aeabi_dcmpgt"
+        | CFge -> Cne, "__aeabi_dcmpge"
+        | CFnge -> Ceq, "__aeabi_dcmpge"
+      in
       (Iintop_imm(Icomp(Iunsigned comp), 0),
        [Cop(Cextcall(func, typ_int, false, None), args, dbg)])
   (* Add coercions around loads and stores of 32-bit floats *)

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -792,18 +792,20 @@ let emit_instr i =
             `	cmp	{emit_reg i.arg.(0)}, #{emit_int n}\n`;
             let comp = name_for_comparison cmp in
             `	b.{emit_string comp}	{emit_label lbl}\n`
-        | Ifloattest(cmp, neg) ->
-            let comp = (match (cmp, neg) with
-                        | (Ceq, false) | (Cne, true) -> "eq"
-                        | (Cne, false) | (Ceq, true) -> "ne"
-                        | (Clt, false) -> "cc"
-                        | (Clt, true)  -> "cs"
-                        | (Cle, false) -> "ls"
-                        | (Cle, true)  -> "hi"
-                        | (Cgt, false) -> "gt"
-                        | (Cgt, true)  -> "le"
-                        | (Cge, false) -> "ge"
-                        | (Cge, true)  -> "lt") in
+        | Ifloattest cmp ->
+            let comp =
+              match cmp with
+              | CFeq -> "eq"
+              | CFneq -> "ne"
+              | CFlt -> "cc"
+              | CFnlt -> "cs"
+              | CFle -> "ls"
+              | CFnle -> "hi"
+              | CFgt -> "gt"
+              | CFngt -> "le"
+              | CFge -> "ge"
+              | CFnge -> "lt"
+            in
             `	fcmp	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
             `	b.{emit_string comp}	{emit_label lbl}\n`
         | Ioddtest ->

--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -226,15 +226,31 @@ let make_const_ref c =
 let make_const_int n = make_const (Uconst_int n)
 let make_const_ptr n = make_const (Uconst_ptr n)
 let make_const_bool b = make_const_ptr(if b then 1 else 0)
-let make_comparison cmp x y =
+
+let make_integer_comparison cmp x y =
   make_const_bool
     (match cmp with
        Ceq -> x = y
-     | Cneq -> x <> y
+     | Cne -> x <> y
      | Clt -> x < y
      | Cgt -> x > y
      | Cle -> x <= y
      | Cge -> x >= y)
+
+let make_float_comparison cmp x y =
+  make_const_bool
+    (match cmp with
+     | CFeq -> x = y
+     | CFneq -> not (x = y)
+     | CFlt -> x < y
+     | CFnlt -> not (x < y)
+     | CFgt -> x > y
+     | CFngt -> not (x > y)
+     | CFle -> x <= y
+     | CFnle -> not (x <= y)
+     | CFge -> x >= y
+     | CFnge -> not (x >= y))
+
 let make_const_float n = make_const_ref (Uconst_float n)
 let make_const_natint n = make_const_ref (Uconst_nativeint n)
 let make_const_int32 n = make_const_ref (Uconst_int32 n)
@@ -280,7 +296,7 @@ let simplif_arith_prim_pure fpc p (args, approxs) dbg =
           make_const_int (n1 lsr n2)
       | Pasrint when 0 <= n2 && n2 < 8 * Arch.size_int ->
           make_const_int (n1 asr n2)
-      | Pintcomp c -> make_comparison c n1 n2
+      | Pintcomp c -> make_integer_comparison c n1 n2
       | _ -> default
       end
   (* float *)
@@ -299,7 +315,7 @@ let simplif_arith_prim_pure fpc p (args, approxs) dbg =
       | Psubfloat -> make_const_float (n1 -. n2)
       | Pmulfloat -> make_const_float (n1 *. n2)
       | Pdivfloat -> make_const_float (n1 /. n2)
-      | Pfloatcomp c  -> make_comparison c n1 n2
+      | Pfloatcomp c  -> make_float_comparison c n1 n2
       | _ -> default
       end
   (* nativeint *)
@@ -325,7 +341,7 @@ let simplif_arith_prim_pure fpc p (args, approxs) dbg =
       | Pandbint Pnativeint -> make_const_natint (Nativeint.logand n1 n2)
       | Porbint Pnativeint ->  make_const_natint (Nativeint.logor n1 n2)
       | Pxorbint Pnativeint -> make_const_natint (Nativeint.logxor n1 n2)
-      | Pbintcomp(Pnativeint, c)  -> make_comparison c n1 n2
+      | Pbintcomp(Pnativeint, c)  -> make_integer_comparison c n1 n2
       | _ -> default
       end
   (* nativeint, int *)
@@ -363,7 +379,7 @@ let simplif_arith_prim_pure fpc p (args, approxs) dbg =
       | Pandbint Pint32 -> make_const_int32 (Int32.logand n1 n2)
       | Porbint Pint32 -> make_const_int32 (Int32.logor n1 n2)
       | Pxorbint Pint32 -> make_const_int32 (Int32.logxor n1 n2)
-      | Pbintcomp(Pint32, c) -> make_comparison c n1 n2
+      | Pbintcomp(Pint32, c) -> make_integer_comparison c n1 n2
       | _ -> default
       end
   (* int32, int *)
@@ -401,7 +417,7 @@ let simplif_arith_prim_pure fpc p (args, approxs) dbg =
       | Pandbint Pint64 -> make_const_int64 (Int64.logand n1 n2)
       | Porbint Pint64 -> make_const_int64 (Int64.logor n1 n2)
       | Pxorbint Pint64 -> make_const_int64 (Int64.logxor n1 n2)
-      | Pbintcomp(Pint64, c) -> make_comparison c n1 n2
+      | Pbintcomp(Pint64, c) -> make_integer_comparison c n1 n2
       | _ -> default
       end
   (* int64, int *)

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -89,24 +89,21 @@ let size_machtype mty =
   done;
   !size
 
-type comparison =
-    Ceq
-  | Cne
-  | Clt
-  | Cle
-  | Cgt
-  | Cge
+type integer_comparison = Lambda.integer_comparison =
+  | Ceq | Cne | Clt | Cgt | Cle | Cge
 
-let negate_comparison = function
-    Ceq -> Cne | Cne -> Ceq
-  | Clt -> Cge | Cle -> Cgt
-  | Cgt -> Cle | Cge -> Clt
+let negate_integer_comparison = Lambda.negate_integer_comparison
 
-let swap_comparison = function
-    Ceq -> Ceq | Cne -> Cne
-  | Clt -> Cgt | Cle -> Cge
-  | Cgt -> Clt | Cge -> Cle
+let swap_integer_comparison = Lambda.swap_integer_comparison
 
+(* With floats [not (x < y)] is not the same as [x >= y] due to NaNs,
+   so we provide additional comparisons to represent the negations.*)
+type float_comparison = Lambda.float_comparison =
+  | CFeq | CFneq | CFlt | CFnlt | CFgt | CFngt | CFle | CFnle | CFge | CFnge
+
+let negate_float_comparison = Lambda.negate_float_comparison
+
+let swap_float_comparison = Lambda.swap_float_comparison
 type label = int
 
 let label_counter = ref 99
@@ -142,13 +139,13 @@ and operation =
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
-  | Ccmpi of comparison
+  | Ccmpi of integer_comparison
   | Caddv | Cadda
-  | Ccmpa of comparison
+  | Ccmpa of integer_comparison
   | Cnegf | Cabsf
   | Caddf | Csubf | Cmulf | Cdivf
   | Cfloatofint | Cintoffloat
-  | Ccmpf of comparison
+  | Ccmpf of float_comparison
   | Craise of raise_kind
   | Ccheckbound
 

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -72,16 +72,17 @@ val ge_component
 
 val size_machtype: machtype -> int
 
-type comparison =
-    Ceq
-  | Cne
-  | Clt
-  | Cle
-  | Cgt
-  | Cge
+type integer_comparison = Lambda.integer_comparison =
+  | Ceq | Cne | Clt | Cgt | Cle | Cge
 
-val negate_comparison: comparison -> comparison
-val swap_comparison: comparison -> comparison
+val negate_integer_comparison: integer_comparison -> integer_comparison
+val swap_integer_comparison: integer_comparison -> integer_comparison
+
+type float_comparison = Lambda.float_comparison =
+  | CFeq | CFneq | CFlt | CFnlt | CFgt | CFngt | CFle | CFnle | CFge | CFnge
+
+val negate_float_comparison: float_comparison -> float_comparison
+val swap_float_comparison: float_comparison -> float_comparison
 
 type label = int
 val new_label: unit -> label
@@ -113,14 +114,14 @@ and operation =
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
-  | Ccmpi of comparison
+  | Ccmpi of integer_comparison
   | Caddv (* pointer addition that produces a [Val] (well-formed Caml value) *)
   | Cadda (* pointer addition that produces a [Addr] (derived heap pointer) *)
-  | Ccmpa of comparison
+  | Ccmpa of integer_comparison
   | Cnegf | Cabsf
   | Caddf | Csubf | Cmulf | Cdivf
   | Cfloatofint | Cintoffloat
-  | Ccmpf of comparison
+  | Ccmpf of float_comparison
   | Craise of raise_kind
   | Ccheckbound
 

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -356,7 +356,7 @@ let is_tos = function { loc = Reg _; typ = Float } -> true | _ -> false
 
 (* Emit the code for a floating-point comparison *)
 
-let emit_float_test cmp neg arg lbl =
+let emit_float_test cmp arg lbl =
   let actual_cmp =
     match (is_tos arg.(0), is_tos arg.(1)) with
     | (true, true) ->
@@ -370,7 +370,7 @@ let emit_float_test cmp neg arg lbl =
     | (false, true) ->
         (* second arg on top of FP stack *)
         I.fcomp (reg arg.(0));
-        Cmm.swap_comparison cmp
+        Cmm.swap_float_comparison cmp
     | (false, false) ->
         I.fld     (reg arg.(0));
         I.fcomp   (reg arg.(1));
@@ -378,49 +378,44 @@ let emit_float_test cmp neg arg lbl =
   in
   I.fnstsw ax;
   match actual_cmp with
-  | Ceq ->
-      if neg then begin
-        I.and_ (int 68) ah;
-        I.xor (int 64) ah;
-        I.jne lbl
-      end else begin
-        I.and_ (int 69) ah;
-        I.cmp (int 64) ah;
-        I.je lbl
-      end
-  | Cne ->
-      if neg then begin
-        I.and_ (int 69) ah;
-        I.cmp (int 64) ah;
-        I.je lbl
-      end else begin
-        I.and_ (int 68) ah;
-        I.xor (int 64) ah;
-        I.jne lbl
-      end
-  | Cle ->
+  | CFeq ->
+      I.and_ (int 69) ah;
+      I.cmp (int 64) ah;
+      I.je lbl
+  | CFneq ->
+      I.and_ (int 68) ah;
+      I.xor (int 64) ah;
+      I.jne lbl
+  | CFle ->
       I.and_ (int 69) ah;
       I.dec ah;
       I.cmp (int 64) ah;
-      if neg
-      then I.jae lbl
-      else I.jb lbl
-  | Cge ->
+      I.jb lbl
+  | CFnle ->
+      I.and_ (int 69) ah;
+      I.dec ah;
+      I.cmp (int 64) ah;
+      I.jae lbl
+  | CFge ->
       I.and_ (int 5) ah;
-      if neg
-      then I.jne lbl
-      else I.je lbl
-  | Clt ->
+      I.je lbl
+  | CFnge ->
+      I.and_ (int 5) ah;
+      I.jne lbl
+  | CFlt ->
       I.and_ (int 69) ah;
       I.cmp (int 1) ah;
-      if neg
-      then I.jne lbl
-      else I.je lbl
-  | Cgt ->
+      I.je lbl
+  | CFnlt ->
       I.and_ (int 69) ah;
-      if neg
-      then I.jne lbl
-      else I.je lbl
+      I.cmp (int 1) ah;
+      I.jne lbl
+  | CFgt ->
+      I.and_ (int 69) ah;
+      I.je lbl
+  | CFngt ->
+      I.and_ (int 69) ah;
+      I.jne lbl
 
 (* Emit a Ifloatspecial instruction *)
 
@@ -825,8 +820,8 @@ let emit_instr fallthrough i =
       | Iinttest_imm(cmp, n) ->
           I.cmp (int n) (reg i.arg.(0));
           I.j (cond cmp) lbl
-      | Ifloattest(cmp, neg) ->
-          emit_float_test cmp neg i.arg lbl
+      | Ifloattest cmp ->
+          emit_float_test cmp i.arg lbl
       | Ioddtest ->
           I.test (int 1) (reg i.arg.(0));
           I.jne lbl

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -191,7 +191,7 @@ let destroyed_at_oper = function
   | Iop(Ialloc _ | Iintop Imulh) -> [| eax |]
   | Iop(Iintop(Icomp _) | Iintop_imm(Icomp _, _)) -> [| eax |]
   | Iop(Iintoffloat) -> [| eax |]
-  | Iifthenelse(Ifloattest(_, _), _, _) -> [| eax |]
+  | Iifthenelse(Ifloattest _, _, _) -> [| eax |]
   | _ -> [||]
 
 let destroyed_at_raise = all_phys_regs

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -59,15 +59,15 @@ type fundecl =
 (* Invert a test *)
 
 let invert_integer_test = function
-    Isigned cmp -> Isigned(Cmm.negate_comparison cmp)
-  | Iunsigned cmp -> Iunsigned(Cmm.negate_comparison cmp)
+    Isigned cmp -> Isigned(Cmm.negate_integer_comparison cmp)
+  | Iunsigned cmp -> Iunsigned(Cmm.negate_integer_comparison cmp)
 
 let invert_test = function
     Itruetest -> Ifalsetest
   | Ifalsetest -> Itruetest
   | Iinttest(cmp) -> Iinttest(invert_integer_test cmp)
   | Iinttest_imm(cmp, n) -> Iinttest_imm(invert_integer_test cmp, n)
-  | Ifloattest(cmp, neg) -> Ifloattest(cmp, not neg)
+  | Ifloattest(cmp) -> Ifloattest(Cmm.negate_float_comparison cmp)
   | Ieventest -> Ioddtest
   | Ioddtest -> Ieventest
 

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -18,8 +18,8 @@
 type label = Cmm.label
 
 type integer_comparison =
-    Isigned of Cmm.comparison
-  | Iunsigned of Cmm.comparison
+    Isigned of Cmm.integer_comparison
+  | Iunsigned of Cmm.integer_comparison
 
 type integer_operation =
     Iadd | Isub | Imul | Imulh | Idiv | Imod
@@ -28,12 +28,14 @@ type integer_operation =
   | Icheckbound of { label_after_error : label option;
         spacetime_index : int; }
 
+type float_comparison = Cmm.float_comparison
+
 type test =
     Itruetest
   | Ifalsetest
   | Iinttest of integer_comparison
   | Iinttest_imm of integer_comparison * int
-  | Ifloattest of Cmm.comparison * bool
+  | Ifloattest of float_comparison
   | Ioddtest
   | Ieventest
 

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -22,8 +22,8 @@
 type label = Cmm.label
 
 type integer_comparison =
-    Isigned of Cmm.comparison
-  | Iunsigned of Cmm.comparison
+    Isigned of Cmm.integer_comparison
+  | Iunsigned of Cmm.integer_comparison
 
 type integer_operation =
     Iadd | Isub | Imul | Imulh | Idiv | Imod
@@ -35,12 +35,14 @@ type integer_operation =
         second being the pointer to the trie node for the current function
         (and the first being as per non-Spacetime mode). *)
 
+type float_comparison = Cmm.float_comparison
+
 type test =
     Itruetest
   | Ifalsetest
   | Iinttest of integer_comparison
   | Iinttest_imm of integer_comparison * int
-  | Ifloattest of Cmm.comparison * bool
+  | Ifloattest of float_comparison
   | Ioddtest
   | Ieventest
 

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -847,22 +847,27 @@ let emit_instr i =
             let (comp, branch) = name_for_int_comparison cmp in
             `	{emit_string comp}i	{emit_reg i.arg.(0)}, {emit_int n}\n`;
             `	{emit_string branch}	{emit_label lbl}\n`
-        | Ifloattest(cmp, neg) ->
+        | Ifloattest cmp -> begin
             `	fcmpu	0, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
             (* bit 0 = lt, bit 1 = gt, bit 2 = eq *)
-            let (bitnum, negtst) =
+            let bitnum =
               match cmp with
-                Ceq -> (2, neg)
-              | Cne -> (2, not neg)
-              | Cle -> `	cror	3, 0, 2\n`; (* lt or eq *)
-                       (3, neg)
-              | Cgt -> (1, neg)
-              | Cge -> `	cror	3, 1, 2\n`; (* gt or eq *)
-                       (3, neg)
-              | Clt -> (0, neg) in
-            if negtst
-            then `	bf	{emit_int bitnum}, {emit_label lbl}\n`
-            else `	bt	{emit_int bitnum}, {emit_label lbl}\n`
+              | CFeq | CFneq -> 2
+              | CFle | CFnle ->
+                `	cror	3, 0, 2\n`; (* lt or eq *)
+                3
+              | CFgt | CFngt -> 1
+              | CFge | CFnge ->
+                `	cror	3, 1, 2\n`; (* gt or eq *)
+                3
+              | CFlt | CFnlt -> 0
+            in
+            match cmp with
+            | CFneq | CFngt | CFnge | CFnlt | CFnle ->
+               `	bf	{emit_int bitnum}, {emit_label lbl}\n`
+            | CFeq | CFgt | CFge | CFlt | CFle ->
+               `	bt	{emit_int bitnum}, {emit_label lbl}\n`
+          end
         | Ioddtest ->
             `	andi.	0, {emit_reg i.arg.(0)}, 1\n`;
             `	bne	{emit_label lbl}\n`

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -36,13 +36,25 @@ let machtype ppf mty =
            fprintf ppf "*%a" machtype_component mty.(i)
          done
 
-let comparison = function
+let integer_comparison = function
   | Ceq -> "=="
   | Cne -> "!="
   | Clt -> "<"
   | Cle -> "<="
   | Cgt -> ">"
   | Cge -> ">="
+
+let float_comparison = function
+  | CFeq -> "=="
+  | CFneq -> "!="
+  | CFlt -> "<"
+  | CFnlt -> "!<"
+  | CFle -> "<="
+  | CFnle -> "!<="
+  | CFgt -> ">"
+  | CFngt -> "!>"
+  | CFge -> ">="
+  | CFnge -> "!>="
 
 let chunk = function
   | Byte_unsigned -> "unsigned int8"
@@ -88,10 +100,10 @@ let operation d = function
   | Clsl -> "<<"
   | Clsr -> ">>u"
   | Casr -> ">>s"
-  | Ccmpi c -> comparison c
+  | Ccmpi c -> integer_comparison c
   | Caddv -> "+v"
   | Cadda -> "+a"
-  | Ccmpa c -> Printf.sprintf "%sa" (comparison c)
+  | Ccmpa c -> Printf.sprintf "%sa" (integer_comparison c)
   | Cnegf -> "~f"
   | Cabsf -> "absf"
   | Caddf -> "+f"
@@ -100,7 +112,7 @@ let operation d = function
   | Cdivf -> "/f"
   | Cfloatofint -> "floatofint"
   | Cintoffloat -> "intoffloat"
-  | Ccmpf c -> Printf.sprintf "%sf" (comparison c)
+  | Ccmpf c -> Printf.sprintf "%sf" (float_comparison c)
   | Craise k -> Format.asprintf "%a%s" raise_kind k (Debuginfo.to_string d)
   | Ccheckbound -> "checkbound" ^ Debuginfo.to_string d
 

--- a/asmcomp/printcmm.mli
+++ b/asmcomp/printcmm.mli
@@ -20,7 +20,8 @@ open Format
 val rec_flag : formatter -> Cmm.rec_flag -> unit
 val machtype_component : formatter -> Cmm.machtype_component -> unit
 val machtype : formatter -> Cmm.machtype_component array -> unit
-val comparison : Cmm.comparison -> string
+val integer_comparison : Cmm.integer_comparison -> string
+val float_comparison : Cmm.float_comparison -> string
 val chunk : Cmm.memory_chunk -> string
 val operation : Debuginfo.t -> Cmm.operation -> string
 val expression : formatter -> Cmm.expression -> unit

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -68,11 +68,11 @@ let regsetaddr ppf s =
     s
 
 let intcomp = function
-  | Isigned c -> Printf.sprintf " %ss " (Printcmm.comparison c)
-  | Iunsigned c -> Printf.sprintf " %su " (Printcmm.comparison c)
+  | Isigned c -> Printf.sprintf " %ss " (Printcmm.integer_comparison c)
+  | Iunsigned c -> Printf.sprintf " %su " (Printcmm.integer_comparison c)
 
 let floatcomp c =
-    Printf.sprintf " %sf " (Printcmm.comparison c)
+    Printf.sprintf " %sf " (Printcmm.float_comparison c)
 
 let intop = function
   | Iadd -> " + "
@@ -105,9 +105,8 @@ let test tst ppf arg =
   | Ifalsetest -> fprintf ppf "not %a" reg arg.(0)
   | Iinttest cmp -> fprintf ppf "%a%s%a" reg arg.(0) (intcomp cmp) reg arg.(1)
   | Iinttest_imm(cmp, n) -> fprintf ppf "%a%s%i" reg arg.(0) (intcomp cmp) n
-  | Ifloattest(cmp, neg) ->
-      fprintf ppf "%s%a%s%a"
-       (if neg then "not " else "")
+  | Ifloattest cmp ->
+      fprintf ppf "%a%s%a"
        reg arg.(0) (floatcomp cmp) reg arg.(1)
   | Ieventest -> fprintf ppf "%a & 1 == 0" reg arg.(0)
   | Ioddtest -> fprintf ppf "%a & 1 == 1" reg arg.(0)

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -252,14 +252,17 @@ let name_for_int_comparison_imm = function
   | Iunsigned cmp -> ("clgfi", branch_for_comparison cmp)
 
 (* bit 0 = eq, bit 1 = lt, bit 2 = gt, bit 3 = unordered*)
-let branch_for_float_comparison cmp neg =
-   match cmp with
-     Ceq -> if neg then 7  else 8
-   | Cne -> if neg then 8  else 7
-   | Cle -> if neg then 3  else 12
-   | Cgt -> if neg then 13 else 2
-   | Cge -> if neg then 5  else 10
-   | Clt -> if neg then 11 else 4
+let branch_for_float_comparison = function
+  | CFeq -> 8
+  | CFneq -> 7
+  | CFle -> 12
+  | CFnle -> 3
+  | CFgt -> 2
+  | CFngt -> 1
+  | CFge -> 10
+  | CFnge -> 5
+  | CFlt -> 4
+  | CFnlt -> 1
 
 (* Names for various instructions *)
 
@@ -554,9 +557,9 @@ let emit_instr i =
             let (comp, mask) = name_for_int_comparison_imm cmp in
             `	{emit_string comp}	{emit_reg i.arg.(0)}, {emit_int n}\n`;
             `	brcl	{emit_int mask}, {emit_label lbl}\n`
-        | Ifloattest(cmp, neg) ->
+        | Ifloattest cmp ->
             `	cdbr	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
-            let mask = branch_for_float_comparison cmp neg in
+            let mask = branch_for_float_comparison cmp in
             `	brcl	{emit_int mask}, {emit_label lbl}\n`
         | Ioddtest ->
             `	tmll	{emit_reg i.arg.(0)}, 1\n`;

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -105,8 +105,8 @@ let size_expr (env:environment) exp =
 (* Swap the two arguments of an integer comparison *)
 
 let swap_intcomp = function
-    Isigned cmp -> Isigned(swap_comparison cmp)
-  | Iunsigned cmp -> Iunsigned(swap_comparison cmp)
+    Isigned cmp -> Isigned(swap_integer_comparison cmp)
+  | Iunsigned cmp -> Iunsigned(swap_integer_comparison cmp)
 
 (* Naming of registers *)
 
@@ -511,11 +511,11 @@ method select_condition = function
     Cop(Ccmpi cmp, [arg1; Cconst_int n], _) when self#is_immediate n ->
       (Iinttest_imm(Isigned cmp, n), arg1)
   | Cop(Ccmpi cmp, [Cconst_int n; arg2], _) when self#is_immediate n ->
-      (Iinttest_imm(Isigned(swap_comparison cmp), n), arg2)
+      (Iinttest_imm(Isigned(swap_integer_comparison cmp), n), arg2)
   | Cop(Ccmpi cmp, [arg1; Cconst_pointer n], _) when self#is_immediate n ->
       (Iinttest_imm(Isigned cmp, n), arg1)
   | Cop(Ccmpi cmp, [Cconst_pointer n; arg2], _) when self#is_immediate n ->
-      (Iinttest_imm(Isigned(swap_comparison cmp), n), arg2)
+      (Iinttest_imm(Isigned(swap_integer_comparison cmp), n), arg2)
   | Cop(Ccmpi cmp, args, _) ->
       (Iinttest(Isigned cmp), Ctuple args)
   | Cop(Ccmpa cmp, [arg1; Cconst_pointer n], _) when self#is_immediate n ->
@@ -523,13 +523,13 @@ method select_condition = function
   | Cop(Ccmpa cmp, [arg1; Cconst_int n], _) when self#is_immediate n ->
       (Iinttest_imm(Iunsigned cmp, n), arg1)
   | Cop(Ccmpa cmp, [Cconst_pointer n; arg2], _) when self#is_immediate n ->
-      (Iinttest_imm(Iunsigned(swap_comparison cmp), n), arg2)
+      (Iinttest_imm(Iunsigned(swap_integer_comparison cmp), n), arg2)
   | Cop(Ccmpa cmp, [Cconst_int n; arg2], _) when self#is_immediate n ->
-      (Iinttest_imm(Iunsigned(swap_comparison cmp), n), arg2)
+      (Iinttest_imm(Iunsigned(swap_integer_comparison cmp), n), arg2)
   | Cop(Ccmpa cmp, args, _) ->
       (Iinttest(Iunsigned cmp), Ctuple args)
   | Cop(Ccmpf cmp, args, _) ->
-      (Ifloattest(cmp, false), Ctuple args)
+      (Ifloattest cmp, Ctuple args)
   | Cop(Cand, [arg; Cconst_int 1], _) ->
       (Ioddtest, arg)
   | arg ->

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -185,12 +185,12 @@ let init () =
 (* Emission of one instruction *)
 
 let emit_comp = function
-| Ceq -> out opEQ    | Cneq -> out opNEQ
+| Ceq -> out opEQ    | Cne -> out opNEQ
 | Clt -> out opLTINT | Cle -> out opLEINT
 | Cgt -> out opGTINT | Cge -> out opGEINT
 
 and emit_branch_comp = function
-| Ceq -> out opBEQ    | Cneq -> out opBNEQ
+| Ceq -> out opBEQ    | Cne -> out opBNEQ
 | Clt -> out opBLTINT | Cle -> out opBLEINT
 | Cgt -> out opBGTINT | Cge -> out opBGEINT
 
@@ -316,7 +316,7 @@ let rec emit = function
         emit rem
   | Kpush::Kconst k::Kintcomp c::Kbranchifnot lbl::rem
       when is_immed_const k ->
-        emit_branch_comp (negate_comparison c) ;
+        emit_branch_comp (negate_integer_comparison c) ;
         out_const k ;
         out_label lbl ;
         emit rem

--- a/bytecomp/instruct.ml
+++ b/bytecomp/instruct.ml
@@ -93,7 +93,7 @@ type instruction =
   | Kccall of string * int
   | Knegint | Kaddint | Ksubint | Kmulint | Kdivint | Kmodint
   | Kandint | Korint | Kxorint | Klslint | Klsrint | Kasrint
-  | Kintcomp of comparison
+  | Kintcomp of integer_comparison
   | Koffsetint of int
   | Koffsetref of int
   | Kisint

--- a/bytecomp/instruct.mli
+++ b/bytecomp/instruct.mli
@@ -113,7 +113,7 @@ type instruction =
   | Kccall of string * int
   | Knegint | Kaddint | Ksubint | Kmulint | Kdivint | Kmodint
   | Kandint | Korint | Kxorint | Klslint | Klsrint | Kasrint
-  | Kintcomp of comparison
+  | Kintcomp of integer_comparison
   | Koffsetint of int
   | Koffsetref of int
   | Kisint

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -80,14 +80,14 @@ type primitive =
   | Pdivint of is_safe | Pmodint of is_safe
   | Pandint | Porint | Pxorint
   | Plslint | Plsrint | Pasrint
-  | Pintcomp of comparison
+  | Pintcomp of integer_comparison
   | Poffsetint of int
   | Poffsetref of int
   (* Float operations *)
   | Pintoffloat | Pfloatofint
   | Pnegfloat | Pabsfloat
   | Paddfloat | Psubfloat | Pmulfloat | Pdivfloat
-  | Pfloatcomp of comparison
+  | Pfloatcomp of float_comparison
   (* String operations *)
   | Pstringlength | Pstringrefu  | Pstringrefs
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
@@ -121,7 +121,7 @@ type primitive =
   | Plslbint of boxed_integer
   | Plsrbint of boxed_integer
   | Pasrbint of boxed_integer
-  | Pbintcomp of boxed_integer * comparison
+  | Pbintcomp of boxed_integer * integer_comparison
   (* Operations on big arrays: (unsafe, #dimensions, kind, layout) *)
   | Pbigarrayref of bool * int * bigarray_kind * bigarray_layout
   | Pbigarrayset of bool * int * bigarray_kind * bigarray_layout
@@ -152,8 +152,11 @@ type primitive =
   (* Inhibition of optimisation *)
   | Popaque
 
-and comparison =
-    Ceq | Cneq | Clt | Cgt | Cle | Cge
+and integer_comparison =
+    Ceq | Cne | Clt | Cgt | Cle | Cge
+
+and float_comparison =
+    CFeq | CFneq | CFlt | CFnlt | CFgt | CFngt | CFle | CFnle | CFge | CFnge
 
 and value_kind =
     Pgenval | Pfloatval | Pboxedintval of boxed_integer | Pintval
@@ -666,15 +669,45 @@ let bind str var exp body =
     Lvar var' when Ident.same var var' -> body
   | _ -> Llet(str, Pgenval, var, exp, body)
 
-and commute_comparison = function
-| Ceq -> Ceq| Cneq -> Cneq
-| Clt -> Cgt | Cle -> Cge
-| Cgt -> Clt | Cge -> Cle
+let negate_integer_comparison = function
+  | Ceq -> Cne
+  | Cne -> Ceq
+  | Clt -> Cge
+  | Cle -> Cgt
+  | Cgt -> Cle
+  | Cge -> Clt
 
-and negate_comparison = function
-| Ceq -> Cneq| Cneq -> Ceq
-| Clt -> Cge | Cle -> Cgt
-| Cgt -> Cle | Cge -> Clt
+let swap_integer_comparison = function
+  | Ceq -> Ceq
+  | Cne -> Cne
+  | Clt -> Cgt
+  | Cle -> Cge
+  | Cgt -> Clt
+  | Cge -> Cle
+
+let negate_float_comparison = function
+  | CFeq -> CFneq
+  | CFneq -> CFeq
+  | CFlt -> CFnlt
+  | CFnlt -> CFlt
+  | CFgt -> CFngt
+  | CFngt -> CFgt
+  | CFle -> CFnle
+  | CFnle -> CFle
+  | CFge -> CFnge
+  | CFnge -> CFge
+
+let swap_float_comparison = function
+  | CFeq -> CFeq
+  | CFneq -> CFneq
+  | CFlt -> CFgt
+  | CFnlt -> CFngt
+  | CFle -> CFge
+  | CFnle -> CFnge
+  | CFgt -> CFlt
+  | CFngt -> CFnlt
+  | CFge -> CFle
+  | CFnge -> CFnle
 
 let raise_kind = function
   | Raise_regular -> "raise"

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -85,14 +85,14 @@ type primitive =
   | Pdivint of is_safe | Pmodint of is_safe
   | Pandint | Porint | Pxorint
   | Plslint | Plsrint | Pasrint
-  | Pintcomp of comparison
+  | Pintcomp of integer_comparison
   | Poffsetint of int
   | Poffsetref of int
   (* Float operations *)
   | Pintoffloat | Pfloatofint
   | Pnegfloat | Pabsfloat
   | Paddfloat | Psubfloat | Pmulfloat | Pdivfloat
-  | Pfloatcomp of comparison
+  | Pfloatcomp of float_comparison
   (* String operations *)
   | Pstringlength | Pstringrefu  | Pstringrefs
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
@@ -129,7 +129,7 @@ type primitive =
   | Plslbint of boxed_integer
   | Plsrbint of boxed_integer
   | Pasrbint of boxed_integer
-  | Pbintcomp of boxed_integer * comparison
+  | Pbintcomp of boxed_integer * integer_comparison
   (* Operations on big arrays: (unsafe, #dimensions, kind, layout) *)
   | Pbigarrayref of bool * int * bigarray_kind * bigarray_layout
   | Pbigarrayset of bool * int * bigarray_kind * bigarray_layout
@@ -160,8 +160,11 @@ type primitive =
   (* Inhibition of optimisation *)
   | Popaque
 
-and comparison =
-    Ceq | Cneq | Clt | Cgt | Cle | Cge
+and integer_comparison =
+    Ceq | Cne | Clt | Cgt | Cle | Cge
+
+and float_comparison =
+    CFeq | CFneq | CFlt | CFnlt | CFgt | CFngt | CFle | CFnle | CFge | CFnge
 
 and array_kind =
     Pgenarray | Paddrarray | Pintarray | Pfloatarray
@@ -342,8 +345,11 @@ val subst_lambda: lambda Ident.tbl -> lambda -> lambda
 val map : (lambda -> lambda) -> lambda -> lambda
 val bind : let_kind -> Ident.t -> lambda -> lambda -> lambda
 
-val commute_comparison : comparison -> comparison
-val negate_comparison : comparison -> comparison
+val negate_integer_comparison : integer_comparison -> integer_comparison
+val swap_integer_comparison : integer_comparison -> integer_comparison
+
+val negate_float_comparison : float_comparison -> float_comparison
+val swap_float_comparison : float_comparison -> float_comparison
 
 val default_function_attribute : function_attribute
 val default_stub_attribute : function_attribute

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1901,7 +1901,7 @@ module SArg = struct
   type primitive = Lambda.primitive
 
   let eqint = Pintcomp Ceq
-  let neint = Pintcomp Cneq
+  let neint = Pintcomp Cne
   let leint = Pintcomp Cle
   let ltint = Pintcomp Clt
   let geint = Pintcomp Cge
@@ -2254,22 +2254,22 @@ let combine_constant loc arg cst partial ctx def
     | Const_float _ ->
         make_test_sequence loc
           fail
-          (Pfloatcomp Cneq) (Pfloatcomp Clt)
+          (Pfloatcomp CFneq) (Pfloatcomp CFlt)
           arg const_lambda_list
     | Const_int32 _ ->
         make_test_sequence loc
           fail
-          (Pbintcomp(Pint32, Cneq)) (Pbintcomp(Pint32, Clt))
+          (Pbintcomp(Pint32, Cne)) (Pbintcomp(Pint32, Clt))
           arg const_lambda_list
     | Const_int64 _ ->
         make_test_sequence loc
           fail
-          (Pbintcomp(Pint64, Cneq)) (Pbintcomp(Pint64, Clt))
+          (Pbintcomp(Pint64, Cne)) (Pbintcomp(Pint64, Clt))
           arg const_lambda_list
     | Const_nativeint _ ->
         make_test_sequence loc
           fail
-          (Pbintcomp(Pnativeint, Cneq)) (Pbintcomp(Pnativeint, Clt))
+          (Pbintcomp(Pnativeint, Cne)) (Pbintcomp(Pnativeint, Clt))
           arg const_lambda_list
   in lambda1,jumps_union local_jumps total
 

--- a/bytecomp/printinstr.ml
+++ b/bytecomp/printinstr.ml
@@ -87,7 +87,7 @@ let instruction ppf = function
   | Klsrint -> fprintf ppf "\tlsrint"
   | Kasrint -> fprintf ppf "\tasrint"
   | Kintcomp Ceq -> fprintf ppf "\teqint"
-  | Kintcomp Cneq -> fprintf ppf "\tneqint"
+  | Kintcomp Cne -> fprintf ppf "\tneqint"
   | Kintcomp Clt -> fprintf ppf "\tltint"
   | Kintcomp Cgt -> fprintf ppf "\tgtint"
   | Kintcomp Cle -> fprintf ppf "\tleint"

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -128,6 +128,26 @@ let block_shape ppf shape = match shape with
         t;
       Format.fprintf ppf ")"
 
+let integer_comparison ppf = function
+  | Ceq -> fprintf ppf "=="
+  | Cne -> fprintf ppf "!="
+  | Clt -> fprintf ppf "<"
+  | Cle -> fprintf ppf "<="
+  | Cgt -> fprintf ppf ">"
+  | Cge -> fprintf ppf ">="
+
+let float_comparison ppf = function
+  | CFeq -> fprintf ppf "==."
+  | CFneq -> fprintf ppf "!=."
+  | CFlt -> fprintf ppf "<."
+  | CFnlt -> fprintf ppf "!<."
+  | CFle -> fprintf ppf "<=."
+  | CFnle -> fprintf ppf "!<=."
+  | CFgt -> fprintf ppf ">."
+  | CFngt -> fprintf ppf "!>."
+  | CFge -> fprintf ppf ">=."
+  | CFnge -> fprintf ppf "!>=."
+
 let primitive ppf = function
   | Pidentity -> fprintf ppf "id"
   | Pbytes_to_string -> fprintf ppf "bytes_to_string"
@@ -200,12 +220,7 @@ let primitive ppf = function
   | Plslint -> fprintf ppf "lsl"
   | Plsrint -> fprintf ppf "lsr"
   | Pasrint -> fprintf ppf "asr"
-  | Pintcomp(Ceq) -> fprintf ppf "=="
-  | Pintcomp(Cneq) -> fprintf ppf "!="
-  | Pintcomp(Clt) -> fprintf ppf "<"
-  | Pintcomp(Cle) -> fprintf ppf "<="
-  | Pintcomp(Cgt) -> fprintf ppf ">"
-  | Pintcomp(Cge) -> fprintf ppf ">="
+  | Pintcomp(cmp) -> integer_comparison ppf cmp
   | Poffsetint n -> fprintf ppf "%i+" n
   | Poffsetref n -> fprintf ppf "+:=%i"n
   | Pintoffloat -> fprintf ppf "int_of_float"
@@ -216,12 +231,7 @@ let primitive ppf = function
   | Psubfloat -> fprintf ppf "-."
   | Pmulfloat -> fprintf ppf "*."
   | Pdivfloat -> fprintf ppf "/."
-  | Pfloatcomp(Ceq) -> fprintf ppf "==."
-  | Pfloatcomp(Cneq) -> fprintf ppf "!=."
-  | Pfloatcomp(Clt) -> fprintf ppf "<."
-  | Pfloatcomp(Cle) -> fprintf ppf "<=."
-  | Pfloatcomp(Cgt) -> fprintf ppf ">."
-  | Pfloatcomp(Cge) -> fprintf ppf ">=."
+  | Pfloatcomp(cmp) -> float_comparison ppf cmp
   | Pstringlength -> fprintf ppf "string.length"
   | Pstringrefu -> fprintf ppf "string.unsafe_get"
   | Pstringrefs -> fprintf ppf "string.get"
@@ -276,7 +286,7 @@ let primitive ppf = function
   | Plsrbint bi -> print_boxed_integer "lsr" ppf bi
   | Pasrbint bi -> print_boxed_integer "asr" ppf bi
   | Pbintcomp(bi, Ceq) -> print_boxed_integer "==" ppf bi
-  | Pbintcomp(bi, Cneq) -> print_boxed_integer "!=" ppf bi
+  | Pbintcomp(bi, Cne) -> print_boxed_integer "!=" ppf bi
   | Pbintcomp(bi, Clt) -> print_boxed_integer "<" ppf bi
   | Pbintcomp(bi, Cgt) -> print_boxed_integer ">" ppf bi
   | Pbintcomp(bi, Cle) -> print_boxed_integer "<=" ppf bi

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -70,7 +70,7 @@ let comparisons_table = create_hashtable 11 [
   "%equal",
       (Pccall(Primitive.simple ~name:"caml_equal" ~arity:2 ~alloc:true),
        Pintcomp Ceq,
-       Pfloatcomp Ceq,
+       Pfloatcomp CFeq,
        Pccall(Primitive.simple ~name:"caml_string_equal" ~arity:2
                 ~alloc:false),
        Pccall(Primitive.simple ~name:"caml_bytes_equal" ~arity:2
@@ -81,20 +81,20 @@ let comparisons_table = create_hashtable 11 [
        true);
   "%notequal",
       (Pccall(Primitive.simple ~name:"caml_notequal" ~arity:2 ~alloc:true),
-       Pintcomp Cneq,
-       Pfloatcomp Cneq,
+       Pintcomp Cne,
+       Pfloatcomp CFneq,
        Pccall(Primitive.simple ~name:"caml_string_notequal" ~arity:2
                 ~alloc:false),
        Pccall(Primitive.simple ~name:"caml_bytes_notequal" ~arity:2
                 ~alloc:false),
-       Pbintcomp(Pnativeint, Cneq),
-       Pbintcomp(Pint32, Cneq),
-       Pbintcomp(Pint64, Cneq),
+       Pbintcomp(Pnativeint, Cne),
+       Pbintcomp(Pint32, Cne),
+       Pbintcomp(Pint64, Cne),
        true);
   "%lessthan",
       (Pccall(Primitive.simple ~name:"caml_lessthan" ~arity:2 ~alloc:true),
        Pintcomp Clt,
-       Pfloatcomp Clt,
+       Pfloatcomp CFlt,
        Pccall(Primitive.simple ~name:"caml_string_lessthan" ~arity:2
                 ~alloc:false),
        Pccall(Primitive.simple ~name:"caml_bytes_lessthan" ~arity:2
@@ -106,7 +106,7 @@ let comparisons_table = create_hashtable 11 [
   "%greaterthan",
       (Pccall(Primitive.simple ~name:"caml_greaterthan" ~arity:2 ~alloc:true),
        Pintcomp Cgt,
-       Pfloatcomp Cgt,
+       Pfloatcomp CFgt,
        Pccall(Primitive.simple ~name:"caml_string_greaterthan" ~arity:2
                 ~alloc: false),
        Pccall(Primitive.simple ~name:"caml_bytes_greaterthan" ~arity:2
@@ -118,7 +118,7 @@ let comparisons_table = create_hashtable 11 [
   "%lessequal",
       (Pccall(Primitive.simple ~name:"caml_lessequal" ~arity:2 ~alloc:true),
        Pintcomp Cle,
-       Pfloatcomp Cle,
+       Pfloatcomp CFle,
        Pccall(Primitive.simple ~name:"caml_string_lessequal" ~arity:2
                 ~alloc:false),
        Pccall(Primitive.simple ~name:"caml_bytes_lessequal" ~arity:2
@@ -130,7 +130,7 @@ let comparisons_table = create_hashtable 11 [
   "%greaterequal",
       (Pccall(Primitive.simple ~name:"caml_greaterequal" ~arity:2 ~alloc:true),
        Pintcomp Cge,
-       Pfloatcomp Cge,
+       Pfloatcomp CFge,
        Pccall(Primitive.simple ~name:"caml_string_greaterequal" ~arity:2
                 ~alloc:false),
        Pccall(Primitive.simple ~name:"caml_bytes_greaterequal" ~arity:2
@@ -209,7 +209,7 @@ let primitives_table = create_hashtable 57 [
   "%lsrint", Plsrint;
   "%asrint", Pasrint;
   "%eq", Pintcomp Ceq;
-  "%noteq", Pintcomp Cneq;
+  "%noteq", Pintcomp Cne;
   "%ltint", Pintcomp Clt;
   "%leint", Pintcomp Cle;
   "%gtint", Pintcomp Cgt;
@@ -224,12 +224,12 @@ let primitives_table = create_hashtable 57 [
   "%subfloat", Psubfloat;
   "%mulfloat", Pmulfloat;
   "%divfloat", Pdivfloat;
-  "%eqfloat", Pfloatcomp Ceq;
-  "%noteqfloat", Pfloatcomp Cneq;
-  "%ltfloat", Pfloatcomp Clt;
-  "%lefloat", Pfloatcomp Cle;
-  "%gtfloat", Pfloatcomp Cgt;
-  "%gefloat", Pfloatcomp Cge;
+  "%eqfloat", Pfloatcomp CFeq;
+  "%noteqfloat", Pfloatcomp CFneq;
+  "%ltfloat", Pfloatcomp CFlt;
+  "%lefloat", Pfloatcomp CFle;
+  "%gtfloat", Pfloatcomp CFgt;
+  "%gefloat", Pfloatcomp CFge;
   "%string_length", Pstringlength;
   "%string_safe_get", Pstringrefs;
   "%string_safe_set", Pbytessets;

--- a/middle_end/simplify_boxed_integer_ops.ml
+++ b/middle_end/simplify_boxed_integer_ops.ml
@@ -73,7 +73,7 @@ end) : Simplify_boxed_integer_ops_intf.S with type t := I.t = struct
     | Porbint kind when kind = I.kind -> eval I.logor
     | Pxorbint kind when kind = I.kind -> eval I.logxor
     | Pbintcomp (kind, c) when kind = I.kind ->
-      S.const_comparison_expr expr c n1 n2
+      S.const_integer_comparison_expr expr c n1 n2
     | _ -> expr, A.value_unknown Other, C.Benefit.zero
 
   let simplify_binop_int (p : Lambda.primitive) (kind : I.t A.boxed_int)

--- a/middle_end/simplify_common.ml
+++ b/middle_end/simplify_common.ml
@@ -52,15 +52,32 @@ let const_boxed_int_expr expr t i =
     new_expr, approx, C.Benefit.remove_code_named expr C.Benefit.zero
   else expr, A.value_boxed_int t i, C.Benefit.zero
 
-let const_comparison_expr expr (cmp : Lambda.comparison) x y =
+let const_integer_comparison_expr expr (cmp : Lambda.integer_comparison) x y =
   (* Using the [Pervasives] comparison functions here in the compiler
      coincides with the definitions of such functions in the code
      compiled by the user, and is thus correct. *)
   const_bool_expr expr
     (match cmp with
      | Ceq -> x = y
-     | Cneq -> x <> y
+     | Cne -> x <> y
      | Clt -> x < y
      | Cgt -> x > y
      | Cle -> x <= y
      | Cge -> x >= y)
+
+let const_float_comparison_expr expr (cmp : Lambda.float_comparison) x y =
+  (* Using the [Pervasives] comparison functions here in the compiler
+     coincides with the definitions of such functions in the code
+     compiled by the user, and is thus correct. *)
+  const_bool_expr expr
+    (match cmp with
+     | CFeq -> x = y
+     | CFneq -> not (x = y)
+     | CFlt -> x < y
+     | CFnlt -> not (x < y)
+     | CFgt -> x > y
+     | CFngt -> not (x > y)
+     | CFle -> x <= y
+     | CFnle -> not (x <= y)
+     | CFge -> x >= y
+     | CFnge -> not (x >= y))

--- a/middle_end/simplify_common.mli
+++ b/middle_end/simplify_common.mli
@@ -58,9 +58,16 @@ val const_boxed_int_expr
   -> 'a
   -> Flambda.named * Simple_value_approx.t * Inlining_cost.Benefit.t
 
-val const_comparison_expr
+val const_integer_comparison_expr
    : Flambda.named
-  -> Lambda.comparison
+  -> Lambda.integer_comparison
+  -> 'a
+  -> 'a
+  -> Flambda.named * Simple_value_approx.t * Inlining_cost.Benefit.t
+
+val const_float_comparison_expr
+   : Flambda.named
+  -> Lambda.float_comparison
   -> 'a
   -> 'a
   -> Flambda.named * Simple_value_approx.t * Inlining_cost.Benefit.t

--- a/middle_end/simplify_primitives.ml
+++ b/middle_end/simplify_primitives.ml
@@ -115,7 +115,7 @@ let primitive (p : Lambda.primitive) (args, approxs) expr dbg ~size_int
       expr, approx, C.Benefit.zero
   | Pintcomp Ceq when phys_equal approxs ->
     S.const_bool_expr expr true
-  | Pintcomp Cneq when phys_equal approxs ->
+  | Pintcomp Cne when phys_equal approxs ->
     S.const_bool_expr expr false
     (* N.B. Having [not (phys_equal approxs)] would not on its own tell us
        anything about whether the two values concerned are unequal.  To judge
@@ -140,7 +140,7 @@ let primitive (p : Lambda.primitive) (args, approxs) expr dbg ~size_int
        invalid. *)
   | Pintcomp Ceq when phys_different approxs ->
     S.const_bool_expr expr false
-  | Pintcomp Cneq when phys_different approxs ->
+  | Pintcomp Cne when phys_different approxs ->
     S.const_bool_expr expr true
     (* If two values are structurally different we are certain they can never
        be shared*)
@@ -174,13 +174,13 @@ let primitive (p : Lambda.primitive) (args, approxs) expr dbg ~size_int
       | Plslint when shift_precond -> S.const_int_expr expr (x lsl y)
       | Plsrint when shift_precond -> S.const_int_expr expr (x lsr y)
       | Pasrint when shift_precond -> S.const_int_expr expr (x asr y)
-      | Pintcomp cmp -> S.const_comparison_expr expr cmp x y
+      | Pintcomp cmp -> S.const_integer_comparison_expr expr cmp x y
       | Pisout -> S.const_bool_expr expr (y > x || y < 0)
       | _ -> expr, A.value_unknown Other, C.Benefit.zero
       end
     | [Value_char x; Value_char y] ->
       begin match p with
-      | Pintcomp cmp -> S.const_comparison_expr expr cmp x y
+      | Pintcomp cmp -> S.const_integer_comparison_expr expr cmp x y
       | _ -> expr, A.value_unknown Other, C.Benefit.zero
       end
     | [Value_constptr x] ->
@@ -220,7 +220,7 @@ let primitive (p : Lambda.primitive) (args, approxs) expr dbg ~size_int
       | Psubfloat -> S.const_float_expr expr (n1 -. n2)
       | Pmulfloat -> S.const_float_expr expr (n1 *. n2)
       | Pdivfloat -> S.const_float_expr expr (n1 /. n2)
-      | Pfloatcomp c  -> S.const_comparison_expr expr c n1 n2
+      | Pfloatcomp c  -> S.const_float_comparison_expr expr c n1 n2
       | _ -> expr, A.value_unknown Other, C.Benefit.zero
       end
     | [A.Value_boxed_int(A.Nativeint, n)] ->

--- a/testsuite/tests/asmgen/lexcmm.mll
+++ b/testsuite/tests/asmgen/lexcmm.mll
@@ -163,6 +163,10 @@ rule token = parse
   | "!=a" { NEA }
   | "!=f" { NEF }
   | "!=" { NEI }
+  | "!>=f" { NGEF }
+  | "!>f" { NGTF }
+  | "!<=f" { NLEF }
+  | "!<f" { NLTF }
   | "]" { RBRACKET }
   | ")" { RPAREN }
   | "-f" { SUBF }

--- a/testsuite/tests/asmgen/parsecmm.mly
+++ b/testsuite/tests/asmgen/parsecmm.mly
@@ -100,6 +100,10 @@ let access_array base numelt size =
 %token NEA
 %token NEF
 %token NEI
+%token NGEF
+%token NGTF
+%token NLEF
+%token NLTF
 %token OR
 %token <int> POINTER
 %token PROJ
@@ -293,12 +297,16 @@ binaryop:
   | ADDF                        { Caddf }
   | MULF                        { Cmulf }
   | DIVF                        { Cdivf }
-  | EQF                         { Ccmpf Ceq }
-  | NEF                         { Ccmpf Cne }
-  | LTF                         { Ccmpf Clt }
-  | LEF                         { Ccmpf Cle }
-  | GTF                         { Ccmpf Cgt }
-  | GEF                         { Ccmpf Cge }
+  | EQF                         { Ccmpf CFeq }
+  | NEF                         { Ccmpf CFneq }
+  | LTF                         { Ccmpf CFlt }
+  | NLTF                        { Ccmpf CFnlt }
+  | LEF                         { Ccmpf CFle }
+  | NLEF                        { Ccmpf CFnle }
+  | GTF                         { Ccmpf CFgt }
+  | NGTF                        { Ccmpf CFngt }
+  | GEF                         { Ccmpf CFge }
+  | NGEF                        { Ccmpf CFnge }
   | CHECKBOUND                  { Ccheckbound }
   | MULH                        { Cmulhi }
 ;

--- a/testsuite/tests/basic-float/float_compare.ml
+++ b/testsuite/tests/basic-float/float_compare.ml
@@ -1,6 +1,112 @@
 
-let compare_nan () =
-  not (nan < 0.0)
+let equal (x : float) (y : float) =
+  x, "=", y, (x = y)
 [@@inline never]
 
-let x = print_endline (string_of_bool (compare_nan ()))
+let not_equal (x : float) (y : float) =
+  x, "!=", y, (x <> y)
+[@@inline never]
+
+let less_than (x : float) (y : float) =
+  x, "<", y, (x < y)
+[@@inline never]
+
+let not_less_than (x : float) (y : float) =
+  x, "!<", y, not (x < y)
+[@@inline never]
+
+let less_equal (x : float) (y : float) =
+  x, "<=", y, (x <= y)
+[@@inline never]
+
+let not_less_equal (x : float) (y : float) =
+  x, "!<=", y, not (x <= y)
+[@@inline never]
+
+let greater_than (x : float) (y : float) =
+  x, ">", y, (x > y)
+[@@inline never]
+
+let not_greater_than (x : float) (y : float) =
+  x, "!>", y, not (x > y)
+[@@inline never]
+
+let greater_equal (x : float) (y : float) =
+  x, ">=", y, (x >= y)
+[@@inline never]
+
+let not_greater_equal (x : float) (y : float) =
+  x, "!>=", y, not (x >= y)
+[@@inline never]
+
+let show (x, op, y, b) =
+  print_float x;
+  print_string " ";
+  print_string op;
+  print_string " ";
+  print_float y;
+  print_string ": ";
+  print_endline (string_of_bool b)
+
+let print_line () =
+  print_endline "------------------"
+
+let () = show (equal 1.0 2.0)
+let () = show (equal 1.0 1.0)
+let () = show (equal 2.0 1.0)
+let () = show (equal 1.0 nan)
+let () = print_line ()
+
+let () = show (not_equal 1.0 2.0)
+let () = show (not_equal 1.0 1.0)
+let () = show (not_equal 2.0 1.0)
+let () = show (not_equal 1.0 nan)
+let () = print_line ()
+
+let () = show (less_than 1.0 2.0)
+let () = show (less_than 1.0 1.0)
+let () = show (less_than 2.0 1.0)
+let () = show (less_than 1.0 nan)
+let () = print_line ()
+
+let () = show (not_less_than 1.0 2.0)
+let () = show (not_less_than 1.0 1.0)
+let () = show (not_less_than 2.0 1.0)
+let () = show (not_less_than 1.0 nan)
+let () = print_line ()
+
+let () = show (less_equal 1.0 2.0)
+let () = show (less_equal 1.0 1.0)
+let () = show (less_equal 2.0 1.0)
+let () = show (less_equal 1.0 nan)
+let () = print_line ()
+
+let () = show (not_less_equal 1.0 2.0)
+let () = show (not_less_equal 1.0 1.0)
+let () = show (not_less_equal 2.0 1.0)
+let () = show (not_less_equal 1.0 nan)
+let () = print_line ()
+
+let () = show (greater_than 1.0 2.0)
+let () = show (greater_than 1.0 1.0)
+let () = show (greater_than 2.0 1.0)
+let () = show (greater_than 1.0 nan)
+let () = print_line ()
+
+let () = show (not_greater_than 1.0 2.0)
+let () = show (not_greater_than 1.0 1.0)
+let () = show (not_greater_than 2.0 1.0)
+let () = show (not_greater_than 1.0 nan)
+let () = print_line ()
+
+let () = show (greater_equal 1.0 2.0)
+let () = show (greater_equal 1.0 1.0)
+let () = show (greater_equal 2.0 1.0)
+let () = show (greater_equal 1.0 nan)
+let () = print_line ()
+
+let () = show (not_greater_equal 1.0 2.0)
+let () = show (not_greater_equal 1.0 1.0)
+let () = show (not_greater_equal 2.0 1.0)
+let () = show (not_greater_equal 1.0 nan)
+let () = print_line ()

--- a/testsuite/tests/basic-float/float_compare.reference
+++ b/testsuite/tests/basic-float/float_compare.reference
@@ -16,7 +16,7 @@
 1. !< 2.: false
 1. !< 1.: true
 2. !< 1.: true
-1. !< nan: false
+1. !< nan: true
 ------------------
 1. <= 2.: true
 1. <= 1.: true
@@ -26,7 +26,7 @@
 1. !<= 2.: false
 1. !<= 1.: false
 2. !<= 1.: true
-1. !<= nan: false
+1. !<= nan: true
 ------------------
 1. > 2.: false
 1. > 1.: false
@@ -36,7 +36,7 @@
 1. !> 2.: true
 1. !> 1.: true
 2. !> 1.: false
-1. !> nan: false
+1. !> nan: true
 ------------------
 1. >= 2.: false
 1. >= 1.: true
@@ -46,5 +46,5 @@
 1. !>= 2.: true
 1. !>= 1.: false
 2. !>= 1.: false
-1. !>= nan: false
+1. !>= nan: true
 ------------------

--- a/testsuite/tests/basic-float/float_compare.reference
+++ b/testsuite/tests/basic-float/float_compare.reference
@@ -1,1 +1,50 @@
-true
+1. = 2.: false
+1. = 1.: true
+2. = 1.: false
+1. = nan: false
+------------------
+1. != 2.: true
+1. != 1.: false
+2. != 1.: true
+1. != nan: true
+------------------
+1. < 2.: true
+1. < 1.: false
+2. < 1.: false
+1. < nan: false
+------------------
+1. !< 2.: false
+1. !< 1.: true
+2. !< 1.: true
+1. !< nan: false
+------------------
+1. <= 2.: true
+1. <= 1.: true
+2. <= 1.: false
+1. <= nan: false
+------------------
+1. !<= 2.: false
+1. !<= 1.: false
+2. !<= 1.: true
+1. !<= nan: false
+------------------
+1. > 2.: false
+1. > 1.: false
+2. > 1.: true
+1. > nan: false
+------------------
+1. !> 2.: true
+1. !> 1.: true
+2. !> 1.: false
+1. !> nan: false
+------------------
+1. >= 2.: false
+1. >= 1.: true
+2. >= 1.: true
+1. >= nan: false
+------------------
+1. !>= 2.: true
+1. !>= 1.: false
+2. !>= 1.: false
+1. !>= nan: false
+------------------


### PR DESCRIPTION
This PR fixes the same problem as #1470 but rather than remove the optimisation of negated float comparisons it fixes it, and tries to ensure that similar bugs are not introduced again. The main part of the patch is replacing the `comparison` type:

```
and comparison =
    Ceq | Cne | Clt | Cgt | Cle | Cge
```

with two separate comparison types:

```ocaml
and integer_comparison =
    Ceq | Cne | Clt | Cgt | Cle | Cge

and basic_float_comparison =
    CFeq | CFlt | CFgt | CFle | CFge

and float_comparison =
  { basic : basic_float_comparison;
    negated : bool; }
```

with the `float_comparison` type now supporting all the negated comparisons as well.

This change is made to both `Lambda` and `Cmm`. These types are also introduced to `Mach`, but in that case it is merely a refactoring of what was already there since `Mach` could already represent the negated float comparisons.

An obvious benefit of this change is that it replaces the negation functions on comparisons:

```ocaml
val negate_comparison : comparison -> comparison
```

which were incorrect for float comparisons, with two correct functions:

```ocaml
val negate_integer_comparison : integer_comparison -> integer_comparison

val negate_float_comparison : float_comparison -> float_comparison
```