### PR TITLE
Fix MPR#7751

### DIFF
--- a/Changes
+++ b/Changes
@@ -363,7 +363,8 @@ Working version
 - MPR#7747: Type checker can loop infinitly and consumes all computer memory
   (Jacques Garrigue, report by kantian)
 
-- MPR#7751: The toplevel prints some concrete types as abstract
+- MPR#7751, GPR#1657: The toplevel prints some concrete types as abstract
+  (Jacques Garrigue, report by Matej Kosik)
 
 - GPR#1530, GPR#1574: testsuite, fix 'make parallel' and 'make one DIR=...'
   to work on ocamltest-based tests.

--- a/Changes
+++ b/Changes
@@ -363,6 +363,8 @@ Working version
 - MPR#7747: Type checker can loop infinitly and consumes all computer memory
   (Jacques Garrigue, report by kantian)
 
+- MPR#7751: The toplevel prints some concrete types as abstract
+
 - GPR#1530, GPR#1574: testsuite, fix 'make parallel' and 'make one DIR=...'
   to work on ocamltest-based tests.
   (Runhang Li and Sébastien Hinderer, review by Gabriel Scherer)

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -41,7 +41,7 @@ let interface ppf sourcefile outputprefix =
       if !Clflags.dump_typedtree then fprintf ppf "%a@." Printtyped.interface tsg;
       let sg = tsg.sig_type in
       if !Clflags.print_types then
