### PR TITLE
Improve error reporting for ill-typed applicative functor type

### DIFF
--- a/.depend
+++ b/.depend
@@ -475,18 +475,20 @@ typing/types.cmi : typing/primitive.cmi typing/path.cmi \
 typing/typetexp.cmo : typing/types.cmi typing/typedtree.cmi utils/tbl.cmi \
     typing/printtyp.cmi typing/predef.cmi typing/path.cmi \
     parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
-    parsing/location.cmi typing/env.cmi typing/ctype.cmi utils/clflags.cmi \
-    parsing/builtin_attributes.cmi typing/btype.cmi parsing/asttypes.cmi \
-    parsing/ast_helper.cmi typing/typetexp.cmi
+    parsing/location.cmi typing/includemod.cmi typing/env.cmi \
+    typing/ctype.cmi utils/clflags.cmi parsing/builtin_attributes.cmi \
+    typing/btype.cmi parsing/asttypes.cmi parsing/ast_helper.cmi \
+    typing/typetexp.cmi
 typing/typetexp.cmx : typing/types.cmx typing/typedtree.cmx utils/tbl.cmx \
     typing/printtyp.cmx typing/predef.cmx typing/path.cmx \
     parsing/parsetree.cmi utils/misc.cmx parsing/longident.cmx \
-    parsing/location.cmx typing/env.cmx typing/ctype.cmx utils/clflags.cmx \
-    parsing/builtin_attributes.cmx typing/btype.cmx parsing/asttypes.cmi \
-    parsing/ast_helper.cmx typing/typetexp.cmi
+    parsing/location.cmx typing/includemod.cmx typing/env.cmx \
+    typing/ctype.cmx utils/clflags.cmx parsing/builtin_attributes.cmx \
+    typing/btype.cmx parsing/asttypes.cmi parsing/ast_helper.cmx \
+    typing/typetexp.cmi
 typing/typetexp.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
     parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/env.cmi parsing/asttypes.cmi
+    typing/includemod.cmi typing/env.cmi parsing/asttypes.cmi
 typing/untypeast.cmo : typing/typedtree.cmi typing/path.cmi \
     parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
     parsing/location.cmi typing/ident.cmi typing/env.cmi parsing/asttypes.cmi \

--- a/Changes
+++ b/Changes
@@ -12,10 +12,6 @@ Working version
 
 ### Type system:
 
-- GPR#1370: Fix code duplication in Cmmgen
-  (Vincent Laviron, with help from Pierre Chambart,
-   reviews by Gabriel Scherer and Luc Maranget)
-
 - GPR#1469: Use the information from [@@immediate] annotations when
   computing whether a type can be [@@unboxed]
   (Damien Doligez, report by Stephan Muenzel, review by ...)
@@ -49,6 +45,10 @@ Working version
   (Arthur Charguéraud and Armaël Guéneau, with help from Gabriel Scherer and
   Frédéric Bour)
 
+- GPR#1491: Improve error reporting for ill-typed applicative functor
+  types, F(M).t.
+  (Valentin Gatien-Baron, review by Florian Angeletti and Gabriel Radanne)
+
 - GPR#1496: Refactor the code printing explanation for unification type errors,
   in order to avoid duplicating pattern matches
   (Armaël Guéneau, review by Florian Angeletti and Gabriel Scherer)
@@ -59,6 +59,10 @@ Working version
   Florian Angeletti and Gabriel Radanne)
 
 ### Code generation and optimizations:
+
+- GPR#1370: Fix code duplication in Cmmgen
+  (Vincent Laviron, with help from Pierre Chambart,
+   reviews by Gabriel Scherer and Luc Maranget)
 
 ### Runtime system:
 

--- a/Changes
+++ b/Changes
@@ -12,6 +12,9 @@ Working version
 
 ### Type system:
 
+- MPR#7611, GPR#1491: reject the use of generative functors as applicative
+  (Valentin Gatien-Baron)
+
 - GPR#1469: Use the information from [@@immediate] annotations when
   computing whether a type can be [@@unboxed]
   (Damien Doligez, report by Stephan Muenzel, review by ...)

