### PR TITLE
do not generalize the type of every sub-pattern, only of variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -40,6 +40,9 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- GPR#1745: do not generalize the type of every sub-pattern, only of variables
+  (Thomas Refis, review by Leo White)
+
 - GPR#1747: type_cases: always propagate
   (Thomas Refis, review by Jacques Garrigue)
 


### PR DESCRIPTION
As I said on #1675:
> in type_cases when propagate is true [...] we pull the type of every pattern (i.e. including subpatterns) to the level of the match, before trying to generalize it.
> [...]
> However, if I understand correctly, we don't actually need to lift & generalize the type of every subpattern, only of things added to the environment (i.e. variables).

And I mentioned it again here : https://github.com/ocaml/ocaml/pull/1735#issuecomment-383820098 , where @garrigue seemed to agree.