### PR TITLE
Fix MPR#7747

### DIFF
--- a/Changes
+++ b/Changes
@@ -289,6 +289,9 @@ Working version
 - MPR#7712, GPR#1576: assertion failure with type abbreviations
   (Thomas Refis, report by Michael O'Connor, review by Jacques Garrigue)
 
+- MPR#7747: Type checker can loop infinitly and consumes all computer memory
+  (Jacques Garrigue, report by kantian)
+
 - GPR#1530, GPR#1574: testsuite, fix 'make parallel' and 'make one DIR=...'
   to work on ocamltest-based tests.
   (Runhang Li and Sébastien Hinderer, review by Gabriel Scherer)

--- a/testsuite/tests/typing-gadts/pr7747.ml
+++ b/testsuite/tests/typing-gadts/pr7747.ml
@@ -1,0 +1,35 @@
+(* TEST
+   * expect
+*)
+
+type (_,_) eq = Refl : ('a,'a) eq
+
+module M = struct type t end
+module N : sig type t = private M.t val eq : (t, M.t) eq end =
+  struct type t = M.t let eq = Refl end;;
+
+(*
+  as long as we are casting between M.t and N.t
+  there is no problem, this will type check.
+*)
+
+let f x = match N.eq with Refl -> (x : N.t :> M.t);;
+[%%expect{|
+type (_, _) eq = Refl : ('a, 'a) eq
+module M : sig type t end
+module N : sig type t = private M.t val eq : (t, M.t) eq end
+val f : N.t -> M.t = <fun>
+|}]
+let f x = match N.eq with Refl -> (x : M.t :> N.t);;
+[%%expect{|
+Line _, characters 34-50:
+  let f x = match N.eq with Refl -> (x : M.t :> N.t);;
+                                    ^^^^^^^^^^^^^^^^
+Error: Type M.t is not a subtype of N.t
+|}]
+
+(*
+  but as soon we're trying to cast to another type,
+  the type checker will never return and memory
+  consumption will increase drastically.
+*)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1685,7 +1685,7 @@ let rec local_non_recursive_abbrev strict visited env p ty =
         begin try
           (* try expanding, since [p] could be hidden *)
           local_non_recursive_abbrev strict visited env p
-            (try_expand_head try_expand_once env ty)
+            (try_expand_head try_expand_once_opt env ty)
         with Cannot_expand ->
           let params =
             try (Env.find_type p' env).type_params
@@ -2257,6 +2257,8 @@ let get_gadt_equations_level () =
   | Some x -> x
 
 let add_gadt_equation env source destination =
+  (* Format.eprintf "@[add_gadt_equation %s %a@]@."
+    (Path.name source) !Btype.print_raw destination; *)
   if local_non_recursive_abbrev !env source destination then begin
     let destination = duplicate_type destination in
     let expansion_scope =


### PR DESCRIPTION
Fix [MPR#7747](https://caml.inria.fr/mantis/view.php?id=7747) by using `try_expand_once_opt` rather than `try_expand_once` in `Ctype.local_non_recursive_abbrev` like in `Typedecl.check_well_founded`.

This is a trivial one-liner.