### PR TITLE
Remove -static-libgcc link flag from mingw32 port

### DIFF
--- a/Changes
+++ b/Changes
@@ -78,6 +78,11 @@ Working version
 
 ### Runtime system:
 
+- MPR#6411, GPR#1535: don't compile everything with -static-libgcc on mingw32,
+  only dllbigarray.dll and libbigarray.a. Allows the use of C++ libraries which
+  raise exceptions.
+  (David Allsopp)
+
 - GPR#1431: remove ocamlrun dependencies on curses/terminfo/termcap C library
   (Xavier Leroy, review by Daniel Bünzli)
 

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -294,8 +294,8 @@ bash or by adding Cygwin's bin directory (e.g. `C:\cygwin\bin`) to your `PATH`.
 
 * The replay debugger is partially supported (no reverse execution).
 
-* The default `config/Makefile.mingw` and `config/Makefile.mingw64` pass
-  `-static-libgcc` to the linker. For more information on this topic:
+* The default `config/Makefile.mingw` passes `-static-libgcc` to the linker.
+  For more information on this topic:
 
   - http://gcc.gnu.org/onlinedocs/gcc-4.9.1/gcc/Link-Options.html#Link-Options
   - http://caml.inria.fr/mantis/view.php?id=6411

--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -294,12 +294,6 @@ bash or by adding Cygwin's bin directory (e.g. `C:\cygwin\bin`) to your `PATH`.
 
 * The replay debugger is partially supported (no reverse execution).
 
-* The default `config/Makefile.mingw` passes `-static-libgcc` to the linker.
-  For more information on this topic:
-
-  - http://gcc.gnu.org/onlinedocs/gcc-4.9.1/gcc/Link-Options.html#Link-Options
-  - http://caml.inria.fr/mantis/view.php?id=6411
-
 [[seflexdll]]
 == FlexDLL
 Although the core of FlexDLL is necessarily written in C, the `flexlink` program

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -133,7 +133,7 @@ FLEXLINK_CMD=flexlink
 FLEXDLL_CHAIN=mingw
 # FLEXLINK_FLAGS must be safe to insert in an OCaml string
 #   (see ocamlmklibconfig.ml in tools/Makefile)
-FLEXLINK_FLAGS=-chain $(FLEXDLL_CHAIN) -stack 16777216 -link -static-libgcc
+FLEXLINK_FLAGS=-chain $(FLEXDLL_CHAIN) -stack 16777216
 FLEXLINK=$(FLEXLINK_CMD) $(FLEXLINK_FLAGS)
 FLEXDIR:=$(shell $(FLEXLINK) -where 2>/dev/null)
 ifeq ($(FLEXDIR),)

--- a/otherlibs/bigarray/Makefile
+++ b/otherlibs/bigarray/Makefile
@@ -21,6 +21,10 @@ CAMLOBJS=bigarray.cmo
 
 include ../Makefile
 
+ifeq "$(SYSTEM)" "mingw"
+LDOPTS=-ldopt "-link -static-libgcc"
+endif
+
 mmap.$(O): ../$(UNIXLIB)/mmap.c
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $(OUTPUTOBJ)$@ $<
 mmap_ba.$(O): ../unix/mmap_ba.c

--- a/otherlibs/win32unix/Makefile
+++ b/otherlibs/win32unix/Makefile
@@ -39,20 +39,24 @@ UNIX_FILES = access.c addrofstr.c chdir.c chmod.c cst2constr.c \
 UNIX_CAML_FILES = unix.mli unixLabels.mli unixLabels.ml
 
 ALL_FILES=$(WIN_FILES) $(UNIX_FILES)
-WSOCKLIB=$(call SYSLIB,ws2_32)
-ADVAPI32LIB=$(call SYSLIB,advapi32)
 
 LIBNAME=unix
 COBJS=$(ALL_FILES:.c=.$(O))
 CAMLOBJS=unix.cmo unixLabels.cmo
-LINKOPTS=-cclib $(WSOCKLIB) -cclib $(ADVAPI32LIB)
-LDOPTS=-ldopt $(WSOCKLIB) -ldopt $(ADVAPI32LIB)
+WIN32_LIBS=$(call SYSLIB,ws2_32) $(call SYSLIB,advapi32)
+LINKOPTS=$(addprefix -cclib ,$(WIN32_LIBS))
 EXTRACAMLFLAGS=-nolabels
 EXTRACFLAGS=-I../unix
 HEADERS=unixsupport.h socketaddr.h
 
 
 include ../Makefile
+
+ifeq "$(SYSTEM)" "mingw"
+LDOPTS=-ldopt "-link -static-libgcc" $(addprefix -ldopt ,$(WIN32_LIBS))
+else
+LDOPTS=$(addprefix -ldopt ,$(WIN32_LIBS))
+endif
 
 clean::
 	rm -f $(UNIX_FILES) $(UNIX_CAML_FILES)


### PR DESCRIPTION
[MPR#6411](https://caml.inria.fr/mantis/view.php?id=6411) added the `-static-libgcc` to all linking instructions for the mingw port in order to fix a problem with dllbigarray.dll. Contrary to README.win32, this has never been set in the 64-bit mingw port.

The change was too broad and in particular prevents use of C++ exceptions.

The fix is to specify `-link -static-libgcc` directly in `LDOPTS` for both otherlibs/bigarray and otherlibs/win32unix (since mmap.o is now compiled by both libraries). This causes dllbigarray.dll and dllunix.dll to obtain `___divdi3` and `___moddi3` statically and eliminates the dependency on `libgcc_s_sjlj-1.dll`.

libunix.a and libbigarray.a are unaffected by this flag. When linking C executables, GCC assumes static by default so these libraries will continue with libgcc.a, as they were before.

My understanding (and testing) is that C++ exceptions will still work even in the presence of dllbigarray.dll or dllunix.dll because the only thing they will have linked statically from libgcc is those two functions, so the exception handler stuff will still correctly in a C/C++ mixed environment.

At the time of the original PR, we didn't really have a working testsuite. Our present testsuite would have caught the original "bug" as soon as AppVeyor's Cygwin updated. I have a vague recollection of having to start symlinking `libgcc_s_sjlj-1.dll` on my own systems back when GCC 4.x appeared but, as Jonathan notes in the MPR discussion, I didn't regard that as a bug so I never looked for the Mantis report at the time.

Note that in conjunction with https://github.com/alainfrisch/flexdll/pull/48, this appears to resolve all issues linking C++ with the two mingw ports (as far as I can tell, linking C++ objects in the MSVC port has always worked)