### PR TITLE
ocamldoc Makefile: change target names to avoid useless recompilation

### DIFF
--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -224,10 +224,10 @@ $(OCAMLDOC_LIBCMXA): $(LIBCMXFILES)
 	$(OCAMLOPT) -a -o $@ $(LINKFLAGS) $^
 
 .PHONY: manpages
-manpages: stdlib_man/Stdlib.3o
+manpages: stdlib_man/Pervasives.3o
 
 .PHONY: html_doc
-html_doc: stdlib_html/Stdlib.html
+html_doc: stdlib_html/Pervasives.html
 
 .PHONY: dot
 dot: ocamldoc.dot
@@ -388,13 +388,13 @@ test_texi:
 SRC=$(ROOTDIR)
 include Makefile.unprefix
 
-stdlib_man/Stdlib.3o: $(OCAMLDOC) $(STDLIB_MLIS) $(STDLIB_CMIS)
+stdlib_man/Pervasives.3o: $(OCAMLDOC) $(STDLIB_MLIS) $(STDLIB_CMIS)
 	$(MKDIR) stdlib_man
 	$(OCAMLDOC_RUN) -man -d stdlib_man -nostdlib -I stdlib_non_prefixed \
 	-t "OCaml library" -man-mini $(STDLIB_MLIS) \
 	-initially-opened-module Pervasives
 
-stdlib_html/Stdlib.html: $(OCAMLDOC) $(STDLIB_MLIS) $(STDLIB_CMIS)
+stdlib_html/Pervasives.html: $(OCAMLDOC) $(STDLIB_MLIS) $(STDLIB_CMIS)
 	$(MKDIR) stdlib_html
 	$(OCAMLDOC_RUN) -d stdlib_html -html -nostdlib -I stdlib_non_prefixed \
 	-t "OCaml library" $(STDLIB_MLIS) \


### PR DESCRIPTION
The target names for the 'man' and 'html' files are
  stdlib_{html,man}/Stdlib.{3o,html}
but these files are never produced by the corresponding rules,
so the rule is re-run on each "make world.opt".

This patch changes these target names to Pervasives.{3o,html}, which
is an actual file produced by the build. It is not fully clear to me
whether the authors of the original rule intended to also produced
documentation for a joint Stdlib module.

Before this patch, running "make world.opt" in an already-built directory
would take 10s on my machine. Now it takes 2s.