### PR TITLE
Allow destructive substitution of module aliases

### DIFF
--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -758,3 +758,12 @@ R.M.f 3;;
 module rec R : sig module M = M end
 - : int = 3
 |}];;
+
+module M = struct type t end
+module type S = sig module N = M val x : N.t end
+module type T = S with module N := M;;
+[%%expect{|
+module M : sig type t end
+module type S = sig module N = M val x : N.t end
+module type T = sig val x : M.t end
+|}];;

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -408,7 +408,8 @@ let merge_constraint initial_env loc sg constr =
     | (Sig_module(id, md, rs) :: rem, [s], Pwith_modsubst (_, lid'))
       when Ident.name id = s ->
         let path, md' = Typetexp.find_module initial_env loc lid'.txt in
-        let newmd = Mtype.strengthen_decl ~aliasable:false env md' path in
+        let aliasable = not (Env.is_functor_arg path env) in
+        let newmd = Mtype.strengthen_decl ~aliasable env md' path in
         ignore(Includemod.modtypes ~loc env newmd.md_type md.md_type);
         real_ids := [Pident id];
         (Pident id, lid, Twith_modsubst (path, lid')),


### PR DESCRIPTION
This fixes a small short-coming in destructive substitution that prevents you substituting module aliases.

Before:
```ocaml
# module M = struct type t end
  module type S = sig module N = M val x : N.t end;;
module M : sig type t end
module type S = sig module N = M val x : N.t end

#   module type T = S with module N := M;;
Characters 17-37:
  module type T = S with module N := M;;
                  ^^^^^^^^^^^^^^^^^^^^
Error: In this `with' constraint, the new definition of N
       does not match its original definition in the constrained signature:
       Modules do not match:
         sig type t = M.t end
       is not included in
         (module M)
```

After:
```ocaml
# module M = struct type t end
  module type S = sig module N = M val x : N.t end;;

module M : sig type t end
module type S = sig module N = M val x : N.t end

#   module type T = S with module N := M;;
module type T = sig val x : M.t end
```