### PR TITLE
Document that -safe-string is the default, -unsafe-string is not.

### DIFF
--- a/man/ocaml.m
+++ b/man/ocaml.m
@@ -170,8 +170,7 @@ are supported.
 .B \-safe\-string
 Enforce the separation between types
 .BR string \ and\  bytes ,
-thereby making strings read-only. This will become the default in
-a future version of OCaml.
+thereby making strings read-only. This is the default.
 .TP
 .B \-short\-paths
 When a type is visible under several module-paths, use the shortest
@@ -207,9 +206,9 @@ accesses an array or string outside of its bounds.
 .B \-unsafe\-string
 Identify the types
 .BR string \ and\  bytes ,
-thereby making strings writable. For reasons of backward compatibility,
-this is the default setting for the moment, but this will change in a future
-version of OCaml.
+thereby making strings writable.
+This is intended for compatibility with old source code and should not
+be used with new software.
 .TP
 .B \-version
 Print version string and exit.

--- a/man/ocamlc.m
+++ b/man/ocamlc.m
@@ -618,8 +618,7 @@ suffix is supported and gives a debug version of the runtime.
 .B \-safe\-string
 Enforce the separation between types
 .BR string \ and\  bytes ,
-thereby making strings read-only. This will become the default in
-a future version of OCaml.
+thereby making strings read-only. This is the default.
 .TP
 .B \-short\-paths
 When a type is visible under several module-paths, use the shortest
@@ -652,9 +651,9 @@ accesses an array or string outside of its bounds.
 .B \-unsafe\-string
 Identify the types
 .BR string \ and\  bytes ,
-thereby making strings writable. For reasons of backward compatibility,
-this is the default setting for the moment, but this will change in a future
-version of OCaml.
+thereby making strings writable.
+This is intended for compatibility with old source code and should not
+be used with new software.
 .TP
 .BI \-use\-runtime \ runtime\-name
 Generate a bytecode executable file that can be executed on the custom

--- a/man/ocamlopt.m
+++ b/man/ocamlopt.m
@@ -567,8 +567,7 @@ is saved in the file
 .B \-safe\-string
 Enforce the separation between types
 .BR string \ and\  bytes ,
-thereby making strings read-only. This will become the default in
-a future version of OCaml.
+thereby making strings read-only. This is the default.
 .TP
 .B \-shared
 Build a plugin (usually .cmxs) that can be dynamically loaded with
@@ -626,9 +625,9 @@ exception.
 .B \-unsafe\-string
 Identify the types
 .BR string \ and\  bytes ,
-thereby making strings writable. For reasons of backward compatibility,
-this is the default setting for the moment, but this will change in a future
-version of OCaml.
+thereby making strings writable.
+This is intended for compatibility with old source code and should not
+be used with new software.
 .TP
 .B \-v
 Print the version number of the compiler and the location of the

--- a/manual/manual/cmds/unified-options.etex
+++ b/manual/manual/cmds/unified-options.etex
@@ -619,8 +619,7 @@ Linux AMD 64, they must contain only position-independent code).
 
 \item["-safe-string"]
 Enforce the separation between types "string" and "bytes",
-thereby making strings read-only. This will become the default in
-a future version of OCaml.
+thereby making strings read-only. This is the default.
 
 \item["-short-paths"]
 When a type is visible under several module-paths, use the shortest
@@ -669,10 +668,9 @@ unspecified result instead of raising a "Division_by_zero" exception.
 }%notop
 
 \item["-unsafe-string"]
-Identify the types "string" and "bytes",
-thereby making strings writable. For reasons of backward compatibility,
-this is the default setting for the moment, but this will change in a future
-version of OCaml.
+Identify the types "string" and "bytes", thereby making strings writable.
+This is intended for compatibility with old source code and should not
+be used with new software.
 
 \comp{%
 \item["-use-runtime" \var{runtime-name}]


### PR DESCRIPTION
Note that -safe-string is the default, as it has been since 4.06.
Similarly, remove the annotation that -unsafe-string is the default.