### PR TITLE
Warning messages: fix references to extended descriptions

### DIFF
--- a/Changes
+++ b/Changes
@@ -78,6 +78,9 @@ Working version
   (Armaël Guéneau, with help and review from Florian Angeletti and Gabriel
   Scherer)
 
+- GPR#1554: warnings 52 and 57: fix reference to manual detailled explanation
+  (Florian Angeletti)
+
 - GPR#1510: Add specific explanation for unification errors caused by type
   constraints propagated by keywords (such as if, while, for...)
   (Armaël Guéneau and Gabriel Scherer, original design by Arthur Charguéraud,

--- a/Changes
+++ b/Changes
@@ -78,8 +78,8 @@ Working version
   (Armaël Guéneau, with help and review from Florian Angeletti and Gabriel
   Scherer)
 
-- GPR#1554: warnings 52 and 57: fix reference to manual detailled explanation
-  (Florian Angeletti)
+- GPR#1554: warnings 52 and 57: fix reference to manual detailed explanation
+  (Florian Angeletti, review by Thomas Refis and Gabriel Scherer)
 
 - GPR#1510: Add specific explanation for unification errors caused by type
   constraints propagated by keywords (such as if, while, for...)

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml.reference
@@ -20,7 +20,7 @@ then just above there should be *no* warning text.
     | ((Val x, _) | (_, Val x)) when x < 0 -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57: Ambiguous or-pattern variables under guard;
-variable x may match different arguments. (See manual section 8.5)
+variable x may match different arguments. (See manual section 9.5)
 val ambiguous_typical_example : expr * expr -> unit = <fun>
 #   Note that an Assert_failure is expected just below.
 #   Exception: Assert_failure ("//toplevel//", 25, 6).
@@ -36,7 +36,7 @@ val ambiguous_typical_example : expr * expr -> unit = <fun>
     | (`B (x, _, Some y) | `B (x, Some y, _)) when y -> ignore x
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57: Ambiguous or-pattern variables under guard;
-variable y may match different arguments. (See manual section 8.5)
+variable y may match different arguments. (See manual section 9.5)
 val ambiguous__y : [> `B of 'a * bool option * bool option ] -> unit = <fun>
 #   * * * * * * * *         val not_ambiguous__rhs_not_protected :
   [> `B of 'a * bool option * bool option ] -> unit = <fun>
@@ -44,13 +44,13 @@ val ambiguous__y : [> `B of 'a * bool option * bool option ] -> unit = <fun>
     | (`B (x, _, Some y) | `B (x, Some y, _)) when x < y -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57: Ambiguous or-pattern variables under guard;
-variable y may match different arguments. (See manual section 8.5)
+variable y may match different arguments. (See manual section 9.5)
 val ambiguous__x_y : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 #         Characters 37-76:
     | (`B (x, z, Some y) | `B (x, Some y, z)) when x < y || Some x = z -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57: Ambiguous or-pattern variables under guard;
-variables y,z may match different arguments. (See manual section 8.5)
+variables y,z may match different arguments. (See manual section 9.5)
 val ambiguous__x_y_z : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
 #         val not_ambiguous__disjoint_in_depth :
   [> `A of [> `B of bool | `C of bool ] ] -> unit = <fun>
@@ -60,7 +60,7 @@ val ambiguous__x_y_z : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
     | `A (`B (Some x, _) | `B (_, Some x)) when x -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57: Ambiguous or-pattern variables under guard;
-variable x may match different arguments. (See manual section 8.5)
+variable x may match different arguments. (See manual section 9.5)
 val ambiguous__in_depth :
   [> `A of [> `B of bool option * bool option ] ] -> unit = <fun>
 #               val not_ambiguous__several_orpats :
@@ -73,7 +73,7 @@ val ambiguous__in_depth :
   ....`A ((`B (Some x, _) | `B (_, Some x)),
           (`C (Some y, Some _, _) | `C (Some y, _, Some _))).................
 Warning 57: Ambiguous or-pattern variables under guard;
-variable x may match different arguments. (See manual section 8.5)
+variable x may match different arguments. (See manual section 9.5)
 val ambiguous__first_orpat :
   [> `A of
        [> `B of 'a option * 'a option ] *
@@ -83,7 +83,7 @@ val ambiguous__first_orpat :
   ....`A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
           (`C (Some y, _) | `C (_, Some y))).................
 Warning 57: Ambiguous or-pattern variables under guard;
-variable y may match different arguments. (See manual section 8.5)
+variable y may match different arguments. (See manual section 9.5)
 val ambiguous__second_orpat :
   [> `A of
        [> `B of 'a option * 'b option * 'c option ] *
@@ -106,14 +106,14 @@ val ambiguous__second_orpat :
   ..X (Z x,Y (y,0))
   | X (Z y,Y (x,_))
 Warning 57: Ambiguous or-pattern variables under guard;
-variables x,y may match different arguments. (See manual section 8.5)
+variables x,y may match different arguments. (See manual section 9.5)
 val ambiguous__amoi : amoi -> int = <fun>
 #     module type S = sig val b : bool end
 #           Characters 56-101:
   ....(module M:S),_,(1,_)
     | _,(module M:S),(_,1)...................
 Warning 57: Ambiguous or-pattern variables under guard;
-variable M may match different arguments. (See manual section 8.5)
+variable M may match different arguments. (See manual section 9.5)
 val ambiguous__module_variable :
   (module S) * (module S) * (int * int) -> bool -> int = <fun>
 #           val not_ambiguous__module_variable :
@@ -134,7 +134,7 @@ Characters 55-107:
     | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57: Ambiguous or-pattern variables under guard;
-variables x,y may match different arguments. (See manual section 8.5)
+variables x,y may match different arguments. (See manual section 9.5)
 val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t2 -> int =
   <fun>
 #   * * * * * * * *         val not_ambiguous__as_disjoint_on_second_column_split :

--- a/testsuite/tests/warnings/w52.ml
+++ b/testsuite/tests/warnings/w52.ml
@@ -1,0 +1,22 @@
+let () = try () with Invalid_argument "Any" -> ();;
+
+type t =
+  | Warn of string  [@ocaml.warn_on_literal_pattern]
+  | Without_warning of string
+  | Warn' of nativeint [@ocaml.warn_on_literal_pattern];;
+
+let f = function
+| Warn "anything" -> ()
+| Warn _ | Warn' _ | Without_warning _ -> ()
+;;
+
+let g = function
+| Warn' 0n -> ()
+| Warn _ | Warn' _ | Without_warning _ -> ()
+;;
+
+
+let h = function
+| Without_warning "outside" -> ()
+| Warn _ | Warn' _ | Without_warning _ -> ()
+;;

--- a/testsuite/tests/warnings/w52.reference
+++ b/testsuite/tests/warnings/w52.reference
@@ -1,0 +1,12 @@
+File "w52.ml", line 1, characters 38-43:
+Warning 52: Code should not depend on the actual values of
+this constructor's arguments. They are only for information
+and may change in future versions. (See manual section 9.5)
+File "w52.ml", line 9, characters 7-17:
+Warning 52: Code should not depend on the actual values of
+this constructor's arguments. They are only for information
+and may change in future versions. (See manual section 9.5)
+File "w52.ml", line 14, characters 8-10:
+Warning 52: Code should not depend on the actual values of
+this constructor's arguments. They are only for information
+and may change in future versions. (See manual section 9.5)

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -474,7 +474,7 @@ let message = function
       Printf.sprintf
         "Code should not depend on the actual values of\n\
          this constructor's arguments. They are only for information\n\
-         and may change in future versions. (See manual section 8.5)"
+         and may change in future versions. (See manual section 9.5)"
   | Unreachable_case ->
       "this match case is unreachable.\n\
        Consider replacing it with a refutation case '<pat> -> .'"
@@ -496,7 +496,7 @@ let message = function
             "variables " ^ String.concat "," vars in
       Printf.sprintf
         "Ambiguous or-pattern variables under guard;\n\
-         %s may match different arguments. (See manual section 8.5)"
+         %s may match different arguments. (See manual section 9.5)"
         msg
   | No_cmx_file name ->
       Printf.sprintf


### PR DESCRIPTION
With the addition of the new polymorphism chapter, the references to the detailed warning explanations for warnings 4 and 57 had gone stale, this PR fixes this issue manually.