### PR TITLE
Expand the "Unexpected existential" error message

### DIFF
--- a/Changes
+++ b/Changes
@@ -16,6 +16,9 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+  -GPR#1733: change the perspective of the unexpected existential error message
+  (Florian Angeletti)
+
 ### Code generation and optimizations:
 
 ### Runtime system:

--- a/Changes
+++ b/Changes
@@ -17,7 +17,7 @@ Working version
 ### Compiler user-interface and warnings:
 
   -GPR#1733: change the perspective of the unexpected existential error message
-  (Florian Angeletti)
+  (Florian Angeletti, review by Gabriel Scherer and Jeremy Yallop)
 
 ### Code generation and optimizations:
 

--- a/testsuite/tests/typing-gadts/ocamltests
+++ b/testsuite/tests/typing-gadts/ocamltests
@@ -43,6 +43,7 @@ pr7618.ml
 pr7747.ml
 term-conv.ml
 test.ml
+unexpected_existentials.ml
 unify_mb.ml
 variables_in_mcomp.ml
 yallop_bugs.ml

--- a/testsuite/tests/typing-gadts/unexpected_existentials.ml
+++ b/testsuite/tests/typing-gadts/unexpected_existentials.ml
@@ -82,7 +82,7 @@ Line _, characters 4-9:
   let Any x = Any ()
       ^^^^^
 Error: Existential types are not allowed in toplevel bindings,
-but the constructor Any introduces unnamed existential types.
+but the constructor Any introduces existential types.
 |}]
 
 
@@ -92,7 +92,7 @@ Line _, characters 14-20:
   class c = let Any _x = () in object end
                 ^^^^^^
 Error: Existential types are not allowed in bindings inside class definition,
-but the constructor Any introduces unnamed existential types.
+but the constructor Any introduces existential types.
 |}]
 
 let () =
@@ -103,7 +103,7 @@ Line _, characters 6-11:
     let Any x = Any () and () = () in
         ^^^^^
 Error: Existential types are not allowed in "let ... and ..." bindings,
-but the constructor Any introduces unnamed existential types.
+but the constructor Any introduces existential types.
 |}]
 
 
@@ -115,7 +115,7 @@ Line _, characters 10-15:
     let rec Any x = Any () in
             ^^^^^
 Error: Existential types are not allowed in recursive bindings,
-but the constructor Any introduces unnamed existential types.
+but the constructor Any introduces existential types.
 |}]
 
 
@@ -127,7 +127,7 @@ Line _, characters 18-23:
     let[@attribute] Any x = Any () in
                     ^^^^^
 Error: Existential types are not allowed in presence of attributes,
-but the constructor Any introduces unnamed existential types.
+but the constructor Any introduces existential types.
 |}]
 
 class c (Any x) = object end
@@ -136,7 +136,7 @@ Line _, characters 8-15:
   class c (Any x) = object end
           ^^^^^^^
 Error: Existential types are not allowed in class arguments,
-but the constructor Any introduces unnamed existential types.
+but the constructor Any introduces existential types.
 |}]
 
 class c = object(Any x) end
@@ -145,7 +145,7 @@ Line _, characters 16-23:
   class c = object(Any x) end
                   ^^^^^^^
 Error: Existential types are not allowed in self patterns,
-but the constructor Any introduces unnamed existential types.
+but the constructor Any introduces existential types.
 |}]
 
 class c = let Any _x = () in object end
@@ -154,5 +154,5 @@ Line _, characters 14-20:
   class c = let Any _x = () in object end
                 ^^^^^^
 Error: Existential types are not allowed in bindings inside class definition,
-but the constructor Any introduces unnamed existential types.
+but the constructor Any introduces existential types.
 |}]

--- a/testsuite/tests/typing-gadts/unexpected_existentials.ml
+++ b/testsuite/tests/typing-gadts/unexpected_existentials.ml
@@ -1,0 +1,68 @@
+(* TEST
+ * expect
+*)
+(** Test the error message for existential types apparearing
+    in unexpected position *)
+type any = Any: 'a -> any
+[%%expect {|
+type any = Any : 'a -> any
+|}]
+
+let Any x = Any ()
+[%%expect {|
+Line _, characters 4-9:
+  let Any x = Any ()
+      ^^^^^
+Error: Existential types are not allowed in toplevel bindings,
+but this pattern introduces the existential type $Any_'a.
+|}]
+
+class c (Any x) = object end
+[%%expect {|
+Line _, characters 8-15:
+  class c (Any x) = object end
+          ^^^^^^^
+Error: Existential types are not allowed in class arguments,
+but this pattern introduces the existential type $Any_'a.
+|}]
+
+class c = object(Any x)end
+[%%expect {|
+Line _, characters 16-23:
+  class c = object(Any x)end
+                  ^^^^^^^
+Error: Existential types are not allowed in self patterns,
+but this pattern introduces the existential type $Any_'a.
+|}]
+
+type other = Any: _ -> other
+[%%expect {|
+type other = Any : 'a -> other
+|}]
+
+let Any x = Any ()
+[%%expect {|
+Line _, characters 4-9:
+  let Any x = Any ()
+      ^^^^^
+Error: Existential types are not allowed in toplevel bindings,
+but the constructor Any introduces unnamed existential types.
+|}]
+
+class c (Any x) = object end
+[%%expect {|
+Line _, characters 8-15:
+  class c (Any x) = object end
+          ^^^^^^^
+Error: Existential types are not allowed in class arguments,
+but the constructor Any introduces unnamed existential types.
+|}]
+
+class c = object(Any x) end
+[%%expect {|
+Line _, characters 16-23:
+  class c = object(Any x) end
+                  ^^^^^^^
+Error: Existential types are not allowed in self patterns,
+but the constructor Any introduces unnamed existential types.
+|}]

