### PR TITLE
Change the set operator to translate to Bytes.set instead of String.set

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,6 +42,11 @@ Working version
   with very large values of the exponent.
   (Olivier Andrieu)
 
+- GPR#110, GPR#1604, MPR#6706: Change the set operator ([]<-) to translate to
+  Bytes.set instead of String.set.
+  This avoids a deprecation warning when using the operator correctly.
+  (Eyyüb Sari, resurrected by Jacques-Pascal Deplaix)
+
 ### Other libraries:
 
 * GPR#1406: Unix.isatty now returns true in the native Windows ports when

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1408,7 +1408,7 @@ expr:
       { mkexp(Pexp_apply(ghexp(Pexp_ident(array_function "Array" "set")),
                          [Nolabel,$1; Nolabel,$4; Nolabel,$7])) }
   | simple_expr DOT LBRACKET seq_expr RBRACKET LESSMINUS expr
-      { mkexp(Pexp_apply(ghexp(Pexp_ident(array_function "String" "set")),
+      { mkexp(Pexp_apply(ghexp(Pexp_ident(array_function "Bytes" "set")),
                          [Nolabel,$1; Nolabel,$4; Nolabel,$7])) }
   | simple_expr DOT LBRACE seq_expr RBRACE LESSMINUS expr
       { bigarray_set $1 $4 $7 }


### PR DESCRIPTION
This is an attempt at resurrecting https://github.com/ocaml/ocaml/pull/110 which has been lost somewhere in a dark place a long time ago for some unknown reason.

Related issues/discussions:
 * https://caml.inria.fr/mantis/view.php?id=6706
 * https://discuss.ocaml.org/t/warning-when-using-a-b-c-operator-with-bytes/1484

Original PR by @Eyyub