### PR TITLE
no debug info by default in expect_test

### DIFF
--- a/testsuite/tests/tool-toplevel/ocamltests
+++ b/testsuite/tests/tool-toplevel/ocamltests
@@ -1,4 +1,5 @@
 exotic_lists.ml
+pr6468.ml
 pr7060.ml
 pr7751.ml
 strings.ml

--- a/testsuite/tests/tool-toplevel/pr6468.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr6468.compilers.reference
@@ -1,0 +1,11 @@
+val f : unit -> 'a = <fun>
+Characters 11-15:
+  let g () = f (); 1;;
+             ^^^^
+Warning 21: this statement never returns (or has an unsound type.)
+val g : unit -> int = <fun>
+Exception: Not_found.
+Raised at file "//toplevel//", line 5, characters 17-26
+Called from file "//toplevel//", line 5, characters -15--11
+Called from file "toplevel/toploop.ml", line 180, characters 17-56
+

--- a/testsuite/tests/tool-toplevel/pr6468.ml
+++ b/testsuite/tests/tool-toplevel/pr6468.ml
@@ -1,0 +1,7 @@
+(* TEST
+   * toplevel
+*)
+
+let f () = raise Not_found;;
+let g () = f (); 1;;
+g ();;

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -467,7 +467,6 @@ let _ =
   if !Sys.interactive then (* PR#6108 *)
     invalid_arg "The ocamltoplevel.cma library from compiler-libs \
                  cannot be loaded inside the OCaml toplevel";
-  Clflags.debug := true;
   Sys.interactive := true;
   let crc_intfs = Symtable.init_toplevel() in
   Compmisc.init_path false;
@@ -511,6 +510,7 @@ let initialize_toplevel_env () =
 exception PPerror
 
 let loop ppf =
+  Clflags.debug := true;
   Location.formatter_for_warnings := ppf;
   if not !Clflags.noversion then
     fprintf ppf "        OCaml version %s@.@." Config.version;


### PR DESCRIPTION
Context: I was adding some expect tests with "-dlambda -dno-unique-ids", in which I placed some empty expect blocks, and ran `make promote`.
At that point, the normal and "Principal" output differed, because:
- there were some debug infos in the lambda that I was dumping, which are printed with some location information.
- when expect_test is called for the second time on the file, with `-principal` all the locations past the first expect blocks are shifted by some amount.
So the `Principal {| ... |}` part is kept. Which means that if you run the tests once more, it will fail again, because the locations will have shifted some more.

The solution to this problem is to not generate debug info. Currently, the initialization of `Toploop` (which expect_tests links against) sets `Clflags.debug` to `true`.
Here I chose to unset it at the initialization of `Expect_test`. Another approach could be to not do the setting at the initialization of `Toploop` but instead do it in `Toploop.loop`, but I do not know if the current implementation was a conscious decision from @gasche or purely incidental. My guess is that we could probably move that setting to `Toploop.loop`, which seems cleaner than the approach proposed here, but I'll let @gasche decide that.