### PR TITLE
Asmlink.reset should also clean lib_ccobjs/lib_ccopts

### DIFF
--- a/Changes
+++ b/Changes
@@ -215,6 +215,9 @@ Working version
 - GPR#1619: expect_test: print all the exceptions, even the unexpected ones
   (Thomas Refis, review by Jérémie Dimino)
 
+- MPR#7738, GPR#1624: Asmlink.reset also resets lib_ccobjs/ccopts
+  (Cedric Cellier, review by Gabriel Scherer)
+
 ### Bug fixes
 
 - MPR#5250, GPR#1435: on Cygwin, when ocamlrun searches the path

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -422,4 +422,6 @@ let reset () =
   implementations_defined := [];
   cmx_required := [];
   interfaces := [];
-  implementations := []
+  implementations := [];
+  lib_ccobjs := [];
+  lib_ccopts := []


### PR DESCRIPTION
As stated in ticket 7738 (https://caml.inria.fr/mantis/view.php?id=7738):


When using the compiler-libs in a program and trying to compile several source codes I noticed some options to gcc accumulated from one compilation to the next, despite I've tried to cleaned as many global variables as I could, including via Asmlink.reset().

Problem seems to be that the aforementioned reset function does not clean lib_ccobjs or lib_ccopts.
A quick test suggest that cleaning those does fix my issue without introducing any bug I could notice.
