### PR TITLE
Internationalization: a localization hook for compiler-libs

### DIFF
--- a/.depend
+++ b/.depend
@@ -318,6 +318,7 @@ parsing/location.cmo : \
     utils/warnings.cmi \
     utils/terminfo.cmi \
     utils/misc.cmi \
+    utils/i18n.cmi \
     utils/clflags.cmi \
     utils/build_path_prefix_map.cmi \
     parsing/location.cmi
@@ -325,6 +326,7 @@ parsing/location.cmx : \
     utils/warnings.cmx \
     utils/terminfo.cmx \
     utils/misc.cmx \
+    utils/i18n.cmx \
     utils/clflags.cmx \
     utils/build_path_prefix_map.cmx \
     parsing/location.cmi
@@ -519,7 +521,6 @@ typing/env.cmo : \
     parsing/location.cmi \
     utils/load_path.cmi \
     typing/ident.cmi \
-    utils/i18n.cmi \
     typing/datarepr.cmi \
     file_formats/cmi_format.cmi \
     utils/clflags.cmi \
@@ -539,7 +540,6 @@ typing/env.cmx : \
     parsing/location.cmx \
     utils/load_path.cmx \
     typing/ident.cmx \
-    utils/i18n.cmx \
     typing/datarepr.cmx \
     file_formats/cmi_format.cmx \
     utils/clflags.cmx \
@@ -595,7 +595,6 @@ typing/includeclass.cmo : \
     typing/types.cmi \
     typing/printtyp.cmi \
     typing/path.cmi \
-    utils/i18n.cmi \
     typing/ctype.cmi \
     parsing/builtin_attributes.cmi \
     typing/includeclass.cmi
@@ -603,7 +602,6 @@ typing/includeclass.cmx : \
     typing/types.cmx \
     typing/printtyp.cmx \
     typing/path.cmx \
-    utils/i18n.cmx \
     typing/ctype.cmx \
     parsing/builtin_attributes.cmx \
     typing/includeclass.cmi
@@ -619,7 +617,6 @@ typing/includecore.cmo : \
     typing/printtyp.cmi \
     typing/path.cmi \
     typing/ident.cmi \
-    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     parsing/builtin_attributes.cmi \
@@ -633,7 +630,6 @@ typing/includecore.cmx : \
     typing/printtyp.cmx \
     typing/path.cmx \
     typing/ident.cmx \
-    utils/i18n.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     parsing/builtin_attributes.cmx \
@@ -647,7 +643,6 @@ typing/includecore.cmi : \
     typing/path.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
-    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi
 typing/includemod.cmo : \
@@ -665,7 +660,6 @@ typing/includemod.cmo : \
     typing/includecore.cmi \
     typing/includeclass.cmi \
     typing/ident.cmi \
-    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     file_formats/cmt_format.cmi \
@@ -688,7 +682,6 @@ typing/includemod.cmx : \
     typing/includecore.cmx \
     typing/includeclass.cmx \
     typing/ident.cmx \
-    utils/i18n.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     file_formats/cmt_format.cmx \
@@ -836,6 +829,7 @@ typing/persistent_env.cmi : \
     file_formats/cmi_format.cmi
 typing/predef.cmo : \
     typing/types.cmi \
+    typing/type_immediacy.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
     parsing/location.cmi \
@@ -846,6 +840,7 @@ typing/predef.cmo : \
     typing/predef.cmi
 typing/predef.cmx : \
     typing/types.cmx \
+    typing/type_immediacy.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \
     parsing/location.cmx \
@@ -905,7 +900,6 @@ typing/printtyp.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
-    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     utils/clflags.cmi \
@@ -926,7 +920,6 @@ typing/printtyp.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
-    utils/i18n.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     utils/clflags.cmx \
@@ -940,7 +933,6 @@ typing/printtyp.cmi : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
-    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     parsing/asttypes.cmi
@@ -1095,7 +1087,6 @@ typing/typeclass.cmo : \
     parsing/location.cmi \
     typing/includeclass.cmi \
     typing/ident.cmi \
-    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     file_formats/cmt_format.cmi \
@@ -1125,7 +1116,6 @@ typing/typeclass.cmx : \
     parsing/location.cmx \
     typing/includeclass.cmx \
     typing/ident.cmx \
-    utils/i18n.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     file_formats/cmt_format.cmx \
@@ -1142,7 +1132,6 @@ typing/typeclass.cmi : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
-    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     parsing/asttypes.cmi
@@ -1249,7 +1238,6 @@ typing/typedecl.cmo : \
     parsing/location.cmi \
     typing/includecore.cmi \
     typing/ident.cmi \
-    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     utils/config.cmi \
@@ -1284,7 +1272,6 @@ typing/typedecl.cmx : \
     parsing/location.cmx \
     typing/includecore.cmx \
     typing/ident.cmx \
-    utils/i18n.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     utils/config.cmx \
@@ -1308,7 +1295,6 @@ typing/typedecl.cmi : \
     parsing/location.cmi \
     typing/includecore.cmi \
     typing/ident.cmi \
-    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     parsing/asttypes.cmi
@@ -1577,6 +1563,7 @@ typing/types.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    utils/identifiable.cmi \
     typing/ident.cmi \
     utils/config.cmi \
     parsing/asttypes.cmi \
@@ -1589,6 +1576,7 @@ typing/types.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
+    utils/identifiable.cmx \
     typing/ident.cmx \
     utils/config.cmx \
     parsing/asttypes.cmi \
@@ -1600,6 +1588,7 @@ typing/types.cmi : \
     parsing/parsetree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    utils/identifiable.cmi \
     typing/ident.cmi \
     parsing/asttypes.cmi
 typing/typetexp.cmo : \
@@ -1614,7 +1603,6 @@ typing/typetexp.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
-    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     utils/clflags.cmi \
@@ -1635,7 +1623,6 @@ typing/typetexp.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
-    utils/i18n.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     utils/clflags.cmx \
@@ -3339,6 +3326,7 @@ lambda/simplif.cmo : \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     utils/clflags.cmi \
     parsing/asttypes.cmi \
     typing/annot.cmi \
@@ -3350,6 +3338,7 @@ lambda/simplif.cmx : \
     parsing/location.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
+    utils/i18n.cmx \
     utils/clflags.cmx \
     parsing/asttypes.cmi \
     typing/annot.cmi \
@@ -3677,6 +3666,7 @@ middle_end/closure/closure.cmo : \
     parsing/location.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     typing/env.cmi \
     lambda/debuginfo.cmi \
     middle_end/convert_primitives.cmi \
@@ -3700,6 +3690,7 @@ middle_end/closure/closure.cmx : \
     parsing/location.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
+    utils/i18n.cmx \
     typing/env.cmx \
     lambda/debuginfo.cmx \
     middle_end/convert_primitives.cmx \
@@ -4274,6 +4265,7 @@ middle_end/flambda/flambda_middle_end.cmo : \
     middle_end/flambda/inlining_cost.cmi \
     middle_end/flambda/inline_and_simplify.cmi \
     middle_end/flambda/initialize_symbol_to_let_symbol.cmi \
+    utils/i18n.cmi \
     middle_end/flambda/flambda_to_clambda.cmi \
     middle_end/flambda/flambda_iterators.cmi \
     middle_end/flambda/flambda_invariants.cmi \
@@ -4309,6 +4301,7 @@ middle_end/flambda/flambda_middle_end.cmx : \
     middle_end/flambda/inlining_cost.cmx \
     middle_end/flambda/inline_and_simplify.cmx \
     middle_end/flambda/initialize_symbol_to_let_symbol.cmx \
+    utils/i18n.cmx \
     middle_end/flambda/flambda_to_clambda.cmx \
     middle_end/flambda/flambda_iterators.cmx \
     middle_end/flambda/flambda_invariants.cmx \
@@ -4608,6 +4601,7 @@ middle_end/flambda/inline_and_simplify.cmo : \
     middle_end/flambda/inlining_cost.cmi \
     middle_end/flambda/inline_and_simplify_aux.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     middle_end/flambda/freshening.cmi \
     middle_end/flambda/flambda_utils.cmi \
     middle_end/flambda/flambda.cmi \
@@ -4651,6 +4645,7 @@ middle_end/flambda/inline_and_simplify.cmx : \
     middle_end/flambda/inlining_cost.cmx \
     middle_end/flambda/inline_and_simplify_aux.cmx \
     typing/ident.cmx \
+    utils/i18n.cmx \
     middle_end/flambda/freshening.cmx \
     middle_end/flambda/flambda_utils.cmx \
     middle_end/flambda/flambda.cmx \
@@ -5783,6 +5778,7 @@ driver/compile_common.cmi : \
     typing/env.cmi
 driver/compmisc.cmo : \
     utils/warnings.cmi \
+    typing/types.cmi \
     typing/typemod.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
@@ -5795,6 +5791,7 @@ driver/compmisc.cmo : \
     driver/compmisc.cmi
 driver/compmisc.cmx : \
     utils/warnings.cmx \
+    typing/types.cmx \
     typing/typemod.cmx \
     utils/misc.cmx \
     parsing/location.cmx \

--- a/.depend
+++ b/.depend
@@ -58,6 +58,11 @@ utils/domainstate.cmo : \
 utils/domainstate.cmx : \
     utils/domainstate.cmi
 utils/domainstate.cmi :
+utils/i18n.cmo : \
+    utils/i18n.cmi
+utils/i18n.cmx : \
+    utils/i18n.cmi
+utils/i18n.cmi :
 utils/identifiable.cmo : \
     utils/misc.cmi \
     utils/identifiable.cmi
@@ -130,11 +135,14 @@ utils/terminfo.cmx : \
 utils/terminfo.cmi :
 utils/warnings.cmo : \
     utils/misc.cmi \
+    utils/i18n.cmi \
     utils/warnings.cmi
 utils/warnings.cmx : \
     utils/misc.cmx \
+    utils/i18n.cmx \
     utils/warnings.cmi
-utils/warnings.cmi :
+utils/warnings.cmi : \
+    utils/i18n.cmi
 parsing/ast_helper.cmo : \
     parsing/syntaxerr.cmi \
     parsing/parsetree.cmi \
@@ -511,6 +519,7 @@ typing/env.cmo : \
     parsing/location.cmi \
     utils/load_path.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     typing/datarepr.cmi \
     file_formats/cmi_format.cmi \
     utils/clflags.cmi \
@@ -530,6 +539,7 @@ typing/env.cmx : \
     parsing/location.cmx \
     utils/load_path.cmx \
     typing/ident.cmx \
+    utils/i18n.cmx \
     typing/datarepr.cmx \
     file_formats/cmi_format.cmx \
     utils/clflags.cmx \
@@ -585,6 +595,7 @@ typing/includeclass.cmo : \
     typing/types.cmi \
     typing/printtyp.cmi \
     typing/path.cmi \
+    utils/i18n.cmi \
     typing/ctype.cmi \
     parsing/builtin_attributes.cmi \
     typing/includeclass.cmi
@@ -592,6 +603,7 @@ typing/includeclass.cmx : \
     typing/types.cmx \
     typing/printtyp.cmx \
     typing/path.cmx \
+    utils/i18n.cmx \
     typing/ctype.cmx \
     parsing/builtin_attributes.cmx \
     typing/includeclass.cmi
@@ -607,6 +619,7 @@ typing/includecore.cmo : \
     typing/printtyp.cmi \
     typing/path.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     parsing/builtin_attributes.cmi \
@@ -620,6 +633,7 @@ typing/includecore.cmx : \
     typing/printtyp.cmx \
     typing/path.cmx \
     typing/ident.cmx \
+    utils/i18n.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     parsing/builtin_attributes.cmx \
@@ -633,6 +647,7 @@ typing/includecore.cmi : \
     typing/path.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi
 typing/includemod.cmo : \
@@ -650,6 +665,7 @@ typing/includemod.cmo : \
     typing/includecore.cmi \
     typing/includeclass.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     file_formats/cmt_format.cmi \
@@ -672,6 +688,7 @@ typing/includemod.cmx : \
     typing/includecore.cmx \
     typing/includeclass.cmx \
     typing/ident.cmx \
+    utils/i18n.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     file_formats/cmt_format.cmx \
@@ -888,6 +905,7 @@ typing/printtyp.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     utils/clflags.cmi \
@@ -908,6 +926,7 @@ typing/printtyp.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
+    utils/i18n.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     utils/clflags.cmx \
@@ -921,6 +940,7 @@ typing/printtyp.cmi : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     parsing/asttypes.cmi
@@ -1075,6 +1095,7 @@ typing/typeclass.cmo : \
     parsing/location.cmi \
     typing/includeclass.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     file_formats/cmt_format.cmi \
@@ -1104,6 +1125,7 @@ typing/typeclass.cmx : \
     parsing/location.cmx \
     typing/includeclass.cmx \
     typing/ident.cmx \
+    utils/i18n.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     file_formats/cmt_format.cmx \
@@ -1120,6 +1142,7 @@ typing/typeclass.cmi : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     parsing/asttypes.cmi
@@ -1146,6 +1169,7 @@ typing/typecore.cmo : \
     parsing/longident.cmi \
     parsing/location.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     file_formats/cmt_format.cmi \
@@ -1179,6 +1203,7 @@ typing/typecore.cmx : \
     parsing/longident.cmx \
     parsing/location.cmx \
     typing/ident.cmx \
+    utils/i18n.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     file_formats/cmt_format.cmx \
@@ -1224,6 +1249,7 @@ typing/typedecl.cmo : \
     parsing/location.cmi \
     typing/includecore.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     utils/config.cmi \
@@ -1258,6 +1284,7 @@ typing/typedecl.cmx : \
     parsing/location.cmx \
     typing/includecore.cmx \
     typing/ident.cmx \
+    utils/i18n.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     utils/config.cmx \
@@ -1281,6 +1308,7 @@ typing/typedecl.cmi : \
     parsing/location.cmi \
     typing/includecore.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     parsing/asttypes.cmi
@@ -1450,6 +1478,7 @@ typing/typemod.cmo : \
     utils/load_path.cmi \
     typing/includemod.cmi \
     typing/ident.cmi \
+    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     utils/config.cmi \
@@ -1483,6 +1512,7 @@ typing/typemod.cmx : \
     utils/load_path.cmx \
     typing/includemod.cmx \
     typing/ident.cmx \
+    utils/i18n.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     utils/config.cmx \
@@ -1584,6 +1614,7 @@ typing/typetexp.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
+    utils/i18n.cmi \
     typing/env.cmi \
     typing/ctype.cmi \
     utils/clflags.cmi \
@@ -1604,6 +1635,7 @@ typing/typetexp.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
+    utils/i18n.cmx \
     typing/env.cmx \
     typing/ctype.cmx \
     utils/clflags.cmx \

--- a/Changes
+++ b/Changes
@@ -156,6 +156,9 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #1523: localization hook for compiler-libs
+  (Florian Angeletti, review by ??)
+
 - GPR#1664: make -output-complete-obj link the runtime native c libraries when
   building shared libraries like `-output-obj`.
   (Florian Angeletti, review by Nicolás Ojeda Bär)

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -195,7 +195,7 @@ let compile_implementation ?toplevel ~backend ~filename ~prefixname ~middle_end
 
 let report_error ppf = function
   | Assembler_error file ->
-      fprintf ppf "Assembler error, input left in file %a"
+      I18n.fprintf ppf "Assembler error, input left in file %a"
         Location.print_filename file
 
 let () =

--- a/asmcomp/asmlibrarian.ml
+++ b/asmcomp/asmlibrarian.ml
@@ -69,13 +69,11 @@ let create_archive file_list lib_name =
        then raise(Error(Archiver_error archive_name));
     )
 
-open Format
-
 let report_error ppf = function
   | File_not_found name ->
-      fprintf ppf "Cannot find file %s" name
+      I18n.fprintf ppf "Cannot find file %s" name
   | Archiver_error name ->
-      fprintf ppf "Error while creating the library %s" name
+      I18n.fprintf ppf "Error while creating the library %s" name
 
 let () =
   Location.register_error_of_exn

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -376,54 +376,52 @@ let link ~ppf_dump objfiles output_name =
 
 (* Error report *)
 
-open Format
-
 let report_error ppf = function
   | File_not_found name ->
-      fprintf ppf "Cannot find file %s" name
+      I18n.fprintf ppf "Cannot find file %s" name
   | Not_an_object_file name ->
-      fprintf ppf "The file %a is not a compilation unit description"
+      I18n.fprintf ppf "The file %a is not a compilation unit description"
         Location.print_filename name
   | Missing_implementations l ->
-     let print_references ppf = function
-       | [] -> ()
-       | r1 :: rl ->
-           fprintf ppf "%s" r1;
-           List.iter (fun r -> fprintf ppf ",@ %s" r) rl in
+      let print_references ppf = function
+        | [] -> ()
+        | r1 :: rl ->
+            Format.fprintf ppf "%s" r1;
+            List.iter (fun r -> Format.fprintf ppf ",@ %s" r) rl in
       let print_modules ppf =
         List.iter
-         (fun (md, rq) ->
-            fprintf ppf "@ @[<hov 2>%s referenced from %a@]" md
-            print_references rq) in
-      fprintf ppf
-       "@[<v 2>No implementations provided for the following modules:%a@]"
-       print_modules l
+          (fun (md, rq) ->
+             I18n.fprintf ppf "@ @[<hov 2>%s referenced from %a@]" md
+               print_references rq) in
+      I18n.fprintf ppf
+        "@[<v 2>No implementations provided for the following modules:%a@]"
+        print_modules l
   | Inconsistent_interface(intf, file1, file2) ->
-      fprintf ppf
-       "@[<hov>Files %a@ and %a@ make inconsistent assumptions \
-              over interface %s@]"
-       Location.print_filename file1
-       Location.print_filename file2
-       intf
+      I18n.fprintf ppf
+        "@[<hov>Files %a@ and %a@ make inconsistent assumptions \
+         over interface %s@]"
+        Location.print_filename file1
+        Location.print_filename file2
+        intf
   | Inconsistent_implementation(intf, file1, file2) ->
-      fprintf ppf
-       "@[<hov>Files %a@ and %a@ make inconsistent assumptions \
-              over implementation %s@]"
-       Location.print_filename file1
-       Location.print_filename file2
-       intf
+      I18n.fprintf ppf
+        "@[<hov>Files %a@ and %a@ make inconsistent assumptions \
+         over implementation %s@]"
+        Location.print_filename file1
+        Location.print_filename file2
+        intf
   | Assembler_error file ->
-      fprintf ppf "Error while assembling %a" Location.print_filename file
+      I18n.fprintf ppf "Error while assembling %a" Location.print_filename file
   | Linking_error ->
-      fprintf ppf "Error during linking"
+      I18n.fprintf ppf "Error during linking"
   | Multiple_definition(modname, file1, file2) ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[<hov>Files %a@ and %a@ both define a module named %s@]"
         Location.print_filename file1
         Location.print_filename file2
         modname
   | Missing_cmx(filename, name) ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[<hov>File %a@ was compiled without access@ \
          to the .cmx file@ for module %s,@ \
          which was produced by `ocamlopt -for-pack'.@ \

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -276,25 +276,24 @@ let package_files ~ppf_dump initial_env files targetcmx ~backend =
 
 (* Error report *)
 
-open Format
-
 let report_error ppf = function
     Illegal_renaming(name, file, id) ->
-      fprintf ppf "Wrong file naming: %a@ contains the code for\
-                   @ %s when %s was expected"
+      I18n.fprintf ppf
+        "Wrong file naming: %a@ contains the code for@ %s when %s was expected"
         Location.print_filename file name id
   | Forward_reference(file, ident) ->
-      fprintf ppf "Forward reference to %s in file %a" ident
+      I18n.fprintf ppf "Forward reference to %s in file %a" ident
         Location.print_filename file
   | Wrong_for_pack(file, path) ->
-      fprintf ppf "File %a@ was not compiled with the `-for-pack %s' option"
-              Location.print_filename file path
+      I18n.fprintf ppf
+        "File %a@ was not compiled with the `-for-pack %s' option"
+        Location.print_filename file path
   | File_not_found file ->
-      fprintf ppf "File %s not found" file
+      I18n.fprintf ppf "File %s not found" file
   | Assembler_error file ->
-      fprintf ppf "Error while assembling %s" file
+      I18n.fprintf ppf "Error while assembling %s" file
   | Linking_error ->
-      fprintf ppf "Error during partial linking"
+      I18n.fprintf ppf "Error during partial linking"
 
 let () =
   Location.register_error_of_exn

--- a/bytecomp/bytelibrarian.ml
+++ b/bytecomp/bytelibrarian.ml
@@ -113,13 +113,11 @@ let create_archive file_list lib_name =
        output_binary_int outchan pos_toc;
     )
 
-open Format
-
 let report_error ppf = function
   | File_not_found name ->
-      fprintf ppf "Cannot find file %s" name
+      I18n.fprintf ppf "Cannot find file %s" name
   | Not_an_object_file name ->
-      fprintf ppf "The file %a is not a bytecode object file"
+      I18n.fprintf ppf "The file %a is not a bytecode object file"
         Location.print_filename name
 
 let () =

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -711,39 +711,39 @@ let link objfiles output_name =
 
 (* Error report *)
 
-open Format
-
 let report_error ppf = function
   | File_not_found name ->
