### PR TITLE
More command line options for expect tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -64,6 +64,9 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- GPR#1502: more command line options for expect tests
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Bug fixes
 
 - MPR#6394, GPR#1425: fix fatal_error from Parmatch.get_type_path

--- a/testsuite/makefiles/Makefile.expect
+++ b/testsuite/makefiles/Makefile.expect
@@ -16,8 +16,8 @@
 default:
 	@for file in *.ml; do \
 	  printf " ... testing '$$file':"; \
-	  TERM=dumb $(EXPECT_TEST) -repo-root $(OTOPDIR) $$file && \
-	  TERM=dumb $(EXPECT_TEST) -repo-root $(OTOPDIR) -principal \
+	  TERM=dumb $(EXPECT_TEST) $(EXPECT_FLAGS) -repo-root $(OTOPDIR) $$file && \
+	  TERM=dumb $(EXPECT_TEST) $(EXPECT_FLAGS) -repo-root $(OTOPDIR) -principal \
 	    $$file.corrected && \
 	  mv $$file.corrected.corrected $$file.corrected && \
 	  $(DIFF) $$file $$file.corrected && \

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -328,13 +328,71 @@ let main fname =
   process_expect_file fname;
   exit 0
 
+module Options = Main_args.Make_bytetop_options (struct
+  let set r () = r := true
+  let clear r () = r := false
+  open Clflags
+  let _absname = set Location.absname
+  let _I dir =
+    let dir = Misc.expand_directory Config.standard_library dir in
+    include_dirs := dir :: !include_dirs
+  let _init s = init_file := Some s
+  let _noinit = set noinit
+  let _labels = clear classic
+  let _alias_deps = clear transparent_modules
+  let _no_alias_deps = set transparent_modules
+  let _app_funct = set applicative_functors
+  let _no_app_funct = clear applicative_functors
+  let _noassert = set noassert
+  let _nolabels = set classic
+  let _noprompt = set noprompt
+  let _nopromptcont = set nopromptcont
+  let _nostdlib = set no_std_include
+  let _open s = open_modules := s :: !open_modules
+  let _ppx _s = (* disabled *) ()
+  let _principal = set principal
+  let _no_principal = clear principal
+  let _rectypes = set recursive_types
+  let _no_rectypes = clear recursive_types
+  let _safe_string = clear unsafe_string
+  let _short_paths = clear real_paths
+  let _stdin () = (* disabled *) ()
+  let _strict_sequence = set strict_sequence
+  let _no_strict_sequence = clear strict_sequence
+  let _strict_formats = set strict_formats
+  let _no_strict_formats = clear strict_formats
+  let _unboxed_types = set unboxed_types
+  let _no_unboxed_types = clear unboxed_types
+  let _unsafe = set fast
+  let _unsafe_string = set unsafe_string
+  let _version () = (* disabled *) ()
+  let _vnum () = (* disabled *) ()
+  let _no_version = set noversion
+  let _w s = Warnings.parse_options false s
+  let _warn_error s = Warnings.parse_options true s
+  let _warn_help = Warnings.help_warnings
+  let _dparsetree = set dump_parsetree
+  let _dtypedtree = set dump_typedtree
+  let _dsource = set dump_source
+  let _drawlambda = set dump_rawlambda
+  let _dlambda = set dump_lambda
+  let _dflambda = set dump_flambda
+  let _dtimings () = profile_columns := [ `Time ]
+  let _dprofile () = profile_columns := Profile.all_columns
+  let _dinstr = set dump_instr
+
+  let _args = Arg.read_arg
+  let _args0 = Arg.read_arg0
+
+  let anonymous s = main s
+end);;
+
 let args =
   Arg.align
-    [ "-repo-root", Set_string repo_root,
-      "<dir> root of the OCaml repository"
-    ; "-principal", Set Clflags.principal,
-      " Evaluate the file with -principal set"
-    ]
+    ( [ "-repo-root", Arg.Set_string repo_root,
+        "<dir> root of the OCaml repository"
+      ] @ Options.list
+    )
 
 let usage = "Usage: expect_test <options> [script-file [arguments]]\n\
              options are:"


### PR DESCRIPTION
This PR (mostly cherry-picked from #1481) updates the `expect_test` tool in order to handle most of the options of the toplevel; this was needed for testing the error size option in #1481, and @Armael mentioned recently that he might also use this possibility. It also adds a new makefile variable for passing such options to `expect_test` for makefile-based tests.