### PR TITLE
Follow up to #1559 : have the name of unknown missing tag depend on the row

### DIFF
--- a/Changes
+++ b/Changes
@@ -204,6 +204,9 @@ Working version
   to ill-typed columns
   (Thomas Refis, with help from Gabriel Scherer and Luc Maranget)
 
+- MPR#7704, GPR#1564: use proper variant tag in non-exhaustiveness warning
+  (Jacques Garrigue, report by Thomas Refis)
+
 - MPR#7705, GPR#1558: add missing bounds check in Bigarray.Genarray.nth_dim.
   (Nicolás Ojeda Bär, report by Jeremy Yallop, review by Gabriel Scherer)
 

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -89,7 +89,7 @@ Line _, characters 0-41:
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-(`<some other tag>, `<some other tag>)
+(`AnyExtraTag, `AnyExtraTag)
 - : [> `A | `B ] * [> `A | `B ] -> int = <fun>
 Line _, characters 0-29:
   function `B,1 -> 1 | _,1 -> 2;;
@@ -154,6 +154,17 @@ Line _, characters 0-24:
   ^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-`<some other tag>
+`<some private tag>
 - : t -> string = <fun>
+|}]
+
+let f = function `AnyExtraTag, _ -> 1 | _, (`AnyExtraTag|`AnyExtraTag') -> 2;;
+[%%expect{|
+Line _, characters 8-76:
+  let f = function `AnyExtraTag, _ -> 1 | _, (`AnyExtraTag|`AnyExtraTag') -> 2;;
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(`AnyExtraTag', `AnyExtraTag'')
+val f : [> `AnyExtraTag ] * [> `AnyExtraTag | `AnyExtraTag' ] -> int = <fun>
 |}]

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -89,7 +89,7 @@ Line _, characters 0-41:
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-(`AnyExtraTag, `AnyExtraTag)
+(`AnyOtherTag, `AnyOtherTag)
 - : [> `A | `B ] * [> `A | `B ] -> int = <fun>
 Line _, characters 0-29:
   function `B,1 -> 1 | _,1 -> 2;;
@@ -158,13 +158,13 @@ Here is an example of a case that is not matched:
 - : t -> string = <fun>
 |}]
 
-let f = function `AnyExtraTag, _ -> 1 | _, (`AnyExtraTag|`AnyExtraTag') -> 2;;
+let f = function `AnyOtherTag, _ -> 1 | _, (`AnyOtherTag|`AnyOtherTag') -> 2;;
 [%%expect{|
 Line _, characters 8-76:
-  let f = function `AnyExtraTag, _ -> 1 | _, (`AnyExtraTag|`AnyExtraTag') -> 2;;
+  let f = function `AnyOtherTag, _ -> 1 | _, (`AnyOtherTag|`AnyOtherTag') -> 2;;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
-(`AnyExtraTag', `AnyExtraTag'')
-val f : [> `AnyExtraTag ] * [> `AnyExtraTag | `AnyExtraTag' ] -> int = <fun>
+(`AnyOtherTag', `AnyOtherTag'')
+val f : [> `AnyOtherTag ] * [> `AnyOtherTag | `AnyOtherTag' ] -> int = <fun>
 |}]

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -64,6 +64,57 @@ Error: This pattern matches values of type [? `C ]
        The second variant type does not allow tag(s) `C
 |}];;
 
+(* imported from in poly.ml *)
+type t = A | B;;
+function `A,_ -> 1 | _,A -> 2 | _,B -> 3;;
+function `A,_ -> 1 | _,(A|B) -> 2;;
+function Some `A, _ -> 1 | Some _, A -> 2 | None, A -> 3 | _, B -> 4;;
+function Some `A, A -> 1 | Some `A, B -> 1
+       | Some _, A -> 2  | None, A -> 3 | _, B -> 4;;
+function A, `A -> 1 | A, `B -> 2 | B, _ -> 3;;
+function `A, A -> 1 | `B, A -> 2 | _, B -> 3;;
+function (`A|`B), _ -> 0 | _,(`A|`B) -> 1;;
+function `B,1 -> 1 | _,1 -> 2;;
+function 1,`B -> 1 | 1,_ -> 2;;
+[%%expect {|
+type t = A | B
+- : [> `A ] * t -> int = <fun>
+- : [> `A ] * t -> int = <fun>
+- : [> `A ] option * t -> int = <fun>
+- : [> `A ] option * t -> int = <fun>
+- : t * [< `A | `B ] -> int = <fun>
+- : [< `A | `B ] * t -> int = <fun>
+Line _, characters 0-41:
+  function (`A|`B), _ -> 0 | _,(`A|`B) -> 1;;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(`<some other tag>, `<some other tag>)
+- : [> `A | `B ] * [> `A | `B ] -> int = <fun>
+Line _, characters 0-29:
+  function `B,1 -> 1 | _,1 -> 2;;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(_, 0)
+Line _, characters 21-24:
+  function `B,1 -> 1 | _,1 -> 2;;
+                       ^^^
+Warning 11: this match case is unused.
+- : [< `B ] * int -> int = <fun>
+Line _, characters 0-29:
+  function 1,`B -> 1 | 1,_ -> 2;;
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+(0, _)
+Line _, characters 21-24:
+  function 1,`B -> 1 | 1,_ -> 2;;
+                       ^^^
+Warning 11: this match case is unused.
+- : int * [< `B ] -> int = <fun>
+|}];;
+
 (* PR#6787 *)
 let revapply x f = f x;;
 

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -926,58 +926,6 @@ type 'a t = < a : 'a >
 type u = 'a t as 'a
 |}];;
 
-
-(* Variant tests *)
-type t = A | B;;
-function `A,_ -> 1 | _,A -> 2 | _,B -> 3;;
-function `A,_ -> 1 | _,(A|B) -> 2;;
-function Some `A, _ -> 1 | Some _, A -> 2 | None, A -> 3 | _, B -> 4;;
-function Some `A, A -> 1 | Some `A, B -> 1
-       | Some _, A -> 2  | None, A -> 3 | _, B -> 4;;
-function A, `A -> 1 | A, `B -> 2 | B, _ -> 3;;
-function `A, A -> 1 | `B, A -> 2 | _, B -> 3;;
-function (`A|`B), _ -> 0 | _,(`A|`B) -> 1;;
-function `B,1 -> 1 | _,1 -> 2;;
-function 1,`B -> 1 | 1,_ -> 2;;
-[%%expect {|
-type t = A | B
-- : [> `A ] * t -> int = <fun>
-- : [> `A ] * t -> int = <fun>
-- : [> `A ] option * t -> int = <fun>
-- : [> `A ] option * t -> int = <fun>
-- : t * [< `A | `B ] -> int = <fun>
-- : [< `A | `B ] * t -> int = <fun>
-Line _, characters 0-41:
-  function (`A|`B), _ -> 0 | _,(`A|`B) -> 1;;
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(`<some other tag>, `<some other tag>)
-- : [> `A | `B ] * [> `A | `B ] -> int = <fun>
-Line _, characters 0-29:
-  function `B,1 -> 1 | _,1 -> 2;;
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(_, 0)
-Line _, characters 21-24:
-  function `B,1 -> 1 | _,1 -> 2;;
-                       ^^^
-Warning 11: this match case is unused.
-- : [< `B ] * int -> int = <fun>
-Line _, characters 0-29:
-  function 1,`B -> 1 | 1,_ -> 2;;
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-(0, _)
-Line _, characters 21-24:
-  function 1,`B -> 1 | 1,_ -> 2;;
-                       ^^^
-Warning 11: this match case is unused.
-- : int * [< `B ] -> int = <fun>
-|}];;
-
 (* pass typetexp, but fails during Typedecl.check_recursion *)
 type ('a, 'b) a = 'a -> unit constraint 'a = [> `B of ('a, 'b) b as 'b]
 and  ('a, 'b) b = 'b -> unit constraint 'b = [> `A of ('a, 'b) a as 'a];;

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -980,7 +980,7 @@ let build_other_constant proj make first next p env =
   the first column of env
 *)
 
-let some_other_tag = "<some other tag>"
+let some_private_tag = "<some private tag>"
 
 let build_other ext env = match env with
 | ({pat_desc = Tpat_construct (lid, {cstr_tag=Cstr_extension _},_)},_) :: _ ->
@@ -1019,7 +1019,9 @@ let build_other ext env = match env with
         [] row.row_fields
     with
       [] ->
-        make_other_pat some_other_tag true
+        let tag =
+          if Btype.row_fixed row then some_private_tag else "<any extra tag>"
+        in make_other_pat tag true
     | pat::other_pats ->
         List.fold_left
           (fun p_res pat ->

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1023,7 +1023,7 @@ let build_other ext env = match env with
           if Btype.row_fixed row then some_private_tag else
           let rec mktag tag =
             if List.mem tag tags then mktag (tag ^ "'") else tag in
-          mktag "AnyExtraTag"
+          mktag "AnyOtherTag"
         in make_other_pat tag true
     | pat::other_pats ->
         List.fold_left

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1020,7 +1020,10 @@ let build_other ext env = match env with
     with
       [] ->
         let tag =
-          if Btype.row_fixed row then some_private_tag else "<any extra tag>"
+          if Btype.row_fixed row then some_private_tag else
+          let rec mktag tag =
+            if List.mem tag tags then mktag (tag ^ "'") else tag in
+          mktag "AnyExtraTag"
         in make_other_pat tag true
     | pat::other_pats ->
         List.fold_left

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -111,5 +111,5 @@ val inactive : partial:partial -> pattern -> bool
 (* Ambiguous bindings *)
 val check_ambiguous_bindings : case list -> unit
 
-(* The tag used for open polymorphic variant types *)
-val some_other_tag : label
+(* The tag used for open polymorphic variant types with an abstract row *)
+val some_private_tag : label

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1249,9 +1249,9 @@ and type_pat_aux ~constrs ~labels ~no_existentials ~mode ~explode ~env
                   row_more = newvar ();
                   row_fixed = false;
                   row_name = None } in
-      (* PR#7404: allow some_other_tag blindly, as it would not unify with
+      (* PR#7404: allow some_private_tag blindly, as it would not unify with
          the abstract row variable *)
-      if l = Parmatch.some_other_tag then assert (constrs <> None)
+      if l = Parmatch.some_private_tag then assert (constrs <> None)
       else unify_pat_types loc !env (newty (Tvariant row)) expected_ty;
       let k arg =
         rp k {


### PR DESCRIPTION
GPR #1559 fixed a soundness issue in exhaustiveness, but didn't try much to improve the warning.
This PR goes further by using a different name depending on the cause of non-exhaustiveness.