-      fprintf ppf "Cannot find file %a" Location.print_filename name
+      I18n.fprintf ppf "Cannot find file %a" Location.print_filename name
   | Not_an_object_file name ->
-      fprintf ppf "The file %a is not a bytecode object file"
+      I18n.fprintf ppf "The file %a is not a bytecode object file"
         Location.print_filename name
   | Wrong_object_name name ->
-      fprintf ppf "The output file %s has the wrong name. The extension implies\
-                  \ an object file but the link step was requested" name
+      I18n.fprintf ppf
+        "The output file %s has the wrong name. The extension implies\
+        \ an object file but the link step was requested" name
   | Symbol_error(name, err) ->
-      fprintf ppf "Error while linking %a:@ %a" Location.print_filename name
-      Symtable.report_error err
+      I18n.fprintf ppf
+        "Error while linking %a:@ %a" Location.print_filename name
+        Symtable.report_error err
   | Inconsistent_import(intf, file1, file2) ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[<hov>Files %a@ and %a@ \
-                 make inconsistent assumptions over interface %s@]"
+         make inconsistent assumptions over interface %s@]"
         Location.print_filename file1
         Location.print_filename file2
         intf
   | Custom_runtime ->
-      fprintf ppf "Error while building custom runtime system"
+      I18n.fprintf ppf "Error while building custom runtime system"
   | File_exists file ->
-      fprintf ppf "Cannot overwrite existing file %a"
+      I18n.fprintf ppf "Cannot overwrite existing file %a"
         Location.print_filename file
   | Cannot_open_dll file ->
-      fprintf ppf "Error on dynamically loaded library: %a"
+      I18n.fprintf ppf "Error on dynamically loaded library: %a"
         Location.print_filename file
   | Required_module_unavailable s ->
-      fprintf ppf "Required module `%s' is unavailable" s
+      I18n.fprintf ppf "Required module `%s' is unavailable" s
   | Camlheader (msg, header) ->
-      fprintf ppf "System error while copying file %s: %s" header msg
+      I18n.fprintf ppf "System error while copying file %s: %s" header msg
 
 let () =
   Location.register_error_of_exn

--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -297,25 +297,23 @@ let package_files ~ppf_dump initial_env files targetfile =
 
 (* Error report *)
 
-open Format
-
 let report_error ppf = function
     Forward_reference(file, ident) ->
-      fprintf ppf "Forward reference to %s in file %a" (Ident.name ident)
+      I18n.fprintf ppf "Forward reference to %s in file %a" (Ident.name ident)
         Location.print_filename file
   | Multiple_definition(file, ident) ->
-      fprintf ppf "File %a redefines %s"
+      I18n.fprintf ppf "File %a redefines %s"
         Location.print_filename file
         (Ident.name ident)
   | Not_an_object_file file ->
-      fprintf ppf "%a is not a bytecode object file"
+      I18n.fprintf ppf "%a is not a bytecode object file"
         Location.print_filename file
   | Illegal_renaming(name, file, id) ->
-      fprintf ppf "Wrong file naming: %a@ contains the code for\
-                   @ %s when %s was expected"
+      I18n.fprintf ppf "Wrong file naming: %a@ contains the code for\
+                        @ %s when %s was expected"
         Location.print_filename file name id
   | File_not_found file ->
-      fprintf ppf "File %s not found" file
+      I18n.fprintf ppf "File %s not found" file
 
 let () =
   Location.register_error_of_exn

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -399,17 +399,15 @@ let empty_global_map = GlobalMap.empty
 
 (* Error report *)
 
-open Format
-
 let report_error ppf = function
   | Undefined_global s ->
-      fprintf ppf "Reference to undefined global `%s'" s
+      I18n.fprintf ppf "Reference to undefined global `%s'" s
   | Unavailable_primitive s ->
-      fprintf ppf "The external function `%s' is not available" s
+      I18n.fprintf ppf "The external function `%s' is not available" s
   | Wrong_vm s ->
-      fprintf ppf "Cannot find or execute the runtime system %s" s
+      I18n.fprintf ppf "Cannot find or execute the runtime system %s" s
   | Uninitialized_global s ->
-      fprintf ppf "The value of the global `%s' is not yet computed" s
+      I18n.fprintf ppf "The value of the global `%s' is not yet computed" s
 
 let () =
   Location.register_error_of_exn

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -27,7 +27,7 @@
 UTILS=utils/config.cmo utils/build_path_prefix_map.cmo utils/misc.cmo \
 	utils/identifiable.cmo utils/numbers.cmo utils/arg_helper.cmo \
 	utils/clflags.cmo utils/profile.cmo utils/load_path.cmo \
-	utils/terminfo.cmo utils/ccomp.cmo utils/warnings.cmo \
+	utils/terminfo.cmo utils/ccomp.cmo utils/i18n.cmo utils/warnings.cmo \
 	utils/consistbl.cmo utils/strongly_connected_components.cmo \
 	utils/targetint.cmo utils/int_replace_polymorphic_compare.cmo \
 	utils/domainstate.cmo

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -13,8 +13,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Format
-
 type error =
   | CannotRun of string
   | WrongMagic of string
@@ -155,7 +153,9 @@ let open_and_check_magic inputfile ast_magic =
       else false
     with
       Outdated_version ->
-        Misc.fatal_error "OCaml and preprocessor have incompatible versions"
+        Misc.fatal_error
+          (I18n.to_string @@
+           I18n.s "OCaml and preprocessor have incompatible versions")
     | _ -> false
   in
   (ic, is_ast_file)
@@ -199,10 +199,10 @@ let file ~tool_name inputfile parse_fun ast_kind =
 
 let report_error ppf = function
   | CannotRun cmd ->
-      fprintf ppf "Error while running external preprocessor@.\
+      I18n.fprintf ppf "Error while running external preprocessor@.\
                    Command line: %s@." cmd
   | WrongMagic cmd ->
-      fprintf ppf "External preprocessor does not produce a valid file@.\
+      I18n.fprintf ppf "External preprocessor does not produce a valid file@.\
                    Command line: %s@." cmd
 
 let () =

--- a/dune
+++ b/dune
@@ -44,7 +44,7 @@
  (modules
    ;; UTILS
    config build_path_prefix_map misc identifiable numbers arg_helper clflags
-   profile terminfo ccomp warnings consistbl strongly_connected_components
+   profile terminfo ccomp i18n warnings consistbl strongly_connected_components
    targetint load_path int_replace_polymorphic_compare
 
    ;; PARSING

--- a/file_formats/cmi_format.ml
+++ b/file_formats/cmi_format.ml
@@ -95,19 +95,17 @@ let output_cmi filename oc cmi =
 
 (* Error report *)
 
-open Format
-
 let report_error ppf = function
   | Not_an_interface filename ->
-      fprintf ppf "%a@ is not a compiled interface"
+      I18n.fprintf ppf "%a@ is not a compiled interface"
         Location.print_filename filename
   | Wrong_version_interface (filename, older_newer) ->
-      fprintf ppf
+      I18n.fprintf ppf
         "%a@ is not a compiled interface for this version of OCaml.@.\
          It seems to be for %s version of OCaml."
         Location.print_filename filename older_newer
   | Corrupted_interface filename ->
-      fprintf ppf "Corrupted compiled interface@ %a"
+      I18n.fprintf ppf "Corrupted compiled interface@ %a"
         Location.print_filename filename
 
 let () =

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -774,9 +774,10 @@ let simplify_local_functions lam =
   let current_scope = ref lam in
   let check_static lf =
     if lf.attr.local = Always_local then
+      let msg =
+        I18n.s "This function cannot be compiled into a static continuation" in
       Location.prerr_warning lf.loc
-        (Warnings.Inlining_impossible
-           "This function cannot be compiled into a static continuation")
+        (Warnings.Inlining_impossible msg)
   in
   let enabled = function
     | {local = Always_local; _}

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -929,11 +929,9 @@ let () =
 
 (* Error report *)
 
-open Format
-
 let report_error ppf = function
   | Tags (lab1, lab2) ->
-      fprintf ppf "Method labels `%s' and `%s' are incompatible.@ %s"
+      I18n.fprintf ppf "Method labels `%s' and `%s' are incompatible.@ %s"
         lab1 lab2 "Change one of them."
 
 let () =

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1042,14 +1042,12 @@ let transl_let rec_flag pat_expr_list body =
 
 (* Error report *)
 
-open Format
-
 let report_error ppf = function
   | Free_super_var ->
-      fprintf ppf
+      I18n.fprintf ppf
         "Ancestor names can only be used to select inherited methods"
   | Unreachable_reached ->
-      fprintf ppf "Unreachable expression was reached"
+      I18n.fprintf ppf "Unreachable expression was reached"
 
 let () =
   Location.register_error_of_exn

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -815,13 +815,11 @@ let transl_primitive_application loc p env ty path exp args arg_exps =
 
 (* Error report *)
 
-open Format
-
 let report_error ppf = function
   | Unknown_builtin_primitive prim_name ->
-      fprintf ppf "Unknown builtin primitive \"%s\"" prim_name
+      I18n.fprintf ppf "Unknown builtin primitive \"%s\"" prim_name
   | Wrong_arity_builtin_primitive prim_name ->
-      fprintf ppf "Wrong arity for builtin primitive \"%s\"" prim_name
+      I18n.fprintf ppf "Wrong arity for builtin primitive \"%s\"" prim_name
 
 let () =
   Location.register_error_of_exn

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -783,7 +783,7 @@ let direct_apply env fundesc ufunct uargs ~loc ~attribute =
     | _, Never_inline | None, _ ->
       let dbg = Debuginfo.from_location loc in
         warning_if_forced_inline ~loc ~attribute
-          "Function information unavailable";
+          (I18n.s "Function information unavailable");
         Udirect_apply(fundesc.fun_label, app_args, dbg)
     | Some(params, body), _  ->
         bind_params env loc fundesc.fun_float_const_prop params app_args
@@ -955,7 +955,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
           iter first_args
             (Ulet (Immutable, Pgenval, VP.create funct_var, ufunct, new_fun))
         in
-        warning_if_forced_inline ~loc ~attribute "Partial application";
+        warning_if_forced_inline ~loc ~attribute (I18n.s "Partial application");
         (new_fun, approx)
 
       | ((ufunct, Value_closure(fundesc, _approx_res)), uargs)
@@ -965,7 +965,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
           let first_args = List.map (fun (id, _) -> Uvar id) first_args in
           let rem_args = List.map (fun (id, _) -> Uvar id) rem_args in
           let dbg = Debuginfo.from_location loc in
-          warning_if_forced_inline ~loc ~attribute "Over-application";
+          warning_if_forced_inline ~loc ~attribute (I18n.s "Over-application");
           let body =
             Ugeneric_apply(direct_apply env ~loc ~attribute
                               fundesc ufunct first_args,
@@ -980,7 +980,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
           result, Value_unknown
       | ((ufunct, _), uargs) ->
           let dbg = Debuginfo.from_location loc in
-          warning_if_forced_inline ~loc ~attribute "Unknown function";
+          warning_if_forced_inline ~loc ~attribute (I18n.s "Unknown function");
           (Ugeneric_apply(ufunct, uargs, dbg), Value_unknown)
       end
   | Lsend(kind, met, obj, args, loc) ->

--- a/middle_end/flambda/flambda_middle_end.ml
+++ b/middle_end/flambda/flambda_middle_end.ml
@@ -177,15 +177,18 @@ let lambda_to_flambda ~ppf_dump ~prefixname ~backend ~size ~filename
                   (inline_and_simplify.ml line 710). *)
                Location.prerr_warning (Debuginfo.to_location apply.dbg)
                  (Warnings.Inlining_impossible
-                    "[@inlined] attribute was not used on this function \
-                     application (the optimizer did not know what function \
-                     was being applied)")
+                    (I18n.s
+                       "[@inlined] attribute was not used on this function \
+                        application (the optimizer did not know what function \
+                        was being applied)")
+                 )
              | Unroll _ ->
                Location.prerr_warning (Debuginfo.to_location apply.dbg)
                  (Warnings.Inlining_impossible
-                    "[@unroll] attribute was not used on this function \
-                     application (the optimizer did not know what function \
-                     was being applied)"));
+                    (I18n.s
+                       "[@unroll] attribute was not used on this function \
+                        application (the optimizer did not know what function \
+                        was being applied)")));
            if !Clflags.dump_flambda
            then
              Format.fprintf ppf_dump "End of middle end:@ %a@."

--- a/middle_end/flambda/inline_and_simplify.ml
+++ b/middle_end/flambda/inline_and_simplify.ml
@@ -793,20 +793,24 @@ and simplify_partial_application env r ~lhs_of_application
      of type class like thing. *)
   begin match (inline_requested : Lambda.inline_attribute) with
   | Always_inline | Never_inline ->
+      let msg = I18n.s
+        "[@inlined] attributes may not be used on partial applications" in
     Location.prerr_warning (Debuginfo.to_location dbg)
-      (Warnings.Inlining_impossible "[@inlined] attributes may not be used \
-        on partial applications")
+      (Warnings.Inlining_impossible msg)
   | Unroll _ ->
     Location.prerr_warning (Debuginfo.to_location dbg)
-      (Warnings.Inlining_impossible "[@unroll] attributes may not be used \
-        on partial applications")
+      (Warnings.Inlining_impossible
+         (I18n.s "[@unroll] attributes may not be used on partial applications")
+      )
   | Default_inline -> ()
   end;
   begin match (specialise_requested : Lambda.specialise_attribute) with
   | Always_specialise | Never_specialise ->
     Location.prerr_warning (Debuginfo.to_location dbg)
-      (Warnings.Inlining_impossible "[@specialised] attributes may not be used \
-        on partial applications")
+      (Warnings.Inlining_impossible
+         ( I18n.s "[@specialised] attributes may not be used on \
+                   partial applications" )
+      )
   | Default_specialise -> ()
   end;
   let freshened_params =

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -86,6 +86,7 @@ COMPILERLIBS_SOURCES=\
   utils/profile.ml \
   utils/consistbl.ml \
   utils/terminfo.ml \
+  utils/i18n.ml \
   utils/warnings.ml \
   utils/load_path.ml \
   parsing/location.ml \

--- a/parsing/ast_invariants.ml
+++ b/parsing/ast_invariants.ml
@@ -18,12 +18,13 @@ open Ast_iterator
 
 let err = Syntaxerr.ill_formed_ast
 
-let empty_record loc = err loc "Records cannot be empty."
-let invalid_tuple loc = err loc "Tuples must have at least 2 components."
-let no_args loc = err loc "Function application with no argument."
-let empty_let loc = err loc "Let with no bindings."
-let empty_type loc = err loc "Type declarations cannot be empty."
-let complex_id loc = err loc "Functor application not allowed here."
+let empty_record loc = err loc (I18n.s"Records cannot be empty.")
+let invalid_tuple loc =
+  err loc (I18n.s"Tuples must have at least 2 components.")
+let no_args loc = err loc (I18n.s"Function application with no argument.")
+let empty_let loc = err loc (I18n.s"Let with no bindings.")
+let empty_type loc = err loc (I18n.s"Type declarations cannot be empty.")
+let complex_id loc = err loc (I18n.s"Functor application not allowed here.")
 
 let simple_longident id =
   let rec is_simple = function
@@ -151,8 +152,8 @@ let iterator =
       if field.prf_attributes = []
       then ()
       else err loc
-          "In variant types, attaching attributes to inherited \
-           subtypes is not allowed."
+          (I18n.s "In variant types, attaching attributes to inherited \
+           subtypes is not allowed.")
   in
   let object_field self field =
     super.object_field self field;
@@ -163,8 +164,8 @@ let iterator =
       if field.pof_attributes = []
       then ()
       else err loc
-          "In object types, attaching attributes to inherited \
-           subtypes is not allowed."
+          (I18n.s "In object types, attaching attributes to inherited \
+           subtypes is not allowed.")
   in
   { super with
     type_declaration

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -840,14 +840,16 @@ module PpxContext = struct
                  ({ pexp_desc = Pexp_record (fields, None) }, [])}] ->
         fields
     | _ ->
-        raise_errorf "Internal error: invalid [@@@ocaml.ppx.context] syntax"
+        Location.raise_errorf
+          "Internal error: invalid [%@%@%@ocaml.ppx.context] syntax"
 
   let restore fields =
     let field name payload =
       let rec get_string = function
         | { pexp_desc = Pexp_constant (Pconst_string (str, _, None)) } -> str
