### PR TITLE
cmmgen: incorrect left shift by 64 if Config.profinfo_width = 0

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -611,7 +611,10 @@ let get_field env ptr n dbg =
 let set_field ptr n newval init dbg =
   Cop(Cstore (Word_val, init), [field_address ptr n dbg; newval], dbg)
 
-let non_profinfo_mask = (1 lsl (64 - Config.profinfo_width)) - 1
+let non_profinfo_mask =
+  if Config.profinfo 
+  then (1 lsl (64 - Config.profinfo_width)) - 1
+  else 0 (* [non_profinfo_mask] is unused in this case *)
 
 let get_header ptr dbg =
   (* We cannot deem this as [Immutable] due to the presence of [Obj.truncate]


### PR DESCRIPTION
If Config.profinfo_width is 0 (which is the default), the computation of Cmmgen.non_profinfo_mask performs a left shift by 64.

In OCaml such a shift is specified as returning an unspecified, machine-dependent result.  This is consistent with the program's logic because the value of Cmmgen.non_profinfo_mask is unused in this case (Config.profinfo = false and Config.profinfo_width = 0).

However, in the C code of the bytecode interpreter, this shift is technically undefined behavior.  We don't know of any processor and compiler combination that would crash the program or mis-optimize it
because of this u.b.  Nonetheless, dynamic verification tools such as LLVM's u.b. sanitizer raise an alarm here.  Silencing the alarm could hide more serious problems where the unspecified shift result is actually used.

This commit avoids the bad shift by performing it only when Config.profinfo = true and therefore Config.profinfo_width > 0.