### PR TITLE
A `-promote` option for ocamltest

### DIFF
--- a/Changes
+++ b/Changes
@@ -190,7 +190,9 @@ Working version
 - GPR#1520: more robust implementation of Misc.no_overflow_mul
   (Max Mouratov, review by Xavier Leroy)
 
-- GPR#1586: ocamltest "-promote" option for reference file promotion
+- GPR#1586: testsuite: 'make promote' for ocamltest tests
+  (The new "-promote" option for ocamltest is experimental
+  and subject to change/removal).
   (Gabriel Scherer)
 
 ### Bug fixes

--- a/Changes
+++ b/Changes
@@ -190,6 +190,9 @@ Working version
 - GPR#1520: more robust implementation of Misc.no_overflow_mul
   (Max Mouratov, review by Xavier Leroy)
 
+- GPR#1586: ocamltest "-promote" option for reference file promotion
+  (Gabriel Scherer)
+
 ### Bug fixes
 
 - MPR#5250, GPR#1435: on Cygwin, when ocamlrun searches the path

--- a/ocamltest/actions_helpers.ml
+++ b/ocamltest/actions_helpers.ml
@@ -267,6 +267,12 @@ let check_output kind_of_output output_variable reference_variable log env =
       let reason =
         Printf.sprintf "%s output %s differs from reference %s: \n%s\n"
         kind_of_output output_filename reference_filename diffstr in
+      if Environments.lookup_as_bool Builtin_variables.promote env = Some true
+      then begin
+        Printf.fprintf log "Promoting %s output %s to reference %s\n%!"
+          kind_of_output output_filename reference_filename;
+        Sys.copy_file output_filename reference_filename;
+      end;
       (Result.fail_with_reason reason, env)
     | Filecompare.Unexpected_output ->
       let banner = String.make 40 '=' in

--- a/ocamltest/builtin_variables.ml
+++ b/ocamltest/builtin_variables.ml
@@ -47,6 +47,9 @@ let program = make ("program",
 let program2 = make ("program2",
   "Name of program produced by ocamlc.opt and ocamlopt.opt")
 
+let promote = make ("promote",
+  "Set to \"true\" to overwrite reference files with the test output")
+
 let reference = make ("reference",
   "Path of file to which program output should be compared")
 

--- a/ocamltest/builtin_variables.mli
+++ b/ocamltest/builtin_variables.mli
@@ -32,6 +32,8 @@ val output : Variables.t
 val program : Variables.t
 val program2 : Variables.t
 
+val promote : Variables.t
+
 val reference : Variables.t
 
 val script : Variables.t

--- a/ocamltest/environments.ml
+++ b/ocamltest/environments.ml
@@ -52,6 +52,12 @@ let expand env value =
 let lookup variable env =
   try Some (expand env (VariableMap.find variable env)) with Not_found -> None
 
+let lookup_as_bool variable env =
+  match lookup variable env with
+  | None -> None
+  | Some "true" -> Some true
+  | Some _ -> Some false
+
 let safe_lookup variable env = match lookup variable env with
   | None -> ""
   | Some value -> value

--- a/ocamltest/environments.mli
+++ b/ocamltest/environments.mli
@@ -29,6 +29,11 @@ val lookup : Variables.t -> t -> string option
 val safe_lookup : Variables.t -> t -> string
 val is_variable_defined : Variables.t -> t -> bool
 
+val lookup_as_bool : Variables.t -> t -> bool option
+(** returns [Some true] if the variable is set to ["true"],
+    [Some false] if it is set to another string, and
+    [None] if not set. *)
+
 val add : Variables.t -> string -> t -> t
 val add_bindings : (Variables.t * string) list -> t -> t
 

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -124,6 +124,7 @@ let test_file test_filename =
            let log_filename = test_prefix ^ ".log" in
            open_out log_filename
          end in
+       let promote = string_of_bool !Options.promote in
        let install_hook name =
          let hook_name = Filename.make_filename hookname_prefix name in
          if Sys.file_exists hook_name then begin
@@ -141,6 +142,7 @@ let test_file test_filename =
              Builtin_variables.test_source_directory, test_source_directory;
              Builtin_variables.test_build_directory_prefix,
                test_build_directory_prefix;
+             Builtin_variables.promote, promote;
            ] in
        let root_environment =
          interprete_environment_statements

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -418,8 +418,8 @@ let really_compare_programs backend comparison_tool log env =
 
 let compare_programs backend comparison_tool log env =
   let compare_programs =
-    Environments.safe_lookup Ocaml_variables.compare_programs env in
-  if compare_programs = "false" then begin
+    Environments.lookup_as_bool Ocaml_variables.compare_programs env in
+  if compare_programs = Some false then begin
     let reason = "program comparison disabled" in
     (Result.pass_with_reason reason, env)
   end else really_compare_programs backend comparison_tool log env

--- a/ocamltest/options.ml
+++ b/ocamltest/options.ml
@@ -38,9 +38,12 @@ let show_tests () =
 
 let log_to_stderr = ref false
 
+let promote = ref false
+
 let commandline_options =
 [
   ("-e", Arg.Set log_to_stderr, "Log to stderr instead of a file.");
+  ("-promote", Arg.Set promote, "Overwrite reference files with the test output");
   ("-show-actions", Arg.Unit show_actions, "Show available actions.");
   ("-show-tests", Arg.Unit show_tests, "Show available tests.");
 ]

