### PR TITLE
testsuite: extend the make one target

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -200,6 +200,12 @@ exec-one:
 	  echo "Running tests from '$$DIR' ..."; \
 	  cd $(DIR) && \
 	  $(MAKE) TERM=dumb BASEDIR=$(BASEDIR) || echo '=> unexpected error'; \
+	elif [ -f $(DIR)/ocamltests ]; then \
+	  echo Running tests from \'$(DIR)\' ... ; \
+	  IFS=$$(printf "\r\n"); while read testfile; do \
+	    TERM=dumb \
+	      $(ocamltest) $(DIR)/$$testfile; \
+	  done < $(DIR)/ocamltests 2>&1 | tee -a _log; \
 	fi
 
 .PHONY: clean-one


### PR DESCRIPTION
Until now, the make one DIR=... command was able to handle only
directories containing legacy tests.

This PR extends the target so that it can also handle directories
containing ocamltest-driven tests.