### PR TITLE
Cleanup: replace uses of Lambda.IdentSet by Ident.Set

### DIFF
--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -1141,7 +1141,7 @@ and close_functions fenv cenv fun_defs =
     !function_nesting_depth < excessive_function_nesting_depth in
   (* Determine the free variables of the functions *)
   let fv =
-    IdentSet.elements (free_variables (Lletrec(fun_defs, lambda_unit))) in
+    Ident.Set.elements (free_variables (Lletrec(fun_defs, lambda_unit))) in
   (* Build the function descriptors for the functions.
      Initially all functions are assumed not to need their environment
      parameter. *)

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -146,7 +146,7 @@ let rec size_of_lambda env = function
   | Lvar id ->
       begin try Ident.find_same id env with Not_found -> RHS_nonrec end
   | Lfunction{params} as funct ->
-      RHS_function (1 + IdentSet.cardinal(free_variables funct),
+      RHS_function (1 + Ident.Set.cardinal(free_variables funct),
                     List.length params)
   | Llet (Strict, _k, id, Lprim (Pduprecord (kind, size), _, _), body)
     when check_recordwith_updates id body ->
@@ -519,7 +519,7 @@ let rec comp_expr env exp sz cont =
         end
   | Lfunction{params; body} -> (* assume kind = Curried *)
       let lbl = new_label() in
-      let fv = IdentSet.elements(free_variables exp) in
+      let fv = Ident.Set.elements(free_variables exp) in
       let to_compile =
         { params = params; body = body; label = lbl;
           free_vars = fv; num_defs = 1; rec_vars = []; rec_pos = 0 } in
@@ -536,7 +536,7 @@ let rec comp_expr env exp sz cont =
                       decl then begin
         (* let rec of functions *)
         let fv =
-          IdentSet.elements (free_variables (Lletrec(decl, lambda_unit))) in
+          Ident.Set.elements (free_variables (Lletrec(decl, lambda_unit))) in
         let rec_idents = List.map (fun (id, _lam) -> id) decl in
         let rec comp_fun pos = function
             [] -> []

--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -85,25 +85,23 @@ let add_ccobjs origin l =
 
 (* First pass: determine which units are needed *)
 
-module IdentSet = Lambda.IdentSet
-
-let missing_globals = ref IdentSet.empty
+let missing_globals = ref Ident.Set.empty
 
 let is_required (rel, _pos) =
   match rel with
     Reloc_setglobal id ->
-      IdentSet.mem id !missing_globals
+      Ident.Set.mem id !missing_globals
   | _ -> false
 
 let add_required compunit =
   let add_required_by_reloc (rel, _pos) =
     match rel with
       Reloc_getglobal id ->
-        missing_globals := IdentSet.add id !missing_globals
+        missing_globals := Ident.Set.add id !missing_globals
     | _ -> ()
   in
   let add_required_for_effects id =
-    missing_globals := IdentSet.add id !missing_globals
+    missing_globals := Ident.Set.add id !missing_globals
   in
   List.iter add_required_by_reloc compunit.cu_reloc;
   List.iter add_required_for_effects compunit.cu_required_globals
@@ -111,7 +109,7 @@ let add_required compunit =
 let remove_required (rel, _pos) =
   match rel with
     Reloc_setglobal id ->
-      missing_globals := IdentSet.remove id !missing_globals
+      missing_globals := Ident.Set.remove id !missing_globals
   | _ -> ()
 
 let scan_file obj_name tolink =
@@ -569,10 +567,10 @@ let link ppf objfiles output_name =
     else "stdlib.cma" :: (objfiles @ ["std_exit.cmo"]) in
   let tolink = List.fold_right scan_file objfiles [] in
   let missing_modules =
-    IdentSet.filter (fun id -> not (Ident.is_predef_exn id)) !missing_globals
+    Ident.Set.filter (fun id -> not (Ident.is_predef_exn id)) !missing_globals
   in
   begin
-    match IdentSet.elements missing_modules with
+    match Ident.Set.elements missing_modules with
     | [] -> ()
     | id :: _ -> raise (Error (Required_module_unavailable (Ident.name id)))
   end;
@@ -707,7 +705,7 @@ let reset () =
   lib_ccobjs := [];
   lib_ccopts := [];
   lib_dllibs := [];
-  missing_globals := IdentSet.empty;
+  missing_globals := Ident.Set.empty;
   Consistbl.clear crc_interfaces;
   implementations_defined := [];
   debug_info := [];

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -455,28 +455,26 @@ let iter f = function
       f e
 
 
-module IdentSet = Set.Make(Ident)
-
 let free_ids get l =
-  let fv = ref IdentSet.empty in
+  let fv = ref Ident.Set.empty in
   let rec free l =
     iter free l;
-    fv := List.fold_right IdentSet.add (get l) !fv;
+    fv := List.fold_right Ident.Set.add (get l) !fv;
     match l with
       Lfunction{params} ->
-        List.iter (fun param -> fv := IdentSet.remove param !fv) params
+        List.iter (fun param -> fv := Ident.Set.remove param !fv) params
     | Llet(_str, _k, id, _arg, _body) ->
-        fv := IdentSet.remove id !fv
+        fv := Ident.Set.remove id !fv
     | Lletrec(decl, _body) ->
-        List.iter (fun (id, _exp) -> fv := IdentSet.remove id !fv) decl
+        List.iter (fun (id, _exp) -> fv := Ident.Set.remove id !fv) decl
     | Lstaticcatch(_e1, (_,vars), _e2) ->
-        List.iter (fun id -> fv := IdentSet.remove id !fv) vars
+        List.iter (fun id -> fv := Ident.Set.remove id !fv) vars
     | Ltrywith(_e1, exn, _e2) ->
-        fv := IdentSet.remove exn !fv
+        fv := Ident.Set.remove exn !fv
     | Lfor(v, _e1, _e2, _dir, _e3) ->
-        fv := IdentSet.remove v !fv
+        fv := Ident.Set.remove v !fv
     | Lassign(id, _e) ->
-        fv := IdentSet.add id !fv
+        fv := Ident.Set.add id !fv
     | Lvar _ | Lconst _ | Lapply _
     | Lprim _ | Lswitch _ | Lstringswitch _ | Lstaticraise _
     | Lifthenelse _ | Lsequence _ | Lwhile _

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -323,9 +323,8 @@ val name_lambda: let_kind -> lambda -> (Ident.t -> lambda) -> lambda
 val name_lambda_list: lambda list -> (lambda list -> lambda) -> lambda
 
 val iter: (lambda -> unit) -> lambda -> unit
-module IdentSet: Set.S with type elt = Ident.t
-val free_variables: lambda -> IdentSet.t
-val free_methods: lambda -> IdentSet.t
+val free_variables: lambda -> Ident.Set.t
+val free_methods: lambda -> Ident.Set.t
 
 val transl_normal_path: Path.t -> lambda   (* Path.t is already normal *)
 val transl_path: ?loc:Location.t -> Env.t -> Path.t -> lambda

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -679,9 +679,9 @@ let default_compat p def =
 
 (* Or-pattern expansion, variables are a complication w.r.t. the article *)
 let rec extract_vars r p = match p.pat_desc with
-| Tpat_var (id, _) -> IdentSet.add id r
+| Tpat_var (id, _) -> Ident.Set.add id r
 | Tpat_alias (p, id,_ ) ->
-    extract_vars (IdentSet.add id r) p
+    extract_vars (Ident.Set.add id r) p
 | Tpat_tuple pats ->
     List.fold_left extract_vars r pats
 | Tpat_record (lpats,_) ->
@@ -727,8 +727,8 @@ let rec explode_or_pat arg patl mk_action rem vars aliases = function
 
 let pm_free_variables {cases=cases} =
   List.fold_right
-    (fun (_,act) r -> IdentSet.union (free_variables act) r)
-    cases IdentSet.empty
+    (fun (_,act) r -> Ident.Set.union (free_variables act) r)
+    cases Ident.Set.empty
 
 
 (* Basic grouping predicates *)
@@ -817,8 +817,8 @@ let insert_or_append p ps act ors no =
         if is_or q then begin
           if may_compat p q then
             if
-              IdentSet.is_empty (extract_vars IdentSet.empty p) &&
-              IdentSet.is_empty (extract_vars IdentSet.empty q) &&
+              Ident.Set.is_empty (extract_vars Ident.Set.empty p) &&
+              Ident.Set.is_empty (extract_vars Ident.Set.empty q) &&
               equiv_pat p q
             then (* attempt insert, for equivalent orpats with no variables *)
               let _, not_e = get_equiv q rem in
@@ -1114,9 +1114,9 @@ and precompile_or argo cls ors args def k = match ors with
               args = (match args with _::r -> r | _ -> assert false) ;
               default = default_compat orp def} in
           let vars =
