### PR TITLE
Fix MPR#7711 (constraint hides object fields and causes assertion)

### DIFF
--- a/Changes
+++ b/Changes
@@ -207,7 +207,7 @@ Working version
 - MPR#7702, GPR#1553: refresh raise counts when inlining a function
   (Vincent Laviron, Xavier Clerc, report by Cheng Sun)
 
-- MPR#7711: Internal typechecker error triggered by a constraint on
+- MPR#7711, GPR#1581: Internal typechecker error triggered by a constraint on
    self type in a class type
   (Jacques Garrigue, report by Florian Angeletti)
 

--- a/Changes
+++ b/Changes
@@ -209,7 +209,7 @@ Working version
 
 - MPR#7711, GPR#1581: Internal typechecker error triggered by a constraint on
    self type in a class type
-  (Jacques Garrigue, report by Florian Angeletti)
+  (Jacques Garrigue, report and review by Florian Angeletti)
 
 - GPR#1517: More robust handling of type variables in mcomp
   (Leo White and Thomas Refis, review by Jacques Garrigue)

--- a/Changes
+++ b/Changes
@@ -207,6 +207,10 @@ Working version
 - MPR#7702, GPR#1553: refresh raise counts when inlining a function
   (Vincent Laviron, Xavier Clerc, report by Cheng Sun)
 
+- MPR#7711: Internal typechecker error triggered by a constraint on
+   self type in a class type
+  (Jacques Garrigue, report by Florian Angeletti)
+
 - GPR#1517: More robust handling of type variables in mcomp
   (Leo White and Thomas Refis, review by Jacques Garrigue)
 

--- a/testsuite/tests/typing-objects/pr7711_ok.compilers.reference
+++ b/testsuite/tests/typing-objects/pr7711_ok.compilers.reference
@@ -1,0 +1,3 @@
+type 'a r = 'a constraint 'a = < w : int -> int; .. >
+class type virtual ct = object method virtual w : int -> int end
+

--- a/testsuite/tests/typing-objects/pr7711_ok.ml
+++ b/testsuite/tests/typing-objects/pr7711_ok.ml
@@ -1,0 +1,9 @@
+(* TEST
+   * toplevel
+*)
+
+type 'a r = <w: int -> int; .. > as 'a;;
+
+class type virtual ct = object('self)
+  constraint 'self = 'not_self r
+end;;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -291,6 +291,11 @@ let associate_fields fields1 fields2 =
   in
   associate [] [] [] (fields1, fields2)
 
+let is_self_type = function
+  | Tobject (ty, _) ->
+      List.exists (fun (m,_,_) -> m = dummy_method) (fst (flatten_fields ty))
+  | _ -> false
+
 (**** Check whether an object is open ****)
 
 (* +++ The abbreviation should eventually be expanded *)
@@ -310,6 +315,7 @@ let concrete_object ty =
   match (object_row ty).desc with
   | Tvar _             -> false
   | _                  -> true
+
 
 (**** Close an object ****)
 
@@ -2437,7 +2443,9 @@ and unify3 env t1 t1' t2 t2' =
     begin match !umode with
     | Expression ->
         occur !env t1' t2';
-        link_type t1' t2
+        if is_self_type d1
+        then link_type t1' t2' (* PR#7711 *)
+        else link_type t1' t2
     | Pattern ->
         add_type_equality t1' t2'
     end;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -291,9 +291,14 @@ let associate_fields fields1 fields2 =
   in
   associate [] [] [] (fields1, fields2)
 
+let rec has_dummy_method ty =
+  match repr ty with
+    {desc = Tfield (m, _, _, ty2)} ->
+      m = dummy_method || has_dummy_method ty2
+  | _ -> false
+
 let is_self_type = function
-  | Tobject (ty, _) ->
-      List.exists (fun (m,_,_) -> m = dummy_method) (fst (flatten_fields ty))
+  | Tobject (ty, _) -> has_dummy_method ty
   | _ -> false
 
 (**** Check whether an object is open ****)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -316,7 +316,6 @@ let concrete_object ty =
   | Tvar _             -> false
   | _                  -> true
 
-
 (**** Close an object ****)
 
 let close_object ty =
@@ -2443,8 +2442,8 @@ and unify3 env t1 t1' t2 t2' =
     begin match !umode with
     | Expression ->
         occur !env t1' t2';
-        if is_self_type d1
-        then link_type t1' t2' (* PR#7711 *)
+        if is_self_type d1 (* PR#7711: do not abbreviate self type *)
+        then link_type t1' t2' 
         else link_type t1' t2
     | Pattern ->
         add_type_equality t1' t2'


### PR DESCRIPTION
Fix [MPR#7711](https://caml.inria.fr/mantis/view.php?id=7711) by checking whether we are updating the self type in `Ctype.unify3`.