### PR TITLE
Allow sequences of SEMISEMI in Parse.use_file

### DIFF
--- a/Changes
+++ b/Changes
@@ -580,8 +580,13 @@ OCaml 4.07
   reviews by Stephen Dolan and Xavier Leroy)
 
 - GPR#1764: in byterun/memory.c, struct pool_block, use C99 flexible arrays
-  if available 
+  if available
   (Xavier Leroy, review by Max Mouratov)
+
+- MPR#7793, GPR#1766: the toplevel #use directive now accepts sequences of ';;'
+  tokens. This fixes a bug in which certain files accepted by the compiler were
+  rejected by ocamldep.
+  (Nicolás Ojeda Bär, report by Hugo Heuzard, review by Hugo Heuzard)
 
 - GPR#1774: ocamlopt for ARM could generate VFP loads and stores with bad
   offsets, rejected by the assembler.

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -654,7 +654,7 @@ top_structure_tail:
   | structure_item top_structure_tail    { (text_str 1) @ $1 :: $2 }
 ;
 use_file:
-    use_file_body                        { extra_def 1 $1 }
+    use_file_body EOF                    { extra_def 1 $1 }
 ;
 use_file_body:
     use_file_tail                        { $1 }
@@ -662,18 +662,10 @@ use_file_body:
       { (text_def 1) @ Ptop_def[mkstrexp $1 $2] :: $3 }
 ;
 use_file_tail:
-    EOF
+    /* empty */
       { [] }
-  | SEMISEMI EOF
-      { text_def 1 }
-  | SEMISEMI seq_expr post_item_attributes use_file_tail
-      {  mark_rhs_docs 2 3;
-        (text_def 1) @ (text_def 2) @ Ptop_def[mkstrexp $2 $3] :: $4 }
-  | SEMISEMI structure_item use_file_tail
-      { (text_def 1) @ (text_def 2) @ Ptop_def[$2] :: $3 }
-  | SEMISEMI toplevel_directive use_file_tail
-      {  mark_rhs_docs 2 3;
-        (text_def 1) @ (text_def 2) @ $2 :: $3 }
+  | SEMISEMI use_file_body
+      { $2 }
   | structure_item use_file_tail
       { (text_def 1) @ Ptop_def[$1] :: $2 }
   | toplevel_directive use_file_tail


### PR DESCRIPTION
See [MPR#7793](https://caml.inria.fr/mantis/view.php?id=7793).

Currently `Parse.implementation` accepts sequences of `;;` but `Parser.use_file` does not. This leads to files which are parseable using the compiler but not `ocamldep` (which uses `Parse.use_file` to process `.ml` files).

This PR rewrites the `Parse.use_file` rule in a manner similar to `Parse.implementation` to fix this discrepancy.