### PR TITLE
Change html manual to use relative font sizes

### DIFF
--- a/Changes
+++ b/Changes
@@ -376,14 +376,6 @@ OCaml 4.07
 
 ### Manual and documentation:
 
-- PR#1757: change html manual to use relative font sizes
-  (Charles Chamberlain, review by Daniel Bünzli, Perry E. Metzger,
-  Josh Berdine, and Gabriel Scherer)
-
-- PR#1757: style the html manual, changing type and layout
-  (Charles Chamberlain, review by Florian Angeletti, Xavier Leroy,
-  Gabriel Radanne, Perry E. Metzger, and Gabriel Scherer)
-
 - MPR#7613: minor reword of the "refutation cases" paragraph
   (Florian Angeletti, review by Jacques Garrigue)
 
@@ -410,11 +402,19 @@ OCaml 4.07
 - GPR#1741: manual, improve typesetting and legibility in HTML output
   (steinuil, review by Gabriel Scherer)
 
+- GPR#1757: style the html manual, changing type and layout
+  (Charles Chamberlain, review by Florian Angeletti, Xavier Leroy,
+  Gabriel Radanne, Perry E. Metzger, and Gabriel Scherer)
+
 - GPR#1765: manual, ellipsis in code examples
   (Florian Angeletti, review and suggestion by Gabriel Scherer)
 
 - GPR#1779: integrate the Bigarray documentation into the main manual.
   (Perry E. Metzger, review by Florian Angeletti and Xavier Clerc)
+
+- GPR#1767: change html manual to use relative font sizes
+  (Charles Chamberlain, review by Daniel Bünzli, Perry E. Metzger,
+  Josh Berdine, and Gabriel Scherer)
 
 ### Compiler distribution build system
 

--- a/Changes
+++ b/Changes
@@ -376,6 +376,10 @@ OCaml 4.07
 
 ### Manual and documentation:
 
+- PR#1757: change html manual to use relative font sizes
+  (Charles Chamberlain, review by Daniel Bünzli, Perry E. Metzger,
+  and Gabriel Scherer)
+
 - PR#1757: style the html manual, changing type and layout
   (Charles Chamberlain, review by Florian Angeletti, Xavier Leroy,
   Gabriel Radanne, Perry E. Metzger, and Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -378,7 +378,7 @@ OCaml 4.07
 
 - PR#1757: change html manual to use relative font sizes
   (Charles Chamberlain, review by Daniel Bünzli, Perry E. Metzger,
-  and Gabriel Scherer)
+  Josh Berdine, and Gabriel Scherer)
 
 - PR#1757: style the html manual, changing type and layout
   (Charles Chamberlain, review by Florian Angeletti, Xavier Leroy,

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -37,6 +37,12 @@
   text-align: center;
 }
 
+\newstyle{@media all}{
+  .c003 \{
+    font-size: 0.91rem;
+  \}
+}
+
 \newstyle{h1, h2, h3}{
   font-family: "Fira Sans", sans-serif;
   font-weight: normal;

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -37,13 +37,6 @@
   text-align: center;
 }
 
-% without this "@media all", the .c003 get's stripped out:
-\newstyle{@media all}{
-  .c003 \{
-    font-size: 0.91em;
-  \}
-}
-
 \newstyle{h1, h2, h3}{
   font-family: "Fira Sans", sans-serif;
   font-weight: normal;
@@ -51,7 +44,7 @@
 }
 
 \newstyle{pre}{
-  font-size: 0.91rem;
+  font-size: 1rem;
   background: beige;
   border: 1px solid grey;
   padding: 10px;

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -23,12 +23,12 @@
 
 % Compact layout
 \newstyle{body}{
-  max-width:850px;
+  max-width:750px;
   width: 85\%;
   margin: auto;
   background: \#f7f7f7;
   margin-top: 80px;
-  font-size: 1.1rem;
+  font-size: 1rem;
 }
 
 % selects the index's title
@@ -144,7 +144,7 @@
 
 \newstyle{.tableau, .syntax, .syntaxleft}{
   /* same width as body */
-  max-width: 850px;
+  max-width: 750px;
   overflow-y: auto;
 }
 

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -44,7 +44,7 @@
 }
 
 \newstyle{pre}{
-  font-size: 0.85em;
+  font-size: 0.91rem;
   background: beige;
   border: 1px solid grey;
   padding: 10px;

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -37,6 +37,7 @@
   text-align: center;
 }
 
