### PR TITLE
cleanup stdlib documentation makefiles

### DIFF
--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -44,7 +44,7 @@ index::
 # Copy and unprefix the standard library when needed
 include $(SRC)/ocamldoc/Makefile.unprefix
 
-html: files $(STDLIB_CMIS)
+html: files
 	cd htmlman; \
 	mkdir -p libref ; \
 	$(OCAMLDOC) -colorize-code -sort -html \
@@ -77,7 +77,8 @@ etex-files: $(FILES)
 	cd cmds; $(MAKE) etex-files RELEASEDIR=$(SRC)
 	cd tutorials; $(MAKE) etex-files RELEASEDIR=$(SRC)
 
-files: $(FILES)
+files: $(FILES) $(STDLIB_MLIS)
+	$(MAKE) unprefix_stdlib_for_ocamldoc
 	cd refman; $(MAKE) all RELEASEDIR=$(SRC)
 	cd library; $(MAKE) all RELEASEDIR=$(SRC)
 	cd cmds; $(MAKE) all RELEASEDIR=$(SRC)

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -388,13 +388,15 @@ test_texi:
 SRC=$(ROOTDIR)
 include Makefile.unprefix
 
-stdlib_man/Pervasives.3o: $(OCAMLDOC) $(STDLIB_MLIS) $(STDLIB_CMIS)
+stdlib_man/Pervasives.3o: $(OCAMLDOC) $(STDLIB_MLIS)
+	$(MAKE) unprefix_stdlib_for_ocamldoc
 	$(MKDIR) stdlib_man
 	$(OCAMLDOC_RUN) -man -d stdlib_man -nostdlib -I stdlib_non_prefixed \
 	-t "OCaml library" -man-mini $(STDLIB_MLIS) \
 	-initially-opened-module Pervasives
 
-stdlib_html/Pervasives.html: $(OCAMLDOC) $(STDLIB_MLIS) $(STDLIB_CMIS)
+stdlib_html/Pervasives.html: $(OCAMLDOC) $(STDLIB_MLIS)
+	$(MAKE) unprefix_stdlib_for_ocamldoc
 	$(MKDIR) stdlib_html
 	$(OCAMLDOC_RUN) -d stdlib_html -html -nostdlib -I stdlib_non_prefixed \
 	-t "OCaml library" $(STDLIB_MLIS) \

--- a/ocamldoc/Makefile.unprefix
+++ b/ocamldoc/Makefile.unprefix
@@ -98,5 +98,6 @@ $(STDLIB_UNPREFIXED)/pervasives.mli: $(SRC)/stdlib/stdlib.mli $(STDLIB_UNPREFIXE
 	$(AWK) -f $(STDLIB_UNPREFIXED)/extract_pervasives.awk $< > $@
 
 # Build cmis file inside the STDLIB_UNPREFIXED directories
-$(STDLIB_CMIS): $(STDLIB_DEPS)
-	cd $(STDLIB_UNPREFIXED); $(MAKE) $(notdir $(STDLIB_CMIS))
+.PHONY: unprefix_stdlib_for_ocamldoc
+unprefix_stdlib_for_ocamldoc: $(STDLIB_MLIS) $(STDLIB_DEPS)
+	@$(MAKE) -C $(STDLIB_UNPREFIXED) $(notdir $(STDLIB_CMIS))

--- a/ocamldoc/stdlib_non_prefixed/Makefile
+++ b/ocamldoc/stdlib_non_prefixed/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/Makefile.tools
 .SUFFIXES:
 
 OCAMLDEP= $(OCAMLRUN) $(TOPDIR)/tools/ocamldep -slash
-OCAMLC_SNP= $(OCAMLRUN) $(TOPDIR)/ocamlc -nostdlib -nopervasives -I $(HERE)
+OCAMLC_SNP= $(OCAMLRUN) $(TOPDIR)/ocamlc -nostdlib -nopervasives
 
 pervasives.cmi: pervasives.mli camlinternalFormatBasics.cmi
 	$(OCAMLC_SNP) -c $<


### PR DESCRIPTION
This PR cleans up some of the Makefiles used to generate the ocamldoc documentation for the standard library: it removes an undefined variable, and rewrite a rule to avoid building the unprefixed cmi files over and over and over when doing a parallel make.