### PR TITLE
Add a hint suggesting to use `!` when a 'a ref is provided but a 'a was expected

### DIFF
--- a/testsuite/tests/typing-core-bugs/missing_bang_hints.ml
+++ b/testsuite/tests/typing-core-bugs/missing_bang_hints.ml
@@ -1,0 +1,57 @@
+(* TEST
+   * expect
+*)
+
+
+let r = ref 1 in
+print_int r        (* should be [!r] *)
+;;
+
+[%%expect{|
+Line _, characters 10-11:
+  print_int r        (* should be [!r] *)
+            ^
+Error: This expression has type int ref
+       but an expression was expected of type int
+       Hint: Did you forget to use `!' to get the content of a reference somewhere?
+|}];;
+
+
+let r = ref 1 in
+r := r + 1         (* should be [!r + 1] *)
+;;
+
+[%%expect{|
+Line _, characters 5-6:
+  r := r + 1         (* should be [!r + 1] *)
+       ^
+Error: This expression has type int ref
+       but an expression was expected of type int
+       Hint: Did you forget to use `!' to get the content of a reference somewhere?
+|}];;
+
+
+
+(* The missing `!' does not necessarily have to be inserted at the reported
+   location in order to fix the typing error. This is illustrated by the
+   following test, and is why the hint says "somewhere". *)
+
+let f x y =
+  let z = ref 0 in
+  z := !z + x;
+  z := !z + y;
+  z                 (* missing `!' here? *)
+
+let _ =
+  print_int (f 3 4) (* or maybe there? *)
+;;
+
+[%%expect{|
+val f : int -> int -> int ref = <fun>
+Line _, characters 12-19:
+    print_int (f 3 4) (* or maybe there? *)
+              ^^^^^^^
+Error: This expression has type int ref
+       but an expression was expected of type int
+       Hint: Did you forget to use `!' to get the content of a reference somewhere?
+|}];;

--- a/testsuite/tests/typing-core-bugs/ocamltests
+++ b/testsuite/tests/typing-core-bugs/ocamltests
@@ -3,3 +3,4 @@ example_let_missing_rec.ml
 example_let_missing_rec_mutual.ml
 unit_fun_hints.ml
 type_expected_explanation.ml
+missing_bang_hints.ml

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1576,7 +1576,7 @@ let rec trace_same_names = function
       type_same_name t1 t2; type_same_name t1' t2'; trace_same_names rem
   | _ -> ()
 
-let unification_error env unif tr txt1 ppf txt2 ty_expect_explanation =
+let unification_error env unif explain_mismatch tr txt1 ppf txt2 ty_expect_explanation =
   reset ();
   trace_same_names tr;
   let tr = List.map (fun (t, t') -> (t, hide_variant_name t')) tr in
@@ -1601,7 +1601,7 @@ let unification_error env unif tr txt1 ppf txt2 ty_expect_explanation =
         txt2 (type_expansion t2) t2'
         ty_expect_explanation
         (trace false "is not compatible with type") tr
-        (explain mis);
+        (fun ppf -> if explain_mismatch then explain mis ppf);
       if env <> Env.empty
       then begin
         warn_on_missing_def env ppf t1;
@@ -1612,10 +1612,11 @@ let unification_error env unif tr txt1 ppf txt2 ty_expect_explanation =
       print_labels := true;
       raise exn
 
-let report_unification_error ppf env ?(unif=true) tr
+let report_unification_error ppf env ?(unif=true) ?(explain_mismatch=true) tr
     ?(type_expected_explanation = fun _ -> ())
     txt1 txt2 =
-  wrap_printing_env env (fun () -> unification_error env unif tr txt1 ppf txt2
+  wrap_printing_env env (fun () -> unification_error env unif explain_mismatch
+                            tr txt1 ppf txt2
                             type_expected_explanation)
 ;;
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1418,6 +1418,11 @@ let is_unit env ty =
   | Tconstr (p, _, _) -> Path.same p Predef.path_unit
   | _ -> false
 
+let is_ref_path p =
+  match p with
+  | Pdot (Pident id, "ref", _) -> Ident.same id ident_pervasives
+  | _ -> false
+
 let unifiable env ty1 ty2 =
   let snap = Btype.snapshot () in
   let res =
@@ -1439,6 +1444,12 @@ let explanation env unif t3 t4 : (Format.formatter -> unit) option =
       Some (fun ppf ->
         fprintf ppf
           "@,@[Hint: Did you forget to wrap the expression using `fun () ->'?@]")
+  | Tconstr (p, [ty1], _), _
+    when is_ref_path p && unifiable env ty1 t4 ->
+      Some (fun ppf ->
+        fprintf ppf
+          "@,@[Hint: Did you forget to use `!' to get the content \
+           of a reference somewhere?@]")
   | Ttuple [], Tvar _ | Tvar _, Ttuple [] ->
       Some (fun ppf ->
         fprintf ppf "@,Self type cannot escape its class")

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -75,7 +75,7 @@ val prepare_expansion: type_expr * type_expr -> type_expr * type_expr
 val trace:
     bool -> bool-> string -> formatter -> (type_expr * type_expr) list -> unit
 val report_unification_error:
-    formatter -> Env.t -> ?unif:bool ->
+    formatter -> Env.t -> ?unif:bool -> ?explain_mismatch:bool ->
     (type_expr * type_expr) list ->
     ?type_expected_explanation:(formatter -> unit) ->
     (formatter -> unit) -> (formatter -> unit) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5014,6 +5014,7 @@ let report_error env ppf = function
        longident lid expected provided
   | Label_mismatch(lid, trace) ->
       report_unification_error ppf env trace
+        ~explain_mismatch:false
         (function ppf ->
            fprintf ppf "The record field %a@ belongs to the type"
                    longident lid)


### PR DESCRIPTION
This is an other small bit extracted from #102 . This PR adds a hint "did you forget to use !" as an explanation for a type mismatch between `'a ref` and `'a`.

```
let r = ref 1 in print_int r;;
                           ^
Error: This expression has type int ref
       but an expression was expected of type int
       Hint: Did you forget to use `!' to get the content of a reference somewhere?
```

The first commit is as one might expect.
I'm less confident about the way the second commit is implemented. The idea is to disable the hint in the following case:

```
type t = { x : int };;
{ x = 3; contents = 0 };;
Error: The record field contents belongs to the type 'a ref
       but is mixed here with fields of type t
```

This case appears in the `explanation` function as a mismatch between `'a ref` and `t` (for label `contents`), but for a label mismatch the `!` hint obviously does not make sense.

The current patch does disable the hint in that case, but it feels a bit hackish.