+% without this "@media all", the .c003 get's stripped out:
 \newstyle{@media all}{
   .c003 \{
     font-size: 0.91rem;

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -28,7 +28,7 @@
   margin: auto;
   background: \#f7f7f7;
   margin-top: 80px;
-  font-size: 19px
+  font-size: 1.1rem;
 }
 
 % selects the index's title

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -40,7 +40,7 @@
 % without this "@media all", the .c003 get's stripped out:
 \newstyle{@media all}{
   .c003 \{
-    font-size: 0.91rem;
+    font-size: 0.91em;
   \}
 }
 

--- a/manual/manual/style.css
+++ b/manual/manual/style.css
@@ -55,13 +55,13 @@ div.h9 { background-color: #FFFFFF; }
 .paramstable { border-style : hidden ; padding: 5pt 5pt}
 body {
   background-color : #f7f7f7;
-  font-size: 17px;
+  font-size: 1rem;
   padding-left: 5%;
   padding-right: 5%;
   padding-bottom: 30px;
 }
 td {
-  font-size: 17px;
+  font-size: 1rem;
 }
 .navbar { /* previous - up - next */
   position: absolute;

--- a/manual/manual/style.css
+++ b/manual/manual/style.css
@@ -24,10 +24,12 @@ a:active {color : Black; text-decoration : underline; }
 .type { color : #5C6585 }
 .string { color : Maroon }
 .warning { color : Red ; font-weight : bold }
-.info { margin-left : 3em; margin-right : 3em } .code { color : #465F91 ; } h1 { font-size : 24pt ; text-align: center; }
+.info { margin-left : 3em; margin-right : 3em }
+.code { color : #465F91 ; }
+h1 { font-size : 2rem ; text-align: center; }
 
 h2, h3, h4, h5, h6, div.h7, div.h8, div.h9 {
-  font-size: 22pt;
+  font-size: 1.75rem;
   border: 1px solid #000;
   margin-top: 20px;
   margin-bottom: 2px;

--- a/manual/manual/style.css
+++ b/manual/manual/style.css
@@ -58,8 +58,9 @@ div.h9 { background-color: #FFFFFF; }
 body {
   background-color : #f7f7f7;
   font-size: 1rem;
-  padding-left: 5%;
-  padding-right: 5%;
+  max-width: 800px;
+  width: 85%;
+  margin: auto;
   padding-bottom: 30px;
 }
 td {
@@ -72,7 +73,7 @@ td {
 }
 tr { background-color : #f7f7f7 }
 td.typefieldcomment { background-color : #f7f7f7 }
-pre { margin-bottom: 4px }
+pre { margin-bottom: 4px; white-space: pre-wrap; }
 div.sig_block {margin-left: 2em}
 ul.info-attributes { list-style: none; margin: 0; padding: 0; }
 div.info > p:first-child{ margin-top:0; }


### PR DESCRIPTION
This changes to `rem` instead of `px` for the units.

The library documentation is set to `1rem` because all the code generation is typeset with tables and they overflow the width of the page very easily.

I've set the manual itself to `1.1rem`. I think this small change improves readability enough to matter in the long run but is hopefully small enough that it won't look "big" to those who prefer small fonts. If we reach a different consensus, I'm more than happy change it. As with before in #1757, the there is an [up-to-date preview](http://preview_docs.narwhal.space/) available.

:balloon: 