### PR TITLE
Pattern matching refactoring

### DIFF
--- a/Changes
+++ b/Changes
@@ -146,7 +146,7 @@ Working version
 
 ### Internal/compiler-libs changes:
 
-- GPR#1488: Refreshing parmatch
+- GPR#1488, GPR#1560: Refreshing parmatch
   (Gabriel Scherer and Thomas Refis, review by Luc Maranget)
 
 - GPR#1502: more command line options for expect tests

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1154,9 +1154,9 @@ let rec satisfiable pss qs = match pss with
           satisfiable pss (q::qs)
     | {pat_desc = (Tpat_any | Tpat_var(_))}::qs ->
         let pss = simplify_first_col pss in
-        if not (all_coherent (first_column pss)) then (
+        if not (all_coherent (first_column pss)) then
           false
-        ) else (
+        else begin
           let q0 = discr_pat omega pss in
           match build_specialized_submatrices ~extend_row:(@) q0 pss with
           | { default; constrs = [] } ->
@@ -1171,17 +1171,17 @@ let rec satisfiable pss qs = match pss with
                   constrs
               else
                 satisfiable default qs
-        )
+        end
     | {pat_desc=Tpat_variant (l,_,r)}::_ when is_absent l r -> false
     | q::qs ->
         let pss = simplify_first_col pss in
-        if not (all_coherent (q :: first_column pss)) then (
+        if not (all_coherent (q :: first_column pss)) then
           false
-        ) else (
+        else begin
           let q0 = discr_pat q pss in
           satisfiable (build_specialized_submatrix ~extend_row:(@) q0 pss)
             (simple_match_args q0 q @ qs)
-        )
+        end
 
 (* While [satisfiable] only checks whether the last row of [pss + qs] is
    satisfiable, this function returns the (possibly empty) list of vectors [es]
@@ -1206,9 +1206,9 @@ let rec list_satisfying_vectors pss qs =
           list_satisfying_vectors pss (q::qs)
       | {pat_desc = (Tpat_any | Tpat_var(_))}::qs ->
           let pss = simplify_first_col pss in
-          if not (all_coherent (first_column pss)) then (
+          if not (all_coherent (first_column pss)) then
             []
-          ) else (
+          else begin
             let q0 = discr_pat omega pss in
             let wild default_matrix p =
               List.map (fun qs -> p::qs)
@@ -1234,26 +1234,27 @@ let rec list_satisfying_vectors pss qs =
                   )
                 in
                 if full_match false constrs then for_constrs () else
-                match p.pat_desc with
+                begin match p.pat_desc with
                 | Tpat_construct _ ->
                     (* activate this code for checking non-gadt constructors *)
                     wild default (build_other_constrs constrs p)
                     @ for_constrs ()
                 | _ ->
                     wild default omega
-          )
+                end
+          end
       | {pat_desc=Tpat_variant (l,_,r)}::_ when is_absent l r -> []
       | q::qs ->
           let pss = simplify_first_col pss in
-          if not (all_coherent (q :: first_column pss)) then (
+          if not (all_coherent (q :: first_column pss)) then
             []
-          ) else (
+          else begin
             let q0 = discr_pat q pss in
             List.map (set_args q0)
               (list_satisfying_vectors
                  (build_specialized_submatrix ~extend_row:(@) q0 pss)
                  (simple_match_args q0 q @ qs))
-          )
+          end
 
 (******************************************)
 (* Look for a row that matches some value *)
@@ -1343,7 +1344,7 @@ let rec exhaust (ext:Path.t option) pss n = match pss with
       (* We're considering an ill-typed branch, we won't actually be able to
          produce a well typed value taking that branch. *)
       No_matching_value
-    else (
+    else begin
       (* Assuming the first column is ill-typed but considered coherent, we
          might end up producing an ill-typed witness of non-exhaustivity
          corresponding to the current branch.
@@ -1392,7 +1393,7 @@ let rec exhaust (ext:Path.t option) pss n = match pss with
                 with
         (* cannot occur, since constructors don't make a full signature *)
                 | Empty -> fatal_error "Parmatch.exhaust"
-  )
+  end
 
 let exhaust ext pss n =
   let ret = exhaust ext pss n in
@@ -1427,7 +1428,7 @@ let rec pressure_variants tdefs = function
       let pss = simplify_first_col pss in
       if not (all_coherent (first_column pss)) then
         true
-      else (
+      else begin
         let q0 = discr_pat omega pss in
         match build_specialized_submatrices ~extend_row:(@) q0 pss with
         | { default; constrs = [] } -> pressure_variants tdefs default
@@ -1451,13 +1452,13 @@ let rec pressure_variants tdefs = function
               let ok =
                 if full then
                   try_non_omega constrs
-                else (
+                else begin
                   let { constrs = partial_constrs; _ } =
                     build_specialized_submatrices ~extend_row:(@) q0
                       (mark_partial pss)
                   in
                   try_non_omega partial_constrs
-                )
+                end
               in
               begin match constrs, tdefs with
                 ({pat_desc=Tpat_variant _} as p,_):: _, Some env ->
@@ -1468,7 +1469,7 @@ let rec pressure_variants tdefs = function
               | _ -> ()
               end;
               ok
-      )
+      end
 
 
 (* Yet another satisfiable function *)
@@ -1663,13 +1664,13 @@ let rec every_satisfiables pss qs = match qs.active with
            [satisfiable] *)
         if not (all_coherent (uq :: first_column pss)) then
           Unused
-        else (
+        else begin
           let q0 = discr_pat q pss in
           every_satisfiables
             (build_specialized_submatrix q0 pss
               ~extend_row:(fun ps r -> { r with active = ps @ r.active }))
             {qs with active=simple_match_args q0 q @ rem}
-        )
+        end
     end
 
 (*
@@ -2384,8 +2385,8 @@ let rec matrix_stable_vars m = match m with
         All
       else begin
         let m = simplify_first_amb_col m in
-        if not (all_coherent (first_column m))
-        then All
+        if not (all_coherent (first_column m)) then
+          All
         else begin
           (* If the column is ill-typed but deemed coherent, we might
              spuriously warn about some variables being unstable.


### PR DESCRIPTION
These are minor refactoring suggested by the ongoing work on `parmatch.ml`. I create separate PRs for those changes for ease of review.

cc @trefis 

The first commit reverts a non-standard "code-blocking" (is that a word?) style that @trefis used in #1550, with `( )` instead of `begin end` for multi-line blocks -- I have no strong opinion on which is better but grepping for `else ($` and `else begin$` shows that `typing/` uses the latter.

The second commit changes `full_match` to return `false` when given an empty list (which is semantically correct) instead of asserting false as it previously did. This allows to factorize some cases where empty and non-empty `constrs` can be handled uniformly. This point came up while writing #1552, and I will rebase #1552 if the current PR is accepted.