### PR TITLE
C-language API permits weaker backward compatibility requirements.

### DIFF
--- a/Changes
+++ b/Changes
@@ -518,6 +518,13 @@ OCaml 4.07.0 (10 July 2018)
 - GPR#1753: avoid potential off-by-one overflow in debugger socket path length.
   (Anil Madhavapeddy)
 
+- GPR#1798: Introduce CAML_API_VERSION macro in "caml/compatibility.h" to
+  facilitate the orderly introduction of changes to the C-language interface
+  with back-compatibility aspects. Users of the C interface may #define this
+  value before inclusion of "caml/compatibility.h" to specify a minimum version
+  of back-compatibility later than the default. The default value 100
+  provides full backward compatibility.
+
 ### Tools:
 
 - MPR#7643, GPR#1377: ocamldep, fix an exponential blowup in presence of nested

--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -17,9 +17,6 @@
 #define CAML_ALLOC_H
 
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "misc.h"
 #include "mlvalues.h"
 

--- a/runtime/caml/callback.h
+++ b/runtime/caml/callback.h
@@ -18,9 +18,6 @@
 #ifndef CAML_CALLBACK_H
 #define CAML_CALLBACK_H
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "mlvalues.h"
 
 #ifdef __cplusplus

--- a/runtime/caml/compatibility.h
+++ b/runtime/caml/compatibility.h
@@ -18,9 +18,22 @@
 #ifndef CAML_COMPATIBILITY_H
 #define CAML_COMPATIBILITY_H
 
+/* minimum API version compatibility: default OCaml 1.0 */
+#ifndef CAML_API_VERSION
+#define CAML_API_VERSION 100
+#endif
+
+#if CAML_API_VERSION >= 400 && !defined(CAML_NAME_SPACE)
+#define CAML_NAME_SPACE
+#endif
+
+#if CAML_API_VERSION < 403
+
 /* internal global variables renamed between 4.02.1 and 4.03.0 */
 #define caml_stat_top_heap_size Bsize_wsize(caml_stat_top_heap_wsz)
 #define caml_stat_heap_size Bsize_wsize(caml_stat_heap_wsz)
+
+#endif /* CAML_API_VERSION < 403 */
 
 #ifndef CAML_NAME_SPACE
 

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -25,9 +25,7 @@
 #undef SUPPORT_DYNAMIC_LINKING
 #endif
 
-#ifndef CAML_NAME_SPACE
 #include "compatibility.h"
-#endif
 
 #include <stddef.h>
 

--- a/runtime/caml/custom.h
+++ b/runtime/caml/custom.h
@@ -17,9 +17,6 @@
 #define CAML_CUSTOM_H
 
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "mlvalues.h"
 
 struct custom_operations {

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -20,9 +20,6 @@
 #include <setjmp.h>
 #endif /* CAML_INTERNALS */
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "misc.h"
 #include "mlvalues.h"
 

--- a/runtime/caml/intext.h
+++ b/runtime/caml/intext.h
@@ -18,9 +18,6 @@
 #ifndef CAML_INTEXT_H
 #define CAML_INTEXT_H
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "misc.h"
 #include "mlvalues.h"
 

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -18,9 +18,6 @@
 #ifndef CAML_MEMORY_H
 #define CAML_MEMORY_H
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "config.h"
 #ifdef CAML_INTERNALS
 #include "gc.h"
@@ -235,10 +232,12 @@ extern uintnat caml_spacetime_my_profinfo(struct ext_table**, uintnat);
   Alloc_small_with_profinfo(result, wosize, tag, (uintnat) 0)
 #endif
 
+#if CAML_API_VERSION < 400
 /* Deprecated alias for [caml_modify] */
 
 #define Modify(fp,val) caml_modify((fp), (val))
 
+#endif /* CAML_API_VERSION < 400 */
 #endif /* CAML_INTERNALS */
 
 struct caml__roots_block {
@@ -466,6 +465,8 @@ CAMLextern struct caml__roots_block *caml_local_roots;  /* defined in roots.c */
   caml_modify (&Field ((block), caml__temp_offset), caml__temp_val); \
 }while(0)
 
+#if CAML_API_VERSION < 400
+
 /*
    NOTE: [Begin_roots] and [End_roots] are superseded by [CAMLparam]*,
    [CAMLxparam]*, [CAMLlocal]*, [CAMLreturn].
@@ -547,6 +548,8 @@ CAMLextern struct caml__roots_block *caml_local_roots;  /* defined in roots.c */
   caml__roots_block.tables[0] = (table);
 
 #define End_roots() caml_local_roots = caml__roots_block.next; }
+
+#endif /* CAML_API_VERSION < 400 */
 
 
 /* [caml_register_global_root] registers a global C variable as a memory root

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -18,9 +18,6 @@
 #ifndef CAML_MISC_H
 #define CAML_MISC_H
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "config.h"
 
 /* Standard definitions */

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -16,9 +16,6 @@
 #ifndef CAML_MLVALUES_H
 #define CAML_MLVALUES_H
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "config.h"
 #include "misc.h"
 

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -16,9 +16,6 @@
 #ifndef CAML_SIGNALS_H
 #define CAML_SIGNALS_H
 
-#ifndef CAML_NAME_SPACE
-#include "compatibility.h"
-#endif
 #include "misc.h"
 #include "mlvalues.h"
 


### PR DESCRIPTION
Change to the C-language API extracted from #1003 for introducing the CAML_API_VERSION mechanism to improve control of the backward compatibility requirement.

- Add CAML_API_VERSION parameter in the "caml/compatibility.h" header.
- Default value is 100.
- Explicitly define CAML_NAME_SPACE if CAML_API_VERSION >= 400.
- If CAML_API_VERSION < 403, then also #define caml_stat_heap_xxx_size.
- If CAML_API_VERSION < 400, then also #define Modify, Begin_roots, End_roots.
- Always include "caml/compatibility.h" from "caml/memory.h" header.
- Never include "caml/compatibility.h" from other headers.