### PR TITLE
Pattern matching refactoring (also)

### DIFF
--- a/Changes
+++ b/Changes
@@ -83,8 +83,9 @@ Working version
   (Armaël Guéneau, with help and review from Florian Angeletti and Gabriel
   Scherer)
 
-- GPR#1552: do not warn about ambiguous variables in guards (warning 57)
-  when the ambiguous values have been filtered by a previous clause
+- GPR#1552, GPR#1561: do not warn about ambiguous variables in guards
+  (warning 57) when the ambiguous values have been filtered
+  by a previous clause
   (Gabriel Scherer and Thomas Refis, review by Luc Maranget)
 
 - GPR#1554: warnings 52 and 57: fix reference to manual detailed explanation


### PR DESCRIPTION
cc @trefis 

This change was suggested by @trefis during the review of #1552.

Sometimes we may want to refer to two different `simplify_first_col`
functions, if you manipulate two kind of rows at once -- typically,
negative and positive rows need not carry the same metadata.