### PR TITLE
make install: remove old bigarray library

### DIFF
--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -87,10 +87,12 @@ allopt-prof: stdlib.p.cmxa std_exit.p.cmx
 
 .PHONY: install
 install::
-# Transitional: when upgrading from 4.06 -> 4.07, module M is in stdlib__m.cm*, while previously
-# it was in m.cm*, which confuses the compiler. Also, pervasives.* is now stdlib.*.
+# Transitional: when upgrading from 4.06 -> 4.07, module M is in stdlib__m.cm*,
+# while previously it was in m.cm*, which confuses the compiler.
 	rm -f $(patsubst stdlib__%,"$(INSTALL_LIBDIR)/%", $(filter stdlib__%,$(OBJS)))
-	rm -f "$(INSTALL_LIBDIR)/pervasives.*"
+# Remove "old" pervasives.* and bigarray.* to avoid getting confused with the
+# Stdlib versions.
+	rm -f "$(INSTALL_LIBDIR)/pervasives.*" "$(INSTALL_LIBDIR)/bigarray.*"
 # End transitional
 	$(INSTALL_DATA) \
 	  stdlib.cma std_exit.cmo *.cmi *.cmt *.cmti *.mli *.ml camlheader_ur \


### PR DESCRIPTION
If one installed the 4.06 `bigarray` library and does *not* install it in 4.07, the compiler will be confused by the old `bigarray.*` files left in the installation directory. Let's remove them.