### PR TITLE
MPR#7679: make sure `.a` files are erased before calling `ar rc`

### DIFF
--- a/Changes
+++ b/Changes
@@ -58,6 +58,10 @@ Working version
 
 ### Compiler distribution build system
 
+- MPR#7679: make sure .a files are erased before calling ar rc, otherwise
+  leftover .a files from an earlier compilation may contain unwanted modules
+  (Xavier Leroy)
+
 ### Internal/compiler-libs changes:
 
 ### Bug fixes

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -156,7 +156,7 @@ MKEXE_BOOT=$(CC) $(CFLAGS) $(LDFLAGS) $(OUTPUTEXE)$(1) $(2)
 MKEXE_ANSI=$(FLEXLINK) -exe
 
 ### How to build a static library
-MKLIB=rm -f $(1); $(TOOLPREF)ar rc $(1) $(2); $(RANLIB) $(1)
+MKLIB=rm -f $(1) && $(TOOLPREF)ar rcs $(1) $(2)
 #ml let mklib out files opts =
 #ml   Printf.sprintf "rm -f %s && %sar rcs %s %s %s"
 #ml                  out toolpref opts out files;;

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -158,8 +158,8 @@ MKEXE_ANSI=$(FLEXLINK) -exe
 ### How to build a static library
 MKLIB=rm -f $(1) && $(TOOLPREF)ar rcs $(1) $(2)
 #ml let mklib out files opts =
-#ml   Printf.sprintf "rm -f %s && %sar rcs %s %s %s"
-#ml                  out toolpref opts out files;;
+#ml   Printf.sprintf "%sar rcs %s %s %s"
+#ml                  toolpref opts out files;;
 
 ### Canonicalize the name of a system library
 SYSLIB=-l$(1)

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -156,7 +156,7 @@ MKEXE_BOOT=$(CC) $(CFLAGS) $(LDFLAGS) $(OUTPUTEXE)$(1) $(2)
 MKEXE_ANSI=$(FLEXLINK) -exe
 
 ### How to build a static library
-MKLIB=rm -f $(1); $(TOOLPREF)ar rc $(1) $(2); $(RANLIB) $(1)
+MKLIB=rm -f $(1) && $(TOOLPREF)ar rcs $(1) $(2)
 #ml let mklib out files opts =
 #ml   Printf.sprintf "rm -f %s && %sar rcs %s %s %s"
 #ml                  out toolpref opts out files;;

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -158,8 +158,8 @@ MKEXE_ANSI=$(FLEXLINK) -exe
 ### How to build a static library
 MKLIB=rm -f $(1) && $(TOOLPREF)ar rcs $(1) $(2)
 #ml let mklib out files opts =
-#ml   Printf.sprintf "rm -f %s && %sar rcs %s %s %s"
-#ml                  out toolpref opts out files;;
+#ml   Printf.sprintf "%sar rcs %s %s %s"
+#ml                  toolpref opts out files;;
 
 ### Canonicalize the name of a system library
 SYSLIB=-l$(1)

--- a/configure
+++ b/configure
@@ -2059,8 +2059,8 @@ SYSLIB=-l\$(1)
 ### How to build a static library
 MKLIB=rm -f \$(1) && ${TOOLPREF}ar rc \$(1) \$(2) && ${TOOLPREF}ranlib \$(1)
 #ml let mklib out files opts =      (* "" *)
-#ml   Printf.sprintf "rm -f %s && ${TOOLPREF}ar rc %s %s %s && ${TOOLPREF}ranlib %s"
-#ml                  out out opts files out;;
+#ml   Printf.sprintf "${TOOLPREF}ar rc %s %s %s && ${TOOLPREF}ranlib %s"
+#ml                  out opts files out;;
 EOF
 config ARCH "$arch"
 config MODEL "$model"

--- a/configure
+++ b/configure
@@ -2057,10 +2057,10 @@ SYSLIB=-l\$(1)
 #ml let syslib x = "-l"^x;;
 
 ### How to build a static library
-MKLIB=${TOOLPREF}ar rc \$(1) \$(2); ${TOOLPREF}ranlib \$(1)
+MKLIB=rm -f \$(1) && ${TOOLPREF}ar rc \$(1) \$(2) && ${TOOLPREF}ranlib \$(1)
 #ml let mklib out files opts =      (* "" *)
-#ml   Printf.sprintf "${TOOLPREF}ar rc %s %s %s; ${TOOLPREF}ranlib %s"
-#ml                  out opts files out;;
+#ml   Printf.sprintf "rm -f %s && ${TOOLPREF}ar rc %s %s %s && ${TOOLPREF}ranlib %s"
+#ml                  out out opts files out;;
 EOF
 config ARCH "$arch"
 config MODEL "$model"


### PR DESCRIPTION
Otherwise, as shown by [MPR#7679](https://caml.inria.fr/mantis/view.php?id=7679), leftover `.a` files from an earlier compilation may contain unwanted modules.

Also: replace `;` by `&&` when chaining several shell commands, it's safer this way.

The second commit freshens up the Mingw32 and Mingw64 configurations.  They did the correct file-remove dance in MKLIB already,  but the `#ml` block contained a different, and better, definition than the MKLIB shell command.  
