### PR TITLE
expect_test: print all the exceptions, even the unexpected ones

### DIFF
--- a/Changes
+++ b/Changes
@@ -209,6 +209,9 @@ Working version
   and subject to change/removal).
   (Gabriel Scherer)
 
+- GPR#1619: expect_test: print all the exceptions, even the unexpected ones
+  (Thomas Refis, review by Jérémie Dimino)
+
 ### Bug fixes
 
 - MPR#5250, GPR#1435: on Cygwin, when ocamlrun searches the path

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -253,8 +253,15 @@ let eval_expect_file _fname ~file_contents =
         try
           exec_phrase ppf phrase
         with exn ->
-          Location.report_exception ppf exn;
-          false)
+          let bt = Printexc.get_raw_backtrace () in
+          begin try Location.report_exception ppf exn
+          with _ ->
+            Format.fprintf ppf "Uncaught exception: %s\n%s\n"
+              (Printexc.to_string exn)
+              (Printexc.raw_backtrace_to_string bt)
+          end;
+          false
+      )
     in
     Format.pp_print_flush ppf ();
     let len = Buffer.length buf in


### PR DESCRIPTION
`expect_test` used to not print exceptions in the `[%%expect {||}]` blocks when the exception hasn't been registered with `Location.register_error_of_exn`.
This means that unexpected errors (`assert false`, `fatal_error`, etc) weren't caught and displayed in the expect block (only on stdout/stderr when running the test).

I'm not adding a test of this feature here but I'm using in another branch for which I'll soon create a PR.

Ping @diml.