### PR TITLE
Add Filename.quote_command function

### DIFF
--- a/Changes
+++ b/Changes
@@ -40,6 +40,10 @@ Working version
    (Jacques-Henri Jourdan, review by Stephen Dolan, Gabriel Scherer and
     Damien Doligez)
 
+- #7672, #1492: Add `Filename.quote_command` to produce properly-quoted
+  commands for execution by Sys.command.
+  (Xavier Leroy, review by David Allsopp and Damien Doligez)
+
 ### Other libraries:
 
 - #1939, #2023: Implement Unix.truncate and Unix.ftruncate on Windows.

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -234,8 +234,11 @@ val system : string -> process_status
 (** Execute the given command, wait until it terminates, and return
    its termination status. The string is interpreted by the shell
    [/bin/sh] (or the command interpreter [cmd.exe] on Windows) and
-   therefore can contain redirections, quotes, variables, etc. The
-   result [WEXITED 127] indicates that the shell couldn't be
+   therefore can contain redirections, quotes, variables, etc.
+   To properly quote whitespace and shell special characters occuring
+   in file names or command arguments, the use of
+   {!Filename.quote_command} is recommended.
+   The result [WEXITED 127] indicates that the shell couldn't be
    executed. *)
 
 val getpid : unit -> int
@@ -780,7 +783,12 @@ val open_process_in : string -> in_channel
    The standard output of the command is redirected to a pipe,
    which can be read via the returned input channel.
    The command is interpreted by the shell [/bin/sh]
