### PR TITLE
Grammar-related changes in elisp sources

### DIFF
--- a/emacs/caml-font-old.el
+++ b/emacs/caml-font-old.el
@@ -42,7 +42,7 @@
     (setq font-lock-variable-name-face 'DarkGoldenRod)
     (setq font-lock-type-face 'DarkOliveGreen)
     (setq font-lock-reference-face 'CadetBlue)))
-  ; extra faces for documention
+  ; extra faces for documentation
   (make-face 'Stop)
   (set-face-foreground 'Stop "White")
   (set-face-background 'Stop "Red")

--- a/emacs/caml-help.el
+++ b/emacs/caml-help.el
@@ -25,7 +25,7 @@
 ;;  This is a preliminary version.
 ;;
 ;;  Possible improvements?
-;;   - dump some databaes: Info, Lib, ...
+;;   - dump some databases: Info, Lib, ...
 ;;   - accept a search path for local libraries instead of current dir
 ;;     (then distinguish between different modules lying in different
 ;;     directories)
@@ -33,8 +33,8 @@
 ;;
 ;;  Abstract over
 ;;   - the viewing method and the database, so that the documentation for
-;;     and identifier could be search in
-;;       * info / html / man / mli's sources
+;;     an identifier could be
+;;       * searched in info / html / man / mli's sources
 ;;       * viewed in Emacs or using an external previewer.
 ;;
 ;;  Take all identifiers (labels, Constructors, exceptions, etc.)
@@ -56,7 +56,7 @@
 (defvar ocaml-lib-path 'lazy
   "Path list for ocaml lib sources (mli files).
 
-`lazy' means ask ocaml to find it for your at first use.")
+`lazy' means ask ocaml to find it for you at first use.")
 (defun ocaml-lib-path ()
   "Compute if necessary and return the path for ocaml libs."
   (if (listp ocaml-lib-path) nil
@@ -233,7 +233,7 @@
   ocaml-visible-modules)
 
 (defun ocaml-open-module (arg)
-  "*Make module of name ARG visible whe ARG is a string.
+  "*Make module of name ARG visible when ARG is a string.
 When call interactively, make completion over known modules."
   (interactive "P")
   (if (not (stringp arg))
@@ -335,7 +335,7 @@ with an optional non-nil argument."
 (defun caml-complete (arg)
   "Does completion for OCaml identifiers qualified.
 
-It attemps to recognize an qualified identifier Module . entry
+It attemps to recognize a qualified identifier Module . entry
 around point using function \\[ocaml-qualified-identifier].
 
 If Module is defined, it does completion for identifier in Module.
@@ -647,14 +647,14 @@ current buffer using \\[ocaml-qualified-identifier]."
 (defun caml-help (arg)
   "Find documentation for OCaml qualified identifiers.
 
-It attemps to recognize an qualified identifier of the form
+It attempts to recognize a qualified identifier of the form
 ``Module . entry'' around point using function `ocaml-qualified-identifier'.
 
 If Module is undetermined it is temptatively guessed from the identifier name
-and according to visible modules.  If this is still unsucessful,  the user is
+and according to visible modules.  If this is still unsuccessful,  the user is
 then prompted for a Module name.
 
-The documentation for Module is first seach in the info manual if available,
+The documentation for Module is first searched in the info manual, if available,
 then in the ``module.mli'' source file.  The entry is then searched in the
 documentation.
 
@@ -666,7 +666,7 @@ Prefix arg 0 forces recompilation of visible modules (and their content)
 from the file content.
 
 Prefix arg 4 prompts for Module and identifier instead of guessing values
-from the possition of point in the current buffer."
+from the position of point in the current buffer."
   (interactive "p")
   (delete-overlay ocaml-help-ovl)
   (let ((module) (entry) (module-entry))
@@ -726,9 +726,9 @@ from the possition of point in the current buffer."
 (defvar ocaml-links nil
   "Local links in the current of last info node or interface file.
 
-The car of the list is a key that indentifies the module to prevent
+The car of the list is a key that identifies the module to prevent
 recompilation when next help command is relative to the same module.
-The cdr is a list of elments, each of which is an string and a pair of
+The cdr is a list of elements, each of which is a string and a pair of
 buffer positions."
 )
 (make-variable-buffer-local 'ocaml-links)

--- a/emacs/caml-types.el
+++ b/emacs/caml-types.el
@@ -669,7 +669,7 @@ The function uses two overlays.
                            (error (message "End of buffer!")))))
                        (setq speed (* speed speed)))))
                   ;; main action, when the motion is inside the window
-                  ;; or on orginal button down event
+                  ;; or on original button down event
                   ((or (caml-mouse-movement-p event)
                        (equal original-event event))
                    (setq cnum (caml-event-point-end event))
@@ -732,7 +732,7 @@ The function uses two overlays.
       ;; However, it could also be a key stroke before mouse release.
       ;; Emacs does not allow to test whether mouse is up or down.
       ;; Not sure it is robust to loop for mouse release after an error
-      ;; occured, as is done for exploration.
+      ;; occurred, as is done for exploration.
       ;; So far, we just ignore next event. (Next line also be uncommenting.)
       (if event (caml-read-event)))))
 

--- a/emacs/caml.el
+++ b/emacs/caml.el
@@ -75,179 +75,179 @@ Priorities are assigned to `interesting' caml operators as follows:
 (make-variable-buffer-local 'caml-apply-extra-indent)
 
 (defvar caml-begin-indent 2
-  "*How many spaces to indent from a begin keyword in caml mode.")
+  "*How many spaces to indent from a \"begin\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-begin-indent)
 
 (defvar caml-class-indent 2
-  "*How many spaces to indent from a class keyword in caml mode.")
+  "*How many spaces to indent from a \"class\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-class-indent)
 
 (defvar caml-exception-indent 2
-  "*How many spaces to indent from an exception keyword in caml mode.")
+  "*How many spaces to indent from an \"exception\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-exception-indent)
 
 (defvar caml-for-indent 2
-  "*How many spaces to indent from a for keyword in caml mode.")
+  "*How many spaces to indent from a \"for\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-for-indent)
 
 (defvar caml-fun-indent 2
-  "*How many spaces to indent from a fun keyword in caml mode.")
+  "*How many spaces to indent from a \"fun\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-fun-indent)
 
 (defvar caml-function-indent 4
-  "*How many spaces to indent from a function keyword in caml mode.")
+  "*How many spaces to indent from a \"function\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-function-indent)
 
 (defvar caml-if-indent  2
-  "*How many spaces to indent from an if keyword in caml mode.")
+  "*How many spaces to indent from an \"if\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-if-indent)
 
 (defvar caml-if-else-indent 0
-  "*How many spaces to indent from an if .. else line in caml mode.")
+  "*How many spaces to indent from an \"if .. else\" line in caml mode.")
 (make-variable-buffer-local 'caml-if-else-indent)
 
 (defvar caml-inherit-indent 2
-  "*How many spaces to indent from an inherit keyword in caml mode.")
+  "*How many spaces to indent from an \"inherit\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-inherit-indent)
 
 (defvar caml-initializer-indent 2
-  "*How many spaces to indent from an initializer keyword in caml mode.")
+  "*How many spaces to indent from an \"initializer\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-initializer-indent)
 
 (defvar caml-include-indent 2
-  "*How many spaces to indent from an include keyword in caml mode.")
+  "*How many spaces to indent from an \"include\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-include-indent)
 
 (defvar caml-let-indent 2
-  "*How many spaces to indent from a let keyword in caml mode.")
+  "*How many spaces to indent from a \"let\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-let-indent)
 
 (defvar caml-let-in-indent 0
-  "*How many spaces to indent from a let .. in keyword in caml mode.")
+  "*How many spaces to indent from a \"let .. in\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-let-in-indent)
 
 (defvar caml-match-indent 2
-  "*How many spaces to indent from a match keyword in caml mode.")
+  "*How many spaces to indent from a \"match\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-match-indent)
 
 (defvar caml-method-indent 2
-  "*How many spaces to indent from a method keyword in caml mode.")
+  "*How many spaces to indent from a \"method\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-method-indent)
 
 (defvar caml-module-indent 2
-  "*How many spaces to indent from a module keyword in caml mode.")
+  "*How many spaces to indent from a \"module\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-module-indent)
 
 (defvar caml-object-indent 2
-  "*How many spaces to indent from an object keyword in caml mode.")
+  "*How many spaces to indent from an \"object\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-object-indent)
 
 (defvar caml-of-indent 2
-  "*How many spaces to indent from an of keyword in caml mode.")
+  "*How many spaces to indent from an \"of\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-of-indent)
 
 (defvar caml-parser-indent 4
-  "*How many spaces to indent from a parser keyword in caml mode.")
+  "*How many spaces to indent from a \"parser\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-parser-indent)
 
 (defvar caml-sig-indent 2
-  "*How many spaces to indent from a sig keyword in caml mode.")
+  "*How many spaces to indent from a \"sig\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-sig-indent)
 
 (defvar caml-struct-indent 2
-  "*How many spaces to indent from a struct keyword in caml mode.")
+  "*How many spaces to indent from a \"struct\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-struct-indent)
 
 (defvar caml-try-indent 2
-  "*How many spaces to indent from a try keyword in caml mode.")
+  "*How many spaces to indent from a \"try\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-try-indent)
 
 (defvar caml-type-indent 4
-  "*How many spaces to indent from a type keyword in caml mode.")
+  "*How many spaces to indent from a \"type\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-type-indent)
 
 (defvar caml-val-indent 2
-  "*How many spaces to indent from a val keyword in caml mode.")
+  "*How many spaces to indent from a \"val\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-val-indent)
 
 (defvar caml-while-indent 2
-  "*How many spaces to indent from a while keyword in caml mode.")
+  "*How many spaces to indent from a \"while\" keyword in caml mode.")
 (make-variable-buffer-local 'caml-while-indent)
 
 (defvar caml-::-indent  2
-  "*How many spaces to indent from a :: operator in caml mode.")
+  "*How many spaces to indent from a \"::\" operator in caml mode.")
 (make-variable-buffer-local 'caml-::-indent)
 
 (defvar caml-@-indent   2
-  "*How many spaces to indent from a @ operator in caml mode.")
+  "*How many spaces to indent from a \"@\" operator in caml mode.")
 (make-variable-buffer-local 'caml-@-indent)
 
 (defvar caml-:=-indent  2
-  "*How many spaces to indent from a := operator in caml mode.")
+  "*How many spaces to indent from a \":=\" operator in caml mode.")
 (make-variable-buffer-local 'caml-:=-indent)
 
 (defvar caml-<--indent  2
-  "*How many spaces to indent from a <- operator in caml mode.")
+  "*How many spaces to indent from a \"<-\" operator in caml mode.")
 (make-variable-buffer-local 'caml-<--indent)
 
 (defvar caml-->-indent  2
-  "*How many spaces to indent from a -> operator in caml mode.")
+  "*How many spaces to indent from a \"->\" operator in caml mode.")
 (make-variable-buffer-local 'caml-->-indent)
 
 (defvar caml-lb-indent 2
-  "*How many spaces to indent from a \[ operator in caml mode.")
+  "*How many spaces to indent from a \"\[\" operator in caml mode.")
 (make-variable-buffer-local 'caml-lb-indent)
 
 (defvar caml-lc-indent 2
-  "*How many spaces to indent from a \{ operator in caml mode.")
+  "*How many spaces to indent from a \"\{\" operator in caml mode.")
 (make-variable-buffer-local 'caml-lc-indent)
 
 (defvar caml-lp-indent  1
-  "*How many spaces to indent from a \( operator in caml mode.")
+  "*How many spaces to indent from a \"\(\" operator in caml mode.")
 (make-variable-buffer-local 'caml-lp-indent)
 
 (defvar caml-and-extra-indent nil
-  "*Extra indent for caml lines starting with the and keyword.
+  "*Extra indent for caml lines starting with the \"and\" keyword.
 Usually negative. nil is align on master.")
 (make-variable-buffer-local 'caml-and-extra-indent)
 
 (defvar caml-do-extra-indent nil
-  "*Extra indent for caml lines starting with the do keyword.
+  "*Extra indent for caml lines starting with the \"do\" keyword.
 Usually negative. nil is align on master.")
 (make-variable-buffer-local 'caml-do-extra-indent)
 
 (defvar caml-done-extra-indent nil
-  "*Extra indent for caml lines starting with the done keyword.
+  "*Extra indent for caml lines starting with the \"done\" keyword.
 Usually negative. nil is align on master.")
 (make-variable-buffer-local 'caml-done-extra-indent)
 
 (defvar caml-else-extra-indent nil
-  "*Extra indent for caml lines starting with the else keyword.
+  "*Extra indent for caml lines starting with the \"else\" keyword.
 Usually negative. nil is align on master.")
 (make-variable-buffer-local 'caml-else-extra-indent)
 
 (defvar caml-end-extra-indent nil
-  "*Extra indent for caml lines starting with the end keyword.
+  "*Extra indent for caml lines starting with the \"end\" keyword.
 Usually negative. nil is align on master.")
 (make-variable-buffer-local 'caml-end-extra-indent)
 
 (defvar caml-in-extra-indent nil
-  "*Extra indent for caml lines starting with the in keyword.
+  "*Extra indent for caml lines starting with the \"in\" keyword.
 Usually negative. nil is align on master.")
 (make-variable-buffer-local 'caml-in-extra-indent)
 
 (defvar caml-then-extra-indent nil
-  "*Extra indent for caml lines starting with the then keyword.
+  "*Extra indent for caml lines starting with the \"then\" keyword.
 Usually negative. nil is align on master.")
 (make-variable-buffer-local 'caml-then-extra-indent)
 
 (defvar caml-to-extra-indent -1
-  "*Extra indent for caml lines starting with the to keyword.
+  "*Extra indent for caml lines starting with the \"to\" keyword.
 Usually negative. nil is align on master.")
 (make-variable-buffer-local 'caml-to-extra-indent)
 
 (defvar caml-with-extra-indent nil
-  "*Extra indent for caml lines starting with the with keyword.
+  "*Extra indent for caml lines starting with the \"with\" keyword.
 Usually negative. nil is align on master.")
 (make-variable-buffer-local 'caml-with-extra-indent)
 

--- a/emacs/caml.el
+++ b/emacs/caml.el
@@ -83,7 +83,7 @@ Priorities are assigned to `interesting' caml operators as follows:
 (make-variable-buffer-local 'caml-class-indent)
 
 (defvar caml-exception-indent 2
-  "*How many spaces to indent from a exception keyword in caml mode.")
+  "*How many spaces to indent from an exception keyword in caml mode.")
 (make-variable-buffer-local 'caml-exception-indent)
 
 (defvar caml-for-indent 2
@@ -99,7 +99,7 @@ Priorities are assigned to `interesting' caml operators as follows:
 (make-variable-buffer-local 'caml-function-indent)
 
 (defvar caml-if-indent  2
-  "*How many spaces to indent from a if keyword in caml mode.")
+  "*How many spaces to indent from an if keyword in caml mode.")
 (make-variable-buffer-local 'caml-if-indent)
 
 (defvar caml-if-else-indent 0
@@ -107,15 +107,15 @@ Priorities are assigned to `interesting' caml operators as follows:
 (make-variable-buffer-local 'caml-if-else-indent)
 
 (defvar caml-inherit-indent 2
-  "*How many spaces to indent from a inherit keyword in caml mode.")
+  "*How many spaces to indent from an inherit keyword in caml mode.")
 (make-variable-buffer-local 'caml-inherit-indent)
 
 (defvar caml-initializer-indent 2
-  "*How many spaces to indent from a initializer keyword in caml mode.")
+  "*How many spaces to indent from an initializer keyword in caml mode.")
 (make-variable-buffer-local 'caml-initializer-indent)
 
 (defvar caml-include-indent 2
-  "*How many spaces to indent from a include keyword in caml mode.")
+  "*How many spaces to indent from an include keyword in caml mode.")
 (make-variable-buffer-local 'caml-include-indent)
 
 (defvar caml-let-indent 2
@@ -139,11 +139,11 @@ Priorities are assigned to `interesting' caml operators as follows:
 (make-variable-buffer-local 'caml-module-indent)
 
 (defvar caml-object-indent 2
-  "*How many spaces to indent from a object keyword in caml mode.")
+  "*How many spaces to indent from an object keyword in caml mode.")
 (make-variable-buffer-local 'caml-object-indent)
 
 (defvar caml-of-indent 2
-  "*How many spaces to indent from a of keyword in caml mode.")
+  "*How many spaces to indent from an of keyword in caml mode.")
 (make-variable-buffer-local 'caml-of-indent)
 
 (defvar caml-parser-indent 4
@@ -261,7 +261,7 @@ Usually negative. nil is align on master.")
 (make-variable-buffer-local 'caml-|-extra-indent)
 
 (defvar caml-rb-extra-indent -2
-  "*Extra indent for caml lines statring with ].
+  "*Extra indent for caml lines starting with ].
 Usually negative. nil is align on master.")
 
 (defvar caml-rc-extra-indent -2
@@ -275,13 +275,13 @@ Usually negative. nil is align on master.")
 (defvar caml-electric-indent t
   "*Non-nil means electrically indent lines starting with |, ] or }.
 
-Many people find eletric keys irritating, so you can disable them if
+Many people find electric keys irritating, so you can disable them if
 you are one.")
 
 (defvar caml-electric-close-vector t
   "*Non-nil means electrically insert a | before a vector-closing ].
 
-Many people find eletric keys irritating, so you can disable them if
+Many people find electric keys irritating, so you can disable them if
 you are one. You should probably have this on, though, if you also
 have caml-electric-indent on, which see.")
 
@@ -623,8 +623,8 @@ have caml-electric-indent on, which see.")
 (defun caml-eval-phrase (arg &optional min max)
   "Send the phrase containing the point to the CAML process.
 With prefix-arg send as many phrases as its numeric value,
-If an error occurs during evalutaion, stop at this phrase and
-repport the error.
+If an error occurs during evaluation, stop at this phrase and
+report the error.
 
 Return nil if noerror and position of error if any.
 
@@ -1136,7 +1136,7 @@ to the end.
 
 (defun caml-in-comment-p ()
   "Returns non-nil if point is inside a caml comment.
-Returns nil for the parenthesis openning a comment."
+Returns nil for the parenthesis opening a comment."
   ;;we look for comments differently than literals. there are two
   ;;reasons for this. first, caml has nested comments and it is not so
   ;;clear that parse-partial-sexp supports them; second, if proper
@@ -1266,7 +1266,7 @@ Used to distinguish it from toplevel let construct.")
   "Look back for a caml keyword or operator matching KWOP-REGEXP.
 Second optional argument MIN-POS bounds the search.
 
-Ignore occurences inside literals. If found, return a list of two
+Ignore occurrences inside literals. If found, return a list of two
 values: the actual text of the keyword or operator, and a boolean
 indicating whether the keyword was one we looked for explicitly
 {non-nil}, or on the other hand one of the block-terminating
@@ -1971,7 +1971,7 @@ with prefix arg, indent that many phrases starting with the current phrase."
   "Explore type annotations by mouse dragging." t)
 
 (autoload 'caml-help "caml-help"
-  "Show documentation for qualilifed OCaml identifier." t)
+  "Show documentation for qualified OCaml identifier." t)
 (autoload 'caml-complete "caml-help"
   "Does completion for documented qualified OCaml identifier." t)
 (autoload 'ocaml-open-module "caml-help"

--- a/emacs/camldebug.el
+++ b/emacs/camldebug.el
@@ -99,7 +99,7 @@ The following commands are available:
 the last line referred to in the camldebug buffer.
 
 \\[camldebug-step], \\[camldebug-back] and \\[camldebug-next], in the camldebug
-window,call camldebug to step, backstep or next and then update the other window
+window, call camldebug to step, backstep or next and then update the other window
 with the current file and position.
 
 If you are in a source file, you may select a point to break

--- a/emacs/inf-caml.el
+++ b/emacs/inf-caml.el
@@ -23,7 +23,7 @@
 
 ;; User modifiable variables
 
-;; Whether you want the output buffer to be diplayed when you send a phrase
+;; Whether you want the output buffer to be displayed when you send a phrase
 
 (defvar caml-display-when-eval t
   "*If true, display the inferior caml buffer when evaluating expressions.")
@@ -205,7 +205,7 @@ Input and output via buffer `*inferior-caml*'."
     (goto-char loc)))
 
 
-;;; orgininal inf-caml.el ended here
+;;; original inf-caml.el ended here
 
 ;; as eval-phrase, but ignores errors.
 
@@ -225,16 +225,16 @@ should lies."
     beg))
 
 (defvar caml-previous-output nil
-  "tells the beginning of output in the shell-output buffer, so that the
-output can be retreived later, asynchronously.")
+  "Tells the beginning of output in the shell-output buffer, so that the
+output can be retrieved later, asynchronously.")
 
-;; enriched version of eval-phrase, to repport errors.
+;; enriched version of eval-phrase, to report errors.
 
 (defun inferior-caml-eval-phrase (arg &optional min max)
   "Send the phrase containing the point to the CAML process.
 With prefix-arg send as many phrases as its numeric value,
-If an error occurs during evalutaion, stop at this phrase and
-repport the error.
+If an error occurs during evaluation, stop at this phrase and
+report the error.
 
 Return nil if noerror and position of error if any.
 


### PR DESCRIPTION
The first commit of this PR includes grammar-related changes to Emacs Lisp sources that were cherry-picked from #817 by @Fourchaux, taking the most obvious and uncontroversial fixes, as well as adding a few by myself.

The second commit includes a bit of cosmetic sugar for the docstrings (it truly bothered me).