### PR TITLE
Fix char vs wchar_t bug when expanding command line arguments under Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -273,6 +273,10 @@ Working version
   to work on ocamltest-based tests.
   (Runhang Li and Sébastien Hinderer, review by Gabriel Scherer)
 
+- GPR#1622: fix bug in the expansion of command-line arguments under Windows
+  which could result in some elements of Sys.argv being truncated in some cases.
+  (Nicolás Ojeda Bär, review by Sébastien Hinderer)
+
 4.06 maintenance branch
 -----------------------
 

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -385,7 +385,7 @@ static void expand_pattern(wchar_t * pat)
   /* We need to stop at the first directory or drive boundary, because the
    * _findata_t structure contains the filename, not the leading directory. */
   for (i = wcslen(prefix); i > 0; i--) {
-    char c = prefix[i - 1];
+    wchar_t c = prefix[i - 1];
     if (c == L'\\' || c == L'/' || c == L':') { prefix[i] = 0; break; }
   }
   /* No separator was found, it's a filename pattern without a leading directory. */


### PR DESCRIPTION
I don't think it would cause a segmentation fault, but it would surely garble `argv`.