### PR TITLE
Fix bad interaction between Simplif and optimized compilation of tuple binding

### DIFF
--- a/Changes
+++ b/Changes
@@ -85,6 +85,10 @@ Working version
 - MPR#7668: -principal is broken with polymorphic variants
   (Jacques Garrigue, report by Jun Furuse)
 
+- MPR#7680, GPR#1497: Incorrect interaction between Matching.for_let and
+  Simplif.simplify_exits
+  (Alain Frisch, report and review by Vincent Laviron)
+
 - MPR#7682, GPR#1495: fix [@@unboxed] for records with 1 polymorphic field
   (Alain Frisch, report by Stéphane Graham-Lengrand)
 

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -496,12 +496,6 @@ let next_raise_count () =
   incr raise_count ;
   !raise_count
 
-let negative_raise_count = ref 0
-
-let next_negative_raise_count () =
-  decr negative_raise_count ;
-  !negative_raise_count
-
 (* Anticipated staticraise, for guards *)
 let staticfail = Lstaticraise (0,[])
 

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -354,11 +354,6 @@ val default_stub_attribute : function_attribute
 
 (* Get a new static failure ident *)
 val next_raise_count : unit -> int
-val next_negative_raise_count : unit -> int
-  (* Negative raise counts are used to compile 'match ... with
-     exception x -> ...'.  This disabled some simplifications
-     performed by the Simplif module that assume that static raises
-     are in tail position in their handler. *)
 
 val staticfail : lambda (* Anticipated static failure *)
 

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -92,22 +92,31 @@ let rec eliminate_ref id = function
 
 (* Simplification of exits *)
 
+type exit = {
+  mutable count: int;
+  mutable max_depth: int;
+}
+
 let simplify_exits lam =
 
   (* Count occurrences of (exit n ...) statements *)
   let exits = Hashtbl.create 17 in
 
-  let count_exit i =
-    try
-      !(Hashtbl.find exits i)
-    with
-    | Not_found -> 0
+  let try_depth = ref 0 in
 
-  and incr_exit i =
-    try
-      incr (Hashtbl.find exits i)
-    with
-    | Not_found -> Hashtbl.add exits i (ref 1) in
+  let get_exit i =
+    try Hashtbl.find exits i
+    with Not_found -> {count = 0; max_depth = 0}
+
+  and incr_exit i nb d =
+    match Hashtbl.find_opt exits i with
+    | Some r ->
+        r.count <- r.count + nb;
+        r.max_depth <- max r.max_depth d
+    | None ->
+        let r = {count = nb; max_depth = d} in
+        Hashtbl.add exits i r
+  in
 
   let rec count = function
   | (Lvar _| Lconst _) -> ()
@@ -133,25 +142,20 @@ let simplify_exits lam =
         | []|[_] -> count d
         | _ -> count d; count d (* default will get replicated *)
       end
