### PR TITLE
Ensure `with module` and `with type` do not weaken module aliases (MPR#7723)

### DIFF
--- a/Changes
+++ b/Changes
@@ -217,6 +217,10 @@ Working version
 - MPR#7726, GPR#1676: Recursive modules, equi-recursive types and stack overflow
   (Jacques Garrigue, report by Jeremy Yallop, review by Leo White)
 
+- MPR#7723, GPR#1698: Ensure `with module` and `with type` do not weaken
+  module aliases.
+  (Leo White, review by Gabriel Radanne and Jacques Garrigue)
+
 - GPR#1719: fix Pervasives.LargeFile functions under Windows.
   (Alain Frisch)
 

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -192,7 +192,7 @@ end with type M2.t = int
 module type S =
   sig
     module M1 : sig type t = int end
-    module M2 : sig type t = int end
+    module M2 = M1
     module M3 : sig module M = M2 end
     module F : functor (X : sig module M = M1 end) -> sig type t end
     type t = F(M3).t

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -217,7 +217,7 @@ end = struct
 end;;
 [%%expect {|
 type (_, _) eq = Refl : ('a, 'a) eq
-Line _, characters 18-58:
+Line 11, characters 18-58:
     module type T = S with type N.t = M.t with module N := N;;
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this `with' constraint, the new definition of N

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -478,10 +478,20 @@ let merge_constraint initial_env remove_aliases loc sg constr =
         real_ids := [Pident id];
         (Pident id, lid, Twith_modsubst (path, lid')),
         update_rec_next rs rem
+    | (Sig_module(id, ({md_type = Mty_alias _} as md), _) as item :: rem,
+       s :: namelist, (Pwith_module _ | Pwith_type _))
+      when Ident.name id = s ->
+        let ((path, _, tcstr), _) =
+          merge env (extract_sig env loc md.md_type) namelist None
+        in
+        let path = path_concat id path in
+        real_ids := path :: !real_ids;
+        (path, lid, tcstr), item :: rem
     | (Sig_module(id, md, rs) :: rem, s :: namelist, _)
       when Ident.name id = s ->
         let ((path, _path_loc, tcstr), newsg) =
-          merge env (extract_sig env loc md.md_type) namelist None in
+          merge env (extract_sig env loc md.md_type) namelist None
+        in
         let path = path_concat id path in
         real_ids := path :: !real_ids;
         let item = Sig_module(id, {md with md_type=Mty_signature newsg}, rs) in


### PR DESCRIPTION
This fixes [MPR#7723](https://caml.inria.fr/mantis/view.php?id=7723) by ensuring that `with module .. =` and `with type .. =` do not weaken module aliases. For example:

```ocaml
module M = struct type t end

module type S = sig module N = M end

module type T = S with type N.t = M.t
```

will now give:

```ocaml
module type T = sig module N = M end
```

instead of:

```ocaml
module type T = sig module N : sig type t = M.t end end
```