### PR TITLE
Make updating lex_curr_p/lex_start_p optional

### DIFF
--- a/Changes
+++ b/Changes
@@ -392,6 +392,12 @@ OCaml 4.07
 - GPR#1585: optimize output of "ocamllex -ml"
   (Alain Frisch, review by Frédéric Bour and Gabriel Scherer)
 
+- GPR#1590: ocamllex-generated lexers can be instructed not to update their
+  lex_curr_p/lex_start_p by setting lex_curr_p to Lexing.dummy_pos,
+  resuting in a significant performance gain when those fields are not
+  required
+  (Alain Frisch, Jérémie Dimino)
+
 - GPR#1667: add command-line options -no-propt, -no-version, -no-time,
   -no-breakpoint and -topdirs-path to ocamldebug
   (Sébastien Hinderer, review by Damien Doligez)

--- a/Changes
+++ b/Changes
@@ -12,6 +12,11 @@ Working version
 
 ### Standard library:
 
+- GPR#1590: ocamllex-generated lexers can be instructed not to update
+  their lex_curr_p/lex_start_p fields, resulting in a significant
+  performance gain when those fields are not required
+  (Alain Frisch, Jérémie Dimino)
+
 - MPR#7795, GPR#1782: Fix off-by-one error in Weak.create
   (KC Sivaramakrishnan)
 
@@ -90,7 +95,7 @@ Working version
   (steinuil, review by Marcello Seri, Gabriel Scherer and Florian Angeletti)
 
 - GPR#1797: remove the deprecated Makefile.nt files
-  (Sébastien Hinderer, review by Nicolas Ojeda Bar)  
+  (Sébastien Hinderer, review by Nicolas Ojeda Bar)
 
 ### Internal/compiler-libs changes:
 
@@ -391,12 +396,6 @@ OCaml 4.07
 
 - GPR#1585: optimize output of "ocamllex -ml"
   (Alain Frisch, review by Frédéric Bour and Gabriel Scherer)
-
-- GPR#1590: ocamllex-generated lexers can be instructed not to update their
-  lex_curr_p/lex_start_p by setting lex_curr_p to Lexing.dummy_pos,
-  resuting in a significant performance gain when those fields are not
-  required
-  (Alain Frisch, Jérémie Dimino)
 
 - GPR#1667: add command-line options -no-propt, -no-version, -no-time,
   -no-breakpoint and -topdirs-path to ocamldebug

--- a/stdlib/lexing.ml
+++ b/stdlib/lexing.ml
@@ -145,7 +145,7 @@ let zero_pos = {
   pos_cnum = 0;
 }
 
-let from_function f =
+let from_function ?(with_positions = true) f =
   { refill_buff = lex_refill f (Bytes.create 512);
     lex_buffer = Bytes.create 1024;
     lex_buffer_len = 0;
@@ -156,14 +156,14 @@ let from_function f =
     lex_last_action = 0;
     lex_mem = [||];
     lex_eof_reached = false;
-    lex_start_p = zero_pos;
-    lex_curr_p = zero_pos;
+    lex_start_p = if with_positions then zero_pos else dummy_pos;
+    lex_curr_p = if with_positions then zero_pos else dummy_pos;
   }
 
-let from_channel ic =
-  from_function (fun buf n -> input ic buf 0 n)
+let from_channel ?with_positions ic =
+  from_function ?with_positions (fun buf n -> input ic buf 0 n)
 
-let from_string s =
+let from_string ?(with_positions = true) s =
   { refill_buff = (fun lexbuf -> lexbuf.lex_eof_reached <- true);
     lex_buffer = Bytes.of_string s; (* have to make a copy for compatibility
                                        with unsafe-string mode *)
@@ -175,9 +175,11 @@ let from_string s =
     lex_last_action = 0;
     lex_mem = [||];
     lex_eof_reached = true;
-    lex_start_p = zero_pos;
-    lex_curr_p = zero_pos;
+    lex_start_p = if with_positions then zero_pos else dummy_pos;
+    lex_curr_p = if with_positions then zero_pos else dummy_pos;
   }
