### PR TITLE
ARM VFD loads and stores: offset must be multiple of 4

### DIFF
--- a/Changes
+++ b/Changes
@@ -583,6 +583,10 @@ OCaml 4.07
   if available 
   (Xavier Leroy, review by Max Mouratov)
 
+- GPR#1774: ocamlopt for ARM could generate VFP loads and stores with bad
+  offsets, rejected by the assembler.
+  (Xavier Leroy, review by Mark Shinwell)
+
 
 OCaml 4.06.1 (16 Feb 2018):
 ---------------------------

--- a/asmcomp/arm/selection.ml
+++ b/asmcomp/arm/selection.ml
@@ -23,10 +23,10 @@ open Mach
 
 let is_offset chunk n =
   match chunk with
-  (* VFPv{2,3} load/store have -1020 to 1020 *)
-    Single | Double | Double_u
+  (* VFPv{2,3} load/store have -1020 to 1020.  Offset must be multiple of 4 *)
+  | Single | Double | Double_u
     when !fpu >= VFPv2 ->
-      n >= -1020 && n <= 1020
+      n >= -1020 && n <= 1020 && n mod 4 = 0
   (* ARM load/store byte/word have -4095 to 4095 *)
   | Byte_unsigned | Byte_signed
   | Thirtytwo_unsigned | Thirtytwo_signed


### PR DESCRIPTION
In flds, fldd, fsts, fstd instructions, using indexed addressing mode, the offset from the index register must be a multiple of 4.  Otherwise, invalid asm is produced and rejected by the assembler.  

This was observed recently on the bigarray tests, following the merge of GPR#1755, which is correct but changes the shape of the generated code in such a way that it triggers this old bug.

Re-testing on ARM32 is in progress.
