### PR TITLE
expect_test tool: disable colorized output

### DIFF
--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -406,6 +406,7 @@ let usage = "Usage: expect_test <options> [script-file [arguments]]\n\
              options are:"
 
 let () =
+  Clflags.color := Some Misc.Color.Never;
   Clflags.error_size := 0;
   try
     Arg.parse args main usage;


### PR DESCRIPTION
Colorized output prevents expect_test from working properly, so the tool
requires that the output does not use colors.

Before this PR, this was achieved by setting the TERM environment
variable to "dumb" before calling expect_test.

This PR disables colorized output from within the tool itself
and thus removes the need of setting the TERM environment variable
before calling it.

Cc @sliquister