### PR TITLE
Reraise and raise_notrace are also nonexpansive

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,6 +42,9 @@ Working version
 - GPR#1609: Changes to ambivalence scope tracking
   (Thomas Refis and Leo White, review by Jacques Garrigue)
 
+- GPR#1628: Treat reraise and raise_notrace as nonexpansive.
+  (Leo White, review by Alain Frisch)
+
 ### Standard library:
 
 - MPR#7690, GPR#1528: fix the float_of_string function for hexadecimal floats

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1630,11 +1630,23 @@ type 'a t = < m : 'a > constraint 'a = int
 |}]
 
 (* GPR#1142 *)
+external reraise : exn -> 'a = "%reraise"
+
 module M () = struct
   let f : 'a -> 'a = assert false
   let g : 'a -> 'a = raise Not_found
+  let h : 'a -> 'a = reraise Not_found
+  let i : 'a -> 'a = raise_notrace Not_found
 end
 
 [%%expect{|
-module M : functor () -> sig val f : 'a -> 'a val g : 'a -> 'a end
+external reraise : exn -> 'a = "%reraise"
+module M :
+  functor () ->
+    sig
+      val f : 'a -> 'a
+      val g : 'a -> 'a
+      val h : 'a -> 'a
+      val i : 'a -> 'a
+    end
 |}]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1685,7 +1685,8 @@ let rec is_nonexpansive exp =
       is_nonexpansive exp
   | Texp_apply (
       { exp_desc = Texp_ident (_, _, {val_kind =
-             Val_prim {Primitive.prim_name = "%raise"}}) },
+             Val_prim {Primitive.prim_name =
+                         ("%raise" | "%reraise" | "%raise_notrace")}}) },
       [Nolabel, Some e]) ->
      is_nonexpansive e
   | _ -> false


### PR DESCRIPTION
#1142 made `raise e` a nonexpansive expression based on it being defined as the `%raise` primitive. This patch extends this treatment to the `%reraise` and `%raise_notrace` primitives.