### PR TITLE
Add explanation for errors caused by a type constraint propagated from a keyword

### DIFF
--- a/Changes
+++ b/Changes
@@ -74,6 +74,11 @@ Working version
   (Armaël Guéneau, with help and review from Florian Angeletti and Gabriel
   Scherer)
 
+- GPR#1510: Add specific explanation for unification errors caused by type
+  constraints propagated by keywords (such as if, while, for...)
+  (Armaël Guéneau and Gabriel Scherer, original design by Arthur Charguéraud,
+  review by Frédéric Bour, Gabriel Radanne and Alain Frisch)
+
 ### Code generation and optimizations:
 
 - GPR#1370: Fix code duplication in Cmmgen

--- a/testsuite/tests/typing-core-bugs/ocamltests
+++ b/testsuite/tests/typing-core-bugs/ocamltests
@@ -2,3 +2,4 @@ example_let_missing_rec_loc.ml
 example_let_missing_rec.ml
 example_let_missing_rec_mutual.ml
 unit_fun_hints.ml
+type_expected_explanation.ml

--- a/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
+++ b/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
@@ -1,0 +1,177 @@
+(* TEST
+   flags = "-strict-sequence"
+   * expect
+*)
+
+if 3 then ();;
+
+[%%expect{|
+Line _, characters 3-4:
+  if 3 then ();;
+     ^
+Error: This expression has type int but an expression was expected of type
+         bool
+       because it is in the condition of an if-statement
+|}];;
+
+fun b -> if true then (print_int b) else (if b then ());;
+
+[%%expect{|
+Line _, characters 45-46:
+  fun b -> if true then (print_int b) else (if b then ());;
+                                               ^
+Error: This expression has type int but an expression was expected of type
+         bool
+       because it is in the condition of an if-statement
+|}];;
+
+(* Left-to-right bias is still there: if we swap the branches, the new error
+   message does not show up because of propagation order. *)
+fun b -> if true then (if b then ()) else (print_int b);;
+
+[%%expect{|
+Line _, characters 53-54:
+  fun b -> if true then (if b then ()) else (print_int b);;
+                                                       ^
+Error: This expression has type bool but an expression was expected of type
+         int
+|}];;
+
+if (let x = 3 in x) then ();;
+
+[%%expect{|
+Line _, characters 17-18:
+  if (let x = 3 in x) then ();;
+                   ^
+Error: This expression has type int but an expression was expected of type
+         bool
+       because it is in the condition of an if-statement
+|}];;
+
+if (if true then 3 else 4) then ();;
+
+[%%expect{|
+Line _, characters 17-18:
+  if (if true then 3 else 4) then ();;
+                   ^
+Error: This expression has type int but an expression was expected of type
+         bool
+       because it is in the condition of an if-statement
+|}];;
+
+if true then 3;;
+
+[%%expect{|
+Line _, characters 13-14:
+  if true then 3;;
+               ^
+Error: This expression has type int but an expression was expected of type
+         unit
+       because it is in the result of a conditional with no else branch
+|}];;
+
+if (fun x -> x) then ();;
+
+[%%expect{|
+Line _, characters 3-15:
+  if (fun x -> x) then ();;
+     ^^^^^^^^^^^^
+Error: This expression should not be a function, the expected type is
+bool
+because it is in the condition of an if-statement
+|}];;
+
+while 42 do () done;;
+
+[%%expect{|
+Line _, characters 6-8:
+  while 42 do () done;;
+        ^^
+Error: This expression has type int but an expression was expected of type
+         bool
+       because it is in the condition of a while-loop
+|}];;
+
+(* -strict-sequence is required for this test to fail, otherwise only a warning
+   is produced *)
+while true do (if true then 3 else 4) done;;
+
+[%%expect{|
+Line _, characters 14-37:
+  while true do (if true then 3 else 4) done;;
+                ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type int but an expression was expected of type
+         unit
+       because it is in the body of a while-loop
+|}];;
+
+for i = 3. to 4 do () done;;
+
+[%%expect{|
+Line _, characters 8-10:
+  for i = 3. to 4 do () done;;
+          ^^
+Error: This expression has type float but an expression was expected of type
+         int
+       because it is in a for-loop start index
+|}];;
+
+for i = 3 to 4. do () done;;
+
+[%%expect{|
+Line _, characters 13-15:
+  for i = 3 to 4. do () done;;
+               ^^
+Error: This expression has type float but an expression was expected of type
+         int
+       because it is in a for-loop stop index
+|}];;
+
+(* -strict-sequence is required for this test to fail, otherwise only a warning
+   is produced *)
+for i = 0 to 0 do (if true then 3 else 4) done;;
+
+[%%expect{|
+Line _, characters 18-41:
+  for i = 0 to 0 do (if true then 3 else 4) done;;
+                    ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type int but an expression was expected of type
+         unit
+       because it is in the body of a for-loop
+|}];;
+
+assert 12;;
+
+[%%expect{|
+Line _, characters 7-9:
+  assert 12;;
+         ^^
+Error: This expression has type int but an expression was expected of type
+         bool
+       because it is in the condition of an assertion
+|}];;
+
+(* -strict-sequence is also required for this test to fail *)
+(let x = 3 in x+1); ();;
+
+[%%expect{|
+Line _, characters 0-18:
+  (let x = 3 in x+1); ();;
+  ^^^^^^^^^^^^^^^^^^
+Error: This expression has type int but an expression was expected of type
+         unit
+       because it is in the left-hand side of a sequence
+|}];;
+
+let ordered_list_with x y =
+  if x <= y then [x;y]
+  else if x > y then [y;x]
+
+[%%expect{|
+Line _, characters 22-26:
+    else if x > y then [y;x]
+                        ^^^^
+Error: This variant expression is expected to have type unit
+         because it is in the result of a conditional with no else branch
+       The constructor :: does not belong to type unit
+|}];;

