### PR TITLE
manual: Minor fix to stdlib.etex to include BigArray

### DIFF
--- a/manual/manual/library/stdlib.etex
+++ b/manual/manual/library/stdlib.etex
@@ -58,7 +58,8 @@ the above 4 modules \\
 "Lazy" & p.~\pageref{Lazy} & delayed evaluation \\
 "Weak" & p.~\pageref{Weak} & references that don't prevent objects
 from being garbage-collected \\
-"Ephemeron" & p.~\pageref{Ephemeron} & ephemerons and weak hash tables
+"Ephemeron" & p.~\pageref{Ephemeron} & ephemerons and weak hash tables \\
+"Bigarray" & p.~\pageref{Bigarray} & large, multi-dimensional, numerical arrays
 \end{tabular}
 \subsubsection*{Arithmetic:}
 \begin{tabular}{lll}


### PR DESCRIPTION
Without this, the check-stdlib script fails.

Also, note that we should change libbigarray.etex with updated compilation instructions for bigarray. I assume `bigarray.cma` no longer needs to be specified, but I'm not sure.