### PR TITLE
Windows multicore-related fixes

### DIFF
--- a/byterun/Makefile
+++ b/byterun/Makefile
@@ -161,17 +161,18 @@ prims.c : primitives
 	 echo '	 0 };') > prims.c
 
 caml/opnames.h : caml/instruct.h
+	cat $^ | tr -d '\r' | \
 	sed -e '/\/\*/d' \
 	    -e '/^#/d' \
 	    -e 's/enum /char * names_of_/' \
 	    -e 's/{$$/[] = {/' \
-	    -e 's/\([[:upper:]][[:upper:]_0-9]*\)/"\1"/g' caml/instruct.h \
-	    > caml/opnames.h
+	    -e 's/\([[:upper:]][[:upper:]_0-9]*\)/"\1"/g' > $@
 
 # caml/jumptbl.h is required only if you have GCC 2.0 or later
 caml/jumptbl.h : caml/instruct.h
+	cat $^ | tr -d '\r' | \
 	sed -n -e '/^  /s/ \([A-Z]\)/ \&\&lbl_\1/gp' \
-	       -e '/^}/q' caml/instruct.h > caml/jumptbl.h
+	       -e '/^}/q' > $@
 
 caml/version.h : ../VERSION ../tools/make-version-header.sh
 	../tools/make-version-header.sh ../VERSION > caml/version.h

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -365,7 +365,7 @@ int caml_runtime_warnings_active(void);
 
 #ifdef DEBUG
 #ifdef ARCH_SIXTYFOUR
-#define Debug_tag(x) (0xD700D7D7D700D6D7ul \
+#define Debug_tag(x) (INT64_LITERAL(0xD700D7D7D700D6D7u) \
                       | ((uintnat) (x) << 16) \
                       | ((uintnat) (x) << 48))
 #else
@@ -401,7 +401,7 @@ int caml_runtime_warnings_active(void);
 /* Note: the first argument is in fact a [value] but we don't have this
    type available yet because we can't include [mlvalues.h] in this file.
 */