+
+let with_positions lexbuf = lexbuf.lex_curr_p != dummy_pos
 
 let lexeme lexbuf =
   let len = lexbuf.lex_curr_pos - lexbuf.lex_start_pos in

--- a/stdlib/lexing.mli
+++ b/stdlib/lexing.mli
@@ -68,7 +68,7 @@ type lexbuf =
    Lexers can optionally maintain the [lex_curr_p] and [lex_start_p]
    position fields.  This "position tracking" mode is the default, and
    it corresponds to passing [~with_position:true] to functions that
-   create lexer buffer. In this mode, the lexing engine and lexer
+   create lexer buffers. In this mode, the lexing engine and lexer
    actions are co-responsible for properly updating the position
    fields, as described in the next paragraph.  When the mode is
    explicitly disabled (with [~with_position:false]), the lexing
@@ -110,8 +110,8 @@ val from_function : ?with_positions:bool -> (bytes -> int -> int) -> lexbuf
 
 val with_positions : lexbuf -> bool
 (** Tell whether the lexer buffer keeps track of position fields
-    [lex_curr_p] / [lex_start_p], as determined by the correspond
-    optional argument for function that create lexer buffers
+    [lex_curr_p] / [lex_start_p], as determined by the corresponding
+    optional argument for functions that create lexer buffers
     (whose default value is [true]).
 
     When [with_positions] is [false], lexer actions should not

--- a/stdlib/lexing.mli
+++ b/stdlib/lexing.mli
@@ -73,7 +73,12 @@ type lexbuf =
    accurate, they must be initialised before the first use of the
    lexbuf, and updated by the relevant lexer actions (i.e. at each
    end of line -- see also [new_line]).
- *)
+
+   Updating [lex_curr_p] and [lex_start_p] is disabled if
+   [lex_curr_p] is physically equal to [dummy_pos].  Setting
+   [lex_curr_p] to [dummy_pos] before calling the engine can thus be
+   used to avoid useless allocations and memory writes in contexts where
+   [lex_start_p] and [lex_curr_p] are not needed.  *)
 
 val from_channel : in_channel -> lexbuf
 (** Create a lexer buffer on the given input channel.

--- a/stdlib/lexing.mli
+++ b/stdlib/lexing.mli
@@ -65,39 +65,59 @@ type lexbuf =
    The lexer buffer holds the current state of the scanner, plus
    a function to refill the buffer from the input.
 
-   At each token, the lexing engine will copy [lex_curr_p] to
-   [lex_start_p], then change the [pos_cnum] field
-   of [lex_curr_p] by updating it with the number of characters read
-   since the start of the [lexbuf].  The other fields are left
-   unchanged by the lexing engine.  In order to keep them
+   Lexers can optionally maintain the [lex_curr_p] and [lex_start_p]
+   position fields.  This "position tracking" mode is the default, and
+   it corresponds to passing [~with_position:true] to functions that
+   create lexer buffer. In this mode, the lexing engine and lexer
+   actions are co-responsible for properly updating the position
+   fields, as described in the next paragraph.  When the mode is
+   explicitly disabled (with [~with_position:false]), the lexing
+   engine will not touch the position fields and the lexer actions
+   should be careful not to do it either; the [lex_curr_p] and
+   [lex_start_p] field will then always hold the [dummy_pos] invalid
+   position.  Not tracking positions avoids allocations and memory
+   writes and can significantly improve the performance of the lexer
+   in contexts where [lex_start_p] and [lex_curr_p] are not needed.
+
+   Position tracking mode works as follows.  At each token, the lexing
+   engine will copy [lex_curr_p] to [lex_start_p], then change the
+   [pos_cnum] field of [lex_curr_p] by updating it with the number of
+   characters read since the start of the [lexbuf].  The other fields
+   are left unchanged by the lexing engine.  In order to keep them
    accurate, they must be initialised before the first use of the
-   lexbuf, and updated by the relevant lexer actions (i.e. at each
-   end of line -- see also [new_line]).
+   lexbuf, and updated by the relevant lexer actions (i.e. at each end
+   of line -- see also [new_line]).
+*)
 
