### PR TITLE
Fix Mantis PR#7767: interaction between labels and let rec check

### DIFF
--- a/Changes
+++ b/Changes
@@ -48,6 +48,10 @@ OCaml 4.07
 
 ### Type system:
 
+- MPR#7767, GPR#1712: restore legacy treatment of partially-applied
+  labeled functions in 'let rec' bindings.
+  (Jeremy Yallop, report by Ivan Gotovchits, review by Gabriel Scherer)
+
 - MPR#7611, GPR#1491: reject the use of generative functors as applicative
   (Valentin Gatien-Baron)
 

--- a/testsuite/tests/letrec-disallowed/labels.ml
+++ b/testsuite/tests/letrec-disallowed/labels.ml
@@ -1,0 +1,6 @@
+(* TEST 
+   * toplevel
+*)
+
+let f ~x () = x ();;
+let rec x = f ~x;;

--- a/testsuite/tests/letrec-disallowed/labels.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/labels.ocaml.reference
@@ -1,0 +1,6 @@
+val f : x:(unit -> 'a) -> unit -> 'a = <fun>
+Characters 12-16:
+  let rec x = f ~x;;
+              ^^^^
+Error: This kind of expression is not allowed as right-hand side of `let rec'
+

--- a/testsuite/tests/letrec-disallowed/ocamltests
+++ b/testsuite/tests/letrec-disallowed/ocamltests
@@ -3,6 +3,7 @@ extension_constructor.ml
 float_block_allowed.ml
 float_block_disallowed.ml
 generic_arrays.ml
+labels.ml
 lazy_.ml
 module_constraints.ml
 pr7215.ml

--- a/testsuite/tests/letrec/labels.ml
+++ b/testsuite/tests/letrec/labels.ml
@@ -1,0 +1,4 @@
+(* TEST *)
+
+let f () ~x = x ()
+let rec x = f ~x

--- a/testsuite/tests/letrec/ocamltests
+++ b/testsuite/tests/letrec/ocamltests
@@ -7,6 +7,7 @@ evaluation_order_2.ml
 evaluation_order_3.ml
 float_block_1.ml
 generic_array.ml
+labels.ml
 lazy_.ml
 lists.ml
 mixing_value_closures_1.ml


### PR DESCRIPTION
A partially-applied labeled function, like this:

```ocaml
let f () ~y = e in f ~y
```
is translated into code that builds a function value, like this:

```ocaml
let f () ~y = e in let g = f in let z = y in fun () -> g ~y:z ()
```

Consequently, the `let rec` check used to accept definitions whose rhss were partial applications of this form ([Mantis PR 7767](https://caml.inria.fr/mantis/view.php?id=7767)).

This PR adds a case for partially-applied labeled functions to the new `let rec` check, to restore the old behaviour.