### PR TITLE
Fix printing of functor types

### DIFF
--- a/Changes
+++ b/Changes
@@ -627,6 +627,9 @@ OCaml 4.07
   disambiguation
   (Thomas Refis, review by Leo White)
 
+- GPR#1687: fix bug in the printing of functor types by adding parentheses
+  (Pieter Goetschalckx, review by Gabriel Scherer)
+
 - GPR#1722: Scrape types in Typeopt.maybe_pointer
   (Leo White, review by Thomas Refis)
 

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -152,6 +152,18 @@ module type S =
     (module type of[@foo] M) ->
     (sig[@foo] end)
 
+module type S = S -> S -> S
+module type S = (S -> S) -> S
+module type S = functor (M : S) -> S -> S
+module type S = (functor (M : S) -> S) -> S
+module type S = (S -> S)[@foo] -> S
+module type S = (functor[@foo] (M : S) -> S) -> S
+
+module type S = sig
+  module rec A : (S with type t = t)
+  and B : (S with type t = t)
+end
+
 (* Structure items *)
 let%foo[@foo] x = 4
 and[@foo] y = x


### PR DESCRIPTION
The module type `(S -> S) -> S` is currently printed as `S -> S -> S`, which is equal to `S -> (S -> S)`.