### PR TITLE
Use C99 flexible arrays for struct pool_block in memory.c if possible

### DIFF
--- a/Changes
+++ b/Changes
@@ -61,6 +61,11 @@ Working version
 - GPR#1739: ensure ocamltest waits for child processes to terminate on Windows
   (David Allsopp, review by Sébastien Hinderer)
 
+- GPR#????: in byterun/memory.c, struct pool_block, use C99 flexible arrays
+  if possible to avoid alarms with Clang's address sanitizer
+  (Xavier Leroy)
+
+
 OCaml 4.07
 ----------
 

--- a/Changes
+++ b/Changes
@@ -61,10 +61,6 @@ Working version
 - GPR#1739: ensure ocamltest waits for child processes to terminate on Windows
   (David Allsopp, review by Sébastien Hinderer)
 
-- GPR#????: in byterun/memory.c, struct pool_block, use C99 flexible arrays
-  if possible to avoid alarms with Clang's address sanitizer
-  (Xavier Leroy)
-
 
 OCaml 4.07
 ----------
@@ -572,6 +568,11 @@ OCaml 4.07
 - GPR#1755: ensure that a bigarray is never collected while reading complex
   values (Xavier Clerc, Mark Shinwell and Leo White, report by Chris Hardin,
   reviews by Stephen Dolan and Xavier Leroy)
+
+- GPR#1764: in byterun/memory.c, struct pool_block, use C99 flexible arrays
+  if available 
+  (Xavier Leroy, review by Max Mouratov)
+
 
 OCaml 4.06.1 (16 Feb 2018):
 ---------------------------

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -728,10 +728,19 @@ struct pool_block {
 #endif
   struct pool_block *next;
   struct pool_block *prev;
-  union max_align data[1];  /* not allocated, used for alignment purposes */
+  /* Use C99's flexible array types if possible */
+#if (__STDC_VERSION__ >= 199901L)
+  union max_align data[];  /* not allocated, used for alignment purposes */
+#else
+  union max_align data[1];
+#endif
 };
 
+#if (__STDC_VERSION__ >= 199901L)
+#define SIZEOF_POOL_BLOCK sizeof(struct pool_block)
+#else
 #define SIZEOF_POOL_BLOCK offsetof(struct pool_block, data)
+#endif
 
 static struct pool_block *pool = NULL;
 


### PR DESCRIPTION
The original code causes alarms with Clang's address sanitizer, because the malloc-ed size of the object is less than its static size (as given by sizeof).   Whether it is valid C99 code is up for debate.

The new code is patterned after `struct caml_ba_array` in `<caml/bigarray.h>`, which is a solution to a similar problem, see [MPR#5516](https://caml.inria.fr/mantis/view.php?id=5516).

I'd like to integrate Clang sanitizers and maybe other static or dynamic checking tools in our CI.  Getting rid of spurious alarms is a first step.

