### PR TITLE
MPR#7528: Format.pp_set_geometry

### DIFF
--- a/Changes
+++ b/Changes
@@ -758,6 +758,10 @@ OCaml 4.07.0 (10 July 2018)
   bigarray library as on overlay adding the deprecated map_file functions.
   (Jérémie Dimino, review by Mark Shinwell)
 
+- MPR#7528: add a Format.pp_set_geometry function to avoid memory effects
+  in set_margin and set_max_indent.
+  (Florian Angeletti)
+
 - MPR#7690, GPR#1528: fix the float_of_string function for hexadecimal floats
   with very large values of the exponent.
   (Olivier Andrieu)

--- a/Changes
+++ b/Changes
@@ -758,8 +758,8 @@ OCaml 4.07.0 (10 July 2018)
   bigarray library as on overlay adding the deprecated map_file functions.
   (Jérémie Dimino, review by Mark Shinwell)
 
-- MPR#7528: add a Format.pp_set_geometry function to avoid memory effects
-  in set_margin and set_max_indent.
+- MPR#7528, GPR#1500: add a Format.pp_set_geometry function to avoid memory
+  effects in set_margin and set_max_indent.
   (Florian Angeletti, review by Richard Bonichon, Gabriel Radanne,
    Gabiel Scherer and Pierre Weis)
 

--- a/Changes
+++ b/Changes
@@ -760,7 +760,8 @@ OCaml 4.07.0 (10 July 2018)
 
 - MPR#7528: add a Format.pp_set_geometry function to avoid memory effects
   in set_margin and set_max_indent.
-  (Florian Angeletti)
+  (Florian Angeletti, review by Richard Bonichon, Gabriel Radanne,
+   Gabiel Scherer and Pierre Weis)
 
 - MPR#7690, GPR#1528: fix the float_of_string function for hexadecimal floats
   with very large values of the exponent.

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -790,8 +790,8 @@ let pp_set_margin state n =
 type geometry = { max_indent:int; margin: int}
 
 let check_geometry geometry =
-  geometry.max_indent >= 2
-  &&  geometry.margin >= geometry.max_indent
+  geometry.max_indent > 1
+  &&  geometry.margin > geometry.max_indent
 
 let pp_get_margin state () = state.pp_margin
 
@@ -802,6 +802,12 @@ let pp_set_geometry state ~max_indent ~margin =
       raise (Invalid_argument "Format.pp_set_geometry: margin <= max_indent")
   else
     pp_set_margin state margin; pp_set_max_indent state max_indent
+
+let pp_safe_set_geometry state ~max_indent ~margin =
+  if check_geometry {max_indent;margin} then
+    pp_set_geometry state ~max_indent ~margin
+  else
+    ()
 
 let pp_get_geometry state () =
   { margin = pp_get_margin state (); max_indent = pp_get_max_indent state () }
@@ -1089,6 +1095,7 @@ and set_max_indent = pp_set_max_indent std_formatter
 and get_max_indent = pp_get_max_indent std_formatter
 
 and set_geometry = pp_set_geometry std_formatter
+and safe_set_geometry = pp_safe_set_geometry std_formatter
 and get_geometry = pp_get_geometry std_formatter
 
 and set_max_boxes = pp_set_max_boxes std_formatter

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -788,6 +788,17 @@ let pp_set_margin state n =
 
 let pp_get_margin state () = state.pp_margin
 
