### PR TITLE
[WIP] Optimize "ocamllex -ml"

### DIFF
--- a/Changes
+++ b/Changes
@@ -135,6 +135,9 @@ Working version
   structures and signatures (e.g. "include struct … include(struct … end) … end")
   (Florian Angeletti, review by Gabriel Scherer, report by Christophe Raffalli)
 
+- GPR#1585: optimize output of "ocamllex -ml"
+  (Alain Frisch, review by Frédéric Bour and Gabriel Scherer)
+
 ### Manual and documentation:
 
 - PR#7647, GPR#1384: emphasize ocaml.org website and forum in README

--- a/experimental/frisch/Makefile
+++ b/experimental/frisch/Makefile
@@ -1,3 +1,5 @@
+include ../../config/Makefile
+
 ROOT=../..
 OCAMLC=$(ROOT)/boot/ocamlrun $(ROOT)/ocamlc -I $(ROOT)/stdlib -I $(ROOT)/parsing -I $(ROOT)/utils -I $(ROOT)/tools -I $(ROOT)/typing -I $(ROOT)/driver -I $(ROOT)/toplevel -w A-4-9-42
 COMMON=$(ROOT)/compilerlibs/ocamlcommon.cma
@@ -77,3 +79,34 @@ nomli:
 matches:
 	$(OCAMLC) -linkall -o ppx_matches.exe $(COMMON) ppx_matches.ml
 	$(OCAMLC) -c -dsource -ppx ./ppx_matches.exe test_matches.ml
+
+
+## Benchmark ocamllex
+
+.PHONY: bench_ocamllex bench_ocamllex2
+ARGS=-o bench.exe -nostdlib \
+     -I $(ROOT)/otherlibs/$(UNIXLIB) -I $(ROOT)/stdlib -I $(ROOT)/parsing -I $(ROOT)/utils \
+     $(ROOT)/compilerlibs/ocamlcommon.cma unix.cma \
+     my_lexer.ml bench.ml
+bench_ocamllex:
+	@cp $(ROOT)/parsing/lexer.mll my_lexer.mll
+	@(cd $(ROOT)/lex && make ocamllex)
+	@$(ROOT)/boot/ocamlrun $(ROOT)/lex/ocamllex -ml my_lexer.mll
+	@echo WITH -ml flag:
+	@make -s bench_ocamllex2
+	@$(ROOT)/boot/ocamlrun $(ROOT)/lex/ocamllex -q my_lexer.mll
+	@echo WITHOUT -ml flag:
+	@make -s bench_ocamllex2
+
+bench_ocamllex2:
+	@echo -n "  NATIVE, -inline 1000: "
+	@$(ROOT)/boot/ocamlrun $(ROOT)/ocamlopt -inline 1000 $(ARGS:.cma=.cmxa)
+	@./bench.exe
+
+	@echo -n "  NATIVE, -inline 10  : "
+	@$(ROOT)/boot/ocamlrun $(ROOT)/ocamlopt -inline 10 $(ARGS:.cma=.cmxa)
+	@./bench.exe
+
+	@echo -n "  BYTECODE            : "
+	@$(ROOT)/boot/ocamlrun $(ROOT)/ocamlc -custom $(ARGS)
+	@./bench.exe

--- a/experimental/frisch/Makefile
+++ b/experimental/frisch/Makefile
@@ -90,6 +90,7 @@ ARGS=-o bench.exe -nostdlib \
      my_lexer.ml bench.ml
 bench_ocamllex:
 	@cp $(ROOT)/parsing/lexer.mll my_lexer.mll
+	cp my_lexer2.mll my_lexer.mll
 	@(cd $(ROOT)/lex && make ocamllex)
 	@$(ROOT)/boot/ocamlrun $(ROOT)/lex/ocamllex -ml my_lexer.mll
 	@echo WITH -ml flag:

