### PR TITLE
Ctype.generalize_expansive does not raise unification exception

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -832,10 +832,7 @@ let rec generalize_expansive env var_level visited ty =
 
 let generalize_expansive env ty =
   simple_abbrevs := Mnil;
-  try
-    generalize_expansive env !nongen_level (Hashtbl.create 7) ty
-  with Unify ([_, ty'] as tr) ->
-    raise (Unify ((ty, ty') :: tr))
+  generalize_expansive env !nongen_level (Hashtbl.create 7) ty
 
 let generalize_global ty = generalize_structure !global_level ty
 let generalize_structure ty = generalize_structure !current_level ty


### PR DESCRIPTION
This PR removes an unnecessary `try ... with` guard in `ctype.ml`:

```OCaml
 let generalize_expansive env ty =
   simple_abbrevs := Mnil;
  try
    generalize_expansive env !nongen_level (Hashtbl.create 7) ty
  with Unify ([_, ty'] as tr) ->
    raise (Unify ((ty, ty') :: tr))
```

More precisely, `generalize_expansive` calls in order
(ignoring stdlb functions and recursive calls):
- Btype.repr
- Env.find_type
- Types.Variance.(may_inv, mem)
- generalize_structure
- Btype.iter_type_expr

whereas `generalize_structure` calls (in order)
- Btype.(repr,is_Tvar,set_level)
- is_object_type
- Btype.iter_type_expr

None of these functions raise an `Unify` exception, thus the `try ... with ...` guard is not necessary.

This was most probably a left-over from the time when `generalize_expansive` called `update_level` (directly before 6c78f42d36 or through `generalize_contravariant`), which is no longer the case since the fix of [Mantis:7285](https://caml.inria.fr/mantis/view.php?id=7285).