### PR TITLE
Export SUPPORTS_SHARED_LIBRARIES in ocamlc -config

### DIFF
--- a/Changes
+++ b/Changes
@@ -122,6 +122,10 @@ Working version
   (Gabriel Scherer, review by Sébastien Hinderer and David Allsopp,
    request by Adrien Nader)
 
+- GPR#1691: add shared_libraries to ocamlc -config exporting
+  SUPPORTS_SHARED_LIBRARIES from Makefile.config.
+  (David Allsopp, review by Gabriel Scherer and Mark Shinwell)
+
 - GPR#1733: change the perspective of the unexpected existential error message.
   (Florian Angeletti, review by Gabriel Scherer and Jeremy Yallop)
 

--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,7 @@ utils/config.ml: utils/config.mlp config/Makefile Makefile
 	    $(call SUBST,FORCE_SAFE_STRING) \
 	    $(call SUBST,DEFAULT_SAFE_STRING) \
 	    $(call SUBST,WINDOWS_UNICODE) \
+	    $(call SUBST,SUPPORTS_SHARED_LIBRARIES) \
 	    $(call SUBST,SYSTEM) \
 	    $(call SUBST,SYSTHREAD_SUPPORT) \
 	    $(call SUBST,TARGET) \

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -79,6 +79,7 @@ let with_flambda_invariants = %%WITH_FLAMBDA_INVARIANTS%%
 let safe_string = %%FORCE_SAFE_STRING%%
 let default_safe_string = %%DEFAULT_SAFE_STRING%%
 let windows_unicode = %%WINDOWS_UNICODE%% != 0
+let supports_shared_libraries = %%SUPPORTS_SHARED_LIBRARIES%%
 
 let flat_float_array = %%FLAT_FLOAT_ARRAY%%
 
@@ -205,6 +206,7 @@ let configuration_variables =
   p_bool "flat_float_array" flat_float_array;
   p_bool "afl_instrument" afl_instrument;
   p_bool "windows_unicode" windows_unicode;
+  p_bool "supports_shared_libraries" supports_shared_libraries;
 
   p "exec_magic_number" exec_magic_number;
   p "cmi_magic_number" cmi_magic_number;


### PR DESCRIPTION
Exposes `SUPPORTS_SHARED_LIBRARIES` from `Makefile.config` as `shared_libraries` in `ocamlc -config`