### PR TITLE
testsuite: test polymorphic record field instantiation in a pattern

### DIFF
--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -21,6 +21,29 @@ val f : 'a list -> 'a fold = <fun>
 - : int = 6
 |}];;
 
+type pty = {pv : 'a. 'a list};;
+[%%expect {|
+type pty = { pv : 'a. 'a list; }
+|}];;
+
+
+let px = {pv = []};;
+[%%expect {|
+val px : pty = {pv = []}
+|}];;
+
+match px with
+| {pv=[]} -> "OK"
+| {pv=5::_} -> "int"
+| {pv=true::_} -> "bool";;
+[%%expect {|
+Line _, characters 3-5:
+  | {pv=5::_} -> "int"
+     ^^
+Error: The record field pv is polymorphic.
+       You cannot instantiate it in a pattern.
+|}];;
+
 class ['b] ilist l = object
   val l = l
   method add x = {< l = x :: l >}

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -44,6 +44,11 @@ Error: The record field pv is polymorphic.
        You cannot instantiate it in a pattern.
 |}];;
 
+fun {pv=v} -> true::v, 1::v;;
+[%%expect {|
+- : pty -> bool list * int list = <fun>
+|}];;
+
 class ['b] ilist l = object
   val l = l
   method add x = {< l = x :: l >}


### PR DESCRIPTION
Noticed that this error path wasn't exercised by the testsuite, so I added the example that inspired this error (cf. [caml-list 2007-02-27](http://caml.inria.fr/pub/ml-archives/caml-list/2007/02/a66e380369e9a6430a7584e7766a4909.fr.html)) as a test case.