### PR TITLE
stdlib documentation additions/fixes

### DIFF
--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -90,6 +90,18 @@ val reset : t -> unit
    For long-lived buffers that may have grown a lot, [reset] allows
    faster reclamation of the space used by the buffer. *)
 
+val output_buffer : out_channel -> t -> unit
+(** [output_buffer oc b] writes the current contents of buffer [b]
+   on the output channel [oc]. *)
+
+val truncate : t -> int -> unit
+(** [truncate b len] truncates the length of [b] to [len]
+  Note: the internal byte sequence is not shortened.
+  @raise Invalid_argument if [len < 0] or [len > length b].
+  @since 4.05.0 *)
+
+(** {1 Appending} *)
+
 (** Note: all [add_*] operations can raise [Failure] if the internal byte
     sequence of the buffer would need to grow beyond {!Sys.max_string_length}.
 *)
@@ -169,16 +181,6 @@ val add_channel : t -> in_channel -> int -> unit
 
    @raise Invalid_argument if [len < 0] or [len > Sys.max_string_length].
  *)
-
-val output_buffer : out_channel -> t -> unit
-(** [output_buffer oc b] writes the current contents of buffer [b]
-   on the output channel [oc]. *)
-
-val truncate : t -> int -> unit
-(** [truncate b len] truncates the length of [b] to [len]
-  Note: the internal byte sequence is not shortened.
-  @raise Invalid_argument if [len < 0] or [len > length b].
-  @since 4.05.0 *)
 
 (** {1 Buffers and Sequences} *)
 

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -59,7 +59,7 @@ val to_bytes : t -> bytes
 val sub : t -> int -> int -> string
 (** [Buffer.sub b off len] returns a copy of [len] bytes from the
     current contents of the buffer [b], starting at offset [off].
-    @raise Invalid_argument if [srcoff] and [len] do not designate a valid
+    @raise Invalid_argument if [off] and [len] do not designate a valid
     range of [b]. *)
 
 val blit : t -> int -> bytes -> int -> int -> unit

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -122,11 +122,18 @@ val add_bytes : t -> bytes -> unit
 
 val add_substring : t -> string -> int -> int -> unit
 (** [add_substring b s ofs len] takes [len] characters from offset
-   [ofs] in string [s] and appends them at the end of buffer [b]. *)
+   [ofs] in string [s] and appends them at the end of buffer [b].
+
+    Raise [Invalid_argument] if [ofs] and [len] do not designate a valid
+    range of [s]. *)
 
 val add_subbytes : t -> bytes -> int -> int -> unit
 (** [add_subbytes b s ofs len] takes [len] characters from offset
     [ofs] in byte sequence [s] and appends them at the end of buffer [b].
+
+    Raise [Invalid_argument] if [ofs] and [len] do not designate a valid
+    range of [s].
+
     @since 4.02 *)
 
 val add_substitute : t -> (string -> string) -> string -> unit
@@ -154,7 +161,10 @@ val add_channel : t -> in_channel -> int -> unit
    input channel [ic] and stores them at the end of buffer [b].
    @raise End_of_file if the channel contains fewer than [n]
    characters. In this case, the characters are still added to
-   the buffer, so as to avoid loss of data. *)
+   the buffer, so as to avoid loss of data.
+
+   Raise [Invalid_argument] if [len < 0] or [len > Sys.max_string_length].
+ *)
 
 val output_buffer : out_channel -> t -> unit
 (** [output_buffer oc b] writes the current contents of buffer [b]

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -90,6 +90,10 @@ val reset : t -> unit
    For long-lived buffers that may have grown a lot, [reset] allows
    faster reclamation of the space used by the buffer. *)
 
+(** Note: all [add_*] operations can raise [Failure] if the internal byte
+    sequence of the buffer would need to grow beyond {!Sys.max_string_length}.
+*)
+
 val add_char : t -> char -> unit
 (** [add_char b c] appends the character [c] at the end of buffer [b]. *)
 

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -128,14 +128,14 @@ val add_substring : t -> string -> int -> int -> unit
 (** [add_substring b s ofs len] takes [len] characters from offset
    [ofs] in string [s] and appends them at the end of buffer [b].
 
-    Raise [Invalid_argument] if [ofs] and [len] do not designate a valid
+    @raise Invalid_argument if [ofs] and [len] do not designate a valid
     range of [s]. *)
 
 val add_subbytes : t -> bytes -> int -> int -> unit
 (** [add_subbytes b s ofs len] takes [len] characters from offset
     [ofs] in byte sequence [s] and appends them at the end of buffer [b].
 
-    Raise [Invalid_argument] if [ofs] and [len] do not designate a valid
+    @raise Invalid_argument if [ofs] and [len] do not designate a valid
     range of [s].
 
     @since 4.02 *)
@@ -167,7 +167,7 @@ val add_channel : t -> in_channel -> int -> unit
    characters. In this case, the characters are still added to
    the buffer, so as to avoid loss of data.
 
-   Raise [Invalid_argument] if [len < 0] or [len > Sys.max_string_length].
+   @raise Invalid_argument if [len < 0] or [len > Sys.max_string_length].
  *)
 
 val output_buffer : out_channel -> t -> unit

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -672,6 +672,9 @@ external classify_float : (float [@unboxed]) -> fpclass =
 val ( ^ ) : string -> string -> string
 (** String concatenation.
     Right-associative operator, see {!Ocaml_operators} for more information.
+
+    Raise [Invalid_argument "Bytes.create"] if the resulting string would be
+    larger than {!Sys.max_string_length}.
 *)
 
 (** {1 Character operations}

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -673,8 +673,8 @@ val ( ^ ) : string -> string -> string
 (** String concatenation.
     Right-associative operator, see {!Ocaml_operators} for more information.
 
-    Raise [Invalid_argument "Bytes.create"] if the resulting string would be
-    larger than {!Sys.max_string_length}.
+    @raise Invalid_argument if the result is longer then
+    than {!Sys.max_string_length} bytes.
 *)
 
 (** {1 Character operations}

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -139,6 +139,9 @@ val concat : string -> string list -> string
 val cat : string -> string -> string
 (** [cat s1 s2] concatenates s1 and s2 ([s1 ^ s2]).
 
+    @raise Invalid_argument if the result is longer then
+    than {!Sys.max_string_length} bytes.
+
     @since 4.13.0
 *)
 

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -139,6 +139,9 @@ val concat : sep:string -> string list -> string
 val cat : string -> string -> string
 (** [cat s1 s2] concatenates s1 and s2 ([s1 ^ s2]).
 
+    @raise Invalid_argument if the result is longer then
+    than {!Sys.max_string_length} bytes.
+
     @since 4.13.0
 *)
 


### PR DESCRIPTION
This updates some documentation comments in the stdlib about the exceptions raised by some functions:
- `Invalid_argument` for invalid sub-array/string arguments
- `Failure` when the internal string in `Buffer` cannot grow because of `Sys.max_string_length`
- the reduced maximum array length for `float` arrays is only valid on 32-bit archs (I didn't mention the `-no-flat-float-array` option — not sure of the long term plans on this one)