-        | _ -> raise_errorf "Internal error: invalid [@@@ocaml.ppx.context \
-                             { %s }] string syntax" name
+        | _ -> Location.raise_errorf
+                 "Internal error: invalid [@@@ocaml.ppx.context \
+                  { %s }] string syntax" name
       and get_bool pexp =
         match pexp with
         | {pexp_desc = Pexp_construct ({txt = Longident.Lident "true"},
@@ -856,8 +858,9 @@ module PpxContext = struct
         | {pexp_desc = Pexp_construct ({txt = Longident.Lident "false"},
                                        None)} ->
             false
-        | _ -> raise_errorf "Internal error: invalid [@@@ocaml.ppx.context \
-                             { %s }] bool syntax" name
+        | _ -> Location.raise_errorf
+                 "Internal error: invalid [%@%@%@ocaml.ppx.context \
+                  { %s }] bool syntax" name
       and get_list elem = function
         | {pexp_desc =
              Pexp_construct ({txt = Longident.Lident "::"},
@@ -866,13 +869,15 @@ module PpxContext = struct
         | {pexp_desc =
              Pexp_construct ({txt = Longident.Lident "[]"}, None)} ->
             []
-        | _ -> raise_errorf "Internal error: invalid [@@@ocaml.ppx.context \
-                             { %s }] list syntax" name
+        | _ -> Location.raise_errorf
+                 "Internal error: invalid [%@%@%@ocaml.ppx.context \
+                  { %s }] list syntax" name
       and get_pair f1 f2 = function
         | {pexp_desc = Pexp_tuple [e1; e2]} ->
             (f1 e1, f2 e2)
-        | _ -> raise_errorf "Internal error: invalid [@@@ocaml.ppx.context \
-                             { %s }] pair syntax" name
+        | _ -> Location.raise_errorf
+                 "Internal error: invalid [%@%@%@ocaml.ppx.context \
+                  { %s }] pair syntax" name
       and get_option elem = function
         | { pexp_desc =
               Pexp_construct ({ txt = Longident.Lident "Some" }, Some exp) } ->
@@ -880,8 +885,9 @@ module PpxContext = struct
         | { pexp_desc =
               Pexp_construct ({ txt = Longident.Lident "None" }, None) } ->
             None
-        | _ -> raise_errorf "Internal error: invalid [@@@ocaml.ppx.context \
-                             { %s }] option syntax" name
+        | _ -> Location.raise_errorf
+                 "Internal error: invalid [%@%@%@ocaml.ppx.context \
+                  { %s }] option syntax" name
       in
       match name with
       | "tool_name" ->
@@ -900,7 +906,8 @@ module PpxContext = struct
           Clflags.use_threads := get_bool payload
       | "use_vmthreads" ->
           if get_bool payload then
-            raise_errorf "Internal error: vmthreads not supported after 4.09.0"
+            Location.raise_errorf
+              "Internal error: vmthreads not supported after 4.09.0"
       | "recursive_types" ->
           Clflags.recursive_types := get_bool payload
       | "principal" ->

--- a/parsing/attr_helper.ml
+++ b/parsing/attr_helper.ml
@@ -36,13 +36,11 @@ let has_no_payload_attribute alt_names attrs =
   | None   -> false
   | Some _ -> true
 
-open Format
-
 let report_error ppf = function
   | Multiple_attributes name ->
-    fprintf ppf "Too many `%s' attributes" name
+    I18n.fprintf ppf "Too many `%s' attributes" name
   | No_payload_expected name ->
-    fprintf ppf "Attribute `%s' does not accept a payload" name
+    I18n.fprintf ppf "Attribute `%s' does not accept a payload" name
 
 let () =
   Location.register_error_of_exn

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -626,7 +626,7 @@ let lines_around_from_current_input ~start_pos ~end_pos =
 type msg = (Format.formatter -> unit) loc
 
 let msg ?(loc = none) fmt =
-  Format.kdprintf (fun txt -> { loc; txt }) fmt
+  I18n.kdprintf (fun txt -> { loc; txt }) fmt
 
 type report_kind =
   | Report_error
@@ -730,13 +730,13 @@ let batch_mode_printer : report_printer =
     ) ()
   in
   let pp_report_kind _self _ ppf = function
-    | Report_error -> Format.fprintf ppf "@{<error>Error@}"
-    | Report_warning w -> Format.fprintf ppf "@{<warning>Warning@} %s" w
+    | Report_error -> I18n.fprintf ppf "@{<error>Error@}"
+    | Report_warning w -> I18n.fprintf ppf "@{<warning>Warning@} %s" w
     | Report_warning_as_error w ->
-        Format.fprintf ppf "@{<error>Error@} (warning %s)" w
+        I18n.fprintf ppf "@{<error>Error@} (warning %s)" w
     | Report_alert w -> Format.fprintf ppf "@{<warning>Alert@} %s" w
     | Report_alert_as_error w ->
-        Format.fprintf ppf "@{<error>Error@} (alert %s)" w
+        I18n.fprintf ppf "@{<error>Error@} (alert %s)" w
   in
   let pp_main_loc self report ppf loc =
     pp_loc self report ppf loc
@@ -815,7 +815,7 @@ let mkerror loc sub txt =
   { kind = Report_error; main = { loc; txt }; sub }
 
 let errorf ?(loc = none) ?(sub = []) =
-  Format.kdprintf (mkerror loc sub)
+  I18n.kdprintf (mkerror loc sub)
 
 let error ?(loc = none) ?(sub = []) msg_str =
   mkerror loc sub (fun ppf -> Format.pp_print_string ppf msg_str)
@@ -834,7 +834,8 @@ let default_warning_alert_reporter report mk (loc: t) w : report option =
   match report w with
   | `Inactive -> None
   | `Active { Warnings.id; message; is_error; sub_locs } ->
-      let msg_of_str str = fun ppf -> Format.pp_print_string ppf str in
+      let msg_of_str str = fun ppf ->
+        Format.pp_print_string ppf (I18n.to_string str) in
       let kind = mk is_error id in
       let main = { loc; txt = msg_of_str message } in
       let sub = List.map (fun (loc, sub_message) ->
@@ -939,4 +940,4 @@ let () =
     )
 
 let raise_errorf ?(loc = none) ?(sub = []) =
-  Format.kdprintf (fun txt -> raise (Error (mkerror loc sub txt)))
+  I18n.kdprintf (fun txt -> raise (Error (mkerror loc sub txt)))

--- a/parsing/parse.ml
+++ b/parsing/parse.ml
@@ -161,7 +161,7 @@ let prepare_error err =
       Location.errorf ~loc "Syntax error"
   | Ill_formed_ast (loc, s) ->
       Location.errorf ~loc
-        "broken invariant in parsetree: %s" s
+        "broken invariant in parsetree: %a" I18n.pp s
   | Invalid_package_type (loc, s) ->
       Location.errorf ~loc "invalid package type: %s" s
 

--- a/parsing/syntaxerr.ml
+++ b/parsing/syntaxerr.ml
@@ -22,7 +22,7 @@ type error =
   | Applicative_path of Location.t
   | Variable_in_scope of Location.t * string
   | Other of Location.t
-  | Ill_formed_ast of Location.t * string
+  | Ill_formed_ast of Location.t * I18n.s
   | Invalid_package_type of Location.t * string
 
 exception Error of error

--- a/parsing/syntaxerr.mli
+++ b/parsing/syntaxerr.mli
@@ -27,11 +27,11 @@ type error =
   | Applicative_path of Location.t
   | Variable_in_scope of Location.t * string
   | Other of Location.t
-  | Ill_formed_ast of Location.t * string
+  | Ill_formed_ast of Location.t * I18n.s
   | Invalid_package_type of Location.t * string
 
 exception Error of error
 exception Escape_error
 
 val location_of_error: error -> Location.t
-val ill_formed_ast: Location.t -> string -> 'a
+val ill_formed_ast: Location.t -> I18n.s -> 'a

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -111,7 +111,7 @@ clean::
 CSLPROF=ocamlprof.cmo
 CSLPROF_IMPORTS=config.cmo build_path_prefix_map.cmo misc.cmo identifiable.cmo \
   numbers.cmo arg_helper.cmo clflags.cmo terminfo.cmo \
-  warnings.cmo location.cmo longident.cmo docstrings.cmo \
+  i18n.cmo warnings.cmo location.cmo longident.cmo docstrings.cmo \
   syntaxerr.cmo ast_helper.cmo \
   camlinternalMenhirLib.cmo parser.cmo \
   pprintast.cmo \
@@ -120,8 +120,8 @@ CSLPROF_IMPORTS=config.cmo build_path_prefix_map.cmo misc.cmo identifiable.cmo \
 $(call byte_and_opt,ocamlprof,$(CSLPROF_IMPORTS) profiling.cmo $(CSLPROF),)
 
 ocamlcp_cmos = config.cmo build_path_prefix_map.cmo misc.cmo profile.cmo \
-               warnings.cmo identifiable.cmo numbers.cmo arg_helper.cmo \
-               clflags.cmo \
+               i18n.cmo warnings.cmo identifiable.cmo numbers.cmo \
+               arg_helper.cmo clflags.cmo \
                terminfo.cmo location.cmo load_path.cmo ccomp.cmo compenv.cmo \
                main_args.cmo
 

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -154,7 +154,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
     ] : (Path.t * printer) list)
 
     let exn_printer ppf path exn =
-      fprintf ppf "<printer %a raised an exception: %s>" Printtyp.path path
+      I18n.fprintf ppf "<printer %a raised an exception: %s>" Printtyp.path path
         (Printexc.to_string exn)
 
     let out_exn path exn =
@@ -605,7 +605,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
       | _ ->
           (fun _obj ->
             let printer ppf =
-              fprintf ppf "<internal error: incorrect arity for '%a'>"
+              I18n.fprintf ppf "<internal error: incorrect arity for '%a'>"
                 Printtyp.path path in
             Oval_printer printer)
 

--- a/toplevel/opttopdirs.ml
+++ b/toplevel/opttopdirs.ml
@@ -79,7 +79,7 @@ let load_file ppf name0 =
     with Not_found -> None
   in
   match name with
-  | None -> fprintf ppf "File not found: %s@." name0; false
+  | None -> I18n.fprintf ppf "File not found: %s@." name0; false
   | Some name ->
     let fn,tmp =
       if Filename.check_suffix name ".cmx" || Filename.check_suffix name ".cmxa"
@@ -97,7 +97,7 @@ let load_file ppf name0 =
       try Dynlink.loadfile fn; true
       with
       | Dynlink.Error err ->
-        fprintf ppf "Error while loading %s: %s.@."
+          I18n.fprintf ppf "Error while loading %s: %s.@."
           name (Dynlink.error_message err);
         false
       | exn ->
@@ -131,7 +131,7 @@ let match_printer_type ppf desc typename =
     with
     | (path, _) -> path
     | exception Not_found ->
-        fprintf ppf "Cannot find type Topdirs.%s.@." typename;
+        I18n.fprintf ppf "Cannot find type Topdirs.%s.@." typename;
         raise Exit
   in
   Ctype.begin_def();
@@ -152,13 +152,13 @@ let find_printer_type ppf lid =
         match match_printer_type ppf desc "printer_type_old" with
         | ty_arg -> (ty_arg, path, true)
         | exception Ctype.Unify _ ->
-            fprintf ppf "%a has a wrong type for a printing function.@."
+            I18n.fprintf ppf "%a has a wrong type for a printing function.@."
               Printtyp.longident lid;
             raise Exit
       end
   end
   | exception Not_found ->
-      fprintf ppf "Unbound value %a.@." Printtyp.longident lid;
+      I18n.fprintf ppf "Unbound value %a.@." Printtyp.longident lid;
       raise Exit
 
 let dir_install_printer ppf lid =
@@ -179,7 +179,7 @@ let dir_remove_printer ppf lid =
     begin try
       remove_printer path
     with Not_found ->
-      fprintf ppf "No printer named %a.@." Printtyp.longident lid
+      I18n.fprintf ppf "No printer named %a.@." Printtyp.longident lid
     end
   with Exit -> ()
 

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -404,7 +404,7 @@ let execute_phrase print_outcome ppf phr =
       in
       begin match d with
       | None ->
-          fprintf ppf "Unknown directive `%s'.@." dir_name;
+          I18n.fprintf ppf "Unknown directive `%s'.@." dir_name;
           false
       | Some d ->
           match d, pdir_arg with
@@ -414,19 +414,19 @@ let execute_phrase print_outcome ppf phr =
              begin match Int_literal_converter.int n with
              | n -> f n; true
              | exception _ ->
-               fprintf ppf "Integer literal exceeds the range of \
-                            representable integers for directive `%s'.@."
-                       dir_name;
-               false
+                 I18n.fprintf ppf "Integer literal exceeds the range of \
+                                   representable integers for directive `%s'.@."
+                   dir_name;
+                 false
              end
           | Directive_int _, Some {pdira_desc = Pdir_int (_, Some _)} ->
-              fprintf ppf "Wrong integer literal for directive `%s'.@."
+              I18n.fprintf ppf "Wrong integer literal for directive `%s'.@."
                 dir_name;
               false
           | Directive_ident f, Some {pdira_desc = Pdir_ident lid} -> f lid; true
           | Directive_bool f, Some {pdira_desc = Pdir_bool b} -> f b; true
           | _ ->
-              fprintf ppf "Wrong type of argument for directive `%s'.@."
+              I18n.fprintf ppf "Wrong type of argument for directive `%s'.@."
                 dir_name;
               false
       end
@@ -478,11 +478,11 @@ let use_file ppf wrap_mod name =
           true
         with
         | Exit -> false
-        | Sys.Break -> fprintf ppf "Interrupted.@."; false
+        | Sys.Break -> I18n.fprintf ppf "Interrupted.@."; false
         | x -> Location.report_exception ppf x; false) in
     if must_close then close_in ic;
     success
-  with Not_found -> fprintf ppf "Cannot find file %s.@." name; false
+  with Not_found -> I18n.fprintf ppf "Cannot find file %s.@." name; false
 
 let mod_use_file ppf name = use_file ppf true name
 let use_file ppf name = use_file ppf false name
@@ -575,7 +575,7 @@ let load_ocamlinit ppf =
   if !Clflags.noinit then ()
   else match !Clflags.init_file with
   | Some f -> if Sys.file_exists f then ignore (use_silently ppf f)
-              else fprintf ppf "Init file not found: \"%s\".@." f
+              else I18n.fprintf ppf "Init file not found: \"%s\".@." f
   | None ->
       match find_ocamlinit () with
       | None -> ()
@@ -609,7 +609,8 @@ exception PPerror
 let loop ppf =
   Location.formatter_for_warnings := ppf;
   if not !Clflags.noversion then
-    fprintf ppf "        OCaml version %s - native toplevel@.@." Config.version;
+    I18n.fprintf ppf "        OCaml version %s - native toplevel@.@."
+      Config.version;
   initialize_toplevel_env ();
   let lb = Lexing.from_function refill_lexbuf in
   Location.init lb "//toplevel//";
@@ -632,7 +633,7 @@ let loop ppf =
       ignore(execute_phrase true ppf phr)
     with
     | End_of_file -> exit 0
-    | Sys.Break -> fprintf ppf "Interrupted.@."; Btype.backtrack snap
+    | Sys.Break -> I18n.fprintf ppf "Interrupted.@."; Btype.backtrack snap
     | PPerror -> ()
     | x -> Location.report_exception ppf x; Btype.backtrack snap
   done

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -338,7 +338,7 @@ let execute_phrase print_outcome ppf phr =
       in
       begin match d with
       | None ->
-          fprintf ppf "Unknown directive `%s'." dir_name;
+          I18n.fprintf ppf "Unknown directive `%s'." dir_name;
           let directives =
             Hashtbl.fold (fun dir _ acc -> dir::acc) directive_table [] in
           Misc.did_you_mean ppf
@@ -353,19 +353,19 @@ let execute_phrase print_outcome ppf phr =
              begin match Int_literal_converter.int n with
              | n -> f n; true
              | exception _ ->
-               fprintf ppf "Integer literal exceeds the range of \
-                            representable integers for directive `%s'.@."
+                 I18n.fprintf ppf "Integer literal exceeds the range of \
+                                   representable integers for directive `%s'.@."
                        dir_name;
                false
              end
           | Directive_int _, Some {pdira_desc = Pdir_int (_, Some _)} ->
-              fprintf ppf "Wrong integer literal for directive `%s'.@."
+              I18n.fprintf ppf "Wrong integer literal for directive `%s'.@."
                 dir_name;
               false
           | Directive_ident f, Some {pdira_desc = Pdir_ident lid} -> f lid; true
           | Directive_bool f, Some {pdira_desc = Pdir_bool b} -> f b; true
           | _ ->
-              fprintf ppf "Wrong type of argument for directive `%s'.@."
+              I18n.fprintf ppf "Wrong type of argument for directive `%s'.@."
                 dir_name;
               false
       end
@@ -426,11 +426,11 @@ let use_file ppf wrap_mod name =
           true
         with
         | Exit -> false
-        | Sys.Break -> fprintf ppf "Interrupted.@."; false
+        | Sys.Break -> I18n.fprintf ppf "Interrupted.@."; false
         | x -> Location.report_exception ppf x; false) in
     if must_close then close_in ic;
     success
-  with Not_found -> fprintf ppf "Cannot find file %s.@." name; false
+  with Not_found -> I18n.fprintf ppf "Cannot find file %s.@." name; false
 
 let mod_use_file ppf name = use_file ppf true name
 let use_file ppf name = use_file ppf false name
@@ -529,7 +529,7 @@ let load_ocamlinit ppf =
   if !Clflags.noinit then ()
   else match !Clflags.init_file with
   | Some f -> if Sys.file_exists f then ignore (use_silently ppf f)
-              else fprintf ppf "Init file not found: \"%s\".@." f
+              else I18n.fprintf ppf "Init file not found: \"%s\".@." f
   | None ->
       match find_ocamlinit () with
       | None -> ()
@@ -565,7 +565,7 @@ let loop ppf =
   Clflags.debug := true;
   Location.formatter_for_warnings := ppf;
   if not !Clflags.noversion then
-    fprintf ppf "        OCaml version %s@.@." Config.version;
+    I18n.fprintf ppf "        OCaml version %s@.@." Config.version;
   begin
     try initialize_toplevel_env ()
     with Env.Error _ | Typetexp.Error _ as exn ->
@@ -594,7 +594,7 @@ let loop ppf =
       ignore(execute_phrase true ppf phr)
     with
     | End_of_file -> exit 0
