### PR TITLE
Fix a grammar error in the description of inline records.

### DIFF
--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -2094,7 +2094,7 @@ range @["g".."z"||"G".."Z"]@ are extension-only literals.
 ;
 \end{syntax}
 
-The arguments of a sum-type constructors can now be defined using the
+The arguments of sum-type constructors can now be defined using the
 same syntax as records.  Mutable and polymorphic fields are allowed.
 GADT syntax is supported.  Attributes can be specified on individual
 fields.


### PR DESCRIPTION
There's an extraneous "a" here. (Alternatively, "constructors" could be changed to "constructor", both alterations probably convey the same meaning.)