### PR TITLE
Improve shell scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ sudo: false
 language: c
 git:
   submodules: false
-script: bash -e tools/ci/travis/travis-ci.sh
+script: tools/ci/travis/travis-ci.sh
 matrix:
   include:
   - env: CI_KIND=build XARCH=i386

--- a/driver/ocamlcomp.sh.in
+++ b/driver/ocamlcomp.sh.in
@@ -15,6 +15,6 @@
 #*                                                                        *
 #**************************************************************************
 
-topdir=`dirname $0`
+topdir=`dirname "$0"`
 
-exec @compiler@ -nostdlib -I $topdir/stdlib "$@"
+exec @compiler@ -nostdlib -I "$topdir/stdlib" "$@"

--- a/lambda/generate_runtimedef.sh
+++ b/lambda/generate_runtimedef.sh
@@ -16,8 +16,7 @@
 #**************************************************************************
 
 echo 'let builtin_exceptions = [|'
-cat "$1" | tr -d '\r' | \
-    sed -n -e 's|.*/\* \("[A-Za-z_]*"\) \*/$|  \1;|p'
+tr -d '\r' < "$1" | sed -n -e 's|.*/\* \("[A-Za-z_]*"\) \*/$|  \1;|p'
 echo '|]'
 
 echo 'let builtin_primitives = [|'

--- a/runtime/gen_primitives.sh
+++ b/runtime/gen_primitives.sh
@@ -23,7 +23,7 @@
       lexing md5 meta memprof obj parsing signals str sys callback weak \
       finalise stacks dynlink backtrace_byt backtrace spacetime_byt afl bigarray
   do
-      sed -n -e "s/^CAMLprim value \([a-z0-9_][a-z0-9_]*\).*/\1/p" "$prim.c"
+      sed -n -e 's/^CAMLprim value \([a-z0-9_][a-z0-9_]*\).*/\1/p' "$prim.c"
   done
   sed -n -e 's/^CAMLprim_int64_[0-9](\([a-z0-9_][a-z0-9_]*\)).*/caml_int64_\1\
 caml_int64_\1_native/p' ints.c

--- a/tools/check-parser-uptodate-or-warn.sh
+++ b/tools/check-parser-uptodate-or-warn.sh
@@ -38,14 +38,14 @@ fi
 mtime() {
   if test -z "$MTIME"
   then echo 0
-  else $MTIME $1
+  else $MTIME "$1"
   fi
 }
 
 # The check itself
 SOURCE_MTIME=$(mtime parsing/parser.mly)
 GENERATED_MTIME=$(mtime boot/menhir/parser.ml)
-if test $SOURCE_MTIME -gt $(( $GENERATED_MTIME + 10 ))
+if test "$SOURCE_MTIME" -gt $(( GENERATED_MTIME + 10 ))
 then
   echo
   tput setaf 3; tput bold; printf "Warning: "; tput sgr0

--- a/tools/ci/appveyor/appveyor_build.cmd
+++ b/tools/ci/appveyor/appveyor_build.cmd
@@ -85,7 +85,7 @@ set CYGWIN_UPGRADE_REQUIRED=0
 for %%P in (%CYGWIN_PACKAGES%) do call :CheckPackage %%P
 call :UpgradeCygwin
 
-"%CYG_ROOT%\bin\bash.exe" -lec "$APPVEYOR_BUILD_FOLDER/tools/ci/appveyor/appveyor_build.sh install" || exit /b 1
+"%CYG_ROOT%\bin\bash.exe" -lc "$APPVEYOR_BUILD_FOLDER/tools/ci/appveyor/appveyor_build.sh install" || exit /b 1
 
 goto :EOF
 
@@ -95,18 +95,18 @@ if "%PORT%" equ "msvc64" (
   call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
 )
 rem Do the main build (either msvc64 or mingw32)
-"%CYG_ROOT%\bin\bash.exe" -lec "$APPVEYOR_BUILD_FOLDER/tools/ci/appveyor/appveyor_build.sh" || exit /b 1
+"%CYG_ROOT%\bin\bash.exe" -lc "$APPVEYOR_BUILD_FOLDER/tools/ci/appveyor/appveyor_build.sh" || exit /b 1
 
 if "%PORT%" neq "msvc64" goto :EOF
 
 rem Reconfigure the environment and run the msvc32 partial build
 endlocal
 call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86