-            IdentSet.elements
-              (IdentSet.inter
-                 (extract_vars IdentSet.empty orp)
+            Ident.Set.elements
+              (Ident.Set.inter
+                 (extract_vars Ident.Set.empty orp)
                  (pm_free_variables orpm)) in
           let or_num = next_raise_count () in
           let new_patl = Parmatch.omega_list patl in

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -31,7 +31,7 @@ let rec eliminate_ref id = function
       Lapply{ap with ap_func = eliminate_ref id ap.ap_func;
                      ap_args = List.map (eliminate_ref id) ap.ap_args}
   | Lfunction _ as lam ->
-      if IdentSet.mem id (free_variables lam)
+      if Ident.Set.mem id (free_variables lam)
       then raise Real_reference
       else lam
   | Llet(str, kind, v, e1, e2) ->
@@ -661,7 +661,7 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~body ~attr ~loc =
         (* Check that those *opt* identifiers don't appear in the remaining
            body. This should not appear, but let's be on the safe side. *)
         let fv = Lambda.free_variables body in
-        List.iter (fun (id, _) -> if IdentSet.mem id fv then raise Exit) map;
+        List.iter (fun (id, _) -> if Ident.Set.mem id fv then raise Exit) map;
 
         let inner_id = Ident.create (Ident.name fun_id ^ "_inner") in
         let map_param p = try List.assoc p map with Not_found -> p in

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -112,11 +112,11 @@ and apply_coercion_result loc strict funct params args cc_res =
 and wrap_id_pos_list loc id_pos_list get_field lam =
   let fv = free_variables lam in
   (*Format.eprintf "%a@." Printlambda.lambda lam;
-  IdentSet.iter (fun id -> Format.eprintf "%a " Ident.print id) fv;
+  Ident.Set.iter (fun id -> Format.eprintf "%a " Ident.print id) fv;
   Format.eprintf "@.";*)
   let (lam,s) =
     List.fold_left (fun (lam,s) (id',pos,c) ->
-      if IdentSet.mem id' fv then
+      if Ident.Set.mem id' fv then
         let id'' = Ident.create (Ident.name id') in
         (Llet(Alias, Pgenval, id'',
               apply_coercion loc Alias c (get_field pos),lam),
@@ -266,7 +266,7 @@ let reorder_rec_bindings bindings =
         if init.(i) = None then begin
           status.(i) <- Inprogress;
           for j = 0 to num_bindings - 1 do
-            if IdentSet.mem id.(j) fv.(i) then emit_binding j
+            if Ident.Set.mem id.(j) fv.(i) then emit_binding j
           done
         end;
         res := (id.(i), init.(i), rhs.(i)) :: !res;
@@ -472,7 +472,7 @@ and transl_structure loc fields cc rootpath final_env = function
             Format.eprintf "@]@.";*)
             let v = Array.of_list (List.rev fields) in
             let get_field pos = Lvar v.(pos)
-            and ids = List.fold_right IdentSet.add fields IdentSet.empty in
+            and ids = List.fold_right Ident.Set.add fields Ident.Set.empty in
             let lam =
               Lprim(Pmakeblock(0, Immutable, None),
                   List.map
@@ -484,7 +484,7 @@ and transl_structure loc fields cc rootpath final_env = function
                       | _ -> apply_coercion loc Strict cc (get_field pos))
                     pos_cc_list, loc)
             and id_pos_list =
-              List.filter (fun (id,_,_) -> not (IdentSet.mem id ids))
+              List.filter (fun (id,_,_) -> not (Ident.Set.mem id ids))
                 id_pos_list
             in
             wrap_id_pos_list loc id_pos_list get_field lam,
@@ -1143,7 +1143,7 @@ let toploop_setvalue id lam =
 let toploop_setvalue_id id = toploop_setvalue id (Lvar id)
 
 let close_toplevel_term (lam, ()) =
-  IdentSet.fold (fun id l -> Llet(Strict, Pgenval, id,
+  Ident.Set.fold (fun id l -> Llet(Strict, Pgenval, id,
                                   toploop_getvalue id, l))
                 (free_variables lam) lam
 

--- a/bytecomp/translobj.ml
+++ b/bytecomp/translobj.ml
@@ -162,7 +162,7 @@ let transl_label_init f =
 let wrapping = ref false
 let top_env = ref Env.empty
 let classes = ref []
-let method_ids = ref IdentSet.empty
+let method_ids = ref Ident.Set.empty
 
 let oo_add_class id =
   classes := id :: !classes;
@@ -178,7 +178,7 @@ let oo_wrap env req f x =
     cache_required := req;
     top_env := env;
     classes := [];
-    method_ids := IdentSet.empty;
+    method_ids := Ident.Set.empty;
     let lambda = f x in
     let lambda =
       List.fold_left
@@ -207,4 +207,4 @@ let reset () =
   wrapping := false;
   top_env := Env.empty;
   classes := [];
-  method_ids := IdentSet.empty
+  method_ids := Ident.Set.empty

--- a/bytecomp/translobj.mli
+++ b/bytecomp/translobj.mli
@@ -25,7 +25,7 @@ val transl_label_init: (unit -> lambda * 'a) -> lambda * 'a
 val transl_store_label_init:
     Ident.t -> int -> ('a -> lambda) -> 'a -> int * lambda
 
-val method_ids: IdentSet.t ref (* reset when starting a new wrapper *)
+val method_ids: Ident.Set.t ref (* reset when starting a new wrapper *)
 
 val oo_wrap: Env.t -> bool -> ('a -> lambda) -> 'a -> lambda
 val oo_add_class: Ident.t -> Env.t * bool

--- a/middle_end/closure_conversion.ml
+++ b/middle_end/closure_conversion.ml
@@ -19,7 +19,6 @@
 module Env = Closure_conversion_aux.Env
 module Function_decls = Closure_conversion_aux.Function_decls
 module Function_decl = Function_decls.Function_decl
-module IdentSet = Lambda.IdentSet
 
 let name_expr = Flambda_utils.name_expr
 
@@ -602,7 +601,7 @@ and close_functions t external_env function_declarations : Flambda.named =
      a single block with tag [Closure_tag].) *)
   let set_of_closures =
     let free_vars =
-      IdentSet.fold (fun var map ->
+      Ident.Set.fold (fun var map ->
           let internal_var =
             Env.find_var closure_env_without_parameters var
           in

--- a/middle_end/closure_conversion_aux.ml
+++ b/middle_end/closure_conversion_aux.ml
@@ -16,8 +16,6 @@
 
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
-module IdentSet = Lambda.IdentSet
-
 module Env = struct
   type t = {
     variables : Variable.t Ident.tbl;
@@ -90,7 +88,7 @@ module Function_decls = struct
       kind : Lambda.function_kind;
       params : Ident.t list;
       body : Lambda.lambda;
-      free_idents_of_body : IdentSet.t;
+      free_idents_of_body : Ident.Set.t;
       attr : Lambda.function_attribute;
       loc : Location.t;
     }
@@ -128,7 +126,7 @@ module Function_decls = struct
 
   type t = {
     function_decls : Function_decl.t list;
-    all_free_idents : IdentSet.t;
+    all_free_idents : Ident.Set.t;
   }
 
   (* All identifiers free in the bodies of the given function declarations,
@@ -140,8 +138,8 @@ module Function_decls = struct
       function_decls Variable.Map.empty
 
   let all_free_idents function_decls =
-    Variable.Map.fold (fun _ -> IdentSet.union)
-      (free_idents_by_function function_decls) IdentSet.empty
+    Variable.Map.fold (fun _ -> Ident.Set.union)
+      (free_idents_by_function function_decls) Ident.Set.empty
 
   (* All identifiers of simultaneously-defined functions in [ts]. *)
   let let_rec_idents function_decls =
@@ -151,8 +149,8 @@ module Function_decls = struct
   let all_params function_decls =
     List.concat (List.map Function_decl.params function_decls)
 
-  let set_diff (from : IdentSet.t) (idents : Ident.t list) =
-    List.fold_right IdentSet.remove idents from
+  let set_diff (from : Ident.Set.t) (idents : Ident.t list) =
+    List.fold_right Ident.Set.remove idents from
 
   (* CR-someday lwhite: use a different name from above or explain the
      difference *)
@@ -179,7 +177,7 @@ module Function_decls = struct
         t.function_decls (Env.clear_local_bindings external_env)
     in
     (* For free variables. *)
-    IdentSet.fold (fun id env ->
+    Ident.Set.fold (fun id env ->
         Env.add_var env id (Variable.create (Ident.name id)))
       t.all_free_idents closure_env
 end

--- a/middle_end/closure_conversion_aux.mli
+++ b/middle_end/closure_conversion_aux.mli
@@ -74,7 +74,7 @@ module Function_decls : sig
     val loc : t -> Location.t
 
     (* Like [all_free_idents], but for just one function. *)
-    val free_idents : t -> Lambda.IdentSet.t
+    val free_idents : t -> Ident.Set.t
   end
 
   type t
@@ -84,7 +84,7 @@ module Function_decls : sig
 
   (* All identifiers free in the given function declarations after the binding
      of parameters and function identifiers has been performed. *)
-  val all_free_idents : t -> Lambda.IdentSet.t
+  val all_free_idents : t -> Ident.Set.t
 
   (* A map from identifiers to their corresponding [Variable.t]s whose domain
      is the set of all identifiers free in the bodies of the declarations that

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -82,7 +82,7 @@ let toplevel_value id =
 
 let close_phrase lam =
   let open Lambda in
-  IdentSet.fold (fun id l ->
+  Ident.Set.fold (fun id l ->
     let glb, pos = toplevel_value id in
     let glob =
       Lprim (Pfield pos,

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -305,7 +305,6 @@ let contains_type env mty =
 
 module PathSet = Set.Make (Path)
 module PathMap = Map.Make (Path)
-module IdentSet = Set.Make (Ident)
 
 let rec get_prefixes = function
     Pident _ -> PathSet.empty
@@ -334,10 +333,10 @@ let rec collect_ids subst bindings p =
       Pident id ->
         let ids =
           try collect_ids subst bindings (Ident.find_same id bindings)
-          with Not_found -> IdentSet.empty
+          with Not_found -> Ident.Set.empty
         in
-        IdentSet.add id ids
-    | _ -> IdentSet.empty
+        Ident.Set.add id ids
+    | _ -> Ident.Set.empty
     end
 
 let collect_arg_paths mty =
@@ -365,8 +364,8 @@ let collect_arg_paths mty =
   let it = {type_iterators with it_path; it_signature_item} in
   it.it_module_type it mty;
   it.it_module_type unmark_iterators mty;
-  PathSet.fold (fun p -> IdentSet.union (collect_ids !subst !bindings p))
-    !paths IdentSet.empty
+  PathSet.fold (fun p -> Ident.Set.union (collect_ids !subst !bindings p))
+    !paths Ident.Set.empty
 
 let rec remove_aliases env excl mty =
   match mty with
@@ -385,7 +384,7 @@ and remove_aliases_sig env excl sg =
   | Sig_module(id, md, rs) :: rem  ->
       let mty =
         match md.md_type with
-          Mty_alias _ when IdentSet.mem id excl ->
+          Mty_alias _ when Ident.Set.mem id excl ->
             md.md_type
         | mty ->
             remove_aliases env excl mty


### PR DESCRIPTION
This avoids to have multiple instances of the same functor with same argument.