### PR TITLE
manual: record and variant disambiguation

### DIFF
--- a/Changes
+++ b/Changes
@@ -196,6 +196,9 @@ Working version
   the compiler source code.
   (Florian Angeletti, review by Gabriel Scherer)
 
+- GPR#1647: manual, subsection on record and variant disambiguation
+  (Florian Angeletti)
+
 ### Compiler distribution build system
 
 - MPR#7679: make sure .a files are erased before calling ar rc, otherwise

--- a/Changes
+++ b/Changes
@@ -197,7 +197,7 @@ Working version
   (Florian Angeletti, review by Gabriel Scherer)
 
 - GPR#1647: manual, subsection on record and variant disambiguation
-  (Florian Angeletti)
+  (Florian Angeletti, review by Alain Frisch and Gabriel Scherer)
 
 ### Compiler distribution build system
 

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -311,10 +311,10 @@ OCaml can pick unambiguously the corresponding field or constructor.
 For instance:
 
 \begin{caml_example}{toplevel}
-let look_at_x_then_y_then_z (r:first_record) =
+let look_at_x_then_z (r:first_record) =
   let x = r.x in
   x + r.z;;
-let rotate_abc_to_bac (x:first_variant) = match x with
+let permute (x:first_variant) = match x with
   | A -> (B:first_variant)
   | B -> A
   | C -> C;;

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -289,6 +289,87 @@ let rec insert x btree =
                 else Node(y, left, insert x right);;
 \end{caml_example}
 
+
+\subsection{Record and variant disambiguation}
+( This subsection can be skipped on the first reading )
+
+Astute readers may have wondered what happens when two or more record
+fields or constructors share the same name,
+
+\begin{caml_example*}{toplevel}
+type first =  { x : int; y:int; z:int }
+type middle = { x:int; y:int }
+type last =   { x: int };;
+type first_variant = A | B | C
+type last_variant = A;;
+\end{caml_example*}
+
+The answer is that when confronted with multiple options, OCaml
+picks the last defined type. For instance,
+
+\begin{caml_example}{toplevel}
+let look_at_x r = r.x;;
+let is_b x = match x with B -> true | _ -> false  ;;
+\end{caml_example}
+
+Nevertheless, Ocaml tries to disambiguate between the different record
+fields or constructors using the locally available information.
+For instance, if you use pattern matching to destructure both fields
+"x" and "y",
+
+\begin{caml_example}{toplevel}
+let look_at_xy {x;y;_} = x + y;;
+\end{caml_example}
+
+OCaml infers that the possible choices are only "first" and "middle",
+since the type "last" does not have a field "y". Ocaml thus picks the
+type "middle" as the last defined type between the two possible types.
+This disambiguation is local, consequently the following function fails
+
+\begin{caml_example}{toplevel}[error]
+let look_at_x_then_y r =
+  let x = r.x in
+  x + r.y;;
+\end{caml_example}
+
+Indeed, due to the line "let x = r.x in", OCaml has already deduced that
+the type of "r" was "last". Since "last" does not define a field "y",
+"r.y" is then an error.
+Similarly, pattern matching on constructors with
+
+\begin{caml_example}{toplevel}[error]
+let is_a_or_b x = match x with
+  | A -> true
+  | B -> true;;
+\end{caml_example}
+
+fails because OCaml has already inferred that the type of the argument
+was "last_variant" by the time it reaches the case "B".
+This problem can be avoided by adding an explicit type annotation
+in order to help OCaml disambiguates between the different types:
+
+\begin{caml_example}{toplevel}
+let look_at_x_then_y_then_z (r:first) =
+  let x = r.x in
+  x + r.z;;
+\end{caml_example}
+
+Here "(r:first)" is an explicit annotation telling OCaml that
+the type of "r" is "first". We can use the same annotations to guide
+the disambiguation of variants:
+
+\begin{caml_example}{toplevel}
+let rotate_abc_to_bac (x:first_variant) = match x with
+  | A -> (B:first_variant)
+  | B -> A
+  | C -> C;;
+\end{caml_example}
+
+Those explicit type annotations can in fact be used anywhere.
+Most of the time they are unnecessary, but they are useful to guide
+disambiguation, to debug unexpected type errors, or combined with some
+of the more advanced features of OCaml described in later chapters.
+
 \section{Imperative features}
 \pdfsection{Imperative features}
 

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -371,6 +371,9 @@ let is_a_or_b x = match x with
   | B -> true;;
 \end{caml_example}
 
+Moreover, being the last defined type is a quite unstable position that
+may change surreptitiously after adding or moving around a type
+definition, or after opening a module (see chapter \ref{c:moduleexamples}).
 Consequently, adding explicit type annotations to guide disambiguation is
 more robust than relying on the last defined type disambiguation.
 

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -297,9 +297,9 @@ Astute readers may have wondered what happens when two or more record
 fields or constructors share the same name
 
 \begin{caml_example*}{toplevel}
