### PR TITLE
Cleanup: remove Pbittest

### DIFF
--- a/Changes
+++ b/Changes
@@ -325,6 +325,9 @@ Working version
   migrate ocamldoc tests to ocamltest
   (Florian Angeletti, review by Sébastien Hinderer)
 
+- GPR#1679 : remove Pbittest from primitives in lambda
+  (Hugo Heuzard, review by Mark Shinwell)
+
 ### Bug fixes
 
 - MPR#5250, GPR#1435: on Cygwin, when ocamlrun searches the path

--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -131,7 +131,6 @@ let prim_size prim args =
   | Parraysetu kind -> if kind = Pgenarray then 16 else 4
   | Parrayrefs kind -> if kind = Pgenarray then 18 else 8
   | Parraysets kind -> if kind = Pgenarray then 22 else 10
-  | Pbittest -> 3
   | Pbigarrayref(_, ndims, _, _) -> 4 + ndims * 6
   | Pbigarrayset(_, ndims, _, _) -> 4 + ndims * 6
   | _ -> 2 (* arithmetic and comparisons *)

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -2348,18 +2348,6 @@ and transl_prim_2 env p arg1 arg2 dbg =
                 unboxed_float_array_ref arr idx dbg))))
       end
 
-  (* Operations on bitvects *)
-  | Pbittest ->
-      bind "index" (untag_int(transl env arg2) dbg) (fun idx ->
-        tag_int(
-          Cop(Cand, [Cop(Clsr, [Cop(Cload (Byte_unsigned, Mutable),
-                                    [add_int (transl env arg1)
-                                      (Cop(Clsr, [idx; Cconst_int 3], dbg))
-                                      dbg],
-                                    dbg);
-                                Cop(Cand, [idx; Cconst_int 7], dbg)], dbg);
-                     Cconst_int 1], dbg)) dbg)
-
   (* Boxed integers *)
   | Paddbint bi ->
       box_int dbg bi (Cop(Caddi,

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -398,7 +398,6 @@ let comp_primitive p args =
      Kccall(Printf.sprintf "caml_sys_const_%s" const_name, 1)
   | Pisint -> Kisint
   | Pisout -> Kisout
-  | Pbittest -> Kccall("caml_bitvect_test", 2)
   | Pbintofint bi -> comp_bint_primitive bi "of_int" args
   | Pintofbint bi -> comp_bint_primitive bi "to_int" args
   | Pcvtbint(Pint32, Pnativeint) -> Kccall("caml_nativeint_of_int32", 1)

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -103,8 +103,6 @@ type primitive =
   | Pisint
   (* Test if the (integer) argument is outside an interval *)
   | Pisout
-  (* Bitvect operations *)
-  | Pbittest
   (* Operations on boxed integers (Nativeint.t, Int32.t, Int64.t) *)
   | Pbintofint of boxed_integer
   | Pintofbint of boxed_integer

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -111,8 +111,6 @@ type primitive =
   | Pisint
   (* Test if the (integer) argument is outside an interval *)
   | Pisout
-  (* Bitvect operations *)
-  | Pbittest
   (* Operations on boxed integers (Nativeint.t, Int32.t, Int64.t) *)
   | Pbintofint of boxed_integer
   | Pintofbint of boxed_integer

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -262,7 +262,6 @@ let primitive ppf = function
      fprintf ppf "sys.constant_%s" const_name
   | Pisint -> fprintf ppf "isint"
   | Pisout -> fprintf ppf "isout"
-  | Pbittest -> fprintf ppf "testbit"
   | Pbintofint bi -> print_boxed_integer "of_int" ppf bi
   | Pintofbint bi -> print_boxed_integer "to_int" ppf bi
   | Pcvtbint (bi1, bi2) -> print_boxed_integer_conversion ppf bi1 bi2
@@ -411,7 +410,6 @@ let name_of_primitive = function
   | Pctconst _ -> "Pctconst"
   | Pisint -> "Pisint"
   | Pisout -> "Pisout"
-  | Pbittest -> "Pbittest"
   | Pbintofint _ -> "Pbintofint"
   | Pintofbint _ -> "Pintofbint"
   | Pcvtbint _ -> "Pcvtbint"

--- a/bytecomp/semantics_of_primitives.ml
+++ b/bytecomp/semantics_of_primitives.ml
@@ -78,7 +78,6 @@ let for_primitive (prim : Lambda.primitive) =
       No_effects, Has_coeffects  (* That old chestnut: [Obj.truncate]. *)
   | Pisint
   | Pisout
-  | Pbittest
   | Pbintofint _
   | Pintofbint _
   | Pcvtbint _

--- a/middle_end/inlining_cost.ml
+++ b/middle_end/inlining_cost.ml
@@ -53,7 +53,6 @@ let prim_size (prim : Lambda.primitive) args =
   | Parrayrefs _ -> 8
   | Parraysets Pgenarray -> 22
   | Parraysets _ -> 10
-  | Pbittest -> 3
   | Pbigarrayref (_, ndims, _, _) -> 4 + ndims * 6
   | Pbigarrayset (_, ndims, _, _) -> 4 + ndims * 6
   | Psequand | Psequor ->


### PR DESCRIPTION
Pbittest seems to be unused.
I did not remove `caml_bitvect_test` has it requires a bootstrap. 