### PR TITLE
attempt at fixing MPR#7726

### DIFF
--- a/Changes
+++ b/Changes
@@ -366,7 +366,7 @@ Working version
 
 - MPR#7747: Type checker can loop infinitly and consumes all computer memory
   (Jacques Garrigue, report by kantian)
-  
+
 - GPR#1530, GPR#1574: testsuite, fix 'make parallel' and 'make one DIR=...'
   to work on ocamltest-based tests.
   (Runhang Li and Sébastien Hinderer, review by Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -359,7 +359,6 @@ Working version
 
 - MPR#7712, GPR#1576: assertion failure with type abbreviations
   (Thomas Refis, report by Michael O'Connor, review by Jacques Garrigue)
-<<<<<<< HEAD
 
 - MPR#7726, GPR#1639: Recursive modules, equi-recursive types
    and stack overflow
@@ -367,14 +366,6 @@ Working version
 
 - MPR#7747: Type checker can loop infinitly and consumes all computer memory
   (Jacques Garrigue, report by kantian)
-=======
-  
-- MPR#7747: Type checker can loop infinitly and consumes all computer memory
-  (Jacques Garrigue, report by kantian)
-  
-- MPR#7726: Recursive modules, equi-recursive types and stack overflow
-  (Jacques Garrigue, report by Jeremy Yallop)
->>>>>>> typo in Changes
 
 - GPR#1530, GPR#1574: testsuite, fix 'make parallel' and 'make one DIR=...'
   to work on ocamltest-based tests.

--- a/Changes
+++ b/Changes
@@ -360,6 +360,10 @@ Working version
 - MPR#7712, GPR#1576: assertion failure with type abbreviations
   (Thomas Refis, report by Michael O'Connor, review by Jacques Garrigue)
 
+- MPR#7726, GPR#1639: Recursive modules, equi-recursive types
+   and stack overflow
+  (Jacques Garrigue, report by Jeremy Yallop)
+
 - MPR#7747: Type checker can loop infinitly and consumes all computer memory
   (Jacques Garrigue, report by kantian)
 

--- a/Changes
+++ b/Changes
@@ -366,7 +366,7 @@ Working version
 
 - MPR#7747: Type checker can loop infinitly and consumes all computer memory
   (Jacques Garrigue, report by kantian)
-
+  
 - GPR#1530, GPR#1574: testsuite, fix 'make parallel' and 'make one DIR=...'
   to work on ocamltest-based tests.
   (Runhang Li and Sébastien Hinderer, review by Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -359,6 +359,7 @@ Working version
 
 - MPR#7712, GPR#1576: assertion failure with type abbreviations
   (Thomas Refis, report by Michael O'Connor, review by Jacques Garrigue)
+<<<<<<< HEAD
 
 - MPR#7726, GPR#1639: Recursive modules, equi-recursive types
    and stack overflow
@@ -366,6 +367,14 @@ Working version
 
 - MPR#7747: Type checker can loop infinitly and consumes all computer memory
   (Jacques Garrigue, report by kantian)
+=======
+  
+- MPR#7747: Type checker can loop infinitly and consumes all computer memory
+  (Jacques Garrigue, report by kantian)
+  
+- MPR#7726: Recursive modules, equi-recursive types and stack overflow
+  (Jacques Garrigue, report by Jeremy Yallop)
+>>>>>>> typo in Changes
 
 - GPR#1530, GPR#1574: testsuite, fix 'make parallel' and 'make one DIR=...'
   to work on ocamltest-based tests.

--- a/testsuite/tests/typing-modules-bugs/pr7726_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7726_bad.ml
@@ -6,4 +6,4 @@ end
 
 module T = Fix(functor (X:sig type t end) -> struct type t = X.t option end)
 
-module T = Fix(functor (X:sig type t end) -> struct type t = X.t end)
+(* module T = Fix(functor (X:sig type t end) -> struct type t = X.t end) *)

--- a/testsuite/tests/typing-modules-bugs/pr7726_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7726_bad.ml
@@ -1,0 +1,9 @@
+module type T = sig type t end
+
+module Fix(F:(T -> T)) = struct
+  module rec Fixed : T with type t = F(Fixed).t = F(Fixed)
+end
+
+module T = Fix(functor (X:sig type t end) -> struct type t = X.t option end)
+
+module T = Fix(functor (X:sig type t end) -> struct type t = X.t end)

--- a/testsuite/tests/typing-modules-bugs/pr7726_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7726_bad.ml
@@ -1,9 +1,0 @@
-module type T = sig type t end
-
-module Fix(F:(T -> T)) = struct
-  module rec Fixed : T with type t = F(Fixed).t = F(Fixed)
-end
-
-module T = Fix(functor (X:sig type t end) -> struct type t = X.t option end)
-
-(* module T = Fix(functor (X:sig type t end) -> struct type t = X.t end) *)

--- a/testsuite/tests/typing-modules/ocamltests
+++ b/testsuite/tests/typing-modules/ocamltests
@@ -6,6 +6,7 @@ pr5911.ml
 pr6394.ml
 pr7207.ml
 pr7348.ml
+pr7726_bad.ml
 printing.ml
 recursive.ml
 Test.ml

--- a/testsuite/tests/typing-modules/pr7726_bad.ml
+++ b/testsuite/tests/typing-modules/pr7726_bad.ml
@@ -1,0 +1,23 @@
+(* TEST
+   * expect
+*)
+
+module type T = sig type t end;;
+[%%expect{|
+module type T = sig type t end
+|}]
+
+module Fix(F:(T -> T)) = struct
+  module rec Fixed : T with type t = F(Fixed).t = F(Fixed)
+end;;
+[%%expect{|
+Line _, characters 21-47:
+    module rec Fixed : T with type t = F(Fixed).t = F(Fixed)
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The type abbreviation Fixed.t is cyclic
+|}]
+
+(*
+module T = Fix(functor (X:sig type t end) -> struct type t = X.t option end)
+
+module T = Fix(functor (X:sig type t end) -> struct type t = X.t end) *)

--- a/testsuite/tests/typing-modules/pr7726_bad.ml
+++ b/testsuite/tests/typing-modules/pr7726_bad.ml
@@ -21,3 +21,14 @@ Error: The type abbreviation Fixed.t is cyclic
 module T = Fix(functor (X:sig type t end) -> struct type t = X.t option end)
 
 module T = Fix(functor (X:sig type t end) -> struct type t = X.t end) *)
+
+module M = struct
+  module F (X : T) : T = X
+  module rec Fixed : sig type t = F(Fixed).t end = Fixed
+end;;
+
+module type S = module type of M;;
+
+module Id (X : T) = X;;
+
+module type Bad = S with module F = Id;;

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -991,9 +991,9 @@ and transl_recmodule_modtypes env sdecls =
     List.fold_left
       (fun env (id, _, mty) -> Env.add_module ~arg:true id mty env)
       env curr in
-  let make_env2 curr =
+  let make_env2 ?(arg=true) curr =
     List.fold_left
-      (fun env (id, _, mty) -> Env.add_module ~arg:true id mty.mty_type env)
+      (fun env (id, _, mty) -> Env.add_module ~arg id mty.mty_type env)
       env curr in
   let transition env_c curr =
     List.map2
@@ -1032,7 +1032,7 @@ and transl_recmodule_modtypes env sdecls =
       (fun () -> transition env0 init)
   in
   let env1 = make_env2 dcl1 in
-  check_recmod_typedecls env1 sdecls dcl1;
+  check_recmod_typedecls (make_env2 ~arg:false dcl1) sdecls dcl1;
   let dcl2 = transition env1 dcl1 in
 (*
   List.iter
@@ -1041,7 +1041,7 @@ and transl_recmodule_modtypes env sdecls =
     dcl2;
 *)
   let env2 = make_env2 dcl2 in
-  check_recmod_typedecls env2 sdecls dcl2;
+  check_recmod_typedecls (make_env2 ~arg:false dcl2) sdecls dcl2;
   let dcl2 =
     List.map2
       (fun pmd (id, id_loc, mty) ->
@@ -1580,7 +1580,7 @@ and type_structure ?(toplevel = false) funct_body anchor env sstr scope =
                    md_loc = md.md_loc;
                  }
                in
-               Env.add_module_declaration ~check:true md.md_id mdecl env
+               Env.enter_module_declaration md.md_id mdecl env
             )
             env decls
         in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -991,7 +991,7 @@ and transl_recmodule_modtypes env sdecls =
     List.fold_left
       (fun env (id, _, mty) -> Env.add_module ~arg:true id mty env)
       env curr in
-  let make_env2 ?(arg=true) curr =
+  let make_env2 ~arg curr =
     List.fold_left
       (fun env (id, _, mty) -> Env.add_module ~arg id mty.mty_type env)
       env curr in
@@ -1031,7 +1031,7 @@ and transl_recmodule_modtypes env sdecls =
     Warnings.without_warnings
       (fun () -> transition env0 init)
   in
-  let env1 = make_env2 dcl1 in
+  let env1 = make_env2 ~arg:true  dcl1 in
   check_recmod_typedecls (make_env2 ~arg:false dcl1) sdecls dcl1;
   let dcl2 = transition env1 dcl1 in
 (*
@@ -1040,7 +1040,7 @@ and transl_recmodule_modtypes env sdecls =
       Format.printf "%a: %a@." Printtyp.ident id Printtyp.modtype mty)
     dcl2;
 *)
-  let env2 = make_env2 dcl2 in
+  let env2 = make_env2 ~arg:true dcl2 in
   check_recmod_typedecls (make_env2 ~arg:false dcl2) sdecls dcl2;
   let dcl2 =
     List.map2


### PR DESCRIPTION
Fix [MPR#7726](https://caml.inria.fr/mantis/view.php?id=7726) by considering that a type extracted from a functor application of a functor argument to a recursive module may be any type of the recursive module.

To make this work using `Env.is_functor_arg` I had to remove the registration of recursive modules as functor arguments. This is probably incorrect as it allows to alias them, but it allowed quick prototyping.