### PR TITLE
Fix MPR#7704

### DIFF
--- a/Changes
+++ b/Changes
@@ -204,7 +204,7 @@ Working version
   to ill-typed columns
   (Thomas Refis, with help from Gabriel Scherer and Luc Maranget)
 
-- MPR#7704: Soundness issue with private rows and module inclusion
+- MPR#7704, GPR#1559: Soundness issue with private rows and module inclusion
   (Jacques Garrigue, report by Jeremy Yallop)
 
 - MPR#7705, GPR#1558: add missing bounds check in Bigarray.Genarray.nth_dim.

--- a/Changes
+++ b/Changes
@@ -204,7 +204,7 @@ Working version
   to ill-typed columns
   (Thomas Refis, with help from Gabriel Scherer and Luc Maranget)
 
-- MPR#7704, GPR#1559: Soundness issue with private rows and module inclusion
+- MPR#7704, GPR#1559: Soundness issue with private rows and pattern-matching
   (Jacques Garrigue, report by Jeremy Yallop)
 
 - MPR#7705, GPR#1558: add missing bounds check in Bigarray.Genarray.nth_dim.

--- a/Changes
+++ b/Changes
@@ -205,7 +205,7 @@ Working version
   (Thomas Refis, with help from Gabriel Scherer and Luc Maranget)
 
 - MPR#7704, GPR#1559: Soundness issue with private rows and pattern-matching
-  (Jacques Garrigue, report by Jeremy Yallop)
+  (Jacques Garrigue, report by Jeremy Yallop, review by Thomas Refis)
 
 - MPR#7705, GPR#1558: add missing bounds check in Bigarray.Genarray.nth_dim.
   (Nicolás Ojeda Bär, report by Jeremy Yallop, review by Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -204,6 +204,9 @@ Working version
   to ill-typed columns
   (Thomas Refis, with help from Gabriel Scherer and Luc Maranget)
 
+- MPR#7704: Soundness issue with private rows and module inclusion
+  (Jacques Garrigue, report by Jeremy Yallop)
+
 - MPR#7705, GPR#1558: add missing bounds check in Bigarray.Genarray.nth_dim.
   (Nicolás Ojeda Bär, report by Jeremy Yallop, review by Gabriel Scherer)
 

--- a/Changes
+++ b/Changes
@@ -204,9 +204,6 @@ Working version
   to ill-typed columns
   (Thomas Refis, with help from Gabriel Scherer and Luc Maranget)
 
-- MPR#7704, GPR#1559: Soundness issue with private rows and pattern-matching
-  (Jacques Garrigue, report by Jeremy Yallop, review by Thomas Refis)
-
 - MPR#7705, GPR#1558: add missing bounds check in Bigarray.Genarray.nth_dim.
   (Nicolás Ojeda Bär, report by Jeremy Yallop, review by Gabriel Scherer)
 
@@ -219,6 +216,9 @@ Working version
   using extensible variants constructors
   (Luc Maranget, review by Thomas Refis and Gabriel Scherer, report
   by Abdelraouf Ouadjaout and Thibault Suzanne)
+
+- MPR#7704, GPR#1559: Soundness issue with private rows and pattern-matching
+  (Jacques Garrigue, report by Jeremy Yallop, review by Thomas Refis)
 
 - GPR#1470: Don't commute negation with float comparison
   (Leo White, review by Xavier Leroy)

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -103,6 +103,6 @@ Line _, characters 0-24:
   ^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-`*any extra tag*
+`<some other tag>
 - : t -> string = <fun>
 |}]

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -92,3 +92,17 @@ type 'a foo = 'a constraint 'a = [< `Tag of & int];;
 [%%expect{|
 type 'a foo = 'a constraint 'a = [< `Tag of & int ]
 |}]
