### PR TITLE
Fix the lib-systhreads test

### DIFF
--- a/testsuite/tests/lib-systhreads/Makefile
+++ b/testsuite/tests/lib-systhreads/Makefile
@@ -15,7 +15,7 @@
 
 BASEDIR=../..
 LIBRARIES=unix threads
-ADD_COMPFLAGS=-thread -I $(OTOPDIR)/otherlibs/systhreads \
+ADD_COMPFLAGS=-I $(OTOPDIR)/otherlibs/systhreads \
 	      -I $(OTOPDIR)/otherlibs/$(UNIXLIBVAR)unix
 LD_PATH=$(TOPDIR)/otherlibs/systhreads:$(TOPDIR)/otherlibs/$(UNIXLIBVAR)unix
 


### PR DESCRIPTION
(@damiendoligez I believe this to be the right fix for the Mac OS
warning we discussed these days.)

This test was using the -thread option while this is not appropriate.

Indeed, the effect of this option is to add "+threads" to the list of
included directories, which will be expanded to the path of the
sys_threads library under the installed standard library.

This is useless because the right path is already specified explicitly.

Moreover, on some platforms like Mac OS 10.12 or Mac OS 10.13, when OCaml is not
installed on the system, the test as done before this commit leads to
the following warning:

ld: warning: directory not found for option '-L/usr/local/lib/ocaml/threads'

Finally if there is already a version of OCaml installed on the system,
this may cause the incorrect library to be used.