### PR TITLE
MPR7765: integer overflows when unmarshaling a bigarray

### DIFF
--- a/Changes
+++ b/Changes
@@ -468,6 +468,11 @@ OCaml 4.07
 - MPR#7751, GPR#1657: The toplevel prints some concrete types as abstract
   (Jacques Garrigue, report by Matej Kosik)
 
+- MPR#7765, GPR#1718: When unmarshaling bigarrays, protect against integer
+  overflows in size computations
+  (Xavier Leroy, report by Maximilian Tschirschnitz,
+   review by Gabriel Scherer)
+
 - PR#7760, GPR#1713: Exact selection of lexing engine, that is
   correct "Segfault in ocamllex-generated code using 'shortest'"
   (Luc Maranget, Frédéric Bour, report by Stephen Dolan,

--- a/byterun/bigarray.c
+++ b/byterun/bigarray.c
@@ -439,22 +439,31 @@ static void caml_ba_deserialize_longarray(void * dest, intnat num_elts)
 CAMLexport uintnat caml_ba_deserialize(void * dst)
 {
   struct caml_ba_array * b = dst;
-  int i, elt_size;
-  uintnat num_elts;
+  int i;
+  uintnat num_elts, size;
 
   /* Read back header information */
   b->num_dims = caml_deserialize_uint_4();
+  if (b->num_dims < 0 || b->num_dims > CAML_BA_MAX_NUM_DIMS)
+    caml_deserialize_error("input_value: wrong number of bigarray dimensions");
   b->flags = caml_deserialize_uint_4() | CAML_BA_MANAGED;
   b->proxy = NULL;
   for (i = 0; i < b->num_dims; i++) b->dim[i] = caml_deserialize_uint_4();
-  /* Compute total number of elements */
-  num_elts = caml_ba_num_elts(b);
-  /* Determine element size in bytes */
+  /* Compute total number of elements.  Watch out for overflows (MPR#7765). */
+  num_elts = 1;
+  for (i = 0; i < b->num_dims; i++) {
+    if (caml_umul_overflow(num_elts, b->dim[i], &num_elts))
+      caml_deserialize_error("input_value: size overflow for bigarray");
+  }
+  /* Determine element size in bytes.  Watch out for overflows (MPR#7765). */
   if ((b->flags & CAML_BA_KIND_MASK) > CAML_BA_CHAR)
     caml_deserialize_error("input_value: bad bigarray kind");
-  elt_size = caml_ba_element_size[b->flags & CAML_BA_KIND_MASK];
+  if (caml_umul_overflow(num_elts,
+                         caml_ba_element_size[b->flags & CAML_BA_KIND_MASK],
+                         &size))
+    caml_deserialize_error("input_value: size overflow for bigarray");
   /* Allocate room for data */
-  b->data = malloc(elt_size * num_elts);
+  b->data = malloc(size);
   if (b->data == NULL)
     caml_deserialize_error("input_value: out of memory for bigarray");
   /* Read data */

--- a/byterun/bigarray.c
+++ b/byterun/bigarray.c
@@ -455,7 +455,7 @@ CAMLexport uintnat caml_ba_deserialize(void * dst)
     if (caml_umul_overflow(num_elts, b->dim[i], &num_elts))
       caml_deserialize_error("input_value: size overflow for bigarray");
   }
-  /* Determine element size in bytes.  Watch out for overflows (MPR#7765). */
+  /* Determine array size in bytes.  Watch out for overflows (MPR#7765). */
   if ((b->flags & CAML_BA_KIND_MASK) > CAML_BA_CHAR)
     caml_deserialize_error("input_value: bad bigarray kind");
   if (caml_umul_overflow(num_elts,


### PR DESCRIPTION
Malicious or corrupted marshaled data can result in a bigarray
with impossibly large dimensions that cause overflow when computing
the in-memory size of the bigarray.  Disaster ensues when the data
is read in a too small memory area.  This PR checks for overflows
when computing the in-memory size of the bigarray.

Closes: https://caml.inria.fr/mantis/view.php?id=7765