### PR TITLE
MPR#7663: reword unsafe recursive modules message

### DIFF
--- a/Changes
+++ b/Changes
@@ -96,9 +96,9 @@ Working version
 
 ### Compiler user-interface and warnings:
 
-- MPR#7663: print the whole cycle and add a reference to the manual in
+- MPR#7663, GPR#1694: print the whole cycle and add a reference to the manual in
   the unsafe recursive module evaluation error message.
-  (Florian Angeletti, review by Gabriel Scherer)
+  (Florian Angeletti, report by Matej Košík, review by Gabriel Scherer)
 
 - GPR#1166: In OCAMLPARAM, an alternative separator can be specified as
   first character (instead of comma) in the set ":|; ,"

--- a/Changes
+++ b/Changes
@@ -96,6 +96,10 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- MPR#7663: print the whole cycle and add a reference to the manual in
+  the unsafe recursive module evaluation error message.
+  (Florian Angeletti)
+
 - GPR#1166: In OCAMLPARAM, an alternative separator can be specified as
   first character (instead of comma) in the set ":|; ,"
   (Fabrice Le Fessant)

--- a/Changes
+++ b/Changes
@@ -98,7 +98,7 @@ Working version
 
 - MPR#7663: print the whole cycle and add a reference to the manual in
   the unsafe recursive module evaluation error message.
-  (Florian Angeletti)
+  (Florian Angeletti, review by Gabriel Scherer)
 
 - GPR#1166: In OCAMLPARAM, an alternative separator can be specified as
   first character (instead of comma) in the set ":|; ,"

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -258,6 +258,9 @@ let extract_unsafe_cycle id status cycle_start =
     | Inprogress Some i when i = stop -> id.(i) :: l
     | Inprogress Some i -> collect stop (id.(i)::l) i in
   collect cycle_start [id.(cycle_start)] cycle_start
+(* This yields [cycle_start; ...; cycle_start]. The start of the cycle
+   is duplicated to make the cycle more visible in the corresponding error
+   message. *)
 
 let reorder_rec_bindings bindings =
   let id = Array.of_list (List.map (fun (id,_,_,_) -> id) bindings)

--- a/bytecomp/translmod.mli
+++ b/bytecomp/translmod.mli
@@ -43,7 +43,7 @@ val nat_toplevel_name: Ident.t -> Ident.t * int
 val primitive_declarations: Primitive.description list ref
 
 type error =
-  Circular_dependency of Ident.t
+  Circular_dependency of Ident.t list
 | Conflicting_inline_attributes
 
 exception Error of Location.t * error

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -199,7 +199,19 @@ module expressions are then evaluated, and the initial values
 for the safe modules are replaced by the values thus computed.  If a
 function component of a safe module is applied during this computation
 (which corresponds to an ill-founded recursive definition), the
-"Undefined_recursive_module" exception is raised.
+"Undefined_recursive_module" exception is raised at runtime:
+
+\begin{caml_example}{verbatim}
+module rec M: sig val f: unit -> int end = struct let f () = N.x end
+and N:sig val x: int end = struct let x = M.f () end
+\end{caml_example}
+
+If there are no safe modules along a dependency cycle, an error is raised
+
+\begin{caml_example}{verbatim}[error]
+module rec M: sig val x: int end = struct let x = N.y end
+and N:sig val x: int val y:int end = struct let x = M.x let y = 0 end
+\end{caml_example}
 
 Note that, in the @specification@ case, the @module-type@s must be
 parenthesized if they use the @'with' mod-constraint@ construct.

--- a/manual/tests/Makefile
+++ b/manual/tests/Makefile
@@ -13,7 +13,8 @@ cross-reference-checker: cross_reference_checker.ml
 check-cross-references: cross-reference-checker
 	$(OCAMLRUN) ./cross-reference-checker \
 	-auxfile $(MANUAL)/texstuff/manual.aux \
