### PR TITLE
Fix location primitives (e.g. __FILE__)

### DIFF
--- a/bytecomp/translprim.ml
+++ b/bytecomp/translprim.ml
@@ -686,13 +686,13 @@ let transl_primitive loc p env ty path =
   let params = make_params p.prim_arity in
   let args = List.map (fun id -> Lvar id) params in
   let body = lambda_of_prim p.prim_name prim loc args None in
-  let lam =
-    Lfunction{ kind = Curried; params;
-               attr = default_stub_attribute;
-               loc = loc;
-               body = body; }
-  in
-  lam
+  match params with
+  | [] -> body
+  | _ ->
+      Lfunction{ kind = Curried; params;
+                 attr = default_stub_attribute;
+                 loc = loc;
+                 body = body; }
 
 (* Determine if a primitive is a Pccall or will be turned later into
    a C function call that may raise an exception *)

--- a/testsuite/tests/translprim/locs.ml
+++ b/testsuite/tests/translprim/locs.ml
@@ -1,0 +1,44 @@
+(* TEST *)
+
+let print_loc loc =
+  print_endline loc
+
+let print_file file =
+  print_endline file
+
+let print_line line =
+  print_endline (string_of_int line)
+
+let print_module md =
+  print_endline md
+
+let print_pos (file, line, col1, col2) =
+  Printf.printf "%s, %d, %d, %d\n" file line col1 col2
+
+let () = print_loc __LOC__
+
+let () = print_file __FILE__
+
+let () = print_line __LINE__
+
+let () = print_module __MODULE__
+
+let () = print_pos __POS__
+
+let loc, s1 = __LOC_OF__ "an expression"
+
+let () = print_loc loc
+
+let () = print_endline s1
+
+let line, s2 = __LINE_OF__ "another expression"
+
+let () = print_line line
+
+let () = print_endline s2
+
+let pos, s3 = __POS_OF__ "yet another expression"
+
+let () = print_pos pos
+
+let () = print_endline s3

--- a/testsuite/tests/translprim/locs.reference
+++ b/testsuite/tests/translprim/locs.reference
@@ -1,0 +1,11 @@
+File "locs.ml", line 18, characters 19-26
+locs.ml
+22
+Locs
+locs.ml, 26, 19, 26
+File "locs.ml", line 28, characters 14-40
+an expression
+34
+another expression
+locs.ml, 40, 14, 49
+yet another expression

--- a/testsuite/tests/translprim/ocamltests
+++ b/testsuite/tests/translprim/ocamltests
@@ -2,3 +2,4 @@ array_spec.ml
 comparison_table.ml
 module_coercion.ml
 ref_spec.ml
+locs.ml


### PR DESCRIPTION
#1557 broke the location primitives (e.g. `__FILE__`) because they are the only primitives of arity 0 and they had no tests in the testsuite. This adds a simple test and fixes them.