### PR TITLE
do not error when instantiating polymorphic fields in patterns

### DIFF
--- a/Changes
+++ b/Changes
@@ -35,6 +35,9 @@ Working version
   (Arthur Charguéraud and Armaël Guéneau, with help and advice
    from Gabriel Scherer, Frédéric Bour, Xavier Clerc and Leo White)
 
+- GPR#1748: do not error when instantiating polymorphic fields in patterns
+  (Thomas Refis, review by Gabriel Scherer)
+
 ### Code generation and optimizations:
 
 ### Runtime system:

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -722,9 +722,33 @@ let pat_as_constr = function
   | {pat_desc=Tpat_construct (_, cstr,_)} -> cstr
   | _ -> fatal_error "Matching.pat_as_constr"
 
-let group_constant = function
-  | {pat_desc= Tpat_constant _} -> true
-  | _                           -> false
+let group_const_int = function
+  | {pat_desc= Tpat_constant Const_int _ } -> true
+  | _                                      -> false
+
+let group_const_char = function
+  | {pat_desc= Tpat_constant Const_char _ } -> true
+  | _                                      -> false
+
+let group_const_string = function
+  | {pat_desc= Tpat_constant Const_string _ } -> true
+  | _                                      -> false
+
+let group_const_float = function
+  | {pat_desc= Tpat_constant Const_float _ } -> true
+  | _                                      -> false
+
+let group_const_int32 = function
+  | {pat_desc= Tpat_constant Const_int32 _ } -> true
+  | _                                      -> false
+
+let group_const_int64 = function
+  | {pat_desc= Tpat_constant Const_int64 _ } -> true
+  | _                                      -> false
+
+let group_const_nativeint = function
+  | {pat_desc= Tpat_constant Const_nativeint _ } -> true
+  | _                                      -> false
 
 and group_constructor = function
   | {pat_desc = Tpat_construct (_,_,_)} -> true
@@ -756,7 +780,13 @@ and group_lazy = function
 
 let get_group p = match p.pat_desc with
 | Tpat_any -> group_var
-| Tpat_constant _ -> group_constant
+| Tpat_constant Const_int _ -> group_const_int
+| Tpat_constant Const_char _ -> group_const_char
+| Tpat_constant Const_string _ -> group_const_string
+| Tpat_constant Const_float _ -> group_const_float
+| Tpat_constant Const_int32 _ -> group_const_int32
+| Tpat_constant Const_int64 _ -> group_const_int64
+| Tpat_constant Const_nativeint _ -> group_const_nativeint
 | Tpat_construct _ -> group_constructor
 | Tpat_tuple _ -> group_tuple
 | Tpat_record _ -> group_record

--- a/testsuite/tests/basic/ocamltests
+++ b/testsuite/tests/basic/ocamltests
@@ -17,6 +17,7 @@ maps.ml
 min_int.ml
 opt_variants.ml
 patmatch.ml
+patmatch_incoherence.ml
 pr7253.ml
 pr7533.ml
 pr7657.ml

