### PR TITLE
remove unreachable error variant: Make_seltype_nongen

### DIFF
--- a/Changes
+++ b/Changes
@@ -43,6 +43,9 @@ Working version
 - GPR#1745: do not generalize the type of every sub-pattern, only of variables
   (Thomas Refis, review by Leo White)
 
+- GPR#1746: remove unreachable error variant: Make_seltype_nongen
+  (Florian Angeletti, review by Gabriel Radanne)
+
 - GPR#1747: type_cases: always propagate
   (Thomas Refis, review by Jacques Garrigue)
 

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -66,7 +66,6 @@ type error =
   | Class_match_failure of Ctype.class_match_failure list
   | Unbound_val of string
   | Unbound_type_var of (formatter -> unit) * Ctype.closed_class_failure
-  | Make_nongen_seltype of type_expr
   | Non_generalizable_class of Ident.t * Types.class_declaration
   | Cannot_coerce_self of type_expr
   | Non_collapsable_conjunction of
@@ -657,10 +656,7 @@ and class_field_aux self_loc cl_num self_type meths vars
                       No_overriding ("instance variable", lab.txt)))
       end;
       if !Clflags.principal then Ctype.begin_def ();
-      let exp =
-        try type_exp val_env sexp with Ctype.Unify [(ty, _)] ->
-          raise(Error(loc, val_env, Make_nongen_seltype ty))
-      in
+      let exp = type_exp val_env sexp in
       if !Clflags.principal then begin
         Ctype.end_def ();
         Ctype.generalize_structure exp.exp_type
@@ -1157,11 +1153,7 @@ and class_expr_aux cl_num val_env met_env scl =
          }
   | Pcl_let (rec_flag, sdefs, scl') ->
       let (defs, val_env) =
-        try
-          Typecore.type_let In_class_def val_env rec_flag sdefs None
-        with Ctype.Unify [(ty, _)] ->
-          raise(Error(scl.pcl_loc, val_env, Make_nongen_seltype ty))
-      in
+        Typecore.type_let In_class_def val_env rec_flag sdefs None in
       let (vals, met_env) =
         List.fold_right
           (fun (id, id_loc) (vals, met_env) ->
@@ -1958,12 +1950,6 @@ let report_error env ppf = function
         "@[<v>@[Some type variables are unbound in this type:@;<1 2>%t@]@ \
               @[%a@]@]"
        printer print_reason reason
-  | Make_nongen_seltype ty ->
-      fprintf ppf
-        "@[<v>@[Self type should not occur in the non-generic type@;<1 2>\
-                %a@]@,\
-           It would escape the scope of its class@]"
-        Printtyp.type_scheme ty
   | Non_generalizable_class (id, clty) ->
       fprintf ppf
         "@[The type of this class,@ %a,@ \

--- a/typing/typeclass.mli
+++ b/typing/typeclass.mli
@@ -108,7 +108,6 @@ type error =
   | Class_match_failure of Ctype.class_match_failure list
   | Unbound_val of string
   | Unbound_type_var of (formatter -> unit) * Ctype.closed_class_failure
-  | Make_nongen_seltype of type_expr
   | Non_generalizable_class of Ident.t * Types.class_declaration
   | Cannot_coerce_self of type_expr
   | Non_collapsable_conjunction of


### PR DESCRIPTION
This PR removes from the type checker an unreachable error variant: `Make_seltype_nongen` which is supposed to raise the following error message
> Self type should not occur in the non-generic type

Currently, this error can only be emitted if `Typecore.type_let` or `Typecore.type_expr` raise an uncaught `Unify` exception. As far as I can see, this behavior is no longer possible;  and it would create issues in `Typemod` which calls those two functions indirectly. 

(Originally, those `try ... with ... ` might have been added 20 years ago to caught the exceptions raised by `make_nongen`, which is no longer present in the compiler.)