### PR TITLE
In <caml/major_gc.h> declare some variables 'extern'

### DIFF
--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -46,6 +46,7 @@
 extern int caml_parser_trace;
 CAMLexport header_t caml_atom_table[256];
 char * caml_code_area_start, * caml_code_area_end;
+struct ext_table caml_code_fragments_table;
 
 /* Initialize the atom table and the static data and code area limits. */
 

--- a/byterun/caml/intext.h
+++ b/byterun/caml/intext.h
@@ -196,7 +196,7 @@ struct code_fragment {
 
 CAMLextern struct code_fragment * caml_extern_find_code(char *addr);
 
-struct ext_table caml_code_fragments_table;
+extern struct ext_table caml_code_fragments_table;
 
 #endif /* CAML_INTERNALS */
 

--- a/byterun/caml/major_gc.h
+++ b/byterun/caml/major_gc.h
@@ -64,9 +64,9 @@ extern uintnat total_heap_size;
 extern char *caml_gc_sweep_hp;
 
 extern int caml_major_window;
-double caml_major_ring[Max_major_window];
-int caml_major_ring_index;
-double caml_major_work_credit;
+extern double caml_major_ring[Max_major_window];
+extern int caml_major_ring_index;
+extern double caml_major_work_credit;
 extern double caml_gc_clock;
 
 /* [caml_major_gc_hook] is called just between the end of the mark

--- a/byterun/fix_code.c
+++ b/byterun/fix_code.c
@@ -38,6 +38,7 @@
 code_t caml_start_code;
 asize_t caml_code_size;
 unsigned char * caml_saved_code;
+struct ext_table caml_code_fragments_table;
 
 /* Read the main bytecode block from a file */
 


### PR DESCRIPTION
The variables in question are caml_major_ring, caml_major_ring_index, and caml_major_work_credit.

It is correct C code to declare those variables in the .h without a storage class, in which case they are treated as "common" variables by the linker.

However, this causes problems with Clang's address sanitizer: it increases the size of the common variable when it is used, but leaves it unchanged when it is not.  As a consequence, the linker sees several occurrences of a "common" variable with different sizes.  The linker does the right thing and takes the "max" of the sizes, but not without printing an annoying warning, which is then reported as suspicious behavior by ocamltest.

This commit puts "extern" storage class on the incriminated variables in <caml/major_gc.h>, consistently with the other GC variables.