### PR TITLE
make install: remove old files to account for new packed stdlib

### DIFF
--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -87,6 +87,11 @@ allopt-prof: stdlib.p.cmxa std_exit.p.cmx
 
 .PHONY: install
 install::
+# Transitional: when upgrading from 4.06 -> 4.07, module M is in stdlib__m.cm*, while previously
+# it was in m.cm*, which confuses the compiler. Also, pervasives.* is now stdlib.*.
+	rm -f $(patsubst stdlib__%,"$(INSTALL_LIBDIR)/%", $(filter stdlib__%,$(OBJS)))
+	rm -f "$(INSTALL_LIBDIR)/pervasives.*"
+# End transitional
 	$(INSTALL_DATA) \
 	  stdlib.cma std_exit.cmo *.cmi *.cmt *.cmti *.mli *.ml camlheader_ur \
 	  "$(INSTALL_LIBDIR)"


### PR DESCRIPTION
See [MPR#7773](https://caml.inria.fr/mantis/view.php?id=7773). The module `M` from the standard library is now contained in modules called `stdlib__m.cm*`, so they do not override the "old" modules `m.cm*`, which confuses the compiler. Similarly, `pervasives` is not overwritten by the new `stdlib`.

So let's erase the old files when doing `make install` to avoid any conflict.