### PR TITLE
Make the check_all_arches target no-op on 32-bit architectures (fresh branch)

### DIFF
--- a/Changes
+++ b/Changes
@@ -250,6 +250,10 @@ Working version
   leftover .a files from an earlier compilation may contain unwanted modules
   (Xavier Leroy)
 
+- GPR#1571: do not perform architecture tests on 32-bit platforms, allowing
+  64-bit back-ends to use 64-bit specific constructs
+  (Xavier Clerc, review by Damien Doligez)
+
 ### Internal/compiler-libs changes:
 
 - GPR#1488, GPR#1560: Refreshing parmatch

--- a/Makefile
+++ b/Makefile
@@ -1169,11 +1169,15 @@ check_arch:
 
 .PHONY: check_all_arches
 check_all_arches:
+ifneq ($(shell grep -E '^\#define ARCH_SIXTYFOUR$$' byterun/caml/m.h 2> /dev/null),)
 	@STATUS=0; \
 	 for i in $(ARCHES); do \
 	   $(MAKE) --no-print-directory check_arch ARCH=$$i || STATUS=1; \
 	 done; \
 	 exit $$STATUS
+else
+	 @echo "Architecture tests are disabled on 32-bit platforms."
+endif
 
 # Compiler Plugins
 


### PR DESCRIPTION
Roughly the same as https://github.com/ocaml/ocaml/pull/1571, were there seems to be a Travis issue.
This PR only uses a stricter matching expression when grepping.