### PR TITLE
Do not trigger the "missing rec" hint for simple values

### DIFF
--- a/testsuite/tests/typing-core-bugs/example_let_missing_rec_value.ml
+++ b/testsuite/tests/typing-core-bugs/example_let_missing_rec_value.ml
@@ -1,0 +1,12 @@
+(* TEST
+   * expect
+*)
+
+let not_a_function = 1 + not_a_function
+
+[%%expect{|
+Line _, characters 25-39:
+  let not_a_function = 1 + not_a_function
+                           ^^^^^^^^^^^^^^
+Error: Unbound value not_a_function
+|}]

--- a/testsuite/tests/typing-core-bugs/ocamltests
+++ b/testsuite/tests/typing-core-bugs/ocamltests
@@ -1,5 +1,6 @@
 example_let_missing_rec_loc.ml
 example_let_missing_rec.ml
 example_let_missing_rec_mutual.ml
+example_let_missing_rec_value.ml
 unit_fun_hints.ml
 type_expected_explanation.ml

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -109,7 +109,7 @@ and value_kind =
 
 and value_unbound_reason =
   | Val_unbound_instance_variable
-  | Val_unbound_ghost_recursive
+  | Val_unbound_ghost_recursive of bool
 
 (* Variance *)
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -264,7 +264,7 @@ and value_kind =
 
 and value_unbound_reason =
   | Val_unbound_instance_variable
-  | Val_unbound_ghost_recursive
+  | Val_unbound_ghost_recursive of bool
 
 (* Variance *)
 

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -856,7 +856,16 @@ let spellcheck ppf fold env lid =
 let fold_descr fold get_name f = fold (fun descr acc -> f (get_name descr) acc)
 let fold_simple fold4 f = fold4 (fun name _path _descr acc -> f name acc)
 
-let fold_values = fold_simple Env.fold_values
+let fold_values f =
+  (* We only use "real" values while spellchecking (as opposed to "phantom"
+     values inserted in the environment to trigger the "missing rec" hint).
+     This is needed in order to avoid dummy suggestions like:
+     "unbound value x, did you mean x?" *)
+  Env.fold_values
+    (fun name _path descr acc ->
+       match descr.val_kind with
+       | Val_unbound _ -> acc
+       | _ -> f name acc)
 let fold_types = fold_simple Env.fold_types
 let fold_modules = fold_simple Env.fold_modules
 let fold_constructors = fold_descr Env.fold_constructors (fun d -> d.cstr_name)


### PR DESCRIPTION
The "You are probably missing the `rec' keyword" hint is mildly
annoying when triggered for simple values because it is almost
always wrong, and very often suggests a fix that will then trigger
an error. For instance:

```
# let myvar1 = 0;;
val myvar1 : int = 0
# let myvar2 = myvar2 + 1;;
Error: Unbound value myvar2.
       Hint: You are probably missing the `rec' keyword on line 1.
# let rec myvar2 = myvar2 + 1;;
Error: This kind of expression is not allowed as right-hand side of `let rec'
```

This PR slightly changes the condition so that the hint is triggered iff
there are multiples definitions (*i.e.* `let`...`and`), or the value is an
arrow type. The previous toplevel session then becomes:

```
# let myvar1 = 0;;
val myvar1 : int = 0
# let myvar2 = myvar2 + 1;;
Error: Unbound value myvar2
Hint: Did you mean myvar1?
```