-        $(TOPDIR)/utils/warnings.ml
+        $(TOPDIR)/utils/warnings.ml \
+	$(TOPDIR)/bytecomp/translmod.ml
 
 check-stdlib:
 	./check-stdlib-modules $(TOPDIR)

--- a/testsuite/tests/basic-modules/ocamltests
+++ b/testsuite/tests/basic-modules/ocamltests
@@ -1,1 +1,2 @@
 main.ml
+recursive_module_evaluation_errors.ml

--- a/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
+++ b/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
@@ -1,0 +1,22 @@
+(* TEST
+   * expect
+*)
+
+module rec A: sig val x: int end = struct let x = B.y end
+and B:sig val x: int val y:int end = struct let x = C.x let y = 0 end
+and C:sig val x: int end = struct let x = B.y end ;;
+[%%expect {|
+Line _, characters 37-69:
+  and B:sig val x: int val y:int end = struct let x = C.x let y = 0 end
+                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Cannot safely evaluate the definition of the following cycle
+       of recursively-defined modules: B -> C -> B.
+       There are no safe modules in this cycle (see manual section 8.4)
+|}]
+
+module rec M: sig val f: unit -> int end = struct let f () = N.x end
+and N:sig val x: int end = struct let x = M.f () end;;
+[%%expect {|
+Exception: Undefined_recursive_module ("", 1, 43).
+|}]
+

--- a/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
+++ b/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
@@ -2,15 +2,17 @@
    * expect
 *)
 
-module rec A: sig val x: int end = struct let x = B.y end
-and B:sig val x: int val y:int end = struct let x = C.x let y = 0 end
-and C:sig val x: int end = struct let x = B.y end ;;
+module rec A: sig val x: int end = struct let x = B.x end
+and B:sig val x: int end = struct let x = E.y end
+and C:sig val x: int end = struct let x = B.x end
+and D:sig val x: int end = struct let x = C.x end
+and E:sig val x: int val y:int end = struct let x = D.x let y = 0 end
 [%%expect {|
-Line _, characters 37-69:
-  and B:sig val x: int val y:int end = struct let x = C.x let y = 0 end
-                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line _, characters 27-49:
+  and B:sig val x: int end = struct let x = E.y end
+                             ^^^^^^^^^^^^^^^^^^^^^^
 Error: Cannot safely evaluate the definition of the following cycle
-       of recursively-defined modules: B -> C -> B.
+       of recursively-defined modules: B -> E -> D -> C -> B.
        There are no safe modules in this cycle (see manual section 8.4)
 |}]
 


### PR DESCRIPTION
This PR proposes to reword the error message raised when a recursive module cycle cannot be safely evaluated and add  few examples in the corresponding part of the manual. Currently, trying to compile this example

```OCaml
module rec A: sig val x: int end = struct let x = B.y end
and B:sig val x: int val y:int end = struct let x = C.x let y = 0 end
and C:sig val x: int end = struct let x = B.y end ;;
```
yields
> Error: Cannot safely evaluate the definition
       of the recursively-defined module B


As reported in [MPR#7633](https://caml.inria.fr/mantis/view.php?id=7663), an user then would have to guess that this unsafe evaluation error relates to the safe modules described inside the recursive module section of the manual. The aim of this PR is to make this connection more evident, by rewording the  previous error message as

> Error: Cannot safely evaluate the definition of the following cycle
       of recursively-defined modules: B -> C -> B.
       There are no safe modules in this cycle (see manual section 8.4)

 In this reworded message, the notion of safe module appears explicitly, even if their descriptions is relegated to the manual ( using the fact that there is now a tool for testing the consistency of such references). Moreover, the error is assigned to the cycle rather than a single module.

To complement this new error message, the recursive module section of the manual has been extended with one example of unsafe cycle and another example of unfounded recursion raising an `Undefined_recursive_module` exception at runtime.

And since this error message was not exercised by the test suite, I added these two examples to the `basic-modules` tests.
