### PR TITLE
Ensure env vars don't exist prior to win-env test

### DIFF
--- a/Changes
+++ b/Changes
@@ -54,6 +54,10 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- #1599: add unset directive to ocamltest to clear environment variables before
+  running tests.
+  (David Allsopp, review by Damien Doligez and Sébastien Hinderer)
+
 - #10433: Remove the distinction between 32-bit aligned and 64-bit aligned
   64-bit floats in Cmm.memory_chunk.
   (Greta Yorsh, review by Xavier Leroy)

--- a/ocamltest/actions_helpers.ml
+++ b/ocamltest/actions_helpers.ml
@@ -160,9 +160,9 @@ let run_cmd
   log_redirection "stdout" stdout_filename;
   log_redirection "stderr" stderr_filename;
   let systemenv =
-    Array.append
+    Environments.append_to_system_env
       environment
-      (Environments.to_system_env env)
+      env
   in
   let timeout =
     match timeout with

--- a/ocamltest/environments.ml
+++ b/ocamltest/environments.ml
@@ -19,12 +19,14 @@ open Ocamltest_stdlib
 
 module VariableMap = Map.Make (Variables)
 
-type t = string VariableMap.t
+type t = string option VariableMap.t
 
 let empty = VariableMap.empty
 
 let to_bindings env =
-  let f variable value lst = (variable, value) :: lst in
+  let f variable value lst =
+    Option.fold ~none:lst ~some:(fun value -> (variable, value) :: lst) value
+  in
   VariableMap.fold f env []
 
 let expand_aux env value =
@@ -39,15 +41,47 @@ let rec expand env value =
   let expanded = expand_aux env value in
   if expanded=value then value else expand env expanded
 
-let to_system_env env =
+let expand env = function
+| None -> raise Not_found
+| Some value -> expand env value
+
+let append_to_system_env environment env =
+  (* Augment env with any bindings which are only in environment. This must be
+     done here as the Windows C implementation doesn't process multiple values
+     coming in in settings.envp. *)
+  let env =
+    let update env binding =
+      let name, value =
+        match String.index binding '=' with
+        | c ->
+            let name = String.sub binding 0 c in
+            let value =
+              String.sub binding (c + 1) (String.length binding - c - 1) in
+            (name, Some value)
+        | exception Not_found ->
+            (binding, None)
+      in
+      let var = Variables.make (name, "system env var") in
+        if not (VariableMap.mem var env) then
+          VariableMap.add var value env
+        else
+          env
+    in
+      Array.fold_left update env environment
+  in
   let system_env = Array.make (VariableMap.cardinal env) "" in
   let i = ref 0 in
   let store variable value =
+    let some value =
+      Variables.string_of_binding variable (expand env (Some value)) in
     system_env.(!i) <-
-      Variables.string_of_binding variable (expand env value);
+      Option.fold ~none:(Variables.name_of_variable variable) ~some value;
     incr i in
   VariableMap.iter store env;
   system_env
+
+let to_system_env env =
+  append_to_system_env [||] env
 
 let lookup variable env =
   try Some (expand env (VariableMap.find variable env)) with Not_found -> None
@@ -75,7 +109,7 @@ let safe_lookup variable env = match lookup variable env with
 let is_variable_defined variable env =
   VariableMap.mem variable env
 
-let add variable value env = VariableMap.add variable value env
+let add variable value env = VariableMap.add variable (Some value) env
 
 let add_if_undefined variable value env =
   if VariableMap.mem variable env then env else add variable value env
@@ -83,9 +117,10 @@ let add_if_undefined variable value env =
 let append variable appened_value environment =
   let previous_value = safe_lookup variable environment in
   let new_value = previous_value ^ appened_value in
-  VariableMap.add variable new_value environment
+  VariableMap.add variable (Some new_value) environment
 
-let remove = VariableMap.remove
+let remove variable environment =
+  VariableMap.add variable None environment
 
 let add_bindings bindings env =
   let f env (variable, value) = add variable value env in
@@ -93,8 +128,10 @@ let add_bindings bindings env =
 
 let from_bindings bindings = add_bindings bindings empty
 
-let dump_assignment log (variable, value) =
+let dump_assignment log = function
+| (variable, Some value) ->
   Printf.fprintf log "%s = %s\n%!" (Variables.name_of_variable variable) value
