### PR TITLE
Add specific explanation for unification errors involving functions of type unit -> _

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,6 +42,11 @@ Working version
   in order to avoid duplicating pattern matches
   (Armaël Guéneau, review by Florian Angeletti and Gabriel Scherer)
 
+- GPR#1505: Add specific error messages for unification errors involving
+  functions of type "unit -> _"
+  (Arthur Charguéraud and Armaël Guéneau, with help from Leo White, review by
+  Florian Angeletti and Gabriel Radanne)
+
 ### Code generation and optimizations:
 
 ### Runtime system:

--- a/testsuite/tests/typing-core-bugs/Makefile
+++ b/testsuite/tests/typing-core-bugs/Makefile
@@ -14,5 +14,6 @@
 #########################################################################
 
 BASEDIR=../..
+EXPECT_FLAGS=-strict-sequence
 include $(BASEDIR)/makefiles/Makefile.expect
 include $(BASEDIR)/makefiles/Makefile.common

--- a/testsuite/tests/typing-core-bugs/unit_fun_hints.ml
+++ b/testsuite/tests/typing-core-bugs/unit_fun_hints.ml
@@ -1,0 +1,57 @@
+let g f = f ()
+let _ = g 3;;       (* missing `fun () ->' *)
+
+[%%expect{|
+val g : (unit -> 'a) -> 'a = <fun>
+Line _, characters 10-11:
+Error: This expression has type int but an expression was expected of type
+         unit -> 'a
+       Hint: Did you forget to wrap the expression using `fun () ->'?
+|}];;
+
+
+let _ =
+   print_int 3;
+   print_newline;    (* missing unit argument *)
+   print_int 5;;
+
+(* We use -strict-sequence for this test: otherwise only a warning is produced
+   about print_newline not being of type unit *)
+[%%expect{|
+Line _, characters 3-16:
+Error: This expression has type unit -> unit
+       but an expression was expected of type unit
+       Hint: Did you forget to provide `()' as argument?
+|}];;
+
+let x = read_int in   (* missing unit argument *)
+print_int x;;
+
+[%%expect{|
+Line _, characters 10-11:
+Error: This expression has type unit -> int
+       but an expression was expected of type int
+       Hint: Did you forget to provide `()' as argument?
+|}];;
+
+let g f =
+  let _ = f () in
+  f = 3;;
+
+[%%expect{|
+Line _, characters 6-7:
+Error: This expression has type int but an expression was expected of type
+         unit -> 'a
+       Hint: Did you forget to wrap the expression using `fun () ->'?
+|}];;
+
+let g f =
+  let _ = f () in
+  3 = f;;
+
+[%%expect{|
+Line _, characters 6-7:
+Error: This expression has type unit -> 'a
+       but an expression was expected of type int
+       Hint: Did you forget to provide `()' as argument?
+|}]


### PR DESCRIPTION
This is another small change extracted from PR #102 by @charguer . Its purpose is to provide suggestions for the common mistake of forgetting to pass `()` as argument to functions e.g. `print_newline`. The patch has also be extended to handle the symmetric situation where a value is passed instead of a thunk (and thus a `fun () ->` is missing).

@garrigue mentioned offline that there could be an issue in interaction with optional arguments (in which case we would disable the message in presence of functions with optional/labeled arguments) -- but I couldn't reproduce the issue.  (cf the example we noted)

```
  let g f = f (); f ~a:1 ()
  let f ?(a=1) () = a + 1
```