### PR TITLE
More robust matches

### DIFF
--- a/Changes
+++ b/Changes
@@ -111,6 +111,9 @@ Working version
 - GPR#1517: More robust handling of type variables in mcomp
   (Leo White and Thomas Refis, review by Jacques Garrigue)
 
+- GPR#1518: More robust matches
+  (Thomas Refis, review by ...)
+
 
 4.06 maintenance branch
 -----------------------

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1440,8 +1440,10 @@ let get_arg_lazy p rem = match p with
 
 let matcher_lazy p rem = match p.pat_desc with
 | Tpat_or (_,_,_)     -> raise OrPat
-| Tpat_var _          -> get_arg_lazy omega rem
-| _                   -> get_arg_lazy p rem
+| Tpat_any
+| Tpat_var _          -> omega :: rem
+| Tpat_lazy arg       -> arg :: rem
+| _                   -> raise NoMatch
 
 (* Inlining the tag tests before calling the primitive that works on
    lazy blocks. This is also used in translcore.ml.

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1604,8 +1604,14 @@ let get_args_record num_fields p rem = match p with
 
 let matcher_record num_fields p rem = match p.pat_desc with
 | Tpat_or (_,_,_) -> raise OrPat
-| Tpat_var _      -> get_args_record num_fields omega rem
-| _               -> get_args_record num_fields p rem
+| Tpat_any
+| Tpat_var _      ->
+  record_matching_line num_fields [] @ rem
+| Tpat_record ([], _) when num_fields = 0 -> rem
+| Tpat_record ((_, lbl, _) :: _ as lbl_pat_list, _)
+  when Array.length lbl.lbl_all = num_fields ->
+    record_matching_line num_fields lbl_pat_list @ rem
+| _ -> raise NoMatch
 
 let make_record_matching loc all_labels def = function
     [] -> fatal_error "Matching.make_record_matching"

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1567,8 +1567,10 @@ let get_args_tuple arity p rem = match p with
 
 let matcher_tuple arity p rem = match p.pat_desc with
 | Tpat_or (_,_,_)     -> raise OrPat
-| Tpat_var _          -> get_args_tuple arity omega rem
-| _                   ->  get_args_tuple arity p rem
+| Tpat_any
+| Tpat_var _ -> omegas arity @ rem
+| Tpat_tuple args when List.length args = arity -> args @ rem
+| _ ->  raise NoMatch
 
 let make_tuple_matching loc arity def = function
     [] -> fatal_error "Matching.make_tuple_matching"

--- a/testsuite/tests/basic-more/ocamltests
+++ b/testsuite/tests/basic-more/ocamltests
@@ -8,6 +8,7 @@ pr1271.ml
 pr2719.ml
 pr6216.ml
 record_evaluation_order.ml
+robustmatch.ml
 sequential_and_or.ml
 structural_constants.ml
 tbuffer.ml

--- a/testsuite/tests/basic-more/robustmatch.compilers.reference
+++ b/testsuite/tests/basic-more/robustmatch.compilers.reference
@@ -1,0 +1,100 @@
+File "robustmatch.ml", line 9, characters 4-73:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, 1)
+File "robustmatch.ml", line 19, characters 4-73:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, (B|C))
+File "robustmatch.ml", line 24, characters 4-73:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, (B|C))
+File "robustmatch.ml", line 29, characters 4-73:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, "")
+File "robustmatch.ml", line 40, characters 4-66:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, (B|C))
+File "robustmatch.ml", line 45, characters 4-87:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, (Y|Z))
+File "robustmatch.ml", line 51, characters 4-66:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, (Y|Z))
+File "robustmatch.ml", line 62, characters 4-66:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, (B|C))
+File "robustmatch.ml", line 84, characters 4-66:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, B)
+File "robustmatch.ml", line 106, characters 4-66:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, B)
+File "robustmatch.ml", line 111, characters 4-87:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, Y)
+File "robustmatch.ml", line 117, characters 4-66:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, Y)
+File "robustmatch.ml", line 122, characters 4-66:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, A)
+File "robustmatch.ml", line 131, characters 4-90:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, [| _ |])
+File "robustmatch.ml", line 137, characters 4-69:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, [| _ |])
+File "robustmatch.ml", line 142, characters 4-90:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, [| _ |])
+File "robustmatch.ml", line 152, characters 4-75:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, 'a')
+File "robustmatch.ml", line 161, characters 4-74:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, `B)
+File "robustmatch.ml", line 170, characters 4-89:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, (3, "*"))
+File "robustmatch.ml", line 181, characters 4-113:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, {x=3; y="*"})
+File "robustmatch.ml", line 186, characters 4-113:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, {a=1; b="coucou"; c='b'})
+File "robustmatch.ml", line 195, characters 4-72:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, (3, "*"))
+File "robustmatch.ml", line 205, characters 4-82:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, {x=3; y="*"})
+File "robustmatch.ml", line 214, characters 4-71:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, lazy 0)
+File "robustmatch.ml", line 223, characters 4-99:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, "")

--- a/testsuite/tests/basic-more/robustmatch.ml
+++ b/testsuite/tests/basic-more/robustmatch.ml
@@ -1,0 +1,241 @@
+(* TEST
+   include testing
+*)
+
+module M1 = struct
+  type _ repr = R1 : int repr | R2 : string repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, 0 -> ()
+    | _, R2, "coucou" -> ()
+end
+
+module M2 = struct
+  type c = A | B | C
+  type _ repr = R1 : c repr | R2 : string repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, "coucou" -> ()
+
+  let g (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | _, R2, "coucou" -> ()
+    | R1, _, A -> ()
+
+  let h (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | _, R2, "coucou" -> ()
+    | R1, _, _ -> ()
+end
+
+module M3 = struct
+  type c1 = A | B | C
+  type c2 = X | Y | Z
+  type _ repr = R1 : c1 repr | R2 : c2 repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+
+  let g (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+    | R1, _, _ -> ()
+
+  let h (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, _ -> ()
+    | _, R2, X -> ()
+end
+
+module M3_gadt = struct
+  type c1 = A | B | C
+  type _ c2 = X : int c2 | Y : char c2 | Z : char c2
+  type _ repr = R1 : c1 repr | R2 : int c2 repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+
+  let g (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+    | R1, _, _ -> ()
+
+  let h (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, _ -> ()
+    | _, R2, X -> ()
+end
+
+module M3_gadt_bis = struct
+  type _ c1 = A : int c1 | B : int c1 | C : char c1
+  type _ c2 = X : int c2 | Y : char c2 | Z : char c2
+  type _ repr = R1 : int c1 repr | R2 : int c2 repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+
+  let g (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+    | R1, _, B -> ()
+
+  let h (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, _ -> ()
+    | _, R2, X -> ()
+end
+
+module M3_gadt_bis_harder = struct
+  type _ c1 = A : int c1 | B : int c1 | C : char c1
+  type _ c2 = X : int c2 | Y : char c2 | Z : char c2
+  type _ repr = R1 : 'a c1 repr | R2 : 'a c2 repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+
+  let g (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+    | R1, _, _ -> ()
+
+  let h (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, _ -> ()
+    | _, R2, X -> ()
+
+  let h (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, C -> ()
+    | _, R2, Y -> ()
+end
+
+module M4 = struct
+  type _ repr = R1 : int repr | R2 : int array repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | _, R1, 0 -> ()
+    | R2, _, [||] -> ()
+    | _, R1, 1 -> ()
+
+  let g (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, _ -> ()
+    | _, R2, [||] -> ()
+
+  let h (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | _, R2, [||] -> ()
+    | R1, _, 0 -> ()
+    | R1, _, _ -> ()
+end
+
+module M5 = struct
+  type _ repr = R1 : char repr | R2 : string repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, 'c' -> ()
+    | _, R2, "coucou" -> ()
+end
+
+module M6 = struct
+  type _ repr = R1 : [ `A | `B ] repr | R2 : string repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, `A -> ()
+    | _, R2, "coucou" -> ()
+end
+
+module M7 = struct
+  type _ repr = R1 : (int * string) repr | R2 : (int * string * char) repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, (3, "") -> ()
+    | _, R2, (1, "coucou", 'a') -> ()
+end
+
+module M8 = struct
+  type r1 = { x : int; y : string }
+  type r2 = { a : int; b : string; c : char }
+  type _ repr = R1 : r1 repr | R2 : r2 repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, { x = 3; y = "" } -> ()
+    | _, R2, { a = 1; b = "coucou"; c = 'a' } -> ()
+
+  let g (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R2, _, { a = 1; b = "coucou"; c = 'a' } -> ()
+    | _, R1, { x = 3; y = "" } -> ()
+end
+
+module M9 = struct
+  type _ repr = R1 : (int * string) repr | R2 : int repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, (3, "") -> ()
+    | _, R2, 1 -> ()
+end
+
+module M10 = struct
+  type r = { x : int; y : string }
+  type _ repr = R1 : r repr | R2 : int repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, { x = 3; y = "" } -> ()
+    | _, R2, 1 -> ()
+end
+
+module M11 = struct
+  type _ repr = R1 : int lazy_t repr | R2 : int repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, lazy 1 -> ()
+    | _, R2, 1 -> ()
+end
+
+module M12 = struct
+  type _ repr = R1 : unit repr | R2 : string repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, () -> ()
+    | _, R2, "coucou" -> ()
+    | _, R2, "foo" -> ()
+end
+
+module GPR1493 = struct
+  type t1 = { x : int; y : string; }
+  type t2 = { a : int; b : string; c : string list; }
+
+  type t = ..
+  type t += C1 of t1 | C2 of t2
+
+  let f (x : t) =
+    match x with
+    | C1 { x; y } -> ()
+    | C2 { a;b;c } -> ()
+    | _ -> ()
+end

--- a/testsuite/tests/basic-more/robustmatch.reference
+++ b/testsuite/tests/basic-more/robustmatch.reference
@@ -1,0 +1,2 @@
+
+All tests succeeded.

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -249,9 +249,9 @@ let simple_match p1 p2 =
   | Tpat_variant(l1, _, _), Tpat_variant(l2, _, _) ->
       l1 = l2
   | Tpat_constant(c1), Tpat_constant(c2) -> const_compare c1 c2 = 0
-  | Tpat_tuple _, Tpat_tuple _ -> true
   | Tpat_lazy _, Tpat_lazy _ -> true
   | Tpat_record _ , Tpat_record _ -> true
+  | Tpat_tuple p1s, Tpat_tuple p2s
   | Tpat_array p1s, Tpat_array p2s -> List.length p1s = List.length p2s
   | _, (Tpat_any | Tpat_var(_)) -> true
   | _, _ -> false

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -181,7 +181,7 @@ module Compat
   | Tpat_array ps, Tpat_array qs ->
       List.length ps = List.length qs &&
       compats ps qs
-  | _,_  -> assert false (* By typing *)
+  | _,_  -> false
 
   and ocompat op oq = match op,oq with
   | None,None -> true
@@ -191,7 +191,7 @@ module Compat
   and compats ps qs = match ps,qs with
   | [], [] -> true
   | p::ps, q::qs -> compat p q && compats ps qs
-  | _,_    -> assert false (* By typing *)
+  | _,_    -> false
 
 end
 

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -655,50 +655,90 @@ let row_of_pat pat =
     {desc = Tvariant row} -> Btype.row_repr row
   | _ -> assert false
 
+let first_column_is_coherent = function
+  | [] -> true
+  | (col1, _) :: matrices ->
+    let same_kind (other_col1, _mat) =
+      match col1.pat_desc, other_col1.pat_desc with
+      | (Tpat_any | Tpat_var _ | Tpat_alias _ | Tpat_or _), _
+      | _, (Tpat_any | Tpat_var _ | Tpat_alias _ | Tpat_or _) ->
+        (* Only ever called on specialized submatrices, which implies:
+           - the first column has been simplified
+           - _ is not present *)
+        assert false
+      | Tpat_construct (_, c, _), Tpat_construct (_, c', _) ->
+        c.cstr_consts = c'.cstr_consts
+        && c.cstr_nonconsts = c'.cstr_nonconsts
+      | Tpat_constant c1, Tpat_constant c2 -> begin
+          match c1, c2 with
+          | Const_char _, Const_char _
+          | Const_int _, Const_int _
+          | Const_int32 _, Const_int32 _
+          | Const_int64 _, Const_int64 _
+          | Const_nativeint _, Const_nativeint _
+          | Const_float _, Const_float _
+          | Const_string _, Const_string _ -> true
+          | _, _ -> false
+        end
+      | Tpat_tuple l1, Tpat_tuple l2 -> List.length l1 = List.length l2
+      | Tpat_variant _, Tpat_variant _
+      | Tpat_record _, Tpat_record _
+      | Tpat_array _, Tpat_array _
+      | Tpat_lazy _, Tpat_lazy _ -> true
+      | _, _ -> false
+    in
+    List.for_all same_kind matrices
+
 (*
   Check whether the first column of env makes up a complete signature or
   not.
+
+   Special case: if the first column is not coherent (i.e. it contains patterns
+   of obviously different types), then we can say the match is full: we're not
+   going to be able to build a value which is an element of both types.
 *)
 
-let full_match closing env =  match env with
-| ({pat_desc = Tpat_construct(_,c,_)},_) :: _ ->
-    if c.cstr_consts < 0 then false (* extensions *)
-    else List.length env = c.cstr_consts + c.cstr_nonconsts
-| ({pat_desc = Tpat_variant _} as p,_) :: _ ->
-    let fields =
-      List.map
-        (function ({pat_desc = Tpat_variant (tag, _, _)}, _) -> tag
-          | _ -> assert false)
-        env
-    in
-    let row = row_of_pat p in
-    if closing && not (Btype.row_fixed row) then
-      (* closing=true, we are considering the variant as closed *)
-      List.for_all
-        (fun (tag,f) ->
-          match Btype.row_field_repr f with
-            Rabsent | Reither(_, _, false, _) -> true
-          | Reither (_, _, true, _)
-              (* m=true, do not discard matched tags, rather warn *)
-          | Rpresent _ -> List.mem tag fields)
-        row.row_fields
-    else
-      row.row_closed &&
-      List.for_all
-        (fun (tag,f) ->
-          Btype.row_field_repr f = Rabsent || List.mem tag fields)
-        row.row_fields
-| ({pat_desc = Tpat_constant(Const_char _)},_) :: _ ->
-    List.length env = 256
-| ({pat_desc = Tpat_constant(_)},_) :: _ -> false
-| ({pat_desc = Tpat_tuple(_)},_) :: _ -> true
-| ({pat_desc = Tpat_record(_)},_) :: _ -> true
-| ({pat_desc = Tpat_array(_)},_) :: _ -> false
-| ({pat_desc = Tpat_lazy(_)},_) :: _ -> true
-| ({pat_desc = (Tpat_any|Tpat_var _|Tpat_alias _|Tpat_or _)},_) :: _
-| []
-  ->
-    assert false
+let full_match closing env =
+  not (first_column_is_coherent env) ||
+  match env with
+  | ({pat_desc = Tpat_construct(_,c,_)},_) :: _ ->
+      if c.cstr_consts < 0 then false (* extensions *)
+      else List.length env = c.cstr_consts + c.cstr_nonconsts
+  | ({pat_desc = Tpat_variant _} as p,_) :: _ ->
+      let fields =
+        List.map
+          (function ({pat_desc = Tpat_variant (tag, _, _)}, _) -> tag
+            | _ -> assert false)
+          env
+      in
+      let row = row_of_pat p in
+      if closing && not (Btype.row_fixed row) then
+        (* closing=true, we are considering the variant as closed *)
+        List.for_all
+          (fun (tag,f) ->
+            match Btype.row_field_repr f with
+              Rabsent | Reither(_, _, false, _) -> true
+            | Reither (_, _, true, _)
+                (* m=true, do not discard matched tags, rather warn *)
+            | Rpresent _ -> List.mem tag fields)
+          row.row_fields
+      else
+        row.row_closed &&
+        List.for_all
+          (fun (tag,f) ->
+            Btype.row_field_repr f = Rabsent || List.mem tag fields)
+          row.row_fields
+  | ({pat_desc = Tpat_constant(Const_char _)},_) :: _ ->
+      List.length env = 256
+  | ({pat_desc = Tpat_constant(_)},_) :: _ -> false
+  | ({pat_desc = Tpat_tuple(_)},_) :: _ -> true
+  | ({pat_desc = Tpat_record(_)},_) :: _ -> true
+  | ({pat_desc = Tpat_array(_)},_) :: _ -> false
+  | ({pat_desc = Tpat_lazy(_)},_) :: _ -> true
+  | ({pat_desc = (Tpat_any|Tpat_var _|Tpat_alias _|Tpat_or _)},_) :: _
+  | []
+    ->
+      assert false
 
 (* Written as a non-fragile matching, PR#7451 originated from a fragile matching below. *)
 let should_extend ext env = match ext with


### PR DESCRIPTION
As noted in #1493 various places in parmatch and matching work under the assumption that patterns in the same column will be of the same type, which is just wrong.

## Parmatch

Two places made such an assumption:
- `Compat.compat(s)`: it expected the patterns it is called on to be of the same kind. There is no need to have such an assumption, considering patterns of different "kinds" as incompatible is corrrect.

- `build_other`: ~~the function in charge of building a value not being matched by a matching when we know the matching to be non-exhaustive.~~
~~This function works by listing all the "constructors" of a type present on the first column, and then returning a constructor of type which is not in that list.~~
~~Here we need to account for the fact that all the patterns in the first column are not necessarily of the same type.~~

- `full_match`: cf. https://github.com/ocaml/ocaml/pull/1518#issuecomment-350072922

I checked the other `assert false` and `fatal_error` present in the file, I believe they are present for other reasons than "oh, these two things can only be of the same type".

## Matching

We sometimes make that assumption when specializing the list of reachable trap-handlers. This was the case when specializing by a record, a tuple, or a lazy pattern.
We now do some kind checking there and when things are of the same kind (two tuples, two records or two lazys) we do, here too, resort to arity checking.
Just as constructor of extensible types, these two cases, as well as array patterns, would benefit from some kind of compatibility checking based on typing information.
This is however not crucial and non-trivial to do well, so let's consider it at a later date.

## Does this PR cover all the cases?

I believe so, but of course can't be sure.
My process was to look at all the `assert false` in parmatch justified by the said assumption, writing a test breaking the assumption, fixing the code, making sure the test passed.

While doing this, I would sometimes get a assertion failure/fatal error in matching.
This happened for records in the expected way (that is: we already knew records weren't handled well), as well as for tuples.
I then looking at all the `matcher_*` functions, and apart from `matcher_lazy`, they all seemed sensible to me; that is: they all raised `NoMatch` instead of failing, which seems *right*.