### PR TITLE
Manual: improve typesetting and legibility of the HTML version

### DIFF
--- a/Changes
+++ b/Changes
@@ -348,6 +348,9 @@ OCaml 4.07
 - GPR#1647: manual, subsection on record and variant disambiguation
   (Florian Angeletti, review by Alain Frisch and Gabriel Scherer)
 
+- GPR#1741: manual, improve typesetting and legibility in HTML output
+  (steinuil, review by Gabriel Scherer)
+
 ### Compiler distribution build system
 
 - MPR#5219, GPR#1680: use 'install' instead of 'cp' in install scripts

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -6,6 +6,16 @@
 \newstyle{a:visited}{color:\visited@color;text-decoration:underline;}
 \newstyle{a:hover}{color:black;text-decoration:none;background-color:\hover@color}
 
+% Compact layout
+\newstyle{body}{max-width:800px}
+\newstyle{@media (min-width:900px)}{body\{margin-left:50px\}}
+\newstyle{@media (min-width:1000px)}{body\{margin-left:100px\}}
+\newstyle{pre}{overflow-y:auto}
+
+% More spacing between lines and inside tables
+\newstyle{p}{line-height:1.3em}
+\newstyle{.cellpadding1 tr td}{padding:1px 4px}
+
 %Styles for caml-example and friends
 \newstyle{div.caml-output}{color:maroon;}
 \newstyle{div.caml-example pre}{margin:2ex 0px;}


### PR DESCRIPTION
Some simple changes to the stylesheet of the manual to improve typesetting and legibility:
- Long lines are very hard to read, so page width is now clamped to 800px which makes the lines about as wide as in the PDF version. I've also added a margin on the left (which disappears when the window shrinks) so it doesn't feel like it's been squeezed to the edge of the screen.
- Line height was increased a bit, so that paragraphs don't feel too cramped. Some padding was also added to table cells for the same purpose.
- Long lines in code blocks will now cause the block to display a horizontal scrollbar instead of overflowing. This doesn't change anything on desktop, but it might make reading on a phone a bit nicer.

Unfortunately some syntax definitions (such as those in Chapter 8) are still too wide and will overflow past the page width, but I don't think there's much that can be done to fix those without making bigger changes. I looked at the PDF manual for inspiration, but it looks like even there they just go off the page...