### PR TITLE
byterun: do not alias function arguments to sigprocmask

### DIFF
--- a/Changes
+++ b/Changes
@@ -311,6 +311,8 @@ OCaml 4.07
 - GPR#1701: fix missing root bug in GPR#1476
   (Mark Shinwell)
 
+- GPR#1752: do not alias function arguments to sigprocmask (Anil Madhavapeddy)
+
 ### Tools:
 
 - MPR#7643, GPR#1377: ocamldep, fix an exponential blowup in presence of nested

--- a/byterun/signals.c
+++ b/byterun/signals.c
@@ -144,12 +144,12 @@ void caml_execute_signal(int signal_number, int in_signal_handler)
   void* saved_spacetime_trie_node_ptr;
 #endif
 #ifdef POSIX_SIGNALS
-  sigset_t sigs;
+  sigset_t nsigs, sigs;
   /* Block the signal before executing the handler, and record in sigs
      the original signal mask */
-  sigemptyset(&sigs);
-  sigaddset(&sigs, signal_number);
-  sigprocmask(SIG_BLOCK, &sigs, &sigs);
+  sigemptyset(&nsigs);
+  sigaddset(&nsigs, signal_number);
+  sigprocmask(SIG_BLOCK, &nsigs, &sigs);
 #endif
 #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
   /* We record the signal handler's execution separately, in the same


### PR DESCRIPTION
Recent gcc versions (e.g. as found in Fedora 28) check that restrict-qualified parameters do not alias each other in function calls. One such example that triggers a compile error is sigprocmask in the bytecode runtime.

The error this changeset fixes while compiling on Fedora 28 is:

```
signals.c: In function 'caml_execute_signal':
signals.c:152:33: error: passing argument 3 to restrict-qualified parameter aliases with argument 2 [-Werror=restrict]
   sigprocmask(SIG_BLOCK, &sigs, &sigs);
```