### PR TITLE
stdlib: add Pervasives.int_size

### DIFF
--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -242,9 +242,9 @@ external ( @@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
 
 (** {1 Integer arithmetic} *)
 
-(** Integers are 31 bits wide (or 63 bits on 64-bit processors).
-   All operations are taken modulo 2{^31} (or 2{^63}).
-   They do not fail on overflow. *)
+(** Integers are [Sys.int_size] bits wide.
+    All operations are taken modulo 2{^[Sys.int_size]}.
+    They do not fail on overflow. *)
 
 external ( ~- ) : int -> int = "%negint"
 (** Unary negation. You can also write [- e] instead of [~- e].
@@ -325,23 +325,21 @@ val lnot : int -> int
 
 external ( lsl ) : int -> int -> int = "%lslint"
 (** [n lsl m] shifts [n] to the left by [m] bits.
-   The result is unspecified if [m < 0] or [m >= bitsize],
-   where [bitsize] is [32] on a 32-bit platform and
-   [64] on a 64-bit platform.
-   Right-associative operator at precedence level 8/11. *)
+    The result is unspecified if [m < 0] or [m > Sys.int_size].
+    Right-associative operator at precedence level 8/11. *)
 
 external ( lsr ) : int -> int -> int = "%lsrint"
 (** [n lsr m] shifts [n] to the right by [m] bits.
-   This is a logical shift: zeroes are inserted regardless of
-   the sign of [n].
-   The result is unspecified if [m < 0] or [m >= bitsize].
-   Right-associative operator at precedence level 8/11. *)
+    This is a logical shift: zeroes are inserted regardless of
+    the sign of [n].
+    The result is unspecified if [m < 0] or [m > Sys.int_size].
+    Right-associative operator at precedence level 8/11. *)
 
 external ( asr ) : int -> int -> int = "%asrint"
 (** [n asr m] shifts [n] to the right by [m] bits.
-   This is an arithmetic shift: the sign bit of [n] is replicated.
-   The result is unspecified if [m < 0] or [m >= bitsize].
-   Right-associative operator at precedence level 8/11. *)
+    This is an arithmetic shift: the sign bit of [n] is replicated.
+    The result is unspecified if [m < 0] or [m > Sys.int_size].
+    Right-associative operator at precedence level 8/11. *)
 
 
 (** {1 Floating-point arithmetic}

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -129,13 +129,12 @@ val cygwin : bool
 
 val word_size : int
 (** Size of one word on the machine currently executing the OCaml
-   program, in bits: 32 or 64. *)
+    program, in bits: 32 or 64. *)
 
 val int_size : int
-(** Size of an int.  It is 31 bits (resp. 63 bits) when using the
-    OCaml compiler on a 32 bits (resp. 64 bits) platform.  It may
-    differ for other compilers, e.g. it is 32 bits when compiling to
-    JavaScript.
+(** Size of [int], in bits. It is 31 (resp. 63) when using OCaml on a
+    32-bit (resp. 64-bit) platform. It may differ for other implementations,
+    e.g. it can be 32 bits when compiling to JavaScript.
     @since 4.03.0 *)
 
 val big_endian : bool


### PR DESCRIPTION
Integer size is an important part of arithmetic specification, so it makes sense to have it in Pervasives, for the purpose of improving documentation.

Now, the docstrings for `lsl`, `lsr`, and `asr` are compatible with Js_of_ocaml.