--- a/testsuite/tests/basic/patmatch_incoherence.ml
+++ b/testsuite/tests/basic/patmatch_incoherence.ml
@@ -1,0 +1,213 @@
+(* TEST
+   flags = "-drawlambda -dno-unique-ids"
+   * expect
+*)
+
+type tlist = { x: 'a. 'a list };;
+[%%expect{|
+0a
+type tlist = { x : 'a. 'a list; }
+|}];;
+
+match { x = [] } with
+| { x = [] } -> ()
+| { x = 3 :: _ } -> ()
+| { x = "" :: _ } -> ()
+;;
+[%%expect{|
+Uncaught exception: File "bytecomp/matching.ml", line 2237, characters 58-64: Assertion failed
+
+|}];;
+
+
+type t = { x: 'a. 'a };;
+[%%expect{|
+0a
+type t = { x : 'a. 'a; }
+|}];;
+
+match { x = assert false } with
+| { x = 3 } -> ()
+| { x = "" } -> ()
+;;
+[%%expect{|
+Uncaught exception: File "bytecomp/matching.ml", line 2237, characters 58-64: Assertion failed
+
+|}];;
+
+match { x = assert false } with
+| { x = 3 } -> ()
+| { x = None } -> ()
+;;
+[%%expect{|
+Line _, characters 0-70:
+  match { x = assert false } with
+  | { x = 3 } -> ()
+  | { x = None } -> ()
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+{x=Some _}
+(catch
+  (let
+    (*match* =
+       (makeblock 0
+         (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
+     *match* =a (field 0 *match*))
+    (catch (if (!= *match* 3) (exit 2) 0a) with (2) (if *match* (exit 1) 0a)))
+ with (1) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
+Exception: Assert_failure ("", 1, 12).
+|}];;
+
+match { x = assert false } with
+| { x = None } -> ()
+| { x = "" } -> ()
+;;
+[%%expect{|
+Line _, characters 0-71:
+  match { x = assert false } with
+  | { x = None } -> ()
+  | { x = "" } -> ()
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+{x="*"}
+(catch
+  (let
+    (*match* =
+       (makeblock 0
+         (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
+     *match* =a (field 0 *match*))
+    (if *match* (exit 3) 0a))
+ with (3) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
+Exception: Assert_failure ("", 1, 12).
+|}];;
+
+match { x = assert false } with
+| { x = None } -> ()
+| { x = `X } -> ()
+;;
+[%%expect{|
+Line _, characters 0-71:
+  match { x = assert false } with
+  | { x = None } -> ()
+  | { x = `X } -> ()
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+{x=`AnyOtherTag}
+(catch
+  (let
+    (*match* =
+       (makeblock 0
+         (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
+     *match* =a (field 0 *match*))
+    (if *match* (exit 5) 0a))
+ with (5) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
+Exception: Assert_failure ("", 1, 12).
+|}];;
+
+match { x = assert false } with
+| { x = [||] } -> ()
+| { x = 3 } -> ()
+;;
+[%%expect{|
+Line _, characters 0-70:
+  match { x = assert false } with
+  | { x = [||] } -> ()
+  | { x = 3 } -> ()
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+{x=0}
+(catch
+  (let
+    (*match* =
+       (makeblock 0
+         (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
+     *match* =a (field 0 *match*))
+    (catch
+      (let (len =a (array.length[gen] *match*)) (if (!= len 0) (exit 8) 0a))
+     with (8) (if (!= *match* 3) (exit 7) 0a)))
+ with (7) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
+Exception: Assert_failure ("", 1, 12).
+|}];;
+
+match { x = assert false } with
+| { x = `X } -> ()
+| { x = 3 } -> ()
+;;
+[%%expect{|
+Line _, characters 0-68:
+  match { x = assert false } with
+  | { x = `X } -> ()
+  | { x = 3 } -> ()
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+{x=0}
+(catch
+  (let
+    (*match* =
+       (makeblock 0
+         (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
+     *match* =a (field 0 *match*))
+    (catch (if (!= *match* 88) (exit 10) 0a) with (10)
+      (if (!= *match* 3) (exit 9) 0a)))
+ with (9) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
+Exception: Assert_failure ("", 1, 12).
+|}];;
+
+match { x = assert false } with
+| { x = `X "lol" } -> ()
+| { x = 3 } -> ()
+;;
+[%%expect{|
+Line _, characters 0-74:
+  match { x = assert false } with
+  | { x = `X "lol" } -> ()
+  | { x = 3 } -> ()
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+{x=0}
+(catch
+  (let
+    (*match* =
+       (makeblock 0
+         (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
+     *match* =a (field 0 *match*))
+    (catch
+      (if (isint *match*) (exit 12)
+        (let (variant =a (field 0 *match*))
+          (if (!= variant 88) (exit 12)
+            (let (*match* =a (field 1 *match*))
+              (stringswitch *match* case "lol": 0a
+                                    default: (exit 11))))))
+     with (12) (if (!= *match* 3) (exit 11) 0a)))
+ with (11) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
+Exception: Assert_failure ("", 1, 12).
+|}];;
+
+match { x = assert false } with
+| { x = (2., "") } -> ()
+| { x = None } -> ()
+| { x = 3 } -> ()
+;;
+[%%expect{|
+Line _, characters 0-95:
+  match { x = assert false } with
+  | { x = (2., "") } -> ()
+  | { x = None } -> ()
+  | { x = 3 } -> ()
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+{x=0}
+(catch
+  (let
+    (*match* =
+       (makeblock 0
+         (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
+     *match* =a (field 0 *match*)
+     *match* =a (field 0 *match*))
+    (if (!=. *match* 2.) (exit 13)
+      (let (*match* =a (field 1 *match*))
+        (stringswitch *match* case "": 0a
+                              default: (exit 13)))))
+ with (13) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
+Exception: Assert_failure ("", 1, 12).
+|}];;

--- a/testsuite/tests/basic/patmatch_incoherence.ml
+++ b/testsuite/tests/basic/patmatch_incoherence.ml
@@ -15,8 +15,16 @@ match { x = [] } with
 | { x = "" :: _ } -> ()
 ;;
 [%%expect{|
-Uncaught exception: File "bytecomp/matching.ml", line 2237, characters 58-64: Assertion failed
-
+(let (*match* = [0: 0a] *match* =a (field 0 *match*))
+  (if *match*
+    (let (*match* =a (field 0 *match*))
+      (catch
+        (if (!= *match* 3) (exit 1) (let (*match* =a (field 1 *match*)) 0a))
+       with (1)
+        (stringswitch *match*
+         case "": (let (*match* =a (field 1 *match*)) 0a))))
+    0a))
+- : unit = ()
 |}];;
 
 
@@ -31,8 +39,14 @@ match { x = assert false } with
 | { x = "" } -> ()
 ;;
 [%%expect{|
-Uncaught exception: File "bytecomp/matching.ml", line 2237, characters 58-64: Assertion failed
-
+(let
+  (*match* =
+     (makeblock 0
+       (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
+   *match* =a (field 0 *match*))
+  (catch (if (!= *match* 3) (exit 2) 0a) with (2)
+    (stringswitch *match* case "": 0a)))
+Exception: Assert_failure ("", 1, 12).
 |}];;
 
 match { x = assert false } with
@@ -53,8 +67,8 @@ Here is an example of a case that is not matched:
        (makeblock 0
          (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
      *match* =a (field 0 *match*))
-    (catch (if (!= *match* 3) (exit 2) 0a) with (2) (if *match* (exit 1) 0a)))
- with (1) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
+    (catch (if (!= *match* 3) (exit 4) 0a) with (4) (if *match* (exit 3) 0a)))
+ with (3) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
 Exception: Assert_failure ("", 1, 12).
 |}];;
 
@@ -76,8 +90,8 @@ Here is an example of a case that is not matched:
        (makeblock 0
          (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
      *match* =a (field 0 *match*))
-    (if *match* (exit 3) 0a))
- with (3) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
+    (if *match* (exit 5) 0a))
+ with (5) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
 Exception: Assert_failure ("", 1, 12).
 |}];;
 
@@ -99,8 +113,8 @@ Here is an example of a case that is not matched:
        (makeblock 0
          (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
      *match* =a (field 0 *match*))
-    (if *match* (exit 5) 0a))
- with (5) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
+    (if *match* (exit 7) 0a))
+ with (7) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
 Exception: Assert_failure ("", 1, 12).
 |}];;
 
@@ -123,9 +137,9 @@ Here is an example of a case that is not matched:
          (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
      *match* =a (field 0 *match*))
     (catch
-      (let (len =a (array.length[gen] *match*)) (if (!= len 0) (exit 8) 0a))
-     with (8) (if (!= *match* 3) (exit 7) 0a)))
- with (7) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
+      (let (len =a (array.length[gen] *match*)) (if (!= len 0) (exit 10) 0a))
+     with (10) (if (!= *match* 3) (exit 9) 0a)))
+ with (9) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
 Exception: Assert_failure ("", 1, 12).
 |}];;
 
@@ -147,9 +161,9 @@ Here is an example of a case that is not matched:
        (makeblock 0
          (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
      *match* =a (field 0 *match*))
-    (catch (if (!= *match* 88) (exit 10) 0a) with (10)
-      (if (!= *match* 3) (exit 9) 0a)))
- with (9) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
+    (catch (if (!= *match* 88) (exit 12) 0a) with (12)
+      (if (!= *match* 3) (exit 11) 0a)))
+ with (11) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
 Exception: Assert_failure ("", 1, 12).
 |}];;
 
@@ -172,14 +186,14 @@ Here is an example of a case that is not matched:
          (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
      *match* =a (field 0 *match*))
     (catch
-      (if (isint *match*) (exit 12)
+      (if (isint *match*) (exit 14)
         (let (variant =a (field 0 *match*))
-          (if (!= variant 88) (exit 12)
+          (if (!= variant 88) (exit 14)
             (let (*match* =a (field 1 *match*))
               (stringswitch *match* case "lol": 0a
-                                    default: (exit 11))))))
-     with (12) (if (!= *match* 3) (exit 11) 0a)))
- with (11) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
+                                    default: (exit 13))))))
+     with (14) (if (!= *match* 3) (exit 13) 0a)))
+ with (13) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
 Exception: Assert_failure ("", 1, 12).
 |}];;
 
@@ -204,10 +218,10 @@ Here is an example of a case that is not matched:
          (raise (makeblock 0 (global Assert_failureg) [0: "" 1 12])))
      *match* =a (field 0 *match*)
      *match* =a (field 0 *match*))
-    (if (!=. *match* 2.) (exit 13)
+    (if (!=. *match* 2.) (exit 15)
       (let (*match* =a (field 1 *match*))
         (stringswitch *match* case "": 0a
-                              default: (exit 13)))))
- with (13) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
+                              default: (exit 15)))))
+ with (15) (raise (makeblock 0 (global Match_failureg) [0: "" 1 0])))
 Exception: Assert_failure ("", 1, 12).
 |}];;

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -35,13 +35,45 @@ val px : pty = {pv = []}
 match px with
 | {pv=[]} -> "OK"
 | {pv=5::_} -> "int"
-| {pv=true::_} -> "bool";;
+| {pv=true::_} -> "bool"
+;;
 [%%expect {|
-Line _, characters 3-5:
+Line _, characters 0-77:
+  match px with
+  | {pv=[]} -> "OK"
   | {pv=5::_} -> "int"
-     ^^
-Error: The record field pv is polymorphic.
-       You cannot instantiate it in a pattern.
+  | {pv=true::_} -> "bool"
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+{pv=false::_}
+- : string = "OK"
+|}];;
+
+match px with
+| {pv=[]} -> "OK"
+| {pv=true::_} -> "bool"
+| {pv=5::_} -> "int"
+;;
+[%%expect {|
+Line _, characters 0-77:
+  match px with
+  | {pv=[]} -> "OK"
+  | {pv=true::_} -> "bool"
+  | {pv=5::_} -> "int"
+Warning 8: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+{pv=0::_}
+- : string = "OK"
+|}];;
+
+match px with
+| {pv=[]} -> "OK"
+| {pv=5::_} -> "int"
+| {pv=true::_} -> "bool"
+| {pv=false::_} -> "bool"
+;;
+[%%expect {|
+- : string = "OK"
 |}];;
 
 fun {pv=v} -> true::v, 1::v;;

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -114,7 +114,6 @@ val name_pattern : string -> Typedtree.case list -> Ident.t
 val self_coercion : (Path.t * Location.t list ref) list ref
 
 type error =
-    Polymorphic_label of Longident.t
   | Constructor_arity_mismatch of Longident.t * int * int
   | Label_mismatch of Longident.t * (type_expr * type_expr) list
   | Pattern_type_clash of (type_expr * type_expr) list


### PR DESCRIPTION
Reading [this thread](http://caml.inria.fr/pub/ml-archives/caml-list/2007/02/a66e380369e9a6430a7584e7766a4909.fr.html) on the caml-list, it seems like the initial motivation for https://github.com/ocaml/ocaml/commit/68006b757145367ff3c83b306e0a4cd19b237313  and https://github.com/ocaml/ocaml/commit/2acec46b9eb9f6aadc880c0c372b3d932254f20b was that `Parmatch` wasn't able to cope with incoherent columns.

Also, these commits apparently had the side effect that matching the field with a variable introduced polymorphic bindings. But nowadays that would remains the case even if we reverted them: `type_cases` makes sure that polymorphism is always propagated to the branches.

As `Parmatch` is now able to deal with incoherent columns, it has become possible to revert the changes introduced by these commits.
Some reasons for doing so would be:
- it would make the code simpler
- the compiler would stop rejecting code that typechecks and cannot go wrong

For the record, one can already write similar examples where we're instantiating polymorphic types from patterns, and where the compiler does not error or warn, e.g.
```ocaml
match [] with
| [] -> ()
| [ 4 ] -> ()
```

This GPR reverts these two commits.

---
People looking at the test output might be surprised to see warning 8 emitted: shouldn't `Parmatch` consider a matrix with an incoherent first column as exhaustive?
Indeed it should, however the exhaustiveness check never sees a matrix with an incoherent column in this case: on this particular example `get_mins` (which is used when building our initial matrix) removes the rows introducing the incoherence.
It should be fairly easy to update `get_mins` so that it notices the incoherence ("and then what?") but that is completely orthogonal to this GPR, so I'll delay that discussion for a later time.