### PR TITLE
Make pattern matching compilation more robust to ill-typed columns

### DIFF
--- a/Changes
+++ b/Changes
@@ -173,6 +173,9 @@ Working version
 - GPR#1470: Don't commute negation with float comparison
   (Leo White, review by Xavier Leroy)
 
+- GPR#1538: Make pattern matching compilation more robust to ill-typed columns
+  (Gabriel Scherer and Thomas Refis, review by Luc Maranget)
+
 OCaml 4.06.0 (3 Nov 2017):
 --------------------------
 

--- a/testsuite/tests/basic-more/ocamltests
+++ b/testsuite/tests/basic-more/ocamltests
@@ -8,6 +8,7 @@ pr1271.ml
 pr2719.ml
 pr6216.ml
 record_evaluation_order.ml
+robustmatch.ml
 sequential_and_or.ml
 structural_constants.ml
 tbuffer.ml

--- a/testsuite/tests/basic-more/robustmatch.ml
+++ b/testsuite/tests/basic-more/robustmatch.ml
@@ -1,0 +1,17 @@
+(* TEST
+   include testing
+*)
+
+module GPR1493 = struct
+  type t1 = { x : int; y : string; }
+  type t2 = { a : int; b : string; c : string list; }
+
+  type t = ..
+  type t += C1 of t1 | C2 of t2
+
+  let f (x : t) =
+    match x with
+    | C1 { x; y } -> ()
+    | C2 { a;b;c } -> ()
+    | _ -> ()
+end

--- a/testsuite/tests/basic-more/robustmatch.reference
+++ b/testsuite/tests/basic-more/robustmatch.reference
@@ -1,0 +1,2 @@
+
+All tests succeeded.


### PR DESCRIPTION
The first commit is extracted from #1518 and the test is the one produced in #1493 .

This GPR, unlike #1518, focuses only on the compilation of pattern matchings and fixes the regression introduced by GPR#1459 (which broke the build of jbuilder).
There is a consensus (among @maranget , @gasche and I) that we should merge it and then cherry-pick it on the 4.06 branch (which I'll do once someone formally approves).
The alternative being to revert #1459 from the 4.06 branch, but that means reintroducing a known compilation bug.