### PR TITLE
ocamldoc: improve printing of subscript/superscript in 'man' format

### DIFF
--- a/Changes
+++ b/Changes
@@ -266,6 +266,10 @@ OCaml 4.07
 - GPR#1695: add the -null-crc command-line option to ocamlobjinfo.
   (Sébastien Hinderer, review by David Allsopp and Gabriel Scherer)
 
+- GPR#1710: ocamldoc, improve the 'man' rendering of subscripts and
+  superscripts.
+  (Gabriel Scherer)
+
 ### Manual and documentation:
 
 - MPR#7613: minor reword of the "refutation cases" paragraph

--- a/ocamldoc/odoc_man.ml
+++ b/ocamldoc/odoc_man.ml
@@ -329,9 +329,9 @@ class man =
           self#man_of_text_element b
             (Odoc_info.Code (Odoc_info.use_hidden_modules name))
       | Odoc_info.Superscript t ->
-          bs b "^{"; self#man_of_text2 b t
+          bs b "^"; self#man_of_text2 b t
       | Odoc_info.Subscript t ->
-          bs b "_{"; self#man_of_text2 b t
+          bs b "_"; self#man_of_text2 b t
       | Odoc_info.Module_list _ ->
           ()
       | Odoc_info.Index_list ->


### PR DESCRIPTION
On a standard OCaml install, `man Nativeint` shows the following
sentence in its first paragraph:

    All arithmetic operations over nativeint are taken
    modulo 2^{32 or 2^{64 depending on the word size of the architecture.

The `2^{32` is a rendering bug. This PR removes the unbalanced curvy
bracket, so it prints 2^32 and 2^64 instead.

In theory just printing ^ and _ risks creating ambiguities for
multi-words superscripts or subscripts: "2^foo bar" could be either
"2^{foo bar}" or "2^{foo} bar". In practice, the ocamldoc text in the
standard library only uses the superscript for bit sizes.

Even for arbitrary user documentation comments, "^{" or "^" have the
same property of not being explicit about where the superscript ends,
so this would not be a regression even on multi-word superscripts.