### PR TITLE
byterun/interp: simplified implementation of LSRINT and ASRINT

### DIFF
--- a/Changes
+++ b/Changes
@@ -116,6 +116,9 @@ Working version
   (lib{caml,asm}run{d,i}.a)
   (Gabriel Scherer, reminded by Julia Lawall)
 
+- GPR#1563: simplify implementation of LSRINT and ASRINT
+  (Max Mouratov, review by Frédéric Bour)
+
 ### Tools:
 
 - MPR#7643, GPR#1377: ocamldep, fix an exponential blowup in presence of nested

--- a/byterun/interp.c
+++ b/byterun/interp.c
@@ -1002,10 +1002,9 @@ value caml_interprete(code_t prog, asize_t prog_size)
     Instruct(LSLINT):
       accu = (value)((((intnat) accu - 1) << Long_val(*sp++)) + 1); Next;
     Instruct(LSRINT):
-      accu = (value)((((uintnat) accu - 1) >> Long_val(*sp++)) | 1);
-      Next;
+      accu = (value)((((uintnat) accu) >> Long_val(*sp++)) | 1); Next;
     Instruct(ASRINT):
-      accu = (value)((((intnat) accu - 1) >> Long_val(*sp++)) | 1); Next;
+      accu = (value)((((intnat) accu) >> Long_val(*sp++)) | 1); Next;
 
 #define Integer_comparison(typ,opname,tst) \
     Instruct(opname): \


### PR DESCRIPTION
Clearing the tag bit of the first argument is redundant.
The formulas are now the same as in cmmgen.