-type first  = { x:int; y:int; z:int }
-type middle = { x:int; z:int }
-type last   = { x:int };;
+type first_record  = { x:int; y:int; z:int }
+type middle_record = { x:int; z:int }
+type last_record   = { x:int };;
 type first_variant = A | B | C
 type last_variant  = A;;
 \end{caml_example*}
@@ -311,25 +311,25 @@ OCaml can pick unambiguously the corresponding field or constructor.
 For instance:
 
 \begin{caml_example}{toplevel}
-let look_at_x_then_y_then_z (r:first) =
+let look_at_x_then_y_then_z (r:first_record) =
   let x = r.x in
   x + r.z;;
 let rotate_abc_to_bac (x:first_variant) = match x with
   | A -> (B:first_variant)
   | B -> A
   | C -> C;;
-type wrapped = First of first
+type wrapped = First of first_record
 let f (First r) = r, r.x;;
 \end{caml_example}
 
-In the first example, "(r:first)" is an explicit annotation telling OCaml
-that the type of "r" is "first". With this annotation, Ocaml knows that
-"r.x" refers to the "x" field of the first type. Similarly, the type
-annotation in the second example makes it clear to OCaml that the
-constructors "A", "B" and "C" come from the first variant type.
-Contrarily, in the last example, OCaml has inferred by itself that the
-type of "r" can only be first and there are no needs for explicit type
-annotations.
+In the first example, "(r:first_record)" is an explicit annotation
+telling OCaml that the type of "r" is "first_record". With this
+annotation, Ocaml knows that "r.x" refers to the "x" field of the first
+record type. Similarly, the type annotation in the second example makes
+it clear to OCaml that the constructors "A", "B" and "C" come from the
+first variant type. Contrarily, in the last example, OCaml has inferred
+by itself that the type of "r" can only be "first_record" and there are
+no needs for explicit type annotations.
 
 Those explicit type annotations can in fact be used anywhere.
 Most of the time they are unnecessary, but they are useful to guide
@@ -342,8 +342,8 @@ looking at the whole set of fields used in a expression or pattern:
 let project_and_rotate {x;y; _ } = { x= - y; y = x ; z = 0} ;;
 \end{caml_example}
 Since the fields "x" and "y" can only appear simultaneously in the first
-type, OCaml infers that the type of "project_and_rotate" is
-"first -> first".
+record type, OCaml infers that the type of "project_and_rotate" is
+"first_record -> first_record".
 
 In last resort, if there is not enough information to disambiguate between
 different fields or constructors, Ocaml picks the last defined type
@@ -354,9 +354,9 @@ let look_at_xz {x;z} = x;;
 \end{caml_example}
 
 Here, OCaml has inferred that the possible choices for the type of
-"{x;z}" are "first" and "middle", since the type "last" has no field "z".
-Ocaml then picks the type "middle" as the last defined type between the
-two possibilities.
+"{x;z}" are "first_record" and "middle_record", since the type
+"last_record" has no field "z". Ocaml then picks the type "middle_record"
+as the last defined type between the two possibilities.
 
 Beware that this last resort disambiguation is local: once Ocaml has
 chosen a disambiguation, it sticks to this choice, even if it leads to
@@ -364,7 +364,7 @@ an ulterior type error:
 
 \begin{caml_example}{toplevel}[error]
 let look_at_x_then_y r =
-  let x = r.x in (* Ocaml deduces [r: last] *)
+  let x = r.x in (* Ocaml deduces [r: last_record] *)
   x + r.y;;
 let is_a_or_b x = match x with
   | A -> true (* OCaml infers [x: last_variant] *)

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -294,81 +294,85 @@ let rec insert x btree =
 ( This subsection can be skipped on the first reading )
 
 Astute readers may have wondered what happens when two or more record
-fields or constructors share the same name,
+fields or constructors share the same name
 
 \begin{caml_example*}{toplevel}
-type first =  { x : int; y:int; z:int }
-type middle = { x:int; y:int }
-type last =   { x: int };;
+type first  = { x:int; y:int; z:int }
+type middle = { x:int; z:int }
+type last   = { x:int };;
 type first_variant = A | B | C
-type last_variant = A;;
+type last_variant  = A;;
 \end{caml_example*}
 
