### PR TITLE
makefiles: use 'install' instead of 'cp' in 'make install' targets

### DIFF
--- a/Changes
+++ b/Changes
@@ -259,6 +259,9 @@ Working version
 
 ### Compiler distribution build system
 
+- MPR#5219, GPR#1680: use 'install' instead of 'cp' in install scripts
+  (Gabriel Scherer, review by Sébastien Hinderer)
+
 - MPR#7679: make sure .a files are erased before calling ar rc, otherwise
   leftover .a files from an earlier compilation may contain unwanted modules
   (Xavier Leroy)

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@
 # make coreboot [new system -- now in a stable state]
 
 include config/Makefile
+include Makefile.common
 
 # For users who don't read the INSTALL file
 .PHONY: defaultentry
@@ -273,17 +274,6 @@ LIBFILES=stdlib.cma std_exit.cmo *.cmi camlheader
 MAXSAVED=boot/Saved/Saved.prev/Saved.prev/Saved.prev/Saved.prev/Saved.prev
 
 COMPLIBDIR=$(LIBDIR)/compiler-libs
-
-INSTALL=install
-INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
-INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
-
-INSTALL_BINDIR=$(DESTDIR)$(BINDIR)
-INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
-INSTALL_COMPLIBDIR=$(DESTDIR)$(COMPLIBDIR)
-INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
-INSTALL_MANDIR=$(DESTDIR)$(MANDIR)
-INSTALL_FLEXDLLDIR=$(INSTALL_LIBDIR)/flexdll
 
 TOPINCLUDES=$(addprefix -I otherlibs/,$(filter-out %threads,$(OTHERLIBRARIES)))
 RUNTOP=./byterun/ocamlrun ./ocaml \
@@ -585,6 +575,9 @@ flexlink.opt:
 	           OCAMLOPT="../ocamlopt.opt -I ../stdlib" flexlink.exe && \
 	mv flexlink.exe flexlink.opt && \
 	mv flexlink flexlink.exe
+
+INSTALL_COMPLIBDIR=$(DESTDIR)$(COMPLIBDIR)
+INSTALL_FLEXDLLDIR=$(INSTALL_LIBDIR)/flexdll
 
 .PHONY: install-flexdll
 install-flexdll:

--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 INSTALL_COMPLIBDIR=$(DESTDIR)$(COMPLIBDIR)
 INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 INSTALL_MANDIR=$(DESTDIR)$(MANDIR)
-INSTALL_FLEXDLL=$(INSTALL_LIBDIR)/flexdll
+INSTALL_FLEXDLLDIR=$(INSTALL_LIBDIR)/flexdll
 
 TOPINCLUDES=$(addprefix -I otherlibs/,$(filter-out %threads,$(OTHERLIBRARIES)))
 RUNTOP=./byterun/ocamlrun ./ocaml \
@@ -591,8 +591,8 @@ ifneq "$(filter-out mingw,$(TOOLCHAIN))" ""
     "$(INSTALL_BINDIR)/"
 endif
 	if test -n "$(wildcard flexdll/flexdll_*.$(O))" ; then \
-	  $(MKDIR) "$(INSTALL_FLEXDLL)" ; \
-	  install -m $(MDATA) flexdll/flexdll_*.$(O) "$(INSTALL_FLEXDLL)" ; \
+	  $(MKDIR) "$(INSTALL_FLEXDLLDIR)" ; \
+	  install -m $(MDATA) flexdll/flexdll_*.$(O) "$(INSTALL_FLEXDLLDIR)" ; \
 	fi
 
 MDATA=u+rw,g+rw,o+r

--- a/Makefile
+++ b/Makefile
@@ -587,13 +587,16 @@ install-flexdll:
 	cat stdlib/camlheader flexdll/flexlink.exe > \
 	  "$(INSTALL_BINDIR)/flexlink.exe"
 ifneq "$(filter-out mingw,$(TOOLCHAIN))" ""
-	cp flexdll/default$(filter-out _i386,_$(ARCH)).manifest \
+	install -m $(MDATA) flexdll/default$(filter-out _i386,_$(ARCH)).manifest \
     "$(INSTALL_BINDIR)/"
 endif
 	if test -n "$(wildcard flexdll/flexdll_*.$(O))" ; then \
 	  $(MKDIR) "$(INSTALL_FLEXDLL)" ; \
-	  cp flexdll/flexdll_*.$(O) "$(INSTALL_FLEXDLL)" ; \
+	  install -m $(MDATA) flexdll/flexdll_*.$(O) "$(INSTALL_FLEXDLL)" ; \
 	fi
+
+MDATA=u+rw,g+rw,o+r
+MPROG=u+rwx,g+rwx,o+rx
 
 # Installation
 .PHONY: install
@@ -602,26 +605,33 @@ install:
 	$(MKDIR) "$(INSTALL_LIBDIR)"
 	$(MKDIR) "$(INSTALL_STUBLIBDIR)"
 	$(MKDIR) "$(INSTALL_COMPLIBDIR)"
-	cp VERSION "$(INSTALL_LIBDIR)"
+	install -m $(MDATA) \
+	  VERSION \
+	  "$(INSTALL_LIBDIR)"
 	$(MAKE) -C byterun install
-	cp ocaml "$(INSTALL_BINDIR)/ocaml$(EXE)"
-	cp ocamlc "$(INSTALL_BINDIR)/ocamlc.byte$(EXE)"
+	install -m $(MPROG) ocaml "$(INSTALL_BINDIR)/ocaml$(EXE)"
+	install -m $(MPROG) ocamlc "$(INSTALL_BINDIR)/ocamlc.byte$(EXE)"
 	$(MAKE) -C stdlib install
