### PR TITLE
output-complete-obj: link runtime C libraries when building shared libraries

### DIFF
--- a/Changes
+++ b/Changes
@@ -144,6 +144,10 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- GPR#1664: make -output-complete-obj link the runtime native c libraries when
+  building shared libraries like `-output-obj`.
+  (Florian Angeletti, review by Nicolás Ojeda Bär)
+
 - #9074: reworded error message for non-regular structural types
   (Florian Angeletti, review by Jacques Garrigue and Leo White,
    report by Chas Emerick)

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -323,7 +323,7 @@ let call_linker file_list startup_file output_name =
   let files, c_lib =
     if (not !Clflags.output_c_object) || main_dll || main_obj_runtime then
       files @ (List.rev !Clflags.ccobjs) @ runtime_lib () @ libunwind,
-      (if !Clflags.nopervasives || main_obj_runtime
+      (if !Clflags.nopervasives || (main_obj_runtime && not main_dll)
        then "" else Config.native_c_libraries)
     else
       files, ""


### PR DESCRIPTION
Thus PR is an offspring of #1351  : currently, when building a shared library with `-output-obj` or `-output-complete-obj`:
```
ocamlopt -output-obj a.ml -o a.so 
```
the only difference between `-output-obj` and `output-complete-obj` is that `-output-complete-obj` does *not* link the C libraries used by the runtime by default. The fact that the `complete` variant links less objects than the simple variant is not intuitive at all — as illustrated by the discussion in #1351 . 

Moreover, @whitequark confirmed that this behavior was not really intended and was inherited from the static linking mode.

Consequently, this small PR proposes to align the behavior of `-output-complete-obj` to the behavior of `output-obj` and link these runtime C libraries in the shared library mode.