+let pp_set_geometry state ~max_indent ~margin =
+  if max_indent < 1 then
+    raise (Invalid_argument "Format.pp_set_geometry: max_indent < 1")
+  else if margin <= max_indent then
+      raise (Invalid_argument "Format.pp_set_geometry: margin <= max_indent")
+  else
+    pp_set_margin state margin; pp_set_max_indent state max_indent
+
+let pp_get_geometry state () =
+  pp_get_margin state (), pp_get_max_indent state ()
+
 (* Setting a formatter basic output functions. *)
 let pp_set_formatter_out_functions state {
       out_string = f;
@@ -1069,6 +1080,9 @@ and get_margin = pp_get_margin std_formatter
 
 and set_max_indent = pp_set_max_indent std_formatter
 and get_max_indent = pp_get_max_indent std_formatter
+
+and set_geometry = pp_set_geometry std_formatter
+and get_geometry = pp_get_geometry std_formatter
 
 and set_max_boxes = pp_set_max_boxes std_formatter
 and get_max_boxes = pp_get_max_boxes std_formatter

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -786,6 +786,13 @@ let pp_set_margin state n =
     pp_set_max_indent state new_max_indent
 
 
+(** Geometry functions and types *)
+type geometry = { max_indent:int; margin: int}
+
+let check_geometry geometry =
+  geometry.max_indent >= 2
+  &&  geometry.margin >= geometry.max_indent
+
 let pp_get_margin state () = state.pp_margin
 
 let pp_set_geometry state ~max_indent ~margin =
@@ -797,7 +804,7 @@ let pp_set_geometry state ~max_indent ~margin =
     pp_set_margin state margin; pp_set_max_indent state max_indent
 
 let pp_get_geometry state () =
-  pp_get_margin state (), pp_get_max_indent state ()
+  { margin = pp_get_margin state (); max_indent = pp_get_max_indent state () }
 
 (* Setting a formatter basic output functions. *)
 let pp_set_formatter_out_functions state {

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -789,8 +789,8 @@ let pp_set_margin state n =
 let pp_get_margin state () = state.pp_margin
 
 let pp_set_geometry state ~max_indent ~margin =
-  if max_indent < 1 then
-    raise (Invalid_argument "Format.pp_set_geometry: max_indent < 1")
+  if max_indent < 2 then
+    raise (Invalid_argument "Format.pp_set_geometry: max_indent < 2")
   else if margin <= max_indent then
       raise (Invalid_argument "Format.pp_set_geometry: margin <= max_indent")
   else

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -412,7 +412,17 @@ val pp_get_max_indent : formatter -> unit -> int
 val get_max_indent : unit -> int
 (** Return the maximum indentation limit (in characters). *)
 
-(** {1 Geometry } *)
+(** {1 Geometry }
+
+Geometric functions can be used to manipulate simultaneously the
+coupled variables, margin and maxixum indentation limit.
+
+*)
+
+type geometry = { max_indent:int; margin: int}
+
+val check_geometry: geometry -> bool
+(** Check if the formatter geometry is valid: [1 < max_indent < margin] *)
 
 val pp_set_geometry : formatter -> max_indent:int -> margin:int  -> unit
 val set_geometry : max_indent:int -> margin:int -> unit
@@ -433,9 +443,9 @@ val set_geometry : max_indent:int -> margin:int -> unit
    @since 4.07.0
 *)
 
-val pp_get_geometry: formatter -> unit -> int * int
-val get_geometry: unit -> int * int
-(** Return both the maximum indentation limit and the margin
+val pp_get_geometry: formatter -> unit -> geometry
+val get_geometry: unit -> geometry
+(** Return the current geometry of the formatter
 
     @since 4.07.0
 *)

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -363,6 +363,8 @@ val set_margin : int -> unit
   maximum indentation limit is decreased while trying to preserve
   a minimal ratio [max_indent/margin>=50%] and if possible
   the current difference [margin - max_indent].
+
+  See also {!pp_set_geometry}.
 *)
 
 val pp_get_margin : formatter -> unit -> int
@@ -402,11 +404,43 @@ val set_max_indent : int -> unit
 
   If [d] is greater or equal than the current margin, it is ignored,
   and the current maximum indentation limit is kept.
+
+  See also {!pp_set_geometry}.
 *)
 
 val pp_get_max_indent : formatter -> unit -> int
 val get_max_indent : unit -> int
 (** Return the maximum indentation limit (in characters). *)
+
+(** {1 Geometry } *)
+
+val pp_set_geometry : formatter -> max_indent:int -> margin:int  -> unit
+val set_geometry : max_indent:int -> margin:int -> unit
+(**
+   [pp_set_geometry ppf ~max_indent ~margin] sets both the margin
+   and maximum indentation limit for [ppf].
+
+   When [0 < max_indent < margin],
+   [pp_set_geometry ppf ~max_indent ~margin]
+   is equivalent to
+   [pp_set_margin ppf margin; pp_set_max_indent ppf max_indent];
+   and avoids the subtly incorrect
+   [pp_set_max_indent ppf max_indent; pp_set_margin ppf margin];
+
+   Outside of this domain, [pp_set_geometry] raises an invalid argument
+   exception.
+
+   @since 4.07.0
+*)
+
+val pp_get_geometry: formatter -> unit -> int * int
+val get_geometry: unit -> int * int
+(** Return both the maximum indentation limit and the margin
+
+    @since 4.07.0
+*)
+
+
 
 (** {1 Maximum formatting depth} *)
 

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -420,7 +420,7 @@ val set_geometry : max_indent:int -> margin:int -> unit
    [pp_set_geometry ppf ~max_indent ~margin] sets both the margin
    and maximum indentation limit for [ppf].
 
