### PR TITLE
manual: move quoted string to the main chapters

### DIFF
--- a/Changes
+++ b/Changes
@@ -44,7 +44,7 @@ Working version
 ### Manual and documentation:
 
 - GPR#1788: move the quoted string description to the main chapters
-  (Florian Angeletti, review by Perry E. Metzger)
+  (Florian Angeletti, review by Xavier Clerc and Perry E. Metzger)
 
 ### Compiler distribution build system:
 

--- a/Changes
+++ b/Changes
@@ -43,6 +43,9 @@ Working version
 
 ### Manual and documentation:
 
+- GPR#1788: move the quoted string description to the main chapters
+  (Florian Angeletti, review by Perry E. Metzger)
+
 ### Compiler distribution build system:
 
 - GPR#1776: add -no-install-bytecode-programs and related configure options to

--- a/manual/manual/refman/const.etex
+++ b/manual/manual/refman/const.etex
@@ -24,7 +24,7 @@ constant:
 \end{syntax}
 See also the following language extensions:
 \hyperref[s:ext-integer]{integer literals for types \texttt{int32}, \texttt{int64}
-and \texttt{nativeint}}, \hyperref[s:quoted-strings]{quoted strings}
+and \texttt{nativeint}},
 and \hyperref[s:extension-literals]{extension literals}.
 
 The syntactic class of constants comprises literals from the four

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1799,8 +1799,9 @@ quotes. For instance, you can use "[%sql {|...|}]" to
 represent arbitrary SQL statements -- assuming you have a ppx-rewriter
 that recognizes the "%sql" extension.
 
-Note that the non-extension form, for example "{sql|...|sql}", should
-not be used for this purpose. Indeed, the user cannot see in the code that
+Note that the word-delimited form, for example "{sql|...|sql}", should
+not be used for signaling an extension is in use.
+Indeed, the user cannot see in the code that
 this string literal has a different semantics than they expect. Moreover,
 giving a semantics to a specific delimiter limits the freedom to
 change the delimiter to avoid escaping issues.

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1792,6 +1792,19 @@ the attributes are considered to apply to the payload:
 fun%foo[@bar] x -> x + 1 === [%foo (fun x -> x + 1)[@bar ] ];
 \end{verbatim}
 
+Quoted strings "{|...|}" are particularly interesting for payloads
+that embed foreign syntax fragments. Those fragments can be interpreted
+by a preprocessor and turned into OCaml code without requiring escaping
+quotes. For instance, you can use "[%sql {|...|}]" to
+represent arbitrary SQL statements -- assuming you have a ppx-rewriter
+that recognizes the "%sql" extension.
+
+Note that the non-extension form, for example "{sql|...|sql}", should
+not be used for this purpose. Indeed, the user cannot see in the code that
+this string literal has a different semantics than they expect. Moreover,
+giving a semantics to a specific delimiter limits the freedom to
+change the delimiter to avoid escaping issues.
+
 \subsection{Built-in extension nodes}
 
 (Introduced in OCaml 4.03)
@@ -1814,52 +1827,6 @@ let y = [%extension_constructor Y]
 \begin{caml_example}{toplevel}
  x <> y;;
 \end{caml_example}