-   (or [cmd.exe] on Windows), cf. [system]. *)
+   (or [cmd.exe] on Windows), cf. {!Unix.system}.
+   The {!Filename.quote_command} function can be used to
+   quote the command and its arguments as appropriate for the shell being
+   used.  If the command does not need to be run through the shell,
+   {!Unix.open_process_args_in} can be used as a more robust and
+   more efficient alternative to {!Unix.open_process_in}. *)
 
 val open_process_out : string -> out_channel
 (** Same as {!Unix.open_process_in}, but redirect the standard input of
@@ -788,20 +796,29 @@ val open_process_out : string -> out_channel
    is sent to the standard input of the command.
    Warning: writes on output channels are buffered, hence be careful
    to call {!Stdlib.flush} at the right times to ensure
-   correct synchronization. *)
+   correct synchronization.
+   If the command does not need to be run through the shell,
+   {!Unix.open_process_args_out} can be used instead of
+   {!Unix.open_process_out}. *)
 
 val open_process : string -> in_channel * out_channel
 (** Same as {!Unix.open_process_out}, but redirects both the standard input
    and standard output of the command to pipes connected to the two
    returned channels.  The input channel is connected to the output
-   of the command, and the output channel to the input of the command. *)
+   of the command, and the output channel to the input of the command.
+   If the command does not need to be run through the shell,
+   {!Unix.open_process_args} can be used instead of
+   {!Unix.open_process}. *)
 
 val open_process_full :
   string -> string array -> in_channel * out_channel * in_channel
 (** Similar to {!Unix.open_process}, but the second argument specifies
    the environment passed to the command.  The result is a triple
    of channels connected respectively to the standard output, standard input,
-   and standard error of the command. *)
+   and standard error of the command.
+   If the command does not need to be run through the shell,
+   {!Unix.open_process_args_full} can be used instead of
+   {!Unix.open_process_full}. *)
 
 val open_process_args_in : string -> string array -> in_channel
 (** High-level pipe and process management. The first argument specifies the

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -225,7 +225,8 @@ Quoting commands for execution by cmd.exe is difficult.
     else
       f
   (* Redirections in cmd.exe: see https://ss64.com/nt/syntax-redirection.html
-     and https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb490982(v=technet.10) *)
+     and https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb490982(v=technet.10)
+  *)
   let quote_command cmd ?stdin ?stdout ?stderr args =
     String.concat "" [
       "\"";

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -69,7 +69,25 @@ let generic_dirname is_dir_sep current_dir_name name =
   then current_dir_name
   else trailing_sep (String.length name - 1)
 
-module Unix = struct
+module type SYSDEPS = sig
+  val current_dir_name : string
+  val parent_dir_name : string
+  val dir_sep : string
+  val is_dir_sep : string -> int -> bool
+  val is_relative : string -> bool
+  val is_implicit : string -> bool
+  val check_suffix : string -> string -> bool
+  val chop_suffix_opt : suffix:string -> string -> string option
+  val temp_dir_name : string
+  val quote : string -> string
+  val quote_command :
+    string -> ?stdin: string -> ?stdout: string -> ?stderr: string
+           -> string list -> string
+  val basename : string -> string
+  val dirname : string -> string
+end
+
+module Unix : SYSDEPS = struct
   let current_dir_name = "."
   let parent_dir_name = ".."
   let dir_sep = "/"
@@ -98,11 +116,18 @@ module Unix = struct
   let temp_dir_name =
     try Sys.getenv "TMPDIR" with Not_found -> "/tmp"
   let quote = generic_quote "'\\''"
+  let quote_command cmd ?stdin ?stdout ?stderr args =
+    String.concat " " (List.map quote (cmd :: args))
+    ^ (match stdin  with None -> "" | Some f -> " <" ^ quote f)
+    ^ (match stdout with None -> "" | Some f -> " >" ^ quote f)
+    ^ (match stderr with None -> "" | Some f -> if stderr = stdout
+                                                then " 2>&1"
+                                                else " 2>" ^ quote f)
   let basename = generic_basename is_dir_sep current_dir_name
   let dirname = generic_dirname is_dir_sep current_dir_name
 end
 
-module Win32 = struct
+module Win32 : SYSDEPS = struct
   let current_dir_name = "."
   let parent_dir_name = ".."
   let dir_sep = "\\"
@@ -161,6 +186,60 @@ module Win32 = struct
     in
     loop 0;
     Buffer.contents b
+(*
+Quoting commands for execution by cmd.exe is difficult.
+1- Each argument is first quoted using the "quote" function above, to
+   protect it against the processing performed by the C runtime system,
+   then cmd.exe's special characters are escaped with '^', using
+   the "quote_cmd" function below.  For more details, see
+   https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23
+2- The command and the redirection files, if any, must be double-quoted
+   in case they contain spaces.  This quoting is interpreted by cmd.exe,
+   not by the C runtime system, hence the "quote" function above
+   cannot be used.  The two characters we don't know how to quote
+   inside a double-quoted cmd.exe string are double-quote and percent.
+   We just fail if the command name or the redirection file names
+   contain a double quote (not allowed in Windows file names, anyway)
+   or a percent.  See function "quote_cmd_filename" below.
+3- The whole string passed to Sys.command is then enclosed in double
+   quotes, which are immediately stripped by cmd.exe.  Otherwise,
+   some of the double quotes from step 2 above can be misparsed.
+   See e.g. https://stackoverflow.com/a/9965141
+*)
+  let quote_cmd s =
+    let b = Buffer.create (String.length s + 20) in
+    String.iter
+      (fun c ->
+        match c with
+        | '(' | ')' | '!' | '^' | '%' | '\"' | '<' | '>' | '&' | '|' ->
+            Buffer.add_char b '^'; Buffer.add_char b c
+        | _ ->
+            Buffer.add_char b c)
+      s;
+    Buffer.contents b
+  let quote_cmd_filename f =
+    if String.contains f '\"' || String.contains f '%' then
+      invalid_arg ("Filename.quote_command: bad file name " ^ f)
+    else if String.contains f ' ' then
+      "\"" ^ f ^ "\""
+    else
+      f
+  (* Redirections in cmd.exe: see https://ss64.com/nt/syntax-redirection.html
+     and https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb490982(v=technet.10) *)
+  let quote_command cmd ?stdin ?stdout ?stderr args =
+    String.concat "" [
+      "\"";
+      quote_cmd_filename cmd;
+      " ";
+      quote_cmd (String.concat " " (List.map quote args));
+      (match stdin  with None -> "" | Some f -> " <" ^ quote_cmd_filename f);
+      (match stdout with None -> "" | Some f -> " >" ^ quote_cmd_filename f);
+      (match stderr with None -> "" | Some f ->
+                                        if stderr = stdout
+                                        then " 2>&1"
+                                        else " 2>" ^ quote_cmd_filename f);
+      "\""
+    ]
   let has_drive s =
     let is_letter = function
       | 'A' .. 'Z' | 'a' .. 'z' -> true
@@ -180,7 +259,7 @@ module Win32 = struct
     generic_basename is_dir_sep current_dir_name path
 end
 
-module Cygwin = struct
+module Cygwin : SYSDEPS = struct
   let current_dir_name = "."
   let parent_dir_name = ".."
   let dir_sep = "/"
@@ -191,33 +270,18 @@ module Cygwin = struct
   let chop_suffix_opt = Win32.chop_suffix_opt
   let temp_dir_name = Unix.temp_dir_name
   let quote = Unix.quote
+  let quote_command = Unix.quote_command
   let basename = generic_basename is_dir_sep current_dir_name
   let dirname = generic_dirname is_dir_sep current_dir_name
 end
 
-let (current_dir_name, parent_dir_name, dir_sep, is_dir_sep,
-     is_relative, is_implicit, check_suffix, chop_suffix_opt,
-     temp_dir_name, quote, basename,
-     dirname) =
-  match Sys.os_type with
-  | "Win32" ->
-      (Win32.current_dir_name, Win32.parent_dir_name, Win32.dir_sep,
-       Win32.is_dir_sep,
-       Win32.is_relative, Win32.is_implicit, Win32.check_suffix,
-       Win32.chop_suffix_opt,
-       Win32.temp_dir_name, Win32.quote, Win32.basename, Win32.dirname)
-  | "Cygwin" ->
-      (Cygwin.current_dir_name, Cygwin.parent_dir_name, Cygwin.dir_sep,
-       Cygwin.is_dir_sep,
-       Cygwin.is_relative, Cygwin.is_implicit, Cygwin.check_suffix,
-       Cygwin.chop_suffix_opt,
-       Cygwin.temp_dir_name, Cygwin.quote, Cygwin.basename, Cygwin.dirname)
-  | _ -> (* normally "Unix" *)
-      (Unix.current_dir_name, Unix.parent_dir_name, Unix.dir_sep,
-       Unix.is_dir_sep,
-       Unix.is_relative, Unix.is_implicit, Unix.check_suffix,
-       Unix.chop_suffix_opt,
-       Unix.temp_dir_name, Unix.quote, Unix.basename, Unix.dirname)
+module Sysdeps =
+  (val (match Sys.os_type with
+       | "Win32" -> (module Win32: SYSDEPS)
+       | "Cygwin" -> (module Cygwin: SYSDEPS)
+       | _ -> (module Unix: SYSDEPS)))
+
+include Sysdeps
 
 let concat dirname filename =
   let l = String.length dirname in

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -219,7 +219,7 @@ Quoting commands for execution by cmd.exe is difficult.
     Buffer.contents b
   let quote_cmd_filename f =
     if String.contains f '\"' || String.contains f '%' then
-      invalid_arg ("Filename.quote_command: bad file name " ^ f)
+      failwith ("Filename.quote_command: bad file name " ^ f)
     else if String.contains f ' ' then
       "\"" ^ f ^ "\""
     else

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -186,3 +186,33 @@ val quote : string -> string
     with programs that follow the standard Windows quoting
     conventions.
  *)
