### PR TITLE
Thread.wait_{timed_}read: document that they also return on EOF

### DIFF
--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -65,11 +65,11 @@ val wait_write : Unix.file_descr -> unit
 (** This function does nothing in this implementation. *)
 
 val wait_timed_read : Unix.file_descr -> float -> bool
-(** See {!Thread.wait_timed_read}.*)
+(** See {!Thread.wait_timed_write}.*)
 
 val wait_timed_write : Unix.file_descr -> float -> bool
 (** Suspend the execution of the calling thread until at least
-   one character is available for reading ([wait_read]) or
+   one character or EOF is available for reading ([wait_read]) or
    one character can be written without blocking ([wait_write])
    on the given Unix file descriptor. Wait for at most
    the amount of time given as second argument (in seconds).

--- a/otherlibs/threads/thread.mli
+++ b/otherlibs/threads/thread.mli
@@ -65,7 +65,7 @@ val wait_read : Unix.file_descr -> unit
 
 val wait_write : Unix.file_descr -> unit
 (** Suspend the execution of the calling thread until at least
-   one character is available for reading ({!Thread.wait_read}) or
+   one character or EOF is available for reading ({!Thread.wait_read}) or
    one character can be written without blocking ([wait_write])
    on the given Unix file descriptor. *)
 


### PR DESCRIPTION
Also the doc of `wait_timed_read` was pointing to itself,
fix it to be the same as in/otherlibs/threads/thread.mli


```
utop # #require "threads.posix";;
─( 16:40:37 )─< command 1 >──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────{ counter: 0 }─
utop # let fd_in, fd_out = Unix.pipe();;
val fd_in : Unix.file_descr = <abstr>
val fd_out : Unix.file_descr = <abstr>
─( 16:40:41 )─< command 2 >──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────{ counter: 0 }─
utop # Thread.create (fun () -> Unix.sleepf 10.; Unix.close fd_out) ();;
- : Thread.t = <abstr>
─( 16:40:44 )─< command 3 >──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────{ counter: 0 }─
utop # Thread.wait_timed_read fd_in 20.;;
- : bool = true
```