### PR TITLE
Fix in testsuite: `make one DIR=` and `make parallel`

### DIFF
--- a/Changes
+++ b/Changes
@@ -233,7 +233,8 @@ Working version
 - MPR#7712, GPR#1576: assertion failure with type abbreviations
   (Thomas Refis, report by Michael O'Connor, review by Jacques Garrigue)
 
-- GPR#1530, GPR#1574: testsuite, fix 'make parallel' target
+- GPR#1530, GPR#1574: testsuite, fix 'make parallel' and 'make one DIR=...'
+  to work on ocamltest-based tests.
   (Runhang Li and Sébastien Hinderer, review by Gabriel Scherer)
 
 4.06 maintenance branch

--- a/Changes
+++ b/Changes
@@ -233,6 +233,9 @@ Working version
 - MPR#7712, GPR#1576: assertion failure with type abbreviations
   (Thomas Refis, report by Michael O'Connor, review by Jacques Garrigue)
 
+- GPR#1530, GPR#1574: testsuite, fix 'make parallel' target
+  (Runhang Li and Sébastien Hinderer, review by Gabriel Scherer)
+
 4.06 maintenance branch
 -----------------------
 

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -204,7 +204,7 @@ exec-one:
 	  echo "Running tests from '$$DIR' ..."; \
 	  file=$(DIR)/ocamltests; \
 	  (IFS=$$(printf "\r\n"); while read testfile; do \
-		  TERM=dumb \
+		  TERM=dumb OCAMLTESTDIR=$(BASEDIR)/$(DIR)/_ocamltest \
 		    $(ocamltest) $(DIR)/$$testfile || \
 		    touch $(failstamp); \
 	  done < $$file) || touch $(failstamp); \

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -88,7 +88,7 @@ legacy:
 .PHONY: legacy-without-report
 legacy-without-report: lib tools
 	@for dir in tests/*; do \
-	  $(MAKE) $(NO_PRINT) exec-one DIR=$$dir; \
+	  $(MAKE) $(NO_PRINT) exec-one DIR=$$dir LEGACY=y; \
 	done 2>&1 | tee -a _log
 	@$(MAKE) $(NO_PRINT) retries
 
@@ -200,6 +200,14 @@ exec-one:
 	  echo "Running tests from '$$DIR' ..."; \
 	  cd $(DIR) && \
 	  $(MAKE) TERM=dumb BASEDIR=$(BASEDIR) || echo '=> unexpected error'; \
+	elif [ -f $(DIR)/ocamltests ] && [ -z $(LEGACY) ] ; then \
+	  echo "Running tests from '$$DIR' ..."; \
+	  file=$(DIR)/ocamltests; \
+	  (IFS=$$(printf "\r\n"); while read testfile; do \
+		  TERM=dumb \
+		    $(ocamltest) $(DIR)/$$testfile || \
+		    touch $(failstamp); \
+	  done < $$file) || touch $(failstamp); \
 	fi
 
 .PHONY: clean-one


### PR DESCRIPTION
Problem: `make one DIR=...` and `make parallel` no longer work on trunk

Solution: patch `testsuite/Makefile`

Test:
* `make one DIR=...`
   `make one DIR=tests/typing-modules` works now
* `make parallel`
    End of output of `make parallel`: 940 tests considered
    End of output of `make all`: 940 tests considered

