### PR TITLE
Unix: add open_process_args{,_in,_out,_full}

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,10 @@ Working version
 - GPR#1731: Format, use raise_notrace to preserve backtraces
   (Frédéric Bour, report by Jules Villard, review by Gabriel Scherer)
 
+- MPR#7794: Add Unix.open_process_args{,_in,_out,_full} similar to
+  Unix.open_process{,_in,_out,_full}, but passing an explicit argv array.
+  (Nicolás Ojeda Bär, review by ..., request by Volker Diels-Grabsch)
+
 ### Other libraries:
 
 ### Compiler user-interface and warnings:

--- a/Changes
+++ b/Changes
@@ -15,9 +15,9 @@ Working version
 - GPR#1731: Format, use raise_notrace to preserve backtraces
   (Frédéric Bour, report by Jules Villard, review by Gabriel Scherer)
 
-- MPR#7794: Add Unix.open_process_args{,_in,_out,_full} similar to
+- GPR#1792, MPR#7794: Add Unix.open_process_args{,_in,_out,_full} similar to
   Unix.open_process{,_in,_out,_full}, but passing an explicit argv array.
-  (Nicolás Ojeda Bär, review by ..., request by Volker Diels-Grabsch)
+  (Nicolás Ojeda Bär, review by Jérémie Dimino, request by Volker Diels-Grabsch)
 
 ### Other libraries:
 

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -646,7 +646,7 @@ val set_close_on_exec : file_descr -> unit
    to the private file and can do bad things with it.  Hence, it is
    highly recommended to set all file descriptors ``close-on-exec'',
    except in the very few cases where a file descriptor actually needs
-   to be transmitted to another program.  
+   to be transmitted to another program.
 
    The best way to set a file descriptor ``close-on-exec'' is to create
    it in this state.  To this end, the [openfile] function has
@@ -790,6 +790,34 @@ val open_process : string -> in_channel * out_channel
 val open_process_full :
   string -> string array -> in_channel * out_channel * in_channel
 (** Similar to {!Unix.open_process}, but the second argument specifies
+   the environment passed to the command.  The result is a triple
+   of channels connected respectively to the standard output, standard input,
+   and standard error of the command. *)
+
+val open_process_args_in : string -> string array -> in_channel
+(** High-level pipe and process management. The first argument specifies the
+   command to run, and the second argument specifies the argument array passed
+   to the command.  This function runs the command in parallel with the program.
+   The standard output of the command is redirected to a pipe, which can be read
+   via the returned input channel. *)
+
+val open_process_args_out : string -> string array -> out_channel
+(** Same as {!Unix.open_process_in}, but redirect the standard input of
+   the command to a pipe.  Data written to the returned output channel
+   is sent to the standard input of the command.
+   Warning: writes on output channels are buffered, hence be careful
+   to call {!Pervasives.flush} at the right times to ensure
+   correct synchronization. *)
+
+val open_process_args : string -> string array -> in_channel * out_channel
+(** Same as {!Unix.open_process_out}, but redirects both the standard input
+   and standard output of the command to pipes connected to the two
+   returned channels.  The input channel is connected to the output
+   of the command, and the output channel to the input of the command. *)
+
+val open_process_args_full :
+  string -> string array -> string array -> in_channel * out_channel * in_channel
+(** Similar to {!Unix.open_process}, but the third argument specifies
    the environment passed to the command.  The result is a triple
    of channels connected respectively to the standard output, standard input,
    and standard error of the command. *)

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -799,28 +799,35 @@ val open_process_args_in : string -> string array -> in_channel
    command to run, and the second argument specifies the argument array passed
    to the command.  This function runs the command in parallel with the program.
    The standard output of the command is redirected to a pipe, which can be read
-   via the returned input channel. *)
+   via the returned input channel.
+
+    @since 4.08.0 *)
 
 val open_process_args_out : string -> string array -> out_channel
-(** Same as {!Unix.open_process_in}, but redirect the standard input of
-   the command to a pipe.  Data written to the returned output channel
-   is sent to the standard input of the command.
-   Warning: writes on output channels are buffered, hence be careful
-   to call {!Pervasives.flush} at the right times to ensure
-   correct synchronization. *)
+(** Same as {!Unix.open_process_args_in}, but redirect the standard input of the
+   command to a pipe.  Data written to the returned output channel is sent to
+   the standard input of the command.  Warning: writes on output channels are
+   buffered, hence be careful to call {!Pervasives.flush} at the right times to
+   ensure correct synchronization.
+
+    @since 4.08.0 *)
 
 val open_process_args : string -> string array -> in_channel * out_channel
-(** Same as {!Unix.open_process_out}, but redirects both the standard input
-   and standard output of the command to pipes connected to the two
-   returned channels.  The input channel is connected to the output
-   of the command, and the output channel to the input of the command. *)
+(** Same as {!Unix.open_process_args_out}, but redirects both the standard input
+   and standard output of the command to pipes connected to the two returned
+   channels.  The input channel is connected to the output of the command, and
+   the output channel to the input of the command.
+
+    @since 4.08.0 *)
 
 val open_process_args_full :
   string -> string array -> string array -> in_channel * out_channel * in_channel
