### PR TITLE
pattern aliases do not ignore type constraints

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ Working version
 
 ### Language features:
 
+- #1655: pattern aliases do not ignore type constraints
+  (Thomas Refis, review by Jacques Garrigue and Gabriel Scherer)
+
 * #9500, #9727: Injectivity annotations
   One can now mark type parameters as injective, which is useful for
   abstract types:

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -233,11 +233,7 @@ let simple_merged_annotated_return_annotated (type a) (t : a t) (a : a) =
 ;;
 
 [%%expect{|
-Lines 3-4, characters 4-30:
-3 | ....IntLit, ((3 : a) as x)
-4 |   | BoolLit, ((true : a) as x)............
-Error: The variable x on the left-hand side of this or-pattern has type
-       a but on the right-hand side it has type bool
+val simple_merged_annotated_return_annotated : 'a t -> 'a -> unit = <fun>
 |}]
 
 (* test more scenarios: when the or-pattern itself is not at toplevel but under
@@ -579,12 +575,7 @@ let lambiguity (type a) (t2 : a t2) =
 ;;
 
 [%%expect{|
-Line 3, characters 8-22:
-3 |   | Int ((_ : a) as x)
-            ^^^^^^^^^^^^^^
-Error: This pattern matches values of type a
-       This instance of a is ambiguous:
-       it would escape the scope of its equation
+val lambiguity : 'a t2 -> 'a = <fun>
 |}]
 
 let rambiguity (type a) (t2 : a t2) =
@@ -594,12 +585,11 @@ let rambiguity (type a) (t2 : a t2) =
 ;;
 
 [%%expect{|
-Line 4, characters 9-23:
-4 |   | Bool ((_ : a) as x) -> x
-             ^^^^^^^^^^^^^^
-Error: This pattern matches values of type a
-       This instance of a is ambiguous:
-       it would escape the scope of its equation
+Lines 3-4, characters 4-23:
+3 | ....Int (_ as x)
+4 |   | Bool ((_ : a) as x).....
+Error: The variable x on the left-hand side of this or-pattern has type
+       int but on the right-hand side it has type a
 |}]
 
 

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -362,7 +362,7 @@ val foo : int foo -> int = <fun>
 Line 3, characters 26-31:
 3 |   | { x = (x : int); eq = Refl3 } -> x
                               ^^^^^
-Warning 18: typing this pattern requires considering M.t and N.t as equal.
+Warning 18: typing this pattern requires considering M.t and int as equal.
 But the knowledge of these types is not principal.
 val foo : int foo -> int = <fun>
 |}]

--- a/testsuite/tests/typing-misc/build_as_type.ml
+++ b/testsuite/tests/typing-misc/build_as_type.ml
@@ -1,0 +1,95 @@
+(* TEST
+   * expect
+*)
+
+let f = function ([] : int list) as x -> x ;;
+[%%expect{|
+Line 1, characters 8-42:
+1 | let f = function ([] : int list) as x -> x ;;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+_::_
+val f : int list -> 'a list = <fun>
+|}]
+
+let f =
+  let f' = function ([] : 'a list) as x -> x in
+  f', f';;
+[%%expect{|
+Line 2, characters 11-44:
+2 |   let f' = function ([] : 'a list) as x -> x in
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+_::_
+val f : ('a list -> 'b list) * ('a list -> 'c list) = (<fun>, <fun>)
+|}]
+
+let f =
+  let f' = function ([] : _ list) as x -> x in
+  f', f';;
+[%%expect{|
+Line 2, characters 11-43:
+2 |   let f' = function ([] : _ list) as x -> x in
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+_::_
+val f : ('a list -> 'b list) * ('c list -> 'd list) = (<fun>, <fun>)
+|}]
+
+type t = [ `A | `B ];;
+[%%expect{|
+type t = [ `A | `B ]
+|}]
+
+let f = function `A as x -> x | `B -> `A;;
+[%%expect{|
+val f : [< `A | `B ] -> [> `A ] = <fun>
+|}]
+
+let f = function (`A : t) as x -> x | `B -> `A;;
+[%%expect{|
+val f : t -> [> `A ] = <fun>
+|}]
+
+let f : t -> _ = function `A as x -> x | `B -> `A;;
+[%%expect{|
+val f : t -> [> `A ] = <fun>
+|}]
+
+let f = function
+  | (`A : t) as x ->
+    begin match x with
+    | `A -> ()
+    end
+  | `B -> ();;
+[%%expect{|
+val f : t -> unit = <fun>
+|}]
+
+
+let f = function
+  | (`A : t) as x ->
+    begin match x with
+    | `A -> ()
+    | `B -> ()
+    end
+  | `B -> ();;
+[%%expect{|
+val f : t -> unit = <fun>
+|}]
+
+
+let f = function
+  | (`A : t) as x ->
+    begin match x with
+    | `A -> ()
+    | `B -> ()
+    | `C -> ()
+    end
+  | `B -> ();;
+[%%expect{|
+val f : t -> unit = <fun>
+|}]

