### PR TITLE
Remove references to the "num" library.

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -25,9 +25,6 @@ B ./otherlibs/dynlink
 S ./otherlibs/graph
 B ./otherlibs/graph
 
-S ./otherlibs/num
-B ./otherlibs/num
-
 S ./otherlibs/str
 B ./otherlibs/str
 

--- a/config/Makefile-templ
+++ b/config/Makefile-templ
@@ -172,14 +172,13 @@ RANLIBCMD=ranlib
 # Currently available:
 #       unix            Unix system calls
 #       str             Regular expressions and high-level string processing
-#       num             Arbitrary-precision rational arithmetic
 #       threads         Lightweight concurrent processes
 #       systhreads      Same as threads, requires POSIX threads
 #       graph           Portable drawing primitives for X11
 #       dynlink         Dynamic linking of bytecode
 #       bigarray        Large, multidimensional numerical arrays
 
-OTHERLIBRARIES=unix str num threads graph dynlink bigarray
+OTHERLIBRARIES=unix str threads graph dynlink bigarray
 
 ### Link-time options to ocamlc or ocamlopt for linking with POSIX threads
 # Needed for the "systhreads" package


### PR DESCRIPTION
While working on https://github.com/janestreet/jbuilder/pull/358, it occurred to me
that there were some references to the "num" library in trunk (Merlin file and
Makefile template).