### PR TITLE
Optimize String.escaped

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,6 +42,10 @@ Working version
   with very large values of the exponent.
   (Olivier Andrieu)
 
+- GPR#1637: String.escaped is faster does and not allocate when called with a
+  string that does not contain any characters needing to be escaped.
+  (Alain Frisch, review by Xavier Leroy and Gabriel Scherer)
+
 ### Other libraries:
 
 - MPR#7745, GPR#1629: Graphics.open_graph displays the correct window title on

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -101,13 +101,13 @@ let trim s =
   else s
 
 let escaped s =
-  let rec escape s n i =
+  let rec escape_if_needed s n i =
     if i >= n then s else
       match unsafe_get s i with
       | '\"' | '\\' | '\000'..'\031' | '\127'.. '\255' -> bts (B.escaped (bos s))
-      | _ -> escape s n (i+1)
+      | _ -> escape_if_needed s n (i+1)
   in
-  escape s (length s) 0
+  escape_if_needed s (length s) 0
 
 (* duplicated in bytes.ml *)
 let rec index_rec s lim i c =

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -100,17 +100,14 @@ let trim s =
     then bts (B.trim (bos s))
   else s
 
-let rec needs_escape s n i =
-  if i >= n then false else
+let rec escape s n i =
+  if i >= n then s else
     match unsafe_get s i with
-    | '\"' | '\\' | '\000'..'\031' | '\127'.. '\255' -> true
-    | _ -> needs_escape s n (i+1)
+    | '\"' | '\\' | '\000'..'\031' | '\127'.. '\255' -> bts (B.escaped (bos s))
+    | _ -> escape s n (i+1)
 
 let escaped s =
-  if needs_escape s (length s) 0 then
-    bts (B.escaped (bos s))
-  else
-    s
+  escape s (length s) 0
 
 (* duplicated in bytes.ml *)
 let rec index_rec s lim i c =

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -102,12 +102,12 @@ let trim s =
 
 let rec needs_escape s n i =
   if i >= n then false else
-    match String.unsafe_get s i with
+    match unsafe_get s i with
     | '\"' | '\\' | '\000'..'\031' | '\127'.. '\255' -> true
     | _ -> needs_escape s n (i+1)
 
 let escaped s =
-  if needs_escape s (String.length s) 0 then
+  if needs_escape s (length s) 0 then
     bts (B.escaped (bos s))
   else
     s

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -101,15 +101,13 @@ let trim s =
   else s
 
 let needs_escape s =
-  let n = length s in
-  let i = ref 0 in
-  let esc = ref false in
-  while !i < n && not !esc do
-    match unsafe_get s !i with
-    | '\"' | '\\' | '\000'..'\031' | '\127'.. '\255' -> esc := true
-    | _ -> incr i
-  done;
-  !esc
+  let rec aux s n i =
+    if i >= n then false else
+      match String.unsafe_get s i with
+      | '\"' | '\\' | '\000'..'\031' | '\127'.. '\255' -> true
+      | _ -> aux s n (i+1)
+  in
+  aux s (String.length s) 0
 
 let escaped s =
   if needs_escape s then

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -100,13 +100,13 @@ let trim s =
     then bts (B.trim (bos s))
   else s
 
-let rec escape s n i =
-  if i >= n then s else
-    match unsafe_get s i with
-    | '\"' | '\\' | '\000'..'\031' | '\127'.. '\255' -> bts (B.escaped (bos s))
-    | _ -> escape s n (i+1)
-
 let escaped s =
+  let rec escape s n i =
+    if i >= n then s else
+      match unsafe_get s i with
+      | '\"' | '\\' | '\000'..'\031' | '\127'.. '\255' -> bts (B.escaped (bos s))
+      | _ -> escape s n (i+1)
+  in
   escape s (length s) 0
 
 (* duplicated in bytes.ml *)

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -100,17 +100,14 @@ let trim s =
     then bts (B.trim (bos s))
   else s
 
-let needs_escape s =
-  let rec aux s n i =
-    if i >= n then false else
-      match String.unsafe_get s i with
-      | '\"' | '\\' | '\000'..'\031' | '\127'.. '\255' -> true
-      | _ -> aux s n (i+1)
-  in
-  aux s (String.length s) 0
+let rec needs_escape s n i =
+  if i >= n then false else
+    match String.unsafe_get s i with
+    | '\"' | '\\' | '\000'..'\031' | '\127'.. '\255' -> true
+    | _ -> needs_escape s n (i+1)
 
 let escaped s =
-  if needs_escape s then
+  if needs_escape s (String.length s) 0 then
     bts (B.escaped (bos s))
   else
     s

--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -100,15 +100,19 @@ let trim s =
     then bts (B.trim (bos s))
   else s
 
+let needs_escape s =
+  let n = length s in
+  let i = ref 0 in
+  let esc = ref false in
+  while !i < n && not !esc do
+    match unsafe_get s !i with
+    | '\"' | '\\' | '\000'..'\031' | '\127'.. '\255' -> esc := true
+    | _ -> incr i
+  done;
+  !esc
+
 let escaped s =
-  let rec needs_escape i =
-    if i >= length s then false else
-      match unsafe_get s i with
-      | '\"' | '\\' | '\n' | '\t' | '\r' | '\b' -> true
-      | ' ' .. '~' -> needs_escape (i+1)
-      | _ -> true
-  in
-  if needs_escape 0 then
+  if needs_escape s then
     bts (B.escaped (bos s))
   else
     s


### PR DESCRIPTION
A small optimization, avoiding some allocation in the fast path.

The patch is due to @alainfrisch, I just packaged it as a PR.

Do we need a Changes entry?