+
+val quote_command :
+       string -> ?stdin:string -> ?stdout:string -> ?stderr:string
+              -> string list -> string
+(** [quote_command cmd args] returns a quoted command line, suitable
+    for use as an argument to {!Sys.command}, {!Unix.system}, and the
+    {!Unix.open_process} functions.
+
+    The string [cmd] is the command to call.  The list [args] is
+    the list of arguments to pass to this command.  It can be empty.
+
+    The optional arguments [?stdin] and [?stdout] and [?stderr] are
+    file names used to redirect the standard input, the standard
+    output, or the standard error of the command.
+    If [~stdin:f] is given, a redirection [< f] is performed and the
+    standard input of the command reads from file [f].
+    If [~stdout:f] is given, a redirection [> f] is performed and the
+    standard output of the command is written to file [f].
+    If [~stderr:f] is given, a redirection [2> f] is performed and the
+    standard error of the command is written to file [f].
+    If both [~stdout:f] and [~stderr:f] are given, with the exact
+    same file name [f], a [2>&1] redirection is performed so that the
+    standard output and the standard error of the command are interleaved
+    and redirected to the same file [f].
+
+    Under Unix and Cygwin, the command, the arguments, and the redirections
+    if any are quoted using {!Filename.quote}, then concatenated.
+    Under Win32, additional quoting is performed as required by the
+    [cmd.exe] shell that is called by {!Sys.command}.
+*)

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -215,4 +215,6 @@ val quote_command :
     if any are quoted using {!Filename.quote}, then concatenated.
     Under Win32, additional quoting is performed as required by the
     [cmd.exe] shell that is called by {!Sys.command}.
+
+    Raise [Failure] if the command cannot be escaped on the current platform.
 *)

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -66,7 +66,24 @@ val getenv_opt: string -> string option
 *)
 
 external command : string -> int = "caml_sys_system_command"
