### PR TITLE
Improve caml_fatal_error

### DIFF
--- a/asmrun/spacetime.c
+++ b/asmrun/spacetime.c
@@ -766,7 +766,7 @@ static NOINLINE void* find_trie_node_from_libunwind(int for_allocation,
       frames =
         (struct ext_table*) caml_stat_alloc_noexc(sizeof(struct ext_table));
       if (!frames) {
-        caml_fatal_error("Not enough memory for ext_table allocation");
+        caml_fatal_error("not enough memory for ext_table allocation");
       }
       caml_ext_table_init(frames, initial_table_size);
       *cached_frames = frames;

--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -66,7 +66,7 @@ static void init_static(void)
     if (caml_page_table_add(In_static_data,
                             caml_data_segments[i].begin,
                             caml_data_segments[i].end + sizeof(value)) != 0)
-      caml_fatal_error("Fatal error: not enough memory for initial page table");
+      caml_fatal_error("not enough memory for initial page table");
   }
 
   caml_code_area_start = caml_code_segments[0].begin;

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -107,15 +107,10 @@ CAMLnoreturn_end;
 #endif
 
 CAMLnoreturn_start
-CAMLextern void caml_fatal_error (char *msg)
-CAMLnoreturn_end;
-
-CAMLnoreturn_start
-CAMLextern void caml_fatal_error_arg (char *fmt, char *arg)
-CAMLnoreturn_end;
-
-CAMLnoreturn_start
-CAMLextern void caml_fatal_error_arg2 (char *fmt, char *arg1, char *arg2)
+CAMLextern void caml_fatal_error (char *, ...)
+#ifdef __GNUC__
+  __attribute__ ((format (printf, 1, 2)))
+#endif
 CAMLnoreturn_end;
 
 /* Detection of available C built-in functions, the Clang way. */

--- a/byterun/caml/misc.h
+++ b/byterun/caml/misc.h
@@ -115,8 +115,7 @@ CAMLextern void caml_fatal_error_arg (char *fmt, char *arg)
 CAMLnoreturn_end;
 
 CAMLnoreturn_start
-CAMLextern void caml_fatal_error_arg2 (char *fmt1, char *arg1,
-                                       char *fmt2, char *arg2)
+CAMLextern void caml_fatal_error_arg2 (char *fmt, char *arg1, char *arg2)
 CAMLnoreturn_end;
 
 /* Detection of available C built-in functions, the Clang way. */

--- a/byterun/debugger.c
+++ b/byterun/debugger.c
@@ -121,8 +121,13 @@ static void open_connection(void)
 #endif
   if (dbg_socket == -1 ||
       connect(dbg_socket, &sock_addr.s_gen, sock_addr_len) == -1){
-    caml_fatal_error_arg2 ("cannot connect to debugger at %s\n", (dbg_addr ? dbg_addr : "(none)"),
-                           "error: %s\n", strerror (errno));
+    caml_fatal_error_arg2
+    (
+      "cannot connect to debugger at %s\n"
+      "error: %s\n",
+      (dbg_addr ? dbg_addr : "(none)"),
+      strerror (errno)
+    );
   }
 #ifdef _WIN32
   dbg_socket = _open_osfhandle(dbg_socket, 0);

--- a/byterun/debugger.c
+++ b/byterun/debugger.c
@@ -124,7 +124,7 @@ static void open_connection(void)
     caml_fatal_error_arg2
     (
       "cannot connect to debugger at %s\n"
-      "error: %s\n",
+      "error: %s",
       (dbg_addr ? dbg_addr : "(none)"),
       strerror (errno)
     );
@@ -202,7 +202,10 @@ void caml_debugger_init(void)
     sock_addr.s_unix.sun_family = AF_UNIX;
     a_len = strlen(address);
     if (a_len >= sizeof(sock_addr.s_unix.sun_path)) {
-      caml_fatal_error("Debug socket path length exceeds maximum permitted length");
+      caml_fatal_error
+      (
+        "debug socket path length exceeds maximum permitted length"
+      );
     }
     strncpy(sock_addr.s_unix.sun_path, address,
             sizeof(sock_addr.s_unix.sun_path) - 1);