--- a/experimental/frisch/bench.ml
+++ b/experimental/frisch/bench.ml
@@ -1,0 +1,38 @@
+let lexing s =
+  let lexbuf = Lexing.from_string s in
+  let rec loop () =
+    match My_lexer.token lexbuf with
+    | Parser.EOF -> ()
+    | token -> loop ()
+  in
+  loop ()
+
+let s =
+  let ic = open_in "../../typing/typecore.ml" in
+  let b = Buffer.create 16 in
+  begin
+    try while true do
+        Buffer.add_string b (input_line ic);
+        Buffer.add_char b '\n'
+      done
+    with End_of_file -> ()
+  end;
+  close_in ic;
+  Buffer.contents b
+
+let () =
+  let alloc0 = Gc.allocated_bytes () in
+  let t0 = Unix.gettimeofday () in
+  let n = 100 in
+  for _ = 1 to n do
+    lexing s
+  done;
+  let time = Unix.gettimeofday () -. t0 in
+  let alloc = Gc.allocated_bytes () -. alloc0 in
+
+  let len = float (String.length s) *. float n in
+  let mb = len /. 1024. /. 1024. in
+  Printf.printf " % 8.02f Mb/s   % 8.02f ms/Mb   alloc x % 8.02f \n%!"
+    (mb /. time)
+    (time *. 1000. /. mb)
+    (alloc /. len)

--- a/experimental/frisch/bench.ml
+++ b/experimental/frisch/bench.ml
@@ -1,5 +1,6 @@
 let lexing s =
   let lexbuf = Lexing.from_string s in
+  lexbuf.lex_curr_p <- Lexing.dummy_pos;
   let rec loop () =
     match My_lexer.token lexbuf with
     | Parser.EOF -> ()

