### PR TITLE
Invalid reads from complex bigarrays (simple version)

### DIFF
--- a/Changes
+++ b/Changes
@@ -52,6 +52,10 @@ Working version
 - GPR#1739: ensure ocamltest waits for child processes to terminate on Windows
   (David Allsopp, review by Sébastien Hinderer)
 
+- GPR#1755: ensure that a bigarray is never collected while reading complex
+  values (Xavier Clerc, Mark Shinwell and Leo White, report by Chris Hardin,
+  reviews by Stephen Dolan and Xavier Leroy)
+
 OCaml 4.07
 ----------
 

--- a/Changes
+++ b/Changes
@@ -52,10 +52,6 @@ Working version
 - GPR#1739: ensure ocamltest waits for child processes to terminate on Windows
   (David Allsopp, review by Sébastien Hinderer)
 
-- GPR#1755: ensure that a bigarray is never collected while reading complex
-  values (Xavier Clerc, Mark Shinwell and Leo White, report by Chris Hardin,
-  reviews by Stephen Dolan and Xavier Leroy)
-
 OCaml 4.07
 ----------
 
@@ -546,6 +542,10 @@ OCaml 4.07
 
 - GPR#1722: Scrape types in Typeopt.maybe_pointer
   (Leo White, review by Thomas Refis)
+
+- GPR#1755: ensure that a bigarray is never collected while reading complex
+  values (Xavier Clerc, Mark Shinwell and Leo White, report by Chris Hardin,
+  reviews by Stephen Dolan and Xavier Leroy)
 
 OCaml 4.06.1 (16 Feb 2018):
 ---------------------------


### PR DESCRIPTION
This PR contains the first/simple implementation of the fix mentioned in https://github.com/ocaml/ocaml/pull/1729.