@@ -211,7 +214,7 @@ void caml_debugger_init(void)
       ((char *)&(sock_addr.s_unix.sun_path) - (char *)&(sock_addr.s_unix))
         + a_len;
 #else
-    caml_fatal_error("Unix sockets not supported");
+    caml_fatal_error("unix sockets not supported");
 #endif
   } else {
     /* Internet domain */
@@ -223,7 +226,7 @@ void caml_debugger_init(void)
     if (sock_addr.s_inet.sin_addr.s_addr == -1) {
       host = gethostbyname(address);
       if (host == NULL)
-        caml_fatal_error_arg("Unknown debugging host %s\n", address);
+        caml_fatal_error_arg("unknown debugging host %s", address);
       memmove(&sock_addr.s_inet.sin_addr, host->h_addr, host->h_length);
     }
     sock_addr.s_inet.sin_port = htons(atoi(port));
@@ -345,7 +348,7 @@ void caml_debugger(enum event_kind event)
         caml_flush(dbg_out);
       }
 #else
-      caml_fatal_error("error: REQ_CHECKPOINT command");
+      caml_fatal_error("REQ_CHECKPOINT command");
       exit(-1);
 #endif
       break;
@@ -359,7 +362,7 @@ void caml_debugger(enum event_kind event)
 #ifndef _WIN32
       wait(NULL);
 #else
-      caml_fatal_error("Fatal error: REQ_WAIT command");
+      caml_fatal_error("REQ_WAIT command");
       exit(-1);
 #endif
       break;

--- a/byterun/debugger.c
+++ b/byterun/debugger.c
@@ -121,7 +121,7 @@ static void open_connection(void)
 #endif
   if (dbg_socket == -1 ||
       connect(dbg_socket, &sock_addr.s_gen, sock_addr_len) == -1){
-    caml_fatal_error_arg2
+    caml_fatal_error
     (
       "cannot connect to debugger at %s\n"
       "error: %s",
@@ -226,7 +226,7 @@ void caml_debugger_init(void)
     if (sock_addr.s_inet.sin_addr.s_addr == -1) {
       host = gethostbyname(address);
       if (host == NULL)
-        caml_fatal_error_arg("unknown debugging host %s", address);
+        caml_fatal_error("unknown debugging host %s", address);
       memmove(&sock_addr.s_inet.sin_addr, host->h_addr, host->h_length);
     }
     sock_addr.s_inet.sin_port = htons(atoi(port));

--- a/byterun/dynlink.c
+++ b/byterun/dynlink.c
@@ -137,9 +137,13 @@ static void open_shared_lib(char_os * name)
   handle = caml_dlopen(realname, 1, 1);
   caml_leave_blocking_section();
   if (handle == NULL)
-    caml_fatal_error_arg2("Fatal error: cannot load shared library %s\n",
-                          caml_stat_strdup_of_os(name),
-                          "Reason: %s\n", caml_dlerror());
+    caml_fatal_error_arg2
+    (
+      "Fatal error: cannot load shared library %s\n"
+      "Reason: %s\n",
+      caml_stat_strdup_of_os(name),
+      caml_dlerror()
+    );
   caml_ext_table_add(&shared_libs, handle);
   caml_stat_free(realname);
 }

--- a/byterun/dynlink.c
+++ b/byterun/dynlink.c
@@ -96,12 +96,12 @@ static char_os * parse_ld_conf(void)
   }
   ldconf = open_os(ldconfname, O_RDONLY, 0);
   if (ldconf == -1)
