### PR TITLE
Doc for caml_alloc_final: allocates n + 1 words

### DIFF
--- a/manual/manual/cmds/intf-c.etex
+++ b/manual/manual/cmds/intf-c.etex
@@ -2005,9 +2005,9 @@ and the "alloc_final" function is still available to allocate a custom
 block with a given finalization function, but default comparison,
 hashing and serialization functions.  "caml_alloc_final("\var{n}",
 "\var{f}", "\var{used}", "\var{max}")" returns a fresh custom block of
-size \var{n} words, with finalization function \var{f}.  The first
+size \var{n}+1 words, with finalization function \var{f}.  The first
 word is reserved for storing the custom operations; the other
-\var{n}-1 words are available for your data.  The two parameters
+\var{n} words are available for your data.  The two parameters
 \var{used} and \var{max} are used to control the speed of garbage
 collection, as described for "caml_alloc_custom".
 


### PR DESCRIPTION
The current documentation for caml_calloc_final, fixed by this commit,
contradicts the documentation for caml_calloc_custom:

  Custom blocks must be allocated via the caml_alloc_custom function:
  caml_alloc_custom(ops, size, used, max) returns a fresh custom block,
  with room for size bytes of user data...

The caml_alloc_final function is defined as follows:

CAMLexport value caml_alloc_final (mlsize_t len, final_fun fun,
				   mlsize_t mem, mlsize_t max)
{
  return caml_alloc_custom(caml_final_custom_operations(fun),
			   len * sizeof(value), mem, max);
}

And the caml_alloc_custom function begins as follows:

CAMLexport value caml_alloc_custom(struct custom_operations * ops,
                                   uintnat size,
                                   mlsize_t mem,
                                   mlsize_t max)
{
  mlsize_t wosize;
  value result;

  wosize = 1 + (size + sizeof(value) - 1) / sizeof(value);
  ...

It adds the extra word to store the custom_operations.

No change entry needed.