### PR TITLE
Syntax proposal: Infix function calls

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -196,9 +196,9 @@ let uchar_for_uchar_escape lexbuf =
 
 (* recover the name from a LABEL or OPTLABEL token *)
 
-let get_label_name lexbuf =
+let get_label_name ?(offset=1) ?(drop_last=0) lexbuf =
   let s = Lexing.lexeme lexbuf in
-  let name = String.sub s 1 (String.length s - 2) in
+  let name = String.sub s offset (String.length s - 1 - offset - drop_last) in
   if Hashtbl.mem keyword_table name then
     raise (Error(Keyword_as_label name, Location.curr lexbuf));
   name
@@ -448,6 +448,8 @@ rule token = parse
   | "&"  { AMPERSAND }
   | "&&" { AMPERAMPER }
   | "`"  { BACKQUOTE }
+  | '`' ['=' '<' '>' '|' '&' '$'] lowercase identchar * '`'
+            { INFIXIDENT0(get_label_name ~offset:2 ~drop_last:0 lexbuf) }
   | "\'" { QUOTE }
   | "("  { LPAREN }
   | ")"  { RPAREN }

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -448,8 +448,6 @@ rule token = parse
   | "&"  { AMPERSAND }
   | "&&" { AMPERAMPER }
   | "`"  { BACKQUOTE }
-  | '`' ['=' '<' '>' '|' '&' '$'] lowercase identchar * '`'
-            { INFIXIDENT0(get_label_name ~offset:2 ~drop_last:0 lexbuf) }
   | "\'" { QUOTE }
   | "("  { LPAREN }
   | ")"  { RPAREN }
@@ -501,15 +499,23 @@ rule token = parse
             { PREFIXOP(Lexing.lexeme lexbuf) }
   | ['=' '<' '>' '|' '&' '$'] symbolchar *
             { INFIXOP0(Lexing.lexeme lexbuf) }
+  | '`' ['=' '<' '>' '|' '&' '$'] lowercase identchar * '`'
+            { INFIXIDENT0(get_label_name ~offset:2 ~drop_last:0 lexbuf) }
   | ['@' '^'] symbolchar *
             { INFIXOP1(Lexing.lexeme lexbuf) }
+  | '`' ['@' '^'] lowercase identchar * '`'
+            { INFIXIDENT1(get_label_name ~offset:2 ~drop_last:0 lexbuf) }
   | ['+' '-'] symbolchar *
             { INFIXOP2(Lexing.lexeme lexbuf) }
+  | '`' ['+' '-'] lowercase identchar * '`'
+            { INFIXIDENT2(get_label_name ~offset:2 ~drop_last:0 lexbuf) }
   | "**" symbolchar *
             { INFIXOP4(Lexing.lexeme lexbuf) }
   | '%'     { PERCENT }
   | ['*' '/' '%'] symbolchar *
             { INFIXOP3(Lexing.lexeme lexbuf) }
+  | '`' ['*' '/' '%'] lowercase identchar * '`'
+            { INFIXIDENT3(get_label_name ~offset:2 ~drop_last:0 lexbuf) }
   | '#' (symbolchar | '#') +
             { HASHOP(Lexing.lexeme lexbuf) }
   | eof { EOF }

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -463,8 +463,11 @@ let package_type_of_module_type pmty =
 %token <string> INFIXOP0
 %token <string> INFIXIDENT0
 %token <string> INFIXOP1
+%token <string> INFIXIDENT1
 %token <string> INFIXOP2
+%token <string> INFIXIDENT2
 %token <string> INFIXOP3
+%token <string> INFIXIDENT3
 %token <string> INFIXOP4
 %token <string> DOTOP
 %token INHERIT
@@ -584,13 +587,13 @@ The precedences must be listed from low to high.
 %right    AMPERSAND AMPERAMPER          /* expr (e && e && e) */
 %nonassoc below_EQUAL
 %left     INFIXOP0 INFIXIDENT0 EQUAL LESS GREATER   /* expr (e OP e OP e) */
-%right    INFIXOP1                      /* expr (e OP e OP e) */
+%right    INFIXOP1 INFIXIDENT1          /* expr (e OP e OP e) */
 %nonassoc below_LBRACKETAT
 %nonassoc LBRACKETAT
 %nonassoc LBRACKETATAT
 %right    COLONCOLON                    /* expr (e :: e :: e) */