-    caml_fatal_error_arg("cannot read loader config file %s",
+    caml_fatal_error("cannot read loader config file %s",
                          caml_stat_strdup_of_os(ldconfname));
   config = caml_stat_alloc(st.st_size + 1);
   nread = read(ldconf, config, st.st_size);
   if (nread == -1)
-    caml_fatal_error_arg
+    caml_fatal_error
       ("error while reading loader config file %s",
        caml_stat_strdup_of_os(ldconfname));
   config[nread] = 0;
@@ -137,7 +137,7 @@ static void open_shared_lib(char_os * name)
   handle = caml_dlopen(realname, 1, 1);
   caml_leave_blocking_section();
   if (handle == NULL)
-    caml_fatal_error_arg2
+    caml_fatal_error
     (
       "cannot load shared library %s\n"
       "Reason: %s",
@@ -183,7 +183,7 @@ void caml_build_primitive_table(char_os * lib_path,
   for (q = req_prims; *q != 0; q += strlen(q) + 1) {
     c_primitive prim = lookup_primitive(q);
     if (prim == NULL)
-          caml_fatal_error_arg("unknown C primitive `%s'", q);
+          caml_fatal_error("unknown C primitive `%s'", q);
     caml_ext_table_add(&caml_prim_table, (void *) prim);
 #ifdef DEBUG
     caml_ext_table_add(&caml_prim_name_table, caml_stat_strdup(q));

--- a/byterun/dynlink.c
+++ b/byterun/dynlink.c
@@ -96,13 +96,13 @@ static char_os * parse_ld_conf(void)
   }
   ldconf = open_os(ldconfname, O_RDONLY, 0);
   if (ldconf == -1)
-    caml_fatal_error_arg("Fatal error: cannot read loader config file %s\n",
+    caml_fatal_error_arg("cannot read loader config file %s",
                          caml_stat_strdup_of_os(ldconfname));
   config = caml_stat_alloc(st.st_size + 1);
   nread = read(ldconf, config, st.st_size);
   if (nread == -1)
     caml_fatal_error_arg
-      ("Fatal error: error while reading loader config file %s\n",
+      ("error while reading loader config file %s",
        caml_stat_strdup_of_os(ldconfname));
   config[nread] = 0;
   wconfig = caml_stat_strdup_to_os(config);
@@ -139,8 +139,8 @@ static void open_shared_lib(char_os * name)
   if (handle == NULL)
     caml_fatal_error_arg2
     (
-      "Fatal error: cannot load shared library %s\n"
-      "Reason: %s\n",
+      "cannot load shared library %s\n"
+      "Reason: %s",
       caml_stat_strdup_of_os(name),
       caml_dlerror()
     );
@@ -183,7 +183,7 @@ void caml_build_primitive_table(char_os * lib_path,
   for (q = req_prims; *q != 0; q += strlen(q) + 1) {
     c_primitive prim = lookup_primitive(q);
     if (prim == NULL)
-          caml_fatal_error_arg("Fatal error: unknown C primitive `%s'\n", q);
+          caml_fatal_error_arg("unknown C primitive `%s'", q);
     caml_ext_table_add(&caml_prim_table, (void *) prim);
 #ifdef DEBUG
     caml_ext_table_add(&caml_prim_name_table, caml_stat_strdup(q));

--- a/byterun/fix_code.c
+++ b/byterun/fix_code.c
@@ -145,7 +145,7 @@ void caml_thread_code (code_t code, asize_t len)
     opcode_t instr = *p;
     if (instr < 0 || instr >= FIRST_UNIMPLEMENTED_OP){
       /* FIXME -- should Assert(false) ?
-      caml_fatal_error_arg ("in fix_code: bad opcode (%lx)",
+      caml_fatal_error ("in fix_code: bad opcode (%lx)",
                             (char *)(long)instr);
       */
       instr = STOP;

--- a/byterun/fix_code.c
+++ b/byterun/fix_code.c
@@ -61,7 +61,7 @@ void caml_load_code(int fd, asize_t len)
   caml_code_size = len;
   caml_start_code = (code_t) caml_stat_alloc(caml_code_size);
   if (read(fd, (char *) caml_start_code, caml_code_size) != caml_code_size)
-    caml_fatal_error("Fatal error: truncated bytecode file.\n");
+    caml_fatal_error("truncated bytecode file");
   caml_init_code_fragments();
   /* Prepare the code for execution */
 #ifdef ARCH_BIG_ENDIAN
@@ -145,7 +145,7 @@ void caml_thread_code (code_t code, asize_t len)
     opcode_t instr = *p;
     if (instr < 0 || instr >= FIRST_UNIMPLEMENTED_OP){
       /* FIXME -- should Assert(false) ?
-      caml_fatal_error_arg ("Fatal error in fix_code: bad opcode (%lx)\n",
+      caml_fatal_error_arg ("in fix_code: bad opcode (%lx)",
                             (char *)(long)instr);
       */
       instr = STOP;

--- a/byterun/gc_ctrl.c
+++ b/byterun/gc_ctrl.c
@@ -591,10 +591,10 @@ void caml_init_gc (uintnat minor_size, uintnat major_size,
 
   CAML_INSTR_INIT ();
   if (caml_init_alloc_for_heap () != 0){
-    caml_fatal_error ("cannot initialize heap: mmap failed\n");
+    caml_fatal_error ("cannot initialize heap: mmap failed");
   }
   if (caml_page_table_initialize(Bsize_wsize(minor_size) + major_heap_size)){
-    caml_fatal_error ("OCaml runtime error: cannot initialize page table\n");
+    caml_fatal_error ("cannot initialize page table");
   }
   caml_set_minor_heap_size (Bsize_wsize (norm_minsize (minor_size)));
   caml_major_heap_increment = major_incr;

--- a/byterun/interp.c
+++ b/byterun/interp.c
@@ -1145,8 +1145,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
 #if _MSC_VER >= 1200
       __assume(0);
 #else
-      caml_fatal_error_arg("Fatal error: bad opcode (%"
-                           ARCH_INTNAT_PRINTF_FORMAT "x)\n",
+      caml_fatal_error_arg("bad opcode (%"
+                           ARCH_INTNAT_PRINTF_FORMAT "x)",
                            (char *) (intnat) *(pc-1));
 #endif
     }

--- a/byterun/interp.c
+++ b/byterun/interp.c
@@ -1145,9 +1145,9 @@ value caml_interprete(code_t prog, asize_t prog_size)
 #if _MSC_VER >= 1200
       __assume(0);
 #else
-      caml_fatal_error_arg("bad opcode (%"
+      caml_fatal_error("bad opcode (%"
                            ARCH_INTNAT_PRINTF_FORMAT "x)",
-                           (char *) (intnat) *(pc-1));
+                           (intnat) *(pc-1));
 #endif
     }
   }

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -873,7 +873,7 @@ void caml_init_major_heap (asize_t heap_size)
   caml_heap_start =
     (char *) caml_alloc_for_heap (Bsize_wsize (caml_stat_heap_wsz));
   if (caml_heap_start == NULL)
-    caml_fatal_error ("Fatal error: cannot allocate initial major heap.\n");
+    caml_fatal_error ("cannot allocate initial major heap");
   Chunk_next (caml_heap_start) = NULL;
   caml_stat_heap_wsz = Wsize_bsize (Chunk_size (caml_heap_start));
   caml_stat_heap_chunks = 1;
@@ -882,8 +882,7 @@ void caml_init_major_heap (asize_t heap_size)
   if (caml_page_table_add(In_heap, caml_heap_start,
                           caml_heap_start + Bsize_wsize (caml_stat_heap_wsz))
       != 0) {
-    caml_fatal_error ("Fatal error: cannot allocate "
-                      "initial page table.\n");
+    caml_fatal_error ("cannot allocate initial page table");
   }
 
   caml_fl_init_merge ();
@@ -893,7 +892,7 @@ void caml_init_major_heap (asize_t heap_size)
   gray_vals_size = 2048;
   gray_vals = (value *) caml_stat_alloc_noexc (gray_vals_size * sizeof (value));
   if (gray_vals == NULL)
-    caml_fatal_error ("Fatal error: not enough memory for the gray cache.\n");
+    caml_fatal_error ("not enough memory for the gray cache");
   gray_vals_cur = gray_vals;
   gray_vals_end = gray_vals + gray_vals_size;
   heap_is_pure = 1;

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -496,7 +496,7 @@ static inline value caml_alloc_shr_aux (mlsize_t wosize, tag_t tag,
       if (!raise_oom)
         return 0;
       else if (caml_in_minor_collection)
-        caml_fatal_error ("Fatal error: out of memory.\n");
+        caml_fatal_error ("out of memory");
       else
         caml_raise_out_of_memory ();
     }
@@ -766,7 +766,7 @@ CAMLexport void caml_stat_create_pool(void)
   if (pool == NULL) {
     pool = malloc(SIZEOF_POOL_BLOCK);
     if (pool == NULL)
-      caml_fatal_error("Fatal error: out of memory.\n");
+      caml_fatal_error("out of memory");
 #ifdef DEBUG
     pool->magic = Debug_pool_magic;
 #endif

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -89,7 +89,7 @@ static void alloc_generic_table (struct generic_table *tbl, asize_t sz,
   tbl->reserve = rsv;
   new_table = (void *) caml_stat_alloc_noexc((tbl->size + tbl->reserve) *
                                              element_size);
-  if (new_table == NULL) caml_fatal_error ("Fatal error: not enough memory\n");
+  if (new_table == NULL) caml_fatal_error ("not enough memory");
   if (tbl->base != NULL) caml_stat_free (tbl->base);
   tbl->base = new_table;
   tbl->ptr = tbl->base;
@@ -534,7 +534,7 @@ void caml_realloc_ref_table (struct caml_ref_table *tbl)
      "request_minor/realloc_ref_table@",
      "ref_table threshold crossed\n",
      "Growing ref_table to %" ARCH_INTNAT_PRINTF_FORMAT "dk bytes\n",
-     "Fatal error: ref_table overflow\n");
+     "ref_table overflow");
 }
 
 void caml_realloc_ephe_ref_table (struct caml_ephe_ref_table *tbl)
@@ -544,7 +544,7 @@ void caml_realloc_ephe_ref_table (struct caml_ephe_ref_table *tbl)
      "request_minor/realloc_ephe_ref_table@",
      "ephe_ref_table threshold crossed\n",
      "Growing ephe_ref_table to %" ARCH_INTNAT_PRINTF_FORMAT "dk bytes\n",
-     "Fatal error: ephe_ref_table overflow\n");
+     "ephe_ref_table overflow");
 }
 
 void caml_realloc_custom_table (struct caml_custom_table *tbl)
@@ -554,5 +554,5 @@ void caml_realloc_custom_table (struct caml_custom_table *tbl)
      "request_minor/realloc_custom_table@",
      "custom_table threshold crossed\n",
      "Growing custom_table to %" ARCH_INTNAT_PRINTF_FORMAT "dk bytes\n",
-     "Fatal error: custom_table overflow\n");
+     "custom_table overflow");
 }

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -518,7 +518,7 @@ static void realloc_generic_table
     caml_gc_message (0x08, msg_growing, (intnat) sz/1024);
     tbl->base = caml_stat_resize_noexc (tbl->base, sz);
     if (tbl->base == NULL){
-      caml_fatal_error (msg_error);
+      caml_fatal_error ("%s", msg_error);
     }
     tbl->end = tbl->base + (tbl->size + tbl->reserve) * element_size;
     tbl->threshold = tbl->base + tbl->size * element_size;

--- a/byterun/misc.c
+++ b/byterun/misc.c
@@ -24,6 +24,8 @@
 #include "caml/osdeps.h"
 #include "caml/version.h"
 
+#define FATAL_ERROR "Fatal error: "
+
 caml_timing_hook caml_major_slice_begin_hook = NULL;
 caml_timing_hook caml_major_slice_end_hook = NULL;
 caml_timing_hook caml_minor_gc_begin_hook = NULL;
@@ -66,19 +68,23 @@ void caml_gc_message (int level, char *msg, ...)
 
 CAMLexport void caml_fatal_error (char *msg)
 {
-  fprintf (stderr, "%s", msg);
+  fprintf (stderr, FATAL_ERROR "%s\n", msg);
   exit(2);
 }
 
 CAMLexport void caml_fatal_error_arg (char *fmt, char *arg)
 {
+  fprintf (stderr, FATAL_ERROR);
   fprintf (stderr, fmt, arg);
+  fprintf(stderr, "\n");
   exit(2);
 }
 
 CAMLexport void caml_fatal_error_arg2 (char *fmt, char *arg1, char *arg2)
 {
+  fprintf (stderr, FATAL_ERROR);
   fprintf (stderr, fmt, arg1, arg2);
+  fprintf(stderr, "\n");
   exit(2);
 }
 

--- a/byterun/misc.c
+++ b/byterun/misc.c
@@ -24,8 +24,6 @@
 #include "caml/osdeps.h"
 #include "caml/version.h"
 
-#define FATAL_ERROR "Fatal error: "
-
 caml_timing_hook caml_major_slice_begin_hook = NULL;
 caml_timing_hook caml_major_slice_end_hook = NULL;
 caml_timing_hook caml_minor_gc_begin_hook = NULL;
@@ -66,25 +64,14 @@ void caml_gc_message (int level, char *msg, ...)
   }
 }
 