-(** Execute the given shell command and return its exit code. *)
+(** Execute the given shell command and return its exit code.
+
+  The argument of {!Sys.command} is generally the name of a
+  command followed by zero, one or several arguments, separated
+  by whitespace.  The given argument is interpreted by a
+  shell: either the Windows shell [cmd.exe] for the Win32 ports of
+  OCaml, or the POSIX shell [sh] for other ports.  It can contain
+  shell builtin commands such as [echo], and also special characters
+  such as file redirections [>] and [<], which will be honored by the
+  shell.
+
+  Conversely, whitespace or special shell characters occuring in
+  command names or in their arguments must be quoted or escaped
+  so that the shell does not interpret them.  The quoting rules vary
+  between the POSIX shell and the Windows shell.
+  The {!Filename.quote_command} performs the appropriate quoting
+  given a command name, a list of arguments, and optional file redirections.
+*)
 
 external time : unit -> (float [@unboxed]) =
   "caml_sys_time" "caml_sys_time_unboxed" [@@noalloc]

--- a/testsuite/tests/lib-filename/myecho.ml
+++ b/testsuite/tests/lib-filename/myecho.ml
@@ -1,0 +1,20 @@
+open Printf
+
+let () =
+  let argc = Array.length Sys.argv in
+  let out = ref stdout in
+  if argc > 1 then begin
+    for i = 1 to argc - 1 do
+      match Sys.argv.(i) with
+      | "-err" -> flush !out; out := stderr
+      | "-out" -> flush !out; out := stdout
+      | arg    -> fprintf !out "argv[%d] = {|%s|}\n" i arg
+    done
+  end else begin
+    try
+      while true do
+        let l = input_line stdin in
+        printf "%s\n" l
+      done
+    with End_of_file -> ()
+  end

--- a/testsuite/tests/lib-filename/ocamltests
+++ b/testsuite/tests/lib-filename/ocamltests
@@ -1,2 +1,3 @@
 extension.ml
 suffix.ml
+quotecommand.ml

