### PR TITLE
Fix size computation in nativeint_deserialize on MSVC64.

### DIFF
--- a/byterun/ints.c
+++ b/byterun/ints.c
@@ -687,7 +687,7 @@ static uintnat nativeint_deserialize(void * dst)
   default:
     caml_deserialize_error("input_value: ill-formed native integer");
   }
-  return sizeof(long);
+  return sizeof(intnat);
 }
 
 CAMLexport struct custom_operations caml_nativeint_ops = {


### PR DESCRIPTION
On MSVC64, sizeof(long) is 4, despite 8-byte words. Use sizeof(intnat) for the word size.

I don't think this bug can cause any actual failures, though. The marshalling code rounds sizes up to the word size, so this issue doesn't cause problems apart from breaking the build in #1683 (which adds more error checking).