+| (_, None) -> ()
 
 let dump log environment =
   List.iter (dump_assignment log) (VariableMap.bindings environment)
@@ -158,6 +195,7 @@ let rec apply_modifier environment = function
     apply_modifiers environment (find_modifiers modifiers_name)
   | Add (variable, value) -> add variable value environment
   | Append (variable, value) -> append variable value environment
-  | Remove variable -> remove variable environment
+    (* XXX Is this used any where - does it actually work? *)
+  | Remove variable -> VariableMap.remove variable environment
 and apply_modifiers environment modifiers =
   List.fold_left apply_modifier environment modifiers

--- a/ocamltest/environments.ml
+++ b/ocamltest/environments.ml
@@ -48,7 +48,7 @@ let expand env = function
 let append_to_system_env environment env =
   (* Augment env with any bindings which are only in environment. This must be
      done here as the Windows C implementation doesn't process multiple values
-     coming in in settings.envp. *)
+     in settings.envp. *)
   let env =
     let update env binding =
       let name, value =
@@ -119,7 +119,9 @@ let append variable appened_value environment =
   let new_value = previous_value ^ appened_value in
   VariableMap.add variable (Some new_value) environment
 
-let remove variable environment =
+let remove = VariableMap.remove
+
+let unsetenv variable environment =
   VariableMap.add variable None environment
 
 let add_bindings bindings env =
@@ -131,7 +133,8 @@ let from_bindings bindings = add_bindings bindings empty
 let dump_assignment log = function
   | (variable, Some value) ->
     Printf.fprintf log "%s = %s\n%!" (Variables.name_of_variable variable) value
-  | (_, None) -> ()
+  | (variable, None) ->
+    Printf.fprintf log "unsetenv %s\n%!" (Variables.name_of_variable variable)
 
 let dump log environment =
   List.iter (dump_assignment log) (VariableMap.bindings environment)
@@ -195,7 +198,6 @@ let rec apply_modifier environment = function
     apply_modifiers environment (find_modifiers modifiers_name)
   | Add (variable, value) -> add variable value environment
   | Append (variable, value) -> append variable value environment
-    (* XXX Is this used any where - does it actually work? *)
-  | Remove variable -> VariableMap.remove variable environment
+  | Remove variable -> remove variable environment
 and apply_modifiers environment modifiers =
   List.fold_left apply_modifier environment modifiers

--- a/ocamltest/environments.ml
+++ b/ocamltest/environments.ml
@@ -42,8 +42,8 @@ let rec expand env value =
   if expanded=value then value else expand env expanded
 
 let expand env = function
-| None -> raise Not_found
-| Some value -> expand env value
+  | None -> raise Not_found
+  | Some value -> expand env value
 
 let append_to_system_env environment env =
   (* Augment env with any bindings which are only in environment. This must be
@@ -129,9 +129,9 @@ let add_bindings bindings env =
 let from_bindings bindings = add_bindings bindings empty
 
 let dump_assignment log = function
-| (variable, Some value) ->
-  Printf.fprintf log "%s = %s\n%!" (Variables.name_of_variable variable) value
-| (_, None) -> ()
+  | (variable, Some value) ->
+    Printf.fprintf log "%s = %s\n%!" (Variables.name_of_variable variable) value
+  | (_, None) -> ()
 
 let dump log environment =
   List.iter (dump_assignment log) (VariableMap.bindings environment)

--- a/ocamltest/environments.mli
+++ b/ocamltest/environments.mli
@@ -43,7 +43,9 @@ val add : Variables.t -> string -> t -> t
 val add_if_undefined : Variables.t -> string -> t -> t
 val add_bindings : (Variables.t * string) list -> t -> t
 
-val remove : Variables.t -> t -> t
+val unsetenv : Variables.t -> t -> t
+(** [unsetenv env name] causes [name] to be ignored from the underlying system
+    environment *)
 
 val append : Variables.t -> string -> t -> t
 

--- a/ocamltest/environments.mli
+++ b/ocamltest/environments.mli
@@ -22,6 +22,7 @@ val empty : t
 val from_bindings : (Variables.t * string) list -> t
 val to_bindings : t -> (Variables.t * string) list
 val to_system_env : t -> string array
+val append_to_system_env : string array -> t -> string array
 
 val lookup : Variables.t -> t -> string option
 val lookup_nonempty : Variables.t -> t -> string option
@@ -41,6 +42,8 @@ val lookup_as_int : Variables.t -> t -> int option
 val add : Variables.t -> string -> t -> t
 val add_if_undefined : Variables.t -> string -> t -> t
 val add_bindings : (Variables.t * string) list -> t -> t
+
+val remove : Variables.t -> t -> t
 
 val append : Variables.t -> string -> t -> t
 

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -86,7 +86,7 @@ let rec run_test log common_prefix path behavior = function
   let (msg, children_behavior, summary) = match behavior with
     | Skip_all_tests -> "n/a", Skip_all_tests, No_failure
     | Run env ->
-      let testenv0 = interprete_environment_statements env testenvspec in
+      let testenv0 = interpret_environment_statements env testenvspec in
       let testenv = List.fold_left apply_modifiers testenv0 env_modifiers in
       let (result, newenv) = Tests.run log testenv test in
       let msg = Result.string_of_result result in
@@ -193,8 +193,7 @@ let test_file test_filename =
        let rootenv =
          Environments.initialize Environments.Pre log initial_environment in
        let rootenv =
-         interprete_environment_statements
-           rootenv rootenv_statements in
+         interpret_environment_statements rootenv rootenv_statements in
        let rootenv = Environments.initialize Environments.Post log rootenv in
        let common_prefix = " ... testing '" ^ test_basename ^ "' with" in
        let initial_status =

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -533,9 +533,9 @@ let debug log env =
     program
   ] in
   let systemenv =