--- a/testsuite/tests/lib-filename/quotecommand.ml
+++ b/testsuite/tests/lib-filename/quotecommand.ml
@@ -1,0 +1,104 @@
+(* TEST
+
+files = "myecho.ml"
+
+* setup-ocamlc.byte-build-env
+program = "${test_build_directory}/quotecommand.byte"
+** ocamlc.byte
+program = "${test_build_directory}/myecho.exe"
+all_modules = "myecho.ml"
+*** ocamlc.byte
+program = "${test_build_directory}/quotecommand.byte"
+all_modules= "quotecommand.ml"
+**** check-ocamlc.byte-output
+***** run
+****** check-program-output
+
+* setup-ocamlopt.byte-build-env
+program = "${test_build_directory}/quotecommand.opt"
+** ocamlopt.byte
+program = "${test_build_directory}/myecho.exe"
+all_modules = "myecho.ml"
+*** ocamlopt.byte
+include unix
+program = "${test_build_directory}/quotecommand.opt"
+all_modules= "quotecommand.ml"
+**** check-ocamlopt.byte-output
+***** run
+****** check-program-output
+
+*)
+
+open Printf
+
+let copy_channels ic oc =
+  let sz = 1024 in
+  let buf = Bytes.create sz in
+  let rec copy () =
+    let n = input ic buf 0 sz in
+    if n > 0 then (output oc buf 0 n; copy()) in
+  copy()
+
+let copy_file src dst =
+  let ic = open_in_bin src in
+  let oc = open_out_gen [Open_wronly; Open_creat; Open_trunc; Open_binary]
+                        0o777 dst in
+  copy_channels ic oc;
+  close_in ic;
+  close_out oc
+
+let cat_file f =
+  let ic = open_in f in
+  copy_channels ic stdout;
+  close_in ic
+
+let myecho =
+  Filename.concat Filename.current_dir_name "my echo.exe"
+
+let run ?stdin ?stdout ?stderr args =
+  flush Stdlib.stdout;
+  let rc =
+   Sys.command (Filename.quote_command myecho ?stdin ?stdout ?stderr args) in
+  if rc > 0 then begin
+    printf "!!! my echo failed\n";
+    exit 2
+  end
+
+let _ =
+  copy_file "myecho.exe" "my echo.exe";
+  printf "-------- Spaces\n";
+  run ["Lorem ipsum dolor"; "sit amet,"; "consectetur adipiscing elit,"];
+  printf "-------- All ASCII characters\n";
+  run ["!\"#$%&'()*+,-./";
+       "0123456789";
+       ":;<=>?@";
+       "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+       "[\\]^_`";
+       "abcdefghijklmnopqrstuvwxyz";
+       "{~|~}"
+  ];
+  printf "-------- Output redirection\n";
+  run ~stdout:"my 'file'.tmp" ["sed do eiusmod tempor incididunt";
+                               "ut labore et dolore magna aliqua."];
+  printf "-------- Input redirection\n";
+  run ~stdin:"my 'file'.tmp" [];
+  Sys.remove "my 'file'.tmp";
+  printf "-------- Error redirection\n";
+  run ~stderr:"my 'file'.tmp"
+              ["Exceptur sint"; "-err"; "occaecat"; "cupidatat";
+               "-out"; "non proident"; "-err"; "sunt in culpa"];
+  printf "-- stderr:\n";
+  cat_file "my 'file'.tmp";
+  Sys.remove "my 'file'.tmp";
+  printf "-------- Output and error redirections (different files)\n";
+  run ~stdout:"my stdout.tmp" ~stderr:"my stderr.tmp"
+              ["qui officia"; "-err"; "deserunt"; "mollit";
+               "-out"; "anim id est"; "-err"; "laborum."];
+  printf "-- stdout:\n"; cat_file "my stdout.tmp"; Sys.remove "my stdout.tmp";
+  printf "-- stderr:\n"; cat_file "my stderr.tmp"; Sys.remove "my stderr.tmp";
+  printf "-------- Output and error redirections (same file)\n";
+  run ~stdout:"my file.tmp" ~stderr:"my file.tmp"
+              ["Duis aute"; "irure dolor"; "-err"; "in reprehenderit";
+               "in voluptate"; "-out"; "velit esse cillum"; "-err"; "dolore"];
+  cat_file "my file.tmp"; Sys.remove "my file.tmp";
+  Sys.remove "my echo.exe"

--- a/testsuite/tests/lib-filename/quotecommand.reference
+++ b/testsuite/tests/lib-filename/quotecommand.reference
@@ -1,0 +1,38 @@
+-------- Spaces
+argv[1] = {|Lorem ipsum dolor|}
+argv[2] = {|sit amet,|}
+argv[3] = {|consectetur adipiscing elit,|}
+-------- All ASCII characters
+argv[1] = {|!"#$%&'()*+,-./|}
+argv[2] = {|0123456789|}
+argv[3] = {|:;<=>?@|}
+argv[4] = {|ABCDEFGHIJKLMNOPQRSTUVWXYZ|}
+argv[5] = {|[\]^_`|}
+argv[6] = {|abcdefghijklmnopqrstuvwxyz|}
+argv[7] = {|{~|~}|}
+-------- Output redirection
+-------- Input redirection
+argv[1] = {|sed do eiusmod tempor incididunt|}
+argv[2] = {|ut labore et dolore magna aliqua.|}
+-------- Error redirection
+argv[1] = {|Exceptur sint|}
+argv[6] = {|non proident|}
+-- stderr:
+argv[3] = {|occaecat|}
+argv[4] = {|cupidatat|}
+argv[8] = {|sunt in culpa|}
+-------- Output and error redirections (different files)
+-- stdout:
+argv[1] = {|qui officia|}
+argv[6] = {|anim id est|}
+-- stderr:
+argv[3] = {|deserunt|}
+argv[4] = {|mollit|}
+argv[8] = {|laborum.|}
+-------- Output and error redirections (same file)
+argv[1] = {|Duis aute|}
+argv[2] = {|irure dolor|}
+argv[4] = {|in reprehenderit|}
+argv[5] = {|in voluptate|}
+argv[7] = {|velit esse cillum|}
+argv[9] = {|dolore|}


### PR DESCRIPTION
As reported in [MPR#6107](https://caml.inria.fr/mantis/view.php?id=6107) and [MPR#7672](https://caml.inria.fr/mantis/view.php?id=7672), it is not easy to properly quote the command name and its arguments in a shell command executed through `Sys.command` or the `Unix.open_process*` functions.  For a POSIX shell it is enough to apply `Filename.quote` on every argument.  But for the Windows shell `cmd.exe`, additional quoting is required on top of that, as explained [here](https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/).

This pull requests grants the feature wish from [MPR#7672](https://caml.inria.fr/mantis/view.php?id=7672) by adding a `Filename.quote_command` function that takes a command and its arguments (as a list of strings) and produces a command line appropriately quoted for the shell that is going to parse and execute it.  

Documentation of `Sys.command`, `Unix.system` and `Unix.open_process*` was updated to encourage the use of `Filename.quote_command`.

### Preventive FAQ

**Q**: why `string list -> string` and not `string array -> string` for consistency with `Unix.exec`?

**A**: it felt right.  MPR#7672 suggested `string list`.  It's easier to build a list (with `::` and `@`) than an array.  Perhaps it's `Unix.exec` that is wrong in its use of a `string array`.