--- a/testsuite/tests/typing-modules/Test.ml
+++ b/testsuite/tests/typing-modules/Test.ml
@@ -119,5 +119,5 @@ module F : functor (X : sig  end) -> sig val x : int end
 Line _, characters 0-3:
   F.x;; (* fail *)
   ^^^
-Error: The module F is a functor, not a structure
+Error: The module F is a functor, it cannot have any components
 |}];;

--- a/testsuite/tests/typing-modules/applicative_functor_type.ml
+++ b/testsuite/tests/typing-modules/applicative_functor_type.ml
@@ -19,7 +19,7 @@ type t = Set.Make(M).t
 Line _, characters 9-22:
   type t = Set.Make(M).t
            ^^^^^^^^^^^^^
-Error: Ill-typed functor application Set.Make(M)
+Error: The type of M does not match Set.Make's parameter
        Modules do not match:
          sig type t = M.t val equal : 'a -> 'a -> bool end
        is not included in
@@ -43,7 +43,7 @@ type t = F(M).t
 Line _, characters 9-15:
   type t = F(M).t
            ^^^^^^
-Error: Ill-typed functor application F(M)
+Error: The type of M does not match F's parameter
        Modules do not match:
          sig type t = M.t val equal : 'a -> 'a -> bool end
        is not included in