-   When [0 < max_indent < margin],
+   When [1 < max_indent < margin],
    [pp_set_geometry ppf ~max_indent ~margin]
    is equivalent to
    [pp_set_margin ppf margin; pp_set_max_indent ppf max_indent];

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -442,14 +442,14 @@ val safe_set_geometry : max_indent:int -> margin:int -> unit
    Outside of this domain, [pp_set_geometry] raises an invalid argument
    exception whereas [pp_safe_set_geometry] does nothing.
 
-   @since 4.07.0
+   @since 4.08.0
 *)
 
 val pp_get_geometry: formatter -> unit -> geometry
 val get_geometry: unit -> geometry
 (** Return the current geometry of the formatter
 
-    @since 4.07.0
+    @since 4.08.0
 *)
 
 

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -424,8 +424,10 @@ type geometry = { max_indent:int; margin: int}
 val check_geometry: geometry -> bool
 (** Check if the formatter geometry is valid: [1 < max_indent < margin] *)
 
-val pp_set_geometry : formatter -> max_indent:int -> margin:int  -> unit
+val pp_set_geometry : formatter -> max_indent:int -> margin:int -> unit
 val set_geometry : max_indent:int -> margin:int -> unit
+val pp_safe_set_geometry : formatter -> max_indent:int -> margin:int -> unit
+val safe_set_geometry : max_indent:int -> margin:int -> unit
 (**
    [pp_set_geometry ppf ~max_indent ~margin] sets both the margin
    and maximum indentation limit for [ppf].
@@ -438,7 +440,7 @@ val set_geometry : max_indent:int -> margin:int -> unit
    [pp_set_max_indent ppf max_indent; pp_set_margin ppf margin];
 
    Outside of this domain, [pp_set_geometry] raises an invalid argument
-   exception.
+   exception whereas [pp_safe_set_geometry] does nothing.
 
    @since 4.07.0
 *)


### PR DESCRIPTION
[MPR7528](https://caml.inria.fr/mantis/view.php?id=7528):
This PR proposes to add a new `pp_set_geometry: formatter -> max_indent:int -> margin:int -> unit ` function to the Format module and its stdout `set_geometry` and `get` counterparts.

This new function sets both the margin and the maximum indentation limit. The labeled argument are here to avoid having two indistinguishable integer arguments.

If `0 < max_indent < margin`, `pp_set_geometry ppf ~max_indent ~margin` is equivalent to
```Ocaml
pp_set_margin ppf margin; pp_set_max_indent ppf max_indent
```
After such call, the margin and maximum indentation limit are guaranteed to be set to the requested values. 
Outside of this cone `0 < max_indent < margin`, the function raises an invalid argument exception.

The main motivation behind this new function is to avoid the memory effects that plague `set_margin` and `set_max_indent` when used separately.

In particular, even if `0 < max_indent < margin`, reversing the order of the call to `set_max_indent`
and `set_margin`, i.e.
```OCaml
set_max_indent max_indent; set_margin margin
```
may not set the maximum indentation to `max_indent`:
if the current margin `get_margin ()` is less than `max_indent`, the call to `set_max_indent` fails silently and let unchanged the current value of the maximum indentation limit.
Even worse, if `max_indent > margin`, the resulting formatter state may invisibly depend on the order of the calls to `set_margin` and `set_max_indent`, the current margin, and the current maximum indentation limit. Similarly, setting only the margin with `set_margin` can modify the maximum indentation limit and the resulting maximum indentation limit depends on the history of the calls to `set_margin`, e.g. `set_margin 120; set_margin 60; set_margin 50` leads to a different state than `set_margin 90; set_margin 60; set_margin 50`.

I made the choice of raising an exception due to the difficulty of defining a completely non-surprising projector on the cone `0< max_indent < margin` . In particular, for `max_indent >= margin > 1`, what is the nearest point on the cone? Is it `(margin-1,margin)`, or `(max_indent, max_indent + 1)`, or maybe the middle point `( (max_indent + margin - 1) / 2, (margin + max_indent + 1) /2 )`?

For reference, in #1236 @jberdine alternatively suggested to have a `pp_set_geometry_with_offset` function (with a better name) that takes the  offset `margin - max_indent` and `margin` as argument; but I thought it will be clearer with the existing documentation to keep `max_indent` as an argument.