--- a/testsuite/tests/typing-core-bugs/unit_fun_hints.ml
+++ b/testsuite/tests/typing-core-bugs/unit_fun_hints.ml
@@ -30,6 +30,7 @@ Line _, characters 3-16:
      ^^^^^^^^^^^^^
 Error: This expression has type unit -> unit
        but an expression was expected of type unit
+       because it is in the left-hand side of a sequence
        Hint: Did you forget to provide `()' as argument?
 |}];;
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1565,7 +1565,7 @@ let rec trace_same_names = function
       type_same_name t1 t2; type_same_name t1' t2'; trace_same_names rem
   | _ -> ()
 
-let unification_error env unif tr txt1 ppf txt2 =
+let unification_error env unif tr txt1 ppf txt2 ty_expect_explanation =
   reset ();
   trace_same_names tr;
   let tr = List.map (fun (t, t') -> (t, hide_variant_name t')) tr in
@@ -1583,10 +1583,12 @@ let unification_error env unif tr txt1 ppf txt2 =
         "@[<v>\
           @[%t@;<1 2>%a@ \
             %t@;<1 2>%a\
+            %t\
           @]%a%t\
          @]"
         txt1 (type_expansion t1) t1'
         txt2 (type_expansion t2) t2'
+        ty_expect_explanation
         (trace false "is not compatible with type") tr
         (explain mis);
       if env <> Env.empty
@@ -1599,9 +1601,11 @@ let unification_error env unif tr txt1 ppf txt2 =
       print_labels := true;
       raise exn
 
-let report_unification_error ppf env ?(unif=true)
-    tr txt1 txt2 =
-  wrap_printing_env env (fun () -> unification_error env unif tr txt1 ppf txt2)
+let report_unification_error ppf env ?(unif=true) tr
+    ?(type_expected_explanation = fun _ -> ())
+    txt1 txt2 =
+  wrap_printing_env env (fun () -> unification_error env unif tr txt1 ppf txt2
+                            type_expected_explanation)
 ;;
 
 let trace fst keep_last txt ppf tr =

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -75,7 +75,9 @@ val prepare_expansion: type_expr * type_expr -> type_expr * type_expr
 val trace:
     bool -> bool-> string -> formatter -> (type_expr * type_expr) list -> unit
 val report_unification_error:
-    formatter -> Env.t -> ?unif:bool -> (type_expr * type_expr) list ->
+    formatter -> Env.t -> ?unif:bool ->
+    (type_expr * type_expr) list ->
+    ?type_expected_explanation:(formatter -> unit) ->
     (formatter -> unit) -> (formatter -> unit) ->
     unit
 val report_subtyping_error:

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -737,8 +737,9 @@ and class_field_aux self_loc cl_num self_type meths vars
           (fun () ->
              (* Read the generalized type *)
              let (_, ty) = Meths.find lab.txt !meths in
-             let meth_type =
-               Btype.newgenty (Tarrow(Nolabel, self_type, ty, Cok)) in
+             let meth_type = mk_expected (
+               Btype.newgenty (Tarrow(Nolabel, self_type, ty, Cok))
+             ) in
              Ctype.raise_nongen_level ();
              vars := vars_local;
              let texp = type_expect met_env meth_expr meth_type in
@@ -762,10 +763,11 @@ and class_field_aux self_loc cl_num self_type meths vars
       let field =
         lazy begin
           Ctype.raise_nongen_level ();
-          let meth_type =
+          let meth_type = mk_expected (
             Ctype.newty
               (Tarrow (Nolabel, self_type,
-                       Ctype.instance_def Predef.type_unit, Cok)) in
+                       Ctype.instance_def Predef.type_unit, Cok))
+          ) in
           vars := vars_local;
           let texp = type_expect met_env expr meth_type in
           Ctype.end_def ();


### PR DESCRIPTION
Another change extracted from PR #102 . This adds specific explanation for type errors that involve type information propagated by a keyword such as if, for, while...

For example,
```
if true then 42
```
highlights "42" and prints:
```
Error: This expression has type int but an expression was expected of type
         unit because it is the result of a conditional with no else branch
```

The idea for this patch comes from #102 but the implementation proposed here is different. The original patch changed the order of propagation in order to get more precise information -- but this doesn't interact well with non-principality AFAIU. The approach followed in this patch is as follows: in the `type_expect` function, we add an "explanation" optional argument. If unification fails between something and the expected type `ty_expected`, then this explanation (if present) explains why this type was expected (e.g. "because it was the body of a for-loop"). When `type_expect` calls itself recursively with a different expected type, the explanation is dropped.
