### PR TITLE
ocamltest: also announce system errors as test errors

### DIFF
--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -38,6 +38,13 @@ let is_test filename =
     | _ -> false
 *)
 
+(* this primitive announce should be used for tests
+   that were aborted on system error before ocamltest
+   could parse them *)
+let announce_test_error test_filename error =
+  Printf.printf " ... testing '%s' => unexpected error (%s)\n%!"
+    (Filename.basename test_filename) error
+
 let tsl_block_of_file test_filename =
   let input_channel = open_in test_filename in
   let lexbuf = Lexing.from_channel input_channel in
@@ -49,10 +56,12 @@ let tsl_block_of_file test_filename =
 let tsl_block_of_file_safe test_filename =
   try tsl_block_of_file test_filename with
   | Sys_error message ->
-    Printf.eprintf "%s\n" message;
+    Printf.eprintf "%s\n%!" message;
+    announce_test_error test_filename message;
     exit 1
   | Parsing.Parse_error ->
-    Printf.eprintf "Could not read test block in %s\n" test_filename;
+    Printf.eprintf "Could not read test block in %s\n%!" test_filename;
+    announce_test_error test_filename "could not read test block";
     exit 1
 
 let print_usage () =


### PR DESCRIPTION
If you forget to commit a test file with your patch (but include it
in ocamltests), ocamltest will fail (print a message to standard error
and return a non-zero code), but until now it would not print the
standard-format "testing ... => failed" message which makes the
failure visible to the summarize.awk script.

(See https://github.com/ocaml/ocaml/pull/1565#issuecomment-368446931)

This commit ensures that such early failures still result in an
explicit test-failed message being shown in the standard way, in
addition to stderr-level error reporting.
