### PR TITLE
MPR#7745: Fix Unicode mismatch in win32graph

### DIFF
--- a/Changes
+++ b/Changes
@@ -44,6 +44,10 @@ Working version
 
 ### Other libraries:
 
+- MPR#7445, GPR#1629: Graphics.open_graph displays the correct window title on
+  Windows again (fault introduced by 4.06 Unicode changes).
+  (David Allsopp)
+
 * GPR#1406: Unix.isatty now returns true in the native Windows ports when
   passed a file descriptor connected to a Cygwin PTY. In particular, compiler
   colors for the native Windows ports now work under Cygwin/MSYS2.

--- a/otherlibs/win32graph/open.c
+++ b/otherlibs/win32graph/open.c
@@ -107,7 +107,7 @@ static LRESULT CALLBACK GraphicsWndProc(HWND hwnd,UINT msg,WPARAM wParam,
                 break;
         }
         caml_gr_handle_event(msg, wParam, lParam);
-        return DefWindowProc(hwnd, msg, wParam, lParam);
+        return DefWindowProcA(hwnd, msg, wParam, lParam);
 }
 
 int DoRegisterClass(void)


### PR DESCRIPTION
The window class is created using `RegisterClassA`, which means that the default window procedure should be `DefWindowProcA`. See [MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/ms633586(v=vs.85).aspx) for explanation.