-"%CYG_ROOT%\bin\bash.exe" -lec "$APPVEYOR_BUILD_FOLDER/tools/ci/appveyor/appveyor_build.sh msvc32-only" || exit /b 1
+"%CYG_ROOT%\bin\bash.exe" -lc "$APPVEYOR_BUILD_FOLDER/tools/ci/appveyor/appveyor_build.sh msvc32-only" || exit /b 1
 goto :EOF
 
 :test
 rem Reconfigure the environment for the msvc64 build
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
-"%CYG_ROOT%\bin\bash.exe" -lec "$APPVEYOR_BUILD_FOLDER/tools/ci/appveyor/appveyor_build.sh test" || exit /b 1
+"%CYG_ROOT%\bin\bash.exe" -lc "$APPVEYOR_BUILD_FOLDER/tools/ci/appveyor/appveyor_build.sh test" || exit /b 1
 goto :EOF

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -23,9 +23,9 @@ function run {
     echo "-=-=- $NAME -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
     "$@"
     CODE=$?
-    if [ $CODE -ne 0 ]; then
+    if [[ $CODE -ne 0 ]] ; then
         echo "-=-=- $NAME failed! -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
-        if [ $BUILD_PID -ne 0 ] ; then
+        if [[ $BUILD_PID -ne 0 ]] ; then
           kill -KILL $BUILD_PID 2>/dev/null
           wait $BUILD_PID 2>/dev/null
         fi
@@ -83,7 +83,7 @@ case "$1" in
     for f in flexdll.h flexlink.exe flexdll*_msvc.obj default*.manifest ; do
       cp "$f" "$OCAMLROOT/bin/flexdll/"
     done
-    if [ "$PORT" = "msvc64" ] ; then
+    if [[ $PORT = 'msvc64' ]] ; then
       echo 'eval $($APPVEYOR_BUILD_FOLDER/tools/msvs-promote-path)' \
         >> ~/.bash_profile
     fi
@@ -93,26 +93,26 @@ case "$1" in
 
     set_configuration msvc "$OCAMLROOT-msvc32" -WX
 
-    run "make world" make world
-    run "make runtimeopt" make runtimeopt
-    run "make -C otherlibs/systhreads libthreadsnat.lib" \
+    run 'make world' make world
+    run 'make runtimeopt' make runtimeopt
+    run 'make -C otherlibs/systhreads libthreadsnat.lib' \
          make -C otherlibs/systhreads libthreadsnat.lib
 
     exit 0
     ;;
   test)
     FULL_BUILD_PREFIX="$APPVEYOR_BUILD_FOLDER/../$BUILD_PREFIX"
-    run "ocamlc.opt -version" "$FULL_BUILD_PREFIX-$PORT/ocamlc.opt" -version
+    run 'ocamlc.opt -version' "$FULL_BUILD_PREFIX-$PORT/ocamlc.opt" -version
     run "test $PORT" make -C "$FULL_BUILD_PREFIX-$PORT" tests
     run "install $PORT" make -C "$FULL_BUILD_PREFIX-$PORT" install
-    if [ "$PORT" = "msvc64" ] ; then
-      run "check_all_arches" make -C "$FULL_BUILD_PREFIX-$PORT" check_all_arches
+    if [[ $PORT = 'msvc64' ]] ; then
+      run 'check_all_arches' make -C "$FULL_BUILD_PREFIX-$PORT" check_all_arches
     fi
     ;;
   *)
     cd "$APPVEYOR_BUILD_FOLDER/../$BUILD_PREFIX-$PORT"
 
-    if [ "$PORT" = "msvc64" ] ; then
+    if [[ $PORT = 'msvc64' ]] ; then
       tar -xzf "$APPVEYOR_BUILD_FOLDER/flexdll.tar.gz"
       cd "flexdll-$FLEXDLL_VERSION"
       make MSVC_DETECT=0 CHAINS=msvc64 support
@@ -120,7 +120,7 @@ case "$1" in
       cd ..
     fi
 
