### PR TITLE
unix documentation: move HTML links to the module documentation up higher on the page

### DIFF
--- a/manual/manual/library/libunix.etex
+++ b/manual/manual/library/libunix.etex
@@ -8,6 +8,14 @@ OCaml programs. This chapter describes briefly the functions
 provided.  Refer to sections 2~and~3 of the Unix manual for more
 details on the behavior of these functions.
 
+\ifouthtml
+\begin{links}
+\item \ahref{libref/Unix.html}{Module \texttt{Unix}: Unix system calls}
+\item \ahref{libref/UnixLabels.html}{Module \texttt{UnixLabels}: Labeled
+   Unix system calls}
+\end{links}
+\fi
+
 Not all functions are provided by all Unix variants. If some functions
 are not available, they will raise "Invalid_arg" when called.
 
@@ -30,13 +38,7 @@ the Windows version of OCaml. The end of this chapter gives
 more information on the functions that are not supported under Windows.
 \end{windows}
 
-\ifouthtml
-\begin{links}
-\item \ahref{libref/Unix.html}{Module \texttt{Unix}: Unix system calls}
-\item \ahref{libref/UnixLabels.html}{Module \texttt{UnixLabels}: Labeled
-   Unix system calls}
-\end{links}
-\else
+\begin{latexonly}
 \input{Unix.tex}
 
 \section{Module \texttt{UnixLabels}: labelized version of the interface}
@@ -47,9 +49,10 @@ more information on the functions that are not supported under Windows.
 This module is identical to "Unix"~(\ref{Unix}), and only differs by
 the addition of labels. You may see these labels directly by looking
 at "unixLabels.mli", or by using the "ocamlbrowser" tool.
-\fi
 
 \newpage
+\end{latexonly}
+
 \begin{windows}
 The Cygwin port of OCaml fully implements all functions from
 the Unix module.  The native Win32 ports implement a subset of them.


### PR DESCRIPTION
Right now, the HTML links to the actual generated documentation are a bit low on the page and thus not that visible to the eye. I noticed this problem when I couldn't find the links while looking for them.

This commit moves them higher up, where they are more obvious.