### PR TITLE
matching: cleanup debug printing

### DIFF
--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -82,11 +82,7 @@ type ctx = {left:pattern list ; right:pattern list}
 let pretty_ctx ctx =
   List.iter
     (fun {left=left ; right=right} ->
-      Format.eprintf "LEFT:" ;
-      pretty_line Format.err_formatter left ;
-      Format.eprintf " RIGHT:" ;
-      pretty_line Format.err_formatter right ;
-      Format.eprintf "\n")
+      Format.eprintf "LEFT:%a RIGHT:%a\n" pretty_line left pretty_line right)
     ctx
 
 let le_ctx c1 c2 =
@@ -424,9 +420,7 @@ let pretty_cases cases =
 let pretty_def def =
   Format.eprintf "+++++ Defaults +++++\n" ;
   List.iter
-    (fun (pss,i) ->
-      Printf.fprintf stderr "Matrix for %d\n"  i ;
-      pretty_matrix Format.err_formatter pss)
+    (fun (pss,i) -> Format.eprintf "Matrix for %d\n%a" i pretty_matrix pss)
     def ;
   Format.eprintf "+++++++++++++++++++++\n"
 
@@ -2724,10 +2718,8 @@ let rec compile_match repr partial ctx m = match m with
 (* verbose version of do_compile_matching, for debug *)
 
 and do_compile_matching_pr repr partial ctx arg x =
-  Format.eprintf "COMPILE: " ;
-  Format.eprintf "%s\n"
+  Format.eprintf "COMPILE: %s\nMATCH\n"
     (match partial with Partial -> "Partial" | Total -> "Total") ;
-  Format.eprintf "MATCH\n" ;
   pretty_precompiled x ;
   Format.eprintf "CTX\n" ;
   pretty_ctx ctx ;

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -82,11 +82,11 @@ type ctx = {left:pattern list ; right:pattern list}
 let pretty_ctx ctx =
   List.iter
     (fun {left=left ; right=right} ->
-      prerr_string "LEFT:" ;
+      Format.eprintf "LEFT:" ;
       pretty_line Format.err_formatter left ;
-      prerr_string " RIGHT:" ;
+      Format.eprintf " RIGHT:" ;
       pretty_line Format.err_formatter right ;
-      prerr_endline "")
+      Format.eprintf "\n")
     ctx
 
 let le_ctx c1 c2 =
@@ -416,27 +416,19 @@ let pretty_cases cases =
   List.iter
     (fun (ps,_l) ->
       List.iter
-        (fun p ->
-          top_pretty Format.str_formatter p ;
-          prerr_string " " ;
-          prerr_string (Format.flush_str_formatter ()))
+        (fun p -> Format.eprintf " %a%!" top_pretty p)
         ps ;
-(*
-      prerr_string " -> " ;
-      Printlambda.lambda Format.str_formatter l ;
-      prerr_string (Format.flush_str_formatter ()) ;
-*)
-      prerr_endline "")
+      Format.eprintf "\n")
     cases
 
 let pretty_def def =
-  prerr_endline "+++++ Defaults +++++" ;
+  Format.eprintf "+++++ Defaults +++++\n" ;
   List.iter
     (fun (pss,i) ->
       Printf.fprintf stderr "Matrix for %d\n"  i ;
       pretty_matrix Format.err_formatter pss)
     def ;
-  prerr_endline "+++++++++++++++++++++"
+  Format.eprintf "+++++++++++++++++++++\n"
 
 let pretty_pm pm =
   pretty_cases pm.cases ;
@@ -446,13 +438,13 @@ let pretty_pm pm =
 
 let rec pretty_precompiled = function
   | Pm pm ->
-      prerr_endline "++++ PM ++++" ;
+      Format.eprintf "++++ PM ++++\n" ;
       pretty_pm pm
   | PmVar x ->
-      prerr_endline "++++ VAR ++++" ;
+      Format.eprintf "++++ VAR ++++\n" ;
       pretty_precompiled x.inside
   | PmOr x ->
-      prerr_endline "++++ OR ++++" ;
+      Format.eprintf "++++ OR ++++\n" ;
       pretty_pm x.body ;
       pretty_matrix Format.err_formatter x.or_matrix ;
       List.iter
@@ -1147,7 +1139,7 @@ let split_precompile argo pm =
   let {me=next}, nexts = split_or argo pm.cases pm.args pm.default  in
   if dbg && (nexts <> [] || (match next with PmOr _ -> true | _ -> false))
   then begin
-    prerr_endline "** SPLIT **" ;
+    Format.eprintf "** SPLIT **\n" ;
     pretty_pm pm ;
     pretty_precompiled_res  next nexts
   end ;
@@ -1231,7 +1223,7 @@ let rec matcher_const cst p rem = match p.pat_desc with
 let get_key_constant caller = function
   | {pat_desc= Tpat_constant cst} -> cst
   | p ->
-      prerr_endline ("BAD: "^caller) ;
+      Format.eprintf "BAD: %s" caller ;
       pretty_pat p ;
       assert false
 
@@ -2184,7 +2176,7 @@ let mk_failaction_neg partial ctx def = match partial with
 (* In line with the article and simpler than before *)
 let mk_failaction_pos partial seen ctx defs  =
   if dbg then begin
-    prerr_endline "**POS**" ;
+    Format.eprintf "**POS**\n" ;
     pretty_def defs ;
     ()
   end ;
@@ -2732,14 +2724,15 @@ let rec compile_match repr partial ctx m = match m with
 (* verbose version of do_compile_matching, for debug *)
 
 and do_compile_matching_pr repr partial ctx arg x =
-  prerr_string "COMPILE: " ;
-  prerr_endline (match partial with Partial -> "Partial" | Total -> "Total") ;
-  prerr_endline "MATCH" ;
+  Format.eprintf "COMPILE: " ;
+  Format.eprintf "%s\n"
+    (match partial with Partial -> "Partial" | Total -> "Total") ;
+  Format.eprintf "MATCH\n" ;
   pretty_precompiled x ;
-  prerr_endline "CTX" ;
+  Format.eprintf "CTX\n" ;
   pretty_ctx ctx ;
   let (_, jumps) as r =  do_compile_matching repr partial ctx arg x in
-  prerr_endline "JUMPS" ;
+  Format.eprintf "JUMPS\n" ;
   pretty_jumps jumps ;
   r
 


### PR DESCRIPTION
Avoid mixing calls to `Format` with calls to `prerr_*` because otherwise the output is all scrambled.