### PR TITLE
forget_abbrev: do not assert when no abbrevs

### DIFF
--- a/Changes
+++ b/Changes
@@ -225,6 +225,9 @@ Working version
 - MPR#7705, GPR#1558: add missing bounds check in Bigarray.Genarray.nth_dim.
   (Nicolás Ojeda Bär, report by Jeremy Yallop, review by Gabriel Scherer)
 
+- MPR#7712, GPR#1576: assertion failure with type abbreviations
+  (Thomas Refis, report by Michael O'Connor, review by Jacques Garrigue)
+
 4.06 maintenance branch
 -----------------------
 

--- a/testsuite/tests/typing-misc/pr7712.ml
+++ b/testsuite/tests/typing-misc/pr7712.ml
@@ -1,0 +1,20 @@
+(* TEST
+   * expect
+*)
+
+type 'a or_error = string
+
+type ('a, 'b) t_ =
+  | Bar : ('a, 'a or_error) t_
+
+type 'a t = ('a, 'a) t_
+
+let f : type a. a t -> a t = function
+  | Bar -> Bar
+;;
+[%%expect{|
+type 'a or_error = string
+type ('a, 'b) t_ = Bar : ('a, 'a or_error) t_
+type 'a t = ('a, 'a) t_
+val f : 'a t -> 'a t = <fun>
+|}];;

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -582,7 +582,7 @@ let memorize_abbrev mem priv path v v' =
 let rec forget_abbrev_rec mem path =
   match mem with
     Mnil ->
-      assert false
+      mem
   | Mcons (_, path', _, _, rem) when Path.same path path' ->
       rem
   | Mcons (priv, path', v, v', rem) ->


### PR DESCRIPTION
The story behind [MPR#7712](https://caml.inria.fr/mantis/view.php?id=7712) seems to be that at the very end of `unify3` if `create_recursion` is true, then we always expect `p` to have some abbrevs.
But in this particular case we've called `add_gadt_equation p t2'` a few lines above, which calls `cleanup_abbrev`.

A simple fix seems to have `forget_abbrev` be happy to just do nothing when there are no abbrevs.
As this is the only place where `forget_abbrev` is called, this seems safe to do.