### PR TITLE
manual Makefiles: set LD_PATH to protect from stale installs

### DIFF
--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -13,10 +13,11 @@ SRC = $(abspath ../../)
 
 export LD_LIBRARY_PATH ?= $(SRC)/otherlibs/unix/:$(SRC)/otherlibs/str/
 export DYLD_LIBRARY_PATH ?= $(SRC)/otherlibs/unix/:$(SRC)/otherlibs/str/
+SET_LD_PATH=CAML_LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)
 
 OCAMLDOC=$(if $(wildcard $(SRC)/ocamldoc/ocamldoc.opt),\
  $(SRC)/ocamldoc/ocamldoc.opt,\
- $(SRC)/byterun/ocamlrun $(SRC)/ocamldoc/ocamldoc)\
+ $(SET_LD_PATH) $(SRC)/byterun/ocamlrun $(SRC)/ocamldoc/ocamldoc)\
  -hide Pervasives -nostdlib -initially-opened-module Pervasives
 
 manual: files
@@ -130,7 +131,7 @@ warnings-help.etex: $(SRC)/utils/warnings.ml $(SRC)/ocamlc
 	 echo "% are inserted through the Makefile, which should be updated";\
 	 echo "% when a new warning is documented.";\
 	 echo "%";\
-	$(SRC)/boot/ocamlrun $(SRC)/ocamlc -warn-help \
+	$(SET_LD_PATH) $(SRC)/boot/ocamlrun $(SRC)/ocamlc -warn-help \
 	| sed -e 's/^ *\([0-9A-Z][0-9]*\)\(.*\)/\\item[\1] \2/'\
 	) >$@
 #	sed --inplace is not portable, emulate

--- a/manual/manual/cmds/Makefile
+++ b/manual/manual/cmds/Makefile
@@ -6,7 +6,9 @@ FILES=comp.tex top.tex runtime.tex native.tex lexyacc.tex intf-c.tex \
 TOPDIR=../../..
 include $(TOPDIR)/Makefile.tools
 
-TRANSF=$(OCAMLRUN) ../../tools/transf
+LD_PATH="$(TOPDIR)/otherlibs/str:$(TOPDIR)/otherlibs/unix"
+
+TRANSF=$(SET_LD_PATH) $(OCAMLRUN) ../../tools/transf
 TEXQUOTE=../../tools/texquote2
 FORMAT=../../tools/format-intf
 

--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -31,6 +31,11 @@ BLURB=core.tex builtin.tex stdlib.tex compilerlibs.tex \
 
 FILES=$(BLURB) $(INTF)
 
+SRC=../../..
+
+LD_PATH := $(SRC)/otherlibs/unix/:$(SRC)/otherlibs/str/
+SET_LD_PATH=CAML_LD_LIBRARY_PATH=$(LD_PATH)
+
 FORMAT=../../tools/format-intf
 TEXQUOTE=../../tools/texquote2
 
@@ -43,16 +48,16 @@ libs: $(FILES)
 
 OCAMLDOC=$(if $(wildcard $(CSLDIR)/ocamldoc/ocamldoc.opt),\
   $(CSLDIR)/ocamldoc/ocamldoc.opt,\
-  $(CSLDIR)/byterun/ocamlrun $(CSLDIR)/ocamldoc/ocamldoc) \
+  $(SET_LD_PATH) $(CSLDIR)/byterun/ocamlrun $(CSLDIR)/ocamldoc/ocamldoc) \
   -nostdlib -initially-opened-module Pervasives
 
 # Copy and unprefix the standard library when needed
-SRC=../../..
 include $(SRC)/ocamldoc/Makefile.unprefix
+
 
 $(INTF):  interfaces
 interfaces: $(STDLIB_CMIS)
-	 $(OCAMLDOC) -latex \
+	$(OCAMLDOC) -latex \
 	-I $(STDLIB_UNPREFIXED) \
 	$(STDLIB_MLIS) \
 	-sepfiles \

--- a/manual/manual/refman/Makefile
+++ b/manual/manual/refman/Makefile
@@ -6,9 +6,11 @@ TOPDIR=../../..
 
 include $(TOPDIR)/Makefile.tools
 
-CAMLLATEX= $(OCAMLRUN) ../../tools/caml-tex2 -caml "TERM=norepeat $(OCAML)" \
--n 80 -v false
-TRANSF=../../tools/transf
+LD_PATH="$(TOPDIR)/otherlibs/str:$(TOPDIR)/otherlibs/unix"
+
+CAMLLATEX=$(SET_LD_PATH) $(OCAMLRUN) ../../tools/caml-tex2 \
+  -caml "TERM=norepeat $(OCAML)" -n 80 -v false
+TRANSF=$(SET_LD_PATH) $(OCAMLRUN) ../../tools/transf
 TEXQUOTE=../../tools/texquote2
 
 ALLFILES=$(FILES)
