### PR TITLE
Remove Const_pointer remnants and fix the fallout

### DIFF
--- a/Changes
+++ b/Changes
@@ -199,6 +199,11 @@ Working version
 * GPR#1617: Make string/bytes distinguishable in the bytecode.
   (Hugo Heuzard, reviewed by Nicolás Ojeda Bär)
 
+- GPR#1660: Continuation of GPR#1580: removal of Const_pointer remnants
+  from Flambda, fixes to instruction selection for mutable variables, removal
+  of [Cloop] and [Iloop] constructs in favour of recursive "catch"es.
+  (Pierre Chambart, Xavier Clerc and Mark Shinwell)
+
 - GPR#1686: Turn off by default flambda invariants checks.
   (Pierre Chambart)
 

--- a/asmcomp/CSEgen.ml
+++ b/asmcomp/CSEgen.ml
@@ -347,9 +347,6 @@ method private cse n i =
      let n1 = set_unknown_regs n (Proc.destroyed_at_oper i.desc) in
       {i with desc = Iswitch(index, Array.map (self#cse n1) cases);
               next = self#cse empty_numbering i.next}
-  | Iloop(body) ->
-      {i with desc = Iloop(self#cse empty_numbering body);
-              next = self#cse empty_numbering i.next}
   | Icatch(rec_flag, handlers, body) ->
       let aux (nfail, handler) =
         nfail, self#cse empty_numbering handler

--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -55,8 +55,6 @@ and instrument = function
   (* these cases add logging, as they may be targets of conditional branches *)
   | Cifthenelse (cond, t, f) ->
      Cifthenelse (instrument cond, with_afl_logging t, with_afl_logging f)
-  | Cloop e ->
-     Cloop (with_afl_logging e)
   | Ctrywith (e, ex, handler) ->
      Ctrywith (instrument e, ex, with_afl_logging handler)
   | Cswitch (e, cases, handlers, dbg) ->

--- a/asmcomp/build_export_info.ml
+++ b/asmcomp/build_export_info.ml
@@ -141,7 +141,7 @@ end = struct
     id
 
   let new_unit_descr t =
-    new_descr t (Value_constptr 0)
+    new_descr t (Value_int 0)
 
   let add_approx t var approx =
     if Variable.Map.mem var t.var then begin
@@ -166,9 +166,6 @@ end
 
 let descr_of_constant (c : Flambda.const) : Export_info.descr =
   match c with
-  (* [Const_pointer] is an immediate value of a type whose values may be
-     boxed (typically a variant type with both constant and non-constant
-     constructors). *)
   | Int i -> Value_int i
   | Char c -> Value_char c
 

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -55,6 +55,8 @@ val typ_addr: machtype
 val typ_int: machtype
 val typ_float: machtype
 
+val equal_component : machtype_component -> machtype_component -> bool
+
 val size_component: machtype_component -> int
 
 (** Least upper bound of two [machtype_component]s. *)
@@ -71,6 +73,12 @@ val ge_component
   -> bool
 
 val size_machtype: machtype -> int
+
+val equal_machtype : machtype -> machtype -> bool
+
+val lub_machtype : machtype -> machtype -> machtype
+
+val ge_machtype : machtype -> machtype -> bool
 
 type integer_comparison = Lambda.integer_comparison =
   | Ceq | Cne | Clt | Cgt | Cle | Cge
@@ -143,7 +151,6 @@ and expression =
   | Csequence of expression * expression
   | Cifthenelse of expression * expression * expression
   | Cswitch of expression * int array * expression array * Debuginfo.t
-  | Cloop of expression
   | Ccatch of rec_flag * (int * Ident.t list * expression) list * expression
   | Cexit of int * expression list
   | Ctrywith of expression * Ident.t * expression

--- a/asmcomp/comballoc.ml
+++ b/asmcomp/comballoc.ml
@@ -73,10 +73,6 @@ let rec combine i allocstate =
       let newnext = combine_restart i.next in
       (instr_cons (Iswitch(table, newcases)) i.arg i.res newnext,
        allocated_size allocstate)
-  | Iloop(body) ->
-      let newbody = combine_restart body in
-      (instr_cons (Iloop(newbody)) i.arg i.res i.next,
-       allocated_size allocstate)
   | Icatch(rec_flag, handlers, body) ->
       let (newbody, sz) = combine body allocstate in
       let newhandlers =

--- a/asmcomp/deadcode.ml
+++ b/asmcomp/deadcode.ml
@@ -54,10 +54,6 @@ let rec deadcode i =
       let (s, _) = deadcode i.next in
       ({i with desc = Iswitch(index, cases'); next = s},
        Reg.add_set_array i.live arg)
-  | Iloop(body) ->
-      let (body', _) = deadcode body in
-      let (s, _) = deadcode i.next in
-      ({i with desc = Iloop body'; next = s}, i.live)
   | Icatch(rec_flag, handlers, body) ->
       let (body', _) = deadcode body in
       let handlers' =

--- a/asmcomp/debug/available_regs.ml
+++ b/asmcomp/debug/available_regs.ml
@@ -223,22 +223,6 @@ let rec available_regs (instr : M.instruction)
         Some (ok avail_across), ok avail_after
       | Iifthenelse (_, ifso, ifnot) -> join [ifso; ifnot] ~avail_before
       | Iswitch (_, cases) -> join (Array.to_list cases) ~avail_before
-      | Iloop body ->
-        let avail_after = ref (ok avail_before) in
-        begin try
-          while true do
-            let avail_after' =
-              RAS.inter !avail_after
-                (available_regs body ~avail_before:!avail_after)
-            in
-            if RAS.equal !avail_after avail_after' then begin
-              raise Exit
-              end;
-            avail_after := avail_after'
-          done
-        with Exit -> ()
-        end;
-        None, unreachable
       | Icatch (recursive, handlers, body) ->
         List.iter (fun (nfail, _handler) ->
             (* In case there are nested [Icatch] expressions with the same

--- a/asmcomp/export_info.ml
+++ b/asmcomp/export_info.ml
@@ -39,7 +39,6 @@ type descr =
   | Value_mutable_block of Tag.t * int
   | Value_int of int
   | Value_char of char
-  | Value_constptr of int
   | Value_float of float
   | Value_float_array of value_float_array
   | Value_boxed_int : 'a Simple_value_approx.boxed_int * 'a -> descr
@@ -108,8 +107,6 @@ let equal_descr (d1:descr) (d2:descr) : bool =
     i1 = i2
   | Value_char c1, Value_char c2 ->
     c1 = c2
-  | Value_constptr i1, Value_constptr i2 ->
-    i1 = i2
   | Value_float f1, Value_float f2 ->
     f1 = f2
   | Value_float_array s1, Value_float_array s2 ->
@@ -124,11 +121,11 @@ let equal_descr (d1:descr) (d2:descr) : bool =
   | Value_set_of_closures s1, Value_set_of_closures s2 ->
     equal_set_of_closures s1 s2
   | ( Value_block (_, _) | Value_mutable_block (_, _) | Value_int _
-    | Value_char _ | Value_constptr _ | Value_float _ | Value_float_array _
+    | Value_char _ | Value_float _ | Value_float_array _
     | Value_boxed_int _ | Value_string _ | Value_closure _
     | Value_set_of_closures _ ),
     ( Value_block (_, _) | Value_mutable_block (_, _) | Value_int _
-    | Value_char _ | Value_constptr _ | Value_float _ | Value_float_array _
+    | Value_char _ | Value_float _ | Value_float_array _
     | Value_boxed_int _ | Value_string _ | Value_closure _
     | Value_set_of_closures _ ) ->
     false
@@ -258,7 +255,6 @@ let print_approx ppf ((t,root_symbols) : t * Symbol.t list) =
     match descr with
     | Value_int i -> Format.pp_print_int ppf i
     | Value_char c -> fprintf ppf "%c" c
-    | Value_constptr i -> fprintf ppf "%ip" i
     | Value_block (tag, fields) ->
       fprintf ppf "[%a:%a]" Tag.print tag print_fields fields
     | Value_mutable_block (tag, size) ->

--- a/asmcomp/export_info.mli
+++ b/asmcomp/export_info.mli
@@ -42,7 +42,6 @@ type descr =
   | Value_mutable_block of Tag.t * int
   | Value_int of int
   | Value_char of char
-  | Value_constptr of int
   | Value_float of float
   | Value_float_array of value_float_array
   | Value_boxed_int : 'a Simple_value_approx.boxed_int * 'a -> descr

--- a/asmcomp/export_info_for_pack.ml
+++ b/asmcomp/export_info_for_pack.ml
@@ -97,7 +97,6 @@ let import_descr_for_pack units pack (descr : Export_info.descr)
   match descr with
   | Value_int _
   | Value_char _
-  | Value_constptr _
   | Value_string _
   | Value_float _
   | Value_float_array _

--- a/asmcomp/import_approx.ml
+++ b/asmcomp/import_approx.ml
@@ -103,7 +103,6 @@ let rec import_ex ex =
   | exception Not_found -> A.value_unknown Other
   | Value_int i -> A.value_int i
   | Value_char c -> A.value_char c
-  | Value_constptr i -> A.value_constptr i
   | Value_float f -> A.value_float f
   | Value_float_array float_array ->
     begin match float_array.contents with

--- a/asmcomp/interf.ml
+++ b/asmcomp/interf.ml
@@ -105,8 +105,6 @@ let build_graph fundecl =
           interf cases.(i)
         done;
         interf i.next
-    | Iloop body ->
-        interf body; interf i.next
     | Icatch(_rec_flag, handlers, body) ->
         interf body;
         List.iter (fun (_, handler) -> interf handler) handlers;
@@ -176,10 +174,6 @@ let build_graph fundecl =
         for i = 0 to Array.length cases - 1 do
           prefer (weight / 2) cases.(i)
         done;
-        prefer weight i.next
-    | Iloop body ->
-        (* Avoid overflow of weight and spill_cost *)
-        prefer (if weight < 1000 then 8 * weight else weight) body;
         prefer weight i.next
     | Icatch(rec_flag, handlers, body) ->
         prefer weight body;

--- a/asmcomp/interval.ml
+++ b/asmcomp/interval.ml
@@ -148,10 +148,6 @@ let build_intervals fd =
         insert_destroyed_at_oper intervals i !pos;
         Array.iter walk_instruction cases;
         walk_instruction i.next
-    | Iloop body ->
-        insert_destroyed_at_oper intervals i !pos;
-        walk_instruction body;
-        walk_instruction i.next
     | Icatch(_, handlers, body) ->
         insert_destroyed_at_oper intervals i !pos;
         List.iter (fun (_, i) -> walk_instruction i) handlers;

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -248,11 +248,6 @@ let rec linear i n =
                    i !n2
       end else
         copy_instr (Lswitch(Array.map (fun n -> lbl_cases.(n)) index)) i !n2
-  | Iloop body ->
-      let lbl_head = Cmm.new_label() in
-      let n1 = linear i.Mach.next n in
-      let n2 = linear body (cons_instr (Lbranch lbl_head) n1) in
-      cons_instr (Llabel lbl_head) n2
   | Icatch(_rec_flag, handlers, body) ->
       let (lbl_end, n1) = get_label(linear i.Mach.next n) in
       (* CR mshinwell for pchambart:

--- a/asmcomp/liveness.ml
+++ b/asmcomp/liveness.ml
@@ -89,20 +89,6 @@ let rec live i finally =
       done;
       i.live <- !at_fork;
       Reg.add_set_array !at_fork arg
-  | Iloop(body) ->
-      let at_top = ref Reg.Set.empty in
-      (* Yes, there are better algorithms, but we'll just iterate till
-         reaching a fixpoint. *)
-      begin try
-        while true do
-          let new_at_top = Reg.Set.union !at_top (live body !at_top) in
-          if Reg.Set.equal !at_top new_at_top then raise Exit;
-          at_top := new_at_top
-        done
-      with Exit -> ()
-      end;
-      i.live <- !at_top;
-      !at_top
   | Icatch(rec_flag, handlers, body) ->
       let at_join = live i.next finally in
       let aux (nfail,handler) (nfail', before_handler) =

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -81,7 +81,6 @@ and instruction_desc =
   | Ireturn
   | Iifthenelse of test * instruction * instruction
   | Iswitch of int array * instruction array
-  | Iloop of instruction
   | Icatch of Cmm.rec_flag * (int * instruction) list * instruction
   | Iexit of int
   | Itrywith of instruction * instruction
@@ -153,8 +152,6 @@ let rec instr_iter f i =
             instr_iter f cases.(i)
           done;
           instr_iter f i.next
-      | Iloop(body) ->
-          instr_iter f body; instr_iter f i.next
       | Icatch(_, handlers, body) ->
           instr_iter f body;
           List.iter (fun (_n, handler) -> instr_iter f handler) handlers;
@@ -197,7 +194,7 @@ let spacetime_node_hole_pointer_is_live_before insn =
     | Ifloatofint | Iintoffloat
     | Iname_for_debugger _ -> false
     end
-  | Iend | Ireturn | Iifthenelse _ | Iswitch _ | Iloop _ | Icatch _
+  | Iend | Ireturn | Iifthenelse _ | Iswitch _ | Icatch _
   | Iexit _ | Itrywith _ | Iraise _ -> false
 
 let operation_can_raise op =

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -97,7 +97,6 @@ and instruction_desc =
   | Ireturn
   | Iifthenelse of test * instruction * instruction
   | Iswitch of int array * instruction array
-  | Iloop of instruction
   | Icatch of Cmm.rec_flag * (int * instruction) list * instruction
   | Iexit of int
   | Itrywith of instruction * instruction

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -175,8 +175,6 @@ let rec expr ppf = function
         fprintf ppf "@ @[<2>%t@ %a@]" (print_case i) sequence cases.(i)
        done in
       fprintf ppf "@[<v 0>@[<2>(switch@ %a@ @]%t)@]" expr e1 print_cases
-  | Cloop e ->
-      fprintf ppf "@[<2>(loop@ %a)@]" sequence e
   | Ccatch(flag, handlers, e1) ->
       let print_handler ppf (i, ids, e2) =
         fprintf ppf "(%d%a)@ %a"

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -205,8 +205,6 @@ let rec instr ppf i =
         fprintf ppf "@]@,%a@]" instr cases.(i)
       done;
       fprintf ppf "@,endswitch"
-  | Iloop(body) ->
-      fprintf ppf "@[<v 2>loop@,%a@;<0 -2>endloop@]" instr body
   | Icatch(flag, handlers, body) ->
       fprintf ppf "@[<v 2>catch%a@,%a@;<0 -2>with"
         Printcmm.rec_flag flag instr body;

--- a/asmcomp/reg.ml
+++ b/asmcomp/reg.ml
@@ -35,7 +35,7 @@ end
 type t =
   { mutable raw_name: Raw_name.t;
     stamp: int;
-    mutable typ: Cmm.machtype_component;
+    typ: Cmm.machtype_component;
     mutable loc: location;
     mutable spill: bool;
     mutable part: int option;

--- a/asmcomp/reg.mli
+++ b/asmcomp/reg.mli
@@ -23,7 +23,7 @@ end
 type t =
   { mutable raw_name: Raw_name.t;       (* Name *)
     stamp: int;                         (* Unique stamp *)
-    mutable typ: Cmm.machtype_component;(* Type of contents *)
+    typ: Cmm.machtype_component;        (* Type of contents *)
     mutable loc: location;              (* Actual location *)
     mutable spill: bool;                (* "true" to force stack allocation  *)
     mutable part: int option;           (* Zero-based index of part of value *)

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -110,8 +110,6 @@ method private reload i =
       insert_moves i.arg newarg
         (instr_cons (Iswitch(index, Array.map (self#reload) cases)) newarg [||]
           (self#reload i.next))
-  | Iloop body ->
-      instr_cons (Iloop(self#reload body)) [||] [||] (self#reload i.next)
   | Icatch(rec_flag, handlers, body) ->
       let new_handlers = List.map
           (fun (nfail, handler) -> nfail, self#reload handler)

--- a/asmcomp/selectgen.mli
+++ b/asmcomp/selectgen.mli
@@ -127,6 +127,15 @@ class virtual selector_generic : object
      (except by [Spacetime_profiling]). *)
   method emit_fundecl : Cmm.fundecl -> Mach.fundecl
 
+  method emit_let :
+       environment
+    -> nothing:'a
+    -> emit_body:(environment -> Cmm.expression -> 'a)
+    -> Ident.t
+    -> defining_expr:Cmm.expression
+    -> body:Cmm.expression
+    -> 'a
+
   (* The following methods should not be overridden.  They cannot be
      declared "private" in the current implementation because they
      are not always applied to "self", but ideally they should be private. *)
@@ -139,8 +148,6 @@ class virtual selector_generic : object
   method insert_move_args : Reg.t array -> Reg.t array -> int -> unit
   method insert_move_results : Reg.t array -> Reg.t array -> int -> unit
   method insert_moves : Reg.t array -> Reg.t array -> unit
-  method adjust_type : Reg.t -> Reg.t -> unit
-  method adjust_types : Reg.t array -> Reg.t array -> unit
   method emit_expr :
     environment -> Cmm.expression -> Reg.t array option
   method emit_tail : environment -> Cmm.expression -> unit

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -198,39 +198,19 @@ let rec reload i before =
                    (instr_cons (Iswitch(index, new_cases))
                                i.arg i.res new_next),
        finally)
-  | Iloop(body) ->
-      let date_start = !current_date in
-      let destroyed_at_fork_start = !destroyed_at_fork in
-      let at_head = ref before in
-      let final_body = ref body in
-      begin try
-        while true do
-          current_date := date_start;
-          destroyed_at_fork := destroyed_at_fork_start;
-          let (new_body, new_at_head) = reload body !at_head in
-          let merged_at_head = Reg.Set.union !at_head new_at_head in
-          if Reg.Set.equal merged_at_head !at_head then begin
-            final_body := new_body;
-            raise Exit
-          end;
-          at_head := merged_at_head
-        done
-      with Exit -> ()
-      end;
-      let (new_next, finally) = reload i.next Reg.Set.empty in
-      (instr_cons (Iloop(!final_body)) i.arg i.res new_next,
-       finally)
   | Icatch(rec_flag, handlers, body) ->
       let new_sets = List.map
           (fun (nfail, _) -> nfail, ref Reg.Set.empty) handlers in
       let previous_reload_at_exit = !reload_at_exit in
       reload_at_exit := new_sets @ !reload_at_exit ;
       let (new_body, after_body) = reload body before in
+      let date_start = !current_date in
       let rec fixpoint () =
         let at_exits = List.map (fun (nfail, set) -> (nfail, !set)) new_sets in
         let res =
           List.map2 (fun (nfail', handler) (nfail, at_exit) ->
               assert(nfail = nfail');
+              current_date := date_start;
               reload handler at_exit) handlers at_exits in
         match rec_flag with
         | Cmm.Nonrecursive ->
@@ -375,26 +355,6 @@ let rec spill i finally =
       inside_arm := saved_inside_arm ;
       (instr_cons (Iswitch(index, new_cases)) i.arg i.res new_next,
        !before)
-  | Iloop(body) ->
-      let (new_next, _) = spill i.next finally in
-      let saved_inside_loop = !inside_loop in
-      inside_loop := true;
-      let at_head = ref Reg.Set.empty in
-      let final_body = ref body in
-      begin try
-        while true do
-          let (new_body, before_body) = spill body !at_head in
-          let new_at_head = Reg.Set.union !at_head before_body in
-          if Reg.Set.equal new_at_head !at_head then begin
-            final_body := new_body; raise Exit
-          end;
-          at_head := new_at_head
-        done
-      with Exit -> ()
-      end;
-      inside_loop := saved_inside_loop;
-      (instr_cons (Iloop(!final_body)) i.arg i.res new_next,
-       !at_head)
   | Icatch(rec_flag, handlers, body) ->
       let (new_next, at_join) = spill i.next finally in
       let saved_inside_catch = !inside_catch in

--- a/asmcomp/split.ml
+++ b/asmcomp/split.ml
@@ -160,11 +160,6 @@ let rec rename i sub =
       (instr_cons (Iswitch(index, Array.map (fun (n, _s) -> n) new_sub_cases))
                   (subst_regs i.arg sub) [||] new_next,
        sub_next)
-  | Iloop(body) ->
-      let (new_body, sub_body) = rename body sub in
-      let (new_next, sub_next) = rename i.next (merge_substs sub sub_body i) in
-      (instr_cons (Iloop(new_body)) [||] [||] new_next,
-       sub_next)
   | Icatch(rec_flag, handlers, body) ->
       let new_subst = List.map (fun (nfail, _) -> nfail, ref None)
           handlers in

--- a/middle_end/inline_and_simplify.ml
+++ b/middle_end/inline_and_simplify.ml
@@ -1211,10 +1211,10 @@ and simplify env r (tree : Flambda.t) : Flambda.t * R.t =
        if arg is not effectful we can also drop it. *)
     simplify_free_variable env arg ~f:(fun env arg arg_approx ->
       begin match arg_approx.descr with
-      | Value_constptr 0 | Value_int 0 ->  (* Constant [false]: keep [ifnot] *)
+      | Value_int 0 ->  (* Constant [false]: keep [ifnot] *)
         let ifnot, r = simplify env r ifnot in
         ifnot, R.map_benefit r B.remove_branch
-      | Value_constptr _ | Value_int _
+      | Value_int _
       | Value_block _ ->  (* Constant [true]: keep [ifso] *)
         let ifso, r = simplify env r ifso in
         ifso, R.map_benefit r B.remove_branch

--- a/middle_end/simple_value_approx.mli
+++ b/middle_end/simple_value_approx.mli
@@ -124,7 +124,6 @@ and descr = private
   | Value_block of Tag.t * t array
   | Value_int of int
   | Value_char of char
-  | Value_constptr of int
   | Value_float of float option
   | Value_boxed_int : 'a boxed_int * 'a -> descr
   | Value_set_of_closures of value_set_of_closures
@@ -205,7 +204,6 @@ val value_mutable_float_array : size:int -> t
 val value_immutable_float_array : t array -> t
 val value_string : int -> string option -> t
 val value_boxed_int : 'i boxed_int -> 'i -> t
-val value_constptr : int -> t
 val value_block : Tag.t -> t array -> t
 val value_extern : Export_id.t -> t
 val value_symbol : Symbol.t -> t
@@ -237,14 +235,12 @@ val value_set_of_closures
     together with an Flambda expression representing it. *)
 val make_const_int : int -> Flambda.t * t
 val make_const_char : char -> Flambda.t * t
-val make_const_ptr : int -> Flambda.t * t
 val make_const_bool : bool -> Flambda.t * t
 val make_const_float : float -> Flambda.t * t
 val make_const_boxed_int : 'i boxed_int -> 'i -> Flambda.t * t
 
 val make_const_int_named : int -> Flambda.named * t
 val make_const_char_named : char -> Flambda.named * t
-val make_const_ptr_named : int -> Flambda.named * t
 val make_const_bool_named : bool -> Flambda.named * t
 val make_const_float_named : float -> Flambda.named * t
 val make_const_boxed_int_named : 'i boxed_int -> 'i -> Flambda.named * t

--- a/middle_end/simplify_common.ml
+++ b/middle_end/simplify_common.ml
@@ -34,11 +34,6 @@ let const_char_expr expr c =
     let (new_expr, approx) = A.make_const_char_named c in
     new_expr, approx, C.Benefit.remove_code_named expr C.Benefit.zero
   else expr, A.value_char c, C.Benefit.zero
-let const_ptr_expr expr n =
-  if Effect_analysis.no_effects_named expr then
-    let (new_expr, approx) = A.make_const_ptr_named n in
-    new_expr, approx, C.Benefit.remove_code_named expr C.Benefit.zero
-  else expr, A.value_constptr n, C.Benefit.zero
 let const_bool_expr expr b =
   const_int_expr expr (if b then 1 else 0)
 let const_float_expr expr f =

--- a/middle_end/simplify_common.mli
+++ b/middle_end/simplify_common.mli
@@ -42,11 +42,6 @@ val const_bool_expr
   -> bool
   -> Flambda.named * Simple_value_approx.t * Inlining_cost.Benefit.t
 
-val const_ptr_expr
-   : Flambda.named
-  -> int
-  -> Flambda.named * Simple_value_approx.t * Inlining_cost.Benefit.t
-
 val const_float_expr
    : Flambda.named
   -> float

--- a/testsuite/tests/asmgen/parsecmm.mly
+++ b/testsuite/tests/asmgen/parsecmm.mly
@@ -205,7 +205,9 @@ expr:
           match $3 with
             Cconst_int x when x <> 0 -> $4
           | _ -> Cifthenelse($3, $4, (Cexit(0,[]))) in
-        Ccatch(Recursive, [0, [], Cloop body], Ctuple []) }
+        Ccatch(Nonrecursive, [0, [],
+          Ccatch(Recursive, [1, [], Csequence (body, Cexit (1, []))],
+            Cexit (1, []))], Ctuple []) }
   | LPAREN EXIT IDENT exprlist RPAREN
     { Cexit(find_label $3, List.rev $4) }
   | LPAREN CATCH sequence WITH catch_handlers RPAREN


### PR DESCRIPTION
This pull request should excise the last remnants of Const_pointer from the compiler.  It is a continuation of GPR#1580.