-CAMLexport void caml_fatal_error (char *msg)
+CAMLexport void caml_fatal_error (char *msg, ...)
 {
-  fprintf (stderr, FATAL_ERROR "%s\n", msg);
-  exit(2);
-}
-
-CAMLexport void caml_fatal_error_arg (char *fmt, char *arg)
-{
-  fprintf (stderr, FATAL_ERROR);
-  fprintf (stderr, fmt, arg);
-  fprintf(stderr, "\n");
-  exit(2);
-}
-
-CAMLexport void caml_fatal_error_arg2 (char *fmt, char *arg1, char *arg2)
-{
-  fprintf (stderr, FATAL_ERROR);
-  fprintf (stderr, fmt, arg1, arg2);
-  fprintf(stderr, "\n");
+  va_list ap;
+  va_start(ap, msg);
+  fprintf (stderr, "Fatal error: ");
+  vfprintf (stderr, msg, ap);
+  va_end(ap);
+  fprintf (stderr, "\n");
   exit(2);
 }
 

--- a/byterun/misc.c
+++ b/byterun/misc.c
@@ -76,11 +76,9 @@ CAMLexport void caml_fatal_error_arg (char *fmt, char *arg)
   exit(2);
 }
 
-CAMLexport void caml_fatal_error_arg2 (char *fmt1, char *arg1,
-                                       char *fmt2, char *arg2)
+CAMLexport void caml_fatal_error_arg2 (char *fmt, char *arg1, char *arg2)
 {
-  fprintf (stderr, fmt1, arg1);
-  fprintf (stderr, fmt2, arg2);
+  fprintf (stderr, fmt, arg1, arg2);
   exit(2);
 }
 

