### PR TITLE
Invalid reads from complex bigarrays

### DIFF
--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -38,13 +38,13 @@ let rec with_afl_logging b =
     let cur_pos = Ident.create "pos" in
     let afl_area = Ident.create "shared_mem" in
     let op oper args = Cop (oper, args, Debuginfo.none) in
-    Clet(afl_area, op (Cload (Word_int, Asttypes.Mutable)) [afl_area_ptr],
-    Clet(cur_pos,  op Cxor [op (Cload (Word_int, Asttypes.Mutable))
+    Clet(afl_area, op (Cload (Word_int, Asttypes.Mutable, None)) [afl_area_ptr],
+    Clet(cur_pos,  op Cxor [op (Cload (Word_int, Asttypes.Mutable, None))
       [afl_prev_loc]; Cconst_int cur_location],
     Csequence(
       op (Cstore(Byte_unsigned, Assignment))
          [op Cadda [Cvar afl_area; Cvar cur_pos];
-          op Cadda [op (Cload (Byte_unsigned, Asttypes.Mutable))
+          op Cadda [op (Cload (Byte_unsigned, Asttypes.Mutable, None))
                        [op Cadda [Cvar afl_area; Cvar cur_pos]];
                     Cconst_int 1]],
       op (Cstore(Word_int, Assignment))

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -203,7 +203,7 @@ method! select_operation op args dbg =
       self#select_floatarith false Idivf Ifloatdiv args
   | Cextcall("sqrt", _, false, _) ->
      begin match args with
-       [Cop(Cload ((Double|Double_u as chunk), _), [loc], _dbg)] ->
+       [Cop(Cload ((Double|Double_u as chunk), _, _), [loc], _dbg)] ->
          let (addr, arg) = self#select_addressing chunk loc in
          (Ispecific(Ifloatsqrtf addr), [arg])
      | [arg] ->
@@ -237,11 +237,11 @@ method! select_operation op args dbg =
 
 method select_floatarith commutative regular_op mem_op args =
   match args with
-    [arg1; Cop(Cload ((Double|Double_u as chunk), _), [loc2], _)] ->
+    [arg1; Cop(Cload ((Double|Double_u as chunk), _, _), [loc2], _)] ->
       let (addr, arg2) = self#select_addressing chunk loc2 in
       (Ispecific(Ifloatarithmem(mem_op, addr)),
                  [arg1; arg2])
-  | [Cop(Cload ((Double|Double_u as chunk), _), [loc1], _); arg2]
+  | [Cop(Cload ((Double|Double_u as chunk), _, _), [loc1], _); arg2]
         when commutative ->
       let (addr, arg1) = self#select_addressing chunk loc1 in
       (Ispecific(Ifloatarithmem(mem_op, addr)),

--- a/asmcomp/arm/selection.ml
+++ b/asmcomp/arm/selection.ml
@@ -256,9 +256,9 @@ method private select_operation_softfp op args dbg =
       (Iintop_imm(Icomp(Iunsigned comp), 0),
        [Cop(Cextcall(func, typ_int, false, None), args, dbg)])
   (* Add coercions around loads and stores of 32-bit floats *)
-  | (Cload (Single, mut), args) ->
+  | (Cload (Single, mut, from), args) ->
       (self#iextcall("__aeabi_f2d", false),
-        [Cop(Cload (Word_int, mut), args, dbg)])
+        [Cop(Cload (Word_int, mut, from), args, dbg)])
   | (Cstore (Single, init), [arg1; arg2]) ->
       let arg2' =
         Cop(Cextcall("__aeabi_d2f", typ_int, false, None), [arg2], dbg) in

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -134,7 +134,7 @@ and operation =
   | Cextcall of string * machtype * bool * label option
     (** If specified, the given label will be placed immediately after the
         call (at the same place as any frame descriptor would reference). *)
-  | Cload of memory_chunk * Asttypes.mutable_flag
+  | Cload of memory_chunk * Asttypes.mutable_flag * Ident.t option
   | Calloc
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -109,7 +109,7 @@ type memory_chunk =
 and operation =
     Capply of machtype
   | Cextcall of string * machtype * bool * label option
-  | Cload of memory_chunk * Asttypes.mutable_flag
+  | Cload of memory_chunk * Asttypes.mutable_flag * Ident.t option
   | Calloc
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -65,6 +65,14 @@ let bind name arg fn =
   | Cblockheader _ -> fn arg
   | _ -> let id = Ident.create name in Clet(id, arg, fn (Cvar id))
 
+let bind_named name arg fn =
+  let id, expr =
+    match arg with
+    | Cvar id -> id, arg
+    | _ -> let id = Ident.create name in id, Cvar id
+  in
+  Clet(id, arg, fn id expr)
+
 let bind_load name arg fn =
   match arg with
   | Cop(Cload _, [Cvar _], _) -> fn arg
@@ -549,15 +557,15 @@ let rec unbox_float dbg cmm =
   | Ccatch(rec_flag, handlers, body) ->
     map_ccatch (unbox_float dbg) rec_flag handlers body
   | Ctrywith(e1, id, e2) -> Ctrywith(unbox_float dbg e1, id, unbox_float dbg e2)
-  | c -> Cop(Cload (Double_u, Immutable), [c], dbg)
+  | c -> Cop(Cload (Double_u, Immutable, None), [c], dbg)
 
 (* Complex *)
 
 let box_complex dbg c_re c_im =
   Cop(Calloc, [alloc_floatarray_header 2 dbg; c_re; c_im], dbg)
 
-let complex_re c dbg = Cop(Cload (Double_u, Immutable), [c], dbg)
-let complex_im c dbg = Cop(Cload (Double_u, Immutable),
+let complex_re c dbg = Cop(Cload (Double_u, Immutable, None), [c], dbg)
+let complex_im c dbg = Cop(Cload (Double_u, Immutable, None),
                         [Cop(Cadda, [c; Cconst_int size_float], dbg)], dbg)
 
 (* Unit *)
@@ -606,7 +614,7 @@ let get_field env ptr n dbg =
         else Mutable
       | _ -> Mutable
   in
-  Cop(Cload (Word_val, mut), [field_address ptr n dbg], dbg)
+  Cop(Cload (Word_val, mut, None), [field_address ptr n dbg], dbg)
 
 let set_field ptr n newval init dbg =
   Cop(Cstore (Word_val, init), [field_address ptr n dbg; newval], dbg)
@@ -616,7 +624,7 @@ let non_profinfo_mask = (1 lsl (64 - Config.profinfo_width)) - 1
 let get_header ptr dbg =
   (* We cannot deem this as [Immutable] due to the presence of [Obj.truncate]
      and [Obj.set_tag]. *)
-  Cop(Cload (Word_int, Mutable),
+  Cop(Cload (Word_int, Mutable, None),
     [Cop(Cadda, [ptr; Cconst_int(-size_int)], dbg)], dbg)
 
 let get_header_without_profinfo ptr dbg =
@@ -632,7 +640,7 @@ let get_tag ptr dbg =
   if Proc.word_addressed then           (* If byte loads are slow *)
     Cop(Cand, [get_header ptr dbg; Cconst_int 255], dbg)
   else                                  (* If byte loads are efficient *)
-    Cop(Cload (Byte_unsigned, Mutable), (* Same comment as [get_header] above *)
+    Cop(Cload (Byte_unsigned, Mutable, None), (* Same comment as [get_header] above *)
         [Cop(Cadda, [ptr; Cconst_int(tag_offset)], dbg)], dbg)
 
 let get_size ptr dbg =
@@ -694,13 +702,13 @@ let array_indexing ?typ log2size ptr ofs dbg =
                     Cconst_int((-1) lsl (log2size - 1))], dbg)
 
 let addr_array_ref arr ofs dbg =
-  Cop(Cload (Word_val, Mutable),
+  Cop(Cload (Word_val, Mutable, None),
     [array_indexing log2_size_addr arr ofs dbg], dbg)
 let int_array_ref arr ofs dbg =
-  Cop(Cload (Word_int, Mutable),
+  Cop(Cload (Word_int, Mutable, None),
     [array_indexing log2_size_addr arr ofs dbg], dbg)
 let unboxed_float_array_ref arr ofs dbg =
-  Cop(Cload (Double_u, Mutable),
+  Cop(Cload (Double_u, Mutable, None),
     [array_indexing log2_size_float arr ofs dbg], dbg)
 let float_array_ref dbg arr ofs =
   box_float dbg (unboxed_float_array_ref arr ofs dbg)
@@ -735,7 +743,7 @@ let string_length exp dbg =
              dbg),
          Cop(Csubi,
              [Cvar tmp_var;
-               Cop(Cload (Byte_unsigned, Mutable),
+               Cop(Cload (Byte_unsigned, Mutable, None),
                      [Cop(Cadda, [str; Cvar tmp_var], dbg)], dbg)], dbg)))
 
 (* Message sending *)
@@ -748,7 +756,7 @@ let lookup_tag obj tag dbg =
 
 let lookup_label obj lab dbg =
   bind "lab" lab (fun lab ->
-    let table = Cop (Cload (Word_val, Mutable), [obj], dbg) in
+    let table = Cop (Cload (Word_val, Mutable, None), [obj], dbg) in
     addr_array_ref table lab dbg)
 
 let call_cached_method obj tag cache pos args dbg =
@@ -949,8 +957,8 @@ let split_int64_for_32bit_target arg dbg =
   bind "split_int64" arg (fun arg ->
     let first = Cop (Cadda, [Cconst_int size_int; arg], dbg) in
     let second = Cop (Cadda, [Cconst_int (2 * size_int); arg], dbg) in
-    Ctuple [Cop (Cload (Thirtytwo_unsigned, Mutable), [first], dbg);
-            Cop (Cload (Thirtytwo_unsigned, Mutable), [second], dbg)])
+    Ctuple [Cop (Cload (Thirtytwo_unsigned, Mutable, None), [first], dbg);
+            Cop (Cload (Thirtytwo_unsigned, Mutable, None), [second], dbg)])
 
 let rec unbox_int bi arg dbg =
   match arg with
@@ -980,7 +988,7 @@ let rec unbox_int bi arg dbg =
         split_int64_for_32bit_target arg dbg
       else
         Cop(
-          Cload((if bi = Pint32 then Thirtytwo_signed else Word_int), Mutable),
+          Cload((if bi = Pint32 then Thirtytwo_signed else Word_int), Mutable, None),
           [Cop(Cadda, [arg; Cconst_int size_addr], dbg)], dbg)
 
 let make_unsigned_int bi arg dbg =
@@ -1043,7 +1051,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
         bind "idx" arg (fun idx ->
           (* Load the untagged int bound for the given dimension *)
           let bound =
-            Cop(Cload (Word_int, Mutable),[field_address b dim_ofs dbg], dbg)
+            Cop(Cload (Word_int, Mutable, None),[field_address b dim_ofs dbg], dbg)
           in
           let idxn = untag_int idx dbg in
           check_ba_bound bound idxn idx)
@@ -1053,7 +1061,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
       let rem = ba_indexing (dim_ofs + delta_ofs) delta_ofs argl in
       (* Load the untagged int bound for the given dimension *)
       let bound =
-        Cop(Cload (Word_int, Mutable), [field_address b dim_ofs dbg], dbg)
+        Cop(Cload (Word_int, Mutable, None), [field_address b dim_ofs dbg], dbg)
       in
       if unsafe then add_int (mul_int (decr_int rem dbg) bound dbg) arg1 dbg
       else
@@ -1079,7 +1087,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
     bigarray_elt_size elt_kind in
   (* [array_indexing] can simplify the given expressions *)
   array_indexing ~typ:Int (log2 elt_size)
-                 (Cop(Cload (Word_int, Mutable),
+                 (Cop(Cload (Word_int, Mutable, None),
                     [field_address b 1 dbg], dbg)) offset dbg
 
 let bigarray_word_kind = function
@@ -1098,7 +1106,7 @@ let bigarray_word_kind = function
   | Pbigarray_complex64 -> Double
 
 let bigarray_get unsafe elt_kind layout b args dbg =
-  bind "ba" b (fun b ->
+  bind_named "ba" b (fun b_ident b ->
     match elt_kind with
       Pbigarray_complex32 | Pbigarray_complex64 ->
         let kind = bigarray_word_kind elt_kind in
@@ -1106,11 +1114,11 @@ let bigarray_get unsafe elt_kind layout b args dbg =
         bind "addr" (bigarray_indexing unsafe elt_kind layout b args dbg)
           (fun addr ->
           box_complex dbg
-            (Cop(Cload (kind, Mutable), [addr], dbg))
-            (Cop(Cload (kind, Mutable),
+            (Cop(Cload (kind, Mutable, Some b_ident), [addr], dbg))
+            (Cop(Cload (kind, Mutable, Some b_ident),
               [Cop(Cadda, [addr; Cconst_int sz], dbg)], dbg)))
     | _ ->
-        Cop(Cload (bigarray_word_kind elt_kind, Mutable),
+        Cop(Cload (bigarray_word_kind elt_kind, Mutable, None),
             [bigarray_indexing unsafe elt_kind layout b args dbg],
             dbg))
 
@@ -1135,10 +1143,10 @@ let bigarray_set unsafe elt_kind layout b args newval dbg =
 
 let unaligned_load_16 ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop(Cload (Sixteen_unsigned, Mutable), [add_int ptr idx dbg], dbg)
+  then Cop(Cload (Sixteen_unsigned, Mutable, None), [add_int ptr idx dbg], dbg)
   else
-    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int ptr idx dbg], dbg) in
-    let v2 = Cop(Cload (Byte_unsigned, Mutable),
+    let v1 = Cop(Cload (Byte_unsigned, Mutable, None), [add_int ptr idx dbg], dbg) in
+    let v2 = Cop(Cload (Byte_unsigned, Mutable, None),
                  [add_int (add_int ptr idx dbg) (Cconst_int 1) dbg], dbg) in
     let b1, b2 = if Arch.big_endian then v1, v2 else v2, v1 in
     Cop(Cor, [lsl_int b1 (Cconst_int 8) dbg; b2], dbg)
@@ -1161,14 +1169,14 @@ let unaligned_set_16 ptr idx newval dbg =
 
 let unaligned_load_32 ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop(Cload (Thirtytwo_unsigned, Mutable), [add_int ptr idx dbg], dbg)
+  then Cop(Cload (Thirtytwo_unsigned, Mutable, None), [add_int ptr idx dbg], dbg)
   else
-    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int ptr idx dbg], dbg) in
-    let v2 = Cop(Cload (Byte_unsigned, Mutable),
+    let v1 = Cop(Cload (Byte_unsigned, Mutable, None), [add_int ptr idx dbg], dbg) in
+    let v2 = Cop(Cload (Byte_unsigned, Mutable, None),
                  [add_int (add_int ptr idx dbg) (Cconst_int 1) dbg], dbg) in
-    let v3 = Cop(Cload (Byte_unsigned, Mutable),
+    let v3 = Cop(Cload (Byte_unsigned, Mutable, None),
                  [add_int (add_int ptr idx dbg) (Cconst_int 2) dbg], dbg) in
-    let v4 = Cop(Cload (Byte_unsigned, Mutable),
+    let v4 = Cop(Cload (Byte_unsigned, Mutable, None),
                  [add_int (add_int ptr idx dbg) (Cconst_int 3) dbg], dbg) in
     let b1, b2, b3, b4 =
       if Arch.big_endian
@@ -1215,22 +1223,22 @@ let unaligned_set_32 ptr idx newval dbg =
 let unaligned_load_64 ptr idx dbg =
   assert(size_int = 8);
   if Arch.allow_unaligned_access
-  then Cop(Cload (Word_int, Mutable), [add_int ptr idx dbg], dbg)
+  then Cop(Cload (Word_int, Mutable, None), [add_int ptr idx dbg], dbg)
   else
-    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int ptr idx dbg], dbg) in
-    let v2 = Cop(Cload (Byte_unsigned, Mutable),
+    let v1 = Cop(Cload (Byte_unsigned, Mutable, None), [add_int ptr idx dbg], dbg) in
+    let v2 = Cop(Cload (Byte_unsigned, Mutable, None),
                  [add_int (add_int ptr idx dbg) (Cconst_int 1) dbg], dbg) in
-    let v3 = Cop(Cload (Byte_unsigned, Mutable),
+    let v3 = Cop(Cload (Byte_unsigned, Mutable, None),
                  [add_int (add_int ptr idx dbg) (Cconst_int 2) dbg], dbg) in
-    let v4 = Cop(Cload (Byte_unsigned, Mutable),
+    let v4 = Cop(Cload (Byte_unsigned, Mutable, None),
                  [add_int (add_int ptr idx dbg) (Cconst_int 3) dbg], dbg) in
-    let v5 = Cop(Cload (Byte_unsigned, Mutable),
+    let v5 = Cop(Cload (Byte_unsigned, Mutable, None),
                  [add_int (add_int ptr idx dbg) (Cconst_int 4) dbg], dbg) in
-    let v6 = Cop(Cload (Byte_unsigned, Mutable),
+    let v6 = Cop(Cload (Byte_unsigned, Mutable, None),
                  [add_int (add_int ptr idx dbg) (Cconst_int 5) dbg], dbg) in
-    let v7 = Cop(Cload (Byte_unsigned, Mutable),
+    let v7 = Cop(Cload (Byte_unsigned, Mutable, None),
                  [add_int (add_int ptr idx dbg) (Cconst_int 6) dbg], dbg) in
-    let v8 = Cop(Cload (Byte_unsigned, Mutable),
+    let v8 = Cop(Cload (Byte_unsigned, Mutable, None),
                  [add_int (add_int ptr idx dbg) (Cconst_int 7) dbg], dbg) in
     let b1, b2, b3, b4, b5, b6, b7, b8 =
       if Arch.big_endian
@@ -1845,7 +1853,7 @@ let rec transl env e =
             dbg)
       | (Pbigarraydim(n), [b]) ->
           let dim_ofs = 4 + n in
-          tag_int (Cop(Cload (Word_int, Mutable),
+          tag_int (Cop(Cload (Word_int, Mutable, None),
             [field_address (transl env b) dim_ofs dbg],
             dbg)) dbg
       | (p, [arg]) ->
@@ -1949,7 +1957,7 @@ let rec transl env e =
       end
   | Uunreachable ->
       let dbg = Debuginfo.none in
-      Cop(Cload (Word_int, Mutable), [Cconst_int 0], dbg)
+      Cop(Cload (Word_int, Mutable, None), [Cconst_int 0], dbg)
 
 and transl_make_array dbg env kind args =
   match kind with
@@ -2007,7 +2015,7 @@ and transl_prim_1 env p arg dbg =
   | Pfloatfield n ->
       let ptr = transl env arg in
       box_float dbg (
-        Cop(Cload (Double_u, Mutable),
+        Cop(Cload (Double_u, Mutable, None),
             [if n = 0 then ptr
                        else Cop(Cadda, [ptr; Cconst_int(n * size_float)], dbg)],
             dbg))
@@ -2050,7 +2058,7 @@ and transl_prim_1 env p arg dbg =
         (bind "ref" (transl env arg) (fun arg ->
           Cop(Cstore (Word_int, Assignment),
               [arg;
-               add_const (Cop(Cload (Word_int, Mutable), [arg], dbg))
+               add_const (Cop(Cload (Word_int, Mutable, None), [arg], dbg))
                  (n lsl 1) dbg],
               dbg)))
   (* Floating-point operations *)
@@ -2230,7 +2238,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
 
   (* String operations *)
   | Pstringrefu | Pbytesrefu ->
-      tag_int(Cop(Cload (Byte_unsigned, Mutable),
+      tag_int(Cop(Cload (Byte_unsigned, Mutable, None),
                   [add_int (transl env arg1) (untag_int(transl env arg2) dbg)
                     dbg],
                   dbg)) dbg
@@ -2240,7 +2248,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
           bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
             Csequence(
               make_checkbound dbg [string_length str dbg; idx],
-              Cop(Cload (Byte_unsigned, Mutable),
+              Cop(Cload (Byte_unsigned, Mutable, None),
                 [add_int str idx dbg], dbg))))) dbg
 
   | Pstring_load_16(unsafe) | Pbytes_load_16(unsafe) ->
@@ -2256,9 +2264,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "ba_data"
-         (Cop(Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg))
+         (Cop(Cload (Word_int, Mutable, None), [field_address ba 1 dbg], dbg))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
+          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable, None),
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 1) dbg) idx
                       (unaligned_load_16 ba_data idx dbg))))) dbg
@@ -2276,9 +2284,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "ba_data"
-         (Cop(Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg))
+         (Cop(Cload (Word_int, Mutable, None), [field_address ba 1 dbg], dbg))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
+          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable, None),
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 3) dbg) idx
                       (unaligned_load_32 ba_data idx dbg)))))
@@ -2296,9 +2304,9 @@ and transl_prim_2 env p arg1 arg2 dbg =
        (bind "ba" (transl env arg1) (fun ba ->
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "ba_data"
-         (Cop(Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg))
+         (Cop(Cload (Word_int, Mutable, None), [field_address ba 1 dbg], dbg))
          (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
+          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable, None),
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 7) dbg) idx
                       (unaligned_load_64 ba_data idx dbg)))))
@@ -2529,9 +2537,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "newval" (untag_int (transl env arg3) dbg) (fun newval ->
         bind "ba_data"
-             (Cop(Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg))
+             (Cop(Cload (Word_int, Mutable, None), [field_address ba 1 dbg], dbg))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
+          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable, None),
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 1)
                                           dbg)
@@ -2552,9 +2560,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "newval" (transl_unbox_int dbg env Pint32 arg3) (fun newval ->
         bind "ba_data"
-             (Cop(Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg))
+             (Cop(Cload (Word_int, Mutable, None), [field_address ba 1 dbg], dbg))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
+          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable, None),
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 3)
                                           dbg)