-	cp lex/ocamllex "$(INSTALL_BINDIR)/ocamllex.byte$(EXE)"
-	cp yacc/ocamlyacc$(EXE) "$(INSTALL_BINDIR)/ocamlyacc$(EXE)"
-	cp utils/*.cmi utils/*.cmt utils/*.cmti utils/*.mli \
+	install -m $(MPROG) lex/ocamllex "$(INSTALL_BINDIR)/ocamllex.byte$(EXE)"
+	install -m $(MPROG) yacc/ocamlyacc$(EXE) "$(INSTALL_BINDIR)/ocamlyacc$(EXE)"
+	install -m $(MDATA) \
+	   utils/*.cmi utils/*.cmt utils/*.cmti utils/*.mli \
 	   parsing/*.cmi parsing/*.cmt parsing/*.cmti parsing/*.mli \
 	   typing/*.cmi typing/*.cmt typing/*.cmti typing/*.mli \
 	   bytecomp/*.cmi bytecomp/*.cmt bytecomp/*.cmti bytecomp/*.mli \
 	   driver/*.cmi driver/*.cmt driver/*.cmti driver/*.mli \
 	   toplevel/*.cmi toplevel/*.cmt toplevel/*.cmti toplevel/*.mli \
 	   "$(INSTALL_COMPLIBDIR)"
-	cp compilerlibs/ocamlcommon.cma compilerlibs/ocamlbytecomp.cma \
+	install -m $(MDATA) \
+	   compilerlibs/ocamlcommon.cma compilerlibs/ocamlbytecomp.cma \
 	   compilerlibs/ocamltoplevel.cma $(BYTESTART) $(TOPLEVELSTART) \
 	   "$(INSTALL_COMPLIBDIR)"
-	cp expunge "$(INSTALL_LIBDIR)/expunge$(EXE)"
-	cp toplevel/topdirs.cmi toplevel/topdirs.cmt toplevel/topdirs.cmti \
-           toplevel/topdirs.mli "$(INSTALL_LIBDIR)"
+	install -m $(MPROG) expunge "$(INSTALL_LIBDIR)/expunge$(EXE)"
+	install -m $(MDATA) \
+	   toplevel/topdirs.cmi \
+	   toplevel/topdirs.cmt toplevel/topdirs.cmti \
+           toplevel/topdirs.mli \
+	   "$(INSTALL_LIBDIR)"
 	$(MAKE) -C tools install
 ifeq "$(UNIX_OR_WIN32)" "unix" # Install manual pages only on Unix
 	$(MKDIR) "$(INSTALL_MANDIR)/man$(PROGRAMS_MAN_SECTION)"
@@ -645,7 +655,7 @@ ifeq "$(UNIX_OR_WIN32)" "win32"
 	  $(MAKE) install-flexdll; \
 	fi
 endif
-	cp config/Makefile "$(INSTALL_LIBDIR)/Makefile.config"
+	install -m $(MDATA) config/Makefile "$(INSTALL_LIBDIR)/Makefile.config"
 	if test -f ocamlopt; then $(MAKE) installopt; else \
 	   cd "$(INSTALL_BINDIR)"; \
 	   $(LN) ocamlc.byte$(EXE) ocamlc$(EXE); \
@@ -656,17 +666,26 @@ endif
 .PHONY: installopt
 installopt:
 	$(MAKE) -C asmrun install
-	cp ocamlopt "$(INSTALL_BINDIR)/ocamlopt.byte$(EXE)"
+	install -m $(MPROG) ocamlopt "$(INSTALL_BINDIR)/ocamlopt.byte$(EXE)"
 	$(MAKE) -C stdlib installopt
-	cp middle_end/*.cmi middle_end/*.cmt middle_end/*.cmti \
+	install -m $(MDATA) \
+	    middle_end/*.cmi \
+	    middle_end/*.cmt middle_end/*.cmti \
 	    middle_end/*.mli \
 	    "$(INSTALL_COMPLIBDIR)"
-	cp middle_end/base_types/*.cmi middle_end/base_types/*.cmt \
-	    middle_end/base_types/*.cmti middle_end/base_types/*.mli \
+	install -m $(MDATA) \
+	    middle_end/base_types/*.cmi \
+	    middle_end/base_types/*.cmt middle_end/base_types/*.cmti \
+	    middle_end/base_types/*.mli \
 	    "$(INSTALL_COMPLIBDIR)"
-	cp asmcomp/*.cmi asmcomp/*.cmt asmcomp/*.cmti asmcomp/*.mli \
+	install -m $(MDATA) \
+	    asmcomp/*.cmi \
+	    asmcomp/*.cmt asmcomp/*.cmti \
+	    asmcomp/*.mli \
 	    "$(INSTALL_COMPLIBDIR)"
-	cp compilerlibs/ocamloptcomp.cma $(OPTSTART) "$(INSTALL_COMPLIBDIR)"
+	install -m $(MDATA) \
+	    compilerlibs/ocamloptcomp.cma $(OPTSTART) \
+	    "$(INSTALL_COMPLIBDIR)"
 	if test -n "$(WITH_OCAMLDOC)"; then \
 	  $(MAKE) -C ocamldoc installopt; \
 	fi
@@ -681,30 +700,39 @@ installopt:
 	fi
 	$(MAKE) -C tools installopt
 	if test -f ocamlopt.opt -a -f flexdll/flexlink.opt ; then \
-	  cp -f flexdll/flexlink.opt "$(INSTALL_BINDIR)/flexlink$(EXE)" ; \
+	  install -m $(MPROG) \
+	    flexdll/flexlink.opt "$(INSTALL_BINDIR)/flexlink$(EXE)" ; \
 	fi
 
 .PHONY: installoptopt
 installoptopt:
-	cp ocamlc.opt "$(INSTALL_BINDIR)/ocamlc.opt$(EXE)"
-	cp ocamlopt.opt "$(INSTALL_BINDIR)/ocamlopt.opt$(EXE)"
-	cp lex/ocamllex.opt "$(INSTALL_BINDIR)/ocamllex.opt$(EXE)"
+	install -m $(MPROG) ocamlc.opt "$(INSTALL_BINDIR)/ocamlc.opt$(EXE)"
+	install -m $(MPROG) ocamlopt.opt "$(INSTALL_BINDIR)/ocamlopt.opt$(EXE)"
+	install -m $(MPROG) \
+	  lex/ocamllex.opt "$(INSTALL_BINDIR)/ocamllex.opt$(EXE)"
 	cd "$(INSTALL_BINDIR)"; \
 	   $(LN) ocamlc.opt$(EXE) ocamlc$(EXE); \
 	   $(LN) ocamlopt.opt$(EXE) ocamlopt$(EXE); \
 	   $(LN) ocamllex.opt$(EXE) ocamllex$(EXE)
-	cp utils/*.cmx parsing/*.cmx typing/*.cmx bytecomp/*.cmx \
-	   driver/*.cmx asmcomp/*.cmx "$(INSTALL_COMPLIBDIR)"
-	cp compilerlibs/ocamlcommon.cmxa compilerlibs/ocamlcommon.$(A) \
+	install -m $(MDATA) \
+	   utils/*.cmx parsing/*.cmx typing/*.cmx bytecomp/*.cmx \
+	   driver/*.cmx asmcomp/*.cmx \
+	  "$(INSTALL_COMPLIBDIR)"
+	install -m $(MDATA) \
+           compilerlibs/ocamlcommon.cmxa compilerlibs/ocamlcommon.$(A) \
 	   compilerlibs/ocamlbytecomp.cmxa compilerlibs/ocamlbytecomp.$(A) \
-	   compilerlibs/ocamloptcomp.cmxa compilerlibs/ocamloptcomp.$(A) \
+	   compilerlibs/ocamloptcomp.cmxa  compilerlibs/ocamloptcomp.$(A) \
 	   $(BYTESTART:.cmo=.cmx) $(BYTESTART:.cmo=.$(O)) \
 	   $(OPTSTART:.cmo=.cmx) $(OPTSTART:.cmo=.$(O)) \
 	   "$(INSTALL_COMPLIBDIR)"
 	if test -f ocamlnat$(EXE) ; then \
-	  cp ocamlnat$(EXE) "$(INSTALL_BINDIR)/ocamlnat$(EXE)"; \
-	  cp toplevel/opttopdirs.cmi "$(INSTALL_LIBDIR)"; \
-	  cp compilerlibs/ocamlopttoplevel.cmxa \
+	  install -m $(MPROG) \
+	    ocamlnat$(EXE) "$(INSTALL_BINDIR)/ocamlnat$(EXE)"; \
+	  install -m $(MDATA) \
+	     toplevel/opttopdirs.cmi \
+	     "$(INSTALL_LIBDIR)"; \
+	  install -m $(MDATA) \
+	     compilerlibs/ocamlopttoplevel.cmxa \
 	     compilerlibs/ocamlopttoplevel.$(A) \
 	     $(OPTTOPLEVELSTART:.cmo=.cmx) $(OPTTOPLEVELSTART:.cmo=.$(O)) \
 	     "$(INSTALL_COMPLIBDIR)"; \
@@ -715,9 +743,11 @@ installoptopt:
 # Installation of the *.ml sources of compiler-libs
 .PHONY: install-compiler-sources
 install-compiler-sources:
-	cp utils/*.ml parsing/*.ml typing/*.ml bytecomp/*.ml driver/*.ml \
+	install -m $(MDATA) \
+	   utils/*.ml parsing/*.ml typing/*.ml bytecomp/*.ml driver/*.ml \
 	   toplevel/*.ml middle_end/*.ml middle_end/base_types/*.ml \
-	   asmcomp/*.ml $(INSTALL_COMPLIBDIR)
+	   asmcomp/*.ml \
+	   "$(INSTALL_COMPLIBDIR)"
 
 # Run all tests
 

--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,10 @@ MAXSAVED=boot/Saved/Saved.prev/Saved.prev/Saved.prev/Saved.prev/Saved.prev
 
 COMPLIBDIR=$(LIBDIR)/compiler-libs
 
+INSTALL=install
+INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
+INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
+
 INSTALL_BINDIR=$(DESTDIR)$(BINDIR)
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 INSTALL_COMPLIBDIR=$(DESTDIR)$(COMPLIBDIR)
@@ -587,16 +591,13 @@ install-flexdll:
 	cat stdlib/camlheader flexdll/flexlink.exe > \
 	  "$(INSTALL_BINDIR)/flexlink.exe"
 ifneq "$(filter-out mingw,$(TOOLCHAIN))" ""
-	install -m $(MDATA) flexdll/default$(filter-out _i386,_$(ARCH)).manifest \
+	$(INSTALL_DATA) flexdll/default$(filter-out _i386,_$(ARCH)).manifest \
     "$(INSTALL_BINDIR)/"
 endif
 	if test -n "$(wildcard flexdll/flexdll_*.$(O))" ; then \
 	  $(MKDIR) "$(INSTALL_FLEXDLLDIR)" ; \
-	  install -m $(MDATA) flexdll/flexdll_*.$(O) "$(INSTALL_FLEXDLLDIR)" ; \
+	  $(INSTALL_DATA) flexdll/flexdll_*.$(O) "$(INSTALL_FLEXDLLDIR)" ; \
 	fi
-
-MDATA=u+rw,g+rw,o+r
-MPROG=u+rwx,g+rwx,o+rx
 
 # Installation
 .PHONY: install
@@ -605,16 +606,16 @@ install:
 	$(MKDIR) "$(INSTALL_LIBDIR)"
 	$(MKDIR) "$(INSTALL_STUBLIBDIR)"
 	$(MKDIR) "$(INSTALL_COMPLIBDIR)"
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	  VERSION \
 	  "$(INSTALL_LIBDIR)"
 	$(MAKE) -C byterun install
-	install -m $(MPROG) ocaml "$(INSTALL_BINDIR)/ocaml$(EXE)"
-	install -m $(MPROG) ocamlc "$(INSTALL_BINDIR)/ocamlc.byte$(EXE)"
+	$(INSTALL_PROG) ocaml "$(INSTALL_BINDIR)/ocaml$(EXE)"
+	$(INSTALL_PROG) ocamlc "$(INSTALL_BINDIR)/ocamlc.byte$(EXE)"
 	$(MAKE) -C stdlib install
-	install -m $(MPROG) lex/ocamllex "$(INSTALL_BINDIR)/ocamllex.byte$(EXE)"
-	install -m $(MPROG) yacc/ocamlyacc$(EXE) "$(INSTALL_BINDIR)/ocamlyacc$(EXE)"
-	install -m $(MDATA) \
+	$(INSTALL_PROG) lex/ocamllex "$(INSTALL_BINDIR)/ocamllex.byte$(EXE)"
+	$(INSTALL_PROG) yacc/ocamlyacc$(EXE) "$(INSTALL_BINDIR)/ocamlyacc$(EXE)"
+	$(INSTALL_DATA) \
 	   utils/*.cmi utils/*.cmt utils/*.cmti utils/*.mli \
 	   parsing/*.cmi parsing/*.cmt parsing/*.cmti parsing/*.mli \
 	   typing/*.cmi typing/*.cmt typing/*.cmti typing/*.mli \
@@ -622,12 +623,12 @@ install:
 	   driver/*.cmi driver/*.cmt driver/*.cmti driver/*.mli \
 	   toplevel/*.cmi toplevel/*.cmt toplevel/*.cmti toplevel/*.mli \
 	   "$(INSTALL_COMPLIBDIR)"
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	   compilerlibs/ocamlcommon.cma compilerlibs/ocamlbytecomp.cma \
 	   compilerlibs/ocamltoplevel.cma $(BYTESTART) $(TOPLEVELSTART) \
 	   "$(INSTALL_COMPLIBDIR)"
-	install -m $(MPROG) expunge "$(INSTALL_LIBDIR)/expunge$(EXE)"
-	install -m $(MDATA) \
+	$(INSTALL_PROG) expunge "$(INSTALL_LIBDIR)/expunge$(EXE)"
+	$(INSTALL_DATA) \
 	   toplevel/topdirs.cmi \
 	   toplevel/topdirs.cmt toplevel/topdirs.cmti \
            toplevel/topdirs.mli \
@@ -655,7 +656,7 @@ ifeq "$(UNIX_OR_WIN32)" "win32"
 	  $(MAKE) install-flexdll; \
 	fi
 endif
-	install -m $(MDATA) config/Makefile "$(INSTALL_LIBDIR)/Makefile.config"
+	$(INSTALL_DATA) config/Makefile "$(INSTALL_LIBDIR)/Makefile.config"
 	if test -f ocamlopt; then $(MAKE) installopt; else \
 	   cd "$(INSTALL_BINDIR)"; \
 	   $(LN) ocamlc.byte$(EXE) ocamlc$(EXE); \
@@ -666,24 +667,24 @@ endif
 .PHONY: installopt
 installopt:
 	$(MAKE) -C asmrun install
-	install -m $(MPROG) ocamlopt "$(INSTALL_BINDIR)/ocamlopt.byte$(EXE)"
+	$(INSTALL_PROG) ocamlopt "$(INSTALL_BINDIR)/ocamlopt.byte$(EXE)"
 	$(MAKE) -C stdlib installopt
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	    middle_end/*.cmi \
 	    middle_end/*.cmt middle_end/*.cmti \
 	    middle_end/*.mli \
 	    "$(INSTALL_COMPLIBDIR)"
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	    middle_end/base_types/*.cmi \
 	    middle_end/base_types/*.cmt middle_end/base_types/*.cmti \
 	    middle_end/base_types/*.mli \
 	    "$(INSTALL_COMPLIBDIR)"
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	    asmcomp/*.cmi \
 	    asmcomp/*.cmt asmcomp/*.cmti \
 	    asmcomp/*.mli \
 	    "$(INSTALL_COMPLIBDIR)"
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	    compilerlibs/ocamloptcomp.cma $(OPTSTART) \
 	    "$(INSTALL_COMPLIBDIR)"
 	if test -n "$(WITH_OCAMLDOC)"; then \
@@ -700,25 +701,25 @@ installopt:
 	fi
 	$(MAKE) -C tools installopt
 	if test -f ocamlopt.opt -a -f flexdll/flexlink.opt ; then \
-	  install -m $(MPROG) \
+	  $(INSTALL_PROG) \
 	    flexdll/flexlink.opt "$(INSTALL_BINDIR)/flexlink$(EXE)" ; \
 	fi
 
 .PHONY: installoptopt
 installoptopt:
-	install -m $(MPROG) ocamlc.opt "$(INSTALL_BINDIR)/ocamlc.opt$(EXE)"
-	install -m $(MPROG) ocamlopt.opt "$(INSTALL_BINDIR)/ocamlopt.opt$(EXE)"
-	install -m $(MPROG) \
+	$(INSTALL_PROG) ocamlc.opt "$(INSTALL_BINDIR)/ocamlc.opt$(EXE)"
+	$(INSTALL_PROG) ocamlopt.opt "$(INSTALL_BINDIR)/ocamlopt.opt$(EXE)"
+	$(INSTALL_PROG) \
 	  lex/ocamllex.opt "$(INSTALL_BINDIR)/ocamllex.opt$(EXE)"
 	cd "$(INSTALL_BINDIR)"; \
 	   $(LN) ocamlc.opt$(EXE) ocamlc$(EXE); \
 	   $(LN) ocamlopt.opt$(EXE) ocamlopt$(EXE); \
 	   $(LN) ocamllex.opt$(EXE) ocamllex$(EXE)
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	   utils/*.cmx parsing/*.cmx typing/*.cmx bytecomp/*.cmx \
 	   driver/*.cmx asmcomp/*.cmx \
 	  "$(INSTALL_COMPLIBDIR)"
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
            compilerlibs/ocamlcommon.cmxa compilerlibs/ocamlcommon.$(A) \
 	   compilerlibs/ocamlbytecomp.cmxa compilerlibs/ocamlbytecomp.$(A) \
 	   compilerlibs/ocamloptcomp.cmxa  compilerlibs/ocamloptcomp.$(A) \
@@ -726,12 +727,12 @@ installoptopt:
 	   $(OPTSTART:.cmo=.cmx) $(OPTSTART:.cmo=.$(O)) \
 	   "$(INSTALL_COMPLIBDIR)"
 	if test -f ocamlnat$(EXE) ; then \
-	  install -m $(MPROG) \
+	  $(INSTALL_PROG) \
 	    ocamlnat$(EXE) "$(INSTALL_BINDIR)/ocamlnat$(EXE)"; \
-	  install -m $(MDATA) \
+	  $(INSTALL_DATA) \
 	     toplevel/opttopdirs.cmi \
 	     "$(INSTALL_LIBDIR)"; \
-	  install -m $(MDATA) \
+	  $(INSTALL_DATA) \
 	     compilerlibs/ocamlopttoplevel.cmxa \
 	     compilerlibs/ocamlopttoplevel.$(A) \
 	     $(OPTTOPLEVELSTART:.cmo=.cmx) $(OPTTOPLEVELSTART:.cmo=.$(O)) \
@@ -743,7 +744,7 @@ installoptopt:
 # Installation of the *.ml sources of compiler-libs
 .PHONY: install-compiler-sources
 install-compiler-sources:
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	   utils/*.ml parsing/*.ml typing/*.ml bytecomp/*.ml driver/*.ml \
 	   toplevel/*.ml middle_end/*.ml middle_end/base_types/*.ml \
 	   asmcomp/*.ml \

--- a/Makefile.common
+++ b/Makefile.common
@@ -17,8 +17,8 @@
 # We assume that config/Makefile has already been included
 
 INSTALL ?= install
-INSTALL_DATA ?= $(INSTALL) -m u+rw,g+rw,o+r
-INSTALL_PROG ?= $(INSTALL) -m u+rwx,g+rwx,o+rx
+INSTALL_DATA ?= $(INSTALL) -m u=rw,g=rw,o=r
+INSTALL_PROG ?= $(INSTALL) -m u=rwx,g=rwx,o=rx
 
 # note: these are defined by lazy expansions
 # as some parts of the makefiles change BINDIR, etc.

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,0 +1,30 @@
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*            Gabriel Scherer, projet Parsifal, INRIA Saclay              *
+#*                                                                        *
+#*   Copyright 2018 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+# This makefile contains common definitions shared by other Makefiles
+# We assume that config/Makefile has already been included
+
+INSTALL ?= install
+INSTALL_DATA ?= $(INSTALL) -m u+rw,g+rw,o+r
+INSTALL_PROG ?= $(INSTALL) -m u+rwx,g+rwx,o+rx
+
+# note: these are defined by lazy expansions
+# as some parts of the makefiles change BINDIR, etc.
+# and expect INSTALL_BINDIR, etc. to stay in synch
+# (see `shellquote` in tools/Makefile)
+INSTALL_BINDIR = $(DESTDIR)$(BINDIR)
+INSTALL_LIBDIR = $(DESTDIR)$(LIBDIR)
+INSTALL_STUBLIBDIR = $(DESTDIR)$(STUBLIBDIR)
+INSTALL_MANDIR = $(DESTDIR)$(MANDIR)

--- a/asmrun/Makefile
+++ b/asmrun/Makefile
@@ -90,28 +90,30 @@ IOBJS=$(COBJS:.$(O)=.i.$(O)) $(ASMOBJS)
 POBJS=$(COBJS:.$(O)=.p.$(O)) $(ASMOBJS:.$(O)=.p.$(O))
 PICOBJS=$(COBJS:.$(O)=.pic.$(O)) $(ASMOBJS:.$(O)=.pic.$(O))
 
-TARGETS = libasmrun.$(A)
+TARGETS_A = libasmrun.$(A)
+TARGETS_SO=
 
 ifeq "$(RUNTIMED)" "true"
-TARGETS += libasmrund.$(A)
+TARGETS_A += libasmrund.$(A)
 endif
 
 ifeq "$(RUNTIMEI)" "true"
-TARGETS += libasmruni.$(A)
+TARGETS_A += libasmruni.$(A)
 endif
 
 ifeq "$(PROFILING)" "true"
-TARGETS += libasmrunp.$(A)
+TARGETS_A += libasmrunp.$(A)
 endif
 
 ifeq "$(UNIX_OR_WIN32)" "unix"
 ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
-TARGETS += libasmrun_pic.$(A) libasmrun_shared.$(SO)
+TARGETS_A += libasmrun_pic.$(A)
+TARGETS_SO += libasmrun_shared.$(SO)
 endif
 endif
 
 .PHONY: all
-all: $(TARGETS)
+all: $(TARGETS_A) $(TARGETS_SO)
 
 libasmrun.$(A): $(OBJS)
 	$(call MKLIB,$@, $^)
@@ -131,9 +133,15 @@ libasmrun_pic.$(A): $(PICOBJS)
 libasmrun_shared.$(SO): $(PICOBJS)
 	$(MKDLL) -o $@ $^ $(NATIVECCLIBS)
 
+MDATA=u+rw,g+rw,o+r
+MPROG=u+rwx,g+rwx,o+rx
+
 .PHONY: install
 install:
-	cp $(TARGETS) "$(INSTALL_LIBDIR)"
+	install -m $(MDATA) $(TARGETS_A) "$(INSTALL_LIBDIR)"
+	if test -n "$(TARGETS_SO)"; then \
+	  install -m $(MPROG) $(TARGETS_SO) "$(INSTALL_LIBDIR)"; \
+	fi
 
 $(LINKEDFILES): %.c: ../byterun/%.c
 	$(LN) $< $@

--- a/asmrun/Makefile
+++ b/asmrun/Makefile
@@ -27,6 +27,10 @@ LINKEDFILES=misc.c freelist.c major_gc.c minor_gc.c memory.c alloc.c array.c \
 # compiled on the platform where make depend is run
 sources := $(LINKEDFILES)
 
+INSTALL=install
+INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
+INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
+
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
 ifeq "$(UNIX_OR_WIN32)" "win32"
@@ -133,14 +137,11 @@ libasmrun_pic.$(A): $(PICOBJS)
 libasmrun_shared.$(SO): $(PICOBJS)
 	$(MKDLL) -o $@ $^ $(NATIVECCLIBS)
 
-MDATA=u+rw,g+rw,o+r
-MPROG=u+rwx,g+rwx,o+rx
-
 .PHONY: install
 install:
-	install -m $(MDATA) $(TARGETS_A) "$(INSTALL_LIBDIR)"
+	$(INSTALL_DATA) $(TARGETS_A) "$(INSTALL_LIBDIR)"
 	if test -n "$(TARGETS_SO)"; then \
-	  install -m $(MPROG) $(TARGETS_SO) "$(INSTALL_LIBDIR)"; \
+	  $(INSTALL_PROG) $(TARGETS_SO) "$(INSTALL_LIBDIR)"; \
 	fi
 
 $(LINKEDFILES): %.c: ../byterun/%.c

--- a/asmrun/Makefile
+++ b/asmrun/Makefile
@@ -14,6 +14,7 @@
 #**************************************************************************
 
 include ../config/Makefile
+include ../Makefile.common
 
 LINKEDFILES=misc.c freelist.c major_gc.c minor_gc.c memory.c alloc.c array.c \
   compare.c ints.c floats.c str.c io.c extern.c intern.c hash.c sys.c \
@@ -26,12 +27,6 @@ LINKEDFILES=misc.c freelist.c major_gc.c minor_gc.c memory.c alloc.c array.c \
 # should be computed. It includes even the files that won't actually be
 # compiled on the platform where make depend is run
 sources := $(LINKEDFILES)
-
-INSTALL=install
-INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
-INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
-
-INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
 ifeq "$(UNIX_OR_WIN32)" "win32"
 LN = cp

--- a/byterun/Makefile
+++ b/byterun/Makefile
@@ -25,6 +25,7 @@ INSTALL_INCDIR=$(INSTALL_LIBDIR)/caml
 
 PROGRAMS = ocamlrun$(EXE)
 LIBRARIES = ld.conf libcamlrun.$(A)
+DYNLIBRARIES=
 
 ifeq "$(RUNTIMED)" "true"
 PROGRAMS += ocamlrund$(EXE)
@@ -38,7 +39,8 @@ endif
 
 ifeq "$(UNIX_OR_WIN32)" "unix"
 ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
-LIBRARIES += libcamlrun_pic.$(A) libcamlrun_shared.$(SO)
+LIBRARIES += libcamlrun_pic.$(A)
+DYNLIBRARIES += libcamlrun_shared.$(SO)
 endif
 endif
 
@@ -106,18 +108,24 @@ IOBJS=$(OBJS:.$(O)=.i.$(O))
 PICOBJS=$(OBJS:.$(O)=.pic.$(O))
 
 .PHONY: all
-all: $(LIBRARIES) $(PROGRAMS)
+all: $(LIBRARIES) $(DYNLIBRARIES) $(PROGRAMS)
 
 ld.conf: ../config/Makefile
 	echo "$(STUBLIBDIR)" > $@
 	echo "$(LIBDIR)" >> $@
 
+MDATA=u+rw,g+rw,o+r
+MPROG=u+rwx,g+rwx,o+rx
+
 .PHONY: install
 install:
-	cp $(PROGRAMS) "$(INSTALL_BINDIR)"
-	cp $(LIBRARIES) "$(INSTALL_LIBDIR)"
+	install -m $(MPROG) $(PROGRAMS) "$(INSTALL_BINDIR)"
+	install -m $(MDATA) $(LIBRARIES) "$(INSTALL_LIBDIR)"
+	if test -n "$(DYNLIBRARIES)"; then \
+	  install -m $(MPROG) $(DYNLIBRARIES) "$(INSTALL_LIBDIR)"; \
+	fi
 	mkdir -p "$(INSTALL_INCDIR)"
-	cp caml/*.h "$(INSTALL_INCDIR)"
+	install -m $(MDATA) caml/*.h "$(INSTALL_INCDIR)"
 
 # If primitives contain duplicated lines (e.g. because the code is defined
 # like
@@ -173,7 +181,7 @@ caml/version.h : ../VERSION ../tools/make-version-header.sh
 
 .PHONY: clean
 clean:
-	rm -f $(LIBRARIES) $(PROGRAMS) *.$(O) *.$(A) *.$(SO)
+	rm -f $(LIBRARIES) $(DYNLIBRARIES) $(PROGRAMS) *.$(O) *.$(A) *.$(SO)
 	rm -f primitives prims.c caml/opnames.h caml/jumptbl.h
 	rm -f caml/version.h
 

--- a/byterun/Makefile
+++ b/byterun/Makefile
@@ -14,14 +14,7 @@
 #**************************************************************************
 
 include ../config/Makefile
-
-INSTALL=install
-INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
-INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
-
-INSTALL_BINDIR=$(DESTDIR)$(BINDIR)
-INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
-INSTALL_INCDIR=$(INSTALL_LIBDIR)/caml
+include ../Makefile.common
 
 # The PROGRAMS (resp. LIBRARIES) variable list the files to build and
 # install as programs in $(INSTALL_BINDIR) (resp. libraries in
@@ -117,6 +110,8 @@ all: $(LIBRARIES) $(DYNLIBRARIES) $(PROGRAMS)
 ld.conf: ../config/Makefile
 	echo "$(STUBLIBDIR)" > $@
 	echo "$(LIBDIR)" >> $@
+
+INSTALL_INCDIR=$(INSTALL_LIBDIR)/caml
 
 .PHONY: install
 install:

--- a/byterun/Makefile
+++ b/byterun/Makefile
@@ -15,6 +15,10 @@
 
 include ../config/Makefile
 
+INSTALL=install
+INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
+INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
+
 INSTALL_BINDIR=$(DESTDIR)$(BINDIR)
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 INSTALL_INCDIR=$(INSTALL_LIBDIR)/caml
@@ -114,18 +118,15 @@ ld.conf: ../config/Makefile
 	echo "$(STUBLIBDIR)" > $@
 	echo "$(LIBDIR)" >> $@
 
-MDATA=u+rw,g+rw,o+r
-MPROG=u+rwx,g+rwx,o+rx
-
 .PHONY: install
 install:
-	install -m $(MPROG) $(PROGRAMS) "$(INSTALL_BINDIR)"
-	install -m $(MDATA) $(LIBRARIES) "$(INSTALL_LIBDIR)"
+	$(INSTALL_PROG) $(PROGRAMS) "$(INSTALL_BINDIR)"
+	$(INSTALL_DATA) $(LIBRARIES) "$(INSTALL_LIBDIR)"
 	if test -n "$(DYNLIBRARIES)"; then \
-	  install -m $(MPROG) $(DYNLIBRARIES) "$(INSTALL_LIBDIR)"; \
+	  $(INSTALL_PROG) $(DYNLIBRARIES) "$(INSTALL_LIBDIR)"; \
 	fi
 	mkdir -p "$(INSTALL_INCDIR)"
-	install -m $(MDATA) caml/*.h "$(INSTALL_INCDIR)"
+	$(INSTALL_DATA) caml/*.h "$(INSTALL_INCDIR)"
 
 # If primitives contain duplicated lines (e.g. because the code is defined
 # like

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -96,8 +96,11 @@ all: ocamldebug$(EXE)
 ocamldebug$(EXE): $(OBJS) $(OTHEROBJS)
 	$(CAMLC) $(LINKFLAGS) -o ocamldebug$(EXE) -linkall $(OTHEROBJS) $(OBJS)
 
+MDATA=u+rw,g+rw,o+r
+MPROG=u+rwx,g+rwx,o+rx
+
 install:
-	cp ocamldebug$(EXE) "$(INSTALL_BINDIR)/ocamldebug$(EXE)"
+	install -m $(MPROG) ocamldebug$(EXE) "$(INSTALL_BINDIR)/ocamldebug$(EXE)"
 
 clean::
 	rm -f ocamldebug$(EXE)

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -14,6 +14,8 @@
 #**************************************************************************
 
 include ../config/Makefile
+include ../Makefile.common
+
 UNIXDIR=../otherlibs/$(UNIXLIB)
 CAMLRUN ?= ../boot/ocamlrun
 CAMLYACC ?= ../boot/ocamlyacc
@@ -26,12 +28,6 @@ YACCFLAGS=
 CAMLLEX=$(CAMLRUN) ../boot/ocamllex
 CAMLDEP=$(CAMLRUN) ../tools/ocamldep
 DEPFLAGS=$(INCLUDES)
-
-INSTALL=install
-INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
-INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
-
-INSTALL_BINDIR=$(DESTDIR)$(BINDIR)
 
 INCLUDES=\
   -I ../utils -I ../parsing -I ../typing -I ../bytecomp -I ../toplevel \
@@ -101,7 +97,7 @@ ocamldebug$(EXE): $(OBJS) $(OTHEROBJS)
 	$(CAMLC) $(LINKFLAGS) -o ocamldebug$(EXE) -linkall $(OTHEROBJS) $(OBJS)
 
 install:
-	install -m $(MPROG) ocamldebug$(EXE) "$(INSTALL_BINDIR)/ocamldebug$(EXE)"
+	$(INSTALL_PROG) ocamldebug$(EXE) "$(INSTALL_BINDIR)/ocamldebug$(EXE)"
 
 clean::
 	rm -f ocamldebug$(EXE)

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -27,6 +27,10 @@ CAMLLEX=$(CAMLRUN) ../boot/ocamllex
 CAMLDEP=$(CAMLRUN) ../tools/ocamldep
 DEPFLAGS=$(INCLUDES)
 
+INSTALL=install
+INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
+INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
+
 INSTALL_BINDIR=$(DESTDIR)$(BINDIR)
 
 INCLUDES=\
@@ -95,9 +99,6 @@ all: ocamldebug$(EXE)
 
 ocamldebug$(EXE): $(OBJS) $(OTHEROBJS)
 	$(CAMLC) $(LINKFLAGS) -o ocamldebug$(EXE) -linkall $(OTHEROBJS) $(OBJS)
-
-MDATA=u+rw,g+rw,o+r
-MPROG=u+rwx,g+rwx,o+rx
 
 install:
 	install -m $(MPROG) ocamldebug$(EXE) "$(INSTALL_BINDIR)/ocamldebug$(EXE)"

--- a/emacs/Makefile
+++ b/emacs/Makefile
@@ -13,6 +13,7 @@
 #**************************************************************************
 
 include ../config/Makefile
+include ../Makefile.common
 
 # Files to install
 FILES=	caml-font.el caml-hilit.el caml.el camldebug.el \
@@ -39,10 +40,6 @@ COMPILECMD=(progn \
 	      (byte-compile-file "caml-types.el") \
 	      (byte-compile-file "caml-font.el") \
 	      (byte-compile-file "camldebug.el"))
-
-INSTALL=install
-INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
-INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
 
 install:
 	@if test "$(EMACSDIR)" = ""; then \

--- a/emacs/Makefile
+++ b/emacs/Makefile
@@ -40,8 +40,9 @@ COMPILECMD=(progn \
 	      (byte-compile-file "caml-font.el") \
 	      (byte-compile-file "camldebug.el"))
 
-MDATA=u+rw,g+rw,o+r
-MPROG=u+rwx,g+rwx,o+rx
+INSTALL=install
+INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
+INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
 
 install:
 	@if test "$(EMACSDIR)" = ""; then \
@@ -67,7 +68,7 @@ install-el:
 simple-install:
 	@echo "Installing in $(EMACSDIR)..."
 	if test -d $(EMACSDIR); then : ; else mkdir -p $(EMACSDIR); fi
-	install -m $(MDATA) $(FILES) $(EMACSDIR)
+	$(INSTALL_DATA) $(FILES) $(EMACSDIR)
 	if [ -z "$(NOCOMPILE)" ]; then \
 	  cd $(EMACSDIR); $(EMACS) --batch --eval '$(COMPILECMD)'; \
 	fi
@@ -77,7 +78,7 @@ ocamltags:	ocamltags.in
 	chmod a+x ocamltags
 
 install-ocamltags: ocamltags
-	install -m $(MDATA) ocamltags $(SCRIPTDIR)/ocamltags
+	$(INSTALL_DATA) ocamltags $(SCRIPTDIR)/ocamltags
 
 # This is for testing purposes
 compile-only:

--- a/emacs/Makefile
+++ b/emacs/Makefile
@@ -40,6 +40,9 @@ COMPILECMD=(progn \
 	      (byte-compile-file "caml-font.el") \
 	      (byte-compile-file "camldebug.el"))
 
+MDATA=u+rw,g+rw,o+r
+MPROG=u+rwx,g+rwx,o+rx
+
 install:
 	@if test "$(EMACSDIR)" = ""; then \
 	  $(EMACS) --batch --eval 't; see PR#5403'; \
@@ -64,7 +67,7 @@ install-el:
 simple-install:
 	@echo "Installing in $(EMACSDIR)..."
 	if test -d $(EMACSDIR); then : ; else mkdir -p $(EMACSDIR); fi
-	cp $(FILES) $(EMACSDIR)
+	install -m $(MDATA) $(FILES) $(EMACSDIR)
 	if [ -z "$(NOCOMPILE)" ]; then \
 	  cd $(EMACSDIR); $(EMACS) --batch --eval '$(COMPILECMD)'; \
 	fi
@@ -74,7 +77,7 @@ ocamltags:	ocamltags.in
 	chmod a+x ocamltags
 
 install-ocamltags: ocamltags
-	cp ocamltags $(SCRIPTDIR)/ocamltags
+	install -m $(MDATA) ocamltags $(SCRIPTDIR)/ocamltags
 
 # This is for testing purposes
 compile-only:

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -289,15 +289,24 @@ odoc_see_lexer.ml: odoc_see_lexer.mll
 # TODO: it may be good to split the following rule in several ones, e.g.
 # install-programs, install-doc, install-libs
 
+MDATA=u+rw,g+rw,o+r
+MPROG=u+rwx,g+rwx,o+rx
+
 .PHONY: install
 install:
 	$(MKDIR) "$(INSTALL_BINDIR)"
 	$(MKDIR) "$(INSTALL_LIBDIR)"
 	$(MKDIR) "$(INSTALL_MANODIR)"
-	$(CP) $(OCAMLDOC) "$(INSTALL_BINDIR)/$(OCAMLDOC)$(EXE)"
-	$(CP) ocamldoc.hva *.cmi $(OCAMLDOC_LIBCMA) "$(INSTALL_LIBDIR)"
-	$(CP) $(INSTALL_MLIS) $(INSTALL_CMIS) $(INSTALL_CMTS) "$(INSTALL_LIBDIR)"
-	if test -d stdlib_man; then $(CP) stdlib_man/* "$(INSTALL_MANODIR)"; else : ; fi
+	install -m $(MPROG) $(OCAMLDOC) "$(INSTALL_BINDIR)/$(OCAMLDOC)$(EXE)"
+	install -m $(MDATA) \
+	  ocamldoc.hva *.cmi $(OCAMLDOC_LIBCMA) \
+	  "$(INSTALL_LIBDIR)"
+	install -m $(MDATA) \
+	  $(INSTALL_MLIS) $(INSTALL_CMIS) $(INSTALL_CMTS) \
+	  "$(INSTALL_LIBDIR)"
+	if test -d stdlib_man; then \
+	  install -m $(MDATA) stdlib_man/* "$(INSTALL_MANODIR)"; \
+	else : ; fi
 
 # Note: at the moment, $(INSTALL_MANODIR) is created even if the doc has
 # not been built. This is not clean and should be changed.
@@ -310,9 +319,13 @@ installopt:
 installopt_really:
 	$(MKDIR) "$(INSTALL_BINDIR)"
 	$(MKDIR) "$(INSTALL_LIBDIR)"
-	$(CP) $(OCAMLDOC_OPT) "$(INSTALL_BINDIR)/$(OCAMLDOC_OPT)$(EXE)"
-	$(CP) $(INSTALL_MLIS) $(INSTALL_CMIS) $(INSTALL_CMTS) "$(INSTALL_LIBDIR)"
-	$(CP) ocamldoc.hva *.cmx $(OCAMLDOC_LIBA) $(OCAMLDOC_LIBCMXA) \
+	install -m $(MPROG) \
+	   $(OCAMLDOC_OPT) "$(INSTALL_BINDIR)/$(OCAMLDOC_OPT)$(EXE)"
+	install -m $(MDATA) \
+	  $(INSTALL_MLIS) $(INSTALL_CMIS) $(INSTALL_CMTS) \
+	  "$(INSTALL_LIBDIR)"
+	install -m $(MDATA) \
+	  ocamldoc.hva *.cmx $(OCAMLDOC_LIBA) $(OCAMLDOC_LIBCMXA) \
 	  "$(INSTALL_LIBDIR)"
 
 # TODO: also split into several rules

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -16,6 +16,8 @@
 ROOTDIR = ..
 
 include $(ROOTDIR)/config/Makefile
+include $(ROOTDIR)/Makefile.common
+
 OCAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 OCAMLYACC ?= $(ROOTDIR)/boot/ocamlyacc
 
@@ -71,14 +73,6 @@ OCAMLDOC_LIBCMA=odoc_info.cma
 OCAMLDOC_LIBCMI=odoc_info.cmi
 OCAMLDOC_LIBCMXA=odoc_info.cmxa
 OCAMLDOC_LIBA=odoc_info.$(A)
-
-INSTALL=install
-INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
-INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
-
-INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)/ocamldoc
-INSTALL_BINDIR=$(DESTDIR)$(BINDIR)
-INSTALL_MANODIR=$(DESTDIR)$(MANDIR)/man3
 
 OCAMLDOC_LIBMLIS=odoc_info.mli
 OCAMLDOC_LIBCMIS=$(OCAMLDOC_LIBMLIS:.mli=.cmi)
@@ -289,6 +283,8 @@ odoc_see_lexer.ml: odoc_see_lexer.mll
 
 # TODO: it may be good to split the following rule in several ones, e.g.
 # install-programs, install-doc, install-libs
+
+INSTALL_MANODIR=$(INSTALL_MANDIR)/man3
 
 .PHONY: install
 install:

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -72,11 +72,12 @@ OCAMLDOC_LIBCMI=odoc_info.cmi
 OCAMLDOC_LIBCMXA=odoc_info.cmxa
 OCAMLDOC_LIBA=odoc_info.$(A)
 
+INSTALL=install
+INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
+INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
+
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)/ocamldoc
-
 INSTALL_BINDIR=$(DESTDIR)$(BINDIR)
-
-#MANO: man ocamldoc
 INSTALL_MANODIR=$(DESTDIR)$(MANDIR)/man3
 
 OCAMLDOC_LIBMLIS=odoc_info.mli
@@ -289,23 +290,20 @@ odoc_see_lexer.ml: odoc_see_lexer.mll
 # TODO: it may be good to split the following rule in several ones, e.g.
 # install-programs, install-doc, install-libs
 
-MDATA=u+rw,g+rw,o+r
-MPROG=u+rwx,g+rwx,o+rx
-
 .PHONY: install
 install:
 	$(MKDIR) "$(INSTALL_BINDIR)"
 	$(MKDIR) "$(INSTALL_LIBDIR)"
 	$(MKDIR) "$(INSTALL_MANODIR)"
-	install -m $(MPROG) $(OCAMLDOC) "$(INSTALL_BINDIR)/$(OCAMLDOC)$(EXE)"
-	install -m $(MDATA) \
+	$(INSTALL_PROG) $(OCAMLDOC) "$(INSTALL_BINDIR)/$(OCAMLDOC)$(EXE)"
+	$(INSTALL_DATA) \
 	  ocamldoc.hva *.cmi $(OCAMLDOC_LIBCMA) \
 	  "$(INSTALL_LIBDIR)"
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	  $(OCAMLDOC_LIBMLIS) $(OCAMLDOC_LIBCMIS) $(OCAMLDOC_LIBCMTS) \
 	  "$(INSTALL_LIBDIR)"
 	if test -d stdlib_man; then \
-	  install -m $(MDATA) stdlib_man/* "$(INSTALL_MANODIR)"; \
+	  $(INSTALL_DATA) stdlib_man/* "$(INSTALL_MANODIR)"; \
 	else : ; fi
 
 # Note: at the moment, $(INSTALL_MANODIR) is created even if the doc has
@@ -319,12 +317,12 @@ installopt:
 installopt_really:
 	$(MKDIR) "$(INSTALL_BINDIR)"
 	$(MKDIR) "$(INSTALL_LIBDIR)"
-	install -m $(MPROG) \
+	$(INSTALL_PROG) \
 	   $(OCAMLDOC_OPT) "$(INSTALL_BINDIR)/$(OCAMLDOC_OPT)$(EXE)"
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	  $(OCAMLDOC_LIBMLIS) $(OCAMLDOC_LIBCMIS) $(OCAMLDOC_LIBCMTS) \
 	  "$(INSTALL_LIBDIR)"
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	  ocamldoc.hva *.cmx $(OCAMLDOC_LIBA) $(OCAMLDOC_LIBCMXA) \
 	  "$(INSTALL_LIBDIR)"
 

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -79,9 +79,9 @@ INSTALL_BINDIR=$(DESTDIR)$(BINDIR)
 #MANO: man ocamldoc
 INSTALL_MANODIR=$(DESTDIR)$(MANDIR)/man3
 
-INSTALL_MLIS=odoc_info.mli
-INSTALL_CMIS=$(INSTALL_MLIS:.mli=.cmi)
-INSTALL_CMTS=$(INSTALL_MLIS:.mli=.cmt) $(INSTALL_MLIS:.mli=.cmti)
+OCAMLDOC_LIBMLIS=odoc_info.mli
+OCAMLDOC_LIBCMIS=$(OCAMLDOC_LIBMLIS:.mli=.cmi)
+OCAMLDOC_LIBCMTS=$(OCAMLDOC_LIBMLIS:.mli=.cmt) $(OCAMLDOC_LIBMLIS:.mli=.cmti)
 
 ODOC_TEST=odoc_test.cmo
 GENERATORS_CMOS= \
@@ -302,7 +302,7 @@ install:
 	  ocamldoc.hva *.cmi $(OCAMLDOC_LIBCMA) \
 	  "$(INSTALL_LIBDIR)"
 	install -m $(MDATA) \
-	  $(INSTALL_MLIS) $(INSTALL_CMIS) $(INSTALL_CMTS) \
+	  $(OCAMLDOC_LIBMLIS) $(OCAMLDOC_LIBCMIS) $(OCAMLDOC_LIBCMTS) \
 	  "$(INSTALL_LIBDIR)"
 	if test -d stdlib_man; then \
 	  install -m $(MDATA) stdlib_man/* "$(INSTALL_MANODIR)"; \
@@ -322,7 +322,7 @@ installopt_really:
 	install -m $(MPROG) \
 	   $(OCAMLDOC_OPT) "$(INSTALL_BINDIR)/$(OCAMLDOC_OPT)$(EXE)"
 	install -m $(MDATA) \
-	  $(INSTALL_MLIS) $(INSTALL_CMIS) $(INSTALL_CMTS) \
+	  $(OCAMLDOC_LIBMLIS) $(OCAMLDOC_LIBCMIS) $(OCAMLDOC_LIBCMTS) \
 	  "$(INSTALL_LIBDIR)"
 	install -m $(MDATA) \
 	  ocamldoc.hva *.cmx $(OCAMLDOC_LIBA) $(OCAMLDOC_LIBCMXA) \

--- a/otherlibs/Makefile
+++ b/otherlibs/Makefile
@@ -17,6 +17,8 @@
 
 ROOTDIR=../..
 include $(ROOTDIR)/config/Makefile
+include $(ROOTDIR)/Makefile.common
+
 CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 CAMLYACC ?= $(ROOTDIR)/boot/ocamlyacc
 
@@ -75,13 +77,6 @@ $(LIBNAME).cmxs: $(LIBNAME).cmxa lib$(CLIBNAME).$(A)
 
 lib$(CLIBNAME).$(A): $(COBJS)
 	$(MKLIB) -oc $(CLIBNAME) $(COBJS) $(LDOPTS)
-
-INSTALL=install
-INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
-INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
-
-INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
-INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 
 install::
 	if test -f dll$(CLIBNAME)$(EXT_DLL); then \

--- a/otherlibs/Makefile
+++ b/otherlibs/Makefile
@@ -79,21 +79,33 @@ lib$(CLIBNAME).$(A): $(COBJS)
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 
+MDATA=u+rw,g+rw,o+r
+MPROG=u+rwx,g+rwx,o+rx
+
 install::
 	if test -f dll$(CLIBNAME)$(EXT_DLL); then \
-	  cp dll$(CLIBNAME)$(EXT_DLL) "$(INSTALL_STUBLIBDIR)/"; fi
-	cp lib$(CLIBNAME).$(A) "$(INSTALL_LIBDIR)/"
+	  install -m $(MPROG) \
+	    dll$(CLIBNAME)$(EXT_DLL) \
+	    "$(INSTALL_STUBLIBDIR)/"; \
+	fi
+	install -m $(MDATA) lib$(CLIBNAME).$(A) "$(INSTALL_LIBDIR)/"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) lib$(CLIBNAME).$(A)
-	cp $(LIBNAME).cma $(CMIFILES) $(CMIFILES:.cmi=.mli) \
-          $(CMIFILES:.cmi=.cmti) "$(INSTALL_LIBDIR)/"
+	install -m $(MDATA) \
+	  $(LIBNAME).cma $(CMIFILES) $(CMIFILES:.cmi=.mli) \
+          $(CMIFILES:.cmi=.cmti) \
+	  "$(INSTALL_LIBDIR)/"
 	if test -n "$(HEADERS)"; then \
-	  cp $(HEADERS) "$(INSTALL_LIBDIR)/caml/"; fi
+	  install -m $(MDATA) $(HEADERS) "$(INSTALL_LIBDIR)/caml/"; \
+	fi
 
 installopt:
-	cp $(CAMLOBJS_NAT) $(LIBNAME).cmxa $(LIBNAME).$(A) "$(INSTALL_LIBDIR)/"
+	install -m $(MDATA) \
+	   $(CAMLOBJS_NAT) $(LIBNAME).cmxa $(LIBNAME).$(A) \
+	   "$(INSTALL_LIBDIR)/"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) $(LIBNAME).a
 	if test -f $(LIBNAME).cmxs; then \
-	  cp $(LIBNAME).cmxs "$(INSTALL_LIBDIR)/"; fi
+	  install -m $(MPROG) $(LIBNAME).cmxs "$(INSTALL_LIBDIR)/"; \
+	fi
 
 partialclean:
 	rm -f *.cm*

--- a/otherlibs/Makefile
+++ b/otherlibs/Makefile
@@ -76,35 +76,36 @@ $(LIBNAME).cmxs: $(LIBNAME).cmxa lib$(CLIBNAME).$(A)
 lib$(CLIBNAME).$(A): $(COBJS)
 	$(MKLIB) -oc $(CLIBNAME) $(COBJS) $(LDOPTS)
 
+INSTALL=install
+INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
+INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
+
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 
-MDATA=u+rw,g+rw,o+r
-MPROG=u+rwx,g+rwx,o+rx
-
 install::
 	if test -f dll$(CLIBNAME)$(EXT_DLL); then \
-	  install -m $(MPROG) \
+	  $(INSTALL_PROG) \
 	    dll$(CLIBNAME)$(EXT_DLL) \
 	    "$(INSTALL_STUBLIBDIR)/"; \
 	fi
-	install -m $(MDATA) lib$(CLIBNAME).$(A) "$(INSTALL_LIBDIR)/"
+	$(INSTALL_DATA) lib$(CLIBNAME).$(A) "$(INSTALL_LIBDIR)/"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) lib$(CLIBNAME).$(A)
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	  $(LIBNAME).cma $(CMIFILES) $(CMIFILES:.cmi=.mli) \
           $(CMIFILES:.cmi=.cmti) \
 	  "$(INSTALL_LIBDIR)/"
 	if test -n "$(HEADERS)"; then \
-	  install -m $(MDATA) $(HEADERS) "$(INSTALL_LIBDIR)/caml/"; \
+	  $(INSTALL_DATA) $(HEADERS) "$(INSTALL_LIBDIR)/caml/"; \
 	fi
 
 installopt:
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	   $(CAMLOBJS_NAT) $(LIBNAME).cmxa $(LIBNAME).$(A) \
 	   "$(INSTALL_LIBDIR)/"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) $(LIBNAME).a
 	if test -f $(LIBNAME).cmxs; then \
-	  install -m $(MPROG) $(LIBNAME).cmxs "$(INSTALL_LIBDIR)/"; \
+	  $(INSTALL_PROG) $(LIBNAME).cmxs "$(INSTALL_LIBDIR)/"; \
 	fi
 
 partialclean:

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -18,6 +18,8 @@
 # FIXME reduce redundancy by including ../Makefile
 
 include ../../config/Makefile
+include ../../Makefile.common
+
 CAMLRUN ?= ../../boot/ocamlrun
 CAMLYACC ?= ../../boot/ocamlyacc
 
@@ -87,12 +89,6 @@ dynlink.cmx: dynlink.cmi natdynlink.ml
 
 extract_crc: dynlink.cma extract_crc.cmo
 	$(OCAMLC) -o extract_crc dynlink.cma extract_crc.cmo
-
-INSTALL=install
-INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
-INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
-
-INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
 install:
 	$(INSTALL_DATA) \

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -88,21 +88,22 @@ dynlink.cmx: dynlink.cmi natdynlink.ml
 extract_crc: dynlink.cma extract_crc.cmo
 	$(OCAMLC) -o extract_crc dynlink.cma extract_crc.cmo
 
+INSTALL=install
+INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
+INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
+
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
-MDATA=u+rw,g+rw,o+r
-MPROG=u+rwx,g+rwx,o+rx
-
 install:
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	  dynlink.cmi dynlink.cmti dynlink.cma dynlink.mli \
 	  "$(INSTALL_LIBDIR)"
-	install -m $(MPROG) \
+	$(INSTALL_PROG) \
 	  extract_crc "$(INSTALL_LIBDIR)/extract_crc$(EXE)"
 
 installopt:
 	if $(NATDYNLINK); then \
-	  install -m $(MDATA) \
+	  $(INSTALL_DATA) \
 	    $(NATOBJS) dynlink.cmxa dynlink.$(A) \
 	    "$(INSTALL_LIBDIR)" && \
 	  cd "$(INSTALL_LIBDIR)" && $(RANLIB) dynlink.$(A); \

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -90,13 +90,21 @@ extract_crc: dynlink.cma extract_crc.cmo
 
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
+MDATA=u+rw,g+rw,o+r
+MPROG=u+rwx,g+rwx,o+rx
+
 install:
-	cp dynlink.cmi dynlink.cmti dynlink.cma dynlink.mli "$(INSTALL_LIBDIR)"
-	cp extract_crc "$(INSTALL_LIBDIR)/extract_crc$(EXE)"
+	install -m $(MDATA) \
+	  dynlink.cmi dynlink.cmti dynlink.cma dynlink.mli \
+	  "$(INSTALL_LIBDIR)"
+	install -m $(MPROG) \
+	  extract_crc "$(INSTALL_LIBDIR)/extract_crc$(EXE)"
 
 installopt:
 	if $(NATDYNLINK); then \
-	  cp $(NATOBJS) dynlink.cmxa dynlink.$(A) "$(INSTALL_LIBDIR)" && \
+	  install -m $(MDATA) \
+	    $(NATOBJS) dynlink.cmxa dynlink.$(A) \
+	    "$(INSTALL_LIBDIR)" && \
 	  cd "$(INSTALL_LIBDIR)" && $(RANLIB) dynlink.$(A); \
 	fi
 

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -112,34 +112,35 @@ partialclean:
 clean: partialclean
 	rm -f dllthreads*$(EXT_DLL) *.$(A) *.$(O)
 
-INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
-THREADS_LIBDIR=$(INSTALL_LIBDIR)/$(LIBNAME)
-INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
+INSTALL=install
+INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
+INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
 
-MDATA=u+rw,g+rw,o+r
-MPROG=u+rwx,g+rwx,o+rx
+INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
+INSTALL_THREADSLIBDIR=$(INSTALL_LIBDIR)/$(LIBNAME)
+INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 
 install:
 	if test -f dllthreads$(EXT_DLL); then \
-	  install -m $(MPROG) \
+	  $(INSTALL_PROG) \
 	    dllthreads$(EXT_DLL) "$(INSTALL_STUBLIBDIR)/dllthreads$(EXT_DLL)"; \
 	fi
-	install -m $(MDATA) libthreads.$(A) "$(INSTALL_LIBDIR)"
+	$(INSTALL_DATA) libthreads.$(A) "$(INSTALL_LIBDIR)"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) libthreads.$(A)
-	mkdir -p "$(THREADS_LIBDIR)"
-	install -m $(MDATA) \
+	mkdir -p "$(INSTALL_THREADSLIBDIR)"
+	$(INSTALL_DATA) \
 	  $(CMIFILES) $(CMIFILES:.cmi=.cmti) threads.cma \
-	  "$(THREADS_LIBDIR)"
-	install -m $(MDATA) $(MLIFILES) "$(INSTALL_LIBDIR)"
-	install -m $(MDATA) threads.h "$(INSTALL_LIBDIR)/caml"
+	  "$(INSTALL_THREADSLIBDIR)"
+	$(INSTALL_DATA) $(MLIFILES) "$(INSTALL_LIBDIR)"
+	$(INSTALL_DATA) threads.h "$(INSTALL_LIBDIR)/caml"
 
 installopt:
-	install -m $(MDATA) libthreadsnat.$(A) "$(INSTALL_LIBDIR)"
+	$(INSTALL_DATA) libthreadsnat.$(A) "$(INSTALL_LIBDIR)"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) libthreadsnat.$(A)
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	  $(THREADS_NCOBJS) threads.cmxa threads.$(A) \
-	  "$(THREADS_LIBDIR)"
-	cd "$(THREADS_LIBDIR)" && $(RANLIB) threads.$(A)
+	  "$(INSTALL_THREADSLIBDIR)"
+	cd "$(INSTALL_THREADSLIBDIR)" && $(RANLIB) threads.$(A)
 
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -116,20 +116,29 @@ INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 THREADS_LIBDIR=$(INSTALL_LIBDIR)/$(LIBNAME)
 INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 
+MDATA=u+rw,g+rw,o+r
+MPROG=u+rwx,g+rwx,o+rx
+
 install:
 	if test -f dllthreads$(EXT_DLL); then \
-	  cp dllthreads$(EXT_DLL) "$(INSTALL_STUBLIBDIR)/dllthreads$(EXT_DLL)"; fi
-	cp libthreads.$(A) "$(INSTALL_LIBDIR)"
+	  install -m $(MPROG) \
+	    dllthreads$(EXT_DLL) "$(INSTALL_STUBLIBDIR)/dllthreads$(EXT_DLL)"; \
+	fi
+	install -m $(MDATA) libthreads.$(A) "$(INSTALL_LIBDIR)"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) libthreads.$(A)
 	mkdir -p "$(THREADS_LIBDIR)"
-	cp $(CMIFILES) $(CMIFILES:.cmi=.cmti) threads.cma "$(THREADS_LIBDIR)"
-	cp $(MLIFILES) "$(INSTALL_LIBDIR)"
-	cp threads.h "$(INSTALL_LIBDIR)/caml"
+	install -m $(MDATA) \
+	  $(CMIFILES) $(CMIFILES:.cmi=.cmti) threads.cma \
+	  "$(THREADS_LIBDIR)"
+	install -m $(MDATA) $(MLIFILES) "$(INSTALL_LIBDIR)"
+	install -m $(MDATA) threads.h "$(INSTALL_LIBDIR)/caml"
 
 installopt:
-	cp libthreadsnat.$(A) "$(INSTALL_LIBDIR)"
+	install -m $(MDATA) libthreadsnat.$(A) "$(INSTALL_LIBDIR)"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) libthreadsnat.$(A)
-	cp $(THREADS_NCOBJS) threads.cmxa threads.$(A) "$(THREADS_LIBDIR)"
+	install -m $(MDATA) \
+	  $(THREADS_NCOBJS) threads.cmxa threads.$(A) \
+	  "$(THREADS_LIBDIR)"
 	cd "$(THREADS_LIBDIR)" && $(RANLIB) threads.$(A)
 
 .SUFFIXES: .ml .mli .cmo .cmi .cmx

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -16,6 +16,7 @@
 ROOTDIR=../..
 
 include $(ROOTDIR)/config/Makefile
+include $(ROOTDIR)/Makefile.common
 
 CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 CAMLYACC ?= $(ROOTDIR)/boot/ocamlyacc
@@ -112,13 +113,7 @@ partialclean:
 clean: partialclean
 	rm -f dllthreads*$(EXT_DLL) *.$(A) *.$(O)
 
-INSTALL=install
-INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
-INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
-
-INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 INSTALL_THREADSLIBDIR=$(INSTALL_LIBDIR)/$(LIBNAME)
-INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 
 install:
 	if test -f dllthreads$(EXT_DLL); then \

--- a/otherlibs/threads/Makefile
+++ b/otherlibs/threads/Makefile
@@ -114,15 +114,20 @@ INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 
 CMIFILES=thread.cmi mutex.cmi condition.cmi event.cmi threadUnix.cmi
 
+MDATA=u+rw,g+rw,o+r
+MPROG=u+rwx,g+rwx,o+rx
+
 install:
 	if test -f dllvmthreads.so; then \
-	  cp dllvmthreads.so "$(INSTALL_STUBLIBDIR)"; \
+	  install -m $(MPROG) dllvmthreads.so "$(INSTALL_STUBLIBDIR)"; \
 	fi
 	mkdir -p "$(INSTALL_LIBDIR)/vmthreads"
-	cp libvmthreads.a "$(INSTALL_LIBDIR)/vmthreads"
+	install -m $(MDATA) libvmthreads.a "$(INSTALL_LIBDIR)/vmthreads"
 	cd "$(INSTALL_LIBDIR)/vmthreads"; $(RANLIB) libvmthreads.a
-	cp $(CMIFILES) $(CMIFILES:.cmi=.mli) $(CMIFILES:.cmi=.cmti) \
-	   threads.cma stdlib.cma unix.cma "$(INSTALL_LIBDIR)/vmthreads"
+	install -m $(MDATA) \
+	  $(CMIFILES) $(CMIFILES:.cmi=.mli) $(CMIFILES:.cmi=.cmti) \
+	  threads.cma stdlib.cma unix.cma \
+	  "$(INSTALL_LIBDIR)/vmthreads"
 
 installopt:
 

--- a/otherlibs/threads/Makefile
+++ b/otherlibs/threads/Makefile
@@ -109,22 +109,23 @@ clean: partialclean
 	rm -f libvmthreads.a dllvmthreads.so *.o
 	rm -f stdlib.mli marshal.mli unix.mli
 
+INSTALL=install
+INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
+INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
+
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 
 CMIFILES=thread.cmi mutex.cmi condition.cmi event.cmi threadUnix.cmi
 
-MDATA=u+rw,g+rw,o+r
-MPROG=u+rwx,g+rwx,o+rx
-
 install:
 	if test -f dllvmthreads.so; then \
-	  install -m $(MPROG) dllvmthreads.so "$(INSTALL_STUBLIBDIR)"; \
+	  $(INSTALL_PROG) dllvmthreads.so "$(INSTALL_STUBLIBDIR)"; \
 	fi
 	mkdir -p "$(INSTALL_LIBDIR)/vmthreads"
-	install -m $(MDATA) libvmthreads.a "$(INSTALL_LIBDIR)/vmthreads"
+	$(INSTALL_DATA) libvmthreads.a "$(INSTALL_LIBDIR)/vmthreads"
 	cd "$(INSTALL_LIBDIR)/vmthreads"; $(RANLIB) libvmthreads.a
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	  $(CMIFILES) $(CMIFILES:.cmi=.mli) $(CMIFILES:.cmi=.cmti) \
 	  threads.cma stdlib.cma unix.cma \
 	  "$(INSTALL_LIBDIR)/vmthreads"

--- a/otherlibs/threads/Makefile
+++ b/otherlibs/threads/Makefile
@@ -16,6 +16,8 @@
 # FIXME reduce redundancy by including ../Makefile
 
 include ../../config/Makefile
+include ../../Makefile.common
+
 CAMLRUN ?= ../../boot/ocamlrun
 CAMLYACC ?= ../../boot/ocamlyacc
 
@@ -108,13 +110,6 @@ partialclean:
 clean: partialclean
 	rm -f libvmthreads.a dllvmthreads.so *.o
 	rm -f stdlib.mli marshal.mli unix.mli
-
-INSTALL=install
-INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
-INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
-
-INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
-INSTALL_STUBLIBDIR=$(DESTDIR)$(STUBLIBDIR)
 
 CMIFILES=thread.cmi mutex.cmi condition.cmi event.cmi threadUnix.cmi
 

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -83,26 +83,27 @@ allopt-noprof:
 allopt-prof: stdlib.p.cmxa std_exit.p.cmx
 	rm -f std_exit.p.cmi
 
-INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
+INSTALL=install
+INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
+INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
 
-MDATA=u+rw,g+rw,o+r
-MPROG=u+rwx,g+rwx,o+rx
+INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
 .PHONY: install
 install::
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	  stdlib.cma std_exit.cmo *.cmi *.cmt *.cmti *.mli *.ml camlheader_ur \
 	  "$(INSTALL_LIBDIR)"
-	install -m $(MDATA) target_camlheader "$(INSTALL_LIBDIR)/camlheader"
+	$(INSTALL_DATA) target_camlheader "$(INSTALL_LIBDIR)/camlheader"
 
 ifeq "$(RUNTIMED)" "true"
 install::
-	install -m $(MDATA) target_camlheaderd $(INSTALL_LIBDIR)
+	$(INSTALL_DATA) target_camlheaderd $(INSTALL_LIBDIR)
 endif
 
 ifeq "$(RUNTIMEI)" "true"
 install::
-	install -m $(MDATA) target_camlheaderi $(INSTALL_LIBDIR)
+	$(INSTALL_DATA) target_camlheaderi $(INSTALL_LIBDIR)
 endif
 
 .PHONY: installopt
@@ -110,7 +111,7 @@ installopt: installopt-default installopt-$(PROFILINGTARGET)
 
 .PHONY: installopt-default
 installopt-default:
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	  stdlib.cmxa stdlib.$(A) std_exit.$(O) *.cmx \
 	  "$(INSTALL_LIBDIR)"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) stdlib.$(A)
@@ -120,7 +121,7 @@ installopt-noprof:
 
 .PHONY: installopt-prof
 installopt-prof:
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	  stdlib.p.cmxa stdlib.p.$(A) std_exit.p.cmx std_exit.p.$(O) \
 	  "$(INSTALL_LIBDIR)"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) stdlib.p.$(A)

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -85,21 +85,24 @@ allopt-prof: stdlib.p.cmxa std_exit.p.cmx
 
 INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
+MDATA=u+rw,g+rw,o+r
+MPROG=u+rwx,g+rwx,o+rx
+
 .PHONY: install
 install::
-	cp stdlib.cma std_exit.cmo *.cmi *.cmt *.cmti *.mli *.ml \
-	  camlheader_ur \
+	install -m $(MDATA) \
+	  stdlib.cma std_exit.cmo *.cmi *.cmt *.cmti *.mli *.ml camlheader_ur \
 	  "$(INSTALL_LIBDIR)"
-	cp target_camlheader "$(INSTALL_LIBDIR)/camlheader"
+	install -m $(MDATA) target_camlheader "$(INSTALL_LIBDIR)/camlheader"
 
 ifeq "$(RUNTIMED)" "true"
 install::
-	cp target_camlheaderd $(INSTALL_LIBDIR)
+	install -m $(MDATA) target_camlheaderd $(INSTALL_LIBDIR)
 endif
 
 ifeq "$(RUNTIMEI)" "true"
 install::
-	cp target_camlheaderi $(INSTALL_LIBDIR)
+	install -m $(MDATA) target_camlheaderi $(INSTALL_LIBDIR)
 endif
 
 .PHONY: installopt
@@ -107,7 +110,9 @@ installopt: installopt-default installopt-$(PROFILINGTARGET)
 
 .PHONY: installopt-default
 installopt-default:
-	cp stdlib.cmxa stdlib.$(A) std_exit.$(O) *.cmx "$(INSTALL_LIBDIR)"
+	install -m $(MDATA) \
+	  stdlib.cmxa stdlib.$(A) std_exit.$(O) *.cmx \
+	  "$(INSTALL_LIBDIR)"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) stdlib.$(A)
 
 .PHONY: installopt-noprof
@@ -115,7 +120,8 @@ installopt-noprof:
 
 .PHONY: installopt-prof
 installopt-prof:
-	cp stdlib.p.cmxa stdlib.p.$(A) std_exit.p.cmx std_exit.p.$(O) \
+	install -m $(MDATA) \
+	  stdlib.p.cmxa stdlib.p.$(A) std_exit.p.cmx std_exit.p.$(O) \
 	  "$(INSTALL_LIBDIR)"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) stdlib.p.$(A)
 

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -14,6 +14,8 @@
 #**************************************************************************
 
 include ../config/Makefile
+include ../Makefile.common
+
 CAMLRUN ?= ../boot/ocamlrun
 CAMLYACC ?= ../boot/ocamlyacc
 TARGET_BINDIR ?= $(BINDIR)
@@ -82,12 +84,6 @@ allopt-noprof:
 .PHONY: allopt-prof
 allopt-prof: stdlib.p.cmxa std_exit.p.cmx
 	rm -f std_exit.p.cmi
-
-INSTALL=install
-INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
-INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
-
-INSTALL_LIBDIR=$(DESTDIR)$(LIBDIR)
 
 .PHONY: install
 install::

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -15,22 +15,13 @@
 
 MAKEFLAGS := -r -R
 include ../config/Makefile
-
-INSTALL=install
-INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
-INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
-
-INSTALL_BINDIR:=$(DESTDIR)$(BINDIR)
-INSTALL_LIBDIR:=$(DESTDIR)$(LIBDIR)
-INSTALL_COMPLIBDIR:=$(DESTDIR)$(COMPLIBDIR)
-INSTALL_STUBLIBDIR:=$(DESTDIR)$(STUBLIBDIR)
-INSTALL_MANDIR:=$(DESTDIR)$(MANDIR)
+include ../Makefile.common
 
 ifeq ($(SYSTEM),unix)
 override define shellquote
 $i := $$(subst ",\",$$(subst $$$$,\$$$$,$$(subst `,\`,$i)))#")#
 endef
-$(foreach i,BINDIR LIBDIR COMPLIBDIR STUBLIBDIR MANDIR,$(eval $(shellquote)))
+$(foreach i,BINDIR LIBDIR STUBLIBDIR MANDIR,$(eval $(shellquote)))
 endif
 
 CAMLRUN ?= ../boot/ocamlrun

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -142,11 +142,18 @@ $(call byte_and_opt,ocamloptp,$(ocamlcp_cmos) ocamloptp.cmo,)
 
 opt:: profiling.cmx
 
+MDATA=u+rw,g+rw,o+r
+MPROG=u+rwx,g+rwx,o+rx
+
 install::
-	cp -- profiling.cmi profiling.cmo profiling.cmt profiling.cmti "$(INSTALL_LIBDIR)"
+	install -m $(MDATA) \
+	  profiling.cmi profiling.cmo profiling.cmt profiling.cmti \
+	  "$(INSTALL_LIBDIR)"
 
 installopt::
-	cp -- profiling.cmx profiling.$(O) "$(INSTALL_LIBDIR)"
+	install -m $(MDATA) \
+          profiling.cmx profiling.$(O) \
+	  "$(INSTALL_LIBDIR)"
 
 # To help building mixed-mode libraries (OCaml + C)
 
@@ -188,7 +195,7 @@ lexer299.ml: lexer299.mll
 	$(CAMLLEX) lexer299.mll
 
 #install::
-#	cp ocaml299to3 "$(INSTALL_BINDIR)/ocaml299to3$(EXE)"
+#	install -m $(MPROG) ocaml299to3 "$(INSTALL_BINDIR)/ocaml299to3$(EXE)"
 
 clean::
 	rm -f ocaml299to3 lexer299.ml
@@ -204,7 +211,7 @@ lexer301.ml: lexer301.mll
 	$(CAMLLEX) lexer301.mll
 
 #install::
-#	cp scrapelabels "$(INSTALL_LIBDIR)"
+#	install -m $(MPROG) scrapelabels "$(INSTALL_LIBDIR)"
 
 clean::
 	rm -f scrapelabels lexer301.ml
@@ -222,7 +229,7 @@ addlabels: addlabels.cmo
 		$(ADDLABELS_IMPORTS) addlabels.cmo
 
 #install::
-#	cp addlabels "$(INSTALL_LIBDIR)"
+#	install -m $(MPROG) addlabels "$(INSTALL_LIBDIR)"
 
 ifeq ($(UNIX_OR_WIN32),unix)
 LN := ln -sf
@@ -233,9 +240,9 @@ endif
 install::
 	for i in $(install_files); \
 	do \
-	  cp -- "$$i" "$(INSTALL_BINDIR)/$$i.byte$(EXE)" && \
+	  install -m $(MPROG) "$$i" "$(INSTALL_BINDIR)/$$i.byte$(EXE)" && \
 	  if test -f "$$i".opt; then \
-	    cp -- "$$i.opt" "$(INSTALL_BINDIR)/$$i.opt$(EXE)" && \
+	    install -m $(MPROG) "$$i.opt" "$(INSTALL_BINDIR)/$$i.opt$(EXE)" && \
 	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
 	  else \
 	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.byte$(EXE)" "$$i$(EXE)"); \
@@ -279,9 +286,9 @@ $(call byte_and_opt,read_cmt,$(READ_CMT),)
 
 install::
 	if test -f read_cmt.opt; then \
-		cp read_cmt.opt "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
+	  install -m $(MPROG) read_cmt.opt "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
 	else \
-		cp read_cmt "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
+	  install -m $(MPROG) read_cmt "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
 	fi
 
 
@@ -329,7 +336,8 @@ OBJINFO=../compilerlibs/ocamlcommon.cma \
 $(call byte_and_opt,ocamlobjinfo,$(OBJINFO),objinfo_helper$(EXE))
 
 install::
-	cp objinfo_helper$(EXE) "$(INSTALL_LIBDIR)/objinfo_helper$(EXE)"
+	install -m $(MPROG) \
+	  objinfo_helper$(EXE) "$(INSTALL_LIBDIR)/objinfo_helper$(EXE)"
 
 # Scan object files for required primitives
 $(call byte_and_opt,primreq,config.cmo primreq.cmo,)
@@ -371,7 +379,9 @@ $(call byte_and_opt,cmpbyt,$(CMPBYT),)
 
 ifeq "$(RUNTIMEI)" "true"
 install::
-	cp ocaml-instr-graph ocaml-instr-report "$(INSTALL_BINDIR)/"
+	install -m $(MPROG) \
+	  ocaml-instr-graph ocaml-instr-report \
+	  "$(INSTALL_BINDIR)/"
 endif
 
 # Common stuff

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -15,6 +15,11 @@
 
 MAKEFLAGS := -r -R
 include ../config/Makefile
+
+INSTALL=install
+INSTALL_DATA=$(INSTALL) -m u+rw,g+rw,o+r
+INSTALL_PROG=$(INSTALL) -m u+rwx,g+rwx,o+rx
+
 INSTALL_BINDIR:=$(DESTDIR)$(BINDIR)
 INSTALL_LIBDIR:=$(DESTDIR)$(LIBDIR)
 INSTALL_COMPLIBDIR:=$(DESTDIR)$(COMPLIBDIR)
@@ -142,16 +147,13 @@ $(call byte_and_opt,ocamloptp,$(ocamlcp_cmos) ocamloptp.cmo,)
 
 opt:: profiling.cmx
 
-MDATA=u+rw,g+rw,o+r
-MPROG=u+rwx,g+rwx,o+rx
-
 install::
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
 	  profiling.cmi profiling.cmo profiling.cmt profiling.cmti \
 	  "$(INSTALL_LIBDIR)"
 
 installopt::
-	install -m $(MDATA) \
+	$(INSTALL_DATA) \
           profiling.cmx profiling.$(O) \
 	  "$(INSTALL_LIBDIR)"
 
@@ -195,7 +197,7 @@ lexer299.ml: lexer299.mll
 	$(CAMLLEX) lexer299.mll
 
 #install::
-#	install -m $(MPROG) ocaml299to3 "$(INSTALL_BINDIR)/ocaml299to3$(EXE)"
+#	$(INSTALL_PROG) ocaml299to3 "$(INSTALL_BINDIR)/ocaml299to3$(EXE)"
 
 clean::
 	rm -f ocaml299to3 lexer299.ml
@@ -211,7 +213,7 @@ lexer301.ml: lexer301.mll
 	$(CAMLLEX) lexer301.mll
 
 #install::
-#	install -m $(MPROG) scrapelabels "$(INSTALL_LIBDIR)"
+#	$(INSTALL_PROG) scrapelabels "$(INSTALL_LIBDIR)"
 
 clean::
 	rm -f scrapelabels lexer301.ml
@@ -229,7 +231,7 @@ addlabels: addlabels.cmo
 		$(ADDLABELS_IMPORTS) addlabels.cmo
 
 #install::
-#	install -m $(MPROG) addlabels "$(INSTALL_LIBDIR)"
+#	$(INSTALL_PROG) addlabels "$(INSTALL_LIBDIR)"
 
 ifeq ($(UNIX_OR_WIN32),unix)
 LN := ln -sf
@@ -240,9 +242,9 @@ endif
 install::
 	for i in $(install_files); \
 	do \
-	  install -m $(MPROG) "$$i" "$(INSTALL_BINDIR)/$$i.byte$(EXE)" && \
+	  $(INSTALL_PROG) "$$i" "$(INSTALL_BINDIR)/$$i.byte$(EXE)" && \
 	  if test -f "$$i".opt; then \
-	    install -m $(MPROG) "$$i.opt" "$(INSTALL_BINDIR)/$$i.opt$(EXE)" && \
+	    $(INSTALL_PROG) "$$i.opt" "$(INSTALL_BINDIR)/$$i.opt$(EXE)" && \
 	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
 	  else \
 	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.byte$(EXE)" "$$i$(EXE)"); \
@@ -286,9 +288,9 @@ $(call byte_and_opt,read_cmt,$(READ_CMT),)
 
 install::
 	if test -f read_cmt.opt; then \
-	  install -m $(MPROG) read_cmt.opt "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
+	  $(INSTALL_PROG) read_cmt.opt "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
 	else \
-	  install -m $(MPROG) read_cmt "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
+	  $(INSTALL_PROG) read_cmt "$(INSTALL_BINDIR)/ocamlcmt$(EXE)"; \
 	fi
 
 
@@ -336,7 +338,7 @@ OBJINFO=../compilerlibs/ocamlcommon.cma \
 $(call byte_and_opt,ocamlobjinfo,$(OBJINFO),objinfo_helper$(EXE))
 
 install::
-	install -m $(MPROG) \
+	$(INSTALL_PROG) \
 	  objinfo_helper$(EXE) "$(INSTALL_LIBDIR)/objinfo_helper$(EXE)"
 
 # Scan object files for required primitives
@@ -379,7 +381,7 @@ $(call byte_and_opt,cmpbyt,$(CMPBYT),)
 
 ifeq "$(RUNTIMEI)" "true"
 install::
-	install -m $(MPROG) \
+	$(INSTALL_PROG) \
 	  ocaml-instr-graph ocaml-instr-report \
 	  "$(INSTALL_BINDIR)/"
 endif


### PR DESCRIPTION
I can observe weird performance bottlenecks on my machine caused by
the use of 'cp' in the 'install' scripts of OCaml. When installing
into a directory that is already populated by an existing
installation, 'make install' can routinely take 10s on my machine¹. After this
change it reliably takes 1.5s, independently of whether the
destination is already populated or not.

¹: a brtfs filesystem on an old-ish SSD

Why I care
----------

An extra 10s delay due to 'make install' can be noticeable in tight
change-build-install-test feedback loops for a compiler change where
we change the compiler, have a fast 'make world.opt' due to
incremental builds, install the change and test it -- possibly after
installing a couple opam packages, which can be fairly quick.

Partial diagnosis
-----------------

The performance issue seems to be caused by the fact that 'cp' (at
least the GNU coreutils version), when the file already exists,
replaces it by opening it in writeonly+truncate mode and writing the
file content ('strace' shows that the delay is caused within an
'openat' call). In particular, using the --remove-destination option
(which changes 'cp' to just remove the destination file before
copying) removes the performance issue, but this option seems missing
from the BSD/OSX 'cp' so it could cause portability issue.

Change
------

The present commit rewrites the 'install' targets of all Makefiles to
use the 'install' command instead. 'install' by default gives
executable-like permission to the destination file, instead of reusing
the source file's permissions, so we specify manually the permission
modes, depending on whether the installed file is an executable (or
dynamically-linked library) or just data (including other compiled
object files).

Testing
-------

I checked manually that the permissions of the installed files are
identical to the ones of the current 'cp'-using targets, except for
some '.mli' file in middle_end which currently have +x bits enabled
for no good reason.

Remark: To test this, playing with the DESTDIR variable is very useful
(this lets you install to a new directory (or the same as before)
without having to re-run the configure script). I used the following,
fairly slow shell script to collect permissions:

    for f in $(find $DESTDIR); do \
      echo $(basename $f) $(ls -l $f | cut -d' ' -f1); \
    done | sort

Remark: it is important to run `sync` in-between 'make install' runs
to avoid timing effects due to filesystem or disk caching
strategies. I believe that this corresponds to the natural time delay
(and unrelated disk activity) that would occur in realistic
change-install-test feedback loops.