### PR TITLE
Ambiguous pattern variables: add negative rows

### DIFF
--- a/Changes
+++ b/Changes
@@ -73,18 +73,22 @@ Working version
   (Arthur Charguéraud and Armaël Guéneau, with help from Leo White, review by
   Florian Angeletti and Gabriel Radanne)
 
+- GPR#1510: Add specific explanation for unification errors caused by type
+  constraints propagated by keywords (such as if, while, for...)
+  (Armaël Guéneau and Gabriel Scherer, original design by Arthur Charguéraud,
+  review by Frédéric Bour, Gabriel Radanne and Alain Frisch)
+
 - GPR#1534: Extend the warning printed when (*) is used, adding a hint to
   suggest using ( * ) instead
   (Armaël Guéneau, with help and review from Florian Angeletti and Gabriel
   Scherer)
 
+- GPR#1552: do not warn about ambiguous variables in guards (warning 57)
+  when the ambiguous values have been filtered by a previous clause
+  (Gabriel Scherer and Thomas Refis, review by Luc Maranget)
+
 - GPR#1554: warnings 52 and 57: fix reference to manual detailed explanation
   (Florian Angeletti, review by Thomas Refis and Gabriel Scherer)
-
-- GPR#1510: Add specific explanation for unification errors caused by type
-  constraints propagated by keywords (such as if, while, for...)
-  (Armaël Guéneau and Gabriel Scherer, original design by Arthur Charguéraud,
-  review by Frédéric Bour, Gabriel Radanne and Alain Frisch)
 
 ### Code generation and optimizations:
 

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -265,3 +265,18 @@ let cmp (pred : a -> bool) (x : a alg) (y : a alg) =
   (* below: silence exhaustiveness/fragility warnings *)
   | (Val (A1 | A2) | Binop _), _ -> ()
 ;;
+
+type a = A1;;
+
+type 'a alg =
+  | Val of 'a
+  | Binop of 'a alg * 'a alg;;
+
+let () = print_endline "no warning below";;
+let cmp (pred : a -> bool) (x : a alg) (y : a alg) =
+  match x, y with
+  | Val A1, Val A1 -> ()
+  | ((Val x, _) | (_, Val x)) when pred x -> ()
+  (* below: silence exhaustiveness/fragility warnings *)
+  | (Val A1 | Binop _), _ -> ()
+;;

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
@@ -139,4 +139,22 @@ val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t2 -> int =
   <fun>
 #   * * * * * * * *         val not_ambiguous__as_disjoint_on_second_column_split :
   int option * int -> unit = <fun>
+#   no warning below
+# *                           val solved_ambiguity_typical_example : expr * expr -> unit = <fun>
+#   yet a warning below
+# *                     Characters 164-189:
+    | ((Val y, _) | (_, Val y)) when y < 0 -> ()
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous or-pattern variables under guard;
+variable y may match different arguments. (See manual section 9.5)
+val guarded_ambiguity : expr * expr -> unit = <fun>
+#     type a = A1 | A2
+#       type 'a alg = Val of 'a | Binop of 'a alg * 'a alg
+#   warning below
+#             Characters 100-125:
+    | ((Val x, _) | (_, Val x)) when pred x -> ()
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous or-pattern variables under guard;
+variable x may match different arguments. (See manual section 9.5)
+val cmp : (a -> bool) -> a alg -> a alg -> unit = <fun>
 # 

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
@@ -157,4 +157,8 @@ val guarded_ambiguity : expr * expr -> unit = <fun>
 Warning 57: Ambiguous or-pattern variables under guard;
 variable x may match different arguments. (See manual section 9.5)
 val cmp : (a -> bool) -> a alg -> a alg -> unit = <fun>
+#   type a = A1
+#       type 'a alg = Val of 'a | Binop of 'a alg * 'a alg
+#   no warning below
+#             val cmp : (a -> bool) -> a alg -> a alg -> unit = <fun>
 # 

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -2386,7 +2386,10 @@ let rec matrix_stable_vars m = match m with
           let q0 = discr_pat omega m in
           let { default; constrs } =
             build_specialized_submatrices ~extend_row q0 m in
-          default :: List.map snd constrs in
+          let non_default = List.map snd constrs in
+          if constrs <> [] && full_match false constrs
+          then non_default
+          else default :: non_default in
         (* A stable variable must be stable in each submatrix. *)
         let submat_stable = List.map matrix_stable_vars submatrices in
         List.fold_left stable_inter All submat_stable


### PR DESCRIPTION
Consider a set of pattern-matching clauses of the form

```ocaml
     | (Foo x, Foo y) -> ...
     | ((Foo x, _) | (_, Foo x)) when bar x -> ...
```

currently this code would raise a [warning 57](http://caml.inria.fr/pub/docs/manual-ocaml-4.06/comp.html#sec288): the variable `x` in the guarded pattern `((Foo x, _) | (_, Foo x))` is ambiguous. However, this ambiguity is spurious, as the values that expose the ambiguity are of the shape `(Foo v, Foo v')`, and would all have been caught by the first clause.

This PR adds support for negative rows in the code computing stable pattern variables.

Note: Clauses that are guarded are not kept as negative clauses below (as we cannot reason on whether they catch values of the corresponding shape or not without analyzing the guard), so the following example would still raise a warning -- which I find slightly frustrating:

```ocaml
     | (Foo x, Foo y) when bar x || bar y -> ...
     | ((Foo x, _) | (_, Foo x)) when bar x -> ...
```

The first commit of this PR is a refactoring (that does not change the semantics) that I wrote as part of a larger PR to handle ill-typed columns in the ambiguous variable code (related to #1550, cc @trefis). In the inconsistent case, one needs to say that all variables are stable. We need to do the same in the case where we end up with an empty row to analyze but there remains a negative matrix -- filled with empty rows -- as this means that no value can ever reach this sub-matrix.