-
-\section{Quoted strings}\label{s:quoted-strings}
-
-(Introduced in OCaml 4.02)
-
-Quoted strings "{foo|...|foo}" provide a different lexical syntax to
-write string literals in OCaml code. They are useful to represent
-strings of arbitrary content without escaping -- as long as the
-delimiter you chose (here "|foo}") does not occur in the string
-itself.
-
-\begin{syntax}
-string-literal: ...
-     |  '{' quoted-string-id '|'  ........ '|' quoted-string-id '}'
-;
-quoted-string-id:
-     { 'a'...'z' || '_' }
-;
-\end{syntax}
-
-The opening delimiter has the form "{id|" where "id" is a (possibly
-empty) sequence of lowercase letters and underscores.  The
-corresponding closing delimiter is "|id}" (with the same
-identifier). Unlike regular OCaml string literals, quoted
-strings do not interpret any character in a special way.
-
-Example:
-
-\begin{verbatim}
-String.length {|\"|}         (* returns 2 *)
-String.length {foo|\"|foo}   (* returns 2 *)
-\end{verbatim}
-
-Quoted strings are interesting in particular in conjunction to
-extension nodes "[%foo ...]" (see \ref{s:extension-nodes}) to embed
-foreign syntax fragments to be interpreted by a preprocessor and
-turned into OCaml code: you can use "[%sql {|...|}]" for example to
-represent arbitrary SQL statements -- assuming you have a ppx-rewriter
-that recognizes the "%sql" extension -- without requiring escaping
-quotes.
-
-Note that the non-extension form, for example "{sql|...|sql}", should
-not be used for this purpose, as the user cannot see in the code that
-this string literal has a different semantics than they expect, and
-giving a semantics to a specific delimiter limits the freedom to
-change the delimiter to avoid escaping issues.
 
 \section{Exception cases in pattern matching}\label{s:exception-match}
 

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -1800,11 +1800,11 @@ represent arbitrary SQL statements -- assuming you have a ppx-rewriter
 that recognizes the "%sql" extension.
 
 Note that the word-delimited form, for example "{sql|...|sql}", should
-not be used for signaling an extension is in use.
-Indeed, the user cannot see in the code that
-this string literal has a different semantics than they expect. Moreover,
-giving a semantics to a specific delimiter limits the freedom to
-change the delimiter to avoid escaping issues.
+not be used for signaling that an extension is in use.
+Indeed, the user cannot see from the code whether this string literal has
+different semantics than they expect. Moreover, giving semantics to a
+specific delimiter limits the freedom to change the delimiter to avoid
+escaping issues.
 
 \subsection{Built-in extension nodes}
 

--- a/manual/manual/refman/lex.etex
+++ b/manual/manual/refman/lex.etex
@@ -185,7 +185,8 @@ any character in a special way but requires that the
 sequence @'|' quoted-string-id '}'@ does not occur in the string itself.
 The identifier @quoted-string-id@ is a (possibly empty) sequence of
 lowercase letters and underscores that can be freely chosen to avoid
-such issue.
+such issue (e.g. "{|hello|}", "{ext|hello {|world|}|ext}", ...).
+
 
 The current implementation places practically no restrictions on the
 length of string literals.

--- a/manual/manual/refman/lex.etex
+++ b/manual/manual/refman/lex.etex
@@ -147,6 +147,11 @@ The two single quotes enclose either one character different from
 \begin{syntax}
 string-literal:
           '"' { string-character } '"'
+       |  '{' quoted-string-id '|'  { any-char } '|' quoted-string-id '}'
+;
+quoted-string-id:
+     { 'a'...'z' || '_' }
+;
 ;
 string-character:
           regular-string-char
@@ -170,6 +175,17 @@ To allow splitting long string literals across lines, the sequence
 "\\"\var{newline}~\var{spaces-or-tabs} (a backslash at the end of a line
 followed by any number of spaces and horizontal tabulations at the
 beginning of the next line) is ignored inside string literals.
+
+Quoted string literals provide an alternative lexical syntax for
+string literals. They are useful to represent strings of arbitrary content
+without escaping. Quoted strings are delimited by a matching pair
+of @'{' quoted-string-id '|'@ and @'|' quoted-string-id '}'@ with
+the same @quoted-string-id@ on both sides. Quoted strings do not interpret
+any character in a special way but requires that the
+sequence @'|' quoted-string-id '}'@ does not occur in the string itself.
+The identifier @quoted-string-id@ is a (possibly empty) sequence of
+lowercase letters and underscores that can be freely chosen to avoid
+such issue.
 
 The current implementation places practically no restrictions on the
 length of string literals.

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -58,7 +58,8 @@ usual basic data types: booleans, characters, and immutable character strings.
 \begin{caml_example}{toplevel}
 (1 < 2) = false;;
 'a';;
-"Hello world";;
+"Hello" ^ " " ^ "world";;
+{|This is a quoted string where \n is not a newline|};;
 \end{caml_example}
 
 Predefined data structures include tuples, arrays, and lists. There are also

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -54,12 +54,23 @@ fib 10;;
 \pdfsection{Data types}
 
 In addition to integers and floating-point numbers, OCaml offers the
-usual basic data types: booleans, characters, and immutable character strings.
+usual basic data types: booleans,
 \begin{caml_example}{toplevel}
 (1 < 2) = false;;
-'a';;
+let one = if true then 1 else 2;;
+\end{caml_example}
+characters,
+\begin{caml_example}{toplevel}
+ 'a';;
+ int_of_char '\n';;
+\end{caml_example}
+and immutable character strings:
+\begin{caml_example}{toplevel}
 "Hello" ^ " " ^ "world";;
-{|This is a quoted string where \n is not a newline|};;
+{|This is a quoted string, here, neither \ nor " are special characters|};;
+{|"\\"|}="\"\\\\\"";;
+  {delimiter|the end of this|}quoted string is here|delimiter}
+=           "the end of this|}quoted string is here";;
 \end{caml_example}
 
 Predefined data structures include tuples, arrays, and lists. There are also

--- a/manual/manual/tutorials/coreexamples.etex
+++ b/manual/manual/tutorials/coreexamples.etex
@@ -54,17 +54,19 @@ fib 10;;
 \pdfsection{Data types}
 
 In addition to integers and floating-point numbers, OCaml offers the
-usual basic data types: booleans,
+usual basic data types:
+\begin{itemize}%
+\item booleans
 \begin{caml_example}{toplevel}
 (1 < 2) = false;;
 let one = if true then 1 else 2;;
 \end{caml_example}
-characters,
+\item characters
 \begin{caml_example}{toplevel}
  'a';;
  int_of_char '\n';;
 \end{caml_example}
-and immutable character strings:
+\item immutable character strings
 \begin{caml_example}{toplevel}
 "Hello" ^ " " ^ "world";;
 {|This is a quoted string, here, neither \ nor " are special characters|};;
@@ -72,6 +74,7 @@ and immutable character strings:
   {delimiter|the end of this|}quoted string is here|delimiter}
 =           "the end of this|}quoted string is here";;
 \end{caml_example}
+\end{itemize}
 
 Predefined data structures include tuples, arrays, and lists. There are also
 general mechanisms for defining your own data structures, such as records and


### PR DESCRIPTION
This PR proposes to move quoted strings outside of the "language extensions" chapter:

- the grammar description is moved to `manual/manual/lex.etex` after the description of the classical string literals.

- their use in extension nodes is now discussed in the `extension nodes` section. I have reworked a bit the paragraph structure to avoid few paragraph-sized sentences.

- they briefly appear in the tutorial when strings are introduced. As a small related change, the "Hello world" introductive strings is replaced by `"Hello" ^ " " ^ "world"` to briefly impart the fact that the operator for string concatenation is `^`.