### PR TITLE
Refactor the code printing explanation for unification errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -38,6 +38,10 @@ Working version
   (Arthur Charguéraud and Armaël Guéneau, with help from Gabriel Scherer and
   Frédéric Bour)
 
+- GPR#1496: Refactor the code printing explanation for unification type errors,
+  in order to avoid duplicating pattern matches
+  (Armaël Guéneau, review by Florian Angeletti and Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 ### Runtime system:


### PR DESCRIPTION
This patches refactor `explanation`/`has_explanation` to avoid duplicating the pattern matches, the first time to check if there is an explanation, and the second time to actually get it. Instead, `explanation` now returns a `(Format.formatter -> unit) option`; in the `Some` case one can call the closure to compute and print the explanation.