### PR TITLE
tentative fix for letrec check error (MPR#7706)

### DIFF
--- a/Changes
+++ b/Changes
@@ -21,7 +21,12 @@ Working version
 - MPR#7611, GPR#1491: reject the use of generative functors as applicative
   (Valentin Gatien-Baron)
 
-- MPR#7717, GPR#1593: don't treat unboxed constructor size as statically known
+- MPR#7706, GPR#1565: in recursive value declarations, track
+  static size of locally-defined variables
+  (Gabriel Scherer, review by Jeremy Yallop and Leo White, report by Leo White)
+
+- MPR#7717, GPR#1593: in recursive value declarations, don't treat
+  unboxed constructor size as statically known
   (Jeremy Yallop, report by Pierre Chambart, review by Gabriel Scherer)
 
 - GPR#1469: Use the information from [@@immediate] annotations when

--- a/testsuite/tests/letrec-disallowed/ocamltests
+++ b/testsuite/tests/letrec-disallowed/ocamltests
@@ -7,4 +7,5 @@ lazy_.ml
 module_constraints.ml
 pr7215.ml
 pr7231.ml
+pr7706.ml
 unboxed.ml

--- a/testsuite/tests/letrec-disallowed/pr7706.ml
+++ b/testsuite/tests/letrec-disallowed/pr7706.ml
@@ -1,0 +1,8 @@
+(* TEST
+   * toplevel
+*)
+let rec x =
+  let y = if false then (fun z -> 1) else (fun z -> x 4 + 1) in
+  y;;
+
+let () = ignore (x 42);;

--- a/testsuite/tests/letrec-disallowed/pr7706.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/pr7706.ocaml.reference
@@ -1,0 +1,9 @@
+Characters 39-104:
+  ..let y = if false then (fun z -> 1) else (fun z -> x 4 + 1) in
+    y..
+Error: This kind of expression is not allowed as right-hand side of `let rec'
+Characters 18-19:
+  let () = ignore (x 42);;
+                   ^
+Error: Unbound value x
+

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1927,14 +1927,26 @@ struct
       | Texp_let (_, _, e)
       | Texp_letmodule (_, _, _, e)
       | Texp_sequence (_, e)
-      | Texp_letexception (_, e) -> classify_expression e
+      | Texp_letexception (_, e) ->
+          classify_expression e
+
       | Texp_construct (_, {cstr_tag = Cstr_unboxed}, [e]) ->
           classify_expression e
-      | Texp_construct _ -> Static
+      | Texp_construct _ ->
+          Static
+
       | Texp_record { representation = Record_unboxed _;
                       fields = [| _, Overridden (_,e) |] } ->
           classify_expression e
-      | Texp_record _ -> Static
+      | Texp_record _ ->
+          Static
+
+      | Texp_apply ({exp_desc = Texp_ident (_, _, vd)}, _)
+        when is_ref vd ->
+          Static
+      | Texp_apply _ ->
+          Dynamic
+
       | Texp_ident _
       | Texp_for _
       | Texp_constant _
@@ -1951,17 +1963,17 @@ struct
       | Texp_function _
       | Texp_lazy _
       | Texp_unreachable
-      | Texp_extension_constructor _ -> Static
-      | Texp_apply ({exp_desc = Texp_ident (_, _, vd)}, _)
-        when is_ref vd -> Static
-      | Texp_apply _
+      | Texp_extension_constructor _ ->
+          Static
+
       | Texp_match _
       | Texp_ifthenelse _
       | Texp_send _
       | Texp_field _
       | Texp_assert _
       | Texp_try _
-      | Texp_override _ -> Dynamic
+      | Texp_override _ ->
+          Dynamic
 
   let rec expression : Env.env -> Typedtree.expression -> Use.t =
     fun env exp -> match exp.exp_desc with


### PR DESCRIPTION
See [MPR#7706](https://caml.inria.fr/mantis/view.php?id=7706), this definition is unsafe and must be rejected (but is currently accepted):

```ocaml
 let rec x =
    let y = if false then (fun z -> 1) else (fun z -> x 4 + 1) in
    y
```

The typechecker-level check for recursive value depends on whether
recursive values use a memory size that is statically known or depends
on their dynamic evaluation. An error in this check results in
a potential segfault.

The error is that the check currently considers variables/identifiable
to have a statically-known size. This is certainly wrong for
locally-defined identifiers (that may be bound to
dynamically-sized expressions), but it is not even clear why that
would be desirable for other expressions of the nested letrec, or for
variables from the context.

This patch considers all identifiers to have dynamic size.