### PR TITLE
MPR#7390: fix the caml_float_of_hex function

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,8 +26,8 @@ Working version
 
 ### Standard library:
 
-- MPR#7690: fix the float_of_string function for hexadecimal floats with very
-  large values of the exponent.
+- MPR#7690, GPR#1528: fix the float_of_string function for hexadecimal floats
+  with very large values of the exponent.
   (Olivier Andrieu)
 
 ### Other libraries:

--- a/Changes
+++ b/Changes
@@ -26,6 +26,10 @@ Working version
 
 ### Standard library:
 
+- MPR#7690: fix the float_of_string function for hexadecimal floats with very
+  large values of the exponent.
+  (Olivier Andrieu)
+
 ### Other libraries:
 
 * GPR#1406: Unix.isatty now returns true in the native Windows ports when

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -226,6 +226,10 @@ static int caml_float_of_hex(const char * s, double * res)
       if (*s == 0) return -1;   /* nothing after exponent mark */
       e = strtol(s, &p, 10);
       if (*p != 0) return -1;   /* ill-formed exponent */
+      /* Handle exponents larger than int by returning 0/∞ directly.
+	 Mind that INT_MIN/INT_MAX are included in the test so as to capture
+	 the overflow case of strtol on Win64 — long and int have the same
+	 size there. */
       if (e <= INT_MIN) {
         *res = 0.;
         return 0;
@@ -234,6 +238,7 @@ static int caml_float_of_hex(const char * s, double * res)
         *res = m == 0 ? 0. : HUGE_VAL;
         return 0;
       }
+      /* regular exponent value */
       exp = e;
       s = p;                    /* stop at next loop iteration */
       break;

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -226,7 +226,14 @@ static int caml_float_of_hex(const char * s, double * res)
       if (*s == 0) return -1;   /* nothing after exponent mark */
       e = strtol(s, &p, 10);
       if (*p != 0) return -1;   /* ill-formed exponent */
-      if (e < INT_MIN || e > INT_MAX) return -1; /* unreasonable exponent */
+      if (e <= INT_MIN) {
+        *res = 0.;
+        return 0;
+      }
+      else if (e >= INT_MAX) {
+        *res = m == 0 ? 0. : HUGE_VAL;
+        return 0;
+      }
       exp = e;
       s = p;                    /* stop at next loop iteration */
       break;
@@ -261,8 +268,17 @@ static int caml_float_of_hex(const char * s, double * res)
      on several architectures. */
   f = (double) (int64_t) m;
   /* Adjust exponent to take decimal point and extra digits into account */
-  if (dec_point >= 0) exp = exp + (dec_point - n_bits);
-  exp = exp + x_bits;
+  {
+    int adj = x_bits;
+    if (dec_point >= 0) adj = adj + (dec_point - n_bits);
+    /* saturated addition exp + adj */
+    if (adj > 0 && exp > INT_MAX - adj)
+      exp = INT_MAX;
+    else if (adj < 0 && exp < INT_MIN - adj)
+      exp = INT_MIN;
+    else
+      exp = exp + adj;
+  }
   /* Apply exponent if needed */
   if (exp != 0) f = ldexp(f, exp);
   /* Done! */

--- a/testsuite/tests/basic-float/tfloat_hex.ml
+++ b/testsuite/tests/basic-float/tfloat_hex.ml
@@ -15,3 +15,8 @@ let () =
   try_float_of_string "0x.";
   try_float_of_string "0xp0";
   try_float_of_string "0x.p0";
+
+  (* MPR#7690 *)
+  try_float_of_string "0x1.0p-2147483648";
+  try_float_of_string "0x123456789ABCDEF0p2147483647";
+  try_float_of_string "0x1p2147483648";

--- a/testsuite/tests/basic-float/tfloat_hex.reference
+++ b/testsuite/tests/basic-float/tfloat_hex.reference
@@ -4,3 +4,6 @@ Failure("float_of_string")
 Failure("float_of_string")
 Failure("float_of_string")
 Failure("float_of_string")
+0.
+inf
+inf


### PR DESCRIPTION
- make sure the adjusted exponent does not overflow
- return 0/inf instead of raising an exception for exponent values ≤ `INT_MIN` or ≥ `INT_MAX`

This fixes the first two points of the [MPR](https://caml.inria.fr/mantis/view.php?id=7690).