-    if [ "$PORT" = "msvc64" ] ; then
+    if [[ $PORT = 'msvc64' ]] ; then
       set_configuration msvc64 "$OCAMLROOT" -WX
     else
       set_configuration mingw "$OCAMLROOT-mingw32" -Werror
@@ -130,7 +130,7 @@ case "$1" in
 
     export TERM=ansi
 
-    if [ "$PORT" = "mingw32" ] ; then
+    if [[ $PORT = 'mingw32' ]] ; then
       set -o pipefail
       # For an explanation of the sed command, see
       # https://github.com/appveyor/ci/issues/1824
@@ -141,10 +141,10 @@ case "$1" in
               -e 's/\d027\[m/\d027[0m/g' \
               -e 's/\d027\[01\([m;]\)/\d027[1\1/g'
     else
-      run "make world" make world
-      run "make bootstrap" make bootstrap
-      run "make opt" make opt
-      run "make opt.opt" make opt.opt
+      run 'make world' make world
+      run 'make bootstrap' make bootstrap
+      run 'make opt' make opt
+      run 'make opt.opt' make opt.opt
     fi
 
     ;;

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -60,7 +60,7 @@ function set_configuration {
 
     FILE=$(pwd | cygpath -f - -m)/Makefile.config
     echo "Edit $FILE to turn C compiler warnings into errors"
-    sed -i -e "/^ *OC_CFLAGS *=/s/\r\?$/ $3\0/" "$FILE"
+    sed -i -e '/^ *OC_CFLAGS *=/s/\r\?$/ '"$3"'\0/' "$FILE"
 #    run "Content of $FILE" cat Makefile.config
 }
 

--- a/tools/ci/travis/travis-ci.sh
+++ b/tools/ci/travis/travis-ci.sh
@@ -14,6 +14,8 @@
 #*                                                                        *
 #**************************************************************************
 
+set -e
+
 # TRAVIS_COMMIT_RANGE has the form   <commit1>...<commit2>
 # TRAVIS_CUR_HEAD is <commit1>
 # TRAVIS_PR_HEAD is <commit2>
@@ -28,11 +30,11 @@
 #        |          /
 #  TRAVIS_MERGE_BASE
 #
-echo TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE
-echo TRAVIS_COMMIT=$TRAVIS_COMMIT
+echo "TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE"
+echo "TRAVIS_COMMIT=$TRAVIS_COMMIT"
 if [[ $TRAVIS_EVENT_TYPE = "pull_request" ]] ; then
   FETCH_HEAD=$(git rev-parse FETCH_HEAD)
-  echo FETCH_HEAD=$FETCH_HEAD
+  echo "FETCH_HEAD=$FETCH_HEAD"
 else
   FETCH_HEAD=$TRAVIS_COMMIT
 fi
@@ -68,11 +70,11 @@ case $TRAVIS_EVENT_TYPE in
      DEEPEN=50
      while ! git merge-base $TRAVIS_CUR_HEAD $TRAVIS_PR_HEAD > /dev/null 2>&1
      do
-       echo Deepening $TRAVIS_BRANCH by $DEEPEN commits
+       echo "Deepening $TRAVIS_BRANCH by $DEEPEN commits"
        git fetch origin --deepen=$DEEPEN $TRAVIS_BRANCH
        ((DEEPEN*=2))
      done
-     TRAVIS_MERGE_BASE=$(git merge-base $TRAVIS_CUR_HEAD $TRAVIS_PR_HEAD);;
+     TRAVIS_MERGE_BASE=$(git merge-base "$TRAVIS_CUR_HEAD" "$TRAVIS_PR_HEAD");;
 esac
 
 BuildAndTest () {
@@ -114,7 +116,7 @@ EOF
   echo Running the testsuite with the normal runtime
   $MAKE all
   echo Running the testsuite with the debug runtime
-  $MAKE USE_RUNTIME="d" OCAMLTESTDIR=$(pwd)/_ocamltestd TESTLOG=_logd all
+  $MAKE USE_RUNTIME="d" OCAMLTESTDIR="$(pwd)/_ocamltestd" TESTLOG=_logd all
   cd ..
   $MAKE install
   echo Check the code examples in the manual
@@ -144,14 +146,14 @@ on the github pull request.
 ------------------------------------------------------------------------
 EOF
   # check that Changes has been modified
-  git diff $TRAVIS_MERGE_BASE..$TRAVIS_PR_HEAD --name-only --exit-code Changes \
-    > /dev/null && CheckNoChangesMessage || echo pass
+  git diff "$TRAVIS_MERGE_BASE..$TRAVIS_PR_HEAD" --name-only --exit-code \
+    Changes > /dev/null && CheckNoChangesMessage || echo pass
 }
 
 CheckNoChangesMessage () {
   API_URL=https://api.github.com/repos/$TRAVIS_REPO_SLUG/issues/$TRAVIS_PULL_REQUEST/labels
   if test -n "$(git log --grep="[Nn]o [Cc]hange.* needed" --max-count=1 \
-    ${TRAVIS_MERGE_BASE}..${TRAVIS_PR_HEAD})"
+    "${TRAVIS_MERGE_BASE}..${TRAVIS_PR_HEAD"})"
   then echo pass
   elif test -n "$(curl $API_URL | grep 'no-change-entry-needed')"
   then echo pass
