### PR TITLE
Delay type duplication in type_cases (follow up to #1648)

### DIFF
--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1274,20 +1274,20 @@ let lookup_class =
 let lookup_cltype =
   lookup (fun env -> env.cltypes) (fun sc -> sc.comp_cltypes)
 
-let get_copy_of_types l env =
-  Stdlib.List.filter_map (fun s ->
-    match IdTbl.find_name ~mark:false s env.values with
-    | exception Not_found -> None
-    | _, d ->
-      Some (s, {d with val_type = Subst.type_expr Subst.identity d.val_type})
-  ) l
+type copy_of_types = {
+  to_copy: string list;
+  initial_values: value_description IdTbl.t;
+  new_values: value_description IdTbl.t;
+}
 
-let do_copy_types l env =
-  let values =
-    List.fold_left (fun env (s, desc) -> IdTbl.update s (fun _ -> desc) env)
-      env.values l
-  in
-  {env with values; summary = Env_copy_types (env.summary, List.map fst l)}
+let make_copy_of_types l env : copy_of_types =
+  let f desc = { desc with val_type = Subst.type_expr Subst.identity desc.val_type} in
+  let values = List.fold_left (fun env s -> IdTbl.update s f env) env.values l in
+  {to_copy = l; initial_values = env.values; new_values = values}
+
+let do_copy_types { to_copy = l; initial_values; new_values = values } env =
+  if initial_values != env.values then fatal_error "Env.do_copy_types";
+  {env with values; summary = Env_copy_types (env.summary, l)}
 
 let mark_value_used name vd =
   try Hashtbl.find value_declarations (name, vd.val_loc) ()

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -127,8 +127,9 @@ val lookup_cltype:
   ?loc:Location.t -> ?mark:bool ->
   Longident.t -> t -> Path.t * class_type_declaration
 
-val copy_types: string list -> t -> t
-  (* Used only in Typecore.duplicate_ident_types. *)
+val get_copy_of_types: string list -> t -> (string * value_description) list
+
+val do_copy_types: (string * value_description) list -> t -> t
 
 exception Recmodule
   (* Raise by lookup_module when the identifier refers

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -127,9 +127,11 @@ val lookup_cltype:
   ?loc:Location.t -> ?mark:bool ->
   Longident.t -> t -> Path.t * class_type_declaration
 
-val get_copy_of_types: string list -> t -> (string * value_description) list
-
-val do_copy_types: (string * value_description) list -> t -> t
+type copy_of_types
+val make_copy_of_types: string list -> t -> copy_of_types
+val do_copy_types: copy_of_types -> t -> t
+(** [do_copy_types copy env] will raise a fatal error if the values in
+    [env] are different from the env passed to [make_copy_of_types]. *)
 
 exception Recmodule
   (* Raise by lookup_module when the identifier refers

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -81,7 +81,7 @@ let rec env_from_summary sum subst =
             map (env_from_summary s subst)
       | Env_copy_types (s, sl) ->
           let env = env_from_summary s subst in
-          Env.do_copy_types (Env.get_copy_of_types sl env) env
+          Env.do_copy_types (Env.make_copy_of_types sl env) env
     in
       Hashtbl.add env_cache (sum, subst) env;
       env

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -80,7 +80,8 @@ let rec env_from_summary sum subst =
                 (Subst.type_declaration subst info))
             map (env_from_summary s subst)
       | Env_copy_types (s, sl) ->
-          Env.copy_types sl (env_from_summary s subst)
+          let env = env_from_summary s subst in
+          Env.do_copy_types (Env.get_copy_of_types sl env) env
     in
       Hashtbl.add env_cache (sum, subst) env;
       env

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2695,7 +2695,7 @@ let duplicate_ident_types half_typed_cases env =
       contains_gadt typed_pat
     ) half_typed_cases
   in
-  Env.get_copy_of_types (all_idents_cases caselist) env
+  Env.make_copy_of_types (all_idents_cases caselist) env
 
 (* Getting proper location of already typed expressions.
 
@@ -4733,7 +4733,7 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
   let ty_res, duplicated_ident_types =
     if does_contain_gadt && not !Clflags.principal then
       correct_levels ty_res, duplicate_ident_types half_typed_cases env
-    else ty_res, []
+    else ty_res, duplicate_ident_types [] env
   in
   (* Unify all cases (delayed to keep it order-free) *)
   let ty_arg' = newvar () in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4705,6 +4705,7 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
         check_scope_escape pat.pat_loc env outer_level ty_arg;
         (pat, ty_arg, (ext_env, unpacks)))
       caselist in
+  let patl = List.map (fun (pat, _, _) -> pat) pat_env_list in
   (* Unify all cases (delayed to keep it order-free) *)
   let ty_arg' = newvar () in
   let unify_pats ty =
@@ -4714,7 +4715,6 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
   in
   unify_pats ty_arg';
   (* Check for polymorphic variants to close *)
-  let patl = List.map (fun (pat, _, _) -> pat) pat_env_list in
   if List.exists has_variants patl then begin
     Parmatch.pressure_variants env patl;
     List.iter (iter_pattern finalize_variant) patl

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2675,7 +2675,10 @@ let check_absent_variant env =
 let duplicate_ident_types caselist env =
   let caselist =
     List.filter (fun {pc_lhs} -> may_contain_gadts pc_lhs) caselist in
-  Env.copy_types (all_idents_cases caselist) env
+  let duplicated =
+    Env.get_copy_of_types (all_idents_cases caselist) env
+  in
+  Env.do_copy_types duplicated env
 
 (* Getting proper location of already typed expressions.
 


### PR DESCRIPTION
This GPR implements what @garrigue suggested on https://github.com/ocaml/ocaml/pull/1648#discussion_r173714137, namely:
> Note that it also means that you could delay building the copied environment to after typing the patterns (since their typing does not depend on values in the environment), and only copy identifiers used in GADT branches.

Which, if I understood correctly, meant: do a single copy of the type of identifiers that get used in branches containing GADTs, and update all the branch environments to refer to that copy.
Note: to be able to do this, it was also necessary to delay the introduction of pattern variables in the environment; which is an harmless change. More precisely: the values in the environment need to be exactly the same when duplicating the types and when the environment gets updated.

Using the same highly elaborate benchmark as last time (i.e. running "make clean && make world.opt" 10 times), I get a slight performance improvement (`< 1%`, which isn't surprising considering the slow down was also `< 1%` last time) on average.

I'm not sure this was worth the time I spent on it, but it gave me an excuse to do some minor cleanups, so I'd be in favor of merging.