### PR TITLE
[RFC] Float identity

### DIFF
--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -103,7 +103,7 @@ let occurs_var var u =
 
 let prim_size prim args =
   match prim with
-    Pidentity | Pbytes_to_string | Pbytes_of_string -> 0
+    Pidentity | Pidentityfloat | Pbytes_to_string | Pbytes_of_string -> 0
   | Pgetglobal _ -> 1
   | Psetglobal _ -> 1
   | Pmakeblock _ -> 5 + List.length args

--- a/asmcomp/closure.ml
+++ b/asmcomp/closure.ml
@@ -301,6 +301,7 @@ let simplif_arith_prim_pure fpc p (args, approxs) dbg =
   (* float *)
   | [Value_const(Uconst_ref(_, Some (Uconst_float n1)))] when fpc ->
       begin match p with
+      | Pidentityfloat -> make_const_float n1
       | Pintoffloat -> make_const_int (int_of_float n1)
       | Pnegfloat -> make_const_float (-. n1)
       | Pabsfloat -> make_const_float (abs_float n1)

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -1616,6 +1616,7 @@ let rec is_unboxed_number ~strict env e =
   | Uprim(p, _, dbg) ->
       begin match simplif_primitive p with
         | Pccall p -> unboxed_number_kind_of_unbox dbg p.prim_native_repr_res
+        | Pidentityfloat
         | Pfloatfield _
         | Pfloatofint
         | Pnegfloat
@@ -2055,6 +2056,8 @@ and transl_prim_1 env p arg dbg =
                  (n lsl 1) dbg],
               dbg)))
   (* Floating-point operations *)
+  | Pidentityfloat ->
+      box_float dbg (transl_unbox_float dbg env arg)
   | Pfloatofint ->
       box_float dbg (Cop(Cfloatofint, [untag_int(transl env arg) dbg], dbg))
   | Pintoffloat ->

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -594,7 +594,7 @@ let rec comp_expr env exp sz cont =
         in
         comp_init env sz decl_size
       end
-  | Lprim((Pidentity | Popaque), [arg], _) ->
+  | Lprim((Pidentity | Pidentityfloat | Popaque), [arg], _) ->
       comp_expr env arg sz cont
   | Lprim(Pignore, [arg], _) ->
       comp_expr env arg sz (add_const_unit cont)

--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -75,6 +75,7 @@ type primitive =
   | Poffsetint of int
   | Poffsetref of int
   (* Float operations *)
+  | Pidentityfloat
   | Pintoffloat | Pfloatofint
   | Pnegfloat | Pabsfloat
   | Paddfloat | Psubfloat | Pmulfloat | Pdivfloat

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -79,6 +79,7 @@ type primitive =
   | Poffsetint of int
   | Poffsetref of int
   (* Float operations *)
+  | Pidentityfloat
   | Pintoffloat | Pfloatofint
   | Pnegfloat | Pabsfloat
   | Paddfloat | Psubfloat | Pmulfloat | Pdivfloat

--- a/bytecomp/printlambda.ml
+++ b/bytecomp/printlambda.ml
@@ -214,6 +214,7 @@ let primitive ppf = function
   | Pintcomp(cmp) -> integer_comparison ppf cmp
   | Poffsetint n -> fprintf ppf "%i+" n
   | Poffsetref n -> fprintf ppf "+:=%i"n
+  | Pidentityfloat -> fprintf ppf "id."
   | Pintoffloat -> fprintf ppf "int_of_float"
   | Pfloatofint -> fprintf ppf "float_of_int"
   | Pnegfloat -> fprintf ppf "~."
@@ -373,6 +374,7 @@ let name_of_primitive = function
   | Pintcomp _ -> "Pintcomp"
   | Poffsetint _ -> "Poffsetint"
   | Poffsetref _ -> "Poffsetref"
+  | Pidentityfloat -> "Pidentityfloat"
   | Pintoffloat -> "Pintoffloat"
   | Pfloatofint -> "Pfloatofint"
   | Pnegfloat -> "Pnegfloat"

--- a/bytecomp/semantics_of_primitives.ml
+++ b/bytecomp/semantics_of_primitives.ml
@@ -63,6 +63,7 @@ let for_primitive (prim : Lambda.primitive) =
       Arbitrary_effects, No_coeffects
   | Poffsetint _ -> No_effects, No_coeffects
   | Poffsetref _ -> Arbitrary_effects, Has_coeffects
+  | Pidentityfloat
   | Pintoffloat
   | Pfloatofint
   | Pnegfloat
@@ -165,6 +166,7 @@ type return_type =
 
 let return_type_of_primitive (prim:Lambda.primitive) =
   match prim with
+  | Pidentityfloat
   | Pfloatofint
   | Pnegfloat
   | Pabsfloat