-    | Sys.Break -> fprintf ppf "Interrupted.@."; Btype.backtrack snap
+    | Sys.Break -> I18n.fprintf ppf "Interrupted.@."; Btype.backtrack snap
     | PPerror -> ()
     | x -> Location.report_exception ppf x; Btype.backtrack snap
   done

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -166,7 +166,7 @@ let () =
       | Tags (l, l') ->
           Some
             Location.
-              (errorf ~loc:(in_file !input_name)
+              (Location.errorf ~loc:(in_file !input_name)
                  "In this program,@ variant constructors@ `%s and `%s@ \
                   have the same hash value.@ Change one of them." l l'
               )

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3050,7 +3050,7 @@ let extract_instance_variables env =
 
 let report_lookup_error _loc env ppf = function
   | Unbound_value(lid, hint) -> begin
-      fprintf ppf "Unbound value %a" !print_longident lid;
+      I18n.fprintf ppf "Unbound value %a" !print_longident lid;
       spellcheck ppf extract_values env lid;
       match hint with
       | No_hint -> ()
@@ -3058,89 +3058,91 @@ let report_lookup_error _loc env ppf = function
           let (_, line, _) =
             Location.get_pos_info def_loc.Location.loc_start
           in
-          fprintf ppf
+          I18n.fprintf ppf
             "@.@[%s@ %s %i@]"
             "Hint: If this is a recursive definition,"
             "you should add the 'rec' keyword on line"
             line
     end
   | Unbound_type lid ->
-      fprintf ppf "Unbound type constructor %a" !print_longident lid;
+      I18n.fprintf ppf "Unbound type constructor %a" !print_longident lid;
       spellcheck ppf extract_types env lid;
   | Unbound_module lid ->
-      fprintf ppf "Unbound module %a" !print_longident lid;
+      I18n.fprintf ppf "Unbound module %a" !print_longident lid;
       spellcheck ppf extract_modules env lid;
   | Unbound_constructor lid ->
-      fprintf ppf "Unbound constructor %a" !print_longident lid;
+      I18n.fprintf ppf "Unbound constructor %a" !print_longident lid;
       spellcheck ppf extract_constructors env lid;
   | Unbound_label lid ->
-      fprintf ppf "Unbound record field %a" !print_longident lid;
+     I18n.fprintf ppf "Unbound record field %a" !print_longident lid;
       spellcheck ppf extract_labels env lid;
   | Unbound_class lid ->
-      fprintf ppf "Unbound class %a" !print_longident lid;
+      I18n.fprintf ppf "Unbound class %a" !print_longident lid;
       spellcheck ppf extract_classes env lid;
   | Unbound_modtype lid ->
-      fprintf ppf "Unbound module type %a" !print_longident lid;
+      I18n.fprintf ppf "Unbound module type %a" !print_longident lid;
       spellcheck ppf extract_modtypes env lid;
   | Unbound_cltype lid ->
-      fprintf ppf "Unbound class type %a" !print_longident lid;
+      I18n.fprintf ppf "Unbound class type %a" !print_longident lid;
       spellcheck ppf extract_cltypes env lid;
   | Unbound_instance_variable s ->
-      fprintf ppf "Unbound instance variable %s" s;
+      I18n.fprintf ppf "Unbound instance variable %s" s;
       spellcheck_name ppf extract_instance_variables env s;
   | Not_an_instance_variable s ->
-      fprintf ppf "The value %s is not an instance variable" s;
+      I18n.fprintf ppf "The value %s is not an instance variable" s;
       spellcheck_name ppf extract_instance_variables env s;
   | Masked_instance_variable lid ->
-      fprintf ppf
+      I18n.fprintf ppf
         "The instance variable %a@ \
          cannot be accessed from the definition of another instance variable"
         !print_longident lid
   | Masked_self_variable lid ->
-      fprintf ppf
+      I18n.fprintf ppf
         "The self variable %a@ \
          cannot be accessed from the definition of an instance variable"
         !print_longident lid
   | Masked_ancestor_variable lid ->
-      fprintf ppf
+      I18n.fprintf ppf
         "The ancestor variable %a@ \
          cannot be accessed from the definition of an instance variable"
         !print_longident lid
   | Illegal_reference_to_recursive_module ->
-     fprintf ppf "Illegal recursive module reference"
+      I18n.fprintf ppf "Illegal recursive module reference"
   | Structure_used_as_functor lid ->
-      fprintf ppf "@[The module %a is a structure, it cannot be applied@]"
+      I18n.fprintf ppf "@[The module %a is a structure, it cannot be applied@]"
         !print_longident lid
   | Abstract_used_as_functor lid ->
-      fprintf ppf "@[The module %a is abstract, it cannot be applied@]"
+      I18n.fprintf ppf "@[The module %a is abstract, it cannot be applied@]"
         !print_longident lid
   | Functor_used_as_structure lid ->
-      fprintf ppf "@[The module %a is a functor, \
-                   it cannot have any components@]" !print_longident lid
+      I18n.fprintf ppf
+        "@[The module %a is a functor, it cannot have any components@]"
+        !print_longident lid
   | Abstract_used_as_structure lid ->
-      fprintf ppf "@[The module %a is abstract, \
-                   it cannot have any components@]" !print_longident lid
+      I18n.fprintf ppf
+        "@[The module %a is abstract, it cannot have any components@]"
+        !print_longident lid
   | Generative_used_as_applicative lid ->
-      fprintf ppf "@[The functor %a is generative,@ it@ cannot@ be@ \
-                   applied@ in@ type@ expressions@]" !print_longident lid
+      I18n.fprintf ppf "@[The functor %a is generative,@ it@ cannot@ be@ \
+                        applied@ in@ type@ expressions@]" !print_longident lid
   | Cannot_scrape_alias(lid, p) ->
-      fprintf ppf
+      I18n.fprintf ppf
         "The module %a is an alias for module %a, which is missing"
         !print_longident lid !print_path p
 
 let report_error ppf = function
   | Missing_module(_, path1, path2) ->
-      fprintf ppf "@[@[<hov>";
+      I18n.fprintf ppf "@[@[<hov>";
       if Path.same path1 path2 then
-        fprintf ppf "Internal path@ %s@ is dangling." (Path.name path1)
+        I18n.fprintf ppf "Internal path@ %s@ is dangling." (Path.name path1)
       else
-        fprintf ppf "Internal path@ %s@ expands to@ %s@ which is dangling."
+        I18n.fprintf ppf "Internal path@ %s@ expands to@ %s@ which is dangling."
           (Path.name path1) (Path.name path2);
-      fprintf ppf "@]@ @[%s@ %s@ %s.@]@]"
-        "The compiled interface for module" (Ident.name (Path.head path2))
-        "was not found"
+      I18n.fprintf ppf
+        "@]@ @[The compiled interface for module@ %s@ was not found.@]@]"
+        (Ident.name (Path.head path2))
   | Illegal_value_name(_loc, name) ->
-      fprintf ppf "'%s' is not a valid value identifier."
+      I18n.fprintf ppf "'%s' is not a valid value identifier."
         name
   | Lookup_error(loc, t, err) -> report_lookup_error loc t ppf err
 

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -52,61 +52,54 @@ let rec hide_params = function
 let include_err ppf =
   function
   | CM_Virtual_class ->
-      fprintf ppf "A class cannot be changed from virtual to concrete"
+      I18n.fprintf ppf "A class cannot be changed from virtual to concrete"
   | CM_Parameter_arity_mismatch _ ->
-      fprintf ppf
+      I18n.fprintf ppf
         "The classes do not have the same number of type parameters"
   | CM_Type_parameter_mismatch (env, trace) ->
       Printtyp.report_unification_error ppf env trace
-        (function ppf ->
-          fprintf ppf "A type parameter has type")
-        (function ppf ->
-          fprintf ppf "but is expected to have type")
+        (I18n.dprintf "A type parameter has type")
+        (I18n.dprintf "but is expected to have type")
   | CM_Class_type_mismatch (env, cty1, cty2) ->
       Printtyp.wrap_printing_env ~error:true env (fun () ->
-        fprintf ppf
-          "@[The class type@;<1 2>%a@ %s@;<1 2>%a@]"
+        I18n.fprintf ppf
+          "@[The class type@;<1 2>%a@ is not matched by \
+           the class type@;<1 2>%a@]"
           Printtyp.class_type cty1
-          "is not matched by the class type"
           Printtyp.class_type cty2)
   | CM_Parameter_mismatch (env, trace) ->
       Printtyp.report_unification_error ppf env trace
-        (function ppf ->
-          fprintf ppf "A parameter has type")
-        (function ppf ->
-          fprintf ppf "but is expected to have type")
+        (I18n.dprintf "A parameter has type")
+        (I18n.dprintf "but is expected to have type")
   | CM_Val_type_mismatch (lab, env, trace) ->
       Printtyp.report_unification_error ppf env trace
-        (function ppf ->
-          fprintf ppf "The instance variable %s@ has type" lab)
-        (function ppf ->
-          fprintf ppf "but is expected to have type")
+        (I18n.dprintf "The instance variable %s@ has type" lab)
+        (I18n.dprintf "but is expected to have type")
   | CM_Meth_type_mismatch (lab, env, trace) ->
       Printtyp.report_unification_error ppf env trace
-        (function ppf ->
-          fprintf ppf "The method %s@ has type" lab)
-        (function ppf ->
-          fprintf ppf "but is expected to have type")
+        (I18n.dprintf "The method %s@ has type" lab)
+        (I18n.dprintf "but is expected to have type")
   | CM_Non_mutable_value lab ->
-      fprintf ppf
+      I18n.fprintf ppf
        "@[The non-mutable instance variable %s cannot become mutable@]" lab
   | CM_Non_concrete_value lab ->
-      fprintf ppf
+      I18n.fprintf ppf
        "@[The virtual instance variable %s cannot become concrete@]" lab
   | CM_Missing_value lab ->
-      fprintf ppf "@[The first class type has no instance variable %s@]" lab
+      I18n.fprintf ppf
+       "@[The first class type has no instance variable %s@]" lab
   | CM_Missing_method lab ->
-      fprintf ppf "@[The first class type has no method %s@]" lab
+      I18n.fprintf ppf "@[The first class type has no method %s@]" lab
   | CM_Hide_public lab ->
-     fprintf ppf "@[The public method %s cannot be hidden@]" lab
+     I18n.fprintf ppf "@[The public method %s cannot be hidden@]" lab
   | CM_Hide_virtual (k, lab) ->
-      fprintf ppf "@[The virtual %s %s cannot be hidden@]" k lab
+      I18n.fprintf ppf "@[The virtual %s %s cannot be hidden@]" k lab
   | CM_Public_method lab ->
-      fprintf ppf "@[The public method %s cannot become private@]" lab
+      I18n.fprintf ppf "@[The public method %s cannot become private@]" lab
   | CM_Virtual_method lab ->
-      fprintf ppf "@[The virtual method %s cannot become concrete@]" lab
+      I18n.fprintf ppf "@[The virtual method %s cannot become concrete@]" lab
   | CM_Private_method lab ->
-      fprintf ppf "@[The private method %s cannot become public@]" lab
+      I18n.fprintf ppf "@[The private method %s cannot become public@]" lab
 
 let report_error ppf = function
   |  [] -> ()

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -22,6 +22,10 @@ exception Dont_match
 
 type position = Ctype.Unification_trace.position = First | Second
 
+type wording =
+  | Declaration
+  | Definition
+
 type label_mismatch =
   | Type
   | Mutability of position
@@ -85,6 +89,6 @@ val class_types:
 *)
 
 val report_type_mismatch:
-    string -> string -> string -> Format.formatter -> type_mismatch -> unit
-val report_extension_constructor_mismatch: string -> string -> string ->
+   wording -> Format.formatter -> type_mismatch -> unit
+val report_extension_constructor_mismatch: wording ->
   Format.formatter -> extension_constructor_mismatch -> unit

--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -344,25 +344,26 @@ let save_cmi penv psig pm =
     ~exceptionally:(fun () -> remove_file filename)
 
 let report_error ppf =
-  let open Format in
   function
-  | Illegal_renaming(modname, ps_name, filename) -> fprintf ppf
+  | Illegal_renaming(modname, ps_name, filename) -> I18n.fprintf ppf
       "Wrong file naming: %a@ contains the compiled interface for@ \
        %s when %s was expected"
       Location.print_filename filename ps_name modname
-  | Inconsistent_import(name, source1, source2) -> fprintf ppf
+  | Inconsistent_import(name, source1, source2) -> I18n.fprintf ppf
       "@[<hov>The files %a@ and %a@ \
               make inconsistent assumptions@ over interface %s@]"
       Location.print_filename source1 Location.print_filename source2 name
   | Need_recursive_types(import) ->
-      fprintf ppf
-        "@[<hov>Invalid import of %s, which uses recursive types.@ %s@]"
-        import "The compilation flag -rectypes is required"
+      I18n.fprintf ppf
+        "@[<hov>Invalid import of %s, which uses recursive types.@ \
+         The compilation flag -rectypes is required@]"
+        import
   | Depend_on_unsafe_string_unit(import) ->
-      fprintf ppf
-        "@[<hov>Invalid import of %s, compiled with -unsafe-string.@ %s@]"
-        import "This compiler has been configured in strict \
-                                  safe-string mode (-force-safe-string)"
+      I18n.fprintf ppf
+        "@[<hov>Invalid import of %s, compiled with -unsafe-string.@ \
+         This compiler has been configured in strict \
+         safe-string mode (-force-safe-string)@]"
+        import
 
 let () =
   Location.register_error_of_exn

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -158,7 +158,7 @@ val cltype_declaration: Ident.t -> formatter -> class_type_declaration -> unit
 val type_expansion: type_expr -> Format.formatter -> type_expr -> unit
 val prepare_expansion: type_expr * type_expr -> type_expr * type_expr
 val trace:
-  bool -> bool-> string -> formatter
+  bool -> bool-> I18n.s -> formatter
   -> (type_expr * type_expr) Ctype.Unification_trace.elt list -> unit
 val report_unification_error:
     formatter -> Env.t ->
@@ -167,11 +167,11 @@ val report_unification_error:
     (formatter -> unit) -> (formatter -> unit) ->
     unit
 val report_subtyping_error:
-    formatter -> Env.t -> Ctype.Unification_trace.t -> string
+    formatter -> Env.t -> Ctype.Unification_trace.t -> I18n.s
     -> Ctype.Unification_trace.t -> unit
 val report_ambiguous_type_error:
     formatter -> Env.t -> (Path.t * Path.t) -> (Path.t * Path.t) list ->
-    (formatter -> unit) -> (formatter -> unit) -> (formatter -> unit) -> unit
+    ((formatter -> unit) as 'f) -> 'f -> 'f -> unit
 
 (* for toploop *)
 val print_items: (Env.t -> signature_item -> 'a option) ->

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -64,9 +64,13 @@ type 'a full_class = {
   req: 'a Typedtree.class_infos;
 }
 
+type field_type=
+  | Instance_variable
+  | Method
+
 type error =
     Unconsistent_constraint of Ctype.Unification_trace.t
-  | Field_type_mismatch of string * string * Ctype.Unification_trace.t
+  | Field_type_mismatch of field_type * string * Ctype.Unification_trace.t
   | Structure_expected of class_type
   | Cannot_apply of class_type
   | Apply_wrong_label of arg_label
@@ -89,8 +93,8 @@ type error =
       Ident.t * Types.class_declaration * Ctype.Unification_trace.t
   | Final_self_clash of Ctype.Unification_trace.t
   | Mutability_mismatch of string * mutable_flag
-  | No_overriding of string * string
-  | Duplicate of string * string
+  | No_overriding of field_type * string
+  | Duplicate of field_type * string
   | Closing_self_type of type_expr
 
 exception Error of Location.t * Env.t * error
@@ -281,7 +285,7 @@ let enter_val cl_num vars inh lab mut virt ty val_env met_env par_env loc =
     with
       Ctype.Unify tr ->
         raise (Error(loc, val_env,
-                     Field_type_mismatch("instance variable", lab, tr)))
+                     Field_type_mismatch(Instance_variable, lab, tr)))
     | Not_found -> None, virt
   in
   let (id, _, _, _) as result =
@@ -309,7 +313,7 @@ let inheritance self_type env ovf concr_meths warn_vals loc parent =
         let open Ctype.Unification_trace in
         match trace with
         | Diff _ :: Incompatible_fields {name = n; _ } :: rem ->
-            raise(Error(loc, env, Field_type_mismatch ("method", n, rem)))
+            raise(Error(loc, env,Field_type_mismatch (Method, n, rem)))
         | _ -> assert false
       end;
 
@@ -333,7 +337,7 @@ let inheritance self_type env ovf concr_meths warn_vals loc parent =
                  (cname :: Concr.elements over_vals));
       | Some Override
         when Concr.is_empty over_meths && Concr.is_empty over_vals ->
-        raise (Error(loc, env, No_overriding ("","")))
+        raise (Error(loc, env, No_overriding (Method,"")))
       | _ -> ()
       end;
 
@@ -354,7 +358,7 @@ let virtual_method val_env meths self_type lab priv sty loc =
   let ty = cty.ctyp_type in
   begin
     try Ctype.unify val_env ty ty' with Ctype.Unify trace ->
-        raise(Error(loc, val_env, Field_type_mismatch ("method", lab, trace)));
+        raise(Error(loc, val_env, Field_type_mismatch(Method, lab, trace)));
   end;
   cty
 
@@ -366,7 +370,7 @@ let declare_method val_env meths self_type lab priv sty loc =
   in
   let unif ty =
     try Ctype.unify val_env ty ty' with Ctype.Unify trace ->
-      raise(Error(loc, val_env, Field_type_mismatch ("method", lab, trace)))
+      raise(Error(loc, val_env, Field_type_mismatch(Method, lab, trace)))
   in
   let sty = Ast_helper.Typ.force_poly sty in
   match sty.ptyp_desc, priv with
@@ -665,15 +669,14 @@ and class_field_aux self_loc cl_num self_type meths vars
 
   | Pcf_val (lab, mut, Cfk_concrete (ovf, sexp)) ->
       if Concr.mem lab.txt local_vals then
-        raise(Error(loc, val_env, Duplicate ("instance variable", lab.txt)));
+        raise(Error(loc, val_env,Duplicate (Instance_variable, lab.txt)));
       if Concr.mem lab.txt warn_vals then begin
         if ovf = Fresh then
           Location.prerr_warning lab.loc
             (Warnings.Instance_variable_override[lab.txt])
       end else begin
         if ovf = Override then
-          raise(Error(loc, val_env,
-                      No_overriding ("instance variable", lab.txt)))
+          raise(Error(loc, val_env,No_overriding (Instance_variable, lab.txt)))
       end;
       if !Clflags.principal then Ctype.begin_def ();
       let exp = type_exp val_env sexp in
@@ -706,13 +709,13 @@ and class_field_aux self_loc cl_num self_type meths vars
         | _ -> Ast_helper.Exp.poly ~loc:expr.pexp_loc expr None
       in
       if Concr.mem lab.txt local_meths then
-        raise(Error(loc, val_env, Duplicate ("method", lab.txt)));
+        raise(Error(loc, val_env, Duplicate (Method, lab.txt)));
       if Concr.mem lab.txt concr_meths then begin
         if ovf = Fresh then
           Location.prerr_warning loc (Warnings.Method_override [lab.txt])
       end else begin
         if ovf = Override then
-          raise(Error(loc, val_env, No_overriding("method", lab.txt)))
+          raise(Error(loc, val_env, No_overriding(Method, lab.txt)))
       end;
       let (_, ty) =
         Ctype.filter_self_method val_env lab.txt priv meths self_type
@@ -739,8 +742,7 @@ and class_field_aux self_loc cl_num self_type meths vars
           end
       | _ -> assert false
       with Ctype.Unify trace ->
-        raise(Error(loc, val_env,
-                    Field_type_mismatch ("method", lab.txt, trace)))
+        raise(Error(loc, val_env,Field_type_mismatch (Method, lab.txt, trace)))
       end;
       let meth_expr = make_method self_loc cl_num expr in
       (* backup variables for Pexp_override *)
@@ -1878,63 +1880,65 @@ let approx_class_declarations env sdecls =
 
 (* Error report *)
 
-open Format
-
 let report_error env ppf = function
   | Repeated_parameter ->
-      fprintf ppf "A type parameter occurs several times"
+      I18n.fprintf ppf "A type parameter occurs several times"
   | Unconsistent_constraint trace ->
-      fprintf ppf "The class constraints are not consistent.@.";
+      I18n.fprintf ppf "The class constraints are not consistent.@.";
       Printtyp.report_unification_error ppf env trace
-        (fun ppf -> fprintf ppf "Type")
-        (fun ppf -> fprintf ppf "is not compatible with type")
+        (I18n.dprintf "Type") (I18n.dprintf "is not compatible with type")
   | Field_type_mismatch (k, m, trace) ->
-      Printtyp.report_unification_error ppf env trace
-        (function ppf ->
-           fprintf ppf "The %s %s@ has type" k m)
-        (function ppf ->
-           fprintf ppf "but is expected to have type")
+      let intro = match k with
+        | Method -> I18n.dprintf "The method %s@ has type" m
+        | Instance_variable ->
+            I18n.dprintf "The instance variable %s@ has type" m in
+      Printtyp.report_unification_error ppf env trace intro
+        (I18n.dprintf "but is expected to have type")
   | Structure_expected clty ->
-      fprintf ppf
-        "@[This class expression is not a class structure; it has type@ %a@]"
+      I18n.fprintf ppf
+        "@[This class expression is not a class structure; \
+            it has type@ %a@]"
         Printtyp.class_type clty
   | Cannot_apply _ ->
-      fprintf ppf
+      I18n.fprintf ppf
         "This class expression is not a class function, it cannot be applied"
   | Apply_wrong_label l ->
-      let mark_label = function
-        | Nolabel -> "out label"
-        |  l -> sprintf " label %s" (Btype.prefixed_label_name l) in
-      fprintf ppf "This argument cannot be applied with%s" (mark_label l)
+      begin match l with
+      | Nolabel ->
+          I18n.fprintf ppf
+            "This argument cannot be applied without label"
+      |  l ->
+          I18n.fprintf ppf
+            "This argument cannot be applied with label %s"
+            (Btype.prefixed_label_name l)
+      end
   | Pattern_type_clash ty ->
       (* XXX Trace *)
       (* XXX Revoir message d'erreur | Improve error message *)
-      fprintf ppf "@[%s@ %a@]"
+      I18n.fprintf ppf "@[%s@ %a@]"
         "This pattern cannot match self: it only matches values of type"
         Printtyp.type_expr ty
   | Unbound_class_2 cl ->
-      fprintf ppf "@[The class@ %a@ is not yet completely defined@]"
+      I18n.fprintf ppf "@[The class@ %a@ is not yet completely defined@]"
       Printtyp.longident cl
   | Unbound_class_type_2 cl ->
-      fprintf ppf "@[The class type@ %a@ is not yet completely defined@]"
+      I18n.fprintf ppf "@[The class type@ %a@ is not yet completely defined@]"
       Printtyp.longident cl
   | Abbrev_type_clash (abbrev, actual, expected) ->
       (* XXX Afficher une trace ? | Print a trace? *)
       Printtyp.reset_and_mark_loops_list [abbrev; actual; expected];
-      fprintf ppf "@[The abbreviation@ %a@ expands to type@ %a@ \
+      I18n.fprintf ppf "@[The abbreviation@ %a@ expands to type@ %a@ \
        but is used with type@ %a@]"
         !Oprint.out_type (Printtyp.tree_of_typexp false abbrev)
         !Oprint.out_type (Printtyp.tree_of_typexp false actual)
         !Oprint.out_type (Printtyp.tree_of_typexp false expected)
   | Constructor_type_mismatch (c, trace) ->
       Printtyp.report_unification_error ppf env trace
-        (function ppf ->
-           fprintf ppf "The expression \"new %s\" has type" c)
-        (function ppf ->
-           fprintf ppf "but is used with type")
+        (I18n.dprintf "The expression \"new %s\" has type" c)
+        (I18n.dprintf "but is used with type")
   | Virtual_class (cl, imm, mets, vals) ->
       let print_mets ppf mets =
-        List.iter (function met -> fprintf ppf "@ %s" met) mets in
+        List.iter (function met -> Format.fprintf ppf "@ %s" met) mets in
       let missings =
         match mets, vals with
           [], _ -> "variables"
@@ -1942,27 +1946,25 @@ let report_error env ppf = function
         | _ -> "methods and variables"
       in
       let print_msg ppf =
-        if imm then fprintf ppf "This object has virtual %s" missings
-        else if cl then fprintf ppf "This class should be virtual"
-        else fprintf ppf "This class type should be virtual"
+        if imm then I18n.fprintf ppf "This object has virtual %s" missings
+        else if cl then I18n.fprintf ppf "This class should be virtual"
+        else I18n.fprintf ppf "This class type should be virtual"
       in
-      fprintf ppf
+      I18n.fprintf ppf
         "@[%t.@ @[<2>The following %s are undefined :%a@]@]"
         print_msg missings print_mets (mets @ vals)
   | Parameter_arity_mismatch(lid, expected, provided) ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[The class constructor %a@ expects %i type argument(s),@ \
            but is here applied to %i type argument(s)@]"
         Printtyp.longident lid expected provided
   | Parameter_mismatch trace ->
       Printtyp.report_unification_error ppf env trace
-        (function ppf ->
-           fprintf ppf "The type parameter")
-        (function ppf ->
-           fprintf ppf "does not meet its constraint: it should be")
+        (I18n.dprintf "The type parameter")
+        (I18n.dprintf "does not meet its constraint: it should be")
   | Bad_parameters (id, params, cstrs) ->
       Printtyp.reset_and_mark_loops_list [params; cstrs];
-      fprintf ppf
+      I18n.fprintf ppf
         "@[The abbreviation %a@ is used with parameters@ %a@ \
            which are incompatible with constraints@ %a@]"
         Printtyp.ident id
@@ -1971,72 +1973,87 @@ let report_error env ppf = function
   | Class_match_failure error ->
       Includeclass.report_error ppf error
   | Unbound_val lab ->
-      fprintf ppf "Unbound instance variable %s" lab
+      I18n.fprintf ppf "Unbound instance variable %s" lab
   | Unbound_type_var (printer, reason) ->
       let print_common ppf kind ty0 real lab ty =
         let ty1 =
           if real then ty0 else Btype.newgenty(Tobject(ty0, ref None)) in
         List.iter Printtyp.mark_loops [ty; ty1];
-        fprintf ppf
-          "The %s %s@ has type@;<1 2>%a@ where@ %a@ is unbound"
-          kind lab
+        ( match kind with
+          | Method ->
+              I18n.fprintf ppf
+                "The method %s@ has type@;<1 2>%a@ where@ %a@ is unbound"
+          | Instance_variable ->
+              I18n.fprintf ppf
+                "The instance variable %s@ has type@;<1 2>%a@ \
+                 where@ %a@ is unbound"
+        )
+          lab
           !Oprint.out_type (Printtyp.tree_of_typexp false ty)
           !Oprint.out_type (Printtyp.tree_of_typexp false ty0)
       in
       let print_reason ppf = function
       | Ctype.CC_Method (ty0, real, lab, ty) ->
-          print_common ppf "method" ty0 real lab ty
+          print_common ppf Method ty0 real lab ty
       | Ctype.CC_Value (ty0, real, lab, ty) ->
-          print_common ppf "instance variable" ty0 real lab ty
+          print_common ppf Instance_variable ty0 real lab ty
       in
       Printtyp.reset ();
-      fprintf ppf
+      I18n.fprintf ppf
         "@[<v>@[Some type variables are unbound in this type:@;<1 2>%t@]@ \
               @[%a@]@]"
        printer print_reason reason
   | Non_generalizable_class (id, clty) ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[The type of this class,@ %a,@ \
            contains type variables that cannot be generalized@]"
         (Printtyp.class_declaration id) clty
   | Cannot_coerce_self ty ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[The type of self cannot be coerced to@ \
            the type of the current class:@ %a.@.\
            Some occurrences are contravariant@]"
         Printtyp.type_scheme ty
   | Non_collapsable_conjunction (id, clty, trace) ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[The type of this class,@ %a,@ \
            contains non-collapsible conjunctive types in constraints.@ %t@]"
         (Printtyp.class_declaration id) clty
         (fun ppf -> Printtyp.report_unification_error ppf env trace
-            (fun ppf -> fprintf ppf "Type")
-            (fun ppf -> fprintf ppf "is not compatible with type")
+            (I18n.dprintf "Type")
+            (I18n.dprintf "is not compatible with type")
         )
   | Final_self_clash trace ->
       Printtyp.report_unification_error ppf env trace
-        (function ppf ->
-           fprintf ppf "This object is expected to have type")
-        (function ppf ->
-           fprintf ppf "but actually has type")
-  | Mutability_mismatch (_lab, mut) ->
-      let mut1, mut2 =
-        if mut = Immutable then "mutable", "immutable"
-        else "immutable", "mutable" in
-      fprintf ppf
-        "@[The instance variable is %s;@ it cannot be redefined as %s@]"
-        mut1 mut2
+        (I18n.dprintf "This object is expected to have type")
+        (I18n.dprintf "but actually has type")
+  | Mutability_mismatch (_lab, Immutable) ->
+      I18n.fprintf ppf
+        "@[The instance variable is immutable;@ \
+         it cannot be redefined as mutable@]"
+  | Mutability_mismatch (_lab, Mutable) ->
+      I18n.fprintf ppf
+        "@[The instance variable is mutable;@ \
+         it cannot be redefined as immutable@]"
   | No_overriding (_, "") ->
-      fprintf ppf "@[This inheritance does not override any method@ %s@]"
-        "instance variable"
-  | No_overriding (kind, name) ->
-      fprintf ppf "@[The %s `%s'@ has no previous definition@]" kind name
-  | Duplicate (kind, name) ->
-      fprintf ppf "@[The %s `%s'@ has multiple definitions in this object@]"
-                    kind name
+    I18n.fprintf ppf
+      "@[This inheritance does not override any method@ instance variable@]"
+  | No_overriding (Method, name) ->
+      I18n.fprintf ppf "@[The method `%s'@ has no previous definition@]" name
+  | No_overriding (Instance_variable, name) ->
+      I18n.fprintf ppf
+        "@[The instance variable `%s'@ has no previous definition@]" name
+  | Duplicate (Method, name) ->
+      I18n.fprintf ppf
+        "@[The method `%s'@ has multiple definitions in this object@]"
+        name
+  | Duplicate (Instance_variable, name) ->
+      I18n.fprintf ppf
+        "@[The instance variable `%s'@ \
+         has multiple definitions in this object@]"
+        name
   | Closing_self_type self ->
-    fprintf ppf
+    I18n.fprintf ppf
       "@[Cannot close type of object literal:@ %a@,\
        it has been unified with the self type of a class that is not yet@ \
        completely defined.@]"

--- a/typing/typeclass.mli
+++ b/typing/typeclass.mli
@@ -89,9 +89,13 @@ val type_classes :
            list * Env.t
 *)
 
