### PR TITLE
Manual: Fix typo in Chapter 8 Language extensions

### DIFF
--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1776,7 +1776,7 @@ When this form is used together with the infix syntax for attributes,
 the attributes are considered to apply to the payload:
 
 \begin{verbatim}
-fun%foo[@bar] x -> x + 1 === [%foo (fun x -> x + 1)[@foo ] ];
+fun%foo[@bar] x -> x + 1 === [%foo (fun x -> x + 1)[@bar ] ];
 \end{verbatim}
 
 \subsection{Built-in extension nodes}


### PR DESCRIPTION
I believe this change reflects the original author's intent. The example is trying to demonstrate that the `[@bar]` attribute applies to the function definition, not to the extension itself.