### PR TITLE
Add configure option to not install ".byte" executables

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,6 +42,10 @@ Working version
 
 ### Compiler distribution build system:
 
+- GPR#1776: add -no-install-bytecode-programs and related configure options to
+  control (non-)installation of ".byte" executables
+  (Mark Shinwell, review by Sébastien Hinderer and Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - GPR#1745: do not generalize the type of every sub-pattern, only of variables

--- a/Makefile
+++ b/Makefile
@@ -606,9 +606,13 @@ install:
 	  "$(INSTALL_LIBDIR)"
 	$(MAKE) -C byterun install
 	$(INSTALL_PROG) ocaml "$(INSTALL_BINDIR)/ocaml$(EXE)"
+ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	$(INSTALL_PROG) ocamlc "$(INSTALL_BINDIR)/ocamlc.byte$(EXE)"
+endif
 	$(MAKE) -C stdlib install
+ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	$(INSTALL_PROG) lex/ocamllex "$(INSTALL_BINDIR)/ocamllex.byte$(EXE)"
+endif
 	$(INSTALL_PROG) yacc/ocamlyacc$(EXE) "$(INSTALL_BINDIR)/ocamlyacc$(EXE)"
 	$(INSTALL_DATA) \
 	   utils/*.cmi utils/*.cmt utils/*.cmti utils/*.mli \
@@ -662,7 +666,9 @@ endif
 .PHONY: installopt
 installopt:
 	$(MAKE) -C asmrun install
+ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	$(INSTALL_PROG) ocamlopt "$(INSTALL_BINDIR)/ocamlopt.byte$(EXE)"
+endif
 	$(MAKE) -C stdlib installopt
 	$(INSTALL_DATA) \
 	    middle_end/*.cmi \

--- a/Makefile
+++ b/Makefile
@@ -656,11 +656,15 @@ ifeq "$(UNIX_OR_WIN32)" "win32"
 	fi
 endif
 	$(INSTALL_DATA) config/Makefile "$(INSTALL_LIBDIR)/Makefile.config"
+ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	if test -f ocamlopt; then $(MAKE) installopt; else \
 	   cd "$(INSTALL_BINDIR)"; \
 	   $(LN) ocamlc.byte$(EXE) ocamlc$(EXE); \
 	   $(LN) ocamllex.byte$(EXE) ocamllex$(EXE); \
 	fi
+else
+	if test -f ocamlopt; then $(MAKE) installopt; fi
+endif
 
 # Installation of the native-code compiler
 .PHONY: installopt
@@ -694,12 +698,16 @@ endif
 	for i in $(OTHERLIBRARIES); do \
 	  $(MAKE) -C otherlibs/$$i installopt || exit $$?; \
 	done
+ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	if test -f ocamlopt.opt ; then $(MAKE) installoptopt; else \
 	   cd "$(INSTALL_BINDIR)"; \
 	   $(LN) ocamlc.byte$(EXE) ocamlc$(EXE); \
 	   $(LN) ocamlopt.byte$(EXE) ocamlopt$(EXE); \
 	   $(LN) ocamllex.byte$(EXE) ocamllex$(EXE); \
 	fi
+else
+	if test -f ocamlopt.opt ; then $(MAKE) installoptopt; fi
+endif
 	$(MAKE) -C tools installopt
 	if test -f ocamlopt.opt -a -f flexdll/flexlink.opt ; then \
 	  $(INSTALL_PROG) \

--- a/config/Makefile-templ
+++ b/config/Makefile-templ
@@ -153,6 +153,9 @@ RANLIBCMD=ranlib
 # On Solaris:
 #ASPP=as -P
 
+### Set to "true" to install ".byte" executables (ocamlc.byte, etc.)
+#INSTALL_BYTECODE_PROGRAMS=true
+
 ### Extra flags to use for assembling .S files in profiling mode
 #ASPPPROFFLAGS=-DPROFILING
 

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -190,6 +190,9 @@ OCAMLOPT_CFLAGS=-O -mms-bitfields
 ### Build partially-linked object file
 PACKLD=$(TOOLPREF)ld -r -o # must have a space after '-o'
 
+### Set to "true" to install ".byte" executables (ocamlc.byte, etc.)
+INSTALL_BYTECODE_PROGRAMS=true
+
 ############# Configuration for the contributed libraries
 
 OTHERLIBRARIES=win32unix str win32graph dynlink bigarray systhreads

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -190,6 +190,9 @@ OCAMLOPT_CFLAGS=-O -mms-bitfields
 ### Build partially-linked object file
 PACKLD=$(TOOLPREF)ld -r -o # must have a space after '-o'
 
+### Set to "true" to install ".byte" executables (ocamlc.byte, etc.)
+INSTALL_BYTECODE_PROGRAMS=true
+
 ############# Configuration for the contributed libraries
 
 OTHERLIBRARIES=win32unix str win32graph dynlink bigarray systhreads

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -186,6 +186,9 @@ OCAMLOPT_CPPFLAGS=-D_CRT_SECURE_NO_DEPRECATE
 ### Build partially-linked object file
 PACKLD=link -lib -nologo -out:# there must be no space after this '-out:'
 
+### Set to "true" to install ".byte" executables (ocamlc.byte, etc.)
+INSTALL_BYTECODE_PROGRAMS=true
+
 ### Clear this to disable compiling ocamldebug
 WITH_DEBUGGER=ocamldebugger
 

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -189,6 +189,9 @@ OCAMLOPT_CPPFLAGS=-D_CRT_SECURE_NO_DEPRECATE
 ### Build partially-linked object file
 PACKLD=link -lib -nologo -machine:AMD64 -out:# must have no space after '-out:'
 
+### Set to "true" to install ".byte" executables (ocamlc.byte, etc.)
+INSTALL_BYTECODE_PROGRAMS=true
+
 ### Clear this to disable compiling ocamldebug
 WITH_DEBUGGER=ocamldebugger
 

--- a/configure
+++ b/configure
@@ -59,6 +59,7 @@ no_naked_pointers=false
 native_compiler=true
 TOOLPREF=""
 with_cfi=true
+install_bytecode_programs=true
 flambda=false
 force_safe_string=false
 default_safe_string=true
@@ -209,6 +210,10 @@ while : ; do
         with_cfi=false;;
     -no-native-compiler|--no-native-compiler)
         native_compiler=false;;
+    -install-bytecode-programs|--install-bytecode-programs)
+        install_bytecode_programs=true;;
+    -no-install-bytecode-programs|--no-install-bytecode-programs)
+        install_bytecode_programs=false;;
     -flambda|--flambda)
         flambda=true;;
     -with-flambda-invariants|--with-flambda-invariants)
@@ -2050,6 +2055,8 @@ if $flat_float_array; then
   echo "#define FLAT_FLOAT_ARRAY" >> m.h
 fi
 
+echo "INSTALL_BYTECODE_PROGRAMS=$install_bytecode_programs" >> Makefile
+
 # Finish generated files
 
 cclibs="$cclibs $mathlib"
@@ -2297,6 +2304,10 @@ fi
 
 if $with_instrumented_runtime; then
   inf "Instrumented runtime will be compiled and installed"
+fi
+
+if ! $install_bytecode_programs; then
+  inf "Bytecode programs will not be installed"
 fi
 
 inf "Additional libraries supported:"

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -235,10 +235,6 @@ ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	for i in $(install_files); \
 	do \
 	  $(INSTALL_PROG) "$$i" "$(INSTALL_BINDIR)/$$i.byte$(EXE)"; \
-	done
-endif
-	for i in $(install_files); \
-	do \
 	  if test -f "$$i".opt; then \
 	    $(INSTALL_PROG) "$$i.opt" "$(INSTALL_BINDIR)/$$i.opt$(EXE)" && \
 	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
@@ -246,6 +242,14 @@ endif
 	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.byte$(EXE)" "$$i$(EXE)"); \
 	  fi; \
 	done
+else
+	for i in $(install_files); \
+	do \
+	  if test -f "$$i".opt; then \
+	    $(INSTALL_PROG) "$$i.opt" "$(INSTALL_BINDIR)/$$i.opt$(EXE)"; \
+	  fi; \
+	done
+endif
 
 clean::
 	rm -f addlabels

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -231,9 +231,14 @@ LN := cp -pf
 endif
 
 install::
+ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	for i in $(install_files); \
 	do \
-	  $(INSTALL_PROG) "$$i" "$(INSTALL_BINDIR)/$$i.byte$(EXE)" && \
+	  $(INSTALL_PROG) "$$i" "$(INSTALL_BINDIR)/$$i.byte$(EXE)"; \
+	done
+endif
+	for i in $(install_files); \
+	do \
 	  if test -f "$$i".opt; then \
 	    $(INSTALL_PROG) "$$i.opt" "$(INSTALL_BINDIR)/$$i.opt$(EXE)" && \
 	    (cd "$(INSTALL_BINDIR)/" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \


### PR DESCRIPTION
In environments where the executables compiled to native code, such as ocamlopt.opt, are always used in preference to the bytecode versions then space can be saved by not installing the latter.  This patch provides a configure option to do such.  It is relatively lightly engineered; in particular, it won't complain if the native code executables aren't themselves being built; but given this is an option for knowledgeable users I think that is reasonable.