### PR TITLE
Use raise_notrace rather than raise in format.ml

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,9 @@ Working version
 
 ### Standard library:
 
+- GPR#1731: Format, use raise_notrace to preserve backtraces
+  (Frédéric Bour, report by Jules Villard, review by Gabriel Scherer)
+
 ### Other libraries:
 
 ### Compiler user-interface and warnings:

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -239,7 +239,7 @@ exception Empty_queue
 
 let peek_queue = function
   | { body = Cons { head = x; tail = _; }; _ } -> x
-  | { body = Nil; insert = _; } -> raise Empty_queue
+  | { body = Nil; insert = _; } -> raise_notrace Empty_queue
 
 
 let take_queue = function
@@ -247,7 +247,7 @@ let take_queue = function
     q.body <- tl;
     if tl = Nil then q.insert <- Nil; (* Maintain the invariant. *)
     x
-  | { body = Nil; insert = _; } -> raise Empty_queue
+  | { body = Nil; insert = _; } -> raise_notrace Empty_queue
 
 
 (* Enter a token in the pretty-printer queue. *)
@@ -393,7 +393,7 @@ let format_pp_token state size = function
     | Pp_tbox tabs :: _ ->
       let rec find n = function
         | x :: l -> if x >= n then x else find n l
-        | [] -> raise Not_found in
+        | [] -> raise_notrace Not_found in
       let tab =
         match !tabs with
         | x :: _ ->


### PR DESCRIPTION
Calls to `raise` in `Format` can accidentally appear in backtraces, especially when formatting an error message after catching an exception.

By using `raise_notrace`, the backtrace is no longer clobbered and the debugger is happy.

Note: I had some failure running the testsuite (on macOS), but these didn't look related to the change, I will investigate more.