### PR TITLE
Fix toplevel printing of -0.

### DIFF
--- a/Changes
+++ b/Changes
@@ -863,6 +863,9 @@ OCaml 4.06.0 (3 Nov 2017):
   (Florian Angeletti, review by Daniel Bünzli, Xavier Leroy and
    Gabriel Scherer)
 
+- GPR#1688: Fix printing of -0.
+  (Nicolás Ojeda Bär, review by Jérémie Dimino)
+
 ### Runtime system:
 
 * MPR#3771, GPR#153, GPR#1200, GPR#1357, GPR#1362, GPR#1363, GPR#1369, GPR#1398,

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -151,7 +151,7 @@ let print_out_value ppf tree =
     | Oval_int32 i -> parenthesize_if_neg ppf "%lil" i (i < 0l)
     | Oval_int64 i -> parenthesize_if_neg ppf "%LiL" i (i < 0L)
     | Oval_nativeint i -> parenthesize_if_neg ppf "%nin" i (i < 0n)
-    | Oval_float f -> parenthesize_if_neg ppf "%s" (float_repres f) (f < 0.0)
+    | Oval_float f -> parenthesize_if_neg ppf "%s" (float_repres f) (f < 0.0 || 1. /. f = neg_infinity)
     | Oval_string (_,_, Ostr_bytes) as tree ->
       pp_print_char ppf '(';
       print_simple_tree ppf tree;


### PR DESCRIPTION
Before:
```
# Some (-0.);;
- : float option = Some -0.
```

After:
```
# Some (-0.);;
- : float option = Some (-0.)
```