-(** Similar to {!Unix.open_process}, but the third argument specifies
-   the environment passed to the command.  The result is a triple
-   of channels connected respectively to the standard output, standard input,
-   and standard error of the command. *)
+(** Similar to {!Unix.open_process_args}, but the third argument specifies the
+   environment passed to the command.  The result is a triple of channels
+   connected respectively to the standard output, standard input, and standard
+   error of the command.
+
+    @since 4.08.0 *)
 
 val close_process_in : in_channel -> process_status
 (** Close channels opened by {!Unix.open_process_in},

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -671,28 +671,35 @@ val open_process_args_in : string -> string array -> in_channel
    command to run, and the second argument specifies the argument array passed
    to the command.  This function runs the command in parallel with the program.
    The standard output of the command is redirected to a pipe, which can be read
-   via the returned input channel. *)
+   via the returned input channel.
+
+    @since 4.08.0 *)
 
 val open_process_args_out : string -> string array -> out_channel
-(** Same as {!Unix.open_process_in}, but redirect the standard input of
-   the command to a pipe.  Data written to the returned output channel
-   is sent to the standard input of the command.
-   Warning: writes on output channels are buffered, hence be careful
-   to call {!Pervasives.flush} at the right times to ensure
-   correct synchronization. *)
+(** Same as {!Unix.open_process_args_in}, but redirect the standard input of the
+   command to a pipe.  Data written to the returned output channel is sent to
+   the standard input of the command.  Warning: writes on output channels are
+   buffered, hence be careful to call {!Pervasives.flush} at the right times to
+   ensure correct synchronization.
+
+    @since 4.08.0 *)
 
 val open_process_args : string -> string array -> in_channel * out_channel
-(** Same as {!Unix.open_process_out}, but redirects both the standard input
-   and standard output of the command to pipes connected to the two
-   returned channels.  The input channel is connected to the output
-   of the command, and the output channel to the input of the command. *)
+(** Same as {!Unix.open_process_args_out}, but redirects both the standard input
+   and standard output of the command to pipes connected to the two returned
+   channels.  The input channel is connected to the output of the command, and
+   the output channel to the input of the command.
+
+    @since 4.08.0 *)
 
 val open_process_args_full :
   string -> string array -> string array -> in_channel * out_channel * in_channel
-(** Similar to {!Unix.open_process}, but the third argument specifies
-   the environment passed to the command.  The result is a triple
-   of channels connected respectively to the standard output, standard input,
-   and standard error of the command. *)
+(** Similar to {!Unix.open_process_args}, but the third argument specifies the
+   environment passed to the command.  The result is a triple of channels
+   connected respectively to the standard output, standard input, and standard
+   error of the command.
+
+    @since 4.08.0 *)
 
 val close_process_in : in_channel -> process_status
 (** Close channels opened by {!UnixLabels.open_process_in},

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -666,6 +666,34 @@ val open_process_full :
    of channels connected respectively to the standard output, standard input,
    and standard error of the command. *)
 
+val open_process_args_in : string -> string array -> in_channel
+(** High-level pipe and process management. The first argument specifies the
+   command to run, and the second argument specifies the argument array passed
+   to the command.  This function runs the command in parallel with the program.
+   The standard output of the command is redirected to a pipe, which can be read
+   via the returned input channel. *)
+
+val open_process_args_out : string -> string array -> out_channel
+(** Same as {!Unix.open_process_in}, but redirect the standard input of
+   the command to a pipe.  Data written to the returned output channel
+   is sent to the standard input of the command.
+   Warning: writes on output channels are buffered, hence be careful
+   to call {!Pervasives.flush} at the right times to ensure
+   correct synchronization. *)
+
+val open_process_args : string -> string array -> in_channel * out_channel
+(** Same as {!Unix.open_process_out}, but redirects both the standard input
+   and standard output of the command to pipes connected to the two
+   returned channels.  The input channel is connected to the output
+   of the command, and the output channel to the input of the command. *)
+
+val open_process_args_full :
+  string -> string array -> string array -> in_channel * out_channel * in_channel
+(** Similar to {!Unix.open_process}, but the third argument specifies
+   the environment passed to the command.  The result is a triple
+   of channels connected respectively to the standard output, standard input,
+   and standard error of the command. *)
+
 val close_process_in : in_channel -> process_status
 (** Close channels opened by {!UnixLabels.open_process_in},
    wait for the associated command to terminate,


### PR DESCRIPTION
See [MPR#7794](https://caml.inria.fr/mantis/view.php?id=7794).

- The idea is to add a variant of the `Unix.open_process{,_in,_out,_full}` functions that work with a pair `(program, args)` directly, without going through the system shell, which introduces extra complexity (in particular, with respect to quoting).

- I used the name `Unix.open_process_args` which is the one suggested in https://github.com/ocaml-batteries-team/batteries-included/issues/858, but I am not completely sold on it.

- One uses the usual "close" functions `Unix.close_process{,_in,_out,_full}` with the new functions as well.

- The "old" functions `Unix.open_process{,_in,_out,_full}` are re-implemented in terms of the "new" functions, so I did not feel pressed to add new tests.