### PR TITLE
Document usage of Build Tools for Visual Studio

### DIFF
--- a/README.win32.adoc
+++ b/README.win32.adoc
@@ -92,17 +92,17 @@ C code (`ocamlc -custom`) require a Microsoft Visual C/C++ Compiler and the
 Any edition (including Express/Community editions) of Microsoft Visual Studio
 2005 or later may be used to provide the required Windows headers and the C
 compiler. Additionally, some older Microsoft Windows SDKs include the
-Visual C/C++ Compiler.
+Visual C/C++ Compiler as well as the Build Tools for Visual Studio.
 
 |=====
-|                    | `cl` Version | Express                 | SDK
-| Visual Studio 2005 | 14.00.x.x    | 32-bit only <<vs1,(*)>> |
+|                    | `cl` Version | Express                 | SDK/Build Tools
+| Visual Studio 2005 | 14.00.x.x    | 32-bit only <<vs1,(*)>> |                                                    
 | Visual Studio 2008 | 15.00.x.x    | 32-bit only             | Windows SDK 7.0 also provides 32/64-bit compilers
 | Visual Studio 2010 | 16.00.x.x    | 32-bit only             | Windows SDK 7.1 also provides 32/64-bit compilers
 | Visual Studio 2012 | 17.00.x.x    | 32/64-bit               |
 | Visual Studio 2013 | 18.00.x.x    | 32/64-bit               |
-| Visual Studio 2015 | 19.00.x.x    | 32/64-bit               |
-| Visual Studio 2017 | 19.10.x.x    | 32/64-bit               |
+| Visual Studio 2015 | 19.00.x.x    | 32/64-bit               | Build Tools for Visual Studio 2015 also provides 32/64-bit compilers
+| Visual Studio 2017 | 19.10.x.x    | 32/64-bit               | Build Tools for Visual Studio 2017 also provides 32/64-bit compilers
 |=====
 
 [[vs1]]
@@ -158,6 +158,9 @@ For Visual Studio 2012 and 2013, both x86 and x64 Command Prompt shortcuts
 indicate if they are the "Native Tools" or "Cross Tools" versions. Visual Studio
 2015 and 2017 make the shortcuts even clearer by including the full name of the
 architecture.
+
+The Build Tools for Visual Studio 2015 and 2017 provide shortcuts similar to
+the ones of their respective Visual Studio version.
 
 You cannot at present use a cross-compiler to compile 64-bit OCaml on 32-bit
 Windows.


### PR DESCRIPTION
The Build Tools for Visual Studio also include a C/C++ compiler and thus
can similar to the old SDK be used for installing ocaml under windows.