### PR TITLE
MPR#7710: ocamldep -sort: treat cyclic dependencies as an error

### DIFF
--- a/Changes
+++ b/Changes
@@ -148,6 +148,10 @@ Working version
   structures and signatures (e.g. "include struct … include(struct … end) … end")
   (Florian Angeletti, review by Gabriel Scherer, report by Christophe Raffalli)
 
+- MPR#7710: `ocamldep -sort` should exit with nonzero code in case of
+  cyclic dependencies
+  (Xavier Leroy, report by Mantis user baileyparker)
+
 - GPR#1585: optimize output of "ocamllex -ml"
   (Alain Frisch, review by Frédéric Bour and Gabriel Scherer)
 

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -464,7 +464,7 @@ let sort_files_by_dependencies files =
 
   if !worklist <> [] then begin
     Format.fprintf Format.err_formatter
-      "@[Warning: cycle in dependencies. End of list is not sorted.@]@.";
+      "@[Error: cycle in dependencies. End of list is not sorted.@]@.";
     let sorted_deps =
       let li = ref [] in
       Hashtbl.iter (fun _ file_deps -> li := file_deps :: !li) h;
@@ -478,6 +478,7 @@ let sort_files_by_dependencies files =
       ) !deps;
       Format.fprintf Format.err_formatter "@]@.";
       Printf.printf "%s " file) sorted_deps;
+    error_occurred := true
   end;
   Printf.printf "\n%!";
   ()


### PR DESCRIPTION
Before, cyclic dependencies were reported as a warning, and ocamldep -sort would exit with code 0.
Now, the message says "error" and the exit code is nonzero.

The original behavior might have been intended as a "Hail Mary", i.e. "produce some ordering and with much luck it will pass linking", taking advantage of the fact that not all dependencies spotted by ocamldep are linking dependencies.  I don't think this should be relied on.
