### PR TITLE
Add "Hint:" to a suggestion message related to coercion failures

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5056,9 +5056,10 @@ let report_error env ppf = function
         (function ppf ->
            fprintf ppf "but is here used with type");
       if b then
-        fprintf ppf ".@.@[<hov>%s@ %s@]"
+        fprintf ppf ".@.@[<hov>%s@ %s@ %s@]"
           "This simple coercion was not fully general."
-          "Consider using a double coercion."
+          "Hint: Consider using a fully explicit coercion"
+          "of the form: `(foo : ty1 :> ty2)'."
   | Too_many_arguments (in_function, ty) ->
       reset_and_mark_loops ty;
       if in_function then begin


### PR DESCRIPTION
The goal is to consistently mark suggestions in error messages with "Hint:", as already done with the [spellcheck suggestion](https://github.com/ocaml/ocaml/blob/trunk/utils/misc.ml#L508) and the [missing rec suggestion](https://github.com/ocaml/ocaml/blob/trunk/typing/typecore.ml#L5178). 

This change was suggested by @garrigue ; since it's only a one line change i'm not sure a Changes entry is needed..?