### PR TITLE
Scrape types in Typeopt.maybe_pointer

### DIFF
--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -50,6 +50,7 @@ let is_base_type env ty base_ty_path =
   | _ -> false
 
 let maybe_pointer_type env ty =
+  let ty = scrape_ty env ty in
   if Ctype.maybe_pointer_type env ty then
     Pointer
   else


### PR DESCRIPTION
Substitutions don't update the immediacy information of types. So code like:

```ocaml
module type T = sig
    type underlying
    type t = private underlying
  end

  module type S = sig
    include T with type underlying = int
    val zero : t
  end

  module X : S
```
Has `X.t` marked as non-immediate, even though it is a private abbreviation for `int`. This means that we get a call to `caml_modify` for:
```ocaml
let f (x : X.t ref) (y : X.t) =
  x := y
```
This patch remedies this by fully expanding the type before checking its `immediate` status. We already do this when classifying the type for array operations, so it is not a surprising change.