### PR TITLE
Proposal - add withFile/with-open-file functions

### DIFF
--- a/otherlibs/threads/stdlib.ml
+++ b/otherlibs/threads/stdlib.ml
@@ -554,6 +554,21 @@ let close_in_noerr ic = (try close_in ic with _ -> ())
 external set_binary_mode_in : in_channel -> bool -> unit
                             = "caml_ml_set_binary_mode"
 
+let with_in_gen mode perm name f =
+  let ic = open_in_gen mode perm name in
+  let result = try
+      f ic
+    with ex -> close_in ic; raise ex
+  in
+  close_in ic;
+  result
+
+let with_in name f =
+  with_in_gen [Open_rdonly; Open_text] 0 name f
+
+let with_in_bin name f =
+  with_in_gen [Open_rdonly; Open_binary] 0 name f
+
 (* Output functions on standard output *)
 
 let print_char c = output_char stdout c

--- a/otherlibs/threads/stdlib.ml
+++ b/otherlibs/threads/stdlib.ml
@@ -439,6 +439,21 @@ let close_out_noerr oc =
 external set_binary_mode_out : out_channel -> bool -> unit
                              = "caml_ml_set_binary_mode"
 
+let with_out_gen mode perm name f =
+  let oc = open_out_gen mode perm name in
+  let result = try
+      f oc
+    with ex -> close_out oc; raise ex
+  in
+  close_out oc;
+  result
+
+let with_out name f =
+  with_out_gen [Open_wronly; Open_creat; Open_trunc; Open_text] 0o666 name f
+
+let with_out_bin name f =
+  with_out_gen [Open_wronly; Open_creat; Open_trunc; Open_binary] 0o666 name f
+
 (* General input functions *)
 
 external set_in_channel_name: in_channel -> string -> unit =

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -381,6 +381,21 @@ let close_out_noerr oc =
 external set_binary_mode_out : out_channel -> bool -> unit
                              = "caml_ml_set_binary_mode"
 
+let with_out_gen mode perm name f =
+  let oc = open_out_gen mode perm name in
+  let result = try
+      f oc
+    with ex -> close_out oc; raise ex
+  in
+  close_out oc;
+  result
+
+let with_out name f =
+  with_out_gen [Open_wronly; Open_creat; Open_trunc; Open_text] 0o666 name f
+
+let with_out_bin name f =
+  with_out_gen [Open_wronly; Open_creat; Open_trunc; Open_binary] 0o666 name f
+
 (* General input functions *)
 
 external set_in_channel_name: in_channel -> string -> unit =

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -466,6 +466,21 @@ let close_in_noerr ic = (try close_in ic with _ -> ())
 external set_binary_mode_in : in_channel -> bool -> unit
                             = "caml_ml_set_binary_mode"
 
+let with_in_gen mode perm name f =
+  let ic = open_in_gen mode perm name in
+  let result = try
+      f ic
+    with ex -> close_in ic; raise ex
+  in
+  close_in ic;
+  result
+
+let with_in name f =
+  with_in_gen [Open_rdonly; Open_text] 0 name f
+
+let with_in_bin name f =
+  with_in_gen [Open_rdonly; Open_binary] 0 name f
+
 (* Output functions on standard output *)
 
 let print_char c = output_char stdout c

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -922,6 +922,29 @@ val set_binary_mode_out : out_channel -> bool -> unit
    This function has no effect under operating systems that
    do not distinguish between text mode and binary mode. *)
 
+val with_out : string -> (out_channel -> 'a) -> 'a
+(** Open the named file for writing, and run a function on
+    a new output channel of that file, positioned at the
+    beginning of the file. The file is truncated to zero
+    length if it already exists. It is created if it
+    does not already exists. After function is complete,
+    the channel is closed and result of the function is
+    returned. If function raises an exception, this exception
+    is intercepted, channel is closed, and exception is reraised. *)
+
+val with_out_bin : string -> (out_channel -> 'a) -> 'a
+(** Same as {!Pervasives.with_out}, but the file is opened in binary mode,
+   so that no translation takes place during writes. On operating
+   systems that do not distinguish between text mode and binary
+   mode, this function behaves like {!Pervasives.with_out}. *)
+
+val with_out_gen : open_flag list -> int -> string -> (out_channel -> 'a) -> 'a
+(** [with_out_gen mode perm filename] opens the named file for writing,
+   and closes after the writing is complete as described above.
+   The extra arguments [mode] and [perm] specify the opening mode
+   and file permissions. {!Pervasives.with_out} and {!Pervasives.with_out_bin}
+   are special cases of this function. *)
+
 
 (** {2 General input functions} *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1038,6 +1038,27 @@ val set_binary_mode_in : in_channel -> bool -> unit
    This function has no effect under operating systems that
    do not distinguish between text mode and binary mode. *)
 
+val with_in : string -> (in_channel -> 'a) -> 'a
+(** Open the named file for reading, and run a function on
+    a new input channel of that file, positioned at the
+    beginning of the file. After function is complete,
+    the channel is closed and result of the function is
+    returned. If function raises an exception, this exception
+    is intercepted, channel is closed, and exception is reraised. *)
+
+val with_in_bin : string -> (in_channel -> 'a) -> 'a
+(** Same as {!Pervasives.with_in}, but the file is opened in binary mode,
+   so that no translation takes place during reads. On operating
+   systems that do not distinguish between text mode and binary
+   mode, this function behaves like {!Pervasives.with_in}. *)
+
+val with_in_gen : open_flag list -> int -> string -> (in_channel -> 'a) -> 'a
+(** [with_in_gen mode perm filename] opens the named file for reading,
+   and closes after the reading is complete as described above.
+   The extra arguments [mode] and [perm] specify the opening mode
+   and file permissions. {!Pervasives.with_in} and {!Pervasives.with_in_bin}
+   are special cases of this function. *)
+
 
 (** {2 Operations on large files} *)
 


### PR DESCRIPTION
In standard libraries of many languages there are functions _bracketing_ file operations inside `open`/`close`. For instance, in Haskell they have [withFile](https://hackage.haskell.org/package/base-4.10.1.0/docs/System-IO.html#v:withFile), in CLOS it is [with-open-file](http://clhs.lisp.se/Body/m_w_open.htm), in Python it is `with`.

This PR adds `with_*` functions, which match corresponding `open_*` functions. Usage is as everywhere:

```ocaml
let _ =
  with_out "hello.txt" @@ fun oc -> Printf.fprintf oc "world!"
```

May be it would be better to introduce generic `bracket` function - see [Haskell bracket](https://hackage.haskell.org/package/base-4.10.1.0/docs/Control-Exception.html#v:bracket)?

```ocaml
let bracket before_f after_f inside_f =
  let resource = before_f in
  let result = try (inside_f resource) 
    with ex -> after_f resource; raise ex
  in
  after_f resource;
  result
```
