### PR TITLE
Genarray.nth_dim: add missing bounds check

### DIFF
--- a/Changes
+++ b/Changes
@@ -200,6 +200,9 @@ Working version
   to ill-typed columns
   (Thomas Refis, with help from Gabriel Scherer and Luc Maranget)
 
+- MPR#7705, GPR#1558: add missing bounds check in Bigarray.Genarray.nth_dim.
+  (Nicolás Ojeda Bär, report by Jeremy Yallop)
+
 4.06 maintenance branch
 -----------------------
 

--- a/otherlibs/bigarray/bigarray_stubs.c
+++ b/otherlibs/bigarray/bigarray_stubs.c
@@ -471,7 +471,7 @@ CAMLprim value caml_ba_dim(value vb, value vn)
 {
   struct caml_ba_array * b = Caml_ba_array_val(vb);
   intnat n = Long_val(vn);
-  if (n >= b->num_dims) caml_invalid_argument("Bigarray.dim");
+  if (n < 0 || n >= b->num_dims) caml_invalid_argument("Bigarray.dim");
   return Val_long(b->dim[n]);
 }
 


### PR DESCRIPTION
See [MPR#7705](https://caml.inria.fr/mantis/view.php?id=7705).