### PR TITLE
testsuite/Makefile: use $(CYGPATH) for portability in one/promote for…

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -203,7 +203,7 @@ exec-one:
 	elif [ -f $(DIR)/ocamltests ] && [ -z $(LEGACY) ] ; then \
 	  echo "Running tests from '$$DIR' ..."; \
 	  $(MAKE) exec-ocamltest DIR=$(DIR) \
-	    OCAMLTESTENV="OCAMLTESTDIR=$(BASEDIR)/$(DIR)/_ocamltest" \
+	    OCAMLTESTENV="OCAMLTESTDIR=$(shell $(CYGPATH) $(BASEDIR)/$(DIR)/_ocamltest)" \
 	    OCAMLTESTFLAGS=""; \
 	fi
 
@@ -242,7 +242,7 @@ promote:
 	fi
 	@if [ -f $(DIR)/ocamltests ]; then \
 	  $(MAKE) exec-ocamltest DIR=$(DIR) \
-	    OCAMLTESTENV="OCAMLTESTDIR=$(BASEDIR)/$(DIR)/_ocamltest" \
+	    OCAMLTESTENV="OCAMLTESTDIR=$(shell $(CYGPATH) $(BASEDIR)/$(DIR)/_ocamltest)" \
 	    OCAMLTESTFLAGS="-promote"; \
 	else \
 	  cd $(DIR) && $(MAKE) TERM=dumb BASEDIR=$(BASEDIR) promote; \


### PR DESCRIPTION
… new tests

Sébastien Hinderer remarked that the `one` or `promote` targets
for ocamltest-style tests seem to fail on Windows. The likely culprit
is the use of unix-style paths in the environment variable passed to
ocamltest, which expects Windows-style paths when running under Windows.
This patch uses the portably-declared $(CYGPATH) variable to, hopefully,
fix this issue: "OCAMLTESTDIR=$(BASEDIR)/foo" is changed into

    "OCAMLTESTDIR=$(shell $(CYGPATH) $(BASEDIR)/foo)"