### PR TITLE
tools/make-version-header.sh: fix minor version extraction

### DIFF
--- a/tools/make-version-header.sh
+++ b/tools/make-version-header.sh
@@ -39,7 +39,7 @@ case $# in
 esac
 
 major="`echo "$version" | sed -n -e '1s/^\([0-9]*\)\..*/\1/p'`"
-minor="`echo "$version" | sed -n -e '1s/^[0-9]*\.\([0-9]*\).*/\1/p'`"
+minor="`echo "$version" | sed -n -e '1s/^[0-9]*\.0*\([0-9]*\).*/\1/p'`"
 patchlvl="`echo "$version" | sed -n -e '1s/^[0-9]*\.[0-9]*\.\([0-9]*\).*/\1/p'`"
 suffix="`echo "$version" | sed -n -e '1s/^[^+]*+\(.*\)/\1/p'`"
 


### PR DESCRIPTION
See CI errors:
- https://travis-ci.org/ocaml/ocaml/jobs/364658842#L1069-L1070
- https://ci.appveyor.com/project/avsm/ocaml/build/1.0.6115?fullLog=true#L63

`bash` considers sequences of integers starting with zero to be octal, so e.g. a
`$minor` value of "08" will be taken as an (illegal) octal number, causing an
error.

To fix this, we drop any leading zero when extracting the minor version.