-  | Lstaticraise (i,ls) -> incr_exit i ; List.iter count ls
+  | Lstaticraise (i,ls) -> incr_exit i 1 !try_depth; List.iter count ls
   | Lstaticcatch (l1,(i,[]),Lstaticraise (j,[])) ->
       (* i will be replaced by j in l1, so each occurrence of i in l1
          increases j's ref count *)
       count l1 ;
-      let ic = count_exit i in
-      begin try
-        let r = Hashtbl.find exits j in r := !r + ic
-      with
-      | Not_found ->
-          Hashtbl.add exits j (ref ic)
-      end
+      let ic = get_exit i in
+      incr_exit j ic.count (max !try_depth ic.max_depth)
   | Lstaticcatch(l1, (i,_), l2) ->
       count l1;
       (* If l1 does not contain (exit i),
          l2 will be removed, so don't count its exits *)
-      if count_exit i > 0 then
+      if (get_exit i).count > 0 then
         count l2
-  | Ltrywith(l1, _v, l2) -> count l1; count l2
+  | Ltrywith(l1, _v, l2) -> incr try_depth; count l1; decr try_depth; count l2
   | Lifthenelse(l1, l2, l3) -> count l1; count l2; count l3
   | Lsequence(l1, l2) -> count l1; count l2
   | Lwhile(l1, l2) -> count l1; count l2
@@ -176,6 +180,7 @@ let simplify_exits lam =
       end
   in
   count lam;
+  assert(!try_depth = 0);
 
   (*
      Second pass simplify  ``catch body with (i ...) handler''
@@ -273,15 +278,23 @@ let simplify_exits lam =
       Hashtbl.add subst i ([],simplif l2) ;
       simplif l1
   | Lstaticcatch (l1,(i,xs),l2) ->
-      begin match count_exit i with
-      | 0 -> simplif l1
-      | 1 when i >= 0 ->
-          Hashtbl.add subst i (xs,simplif l2) ;
-          simplif l1
-      | _ ->
-          Lstaticcatch (simplif l1, (i,xs), simplif l2)
-      end
-  | Ltrywith(l1, v, l2) -> Ltrywith(simplif l1, v, simplif l2)
+      let {count; max_depth} = get_exit i in
+      if count = 0 then
+        (* Discard staticcatch: not matching exit *)
+        simplif l1
+      else if i >= 0 && count = 1 && max_depth <= !try_depth then begin
+        (* Inline handler if there is a single occurrence and it is not
+           nested within an inner try..with *)
+        assert(max_depth = !try_depth);
+        Hashtbl.add subst i (xs,simplif l2);
+        simplif l1
+      end else
+        Lstaticcatch (simplif l1, (i,xs), simplif l2)
+  | Ltrywith(l1, v, l2) ->
+      incr try_depth;
+      let l1 = simplif l1 in
+      decr try_depth;
+      Ltrywith(l1, v, simplif l2)
   | Lifthenelse(l1, l2, l3) -> Lifthenelse(simplif l1, simplif l2, simplif l3)
   | Lsequence(l1, l2) -> Lsequence(simplif l1, simplif l2)
   | Lwhile(l1, l2) -> Lwhile(simplif l1, simplif l2)

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -282,7 +282,7 @@ let simplify_exits lam =
       if count = 0 then
         (* Discard staticcatch: not matching exit *)
         simplif l1
-      else if i >= 0 && count = 1 && max_depth <= !try_depth then begin
+      else if count = 1 && max_depth <= !try_depth then begin
         (* Inline handler if there is a single occurrence and it is not
            nested within an inner try..with *)
         assert(max_depth = !try_depth);

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -1021,7 +1021,7 @@ and transl_exp0 e =
       | `Constant_or_function ->
         (* a constant expr of type <> float gets compiled as itself *)
          transl_exp e
-      | `Float -> 
+      | `Float ->
           (* We don't need to wrap with Popaque: this forward
              block will never be shortcutted since it points to a float. *)
           Lprim(Pmakeblock(Obj.forward_tag, Immutable, None),
@@ -1347,7 +1347,7 @@ and transl_match e arg pat_expr_list exn_pat_expr_list partial =
   and cases = transl_cases pat_expr_list
   and exn_cases = transl_cases_try exn_pat_expr_list in
   let static_catch body val_ids handler =
-    let static_exception_id = next_negative_raise_count () in
+    let static_exception_id = next_raise_count () in
     Lstaticcatch
       (Ltrywith (Lstaticraise (static_exception_id, body), id,
                  Matching.for_trywith (Lvar id) exn_cases),

--- a/testsuite/tests/asmcomp/bind_tuples.ml
+++ b/testsuite/tests/asmcomp/bind_tuples.ml
@@ -20,9 +20,21 @@ let f () =
     r := !r * x + y
   done;
   let x2 = Gc.allocated_bytes () in
-  print_int !r;
   assert (!r = 82);
   assert(x1 -. x0 = x2 -. x1) (* check no allocation between x1 and x2 *)
   [@@inline never]
 
 let () = f ()
+
+
+
+(* MPR#7680 *)
+
+let f () =
+  let (a,b) =
+    try (1,2)
+    with _ -> assert false
+  in
+  if a + b = 3 then raise Not_found
+
+let () = try f (); assert false with Not_found -> ()


### PR DESCRIPTION
Fix [MPR#7680](https://caml.inria.fr/mantis/view.php?id=7680).

The proposed fix is to make the simplification of "exits" (in Simplif) more robust against static raises that "traverse" a try...with.  The simplification consists in inlining the static handler when there is a single corresponding static raise (in tail context).  The fix disables this inlining if the static handler and static raise are at different nesting level w.r.t. try...with (the level is incremented when inspecting the body of the try...with).