-extern void caml_set_fields (intnat v, unsigned long, unsigned long);
+extern void caml_set_fields (intnat v, uintnat, uintnat);
 #endif /* DEBUG */
 
 

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -724,7 +724,7 @@ union max_align {
 
 struct pool_block {
 #ifdef DEBUG
-  long magic;
+  intnat magic;
 #endif
   struct pool_block *next;
   struct pool_block *prev;

--- a/byterun/misc.c
+++ b/byterun/misc.c
@@ -33,11 +33,13 @@ caml_timing_hook caml_finalise_end_hook = NULL;
 
 #ifdef DEBUG
 
-void caml_failed_assert (char * expr, char * file, int line)
+void caml_failed_assert (char * expr, char_os * file_os, int line)
 {
+  char* file = caml_stat_strdup_of_os(file_os);
   fprintf (stderr, "file %s; line %d ### Assertion failed: %s\n",
            file, line, expr);
   fflush (stderr);
+  caml_stat_free(file);
   abort();
 }
 

--- a/byterun/misc.c
+++ b/byterun/misc.c
@@ -41,7 +41,7 @@ void caml_failed_assert (char * expr, char * file, int line)
   abort();
 }
 
-void caml_set_fields (value v, unsigned long start, unsigned long filler)
+void caml_set_fields (value v, uintnat start, uintnat filler)
 {
   mlsize_t i;
   for (i = start; i < Wosize_val (v); i++){

--- a/byterun/misc.c
+++ b/byterun/misc.c
@@ -15,6 +15,16 @@
 
 #define CAML_INTERNALS
 
+#if _MSC_VER >= 1400 && _MSC_VER < 1700
+/* Microsoft introduced a regression in Visual Studio 2005 (technically it's
+   not present in the Windows Server 2003 SDK which has a pre-release version)
+   and the abort function ceased to be declared __declspec(noreturn). This was
+   fixed in Visual Studio 2012. Trick stdlib.h into not defining abort (this
+   means exit and _exit are not defined either, but they aren't required). */
+#define _CRT_TERMINATE_DEFINED
+__declspec(noreturn) void __cdecl abort(void);
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>

--- a/byterun/win32.c
+++ b/byterun/win32.c
@@ -894,7 +894,7 @@ CAMLexport inline wchar_t* caml_stat_strdup_to_utf16(const char *s)
   int retcode;
 
   retcode = win_multi_byte_to_wide_char(s, -1, NULL, 0);
-  ws = malloc(retcode * sizeof(*ws));
+  ws = caml_stat_alloc_noexc(retcode * sizeof(*ws));
   win_multi_byte_to_wide_char(s, -1, ws, retcode);
 
   return ws;

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -106,12 +106,12 @@ endif
 
 ifeq "$(RUNTIMED)" "true"
 install::
-	$(INSTALL_DATA) target_camlheaderd $(INSTALL_LIBDIR)
+	$(INSTALL_DATA) target_camlheaderd "$(INSTALL_LIBDIR)"
 endif
 
 ifeq "$(RUNTIMEI)" "true"
 install::
-	$(INSTALL_DATA) target_camlheaderi $(INSTALL_LIBDIR)
+	$(INSTALL_DATA) target_camlheaderi "$(INSTALL_LIBDIR)"
 endif
 
 .PHONY: installopt

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -40,6 +40,7 @@ function set_configuration {
     FILE=$(pwd | cygpath -f - -m)/config/Makefile
     echo "Edit $FILE to set PREFIX=$2"
     sed -e "/PREFIX=/s|=.*|=$2|" \
+        -e "/RUNTIMED=/s|=.*|=true|" \
         -e "/^ *CFLAGS *=/s/\r\?$/ $3\0/" \
          config/Makefile.$1 > config/Makefile
 #    run "Content of $FILE" cat config/Makefile
@@ -82,7 +83,8 @@ case "$1" in
     FULL_BUILD_PREFIX=$APPVEYOR_BUILD_FOLDER/../$BUILD_PREFIX
     run "ocamlc.opt -version" $FULL_BUILD_PREFIX-msvc64/ocamlc.opt -version
     run "test msvc64" make -C $FULL_BUILD_PREFIX-msvc64 tests
-    run "test mingw32" make -C $FULL_BUILD_PREFIX-mingw32 tests
+    run "test mingw32" make -C $FULL_BUILD_PREFIX-mingw32/testsuite \
+                            USE_RUNTIME="d" all
     run "install msvc64" make -C $FULL_BUILD_PREFIX-msvc64 install
     run "install mingw32" make -C $FULL_BUILD_PREFIX-mingw32 install
     ;;


### PR DESCRIPTION
A few things found getting multicore-ocaml working on Windows:

 - `caml_stat_strdup_to_utf16` should use `caml_stat_alloc_noexc` not `malloc`. This would have caused problems when using the unloadable runtime on Windows, but is not a problem in backwards-compatible mode.
 - The debug runtime tags contain a long-standing overflow in 64-bit mode on Windows.
 - As a consequence of this, the debug runtime is now actually built on AppVeyor.
 - `caml_set_fields` incorrectly assumes `sizeof(long) == sizeof(intnat)`, as did the `magic` field of pool blocks. Both these only affect the debug runtime.

We already run the testsuite twice on AppVeyor, so I'm seeing what happens if the mingw32 testsuite uses the debug runtime and the msvc64 testsuite continues to use the normal runtime.

@shindere - does Inria CI test the debug runtime on Windows at all (I think this may have been mentioned recently, but I can't remember what the answer was)
@murmour - I'd be grateful if the unloadable runtime-related changes could have a quick glance, but I don't think I've damaged anything!
@damiendoligez - I wouldn't say that any of this is critical for 4.07.0