### PR TITLE
AFL stability fixes for objects (MPR#7725) and lazy values.

### DIFF
--- a/Changes
+++ b/Changes
@@ -313,6 +313,9 @@ OCaml 4.07
 
 - GPR#1752: do not alias function arguments to sigprocmask (Anil Madhavapeddy)
 
+- GPR#1754, MPR#7725: improve AFL instrumentation for objects and lazy values
+  (Stephen Dolan)
+
 ### Tools:
 
 - MPR#7643, GPR#1377: ocamldep, fix an exponential blowup in presence of nested

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1545,7 +1545,8 @@ let inline_lazy_force arg loc =
   if !Clflags.afl_instrument then
     (* Disable inlining optimisation if AFL instrumentation active,
        so that the GC forwarding optimisation is not visible in the
-       instrumentation output. (PR#???) *)
+       instrumentation output.
+       (see https://github.com/stedolan/crowbar/issues/14) *)
     Lapply{ap_should_be_tailcall = false;
            ap_loc=loc;
            ap_func=Lazy.force code_force_lazy;

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1478,6 +1478,8 @@ let get_mod_field modname field =
 
 let code_force_lazy_block =
   get_mod_field "CamlinternalLazy" "force_lazy_block"
+let code_force_lazy =
+  get_mod_field "CamlinternalLazy" "force"
 ;;
 
 (* inline_lazy_force inlines the beginning of the code of Lazy.force. When
@@ -1540,13 +1542,24 @@ let inline_lazy_force_switch arg loc =
                sw_failaction = Some varg }, loc ))))
 
 let inline_lazy_force arg loc =
-  if !Clflags.native_code then
-    (* Lswitch generates compact and efficient native code *)
-    inline_lazy_force_switch arg loc
+  if !Clflags.afl_instrument then
+    (* Disable inlining optimisation if AFL instrumentation active,
+       so that the GC forwarding optimisation is not visible in the
+       instrumentation output. (PR#???) *)
+    Lapply{ap_should_be_tailcall = false;
+           ap_loc=loc;
+           ap_func=Lazy.force code_force_lazy;
+           ap_args=[arg];
+           ap_inlined=Default_inline;
+           ap_specialised=Default_specialise}
   else
-    (* generating bytecode: Lswitch would generate too many rather big
-       tables (~ 250 elts); conditionals are better *)
-    inline_lazy_force_cond arg loc
+    if !Clflags.native_code then
+      (* Lswitch generates compact and efficient native code *)
+      inline_lazy_force_switch arg loc
+    else
+      (* generating bytecode: Lswitch would generate too many rather big
+         tables (~ 250 elts); conditionals are better *)
+      inline_lazy_force_cond arg loc
 
 let make_lazy_matching def = function
     [] -> fatal_error "Matching.make_lazy_matching"

--- a/stdlib/Compflags
+++ b/stdlib/Compflags
@@ -20,7 +20,8 @@ case $1 in
            ' -pp "$AWK -f expand_module_aliases.awk"';;
   stdlib__pervasives.cm[iox]|stdlib__pervasives.p.cmx) echo ' -nopervasives';;
   camlinternalOO.cmx|camlinternalOO.p.cmx) echo ' -inline 0 -afl-inst-ratio 0';;
-    # never instrument camlinternalOO (PR#7725)
+  camlinternalLazy.cmx|camlinternalLazy.p.cmx) echo ' -afl-inst-ratio 0';;
+    # never instrument camlinternalOO or camlinternalLazy (PR#7725)
   stdlib__buffer.cmx|stdlib__buffer.p.cmx) echo ' -inline 3';;
                            # make sure add_char is inlined (PR#5872)
   stdlib__buffer.cm[io]) echo ' -w A';;

--- a/stdlib/Compflags
+++ b/stdlib/Compflags
@@ -19,7 +19,8 @@ case $1 in
       echo ' -nopervasives -no-alias-deps -w -49' \
            ' -pp "$AWK -f expand_module_aliases.awk"';;
   stdlib__pervasives.cm[iox]|stdlib__pervasives.p.cmx) echo ' -nopervasives';;
-  camlinternalOO.cmx|camlinternalOO.p.cmx) echo ' -inline 0';;
+  camlinternalOO.cmx|camlinternalOO.p.cmx) echo ' -inline 0 -afl-inst-ratio 0';;
+    # never instrument camlinternalOO (PR#7725)
   stdlib__buffer.cmx|stdlib__buffer.p.cmx) echo ' -inline 3';;
                            # make sure add_char is inlined (PR#5872)
   stdlib__buffer.cm[io]) echo ' -w A';;

--- a/testsuite/tests/afl-instrumentation/afltest.ml
+++ b/testsuite/tests/afl-instrumentation/afltest.ml
@@ -1,17 +1,16 @@
 (* TEST (* Just a test-driver *)
    * native-compiler
-   ** no-afl-instrument
-   *** script
+   ** script
        script = "sh ${test_source_directory}/afl-showmap-available"
        files = "harness.ml  test.ml"
-   **** setup-ocamlopt.byte-build-env
-   ***** ocamlopt.byte
+   *** setup-ocamlopt.byte-build-env
+   **** ocamlopt.byte
          module = "test.ml"
          flags = "-afl-instrument"
-   ****** ocamlopt.byte
+   ***** ocamlopt.byte
 	  module = ""
           program = "${test_build_directory}/test"
           flags = "-afl-inst-ratio 0"
           all_modules = "test.cmx harness.ml"
-   ******* run
+   ****** run
 *)

--- a/testsuite/tests/afl-instrumentation/test.ml
+++ b/testsuite/tests/afl-instrumentation/test.ml
@@ -60,6 +60,13 @@ let random () = opaque @@
   if Random.int 100 < 50 then print_string "a" else print_string "b";
   if Random.int 100 < 50 then print_string "a" else print_string "b"
 
+let already_forced = lazy (ref 42)
+let _ = Lazy.force already_forced
+
+let laziness () = opaque @@
+  let _ = Lazy.force already_forced in
+  Gc.major ()
+
 let tests =
   [| ("lists", fun () -> lists 42);
      ("manylists", fun () -> for i = 1 to 10 do lists 42 done);
@@ -69,5 +76,6 @@ let tests =
      ("classes", fun () -> classes 42);
      ("obj_ordering", obj_ordering);
      (* ("random", random); *)
+     ("laziness", laziness);
   |]
   


### PR DESCRIPTION
For AFL fuzzing to be useful, code that does the same thing twice should produce exactly the same instrumentation output both times, but this currently fails for objects (see MPR#7725) and lazy values.

For objects, the class initialisation logic in `camlinternalOO.ml` uses some global state as a cache. Since this is not visible outside this file, the fix is just to disable instrumentation for this file (even if instrumentation is otherwise globally enabled).

For lazy values, the GC can silently replace `Forward_tag` values (forced lazy thunks) with their contents, causing the inlined `Lazy.force` test to branch differently. The fix is to stop inlining this test if AFL instrumentation is enabled, and ensure that `camlinternalLazy.ml` is never instrumented.