### PR TITLE
CI: all standard libraries modules should be linked in stdlib.etex

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -79,6 +79,8 @@ EOF
   $MAKE USE_RUNTIME="d" OCAMLTESTDIR=$(pwd)/_ocamltestd TESTLOG=_logd all
   cd ..
   $MAKE install
+  echo Shallow tests for the manual
+  $MAKE -C manual/tests check-stdlib
   $MAKE manual-pregen
   # check_all_arches checks tries to compile all backends in place,
   # we would need to redo (small parts of) world.opt afterwards to

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -79,9 +79,6 @@ EOF
   $MAKE USE_RUNTIME="d" OCAMLTESTDIR=$(pwd)/_ocamltestd TESTLOG=_logd all
   cd ..
   $MAKE install
-  echo Shallow tests for the manual
-  $MAKE -C manual/tests check-stdlib
-  $MAKE manual-pregen
   # check_all_arches checks tries to compile all backends in place,
   # we would need to redo (small parts of) world.opt afterwards to
   # use the compiler again
@@ -122,6 +119,22 @@ CheckNoChangesMessage () {
   fi
 }
 
+CheckManual () {
+      cat<<EOF
+--------------------------------------------------------------------------
+This test checks that all standard libraries modules are referenced by the
+standard library chapter of the manual and that the code examples
+build correctly.
+--------------------------------------------------------------------------
+EOF
+  # we need some of the configuration data provided by configure
+  ./configure -no-ocamldoc
+  $MAKE check-stdlib -C manual/tests
+  # pregen-etex needs a working toplevel
+  $MAKE world
+  $MAKE -C manual pregen-etex
+}
+
 CheckTestsuiteModified () {
   cat<<EOF
 ------------------------------------------------------------------------
@@ -152,6 +165,8 @@ changes)
     case $TRAVIS_EVENT_TYPE in
         pull_request) CheckChangesModified;;
     esac;;
+manual)
+    CheckManual;;
 tests)
     case $TRAVIS_EVENT_TYPE in
         pull_request) CheckTestsuiteModified;;

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -79,6 +79,8 @@ EOF
   $MAKE USE_RUNTIME="d" OCAMLTESTDIR=$(pwd)/_ocamltestd TESTLOG=_logd all
   cd ..
   $MAKE install
+  echo Check the code examples in the manual
+  $MAKE manual-pregen
   # check_all_arches checks tries to compile all backends in place,
   # we would need to redo (small parts of) world.opt afterwards to
   # use the compiler again
@@ -122,17 +124,13 @@ CheckNoChangesMessage () {
 CheckManual () {
       cat<<EOF
 --------------------------------------------------------------------------
-This test checks that all standard libraries modules are referenced by the
-standard library chapter of the manual and that the code examples
-build correctly.
+This test checks that all standard library modules are referenced by the
+standard library chapter of the manual.
 --------------------------------------------------------------------------
 EOF
   # we need some of the configuration data provided by configure
-  ./configure -no-ocamldoc
+  ./configure
   $MAKE check-stdlib -C manual/tests
-  # pregen-etex needs a working toplevel
-  $MAKE world
-  $MAKE -C manual pregen-etex
 }
 
 CheckTestsuiteModified () {

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
   - env: CI_KIND=build XARCH=x64
   - env: CI_KIND=build XARCH=x64 CONFIG_ARG=-flambda OCAMLRUNPARAM=b,v=0
   - env: CI_KIND=changes
+  - env: CI_KIND=manual
   - env: CI_KIND=tests
   allow_failures:
   - env: CI_KIND=tests


### PR DESCRIPTION
This PR adds the `check-stdlib` test to the travis CI. This test verifies that all standard library modules are referenced in `stdlib.etex` and is currently broken due to the recent integration  of `Bigarray` into the standard library.

However in this case the right fix is a bit more involved than just adding the links in `stdlib.etex` : part of the Bigarray's syntax is still described in the language extension section, the extended module description still speaks of Bigarray as a library and recommend to link `bigarray.cmxa` , etc. Thus this PR should not be fixed before Bigarray documentation has been updated. I may have the time to do so in the coming week.