--- a/experimental/frisch/bench_ocamllex_optims.md
+++ b/experimental/frisch/bench_ocamllex_optims.md
@@ -1,0 +1,98 @@
+Some benchmark to evaluate the speedup to `ocamllex -ml`.
+
+In all tests, we tokenize the `typecore.ml` file (first loaded in
+memory) file using either:
+
+  - the OCaml lexer, or
+
+  - a simpler lexer with trivial actions (to eliminate the cost of
+actions themselves, which is not under the control of ocamllex).
+
+We run the output of:
+
+   - `ocamllex` without the -ml flag, i.e. using tables interpreted at
+runtime by the C support code
+
+   - `ocamllex -ml`, i.e. the automaton is translated to OCaml code;
+this is done on before and after the optimizations.
+
+For each case, we compile the benchmark with:
+
+   - `ocamlc`
+
+   - `ocamlopt -inline 10`
+
+   - `ocamlopt -inline 1000`
+
+(flambda disabled).
+
+The tables below show:
+
+   - the throughput (Mb of source code tokenized
+by second -- higher is better;
+
+   - its inverse (number of milleseconds to parse one Mb) -- lower is better;
+
+   - the allocation ratio (number of bytes allocated by the GC for each byte of source code)
+
+
+Conclusions:
+
+  - In native code, the "-ml" mode is slightly slower than the table
+    mode before the optimizations, but it becomes significantly faster
+    after the optimizations, obviously even more so when the
+    lexer actions are trivial (throughput 58.44 -> 98.30).
+
+  - In bytecode, the "-ml" mode is always much slower than the table
+    mode, but the optimization reduce the gap is little bit.
+
+  - Not tested here, but it is likely that the optimizations produce
+    code which would be more friendly to Javascript backends
+    (js_of_ocaml and Bucklescript), as they reduce quite a bit
+    the number of function calls and mutations.
+
+Note:
+
+  - The "refill handler" mode has been lightly tested only.
+
+
+OCaml lexer:
+
+````
+WITHOUT -ml flag:
+  NATIVE, -inline 1000:     38.07 Mb/s      26.27 ms/Mb   alloc x    36.79
+  NATIVE, -inline 10  :     35.42 Mb/s      28.23 ms/Mb   alloc x    36.79
+  BYTECODE            :      7.84 Mb/s     127.54 ms/Mb   alloc x    35.48
+
+
+WITH -ml flag, TRUNK:
+  NATIVE, -inline 1000:     34.36 Mb/s      29.11 ms/Mb   alloc x    36.79
+  NATIVE, -inline 10  :     34.12 Mb/s      29.31 ms/Mb   alloc x    36.79
+  BYTECODE            :      4.08 Mb/s     244.93 ms/Mb   alloc x    35.48
+
+
+WITH -ml flag, BRANCH:
+  NATIVE, -inline 1000:     45.56 Mb/s      21.95 ms/Mb   alloc x    36.79
+  NATIVE, -inline 10  :     43.19 Mb/s      23.15 ms/Mb   alloc x    36.79
+  BYTECODE            :      4.35 Mb/s     229.91 ms/Mb   alloc x    35.48
+````
+
+
+Simpler lexer (trivial actions):
+
+````
+WITHOUT -ml flag:
+  NATIVE, -inline 1000:     58.44 Mb/s      17.11 ms/Mb   alloc x    21.94
+  NATIVE, -inline 10  :     58.24 Mb/s      17.17 ms/Mb   alloc x    21.94
+  BYTECODE            :     12.63 Mb/s      79.21 ms/Mb   alloc x    21.93
+
+WITH -ml flag, TRUNK:
+  NATIVE, -inline 1000:     55.14 Mb/s      18.13 ms/Mb   alloc x    21.94
+  NATIVE, -inline 10  :     50.76 Mb/s      19.70 ms/Mb   alloc x    21.94
+  BYTECODE            :      5.74 Mb/s     174.22 ms/Mb   alloc x    21.93
+
+WITH -ml flag, BRANCH:
+  NATIVE, -inline 1000:     98.30 Mb/s      10.17 ms/Mb   alloc x    21.94
+  NATIVE, -inline 10  :     87.16 Mb/s      11.47 ms/Mb   alloc x    21.94
+  BYTECODE            :      6.48 Mb/s     154.43 ms/Mb   alloc x    21.93
+````

--- a/experimental/frisch/bench_ocamllex_optims.md
+++ b/experimental/frisch/bench_ocamllex_optims.md
@@ -14,7 +14,14 @@ We run the output of:
 runtime by the C support code
 
    - `ocamllex -ml`, i.e. the automaton is translated to OCaml code;
-this is done on before and after the optimizations.
+this is done on before and after the optimizations;
+
+In adition, since it turned out that the automatic update of lex_start_p by
+the generated code is quite costly, there is now logic so that
+the generated code does not update this field and lex_curr_p when
+lex_start_p is initially physically equal to Lexing.dummy_pos.  This is also
+tested (only for the simpler lexer, since the OCaml one update the field in
+its actions).
 
 For each case, we compile the benchmark with:
 
@@ -95,4 +102,9 @@ WITH -ml flag, BRANCH:
   NATIVE, -inline 1000:     98.30 Mb/s      10.17 ms/Mb   alloc x    21.94
   NATIVE, -inline 10  :     87.16 Mb/s      11.47 ms/Mb   alloc x    21.94
   BYTECODE            :      6.48 Mb/s     154.43 ms/Mb   alloc x    21.93
+
+WITH -ml flag, BRANCH, dummy_pos:
+  NATIVE, -inline 1000:    152.68 Mb/s       6.55 ms/Mb   alloc x     1.00
+  NATIVE, -inline 10  :    133.97 Mb/s       7.46 ms/Mb   alloc x     1.00
+  BYTECODE            :      7.42 Mb/s     134.81 ms/Mb   alloc x     1.00
 ````

--- a/experimental/frisch/my_lexer2.mll
+++ b/experimental/frisch/my_lexer2.mll
@@ -1,0 +1,89 @@
+{
+open Parser
+}
+let newline = ('\013'* '\010')
+let blank = [' ' '\009' '\012']
+let lowercase = ['a'-'z' '_']
+let uppercase = ['A'-'Z']
+let identchar = ['A'-'Z' 'a'-'z' '_' '\'' '0'-'9']
+let lowercase_latin1 = ['a'-'z' '\223'-'\246' '\248'-'\255' '_']
+let uppercase_latin1 = ['A'-'Z' '\192'-'\214' '\216'-'\222']
+let identchar_latin1 =
+  ['A'-'Z' 'a'-'z' '_' '\192'-'\214' '\216'-'\246' '\248'-'\255' '\'' '0'-'9']
+let symbolchar =
+  ['!' '$' '%' '&' '*' '+' '-' '.' '/' ':' '<' '=' '>' '?' '@' '^' '|' '~']
+let dotsymbolchar =
+  ['!' '$' '%' '&' '*' '+' '-' '/' ':' '=' '>' '?' '@' '^' '|' '~']
+let decimal_literal =
+  ['0'-'9'] ['0'-'9' '_']*
+let hex_digit =
+  ['0'-'9' 'A'-'F' 'a'-'f']
+let hex_literal =
+  '0' ['x' 'X'] ['0'-'9' 'A'-'F' 'a'-'f']['0'-'9' 'A'-'F' 'a'-'f' '_']*
+let oct_literal =
+  '0' ['o' 'O'] ['0'-'7'] ['0'-'7' '_']*
+let bin_literal =
+  '0' ['b' 'B'] ['0'-'1'] ['0'-'1' '_']*
+let int_literal =
+  decimal_literal | hex_literal | oct_literal | bin_literal
+let float_literal =
+  ['0'-'9'] ['0'-'9' '_']*
+  ('.' ['0'-'9' '_']* )?
+  (['e' 'E'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']* )?
+let hex_float_literal =
+  '0' ['x' 'X']
+  ['0'-'9' 'A'-'F' 'a'-'f'] ['0'-'9' 'A'-'F' 'a'-'f' '_']*
+  ('.' ['0'-'9' 'A'-'F' 'a'-'f' '_']* )?
+  (['p' 'P'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']* )?
+let literal_modifier = ['G'-'Z' 'g'-'z']
+
+rule token = parse
+ | eof { EOF }
+ | lowercase identchar * { TILDE }
+  | "&"  { AMPERSAND }
+  | "&&" { AMPERAMPER }
+  | "`"  { BACKQUOTE }
+  | "\'" { QUOTE }
+  | "("  { LPAREN }
+  | ")"  { RPAREN }
+  | "*"  { STAR }
+  | ","  { COMMA }
+  | "->" { MINUSGREATER }
+  | "."  { DOT }
+  | ".." { DOTDOT }
+  | ":"  { COLON }
+  | "::" { COLONCOLON }
+  | ":=" { COLONEQUAL }
+  | ":>" { COLONGREATER }
+  | ";"  { SEMI }
+  | ";;" { SEMISEMI }
+  | "<"  { LESS }
+  | "<-" { LESSMINUS }
+  | "="  { EQUAL }
+  | "["  { LBRACKET }
+  | "[|" { LBRACKETBAR }
+  | "[<" { LBRACKETLESS }
+  | "[>" { LBRACKETGREATER }
+  | "]"  { RBRACKET }
+  | "{"  { LBRACE }
+  | "{<" { LBRACELESS }
+  | "|"  { BAR }
+  | "||" { BARBAR }
+  | "|]" { BARRBRACKET }
+  | ">"  { GREATER }
+  | ">]" { GREATERRBRACKET }
+  | "}"  { RBRACE }
+  | ">}" { GREATERRBRACE }
+  | "[@" { LBRACKETAT }
+  | "[@@"  { LBRACKETATAT }
+  | "[@@@" { LBRACKETATATAT }
+  | "[%"   { LBRACKETPERCENT }
+  | "[%%"  { LBRACKETPERCENTPERCENT }
+  | "!"  { BANG }
+  | "!=" { INFIXOP0 "!=" }
+  | "+"  { PLUS }
+  | "+." { PLUSDOT }
+  | "+=" { PLUSEQ }
+  | "-"  { MINUS }
+  | "-." { MINUSDOT }
+ | _ { EOL }

--- a/lex/outputbis.ml
+++ b/lex/outputbis.ml
@@ -287,11 +287,15 @@ let output_entry ic ctx tr e =
     ctx.goto_state ctx init_num;
     pr ctx "in\n";
   end;
-  pr ctx "\
-\n  lexbuf.Lexing.lex_start_p <- lexbuf.Lexing.lex_curr_p;\
-\n  lexbuf.Lexing.lex_curr_p <- {lexbuf.Lexing.lex_curr_p with\
-\n    Lexing.pos_cnum = lexbuf.Lexing.lex_abs_pos+lexbuf.Lexing.lex_curr_pos};\
-\n  match __ocaml_lex_result with\n";
+  pr ctx {|
+  let _curr_p = lexbuf.Lexing.lex_curr_p in
+  if _curr_p != Lexing.dummy_pos then begin
+    lexbuf.Lexing.lex_start_p <- _curr_p;
+    lexbuf.Lexing.lex_curr_p <- {_curr_p with
+         Lexing.pos_cnum = lexbuf.Lexing.lex_abs_pos+lexbuf.Lexing.lex_curr_pos}
+  end;
+  match __ocaml_lex_result with
+|};
   List.iter
     (fun (num, env, loc) ->
       pr ctx "  | ";


### PR DESCRIPTION
ocamllex has a `-ml` mode, where the lexing automaton is translated to OCaml functions instead of the usual approach of generating binary tables interpreted by the C runtime.  This PR tweaks ocamllex to produce better code in `-ml` mode.

Benchmarks are included in the PR, and available on https://github.com/alainfrisch/ocaml/blob/optim_ocamllex_ml/experimental/frisch/bench_ocamllex_optims.md .

Long story short: in native code, the optimizations brings almost a 2x speedup for the part of lexing under the responsibility of ocamllex (i.e. excluding actions).  This materializes with a smaller but significant speedup e.g. when lexing OCaml source code with the OCaml lexer.  While `ocamllex -ml` was a bit slower than `ocamllex`, it becomes significantly faster.

One might thus consider switching to `ocamllex -ml` to compile OCaml itself (at least for ocamlc.opt/ocamlopt.opt).

In bytecode, `ocamllex -ml` remains much slower than `ocamllex`, but the gap is reduced is bit.  I believe that the impact for Javascript backends might be significant (not tested).

Optimizations:

  - Inlining functions corresponding to "states", when they are called once or are trivial => fewer function calls, more effective constant propagation.

  - Also avoid a function call to fetch the next character when no buffer refill is needed.

  - Keep more state in OCaml variables, synchronizing with the lexbuf structure only when needed => fewer memory reads/writes.

  - Avoid (non-)allocation of lex_mem when its size is 0 (surprisingly, this brings some significant speedup).

About "keeping more state in OCaml variables":

 - `last_action` is never stored in lexbuf, but always kept in an OCaml variable (moreover, some constant propagation is performed -- I believe this is only useful to make some closures constant in the "refill handler" case).

 - `buffer_len`, `buffer`, `curr_pos`, `last_pos` are read from the lexbuf 
    when the automaton starts or after refilling the buffer.

 - `curr_pos`, `last_pos` are stored to the lexbuf when the automaton returns its result (before passing the hand to the action) or before refilling the buffer.
 
 - `buffer_len`, `buffer` are never modified by the automaton and thus never written back to the lexbuf.


Notes:

  - This has not been extensively tested yet with the "refill handler" feature (only tested that one lexer works with an identity "handler").

  - I've only tested the case where the string is in memory (no refill needed).  I suspect that refill is rare enough to not affect performances, but correctness should be tested.

 - A good fraction of the remaining time (esp. with trivial actions) is caused by the update of the `lex_curr_p` field.  It might be worth having a mode where the lexer specification tells ocamllex not to update the field (either because the lexer does not need to track position, or track them by character position, not using `Lexing.position`).