### PR TITLE
test error message for ill-typed record pattern

### DIFF
--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -77,6 +77,19 @@ Error: This expression has type int but an expression was expected of type
          foo
 |}];;
 
+let f (r: int) =
+  match r with
+  | { contents = 3 } -> ()
+[%%expect{|
+Line _, characters 4-20:
+    | { contents = 3 } -> ()
+      ^^^^^^^^^^^^^^^^
+Error: This pattern matches values of type int ref
+       but a pattern was expected which matches values of type int
+|}];;
+
+
+
 (* bugs *)
 type foo = { y: int; z: int };;
 type bar = { x: int };;


### PR DESCRIPTION
I was wondering what happened if we just used `expected_ty` instead of a fresh variable when `extract_concrete_record` fails in `type_pat`:
https://github.com/ocaml/ocaml/blob/34504e849d165694cc51bc2430ef0e28bb910f95/typing/typecore.ml#L1293-L1296

Turns out nothing happened in the testsuite, but playing in the toplevel I noticed that we go from:
```
# let f (x : int) = match x with { contents = 3 } -> ();;
Characters 31-47:
  let f (x : int) = match x with { contents = 3 } -> ();;
                                 ^^^^^^^^^^^^^^^^
Error: This pattern matches values of type int ref
       but a pattern was expected which matches values of type int
```
to
```
# let f (x : int) = match x with { contents = 3 } -> ();;
Characters 31-47:
  let f (x : int) = match x with { contents = 3 } -> ();;
                                 ^^^^^^^^^^^^^^^^
Error: This pattern matches values of type 'a ref
       but a pattern was expected which matches values of type int
```
which seems slightly worse.

This GPR adds that test to the testsuite.