--- a/testsuite/tests/typing-gadts/unexpected_existentials.ml
+++ b/testsuite/tests/typing-gadts/unexpected_existentials.ml
@@ -17,6 +17,42 @@ Error: Existential types are not allowed in toplevel bindings,
 but this pattern introduces the existential type $Any_'a.
 |}]
 
+let () =
+  let Any x = Any () and () = () in
+  ()
+[%%expect {|
+Line _, characters 6-11:
+    let Any x = Any () and () = () in
+        ^^^^^
+Error: Existential types are not allowed in "let ... and ..." bindings,
+but this pattern introduces the existential type $Any_'a.
+|}]
+
+
+let () =
+  let rec Any x = Any () in
+  ()
+[%%expect {|
+Line _, characters 10-15:
+    let rec Any x = Any () in
+            ^^^^^
+Error: Existential types are not allowed in recursive bindings,
+but this pattern introduces the existential type $Any_'a.
+|}]
+
+
+let () =
+  let[@attribute] Any x = Any () in
+  ()
+[%%expect {|
+Line _, characters 18-23:
+    let[@attribute] Any x = Any () in
+                    ^^^^^
+Error: Existential types are not allowed in presence of attributes,
+but this pattern introduces the existential type $Any_'a.
+|}]
+
+
 class c (Any x) = object end
 [%%expect {|
 Line _, characters 8-15:
@@ -49,6 +85,51 @@ Error: Existential types are not allowed in toplevel bindings,
 but the constructor Any introduces unnamed existential types.
 |}]
 
