### PR TITLE
[RFC] More informative errors when Ccomp.command exits with status 127

### DIFF
--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -21,7 +21,9 @@ let command cmdline =
     prerr_string cmdline;
     prerr_newline()
   end;
-  Sys.command cmdline
+  let res = Sys.command cmdline in
+  if res = 127 then raise (Sys_error cmdline);
+  res
 
 let run_command cmdline = ignore(command cmdline)
 


### PR DESCRIPTION
I spent a non-zero amount of time recently trying to understand the following output (reproduced in full) from ocamlopt (which exited with -1):
```
File "caml_startup", line 1:
Error: Error during linking
```

As it turns out, the command line used by ocamlopt to invoke the linker was bigger than `ARG_MAX`.
In such cases, `Sys.command` won't print anything to stderr or stdout, and return `127` on Linux (windows apparently returns `-1`).

I think it would be a nice to print something when that happens (even though we can't be sure whether our call silently failed, or the command itself exited with `127`; I don't think we should be worrying too much about the added noise however).
I initially wanted `Ccomp.command` to print something along the lines of:
```
Error: command exited with status 127
Can be due to argument size limit, run with -verbose to get the actual command line.
```
which seems like a nice hint.
But I noticed that `caml_sys_system_command` raises `Sys_error` when `-1` is returned and figured that I could do that too in this case as well and that it would probably be enough.

For the record: the invocation of ocamlopt was hidden by a build system, so `Sys_error` with the faulty cmdline would most likely have made the issue obvious.

Any opinion?