### PR TITLE
Add a hint suggesting to use ( * ) when (*) is used 

### DIFF
--- a/Changes
+++ b/Changes
@@ -65,6 +65,11 @@ Working version
   (Arthur Charguéraud and Armaël Guéneau, with help from Leo White, review by
   Florian Angeletti and Gabriel Radanne)
 
+- GPR#1534: Extend the warning printed when (*) is used, adding a hint to
+  suggest using ( * ) instead
+  (Armaël Guéneau, with help and review from Florian Angeletti and Gabriel
+  Scherer)
+
 ### Code generation and optimizations:
 
 - GPR#1370: Fix code duplication in Cmmgen

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -304,7 +304,9 @@ let () = parse_options false defaults_w;;
 let () = parse_options true defaults_warn_error;;
 
 let message = function
-  | Comment_start -> "this is the start of a comment."
+  | Comment_start ->
+      "this `(*' is the start of a comment.\n\
+       Hint: Did you forget spaces when writing the infix operator `( * )'?"
   | Comment_not_end -> "this is not the end of a comment."
   | Deprecated (s, _, _) ->
       (* Reduce \r\n to \n:


### PR DESCRIPTION
A common rookie mistake is to write `(*)`, trying to get the prefix equivalent of the multiplication function -- the compiler rightfully warns that this is in fact the beginning of a comment, but does not explain how to actually get the prefix version.

This patch simply extends the existing warning in order to suggest using `( * )` instead.