### PR TITLE
ocamlrun: make debugging executable magic number issues easier

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,6 +42,9 @@ Working version
 
 ### Runtime system:
 
+- GPR#1793: add the -m and -M command-line options to ocamlrun
+  (Sébastien Hinderer, review by ??)
+
 ### Tools:
 
 - GPR#1711: the new 'open' flag in OCAMLRUNPARAM takes a comma-separated list of

--- a/byterun/caml/exec.h
+++ b/byterun/caml/exec.h
@@ -46,15 +46,17 @@ struct section_descriptor {
   uint32_t len;                   /* Length of data in bytes */
 };
 
+#define EXEC_MAGIC_LENGTH 12
+
 /* Structure of the trailer. */
 
 struct exec_trailer {
-  uint32_t num_sections;          /* Number of sections */
-  char magic[12];               /* The magic number */
+  uint32_t num_sections;               /* Number of sections */
+  char magic[EXEC_MAGIC_LENGTH];       /* The magic number */
   struct section_descriptor * section; /* Not part of file */
 };
 
-#define TRAILER_SIZE (4+12)
+#define TRAILER_SIZE (4+EXEC_MAGIC_LENGTH)
 
 /* Magic number for this release */
 

--- a/byterun/caml/startup.h
+++ b/byterun/caml/startup.h
@@ -37,7 +37,7 @@ CAMLextern value caml_startup_code_exn(
   int pooling,
   char_os **argv);
 
-enum { FILE_NOT_FOUND = -1, BAD_BYTECODE  = -2 };
+enum { FILE_NOT_FOUND = -1, BAD_BYTECODE = -2, WRONG_MAGIC = -3 };
 
 extern int caml_attempt_open(char_os **name, struct exec_trailer *trail,
                              int do_open_script);

--- a/byterun/startup.c
+++ b/byterun/startup.c
@@ -67,6 +67,7 @@
 #endif
 
 static char magicstr[EXEC_MAGIC_LENGTH+1];
+static int print_magic = 0;
 
 /* Read the trailer of a bytecode file */
 
@@ -84,13 +85,16 @@ static int read_trailer(int fd, struct exec_trailer *trail)
   if (read(fd, (char *) trail, TRAILER_SIZE) < TRAILER_SIZE)
     return BAD_BYTECODE;
   fixup_endianness_trailer(&trail->num_sections);
-  if (strncmp(trail->magic, EXEC_MAGIC, sizeof(trail->magic)) == 0)
-    return 0;
-  else {
-    memcpy(magicstr, trail->magic, EXEC_MAGIC_LENGTH);
-    magicstr[EXEC_MAGIC_LENGTH] = 0;
-    return WRONG_MAGIC;
+  memcpy(magicstr, trail->magic, EXEC_MAGIC_LENGTH);
+  magicstr[EXEC_MAGIC_LENGTH] = 0;
+  
+  if (print_magic) {
+    printf("%s\n", magicstr);
+    exit(0);
   }
+  return
+    (strncmp(trail->magic, EXEC_MAGIC, sizeof(trail->magic)) == 0)
+      ? 0 : WRONG_MAGIC;
 }
 
 int caml_attempt_open(char_os **name, struct exec_trailer *trail,
@@ -284,6 +288,13 @@ static int parse_command_line(char_os **argv)
         caml_ext_table_add(&caml_shared_libs_path, argv[i + 1]);
         i++;
       }
+      break;
+    case _T('m'):
+      print_magic = 1;
+      break;
+    case _T('M'):
+      printf ( EXEC_MAGIC "\n");
+      exit(0);
       break;
     default:
       caml_fatal_error("unknown option %s", caml_stat_strdup_of_os(argv[i]));

--- a/manual/manual/cmds/runtime.etex
+++ b/manual/manual/cmds/runtime.etex
@@ -63,6 +63,11 @@ in the "OCAMLRUNPARAM" environment variable (see below).
 Search the directory \var{dir} for dynamically-loaded libraries,
 in addition to the standard search path (see
 section~\ref{s-ocamlrun-dllpath}).
+\item["-m"]
+Print the magic number of the bytecode executable given as argument
+and exit.
+\item["-M"]
+Print the magic number expected by this version of the runtime and exit.
 \item["-p"]
 Print the names of the primitives known to this version of
 "ocamlrun" and exit.


### PR DESCRIPTION
First, this PR provides a more precise error message in the case where the
magic number of an executable bytecode file differs from the one
expected by the runtime.
Instead of the "bad bytecode" message, bothe the expected and encountered
magic nubmers are reported.


Second, two command-line options are added to ocamlrun:

- -m: print the magic number of the executable given as argument and exit

- -M: print the magic number expected by this version of the runtime

These changes turn out to be useful when debugging the compiler's
bootstrap process.

Finally, this PR relies on #1787 which should hence be merged first.