+type field_type=
+  | Instance_variable
+  | Method
+
 type error =
     Unconsistent_constraint of Ctype.Unification_trace.t
-  | Field_type_mismatch of string * string * Ctype.Unification_trace.t
+  | Field_type_mismatch of field_type * string * Ctype.Unification_trace.t
   | Structure_expected of class_type
   | Cannot_apply of class_type
   | Apply_wrong_label of arg_label
@@ -114,8 +118,8 @@ type error =
       Ident.t * Types.class_declaration * Ctype.Unification_trace.t
   | Final_self_clash of Ctype.Unification_trace.t
   | Mutability_mismatch of string * mutable_flag
-  | No_overriding of string * string
-  | Duplicate of string * string
+  | No_overriding of field_type * string
+  | Duplicate of field_type * string
   | Closing_self_type of type_expr
 
 exception Error of Location.t * Env.t * error

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -68,6 +68,23 @@ type existential_restriction =
   | In_class_def  (** or in [class c = let ... in ...] *)
   | In_self_pattern (** or in self pattern *)
 
+type polymorphic_kind =
+  | Method
+  | Field_value
+  | Definition
+
+type name_kind =
+  | Constructor
+  | Label
+
+type disambiguation_context =
+  | Record_access
+  | Record_expression
+  | Record_pattern
+  | Variant_expression
+  | Variant_pattern
+
+
 type error =
   | Constructor_arity_mismatch of Longident.t * int * int
   | Label_mismatch of Longident.t * Ctype.Unification_trace.t
@@ -84,7 +101,8 @@ type error =
   | Label_multiply_defined of string
   | Label_missing of Ident.t list
   | Label_not_mutable of Longident.t
-  | Wrong_name of string * type_expected * wrong_name
+  | Wrong_name of
+      disambiguation_context * type_expected * wrong_name
   | Name_type_mismatch of
       Datatype_kind.t * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
   | Invalid_format of string
@@ -106,7 +124,7 @@ type error =
   | Scoping_let_module of string * type_expr
   | Not_a_variant_type of Longident.t
   | Incoherent_label_order
-  | Less_general of string * Ctype.Unification_trace.t
+  | Less_general of polymorphic_kind * Ctype.Unification_trace.t
   | Modules_not_allowed
   | Cannot_infer_signature
   | Not_a_packed_module of type_expr
@@ -1496,7 +1514,7 @@ and type_pat_aux
         | _ ->
         let candidates =
           Env.lookup_all_constructors Env.Pattern ~loc:lid.loc lid.txt !env in
-        wrap_disambiguate "This variant pattern is expected to have"
+        wrap_disambiguate Variant_pattern
           (mk_expected expected_ty)
           (Constructor.disambiguate Env.Pattern lid !env expected_type)
           candidates
@@ -1645,7 +1663,7 @@ and type_pat_aux
       let k' pat = rvp k (unif pat) in
       begin match mode with
       | Normal ->
-          k' (wrap_disambiguate "This record pattern is expected to have"
+          k' (wrap_disambiguate Record_pattern
                (mk_expected expected_ty)
                (type_label_a_list loc false !env type_label_pat expected_type
                   lid_sp_list)
@@ -2823,7 +2841,7 @@ and type_expect_
       in
       let closed = (opt_sexp = None) in
       let lbl_exp_list =
-        wrap_disambiguate "This record expression is expected to have"
+        wrap_disambiguate Record_expression
           (mk_expected ty_record)
           (type_label_a_list loc closed env
              (fun e k -> k (type_label_exp true env loc ty_record e))
@@ -3216,9 +3234,9 @@ and type_expect_
             {desc = Tpoly (ty, [])} ->
               instance ty
           | {desc = Tpoly (ty, tl); level = l} ->
-              if !Clflags.principal && l <> generic_level then
-                (let msg = I18n.s "this use of a polymorphic method" in
-                 Location.prerr_warning loc (Warnings.Not_principal msg));
+              (if !Clflags.principal && l <> generic_level then
+                let msg = I18n.s "this use of a polymorphic method" in
+                Location.prerr_warning loc (Warnings.Not_principal msg));
               snd (instance_poly false tl ty)
           | {desc = Tvar _} as ty ->
               let ty' = newvar () in
@@ -3447,7 +3465,7 @@ and type_expect_
             end;
             let exp = type_expect env sbody (mk_expected ty'') in
             end_def ();
-            generalize_and_check_univars env "method" exp ty_expected vars;
+            generalize_and_check_univars env Method exp ty_expected vars;
             { exp with exp_type = instance ty }
         | Tvar _ ->
             let exp = type_exp env sbody in
@@ -3759,7 +3777,7 @@ and type_label_access env srecord lid =
   in
   let labels = Env.lookup_all_labels ~loc:lid.loc lid.txt env in
   let label =
-    wrap_disambiguate "This expression has" (mk_expected ty_exp)
+    wrap_disambiguate Record_access (mk_expected ty_exp)
       (Label.disambiguate () lid env expected_type) labels in
   (record, label, expected_type)
 
@@ -4048,7 +4066,7 @@ and type_label_exp create env loc ty_expected
       else begin
         if maybe_expansive arg then
           lower_contravariant env arg.exp_type;
-        generalize_and_check_univars env "field value" arg label.lbl_arg vars;
+        generalize_and_check_univars env Field_value arg label.lbl_arg vars;
         {arg with exp_type = instance arg.exp_type}
       end
     with exn when maybe_expansive arg -> try
@@ -4062,7 +4080,7 @@ and type_label_exp create env loc ty_expected
       let arg = {arg with exp_type = instance arg.exp_type} in
       unify_exp env arg (instance ty_arg);
       end_def ();
-      generalize_and_check_univars env "field value" arg label.lbl_arg vars;
+      generalize_and_check_univars env Field_value arg label.lbl_arg vars;
       {arg with exp_type = instance arg.exp_type}
     with Error (_, _, Less_general _) as e -> raise e
     | _ -> raise exn    (* In case of failure return the first error *)
@@ -4381,7 +4399,7 @@ and type_construct env loc lid sarg ty_expected_explained attrs =
     Env.lookup_all_constructors ~loc:lid.loc Env.Positive lid.txt env
   in
   let constr =
-    wrap_disambiguate "This variant expression is expected to have"
+    wrap_disambiguate Variant_expression
       ty_expected_explained
       (Constructor.disambiguate Env.Positive lid env expected_type) constrs
   in
@@ -4980,7 +4998,7 @@ and type_let
             so we do it anyway. *)
          generalize exp.exp_type
        | Some vars ->
-         generalize_and_check_univars env "definition" exp pat.pat_type vars)
+         generalize_and_check_univars env Definition exp pat.pat_type vars)
     pat_list exp_list;
   let l = List.combine pat_list exp_list in
   let l =
@@ -5095,8 +5113,6 @@ let spellcheck ppf unbound_name valid_names =
 let spellcheck_idents ppf unbound valid_idents =
   spellcheck ppf (Ident.name unbound) (List.map Ident.name valid_idents)
 
-open Format
-
 let longident = Printtyp.longident
 
 (* Returns the first diff of the trace *)
@@ -5129,7 +5145,8 @@ let report_literal_type_constraint expected_type const =
     else None
   in
   match const_str, suffix with
-  | Some c, Some s -> [ Location.msg "@[Hint: Did you mean `%s%c'?@]" c s ]
+  | Some c, Some s ->
+      [ Location.msg "@[Hint: Did you mean `%s%c'?@]" c s ]
   | _, _ -> []
 
 let report_literal_type_constraint const = function
@@ -5150,28 +5167,29 @@ let report_pattern_type_clash_hints
   | _ -> []
 
 let report_type_expected_explanation expl ppf =
-  let because expl_str = fprintf ppf "@ because it is in %s" expl_str in
+  let because expl_str =
+    I18n.fprintf ppf "@ because it is in %a" I18n.pp expl_str in
   match expl with
   | If_conditional ->
-      because "the condition of an if-statement"
+      because (I18n.s "the condition of an if-statement")
   | If_no_else_branch ->
-      because "the result of a conditional with no else branch"
+      because (I18n.s "the result of a conditional with no else branch")
   | While_loop_conditional ->
-      because "the condition of a while-loop"
+      because (I18n.s "the condition of a while-loop")
   | While_loop_body ->
-      because "the body of a while-loop"
+      because (I18n.s "the body of a while-loop")
   | For_loop_start_index ->
-      because "a for-loop start index"
+      because (I18n.s "a for-loop start index")
   | For_loop_stop_index ->
-      because "a for-loop stop index"
+      because (I18n.s "a for-loop stop index")
   | For_loop_body ->
-      because "the body of a for-loop"
+      because (I18n.s "the body of a for-loop")
   | Assert_condition ->
-      because "the condition of an assertion"
+      because (I18n.s "the condition of an assertion")
   | Sequence_left_hand_side ->
-      because "the left-hand side of a sequence"
+      because (I18n.s "the left-hand side of a sequence")
   | When_guard ->
-      because "a when-guard"
+      because (I18n.s "a when-guard")
 
 let report_type_expected_explanation_opt expl ppf =
   match expl with
@@ -5193,36 +5211,30 @@ let report_error ~loc env = function
        longident lid expected provided
   | Label_mismatch(lid, trace) ->
       report_unification_error ~loc env trace
-        (function ppf ->
-           fprintf ppf "The record field %a@ belongs to the type"
-                   longident lid)
-        (function ppf ->
-           fprintf ppf "but is mixed here with fields of type")
+        (I18n.dprintf "The record field %a@ belongs to the type" longident lid)
+        (I18n.dprintf "but is mixed here with fields of type")
   | Pattern_type_clash (trace, pat) ->
       let diff = type_clash_of_trace trace in
       let sub = report_pattern_type_clash_hints pat diff in
       Location.error_of_printer ~loc ~sub (fun ppf () ->
         Printtyp.report_unification_error ppf env trace
-          (function ppf ->
-            fprintf ppf "This pattern matches values of type")
-          (function ppf ->
-            fprintf ppf "but a pattern was expected which matches values of \
-                         type");
+          (I18n.dprintf "This pattern matches values of type")
+          (I18n.dprintf
+             "but a pattern was expected which matches values of type"
+          );
       ) ()
   | Or_pattern_type_clash (id, trace) ->
       report_unification_error ~loc env trace
-        (function ppf ->
-          fprintf ppf "The variable %s on the left-hand side of this \
-                       or-pattern has type" (Ident.name id))
-        (function ppf ->
-          fprintf ppf "but on the right-hand side it has type")
+        (I18n.dprintf
+           "The variable %s on the left-hand side of this or-pattern has type"
+           (Ident.name id))
+        (I18n.dprintf "but on the right-hand side it has type")
   | Multiply_bound_variable name ->
-      Location.errorf ~loc
-        "Variable %s is bound several times in this matching"
+      Location.errorf ~loc "Variable %s is bound several times in this matching"
         name
   | Orpat_vars (id, valid_idents) ->
       Location.error_of_printer ~loc (fun ppf () ->
-        fprintf ppf
+        I18n.fprintf ppf
           "Variable %s must occur on both sides of this | pattern"
           (Ident.name id);
         spellcheck_idents ppf id valid_idents
@@ -5234,10 +5246,8 @@ let report_error ~loc env = function
         Printtyp.report_unification_error ppf env trace
           ~type_expected_explanation:
             (report_type_expected_explanation_opt explanation)
-          (function ppf ->
-             fprintf ppf "This expression has type")
-          (function ppf ->
-             fprintf ppf "but an expression was expected of type");
+          (I18n.dprintf "This expression has type")
+          (I18n.dprintf "but an expression was expected of type")
       ) ()
   | Apply_non_function typ ->
       begin match (repr typ).desc with
@@ -5253,65 +5263,87 @@ let report_error ~loc env = function
       end
   | Apply_wrong_label (l, ty) ->
       let print_label ppf = function
-        | Nolabel -> fprintf ppf "without label"
-        | l -> fprintf ppf "with label %s" (prefixed_label_name l)
+        | Nolabel ->
+            I18n.fprintf ppf "This argument cannot be applied without label"
+        | l -> I18n.fprintf ppf "This argument cannot be applied with label %s"
+                 (prefixed_label_name l)
       in
       Location.errorf ~loc
-        "@[<v>@[<2>The function applied to this argument has type@ %a@]@.\
-         This argument cannot be applied %a@]"
+        "@[<2>The function applied to this argument has type@ %a@]\n\
+         %a"
         Printtyp.type_expr ty print_label l
   | Label_multiply_defined s ->
       Location.errorf ~loc "The record field label %s is defined several times"
         s
   | Label_missing labels ->
       let print_labels ppf =
-        List.iter (fun lbl -> fprintf ppf "@ %s" (Ident.name lbl)) in
+        List.iter (fun lbl -> Format.fprintf ppf "@ %s" (Ident.name lbl)) in
       Location.errorf ~loc "@[<hov>Some record fields are undefined:%a@]"
         print_labels labels
   | Label_not_mutable lid ->
       Location.errorf ~loc "The record field %a is not mutable" longident lid
-  | Wrong_name (eorp, ty_expected, { type_path; kind; name; valid_names; }) ->
+  | Wrong_name (eorp, ty_expected, { type_path; kind=_; name; valid_names; }) ->
       Location.error_of_printer ~loc (fun ppf () ->
         Printtyp.wrap_printing_env ~error:true env (fun () ->
           let { ty; explanation } = ty_expected in
           if Path.is_constructor_typath type_path then begin
-            fprintf ppf
+            I18n.fprintf ppf
               "@[The field %s is not part of the record \
                argument for the %a constructor@]"
               name.txt
               Printtyp.type_path type_path;
-          end else begin
-            fprintf ppf
-              "@[@[<2>%s type@ %a%t@]@ \
-               The %s %s does not belong to type %a@]"
-              eorp Printtyp.type_expr ty
-              (report_type_expected_explanation_opt explanation)
-              (Datatype_kind.label_name kind)
-              name.txt (*kind*) Printtyp.type_path type_path;
-          end;
-          spellcheck ppf name.txt valid_names
+          end else begin (match eorp with
+           | Record_expression ->
+               I18n.fprintf ppf
+                 "@[@[<2>This record expression is expected to have type@ \
+                  %a%t@]@ The field %s does not belong to type %a@]"
+           | Record_access ->
+               I18n.fprintf ppf
+                 "@[@[<2>This expression has type@ %a%t@]@ \
+                  The field %s does not belong to type %a@]"
+           | Record_pattern ->
+               I18n.fprintf ppf
+                 "@[@[<2>This record pattern is expected to have type@ %a%t@]@ \
+                  The field %s does not belong to type %a@]"
+           | Variant_expression ->
+               I18n.fprintf ppf
+                 "@[@[<2>This variant expression is expected to have type@ \
+                  %a%t@]@ The constructor %s does not belong to type %a@]"
+           | Variant_pattern ->
+               I18n.fprintf ppf
+                 "@[@[<2>This variant pattern is expected to have type@ \
+                  %a%t@]@ The constructor %s does not belong to type %a@]"
+          )  Printtyp.type_expr ty
+            (report_type_expected_explanation_opt explanation)
+            name.txt Printtyp.type_path type_path;
+        end;
+        spellcheck ppf name.txt valid_names
       )) ()
   | Name_type_mismatch (kind, lid, tp, tpl) ->
-      let type_name = Datatype_kind.type_name kind in
-      let name = Datatype_kind.label_name kind in
-      Location.error_of_printer ~loc (fun ppf () ->
-        Printtyp.report_ambiguous_type_error ppf env tp tpl
-          (function ppf ->
-             fprintf ppf "The %s %a@ belongs to the %s type"
-               name longident lid type_name)
-          (function ppf ->
-             fprintf ppf "The %s %a@ belongs to one of the following %s types:"
-               name longident lid type_name)
-          (function ppf ->
-             fprintf ppf "but a %s was expected belonging to the %s type"
-               name type_name)
-      ) ()
+      let report x y z =
+        Location.error_of_printer ~loc (fun ppf () ->
+            Printtyp.report_ambiguous_type_error ppf env tp tpl
+              (I18n.dprintf x longident lid)
+              (I18n.dprintf y longident lid)
+              (I18n.dprintf z)) () in
+      begin match kind with
+      | Datatype_kind.Record ->
+          report
+            "The field %a@ belongs to the record type"
+            "The field %a@ belongs to one of the following record types:"
+            "but a field was expected belonging to the record type"
+      | Datatype_kind.Variant ->
+          report
+            "The constructor %a@ belongs to the variant type"
+            "The constructor %a@ belongs to one of the following variant types:"
+            "but a constructor was expected belonging to the variant type"
+      end
   | Invalid_format msg ->
       Location.errorf ~loc "%s" msg
   | Undefined_method (ty, me, valid_methods) ->
       Location.error_of_printer ~loc (fun ppf () ->
         Printtyp.wrap_printing_env ~error:true env (fun () ->
-          fprintf ppf
+          I18n.fprintf ppf
             "@[<v>@[This expression has type@;<1 2>%a@]@,\
              It has no method %s@]" Printtyp.type_expr ty me;
           begin match valid_methods with
@@ -5321,7 +5353,7 @@ let report_error ~loc env = function
       )) ()
   | Undefined_inherited_method (me, valid_methods) ->
       Location.error_of_printer ~loc (fun ppf () ->
-        fprintf ppf "This expression has no method %s" me;
+        I18n.fprintf ppf "This expression has no method %s" me;
         spellcheck ppf me valid_methods;
       ) ()
   | Virtual_class cl ->
@@ -5329,14 +5361,15 @@ let report_error ~loc env = function
         longident cl
   | Unbound_instance_variable (var, valid_vars) ->
       Location.error_of_printer ~loc (fun ppf () ->
-        fprintf ppf "Unbound instance variable %s" var;
+        I18n.fprintf ppf "Unbound instance variable %s" var;
         spellcheck ppf var valid_vars;
       ) ()
   | Instance_variable_not_mutable v ->
       Location.errorf ~loc "The instance variable %s is not mutable" v
   | Not_subtype(tr1, tr2) ->
       Location.error_of_printer ~loc (fun ppf () ->
-        Printtyp.report_subtyping_error ppf env tr1 "is not a subtype of" tr2
+          Printtyp.report_subtyping_error ppf env tr1
+            (I18n.s "is not a subtype of") tr2
       ) ()
   | Outside_class ->
       Location.errorf ~loc
@@ -5350,22 +5383,21 @@ let report_error ~loc env = function
         Printtyp.report_unification_error ppf env trace
           (function ppf ->
              let ty, ty' = Printtyp.prepare_expansion (ty, ty') in
-             fprintf ppf "This expression cannot be coerced to type@;<1 2>%a;@ \
-                          it has type"
+             I18n.fprintf ppf
+               "This expression cannot be coerced to type@;<1 2>%a;@ \
+                it has type"
              (Printtyp.type_expansion ty) ty')
-          (function ppf ->
-             fprintf ppf "but is here used with type");
+          (I18n.dprintf "but is here used with type");
         if b then
-          fprintf ppf ".@.@[<hov>%s@ %s@ %s@]"
-            "This simple coercion was not fully general."
-            "Hint: Consider using a fully explicit coercion"
-            "of the form: `(foo : ty1 :> ty2)'."
+          I18n.fprintf ppf
+            ".@.@[<hov>This simple coercion was not fully general.@ \
+             Hint: Consider using a fully explicit coercion@ of the form: \
+             `(foo : ty1 :> ty2)'.@]"
       ) ()
   | Too_many_arguments (in_function, ty, explanation) ->
       if in_function then begin
         Location.errorf ~loc