@@ -191,7 +193,7 @@ does *not* imply that your change is appropriately tested.
 ------------------------------------------------------------------------
 EOF
   # check that at least a file in testsuite/ has been modified
-  git diff $TRAVIS_MERGE_BASE..$TRAVIS_PR_HEAD --name-only --exit-code \
+  git diff "$TRAVIS_MERGE_BASE..$TRAVIS_PR_HEAD" --name-only --exit-code \
     testsuite > /dev/null && exit 1 || echo pass
 }
 
@@ -267,7 +269,7 @@ CheckTypo () {
     fi
     if [ $CHECK_ALL_COMMITS -eq 1 ]
     then
-      for commit in $(git rev-list $TRAVIS_COMMIT_RANGE --reverse)
+      for commit in $(git rev-list "$TRAVIS_COMMIT_RANGE" --reverse)
       do
         CheckTypoTree $commit $commit
       done

--- a/tools/ci/travis/travis-ci.sh
+++ b/tools/ci/travis/travis-ci.sh
@@ -32,7 +32,7 @@ set -e
 #
 echo "TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE"
 echo "TRAVIS_COMMIT=$TRAVIS_COMMIT"
-if [[ $TRAVIS_EVENT_TYPE = "pull_request" ]] ; then
+if [[ $TRAVIS_EVENT_TYPE = 'pull_request' ]] ; then
   FETCH_HEAD=$(git rev-parse FETCH_HEAD)
   echo "FETCH_HEAD=$FETCH_HEAD"
 else
@@ -46,11 +46,11 @@ if [[ $TRAVIS_EVENT_TYPE = 'push' ]] ; then
   fi
 else
   if [[ $TRAVIS_COMMIT != $(git rev-parse FETCH_HEAD) ]] ; then
-    echo "WARNING! Travis TRAVIS_COMMIT and FETCH_HEAD do not agree!"
+    echo 'WARNING! Travis TRAVIS_COMMIT and FETCH_HEAD do not agree!'
     if git cat-file -e $TRAVIS_COMMIT 2> /dev/null ; then
-      echo "TRAVIS_COMMIT exists, so going with it"
+      echo 'TRAVIS_COMMIT exists, so going with it'
     else
-      echo "TRAVIS_COMMIT does not exist; setting to FETCH_HEAD"
+      echo 'TRAVIS_COMMIT does not exist; setting to FETCH_HEAD'
       TRAVIS_COMMIT=$FETCH_HEAD
     fi
   fi
@@ -100,7 +100,7 @@ EOF
     ;;
   i386)
     ./configure --build=x86_64-pc-linux-gnu --host=i386-pc-linux-gnu \
-      AS="as" ASPP="gcc -c" \
+      AS='as' ASPP='gcc -c' \
       $configure_flags
     ;;
   *)
@@ -116,7 +116,7 @@ EOF
   echo Running the testsuite with the normal runtime
   $MAKE all
   echo Running the testsuite with the debug runtime
-  $MAKE USE_RUNTIME="d" OCAMLTESTDIR="$(pwd)/_ocamltestd" TESTLOG=_logd all
+  $MAKE USE_RUNTIME='d' OCAMLTESTDIR="$(pwd)/_ocamltestd" TESTLOG=_logd all
   cd ..
   $MAKE install
   echo Check the code examples in the manual