+
+(* PR#7704 *)
+type t = private [> `A of string ];;
+function (`A x : t) -> x;;
+[%%expect{|
+type t = private [> `A of string ]
+Line _, characters 0-24:
+  function (`A x : t) -> x;;
+  ^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+`AnyExtraTag
+- : t -> string = <fun>
+|}]

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -103,6 +103,6 @@ Line _, characters 0-24:
   ^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-`AnyExtraTag
+`*any extra tag*
 - : t -> string = <fun>
 |}]

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -952,7 +952,7 @@ Line _, characters 0-41:
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-(`*any extra tag*, `*any extra tag*)
+(`<some other tag>, `<some other tag>)
 - : [> `A | `B ] * [> `A | `B ] -> int = <fun>
 Line _, characters 0-29:
   function `B,1 -> 1 | _,1 -> 2;;

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -952,7 +952,7 @@ Line _, characters 0-41:
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-(`AnyExtraTag, `AnyExtraTag)
+(`*any extra tag*, `*any extra tag*)
 - : [> `A | `B ] * [> `A | `B ] -> int = <fun>
 Line _, characters 0-29:
   function `B,1 -> 1 | _,1 -> 2;;

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -980,6 +980,8 @@ let build_other_constant proj make first next p env =
   the first column of env
 *)
 
+let any_extra_tag = "AnyExtraTag"
+
 let build_other ext env = match env with
 | ({pat_desc = Tpat_construct (lid, {cstr_tag=Cstr_extension _},_)},_) :: _ ->
         (* let c = {c with cstr_name = "*extension*"} in *) (* PR#7330 *)
@@ -1017,7 +1019,7 @@ let build_other ext env = match env with
         [] row.row_fields
     with
       [] ->
-        make_other_pat "AnyExtraTag" true
+        make_other_pat any_extra_tag true
     | pat::other_pats ->
         List.fold_left
           (fun p_res pat ->

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -980,7 +980,7 @@ let build_other_constant proj make first next p env =
   the first column of env
 *)
 
-let any_extra_tag = "AnyExtraTag"
+let any_extra_tag = "*any extra tag*"
 
 let build_other ext env = match env with
 | ({pat_desc = Tpat_construct (lid, {cstr_tag=Cstr_extension _},_)},_) :: _ ->

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -980,7 +980,7 @@ let build_other_constant proj make first next p env =
   the first column of env
 *)
 
-let any_extra_tag = "*any extra tag*"
+let some_other_tag = "<some other tag>"
 
 let build_other ext env = match env with
 | ({pat_desc = Tpat_construct (lid, {cstr_tag=Cstr_extension _},_)},_) :: _ ->
@@ -1019,7 +1019,7 @@ let build_other ext env = match env with
         [] row.row_fields
     with
       [] ->
-        make_other_pat any_extra_tag true
+        make_other_pat some_other_tag true
     | pat::other_pats ->
         List.fold_left
           (fun p_res pat ->

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -112,4 +112,4 @@ val inactive : partial:partial -> pattern -> bool
 val check_ambiguous_bindings : case list -> unit
 
 (* The tag used for open polymorphic variant types *)
-val any_extra_tag : label
+val some_other_tag : label

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -110,3 +110,6 @@ val inactive : partial:partial -> pattern -> bool
 
 (* Ambiguous bindings *)
 val check_ambiguous_bindings : case list -> unit
+
+(* The tag used for open polymorphic variant types *)
+val any_extra_tag : label

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1249,7 +1249,8 @@ and type_pat_aux ~constrs ~labels ~no_existentials ~mode ~explode ~env
                   row_more = newvar ();
                   row_fixed = false;
                   row_name = None } in
-      unify_pat_types loc !env (newty (Tvariant row)) expected_ty;
+      if constrs = None || l <> Parmatch.any_extra_tag then
+        unify_pat_types loc !env (newty (Tvariant row)) expected_ty;
       let k arg =
         rp k {
         pat_desc = Tpat_variant(l, arg, ref {row with row_more = newvar()});

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1249,7 +1249,7 @@ and type_pat_aux ~constrs ~labels ~no_existentials ~mode ~explode ~env
                   row_more = newvar ();
                   row_fixed = false;
                   row_name = None } in
-      if constrs = None || l <> Parmatch.any_extra_tag then
+      if constrs = None || l <> Parmatch.any_extra_tag || sarg <> None then
         unify_pat_types loc !env (newty (Tvariant row)) expected_ty;
       let k arg =
         rp k {

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1249,10 +1249,10 @@ and type_pat_aux ~constrs ~labels ~no_existentials ~mode ~explode ~env
                   row_more = newvar ();
                   row_fixed = false;
                   row_name = None } in
-      (* PR#7404: allow any_extra_tag blindly, as it would not unify with
+      (* PR#7404: allow some_other_tag blindly, as it would not unify with
          the abstract row variable *)
-      if constrs = None || l <> Parmatch.any_extra_tag || sarg <> None then
-        unify_pat_types loc !env (newty (Tvariant row)) expected_ty;
+      if l = Parmatch.some_other_tag then assert (constrs <> None)
+      else unify_pat_types loc !env (newty (Tvariant row)) expected_ty;
       let k arg =
         rp k {
         pat_desc = Tpat_variant(l, arg, ref {row with row_more = newvar()});

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1249,6 +1249,8 @@ and type_pat_aux ~constrs ~labels ~no_existentials ~mode ~explode ~env
                   row_more = newvar ();
                   row_fixed = false;
                   row_name = None } in
+      (* PR#7404: allow any_extra_tag blindly, as it would not unify with
+         the abstract row variable *)
       if constrs = None || l <> Parmatch.any_extra_tag || sarg <> None then
         unify_pat_types loc !env (newty (Tvariant row)) expected_ty;
       let k arg =


### PR DESCRIPTION
Fix [MPR#7704](https://caml.inria.fr/mantis/view.php?id=7704) by disabling unification for `AnyExtraTag` in check mode (i.e. calling `type_pat` from `Parmatch`)

Note that one could have used `AnyExtraTag` in her own program, but then it only means that in some very special case we would have a spurious warning, which is still sound.