@@ -2575,9 +2583,9 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
         bind "index" (untag_int (transl env arg2) dbg) (fun idx ->
         bind "newval" (transl_unbox_int dbg env Pint64 arg3) (fun newval ->
         bind "ba_data"
-             (Cop(Cload (Word_int, Mutable), [field_address ba 1 dbg], dbg))
+             (Cop(Cload (Word_int, Mutable, None), [field_address ba 1 dbg], dbg))
              (fun ba_data ->
-          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable),
+          check_bound unsafe dbg (sub_int (Cop(Cload (Word_int, Mutable, None),
                                                [field_address ba 5 dbg], dbg))
                                           (Cconst_int 7)
                                           dbg) idx
@@ -3121,7 +3129,7 @@ let cache_public_method meths tag cache dbg =
   Clet (
   li, Cconst_int 3,
   Clet (
-  hi, Cop(Cload (Word_int, Mutable), [meths], dbg),
+  hi, Cop(Cload (Word_int, Mutable, None), [meths], dbg),
   Csequence(
   ccatch
     (raise_num, [],
@@ -3137,7 +3145,7 @@ let cache_public_method meths tag cache dbg =
         Cifthenelse
           (Cop (Ccmpi Clt,
                 [tag;
-                 Cop(Cload (Word_int, Mutable),
+                 Cop(Cload (Word_int, Mutable, None),
                      [Cop(Cadda,
                           [meths; lsl_const (Cvar mi) log2_size_addr dbg],
                           dbg)],
@@ -3209,18 +3217,18 @@ let send_function arity =
     let cached_pos = Cvar cached in
     let tag_pos = Cop(Cadda, [Cop (Cadda, [cached_pos; Cvar meths], dbg);
                               Cconst_int(3*size_addr-1)], dbg) in
-    let tag' = Cop(Cload (Word_int, Mutable), [tag_pos], dbg) in
+    let tag' = Cop(Cload (Word_int, Mutable, None), [tag_pos], dbg) in
     Clet (
-    meths, Cop(Cload (Word_val, Mutable), [obj], dbg),
+    meths, Cop(Cload (Word_val, Mutable, None), [obj], dbg),
     Clet (
     cached,
-      Cop(Cand, [Cop(Cload (Word_int, Mutable), [cache], dbg); mask], dbg),
+      Cop(Cand, [Cop(Cload (Word_int, Mutable, None), [cache], dbg); mask], dbg),
     Clet (
     real,
     Cifthenelse(Cop(Ccmpa Cne, [tag'; tag], dbg),
                 cache_public_method (Cvar meths) tag cache dbg,
                 cached_pos),
-    Cop(Cload (Word_val, Mutable),
+    Cop(Cload (Word_val, Mutable, None),
       [Cop(Cadda, [Cop (Cadda, [Cvar real; Cvar meths], dbg);
        Cconst_int(2*size_addr-1)], dbg)], dbg))))
 
@@ -3441,7 +3449,7 @@ let entry_point namelist =
   let incr_global_inited =
     Cop(Cstore (Word_int, Assignment),
         [Cconst_symbol "caml_globals_inited";
-         Cop(Caddi, [Cop(Cload (Word_int, Mutable),
+         Cop(Caddi, [Cop(Cload (Word_int, Mutable, None),
                        [Cconst_symbol "caml_globals_inited"], dbg);
                      Cconst_int 1], dbg)], dbg) in
   let body =

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -1078,7 +1078,7 @@ let bigarray_indexing unsafe elt_kind layout b args dbg =
   and elt_size =
     bigarray_elt_size elt_kind in
   (* [array_indexing] can simplify the given expressions *)
-  array_indexing ~typ:Addr (log2 elt_size)
+  array_indexing ~typ:Int (log2 elt_size)
                  (Cop(Cload (Word_int, Mutable),
                     [field_address b 1 dbg], dbg)) offset dbg
 
@@ -1103,13 +1103,12 @@ let bigarray_get unsafe elt_kind layout b args dbg =
       Pbigarray_complex32 | Pbigarray_complex64 ->
         let kind = bigarray_word_kind elt_kind in
         let sz = bigarray_elt_size elt_kind / 2 in
-        bind "addr" (bigarray_indexing unsafe elt_kind layout b args dbg) (fun addr ->
-          bind "reval"
-            (Cop(Cload (kind, Mutable), [addr], dbg)) (fun reval ->
-              bind "imval"
-                (Cop(Cload (kind, Mutable),
-                     [Cop(Cadda, [addr; Cconst_int sz], dbg)], dbg)) (fun imval ->
-          box_complex dbg reval imval)))
+        bind "addr" (bigarray_indexing unsafe elt_kind layout b args dbg)
+          (fun addr ->
+          box_complex dbg
+            (Cop(Cload (kind, Mutable), [addr], dbg))
+            (Cop(Cload (kind, Mutable),
+              [Cop(Cadda, [addr; Cconst_int sz], dbg)], dbg)))
     | _ ->
         Cop(Cload (bigarray_word_kind elt_kind, Mutable),
             [bigarray_indexing unsafe elt_kind layout b args dbg],

--- a/asmcomp/i386/selection.ml
+++ b/asmcomp/i386/selection.ml
@@ -250,11 +250,11 @@ method! select_operation op args dbg =
 
 method select_floatarith regular_op reversed_op mem_op mem_rev_op args =
   match args with
-    [arg1; Cop(Cload (chunk, _), [loc2], _)] ->
+    [arg1; Cop(Cload (chunk, _, _), [loc2], _)] ->
       let (addr, arg2) = self#select_addressing chunk loc2 in
       (Ispecific(Ifloatarithmem(chunk_double chunk, mem_op, addr)),
                  [arg1; arg2])
-  | [Cop(Cload (chunk, _), [loc1], _); arg2] ->
+  | [Cop(Cload (chunk, _, _), [loc1], _); arg2] ->
       let (addr, arg1) = self#select_addressing chunk loc1 in
       (Ispecific(Ifloatarithmem(chunk_double chunk, mem_rev_op, addr)),
                  [arg2; arg1])
@@ -292,10 +292,10 @@ method select_push exp =
   | Cconst_pointer n -> (Ispecific(Ipush_int(Nativeint.of_int n)), Ctuple [])
   | Cconst_natpointer n -> (Ispecific(Ipush_int n), Ctuple [])
   | Cconst_symbol s -> (Ispecific(Ipush_symbol s), Ctuple [])
-  | Cop(Cload ((Word_int | Word_val as chunk), _), [loc], _) ->
+  | Cop(Cload ((Word_int | Word_val as chunk), _, _), [loc], _) ->
       let (addr, arg) = self#select_addressing chunk loc in
       (Ispecific(Ipush_load addr), arg)
-  | Cop(Cload (Double_u, _), [loc], _) ->
+  | Cop(Cload (Double_u, _, _), [loc], _) ->
       let (addr, arg) = self#select_addressing Double_u loc in
       (Ispecific(Ipush_load_float addr), arg)
   | _ -> (Ispecific(Ipush), exp)

--- a/asmcomp/liveness.ml
+++ b/asmcomp/liveness.ml
@@ -71,7 +71,9 @@ let rec live i finally =
                  Hence, everything that must be live at the beginning of
                  the exception handler must also be live across this instr. *)
                Reg.Set.union across_after !live_at_raise
-           | _ ->
+          | Iload _ when Array.length i.arg = 2 ->
+               Reg.Set.add i.arg.(1) across_after
+          | _ ->
                across_after in
         i.live <- across;
         Reg.add_set_array across arg

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -73,12 +73,18 @@ let raise_kind fmt = function
   | Raise_withtrace -> Format.fprintf fmt "raise_withtrace"
   | Raise_notrace -> Format.fprintf fmt "raise_notrace"
 
+let ident_option = function
+  | None -> ""
+  | Some id -> Printf.sprintf " from %s" (Ident.unique_name id)
+
 let operation d = function
   | Capply _ty -> "app" ^ Debuginfo.to_string d
   | Cextcall(lbl, _ty, _alloc, _) ->
       Printf.sprintf "extcall \"%s\"%s" lbl (Debuginfo.to_string d)
-  | Cload (c, Asttypes.Immutable) -> Printf.sprintf "load %s" (chunk c)
-  | Cload (c, Asttypes.Mutable) -> Printf.sprintf "load_mut %s" (chunk c)
+  | Cload (c, Asttypes.Immutable, from) ->
+      Printf.sprintf "load %s%s" (chunk c) (ident_option from)
+  | Cload (c, Asttypes.Mutable, from) ->
+      Printf.sprintf "load_mut %s%s" (chunk c) (ident_option from)
   | Calloc -> "alloc" ^ Debuginfo.to_string d
   | Cstore (c, init) ->
     let init =

--- a/asmcomp/spacetime_profiling.ml
+++ b/asmcomp/spacetime_profiling.ml
@@ -89,7 +89,7 @@ let code_for_function_prologue ~function_name ~node_hole =
         body)
   in
   let pc = Ident.create "pc" in
-  Clet (node, Cop (Cload (Word_int, Asttypes.Mutable), [Cvar node_hole], dbg),
+  Clet (node, Cop (Cload (Word_int, Asttypes.Mutable, None), [Cvar node_hole], dbg),
     Clet (must_allocate_node,
       Cop (Cand, [Cvar node; Cconst_int 1], dbg),
       Cifthenelse (
@@ -105,7 +105,7 @@ let code_for_function_prologue ~function_name ~node_hole =
               ],
               dbg)),
             Clet (new_node,
-              Cop (Cload (Word_int, Asttypes.Mutable), [Cvar node_hole], dbg),
+              Cop (Cload (Word_int, Asttypes.Mutable, None), [Cvar node_hole], dbg),
               if no_tail_calls then Cvar new_node
               else
                 Cifthenelse (
@@ -149,7 +149,7 @@ let code_for_blockheader ~value's_header ~node ~dbg =
       Cconst_int offset_into_node;
     ], dbg),
     Clet (existing_profinfo,
-        Cop (Cload (Word_int, Asttypes.Mutable), [Cvar address_of_profinfo],
+        Cop (Cload (Word_int, Asttypes.Mutable, None), [Cvar address_of_profinfo],
           dbg),
       Clet (profinfo,
         Cifthenelse (
@@ -157,7 +157,7 @@ let code_for_blockheader ~value's_header ~node ~dbg =
           Cvar existing_profinfo,
           generate_new_profinfo),
         Clet (existing_count,
-          Cop (Cload (Word_int, Asttypes.Mutable), [
+          Cop (Cload (Word_int, Asttypes.Mutable, None), [
             Cop (Caddi,
               [Cvar address_of_profinfo; Cconst_int Arch.size_addr], dbg)
           ], dbg),
@@ -232,7 +232,7 @@ let code_for_call ~node ~callee ~is_tail ~label =
         Clet (count_addr,
           Cop (Caddi, [Cvar place_within_node; Cconst_int Arch.size_addr], dbg),
           Clet (count,
-            Cop (Cload (Word_int, Asttypes.Mutable), [Cvar count_addr], dbg),
+            Cop (Cload (Word_int, Asttypes.Mutable, None), [Cvar count_addr], dbg),
             Csequence (
               Cop (Cstore (Word_int, Lambda.Assignment),
                 (* Adding 2 really means adding 1; the count is encoded

--- a/asmcomp/strmatch.ml
+++ b/asmcomp/strmatch.ml
@@ -73,7 +73,7 @@ module Make(I:I) = struct
   let mk_let_cell id str ind body =
     let dbg = Debuginfo.none in
     let cell =
-      Cop(Cload (Word_int, Asttypes.Mutable),
+      Cop(Cload (Word_int, Asttypes.Mutable, None),
         [Cop(Cadda,[str;Cconst_int(Arch.size_int*ind)], dbg)],
         dbg) in
     Clet(id, cell, body)

--- a/testsuite/tests/asmgen/parsecmm.mly
+++ b/testsuite/tests/asmgen/parsecmm.mly
@@ -216,16 +216,16 @@ expr:
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
                 { unbind_ident $5; Ctrywith($3, $5, $6) }
   | LPAREN VAL expr expr RPAREN
-      { Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],
+      { Cop(Cload (Word_val, Mutable, None), [access_array $3 $4 Arch.size_addr],
           debuginfo ()) }
   | LPAREN ADDRAREF expr expr RPAREN
-      { Cop(Cload (Word_val, Mutable), [access_array $3 $4 Arch.size_addr],
+      { Cop(Cload (Word_val, Mutable, None), [access_array $3 $4 Arch.size_addr],
           Debuginfo.none) }
   | LPAREN INTAREF expr expr RPAREN
-      { Cop(Cload (Word_int, Mutable), [access_array $3 $4 Arch.size_int],
+      { Cop(Cload (Word_int, Mutable, None), [access_array $3 $4 Arch.size_int],
           Debuginfo.none) }
   | LPAREN FLOATAREF expr expr RPAREN
-      { Cop(Cload (Double_u, Mutable), [access_array $3 $4 Arch.size_float],
+      { Cop(Cload (Double_u, Mutable, None), [access_array $3 $4 Arch.size_float],
           Debuginfo.none) }
   | LPAREN ADDRASET expr expr expr RPAREN
       { Cop(Cstore (Word_val, Assignment),
@@ -267,7 +267,7 @@ chunk:
   | VAL                         { Word_val }
 ;
 unaryop:
-    LOAD chunk                  { Cload ($2, Mutable) }
+    LOAD chunk                  { Cload ($2, Mutable, None) }
   | FLOATOFINT                  { Cfloatofint }
   | INTOFFLOAT                  { Cintoffloat }
   | RAISE                       { Craise $1 }


### PR DESCRIPTION
(joint work with @mshinwell and @lpw25)

The following function can raise an `Assert_failure` in trunk:
```
let bug_example () =
  let open Bigarray in
  let work = Array1.create complex64 c_layout 1 in
  work.{0} <- { Complex. re=0.; im=0. };
  let result = work.{0}.Complex.re in (* alloc *)
  assert (result = 0.)
```
because the `Complex.t` value (corresponding to `work.{0}` on
line "alloc" ) is allocated after the address inside the bigarray
has been computed but before the reads actually occur.
The allocation can trigger a collection that then deallocates the
bigarray.

This PR moves the allocation of the `Complex.t` value so that
it occurs after the reads from the bigarray. Our understanding
is that only complex reads can allocate: non-complex reads do
not allocate, and writes never allocate.

For the record, here is the linear code for the function above
(`addr/45` is live across the `alloc 24`):
```
camlBa_complex_bug__bug_example_1002: {ba_complex_bug.ml:3,16-307}
  I/30[%rdi] := 3
  V/31[%rbx] := 1
  V/32[%rax] := 23
  {}
  R/0[%rax] := call "camlStdlib__bigarray__create_1242" R/0[%rax] R/1[%rbx] R/2[%rdi] {ba_complex_bug.ml:4,13-47}
  I/34[%rbx] := int[work/33[%rax] + 40] {ba_complex_bug.ml:5,2-39}
  I/34[%rbx] check > 0 {ba_complex_bug.ml:5,2-39}
  I/35[%rbx] := 1
  I/36[%rdi] := int[work/33[%rax] + 8] {ba_complex_bug.ml:5,2-39}
  addr/37[%rbx] := I/36[%rdi] + I/35[%rbx] * 8 + -8 {ba_complex_bug.ml:5,2-39}
  V/38[%rdi] := "camlBa_complex_bug__1"
  F/39[%xmm0] := float64u[V/38[%rdi]] {ba_complex_bug.ml:5,2-39}
  float64[addr/37[%rbx]] := F/39[%xmm0] (assign) {ba_complex_bug.ml:5,2-39}
  F/41[%xmm0] := float64u[V/40[%rdi] + 8] {ba_complex_bug.ml:5,2-39}
  float64[addr/37[%rbx] + 8] := F/41[%xmm0] (assign) {ba_complex_bug.ml:5,2-39}
  I/42[%rbx] := int[work/33[%rax] + 40] {ba_complex_bug.ml:6,15-23}
  I/42[%rbx] check > 0 {ba_complex_bug.ml:6,15-23}
  I/43[%rbx] := 1
  I/44[%rax] := int[work/33[%rax] + 8] {ba_complex_bug.ml:6,15-23}
  addr/45[%rbx] := I/44[%rax] + I/43[%rbx] * 8 + -8 {ba_complex_bug.ml:6,15-23}
  {addr/45[%rbx]}
  V/46[%rax] := alloc 24 {ba_complex_bug.ml:6,15-23}
  [V/46[%rax] + -8] := 2302 (init)
  F/47[%xmm0] := float64[addr/45[%rbx]] {ba_complex_bug.ml:6,15-23}
  float64u[V/46[%rax]] := F/47[%xmm0] (init)
  F/48[%xmm0] := float64[addr/45[%rbx] + 8] {ba_complex_bug.ml:6,15-23}
  float64u[V/46[%rax] + 8] := F/48[%xmm0] (init)
  result/49[%xmm0] := float64u[V/46[%rax]] {ba_complex_bug.ml:6,15-34}
  F/50[%xmm1] := 0.
  if result/49[%xmm0] !=f F/50[%xmm1] goto L101
  V/54[%rax] := 1
  reload retaddr
  return R/0[%rax]
  L101:
  {}
  V/51[%rax] := alloc 24 {ba_complex_bug.ml:7,32-156}
  [V/51[%rax] + -8] := 2048 (init)
  V/52[%rbx] := "caml_exn_Assert_failure"
  val[V/51[%rax]] := V/52[%rbx] (init)
  V/53[%rbx] := "camlBa_complex_bug__4"
  val[V/51[%rax] + 8] := V/53[%rbx] (init)
  raise_notrace R/0[%rax] {ba_complex_bug.ml:7,32-156}
```