--- a/ocamltest/options.ml
+++ b/ocamltest/options.ml
@@ -43,7 +43,8 @@ let promote = ref false
 let commandline_options =
 [
   ("-e", Arg.Set log_to_stderr, "Log to stderr instead of a file.");
-  ("-promote", Arg.Set promote, "Overwrite reference files with the test output");
+  ("-promote", Arg.Set promote,
+   "Overwrite reference files with the test output (experimental, unstable)");
   ("-show-actions", Arg.Unit show_actions, "Show available actions.");
   ("-show-tests", Arg.Unit show_tests, "Show available tests.");
 ]

--- a/ocamltest/options.mli
+++ b/ocamltest/options.mli
@@ -19,4 +19,6 @@ val log_to_stderr : bool ref
 
 val files_to_test : string list ref
 
+val promote : bool ref
+
 val usage : string

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -238,7 +238,13 @@ promote:
 	  echo "Directory '$(DIR)' does not exist."; \
 	  exit 1; \
 	fi
-	@cd $(DIR) && $(MAKE) TERM=dumb BASEDIR=$(BASEDIR) promote
+	@if [ -f $(DIR)/ocamltests ]; then \
+	  $(MAKE) exec-ocamltest DIR=$(DIR) \
+	    OCAMLTESTENV="OCAMLTESTDIR=$(BASEDIR)/$(DIR)/_ocamltest" \
+	    OCAMLTESTFLAGS="-promote"; \
+	else \
+	  cd $(DIR) && $(MAKE) TERM=dumb BASEDIR=$(BASEDIR) promote; \
+	fi
 
 .PHONY: lib
 lib:

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -104,11 +104,8 @@ new-without-report: lib tools
 	@(for file in `$(find) tests -name ocamltests`; do \
 	  dir=`dirname $$file`; \
 	  echo Running tests from \'$$dir\' ... ; \
-	  (IFS=$$(printf "\r\n"); while read testfile; do \
-	    TERM=dumb \
-	      $(ocamltest) $$dir/$$testfile || \
-	      touch $(failstamp); \
-	  done < $$file) || touch $(failstamp); \
+	  $(MAKE) exec-ocamltest DIR=$$dir \
+	    OCAMLTESTENV="" OCAMLTESTFLAGS=""; \
 	done || touch $(failstamp)) 2>&1 | tee -a _log
 	@if [ -f $(failstamp) ]; then rm $(failstamp); exit 1; fi
 
@@ -187,6 +184,7 @@ one: lib tools
 	  exit 1; \
 	fi
 	@$(MAKE) $(NO_PRINT) exec-one DIR=$(DIR)
+	@if [ -f $(failstamp) ]; then rm $(failstamp); exit 1; fi
 
 .PHONY: exec-one
 exec-one:
@@ -202,13 +200,21 @@ exec-one:
 	  $(MAKE) TERM=dumb BASEDIR=$(BASEDIR) || echo '=> unexpected error'; \
 	elif [ -f $(DIR)/ocamltests ] && [ -z $(LEGACY) ] ; then \
 	  echo "Running tests from '$$DIR' ..."; \
-	  file=$(DIR)/ocamltests; \
-	  (IFS=$$(printf "\r\n"); while read testfile; do \
-		  TERM=dumb OCAMLTESTDIR=$(BASEDIR)/$(DIR)/_ocamltest \
-		    $(ocamltest) $(DIR)/$$testfile || \
-		    touch $(failstamp); \
-	  done < $$file) || touch $(failstamp); \
+	  $(MAKE) exec-ocamltest DIR=$(DIR) \
+	    OCAMLTESTENV="OCAMLTESTDIR=$(BASEDIR)/$(DIR)/_ocamltest" \
+	    OCAMLTESTFLAGS=""; \
 	fi
+
+.PHONY: exec-ocamltest
+exec-ocamltest:
+	@if [ -z "$(DIR)" ]; then exit 1; fi
+	@if [ ! -d "$(DIR)" ]; then exit 1; fi
+	@file=$(DIR)/ocamltests; \
+	(IFS=$$(printf "\r\n"); while read testfile; do \
+	   TERM=dumb $(OCAMLTESTENV) \
+	     $(ocamltest) $(OCAMLTESTFLAGS) $(DIR)/$$testfile || \
+	   touch $(failstamp); \
+	done < $$file) || touch $(failstamp)
 
 .PHONY: clean-one
 clean-one:


### PR DESCRIPTION
When -promote is set, running the test automatically overwrites each
reference output file with the actual output of the test. This option,
which mirrors the "make promote" target of old-style testsuite tests,
is very useful when a minor change in compiler/toplevel output affects
a lot of reference files in innocuous ways.

This is the only option of ocamltest that overwrites file in the
source directory, so it should be used with care -- under strict
version-control supervision.

The 'make promote' target is not yet supported for new-style testsuite
tests, as this feature depends on the not-yet-merged GPR#1574

  https://github.com/ocaml/ocaml/pull/1574

For a previous discussions of this feature, see GPR#1519

  https://github.com/ocaml/ocaml/pull/1519

I checked manually that this option works as expected both for
expect-style tests and for normal `foo.reference` tests.
