### PR TITLE
Make sure a function registered with `at_exit` is executed only once

### DIFF
--- a/Changes
+++ b/Changes
@@ -532,6 +532,10 @@ OCaml 4.07
   even in empty structures and signatures
   (Leo White, Florian Angeletti, report by Anton Bachin)
 
+- MPR#7253, MPR#7796: Make sure a function registered with "at_exit"
+  is executed only once when the program exits
+  (Nicolás Ojeda Bär and Xavier Leroy)
+
 - MPR#7391, GPR#1620: Do not put a dummy method in object types
   (Thomas Refis, review by Jacques Garrigue)
 

--- a/Changes
+++ b/Changes
@@ -532,9 +532,9 @@ OCaml 4.07
   even in empty structures and signatures
   (Leo White, Florian Angeletti, report by Anton Bachin)
 
-- MPR#7253, MPR#7796: Make sure a function registered with "at_exit"
+- MPR#7253, MPR#7796, GPR#1790: Make sure a function registered with "at_exit"
   is executed only once when the program exits
-  (Nicolás Ojeda Bär and Xavier Leroy)
+  (Nicolás Ojeda Bär and Xavier Leroy, review by Max Mouratov)
 
 - MPR#7391, GPR#1620: Do not put a dummy method in object types
   (Thomas Refis, review by Jacques Garrigue)

--- a/otherlibs/threads/stdlib.ml
+++ b/otherlibs/threads/stdlib.ml
@@ -626,7 +626,12 @@ let exit_function = ref flush_all
 
 let at_exit f =
   let g = !exit_function in
-  exit_function := (fun () -> f(); g())
+  (* MPR#7253, MPR#7796: make sure "f" is executed only once *)
+  let f_already_ran = ref false in
+  exit_function :=
+    (fun () -> 
+      if not !f_already_ran then begin f_already_ran := true; f() end;
+      g())
 
 let do_at_exit () = (!exit_function) ()
 

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -538,7 +538,12 @@ let exit_function = ref flush_all
 
 let at_exit f =
   let g = !exit_function in
-  exit_function := (fun () -> f(); g())
+  (* MPR#7253, MPR#7796: make sure "f" is executed only once *)
+  let f_already_ran = ref false in
+  exit_function :=
+    (fun () -> 
+      if not !f_already_ran then begin f_already_ran := true; f() end;
+      g())
 
 let do_at_exit () = (!exit_function) ()
 

--- a/testsuite/tests/basic/ocamltests
+++ b/testsuite/tests/basic/ocamltests
@@ -17,6 +17,7 @@ maps.ml
 min_int.ml
 opt_variants.ml
 patmatch.ml
+pr7253.ml
 pr7533.ml
 pr7657.ml
 recvalues.ml

--- a/testsuite/tests/basic/pr7253.ml
+++ b/testsuite/tests/basic/pr7253.ml
@@ -1,0 +1,16 @@
+(* TEST *)
+
+(* MPR#7253: "at_exit functions get called twice if a callback raises
+   and prevents earlier handlers to execute." *)
+
+exception My_exception
+
+let () =
+  Printexc.set_uncaught_exception_handler (fun exn bt ->
+    match exn with
+    | My_exception -> print_endline "Caught"; exit 0
+    | _ -> print_endline "Unexpected uncaught exception");
+  at_exit (fun () -> print_endline "Last");
+  at_exit (fun () -> print_endline "Raise"; raise My_exception);
+  at_exit (fun () -> print_endline "First")
+

--- a/testsuite/tests/basic/pr7253.reference
+++ b/testsuite/tests/basic/pr7253.reference
@@ -1,0 +1,4 @@
+First
+Raise
+Last
+Caught


### PR DESCRIPTION
As shown in  [MPR#7253](https://caml.inria.fr/mantis/view.php?id=7253) and [MPR#7796](https://caml.inria.fr/mantis/view.php?id=7796), there are several cases where `do_at_exit` is called several times, causing functions registered with `at_exit` to be called several times.  Also, an `at_exit` function that raises could prevent other `at_exit` functions from being run.

This GPR makes sure that each function registered with `at_exit` is run at most once.  The idea and implementation is due to @nojb in https://github.com/ocaml/ocaml/pull/1783#issuecomment-389854641.

Implementation notes:
* The test-and-set on a bool ref is atomic with the two thread libraries of OCaml.
* Consequently, if two threads race to call `exit`, each `at_exit` function will be called exactly once, but possibly not in the normal order.
* Lazy evaluation (as suggested by @xclerc) would work too, except that the `Lazy` module is not available in `Stdlib`.