--- a/bytecomp/simplif.ml
+++ b/bytecomp/simplif.ml
@@ -582,7 +582,7 @@ let rec emit_tail_infos is_tail lambda =
   | Lletrec (bindings, body) ->
       List.iter (fun (_, lam) -> emit_tail_infos false lam) bindings;
       emit_tail_infos is_tail body
-  | Lprim (Pidentity, [arg], _) ->
+  | Lprim ((Pidentity | Pidentityfloat), [arg], _) ->
       emit_tail_infos is_tail arg
   | Lprim ((Pbytes_to_string | Pbytes_of_string), [arg], _) ->
       emit_tail_infos is_tail arg

--- a/bytecomp/translprim.ml
+++ b/bytecomp/translprim.ml
@@ -157,6 +157,7 @@ let primitives_table = create_hashtable 57 [
   "%geint", Primitive (Pintcomp Cge);
   "%incr", Primitive (Poffsetref(1));
   "%decr", Primitive (Poffsetref(-1));
+  "%identityfloat", Primitive Pidentityfloat;
   "%intoffloat", Primitive Pintoffloat;
   "%floatofint", Primitive Pfloatofint;
   "%negfloat", Primitive Pnegfloat;

--- a/middle_end/inlining_cost.ml
+++ b/middle_end/inlining_cost.ml
@@ -20,7 +20,7 @@
 
 let prim_size (prim : Lambda.primitive) args =
   match prim with
-  | Pidentity -> 0
+  | Pidentity | Pidentityfloat -> 0
   | Pgetglobal _ -> 1
   | Psetglobal _ -> 1
   | Pmakeblock _ -> 5 + List.length args

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -64,6 +64,7 @@ let new_value = "new_value"
 let numerator = "numerator"
 let obj = "obj"
 let offsetted = "offsetted"
+let pidentityfloat = "Pidentityfloat"
 let pabsfloat = "Pabsfloat"
 let paddbint = "Paddbint"
 let paddfloat = "Paddfloat"
@@ -168,6 +169,7 @@ let psubfloat = "Psubfloat"
 let psubint = "Psubint"
 let pxorbint = "Pxorbint"
 let pxorint = "Pxorint"
+let pidentityfloat_arg = "Pidentityfloat_arg"
 let pabsfloat_arg = "Pabsfloat_arg"
 let paddbint_arg = "Paddbint_arg"
 let paddfloat_arg = "Paddfloat_arg"
@@ -334,6 +336,7 @@ let of_primitive : Lambda.primitive -> string = function
   | Pintcomp _ -> pintcomp
   | Poffsetint _ -> poffsetint
   | Poffsetref _ -> poffsetref
+  | Pidentityfloat -> pidentityfloat
   | Pintoffloat -> pintoffloat
   | Pfloatofint -> pfloatofint
   | Pnegfloat -> pnegfloat
@@ -437,6 +440,7 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pintcomp _ -> pintcomp_arg
   | Poffsetint _ -> poffsetint_arg
   | Poffsetref _ -> poffsetref_arg
+  | Pidentityfloat -> pidentityfloat_arg
   | Pintoffloat -> pintoffloat_arg
   | Pfloatofint -> pfloatofint_arg
   | Pnegfloat -> pnegfloat_arg

--- a/middle_end/simplify_primitives.ml
+++ b/middle_end/simplify_primitives.ml
@@ -209,6 +209,7 @@ let primitive (p : Lambda.primitive) (args, approxs) expr dbg ~size_int
       end
     | [Value_float (Some x)] when fpc ->
       begin match p with
+      | Pidentityfloat -> S.const_float_expr expr x
       | Pintoffloat -> S.const_int_expr expr (int_of_float x)
       | Pnegfloat -> S.const_float_expr expr (-. x)
       | Pabsfloat -> S.const_float_expr expr (abs_float x)

--- a/stdlib/float.ml
+++ b/stdlib/float.ml
@@ -14,6 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
+external identity : float -> float = "%identityfloat"
 external neg : float -> float = "%negfloat"
 external add : float -> float -> float = "%addfloat"
 external sub : float -> float -> float = "%subfloat"

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -30,6 +30,9 @@
     @since 4.07.0
 *)
 
+external identity : float -> float = "%identityfloat"
+(** Identity. *)
+
 external neg : float -> float = "%negfloat"
 (** Unary negation. *)
 


### PR DESCRIPTION
In order to ensure that floats are unboxed, it is not uncommon for
developers to replace `some_float_expr` with `0. +. some_float_expr`.

However, while it saves an allocation, it is not a no-op (and cannot
be, as in some corner cases the result might be different from
`some_float_expr`). On `amd64`, it costs two instructions: a `xorpd`
followed by an `addsd`.

This PR introduces a new primitive, the identity over float values, that
can be used to replace the previous trick. The primitive is exposed
through a new `Float.identity` function (as we now have a proper
`Float` module, I assumed that namespace pollution was no longer
an issue).

(note: the same idea could also be applied to boxed integers.)