### PR TITLE
Spellchecker hints and type-directed disambiguation for extensible variants: bis

### DIFF
--- a/Changes
+++ b/Changes
@@ -24,6 +24,12 @@ Working version
   (Gabriel Scherer and Rodolphe Lepigre,
    review by Jeremy Yallop, Damien Doligez and Frédéric Bour)
 
+- #1154, #1706: spellchecker hints and type-directed disambiguation
+  for extensible sum type constructors
+  (Florian Angeletti, review by Alain Frisch, Gabriel Radanne, Gabriel Scherer
+  and Leo White)
+
+
 ### Runtime system:
 
 - #9119: Make [caml_stat_resize_noexc] compatible with the [realloc]

--- a/testsuite/tests/typing-extensions/disambiguation.ml
+++ b/testsuite/tests/typing-extensions/disambiguation.ml
@@ -1,0 +1,248 @@
+(* TEST
+   * expect
+*)
+(** Test type-directed disambiguation and spellchecker hints *)
+
+type t = ..
+type t += Alpha | Aleph
+
+module M = struct
+  type w = ..
+  type w += Alpha | Beta ;;
+  type t += Beth
+end;;
+
+module F(X:sig end) = struct type u = .. type t += Gamma type u += Gamme end;;
+module X = struct end;;
+[%%expect {|
+type t = ..
+type t += Alpha | Aleph
+module M : sig type w = .. type w += Alpha | Beta type t += Beth end
+module F :
+  functor (X : sig end) ->
+    sig type u = .. type t += Gamma type u += Gamme end
+module X : sig end
+|}]
+
+let x: t = Alph;;
+[%%expect {|
+Line 1, characters 11-15:
+1 | let x: t = Alph;;
+               ^^^^
+Error: This variant expression is expected to have type t
+       The constructor Alph does not belong to type t
+Hint: Did you mean Aleph or Alpha?
+|}]
+
+open M;;
+let y : w = Alha;;
+[%%expect {|
+Line 2, characters 12-16:
+2 | let y : w = Alha;;
+                ^^^^
+Error: This variant expression is expected to have type M.w
+       The constructor Alha does not belong to type M.w
+Hint: Did you mean Alpha?
+|}]
+
+let z: t = Bet;;
+[%%expect {|
+Line 1, characters 11-14:
+1 | let z: t = Bet;;
+               ^^^
+Error: This variant expression is expected to have type t
+       The constructor Bet does not belong to type t
+Hint: Did you mean Beth?
+|}]
+
+
+module N = F(X);;
+open N
+let g = (Gamm:t);;
+[%%expect {|
+module N : sig type u = F(X).u = .. type t += Gamma type u += Gamme end
+Line 3, characters 9-13:
+3 | let g = (Gamm:t);;
+             ^^^^
+Error: This variant expression is expected to have type t
+       The constructor Gamm does not belong to type t
+Hint: Did you mean Gamma?
+|}];;
+
+raise Not_Found;;
+[%%expect {|
+Line 1, characters 6-15:
+1 | raise Not_Found;;
+          ^^^^^^^^^
+Error: This variant expression is expected to have type exn
+       The constructor Not_Found does not belong to type exn
+Hint: Did you mean Not_found?
+|}]
+
+(** Aliasing *)
+type r = ..;;
+module M = struct
+  type t = r = ..
+  type s = t = ..
+  module N = struct
+    type u = s = ..
+    type u += Foo
+  end
+end
+open M.N;;
+
+type exn += Foo;;
+
+let x : r = Foo;;
+[%%expect {|
+type r = ..
+module M :
+  sig
+    type t = r = ..
+    type s = t = ..
+    module N : sig type u = s = .. type u += Foo end
+  end
+type exn += Foo
+val x : r = M.N.Foo
+|}]
+
+(** Closed open extensible type support *)
+
+module M : sig
+  type t = private ..
+  type t += Aleph
+end = struct
+  type t = ..
+  type t += Aleph
+end;;
+open M;;
+
+type exn += Aleph ;;
+[%%expect {|
+module M : sig type t = private .. type t += Aleph end
+type exn += Aleph
+|}]
+
+let x : t = Aleph;;
+[%%expect {|
+val x : M.t = M.Aleph
+|}]
+
+module F(X: sig type t = .. end ) = struct type X.t+= Beth end
+module X = struct type t = .. end
+module FX = F(X) open FX
+type exn += Beth;;
+let x : X.t = Beth;;
+[%%expect {|
+module F : functor (X : sig type t = .. end) -> sig type X.t += Beth end
+module X : sig type t = .. end
+module FX : sig type X.t += Beth end
+type exn += Beth
+val x : X.t = <extension>
+|}]
+
+(** Aliasing *)
+
+type x = ..
+type x += Alpha
+module P = struct type p = x end
+
+let x: P.p = Alha;;
+[%%expect {|
+type x = ..
+type x += Alpha
+module P : sig type p = x end
+Line 7, characters 13-17:
+7 | let x: P.p = Alha;;
+                 ^^^^
+Error: This variant expression is expected to have type P.p
+       The constructor Alha does not belong to type x
+Hint: Did you mean Alpha?
+|}]
+
+module M = struct type t = .. type t += T end
+module N = struct type s = M.t end
+let y: N.s = T ;;
+[%%expect {|
+module M : sig type t = .. type t += T end
+module N : sig type s = M.t end
+Line 3, characters 13-14:
+3 | let y: N.s = T ;;
+                 ^
+Error: This variant expression is expected to have type N.s
+       The constructor T does not belong to type M.t
+|}]
+
+(** Pattern matching *)
+type x = ..
+type x += A | B
+type u = A | B
+module M = struct type y = .. type y+= A|B end
+open M
+let f: x -> int = function A -> 1 | B -> 2 | _ -> 0;;
+[%%expect {|
+type x = ..
+type x += A | B
+type u = A | B
+module M : sig type y = .. type y += A | B  end
+val f : x -> int = <fun>
+|}]
+
+(** Local exception *)
+let x =
+  let exception Local in
+  raise Locl;;
+[%%expect {|
+Line 3, characters 8-12:
+3 |   raise Locl;;
+            ^^^^
+Error: This variant expression is expected to have type exn
+       The constructor Locl does not belong to type exn
+Hint: Did you mean Local?
+|}]
+
+let x =
+  let exception Local in
+  let module M = struct type t = .. type t+= Local end in
+  let open M in
+  (Local:exn);;
+[%%expect{|
+val x : exn = Local
+|}
+]
+
+(** Path capture *)
+module M = struct type t = .. type t += T end
+open M
+let f = (=) M.T
+module M = struct type t = .. type t += S end
+open M
+let y = f T ;;
+[%%expect {|
+module M : sig type t = .. type t += T end
+val f : M.t -> bool = <fun>
+module M : sig type t = .. type t += S end
+val y : bool = true
+|}]
+
+(** Amniguity warning *)
+[@@@warning "+41"];;
+type a = Unique
+type t = ..
+type t += Unique
+module M = struct type s = .. type s+= Unique end open M
+type b = Unique
+let x = Unique;;
+[%%expect {|
+type a = Unique
+type t = ..
+type t += Unique
+module M : sig type s = .. type s += Unique end
+type b = Unique
+Line 7, characters 8-14:
+7 | let x = Unique;;
+            ^^^^^^
+Warning 41: Unique belongs to several types: b M.s t a
+The first one was selected. Please disambiguate if this is wrong.
+val x : b = Unique
+|}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2377,23 +2377,10 @@ let lookup_all_ident_labels ~errors ~use ~loc s env =
         lbls
     end
 
-(* Drop all extension constructors *)
-let drop_exts cstrs =
-  List.filter (fun (cda, _) -> not (is_ext cda)) cstrs
-
-(* Only keep the latest extension constructor *)
-let rec filter_shadowed_constructors cstrs =
-  match cstrs with
-  | (cda, _) as hd :: tl ->
-      if is_ext cda then hd :: drop_exts tl
-      else hd :: filter_shadowed_constructors tl
-  | [] -> []
-
 let lookup_all_ident_constructors ~errors ~use ~loc usage s env =
   match TycompTbl.find_all ~mark:use s env.constrs with
   | [] -> may_lookup_error errors loc env (Unbound_constructor (Lident s))
   | cstrs ->
-      let cstrs = filter_shadowed_constructors cstrs in
       List.map
         (fun (cda, use_fn) ->
            let use_fn () =

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -428,6 +428,13 @@ val print_longident: (Format.formatter -> Longident.t -> unit) ref
 (* Forward declaration to break mutual recursion with Printtyp. *)
 val print_path: (Format.formatter -> Path.t -> unit) ref
 
+
+(** Folds *)
+
+val fold_constructors:
+  (constructor_description -> 'a -> 'a) ->
+  Longident.t option -> t -> 'a -> 'a
+
 (** Utilities *)
 val scrape_alias: t -> module_type -> module_type
 val check_value_name: string -> Location.t -> unit

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -596,6 +596,11 @@ let compare_type_path env tpath1 tpath2 =
 (* Records *)
 exception Wrong_name_disambiguation of Env.t * wrong_name
 
+let get_constr_type_path ty =
+  match (repr ty).desc with
+  | Tconstr(p, _, _) -> p
+  | _ -> assert false
+
 module NameChoice(Name : sig
   type t
   type usage
@@ -612,10 +617,7 @@ module NameChoice(Name : sig
 end) = struct
   open Name
 
-  let get_type_path d =
-    match (repr (get_type d)).desc with
-    | Tconstr(p, _, _) -> p
-    | _ -> assert false
+  let get_type_path d = get_constr_type_path (get_type d)
 
   let lookup_from_type env type_path usage lid =
     let descrs = lookup_all_from_type lid.loc usage type_path env in
@@ -983,7 +985,21 @@ module Constructor = NameChoice (struct
   let get_name cstr = cstr.cstr_name
   let get_type cstr = cstr.cstr_res
   let lookup_all_from_type loc usage path env =
-    Env.lookup_all_constructors_from_type ~loc usage path env
+    match Env.lookup_all_constructors_from_type ~loc usage path env with
+    | _ :: _ as x -> x
+    | [] ->
+        match (Env.find_type path env).type_kind with
+        | Type_open ->
+            (* Extension constructors cannot be found by looking at the type
+               declaration.
+               We scan the whole environment to get an accurate spellchecking
+               hint in the subsequent error message *)
+            let filter lbl =
+              compare_type_path env
+                path (get_constr_type_path @@ get_type lbl) in
+            let add_valid x acc = if filter x then (x,ignore)::acc else acc in
+            Env.fold_constructors add_valid None env []
+        | _ -> []
   let in_env _ = true
 end)
 


### PR DESCRIPTION
This PR is an alternative implementation of #1154. Rather than tracking the list of extension constructors associated to a type in `Env.t`, this implementation splits the list of candidates used in `Typescore.NameChoice` into a list of spellchecking candidates list and a list of disambiguation candidates. Since the list of spellchecking candidates is only used in a user-facing error path; it can afford to be relatively slow contrarily to the disambiguation candidates list.

This patch keeps the same candidate lists as before for both labels and standard constructors. Contrarily, for extension constructors, the disambiguation candidates are generated with a call to `lookup_all_constructors` and the computation of the list of all extension constructors associated to a specific type is relegated to the spellchecking path.