### PR TITLE
manual: ellipses in examples

### DIFF
--- a/Changes
+++ b/Changes
@@ -387,6 +387,9 @@ OCaml 4.07
 - GPR#1741: manual, improve typesetting and legibility in HTML output
   (steinuil, review by Gabriel Scherer)
 
+- GPR#1765: manual, ellipsis in code examples
+  (Florian Angeletti, review and suggestion by Gabriel Scherer)
+
 ### Compiler distribution build system
 
 - MPR#5219, GPR#1680: use 'install' instead of 'cp' in install scripts

--- a/manual/README.md
+++ b/manual/README.md
@@ -171,9 +171,31 @@ let f None = None [@@expect warning 8];;
 \end{caml_example}
 ```
 
-The `caml_eval` environment is a companion environment to `caml_example`
-and can be used to evaluate OCaml expressions in the toplevel without
-printing anything:
+It is also possible to elide a code fragment by annotating it with
+an `[@ellipsis]` attribute
+
+```latex
+\begin{caml_example}{toplevel}
+let f: type a. a list -> int = List.length[@ellipsis] ;;
+\end{caml_example}
+```
+For module components, it might be easier to hide them by using
+`[@@@ellipsis.start]` and `[@@@ellipsis.stop]`:
+```latex
+\begin{caml_example*}{verbatim}
+module M = struct
+  [@@@ellipsis.start]
+  type t = T
+  let x = 0
+  [@@@ellipsis.stop]
+ end
+\end{caml_example*}
+```
+
+Another possibility to avoid displaying distracting code is to use
+the `caml_eval` environment. This environment is a companion environment
+to `caml_example` and can be used to evaluate OCaml expressions in the
+toplevel without printing anything:
 ```latex
 \begin{caml_eval}
 let pi = 4. *. atan 1.;;

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -481,19 +481,19 @@ This construction is useful because the type constructors it introduces
 can be used in places where a type variable is not allowed. For
 instance, one can use it to define an exception in a local module
 within a polymorphic function.
-\begin{caml_example*}{verbatim}
+\begin{verbatim}
         let f (type t) () =
           let module M = struct exception E of t end in
           (fun x -> M.E x), (function M.E x -> Some x | _ -> None)
-\end{caml_example*}
+\end{verbatim}
 
 Here is another example:
-\begin{caml_example*}{verbatim}
+\begin{verbatim}
         let sort_uniq (type s) (cmp : s -> s -> int) =
           let module S = Set.Make(struct type t = s let compare = cmp end) in
           fun l ->
             S.elements (List.fold_right S.add l S.empty)
-\end{caml_example*}
+\end{verbatim}
 
 It is also extremely useful for first-class modules (see
 section~\ref{s-first-class-modules}) and generalized algebraic datatypes

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -621,13 +621,13 @@ Each implementation is a structure that we can encapsulate as a
 first-class module, then store in a data structure such as a hash
 table:
 \begin{caml_example*}{verbatim}
-        module type DEVICE = sig [@@@ellipsis.start][@@@ellipsis.stop] end
+        module type DEVICE = sig [@@@ellipsis] end
         let devices : (string, (module DEVICE)) Hashtbl.t = Hashtbl.create 17
 
-        module SVG = struct [@@@ellipsis.start][@@@ellipsis.stop] end
+        module SVG = struct [@@@ellipsis] end
         let _ = Hashtbl.add devices "SVG" (module SVG : DEVICE)
 
-        module PDF = struct [@@@ellipsis.start][@@@ellipsis.stop] end
+        module PDF = struct [@@@ellipsis] end
         let _ = Hashtbl.add devices "PDF" (module PDF: DEVICE)
 \end{caml_example*}
 We can then select one implementation based on command-line

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -460,40 +460,40 @@ suspend the evaluation of @expr@ as a regular abstraction would.  The
 syntax has been chosen to fit nicely in the context of function
 declarations, where it is generally used. It is possible to freely mix
 regular function parameters with pseudo type parameters, as in:
-\begin{verbatim}
-        let f = fun (type t) (foo : t list) -> ...
-\end{verbatim}
+\begin{caml_example*}{verbatim}
+        let f = fun (type t) (foo : t list) -> assert false[@ellipsis]
+\end{caml_example*}
 and even use the alternative syntax for declaring functions:
