### PR TITLE
fix build on musl libc ppc64le

### DIFF
--- a/asmrun/signals_osdep.h
+++ b/asmrun/signals_osdep.h
@@ -297,11 +297,11 @@
      sigact.sa_flags = 0
 
   typedef unsigned long context_reg;
-  #define CONTEXT_PC (context->regs->nip)
-  #define CONTEXT_EXCEPTION_POINTER (context->regs->gpr[29])
-  #define CONTEXT_YOUNG_LIMIT (context->regs->gpr[30])
-  #define CONTEXT_YOUNG_PTR (context->regs->gpr[31])
-  #define CONTEXT_SP (context->regs->gpr[1])
+  #define CONTEXT_PC (context->gp_regs[32])
+  #define CONTEXT_EXCEPTION_POINTER (context->gp_regs[29])
+  #define CONTEXT_YOUNG_LIMIT (context->gp_regs[30])
+  #define CONTEXT_YOUNG_PTR (context->gp_regs[31])
+  #define CONTEXT_SP (context->gp_regs[1])
 
 /****************** PowerPC, NetBSD */
 


### PR DESCRIPTION
muslc libc appears to define the context registers through `gp_regs` and does not provide the `gpr` struct member.  However, the `gp_regs` method appears to also work backwards compatibly with Debian and Ubuntu ppc64le libc (compile tested only).

This changeset therefore hopefully fixes the build on Alpine ppc64le and continues to compile on Debian and Ubuntu ppc64le.

*Disclaimer:* I am deeply unfamiliar with the innards of ppc64le ucontext portability, and so invoke the last person to touch this blob of code in 1994 in d704771b  ...  @xavierleroy 