### PR TITLE
Travis: test a compiler with -no-flat-float-array set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
         - libc6-dev:i386
   - env: CI_KIND=build XARCH=x64
   - env: CI_KIND=build XARCH=x64 CONFIG_ARG=-flambda OCAMLRUNPARAM=b,v=0
+  - env: CI_KIND=build XARCH=x64 CONFIG_ARG=-no-flat-float-array
   - env: CI_KIND=changes
   - env: CI_KIND=tests
   allow_failures:


### PR DESCRIPTION
We have some tests whose behavior differ when `-no-flat-float-array` is set and they are currently not checked by our continuous integration. In fact, they remained broken for months, between #556 merged on September 25 and #1516 merged on December 7th.

This PR proposes to add a new check to the Travis CI that runs the testsuite with `-no-flat-float-array` set.

I'm a bit torn over whether this flag (which affects a couple test, and maybe three/four PRs each releases) is worth a 20% increase in computing resources used for continuous integration.