### PR TITLE
make string_of_float and float_of_string locale-independent (#1185)

### DIFF
--- a/Changes
+++ b/Changes
@@ -605,6 +605,9 @@ OCaml 4.06.0 (3 Nov 2017):
   the null device.
   (David Allsopp)
 
+- GPR#1185: make float_of_string and string_of_float locale-independent
+  (ygrek)
+
 ### Compiler user-interface and warnings:
 
 - MPR#7361, GPR#1248: support "ocaml.warning" in all attribute contexts, and

--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -126,6 +126,7 @@ value caml_startup_common(char_os **argv, int pooling)
 #endif
   caml_init_frame_descriptors();
   caml_init_ieee_floats();
+  caml_init_locale();
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();
 #endif

--- a/byterun/caml/startup_aux.h
+++ b/byterun/caml/startup_aux.h
@@ -20,6 +20,9 @@
 
 #include "config.h"
 
+extern void caml_init_locale(void);
+extern void caml_free_locale(void);
+
 extern void caml_init_atom_table (void);
 
 extern uintnat caml_init_percent_free;

--- a/byterun/startup.c
+++ b/byterun/startup.c
@@ -330,6 +330,7 @@ CAMLexport void caml_main(char_os **argv)
   /* Machine-dependent initialization of the floating-point hardware
      so that it behaves as much as possible as specified in IEEE */
   caml_init_ieee_floats();
+  caml_init_locale();
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();
 #endif
@@ -454,6 +455,7 @@ CAMLexport value caml_startup_code_exn(
     return Val_unit;
 
   caml_init_ieee_floats();
+  caml_init_locale();
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();
 #endif

--- a/byterun/startup_aux.c
+++ b/byterun/startup_aux.c
@@ -159,6 +159,7 @@ CAMLexport void caml_shutdown(void)
   call_registered_value("Pervasives.do_at_exit");
   call_registered_value("Thread.at_shutdown");
   caml_finalise_heap();
+  caml_free_locale();
 #ifndef NATIVE_CODE
   caml_free_shared_libs();
 #endif

--- a/config/s-nt.h
+++ b/config/s-nt.h
@@ -29,7 +29,10 @@
 #define HAS_GETHOSTNAME
 #define HAS_MKTIME
 #define HAS_PUTENV
+#ifndef __MINGW32__
 #define HAS_LOCALE
+#define HAS_STRTOD_L
+#endif
 #define HAS_BROKEN_PRINTF
 #define HAS_IPV6
 #define HAS_NICE

--- a/config/s-templ.h
+++ b/config/s-templ.h
@@ -188,7 +188,11 @@
 #define HAS_LOCALE
 
 /* Define HAS_LOCALE if you have the include file <locale.h> and the
-   setlocale() function. */
+   uselocale() function. */
+
+#define HAS_STRTOD_L
+
+/* Define HAS_STRTOD_L if you have strtod_l */
 
 #define HAS_MMAP
 

--- a/configure
+++ b/configure
@@ -1468,9 +1468,14 @@ if sh ./hasgot putenv; then
   echo "#define HAS_PUTENV" >> s.h
 fi
 
-if sh ./hasgot -i locale.h && sh ./hasgot setlocale; then
-  inf "setlocale() and <locale.h> found."
+if sh ./hasgot -i locale.h && sh ./hasgot newlocale freelocale uselocale; then
+  inf "newlocale() and <locale.h> found."
   echo "#define HAS_LOCALE" >> s.h
+fi
+
+if sh ./hasgot strtod_l; then
+  inf "strtod_l() found."
+  echo "#define HAS_STRTOD_L" >> s.h
 fi
 
 

--- a/testsuite/tests/locale/Makefile
+++ b/testsuite/tests/locale/Makefile
@@ -1,0 +1,9 @@
+BASEDIR=../..
+MODULES=
+MAIN_MODULE=test
+C_FILES=stubs
+
+include $(BASEDIR)/makefiles/Makefile.one
+include $(BASEDIR)/makefiles/Makefile.common
+
+NATIVECODE_ONLY=true

--- a/testsuite/tests/locale/stubs.c
+++ b/testsuite/tests/locale/stubs.c
@@ -1,0 +1,8 @@
+#include <caml/mlvalues.h>
+#include <locale.h>
+
+value ml_setlocale(value v_locale)
+{
+  setlocale(LC_ALL,String_val(v_locale));
+  return Val_unit;
+}

--- a/testsuite/tests/locale/test.ml
+++ b/testsuite/tests/locale/test.ml
@@ -1,0 +1,24 @@
+
+external setlocale : string -> unit = "ml_setlocale"
+
+let show f = try string_of_float @@ f () with exn -> Printf.sprintf "exn %s" (Printexc.to_string exn)
+let pr fmt = Printf.ksprintf print_endline fmt
+
+let () =
+  let s = "12345.6789" in
+  let f = 1.23 in
+  let test () =
+    pr "  print 1.23 : %s" (show @@ fun () -> f);
+    pr "  parse %S : %s" s (show @@ fun () -> float_of_string s);
+    pr "  roundtrip 1.23 : %s" (show @@ fun () -> float_of_string @@ string_of_float f);
+  in
+  pr "locale from environment";
+  setlocale "";
+  test ();
+  pr "locale nl_NL";
+  setlocale "nl_NL";
+  test ();
+  pr "locale POSIX";
+  setlocale "C";
+  test ();
+  ()

--- a/testsuite/tests/locale/test.reference
+++ b/testsuite/tests/locale/test.reference
@@ -1,0 +1,12 @@
+locale from environment
+  print 1.23 : 1.23
+  parse "12345.6789" : 12345.6789
+  roundtrip 1.23 : 1.23
+locale nl_NL
+  print 1.23 : 1.23
+  parse "12345.6789" : 12345.6789
+  roundtrip 1.23 : 1.23
+locale POSIX
+  print 1.23 : 1.23
+  parse "12345.6789" : 12345.6789
+  roundtrip 1.23 : 1.23


### PR DESCRIPTION
This is the second PR for this change, as merging the first one broke OSX build see   https://github.com/ocaml/ocaml/pull/1185#issuecomment-377098168 .

notes:

* ifdef fest for MSVC
https://docs.microsoft.com/en-us/cpp/c-runtime-library/locale

* avoid duplocale due to different semantics on BSD
https://www.freebsd.org/cgi/man.cgi?query=newlocale&sektion=3

* mingw links against old msvcrt and doesn't have _create_locale