### PR TITLE
ocamldep: colored error message for -sort

### DIFF
--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -464,7 +464,8 @@ let sort_files_by_dependencies files =
 
   if !worklist <> [] then begin
     Format.fprintf Format.err_formatter
-      "@[Error: cycle in dependencies. End of list is not sorted.@]@.";
+      "@[%t: cycle in dependencies. End of list is not sorted.@]@."
+      Location.print_error_prefix;
     let sorted_deps =
       let li = ref [] in
       Hashtbl.iter (fun _ file_deps -> li := file_deps :: !li) h;

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -55,6 +55,7 @@ val input_lexbuf: Lexing.lexbuf option ref
 
 val get_pos_info: Lexing.position -> string * int * int (* file, line, char *)
 val print_loc: formatter -> t -> unit
+val print_error_prefix: formatter -> unit
 val print_error: formatter -> t -> unit
 val print_error_cur_file: formatter -> unit -> unit
 val print_warning: t -> formatter -> Warnings.t -> unit


### PR DESCRIPTION
This small PR is a follow-up to #1578 : it aligns the appearance of the error message for `ocamldep -sort` with the ones raised for parsing errors. In order to avoid duplicating code (notably the color setup), it exposes `Location.print_error_prefix` function since the available error printing functions were not really a good fit here.