--- a/byterun/startup.c
+++ b/byterun/startup.c
@@ -136,7 +136,7 @@ void caml_read_section_descriptors(int fd, struct exec_trailer *trail)
   trail->section = caml_stat_alloc(toc_size);
   lseek(fd, - (long) (TRAILER_SIZE + toc_size), SEEK_END);
   if (read(fd, (char *) trail->section, toc_size) != toc_size)
-    caml_fatal_error("Fatal error: cannot read section table\n");
+    caml_fatal_error("cannot read section table");
   /* Fixup endianness of lengths */
   for (i = 0; i < trail->num_sections; i++)
     fixup_endianness_trailer(&(trail->section[i].len));
@@ -170,7 +170,7 @@ int32_t caml_seek_section(int fd, struct exec_trailer *trail, char *name)
 {
   int32_t len = caml_seek_optional_section(fd, trail, name);
   if (len == -1)
-    caml_fatal_error_arg("Fatal_error: section `%s' is missing\n", name);
+    caml_fatal_error_arg("section `%s' is missing", name);
   return len;
 }
 
@@ -186,7 +186,7 @@ static char * read_section(int fd, struct exec_trailer *trail, char *name)
   if (len == -1) return NULL;
   data = caml_stat_alloc(len + 1);
   if (read(fd, data, len) != len)
