### PR TITLE
PR#7787: fix module type of and recursive modules interaction

### DIFF
--- a/Changes
+++ b/Changes
@@ -114,9 +114,10 @@ OCaml 4.07
 - GPR#1628: Treat reraise and raise_notrace as nonexpansive.
   (Leo White, review by Alain Frisch)
 
-* GPR#1652: Don't remove module aliases in `module type of` and `with module`.
+* GPR#1652, MPR#7787, GPR#1743: Don't remove module aliases in `module type of`
+  and `with module`.
   The old behaviour can be obtained using the `[@remove_aliases]` attribute.
-  (Leo White, review by Jacques Garrigue)
+  (Leo White and Thomas Refis, review by Jacques Garrigue)
 
 ### Standard library:
 

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -199,9 +199,10 @@ let undefined_location loc =
 let init_shape modl =
   let rec init_shape_mod env mty =
     match Mtype.scrape env mty with
-      Mty_ident _ ->
+      Mty_ident _
+    | Mty_alias (Mta_present, _) ->
         raise Not_found
-    | Mty_alias _ ->
+    | Mty_alias (Mta_absent, _) ->
         Const_block (1, [Const_pointer 0])
     | Mty_signature sg ->
         Const_block(0, [Const_block(0, init_shape_struct env sg)])

--- a/testsuite/tests/typing-modules/ocamltests
+++ b/testsuite/tests/typing-modules/ocamltests
@@ -6,6 +6,7 @@ pr5911.ml
 pr6394.ml
 pr7207.ml
 pr7348.ml
+pr7787.ml
 printing.ml
 recursive.ml
 Test.ml

--- a/testsuite/tests/typing-modules/pr7787.ml
+++ b/testsuite/tests/typing-modules/pr7787.ml
@@ -1,0 +1,45 @@
+(* TEST
+   * expect
+*)
+
+module O (T : sig
+    module N : sig
+      val foo : int -> int
+    end
+  end) = struct
+  open T
+
+  let go () =
+    N.foo 42 (* finding N (from T) goes wrong *)
+end
+
+module T = struct
+  module N = struct
+    let foo x = x + 3
+  end
+end;;
+[%%expect{|
+module O :
+  functor (T : sig module N : sig val foo : int -> int end end) ->
+    sig val go : unit -> int end
+module T : sig module N : sig val foo : int -> int end end
+|}]
+
+(* Incidentally, M isn't used in T2, but it doesn't seem to fail if
+   it's just "module M" and "module T2" separately *)
+module rec M : sig
+  val go : unit -> int
+end = O (T2)
+and T2 : sig
+  include module type of struct include T end
+end = struct
+  include T
+end;;
+[%%expect{|
+module rec M : sig val go : unit -> int end
+and T2 : sig module N = T.N end
+|}]
+
+let () = ignore (M.go ())
+[%%expect{|
+|}]


### PR DESCRIPTION
This completes the revert of 65b11934069a7b55d60fb68b09de8b397ad7e491 which was started in GPR #1652 .

For the record, the diff in the lambda code is the following:
```diff
  (let
    (O/1002 =
       (function T/1054 is_a_functor
         (let
           (go/1006 =
              (function param/1008 (apply (field 0 (field 0 T/1054)) 42)))
           (makeblock 0 go/1006))))
    (seq (setfield_ptr(root-init) 0 (global PR7787!) O/1002)
      (let (foo/1011 = (function x/1012 (+ x/1012 3)))
        (setfield_ptr(root-init) 5 (global PR7787!) foo/1011))
      0a
      (let (N/1010 = (makeblock 0 (field 5 (global PR7787!))))
        (seq (setfield_ptr(root-init) 4 (global PR7787!) N/1010) 0a))
      (let (T/1009 = (makeblock 0 (field 4 (global PR7787!))))
        (seq (setfield_ptr(root-init) 1 (global PR7787!) T/1009)
          (let
            (M/1013 =
               (apply (field 0 (global CamlinternalMod!))
                 [0: "./PR7787.ml" 22 6] [0: [0: 0a]])
-|           T2/1014 =
-|             (apply (field 0 (global CamlinternalMod!))
-|               [0: "./PR7787.ml" 25 6] [0: [0: [1: 0a]]]))
+|           T2/1014 = (makeblock 0 (field 0 (field 1 (global PR7787!)))))
            (seq
              (apply (field 1 (global CamlinternalMod!)) [0: [0: 0a]] M/1013
                (apply (field 0 (global PR7787!)) T2/1014))
-|            (apply (field 1 (global CamlinternalMod!)) [0: [0: [1: 0a]]]
-|              T2/1014 (makeblock 0 (field 0 (field 1 (global PR7787!)))))
              (setfield_ptr(root-init) 2 (global PR7787!) M/1013)
              (setfield_ptr(root-init) 3 (global PR7787!) T2/1014)
              (apply (field 32 (global Stdlib!))
                (apply (field 0 (field 2 (global PR7787!))) 0a))
              (apply (field 35 (global Stdlib!)) 0a) 0a 0a))))))
```

Should I create a fresh changelog entry or just add the MPR and GPR number to the entry of #1652 ?
Also, I think this should be backported on 4.07.