### PR TITLE
Change compilation order of toplevel definitions.

### DIFF
--- a/Changes
+++ b/Changes
@@ -128,6 +128,10 @@ Working version
 - GPR#1618: add the -dno-unique-ids and -dunique-ids compiler flags
   (Sébastien Hinderer, review by Leo White and Damien Doligez)
 
+- GPR#1649 change compilation order of toplevel definitions, so that some warnings
+  emitted by the bytecode compiler appear more in-order than before.
+  (Luc Maranget, advice by Damien Doligez)
+
 ### Code generation and optimizations:
 
 - GPR#1370: Fix code duplication in Cmmgen

--- a/Changes
+++ b/Changes
@@ -130,7 +130,7 @@ Working version
 
 - GPR#1649 change compilation order of toplevel definitions, so that some warnings
   emitted by the bytecode compiler appear more in-order than before.
-  (Luc Maranget, advice by Damien Doligez)
+  (Luc Maranget, advice and review by Damien Doligez)
 
 ### Code generation and optimizations:
 

--- a/testsuite/tests/warnings/w47_inline.reference
+++ b/testsuite/tests/warnings/w47_inline.reference
@@ -1,15 +1,15 @@
-File "w47_inline.ml", line 13, characters 15-22:
-Warning 47: illegal payload for attribute 'inlined'.
-It must be either empty, 'always' or 'never'
-File "w47_inline.ml", line 8, characters 23-29:
-Warning 47: illegal payload for attribute 'inline'.
-It must be either empty, 'always' or 'never'
-File "w47_inline.ml", line 7, characters 23-29:
+File "w47_inline.ml", line 5, characters 23-29:
 Warning 47: illegal payload for attribute 'inline'.
 It must be either empty, 'always' or 'never'
 File "w47_inline.ml", line 6, characters 23-29:
 Warning 47: illegal payload for attribute 'inline'.
 It must be either empty, 'always' or 'never'
-File "w47_inline.ml", line 5, characters 23-29:
+File "w47_inline.ml", line 7, characters 23-29:
 Warning 47: illegal payload for attribute 'inline'.
+It must be either empty, 'always' or 'never'
+File "w47_inline.ml", line 8, characters 23-29:
+Warning 47: illegal payload for attribute 'inline'.
+It must be either empty, 'always' or 'never'
+File "w47_inline.ml", line 13, characters 15-22:
+Warning 47: illegal payload for attribute 'inlined'.
 It must be either empty, 'always' or 'never'

--- a/testsuite/tests/warnings/w53.reference
+++ b/testsuite/tests/warnings/w53.reference
@@ -1,26 +1,26 @@
 File "w53.ml", line 2, characters 4-5:
 Warning 32: unused value h.
-File "w53.ml", line 31, characters 17-29:
+File "w53.ml", line 2, characters 14-20:
+Warning 53: the "inline" attribute cannot appear in this context
+File "w53.ml", line 3, characters 14-26:
 Warning 53: the "ocaml.inline" attribute cannot appear in this context
-File "w53.ml", line 30, characters 16-22:
-Warning 53: the "inline" attribute cannot appear in this context
-File "w53.ml", line 24, characters 0-39:
-Warning 53: the "inline" attribute cannot appear in this context
-File "w53.ml", line 23, characters 0-32:
-Warning 53: the "inline" attribute cannot appear in this context
-File "w53.ml", line 15, characters 16-24:
-Warning 53: the "tailcall" attribute cannot appear in this context
-File "w53.ml", line 12, characters 14-28:
-Warning 53: the "ocaml.tailcall" attribute cannot appear in this context
-File "w53.ml", line 11, characters 14-22:
-Warning 53: the "tailcall" attribute cannot appear in this context
-File "w53.ml", line 9, characters 16-23:
+File "w53.ml", line 5, characters 14-21:
 Warning 53: the "inlined" attribute cannot appear in this context
 File "w53.ml", line 6, characters 14-27:
 Warning 53: the "ocaml.inlined" attribute cannot appear in this context
-File "w53.ml", line 5, characters 14-21:
+File "w53.ml", line 9, characters 16-23:
 Warning 53: the "inlined" attribute cannot appear in this context
-File "w53.ml", line 3, characters 14-26:
-Warning 53: the "ocaml.inline" attribute cannot appear in this context
-File "w53.ml", line 2, characters 14-20:
+File "w53.ml", line 11, characters 14-22:
+Warning 53: the "tailcall" attribute cannot appear in this context
+File "w53.ml", line 12, characters 14-28:
+Warning 53: the "ocaml.tailcall" attribute cannot appear in this context
+File "w53.ml", line 15, characters 16-24:
+Warning 53: the "tailcall" attribute cannot appear in this context
+File "w53.ml", line 23, characters 0-32:
 Warning 53: the "inline" attribute cannot appear in this context
+File "w53.ml", line 24, characters 0-39:
+Warning 53: the "inline" attribute cannot appear in this context
+File "w53.ml", line 30, characters 16-22:
+Warning 53: the "inline" attribute cannot appear in this context
+File "w53.ml", line 31, characters 17-29:
+Warning 53: the "ocaml.inline" attribute cannot appear in this context

--- a/testsuite/tests/warnings/w54.reference
+++ b/testsuite/tests/warnings/w54.reference
@@ -1,8 +1,8 @@
-File "w54.ml", line 9, characters 0-43:
+File "w54.ml", line 2, characters 33-39:
 Warning 54: the "inline" attribute is used more than once on this expression
-File "w54.ml", line 5, characters 26-39:
-Warning 54: the "ocaml.inlined" attribute is used more than once on this expression
 File "w54.ml", line 3, characters 51-63:
 Warning 54: the "ocaml.inline" attribute is used more than once on this expression
-File "w54.ml", line 2, characters 33-39:
+File "w54.ml", line 5, characters 26-39:
+Warning 54: the "ocaml.inlined" attribute is used more than once on this expression
+File "w54.ml", line 9, characters 0-43:
 Warning 54: the "inline" attribute is used more than once on this expression


### PR DESCRIPTION
This simple patch set changes the order of compilation of toplevel definitions, so that they are compiled by following input order. The change applies to the bytecode compiler at the lambda-code production phase. Notice that the native code compiler is unchnaged in tat aspect.

 As a result:

- Warnings emitted during lambfda-code production and resulting from the compilation of  successive toplevel definition now appear by following definition order.

- Native code and bytecode compiler console output get closer one to the other.


This is a "best effort" patch, it is not claimed that all warnings will appear by increasing location order, nor that the native and bytecode compilers always produce the same console output.
