### PR TITLE
Make the character set for OCaml source code officially UTF-8.

### DIFF
--- a/Changes
+++ b/Changes
@@ -64,6 +64,11 @@ Working version
 - GPR#1822: keep attributes attached to pattern variables from being discarded.
   (Nicolás Ojeda Bär, review by Thomas Refis)
 
+- GPR#1802: OCaml source files are now officially UTF-8, Latin-1
+  identifiers etc. are no longer supported.
+  (Perry E. Metzger)
+
+
 ### Code generation and optimizations:
 
 - MPR#7725, GPR#1754: improve AFL instrumentation for objects and lazy values
@@ -91,6 +96,9 @@ Working version
 
 - GPR#1788: move the quoted string description to the main chapters
   (Florian Angeletti, review by Xavier Clerc and Perry E. Metzger)
+
+- GPR#1802: Explain that OCaml source files are now officially UTF-8
+  (Perry E. Metzger)
 
 ### Compiler distribution build system:
 

--- a/manual/manual/refman/lex.etex
+++ b/manual/manual/refman/lex.etex
@@ -1,6 +1,13 @@
 \section{Lexical conventions}
 \pdfsection{Lexical conventions}
 %HEVEA\cutname{lex.html}
+\subsubsection*{Character set}
+
+The character set of OCaml source code files is Unicode, encoded as
+UTF-8. However, codepoints outside of the ASCII character set are
+only permitted inside comments and string literals. (Non-ASCII
+characters are not legal in character literals.)
+
 \subsubsection*{Blanks}
 
 The following characters are considered as blanks: space,
@@ -30,12 +37,8 @@ letter: "A" \ldots "Z" || "a" \ldots "z"
 Identifiers are sequences of letters, digits, "_" (the underscore
 character), and "'" (the single quote), starting with a
 letter or an underscore.
-Letters contain at least the 52 lowercase and uppercase
-letters from the ASCII set. The current implementation
-also recognizes as letters some characters from the ISO
-8859-1 set (characters 192--214 and 216--222 as uppercase letters;
-characters 223--246 and 248--255 as lowercase letters). This
-feature is deprecated and should be avoided for future compatibility.
+Letters consist of the 52 lowercase and uppercase
+letters from the ASCII character set.
 
 All characters in an identifier are
 meaningful. The current implementation accepts identifiers up to


### PR DESCRIPTION
By doing this, editors and other tools can presume that UTF-8 is the encoding to use for OCaml source. I think this is an idea whose time has come. Latin-1 identifiers have now been deprecated with a warning for many years.

Note: I've made the `Changes` entry assuming this would _NOT_ be a candidate for 4.07.

1. lexer.mll: change to no longer recognize latin-1 in identifiers and the like. Previously this was accepted with a warning. UTF-8 encoding conflicts with Latin-1.
2. lexer.mll: changes to validate that the file is valid UTF-8. This is done by recognizing a regular expression for valid UTF-8 characters in comments, strings, and quoted strings, and by assuring that character literals do not have a literal character with its eighth bit set.
3. lex.etex: change documentation to state explicitly that the character set for source code is Unicode/UTF-8, but that only ASCII codepoints are permitted in source except for comments and string literals. Also note that character literals can't contain non-ASCII. Note in the identifier syntax that letters mean ASCII letters.
4. Changes: Note the above has happened.

Note that this set of changes is a strawman. I would like to know people's opinions on how to do this and which parts should be done which way.

Each of the following question is followed by the likely available options for answers, and I'd appreciate hearing what people prefer:

1. Should we be specifying UTF-8 as the encoding of OCaml source code files going forward? (Yes/No?)
2. If (1) is yes, should we actually check that the files are valid UTF-8 and warn or error if not? If we check, should it be a warning or an error? (Don't Check/Warn/Error?)
3. If (1) is yes, should we follow up the deprecation of Latin-1 identifier codepoints in 4.01 (that is, bare eighth bit set characters intended to be interpreted as ISO/IEC 8859-1) with removing them as valid in the lexer? (Remove/Leave the current deprecation warning?)
4. If (3) is yes, should we change the regular expression for identifiers to accept Latin-1 letters encoded as UTF-8? (Yes/No?)

