### PR TITLE
Parmatch column coherence

### DIFF
--- a/Changes
+++ b/Changes
@@ -196,6 +196,9 @@ Working version
   (Nicolás Ojeda Bär, report by Alain Frisch, review by David Allsopp, Xavier
   Leroy)
 
+- GPR#1550: Make pattern matching warnings more robust to ill-typed columns
+  (Thomas Refis, with help from Gabriel Scherer and Luc Maranget)
+
 4.06 maintenance branch
 -----------------------
 

--- a/testsuite/tests/basic-more/robustmatch.compilers.reference
+++ b/testsuite/tests/basic-more/robustmatch.compilers.reference
@@ -1,0 +1,107 @@
+File "robustmatch.ml", line 33, characters 6-122:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(AB, MAB, A)
+File "robustmatch.ml", line 54, characters 4-73:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, 1)
+File "robustmatch.ml", line 64, characters 4-73:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, (B|C))
+File "robustmatch.ml", line 69, characters 4-73:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, (B|C))
+File "robustmatch.ml", line 74, characters 4-73:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, "")
+File "robustmatch.ml", line 85, characters 4-66:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, (B|C))
+File "robustmatch.ml", line 90, characters 4-87:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, (Y|Z))
+File "robustmatch.ml", line 96, characters 4-66:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, (Y|Z))
+File "robustmatch.ml", line 107, characters 4-66:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, (B|C))
+File "robustmatch.ml", line 129, characters 4-66:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, B)
+File "robustmatch.ml", line 151, characters 4-66:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, B)
+File "robustmatch.ml", line 156, characters 4-87:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, Y)
+File "robustmatch.ml", line 162, characters 4-66:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, Y)
+File "robustmatch.ml", line 167, characters 4-66:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, A)
+File "robustmatch.ml", line 176, characters 4-90:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, [| _ |])
+File "robustmatch.ml", line 182, characters 4-69:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, [| _ |])
+File "robustmatch.ml", line 187, characters 4-90:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, [| _ |])
+File "robustmatch.ml", line 200, characters 4-89:
+Warning 4: this pattern-matching is fragile.
+It will remain exhaustive when constructors are added to type repr.
+File "robustmatch.ml", line 210, characters 4-75:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, 'a')
+File "robustmatch.ml", line 219, characters 4-74:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, `B)
+File "robustmatch.ml", line 228, characters 4-89:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, (3, "*"))
+File "robustmatch.ml", line 239, characters 4-113:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, {x=3; y="*"})
+File "robustmatch.ml", line 244, characters 4-113:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, {a=1; b="coucou"; c='b'})
+File "robustmatch.ml", line 253, characters 4-72:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, (3, "*"))
+File "robustmatch.ml", line 263, characters 4-82:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, {x=3; y="*"})
+File "robustmatch.ml", line 272, characters 4-71:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R1, R1, lazy 0)
+File "robustmatch.ml", line 281, characters 4-99:
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(R2, R2, "")

--- a/testsuite/tests/basic-more/robustmatch.ml
+++ b/testsuite/tests/basic-more/robustmatch.ml
@@ -1,4 +1,5 @@
 (* TEST
+   flags += "-w +4+8+9+11+12+52+56+57"
    include testing
 *)
 
@@ -14,4 +15,271 @@ module GPR1493 = struct
     | C1 { x; y } -> ()
     | C2 { a;b;c } -> ()
     | _ -> ()
+end
+
+module Coherence_illustration = struct
+  type ab = A | B
+
+  module M : sig
+    type mab = A | B
+
+    type _ t = AB : ab t | MAB : mab t
+  end = struct
+    type mab = ab = A | B
+
+    type _ t = AB : ab t | MAB : mab t
+
+    let f (type x) (t1 : x t) (t2 : x t) (x : x) =
+      match t1, t2, x with
+      | AB, AB, A -> ()
+      | MAB, _, A -> ()
+      | _,  AB, B -> ()
+      | _, MAB, B -> ()
+  end
+
+  open M
+
+  let f (type x) (t1 : x t) (t2 : x t) (x : x) =
+    match t1, t2, x with
+    | AB,  AB, A -> ()
+    | MAB, _, A -> ()
+    | _,  AB, B -> ()
+    | _, MAB, B -> ()
+end
+
+module M1 = struct
+  type _ repr = R1 : int repr | R2 : string repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, 0 -> ()
+    | _, R2, "coucou" -> ()
+end
+
+module M2 = struct
+  type c = A | B | C
+  type _ repr = R1 : c repr | R2 : string repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, "coucou" -> ()
+
+  let g (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | _, R2, "coucou" -> ()
+    | R1, _, A -> ()
+
+  let h (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | _, R2, "coucou" -> ()
+    | R1, _, _ -> ()
+end
+
+module M3 = struct
+  type c1 = A | B | C
+  type c2 = X | Y | Z
+  type _ repr = R1 : c1 repr | R2 : c2 repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+
+  let g (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+    | R1, _, _ -> ()
+
+  let h (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, _ -> ()
+    | _, R2, X -> ()
+end
+
+module M3_gadt = struct
+  type c1 = A | B | C
+  type _ c2 = X : int c2 | Y : char c2 | Z : char c2
+  type _ repr = R1 : c1 repr | R2 : int c2 repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+
+  let g (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+    | R1, _, _ -> ()
+
+  let h (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, _ -> ()
+    | _, R2, X -> ()
+end
+
+module M3_gadt_bis = struct
+  type _ c1 = A : int c1 | B : int c1 | C : char c1
+  type _ c2 = X : int c2 | Y : char c2 | Z : char c2
+  type _ repr = R1 : int c1 repr | R2 : int c2 repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+
+  let g (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+    | R1, _, B -> ()
+
+  let h (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, _ -> ()
+    | _, R2, X -> ()
+end
+
+module M3_gadt_bis_harder = struct
+  type _ c1 = A : int c1 | B : int c1 | C : char c1
+  type _ c2 = X : int c2 | Y : char c2 | Z : char c2
+  type _ repr = R1 : 'a c1 repr | R2 : 'a c2 repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+
+  let g (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, A -> ()
+    | _, R2, X -> ()
+    | R1, _, _ -> ()
+
+  let h (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, _ -> ()
+    | _, R2, X -> ()
+
+  let h (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, C -> ()
+    | _, R2, Y -> ()
+end
+
+module M4 = struct
+  type _ repr = R1 : int repr | R2 : int array repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | _, R1, 0 -> ()
+    | R2, _, [||] -> ()
+    | _, R1, 1 -> ()
+
+  let g (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, _ -> ()
+    | _, R2, [||] -> ()
+
+  let h (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | _, R2, [||] -> ()
+    | R1, _, 0 -> ()
+    | R1, _, _ -> ()
+
+  let i (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | _, R2, [||] -> ()
+    | R1, _, 0 -> ()
+    | R1, _, _ -> ()
+    | _, R2, _ -> ()
+
+  let j (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | _, R2, [||] -> ()
+    | R1, _, 0 -> ()
+    | _, _, _ -> ()
+end
+
+module M5 = struct
+  type _ repr = R1 : char repr | R2 : string repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, 'c' -> ()
+    | _, R2, "coucou" -> ()
+end
+
+module M6 = struct
+  type _ repr = R1 : [ `A | `B ] repr | R2 : string repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, `A -> ()
+    | _, R2, "coucou" -> ()
+end
+
+module M7 = struct
+  type _ repr = R1 : (int * string) repr | R2 : (int * string * char) repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, (3, "") -> ()
+    | _, R2, (1, "coucou", 'a') -> ()
+end
+
+module M8 = struct
+  type r1 = { x : int; y : string }
+  type r2 = { a : int; b : string; c : char }
+  type _ repr = R1 : r1 repr | R2 : r2 repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, { x = 3; y = "" } -> ()
+    | _, R2, { a = 1; b = "coucou"; c = 'a' } -> ()
+
+  let g (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R2, _, { a = 1; b = "coucou"; c = 'a' } -> ()
+    | _, R1, { x = 3; y = "" } -> ()
+end
+
+module M9 = struct
+  type _ repr = R1 : (int * string) repr | R2 : int repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, (3, "") -> ()
+    | _, R2, 1 -> ()
+end
+
+module M10 = struct
+  type r = { x : int; y : string }
+  type _ repr = R1 : r repr | R2 : int repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, { x = 3; y = "" } -> ()
+    | _, R2, 1 -> ()
+end
+
+module M11 = struct
+  type _ repr = R1 : int lazy_t repr | R2 : int repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, lazy 1 -> ()
+    | _, R2, 1 -> ()
+end
+
+module M12 = struct
+  type _ repr = R1 : unit repr | R2 : string repr
+
+  let f (type a) (r1 : a repr) (r2 : a repr) (a : a) =
+    match r1, r2, a with
+    | R1, _, () -> ()
+    | _, R2, "coucou" -> ()
+    | _, R2, "foo" -> ()
 end

--- a/testsuite/tests/warnings/w04_failure.ml
+++ b/testsuite/tests/warnings/w04_failure.ml
@@ -1,0 +1,28 @@
+type ab = A | B
+type xy = X | Y
+
+type _ repr = AB : ab repr | XY : xy repr
+
+(* Correctly reports fragility w.r.t. [repr], [ab] and [xy]. *)
+
+let vocal_fragile (type t) (r1 : t repr) (r2 : t repr) (t : t) =
+  match r1, r2, t with
+  | AB, _, A -> ()
+  | _, XY, X -> ()
+  | _, _, _ -> ()
+
+(* Fails to report fragility on [ab] and [xy]. *)
+
+let silent_fragile1 (type t) (r1 : t repr) (r2 : t repr) (t : t) =
+  match r1, r2, t with
+  | AB, _, A -> ()
+  | _, XY, X -> ()
+  | _, AB, _ -> ()
+  | XY, _, _ -> ()
+
+let silent_fragile2 (type t) (r1 : t repr) (r2 : t repr) (t : t) =
+  match r1, r2, t with
+  | AB, _, A -> ()
+  | _, XY, X -> ()
+  | AB, _, _ -> ()
+  | _, XY, _ -> ()

--- a/testsuite/tests/warnings/w04_failure.reference
+++ b/testsuite/tests/warnings/w04_failure.reference
@@ -1,0 +1,9 @@
+File "w04_failure.ml", line 9, characters 2-78:
+Warning 4: this pattern-matching is fragile.
+It will remain exhaustive when constructors are added to type repr.
+File "w04_failure.ml", line 9, characters 2-78:
+Warning 4: this pattern-matching is fragile.
+It will remain exhaustive when constructors are added to type ab.
+File "w04_failure.ml", line 9, characters 2-78:
+Warning 4: this pattern-matching is fragile.
+It will remain exhaustive when constructors are added to type xy.

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -249,9 +249,9 @@ let simple_match p1 p2 =
   | Tpat_variant(l1, _, _), Tpat_variant(l2, _, _) ->
       l1 = l2
   | Tpat_constant(c1), Tpat_constant(c2) -> const_compare c1 c2 = 0
-  | Tpat_tuple _, Tpat_tuple _ -> true
   | Tpat_lazy _, Tpat_lazy _ -> true
   | Tpat_record _ , Tpat_record _ -> true
+  | Tpat_tuple p1s, Tpat_tuple p2s
   | Tpat_array p1s, Tpat_array p2s -> List.length p1s = List.length p2s
   | _, (Tpat_any | Tpat_var(_)) -> true
   | _, _ -> false

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -181,7 +181,7 @@ module Compat
   | Tpat_array ps, Tpat_array qs ->
       List.length ps = List.length qs &&
       compats ps qs
-  | _,_  -> assert false (* By typing *)
+  | _,_  -> false
 
   and ocompat op oq = match op,oq with
   | None,None -> true
@@ -191,7 +191,7 @@ module Compat
   and compats ps qs = match ps,qs with
   | [], [] -> true
   | p::ps, q::qs -> compat p q && compats ps qs
-  | _,_    -> assert false (* By typing *)
+  | _,_    -> false
 
 end
 

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -44,6 +44,135 @@ let omega_list l = List.map (fun _ -> omega) l
 
 let zero = make_pat (Tpat_constant (Const_int 0)) Ctype.none Env.empty
 
+(*******************)
+(* Coherence check *)
+(*******************)
+
+(* For some of the operations we do in this module, we would like (because it
+   simplifies matters) to assume that patterns appearing on a given column in a
+   pattern matrix are /coherent/ (think "of the same type").
+   Unfortunately that is not always true.
+
+   Consider the following (well-typed) example:
+   {[
+     type _ t = S : string t | U : unit t
+
+     let f (type a) (t1 : a t) (t2 : a t) (a : a) =
+       match t1, t2, a with
+       | U, _, () -> ()
+       | _, S, "" -> ()
+   ]}
+
+   Clearly the 3rd column contains incoherent patterns.
+
+   On the example above, most of the algorithms will explore the pattern matrix
+   as illustrated by the following tree:
+
+   {v
+                                                   S
+                                                -------> | "" |
+                             U     | S, "" | __/         | () |
+                         --------> | _, () |   \  ¬ S
+        | U, _, () | __/                        -------> | () |
+        | _, S, "" |   \
+                        ---------> | S, "" | ----------> | "" |
+                           ¬ U                    S
+   v}
+
+   where following an edge labelled by a pattern P means "assuming the value I
+   am matching on is filtered by [P] on the column I am currently looking at,
+   then the following submatrix is still reachable".
+
+   Notice that at any point of that tree, if the first column of a matrix is
+   incoherent, then the branch leading to it can only be taken if the scrutinee
+   is ill-typed.
+   In the example above the only case where we have a matrix with an incoherent
+   first column is when we consider [t1, t2, a] to be [U, S, ...]. However such
+   a value would be ill-typed, so we can never actually get there.
+
+   Checking the first column at each step of the recursion and making the
+   concious decision of "aborting" the algorithm whenever the first column
+   becomes incoherent, allows us to retain the initial assumption in later
+   stages of the algorithms.
+
+   ---
+
+   N.B. two patterns can be considered coherent even though they might not be of
+   the same type.
+
+   That's in part because we only care about the "head" of patterns and leave
+   checking coherence of subpatterns for the next steps of the algorithm:
+   ('a', 'b') and (1, ()) will be deemed coherent because they are both a tuples
+   of arity 2 (we'll notice at a later stage the incoherence of 'a' and 1).
+
+   But also because it can be hard/costly to determine exactly whether two
+   patterns are of the same type or not (eg. in the example above with _ and S,
+   but see also the module [Coherence_illustration] in
+   testsuite/tests/basic-more/robustmatch.ml).
+
+   For the moment our weak, loosely-syntactic, coherence check seems to be
+   enough and we leave it to each user to consider (and document!) what happens
+   when an "incoherence" is not detected by this check.
+*)
+
+(* Given the first column of a simplified matrix, this function first looks for
+   a "discriminating" pattern on that column (i.e. a non-omega one) and then
+   check that every other head pattern in the column is coherent with that one.
+*)
+let all_coherent column =
+  let coherent_heads hp1 hp2 =
+    match hp1.pat_desc, hp2.pat_desc with
+    | (Tpat_var _ | Tpat_alias _ | Tpat_or _), _
+    | _, (Tpat_var _ | Tpat_alias _ | Tpat_or _) ->
+      assert false
+    | Tpat_construct (_, c, _), Tpat_construct (_, c', _) ->
+      c.cstr_consts = c'.cstr_consts
+      && c.cstr_nonconsts = c'.cstr_nonconsts
+    | Tpat_constant c1, Tpat_constant c2 -> begin
+        match c1, c2 with
+        | Const_char _, Const_char _
+        | Const_int _, Const_int _
+        | Const_int32 _, Const_int32 _
+        | Const_int64 _, Const_int64 _
+        | Const_nativeint _, Const_nativeint _
+        | Const_float _, Const_float _
+        | Const_string _, Const_string _ -> true
+        | ( Const_char _
+          | Const_int _
+          | Const_int32 _
+          | Const_int64 _
+          | Const_nativeint _
+          | Const_float _
+          | Const_string _), _ -> false
+      end
+    | Tpat_tuple l1, Tpat_tuple l2 -> List.length l1 = List.length l2
+    | Tpat_record ((_, lbl1, _) :: _, _), Tpat_record ((_, lbl2, _) :: _, _) ->
+      Array.length lbl1.lbl_all = Array.length lbl2.lbl_all
+    | Tpat_any, _
+    | _, Tpat_any
+    | Tpat_record ([], _), Tpat_record ([], _)
+    | Tpat_variant _, Tpat_variant _
+    | Tpat_array _, Tpat_array _
+    | Tpat_lazy _, Tpat_lazy _ -> true
+    | _, _ -> false
+  in
+  match
+    List.find (fun head_pat ->
+      match head_pat.pat_desc with
+      | Tpat_var _ | Tpat_alias _ | Tpat_or _ -> assert false
+      | Tpat_any -> false
+      | _ -> true
+    ) column
+  with
+  | exception Not_found ->
+    (* only omegas on the column: the column is coherent. *)
+    true
+  | discr_pat ->
+    List.for_all (coherent_heads discr_pat) column
+
+let first_column simplified_matrix =
+  List.map fst simplified_matrix
+
 (***********************)
 (* Compatibility check *)
 (***********************)
@@ -329,8 +458,8 @@ let rec normalize_pat q = match q.pat_desc with
       make_pat (Tpat_lazy omega) q.pat_type q.pat_env
   | Tpat_or _ -> fatal_error "Parmatch.normalize_pat"
 
-(* Consider a pattern matrix whose first column has been simplified
-   to contain only _ or a head constructor
+(* Consider a pattern matrix whose first column has been simplified to contain
+   only _ or a head constructor
      | p1, r1...
      | p2, r2...
      | p3, r3...
@@ -996,6 +1125,21 @@ and has_instances = function
     Does there exists at least one value vector, es such that :
      1- for all ps in pss ps # es (ps and es are not compatible)
      2- qs <= es                  (es matches qs)
+
+   ---
+
+   In two places in the following function, we check the coherence of the first
+   column of (pss + qs).
+   If it is incoherent, then we exit early saying that (pss + qs) is not
+   satisfiable (which is equivalent to saying "oh, we shouldn't have considered
+   that branch, no good result came come from here").
+
+   But what happens if we have a coherent but ill-typed column?
+   - we might end up returning [false], which is equivalent to noticing the
+   incompatibility: clearly this is fine.
+   - if we end up returning [true] then we're saying that [qs] is useful while
+   it is not. This is sad but not the end of the world, we're just allowing dead
+   code to survive.
 *)
 let rec satisfiable pss qs = match pss with
 | [] -> has_instances qs
@@ -1008,27 +1152,34 @@ let rec satisfiable pss qs = match pss with
           satisfiable pss (q::qs)
     | {pat_desc = (Tpat_any | Tpat_var(_))}::qs ->
         let pss = simplify_first_col pss in
-        let q0 = discr_pat omega pss in
-        begin match build_specialized_submatrices ~extend_row:(@) q0 pss with
-        | { default; constrs = [] } ->
-          (* first column of pss is made of variables only *)
-          satisfiable default qs
-        | { default; constrs }  ->
-            if full_match false constrs then
-              List.exists
-                (fun (p,pss) ->
-                  not (is_absent_pat p) &&
-                  satisfiable pss (simple_match_args p omega @ qs))
-                constrs
-            else
+        if not (all_coherent (first_column pss)) then (
+          false
+        ) else (
+          let q0 = discr_pat omega pss in
+          match build_specialized_submatrices ~extend_row:(@) q0 pss with
+          | { default; constrs = [] } ->
+              (* first column of pss is made of variables only *)
               satisfiable default qs
-        end
+          | { default; constrs }  ->
+              if full_match false constrs then
+                List.exists
+                  (fun (p,pss) ->
+                    not (is_absent_pat p) &&
+                    satisfiable pss (simple_match_args p omega @ qs))
+                  constrs
+              else
+                satisfiable default qs
+        )
     | {pat_desc=Tpat_variant (l,_,r)}::_ when is_absent l r -> false
     | q::qs ->
         let pss = simplify_first_col pss in
-        let q0 = discr_pat q pss in
-        satisfiable (build_specialized_submatrix ~extend_row:(@) q0 pss)
-          (simple_match_args q0 q @ qs)
+        if not (all_coherent (q :: first_column pss)) then (
+          false
+        ) else (
+          let q0 = discr_pat q pss in
+          satisfiable (build_specialized_submatrix ~extend_row:(@) q0 pss)
+            (simple_match_args q0 q @ qs)
+        )
 
 (* While [satisfiable] only checks whether the last row of [pss + qs] is
    satisfiable, this function returns the (possibly empty) list of vectors [es]
@@ -1036,7 +1187,10 @@ let rec satisfiable pss qs = match pss with
      1- for all ps in pss, ps # es (ps and es are not compatible)
      2- qs <= es                   (es matches qs)
 
-   This is done to enable GADT handling *)
+   This is done to enable GADT handling
+
+   For considerations regarding the coherence check, see the comment on
+   [satisfiable] above.  *)
 let rec list_satisfying_vectors pss qs =
   match pss with
   | [] -> if has_instances qs then [qs] else []
@@ -1050,46 +1204,54 @@ let rec list_satisfying_vectors pss qs =
           list_satisfying_vectors pss (q::qs)
       | {pat_desc = (Tpat_any | Tpat_var(_))}::qs ->
           let pss = simplify_first_col pss in
-          let q0 = discr_pat omega pss in
-          let wild default_matrix p =
-            List.map (fun qs -> p::qs)
-              (list_satisfying_vectors default_matrix qs)
-          in
-          begin match build_specialized_submatrices ~extend_row:(@) q0 pss with
-          | { default; constrs = [] } ->
-              (* first column of pss is made of variables only *)
-              wild default omega
-          | { default; constrs = ((p,_)::_ as constrs) } ->
-              let for_constrs () =
-                List.flatten (
-                  List.map (fun (p,pss) ->
-                    if is_absent_pat p then
-                      []
-                    else
-                      let witnesses =
-                        list_satisfying_vectors pss
-                          (simple_match_args p omega @ qs)
-                      in
-                      List.map (set_args p) witnesses
-                  ) constrs
-                )
-              in
-              if full_match false constrs then for_constrs () else
-              match p.pat_desc with
-              | Tpat_construct _ ->
-                  (* activate this code for checking non-gadt constructors *)
-                  wild default (build_other_constrs constrs p) @ for_constrs ()
-              | _ ->
-                  wild default omega
-          end
+          if not (all_coherent (first_column pss)) then (
+            []
+          ) else (
+            let q0 = discr_pat omega pss in
+            let wild default_matrix p =
+              List.map (fun qs -> p::qs)
+                (list_satisfying_vectors default_matrix qs)
+            in
+            match build_specialized_submatrices ~extend_row:(@) q0 pss with
+            | { default; constrs = [] } ->
+                (* first column of pss is made of variables only *)
+                wild default omega
+            | { default; constrs = ((p,_)::_ as constrs) } ->
+                let for_constrs () =
+                  List.flatten (
+                    List.map (fun (p,pss) ->
+                      if is_absent_pat p then
+                        []
+                      else
+                        let witnesses =
+                          list_satisfying_vectors pss
+                            (simple_match_args p omega @ qs)
+                        in
+                        List.map (set_args p) witnesses
+                    ) constrs
+                  )
+                in
+                if full_match false constrs then for_constrs () else
+                match p.pat_desc with
+                | Tpat_construct _ ->
+                    (* activate this code for checking non-gadt constructors *)
+                    wild default (build_other_constrs constrs p)
+                    @ for_constrs ()
+                | _ ->
+                    wild default omega
+          )
       | {pat_desc=Tpat_variant (l,_,r)}::_ when is_absent l r -> []
       | q::qs ->
           let pss = simplify_first_col pss in
-          let q0 = discr_pat q pss in
-          List.map (set_args q0)
-            (list_satisfying_vectors
-               (build_specialized_submatrix ~extend_row:(@) q0 pss)
-               (simple_match_args q0 q @ qs))
+          if not (all_coherent (q :: first_column pss)) then (
+            []
+          ) else (
+            let q0 = discr_pat q pss in
+            List.map (set_args q0)
+              (list_satisfying_vectors
+                 (build_specialized_submatrix ~extend_row:(@) q0 pss)
+                 (simple_match_args q0 q @ qs))
+          )
 
 (******************************************)
 (* Look for a row that matches some value *)
@@ -1118,9 +1280,11 @@ let rec do_match pss qs = match qs with
       do_match (remove_first_column pss) qs
   | _ ->
       let q0 = normalize_pat q in
+      let pss = simplify_first_col pss in
+      (* [pss] will (or won't) match [q0 :: qs] regardless of the coherence of
+         its first column. *)
       do_match
-        (build_specialized_submatrix ~extend_row:(@) q0
-           (simplify_first_col pss))
+        (build_specialized_submatrix ~extend_row:(@) q0 pss)
         (simple_match_args q0 q @ qs)
 
 
@@ -1173,45 +1337,60 @@ let rec exhaust (ext:Path.t option) pss n = match pss with
 | []::_ ->  No_matching_value
 | pss   ->
     let pss = simplify_first_col pss in
-    let q0 = discr_pat omega pss in
-    begin match build_specialized_submatrices ~extend_row:(@) q0 pss with
-    | { default; constrs = [] } ->
-        (* first column of pss is made of variables only *)
-        begin match exhaust ext default (n-1) with
-        | Witnesses r -> Witnesses (List.map (fun row -> q0::row) r)
-        | r -> r
-      end
-    | { default; constrs } ->
-        let try_non_omega (p,pss) =
-          if is_absent_pat p then
-            No_matching_value
-          else
-            match
-              exhaust
-                ext pss (List.length (simple_match_args p omega) + n - 1)
-            with
-            | Witnesses r -> Witnesses (List.map (fun row ->  (set_args p row)) r)
-            | r       -> r in
-        let before = try_many try_non_omega constrs in
-        if
-          full_match false constrs && not (should_extend ext constrs)
-        then
-          before
-        else
-          let r =  exhaust ext default (n-1) in
-          match r with
-          | No_matching_value -> before
-          | Witnesses r ->
-              try
-                let p = build_other ext constrs in
-                let dug = List.map (fun tail -> p :: tail) r in
-                match before with
-                | No_matching_value -> Witnesses dug
-                | Witnesses x -> Witnesses (x @ dug)
+    if not (all_coherent (first_column pss)) then
+      (* We're considering an ill-typed branch, we won't actually be able to
+         produce a well typed value taking that branch. *)
+      No_matching_value
+    else (
+      (* Assuming the first column is ill-typed but considered coherent, we
+         might end up producing an ill-typed witness of non-exhaustivity
+         corresponding to the current branch.
+
+         If [exhaust] has been called by [do_check_partial], then the witnesses
+         produced get typechecked and the ill-typed ones are discarded.
+
+         If [exhaust] has been called by [do_check_fragile], then it is possible
+         we might fail to warn the user that the matching is fragile. See for
+         example testsuite/tests/warnings/w04_failure.ml. *)
+      let q0 = discr_pat omega pss in
+      match build_specialized_submatrices ~extend_row:(@) q0 pss with
+      | { default; constrs = [] } ->
+          (* first column of pss is made of variables only *)
+          begin match exhaust ext default (n-1) with
+          | Witnesses r -> Witnesses (List.map (fun row -> q0::row) r)
+          | r -> r
+        end
+      | { default; constrs } ->
+          let try_non_omega (p,pss) =
+            if is_absent_pat p then
+              No_matching_value
+            else
+              match
+                exhaust
+                  ext pss (List.length (simple_match_args p omega) + n - 1)
               with
-      (* cannot occur, since constructors don't make a full signature *)
-              | Empty -> fatal_error "Parmatch.exhaust"
-    end
+              | Witnesses r -> Witnesses (List.map (fun row ->  (set_args p row)) r)
+              | r       -> r in
+          let before = try_many try_non_omega constrs in
+          if
+            full_match false constrs && not (should_extend ext constrs)
+          then
+            before
+          else
+            let r =  exhaust ext default (n-1) in
+            match r with
+            | No_matching_value -> before
+            | Witnesses r ->
+                try
+                  let p = build_other ext constrs in
+                  let dug = List.map (fun tail -> p :: tail) r in
+                  match before with
+                  | No_matching_value -> Witnesses dug
+                  | Witnesses x -> Witnesses (x @ dug)
+                with
+        (* cannot occur, since constructors don't make a full signature *)
+                | Empty -> fatal_error "Parmatch.exhaust"
+  )
 
 let exhaust ext pss n =
   let ret = exhaust ext pss n in
@@ -1244,47 +1423,50 @@ let rec pressure_variants tdefs = function
   | []::_ -> true
   | pss   ->
       let pss = simplify_first_col pss in
-      let q0 = discr_pat omega pss in
-      begin match build_specialized_submatrices ~extend_row:(@) q0 pss with
-      | { default; constrs = [] } -> pressure_variants tdefs default
-      | { default; constrs } ->
-          let rec try_non_omega = function
-            | (_p,pss) :: rem ->
-                let ok = pressure_variants tdefs pss in
-                (* The order below matters : we want [pressure_variants] to be
-                   called on all the specialized submatrices because we might
-                   close some variant in any of them regardless of whether [ok]
-                   is true for [pss] or not *)
-                try_non_omega rem && ok
-            | [] -> true
-          in
-          if full_match (tdefs=None) constrs then
-            try_non_omega constrs
-          else if tdefs = None then
-            pressure_variants None default
-          else
-            let full = full_match true constrs in
-            let ok =
-              if full then
-                try_non_omega constrs
-              else (
-                let { constrs = partial_constrs; _ } =
-                  build_specialized_submatrices ~extend_row:(@) q0
-                    (mark_partial pss)
-                in
-                try_non_omega partial_constrs
-              )
+      if not (all_coherent (first_column pss)) then
+        true
+      else (
+        let q0 = discr_pat omega pss in
+        match build_specialized_submatrices ~extend_row:(@) q0 pss with
+        | { default; constrs = [] } -> pressure_variants tdefs default
+        | { default; constrs } ->
+            let rec try_non_omega = function
+              | (_p,pss) :: rem ->
+                  let ok = pressure_variants tdefs pss in
+                  (* The order below matters : we want [pressure_variants] to be
+                    called on all the specialized submatrices because we might
+                    close some variant in any of them regardless of whether [ok]
+                    is true for [pss] or not *)
+                  try_non_omega rem && ok
+              | [] -> true
             in
-            begin match constrs, tdefs with
-              ({pat_desc=Tpat_variant _} as p,_):: _, Some env ->
-                let row = row_of_pat p in
-                if Btype.row_fixed row
-                || pressure_variants None default then ()
-                else close_variant env row
-            | _ -> ()
-            end;
-            ok
-      end
+            if full_match (tdefs=None) constrs then
+              try_non_omega constrs
+            else if tdefs = None then
+              pressure_variants None default
+            else
+              let full = full_match true constrs in
+              let ok =
+                if full then
+                  try_non_omega constrs
+                else (
+                  let { constrs = partial_constrs; _ } =
+                    build_specialized_submatrices ~extend_row:(@) q0
+                      (mark_partial pss)
+                  in
+                  try_non_omega partial_constrs
+                )
+              in
+              begin match constrs, tdefs with
+                ({pat_desc=Tpat_variant _} as p,_):: _, Some env ->
+                  let row = row_of_pat p in
+                  if Btype.row_fixed row
+                  || pressure_variants None default then ()
+                  else close_variant env row
+              | _ -> ()
+              end;
+              ok
+      )
 
 
 (* Yet another satisfiable function *)
@@ -1393,7 +1575,7 @@ and simplify_head_pat p ps k =
 
 
 (* Back to normal matrices *)
-let make_vector r = r.no_ors
+let make_vector r = List.rev r.no_ors
 
 let make_matrix rs = List.map make_vector rs
 
@@ -1485,11 +1667,17 @@ let rec every_satisfiables pss qs = match qs.active with
     | _ ->
 (* standard case, filter matrix *)
         let pss = simplify_first_col pss in
-        let q0 = discr_pat q pss in
-        every_satisfiables
-          (build_specialized_submatrix q0 pss
-             ~extend_row:(fun ps r -> { r with active = ps @ r.active }))
-          {qs with active=simple_match_args q0 q @ rem}
+        (* The handling of incoherent matrices is kept in line with
+           [satisfiable] *)
+        if not (all_coherent (uq :: first_column pss)) then
+          Unused
+        else (
+          let q0 = discr_pat q pss in
+          every_satisfiables
+            (build_specialized_submatrix q0 pss
+              ~extend_row:(fun ps r -> { r with active = ps @ r.active }))
+            {qs with active=simple_match_args q0 q @ rem}
+        )
     end
 
 (*
@@ -2167,11 +2355,26 @@ let rec matrix_stable_vars rs = match rs with
     (* The stable variables are those stable at any position *)
     List.fold_left IdSet.union IdSet.empty stables_in_varsets
 | rs ->
-   let submatrices = split_rows (simplify_first_col rs) in
-   let submat_stable = List.map matrix_stable_vars submatrices in
-   (* a stable variable must be stable in each submatrix;
-      if the matrix has at least one row, there is at least one submatrix *)
-   reduce IdSet.inter submat_stable
+    let rs = simplify_first_col rs in
+    if not (all_coherent (first_column rs)) then (
+      (* If the first column is incoherent, then all the variables of this
+         matrix are stable. *)
+      List.fold_left (fun acc (_, { varsets; _ }) ->
+        List.fold_left IdSet.union acc varsets
+      ) IdSet.empty rs
+    ) else (
+      (* If the column is ill-typed but deemed coherent, we might spuriously
+         warn about some variables being unstable.
+
+         As sad as that might be, the warning can be silenced by splitting the
+         or-pattern...
+      *)
+      let submatrices = split_rows rs in
+      let submat_stable = List.map matrix_stable_vars submatrices in
+      (* a stable variable must be stable in each submatrix;
+        if the matrix has at least one row, there is at least one submatrix *)
+      reduce IdSet.inter submat_stable
+    )
 
 let pattern_stable_vars p = matrix_stable_vars [{varsets = []; row = [p]}]
 


### PR DESCRIPTION
Spin off of #1518 following discussions with Gabriel and Luc.

This version of the patch introduce an explicit *coherence* check at various points in parmatch.
There is a somewhat lengthy description of the check in the code itself, so I won't go into the details here (improvements to that documentation are very welcome though!).

A perhaps more readable version of the diff (as it ignores whitespaces changes) on `parmatch.ml` can be seen [here](https://ocaml.janestreet.com/parmatch-column-coherence.patdiff.html).

## A note on pattern typing

Currently patterns are typechecked from "left to right", that is
```ocaml
type _ t = I : int t | C : char t

let f (type a) (t : a t) (a : a) =
  match t, a with
  | I, 3 -> ()
  | C, 'a' -> ()
```
is well typed, but the following is not:
```ocaml
let f (type a) (t : a t) (a : a) =
  match a, t with
  | 3, I -> ()
  | 'a', C -> ()
```

From the point of view of typing alone, one could imagine lifting that restriction at some point in the future and allowing both versions to typecheck.

In pratice however, in their current state, neither parmatch nor matching would survive such a change.

Incidentally `Parmatch.every_satisfiable` was reversing the order of columns between being called and calling `satisfiable`.
You'll notice the `List.rev`, hidden in the commit introducing the coherence check, fixing that problem.

## Limitations of the current coherence check

In various places I give a brief explanation of what can happen when we accept a column as coherent while it is in fact ill-typed.
The potential outcomes include false positives and negatives.

However:
- for the checks which have an impact on the soundness (i.e. exhaustivity and usefulness) we always error on the safe side: we never say something is exhaustive or unused when it in fact isn't.
- the proposed coherence check catches all the cases (and some more) which resulted in assertion failures/fatal errors in parmatch. The issues that are not detected by the current check were already silently accepted before (see for example the test added by the first commit whose result is left unchanged by the other patches).