### PR TITLE
Preemption

### DIFF
--- a/Changes
+++ b/Changes
@@ -39,6 +39,10 @@ Working version
 - GPR#1477: raw_spacetime_lib can now be used in bytecode.
   (Nicolas Ojeda Bar, review by Mark Shinwell)
 
+- GPR#1533: (a) The implementation of Thread.yield for system thread
+  now uses nanosleep(1) for enabling better preemption.
+  (b) Thread.delay is now an alias for Unix.sleepf.
+
 ### Compiler user-interface and warnings:
 
 - GPR#1166: In OCAMLPARAM, an alternative separator can be specified as

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -24,6 +24,7 @@
 #define _POSIX_PTHREAD_SEMANTICS
 #endif
 #include <signal.h>
+#include <time.h>
 #include <sys/time.h>
 #ifdef __linux__
 #include <unistd.h>
@@ -90,8 +91,14 @@ static void st_thread_join(st_thread_id thr)
 
 static void INLINE st_thread_yield(void)
 {
-#ifndef __linux__
+#ifdef __linux__
   /* sched_yield() doesn't do what we want in Linux 2.6 and up (PR#2663) */
+  /* but not doing anything here would actually disable preemption (PR#7669) */
+  struct timespec t;
+  t.tv_sec = 0;
+  t.tv_nsec = 1;
+  nanosleep(&t, NULL);
+#else
   sched_yield();
 #endif
 }

--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -71,7 +71,7 @@ let () =
 
 (* Wait functions *)
 
-let delay time = ignore(Unix.select [] [] [] time)
+let delay = Unix.sleepf
 
 let wait_read fd = ()
 let wait_write fd = ()

--- a/testsuite/tests/lib-systhreads/testpreempt.ml
+++ b/testsuite/tests/lib-systhreads/testpreempt.ml
@@ -1,0 +1,23 @@
+let rec generate_list n =
+  let rec aux acc = function
+    | 0 -> acc
+    | n -> aux (float n :: acc) (n-1)
+  in
+  aux [] n
+
+let rec long_computation time0 =
+  let long_list = generate_list 100000 in
+  let res = List.length (List.rev_map sin long_list) in
+  if Sys.time () -. time0 > 2. then
+    Printf.printf "Long computation result: %d\n%!" res
+  else long_computation time0
+
+let interaction () =
+  Thread.delay 0.1;
+  Printf.printf "Interaction 1\n";
+  Thread.delay 0.1;
+  Printf.printf "Interaction 2\n"
+
+let () =
+  ignore (Thread.create interaction ());
+  long_computation (Sys.time ())

--- a/testsuite/tests/lib-systhreads/testpreempt.precheck
+++ b/testsuite/tests/lib-systhreads/testpreempt.precheck
@@ -1,0 +1,5 @@
+# On Windows, we use Sleep(0) for triggering preemption of threads.
+# However, this does not seem very reliable, so that this test fails
+# on some Windows configurations. See GPR #1533.
+
+test "$OS" != "Windows_NT"

--- a/testsuite/tests/lib-systhreads/testpreempt.reference
+++ b/testsuite/tests/lib-systhreads/testpreempt.reference
@@ -1,0 +1,3 @@
+Interaction 1
+Interaction 2
+Long computation result: 100000

--- a/testsuite/tests/lib-threads/signal.runner
+++ b/testsuite/tests/lib-threads/signal.runner
@@ -17,3 +17,4 @@ $RUNTIME ./program >signal.result &
 pid=$!
 sleep 2
 test -e ./sigint.exe && ./sigint $pid || kill -INT $pid
+wait


### PR DESCRIPTION
Two changes:

1. As discussed in MPR#7669, use nanosleep as an implementation of yield for better preemption
2. Make Thread.delay an alias for Unix.sleepf. There is no longer any point for using select here. Moreover, Unix.sleepf supports (theoretically) nanosecond precision.