### PR TITLE
typecore: remove trivially dead code

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1312,8 +1312,7 @@ and type_pat_aux ~constrs ~labels ~no_existentials ~mode ~explode ~env
       let ty_elt = newvar() in
       unify_pat_types
         loc !env (instance_def (Predef.type_array ty_elt)) expected_ty;
-      let spl_ann = List.map (fun p -> (p,newvar())) spl in
-      map_fold_cont (fun (p,_) -> type_pat p ty_elt) spl_ann (fun pl ->
+      map_fold_cont (fun p -> type_pat p ty_elt) spl (fun pl ->
         rp k {
         pat_desc = Tpat_array pl;
         pat_loc = loc; pat_extra=[];


### PR DESCRIPTION
Introduced by https://github.com/ocaml/ocaml/commit/6de25fef2f6db569e0499e5eb492e31caf784a6c (i.e. it was deadcode from the start).

Not that it matters but my guess is that it was initially written like the `Ppat_tuple` case and then partially reverted (because unlike the tuple case, all the subpatterns must be of the same type).