--- a/testsuite/tests/typing-misc/build_as_type.ml
+++ b/testsuite/tests/typing-misc/build_as_type.ml
@@ -93,3 +93,8 @@ let f = function
 [%%expect{|
 val f : t -> unit = <fun>
 |}]
+
+let f = function (`A, _ : _ * int) as x -> x;;
+[%%expect{|
+val f : [< `A ] * int -> [> `A ] * int = <fun>
+|}]

--- a/testsuite/tests/typing-misc/build_as_type.ml
+++ b/testsuite/tests/typing-misc/build_as_type.ml
@@ -10,7 +10,7 @@ Line 1, characters 8-42:
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 _::_
-val f : int list -> 'a list = <fun>
+val f : int list -> int list = <fun>
 |}]
 
 let f =
@@ -23,7 +23,7 @@ Line 2, characters 11-44:
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 _::_
-val f : ('a list -> 'b list) * ('a list -> 'c list) = (<fun>, <fun>)
+val f : ('a list -> 'a list) * ('a list -> 'a list) = (<fun>, <fun>)
 |}]
 
 let f =
@@ -51,7 +51,7 @@ val f : [< `A | `B ] -> [> `A ] = <fun>
 
 let f = function (`A : t) as x -> x | `B -> `A;;
 [%%expect{|
-val f : t -> [> `A ] = <fun>
+val f : t -> t = <fun>
 |}]
 
 let f : t -> _ = function `A as x -> x | `B -> `A;;
@@ -66,6 +66,13 @@ let f = function
     end
   | `B -> ();;
 [%%expect{|
+Lines 3-5, characters 4-7:
+3 | ....begin match x with
+4 |     | `A -> ()
+5 |     end
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+`B
 val f : t -> unit = <fun>
 |}]
 