-          "This function expects too many arguments,@ \
-           it should have type@ %a%t"
+          "This function expects too many arguments,@ it should have type@ %a%t"
           Printtyp.type_expr ty
           (report_type_expected_explanation_opt explanation)
       end else begin
@@ -5377,14 +5409,14 @@ let report_error ~loc env = function
       end
   | Abstract_wrong_label (l, ty, explanation) ->
       let label_mark = function
-        | Nolabel -> "but its first argument is not labelled"
-        | l -> sprintf "but its first argument is labelled %s"
+        | Nolabel -> I18n.sprintf "but its first argument is not labelled"
+        | l -> I18n.sprintf "but its first argument is labelled %s"
                        (prefixed_label_name l) in
       Location.errorf ~loc
-        "@[<v>@[<2>This function should have type@ %a%t@]@,%s@]"
+        "@[<v>@[<2>This function should have type@ %a%t@]@,%a@]"
         Printtyp.type_expr ty
         (report_type_expected_explanation_opt explanation)
-        (label_mark l)
+        I18n.pp (label_mark l)
   | Scoping_let_module(id, ty) ->
       Location.errorf ~loc
         "This `let module' expression has type@ %a@ \
@@ -5406,11 +5438,15 @@ let report_error ~loc env = function
       Location.errorf ~loc
         "This function is applied to arguments@ \
         in an order different from other calls.@ \
-        This is only allowed when the real type is known."
+         This is only allowed when the real type is known."
   | Less_general (kind, trace) ->
-      report_unification_error ~loc env trace
-        (fun ppf -> fprintf ppf "This %s has type" kind)
-        (fun ppf -> fprintf ppf "which is less general than")
+      let intro = match kind with
+        | Definition -> I18n.dprintf "This definition has type"
+        | Method -> I18n.dprintf "This method has type"
+        | Field_value -> I18n.dprintf "This field value has type"
+      in
+      report_unification_error ~loc env trace intro
+        (I18n.dprintf "which is less general than")
   | Modules_not_allowed ->
       Location.errorf ~loc "Modules are not allowed in this pattern."
   | Cannot_infer_signature ->
@@ -5424,30 +5460,31 @@ let report_error ~loc env = function
       let reason_str =
         match reason with
         | In_class_args ->
-            "Existential types are not allowed in class arguments"
+            I18n.s "Existential types are not allowed in class arguments"
         | In_class_def ->
-            "Existential types are not allowed in bindings inside \
+            I18n.s "Existential types are not allowed in bindings inside \
              class definition"
         | In_self_pattern ->
-            "Existential types are not allowed in self patterns"
+            I18n.s "Existential types are not allowed in self patterns"
         | At_toplevel ->
-            "Existential types are not allowed in toplevel bindings"
+            I18n.s "Existential types are not allowed in toplevel bindings"
         | In_group ->
-            "Existential types are not allowed in \"let ... and ...\" bindings"
+            I18n.s "Existential types are not allowed \
+                    in \"let ... and ...\" bindings"
         | In_rec ->
-            "Existential types are not allowed in recursive bindings"
+            I18n.s "Existential types are not allowed in recursive bindings"
         | With_attributes ->
-            "Existential types are not allowed in presence of attributes"
+            I18n.s "Existential types are not allowed in presence of attributes"
       in
       begin match List.find (fun ty -> ty <> "$" ^ name) types with
       | example ->
           Location.errorf ~loc
-            "%s,@ but this pattern introduces the existential type %s."
-            reason_str example
+            "%a,@ but this pattern introduces the existential type %s."
+            I18n.pp reason_str example
       | exception Not_found ->
           Location.errorf ~loc
-            "%s,@ but the constructor %s introduces existential types."
-            reason_str name
+            "%a,@ but the constructor %s introduces existential types."
+            I18n.pp reason_str name
       end
   | Invalid_interval ->
       Location.errorf ~loc
@@ -5457,33 +5494,31 @@ let report_error ~loc env = function
         "@[Invalid for-loop index: only variables and _ are allowed.@]"
   | No_value_clauses ->
       Location.errorf ~loc
-        "None of the patterns in this 'match' expression match values."
+         "None of the patterns in this 'match' expression match values."
   | Exception_pattern_disallowed ->
       Location.errorf ~loc
-        "@[Exception patterns are not allowed in this position.@]"
+         "@[Exception patterns are not allowed in this position.@]"
   | Mixed_value_and_exception_patterns_under_guard ->
       Location.errorf ~loc
-        "@[Mixing value and exception patterns under when-guards is not \
-         supported.@]"
+        "@[Mixing value and exception patterns under when-guards \
+         is not supported.@]"
   | Inlined_record_escape ->
       Location.errorf ~loc
-        "@[This form is not allowed as the type of the inlined record could \
-         escape.@]"
+        "@[This form is not allowed as the type of the inlined record \
+         could escape.@]"
   | Inlined_record_expected ->
       Location.errorf ~loc
         "@[This constructor expects an inlined record argument.@]"
   | Unrefuted_pattern pat ->
       Location.errorf ~loc
-        "@[%s@ %s@ %a@]"
-        "This match case could not be refuted."
-        "Here is an example of a value that would reach it:"
+        "@[This match case could not be refuted.@ \
+         Here is an example of a value that would reach it:@ %a@]"
         Printpat.top_pretty pat
   | Invalid_extension_constructor_payload ->
       Location.errorf ~loc
         "Invalid [%%extension_constructor] payload, a constructor is expected."
   | Not_an_extension_constructor ->
-      Location.errorf ~loc
-        "This constructor is not an extension constructor."
+      Location.errorf ~loc "This constructor is not an extension constructor."
   | Literal_overflow ty ->
       Location.errorf ~loc
         "Integer literal exceeds the range of representable integers of type %s"
@@ -5495,28 +5530,23 @@ let report_error ~loc env = function
         "Only variables are allowed as left-hand side of `let rec'"
   | Illegal_letrec_expr ->
       Location.errorf ~loc
-        "This kind of expression is not allowed as right-hand side of `let rec'"
+         "This kind of expression is not allowed as \
+          right-hand side of `let rec'"
   | Illegal_class_expr ->
       Location.errorf ~loc
         "This kind of recursive class expression is not allowed"
   | Letop_type_clash(name, trace) ->
       report_unification_error ~loc env trace
-        (function ppf ->
-          fprintf ppf "The operator %s has type" name)
-        (function ppf ->
-          fprintf ppf "but it was expected to have type")
+        (I18n.dprintf "The operator %s has type" name)
+        (I18n.dprintf "but it was expected to have type")
   | Andop_type_clash(name, trace) ->
       report_unification_error ~loc env trace
-        (function ppf ->
-          fprintf ppf "The operator %s has type" name)
-        (function ppf ->
-          fprintf ppf "but it was expected to have type")
+        (I18n.dprintf "The operator %s has type" name)
+        (I18n.dprintf "but it was expected to have type")
   | Bindings_type_clash(trace) ->
       report_unification_error ~loc env trace
-        (function ppf ->
-          fprintf ppf "These bindings have type")
-        (function ppf ->
-          fprintf ppf "but bindings were expected of type")
+        (I18n.dprintf "These bindings have type")
+        (I18n.dprintf "but bindings were expected of type")
 
 let report_error ~loc env err =
   Printtyp.wrap_printing_env ~error:true env

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -127,6 +127,22 @@ val name_cases : string -> Typedtree.value Typedtree.case list -> Ident.t
 
 val self_coercion : (Path.t * Location.t list ref) list ref
 
+type polymorphic_kind =
+  | Method
+  | Field_value
+  | Definition
+
+type name_kind =
+  | Constructor
+  | Label
+
+type disambiguation_context =
+  | Record_access
+  | Record_expression
+  | Record_pattern
+  | Variant_expression
+  | Variant_pattern
+
 type error =
   | Constructor_arity_mismatch of Longident.t * int * int
   | Label_mismatch of Longident.t * Ctype.Unification_trace.t
@@ -143,7 +159,7 @@ type error =
   | Label_multiply_defined of string
   | Label_missing of Ident.t list
   | Label_not_mutable of Longident.t
-  | Wrong_name of string * type_expected * wrong_name
+  | Wrong_name of disambiguation_context * type_expected * wrong_name
   | Name_type_mismatch of
       Datatype_kind.t * Longident.t * (Path.t * Path.t) * (Path.t * Path.t) list
   | Invalid_format of string
@@ -165,7 +181,7 @@ type error =
   | Scoping_let_module of string * type_expr
   | Not_a_variant_type of Longident.t
   | Incoherent_label_order
-  | Less_general of string * Ctype.Unification_trace.t
+  | Less_general of polymorphic_kind * Ctype.Unification_trace.t
   | Modules_not_allowed
   | Cannot_infer_signature
   | Not_a_packed_module of type_expr

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -95,7 +95,7 @@ type error =
   | Deep_unbox_or_untag_attribute of native_repr_kind
   | Immediacy of Typedecl_immediacy.error
   | Separability of Typedecl_separability.error
-  | Bad_unboxed_attribute of string
+  | Bad_unboxed_attribute of I18n.s
   | Boxed_and_unboxed
   | Nonrec_gadt
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -19,7 +19,6 @@ open Path
 open Asttypes
 open Parsetree
 open Types
-open Format
 
 module String = Misc.Stdlib.String
 
@@ -2637,7 +2636,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
       if !Clflags.print_types then begin
         Typecore.force_delayed_checks ();
         Printtyp.wrap_printing_env ~error:false initial_env