-        Printtyp.wrap_printing_env initial_env (fun () ->
+        Printtyp.wrap_printing_env ~error:false initial_env (fun () ->
             fprintf std_formatter "%a@."
               Printtyp.signature (Typemod.simplify_signature sg));
       ignore (Includemod.signatures initial_env sg sg);

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -41,7 +41,7 @@ let interface ppf sourcefile outputprefix =
       if !Clflags.dump_typedtree then fprintf ppf "%a@." Printtyped.interface tsg;
       let sg = tsg.sig_type in
       if !Clflags.print_types then
-        Printtyp.wrap_printing_env initial_env (fun () ->
+        Printtyp.wrap_printing_env ~error:false initial_env (fun () ->
             fprintf std_formatter "%a@."
               Printtyp.signature (Typemod.simplify_signature sg));
       ignore (Includemod.signatures initial_env sg sg);

--- a/testsuite/tests/tool-toplevel/ocamltests
+++ b/testsuite/tests/tool-toplevel/ocamltests
@@ -1,4 +1,5 @@
 exotic_lists.ml
 pr7060.ml
+pr7751.ml
 strings.ml
 tracing.ml

--- a/testsuite/tests/tool-toplevel/pr7751.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr7751.compilers.reference
@@ -1,0 +1,10 @@
+- : Parsetree.expression =
+{Parsetree.pexp_desc =
+  Parsetree.Pexp_constant (Parsetree.Pconst_integer ("1", None));
+ pexp_loc =
+  {Location.loc_start =
+    {Lexing.pos_fname = ""; pos_lnum = 1; pos_bol = 0; pos_cnum = 0};
+   loc_end = {Lexing.pos_fname = ""; pos_lnum = 1; pos_bol = 0; pos_cnum = 1};
+   loc_ghost = false};
+ pexp_attributes = []}
+

--- a/testsuite/tests/tool-toplevel/pr7751.ml
+++ b/testsuite/tests/tool-toplevel/pr7751.ml
@@ -1,11 +1,6 @@
 (* TEST
+   include ocamlcommon
    * toplevel
 *)
-
-(* Horrible hack; there should be a way to do that... *)
-#directory"../../../../../../../../utils";;
-#directory"../../../../../../../../parsing";;
-#directory"../../../../../../../../compilerlibs";;
-#load"ocamlcommon.cma";;
 
 Parse.expression (Lexing.from_string "1");;

--- a/testsuite/tests/tool-toplevel/pr7751.ml
+++ b/testsuite/tests/tool-toplevel/pr7751.ml
@@ -2,9 +2,10 @@
    * toplevel
 *)
 
-#directory"../../../../../../utils";;
-#directory"../../../../../../parsing";;
-#directory"../../../../../../compilerlibs";;
+(* Horrible hack; there should be a way to do that... *)
+#directory"../../../../../../../../utils";;
+#directory"../../../../../../../../parsing";;
+#directory"../../../../../../../../compilerlibs";;
 #load"ocamlcommon.cma";;
 
 Parse.expression (Lexing.from_string "1");;

--- a/testsuite/tests/tool-toplevel/pr7751.ml
+++ b/testsuite/tests/tool-toplevel/pr7751.ml
@@ -1,0 +1,10 @@
+(* TEST
+   * toplevel
+*)
+
+#directory"../../../../../../utils";;
+#directory"../../../../../../parsing";;
+#directory"../../../../../../compilerlibs";;
+#load"ocamlcommon.cma";;
+
+Parse.expression (Lexing.from_string "1");;

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -329,7 +329,7 @@ let execute_phrase print_outcome ppf phr =
               else
                 Compilenv.record_global_approx_toplevel ();
               if print_outcome then
-                Printtyp.wrap_printing_env oldenv (fun () ->
+                Printtyp.wrap_printing_env ~error:false oldenv (fun () ->
                 match str.str_items with
                 | [] -> Ophr_signature []
                 | _ ->

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -508,7 +508,7 @@ let show_prim to_sig ppf lid =
     in
     let id = Ident.create_persistent s in
     let sg = to_sig env loc id lid in
-    Printtyp.wrap_printing_env env
+    Printtyp.wrap_printing_env ~error:false env
       (fun () -> fprintf ppf "@[%a@]@." Printtyp.signature sg)
   with
   | Not_found ->

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -262,7 +262,7 @@ let execute_phrase print_outcome ppf phr =
           match res with
           | Result v ->
               if print_outcome then
-                Printtyp.wrap_printing_env oldenv (fun () ->
+                Printtyp.wrap_printing_env ~error:false oldenv (fun () ->
                   match str.str_items with
                   | [ { str_desc =
                           (Tstr_eval (exp, _)

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -63,7 +63,7 @@ let include_err ppf =
         (function ppf ->
           fprintf ppf "but is expected to have type")
   | CM_Class_type_mismatch (env, cty1, cty2) ->
-      Printtyp.wrap_printing_env env (fun () ->
+      Printtyp.wrap_printing_env ~error:true env (fun () ->
         fprintf ppf
           "@[The class type@;<1 2>%a@ %s@;<1 2>%a@]"
           Printtyp.class_type cty1

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -674,7 +674,7 @@ let context ppf cxt =
     fprintf ppf "@[<hv 2>At position@ %a@]@ " context cxt
 
 let include_err ppf (cxt, env, err) =
-  Printtyp.wrap_printing_env env (fun () ->
+  Printtyp.wrap_printing_env ~error:true env (fun () ->
     fprintf ppf "@[<v>%a%a@]" context (List.rev cxt) include_err err)
 
 let buffer = ref Bytes.empty

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -420,8 +420,9 @@ let wrap_printing_env env f =
   set_printing_env env;
   try_finally f (fun () -> set_printing_env Env.empty)
 
-let wrap_printing_env env f =
-  Env.without_cmis (wrap_printing_env env) f
+let wrap_printing_env ~error env f =
+  if error then Env.without_cmis (wrap_printing_env env) f
+  else wrap_printing_env env f
 
 let is_unambiguous path env =
   let l = Env.find_shadowed_types path env in
@@ -1693,6 +1694,7 @@ let report_unification_error ppf env ?(unif=true) tr
     txt1 txt2 =
   wrap_printing_env env (fun () -> unification_error env unif tr txt1 ppf txt2
                             type_expected_explanation)
+    ~error:true
 ;;
 
 let trace fst keep_last txt ppf tr =
@@ -1709,7 +1711,7 @@ let trace fst keep_last txt ppf tr =
     raise exn
 
 let report_subtyping_error ppf env tr1 txt1 tr2 =
-  wrap_printing_env env (fun () ->
+  wrap_printing_env ~error:true env (fun () ->
     reset ();
     let tr1 = List.map prepare_expansion tr1
     and tr2 = List.map prepare_expansion tr2 in
@@ -1721,7 +1723,7 @@ let report_subtyping_error ppf env tr1 txt1 tr2 =
       (explain mis))
 
 let report_ambiguous_type_error ppf env (tp0, tp0') tpl txt1 txt2 txt3 =
-  wrap_printing_env env (fun () ->
+  wrap_printing_env ~error:true env (fun () ->
     reset ();
     List.iter
       (fun (tp, tp') -> path_same_name tp0 tp; path_same_name tp0' tp')

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -27,9 +27,10 @@ val string_of_path: Path.t -> string
 val raw_type_expr: formatter -> type_expr -> unit
 val string_of_label: Asttypes.arg_label -> string
 
-val wrap_printing_env: Env.t -> (unit -> 'a) -> 'a
+val wrap_printing_env: error:bool -> Env.t -> (unit -> 'a) -> 'a
     (* Call the function using the environment for type path shortening *)
     (* This affects all the printing functions below *)
+    (* Also, if [~error:true], then disable the loading of cmis *)
 
 val reset: unit -> unit
 val mark_loops: type_expr -> unit

--- a/typing/stypes.ml
+++ b/typing/stypes.ml
@@ -159,7 +159,7 @@ let print_info pp prev_loc ti =
       printtyp_reset_maybe loc;
       Printtyp.mark_loops typ;
       Format.pp_print_string Format.str_formatter "  ";
-      Printtyp.wrap_printing_env env
+      Printtyp.wrap_printing_env ~error:false env
                        (fun () -> Printtyp.type_sch Format.str_formatter typ);
       Format.pp_print_newline Format.str_formatter ();
       let s = Format.flush_str_formatter () in

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -2014,7 +2014,8 @@ let report_error env ppf = function
       Printtyp.type_scheme self
 
 let report_error env ppf err =
-  Printtyp.wrap_printing_env env (fun () -> report_error env ppf err)
+  Printtyp.wrap_printing_env ~error:true
+    env (fun () -> report_error env ppf err)
 
 let () =
   Location.register_error_of_exn

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5296,7 +5296,7 @@ let report_error env ppf = function
   | Empty_pattern -> assert false
 
 let report_error env ppf err =
-  wrap_printing_env env (fun () -> report_error env ppf err)
+  wrap_printing_env ~error:true env (fun () -> report_error env ppf err)
 
 let () =
   Location.register_error_of_exn

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1825,7 +1825,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
   let simple_sg = simplify_signature sg in
   if !Clflags.print_types then begin
     Typecore.force_delayed_checks ();
-    Printtyp.wrap_printing_env initial_env
+    Printtyp.wrap_printing_env ~error:false initial_env
       (fun () -> fprintf std_formatter "%a@." Printtyp.signature simple_sg);
     (str, Tcoerce_none)   (* result is ignored by Compile.implementation *)
   end else begin
@@ -2061,7 +2061,7 @@ let report_error ppf = function
         path p
 
 let report_error env ppf err =
-  Printtyp.wrap_printing_env env (fun () -> report_error ppf err)
+  Printtyp.wrap_printing_env ~error:true env (fun () -> report_error ppf err)
 
 let () =
   Location.register_error_of_exn

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -907,7 +907,7 @@ let report_error env ppf = function
   | Present_has_no_type l ->
       fprintf ppf "The present constructor %s has no type" l
   | Constructor_mismatch (ty, ty') ->
-      wrap_printing_env env (fun ()  ->
+      wrap_printing_env ~error:true env (fun ()  ->
         Printtyp.reset_and_mark_loops_list [ty; ty'];
         fprintf ppf "@[<hov>%s %a@ %s@ %a@]"
           "This variant type contains a constructor"
@@ -941,7 +941,7 @@ let report_error env ppf = function
   | Multiple_constraints_on_type s ->
       fprintf ppf "Multiple constraints for type %a" longident s
   | Method_mismatch (l, ty, ty') ->
-      wrap_printing_env env (fun ()  ->
+      wrap_printing_env ~error:true env (fun ()  ->
         Printtyp.reset_and_mark_loops_list [ty; ty'];
         fprintf ppf "@[<hov>Method '%s' has type %a,@ which should be %a@]"
           l Printtyp.type_expr ty Printtyp.type_expr ty')


### PR DESCRIPTION
Fixes [MPR#7751](https://caml.inria.fr/mantis/view.php?id=7751): The toplevel prints some concrete types as abstract.

This was a side effect of the fix of [MPR#7734](https://caml.inria.fr/mantis/view.php?id=7134), which prevented most printing functions from loading cmis, whereas this should only be done for errors.

This PR adds and `error` parameter to `Printtyp.wrap_printing_env`, and disables the loading of cmis only when it is set to `true`.