### PR TITLE
Manual: fix obsolete reference to "curses.mli"

### DIFF
--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -1178,7 +1178,7 @@ has taken place since "r" was allocated.
 
 This section outlines how the functions from the Unix "curses" library
 can be made available to OCaml programs. First of all, here is
-the interface "curses.mli" that declares the "curses" primitives and
+the interface "curses.ml" that declares the "curses" primitives and
 data types:
 \begin{verbatim}
 (* File curses.ml -- declaration of primitives and data types *)


### PR DESCRIPTION
In b843100a64f9029032ca4b1eb1fc357fa44fa238, `curses.mli` was renamed to `curses.ml`, but not everywhere.