-    caml_fatal_error_arg("Fatal error: error reading section %s\n", name);
+    caml_fatal_error_arg("error reading section %s", name);
   data[len] = 0;
   return data;
 }
@@ -203,7 +203,7 @@ static char_os * read_section_to_os(int fd, struct exec_trailer *trail, char *na
   if (len == -1) return NULL;
   data = caml_stat_alloc(len + 1);
   if (read(fd, data, len) != len)
-    caml_fatal_error_arg("Fatal error: error reading section %s\n", name);
+    caml_fatal_error_arg("error reading section %s", name);
   data[len] = 0;
   wlen = win_multi_byte_to_wide_char(data, len, NULL, 0);
   wdata = caml_stat_alloc((wlen + 1)*sizeof(wchar_t));
@@ -281,7 +281,7 @@ static int parse_command_line(char_os **argv)
       }
       break;
     default:
-      caml_fatal_error_arg("Unknown option %s.\n", caml_stat_strdup_of_os(argv[i]));
+      caml_fatal_error_arg("unknown option %s", caml_stat_strdup_of_os(argv[i]));
     }
   }
   return i;
@@ -358,16 +358,16 @@ CAMLexport void caml_main(char_os **argv)
   if (fd < 0) {
     pos = parse_command_line(argv);
     if (argv[pos] == 0)
-      caml_fatal_error("No bytecode file specified.\n");
+      caml_fatal_error("no bytecode file specified");
     exe_name = argv[pos];
     fd = caml_attempt_open(&exe_name, &trail, 1);
     switch(fd) {
     case FILE_NOT_FOUND:
-      caml_fatal_error_arg("Fatal error: cannot find file '%s'\n", caml_stat_strdup_of_os(argv[pos]));
+      caml_fatal_error_arg("cannot find file '%s'", caml_stat_strdup_of_os(argv[pos]));
       break;
     case BAD_BYTECODE:
       caml_fatal_error_arg(
-        "Fatal error: the file '%s' is not a bytecode executable file\n",
+        "the file '%s' is not a bytecode executable file",
         caml_stat_strdup_of_os(exe_name));
       break;
     }
@@ -393,7 +393,7 @@ CAMLexport void caml_main(char_os **argv)
   shared_lib_path = read_section_to_os(fd, &trail, "DLPT");
   shared_libs = read_section_to_os(fd, &trail, "DLLS");
   req_prims = read_section(fd, &trail, "PRIM");
-  if (req_prims == NULL) caml_fatal_error("Fatal error: no PRIM section\n");
+  if (req_prims == NULL) caml_fatal_error("no PRIM section");
   caml_build_primitive_table(shared_lib_path, shared_libs, req_prims);
   caml_stat_free(shared_lib_path);
   caml_stat_free(shared_libs);

--- a/byterun/startup.c
+++ b/byterun/startup.c
@@ -170,7 +170,7 @@ int32_t caml_seek_section(int fd, struct exec_trailer *trail, char *name)
 {
   int32_t len = caml_seek_optional_section(fd, trail, name);
   if (len == -1)
-    caml_fatal_error_arg("section `%s' is missing", name);
+    caml_fatal_error("section `%s' is missing", name);
   return len;
 }
 
@@ -186,7 +186,7 @@ static char * read_section(int fd, struct exec_trailer *trail, char *name)
   if (len == -1) return NULL;
   data = caml_stat_alloc(len + 1);
   if (read(fd, data, len) != len)
-    caml_fatal_error_arg("error reading section %s", name);
+    caml_fatal_error("error reading section %s", name);
   data[len] = 0;
   return data;
 }
