### PR TITLE
Fix MPR#7695

### DIFF
--- a/Changes
+++ b/Changes
@@ -176,6 +176,9 @@ Working version
 - MPR#7682, GPR#1495: fix [@@unboxed] for records with 1 polymorphic field
   (Alain Frisch, report by Stéphane Graham-Lengrand, review by Gabriel Scherer)
 
+- MPR#7695, GPR#1541: Fatal error: exception Ctype.Unify(_) with field override
+  (Jacques Garrigue, report by Nicolas Ojeda Bar)
+
 - GPR#1517: More robust handling of type variables in mcomp
   (Leo White and Thomas Refis, review by Jacques Garrigue)
 

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -141,4 +141,13 @@ val with_fst : ('a, 'b) t -> 'c -> ('c, 'b) t = <fun>
 type 'a t = { f : 'a; g : 'a };;
 let x = { f = 12; g = 43 };;
 {x with f = "hola"};;
-[%%expect]
+[%%expect{|
+type 'a t = { f : 'a; g : 'a; }
+val x : int t = {f = 12; g = 43}
+Line _, characters 0-19:
+  {x with f = "hola"};;
+  ^^^^^^^^^^^^^^^^^^^
+Error: This expression has type string t
+       but an expression was expected of type int t
+       Type string is not compatible with type int
+|}, Principal{||}]

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -150,4 +150,4 @@ Line _, characters 0-19:
 Error: This expression has type string t
        but an expression was expected of type int t
        Type string is not compatible with type int
-|}, Principal{||}]
+|}]

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -136,3 +136,9 @@ type ('a, 'b) t = { fst : 'a; snd : 'b; }
 val with_fst : ('a, 'b) t -> 'c -> ('c, 'b) t = <fun>
 - : (int, string) t = {fst = 2; snd = ""}
 |}];;
+
+(* PR#7695 *)
+type 'a t = { f : 'a; g : 'a };;
+let x = { f = 12; g = 43 };;
+{x with f = "hola"};;
+[%%expect]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3069,9 +3069,9 @@ and type_expect_
                   Overridden (lid, lbl_exp)
               | exception Not_found -> begin
                   let _, ty_arg2, ty_res2 = instance_label false lbl in
-                  unify env ty_arg1 ty_arg2;
+                  unify_exp_types loc env ty_arg1 ty_arg2;
                   with_explanation (fun () ->
-                    unify env (instance env ty_expected) ty_res2);
+                    unify_exp_types loc env (instance env ty_expected) ty_res2);
                   Kept ty_arg1
                 end
             in


### PR DESCRIPTION
There where some raw calls to `Ctype.unify` in the code.
Original MPR: [7695](https://caml.inria.fr/mantis/view.php?id=7695)
