### PR TITLE
Perform case-sensitive search for files to prevent accidental .cmi shadowing

### DIFF
--- a/Changes
+++ b/Changes
@@ -156,6 +156,11 @@ Working version
   emitted by the bytecode compiler appear more in-order than before.
   (Luc Maranget, advice and review by Damien Doligez)
 
+- GPR#1696: perform case-sensitive search for files, even on case-insensitive
+  file/operating systems (allows, for example, uChar.cmi in one directory not to
+  shadow uchar.cmi in a directory further down the search path).
+  (David Allsopp, review by ?)
+
 ### Code generation and optimizations:
 
 - GPR#1370: Fix code duplication in Cmmgen

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -558,6 +558,7 @@ let loop ppf =
       Lexing.flush_input lb;
       Location.reset();
       first_line := true;
+      Misc.reset_find_cache ();
       let phr = try !parse_toplevel_phrase lb with Exit -> raise PPerror in
       let phr = preprocess_phrase ppf phr  in
       Env.reset_cache_toplevel ();

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -532,6 +532,7 @@ let loop ppf =
       Location.reset();
       Warnings.reset_fatal ();
       first_line := true;
+      Misc.reset_find_cache ();
       let phr = try !parse_toplevel_phrase lb with Exit -> raise PPerror in
       let phr = preprocess_phrase ppf phr  in
       Env.reset_cache_toplevel ();

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -220,7 +220,11 @@ let find_in_path path name =
     let rec try_dir = function
       [] -> raise Not_found
     | dir::rem ->
-        if really_exists dir name then Filename.concat dir name else try_dir rem
+        let name = Filename.concat dir name in
+        if really_exists (Filename.dirname name) (Filename.basename name) then
+          name
+        else
+          try_dir rem
     in try_dir path
   end
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -99,6 +99,8 @@ module Stdlib : sig
   end
 end
 
+val reset_find_cache: unit -> unit
+        (* Allows the toploop to spot new files created between phrases. *)
 val find_in_path: string list -> string -> string
         (* Search a file in a list of directories. *)
 val find_in_path_rel: string list -> string -> string


### PR DESCRIPTION
When a file-system is set to be case-insensitive, it is possible for a .cmi file to shadow another .cmi file further down the search path (for example, a `uChar.cmi` can shadow the standard library's `uchar.cmi`). This is a long-standing problem on both Windows and macOS.

This changes the search to be based on `Sys.readdir` instead of `Sys.file_exists` with a cache to prevent too many calls to the function.

An escape switch `Misc.reset_find_cache` allows the toplevel to clear this cache before each phrase is parsed, meaning that a long-lived toploop can still see changes made externally.

I've taken the view that any use of those Misc.find_ functions can be safely switched to be case-sensitive, given that in so many instances it's necessary for the case of the filename to be correct for it to be used anyway.

I've gone through places in the codebase where `Sys.file_exists` is used directly and identified a few where `Misc.really_exists` should probably be used instead, but I'd like the implementation as it stands now to be reviewed before extending it to this.

This GPR means that Unix and Windows/macOS now behave the same way when presented with `FOo.ml` containing `let answer = 42` and `Bar.ml` containing `print_int Foo.answer` when running `ocamlc -c FOo.ml Bar.ml` in that both now display:

```
File "Bar.ml", line 1, characters 29-39:
Error: Unbound module Foo
```
where before Windows and macOS would display:
```
File "Bar.ml", line 1:
Error: Wrong file naming: foo.cmi contains the compiled interface for
FOo when Foo was expected
```