-    Array.append
+    Environments.append_to_system_env
       default_ocaml_env
-      (Environments.to_system_env (env_with_lib_unix env))
+      (env_with_lib_unix env)
   in
   let expected_exit_status = 0 in
   let exit_status =
@@ -570,12 +570,13 @@ let objinfo log env =
   ] in
   let ocamllib = [| (Printf.sprintf "OCAMLLIB=%s" tools_directory) |] in
   let systemenv =
-    Array.concat
-    [
-      default_ocaml_env;
-      ocamllib;
-      (Environments.to_system_env (env_with_lib_unix env))
-    ]
+    Environments.append_to_system_env
+      (Array.concat
+       [
+         default_ocaml_env;
+         ocamllib;
+       ])
+      (env_with_lib_unix env)
   in
   let expected_exit_status = 0 in
   let exit_status =

--- a/ocamltest/ocaml_variables.ml
+++ b/ocamltest/ocaml_variables.ml
@@ -54,7 +54,7 @@ let export_caml_ld_library_path value =
     if local_value="" then current_value else
     if current_value="" then local_value else
     String.concat Filename.path_sep [local_value; current_value] in
-  Printf.sprintf "%s=%s" caml_ld_library_path_name new_value
+  (caml_ld_library_path_name, new_value)
 
 let caml_ld_library_path =
   make_with_exporter
@@ -183,7 +183,7 @@ let ocamlopt_opt_exit_status = make ("ocamlopt_opt_exit_status",
   "Expected exit status of ocamlopt.opt")
 
 let export_ocamlrunparam value =
-  Printf.sprintf "%s=%s" "OCAMLRUNPARAM" value
+  ("OCAMLRUNPARAM", value)
 
 let ocamlrunparam =
   make_with_exporter

--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -149,6 +149,8 @@ static void update_environment(array local_env)
       setenv(name, value, 1); /* 1 means overwrite */
       free(name);
       free(value);
+    } else {
+      unsetenv(*envp);
     }
   }
 }

--- a/ocamltest/run_win32.c
+++ b/ocamltest/run_win32.c
@@ -190,9 +190,9 @@ static LPVOID prepare_environment(WCHAR **localenv)
       if (!wcscmp(*q, p)) copy = 0;
       if (pos_eq2) *pos_eq2 = L'=';
     }
+    *pos_eq = L'=';
     if (copy) {
       /* This name is not marked for deletion/update in localenv, so copy */
-      *pos_eq = L'=';
       memcpy(r, p, l * sizeof(WCHAR));
       r += l;
     }

--- a/ocamltest/run_win32.c
+++ b/ocamltest/run_win32.c
@@ -163,10 +163,8 @@ static LPVOID prepare_environment(WCHAR **localenv)
 
   /* Compute length of local environment */
   localenv_length = 0;
