### PR TITLE
MPR#7720, format documentation: maximum indentation limit

### DIFF
--- a/Changes
+++ b/Changes
@@ -717,6 +717,10 @@ OCaml 4.07.0 (10 July 2018)
   mostly in Chapter 1.  This addresses the easier changes suggested in the PR.
   (Jim Fehrle, review by Florian Angeletti and David Allsopp)
 
+- MPR#7720, GPR#1596, precise the documentation of the maximum indentation limit
+  in Format.
+  (Florian Angeletti, review by Richard Bonichon and Pierre Weis)
+
 - GPR#1540: manual, decouple verbatim and toplevel style in code examples.
   (Florian Angeletti, review by Gabriel Scherer)
 

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -376,7 +376,25 @@ val set_max_indent : int -> unit
 (** [pp_set_max_indent ppf d] sets the maximum indentation limit of lines
   to [d] (in characters):
   once this limit is reached, new pretty-printing boxes are rejected to the
-  left, if they do not fit on the current line.
+  left, unless the enclosing box fully fits on the current line.
+  As an illustration,
+  {[ set_margin 10; set_max_indent 5; printf "@[123456@[7@]89A@]@." ]}
+  yields
+  {[
+    123456
+    789A
+  ]}
+  because the nested box ["@[7@]"] is opened after the maximum indentation
+  limit ([7>5]) and its parent box does not fit on the current line.
+  Either decreasing the length of the parent box to make it fit on a line:
+  {[ printf "@[123456@[7@]89@]@." ]}
+  or opening an intermediary box before the maximum indentation limit which
+  fits on the current line
+  {[ printf "@[123@[456@[7@]89@]A@]@." ]}
+  avoids the rejection to the left of the inner boxes and print respectively
+  ["123456789"] and ["123456789A"] .
+  Note also that vertical boxes never fit on a line whereas horizontal boxes
+  always fully fit on the current line.
 
   Nothing happens if [d] is smaller than 2.
   If [d] is too large, the limit is set to the maximum


### PR DESCRIPTION
This PR proposes to fix a discrepancy between the documentation of `Format.set_indent` and the implemented behavior of Format on the subject of when a new box is rejected to the left.

The current documentation precises that
> pp_set_max_indent ppf d sets the maximum indentation limit of lines to d (in characters): once this limit is reached, new pretty-printing boxes are rejected to the left, if they do not fit on the current line.

With this documentation, it seems natural to expect that
```OCaml
 set_margin 10;
set_max_indent 5; printf "@[123456@[7@]89A@]@."
```
displays
> "123456789A"

since the contents of the box `@[7@]` does fit on the line.

However, the currently implemented behavior is to reject new box opened after the indentation limit to the left if their *parent* box does not fit on the line (i.e. if they are not replaced by a fit box). Consequently, the previous example rejects the inner box to the left and prints

> 123456
> 789A

whereas both `printf "@[123456@[7@]89@]@."` and `printf "@[123@[456@[7@]89@]A@]@."` avoid this rejection to the left and prints `123456789` and `123456789A` respectively.

This PR updates the documentation to reflect the current behavior and adds the three examples above to illustrate this behavior.