### PR TITLE
testsuite: move one test from typing-warnings to typing-misc

### DIFF
--- a/testsuite/tests/typing-misc/inside_out.ml
+++ b/testsuite/tests/typing-misc/inside_out.ml
@@ -68,8 +68,6 @@ val f3' : unit -> unit = <fun>
 |}]
 
 
-(* no warning *)
-
 let (Left () : (unit, empty) t) = Left ();;
 [%%expect {|
 |}]
@@ -82,8 +80,6 @@ let f () =
 val f : unit -> unit = <fun>
 |}]
 
-(* warning *)
-
 let f () =
   let (Left () : (unit, empty) t) = Left () in
   ()
@@ -91,8 +87,6 @@ let f () =
 [%%expect{|
 val f : unit -> unit = <fun>
 |}]
-
-(* no warning *)
 
 let f () =
   match (Left () : (unit, empty) t) with
@@ -111,8 +105,6 @@ let f () =
 val f : unit -> unit = <fun>
 |}]
 
-(* warning *)
-
 let f () =
   match Left () with
   | (Left () : (unit, empty) t) -> ()
@@ -120,8 +112,6 @@ let f () =
 [%%expect {|
 val f : unit -> unit = <fun>
 |}]
-
-(* error *)
 
 let f () =
   match Left () with

--- a/testsuite/tests/typing-misc/ocamltests
+++ b/testsuite/tests/typing-misc/ocamltests
@@ -1,5 +1,6 @@
 constraints.ml
 disambiguate_principality.ml
+inside_out.ml
 labels.ml
 occur_check.ml
 polyvars.ml

--- a/testsuite/tests/typing-warnings/ocamltests
+++ b/testsuite/tests/typing-warnings/ocamltests
@@ -2,7 +2,6 @@ ambiguous_guarded_disjunction.ml
 application.ml
 coercions.ml
 exhaustiveness.ml
-inside_out.ml
 pr5892.ml
 pr6587.ml
 pr6872.ml


### PR DESCRIPTION
Follow up to discussion with @gasche on https://github.com/ocaml/ocaml/commit/1b670fb2f181bd9ca9986d1ac0808ff1412875c5.