-%left     INFIXOP2 PLUS PLUSDOT MINUS MINUSDOT PLUSEQ /* expr (e OP e OP e) */
-%left     PERCENT INFIXOP3 STAR                 /* expr (e OP e OP e) */
+%left     INFIXOP2 INFIXIDENT2 PLUS PLUSDOT MINUS MINUSDOT PLUSEQ /* expr (e OP e OP e) */
+%left     PERCENT INFIXOP3 INFIXIDENT3 STAR                 /* expr (e OP e OP e) */
 %right    INFIXOP4                      /* expr (e OP e OP e) */
 %nonassoc prec_unary_minus prec_unary_plus /* unary - */
 %nonassoc prec_constant_constructor     /* cf. simple_expr (C versus C x) */
@@ -1360,6 +1363,12 @@ expr:
   | expr COLONCOLON expr
       { mkexp_cons (rhs_loc 2) (ghexp(Pexp_tuple[$1;$3])) (symbol_rloc()) }
   | expr INFIXIDENT0 expr
+      { mkinfix $1 $2 $3 }
+  | expr INFIXIDENT1 expr
+      { mkinfix $1 $2 $3 }
+  | expr INFIXIDENT2 expr
+      { mkinfix $1 $2 $3 }
+  | expr INFIXIDENT3 expr
       { mkinfix $1 $2 $3 }
   | expr INFIXOP0 expr
       { mkinfix $1 $2 $3 }

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -461,6 +461,7 @@ let package_type_of_module_type pmty =
 %token IN
 %token INCLUDE
 %token <string> INFIXOP0
+%token <string> INFIXIDENT0
 %token <string> INFIXOP1
 %token <string> INFIXOP2
 %token <string> INFIXOP3
@@ -582,7 +583,7 @@ The precedences must be listed from low to high.
 %right    OR BARBAR                     /* expr (e || e || e) */
 %right    AMPERSAND AMPERAMPER          /* expr (e && e && e) */
 %nonassoc below_EQUAL
-%left     INFIXOP0 EQUAL LESS GREATER   /* expr (e OP e OP e) */
+%left     INFIXOP0 INFIXIDENT0 EQUAL LESS GREATER   /* expr (e OP e OP e) */
 %right    INFIXOP1                      /* expr (e OP e OP e) */
 %nonassoc below_LBRACKETAT
 %nonassoc LBRACKETAT
@@ -1358,6 +1359,8 @@ expr:
       { mkexp_attrs(Pexp_for($3, $5, $7, $6, $9)) $2 }
   | expr COLONCOLON expr
       { mkexp_cons (rhs_loc 2) (ghexp(Pexp_tuple[$1;$3])) (symbol_rloc()) }
+  | expr INFIXIDENT0 expr
+      { mkinfix $1 $2 $3 }
   | expr INFIXOP0 expr
       { mkinfix $1 $2 $3 }
   | expr INFIXOP1 expr


### PR DESCRIPTION
Sometimes we really desire to use infix notation so as to clarify code. For this purpose, we have infix operators in OCaml. However, the problem with infix operators is that they're unclear to anyone not used to the particular meaning of specific operators. They can obfuscate code rather than clarifying it, raising the bar for learning any particular library.

What would be really nice, would be a way to use identifiers in an infix manner. For example, 

```ocaml
Lwt.(print_int 5 `and_then` fun () -> get_state `and_then` fun x -> print_int x)
```
is clearer than 

```ocaml
Lwt.(print_int 5 >>= fun () -> get_state >>= fun x -> print_int x)
```
If you know what `>>=` means, this example isn't too bad, but if you don't, you're lost without the meaning of the words. Obviously much worse examples can be drawn up.

Unfortunately, we can't do this in OCaml. backtick quotation is used in haskell, but OCaml uses backtick for polymorphic variants. Not only that, we have no way to dynamically change the precedence of these functions, unlike in haskell.

What I propose in this pull request is to leverage the fact that polymorphic variants can only contain identifier symbols to create a new syntactic element. The example above would be:

```ocaml
Lwt.(print_int 5 `>and_then` fun () -> get_state `>and_then` fun x -> print_int x)
```

Backquotes are still used to identify the infix function. Additionally, though, one symbol is needed to specify the associativity and precedence of the infix call, using OCaml conventions. This gives the user full flexibility in how he wants to call his functions -- any single operator symbol may be used. The functions are defined as normal, without the extra prefix symbol.

Note that this is a proof-of-concept and not a complete implementation. I'd like to see the response to this idea before making it merge-worthy.