### PR TITLE
added support for caml_alloc_abstract

### DIFF
--- a/Changes
+++ b/Changes
@@ -123,6 +123,8 @@ Working version
 
 ### Runtime system:
 
+- MPR#7721, GPR#1602: add support for caml_alloc_octets
+
 - MPR#6411, GPR#1535: don't compile everything with -static-libgcc on mingw32,
   only dllbigarray.dll and libbigarray.a. Allows the use of C++ libraries which
   raise exceptions.

--- a/byterun/alloc.c
+++ b/byterun/alloc.c
@@ -138,6 +138,22 @@ CAMLexport value caml_copy_string(char const *s)
   return res;
 }
 
+static struct custom_operations octets_custom_ops = {
+  "octets",
+  custom_finalize_default,
+  custom_compare_default,
+  custom_compare_ext_default,
+  custom_hash_default,
+  custom_serialize_default,
+  custom_deserialize_default
+};
+
+/* [len] is a number of bytes */
+CAMLexport value caml_alloc_octets (mlsize_t len)
+{
+  return caml_alloc_custom(&octets_custom_ops, len, 0, 1);
+}
+
 CAMLexport value caml_alloc_array(value (*funct)(char const *),
                                   char const ** arr)
 {

--- a/byterun/caml/alloc.h
+++ b/byterun/caml/alloc.h
@@ -32,6 +32,7 @@ CAMLextern value caml_alloc_small (mlsize_t wosize, tag_t);
 CAMLextern value caml_alloc_tuple (mlsize_t wosize);
 CAMLextern value caml_alloc_float_array (mlsize_t len);
 CAMLextern value caml_alloc_string (mlsize_t len);  /* len in bytes (chars) */
+CAMLextern value caml_alloc_octets (mlsize_t len);  /* len in bytes */
 CAMLextern value caml_alloc_initialized_string (mlsize_t len, const char *);
 CAMLextern value caml_copy_string (char const *);
 CAMLextern value caml_copy_string_array (char const **);

--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -332,6 +332,9 @@ CAMLextern int caml_is_double_array (value);   /* 0 is false, 1 is true */
 #define Data_custom_val(v) ((void *) &Field((v), 1))
 struct custom_operations;       /* defined in [custom.h] */
 
+/* Simplified custom bytes allocation layered on top of custom blocks */
+#define Data_octets_val(v) ((void *) &Field((v), 1))
+
 /* Int32.t, Int64.t and Nativeint.t are represented as custom blocks. */
 
 #define Int32_val(v) (*((int32_t *) Data_custom_val(v)))

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -722,6 +722,9 @@ in the $n\th$ element of the array of floating-point numbers \var{v}.
 \item "Data_custom_val("\var{v}")" returns a pointer to the data part
 of the custom block \var{v}.  This pointer has type "void *" and must
 be cast to the type of the data contained in the custom block.
+\item "Data_octets_val("\var{v}")" returns a pointer to the data part
+of the octets block \var{v}.  This pointer has type "void *" and must
+be cast to the type of the data contained in the octets block.
 \item "Int32_val("\var{v}")" returns the 32-bit integer contained
 in the "int32" \var{v}.
 \item "Int64_val("\var{v}")" returns the 64-bit integer contained
@@ -766,6 +769,9 @@ satisfy the GC constraints.
 \item
 "caml_alloc_string("\var{n}")" returns a byte sequence (or string) value of
 length \var{n} bytes. The sequence initially contains uninitialized bytes.
+\item
+"caml_alloc_octets("\var{n}")" returns a byte sequence value of length \var{n}
+bytes. The sequence initially contains uninitialized bytes.
 \item
 "caml_alloc_initialized_string("\var{n}", "\var{p}")" returns a byte sequence
 (or string) value of length \var{n} bytes.  The value is initialized from the

--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -770,8 +770,9 @@ satisfy the GC constraints.
 "caml_alloc_string("\var{n}")" returns a byte sequence (or string) value of
 length \var{n} bytes. The sequence initially contains uninitialized bytes.
 \item
-"caml_alloc_octets("\var{n}")" returns a byte sequence value of length \var{n}
-bytes. The sequence initially contains uninitialized bytes.
+"caml_alloc_octets("\var{n}")" returns an allocated block of length \var{n}
+bytes. The block initially contains uninitialized bytes. Use  "Data_octets_val("\var{v}")"
+to access the data part of the block
 \item
 "caml_alloc_initialized_string("\var{n}", "\var{p}")" returns a byte sequence
 (or string) value of length \var{n} bytes.  The value is initialized from the


### PR DESCRIPTION
Add support for the simple block allocation method `caml_alloc_abstract`. This allocates in the same way as a string but tags the block as Abstract. Resolves mantis ticket [7721](https://caml.inria.fr/mantis/view.php?id=7721)