### PR TITLE
Don't treat unboxed constructors as having statically-known size in the let-rec check

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,9 @@ Working version
 
 ### Type system:
 
+- MPR#7717, GPR#1593: don't treat unboxed constructor size as statically known
+  (Jeremy Yallop, report by Pierre Chambart, review by Gabriel Scherer)
+
 - MPR#7611, GPR#1491: reject the use of generative functors as applicative
   (Valentin Gatien-Baron)
 

--- a/testsuite/tests/letrec-disallowed/unboxed.ml
+++ b/testsuite/tests/letrec-disallowed/unboxed.ml
@@ -8,3 +8,22 @@ let rec x = {x = y} and y = 3L;;
 type r = A of r [@@unboxed];;
 let rec y = A y;;
               
+type a = {a: b }[@@unboxed]
+and b = X of a | Y
+
+let rec a =
+  {a=
+    (if Sys.opaque_identity true then
+       X a
+     else
+       Y)};;
+
+type d = D of e [@@unboxed]
+and e = V of d | W;;
+
+let rec d =
+  D
+    (if Sys.opaque_identity true then
+       V d
+     else
+       W);;

--- a/testsuite/tests/letrec-disallowed/unboxed.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/unboxed.ocaml.reference
@@ -8,4 +8,20 @@ Characters 12-15:
   let rec y = A y;;
               ^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
+Characters 77-150:
+  ..{a=
+      (if Sys.opaque_identity true then
+         X a
+       else
+         Y)}..
+Error: This kind of expression is not allowed as right-hand side of `let rec'
+type d = D of e [@@unboxed]
+and e = V of d | W
+Characters 15-85:
+  ..D
+      (if Sys.opaque_identity true then
+         V d
+       else
+         W)..
+Error: This kind of expression is not allowed as right-hand side of `let rec'
 

--- a/testsuite/tests/letrec/allowed.ml
+++ b/testsuite/tests/letrec/allowed.ml
@@ -103,3 +103,6 @@ let rec d =
        V d
      else
        W);;
+
+type r = R of r list [@@unboxed];;
+let rec a = R [a];;

--- a/testsuite/tests/letrec/allowed.ml
+++ b/testsuite/tests/letrec/allowed.ml
@@ -79,3 +79,27 @@ let rec deep_cycle : [`Tuple of [`Shared of 'a] array] as 'a
    by an overzealous check.  Constructing float arrays in recursive
    bindings is fine when they don't partake in the recursion. *)
 let rec _x = let _ = [| 1.0 |] in 1. in ();;
+
+(* This test is not allowed if 'a' is unboxed, but should be accepted
+   as written *)
+type a = {a: b}
+and b = X of a | Y
+
+let rec a =
+  {a=
+    (if Sys.opaque_identity true then
+       X a
+     else
+       Y)};;
+
+(* This test is not allowed if 'c' is unboxed, but should be accepted
+   as written *)
+type d = D of e
+and e = V of d | W;;
+
+let rec d =
+  D
+    (if Sys.opaque_identity true then
+       V d
+     else
+       W);;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1956,6 +1956,13 @@ struct
       | Texp_letmodule (_, _, _, e)
       | Texp_sequence (_, e)
       | Texp_letexception (_, e) -> classify_expression e
+      | Texp_construct (_, {cstr_tag = Cstr_unboxed}, [e]) ->
+          classify_expression e
+      | Texp_construct _ -> Static
+      | Texp_record { representation = Record_unboxed _;
+                      fields = [| _, Overridden (_,e) |] } ->
+          classify_expression e
+      | Texp_record _ -> Static
       | Texp_ident _
       | Texp_for _
       | Texp_constant _
@@ -1963,9 +1970,7 @@ struct
       | Texp_instvar _
       | Texp_tuple _
       | Texp_array _
-      | Texp_construct _
       | Texp_variant _
-      | Texp_record _
       | Texp_setfield _
       | Texp_while _
       | Texp_setinstvar _


### PR DESCRIPTION
Fixes [PR7717](https://caml.inria.fr/mantis/view.php?id=7717).

Here's @chambart's test case

```ocaml
type a = A of b [@@unboxed]
and b = X of a | Y

let rec a = A (if Sys.opaque_identity true then X a else Y)
```

Previously this would pass the `let rec` well-formedness check, compile, and crash when `a` was examined.

This PR changes the code to special-case unboxed variants and records so that they're no longer considered to have statically-known size.  After this PR the rhs of the `let rec` binding is considered dynamic and the program is rejected.