### PR TITLE
type_cases: always propagate

### DIFF
--- a/Changes
+++ b/Changes
@@ -40,6 +40,9 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- GPR#1747: type_cases: always propagate
+  (Thomas Refis, review by Jacques Garrigue)
+
 ### Bug fixes:
 
 - MPR#7769, GPR#1714: calls to Stream.junk could, under some conditions, be

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4772,7 +4772,7 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
   if take_partial_instance <> None then unify_pats (instance ty_arg);
   if propagate then begin
     List.iter
-      (iter_pattern (fun {pat_type=t} -> unify_var env t (newvar()))) patl;
+      (iter_pattern (fun {pat_type=t} -> unify_var env (newvar()) t)) patl;
     end_def ();
     generalize ty_arg';
     List.iter (iter_pattern (fun {pat_type=t} -> generalize t)) patl;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4692,17 +4692,11 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
   let lev =
     if may_contain_gadts then init_env () else get_current_level ()
   in
-  (* Do we need to propagate polymorphism *)
-  let propagate =
-    !Clflags.principal || may_contain_gadts || (repr ty_arg).level = generic_level ||
-    match caselist with
-      [{pc_lhs}] when is_var pc_lhs -> false
-    | _ -> true in
   let take_partial_instance =
     if !Clflags.principal || erase_either
     then Some false else None
   in
-  if propagate then begin_def (); (* propagation of the argument *)
+  begin_def (); (* propagation of the argument *)
   let pattern_force = ref [] in
 (*  Format.printf "@[%i %i@ %a@]@." lev (get_current_level())
     Printtyp.raw_type_expr ty_arg; *)
@@ -4770,13 +4764,11 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
   List.iter (fun f -> f()) !pattern_force;
   (* Post-processing and generalization *)
   if take_partial_instance <> None then unify_pats (instance ty_arg);
-  if propagate then begin
-    List.iter
-      (iter_pattern (fun {pat_type=t} -> unify_var env (newvar()) t)) patl;
-    end_def ();
-    generalize ty_arg';
-    List.iter (iter_pattern (fun {pat_type=t} -> generalize t)) patl;
-  end;
+  List.iter
+    (iter_pattern (fun {pat_type=t} -> unify_var env (newvar()) t)) patl;
+  end_def ();
+  generalize ty_arg';
+  List.iter (iter_pattern (fun {pat_type=t} -> generalize t)) patl;
   (* type bodies *)
   let in_function = if List.length caselist = 1 then in_function else None in
   let cases =


### PR DESCRIPTION
Reading [MPR#6542](https://caml.inria.fr/mantis/view.php?id=6542) it seems like https://github.com/ocaml/ocaml/commit/8db1b59233ab1127f7d634b06f975bbc4beaea08 brings a noticeable speedup when typechecking classes, at the cost of make the code of `type_cases` noticeably more convoluted.

Looking at the code, the following can be deduced:
- the optimization triggers (i.e. `propagate = false`) iff. `ty_arg` is generic and the matching only has one clause, consisting of a variable
- the optimization avoids:
  - bringing the type of every subpattern to the level of the match (done by a call to `unify_var` with a fresh variable for every subpattern)
  - generalizing ty_arg'
  - generalizing the type of every subpattern

However, given the first condition, the calls to generalize that are avoided should actually be noops even if we ran them.
So the speed up comes from avoiding the call to `unify_var` (which is what's hinted at in the MPR, even though the code was slightly different at the time).

As it turns out, the same speed-up can be achieved by a more straightforward change: passing the arguments in the correct order when calling `unify_var`. Indeed, with the way it is currently called in trunk, it always degrades to `unify`.

For benchmarking I reused the same test case as given in the MPR, that is:
```
(echo "class foo = object" ; for ((i = 0; i < 2000; i++)) do echo method x$i = $i; done ; echo end) > test_propagate.ml
```

I timed the compilation of that file (and a slightly bigger one where I have 8k methods instead of 2k) a few times, with various compilers, here are the results:
```
TRUNK:

test_propagate 2k methods : ../ocaml-install/bin/ocamlc -c ./test_propagate.ml   0.89s user 0.05s system 99% cpu  0.942 total
test_propagate 8k methods : ../ocaml-install/bin/ocamlc -c ./test_propagate.ml  14.51s user 0.09s system 99% cpu 14.645 total
test_propagate 8k methods : ../ocaml-install/bin/ocamlc -c ./test_propagate.ml  14.36s user 0.12s system 99% cpu 14.492 total
test_propagate 8k methods : ../ocaml-install/bin/ocamlc -c ./test_propagate.ml  14.21s user 0.09s system 99% cpu 14.308 total

UNIFY_VAR in the right order:

test_propagate 2k methods : ../ocaml-install/bin/ocamlc -c ./test_propagate.ml   0.88s user 0.02s system 99% cpu  0.900 total
test_propagate 8k methods : ../ocaml-install/bin/ocamlc -c ./test_propagate.ml  14.09s user 0.10s system 99% cpu 14.203 total
test_propagate 8k methods : ../ocaml-install/bin/ocamlc -c ./test_propagate.ml  14.81s user 0.09s system 99% cpu 14.917 total
test_propagate 8k methods : ../ocaml-install/bin/ocamlc -c ./test_propagate.ml  14.17s user 0.07s system 99% cpu 14.254 total

PROPAGATE = true always:

test_propagate 2k methods : ../ocaml-install/bin/ocamlc -c ./test_propagate.ml   1.39s user 0.05s system 99% cpu  1.445 total
test_propagate 8k methods : ../ocaml-install/bin/ocamlc -c ./test_propagate.ml  31.54s user 0.10s system 99% cpu 31.647 total

PROPAGATE = true always && UNIFY_VAR in the right order:

test_propagate 2k methods : ../ocaml-install/bin/ocamlc -c ./test_propagate.ml   0.80s user 0.02s system 99% cpu  0.822 total
test_propagate 8k methods : ../ocaml-install/bin/ocamlc -c ./test_propagate.ml  14.61s user 0.07s system 99% cpu 14.693 total
test_propagate 8k methods : ../ocaml-install/bin/ocamlc -c ./test_propagate.ml  14.32s user 0.07s system 99% cpu 14.409 total
test_propagate 8k methods : ../ocaml-install/bin/ocamlc -c ./test_propagate.ml  14.45s user 0.07s system 99% cpu 14.544 total
```