### PR TITLE
fix grammar conflicts in ocamldoc

### DIFF
--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -273,10 +273,10 @@ odoc_see_lexer.ml: odoc_see_lexer.mll
 	$(OCAMLLEX) $<
 
 .mly.ml:
-	$(OCAMLYACC) -v $<
+	$(OCAMLYACC) --strict -v $<
 
 .mly.mli:
-	$(OCAMLYACC) -v $<
+	$(OCAMLYACC) --strict -v $<
 
 # Installation targets
 ######################

--- a/ocamldoc/odoc_text_parser.mly
+++ b/ocamldoc/odoc_text_parser.mly
@@ -82,6 +82,9 @@ let print_DEBUG s = print_string s; print_newline ()
 %token EOF
 %token <string> Char
 
+%nonassoc below_Char
+%nonassoc Char
+
 /* Start Symbols */
 %start main located_element_list
 %type <Odoc_types.text> main
@@ -177,7 +180,6 @@ text_element:
 list:
 | string { [] (* TODO: a test to check that there is only space characters *) }
 | string list { $2 }
-| list string  { $1 }
 | item { [ $1 ] }
 | item list { $1 :: $2 }
 
@@ -207,7 +209,7 @@ shortcut_enum2:
 
 
 string:
-    Char { $1 }
+    Char %prec below_Char { $1 }
 | Char string { $1^$2 }
 ;
 


### PR DESCRIPTION
Fix conflicts in ocamldoc text parser, and make sure they won't come back.
