### PR TITLE
More robust handling of type variables in mcomp

### DIFF
--- a/Changes
+++ b/Changes
@@ -108,6 +108,9 @@ Working version
 - MPR#7682, GPR#1495: fix [@@unboxed] for records with 1 polymorphic field
   (Alain Frisch, report by Stéphane Graham-Lengrand, review by Gabriel Scherer)
 
+- GPR#1517: More robust handling of type variables in mcomp
+  (Leo White and Thomas Refis, review by Jacques Garrigue)
+
 
 4.06 maintenance branch
 -----------------------

--- a/testsuite/tests/typing-gadts/variables_in_mcomp.ml
+++ b/testsuite/tests/typing-gadts/variables_in_mcomp.ml
@@ -1,0 +1,15 @@
+module M = struct
+  type 'a s = 'a
+  type t = T : 'a s -> t
+end
+
+module N = struct
+  type 'a s = 'a
+  type t = T : 'a s -> t
+end
+
+type (_, _) eq = Refl : ('a, 'a) eq
+
+let f (x : (M.t, N.t) eq)=
+  match x with
+  | Refl -> ()

--- a/testsuite/tests/typing-gadts/variables_in_mcomp.ml
+++ b/testsuite/tests/typing-gadts/variables_in_mcomp.ml
@@ -13,3 +13,10 @@ type (_, _) eq = Refl : ('a, 'a) eq
 let f (x : (M.t, N.t) eq)=
   match x with
   | Refl -> ()
+
+[%%expect{|
+module M : sig type 'a s = 'a type t = T : 'a s -> t end
+module N : sig type 'a s = 'a type t = T : 'a s -> t end
+type (_, _) eq = Refl : ('a, 'a) eq
+val f : (M.t, N.t) eq -> unit = <fun>
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2025,7 +2025,9 @@ let rec mcomp type_pairs env t1 t2 =
       with Not_found ->
         TypePairs.add type_pairs (t1', t2') ();
         match (t1'.desc, t2'.desc) with
-          (Tvar _, Tvar _) -> assert false
+        | (Tvar _, _)
+        | (_, Tvar _)  ->
+            ()
         | (Tarrow (l1, t1, u1, _), Tarrow (l2, t2, u2, _))
           when l1 = l2 || not (is_optional l1 || is_optional l2) ->
             mcomp type_pairs env t1 t2;


### PR DESCRIPTION
When comparing two types, `Ctype.mcomp` asserts that if neither of them is a variable, then they can't both be expanded to a variable.
The first commit adds an example of a code to the testsuite showing that this assertion doesn't hold.

The second commit removes the assertion and handles variables in the exact same way as before expansion of the types.
[MPR#6158](https://caml.inria.fr/mantis/view.php?id=6158) and the related [commit](https://github.com/ocaml/ocaml/commit/567bca77d28c082c9385f442c3d6f6be8771626c) seem to confirm that this is the correct fix.

The handling of variables pre-expansion is redundant, but I left it in place to serve as a short-circuit since expansion might be costly.
I however doubt that it will be triggered often in practice, as "external" calls to `mcomp` are always preceeded by calls to `reify`.

