### PR TITLE
MPR#7796: avoid running at_exit functions twice

### DIFF
--- a/Changes
+++ b/Changes
@@ -563,6 +563,10 @@ OCaml 4.07
   (Luc Maranget, Frédéric Bour, report by Stephen Dolan,
   review by Gabriel Scherer)
 
+- MPR#7796: Avoid executing at_exit functions twice in cleanup-at-exit mode
+  (when "c" is set in OCAMLRUNPARAM)
+  (Xavier Leroy)
+
 - GPR#1517: More robust handling of type variables in mcomp
   (Leo White and Thomas Refis, review by Jacques Garrigue)
 

--- a/otherlibs/threads/stdlib.ml
+++ b/otherlibs/threads/stdlib.ml
@@ -628,7 +628,11 @@ let at_exit f =
   let g = !exit_function in
   exit_function := (fun () -> f(); g())
 
-let do_at_exit () = (!exit_function) ()
+let do_at_exit () =
+  (* MPR#7796: make sure these at-exit functions will not be run again *)
+  let f = !exit_function in
+  exit_function := (fun () -> ());
+  f ()
 
 let exit retcode =
   do_at_exit ();

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -540,7 +540,10 @@ let at_exit f =
   let g = !exit_function in
   exit_function := (fun () -> f(); g())
 
-let do_at_exit () = (!exit_function) ()
+let do_at_exit () =
+  (!exit_function) ();
+  (* MPR#7796: make sure these at-exit functions will not be run again *)
+  exit_function := (fun () -> ())
 
 let exit retcode =
   do_at_exit ();

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -541,9 +541,10 @@ let at_exit f =
   exit_function := (fun () -> f(); g())
 
 let do_at_exit () =
-  (!exit_function) ();
   (* MPR#7796: make sure these at-exit functions will not be run again *)
-  exit_function := (fun () -> ())
+  let f = !exit_function in
+  exit_function := (fun () -> ());
+  f ()
 
 let exit retcode =
   do_at_exit ();


### PR DESCRIPTION
In particular when the runtime is in cleanup-at-exit mode.  Fixes [MPR#7796](https://caml.inria.fr/mantis/view.php?id=7796)

Other cases of multiple execution of at-exit functions remain, e.g. [MPR#7253](https://caml.inria.fr/mantis/view.php?id=7253).  See also #685.