### PR TITLE
[RFC] implementation of non-raising primitives

### DIFF
--- a/byterun/alloc.c
+++ b/byterun/alloc.c
@@ -91,6 +91,14 @@ CAMLexport value caml_alloc_tuple(mlsize_t n)
   return caml_alloc(n, 0);
 }
 
+CAMLexport value caml_alloc_some(value v)
+{
+  value result;
+  Alloc_small (result, 1, 0);
+  Field(result, 0) = v;
+  return result;
+}
+
 /* [len] is a number of bytes (chars) */
 CAMLexport value caml_alloc_string (mlsize_t len)
 {

--- a/byterun/caml/alloc.h
+++ b/byterun/caml/alloc.h
@@ -39,6 +39,7 @@ CAMLextern value caml_copy_double (double);
 CAMLextern value caml_copy_int32 (int32_t);       /* defined in [ints.c] */
 CAMLextern value caml_copy_int64 (int64_t);       /* defined in [ints.c] */
 CAMLextern value caml_copy_nativeint (intnat);  /* defined in [ints.c] */
+CAMLextern value caml_alloc_some (value);
 CAMLextern value caml_alloc_array (value (*funct) (char const *),
                                    char const ** array);
 CAMLextern value caml_alloc_sprintf(const char * format, ...)

--- a/otherlibs/threads/stdlib.ml
+++ b/otherlibs/threads/stdlib.ml
@@ -280,10 +280,7 @@ let string_of_float f = valid_float_lexem (format_float "%.12g" f)
 
 external float_of_string : string -> float = "caml_float_of_string"
 
-let float_of_string_opt s =
-  (* TODO: provide this directly as a non-raising primitive. *)
-  try Some (float_of_string s)
-  with Failure _ -> None
+external float_of_string_opt: string -> float option = "caml_float_of_string_opt"
 
 (* List operations -- more in module List *)
 

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -275,10 +275,7 @@ let string_of_float f = valid_float_lexem (format_float "%.12g" f)
 
 external float_of_string : string -> float = "caml_float_of_string"
 
-let float_of_string_opt s =
-  (* TODO: provide this directly as a non-raising primitive. *)
-  try Some (float_of_string s)
-  with Failure _ -> None
+external float_of_string_opt: string -> float option = "caml_float_of_string_opt"
 
 (* List operations -- more in module List *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -671,7 +671,7 @@ external float_of_string : string -> float = "caml_float_of_string"
    Raise [Failure "float_of_string"] if the given string is not a valid
    representation of a float. *)
 
-val float_of_string_opt: string -> float option
+external float_of_string_opt: string -> float option = "caml_float_of_string_opt"
 (** Same as [float_of_string], but returns [None] instead of raising.
     @since 4.05
 *)


### PR DESCRIPTION
For some operations, OCaml now provides two variants: a raising
function as well as a non-raising one, so that developers can read
the possibility of a failure from the function type. However, for
some operations the implementation of the non-raising variant is
basically a call to the raising variant followed by the appropriate
conversion/wrapping.

In particular, the following functions have a "TODO" comment stating
that a non-raising primitive should be provided:

- `Stdlib.float_of_string_opt`;
- `Stdlib.int_of_string_opt`;
- `Int32.of_string_opt`;
- `Int64.of_string_opt`;
- `Nativeint.of_string_opt`;
- `Sys.getenv_opt`.

This PR currently addresses only the first function, to gather some
feedback about the strategy used, and will be extended to the other
functions if there is interest.

Steps:
- the old `caml_float_of_string` primitive is turned into a
  `FLOAT_OF_STRING` macro that accepts 3 parameters: the primitive
  name, what to execute upon failure, and how to wrap the result upon
  success;
- the updated `caml_float_of_string` primitive is an application of
  `FLOAT_OF_STRING` where failure is a call to `caml_failwith` and
  there is no wrapping of the result;
- the new `caml_float_of_string_opt` primitive is an application of
  `FLOAT_OF_STRING` where failure is `return None` and the result is
  wrapped into `Some`.

This avoids both code duplication and runtime overhead but has
some drawbacks: the code is slightly less pleasant to edit, and in
order to allow the `Makefile` to still correctly compute the list of
primitives, comments with the following lines are inserted:

    CAMLprim value caml_float_of_string
    CAMLprim value caml_float_of_string_opt

(The comments would be augmented with an explanation if this PR
is accepted.)

A micro benchmark, clock-timing the conversion (`float_of_string_opt`)
of 10 000 000 strings stored in an array, shows an improvement of
roughly 5% (varying the percentage of faulty strings between 0%
and 5%).