-   Updating [lex_curr_p] and [lex_start_p] is disabled if
-   [lex_curr_p] is physically equal to [dummy_pos].  Setting
-   [lex_curr_p] to [dummy_pos] before calling the engine can thus be
-   used to avoid useless allocations and memory writes in contexts where
-   [lex_start_p] and [lex_curr_p] are not needed.  *)
-
-val from_channel : in_channel -> lexbuf
+val from_channel : ?with_positions:bool -> in_channel -> lexbuf
 (** Create a lexer buffer on the given input channel.
    [Lexing.from_channel inchan] returns a lexer buffer which reads
    from the input channel [inchan], at the current reading position. *)
 
-val from_string : string -> lexbuf
+val from_string : ?with_positions:bool -> string -> lexbuf
 (** Create a lexer buffer which reads from
    the given string. Reading starts from the first character in
    the string. An end-of-input condition is generated when the
    end of the string is reached. *)
 
-val from_function : (bytes -> int -> int) -> lexbuf
+val from_function : ?with_positions:bool -> (bytes -> int -> int) -> lexbuf
 (** Create a lexer buffer with the given function as its reading method.
    When the scanner needs more characters, it will call the given
    function, giving it a byte sequence [s] and a byte
    count [n]. The function should put [n] bytes or fewer in [s],
    starting at index 0, and return the number of bytes
    provided. A return value of 0 means end of input. *)
+
+val with_positions : lexbuf -> bool
+(** Tell whether the lexer buffer keeps track of position fields
+    [lex_curr_p] / [lex_start_p], as determined by the correspond
+    optional argument for function that create lexer buffers
+    (whose default value is [true]).
+
+    When [with_positions] is [false], lexer actions should not
+    modify position fields.  Doing it nevertheless could
+    re-enable the [with_position] mode and degrade performances.
+*)
 
 
 (** {1 Functions for lexer semantic actions} *)
@@ -132,16 +152,19 @@ val lexeme_end : lexbuf -> int
 
 val lexeme_start_p : lexbuf -> position
 (** Like [lexeme_start], but return a complete [position] instead
-    of an offset. *)
+    of an offset.  When position tracking is disabled, the function
+    returns [dummy_pos]. *)
 
 val lexeme_end_p : lexbuf -> position
 (** Like [lexeme_end], but return a complete [position] instead
-    of an offset. *)
+    of an offset.  When position tracking is disabled, the function
+    returns [dummy_pos]. *)
 
 val new_line : lexbuf -> unit
 (** Update the [lex_curr_p] field of the lexbuf to reflect the start
     of a new line.  You can call this function in the semantic action
-    of the rule that matches the end-of-line character.
+    of the rule that matches the end-of-line character.  The function
+    does nothing when position tracking is disabled.
     @since 3.11.0
 *)
 


### PR DESCRIPTION
Follow up to #1585, where I noticed that disabled the update of lex_curr_p/lex_start_p can bring significant speedup to lexers generated by ocamllex.  Since #1585, lexers generated by "ocamllex -ml" don't update these fields if `lex_curr_p == Lexing.dummy_pos` (the lexer actions need to be careful not to break this property).

This PR document this behavior, and port it to lexers generated by ocamllex (without -ml).

A slightly tangential question is whether `Lexing.lexeme_start` should return `buf.lex_abs_pos + buf.lex_start_pos` instead of `lexbuf.lex_start_p.pos_cnum` as currently (and similarly for lexeme_end).  This would make the function usable even when updating the position fields is disabled.  Do people see use cases where the new definition would not work?