### PR TITLE
add information in Asmcomp.Asmlink fatal error

### DIFF
--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -119,7 +119,7 @@ let object_file_name name =
     try
       find_in_path !load_path name
     with Not_found ->
-      fatal_error "Asmlink.object_file_name: not found" in
+      fatal_errorf "Asmlink.object_file_name: %s not found" name in
   if Filename.check_suffix file_name ".cmx" then
     Filename.chop_suffix file_name ".cmx" ^ ext_obj
   else if Filename.check_suffix file_name ".cmxa" then


### PR DESCRIPTION
I ran into this error: `Fatal error: Asmlink.object_file_name: not found`.
Judging from the code, it looks like a race on the filesystem, but I don't see how that could have happened either, so at least let's display what it is that was not found.