### PR TITLE
emitcode: merge events after instructions reordering

### DIFF
--- a/Changes
+++ b/Changes
@@ -197,6 +197,10 @@ Working version
 - GPR#1520: more robust implementation of Misc.no_overflow_mul
   (Max Mouratov, review by Xavier Leroy)
 
+- GPR#1573: emitcode: merge events after instructions reordering
+  (Thomas Refis and Leo White, with help from David Allsopp, review by Frédéric
+  Bour)
+
 - GPR#1586: testsuite: 'make promote' for ocamltest tests
   (The new "-promote" option for ocamltest is experimental
   and subject to change/removal).

--- a/bytecomp/bytegen.mli
+++ b/bytecomp/bytegen.mli
@@ -21,3 +21,5 @@ open Instruct
 val compile_implementation: string -> lambda -> instruction list
 val compile_phrase: lambda -> instruction list * instruction list
 val reset: unit -> unit
+
+val merge_events : Instruct.debug_event -> Instruct.debug_event -> Instruct.debug_event


### PR DESCRIPTION
Because of some "peephole optimizations" done in `Emitcode` we can sometimes end-up with two debug events at the same position.
Consider for example `test.ml`:
```ocaml
let run f =
  try f ()
  with exn ->
    match exn with
    | x -> (* disable reraise *)
      raise x

let () =
  run (fun () -> raise Exit)
```
If we look at the `.cmo` currently being generated, we get:
```
## start of ocaml dump of "test.cmo"
       0  BRANCH 13
File "test.ml", line 2, characters 2-90:
       2  PUSHTRAP 10
       4  CONST0
       5  PUSHACC5
       6  APPLY1
File "test.ml", line 2, characters 6-10:
       7  POPTRAP
       8  RETURN 1
      10  PUSHACC0
File "test.ml", line 4, characters 4-65:
      11  PUSHACC0
File "test.ml", line 6, characters 6-13:
File "test.ml", line 6, characters 12-13:
      12  RAISE
      13  CLOSURE 0, 2
      16  PUSH
File "_none_", line 1, characters -1--1:
      17  ACC0
      18  MAKEBLOCK1 0
      20  POP 1
      22  SETGLOBAL Test
## end of ocaml dump of "test.cmo"
```
When I run that bytecode executable on my linux machine, I get the following
```
$ ./a.out
Fatal error: exception Pervasives.Exit
Raised at file "test.ml", line 6, characters 6-13
Called from file "test.ml", line 9, characters 2-28
```
But when @dra27 runs it on his windows (mingw?) machine, he gets:
```
Fatal error: exception Pervasives.Exit
Raised at file "test.ml", line 6, characters 12-13
Called from file "test.ml", line 9, characters 2-28
```

Which is consistent with what we observe on #1567 (that is: the appveyor failure).

I'm guessing that's because of the call to `qsort` in `process_debug_events` in `byterun/backtrace_prim.c`, and that a stable sort would make this discrepancy disappear.

As I was not in the mood to write any C code, I instead chose to change `Emitcode` so it doesn't emit two events at the same position.
That is, after this PR `test.cmo` looks like this:
```
## start of ocaml dump of "test.cmo"
       0  BRANCH 13
File "test.ml", line 2, characters 2-90:
       2  PUSHTRAP 10
       4  CONST0
       5  PUSHACC5
       6  APPLY1
File "test.ml", line 2, characters 6-10:
       7  POPTRAP
       8  RETURN 1
      10  PUSHACC0
File "test.ml", line 4, characters 4-65:
      11  PUSHACC0
File "test.ml", line 6, characters 12-13:
      12  RAISE
      13  CLOSURE 0, 2
      16  PUSH
File "_none_", line 1, characters -1--1:
      17  ACC0
      18  MAKEBLOCK1 0
      20  POP 1
      22  SETGLOBAL Test
## end of ocaml dump of "test.cmo"
```

Which will result in consistent backtraces between linux and windows.

--- 

Questions / remarks:

- I am not adding a new test in the testsuite because I'm hoping for #1567 to get merged, and it does contain a test for this.
- why are the optimizations done in emitcode and not bytegen? Before calling `tools/dumpobj` I was actually looking at the output of `-dinstr` which happens before the optimizations, it made me sad.
- in `byterun/backtrace_prim.c` there is a comment saying "ocamlc sometimes moves an event past a following PUSH instruction; ...". Could that be related to this? (or this to that)