@@ -25,17 +27,17 @@ clean:
 exten.tex:exten.etex
 	@$(CAMLLATEX) -o $*.caml_tex_error.tex $*.etex \
 	&& mv $*.caml_tex_error.tex $*.gen.tex \
-	&& $(OCAMLRUN) $(TRANSF) < $*.gen.tex > $*.transf_error.tex \
+	&& $(TRANSF) < $*.gen.tex > $*.transf_error.tex \
 	&& mv $*.transf_error.tex $*.gen.tex\
 	&& $(TEXQUOTE) < $*.gen.tex  > $*.texquote_error.tex\
 	&& mv $*.texquote_error.tex $*.tex\
 	|| printf "Failure when generating %s\n" $*.tex
 .etex.tex:
-	@$(OCAMLRUN) $(TRANSF) < $*.etex > $*.transf_error.tex \
+	@$(TRANSF) < $*.etex > $*.transf_error.tex \
 	&& mv $*.transf_error.tex $*.gen.tex\
 	&& $(TEXQUOTE) < $*.gen.tex  > $*.texquote_error.tex\
 	&& mv $*.texquote_error.tex $*.tex\
 	|| printf "Failure when generating %s\n" $*.tex
 
 
-$(ALLFILES): $(TRANSF) $(TEXQUOTE)
+$(ALLFILES): ../../tools/transf $(TEXQUOTE)

--- a/manual/manual/tutorials/Makefile
+++ b/manual/manual/tutorials/Makefile
@@ -4,7 +4,9 @@ advexamples.tex polymorphism.tex
 TOPDIR=../../..
 include $(TOPDIR)/Makefile.tools
 
-CAMLLATEX= $(OCAMLRUN) ../../tools/caml-tex2
+LD_PATH="$(TOPDIR)/otherlibs/str:$(TOPDIR)/otherlibs/unix"
+
+CAMLLATEX=$(SET_LD_PATH) $(OCAMLRUN) ../../tools/caml-tex2
 TEXQUOTE=../../tools/texquote2
 
 ALLFILES=$(FILES)
@@ -26,4 +28,4 @@ clean:
 	&& mv $*.texquote_error.tex $*.tex\
 	|| printf "Failure when generating %s\n" $*.tex
 
-$(ALLFILES): $(CAMLLATEX) $(TEXQUOTE)
+$(ALLFILES): ../../tools/caml-tex2 $(TEXQUOTE)


### PR DESCRIPTION
Trying to build the manual (make -C manual/manual etex-files) when
your current opan switch is stale (for example, 4.05.0 when working on
the current 4.07.0+dev trunk) results in the following error:

    make[1]: Entering directory '/home/gasche/Prog/ocaml/github-trunk/manual/manual/tutorials'
    Fatal error: cannot load shared library dllunix
    Reason: /home/gasche/.opam/4.05.0/lib/ocaml/stublibs/dllunix.so: undefined symbol: caml_strdup
    Failure when generating coreexamples.tex
    Fatal error: cannot load shared library dllunix
    Reason: /home/gasche/.opam/4.05.0/lib/ocaml/stublibs/dllunix.so: undefined symbol: caml_strdup
    Failure when generating lablexamples.tex
    Fatal error: cannot load shared library dllunix
    Reason: /home/gasche/.opam/4.05.0/lib/ocaml/stublibs/dllunix.so: undefined symbol: caml_strdup
    Failure when generating objectexamples.tex
    Fatal error: cannot load shared library dllunix
    Reason: /home/gasche/.opam/4.05.0/lib/ocaml/stublibs/dllunix.so: undefined symbol: caml_strdup
    Failure when generating moduleexamples.tex
    Fatal error: cannot load shared library dllunix
    Reason: /home/gasche/.opam/4.05.0/lib/ocaml/stublibs/dllunix.so: undefined symbol: caml_strdup
    Failure when generating advexamples.tex
    Fatal error: cannot load shared library dllunix
    Reason: /home/gasche/.opam/4.05.0/lib/ocaml/stublibs/dllunix.so: undefined symbol: caml_strdup
    Failure when generating polymorphism.tex
    make[1]: Leaving directory '/home/gasche/Prog/ocaml/github-trunk/manual/manual/tutorials'

This PR fixes the issue by using Makefile.tools' SET_LD_PATH variable
to set a LD_PATH containing the required build directory's otherlibs/
libraries, instead of looking in an installed path.

(no change entry needed)