-          (fun () -> fprintf std_formatter "%a@."
+          (fun () -> Format.fprintf Format.std_formatter "%a@."
               (Printtyp.printed_signature sourcefile) simple_sg
           );
         (str, Tcoerce_none)   (* result is ignored by Compile.implementation *)
@@ -2791,26 +2790,26 @@ open Printtyp
 
 let report_error ppf = function
     Cannot_apply mty ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[This module is not a functor; it has type@ %a@]" modtype mty
   | Not_included errs ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[<v>Signature mismatch:@ %a@]" Includemod.report_error errs
   | Cannot_eliminate_dependency mty ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[This functor has type@ %a@ \
            The parameter cannot be eliminated in the result type.@ \
            Please bind the argument to a module identifier.@]" modtype mty
-  | Signature_expected -> fprintf ppf "This module type is not a signature"
+  | Signature_expected -> I18n.fprintf ppf "This module type is not a signature"
   | Structure_expected mty ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[This module is not a structure; it has type@ %a" modtype mty
   | With_no_component lid ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[The signature constrained by `with' has no component named %a@]"
         longident lid
   | With_mismatch(lid, explanation) ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[<v>\
            @[In this `with' constraint, the new definition of %a@ \
              does not match its original definition@ \
@@ -2818,82 +2817,83 @@ let report_error ppf = function
            %a@]"
         longident lid Includemod.report_error explanation
   | With_makes_applicative_functor_ill_typed(lid, path, explanation) ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[<v>\
            @[This `with' constraint on %a makes the applicative functor @ \
              type %s ill-typed in the constrained signature:@]@ \
            %a@]"
         longident lid (Path.name path) Includemod.report_error explanation
   | With_changes_module_alias(lid, id, path) ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[<v>\
            @[This `with' constraint on %a changes %s, which is aliased @ \
              in the constrained signature (as %s)@].@]"
         longident lid (Path.name path) (Ident.name id)
   | With_cannot_remove_constrained_type ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[<v>Destructive substitutions are not supported for constrained @ \
               types (other than when replacing a type constructor with @ \
               a type constructor with the same arguments).@]"
   | Repeated_name(kind, name) ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[Multiple definition of the %s name %s.@ \
          Names must be unique in a given structure or signature.@]"
         (Sig_component_kind.to_string kind) name
   | Non_generalizable typ ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[The type of this expression,@ %a,@ \
            contains type variables that cannot be generalized@]" type_scheme typ
   | Non_generalizable_class (id, desc) ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[The type of this class,@ %a,@ \
            contains type variables that cannot be generalized@]"
         (class_declaration id) desc
   | Non_generalizable_module mty ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[The type of this module,@ %a,@ \
            contains type variables that cannot be generalized@]" modtype mty
   | Implementation_is_required intf_name ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[The interface %a@ declares values, not just types.@ \
            An implementation must be provided.@]"
         Location.print_filename intf_name
   | Interface_not_compiled intf_name ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[Could not find the .cmi file for interface@ %a.@]"
         Location.print_filename intf_name
   | Not_allowed_in_functor_body ->
-      fprintf ppf
+      I18n.fprintf ppf
         "@[This expression creates fresh types.@ %s@]"
         "It is not allowed inside applicative functors."
   | Not_a_packed_module ty ->
-      fprintf ppf
+      I18n.fprintf ppf
         "This expression is not a packed module. It has type@ %a"
         type_expr ty
   | Incomplete_packed_module ty ->
-      fprintf ppf
+      I18n.fprintf ppf
         "The type of this packed module contains variables:@ %a"
         type_expr ty
   | Scoping_pack (lid, ty) ->
-      fprintf ppf
+      I18n.fprintf ppf
         "The type %a in this module cannot be exported.@ " longident lid;
-      fprintf ppf
+      I18n.fprintf ppf
         "Its type contains local dependencies:@ %a" type_expr ty
   | Recursive_module_require_explicit_type ->
-      fprintf ppf "Recursive modules require an explicit module type."
+      I18n.fprintf ppf "Recursive modules require an explicit module type."
   | Apply_generative ->
-      fprintf ppf "This is a generative functor. It can only be applied to ()"
+      I18n.fprintf ppf
+        "This is a generative functor. It can only be applied to ()"
   | Cannot_scrape_alias p ->
-      fprintf ppf
+      I18n.fprintf ppf
         "This is an alias for module %a, which is missing"
         path p
   | Badly_formed_signature (context, err) ->
-      fprintf ppf "@[In %s:@ %a@]" context Typedecl.report_error err
+      I18n.fprintf ppf "@[In %s:@ %a@]" context Typedecl.report_error err
   | Cannot_hide_id Illegal_shadowing
       { shadowed_item_kind; shadowed_item_id; shadowed_item_loc;
         shadower_id; user_id; user_kind; user_loc } ->
       let shadowed_item_kind= Sig_component_kind.to_string shadowed_item_kind in
-      fprintf ppf
+      I18n.fprintf ppf
         "@[<v>Illegal shadowing of included %s %a by %a@ \
          %a:@;<1 2>%s %a came from this include@ \
          %a:@;<1 2>The %s %s has no valid type if %a is shadowed@]"
@@ -2907,7 +2907,7 @@ let report_error ppf = function
   | Cannot_hide_id Appears_in_signature
       { opened_item_kind; opened_item_id; user_id; user_kind; user_loc } ->
       let opened_item_kind= Sig_component_kind.to_string opened_item_kind in
-      fprintf ppf
+      I18n.fprintf ppf
         "@[<v>The %s %a introduced by this open appears in the signature@ \
          %a:@;<1 2>The %s %s has no valid type if %a is hidden@]"
         opened_item_kind Ident.print opened_item_id
@@ -2915,7 +2915,7 @@ let report_error ppf = function
         (Sig_component_kind.to_string user_kind) (Ident.name user_id)
         Ident.print opened_item_id
   | Invalid_type_subst_rhs ->
-      fprintf ppf "Only type synonyms are allowed on the right of :="
+      I18n.fprintf ppf "Only type synonyms are allowed on the right of :="
 
 let report_error env ppf err =
   Printtyp.wrap_printing_env ~error:true env (fun () -> report_error ppf err)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2055,7 +2055,7 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
               not (Typecore.generalizable (Btype.generic_level-1) exp.exp_type)
             then
               Location.prerr_warning smod.pmod_loc
-                (Warnings.Not_principal "this module unpacking");
+                (Warnings.Not_principal (I18n.s "this module unpacking"));
             modtype_of_package env smod.pmod_loc p nl tl
         | {desc = Tvar _} ->
             raise (Typecore.Error

--- a/utils/i18n.ml
+++ b/utils/i18n.ml
@@ -1,0 +1,110 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Florian Angeletti, Inria Paris                             *)
+(*                                                                        *)
+(*   Copyright 2019 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Internationalization and localization plugin hooks *)
+
+(** translated string type *)
+type s = string
+
+(** I18n implementation *)
+
+type implementation =
+  {
+
+    kdprintf:
+      'a 'r.
+         ( (Format.formatter -> unit) -> 'r)
+      -> ('a, Format.formatter,unit, 'r) format4 -> 'a;
+
+    kfprintf:
+      'a 'r. (Format.formatter -> 'r) -> Format.formatter
+      -> ('a,Format.formatter,unit,'r) format4-> 'a;
+      (** Singular form printing function *)
+
+    kdnprintf:
+      'a 'r.
+         ((Format.formatter -> unit) -> 'r)
+      -> int -> (('a, Format.formatter,unit, 'r) format4 as 'f) -> 'f -> 'a;
+
+    knfprintf:
+      'a 'r. (Format.formatter -> 'r) -> Format.formatter
+      -> int -> (('a,Format.formatter,unit,'r) format4 as 'f)
+      -> 'f -> 'a;
+    (** Plural form printing function *)
+
+    text: Format.formatter -> string -> unit
+
+  }
+
+let choice n x y =
+  (* folloxing gettext convention, the default behavior is assumed to be the
+     germanic language with a singular(=1) and non-singular form
+     (i.e. {0} union [2,+infinity]) *)
+  if n = 1 then x else y
+
+(** The default implementation only convert type *)
+let default = {
+  kdprintf = Format.kdprintf;
+  kdnprintf = (fun k n singular plural ->
+      Format.kdprintf k (choice n singular plural)
+    );
+  kfprintf = Format.kfprintf;
+  knfprintf = (fun k ppf n x y -> Format.kfprintf k ppf (choice n x y) );
+  text = Format.pp_print_text
+}
+
+let hook = ref default
+(** Plugin hook for i18n implementation *)
+
+
+let kfprintf k ppf fmt = !hook.kfprintf k ppf fmt
+
+let ksprintf k fmt =
+  let b = Buffer.create 10 in
+  let ppf = Format.formatter_of_buffer b in
+  kfprintf (fun ppf -> Format.pp_print_flush ppf (); k (Buffer.contents b))
+    ppf fmt
+let sprintf fmt = ksprintf (fun x -> x) fmt
+let formattify x =
+  let open CamlinternalFormatBasics in
+  Format(String_literal (x,End_of_format), x)
+
+let s x = sprintf (formattify x)
+
+let i18n x = s x
+
+let fprintf ppf fmt = !hook.kfprintf ignore ppf fmt
+let printf fmt = fprintf  (Format.std_formatter) fmt
+let eprintf fmt = fprintf (Format.std_formatter) fmt
+let kdprintf k fmt = !hook.kdprintf k fmt
+let dprintf fmt = kdprintf (fun x -> x) fmt
+let kfnprintf k ppf n fmt fmt2 =
+  !hook.knfprintf k ppf n fmt fmt2
+let dnprintf n singular plural = !hook.kdnprintf (fun x -> x) n singular plural
+let fnprintf x = kfnprintf ignore x
+let snprintf n fmt fmt' =
+  let b = Buffer.create 10 in
+  let ppf = Format.formatter_of_buffer b in
+  kfnprintf (fun ppf -> Format.pp_print_flush ppf (); Buffer.contents b)
+    ppf n fmt fmt'
+
+let sn n x y = snprintf n (formattify x) (formattify y)
+
+
+let raw x = x
+let to_string x = x
+
+let pp ppf s = Format.pp_print_string ppf (i18n s)
+let pp_print_text ppf s = !hook.text ppf s

--- a/utils/i18n.mli
+++ b/utils/i18n.mli
@@ -178,6 +178,8 @@ val pp_print_text: Format.formatter -> s -> unit
 (** {1 Conversion function}
     Convert back-and-forth to standard string *)
 val to_string: s -> string
+
+(**  [raw] breaks localization, uses as little as possible *)
 val raw: string -> s
 
 

--- a/utils/i18n.mli
+++ b/utils/i18n.mli
@@ -1,0 +1,219 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Florian Angeletti, Inria Paris                             *)
+(*                                                                        *)
+(*   Copyright 2019 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+
+(** Localization hook *)
+
+(**
+
+   This module provides a compiler-libs hook for localizing
+   OCaml user-facing messages.
+
+   More precisely, this module contains localizable version of the
+   printing functions of Format( [fprintf], [dprintf], [kprintf], ...),
+   together with an overridable implementation {!hook} for those functions.
+
+   Those functions are expected to be used whenever we print a message intended
+   to an user. For instance
+
+   {[
+     I18n.fprintf ppf
+       "Variable %s must occur on both sides of this | pattern"
+       (Ident.name id)
+   ]}
+
+   The default hook merely calls back the corresponding {!Format} functions.
+   Localization-aware compiler-libs clients can override this implementation
+   to perform translation on the fly of the format string.
+   for instance, one possible implementation is to replace
+   [ "Variable %s must occur on both sides of this | pattern"]
+   with [" "A variavel %s deve ocorrer em ambos os lados deste | pattern"].
+
+   This module also provides anabstract type {!s} to represent a stored
+   translated text for compatibility reason.
+   This abstract type can only be printed, because no
+   string operations works on all human languages simultaneously.
+
+   On a first approximation, using this module is only a matter of using
+   [I18n.fprintf] whenever we are printing a grammatically correct text,
+   and [Format.fprintf] otherwise. There is however an important rule to provide
+   nicely translatable message for translators:
+   the smallest translatable unit is the phrase.
+   Any smaller grammatical component (nouns, adjectives, verbs, ...)
+   may create unstranlatable messages due to incompatible contexts.
+
+   A classic example of a problematic format string is
+   {["the %a %s is defined in both types %s and %s.]}
+   where the first [%a] is supposed to be a translation for "label" or
+   "constructor". However, it is not always possible to use this
+   translations to construct a grammatically correct sentence.
+   As an illustration the French translations for those two cases
+   {["l'etiquette %s est definie dans les deux types %s and %s"]}
+   or
+   {["Le constructeur %s est defini dans les deux types %s and %s"]}
+   Notice that the declensions of the translation of "the", "l'" and "le", are
+   not the same in the two cases, and the French translator ends up stuck.
+
+   To avoid this issue is often better to not generate partial text fragment
+   and use variants to carry the information to the error or warning reporter.
+   This reporter should have enough information to construct well-formed and
+   translatable sentences.
+
+   In particular, the stored translated type {!s} is currently
+   misused at few places, and it may be better to remove it completely
+   in the future.
+
+   Note that this module should not be opened:
+   most translation framework requires the ability to syntactically
+   distinguish user-facing string constants that should be translated
+   when scanning the code base. To make this scan relatively easy, we
+   are currently using localization-aware function in a fully-qualified.
+
+   Note for extractions tools:
+   Extractions tools should be able to extract translatable message from
+   the arguments of all function defined in this module and
+   {!Location.raise_errorf}, {!Location.errorf} and {!Location.msg}.
+
+*)
+
+
+(** {1 Convenience functions}
+    These functions share the same interface as {!Format}'s function but use the
+    implementation provided by {!hook}
+*)
+
+val kfprintf: (Format.formatter -> 'r) -> Format.formatter
+  -> ('a,Format.formatter,unit,'r) format4  -> 'a
+val fprintf: Format.formatter -> ('a,Format.formatter,unit) format  -> 'a
+val eprintf: ('a,Format.formatter,unit) format  -> 'a
+val printf: ('a,Format.formatter,unit) format  -> 'a
+val kdprintf:
+  ((Format.formatter-> unit) -> 'r)
+  -> ('a,Format.formatter, unit, 'r) format4 -> 'a
+val dprintf: ('a,Format.formatter, unit, Format.formatter -> unit) format4 -> 'a
+
+
+(** {2 Plural variants}
+
+    Translating messages with varying grammatical number is hard.
+
+    Indeed, not all languages only have a singular and a plural. For
+    instance, few indo-european language have preserved the dual, a special
+    case for two objects.
+    If one consider ordinals (1st, 2nd, 3rd, 4th, 11th, 21st, 22nd, ...) this
+    problem appears even in English..
+    In order to try to make it possible to translate such sentences, we provide
+    a plural version for each Format's printing functions that
+    provides more information to the translator:
+    - the numerical number of varying entities
+    - a default text for the singular case
+    - a default text for the plural case.
+
+*)
+
+
+val fnprintf:
+  Format.formatter
+  -> int
+  -> ( ('a,Format.formatter,unit) format as 'f)
+  -> 'f
+  -> 'a
+(** [fnprintf num ppf singular plural] *)
+
+val dnprintf:
+  int
+  -> ( ('a,Format.formatter, unit, Format.formatter -> unit) format4 as 'f)
+  -> 'f
+  -> 'a
+(** [dnprintf num singular plural] *)
+
+
+
+
+
+
+(** {1 Translated string}
+  A type for already translated string.
+  This type is used for compatibility reason when functions expect
+  fully rendered strings rather than printer
+*)
+type s
+
+
+(** Those three functions can be used to translate and store
+    an user-facing message *)
+val s: string -> s
+val i18n: string -> s
+val sn: int -> string -> string -> s
+  (** [sn num singular plural] *)
+
+(** Store the result of a format string into a {!s} value *)
+val ksprintf: (s -> 'r) -> ('a,Format.formatter,unit,'r) format4 -> 'a
+val sprintf: ('a,Format.formatter,unit,s) format4 -> 'a
+val snprintf:
+  int -> ( ('a,Format.formatter,unit,s) format4 as 'f) -> 'f -> 'a
+(** [snprintf num singular plural] *)
+
+val pp: Format.formatter -> s -> unit
+(** The printing function for stored translation *)
+
+
+val pp_print_text: Format.formatter -> s -> unit
+(** [pp_print_text] is here because the notion of space differs from language,
+     it is thus better to let the translation layer handle the layouting here *)
+
+
+(** {1 Conversion function}
+    Convert back-and-forth to standard string *)
+val to_string: s -> string
+val raw: string -> s
+
+
+(** {1 Localizatio hook} *)
+
+type implementation =
+  {
+
+   kdprintf:
+      'a 'r.
+         ( (Format.formatter -> unit) -> 'r)
+      -> ('a, Format.formatter,unit, 'r) format4 -> 'a;
+
+    kfprintf:
+      'a 'r. (Format.formatter -> 'r) -> Format.formatter
+      -> ('a,Format.formatter,unit,'r) format4-> 'a;
+    (** Singular form printing function *)
+
+    kdnprintf:
+      'a 'r.
+         ((Format.formatter -> unit) -> 'r)
+      -> int -> (('a, Format.formatter,unit, 'r) format4 as 'f) -> 'f -> 'a;
+
+    knfprintf:
+      'a 'r. (Format.formatter -> 'r) -> Format.formatter
+      -> int -> (('a,Format.formatter,unit,'r) format4 as 'f)
+      -> 'f -> 'a;
+    (** Plural form printing function *)
+
+    text: Format.formatter -> string -> unit
+    (** Pretty printed text (see {!Format.pp_print_text}) *)
+
+  }
+
+(** The default implementation calls the original [Format] functions directly *)
+val default:implementation
+
+(** Hook for localization implementation *)
+val hook : implementation ref

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -24,6 +24,9 @@ type loc = {
   loc_ghost: bool;
 }
 
+type shadowed_identifier =
+  [`Value|`Type|`Module|`Module_type|`Class|`Class_type]
+
 type t =
   | Comment_start                           (*  1 *)
   | Comment_not_end                         (*  2 *)
@@ -42,8 +45,8 @@ type t =
   | Implicit_public_methods of string list  (* 15 *)
   | Unerasable_optional_argument            (* 16 *)
   | Undeclared_virtual_method of string     (* 17 *)
-  | Not_principal of string                 (* 18 *)
-  | Without_principality of string          (* 19 *)
+  | Not_principal of I18n.s                 (* 18 *)
+  | Without_principality of I18n.s          (* 19 *)
   | Unused_argument                         (* 20 *)
   | Nonreturning_statement                  (* 21 *)
   | Preprocessor of string                  (* 22 *)
@@ -65,11 +68,12 @@ type t =
   | Unused_extension of string * bool * bool * bool (* 38 *)
   | Unused_rec_flag                         (* 39 *)
   | Name_out_of_scope of string * string list * bool (* 40 *)
-  | Ambiguous_name of string list * string list *  bool * string (* 41 *)
+  | Ambiguous_name of string list * string list *  bool * I18n.s (* 41 *)
   | Disambiguated_name of string            (* 42 *)
   | Nonoptional_label of string             (* 43 *)
-  | Open_shadow_identifier of string * string (* 44 *)
-  | Open_shadow_label_constructor of string * string (* 45 *)
+  | Open_shadow_identifier of shadowed_identifier * string (* 44 *)
+  | Open_shadow_label_constructor of
+      [ `Label | `Constructor ] * string    (* 45 *)
   | Bad_env_variable of string * string     (* 46 *)
   | Attribute_payload of string * string    (* 47 *)
   | Eliminated_optional_arguments of string list (* 48 *)
@@ -79,7 +83,7 @@ type t =
   | Fragile_literal_pattern                 (* 52 *)
   | Misplaced_attribute of string           (* 53 *)
   | Duplicated_attribute of string          (* 54 *)
-  | Inlining_impossible of string           (* 55 *)
+  | Inlining_impossible of I18n.s           (* 55 *)
   | Unreachable_case                        (* 56 *)
   | Ambiguous_pattern of string list        (* 57 *)
   | No_cmx_file of string                   (* 58 *)
@@ -399,247 +403,302 @@ let defaults_warn_error = "-a+31";;
 let () = parse_options false defaults_w;;
 let () = parse_options true defaults_warn_error;;
 
-let ref_manual_explanation () =
+let ref_manual_explanation ppf =
   (* manual references are checked a posteriori by the manual
      cross-reference consistency check in manual/tests*)
   let[@manual.ref "s:comp-warnings"] chapter, section = 9, 5 in
-  Printf.sprintf "(See manual section %d.%d)" chapter section
+  I18n.fprintf ppf "(See manual section %d.%d)" chapter section
 
 let message = function
   | Comment_start ->
+      I18n.s
       "this `(*' is the start of a comment.\n\
        Hint: Did you forget spaces when writing the infix operator `( * )'?"
-  | Comment_not_end -> "this is not the end of a comment."
+  | Comment_not_end -> I18n.s "this is not the end of a comment."
   | Fragile_match "" ->
-      "this pattern-matching is fragile."
+      I18n.s "this pattern-matching is fragile."
   | Fragile_match s ->
-      "this pattern-matching is fragile.\n\
-       It will remain exhaustive when constructors are added to type " ^ s ^ "."
+      I18n.sprintf
+        "this pattern-matching is fragile.\n\
+         It will remain exhaustive when constructors are added to type %s."
+        s
   | Partial_application ->
-      "this function application is partial,\n\
+      I18n.s "this function application is partial,\n\
        maybe some arguments are missing."
   | Labels_omitted [] -> assert false
-  | Labels_omitted [l] ->
-     "label " ^ l ^ " was omitted in the application of this function."
-  | Labels_omitted ls ->
-     "labels " ^ String.concat ", " ls ^
-       " were omitted in the application of this function."
-  | Method_override [lab] ->
-      "the method " ^ lab ^ " is overridden."
+  | Labels_omitted l ->
+      let n = List.length l in
+      I18n.snprintf n
+        "label %s was omitted in the application of this function."
+        "labels %s were omitted in the application of this function."
+        (String.concat ", " l)
+| Method_override [lab] ->
+      I18n.sprintf "the method %s is overridden." lab
   | Method_override (cname :: slist) ->
-      String.concat " "
-        ("the following methods are overridden by the class"
-         :: cname  :: ":\n " :: slist)
+        I18n.sprintf "the following methods are overridden by the class %s"
+        (String.concat " " (cname  :: ":\n " :: slist))
   | Method_override [] -> assert false
-  | Partial_match "" -> "this pattern-matching is not exhaustive."
+  | Partial_match "" -> I18n.s "this pattern-matching is not exhaustive."
   | Partial_match s ->
-      "this pattern-matching is not exhaustive.\n\
-       Here is an example of a case that is not matched:\n" ^ s
+      I18n.sprintf "this pattern-matching is not exhaustive.\n\
+       Here is an example of a case that is not matched:\n%s" s
   | Non_closed_record_pattern s ->
-      "the following labels are not bound in this record pattern:\n" ^ s ^
-      "\nEither bind these labels explicitly or add '; _' to the pattern."
+      I18n.sprintf
+        "the following labels are not bound in this record pattern:\n%s\n\
+         Either bind these labels explicitly or add '; _' to the pattern."
+        s
   | Statement_type ->
-      "this expression should have type unit."
-  | Unused_match -> "this match case is unused."
-  | Unused_pat   -> "this sub-pattern is unused."
+      I18n.s "this expression should have type unit."
+  | Unused_match -> I18n.s "this match case is unused."
+  | Unused_pat   -> I18n.s"this sub-pattern is unused."
   | Instance_variable_override [lab] ->
-      "the instance variable " ^ lab ^ " is overridden.\n" ^
-      "The behaviour changed in ocaml 3.10 (previous behaviour was hiding.)"
+      I18n.sprintf
+        "the instance variable %s is overridden.\n\
+         The behaviour changed in ocaml 3.10 (previous behaviour was hiding.)"
+        lab
   | Instance_variable_override (cname :: slist) ->
-      String.concat " "
-        ("the following instance variables are overridden by the class"
-         :: cname  :: ":\n " :: slist) ^
-      "\nThe behaviour changed in ocaml 3.10 (previous behaviour was hiding.)"
+      I18n.sprintf
+        "the following instance variables are overridden by the class %s\n\
+         The behaviour changed in ocaml 3.10 (previous behaviour was hiding.)"
+        (String.concat " " (cname  :: ":\n " :: slist))
   | Instance_variable_override [] -> assert false
-  | Illegal_backslash -> "illegal backslash escape in string."
+  | Illegal_backslash -> I18n.sprintf "illegal backslash escape in string."
   | Implicit_public_methods l ->
-      "the following private methods were made public implicitly:\n "
-      ^ String.concat " " l ^ "."
-  | Unerasable_optional_argument -> "this optional argument cannot be erased."
-  | Undeclared_virtual_method m -> "the virtual method "^m^" is not declared."
-  | Not_principal s -> s^" is not principal."
-  | Without_principality s -> s^" without principality."
-  | Unused_argument -> "this argument will not be used by the function."
+      I18n.sprintf
+        "the following private methods were made public implicitly:\n %s."
+        (String.concat " " l)
+  | Unerasable_optional_argument ->
+      I18n.s "this optional argument cannot be erased."
+  | Undeclared_virtual_method m ->
+      I18n.sprintf "the virtual method %s is not declared." m
+  | Not_principal s -> I18n.sprintf "%a is not principal." I18n.pp s
+  | Without_principality s -> I18n.sprintf "%a without principality." I18n.pp s
+  | Unused_argument ->
+      I18n.s"this argument will not be used by the function."
   | Nonreturning_statement ->
-      "this statement never returns (or has an unsound type.)"
-  | Preprocessor s -> s
+      I18n.s"this statement never returns (or has an unsound type.)"
+  | Preprocessor s -> I18n.raw s
   | Useless_record_with ->
-      "all the fields are explicitly listed in this record:\n\
+      I18n.s"all the fields are explicitly listed in this record:\n\
        the 'with' clause is useless."
   | Bad_module_name (modname) ->
-      "bad source file name: \"" ^ modname ^ "\" is not a valid module name."
+      I18n.sprintf
+       "bad source file name: \"%s\" is not a valid module name." modname
   | All_clauses_guarded ->
-      "this pattern-matching is not exhaustive.\n\
+      I18n.s"this pattern-matching is not exhaustive.\n\
        All clauses in this pattern-matching are guarded."
-  | Unused_var v | Unused_var_strict v -> "unused variable " ^ v ^ "."
+  | Unused_var v | Unused_var_strict v -> I18n.sprintf "unused variable %s." v
   | Wildcard_arg_to_constant_constr ->
-     "wildcard pattern given as argument to a constant constructor"
+     I18n.s "wildcard pattern given as argument to a constant constructor"
   | Eol_in_string ->
-     "unescaped end-of-line in a string constant (non-portable code)"
+     I18n.s"unescaped end-of-line in a string constant (non-portable code)"
   | Duplicate_definitions (kind, cname, tc1, tc2) ->
-      Printf.sprintf "the %s %s is defined in both types %s and %s."
-        kind cname tc1 tc2
+      I18n.sprintf "the %a %s is defined in both types %s and %s."
+        I18n.pp (I18n.s kind) cname tc1 tc2
   | Multiple_definition(modname, file1, file2) ->
-      Printf.sprintf
+      I18n.sprintf
         "files %s and %s both define a module named %s"
         file1 file2 modname
-  | Unused_value_declaration v -> "unused value " ^ v ^ "."
-  | Unused_open s -> "unused open " ^ s ^ "."
-  | Unused_open_bang s -> "unused open! " ^ s ^ "."
-  | Unused_type_declaration s -> "unused type " ^ s ^ "."
-  | Unused_for_index s -> "unused for-loop index " ^ s ^ "."
-  | Unused_ancestor s -> "unused ancestor variable " ^ s ^ "."
-  | Unused_constructor (s, false, false) -> "unused constructor " ^ s ^ "."
+  | Unused_value_declaration v -> I18n.sprintf "unused value %s." v
+  | Unused_open s -> I18n.sprintf "unused open %s." s
+  | Unused_open_bang s -> I18n.sprintf "unused open! %s." s
+  | Unused_type_declaration s -> I18n.sprintf "unused type %s." s
+  | Unused_for_index s -> I18n.sprintf "unused for-loop index %s." s
+  | Unused_ancestor s -> I18n.sprintf "unused ancestor variable %s." s
+  | Unused_constructor (s, false, false) ->
+      I18n.sprintf "unused constructor %s." s
   | Unused_constructor (s, true, _) ->
-      "constructor " ^ s ^
-      " is never used to build values.\n\
-        (However, this constructor appears in patterns.)"
+      I18n.sprintf "constructor %s is never used to build values.\n\
+                    (However, this constructor appears in patterns.)"
+        s
   | Unused_constructor (s, false, true) ->
-      "constructor " ^ s ^
-      " is never used to build values.\n\
-        Its type is exported as a private type."
+      I18n.sprintf "constructor %s is never used to build values.\n\
+                    Its type is exported as a private type."
+        s
   | Unused_extension (s, is_exception, cu_pattern, cu_privatize) ->
-     let kind =
-       if is_exception then "exception" else "extension constructor" in
-     let name = kind ^ " " ^ s in
+      let kind =
+        if is_exception then I18n.s "exception"
+        else I18n.s"extension constructor" in
      begin match cu_pattern, cu_privatize with
-       | false, false -> "unused " ^ name
-       | true, _ ->
-          name ^
-          " is never used to build values.\n\
-           (However, this constructor appears in patterns.)"
-       | false, true ->
-          name ^
-          " is never used to build values.\n\
-            It is exported or rebound as a private extension."
+     | false, false -> I18n.sprintf "unused %a %s" I18n.pp kind s
+     | true, _ ->
+         I18n.sprintf "%a %s is never used to build values.\n\
+                  (However, this constructor appears in patterns.)"
+           I18n.pp kind s
+     | false, true ->
+         I18n.sprintf
+           "%a %s is never used to build values.\n\
+             It is exported or rebound as a private extension."
+           I18n.pp kind s
      end
   | Unused_rec_flag ->
-      "unused rec flag."
+      I18n.s "unused rec flag."
   | Name_out_of_scope (ty, [nm], false) ->
-      nm ^ " was selected from type " ^ ty ^
-      ".\nIt is not visible in the current scope, and will not \n\
-       be selected if the type becomes unknown."
+      I18n.sprintf
+        "%s was selected from type %s.\n\
+         It is not visible in the current scope, and will not \n\
+         be selected if the type becomes unknown." nm ty
   | Name_out_of_scope (_, _, false) -> assert false
   | Name_out_of_scope (ty, slist, true) ->
-      "this record of type "^ ty ^" contains fields that are \n\
-       not visible in the current scope: "
-      ^ String.concat " " slist ^ ".\n\
-       They will not be selected if the type becomes unknown."
+      I18n.sprintf
+        "this record of type %s contains fields that are \n\
+         not visible in the current scope: %s.\n\
+         They will not be selected if the type becomes unknown."
+        ty (String.concat " " slist)
   | Ambiguous_name ([s], tl, false, expansion) ->
-      s ^ " belongs to several types: " ^ String.concat " " tl ^
-      "\nThe first one was selected. Please disambiguate if this is wrong."
-      ^ expansion
-  | Ambiguous_name (_, _, false, _ ) -> assert false
-  | Ambiguous_name (_slist, tl, true, expansion) ->
-      "these field labels belong to several types: " ^
-      String.concat " " tl ^
-      "\nThe first one was selected. Please disambiguate if this is wrong."
-      ^ expansion
+      I18n.sprintf
+        "%s belongs to several types: %s\n\
+         The first one was selected. Please disambiguate if this is wrong.%a"
+        s (String.concat " " tl) I18n.pp expansion
+  | Ambiguous_name (_, _, false,_) -> assert false
+  | Ambiguous_name (_slist, tl, true,expansion) ->
+      I18n.sprintf
+        "these field labels belong to several types: %s@ \
+         The first one was selected. Please disambiguate if this is wrong.%a"
+        (String.concat " " tl) I18n.pp expansion
   | Disambiguated_name s ->
-      "this use of " ^ s ^ " relies on type-directed disambiguation,\n\
-       it will not compile with OCaml 4.00 or earlier."
+      I18n.sprintf
+        "this use of %s relies on type-directed disambiguation,\n\
+         it will not compile with OCaml 4.00 or earlier."
+        s
   | Nonoptional_label s ->
-      "the label " ^ s ^ " is not optional."
+      I18n.sprintf "the label %s is not optional." s
   | Open_shadow_identifier (kind, s) ->
-      Printf.sprintf
-        "this open statement shadows the %s identifier %s (which is later used)"
-        kind s
-  | Open_shadow_label_constructor (kind, s) ->
-      Printf.sprintf
-        "this open statement shadows the %s %s (which is later used)"
-        kind s
+      begin match kind with
+      | `Type ->
+          I18n.sprintf
+            "this open statement shadows the type identifier %s \
+             (which is later used)" s
+      | `Value ->
+          I18n.sprintf
+            "this open statement shadows the value identifier %s \
+             (which is later used)" s
+      | `Module_type ->
+          I18n.sprintf
+            "this open statement shadows the module type identifier %s \
+             (which is later used)" s
+      | `Module ->
+          I18n.sprintf
+            "this open statement shadows the module identifier %s \
+             (which is later used)" s
+      | `Class_type ->
+          I18n.sprintf
+            "this open statement shadows the class type identifier %s \
+             (which is later used)" s
+      | `Class ->
+          I18n.sprintf
+            "this open statement shadows the class identifier %s \
+             (which is later used)" s
+      end
+ | Open_shadow_label_constructor (kind, s) ->
+     begin match kind with
+     | `Label ->
+         I18n.sprintf
+           "this open statement shadows the label %s (which is later used)" s
+     | `Constructor ->
+         I18n.sprintf
+           "this open statement shadows the constructor %s \
+            (which is later used)"
+           s
+     end
   | Bad_env_variable (var, s) ->
-      Printf.sprintf "illegal environment variable %s : %s" var s
+      I18n.sprintf "illegal environment variable %s : %s" var s
   | Attribute_payload (a, s) ->
-      Printf.sprintf "illegal payload for attribute '%s'.\n%s" a s
+      I18n.sprintf "illegal payload for attribute '%s'.\n%s" a s
   | Eliminated_optional_arguments sl ->
-      Printf.sprintf "implicit elimination of optional argument%s %s"
-        (if List.length sl = 1 then "" else "s")
+      I18n.snprintf
+        (List.length sl)
+        "implicit elimination of optional argument %s"
+        "implicit elimination of optional arguments %s"
         (String.concat ", " sl)
   | No_cmi_file(name, None) ->
-      "no cmi file was found in path for module " ^ name
+      I18n.sprintf "no cmi file was found in path for module %s" name
   | No_cmi_file(name, Some msg) ->
-      Printf.sprintf
+      I18n.sprintf
         "no valid cmi file was found in path for module %s. %s"
         name msg
   | Bad_docstring unattached ->
-      if unattached then "unattached documentation comment (ignored)"
-      else "ambiguous documentation comment"
+      if unattached then I18n.s"unattached documentation comment (ignored)"
+      else I18n.s"ambiguous documentation comment"
   | Expect_tailcall ->
-      Printf.sprintf "expected tailcall"
+      I18n.s"expected tailcall"
   | Fragile_literal_pattern ->
-      Printf.sprintf
+      I18n.sprintf
         "Code should not depend on the actual values of\n\
          this constructor's arguments. They are only for information\n\
          and may change in future versions. %t" ref_manual_explanation
   | Unreachable_case ->
-      "this match case is unreachable.\n\
-       Consider replacing it with a refutation case '<pat> -> .'"
+      I18n.s
+        "this match case is unreachable.\n\
+         Consider replacing it with a refutation case '<pat> -> .'"
   | Misplaced_attribute attr_name ->
-      Printf.sprintf "the %S attribute cannot appear in this context" attr_name
+      I18n.sprintf "the %S attribute cannot appear in this context" attr_name
   | Duplicated_attribute attr_name ->
-      Printf.sprintf "the %S attribute is used more than once on this \
-          expression"
+      I18n.sprintf "the %S attribute is used more than once on this \
+                    expression"
         attr_name
   | Inlining_impossible reason ->
-      Printf.sprintf "Cannot inline: %s" reason
+      I18n.sprintf "Cannot inline: %a" I18n.pp reason
   | Ambiguous_pattern vars ->
       let msg =
         let vars = List.sort String.compare vars in
         match vars with
         | [] -> assert false
-        | [x] -> "variable " ^ x
-        | _::_ ->
-            "variables " ^ String.concat "," vars in
-      Printf.sprintf
+        | l ->
+            I18n.snprintf (List.length l)
+              "variable %s" "variables %s"
+              (String.concat "," vars) in
+      I18n.sprintf
         "Ambiguous or-pattern variables under guard;\n\
-         %s may match different arguments. %t"
-        msg ref_manual_explanation
+         %a may match different arguments. %t"
+        I18n.pp msg ref_manual_explanation
   | No_cmx_file name ->
-      Printf.sprintf
+      I18n.sprintf
         "no cmx file was found in path for module %s, \
          and its interface was not compiled with -opaque" name
   | Assignment_to_non_mutable_value ->
-      "A potential assignment to a non-mutable value was detected \n\
-        in this source file.  Such assignments may generate incorrect code \n\
-        when using Flambda."
-  | Unused_module s -> "unused module " ^ s ^ "."
+      I18n.sprintf
+        "A potential assignment to a non-mutable value was detected \n\
+         in this source file.  Such assignments may generate incorrect code \n\
+         when using Flambda."
+  | Unused_module s -> I18n.sprintf "unused module %s." s
   | Unboxable_type_in_prim_decl t ->
-      Printf.sprintf
+      I18n.sprintf
         "This primitive declaration uses type %s, whose representation\n\
          may be either boxed or unboxed. Without an annotation to indicate\n\
          which representation is intended, the boxed representation has been\n\
          selected by default. This default choice may change in future\n\
          versions of the compiler, breaking the primitive implementation.\n\
          You should explicitly annotate the declaration of %s\n\
-         with [@@boxed] or [@@unboxed], so that its external interface\n\
+         with [@@@@boxed] or [@@@@unboxed], so that its external interface\n\
          remains stable in the future." t t
   | Constraint_on_gadt ->
-      "Type constraints do not apply to GADT cases of variant types."
+      I18n.s "Type constraints do not apply to GADT cases of variant types."
   | Erroneous_printed_signature s ->
-      "The printed interface differs from the inferred interface.\n\
-       The inferred interface contained items which could not be printed\n\
-       properly due to name collisions between identifiers."
-     ^ s
-     ^ "\nBeware that this warning is purely informational and will not catch\n\
-        all instances of erroneous printed interface."
+      I18n.sprintf
+        "The printed interface differs from the inferred interface.@ \
+         The inferred interface contained items which could not be printed@ \
+         properly due to name collisions between identifiers.%s@ \
+         Beware that this warning is purely informational and will not catch@ \
+         all instances of erroneous printed interface."
+        s
   | Unsafe_without_parsing ->
-     "option -unsafe used with a preprocessor returning a syntax tree"
+     I18n.s "option -unsafe used with a preprocessor returning a syntax tree"
   | Redefining_unit name ->
-      Printf.sprintf
+      I18n.sprintf
         "This type declaration is defining a new '()' constructor\n\
          which shadows the existing one.\n\
          Hint: Did you mean 'type %s = unit'?" name
-  | Unused_functor_parameter s -> "unused functor parameter " ^ s ^ "."
+  | Unused_functor_parameter s -> I18n.sprintf "unused functor parameter %s." s
 ;;
 
 let nerrors = ref 0;;
 
 type reporting_information =
   { id : string
-  ; message : string
+  ; message : I18n.s
   ; is_error : bool
-  ; sub_locs : (loc * string) list;
+  ; sub_locs : (loc * I18n.s) list;
   }
 
 let report w =
@@ -660,7 +719,7 @@ let report_alert (alert : alert) =
   | true ->
       let is_error = alert_is_error alert in
       if is_error then incr nerrors;
-      let message = Misc.normalise_eol alert.message in
+      let message = I18n.raw (Misc.normalise_eol alert.message) in
        (* Reduce \r\n to \n:
            - Prevents any \r characters being printed on Unix when processing
              Windows sources
@@ -670,8 +729,8 @@ let report_alert (alert : alert) =
       let sub_locs =
         if not alert.def.loc_ghost && not alert.use.loc_ghost then
           [
-            alert.def, "Definition";
-            alert.use, "Expected signature";
+            alert.def, I18n.s "Definition";
+            alert.use, I18n.s "Expected signature";
           ]
         else
           []
@@ -696,99 +755,101 @@ let check_fatal () =
   end;
 ;;
 
-let descriptions =
+let descriptions () =
   [
-    1, "Suspicious-looking start-of-comment mark.";
-    2, "Suspicious-looking end-of-comment mark.";
-    3, "Deprecated synonym for the 'deprecated' alert";
-    4, "Fragile pattern matching: matching that will remain complete even\n\
-   \    if additional constructors are added to one of the variant types\n\
+    1, I18n.s"Suspicious-looking start-of-comment mark.";
+    2, I18n.s"Suspicious-looking end-of-comment mark.";
+    3, I18n.s"Deprecated synonym for the 'deprecated' alert";
+    4, I18n.s"Fragile pattern matching: matching that will remain complete \n\
+   \    even if additional constructors are added to one of the variant types\n\
    \    matched.";
-    5, "Partially applied function: expression whose result has function\n\
-   \    type and is ignored.";
-    6, "Label omitted in function application.";
-    7, "Method overridden.";
-    8, "Partial match: missing cases in pattern-matching.";
-    9, "Missing fields in a record pattern.";
-   10, "Expression on the left-hand side of a sequence that doesn't have \
-      type\n\
+    5, I18n.s"Partially applied function: expression whose result has\n\
+   \    function type and is ignored.";
+    6, I18n.s"Label omitted in function application.";
+    7, I18n.s"Method overridden.";
+    8, I18n.s"Partial match: missing cases in pattern-matching.";
+    9, I18n.s"Missing fields in a record pattern.";
+   10, I18n.s"Expression on the left-hand side of a sequence that doesn't have \
+   \    type\n\
    \    \"unit\" (and that is not a function, see warning number 5).";
-   11, "Redundant case in a pattern matching (unused match case).";
-   12, "Redundant sub-pattern in a pattern-matching.";
-   13, "Instance variable overridden.";
-   14, "Illegal backslash escape in a string constant.";
-   15, "Private method made public implicitly.";
-   16, "Unerasable optional argument.";
-   17, "Undeclared virtual method.";
-   18, "Non-principal type.";
-   19, "Type without principality.";
-   20, "Unused function argument.";
-   21, "Non-returning statement.";
-   22, "Preprocessor warning.";
-   23, "Useless record \"with\" clause.";
-   24, "Bad module name: the source file name is not a valid OCaml module \
-        name.";
-   25, "Deprecated: now part of warning 8.";
-   26, "Suspicious unused variable: unused variable that is bound\n\
+   11, I18n.s"Redundant case in a pattern matching (unused match case).";
+   12, I18n.s"Redundant sub-pattern in a pattern-matching.";
+   13, I18n.s"Instance variable overridden.";
+   14, I18n.s"Illegal backslash escape in a string constant.";
+   15, I18n.s"Private method made public implicitly.";
+   16, I18n.s"Unerasable optional argument.";
+   17, I18n.s"Undeclared virtual method.";
+   18, I18n.s"Non-principal type.";
+   19, I18n.s"Type without principality.";
+   20, I18n.s"Unused function argument.";
+   21, I18n.s"Non-returning statement.";
+   22, I18n.s"Preprocessor warning.";
+   23, I18n.s"Useless record \"with\" clause.";
+   24, I18n.s"Bad module name: the source file name is not a valid\n\
+   \    OCaml module name.";
+   25, I18n.s"Deprecated: now part of warning 8.";
+   26, I18n.s"Suspicious unused variable: unused variable that is bound\n\
    \    with \"let\" or \"as\", and doesn't start with an underscore (\"_\")\n\
    \    character.";
-   27, "Innocuous unused variable: unused variable that is not bound with\n\
-   \    \"let\" nor \"as\", and doesn't start with an underscore (\"_\")\n\
+   27, I18n.s"Innocuous unused variable: unused variable that is not bound\n\
+   \    with \"let\" nor \"as\", and doesn't start with an underscore (\"_\")\n\
    \    character.";
-   28, "Wildcard pattern given as argument to a constant constructor.";
-   29, "Unescaped end-of-line in a string constant (non-portable code).";
-   30, "Two labels or constructors of the same name are defined in two\n\
+   28, I18n.s"Wildcard pattern given as argument to a constant constructor.";
+   29, I18n.s"Unescaped end-of-line in a string constant (non-portable code).";
+   30, I18n.s"Two labels or constructors of the same name are defined in two\n\
    \    mutually recursive types.";
-   31, "A module is linked twice in the same executable.";
-   32, "Unused value declaration.";
-   33, "Unused open statement.";
-   34, "Unused type declaration.";
-   35, "Unused for-loop index.";
-   36, "Unused ancestor variable.";
-   37, "Unused constructor.";
-   38, "Unused extension constructor.";
-   39, "Unused rec flag.";
-   40, "Constructor or label name used out of scope.";
-   41, "Ambiguous constructor or label name.";
-   42, "Disambiguated constructor or label name (compatibility warning).";
-   43, "Nonoptional label applied as optional.";
-   44, "Open statement shadows an already defined identifier.";
-   45, "Open statement shadows an already defined label or constructor.";
-   46, "Error in environment variable.";
-   47, "Illegal attribute payload.";
-   48, "Implicit elimination of optional arguments.";
-   49, "Absent cmi file when looking up module alias.";
-   50, "Unexpected documentation comment.";
-   51, "Warning on non-tail calls if @tailcall present.";
-   52, "Fragile constant pattern.";
-   53, "Attribute cannot appear in this context";
-   54, "Attribute used more than once on an expression";
-   55, "Inlining impossible";
-   56, "Unreachable case in a pattern-matching (based on type information).";
-   57, "Ambiguous or-pattern variables under guard";
-   58, "Missing cmx file";
-   59, "Assignment to non-mutable value";
-   60, "Unused module declaration";
-   61, "Unboxable type in primitive declaration";
-   62, "Type constraint on GADT type declaration";
-   63, "Erroneous printed signature";
-   64, "-unsafe used with a preprocessor returning a syntax tree";
-   65, "Type declaration defining a new '()' constructor";
-   66, "Unused open! statement";
+   31, I18n.s"A module is linked twice in the same executable.";
+   32, I18n.s"Unused value declaration.";
+   33, I18n.s"Unused open statement.";
+   34, I18n.s"Unused type declaration.";
+   35, I18n.s"Unused for-loop index.";
+   36, I18n.s"Unused ancestor variable.";
+   37, I18n.s"Unused constructor.";
+   38, I18n.s"Unused extension constructor.";
+   39, I18n.s"Unused rec flag.";
+   40, I18n.s"Constructor or label name used out of scope.";
+   41, I18n.s"Ambiguous constructor or label name.";
+   42, I18n.s"Disambiguated constructor or label name (compatibility warning).";
+   43, I18n.s"Nonoptional label applied as optional.";
+   44, I18n.s"Open statement shadows an already defined identifier.";
+   45, I18n.s"Open statement shadows an already defined label or constructor.";
+   46, I18n.s"Error in environment variable.";
+   47, I18n.s"Illegal attribute payload.";
+   48, I18n.s"Implicit elimination of optional arguments.";
+   49, I18n.s"Absent cmi file when looking up module alias.";
+   50, I18n.s"Unexpected documentation comment.";
+   51, I18n.s"Warning on non-tail calls if @tailcall present.";
+   52, I18n.s"Fragile constant pattern.";
+   53, I18n.s"Attribute cannot appear in this context";
+   54, I18n.s"Attribute used more than once on an expression";
+   55, I18n.s"Inlining impossible";
+   56, I18n.s"Unreachable case in a pattern-matching\
+  \     (based on type information).";
+   57, I18n.s"Ambiguous or-pattern variables under guard";
+   58, I18n.s"Missing cmx file";
+   59, I18n.s"Assignment to non-mutable value";
+   60, I18n.s"Unused module declaration";
+   61, I18n.s"Unboxable type in primitive declaration";
+   62, I18n.s"Type constraint on GADT type declaration";
+   63, I18n.s"Erroneous printed signature";
+   64, I18n.s"-unsafe used with a preprocessor returning a syntax tree";
+   65, I18n.s"Type declaration defining a new '()' constructor";
+   66, I18n.s"Unused open! statement";
   ]
 ;;
 
 let help_warnings () =
-  List.iter (fun (i, s) -> Printf.printf "%3i %s\n" i s) descriptions;
+  List.iter (fun (i, s) ->
+      Format.printf "%3i %a\n" i I18n.pp s) (descriptions ());
   print_endline "  A all warnings";
   for i = Char.code 'b' to Char.code 'z' do
     let c = Char.chr i in
     match letter c with
     | [] -> ()
     | [n] ->
-        Printf.printf "  %c Alias for warning %i.\n" (Char.uppercase_ascii c) n
+        I18n.printf "  %c Alias for warning %i.\n" (Char.uppercase_ascii c) n
     | l ->
-        Printf.printf "  %c warnings %s.\n"
+        I18n.printf "  %c warnings %s.\n"
           (Char.uppercase_ascii c)
           (String.concat ", " (List.map Int.to_string l))
   done;

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -26,6 +26,10 @@ type loc = {
   loc_ghost: bool;
 }
 
+
+type shadowed_identifier =
+  [`Value|`Type|`Module|`Module_type|`Class|`Class_type]
+
 type t =
   | Comment_start                           (*  1 *)
   | Comment_not_end                         (*  2 *)
@@ -44,8 +48,8 @@ type t =
   | Implicit_public_methods of string list  (* 15 *)
   | Unerasable_optional_argument            (* 16 *)
   | Undeclared_virtual_method of string     (* 17 *)
-  | Not_principal of string                 (* 18 *)
-  | Without_principality of string          (* 19 *)
+  | Not_principal of I18n.s                 (* 18 *)
+  | Without_principality of I18n.s          (* 19 *)
   | Unused_argument                         (* 20 *)
   | Nonreturning_statement                  (* 21 *)
   | Preprocessor of string                  (* 22 *)
@@ -67,11 +71,12 @@ type t =
   | Unused_extension of string * bool * bool * bool (* 38 *)
   | Unused_rec_flag                         (* 39 *)
   | Name_out_of_scope of string * string list * bool   (* 40 *)
-  | Ambiguous_name of string list * string list * bool * string (* 41 *)
+  | Ambiguous_name of string list * string list * bool * I18n.s (* 41 *)
   | Disambiguated_name of string            (* 42 *)
   | Nonoptional_label of string             (* 43 *)
-  | Open_shadow_identifier of string * string (* 44 *)
-  | Open_shadow_label_constructor of string * string (* 45 *)
+  | Open_shadow_identifier of shadowed_identifier * string (* 44 *)
+  | Open_shadow_label_constructor of
+      [ `Label | `Constructor ] * string    (* 45 *)
   | Bad_env_variable of string * string     (* 46 *)
   | Attribute_payload of string * string    (* 47 *)
   | Eliminated_optional_arguments of string list (* 48 *)
@@ -81,7 +86,7 @@ type t =
   | Fragile_literal_pattern                 (* 52 *)
   | Misplaced_attribute of string           (* 53 *)
   | Duplicated_attribute of string          (* 54 *)
-  | Inlining_impossible of string           (* 55 *)
+  | Inlining_impossible of I18n.s           (* 55 *)
   | Unreachable_case                        (* 56 *)
   | Ambiguous_pattern of string list        (* 57 *)
   | No_cmx_file of string                   (* 58 *)
@@ -117,9 +122,9 @@ val defaults_warn_error : string;;
 
 type reporting_information =
   { id : string
-  ; message : string
+  ; message : I18n.s
   ; is_error : bool
-  ; sub_locs : (loc * string) list;
+  ; sub_locs : (loc * I18n.s) list;
   }
 
 val report : t -> [ `Active of reporting_information | `Inactive ]


### PR DESCRIPTION
This PR proposes to make it easier for (ocaml) compiler plugins to localize error and warning messages. Exposing this feature as a plugin seemed to be a good compromise in term of maintenance burden on the compiler side and would allow faster iterations of available translations in a first phase.

To this end, the first commit in this PR adds a new utility module `utils/I18n` which provides localized printing function. By default, these functions are mostly thin veneer over classical Format printing functions, completed with a string translation function `s: string -> I18n.s` and their plural form counterpart (based on gettext handling of the complexity of plural forms across languages).
Simultaneously, this new module exposes a hook to let plugin overwrite the implementation of these functions with their own.

Maybe surprisingly, this implementation hook takes the form of a reference to custom `kfprintf` function (and its plural `knprintf` counterpart); these functions were chosen because they allow plugins to implement additional functionality on the top of the Format module.

All the other commits (except the last one) refactorize user-facing messages in the compiler source to use the new infrastructure. Importantly, this translation is not completely trivial, since the compiler is full of small word tricks where few isolated words are passed as arguments into some function, which recompose a meaningful sentence on the fly from these isolated words. Unfortunately, making these word tricks work across all languages is tricky — or impossible.

Consequently, these internationalization commits try to expand all error messages into independently understandable and translatable chunks (and I most probably failed here because I have only tested an English to French translation). Nevertheless, making error messages easier to read at the price of some duplication seemed sensible. However, there is one case where the message is actually degraded due to the removal of an ordinal printing function.

On the extraction side, the extraction of text to be translated is supposed to be done on the AST level, potentially helped by few `[@i18n]` annotation.

As a small proof-of-concept, I have written a plugin based on the gettext format with both a full (but atrocious) french translation and a position-aware Format overlay (e.g. `printf "%0$s %1$s"` switches the two string ): [babilim](https://github.com/Octachron/babilim)