### PR TITLE
manual: ellipsis extension nodes for examples

### DIFF
--- a/manual/README.md
+++ b/manual/README.md
@@ -171,26 +171,36 @@ let f None = None [@@expect warning 8];;
 \end{caml_example}
 ```
 
-It is also possible to elide a code fragment by annotating it with
-an `[@ellipsis]` attribute
+It is also possible to elide a code fragment by putting it inside
+an [%ellipsis] extension node.
 
 ```latex
 \begin{caml_example}{toplevel}
-let f: type a. a list -> int = List.length[@ellipsis] ;;
+let f: type a. a list -> int = [%ellipsis List.length];;
 \end{caml_example}
 ```
 For module components, it might be easier to hide them by using
-`[@@@ellipsis.start]` and `[@@@ellipsis.stop]`:
+`[%%ellipsis.start]` and `[%%ellipsis.stop]`:
 ```latex
 \begin{caml_example*}{verbatim}
 module M = struct
-  [@@@ellipsis.start]
+  [%%ellipsis.start]
   type t = T
   let x = 0
-  [@@@ellipsis.stop]
+  [%%ellipsis.stop]
  end
 \end{caml_example*}
 ```
+
+In some case, it may be possible to simply use `[%ellipsis]` without any
+payload, which is translated to
+- `assert false` for expressions
+- `_` for type expressions or patterns
+-`struct end` for module expression
+- nothing for structure and signature items
+- `object end` for classes and class types
+- `val ellipsis=()` for class fields
+- `val ellipsis:unit` for class type fields
 
 Another possibility to avoid displaying distracting code is to use
 the `caml_eval` environment. This environment is a companion environment

--- a/manual/manual/cmds/Makefile
+++ b/manual/manual/cmds/Makefile
@@ -13,7 +13,7 @@ TEXQUOTE=../../tools/texquote2
 FORMAT=../../tools/format-intf
 
 CAMLLATEX=$(SET_LD_PATH) $(OCAMLRUN) ../../tools/caml-tex2 \
--caml "TERM=norepeat $(OCAML)" -n 80 -v false
+-repo-root $(TOPDIR) -n 80 -v false
 
 WITH_TRANSF= top.tex intf-c.tex flambda.tex spacetime.tex \
   afl-fuzz.tex lexyacc.tex debugger.tex

--- a/manual/manual/refman/Makefile
+++ b/manual/manual/refman/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/Makefile.tools
 LD_PATH="$(TOPDIR)/otherlibs/str:$(TOPDIR)/otherlibs/unix"
 
 CAMLLATEX=$(SET_LD_PATH) $(OCAMLRUN) ../../tools/caml-tex2 \
-  -caml "TERM=norepeat $(OCAML)" -n 80 -v false
+  -repo-root $(TOPDIR) -n 80 -v false
 TRANSF=$(SET_LD_PATH) $(OCAMLRUN) ../../tools/transf
 TEXQUOTE=../../tools/texquote2
 

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -461,11 +461,11 @@ syntax has been chosen to fit nicely in the context of function
 declarations, where it is generally used. It is possible to freely mix
 regular function parameters with pseudo type parameters, as in:
 \begin{caml_example*}{verbatim}
-        let f = fun (type t) (foo : t list) -> assert false[@ellipsis]
+        let f = fun (type t) (foo : t list) -> [%ellipsis]
 \end{caml_example*}
 and even use the alternative syntax for declaring functions:
 \begin{caml_example*}{verbatim}
-        let f (type t) (foo : t list) = assert false[@ellipsis]
+        let f (type t) (foo : t list) = [%ellipsis assert false]
 \end{caml_example*}
 If several locally abstract types need to be introduced, it is possible to use
 the syntax
@@ -473,8 +473,8 @@ the syntax
 as syntactic sugar for @"fun" '(' "type" typeconstr-name_1 ')' "->" \ldots "->"
 "fun" '(' "type" typeconstr-name_n ')' "->" expr@. For instance,
 \begin{caml_example*}{verbatim}
-        let f = fun (type t u v) -> fun (foo : (t * u * v) list) -> assert false[@ellipsis]
-        let f' (type t u v) (foo : (t * u * v) list) = assert false[@ellipsis]
+        let f = fun (type t u v) -> fun (foo : (t * u * v) list) -> [%ellipsis]
+        let f' (type t u v) (foo : (t * u * v) list) = [%ellipsis]
 \end{caml_example}
 
 This construction is useful because the type constructors it introduces
@@ -519,13 +519,13 @@ polymorphic the type variable it introduces, but it can be combined
 with explicit polymorphic annotations where needed.
 The above rule is provided as syntactic sugar to make this easier:
 \begin{caml_example*}{verbatim}
-        let rec f : type t1 t2. t1 * t2 list -> t1 = assert false[@ellipsis]
+        let rec f : type t1 t2. t1 * t2 list -> t1 = [%ellipsis]
 \end{caml_example*}
 \noindent
 is automatically expanded into
 \begin{caml_example*}{verbatim}
         let rec f : 't1 't2. 't1 * 't2 list -> 't1 =
-          fun (type t1) (type t2) -> ( assert false[@ellipsis] : t1 * t2 list -> t1)
+          fun (type t1) (type t2) -> ( [%ellipsis] : t1 * t2 list -> t1)
 \end{caml_example*}
 This syntax can be very useful when defining recursive functions involving
 GADTs, see the section~\ref{s:gadts} for a more detailed explanation.
@@ -621,13 +621,13 @@ Each implementation is a structure that we can encapsulate as a
 first-class module, then store in a data structure such as a hash
 table:
 \begin{caml_example*}{verbatim}
-        module type DEVICE = sig [@@@ellipsis] end
+        module type DEVICE = sig [%%ellipsis] end
         let devices : (string, (module DEVICE)) Hashtbl.t = Hashtbl.create 17
 
-        module SVG = struct [@@@ellipsis] end
+        module SVG = struct [%%ellipsis] end
         let _ = Hashtbl.add devices "SVG" (module SVG : DEVICE)
 
-        module PDF = struct [@@@ellipsis] end
+        module PDF = struct [%%ellipsis] end
         let _ = Hashtbl.add devices "PDF" (module PDF: DEVICE)
 \end{caml_example*}
 We can then select one implementation based on command-line

--- a/manual/manual/tutorials/Makefile
+++ b/manual/manual/tutorials/Makefile
@@ -21,7 +21,7 @@ clean:
 .SUFFIXES: .etex .tex
 
 .etex.tex:
-	@$(CAMLLATEX) -caml "TERM=norepeat $(OCAML)" -n 80 -v false\
+	@$(CAMLLATEX) -repo-root $(TOPDIR) -n 80 -v false\
                        -o $*.caml_tex_error.tex $*.etex\
 	&& mv $*.caml_tex_error.tex $*.gen.tex\
 	&& $(TEXQUOTE) < $*.gen.tex > $*.texquote_error.tex\

--- a/manual/tools/Makefile
+++ b/manual/tools/Makefile
@@ -1,8 +1,18 @@
 TOPDIR=../..
 COMPFLAGS=-I $(OTOPDIR)/otherlibs/str -I $(OTOPDIR)/otherlibs/unix
+CAMLTEX2_FLAGS= -I $(OTOPDIR)/parsing -I $(OTOPDIR)/utils \
+          -I $(OTOPDIR)/driver -I $(OTOPDIR)/toplevel
+
+CAMLTEX2_LIBS = $(TOPDIR)/compilerlibs/ocamlcommon.cma \
+ $(TOPDIR)/compilerlibs/ocamlbytecomp.cma \
+ $(TOPDIR)/compilerlibs/ocamltoplevel.cma
+
+
 include $(TOPDIR)/Makefile.tools
 
 CFLAGS=-g -O
+
+
 
 all: texquote2 transf htmlquote htmlgen dvi2txt caml-tex2
 
@@ -25,7 +35,8 @@ latexscan.ml: latexscan.mll
 	ocamllex latexscan.mll
 
 caml-tex2: caml_tex2.ml
-	$(OCAMLC) $(TOPDIR)/compilerlibs/ocamlcommon.cma -I $(TOPDIR)/parsing \
+	$(OCAMLC) -linkall \
+	$(CAMLTEX2_FLAGS) $(CAMLTEX2_LIBS) \
 	-o caml-tex2 str.cma unix.cma caml_tex2.ml
 
 .SUFFIXES:

--- a/manual/tools/caml_tex2.ml
+++ b/manual/tools/caml_tex2.ml
@@ -872,11 +872,17 @@ let process_file file =
         (* Special characters may also appear in output strings -Didier *)
         let output = Text_transform.escape_specials raw_output in
         let phrase = global_replace ~!{|^\(.\)|} camlin phrase
-        and output = global_replace ~!{|^\(.\)|} camlout output in
+        and output = global_replace ~!{|^\(.\)|} camlout output
+        and msgs =
+          if String.length msgs > 0 then
+            global_replace ~!{|^\(.\)|} camlout output
+          else msgs
+        in
         start false tex_fmt phrase_env [];
         code_env ~newline:omit_answer input_env tex_fmt phrase;
-        if not omit_answer then
-          code_env ~newline:false (Output.env status) tex_fmt output;
+        if not omit_answer || String.length msgs > 0  then
+          code_env ~newline:false (Output.env status) tex_fmt
+            (if omit_answer then msgs else output);
         stop true tex_fmt phrase_env;
         flush oc;
         first := false;

--- a/manual/tools/caml_tex2.ml
+++ b/manual/tools/caml_tex2.ml
@@ -337,17 +337,20 @@ module Text_transform = struct
     | Underline
     | Ellipsis
 
+  type t = { kind:kind; start:int; stop:int}
   exception Intersection of
-      {line:int; file:string; left:kind; stop:int; start:int; right:kind}
+      {line:int;
+       file:string;
+       left: t;
+       right: t;
+      }
 
   let pp ppf = function
     | Underline -> Format.fprintf ppf "underline"
     | Ellipsis -> Format.fprintf ppf "ellipsis"
 
-  type t = { kind:kind; start:int; stop:int}
-
   let underline start stop = { kind = Underline; start; stop}
-  let ellipsis start stop = { kind = Ellipsis; start; stop}
+  let ellipsis start stop = { kind = Ellipsis; start; stop }
 
   let escape_specials s =
     let s1 = global_replace ~!"\\\\" "\\\\\\\\" s in
@@ -375,7 +378,7 @@ module Text_transform = struct
       transform in a list of transforms *)
   type partition = U of t * t list | E of t
   let check_partition line file l =
-    let init = Ellipsis, 0 in
+    let init = ellipsis 0 0 in
     let rec partition = function
       | [] -> []
       | {kind=Underline; _ } as t :: q -> underline t [] q
@@ -387,21 +390,27 @@ module Text_transform = struct
           if t.stop < u.stop then underline u (t::n) q
           else end_underline u n (t::q)
     and end_underline u n l = U(u,List.rev n) :: partition l in
-    let check_elt (left,stop) t =
-      if t.start < stop then
-        raise (Intersection{line;file;left;stop;start=t.start;right=t.kind})
+    let check_elt last t =
+      if t.start < last.stop then
+        raise (Intersection {line;file; left = last; right = t})
       else
-        (t.kind,t.stop) in
+        t in
     let check acc = function
       | E t -> check_elt acc t
       | U(u,n) ->
           let _ = check_elt acc u in
           let _ = List.fold_left ~f:check_elt ~init n in
-          u.kind, u.stop in
+          u in
     List.fold_left ~f:check ~init (partition l)
     |> ignore
 
   let apply ts file line s =
+    (* remove duplicated transforms that can appear due to
+        duplicated parse tree elements. For instance,
+        [let f : [%ellipsis] = ()] is transformed to
+        [let f: [%ellipsis] = (():[%ellipsis])] with the same location
+        for the two ellipses. *)
+    let ts = List.sort_uniq compare ts in
     let ts = List.sort (fun x y -> compare x.start y.start) ts in
     check_partition line file ts;
     let last, underline, ls =
@@ -911,24 +920,26 @@ let process_file file =
   | Missing_mode (file, line_number) ->
       fatal "when parsing a caml_example environment in %s:@;\
              missing mode argument at line %d,@ \
-             available modes {toplevel,verbatim}@]@."
+             available modes {toplevel,verbatim}"
           file (line_number-2)
   | Incompatible_options Signature_with_visible_answer (file, line_number) ->
       fatal
           "when parsing a caml_example environment in@ \
            %s, line %d:@,\
            the signature mode is only compatible with \"caml_example*\"@ \
-           Hint: did you forget to add \"*\"?@]@."
+           Hint: did you forget to add \"*\"?"
           file (line_number-2);
-  | Text_transform.Intersection {line;file;left;stop;start;right} ->
+  | Text_transform.Intersection {line;file;left;right} ->
       fatal
         "when evaluating a caml_example environment in %s, line %d:@ \
          Textual transforms must be well-separated.@ The \"%a\" transform \
-         ended at %d,@ after the start at %d of another \"%a\" transform.@ \
-         Hind: did you try to elide a code fragment which raised a warning?\
-         @]@."
+         spanned the interval %d-%d,@ \
+         intersecting with another \"%a\" transform @ \
+         on the %d-%d interval.@ \
+         Hind: did you try to elide a code fragment which raised a warning?"
         file (line-2)
-        Text_transform.pp left stop start Text_transform.pp right
+        Text_transform.pp left.kind left.start left.stop
+        Text_transform.pp right.kind right.start right.stop
   | Ellipsis.Unmatched_ellipsis {kind;start;stop} ->
       fatal "when evaluating a caml_example environment,@ \
              the %s mark at position %d-%d was unmatched"

--- a/manual/tools/caml_tex2.ml
+++ b/manual/tools/caml_tex2.ml
@@ -1,7 +1,6 @@
 (* $Id$ *)
 
 open StdLabels
-open Printf
 open Str
 
 let camlbegin = "\\caml"
@@ -12,16 +11,16 @@ let camlbunderline = "\\<"
 let camleunderline = "\\>"
 
 let start newline out s args =
-  Printf.fprintf out "%s%s" camlbegin s;
-  List.iter (Printf.fprintf out "{%s}") args;
-  if newline then Printf.fprintf out "\n"
+  Format.fprintf out "%s%s" camlbegin s;
+  List.iter (Format.fprintf out "{%s}") args;
+  if newline then Format.fprintf out "\n"
 
 let stop newline out s =
-  Printf.fprintf out "%s%s" camlend s;
-  if newline then Printf.fprintf out "\n"
+  Format.fprintf out "%s%s" camlend s;
+  if newline then Format.fprintf out "\n"
 
 let code_env ?(newline=true) env out s =
-  Printf.fprintf out "%a%s\n%a"
+  Format.fprintf out "%a%s\n%a"
     (fun ppf env -> start false ppf env []) env s (stop newline) env
 
 let main = "example"
@@ -44,16 +43,7 @@ let linelen = ref 72
 let outfile = ref ""
 let cut_at_blanks = ref false
 let files = ref []
-
-let _ =
-  Arg.parse ["-n", Arg.Int (fun n -> linelen := n), "line length";
-             "-o", Arg.String (fun s -> outfile := s), "output";
-             "-caml", Arg.String (fun s -> camllight := s), "toplevel";
-             "-w", Arg.Set cut_at_blanks, "cut at blanks";
-             "-v", Arg.Bool (fun b -> verbose := b ), "output result on stderr"
-            ]
-    (fun s -> files := s :: !files)
-    "caml-tex2: "
+let repo_root = ref ""
 
 let (~!) =
   let memo = ref [] in
@@ -63,6 +53,143 @@ let (~!) =
       let data = Str.regexp key in
       memo := (key, data) :: !memo;
       data
+
+module Toplevel = struct
+  (** Initialize the toplevel loop, redirect stdout and stderr,
+      capture warnings and error messages *)
+
+  type output =
+    { error:string; (** error message text *)
+      warnings:string list; (** warning messages text *)
+      values:string; (** toplevel output *)
+      stdout:string; (** output printed on the toplevel stdout *)
+      underlined: (int * int) list
+      (** locations to underline in input phrases *)
+    }
+
+  let buffer_fmt () =
+    let b = Buffer.create 30 in b, Format.formatter_of_buffer b
+
+  let error_fmt = buffer_fmt ()
+  let warning_fmt = buffer_fmt ()
+
+  let out_fmt = buffer_fmt ()
+
+  let flush_fmt (b,fmt) =
+    Format.pp_print_flush fmt ();
+    let r = Buffer.contents b in
+    Buffer.reset b;
+    r
+
+  (** Redirect the stdout *)
+  let stdout_out, stdout_in = Unix.pipe ~cloexec:true ()
+  let () = Unix.dup2 stdout_in Unix.stdout;
+    Unix.set_nonblock stdout_out
+
+  let self_error_fmt = Format.formatter_of_out_channel stderr
+  let eprintf = Format.eprintf
+
+  let read_stdout =
+    let size = 50 in
+    let b = Bytes.create size in
+    let buffer = Buffer.create 100 in
+    let max_retry = 5 in
+    let rec loop retry =
+      try
+        let n = Unix.read stdout_out b 0 size in
+        if n = size then
+          (Buffer.add_bytes buffer b; loop max_retry)
+        else
+          Buffer.add_bytes buffer (Bytes.sub b 0 n)
+      with Unix.(Unix_error (EAGAIN,_,_) ) ->
+        if retry = 0 then () else loop (retry - 1)
+    in
+    fun () ->
+      let () = flush stdout; loop max_retry in
+      let r = Buffer.contents buffer in
+      Buffer.reset buffer;
+      r
+
+  (** Store character intervals directly *)
+  let locs = ref []
+  let print_loc _ppf (loc : Location.t) =
+    let startchar = loc.loc_start.pos_cnum in
+    let endchar = loc.loc_end.pos_cnum in
+    if startchar >= 0 then
+      locs := (startchar, endchar) :: !locs
+
+  (** Capture warnings and keep them in a list *)
+  let warnings = ref []
+  let print_warning loc _ppf w =
+    Location.default_warning_printer loc (snd warning_fmt) w;
+    let w = flush_fmt warning_fmt in
+    warnings := w :: !warnings
+
+  let fatal ic oc fmt =
+    Format.kfprintf
+      (fun ppf -> Format.fprintf ppf "@]@."; close_in ic; close_out oc; exit 1)
+      self_error_fmt ("@[<hov 2>  Error " ^^ fmt)
+
+  let init () =
+    Location.printer := print_loc;
+    Location.warning_printer := print_warning;
+    Clflags.color := Some Misc.Color.Never;
+    Clflags.no_std_include := true;
+    Compenv.last_include_dirs := [Filename.concat !repo_root "stdlib"];
+    Location.error_reporter :=
+      (fun _ e -> Location.default_error_reporter (snd error_fmt) e);
+    Compmisc.init_path false;
+    try
+      Toploop.initialize_toplevel_env ();
+      Sys.interactive := false
+    with _ ->
+      (eprintf "Invalid repo root: %s?%!" !repo_root; exit 2)
+
+  let exec (_,ppf) p =
+    try
+      ignore @@ Toploop.execute_phrase true ppf p
+    with exn ->
+      let bt = Printexc.get_raw_backtrace () in
+      begin try Location.report_exception (snd error_fmt) exn
+      with _ ->
+        eprintf "Uncaught exception: %s\n%s\n"
+          (Printexc.to_string exn)
+          (Printexc.raw_backtrace_to_string bt)
+      end
+
+  let read_output ()  =
+    let ws = !warnings in
+    warnings := [];
+    let es = flush_fmt error_fmt in
+    let s = flush_fmt out_fmt in
+    let s = replace_first ~!{|^#\( *\*\)* *|} "" s in
+    (* the inner ( *\* )* group is here to clean the starting "*"
+       introduced for multiline comments *)
+    let underlined = !locs in
+    locs := [];
+    let msgs = read_stdout () in
+    { values = s; warnings=ws; error=es; stdout= msgs; underlined }
+
+  (** exec and ignore all output from the toplevel *)
+  let eval b =
+    let s = Buffer.contents b in
+    let ast = Parse.toplevel_phrase (Lexing.from_string s) in
+    exec out_fmt ast;
+    ignore (read_output())
+
+end
+
+let () =
+  Arg.parse ["-n", Arg.Int (fun n -> linelen := n), "line length";
+             "-o", Arg.String (fun s -> outfile := s), "output";
+             "-repo-root", Arg.String ((:=) repo_root ), "repo root";
+             "-w", Arg.Set cut_at_blanks, "cut at blanks";
+             "-v", Arg.Bool (fun b -> verbose := b ), "output result on stderr"
+            ]
+    (fun s -> files := s :: !files)
+    "caml-tex2: ";
+  Toplevel.init ()
+
 
 (** The Output module deals with the analysis and classification
     of the interpreter output and the parsing of status-related options
@@ -84,15 +211,15 @@ module Output = struct
 
   (** Pretty printer for status *)
   let pp_status ppf = function
-    | Error -> Printf.fprintf ppf "error"
-    | Ok -> Printf.fprintf ppf "ok"
-    | Warning n -> Printf.fprintf ppf "warning %d" n
+    | Error -> Format.fprintf ppf "error"
+    | Ok -> Format.fprintf ppf "ok"
+    | Warning n -> Format.fprintf ppf "warning %d" n
 
   (** Pretty printer for status preceded with an undefined determinant *)
   let pp_a_status ppf = function
-    | Error -> Printf.fprintf ppf "an error"
-    | Ok -> Printf.fprintf ppf "an ok"
-    | Warning n -> Printf.fprintf ppf "a warning %d" n
+    | Error -> Format.fprintf ppf "an error"
+    | Ok -> Format.fprintf ppf "an ok"
+    | Warning n -> Format.fprintf ppf "a warning %d" n
 
   (** {1 Related latex environment } *)
   let env = function
@@ -108,12 +235,12 @@ module Output = struct
   exception Unexpected_status of unexpected_report
 
   let print_source ppf {file; lines = (start, stop); phrase; output} =
-    Printf.fprintf ppf "%s, lines %d to %d:\n\"\n%s\n\"\n\"\n%s\n\"."
+    Format.fprintf ppf "%s, lines %d to %d:\n\"\n%s\n\"\n\"\n%s\n\"."
       file start stop phrase output
 
   let print_unexpected {source; expected; got} =
     if expected = Ok then
-      Printf.eprintf
+      Toplevel.eprintf
         "Error when evaluating a caml_example environment in %a\n\
          Unexpected %a status.\n\
          If %a status was expected, add an [@@expect %a] annotation.\n"
@@ -122,7 +249,7 @@ module Output = struct
         pp_a_status got
         pp_status got
     else
-      Printf.eprintf
+      Toplevel.eprintf
         "Error when evaluating a guarded caml_example environment in %a\n\
          Unexpected %a status, %a status was expected.\n\
          If %a status was in fact expected, change the status annotation to \
@@ -137,27 +264,30 @@ module Output = struct
   let print_parsing_error k s =
     match k with
     | Option ->
-        Printf.eprintf
+        Toplevel.eprintf
           "Unknown caml_example option: [%s].\n\
            Supported options are \"ok\",\"error\", or \"warning=n\" (with n \
            a warning number).\n" s
     | Annotation ->
-        Printf.eprintf
+        Toplevel.eprintf
           "Unknown caml_example phrase annotation: [@@expect %s].\n\
            Supported annotations are [@@expect ok], [@@expect error],\n\
            and [@@expect warning n] (with n a warning number).\n" s
 
   (** {1 Output analysis} *)
-  let catch_error s =
-    if string_match ~!{|Error:|} s 0 then Some Error else None
+  let catch_error = function
+    | "" -> None
+    | _ -> Some Error
 
-  let catch_warning s =
-    if string_match ~!{|Warning \([0-9]+\):|} s 0 then
-      Some (Warning (int_of_string @@ matched_group 1 s))
-    else
-      None
+  let catch_warning =
+    function
+    | [] -> None
+    | s :: _ when string_match ~!{|Warning \([0-9]+\):|} s 0 ->
+        Some (Warning (int_of_string @@ matched_group 1 s))
+    | _ -> None
 
-  let status s = match catch_warning s, catch_error s with
+  let status ws es =
+    match catch_warning ws, catch_error es with
     | Some w, _ -> w
     | None, Some e -> e
     | None, None -> Ok
@@ -215,6 +345,9 @@ module Text_transform = struct
     | Ellipsis -> Format.fprintf ppf "ellipsis"
 
   type t = { kind:kind; start:int; stop:int}
+
+  let underline start stop = { kind = Underline; start; stop}
+
   let escape_specials s =
     let s1 = global_replace ~!"\\\\" "\\\\\\\\" s in
     let s2 = global_replace ~!"'" "\\\\textquotesingle\\\\-" s1 in
@@ -285,38 +418,6 @@ module Text_transform = struct
 end
 
 
-let caml_input, caml_output =
-  let cmd = !camllight ^ " 2>&1" in
-  try Unix.open_process cmd with _ -> failwith "Cannot start toplevel"
-let () =
-  at_exit (fun () -> ignore (Unix.close_process (caml_input, caml_output)));
-  ignore (input_line caml_input);
-  ignore (input_line caml_input)
-
-let read_output () =
-  let input = ref (input_line caml_input) in
-  input := replace_first ~!{|^#\( *\*\)* *|} "" !input;
-  (* the inner ( *\* )* group is here to clean the starting "*"
-     introduced for multiline comments *)
-  let underline =
-    if string_match ~!"Characters *\\([0-9]+\\)-\\([0-9]+\\):$" !input 0
-    then
-      let start = int_of_string (matched_group 1 !input)
-      and stop = int_of_string (matched_group 2 !input) in
-      input := input_line caml_input;
-      Text_transform.[{kind=Underline; start; stop}]
-    else []
-  in
-  let output = Buffer.create 256 in
-  let first_line = ref true in
-  while not (string_match ~!".*\"end_of_input\"$" !input 0) do
-    if !verbose then prerr_endline !input;
-    if not !first_line then Buffer.add_char output '\n' else first_line:=false;
-    Buffer.add_string output !input;
-    input := input_line caml_input;
-  done;
-  Buffer.contents output, underline
-
 exception Missing_double_semicolon of string * int
 
 exception Missing_mode of string * int
@@ -385,7 +486,7 @@ module Ellipsis = struct
     );
     !transforms
 
-  let find fname mode s =
+  let parse_and_find fname mode s =
     let lex = Lexing.from_string s in
     Location.init lex fname;
     Location.input_name := fname;
@@ -394,13 +495,19 @@ module Ellipsis = struct
       match mode with
       | Toplevel -> begin
           match Parse.toplevel_phrase lex with
-          | Ptop_dir _ -> []
-          | Ptop_def str -> extract (fun it -> it.structure it) str
+          | Ptop_dir _ -> Parsetree.Ptop_def [], []
+          | Ptop_def str as ast -> ast, extract (fun it -> it.structure it) str
         end
       | Verbatim ->
-          extract (fun it -> it.structure it) (Parse.implementation lex)
+          let str = Parse.implementation lex in
+          Ptop_def str, extract (fun it -> it.structure it) str
       | Signature ->
-          extract (fun it -> it.signature it) (Parse.interface lex)
+          let sign = Parse.interface lex in
+          let name = Location.mknoloc "wrap" in
+          let str =
+            Ast_helper.[Str.modtype @@ Mtd.mk ~typ:(Mty.signature sign) name] in
+          Ptop_def str,
+          extract (fun it -> it.signature it) sign
     with Syntaxerr.Error _ -> raise (Phrase_parsing s)
 
 end
@@ -421,10 +528,8 @@ let process_file file =
       open_out_gen [Open_wronly; Open_creat; Open_append; Open_text]
         0x666 !outfile
     with _ -> failwith "Cannot open output file" in
-  let fatal fmt =
-    Format.kfprintf
-      (fun ppf -> Format.fprintf ppf "@]@."; close_in ic; close_out oc; exit 1)
-      Format.err_formatter ("@[<hov 2>  Error " ^^ fmt) in
+  let tex_fmt = Format.formatter_of_out_channel oc in
+  let fatal x = Toplevel.fatal ic oc x in
   let re_spaces = "[ \t]*" in
   let re_start = ~!(
       {|\\begin{caml_example\(\*?\)}|} ^ re_spaces
@@ -454,7 +559,7 @@ let process_file file =
         | Toplevel -> true in
       let global_expected = try Output.expected @@ matched_group 4 !input
         with Not_found -> Output.Ok in
-      start true oc main [string_of_mode mode];
+      start true tex_fmt main [string_of_mode mode];
       let first = ref true in
       let read_phrase () =
         let phrase = Buffer.create 256 in
@@ -499,60 +604,62 @@ let process_file file =
       in
       try while true do
         let implicit_stop, phrase, expected = read_phrase () in
-        let ellipses = Ellipsis.find file mode phrase in
-        if mode = Signature then fprintf caml_output "module type Wrap = sig\n";
-        fprintf caml_output "%s%s%s" phrase
-        (if mode = Signature then "\nend" else "")
-        (if implicit_stop then ";;\n" else "\n");
-        flush caml_output;
-        output_string caml_output "\"end_of_input\";;\n";
-        flush caml_output;
-        let output, underline = read_output () in
-        let status = Output.status output in
+        let ast, ellipses = Ellipsis.parse_and_find file mode phrase in
+        let out = Toplevel.read_output () in
+        let msgs = String.concat "" (out.warnings @ [out.error]) in
+        let raw_output = msgs ^ out.stdout ^ out.values in
+        let status = Output.status out.warnings out.error in
         if status <> expected then (
           let source = Output.{
               file;
               lines = (!phrase_start, !phrase_stop);
               phrase;
-              output
+              output = raw_output
             } in
           raise (Output.Unexpected_status
                    {Output.got=status; expected; source} ) )
         else ( incr phrase_stop; phrase_start := !phrase_stop );
         let phrase =
+          let underline =
+            List.map (fun (x,y) -> Text_transform.underline x y)
+              out.underlined in
           Text_transform.apply (underline @ ellipses)
             file !phrase_stop phrase in
         (* Special characters may also appear in output strings -Didier *)
-        let output = Text_transform.escape_specials output in
+        let output = Text_transform.escape_specials raw_output in
         let phrase = global_replace ~!{|^\(.\)|} camlin phrase
         and output = global_replace ~!{|^\(.\)|} camlout output in
-        start false oc phrase_env [];
-        code_env ~newline:omit_answer input_env oc phrase;
+        start false tex_fmt phrase_env [];
+        code_env ~newline:omit_answer input_env tex_fmt phrase;
         if not omit_answer then
-          code_env ~newline:false (Output.env status) oc output;
-        stop true oc phrase_env;
+          code_env ~newline:false (Output.env status) tex_fmt output;
+        stop true tex_fmt phrase_env;
         flush oc;
         first := false;
         if implicit_stop then raise End_of_file
       done
-      with End_of_file -> phrase_start:= !phrase_stop; stop true oc main
+      with End_of_file -> phrase_start:= !phrase_stop; stop true tex_fmt main
     end
     else if string_match ~!"\\\\begin{caml_eval}[ \t]*$" !input 0
     then begin
+      let eval_buffer = Buffer.create 256 in
       while input := input_line ic;
         not (string_match ~!"\\\\end{caml_eval}[ \t]*$" !input 0)
       do
-        fprintf caml_output "%s\n" !input;
+        Buffer.add_string eval_buffer !input;
+        Buffer.add_char eval_buffer '\n';
         if string_match ~!".*;;[ \t]*$" !input 0 then begin
-          flush caml_output;
-          output_string caml_output "\"end_of_input\";;\n";
-          flush caml_output;
-          ignore (read_output ())
+          Buffer.add_string eval_buffer !input;
+          Buffer.add_char eval_buffer '\n';
+          Toplevel.eval eval_buffer;
+          Buffer.reset eval_buffer
         end
-      done
+      done;
+      if Buffer.length eval_buffer > 0 then
+        ( Buffer.add_string eval_buffer ";;\n"; Toplevel.eval eval_buffer )
     end else begin
-      fprintf oc "%s\n" !input;
-      flush oc
+      Format.fprintf tex_fmt "%s\n" !input;
+      Format.pp_print_flush tex_fmt ()
     end
   done with
   | End_of_file -> close_in ic; close_out oc


### PR DESCRIPTION
As a follow-up to #1765, this PR replaces the `[@ellipsis]` attribute with `[%ellipsis]` extension nodes.

As a first step, the first commit in this PR replaces the separate toplevel process by the toplevel compiler-libraries. This was done mostly to have accurate location on the input phrase.
The other alternative would have been to launch the separate toplevel process with a custom ppx. However, taking direct control of the toplevel loop makes it possible to have finer separation of the different streams produced by the toplevel, so I judged the change worthwhile.
In particular, it becomes quite easy to underline the location of more than one error or warning messages, or to always print error and warning messages (see the fourth commit).

The second commit implements the ellipsis extension node themselves. All variants of extension nodes are supported. However, the syntax for some variants (the class related ones, the module expression and the module type extension nodes) is quite awkward, e.g.
```OCaml
module type s= [%ellipsis module type x = sig type t end];;
class c = [%ellipsis class x a b c = object end];; (* for class expressions *)
class c = object [%%ellipsis object method f = () end] end;; (* for class fields *)
class type c = [%ellipsis class type x = object end];; (* for simple class types *)

class type c = object [%%ellipsis class type x = object method f: int end] end;; 
(* for class type fields *)

module type w = sig
  class c: int -> [%ellipsis: class x: int -> object end] (* for class types *)
  module type X = [%ellipsis: module type x = sig end] (* alternative for module types *)
end;;
```
due to the mismatch between supported payloads and the corresponding parsetree nodes.
However, all extension nodes have a short variant `[%ellipsis]` which should
cover the most frequent use cases.

The third commit is a minor improvement of the error messages for intersecting text transforms that I wrote when debugging.

The last commit documents the new syntax, and in particular the replacement rule for the `[%ellipsis]` shorthand.
