### PR TITLE
MPR#7701: avoid dropping docstrings in otherwise empty files

### DIFF
--- a/Changes
+++ b/Changes
@@ -204,6 +204,10 @@ Working version
   to ill-typed columns
   (Thomas Refis, with help from Gabriel Scherer and Luc Maranget)
 
+- MPR#7701,GPR#1561: do not drop documentation comments in (otherwise) empty
+  files
+  (Florian Angeletti)
+
 - MPR#7705, GPR#1558: add missing bounds check in Bigarray.Genarray.nth_dim.
   (Nicolás Ojeda Bär, report by Jeremy Yallop, review by Gabriel Scherer)
 

--- a/Changes
+++ b/Changes
@@ -175,6 +175,10 @@ Working version
   (Tadeu Zagallo, report by Roberto Di Cosmo,
    review by Hongbo Zhang, David Allsopp, Gabriel Scherer, Xavier Leroy)
 
+- MPR#7138,GPR#1561: do not drop documentation comments in (otherwise) empty
+  files
+  (Florian Angeletti, review by Thomas Refis)
+
 - PR#7660, GPR#1445: Use native Windows API to implement Unix.utimes in order to
   avoid unintended shifts of the argument timestamp depending on DST setting.
   (Nicolás Ojeda Bär, review by David Allsopp, Xavier Leroy)
@@ -203,10 +207,6 @@ Working version
 - GPR#1550, GPR#1555: Make pattern matching warnings more robust
   to ill-typed columns
   (Thomas Refis, with help from Gabriel Scherer and Luc Maranget)
-
-- MPR#7701,GPR#1561: do not drop documentation comments in (otherwise) empty
-  files
-  (Florian Angeletti)
 
 - MPR#7705, GPR#1558: add missing bounds check in Bigarray.Genarray.nth_dim.
   (Nicolás Ojeda Bär, report by Jeremy Yallop, review by Gabriel Scherer)

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -756,7 +756,6 @@ and skip_hash_bang = parse
             set_pre_extra_docstrings pre_pos (List.rev a)
     in
     let rec loop lines docs lexbuf =
-      docs_initial_newline_state := NoLine;
       match token_with_comments lexbuf with
       | COMMENT (s, loc) ->
           add_comment (s, loc);
@@ -793,12 +792,15 @@ and skip_hash_bang = parse
               | Before(a, f, b), (NoLine | NewLine) -> Before(a, f, doc :: b)
               | Before(a, f, b), BlankLine -> Before(a, b @ f, [doc])
           in
-          loop !docs_initial_newline_state docs' lexbuf
+          loop NoLine docs' lexbuf
       | tok ->
           attach lines docs (lexeme_start_p lexbuf);
           tok
     in
-      loop !docs_initial_newline_state Initial lexbuf
+    let tok = loop !docs_initial_newline_state Initial lexbuf in
+    docs_initial_newline_state := NoLine;
+    tok
+
 
   let init () =
     is_in_string := false;

--- a/testsuite/tests/docstrings/lone_docstring.compilers.reference
+++ b/testsuite/tests/docstrings/lone_docstring.compilers.reference
@@ -1,0 +1,11 @@
+[
+  structure_item (lone_docstring.ml[5,53+0]..[7,175+3])
+    Pstr_attribute "ocaml.text"
+    [
+      structure_item (lone_docstring.ml[5,53+0]..[7,175+3])
+        Pstr_eval
+        expression (lone_docstring.ml[5,53+0]..[7,175+3])
+          Pexp_constant PConst_string(" This comment should not be droped. Beware that this test is very sensitive\n    to the presence or absence of newline.\n ",None)
+    ]
+]
+

--- a/testsuite/tests/docstrings/lone_docstring.ml
+++ b/testsuite/tests/docstrings/lone_docstring.ml
@@ -1,0 +1,7 @@
+(* TEST
+   * bytecode
+   flags += " -dparsetree "
+*)
+(** This comment should not be droped. Beware that this test is very sensitive
+    to the presence or absence of newline.
+ *)

--- a/testsuite/tests/docstrings/ocamltests
+++ b/testsuite/tests/docstrings/ocamltests
@@ -1,1 +1,2 @@
 empty.ml
+lone_docstring.ml


### PR DESCRIPTION
As stated in [MPR#7701](https://caml.inria.fr/mantis/view.php?id=7701), documentation comments in otherwise empty files can be silently dropped by the parser.

More precisely, the first documentation comment is dropped if it is not preceded by two empty lines. This happens due to the lexer trying to attach these documentation comments to the non-existing previous token.

This PR proposes to fix this issue by making the lexer considers that any documentation comment is always preceded by a blank line in the begining of a file.