-\begin{verbatim}
-        let f (type t) (foo : t list) = ...
-\end{verbatim}
+\begin{caml_example*}{verbatim}
+        let f (type t) (foo : t list) = assert false[@ellipsis]
+\end{caml_example*}
 If several locally abstract types need to be introduced, it is possible to use
 the syntax
 @"fun" '(' "type" typeconstr-name_1 \ldots typeconstr-name_n ')' "->" expr@
 as syntactic sugar for @"fun" '(' "type" typeconstr-name_1 ')' "->" \ldots "->"
 "fun" '(' "type" typeconstr-name_n ')' "->" expr@. For instance,
-\begin{verbatim}
-        let f = fun (type t u v) -> fun (foo : (t * u * v) list) -> ...
-        let f' (type t u v) (foo : (t * u * v) list) = ...
-\end{verbatim}
+\begin{caml_example*}{verbatim}
+        let f = fun (type t u v) -> fun (foo : (t * u * v) list) -> assert false[@ellipsis]
+        let f' (type t u v) (foo : (t * u * v) list) = assert false[@ellipsis]
+\end{caml_example}
 
 This construction is useful because the type constructors it introduces
 can be used in places where a type variable is not allowed. For
 instance, one can use it to define an exception in a local module
 within a polymorphic function.
-\begin{verbatim}
+\begin{caml_example*}{verbatim}
         let f (type t) () =
           let module M = struct exception E of t end in
           (fun x -> M.E x), (function M.E x -> Some x | _ -> None)
-\end{verbatim}
+\end{caml_example*}
 
 Here is another example:
-\begin{verbatim}
+\begin{caml_example*}{verbatim}
         let sort_uniq (type s) (cmp : s -> s -> int) =
           let module S = Set.Make(struct type t = s let compare = cmp end) in
           fun l ->
             S.elements (List.fold_right S.add l S.empty)
-\end{verbatim}
+\end{caml_example*}
 
 It is also extremely useful for first-class modules (see
 section~\ref{s-first-class-modules}) and generalized algebraic datatypes
@@ -518,15 +518,15 @@ The @"(type" typeconstr-name")"@ syntax construction by itself does not make
 polymorphic the type variable it introduces, but it can be combined
 with explicit polymorphic annotations where needed.
 The above rule is provided as syntactic sugar to make this easier:
-\begin{verbatim}
-        let rec f : type t1 t2. t1 * t2 list -> t1 = ...
-\end{verbatim}
+\begin{caml_example*}{verbatim}
+        let rec f : type t1 t2. t1 * t2 list -> t1 = assert false[@ellipsis]
+\end{caml_example*}
 \noindent
 is automatically expanded into
-\begin{verbatim}
+\begin{caml_example*}{verbatim}
         let rec f : 't1 't2. 't1 * 't2 list -> 't1 =
-          fun (type t1) (type t2) -> (... : t1 * t2 list -> t1)
-\end{verbatim}
+          fun (type t1) (type t2) -> ( assert false[@ellipsis] : t1 * t2 list -> t1)
+\end{caml_example*}
 This syntax can be very useful when defining recursive functions involving
 GADTs, see the section~\ref{s:gadts} for a more detailed explanation.
 
@@ -620,16 +620,16 @@ select at run-time among several implementations of a signature.
 Each implementation is a structure that we can encapsulate as a
 first-class module, then store in a data structure such as a hash
 table:
-\begin{verbatim}
-        module type DEVICE = sig ... end
+\begin{caml_example*}{verbatim}
+        module type DEVICE = sig [@@@ellipsis.start][@@@ellipsis.stop] end
         let devices : (string, (module DEVICE)) Hashtbl.t = Hashtbl.create 17
 
-        module SVG = struct ... end
+        module SVG = struct [@@@ellipsis.start][@@@ellipsis.stop] end
         let _ = Hashtbl.add devices "SVG" (module SVG : DEVICE)
 
-        module PDF = struct ... end
+        module PDF = struct [@@@ellipsis.start][@@@ellipsis.stop] end
         let _ = Hashtbl.add devices "PDF" (module PDF: DEVICE)
-\end{verbatim}
+\end{caml_example*}
 We can then select one implementation based on command-line
 arguments, for instance:
 \begin{verbatim}

