### PR TITLE
Do not run ocamldoc-related tests when it is not built

### DIFF
--- a/testsuite/tests/tool-ocamldoc-2/Makefile
+++ b/testsuite/tests/tool-ocamldoc-2/Makefile
@@ -31,7 +31,11 @@ default:
 	@if ! $(SUPPORTS_SHARED_LIBRARIES); then \
 	  echo 'skipped (shared libraries not available)'; \
 	else \
-	  $(SET_LD_PATH) $(MAKE) run; \
+	  if [ -n "$(WITH_OCAMLDOC)" ]; then \
+	    $(SET_LD_PATH) $(MAKE) run; \
+	  else \
+	    echo 'skipped (ocamldoc not built)'; \
+	  fi; \
 	fi
 
 .PHONY: run

--- a/testsuite/tests/tool-ocamldoc-html/Makefile
+++ b/testsuite/tests/tool-ocamldoc-html/Makefile
@@ -29,7 +29,11 @@ default:
 	@if ! $(SUPPORTS_SHARED_LIBRARIES); then \
 	  echo 'skipped (shared libraries not available)'; \
 	else \
-	  $(SET_LD_PATH) $(MAKE) run; \
+	  if [ -n "$(WITH_OCAMLDOC)" ]; then \
+	    $(SET_LD_PATH) $(MAKE) run; \
+	  else \
+	    echo 'skipped (ocamldoc not built)'; \
+	  fi; \
 	fi
 
 .PHONY: run

--- a/testsuite/tests/tool-ocamldoc-man/Makefile
+++ b/testsuite/tests/tool-ocamldoc-man/Makefile
@@ -29,7 +29,11 @@ default:
 	@if ! $(SUPPORTS_SHARED_LIBRARIES); then \
 	  echo 'skipped (shared libraries not available)'; \
 	else \
-	  $(SET_LD_PATH) $(MAKE) run; \
+	  if [ -n "$(WITH_OCAMLDOC)" ]; then \
+	    $(SET_LD_PATH) $(MAKE) run; \
+	  else \
+	    echo 'skipped (ocamldoc not built)'; \
+	  fi; \
 	fi
 
 .PHONY: run

--- a/testsuite/tests/tool-ocamldoc-open/Makefile
+++ b/testsuite/tests/tool-ocamldoc-open/Makefile
@@ -11,7 +11,11 @@ default:
 	@if ! $(SUPPORTS_SHARED_LIBRARIES); then \
 	  echo 'skipped (shared libraries not available)'; \
 	else \
-	  $(SET_LD_PATH) $(MAKE) doc; \
+	  if [ -n "$(WITH_OCAMLDOC)" ]; then \
+	    $(SET_LD_PATH) $(MAKE) doc; \
+	  else \
+	    echo 'skipped (ocamldoc not built)'; \
+	  fi; \
 	fi
 
 .PHONY: doc

--- a/testsuite/tests/tool-ocamldoc/Makefile
+++ b/testsuite/tests/tool-ocamldoc/Makefile
@@ -24,7 +24,11 @@ default:
 	@if ! $(SUPPORTS_SHARED_LIBRARIES); then \
 	  echo 'skipped (shared libraries not available)'; \
 	else \
-	  $(SET_LD_PATH) $(MAKE) run; \
+	  if [ -n "$(WITH_OCAMLDOC)" ]; then \
+	    $(SET_LD_PATH) $(MAKE) run; \
+	  else \
+	    echo 'skipped (ocamldoc not built)'; \
+	  fi; \
 	fi
 
 .PHONY: run


### PR DESCRIPTION
It is sometimes pleasant to pass `-no-ocamldoc` to the
`configure` script in order to have a shorter (re)build. 
However, the test suite will always try to run `ocamldoc`
tests, and as they will result in errors it means one has
to carefully read the output rather than to check whether
the number of failing tests is zero.