### PR TITLE
Manual: decouple verbatim and toplevel styles in code examples

### DIFF
--- a/Changes
+++ b/Changes
@@ -109,6 +109,9 @@ Working version
 - PR#7647, GPR#1384: emphasize ocaml.org website and forum in README
   (Yawar Amin, review by Gabriel Scherer)
 
+- GPR#1540: manual, decouple verbatim and toplevel style in code examples
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Compiler distribution build system
 
 - MPR#7679: make sure .a files are erased before calling ar rc, otherwise

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -6,31 +6,43 @@
 \newstyle{a:visited}{color:\visited@color;text-decoration:underline;}
 \newstyle{a:hover}{color:black;text-decoration:none;background-color:\hover@color}
 
+%Styles for caml-example and friends
 \newstyle{div.caml-output}{color:maroon;}
-\newstyle{div.caml-input::before}{content:"\#"; color:black;}
-\newstyle{div.caml-input}{color:\#006000;}
 \newstyle{div.caml-example pre}{margin:2ex 0px;}
-
+% Styles for toplevel mode only
+\newstyle{div.caml-example.toplevel div.caml-input::before}
+         {content:"\#"; color:black;}
+\newstyle{div.caml-example.toplevel div.caml-input}{color:\#006000;}
 %%%
 \newcommand{\input@color}{\htmlcolor{006000}}
 \newcommand{\output@color}{\maroon}
 \newcommand{\machine}{\tt}
 \newenvironment{machineenv}{\begin{alltt}}{\end{alltt}}
 \newcommand{\firstline}{\ }
-\newcommand{\nextline}{\ \ }
+\newcommand{\examplespace}{\ }
+\newcommand{\nextline}{\examplespace\ }
 \newcommand{\@zyva}{\firstline\renewcommand{\?}{\nextline}}
+\let\?=\@zyva
 \newenvironment{camlunder}{\@style{U}}{}
 \newcommand{\caml}{\begin{alltt}\renewcommand{\;}{}\renewcommand{\\}{\char92}\def\<{\begin{camlunder}}\def\>{\end{camlunder}}\activebracefalse}
-\let\?=\@zyva
 \newcommand{\endcaml}{\activebracetrue\end{alltt}
 }
 \renewcommand{\:}{\renewcommand{\?}{\@zyva}}
 \newcommand{\var}[1]{\textit{#1}}
 
 % Caml-example environment
-\newcommand{\camlexample}{\@open{div}{class="caml-example"}
+\newcommand{\camlexample}[1]{
+  \ifthenelse{\equal{#1}{verbatim}}
+  {\renewcommand{\examplespace}{}}
+  {\renewcommand{\examplespace}{\ }}
+  \fi
+  \@open{div}{class="caml-example #1"}
 }
-\newcommand{\endcamlexample}{\@close{div}}
+\newcommand{\endcamlexample}{
+  \@close{div}
+  \renewcommand{\examplespace}{\ }
+}
+
 \newcommand{\camlinput}{\@open{div}{class="caml-input"}}
 \newcommand{\endcamlinput}{\@close{div}}
 \newcommand{\camloutput}{\@open{div}{class="caml-output ok"}}

--- a/manual/styles/caml-sl.sty
+++ b/manual/styles/caml-sl.sty
@@ -1,9 +1,9 @@
 % CAML style option, for use with the caml-latex filter.
 
 \typeout{Document Style option `caml-sl' <7 Apr 92>.}
-
+\newcommand{\hash}{\#}
 {\catcode`\^^M=\active %
- \gdef\@camlinputline#1^^M{\normalsize\tt\# #1\par} %
+ \gdef\@camlinputline#1^^M{\normalsize\tt\hash{} #1\par} %
  \gdef\@camloutputline#1^^M{\small\ttfamily\slshape#1\par} } %
 \def\@camlblankline{\medskip}
 \chardef\@camlbackslash="5C
@@ -42,8 +42,15 @@
 }
 
 % Caml-example related command
-\def\camlexample{\begin{flushleft}}
-\def\endcamlexample{\end{flushleft}}
+\def\camlexample#1{
+  \ifnum\pdfstrcmp{#1}{verbatim}=0
+  \renewcommand{\hash}{}
+  \else
+  \renewcommand{\hash}{\#}
+  \fi
+  \begin{flushleft}
+}
+\def\endcamlexample{\end{flushleft}\renewcommand{\hash}{\#}}
 \def\camlinput{}
 \def\endcamlinput{}
 \def\camloutput{}


### PR DESCRIPTION
This small PR tweaks the latex code emitted by `manual/tools/caml_tex2.ml` in order to decouple the styles of the verbatim and toplevel mode of the `caml_example` pseudo-environment.

More precisely, it adds two latex macros `\camlverbatim` and `\endcamlverbatim` that complements the existing `\camlexample` and `\endcamlexample`. These macros are emitted in the verbatim variant of the caml example pseudo-mode and are used to tune separately the styles of the classic (aka toplevel) mode and this new verbatim mode as requested by @gasche in #1209 . Moreover, this PR directly exploit this possibility to remove the `#` prefix in the verbatim mode, see the small examples [here](http://www.polychoron.fr/ocaml-nonmanual/pr1540/extn.html#sec256).