### PR TITLE
Fix MPR#7636 by using variance when lowering levels

### DIFF
--- a/Changes
+++ b/Changes
@@ -192,7 +192,7 @@ Working version
   (Tadeu Zagallo, report by Roberto Di Cosmo,
    review by Hongbo Zhang, David Allsopp, Gabriel Scherer, Xavier Leroy)
 
-- MPR#7636, GPR#: Constant type cannot be generalized
+- MPR#7636, GPR#1588: Constant type cannot be generalized
   (Jacques Garrigue, report by Christophe Raffalli)
 
 - PR#7660, GPR#1445: Use native Windows API to implement Unix.utimes in order to

--- a/Changes
+++ b/Changes
@@ -192,6 +192,9 @@ Working version
   (Tadeu Zagallo, report by Roberto Di Cosmo,
    review by Hongbo Zhang, David Allsopp, Gabriel Scherer, Xavier Leroy)
 
+- MPR#7636, GPR#: Constant type cannot be generalized
+  (Jacques Garrigue, report by Christophe Raffalli)
+
 - PR#7660, GPR#1445: Use native Windows API to implement Unix.utimes in order to
   avoid unintended shifts of the argument timestamp depending on DST setting.
   (Nicolás Ojeda Bär, review by David Allsopp, Xavier Leroy)

--- a/testsuite/tests/typing-poly/pr7636.ml
+++ b/testsuite/tests/typing-poly/pr7636.ml
@@ -1,0 +1,26 @@
+(* TEST
+   * expect
+*)
+
+type ('a, 'b) elt = 'a
+
+type 'a iter = { f : 'b.('a, 'b) elt -> unit }
+
+let promote (f : 'a -> unit) =
+ let f : 'b.('a, 'b) elt -> unit = fun x -> f x in 
+ { f }
+[%%expect{|
+type ('a, 'b) elt = 'a
+type 'a iter = { f : 'b. ('a, 'b) elt -> unit; }
+val promote : (('a, 'b) elt -> unit) -> 'a iter = <fun>
+|}]
+
+type 'a t = int
+let test : 'a. int -> 'a t = fun i -> i;;
+[%%expect{|
+type 'a t = int
+val test : 'a t -> 'a0 t = <fun>
+|}, Principal{|
+type 'a t = int
+val test : int -> 'a t = <fun>
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -43,7 +43,7 @@ open Btype
    - All nodes of a type have a level : that way, one know whether a
      node need to be duplicated or not when instantiating a type.
    - Levels of a type are decreasing (generic level being considered
-     as greatest).
+     as greatest), except for null-variant parameters of type constructors.
    - The level of a type constructor is superior to the binding
      time of its path.
    - Recursive types without limitation should be handled (even if
@@ -759,7 +759,6 @@ let rec update_level env level expand ty =
         raise (Unify [(ty1, newvar2 level)])
     | _ ->
         set_level ty level;
-        (* XXX what about abbreviations in Tconstr ? *)
         iter_type_expr (update_level env level expand) ty
   end
 


### PR DESCRIPTION
This fixes [MPR#7636](https://caml.inria.fr/mantis/view.php?id=7636), following Didier Remy's idea of not lowering levels of "absent" variables, i.e. whose variance is null.

Note that the `expand` argument of `update_level` is much less meaningful now: in general, absent variables are not going to be lowered any more, so there is no need to expand for them. However, variance information is not always as strong as it could (cf. functors), so it is better to still leave it here.

This also removes some dead code in `update_levels`, when `level < get_level p`.
I have no idea what the role of this code was, but it makes no sense to me (if there is a problem after expansion succeeded, it should generate `Unify`, not `Cannot_expand`), and is not exercised by the test suite.