### PR TITLE
StrictOpt cannot be converted to Alias

### DIFF
--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -494,7 +494,7 @@ let simplify_lets lam =
   | Llet(StrictOpt, kind, v, l1, l2) ->
       begin match count_var v with
         0 -> simplif l2
-      | _ -> mklet Alias kind v (simplif l1) (simplif l2)
+      | _ -> mklet StrictOpt kind v (simplif l1) (simplif l2)
       end
   | Llet(str, kind, v, l1, l2) -> mklet str kind v (simplif l1) (simplif l2)
   | Lletrec(bindings, body) ->


### PR DESCRIPTION
The `StrictOpt` annotation on let is stricter than `Alias`. I couldn't find any easy bug that exhibited the problem here, but if the backend didn't drop that annotation and assumed that it means pure, that could change the order of effect.