### PR TITLE
Fix off-by-one error in Weak.create.

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,9 @@ Working version
 
 ### Standard library:
 
+- MPR#7795, GPR#1782: Fix off-by-one error in Weak.create
+  (KC Sivaramakrishnan)
+
 - GPR#1731: Format, use raise_notrace to preserve backtraces
   (Frédéric Bour, report by Jules Villard, review by Gabriel Scherer)
 

--- a/byterun/weak.c
+++ b/byterun/weak.c
@@ -55,7 +55,7 @@ static inline int Is_Dead_during_clean(value x){
   return Is_block (x) && Is_in_heap (x) && Is_white_val(x);
 }
 static inline int Must_be_Marked_during_mark(value x){
-  CAMLassert (x != caml_ephe_none); 
+  CAMLassert (x != caml_ephe_none);
   CAMLassert (caml_gc_phase == Phase_mark);
   return Is_block (x) && Is_in_heap (x);
 }
@@ -69,7 +69,7 @@ CAMLprim value caml_ephe_create (value len)
   value res;
 
   size = Long_val (len) + 1 /* weak_list */ + 1 /* the value */;
-  if (size <= 0 || size > Max_wosize) caml_invalid_argument ("Weak.create");
+  if (size < 2 || size > Max_wosize) caml_invalid_argument ("Weak.create");
   res = caml_alloc_shr (size, Abstract_tag);
   for (i = 1; i < size; i++) Field (res, i) = caml_ephe_none;
   Field (res, CAML_EPHE_LINK_OFFSET) = caml_ephe_list_head;


### PR DESCRIPTION
Weak.create accepts `-1` for the array length. It should raise `Invalid_argument` instead. 

```
$ ocaml
        OCaml version 4.08.0+dev0-2018-04-09

# let v = Weak.create (-1);;
val v : '_weak1 Weak.t = <abstr>
# Weak.length v;;
- : int = -1
```
This appears to be an off-by-one error in the bounds check in `caml_weak_create`. This PR fixes the bounds. The corresponding bug report is [MPR#7785](https://caml.inria.fr/mantis/view.php?id=7795). 