--- a/manual/tools/Makefile
+++ b/manual/tools/Makefile
@@ -24,8 +24,9 @@ htmlgen: latexmacros.cmo latexscan.cmo latexmain.cmo
 latexscan.ml: latexscan.mll
 	ocamllex latexscan.mll
 
-caml-tex2: caml_tex2.cmo
-	$(OCAMLC) -o caml-tex2 str.cma unix.cma caml_tex2.cmo
+caml-tex2: caml_tex2.ml
+	$(OCAMLC) $(TOPDIR)/compilerlibs/ocamlcommon.cma -I $(TOPDIR)/parsing \
+	-o caml-tex2 str.cma unix.cma caml_tex2.ml
 
 .SUFFIXES:
 .SUFFIXES: .ml .cmo .mli .cmi .c

--- a/manual/tools/caml_tex2.ml
+++ b/manual/tools/caml_tex2.ml
@@ -253,17 +253,17 @@ module Text_transform = struct
           if t.stop < u.stop then underline u (t::n) q
           else end_underline u n (t::q)
     and end_underline u n l = U(u,List.rev n) :: partition l in
-  let check_elt (left,stop) t =
-    if t.start < stop then
-      raise (Intersection{line;file;left;stop;start=t.start;right=t.kind})
-    else
-      (t.kind,t.stop) in
-  let check acc = function
-    | E t -> check_elt acc t
-    | U(u,n) ->
-        let _ = check_elt acc u in
-        let _ = List.fold_left ~f:check_elt ~init n in
-        u.kind, u.stop in
+    let check_elt (left,stop) t =
+      if t.start < stop then
+        raise (Intersection{line;file;left;stop;start=t.start;right=t.kind})
+      else
+        (t.kind,t.stop) in
+    let check acc = function
+      | E t -> check_elt acc t
+      | U(u,n) ->
+          let _ = check_elt acc u in
+          let _ = List.fold_left ~f:check_elt ~init n in
+          u.kind, u.stop in
     List.fold_left ~f:check ~init (partition l)
     |> ignore
 

--- a/manual/tools/caml_tex2.ml
+++ b/manual/tools/caml_tex2.ml
@@ -355,18 +355,19 @@ module Ellipsis = struct
       let start = loc.Location.loc_start.Lexing.pos_cnum in
       let attr_start = attr.Location.loc.loc_start.Lexing.pos_cnum in
       let attr_stop = 1 + attr.Location.loc.loc_end.Lexing.pos_cnum in
-      let stop = loc.Location.loc_end.Lexing.pos_cnum
-      in
+      let stop = loc.Location.loc_end.Lexing.pos_cnum in
+      let check_nested () = match !left_mark with
+        | Some (first,_) -> raise (Nested_ellipses {first; second=attr_start})
+        | None -> () in
       match name with
       | "ellipsis" ->
+          check_nested ();
           transforms :=
-            { Text_transform.kind=Ellipsis; start; stop= max attr_stop stop }
+            {Text_transform.kind=Ellipsis; start; stop=max attr_stop stop }
             :: !transforms
       | "ellipsis.start" ->
-          begin match !left_mark with
-          | None -> left_mark := Some (start, stop)
-          | Some (first,_) -> raise (Nested_ellipses {first; second=attr_start})
-          end
+          check_nested ();
+          left_mark := Some (start, stop)
       | "ellipsis.stop" ->
           begin match !left_mark with
           | None -> raise (Unmatched_ellipsis {kind="right"; start; stop})


### PR DESCRIPTION
As suggested in #1209, this PR proposes to add the ability to elide some of the content in the `caml_example` code examples. More precisely, term annotated by `[@ellipsis]` or between `[@ellipsis.start]` and `[ellipsis.stop]` are replaced by `\ldots` (i.e. `…`):

```OCaml
module M = struct
  [@@@ellipsis.start]
  type t = T
  let x = 0
  [@@@ellipsis.stop]
end
let f = fun (type t) (foo : t list) -> assert false[@ellipsis]
``` 
becomes 
```OCaml
module M = struct
  …
end
let f = fun (type t) (foo : t list) -> …
```
in the manual text.

As an illustration, I translated the locally abstract type section of the extension chapter to `caml_examples` and one of the verbatim examples in the section on first-class modules.

This PR also adds a notion of textual transformation to `caml_tex2` and checks that no transformation applies to intersecting text fragment. Consequently, it is not possible to elide a part of an example which raises a warning or an error. 