@@ -152,10 +152,10 @@ EOF
 
 CheckNoChangesMessage () {
   API_URL=https://api.github.com/repos/$TRAVIS_REPO_SLUG/issues/$TRAVIS_PULL_REQUEST/labels
-  if test -n "$(git log --grep="[Nn]o [Cc]hange.* needed" --max-count=1 \
-    "${TRAVIS_MERGE_BASE}..${TRAVIS_PR_HEAD"})"
+  if [[ -n $(git log --grep='[Nn]o [Cc]hange.* needed' --max-count=1 \
+    "$TRAVIS_MERGE_BASE..$TRAVIS_PR_HEAD") ]]
   then echo pass
-  elif test -n "$(curl $API_URL | grep 'no-change-entry-needed')"
+  elif [[ -n $(curl "$API_URL" | grep 'no-change-entry-needed') ]]
   then echo pass
   else exit 1
   fi
@@ -200,7 +200,7 @@ EOF
 # Test to see if any part of the directory name has been marked prune
 not_pruned () {
   DIR=$(dirname "$1")
-  if [ "$DIR" = "." ] ; then
+  if [[ $DIR = '.' ]] ; then
     return 0
   else
     case ",$(git check-attr typo.prune "$DIR" | sed -e 's/.*: //')," in
@@ -218,7 +218,7 @@ not_pruned () {
 CheckTypoTree () {
   export OCAML_CT_HEAD=$1
   export OCAML_CT_LS_FILES="git diff-tree --no-commit-id --name-only -r $2 --"
-  export OCAML_CT_CAT="git cat-file --textconv"
+  export OCAML_CT_CAT='git cat-file --textconv'
   export OCAML_CT_PREFIX="$1:"
   GIT_INDEX_FILE=tmp-index git read-tree --reset -i $1
   git diff-tree --diff-filter=d --no-commit-id --name-only -r $2 \
@@ -238,10 +238,10 @@ CheckTypoTree () {
     esac
   done)
   rm -f tmp-index
-  if [ -e CHECK_CONFIGURE ] ; then
+  if [[ -e CHECK_CONFIGURE ]] ; then
     rm -f CHECK_CONFIGURE
     echo "configure generation altered in $1"
-    echo "Verifying that configure.ac generates configure"
+    echo 'Verifying that configure.ac generates configure'
     git checkout "$1"
     mv configure configure.ref
     ./autogen
@@ -256,32 +256,32 @@ please run ./autogen and commit"
 CHECK_ALL_COMMITS=0
 
 CheckTypo () {
-  export OCAML_CT_GIT_INDEX="tmp-index"
-  export OCAML_CT_CA_FLAG="--cached"
+  export OCAML_CT_GIT_INDEX='tmp-index'
+  export OCAML_CT_CA_FLAG='--cached'
   # Work around an apparent bug in Ubuntu 12.4.5
   # See https://bugs.launchpad.net/ubuntu/+source/gawk/+bug/1647879
   rm -f check-typo-failed
-  if test -z "$TRAVIS_COMMIT_RANGE"
+  if [[ -z $TRAVIS_COMMIT_RANGE ]]
   then CheckTypoTree $TRAVIS_COMMIT $TRAVIS_COMMIT
   else
-    if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]
+    if [[ $TRAVIS_EVENT_TYPE = 'pull_request' ]]
     then TRAVIS_COMMIT_RANGE=$TRAVIS_MERGE_BASE..$TRAVIS_PULL_REQUEST_SHA
     fi
-    if [ $CHECK_ALL_COMMITS -eq 1 ]
+    if [[ $CHECK_ALL_COMMITS -eq 1 ]]
     then
       for commit in $(git rev-list "$TRAVIS_COMMIT_RANGE" --reverse)
       do
         CheckTypoTree $commit $commit
       done
     else
-      if [ -z "$TRAVIS_PULL_REQUEST_SHA" ]
+      if [[ -z $TRAVIS_PULL_REQUEST_SHA ]]
       then CheckTypoTree $TRAVIS_COMMIT $TRAVIS_COMMIT
       else CheckTypoTree $TRAVIS_COMMIT $TRAVIS_COMMIT_RANGE
       fi
     fi
   fi
   echo complete
-  if [ -e check-typo-failed ]
+  if [[ -e check-typo-failed ]]
   then exit 1
   fi
 }

--- a/tools/make-version-header.sh
+++ b/tools/make-version-header.sh
@@ -44,12 +44,12 @@ patchlvl="`echo "$version" | sed -n -e '1s/^[0-9]*\.[0-9]*\.\([0-9]*\).*/\1/p'`"
 suffix="`echo "$version" | sed -n -e '1s/^[^+]*+\(.*\)/\1/p'`"
 
 echo "#define OCAML_VERSION_MAJOR $major"
-printf "#define OCAML_VERSION_MINOR %d\n" "$minor"
+printf '#define OCAML_VERSION_MINOR %d\n' "$minor"
 case $patchlvl in "") patchlvl=0;; esac
 echo "#define OCAML_VERSION_PATCHLEVEL $patchlvl"
 case "$suffix" in
   "") echo "#undef OCAML_VERSION_ADDITIONAL";;
   *) echo "#define OCAML_VERSION_ADDITIONAL \"$suffix\"";;
 esac
-printf "#define OCAML_VERSION %d%02d%02d\n" "$major" "$minor" "$patchlvl"
+printf '#define OCAML_VERSION %d%02d%02d\n' "$major" "$minor" "$patchlvl"
 echo "#define OCAML_VERSION_STRING \"$version\""

--- a/tools/make-version-header.sh
+++ b/tools/make-version-header.sh
@@ -33,7 +33,7 @@
 
 case $# in
   0) version="`ocamlc -v | tr -d '\r' | sed -n -e 's/.*version //p'`";;
