### PR TITLE
Improve handling of travis test results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,7 +242,7 @@ _ocamltest
 /testsuite/**/*.byte
 /testsuite/**/*.native
 /testsuite/**/program
-/testsuite/**/_log
+/testsuite/**/_log*
 /testsuite/failure.stamp
 
 /testsuite/_retries

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 *.out.dSYM
 *.swp
 _ocamltest
+_ocamltestd
 *.odoc
 
 # local to root directory

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -72,8 +72,12 @@ EOF
   export PATH=$PREFIX/bin:$PATH
   $MAKE world.opt
   $MAKE ocamlnat
-  (cd testsuite && $MAKE all)
-  (cd testsuite && $MAKE USE_RUNTIME="d" all)
+  cd testsuite
+  echo Running the testsuite with the normal runtime
+  $MAKE all
+  echo Running the testsuite with the debug runtime
+  $MAKE USE_RUNTIME="d" OCAMLTESTDIR=$(pwd)/_ocamltestd TESTLOG=_logd all
+  cd ..
   $MAKE install
   $MAKE manual-pregen
   # check_all_arches checks tries to compile all backends in place,

--- a/Makefile
+++ b/Makefile
@@ -1289,6 +1289,6 @@ distclean: clean
 	rm -f config/Makefile byterun/caml/m.h byterun/caml/s.h
 	rm -f tools/*.bak
 	rm -f ocaml ocamlc
-	rm -f testsuite/_log
+	rm -f testsuite/_log*
 
 include .depend

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -42,6 +42,8 @@ endif
 
 failstamp := failure.stamp
 
+TESTLOG ?= _log
+
 ocamltest_directory := ../ocamltest
 
 ocamltest_program := $(or \
@@ -74,14 +76,14 @@ default:
 
 .PHONY: all
 all:
-	@rm -f _log
+	@rm -f $(TESTLOG)
 	@$(MAKE) $(NO_PRINT) legacy-without-report
 	@$(MAKE) $(NO_PRINT) new-without-report
 	@$(MAKE) $(NO_PRINT) report
 
 .PHONY: legacy
 legacy:
-	@rm -f _log
+	@rm -f $(TESTLOG)
 	@$(MAKE) $(NO_PRINT) legacy-without-report
 	@$(MAKE) $(NO_PRINT) report
 
@@ -89,12 +91,12 @@ legacy:
 legacy-without-report: lib tools
 	@for dir in tests/*; do \
 	  $(MAKE) $(NO_PRINT) exec-one DIR=$$dir LEGACY=y; \
-	done 2>&1 | tee -a _log
+	done 2>&1 | tee -a $(TESTLOG)
 	@$(MAKE) $(NO_PRINT) retries
 
 .PHONY: new
 new:
-	@rm -f _log
+	@rm -f $(TESTLOG)
 	@$(MAKE) $(NO_PRINT) new-without-report
 	@$(MAKE) $(NO_PRINT) report
 
@@ -106,14 +108,14 @@ new-without-report: lib tools
 	  echo Running tests from \'$$dir\' ... ; \
 	  $(MAKE) exec-ocamltest DIR=$$dir \
 	    OCAMLTESTENV="" OCAMLTESTFLAGS=""; \
-	done || touch $(failstamp)) 2>&1 | tee -a _log
+	done || touch $(failstamp)) 2>&1 | tee -a $(TESTLOG)
 	@if [ -f $(failstamp) ]; then rm $(failstamp); exit 1; fi
 
 .PHONY: all-%
 all-%: lib tools
 	@for dir in tests/$**; do \
 	  $(MAKE) $(NO_PRINT) exec-one DIR=$$dir; \
-	done 2>&1 | tee _log
+	done 2>&1 | tee $(TESTLOG)
 	@$(MAKE) $(NO_PRINT) retries
 	@$(MAKE) report
 
@@ -154,7 +156,7 @@ parallel-%: lib tools
 	@for dir in tests/$**; do echo $$dir; done \
 	 | parallel --gnu --no-notice --keep-order \
 	     "$(MAKE) $(NO_PRINT) exec-one DIR={} 2>&1" \
-	 | tee _log
+	 | tee $(TESTLOG)
 	@$(MAKE) $(NO_PRINT) retries
 	@$(MAKE) report
 
@@ -169,7 +171,7 @@ list: lib tools
 	fi
 	@while read LINE; do \
 	  $(MAKE) $(NO_PRINT) exec-one DIR=$$LINE; \
-	done <$(FILE) 2>&1 | tee _log
+	done <$(FILE) 2>&1 | tee $(TESTLOG)
 	@$(MAKE) $(NO_PRINT) retries
 	@$(MAKE) report
 
@@ -266,16 +268,16 @@ clean:
 
 .PHONY: report
 report:
-	@if [ ! -f _log ]; then echo "No '_log' file."; exit 1; fi
-	@awk -f makefiles/summarize.awk <_log
+	@if [ ! -f $$(TESTLOG) ]; then echo "No $$(TESTLOG) file."; exit 1; fi
+	@awk -f makefiles/summarize.awk < $(TESTLOG)
 
 .PHONY: retry-list
 retry-list:
 	@while read LINE; do \
 	  if [ -n "$$LINE" ] ; then \
-	    echo re-ran $$LINE>>_log; \
+	    echo re-ran $$LINE>> $(TESTLOG); \
 	    $(MAKE) $(NO_PRINT) clean-one DIR=$$LINE; \
-	    $(MAKE) $(NO_PRINT) exec-one DIR=$$LINE 2>&1 | tee -a _log ; \
+	    $(MAKE) $(NO_PRINT) exec-one DIR=$$LINE 2>&1 | tee -a $(TESTLOG) ; \
 	  fi \
 	done <_retries;
 	@$(MAKE) $(NO_PRINT) retries
@@ -283,7 +285,7 @@ retry-list:
 .PHONY: retries
 retries:
 	@awk -v retries=1 -v max_retries=$(MAX_TESTSUITE_DIR_RETRIES) \
-	     -f makefiles/summarize.awk <_log >_retries
+	     -f makefiles/summarize.awk < $(TESTLOG) > _retries
 	@test `cat _retries | wc -l` -eq 0 || $(MAKE) $(NO_PRINT) retry-list
 	@rm -f _retries
 


### PR DESCRIPTION
On Travis, the testsuite is run twice: first with the normal runtime
and then with the debug runtime.

Before this commit, all the tests were built in the _ocamltest
directory and the _log file for the first run was overwritten by
the second one.

This commit makes sure the results of the test of the debug runtime go to
the _ocamltestd directory and the _logd file.

OCAMLTESTDIR should be an absolute path, not a relative one.