-  q = localenv;
-  while (*q != NULL) {
+  for (q = localenv; *q != NULL; q++) {
     localenv_length += wcslen(*q) + 1;
-    q++;
   }
 
   /* Build new env that contains both process and local env */
@@ -185,14 +183,12 @@ static LPVOID prepare_environment(WCHAR **localenv)
     l = wcslen(p) + 1; /* also count terminating '\0' */
     /* Temporarily change the = to \0 for wcscmp */
     *pos_eq = L'\0';
-    q = localenv;
-    while (*q != NULL) {
+    for (q = localenv; *q != NULL; q++) {
       wchar_t *pos_eq2 = wcschr(*q, L'=');
       /* Compare this name in localenv with the current one in processenv */
       if (pos_eq2) *pos_eq2 = L'\0';
       if (!wcscmp(*q, p)) copy = 0;
       if (pos_eq2) *pos_eq2 = L'=';
-      q++;
     }
     if (copy) {
       /* This name is not marked for deletion/update in localenv, so copy */
@@ -203,8 +199,7 @@ static LPVOID prepare_environment(WCHAR **localenv)
     p += l;
   }
   FreeEnvironmentStrings(process_env);
-  q = localenv;
-  while (*q != NULL) {
+  for (q = localenv; *q != NULL; q++) {
     /* A string in localenv without '=' signals deletion, which has been done */
     wchar_t *pos_eq = wcschr(*q, L'=');
     if (pos_eq) {
@@ -212,7 +207,6 @@ static LPVOID prepare_environment(WCHAR **localenv)
       memcpy(r, *q, l * sizeof(WCHAR));
       r += l;
     }
-    q++;
   }
   *r = L'\0';
   return env;

--- a/ocamltest/tsl_ast.ml
+++ b/ocamltest/tsl_ast.ml
@@ -24,6 +24,7 @@ type environment_statement =
   | Assignment of bool * string located * string located (* variable = value *)
   | Append of string located * string located
   | Include of string located (* include named environment *)
+  | Unset of string located (* clear environment variable *)
 
 type tsl_item =
   | Environment_statement of environment_statement located

--- a/ocamltest/tsl_ast.mli
+++ b/ocamltest/tsl_ast.mli
@@ -24,6 +24,7 @@ type environment_statement =
   | Assignment of bool * string located * string located (* variable = value *)
   | Append of string located * string located (* variable += value *)
   | Include of string located (* include named environment *)
+  | Unset of string located (* clear environment variable *)
 
 type tsl_item =
   | Environment_statement of environment_statement located

--- a/ocamltest/tsl_lexer.mll
+++ b/ocamltest/tsl_lexer.mll
@@ -47,6 +47,7 @@ rule token = parse
       match s with
         | "include" -> INCLUDE
         | "set" -> SET
+        | "unset" -> UNSET
         | "with" -> WITH
         | _ -> IDENTIFIER s
     }

--- a/ocamltest/tsl_parser.mly
+++ b/ocamltest/tsl_parser.mly
@@ -37,7 +37,7 @@ let mkenvstmt envstmt =
 %token <int> TEST_DEPTH
 %token EQUAL PLUSEQUAL
 /* %token COLON */
-%token INCLUDE SET WITH
+%token INCLUDE SET UNSET WITH
 %token <string> IDENTIFIER
 %token <string> STRING
 
@@ -76,6 +76,8 @@ env_item:
     { mkenvstmt (Append ($1, $3)) }
 | SET identifier EQUAL string
     { mkenvstmt (Assignment (true, $2, $4)) }
+| UNSET identifier
+    { mkenvstmt (Unset $2) }
 
 | INCLUDE identifier
   { mkenvstmt (Include $2) }

--- a/ocamltest/tsl_semantics.ml
+++ b/ocamltest/tsl_semantics.ml
@@ -80,7 +80,7 @@ let interpret_environment_statement env statement = match statement.node with
         | None -> Variables.make (var.node,"User variable")
         | Some var -> var
       in
-      Environments.remove var env
+      Environments.unsetenv var env
 
 let interpret_environment_statements env l =
   List.fold_left interpret_environment_statement env l

--- a/ocamltest/tsl_semantics.ml
+++ b/ocamltest/tsl_semantics.ml
@@ -67,16 +67,23 @@ let append_to_env loc variable_name value env =
   with Variables.No_such_variable name ->
     no_such_variable loc name
 
-let interprete_environment_statement env statement = match statement.node with
+let interpret_environment_statement env statement = match statement.node with
   | Assignment (decl, var, value) ->
       add_to_env decl statement.loc var.node value.node env
   | Append (var, value) ->
       append_to_env statement.loc var.node value.node env
   | Include modifiers_name ->
       apply_modifiers env modifiers_name
+  | Unset var ->
+      let var =
+        match Variables.find_variable var.node with
+        | None -> Variables.make (var.node,"User variable")
+        | Some var -> var
+      in
+      Environments.remove var env
 
-let interprete_environment_statements env l =
-  List.fold_left interprete_environment_statement env l
+let interpret_environment_statements env l =
+  List.fold_left interpret_environment_statement env l
 
 type test_tree =
   | Node of

--- a/ocamltest/tsl_semantics.mli
+++ b/ocamltest/tsl_semantics.mli
@@ -19,11 +19,11 @@ open Tsl_ast
 
 val apply_modifiers : Environments.t -> string located -> Environments.t
 
-val interprete_environment_statement :
+val interpret_environment_statement :
   Environments.t -> Tsl_ast.environment_statement Tsl_ast.located ->
   Environments.t
 
-val interprete_environment_statements :
+val interpret_environment_statements :
   Environments.t -> Tsl_ast.environment_statement Tsl_ast.located list ->
   Environments.t
 

--- a/ocamltest/variables.ml
+++ b/ocamltest/variables.ml
@@ -17,7 +17,7 @@
 
 type value = string
 
-type exporter = value -> string
+type exporter = value -> string * string
 
 type t = {
   variable_name : string;
@@ -33,7 +33,7 @@ exception Variable_already_registered of string
 
 exception No_such_variable of string
 
-let default_exporter varname value = Printf.sprintf "%s=%s" varname value
+let default_exporter varname value = (varname, value)
 
 let make (name, description) =
   if name="" then raise Empty_variable_name else {
@@ -65,7 +65,8 @@ let find_variable variable_name =
   with Not_found -> None
 
 let string_of_binding variable value =
-  variable.variable_exporter value
+  let (varname, value) = variable.variable_exporter value in
+  Printf.sprintf "%s=%s" varname value
 
 let get_registered_variables () =
   let f _variable_name variable variable_list = variable::variable_list in

--- a/ocamltest/variables.mli
+++ b/ocamltest/variables.mli
@@ -17,7 +17,7 @@
 
 type value = string
 
-type exporter = value -> string
+type exporter = value -> string * string
 
 type t
 

--- a/testsuite/tests/basic/opt_variants.ml
+++ b/testsuite/tests/basic/opt_variants.ml
@@ -1,7 +1,9 @@
-(* TEST *)
+(* TEST
+unset DOES_NOT_EXIST
+*)
 
 let () =
-  assert(Sys.getenv_opt "FOOBAR_UNLIKELY_TO_EXIST_42" = None);
+  assert(Sys.getenv_opt "DOES_NOT_EXIST" = None);
 
   assert(int_of_string_opt "foo" = None);
   assert(int_of_string_opt "42" = Some 42);

--- a/testsuite/tests/lib-threads/pr7638.ml
+++ b/testsuite/tests/lib-threads/pr7638.ml
@@ -1,5 +1,7 @@
 (* TEST
 
+unset FOO
+
 * hassysthreads
 include systhreads
 ** bytecode
@@ -15,5 +17,5 @@ let crashme v =
   | s -> print_string "Surprising but OK\n"
 
 let _ =
-  let th = Thread.create crashme "no such variable" in
+  let th = Thread.create crashme "FOO" in
   Thread.join th

--- a/testsuite/tests/lib-threads/pr7638.ml
+++ b/testsuite/tests/lib-threads/pr7638.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-unset FOO
+unset DOES_NOT_EXIST
 
 * hassysthreads
 include systhreads
@@ -17,5 +17,5 @@ let crashme v =
   | s -> print_string "Surprising but OK\n"
 
 let _ =
-  let th = Thread.create crashme "FOO" in
+  let th = Thread.create crashme "DOES_NOT_EXIST" in
   Thread.join th

--- a/testsuite/tests/lib-unix/common/redirections.ml
+++ b/testsuite/tests/lib-unix/common/redirections.ml
@@ -1,6 +1,7 @@
 (* TEST
 
 readonly_files = "reflector.ml"
+unset XVAR
 
 * hasunix
 ** setup-ocamlc.byte-build-env

--- a/testsuite/tests/lib-unix/common/test_unix_cmdline.ml
+++ b/testsuite/tests/lib-unix/common/test_unix_cmdline.ml
@@ -31,27 +31,25 @@ all_modules= "test_unix_cmdline.ml"
 
 *)
 
-open Unix
-
 let prog_name = "cmdline_prog.exe"
 
 let run args =
-  let out, inp = pipe () in
-  let in_chan = in_channel_of_descr out in
+  let out, inp = Unix.pipe () in
+  let in_chan = Unix.in_channel_of_descr out in
   set_binary_mode_in in_chan false;
   let pid =
-    create_process ("./" ^ prog_name) (Array.of_list (prog_name :: args))
+    Unix.create_process ("./" ^ prog_name) (Array.of_list (prog_name :: args))
       Unix.stdin inp Unix.stderr in
   List.iter (fun arg ->
       let s = input_line in_chan in
       Printf.printf "%S -> %S [%s]\n" arg s (if s = arg then "OK" else "FAIL")
     ) args;
   close_in in_chan;
-  let _, exit = waitpid [] pid in
-  assert (exit = WEXITED 0)
+  let _, exit = Unix.waitpid [] pid in
+  assert (exit = Unix.WEXITED 0)
 
 let exec args =
-  execv ("./" ^ prog_name) (Array.of_list (prog_name :: args))
+  Unix.execv ("./" ^ prog_name) (Array.of_list (prog_name :: args))
 
 let () =
   List.iter run

--- a/testsuite/tests/lib-unix/unix-execvpe/exec.ml
+++ b/testsuite/tests/lib-unix/unix-execvpe/exec.ml
@@ -1,4 +1,5 @@
 (* TEST
+   unset FOO
    * hasunix
    include unix
    script = "sh ${test_source_directory}/has-execvpe.sh"

--- a/testsuite/tests/lib-unix/unix-socket/recvfrom.ml
+++ b/testsuite/tests/lib-unix/unix-socket/recvfrom.ml
@@ -1,17 +1,15 @@
-open Unix
-
 let path_of_addr = function
-  | ADDR_UNIX path -> path
+  | Unix.ADDR_UNIX path -> path
   | _ -> assert false
 ;;
 
 let test_sender ~client_socket ~server_socket ~server_addr ~client_addr =
   Printf.printf "%S" (path_of_addr client_addr);
   let byte = Bytes.make 1 't' in
-  let sent_len = sendto client_socket byte 0 1 [] server_addr in
+  let sent_len = Unix.sendto client_socket byte 0 1 [] server_addr in
   assert (sent_len = 1);
   let buf = Bytes.make 1024 '\x00' in
-  let (recv_len, sender) = recvfrom server_socket buf 0 1024 [] in
+  let (recv_len, sender) = Unix.recvfrom server_socket buf 0 1024 [] in
 
   Printf.printf " as %S: " (path_of_addr sender);
   assert (sender = client_addr);
@@ -19,15 +17,15 @@ let test_sender ~client_socket ~server_socket ~server_addr ~client_addr =
   print_endline "OK";;
 
 let ensure_no_file path =
-  try unlink path with Unix_error (ENOENT, _, _) -> ();;
+  try Unix.unlink path with Unix.Unix_error (ENOENT, _, _) -> ();;
 
 let with_socket fn =
-  let s = socket PF_UNIX SOCK_DGRAM 0 in
-  Fun.protect ~finally:(fun () -> close s) (fun () -> fn s)
+  let s = Unix.socket PF_UNIX SOCK_DGRAM 0 in
+  Fun.protect ~finally:(fun () -> Unix.close s) (fun () -> fn s)
 
 let with_bound_socket path fn =
   with_socket (fun s ->
-    let addr = ADDR_UNIX path in
-    bind s addr;
+    let addr = Unix.ADDR_UNIX path in
+    Unix.bind s addr;
     fn addr s
   )

--- a/testsuite/tests/lib-unix/win-env/test_env.ml
+++ b/testsuite/tests/lib-unix/win-env/test_env.ml
@@ -1,4 +1,6 @@
 (* TEST
+unset FOO
+unset FOO2
 include unix
 flags += "-strict-sequence -safe-string -w +A-70 -warn-error +A"
 modules = "stubs.c"

--- a/testsuite/tests/lib-unix/win-stat/test.ml
+++ b/testsuite/tests/lib-unix/win-stat/test.ml
@@ -6,11 +6,10 @@ include unix
 ** native
 *)
 
-open Unix
-
 external set_fake_clock : int64 -> unit = "set_fake_clock"
 
-let real_time tm = {tm with tm_year = tm.tm_year + 1900; tm_mon = tm.tm_mon + 1}
+let real_time tm =
+  Unix.{tm with tm_year = tm.tm_year + 1900; tm_mon = tm.tm_mon + 1}
 
 let print_time () =
   let time = Unix.time () |> Unix.gmtime |> real_time in

--- a/testsuite/tests/output-complete-obj/test2.ml
+++ b/testsuite/tests/output-complete-obj/test2.ml
@@ -2,6 +2,7 @@
 
 readonly_files = "puts.c"
 use_runtime = "false"
+unset FOO
 
 * hasunix
 include unix

--- a/testsuite/tests/win-unicode/mltest.compilers.reference
+++ b/testsuite/tests/win-unicode/mltest.compilers.reference
@@ -14,7 +14,8 @@ val unix_readdir : string -> string list = <fun>
 val sys_readdir : string -> string list = <fun>
 val test_readdir : (string -> string list) -> string list = <fun>
 val test_open_in : unit -> string list = <fun>
-val test_getenv : unit -> (string * string) list = <fun>
+val test_getenv : unit -> ((string * string) * (string * string)) list =
+  <fun>
 val test_mkdir : unit -> (bool * bool) list = <fun>
 val test_chdir : (string -> unit) -> (unit -> 'a) -> 'a list = <fun>
 val test_rmdir : unit -> bool list = <fun>
@@ -76,8 +77,11 @@ val t_sys_rename : ((bool * bool) * (bool * bool)) list =
 val t_sys_chdir : string list = ["été"; "simple"; "sœur"; "你好"]
 val t_unix_chdir : string list = ["été"; "simple"; "sœur"; "你好"]
 - : bool list = [false; false; false; false]
-val t_getenv : (string * string) list =
-  [("верблюды", "верблюды"); ("骆驼", "骆驼");
-   ("קעמל", "קעמל"); ("اونٹ", "اونٹ")]
+val t_getenv : ((string * string) * (string * string)) list =
+  [(("верблюды", "верблюды"),
+    ("верблюдыверблюды", "верблюдыверблюды"));
+   (("骆驼", "骆驼"), ("骆驼骆驼", "骆驼骆驼"));
+   (("קעמל", "קעמל"), ("קעמלקעמל", "קעמלקעמל"));
+   (("اونٹ", "اونٹ"), ("اونٹاونٹ", "اونٹاونٹ"))]
 - : bool = true
 

--- a/testsuite/tests/win-unicode/mltest.ml
+++ b/testsuite/tests/win-unicode/mltest.ml
@@ -144,9 +144,18 @@ let test_open_in () =
 ;;
 
 let test_getenv () =
+  let equiv l r =
+    assert (l = r);
+    l, r
+  in
   let doit key s =
     Unix.putenv key s;
-    Sys.getenv key, getenvironmentenv key
+    let l = equiv (Sys.getenv key) (getenvironmentenv key) in
+    let r =
+      Unix.putenv key (s ^ s);
+      equiv (Sys.getenv key) (getenvironmentenv key)
+    in
+      l, r
   in
   List.map2 doit foreign_names foreign_names2
 ;;


### PR DESCRIPTION
The `test_env.ml` test in `tests/lib-unix/win-env` sets environment variables called `FOO` and `FOO2`. I just hit a false-negative testing 4.06.1 because my environment happened to include the environment variable `FOO` from something else I'd been doing.

This tiny tweak ensures that the variables are unset before the test is run - less of an issue as the 4.07 version of this test is slightly different, though still capable of producing a false positive.