--- a/testsuite/tests/typing-modules/applicative_functor_type.ml
+++ b/testsuite/tests/typing-modules/applicative_functor_type.ml
@@ -1,0 +1,53 @@
+(* TEST
+   * expect
+*)
+
+type t = Set.Make(String).t
+[%%expect{|
+type t = Set.Make(String).t
+|} ]
+
+
+(* Check the error messages of an ill-typed applicatived functor type. *)
+module M = struct type t let equal = (=) end
+[%%expect{|
+module M : sig type t val equal : 'a -> 'a -> bool end
+|} ]
+
+type t = Set.Make(M).t
+[%%expect{|
+Line _, characters 9-22:
+  type t = Set.Make(M).t
+           ^^^^^^^^^^^^^
+Error: Ill-typed functor application Set.Make(M)
+|} ]
+
+
+(* We would report the wrong error here if we didn't strengthen the
+   type of the argument (type t wouldn't match). *)
+module F(X : sig type t = M.t val equal : unit end)
+  = struct type t end
+[%%expect{|
+module F :
+  functor (X : sig type t = M.t val equal : unit end) -> sig type t end
+|} ]
+
+type t = F(M).t
+[%%expect{|
+Line _, characters 9-15:
+  type t = F(M).t
+           ^^^^^^
+Error: Ill-typed functor application F(M)
+|} ]
+
+
+(* We can use generative functors as applicative (bug MPR#7611). *)
+module Generative() = struct type t end
+[%%expect{|
+module Generative : functor () -> sig type t end
+|}]
+
+type t = Generative(M).t
+[%%expect{|
+type t = Generative(M).t
+|}]

--- a/testsuite/tests/typing-modules/applicative_functor_type.ml
+++ b/testsuite/tests/typing-modules/applicative_functor_type.ml
@@ -20,6 +20,12 @@ Line _, characters 9-22:
   type t = Set.Make(M).t
            ^^^^^^^^^^^^^
 Error: Ill-typed functor application Set.Make(M)
+       Modules do not match:
+         sig type t = M.t val equal : 'a -> 'a -> bool end
+       is not included in
+         Set.OrderedType
+       The value `compare' is required but not provided
+       File "set.mli", line 52, characters 4-31: Expected declaration
 |} ]
 
 
@@ -38,6 +44,14 @@ Line _, characters 9-15:
   type t = F(M).t
            ^^^^^^
 Error: Ill-typed functor application F(M)
+       Modules do not match:
+         sig type t = M.t val equal : 'a -> 'a -> bool end
+       is not included in
+         sig type t = M.t val equal : unit end
+       Values do not match:
+         val equal : 'a -> 'a -> bool
+       is not included in
+         val equal : unit
 |} ]
 
 

--- a/testsuite/tests/typing-modules/applicative_functor_type.ml
+++ b/testsuite/tests/typing-modules/applicative_functor_type.ml
@@ -55,7 +55,7 @@ Error: The type of M does not match F's parameter
 |} ]
 
 
-(* We can use generative functors as applicative (bug MPR#7611). *)
+(* MPR#7611 *)
 module Generative() = struct type t end
 [%%expect{|
 module Generative : functor () -> sig type t end
@@ -63,5 +63,9 @@ module Generative : functor () -> sig type t end
 
 type t = Generative(M).t
 [%%expect{|
-type t = Generative(M).t
+Line _, characters 9-24:
+  type t = Generative(M).t
+           ^^^^^^^^^^^^^^^
+Error: Generative is a generative functor, and so cannot be applied in type
+       expressions
 |}]

--- a/testsuite/tests/typing-modules/applicative_functor_type.ml
+++ b/testsuite/tests/typing-modules/applicative_functor_type.ml
@@ -66,6 +66,18 @@ type t = Generative(M).t
 Line _, characters 9-24:
   type t = Generative(M).t
            ^^^^^^^^^^^^^^^
-Error: Generative is a generative functor, and so cannot be applied in type
+Error: The functor Generative is generative, it cannot be applied in type
        expressions
+|}]
+
+
+
+module F(X : sig module type S module F : S end) = struct
+  type t = X.F(Parsing).t
+end
+[%%expect{|
+Line _, characters 11-25:
+    type t = X.F(Parsing).t
+             ^^^^^^^^^^^^^^
+Error: The module X.F is abstract, it cannot be applied
 |}]

--- a/testsuite/tests/typing-modules/ocamltests
+++ b/testsuite/tests/typing-modules/ocamltests
@@ -1,4 +1,5 @@
 aliases.ml
+applicative_functor_type.ml
 firstclass.ml
 generative.ml
 pr5911.ml

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1136,7 +1136,9 @@ let rec lookup_module_descr_aux ?loc ~mark lid env =
       begin match get_components desc1 with
         Functor_comps f ->
           let loc = match loc with Some l -> l | None -> Location.none in
-          Misc.may (!check_modtype_inclusion ~loc env mty2 p2) f.fcomp_arg;
+          (match f.fcomp_arg with
+          | None ->  raise Not_found (* PR#7611 *)
+          | Some arg -> !check_modtype_inclusion ~loc env mty2 p2 arg);
           (Papply(p1, p2), !components_of_functor_appl' f env p1 p2)
       | Structure_comps _ ->
           raise Not_found
@@ -1204,7 +1206,9 @@ and lookup_module ~load ?loc ~mark lid env : Path.t =
       begin match get_components desc1 with
         Functor_comps f ->
           let loc = match loc with Some l -> l | None -> Location.none in
-          Misc.may (!check_modtype_inclusion ~loc env mty2 p2) f.fcomp_arg;
+          (match f.fcomp_arg with
+          | None -> raise Not_found (* PR#7611 *)
+          | Some arg -> (!check_modtype_inclusion ~loc env mty2 p2) arg);
           p
       | Structure_comps _ ->
           raise Not_found

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -482,14 +482,14 @@ let can_alias env path =
   no_apply path && not (Env.is_functor_arg path env)
 
 let check_modtype_inclusion ~loc env mty1 path1 mty2 =
-  try
-    let aliasable = can_alias env path1 in
-    ignore(modtypes ~loc env [] Subst.identity
-                    (Mtype.strengthen ~aliasable env mty1 path1) mty2)
-  with Error _ ->
-    raise Not_found
+  let aliasable = can_alias env path1 in
+  ignore(modtypes ~loc env [] Subst.identity
+           (Mtype.strengthen ~aliasable env mty1 path1) mty2)
 
-let _ = Env.check_modtype_inclusion := check_modtype_inclusion
+let () =
+  Env.check_modtype_inclusion := (fun ~loc a b c d ->
+    try (check_modtype_inclusion ~loc a b c d : unit)
+    with Error _ -> raise Not_found)
 
 (* Check that an implementation of a compilation unit meets its
    interface. *)

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -23,6 +23,12 @@ val modtypes:
   loc:Location.t -> Env.t ->
   module_type -> module_type -> module_coercion
 
+val check_modtype_inclusion :
+  loc:Location.t -> Env.t -> Types.module_type -> Path.t -> Types.module_type -> unit
+(** [check_modtype_inclusion ~loc env mty1 path1 mty2] checks that the
+    functor application F(M) is well typed, where mty2 is the type of
+    the argument of F and path1/mty1 is the path/unstrenghened type of M. *)
+
 val signatures: Env.t -> signature -> signature -> module_coercion
 
 val compunit:

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -214,9 +214,7 @@ let retype_applicative_functor_type ~loc env funct arg =
     | Mty_functor (_, Some mty_param, _) -> mty_param
     | _ -> assert false (* could trigger due to MPR#7611 *)
   in
-  let aliasable = not (Env.is_functor_arg arg env) in
-  ignore(Includemod.modtypes ~loc env
-           (Mtype.strengthen ~aliasable env mty_arg arg) mty_param)
+  Includemod.check_modtype_inclusion ~loc env mty_arg arg mty_param
 
 (* When doing a deep destructive substitution with type M.N.t := .., we change M
    and M.N and so we have to check that uses of the modules other than just

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -64,7 +64,8 @@ type error =
   | Unbound_class of Longident.t
   | Unbound_modtype of Longident.t
   | Unbound_cltype of Longident.t
-  | Ill_typed_functor_application of Longident.t * Includemod.error list option
+  | Ill_typed_functor_application
+      of Longident.t * Longident.t * Includemod.error list option
   | Illegal_reference_to_recursive_module
   | Access_functor_as_structure of Longident.t
   | Apply_structure_as_functor of Longident.t

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -69,6 +69,7 @@ type error =
   | Illegal_reference_to_recursive_module
   | Access_functor_as_structure of Longident.t
   | Apply_structure_as_functor of Longident.t
+  | Use_generative_functor_as_applicative of Longident.t
   | Cannot_scrape_alias of Longident.t * Path.t
   | Opened_object of Path.t option
   | Not_an_object of type_expr

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -67,9 +67,12 @@ type error =
   | Ill_typed_functor_application
       of Longident.t * Longident.t * Includemod.error list option
   | Illegal_reference_to_recursive_module
-  | Access_functor_as_structure of Longident.t
-  | Apply_structure_as_functor of Longident.t
-  | Use_generative_functor_as_applicative of Longident.t
+  | Wrong_use_of_module of Longident.t * [ `Structure_used_as_functor
+                                         | `Abstract_used_as_functor
+                                         | `Functor_used_as_structure
+                                         | `Abstract_used_as_structure
+                                         | `Generative_used_as_applicative
+                                         ]
   | Cannot_scrape_alias of Longident.t * Path.t
   | Opened_object of Path.t option
   | Not_an_object of type_expr

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -64,7 +64,7 @@ type error =
   | Unbound_class of Longident.t
   | Unbound_modtype of Longident.t
   | Unbound_cltype of Longident.t
-  | Ill_typed_functor_application of Longident.t
+  | Ill_typed_functor_application of Longident.t * Includemod.error list option
   | Illegal_reference_to_recursive_module
   | Access_functor_as_structure of Longident.t
   | Apply_structure_as_functor of Longident.t


### PR DESCRIPTION
Right now, type errors in applicative functor types are annoying to fix since they contain very little information. Here is an example of what I change:

```ocaml
type t = Set.Make(M).t
 [%%expect{|
 Line _, characters 9-22:
-Error: Ill-typed functor application Set.Make(M)
+Error: The type of M does not match Set.Make's parameter
+       Modules do not match:
+         sig type t val equal : 'a -> 'a -> bool end
+       is not included in
+         Set.OrderedType
+       The value `compare' is required but not provided
+       File "set.mli", line 52, characters 4-31: Expected declaration
 |} ]
```

The change introduces a dependency from typetexp.ml to includemod.ml, I am not sure if that's undesirable.

While I was there, I also fixed MPR#7611 and changed the wording of related error messages.