### PR TITLE
type_cases: propagate refined ty_arg to Parmatch checks

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,6 +23,9 @@ Working version
   when configured with -no-flat-float-array
   (Jeremy Yallop, report by Gabriel Scherer)
 
+- GPR#1583: propagate refined ty_arg to Parmatch checks
+  (Thomas Refis, review by Jacques Garrigue)
+
 ### Standard library:
 
 - MPR#7690, GPR#1528: fix the float_of_string function for hexadecimal floats

--- a/testsuite/tests/typing-warnings/inside_out.ml
+++ b/testsuite/tests/typing-warnings/inside_out.ml
@@ -1,0 +1,169 @@
+(* TEST
+   * expect
+*)
+
+type ('a, 'b) eq = Refl : ('a, 'a) eq
+
+type empty = (int, string) eq
+
+type ('a, 'b) t = Left : 'a -> ('a, 'b) t | Right : 'b -> ('a, 'b) t;;
+
+[%%expect{|
+type ('a, 'b) eq = Refl : ('a, 'a) eq
+type empty = (int, string) eq
+type ('a, 'b) t = Left : 'a -> ('a, 'b) t | Right : 'b -> ('a, 'b) t
+|}]
+
+let f1 x =
+  match x with
+  | (None : empty option) -> ()
+;;
+[%%expect {|
+val f1 : empty option -> unit = <fun>
+|}]
+
+let f2 () =
+  match None with
+  | (None : empty option) -> ()
+;;
+[%%expect {|
+Line _, characters 2-49:
+  ..match None with
+    | (None : empty option) -> ()
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Some _
+val f2 : unit -> unit = <fun>
+|}]
+
+let f3 () =
+  let x = None in
+  match x with
+  | (None : empty option) -> ()
+;;
+[%%expect {|
+Line _, characters 2-46:
+  ..match x with
+    | (None : empty option) -> ()
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Some _
+val f3 : unit -> unit = <fun>
+|}]
+
+let f1' x =
+  match x with
+  | (None : empty option) -> ()
+  | Some _ -> .
+;;
+[%%expect {|
+val f1' : empty option -> unit = <fun>
+|}]
+
+let f2' () =
+  match None with
+  | (None : empty option) -> ()
+  | Some _ -> .
+;;
+[%%expect {|
+Line _, characters 4-10:
+    | Some _ -> .
+      ^^^^^^
+Error: This match case could not be refuted.
+       Here is an example of a value that would reach it: Some _
+|}]
+
+let f3' () =
+  let x = None in
+  match x with
+  | (None : empty option) -> ()
+  | Some _ -> .
+;;
+[%%expect {|
+Line _, characters 4-10:
+    | Some _ -> .
+      ^^^^^^
+Error: This match case could not be refuted.
+       Here is an example of a value that would reach it: Some _
+|}]
+
+
+(* no warning *)
+
+let (Left () : (unit, empty) t) = Left ();;
+[%%expect {|
+|}]
+
+let f () =
+  let Left () = (Left () : (unit, empty) t) in
+  ()
+;;
+[%%expect {|
+val f : unit -> unit = <fun>
+|}]
+
+(* warning *)
+
+let f () =
+  let (Left () : (unit, empty) t) = Left () in
+  ()
+;;
+[%%expect{|
+Line _, characters 2-51:
+  ..let (Left () : (unit, empty) t) = Left () in
+    ()
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Right _
+val f : unit -> unit = <fun>
+|}]
+
+(* no warning *)
+
+let f () =
+  match (Left () : (unit, empty) t) with
+  | Left () -> ()
+;;
+[%%expect {|
+val f : unit -> unit = <fun>
+|}]
+
+let f () =
+  match (Left () : (unit, empty) t) with
+  | Left () -> ()
+  | Right _ -> .
+;;
+[%%expect {|
+val f : unit -> unit = <fun>
+|}]
+
+(* warning *)
+
+let f () =
+  match Left () with
+  | (Left () : (unit, empty) t) -> ()
+;;
+[%%expect {|
+Line _, characters 2-58:
+  ..match Left () with
+    | (Left () : (unit, empty) t) -> ()
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+Right _
+val f : unit -> unit = <fun>
+|}]
+
+(* error *)
+
+let f () =
+  match Left () with
+  | (Left () : (unit, empty) t) -> ()
+  | (Right _ : (unit, empty) t) -> .
+;;
+[%%expect {|
+Line _, characters 5-12:
+    | (Right _ : (unit, empty) t) -> .
+       ^^^^^^^
+Error: This match case could not be refuted.
+       Here is an example of a value that would reach it: Right _
+|}]

--- a/testsuite/tests/typing-warnings/inside_out.ml
+++ b/testsuite/tests/typing-warnings/inside_out.ml
@@ -27,12 +27,6 @@ let f2 () =
   | (None : empty option) -> ()
 ;;
 [%%expect {|
-Line _, characters 2-49:
-  ..match None with
-    | (None : empty option) -> ()
-Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some _
 val f2 : unit -> unit = <fun>
 |}]
 