@@ -203,7 +203,7 @@ static char_os * read_section_to_os(int fd, struct exec_trailer *trail, char *na
   if (len == -1) return NULL;
   data = caml_stat_alloc(len + 1);
   if (read(fd, data, len) != len)
-    caml_fatal_error_arg("error reading section %s", name);
+    caml_fatal_error("error reading section %s", name);
   data[len] = 0;
   wlen = win_multi_byte_to_wide_char(data, len, NULL, 0);
   wdata = caml_stat_alloc((wlen + 1)*sizeof(wchar_t));
@@ -281,7 +281,7 @@ static int parse_command_line(char_os **argv)
       }
       break;
     default:
-      caml_fatal_error_arg("unknown option %s", caml_stat_strdup_of_os(argv[i]));
+      caml_fatal_error("unknown option %s", caml_stat_strdup_of_os(argv[i]));
     }
   }
   return i;
@@ -363,10 +363,10 @@ CAMLexport void caml_main(char_os **argv)
     fd = caml_attempt_open(&exe_name, &trail, 1);
     switch(fd) {
     case FILE_NOT_FOUND:
-      caml_fatal_error_arg("cannot find file '%s'", caml_stat_strdup_of_os(argv[pos]));
+      caml_fatal_error("cannot find file '%s'", caml_stat_strdup_of_os(argv[pos]));
       break;
     case BAD_BYTECODE:
-      caml_fatal_error_arg(
+      caml_fatal_error(
         "the file '%s' is not a bytecode executable file",
         caml_stat_strdup_of_os(exe_name));
       break;

--- a/byterun/startup_aux.c
+++ b/byterun/startup_aux.c
@@ -45,7 +45,7 @@ void caml_init_atom_table(void)
   }
   if (caml_page_table_add(In_static_data,
                           caml_atom_table, caml_atom_table + 256) != 0) {
-    caml_fatal_error("Fatal error: not enough memory for initial page table");
+    caml_fatal_error("not enough memory for initial page table");
   }
 }
 