-The answer is that when confronted with multiple options, OCaml
-picks the last defined type. For instance,
-
-\begin{caml_example}{toplevel}
-let look_at_x r = r.x;;
-let is_b x = match x with B -> true | _ -> false  ;;
-\end{caml_example}
-
-Nevertheless, Ocaml tries to disambiguate between the different record
-fields or constructors using the locally available information.
-For instance, if you use pattern matching to destructure both fields
-"x" and "y",
-
-\begin{caml_example}{toplevel}
-let look_at_xy {x;y;_} = x + y;;
-\end{caml_example}
-
-OCaml infers that the possible choices are only "first" and "middle",
-since the type "last" does not have a field "y". Ocaml thus picks the
-type "middle" as the last defined type between the two possible types.
-This disambiguation is local, consequently the following function fails
-
-\begin{caml_example}{toplevel}[error]
-let look_at_x_then_y r =
-  let x = r.x in
-  x + r.y;;
-\end{caml_example}
-
-Indeed, due to the line "let x = r.x in", OCaml has already deduced that
-the type of "r" was "last". Since "last" does not define a field "y",
-"r.y" is then an error.
-Similarly, pattern matching on constructors with
-
-\begin{caml_example}{toplevel}[error]
-let is_a_or_b x = match x with
-  | A -> true
-  | B -> true;;
-\end{caml_example}
-
-fails because OCaml has already inferred that the type of the argument
-was "last_variant" by the time it reaches the case "B".
-This problem can be avoided by adding an explicit type annotation
-in order to help OCaml disambiguates between the different types:
+The answer is that when confronted with multiple options, OCaml tries to
+use locally available information to disambiguate between the various fields
+and constructors. First, if the type of the record or variant is known,
+OCaml can pick unambiguously the corresponding field or constructor.
+For instance:
 
 \begin{caml_example}{toplevel}
 let look_at_x_then_y_then_z (r:first) =
   let x = r.x in
   x + r.z;;
-\end{caml_example}
-
-Here "(r:first)" is an explicit annotation telling OCaml that
-the type of "r" is "first". We can use the same annotations to guide
-the disambiguation of variants:
-
-\begin{caml_example}{toplevel}
 let rotate_abc_to_bac (x:first_variant) = match x with
   | A -> (B:first_variant)
   | B -> A
   | C -> C;;
+type wrapped = First of first
+let f (First r) = r, r.x;;
 \end{caml_example}
+
+In the first example, "(r:first)" is an explicit annotation telling OCaml
+that the type of "r" is "first". With this annotation, Ocaml knows that
+"r.x" refers to the "x" field of the first type. Similarly, the type
+annotation in the second example makes it clear to OCaml that the
+constructors "A", "B" and "C" come from the first variant type.
+Contrarily, in the last example, OCaml has inferred by itself that the
+type of "r" can only be first and there are no needs for explicit type
+annotations.
 
 Those explicit type annotations can in fact be used anywhere.
 Most of the time they are unnecessary, but they are useful to guide
 disambiguation, to debug unexpected type errors, or combined with some
 of the more advanced features of OCaml described in later chapters.
+
+Secondly, for records, OCaml can also deduce the right record type by
+looking at the whole set of fields used in a expression or pattern:
+\begin{caml_example}{toplevel}
+let project_and_rotate {x;y; _ } = { x= - y; y = x ; z = 0} ;;
+\end{caml_example}
+Since the fields "x" and "y" can only appear simultaneously in the first
+type, OCaml infers that the type of "project_and_rotate" is
+"first -> first".
+
+In last resort, if there is not enough information to disambiguate between
+different fields or constructors, Ocaml picks the last defined type
+amongst all locally valid choices:
+
+\begin{caml_example}{toplevel}
+let look_at_xz {x;z} = x;;
+\end{caml_example}
+
+Here, OCaml has inferred that the possible choices for the type of
+"{x;z}" are "first" and "middle", since the type "last" has no field "z".
+Ocaml then picks the type "middle" as the last defined type between the
+two possibilities.
+
+Beware that this last resort disambiguation is local: once Ocaml has
+chosen a disambiguation, it sticks to this choice, even if it leads to
+an ulterior type error:
+
+\begin{caml_example}{toplevel}[error]
+let look_at_x_then_y r =
+  let x = r.x in (* Ocaml deduces [r: last] *)
+  x + r.y;;
+let is_a_or_b x = match x with
+  | A -> true (* OCaml infers [x: last_variant] *)
+  | B -> true;;
+\end{caml_example}
+
+Consequently, adding explicit type annotations to guide disambiguation is
+more robust than relying on the last defined type disambiguation.
 
 \section{Imperative features}
 \pdfsection{Imperative features}


### PR DESCRIPTION
This PR adds a new subsection to the first chapter of the manual about the type-directed disambiguation of record fields  and variant constructors just after the section on variant and records. This disambiguation is not currently documented in the manual, and tends to trip quite a few beginners.

Another emplacement that I considered was a new FAQ section at the end of the tutorial, but the new subsection seemed to fall quite well in place at its current location.

CC @Drup which suggested the subsection.