@@ -42,12 +36,6 @@ let f3 () =
   | (None : empty option) -> ()
 ;;
 [%%expect {|
-Line _, characters 2-46:
-  ..match x with
-    | (None : empty option) -> ()
-Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Some _
 val f3 : unit -> unit = <fun>
 |}]
 
@@ -66,11 +54,7 @@ let f2' () =
   | Some _ -> .
 ;;
 [%%expect {|
-Line _, characters 4-10:
-    | Some _ -> .
-      ^^^^^^
-Error: This match case could not be refuted.
-       Here is an example of a value that would reach it: Some _
+val f2' : unit -> unit = <fun>
 |}]
 
 let f3' () =
@@ -80,11 +64,7 @@ let f3' () =
   | Some _ -> .
 ;;
 [%%expect {|
-Line _, characters 4-10:
-    | Some _ -> .
-      ^^^^^^
-Error: This match case could not be refuted.
-       Here is an example of a value that would reach it: Some _
+val f3' : unit -> unit = <fun>
 |}]
 
 
@@ -109,12 +89,6 @@ let f () =
   ()
 ;;
 [%%expect{|
-Line _, characters 2-51:
-  ..let (Left () : (unit, empty) t) = Left () in
-    ()
-Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Right _
 val f : unit -> unit = <fun>
 |}]
 
@@ -144,12 +118,6 @@ let f () =
   | (Left () : (unit, empty) t) -> ()
 ;;
 [%%expect {|
-Line _, characters 2-58:
-  ..match Left () with
-    | (Left () : (unit, empty) t) -> ()
-Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-Right _
 val f : unit -> unit = <fun>
 |}]
 
@@ -161,9 +129,5 @@ let f () =
   | (Right _ : (unit, empty) t) -> .
 ;;
 [%%expect {|
-Line _, characters 5-12:
-    | (Right _ : (unit, empty) t) -> .
-       ^^^^^^^
-Error: This match case could not be refuted.
-       Here is an example of a value that would reach it: Right _
+val f : unit -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-warnings/ocamltests
+++ b/testsuite/tests/typing-warnings/ocamltests
@@ -2,6 +2,7 @@ ambiguous_guarded_disjunction.ml
 application.ml
 coercions.ml
 exhaustiveness.ml
+inside_out.ml
 pr5892.ml
 pr6587.ml
 pr6872.ml

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4684,8 +4684,8 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
   let ty_arg_check =
     if do_init then
       (* Hack: use for_saving to copy variables too *)
-      Subst.type_expr (Subst.for_saving Subst.identity) ty_arg
-    else ty_arg
+      Subst.type_expr (Subst.for_saving Subst.identity) ty_arg'
+    else ty_arg'
   in
   let partial =
     if partial_flag then

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4689,7 +4689,7 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
   in
   let partial =
     if partial_flag then
-      check_partial ~lev env ty_arg_check loc cases
+      check_partial ~lev env (instance env ty_arg_check) loc cases
     else
       Partial
   in


### PR DESCRIPTION
This PR actually does a bit more than what the title says:
- ~the first commit is an unrelated (hopefully trivial) cleanup~
- the second commit is a small refactoring which hopefully should clarify why `unify_pats (instance env ty_arg)` was called when `propagate || erased_either`. If I understood correctly, the condition is slightly off: we have to `unify_pats (instance env ty_arg)` when we've typechecked the patterns with a *partial* instance of `ty_arg` as expected type. But, in general, I don't think we need to when `propagate` is true.
- the 3rd commit is not required, but feels "more correct" than the current situation.
- the remaining commits actually concern themselves with what the title of the GPR mentions.

*Context*:
After having typed all the clauses of a match, we do various checks (usefulness, exhaustivity, ...) which work by producing "values" which can (or not) be matched by the clauses of the match.
During that process, we typecheck the values produced to make sure they are of the same type as the scrutiny/patterns.

However, the type we expect these values to have is the `ty_arg` that has flowed into `type_cases`, ignoring some new information which might have been gained by typing the patterns.
Consider:
```ocaml
type (_,_) eq = Refl : ('a, 'a) eq

type empty = (int, string) eq

let f () =
  match None with
  | (None : empty option) -> ()
```
The match is currently flagged as non-exhaustive.

If we somehow propagated the information we got from typechecking the pattern, then we would notice that the match actually is exhaustive.
Notice that this is what happens (through a side channel) here:
```ocaml
let f x =
  match x with
  | (None : empty option) -> ()
```
which doesn't trigger the warning.
The 4th commit adds other similar examples.

The last commit does the suggested change: instead of using an instance of the original `ty_arg` for typing the productions of `Parmatch`, we use an instance of `ty_arg'` (which has been unified with all the patterns as well as with an instance of `type_arg`, so all the information has been gathered).