### PR TITLE
debugger: avoid out of bounds access

### DIFF
--- a/Changes
+++ b/Changes
@@ -359,6 +359,9 @@ OCaml 4.07
   superscripts.
   (Gabriel Scherer)
 
+- GPR#1771: ocamdebug, avoid out of bound access
+  (Thomas Refis)
+
 ### Manual and documentation:
 
 - PR#1757: style the html manual, changing type and layout

--- a/debugger/symbols.ml
+++ b/debugger/symbols.ml
@@ -167,7 +167,10 @@ let find_event ev char =
       else bsearch (pivot + 1) hi
     end
   in
-  bsearch 0 (Array.length ev - 1)
+  if Array.length ev = 0 then
+    raise Not_found
+  else
+    bsearch 0 (Array.length ev - 1)
 
 (* Return first event after the given position. *)
 (* Raise [Not_found] if module is unknown or no event is found. *)


### PR DESCRIPTION
Test case:
```
$ cat test_debugger.ml
let x = 3

let () =
  Printf.printf "%d\n" x
$ ocamlc -o test_debugger.exe -g ./test_debugger.ml
$ ocamldebug ./test_debugger.exe
	OCaml Debugger version 4.08.0+dev0-2018-04-09

(ocd) break @Test_debugger 4
Loading program... done.
Can't find any event there.
```

Without this GPR, instead of printing that last line, we'd get "Uncaught exception: Invalid argument ..." and the debugger would exit.