### PR TITLE
[format] Make the code respect the documentation for set_max_indent

### DIFF
--- a/Changes
+++ b/Changes
@@ -190,6 +190,9 @@ Working version
 - GPR#2185: Add `List.filter_map`
   (Thomas Refis, review by Alain Frisch and Gabriel Scherer)
 
+- GPR#1525: Make function set_max_indent respect documentation
+  (Pierre Weis, Richard Bonichon, review by Florian Angeletti)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -789,7 +789,8 @@ let pp_set_min_space_left state n =
    pp_max_indent = pp_margin - pp_min_space_left, and
    pp_space_left = pp_margin. *)
 let pp_set_max_indent state n =
-  pp_set_min_space_left state (state.pp_margin - n)
+  if n > 1 then
+    pp_set_min_space_left state (state.pp_margin - n)
 
 
 let pp_get_max_indent state () = state.pp_max_indent

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -441,6 +441,7 @@ val set_max_indent : int -> unit
   always fully fit on the current line.
 
   Nothing happens if [d] is smaller than 2.
+
   If [d] is too large, the limit is set to the maximum
   admissible value (which is greater than [10 ^ 9]).
 


### PR DESCRIPTION
Nothing should happen when new maximum indentation is smaller than 2.

This is a fix.