### PR TITLE
 let rec: allow float array construction with -no-flat-float-array

### DIFF
--- a/Changes
+++ b/Changes
@@ -16,6 +16,10 @@ Working version
   (Vincent Laviron, with help from Pierre Chambart,
    reviews by Gabriel Scherer and Luc Maranget)
 
+- GPR#1516: Allow float array construction in recursive bindings
+  when configured with -no-flat-float-array
+  (Jeremy Yallop, report by Gabriel Scherer)
+
 ### Standard library:
 
 ### Other libraries:

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1884,7 +1884,7 @@ struct
         if Path.same p Predef.path_int || Path.same p Predef.path_char then
           `Pintarray
         else if Path.same p Predef.path_float then
-          `Pfloatarray
+          if Config.flat_float_array then `Pfloatarray else `Paddrarray
         else if Path.same p Predef.path_string
              || Path.same p Predef.path_array
              || Path.same p Predef.path_nativeint


### PR DESCRIPTION
On #1471, @gasche [wrote](https://github.com/ocaml/ocaml/pull/1471#issuecomment-348814736):

> [T]he test file `testsuite/tests/typing-misc/pr6939.ml-noflat` is broken. When `-no-flat-float-array` is set, the following definitions should be accepted as valid recursive definitions:
> 
> ```ocaml
> let rec x = [| x |]; 1.;;
> let rec x = let u = [|y|] in 10. and y = 1.;;
> ```
> 
> and currently they are rejected.

This PR adds a check for `-no-flat-float-array` in the let-rec checking code so that the definitions are accepted and the failing `pr6939.ml-noflat` passes.
