### PR TITLE
Fix the formatting of the "non-collapsible conjunctions in class parameters" error message

### DIFF
--- a/testsuite/tests/typing-objects/errors.ml
+++ b/testsuite/tests/typing-objects/errors.ml
@@ -1,0 +1,15 @@
+(* TEST
+   * expect
+*)
+
+class type virtual ['a] c = object constraint 'a = [<`A of int & float] end
+[%%expect {|
+Line _, characters 0-75:
+  class type virtual ['a] c = object constraint 'a = [<`A of int & float] end
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The type of this class,
+       class virtual ['a] c :
+         object constraint 'a = _[< `A of int & float ] end,
+       contains non-collapsible conjunctive types in constraints.
+       Type int is not compatible with type float
+|}]

--- a/testsuite/tests/typing-objects/ocamltests
+++ b/testsuite/tests/typing-objects/ocamltests
@@ -1,4 +1,5 @@
 dummy.ml
+errors.ml
 Exemples.ml
 open_in_classes.ml
 pr5545.ml

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1978,11 +1978,12 @@ let report_error env ppf = function
   | Non_collapsable_conjunction (id, clty, trace) ->
       fprintf ppf
         "@[The type of this class,@ %a,@ \
-           contains non-collapsible conjunctive types in constraints@]"
-        (Printtyp.class_declaration id) clty;
-      Printtyp.report_unification_error ppf env trace
-        (fun ppf -> fprintf ppf "Type")
-        (fun ppf -> fprintf ppf "is not compatible with type")
+           contains non-collapsible conjunctive types in constraints.@ %t@]"
+        (Printtyp.class_declaration id) clty
+        (fun ppf -> Printtyp.report_unification_error ppf env trace
+            (fun ppf -> fprintf ppf "Type")
+            (fun ppf -> fprintf ppf "is not compatible with type")
+        )
   | Final_self_clash trace ->
       Printtyp.report_unification_error ppf env trace
         (function ppf ->


### PR DESCRIPTION
Before this PR
```OCaml
 class type virtual['a] c = object('self) constraint 'a = [<`A of int & float ] end;;
```
yields
>``` 
>Error: The type of this class,
>       class virtual ['a] c :
>         object constraint 'a = _[< `A of int & float ] end,
>       contains non-collapsible conjunctive types in constraintsType 
>                                                                int
>                                                                is not compatible with type
>                                                                  float
>```

due to a lack of line breaks. Once fixed, the error message becomes

> Error: The type of this class,
       class virtual ['a] c :
         object constraint 'a = _[< `A of int & float ] end,
       contains non-collapsible conjunctive types in constraints.
       Type int is not compatible with type float