+
+class c = let Any _x = () in object end
+[%%expect {|
+Line _, characters 14-20:
+  class c = let Any _x = () in object end
+                ^^^^^^
+Error: Existential types are not allowed in bindings inside class definition,
+but the constructor Any introduces unnamed existential types.
+|}]
+
+let () =
+  let Any x = Any () and () = () in
+  ()
+[%%expect {|
+Line _, characters 6-11:
+    let Any x = Any () and () = () in
+        ^^^^^
+Error: Existential types are not allowed in "let ... and ..." bindings,
+but the constructor Any introduces unnamed existential types.
+|}]
+
+
+let () =
+  let rec Any x = Any () in
+  ()
+[%%expect {|
+Line _, characters 10-15:
+    let rec Any x = Any () in
+            ^^^^^
+Error: Existential types are not allowed in recursive bindings,
+but the constructor Any introduces unnamed existential types.
+|}]
+
+
+let () =
+  let[@attribute] Any x = Any () in
+  ()
+[%%expect {|
+Line _, characters 18-23:
+    let[@attribute] Any x = Any () in
+                    ^^^^^
+Error: Existential types are not allowed in presence of attributes,
+but the constructor Any introduces unnamed existential types.
+|}]
+
 class c (Any x) = object end
 [%%expect {|
 Line _, characters 8-15:
@@ -64,5 +145,14 @@ Line _, characters 16-23:
   class c = object(Any x) end
                   ^^^^^^^
 Error: Existential types are not allowed in self patterns,
+but the constructor Any introduces unnamed existential types.
+|}]
+
+class c = let Any _x = () in object end
+[%%expect {|
+Line _, characters 14-20:
+  class c = let Any _x = () in object end
+                ^^^^^^
+Error: Existential types are not allowed in bindings inside class definition,
 but the constructor Any introduces unnamed existential types.
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1145,17 +1145,17 @@ let new_declaration expansion_scope manifest =
     type_unboxed = unboxed_false_default_false;
   }
 
+let existential_name cstr ty = match repr ty with
+  | {desc = Tvar (Some name)} -> "$" ^ cstr.cstr_name ^ "_'" ^ name
+  | _ -> "$" ^ cstr.cstr_name
+
 let instance_constructor ?in_pattern cstr =
   begin match in_pattern with
   | None -> ()
   | Some (env, expansion_scope) ->
       let process existential =
         let decl = new_declaration (Some expansion_scope) None in
-        let name =
-          match repr existential with
-            {desc = Tvar (Some name)} -> "$" ^ cstr.cstr_name ^ "_'" ^ name
-          | _ -> "$" ^ cstr.cstr_name
-        in
+        let name = existential_name cstr existential in
         let path = Path.Pident (Ident.create (get_new_abstract_name name)) in
         let new_env = Env.add_local_type path decl !env in
         env := new_env;

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -125,6 +125,7 @@ val generic_instance: type_expr -> type_expr
         (* Same as instance, but new nodes at generic_level *)
 val instance_list: type_expr list -> type_expr list
         (* Take an instance of a list of type schemes *)
+val existential_name: constructor_description -> type_expr -> string
 val instance_constructor:
         ?in_pattern:Env.t ref * int ->
         constructor_description -> type_expr list * type_expr

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1158,7 +1158,7 @@ and class_expr_aux cl_num val_env met_env scl =
   | Pcl_let (rec_flag, sdefs, scl') ->
       let (defs, val_env) =
         try
-          Typecore.type_let val_env rec_flag sdefs None
+          Typecore.type_let In_class_def val_env rec_flag sdefs None
         with Ctype.Unify [(ty, _)] ->
           raise(Error(scl.pcl_loc, val_env, Make_nongen_seltype ty))
       in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5410,7 +5410,7 @@ let report_error env ppf = function
           "but this pattern introduces the existential type %s." example
       with Not_found ->
         fprintf ppf
-          "but the constructor %s introduces unnamed existential types." name
+          "but the constructor %s introduces existential types." name
     )
   | Invalid_interval ->
       fprintf ppf "@[Only character intervals are supported in patterns.@]"

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -104,6 +104,11 @@ val name_pattern : string -> Typedtree.case list -> Ident.t
 
 val self_coercion : (Path.t * Location.t list ref) list ref
 
+type existential_restriction =
+  | At_toplevel (** no existential types at the toplevel *)
+  | In_class_args (** nor in class arguments *)
+  | In_self_pattern (** or in self pattern *)
+
 type error =
     Polymorphic_label of Longident.t
   | Constructor_arity_mismatch of Longident.t * int * int
@@ -145,7 +150,7 @@ type error =
   | Cannot_infer_signature
   | Not_a_packed_module of type_expr
   | Recursive_local_constraint of (type_expr * type_expr) list
-  | Unexpected_existential
+  | Unexpected_existential of existential_restriction * string * string list
   | Invalid_interval
   | Invalid_for_loop_index
   | No_value_clauses

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -55,13 +55,22 @@ val mk_expected:
 
 val is_nonexpansive: Typedtree.expression -> bool
 
+type existential_restriction =
+  | At_toplevel (** no existential types at the toplevel *)
+  | In_group (** nor with [let ... and ...] *)
+  | In_rec (** or recursive definition *)
+  | With_attributes (** or [let[@any_attribute] = ...] *)
+  | In_class_args (** or in class arguments [class c (...) = ...] *)
+  | In_class_def (** or in [class c = let ... in ...] *)
+  | In_self_pattern (** or in self pattern *)
+
 val type_binding:
         Env.t -> rec_flag ->
           Parsetree.value_binding list ->
           Annot.ident option ->
           Typedtree.value_binding list * Env.t
 val type_let:
-        Env.t -> rec_flag ->
+        existential_restriction -> Env.t -> rec_flag ->
           Parsetree.value_binding list ->
           Annot.ident option ->
           Typedtree.value_binding list * Env.t
@@ -103,11 +112,6 @@ val force_delayed_checks: unit -> unit
 val name_pattern : string -> Typedtree.case list -> Ident.t
 
 val self_coercion : (Path.t * Location.t list ref) list ref
-
-type existential_restriction =
-  | At_toplevel (** no existential types at the toplevel *)
-  | In_class_args (** nor in class arguments *)
-  | In_self_pattern (** or in self pattern *)
 
 type error =
     Polymorphic_label of Longident.t


### PR DESCRIPTION
Currently when the type-checker encounters unexpected existentially quantified types, e.g.

```OCaml
   type any = Any : 'any -> any
   let Any x = Any ()
   class c (Any x) = object end
   class c = object(Any x) end
```
it emits the following errror message
> Error: Unexpected existential

If this terse message is clear from the perspective of the type-checker, it may seem mysterious from an user perspective.

This PR proposes thus to focus on the user perspective in this error message by making clear in which contexts existential types are not allowed and from where the problematic existential types come from:

```OCaml
let Any x = Any ()
```
> Error: Existential types are not allowed in toplevel bindings,
but this pattern introduces the existential type $Any_'a.

```OCaml
class c (Any x) = object end
```
> Error: Existential types are not allowed in class arguments,
but this pattern introduces the existential type $Any_'a.

```OCaml
class c = object(Any x) end
```
> Error: Existential types are not allowed in self patterns,
but this pattern introduces the existential type $Any_'a.

The error message directly refers to an existential type name if one is available, otherwise it names the constructor itself:

```OCaml
type other = C: _ -> other
let C x = C ()
```
> Error: Existential types are not allowed in toplevel bindings,
but the constructor C introduces unnamed existential types.