### PR TITLE
Add configure option to not install .cmt, .cmti, .ml and .mli files

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,6 +42,10 @@ Working version
 
 ### Compiler distribution build system:
 
+- GPR#1777: add -no-install-source-artifacts and related configure options to
+  control installation of .cmt, .cmti, .mli and .ml files
+  (Mark Shinwell, review by Nicolas Ojeda Bar and Sébastien Hinderer)
+
 ### Internal/compiler-libs changes:
 
 - GPR#1745: do not generalize the type of every sub-pattern, only of variables

--- a/Makefile
+++ b/Makefile
@@ -611,13 +611,23 @@ install:
 	$(INSTALL_PROG) lex/ocamllex "$(INSTALL_BINDIR)/ocamllex.byte$(EXE)"
 	$(INSTALL_PROG) yacc/ocamlyacc$(EXE) "$(INSTALL_BINDIR)/ocamlyacc$(EXE)"
 	$(INSTALL_DATA) \
-	   utils/*.cmi utils/*.cmt utils/*.cmti utils/*.mli \
-	   parsing/*.cmi parsing/*.cmt parsing/*.cmti parsing/*.mli \
-	   typing/*.cmi typing/*.cmt typing/*.cmti typing/*.mli \
-	   bytecomp/*.cmi bytecomp/*.cmt bytecomp/*.cmti bytecomp/*.mli \
-	   driver/*.cmi driver/*.cmt driver/*.cmti driver/*.mli \
-	   toplevel/*.cmi toplevel/*.cmt toplevel/*.cmti toplevel/*.mli \
+	   utils/*.cmi \
+	   parsing/*.cmi \
+	   typing/*.cmi \
+	   bytecomp/*.cmi \
+	   driver/*.cmi \
+	   toplevel/*.cmi \
 	   "$(INSTALL_COMPLIBDIR)"
+ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
+	$(INSTALL_DATA) \
+	   utils/*.cmt utils/*.cmti utils/*.mli \
+	   parsing/*.cmt parsing/*.cmti parsing/*.mli \
+	   typing/*.cmt typing/*.cmti typing/*.mli \
+	   bytecomp/*.cmt bytecomp/*.cmti bytecomp/*.mli \
+	   driver/*.cmt driver/*.cmti driver/*.mli \
+	   toplevel/*.cmt toplevel/*.cmti toplevel/*.mli \
+	   "$(INSTALL_COMPLIBDIR)"
+endif
 	$(INSTALL_DATA) \
 	   compilerlibs/ocamlcommon.cma compilerlibs/ocamlbytecomp.cma \
 	   compilerlibs/ocamltoplevel.cma $(BYTESTART) $(TOPLEVELSTART) \
@@ -625,9 +635,13 @@ install:
 	$(INSTALL_PROG) expunge "$(INSTALL_LIBDIR)/expunge$(EXE)"
 	$(INSTALL_DATA) \
 	   toplevel/topdirs.cmi \
+	   "$(INSTALL_LIBDIR)"
+ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
+	$(INSTALL_DATA) \
 	   toplevel/topdirs.cmt toplevel/topdirs.cmti \
            toplevel/topdirs.mli \
 	   "$(INSTALL_LIBDIR)"
+endif
 	$(MAKE) -C tools install
 ifeq "$(UNIX_OR_WIN32)" "unix" # Install manual pages only on Unix
 	$(MKDIR) "$(INSTALL_MANDIR)/man$(PROGRAMS_MAN_SECTION)"
@@ -666,19 +680,27 @@ installopt:
 	$(MAKE) -C stdlib installopt
 	$(INSTALL_DATA) \
 	    middle_end/*.cmi \
+	    "$(INSTALL_COMPLIBDIR)"
+	$(INSTALL_DATA) \
+	    middle_end/base_types/*.cmi \
+	    "$(INSTALL_COMPLIBDIR)"
+	$(INSTALL_DATA) \
+	    asmcomp/*.cmi \
+	    "$(INSTALL_COMPLIBDIR)"
+ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
+	$(INSTALL_DATA) \
 	    middle_end/*.cmt middle_end/*.cmti \
 	    middle_end/*.mli \
 	    "$(INSTALL_COMPLIBDIR)"
 	$(INSTALL_DATA) \
-	    middle_end/base_types/*.cmi \
 	    middle_end/base_types/*.cmt middle_end/base_types/*.cmti \
 	    middle_end/base_types/*.mli \
 	    "$(INSTALL_COMPLIBDIR)"
 	$(INSTALL_DATA) \
-	    asmcomp/*.cmi \
 	    asmcomp/*.cmt asmcomp/*.cmti \
 	    asmcomp/*.mli \
 	    "$(INSTALL_COMPLIBDIR)"
+endif
 	$(INSTALL_DATA) \
 	    compilerlibs/ocamloptcomp.cma $(OPTSTART) \
 	    "$(INSTALL_COMPLIBDIR)"
@@ -739,11 +761,13 @@ installoptopt:
 # Installation of the *.ml sources of compiler-libs
 .PHONY: install-compiler-sources
 install-compiler-sources:
+ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	$(INSTALL_DATA) \
 	   utils/*.ml parsing/*.ml typing/*.ml bytecomp/*.ml driver/*.ml \
 	   toplevel/*.ml middle_end/*.ml middle_end/base_types/*.ml \
 	   asmcomp/*.ml \
 	   "$(INSTALL_COMPLIBDIR)"
+endif
 
 # Run all tests
 

--- a/configure
+++ b/configure
@@ -59,6 +59,7 @@ no_naked_pointers=false
 native_compiler=true
 TOOLPREF=""
 with_cfi=true
+install_source_artifacts=true
 flambda=false
 force_safe_string=false
 default_safe_string=true
@@ -207,6 +208,10 @@ while : ; do
         ;;
     -no-cfi|--no-cfi)
         with_cfi=false;;
+    -install-source-artifacts|--install-source-artifacts)
+        install_source_artifacts=true;;
+    -no-install-source-artifacts|--no-install-source-artifacts)
+        install_source_artifacts=false;;
     -no-native-compiler|--no-native-compiler)
         native_compiler=false;;
     -flambda|--flambda)
@@ -2050,6 +2055,8 @@ if $flat_float_array; then
   echo "#define FLAT_FLOAT_ARRAY" >> m.h
 fi
 
+echo "INSTALL_SOURCE_ARTIFACTS=$install_source_artifacts" >> Makefile
+
 # Finish generated files
 
 cclibs="$cclibs $mathlib"
@@ -2297,6 +2304,10 @@ fi
 
 if $with_instrumented_runtime; then
   inf "Instrumented runtime will be compiled and installed"
+fi
+
+if ! $install_source_artifacts; then
+  inf ".cmt, .cmti, .ml and .mli files will not be installed"
 fi
 
 inf "Additional libraries supported:"

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -296,8 +296,13 @@ install:
 	  ocamldoc.hva *.cmi $(OCAMLDOC_LIBCMA) \
 	  "$(INSTALL_LIBDIR)"
 	$(INSTALL_DATA) \
-	  $(OCAMLDOC_LIBMLIS) $(OCAMLDOC_LIBCMIS) $(OCAMLDOC_LIBCMTS) \
+	  $(OCAMLDOC_LIBCMIS) \
 	  "$(INSTALL_LIBDIR)"
+ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
+	$(INSTALL_DATA) \
+	  $(OCAMLDOC_LIBMLIS) $(OCAMLDOC_LIBCMTS) \
+	  "$(INSTALL_LIBDIR)"
+endif
 	if test -d stdlib_man; then \
 	  $(INSTALL_DATA) stdlib_man/* "$(INSTALL_MANODIR)"; \
 	else : ; fi
@@ -316,8 +321,13 @@ installopt_really:
 	$(INSTALL_PROG) \
 	   $(OCAMLDOC_OPT) "$(INSTALL_BINDIR)/$(OCAMLDOC_OPT)$(EXE)"
 	$(INSTALL_DATA) \
-	  $(OCAMLDOC_LIBMLIS) $(OCAMLDOC_LIBCMIS) $(OCAMLDOC_LIBCMTS) \
+	  $(OCAMLDOC_LIBCMIS) \
 	  "$(INSTALL_LIBDIR)"
+ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
+	$(INSTALL_DATA) \
+	  $(OCAMLDOC_LIBMLIS) $(OCAMLDOC_LIBCMTS) \
+	  "$(INSTALL_LIBDIR)"
+endif
 	$(INSTALL_DATA) \
 	  ocamldoc.hva *.cmx $(OCAMLDOC_LIBA) $(OCAMLDOC_LIBCMXA) \
 	  "$(INSTALL_LIBDIR)"

--- a/otherlibs/Makefile
+++ b/otherlibs/Makefile
@@ -86,10 +86,16 @@ install::
 	fi
 	$(INSTALL_DATA) lib$(CLIBNAME).$(A) "$(INSTALL_LIBDIR)/"
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) lib$(CLIBNAME).$(A)
+
 	$(INSTALL_DATA) \
-	  $(LIBNAME).cma $(CMIFILES) $(CMIFILES:.cmi=.mli) \
+	  $(LIBNAME).cma $(CMIFILES) \
+	  "$(INSTALL_LIBDIR)/"
+ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
+	$(INSTALL_DATA) \
+	  $(CMIFILES:.cmi=.mli) \
           $(CMIFILES:.cmi=.cmti) \
 	  "$(INSTALL_LIBDIR)/"
+endif
 	if test -n "$(HEADERS)"; then \
 	  $(INSTALL_DATA) $(HEADERS) "$(INSTALL_LIBDIR)/caml/"; \
 	fi

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -92,8 +92,13 @@ extract_crc: dynlink.cma extract_crc.cmo
 
 install:
 	$(INSTALL_DATA) \
-	  dynlink.cmi dynlink.cmti dynlink.cma dynlink.mli \
+	  dynlink.cmi dynlink.cma \
 	  "$(INSTALL_LIBDIR)"
+ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
+	$(INSTALL_DATA) \
+	  dynlink.cmti dynlink.mli \
+	  "$(INSTALL_LIBDIR)"
+endif
 	$(INSTALL_PROG) \
 	  extract_crc "$(INSTALL_LIBDIR)/extract_crc$(EXE)"
 

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -124,9 +124,14 @@ install:
 	cd "$(INSTALL_LIBDIR)"; $(RANLIB) libthreads.$(A)
 	mkdir -p "$(INSTALL_THREADSLIBDIR)"
 	$(INSTALL_DATA) \
-	  $(CMIFILES) $(CMIFILES:.cmi=.cmti) threads.cma \
+	  $(CMIFILES) threads.cma \
+	  "$(INSTALL_THREADSLIBDIR)"
+ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
+	$(INSTALL_DATA) \
+	  $(CMIFILES:.cmi=.cmti) \
 	  "$(INSTALL_THREADSLIBDIR)"
 	$(INSTALL_DATA) $(MLIFILES) "$(INSTALL_LIBDIR)"
+endif
 	$(INSTALL_DATA) threads.h "$(INSTALL_LIBDIR)/caml"
 
 installopt:

--- a/otherlibs/threads/Makefile
+++ b/otherlibs/threads/Makefile
@@ -121,9 +121,14 @@ install:
 	$(INSTALL_DATA) libvmthreads.a "$(INSTALL_LIBDIR)/vmthreads"
 	cd "$(INSTALL_LIBDIR)/vmthreads"; $(RANLIB) libvmthreads.a
 	$(INSTALL_DATA) \
-	  $(CMIFILES) $(CMIFILES:.cmi=.mli) $(CMIFILES:.cmi=.cmti) \
+	  $(CMIFILES) \
 	  threads.cma stdlib.cma unix.cma \
 	  "$(INSTALL_LIBDIR)/vmthreads"
+ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
+	$(INSTALL_DATA) \
+	  $(CMIFILES:.cmi=.mli) $(CMIFILES:.cmi=.cmti) \
+	  "$(INSTALL_LIBDIR)/vmthreads"
+endif
 
 installopt:
 

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -95,8 +95,13 @@ install::
 	rm -f "$(INSTALL_LIBDIR)/pervasives.*" "$(INSTALL_LIBDIR)/bigarray.*"
 # End transitional
 	$(INSTALL_DATA) \
-	  stdlib.cma std_exit.cmo *.cmi *.cmt *.cmti *.mli *.ml camlheader_ur \
+	  stdlib.cma std_exit.cmo *.cmi camlheader_ur \
 	  "$(INSTALL_LIBDIR)"
+ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
+	$(INSTALL_DATA) \
+	  *.cmt *.cmti *.mli *.ml \
+	  "$(INSTALL_LIBDIR)"
+endif
 	$(INSTALL_DATA) target_camlheader "$(INSTALL_LIBDIR)/camlheader"
 
 ifeq "$(RUNTIMED)" "true"

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -140,8 +140,13 @@ opt:: profiling.cmx
 
 install::
 	$(INSTALL_DATA) \
-	  profiling.cmi profiling.cmo profiling.cmt profiling.cmti \
+	  profiling.cmi profiling.cmo \
 	  "$(INSTALL_LIBDIR)"
+ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
+	$(INSTALL_DATA) \
+	  profiling.cmt profiling.cmti \
+	  "$(INSTALL_LIBDIR)"
+endif
 
 installopt::
 	$(INSTALL_DATA) \


### PR DESCRIPTION
This patch adds a configure option to disable installation of `.cmt`, `.cmti`, `.ml` and `.mli` files.  The rationale is that in an environment where multiple different compiler variants are installed (for example, non-flambda, flambda, flambda+spacetime, etc.) it suffices to use the `.cmt` and related files from just one of these installations (typically the default one with no special features).  These files will not be exactly right---for example some constants in `Config` may differ---but for practical purposes this is a sufficiently close approximation.  A substantial disk space saving may be made as a result.