### PR TITLE
Enforce that .depend files are up to date

### DIFF
--- a/.depend
+++ b/.depend
@@ -1,2312 +1,5545 @@
-utils/arg_helper.cmo : utils/arg_helper.cmi
-utils/arg_helper.cmx : utils/arg_helper.cmi
+utils/arg_helper.cmo : \
+  utils/arg_helper.cmi
+utils/arg_helper.cmx : \
+  utils/arg_helper.cmi
 utils/arg_helper.cmi :
-utils/ccomp.cmo : utils/misc.cmi utils/config.cmi utils/clflags.cmi \
-    utils/ccomp.cmi
-utils/ccomp.cmx : utils/misc.cmx utils/config.cmx utils/clflags.cmx \
-    utils/ccomp.cmi
+utils/ccomp.cmo : \
+  utils/ccomp.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+utils/ccomp.cmx : \
+  utils/ccomp.cmi \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
 utils/ccomp.cmi :
-utils/clflags.cmo : utils/profile.cmi utils/numbers.cmi utils/misc.cmi \
-    utils/config.cmi utils/arg_helper.cmi utils/clflags.cmi
-utils/clflags.cmx : utils/profile.cmx utils/numbers.cmx utils/misc.cmx \
-    utils/config.cmx utils/arg_helper.cmx utils/clflags.cmi
-utils/clflags.cmi : utils/profile.cmi utils/misc.cmi
-utils/config.cmo : utils/config.cmi
-utils/config.cmx : utils/config.cmi
+utils/clflags.cmo : \
+  utils/arg_helper.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/numbers.cmi \
+  utils/profile.cmi
+utils/clflags.cmx : \
+  utils/arg_helper.cmx \
+  utils/clflags.cmi \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/numbers.cmx \
+  utils/profile.cmx
+utils/clflags.cmi : \
+  utils/misc.cmi \
+  utils/profile.cmi
+utils/config.cmo : \
+  utils/config.cmi
+utils/config.cmx : \
+  utils/config.cmi
 utils/config.cmi :
-utils/consistbl.cmo : utils/consistbl.cmi
-utils/consistbl.cmx : utils/consistbl.cmi
+utils/consistbl.cmo : \
+  utils/consistbl.cmi
+utils/consistbl.cmx : \
+  utils/consistbl.cmi
 utils/consistbl.cmi :
-utils/identifiable.cmo : utils/misc.cmi utils/identifiable.cmi
-utils/identifiable.cmx : utils/misc.cmx utils/identifiable.cmi
+utils/identifiable.cmo : \
+  utils/identifiable.cmi \
+  utils/misc.cmi
+utils/identifiable.cmx : \
+  utils/identifiable.cmi \
+  utils/misc.cmx
 utils/identifiable.cmi :
-utils/misc.cmo : utils/misc.cmi
-utils/misc.cmx : utils/misc.cmi
+utils/misc.cmo : \
+  utils/misc.cmi
+utils/misc.cmx : \
+  utils/misc.cmi
 utils/misc.cmi :
-utils/numbers.cmo : utils/misc.cmi utils/identifiable.cmi utils/numbers.cmi
-utils/numbers.cmx : utils/misc.cmx utils/identifiable.cmx utils/numbers.cmi
-utils/numbers.cmi : utils/identifiable.cmi
-utils/profile.cmo : utils/misc.cmi utils/profile.cmi
-utils/profile.cmx : utils/misc.cmx utils/profile.cmi
+utils/numbers.cmo : \
+  utils/identifiable.cmi \
+  utils/misc.cmi \
+  utils/numbers.cmi
+utils/numbers.cmx : \
+  utils/identifiable.cmx \
+  utils/misc.cmx \
+  utils/numbers.cmi
+utils/numbers.cmi : \
+  utils/identifiable.cmi
+utils/profile.cmo : \
+  utils/misc.cmi \
+  utils/profile.cmi
+utils/profile.cmx : \
+  utils/misc.cmx \
+  utils/profile.cmi
 utils/profile.cmi :
-utils/strongly_connected_components.cmo : utils/numbers.cmi utils/misc.cmi \
-    utils/identifiable.cmi utils/strongly_connected_components.cmi
-utils/strongly_connected_components.cmx : utils/numbers.cmx utils/misc.cmx \
-    utils/identifiable.cmx utils/strongly_connected_components.cmi
-utils/strongly_connected_components.cmi : utils/identifiable.cmi
-utils/targetint.cmo : utils/misc.cmi utils/targetint.cmi
-utils/targetint.cmx : utils/misc.cmx utils/targetint.cmi
+utils/strongly_connected_components.cmo : \
+  utils/identifiable.cmi \
+  utils/misc.cmi \
+  utils/numbers.cmi \
+  utils/strongly_connected_components.cmi
+utils/strongly_connected_components.cmx : \
+  utils/identifiable.cmx \
+  utils/misc.cmx \
+  utils/numbers.cmx \
+  utils/strongly_connected_components.cmi
+utils/strongly_connected_components.cmi : \
+  utils/identifiable.cmi
+utils/targetint.cmo : \
+  utils/misc.cmi \
+  utils/targetint.cmi
+utils/targetint.cmx : \
+  utils/misc.cmx \
+  utils/targetint.cmi
 utils/targetint.cmi :
-utils/tbl.cmo : utils/tbl.cmi
-utils/tbl.cmx : utils/tbl.cmi
+utils/tbl.cmo : \
+  utils/tbl.cmi
+utils/tbl.cmx : \
+  utils/tbl.cmi
 utils/tbl.cmi :
-utils/terminfo.cmo : utils/terminfo.cmi
-utils/terminfo.cmx : utils/terminfo.cmi
+utils/terminfo.cmo : \
+  utils/terminfo.cmi
+utils/terminfo.cmx : \
+  utils/terminfo.cmi
 utils/terminfo.cmi :
-utils/warnings.cmo : utils/misc.cmi utils/warnings.cmi
-utils/warnings.cmx : utils/misc.cmx utils/warnings.cmi
+utils/warnings.cmo : \
+  utils/misc.cmi \
+  utils/warnings.cmi
+utils/warnings.cmx : \
+  utils/misc.cmx \
+  utils/warnings.cmi
 utils/warnings.cmi :
-parsing/ast_helper.cmo : parsing/syntaxerr.cmi parsing/parsetree.cmi \
-    parsing/longident.cmi parsing/location.cmi parsing/docstrings.cmi \
-    parsing/asttypes.cmi parsing/ast_helper.cmi
-parsing/ast_helper.cmx : parsing/syntaxerr.cmx parsing/parsetree.cmi \
-    parsing/longident.cmx parsing/location.cmx parsing/docstrings.cmx \
-    parsing/asttypes.cmi parsing/ast_helper.cmi
-parsing/ast_helper.cmi : parsing/parsetree.cmi parsing/longident.cmi \
-    parsing/location.cmi parsing/docstrings.cmi parsing/asttypes.cmi
-parsing/ast_invariants.cmo : parsing/syntaxerr.cmi parsing/parsetree.cmi \
-    parsing/longident.cmi parsing/builtin_attributes.cmi parsing/asttypes.cmi \
-    parsing/ast_iterator.cmi parsing/ast_invariants.cmi
-parsing/ast_invariants.cmx : parsing/syntaxerr.cmx parsing/parsetree.cmi \
-    parsing/longident.cmx parsing/builtin_attributes.cmx parsing/asttypes.cmi \
-    parsing/ast_iterator.cmx parsing/ast_invariants.cmi
-parsing/ast_invariants.cmi : parsing/parsetree.cmi
-parsing/ast_iterator.cmo : parsing/parsetree.cmi parsing/location.cmi \
-    parsing/ast_iterator.cmi
-parsing/ast_iterator.cmx : parsing/parsetree.cmi parsing/location.cmx \
-    parsing/ast_iterator.cmi
-parsing/ast_iterator.cmi : parsing/parsetree.cmi parsing/location.cmi
-parsing/ast_mapper.cmo : parsing/parsetree.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi utils/config.cmi \
-    utils/clflags.cmi parsing/asttypes.cmi parsing/ast_helper.cmi \
-    parsing/ast_mapper.cmi
-parsing/ast_mapper.cmx : parsing/parsetree.cmi utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx utils/config.cmx \
-    utils/clflags.cmx parsing/asttypes.cmi parsing/ast_helper.cmx \
-    parsing/ast_mapper.cmi
-parsing/ast_mapper.cmi : parsing/parsetree.cmi parsing/location.cmi
-parsing/asttypes.cmi : parsing/location.cmi
-parsing/attr_helper.cmo : parsing/parsetree.cmi parsing/location.cmi \
-    parsing/asttypes.cmi parsing/attr_helper.cmi
-parsing/attr_helper.cmx : parsing/parsetree.cmi parsing/location.cmx \
-    parsing/asttypes.cmi parsing/attr_helper.cmi
-parsing/attr_helper.cmi : parsing/parsetree.cmi parsing/location.cmi \
-    parsing/asttypes.cmi
-parsing/builtin_attributes.cmo : utils/warnings.cmi parsing/parsetree.cmi \
-    parsing/location.cmi parsing/asttypes.cmi parsing/builtin_attributes.cmi
-parsing/builtin_attributes.cmx : utils/warnings.cmx parsing/parsetree.cmi \
-    parsing/location.cmx parsing/asttypes.cmi parsing/builtin_attributes.cmi
-parsing/builtin_attributes.cmi : parsing/parsetree.cmi parsing/location.cmi
-parsing/depend.cmo : parsing/parsetree.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi utils/clflags.cmi \
-    parsing/builtin_attributes.cmi parsing/asttypes.cmi parsing/depend.cmi
-parsing/depend.cmx : parsing/parsetree.cmi utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx utils/clflags.cmx \
-    parsing/builtin_attributes.cmx parsing/asttypes.cmi parsing/depend.cmi
-parsing/depend.cmi : parsing/parsetree.cmi parsing/longident.cmi
-parsing/docstrings.cmo : utils/warnings.cmi parsing/parsetree.cmi \
-    parsing/location.cmi parsing/docstrings.cmi
-parsing/docstrings.cmx : utils/warnings.cmx parsing/parsetree.cmi \
-    parsing/location.cmx parsing/docstrings.cmi
-parsing/docstrings.cmi : parsing/parsetree.cmi parsing/location.cmi
-parsing/lexer.cmo : utils/warnings.cmi parsing/parser.cmi utils/misc.cmi \
-    parsing/location.cmi parsing/docstrings.cmi parsing/lexer.cmi
-parsing/lexer.cmx : utils/warnings.cmx parsing/parser.cmx utils/misc.cmx \
-    parsing/location.cmx parsing/docstrings.cmx parsing/lexer.cmi
-parsing/lexer.cmi : parsing/parser.cmi parsing/location.cmi
-parsing/location.cmo : utils/warnings.cmi utils/terminfo.cmi utils/misc.cmi \
-    utils/clflags.cmi parsing/location.cmi
-parsing/location.cmx : utils/warnings.cmx utils/terminfo.cmx utils/misc.cmx \
-    utils/clflags.cmx parsing/location.cmi
-parsing/location.cmi : utils/warnings.cmi
-parsing/longident.cmo : utils/misc.cmi parsing/longident.cmi
-parsing/longident.cmx : utils/misc.cmx parsing/longident.cmi
+parsing/ast_helper.cmo : \
+  parsing/ast_helper.cmi \
+  parsing/asttypes.cmi \
+  parsing/docstrings.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  parsing/syntaxerr.cmi
+parsing/ast_helper.cmx : \
+  parsing/ast_helper.cmi \
+  parsing/asttypes.cmi \
+  parsing/docstrings.cmx \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  parsing/syntaxerr.cmx
+parsing/ast_helper.cmi : \
+  parsing/asttypes.cmi \
+  parsing/docstrings.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi
+parsing/ast_invariants.cmo : \
+  parsing/ast_invariants.cmi \
+  parsing/ast_iterator.cmi \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  parsing/syntaxerr.cmi
+parsing/ast_invariants.cmx : \
+  parsing/ast_invariants.cmi \
+  parsing/ast_iterator.cmx \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  parsing/syntaxerr.cmx
+parsing/ast_invariants.cmi : \
+  parsing/parsetree.cmi
+parsing/ast_iterator.cmo : \
+  parsing/ast_iterator.cmi \
+  parsing/location.cmi \
+  parsing/parsetree.cmi
+parsing/ast_iterator.cmx : \
+  parsing/ast_iterator.cmi \
+  parsing/location.cmx \
+  parsing/parsetree.cmi
+parsing/ast_iterator.cmi : \
+  parsing/location.cmi \
+  parsing/parsetree.cmi
+parsing/ast_mapper.cmo : \
+  parsing/ast_helper.cmi \
+  parsing/ast_mapper.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+parsing/ast_mapper.cmx : \
+  parsing/ast_helper.cmx \
+  parsing/ast_mapper.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+parsing/ast_mapper.cmi : \
+  parsing/location.cmi \
+  parsing/parsetree.cmi
+parsing/asttypes.cmi : \
+  parsing/location.cmi
+parsing/attr_helper.cmo : \
+  parsing/asttypes.cmi \
+  parsing/attr_helper.cmi \
+  parsing/location.cmi \
+  parsing/parsetree.cmi
+parsing/attr_helper.cmx : \
+  parsing/asttypes.cmi \
+  parsing/attr_helper.cmi \
+  parsing/location.cmx \
+  parsing/parsetree.cmi
+parsing/attr_helper.cmi : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/parsetree.cmi
+parsing/builtin_attributes.cmo : \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmi \
+  parsing/location.cmi \
+  parsing/parsetree.cmi \
+  utils/warnings.cmi
+parsing/builtin_attributes.cmx : \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmi \
+  parsing/location.cmx \
+  parsing/parsetree.cmi \
+  utils/warnings.cmx
+parsing/builtin_attributes.cmi : \
+  parsing/location.cmi \
+  parsing/parsetree.cmi
+parsing/depend.cmo : \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmi \
+  parsing/depend.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+parsing/depend.cmx : \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmx \
+  parsing/depend.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  utils/clflags.cmx \
+  utils/misc.cmx
+parsing/depend.cmi : \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi
+parsing/docstrings.cmo : \
+  parsing/docstrings.cmi \
+  parsing/location.cmi \
+  parsing/parsetree.cmi \
+  utils/warnings.cmi
+parsing/docstrings.cmx : \
+  parsing/docstrings.cmi \
+  parsing/location.cmx \
+  parsing/parsetree.cmi \
+  utils/warnings.cmx
+parsing/docstrings.cmi : \
+  parsing/location.cmi \
+  parsing/parsetree.cmi
+parsing/lexer.cmo : \
+  parsing/docstrings.cmi \
+  parsing/lexer.cmi \
+  parsing/location.cmi \
+  parsing/parser.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+parsing/lexer.cmx : \
+  parsing/docstrings.cmx \
+  parsing/lexer.cmi \
+  parsing/location.cmx \
+  parsing/parser.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+parsing/lexer.cmi : \
+  parsing/location.cmi \
+  parsing/parser.cmi
+parsing/location.cmo : \
+  parsing/location.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi \
+  utils/terminfo.cmi \
+  utils/warnings.cmi
+parsing/location.cmx : \
+  parsing/location.cmi \
+  utils/clflags.cmx \
+  utils/misc.cmx \
+  utils/terminfo.cmx \
+  utils/warnings.cmx
+parsing/location.cmi : \
+  utils/warnings.cmi
+parsing/longident.cmo : \
+  parsing/longident.cmi \
+  utils/misc.cmi
+parsing/longident.cmx : \
+  parsing/longident.cmi \
+  utils/misc.cmx
 parsing/longident.cmi :
-parsing/parse.cmo : parsing/syntaxerr.cmi parsing/parser.cmi \
-    parsing/location.cmi parsing/lexer.cmi parsing/docstrings.cmi \
-    parsing/parse.cmi
-parsing/parse.cmx : parsing/syntaxerr.cmx parsing/parser.cmx \
-    parsing/location.cmx parsing/lexer.cmx parsing/docstrings.cmx \
-    parsing/parse.cmi
-parsing/parse.cmi : parsing/parsetree.cmi
-parsing/parser.cmo : parsing/syntaxerr.cmi parsing/parsetree.cmi \
-    parsing/longident.cmi parsing/location.cmi parsing/docstrings.cmi \
-    utils/clflags.cmi parsing/asttypes.cmi parsing/ast_helper.cmi \
-    parsing/parser.cmi
-parsing/parser.cmx : parsing/syntaxerr.cmx parsing/parsetree.cmi \
-    parsing/longident.cmx parsing/location.cmx parsing/docstrings.cmx \
-    utils/clflags.cmx parsing/asttypes.cmi parsing/ast_helper.cmx \
-    parsing/parser.cmi
-parsing/parser.cmi : parsing/parsetree.cmi parsing/location.cmi \
-    parsing/docstrings.cmi
-parsing/parsetree.cmi : parsing/longident.cmi parsing/location.cmi \
-    parsing/asttypes.cmi
-parsing/pprintast.cmo : parsing/parsetree.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi parsing/asttypes.cmi \
-    parsing/ast_helper.cmi parsing/pprintast.cmi
-parsing/pprintast.cmx : parsing/parsetree.cmi utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx parsing/asttypes.cmi \
-    parsing/ast_helper.cmx parsing/pprintast.cmi
-parsing/pprintast.cmi : parsing/parsetree.cmi
-parsing/printast.cmo : parsing/parsetree.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi parsing/asttypes.cmi \
-    parsing/printast.cmi
-parsing/printast.cmx : parsing/parsetree.cmi utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx parsing/asttypes.cmi \
-    parsing/printast.cmi
-parsing/printast.cmi : parsing/parsetree.cmi
-parsing/syntaxerr.cmo : parsing/location.cmi parsing/syntaxerr.cmi
-parsing/syntaxerr.cmx : parsing/location.cmx parsing/syntaxerr.cmi
-parsing/syntaxerr.cmi : parsing/location.cmi
-typing/annot.cmi : parsing/location.cmi
-typing/btype.cmo : typing/types.cmi typing/path.cmi utils/misc.cmi \
-    typing/ident.cmi parsing/asttypes.cmi typing/btype.cmi
-typing/btype.cmx : typing/types.cmx typing/path.cmx utils/misc.cmx \
-    typing/ident.cmx parsing/asttypes.cmi typing/btype.cmi
-typing/btype.cmi : typing/types.cmi typing/path.cmi parsing/asttypes.cmi
-typing/cmi_format.cmo : typing/types.cmi parsing/location.cmi \
-    utils/config.cmi typing/cmi_format.cmi
-typing/cmi_format.cmx : typing/types.cmx parsing/location.cmx \
-    utils/config.cmx typing/cmi_format.cmi
-typing/cmi_format.cmi : typing/types.cmi
-typing/cmt_format.cmo : typing/types.cmi typing/typedtree.cmi \
-    typing/tast_mapper.cmi utils/misc.cmi parsing/location.cmi \
-    parsing/lexer.cmi typing/env.cmi utils/config.cmi typing/cmi_format.cmi \
-    utils/clflags.cmi typing/cmt_format.cmi
-typing/cmt_format.cmx : typing/types.cmx typing/typedtree.cmx \
-    typing/tast_mapper.cmx utils/misc.cmx parsing/location.cmx \
-    parsing/lexer.cmx typing/env.cmx utils/config.cmx typing/cmi_format.cmx \
-    utils/clflags.cmx typing/cmt_format.cmi
-typing/cmt_format.cmi : typing/types.cmi typing/typedtree.cmi \
-    parsing/location.cmi typing/env.cmi typing/cmi_format.cmi
-typing/ctype.cmo : typing/types.cmi typing/subst.cmi typing/predef.cmi \
-    typing/path.cmi utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi typing/env.cmi utils/clflags.cmi typing/btype.cmi \
-    parsing/asttypes.cmi typing/ctype.cmi
-typing/ctype.cmx : typing/types.cmx typing/subst.cmx typing/predef.cmx \
-    typing/path.cmx utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
-    typing/ident.cmx typing/env.cmx utils/clflags.cmx typing/btype.cmx \
-    parsing/asttypes.cmi typing/ctype.cmi
-typing/ctype.cmi : typing/types.cmi typing/path.cmi parsing/longident.cmi \
-    typing/ident.cmi typing/env.cmi parsing/asttypes.cmi
-typing/datarepr.cmo : typing/types.cmi typing/path.cmi parsing/location.cmi \
-    typing/ident.cmi typing/btype.cmi parsing/asttypes.cmi \
-    typing/datarepr.cmi
-typing/datarepr.cmx : typing/types.cmx typing/path.cmx parsing/location.cmx \
-    typing/ident.cmx typing/btype.cmx parsing/asttypes.cmi \
-    typing/datarepr.cmi
-typing/datarepr.cmi : typing/types.cmi typing/path.cmi typing/ident.cmi
-typing/env.cmo : utils/warnings.cmi typing/types.cmi utils/tbl.cmi \
-    typing/subst.cmi typing/predef.cmi typing/path.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi typing/ident.cmi \
-    typing/datarepr.cmi utils/consistbl.cmi utils/config.cmi \
-    typing/cmi_format.cmi utils/clflags.cmi parsing/builtin_attributes.cmi \
-    typing/btype.cmi parsing/asttypes.cmi typing/env.cmi
-typing/env.cmx : utils/warnings.cmx typing/types.cmx utils/tbl.cmx \
-    typing/subst.cmx typing/predef.cmx typing/path.cmx utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx typing/ident.cmx \
-    typing/datarepr.cmx utils/consistbl.cmx utils/config.cmx \
-    typing/cmi_format.cmx utils/clflags.cmx parsing/builtin_attributes.cmx \
-    typing/btype.cmx parsing/asttypes.cmi typing/env.cmi
-typing/env.cmi : utils/warnings.cmi typing/types.cmi typing/subst.cmi \
-    typing/path.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi utils/consistbl.cmi typing/cmi_format.cmi \
-    parsing/asttypes.cmi
-typing/envaux.cmo : typing/subst.cmi typing/printtyp.cmi typing/path.cmi \
-    typing/ident.cmi typing/env.cmi parsing/asttypes.cmi typing/envaux.cmi
-typing/envaux.cmx : typing/subst.cmx typing/printtyp.cmx typing/path.cmx \
-    typing/ident.cmx typing/env.cmx parsing/asttypes.cmi typing/envaux.cmi
-typing/envaux.cmi : typing/subst.cmi typing/path.cmi typing/env.cmi
-typing/ident.cmo : utils/identifiable.cmi typing/ident.cmi
-typing/ident.cmx : utils/identifiable.cmx typing/ident.cmi
-typing/ident.cmi : utils/identifiable.cmi
-typing/includeclass.cmo : typing/types.cmi typing/printtyp.cmi \
-    typing/path.cmi typing/ctype.cmi parsing/builtin_attributes.cmi \
-    typing/includeclass.cmi
-typing/includeclass.cmx : typing/types.cmx typing/printtyp.cmx \
-    typing/path.cmx typing/ctype.cmx parsing/builtin_attributes.cmx \
-    typing/includeclass.cmi
-typing/includeclass.cmi : typing/types.cmi parsing/location.cmi \
-    typing/env.cmi typing/ctype.cmi
-typing/includecore.cmo : typing/types.cmi typing/typedtree.cmi \
-    typing/path.cmi typing/ident.cmi typing/env.cmi typing/ctype.cmi \
-    parsing/builtin_attributes.cmi typing/btype.cmi parsing/asttypes.cmi \
-    typing/includecore.cmi
-typing/includecore.cmx : typing/types.cmx typing/typedtree.cmx \
-    typing/path.cmx typing/ident.cmx typing/env.cmx typing/ctype.cmx \
-    parsing/builtin_attributes.cmx typing/btype.cmx parsing/asttypes.cmi \
-    typing/includecore.cmi
-typing/includecore.cmi : typing/types.cmi typing/typedtree.cmi \
-    parsing/location.cmi typing/ident.cmi typing/env.cmi
-typing/includemod.cmo : typing/types.cmi typing/typedtree.cmi utils/tbl.cmi \
-    typing/subst.cmi typing/printtyp.cmi typing/primitive.cmi typing/path.cmi \
-    typing/mtype.cmi utils/misc.cmi parsing/location.cmi \
-    typing/includecore.cmi typing/includeclass.cmi typing/ident.cmi \
-    typing/env.cmi typing/ctype.cmi typing/cmt_format.cmi utils/clflags.cmi \
-    parsing/builtin_attributes.cmi typing/btype.cmi typing/includemod.cmi
-typing/includemod.cmx : typing/types.cmx typing/typedtree.cmx utils/tbl.cmx \
-    typing/subst.cmx typing/printtyp.cmx typing/primitive.cmx typing/path.cmx \
-    typing/mtype.cmx utils/misc.cmx parsing/location.cmx \
-    typing/includecore.cmx typing/includeclass.cmx typing/ident.cmx \
-    typing/env.cmx typing/ctype.cmx typing/cmt_format.cmx utils/clflags.cmx \
-    parsing/builtin_attributes.cmx typing/btype.cmx typing/includemod.cmi
-typing/includemod.cmi : typing/types.cmi typing/typedtree.cmi \
-    typing/path.cmi parsing/location.cmi typing/includecore.cmi \
-    typing/ident.cmi typing/env.cmi typing/ctype.cmi
-typing/mtype.cmo : typing/types.cmi typing/subst.cmi typing/path.cmi \
-    utils/misc.cmi parsing/location.cmi typing/ident.cmi typing/env.cmi \
-    typing/ctype.cmi utils/clflags.cmi typing/btype.cmi parsing/asttypes.cmi \
-    typing/mtype.cmi
-typing/mtype.cmx : typing/types.cmx typing/subst.cmx typing/path.cmx \
-    utils/misc.cmx parsing/location.cmx typing/ident.cmx typing/env.cmx \
-    typing/ctype.cmx utils/clflags.cmx typing/btype.cmx parsing/asttypes.cmi \
-    typing/mtype.cmi
-typing/mtype.cmi : typing/types.cmi typing/path.cmi typing/ident.cmi \
-    typing/env.cmi
-typing/oprint.cmo : typing/outcometree.cmi parsing/asttypes.cmi \
-    typing/oprint.cmi
-typing/oprint.cmx : typing/outcometree.cmi parsing/asttypes.cmi \
-    typing/oprint.cmi
-typing/oprint.cmi : typing/outcometree.cmi
-typing/outcometree.cmi : parsing/asttypes.cmi
-typing/parmatch.cmo : utils/warnings.cmi typing/untypeast.cmi \
-    typing/types.cmi typing/typedtreeIter.cmi typing/typedtree.cmi \
-    typing/subst.cmi typing/predef.cmi typing/path.cmi parsing/parsetree.cmi \
-    utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi typing/env.cmi typing/ctype.cmi utils/config.cmi \
-    typing/btype.cmi parsing/asttypes.cmi parsing/ast_helper.cmi \
-    typing/parmatch.cmi
-typing/parmatch.cmx : utils/warnings.cmx typing/untypeast.cmx \
-    typing/types.cmx typing/typedtreeIter.cmx typing/typedtree.cmx \
-    typing/subst.cmx typing/predef.cmx typing/path.cmx parsing/parsetree.cmi \
-    utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
-    typing/ident.cmx typing/env.cmx typing/ctype.cmx utils/config.cmx \
-    typing/btype.cmx parsing/asttypes.cmi parsing/ast_helper.cmx \
-    typing/parmatch.cmi
-typing/parmatch.cmi : typing/types.cmi typing/typedtree.cmi \
-    parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/env.cmi parsing/asttypes.cmi
-typing/path.cmo : typing/ident.cmi typing/path.cmi
-typing/path.cmx : typing/ident.cmx typing/path.cmi
-typing/path.cmi : typing/ident.cmi
-typing/predef.cmo : typing/types.cmi typing/path.cmi parsing/parsetree.cmi \
-    parsing/location.cmi typing/ident.cmi typing/btype.cmi \
-    parsing/asttypes.cmi typing/predef.cmi
-typing/predef.cmx : typing/types.cmx typing/path.cmx parsing/parsetree.cmi \
-    parsing/location.cmx typing/ident.cmx typing/btype.cmx \
-    parsing/asttypes.cmi typing/predef.cmi
-typing/predef.cmi : typing/types.cmi typing/path.cmi typing/ident.cmi
-typing/primitive.cmo : parsing/parsetree.cmi typing/outcometree.cmi \
-    utils/misc.cmi parsing/location.cmi parsing/attr_helper.cmi \
-    typing/primitive.cmi
-typing/primitive.cmx : parsing/parsetree.cmi typing/outcometree.cmi \
-    utils/misc.cmx parsing/location.cmx parsing/attr_helper.cmx \
-    typing/primitive.cmi
-typing/primitive.cmi : parsing/parsetree.cmi typing/outcometree.cmi \
-    parsing/location.cmi
-typing/printtyp.cmo : typing/types.cmi typing/primitive.cmi \
-    typing/predef.cmi typing/path.cmi parsing/parsetree.cmi \
-    typing/outcometree.cmi typing/oprint.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi typing/ident.cmi \
-    typing/env.cmi typing/ctype.cmi utils/clflags.cmi \
-    parsing/builtin_attributes.cmi typing/btype.cmi parsing/asttypes.cmi \
-    typing/printtyp.cmi
-typing/printtyp.cmx : typing/types.cmx typing/primitive.cmx \
-    typing/predef.cmx typing/path.cmx parsing/parsetree.cmi \
-    typing/outcometree.cmi typing/oprint.cmx utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx typing/ident.cmx \
-    typing/env.cmx typing/ctype.cmx utils/clflags.cmx \
-    parsing/builtin_attributes.cmx typing/btype.cmx parsing/asttypes.cmi \
-    typing/printtyp.cmi
-typing/printtyp.cmi : typing/types.cmi typing/path.cmi \
-    typing/outcometree.cmi parsing/longident.cmi typing/ident.cmi \
-    typing/env.cmi parsing/asttypes.cmi
-typing/printtyped.cmo : typing/typedtree.cmi parsing/printast.cmi \
-    typing/path.cmi utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi parsing/asttypes.cmi typing/printtyped.cmi
-typing/printtyped.cmx : typing/typedtree.cmx parsing/printast.cmx \
-    typing/path.cmx utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
-    typing/ident.cmx parsing/asttypes.cmi typing/printtyped.cmi
-typing/printtyped.cmi : typing/typedtree.cmi
-typing/stypes.cmo : typing/typedtree.cmi typing/printtyp.cmi utils/misc.cmi \
-    parsing/location.cmi utils/clflags.cmi typing/annot.cmi typing/stypes.cmi
-typing/stypes.cmx : typing/typedtree.cmx typing/printtyp.cmx utils/misc.cmx \
-    parsing/location.cmx utils/clflags.cmx typing/annot.cmi typing/stypes.cmi
-typing/stypes.cmi : typing/typedtree.cmi parsing/location.cmi \
-    typing/annot.cmi
-typing/subst.cmo : typing/types.cmi utils/tbl.cmi typing/path.cmi \
-    utils/misc.cmi parsing/location.cmi typing/ident.cmi utils/clflags.cmi \
-    typing/btype.cmi parsing/ast_mapper.cmi typing/subst.cmi
-typing/subst.cmx : typing/types.cmx utils/tbl.cmx typing/path.cmx \
-    utils/misc.cmx parsing/location.cmx typing/ident.cmx utils/clflags.cmx \
-    typing/btype.cmx parsing/ast_mapper.cmx typing/subst.cmi
-typing/subst.cmi : typing/types.cmi typing/path.cmi typing/ident.cmi
-typing/tast_mapper.cmo : typing/typedtree.cmi typing/env.cmi \
-    parsing/asttypes.cmi typing/tast_mapper.cmi
-typing/tast_mapper.cmx : typing/typedtree.cmx typing/env.cmx \
-    parsing/asttypes.cmi typing/tast_mapper.cmi
-typing/tast_mapper.cmi : typing/typedtree.cmi typing/env.cmi \
-    parsing/asttypes.cmi
-typing/typeclass.cmo : utils/warnings.cmi typing/typetexp.cmi \
-    typing/types.cmi typing/typedtree.cmi typing/typedecl.cmi \
-    typing/typecore.cmi typing/subst.cmi typing/stypes.cmi \
-    typing/printtyp.cmi typing/predef.cmi typing/path.cmi \
-    parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
-    parsing/location.cmi typing/includeclass.cmi typing/ident.cmi \
-    typing/env.cmi typing/ctype.cmi typing/cmt_format.cmi utils/clflags.cmi \
-    parsing/builtin_attributes.cmi typing/btype.cmi parsing/asttypes.cmi \
-    parsing/ast_helper.cmi typing/typeclass.cmi
-typing/typeclass.cmx : utils/warnings.cmx typing/typetexp.cmx \
-    typing/types.cmx typing/typedtree.cmx typing/typedecl.cmx \
-    typing/typecore.cmx typing/subst.cmx typing/stypes.cmx \
-    typing/printtyp.cmx typing/predef.cmx typing/path.cmx \
-    parsing/parsetree.cmi utils/misc.cmx parsing/longident.cmx \
-    parsing/location.cmx typing/includeclass.cmx typing/ident.cmx \
-    typing/env.cmx typing/ctype.cmx typing/cmt_format.cmx utils/clflags.cmx \
-    parsing/builtin_attributes.cmx typing/btype.cmx parsing/asttypes.cmi \
-    parsing/ast_helper.cmx typing/typeclass.cmi
-typing/typeclass.cmi : typing/types.cmi typing/typedtree.cmi \
-    parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi typing/env.cmi typing/ctype.cmi parsing/asttypes.cmi
-typing/typecore.cmo : utils/warnings.cmi typing/typetexp.cmi \
-    typing/types.cmi typing/typedtree.cmi typing/typedecl.cmi \
-    typing/subst.cmi typing/stypes.cmi typing/printtyp.cmi \
-    typing/primitive.cmi typing/predef.cmi typing/path.cmi \
-    parsing/parsetree.cmi typing/parmatch.cmi typing/oprint.cmi \
-    utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi typing/env.cmi typing/ctype.cmi typing/cmt_format.cmi \
-    utils/clflags.cmi parsing/builtin_attributes.cmi typing/btype.cmi \
-    parsing/asttypes.cmi parsing/ast_helper.cmi typing/annot.cmi \
-    typing/typecore.cmi
-typing/typecore.cmx : utils/warnings.cmx typing/typetexp.cmx \
-    typing/types.cmx typing/typedtree.cmx typing/typedecl.cmx \
-    typing/subst.cmx typing/stypes.cmx typing/printtyp.cmx \
-    typing/primitive.cmx typing/predef.cmx typing/path.cmx \
-    parsing/parsetree.cmi typing/parmatch.cmx typing/oprint.cmx \
-    utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
-    typing/ident.cmx typing/env.cmx typing/ctype.cmx typing/cmt_format.cmx \
-    utils/clflags.cmx parsing/builtin_attributes.cmx typing/btype.cmx \
-    parsing/asttypes.cmi parsing/ast_helper.cmx typing/annot.cmi \
-    typing/typecore.cmi
-typing/typecore.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
-    parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi typing/env.cmi parsing/asttypes.cmi typing/annot.cmi
-typing/typedecl.cmo : utils/warnings.cmi typing/typetexp.cmi \
-    typing/types.cmi typing/typedtree.cmi typing/subst.cmi \
-    typing/printtyp.cmi typing/primitive.cmi typing/predef.cmi \
-    typing/path.cmi parsing/parsetree.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi typing/includecore.cmi \
-    typing/ident.cmi typing/env.cmi typing/datarepr.cmi typing/ctype.cmi \
-    utils/config.cmi utils/clflags.cmi parsing/builtin_attributes.cmi \
-    typing/btype.cmi parsing/attr_helper.cmi parsing/asttypes.cmi \
-    parsing/ast_iterator.cmi parsing/ast_helper.cmi typing/typedecl.cmi
-typing/typedecl.cmx : utils/warnings.cmx typing/typetexp.cmx \
-    typing/types.cmx typing/typedtree.cmx typing/subst.cmx \
-    typing/printtyp.cmx typing/primitive.cmx typing/predef.cmx \
-    typing/path.cmx parsing/parsetree.cmi utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx typing/includecore.cmx \
-    typing/ident.cmx typing/env.cmx typing/datarepr.cmx typing/ctype.cmx \
-    utils/config.cmx utils/clflags.cmx parsing/builtin_attributes.cmx \
-    typing/btype.cmx parsing/attr_helper.cmx parsing/asttypes.cmi \
-    parsing/ast_iterator.cmx parsing/ast_helper.cmx typing/typedecl.cmi
-typing/typedecl.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
-    parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/includecore.cmi typing/ident.cmi typing/env.cmi \
-    parsing/asttypes.cmi
-typing/typedtree.cmo : typing/types.cmi typing/primitive.cmi typing/path.cmi \
-    parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
-    parsing/location.cmi typing/ident.cmi typing/env.cmi parsing/asttypes.cmi \
-    typing/typedtree.cmi
-typing/typedtree.cmx : typing/types.cmx typing/primitive.cmx typing/path.cmx \
-    parsing/parsetree.cmi utils/misc.cmx parsing/longident.cmx \
-    parsing/location.cmx typing/ident.cmx typing/env.cmx parsing/asttypes.cmi \
-    typing/typedtree.cmi
-typing/typedtree.cmi : typing/types.cmi typing/primitive.cmi typing/path.cmi \
-    parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi typing/env.cmi parsing/asttypes.cmi
-typing/typedtreeIter.cmo : typing/typedtree.cmi utils/misc.cmi \
-    parsing/asttypes.cmi typing/typedtreeIter.cmi
-typing/typedtreeIter.cmx : typing/typedtree.cmx utils/misc.cmx \
-    parsing/asttypes.cmi typing/typedtreeIter.cmi
-typing/typedtreeIter.cmi : typing/typedtree.cmi parsing/asttypes.cmi
-typing/typedtreeMap.cmo : typing/typedtree.cmi utils/misc.cmi \
-    typing/typedtreeMap.cmi
-typing/typedtreeMap.cmx : typing/typedtree.cmx utils/misc.cmx \
-    typing/typedtreeMap.cmi
-typing/typedtreeMap.cmi : typing/typedtree.cmi
-typing/typemod.cmo : utils/warnings.cmi typing/typetexp.cmi typing/types.cmi \
-    typing/typedtree.cmi typing/typedecl.cmi typing/typecore.cmi \
-    typing/typeclass.cmi typing/subst.cmi typing/stypes.cmi \
-    typing/printtyp.cmi typing/path.cmi parsing/parsetree.cmi \
-    typing/mtype.cmi utils/misc.cmi parsing/longident.cmi \
-    parsing/location.cmi typing/includemod.cmi typing/ident.cmi \
-    typing/env.cmi typing/ctype.cmi utils/config.cmi typing/cmt_format.cmi \
-    typing/cmi_format.cmi utils/clflags.cmi parsing/builtin_attributes.cmi \
-    typing/btype.cmi parsing/asttypes.cmi typing/annot.cmi typing/typemod.cmi
-typing/typemod.cmx : utils/warnings.cmx typing/typetexp.cmx typing/types.cmx \
-    typing/typedtree.cmx typing/typedecl.cmx typing/typecore.cmx \
-    typing/typeclass.cmx typing/subst.cmx typing/stypes.cmx \
-    typing/printtyp.cmx typing/path.cmx parsing/parsetree.cmi \
-    typing/mtype.cmx utils/misc.cmx parsing/longident.cmx \
-    parsing/location.cmx typing/includemod.cmx typing/ident.cmx \
-    typing/env.cmx typing/ctype.cmx utils/config.cmx typing/cmt_format.cmx \
-    typing/cmi_format.cmx utils/clflags.cmx parsing/builtin_attributes.cmx \
-    typing/btype.cmx parsing/asttypes.cmi typing/annot.cmi typing/typemod.cmi
-typing/typemod.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
-    parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
-    parsing/location.cmi typing/includemod.cmi typing/ident.cmi \
-    typing/env.cmi typing/cmi_format.cmi parsing/asttypes.cmi
-typing/typeopt.cmo : typing/types.cmi typing/typedtree.cmi \
-    typing/typedecl.cmi typing/predef.cmi typing/path.cmi bytecomp/lambda.cmi \
-    typing/ident.cmi typing/env.cmi typing/ctype.cmi utils/config.cmi \
-    typing/typeopt.cmi
-typing/typeopt.cmx : typing/types.cmx typing/typedtree.cmx \
-    typing/typedecl.cmx typing/predef.cmx typing/path.cmx bytecomp/lambda.cmx \
-    typing/ident.cmx typing/env.cmx typing/ctype.cmx utils/config.cmx \
-    typing/typeopt.cmi
-typing/typeopt.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
-    bytecomp/lambda.cmi typing/env.cmi
-typing/types.cmo : typing/primitive.cmi typing/path.cmi \
-    parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi parsing/asttypes.cmi typing/types.cmi
-typing/types.cmx : typing/primitive.cmx typing/path.cmx \
-    parsing/parsetree.cmi parsing/longident.cmx parsing/location.cmx \
-    typing/ident.cmx parsing/asttypes.cmi typing/types.cmi
-typing/types.cmi : typing/primitive.cmi typing/path.cmi \
-    parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi parsing/asttypes.cmi
-typing/typetexp.cmo : typing/types.cmi typing/typedtree.cmi utils/tbl.cmi \
-    typing/printtyp.cmi typing/predef.cmi typing/path.cmi \
-    parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
-    parsing/location.cmi typing/env.cmi typing/ctype.cmi utils/clflags.cmi \
-    parsing/builtin_attributes.cmi typing/btype.cmi parsing/asttypes.cmi \
-    parsing/ast_helper.cmi typing/typetexp.cmi
-typing/typetexp.cmx : typing/types.cmx typing/typedtree.cmx utils/tbl.cmx \
-    typing/printtyp.cmx typing/predef.cmx typing/path.cmx \
-    parsing/parsetree.cmi utils/misc.cmx parsing/longident.cmx \
-    parsing/location.cmx typing/env.cmx typing/ctype.cmx utils/clflags.cmx \
-    parsing/builtin_attributes.cmx typing/btype.cmx parsing/asttypes.cmi \
-    parsing/ast_helper.cmx typing/typetexp.cmi
-typing/typetexp.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
-    parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/env.cmi parsing/asttypes.cmi
-typing/untypeast.cmo : typing/typedtree.cmi typing/path.cmi \
-    parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
-    parsing/location.cmi typing/ident.cmi typing/env.cmi parsing/asttypes.cmi \
-    parsing/ast_helper.cmi typing/untypeast.cmi
-typing/untypeast.cmx : typing/typedtree.cmx typing/path.cmx \
-    parsing/parsetree.cmi utils/misc.cmx parsing/longident.cmx \
-    parsing/location.cmx typing/ident.cmx typing/env.cmx parsing/asttypes.cmi \
-    parsing/ast_helper.cmx typing/untypeast.cmi
-typing/untypeast.cmi : typing/typedtree.cmi typing/path.cmi \
-    parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    parsing/asttypes.cmi
-bytecomp/bytegen.cmo : typing/types.cmi bytecomp/switch.cmi typing/subst.cmi \
-    typing/primitive.cmi utils/misc.cmi bytecomp/matching.cmi \
-    bytecomp/lambda.cmi bytecomp/instruct.cmi typing/ident.cmi \
-    utils/config.cmi parsing/asttypes.cmi bytecomp/bytegen.cmi
-bytecomp/bytegen.cmx : typing/types.cmx bytecomp/switch.cmx typing/subst.cmx \
-    typing/primitive.cmx utils/misc.cmx bytecomp/matching.cmx \
-    bytecomp/lambda.cmx bytecomp/instruct.cmx typing/ident.cmx \
-    utils/config.cmx parsing/asttypes.cmi bytecomp/bytegen.cmi
-bytecomp/bytegen.cmi : bytecomp/lambda.cmi bytecomp/instruct.cmi
-bytecomp/bytelibrarian.cmo : utils/misc.cmi parsing/location.cmi \
-    bytecomp/emitcode.cmi utils/config.cmi bytecomp/cmo_format.cmi \
-    utils/clflags.cmi bytecomp/bytelink.cmi bytecomp/bytelibrarian.cmi
-bytecomp/bytelibrarian.cmx : utils/misc.cmx parsing/location.cmx \
-    bytecomp/emitcode.cmx utils/config.cmx bytecomp/cmo_format.cmi \
-    utils/clflags.cmx bytecomp/bytelink.cmx bytecomp/bytelibrarian.cmi
+parsing/parse.cmo : \
+  parsing/docstrings.cmi \
+  parsing/lexer.cmi \
+  parsing/location.cmi \
+  parsing/parse.cmi \
+  parsing/parser.cmi \
+  parsing/syntaxerr.cmi
+parsing/parse.cmx : \
+  parsing/docstrings.cmx \
+  parsing/lexer.cmx \
+  parsing/location.cmx \
+  parsing/parse.cmi \
+  parsing/parser.cmx \
+  parsing/syntaxerr.cmx
+parsing/parse.cmi : \
+  parsing/parsetree.cmi
+parsing/parser.cmo : \
+  parsing/ast_helper.cmi \
+  parsing/asttypes.cmi \
+  parsing/docstrings.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parser.cmi \
+  parsing/parsetree.cmi \
+  parsing/syntaxerr.cmi \
+  utils/clflags.cmi
+parsing/parser.cmx : \
+  parsing/ast_helper.cmx \
+  parsing/asttypes.cmi \
+  parsing/docstrings.cmx \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parser.cmi \
+  parsing/parsetree.cmi \
+  parsing/syntaxerr.cmx \
+  utils/clflags.cmx
+parsing/parser.cmi : \
+  parsing/docstrings.cmi \
+  parsing/location.cmi \
+  parsing/parsetree.cmi
+parsing/parsetree.cmi : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi
+parsing/pprintast.cmo : \
+  parsing/ast_helper.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  parsing/pprintast.cmi \
+  utils/misc.cmi
+parsing/pprintast.cmx : \
+  parsing/ast_helper.cmx \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  parsing/pprintast.cmi \
+  utils/misc.cmx
+parsing/pprintast.cmi : \
+  parsing/parsetree.cmi
+parsing/printast.cmo : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  parsing/printast.cmi \
+  utils/misc.cmi
+parsing/printast.cmx : \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  parsing/printast.cmi \
+  utils/misc.cmx
+parsing/printast.cmi : \
+  parsing/parsetree.cmi
+parsing/syntaxerr.cmo : \
+  parsing/location.cmi \
+  parsing/syntaxerr.cmi
+parsing/syntaxerr.cmx : \
+  parsing/location.cmx \
+  parsing/syntaxerr.cmi
+parsing/syntaxerr.cmi : \
+  parsing/location.cmi
+typing/annot.cmi : \
+  parsing/location.cmi
+typing/btype.cmo : \
+  parsing/asttypes.cmi \
+  typing/btype.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/types.cmi \
+  utils/misc.cmi
+typing/btype.cmx : \
+  parsing/asttypes.cmi \
+  typing/btype.cmi \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/types.cmx \
+  utils/misc.cmx
+typing/btype.cmi : \
+  parsing/asttypes.cmi \
+  typing/path.cmi \
+  typing/types.cmi
+typing/cmi_format.cmo : \
+  parsing/location.cmi \
+  typing/cmi_format.cmi \
+  typing/types.cmi \
+  utils/config.cmi
+typing/cmi_format.cmx : \
+  parsing/location.cmx \
+  typing/cmi_format.cmi \
+  typing/types.cmx \
+  utils/config.cmx
+typing/cmi_format.cmi : \
+  typing/types.cmi
+typing/cmt_format.cmo : \
+  parsing/lexer.cmi \
+  parsing/location.cmi \
+  typing/cmi_format.cmi \
+  typing/cmt_format.cmi \
+  typing/env.cmi \
+  typing/tast_mapper.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+typing/cmt_format.cmx : \
+  parsing/lexer.cmx \
+  parsing/location.cmx \
+  typing/cmi_format.cmx \
+  typing/cmt_format.cmi \
+  typing/env.cmx \
+  typing/tast_mapper.cmx \
+  typing/typedtree.cmx \
+  typing/types.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+typing/cmt_format.cmi : \
+  parsing/location.cmi \
+  typing/cmi_format.cmi \
+  typing/env.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi
+typing/ctype.cmo : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  typing/btype.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/subst.cmi \
+  typing/types.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+typing/ctype.cmx : \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  typing/btype.cmx \
+  typing/ctype.cmi \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/subst.cmx \
+  typing/types.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx
+typing/ctype.cmi : \
+  parsing/asttypes.cmi \
+  parsing/longident.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/types.cmi
+typing/datarepr.cmo : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  typing/btype.cmi \
+  typing/datarepr.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/types.cmi
+typing/datarepr.cmx : \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  typing/btype.cmx \
+  typing/datarepr.cmi \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/types.cmx
+typing/datarepr.cmi : \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/types.cmi
+typing/env.cmo : \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  typing/btype.cmi \
+  typing/cmi_format.cmi \
+  typing/datarepr.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/subst.cmi \
+  typing/types.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/consistbl.cmi \
+  utils/misc.cmi \
+  utils/tbl.cmi \
+  utils/warnings.cmi
+typing/env.cmx : \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmx \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  typing/btype.cmx \
+  typing/cmi_format.cmx \
+  typing/datarepr.cmx \
+  typing/env.cmi \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/subst.cmx \
+  typing/types.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/consistbl.cmx \
+  utils/misc.cmx \
+  utils/tbl.cmx \
+  utils/warnings.cmx
+typing/env.cmi : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  typing/cmi_format.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/subst.cmi \
+  typing/types.cmi \
+  utils/consistbl.cmi \
+  utils/warnings.cmi
+typing/envaux.cmo : \
+  parsing/asttypes.cmi \
+  typing/env.cmi \
+  typing/envaux.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/printtyp.cmi \
+  typing/subst.cmi
+typing/envaux.cmx : \
+  parsing/asttypes.cmi \
+  typing/env.cmx \
+  typing/envaux.cmi \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/printtyp.cmx \
+  typing/subst.cmx
+typing/envaux.cmi : \
+  typing/env.cmi \
+  typing/path.cmi \
+  typing/subst.cmi
+typing/ident.cmo : \
+  typing/ident.cmi \
+  utils/identifiable.cmi
+typing/ident.cmx : \
+  typing/ident.cmi \
+  utils/identifiable.cmx
+typing/ident.cmi : \
+  utils/identifiable.cmi
+typing/includeclass.cmo : \
+  parsing/builtin_attributes.cmi \
+  typing/ctype.cmi \
+  typing/includeclass.cmi \
+  typing/path.cmi \
+  typing/printtyp.cmi \
+  typing/types.cmi
+typing/includeclass.cmx : \
+  parsing/builtin_attributes.cmx \
+  typing/ctype.cmx \
+  typing/includeclass.cmi \
+  typing/path.cmx \
+  typing/printtyp.cmx \
+  typing/types.cmx
+typing/includeclass.cmi : \
+  parsing/location.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/types.cmi
+typing/includecore.cmo : \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmi \
+  typing/btype.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/includecore.cmi \
+  typing/path.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi
+typing/includecore.cmx : \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmx \
+  typing/btype.cmx \
+  typing/ctype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/includecore.cmi \
+  typing/path.cmx \
+  typing/typedtree.cmx \
+  typing/types.cmx
+typing/includecore.cmi : \
+  parsing/location.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi
+typing/includemod.cmo : \
+  parsing/builtin_attributes.cmi \
+  parsing/location.cmi \
+  typing/btype.cmi \
+  typing/cmt_format.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/includeclass.cmi \
+  typing/includecore.cmi \
+  typing/includemod.cmi \
+  typing/mtype.cmi \
+  typing/path.cmi \
+  typing/primitive.cmi \
+  typing/printtyp.cmi \
+  typing/subst.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi \
+  utils/tbl.cmi
+typing/includemod.cmx : \
+  parsing/builtin_attributes.cmx \
+  parsing/location.cmx \
+  typing/btype.cmx \
+  typing/cmt_format.cmx \
+  typing/ctype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/includeclass.cmx \
+  typing/includecore.cmx \
+  typing/includemod.cmi \
+  typing/mtype.cmx \
+  typing/path.cmx \
+  typing/primitive.cmx \
+  typing/printtyp.cmx \
+  typing/subst.cmx \
+  typing/typedtree.cmx \
+  typing/types.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx \
+  utils/tbl.cmx
+typing/includemod.cmi : \
+  parsing/location.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/includecore.cmi \
+  typing/path.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi
+typing/mtype.cmo : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  typing/btype.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/mtype.cmi \
+  typing/path.cmi \
+  typing/subst.cmi \
+  typing/types.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+typing/mtype.cmx : \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  typing/btype.cmx \
+  typing/ctype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/mtype.cmi \
+  typing/path.cmx \
+  typing/subst.cmx \
+  typing/types.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx
+typing/mtype.cmi : \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/types.cmi
+typing/oprint.cmo : \
+  parsing/asttypes.cmi \
+  typing/oprint.cmi \
+  typing/outcometree.cmi
+typing/oprint.cmx : \
+  parsing/asttypes.cmi \
+  typing/oprint.cmi \
+  typing/outcometree.cmi
+typing/oprint.cmi : \
+  typing/outcometree.cmi
+typing/outcometree.cmi : \
+  parsing/asttypes.cmi
+typing/parmatch.cmo : \
+  parsing/ast_helper.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/btype.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/parmatch.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/subst.cmi \
+  typing/typedtree.cmi \
+  typing/typedtreeIter.cmi \
+  typing/types.cmi \
+  typing/untypeast.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+typing/parmatch.cmx : \
+  parsing/ast_helper.cmx \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  typing/btype.cmx \
+  typing/ctype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/parmatch.cmi \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/subst.cmx \
+  typing/typedtree.cmx \
+  typing/typedtreeIter.cmx \
+  typing/types.cmx \
+  typing/untypeast.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+typing/parmatch.cmi : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/env.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi
+typing/path.cmo : \
+  typing/ident.cmi \
+  typing/path.cmi
+typing/path.cmx : \
+  typing/ident.cmx \
+  typing/path.cmi
+typing/path.cmi : \
+  typing/ident.cmi
+typing/predef.cmo : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/parsetree.cmi \
+  typing/btype.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/types.cmi
+typing/predef.cmx : \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/parsetree.cmi \
+  typing/btype.cmx \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/predef.cmi \
+  typing/types.cmx
+typing/predef.cmi : \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/types.cmi
+typing/primitive.cmo : \
+  parsing/attr_helper.cmi \
+  parsing/location.cmi \
+  parsing/parsetree.cmi \
+  typing/outcometree.cmi \
+  typing/primitive.cmi \
+  utils/misc.cmi
+typing/primitive.cmx : \
+  parsing/attr_helper.cmx \
+  parsing/location.cmx \
+  parsing/parsetree.cmi \
+  typing/outcometree.cmi \
+  typing/primitive.cmi \
+  utils/misc.cmx
+typing/primitive.cmi : \
+  parsing/location.cmi \
+  parsing/parsetree.cmi \
+  typing/outcometree.cmi
+typing/printtyp.cmo : \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/btype.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/oprint.cmi \
+  typing/outcometree.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/primitive.cmi \
+  typing/printtyp.cmi \
+  typing/types.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+typing/printtyp.cmx : \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmx \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  typing/btype.cmx \
+  typing/ctype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/oprint.cmx \
+  typing/outcometree.cmi \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/primitive.cmx \
+  typing/printtyp.cmi \
+  typing/types.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx
+typing/printtyp.cmi : \
+  parsing/asttypes.cmi \
+  parsing/longident.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/outcometree.cmi \
+  typing/path.cmi \
+  typing/types.cmi
+typing/printtyped.cmo : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/printast.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/printtyped.cmi \
+  typing/typedtree.cmi \
+  utils/misc.cmi
+typing/printtyped.cmx : \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/printast.cmx \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/printtyped.cmi \
+  typing/typedtree.cmx \
+  utils/misc.cmx
+typing/printtyped.cmi : \
+  typing/typedtree.cmi
+typing/stypes.cmo : \
+  parsing/location.cmi \
+  typing/annot.cmi \
+  typing/printtyp.cmi \
+  typing/stypes.cmi \
+  typing/typedtree.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+typing/stypes.cmx : \
+  parsing/location.cmx \
+  typing/annot.cmi \
+  typing/printtyp.cmx \
+  typing/stypes.cmi \
+  typing/typedtree.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx
+typing/stypes.cmi : \
+  parsing/location.cmi \
+  typing/annot.cmi \
+  typing/typedtree.cmi
+typing/subst.cmo : \
+  parsing/ast_mapper.cmi \
+  parsing/location.cmi \
+  typing/btype.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/subst.cmi \
+  typing/types.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi \
+  utils/tbl.cmi
+typing/subst.cmx : \
+  parsing/ast_mapper.cmx \
+  parsing/location.cmx \
+  typing/btype.cmx \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/subst.cmi \
+  typing/types.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx \
+  utils/tbl.cmx
+typing/subst.cmi : \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/types.cmi
+typing/tast_mapper.cmo : \
+  parsing/asttypes.cmi \
+  typing/env.cmi \
+  typing/tast_mapper.cmi \
+  typing/typedtree.cmi
+typing/tast_mapper.cmx : \
+  parsing/asttypes.cmi \
+  typing/env.cmx \
+  typing/tast_mapper.cmi \
+  typing/typedtree.cmx
+typing/tast_mapper.cmi : \
+  parsing/asttypes.cmi \
+  typing/env.cmi \
+  typing/typedtree.cmi
+typing/typeclass.cmo : \
+  parsing/ast_helper.cmi \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/btype.cmi \
+  typing/cmt_format.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/includeclass.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/printtyp.cmi \
+  typing/stypes.cmi \
+  typing/subst.cmi \
+  typing/typeclass.cmi \
+  typing/typecore.cmi \
+  typing/typedecl.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi \
+  typing/typetexp.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+typing/typeclass.cmx : \
+  parsing/ast_helper.cmx \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmx \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  typing/btype.cmx \
+  typing/cmt_format.cmx \
+  typing/ctype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/includeclass.cmx \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/printtyp.cmx \
+  typing/stypes.cmx \
+  typing/subst.cmx \
+  typing/typeclass.cmi \
+  typing/typecore.cmx \
+  typing/typedecl.cmx \
+  typing/typedtree.cmx \
+  typing/types.cmx \
+  typing/typetexp.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+typing/typeclass.cmi : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi
+typing/typecore.cmo : \
+  parsing/ast_helper.cmi \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/annot.cmi \
+  typing/btype.cmi \
+  typing/cmt_format.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/oprint.cmi \
+  typing/parmatch.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/primitive.cmi \
+  typing/printtyp.cmi \
+  typing/stypes.cmi \
+  typing/subst.cmi \
+  typing/typecore.cmi \
+  typing/typedecl.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi \
+  typing/typetexp.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+typing/typecore.cmx : \
+  parsing/ast_helper.cmx \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmx \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  typing/annot.cmi \
+  typing/btype.cmx \
+  typing/cmt_format.cmx \
+  typing/ctype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/oprint.cmx \
+  typing/parmatch.cmx \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/primitive.cmx \
+  typing/printtyp.cmx \
+  typing/stypes.cmx \
+  typing/subst.cmx \
+  typing/typecore.cmi \
+  typing/typedecl.cmx \
+  typing/typedtree.cmx \
+  typing/types.cmx \
+  typing/typetexp.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+typing/typecore.cmi : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/annot.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi
+typing/typedecl.cmo : \
+  parsing/ast_helper.cmi \
+  parsing/ast_iterator.cmi \
+  parsing/asttypes.cmi \
+  parsing/attr_helper.cmi \
+  parsing/builtin_attributes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/btype.cmi \
+  typing/ctype.cmi \
+  typing/datarepr.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/includecore.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/primitive.cmi \
+  typing/printtyp.cmi \
+  typing/subst.cmi \
+  typing/typedecl.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi \
+  typing/typetexp.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+typing/typedecl.cmx : \
+  parsing/ast_helper.cmx \
+  parsing/ast_iterator.cmx \
+  parsing/asttypes.cmi \
+  parsing/attr_helper.cmx \
+  parsing/builtin_attributes.cmx \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  typing/btype.cmx \
+  typing/ctype.cmx \
+  typing/datarepr.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/includecore.cmx \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/primitive.cmx \
+  typing/printtyp.cmx \
+  typing/subst.cmx \
+  typing/typedecl.cmi \
+  typing/typedtree.cmx \
+  typing/types.cmx \
+  typing/typetexp.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+typing/typedecl.cmi : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/includecore.cmi \
+  typing/path.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi
+typing/typedtree.cmo : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/primitive.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi \
+  utils/misc.cmi
+typing/typedtree.cmx : \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/primitive.cmx \
+  typing/typedtree.cmi \
+  typing/types.cmx \
+  utils/misc.cmx
+typing/typedtree.cmi : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/primitive.cmi \
+  typing/types.cmi
+typing/typedtreeIter.cmo : \
+  parsing/asttypes.cmi \
+  typing/typedtree.cmi \
+  typing/typedtreeIter.cmi \
+  utils/misc.cmi
+typing/typedtreeIter.cmx : \
+  parsing/asttypes.cmi \
+  typing/typedtree.cmx \
+  typing/typedtreeIter.cmi \
+  utils/misc.cmx
+typing/typedtreeIter.cmi : \
+  parsing/asttypes.cmi \
+  typing/typedtree.cmi
+typing/typedtreeMap.cmo : \
+  typing/typedtree.cmi \
+  typing/typedtreeMap.cmi \
+  utils/misc.cmi
+typing/typedtreeMap.cmx : \
+  typing/typedtree.cmx \
+  typing/typedtreeMap.cmi \
+  utils/misc.cmx
+typing/typedtreeMap.cmi : \
+  typing/typedtree.cmi
+typing/typemod.cmo : \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/annot.cmi \
+  typing/btype.cmi \
+  typing/cmi_format.cmi \
+  typing/cmt_format.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/includemod.cmi \
+  typing/mtype.cmi \
+  typing/path.cmi \
+  typing/printtyp.cmi \
+  typing/stypes.cmi \
+  typing/subst.cmi \
+  typing/typeclass.cmi \
+  typing/typecore.cmi \
+  typing/typedecl.cmi \
+  typing/typedtree.cmi \
+  typing/typemod.cmi \
+  typing/types.cmi \
+  typing/typetexp.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+typing/typemod.cmx : \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmx \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  typing/annot.cmi \
+  typing/btype.cmx \
+  typing/cmi_format.cmx \
+  typing/cmt_format.cmx \
+  typing/ctype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/includemod.cmx \
+  typing/mtype.cmx \
+  typing/path.cmx \
+  typing/printtyp.cmx \
+  typing/stypes.cmx \
+  typing/subst.cmx \
+  typing/typeclass.cmx \
+  typing/typecore.cmx \
+  typing/typedecl.cmx \
+  typing/typedtree.cmx \
+  typing/typemod.cmi \
+  typing/types.cmx \
+  typing/typetexp.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+typing/typemod.cmi : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/cmi_format.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/includemod.cmi \
+  typing/path.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi \
+  utils/misc.cmi
+typing/typeopt.cmo : \
+  bytecomp/lambda.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/typedecl.cmi \
+  typing/typedtree.cmi \
+  typing/typeopt.cmi \
+  typing/types.cmi \
+  utils/config.cmi
+typing/typeopt.cmx : \
+  bytecomp/lambda.cmx \
+  typing/ctype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/typedecl.cmx \
+  typing/typedtree.cmx \
+  typing/typeopt.cmi \
+  typing/types.cmx \
+  utils/config.cmx
+typing/typeopt.cmi : \
+  bytecomp/lambda.cmi \
+  typing/env.cmi \
+  typing/path.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi
+typing/types.cmo : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/primitive.cmi \
+  typing/types.cmi
+typing/types.cmx : \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/primitive.cmx \
+  typing/types.cmi
+typing/types.cmi : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/primitive.cmi
+typing/typetexp.cmo : \
+  parsing/ast_helper.cmi \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/btype.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/printtyp.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi \
+  typing/typetexp.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi \
+  utils/tbl.cmi
+typing/typetexp.cmx : \
+  parsing/ast_helper.cmx \
+  parsing/asttypes.cmi \
+  parsing/builtin_attributes.cmx \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  typing/btype.cmx \
+  typing/ctype.cmx \
+  typing/env.cmx \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/printtyp.cmx \
+  typing/typedtree.cmx \
+  typing/types.cmx \
+  typing/typetexp.cmi \
+  utils/clflags.cmx \
+  utils/misc.cmx \
+  utils/tbl.cmx
+typing/typetexp.cmi : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/env.cmi \
+  typing/path.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi
+typing/untypeast.cmo : \
+  parsing/ast_helper.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/typedtree.cmi \
+  typing/untypeast.cmi \
+  utils/misc.cmi
+typing/untypeast.cmx : \
+  parsing/ast_helper.cmx \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/typedtree.cmx \
+  typing/untypeast.cmi \
+  utils/misc.cmx
+typing/untypeast.cmi : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/path.cmi \
+  typing/typedtree.cmi
+bytecomp/bytegen.cmo : \
+  bytecomp/bytegen.cmi \
+  bytecomp/instruct.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/matching.cmi \
+  bytecomp/switch.cmi \
+  parsing/asttypes.cmi \
+  typing/ident.cmi \
+  typing/primitive.cmi \
+  typing/subst.cmi \
+  typing/types.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+bytecomp/bytegen.cmx : \
+  bytecomp/bytegen.cmi \
+  bytecomp/instruct.cmx \
+  bytecomp/lambda.cmx \
+  bytecomp/matching.cmx \
+  bytecomp/switch.cmx \
+  parsing/asttypes.cmi \
+  typing/ident.cmx \
+  typing/primitive.cmx \
+  typing/subst.cmx \
+  typing/types.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+bytecomp/bytegen.cmi : \
+  bytecomp/instruct.cmi \
+  bytecomp/lambda.cmi
+bytecomp/bytelibrarian.cmo : \
+  bytecomp/bytelibrarian.cmi \
+  bytecomp/bytelink.cmi \
+  bytecomp/cmo_format.cmi \
+  bytecomp/emitcode.cmi \
+  parsing/location.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+bytecomp/bytelibrarian.cmx : \
+  bytecomp/bytelibrarian.cmi \
+  bytecomp/bytelink.cmx \
+  bytecomp/cmo_format.cmi \
+  bytecomp/emitcode.cmx \
+  parsing/location.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
 bytecomp/bytelibrarian.cmi :
-bytecomp/bytelink.cmo : utils/warnings.cmi bytecomp/symtable.cmi \
-    bytecomp/opcodes.cmo utils/misc.cmi parsing/location.cmi \
-    bytecomp/lambda.cmi bytecomp/instruct.cmi typing/ident.cmi \
-    bytecomp/emitcode.cmi bytecomp/dll.cmi utils/consistbl.cmi \
-    utils/config.cmi bytecomp/cmo_format.cmi utils/clflags.cmi \
-    utils/ccomp.cmi bytecomp/bytesections.cmi bytecomp/bytelink.cmi
-bytecomp/bytelink.cmx : utils/warnings.cmx bytecomp/symtable.cmx \
-    bytecomp/opcodes.cmx utils/misc.cmx parsing/location.cmx \
-    bytecomp/lambda.cmx bytecomp/instruct.cmx typing/ident.cmx \
-    bytecomp/emitcode.cmx bytecomp/dll.cmx utils/consistbl.cmx \
-    utils/config.cmx bytecomp/cmo_format.cmi utils/clflags.cmx \
-    utils/ccomp.cmx bytecomp/bytesections.cmx bytecomp/bytelink.cmi
-bytecomp/bytelink.cmi : bytecomp/symtable.cmi bytecomp/cmo_format.cmi
-bytecomp/bytepackager.cmo : typing/typemod.cmi bytecomp/translmod.cmi \
-    typing/subst.cmi bytecomp/printlambda.cmi typing/path.cmi utils/misc.cmi \
-    parsing/location.cmi bytecomp/instruct.cmi typing/ident.cmi \
-    typing/env.cmi bytecomp/emitcode.cmi utils/config.cmi \
-    bytecomp/cmo_format.cmi utils/clflags.cmi bytecomp/bytelink.cmi \
-    bytecomp/bytegen.cmi bytecomp/bytepackager.cmi
-bytecomp/bytepackager.cmx : typing/typemod.cmx bytecomp/translmod.cmx \
-    typing/subst.cmx bytecomp/printlambda.cmx typing/path.cmx utils/misc.cmx \
-    parsing/location.cmx bytecomp/instruct.cmx typing/ident.cmx \
-    typing/env.cmx bytecomp/emitcode.cmx utils/config.cmx \
-    bytecomp/cmo_format.cmi utils/clflags.cmx bytecomp/bytelink.cmx \
-    bytecomp/bytegen.cmx bytecomp/bytepackager.cmi
-bytecomp/bytepackager.cmi : typing/ident.cmi typing/env.cmi
-bytecomp/bytesections.cmo : utils/config.cmi bytecomp/bytesections.cmi
-bytecomp/bytesections.cmx : utils/config.cmx bytecomp/bytesections.cmi
+bytecomp/bytelink.cmo : \
+  bytecomp/bytelink.cmi \
+  bytecomp/bytesections.cmi \
+  bytecomp/cmo_format.cmi \
+  bytecomp/dll.cmi \
+  bytecomp/emitcode.cmi \
+  bytecomp/instruct.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/opcodes.cmo \
+  bytecomp/symtable.cmi \
+  parsing/location.cmi \
+  typing/ident.cmi \
+  utils/ccomp.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/consistbl.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+bytecomp/bytelink.cmx : \
+  bytecomp/bytelink.cmi \
+  bytecomp/bytesections.cmx \
+  bytecomp/cmo_format.cmi \
+  bytecomp/dll.cmx \
+  bytecomp/emitcode.cmx \
+  bytecomp/instruct.cmx \
+  bytecomp/lambda.cmx \
+  bytecomp/opcodes.cmx \
+  bytecomp/symtable.cmx \
+  parsing/location.cmx \
+  typing/ident.cmx \
+  utils/ccomp.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/consistbl.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+bytecomp/bytelink.cmi : \
+  bytecomp/cmo_format.cmi \
+  bytecomp/symtable.cmi
+bytecomp/bytepackager.cmo : \
+  bytecomp/bytegen.cmi \
+  bytecomp/bytelink.cmi \
+  bytecomp/bytepackager.cmi \
+  bytecomp/cmo_format.cmi \
+  bytecomp/emitcode.cmi \
+  bytecomp/instruct.cmi \
+  bytecomp/printlambda.cmi \
+  bytecomp/translmod.cmi \
+  parsing/location.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/subst.cmi \
+  typing/typemod.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+bytecomp/bytepackager.cmx : \
+  bytecomp/bytegen.cmx \
+  bytecomp/bytelink.cmx \
+  bytecomp/bytepackager.cmi \
+  bytecomp/cmo_format.cmi \
+  bytecomp/emitcode.cmx \
+  bytecomp/instruct.cmx \
+  bytecomp/printlambda.cmx \
+  bytecomp/translmod.cmx \
+  parsing/location.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/subst.cmx \
+  typing/typemod.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+bytecomp/bytepackager.cmi : \
+  typing/env.cmi \
+  typing/ident.cmi
+bytecomp/bytesections.cmo : \
+  bytecomp/bytesections.cmi \
+  utils/config.cmi
+bytecomp/bytesections.cmx : \
+  bytecomp/bytesections.cmi \
+  utils/config.cmx
 bytecomp/bytesections.cmi :
-bytecomp/cmo_format.cmi : utils/tbl.cmi bytecomp/lambda.cmi typing/ident.cmi
-bytecomp/dll.cmo : utils/misc.cmi utils/config.cmi bytecomp/dll.cmi
-bytecomp/dll.cmx : utils/misc.cmx utils/config.cmx bytecomp/dll.cmi
+bytecomp/cmo_format.cmi : \
+  bytecomp/lambda.cmi \
+  typing/ident.cmi \
+  utils/tbl.cmi
+bytecomp/dll.cmo : \
+  bytecomp/dll.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+bytecomp/dll.cmx : \
+  bytecomp/dll.cmi \
+  utils/config.cmx \
+  utils/misc.cmx
 bytecomp/dll.cmi :
-bytecomp/emitcode.cmo : bytecomp/translmod.cmi typing/primitive.cmi \
-    bytecomp/opcodes.cmo utils/misc.cmi bytecomp/meta.cmi \
-    parsing/location.cmi bytecomp/lambda.cmi bytecomp/instruct.cmi \
-    typing/ident.cmi typing/env.cmi utils/config.cmi bytecomp/cmo_format.cmi \
-    utils/clflags.cmi typing/btype.cmi parsing/asttypes.cmi \
-    bytecomp/emitcode.cmi
-bytecomp/emitcode.cmx : bytecomp/translmod.cmx typing/primitive.cmx \
-    bytecomp/opcodes.cmx utils/misc.cmx bytecomp/meta.cmx \
-    parsing/location.cmx bytecomp/lambda.cmx bytecomp/instruct.cmx \
-    typing/ident.cmx typing/env.cmx utils/config.cmx bytecomp/cmo_format.cmi \
-    utils/clflags.cmx typing/btype.cmx parsing/asttypes.cmi \
-    bytecomp/emitcode.cmi
-bytecomp/emitcode.cmi : bytecomp/instruct.cmi typing/ident.cmi \
-    bytecomp/cmo_format.cmi
-bytecomp/instruct.cmo : typing/types.cmi typing/subst.cmi \
-    parsing/location.cmi bytecomp/lambda.cmi typing/ident.cmi typing/env.cmi \
-    bytecomp/instruct.cmi
-bytecomp/instruct.cmx : typing/types.cmx typing/subst.cmx \
-    parsing/location.cmx bytecomp/lambda.cmx typing/ident.cmx typing/env.cmx \
-    bytecomp/instruct.cmi
-bytecomp/instruct.cmi : typing/types.cmi typing/subst.cmi \
-    parsing/location.cmi bytecomp/lambda.cmi typing/ident.cmi typing/env.cmi
-bytecomp/lambda.cmo : typing/types.cmi typing/primitive.cmi typing/path.cmi \
-    utils/misc.cmi parsing/location.cmi typing/ident.cmi typing/env.cmi \
-    parsing/asttypes.cmi bytecomp/lambda.cmi
-bytecomp/lambda.cmx : typing/types.cmx typing/primitive.cmx typing/path.cmx \
-    utils/misc.cmx parsing/location.cmx typing/ident.cmx typing/env.cmx \
-    parsing/asttypes.cmi bytecomp/lambda.cmi
-bytecomp/lambda.cmi : typing/types.cmi typing/primitive.cmi typing/path.cmi \
-    parsing/location.cmi typing/ident.cmi typing/env.cmi parsing/asttypes.cmi
-bytecomp/matching.cmo : typing/types.cmi typing/typeopt.cmi \
-    typing/typedtree.cmi bytecomp/switch.cmi bytecomp/printlambda.cmi \
-    typing/primitive.cmi typing/predef.cmi typing/path.cmi \
-    typing/parmatch.cmi utils/misc.cmi parsing/longident.cmi \
-    parsing/location.cmi bytecomp/lambda.cmi typing/ident.cmi typing/env.cmi \
-    utils/clflags.cmi typing/btype.cmi parsing/asttypes.cmi \
-    bytecomp/matching.cmi
-bytecomp/matching.cmx : typing/types.cmx typing/typeopt.cmx \
-    typing/typedtree.cmx bytecomp/switch.cmx bytecomp/printlambda.cmx \
-    typing/primitive.cmx typing/predef.cmx typing/path.cmx \
-    typing/parmatch.cmx utils/misc.cmx parsing/longident.cmx \
-    parsing/location.cmx bytecomp/lambda.cmx typing/ident.cmx typing/env.cmx \
-    utils/clflags.cmx typing/btype.cmx parsing/asttypes.cmi \
-    bytecomp/matching.cmi
-bytecomp/matching.cmi : typing/typedtree.cmi parsing/location.cmi \
-    bytecomp/lambda.cmi typing/ident.cmi
-bytecomp/meta.cmo : bytecomp/instruct.cmi bytecomp/meta.cmi
-bytecomp/meta.cmx : bytecomp/instruct.cmx bytecomp/meta.cmi
-bytecomp/meta.cmi : bytecomp/instruct.cmi
+bytecomp/emitcode.cmo : \
+  bytecomp/cmo_format.cmi \
+  bytecomp/emitcode.cmi \
+  bytecomp/instruct.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/meta.cmi \
+  bytecomp/opcodes.cmo \
+  bytecomp/translmod.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  typing/btype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/primitive.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+bytecomp/emitcode.cmx : \
+  bytecomp/cmo_format.cmi \
+  bytecomp/emitcode.cmi \
+  bytecomp/instruct.cmx \
+  bytecomp/lambda.cmx \
+  bytecomp/meta.cmx \
+  bytecomp/opcodes.cmx \
+  bytecomp/translmod.cmx \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  typing/btype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/primitive.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+bytecomp/emitcode.cmi : \
+  bytecomp/cmo_format.cmi \
+  bytecomp/instruct.cmi \
+  typing/ident.cmi
+bytecomp/instruct.cmo : \
+  bytecomp/instruct.cmi \
+  bytecomp/lambda.cmi \
+  parsing/location.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/subst.cmi \
+  typing/types.cmi
+bytecomp/instruct.cmx : \
+  bytecomp/instruct.cmi \
+  bytecomp/lambda.cmx \
+  parsing/location.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/subst.cmx \
+  typing/types.cmx
+bytecomp/instruct.cmi : \
+  bytecomp/lambda.cmi \
+  parsing/location.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/subst.cmi \
+  typing/types.cmi
+bytecomp/lambda.cmo : \
+  bytecomp/lambda.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/primitive.cmi \
+  typing/types.cmi \
+  utils/misc.cmi
+bytecomp/lambda.cmx : \
+  bytecomp/lambda.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/primitive.cmx \
+  typing/types.cmx \
+  utils/misc.cmx
+bytecomp/lambda.cmi : \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/primitive.cmi \
+  typing/types.cmi
+bytecomp/matching.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/matching.cmi \
+  bytecomp/printlambda.cmi \
+  bytecomp/switch.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  typing/btype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/parmatch.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/primitive.cmi \
+  typing/typedtree.cmi \
+  typing/typeopt.cmi \
+  typing/types.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+bytecomp/matching.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/matching.cmi \
+  bytecomp/printlambda.cmx \
+  bytecomp/switch.cmx \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  typing/btype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/parmatch.cmx \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/primitive.cmx \
+  typing/typedtree.cmx \
+  typing/typeopt.cmx \
+  typing/types.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx
+bytecomp/matching.cmi : \
+  bytecomp/lambda.cmi \
+  parsing/location.cmi \
+  typing/ident.cmi \
+  typing/typedtree.cmi
+bytecomp/meta.cmo : \
+  bytecomp/instruct.cmi \
+  bytecomp/meta.cmi
+bytecomp/meta.cmx : \
+  bytecomp/instruct.cmx \
+  bytecomp/meta.cmi
+bytecomp/meta.cmi : \
+  bytecomp/instruct.cmi
 bytecomp/opcodes.cmo :
 bytecomp/opcodes.cmx :
-bytecomp/printinstr.cmo : bytecomp/printlambda.cmi parsing/location.cmi \
-    bytecomp/lambda.cmi bytecomp/instruct.cmi typing/ident.cmi \
-    bytecomp/printinstr.cmi
-bytecomp/printinstr.cmx : bytecomp/printlambda.cmx parsing/location.cmx \
-    bytecomp/lambda.cmx bytecomp/instruct.cmx typing/ident.cmx \
-    bytecomp/printinstr.cmi
-bytecomp/printinstr.cmi : bytecomp/instruct.cmi
-bytecomp/printlambda.cmo : typing/types.cmi typing/primitive.cmi \
-    parsing/location.cmi bytecomp/lambda.cmi typing/ident.cmi \
-    parsing/asttypes.cmi bytecomp/printlambda.cmi
-bytecomp/printlambda.cmx : typing/types.cmx typing/primitive.cmx \
-    parsing/location.cmx bytecomp/lambda.cmx typing/ident.cmx \
-    parsing/asttypes.cmi bytecomp/printlambda.cmi
-bytecomp/printlambda.cmi : bytecomp/lambda.cmi
-bytecomp/runtimedef.cmo : bytecomp/runtimedef.cmi
-bytecomp/runtimedef.cmx : bytecomp/runtimedef.cmi
+bytecomp/printinstr.cmo : \
+  bytecomp/instruct.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/printinstr.cmi \
+  bytecomp/printlambda.cmi \
+  parsing/location.cmi \
+  typing/ident.cmi
+bytecomp/printinstr.cmx : \
+  bytecomp/instruct.cmx \
+  bytecomp/lambda.cmx \
+  bytecomp/printinstr.cmi \
+  bytecomp/printlambda.cmx \
+  parsing/location.cmx \
+  typing/ident.cmx
+bytecomp/printinstr.cmi : \
+  bytecomp/instruct.cmi
+bytecomp/printlambda.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/printlambda.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  typing/ident.cmi \
+  typing/primitive.cmi \
+  typing/types.cmi
+bytecomp/printlambda.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/printlambda.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  typing/ident.cmx \
+  typing/primitive.cmx \
+  typing/types.cmx
+bytecomp/printlambda.cmi : \
+  bytecomp/lambda.cmi
+bytecomp/runtimedef.cmo : \
+  bytecomp/runtimedef.cmi
+bytecomp/runtimedef.cmx : \
+  bytecomp/runtimedef.cmi
 bytecomp/runtimedef.cmi :
-bytecomp/semantics_of_primitives.cmo : bytecomp/lambda.cmi \
-    bytecomp/semantics_of_primitives.cmi
-bytecomp/semantics_of_primitives.cmx : bytecomp/lambda.cmx \
-    bytecomp/semantics_of_primitives.cmi
-bytecomp/semantics_of_primitives.cmi : bytecomp/lambda.cmi
-bytecomp/simplif.cmo : utils/warnings.cmi utils/tbl.cmi typing/stypes.cmi \
-    utils/misc.cmi parsing/location.cmi bytecomp/lambda.cmi typing/ident.cmi \
-    utils/clflags.cmi parsing/asttypes.cmi typing/annot.cmi \
-    bytecomp/simplif.cmi
-bytecomp/simplif.cmx : utils/warnings.cmx utils/tbl.cmx typing/stypes.cmx \
-    utils/misc.cmx parsing/location.cmx bytecomp/lambda.cmx typing/ident.cmx \
-    utils/clflags.cmx parsing/asttypes.cmi typing/annot.cmi \
-    bytecomp/simplif.cmi
-bytecomp/simplif.cmi : utils/misc.cmi parsing/location.cmi \
-    bytecomp/lambda.cmi typing/ident.cmi
-bytecomp/switch.cmo : parsing/location.cmi bytecomp/switch.cmi
-bytecomp/switch.cmx : parsing/location.cmx bytecomp/switch.cmi
-bytecomp/switch.cmi : parsing/location.cmi
-bytecomp/symtable.cmo : utils/tbl.cmi bytecomp/runtimedef.cmi \
-    typing/predef.cmi utils/misc.cmi bytecomp/meta.cmi parsing/location.cmi \
-    bytecomp/lambda.cmi typing/ident.cmi bytecomp/dll.cmi utils/config.cmi \
-    bytecomp/cmo_format.cmi utils/clflags.cmi bytecomp/bytesections.cmi \
-    parsing/asttypes.cmi bytecomp/symtable.cmi
-bytecomp/symtable.cmx : utils/tbl.cmx bytecomp/runtimedef.cmx \
-    typing/predef.cmx utils/misc.cmx bytecomp/meta.cmx parsing/location.cmx \
-    bytecomp/lambda.cmx typing/ident.cmx bytecomp/dll.cmx utils/config.cmx \
-    bytecomp/cmo_format.cmi utils/clflags.cmx bytecomp/bytesections.cmx \
-    parsing/asttypes.cmi bytecomp/symtable.cmi
-bytecomp/symtable.cmi : utils/misc.cmi bytecomp/lambda.cmi typing/ident.cmi \
-    bytecomp/cmo_format.cmi
-bytecomp/translattribute.cmo : utils/warnings.cmi typing/typedtree.cmi \
-    parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
-    parsing/location.cmi bytecomp/lambda.cmi utils/config.cmi \
-    bytecomp/translattribute.cmi
-bytecomp/translattribute.cmx : utils/warnings.cmx typing/typedtree.cmx \
-    parsing/parsetree.cmi utils/misc.cmx parsing/longident.cmx \
-    parsing/location.cmx bytecomp/lambda.cmx utils/config.cmx \
-    bytecomp/translattribute.cmi
-bytecomp/translattribute.cmi : typing/typedtree.cmi parsing/parsetree.cmi \
-    parsing/location.cmi bytecomp/lambda.cmi
-bytecomp/translclass.cmo : typing/types.cmi typing/typeopt.cmi \
-    typing/typedtree.cmi bytecomp/translobj.cmi bytecomp/translcore.cmi \
-    typing/path.cmi bytecomp/matching.cmi parsing/location.cmi \
-    bytecomp/lambda.cmi typing/ident.cmi typing/env.cmi utils/clflags.cmi \
-    typing/btype.cmi parsing/asttypes.cmi bytecomp/translclass.cmi
-bytecomp/translclass.cmx : typing/types.cmx typing/typeopt.cmx \
-    typing/typedtree.cmx bytecomp/translobj.cmx bytecomp/translcore.cmx \
-    typing/path.cmx bytecomp/matching.cmx parsing/location.cmx \
-    bytecomp/lambda.cmx typing/ident.cmx typing/env.cmx utils/clflags.cmx \
-    typing/btype.cmx parsing/asttypes.cmi bytecomp/translclass.cmi
-bytecomp/translclass.cmi : typing/typedtree.cmi parsing/location.cmi \
-    bytecomp/lambda.cmi typing/ident.cmi parsing/asttypes.cmi
-bytecomp/translcore.cmo : typing/types.cmi typing/typeopt.cmi \
-    typing/typedtree.cmi typing/typecore.cmi bytecomp/translobj.cmi \
-    bytecomp/translattribute.cmi typing/primitive.cmi typing/predef.cmi \
-    typing/path.cmi typing/parmatch.cmi utils/misc.cmi bytecomp/matching.cmi \
-    parsing/longident.cmi parsing/location.cmi bytecomp/lambda.cmi \
-    typing/ident.cmi typing/env.cmi utils/config.cmi utils/clflags.cmi \
-    typing/btype.cmi parsing/asttypes.cmi bytecomp/translcore.cmi
-bytecomp/translcore.cmx : typing/types.cmx typing/typeopt.cmx \
-    typing/typedtree.cmx typing/typecore.cmx bytecomp/translobj.cmx \
-    bytecomp/translattribute.cmx typing/primitive.cmx typing/predef.cmx \
-    typing/path.cmx typing/parmatch.cmx utils/misc.cmx bytecomp/matching.cmx \
-    parsing/longident.cmx parsing/location.cmx bytecomp/lambda.cmx \
-    typing/ident.cmx typing/env.cmx utils/config.cmx utils/clflags.cmx \
-    typing/btype.cmx parsing/asttypes.cmi bytecomp/translcore.cmi
-bytecomp/translcore.cmi : typing/types.cmi typing/typedtree.cmi \
-    typing/primitive.cmi typing/path.cmi parsing/location.cmi \
-    bytecomp/lambda.cmi typing/ident.cmi typing/env.cmi parsing/asttypes.cmi
-bytecomp/translmod.cmo : typing/types.cmi typing/typedtree.cmi \
-    bytecomp/translobj.cmi bytecomp/translcore.cmi bytecomp/translclass.cmi \
-    bytecomp/translattribute.cmi typing/printtyp.cmi typing/primitive.cmi \
-    typing/predef.cmi typing/path.cmi typing/mtype.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi bytecomp/lambda.cmi \
-    typing/ident.cmi typing/env.cmi typing/ctype.cmi utils/clflags.cmi \
-    parsing/asttypes.cmi bytecomp/translmod.cmi
-bytecomp/translmod.cmx : typing/types.cmx typing/typedtree.cmx \
-    bytecomp/translobj.cmx bytecomp/translcore.cmx bytecomp/translclass.cmx \
-    bytecomp/translattribute.cmx typing/printtyp.cmx typing/primitive.cmx \
-    typing/predef.cmx typing/path.cmx typing/mtype.cmx utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx bytecomp/lambda.cmx \
-    typing/ident.cmx typing/env.cmx typing/ctype.cmx utils/clflags.cmx \
-    parsing/asttypes.cmi bytecomp/translmod.cmi
-bytecomp/translmod.cmi : typing/typedtree.cmi typing/primitive.cmi \
-    parsing/location.cmi bytecomp/lambda.cmi typing/ident.cmi
-bytecomp/translobj.cmo : typing/primitive.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi bytecomp/lambda.cmi \
-    typing/ident.cmi typing/env.cmi utils/config.cmi utils/clflags.cmi \
-    typing/btype.cmi parsing/asttypes.cmi bytecomp/translobj.cmi
-bytecomp/translobj.cmx : typing/primitive.cmx utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx bytecomp/lambda.cmx \
-    typing/ident.cmx typing/env.cmx utils/config.cmx utils/clflags.cmx \
-    typing/btype.cmx parsing/asttypes.cmi bytecomp/translobj.cmi
-bytecomp/translobj.cmi : bytecomp/lambda.cmi typing/ident.cmi typing/env.cmi
-asmcomp/CSE.cmo : asmcomp/mach.cmi asmcomp/CSEgen.cmi asmcomp/arch.cmo
-asmcomp/CSE.cmx : asmcomp/mach.cmx asmcomp/CSEgen.cmx asmcomp/arch.cmx
-asmcomp/CSEgen.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/mach.cmi \
-    asmcomp/cmm.cmi asmcomp/CSEgen.cmi
-asmcomp/CSEgen.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/mach.cmx \
-    asmcomp/cmm.cmx asmcomp/CSEgen.cmi
-asmcomp/CSEgen.cmi : asmcomp/mach.cmi
-asmcomp/afl_instrument.cmo : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/debuginfo.cmi asmcomp/cmm.cmi utils/clflags.cmi \
-    parsing/asttypes.cmi asmcomp/afl_instrument.cmi
-asmcomp/afl_instrument.cmx : bytecomp/lambda.cmx typing/ident.cmx \
-    middle_end/debuginfo.cmx asmcomp/cmm.cmx utils/clflags.cmx \
-    parsing/asttypes.cmi asmcomp/afl_instrument.cmi
-asmcomp/afl_instrument.cmi : asmcomp/cmm.cmi
-asmcomp/arch.cmo : utils/config.cmi utils/clflags.cmi
-asmcomp/arch.cmx : utils/config.cmx utils/clflags.cmx
-asmcomp/asmgen.cmo : asmcomp/un_anf.cmi bytecomp/translmod.cmi \
-    middle_end/base_types/symbol.cmi asmcomp/split.cmi asmcomp/spill.cmi \
-    asmcomp/selection.cmi asmcomp/scheduling.cmi asmcomp/reload.cmi \
-    asmcomp/reg.cmi utils/profile.cmi asmcomp/proc.cmi asmcomp/printmach.cmi \
-    asmcomp/printlinear.cmi asmcomp/printcmm.cmi asmcomp/printclambda.cmi \
-    typing/primitive.cmi utils/misc.cmi asmcomp/mach.cmi parsing/location.cmi \
-    asmcomp/liveness.cmi asmcomp/linscan.cmi \
-    middle_end/base_types/linkage_name.cmi asmcomp/linearize.cmi \
-    bytecomp/lambda.cmi asmcomp/interval.cmi asmcomp/interf.cmi \
-    typing/ident.cmi asmcomp/flambda_to_clambda.cmi middle_end/flambda.cmi \
-    asmcomp/emitaux.cmi asmcomp/emit.cmi asmcomp/deadcode.cmi \
-    utils/config.cmi asmcomp/compilenv.cmi asmcomp/comballoc.cmi \
-    asmcomp/coloring.cmi asmcomp/cmmgen.cmi asmcomp/cmm.cmi \
-    asmcomp/closure.cmi utils/clflags.cmi asmcomp/clambda.cmi asmcomp/CSE.cmo \
-    asmcomp/build_export_info.cmi asmcomp/debug/available_regs.cmi \
-    asmcomp/asmgen.cmi
-asmcomp/asmgen.cmx : asmcomp/un_anf.cmx bytecomp/translmod.cmx \
-    middle_end/base_types/symbol.cmx asmcomp/split.cmx asmcomp/spill.cmx \
-    asmcomp/selection.cmx asmcomp/scheduling.cmx asmcomp/reload.cmx \
-    asmcomp/reg.cmx utils/profile.cmx asmcomp/proc.cmx asmcomp/printmach.cmx \
-    asmcomp/printlinear.cmx asmcomp/printcmm.cmx asmcomp/printclambda.cmx \
-    typing/primitive.cmx utils/misc.cmx asmcomp/mach.cmx parsing/location.cmx \
-    asmcomp/liveness.cmx asmcomp/linscan.cmx \
-    middle_end/base_types/linkage_name.cmx asmcomp/linearize.cmx \
-    bytecomp/lambda.cmx asmcomp/interval.cmx asmcomp/interf.cmx \
-    typing/ident.cmx asmcomp/flambda_to_clambda.cmx middle_end/flambda.cmx \
-    asmcomp/emitaux.cmx asmcomp/emit.cmx asmcomp/deadcode.cmx \
-    utils/config.cmx asmcomp/compilenv.cmx asmcomp/comballoc.cmx \
-    asmcomp/coloring.cmx asmcomp/cmmgen.cmx asmcomp/cmm.cmx \
-    asmcomp/closure.cmx utils/clflags.cmx asmcomp/clambda.cmx asmcomp/CSE.cmx \
-    asmcomp/build_export_info.cmx asmcomp/debug/available_regs.cmx \
-    asmcomp/asmgen.cmi
-asmcomp/asmgen.cmi : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/flambda.cmi asmcomp/cmm.cmi middle_end/backend_intf.cmi
-asmcomp/asmlibrarian.cmo : utils/misc.cmi parsing/location.cmi \
-    asmcomp/export_info.cmi utils/config.cmi asmcomp/compilenv.cmi \
-    asmcomp/cmx_format.cmi utils/clflags.cmi asmcomp/clambda.cmi \
-    utils/ccomp.cmi asmcomp/asmlink.cmi asmcomp/asmlibrarian.cmi
-asmcomp/asmlibrarian.cmx : utils/misc.cmx parsing/location.cmx \
-    asmcomp/export_info.cmx utils/config.cmx asmcomp/compilenv.cmx \
-    asmcomp/cmx_format.cmi utils/clflags.cmx asmcomp/clambda.cmx \
-    utils/ccomp.cmx asmcomp/asmlink.cmx asmcomp/asmlibrarian.cmi
+bytecomp/semantics_of_primitives.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/semantics_of_primitives.cmi
+bytecomp/semantics_of_primitives.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/semantics_of_primitives.cmi
+bytecomp/semantics_of_primitives.cmi : \
+  bytecomp/lambda.cmi
+bytecomp/simplif.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/simplif.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  typing/annot.cmi \
+  typing/ident.cmi \
+  typing/stypes.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi \
+  utils/tbl.cmi \
+  utils/warnings.cmi
+bytecomp/simplif.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/simplif.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  typing/annot.cmi \
+  typing/ident.cmx \
+  typing/stypes.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx \
+  utils/tbl.cmx \
+  utils/warnings.cmx
+bytecomp/simplif.cmi : \
+  bytecomp/lambda.cmi \
+  parsing/location.cmi \
+  typing/ident.cmi \
+  utils/misc.cmi
+bytecomp/switch.cmo : \
+  bytecomp/switch.cmi \
+  parsing/location.cmi
+bytecomp/switch.cmx : \
+  bytecomp/switch.cmi \
+  parsing/location.cmx
+bytecomp/switch.cmi : \
+  parsing/location.cmi
+bytecomp/symtable.cmo : \
+  bytecomp/bytesections.cmi \
+  bytecomp/cmo_format.cmi \
+  bytecomp/dll.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/meta.cmi \
+  bytecomp/runtimedef.cmi \
+  bytecomp/symtable.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  typing/ident.cmi \
+  typing/predef.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/tbl.cmi
+bytecomp/symtable.cmx : \
+  bytecomp/bytesections.cmx \
+  bytecomp/cmo_format.cmi \
+  bytecomp/dll.cmx \
+  bytecomp/lambda.cmx \
+  bytecomp/meta.cmx \
+  bytecomp/runtimedef.cmx \
+  bytecomp/symtable.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  typing/ident.cmx \
+  typing/predef.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/tbl.cmx
+bytecomp/symtable.cmi : \
+  bytecomp/cmo_format.cmi \
+  bytecomp/lambda.cmi \
+  typing/ident.cmi \
+  utils/misc.cmi
+bytecomp/translattribute.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/translattribute.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/typedtree.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+bytecomp/translattribute.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/translattribute.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  typing/typedtree.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+bytecomp/translattribute.cmi : \
+  bytecomp/lambda.cmi \
+  parsing/location.cmi \
+  parsing/parsetree.cmi \
+  typing/typedtree.cmi
+bytecomp/translclass.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/matching.cmi \
+  bytecomp/translclass.cmi \
+  bytecomp/translcore.cmi \
+  bytecomp/translobj.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  typing/btype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/typedtree.cmi \
+  typing/typeopt.cmi \
+  typing/types.cmi \
+  utils/clflags.cmi
+bytecomp/translclass.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/matching.cmx \
+  bytecomp/translclass.cmi \
+  bytecomp/translcore.cmx \
+  bytecomp/translobj.cmx \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  typing/btype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/typedtree.cmx \
+  typing/typeopt.cmx \
+  typing/types.cmx \
+  utils/clflags.cmx
+bytecomp/translclass.cmi : \
+  bytecomp/lambda.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  typing/ident.cmi \
+  typing/typedtree.cmi
+bytecomp/translcore.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/matching.cmi \
+  bytecomp/translattribute.cmi \
+  bytecomp/translcore.cmi \
+  bytecomp/translobj.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  typing/btype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/parmatch.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/primitive.cmi \
+  typing/typecore.cmi \
+  typing/typedtree.cmi \
+  typing/typeopt.cmi \
+  typing/types.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+bytecomp/translcore.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/matching.cmx \
+  bytecomp/translattribute.cmx \
+  bytecomp/translcore.cmi \
+  bytecomp/translobj.cmx \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  typing/btype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/parmatch.cmx \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/primitive.cmx \
+  typing/typecore.cmx \
+  typing/typedtree.cmx \
+  typing/typeopt.cmx \
+  typing/types.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+bytecomp/translcore.cmi : \
+  bytecomp/lambda.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/primitive.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi
+bytecomp/translmod.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/translattribute.cmi \
+  bytecomp/translclass.cmi \
+  bytecomp/translcore.cmi \
+  bytecomp/translmod.cmi \
+  bytecomp/translobj.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/mtype.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/primitive.cmi \
+  typing/printtyp.cmi \
+  typing/typedtree.cmi \
+  typing/types.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+bytecomp/translmod.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/translattribute.cmx \
+  bytecomp/translclass.cmx \
+  bytecomp/translcore.cmx \
+  bytecomp/translmod.cmi \
+  bytecomp/translobj.cmx \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  typing/ctype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/mtype.cmx \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/primitive.cmx \
+  typing/printtyp.cmx \
+  typing/typedtree.cmx \
+  typing/types.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx
+bytecomp/translmod.cmi : \
+  bytecomp/lambda.cmi \
+  parsing/location.cmi \
+  typing/ident.cmi \
+  typing/primitive.cmi \
+  typing/typedtree.cmi
+bytecomp/translobj.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/translobj.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  typing/btype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/primitive.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+bytecomp/translobj.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/translobj.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  typing/btype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/primitive.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+bytecomp/translobj.cmi : \
+  bytecomp/lambda.cmi \
+  typing/env.cmi \
+  typing/ident.cmi
+asmcomp/CSE.cmo : \
+  asmcomp/CSEgen.cmi \
+  asmcomp/arch.cmo \
+  asmcomp/mach.cmi
+asmcomp/CSE.cmx : \
+  asmcomp/CSEgen.cmx \
+  asmcomp/arch.cmx \
+  asmcomp/mach.cmx
+asmcomp/CSEgen.cmo : \
+  asmcomp/CSEgen.cmi \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi
+asmcomp/CSEgen.cmx : \
+  asmcomp/CSEgen.cmi \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx
+asmcomp/CSEgen.cmi : \
+  asmcomp/mach.cmi
+asmcomp/afl_instrument.cmo : \
+  asmcomp/afl_instrument.cmi \
+  asmcomp/cmm.cmi \
+  bytecomp/lambda.cmi \
+  middle_end/debuginfo.cmi \
+  parsing/asttypes.cmi \
+  typing/ident.cmi \
+  utils/clflags.cmi
+asmcomp/afl_instrument.cmx : \
+  asmcomp/afl_instrument.cmi \
+  asmcomp/cmm.cmx \
+  bytecomp/lambda.cmx \
+  middle_end/debuginfo.cmx \
+  parsing/asttypes.cmi \
+  typing/ident.cmx \
+  utils/clflags.cmx
+asmcomp/afl_instrument.cmi : \
+  asmcomp/cmm.cmi
+asmcomp/arch.cmo : \
+  utils/clflags.cmi \
+  utils/config.cmi
+asmcomp/arch.cmx : \
+  utils/clflags.cmx \
+  utils/config.cmx
+asmcomp/asmgen.cmo : \
+  asmcomp/CSE.cmo \
+  asmcomp/asmgen.cmi \
+  asmcomp/build_export_info.cmi \
+  asmcomp/clambda.cmi \
+  asmcomp/closure.cmi \
+  asmcomp/cmm.cmi \
+  asmcomp/cmmgen.cmi \
+  asmcomp/coloring.cmi \
+  asmcomp/comballoc.cmi \
+  asmcomp/compilenv.cmi \
+  asmcomp/deadcode.cmi \
+  asmcomp/debug/available_regs.cmi \
+  asmcomp/emit.cmi \
+  asmcomp/emitaux.cmi \
+  asmcomp/flambda_to_clambda.cmi \
+  asmcomp/interf.cmi \
+  asmcomp/interval.cmi \
+  asmcomp/linearize.cmi \
+  asmcomp/linscan.cmi \
+  asmcomp/liveness.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/printclambda.cmi \
+  asmcomp/printcmm.cmi \
+  asmcomp/printlinear.cmi \
+  asmcomp/printmach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi \
+  asmcomp/reload.cmi \
+  asmcomp/scheduling.cmi \
+  asmcomp/selection.cmi \
+  asmcomp/spill.cmi \
+  asmcomp/split.cmi \
+  asmcomp/un_anf.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/translmod.cmi \
+  middle_end/base_types/linkage_name.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/flambda.cmi \
+  parsing/location.cmi \
+  typing/ident.cmi \
+  typing/primitive.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/profile.cmi
+asmcomp/asmgen.cmx : \
+  asmcomp/CSE.cmx \
+  asmcomp/asmgen.cmi \
+  asmcomp/build_export_info.cmx \
+  asmcomp/clambda.cmx \
+  asmcomp/closure.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/cmmgen.cmx \
+  asmcomp/coloring.cmx \
+  asmcomp/comballoc.cmx \
+  asmcomp/compilenv.cmx \
+  asmcomp/deadcode.cmx \
+  asmcomp/debug/available_regs.cmx \
+  asmcomp/emit.cmx \
+  asmcomp/emitaux.cmx \
+  asmcomp/flambda_to_clambda.cmx \
+  asmcomp/interf.cmx \
+  asmcomp/interval.cmx \
+  asmcomp/linearize.cmx \
+  asmcomp/linscan.cmx \
+  asmcomp/liveness.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/printclambda.cmx \
+  asmcomp/printcmm.cmx \
+  asmcomp/printlinear.cmx \
+  asmcomp/printmach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx \
+  asmcomp/reload.cmx \
+  asmcomp/scheduling.cmx \
+  asmcomp/selection.cmx \
+  asmcomp/spill.cmx \
+  asmcomp/split.cmx \
+  asmcomp/un_anf.cmx \
+  bytecomp/lambda.cmx \
+  bytecomp/translmod.cmx \
+  middle_end/base_types/linkage_name.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/flambda.cmx \
+  parsing/location.cmx \
+  typing/ident.cmx \
+  typing/primitive.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/profile.cmx
+asmcomp/asmgen.cmi : \
+  asmcomp/cmm.cmi \
+  bytecomp/lambda.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/flambda.cmi \
+  typing/ident.cmi
+asmcomp/asmlibrarian.cmo : \
+  asmcomp/asmlibrarian.cmi \
+  asmcomp/asmlink.cmi \
+  asmcomp/clambda.cmi \
+  asmcomp/cmx_format.cmi \
+  asmcomp/compilenv.cmi \
+  asmcomp/export_info.cmi \
+  parsing/location.cmi \
+  utils/ccomp.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+asmcomp/asmlibrarian.cmx : \
+  asmcomp/asmlibrarian.cmi \
+  asmcomp/asmlink.cmx \
+  asmcomp/clambda.cmx \
+  asmcomp/cmx_format.cmi \
+  asmcomp/compilenv.cmx \
+  asmcomp/export_info.cmx \
+  parsing/location.cmx \
+  utils/ccomp.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
 asmcomp/asmlibrarian.cmi :
-asmcomp/asmlink.cmo : bytecomp/runtimedef.cmi utils/profile.cmi \
-    utils/misc.cmi parsing/location.cmi asmcomp/emitaux.cmi asmcomp/emit.cmi \
-    utils/consistbl.cmi utils/config.cmi asmcomp/compilenv.cmi \
-    asmcomp/cmx_format.cmi asmcomp/cmmgen.cmi utils/clflags.cmi \
-    utils/ccomp.cmi asmcomp/asmgen.cmi asmcomp/asmlink.cmi
-asmcomp/asmlink.cmx : bytecomp/runtimedef.cmx utils/profile.cmx \
-    utils/misc.cmx parsing/location.cmx asmcomp/emitaux.cmx asmcomp/emit.cmx \
-    utils/consistbl.cmx utils/config.cmx asmcomp/compilenv.cmx \
-    asmcomp/cmx_format.cmi asmcomp/cmmgen.cmx utils/clflags.cmx \
-    utils/ccomp.cmx asmcomp/asmgen.cmx asmcomp/asmlink.cmi
-asmcomp/asmlink.cmi : asmcomp/cmx_format.cmi
-asmcomp/asmpackager.cmo : typing/typemod.cmi bytecomp/translmod.cmi \
-    utils/profile.cmi utils/misc.cmi middle_end/middle_end.cmi \
-    parsing/location.cmi bytecomp/lambda.cmi typing/ident.cmi \
-    asmcomp/export_info_for_pack.cmi asmcomp/export_info.cmi typing/env.cmi \
-    utils/config.cmi asmcomp/compilenv.cmi \
-    middle_end/base_types/compilation_unit.cmi asmcomp/cmx_format.cmi \
-    utils/clflags.cmi utils/ccomp.cmi asmcomp/asmlink.cmi asmcomp/asmgen.cmi \
-    asmcomp/asmpackager.cmi
-asmcomp/asmpackager.cmx : typing/typemod.cmx bytecomp/translmod.cmx \
-    utils/profile.cmx utils/misc.cmx middle_end/middle_end.cmx \
-    parsing/location.cmx bytecomp/lambda.cmx typing/ident.cmx \
-    asmcomp/export_info_for_pack.cmx asmcomp/export_info.cmx typing/env.cmx \
-    utils/config.cmx asmcomp/compilenv.cmx \
-    middle_end/base_types/compilation_unit.cmx asmcomp/cmx_format.cmi \
-    utils/clflags.cmx utils/ccomp.cmx asmcomp/asmlink.cmx asmcomp/asmgen.cmx \
-    asmcomp/asmpackager.cmi
-asmcomp/asmpackager.cmi : typing/env.cmi middle_end/backend_intf.cmi
-asmcomp/branch_relaxation.cmo : utils/misc.cmi asmcomp/mach.cmi \
-    asmcomp/linearize.cmi asmcomp/cmm.cmi asmcomp/branch_relaxation_intf.cmo \
-    asmcomp/branch_relaxation.cmi
-asmcomp/branch_relaxation.cmx : utils/misc.cmx asmcomp/mach.cmx \
-    asmcomp/linearize.cmx asmcomp/cmm.cmx asmcomp/branch_relaxation_intf.cmx \
-    asmcomp/branch_relaxation.cmi
-asmcomp/branch_relaxation.cmi : asmcomp/linearize.cmi \
-    asmcomp/branch_relaxation_intf.cmo
-asmcomp/branch_relaxation_intf.cmo : asmcomp/linearize.cmi asmcomp/cmm.cmi \
-    asmcomp/arch.cmo
-asmcomp/branch_relaxation_intf.cmx : asmcomp/linearize.cmx asmcomp/cmm.cmx \
-    asmcomp/arch.cmx
-asmcomp/build_export_info.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    middle_end/base_types/set_of_closures_id.cmi utils/misc.cmi \
-    middle_end/invariant_params.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi asmcomp/export_info.cmi \
-    middle_end/base_types/export_id.cmi asmcomp/compilenv.cmi \
-    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
-    middle_end/backend_intf.cmi middle_end/allocated_const.cmi \
-    asmcomp/build_export_info.cmi
-asmcomp/build_export_info.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
-    middle_end/base_types/set_of_closures_id.cmx utils/misc.cmx \
-    middle_end/invariant_params.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx asmcomp/export_info.cmx \
-    middle_end/base_types/export_id.cmx asmcomp/compilenv.cmx \
-    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
-    middle_end/backend_intf.cmi middle_end/allocated_const.cmx \
-    asmcomp/build_export_info.cmi
-asmcomp/build_export_info.cmi : middle_end/flambda.cmi \
-    asmcomp/export_info.cmi middle_end/backend_intf.cmi
-asmcomp/clambda.cmo : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/debuginfo.cmi parsing/asttypes.cmi asmcomp/clambda.cmi
-asmcomp/clambda.cmx : bytecomp/lambda.cmx typing/ident.cmx \
-    middle_end/debuginfo.cmx parsing/asttypes.cmi asmcomp/clambda.cmi
-asmcomp/clambda.cmi : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/debuginfo.cmi parsing/asttypes.cmi
-asmcomp/closure.cmo : utils/warnings.cmi utils/tbl.cmi bytecomp/switch.cmi \
-    bytecomp/simplif.cmi bytecomp/semantics_of_primitives.cmi \
-    typing/primitive.cmi utils/misc.cmi parsing/location.cmi \
-    bytecomp/lambda.cmi typing/ident.cmi typing/env.cmi \
-    middle_end/debuginfo.cmi utils/config.cmi asmcomp/compilenv.cmi \
-    utils/clflags.cmi asmcomp/clambda.cmi parsing/asttypes.cmi \
-    asmcomp/arch.cmo asmcomp/closure.cmi
-asmcomp/closure.cmx : utils/warnings.cmx utils/tbl.cmx bytecomp/switch.cmx \
-    bytecomp/simplif.cmx bytecomp/semantics_of_primitives.cmx \
-    typing/primitive.cmx utils/misc.cmx parsing/location.cmx \
-    bytecomp/lambda.cmx typing/ident.cmx typing/env.cmx \
-    middle_end/debuginfo.cmx utils/config.cmx asmcomp/compilenv.cmx \
-    utils/clflags.cmx asmcomp/clambda.cmx parsing/asttypes.cmi \
-    asmcomp/arch.cmx asmcomp/closure.cmi
-asmcomp/closure.cmi : bytecomp/lambda.cmi asmcomp/clambda.cmi
-asmcomp/closure_offsets.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi utils/misc.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/base_types/closure_id.cmi \
-    asmcomp/closure_offsets.cmi
-asmcomp/closure_offsets.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx utils/misc.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/base_types/closure_id.cmx \
-    asmcomp/closure_offsets.cmi
-asmcomp/closure_offsets.cmi : middle_end/base_types/var_within_closure.cmi \
-    middle_end/flambda.cmi middle_end/base_types/closure_id.cmi
-asmcomp/cmm.cmo : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/debuginfo.cmi parsing/asttypes.cmi asmcomp/arch.cmo \
-    asmcomp/cmm.cmi
-asmcomp/cmm.cmx : bytecomp/lambda.cmx typing/ident.cmx \
-    middle_end/debuginfo.cmx parsing/asttypes.cmi asmcomp/arch.cmx \
-    asmcomp/cmm.cmi
-asmcomp/cmm.cmi : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/debuginfo.cmi parsing/asttypes.cmi
-asmcomp/cmmgen.cmo : asmcomp/un_anf.cmi typing/types.cmi bytecomp/switch.cmi \
-    asmcomp/strmatch.cmi asmcomp/proc.cmi bytecomp/printlambda.cmi \
-    typing/primitive.cmi utils/misc.cmi bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/debuginfo.cmi utils/config.cmi asmcomp/compilenv.cmi \
-    asmcomp/cmx_format.cmi asmcomp/cmm.cmi utils/clflags.cmi \
-    asmcomp/clambda.cmi parsing/asttypes.cmi asmcomp/arch.cmo \
-    asmcomp/afl_instrument.cmi asmcomp/cmmgen.cmi
-asmcomp/cmmgen.cmx : asmcomp/un_anf.cmx typing/types.cmx bytecomp/switch.cmx \
-    asmcomp/strmatch.cmx asmcomp/proc.cmx bytecomp/printlambda.cmx \
-    typing/primitive.cmx utils/misc.cmx bytecomp/lambda.cmx typing/ident.cmx \
-    middle_end/debuginfo.cmx utils/config.cmx asmcomp/compilenv.cmx \
-    asmcomp/cmx_format.cmi asmcomp/cmm.cmx utils/clflags.cmx \
-    asmcomp/clambda.cmx parsing/asttypes.cmi asmcomp/arch.cmx \
-    asmcomp/afl_instrument.cmx asmcomp/cmmgen.cmi
-asmcomp/cmmgen.cmi : asmcomp/cmx_format.cmi asmcomp/cmm.cmi \
-    asmcomp/clambda.cmi
-asmcomp/cmx_format.cmi : asmcomp/export_info.cmi asmcomp/clambda.cmi
-asmcomp/coloring.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/coloring.cmi
-asmcomp/coloring.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/coloring.cmi
+asmcomp/asmlink.cmo : \
+  asmcomp/asmgen.cmi \
+  asmcomp/asmlink.cmi \
+  asmcomp/cmmgen.cmi \
+  asmcomp/cmx_format.cmi \
+  asmcomp/compilenv.cmi \
+  asmcomp/emit.cmi \
+  asmcomp/emitaux.cmi \
+  bytecomp/runtimedef.cmi \
+  parsing/location.cmi \
+  utils/ccomp.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/consistbl.cmi \
+  utils/misc.cmi \
+  utils/profile.cmi
+asmcomp/asmlink.cmx : \
+  asmcomp/asmgen.cmx \
+  asmcomp/asmlink.cmi \
+  asmcomp/cmmgen.cmx \
+  asmcomp/cmx_format.cmi \
+  asmcomp/compilenv.cmx \
+  asmcomp/emit.cmx \
+  asmcomp/emitaux.cmx \
+  bytecomp/runtimedef.cmx \
+  parsing/location.cmx \
+  utils/ccomp.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/consistbl.cmx \
+  utils/misc.cmx \
+  utils/profile.cmx
+asmcomp/asmlink.cmi : \
+  asmcomp/cmx_format.cmi
+asmcomp/asmpackager.cmo : \
+  asmcomp/asmgen.cmi \
+  asmcomp/asmlink.cmi \
+  asmcomp/asmpackager.cmi \
+  asmcomp/cmx_format.cmi \
+  asmcomp/compilenv.cmi \
+  asmcomp/export_info.cmi \
+  asmcomp/export_info_for_pack.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/translmod.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/middle_end.cmi \
+  parsing/location.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/typemod.cmi \
+  utils/ccomp.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/profile.cmi
+asmcomp/asmpackager.cmx : \
+  asmcomp/asmgen.cmx \
+  asmcomp/asmlink.cmx \
+  asmcomp/asmpackager.cmi \
+  asmcomp/cmx_format.cmi \
+  asmcomp/compilenv.cmx \
+  asmcomp/export_info.cmx \
+  asmcomp/export_info_for_pack.cmx \
+  bytecomp/lambda.cmx \
+  bytecomp/translmod.cmx \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/middle_end.cmx \
+  parsing/location.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/typemod.cmx \
+  utils/ccomp.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/profile.cmx
+asmcomp/asmpackager.cmi : \
+  middle_end/backend_intf.cmi \
+  typing/env.cmi
+asmcomp/branch_relaxation.cmo : \
+  asmcomp/branch_relaxation.cmi \
+  asmcomp/branch_relaxation_intf.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/linearize.cmi \
+  asmcomp/mach.cmi \
+  utils/misc.cmi
+asmcomp/branch_relaxation.cmx : \
+  asmcomp/branch_relaxation.cmi \
+  asmcomp/branch_relaxation_intf.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/linearize.cmx \
+  asmcomp/mach.cmx \
+  utils/misc.cmx
+asmcomp/branch_relaxation.cmi : \
+  asmcomp/branch_relaxation_intf.cmo \
+  asmcomp/linearize.cmi
+asmcomp/branch_relaxation_intf.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/linearize.cmi
+asmcomp/branch_relaxation_intf.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/linearize.cmx
+asmcomp/build_export_info.cmo : \
+  asmcomp/build_export_info.cmi \
+  asmcomp/compilenv.cmi \
+  asmcomp/export_info.cmi \
+  middle_end/allocated_const.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/export_id.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/invariant_params.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+asmcomp/build_export_info.cmx : \
+  asmcomp/build_export_info.cmi \
+  asmcomp/compilenv.cmx \
+  asmcomp/export_info.cmx \
+  middle_end/allocated_const.cmx \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/export_id.cmx \
+  middle_end/base_types/set_of_closures_id.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/tag.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/invariant_params.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx
+asmcomp/build_export_info.cmi : \
+  asmcomp/export_info.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/flambda.cmi
+asmcomp/clambda.cmo : \
+  asmcomp/clambda.cmi \
+  bytecomp/lambda.cmi \
+  middle_end/debuginfo.cmi \
+  parsing/asttypes.cmi \
+  typing/ident.cmi
+asmcomp/clambda.cmx : \
+  asmcomp/clambda.cmi \
+  bytecomp/lambda.cmx \
+  middle_end/debuginfo.cmx \
+  parsing/asttypes.cmi \
+  typing/ident.cmx
+asmcomp/clambda.cmi : \
+  bytecomp/lambda.cmi \
+  middle_end/debuginfo.cmi \
+  parsing/asttypes.cmi \
+  typing/ident.cmi
+asmcomp/closure.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/clambda.cmi \
+  asmcomp/closure.cmi \
+  asmcomp/compilenv.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/semantics_of_primitives.cmi \
+  bytecomp/simplif.cmi \
+  bytecomp/switch.cmi \
+  middle_end/debuginfo.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/primitive.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/tbl.cmi \
+  utils/warnings.cmi
+asmcomp/closure.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/clambda.cmx \
+  asmcomp/closure.cmi \
+  asmcomp/compilenv.cmx \
+  bytecomp/lambda.cmx \
+  bytecomp/semantics_of_primitives.cmx \
+  bytecomp/simplif.cmx \
+  bytecomp/switch.cmx \
+  middle_end/debuginfo.cmx \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/primitive.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/tbl.cmx \
+  utils/warnings.cmx
+asmcomp/closure.cmi : \
+  asmcomp/clambda.cmi \
+  bytecomp/lambda.cmi
+asmcomp/closure_offsets.cmo : \
+  asmcomp/closure_offsets.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/flambda_utils.cmi \
+  utils/misc.cmi
+asmcomp/closure_offsets.cmx : \
+  asmcomp/closure_offsets.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/flambda_utils.cmx \
+  utils/misc.cmx
+asmcomp/closure_offsets.cmi : \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/flambda.cmi
+asmcomp/cmm.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  bytecomp/lambda.cmi \
+  middle_end/debuginfo.cmi \
+  parsing/asttypes.cmi \
+  typing/ident.cmi
+asmcomp/cmm.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmi \
+  bytecomp/lambda.cmx \
+  middle_end/debuginfo.cmx \
+  parsing/asttypes.cmi \
+  typing/ident.cmx
+asmcomp/cmm.cmi : \
+  bytecomp/lambda.cmi \
+  middle_end/debuginfo.cmi \
+  parsing/asttypes.cmi \
+  typing/ident.cmi
+asmcomp/cmmgen.cmo : \
+  asmcomp/afl_instrument.cmi \
+  asmcomp/arch.cmo \
+  asmcomp/clambda.cmi \
+  asmcomp/cmm.cmi \
+  asmcomp/cmmgen.cmi \
+  asmcomp/cmx_format.cmi \
+  asmcomp/compilenv.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/strmatch.cmi \
+  asmcomp/un_anf.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/printlambda.cmi \
+  bytecomp/switch.cmi \
+  middle_end/debuginfo.cmi \
+  parsing/asttypes.cmi \
+  typing/ident.cmi \
+  typing/primitive.cmi \
+  typing/types.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+asmcomp/cmmgen.cmx : \
+  asmcomp/afl_instrument.cmx \
+  asmcomp/arch.cmx \
+  asmcomp/clambda.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/cmmgen.cmi \
+  asmcomp/cmx_format.cmi \
+  asmcomp/compilenv.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/strmatch.cmx \
+  asmcomp/un_anf.cmx \
+  bytecomp/lambda.cmx \
+  bytecomp/printlambda.cmx \
+  bytecomp/switch.cmx \
+  middle_end/debuginfo.cmx \
+  parsing/asttypes.cmi \
+  typing/ident.cmx \
+  typing/primitive.cmx \
+  typing/types.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+asmcomp/cmmgen.cmi : \
+  asmcomp/clambda.cmi \
+  asmcomp/cmm.cmi \
+  asmcomp/cmx_format.cmi
+asmcomp/cmx_format.cmi : \
+  asmcomp/clambda.cmi \
+  asmcomp/export_info.cmi
+asmcomp/coloring.cmo : \
+  asmcomp/coloring.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi
+asmcomp/coloring.cmx : \
+  asmcomp/coloring.cmi \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx
 asmcomp/coloring.cmi :
-asmcomp/comballoc.cmo : asmcomp/reg.cmi asmcomp/mach.cmi utils/config.cmi \
-    asmcomp/arch.cmo asmcomp/comballoc.cmi
-asmcomp/comballoc.cmx : asmcomp/reg.cmx asmcomp/mach.cmx utils/config.cmx \
-    asmcomp/arch.cmx asmcomp/comballoc.cmi
-asmcomp/comballoc.cmi : asmcomp/mach.cmi
-asmcomp/compilenv.cmo : utils/warnings.cmi middle_end/base_types/symbol.cmi \
-    middle_end/base_types/set_of_closures_id.cmi utils/misc.cmi \
-    parsing/location.cmi middle_end/base_types/linkage_name.cmi \
-    typing/ident.cmi middle_end/flambda.cmi asmcomp/export_info.cmi \
-    typing/env.cmi utils/config.cmi \
-    middle_end/base_types/compilation_unit.cmi asmcomp/cmx_format.cmi \
-    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
-    asmcomp/clambda.cmi asmcomp/compilenv.cmi
-asmcomp/compilenv.cmx : utils/warnings.cmx middle_end/base_types/symbol.cmx \
-    middle_end/base_types/set_of_closures_id.cmx utils/misc.cmx \
-    parsing/location.cmx middle_end/base_types/linkage_name.cmx \
-    typing/ident.cmx middle_end/flambda.cmx asmcomp/export_info.cmx \
-    typing/env.cmx utils/config.cmx \
-    middle_end/base_types/compilation_unit.cmx asmcomp/cmx_format.cmi \
-    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
-    asmcomp/clambda.cmx asmcomp/compilenv.cmi
-asmcomp/compilenv.cmi : middle_end/base_types/symbol.cmi \
-    middle_end/base_types/set_of_closures_id.cmi \
-    middle_end/base_types/linkage_name.cmi typing/ident.cmi \
-    middle_end/flambda.cmi asmcomp/export_info.cmi \
-    middle_end/base_types/compilation_unit.cmi asmcomp/cmx_format.cmi \
-    middle_end/base_types/closure_id.cmi asmcomp/clambda.cmi
-asmcomp/deadcode.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/mach.cmi \
-    utils/config.cmi asmcomp/deadcode.cmi
-asmcomp/deadcode.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/mach.cmx \
-    utils/config.cmx asmcomp/deadcode.cmi
-asmcomp/deadcode.cmi : asmcomp/mach.cmi
-asmcomp/emit.cmo : asmcomp/x86_proc.cmi asmcomp/x86_masm.cmi \
-    asmcomp/x86_gas.cmi asmcomp/x86_dsl.cmi asmcomp/x86_ast.cmi \
-    asmcomp/reg.cmi asmcomp/proc.cmi utils/misc.cmi asmcomp/mach.cmi \
-    asmcomp/linearize.cmi asmcomp/emitaux.cmi middle_end/debuginfo.cmi \
-    utils/config.cmi asmcomp/compilenv.cmi asmcomp/cmm.cmi utils/clflags.cmi \
-    asmcomp/branch_relaxation.cmi asmcomp/arch.cmo asmcomp/emit.cmi
-asmcomp/emit.cmx : asmcomp/x86_proc.cmx asmcomp/x86_masm.cmx \
-    asmcomp/x86_gas.cmx asmcomp/x86_dsl.cmx asmcomp/x86_ast.cmi \
-    asmcomp/reg.cmx asmcomp/proc.cmx utils/misc.cmx asmcomp/mach.cmx \
-    asmcomp/linearize.cmx asmcomp/emitaux.cmx middle_end/debuginfo.cmx \
-    utils/config.cmx asmcomp/compilenv.cmx asmcomp/cmm.cmx utils/clflags.cmx \
-    asmcomp/branch_relaxation.cmx asmcomp/arch.cmx asmcomp/emit.cmi
-asmcomp/emit.cmi : asmcomp/linearize.cmi asmcomp/cmm.cmi
-asmcomp/emitaux.cmo : middle_end/debuginfo.cmi utils/config.cmi \
-    asmcomp/cmm.cmi utils/clflags.cmi asmcomp/arch.cmo asmcomp/emitaux.cmi
-asmcomp/emitaux.cmx : middle_end/debuginfo.cmx utils/config.cmx \
-    asmcomp/cmm.cmx utils/clflags.cmx asmcomp/arch.cmx asmcomp/emitaux.cmi
-asmcomp/emitaux.cmi : middle_end/debuginfo.cmi
-asmcomp/export_info.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    middle_end/simple_value_approx.cmi \
-    middle_end/base_types/set_of_closures_id.cmi middle_end/flambda.cmi \
-    middle_end/base_types/export_id.cmi \
-    middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi asmcomp/export_info.cmi
-asmcomp/export_info.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
-    middle_end/simple_value_approx.cmx \
-    middle_end/base_types/set_of_closures_id.cmx middle_end/flambda.cmx \
-    middle_end/base_types/export_id.cmx \
-    middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx asmcomp/export_info.cmi
-asmcomp/export_info.cmi : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    middle_end/simple_value_approx.cmi \
-    middle_end/base_types/set_of_closures_id.cmi middle_end/flambda.cmi \
-    middle_end/base_types/export_id.cmi \
-    middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi
-asmcomp/export_info_for_pack.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/symbol.cmi \
-    middle_end/base_types/set_of_closures_origin.cmi \
-    middle_end/base_types/set_of_closures_id.cmi utils/misc.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi asmcomp/export_info.cmi \
-    middle_end/base_types/export_id.cmi \
-    middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi asmcomp/export_info_for_pack.cmi
-asmcomp/export_info_for_pack.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/symbol.cmx \
-    middle_end/base_types/set_of_closures_origin.cmx \
-    middle_end/base_types/set_of_closures_id.cmx utils/misc.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx asmcomp/export_info.cmx \
-    middle_end/base_types/export_id.cmx \
-    middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx asmcomp/export_info_for_pack.cmi
-asmcomp/export_info_for_pack.cmi : asmcomp/export_info.cmi \
-    middle_end/base_types/compilation_unit.cmi
-asmcomp/flambda_to_clambda.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi \
-    middle_end/base_types/set_of_closures_id.cmi typing/primitive.cmi \
-    middle_end/parameter.cmi utils/numbers.cmi \
-    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    middle_end/base_types/linkage_name.cmi typing/ident.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda.cmi \
-    asmcomp/export_info.cmi middle_end/debuginfo.cmi asmcomp/compilenv.cmi \
-    asmcomp/closure_offsets.cmi middle_end/base_types/closure_id.cmi \
-    utils/clflags.cmi asmcomp/clambda.cmi middle_end/allocated_const.cmi \
-    asmcomp/flambda_to_clambda.cmi
-asmcomp/flambda_to_clambda.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
-    middle_end/base_types/static_exception.cmx \
-    middle_end/base_types/set_of_closures_id.cmx typing/primitive.cmx \
-    middle_end/parameter.cmx utils/numbers.cmx \
-    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    middle_end/base_types/linkage_name.cmx typing/ident.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda.cmx \
-    asmcomp/export_info.cmx middle_end/debuginfo.cmx asmcomp/compilenv.cmx \
-    asmcomp/closure_offsets.cmx middle_end/base_types/closure_id.cmx \
-    utils/clflags.cmx asmcomp/clambda.cmx middle_end/allocated_const.cmx \
-    asmcomp/flambda_to_clambda.cmi
-asmcomp/flambda_to_clambda.cmi : middle_end/base_types/symbol.cmi \
-    middle_end/flambda.cmi asmcomp/export_info.cmi asmcomp/clambda.cmi
-asmcomp/import_approx.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/symbol.cmi middle_end/simple_value_approx.cmi \
-    middle_end/base_types/set_of_closures_id.cmi utils/misc.cmi \
-    middle_end/freshening.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi asmcomp/export_info.cmi \
-    middle_end/base_types/export_id.cmi asmcomp/compilenv.cmi \
-    middle_end/base_types/closure_id.cmi asmcomp/import_approx.cmi
-asmcomp/import_approx.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/symbol.cmx middle_end/simple_value_approx.cmx \
-    middle_end/base_types/set_of_closures_id.cmx utils/misc.cmx \
-    middle_end/freshening.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx asmcomp/export_info.cmx \
-    middle_end/base_types/export_id.cmx asmcomp/compilenv.cmx \
-    middle_end/base_types/closure_id.cmx asmcomp/import_approx.cmi
-asmcomp/import_approx.cmi : middle_end/base_types/symbol.cmi \
-    middle_end/simple_value_approx.cmi
-asmcomp/interf.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/mach.cmi \
-    asmcomp/cmm.cmi asmcomp/interf.cmi
-asmcomp/interf.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/mach.cmx \
-    asmcomp/cmm.cmx asmcomp/interf.cmi
-asmcomp/interf.cmi : asmcomp/mach.cmi
-asmcomp/interval.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/mach.cmi \
-    asmcomp/interval.cmi
-asmcomp/interval.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/mach.cmx \
-    asmcomp/interval.cmi
-asmcomp/interval.cmi : asmcomp/reg.cmi asmcomp/mach.cmi
-asmcomp/linearize.cmo : asmcomp/reg.cmi asmcomp/proc.cmi utils/misc.cmi \
-    asmcomp/mach.cmi middle_end/debuginfo.cmi utils/config.cmi \
-    asmcomp/cmm.cmi asmcomp/linearize.cmi
-asmcomp/linearize.cmx : asmcomp/reg.cmx asmcomp/proc.cmx utils/misc.cmx \
-    asmcomp/mach.cmx middle_end/debuginfo.cmx utils/config.cmx \
-    asmcomp/cmm.cmx asmcomp/linearize.cmi
-asmcomp/linearize.cmi : asmcomp/reg.cmi asmcomp/mach.cmi \
-    middle_end/debuginfo.cmi asmcomp/cmm.cmi
-asmcomp/linscan.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/interval.cmi \
-    asmcomp/linscan.cmi
-asmcomp/linscan.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/interval.cmx \
-    asmcomp/linscan.cmi
+asmcomp/comballoc.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/comballoc.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  utils/config.cmi
+asmcomp/comballoc.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/comballoc.cmi \
+  asmcomp/mach.cmx \
+  asmcomp/reg.cmx \
+  utils/config.cmx
+asmcomp/comballoc.cmi : \
+  asmcomp/mach.cmi
+asmcomp/compilenv.cmo : \
+  asmcomp/clambda.cmi \
+  asmcomp/cmx_format.cmi \
+  asmcomp/compilenv.cmi \
+  asmcomp/export_info.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/linkage_name.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/flambda.cmi \
+  parsing/location.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+asmcomp/compilenv.cmx : \
+  asmcomp/clambda.cmx \
+  asmcomp/cmx_format.cmi \
+  asmcomp/compilenv.cmi \
+  asmcomp/export_info.cmx \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/linkage_name.cmx \
+  middle_end/base_types/set_of_closures_id.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/flambda.cmx \
+  parsing/location.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+asmcomp/compilenv.cmi : \
+  asmcomp/clambda.cmi \
+  asmcomp/cmx_format.cmi \
+  asmcomp/export_info.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/linkage_name.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/flambda.cmi \
+  typing/ident.cmi
+asmcomp/deadcode.cmo : \
+  asmcomp/deadcode.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi \
+  utils/config.cmi
+asmcomp/deadcode.cmx : \
+  asmcomp/deadcode.cmi \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx \
+  utils/config.cmx
+asmcomp/deadcode.cmi : \
+  asmcomp/mach.cmi
+asmcomp/emit.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/branch_relaxation.cmi \
+  asmcomp/cmm.cmi \
+  asmcomp/compilenv.cmi \
+  asmcomp/emit.cmi \
+  asmcomp/emitaux.cmi \
+  asmcomp/linearize.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi \
+  asmcomp/x86_ast.cmi \
+  asmcomp/x86_dsl.cmi \
+  asmcomp/x86_gas.cmi \
+  asmcomp/x86_masm.cmi \
+  asmcomp/x86_proc.cmi \
+  middle_end/debuginfo.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+asmcomp/emit.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/branch_relaxation.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/compilenv.cmx \
+  asmcomp/emit.cmi \
+  asmcomp/emitaux.cmx \
+  asmcomp/linearize.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx \
+  asmcomp/x86_ast.cmi \
+  asmcomp/x86_dsl.cmx \
+  asmcomp/x86_gas.cmx \
+  asmcomp/x86_masm.cmx \
+  asmcomp/x86_proc.cmx \
+  middle_end/debuginfo.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+asmcomp/emit.cmi : \
+  asmcomp/cmm.cmi \
+  asmcomp/linearize.cmi
+asmcomp/emitaux.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/emitaux.cmi \
+  middle_end/debuginfo.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi
+asmcomp/emitaux.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/emitaux.cmi \
+  middle_end/debuginfo.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx
+asmcomp/emitaux.cmi : \
+  middle_end/debuginfo.cmi
+asmcomp/export_info.cmo : \
+  asmcomp/export_info.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/export_id.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/simple_value_approx.cmi
+asmcomp/export_info.cmx : \
+  asmcomp/export_info.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/export_id.cmx \
+  middle_end/base_types/set_of_closures_id.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/tag.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/simple_value_approx.cmx
+asmcomp/export_info.cmi : \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/export_id.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/simple_value_approx.cmi
+asmcomp/export_info_for_pack.cmo : \
+  asmcomp/export_info.cmi \
+  asmcomp/export_info_for_pack.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/export_id.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/set_of_closures_origin.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/flambda_utils.cmi \
+  utils/misc.cmi
+asmcomp/export_info_for_pack.cmx : \
+  asmcomp/export_info.cmx \
+  asmcomp/export_info_for_pack.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/export_id.cmx \
+  middle_end/base_types/set_of_closures_id.cmx \
+  middle_end/base_types/set_of_closures_origin.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/flambda_utils.cmx \
+  utils/misc.cmx
+asmcomp/export_info_for_pack.cmi : \
+  asmcomp/export_info.cmi \
+  middle_end/base_types/compilation_unit.cmi
+asmcomp/flambda_to_clambda.cmo : \
+  asmcomp/clambda.cmi \
+  asmcomp/closure_offsets.cmi \
+  asmcomp/compilenv.cmi \
+  asmcomp/export_info.cmi \
+  asmcomp/flambda_to_clambda.cmi \
+  middle_end/allocated_const.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/linkage_name.cmi \
+  middle_end/base_types/mutable_variable.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/static_exception.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/parameter.cmi \
+  typing/ident.cmi \
+  typing/primitive.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi \
+  utils/numbers.cmi
+asmcomp/flambda_to_clambda.cmx : \
+  asmcomp/clambda.cmx \
+  asmcomp/closure_offsets.cmx \
+  asmcomp/compilenv.cmx \
+  asmcomp/export_info.cmx \
+  asmcomp/flambda_to_clambda.cmi \
+  middle_end/allocated_const.cmx \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/linkage_name.cmx \
+  middle_end/base_types/mutable_variable.cmx \
+  middle_end/base_types/set_of_closures_id.cmx \
+  middle_end/base_types/static_exception.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/tag.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/debuginfo.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/parameter.cmx \
+  typing/ident.cmx \
+  typing/primitive.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx \
+  utils/numbers.cmx
+asmcomp/flambda_to_clambda.cmi : \
+  asmcomp/clambda.cmi \
+  asmcomp/export_info.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/flambda.cmi
+asmcomp/import_approx.cmo : \
+  asmcomp/compilenv.cmi \
+  asmcomp/export_info.cmi \
+  asmcomp/import_approx.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/export_id.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/freshening.cmi \
+  middle_end/simple_value_approx.cmi \
+  utils/misc.cmi
+asmcomp/import_approx.cmx : \
+  asmcomp/compilenv.cmx \
+  asmcomp/export_info.cmx \
+  asmcomp/import_approx.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/export_id.cmx \
+  middle_end/base_types/set_of_closures_id.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/freshening.cmx \
+  middle_end/simple_value_approx.cmx \
+  utils/misc.cmx
+asmcomp/import_approx.cmi : \
+  middle_end/base_types/symbol.cmi \
+  middle_end/simple_value_approx.cmi
+asmcomp/interf.cmo : \
+  asmcomp/cmm.cmi \
+  asmcomp/interf.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi
+asmcomp/interf.cmx : \
+  asmcomp/cmm.cmx \
+  asmcomp/interf.cmi \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx
+asmcomp/interf.cmi : \
+  asmcomp/mach.cmi
+asmcomp/interval.cmo : \
+  asmcomp/interval.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi
+asmcomp/interval.cmx : \
+  asmcomp/interval.cmi \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx
+asmcomp/interval.cmi : \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi
+asmcomp/linearize.cmo : \
+  asmcomp/cmm.cmi \
+  asmcomp/linearize.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi \
+  middle_end/debuginfo.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+asmcomp/linearize.cmx : \
+  asmcomp/cmm.cmx \
+  asmcomp/linearize.cmi \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx \
+  middle_end/debuginfo.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+asmcomp/linearize.cmi : \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  middle_end/debuginfo.cmi
+asmcomp/linscan.cmo : \
+  asmcomp/interval.cmi \
+  asmcomp/linscan.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi
+asmcomp/linscan.cmx : \
+  asmcomp/interval.cmx \
+  asmcomp/linscan.cmi \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx
 asmcomp/linscan.cmi :
-asmcomp/liveness.cmo : asmcomp/reg.cmi asmcomp/proc.cmi \
-    asmcomp/printmach.cmi utils/misc.cmi asmcomp/mach.cmi utils/config.cmi \
-    asmcomp/cmm.cmi asmcomp/liveness.cmi
-asmcomp/liveness.cmx : asmcomp/reg.cmx asmcomp/proc.cmx \
-    asmcomp/printmach.cmx utils/misc.cmx asmcomp/mach.cmx utils/config.cmx \
-    asmcomp/cmm.cmx asmcomp/liveness.cmi
-asmcomp/liveness.cmi : asmcomp/mach.cmi
-asmcomp/mach.cmo : asmcomp/debug/reg_with_debug_info.cmi \
-    asmcomp/debug/reg_availability_set.cmi asmcomp/reg.cmi typing/ident.cmi \
-    middle_end/debuginfo.cmi asmcomp/cmm.cmi asmcomp/arch.cmo \
-    asmcomp/mach.cmi
-asmcomp/mach.cmx : asmcomp/debug/reg_with_debug_info.cmx \
-    asmcomp/debug/reg_availability_set.cmx asmcomp/reg.cmx typing/ident.cmx \
-    middle_end/debuginfo.cmx asmcomp/cmm.cmx asmcomp/arch.cmx \
-    asmcomp/mach.cmi
-asmcomp/mach.cmi : asmcomp/debug/reg_availability_set.cmi asmcomp/reg.cmi \
-    typing/ident.cmi middle_end/debuginfo.cmi asmcomp/cmm.cmi \
-    asmcomp/arch.cmo
-asmcomp/printclambda.cmo : bytecomp/printlambda.cmi bytecomp/lambda.cmi \
-    typing/ident.cmi asmcomp/clambda.cmi parsing/asttypes.cmi \
-    asmcomp/printclambda.cmi
-asmcomp/printclambda.cmx : bytecomp/printlambda.cmx bytecomp/lambda.cmx \
-    typing/ident.cmx asmcomp/clambda.cmx parsing/asttypes.cmi \
-    asmcomp/printclambda.cmi
-asmcomp/printclambda.cmi : asmcomp/clambda.cmi
-asmcomp/printcmm.cmo : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/debuginfo.cmi asmcomp/cmm.cmi parsing/asttypes.cmi \
-    asmcomp/printcmm.cmi
-asmcomp/printcmm.cmx : bytecomp/lambda.cmx typing/ident.cmx \
-    middle_end/debuginfo.cmx asmcomp/cmm.cmx parsing/asttypes.cmi \
-    asmcomp/printcmm.cmi
-asmcomp/printcmm.cmi : middle_end/debuginfo.cmi asmcomp/cmm.cmi
-asmcomp/printlinear.cmo : asmcomp/printmach.cmi asmcomp/printcmm.cmi \
-    asmcomp/mach.cmi asmcomp/linearize.cmi middle_end/debuginfo.cmi \
-    asmcomp/printlinear.cmi
-asmcomp/printlinear.cmx : asmcomp/printmach.cmx asmcomp/printcmm.cmx \
-    asmcomp/mach.cmx asmcomp/linearize.cmx middle_end/debuginfo.cmx \
-    asmcomp/printlinear.cmi
-asmcomp/printlinear.cmi : asmcomp/linearize.cmi
-asmcomp/printmach.cmo : asmcomp/debug/reg_availability_set.cmi \
-    asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/printcmm.cmi asmcomp/mach.cmi \
-    asmcomp/interval.cmi typing/ident.cmi middle_end/debuginfo.cmi \
-    utils/config.cmi asmcomp/cmm.cmi utils/clflags.cmi asmcomp/arch.cmo \
-    asmcomp/printmach.cmi
-asmcomp/printmach.cmx : asmcomp/debug/reg_availability_set.cmx \
-    asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/printcmm.cmx asmcomp/mach.cmx \
-    asmcomp/interval.cmx typing/ident.cmx middle_end/debuginfo.cmx \
-    utils/config.cmx asmcomp/cmm.cmx utils/clflags.cmx asmcomp/arch.cmx \
-    asmcomp/printmach.cmi
-asmcomp/printmach.cmi : asmcomp/reg.cmi asmcomp/mach.cmi
-asmcomp/proc.cmo : asmcomp/x86_proc.cmi asmcomp/reg.cmi utils/misc.cmi \
-    asmcomp/mach.cmi utils/config.cmi asmcomp/cmm.cmi asmcomp/arch.cmo \
-    asmcomp/proc.cmi
-asmcomp/proc.cmx : asmcomp/x86_proc.cmx asmcomp/reg.cmx utils/misc.cmx \
-    asmcomp/mach.cmx utils/config.cmx asmcomp/cmm.cmx asmcomp/arch.cmx \
-    asmcomp/proc.cmi
-asmcomp/proc.cmi : asmcomp/reg.cmi asmcomp/mach.cmi
-asmcomp/reg.cmo : typing/ident.cmi asmcomp/cmm.cmi asmcomp/reg.cmi
-asmcomp/reg.cmx : typing/ident.cmx asmcomp/cmm.cmx asmcomp/reg.cmi
-asmcomp/reg.cmi : typing/ident.cmi asmcomp/cmm.cmi
-asmcomp/reload.cmo : asmcomp/reloadgen.cmi asmcomp/reg.cmi asmcomp/mach.cmi \
-    asmcomp/cmm.cmi utils/clflags.cmi asmcomp/arch.cmo asmcomp/reload.cmi
-asmcomp/reload.cmx : asmcomp/reloadgen.cmx asmcomp/reg.cmx asmcomp/mach.cmx \
-    asmcomp/cmm.cmx utils/clflags.cmx asmcomp/arch.cmx asmcomp/reload.cmi
-asmcomp/reload.cmi : asmcomp/mach.cmi
-asmcomp/reloadgen.cmo : asmcomp/reg.cmi utils/misc.cmi asmcomp/mach.cmi \
-    asmcomp/reloadgen.cmi
-asmcomp/reloadgen.cmx : asmcomp/reg.cmx utils/misc.cmx asmcomp/mach.cmx \
-    asmcomp/reloadgen.cmi
-asmcomp/reloadgen.cmi : asmcomp/reg.cmi asmcomp/mach.cmi
-asmcomp/schedgen.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/mach.cmi \
-    asmcomp/linearize.cmi asmcomp/cmm.cmi asmcomp/arch.cmo \
-    asmcomp/schedgen.cmi
-asmcomp/schedgen.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/mach.cmx \
-    asmcomp/linearize.cmx asmcomp/cmm.cmx asmcomp/arch.cmx \
-    asmcomp/schedgen.cmi
-asmcomp/schedgen.cmi : asmcomp/mach.cmi asmcomp/linearize.cmi
-asmcomp/scheduling.cmo : asmcomp/schedgen.cmi asmcomp/scheduling.cmi
-asmcomp/scheduling.cmx : asmcomp/schedgen.cmx asmcomp/scheduling.cmi
-asmcomp/scheduling.cmi : asmcomp/linearize.cmi
-asmcomp/selectgen.cmo : utils/tbl.cmi bytecomp/simplif.cmi asmcomp/reg.cmi \
-    asmcomp/proc.cmi utils/misc.cmi asmcomp/mach.cmi bytecomp/lambda.cmi \
-    typing/ident.cmi middle_end/debuginfo.cmi utils/config.cmi \
-    asmcomp/cmm.cmi parsing/asttypes.cmi asmcomp/arch.cmo \
-    asmcomp/selectgen.cmi
-asmcomp/selectgen.cmx : utils/tbl.cmx bytecomp/simplif.cmx asmcomp/reg.cmx \
-    asmcomp/proc.cmx utils/misc.cmx asmcomp/mach.cmx bytecomp/lambda.cmx \
-    typing/ident.cmx middle_end/debuginfo.cmx utils/config.cmx \
-    asmcomp/cmm.cmx parsing/asttypes.cmi asmcomp/arch.cmx \
-    asmcomp/selectgen.cmi
-asmcomp/selectgen.cmi : asmcomp/reg.cmi asmcomp/mach.cmi typing/ident.cmi \
-    middle_end/debuginfo.cmi asmcomp/cmm.cmi asmcomp/arch.cmo
-asmcomp/selection.cmo : asmcomp/spacetime_profiling.cmi \
-    asmcomp/selectgen.cmi asmcomp/proc.cmi asmcomp/mach.cmi utils/config.cmi \
-    asmcomp/cmm.cmi utils/clflags.cmi asmcomp/arch.cmo asmcomp/selection.cmi
-asmcomp/selection.cmx : asmcomp/spacetime_profiling.cmx \
-    asmcomp/selectgen.cmx asmcomp/proc.cmx asmcomp/mach.cmx utils/config.cmx \
-    asmcomp/cmm.cmx utils/clflags.cmx asmcomp/arch.cmx asmcomp/selection.cmi
-asmcomp/selection.cmi : asmcomp/mach.cmi asmcomp/cmm.cmi
-asmcomp/spacetime_profiling.cmo : asmcomp/selectgen.cmi asmcomp/proc.cmi \
-    utils/misc.cmi asmcomp/mach.cmi bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/debuginfo.cmi utils/config.cmi asmcomp/cmm.cmi \
-    parsing/asttypes.cmi asmcomp/arch.cmo asmcomp/spacetime_profiling.cmi
-asmcomp/spacetime_profiling.cmx : asmcomp/selectgen.cmx asmcomp/proc.cmx \
-    utils/misc.cmx asmcomp/mach.cmx bytecomp/lambda.cmx typing/ident.cmx \
-    middle_end/debuginfo.cmx utils/config.cmx asmcomp/cmm.cmx \
-    parsing/asttypes.cmi asmcomp/arch.cmx asmcomp/spacetime_profiling.cmi
-asmcomp/spacetime_profiling.cmi : asmcomp/selectgen.cmi
-asmcomp/spill.cmo : asmcomp/reg.cmi asmcomp/proc.cmi utils/misc.cmi \
-    asmcomp/mach.cmi asmcomp/cmm.cmi utils/clflags.cmi asmcomp/spill.cmi
-asmcomp/spill.cmx : asmcomp/reg.cmx asmcomp/proc.cmx utils/misc.cmx \
-    asmcomp/mach.cmx asmcomp/cmm.cmx utils/clflags.cmx asmcomp/spill.cmi
-asmcomp/spill.cmi : asmcomp/mach.cmi
-asmcomp/split.cmo : asmcomp/reg.cmi utils/misc.cmi asmcomp/mach.cmi \
-    asmcomp/split.cmi
-asmcomp/split.cmx : asmcomp/reg.cmx utils/misc.cmx asmcomp/mach.cmx \
-    asmcomp/split.cmi
-asmcomp/split.cmi : asmcomp/mach.cmi
-asmcomp/strmatch.cmo : parsing/location.cmi bytecomp/lambda.cmi \
-    typing/ident.cmi middle_end/debuginfo.cmi asmcomp/cmm.cmi \
-    parsing/asttypes.cmi asmcomp/arch.cmo asmcomp/strmatch.cmi
-asmcomp/strmatch.cmx : parsing/location.cmx bytecomp/lambda.cmx \
-    typing/ident.cmx middle_end/debuginfo.cmx asmcomp/cmm.cmx \
-    parsing/asttypes.cmi asmcomp/arch.cmx asmcomp/strmatch.cmi
-asmcomp/strmatch.cmi : parsing/location.cmi middle_end/debuginfo.cmi \
-    asmcomp/cmm.cmi
-asmcomp/un_anf.cmo : bytecomp/semantics_of_primitives.cmi \
-    asmcomp/printclambda.cmi utils/misc.cmi bytecomp/lambda.cmi \
-    typing/ident.cmi middle_end/debuginfo.cmi utils/clflags.cmi \
-    asmcomp/clambda.cmi parsing/asttypes.cmi asmcomp/un_anf.cmi
-asmcomp/un_anf.cmx : bytecomp/semantics_of_primitives.cmx \
-    asmcomp/printclambda.cmx utils/misc.cmx bytecomp/lambda.cmx \
-    typing/ident.cmx middle_end/debuginfo.cmx utils/clflags.cmx \
-    asmcomp/clambda.cmx parsing/asttypes.cmi asmcomp/un_anf.cmi
-asmcomp/un_anf.cmi : asmcomp/clambda.cmi
+asmcomp/liveness.cmo : \
+  asmcomp/cmm.cmi \
+  asmcomp/liveness.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/printmach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+asmcomp/liveness.cmx : \
+  asmcomp/cmm.cmx \
+  asmcomp/liveness.cmi \
+  asmcomp/mach.cmx \
+  asmcomp/printmach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+asmcomp/liveness.cmi : \
+  asmcomp/mach.cmi
+asmcomp/mach.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/debug/reg_availability_set.cmi \
+  asmcomp/debug/reg_with_debug_info.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  middle_end/debuginfo.cmi \
+  typing/ident.cmi
+asmcomp/mach.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/debug/reg_availability_set.cmx \
+  asmcomp/debug/reg_with_debug_info.cmx \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmx \
+  middle_end/debuginfo.cmx \
+  typing/ident.cmx
+asmcomp/mach.cmi : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/debug/reg_availability_set.cmi \
+  asmcomp/reg.cmi \
+  middle_end/debuginfo.cmi \
+  typing/ident.cmi
+asmcomp/printclambda.cmo : \
+  asmcomp/clambda.cmi \
+  asmcomp/printclambda.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/printlambda.cmi \
+  parsing/asttypes.cmi \
+  typing/ident.cmi
+asmcomp/printclambda.cmx : \
+  asmcomp/clambda.cmx \
+  asmcomp/printclambda.cmi \
+  bytecomp/lambda.cmx \
+  bytecomp/printlambda.cmx \
+  parsing/asttypes.cmi \
+  typing/ident.cmx
+asmcomp/printclambda.cmi : \
+  asmcomp/clambda.cmi
+asmcomp/printcmm.cmo : \
+  asmcomp/cmm.cmi \
+  asmcomp/printcmm.cmi \
+  bytecomp/lambda.cmi \
+  middle_end/debuginfo.cmi \
+  parsing/asttypes.cmi \
+  typing/ident.cmi
+asmcomp/printcmm.cmx : \
+  asmcomp/cmm.cmx \
+  asmcomp/printcmm.cmi \
+  bytecomp/lambda.cmx \
+  middle_end/debuginfo.cmx \
+  parsing/asttypes.cmi \
+  typing/ident.cmx
+asmcomp/printcmm.cmi : \
+  asmcomp/cmm.cmi \
+  middle_end/debuginfo.cmi
+asmcomp/printlinear.cmo : \
+  asmcomp/linearize.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/printcmm.cmi \
+  asmcomp/printlinear.cmi \
+  asmcomp/printmach.cmi \
+  middle_end/debuginfo.cmi
+asmcomp/printlinear.cmx : \
+  asmcomp/linearize.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/printcmm.cmx \
+  asmcomp/printlinear.cmi \
+  asmcomp/printmach.cmx \
+  middle_end/debuginfo.cmx
+asmcomp/printlinear.cmi : \
+  asmcomp/linearize.cmi
+asmcomp/printmach.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/debug/reg_availability_set.cmi \
+  asmcomp/interval.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/printcmm.cmi \
+  asmcomp/printmach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi \
+  middle_end/debuginfo.cmi \
+  typing/ident.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi
+asmcomp/printmach.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/debug/reg_availability_set.cmx \
+  asmcomp/interval.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/printcmm.cmx \
+  asmcomp/printmach.cmi \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx \
+  middle_end/debuginfo.cmx \
+  typing/ident.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx
+asmcomp/printmach.cmi : \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi
+asmcomp/proc.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi \
+  asmcomp/x86_proc.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+asmcomp/proc.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmx \
+  asmcomp/x86_proc.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+asmcomp/proc.cmi : \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi
+asmcomp/reg.cmo : \
+  asmcomp/cmm.cmi \
+  asmcomp/reg.cmi \
+  typing/ident.cmi
+asmcomp/reg.cmx : \
+  asmcomp/cmm.cmx \
+  asmcomp/reg.cmi \
+  typing/ident.cmx
+asmcomp/reg.cmi : \
+  asmcomp/cmm.cmi \
+  typing/ident.cmi
+asmcomp/reload.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  asmcomp/reload.cmi \
+  asmcomp/reloadgen.cmi \
+  utils/clflags.cmi
+asmcomp/reload.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/reg.cmx \
+  asmcomp/reload.cmi \
+  asmcomp/reloadgen.cmx \
+  utils/clflags.cmx
+asmcomp/reload.cmi : \
+  asmcomp/mach.cmi
+asmcomp/reloadgen.cmo : \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  asmcomp/reloadgen.cmi \
+  utils/misc.cmi
+asmcomp/reloadgen.cmx : \
+  asmcomp/mach.cmx \
+  asmcomp/reg.cmx \
+  asmcomp/reloadgen.cmi \
+  utils/misc.cmx
+asmcomp/reloadgen.cmi : \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi
+asmcomp/schedgen.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/linearize.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi \
+  asmcomp/schedgen.cmi
+asmcomp/schedgen.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/linearize.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx \
+  asmcomp/schedgen.cmi
+asmcomp/schedgen.cmi : \
+  asmcomp/linearize.cmi \
+  asmcomp/mach.cmi
+asmcomp/scheduling.cmo : \
+  asmcomp/schedgen.cmi \
+  asmcomp/scheduling.cmi
+asmcomp/scheduling.cmx : \
+  asmcomp/schedgen.cmx \
+  asmcomp/scheduling.cmi
+asmcomp/scheduling.cmi : \
+  asmcomp/linearize.cmi
+asmcomp/selectgen.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi \
+  asmcomp/selectgen.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/simplif.cmi \
+  middle_end/debuginfo.cmi \
+  parsing/asttypes.cmi \
+  typing/ident.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/tbl.cmi
+asmcomp/selectgen.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx \
+  asmcomp/selectgen.cmi \
+  bytecomp/lambda.cmx \
+  bytecomp/simplif.cmx \
+  middle_end/debuginfo.cmx \
+  parsing/asttypes.cmi \
+  typing/ident.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/tbl.cmx
+asmcomp/selectgen.cmi : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  middle_end/debuginfo.cmi \
+  typing/ident.cmi
+asmcomp/selection.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/selectgen.cmi \
+  asmcomp/selection.cmi \
+  asmcomp/spacetime_profiling.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi
+asmcomp/selection.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/selectgen.cmx \
+  asmcomp/selection.cmi \
+  asmcomp/spacetime_profiling.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx
+asmcomp/selection.cmi : \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi
+asmcomp/spacetime_profiling.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/selectgen.cmi \
+  asmcomp/spacetime_profiling.cmi \
+  bytecomp/lambda.cmi \
+  middle_end/debuginfo.cmi \
+  parsing/asttypes.cmi \
+  typing/ident.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+asmcomp/spacetime_profiling.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/selectgen.cmx \
+  asmcomp/spacetime_profiling.cmi \
+  bytecomp/lambda.cmx \
+  middle_end/debuginfo.cmx \
+  parsing/asttypes.cmi \
+  typing/ident.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+asmcomp/spacetime_profiling.cmi : \
+  asmcomp/selectgen.cmi
+asmcomp/spill.cmo : \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi \
+  asmcomp/spill.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+asmcomp/spill.cmx : \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx \
+  asmcomp/spill.cmi \
+  utils/clflags.cmx \
+  utils/misc.cmx
+asmcomp/spill.cmi : \
+  asmcomp/mach.cmi
+asmcomp/split.cmo : \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  asmcomp/split.cmi \
+  utils/misc.cmi
+asmcomp/split.cmx : \
+  asmcomp/mach.cmx \
+  asmcomp/reg.cmx \
+  asmcomp/split.cmi \
+  utils/misc.cmx
+asmcomp/split.cmi : \
+  asmcomp/mach.cmi
+asmcomp/strmatch.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/strmatch.cmi \
+  bytecomp/lambda.cmi \
+  middle_end/debuginfo.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  typing/ident.cmi
+asmcomp/strmatch.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/strmatch.cmi \
+  bytecomp/lambda.cmx \
+  middle_end/debuginfo.cmx \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  typing/ident.cmx
+asmcomp/strmatch.cmi : \
+  asmcomp/cmm.cmi \
+  middle_end/debuginfo.cmi \
+  parsing/location.cmi
+asmcomp/un_anf.cmo : \
+  asmcomp/clambda.cmi \
+  asmcomp/printclambda.cmi \
+  asmcomp/un_anf.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/semantics_of_primitives.cmi \
+  middle_end/debuginfo.cmi \
+  parsing/asttypes.cmi \
+  typing/ident.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+asmcomp/un_anf.cmx : \
+  asmcomp/clambda.cmx \
+  asmcomp/printclambda.cmx \
+  asmcomp/un_anf.cmi \
+  bytecomp/lambda.cmx \
+  bytecomp/semantics_of_primitives.cmx \
+  middle_end/debuginfo.cmx \
+  parsing/asttypes.cmi \
+  typing/ident.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx
+asmcomp/un_anf.cmi : \
+  asmcomp/clambda.cmi
 asmcomp/x86_ast.cmi :
-asmcomp/x86_dsl.cmo : asmcomp/x86_proc.cmi asmcomp/x86_ast.cmi \
-    asmcomp/x86_dsl.cmi
-asmcomp/x86_dsl.cmx : asmcomp/x86_proc.cmx asmcomp/x86_ast.cmi \
-    asmcomp/x86_dsl.cmi
-asmcomp/x86_dsl.cmi : asmcomp/x86_ast.cmi
-asmcomp/x86_gas.cmo : asmcomp/x86_proc.cmi asmcomp/x86_ast.cmi \
-    utils/misc.cmi asmcomp/x86_gas.cmi
-asmcomp/x86_gas.cmx : asmcomp/x86_proc.cmx asmcomp/x86_ast.cmi \
-    utils/misc.cmx asmcomp/x86_gas.cmi
-asmcomp/x86_gas.cmi : asmcomp/x86_ast.cmi
-asmcomp/x86_masm.cmo : asmcomp/x86_proc.cmi asmcomp/x86_ast.cmi \
-    asmcomp/x86_masm.cmi
-asmcomp/x86_masm.cmx : asmcomp/x86_proc.cmx asmcomp/x86_ast.cmi \
-    asmcomp/x86_masm.cmi
-asmcomp/x86_masm.cmi : asmcomp/x86_ast.cmi
-asmcomp/x86_proc.cmo : asmcomp/x86_ast.cmi utils/config.cmi \
-    utils/clflags.cmi utils/ccomp.cmi asmcomp/x86_proc.cmi
-asmcomp/x86_proc.cmx : asmcomp/x86_ast.cmi utils/config.cmx \
-    utils/clflags.cmx utils/ccomp.cmx asmcomp/x86_proc.cmi
-asmcomp/x86_proc.cmi : asmcomp/x86_ast.cmi
-middle_end/alias_analysis.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    utils/misc.cmi bytecomp/lambda.cmi middle_end/flambda.cmi \
-    parsing/asttypes.cmi middle_end/allocated_const.cmi \
-    middle_end/alias_analysis.cmi
-middle_end/alias_analysis.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
-    utils/misc.cmx bytecomp/lambda.cmx middle_end/flambda.cmx \
-    parsing/asttypes.cmi middle_end/allocated_const.cmx \
-    middle_end/alias_analysis.cmi
-middle_end/alias_analysis.cmi : middle_end/base_types/variable.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    bytecomp/lambda.cmi middle_end/flambda.cmi parsing/asttypes.cmi \
-    middle_end/allocated_const.cmi
-middle_end/allocated_const.cmo : middle_end/allocated_const.cmi
-middle_end/allocated_const.cmx : middle_end/allocated_const.cmi
+asmcomp/x86_dsl.cmo : \
+  asmcomp/x86_ast.cmi \
+  asmcomp/x86_dsl.cmi \
+  asmcomp/x86_proc.cmi
+asmcomp/x86_dsl.cmx : \
+  asmcomp/x86_ast.cmi \
+  asmcomp/x86_dsl.cmi \
+  asmcomp/x86_proc.cmx
+asmcomp/x86_dsl.cmi : \
+  asmcomp/x86_ast.cmi
+asmcomp/x86_gas.cmo : \
+  asmcomp/x86_ast.cmi \
+  asmcomp/x86_gas.cmi \
+  asmcomp/x86_proc.cmi \
+  utils/misc.cmi
+asmcomp/x86_gas.cmx : \
+  asmcomp/x86_ast.cmi \
+  asmcomp/x86_gas.cmi \
+  asmcomp/x86_proc.cmx \
+  utils/misc.cmx
+asmcomp/x86_gas.cmi : \
+  asmcomp/x86_ast.cmi
+asmcomp/x86_masm.cmo : \
+  asmcomp/x86_ast.cmi \
+  asmcomp/x86_masm.cmi \
+  asmcomp/x86_proc.cmi
+asmcomp/x86_masm.cmx : \
+  asmcomp/x86_ast.cmi \
+  asmcomp/x86_masm.cmi \
+  asmcomp/x86_proc.cmx
+asmcomp/x86_masm.cmi : \
+  asmcomp/x86_ast.cmi
+asmcomp/x86_proc.cmo : \
+  asmcomp/x86_ast.cmi \
+  asmcomp/x86_proc.cmi \
+  utils/ccomp.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi
+asmcomp/x86_proc.cmx : \
+  asmcomp/x86_ast.cmi \
+  asmcomp/x86_proc.cmi \
+  utils/ccomp.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx
+asmcomp/x86_proc.cmi : \
+  asmcomp/x86_ast.cmi
+middle_end/alias_analysis.cmo : \
+  bytecomp/lambda.cmi \
+  middle_end/alias_analysis.cmi \
+  middle_end/allocated_const.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  parsing/asttypes.cmi \
+  utils/misc.cmi
+middle_end/alias_analysis.cmx : \
+  bytecomp/lambda.cmx \
+  middle_end/alias_analysis.cmi \
+  middle_end/allocated_const.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/tag.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  parsing/asttypes.cmi \
+  utils/misc.cmx
+middle_end/alias_analysis.cmi : \
+  bytecomp/lambda.cmi \
+  middle_end/allocated_const.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  parsing/asttypes.cmi
+middle_end/allocated_const.cmo : \
+  middle_end/allocated_const.cmi
+middle_end/allocated_const.cmx : \
+  middle_end/allocated_const.cmi
 middle_end/allocated_const.cmi :
-middle_end/augment_specialised_args.cmo : middle_end/base_types/variable.cmi \
-    middle_end/projection.cmi middle_end/pass_wrapper.cmi \
-    middle_end/parameter.cmi utils/misc.cmi middle_end/inlining_cost.cmi \
-    middle_end/inline_and_simplify_aux.cmi utils/identifiable.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda.cmi \
-    middle_end/debuginfo.cmi middle_end/base_types/closure_id.cmi \
-    utils/clflags.cmi middle_end/backend_intf.cmi \
-    middle_end/augment_specialised_args.cmi
-middle_end/augment_specialised_args.cmx : middle_end/base_types/variable.cmx \
-    middle_end/projection.cmx middle_end/pass_wrapper.cmx \
-    middle_end/parameter.cmx utils/misc.cmx middle_end/inlining_cost.cmx \
-    middle_end/inline_and_simplify_aux.cmx utils/identifiable.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda.cmx \
-    middle_end/debuginfo.cmx middle_end/base_types/closure_id.cmx \
-    utils/clflags.cmx middle_end/backend_intf.cmi \
-    middle_end/augment_specialised_args.cmi
-middle_end/augment_specialised_args.cmi : middle_end/base_types/variable.cmi \
-    middle_end/projection.cmi middle_end/inlining_cost.cmi \
-    middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi
-middle_end/backend_intf.cmi : middle_end/base_types/symbol.cmi \
-    middle_end/simple_value_approx.cmi typing/ident.cmi \
-    middle_end/base_types/closure_id.cmi
-middle_end/closure_conversion.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi bytecomp/simplif.cmi \
-    bytecomp/printlambda.cmi typing/predef.cmi middle_end/parameter.cmi \
-    utils/numbers.cmi middle_end/base_types/mutable_variable.cmi \
-    utils/misc.cmi parsing/location.cmi \
-    middle_end/base_types/linkage_name.cmi middle_end/lift_code.cmi \
-    bytecomp/lambda.cmi typing/ident.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi middle_end/debuginfo.cmi utils/config.cmi \
-    middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi \
-    middle_end/closure_conversion_aux.cmi utils/clflags.cmi \
-    middle_end/backend_intf.cmi middle_end/closure_conversion.cmi
-middle_end/closure_conversion.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
-    middle_end/base_types/static_exception.cmx bytecomp/simplif.cmx \
-    bytecomp/printlambda.cmx typing/predef.cmx middle_end/parameter.cmx \
-    utils/numbers.cmx middle_end/base_types/mutable_variable.cmx \
-    utils/misc.cmx parsing/location.cmx \
-    middle_end/base_types/linkage_name.cmx middle_end/lift_code.cmx \
-    bytecomp/lambda.cmx typing/ident.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx middle_end/debuginfo.cmx utils/config.cmx \
-    middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx \
-    middle_end/closure_conversion_aux.cmx utils/clflags.cmx \
-    middle_end/backend_intf.cmi middle_end/closure_conversion.cmi
-middle_end/closure_conversion.cmi : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/flambda.cmi middle_end/backend_intf.cmi
-middle_end/closure_conversion_aux.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi utils/numbers.cmi \
-    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    parsing/location.cmi bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/closure_conversion_aux.cmi
-middle_end/closure_conversion_aux.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/symbol.cmx \
-    middle_end/base_types/static_exception.cmx utils/numbers.cmx \
-    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    parsing/location.cmx bytecomp/lambda.cmx typing/ident.cmx \
-    middle_end/closure_conversion_aux.cmi
-middle_end/closure_conversion_aux.cmi : middle_end/base_types/variable.cmi \
-    middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi \
-    middle_end/base_types/mutable_variable.cmi parsing/location.cmi \
-    bytecomp/lambda.cmi typing/ident.cmi
-middle_end/debuginfo.cmo : parsing/location.cmi middle_end/debuginfo.cmi
-middle_end/debuginfo.cmx : parsing/location.cmx middle_end/debuginfo.cmi
-middle_end/debuginfo.cmi : parsing/location.cmi
-middle_end/effect_analysis.cmo : bytecomp/semantics_of_primitives.cmi \
-    utils/misc.cmi bytecomp/lambda.cmi middle_end/flambda.cmi \
-    middle_end/effect_analysis.cmi
-middle_end/effect_analysis.cmx : bytecomp/semantics_of_primitives.cmx \
-    utils/misc.cmx bytecomp/lambda.cmx middle_end/flambda.cmx \
-    middle_end/effect_analysis.cmi
-middle_end/effect_analysis.cmi : middle_end/flambda.cmi
-middle_end/extract_projections.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/simple_value_approx.cmi middle_end/projection.cmi \
-    middle_end/inline_and_simplify_aux.cmi middle_end/freshening.cmi \
-    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
-    middle_end/base_types/closure_id.cmi middle_end/extract_projections.cmi
-middle_end/extract_projections.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/simple_value_approx.cmx middle_end/projection.cmx \
-    middle_end/inline_and_simplify_aux.cmx middle_end/freshening.cmx \
-    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
-    middle_end/base_types/closure_id.cmx middle_end/extract_projections.cmi
-middle_end/extract_projections.cmi : middle_end/base_types/variable.cmi \
-    middle_end/projection.cmi middle_end/inline_and_simplify_aux.cmi \
-    middle_end/flambda.cmi
-middle_end/find_recursive_functions.cmo : middle_end/base_types/variable.cmi \
-    utils/strongly_connected_components.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi middle_end/find_recursive_functions.cmi
-middle_end/find_recursive_functions.cmx : middle_end/base_types/variable.cmx \
-    utils/strongly_connected_components.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx middle_end/find_recursive_functions.cmi
-middle_end/find_recursive_functions.cmi : middle_end/base_types/variable.cmi \
-    middle_end/flambda.cmi middle_end/backend_intf.cmi
-middle_end/flambda.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi \
-    middle_end/base_types/set_of_closures_origin.cmi \
-    middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
-    bytecomp/printlambda.cmi middle_end/parameter.cmi utils/numbers.cmi \
-    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    bytecomp/lambda.cmi utils/identifiable.cmi middle_end/debuginfo.cmi \
-    middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
-    parsing/asttypes.cmi middle_end/allocated_const.cmi \
-    middle_end/flambda.cmi
-middle_end/flambda.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
-    middle_end/base_types/static_exception.cmx \
-    middle_end/base_types/set_of_closures_origin.cmx \
-    middle_end/base_types/set_of_closures_id.cmx middle_end/projection.cmx \
-    bytecomp/printlambda.cmx middle_end/parameter.cmx utils/numbers.cmx \
-    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    bytecomp/lambda.cmx utils/identifiable.cmx middle_end/debuginfo.cmx \
-    middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
-    parsing/asttypes.cmi middle_end/allocated_const.cmx \
-    middle_end/flambda.cmi
-middle_end/flambda.cmi : middle_end/base_types/variable.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi \
-    middle_end/base_types/set_of_closures_origin.cmi \
-    middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
-    middle_end/parameter.cmi utils/numbers.cmi \
-    middle_end/base_types/mutable_variable.cmi bytecomp/lambda.cmi \
-    utils/identifiable.cmi middle_end/debuginfo.cmi \
-    middle_end/base_types/closure_id.cmi parsing/asttypes.cmi \
-    middle_end/allocated_const.cmi
-middle_end/flambda_invariants.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi \
-    middle_end/base_types/set_of_closures_origin.cmi \
-    middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
-    bytecomp/printlambda.cmi middle_end/parameter.cmi utils/numbers.cmi \
-    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    bytecomp/lambda.cmi typing/ident.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/debuginfo.cmi \
-    middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi parsing/asttypes.cmi \
-    middle_end/allocated_const.cmi middle_end/flambda_invariants.cmi
-middle_end/flambda_invariants.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
-    middle_end/base_types/static_exception.cmx \
-    middle_end/base_types/set_of_closures_origin.cmx \
-    middle_end/base_types/set_of_closures_id.cmx middle_end/projection.cmx \
-    bytecomp/printlambda.cmx middle_end/parameter.cmx utils/numbers.cmx \
-    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    bytecomp/lambda.cmx typing/ident.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/debuginfo.cmx \
-    middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx parsing/asttypes.cmi \
-    middle_end/allocated_const.cmx middle_end/flambda_invariants.cmi
-middle_end/flambda_invariants.cmi : middle_end/flambda.cmi
-middle_end/flambda_iterators.cmo : middle_end/base_types/variable.cmi \
-    utils/misc.cmi middle_end/flambda.cmi middle_end/flambda_iterators.cmi
-middle_end/flambda_iterators.cmx : middle_end/base_types/variable.cmx \
-    utils/misc.cmx middle_end/flambda.cmx middle_end/flambda_iterators.cmi
-middle_end/flambda_iterators.cmi : middle_end/base_types/variable.cmi \
-    middle_end/base_types/symbol.cmi middle_end/flambda.cmi
-middle_end/flambda_utils.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/symbol.cmi bytecomp/switch.cmi \
-    middle_end/base_types/static_exception.cmi \
-    middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
-    middle_end/parameter.cmi middle_end/base_types/mutable_variable.cmi \
-    utils/misc.cmi middle_end/base_types/linkage_name.cmi bytecomp/lambda.cmi \
-    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
-    middle_end/debuginfo.cmi middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi \
-    middle_end/allocated_const.cmi middle_end/flambda_utils.cmi
-middle_end/flambda_utils.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/symbol.cmx bytecomp/switch.cmx \
-    middle_end/base_types/static_exception.cmx \
-    middle_end/base_types/set_of_closures_id.cmx middle_end/projection.cmx \
-    middle_end/parameter.cmx middle_end/base_types/mutable_variable.cmx \
-    utils/misc.cmx middle_end/base_types/linkage_name.cmx bytecomp/lambda.cmx \
-    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
-    middle_end/debuginfo.cmx middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx middle_end/backend_intf.cmi \
-    middle_end/allocated_const.cmx middle_end/flambda_utils.cmi
-middle_end/flambda_utils.cmi : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    bytecomp/switch.cmi middle_end/base_types/static_exception.cmi \
-    middle_end/base_types/set_of_closures_id.cmi middle_end/projection.cmi \
-    middle_end/parameter.cmi middle_end/flambda.cmi \
-    middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi
-middle_end/freshening.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi middle_end/projection.cmi \
-    middle_end/parameter.cmi middle_end/base_types/mutable_variable.cmi \
-    utils/misc.cmi utils/identifiable.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
-    middle_end/base_types/closure_id.cmi middle_end/freshening.cmi
-middle_end/freshening.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/symbol.cmx \
-    middle_end/base_types/static_exception.cmx middle_end/projection.cmx \
-    middle_end/parameter.cmx middle_end/base_types/mutable_variable.cmx \
-    utils/misc.cmx utils/identifiable.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
-    middle_end/base_types/closure_id.cmx middle_end/freshening.cmi
-middle_end/freshening.cmi : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi \
-    middle_end/base_types/mutable_variable.cmi middle_end/flambda.cmi \
-    middle_end/base_types/closure_id.cmi
-middle_end/inconstant_idents.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/symbol.cmi \
-    middle_end/base_types/set_of_closures_id.cmi middle_end/parameter.cmi \
-    utils/numbers.cmi utils/misc.cmi bytecomp/lambda.cmi \
-    utils/identifiable.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi \
-    parsing/asttypes.cmi middle_end/inconstant_idents.cmi
-middle_end/inconstant_idents.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/symbol.cmx \
-    middle_end/base_types/set_of_closures_id.cmx middle_end/parameter.cmx \
-    utils/numbers.cmx utils/misc.cmx bytecomp/lambda.cmx \
-    utils/identifiable.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx middle_end/backend_intf.cmi \
-    parsing/asttypes.cmi middle_end/inconstant_idents.cmi
-middle_end/inconstant_idents.cmi : middle_end/base_types/variable.cmi \
-    middle_end/base_types/set_of_closures_id.cmi middle_end/flambda.cmi \
-    middle_end/base_types/compilation_unit.cmi middle_end/backend_intf.cmi
+middle_end/augment_specialised_args.cmo : \
+  middle_end/augment_specialised_args.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/parameter.cmi \
+  middle_end/pass_wrapper.cmi \
+  middle_end/projection.cmi \
+  utils/clflags.cmi \
+  utils/identifiable.cmi \
+  utils/misc.cmi
+middle_end/augment_specialised_args.cmx : \
+  middle_end/augment_specialised_args.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/debuginfo.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/inline_and_simplify_aux.cmx \
+  middle_end/inlining_cost.cmx \
+  middle_end/parameter.cmx \
+  middle_end/pass_wrapper.cmx \
+  middle_end/projection.cmx \
+  utils/clflags.cmx \
+  utils/identifiable.cmx \
+  utils/misc.cmx
+middle_end/augment_specialised_args.cmi : \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/projection.cmi
+middle_end/backend_intf.cmi : \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/simple_value_approx.cmi \
+  typing/ident.cmi
+middle_end/closure_conversion.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/printlambda.cmi \
+  bytecomp/simplif.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/linkage_name.cmi \
+  middle_end/base_types/mutable_variable.cmi \
+  middle_end/base_types/static_exception.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/closure_conversion.cmi \
+  middle_end/closure_conversion_aux.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/lift_code.cmi \
+  middle_end/parameter.cmi \
+  parsing/location.cmi \
+  typing/ident.cmi \
+  typing/predef.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/numbers.cmi
+middle_end/closure_conversion.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/printlambda.cmx \
+  bytecomp/simplif.cmx \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/linkage_name.cmx \
+  middle_end/base_types/mutable_variable.cmx \
+  middle_end/base_types/static_exception.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/tag.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/closure_conversion.cmi \
+  middle_end/closure_conversion_aux.cmx \
+  middle_end/debuginfo.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/lift_code.cmx \
+  middle_end/parameter.cmx \
+  parsing/location.cmx \
+  typing/ident.cmx \
+  typing/predef.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/numbers.cmx
+middle_end/closure_conversion.cmi : \
+  bytecomp/lambda.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/flambda.cmi \
+  typing/ident.cmi
+middle_end/closure_conversion_aux.cmo : \
+  bytecomp/lambda.cmi \
+  middle_end/base_types/mutable_variable.cmi \
+  middle_end/base_types/static_exception.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/closure_conversion_aux.cmi \
+  parsing/location.cmi \
+  typing/ident.cmi \
+  utils/misc.cmi \
+  utils/numbers.cmi
+middle_end/closure_conversion_aux.cmx : \
+  bytecomp/lambda.cmx \
+  middle_end/base_types/mutable_variable.cmx \
+  middle_end/base_types/static_exception.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/closure_conversion_aux.cmi \
+  parsing/location.cmx \
+  typing/ident.cmx \
+  utils/misc.cmx \
+  utils/numbers.cmx
+middle_end/closure_conversion_aux.cmi : \
+  bytecomp/lambda.cmi \
+  middle_end/base_types/mutable_variable.cmi \
+  middle_end/base_types/static_exception.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/variable.cmi \
+  parsing/location.cmi \
+  typing/ident.cmi
+middle_end/debuginfo.cmo : \
+  middle_end/debuginfo.cmi \
+  parsing/location.cmi
+middle_end/debuginfo.cmx : \
+  middle_end/debuginfo.cmi \
+  parsing/location.cmx
+middle_end/debuginfo.cmi : \
+  parsing/location.cmi
+middle_end/effect_analysis.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/semantics_of_primitives.cmi \
+  middle_end/effect_analysis.cmi \
+  middle_end/flambda.cmi \
+  utils/misc.cmi
+middle_end/effect_analysis.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/semantics_of_primitives.cmx \
+  middle_end/effect_analysis.cmi \
+  middle_end/flambda.cmx \
+  utils/misc.cmx
+middle_end/effect_analysis.cmi : \
+  middle_end/flambda.cmi
+middle_end/extract_projections.cmo : \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/extract_projections.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/freshening.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/projection.cmi \
+  middle_end/simple_value_approx.cmi
+middle_end/extract_projections.cmx : \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/extract_projections.cmi \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/freshening.cmx \
+  middle_end/inline_and_simplify_aux.cmx \
+  middle_end/projection.cmx \
+  middle_end/simple_value_approx.cmx
+middle_end/extract_projections.cmi : \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/projection.cmi
+middle_end/find_recursive_functions.cmo : \
+  middle_end/base_types/variable.cmi \
+  middle_end/find_recursive_functions.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_utils.cmi \
+  utils/strongly_connected_components.cmi
+middle_end/find_recursive_functions.cmx : \
+  middle_end/base_types/variable.cmx \
+  middle_end/find_recursive_functions.cmi \
+  middle_end/flambda.cmx \
+  middle_end/flambda_utils.cmx \
+  utils/strongly_connected_components.cmx
+middle_end/find_recursive_functions.cmi : \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi
+middle_end/flambda.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/printlambda.cmi \
+  middle_end/allocated_const.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/mutable_variable.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/set_of_closures_origin.cmi \
+  middle_end/base_types/static_exception.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/flambda.cmi \
+  middle_end/parameter.cmi \
+  middle_end/projection.cmi \
+  parsing/asttypes.cmi \
+  utils/clflags.cmi \
+  utils/identifiable.cmi \
+  utils/misc.cmi \
+  utils/numbers.cmi
+middle_end/flambda.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/printlambda.cmx \
+  middle_end/allocated_const.cmx \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/mutable_variable.cmx \
+  middle_end/base_types/set_of_closures_id.cmx \
+  middle_end/base_types/set_of_closures_origin.cmx \
+  middle_end/base_types/static_exception.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/tag.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/debuginfo.cmx \
+  middle_end/flambda.cmi \
+  middle_end/parameter.cmx \
+  middle_end/projection.cmx \
+  parsing/asttypes.cmi \
+  utils/clflags.cmx \
+  utils/identifiable.cmx \
+  utils/misc.cmx \
+  utils/numbers.cmx
+middle_end/flambda.cmi : \
+  bytecomp/lambda.cmi \
+  middle_end/allocated_const.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/mutable_variable.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/set_of_closures_origin.cmi \
+  middle_end/base_types/static_exception.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/parameter.cmi \
+  middle_end/projection.cmi \
+  parsing/asttypes.cmi \
+  utils/identifiable.cmi \
+  utils/numbers.cmi
+middle_end/flambda_invariants.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/printlambda.cmi \
+  middle_end/allocated_const.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/mutable_variable.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/set_of_closures_origin.cmi \
+  middle_end/base_types/static_exception.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_invariants.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/parameter.cmi \
+  middle_end/projection.cmi \
+  parsing/asttypes.cmi \
+  typing/ident.cmi \
+  utils/misc.cmi \
+  utils/numbers.cmi
+middle_end/flambda_invariants.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/printlambda.cmx \
+  middle_end/allocated_const.cmx \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/mutable_variable.cmx \
+  middle_end/base_types/set_of_closures_id.cmx \
+  middle_end/base_types/set_of_closures_origin.cmx \
+  middle_end/base_types/static_exception.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/tag.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/debuginfo.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_invariants.cmi \
+  middle_end/flambda_iterators.cmx \
+  middle_end/parameter.cmx \
+  middle_end/projection.cmx \
+  parsing/asttypes.cmi \
+  typing/ident.cmx \
+  utils/misc.cmx \
+  utils/numbers.cmx
+middle_end/flambda_invariants.cmi : \
+  middle_end/flambda.cmi
+middle_end/flambda_iterators.cmo : \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  utils/misc.cmi
+middle_end/flambda_iterators.cmx : \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmi \
+  utils/misc.cmx
+middle_end/flambda_iterators.cmi : \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi
+middle_end/flambda_utils.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/switch.cmi \
+  middle_end/allocated_const.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/linkage_name.cmi \
+  middle_end/base_types/mutable_variable.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/static_exception.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/parameter.cmi \
+  middle_end/projection.cmi \
+  utils/misc.cmi
+middle_end/flambda_utils.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/switch.cmx \
+  middle_end/allocated_const.cmx \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/linkage_name.cmx \
+  middle_end/base_types/mutable_variable.cmx \
+  middle_end/base_types/set_of_closures_id.cmx \
+  middle_end/base_types/static_exception.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/debuginfo.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/flambda_utils.cmi \
+  middle_end/parameter.cmx \
+  middle_end/projection.cmx \
+  utils/misc.cmx
+middle_end/flambda_utils.cmi : \
+  bytecomp/switch.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/static_exception.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/parameter.cmi \
+  middle_end/projection.cmi
+middle_end/freshening.cmo : \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/mutable_variable.cmi \
+  middle_end/base_types/static_exception.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/freshening.cmi \
+  middle_end/parameter.cmi \
+  middle_end/projection.cmi \
+  utils/identifiable.cmi \
+  utils/misc.cmi
+middle_end/freshening.cmx : \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/mutable_variable.cmx \
+  middle_end/base_types/static_exception.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/freshening.cmi \
+  middle_end/parameter.cmx \
+  middle_end/projection.cmx \
+  utils/identifiable.cmx \
+  utils/misc.cmx
+middle_end/freshening.cmi : \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/mutable_variable.cmi \
+  middle_end/base_types/static_exception.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi
+middle_end/inconstant_idents.cmo : \
+  bytecomp/lambda.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/inconstant_idents.cmi \
+  middle_end/parameter.cmi \
+  parsing/asttypes.cmi \
+  utils/identifiable.cmi \
+  utils/misc.cmi \
+  utils/numbers.cmi
+middle_end/inconstant_idents.cmx : \
+  bytecomp/lambda.cmx \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/set_of_closures_id.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/inconstant_idents.cmi \
+  middle_end/parameter.cmx \
+  parsing/asttypes.cmi \
+  utils/identifiable.cmx \
+  utils/misc.cmx \
+  utils/numbers.cmx
+middle_end/inconstant_idents.cmi : \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi
 middle_end/initialize_symbol_to_let_symbol.cmo : \
-    middle_end/base_types/variable.cmi utils/misc.cmi middle_end/flambda.cmi \
-    middle_end/initialize_symbol_to_let_symbol.cmi
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/initialize_symbol_to_let_symbol.cmi \
+  utils/misc.cmi
 middle_end/initialize_symbol_to_let_symbol.cmx : \
-    middle_end/base_types/variable.cmx utils/misc.cmx middle_end/flambda.cmx \
-    middle_end/initialize_symbol_to_let_symbol.cmi
-middle_end/initialize_symbol_to_let_symbol.cmi : middle_end/flambda.cmi
-middle_end/inline_and_simplify.cmo : utils/warnings.cmi \
-    middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/unbox_specialised_args.cmi \
-    middle_end/unbox_free_vars_of_closures.cmi middle_end/unbox_closures.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi \
-    middle_end/simplify_primitives.cmi middle_end/simple_value_approx.cmi \
-    middle_end/remove_unused_arguments.cmi \
-    middle_end/remove_free_vars_equal_to_args.cmi middle_end/projection.cmi \
-    typing/predef.cmi middle_end/parameter.cmi utils/misc.cmi \
-    parsing/location.cmi middle_end/lift_code.cmi bytecomp/lambda.cmi \
-    middle_end/invariant_params.cmi middle_end/inlining_stats.cmi \
-    middle_end/inlining_decision.cmi middle_end/inlining_cost.cmi \
-    middle_end/inline_and_simplify_aux.cmi typing/ident.cmi \
-    middle_end/freshening.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi middle_end/effect_analysis.cmi \
-    middle_end/debuginfo.cmi utils/config.cmi \
-    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
-    middle_end/backend_intf.cmi middle_end/allocated_const.cmi \
-    middle_end/inline_and_simplify.cmi
-middle_end/inline_and_simplify.cmx : utils/warnings.cmx \
-    middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/unbox_specialised_args.cmx \
-    middle_end/unbox_free_vars_of_closures.cmx middle_end/unbox_closures.cmx \
-    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
-    middle_end/base_types/static_exception.cmx \
-    middle_end/simplify_primitives.cmx middle_end/simple_value_approx.cmx \
-    middle_end/remove_unused_arguments.cmx \
-    middle_end/remove_free_vars_equal_to_args.cmx middle_end/projection.cmx \
-    typing/predef.cmx middle_end/parameter.cmx utils/misc.cmx \
-    parsing/location.cmx middle_end/lift_code.cmx bytecomp/lambda.cmx \
-    middle_end/invariant_params.cmx middle_end/inlining_stats.cmx \
-    middle_end/inlining_decision.cmx middle_end/inlining_cost.cmx \
-    middle_end/inline_and_simplify_aux.cmx typing/ident.cmx \
-    middle_end/freshening.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx middle_end/effect_analysis.cmx \
-    middle_end/debuginfo.cmx utils/config.cmx \
-    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
-    middle_end/backend_intf.cmi middle_end/allocated_const.cmx \
-    middle_end/inline_and_simplify.cmi
-middle_end/inline_and_simplify.cmi : middle_end/base_types/variable.cmi \
-    middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi \
-    middle_end/backend_intf.cmi
-middle_end/inline_and_simplify_aux.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi \
-    middle_end/simple_value_approx.cmi \
-    middle_end/base_types/set_of_closures_origin.cmi \
-    middle_end/projection.cmi middle_end/parameter.cmi \
-    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    middle_end/inlining_stats.cmi middle_end/inlining_cost.cmi \
-    middle_end/freshening.cmi middle_end/flambda.cmi middle_end/debuginfo.cmi \
-    middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
-    middle_end/backend_intf.cmi middle_end/inline_and_simplify_aux.cmi
-middle_end/inline_and_simplify_aux.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/symbol.cmx \
-    middle_end/base_types/static_exception.cmx \
-    middle_end/simple_value_approx.cmx \
-    middle_end/base_types/set_of_closures_origin.cmx \
-    middle_end/projection.cmx middle_end/parameter.cmx \
-    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    middle_end/inlining_stats.cmx middle_end/inlining_cost.cmx \
-    middle_end/freshening.cmx middle_end/flambda.cmx middle_end/debuginfo.cmx \
-    middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
-    middle_end/backend_intf.cmi middle_end/inline_and_simplify_aux.cmi
-middle_end/inline_and_simplify_aux.cmi : middle_end/base_types/variable.cmi \
-    middle_end/base_types/symbol.cmi \
-    middle_end/base_types/static_exception.cmi \
-    middle_end/simple_value_approx.cmi \
-    middle_end/base_types/set_of_closures_origin.cmi \
-    middle_end/projection.cmi middle_end/base_types/mutable_variable.cmi \
-    middle_end/inlining_stats_types.cmi middle_end/inlining_cost.cmi \
-    middle_end/freshening.cmi middle_end/flambda.cmi middle_end/debuginfo.cmi \
-    middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi
-middle_end/inlining_cost.cmo : middle_end/base_types/variable.cmi \
-    middle_end/projection.cmi typing/primitive.cmi utils/misc.cmi \
-    bytecomp/lambda.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi utils/clflags.cmi middle_end/inlining_cost.cmi
-middle_end/inlining_cost.cmx : middle_end/base_types/variable.cmx \
-    middle_end/projection.cmx typing/primitive.cmx utils/misc.cmx \
-    bytecomp/lambda.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx utils/clflags.cmx middle_end/inlining_cost.cmi
-middle_end/inlining_cost.cmi : middle_end/projection.cmi \
-    middle_end/flambda.cmi
-middle_end/inlining_decision.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/simple_value_approx.cmi middle_end/parameter.cmi \
-    utils/misc.cmi bytecomp/lambda.cmi middle_end/inlining_transforms.cmi \
-    middle_end/inlining_stats_types.cmi middle_end/inlining_cost.cmi \
-    middle_end/inline_and_simplify_aux.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi middle_end/find_recursive_functions.cmi \
-    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
-    middle_end/inlining_decision.cmi
-middle_end/inlining_decision.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/simple_value_approx.cmx middle_end/parameter.cmx \
-    utils/misc.cmx bytecomp/lambda.cmx middle_end/inlining_transforms.cmx \
-    middle_end/inlining_stats_types.cmx middle_end/inlining_cost.cmx \
-    middle_end/inline_and_simplify_aux.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx middle_end/find_recursive_functions.cmx \
-    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
-    middle_end/inlining_decision.cmi
-middle_end/inlining_decision.cmi : middle_end/base_types/variable.cmi \
-    middle_end/simple_value_approx.cmi bytecomp/lambda.cmi \
-    middle_end/inlining_decision_intf.cmi \
-    middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi \
-    middle_end/debuginfo.cmi middle_end/base_types/closure_id.cmi
-middle_end/inlining_decision_intf.cmi : middle_end/base_types/variable.cmi \
-    middle_end/simple_value_approx.cmi middle_end/inline_and_simplify_aux.cmi \
-    middle_end/flambda.cmi middle_end/debuginfo.cmi \
-    middle_end/base_types/closure_id.cmi
-middle_end/inlining_stats.cmo : utils/misc.cmi \
-    middle_end/inlining_stats_types.cmi middle_end/debuginfo.cmi \
-    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
-    middle_end/inlining_stats.cmi
-middle_end/inlining_stats.cmx : utils/misc.cmx \
-    middle_end/inlining_stats_types.cmx middle_end/debuginfo.cmx \
-    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
-    middle_end/inlining_stats.cmi
-middle_end/inlining_stats.cmi : middle_end/inlining_stats_types.cmi \
-    middle_end/debuginfo.cmi middle_end/base_types/closure_id.cmi
-middle_end/inlining_stats_types.cmo : middle_end/inlining_cost.cmi \
-    middle_end/inlining_stats_types.cmi
-middle_end/inlining_stats_types.cmx : middle_end/inlining_cost.cmx \
-    middle_end/inlining_stats_types.cmi
-middle_end/inlining_stats_types.cmi : middle_end/inlining_cost.cmi
-middle_end/inlining_transforms.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/simple_value_approx.cmi middle_end/parameter.cmi \
-    utils/misc.cmi bytecomp/lambda.cmi middle_end/inlining_cost.cmi \
-    middle_end/inline_and_simplify_aux.cmi middle_end/freshening.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi \
-    middle_end/inlining_transforms.cmi
-middle_end/inlining_transforms.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/simple_value_approx.cmx middle_end/parameter.cmx \
-    utils/misc.cmx bytecomp/lambda.cmx middle_end/inlining_cost.cmx \
-    middle_end/inline_and_simplify_aux.cmx middle_end/freshening.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx middle_end/backend_intf.cmi \
-    middle_end/inlining_transforms.cmi
-middle_end/inlining_transforms.cmi : middle_end/base_types/variable.cmi \
-    middle_end/simple_value_approx.cmi bytecomp/lambda.cmi \
-    middle_end/inlining_decision_intf.cmi \
-    middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi \
-    middle_end/debuginfo.cmi middle_end/base_types/closure_id.cmi
-middle_end/invariant_params.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/symbol.cmi middle_end/parameter.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/base_types/closure_id.cmi \
-    utils/clflags.cmi middle_end/backend_intf.cmi \
-    middle_end/invariant_params.cmi
-middle_end/invariant_params.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/symbol.cmx middle_end/parameter.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/base_types/closure_id.cmx \
-    utils/clflags.cmx middle_end/backend_intf.cmi \
-    middle_end/invariant_params.cmi
-middle_end/invariant_params.cmi : middle_end/base_types/variable.cmi \
-    middle_end/flambda.cmi middle_end/backend_intf.cmi
-middle_end/lift_code.cmo : middle_end/base_types/variable.cmi \
-    utils/strongly_connected_components.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/base_types/compilation_unit.cmi \
-    middle_end/lift_code.cmi
-middle_end/lift_code.cmx : middle_end/base_types/variable.cmx \
-    utils/strongly_connected_components.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/base_types/compilation_unit.cmx \
-    middle_end/lift_code.cmi
-middle_end/lift_code.cmi : middle_end/base_types/variable.cmi \
-    middle_end/flambda.cmi
-middle_end/lift_constants.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    utils/strongly_connected_components.cmi \
-    middle_end/simple_value_approx.cmi utils/misc.cmi \
-    middle_end/base_types/linkage_name.cmi middle_end/inconstant_idents.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi middle_end/backend_intf.cmi \
-    parsing/asttypes.cmi middle_end/allocated_const.cmi \
-    middle_end/alias_analysis.cmi middle_end/lift_constants.cmi
-middle_end/lift_constants.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
-    utils/strongly_connected_components.cmx \
-    middle_end/simple_value_approx.cmx utils/misc.cmx \
-    middle_end/base_types/linkage_name.cmx middle_end/inconstant_idents.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx middle_end/backend_intf.cmi \
-    parsing/asttypes.cmi middle_end/allocated_const.cmx \
-    middle_end/alias_analysis.cmx middle_end/lift_constants.cmi
-middle_end/lift_constants.cmi : middle_end/flambda.cmi \
-    middle_end/backend_intf.cmi
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/initialize_symbol_to_let_symbol.cmi \
+  utils/misc.cmx
+middle_end/initialize_symbol_to_let_symbol.cmi : \
+  middle_end/flambda.cmi
+middle_end/inline_and_simplify.cmo : \
+  bytecomp/lambda.cmi \
+  middle_end/allocated_const.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/static_exception.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/effect_analysis.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/freshening.cmi \
+  middle_end/inline_and_simplify.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/inlining_decision.cmi \
+  middle_end/inlining_stats.cmi \
+  middle_end/invariant_params.cmi \
+  middle_end/lift_code.cmi \
+  middle_end/parameter.cmi \
+  middle_end/projection.cmi \
+  middle_end/remove_free_vars_equal_to_args.cmi \
+  middle_end/remove_unused_arguments.cmi \
+  middle_end/simple_value_approx.cmi \
+  middle_end/simplify_primitives.cmi \
+  middle_end/unbox_closures.cmi \
+  middle_end/unbox_free_vars_of_closures.cmi \
+  middle_end/unbox_specialised_args.cmi \
+  parsing/location.cmi \
+  typing/ident.cmi \
+  typing/predef.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+middle_end/inline_and_simplify.cmx : \
+  bytecomp/lambda.cmx \
+  middle_end/allocated_const.cmx \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/static_exception.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/tag.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/debuginfo.cmx \
+  middle_end/effect_analysis.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/freshening.cmx \
+  middle_end/inline_and_simplify.cmi \
+  middle_end/inline_and_simplify_aux.cmx \
+  middle_end/inlining_cost.cmx \
+  middle_end/inlining_decision.cmx \
+  middle_end/inlining_stats.cmx \
+  middle_end/invariant_params.cmx \
+  middle_end/lift_code.cmx \
+  middle_end/parameter.cmx \
+  middle_end/projection.cmx \
+  middle_end/remove_free_vars_equal_to_args.cmx \
+  middle_end/remove_unused_arguments.cmx \
+  middle_end/simple_value_approx.cmx \
+  middle_end/simplify_primitives.cmx \
+  middle_end/unbox_closures.cmx \
+  middle_end/unbox_free_vars_of_closures.cmx \
+  middle_end/unbox_specialised_args.cmx \
+  parsing/location.cmx \
+  typing/ident.cmx \
+  typing/predef.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+middle_end/inline_and_simplify.cmi : \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/inline_and_simplify_aux.cmi
+middle_end/inline_and_simplify_aux.cmo : \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/mutable_variable.cmi \
+  middle_end/base_types/set_of_closures_origin.cmi \
+  middle_end/base_types/static_exception.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/flambda.cmi \
+  middle_end/freshening.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/inlining_stats.cmi \
+  middle_end/parameter.cmi \
+  middle_end/projection.cmi \
+  middle_end/simple_value_approx.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+middle_end/inline_and_simplify_aux.cmx : \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/mutable_variable.cmx \
+  middle_end/base_types/set_of_closures_origin.cmx \
+  middle_end/base_types/static_exception.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/debuginfo.cmx \
+  middle_end/flambda.cmx \
+  middle_end/freshening.cmx \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/inlining_cost.cmx \
+  middle_end/inlining_stats.cmx \
+  middle_end/parameter.cmx \
+  middle_end/projection.cmx \
+  middle_end/simple_value_approx.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx
+middle_end/inline_and_simplify_aux.cmi : \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/mutable_variable.cmi \
+  middle_end/base_types/set_of_closures_origin.cmi \
+  middle_end/base_types/static_exception.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/flambda.cmi \
+  middle_end/freshening.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/inlining_stats_types.cmi \
+  middle_end/projection.cmi \
+  middle_end/simple_value_approx.cmi
+middle_end/inlining_cost.cmo : \
+  bytecomp/lambda.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/projection.cmi \
+  typing/primitive.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+middle_end/inlining_cost.cmx : \
+  bytecomp/lambda.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/inlining_cost.cmi \
+  middle_end/projection.cmx \
+  typing/primitive.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx
+middle_end/inlining_cost.cmi : \
+  middle_end/flambda.cmi \
+  middle_end/projection.cmi
+middle_end/inlining_decision.cmo : \
+  bytecomp/lambda.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/find_recursive_functions.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/inlining_decision.cmi \
+  middle_end/inlining_stats_types.cmi \
+  middle_end/inlining_transforms.cmi \
+  middle_end/parameter.cmi \
+  middle_end/simple_value_approx.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+middle_end/inlining_decision.cmx : \
+  bytecomp/lambda.cmx \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/find_recursive_functions.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/inline_and_simplify_aux.cmx \
+  middle_end/inlining_cost.cmx \
+  middle_end/inlining_decision.cmi \
+  middle_end/inlining_stats_types.cmx \
+  middle_end/inlining_transforms.cmx \
+  middle_end/parameter.cmx \
+  middle_end/simple_value_approx.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx
+middle_end/inlining_decision.cmi : \
+  bytecomp/lambda.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/flambda.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/inlining_decision_intf.cmi \
+  middle_end/simple_value_approx.cmi
+middle_end/inlining_decision_intf.cmi : \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/flambda.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/simple_value_approx.cmi
+middle_end/inlining_stats.cmo : \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/inlining_stats.cmi \
+  middle_end/inlining_stats_types.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+middle_end/inlining_stats.cmx : \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/debuginfo.cmx \
+  middle_end/inlining_stats.cmi \
+  middle_end/inlining_stats_types.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx
+middle_end/inlining_stats.cmi : \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/inlining_stats_types.cmi
+middle_end/inlining_stats_types.cmo : \
+  middle_end/inlining_cost.cmi \
+  middle_end/inlining_stats_types.cmi
+middle_end/inlining_stats_types.cmx : \
+  middle_end/inlining_cost.cmx \
+  middle_end/inlining_stats_types.cmi
+middle_end/inlining_stats_types.cmi : \
+  middle_end/inlining_cost.cmi
+middle_end/inlining_transforms.cmo : \
+  bytecomp/lambda.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/freshening.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/inlining_transforms.cmi \
+  middle_end/parameter.cmi \
+  middle_end/simple_value_approx.cmi \
+  utils/misc.cmi
+middle_end/inlining_transforms.cmx : \
+  bytecomp/lambda.cmx \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/freshening.cmx \
+  middle_end/inline_and_simplify_aux.cmx \
+  middle_end/inlining_cost.cmx \
+  middle_end/inlining_transforms.cmi \
+  middle_end/parameter.cmx \
+  middle_end/simple_value_approx.cmx \
+  utils/misc.cmx
+middle_end/inlining_transforms.cmi : \
+  bytecomp/lambda.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/flambda.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/inlining_decision_intf.cmi \
+  middle_end/simple_value_approx.cmi
+middle_end/invariant_params.cmo : \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/invariant_params.cmi \
+  middle_end/parameter.cmi \
+  utils/clflags.cmi
+middle_end/invariant_params.cmx : \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/invariant_params.cmi \
+  middle_end/parameter.cmx \
+  utils/clflags.cmx
+middle_end/invariant_params.cmi : \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi
+middle_end/lift_code.cmo : \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/lift_code.cmi \
+  utils/strongly_connected_components.cmi
+middle_end/lift_code.cmx : \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/lift_code.cmi \
+  utils/strongly_connected_components.cmx
+middle_end/lift_code.cmi : \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi
+middle_end/lift_constants.cmo : \
+  middle_end/alias_analysis.cmi \
+  middle_end/allocated_const.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/linkage_name.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/inconstant_idents.cmi \
+  middle_end/lift_constants.cmi \
+  middle_end/simple_value_approx.cmi \
+  parsing/asttypes.cmi \
+  utils/misc.cmi \
+  utils/strongly_connected_components.cmi
+middle_end/lift_constants.cmx : \
+  middle_end/alias_analysis.cmx \
+  middle_end/allocated_const.cmx \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/linkage_name.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/tag.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/inconstant_idents.cmx \
+  middle_end/lift_constants.cmi \
+  middle_end/simple_value_approx.cmx \
+  parsing/asttypes.cmi \
+  utils/misc.cmx \
+  utils/strongly_connected_components.cmx
+middle_end/lift_constants.cmi : \
+  middle_end/backend_intf.cmi \
+  middle_end/flambda.cmi
 middle_end/lift_let_to_initialize_symbol.cmo : \
-    middle_end/base_types/variable.cmi middle_end/base_types/tag.cmi \
-    middle_end/base_types/symbol.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi middle_end/debuginfo.cmi parsing/asttypes.cmi \
-    middle_end/lift_let_to_initialize_symbol.cmi
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/lift_let_to_initialize_symbol.cmi \
+  parsing/asttypes.cmi
 middle_end/lift_let_to_initialize_symbol.cmx : \
-    middle_end/base_types/variable.cmx middle_end/base_types/tag.cmx \
-    middle_end/base_types/symbol.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx middle_end/debuginfo.cmx parsing/asttypes.cmi \
-    middle_end/lift_let_to_initialize_symbol.cmi
-middle_end/lift_let_to_initialize_symbol.cmi : middle_end/flambda.cmi \
-    middle_end/backend_intf.cmi
-middle_end/middle_end.cmo : utils/warnings.cmi \
-    middle_end/base_types/variable.cmi middle_end/base_types/symbol.cmi \
-    middle_end/share_constants.cmi \
-    middle_end/remove_unused_program_constructs.cmi \
-    middle_end/remove_unused_closure_vars.cmi middle_end/ref_to_variables.cmi \
-    utils/profile.cmi utils/misc.cmi parsing/location.cmi \
-    middle_end/lift_let_to_initialize_symbol.cmi \
-    middle_end/lift_constants.cmi middle_end/lift_code.cmi \
-    middle_end/inlining_cost.cmi middle_end/inline_and_simplify.cmi \
-    middle_end/initialize_symbol_to_let_symbol.cmi \
-    middle_end/flambda_iterators.cmi middle_end/flambda_invariants.cmi \
-    middle_end/flambda.cmi middle_end/debuginfo.cmi \
-    middle_end/base_types/closure_id.cmi middle_end/closure_conversion.cmi \
-    utils/clflags.cmi middle_end/backend_intf.cmi middle_end/middle_end.cmi
-middle_end/middle_end.cmx : utils/warnings.cmx \
-    middle_end/base_types/variable.cmx middle_end/base_types/symbol.cmx \
-    middle_end/share_constants.cmx \
-    middle_end/remove_unused_program_constructs.cmx \
-    middle_end/remove_unused_closure_vars.cmx middle_end/ref_to_variables.cmx \
-    utils/profile.cmx utils/misc.cmx parsing/location.cmx \
-    middle_end/lift_let_to_initialize_symbol.cmx \
-    middle_end/lift_constants.cmx middle_end/lift_code.cmx \
-    middle_end/inlining_cost.cmx middle_end/inline_and_simplify.cmx \
-    middle_end/initialize_symbol_to_let_symbol.cmx \
-    middle_end/flambda_iterators.cmx middle_end/flambda_invariants.cmx \
-    middle_end/flambda.cmx middle_end/debuginfo.cmx \
-    middle_end/base_types/closure_id.cmx middle_end/closure_conversion.cmx \
-    utils/clflags.cmx middle_end/backend_intf.cmi middle_end/middle_end.cmi
-middle_end/middle_end.cmi : bytecomp/lambda.cmi typing/ident.cmi \
-    middle_end/flambda.cmi middle_end/backend_intf.cmi
-middle_end/parameter.cmo : middle_end/base_types/variable.cmi \
-    utils/identifiable.cmi middle_end/parameter.cmi
-middle_end/parameter.cmx : middle_end/base_types/variable.cmx \
-    utils/identifiable.cmx middle_end/parameter.cmi
-middle_end/parameter.cmi : middle_end/base_types/variable.cmi \
-    utils/identifiable.cmi middle_end/base_types/compilation_unit.cmi
-middle_end/pass_wrapper.cmo : utils/clflags.cmi middle_end/pass_wrapper.cmi
-middle_end/pass_wrapper.cmx : utils/clflags.cmx middle_end/pass_wrapper.cmi
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/tag.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/debuginfo.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/lift_let_to_initialize_symbol.cmi \
+  parsing/asttypes.cmi
+middle_end/lift_let_to_initialize_symbol.cmi : \
+  middle_end/backend_intf.cmi \
+  middle_end/flambda.cmi
+middle_end/middle_end.cmo : \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/closure_conversion.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_invariants.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/initialize_symbol_to_let_symbol.cmi \
+  middle_end/inline_and_simplify.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/lift_code.cmi \
+  middle_end/lift_constants.cmi \
+  middle_end/lift_let_to_initialize_symbol.cmi \
+  middle_end/middle_end.cmi \
+  middle_end/ref_to_variables.cmi \
+  middle_end/remove_unused_closure_vars.cmi \
+  middle_end/remove_unused_program_constructs.cmi \
+  middle_end/share_constants.cmi \
+  parsing/location.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi \
+  utils/profile.cmi \
+  utils/warnings.cmi
+middle_end/middle_end.cmx : \
+  middle_end/backend_intf.cmi \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/closure_conversion.cmx \
+  middle_end/debuginfo.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_invariants.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/initialize_symbol_to_let_symbol.cmx \
+  middle_end/inline_and_simplify.cmx \
+  middle_end/inlining_cost.cmx \
+  middle_end/lift_code.cmx \
+  middle_end/lift_constants.cmx \
+  middle_end/lift_let_to_initialize_symbol.cmx \
+  middle_end/middle_end.cmi \
+  middle_end/ref_to_variables.cmx \
+  middle_end/remove_unused_closure_vars.cmx \
+  middle_end/remove_unused_program_constructs.cmx \
+  middle_end/share_constants.cmx \
+  parsing/location.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx \
+  utils/profile.cmx \
+  utils/warnings.cmx
+middle_end/middle_end.cmi : \
+  bytecomp/lambda.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/flambda.cmi \
+  typing/ident.cmi
+middle_end/parameter.cmo : \
+  middle_end/base_types/variable.cmi \
+  middle_end/parameter.cmi \
+  utils/identifiable.cmi
+middle_end/parameter.cmx : \
+  middle_end/base_types/variable.cmx \
+  middle_end/parameter.cmi \
+  utils/identifiable.cmx
+middle_end/parameter.cmi : \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/variable.cmi \
+  utils/identifiable.cmi
+middle_end/pass_wrapper.cmo : \
+  middle_end/pass_wrapper.cmi \
+  utils/clflags.cmi
+middle_end/pass_wrapper.cmx : \
+  middle_end/pass_wrapper.cmi \
+  utils/clflags.cmx
 middle_end/pass_wrapper.cmi :
-middle_end/projection.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi utils/identifiable.cmi \
-    middle_end/base_types/closure_id.cmi middle_end/projection.cmi
-middle_end/projection.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx utils/identifiable.cmx \
-    middle_end/base_types/closure_id.cmx middle_end/projection.cmi
-middle_end/projection.cmi : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi utils/identifiable.cmi \
-    middle_end/base_types/closure_id.cmi
-middle_end/ref_to_variables.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/mutable_variable.cmi utils/misc.cmi \
-    bytecomp/lambda.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi parsing/asttypes.cmi \
-    middle_end/ref_to_variables.cmi
-middle_end/ref_to_variables.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/mutable_variable.cmx utils/misc.cmx \
-    bytecomp/lambda.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx parsing/asttypes.cmi \
-    middle_end/ref_to_variables.cmi
-middle_end/ref_to_variables.cmi : middle_end/flambda.cmi
+middle_end/projection.cmo : \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/projection.cmi \
+  utils/identifiable.cmi
+middle_end/projection.cmx : \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/projection.cmi \
+  utils/identifiable.cmx
+middle_end/projection.cmi : \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  utils/identifiable.cmi
+middle_end/ref_to_variables.cmo : \
+  bytecomp/lambda.cmi \
+  middle_end/base_types/mutable_variable.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/ref_to_variables.cmi \
+  parsing/asttypes.cmi \
+  utils/misc.cmi
+middle_end/ref_to_variables.cmx : \
+  bytecomp/lambda.cmx \
+  middle_end/base_types/mutable_variable.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/ref_to_variables.cmi \
+  parsing/asttypes.cmi \
+  utils/misc.cmx
+middle_end/ref_to_variables.cmi : \
+  middle_end/flambda.cmi
 middle_end/remove_free_vars_equal_to_args.cmo : \
-    middle_end/base_types/variable.cmi middle_end/pass_wrapper.cmi \
-    middle_end/parameter.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi middle_end/remove_free_vars_equal_to_args.cmi
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/parameter.cmi \
+  middle_end/pass_wrapper.cmi \
+  middle_end/remove_free_vars_equal_to_args.cmi
 middle_end/remove_free_vars_equal_to_args.cmx : \
-    middle_end/base_types/variable.cmx middle_end/pass_wrapper.cmx \
-    middle_end/parameter.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx middle_end/remove_free_vars_equal_to_args.cmi
-middle_end/remove_free_vars_equal_to_args.cmi : middle_end/flambda.cmi
-middle_end/remove_unused_arguments.cmo : middle_end/base_types/variable.cmi \
-    middle_end/projection.cmi middle_end/parameter.cmi \
-    middle_end/invariant_params.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
-    middle_end/find_recursive_functions.cmi \
-    middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/closure_id.cmi utils/clflags.cmi \
-    middle_end/remove_unused_arguments.cmi
-middle_end/remove_unused_arguments.cmx : middle_end/base_types/variable.cmx \
-    middle_end/projection.cmx middle_end/parameter.cmx \
-    middle_end/invariant_params.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
-    middle_end/find_recursive_functions.cmx \
-    middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/closure_id.cmx utils/clflags.cmx \
-    middle_end/remove_unused_arguments.cmi
-middle_end/remove_unused_arguments.cmi : middle_end/flambda.cmi \
-    middle_end/backend_intf.cmi
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/parameter.cmx \
+  middle_end/pass_wrapper.cmx \
+  middle_end/remove_free_vars_equal_to_args.cmi
+middle_end/remove_free_vars_equal_to_args.cmi : \
+  middle_end/flambda.cmi
+middle_end/remove_unused_arguments.cmo : \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/find_recursive_functions.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/invariant_params.cmi \
+  middle_end/parameter.cmi \
+  middle_end/projection.cmi \
+  middle_end/remove_unused_arguments.cmi \
+  utils/clflags.cmi
+middle_end/remove_unused_arguments.cmx : \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/find_recursive_functions.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/invariant_params.cmx \
+  middle_end/parameter.cmx \
+  middle_end/projection.cmx \
+  middle_end/remove_unused_arguments.cmi \
+  utils/clflags.cmx
+middle_end/remove_unused_arguments.cmi : \
+  middle_end/backend_intf.cmi \
+  middle_end/flambda.cmi
 middle_end/remove_unused_closure_vars.cmo : \
-    middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi middle_end/parameter.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/base_types/closure_id.cmi \
-    middle_end/remove_unused_closure_vars.cmi
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/parameter.cmi \
+  middle_end/remove_unused_closure_vars.cmi
 middle_end/remove_unused_closure_vars.cmx : \
-    middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx middle_end/parameter.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/base_types/closure_id.cmx \
-    middle_end/remove_unused_closure_vars.cmi
-middle_end/remove_unused_closure_vars.cmi : middle_end/flambda.cmi
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/parameter.cmx \
+  middle_end/remove_unused_closure_vars.cmi
+middle_end/remove_unused_closure_vars.cmi : \
+  middle_end/flambda.cmi
 middle_end/remove_unused_program_constructs.cmo : \
-    middle_end/base_types/symbol.cmi utils/misc.cmi middle_end/flambda.cmi \
-    middle_end/effect_analysis.cmi \
-    middle_end/remove_unused_program_constructs.cmi
+  middle_end/base_types/symbol.cmi \
+  middle_end/effect_analysis.cmi \
+  middle_end/flambda.cmi \
+  middle_end/remove_unused_program_constructs.cmi \
+  utils/misc.cmi
 middle_end/remove_unused_program_constructs.cmx : \
-    middle_end/base_types/symbol.cmx utils/misc.cmx middle_end/flambda.cmx \
-    middle_end/effect_analysis.cmx \
-    middle_end/remove_unused_program_constructs.cmi
-middle_end/remove_unused_program_constructs.cmi : middle_end/flambda.cmi
-middle_end/share_constants.cmo : middle_end/base_types/symbol.cmi \
-    middle_end/flambda_iterators.cmi middle_end/flambda.cmi \
-    middle_end/share_constants.cmi
-middle_end/share_constants.cmx : middle_end/base_types/symbol.cmx \
-    middle_end/flambda_iterators.cmx middle_end/flambda.cmx \
-    middle_end/share_constants.cmi
-middle_end/share_constants.cmi : middle_end/flambda.cmi
-middle_end/simple_value_approx.cmo : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    middle_end/base_types/set_of_closures_id.cmi middle_end/parameter.cmi \
-    utils/misc.cmi bytecomp/lambda.cmi middle_end/inlining_cost.cmi \
-    middle_end/freshening.cmi middle_end/flambda_utils.cmi \
-    middle_end/flambda.cmi middle_end/base_types/export_id.cmi \
-    middle_end/effect_analysis.cmi middle_end/base_types/closure_id.cmi \
-    middle_end/allocated_const.cmi middle_end/simple_value_approx.cmi
-middle_end/simple_value_approx.cmx : middle_end/base_types/variable.cmx \
-    middle_end/base_types/var_within_closure.cmx \
-    middle_end/base_types/tag.cmx middle_end/base_types/symbol.cmx \
-    middle_end/base_types/set_of_closures_id.cmx middle_end/parameter.cmx \
-    utils/misc.cmx bytecomp/lambda.cmx middle_end/inlining_cost.cmx \
-    middle_end/freshening.cmx middle_end/flambda_utils.cmx \
-    middle_end/flambda.cmx middle_end/base_types/export_id.cmx \
-    middle_end/effect_analysis.cmx middle_end/base_types/closure_id.cmx \
-    middle_end/allocated_const.cmx middle_end/simple_value_approx.cmi
-middle_end/simple_value_approx.cmi : middle_end/base_types/variable.cmi \
-    middle_end/base_types/var_within_closure.cmi \
-    middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
-    middle_end/base_types/set_of_closures_id.cmi bytecomp/lambda.cmi \
-    middle_end/freshening.cmi middle_end/flambda.cmi \
-    middle_end/base_types/export_id.cmi middle_end/base_types/closure_id.cmi
-middle_end/simplify_boxed_integer_ops.cmo : middle_end/simplify_common.cmi \
-    middle_end/simplify_boxed_integer_ops_intf.cmi \
-    middle_end/simple_value_approx.cmi bytecomp/lambda.cmi \
-    middle_end/inlining_cost.cmi middle_end/simplify_boxed_integer_ops.cmi
-middle_end/simplify_boxed_integer_ops.cmx : middle_end/simplify_common.cmx \
-    middle_end/simplify_boxed_integer_ops_intf.cmi \
-    middle_end/simple_value_approx.cmx bytecomp/lambda.cmx \
-    middle_end/inlining_cost.cmx middle_end/simplify_boxed_integer_ops.cmi
+  middle_end/base_types/symbol.cmx \
+  middle_end/effect_analysis.cmx \
+  middle_end/flambda.cmx \
+  middle_end/remove_unused_program_constructs.cmi \
+  utils/misc.cmx
+middle_end/remove_unused_program_constructs.cmi : \
+  middle_end/flambda.cmi
+middle_end/share_constants.cmo : \
+  middle_end/base_types/symbol.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/share_constants.cmi
+middle_end/share_constants.cmx : \
+  middle_end/base_types/symbol.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/share_constants.cmi
+middle_end/share_constants.cmi : \
+  middle_end/flambda.cmi
+middle_end/simple_value_approx.cmo : \
+  bytecomp/lambda.cmi \
+  middle_end/allocated_const.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/export_id.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/effect_analysis.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/freshening.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/parameter.cmi \
+  middle_end/simple_value_approx.cmi \
+  utils/misc.cmi
+middle_end/simple_value_approx.cmx : \
+  bytecomp/lambda.cmx \
+  middle_end/allocated_const.cmx \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/export_id.cmx \
+  middle_end/base_types/set_of_closures_id.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/tag.cmx \
+  middle_end/base_types/var_within_closure.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/effect_analysis.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/freshening.cmx \
+  middle_end/inlining_cost.cmx \
+  middle_end/parameter.cmx \
+  middle_end/simple_value_approx.cmi \
+  utils/misc.cmx
+middle_end/simple_value_approx.cmi : \
+  bytecomp/lambda.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/export_id.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/base_types/var_within_closure.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/freshening.cmi
+middle_end/simplify_boxed_integer_ops.cmo : \
+  bytecomp/lambda.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/simple_value_approx.cmi \
+  middle_end/simplify_boxed_integer_ops.cmi \
+  middle_end/simplify_boxed_integer_ops_intf.cmi \
+  middle_end/simplify_common.cmi
+middle_end/simplify_boxed_integer_ops.cmx : \
+  bytecomp/lambda.cmx \
+  middle_end/inlining_cost.cmx \
+  middle_end/simple_value_approx.cmx \
+  middle_end/simplify_boxed_integer_ops.cmi \
+  middle_end/simplify_boxed_integer_ops_intf.cmi \
+  middle_end/simplify_common.cmx
 middle_end/simplify_boxed_integer_ops.cmi : \
-    middle_end/simplify_boxed_integer_ops_intf.cmi
+  middle_end/simplify_boxed_integer_ops_intf.cmi
 middle_end/simplify_boxed_integer_ops_intf.cmi : \
-    middle_end/simple_value_approx.cmi bytecomp/lambda.cmi \
-    middle_end/inlining_cost.cmi middle_end/flambda.cmi
-middle_end/simplify_common.cmo : middle_end/simple_value_approx.cmi \
-    bytecomp/lambda.cmi middle_end/inlining_cost.cmi \
-    middle_end/effect_analysis.cmi middle_end/simplify_common.cmi
-middle_end/simplify_common.cmx : middle_end/simple_value_approx.cmx \
-    bytecomp/lambda.cmx middle_end/inlining_cost.cmx \
-    middle_end/effect_analysis.cmx middle_end/simplify_common.cmi
-middle_end/simplify_common.cmi : middle_end/simple_value_approx.cmi \
-    bytecomp/lambda.cmi middle_end/inlining_cost.cmi middle_end/flambda.cmi
-middle_end/simplify_primitives.cmo : middle_end/base_types/tag.cmi \
-    middle_end/base_types/symbol.cmi middle_end/simplify_common.cmi \
-    middle_end/simplify_boxed_integer_ops.cmi \
-    middle_end/simple_value_approx.cmi bytecomp/semantics_of_primitives.cmi \
-    utils/misc.cmi bytecomp/lambda.cmi middle_end/inlining_cost.cmi \
-    middle_end/flambda.cmi utils/clflags.cmi parsing/asttypes.cmi \
-    middle_end/simplify_primitives.cmi
-middle_end/simplify_primitives.cmx : middle_end/base_types/tag.cmx \
-    middle_end/base_types/symbol.cmx middle_end/simplify_common.cmx \
-    middle_end/simplify_boxed_integer_ops.cmx \
-    middle_end/simple_value_approx.cmx bytecomp/semantics_of_primitives.cmx \
-    utils/misc.cmx bytecomp/lambda.cmx middle_end/inlining_cost.cmx \
-    middle_end/flambda.cmx utils/clflags.cmx parsing/asttypes.cmi \
-    middle_end/simplify_primitives.cmi
-middle_end/simplify_primitives.cmi : middle_end/base_types/variable.cmi \
-    middle_end/simple_value_approx.cmi bytecomp/lambda.cmi \
-    middle_end/inlining_cost.cmi middle_end/flambda.cmi \
-    middle_end/debuginfo.cmi
-middle_end/unbox_closures.cmo : middle_end/base_types/variable.cmi \
-    middle_end/inlining_cost.cmi middle_end/inline_and_simplify_aux.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/base_types/closure_id.cmi \
-    utils/clflags.cmi middle_end/augment_specialised_args.cmi \
-    middle_end/unbox_closures.cmi
-middle_end/unbox_closures.cmx : middle_end/base_types/variable.cmx \
-    middle_end/inlining_cost.cmx middle_end/inline_and_simplify_aux.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/base_types/closure_id.cmx \
-    utils/clflags.cmx middle_end/augment_specialised_args.cmx \
-    middle_end/unbox_closures.cmi
-middle_end/unbox_closures.cmi : middle_end/base_types/variable.cmi \
-    middle_end/inlining_cost.cmi middle_end/inline_and_simplify_aux.cmi \
-    middle_end/flambda.cmi
+  bytecomp/lambda.cmi \
+  middle_end/flambda.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/simple_value_approx.cmi
+middle_end/simplify_common.cmo : \
+  bytecomp/lambda.cmi \
+  middle_end/effect_analysis.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/simple_value_approx.cmi \
+  middle_end/simplify_common.cmi
+middle_end/simplify_common.cmx : \
+  bytecomp/lambda.cmx \
+  middle_end/effect_analysis.cmx \
+  middle_end/inlining_cost.cmx \
+  middle_end/simple_value_approx.cmx \
+  middle_end/simplify_common.cmi
+middle_end/simplify_common.cmi : \
+  bytecomp/lambda.cmi \
+  middle_end/flambda.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/simple_value_approx.cmi
+middle_end/simplify_primitives.cmo : \
+  bytecomp/lambda.cmi \
+  bytecomp/semantics_of_primitives.cmi \
+  middle_end/base_types/symbol.cmi \
+  middle_end/base_types/tag.cmi \
+  middle_end/flambda.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/simple_value_approx.cmi \
+  middle_end/simplify_boxed_integer_ops.cmi \
+  middle_end/simplify_common.cmi \
+  middle_end/simplify_primitives.cmi \
+  parsing/asttypes.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+middle_end/simplify_primitives.cmx : \
+  bytecomp/lambda.cmx \
+  bytecomp/semantics_of_primitives.cmx \
+  middle_end/base_types/symbol.cmx \
+  middle_end/base_types/tag.cmx \
+  middle_end/flambda.cmx \
+  middle_end/inlining_cost.cmx \
+  middle_end/simple_value_approx.cmx \
+  middle_end/simplify_boxed_integer_ops.cmx \
+  middle_end/simplify_common.cmx \
+  middle_end/simplify_primitives.cmi \
+  parsing/asttypes.cmi \
+  utils/clflags.cmx \
+  utils/misc.cmx
+middle_end/simplify_primitives.cmi : \
+  bytecomp/lambda.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/debuginfo.cmi \
+  middle_end/flambda.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/simple_value_approx.cmi
+middle_end/unbox_closures.cmo : \
+  middle_end/augment_specialised_args.cmi \
+  middle_end/base_types/closure_id.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/unbox_closures.cmi \
+  utils/clflags.cmi
+middle_end/unbox_closures.cmx : \
+  middle_end/augment_specialised_args.cmx \
+  middle_end/base_types/closure_id.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/inline_and_simplify_aux.cmx \
+  middle_end/inlining_cost.cmx \
+  middle_end/unbox_closures.cmi \
+  utils/clflags.cmx
+middle_end/unbox_closures.cmi : \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/inlining_cost.cmi
 middle_end/unbox_free_vars_of_closures.cmo : \
-    middle_end/base_types/variable.cmi middle_end/projection.cmi \
-    middle_end/pass_wrapper.cmi utils/misc.cmi middle_end/inlining_cost.cmi \
-    middle_end/flambda_utils.cmi middle_end/flambda_iterators.cmi \
-    middle_end/flambda.cmi middle_end/extract_projections.cmi \
-    utils/clflags.cmi middle_end/unbox_free_vars_of_closures.cmi
+  middle_end/base_types/variable.cmi \
+  middle_end/extract_projections.cmi \
+  middle_end/flambda.cmi \
+  middle_end/flambda_iterators.cmi \
+  middle_end/flambda_utils.cmi \
+  middle_end/inlining_cost.cmi \
+  middle_end/pass_wrapper.cmi \
+  middle_end/projection.cmi \
+  middle_end/unbox_free_vars_of_closures.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
 middle_end/unbox_free_vars_of_closures.cmx : \
-    middle_end/base_types/variable.cmx middle_end/projection.cmx \
-    middle_end/pass_wrapper.cmx utils/misc.cmx middle_end/inlining_cost.cmx \
-    middle_end/flambda_utils.cmx middle_end/flambda_iterators.cmx \
-    middle_end/flambda.cmx middle_end/extract_projections.cmx \
-    utils/clflags.cmx middle_end/unbox_free_vars_of_closures.cmi
-middle_end/unbox_free_vars_of_closures.cmi : middle_end/inlining_cost.cmi \
-    middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi
-middle_end/unbox_specialised_args.cmo : middle_end/base_types/variable.cmi \
-    middle_end/projection.cmi middle_end/invariant_params.cmi \
-    middle_end/inline_and_simplify_aux.cmi middle_end/flambda.cmi \
-    middle_end/extract_projections.cmi utils/clflags.cmi \
-    middle_end/augment_specialised_args.cmi \
-    middle_end/unbox_specialised_args.cmi
-middle_end/unbox_specialised_args.cmx : middle_end/base_types/variable.cmx \
-    middle_end/projection.cmx middle_end/invariant_params.cmx \
-    middle_end/inline_and_simplify_aux.cmx middle_end/flambda.cmx \
-    middle_end/extract_projections.cmx utils/clflags.cmx \
-    middle_end/augment_specialised_args.cmx \
-    middle_end/unbox_specialised_args.cmi
-middle_end/unbox_specialised_args.cmi : middle_end/base_types/variable.cmi \
-    middle_end/inlining_cost.cmi middle_end/inline_and_simplify_aux.cmi \
-    middle_end/flambda.cmi
+  middle_end/base_types/variable.cmx \
+  middle_end/extract_projections.cmx \
+  middle_end/flambda.cmx \
+  middle_end/flambda_iterators.cmx \
+  middle_end/flambda_utils.cmx \
+  middle_end/inlining_cost.cmx \
+  middle_end/pass_wrapper.cmx \
+  middle_end/projection.cmx \
+  middle_end/unbox_free_vars_of_closures.cmi \
+  utils/clflags.cmx \
+  utils/misc.cmx
+middle_end/unbox_free_vars_of_closures.cmi : \
+  middle_end/flambda.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/inlining_cost.cmi
+middle_end/unbox_specialised_args.cmo : \
+  middle_end/augment_specialised_args.cmi \
+  middle_end/base_types/variable.cmi \
+  middle_end/extract_projections.cmi \
+  middle_end/flambda.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/invariant_params.cmi \
+  middle_end/projection.cmi \
+  middle_end/unbox_specialised_args.cmi \
+  utils/clflags.cmi
+middle_end/unbox_specialised_args.cmx : \
+  middle_end/augment_specialised_args.cmx \
+  middle_end/base_types/variable.cmx \
+  middle_end/extract_projections.cmx \
+  middle_end/flambda.cmx \
+  middle_end/inline_and_simplify_aux.cmx \
+  middle_end/invariant_params.cmx \
+  middle_end/projection.cmx \
+  middle_end/unbox_specialised_args.cmi \
+  utils/clflags.cmx
+middle_end/unbox_specialised_args.cmi : \
+  middle_end/base_types/variable.cmi \
+  middle_end/flambda.cmi \
+  middle_end/inline_and_simplify_aux.cmi \
+  middle_end/inlining_cost.cmi
 middle_end/base_types/closure_element.cmo : \
-    middle_end/base_types/variable.cmi \
-    middle_end/base_types/closure_element.cmi
+  middle_end/base_types/closure_element.cmi \
+  middle_end/base_types/variable.cmi
 middle_end/base_types/closure_element.cmx : \
-    middle_end/base_types/variable.cmx \
-    middle_end/base_types/closure_element.cmi
+  middle_end/base_types/closure_element.cmi \
+  middle_end/base_types/variable.cmx
 middle_end/base_types/closure_element.cmi : \
-    middle_end/base_types/variable.cmi utils/identifiable.cmi \
-    middle_end/base_types/compilation_unit.cmi
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/variable.cmi \
+  utils/identifiable.cmi
 middle_end/base_types/closure_id.cmo : \
-    middle_end/base_types/closure_element.cmi \
-    middle_end/base_types/closure_id.cmi
+  middle_end/base_types/closure_element.cmi \
+  middle_end/base_types/closure_id.cmi
 middle_end/base_types/closure_id.cmx : \
-    middle_end/base_types/closure_element.cmx \
-    middle_end/base_types/closure_id.cmi
+  middle_end/base_types/closure_element.cmx \
+  middle_end/base_types/closure_id.cmi
 middle_end/base_types/closure_id.cmi : \
-    middle_end/base_types/closure_element.cmi
-middle_end/base_types/compilation_unit.cmo : utils/misc.cmi \
-    middle_end/base_types/linkage_name.cmi utils/identifiable.cmi \
-    typing/ident.cmi middle_end/base_types/compilation_unit.cmi
-middle_end/base_types/compilation_unit.cmx : utils/misc.cmx \
-    middle_end/base_types/linkage_name.cmx utils/identifiable.cmx \
-    typing/ident.cmx middle_end/base_types/compilation_unit.cmi
+  middle_end/base_types/closure_element.cmi
+middle_end/base_types/compilation_unit.cmo : \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/linkage_name.cmi \
+  typing/ident.cmi \
+  utils/identifiable.cmi \
+  utils/misc.cmi
+middle_end/base_types/compilation_unit.cmx : \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/linkage_name.cmx \
+  typing/ident.cmx \
+  utils/identifiable.cmx \
+  utils/misc.cmx
 middle_end/base_types/compilation_unit.cmi : \
-    middle_end/base_types/linkage_name.cmi utils/identifiable.cmi \
-    typing/ident.cmi
-middle_end/base_types/export_id.cmo : utils/identifiable.cmi \
-    middle_end/base_types/id_types.cmi \
-    middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/export_id.cmi
-middle_end/base_types/export_id.cmx : utils/identifiable.cmx \
-    middle_end/base_types/id_types.cmx \
-    middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/export_id.cmi
-middle_end/base_types/export_id.cmi : utils/identifiable.cmi \
-    middle_end/base_types/compilation_unit.cmi
-middle_end/base_types/id_types.cmo : utils/identifiable.cmi \
-    middle_end/base_types/id_types.cmi
-middle_end/base_types/id_types.cmx : utils/identifiable.cmx \
-    middle_end/base_types/id_types.cmi
-middle_end/base_types/id_types.cmi : utils/identifiable.cmi
-middle_end/base_types/linkage_name.cmo : utils/identifiable.cmi \
-    middle_end/base_types/linkage_name.cmi
-middle_end/base_types/linkage_name.cmx : utils/identifiable.cmx \
-    middle_end/base_types/linkage_name.cmi
-middle_end/base_types/linkage_name.cmi : utils/identifiable.cmi
-middle_end/base_types/mutable_variable.cmo : utils/identifiable.cmi \
-    typing/ident.cmi middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/mutable_variable.cmi
-middle_end/base_types/mutable_variable.cmx : utils/identifiable.cmx \
-    typing/ident.cmx middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/mutable_variable.cmi
-middle_end/base_types/mutable_variable.cmi : utils/identifiable.cmi \
-    typing/ident.cmi middle_end/base_types/compilation_unit.cmi
-middle_end/base_types/set_of_closures_id.cmo : utils/identifiable.cmi \
-    middle_end/base_types/id_types.cmi \
-    middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/set_of_closures_id.cmi
-middle_end/base_types/set_of_closures_id.cmx : utils/identifiable.cmx \
-    middle_end/base_types/id_types.cmx \
-    middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/set_of_closures_id.cmi
-middle_end/base_types/set_of_closures_id.cmi : utils/identifiable.cmi \
-    middle_end/base_types/compilation_unit.cmi
+  middle_end/base_types/linkage_name.cmi \
+  typing/ident.cmi \
+  utils/identifiable.cmi
+middle_end/base_types/export_id.cmo : \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/export_id.cmi \
+  middle_end/base_types/id_types.cmi \
+  utils/identifiable.cmi
+middle_end/base_types/export_id.cmx : \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/export_id.cmi \
+  middle_end/base_types/id_types.cmx \
+  utils/identifiable.cmx
+middle_end/base_types/export_id.cmi : \
+  middle_end/base_types/compilation_unit.cmi \
+  utils/identifiable.cmi
+middle_end/base_types/id_types.cmo : \
+  middle_end/base_types/id_types.cmi \
+  utils/identifiable.cmi
+middle_end/base_types/id_types.cmx : \
+  middle_end/base_types/id_types.cmi \
+  utils/identifiable.cmx
+middle_end/base_types/id_types.cmi : \
+  utils/identifiable.cmi
+middle_end/base_types/linkage_name.cmo : \
+  middle_end/base_types/linkage_name.cmi \
+  utils/identifiable.cmi
+middle_end/base_types/linkage_name.cmx : \
+  middle_end/base_types/linkage_name.cmi \
+  utils/identifiable.cmx
+middle_end/base_types/linkage_name.cmi : \
+  utils/identifiable.cmi
+middle_end/base_types/mutable_variable.cmo : \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/mutable_variable.cmi \
+  typing/ident.cmi \
+  utils/identifiable.cmi
+middle_end/base_types/mutable_variable.cmx : \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/mutable_variable.cmi \
+  typing/ident.cmx \
+  utils/identifiable.cmx
+middle_end/base_types/mutable_variable.cmi : \
+  middle_end/base_types/compilation_unit.cmi \
+  typing/ident.cmi \
+  utils/identifiable.cmi
+middle_end/base_types/set_of_closures_id.cmo : \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/id_types.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  utils/identifiable.cmi
+middle_end/base_types/set_of_closures_id.cmx : \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/id_types.cmx \
+  middle_end/base_types/set_of_closures_id.cmi \
+  utils/identifiable.cmx
+middle_end/base_types/set_of_closures_id.cmi : \
+  middle_end/base_types/compilation_unit.cmi \
+  utils/identifiable.cmi
 middle_end/base_types/set_of_closures_origin.cmo : \
-    middle_end/base_types/set_of_closures_id.cmi \
-    middle_end/base_types/set_of_closures_origin.cmi
+  middle_end/base_types/set_of_closures_id.cmi \
+  middle_end/base_types/set_of_closures_origin.cmi
 middle_end/base_types/set_of_closures_origin.cmx : \
-    middle_end/base_types/set_of_closures_id.cmx \
-    middle_end/base_types/set_of_closures_origin.cmi
+  middle_end/base_types/set_of_closures_id.cmx \
+  middle_end/base_types/set_of_closures_origin.cmi
 middle_end/base_types/set_of_closures_origin.cmi : \
-    middle_end/base_types/set_of_closures_id.cmi utils/identifiable.cmi \
-    middle_end/base_types/compilation_unit.cmi
-middle_end/base_types/static_exception.cmo : utils/numbers.cmi \
-    bytecomp/lambda.cmi middle_end/base_types/static_exception.cmi
-middle_end/base_types/static_exception.cmx : utils/numbers.cmx \
-    bytecomp/lambda.cmx middle_end/base_types/static_exception.cmi
-middle_end/base_types/static_exception.cmi : utils/identifiable.cmi
-middle_end/base_types/symbol.cmo : utils/misc.cmi \
-    middle_end/base_types/linkage_name.cmi utils/identifiable.cmi \
-    middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/symbol.cmi
-middle_end/base_types/symbol.cmx : utils/misc.cmx \
-    middle_end/base_types/linkage_name.cmx utils/identifiable.cmx \
-    middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/symbol.cmi
-middle_end/base_types/symbol.cmi : middle_end/base_types/linkage_name.cmi \
-    utils/identifiable.cmi middle_end/base_types/compilation_unit.cmi
-middle_end/base_types/tag.cmo : utils/numbers.cmi utils/misc.cmi \
-    utils/identifiable.cmi middle_end/base_types/tag.cmi
-middle_end/base_types/tag.cmx : utils/numbers.cmx utils/misc.cmx \
-    utils/identifiable.cmx middle_end/base_types/tag.cmi
-middle_end/base_types/tag.cmi : utils/identifiable.cmi
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/set_of_closures_id.cmi \
+  utils/identifiable.cmi
+middle_end/base_types/static_exception.cmo : \
+  bytecomp/lambda.cmi \
+  middle_end/base_types/static_exception.cmi \
+  utils/numbers.cmi
+middle_end/base_types/static_exception.cmx : \
+  bytecomp/lambda.cmx \
+  middle_end/base_types/static_exception.cmi \
+  utils/numbers.cmx
+middle_end/base_types/static_exception.cmi : \
+  utils/identifiable.cmi
+middle_end/base_types/symbol.cmo : \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/linkage_name.cmi \
+  middle_end/base_types/symbol.cmi \
+  utils/identifiable.cmi \
+  utils/misc.cmi
+middle_end/base_types/symbol.cmx : \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/linkage_name.cmx \
+  middle_end/base_types/symbol.cmi \
+  utils/identifiable.cmx \
+  utils/misc.cmx
+middle_end/base_types/symbol.cmi : \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/linkage_name.cmi \
+  utils/identifiable.cmi
+middle_end/base_types/tag.cmo : \
+  middle_end/base_types/tag.cmi \
+  utils/identifiable.cmi \
+  utils/misc.cmi \
+  utils/numbers.cmi
+middle_end/base_types/tag.cmx : \
+  middle_end/base_types/tag.cmi \
+  utils/identifiable.cmx \
+  utils/misc.cmx \
+  utils/numbers.cmx
+middle_end/base_types/tag.cmi : \
+  utils/identifiable.cmi
 middle_end/base_types/var_within_closure.cmo : \
-    middle_end/base_types/closure_element.cmi \
-    middle_end/base_types/var_within_closure.cmi
+  middle_end/base_types/closure_element.cmi \
+  middle_end/base_types/var_within_closure.cmi
 middle_end/base_types/var_within_closure.cmx : \
-    middle_end/base_types/closure_element.cmx \
-    middle_end/base_types/var_within_closure.cmi
+  middle_end/base_types/closure_element.cmx \
+  middle_end/base_types/var_within_closure.cmi
 middle_end/base_types/var_within_closure.cmi : \
-    middle_end/base_types/closure_element.cmi
-middle_end/base_types/variable.cmo : utils/misc.cmi utils/identifiable.cmi \
-    typing/ident.cmi middle_end/base_types/compilation_unit.cmi \
-    middle_end/base_types/variable.cmi
-middle_end/base_types/variable.cmx : utils/misc.cmx utils/identifiable.cmx \
-    typing/ident.cmx middle_end/base_types/compilation_unit.cmx \
-    middle_end/base_types/variable.cmi
-middle_end/base_types/variable.cmi : utils/identifiable.cmi typing/ident.cmi \
-    middle_end/base_types/compilation_unit.cmi
-asmcomp/debug/available_regs.cmo : asmcomp/debug/reg_with_debug_info.cmi \
-    asmcomp/debug/reg_availability_set.cmi asmcomp/reg.cmi asmcomp/proc.cmi \
-    asmcomp/printmach.cmi utils/misc.cmi asmcomp/mach.cmi typing/ident.cmi \
-    utils/clflags.cmi asmcomp/debug/available_regs.cmi
-asmcomp/debug/available_regs.cmx : asmcomp/debug/reg_with_debug_info.cmx \
-    asmcomp/debug/reg_availability_set.cmx asmcomp/reg.cmx asmcomp/proc.cmx \
-    asmcomp/printmach.cmx utils/misc.cmx asmcomp/mach.cmx typing/ident.cmx \
-    utils/clflags.cmx asmcomp/debug/available_regs.cmi
-asmcomp/debug/available_regs.cmi : asmcomp/mach.cmi
+  middle_end/base_types/closure_element.cmi
+middle_end/base_types/variable.cmo : \
+  middle_end/base_types/compilation_unit.cmi \
+  middle_end/base_types/variable.cmi \
+  typing/ident.cmi \
+  utils/identifiable.cmi \
+  utils/misc.cmi
+middle_end/base_types/variable.cmx : \
+  middle_end/base_types/compilation_unit.cmx \
+  middle_end/base_types/variable.cmi \
+  typing/ident.cmx \
+  utils/identifiable.cmx \
+  utils/misc.cmx
+middle_end/base_types/variable.cmi : \
+  middle_end/base_types/compilation_unit.cmi \
+  typing/ident.cmi \
+  utils/identifiable.cmi
+asmcomp/debug/available_regs.cmo : \
+  asmcomp/debug/available_regs.cmi \
+  asmcomp/debug/reg_availability_set.cmi \
+  asmcomp/debug/reg_with_debug_info.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/printmach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi \
+  typing/ident.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi
+asmcomp/debug/available_regs.cmx : \
+  asmcomp/debug/available_regs.cmi \
+  asmcomp/debug/reg_availability_set.cmx \
+  asmcomp/debug/reg_with_debug_info.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/printmach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx \
+  typing/ident.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx
+asmcomp/debug/available_regs.cmi : \
+  asmcomp/mach.cmi
 asmcomp/debug/reg_availability_set.cmo : \
-    asmcomp/debug/reg_with_debug_info.cmi typing/ident.cmi \
-    asmcomp/debug/reg_availability_set.cmi
+  asmcomp/debug/reg_availability_set.cmi \
+  asmcomp/debug/reg_with_debug_info.cmi \
+  typing/ident.cmi
 asmcomp/debug/reg_availability_set.cmx : \
-    asmcomp/debug/reg_with_debug_info.cmx typing/ident.cmx \
-    asmcomp/debug/reg_availability_set.cmi
+  asmcomp/debug/reg_availability_set.cmi \
+  asmcomp/debug/reg_with_debug_info.cmx \
+  typing/ident.cmx
 asmcomp/debug/reg_availability_set.cmi : \
-    asmcomp/debug/reg_with_debug_info.cmi asmcomp/reg.cmi
-asmcomp/debug/reg_with_debug_info.cmo : asmcomp/reg.cmi typing/ident.cmi \
-    asmcomp/debug/reg_with_debug_info.cmi
-asmcomp/debug/reg_with_debug_info.cmx : asmcomp/reg.cmx typing/ident.cmx \
-    asmcomp/debug/reg_with_debug_info.cmi
-asmcomp/debug/reg_with_debug_info.cmi : asmcomp/reg.cmi typing/ident.cmi
+  asmcomp/debug/reg_with_debug_info.cmi \
+  asmcomp/reg.cmi
+asmcomp/debug/reg_with_debug_info.cmo : \
+  asmcomp/debug/reg_with_debug_info.cmi \
+  asmcomp/reg.cmi \
+  typing/ident.cmi
+asmcomp/debug/reg_with_debug_info.cmx : \
+  asmcomp/debug/reg_with_debug_info.cmi \
+  asmcomp/reg.cmx \
+  typing/ident.cmx
+asmcomp/debug/reg_with_debug_info.cmi : \
+  asmcomp/reg.cmi \
+  typing/ident.cmi
 driver/compdynlink.cmi :
-driver/compenv.cmo : utils/warnings.cmi utils/profile.cmi utils/misc.cmi \
-    parsing/location.cmi utils/config.cmi utils/clflags.cmi utils/ccomp.cmi \
-    driver/compenv.cmi
-driver/compenv.cmx : utils/warnings.cmx utils/profile.cmx utils/misc.cmx \
-    parsing/location.cmx utils/config.cmx utils/clflags.cmx utils/ccomp.cmx \
-    driver/compenv.cmi
+driver/compenv.cmo : \
+  driver/compenv.cmi \
+  parsing/location.cmi \
+  utils/ccomp.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/profile.cmi \
+  utils/warnings.cmi
+driver/compenv.cmx : \
+  driver/compenv.cmi \
+  parsing/location.cmx \
+  utils/ccomp.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/profile.cmx \
+  utils/warnings.cmx
 driver/compenv.cmi :
-driver/compile.cmo : utils/warnings.cmi typing/typemod.cmi \
-    typing/typedtree.cmi typing/typecore.cmi bytecomp/translmod.cmi \
-    typing/stypes.cmi bytecomp/simplif.cmi utils/profile.cmi \
-    typing/printtyped.cmi typing/printtyp.cmi bytecomp/printlambda.cmi \
-    bytecomp/printinstr.cmi parsing/printast.cmi parsing/pprintast.cmi \
-    driver/pparse.cmi utils/misc.cmi bytecomp/lambda.cmi \
-    typing/includemod.cmi typing/env.cmi bytecomp/emitcode.cmi \
-    driver/compmisc.cmi driver/compenv.cmi utils/clflags.cmi \
-    bytecomp/bytegen.cmi parsing/builtin_attributes.cmi driver/compile.cmi
-driver/compile.cmx : utils/warnings.cmx typing/typemod.cmx \
-    typing/typedtree.cmx typing/typecore.cmx bytecomp/translmod.cmx \
-    typing/stypes.cmx bytecomp/simplif.cmx utils/profile.cmx \
-    typing/printtyped.cmx typing/printtyp.cmx bytecomp/printlambda.cmx \
-    bytecomp/printinstr.cmx parsing/printast.cmx parsing/pprintast.cmx \
-    driver/pparse.cmx utils/misc.cmx bytecomp/lambda.cmx \
-    typing/includemod.cmx typing/env.cmx bytecomp/emitcode.cmx \
-    driver/compmisc.cmx driver/compenv.cmx utils/clflags.cmx \
-    bytecomp/bytegen.cmx parsing/builtin_attributes.cmx driver/compile.cmi
+driver/compile.cmo : \
+  bytecomp/bytegen.cmi \
+  bytecomp/emitcode.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/printinstr.cmi \
+  bytecomp/printlambda.cmi \
+  bytecomp/simplif.cmi \
+  bytecomp/translmod.cmi \
+  driver/compenv.cmi \
+  driver/compile.cmi \
+  driver/compmisc.cmi \
+  driver/pparse.cmi \
+  parsing/builtin_attributes.cmi \
+  parsing/pprintast.cmi \
+  parsing/printast.cmi \
+  typing/env.cmi \
+  typing/includemod.cmi \
+  typing/printtyp.cmi \
+  typing/printtyped.cmi \
+  typing/stypes.cmi \
+  typing/typecore.cmi \
+  typing/typedtree.cmi \
+  typing/typemod.cmi \
+  utils/clflags.cmi \
+  utils/misc.cmi \
+  utils/profile.cmi \
+  utils/warnings.cmi
+driver/compile.cmx : \
+  bytecomp/bytegen.cmx \
+  bytecomp/emitcode.cmx \
+  bytecomp/lambda.cmx \
+  bytecomp/printinstr.cmx \
+  bytecomp/printlambda.cmx \
+  bytecomp/simplif.cmx \
+  bytecomp/translmod.cmx \
+  driver/compenv.cmx \
+  driver/compile.cmi \
+  driver/compmisc.cmx \
+  driver/pparse.cmx \
+  parsing/builtin_attributes.cmx \
+  parsing/pprintast.cmx \
+  parsing/printast.cmx \
+  typing/env.cmx \
+  typing/includemod.cmx \
+  typing/printtyp.cmx \
+  typing/printtyped.cmx \
+  typing/stypes.cmx \
+  typing/typecore.cmx \
+  typing/typedtree.cmx \
+  typing/typemod.cmx \
+  utils/clflags.cmx \
+  utils/misc.cmx \
+  utils/profile.cmx \
+  utils/warnings.cmx
 driver/compile.cmi :
-driver/compmisc.cmo : utils/warnings.cmi typing/typemod.cmi utils/misc.cmi \
-    parsing/longident.cmi parsing/location.cmi typing/ident.cmi \
-    typing/env.cmi utils/config.cmi driver/compenv.cmi utils/clflags.cmi \
-    parsing/asttypes.cmi driver/compmisc.cmi
-driver/compmisc.cmx : utils/warnings.cmx typing/typemod.cmx utils/misc.cmx \
-    parsing/longident.cmx parsing/location.cmx typing/ident.cmx \
-    typing/env.cmx utils/config.cmx driver/compenv.cmx utils/clflags.cmx \
-    parsing/asttypes.cmi driver/compmisc.cmi
-driver/compmisc.cmi : typing/env.cmi
-driver/compplugin.cmo : utils/misc.cmi parsing/location.cmi utils/config.cmi \
-    driver/compmisc.cmi driver/compenv.cmi driver/compdynlink.cmi \
-    utils/clflags.cmi driver/compplugin.cmi
-driver/compplugin.cmx : utils/misc.cmx parsing/location.cmx utils/config.cmx \
-    driver/compmisc.cmx driver/compenv.cmx driver/compdynlink.cmi \
-    utils/clflags.cmx driver/compplugin.cmi
+driver/compmisc.cmo : \
+  driver/compenv.cmi \
+  driver/compmisc.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/typemod.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+driver/compmisc.cmx : \
+  driver/compenv.cmx \
+  driver/compmisc.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/typemod.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+driver/compmisc.cmi : \
+  typing/env.cmi
+driver/compplugin.cmo : \
+  driver/compdynlink.cmi \
+  driver/compenv.cmi \
+  driver/compmisc.cmi \
+  driver/compplugin.cmi \
+  parsing/location.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+driver/compplugin.cmx : \
+  driver/compdynlink.cmi \
+  driver/compenv.cmx \
+  driver/compmisc.cmx \
+  driver/compplugin.cmi \
+  parsing/location.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
 driver/compplugin.cmi :
-driver/errors.cmo : parsing/location.cmi driver/errors.cmi
-driver/errors.cmx : parsing/location.cmx driver/errors.cmi
+driver/errors.cmo : \
+  driver/errors.cmi \
+  parsing/location.cmi
+driver/errors.cmx : \
+  driver/errors.cmi \
+  parsing/location.cmx
 driver/errors.cmi :
-driver/main.cmo : utils/warnings.cmi utils/profile.cmi utils/misc.cmi \
-    driver/makedepend.cmi driver/main_args.cmi parsing/location.cmi \
-    utils/config.cmi driver/compplugin.cmi driver/compmisc.cmi \
-    driver/compile.cmi driver/compenv.cmi utils/clflags.cmi \
-    bytecomp/bytepackager.cmi bytecomp/bytelink.cmi \
-    bytecomp/bytelibrarian.cmi driver/main.cmi
-driver/main.cmx : utils/warnings.cmx utils/profile.cmx utils/misc.cmx \
-    driver/makedepend.cmx driver/main_args.cmx parsing/location.cmx \
-    utils/config.cmx driver/compplugin.cmx driver/compmisc.cmx \
-    driver/compile.cmx driver/compenv.cmx utils/clflags.cmx \
-    bytecomp/bytepackager.cmx bytecomp/bytelink.cmx \
-    bytecomp/bytelibrarian.cmx driver/main.cmi
+driver/main.cmo : \
+  bytecomp/bytelibrarian.cmi \
+  bytecomp/bytelink.cmi \
+  bytecomp/bytepackager.cmi \
+  driver/compenv.cmi \
+  driver/compile.cmi \
+  driver/compmisc.cmi \
+  driver/compplugin.cmi \
+  driver/main.cmi \
+  driver/main_args.cmi \
+  driver/makedepend.cmi \
+  parsing/location.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/profile.cmi \
+  utils/warnings.cmi
+driver/main.cmx : \
+  bytecomp/bytelibrarian.cmx \
+  bytecomp/bytelink.cmx \
+  bytecomp/bytepackager.cmx \
+  driver/compenv.cmx \
+  driver/compile.cmx \
+  driver/compmisc.cmx \
+  driver/compplugin.cmx \
+  driver/main.cmi \
+  driver/main_args.cmx \
+  driver/makedepend.cmx \
+  parsing/location.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/profile.cmx \
+  utils/warnings.cmx
 driver/main.cmi :
-driver/main_args.cmo : utils/warnings.cmi utils/profile.cmi utils/config.cmi \
-    utils/clflags.cmi driver/main_args.cmi
-driver/main_args.cmx : utils/warnings.cmx utils/profile.cmx utils/config.cmx \
-    utils/clflags.cmx driver/main_args.cmi
+driver/main_args.cmo : \
+  driver/main_args.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/profile.cmi \
+  utils/warnings.cmi
+driver/main_args.cmx : \
+  driver/main_args.cmi \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/profile.cmx \
+  utils/warnings.cmx
 driver/main_args.cmi :
-driver/makedepend.cmo : driver/pparse.cmi parsing/parsetree.cmi \
-    parsing/parser.cmi parsing/parse.cmi utils/misc.cmi parsing/longident.cmi \
-    parsing/location.cmi parsing/lexer.cmi parsing/depend.cmi \
-    utils/config.cmi driver/compplugin.cmi driver/compenv.cmi \
-    utils/clflags.cmi driver/makedepend.cmi
-driver/makedepend.cmx : driver/pparse.cmx parsing/parsetree.cmi \
-    parsing/parser.cmx parsing/parse.cmx utils/misc.cmx parsing/longident.cmx \
-    parsing/location.cmx parsing/lexer.cmx parsing/depend.cmx \
-    utils/config.cmx driver/compplugin.cmx driver/compenv.cmx \
-    utils/clflags.cmx driver/makedepend.cmi
+driver/makedepend.cmo : \
+  driver/compenv.cmi \
+  driver/compplugin.cmi \
+  driver/makedepend.cmi \
+  driver/pparse.cmi \
+  parsing/depend.cmi \
+  parsing/lexer.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parse.cmi \
+  parsing/parser.cmi \
+  parsing/parsetree.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+driver/makedepend.cmx : \
+  driver/compenv.cmx \
+  driver/compplugin.cmx \
+  driver/makedepend.cmi \
+  driver/pparse.cmx \
+  parsing/depend.cmx \
+  parsing/lexer.cmx \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parse.cmx \
+  parsing/parser.cmx \
+  parsing/parsetree.cmi \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
 driver/makedepend.cmi :
-driver/optcompile.cmo : utils/warnings.cmi typing/typemod.cmi \
-    typing/typedtree.cmi typing/typecore.cmi bytecomp/translmod.cmi \
-    typing/stypes.cmi bytecomp/simplif.cmi utils/profile.cmi \
-    typing/printtyped.cmi typing/printtyp.cmi bytecomp/printlambda.cmi \
-    parsing/printast.cmi parsing/pprintast.cmi driver/pparse.cmi \
-    utils/misc.cmi middle_end/middle_end.cmi bytecomp/lambda.cmi \
-    typing/includemod.cmi typing/env.cmi utils/config.cmi driver/compmisc.cmi \
-    asmcomp/compilenv.cmi driver/compenv.cmi utils/clflags.cmi \
-    parsing/builtin_attributes.cmi asmcomp/asmgen.cmi driver/optcompile.cmi
-driver/optcompile.cmx : utils/warnings.cmx typing/typemod.cmx \
-    typing/typedtree.cmx typing/typecore.cmx bytecomp/translmod.cmx \
-    typing/stypes.cmx bytecomp/simplif.cmx utils/profile.cmx \
-    typing/printtyped.cmx typing/printtyp.cmx bytecomp/printlambda.cmx \
-    parsing/printast.cmx parsing/pprintast.cmx driver/pparse.cmx \
-    utils/misc.cmx middle_end/middle_end.cmx bytecomp/lambda.cmx \
-    typing/includemod.cmx typing/env.cmx utils/config.cmx driver/compmisc.cmx \
-    asmcomp/compilenv.cmx driver/compenv.cmx utils/clflags.cmx \
-    parsing/builtin_attributes.cmx asmcomp/asmgen.cmx driver/optcompile.cmi
-driver/optcompile.cmi : middle_end/backend_intf.cmi
-driver/opterrors.cmo : parsing/location.cmi driver/opterrors.cmi
-driver/opterrors.cmx : parsing/location.cmx driver/opterrors.cmi
+driver/optcompile.cmo : \
+  asmcomp/asmgen.cmi \
+  asmcomp/compilenv.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/printlambda.cmi \
+  bytecomp/simplif.cmi \
+  bytecomp/translmod.cmi \
+  driver/compenv.cmi \
+  driver/compmisc.cmi \
+  driver/optcompile.cmi \
+  driver/pparse.cmi \
+  middle_end/middle_end.cmi \
+  parsing/builtin_attributes.cmi \
+  parsing/pprintast.cmi \
+  parsing/printast.cmi \
+  typing/env.cmi \
+  typing/includemod.cmi \
+  typing/printtyp.cmi \
+  typing/printtyped.cmi \
+  typing/stypes.cmi \
+  typing/typecore.cmi \
+  typing/typedtree.cmi \
+  typing/typemod.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/profile.cmi \
+  utils/warnings.cmi
+driver/optcompile.cmx : \
+  asmcomp/asmgen.cmx \
+  asmcomp/compilenv.cmx \
+  bytecomp/lambda.cmx \
+  bytecomp/printlambda.cmx \
+  bytecomp/simplif.cmx \
+  bytecomp/translmod.cmx \
+  driver/compenv.cmx \
+  driver/compmisc.cmx \
+  driver/optcompile.cmi \
+  driver/pparse.cmx \
+  middle_end/middle_end.cmx \
+  parsing/builtin_attributes.cmx \
+  parsing/pprintast.cmx \
+  parsing/printast.cmx \
+  typing/env.cmx \
+  typing/includemod.cmx \
+  typing/printtyp.cmx \
+  typing/printtyped.cmx \
+  typing/stypes.cmx \
+  typing/typecore.cmx \
+  typing/typedtree.cmx \
+  typing/typemod.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/profile.cmx \
+  utils/warnings.cmx
+driver/optcompile.cmi : \
+  middle_end/backend_intf.cmi
+driver/opterrors.cmo : \
+  driver/opterrors.cmi \
+  parsing/location.cmi
+driver/opterrors.cmx : \
+  driver/opterrors.cmi \
+  parsing/location.cmx
 driver/opterrors.cmi :
-driver/optmain.cmo : utils/warnings.cmi utils/profile.cmi asmcomp/proc.cmi \
-    asmcomp/printmach.cmi driver/optcompile.cmi utils/misc.cmi \
-    driver/makedepend.cmi driver/main_args.cmi parsing/location.cmi \
-    asmcomp/import_approx.cmi utils/config.cmi driver/compplugin.cmi \
-    driver/compmisc.cmi asmcomp/compilenv.cmi driver/compenv.cmi \
-    utils/clflags.cmi middle_end/backend_intf.cmi asmcomp/asmpackager.cmi \
-    asmcomp/asmlink.cmi asmcomp/asmlibrarian.cmi asmcomp/arch.cmo \
-    driver/optmain.cmi
-driver/optmain.cmx : utils/warnings.cmx utils/profile.cmx asmcomp/proc.cmx \
-    asmcomp/printmach.cmx driver/optcompile.cmx utils/misc.cmx \
-    driver/makedepend.cmx driver/main_args.cmx parsing/location.cmx \
-    asmcomp/import_approx.cmx utils/config.cmx driver/compplugin.cmx \
-    driver/compmisc.cmx asmcomp/compilenv.cmx driver/compenv.cmx \
-    utils/clflags.cmx middle_end/backend_intf.cmi asmcomp/asmpackager.cmx \
-    asmcomp/asmlink.cmx asmcomp/asmlibrarian.cmx asmcomp/arch.cmx \
-    driver/optmain.cmi
+driver/optmain.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/asmlibrarian.cmi \
+  asmcomp/asmlink.cmi \
+  asmcomp/asmpackager.cmi \
+  asmcomp/compilenv.cmi \
+  asmcomp/import_approx.cmi \
+  asmcomp/printmach.cmi \
+  asmcomp/proc.cmi \
+  driver/compenv.cmi \
+  driver/compmisc.cmi \
+  driver/compplugin.cmi \
+  driver/main_args.cmi \
+  driver/makedepend.cmi \
+  driver/optcompile.cmi \
+  driver/optmain.cmi \
+  middle_end/backend_intf.cmi \
+  parsing/location.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/profile.cmi \
+  utils/warnings.cmi
+driver/optmain.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/asmlibrarian.cmx \
+  asmcomp/asmlink.cmx \
+  asmcomp/asmpackager.cmx \
+  asmcomp/compilenv.cmx \
+  asmcomp/import_approx.cmx \
+  asmcomp/printmach.cmx \
+  asmcomp/proc.cmx \
+  driver/compenv.cmx \
+  driver/compmisc.cmx \
+  driver/compplugin.cmx \
+  driver/main_args.cmx \
+  driver/makedepend.cmx \
+  driver/optcompile.cmx \
+  driver/optmain.cmi \
+  middle_end/backend_intf.cmi \
+  parsing/location.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/profile.cmx \
+  utils/warnings.cmx
 driver/optmain.cmi :
-driver/pparse.cmo : utils/profile.cmi parsing/parsetree.cmi \
-    parsing/parse.cmi utils/misc.cmi parsing/location.cmi utils/config.cmi \
-    utils/clflags.cmi utils/ccomp.cmi parsing/ast_mapper.cmi \
-    parsing/ast_invariants.cmi driver/pparse.cmi
-driver/pparse.cmx : utils/profile.cmx parsing/parsetree.cmi \
-    parsing/parse.cmx utils/misc.cmx parsing/location.cmx utils/config.cmx \
-    utils/clflags.cmx utils/ccomp.cmx parsing/ast_mapper.cmx \
-    parsing/ast_invariants.cmx driver/pparse.cmi
-driver/pparse.cmi : parsing/parsetree.cmi utils/misc.cmi
-toplevel/expunge.cmo : bytecomp/symtable.cmi bytecomp/runtimedef.cmi \
-    utils/misc.cmi typing/ident.cmi bytecomp/bytesections.cmi
-toplevel/expunge.cmx : bytecomp/symtable.cmx bytecomp/runtimedef.cmx \
-    utils/misc.cmx typing/ident.cmx bytecomp/bytesections.cmx
-toplevel/genprintval.cmo : typing/types.cmi typing/printtyp.cmi \
-    typing/predef.cmi typing/path.cmi typing/outcometree.cmi \
-    typing/oprint.cmi utils/misc.cmi parsing/longident.cmi typing/ident.cmi \
-    typing/env.cmi typing/datarepr.cmi typing/ctype.cmi typing/btype.cmi \
-    toplevel/genprintval.cmi
-toplevel/genprintval.cmx : typing/types.cmx typing/printtyp.cmx \
-    typing/predef.cmx typing/path.cmx typing/outcometree.cmi \
-    typing/oprint.cmx utils/misc.cmx parsing/longident.cmx typing/ident.cmx \
-    typing/env.cmx typing/datarepr.cmx typing/ctype.cmx typing/btype.cmx \
-    toplevel/genprintval.cmi
-toplevel/genprintval.cmi : typing/types.cmi typing/path.cmi \
-    typing/outcometree.cmi typing/env.cmi
-toplevel/opttopdirs.cmo : utils/warnings.cmi typing/types.cmi \
-    typing/printtyp.cmi toplevel/opttoploop.cmi utils/misc.cmi \
-    parsing/longident.cmi typing/ident.cmi typing/env.cmi typing/ctype.cmi \
-    utils/config.cmi driver/compdynlink.cmi utils/clflags.cmi \
-    asmcomp/asmlink.cmi toplevel/opttopdirs.cmi
-toplevel/opttopdirs.cmx : utils/warnings.cmx typing/types.cmx \
-    typing/printtyp.cmx toplevel/opttoploop.cmx utils/misc.cmx \
-    parsing/longident.cmx typing/ident.cmx typing/env.cmx typing/ctype.cmx \
-    utils/config.cmx driver/compdynlink.cmi utils/clflags.cmx \
-    asmcomp/asmlink.cmx toplevel/opttopdirs.cmi
-toplevel/opttopdirs.cmi : parsing/longident.cmi
-toplevel/opttoploop.cmo : utils/warnings.cmi typing/types.cmi \
-    typing/typemod.cmi typing/typedtree.cmi typing/typecore.cmi \
-    bytecomp/translmod.cmi bytecomp/simplif.cmi asmcomp/proc.cmi \
-    typing/printtyped.cmi typing/printtyp.cmi bytecomp/printlambda.cmi \
-    parsing/printast.cmi typing/predef.cmi parsing/pprintast.cmi \
-    driver/pparse.cmi typing/path.cmi parsing/parsetree.cmi parsing/parse.cmi \
-    typing/outcometree.cmi typing/oprint.cmi utils/misc.cmi \
-    middle_end/middle_end.cmi parsing/longident.cmi parsing/location.cmi \
-    parsing/lexer.cmi bytecomp/lambda.cmi typing/includemod.cmi \
-    asmcomp/import_approx.cmi typing/ident.cmi toplevel/genprintval.cmi \
-    typing/env.cmi utils/config.cmi driver/compmisc.cmi asmcomp/compilenv.cmi \
-    driver/compdynlink.cmi utils/clflags.cmi typing/btype.cmi \
-    middle_end/backend_intf.cmi parsing/asttypes.cmi parsing/ast_helper.cmi \
-    asmcomp/asmlink.cmi asmcomp/asmgen.cmi asmcomp/arch.cmo \
-    toplevel/opttoploop.cmi
-toplevel/opttoploop.cmx : utils/warnings.cmx typing/types.cmx \
-    typing/typemod.cmx typing/typedtree.cmx typing/typecore.cmx \
-    bytecomp/translmod.cmx bytecomp/simplif.cmx asmcomp/proc.cmx \
-    typing/printtyped.cmx typing/printtyp.cmx bytecomp/printlambda.cmx \
-    parsing/printast.cmx typing/predef.cmx parsing/pprintast.cmx \
-    driver/pparse.cmx typing/path.cmx parsing/parsetree.cmi parsing/parse.cmx \
-    typing/outcometree.cmi typing/oprint.cmx utils/misc.cmx \
-    middle_end/middle_end.cmx parsing/longident.cmx parsing/location.cmx \
-    parsing/lexer.cmx bytecomp/lambda.cmx typing/includemod.cmx \
-    asmcomp/import_approx.cmx typing/ident.cmx toplevel/genprintval.cmx \
-    typing/env.cmx utils/config.cmx driver/compmisc.cmx asmcomp/compilenv.cmx \
-    driver/compdynlink.cmi utils/clflags.cmx typing/btype.cmx \
-    middle_end/backend_intf.cmi parsing/asttypes.cmi parsing/ast_helper.cmx \
-    asmcomp/asmlink.cmx asmcomp/asmgen.cmx asmcomp/arch.cmx \
-    toplevel/opttoploop.cmi
-toplevel/opttoploop.cmi : utils/warnings.cmi typing/types.cmi \
-    typing/path.cmi parsing/parsetree.cmi typing/outcometree.cmi \
-    parsing/longident.cmi parsing/location.cmi typing/env.cmi
-toplevel/opttopmain.cmo : utils/warnings.cmi asmcomp/printmach.cmi \
-    toplevel/opttoploop.cmi toplevel/opttopdirs.cmi utils/misc.cmi \
-    driver/main_args.cmi parsing/location.cmi utils/config.cmi \
-    driver/compplugin.cmi driver/compmisc.cmi driver/compenv.cmi \
-    utils/clflags.cmi toplevel/opttopmain.cmi
-toplevel/opttopmain.cmx : utils/warnings.cmx asmcomp/printmach.cmx \
-    toplevel/opttoploop.cmx toplevel/opttopdirs.cmx utils/misc.cmx \
-    driver/main_args.cmx parsing/location.cmx utils/config.cmx \
-    driver/compplugin.cmx driver/compmisc.cmx driver/compenv.cmx \
-    utils/clflags.cmx toplevel/opttopmain.cmi
+driver/pparse.cmo : \
+  driver/pparse.cmi \
+  parsing/ast_invariants.cmi \
+  parsing/ast_mapper.cmi \
+  parsing/location.cmi \
+  parsing/parse.cmi \
+  parsing/parsetree.cmi \
+  utils/ccomp.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/profile.cmi
+driver/pparse.cmx : \
+  driver/pparse.cmi \
+  parsing/ast_invariants.cmx \
+  parsing/ast_mapper.cmx \
+  parsing/location.cmx \
+  parsing/parse.cmx \
+  parsing/parsetree.cmi \
+  utils/ccomp.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/profile.cmx
+driver/pparse.cmi : \
+  parsing/parsetree.cmi \
+  utils/misc.cmi
+toplevel/expunge.cmo : \
+  bytecomp/bytesections.cmi \
+  bytecomp/runtimedef.cmi \
+  bytecomp/symtable.cmi \
+  typing/ident.cmi \
+  utils/misc.cmi
+toplevel/expunge.cmx : \
+  bytecomp/bytesections.cmx \
+  bytecomp/runtimedef.cmx \
+  bytecomp/symtable.cmx \
+  typing/ident.cmx \
+  utils/misc.cmx
+toplevel/genprintval.cmo : \
+  parsing/longident.cmi \
+  toplevel/genprintval.cmi \
+  typing/btype.cmi \
+  typing/ctype.cmi \
+  typing/datarepr.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/oprint.cmi \
+  typing/outcometree.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/printtyp.cmi \
+  typing/types.cmi \
+  utils/misc.cmi
+toplevel/genprintval.cmx : \
+  parsing/longident.cmx \
+  toplevel/genprintval.cmi \
+  typing/btype.cmx \
+  typing/ctype.cmx \
+  typing/datarepr.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/oprint.cmx \
+  typing/outcometree.cmi \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/printtyp.cmx \
+  typing/types.cmx \
+  utils/misc.cmx
+toplevel/genprintval.cmi : \
+  typing/env.cmi \
+  typing/outcometree.cmi \
+  typing/path.cmi \
+  typing/types.cmi
+toplevel/opttopdirs.cmo : \
+  asmcomp/asmlink.cmi \
+  driver/compdynlink.cmi \
+  parsing/longident.cmi \
+  toplevel/opttopdirs.cmi \
+  toplevel/opttoploop.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/printtyp.cmi \
+  typing/types.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+toplevel/opttopdirs.cmx : \
+  asmcomp/asmlink.cmx \
+  driver/compdynlink.cmi \
+  parsing/longident.cmx \
+  toplevel/opttopdirs.cmi \
+  toplevel/opttoploop.cmx \
+  typing/ctype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/printtyp.cmx \
+  typing/types.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+toplevel/opttopdirs.cmi : \
+  parsing/longident.cmi
+toplevel/opttoploop.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/asmgen.cmi \
+  asmcomp/asmlink.cmi \
+  asmcomp/compilenv.cmi \
+  asmcomp/import_approx.cmi \
+  asmcomp/proc.cmi \
+  bytecomp/lambda.cmi \
+  bytecomp/printlambda.cmi \
+  bytecomp/simplif.cmi \
+  bytecomp/translmod.cmi \
+  driver/compdynlink.cmi \
+  driver/compmisc.cmi \
+  driver/pparse.cmi \
+  middle_end/backend_intf.cmi \
+  middle_end/middle_end.cmi \
+  parsing/ast_helper.cmi \
+  parsing/asttypes.cmi \
+  parsing/lexer.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parse.cmi \
+  parsing/parsetree.cmi \
+  parsing/pprintast.cmi \
+  parsing/printast.cmi \
+  toplevel/genprintval.cmi \
+  toplevel/opttoploop.cmi \
+  typing/btype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/includemod.cmi \
+  typing/oprint.cmi \
+  typing/outcometree.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/printtyp.cmi \
+  typing/printtyped.cmi \
+  typing/typecore.cmi \
+  typing/typedtree.cmi \
+  typing/typemod.cmi \
+  typing/types.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+toplevel/opttoploop.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/asmgen.cmx \
+  asmcomp/asmlink.cmx \
+  asmcomp/compilenv.cmx \
+  asmcomp/import_approx.cmx \
+  asmcomp/proc.cmx \
+  bytecomp/lambda.cmx \
+  bytecomp/printlambda.cmx \
+  bytecomp/simplif.cmx \
+  bytecomp/translmod.cmx \
+  driver/compdynlink.cmi \
+  driver/compmisc.cmx \
+  driver/pparse.cmx \
+  middle_end/backend_intf.cmi \
+  middle_end/middle_end.cmx \
+  parsing/ast_helper.cmx \
+  parsing/asttypes.cmi \
+  parsing/lexer.cmx \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parse.cmx \
+  parsing/parsetree.cmi \
+  parsing/pprintast.cmx \
+  parsing/printast.cmx \
+  toplevel/genprintval.cmx \
+  toplevel/opttoploop.cmi \
+  typing/btype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/includemod.cmx \
+  typing/oprint.cmx \
+  typing/outcometree.cmi \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/printtyp.cmx \
+  typing/printtyped.cmx \
+  typing/typecore.cmx \
+  typing/typedtree.cmx \
+  typing/typemod.cmx \
+  typing/types.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+toplevel/opttoploop.cmi : \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/env.cmi \
+  typing/outcometree.cmi \
+  typing/path.cmi \
+  typing/types.cmi \
+  utils/warnings.cmi
+toplevel/opttopmain.cmo : \
+  asmcomp/printmach.cmi \
+  driver/compenv.cmi \
+  driver/compmisc.cmi \
+  driver/compplugin.cmi \
+  driver/main_args.cmi \
+  parsing/location.cmi \
+  toplevel/opttopdirs.cmi \
+  toplevel/opttoploop.cmi \
+  toplevel/opttopmain.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+toplevel/opttopmain.cmx : \
+  asmcomp/printmach.cmx \
+  driver/compenv.cmx \
+  driver/compmisc.cmx \
+  driver/compplugin.cmx \
+  driver/main_args.cmx \
+  parsing/location.cmx \
+  toplevel/opttopdirs.cmx \
+  toplevel/opttoploop.cmx \
+  toplevel/opttopmain.cmi \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
 toplevel/opttopmain.cmi :
-toplevel/opttopstart.cmo : toplevel/opttopmain.cmi
-toplevel/opttopstart.cmx : toplevel/opttopmain.cmx
-toplevel/topdirs.cmo : utils/warnings.cmi typing/typetexp.cmi \
-    typing/types.cmi toplevel/trace.cmi toplevel/toploop.cmi \
-    bytecomp/symtable.cmi typing/printtyp.cmi typing/predef.cmi \
-    typing/path.cmi parsing/parsetree.cmi bytecomp/opcodes.cmo utils/misc.cmi \
-    bytecomp/meta.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi typing/env.cmi bytecomp/dll.cmi typing/ctype.cmi \
-    utils/consistbl.cmi utils/config.cmi bytecomp/cmo_format.cmi \
-    utils/clflags.cmi typing/btype.cmi parsing/asttypes.cmi \
-    toplevel/topdirs.cmi
-toplevel/topdirs.cmx : utils/warnings.cmx typing/typetexp.cmx \
-    typing/types.cmx toplevel/trace.cmx toplevel/toploop.cmx \
-    bytecomp/symtable.cmx typing/printtyp.cmx typing/predef.cmx \
-    typing/path.cmx parsing/parsetree.cmi bytecomp/opcodes.cmx utils/misc.cmx \
-    bytecomp/meta.cmx parsing/longident.cmx parsing/location.cmx \
-    typing/ident.cmx typing/env.cmx bytecomp/dll.cmx typing/ctype.cmx \
-    utils/consistbl.cmx utils/config.cmx bytecomp/cmo_format.cmi \
-    utils/clflags.cmx typing/btype.cmx parsing/asttypes.cmi \
-    toplevel/topdirs.cmi
-toplevel/topdirs.cmi : parsing/longident.cmi
-toplevel/toploop.cmo : utils/warnings.cmi typing/typetexp.cmi \
-    typing/types.cmi typing/typemod.cmi typing/typedtree.cmi \
-    typing/typecore.cmi bytecomp/translmod.cmi bytecomp/symtable.cmi \
-    bytecomp/simplif.cmi typing/printtyped.cmi typing/printtyp.cmi \
-    bytecomp/printlambda.cmi bytecomp/printinstr.cmi parsing/printast.cmi \
-    typing/predef.cmi parsing/pprintast.cmi driver/pparse.cmi typing/path.cmi \
-    parsing/parsetree.cmi parsing/parse.cmi typing/outcometree.cmi \
-    typing/oprint.cmi utils/misc.cmi bytecomp/meta.cmi parsing/longident.cmi \
-    parsing/location.cmi parsing/lexer.cmi typing/includemod.cmi \
-    typing/ident.cmi toplevel/genprintval.cmi typing/env.cmi \
-    bytecomp/emitcode.cmi bytecomp/dll.cmi utils/consistbl.cmi \
-    utils/config.cmi driver/compmisc.cmi driver/compenv.cmi utils/clflags.cmi \
-    bytecomp/bytegen.cmi typing/btype.cmi parsing/asttypes.cmi \
-    parsing/ast_helper.cmi toplevel/toploop.cmi
-toplevel/toploop.cmx : utils/warnings.cmx typing/typetexp.cmx \
-    typing/types.cmx typing/typemod.cmx typing/typedtree.cmx \
-    typing/typecore.cmx bytecomp/translmod.cmx bytecomp/symtable.cmx \
-    bytecomp/simplif.cmx typing/printtyped.cmx typing/printtyp.cmx \
-    bytecomp/printlambda.cmx bytecomp/printinstr.cmx parsing/printast.cmx \
-    typing/predef.cmx parsing/pprintast.cmx driver/pparse.cmx typing/path.cmx \
-    parsing/parsetree.cmi parsing/parse.cmx typing/outcometree.cmi \
-    typing/oprint.cmx utils/misc.cmx bytecomp/meta.cmx parsing/longident.cmx \
-    parsing/location.cmx parsing/lexer.cmx typing/includemod.cmx \
-    typing/ident.cmx toplevel/genprintval.cmx typing/env.cmx \
-    bytecomp/emitcode.cmx bytecomp/dll.cmx utils/consistbl.cmx \
-    utils/config.cmx driver/compmisc.cmx driver/compenv.cmx utils/clflags.cmx \
-    bytecomp/bytegen.cmx typing/btype.cmx parsing/asttypes.cmi \
-    parsing/ast_helper.cmx toplevel/toploop.cmi
-toplevel/toploop.cmi : utils/warnings.cmi typing/types.cmi typing/path.cmi \
-    parsing/parsetree.cmi typing/outcometree.cmi parsing/longident.cmi \
-    parsing/location.cmi typing/env.cmi
-toplevel/topmain.cmo : utils/warnings.cmi toplevel/toploop.cmi \
-    toplevel/topdirs.cmi utils/profile.cmi utils/misc.cmi \
-    driver/main_args.cmi parsing/location.cmi utils/config.cmi \
-    driver/compplugin.cmi driver/compmisc.cmi driver/compenv.cmi \
-    utils/clflags.cmi toplevel/topmain.cmi
-toplevel/topmain.cmx : utils/warnings.cmx toplevel/toploop.cmx \
-    toplevel/topdirs.cmx utils/profile.cmx utils/misc.cmx \
-    driver/main_args.cmx parsing/location.cmx utils/config.cmx \
-    driver/compplugin.cmx driver/compmisc.cmx driver/compenv.cmx \
-    utils/clflags.cmx toplevel/topmain.cmi
+toplevel/opttopstart.cmo : \
+  toplevel/opttopmain.cmi
+toplevel/opttopstart.cmx : \
+  toplevel/opttopmain.cmx
+toplevel/topdirs.cmo : \
+  bytecomp/cmo_format.cmi \
+  bytecomp/dll.cmi \
+  bytecomp/meta.cmi \
+  bytecomp/opcodes.cmo \
+  bytecomp/symtable.cmi \
+  parsing/asttypes.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  toplevel/topdirs.cmi \
+  toplevel/toploop.cmi \
+  toplevel/trace.cmi \
+  typing/btype.cmi \
+  typing/ctype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/printtyp.cmi \
+  typing/types.cmi \
+  typing/typetexp.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/consistbl.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+toplevel/topdirs.cmx : \
+  bytecomp/cmo_format.cmi \
+  bytecomp/dll.cmx \
+  bytecomp/meta.cmx \
+  bytecomp/opcodes.cmx \
+  bytecomp/symtable.cmx \
+  parsing/asttypes.cmi \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parsetree.cmi \
+  toplevel/topdirs.cmi \
+  toplevel/toploop.cmx \
+  toplevel/trace.cmx \
+  typing/btype.cmx \
+  typing/ctype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/printtyp.cmx \
+  typing/types.cmx \
+  typing/typetexp.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/consistbl.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+toplevel/topdirs.cmi : \
+  parsing/longident.cmi
+toplevel/toploop.cmo : \
+  bytecomp/bytegen.cmi \
+  bytecomp/dll.cmi \
+  bytecomp/emitcode.cmi \
+  bytecomp/meta.cmi \
+  bytecomp/printinstr.cmi \
+  bytecomp/printlambda.cmi \
+  bytecomp/simplif.cmi \
+  bytecomp/symtable.cmi \
+  bytecomp/translmod.cmi \
+  driver/compenv.cmi \
+  driver/compmisc.cmi \
+  driver/pparse.cmi \
+  parsing/ast_helper.cmi \
+  parsing/asttypes.cmi \
+  parsing/lexer.cmi \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parse.cmi \
+  parsing/parsetree.cmi \
+  parsing/pprintast.cmi \
+  parsing/printast.cmi \
+  toplevel/genprintval.cmi \
+  toplevel/toploop.cmi \
+  typing/btype.cmi \
+  typing/env.cmi \
+  typing/ident.cmi \
+  typing/includemod.cmi \
+  typing/oprint.cmi \
+  typing/outcometree.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/printtyp.cmi \
+  typing/printtyped.cmi \
+  typing/typecore.cmi \
+  typing/typedtree.cmi \
+  typing/typemod.cmi \
+  typing/types.cmi \
+  typing/typetexp.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/consistbl.cmi \
+  utils/misc.cmi \
+  utils/warnings.cmi
+toplevel/toploop.cmx : \
+  bytecomp/bytegen.cmx \
+  bytecomp/dll.cmx \
+  bytecomp/emitcode.cmx \
+  bytecomp/meta.cmx \
+  bytecomp/printinstr.cmx \
+  bytecomp/printlambda.cmx \
+  bytecomp/simplif.cmx \
+  bytecomp/symtable.cmx \
+  bytecomp/translmod.cmx \
+  driver/compenv.cmx \
+  driver/compmisc.cmx \
+  driver/pparse.cmx \
+  parsing/ast_helper.cmx \
+  parsing/asttypes.cmi \
+  parsing/lexer.cmx \
+  parsing/location.cmx \
+  parsing/longident.cmx \
+  parsing/parse.cmx \
+  parsing/parsetree.cmi \
+  parsing/pprintast.cmx \
+  parsing/printast.cmx \
+  toplevel/genprintval.cmx \
+  toplevel/toploop.cmi \
+  typing/btype.cmx \
+  typing/env.cmx \
+  typing/ident.cmx \
+  typing/includemod.cmx \
+  typing/oprint.cmx \
+  typing/outcometree.cmi \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/printtyp.cmx \
+  typing/printtyped.cmx \
+  typing/typecore.cmx \
+  typing/typedtree.cmx \
+  typing/typemod.cmx \
+  typing/types.cmx \
+  typing/typetexp.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/consistbl.cmx \
+  utils/misc.cmx \
+  utils/warnings.cmx
+toplevel/toploop.cmi : \
+  parsing/location.cmi \
+  parsing/longident.cmi \
+  parsing/parsetree.cmi \
+  typing/env.cmi \
+  typing/outcometree.cmi \
+  typing/path.cmi \
+  typing/types.cmi \
+  utils/warnings.cmi
+toplevel/topmain.cmo : \
+  driver/compenv.cmi \
+  driver/compmisc.cmi \
+  driver/compplugin.cmi \
+  driver/main_args.cmi \
+  parsing/location.cmi \
+  toplevel/topdirs.cmi \
+  toplevel/toploop.cmi \
+  toplevel/topmain.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi \
+  utils/profile.cmi \
+  utils/warnings.cmi
+toplevel/topmain.cmx : \
+  driver/compenv.cmx \
+  driver/compmisc.cmx \
+  driver/compplugin.cmx \
+  driver/main_args.cmx \
+  parsing/location.cmx \
+  toplevel/topdirs.cmx \
+  toplevel/toploop.cmx \
+  toplevel/topmain.cmi \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx \
+  utils/profile.cmx \
+  utils/warnings.cmx
 toplevel/topmain.cmi :
-toplevel/topstart.cmo : toplevel/topmain.cmi
-toplevel/topstart.cmx : toplevel/topmain.cmx
-toplevel/trace.cmo : typing/types.cmi toplevel/toploop.cmi \
-    typing/printtyp.cmi typing/predef.cmi typing/path.cmi utils/misc.cmi \
-    bytecomp/meta.cmi parsing/longident.cmi typing/ctype.cmi \
-    parsing/asttypes.cmi toplevel/trace.cmi
-toplevel/trace.cmx : typing/types.cmx toplevel/toploop.cmx \
-    typing/printtyp.cmx typing/predef.cmx typing/path.cmx utils/misc.cmx \
-    bytecomp/meta.cmx parsing/longident.cmx typing/ctype.cmx \
-    parsing/asttypes.cmi toplevel/trace.cmi
-toplevel/trace.cmi : typing/types.cmi typing/path.cmi parsing/longident.cmi \
-    typing/env.cmi
-driver/compdynlink.cmx : asmcomp/cmx_format.cmi driver/compdynlink.cmi
-driver/compdynlink.cmo : bytecomp/symtable.cmi bytecomp/opcodes.cmo \
-    utils/misc.cmi bytecomp/meta.cmi bytecomp/dll.cmi utils/consistbl.cmi \
-    utils/config.cmi bytecomp/cmo_format.cmi typing/cmi_format.cmi \
-    driver/compdynlink.cmi
+toplevel/topstart.cmo : \
+  toplevel/topmain.cmi
+toplevel/topstart.cmx : \
+  toplevel/topmain.cmx
+toplevel/trace.cmo : \
+  bytecomp/meta.cmi \
+  parsing/asttypes.cmi \
+  parsing/longident.cmi \
+  toplevel/toploop.cmi \
+  toplevel/trace.cmi \
+  typing/ctype.cmi \
+  typing/path.cmi \
+  typing/predef.cmi \
+  typing/printtyp.cmi \
+  typing/types.cmi \
+  utils/misc.cmi
+toplevel/trace.cmx : \
+  bytecomp/meta.cmx \
+  parsing/asttypes.cmi \
+  parsing/longident.cmx \
+  toplevel/toploop.cmx \
+  toplevel/trace.cmi \
+  typing/ctype.cmx \
+  typing/path.cmx \
+  typing/predef.cmx \
+  typing/printtyp.cmx \
+  typing/types.cmx \
+  utils/misc.cmx
+toplevel/trace.cmi : \
+  parsing/longident.cmi \
+  typing/env.cmi \
+  typing/path.cmi \
+  typing/types.cmi
+driver/compdynlink.cmx : \
+  asmcomp/cmx_format.cmi \
+  driver/compdynlink.cmi
+driver/compdynlink.cmo : \
+  bytecomp/cmo_format.cmi \
+  bytecomp/dll.cmi \
+  bytecomp/meta.cmi \
+  bytecomp/opcodes.cmo \
+  bytecomp/symtable.cmi \
+  driver/compdynlink.cmi \
+  typing/cmi_format.cmi \
+  utils/config.cmi \
+  utils/consistbl.cmi \
+  utils/misc.cmi

--- a/.depend
+++ b/.depend
@@ -859,6 +859,7 @@ typing/printtyped.cmo : \
   typing/path.cmi \
   typing/printtyped.cmi \
   typing/typedtree.cmi \
+  typing/types.cmi \
   utils/misc.cmi
 typing/printtyped.cmx : \
   parsing/asttypes.cmi \
@@ -869,6 +870,7 @@ typing/printtyped.cmx : \
   typing/path.cmx \
   typing/printtyped.cmi \
   typing/typedtree.cmx \
+  typing/types.cmx \
   utils/misc.cmx
 typing/printtyped.cmi : \
   typing/typedtree.cmi
@@ -1020,6 +1022,7 @@ typing/typecore.cmo : \
   typing/typecore.cmi \
   typing/typedecl.cmi \
   typing/typedtree.cmi \
+  typing/typeopt.cmi \
   typing/types.cmi \
   typing/typetexp.cmi \
   utils/clflags.cmi \
@@ -1049,6 +1052,7 @@ typing/typecore.cmx : \
   typing/typecore.cmi \
   typing/typedecl.cmx \
   typing/typedtree.cmx \
+  typing/typeopt.cmx \
   typing/types.cmx \
   typing/typetexp.cmx \
   utils/clflags.cmx \
@@ -1264,6 +1268,7 @@ typing/typemod.cmi : \
   utils/misc.cmi
 typing/typeopt.cmo : \
   bytecomp/lambda.cmi \
+  parsing/asttypes.cmi \
   typing/ctype.cmi \
   typing/env.cmi \
   typing/ident.cmi \
@@ -1276,6 +1281,7 @@ typing/typeopt.cmo : \
   utils/config.cmi
 typing/typeopt.cmx : \
   bytecomp/lambda.cmx \
+  parsing/asttypes.cmi \
   typing/ctype.cmx \
   typing/env.cmx \
   typing/ident.cmx \
@@ -5285,7 +5291,6 @@ toplevel/opttopmain.cmo : \
   asmcomp/printmach.cmi \
   driver/compenv.cmi \
   driver/compmisc.cmi \
-  driver/compplugin.cmi \
   driver/main_args.cmi \
   parsing/location.cmi \
   toplevel/opttopdirs.cmi \
@@ -5299,7 +5304,6 @@ toplevel/opttopmain.cmx : \
   asmcomp/printmach.cmx \
   driver/compenv.cmx \
   driver/compmisc.cmx \
-  driver/compplugin.cmx \
   driver/main_args.cmx \
   parsing/location.cmx \
   toplevel/opttopdirs.cmx \
@@ -5470,7 +5474,6 @@ toplevel/toploop.cmi : \
 toplevel/topmain.cmo : \
   driver/compenv.cmi \
   driver/compmisc.cmi \
-  driver/compplugin.cmi \
   driver/main_args.cmi \
   parsing/location.cmi \
   toplevel/topdirs.cmi \
@@ -5484,7 +5487,6 @@ toplevel/topmain.cmo : \
 toplevel/topmain.cmx : \
   driver/compenv.cmx \
   driver/compmisc.cmx \
-  driver/compplugin.cmx \
   driver/main_args.cmx \
   parsing/location.cmx \
   toplevel/topdirs.cmx \

--- a/.depend
+++ b/.depend
@@ -2012,14 +2012,6 @@ bytecomp/translobj.cmi : \
   bytecomp/lambda.cmi \
   typing/env.cmi \
   typing/ident.cmi
-asmcomp/CSE.cmo : \
-  asmcomp/CSEgen.cmi \
-  asmcomp/arch.cmo \
-  asmcomp/mach.cmi
-asmcomp/CSE.cmx : \
-  asmcomp/CSEgen.cmx \
-  asmcomp/arch.cmx \
-  asmcomp/mach.cmx
 asmcomp/CSEgen.cmo : \
   asmcomp/CSEgen.cmi \
   asmcomp/cmm.cmi \
@@ -2052,12 +2044,6 @@ asmcomp/afl_instrument.cmx : \
   utils/clflags.cmx
 asmcomp/afl_instrument.cmi : \
   asmcomp/cmm.cmi
-asmcomp/arch.cmo : \
-  utils/clflags.cmi \
-  utils/config.cmi
-asmcomp/arch.cmx : \
-  utils/clflags.cmx \
-  utils/config.cmx
 asmcomp/asmgen.cmo : \
   asmcomp/CSE.cmo \
   asmcomp/asmgen.cmi \
@@ -2962,24 +2948,6 @@ asmcomp/printmach.cmx : \
 asmcomp/printmach.cmi : \
   asmcomp/mach.cmi \
   asmcomp/reg.cmi
-asmcomp/proc.cmo : \
-  asmcomp/arch.cmo \
-  asmcomp/cmm.cmi \
-  asmcomp/mach.cmi \
-  asmcomp/proc.cmi \
-  asmcomp/reg.cmi \
-  asmcomp/x86_proc.cmi \
-  utils/config.cmi \
-  utils/misc.cmi
-asmcomp/proc.cmx : \
-  asmcomp/arch.cmx \
-  asmcomp/cmm.cmx \
-  asmcomp/mach.cmx \
-  asmcomp/proc.cmi \
-  asmcomp/reg.cmx \
-  asmcomp/x86_proc.cmx \
-  utils/config.cmx \
-  utils/misc.cmx
 asmcomp/proc.cmi : \
   asmcomp/mach.cmi \
   asmcomp/reg.cmi
@@ -2994,22 +2962,6 @@ asmcomp/reg.cmx : \
 asmcomp/reg.cmi : \
   asmcomp/cmm.cmi \
   typing/ident.cmi
-asmcomp/reload.cmo : \
-  asmcomp/arch.cmo \
-  asmcomp/cmm.cmi \
-  asmcomp/mach.cmi \
-  asmcomp/reg.cmi \
-  asmcomp/reload.cmi \
-  asmcomp/reloadgen.cmi \
-  utils/clflags.cmi
-asmcomp/reload.cmx : \
-  asmcomp/arch.cmx \
-  asmcomp/cmm.cmx \
-  asmcomp/mach.cmx \
-  asmcomp/reg.cmx \
-  asmcomp/reload.cmi \
-  asmcomp/reloadgen.cmx \
-  utils/clflags.cmx
 asmcomp/reload.cmi : \
   asmcomp/mach.cmi
 asmcomp/reloadgen.cmo : \
@@ -3044,12 +2996,6 @@ asmcomp/schedgen.cmx : \
 asmcomp/schedgen.cmi : \
   asmcomp/linearize.cmi \
   asmcomp/mach.cmi
-asmcomp/scheduling.cmo : \
-  asmcomp/schedgen.cmi \
-  asmcomp/scheduling.cmi
-asmcomp/scheduling.cmx : \
-  asmcomp/schedgen.cmx \
-  asmcomp/scheduling.cmi
 asmcomp/scheduling.cmi : \
   asmcomp/linearize.cmi
 asmcomp/selectgen.cmo : \
@@ -3089,26 +3035,6 @@ asmcomp/selectgen.cmi : \
   asmcomp/reg.cmi \
   middle_end/debuginfo.cmi \
   typing/ident.cmi
-asmcomp/selection.cmo : \
-  asmcomp/arch.cmo \
-  asmcomp/cmm.cmi \
-  asmcomp/mach.cmi \
-  asmcomp/proc.cmi \
-  asmcomp/selectgen.cmi \
-  asmcomp/selection.cmi \
-  asmcomp/spacetime_profiling.cmi \
-  utils/clflags.cmi \
-  utils/config.cmi
-asmcomp/selection.cmx : \
-  asmcomp/arch.cmx \
-  asmcomp/cmm.cmx \
-  asmcomp/mach.cmx \
-  asmcomp/proc.cmx \
-  asmcomp/selectgen.cmx \
-  asmcomp/selection.cmi \
-  asmcomp/spacetime_profiling.cmx \
-  utils/clflags.cmx \
-  utils/config.cmx
 asmcomp/selection.cmi : \
   asmcomp/cmm.cmi \
   asmcomp/mach.cmi
@@ -5531,6 +5457,344 @@ toplevel/trace.cmi : \
   typing/env.cmi \
   typing/path.cmi \
   typing/types.cmi
+asmcomp/CSE.cmo : \
+  asmcomp/CSEgen.cmi \
+  asmcomp/arch.cmo \
+  asmcomp/mach.cmi
+asmcomp/CSE.cmx : \
+  asmcomp/CSEgen.cmx \
+  asmcomp/arch.cmx \
+  asmcomp/mach.cmx
+asmcomp/arch.cmo : \
+  utils/clflags.cmi \
+  utils/config.cmi
+asmcomp/arch.cmx : \
+  utils/clflags.cmx \
+  utils/config.cmx
+asmcomp/proc.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  asmcomp/x86_proc.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+asmcomp/proc.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/reg.cmx \
+  asmcomp/x86_proc.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+asmcomp/reload.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  asmcomp/reloadgen.cmi \
+  utils/clflags.cmi
+asmcomp/reload.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/reg.cmx \
+  asmcomp/reloadgen.cmx \
+  utils/clflags.cmx
+asmcomp/scheduling.cmo : \
+  asmcomp/schedgen.cmi
+asmcomp/scheduling.cmx : \
+  asmcomp/schedgen.cmx
+asmcomp/selection.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/selectgen.cmi \
+  asmcomp/spacetime_profiling.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi
+asmcomp/selection.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/selectgen.cmx \
+  asmcomp/spacetime_profiling.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx
+asmcomp/CSE.cmo : \
+  asmcomp/CSEgen.cmi \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi
+asmcomp/CSE.cmx : \
+  asmcomp/CSEgen.cmx \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx
+asmcomp/arch.cmo : \
+  utils/config.cmi
+asmcomp/arch.cmx : \
+  utils/config.cmx
+asmcomp/proc.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  asmcomp/x86_proc.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+asmcomp/proc.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/reg.cmx \
+  asmcomp/x86_proc.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+asmcomp/reload.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  asmcomp/reloadgen.cmi
+asmcomp/reload.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/reg.cmx \
+  asmcomp/reloadgen.cmx
+asmcomp/scheduling.cmo : \
+  asmcomp/schedgen.cmi
+asmcomp/scheduling.cmx : \
+  asmcomp/schedgen.cmx
+asmcomp/selection.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/selectgen.cmi \
+  utils/misc.cmi
+asmcomp/selection.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/selectgen.cmx \
+  utils/misc.cmx
+asmcomp/CSE.cmo : \
+  asmcomp/CSEgen.cmi \
+  asmcomp/arch.cmo \
+  asmcomp/mach.cmi
+asmcomp/CSE.cmx : \
+  asmcomp/CSEgen.cmx \
+  asmcomp/arch.cmx \
+  asmcomp/mach.cmx
+asmcomp/arch.cmo : \
+  utils/clflags.cmi \
+  utils/config.cmi
+asmcomp/arch.cmx : \
+  utils/clflags.cmx \
+  utils/config.cmx
+asmcomp/proc.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  utils/ccomp.cmi \
+  utils/clflags.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+asmcomp/proc.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/reg.cmx \
+  utils/ccomp.cmx \
+  utils/clflags.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+asmcomp/reload.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/mach.cmi \
+  asmcomp/reloadgen.cmi
+asmcomp/reload.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/reloadgen.cmx
+asmcomp/scheduling.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/mach.cmi \
+  asmcomp/schedgen.cmi
+asmcomp/scheduling.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/schedgen.cmx
+asmcomp/selection.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/proc.cmi \
+  asmcomp/reg.cmi \
+  asmcomp/selectgen.cmi
+asmcomp/selection.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/proc.cmx \
+  asmcomp/reg.cmx \
+  asmcomp/selectgen.cmx
+asmcomp/CSE.cmo : \
+  asmcomp/CSEgen.cmi \
+  asmcomp/arch.cmo \
+  asmcomp/mach.cmi
+asmcomp/CSE.cmx : \
+  asmcomp/CSEgen.cmx \
+  asmcomp/arch.cmx \
+  asmcomp/mach.cmx
+asmcomp/arch.cmo :
+asmcomp/arch.cmx :
+asmcomp/proc.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  utils/ccomp.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+asmcomp/proc.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/reg.cmx \
+  utils/ccomp.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+asmcomp/reload.cmo : \
+  asmcomp/reloadgen.cmi
+asmcomp/reload.cmx : \
+  asmcomp/reloadgen.cmx
+asmcomp/scheduling.cmo : \
+  asmcomp/schedgen.cmi
+asmcomp/scheduling.cmx : \
+  asmcomp/schedgen.cmx
+asmcomp/selection.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/selectgen.cmi \
+  utils/clflags.cmi
+asmcomp/selection.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/selectgen.cmx \
+  utils/clflags.cmx
+asmcomp/CSE.cmo : \
+  asmcomp/CSEgen.cmi \
+  asmcomp/arch.cmo \
+  asmcomp/mach.cmi
+asmcomp/CSE.cmx : \
+  asmcomp/CSEgen.cmx \
+  asmcomp/arch.cmx \
+  asmcomp/mach.cmx
+asmcomp/arch.cmo : \
+  utils/config.cmi
+asmcomp/arch.cmx : \
+  utils/config.cmx
+asmcomp/proc.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  utils/ccomp.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+asmcomp/proc.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/reg.cmx \
+  utils/ccomp.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+asmcomp/reload.cmo : \
+  asmcomp/reloadgen.cmi
+asmcomp/reload.cmx : \
+  asmcomp/reloadgen.cmx
+asmcomp/scheduling.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/mach.cmi \
+  asmcomp/schedgen.cmi
+asmcomp/scheduling.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/schedgen.cmx
+asmcomp/selection.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/selectgen.cmi \
+  middle_end/debuginfo.cmi
+asmcomp/selection.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/selectgen.cmx \
+  middle_end/debuginfo.cmx
+asmcomp/CSE.cmo : \
+  asmcomp/CSEgen.cmi \
+  asmcomp/arch.cmo \
+  asmcomp/mach.cmi
+asmcomp/CSE.cmx : \
+  asmcomp/CSEgen.cmx \
+  asmcomp/arch.cmx \
+  asmcomp/mach.cmx
+asmcomp/arch.cmo :
+asmcomp/arch.cmx :
+asmcomp/proc.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/reg.cmi \
+  utils/ccomp.cmi \
+  utils/config.cmi \
+  utils/misc.cmi
+asmcomp/proc.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/reg.cmx \
+  utils/ccomp.cmx \
+  utils/config.cmx \
+  utils/misc.cmx
+asmcomp/reload.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/mach.cmi \
+  asmcomp/reloadgen.cmi
+asmcomp/reload.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/reloadgen.cmx
+asmcomp/scheduling.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/mach.cmi \
+  asmcomp/schedgen.cmi
+asmcomp/scheduling.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/schedgen.cmx
+asmcomp/selection.cmo : \
+  asmcomp/arch.cmo \
+  asmcomp/cmm.cmi \
+  asmcomp/mach.cmi \
+  asmcomp/selectgen.cmi
+asmcomp/selection.cmx : \
+  asmcomp/arch.cmx \
+  asmcomp/cmm.cmx \
+  asmcomp/mach.cmx \
+  asmcomp/selectgen.cmx
 driver/compdynlink.cmx : \
   asmcomp/cmx_format.cmi \
   driver/compdynlink.cmi

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -76,6 +76,13 @@ EOF
   [ $XARCH =  "i386" ] ||  (cd testsuite && $MAKE USE_RUNTIME="d" all)
   $MAKE install
   $MAKE manual-pregen
+  $MAKE alldepend
+  stale_depends_files="$(git status --short ':(glob)**/.depend')"
+  if [ "$stale_depends_files" ]; then
+      echo >&2 ".depend files are stale, you need to run make alldepend."
+      git diff | head -n 1000
+      exit 1
+  fi
   # check_all_arches checks tries to compile all backends in place,
   # we would need to redo (small parts of) world.opt afterwards to
   # use the compiler again

--- a/Makefile
+++ b/Makefile
@@ -1313,6 +1313,7 @@ depend: beforedepend
 		-impl driver/compdynlink.mlopt >> .depend
 	$(CAMLDEP) -slash $(DEPFLAGS) -bytecode \
 		-impl driver/compdynlink.mlbyte >> .depend
+	tools/normalize_depend .depend
 
 .PHONY: distclean
 distclean: clean

--- a/Makefile
+++ b/Makefile
@@ -923,6 +923,9 @@ beforedepend:: bytecomp/runtimedef.ml
 
 # Choose the right machine-dependent files
 
+ARCH_FILES_GREP_PATTERN=^asmcomp/\(arch\|proc\|selection\|CSE\|reload\|scheduling\)\.ml$
+ARCH_FILES=arch proc selection CSE reload scheduling
+
 asmcomp/arch.ml: asmcomp/$(ARCH)/arch.ml
 	cd asmcomp; $(LN) $(ARCH)/arch.ml .
 
@@ -1307,8 +1310,12 @@ partialclean::
 depend: beforedepend
 	(for d in utils parsing typing bytecomp asmcomp middle_end \
 	 middle_end/base_types asmcomp/debug driver toplevel; \
-	 do $(CAMLDEP) -slash $(DEPFLAGS) $$d/*.mli $$d/*.ml || exit; \
+	 do $(CAMLDEP) -slash $(DEPFLAGS) $$d/*.mli $$(echo $$d/*.ml | tr ' ' '\n' | grep -v "$(ARCH_FILES_GREP_PATTERN)") || exit; \
 	 done) > .depend
+	(for arch in $(ARCHES); do \
+	    $(CAMLDEP) -slash $(DEPFLAGS) asmcomp/$$arch/*.mli asmcomp/$$arch/*.ml \
+	       | sed -e s%asmcomp/$$arch/%asmcomp/% || exit; \
+          done) >> .depend
 	$(CAMLDEP) -slash $(DEPFLAGS) -native \
 		-impl driver/compdynlink.mlopt >> .depend
 	$(CAMLDEP) -slash $(DEPFLAGS) -bytecode \

--- a/asmrun/.depend
+++ b/asmrun/.depend
@@ -44,10 +44,17 @@ startup.$(O): \
   ../byterun/caml/sys.h \
   startup.c
 main.$(O): \
+  ../byterun/caml/address_class.h \
   ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
   ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
   ../byterun/caml/misc.h \
   ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
   ../byterun/caml/s.h \
   ../byterun/caml/sys.h \
   main.c
@@ -402,7 +409,6 @@ sys.$(O): \
   ../byterun/caml/freelist.h \
   ../byterun/caml/gc.h \
   ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/instruct.h \
   ../byterun/caml/io.h \
   ../byterun/caml/m.h \
   ../byterun/caml/major_gc.h \
@@ -512,6 +518,7 @@ lexing.$(O): \
   lexing.c
 unix.$(O): \
   ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
   ../byterun/caml/config.h \
   ../byterun/caml/fail.h \
   ../byterun/caml/freelist.h \
@@ -843,10 +850,17 @@ spacetime_offline.$(O): \
   ../byterun/caml/sys.h \
   spacetime_offline.c
 afl.$(O): \
+  ../byterun/caml/address_class.h \
   ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
   ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
   ../byterun/caml/misc.h \
   ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
   ../byterun/caml/s.h \
   afl.c
 bigarray.$(O): \
@@ -869,6 +883,25 @@ bigarray.$(O): \
   ../byterun/caml/mlvalues.h \
   ../byterun/caml/s.h \
   bigarray.c
+win32.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/sys.h \
+  ../byterun/win32.c
 startup_aux.p.$(O): \
   ../byterun/caml/address_class.h \
   ../byterun/caml/backtrace.h \
@@ -915,10 +948,17 @@ startup.p.$(O): \
   ../byterun/caml/sys.h \
   startup.c
 main.p.$(O): \
+  ../byterun/caml/address_class.h \
   ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
   ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
   ../byterun/caml/misc.h \
   ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
   ../byterun/caml/s.h \
   ../byterun/caml/sys.h \
   main.c
@@ -1273,7 +1313,6 @@ sys.p.$(O): \
   ../byterun/caml/freelist.h \
   ../byterun/caml/gc.h \
   ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/instruct.h \
   ../byterun/caml/io.h \
   ../byterun/caml/m.h \
   ../byterun/caml/major_gc.h \
@@ -1383,6 +1422,7 @@ lexing.p.$(O): \
   lexing.c
 unix.p.$(O): \
   ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
   ../byterun/caml/config.h \
   ../byterun/caml/fail.h \
   ../byterun/caml/freelist.h \
@@ -1714,10 +1754,17 @@ spacetime_offline.p.$(O): \
   ../byterun/caml/sys.h \
   spacetime_offline.c
 afl.p.$(O): \
+  ../byterun/caml/address_class.h \
   ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
   ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
   ../byterun/caml/misc.h \
   ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
   ../byterun/caml/s.h \
   afl.c
 bigarray.p.$(O): \
@@ -1740,6 +1787,25 @@ bigarray.p.$(O): \
   ../byterun/caml/mlvalues.h \
   ../byterun/caml/s.h \
   bigarray.c
+win32.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/sys.h \
+  ../byterun/win32.c
 startup_aux.d.$(O): \
   ../byterun/caml/address_class.h \
   ../byterun/caml/backtrace.h \
@@ -1786,10 +1852,17 @@ startup.d.$(O): \
   ../byterun/caml/sys.h \
   startup.c
 main.d.$(O): \
+  ../byterun/caml/address_class.h \
   ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
   ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
   ../byterun/caml/misc.h \
   ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
   ../byterun/caml/s.h \
   ../byterun/caml/sys.h \
   main.c
@@ -2144,7 +2217,6 @@ sys.d.$(O): \
   ../byterun/caml/freelist.h \
   ../byterun/caml/gc.h \
   ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/instruct.h \
   ../byterun/caml/io.h \
   ../byterun/caml/m.h \
   ../byterun/caml/major_gc.h \
@@ -2254,6 +2326,7 @@ lexing.d.$(O): \
   lexing.c
 unix.d.$(O): \
   ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
   ../byterun/caml/config.h \
   ../byterun/caml/fail.h \
   ../byterun/caml/freelist.h \
@@ -2585,10 +2658,17 @@ spacetime_offline.d.$(O): \
   ../byterun/caml/sys.h \
   spacetime_offline.c
 afl.d.$(O): \
+  ../byterun/caml/address_class.h \
   ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
   ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
   ../byterun/caml/misc.h \
   ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
   ../byterun/caml/s.h \
   afl.c
 bigarray.d.$(O): \
@@ -2611,6 +2691,25 @@ bigarray.d.$(O): \
   ../byterun/caml/mlvalues.h \
   ../byterun/caml/s.h \
   bigarray.c
+win32.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/sys.h \
+  ../byterun/win32.c
 startup_aux.i.$(O): \
   ../byterun/caml/address_class.h \
   ../byterun/caml/backtrace.h \
@@ -2657,10 +2756,17 @@ startup.i.$(O): \
   ../byterun/caml/sys.h \
   startup.c
 main.i.$(O): \
+  ../byterun/caml/address_class.h \
   ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
   ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
   ../byterun/caml/misc.h \
   ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
   ../byterun/caml/s.h \
   ../byterun/caml/sys.h \
   main.c
@@ -3015,7 +3121,6 @@ sys.i.$(O): \
   ../byterun/caml/freelist.h \
   ../byterun/caml/gc.h \
   ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/instruct.h \
   ../byterun/caml/io.h \
   ../byterun/caml/m.h \
   ../byterun/caml/major_gc.h \
@@ -3125,6 +3230,7 @@ lexing.i.$(O): \
   lexing.c
 unix.i.$(O): \
   ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
   ../byterun/caml/config.h \
   ../byterun/caml/fail.h \
   ../byterun/caml/freelist.h \
@@ -3456,10 +3562,17 @@ spacetime_offline.i.$(O): \
   ../byterun/caml/sys.h \
   spacetime_offline.c
 afl.i.$(O): \
+  ../byterun/caml/address_class.h \
   ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
   ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
   ../byterun/caml/misc.h \
   ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
   ../byterun/caml/s.h \
   afl.c
 bigarray.i.$(O): \
@@ -3482,3 +3595,22 @@ bigarray.i.$(O): \
   ../byterun/caml/mlvalues.h \
   ../byterun/caml/s.h \
   bigarray.c
+win32.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/sys.h \
+  ../byterun/win32.c

--- a/asmrun/.depend
+++ b/asmrun/.depend
@@ -1,1464 +1,3484 @@
-startup_aux.$(O): startup_aux.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/exec.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/callback.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/startup_aux.h
-startup.$(O): startup.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/custom.h ../byterun/caml/debugger.h \
-  ../byterun/caml/fail.h ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/printexc.h ../byterun/caml/stack.h \
-  ../byterun/caml/startup_aux.h ../byterun/caml/sys.h
-main.$(O): main.c ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/sys.h
-fail.$(O): fail.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/io.h \
-  ../byterun/caml/gc.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/printexc.h ../byterun/caml/signals.h \
-  ../byterun/caml/stack.h ../byterun/caml/roots.h \
-  ../byterun/caml/callback.h
-roots.$(O): roots.c ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/globroots.h \
-  ../byterun/caml/stack.h
-signals.$(O): signals.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/callback.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/signals.h \
-  ../byterun/caml/signals_machdep.h ../byterun/caml/sys.h
-signals_asm.$(O): signals_asm.c ../byterun/caml/fail.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
-  ../byterun/caml/signals_machdep.h signals_osdep.h \
-  ../byterun/caml/stack.h ../byterun/caml/spacetime.h \
-  ../byterun/caml/io.h
-misc.$(O): misc.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/misc.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/version.h
-freelist.$(O): freelist.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/freelist.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
-major_gc.$(O): major_gc.c ../byterun/caml/compact.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/weak.h
-minor_gc.$(O): minor_gc.c ../byterun/caml/custom.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/fail.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/weak.h
-memory.$(O): memory.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/signals.h
-alloc.$(O): alloc.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/stacks.h
-compare.$(O): compare.c ../byterun/caml/custom.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
-ints.$(O): ints.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-floats.$(O): floats.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h ../byterun/caml/stacks.h
-str.$(O): str.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-array.$(O): array.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h ../byterun/caml/spacetime.h \
-  ../byterun/caml/io.h ../byterun/caml/stack.h
-io.$(O): io.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/sys.h
-extern.$(O): extern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/md5.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h
-intern.$(O): intern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/callback.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/md5.h \
-  ../byterun/caml/memory.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/reverse.h
-hash.$(O): hash.c ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/custom.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/hash.h
-sys.$(O): sys.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/debugger.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/instruct.h ../byterun/caml/io.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h ../byterun/caml/stacks.h \
-  ../byterun/caml/sys.h ../byterun/caml/version.h \
-  ../byterun/caml/callback.h ../byterun/caml/startup_aux.h
-parsing.$(O): parsing.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/alloc.h
-gc_ctrl.$(O): gc_ctrl.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/compact.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/stack.h ../byterun/caml/startup_aux.h
-md5.$(O): md5.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/md5.h ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/reverse.h
-obj.$(O): obj.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
-  ../byterun/caml/interp.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/prims.h ../byterun/caml/spacetime.h \
-  ../byterun/caml/io.h ../byterun/caml/stack.h
-lexing.$(O): lexing.c ../byterun/caml/fail.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/stacks.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-unix.$(O): unix.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/fail.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/sys.h ../byterun/caml/io.h
-printexc.$(O): printexc.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/exec.h ../byterun/caml/callback.h \
-  ../byterun/caml/debugger.h ../byterun/caml/fail.h \
-  ../byterun/caml/printexc.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
-callback.$(O): callback.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-weak.$(O): weak.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/weak.h
-compact.$(O): compact.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/weak.h ../byterun/caml/compact.h
-finalise.$(O): finalise.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/compact.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h
-custom.$(O): custom.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-globroots.$(O): globroots.c ../byterun/caml/memory.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/gc.h ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/globroots.h
-backtrace_prim.$(O): backtrace_prim.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/backtrace_prim.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/stack.h
-backtrace.$(O): backtrace.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
-  ../byterun/caml/fail.h
-natdynlink.$(O): natdynlink.c ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/stack.h \
-  ../byterun/caml/callback.h ../byterun/caml/alloc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/fail.h ../byterun/caml/signals.h \
-  ../byterun/caml/hooks.h
-debugger.$(O): debugger.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/debugger.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-meta.$(O): meta.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/fix_code.h ../byterun/caml/interp.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/prims.h ../byterun/caml/stacks.h
-dynlink.$(O): dynlink.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/dynlink.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/prims.h \
-  ../byterun/caml/signals.h
-clambda_checks.$(O): clambda_checks.c ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h
-spacetime.$(O): spacetime.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/backtrace_prim.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/roots.h \
-  ../byterun/caml/signals.h ../byterun/caml/stack.h \
-  ../byterun/caml/sys.h ../byterun/caml/spacetime.h
-spacetime_snapshot.$(O): spacetime_snapshot.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/backtrace_prim.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/gc.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/roots.h \
-  ../byterun/caml/signals.h ../byterun/caml/stack.h \
-  ../byterun/caml/sys.h ../byterun/caml/spacetime.h
-spacetime_offline.$(O): spacetime_offline.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/gc.h ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/roots.h \
-  ../byterun/caml/signals.h ../byterun/caml/stack.h \
-  ../byterun/caml/sys.h ../byterun/caml/spacetime.h
-afl.$(O): afl.c ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/mlvalues.h
-bigarray.$(O): bigarray.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/bigarray.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/hash.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-startup_aux.p.$(O): startup_aux.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/exec.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/callback.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/startup_aux.h
-startup.p.$(O): startup.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/custom.h ../byterun/caml/debugger.h \
-  ../byterun/caml/fail.h ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/printexc.h ../byterun/caml/stack.h \
-  ../byterun/caml/startup_aux.h ../byterun/caml/sys.h
-main.p.$(O): main.c ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/sys.h
-fail.p.$(O): fail.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/io.h \
-  ../byterun/caml/gc.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/printexc.h ../byterun/caml/signals.h \
-  ../byterun/caml/stack.h ../byterun/caml/roots.h \
-  ../byterun/caml/callback.h
-roots.p.$(O): roots.c ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/globroots.h \
-  ../byterun/caml/stack.h
-signals.p.$(O): signals.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/callback.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/signals.h \
-  ../byterun/caml/signals_machdep.h ../byterun/caml/sys.h
-signals_asm.p.$(O): signals_asm.c ../byterun/caml/fail.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
-  ../byterun/caml/signals_machdep.h signals_osdep.h \
-  ../byterun/caml/stack.h ../byterun/caml/spacetime.h \
-  ../byterun/caml/io.h
-misc.p.$(O): misc.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/misc.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/version.h
-freelist.p.$(O): freelist.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/freelist.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
-major_gc.p.$(O): major_gc.c ../byterun/caml/compact.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/weak.h
-minor_gc.p.$(O): minor_gc.c ../byterun/caml/custom.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/fail.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/weak.h
-memory.p.$(O): memory.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/signals.h
-alloc.p.$(O): alloc.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/stacks.h
-compare.p.$(O): compare.c ../byterun/caml/custom.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
-ints.p.$(O): ints.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-floats.p.$(O): floats.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h ../byterun/caml/stacks.h
-str.p.$(O): str.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-array.p.$(O): array.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h ../byterun/caml/spacetime.h \
-  ../byterun/caml/io.h ../byterun/caml/stack.h
-io.p.$(O): io.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/sys.h
-extern.p.$(O): extern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/md5.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h
-intern.p.$(O): intern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/callback.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/md5.h \
-  ../byterun/caml/memory.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/reverse.h
-hash.p.$(O): hash.c ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/custom.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/hash.h
-sys.p.$(O): sys.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/debugger.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/instruct.h ../byterun/caml/io.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h ../byterun/caml/stacks.h \
-  ../byterun/caml/sys.h ../byterun/caml/version.h \
-  ../byterun/caml/callback.h ../byterun/caml/startup_aux.h
-parsing.p.$(O): parsing.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/alloc.h
-gc_ctrl.p.$(O): gc_ctrl.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/compact.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/stack.h ../byterun/caml/startup_aux.h
-md5.p.$(O): md5.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/md5.h ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/reverse.h
-obj.p.$(O): obj.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
-  ../byterun/caml/interp.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/prims.h ../byterun/caml/spacetime.h \
-  ../byterun/caml/io.h ../byterun/caml/stack.h
-lexing.p.$(O): lexing.c ../byterun/caml/fail.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/stacks.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-unix.p.$(O): unix.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/fail.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/sys.h ../byterun/caml/io.h
-printexc.p.$(O): printexc.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/exec.h ../byterun/caml/callback.h \
-  ../byterun/caml/debugger.h ../byterun/caml/fail.h \
-  ../byterun/caml/printexc.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
-callback.p.$(O): callback.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-weak.p.$(O): weak.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/weak.h
-compact.p.$(O): compact.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/weak.h ../byterun/caml/compact.h
-finalise.p.$(O): finalise.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/compact.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h
-custom.p.$(O): custom.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-globroots.p.$(O): globroots.c ../byterun/caml/memory.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/gc.h ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/globroots.h
-backtrace_prim.p.$(O): backtrace_prim.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/backtrace_prim.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/stack.h
-backtrace.p.$(O): backtrace.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
-  ../byterun/caml/fail.h
-natdynlink.p.$(O): natdynlink.c ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/stack.h \
-  ../byterun/caml/callback.h ../byterun/caml/alloc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/fail.h ../byterun/caml/signals.h \
-  ../byterun/caml/hooks.h
-debugger.p.$(O): debugger.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/debugger.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-meta.p.$(O): meta.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/fix_code.h ../byterun/caml/interp.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/prims.h ../byterun/caml/stacks.h
-dynlink.p.$(O): dynlink.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/dynlink.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/prims.h \
-  ../byterun/caml/signals.h
-clambda_checks.p.$(O): clambda_checks.c ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h
-spacetime.p.$(O): spacetime.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/backtrace_prim.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/roots.h \
-  ../byterun/caml/signals.h ../byterun/caml/stack.h \
-  ../byterun/caml/sys.h ../byterun/caml/spacetime.h
-spacetime_snapshot.p.$(O): spacetime_snapshot.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/backtrace_prim.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/gc.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/roots.h \
-  ../byterun/caml/signals.h ../byterun/caml/stack.h \
-  ../byterun/caml/sys.h ../byterun/caml/spacetime.h
-spacetime_offline.p.$(O): spacetime_offline.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/gc.h ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/roots.h \
-  ../byterun/caml/signals.h ../byterun/caml/stack.h \
-  ../byterun/caml/sys.h ../byterun/caml/spacetime.h
-afl.p.$(O): afl.c ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/mlvalues.h
-bigarray.p.$(O): bigarray.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/bigarray.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/hash.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-startup_aux.d.$(O): startup_aux.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/exec.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/callback.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/startup_aux.h
-startup.d.$(O): startup.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/custom.h ../byterun/caml/debugger.h \
-  ../byterun/caml/fail.h ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/printexc.h ../byterun/caml/stack.h \
-  ../byterun/caml/startup_aux.h ../byterun/caml/sys.h
-main.d.$(O): main.c ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/sys.h
-fail.d.$(O): fail.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/io.h \
-  ../byterun/caml/gc.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/printexc.h ../byterun/caml/signals.h \
-  ../byterun/caml/stack.h ../byterun/caml/roots.h \
-  ../byterun/caml/callback.h
-roots.d.$(O): roots.c ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/globroots.h \
-  ../byterun/caml/stack.h
-signals.d.$(O): signals.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/callback.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/signals.h \
-  ../byterun/caml/signals_machdep.h ../byterun/caml/sys.h
-signals_asm.d.$(O): signals_asm.c ../byterun/caml/fail.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
-  ../byterun/caml/signals_machdep.h signals_osdep.h \
-  ../byterun/caml/stack.h ../byterun/caml/spacetime.h \
-  ../byterun/caml/io.h
-misc.d.$(O): misc.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/misc.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/version.h
-freelist.d.$(O): freelist.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/freelist.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
-major_gc.d.$(O): major_gc.c ../byterun/caml/compact.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/weak.h
-minor_gc.d.$(O): minor_gc.c ../byterun/caml/custom.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/fail.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/weak.h
-memory.d.$(O): memory.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/signals.h
-alloc.d.$(O): alloc.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/stacks.h
-compare.d.$(O): compare.c ../byterun/caml/custom.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
-ints.d.$(O): ints.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-floats.d.$(O): floats.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h ../byterun/caml/stacks.h
-str.d.$(O): str.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-array.d.$(O): array.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h ../byterun/caml/spacetime.h \
-  ../byterun/caml/io.h ../byterun/caml/stack.h
-io.d.$(O): io.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/sys.h
-extern.d.$(O): extern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/md5.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h
-intern.d.$(O): intern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/callback.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/md5.h \
-  ../byterun/caml/memory.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/reverse.h
-hash.d.$(O): hash.c ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/custom.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/hash.h
-sys.d.$(O): sys.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/debugger.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/instruct.h ../byterun/caml/io.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h ../byterun/caml/stacks.h \
-  ../byterun/caml/sys.h ../byterun/caml/version.h \
-  ../byterun/caml/callback.h ../byterun/caml/startup_aux.h
-parsing.d.$(O): parsing.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/alloc.h
-gc_ctrl.d.$(O): gc_ctrl.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/compact.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/stack.h ../byterun/caml/startup_aux.h
-md5.d.$(O): md5.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/md5.h ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/reverse.h
-obj.d.$(O): obj.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
-  ../byterun/caml/interp.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/prims.h ../byterun/caml/spacetime.h \
-  ../byterun/caml/io.h ../byterun/caml/stack.h
-lexing.d.$(O): lexing.c ../byterun/caml/fail.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/stacks.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-unix.d.$(O): unix.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/fail.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/sys.h ../byterun/caml/io.h
-printexc.d.$(O): printexc.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/exec.h ../byterun/caml/callback.h \
-  ../byterun/caml/debugger.h ../byterun/caml/fail.h \
-  ../byterun/caml/printexc.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
-callback.d.$(O): callback.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-weak.d.$(O): weak.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/weak.h
-compact.d.$(O): compact.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/weak.h ../byterun/caml/compact.h
-finalise.d.$(O): finalise.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/compact.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h
-custom.d.$(O): custom.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-globroots.d.$(O): globroots.c ../byterun/caml/memory.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/gc.h ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/globroots.h
-backtrace_prim.d.$(O): backtrace_prim.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/backtrace_prim.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/stack.h
-backtrace.d.$(O): backtrace.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
-  ../byterun/caml/fail.h
-natdynlink.d.$(O): natdynlink.c ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/stack.h \
-  ../byterun/caml/callback.h ../byterun/caml/alloc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/fail.h ../byterun/caml/signals.h \
-  ../byterun/caml/hooks.h
-debugger.d.$(O): debugger.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/debugger.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-meta.d.$(O): meta.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/fix_code.h ../byterun/caml/interp.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/prims.h ../byterun/caml/stacks.h
-dynlink.d.$(O): dynlink.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/dynlink.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/prims.h \
-  ../byterun/caml/signals.h
-clambda_checks.d.$(O): clambda_checks.c ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h
-spacetime.d.$(O): spacetime.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/backtrace_prim.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/roots.h \
-  ../byterun/caml/signals.h ../byterun/caml/stack.h \
-  ../byterun/caml/sys.h ../byterun/caml/spacetime.h
-spacetime_snapshot.d.$(O): spacetime_snapshot.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/backtrace_prim.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/gc.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/roots.h \
-  ../byterun/caml/signals.h ../byterun/caml/stack.h \
-  ../byterun/caml/sys.h ../byterun/caml/spacetime.h
-spacetime_offline.d.$(O): spacetime_offline.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/gc.h ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/roots.h \
-  ../byterun/caml/signals.h ../byterun/caml/stack.h \
-  ../byterun/caml/sys.h ../byterun/caml/spacetime.h
-afl.d.$(O): afl.c ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/mlvalues.h
-bigarray.d.$(O): bigarray.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/bigarray.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/hash.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-startup_aux.i.$(O): startup_aux.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/exec.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/callback.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/startup_aux.h
-startup.i.$(O): startup.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/custom.h ../byterun/caml/debugger.h \
-  ../byterun/caml/fail.h ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/printexc.h ../byterun/caml/stack.h \
-  ../byterun/caml/startup_aux.h ../byterun/caml/sys.h
-main.i.$(O): main.c ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/sys.h
-fail.i.$(O): fail.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/io.h \
-  ../byterun/caml/gc.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/printexc.h ../byterun/caml/signals.h \
-  ../byterun/caml/stack.h ../byterun/caml/roots.h \
-  ../byterun/caml/callback.h
-roots.i.$(O): roots.c ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/globroots.h \
-  ../byterun/caml/stack.h
-signals.i.$(O): signals.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/callback.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/signals.h \
-  ../byterun/caml/signals_machdep.h ../byterun/caml/sys.h
-signals_asm.i.$(O): signals_asm.c ../byterun/caml/fail.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/signals.h \
-  ../byterun/caml/signals_machdep.h signals_osdep.h \
-  ../byterun/caml/stack.h ../byterun/caml/spacetime.h \
-  ../byterun/caml/io.h
-misc.i.$(O): misc.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/misc.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/version.h
-freelist.i.$(O): freelist.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/freelist.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
-major_gc.i.$(O): major_gc.c ../byterun/caml/compact.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/weak.h
-minor_gc.i.$(O): minor_gc.c ../byterun/caml/custom.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/fail.h ../byterun/caml/finalise.h \
-  ../byterun/caml/roots.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/weak.h
-memory.i.$(O): memory.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/fail.h ../byterun/caml/freelist.h ../byterun/caml/gc.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/signals.h
-alloc.i.$(O): alloc.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/stacks.h
-compare.i.$(O): compare.c ../byterun/caml/custom.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/fail.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
-ints.i.$(O): ints.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-floats.i.$(O): floats.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h ../byterun/caml/stacks.h
-str.i.$(O): str.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-array.i.$(O): array.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h ../byterun/caml/spacetime.h \
-  ../byterun/caml/io.h ../byterun/caml/stack.h
-io.i.$(O): io.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/sys.h
-extern.i.$(O): extern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/md5.h ../byterun/caml/memory.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/reverse.h
-intern.i.$(O): intern.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/callback.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/md5.h \
-  ../byterun/caml/memory.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/reverse.h
-hash.i.$(O): hash.c ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/custom.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/hash.h
-sys.i.$(O): sys.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/debugger.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/instruct.h ../byterun/caml/io.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h ../byterun/caml/stacks.h \
-  ../byterun/caml/sys.h ../byterun/caml/version.h \
-  ../byterun/caml/callback.h ../byterun/caml/startup_aux.h
-parsing.i.$(O): parsing.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/alloc.h
-gc_ctrl.i.$(O): gc_ctrl.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/compact.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/gc_ctrl.h ../byterun/caml/signals.h \
-  ../byterun/caml/stack.h ../byterun/caml/startup_aux.h
-md5.i.$(O): md5.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/md5.h ../byterun/caml/io.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/reverse.h
-obj.i.$(O): obj.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h ../byterun/caml/gc.h \
-  ../byterun/caml/interp.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/prims.h ../byterun/caml/spacetime.h \
-  ../byterun/caml/io.h ../byterun/caml/stack.h
-lexing.i.$(O): lexing.c ../byterun/caml/fail.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/stacks.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-unix.i.$(O): unix.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/fail.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/signals.h ../byterun/caml/sys.h ../byterun/caml/io.h
-printexc.i.$(O): printexc.c ../byterun/caml/backtrace.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/exec.h ../byterun/caml/callback.h \
-  ../byterun/caml/debugger.h ../byterun/caml/fail.h \
-  ../byterun/caml/printexc.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h
-callback.i.$(O): callback.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-weak.i.$(O): weak.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/weak.h
-compact.i.$(O): compact.c ../byterun/caml/address_class.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/weak.h ../byterun/caml/compact.h
-finalise.i.$(O): finalise.c ../byterun/caml/callback.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/misc.h \
-  ../byterun/caml/compact.h ../byterun/caml/fail.h \
-  ../byterun/caml/finalise.h ../byterun/caml/roots.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/signals.h
-custom.i.$(O): custom.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/custom.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-globroots.i.$(O): globroots.c ../byterun/caml/memory.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/gc.h ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/roots.h ../byterun/caml/globroots.h
-backtrace_prim.i.$(O): backtrace_prim.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/backtrace_prim.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/stack.h
-backtrace.i.$(O): backtrace.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/backtrace_prim.h \
-  ../byterun/caml/fail.h
-natdynlink.i.$(O): natdynlink.c ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/memory.h \
-  ../byterun/caml/gc.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/stack.h \
-  ../byterun/caml/callback.h ../byterun/caml/alloc.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/osdeps.h \
-  ../byterun/caml/fail.h ../byterun/caml/signals.h \
-  ../byterun/caml/hooks.h
-debugger.i.$(O): debugger.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/debugger.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
-meta.i.$(O): meta.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/fix_code.h ../byterun/caml/interp.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/prims.h ../byterun/caml/stacks.h
-dynlink.i.$(O): dynlink.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/dynlink.h \
-  ../byterun/caml/fail.h ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/prims.h \
-  ../byterun/caml/signals.h
-clambda_checks.i.$(O): clambda_checks.c ../byterun/caml/mlvalues.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/misc.h
-spacetime.i.$(O): spacetime.c ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/backtrace_prim.h \
-  ../byterun/caml/backtrace.h ../byterun/caml/exec.h \
-  ../byterun/caml/fail.h ../byterun/caml/gc.h ../byterun/caml/intext.h \
-  ../byterun/caml/io.h ../byterun/caml/major_gc.h \
-  ../byterun/caml/freelist.h ../byterun/caml/memory.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
-  ../byterun/caml/osdeps.h ../byterun/caml/roots.h \
-  ../byterun/caml/signals.h ../byterun/caml/stack.h \
-  ../byterun/caml/sys.h ../byterun/caml/spacetime.h
-spacetime_snapshot.i.$(O): spacetime_snapshot.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h \
-  ../byterun/caml/backtrace_prim.h ../byterun/caml/backtrace.h \
-  ../byterun/caml/exec.h ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/gc.h ../byterun/caml/gc_ctrl.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/roots.h \
-  ../byterun/caml/signals.h ../byterun/caml/stack.h \
-  ../byterun/caml/sys.h ../byterun/caml/spacetime.h
-spacetime_offline.i.$(O): spacetime_offline.c ../byterun/caml/alloc.h \
-  ../byterun/caml/misc.h ../byterun/caml/config.h ../byterun/caml/m.h \
-  ../byterun/caml/s.h ../byterun/caml/mlvalues.h ../byterun/caml/fail.h \
-  ../byterun/caml/gc.h ../byterun/caml/intext.h ../byterun/caml/io.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/memory.h ../byterun/caml/minor_gc.h \
-  ../byterun/caml/address_class.h ../byterun/caml/roots.h \
-  ../byterun/caml/signals.h ../byterun/caml/stack.h \
-  ../byterun/caml/sys.h ../byterun/caml/spacetime.h
-afl.i.$(O): afl.c ../byterun/caml/misc.h ../byterun/caml/config.h \
-  ../byterun/caml/m.h ../byterun/caml/s.h ../byterun/caml/mlvalues.h
-bigarray.i.$(O): bigarray.c ../byterun/caml/alloc.h ../byterun/caml/misc.h \
-  ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
-  ../byterun/caml/mlvalues.h ../byterun/caml/bigarray.h \
-  ../byterun/caml/custom.h ../byterun/caml/fail.h \
-  ../byterun/caml/intext.h ../byterun/caml/io.h ../byterun/caml/hash.h \
-  ../byterun/caml/memory.h ../byterun/caml/gc.h \
-  ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
-  ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h
+startup_aux.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/startup_aux.h \
+  startup_aux.c
+startup.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/printexc.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/startup_aux.h \
+  ../byterun/caml/sys.h \
+  startup.c
+main.$(O): \
+  ../byterun/caml/config.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/sys.h \
+  main.c
+fail.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/printexc.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stack.h \
+  fail.c
+roots.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/globroots.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stack.h \
+  roots.c
+signals.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/signals_machdep.h \
+  ../byterun/caml/sys.h \
+  signals.c
+signals_asm.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/signals_machdep.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  signals_asm.c \
+  signals_osdep.h
+misc.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/version.h \
+  misc.c
+freelist.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  freelist.c
+major_gc.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/weak.h \
+  major_gc.c
+minor_gc.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/weak.h \
+  minor_gc.c
+memory.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  memory.c
+alloc.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  alloc.c
+compare.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  compare.c
+ints.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ints.c
+floats.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  floats.c
+str.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  str.c
+array.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  array.c
+io.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/sys.h \
+  io.c
+extern.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/md5.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  extern.c
+intern.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/md5.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  intern.c
+hash.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/hash.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  hash.c
+sys.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/instruct.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stacks.h \
+  ../byterun/caml/startup_aux.h \
+  ../byterun/caml/sys.h \
+  ../byterun/caml/version.h \
+  sys.c
+parsing.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  parsing.c
+gc_ctrl.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/startup_aux.h \
+  gc_ctrl.c
+md5.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/md5.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  md5.c
+obj.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/interp.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/prims.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  obj.c
+lexing.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  lexing.c
+unix.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/sys.h \
+  unix.c
+printexc.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/printexc.h \
+  ../byterun/caml/s.h \
+  printexc.c
+callback.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  callback.c
+weak.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/weak.h \
+  weak.c
+compact.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/weak.h \
+  compact.c
+finalise.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  finalise.c
+custom.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  custom.c
+globroots.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/globroots.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  globroots.c
+backtrace_prim.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stack.h \
+  backtrace_prim.c
+backtrace.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  backtrace.c
+natdynlink.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/hooks.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stack.h \
+  natdynlink.c
+debugger.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  debugger.c
+meta.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/fix_code.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/interp.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/prims.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  meta.c
+dynlink.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/dynlink.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/prims.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  dynlink.c
+clambda_checks.$(O): \
+  ../byterun/caml/config.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  clambda_checks.c
+spacetime.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/sys.h \
+  spacetime.c
+spacetime_snapshot.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/sys.h \
+  spacetime_snapshot.c
+spacetime_offline.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/sys.h \
+  spacetime_offline.c
+afl.$(O): \
+  ../byterun/caml/config.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  afl.c
+bigarray.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/bigarray.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/hash.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  bigarray.c
+startup_aux.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/startup_aux.h \
+  startup_aux.c
+startup.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/printexc.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/startup_aux.h \
+  ../byterun/caml/sys.h \
+  startup.c
+main.p.$(O): \
+  ../byterun/caml/config.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/sys.h \
+  main.c
+fail.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/printexc.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stack.h \
+  fail.c
+roots.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/globroots.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stack.h \
+  roots.c
+signals.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/signals_machdep.h \
+  ../byterun/caml/sys.h \
+  signals.c
+signals_asm.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/signals_machdep.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  signals_asm.c \
+  signals_osdep.h
+misc.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/version.h \
+  misc.c
+freelist.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  freelist.c
+major_gc.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/weak.h \
+  major_gc.c
+minor_gc.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/weak.h \
+  minor_gc.c
+memory.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  memory.c
+alloc.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  alloc.c
+compare.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  compare.c
+ints.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ints.c
+floats.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  floats.c
+str.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  str.c
+array.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  array.c
+io.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/sys.h \
+  io.c
+extern.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/md5.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  extern.c
+intern.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/md5.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  intern.c
+hash.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/hash.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  hash.c
+sys.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/instruct.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stacks.h \
+  ../byterun/caml/startup_aux.h \
+  ../byterun/caml/sys.h \
+  ../byterun/caml/version.h \
+  sys.c
+parsing.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  parsing.c
+gc_ctrl.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/startup_aux.h \
+  gc_ctrl.c
+md5.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/md5.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  md5.c
+obj.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/interp.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/prims.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  obj.c
+lexing.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  lexing.c
+unix.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/sys.h \
+  unix.c
+printexc.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/printexc.h \
+  ../byterun/caml/s.h \
+  printexc.c
+callback.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  callback.c
+weak.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/weak.h \
+  weak.c
+compact.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/weak.h \
+  compact.c
+finalise.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  finalise.c
+custom.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  custom.c
+globroots.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/globroots.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  globroots.c
+backtrace_prim.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stack.h \
+  backtrace_prim.c
+backtrace.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  backtrace.c
+natdynlink.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/hooks.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stack.h \
+  natdynlink.c
+debugger.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  debugger.c
+meta.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/fix_code.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/interp.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/prims.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  meta.c
+dynlink.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/dynlink.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/prims.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  dynlink.c
+clambda_checks.p.$(O): \
+  ../byterun/caml/config.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  clambda_checks.c
+spacetime.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/sys.h \
+  spacetime.c
+spacetime_snapshot.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/sys.h \
+  spacetime_snapshot.c
+spacetime_offline.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/sys.h \
+  spacetime_offline.c
+afl.p.$(O): \
+  ../byterun/caml/config.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  afl.c
+bigarray.p.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/bigarray.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/hash.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  bigarray.c
+startup_aux.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/startup_aux.h \
+  startup_aux.c
+startup.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/printexc.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/startup_aux.h \
+  ../byterun/caml/sys.h \
+  startup.c
+main.d.$(O): \
+  ../byterun/caml/config.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/sys.h \
+  main.c
+fail.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/printexc.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stack.h \
+  fail.c
+roots.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/globroots.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stack.h \
+  roots.c
+signals.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/signals_machdep.h \
+  ../byterun/caml/sys.h \
+  signals.c
+signals_asm.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/signals_machdep.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  signals_asm.c \
+  signals_osdep.h
+misc.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/version.h \
+  misc.c
+freelist.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  freelist.c
+major_gc.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/weak.h \
+  major_gc.c
+minor_gc.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/weak.h \
+  minor_gc.c
+memory.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  memory.c
+alloc.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  alloc.c
+compare.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  compare.c
+ints.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ints.c
+floats.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  floats.c
+str.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  str.c
+array.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  array.c
+io.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/sys.h \
+  io.c
+extern.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/md5.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  extern.c
+intern.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/md5.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  intern.c
+hash.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/hash.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  hash.c
+sys.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/instruct.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stacks.h \
+  ../byterun/caml/startup_aux.h \
+  ../byterun/caml/sys.h \
+  ../byterun/caml/version.h \
+  sys.c
+parsing.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  parsing.c
+gc_ctrl.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/startup_aux.h \
+  gc_ctrl.c
+md5.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/md5.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  md5.c
+obj.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/interp.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/prims.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  obj.c
+lexing.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  lexing.c
+unix.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/sys.h \
+  unix.c
+printexc.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/printexc.h \
+  ../byterun/caml/s.h \
+  printexc.c
+callback.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  callback.c
+weak.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/weak.h \
+  weak.c
+compact.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/weak.h \
+  compact.c
+finalise.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  finalise.c
+custom.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  custom.c
+globroots.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/globroots.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  globroots.c
+backtrace_prim.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stack.h \
+  backtrace_prim.c
+backtrace.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  backtrace.c
+natdynlink.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/hooks.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stack.h \
+  natdynlink.c
+debugger.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  debugger.c
+meta.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/fix_code.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/interp.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/prims.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  meta.c
+dynlink.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/dynlink.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/prims.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  dynlink.c
+clambda_checks.d.$(O): \
+  ../byterun/caml/config.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  clambda_checks.c
+spacetime.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/sys.h \
+  spacetime.c
+spacetime_snapshot.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/sys.h \
+  spacetime_snapshot.c
+spacetime_offline.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/sys.h \
+  spacetime_offline.c
+afl.d.$(O): \
+  ../byterun/caml/config.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  afl.c
+bigarray.d.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/bigarray.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/hash.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  bigarray.c
+startup_aux.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/startup_aux.h \
+  startup_aux.c
+startup.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/printexc.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/startup_aux.h \
+  ../byterun/caml/sys.h \
+  startup.c
+main.i.$(O): \
+  ../byterun/caml/config.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/sys.h \
+  main.c
+fail.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/printexc.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stack.h \
+  fail.c
+roots.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/globroots.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stack.h \
+  roots.c
+signals.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/signals_machdep.h \
+  ../byterun/caml/sys.h \
+  signals.c
+signals_asm.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/signals_machdep.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  signals_asm.c \
+  signals_osdep.h
+misc.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/version.h \
+  misc.c
+freelist.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  freelist.c
+major_gc.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/weak.h \
+  major_gc.c
+minor_gc.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/weak.h \
+  minor_gc.c
+memory.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  memory.c
+alloc.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  alloc.c
+compare.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  compare.c
+ints.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ints.c
+floats.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  floats.c
+str.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  str.c
+array.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  array.c
+io.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/sys.h \
+  io.c
+extern.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/md5.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  extern.c
+intern.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/md5.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  intern.c
+hash.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/hash.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  hash.c
+sys.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/instruct.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stacks.h \
+  ../byterun/caml/startup_aux.h \
+  ../byterun/caml/sys.h \
+  ../byterun/caml/version.h \
+  sys.c
+parsing.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  parsing.c
+gc_ctrl.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/startup_aux.h \
+  gc_ctrl.c
+md5.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/md5.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/reverse.h \
+  ../byterun/caml/s.h \
+  md5.c
+obj.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/interp.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/prims.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  obj.c
+lexing.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  lexing.c
+unix.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/sys.h \
+  unix.c
+printexc.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/printexc.h \
+  ../byterun/caml/s.h \
+  printexc.c
+callback.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  callback.c
+weak.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/weak.h \
+  weak.c
+compact.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/weak.h \
+  compact.c
+finalise.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/compact.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/finalise.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  finalise.c
+custom.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  custom.c
+globroots.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/globroots.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  globroots.c
+backtrace_prim.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stack.h \
+  backtrace_prim.c
+backtrace.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  backtrace.c
+natdynlink.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/callback.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/hooks.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/stack.h \
+  natdynlink.c
+debugger.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/debugger.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  debugger.c
+meta.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/fix_code.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/interp.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/prims.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/stacks.h \
+  meta.c
+dynlink.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/dynlink.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/prims.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  dynlink.c
+clambda_checks.i.$(O): \
+  ../byterun/caml/config.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  clambda_checks.c
+spacetime.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/sys.h \
+  spacetime.c
+spacetime_snapshot.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/backtrace.h \
+  ../byterun/caml/backtrace_prim.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/exec.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/gc_ctrl.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/sys.h \
+  spacetime_snapshot.c
+spacetime_offline.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/roots.h \
+  ../byterun/caml/s.h \
+  ../byterun/caml/signals.h \
+  ../byterun/caml/spacetime.h \
+  ../byterun/caml/stack.h \
+  ../byterun/caml/sys.h \
+  spacetime_offline.c
+afl.i.$(O): \
+  ../byterun/caml/config.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  afl.c
+bigarray.i.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/alloc.h \
+  ../byterun/caml/bigarray.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/custom.h \
+  ../byterun/caml/fail.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/hash.h \
+  ../byterun/caml/intext.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/s.h \
+  bigarray.c

--- a/asmrun/Makefile
+++ b/asmrun/Makefile
@@ -190,6 +190,7 @@ depend: $(COBJS:.$(O)=.c) $(sources)
 	  >> .depend
 	$(CC) -MM $(IFLAGS) $(CPPFLAGS) $^ | sed -e 's/\.o/.i.$$(O)/' \
 	  >> .depend
+	../tools/normalize_depend .depend
 endif
 
 include .depend

--- a/byterun/.depend
+++ b/byterun/.depend
@@ -1,791 +1,3484 @@
-afl.$(O): afl.c caml/misc.h caml/config.h caml/m.h caml/s.h caml/mlvalues.h
-alloc.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
+afl.$(O): \
+  afl.c \
+  caml/config.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h
+alloc.$(O): \
+  alloc.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
   caml/stacks.h
-array.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/signals.h \
+array.$(O): \
+  array.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/signals.h \
   caml/spacetime.h
-backtrace.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
-  caml/exec.h caml/backtrace_prim.h caml/fail.h
-backtrace_prim.$(O): backtrace_prim.c caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/alloc.h caml/custom.h caml/io.h \
-  caml/instruct.h caml/intext.h caml/exec.h caml/fix_code.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/startup.h caml/stacks.h \
-  caml/sys.h caml/backtrace.h caml/fail.h caml/backtrace_prim.h
-bigarray.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/bigarray.h caml/custom.h caml/fail.h \
-  caml/intext.h caml/io.h caml/hash.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-callback.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/interp.h caml/instruct.h caml/fix_code.h caml/stacks.h
-compact.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/mlvalues.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/gc_ctrl.h caml/weak.h caml/compact.h
-compare.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-custom.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h
-debugger.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/debugger.h caml/osdeps.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/fail.h caml/fix_code.h caml/instruct.h \
-  caml/intext.h caml/io.h caml/stacks.h caml/sys.h
-dynlink.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/mlvalues.h caml/dynlink.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/osdeps.h caml/prims.h caml/signals.h
-extern.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h
-fail.$(O): fail.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/printexc.h caml/signals.h caml/stacks.h
-finalise.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/compact.h caml/fail.h \
-  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/signals.h
-fix_code.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
-  caml/misc.h caml/mlvalues.h caml/fix_code.h caml/instruct.h \
-  caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h
-floats.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h caml/stacks.h
-freelist.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
-  caml/misc.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h caml/memory.h \
-  caml/major_gc.h caml/minor_gc.h caml/address_class.h
-gc_ctrl.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
-  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/gc_ctrl.h caml/signals.h caml/stacks.h \
-  caml/startup_aux.h
-globroots.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
-  caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/roots.h caml/globroots.h
-hash.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/hash.h
-instrtrace.$(O): instrtrace.c
-intern.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/callback.h caml/custom.h caml/fail.h \
-  caml/gc.h caml/intext.h caml/io.h caml/md5.h caml/memory.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h
-interp.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
-  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/prims.h caml/signals.h caml/stacks.h caml/startup_aux.h \
-  caml/jumptbl.h
-ints.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h
-io.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/osdeps.h caml/signals.h caml/sys.h
-lexing.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-main.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/sys.h
-major_gc.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/mlvalues.h caml/custom.h caml/fail.h caml/finalise.h \
-  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/gc_ctrl.h caml/signals.h \
-  caml/weak.h
-md5.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/md5.h caml/io.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/reverse.h
-memory.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/mlvalues.h caml/fail.h caml/freelist.h caml/gc.h \
-  caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
-  caml/signals.h
-meta.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/fix_code.h caml/interp.h \
-  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/address_class.h caml/prims.h \
+backtrace.$(O): \
+  backtrace.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/backtrace_prim.h \
+  caml/config.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h
+backtrace_prim.$(O): \
+  backtrace_prim.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/backtrace_prim.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/stacks.h \
+  caml/startup.h \
+  caml/sys.h
+bigarray.$(O): \
+  bigarray.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/bigarray.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/hash.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h
+callback.$(O): \
+  callback.c \
+  caml/address_class.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/interp.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
   caml/stacks.h
-minor_gc.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/finalise.h caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/gc_ctrl.h caml/signals.h \
-  caml/weak.h
-misc.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/memory.h \
-  caml/gc.h caml/mlvalues.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/version.h
-obj.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h \
-  caml/freelist.h caml/memory.h caml/minor_gc.h caml/address_class.h \
-  caml/prims.h caml/spacetime.h
-parsing.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
-  caml/misc.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/alloc.h
-prims.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/prims.h
-printexc.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/printexc.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-roots.$(O): roots.c caml/finalise.h caml/roots.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/globroots.h caml/stacks.h
-signals.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/callback.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/roots.h caml/signals.h \
-  caml/signals_machdep.h caml/sys.h
-signals_byt.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
-  caml/signals.h caml/signals_machdep.h
-spacetime.$(O): spacetime.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h
-stacks.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
-  caml/misc.h caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-startup.$(O): startup.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
-  caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h \
-  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
-  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
-  caml/osdeps.h caml/prims.h caml/printexc.h caml/reverse.h \
-  caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
-  caml/startup_aux.h caml/version.h
-startup_aux.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/exec.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/callback.h caml/dynlink.h caml/osdeps.h \
-  caml/startup_aux.h
-str.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h
-sys.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
-  caml/instruct.h caml/io.h caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
-  caml/startup_aux.h
-unix.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
-  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
-  caml/signals.h caml/sys.h caml/io.h
-weak.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/weak.h
-afl.d.$(O): afl.c caml/misc.h caml/config.h caml/m.h caml/s.h caml/mlvalues.h
-alloc.d.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
+compact.$(O): \
+  caml/address_class.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/weak.h \
+  compact.c
+compare.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  compare.c
+custom.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  custom.c
+debugger.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/stacks.h \
+  caml/sys.h \
+  debugger.c
+dynlink.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/dynlink.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/signals.h \
+  dynlink.c
+extern.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  extern.c
+fail.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/printexc.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  fail.c
+finalise.$(O): \
+  caml/address_class.h \
+  caml/callback.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  finalise.c
+fix_code.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  fix_code.c
+floats.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  caml/stacks.h \
+  floats.c
+freelist.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  freelist.c
+gc_ctrl.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup_aux.h \
+  gc_ctrl.c
+globroots.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/globroots.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  globroots.c
+hash.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/hash.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  hash.c
+instrtrace.$(O): \
+  instrtrace.c
+intern.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  intern.c
+interp.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instrtrace.h \
+  caml/instruct.h \
+  caml/interp.h \
+  caml/jumptbl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup_aux.h \
+  interp.c
+ints.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  ints.c
+io.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/sys.h \
+  io.c
+lexing.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/stacks.h \
+  lexing.c
+main.$(O): \
+  caml/config.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/sys.h \
+  main.c
+major_gc.$(O): \
+  caml/address_class.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/weak.h \
+  major_gc.c
+md5.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  md5.c
+memory.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/signals.h \
+  memory.c
+meta.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/interp.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/stacks.h \
+  meta.c
+minor_gc.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/weak.h \
+  minor_gc.c
+misc.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/version.h \
+  misc.c
+obj.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/interp.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/spacetime.h \
+  obj.c
+parsing.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  parsing.c
+prims.$(O): \
+  caml/config.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  prims.c
+printexc.$(O): \
+  caml/address_class.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/printexc.h \
+  caml/s.h \
+  printexc.c
+roots.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/globroots.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/stacks.h \
+  roots.c
+signals.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/signals_machdep.h \
+  caml/sys.h \
+  signals.c
+signals_byt.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/signals_machdep.h \
+  signals_byt.c
+spacetime.$(O): \
+  caml/config.h \
+  caml/fail.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  spacetime.c
+stacks.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/stacks.h \
+  stacks.c
+startup.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/debugger.h \
+  caml/dynlink.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/instrtrace.h \
+  caml/interp.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/prims.h \
+  caml/printexc.h \
+  caml/reverse.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup.h \
+  caml/startup_aux.h \
+  caml/sys.h \
+  caml/version.h \
+  startup.c
+startup_aux.$(O): \
+  caml/address_class.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/dynlink.h \
+  caml/exec.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/startup_aux.h \
+  startup_aux.c
+str.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  str.c
+sys.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/instruct.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup_aux.h \
+  caml/sys.h \
+  caml/version.h \
+  sys.c
+unix.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/sys.h \
+  unix.c
+weak.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/weak.h \
+  weak.c
+afl.d.$(O): \
+  afl.c \
+  caml/config.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h
+alloc.d.$(O): \
+  alloc.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
   caml/stacks.h
-array.d.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/signals.h \
+array.d.$(O): \
+  array.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/signals.h \
   caml/spacetime.h
-backtrace.d.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
-  caml/exec.h caml/backtrace_prim.h caml/fail.h
-backtrace_prim.d.$(O): backtrace_prim.c caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/alloc.h caml/custom.h caml/io.h \
-  caml/instruct.h caml/intext.h caml/exec.h caml/fix_code.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/startup.h caml/stacks.h \
-  caml/sys.h caml/backtrace.h caml/fail.h caml/backtrace_prim.h
-bigarray.d.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/bigarray.h caml/custom.h caml/fail.h \
-  caml/intext.h caml/io.h caml/hash.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-callback.d.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/interp.h caml/instruct.h caml/fix_code.h caml/stacks.h
-compact.d.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/mlvalues.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/gc_ctrl.h caml/weak.h caml/compact.h
-compare.d.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-custom.d.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h
-debugger.d.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/debugger.h caml/osdeps.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/fail.h caml/fix_code.h caml/instruct.h \
-  caml/intext.h caml/io.h caml/stacks.h caml/sys.h
-dynlink.d.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/mlvalues.h caml/dynlink.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/osdeps.h caml/prims.h caml/signals.h
-extern.d.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h
-fail.d.$(O): fail.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/printexc.h caml/signals.h caml/stacks.h
-finalise.d.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/compact.h caml/fail.h \
-  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/signals.h
-fix_code.d.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
-  caml/misc.h caml/mlvalues.h caml/fix_code.h caml/instruct.h \
-  caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h
-floats.d.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h caml/stacks.h
-freelist.d.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
-  caml/misc.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h caml/memory.h \
-  caml/major_gc.h caml/minor_gc.h caml/address_class.h
-gc_ctrl.d.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
-  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/gc_ctrl.h caml/signals.h caml/stacks.h \
-  caml/startup_aux.h
-globroots.d.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
-  caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/roots.h caml/globroots.h
-hash.d.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/hash.h
-instrtrace.d.$(O): instrtrace.c caml/instrtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/instruct.h \
-  caml/opnames.h caml/prims.h caml/stacks.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/startup_aux.h
-intern.d.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/callback.h caml/custom.h caml/fail.h \
-  caml/gc.h caml/intext.h caml/io.h caml/md5.h caml/memory.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h
-interp.d.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
-  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/prims.h caml/signals.h caml/stacks.h caml/startup_aux.h
-ints.d.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h
-io.d.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/osdeps.h caml/signals.h caml/sys.h
-lexing.d.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-main.d.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/sys.h
-major_gc.d.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/mlvalues.h caml/custom.h caml/fail.h caml/finalise.h \
-  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/gc_ctrl.h caml/signals.h \
-  caml/weak.h
-md5.d.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/md5.h caml/io.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/reverse.h
-memory.d.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/mlvalues.h caml/fail.h caml/freelist.h caml/gc.h \
-  caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
-  caml/signals.h
-meta.d.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/fix_code.h caml/interp.h \
-  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/address_class.h caml/prims.h \
+backtrace.d.$(O): \
+  backtrace.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/backtrace_prim.h \
+  caml/config.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h
+backtrace_prim.d.$(O): \
+  backtrace_prim.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/backtrace_prim.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/stacks.h \
+  caml/startup.h \
+  caml/sys.h
+bigarray.d.$(O): \
+  bigarray.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/bigarray.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/hash.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h
+callback.d.$(O): \
+  callback.c \
+  caml/address_class.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/interp.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
   caml/stacks.h
-minor_gc.d.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/finalise.h caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/gc_ctrl.h caml/signals.h \
-  caml/weak.h
-misc.d.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/memory.h \
-  caml/gc.h caml/mlvalues.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/version.h
-obj.d.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h \
-  caml/freelist.h caml/memory.h caml/minor_gc.h caml/address_class.h \
-  caml/prims.h caml/spacetime.h
-parsing.d.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
-  caml/misc.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/alloc.h
-prims.d.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/prims.h
-printexc.d.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/printexc.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-roots.d.$(O): roots.c caml/finalise.h caml/roots.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/globroots.h caml/stacks.h
-signals.d.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/callback.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/roots.h caml/signals.h \
-  caml/signals_machdep.h caml/sys.h
-signals_byt.d.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
-  caml/signals.h caml/signals_machdep.h
-spacetime.d.$(O): spacetime.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h
-stacks.d.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
-  caml/misc.h caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-startup.d.$(O): startup.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
-  caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h \
-  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
-  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
-  caml/osdeps.h caml/prims.h caml/printexc.h caml/reverse.h \
-  caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
-  caml/startup_aux.h caml/version.h
-startup_aux.d.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/exec.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/callback.h caml/dynlink.h caml/osdeps.h \
-  caml/startup_aux.h
-str.d.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h
-sys.d.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
-  caml/instruct.h caml/io.h caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
-  caml/startup_aux.h
-unix.d.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
-  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
-  caml/signals.h caml/sys.h caml/io.h
-weak.d.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/weak.h
-afl.i.$(O): afl.c caml/misc.h caml/config.h caml/m.h caml/s.h caml/mlvalues.h
-alloc.i.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
+compact.d.$(O): \
+  caml/address_class.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/weak.h \
+  compact.c
+compare.d.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  compare.c
+custom.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  custom.c
+debugger.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/stacks.h \
+  caml/sys.h \
+  debugger.c
+dynlink.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/dynlink.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/signals.h \
+  dynlink.c
+extern.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  extern.c
+fail.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/printexc.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  fail.c
+finalise.d.$(O): \
+  caml/address_class.h \
+  caml/callback.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  finalise.c
+fix_code.d.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  fix_code.c
+floats.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  caml/stacks.h \
+  floats.c
+freelist.d.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  freelist.c
+gc_ctrl.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup_aux.h \
+  gc_ctrl.c
+globroots.d.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/globroots.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  globroots.c
+hash.d.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/hash.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  hash.c
+instrtrace.d.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instrtrace.h \
+  caml/instruct.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/opnames.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/stacks.h \
+  caml/startup_aux.h \
+  instrtrace.c
+intern.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  intern.c
+interp.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instrtrace.h \
+  caml/instruct.h \
+  caml/interp.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup_aux.h \
+  interp.c
+ints.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  ints.c
+io.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/sys.h \
+  io.c
+lexing.d.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/stacks.h \
+  lexing.c
+main.d.$(O): \
+  caml/config.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/sys.h \
+  main.c
+major_gc.d.$(O): \
+  caml/address_class.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/weak.h \
+  major_gc.c
+md5.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  md5.c
+memory.d.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/signals.h \
+  memory.c
+meta.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/interp.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/stacks.h \
+  meta.c
+minor_gc.d.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/weak.h \
+  minor_gc.c
+misc.d.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/version.h \
+  misc.c
+obj.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/interp.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/spacetime.h \
+  obj.c
+parsing.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  parsing.c
+prims.d.$(O): \
+  caml/config.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  prims.c
+printexc.d.$(O): \
+  caml/address_class.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/printexc.h \
+  caml/s.h \
+  printexc.c
+roots.d.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/globroots.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/stacks.h \
+  roots.c
+signals.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/signals_machdep.h \
+  caml/sys.h \
+  signals.c
+signals_byt.d.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/signals_machdep.h \
+  signals_byt.c
+spacetime.d.$(O): \
+  caml/config.h \
+  caml/fail.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  spacetime.c
+stacks.d.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/stacks.h \
+  stacks.c
+startup.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/debugger.h \
+  caml/dynlink.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/instrtrace.h \
+  caml/interp.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/prims.h \
+  caml/printexc.h \
+  caml/reverse.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup.h \
+  caml/startup_aux.h \
+  caml/sys.h \
+  caml/version.h \
+  startup.c
+startup_aux.d.$(O): \
+  caml/address_class.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/dynlink.h \
+  caml/exec.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/startup_aux.h \
+  startup_aux.c
+str.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  str.c
+sys.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/instruct.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup_aux.h \
+  caml/sys.h \
+  caml/version.h \
+  sys.c
+unix.d.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/sys.h \
+  unix.c
+weak.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/weak.h \
+  weak.c
+afl.i.$(O): \
+  afl.c \
+  caml/config.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h
+alloc.i.$(O): \
+  alloc.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
   caml/stacks.h
-array.i.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/signals.h \
+array.i.$(O): \
+  array.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/signals.h \
   caml/spacetime.h
-backtrace.i.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
-  caml/exec.h caml/backtrace_prim.h caml/fail.h
-backtrace_prim.i.$(O): backtrace_prim.c caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/alloc.h caml/custom.h caml/io.h \
-  caml/instruct.h caml/intext.h caml/exec.h caml/fix_code.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/startup.h caml/stacks.h \
-  caml/sys.h caml/backtrace.h caml/fail.h caml/backtrace_prim.h
-bigarray.i.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/bigarray.h caml/custom.h caml/fail.h \
-  caml/intext.h caml/io.h caml/hash.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-callback.i.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/interp.h caml/instruct.h caml/fix_code.h caml/stacks.h
-compact.i.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/mlvalues.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/gc_ctrl.h caml/weak.h caml/compact.h
-compare.i.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-custom.i.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h
-debugger.i.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/debugger.h caml/osdeps.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/fail.h caml/fix_code.h caml/instruct.h \
-  caml/intext.h caml/io.h caml/stacks.h caml/sys.h
-dynlink.i.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/mlvalues.h caml/dynlink.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/osdeps.h caml/prims.h caml/signals.h
-extern.i.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h
-fail.i.$(O): fail.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/printexc.h caml/signals.h caml/stacks.h
-finalise.i.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/compact.h caml/fail.h \
-  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/signals.h
-fix_code.i.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
-  caml/misc.h caml/mlvalues.h caml/fix_code.h caml/instruct.h \
-  caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h
-floats.i.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h caml/stacks.h
-freelist.i.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
-  caml/misc.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h caml/memory.h \
-  caml/major_gc.h caml/minor_gc.h caml/address_class.h
-gc_ctrl.i.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
-  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/gc_ctrl.h caml/signals.h caml/stacks.h \
-  caml/startup_aux.h
-globroots.i.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
-  caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/roots.h caml/globroots.h
-hash.i.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/hash.h
-instrtrace.i.$(O): instrtrace.c
-intern.i.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/callback.h caml/custom.h caml/fail.h \
-  caml/gc.h caml/intext.h caml/io.h caml/md5.h caml/memory.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h
-interp.i.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
-  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/prims.h caml/signals.h caml/stacks.h caml/startup_aux.h \
-  caml/jumptbl.h
-ints.i.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h
-io.i.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/osdeps.h caml/signals.h caml/sys.h
-lexing.i.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-main.i.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/sys.h
-major_gc.i.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/mlvalues.h caml/custom.h caml/fail.h caml/finalise.h \
-  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/gc_ctrl.h caml/signals.h \
-  caml/weak.h
-md5.i.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/md5.h caml/io.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/reverse.h
-memory.i.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/mlvalues.h caml/fail.h caml/freelist.h caml/gc.h \
-  caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
-  caml/signals.h
-meta.i.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/fix_code.h caml/interp.h \
-  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/address_class.h caml/prims.h \
+backtrace.i.$(O): \
+  backtrace.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/backtrace_prim.h \
+  caml/config.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h
+backtrace_prim.i.$(O): \
+  backtrace_prim.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/backtrace_prim.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/stacks.h \
+  caml/startup.h \
+  caml/sys.h
+bigarray.i.$(O): \
+  bigarray.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/bigarray.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/hash.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h
+callback.i.$(O): \
+  callback.c \
+  caml/address_class.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/interp.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
   caml/stacks.h
-minor_gc.i.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/finalise.h caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/gc_ctrl.h caml/signals.h \
-  caml/weak.h
-misc.i.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/memory.h \
-  caml/gc.h caml/mlvalues.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/version.h
-obj.i.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h \
-  caml/freelist.h caml/memory.h caml/minor_gc.h caml/address_class.h \
-  caml/prims.h caml/spacetime.h
-parsing.i.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
-  caml/misc.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/alloc.h
-prims.i.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/prims.h
-printexc.i.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/printexc.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-roots.i.$(O): roots.c caml/finalise.h caml/roots.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/globroots.h caml/stacks.h
-signals.i.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/callback.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/roots.h caml/signals.h \
-  caml/signals_machdep.h caml/sys.h
-signals_byt.i.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
-  caml/signals.h caml/signals_machdep.h
-spacetime.i.$(O): spacetime.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h
-stacks.i.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
-  caml/misc.h caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-startup.i.$(O): startup.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
-  caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h \
-  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
-  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
-  caml/osdeps.h caml/prims.h caml/printexc.h caml/reverse.h \
-  caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
-  caml/startup_aux.h caml/version.h
-startup_aux.i.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/exec.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/callback.h caml/dynlink.h caml/osdeps.h \
-  caml/startup_aux.h
-str.i.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h
-sys.i.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
-  caml/instruct.h caml/io.h caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
-  caml/startup_aux.h
-unix.i.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
-  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
-  caml/signals.h caml/sys.h caml/io.h
-weak.i.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/weak.h
-afl.pic.$(O): afl.c caml/misc.h caml/config.h caml/m.h caml/s.h caml/mlvalues.h
-alloc.pic.$(O): alloc.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/custom.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
+compact.i.$(O): \
+  caml/address_class.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/weak.h \
+  compact.c
+compare.i.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  compare.c
+custom.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  custom.c
+debugger.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/stacks.h \
+  caml/sys.h \
+  debugger.c
+dynlink.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/dynlink.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/signals.h \
+  dynlink.c
+extern.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  extern.c
+fail.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/printexc.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  fail.c
+finalise.i.$(O): \
+  caml/address_class.h \
+  caml/callback.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  finalise.c
+fix_code.i.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  fix_code.c
+floats.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  caml/stacks.h \
+  floats.c
+freelist.i.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  freelist.c
+gc_ctrl.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup_aux.h \
+  gc_ctrl.c
+globroots.i.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/globroots.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  globroots.c
+hash.i.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/hash.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  hash.c
+instrtrace.i.$(O): \
+  instrtrace.c
+intern.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  intern.c
+interp.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instrtrace.h \
+  caml/instruct.h \
+  caml/interp.h \
+  caml/jumptbl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup_aux.h \
+  interp.c
+ints.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  ints.c
+io.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/sys.h \
+  io.c
+lexing.i.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/stacks.h \
+  lexing.c
+main.i.$(O): \
+  caml/config.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/sys.h \
+  main.c
+major_gc.i.$(O): \
+  caml/address_class.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/weak.h \
+  major_gc.c
+md5.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  md5.c
+memory.i.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/signals.h \
+  memory.c
+meta.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/interp.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/stacks.h \
+  meta.c
+minor_gc.i.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/weak.h \
+  minor_gc.c
+misc.i.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/version.h \
+  misc.c
+obj.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/interp.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/spacetime.h \
+  obj.c
+parsing.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  parsing.c
+prims.i.$(O): \
+  caml/config.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  prims.c
+printexc.i.$(O): \
+  caml/address_class.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/printexc.h \
+  caml/s.h \
+  printexc.c
+roots.i.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/globroots.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/stacks.h \
+  roots.c
+signals.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/signals_machdep.h \
+  caml/sys.h \
+  signals.c
+signals_byt.i.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/signals_machdep.h \
+  signals_byt.c
+spacetime.i.$(O): \
+  caml/config.h \
+  caml/fail.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  spacetime.c
+stacks.i.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/stacks.h \
+  stacks.c
+startup.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/debugger.h \
+  caml/dynlink.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/instrtrace.h \
+  caml/interp.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/prims.h \
+  caml/printexc.h \
+  caml/reverse.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup.h \
+  caml/startup_aux.h \
+  caml/sys.h \
+  caml/version.h \
+  startup.c
+startup_aux.i.$(O): \
+  caml/address_class.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/dynlink.h \
+  caml/exec.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/startup_aux.h \
+  startup_aux.c
+str.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  str.c
+sys.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/instruct.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup_aux.h \
+  caml/sys.h \
+  caml/version.h \
+  sys.c
+unix.i.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/sys.h \
+  unix.c
+weak.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/weak.h \
+  weak.c
+afl.pic.$(O): \
+  afl.c \
+  caml/config.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h
+alloc.pic.$(O): \
+  alloc.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
   caml/stacks.h
-array.pic.$(O): array.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/signals.h \
+array.pic.$(O): \
+  array.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/signals.h \
   caml/spacetime.h
-backtrace.pic.$(O): backtrace.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/backtrace.h \
-  caml/exec.h caml/backtrace_prim.h caml/fail.h
-backtrace_prim.pic.$(O): backtrace_prim.c caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/misc.h caml/alloc.h caml/custom.h caml/io.h \
-  caml/instruct.h caml/intext.h caml/exec.h caml/fix_code.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/startup.h caml/stacks.h \
-  caml/sys.h caml/backtrace.h caml/fail.h caml/backtrace_prim.h
-bigarray.pic.$(O): bigarray.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/bigarray.h caml/custom.h caml/fail.h \
-  caml/intext.h caml/io.h caml/hash.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-callback.pic.$(O): callback.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/interp.h caml/instruct.h caml/fix_code.h caml/stacks.h
-compact.pic.$(O): compact.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/mlvalues.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/gc_ctrl.h caml/weak.h caml/compact.h
-compare.pic.$(O): compare.c caml/custom.h caml/mlvalues.h caml/config.h caml/m.h \
-  caml/s.h caml/misc.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-custom.pic.$(O): custom.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h
-debugger.pic.$(O): debugger.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/debugger.h caml/osdeps.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/fail.h caml/fix_code.h caml/instruct.h \
-  caml/intext.h caml/io.h caml/stacks.h caml/sys.h
-dynlink.pic.$(O): dynlink.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/mlvalues.h caml/dynlink.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/osdeps.h caml/prims.h caml/signals.h
-extern.pic.$(O): extern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/custom.h caml/fail.h caml/gc.h \
-  caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/reverse.h
-fail.pic.$(O): fail.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/io.h caml/gc.h caml/memory.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/printexc.h caml/signals.h caml/stacks.h
-finalise.pic.$(O): finalise.c caml/callback.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/compact.h caml/fail.h \
-  caml/finalise.h caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/signals.h
-fix_code.pic.$(O): fix_code.c caml/config.h caml/m.h caml/s.h caml/debugger.h \
-  caml/misc.h caml/mlvalues.h caml/fix_code.h caml/instruct.h \
-  caml/intext.h caml/io.h caml/md5.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h
-floats.pic.$(O): floats.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h caml/stacks.h
-freelist.pic.$(O): freelist.c caml/config.h caml/m.h caml/s.h caml/freelist.h \
-  caml/misc.h caml/mlvalues.h caml/gc.h caml/gc_ctrl.h caml/memory.h \
-  caml/major_gc.h caml/minor_gc.h caml/address_class.h
-gc_ctrl.pic.$(O): gc_ctrl.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/compact.h \
-  caml/custom.h caml/fail.h caml/finalise.h caml/roots.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/gc_ctrl.h caml/signals.h caml/stacks.h \
-  caml/startup_aux.h
-globroots.pic.$(O): globroots.c caml/memory.h caml/config.h caml/m.h caml/s.h \
-  caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/roots.h caml/globroots.h
-hash.pic.$(O): hash.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/custom.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/hash.h
-instrtrace.pic.$(O): instrtrace.c
-intern.pic.$(O): intern.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/callback.h caml/custom.h caml/fail.h \
-  caml/gc.h caml/intext.h caml/io.h caml/md5.h caml/memory.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/reverse.h
-interp.pic.$(O): interp.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/backtrace.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/fix_code.h caml/instrtrace.h \
-  caml/instruct.h caml/interp.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/prims.h caml/signals.h caml/stacks.h caml/startup_aux.h \
-  caml/jumptbl.h
-ints.pic.$(O): ints.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/intext.h caml/io.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h
-io.pic.$(O): io.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/custom.h caml/fail.h caml/io.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/osdeps.h caml/signals.h caml/sys.h
-lexing.pic.$(O): lexing.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-main.pic.$(O): main.c caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/sys.h
-major_gc.pic.$(O): major_gc.c caml/compact.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/mlvalues.h caml/custom.h caml/fail.h caml/finalise.h \
-  caml/roots.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/gc_ctrl.h caml/signals.h \
-  caml/weak.h
-md5.pic.$(O): md5.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/md5.h caml/io.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/reverse.h
-memory.pic.$(O): memory.c caml/address_class.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/mlvalues.h caml/fail.h caml/freelist.h caml/gc.h \
-  caml/gc_ctrl.h caml/major_gc.h caml/memory.h caml/minor_gc.h \
-  caml/signals.h
-meta.pic.$(O): meta.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/fix_code.h caml/interp.h \
-  caml/intext.h caml/io.h caml/major_gc.h caml/freelist.h caml/memory.h \
-  caml/gc.h caml/minor_gc.h caml/address_class.h caml/prims.h \
+backtrace.pic.$(O): \
+  backtrace.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/backtrace_prim.h \
+  caml/config.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h
+backtrace_prim.pic.$(O): \
+  backtrace_prim.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/backtrace_prim.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/stacks.h \
+  caml/startup.h \
+  caml/sys.h
+bigarray.pic.$(O): \
+  bigarray.c \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/bigarray.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/hash.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h
+callback.pic.$(O): \
+  callback.c \
+  caml/address_class.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/interp.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
   caml/stacks.h
-minor_gc.pic.$(O): minor_gc.c caml/custom.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/fail.h caml/finalise.h caml/roots.h \
-  caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/gc_ctrl.h caml/signals.h \
-  caml/weak.h
-misc.pic.$(O): misc.c caml/config.h caml/m.h caml/s.h caml/misc.h caml/memory.h \
-  caml/gc.h caml/mlvalues.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/osdeps.h caml/version.h
-obj.pic.$(O): obj.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/gc.h caml/interp.h caml/major_gc.h \
-  caml/freelist.h caml/memory.h caml/minor_gc.h caml/address_class.h \
-  caml/prims.h caml/spacetime.h
-parsing.pic.$(O): parsing.c caml/config.h caml/m.h caml/s.h caml/mlvalues.h \
-  caml/misc.h caml/memory.h caml/gc.h caml/major_gc.h caml/freelist.h \
-  caml/minor_gc.h caml/address_class.h caml/alloc.h
-prims.pic.$(O): prims.c caml/mlvalues.h caml/config.h caml/m.h caml/s.h \
-  caml/misc.h caml/prims.h
-printexc.pic.$(O): printexc.c caml/backtrace.h caml/mlvalues.h caml/config.h \
-  caml/m.h caml/s.h caml/misc.h caml/exec.h caml/callback.h \
-  caml/debugger.h caml/fail.h caml/printexc.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-roots.pic.$(O): roots.c caml/finalise.h caml/roots.h caml/misc.h caml/config.h \
-  caml/m.h caml/s.h caml/memory.h caml/gc.h caml/mlvalues.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/globroots.h caml/stacks.h
-signals.pic.$(O): signals.c caml/alloc.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h caml/callback.h caml/fail.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/roots.h caml/signals.h \
-  caml/signals_machdep.h caml/sys.h
-signals_byt.pic.$(O): signals_byt.c caml/config.h caml/m.h caml/s.h \
-  caml/memory.h caml/gc.h caml/mlvalues.h caml/misc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
-  caml/signals.h caml/signals_machdep.h
-spacetime.pic.$(O): spacetime.c caml/fail.h caml/misc.h caml/config.h caml/m.h \
-  caml/s.h caml/mlvalues.h
-stacks.pic.$(O): stacks.c caml/config.h caml/m.h caml/s.h caml/fail.h \
-  caml/misc.h caml/mlvalues.h caml/stacks.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h
-startup.pic.$(O): startup.c caml/config.h caml/m.h caml/s.h caml/alloc.h \
-  caml/misc.h caml/mlvalues.h caml/backtrace.h caml/exec.h \
-  caml/callback.h caml/custom.h caml/debugger.h caml/dynlink.h \
-  caml/fail.h caml/fix_code.h caml/freelist.h caml/gc_ctrl.h \
-  caml/instrtrace.h caml/interp.h caml/intext.h caml/io.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/minor_gc.h caml/address_class.h \
-  caml/osdeps.h caml/prims.h caml/printexc.h caml/reverse.h \
-  caml/signals.h caml/stacks.h caml/sys.h caml/startup.h \
-  caml/startup_aux.h caml/version.h
-startup_aux.pic.$(O): startup_aux.c caml/backtrace.h caml/mlvalues.h \
-  caml/config.h caml/m.h caml/s.h caml/misc.h caml/exec.h caml/memory.h \
-  caml/gc.h caml/major_gc.h caml/freelist.h caml/minor_gc.h \
-  caml/address_class.h caml/callback.h caml/dynlink.h caml/osdeps.h \
-  caml/startup_aux.h
-str.pic.$(O): str.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h
-sys.pic.$(O): sys.c caml/config.h caml/m.h caml/s.h caml/alloc.h caml/misc.h \
-  caml/mlvalues.h caml/debugger.h caml/fail.h caml/gc_ctrl.h \
-  caml/instruct.h caml/io.h caml/osdeps.h caml/memory.h caml/gc.h \
-  caml/major_gc.h caml/freelist.h caml/minor_gc.h caml/address_class.h \
-  caml/signals.h caml/stacks.h caml/sys.h caml/version.h caml/callback.h \
-  caml/startup_aux.h
-unix.pic.$(O): unix.c caml/config.h caml/m.h caml/s.h caml/fail.h caml/misc.h \
-  caml/mlvalues.h caml/memory.h caml/gc.h caml/major_gc.h \
-  caml/freelist.h caml/minor_gc.h caml/address_class.h caml/osdeps.h \
-  caml/signals.h caml/sys.h caml/io.h
-weak.pic.$(O): weak.c caml/alloc.h caml/misc.h caml/config.h caml/m.h caml/s.h \
-  caml/mlvalues.h caml/fail.h caml/major_gc.h caml/freelist.h \
-  caml/memory.h caml/gc.h caml/minor_gc.h caml/address_class.h \
-  caml/weak.h
+compact.pic.$(O): \
+  caml/address_class.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/weak.h \
+  compact.c
+compare.pic.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  compare.c
+custom.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  custom.c
+debugger.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/stacks.h \
+  caml/sys.h \
+  debugger.c
+dynlink.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/dynlink.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/signals.h \
+  dynlink.c
+extern.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  extern.c
+fail.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/printexc.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  fail.c
+finalise.pic.$(O): \
+  caml/address_class.h \
+  caml/callback.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  finalise.c
+fix_code.pic.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instruct.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  fix_code.c
+floats.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  caml/stacks.h \
+  floats.c
+freelist.pic.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  freelist.c
+gc_ctrl.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup_aux.h \
+  gc_ctrl.c
+globroots.pic.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/globroots.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  globroots.c
+hash.pic.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/hash.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  hash.c
+instrtrace.pic.$(O): \
+  instrtrace.c
+intern.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  intern.c
+interp.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/instrtrace.h \
+  caml/instruct.h \
+  caml/interp.h \
+  caml/jumptbl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup_aux.h \
+  interp.c
+ints.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  ints.c
+io.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/sys.h \
+  io.c
+lexing.pic.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/stacks.h \
+  lexing.c
+main.pic.$(O): \
+  caml/config.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/sys.h \
+  main.c
+major_gc.pic.$(O): \
+  caml/address_class.h \
+  caml/compact.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/weak.h \
+  major_gc.c
+md5.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/md5.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/reverse.h \
+  caml/s.h \
+  md5.c
+memory.pic.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/signals.h \
+  memory.c
+meta.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/interp.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/stacks.h \
+  meta.c
+minor_gc.pic.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/fail.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/weak.h \
+  minor_gc.c
+misc.pic.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/version.h \
+  misc.c
+obj.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/interp.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  caml/spacetime.h \
+  obj.c
+parsing.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  parsing.c
+prims.pic.$(O): \
+  caml/config.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/prims.h \
+  caml/s.h \
+  prims.c
+printexc.pic.$(O): \
+  caml/address_class.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/printexc.h \
+  caml/s.h \
+  printexc.c
+roots.pic.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/finalise.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/globroots.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/stacks.h \
+  roots.c
+signals.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/roots.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/signals_machdep.h \
+  caml/sys.h \
+  signals.c
+signals_byt.pic.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/signals_machdep.h \
+  signals_byt.c
+spacetime.pic.$(O): \
+  caml/config.h \
+  caml/fail.h \
+  caml/m.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  spacetime.c
+stacks.pic.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/stacks.h \
+  stacks.c
+startup.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/custom.h \
+  caml/debugger.h \
+  caml/dynlink.h \
+  caml/exec.h \
+  caml/fail.h \
+  caml/fix_code.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/instrtrace.h \
+  caml/interp.h \
+  caml/intext.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/prims.h \
+  caml/printexc.h \
+  caml/reverse.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup.h \
+  caml/startup_aux.h \
+  caml/sys.h \
+  caml/version.h \
+  startup.c
+startup_aux.pic.$(O): \
+  caml/address_class.h \
+  caml/backtrace.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/dynlink.h \
+  caml/exec.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/startup_aux.h \
+  startup_aux.c
+str.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  str.c
+sys.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/callback.h \
+  caml/config.h \
+  caml/debugger.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/gc_ctrl.h \
+  caml/instruct.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/stacks.h \
+  caml/startup_aux.h \
+  caml/sys.h \
+  caml/version.h \
+  sys.c
+unix.pic.$(O): \
+  caml/address_class.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/sys.h \
+  unix.c
+weak.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/s.h \
+  caml/weak.h \
+  weak.c

--- a/byterun/.depend
+++ b/byterun/.depend
@@ -1,9 +1,16 @@
 afl.$(O): \
   afl.c \
+  caml/address_class.h \
   caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
   caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
   caml/misc.h \
   caml/mlvalues.h \
+  caml/osdeps.h \
   caml/s.h
 alloc.$(O): \
   alloc.c \
@@ -481,10 +488,17 @@ lexing.$(O): \
   caml/stacks.h \
   lexing.c
 main.$(O): \
+  caml/address_class.h \
   caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
   caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
   caml/misc.h \
   caml/mlvalues.h \
+  caml/osdeps.h \
   caml/s.h \
   caml/sys.h \
   main.c
@@ -815,7 +829,6 @@ sys.$(O): \
   caml/freelist.h \
   caml/gc.h \
   caml/gc_ctrl.h \
-  caml/instruct.h \
   caml/io.h \
   caml/m.h \
   caml/major_gc.h \
@@ -833,6 +846,7 @@ sys.$(O): \
   sys.c
 unix.$(O): \
   caml/address_class.h \
+  caml/alloc.h \
   caml/config.h \
   caml/fail.h \
   caml/freelist.h \
@@ -865,12 +879,38 @@ weak.$(O): \
   caml/s.h \
   caml/weak.h \
   weak.c
-afl.d.$(O): \
-  afl.c \
+win32.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
   caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
   caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
   caml/misc.h \
   caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/sys.h \
+  win32.c
+afl.d.$(O): \
+  afl.c \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
   caml/s.h
 alloc.d.$(O): \
   alloc.c \
@@ -1364,10 +1404,17 @@ lexing.d.$(O): \
   caml/stacks.h \
   lexing.c
 main.d.$(O): \
+  caml/address_class.h \
   caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
   caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
   caml/misc.h \
   caml/mlvalues.h \
+  caml/osdeps.h \
   caml/s.h \
   caml/sys.h \
   main.c
@@ -1698,7 +1745,6 @@ sys.d.$(O): \
   caml/freelist.h \
   caml/gc.h \
   caml/gc_ctrl.h \
-  caml/instruct.h \
   caml/io.h \
   caml/m.h \
   caml/major_gc.h \
@@ -1716,6 +1762,7 @@ sys.d.$(O): \
   sys.c
 unix.d.$(O): \
   caml/address_class.h \
+  caml/alloc.h \
   caml/config.h \
   caml/fail.h \
   caml/freelist.h \
@@ -1748,12 +1795,38 @@ weak.d.$(O): \
   caml/s.h \
   caml/weak.h \
   weak.c
-afl.i.$(O): \
-  afl.c \
+win32.d.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
   caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
   caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
   caml/misc.h \
   caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/sys.h \
+  win32.c
+afl.i.$(O): \
+  afl.c \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
   caml/s.h
 alloc.i.$(O): \
   alloc.c \
@@ -2231,10 +2304,17 @@ lexing.i.$(O): \
   caml/stacks.h \
   lexing.c
 main.i.$(O): \
+  caml/address_class.h \
   caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
   caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
   caml/misc.h \
   caml/mlvalues.h \
+  caml/osdeps.h \
   caml/s.h \
   caml/sys.h \
   main.c
@@ -2565,7 +2645,6 @@ sys.i.$(O): \
   caml/freelist.h \
   caml/gc.h \
   caml/gc_ctrl.h \
-  caml/instruct.h \
   caml/io.h \
   caml/m.h \
   caml/major_gc.h \
@@ -2583,6 +2662,7 @@ sys.i.$(O): \
   sys.c
 unix.i.$(O): \
   caml/address_class.h \
+  caml/alloc.h \
   caml/config.h \
   caml/fail.h \
   caml/freelist.h \
@@ -2615,12 +2695,38 @@ weak.i.$(O): \
   caml/s.h \
   caml/weak.h \
   weak.c
-afl.pic.$(O): \
-  afl.c \
+win32.i.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
   caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
   caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
   caml/misc.h \
   caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/sys.h \
+  win32.c
+afl.pic.$(O): \
+  afl.c \
+  caml/address_class.h \
+  caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
   caml/s.h
 alloc.pic.$(O): \
   alloc.c \
@@ -3098,10 +3204,17 @@ lexing.pic.$(O): \
   caml/stacks.h \
   lexing.c
 main.pic.$(O): \
+  caml/address_class.h \
   caml/config.h \
+  caml/freelist.h \
+  caml/gc.h \
   caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
   caml/misc.h \
   caml/mlvalues.h \
+  caml/osdeps.h \
   caml/s.h \
   caml/sys.h \
   main.c
@@ -3432,7 +3545,6 @@ sys.pic.$(O): \
   caml/freelist.h \
   caml/gc.h \
   caml/gc_ctrl.h \
-  caml/instruct.h \
   caml/io.h \
   caml/m.h \
   caml/major_gc.h \
@@ -3450,6 +3562,7 @@ sys.pic.$(O): \
   sys.c
 unix.pic.$(O): \
   caml/address_class.h \
+  caml/alloc.h \
   caml/config.h \
   caml/fail.h \
   caml/freelist.h \
@@ -3482,3 +3595,22 @@ weak.pic.$(O): \
   caml/s.h \
   caml/weak.h \
   weak.c
+win32.pic.$(O): \
+  caml/address_class.h \
+  caml/alloc.h \
+  caml/config.h \
+  caml/fail.h \
+  caml/freelist.h \
+  caml/gc.h \
+  caml/io.h \
+  caml/m.h \
+  caml/major_gc.h \
+  caml/memory.h \
+  caml/minor_gc.h \
+  caml/misc.h \
+  caml/mlvalues.h \
+  caml/osdeps.h \
+  caml/s.h \
+  caml/signals.h \
+  caml/sys.h \
+  win32.c

--- a/byterun/Makefile
+++ b/byterun/Makefile
@@ -223,6 +223,7 @@ depend: prims.c caml/opnames.h caml/jumptbl.h caml/version.h
 	$(CC) -MM $(DFLAGS) $(CPPFLAGS) *.c | sed -e 's/\.o/.d.$$(O)/'>>.$@
 	$(CC) -MM $(IFLAGS) $(CPPFLAGS) *.c | sed -e 's/\.o/.i.$$(O)/'>>.$@
 	$(CC) -MM $(PICFLAGS) $(CPPFLAGS) *.c | sed -e 's/\.o/.pic.$$(O)/'>>.$@
+	../tools/normalize_depend .$@
 endif
 
 include .depend

--- a/debugger/.depend
+++ b/debugger/.depend
@@ -1,202 +1,620 @@
-breakpoints.cmo : symbols.cmi pos.cmi ../bytecomp/instruct.cmi exec.cmi \
-    debugcom.cmi checkpoints.cmi breakpoints.cmi
-breakpoints.cmx : symbols.cmx pos.cmx ../bytecomp/instruct.cmx exec.cmx \
-    debugcom.cmx checkpoints.cmx breakpoints.cmi
-breakpoints.cmi : ../bytecomp/instruct.cmi
-checkpoints.cmo : primitives.cmi int64ops.cmi debugcom.cmi checkpoints.cmi
-checkpoints.cmx : primitives.cmx int64ops.cmx debugcom.cmx checkpoints.cmi
-checkpoints.cmi : primitives.cmi debugcom.cmi
-command_line.cmo : unix_tools.cmi $(UNIXDIR)/unix.cmi \
-    ../typing/types.cmi time_travel.cmi symbols.cmi source.cmi \
-    show_source.cmi show_information.cmi question.cmi program_management.cmi \
-    program_loading.cmi printval.cmi primitives.cmi pos.cmi parser_aux.cmi \
-    parser.cmi parameters.cmi ../utils/misc.cmi ../parsing/longident.cmi \
-    ../parsing/location.cmi loadprinter.cmi lexer.cmi int64ops.cmi \
-    ../bytecomp/instruct.cmi input_handling.cmi history.cmi frames.cmi \
-    events.cmi eval.cmi ../typing/envaux.cmi ../typing/env.cmi \
-    debugger_config.cmi debugcom.cmi ../typing/ctype.cmi ../utils/config.cmi \
-    checkpoints.cmi breakpoints.cmi command_line.cmi
-command_line.cmx : unix_tools.cmx $(UNIXDIR)/unix.cmx \
-    ../typing/types.cmx time_travel.cmx symbols.cmx source.cmx \
-    show_source.cmx show_information.cmx question.cmx program_management.cmx \
-    program_loading.cmx printval.cmx primitives.cmx pos.cmx parser_aux.cmi \
-    parser.cmx parameters.cmx ../utils/misc.cmx ../parsing/longident.cmx \
-    ../parsing/location.cmx loadprinter.cmx lexer.cmx int64ops.cmx \
-    ../bytecomp/instruct.cmx input_handling.cmx history.cmx frames.cmx \
-    events.cmx eval.cmx ../typing/envaux.cmx ../typing/env.cmx \
-    debugger_config.cmx debugcom.cmx ../typing/ctype.cmx ../utils/config.cmx \
-    checkpoints.cmx breakpoints.cmx command_line.cmi
+breakpoints.cmo : \
+  ../bytecomp/instruct.cmi \
+  breakpoints.cmi \
+  checkpoints.cmi \
+  debugcom.cmi \
+  exec.cmi \
+  pos.cmi \
+  symbols.cmi
+breakpoints.cmx : \
+  ../bytecomp/instruct.cmx \
+  breakpoints.cmi \
+  checkpoints.cmx \
+  debugcom.cmx \
+  exec.cmx \
+  pos.cmx \
+  symbols.cmx
+breakpoints.cmi : \
+  ../bytecomp/instruct.cmi
+checkpoints.cmo : \
+  checkpoints.cmi \
+  debugcom.cmi \
+  int64ops.cmi \
+  primitives.cmi
+checkpoints.cmx : \
+  checkpoints.cmi \
+  debugcom.cmx \
+  int64ops.cmx \
+  primitives.cmx
+checkpoints.cmi : \
+  debugcom.cmi \
+  primitives.cmi
+command_line.cmo : \
+  $(UNIXDIR)/unix.cmi \
+  ../bytecomp/instruct.cmi \
+  ../parsing/location.cmi \
+  ../parsing/longident.cmi \
+  ../typing/ctype.cmi \
+  ../typing/env.cmi \
+  ../typing/envaux.cmi \
+  ../typing/types.cmi \
+  ../utils/config.cmi \
+  ../utils/misc.cmi \
+  breakpoints.cmi \
+  checkpoints.cmi \
+  command_line.cmi \
+  debugcom.cmi \
+  debugger_config.cmi \
+  eval.cmi \
+  events.cmi \
+  frames.cmi \
+  history.cmi \
+  input_handling.cmi \
+  int64ops.cmi \
+  lexer.cmi \
+  loadprinter.cmi \
+  parameters.cmi \
+  parser.cmi \
+  parser_aux.cmi \
+  pos.cmi \
+  primitives.cmi \
+  printval.cmi \
+  program_loading.cmi \
+  program_management.cmi \
+  question.cmi \
+  show_information.cmi \
+  show_source.cmi \
+  source.cmi \
+  symbols.cmi \
+  time_travel.cmi \
+  unix_tools.cmi
+command_line.cmx : \
+  $(UNIXDIR)/unix.cmx \
+  ../bytecomp/instruct.cmx \
+  ../parsing/location.cmx \
+  ../parsing/longident.cmx \
+  ../typing/ctype.cmx \
+  ../typing/env.cmx \
+  ../typing/envaux.cmx \
+  ../typing/types.cmx \
+  ../utils/config.cmx \
+  ../utils/misc.cmx \
+  breakpoints.cmx \
+  checkpoints.cmx \
+  command_line.cmi \
+  debugcom.cmx \
+  debugger_config.cmx \
+  eval.cmx \
+  events.cmx \
+  frames.cmx \
+  history.cmx \
+  input_handling.cmx \
+  int64ops.cmx \
+  lexer.cmx \
+  loadprinter.cmx \
+  parameters.cmx \
+  parser.cmx \
+  parser_aux.cmi \
+  pos.cmx \
+  primitives.cmx \
+  printval.cmx \
+  program_loading.cmx \
+  program_management.cmx \
+  question.cmx \
+  show_information.cmx \
+  show_source.cmx \
+  source.cmx \
+  symbols.cmx \
+  time_travel.cmx \
+  unix_tools.cmx
 command_line.cmi :
-debugcom.cmo : primitives.cmi ../utils/misc.cmi int64ops.cmi \
-    input_handling.cmi debugcom.cmi
-debugcom.cmx : primitives.cmx ../utils/misc.cmx int64ops.cmx \
-    input_handling.cmx debugcom.cmi
-debugcom.cmi : primitives.cmi
-debugger_config.cmo : int64ops.cmi debugger_config.cmi
-debugger_config.cmx : int64ops.cmx debugger_config.cmi
+debugcom.cmo : \
+  ../utils/misc.cmi \
+  debugcom.cmi \
+  input_handling.cmi \
+  int64ops.cmi \
+  primitives.cmi
+debugcom.cmx : \
+  ../utils/misc.cmx \
+  debugcom.cmi \
+  input_handling.cmx \
+  int64ops.cmx \
+  primitives.cmx
+debugcom.cmi : \
+  primitives.cmi
+debugger_config.cmo : \
+  debugger_config.cmi \
+  int64ops.cmi
+debugger_config.cmx : \
+  debugger_config.cmi \
+  int64ops.cmx
 debugger_config.cmi :
-eval.cmo : ../typing/types.cmi ../bytecomp/symtable.cmi ../typing/subst.cmi \
-    printval.cmi ../typing/printtyp.cmi ../typing/predef.cmi \
-    ../typing/path.cmi parser_aux.cmi ../utils/misc.cmi \
-    ../parsing/longident.cmi ../bytecomp/instruct.cmi ../typing/ident.cmi \
-    frames.cmi ../typing/env.cmi debugcom.cmi ../typing/ctype.cmi \
-    ../typing/btype.cmi eval.cmi
-eval.cmx : ../typing/types.cmx ../bytecomp/symtable.cmx ../typing/subst.cmx \
-    printval.cmx ../typing/printtyp.cmx ../typing/predef.cmx \
-    ../typing/path.cmx parser_aux.cmi ../utils/misc.cmx \
-    ../parsing/longident.cmx ../bytecomp/instruct.cmx ../typing/ident.cmx \
-    frames.cmx ../typing/env.cmx debugcom.cmx ../typing/ctype.cmx \
-    ../typing/btype.cmx eval.cmi
-eval.cmi : ../typing/types.cmi ../typing/path.cmi parser_aux.cmi \
-    ../parsing/longident.cmi ../bytecomp/instruct.cmi ../typing/ident.cmi \
-    ../typing/env.cmi debugcom.cmi
-events.cmo : ../parsing/location.cmi ../bytecomp/instruct.cmi events.cmi
-events.cmx : ../parsing/location.cmx ../bytecomp/instruct.cmx events.cmi
-events.cmi : ../bytecomp/instruct.cmi
-exec.cmo : exec.cmi
-exec.cmx : exec.cmi
+eval.cmo : \
+  ../bytecomp/instruct.cmi \
+  ../bytecomp/symtable.cmi \
+  ../parsing/longident.cmi \
+  ../typing/btype.cmi \
+  ../typing/ctype.cmi \
+  ../typing/env.cmi \
+  ../typing/ident.cmi \
+  ../typing/path.cmi \
+  ../typing/predef.cmi \
+  ../typing/printtyp.cmi \
+  ../typing/subst.cmi \
+  ../typing/types.cmi \
+  ../utils/misc.cmi \
+  debugcom.cmi \
+  eval.cmi \
+  frames.cmi \
+  parser_aux.cmi \
+  printval.cmi
+eval.cmx : \
+  ../bytecomp/instruct.cmx \
+  ../bytecomp/symtable.cmx \
+  ../parsing/longident.cmx \
+  ../typing/btype.cmx \
+  ../typing/ctype.cmx \
+  ../typing/env.cmx \
+  ../typing/ident.cmx \
+  ../typing/path.cmx \
+  ../typing/predef.cmx \
+  ../typing/printtyp.cmx \
+  ../typing/subst.cmx \
+  ../typing/types.cmx \
+  ../utils/misc.cmx \
+  debugcom.cmx \
+  eval.cmi \
+  frames.cmx \
+  parser_aux.cmi \
+  printval.cmx
+eval.cmi : \
+  ../bytecomp/instruct.cmi \
+  ../parsing/longident.cmi \
+  ../typing/env.cmi \
+  ../typing/ident.cmi \
+  ../typing/path.cmi \
+  ../typing/types.cmi \
+  debugcom.cmi \
+  parser_aux.cmi
+events.cmo : \
+  ../bytecomp/instruct.cmi \
+  ../parsing/location.cmi \
+  events.cmi
+events.cmx : \
+  ../bytecomp/instruct.cmx \
+  ../parsing/location.cmx \
+  events.cmi
+events.cmi : \
+  ../bytecomp/instruct.cmi
+exec.cmo : \
+  exec.cmi
+exec.cmx : \
+  exec.cmi
 exec.cmi :
-frames.cmo : symbols.cmi ../utils/misc.cmi ../bytecomp/instruct.cmi \
-    events.cmi debugcom.cmi frames.cmi
-frames.cmx : symbols.cmx ../utils/misc.cmx ../bytecomp/instruct.cmx \
-    events.cmx debugcom.cmx frames.cmi
-frames.cmi : ../bytecomp/instruct.cmi
-history.cmo : primitives.cmi int64ops.cmi debugger_config.cmi \
-    checkpoints.cmi history.cmi
-history.cmx : primitives.cmx int64ops.cmx debugger_config.cmx \
-    checkpoints.cmx history.cmi
+frames.cmo : \
+  ../bytecomp/instruct.cmi \
+  ../utils/misc.cmi \
+  debugcom.cmi \
+  events.cmi \
+  frames.cmi \
+  symbols.cmi
+frames.cmx : \
+  ../bytecomp/instruct.cmx \
+  ../utils/misc.cmx \
+  debugcom.cmx \
+  events.cmx \
+  frames.cmi \
+  symbols.cmx
+frames.cmi : \
+  ../bytecomp/instruct.cmi
+history.cmo : \
+  checkpoints.cmi \
+  debugger_config.cmi \
+  history.cmi \
+  int64ops.cmi \
+  primitives.cmi
+history.cmx : \
+  checkpoints.cmx \
+  debugger_config.cmx \
+  history.cmi \
+  int64ops.cmx \
+  primitives.cmx
 history.cmi :
-input_handling.cmo : $(UNIXDIR)/unix.cmi primitives.cmi \
-    input_handling.cmi
-input_handling.cmx : $(UNIXDIR)/unix.cmx primitives.cmx \
-    input_handling.cmi
-input_handling.cmi : primitives.cmi
-int64ops.cmo : int64ops.cmi
-int64ops.cmx : int64ops.cmi
+input_handling.cmo : \
+  $(UNIXDIR)/unix.cmi \
+  input_handling.cmi \
+  primitives.cmi
+input_handling.cmx : \
+  $(UNIXDIR)/unix.cmx \
+  input_handling.cmi \
+  primitives.cmx
+input_handling.cmi : \
+  primitives.cmi
+int64ops.cmo : \
+  int64ops.cmi
+int64ops.cmx : \
+  int64ops.cmi
 int64ops.cmi :
-lexer.cmo : parser.cmi lexer.cmi
-lexer.cmx : parser.cmx lexer.cmi
-lexer.cmi : parser.cmi
-loadprinter.cmo : ../typing/types.cmi ../bytecomp/symtable.cmi printval.cmi \
-    ../typing/printtyp.cmi ../typing/path.cmi ../utils/misc.cmi \
-    ../parsing/longident.cmi ../parsing/location.cmi ../typing/ident.cmi \
-    ../typing/env.cmi ../typing/ctype.cmi ../utils/config.cmi \
-    ../driver/compdynlink.cmi loadprinter.cmi
-loadprinter.cmx : ../typing/types.cmx ../bytecomp/symtable.cmx printval.cmx \
-    ../typing/printtyp.cmx ../typing/path.cmx ../utils/misc.cmx \
-    ../parsing/longident.cmx ../parsing/location.cmx ../typing/ident.cmx \
-    ../typing/env.cmx ../typing/ctype.cmx ../utils/config.cmx \
-    ../driver/compdynlink.cmi loadprinter.cmi
-loadprinter.cmi : ../parsing/longident.cmi ../driver/compdynlink.cmi
-main.cmo : unix_tools.cmi $(UNIXDIR)/unix.cmi time_travel.cmi \
-    show_information.cmi question.cmi program_management.cmi primitives.cmi \
-    parameters.cmi ../utils/misc.cmi input_handling.cmi frames.cmi exec.cmi \
-    ../typing/env.cmi debugger_config.cmi ../utils/config.cmi \
-    command_line.cmi ../typing/cmi_format.cmi ../utils/clflags.cmi \
-    checkpoints.cmi
-main.cmx : unix_tools.cmx $(UNIXDIR)/unix.cmx time_travel.cmx \
-    show_information.cmx question.cmx program_management.cmx primitives.cmx \
-    parameters.cmx ../utils/misc.cmx input_handling.cmx frames.cmx exec.cmx \
-    ../typing/env.cmx debugger_config.cmx ../utils/config.cmx \
-    command_line.cmx ../typing/cmi_format.cmx ../utils/clflags.cmx \
-    checkpoints.cmx
-parameters.cmo : primitives.cmi ../typing/envaux.cmi debugger_config.cmi \
-    ../utils/config.cmi parameters.cmi
-parameters.cmx : primitives.cmx ../typing/envaux.cmx debugger_config.cmx \
-    ../utils/config.cmx parameters.cmi
+lexer.cmo : \
+  lexer.cmi \
+  parser.cmi
+lexer.cmx : \
+  lexer.cmi \
+  parser.cmx
+lexer.cmi : \
+  parser.cmi
+loadprinter.cmo : \
+  ../bytecomp/symtable.cmi \
+  ../driver/compdynlink.cmi \
+  ../parsing/location.cmi \
+  ../parsing/longident.cmi \
+  ../typing/ctype.cmi \
+  ../typing/env.cmi \
+  ../typing/ident.cmi \
+  ../typing/path.cmi \
+  ../typing/printtyp.cmi \
+  ../typing/types.cmi \
+  ../utils/config.cmi \
+  ../utils/misc.cmi \
+  loadprinter.cmi \
+  printval.cmi
+loadprinter.cmx : \
+  ../bytecomp/symtable.cmx \
+  ../driver/compdynlink.cmi \
+  ../parsing/location.cmx \
+  ../parsing/longident.cmx \
+  ../typing/ctype.cmx \
+  ../typing/env.cmx \
+  ../typing/ident.cmx \
+  ../typing/path.cmx \
+  ../typing/printtyp.cmx \
+  ../typing/types.cmx \
+  ../utils/config.cmx \
+  ../utils/misc.cmx \
+  loadprinter.cmi \
+  printval.cmx
+loadprinter.cmi : \
+  ../driver/compdynlink.cmi \
+  ../parsing/longident.cmi
+main.cmo : \
+  $(UNIXDIR)/unix.cmi \
+  ../typing/cmi_format.cmi \
+  ../typing/env.cmi \
+  ../utils/clflags.cmi \
+  ../utils/config.cmi \
+  ../utils/misc.cmi \
+  checkpoints.cmi \
+  command_line.cmi \
+  debugger_config.cmi \
+  exec.cmi \
+  frames.cmi \
+  input_handling.cmi \
+  parameters.cmi \
+  primitives.cmi \
+  program_management.cmi \
+  question.cmi \
+  show_information.cmi \
+  time_travel.cmi \
+  unix_tools.cmi
+main.cmx : \
+  $(UNIXDIR)/unix.cmx \
+  ../typing/cmi_format.cmx \
+  ../typing/env.cmx \
+  ../utils/clflags.cmx \
+  ../utils/config.cmx \
+  ../utils/misc.cmx \
+  checkpoints.cmx \
+  command_line.cmx \
+  debugger_config.cmx \
+  exec.cmx \
+  frames.cmx \
+  input_handling.cmx \
+  parameters.cmx \
+  primitives.cmx \
+  program_management.cmx \
+  question.cmx \
+  show_information.cmx \
+  time_travel.cmx \
+  unix_tools.cmx
+parameters.cmo : \
+  ../typing/envaux.cmi \
+  ../utils/config.cmi \
+  debugger_config.cmi \
+  parameters.cmi \
+  primitives.cmi
+parameters.cmx : \
+  ../typing/envaux.cmx \
+  ../utils/config.cmx \
+  debugger_config.cmx \
+  parameters.cmi \
+  primitives.cmx
 parameters.cmi :
-parser.cmo : parser_aux.cmi ../parsing/longident.cmi int64ops.cmi \
-    input_handling.cmi parser.cmi
-parser.cmx : parser_aux.cmi ../parsing/longident.cmx int64ops.cmx \
-    input_handling.cmx parser.cmi
-parser.cmi : parser_aux.cmi ../parsing/longident.cmi
-parser_aux.cmi : ../parsing/longident.cmi
-pattern_matching.cmo : ../typing/typedtree.cmi parser_aux.cmi \
-    ../utils/misc.cmi debugger_config.cmi debugcom.cmi ../typing/ctype.cmi \
-    pattern_matching.cmi
-pattern_matching.cmx : ../typing/typedtree.cmx parser_aux.cmi \
-    ../utils/misc.cmx debugger_config.cmx debugcom.cmx ../typing/ctype.cmx \
-    pattern_matching.cmi
-pattern_matching.cmi : ../typing/typedtree.cmi parser_aux.cmi debugcom.cmi
-pos.cmo : ../parsing/location.cmi ../bytecomp/instruct.cmi pos.cmi
-pos.cmx : ../parsing/location.cmx ../bytecomp/instruct.cmx pos.cmi
-pos.cmi : ../bytecomp/instruct.cmi
-primitives.cmo : $(UNIXDIR)/unix.cmi primitives.cmi
-primitives.cmx : $(UNIXDIR)/unix.cmx primitives.cmi
-primitives.cmi : $(UNIXDIR)/unix.cmi
-printval.cmo : ../typing/types.cmi ../bytecomp/symtable.cmi \
-    ../typing/printtyp.cmi ../typing/path.cmi parser_aux.cmi \
-    ../typing/outcometree.cmi ../typing/oprint.cmi \
-    ../toplevel/genprintval.cmi debugcom.cmi printval.cmi
-printval.cmx : ../typing/types.cmx ../bytecomp/symtable.cmx \
-    ../typing/printtyp.cmx ../typing/path.cmx parser_aux.cmi \
-    ../typing/outcometree.cmi ../typing/oprint.cmx \
-    ../toplevel/genprintval.cmx debugcom.cmx printval.cmi
-printval.cmi : ../typing/types.cmi ../typing/path.cmi parser_aux.cmi \
-    ../typing/env.cmi debugcom.cmi
-program_loading.cmo : unix_tools.cmi $(UNIXDIR)/unix.cmi \
-    primitives.cmi parameters.cmi input_handling.cmi debugger_config.cmi \
-    program_loading.cmi
-program_loading.cmx : unix_tools.cmx $(UNIXDIR)/unix.cmx \
-    primitives.cmx parameters.cmx input_handling.cmx debugger_config.cmx \
-    program_loading.cmi
-program_loading.cmi : primitives.cmi
-program_management.cmo : unix_tools.cmi $(UNIXDIR)/unix.cmi \
-    time_travel.cmi symbols.cmi question.cmi program_loading.cmi \
-    primitives.cmi parameters.cmi int64ops.cmi input_handling.cmi history.cmi \
-    ../typing/envaux.cmi debugger_config.cmi ../utils/config.cmi \
-    breakpoints.cmi program_management.cmi
-program_management.cmx : unix_tools.cmx $(UNIXDIR)/unix.cmx \
-    time_travel.cmx symbols.cmx question.cmx program_loading.cmx \
-    primitives.cmx parameters.cmx int64ops.cmx input_handling.cmx history.cmx \
-    ../typing/envaux.cmx debugger_config.cmx ../utils/config.cmx \
-    breakpoints.cmx program_management.cmi
+parser.cmo : \
+  ../parsing/longident.cmi \
+  input_handling.cmi \
+  int64ops.cmi \
+  parser.cmi \
+  parser_aux.cmi
+parser.cmx : \
+  ../parsing/longident.cmx \
+  input_handling.cmx \
+  int64ops.cmx \
+  parser.cmi \
+  parser_aux.cmi
+parser.cmi : \
+  ../parsing/longident.cmi \
+  parser_aux.cmi
+parser_aux.cmi : \
+  ../parsing/longident.cmi
+pattern_matching.cmo : \
+  ../typing/ctype.cmi \
+  ../typing/typedtree.cmi \
+  ../utils/misc.cmi \
+  debugcom.cmi \
+  debugger_config.cmi \
+  parser_aux.cmi \
+  pattern_matching.cmi
+pattern_matching.cmx : \
+  ../typing/ctype.cmx \
+  ../typing/typedtree.cmx \
+  ../utils/misc.cmx \
+  debugcom.cmx \
+  debugger_config.cmx \
+  parser_aux.cmi \
+  pattern_matching.cmi
+pattern_matching.cmi : \
+  ../typing/typedtree.cmi \
+  debugcom.cmi \
+  parser_aux.cmi
+pos.cmo : \
+  ../bytecomp/instruct.cmi \
+  ../parsing/location.cmi \
+  pos.cmi
+pos.cmx : \
+  ../bytecomp/instruct.cmx \
+  ../parsing/location.cmx \
+  pos.cmi
+pos.cmi : \
+  ../bytecomp/instruct.cmi
+primitives.cmo : \
+  $(UNIXDIR)/unix.cmi \
+  primitives.cmi
+primitives.cmx : \
+  $(UNIXDIR)/unix.cmx \
+  primitives.cmi
+primitives.cmi : \
+  $(UNIXDIR)/unix.cmi
+printval.cmo : \
+  ../bytecomp/symtable.cmi \
+  ../toplevel/genprintval.cmi \
+  ../typing/oprint.cmi \
+  ../typing/outcometree.cmi \
+  ../typing/path.cmi \
+  ../typing/printtyp.cmi \
+  ../typing/types.cmi \
+  debugcom.cmi \
+  parser_aux.cmi \
+  printval.cmi
+printval.cmx : \
+  ../bytecomp/symtable.cmx \
+  ../toplevel/genprintval.cmx \
+  ../typing/oprint.cmx \
+  ../typing/outcometree.cmi \
+  ../typing/path.cmx \
+  ../typing/printtyp.cmx \
+  ../typing/types.cmx \
+  debugcom.cmx \
+  parser_aux.cmi \
+  printval.cmi
+printval.cmi : \
+  ../typing/env.cmi \
+  ../typing/path.cmi \
+  ../typing/types.cmi \
+  debugcom.cmi \
+  parser_aux.cmi
+program_loading.cmo : \
+  $(UNIXDIR)/unix.cmi \
+  debugger_config.cmi \
+  input_handling.cmi \
+  parameters.cmi \
+  primitives.cmi \
+  program_loading.cmi \
+  unix_tools.cmi
+program_loading.cmx : \
+  $(UNIXDIR)/unix.cmx \
+  debugger_config.cmx \
+  input_handling.cmx \
+  parameters.cmx \
+  primitives.cmx \
+  program_loading.cmi \
+  unix_tools.cmx
+program_loading.cmi : \
+  primitives.cmi
+program_management.cmo : \
+  $(UNIXDIR)/unix.cmi \
+  ../typing/envaux.cmi \
+  ../utils/config.cmi \
+  breakpoints.cmi \
+  debugger_config.cmi \
+  history.cmi \
+  input_handling.cmi \
+  int64ops.cmi \
+  parameters.cmi \
+  primitives.cmi \
+  program_loading.cmi \
+  program_management.cmi \
+  question.cmi \
+  symbols.cmi \
+  time_travel.cmi \
+  unix_tools.cmi
+program_management.cmx : \
+  $(UNIXDIR)/unix.cmx \
+  ../typing/envaux.cmx \
+  ../utils/config.cmx \
+  breakpoints.cmx \
+  debugger_config.cmx \
+  history.cmx \
+  input_handling.cmx \
+  int64ops.cmx \
+  parameters.cmx \
+  primitives.cmx \
+  program_loading.cmx \
+  program_management.cmi \
+  question.cmx \
+  symbols.cmx \
+  time_travel.cmx \
+  unix_tools.cmx
 program_management.cmi :
-question.cmo : primitives.cmi lexer.cmi input_handling.cmi question.cmi
-question.cmx : primitives.cmx lexer.cmx input_handling.cmx question.cmi
+question.cmo : \
+  input_handling.cmi \
+  lexer.cmi \
+  primitives.cmi \
+  question.cmi
+question.cmx : \
+  input_handling.cmx \
+  lexer.cmx \
+  primitives.cmx \
+  question.cmi
 question.cmi :
-show_information.cmo : symbols.cmi source.cmi show_source.cmi printval.cmi \
-    parameters.cmi ../utils/misc.cmi ../bytecomp/instruct.cmi frames.cmi \
-    events.cmi debugcom.cmi checkpoints.cmi breakpoints.cmi \
-    show_information.cmi
-show_information.cmx : symbols.cmx source.cmx show_source.cmx printval.cmx \
-    parameters.cmx ../utils/misc.cmx ../bytecomp/instruct.cmx frames.cmx \
-    events.cmx debugcom.cmx checkpoints.cmx breakpoints.cmx \
-    show_information.cmi
-show_information.cmi : ../bytecomp/instruct.cmi
-show_source.cmo : source.cmi primitives.cmi parameters.cmi \
-    ../parsing/location.cmi ../bytecomp/instruct.cmi events.cmi \
-    debugger_config.cmi show_source.cmi
-show_source.cmx : source.cmx primitives.cmx parameters.cmx \
-    ../parsing/location.cmx ../bytecomp/instruct.cmx events.cmx \
-    debugger_config.cmx show_source.cmi
-show_source.cmi : ../bytecomp/instruct.cmi
-source.cmo : primitives.cmi ../utils/misc.cmi debugger_config.cmi \
-    ../utils/config.cmi source.cmi
-source.cmx : primitives.cmx ../utils/misc.cmx debugger_config.cmx \
-    ../utils/config.cmx source.cmi
+show_information.cmo : \
+  ../bytecomp/instruct.cmi \
+  ../utils/misc.cmi \
+  breakpoints.cmi \
+  checkpoints.cmi \
+  debugcom.cmi \
+  events.cmi \
+  frames.cmi \
+  parameters.cmi \
+  printval.cmi \
+  show_information.cmi \
+  show_source.cmi \
+  source.cmi \
+  symbols.cmi
+show_information.cmx : \
+  ../bytecomp/instruct.cmx \
+  ../utils/misc.cmx \
+  breakpoints.cmx \
+  checkpoints.cmx \
+  debugcom.cmx \
+  events.cmx \
+  frames.cmx \
+  parameters.cmx \
+  printval.cmx \
+  show_information.cmi \
+  show_source.cmx \
+  source.cmx \
+  symbols.cmx
+show_information.cmi : \
+  ../bytecomp/instruct.cmi
+show_source.cmo : \
+  ../bytecomp/instruct.cmi \
+  ../parsing/location.cmi \
+  debugger_config.cmi \
+  events.cmi \
+  parameters.cmi \
+  primitives.cmi \
+  show_source.cmi \
+  source.cmi
+show_source.cmx : \
+  ../bytecomp/instruct.cmx \
+  ../parsing/location.cmx \
+  debugger_config.cmx \
+  events.cmx \
+  parameters.cmx \
+  primitives.cmx \
+  show_source.cmi \
+  source.cmx
+show_source.cmi : \
+  ../bytecomp/instruct.cmi
+source.cmo : \
+  ../utils/config.cmi \
+  ../utils/misc.cmi \
+  debugger_config.cmi \
+  primitives.cmi \
+  source.cmi
+source.cmx : \
+  ../utils/config.cmx \
+  ../utils/misc.cmx \
+  debugger_config.cmx \
+  primitives.cmx \
+  source.cmi
 source.cmi :
-symbols.cmo : ../bytecomp/symtable.cmi program_loading.cmi \
-    ../bytecomp/instruct.cmi events.cmi debugger_config.cmi debugcom.cmi \
-    checkpoints.cmi ../bytecomp/bytesections.cmi symbols.cmi
-symbols.cmx : ../bytecomp/symtable.cmx program_loading.cmx \
-    ../bytecomp/instruct.cmx events.cmx debugger_config.cmx debugcom.cmx \
-    checkpoints.cmx ../bytecomp/bytesections.cmx symbols.cmi
-symbols.cmi : ../bytecomp/instruct.cmi
-time_travel.cmo : trap_barrier.cmi symbols.cmi question.cmi \
-    program_loading.cmi primitives.cmi ../utils/misc.cmi int64ops.cmi \
-    ../bytecomp/instruct.cmi input_handling.cmi exec.cmi events.cmi \
-    debugger_config.cmi debugcom.cmi checkpoints.cmi breakpoints.cmi \
-    time_travel.cmi
-time_travel.cmx : trap_barrier.cmx symbols.cmx question.cmx \
-    program_loading.cmx primitives.cmx ../utils/misc.cmx int64ops.cmx \
-    ../bytecomp/instruct.cmx input_handling.cmx exec.cmx events.cmx \
-    debugger_config.cmx debugcom.cmx checkpoints.cmx breakpoints.cmx \
-    time_travel.cmi
-time_travel.cmi : primitives.cmi
-trap_barrier.cmo : exec.cmi debugcom.cmi checkpoints.cmi trap_barrier.cmi
-trap_barrier.cmx : exec.cmx debugcom.cmx checkpoints.cmx trap_barrier.cmi
+symbols.cmo : \
+  ../bytecomp/bytesections.cmi \
+  ../bytecomp/instruct.cmi \
+  ../bytecomp/symtable.cmi \
+  checkpoints.cmi \
+  debugcom.cmi \
+  debugger_config.cmi \
+  events.cmi \
+  program_loading.cmi \
+  symbols.cmi
+symbols.cmx : \
+  ../bytecomp/bytesections.cmx \
+  ../bytecomp/instruct.cmx \
+  ../bytecomp/symtable.cmx \
+  checkpoints.cmx \
+  debugcom.cmx \
+  debugger_config.cmx \
+  events.cmx \
+  program_loading.cmx \
+  symbols.cmi
+symbols.cmi : \
+  ../bytecomp/instruct.cmi
+time_travel.cmo : \
+  ../bytecomp/instruct.cmi \
+  ../utils/misc.cmi \
+  breakpoints.cmi \
+  checkpoints.cmi \
+  debugcom.cmi \
+  debugger_config.cmi \
+  events.cmi \
+  exec.cmi \
+  input_handling.cmi \
+  int64ops.cmi \
+  primitives.cmi \
+  program_loading.cmi \
+  question.cmi \
+  symbols.cmi \
+  time_travel.cmi \
+  trap_barrier.cmi
+time_travel.cmx : \
+  ../bytecomp/instruct.cmx \
+  ../utils/misc.cmx \
+  breakpoints.cmx \
+  checkpoints.cmx \
+  debugcom.cmx \
+  debugger_config.cmx \
+  events.cmx \
+  exec.cmx \
+  input_handling.cmx \
+  int64ops.cmx \
+  primitives.cmx \
+  program_loading.cmx \
+  question.cmx \
+  symbols.cmx \
+  time_travel.cmi \
+  trap_barrier.cmx
+time_travel.cmi : \
+  primitives.cmi
+trap_barrier.cmo : \
+  checkpoints.cmi \
+  debugcom.cmi \
+  exec.cmi \
+  trap_barrier.cmi
+trap_barrier.cmx : \
+  checkpoints.cmx \
+  debugcom.cmx \
+  exec.cmx \
+  trap_barrier.cmi
 trap_barrier.cmi :
-unix_tools.cmo : $(UNIXDIR)/unix.cmi ../utils/misc.cmi unix_tools.cmi
-unix_tools.cmx : $(UNIXDIR)/unix.cmx ../utils/misc.cmx unix_tools.cmi
-unix_tools.cmi : $(UNIXDIR)/unix.cmi
+unix_tools.cmo : \
+  $(UNIXDIR)/unix.cmi \
+  ../utils/misc.cmi \
+  unix_tools.cmi
+unix_tools.cmx : \
+  $(UNIXDIR)/unix.cmx \
+  ../utils/misc.cmx \
+  unix_tools.cmi
+unix_tools.cmi : \
+  $(UNIXDIR)/unix.cmi

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -114,6 +114,7 @@ clean::
 depend: beforedepend
 	$(CAMLDEP) -slash $(DEPFLAGS) *.mli *.ml \
 	| sed -e 's,$(UNIXDIR)/,$$(UNIXDIR)/,' > .depend
+	../tools/normalize_depend .depend
 
 lexer.ml: lexer.mll
 	$(CAMLLEX) lexer.mll

--- a/lex/.depend
+++ b/lex/.depend
@@ -1,34 +1,118 @@
-common.cmo : syntax.cmi lexgen.cmi common.cmi
-common.cmx : syntax.cmx lexgen.cmx common.cmi
-common.cmi : syntax.cmi lexgen.cmi
-compact.cmo : table.cmi lexgen.cmi compact.cmi
-compact.cmx : table.cmx lexgen.cmx compact.cmi
-compact.cmi : lexgen.cmi
-cset.cmo : cset.cmi
-cset.cmx : cset.cmi
+common.cmo : \
+  common.cmi \
+  lexgen.cmi \
+  syntax.cmi
+common.cmx : \
+  common.cmi \
+  lexgen.cmx \
+  syntax.cmx
+common.cmi : \
+  lexgen.cmi \
+  syntax.cmi
+compact.cmo : \
+  compact.cmi \
+  lexgen.cmi \
+  table.cmi
+compact.cmx : \
+  compact.cmi \
+  lexgen.cmx \
+  table.cmx
+compact.cmi : \
+  lexgen.cmi
+cset.cmo : \
+  cset.cmi
+cset.cmx : \
+  cset.cmi
 cset.cmi :
-lexer.cmo : syntax.cmi parser.cmi lexer.cmi
-lexer.cmx : syntax.cmx parser.cmx lexer.cmi
-lexer.cmi : parser.cmi
-lexgen.cmo : table.cmi syntax.cmi cset.cmi lexgen.cmi
-lexgen.cmx : table.cmx syntax.cmx cset.cmx lexgen.cmi
-lexgen.cmi : syntax.cmi
-main.cmo : syntax.cmi parser.cmi outputbis.cmi output.cmi lexgen.cmi \
-    lexer.cmi cset.cmi compact.cmi common.cmi
-main.cmx : syntax.cmx parser.cmx outputbis.cmx output.cmx lexgen.cmx \
-    lexer.cmx cset.cmx compact.cmx common.cmx
-output.cmo : lexgen.cmi compact.cmi common.cmi output.cmi
-output.cmx : lexgen.cmx compact.cmx common.cmx output.cmi
-output.cmi : syntax.cmi lexgen.cmi compact.cmi common.cmi
-outputbis.cmo : lexgen.cmi common.cmi outputbis.cmi
-outputbis.cmx : lexgen.cmx common.cmx outputbis.cmi
-outputbis.cmi : syntax.cmi lexgen.cmi common.cmi
-parser.cmo : syntax.cmi cset.cmi parser.cmi
-parser.cmx : syntax.cmx cset.cmx parser.cmi
-parser.cmi : syntax.cmi
-syntax.cmo : cset.cmi syntax.cmi
-syntax.cmx : cset.cmx syntax.cmi
-syntax.cmi : cset.cmi
-table.cmo : table.cmi
-table.cmx : table.cmi
+lexer.cmo : \
+  lexer.cmi \
+  parser.cmi \
+  syntax.cmi
+lexer.cmx : \
+  lexer.cmi \
+  parser.cmx \
+  syntax.cmx
+lexer.cmi : \
+  parser.cmi
+lexgen.cmo : \
+  cset.cmi \
+  lexgen.cmi \
+  syntax.cmi \
+  table.cmi
+lexgen.cmx : \
+  cset.cmx \
+  lexgen.cmi \
+  syntax.cmx \
+  table.cmx
+lexgen.cmi : \
+  syntax.cmi
+main.cmo : \
+  common.cmi \
+  compact.cmi \
+  cset.cmi \
+  lexer.cmi \
+  lexgen.cmi \
+  output.cmi \
+  outputbis.cmi \
+  parser.cmi \
+  syntax.cmi
+main.cmx : \
+  common.cmx \
+  compact.cmx \
+  cset.cmx \
+  lexer.cmx \
+  lexgen.cmx \
+  output.cmx \
+  outputbis.cmx \
+  parser.cmx \
+  syntax.cmx
+output.cmo : \
+  common.cmi \
+  compact.cmi \
+  lexgen.cmi \
+  output.cmi
+output.cmx : \
+  common.cmx \
+  compact.cmx \
+  lexgen.cmx \
+  output.cmi
+output.cmi : \
+  common.cmi \
+  compact.cmi \
+  lexgen.cmi \
+  syntax.cmi
+outputbis.cmo : \
+  common.cmi \
+  lexgen.cmi \
+  outputbis.cmi
+outputbis.cmx : \
+  common.cmx \
+  lexgen.cmx \
+  outputbis.cmi
+outputbis.cmi : \
+  common.cmi \
+  lexgen.cmi \
+  syntax.cmi
+parser.cmo : \
+  cset.cmi \
+  parser.cmi \
+  syntax.cmi
+parser.cmx : \
+  cset.cmx \
+  parser.cmi \
+  syntax.cmx
+parser.cmi : \
+  syntax.cmi
+syntax.cmo : \
+  cset.cmi \
+  syntax.cmi
+syntax.cmx : \
+  cset.cmx \
+  syntax.cmi
+syntax.cmi : \
+  cset.cmi
+table.cmo : \
+  table.cmi
+table.cmx : \
+  table.cmi
 table.cmi :

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -83,5 +83,6 @@ beforedepend:: lexer.ml
 
 depend: beforedepend
 	$(CAMLDEP) -slash *.mli *.ml > .depend
+	../tools/normalize_depend .depend
 
 include .depend

--- a/ocamldoc/.depend
+++ b/ocamldoc/.depend
@@ -1,278 +1,872 @@
-odoc.cmo : odoc_messages.cmo odoc_info.cmi odoc_global.cmi odoc_gen.cmi \
-    odoc_config.cmi odoc_args.cmi odoc_analyse.cmi
-odoc.cmx : odoc_messages.cmx odoc_info.cmx odoc_global.cmx odoc_gen.cmx \
-    odoc_config.cmx odoc_args.cmx odoc_analyse.cmx
-odoc_analyse.cmo : ../utils/warnings.cmi ../typing/types.cmi \
-    ../typing/typemod.cmi ../typing/typedtree.cmi ../parsing/syntaxerr.cmi \
-    ../driver/pparse.cmi ../parsing/parse.cmi odoc_types.cmi odoc_text.cmi \
-    odoc_sig.cmi odoc_module.cmo odoc_misc.cmi odoc_messages.cmo \
-    odoc_merge.cmi odoc_global.cmi odoc_dep.cmo odoc_cross.cmi \
-    odoc_comments.cmi odoc_class.cmo odoc_ast.cmi ../parsing/longident.cmi \
-    ../parsing/location.cmi ../parsing/lexer.cmi ../typing/env.cmi \
-    ../utils/config.cmi ../utils/clflags.cmi ../parsing/asttypes.cmi \
-    odoc_analyse.cmi
-odoc_analyse.cmx : ../utils/warnings.cmx ../typing/types.cmx \
-    ../typing/typemod.cmx ../typing/typedtree.cmx ../parsing/syntaxerr.cmx \
-    ../driver/pparse.cmx ../parsing/parse.cmx odoc_types.cmx odoc_text.cmx \
-    odoc_sig.cmx odoc_module.cmx odoc_misc.cmx odoc_messages.cmx \
-    odoc_merge.cmx odoc_global.cmx odoc_dep.cmx odoc_cross.cmx \
-    odoc_comments.cmx odoc_class.cmx odoc_ast.cmx ../parsing/longident.cmx \
-    ../parsing/location.cmx ../parsing/lexer.cmx ../typing/env.cmx \
-    ../utils/config.cmx ../utils/clflags.cmx ../parsing/asttypes.cmi \
-    odoc_analyse.cmi
-odoc_analyse.cmi : odoc_module.cmo odoc_global.cmi
-odoc_args.cmo : ../utils/warnings.cmi odoc_types.cmi odoc_texi.cmo \
-    odoc_messages.cmo odoc_man.cmo odoc_latex.cmo odoc_html.cmo \
-    odoc_global.cmi odoc_gen.cmi odoc_dot.cmo odoc_config.cmi \
-    ../utils/misc.cmi ../driver/main_args.cmi ../parsing/location.cmi \
-    ../utils/config.cmi ../driver/compenv.cmi ../utils/clflags.cmi \
-    odoc_args.cmi
-odoc_args.cmx : ../utils/warnings.cmx odoc_types.cmx odoc_texi.cmx \
-    odoc_messages.cmx odoc_man.cmx odoc_latex.cmx odoc_html.cmx \
-    odoc_global.cmx odoc_gen.cmx odoc_dot.cmx odoc_config.cmx \
-    ../utils/misc.cmx ../driver/main_args.cmx ../parsing/location.cmx \
-    ../utils/config.cmx ../driver/compenv.cmx ../utils/clflags.cmx \
-    odoc_args.cmi
-odoc_args.cmi : odoc_gen.cmi
-odoc_ast.cmo : ../typing/types.cmi ../typing/typedtree.cmi \
-    ../typing/predef.cmi ../typing/path.cmi ../parsing/parsetree.cmi \
-    odoc_value.cmo odoc_types.cmi odoc_type.cmo odoc_sig.cmi \
-    odoc_parameter.cmo odoc_module.cmo odoc_messages.cmo odoc_global.cmi \
-    odoc_extension.cmo odoc_exception.cmo odoc_env.cmi odoc_class.cmo \
-    ../utils/misc.cmi ../parsing/location.cmi ../typing/ident.cmi \
-    ../parsing/asttypes.cmi odoc_ast.cmi
-odoc_ast.cmx : ../typing/types.cmx ../typing/typedtree.cmx \
-    ../typing/predef.cmx ../typing/path.cmx ../parsing/parsetree.cmi \
-    odoc_value.cmx odoc_types.cmx odoc_type.cmx odoc_sig.cmx \
-    odoc_parameter.cmx odoc_module.cmx odoc_messages.cmx odoc_global.cmx \
-    odoc_extension.cmx odoc_exception.cmx odoc_env.cmx odoc_class.cmx \
-    ../utils/misc.cmx ../parsing/location.cmx ../typing/ident.cmx \
-    ../parsing/asttypes.cmi odoc_ast.cmi
-odoc_ast.cmi : ../typing/types.cmi ../typing/typedtree.cmi \
-    ../parsing/parsetree.cmi odoc_sig.cmi odoc_name.cmi odoc_module.cmo
-odoc_class.cmo : ../typing/types.cmi odoc_value.cmo odoc_types.cmi \
-    odoc_parameter.cmo odoc_name.cmi
-odoc_class.cmx : ../typing/types.cmx odoc_value.cmx odoc_types.cmx \
-    odoc_parameter.cmx odoc_name.cmx
-odoc_comments.cmo : odoc_types.cmi odoc_text.cmi odoc_see_lexer.cmo \
-    odoc_parser.cmi odoc_misc.cmi odoc_messages.cmo odoc_merge.cmi \
-    odoc_lexer.cmo odoc_global.cmi odoc_cross.cmi odoc_comments_global.cmi \
-    odoc_comments.cmi
-odoc_comments.cmx : odoc_types.cmx odoc_text.cmx odoc_see_lexer.cmx \
-    odoc_parser.cmx odoc_misc.cmx odoc_messages.cmx odoc_merge.cmx \
-    odoc_lexer.cmx odoc_global.cmx odoc_cross.cmx odoc_comments_global.cmx \
-    odoc_comments.cmi
-odoc_comments.cmi : odoc_types.cmi odoc_module.cmo
-odoc_comments_global.cmo : odoc_comments_global.cmi
-odoc_comments_global.cmx : odoc_comments_global.cmi
+odoc.cmo : \
+  odoc_analyse.cmi \
+  odoc_args.cmi \
+  odoc_config.cmi \
+  odoc_gen.cmi \
+  odoc_global.cmi \
+  odoc_info.cmi \
+  odoc_messages.cmo
+odoc.cmx : \
+  odoc_analyse.cmx \
+  odoc_args.cmx \
+  odoc_config.cmx \
+  odoc_gen.cmx \
+  odoc_global.cmx \
+  odoc_info.cmx \
+  odoc_messages.cmx
+odoc_analyse.cmo : \
+  ../driver/pparse.cmi \
+  ../parsing/asttypes.cmi \
+  ../parsing/lexer.cmi \
+  ../parsing/location.cmi \
+  ../parsing/longident.cmi \
+  ../parsing/parse.cmi \
+  ../parsing/syntaxerr.cmi \
+  ../typing/env.cmi \
+  ../typing/typedtree.cmi \
+  ../typing/typemod.cmi \
+  ../typing/types.cmi \
+  ../utils/clflags.cmi \
+  ../utils/config.cmi \
+  ../utils/warnings.cmi \
+  odoc_analyse.cmi \
+  odoc_ast.cmi \
+  odoc_class.cmo \
+  odoc_comments.cmi \
+  odoc_cross.cmi \
+  odoc_dep.cmo \
+  odoc_global.cmi \
+  odoc_merge.cmi \
+  odoc_messages.cmo \
+  odoc_misc.cmi \
+  odoc_module.cmo \
+  odoc_sig.cmi \
+  odoc_text.cmi \
+  odoc_types.cmi
+odoc_analyse.cmx : \
+  ../driver/pparse.cmx \
+  ../parsing/asttypes.cmi \
+  ../parsing/lexer.cmx \
+  ../parsing/location.cmx \
+  ../parsing/longident.cmx \
+  ../parsing/parse.cmx \
+  ../parsing/syntaxerr.cmx \
+  ../typing/env.cmx \
+  ../typing/typedtree.cmx \
+  ../typing/typemod.cmx \
+  ../typing/types.cmx \
+  ../utils/clflags.cmx \
+  ../utils/config.cmx \
+  ../utils/warnings.cmx \
+  odoc_analyse.cmi \
+  odoc_ast.cmx \
+  odoc_class.cmx \
+  odoc_comments.cmx \
+  odoc_cross.cmx \
+  odoc_dep.cmx \
+  odoc_global.cmx \
+  odoc_merge.cmx \
+  odoc_messages.cmx \
+  odoc_misc.cmx \
+  odoc_module.cmx \
+  odoc_sig.cmx \
+  odoc_text.cmx \
+  odoc_types.cmx
+odoc_analyse.cmi : \
+  odoc_global.cmi \
+  odoc_module.cmo
+odoc_args.cmo : \
+  ../driver/compenv.cmi \
+  ../driver/main_args.cmi \
+  ../parsing/location.cmi \
+  ../utils/clflags.cmi \
+  ../utils/config.cmi \
+  ../utils/misc.cmi \
+  ../utils/warnings.cmi \
+  odoc_args.cmi \
+  odoc_config.cmi \
+  odoc_dot.cmo \
+  odoc_gen.cmi \
+  odoc_global.cmi \
+  odoc_html.cmo \
+  odoc_latex.cmo \
+  odoc_man.cmo \
+  odoc_messages.cmo \
+  odoc_texi.cmo \
+  odoc_types.cmi
+odoc_args.cmx : \
+  ../driver/compenv.cmx \
+  ../driver/main_args.cmx \
+  ../parsing/location.cmx \
+  ../utils/clflags.cmx \
+  ../utils/config.cmx \
+  ../utils/misc.cmx \
+  ../utils/warnings.cmx \
+  odoc_args.cmi \
+  odoc_config.cmx \
+  odoc_dot.cmx \
+  odoc_gen.cmx \
+  odoc_global.cmx \
+  odoc_html.cmx \
+  odoc_latex.cmx \
+  odoc_man.cmx \
+  odoc_messages.cmx \
+  odoc_texi.cmx \
+  odoc_types.cmx
+odoc_args.cmi : \
+  odoc_gen.cmi
+odoc_ast.cmo : \
+  ../parsing/asttypes.cmi \
+  ../parsing/location.cmi \
+  ../parsing/parsetree.cmi \
+  ../typing/ident.cmi \
+  ../typing/path.cmi \
+  ../typing/predef.cmi \
+  ../typing/typedtree.cmi \
+  ../typing/types.cmi \
+  ../utils/misc.cmi \
+  odoc_ast.cmi \
+  odoc_class.cmo \
+  odoc_env.cmi \
+  odoc_exception.cmo \
+  odoc_extension.cmo \
+  odoc_global.cmi \
+  odoc_messages.cmo \
+  odoc_module.cmo \
+  odoc_parameter.cmo \
+  odoc_sig.cmi \
+  odoc_type.cmo \
+  odoc_types.cmi \
+  odoc_value.cmo
+odoc_ast.cmx : \
+  ../parsing/asttypes.cmi \
+  ../parsing/location.cmx \
+  ../parsing/parsetree.cmi \
+  ../typing/ident.cmx \
+  ../typing/path.cmx \
+  ../typing/predef.cmx \
+  ../typing/typedtree.cmx \
+  ../typing/types.cmx \
+  ../utils/misc.cmx \
+  odoc_ast.cmi \
+  odoc_class.cmx \
+  odoc_env.cmx \
+  odoc_exception.cmx \
+  odoc_extension.cmx \
+  odoc_global.cmx \
+  odoc_messages.cmx \
+  odoc_module.cmx \
+  odoc_parameter.cmx \
+  odoc_sig.cmx \
+  odoc_type.cmx \
+  odoc_types.cmx \
+  odoc_value.cmx
+odoc_ast.cmi : \
+  ../parsing/parsetree.cmi \
+  ../typing/typedtree.cmi \
+  ../typing/types.cmi \
+  odoc_module.cmo \
+  odoc_name.cmi \
+  odoc_sig.cmi
+odoc_class.cmo : \
+  ../typing/types.cmi \
+  odoc_name.cmi \
+  odoc_parameter.cmo \
+  odoc_types.cmi \
+  odoc_value.cmo
+odoc_class.cmx : \
+  ../typing/types.cmx \
+  odoc_name.cmx \
+  odoc_parameter.cmx \
+  odoc_types.cmx \
+  odoc_value.cmx
+odoc_comments.cmo : \
+  odoc_comments.cmi \
+  odoc_comments_global.cmi \
+  odoc_cross.cmi \
+  odoc_global.cmi \
+  odoc_lexer.cmo \
+  odoc_merge.cmi \
+  odoc_messages.cmo \
+  odoc_misc.cmi \
+  odoc_parser.cmi \
+  odoc_see_lexer.cmo \
+  odoc_text.cmi \
+  odoc_types.cmi
+odoc_comments.cmx : \
+  odoc_comments.cmi \
+  odoc_comments_global.cmx \
+  odoc_cross.cmx \
+  odoc_global.cmx \
+  odoc_lexer.cmx \
+  odoc_merge.cmx \
+  odoc_messages.cmx \
+  odoc_misc.cmx \
+  odoc_parser.cmx \
+  odoc_see_lexer.cmx \
+  odoc_text.cmx \
+  odoc_types.cmx
+odoc_comments.cmi : \
+  odoc_module.cmo \
+  odoc_types.cmi
+odoc_comments_global.cmo : \
+  odoc_comments_global.cmi
+odoc_comments_global.cmx : \
+  odoc_comments_global.cmi
 odoc_comments_global.cmi :
-odoc_config.cmo : ../utils/config.cmi odoc_config.cmi
-odoc_config.cmx : ../utils/config.cmx odoc_config.cmi
+odoc_config.cmo : \
+  ../utils/config.cmi \
+  odoc_config.cmi
+odoc_config.cmx : \
+  ../utils/config.cmx \
+  odoc_config.cmi
 odoc_config.cmi :
 odoc_control.cmo :
 odoc_control.cmx :
-odoc_cross.cmo : odoc_value.cmo odoc_types.cmi odoc_type.cmo odoc_search.cmi \
-    odoc_scan.cmo odoc_parameter.cmo odoc_name.cmi odoc_module.cmo \
-    odoc_misc.cmi odoc_messages.cmo odoc_global.cmi odoc_extension.cmo \
-    odoc_exception.cmo odoc_class.cmo odoc_cross.cmi
-odoc_cross.cmx : odoc_value.cmx odoc_types.cmx odoc_type.cmx odoc_search.cmx \
-    odoc_scan.cmx odoc_parameter.cmx odoc_name.cmx odoc_module.cmx \
-    odoc_misc.cmx odoc_messages.cmx odoc_global.cmx odoc_extension.cmx \
-    odoc_exception.cmx odoc_class.cmx odoc_cross.cmi
-odoc_cross.cmi : odoc_types.cmi odoc_module.cmo
-odoc_dag2html.cmo : odoc_info.cmi odoc_dag2html.cmi
-odoc_dag2html.cmx : odoc_info.cmx odoc_dag2html.cmi
-odoc_dag2html.cmi : odoc_info.cmi
-odoc_dep.cmo : ../parsing/parsetree.cmi odoc_type.cmo odoc_print.cmi \
-    odoc_module.cmo ../parsing/depend.cmi
-odoc_dep.cmx : ../parsing/parsetree.cmi odoc_type.cmx odoc_print.cmx \
-    odoc_module.cmx ../parsing/depend.cmx
-odoc_dot.cmo : odoc_messages.cmo odoc_info.cmi
-odoc_dot.cmx : odoc_messages.cmx odoc_info.cmx
-odoc_env.cmo : ../typing/types.cmi ../typing/printtyp.cmi \
-    ../typing/predef.cmi ../typing/path.cmi odoc_name.cmi ../utils/misc.cmi \
-    ../typing/btype.cmi odoc_env.cmi
-odoc_env.cmx : ../typing/types.cmx ../typing/printtyp.cmx \
-    ../typing/predef.cmx ../typing/path.cmx odoc_name.cmx ../utils/misc.cmx \
-    ../typing/btype.cmx odoc_env.cmi
-odoc_env.cmi : ../typing/types.cmi odoc_name.cmi
-odoc_exception.cmo : ../typing/types.cmi odoc_types.cmi odoc_type.cmo \
-    odoc_name.cmi
-odoc_exception.cmx : ../typing/types.cmx odoc_types.cmx odoc_type.cmx \
-    odoc_name.cmx
-odoc_extension.cmo : ../typing/types.cmi odoc_types.cmi odoc_type.cmo \
-    odoc_name.cmi ../parsing/asttypes.cmi
-odoc_extension.cmx : ../typing/types.cmx odoc_types.cmx odoc_type.cmx \
-    odoc_name.cmx ../parsing/asttypes.cmi
-odoc_gen.cmo : odoc_texi.cmo odoc_module.cmo odoc_man.cmo odoc_latex.cmo \
-    odoc_html.cmo odoc_dot.cmo odoc_gen.cmi
-odoc_gen.cmx : odoc_texi.cmx odoc_module.cmx odoc_man.cmx odoc_latex.cmx \
-    odoc_html.cmx odoc_dot.cmx odoc_gen.cmi
-odoc_gen.cmi : odoc_texi.cmo odoc_module.cmo odoc_man.cmo odoc_latex.cmo \
-    odoc_html.cmo odoc_dot.cmo
-odoc_global.cmo : odoc_types.cmi odoc_messages.cmo odoc_config.cmi \
-    ../utils/clflags.cmi odoc_global.cmi
-odoc_global.cmx : odoc_types.cmx odoc_messages.cmx odoc_config.cmx \
-    ../utils/clflags.cmx odoc_global.cmi
-odoc_global.cmi : odoc_types.cmi
-odoc_html.cmo : odoc_text.cmi odoc_ocamlhtml.cmo odoc_messages.cmo \
-    odoc_info.cmi odoc_global.cmi odoc_dag2html.cmi ../parsing/asttypes.cmi
-odoc_html.cmx : odoc_text.cmx odoc_ocamlhtml.cmx odoc_messages.cmx \
-    odoc_info.cmx odoc_global.cmx odoc_dag2html.cmx ../parsing/asttypes.cmi
-odoc_info.cmo : ../typing/printtyp.cmi odoc_value.cmo odoc_types.cmi \
-    odoc_type.cmo odoc_text.cmi odoc_str.cmi odoc_search.cmi odoc_scan.cmo \
-    odoc_print.cmi odoc_parameter.cmo odoc_name.cmi odoc_module.cmo \
-    odoc_misc.cmi odoc_global.cmi odoc_extension.cmo odoc_exception.cmo \
-    odoc_dep.cmo odoc_config.cmi odoc_comments.cmi odoc_class.cmo \
-    odoc_analyse.cmi ../parsing/location.cmi odoc_info.cmi
-odoc_info.cmx : ../typing/printtyp.cmx odoc_value.cmx odoc_types.cmx \
-    odoc_type.cmx odoc_text.cmx odoc_str.cmx odoc_search.cmx odoc_scan.cmx \
-    odoc_print.cmx odoc_parameter.cmx odoc_name.cmx odoc_module.cmx \
-    odoc_misc.cmx odoc_global.cmx odoc_extension.cmx odoc_exception.cmx \
-    odoc_dep.cmx odoc_config.cmx odoc_comments.cmx odoc_class.cmx \
-    odoc_analyse.cmx ../parsing/location.cmx odoc_info.cmi
-odoc_info.cmi : ../typing/types.cmi odoc_value.cmo odoc_types.cmi \
-    odoc_type.cmo odoc_search.cmi odoc_parameter.cmo odoc_module.cmo \
-    odoc_global.cmi odoc_extension.cmo odoc_exception.cmo odoc_class.cmo \
-    ../parsing/location.cmi ../parsing/asttypes.cmi
+odoc_cross.cmo : \
+  odoc_class.cmo \
+  odoc_cross.cmi \
+  odoc_exception.cmo \
+  odoc_extension.cmo \
+  odoc_global.cmi \
+  odoc_messages.cmo \
+  odoc_misc.cmi \
+  odoc_module.cmo \
+  odoc_name.cmi \
+  odoc_parameter.cmo \
+  odoc_scan.cmo \
+  odoc_search.cmi \
+  odoc_type.cmo \
+  odoc_types.cmi \
+  odoc_value.cmo
+odoc_cross.cmx : \
+  odoc_class.cmx \
+  odoc_cross.cmi \
+  odoc_exception.cmx \
+  odoc_extension.cmx \
+  odoc_global.cmx \
+  odoc_messages.cmx \
+  odoc_misc.cmx \
+  odoc_module.cmx \
+  odoc_name.cmx \
+  odoc_parameter.cmx \
+  odoc_scan.cmx \
+  odoc_search.cmx \
+  odoc_type.cmx \
+  odoc_types.cmx \
+  odoc_value.cmx
+odoc_cross.cmi : \
+  odoc_module.cmo \
+  odoc_types.cmi
+odoc_dag2html.cmo : \
+  odoc_dag2html.cmi \
+  odoc_info.cmi
+odoc_dag2html.cmx : \
+  odoc_dag2html.cmi \
+  odoc_info.cmx
+odoc_dag2html.cmi : \
+  odoc_info.cmi
+odoc_dep.cmo : \
+  ../parsing/depend.cmi \
+  ../parsing/parsetree.cmi \
+  odoc_module.cmo \
+  odoc_print.cmi \
+  odoc_type.cmo
+odoc_dep.cmx : \
+  ../parsing/depend.cmx \
+  ../parsing/parsetree.cmi \
+  odoc_module.cmx \
+  odoc_print.cmx \
+  odoc_type.cmx
+odoc_dot.cmo : \
+  odoc_info.cmi \
+  odoc_messages.cmo
+odoc_dot.cmx : \
+  odoc_info.cmx \
+  odoc_messages.cmx
+odoc_env.cmo : \
+  ../typing/btype.cmi \
+  ../typing/path.cmi \
+  ../typing/predef.cmi \
+  ../typing/printtyp.cmi \
+  ../typing/types.cmi \
+  ../utils/misc.cmi \
+  odoc_env.cmi \
+  odoc_name.cmi
+odoc_env.cmx : \
+  ../typing/btype.cmx \
+  ../typing/path.cmx \
+  ../typing/predef.cmx \
+  ../typing/printtyp.cmx \
+  ../typing/types.cmx \
+  ../utils/misc.cmx \
+  odoc_env.cmi \
+  odoc_name.cmx
+odoc_env.cmi : \
+  ../typing/types.cmi \
+  odoc_name.cmi
+odoc_exception.cmo : \
+  ../typing/types.cmi \
+  odoc_name.cmi \
+  odoc_type.cmo \
+  odoc_types.cmi
+odoc_exception.cmx : \
+  ../typing/types.cmx \
+  odoc_name.cmx \
+  odoc_type.cmx \
+  odoc_types.cmx
+odoc_extension.cmo : \
+  ../parsing/asttypes.cmi \
+  ../typing/types.cmi \
+  odoc_name.cmi \
+  odoc_type.cmo \
+  odoc_types.cmi
+odoc_extension.cmx : \
+  ../parsing/asttypes.cmi \
+  ../typing/types.cmx \
+  odoc_name.cmx \
+  odoc_type.cmx \
+  odoc_types.cmx
+odoc_gen.cmo : \
+  odoc_dot.cmo \
+  odoc_gen.cmi \
+  odoc_html.cmo \
+  odoc_latex.cmo \
+  odoc_man.cmo \
+  odoc_module.cmo \
+  odoc_texi.cmo
+odoc_gen.cmx : \
+  odoc_dot.cmx \
+  odoc_gen.cmi \
+  odoc_html.cmx \
+  odoc_latex.cmx \
+  odoc_man.cmx \
+  odoc_module.cmx \
+  odoc_texi.cmx
+odoc_gen.cmi : \
+  odoc_dot.cmo \
+  odoc_html.cmo \
+  odoc_latex.cmo \
+  odoc_man.cmo \
+  odoc_module.cmo \
+  odoc_texi.cmo
+odoc_global.cmo : \
+  ../utils/clflags.cmi \
+  odoc_config.cmi \
+  odoc_global.cmi \
+  odoc_messages.cmo \
+  odoc_types.cmi
+odoc_global.cmx : \
+  ../utils/clflags.cmx \
+  odoc_config.cmx \
+  odoc_global.cmi \
+  odoc_messages.cmx \
+  odoc_types.cmx
+odoc_global.cmi : \
+  odoc_types.cmi
+odoc_html.cmo : \
+  ../parsing/asttypes.cmi \
+  odoc_dag2html.cmi \
+  odoc_global.cmi \
+  odoc_info.cmi \
+  odoc_messages.cmo \
+  odoc_ocamlhtml.cmo \
+  odoc_text.cmi
+odoc_html.cmx : \
+  ../parsing/asttypes.cmi \
+  odoc_dag2html.cmx \
+  odoc_global.cmx \
+  odoc_info.cmx \
+  odoc_messages.cmx \
+  odoc_ocamlhtml.cmx \
+  odoc_text.cmx
+odoc_info.cmo : \
+  ../parsing/location.cmi \
+  ../typing/printtyp.cmi \
+  odoc_analyse.cmi \
+  odoc_class.cmo \
+  odoc_comments.cmi \
+  odoc_config.cmi \
+  odoc_dep.cmo \
+  odoc_exception.cmo \
+  odoc_extension.cmo \
+  odoc_global.cmi \
+  odoc_info.cmi \
+  odoc_misc.cmi \
+  odoc_module.cmo \
+  odoc_name.cmi \
+  odoc_parameter.cmo \
+  odoc_print.cmi \
+  odoc_scan.cmo \
+  odoc_search.cmi \
+  odoc_str.cmi \
+  odoc_text.cmi \
+  odoc_type.cmo \
+  odoc_types.cmi \
+  odoc_value.cmo
+odoc_info.cmx : \
+  ../parsing/location.cmx \
+  ../typing/printtyp.cmx \
+  odoc_analyse.cmx \
+  odoc_class.cmx \
+  odoc_comments.cmx \
+  odoc_config.cmx \
+  odoc_dep.cmx \
+  odoc_exception.cmx \
+  odoc_extension.cmx \
+  odoc_global.cmx \
+  odoc_info.cmi \
+  odoc_misc.cmx \
+  odoc_module.cmx \
+  odoc_name.cmx \
+  odoc_parameter.cmx \
+  odoc_print.cmx \
+  odoc_scan.cmx \
+  odoc_search.cmx \
+  odoc_str.cmx \
+  odoc_text.cmx \
+  odoc_type.cmx \
+  odoc_types.cmx \
+  odoc_value.cmx
+odoc_info.cmi : \
+  ../parsing/asttypes.cmi \
+  ../parsing/location.cmi \
+  ../typing/types.cmi \
+  odoc_class.cmo \
+  odoc_exception.cmo \
+  odoc_extension.cmo \
+  odoc_global.cmi \
+  odoc_module.cmo \
+  odoc_parameter.cmo \
+  odoc_search.cmi \
+  odoc_type.cmo \
+  odoc_types.cmi \
+  odoc_value.cmo
 odoc_inherit.cmo :
 odoc_inherit.cmx :
-odoc_latex.cmo : odoc_to_text.cmo odoc_messages.cmo odoc_latex_style.cmo \
-    odoc_info.cmi ../parsing/asttypes.cmi
-odoc_latex.cmx : odoc_to_text.cmx odoc_messages.cmx odoc_latex_style.cmx \
-    odoc_info.cmx ../parsing/asttypes.cmi
+odoc_latex.cmo : \
+  ../parsing/asttypes.cmi \
+  odoc_info.cmi \
+  odoc_latex_style.cmo \
+  odoc_messages.cmo \
+  odoc_to_text.cmo
+odoc_latex.cmx : \
+  ../parsing/asttypes.cmi \
+  odoc_info.cmx \
+  odoc_latex_style.cmx \
+  odoc_messages.cmx \
+  odoc_to_text.cmx
 odoc_latex_style.cmo :
 odoc_latex_style.cmx :
-odoc_lexer.cmo : odoc_parser.cmi odoc_messages.cmo odoc_global.cmi \
-    odoc_comments_global.cmi
-odoc_lexer.cmx : odoc_parser.cmx odoc_messages.cmx odoc_global.cmx \
-    odoc_comments_global.cmx
-odoc_man.cmo : odoc_str.cmi odoc_print.cmi odoc_misc.cmi odoc_messages.cmo \
-    odoc_info.cmi ../utils/misc.cmi ../parsing/asttypes.cmi
-odoc_man.cmx : odoc_str.cmx odoc_print.cmx odoc_misc.cmx odoc_messages.cmx \
-    odoc_info.cmx ../utils/misc.cmx ../parsing/asttypes.cmi
-odoc_merge.cmo : odoc_value.cmo odoc_types.cmi odoc_type.cmo \
-    odoc_parameter.cmo odoc_module.cmo odoc_messages.cmo odoc_global.cmi \
-    odoc_extension.cmo odoc_exception.cmo odoc_class.cmo odoc_merge.cmi
-odoc_merge.cmx : odoc_value.cmx odoc_types.cmx odoc_type.cmx \
-    odoc_parameter.cmx odoc_module.cmx odoc_messages.cmx odoc_global.cmx \
-    odoc_extension.cmx odoc_exception.cmx odoc_class.cmx odoc_merge.cmi
-odoc_merge.cmi : odoc_types.cmi odoc_module.cmo
-odoc_messages.cmo : ../utils/config.cmi
-odoc_messages.cmx : ../utils/config.cmx
-odoc_misc.cmo : ../typing/types.cmi ../typing/predef.cmi ../typing/path.cmi \
-    odoc_types.cmi odoc_messages.cmo ../parsing/longident.cmi \
-    ../typing/ctype.cmi ../typing/btype.cmi odoc_misc.cmi
-odoc_misc.cmx : ../typing/types.cmx ../typing/predef.cmx ../typing/path.cmx \
-    odoc_types.cmx odoc_messages.cmx ../parsing/longident.cmx \
-    ../typing/ctype.cmx ../typing/btype.cmx odoc_misc.cmi
-odoc_misc.cmi : ../typing/types.cmi odoc_types.cmi ../parsing/longident.cmi \
-    ../parsing/asttypes.cmi
-odoc_module.cmo : ../typing/types.cmi odoc_value.cmo odoc_types.cmi \
-    odoc_type.cmo odoc_name.cmi odoc_extension.cmo odoc_exception.cmo \
-    odoc_class.cmo ../utils/misc.cmi
-odoc_module.cmx : ../typing/types.cmx odoc_value.cmx odoc_types.cmx \
-    odoc_type.cmx odoc_name.cmx odoc_extension.cmx odoc_exception.cmx \
-    odoc_class.cmx ../utils/misc.cmx
-odoc_name.cmo : ../typing/path.cmi odoc_misc.cmi ../typing/ident.cmi \
-    odoc_name.cmi
-odoc_name.cmx : ../typing/path.cmx odoc_misc.cmx ../typing/ident.cmx \
-    odoc_name.cmi
-odoc_name.cmi : ../typing/path.cmi ../parsing/longident.cmi \
-    ../typing/ident.cmi
+odoc_lexer.cmo : \
+  odoc_comments_global.cmi \
+  odoc_global.cmi \
+  odoc_messages.cmo \
+  odoc_parser.cmi
+odoc_lexer.cmx : \
+  odoc_comments_global.cmx \
+  odoc_global.cmx \
+  odoc_messages.cmx \
+  odoc_parser.cmx
+odoc_man.cmo : \
+  ../parsing/asttypes.cmi \
+  ../utils/misc.cmi \
+  odoc_info.cmi \
+  odoc_messages.cmo \
+  odoc_misc.cmi \
+  odoc_print.cmi \
+  odoc_str.cmi
+odoc_man.cmx : \
+  ../parsing/asttypes.cmi \
+  ../utils/misc.cmx \
+  odoc_info.cmx \
+  odoc_messages.cmx \
+  odoc_misc.cmx \
+  odoc_print.cmx \
+  odoc_str.cmx
+odoc_merge.cmo : \
+  odoc_class.cmo \
+  odoc_exception.cmo \
+  odoc_extension.cmo \
+  odoc_global.cmi \
+  odoc_merge.cmi \
+  odoc_messages.cmo \
+  odoc_module.cmo \
+  odoc_parameter.cmo \
+  odoc_type.cmo \
+  odoc_types.cmi \
+  odoc_value.cmo
+odoc_merge.cmx : \
+  odoc_class.cmx \
+  odoc_exception.cmx \
+  odoc_extension.cmx \
+  odoc_global.cmx \
+  odoc_merge.cmi \
+  odoc_messages.cmx \
+  odoc_module.cmx \
+  odoc_parameter.cmx \
+  odoc_type.cmx \
+  odoc_types.cmx \
+  odoc_value.cmx
+odoc_merge.cmi : \
+  odoc_module.cmo \
+  odoc_types.cmi
+odoc_messages.cmo : \
+  ../utils/config.cmi
+odoc_messages.cmx : \
+  ../utils/config.cmx
+odoc_misc.cmo : \
+  ../parsing/longident.cmi \
+  ../typing/btype.cmi \
+  ../typing/ctype.cmi \
+  ../typing/path.cmi \
+  ../typing/predef.cmi \
+  ../typing/types.cmi \
+  odoc_messages.cmo \
+  odoc_misc.cmi \
+  odoc_types.cmi
+odoc_misc.cmx : \
+  ../parsing/longident.cmx \
+  ../typing/btype.cmx \
+  ../typing/ctype.cmx \
+  ../typing/path.cmx \
+  ../typing/predef.cmx \
+  ../typing/types.cmx \
+  odoc_messages.cmx \
+  odoc_misc.cmi \
+  odoc_types.cmx
+odoc_misc.cmi : \
+  ../parsing/asttypes.cmi \
+  ../parsing/longident.cmi \
+  ../typing/types.cmi \
+  odoc_types.cmi
+odoc_module.cmo : \
+  ../typing/types.cmi \
+  ../utils/misc.cmi \
+  odoc_class.cmo \
+  odoc_exception.cmo \
+  odoc_extension.cmo \
+  odoc_name.cmi \
+  odoc_type.cmo \
+  odoc_types.cmi \
+  odoc_value.cmo
+odoc_module.cmx : \
+  ../typing/types.cmx \
+  ../utils/misc.cmx \
+  odoc_class.cmx \
+  odoc_exception.cmx \
+  odoc_extension.cmx \
+  odoc_name.cmx \
+  odoc_type.cmx \
+  odoc_types.cmx \
+  odoc_value.cmx
+odoc_name.cmo : \
+  ../typing/ident.cmi \
+  ../typing/path.cmi \
+  odoc_misc.cmi \
+  odoc_name.cmi
+odoc_name.cmx : \
+  ../typing/ident.cmx \
+  ../typing/path.cmx \
+  odoc_misc.cmx \
+  odoc_name.cmi
+odoc_name.cmi : \
+  ../parsing/longident.cmi \
+  ../typing/ident.cmi \
+  ../typing/path.cmi
 odoc_ocamlhtml.cmo :
 odoc_ocamlhtml.cmx :
-odoc_parameter.cmo : ../typing/types.cmi odoc_types.cmi
-odoc_parameter.cmx : ../typing/types.cmx odoc_types.cmx
-odoc_parser.cmo : odoc_types.cmi odoc_comments_global.cmi odoc_parser.cmi
-odoc_parser.cmx : odoc_types.cmx odoc_comments_global.cmx odoc_parser.cmi
-odoc_parser.cmi : odoc_types.cmi
-odoc_print.cmo : ../typing/types.cmi ../typing/printtyp.cmi \
-    ../utils/misc.cmi odoc_print.cmi
-odoc_print.cmx : ../typing/types.cmx ../typing/printtyp.cmx \
-    ../utils/misc.cmx odoc_print.cmi
-odoc_print.cmi : ../typing/types.cmi
-odoc_scan.cmo : odoc_value.cmo odoc_types.cmi odoc_type.cmo odoc_module.cmo \
-    odoc_extension.cmo odoc_exception.cmo odoc_class.cmo
-odoc_scan.cmx : odoc_value.cmx odoc_types.cmx odoc_type.cmx odoc_module.cmx \
-    odoc_extension.cmx odoc_exception.cmx odoc_class.cmx
-odoc_search.cmo : odoc_value.cmo odoc_types.cmi odoc_type.cmo \
-    odoc_module.cmo odoc_extension.cmo odoc_exception.cmo odoc_class.cmo \
-    odoc_search.cmi
-odoc_search.cmx : odoc_value.cmx odoc_types.cmx odoc_type.cmx \
-    odoc_module.cmx odoc_extension.cmx odoc_exception.cmx odoc_class.cmx \
-    odoc_search.cmi
-odoc_search.cmi : odoc_value.cmo odoc_types.cmi odoc_type.cmo \
-    odoc_module.cmo odoc_extension.cmo odoc_exception.cmo odoc_class.cmo
-odoc_see_lexer.cmo : odoc_parser.cmi
-odoc_see_lexer.cmx : odoc_parser.cmx
-odoc_sig.cmo : ../typing/types.cmi ../typing/typedtree.cmi \
-    ../parsing/parsetree.cmi odoc_value.cmo odoc_types.cmi odoc_type.cmo \
-    odoc_parameter.cmo odoc_module.cmo odoc_misc.cmi odoc_messages.cmo \
-    odoc_merge.cmi odoc_global.cmi odoc_extension.cmo odoc_exception.cmo \
-    odoc_env.cmi odoc_class.cmo ../utils/misc.cmi ../parsing/location.cmi \
-    ../typing/ident.cmi ../typing/ctype.cmi ../typing/btype.cmi \
-    ../parsing/asttypes.cmi odoc_sig.cmi
-odoc_sig.cmx : ../typing/types.cmx ../typing/typedtree.cmx \
-    ../parsing/parsetree.cmi odoc_value.cmx odoc_types.cmx odoc_type.cmx \
-    odoc_parameter.cmx odoc_module.cmx odoc_misc.cmx odoc_messages.cmx \
-    odoc_merge.cmx odoc_global.cmx odoc_extension.cmx odoc_exception.cmx \
-    odoc_env.cmx odoc_class.cmx ../utils/misc.cmx ../parsing/location.cmx \
-    ../typing/ident.cmx ../typing/ctype.cmx ../typing/btype.cmx \
-    ../parsing/asttypes.cmi odoc_sig.cmi
-odoc_sig.cmi : ../typing/types.cmi ../typing/typedtree.cmi \
-    ../parsing/parsetree.cmi odoc_types.cmi odoc_type.cmo odoc_name.cmi \
-    odoc_module.cmo odoc_env.cmi odoc_class.cmo
-odoc_str.cmo : ../typing/types.cmi ../typing/printtyp.cmi odoc_value.cmo \
-    odoc_type.cmo odoc_print.cmi odoc_name.cmi odoc_misc.cmi \
-    odoc_messages.cmo odoc_extension.cmo odoc_exception.cmo odoc_class.cmo \
-    ../parsing/asttypes.cmi odoc_str.cmi
-odoc_str.cmx : ../typing/types.cmx ../typing/printtyp.cmx odoc_value.cmx \
-    odoc_type.cmx odoc_print.cmx odoc_name.cmx odoc_misc.cmx \
-    odoc_messages.cmx odoc_extension.cmx odoc_exception.cmx odoc_class.cmx \
-    ../parsing/asttypes.cmi odoc_str.cmi
-odoc_str.cmi : ../typing/types.cmi odoc_value.cmo odoc_type.cmo \
-    odoc_extension.cmo odoc_exception.cmo odoc_class.cmo
-odoc_test.cmo : odoc_info.cmi odoc_gen.cmi odoc_args.cmi
-odoc_test.cmx : odoc_info.cmx odoc_gen.cmx odoc_args.cmx
-odoc_texi.cmo : ../typing/types.cmi odoc_to_text.cmo odoc_messages.cmo \
-    odoc_info.cmi ../parsing/asttypes.cmi
-odoc_texi.cmx : ../typing/types.cmx odoc_to_text.cmx odoc_messages.cmx \
-    odoc_info.cmx ../parsing/asttypes.cmi
-odoc_text.cmo : odoc_types.cmi odoc_text_parser.cmi odoc_text_lexer.cmo \
-    odoc_text.cmi
-odoc_text.cmx : odoc_types.cmx odoc_text_parser.cmx odoc_text_lexer.cmx \
-    odoc_text.cmi
-odoc_text.cmi : odoc_types.cmi
-odoc_text_lexer.cmo : odoc_text_parser.cmi odoc_misc.cmi
-odoc_text_lexer.cmx : odoc_text_parser.cmx odoc_misc.cmx
-odoc_text_parser.cmo : odoc_types.cmi odoc_misc.cmi odoc_text_parser.cmi
-odoc_text_parser.cmx : odoc_types.cmx odoc_misc.cmx odoc_text_parser.cmi
-odoc_text_parser.cmi : odoc_types.cmi
-odoc_to_text.cmo : odoc_str.cmi odoc_module.cmo odoc_messages.cmo \
-    odoc_info.cmi
-odoc_to_text.cmx : odoc_str.cmx odoc_module.cmx odoc_messages.cmx \
-    odoc_info.cmx
-odoc_type.cmo : ../typing/types.cmi odoc_types.cmi odoc_name.cmi \
-    ../parsing/asttypes.cmi
-odoc_type.cmx : ../typing/types.cmx odoc_types.cmx odoc_name.cmx \
-    ../parsing/asttypes.cmi
-odoc_types.cmo : odoc_messages.cmo ../parsing/location.cmi odoc_types.cmi
-odoc_types.cmx : odoc_messages.cmx ../parsing/location.cmx odoc_types.cmi
-odoc_types.cmi : ../parsing/location.cmi
-odoc_value.cmo : ../typing/types.cmi ../typing/printtyp.cmi odoc_types.cmi \
-    odoc_parameter.cmo odoc_name.cmi odoc_misc.cmi ../parsing/asttypes.cmi
-odoc_value.cmx : ../typing/types.cmx ../typing/printtyp.cmx odoc_types.cmx \
-    odoc_parameter.cmx odoc_name.cmx odoc_misc.cmx ../parsing/asttypes.cmi
-generators/odoc_literate.cmo : odoc_info.cmi odoc_html.cmo odoc_gen.cmi \
-    odoc_args.cmi
-generators/odoc_literate.cmx : odoc_info.cmx odoc_html.cmx odoc_gen.cmx \
-    odoc_args.cmx
-generators/odoc_literate.cmxs : odoc_info.cmx odoc_html.cmx odoc_gen.cmx \
-    odoc_args.cmx
-generators/odoc_todo.cmo : odoc_module.cmo odoc_info.cmi odoc_html.cmo \
-    odoc_gen.cmi odoc_args.cmi
-generators/odoc_todo.cmx : odoc_module.cmx odoc_info.cmx odoc_html.cmx \
-    odoc_gen.cmx odoc_args.cmx
-generators/odoc_todo.cmxs : odoc_module.cmx odoc_info.cmx odoc_html.cmx \
-    odoc_gen.cmx odoc_args.cmx
+odoc_parameter.cmo : \
+  ../typing/types.cmi \
+  odoc_types.cmi
+odoc_parameter.cmx : \
+  ../typing/types.cmx \
+  odoc_types.cmx
+odoc_parser.cmo : \
+  odoc_comments_global.cmi \
+  odoc_parser.cmi \
+  odoc_types.cmi
+odoc_parser.cmx : \
+  odoc_comments_global.cmx \
+  odoc_parser.cmi \
+  odoc_types.cmx
+odoc_parser.cmi : \
+  odoc_types.cmi
+odoc_print.cmo : \
+  ../typing/printtyp.cmi \
+  ../typing/types.cmi \
+  ../utils/misc.cmi \
+  odoc_print.cmi
+odoc_print.cmx : \
+  ../typing/printtyp.cmx \
+  ../typing/types.cmx \
+  ../utils/misc.cmx \
+  odoc_print.cmi
+odoc_print.cmi : \
+  ../typing/types.cmi
+odoc_scan.cmo : \
+  odoc_class.cmo \
+  odoc_exception.cmo \
+  odoc_extension.cmo \
+  odoc_module.cmo \
+  odoc_type.cmo \
+  odoc_types.cmi \
+  odoc_value.cmo
+odoc_scan.cmx : \
+  odoc_class.cmx \
+  odoc_exception.cmx \
+  odoc_extension.cmx \
+  odoc_module.cmx \
+  odoc_type.cmx \
+  odoc_types.cmx \
+  odoc_value.cmx
+odoc_search.cmo : \
+  odoc_class.cmo \
+  odoc_exception.cmo \
+  odoc_extension.cmo \
+  odoc_module.cmo \
+  odoc_search.cmi \
+  odoc_type.cmo \
+  odoc_types.cmi \
+  odoc_value.cmo
+odoc_search.cmx : \
+  odoc_class.cmx \
+  odoc_exception.cmx \
+  odoc_extension.cmx \
+  odoc_module.cmx \
+  odoc_search.cmi \
+  odoc_type.cmx \
+  odoc_types.cmx \
+  odoc_value.cmx
+odoc_search.cmi : \
+  odoc_class.cmo \
+  odoc_exception.cmo \
+  odoc_extension.cmo \
+  odoc_module.cmo \
+  odoc_type.cmo \
+  odoc_types.cmi \
+  odoc_value.cmo
+odoc_see_lexer.cmo : \
+  odoc_parser.cmi
+odoc_see_lexer.cmx : \
+  odoc_parser.cmx
+odoc_sig.cmo : \
+  ../parsing/asttypes.cmi \
+  ../parsing/location.cmi \
+  ../parsing/parsetree.cmi \
+  ../typing/btype.cmi \
+  ../typing/ctype.cmi \
+  ../typing/ident.cmi \
+  ../typing/typedtree.cmi \
+  ../typing/types.cmi \
+  ../utils/misc.cmi \
+  odoc_class.cmo \
+  odoc_env.cmi \
+  odoc_exception.cmo \
+  odoc_extension.cmo \
+  odoc_global.cmi \
+  odoc_merge.cmi \
+  odoc_messages.cmo \
+  odoc_misc.cmi \
+  odoc_module.cmo \
+  odoc_parameter.cmo \
+  odoc_sig.cmi \
+  odoc_type.cmo \
+  odoc_types.cmi \
+  odoc_value.cmo
+odoc_sig.cmx : \
+  ../parsing/asttypes.cmi \
+  ../parsing/location.cmx \
+  ../parsing/parsetree.cmi \
+  ../typing/btype.cmx \
+  ../typing/ctype.cmx \
+  ../typing/ident.cmx \
+  ../typing/typedtree.cmx \
+  ../typing/types.cmx \
+  ../utils/misc.cmx \
+  odoc_class.cmx \
+  odoc_env.cmx \
+  odoc_exception.cmx \
+  odoc_extension.cmx \
+  odoc_global.cmx \
+  odoc_merge.cmx \
+  odoc_messages.cmx \
+  odoc_misc.cmx \
+  odoc_module.cmx \
+  odoc_parameter.cmx \
+  odoc_sig.cmi \
+  odoc_type.cmx \
+  odoc_types.cmx \
+  odoc_value.cmx
+odoc_sig.cmi : \
+  ../parsing/parsetree.cmi \
+  ../typing/typedtree.cmi \
+  ../typing/types.cmi \
+  odoc_class.cmo \
+  odoc_env.cmi \
+  odoc_module.cmo \
+  odoc_name.cmi \
+  odoc_type.cmo \
+  odoc_types.cmi
+odoc_str.cmo : \
+  ../parsing/asttypes.cmi \
+  ../typing/printtyp.cmi \
+  ../typing/types.cmi \
+  odoc_class.cmo \
+  odoc_exception.cmo \
+  odoc_extension.cmo \
+  odoc_messages.cmo \
+  odoc_misc.cmi \
+  odoc_name.cmi \
+  odoc_print.cmi \
+  odoc_str.cmi \
+  odoc_type.cmo \
+  odoc_value.cmo
+odoc_str.cmx : \
+  ../parsing/asttypes.cmi \
+  ../typing/printtyp.cmx \
+  ../typing/types.cmx \
+  odoc_class.cmx \
+  odoc_exception.cmx \
+  odoc_extension.cmx \
+  odoc_messages.cmx \
+  odoc_misc.cmx \
+  odoc_name.cmx \
+  odoc_print.cmx \
+  odoc_str.cmi \
+  odoc_type.cmx \
+  odoc_value.cmx
+odoc_str.cmi : \
+  ../typing/types.cmi \
+  odoc_class.cmo \
+  odoc_exception.cmo \
+  odoc_extension.cmo \
+  odoc_type.cmo \
+  odoc_value.cmo
+odoc_test.cmo : \
+  odoc_args.cmi \
+  odoc_gen.cmi \
+  odoc_info.cmi
+odoc_test.cmx : \
+  odoc_args.cmx \
+  odoc_gen.cmx \
+  odoc_info.cmx
+odoc_texi.cmo : \
+  ../parsing/asttypes.cmi \
+  ../typing/types.cmi \
+  odoc_info.cmi \
+  odoc_messages.cmo \
+  odoc_to_text.cmo
+odoc_texi.cmx : \
+  ../parsing/asttypes.cmi \
+  ../typing/types.cmx \
+  odoc_info.cmx \
+  odoc_messages.cmx \
+  odoc_to_text.cmx
+odoc_text.cmo : \
+  odoc_text.cmi \
+  odoc_text_lexer.cmo \
+  odoc_text_parser.cmi \
+  odoc_types.cmi
+odoc_text.cmx : \
+  odoc_text.cmi \
+  odoc_text_lexer.cmx \
+  odoc_text_parser.cmx \
+  odoc_types.cmx
+odoc_text.cmi : \
+  odoc_types.cmi
+odoc_text_lexer.cmo : \
+  odoc_misc.cmi \
+  odoc_text_parser.cmi
+odoc_text_lexer.cmx : \
+  odoc_misc.cmx \
+  odoc_text_parser.cmx
+odoc_text_parser.cmo : \
+  odoc_misc.cmi \
+  odoc_text_parser.cmi \
+  odoc_types.cmi
+odoc_text_parser.cmx : \
+  odoc_misc.cmx \
+  odoc_text_parser.cmi \
+  odoc_types.cmx
+odoc_text_parser.cmi : \
+  odoc_types.cmi
+odoc_to_text.cmo : \
+  odoc_info.cmi \
+  odoc_messages.cmo \
+  odoc_module.cmo \
+  odoc_str.cmi
+odoc_to_text.cmx : \
+  odoc_info.cmx \
+  odoc_messages.cmx \
+  odoc_module.cmx \
+  odoc_str.cmx
+odoc_type.cmo : \
+  ../parsing/asttypes.cmi \
+  ../typing/types.cmi \
+  odoc_name.cmi \
+  odoc_types.cmi
+odoc_type.cmx : \
+  ../parsing/asttypes.cmi \
+  ../typing/types.cmx \
+  odoc_name.cmx \
+  odoc_types.cmx
+odoc_types.cmo : \
+  ../parsing/location.cmi \
+  odoc_messages.cmo \
+  odoc_types.cmi
+odoc_types.cmx : \
+  ../parsing/location.cmx \
+  odoc_messages.cmx \
+  odoc_types.cmi
+odoc_types.cmi : \
+  ../parsing/location.cmi
+odoc_value.cmo : \
+  ../parsing/asttypes.cmi \
+  ../typing/printtyp.cmi \
+  ../typing/types.cmi \
+  odoc_misc.cmi \
+  odoc_name.cmi \
+  odoc_parameter.cmo \
+  odoc_types.cmi
+odoc_value.cmx : \
+  ../parsing/asttypes.cmi \
+  ../typing/printtyp.cmx \
+  ../typing/types.cmx \
+  odoc_misc.cmx \
+  odoc_name.cmx \
+  odoc_parameter.cmx \
+  odoc_types.cmx
+generators/odoc_literate.cmo : \
+  odoc_args.cmi \
+  odoc_gen.cmi \
+  odoc_html.cmo \
+  odoc_info.cmi
+generators/odoc_literate.cmx : \
+  odoc_args.cmx \
+  odoc_gen.cmx \
+  odoc_html.cmx \
+  odoc_info.cmx
+generators/odoc_literate.cmxs : \
+  odoc_args.cmx \
+  odoc_gen.cmx \
+  odoc_html.cmx \
+  odoc_info.cmx
+generators/odoc_todo.cmo : \
+  odoc_args.cmi \
+  odoc_gen.cmi \
+  odoc_html.cmo \
+  odoc_info.cmi \
+  odoc_module.cmo
+generators/odoc_todo.cmx : \
+  odoc_args.cmx \
+  odoc_gen.cmx \
+  odoc_html.cmx \
+  odoc_info.cmx \
+  odoc_module.cmx
+generators/odoc_todo.cmxs : \
+  odoc_args.cmx \
+  odoc_gen.cmx \
+  odoc_html.cmx \
+  odoc_info.cmx \
+  odoc_module.cmx

--- a/ocamldoc/.depend
+++ b/ocamldoc/.depend
@@ -653,6 +653,7 @@ odoc_see_lexer.cmx : \
 odoc_sig.cmo : \
   ../parsing/asttypes.cmi \
   ../parsing/location.cmi \
+  ../parsing/longident.cmi \
   ../parsing/parsetree.cmi \
   ../typing/btype.cmi \
   ../typing/ctype.cmi \
@@ -677,6 +678,7 @@ odoc_sig.cmo : \
 odoc_sig.cmx : \
   ../parsing/asttypes.cmi \
   ../parsing/location.cmx \
+  ../parsing/longident.cmx \
   ../parsing/parsetree.cmi \
   ../typing/btype.cmx \
   ../typing/ctype.cmx \
@@ -699,6 +701,7 @@ odoc_sig.cmx : \
   odoc_types.cmx \
   odoc_value.cmx
 odoc_sig.cmi : \
+  ../parsing/location.cmi \
   ../parsing/parsetree.cmi \
   ../typing/typedtree.cmi \
   ../typing/types.cmi \

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -424,5 +424,6 @@ depend:
 	$(OCAMLLEX) odoc_see_lexer.mll
 	$(OCAMLDEP) $(INCLUDES_DEP) *.mll *.mly *.ml *.mli > .depend
 	$(OCAMLDEP) $(INCLUDES_DEP) -shared generators/*.ml >> .depend
+	$(ROOTDIR)/tools/normalize_depend .depend
 
 include .depend

--- a/ocamltest/.depend
+++ b/ocamltest/.depend
@@ -1,105 +1,285 @@
-run_unix.$(O): run_unix.c run.h ../byterun/caml/misc.h \
- ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
- run_common.h
-run_stubs.$(O): run_stubs.c run.h ../byterun/caml/misc.h \
- ../byterun/caml/config.h ../byterun/caml/m.h ../byterun/caml/s.h \
- ../byterun/caml/mlvalues.h ../byterun/caml/misc.h \
- ../byterun/caml/memory.h ../byterun/caml/gc.h ../byterun/caml/mlvalues.h \
- ../byterun/caml/major_gc.h ../byterun/caml/freelist.h \
- ../byterun/caml/minor_gc.h ../byterun/caml/address_class.h \
- ../byterun/caml/io.h ../byterun/caml/osdeps.h ../byterun/caml/memory.h
-actions.cmo : environments.cmi actions.cmi
-actions.cmx : environments.cmx actions.cmi
-actions.cmi : environments.cmi
-actions_helpers.cmo : variables.cmi run_command.cmi ocamltest_stdlib.cmi \
-    filecompare.cmi environments.cmi builtin_variables.cmi actions.cmi \
-    actions_helpers.cmi
-actions_helpers.cmx : variables.cmx run_command.cmx ocamltest_stdlib.cmx \
-    filecompare.cmx environments.cmx builtin_variables.cmx actions.cmx \
-    actions_helpers.cmi
-actions_helpers.cmi : variables.cmi environments.cmi actions.cmi
-builtin_actions.cmo : ocamltest_stdlib.cmi ocamltest_config.cmi \
-    environments.cmi builtin_variables.cmi actions_helpers.cmi actions.cmi \
-    builtin_actions.cmi
-builtin_actions.cmx : ocamltest_stdlib.cmx ocamltest_config.cmx \
-    environments.cmx builtin_variables.cmx actions_helpers.cmx actions.cmx \
-    builtin_actions.cmi
-builtin_actions.cmi : actions.cmi
-builtin_variables.cmo : variables.cmi builtin_variables.cmi
-builtin_variables.cmx : variables.cmx builtin_variables.cmi
-builtin_variables.cmi : variables.cmi
-environments.cmo : variables.cmi ocamltest_stdlib.cmi environments.cmi
-environments.cmx : variables.cmx ocamltest_stdlib.cmx environments.cmi
-environments.cmi : variables.cmi
-filecompare.cmo : run_command.cmi ocamltest_stdlib.cmi filecompare.cmi
-filecompare.cmx : run_command.cmx ocamltest_stdlib.cmx filecompare.cmi
+run_unix.$(O): \
+  ../byterun/caml/config.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/s.h \
+  run.h \
+  run_common.h \
+  run_unix.c
+run_stubs.$(O): \
+  ../byterun/caml/address_class.h \
+  ../byterun/caml/config.h \
+  ../byterun/caml/freelist.h \
+  ../byterun/caml/gc.h \
+  ../byterun/caml/io.h \
+  ../byterun/caml/m.h \
+  ../byterun/caml/major_gc.h \
+  ../byterun/caml/memory.h \
+  ../byterun/caml/minor_gc.h \
+  ../byterun/caml/misc.h \
+  ../byterun/caml/mlvalues.h \
+  ../byterun/caml/osdeps.h \
+  ../byterun/caml/s.h \
+  run.h \
+  run_stubs.c
+actions.cmo : \
+  actions.cmi \
+  environments.cmi
+actions.cmx : \
+  actions.cmi \
+  environments.cmx
+actions.cmi : \
+  environments.cmi
+actions_helpers.cmo : \
+  actions.cmi \
+  actions_helpers.cmi \
+  builtin_variables.cmi \
+  environments.cmi \
+  filecompare.cmi \
+  ocamltest_stdlib.cmi \
+  run_command.cmi \
+  variables.cmi
+actions_helpers.cmx : \
+  actions.cmx \
+  actions_helpers.cmi \
+  builtin_variables.cmx \
+  environments.cmx \
+  filecompare.cmx \
+  ocamltest_stdlib.cmx \
+  run_command.cmx \
+  variables.cmx
+actions_helpers.cmi : \
+  actions.cmi \
+  environments.cmi \
+  variables.cmi
+builtin_actions.cmo : \
+  actions.cmi \
+  actions_helpers.cmi \
+  builtin_actions.cmi \
+  builtin_variables.cmi \
+  environments.cmi \
+  ocamltest_config.cmi \
+  ocamltest_stdlib.cmi
+builtin_actions.cmx : \
+  actions.cmx \
+  actions_helpers.cmx \
+  builtin_actions.cmi \
+  builtin_variables.cmx \
+  environments.cmx \
+  ocamltest_config.cmx \
+  ocamltest_stdlib.cmx
+builtin_actions.cmi : \
+  actions.cmi
+builtin_variables.cmo : \
+  builtin_variables.cmi \
+  variables.cmi
+builtin_variables.cmx : \
+  builtin_variables.cmi \
+  variables.cmx
+builtin_variables.cmi : \
+  variables.cmi
+environments.cmo : \
+  environments.cmi \
+  ocamltest_stdlib.cmi \
+  variables.cmi
+environments.cmx : \
+  environments.cmi \
+  ocamltest_stdlib.cmx \
+  variables.cmx
+environments.cmi : \
+  variables.cmi
+filecompare.cmo : \
+  filecompare.cmi \
+  ocamltest_stdlib.cmi \
+  run_command.cmi
+filecompare.cmx : \
+  filecompare.cmi \
+  ocamltest_stdlib.cmx \
+  run_command.cmx
 filecompare.cmi :
-filetype.cmo : filetype.cmi
-filetype.cmx : filetype.cmi
+filetype.cmo : \
+  filetype.cmi
+filetype.cmx : \
+  filetype.cmi
 filetype.cmi :
-main.cmo : tsl_semantics.cmi tsl_parser.cmi tsl_lexer.cmi tests.cmi \
-    options.cmi ocamltest_stdlib.cmi environments.cmi builtin_variables.cmi \
-    actions_helpers.cmi actions.cmi main.cmi
-main.cmx : tsl_semantics.cmx tsl_parser.cmx tsl_lexer.cmx tests.cmx \
-    options.cmx ocamltest_stdlib.cmx environments.cmx builtin_variables.cmx \
-    actions_helpers.cmx actions.cmx main.cmi
+main.cmo : \
+  actions.cmi \
+  actions_helpers.cmi \
+  builtin_variables.cmi \
+  environments.cmi \
+  main.cmi \
+  ocamltest_stdlib.cmi \
+  options.cmi \
+  tests.cmi \
+  tsl_lexer.cmi \
+  tsl_parser.cmi \
+  tsl_semantics.cmi
+main.cmx : \
+  actions.cmx \
+  actions_helpers.cmx \
+  builtin_variables.cmx \
+  environments.cmx \
+  main.cmi \
+  ocamltest_stdlib.cmx \
+  options.cmx \
+  tests.cmx \
+  tsl_lexer.cmx \
+  tsl_parser.cmx \
+  tsl_semantics.cmx
 main.cmi :
-ocaml_actions.cmo : variables.cmi ocamltest_stdlib.cmi ocamltest_config.cmi \
-    ocaml_variables.cmi ocaml_modifiers.cmi ocaml_backends.cmi filetype.cmi \
-    filecompare.cmi environments.cmi builtin_variables.cmi \
-    actions_helpers.cmi actions.cmi ocaml_actions.cmi
-ocaml_actions.cmx : variables.cmx ocamltest_stdlib.cmx ocamltest_config.cmx \
-    ocaml_variables.cmx ocaml_modifiers.cmx ocaml_backends.cmx filetype.cmx \
-    filecompare.cmx environments.cmx builtin_variables.cmx \
-    actions_helpers.cmx actions.cmx ocaml_actions.cmi
-ocaml_actions.cmi : actions.cmi
-ocaml_backends.cmo : ocamltest_stdlib.cmi ocaml_backends.cmi
-ocaml_backends.cmx : ocamltest_stdlib.cmx ocaml_backends.cmi
-ocaml_backends.cmi : ocamltest_stdlib.cmi
-ocaml_modifiers.cmo : ocamltest_stdlib.cmi ocamltest_config.cmi \
-    ocaml_variables.cmi environments.cmi builtin_variables.cmi \
-    ocaml_modifiers.cmi
-ocaml_modifiers.cmx : ocamltest_stdlib.cmx ocamltest_config.cmx \
-    ocaml_variables.cmx environments.cmx builtin_variables.cmx \
-    ocaml_modifiers.cmi
-ocaml_modifiers.cmi : environments.cmi
-ocaml_tests.cmo : tests.cmi ocamltest_config.cmi ocaml_actions.cmi \
-    builtin_actions.cmi ocaml_tests.cmi
-ocaml_tests.cmx : tests.cmx ocamltest_config.cmx ocaml_actions.cmx \
-    builtin_actions.cmx ocaml_tests.cmi
-ocaml_tests.cmi : tests.cmi
-ocaml_variables.cmo : variables.cmi ocaml_variables.cmi
-ocaml_variables.cmx : variables.cmx ocaml_variables.cmi
-ocaml_variables.cmi : variables.cmi
-ocamltest_config.cmo : ocamltest_config.cmi
-ocamltest_config.cmx : ocamltest_config.cmi
+ocaml_actions.cmo : \
+  actions.cmi \
+  actions_helpers.cmi \
+  builtin_variables.cmi \
+  environments.cmi \
+  filecompare.cmi \
+  filetype.cmi \
+  ocaml_actions.cmi \
+  ocaml_backends.cmi \
+  ocaml_modifiers.cmi \
+  ocaml_variables.cmi \
+  ocamltest_config.cmi \
+  ocamltest_stdlib.cmi \
+  variables.cmi
+ocaml_actions.cmx : \
+  actions.cmx \
+  actions_helpers.cmx \
+  builtin_variables.cmx \
+  environments.cmx \
+  filecompare.cmx \
+  filetype.cmx \
+  ocaml_actions.cmi \
+  ocaml_backends.cmx \
+  ocaml_modifiers.cmx \
+  ocaml_variables.cmx \
+  ocamltest_config.cmx \
+  ocamltest_stdlib.cmx \
+  variables.cmx
+ocaml_actions.cmi : \
+  actions.cmi
+ocaml_backends.cmo : \
+  ocaml_backends.cmi \
+  ocamltest_stdlib.cmi
+ocaml_backends.cmx : \
+  ocaml_backends.cmi \
+  ocamltest_stdlib.cmx
+ocaml_backends.cmi : \
+  ocamltest_stdlib.cmi
+ocaml_modifiers.cmo : \
+  builtin_variables.cmi \
+  environments.cmi \
+  ocaml_modifiers.cmi \
+  ocaml_variables.cmi \
+  ocamltest_config.cmi \
+  ocamltest_stdlib.cmi
+ocaml_modifiers.cmx : \
+  builtin_variables.cmx \
+  environments.cmx \
+  ocaml_modifiers.cmi \
+  ocaml_variables.cmx \
+  ocamltest_config.cmx \
+  ocamltest_stdlib.cmx
+ocaml_modifiers.cmi : \
+  environments.cmi
+ocaml_tests.cmo : \
+  builtin_actions.cmi \
+  ocaml_actions.cmi \
+  ocaml_tests.cmi \
+  ocamltest_config.cmi \
+  tests.cmi
+ocaml_tests.cmx : \
+  builtin_actions.cmx \
+  ocaml_actions.cmx \
+  ocaml_tests.cmi \
+  ocamltest_config.cmx \
+  tests.cmx
+ocaml_tests.cmi : \
+  tests.cmi
+ocaml_variables.cmo : \
+  ocaml_variables.cmi \
+  variables.cmi
+ocaml_variables.cmx : \
+  ocaml_variables.cmi \
+  variables.cmx
+ocaml_variables.cmi : \
+  variables.cmi
+ocamltest_config.cmo : \
+  ocamltest_config.cmi
+ocamltest_config.cmx : \
+  ocamltest_config.cmi
 ocamltest_config.cmi :
-ocamltest_stdlib.cmo : ocamltest_stdlib.cmi
-ocamltest_stdlib.cmx : ocamltest_stdlib.cmi
+ocamltest_stdlib.cmo : \
+  ocamltest_stdlib.cmi
+ocamltest_stdlib.cmx : \
+  ocamltest_stdlib.cmi
 ocamltest_stdlib.cmi :
-options.cmo : tests.cmi actions.cmi options.cmi
-options.cmx : tests.cmx actions.cmx options.cmi
+options.cmo : \
+  actions.cmi \
+  options.cmi \
+  tests.cmi
+options.cmx : \
+  actions.cmx \
+  options.cmi \
+  tests.cmx
 options.cmi :
-run_command.cmo : ocamltest_stdlib.cmi run_command.cmi
-run_command.cmx : ocamltest_stdlib.cmx run_command.cmi
+run_command.cmo : \
+  ocamltest_stdlib.cmi \
+  run_command.cmi
+run_command.cmx : \
+  ocamltest_stdlib.cmx \
+  run_command.cmi
 run_command.cmi :
-tests.cmo : actions.cmi tests.cmi
-tests.cmx : actions.cmx tests.cmi
-tests.cmi : environments.cmi actions.cmi
-tsl_ast.cmo : tsl_ast.cmi
-tsl_ast.cmx : tsl_ast.cmi
+tests.cmo : \
+  actions.cmi \
+  tests.cmi
+tests.cmx : \
+  actions.cmx \
+  tests.cmi
+tests.cmi : \
+  actions.cmi \
+  environments.cmi
+tsl_ast.cmo : \
+  tsl_ast.cmi
+tsl_ast.cmx : \
+  tsl_ast.cmi
 tsl_ast.cmi :
-tsl_lexer.cmo : tsl_parser.cmi tsl_lexer.cmi
-tsl_lexer.cmx : tsl_parser.cmx tsl_lexer.cmi
-tsl_lexer.cmi : tsl_parser.cmi
-tsl_parser.cmo : tsl_ast.cmi tsl_parser.cmi
-tsl_parser.cmx : tsl_ast.cmx tsl_parser.cmi
-tsl_parser.cmi : tsl_ast.cmi
-tsl_semantics.cmo : variables.cmi tsl_ast.cmi tests.cmi environments.cmi \
-    actions.cmi tsl_semantics.cmi
-tsl_semantics.cmx : variables.cmx tsl_ast.cmx tests.cmx environments.cmx \
-    actions.cmx tsl_semantics.cmi
-tsl_semantics.cmi : tsl_ast.cmi tests.cmi environments.cmi actions.cmi
-variables.cmo : variables.cmi
-variables.cmx : variables.cmi
+tsl_lexer.cmo : \
+  tsl_lexer.cmi \
+  tsl_parser.cmi
+tsl_lexer.cmx : \
+  tsl_lexer.cmi \
+  tsl_parser.cmx
+tsl_lexer.cmi : \
+  tsl_parser.cmi
+tsl_parser.cmo : \
+  tsl_ast.cmi \
+  tsl_parser.cmi
+tsl_parser.cmx : \
+  tsl_ast.cmx \
+  tsl_parser.cmi
+tsl_parser.cmi : \
+  tsl_ast.cmi
+tsl_semantics.cmo : \
+  actions.cmi \
+  environments.cmi \
+  tests.cmi \
+  tsl_ast.cmi \
+  tsl_semantics.cmi \
+  variables.cmi
+tsl_semantics.cmx : \
+  actions.cmx \
+  environments.cmx \
+  tests.cmx \
+  tsl_ast.cmx \
+  tsl_semantics.cmi \
+  variables.cmx
+tsl_semantics.cmi : \
+  actions.cmi \
+  environments.cmi \
+  tests.cmi \
+  tsl_ast.cmi
+variables.cmo : \
+  variables.cmi
+variables.cmx : \
+  variables.cmi
 variables.cmi :

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -190,6 +190,7 @@ depend: $(dependencies_generated_prereqs)
 	$(CC) -MM $(CPPFLAGS) $(c_files) \
 	  | sed -e 's/\.o/.$$(O)/' > .depend
 	$(ocamldep) $(mli_files) $(ml_files) >> .depend
+	../tools/normalize_depend .depend
 endif
 
 -include .depend

--- a/otherlibs/bigarray/.depend
+++ b/otherlibs/bigarray/.depend
@@ -1,14 +1,26 @@
-bigarray_stubs.$(O): bigarray_stubs.c ../../byterun/caml/alloc.h \
- ../../byterun/caml/misc.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/bigarray.h \
- ../../byterun/caml/custom.h ../../byterun/caml/fail.h \
- ../../byterun/caml/intext.h ../../byterun/caml/io.h \
- ../../byterun/caml/hash.h ../../byterun/caml/memory.h \
- ../../byterun/caml/gc.h ../../byterun/caml/major_gc.h \
- ../../byterun/caml/freelist.h ../../byterun/caml/minor_gc.h \
- ../../byterun/caml/address_class.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h
-bigarray.cmo : bigarray.cmi
-bigarray.cmx : bigarray.cmi
+bigarray_stubs.$(O): \
+  ../../byterun/caml/address_class.h \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/bigarray.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/custom.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
+  ../../byterun/caml/hash.h \
+  ../../byterun/caml/intext.h \
+  ../../byterun/caml/io.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  bigarray_stubs.c
+bigarray.cmo : \
+  bigarray.cmi
+bigarray.cmx : \
+  bigarray.cmi
 bigarray.cmi :

--- a/otherlibs/bigarray/Makefile
+++ b/otherlibs/bigarray/Makefile
@@ -34,6 +34,7 @@ ifeq "$(TOOLCHAIN)" "msvc"
 else
 	$(CC) -MM $(CFLAGS) $(CPPFLAGS) *.c | sed -e 's/\.o/.$$(O)/g' > .depend
 	$(CAMLRUN) $(ROOTDIR)/tools/ocamldep -slash *.mli *.ml >> .depend
+	$(ROOTDIR)/tools/normalize_depend .depend
 endif
 
 include .depend

--- a/otherlibs/graph/.depend
+++ b/otherlibs/graph/.depend
@@ -1,63 +1,125 @@
-color.o: color.c libgraph.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/misc.h
-draw.o: draw.c libgraph.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/misc.h ../../byterun/caml/alloc.h \
- ../../byterun/caml/mlvalues.h
-dump_img.o: dump_img.c libgraph.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/misc.h image.h ../../byterun/caml/alloc.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/memory.h
-events.o: events.c libgraph.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/misc.h ../../byterun/caml/alloc.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/signals.h
-fill.o: fill.c libgraph.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/misc.h ../../byterun/caml/memory.h \
- ../../byterun/caml/mlvalues.h
-image.o: image.c libgraph.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/misc.h image.h ../../byterun/caml/alloc.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/custom.h
-make_img.o: make_img.c libgraph.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/misc.h image.h ../../byterun/caml/memory.h \
- ../../byterun/caml/mlvalues.h
-open.o: open.c libgraph.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/misc.h ../../byterun/caml/alloc.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/callback.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h
-point_col.o: point_col.c libgraph.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/misc.h
-sound.o: sound.c libgraph.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/misc.h
-subwindow.o: subwindow.c libgraph.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/misc.h
-text.o: text.c libgraph.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/misc.h ../../byterun/caml/alloc.h \
- ../../byterun/caml/mlvalues.h
-graphics.cmo : graphics.cmi
-graphics.cmx : graphics.cmi
+color.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  color.c \
+  libgraph.h
+draw.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  draw.c \
+  libgraph.h
+dump_img.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  dump_img.c \
+  image.h \
+  libgraph.h
+events.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  events.c \
+  libgraph.h
+fill.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  fill.c \
+  libgraph.h
+image.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/custom.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  image.c \
+  image.h \
+  libgraph.h
+make_img.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  image.h \
+  libgraph.h \
+  make_img.c
+open.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/callback.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  libgraph.h \
+  open.c
+point_col.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  libgraph.h \
+  point_col.c
+sound.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  libgraph.h \
+  sound.c
+subwindow.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  libgraph.h \
+  subwindow.c
+text.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  libgraph.h \
+  text.c
+graphics.cmo : \
+  graphics.cmi
+graphics.cmx : \
+  graphics.cmi
 graphics.cmi :
-graphicsX11.cmo : graphics.cmi graphicsX11.cmi
-graphicsX11.cmx : graphics.cmx graphicsX11.cmi
+graphicsX11.cmo : \
+  graphics.cmi \
+  graphicsX11.cmi
+graphicsX11.cmx : \
+  graphics.cmx \
+  graphicsX11.cmi
 graphicsX11.cmi :

--- a/otherlibs/graph/Makefile
+++ b/otherlibs/graph/Makefile
@@ -30,5 +30,6 @@ include ../Makefile
 depend:
 	$(CC) -MM $(CPPFLAGS) *.c | sed -e 's, /[^ ]*\.h,,g' > .depend
 	$(CAMLRUN) ../../tools/ocamldep -slash *.mli *.ml >> .depend
+	../..//tools/normalize_depend .depend
 
 include .depend

--- a/otherlibs/raw_spacetime_lib/.depend
+++ b/otherlibs/raw_spacetime_lib/.depend
@@ -1,21 +1,35 @@
-raw_spacetime_lib.cmo : raw_spacetime_lib.cmi
-raw_spacetime_lib.cmx : raw_spacetime_lib.cmi
+raw_spacetime_lib.cmo : \
+  raw_spacetime_lib.cmi
+raw_spacetime_lib.cmx : \
+  raw_spacetime_lib.cmi
 raw_spacetime_lib.cmi :
-raw_spacetime_lib.cmo : raw_spacetime_lib.cmi
-raw_spacetime_lib.cmx : raw_spacetime_lib.cmi
+raw_spacetime_lib.cmo : \
+  raw_spacetime_lib.cmi
+raw_spacetime_lib.cmx : \
+  raw_spacetime_lib.cmi
 raw_spacetime_lib.cmi :
-raw_spacetime_lib.cmo : raw_spacetime_lib.cmi
-raw_spacetime_lib.cmx : raw_spacetime_lib.cmi
+raw_spacetime_lib.cmo : \
+  raw_spacetime_lib.cmi
+raw_spacetime_lib.cmx : \
+  raw_spacetime_lib.cmi
 raw_spacetime_lib.cmi :
-raw_spacetime_lib.cmo : raw_spacetime_lib.cmi
-raw_spacetime_lib.cmx : raw_spacetime_lib.cmi
+raw_spacetime_lib.cmo : \
+  raw_spacetime_lib.cmi
+raw_spacetime_lib.cmx : \
+  raw_spacetime_lib.cmi
 raw_spacetime_lib.cmi :
-raw_spacetime_lib.cmo : raw_spacetime_lib.cmi
-raw_spacetime_lib.cmx : raw_spacetime_lib.cmi
+raw_spacetime_lib.cmo : \
+  raw_spacetime_lib.cmi
+raw_spacetime_lib.cmx : \
+  raw_spacetime_lib.cmi
 raw_spacetime_lib.cmi :
-raw_spacetime_lib.cmo : raw_spacetime_lib.cmi
-raw_spacetime_lib.cmx : raw_spacetime_lib.cmi
+raw_spacetime_lib.cmo : \
+  raw_spacetime_lib.cmi
+raw_spacetime_lib.cmx : \
+  raw_spacetime_lib.cmi
 raw_spacetime_lib.cmi :
-raw_spacetime_lib.cmo : raw_spacetime_lib.cmi
-raw_spacetime_lib.cmx : raw_spacetime_lib.cmi
+raw_spacetime_lib.cmo : \
+  raw_spacetime_lib.cmi
+raw_spacetime_lib.cmx : \
+  raw_spacetime_lib.cmi
 raw_spacetime_lib.cmi :

--- a/otherlibs/raw_spacetime_lib/.depend
+++ b/otherlibs/raw_spacetime_lib/.depend
@@ -3,33 +3,3 @@ raw_spacetime_lib.cmo : \
 raw_spacetime_lib.cmx : \
   raw_spacetime_lib.cmi
 raw_spacetime_lib.cmi :
-raw_spacetime_lib.cmo : \
-  raw_spacetime_lib.cmi
-raw_spacetime_lib.cmx : \
-  raw_spacetime_lib.cmi
-raw_spacetime_lib.cmi :
-raw_spacetime_lib.cmo : \
-  raw_spacetime_lib.cmi
-raw_spacetime_lib.cmx : \
-  raw_spacetime_lib.cmi
-raw_spacetime_lib.cmi :
-raw_spacetime_lib.cmo : \
-  raw_spacetime_lib.cmi
-raw_spacetime_lib.cmx : \
-  raw_spacetime_lib.cmi
-raw_spacetime_lib.cmi :
-raw_spacetime_lib.cmo : \
-  raw_spacetime_lib.cmi
-raw_spacetime_lib.cmx : \
-  raw_spacetime_lib.cmi
-raw_spacetime_lib.cmi :
-raw_spacetime_lib.cmo : \
-  raw_spacetime_lib.cmi
-raw_spacetime_lib.cmx : \
-  raw_spacetime_lib.cmi
-raw_spacetime_lib.cmi :
-raw_spacetime_lib.cmo : \
-  raw_spacetime_lib.cmi
-raw_spacetime_lib.cmx : \
-  raw_spacetime_lib.cmi
-raw_spacetime_lib.cmi :

--- a/otherlibs/raw_spacetime_lib/Makefile
+++ b/otherlibs/raw_spacetime_lib/Makefile
@@ -77,5 +77,6 @@ clean:: partialclean
 
 depend:
 	$(CAMLRUN) $(ROOTDIR)/tools/ocamldep *.mli *.ml > .depend
+	$(ROOTDIR)/tools/normalize_depend .depend
 
 include .depend

--- a/otherlibs/str/.depend
+++ b/otherlibs/str/.depend
@@ -1,8 +1,15 @@
-strstubs.$(O): strstubs.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h ../../byterun/caml/fail.h
-str.cmo : str.cmi
-str.cmx : str.cmi
+strstubs.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  strstubs.c
+str.cmo : \
+  str.cmi
+str.cmx : \
+  str.cmi
 str.cmi :

--- a/otherlibs/str/Makefile
+++ b/otherlibs/str/Makefile
@@ -31,6 +31,7 @@ ifeq "$(TOOLCHAIN)" "msvc"
 else
 	$(CC) -MM $(CPPFLAGS) *.c | sed -e 's/\.o/.$$(O)/g' > .depend
 	$(CAMLRUN) $(ROOTDIR)/tools/ocamldep -slash *.mli *.ml >> .depend
+	$(ROOTDIR)/tools/normalize_depend .depend
 endif
 
 include .depend

--- a/otherlibs/systhreads/.depend
+++ b/otherlibs/systhreads/.depend
@@ -1,43 +1,86 @@
-st_stubs_b.$(O): st_stubs.c ../../byterun/caml/alloc.h \
- ../../byterun/caml/misc.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/backtrace.h \
- ../../byterun/caml/exec.h ../../byterun/caml/callback.h \
- ../../byterun/caml/custom.h ../../byterun/caml/fail.h \
- ../../byterun/caml/io.h ../../byterun/caml/memory.h \
- ../../byterun/caml/gc.h ../../byterun/caml/major_gc.h \
- ../../byterun/caml/freelist.h ../../byterun/caml/minor_gc.h \
- ../../byterun/caml/address_class.h ../../byterun/caml/misc.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/printexc.h \
- ../../byterun/caml/roots.h ../../byterun/caml/memory.h \
- ../../byterun/caml/signals.h ../../byterun/caml/stacks.h \
- ../../byterun/caml/sys.h threads.h
-st_stubs_n.$(O): st_stubs.c ../../byterun/caml/alloc.h \
- ../../byterun/caml/misc.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/backtrace.h \
- ../../byterun/caml/exec.h ../../byterun/caml/callback.h \
- ../../byterun/caml/custom.h ../../byterun/caml/fail.h \
- ../../byterun/caml/io.h ../../byterun/caml/memory.h \
- ../../byterun/caml/gc.h ../../byterun/caml/major_gc.h \
- ../../byterun/caml/freelist.h ../../byterun/caml/minor_gc.h \
- ../../byterun/caml/address_class.h ../../byterun/caml/misc.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/printexc.h \
- ../../byterun/caml/roots.h ../../byterun/caml/memory.h \
- ../../byterun/caml/signals.h ../../byterun/caml/stack.h \
- ../../byterun/caml/sys.h threads.h
-condition.cmo : mutex.cmi condition.cmi
-condition.cmx : mutex.cmx condition.cmi
-condition.cmi : mutex.cmi
-event.cmo : mutex.cmi condition.cmi event.cmi
-event.cmx : mutex.cmx condition.cmx event.cmi
+st_stubs_b.$(O): \
+  ../../byterun/caml/address_class.h \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/backtrace.h \
+  ../../byterun/caml/callback.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/custom.h \
+  ../../byterun/caml/exec.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
+  ../../byterun/caml/io.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/printexc.h \
+  ../../byterun/caml/roots.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  ../../byterun/caml/stacks.h \
+  ../../byterun/caml/sys.h \
+  st_stubs.c \
+  threads.h
+st_stubs_n.$(O): \
+  ../../byterun/caml/address_class.h \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/backtrace.h \
+  ../../byterun/caml/callback.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/custom.h \
+  ../../byterun/caml/exec.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
+  ../../byterun/caml/io.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/printexc.h \
+  ../../byterun/caml/roots.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  ../../byterun/caml/stack.h \
+  ../../byterun/caml/sys.h \
+  st_stubs.c \
+  threads.h
+condition.cmo : \
+  condition.cmi \
+  mutex.cmi
+condition.cmx : \
+  condition.cmi \
+  mutex.cmx
+condition.cmi : \
+  mutex.cmi
+event.cmo : \
+  condition.cmi \
+  event.cmi \
+  mutex.cmi
+event.cmx : \
+  condition.cmx \
+  event.cmi \
+  mutex.cmx
 event.cmi :
-mutex.cmo : mutex.cmi
-mutex.cmx : mutex.cmi
+mutex.cmo : \
+  mutex.cmi
+mutex.cmx : \
+  mutex.cmi
 mutex.cmi :
-thread.cmo : thread.cmi
-thread.cmx : thread.cmi
+thread.cmo : \
+  thread.cmi
+thread.cmx : \
+  thread.cmi
 thread.cmi :
-threadUnix.cmo : thread.cmi threadUnix.cmi
-threadUnix.cmx : thread.cmx threadUnix.cmi
+threadUnix.cmo : \
+  thread.cmi \
+  threadUnix.cmi
+threadUnix.cmx : \
+  thread.cmx \
+  threadUnix.cmi
 threadUnix.cmi :

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -157,6 +157,7 @@ depend:
 	  st_stubs.c | sed -e 's/st_stubs\.o/st_stubs_n.$$(O)/' \
 	  -e 's/ st_\(posix\|win32\)\.h//g' >> .depend
 	$(CAMLRUN) ../../tools/ocamldep -slash *.mli *.ml >> .depend
+	../../tools/normalize_depend .depend
 endif
 
 include .depend

--- a/otherlibs/threads/.depend
+++ b/otherlibs/threads/.depend
@@ -1,38 +1,85 @@
-scheduler.o: scheduler.c ../../byterun/caml/alloc.h \
- ../../byterun/caml/misc.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/backtrace.h \
- ../../byterun/caml/exec.h ../../byterun/caml/callback.h \
- ../../byterun/caml/config.h ../../byterun/caml/fail.h \
- ../../byterun/caml/io.h ../../byterun/caml/memory.h \
- ../../byterun/caml/gc.h ../../byterun/caml/major_gc.h \
- ../../byterun/caml/freelist.h ../../byterun/caml/minor_gc.h \
- ../../byterun/caml/address_class.h ../../byterun/caml/misc.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/printexc.h \
- ../../byterun/caml/roots.h ../../byterun/caml/memory.h \
- ../../byterun/caml/signals.h ../../byterun/caml/stacks.h \
- ../../byterun/caml/sys.h
-condition.cmo : thread.cmi mutex.cmi condition.cmi
-condition.cmx : thread.cmx mutex.cmx condition.cmi
-condition.cmi : mutex.cmi
-event.cmo : mutex.cmi condition.cmi event.cmi
-event.cmx : mutex.cmx condition.cmx event.cmi
+scheduler.o: \
+  ../../byterun/caml/address_class.h \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/backtrace.h \
+  ../../byterun/caml/callback.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/exec.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
+  ../../byterun/caml/io.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/printexc.h \
+  ../../byterun/caml/roots.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  ../../byterun/caml/stacks.h \
+  ../../byterun/caml/sys.h \
+  scheduler.c
+condition.cmo : \
+  condition.cmi \
+  mutex.cmi \
+  thread.cmi
+condition.cmx : \
+  condition.cmi \
+  mutex.cmx \
+  thread.cmx
+condition.cmi : \
+  mutex.cmi
+event.cmo : \
+  condition.cmi \
+  event.cmi \
+  mutex.cmi
+event.cmx : \
+  condition.cmx \
+  event.cmi \
+  mutex.cmx
 event.cmi :
-marshal.cmo : marshal.cmi
-marshal.cmx : marshal.cmi
+marshal.cmo : \
+  marshal.cmi
+marshal.cmx : \
+  marshal.cmi
 marshal.cmi :
-mutex.cmo : thread.cmi mutex.cmi
-mutex.cmx : thread.cmx mutex.cmi
+mutex.cmo : \
+  mutex.cmi \
+  thread.cmi
+mutex.cmx : \
+  mutex.cmi \
+  thread.cmx
 mutex.cmi :
-pervasives.cmo : unix.cmi pervasives.cmi
-pervasives.cmx : unix.cmx pervasives.cmi
+pervasives.cmo : \
+  pervasives.cmi \
+  unix.cmi
+pervasives.cmx : \
+  pervasives.cmi \
+  unix.cmx
 pervasives.cmi :
-thread.cmo : unix.cmi thread.cmi
-thread.cmx : unix.cmx thread.cmi
-thread.cmi : unix.cmi
-threadUnix.cmo : unix.cmi thread.cmi threadUnix.cmi
-threadUnix.cmx : unix.cmx thread.cmx threadUnix.cmi
-threadUnix.cmi : unix.cmi
-unix.cmo : unix.cmi
-unix.cmx : unix.cmi
+thread.cmo : \
+  thread.cmi \
+  unix.cmi
+thread.cmx : \
+  thread.cmi \
+  unix.cmx
+thread.cmi : \
+  unix.cmi
+threadUnix.cmo : \
+  thread.cmi \
+  threadUnix.cmi \
+  unix.cmi
+threadUnix.cmx : \
+  thread.cmx \
+  threadUnix.cmi \
+  unix.cmx
+threadUnix.cmi : \
+  unix.cmi
+unix.cmo : \
+  unix.cmi
+unix.cmx : \
+  unix.cmi
 unix.cmi :

--- a/otherlibs/threads/Makefile
+++ b/otherlibs/threads/Makefile
@@ -136,6 +136,7 @@ ifeq "$(TOOLCHAIN)" "msvc"
 else
 	$(CC) -MM $(CPPFLAGS) *.c > .depend
 	$(CAMLRUN) ../../tools/ocamldep -slash *.mli *.ml >> .depend
+	../../tools/normalize_depend .depend
 endif
 
 include .depend

--- a/otherlibs/unix/.depend
+++ b/otherlibs/unix/.depend
@@ -1,469 +1,1017 @@
-accept.o: accept.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h \
- ../../byterun/caml/signals.h unixsupport.h socketaddr.h \
- ../../byterun/caml/misc.h
-access.o: access.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h ../../byterun/caml/signals.h unixsupport.h
-addrofstr.o: addrofstr.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h unixsupport.h socketaddr.h \
- ../../byterun/caml/misc.h
-alarm.o: alarm.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-bind.o: bind.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/mlvalues.h unixsupport.h socketaddr.h \
- ../../byterun/caml/misc.h
-chdir.o: chdir.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-chmod.o: chmod.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-chown.o: chown.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-chroot.o: chroot.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-close.o: close.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/signals.h ../../byterun/caml/mlvalues.h unixsupport.h
-closedir.o: closedir.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-connect.o: connect.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/signals.h unixsupport.h \
- socketaddr.h ../../byterun/caml/misc.h
-cst2constr.o: cst2constr.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/fail.h ../../byterun/caml/mlvalues.h cst2constr.h
-cstringv.o: cstringv.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h unixsupport.h
-dup.o: dup.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- unixsupport.h
-dup2.o: dup2.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- unixsupport.h
-envir.o: envir.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h
-errmsg.o: errmsg.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h
-execv.o: execv.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h unixsupport.h
-execve.o: execve.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h unixsupport.h
-execvp.o: execvp.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/osdeps.h ../../byterun/caml/memory.h unixsupport.h
-exit.o: exit.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- unixsupport.h
-fchmod.o: fchmod.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/signals.h unixsupport.h
-fchown.o: fchown.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/signals.h unixsupport.h
-fcntl.o: fcntl.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/mlvalues.h unixsupport.h
-fork.o: fork.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/debugger.h ../../byterun/caml/mlvalues.h \
- unixsupport.h
-ftruncate.o: ftruncate.c ../../byterun/caml/fail.h \
- ../../byterun/caml/misc.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/io.h ../../byterun/caml/signals.h unixsupport.h
-getaddrinfo.o: getaddrinfo.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h \
- ../../byterun/caml/misc.h ../../byterun/caml/signals.h unixsupport.h \
- cst2constr.h socketaddr.h
-getcwd.o: getcwd.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h unixsupport.h
-getegid.o: getegid.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-geteuid.o: geteuid.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-getgid.o: getgid.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-getgr.o: getgr.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/fail.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/memory.h unixsupport.h
-getgroups.o: getgroups.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h unixsupport.h
-gethost.o: gethost.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h \
- ../../byterun/caml/signals.h unixsupport.h socketaddr.h \
- ../../byterun/caml/misc.h
-gethostname.o: gethostname.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h unixsupport.h
-getlogin.o: getlogin.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h unixsupport.h
-getnameinfo.o: getnameinfo.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h \
- ../../byterun/caml/signals.h unixsupport.h socketaddr.h \
- ../../byterun/caml/misc.h
-getpeername.o: getpeername.c ../../byterun/caml/fail.h \
- ../../byterun/caml/misc.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/mlvalues.h \
- unixsupport.h socketaddr.h ../../byterun/caml/misc.h
-getpid.o: getpid.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-getppid.o: getppid.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-getproto.o: getproto.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h unixsupport.h
-getpw.o: getpw.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h ../../byterun/caml/fail.h unixsupport.h
-getserv.o: getserv.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h unixsupport.h
-getsockname.o: getsockname.c ../../byterun/caml/fail.h \
- ../../byterun/caml/misc.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/mlvalues.h \
- unixsupport.h socketaddr.h ../../byterun/caml/misc.h
-gettimeofday.o: gettimeofday.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h unixsupport.h
-getuid.o: getuid.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-gmtime.o: gmtime.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h unixsupport.h
-initgroups.o: initgroups.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h unixsupport.h
-isatty.o: isatty.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-itimer.o: itimer.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h unixsupport.h
-kill.o: kill.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/fail.h ../../byterun/caml/mlvalues.h unixsupport.h \
- ../../byterun/caml/signals.h
-link.o: link.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-listen.o: listen.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/mlvalues.h unixsupport.h
-lockf.o: lockf.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/signals.h unixsupport.h
-lseek.o: lseek.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/io.h ../../byterun/caml/signals.h unixsupport.h
-mkdir.o: mkdir.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-mkfifo.o: mkfifo.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/memory.h \
- ../../byterun/caml/signals.h unixsupport.h
-mmap.o: mmap.c ../../byterun/caml/bigarray.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/misc.h \
- ../../byterun/caml/fail.h ../../byterun/caml/io.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/signals.h \
- ../../byterun/caml/sys.h unixsupport.h
-mmap_ba.o: mmap_ba.c ../../byterun/caml/alloc.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/bigarray.h ../../byterun/caml/custom.h \
- ../../byterun/caml/memory.h ../../byterun/caml/gc.h \
- ../../byterun/caml/major_gc.h ../../byterun/caml/freelist.h \
- ../../byterun/caml/minor_gc.h ../../byterun/caml/address_class.h \
- ../../byterun/caml/misc.h
-nice.o: nice.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- unixsupport.h
-open.o: open.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h ../../byterun/caml/misc.h \
- ../../byterun/caml/signals.h unixsupport.h
-opendir.o: opendir.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/signals.h unixsupport.h
-pipe.o: pipe.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h unixsupport.h
-putenv.o: putenv.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h unixsupport.h
-read.o: read.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-readdir.o: readdir.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/fail.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/signals.h unixsupport.h
-readlink.o: readlink.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/fail.h \
- ../../byterun/caml/signals.h unixsupport.h
-rename.o: rename.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-rewinddir.o: rewinddir.c ../../byterun/caml/fail.h \
- ../../byterun/caml/misc.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/mlvalues.h \
- unixsupport.h
-rmdir.o: rmdir.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-select.o: select.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h \
- ../../byterun/caml/signals.h unixsupport.h
-sendrecv.o: sendrecv.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h \
- ../../byterun/caml/signals.h unixsupport.h socketaddr.h \
- ../../byterun/caml/misc.h
-setgid.o: setgid.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-setgroups.o: setgroups.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h unixsupport.h
-setsid.o: setsid.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/mlvalues.h unixsupport.h
-setuid.o: setuid.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-shutdown.o: shutdown.c ../../byterun/caml/fail.h \
- ../../byterun/caml/misc.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/mlvalues.h \
- unixsupport.h
-signals.o: signals.c ../../byterun/caml/alloc.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h \
- ../../byterun/caml/gc.h ../../byterun/caml/major_gc.h \
- ../../byterun/caml/freelist.h ../../byterun/caml/minor_gc.h \
- ../../byterun/caml/address_class.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-sleep.o: sleep.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/signals.h ../../byterun/caml/mlvalues.h unixsupport.h
-socket.o: socket.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/mlvalues.h unixsupport.h
-socketaddr.o: socketaddr.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h unixsupport.h socketaddr.h \
- ../../byterun/caml/misc.h
-socketpair.o: socketpair.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h unixsupport.h
-sockopt.o: sockopt.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/fail.h unixsupport.h \
- socketaddr.h ../../byterun/caml/misc.h
-stat.o: stat.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/gc.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/major_gc.h \
- ../../byterun/caml/freelist.h ../../byterun/caml/minor_gc.h \
- ../../byterun/caml/address_class.h ../../byterun/caml/alloc.h \
- ../../byterun/caml/signals.h ../../byterun/caml/io.h unixsupport.h \
- cst2constr.h nanosecond_stat.h
-strofaddr.o: strofaddr.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h unixsupport.h socketaddr.h \
- ../../byterun/caml/misc.h
-symlink.o: symlink.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/memory.h \
- ../../byterun/caml/signals.h unixsupport.h
-termios.o: termios.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h unixsupport.h
-time.o: time.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h unixsupport.h
-times.o: times.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h unixsupport.h
-truncate.o: truncate.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/gc.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/major_gc.h \
- ../../byterun/caml/freelist.h ../../byterun/caml/minor_gc.h \
- ../../byterun/caml/address_class.h ../../byterun/caml/fail.h \
- ../../byterun/caml/signals.h ../../byterun/caml/io.h unixsupport.h
-umask.o: umask.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-unixsupport.o: unixsupport.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/callback.h ../../byterun/caml/memory.h \
- ../../byterun/caml/fail.h unixsupport.h cst2constr.h
-unlink.o: unlink.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-utimes.o: utimes.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/memory.h \
- ../../byterun/caml/signals.h unixsupport.h
-wait.o: wait.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h \
- ../../byterun/caml/gc.h ../../byterun/caml/major_gc.h \
- ../../byterun/caml/freelist.h ../../byterun/caml/minor_gc.h \
- ../../byterun/caml/address_class.h ../../byterun/caml/signals.h \
- unixsupport.h
-write.o: write.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-unix.cmo : unix.cmi
-unix.cmx : unix.cmi
+accept.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  accept.c \
+  socketaddr.h \
+  unixsupport.h
+access.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  access.c \
+  unixsupport.h
+addrofstr.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  addrofstr.c \
+  socketaddr.h \
+  unixsupport.h
+alarm.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  alarm.c \
+  unixsupport.h
+bind.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  bind.c \
+  socketaddr.h \
+  unixsupport.h
+chdir.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  chdir.c \
+  unixsupport.h
+chmod.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  chmod.c \
+  unixsupport.h
+chown.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  chown.c \
+  unixsupport.h
+chroot.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  chroot.c \
+  unixsupport.h
+close.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  close.c \
+  unixsupport.h
+closedir.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  closedir.c \
+  unixsupport.h
+connect.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  connect.c \
+  socketaddr.h \
+  unixsupport.h
+cst2constr.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  cst2constr.c \
+  cst2constr.h
+cstringv.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  cstringv.c \
+  unixsupport.h
+dup.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  dup.c \
+  unixsupport.h
+dup2.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  dup2.c \
+  unixsupport.h
+envir.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  envir.c
+errmsg.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  errmsg.c
+execv.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  execv.c \
+  unixsupport.h
+execve.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  execve.c \
+  unixsupport.h
+execvp.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
+  ../../byterun/caml/s.h \
+  execvp.c \
+  unixsupport.h
+exit.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  exit.c \
+  unixsupport.h
+fchmod.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  fchmod.c \
+  unixsupport.h
+fchown.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  fchown.c \
+  unixsupport.h
+fcntl.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  fcntl.c \
+  unixsupport.h
+fork.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/debugger.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  fork.c \
+  unixsupport.h
+ftruncate.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/io.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  ftruncate.c \
+  unixsupport.h
+getaddrinfo.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  cst2constr.h \
+  getaddrinfo.c \
+  socketaddr.h \
+  unixsupport.h
+getcwd.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getcwd.c \
+  unixsupport.h
+getegid.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getegid.c \
+  unixsupport.h
+geteuid.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  geteuid.c \
+  unixsupport.h
+getgid.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getgid.c \
+  unixsupport.h
+getgr.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getgr.c \
+  unixsupport.h
+getgroups.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getgroups.c \
+  unixsupport.h
+gethost.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  gethost.c \
+  socketaddr.h \
+  unixsupport.h
+gethostname.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  gethostname.c \
+  unixsupport.h
+getlogin.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getlogin.c \
+  unixsupport.h
+getnameinfo.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  getnameinfo.c \
+  socketaddr.h \
+  unixsupport.h
+getpeername.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getpeername.c \
+  socketaddr.h \
+  unixsupport.h
+getpid.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getpid.c \
+  unixsupport.h
+getppid.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getppid.c \
+  unixsupport.h
+getproto.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getproto.c \
+  unixsupport.h
+getpw.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getpw.c \
+  unixsupport.h
+getserv.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getserv.c \
+  unixsupport.h
+getsockname.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getsockname.c \
+  socketaddr.h \
+  unixsupport.h
+gettimeofday.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  gettimeofday.c \
+  unixsupport.h
+getuid.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getuid.c \
+  unixsupport.h
+gmtime.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  gmtime.c \
+  unixsupport.h
+initgroups.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  initgroups.c \
+  unixsupport.h
+isatty.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  isatty.c \
+  unixsupport.h
+itimer.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  itimer.c \
+  unixsupport.h
+kill.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  kill.c \
+  unixsupport.h
+link.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  link.c \
+  unixsupport.h
+listen.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  listen.c \
+  unixsupport.h
+lockf.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  lockf.c \
+  unixsupport.h
+lseek.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/io.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  lseek.c \
+  unixsupport.h
+mkdir.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  mkdir.c \
+  unixsupport.h
+mkfifo.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  mkfifo.c \
+  unixsupport.h
+mmap.o: \
+  ../../byterun/caml/bigarray.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/io.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  ../../byterun/caml/sys.h \
+  mmap.c \
+  unixsupport.h
+mmap_ba.o: \
+  ../../byterun/caml/address_class.h \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/bigarray.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/custom.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  mmap_ba.c
+nice.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  nice.c \
+  unixsupport.h
+open.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  open.c \
+  unixsupport.h
+opendir.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  opendir.c \
+  unixsupport.h
+pipe.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  pipe.c \
+  unixsupport.h
+putenv.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  putenv.c \
+  unixsupport.h
+read.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  read.c \
+  unixsupport.h
+readdir.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  readdir.c \
+  unixsupport.h
+readlink.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  readlink.c \
+  unixsupport.h
+rename.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  rename.c \
+  unixsupport.h
+rewinddir.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  rewinddir.c \
+  unixsupport.h
+rmdir.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  rmdir.c \
+  unixsupport.h
+select.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  select.c \
+  unixsupport.h
+sendrecv.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  sendrecv.c \
+  socketaddr.h \
+  unixsupport.h
+setgid.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  setgid.c \
+  unixsupport.h
+setgroups.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  setgroups.c \
+  unixsupport.h
+setsid.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  setsid.c \
+  unixsupport.h
+setuid.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  setuid.c \
+  unixsupport.h
+shutdown.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  shutdown.c \
+  unixsupport.h
+signals.o: \
+  ../../byterun/caml/address_class.h \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  signals.c \
+  unixsupport.h
+sleep.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  sleep.c \
+  unixsupport.h
+socket.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  socket.c \
+  unixsupport.h
+socketaddr.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  socketaddr.c \
+  socketaddr.h \
+  unixsupport.h
+socketpair.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  socketpair.c \
+  unixsupport.h
+sockopt.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  socketaddr.h \
+  sockopt.c \
+  unixsupport.h
+stat.o: \
+  ../../byterun/caml/address_class.h \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
+  ../../byterun/caml/io.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  cst2constr.h \
+  nanosecond_stat.h \
+  stat.c \
+  unixsupport.h
+strofaddr.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  socketaddr.h \
+  strofaddr.c \
+  unixsupport.h
+symlink.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  symlink.c \
+  unixsupport.h
+termios.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  termios.c \
+  unixsupport.h
+time.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  time.c \
+  unixsupport.h
+times.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  times.c \
+  unixsupport.h
+truncate.o: \
+  ../../byterun/caml/address_class.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
+  ../../byterun/caml/io.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  truncate.c \
+  unixsupport.h
+umask.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  umask.c \
+  unixsupport.h
+unixsupport.o: \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/callback.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  cst2constr.h \
+  unixsupport.c \
+  unixsupport.h
+unlink.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  unixsupport.h \
+  unlink.c
+utimes.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  unixsupport.h \
+  utimes.c
+wait.o: \
+  ../../byterun/caml/address_class.h \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  unixsupport.h \
+  wait.c
+write.o: \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  unixsupport.h \
+  write.c
+unix.cmo : \
+  unix.cmi
+unix.cmx : \
+  unix.cmi
 unix.cmi :
-unixLabels.cmo : unix.cmi unixLabels.cmi
-unixLabels.cmx : unix.cmx unixLabels.cmi
-unixLabels.cmi : unix.cmi
+unixLabels.cmo : \
+  unix.cmi \
+  unixLabels.cmi
+unixLabels.cmx : \
+  unix.cmx \
+  unixLabels.cmi
+unixLabels.cmi : \
+  unix.cmi

--- a/otherlibs/unix/.depend
+++ b/otherlibs/unix/.depend
@@ -18,6 +18,7 @@ access.o: \
   ../../byterun/caml/memory.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   access.c \
@@ -52,21 +53,33 @@ bind.o: \
   socketaddr.h \
   unixsupport.h
 chdir.o: \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   chdir.c \
   unixsupport.h
 chmod.o: \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   chmod.c \
@@ -131,11 +144,17 @@ cst2constr.o: \
   cst2constr.c \
   cst2constr.h
 cstringv.o: \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   cstringv.c \
   unixsupport.h
@@ -172,20 +191,32 @@ errmsg.o: \
   ../../byterun/caml/s.h \
   errmsg.c
 execv.o: \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   execv.c \
   unixsupport.h
 execve.o: \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   execve.c \
   unixsupport.h
@@ -271,12 +302,19 @@ getaddrinfo.o: \
   socketaddr.h \
   unixsupport.h
 getcwd.o: \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/alloc.h \
   ../../byterun/caml/config.h \
   ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   getcwd.c \
   unixsupport.h
@@ -637,12 +675,18 @@ pipe.o: \
   pipe.c \
   unixsupport.h
 putenv.o: \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
   ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   putenv.c \
   unixsupport.h
@@ -699,11 +743,17 @@ rewinddir.o: \
   rewinddir.c \
   unixsupport.h
 rmdir.o: \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   rmdir.c \
@@ -955,22 +1005,34 @@ unixsupport.o: \
   unixsupport.c \
   unixsupport.h
 unlink.o: \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   unixsupport.h \
   unlink.c
 utimes.o: \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
   ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   unixsupport.h \

--- a/otherlibs/unix/Makefile
+++ b/otherlibs/unix/Makefile
@@ -53,6 +53,7 @@ ifeq "$(TOOLCHAIN)" "msvc"
 else
 	$(CC) -MM $(CPPFLAGS) *.c > .depend
 	$(CAMLRUN) ../../tools/ocamldep -slash *.mli *.ml >> .depend
+	../../tools/normalize_depend .depend
 endif
 
 include .depend

--- a/otherlibs/win32unix/.depend
+++ b/otherlibs/win32unix/.depend
@@ -1,337 +1,738 @@
-accept.$(O): accept.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h ../../byterun/caml/signals.h unixsupport.h \
- socketaddr.h ../../byterun/caml/misc.h
-bind.$(O): bind.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- unixsupport.h socketaddr.h ../../byterun/caml/misc.h
-channels.$(O): channels.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/io.h ../../byterun/caml/memory.h \
- ../../byterun/caml/gc.h ../../byterun/caml/major_gc.h \
- ../../byterun/caml/freelist.h ../../byterun/caml/minor_gc.h \
- ../../byterun/caml/address_class.h unixsupport.h
-close.$(O): close.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h \
- ../../byterun/caml/io.h
-close_on.$(O): close_on.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-connect.$(O): connect.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/signals.h ../../byterun/caml/mlvalues.h unixsupport.h \
- socketaddr.h ../../byterun/caml/misc.h
-createprocess.$(O): createprocess.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/gc.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/major_gc.h \
- ../../byterun/caml/freelist.h ../../byterun/caml/minor_gc.h \
- ../../byterun/caml/address_class.h unixsupport.h \
- ../../byterun/caml/osdeps.h ../../byterun/caml/memory.h
-dup.$(O): dup.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- unixsupport.h
-dup2.$(O): dup2.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- unixsupport.h
-errmsg.$(O): errmsg.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h unixsupport.h
-getpeername.$(O): getpeername.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h \
- socketaddr.h ../../byterun/caml/misc.h
-getpid.$(O): getpid.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-getsockname.$(O): getsockname.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h \
- socketaddr.h ../../byterun/caml/misc.h
-gettimeofday.$(O): gettimeofday.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h unixsupport.h
-link.$(O): link.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/fail.h ../../byterun/caml/mlvalues.h unixsupport.h
-listen.$(O): listen.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-lockf.$(O): lockf.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h unixsupport.h ../../byterun/caml/signals.h
-lseek.$(O): lseek.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h unixsupport.h
-nonblock.$(O): nonblock.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/signals.h ../../byterun/caml/mlvalues.h unixsupport.h
-mkdir.$(O): mkdir.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-mmap.$(O): mmap.c ../../byterun/caml/alloc.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/bigarray.h ../../byterun/caml/fail.h \
- ../../byterun/caml/io.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h ../../byterun/caml/sys.h unixsupport.h
-open.$(O): open.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h unixsupport.h
-pipe.$(O): pipe.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/alloc.h unixsupport.h
-read.$(O): read.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-readlink.$(O): readlink.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/fail.h \
- ../../byterun/caml/signals.h unixsupport.h
-rename.$(O): rename.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-select.$(O): select.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h ../../byterun/caml/fail.h \
- ../../byterun/caml/signals.h winworker.h unixsupport.h windbug.h \
- winlist.h
-sendrecv.$(O): sendrecv.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h ../../byterun/caml/signals.h unixsupport.h \
- socketaddr.h ../../byterun/caml/misc.h
-shutdown.$(O): shutdown.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-sleep.$(O): sleep.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/signals.h ../../byterun/caml/mlvalues.h unixsupport.h
-socket.$(O): socket.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h unixsupport.h
-sockopt.$(O): sockopt.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/fail.h unixsupport.h \
- socketaddr.h ../../byterun/caml/misc.h
-startup.$(O): startup.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h winworker.h \
- unixsupport.h windbug.h
-stat.$(O): stat.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/signals.h unixsupport.h \
- ../unix/cst2constr.h
-symlink.$(O): symlink.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/fail.h \
- ../../byterun/caml/signals.h unixsupport.h
-system.$(O): system.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/signals.h unixsupport.h
-times.$(O): times.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h unixsupport.h
-unixsupport.$(O): unixsupport.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/callback.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/memory.h \
- ../../byterun/caml/fail.h ../../byterun/caml/custom.h unixsupport.h \
- ../unix/cst2constr.h
-windir.$(O): windir.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/fail.h unixsupport.h
-winwait.$(O): winwait.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h ../../byterun/caml/signals.h unixsupport.h
-write.$(O): write.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-winlist.$(O): winlist.c winlist.h
-winworker.$(O): winworker.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h ../../byterun/caml/signals.h winworker.h \
- unixsupport.h winlist.h windbug.h
-windbug.$(O): windbug.c windbug.h
-access.$(O): access.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h ../../byterun/caml/signals.h unixsupport.h
-addrofstr.$(O): addrofstr.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h unixsupport.h socketaddr.h \
- ../../byterun/caml/misc.h
-chdir.$(O): chdir.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-chmod.$(O): chmod.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-cst2constr.$(O): cst2constr.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/fail.h ../../byterun/caml/mlvalues.h \
- ../unix/cst2constr.h
-cstringv.$(O): cstringv.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h unixsupport.h
-envir.$(O): envir.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h
-execv.$(O): execv.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h unixsupport.h
-execve.$(O): execve.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h unixsupport.h
-execvp.$(O): execvp.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/osdeps.h ../../byterun/caml/memory.h unixsupport.h
-exit.$(O): exit.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- unixsupport.h
-getaddrinfo.$(O): getaddrinfo.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h \
- ../../byterun/caml/misc.h ../../byterun/caml/signals.h unixsupport.h \
- ../unix/cst2constr.h socketaddr.h
-getcwd.$(O): getcwd.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h unixsupport.h
-gethost.$(O): gethost.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h \
- ../../byterun/caml/signals.h unixsupport.h socketaddr.h \
- ../../byterun/caml/misc.h
-gethostname.$(O): gethostname.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h unixsupport.h
-getnameinfo.$(O): getnameinfo.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h \
- ../../byterun/caml/signals.h unixsupport.h socketaddr.h \
- ../../byterun/caml/misc.h
-getproto.$(O): getproto.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h unixsupport.h
-getserv.$(O): getserv.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h unixsupport.h
-gmtime.$(O): gmtime.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h ../../byterun/caml/memory.h unixsupport.h
-mmap_ba.$(O): mmap_ba.c ../../byterun/caml/alloc.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/bigarray.h ../../byterun/caml/custom.h \
- ../../byterun/caml/memory.h ../../byterun/caml/gc.h \
- ../../byterun/caml/major_gc.h ../../byterun/caml/freelist.h \
- ../../byterun/caml/minor_gc.h ../../byterun/caml/address_class.h \
- ../../byterun/caml/misc.h
-putenv.$(O): putenv.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h unixsupport.h
-rmdir.$(O): rmdir.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-socketaddr.$(O): socketaddr.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/memory.h unixsupport.h socketaddr.h \
- ../../byterun/caml/misc.h
-strofaddr.$(O): strofaddr.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/fail.h unixsupport.h socketaddr.h \
- ../../byterun/caml/misc.h
-time.$(O): time.c ../../byterun/caml/mlvalues.h ../../byterun/caml/config.h \
- ../../byterun/caml/m.h ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/alloc.h ../../byterun/caml/mlvalues.h unixsupport.h
-unlink.$(O): unlink.c ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/misc.h \
- ../../byterun/caml/memory.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/signals.h unixsupport.h
-utimes.$(O): utimes.c ../../byterun/caml/fail.h ../../byterun/caml/misc.h \
- ../../byterun/caml/config.h ../../byterun/caml/m.h \
- ../../byterun/caml/s.h ../../byterun/caml/mlvalues.h \
- ../../byterun/caml/mlvalues.h ../../byterun/caml/memory.h \
- ../../byterun/caml/signals.h unixsupport.h
-unix.cmo : unix.cmi
-unix.cmx : unix.cmi
+accept.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  accept.c \
+  socketaddr.h \
+  unixsupport.h
+bind.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  bind.c \
+  socketaddr.h \
+  unixsupport.h
+channels.$(O): \
+  ../../byterun/caml/address_class.h \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
+  ../../byterun/caml/io.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  channels.c \
+  unixsupport.h
+close.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/io.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  close.c \
+  unixsupport.h
+close_on.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  close_on.c \
+  unixsupport.h
+connect.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  connect.c \
+  socketaddr.h \
+  unixsupport.h
+createprocess.$(O): \
+  ../../byterun/caml/address_class.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
+  ../../byterun/caml/s.h \
+  createprocess.c \
+  unixsupport.h
+dup.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  dup.c \
+  unixsupport.h
+dup2.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  dup2.c \
+  unixsupport.h
+errmsg.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  errmsg.c \
+  unixsupport.h
+getpeername.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getpeername.c \
+  socketaddr.h \
+  unixsupport.h
+getpid.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getpid.c \
+  unixsupport.h
+getsockname.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getsockname.c \
+  socketaddr.h \
+  unixsupport.h
+gettimeofday.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  gettimeofday.c \
+  unixsupport.h
+link.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  link.c \
+  unixsupport.h
+listen.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  listen.c \
+  unixsupport.h
+lockf.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  lockf.c \
+  unixsupport.h
+lseek.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  lseek.c \
+  unixsupport.h
+nonblock.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  nonblock.c \
+  unixsupport.h
+mkdir.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  mkdir.c \
+  unixsupport.h
+mmap.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/bigarray.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/io.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  ../../byterun/caml/sys.h \
+  mmap.c \
+  unixsupport.h
+open.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  open.c \
+  unixsupport.h
+pipe.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  pipe.c \
+  unixsupport.h
+read.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  read.c \
+  unixsupport.h
+readlink.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  readlink.c \
+  unixsupport.h
+rename.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  rename.c \
+  unixsupport.h
+select.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  select.c \
+  unixsupport.h \
+  windbug.h \
+  winlist.h \
+  winworker.h
+sendrecv.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  sendrecv.c \
+  socketaddr.h \
+  unixsupport.h
+shutdown.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  shutdown.c \
+  unixsupport.h
+sleep.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  sleep.c \
+  unixsupport.h
+socket.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  socket.c \
+  unixsupport.h
+sockopt.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  socketaddr.h \
+  sockopt.c \
+  unixsupport.h
+startup.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  startup.c \
+  unixsupport.h \
+  windbug.h \
+  winworker.h
+stat.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  ../unix/cst2constr.h \
+  stat.c \
+  unixsupport.h
+symlink.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  symlink.c \
+  unixsupport.h
+system.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  system.c \
+  unixsupport.h
+times.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  times.c \
+  unixsupport.h
+unixsupport.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/callback.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/custom.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../unix/cst2constr.h \
+  unixsupport.c \
+  unixsupport.h
+windir.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  unixsupport.h \
+  windir.c
+winwait.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  unixsupport.h \
+  winwait.c
+write.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  unixsupport.h \
+  write.c
+winlist.$(O): \
+  winlist.c \
+  winlist.h
+winworker.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  unixsupport.h \
+  windbug.h \
+  winlist.h \
+  winworker.c \
+  winworker.h
+windbug.$(O): \
+  windbug.c \
+  windbug.h
+access.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  access.c \
+  unixsupport.h
+addrofstr.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  addrofstr.c \
+  socketaddr.h \
+  unixsupport.h
+chdir.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  chdir.c \
+  unixsupport.h
+chmod.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  chmod.c \
+  unixsupport.h
+cst2constr.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../unix/cst2constr.h \
+  cst2constr.c
+cstringv.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  cstringv.c \
+  unixsupport.h
+envir.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  envir.c
+execv.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  execv.c \
+  unixsupport.h
+execve.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  execve.c \
+  unixsupport.h
+execvp.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
+  ../../byterun/caml/s.h \
+  execvp.c \
+  unixsupport.h
+exit.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  exit.c \
+  unixsupport.h
+getaddrinfo.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  ../unix/cst2constr.h \
+  getaddrinfo.c \
+  socketaddr.h \
+  unixsupport.h
+getcwd.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getcwd.c \
+  unixsupport.h
+gethost.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  gethost.c \
+  socketaddr.h \
+  unixsupport.h
+gethostname.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  gethostname.c \
+  unixsupport.h
+getnameinfo.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  getnameinfo.c \
+  socketaddr.h \
+  unixsupport.h
+getproto.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getproto.c \
+  unixsupport.h
+getserv.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  getserv.c \
+  unixsupport.h
+gmtime.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  gmtime.c \
+  unixsupport.h
+mmap_ba.$(O): \
+  ../../byterun/caml/address_class.h \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/bigarray.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/custom.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  mmap_ba.c
+putenv.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  putenv.c \
+  unixsupport.h
+rmdir.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  rmdir.c \
+  unixsupport.h
+socketaddr.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  socketaddr.c \
+  socketaddr.h \
+  unixsupport.h
+strofaddr.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  socketaddr.h \
+  strofaddr.c \
+  unixsupport.h
+time.$(O): \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  time.c \
+  unixsupport.h
+unlink.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  unixsupport.h \
+  unlink.c
+utimes.$(O): \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/s.h \
+  ../../byterun/caml/signals.h \
+  unixsupport.h \
+  utimes.c
+unix.cmo : \
+  unix.cmi
+unix.cmx : \
+  unix.cmi
 unix.cmi :
-unixLabels.cmo : unix.cmi unixLabels.cmi
-unixLabels.cmx : unix.cmx unixLabels.cmi
-unixLabels.cmi : unix.cmi
+unixLabels.cmo : \
+  unix.cmi \
+  unixLabels.cmi
+unixLabels.cmx : \
+  unix.cmx \
+  unixLabels.cmi
+unixLabels.cmi : \
+  unix.cmi

--- a/otherlibs/win32unix/.depend
+++ b/otherlibs/win32unix/.depend
@@ -94,14 +94,36 @@ dup2.$(O): \
   dup2.c \
   unixsupport.h
 errmsg.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/alloc.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   errmsg.c \
   unixsupport.h
+envir.$(O): \
+  ../../byterun/caml/address_class.h \
+  ../../byterun/caml/alloc.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
+  ../../byterun/caml/s.h \
+  envir.c
 getpeername.$(O): \
   ../../byterun/caml/config.h \
   ../../byterun/caml/m.h \
@@ -137,12 +159,34 @@ gettimeofday.$(O): \
   ../../byterun/caml/s.h \
   gettimeofday.c \
   unixsupport.h
-link.$(O): \
+isatty.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
-  ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
+  ../../byterun/caml/s.h \
+  isatty.c \
+  unixsupport.h
+link.$(O): \
+  ../../byterun/caml/address_class.h \
+  ../../byterun/caml/config.h \
+  ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
+  ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
+  ../../byterun/caml/misc.h \
+  ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   link.c \
   unixsupport.h
@@ -184,33 +228,54 @@ nonblock.$(O): \
   nonblock.c \
   unixsupport.h
 mkdir.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   mkdir.c \
   unixsupport.h
 mmap.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/alloc.h \
   ../../byterun/caml/bigarray.h \
   ../../byterun/caml/config.h \
   ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/io.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   ../../byterun/caml/sys.h \
   mmap.c \
   unixsupport.h
 open.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/alloc.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   open.c \
   unixsupport.h
@@ -235,22 +300,35 @@ read.$(O): \
   read.c \
   unixsupport.h
 readlink.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/alloc.h \
   ../../byterun/caml/config.h \
   ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   readlink.c \
   unixsupport.h
 rename.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   rename.c \
   unixsupport.h
@@ -329,36 +407,54 @@ startup.$(O): \
   windbug.h \
   winworker.h
 stat.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/alloc.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   ../unix/cst2constr.h \
   stat.c \
   unixsupport.h
 symlink.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/alloc.h \
   ../../byterun/caml/config.h \
   ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   symlink.c \
   unixsupport.h
 system.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/alloc.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   system.c \
@@ -387,13 +483,19 @@ unixsupport.$(O): \
   unixsupport.c \
   unixsupport.h
 windir.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/alloc.h \
   ../../byterun/caml/config.h \
   ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   unixsupport.h \
   windir.c
@@ -445,6 +547,7 @@ access.$(O): \
   ../../byterun/caml/memory.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   access.c \
@@ -461,21 +564,33 @@ addrofstr.$(O): \
   socketaddr.h \
   unixsupport.h
 chdir.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   chdir.c \
   unixsupport.h
 chmod.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   chmod.c \
@@ -490,37 +605,47 @@ cst2constr.$(O): \
   ../unix/cst2constr.h \
   cst2constr.c
 cstringv.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   cstringv.c \
   unixsupport.h
-envir.$(O): \
-  ../../byterun/caml/alloc.h \
-  ../../byterun/caml/config.h \
-  ../../byterun/caml/m.h \
-  ../../byterun/caml/misc.h \
-  ../../byterun/caml/mlvalues.h \
-  ../../byterun/caml/s.h \
-  envir.c
 execv.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   execv.c \
   unixsupport.h
 execve.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   execve.c \
   unixsupport.h
@@ -557,12 +682,19 @@ getaddrinfo.$(O): \
   socketaddr.h \
   unixsupport.h
 getcwd.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/alloc.h \
   ../../byterun/caml/config.h \
   ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
+  ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   getcwd.c \
   unixsupport.h
@@ -652,21 +784,33 @@ mmap_ba.$(O): \
   ../../byterun/caml/s.h \
   mmap_ba.c
 putenv.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
   ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   putenv.c \
   unixsupport.h
 rmdir.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   rmdir.c \
@@ -703,22 +847,34 @@ time.$(O): \
   time.c \
   unixsupport.h
 unlink.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   unixsupport.h \
   unlink.c
 utimes.$(O): \
+  ../../byterun/caml/address_class.h \
   ../../byterun/caml/config.h \
   ../../byterun/caml/fail.h \
+  ../../byterun/caml/freelist.h \
+  ../../byterun/caml/gc.h \
   ../../byterun/caml/m.h \
+  ../../byterun/caml/major_gc.h \
   ../../byterun/caml/memory.h \
+  ../../byterun/caml/minor_gc.h \
   ../../byterun/caml/misc.h \
   ../../byterun/caml/mlvalues.h \
+  ../../byterun/caml/osdeps.h \
   ../../byterun/caml/s.h \
   ../../byterun/caml/signals.h \
   unixsupport.h \

--- a/otherlibs/win32unix/Makefile
+++ b/otherlibs/win32unix/Makefile
@@ -70,6 +70,7 @@ depend: $(ALL_FILES) $(UNIX_CAML_FILES) unix.ml
 	  | sed -e 's/\.o/.$$(O)/g' > .depend
 	$(CAMLRUN) $(ROOTDIR)/tools/ocamldep -slash $(UNIX_CAML_FILES) \
 	  unix.ml >> .depend
+	$(ROOTDIR)/tools/normalize_depend .depend
 endif
 
 include .depend

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -1,324 +1,1042 @@
-arg.cmo : sys.cmi string.cmi printf.cmi list.cmi buffer.cmi array.cmi \
-    arg.cmi
-arg.cmx : sys.cmx string.cmx printf.cmx list.cmx buffer.cmx array.cmx \
-    arg.cmi
+arg.cmo : \
+  arg.cmi \
+  array.cmi \
+  buffer.cmi \
+  list.cmi \
+  printf.cmi \
+  string.cmi \
+  sys.cmi
+arg.cmx : \
+  arg.cmi \
+  array.cmx \
+  buffer.cmx \
+  list.cmx \
+  printf.cmx \
+  string.cmx \
+  sys.cmx
 arg.cmi :
-array.cmo : array.cmi
-array.cmx : array.cmi
+array.cmo : \
+  array.cmi
+array.cmx : \
+  array.cmi
 array.cmi :
-arrayLabels.cmo : array.cmi arrayLabels.cmi
-arrayLabels.cmx : array.cmx arrayLabels.cmi
+arrayLabels.cmo : \
+  array.cmi \
+  arrayLabels.cmi
+arrayLabels.cmx : \
+  array.cmx \
+  arrayLabels.cmi
 arrayLabels.cmi :
-buffer.cmo : uchar.cmi sys.cmi string.cmi char.cmi bytes.cmi buffer.cmi
-buffer.cmx : uchar.cmx sys.cmx string.cmx char.cmx bytes.cmx buffer.cmi
-buffer.cmi : uchar.cmi
-bytes.cmo : pervasives.cmi char.cmi bytes.cmi
-bytes.cmx : pervasives.cmx char.cmx bytes.cmi
+buffer.cmo : \
+  buffer.cmi \
+  bytes.cmi \
+  char.cmi \
+  string.cmi \
+  sys.cmi \
+  uchar.cmi
+buffer.cmx : \
+  buffer.cmi \
+  bytes.cmx \
+  char.cmx \
+  string.cmx \
+  sys.cmx \
+  uchar.cmx
+buffer.cmi : \
+  uchar.cmi
+bytes.cmo : \
+  bytes.cmi \
+  char.cmi \
+  pervasives.cmi
+bytes.cmx : \
+  bytes.cmi \
+  char.cmx \
+  pervasives.cmx
 bytes.cmi :
-bytesLabels.cmo : bytes.cmi bytesLabels.cmi
-bytesLabels.cmx : bytes.cmx bytesLabels.cmi
+bytesLabels.cmo : \
+  bytes.cmi \
+  bytesLabels.cmi
+bytesLabels.cmx : \
+  bytes.cmx \
+  bytesLabels.cmi
 bytesLabels.cmi :
-callback.cmo : obj.cmi callback.cmi
-callback.cmx : obj.cmx callback.cmi
+callback.cmo : \
+  callback.cmi \
+  obj.cmi
+callback.cmx : \
+  callback.cmi \
+  obj.cmx
 callback.cmi :
-camlinternalBigarray.cmo : complex.cmi
-camlinternalBigarray.cmx : complex.cmx
-camlinternalFormat.cmo : sys.cmi string.cmi char.cmi \
-    camlinternalFormatBasics.cmi bytes.cmi buffer.cmi camlinternalFormat.cmi
-camlinternalFormat.cmx : sys.cmx string.cmx char.cmx \
-    camlinternalFormatBasics.cmx bytes.cmx buffer.cmx camlinternalFormat.cmi
-camlinternalFormat.cmi : camlinternalFormatBasics.cmi buffer.cmi
-camlinternalFormatBasics.cmo : camlinternalFormatBasics.cmi
-camlinternalFormatBasics.cmx : camlinternalFormatBasics.cmi
+camlinternalBigarray.cmo : \
+  complex.cmi
+camlinternalBigarray.cmx : \
+  complex.cmx
+camlinternalFormat.cmo : \
+  buffer.cmi \
+  bytes.cmi \
+  camlinternalFormat.cmi \
+  camlinternalFormatBasics.cmi \
+  char.cmi \
+  string.cmi \
+  sys.cmi
+camlinternalFormat.cmx : \
+  buffer.cmx \
+  bytes.cmx \
+  camlinternalFormat.cmi \
+  camlinternalFormatBasics.cmx \
+  char.cmx \
+  string.cmx \
+  sys.cmx
+camlinternalFormat.cmi : \
+  buffer.cmi \
+  camlinternalFormatBasics.cmi
+camlinternalFormatBasics.cmo : \
+  camlinternalFormatBasics.cmi
+camlinternalFormatBasics.cmx : \
+  camlinternalFormatBasics.cmi
 camlinternalFormatBasics.cmi :
-camlinternalLazy.cmo : obj.cmi camlinternalLazy.cmi
-camlinternalLazy.cmx : obj.cmx camlinternalLazy.cmi
+camlinternalLazy.cmo : \
+  camlinternalLazy.cmi \
+  obj.cmi
+camlinternalLazy.cmx : \
+  camlinternalLazy.cmi \
+  obj.cmx
 camlinternalLazy.cmi :
-camlinternalMod.cmo : obj.cmi camlinternalOO.cmi array.cmi \
-    camlinternalMod.cmi
-camlinternalMod.cmx : obj.cmx camlinternalOO.cmx array.cmx \
-    camlinternalMod.cmi
-camlinternalMod.cmi : obj.cmi
-camlinternalOO.cmo : sys.cmi string.cmi obj.cmi map.cmi list.cmi char.cmi \
-    array.cmi camlinternalOO.cmi
-camlinternalOO.cmx : sys.cmx string.cmx obj.cmx map.cmx list.cmx char.cmx \
-    array.cmx camlinternalOO.cmi
-camlinternalOO.cmi : obj.cmi
-char.cmo : char.cmi
-char.cmx : char.cmi
+camlinternalMod.cmo : \
+  array.cmi \
+  camlinternalMod.cmi \
+  camlinternalOO.cmi \
+  obj.cmi
+camlinternalMod.cmx : \
+  array.cmx \
+  camlinternalMod.cmi \
+  camlinternalOO.cmx \
+  obj.cmx
+camlinternalMod.cmi : \
+  obj.cmi
+camlinternalOO.cmo : \
+  array.cmi \
+  camlinternalOO.cmi \
+  char.cmi \
+  list.cmi \
+  map.cmi \
+  obj.cmi \
+  string.cmi \
+  sys.cmi
+camlinternalOO.cmx : \
+  array.cmx \
+  camlinternalOO.cmi \
+  char.cmx \
+  list.cmx \
+  map.cmx \
+  obj.cmx \
+  string.cmx \
+  sys.cmx
+camlinternalOO.cmi : \
+  obj.cmi
+char.cmo : \
+  char.cmi
+char.cmx : \
+  char.cmi
 char.cmi :
-complex.cmo : complex.cmi
-complex.cmx : complex.cmi
+complex.cmo : \
+  complex.cmi
+complex.cmx : \
+  complex.cmi
 complex.cmi :
-digest.cmo : string.cmi char.cmi bytes.cmi digest.cmi
-digest.cmx : string.cmx char.cmx bytes.cmx digest.cmi
+digest.cmo : \
+  bytes.cmi \
+  char.cmi \
+  digest.cmi \
+  string.cmi
+digest.cmx : \
+  bytes.cmx \
+  char.cmx \
+  digest.cmi \
+  string.cmx
 digest.cmi :
-ephemeron.cmo : sys.cmi random.cmi obj.cmi lazy.cmi hashtbl.cmi array.cmi \
-    ephemeron.cmi
-ephemeron.cmx : sys.cmx random.cmx obj.cmx lazy.cmx hashtbl.cmx array.cmx \
-    ephemeron.cmi
-ephemeron.cmi : hashtbl.cmi
-filename.cmo : sys.cmi string.cmi random.cmi printf.cmi lazy.cmi buffer.cmi \
-    filename.cmi
-filename.cmx : sys.cmx string.cmx random.cmx printf.cmx lazy.cmx buffer.cmx \
-    filename.cmi
+ephemeron.cmo : \
+  array.cmi \
+  ephemeron.cmi \
+  hashtbl.cmi \
+  lazy.cmi \
+  obj.cmi \
+  random.cmi \
+  sys.cmi
+ephemeron.cmx : \
+  array.cmx \
+  ephemeron.cmi \
+  hashtbl.cmx \
+  lazy.cmx \
+  obj.cmx \
+  random.cmx \
+  sys.cmx
+ephemeron.cmi : \
+  hashtbl.cmi
+filename.cmo : \
+  buffer.cmi \
+  filename.cmi \
+  lazy.cmi \
+  printf.cmi \
+  random.cmi \
+  string.cmi \
+  sys.cmi
+filename.cmx : \
+  buffer.cmx \
+  filename.cmi \
+  lazy.cmx \
+  printf.cmx \
+  random.cmx \
+  string.cmx \
+  sys.cmx
 filename.cmi :
-format.cmo : string.cmi pervasives.cmi list.cmi camlinternalFormatBasics.cmi \
-    camlinternalFormat.cmi buffer.cmi format.cmi
-format.cmx : string.cmx pervasives.cmx list.cmx camlinternalFormatBasics.cmx \
-    camlinternalFormat.cmx buffer.cmx format.cmi
-format.cmi : pervasives.cmi buffer.cmi
-gc.cmo : sys.cmi string.cmi printf.cmi gc.cmi
-gc.cmx : sys.cmx string.cmx printf.cmx gc.cmi
+format.cmo : \
+  buffer.cmi \
+  camlinternalFormat.cmi \
+  camlinternalFormatBasics.cmi \
+  format.cmi \
+  list.cmi \
+  pervasives.cmi \
+  string.cmi
+format.cmx : \
+  buffer.cmx \
+  camlinternalFormat.cmx \
+  camlinternalFormatBasics.cmx \
+  format.cmi \
+  list.cmx \
+  pervasives.cmx \
+  string.cmx
+format.cmi : \
+  buffer.cmi \
+  pervasives.cmi
+gc.cmo : \
+  gc.cmi \
+  printf.cmi \
+  string.cmi \
+  sys.cmi
+gc.cmx : \
+  gc.cmi \
+  printf.cmx \
+  string.cmx \
+  sys.cmx
 gc.cmi :
-genlex.cmo : string.cmi stream.cmi list.cmi hashtbl.cmi char.cmi bytes.cmi \
-    genlex.cmi
-genlex.cmx : string.cmx stream.cmx list.cmx hashtbl.cmx char.cmx bytes.cmx \
-    genlex.cmi
-genlex.cmi : stream.cmi
-hashtbl.cmo : sys.cmi string.cmi random.cmi obj.cmi lazy.cmi array.cmi \
-    hashtbl.cmi
-hashtbl.cmx : sys.cmx string.cmx random.cmx obj.cmx lazy.cmx array.cmx \
-    hashtbl.cmi
+genlex.cmo : \
+  bytes.cmi \
+  char.cmi \
+  genlex.cmi \
+  hashtbl.cmi \
+  list.cmi \
+  stream.cmi \
+  string.cmi
+genlex.cmx : \
+  bytes.cmx \
+  char.cmx \
+  genlex.cmi \
+  hashtbl.cmx \
+  list.cmx \
+  stream.cmx \
+  string.cmx
+genlex.cmi : \
+  stream.cmi
+hashtbl.cmo : \
+  array.cmi \
+  hashtbl.cmi \
+  lazy.cmi \
+  obj.cmi \
+  random.cmi \
+  string.cmi \
+  sys.cmi
+hashtbl.cmx : \
+  array.cmx \
+  hashtbl.cmi \
+  lazy.cmx \
+  obj.cmx \
+  random.cmx \
+  string.cmx \
+  sys.cmx
 hashtbl.cmi :
-int32.cmo : pervasives.cmi int32.cmi
-int32.cmx : pervasives.cmx int32.cmi
+int32.cmo : \
+  int32.cmi \
+  pervasives.cmi
+int32.cmx : \
+  int32.cmi \
+  pervasives.cmx
 int32.cmi :
-int64.cmo : pervasives.cmi int64.cmi
-int64.cmx : pervasives.cmx int64.cmi
+int64.cmo : \
+  int64.cmi \
+  pervasives.cmi
+int64.cmx : \
+  int64.cmi \
+  pervasives.cmx
 int64.cmi :
-lazy.cmo : obj.cmi camlinternalLazy.cmi lazy.cmi
-lazy.cmx : obj.cmx camlinternalLazy.cmx lazy.cmi
+lazy.cmo : \
+  camlinternalLazy.cmi \
+  lazy.cmi \
+  obj.cmi
+lazy.cmx : \
+  camlinternalLazy.cmx \
+  lazy.cmi \
+  obj.cmx
 lazy.cmi :
-lexing.cmo : sys.cmi string.cmi bytes.cmi array.cmi lexing.cmi
-lexing.cmx : sys.cmx string.cmx bytes.cmx array.cmx lexing.cmi
+lexing.cmo : \
+  array.cmi \
+  bytes.cmi \
+  lexing.cmi \
+  string.cmi \
+  sys.cmi
+lexing.cmx : \
+  array.cmx \
+  bytes.cmx \
+  lexing.cmi \
+  string.cmx \
+  sys.cmx
 lexing.cmi :
-list.cmo : list.cmi
-list.cmx : list.cmi
+list.cmo : \
+  list.cmi
+list.cmx : \
+  list.cmi
 list.cmi :
-listLabels.cmo : list.cmi listLabels.cmi
-listLabels.cmx : list.cmx listLabels.cmi
+listLabels.cmo : \
+  list.cmi \
+  listLabels.cmi
+listLabels.cmx : \
+  list.cmx \
+  listLabels.cmi
 listLabels.cmi :
-map.cmo : map.cmi
-map.cmx : map.cmi
+map.cmo : \
+  map.cmi
+map.cmx : \
+  map.cmi
 map.cmi :
-marshal.cmo : bytes.cmi marshal.cmi
-marshal.cmx : bytes.cmx marshal.cmi
+marshal.cmo : \
+  bytes.cmi \
+  marshal.cmi
+marshal.cmx : \
+  bytes.cmx \
+  marshal.cmi
 marshal.cmi :
-moreLabels.cmo : set.cmi map.cmi hashtbl.cmi moreLabels.cmi
-moreLabels.cmx : set.cmx map.cmx hashtbl.cmx moreLabels.cmi
-moreLabels.cmi : set.cmi map.cmi hashtbl.cmi
-nativeint.cmo : sys.cmi pervasives.cmi nativeint.cmi
-nativeint.cmx : sys.cmx pervasives.cmx nativeint.cmi
+moreLabels.cmo : \
+  hashtbl.cmi \
+  map.cmi \
+  moreLabels.cmi \
+  set.cmi
+moreLabels.cmx : \
+  hashtbl.cmx \
+  map.cmx \
+  moreLabels.cmi \
+  set.cmx
+moreLabels.cmi : \
+  hashtbl.cmi \
+  map.cmi \
+  set.cmi
+nativeint.cmo : \
+  nativeint.cmi \
+  pervasives.cmi \
+  sys.cmi
+nativeint.cmx : \
+  nativeint.cmi \
+  pervasives.cmx \
+  sys.cmx
 nativeint.cmi :
-obj.cmo : marshal.cmi int32.cmi obj.cmi
-obj.cmx : marshal.cmx int32.cmx obj.cmi
-obj.cmi : int32.cmi
-oo.cmo : camlinternalOO.cmi oo.cmi
-oo.cmx : camlinternalOO.cmx oo.cmi
-oo.cmi : camlinternalOO.cmi
-parsing.cmo : obj.cmi lexing.cmi array.cmi parsing.cmi
-parsing.cmx : obj.cmx lexing.cmx array.cmx parsing.cmi
-parsing.cmi : obj.cmi lexing.cmi
-pervasives.cmo : camlinternalFormatBasics.cmi pervasives.cmi
-pervasives.cmx : camlinternalFormatBasics.cmx pervasives.cmi
-pervasives.cmi : camlinternalFormatBasics.cmi
-printexc.cmo : printf.cmi pervasives.cmi obj.cmi buffer.cmi array.cmi \
-    printexc.cmi
-printexc.cmx : printf.cmx pervasives.cmx obj.cmx buffer.cmx array.cmx \
-    printexc.cmi
+obj.cmo : \
+  int32.cmi \
+  marshal.cmi \
+  obj.cmi
+obj.cmx : \
+  int32.cmx \
+  marshal.cmx \
+  obj.cmi
+obj.cmi : \
+  int32.cmi
+oo.cmo : \
+  camlinternalOO.cmi \
+  oo.cmi
+oo.cmx : \
+  camlinternalOO.cmx \
+  oo.cmi
+oo.cmi : \
+  camlinternalOO.cmi
+parsing.cmo : \
+  array.cmi \
+  lexing.cmi \
+  obj.cmi \
+  parsing.cmi
+parsing.cmx : \
+  array.cmx \
+  lexing.cmx \
+  obj.cmx \
+  parsing.cmi
+parsing.cmi : \
+  lexing.cmi \
+  obj.cmi
+pervasives.cmo : \
+  camlinternalFormatBasics.cmi \
+  pervasives.cmi
+pervasives.cmx : \
+  camlinternalFormatBasics.cmx \
+  pervasives.cmi
+pervasives.cmi : \
+  camlinternalFormatBasics.cmi
+printexc.cmo : \
+  array.cmi \
+  buffer.cmi \
+  obj.cmi \
+  pervasives.cmi \
+  printexc.cmi \
+  printf.cmi
+printexc.cmx : \
+  array.cmx \
+  buffer.cmx \
+  obj.cmx \
+  pervasives.cmx \
+  printexc.cmi \
+  printf.cmx
 printexc.cmi :
-printf.cmo : camlinternalFormatBasics.cmi camlinternalFormat.cmi buffer.cmi \
-    printf.cmi
-printf.cmx : camlinternalFormatBasics.cmx camlinternalFormat.cmx buffer.cmx \
-    printf.cmi
-printf.cmi : buffer.cmi
-queue.cmo : queue.cmi
-queue.cmx : queue.cmi
+printf.cmo : \
+  buffer.cmi \
+  camlinternalFormat.cmi \
+  camlinternalFormatBasics.cmi \
+  printf.cmi
+printf.cmx : \
+  buffer.cmx \
+  camlinternalFormat.cmx \
+  camlinternalFormatBasics.cmx \
+  printf.cmi
+printf.cmi : \
+  buffer.cmi
+queue.cmo : \
+  queue.cmi
+queue.cmx : \
+  queue.cmi
 queue.cmi :
-random.cmo : string.cmi pervasives.cmi nativeint.cmi int64.cmi int32.cmi \
-    digest.cmi char.cmi array.cmi random.cmi
-random.cmx : string.cmx pervasives.cmx nativeint.cmx int64.cmx int32.cmx \
-    digest.cmx char.cmx array.cmx random.cmi
-random.cmi : nativeint.cmi int64.cmi int32.cmi
-scanf.cmo : string.cmi printf.cmi pervasives.cmi list.cmi \
-    camlinternalFormatBasics.cmi camlinternalFormat.cmi bytes.cmi buffer.cmi \
-    scanf.cmi
-scanf.cmx : string.cmx printf.cmx pervasives.cmx list.cmx \
-    camlinternalFormatBasics.cmx camlinternalFormat.cmx bytes.cmx buffer.cmx \
-    scanf.cmi
-scanf.cmi : pervasives.cmi
-set.cmo : list.cmi set.cmi
-set.cmx : list.cmx set.cmi
+random.cmo : \
+  array.cmi \
+  char.cmi \
+  digest.cmi \
+  int32.cmi \
+  int64.cmi \
+  nativeint.cmi \
+  pervasives.cmi \
+  random.cmi \
+  string.cmi
+random.cmx : \
+  array.cmx \
+  char.cmx \
+  digest.cmx \
+  int32.cmx \
+  int64.cmx \
+  nativeint.cmx \
+  pervasives.cmx \
+  random.cmi \
+  string.cmx
+random.cmi : \
+  int32.cmi \
+  int64.cmi \
+  nativeint.cmi
+scanf.cmo : \
+  buffer.cmi \
+  bytes.cmi \
+  camlinternalFormat.cmi \
+  camlinternalFormatBasics.cmi \
+  list.cmi \
+  pervasives.cmi \
+  printf.cmi \
+  scanf.cmi \
+  string.cmi
+scanf.cmx : \
+  buffer.cmx \
+  bytes.cmx \
+  camlinternalFormat.cmx \
+  camlinternalFormatBasics.cmx \
+  list.cmx \
+  pervasives.cmx \
+  printf.cmx \
+  scanf.cmi \
+  string.cmx
+scanf.cmi : \
+  pervasives.cmi
+set.cmo : \
+  list.cmi \
+  set.cmi
+set.cmx : \
+  list.cmx \
+  set.cmi
 set.cmi :
-sort.cmo : array.cmi sort.cmi
-sort.cmx : array.cmx sort.cmi
+sort.cmo : \
+  array.cmi \
+  sort.cmi
+sort.cmx : \
+  array.cmx \
+  sort.cmi
 sort.cmi :
-spacetime.cmo : gc.cmi spacetime.cmi
-spacetime.cmx : gc.cmx spacetime.cmi
+spacetime.cmo : \
+  gc.cmi \
+  spacetime.cmi
+spacetime.cmx : \
+  gc.cmx \
+  spacetime.cmi
 spacetime.cmi :
-stack.cmo : list.cmi stack.cmi
-stack.cmx : list.cmx stack.cmi
+stack.cmo : \
+  list.cmi \
+  stack.cmi
+stack.cmx : \
+  list.cmx \
+  stack.cmi
 stack.cmi :
-stdLabels.cmo : stringLabels.cmi listLabels.cmi bytesLabels.cmi \
-    arrayLabels.cmi stdLabels.cmi
-stdLabels.cmx : stringLabels.cmx listLabels.cmx bytesLabels.cmx \
-    arrayLabels.cmx stdLabels.cmi
-stdLabels.cmi : stringLabels.cmi listLabels.cmi bytesLabels.cmi \
-    arrayLabels.cmi
+stdLabels.cmo : \
+  arrayLabels.cmi \
+  bytesLabels.cmi \
+  listLabels.cmi \
+  stdLabels.cmi \
+  stringLabels.cmi
+stdLabels.cmx : \
+  arrayLabels.cmx \
+  bytesLabels.cmx \
+  listLabels.cmx \
+  stdLabels.cmi \
+  stringLabels.cmx
+stdLabels.cmi : \
+  arrayLabels.cmi \
+  bytesLabels.cmi \
+  listLabels.cmi \
+  stringLabels.cmi
 std_exit.cmo :
 std_exit.cmx :
-stream.cmo : string.cmi list.cmi lazy.cmi bytes.cmi stream.cmi
-stream.cmx : string.cmx list.cmx lazy.cmx bytes.cmx stream.cmi
+stream.cmo : \
+  bytes.cmi \
+  lazy.cmi \
+  list.cmi \
+  stream.cmi \
+  string.cmi
+stream.cmx : \
+  bytes.cmx \
+  lazy.cmx \
+  list.cmx \
+  stream.cmi \
+  string.cmx
 stream.cmi :
-string.cmo : pervasives.cmi bytes.cmi string.cmi
-string.cmx : pervasives.cmx bytes.cmx string.cmi
+string.cmo : \
+  bytes.cmi \
+  pervasives.cmi \
+  string.cmi
+string.cmx : \
+  bytes.cmx \
+  pervasives.cmx \
+  string.cmi
 string.cmi :
-stringLabels.cmo : string.cmi stringLabels.cmi
-stringLabels.cmx : string.cmx stringLabels.cmi
+stringLabels.cmo : \
+  string.cmi \
+  stringLabels.cmi
+stringLabels.cmx : \
+  string.cmx \
+  stringLabels.cmi
 stringLabels.cmi :
-sys.cmo : sys.cmi
-sys.cmx : sys.cmi
+sys.cmo : \
+  sys.cmi
+sys.cmx : \
+  sys.cmi
 sys.cmi :
-uchar.cmo : pervasives.cmi char.cmi uchar.cmi
-uchar.cmx : pervasives.cmx char.cmx uchar.cmi
+uchar.cmo : \
+  char.cmi \
+  pervasives.cmi \
+  uchar.cmi
+uchar.cmx : \
+  char.cmx \
+  pervasives.cmx \
+  uchar.cmi
 uchar.cmi :
-weak.cmo : sys.cmi obj.cmi hashtbl.cmi array.cmi weak.cmi
-weak.cmx : sys.cmx obj.cmx hashtbl.cmx array.cmx weak.cmi
-weak.cmi : hashtbl.cmi
-arg.cmo : sys.cmi string.cmi printf.cmi list.cmi buffer.cmi array.cmi \
-    arg.cmi
-arg.p.cmx : sys.cmx string.cmx printf.cmx list.cmx buffer.cmx array.cmx \
-    arg.cmi
-array.cmo : array.cmi
-array.p.cmx : array.cmi
-arrayLabels.cmo : array.cmi arrayLabels.cmi
-arrayLabels.p.cmx : array.cmx arrayLabels.cmi
-buffer.cmo : uchar.cmi sys.cmi string.cmi char.cmi bytes.cmi buffer.cmi
-buffer.p.cmx : uchar.cmx sys.cmx string.cmx char.cmx bytes.cmx buffer.cmi
-bytes.cmo : pervasives.cmi char.cmi bytes.cmi
-bytes.p.cmx : pervasives.cmx char.cmx bytes.cmi
-bytesLabels.cmo : bytes.cmi bytesLabels.cmi
-bytesLabels.p.cmx : bytes.cmx bytesLabels.cmi
-callback.cmo : obj.cmi callback.cmi
-callback.p.cmx : obj.cmx callback.cmi
-camlinternalBigarray.cmo : complex.cmi
-camlinternalBigarray.p.cmx : complex.cmx
-camlinternalFormat.cmo : sys.cmi string.cmi char.cmi \
-    camlinternalFormatBasics.cmi bytes.cmi buffer.cmi camlinternalFormat.cmi
-camlinternalFormat.p.cmx : sys.cmx string.cmx char.cmx \
-    camlinternalFormatBasics.cmx bytes.cmx buffer.cmx camlinternalFormat.cmi
-camlinternalFormatBasics.cmo : camlinternalFormatBasics.cmi
-camlinternalFormatBasics.p.cmx : camlinternalFormatBasics.cmi
-camlinternalLazy.cmo : obj.cmi camlinternalLazy.cmi
-camlinternalLazy.p.cmx : obj.cmx camlinternalLazy.cmi
-camlinternalMod.cmo : obj.cmi camlinternalOO.cmi array.cmi \
-    camlinternalMod.cmi
-camlinternalMod.p.cmx : obj.cmx camlinternalOO.cmx array.cmx \
-    camlinternalMod.cmi
-camlinternalOO.cmo : sys.cmi string.cmi obj.cmi map.cmi list.cmi char.cmi \
-    array.cmi camlinternalOO.cmi
-camlinternalOO.p.cmx : sys.cmx string.cmx obj.cmx map.cmx list.cmx char.cmx \
-    array.cmx camlinternalOO.cmi
-char.cmo : char.cmi
-char.p.cmx : char.cmi
-complex.cmo : complex.cmi
-complex.p.cmx : complex.cmi
-digest.cmo : string.cmi char.cmi bytes.cmi digest.cmi
-digest.p.cmx : string.cmx char.cmx bytes.cmx digest.cmi
-ephemeron.cmo : sys.cmi random.cmi obj.cmi lazy.cmi hashtbl.cmi array.cmi \
-    ephemeron.cmi
-ephemeron.p.cmx : sys.cmx random.cmx obj.cmx lazy.cmx hashtbl.cmx array.cmx \
-    ephemeron.cmi
-filename.cmo : sys.cmi string.cmi random.cmi printf.cmi lazy.cmi buffer.cmi \
-    filename.cmi
-filename.p.cmx : sys.cmx string.cmx random.cmx printf.cmx lazy.cmx buffer.cmx \
-    filename.cmi
-format.cmo : string.cmi pervasives.cmi list.cmi camlinternalFormatBasics.cmi \
-    camlinternalFormat.cmi buffer.cmi format.cmi
-format.p.cmx : string.cmx pervasives.cmx list.cmx camlinternalFormatBasics.cmx \
-    camlinternalFormat.cmx buffer.cmx format.cmi
-gc.cmo : sys.cmi string.cmi printf.cmi gc.cmi
-gc.p.cmx : sys.cmx string.cmx printf.cmx gc.cmi
-genlex.cmo : string.cmi stream.cmi list.cmi hashtbl.cmi char.cmi bytes.cmi \
-    genlex.cmi
-genlex.p.cmx : string.cmx stream.cmx list.cmx hashtbl.cmx char.cmx bytes.cmx \
-    genlex.cmi
-hashtbl.cmo : sys.cmi string.cmi random.cmi obj.cmi lazy.cmi array.cmi \
-    hashtbl.cmi
-hashtbl.p.cmx : sys.cmx string.cmx random.cmx obj.cmx lazy.cmx array.cmx \
-    hashtbl.cmi
-int32.cmo : pervasives.cmi int32.cmi
-int32.p.cmx : pervasives.cmx int32.cmi
-int64.cmo : pervasives.cmi int64.cmi
-int64.p.cmx : pervasives.cmx int64.cmi
-lazy.cmo : obj.cmi camlinternalLazy.cmi lazy.cmi
-lazy.p.cmx : obj.cmx camlinternalLazy.cmx lazy.cmi
-lexing.cmo : sys.cmi string.cmi bytes.cmi array.cmi lexing.cmi
-lexing.p.cmx : sys.cmx string.cmx bytes.cmx array.cmx lexing.cmi
-list.cmo : list.cmi
-list.p.cmx : list.cmi
-listLabels.cmo : list.cmi listLabels.cmi
-listLabels.p.cmx : list.cmx listLabels.cmi
-map.cmo : map.cmi
-map.p.cmx : map.cmi
-marshal.cmo : bytes.cmi marshal.cmi
-marshal.p.cmx : bytes.cmx marshal.cmi
-moreLabels.cmo : set.cmi map.cmi hashtbl.cmi moreLabels.cmi
-moreLabels.p.cmx : set.cmx map.cmx hashtbl.cmx moreLabels.cmi
-nativeint.cmo : sys.cmi pervasives.cmi nativeint.cmi
-nativeint.p.cmx : sys.cmx pervasives.cmx nativeint.cmi
-obj.cmo : marshal.cmi int32.cmi obj.cmi
-obj.p.cmx : marshal.cmx int32.cmx obj.cmi
-oo.cmo : camlinternalOO.cmi oo.cmi
-oo.p.cmx : camlinternalOO.cmx oo.cmi
-parsing.cmo : obj.cmi lexing.cmi array.cmi parsing.cmi
-parsing.p.cmx : obj.cmx lexing.cmx array.cmx parsing.cmi
-pervasives.cmo : camlinternalFormatBasics.cmi pervasives.cmi
-pervasives.p.cmx : camlinternalFormatBasics.cmx pervasives.cmi
-printexc.cmo : printf.cmi pervasives.cmi obj.cmi buffer.cmi array.cmi \
-    printexc.cmi
-printexc.p.cmx : printf.cmx pervasives.cmx obj.cmx buffer.cmx array.cmx \
-    printexc.cmi
-printf.cmo : camlinternalFormatBasics.cmi camlinternalFormat.cmi buffer.cmi \
-    printf.cmi
-printf.p.cmx : camlinternalFormatBasics.cmx camlinternalFormat.cmx buffer.cmx \
-    printf.cmi
-queue.cmo : queue.cmi
-queue.p.cmx : queue.cmi
-random.cmo : string.cmi pervasives.cmi nativeint.cmi int64.cmi int32.cmi \
-    digest.cmi char.cmi array.cmi random.cmi
-random.p.cmx : string.cmx pervasives.cmx nativeint.cmx int64.cmx int32.cmx \
-    digest.cmx char.cmx array.cmx random.cmi
-scanf.cmo : string.cmi printf.cmi pervasives.cmi list.cmi \
-    camlinternalFormatBasics.cmi camlinternalFormat.cmi bytes.cmi buffer.cmi \
-    scanf.cmi
-scanf.p.cmx : string.cmx printf.cmx pervasives.cmx list.cmx \
-    camlinternalFormatBasics.cmx camlinternalFormat.cmx bytes.cmx buffer.cmx \
-    scanf.cmi
-set.cmo : list.cmi set.cmi
-set.p.cmx : list.cmx set.cmi
-sort.cmo : array.cmi sort.cmi
-sort.p.cmx : array.cmx sort.cmi
-spacetime.cmo : gc.cmi spacetime.cmi
-spacetime.p.cmx : gc.cmx spacetime.cmi
-stack.cmo : list.cmi stack.cmi
-stack.p.cmx : list.cmx stack.cmi
-stdLabels.cmo : stringLabels.cmi listLabels.cmi bytesLabels.cmi \
-    arrayLabels.cmi stdLabels.cmi
-stdLabels.p.cmx : stringLabels.cmx listLabels.cmx bytesLabels.cmx \
-    arrayLabels.cmx stdLabels.cmi
+weak.cmo : \
+  array.cmi \
+  hashtbl.cmi \
+  obj.cmi \
+  sys.cmi \
+  weak.cmi
+weak.cmx : \
+  array.cmx \
+  hashtbl.cmx \
+  obj.cmx \
+  sys.cmx \
+  weak.cmi
+weak.cmi : \
+  hashtbl.cmi
+arg.cmo : \
+  arg.cmi \
+  array.cmi \
+  buffer.cmi \
+  list.cmi \
+  printf.cmi \
+  string.cmi \
+  sys.cmi
+arg.p.cmx : \
+  arg.cmi \
+  array.cmx \
+  buffer.cmx \
+  list.cmx \
+  printf.cmx \
+  string.cmx \
+  sys.cmx
+array.cmo : \
+  array.cmi
+array.p.cmx : \
+  array.cmi
+arrayLabels.cmo : \
+  array.cmi \
+  arrayLabels.cmi
+arrayLabels.p.cmx : \
+  array.cmx \
+  arrayLabels.cmi
+buffer.cmo : \
+  buffer.cmi \
+  bytes.cmi \
+  char.cmi \
+  string.cmi \
+  sys.cmi \
+  uchar.cmi
+buffer.p.cmx : \
+  buffer.cmi \
+  bytes.cmx \
+  char.cmx \
+  string.cmx \
+  sys.cmx \
+  uchar.cmx
+bytes.cmo : \
+  bytes.cmi \
+  char.cmi \
+  pervasives.cmi
+bytes.p.cmx : \
+  bytes.cmi \
+  char.cmx \
+  pervasives.cmx
+bytesLabels.cmo : \
+  bytes.cmi \
+  bytesLabels.cmi
+bytesLabels.p.cmx : \
+  bytes.cmx \
+  bytesLabels.cmi
+callback.cmo : \
+  callback.cmi \
+  obj.cmi
+callback.p.cmx : \
+  callback.cmi \
+  obj.cmx
+camlinternalBigarray.cmo : \
+  complex.cmi
+camlinternalBigarray.p.cmx : \
+  complex.cmx
+camlinternalFormat.cmo : \
+  buffer.cmi \
+  bytes.cmi \
+  camlinternalFormat.cmi \
+  camlinternalFormatBasics.cmi \
+  char.cmi \
+  string.cmi \
+  sys.cmi
+camlinternalFormat.p.cmx : \
+  buffer.cmx \
+  bytes.cmx \
+  camlinternalFormat.cmi \
+  camlinternalFormatBasics.cmx \
+  char.cmx \
+  string.cmx \
+  sys.cmx
+camlinternalFormatBasics.cmo : \
+  camlinternalFormatBasics.cmi
+camlinternalFormatBasics.p.cmx : \
+  camlinternalFormatBasics.cmi
+camlinternalLazy.cmo : \
+  camlinternalLazy.cmi \
+  obj.cmi
+camlinternalLazy.p.cmx : \
+  camlinternalLazy.cmi \
+  obj.cmx
+camlinternalMod.cmo : \
+  array.cmi \
+  camlinternalMod.cmi \
+  camlinternalOO.cmi \
+  obj.cmi
+camlinternalMod.p.cmx : \
+  array.cmx \
+  camlinternalMod.cmi \
+  camlinternalOO.cmx \
+  obj.cmx
+camlinternalOO.cmo : \
+  array.cmi \
+  camlinternalOO.cmi \
+  char.cmi \
+  list.cmi \
+  map.cmi \
+  obj.cmi \
+  string.cmi \
+  sys.cmi
+camlinternalOO.p.cmx : \
+  array.cmx \
+  camlinternalOO.cmi \
+  char.cmx \
+  list.cmx \
+  map.cmx \
+  obj.cmx \
+  string.cmx \
+  sys.cmx
+char.cmo : \
+  char.cmi
+char.p.cmx : \
+  char.cmi
+complex.cmo : \
+  complex.cmi
+complex.p.cmx : \
+  complex.cmi
+digest.cmo : \
+  bytes.cmi \
+  char.cmi \
+  digest.cmi \
+  string.cmi
+digest.p.cmx : \
+  bytes.cmx \
+  char.cmx \
+  digest.cmi \
+  string.cmx
+ephemeron.cmo : \
+  array.cmi \
+  ephemeron.cmi \
+  hashtbl.cmi \
+  lazy.cmi \
+  obj.cmi \
+  random.cmi \
+  sys.cmi
+ephemeron.p.cmx : \
+  array.cmx \
+  ephemeron.cmi \
+  hashtbl.cmx \
+  lazy.cmx \
+  obj.cmx \
+  random.cmx \
+  sys.cmx
+filename.cmo : \
+  buffer.cmi \
+  filename.cmi \
+  lazy.cmi \
+  printf.cmi \
+  random.cmi \
+  string.cmi \
+  sys.cmi
+filename.p.cmx : \
+  buffer.cmx \
+  filename.cmi \
+  lazy.cmx \
+  printf.cmx \
+  random.cmx \
+  string.cmx \
+  sys.cmx
+format.cmo : \
+  buffer.cmi \
+  camlinternalFormat.cmi \
+  camlinternalFormatBasics.cmi \
+  format.cmi \
+  list.cmi \
+  pervasives.cmi \
+  string.cmi
+format.p.cmx : \
+  buffer.cmx \
+  camlinternalFormat.cmx \
+  camlinternalFormatBasics.cmx \
+  format.cmi \
+  list.cmx \
+  pervasives.cmx \
+  string.cmx
+gc.cmo : \
+  gc.cmi \
+  printf.cmi \
+  string.cmi \
+  sys.cmi
+gc.p.cmx : \
+  gc.cmi \
+  printf.cmx \
+  string.cmx \
+  sys.cmx
+genlex.cmo : \
+  bytes.cmi \
+  char.cmi \
+  genlex.cmi \
+  hashtbl.cmi \
+  list.cmi \
+  stream.cmi \
+  string.cmi
+genlex.p.cmx : \
+  bytes.cmx \
+  char.cmx \
+  genlex.cmi \
+  hashtbl.cmx \
+  list.cmx \
+  stream.cmx \
+  string.cmx
+hashtbl.cmo : \
+  array.cmi \
+  hashtbl.cmi \
+  lazy.cmi \
+  obj.cmi \
+  random.cmi \
+  string.cmi \
+  sys.cmi
+hashtbl.p.cmx : \
+  array.cmx \
+  hashtbl.cmi \
+  lazy.cmx \
+  obj.cmx \
+  random.cmx \
+  string.cmx \
+  sys.cmx
+int32.cmo : \
+  int32.cmi \
+  pervasives.cmi
+int32.p.cmx : \
+  int32.cmi \
+  pervasives.cmx
+int64.cmo : \
+  int64.cmi \
+  pervasives.cmi
+int64.p.cmx : \
+  int64.cmi \
+  pervasives.cmx
+lazy.cmo : \
+  camlinternalLazy.cmi \
+  lazy.cmi \
+  obj.cmi
+lazy.p.cmx : \
+  camlinternalLazy.cmx \
+  lazy.cmi \
+  obj.cmx
+lexing.cmo : \
+  array.cmi \
+  bytes.cmi \
+  lexing.cmi \
+  string.cmi \
+  sys.cmi
+lexing.p.cmx : \
+  array.cmx \
+  bytes.cmx \
+  lexing.cmi \
+  string.cmx \
+  sys.cmx
+list.cmo : \
+  list.cmi
+list.p.cmx : \
+  list.cmi
+listLabels.cmo : \
+  list.cmi \
+  listLabels.cmi
+listLabels.p.cmx : \
+  list.cmx \
+  listLabels.cmi
+map.cmo : \
+  map.cmi
+map.p.cmx : \
+  map.cmi
+marshal.cmo : \
+  bytes.cmi \
+  marshal.cmi
+marshal.p.cmx : \
+  bytes.cmx \
+  marshal.cmi
+moreLabels.cmo : \
+  hashtbl.cmi \
+  map.cmi \
+  moreLabels.cmi \
+  set.cmi
+moreLabels.p.cmx : \
+  hashtbl.cmx \
+  map.cmx \
+  moreLabels.cmi \
+  set.cmx
+nativeint.cmo : \
+  nativeint.cmi \
+  pervasives.cmi \
+  sys.cmi
+nativeint.p.cmx : \
+  nativeint.cmi \
+  pervasives.cmx \
+  sys.cmx
+obj.cmo : \
+  int32.cmi \
+  marshal.cmi \
+  obj.cmi
+obj.p.cmx : \
+  int32.cmx \
+  marshal.cmx \
+  obj.cmi
+oo.cmo : \
+  camlinternalOO.cmi \
+  oo.cmi
+oo.p.cmx : \
+  camlinternalOO.cmx \
+  oo.cmi
+parsing.cmo : \
+  array.cmi \
+  lexing.cmi \
+  obj.cmi \
+  parsing.cmi
+parsing.p.cmx : \
+  array.cmx \
+  lexing.cmx \
+  obj.cmx \
+  parsing.cmi
+pervasives.cmo : \
+  camlinternalFormatBasics.cmi \
+  pervasives.cmi
+pervasives.p.cmx : \
+  camlinternalFormatBasics.cmx \
+  pervasives.cmi
+printexc.cmo : \
+  array.cmi \
+  buffer.cmi \
+  obj.cmi \
+  pervasives.cmi \
+  printexc.cmi \
+  printf.cmi
+printexc.p.cmx : \
+  array.cmx \
+  buffer.cmx \
+  obj.cmx \
+  pervasives.cmx \
+  printexc.cmi \
+  printf.cmx
+printf.cmo : \
+  buffer.cmi \
+  camlinternalFormat.cmi \
+  camlinternalFormatBasics.cmi \
+  printf.cmi
+printf.p.cmx : \
+  buffer.cmx \
+  camlinternalFormat.cmx \
+  camlinternalFormatBasics.cmx \
+  printf.cmi
+queue.cmo : \
+  queue.cmi
+queue.p.cmx : \
+  queue.cmi
+random.cmo : \
+  array.cmi \
+  char.cmi \
+  digest.cmi \
+  int32.cmi \
+  int64.cmi \
+  nativeint.cmi \
+  pervasives.cmi \
+  random.cmi \
+  string.cmi
+random.p.cmx : \
+  array.cmx \
+  char.cmx \
+  digest.cmx \
+  int32.cmx \
+  int64.cmx \
+  nativeint.cmx \
+  pervasives.cmx \
+  random.cmi \
+  string.cmx
+scanf.cmo : \
+  buffer.cmi \
+  bytes.cmi \
+  camlinternalFormat.cmi \
+  camlinternalFormatBasics.cmi \
+  list.cmi \
+  pervasives.cmi \
+  printf.cmi \
+  scanf.cmi \
+  string.cmi
+scanf.p.cmx : \
+  buffer.cmx \
+  bytes.cmx \
+  camlinternalFormat.cmx \
+  camlinternalFormatBasics.cmx \
+  list.cmx \
+  pervasives.cmx \
+  printf.cmx \
+  scanf.cmi \
+  string.cmx
+set.cmo : \
+  list.cmi \
+  set.cmi
+set.p.cmx : \
+  list.cmx \
+  set.cmi
+sort.cmo : \
+  array.cmi \
+  sort.cmi
+sort.p.cmx : \
+  array.cmx \
+  sort.cmi
+spacetime.cmo : \
+  gc.cmi \
+  spacetime.cmi
+spacetime.p.cmx : \
+  gc.cmx \
+  spacetime.cmi
+stack.cmo : \
+  list.cmi \
+  stack.cmi
+stack.p.cmx : \
+  list.cmx \
+  stack.cmi
+stdLabels.cmo : \
+  arrayLabels.cmi \
+  bytesLabels.cmi \
+  listLabels.cmi \
+  stdLabels.cmi \
+  stringLabels.cmi
+stdLabels.p.cmx : \
+  arrayLabels.cmx \
+  bytesLabels.cmx \
+  listLabels.cmx \
+  stdLabels.cmi \
+  stringLabels.cmx
 std_exit.cmo :
 std_exit.cmx :
-stream.cmo : string.cmi list.cmi lazy.cmi bytes.cmi stream.cmi
-stream.p.cmx : string.cmx list.cmx lazy.cmx bytes.cmx stream.cmi
-string.cmo : pervasives.cmi bytes.cmi string.cmi
-string.p.cmx : pervasives.cmx bytes.cmx string.cmi
-stringLabels.cmo : string.cmi stringLabels.cmi
-stringLabels.p.cmx : string.cmx stringLabels.cmi
-sys.cmo : sys.cmi
-sys.p.cmx : sys.cmi
-uchar.cmo : pervasives.cmi char.cmi uchar.cmi
-uchar.p.cmx : pervasives.cmx char.cmx uchar.cmi
-weak.cmo : sys.cmi obj.cmi hashtbl.cmi array.cmi weak.cmi
-weak.p.cmx : sys.cmx obj.cmx hashtbl.cmx array.cmx weak.cmi
+stream.cmo : \
+  bytes.cmi \
+  lazy.cmi \
+  list.cmi \
+  stream.cmi \
+  string.cmi
+stream.p.cmx : \
+  bytes.cmx \
+  lazy.cmx \
+  list.cmx \
+  stream.cmi \
+  string.cmx
+string.cmo : \
+  bytes.cmi \
+  pervasives.cmi \
+  string.cmi
+string.p.cmx : \
+  bytes.cmx \
+  pervasives.cmx \
+  string.cmi
+stringLabels.cmo : \
+  string.cmi \
+  stringLabels.cmi
+stringLabels.p.cmx : \
+  string.cmx \
+  stringLabels.cmi
+sys.cmo : \
+  sys.cmi
+sys.p.cmx : \
+  sys.cmi
+uchar.cmo : \
+  char.cmi \
+  pervasives.cmi \
+  uchar.cmi
+uchar.p.cmx : \
+  char.cmx \
+  pervasives.cmx \
+  uchar.cmi
+weak.cmo : \
+  array.cmi \
+  hashtbl.cmi \
+  obj.cmi \
+  sys.cmi \
+  weak.cmi
+weak.p.cmx : \
+  array.cmx \
+  hashtbl.cmx \
+  obj.cmx \
+  sys.cmx \
+  weak.cmi

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -248,3 +248,4 @@ include .depend
 depend:
 	$(CAMLDEP) -slash *.mli *.ml > .depend
 	$(CAMLDEP) -slash *.ml | sed -e 's/\.cmx : /.p.cmx : /g' >>.depend
+	../tools/normalize_depend .depend

--- a/tools/.depend
+++ b/tools/.depend
@@ -1,93 +1,227 @@
-addlabels.cmo : ../parsing/parsetree.cmi ../parsing/parse.cmi \
-    ../parsing/longident.cmi ../parsing/location.cmi ../parsing/asttypes.cmi
-addlabels.cmx : ../parsing/parsetree.cmi ../parsing/parse.cmx \
-    ../parsing/longident.cmx ../parsing/location.cmx ../parsing/asttypes.cmi
-cmpbyt.cmo : ../bytecomp/bytesections.cmi
-cmpbyt.cmx : ../bytecomp/bytesections.cmx
-cmt2annot.cmo : ../typing/untypeast.cmi ../typing/types.cmi \
-    ../typing/typedtree.cmi ../typing/tast_mapper.cmi ../typing/stypes.cmi \
-    ../parsing/pprintast.cmi ../typing/path.cmi ../typing/oprint.cmi \
-    ../parsing/location.cmi ../typing/ident.cmi ../typing/envaux.cmi \
-    ../typing/env.cmi ../utils/config.cmi ../typing/cmt_format.cmi \
-    ../parsing/asttypes.cmi ../typing/annot.cmi
-cmt2annot.cmx : ../typing/untypeast.cmx ../typing/types.cmx \
-    ../typing/typedtree.cmx ../typing/tast_mapper.cmx ../typing/stypes.cmx \
-    ../parsing/pprintast.cmx ../typing/path.cmx ../typing/oprint.cmx \
-    ../parsing/location.cmx ../typing/ident.cmx ../typing/envaux.cmx \
-    ../typing/env.cmx ../utils/config.cmx ../typing/cmt_format.cmx \
-    ../parsing/asttypes.cmi ../typing/annot.cmi
+addlabels.cmo : \
+  ../parsing/asttypes.cmi \
+  ../parsing/location.cmi \
+  ../parsing/longident.cmi \
+  ../parsing/parse.cmi \
+  ../parsing/parsetree.cmi
+addlabels.cmx : \
+  ../parsing/asttypes.cmi \
+  ../parsing/location.cmx \
+  ../parsing/longident.cmx \
+  ../parsing/parse.cmx \
+  ../parsing/parsetree.cmi
+cmpbyt.cmo : \
+  ../bytecomp/bytesections.cmi
+cmpbyt.cmx : \
+  ../bytecomp/bytesections.cmx
+cmt2annot.cmo : \
+  ../parsing/asttypes.cmi \
+  ../parsing/location.cmi \
+  ../parsing/pprintast.cmi \
+  ../typing/annot.cmi \
+  ../typing/cmt_format.cmi \
+  ../typing/env.cmi \
+  ../typing/envaux.cmi \
+  ../typing/ident.cmi \
+  ../typing/oprint.cmi \
+  ../typing/path.cmi \
+  ../typing/stypes.cmi \
+  ../typing/tast_mapper.cmi \
+  ../typing/typedtree.cmi \
+  ../typing/types.cmi \
+  ../typing/untypeast.cmi \
+  ../utils/config.cmi
+cmt2annot.cmx : \
+  ../parsing/asttypes.cmi \
+  ../parsing/location.cmx \
+  ../parsing/pprintast.cmx \
+  ../typing/annot.cmi \
+  ../typing/cmt_format.cmx \
+  ../typing/env.cmx \
+  ../typing/envaux.cmx \
+  ../typing/ident.cmx \
+  ../typing/oprint.cmx \
+  ../typing/path.cmx \
+  ../typing/stypes.cmx \
+  ../typing/tast_mapper.cmx \
+  ../typing/typedtree.cmx \
+  ../typing/types.cmx \
+  ../typing/untypeast.cmx \
+  ../utils/config.cmx
 cvt_emit.cmo :
 cvt_emit.cmx :
-dumpobj.cmo : ../utils/tbl.cmi opnames.cmo ../bytecomp/opcodes.cmo \
-    ../parsing/location.cmi ../bytecomp/lambda.cmi ../bytecomp/instruct.cmi \
-    ../typing/ident.cmi ../utils/config.cmi ../bytecomp/cmo_format.cmi \
-    ../bytecomp/bytesections.cmi ../parsing/asttypes.cmi
-dumpobj.cmx : ../utils/tbl.cmx opnames.cmx ../bytecomp/opcodes.cmx \
-    ../parsing/location.cmx ../bytecomp/lambda.cmx ../bytecomp/instruct.cmx \
-    ../typing/ident.cmx ../utils/config.cmx ../bytecomp/cmo_format.cmi \
-    ../bytecomp/bytesections.cmx ../parsing/asttypes.cmi
-eqparsetree.cmo : ../parsing/parsetree.cmi ../parsing/longident.cmi \
-    ../parsing/location.cmi ../parsing/asttypes.cmi
-eqparsetree.cmx : ../parsing/parsetree.cmi ../parsing/longident.cmx \
-    ../parsing/location.cmx ../parsing/asttypes.cmi
-lintapidiff.cmo : ../typing/printtyp.cmi ../driver/pparse.cmi \
-    ../typing/path.cmi ../parsing/parsetree.cmi ../parsing/parse.cmi \
-    ../utils/misc.cmi ../parsing/location.cmi ../typing/ident.cmi
-lintapidiff.cmx : ../typing/printtyp.cmx ../driver/pparse.cmx \
-    ../typing/path.cmx ../parsing/parsetree.cmi ../parsing/parse.cmx \
-    ../utils/misc.cmx ../parsing/location.cmx ../typing/ident.cmx
+dumpobj.cmo : \
+  ../bytecomp/bytesections.cmi \
+  ../bytecomp/cmo_format.cmi \
+  ../bytecomp/instruct.cmi \
+  ../bytecomp/lambda.cmi \
+  ../bytecomp/opcodes.cmo \
+  ../parsing/asttypes.cmi \
+  ../parsing/location.cmi \
+  ../typing/ident.cmi \
+  ../utils/config.cmi \
+  ../utils/tbl.cmi \
+  opnames.cmo
+dumpobj.cmx : \
+  ../bytecomp/bytesections.cmx \
+  ../bytecomp/cmo_format.cmi \
+  ../bytecomp/instruct.cmx \
+  ../bytecomp/lambda.cmx \
+  ../bytecomp/opcodes.cmx \
+  ../parsing/asttypes.cmi \
+  ../parsing/location.cmx \
+  ../typing/ident.cmx \
+  ../utils/config.cmx \
+  ../utils/tbl.cmx \
+  opnames.cmx
+eqparsetree.cmo : \
+  ../parsing/asttypes.cmi \
+  ../parsing/location.cmi \
+  ../parsing/longident.cmi \
+  ../parsing/parsetree.cmi
+eqparsetree.cmx : \
+  ../parsing/asttypes.cmi \
+  ../parsing/location.cmx \
+  ../parsing/longident.cmx \
+  ../parsing/parsetree.cmi
+lintapidiff.cmo : \
+  ../driver/pparse.cmi \
+  ../parsing/location.cmi \
+  ../parsing/parse.cmi \
+  ../parsing/parsetree.cmi \
+  ../typing/ident.cmi \
+  ../typing/path.cmi \
+  ../typing/printtyp.cmi \
+  ../utils/misc.cmi
+lintapidiff.cmx : \
+  ../driver/pparse.cmx \
+  ../parsing/location.cmx \
+  ../parsing/parse.cmx \
+  ../parsing/parsetree.cmi \
+  ../typing/ident.cmx \
+  ../typing/path.cmx \
+  ../typing/printtyp.cmx \
+  ../utils/misc.cmx
 make_opcodes.cmo :
 make_opcodes.cmx :
-objinfo.cmo : ../utils/tbl.cmi ../middle_end/base_types/symbol.cmi \
-    ../asmcomp/printclambda.cmi ../utils/misc.cmi \
-    ../middle_end/base_types/linkage_name.cmi ../typing/ident.cmi \
-    ../asmcomp/export_info.cmi ../utils/config.cmi \
-    ../middle_end/base_types/compilation_unit.cmi ../asmcomp/cmx_format.cmi \
-    ../typing/cmt_format.cmi ../bytecomp/cmo_format.cmi \
-    ../typing/cmi_format.cmi ../bytecomp/bytesections.cmi
-objinfo.cmx : ../utils/tbl.cmx ../middle_end/base_types/symbol.cmx \
-    ../asmcomp/printclambda.cmx ../utils/misc.cmx \
-    ../middle_end/base_types/linkage_name.cmx ../typing/ident.cmx \
-    ../asmcomp/export_info.cmx ../utils/config.cmx \
-    ../middle_end/base_types/compilation_unit.cmx ../asmcomp/cmx_format.cmi \
-    ../typing/cmt_format.cmx ../bytecomp/cmo_format.cmi \
-    ../typing/cmi_format.cmx ../bytecomp/bytesections.cmx
+objinfo.cmo : \
+  ../asmcomp/cmx_format.cmi \
+  ../asmcomp/export_info.cmi \
+  ../asmcomp/printclambda.cmi \
+  ../bytecomp/bytesections.cmi \
+  ../bytecomp/cmo_format.cmi \
+  ../middle_end/base_types/compilation_unit.cmi \
+  ../middle_end/base_types/linkage_name.cmi \
+  ../middle_end/base_types/symbol.cmi \
+  ../typing/cmi_format.cmi \
+  ../typing/cmt_format.cmi \
+  ../typing/ident.cmi \
+  ../utils/config.cmi \
+  ../utils/misc.cmi \
+  ../utils/tbl.cmi
+objinfo.cmx : \
+  ../asmcomp/cmx_format.cmi \
+  ../asmcomp/export_info.cmx \
+  ../asmcomp/printclambda.cmx \
+  ../bytecomp/bytesections.cmx \
+  ../bytecomp/cmo_format.cmi \
+  ../middle_end/base_types/compilation_unit.cmx \
+  ../middle_end/base_types/linkage_name.cmx \
+  ../middle_end/base_types/symbol.cmx \
+  ../typing/cmi_format.cmx \
+  ../typing/cmt_format.cmx \
+  ../typing/ident.cmx \
+  ../utils/config.cmx \
+  ../utils/misc.cmx \
+  ../utils/tbl.cmx
 ocaml299to3.cmo :
 ocaml299to3.cmx :
-ocamlcp.cmo : ../driver/main_args.cmi
-ocamlcp.cmx : ../driver/main_args.cmx
-ocamldep.cmo : ../driver/pparse.cmi ../parsing/parsetree.cmi \
-    ../parsing/parser.cmi ../parsing/parse.cmi ../utils/misc.cmi \
-    ../parsing/longident.cmi ../parsing/location.cmi ../parsing/lexer.cmi \
-    ../parsing/depend.cmi ../utils/config.cmi ../driver/compplugin.cmi \
-    ../driver/compenv.cmi ../utils/clflags.cmi
-ocamldep.cmx : ../driver/pparse.cmx ../parsing/parsetree.cmi \
-    ../parsing/parser.cmx ../parsing/parse.cmx ../utils/misc.cmx \
-    ../parsing/longident.cmx ../parsing/location.cmx ../parsing/lexer.cmx \
-    ../parsing/depend.cmx ../utils/config.cmx ../driver/compplugin.cmx \
-    ../driver/compenv.cmx ../utils/clflags.cmx
-ocamlmklib.cmo : ocamlmklibconfig.cmo ../utils/misc.cmi ../utils/config.cmi
-ocamlmklib.cmx : ocamlmklibconfig.cmx ../utils/misc.cmx ../utils/config.cmx
+ocamlcp.cmo : \
+  ../driver/main_args.cmi
+ocamlcp.cmx : \
+  ../driver/main_args.cmx
+ocamldep.cmo : \
+  ../driver/compenv.cmi \
+  ../driver/compplugin.cmi \
+  ../driver/pparse.cmi \
+  ../parsing/depend.cmi \
+  ../parsing/lexer.cmi \
+  ../parsing/location.cmi \
+  ../parsing/longident.cmi \
+  ../parsing/parse.cmi \
+  ../parsing/parser.cmi \
+  ../parsing/parsetree.cmi \
+  ../utils/clflags.cmi \
+  ../utils/config.cmi \
+  ../utils/misc.cmi
+ocamldep.cmx : \
+  ../driver/compenv.cmx \
+  ../driver/compplugin.cmx \
+  ../driver/pparse.cmx \
+  ../parsing/depend.cmx \
+  ../parsing/lexer.cmx \
+  ../parsing/location.cmx \
+  ../parsing/longident.cmx \
+  ../parsing/parse.cmx \
+  ../parsing/parser.cmx \
+  ../parsing/parsetree.cmi \
+  ../utils/clflags.cmx \
+  ../utils/config.cmx \
+  ../utils/misc.cmx
+ocamlmklib.cmo : \
+  ../utils/config.cmi \
+  ../utils/misc.cmi \
+  ocamlmklibconfig.cmo
+ocamlmklib.cmx : \
+  ../utils/config.cmx \
+  ../utils/misc.cmx \
+  ocamlmklibconfig.cmx
 ocamlmklibconfig.cmo :
 ocamlmklibconfig.cmx :
-ocamlmktop.cmo : ../utils/ccomp.cmi
-ocamlmktop.cmx : ../utils/ccomp.cmx
-ocamloptp.cmo : ../driver/main_args.cmi
-ocamloptp.cmx : ../driver/main_args.cmx
-ocamlprof.cmo : ../utils/warnings.cmi ../parsing/parsetree.cmi \
-    ../parsing/parse.cmi ../parsing/location.cmi
-ocamlprof.cmx : ../utils/warnings.cmx ../parsing/parsetree.cmi \
-    ../parsing/parse.cmx ../parsing/location.cmx
+ocamlmktop.cmo : \
+  ../utils/ccomp.cmi
+ocamlmktop.cmx : \
+  ../utils/ccomp.cmx
+ocamloptp.cmo : \
+  ../driver/main_args.cmi
+ocamloptp.cmx : \
+  ../driver/main_args.cmx
+ocamlprof.cmo : \
+  ../parsing/location.cmi \
+  ../parsing/parse.cmi \
+  ../parsing/parsetree.cmi \
+  ../utils/warnings.cmi
+ocamlprof.cmx : \
+  ../parsing/location.cmx \
+  ../parsing/parse.cmx \
+  ../parsing/parsetree.cmi \
+  ../utils/warnings.cmx
 opnames.cmo :
 opnames.cmx :
-primreq.cmo : ../utils/config.cmi ../bytecomp/cmo_format.cmi
-primreq.cmx : ../utils/config.cmx ../bytecomp/cmo_format.cmi
-profiling.cmo : profiling.cmi
-profiling.cmx : profiling.cmi
+primreq.cmo : \
+  ../bytecomp/cmo_format.cmi \
+  ../utils/config.cmi
+primreq.cmx : \
+  ../bytecomp/cmo_format.cmi \
+  ../utils/config.cmx
+profiling.cmo : \
+  profiling.cmi
+profiling.cmx : \
+  profiling.cmi
 profiling.cmi :
-read_cmt.cmo : ../typing/cmt_format.cmi cmt2annot.cmo ../utils/clflags.cmi
-read_cmt.cmx : ../typing/cmt_format.cmx cmt2annot.cmx ../utils/clflags.cmx
+read_cmt.cmo : \
+  ../typing/cmt_format.cmi \
+  ../utils/clflags.cmi \
+  cmt2annot.cmo
+read_cmt.cmx : \
+  ../typing/cmt_format.cmx \
+  ../utils/clflags.cmx \
+  cmt2annot.cmx
 scrapelabels.cmo :
 scrapelabels.cmx :
-stripdebug.cmo : ../utils/misc.cmi ../bytecomp/bytesections.cmi
-stripdebug.cmx : ../utils/misc.cmx ../bytecomp/bytesections.cmx
+stripdebug.cmo : \
+  ../bytecomp/bytesections.cmi \
+  ../utils/misc.cmi
+stripdebug.cmx : \
+  ../bytecomp/bytesections.cmx \
+  ../utils/misc.cmx

--- a/tools/.depend
+++ b/tools/.depend
@@ -141,33 +141,9 @@ ocamlcp.cmo : \
 ocamlcp.cmx : \
   ../driver/main_args.cmx
 ocamldep.cmo : \
-  ../driver/compenv.cmi \
-  ../driver/compplugin.cmi \
-  ../driver/pparse.cmi \
-  ../parsing/depend.cmi \
-  ../parsing/lexer.cmi \
-  ../parsing/location.cmi \
-  ../parsing/longident.cmi \
-  ../parsing/parse.cmi \
-  ../parsing/parser.cmi \
-  ../parsing/parsetree.cmi \
-  ../utils/clflags.cmi \
-  ../utils/config.cmi \
-  ../utils/misc.cmi
+  ../driver/makedepend.cmi
 ocamldep.cmx : \
-  ../driver/compenv.cmx \
-  ../driver/compplugin.cmx \
-  ../driver/pparse.cmx \
-  ../parsing/depend.cmx \
-  ../parsing/lexer.cmx \
-  ../parsing/location.cmx \
-  ../parsing/longident.cmx \
-  ../parsing/parse.cmx \
-  ../parsing/parser.cmx \
-  ../parsing/parsetree.cmi \
-  ../utils/clflags.cmx \
-  ../utils/config.cmx \
-  ../utils/misc.cmx
+  ../driver/makedepend.cmx
 ocamlmklib.cmo : \
   ../utils/config.cmi \
   ../utils/misc.cmi \
@@ -210,10 +186,14 @@ profiling.cmx : \
   profiling.cmi
 profiling.cmi :
 read_cmt.cmo : \
+  ../driver/compmisc.cmi \
+  ../parsing/location.cmi \
   ../typing/cmt_format.cmi \
   ../utils/clflags.cmi \
   cmt2annot.cmo
 read_cmt.cmx : \
+  ../driver/compmisc.cmx \
+  ../parsing/location.cmx \
   ../typing/cmt_format.cmx \
   ../utils/clflags.cmx \
   cmt2annot.cmx

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -390,6 +390,7 @@ clean::
 
 depend: beforedepend
 	$(CAMLRUN) ./ocamldep -slash $(INCLUDES) *.mli *.ml > .depend
+	../tools/normalize_depend .depend
 
 .PHONY: clean install beforedepend depend
 

--- a/tools/normalize_depend
+++ b/tools/normalize_depend
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This file rewrites in place every file provided on the command line,
+# which are assumed to be .depend file.
+# These files need to deterministic so there is no fighting across
+# committers.  We think we need to normalize such files because gcc
+# -MM has been observed to output the same include multiple times (if
+# it is included with different paths), which is likely not reliably
+# true across compilers.  We would also depend on the exact line
+# breaks. Sorting also reduces spurious changes due to minor code
+# changes, like reordering includes.
+
+for f in "$@"; do
+    while IFS=: read first rest; do
+	echo -n $first:
+	echo -n $rest | tr ' ' '\n' | LC_ALL=C sort | uniq | while read line; do
+	    printf ' \\\n  %s' "$line"
+	done
+	printf '\n'
+    done < "$f" > "$f.tmp"
+    mv "$f.tmp" "$f"
+done


### PR DESCRIPTION
I propose that we check, in travis, that .depend files are to up to date.

The reason for this is that it seems that every other feature I make ends up running `make depend` and picking up random changes because other people didn't run or didn't know to run `make depend`. I actually learned while writing this that there is `make alldepend` that updates more such files and is even more stale, so it's almost guaranteed that many people submitting requests also don't know about it.
Also, step 0 of having reliable incremental or parallel builds is to have reliable dependencies.

Other ways of achieving something similar would be:
- stop committing these .depend files. I don't understand `make` enough to know if it can be done, or whether `gnu make` can do it, and whether we can require `gnu make` specifically
- some background job or push hook that regenerates and commits these files automatically

In addition to regenerating all .depend files and changing the travis check, this pull request also normalizes the .depend files in the following ways:
1. one dependency per line
2. dependencies for a given files are sorted
3. dependencies are uniquified

The normalization is because if we force people to rerun `make alldepend`, everyone should generate identical files, to avoid conflicts and diffs that constantly switch between different formats depending on locale or compiler version or what have you.
1 avoid possible issues where compilers don't agree where to put line breaks. 2 may avoid locale problem but mostly happens for 3. 3 avoids issues where `#include <caml/mlvalues.h>` and `#include "mlvalues.h"` ends up listing mlvalue.h twice, which I think could be subject to change (this happens a lot with the inclusions of osdeps.h).