-  1) version="`sed -e 1q $1 | tr -d '\r'`";;
+  1) version="`sed -e 1q "$1" | tr -d '\r'`";;
   *) echo "usage: make-version-header.sh [version-file]" >&2
      exit 2;;
 esac
@@ -44,12 +44,12 @@ patchlvl="`echo "$version" | sed -n -e '1s/^[0-9]*\.[0-9]*\.\([0-9]*\).*/\1/p'`"
 suffix="`echo "$version" | sed -n -e '1s/^[^+]*+\(.*\)/\1/p'`"
 
 echo "#define OCAML_VERSION_MAJOR $major"
-printf "#define OCAML_VERSION_MINOR %d\n" $minor
+printf "#define OCAML_VERSION_MINOR %d\n" "$minor"
 case $patchlvl in "") patchlvl=0;; esac
 echo "#define OCAML_VERSION_PATCHLEVEL $patchlvl"
 case "$suffix" in
   "") echo "#undef OCAML_VERSION_ADDITIONAL";;
   *) echo "#define OCAML_VERSION_ADDITIONAL \"$suffix\"";;
 esac
-printf "#define OCAML_VERSION %d%02d%02d\n" $major $minor $patchlvl
+printf "#define OCAML_VERSION %d%02d%02d\n" "$major" "$minor" "$patchlvl"
 echo "#define OCAML_VERSION_STRING \"$version\""


### PR DESCRIPTION
Hi,

I fixed some stuff spotted using: `find -O3 . -type f -name '*.sh' -exec shellcheck -x  {} \;`.

Some warnings are remaining:

```sh
In ./.travis-ci.sh line 59:
      -with-instrumented-runtime $CONFIG_ARG
                                 ^-- SC2086: Double quote to prevent globbing and word splitting.


In ./.travis-ci.sh line 63:
      -with-instrumented-runtime $CONFIG_ARG \
                                 ^-- SC2086: Double quote to prevent globbing and word splitting.


In ./appveyor_build.sh line 68:
    echo 'eval $($APPVEYOR_BUILD_FOLDER/tools/msvs-promote-path)' >> ~/.bash_profile
         ^-- SC2016: Expressions don't expand in single quotes, use double quotes for that.
```

I believe the first and the second are false positives, as I guess that `$CONFIG_ARG` contains many arguments. We could instead use an array which is probably the best solution, or juste leave it like this.

For the third, it's definitively a false positive.

I can also add a comment like: `# shellcheck disable=SCxxxx` before each of them, to specifically disable these checks on these lines. Which would ease the process of checking again for some issues later.

Cheers,