### PR TITLE
ocamldoc: honour nostdlib flag

### DIFF
--- a/ocamldoc/odoc_analyse.ml
+++ b/ocamldoc/odoc_analyse.ml
@@ -28,7 +28,7 @@ open Typedtree
    then the standard library directory. *)
 let init_path () =
   Config.load_path :=
-    "" :: List.rev (Config.standard_library :: !Clflags.include_dirs);
+    "" :: List.rev ( Clflags.std_include_dir () @ !Clflags.include_dirs);
   Env.reset_cache ()
 
 (** Return the initial environment in which compilation proceeds. *)


### PR DESCRIPTION
This PR makes ocamldoc honour the `-nostdlib` flag. This may fix the issue reported in #1621 , but I have not yet repoduced an instance of the bug.
@gasche , do you have an explicit commit number for the stale installation that triggered the issue ?