@@ -91,7 +98,12 @@ let f = function
     end
   | `B -> ();;
 [%%expect{|
-val f : t -> unit = <fun>
+Line 6, characters 6-8:
+6 |     | `C -> ()
+          ^^
+Error: This pattern matches values of type [? `C ]
+       but a pattern was expected which matches values of type t
+       The second variant type does not allow tag(s) `C
 |}]
 
 let f = function (`A, _ : _ * int) as x -> x;;

--- a/testsuite/tests/typing-misc/build_as_type.ml
+++ b/testsuite/tests/typing-misc/build_as_type.ml
@@ -144,5 +144,12 @@ let f = function
   | `B -> ();;
 
 [%%expect{|
+Lines 5-7, characters 4-7:
+5 | ....begin match x with
+6 |     | `A -> ()
+7 |     end
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+`B
 val f : t -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-misc/build_as_type.ml
+++ b/testsuite/tests/typing-misc/build_as_type.ml
@@ -21,7 +21,7 @@ val f : ('a list -> 'a list) * ('a list -> 'a list) = (<fun>, <fun>)
 
 let f =
   let f' = function
-    | ([] : _ list) as x -> x 
+    | ([] : _ list) as x -> x
     | _ :: _ -> assert false
   in
   f', f';;
@@ -31,7 +31,7 @@ val f : ('a list -> 'b list) * ('c list -> 'd list) = (<fun>, <fun>)
 
 let f =
   let f' (type a) = function
-    | ([] : a list) as x -> x 
+    | ([] : a list) as x -> x
     | _ :: _ -> assert false
   in
   f', f';;

--- a/testsuite/tests/typing-misc/build_as_type.ml
+++ b/testsuite/tests/typing-misc/build_as_type.ml
@@ -2,41 +2,41 @@
    * expect
 *)
 
-let f = function ([] : int list) as x -> x ;;
+let f = function
+  | ([] : int list) as x -> x
+  | _ :: _ -> assert false;;
 [%%expect{|
-Line 1, characters 8-42:
-1 | let f = function ([] : int list) as x -> x ;;
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-_::_
 val f : int list -> int list = <fun>
 |}]
 
 let f =
-  let f' = function ([] : 'a list) as x -> x in
+  let f' = function
+    | ([] : 'a list) as x -> x
+    | _ :: _ -> assert false
+  in
   f', f';;
 [%%expect{|
-Line 2, characters 11-44:
-2 |   let f' = function ([] : 'a list) as x -> x in
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-_::_
 val f : ('a list -> 'a list) * ('a list -> 'a list) = (<fun>, <fun>)
 |}]
 
 let f =
-  let f' = function ([] : _ list) as x -> x in
+  let f' = function
+    | ([] : _ list) as x -> x 
+    | _ :: _ -> assert false
+  in
   f', f';;
 [%%expect{|
-Line 2, characters 11-43:
-2 |   let f' = function ([] : _ list) as x -> x in
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 8: this pattern-matching is not exhaustive.
-Here is an example of a case that is not matched:
-_::_
 val f : ('a list -> 'b list) * ('c list -> 'd list) = (<fun>, <fun>)
+|}]
+
+let f =
+  let f' (type a) = function
+    | ([] : a list) as x -> x 
+    | _ :: _ -> assert false
+  in
+  f', f';;
+[%%expect{|
+val f : ('a list -> 'a list) * ('b list -> 'b list) = (<fun>, <fun>)
 |}]
 
 type t = [ `A | `B ];;
@@ -61,15 +61,17 @@ val f : t -> [> `A ] = <fun>
 
 let f = function
   | (`A : t) as x ->
+    (* This should be flagged as non-exhaustive: because of the constraint [x]
+       is of type [t]. *)
     begin match x with
     | `A -> ()
     end
   | `B -> ();;
 [%%expect{|
-Lines 3-5, characters 4-7:
-3 | ....begin match x with
-4 |     | `A -> ()
-5 |     end
+Lines 5-7, characters 4-7:
+5 | ....begin match x with
+6 |     | `A -> ()
+7 |     end
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 `B

--- a/testsuite/tests/typing-misc/build_as_type.ml
+++ b/testsuite/tests/typing-misc/build_as_type.ml
@@ -112,3 +112,37 @@ let f = function (`A, _ : _ * int) as x -> x;;
 [%%expect{|
 val f : [< `A ] * int -> [> `A ] * int = <fun>
 |}]
+
+(* Make sure *all* the constraints are respected: *)
+
+let f = function
+  | ((`A : _) : t) as x ->
+    (* This should be flagged as non-exhaustive: because of the constraint [x]
+       is of type [t]. *)
+    begin match x with
+    | `A -> ()
+    end
+  | `B -> ();;
+[%%expect{|
+Lines 5-7, characters 4-7:
+5 | ....begin match x with
+6 |     | `A -> ()
+7 |     end
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+`B
+val f : t -> unit = <fun>
+|}]
+
+let f = function
+  | ((`A : t) : _) as x ->
+    (* This should be flagged as non-exhaustive: because of the constraint [x]
+       is of type [t]. *)
+    begin match x with
+    | `A -> ()
+    end
+  | `B -> ();;
+
+[%%expect{|
+val f : t -> unit = <fun>
+|}]

--- a/testsuite/tests/typing-misc/disambiguate_principality.ml
+++ b/testsuite/tests/typing-misc/disambiguate_principality.ml
@@ -304,12 +304,6 @@ let u = function
 ;;
 [%%expect{|
 val u : M.r ref -> int = <fun>
-|}, Principal{|
-Line 3, characters 7-10:
-3 |     !x.lbl
-           ^^^
-Warning 18: this type-based field disambiguation is not principal.
-val u : M.r ref -> int = <fun>
 |}]
 
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -467,6 +467,7 @@ let enter_orpat_variables loc env  p1_vs p2_vs =
 
 let rec build_as_type env p =
   let as_ty = build_as_type_aux env p in
+  (* Cf. #1655 *)
   List.fold_left (fun as_ty (extra, _loc, _attrs) ->
     match extra with
     | Tpat_type _ | Tpat_open _ | Tpat_unpack -> as_ty

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1439,8 +1439,7 @@ and type_pat_aux
       ({ptyp_desc=Ptyp_poly _} as sty)) ->
       (* explicitly polymorphic type *)
       assert construction_not_used_in_counterexamples;
-      let cty, force = Typetexp.transl_simple_type_delayed !env sty in
-      let ty = instance cty.ctyp_type in
+      let cty, ty, force = Typetexp.transl_simple_type_delayed !env sty in
       unify_pat_types ~refine lloc env ty (instance expected_ty);
       pattern_force := force :: !pattern_force;
       begin match ty.desc with
@@ -1829,8 +1828,7 @@ and type_pat_aux
   | Ppat_constraint(sp, sty) ->
       (* Pretend separate = true *)
       begin_def();
-      let cty, force = Typetexp.transl_simple_type_delayed !env sty in
-      let ty = instance cty.ctyp_type in
+      let cty, ty, force = Typetexp.transl_simple_type_delayed !env sty in
       end_def();
       generalize_structure ty;
       let ty, expected_ty' = instance ty, ty in
@@ -3143,10 +3141,9 @@ and type_expect_
       let (arg, ty',cty,cty') =
         match sty with
         | None ->
-            let (cty', force) =
+            let (cty', ty', force) =
               Typetexp.transl_simple_type_delayed env sty'
             in
-            let ty' = instance cty'.ctyp_type in
             begin_def ();
             let arg = type_exp env sarg in
             end_def ();
@@ -3190,13 +3187,11 @@ and type_expect_
             (arg, ty', None, cty')
         | Some sty ->
             begin_def ();
-            let (cty, force) =
+            let (cty, ty, force) =
               Typetexp.transl_simple_type_delayed env sty
-            and (cty', force') =
+            and (cty', ty', force') =
               Typetexp.transl_simple_type_delayed env sty'
             in
-            let ty = instance cty.ctyp_type in
-            let ty' = instance cty'.ctyp_type in
             begin try
               let force'' = subtype env ty ty' in
               force (); force' (); force'' ()

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1421,7 +1421,7 @@ and type_pat_aux
       (* explicitly polymorphic type *)
       assert construction_not_used_in_counterexamples;
       let cty, force = Typetexp.transl_simple_type_delayed !env sty in
-      let ty = cty.ctyp_type in
+      let ty = instance cty.ctyp_type in
       unify_pat_types ~refine lloc env ty (instance expected_ty);
       pattern_force := force :: !pattern_force;
       begin match ty.desc with
@@ -1811,7 +1811,7 @@ and type_pat_aux
       (* Pretend separate = true *)
       begin_def();
       let cty, force = Typetexp.transl_simple_type_delayed !env sty in
-      let ty = cty.ctyp_type in
+      let ty = instance cty.ctyp_type in
       end_def();
       generalize_structure ty;
       let ty, expected_ty' = instance ty, ty in
@@ -3127,7 +3127,7 @@ and type_expect_
             let (cty', force) =
               Typetexp.transl_simple_type_delayed env sty'
             in
-            let ty' = cty'.ctyp_type in
+            let ty' = instance cty'.ctyp_type in
             begin_def ();
             let arg = type_exp env sarg in
             end_def ();
@@ -3176,8 +3176,8 @@ and type_expect_
             and (cty', force') =
               Typetexp.transl_simple_type_delayed env sty'
             in
-            let ty = cty.ctyp_type in
-            let ty' = cty'.ctyp_type in
+            let ty = instance cty.ctyp_type in
+            let ty' = instance cty'.ctyp_type in
             begin try
               let force'' = subtype env ty ty' in
               force (); force' (); force'' ()

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -466,6 +466,25 @@ let enter_orpat_variables loc env  p1_vs p2_vs =
   unify_vars p1_vs p2_vs
 
 let rec build_as_type env p =
+  let as_ty = build_as_type_aux env p in
+  match
+    List.find_opt (function
+      | Tpat_constraint _, _, _ -> true
+      | _ -> false
+    ) p.pat_extra
+  with
+  | None -> as_ty
+  | Some (Tpat_constraint cty, _, _) ->
+      begin_def ();
+      let ty = instance cty.ctyp_type in
+      end_def ();
+      generalize_structure ty;
+      (* This call to unify can't fail since the pattern is well typed. *)
+      unify !env (instance as_ty) (instance ty);
+      ty
+  | Some _ -> assert false
+
+and build_as_type_aux env p =
   match p.pat_desc with
     Tpat_alias(p1,_, _) -> build_as_type env p1
   | Tpat_tuple pl ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -687,9 +687,17 @@ let transl_simple_type_univars env styp =
 
 let transl_simple_type_delayed env styp =
   univars := []; used_variables := TyVarMap.empty;
+  begin_def ();
   let typ = transl_type env Extensible styp in
+  end_def ();
   make_fixed_univars typ.ctyp_type;
-  (typ, globalize_used_variables env false)
+  (* This brings the used variables to the global level, but doesn't link them
+     to their other occurences just yet. This will be done when [force] is
+     called. *)
+  let force = globalize_used_variables env false in
+  (* Generalizes everything except the variables that were just globalized. *)
+  generalize typ.ctyp_type;
+  (typ, force)
 
 let transl_type_scheme env styp =
   reset_type_variables();

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -697,7 +697,7 @@ let transl_simple_type_delayed env styp =
   let force = globalize_used_variables env false in
   (* Generalizes everything except the variables that were just globalized. *)
   generalize typ.ctyp_type;
-  (typ, force)
+  (typ, instance typ.ctyp_type, force)
 
 let transl_type_scheme env styp =
   reset_type_variables();

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -23,10 +23,13 @@ val transl_simple_type:
         Env.t -> bool -> Parsetree.core_type -> Typedtree.core_type
 val transl_simple_type_univars:
         Env.t -> Parsetree.core_type -> Typedtree.core_type
-val transl_simple_type_delayed:
-        Env.t -> Parsetree.core_type -> Typedtree.core_type * (unit -> unit)
+val transl_simple_type_delayed
+  :  Env.t
+  -> Parsetree.core_type
+  -> Typedtree.core_type * type_expr * (unit -> unit)
         (* Translate a type, but leave type variables unbound. Returns
-           the type and a function that binds the type variable. *)
+           the type, an instance of the corresponding type_expr, and a
+           function that binds the type variable. *)
 val transl_type_scheme:
         Env.t -> Parsetree.core_type -> Typedtree.core_type
 val reset_type_variables: unit -> unit


### PR DESCRIPTION
`build_as_type` currently ignores type constraints. While this doesn't pose any soundness issue, it can lead to surprising results, e.g.
```ocaml
# let f = function ([] : int list) as x -> x;;
val f : int list -> 'a list = <fun>
```

The fix consists simply in reusing the pattern type if a constraint is present.
I added a few test cases to the testsuite and I believe the new behavior is an improvement.