@@ -123,7 +123,7 @@ static int shutdown_happened = 0;
 int caml_startup_aux(int pooling)
 {
   if (shutdown_happened == 1)
-    caml_fatal_error("Fatal error: caml_startup was called after the runtime "
+    caml_fatal_error("caml_startup was called after the runtime "
                      "was shut down with caml_shutdown");
 
   /* Second and subsequent calls are ignored,
@@ -148,7 +148,7 @@ static void call_registered_value(char* name)
 CAMLexport void caml_shutdown(void)
 {
   if (startup_count <= 0)
-    caml_fatal_error("Fatal error: a call to caml_shutdown has no "
+    caml_fatal_error("a call to caml_shutdown has no "
                      "corresponding call to caml_startup");
 
   /* Do nothing unless it's the last call remaining */


### PR DESCRIPTION
This PR extends caml_fatal_error so that it accepts a variable number
of arguments. The caml_fatal_error_arg and caml_fatal_error_arg2 functions
thus become useless and are removed, caml_fatal_error being called instead.

Also, the "Fatal error: " prefix and the final "\n" are both printed
by caml_fatal_error, so a few error messages had to be adjusted. In the same
vein, a few error messages were terminated by a period that has been
removed. The first letter of the error messages has been systematically
lower-cased, except when there was a good reason to keep the uppercase.

It seems this PR also fixes a bug in byterun/interp.c: I think the cast to
char * in the "bad opcode" error message was wrong and would have caused
problems, if the error message had been reached.

The branch passes both Inria's precheck and AppVeyor.

Is there a risk that user code was relying on one of these functions?