### PR TITLE
Tweak runtop and natruntop targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,11 +280,18 @@ INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 INSTALL_MANDIR=$(DESTDIR)$(MANDIR)
 INSTALL_FLEXDLL=$(INSTALL_LIBDIR)/flexdll
 
+TOPINCLUDES=-I otherlibs/$(UNIXLIB) \
+  -I otherlibs/bigarray \
+  -I otherlibs/dynlink \
+  -I otherlibs/str \
+  -I otherlibs/$(GRAPHLIB) \
+  -I otherlibs/raw_spacetime_lib
 RUNTOP=./byterun/ocamlrun ./ocaml \
   -nostdlib -I stdlib \
-  -noinit $(TOPFLAGS) \
-  -I otherlibs/$(UNIXLIB)
-NATRUNTOP=./ocamlnat$(EXE) -nostdlib -I stdlib -noinit $(TOPFLAGS)
+  -noinit $(TOPFLAGS) $(TOPINCLUDES)
+NATRUNTOP=./ocamlnat$(EXE) \
+  -nostdlib -I stdlib \
+  -noinit $(TOPFLAGS) $(TOPINCLUDES)
 ifeq "$(UNIX_OR_WIN32)" "unix"
 EXTRAPATH=
 else

--- a/Makefile
+++ b/Makefile
@@ -814,7 +814,6 @@ runtop:
 natruntop:
 	$(MAKE) core
 	$(MAKE) opt
-	$(MAKE) opt.opt
 	$(MAKE) ocamlnat
 	@rlwrap --help 2>/dev/null && $(EXTRAPATH) rlwrap $(NATRUNTOP) ||\
 	  $(EXTRAPATH) $(NATRUNTOP)

--- a/Makefile
+++ b/Makefile
@@ -280,12 +280,7 @@ INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 INSTALL_MANDIR=$(DESTDIR)$(MANDIR)
 INSTALL_FLEXDLL=$(INSTALL_LIBDIR)/flexdll
 
-TOPINCLUDES=-I otherlibs/$(UNIXLIB) \
-  -I otherlibs/bigarray \
-  -I otherlibs/dynlink \
-  -I otherlibs/str \
-  -I otherlibs/$(GRAPHLIB) \
-  -I otherlibs/raw_spacetime_lib
+TOPINCLUDES=$(addprefix -I otherlibs/,$(filter-out %threads,$(OTHERLIBRARIES)))
 RUNTOP=./byterun/ocamlrun ./ocaml \
   -nostdlib -I stdlib \
   -noinit $(TOPFLAGS) $(TOPINCLUDES)


### PR DESCRIPTION
Two tweaks for developers:
 - The `runtop` target only added the directory for the `unix` library; it now adds the directories for everything else in `otherlibs`. The `runtop` and `natruntop` also add the same directories.
 - `natruntop` builds `opt.opt` which meant, amongst other things, that it always compiles the standard library docs. As far as I can tell, it can just be omitted?