### PR TITLE
make string_of_float and float_of_string locale-independent

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,10 @@ Working version
 
 ### Standard library:
 
+- MPR#6701, GPR#1185, GPR#1803: make float_of_string and string_of_float
+  locale-independent
+  (ygrek, review by Xavier Leroy and Damien Doligez)
+
 - GPR#1590: ocamllex-generated lexers can be instructed not to update
   their lex_curr_p/lex_start_p fields, resulting in a significant
   performance gain when those fields are not required

--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -127,6 +127,7 @@ value caml_startup_common(char_os **argv, int pooling)
 #endif
   caml_init_frame_descriptors();
   caml_init_ieee_floats();
+  caml_init_locale();
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();
 #endif

--- a/byterun/caml/config.h
+++ b/byterun/caml/config.h
@@ -31,6 +31,10 @@
 
 #include <stddef.h>
 
+#if defined(HAS_LOCALE_H) || defined(HAS_XLOCALE_H)
+#define HAS_LOCALE
+#endif
+
 #ifdef HAS_STDINT_H
 #include <stdint.h>
 #endif

--- a/byterun/caml/startup_aux.h
+++ b/byterun/caml/startup_aux.h
@@ -20,6 +20,9 @@
 
 #include "config.h"
 
+extern void caml_init_locale(void);
+extern void caml_free_locale(void);
+
 extern void caml_init_atom_table (void);
 
 extern uintnat caml_init_percent_free;

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -40,6 +40,19 @@
 
 #ifdef HAS_LOCALE
 #include <locale.h>
+
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#ifndef locale_t
+#define locale_t _locale_t
+#endif
+#ifndef freelocale
+#define freelocale _free_locale
+#endif
+#ifndef strtod_l
+#define strtod_l _strtod_l
+#endif
+#endif
+
 #endif
 
 #ifdef _MSC_VER
@@ -82,24 +95,21 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
  third-party code loaded into process does.
 */
 #ifdef HAS_LOCALE
-
-#ifdef _MSC_VER
-
-#ifndef locale_t
-#define locale_t _locale_t
-#endif
-
-#ifndef freelocale
-#define freelocale _free_locale
-#endif
-
-#ifndef strtod_l
-#define strtod_l _strtod_l
-#endif
-
-#endif
-
 locale_t caml_locale = (locale_t)0;
+
+#if defined(_MSC_VER) || defined(__MINGW32__)
+/* there is no analogue to uselocale in MSVC so just set locale for thread */
+#define USE_LOCALE setlocale(LC_NUMERIC,"C")
+#define RESTORE_LOCALE do {} while(0)
+#else
+#define USE_LOCALE locale_t saved_locale = uselocale(caml_locale)
+#define RESTORE_LOCALE uselocale(saved_locale)
+#endif
+
+#else
+
+#define USE_LOCALE do {} while(0)
+#define RESTORE_LOCALE do {} while(0)
 
 #endif
 
@@ -108,7 +118,7 @@ void caml_init_locale(void)
 #ifdef HAS_LOCALE
   if ((locale_t)0 == caml_locale)
   {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
     _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
     caml_locale = _create_locale(LC_NUMERIC, "C");
 #else
@@ -159,20 +169,9 @@ CAMLprim value caml_format_float(value fmt, value arg)
 #ifdef HAS_BROKEN_PRINTF
   if (isfinite(d)) {
 #endif
-#ifdef HAS_LOCALE
-#ifdef _MSC_VER
-    /* there is no analogue to uselocale in MSVC so just set locale for thread */
-    setlocale(LC_NUMERIC,"C");
-#else
-    locale_t saved_locale = uselocale(caml_locale);
-#endif
-#endif
+    USE_LOCALE;
     res = caml_alloc_sprintf(String_val(fmt), d);
-#ifdef HAS_LOCALE
-#ifndef _MSC_VER
-    uselocale(saved_locale);
-#endif
-#endif
+    RESTORE_LOCALE;
 #ifdef HAS_BROKEN_PRINTF
   } else {
     if (isnan(d)) {
@@ -397,20 +396,10 @@ CAMLprim value caml_float_of_string(value vs)
 #if defined(HAS_STRTOD_L) && defined(HAS_LOCALE)
   d = strtod_l((const char *) buf, &end, caml_locale);
 #else
-#ifdef HAS_LOCALE
-#ifdef _MSC_VER
-  setlocale(LC_NUMERIC,"C");
-#else
-  locale_t saved_locale = uselocale(caml_locale);
-#endif
-#endif
+  USE_LOCALE;
   /* Convert using strtod */
   d = strtod((const char *) buf, &end);
-#ifdef HAS_LOCALE
-#ifndef _MSC_VER
-  uselocale(saved_locale);
-#endif
-#endif
+  RESTORE_LOCALE;
 #endif /* HAS_STRTOD_L */
   if (end != dst) goto error;
   if (buf != parse_buffer) caml_stat_free(buf);

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -82,7 +82,25 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
  thirt-party code loaded into process does.
 */
 #ifdef HAS_LOCALE
+
+#ifdef _MSC_VER
+
+#ifndef locale_t
+#define locale_t _locale_t
+#endif
+
+#ifndef freelocale
+#define freelocale _free_locale
+#endif
+
+#ifndef strtod_l
+#define strtod_l _strtod_l
+#endif
+
+#endif
+
 locale_t caml_locale = 0;
+
 #endif
 
 void caml_init_locale(void)
@@ -90,8 +108,13 @@ void caml_init_locale(void)
 #ifdef HAS_LOCALE
   if (0 == caml_locale)
   {
+#ifdef _MSC_VER
+    _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+    caml_locale = _create_locale(LC_NUMERIC, "C");
+#else
     caml_locale = duplocale(LC_GLOBAL_LOCALE);
     caml_locale = newlocale(LC_NUMERIC_MASK,"C",caml_locale);
+#endif
   }
 #endif
 }
@@ -138,11 +161,18 @@ CAMLprim value caml_format_float(value fmt, value arg)
   if (isfinite(d)) {
 #endif
 #ifdef HAS_LOCALE
+#ifdef _MSC_VER
+    /* there is no analogue to uselocale in MSVC so just set locale for thread */
+    setlocale(LC_NUMERIC,"C");
+#else
     locale_t saved_locale = uselocale(caml_locale);
+#endif
 #endif
     res = caml_alloc_sprintf(String_val(fmt), d);
 #ifdef HAS_LOCALE
+#ifndef _MSC_VER
     uselocale(saved_locale);
+#endif
 #endif
 #ifdef HAS_BROKEN_PRINTF
   } else {
@@ -365,16 +395,22 @@ CAMLprim value caml_float_of_string(value vs)
   }
   *dst = 0;
   if (dst == buf) goto error;
-#ifdef HAS_STRTOD_L
+#if defined(HAS_STRTOD_L) && defined(HAS_LOCALE)
   d = strtod_l((const char *) buf, &end, caml_locale);
 #else
 #ifdef HAS_LOCALE
+#ifdef _MSC_VER
+  setlocale(LC_NUMERIC,"C");
+#else
   locale_t saved_locale = uselocale(caml_locale);
+#endif
 #endif
   /* Convert using strtod */
   d = strtod((const char *) buf, &end);
 #ifdef HAS_LOCALE
+#ifndef _MSC_VER
   uselocale(saved_locale);
+#endif
 #endif
 #endif /* HAS_STRTOD_L */
   if (end != dst) goto error;

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -39,7 +39,14 @@
 #include "caml/stacks.h"
 
 #if defined(HAS_LOCALE) || defined(__MINGW32__)
+
+#if defined(HAS_LOCALE_H) || defined(__MINGW32__)
 #include <locale.h>
+#endif
+
+#if defined(HAS_XLOCALE_H)
+#include <xlocale.h>
+#endif
 
 #if defined(_MSC_VER)
 #ifndef locale_t
@@ -53,7 +60,7 @@
 #endif
 #endif
 
-#endif
+#endif /* defined(HAS_LOCALE) */
 
 #ifdef _MSC_VER
 #include <float.h>

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -79,7 +79,7 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
 /*
  OCaml runtime itself doesn't call setlocale, i.e. it is using
  standard "C" locale by default, but it is possible that
- thirt-party code loaded into process does.
+ third-party code loaded into process does.
 */
 #ifdef HAS_LOCALE
 
@@ -99,21 +99,20 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
 
 #endif
 
-locale_t caml_locale = 0;
+locale_t caml_locale = (locale_t)0;
 
 #endif
 
 void caml_init_locale(void)
 {
 #ifdef HAS_LOCALE
-  if (0 == caml_locale)
+  if ((locale_t)0 == caml_locale)
   {
 #ifdef _MSC_VER
     _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
     caml_locale = _create_locale(LC_NUMERIC, "C");
 #else
-    caml_locale = duplocale(LC_GLOBAL_LOCALE);
-    caml_locale = newlocale(LC_NUMERIC_MASK,"C",caml_locale);
+    caml_locale = newlocale(LC_NUMERIC_MASK,"C",(locale_t)0);
 #endif
   }
 #endif
@@ -122,8 +121,8 @@ void caml_init_locale(void)
 void caml_free_locale(void)
 {
 #ifdef HAS_LOCALE
-  if (0 != caml_locale) freelocale(caml_locale);
-  caml_locale = 0;
+  if ((locale_t)0 != caml_locale) freelocale(caml_locale);
+  caml_locale = (locale_t)0;
 #endif
 }
 

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -38,10 +38,10 @@
 #include "caml/reverse.h"
 #include "caml/stacks.h"
 
-#ifdef HAS_LOCALE
+#if defined(HAS_LOCALE) || defined(__MINGW32__)
 #include <locale.h>
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(_MSC_VER)
 #ifndef locale_t
 #define locale_t _locale_t
 #endif
@@ -96,30 +96,29 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
 */
 #ifdef HAS_LOCALE
 locale_t caml_locale = (locale_t)0;
+#endif
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 /* there is no analogue to uselocale in MSVC so just set locale for thread */
 #define USE_LOCALE setlocale(LC_NUMERIC,"C")
 #define RESTORE_LOCALE do {} while(0)
-#else
+#elif defined(HAS_LOCALE)
 #define USE_LOCALE locale_t saved_locale = uselocale(caml_locale)
 #define RESTORE_LOCALE uselocale(saved_locale)
-#endif
-
 #else
-
 #define USE_LOCALE do {} while(0)
 #define RESTORE_LOCALE do {} while(0)
-
 #endif
 
 void caml_init_locale(void)
 {
+#if defined(_MSC_VER) || defined(__MINGW32__)
+  _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+#endif
 #ifdef HAS_LOCALE
   if ((locale_t)0 == caml_locale)
   {
-#if defined(_MSC_VER) || defined(__MINGW32__)
-    _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+#if defined(_MSC_VER)
     caml_locale = _create_locale(LC_NUMERIC, "C");
 #else
     caml_locale = newlocale(LC_NUMERIC_MASK,"C",(locale_t)0);

--- a/byterun/startup.c
+++ b/byterun/startup.c
@@ -346,6 +346,7 @@ CAMLexport void caml_main(char_os **argv)
   /* Machine-dependent initialization of the floating-point hardware
      so that it behaves as much as possible as specified in IEEE */
   caml_init_ieee_floats();
+  caml_init_locale();
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();
 #endif
@@ -478,6 +479,7 @@ CAMLexport value caml_startup_code_exn(
     return Val_unit;
 
   caml_init_ieee_floats();
+  caml_init_locale();
 #if defined(_MSC_VER) && __STDC_SECURE_LIB__ >= 200411L
   caml_install_invalid_parameter_handler();
 #endif

--- a/byterun/startup_aux.c
+++ b/byterun/startup_aux.c
@@ -159,6 +159,7 @@ CAMLexport void caml_shutdown(void)
   call_registered_value("Pervasives.do_at_exit");
   call_registered_value("Thread.at_shutdown");
   caml_finalise_heap();
+  caml_free_locale();
 #ifndef NATIVE_CODE
   caml_free_shared_libs();
 #endif

--- a/config/s-nt.h
+++ b/config/s-nt.h
@@ -29,8 +29,10 @@
 #define HAS_GETHOSTNAME
 #define HAS_MKTIME
 #define HAS_PUTENV
+#ifndef __MINGW32__
 #define HAS_LOCALE
 #define HAS_STRTOD_L
+#endif
 #define HAS_BROKEN_PRINTF
 #define HAS_IPV6
 #define HAS_NICE

--- a/config/s-nt.h
+++ b/config/s-nt.h
@@ -30,7 +30,7 @@
 #define HAS_MKTIME
 #define HAS_PUTENV
 #ifndef __MINGW32__
-#define HAS_LOCALE
+#define HAS_LOCALE_H
 #define HAS_STRTOD_L
 #endif
 #define HAS_BROKEN_PRINTF

--- a/config/s-nt.h
+++ b/config/s-nt.h
@@ -30,6 +30,7 @@
 #define HAS_MKTIME
 #define HAS_PUTENV
 #define HAS_LOCALE
+#define HAS_STRTOD_L
 #define HAS_BROKEN_PRINTF
 #define HAS_IPV6
 #define HAS_NICE

--- a/config/s-templ.h
+++ b/config/s-templ.h
@@ -188,7 +188,11 @@
 #define HAS_LOCALE
 
 /* Define HAS_LOCALE if you have the include file <locale.h> and the
-   setlocale() function. */
+   uselocale() function. */
+
+#define HAS_STRTOD_L
+
+/* Define HAS_STRTOD_L if you have strtod_l */
 
 #define HAS_MMAP
 

--- a/config/s-templ.h
+++ b/config/s-templ.h
@@ -185,9 +185,14 @@
 
 /* Define HAS_PUTENV if you have putenv(). */
 
-#define HAS_LOCALE
+#define HAS_LOCALE_H
 
-/* Define HAS_LOCALE if you have the include file <locale.h> and the
+/* Define HAS_LOCALE_H if you have the include file <locale.h> and the
+   uselocale() function. */
+
+#define HAS_XLOCALE_H
+
+/* Define HAS_XLOCALE_H if you have the include file <xlocale.h> and the
    uselocale() function. */
 
 #define HAS_STRTOD_L

--- a/configure
+++ b/configure
@@ -1485,7 +1485,12 @@ fi
 
 if sh ./hasgot -i locale.h && sh ./hasgot newlocale freelocale uselocale; then
   inf "newlocale() and <locale.h> found."
-  echo "#define HAS_LOCALE" >> s.h
+  echo "#define HAS_LOCALE_H" >> s.h
+fi
+
+if sh ./hasgot -i xlocale.h && sh ./hasgot newlocale freelocale uselocale; then
+  inf "newlocale() and <xlocale.h> found."
+  echo "#define HAS_XLOCALE_H" >> s.h
 fi
 
 if sh ./hasgot strtod_l; then

--- a/configure
+++ b/configure
@@ -1483,7 +1483,7 @@ if sh ./hasgot putenv; then
   echo "#define HAS_PUTENV" >> s.h
 fi
 
-if sh ./hasgot -i locale.h && sh ./hasgot newlocale duplocale freelocale uselocale; then
+if sh ./hasgot -i locale.h && sh ./hasgot newlocale freelocale uselocale; then
   inf "newlocale() and <locale.h> found."
   echo "#define HAS_LOCALE" >> s.h
 fi

--- a/configure
+++ b/configure
@@ -1483,9 +1483,14 @@ if sh ./hasgot putenv; then
   echo "#define HAS_PUTENV" >> s.h
 fi
 
-if sh ./hasgot -i locale.h && sh ./hasgot setlocale; then
-  inf "setlocale() and <locale.h> found."
+if sh ./hasgot -i locale.h && sh ./hasgot newlocale duplocale freelocale uselocale; then
+  inf "newlocale() and <locale.h> found."
   echo "#define HAS_LOCALE" >> s.h
+fi
+
+if sh ./hasgot strtod_l; then
+  inf "strtod_l() found."
+  echo "#define HAS_STRTOD_L" >> s.h
 fi
 
 

--- a/testsuite/tests/locale/Makefile
+++ b/testsuite/tests/locale/Makefile
@@ -1,0 +1,9 @@
+BASEDIR=../..
+MODULES=
+MAIN_MODULE=test
+C_FILES=stubs
+
+include $(BASEDIR)/makefiles/Makefile.one
+include $(BASEDIR)/makefiles/Makefile.common
+
+NATIVECODE_ONLY=true

--- a/testsuite/tests/locale/Makefile
+++ b/testsuite/tests/locale/Makefile
@@ -5,5 +5,3 @@ C_FILES=stubs
 
 include $(BASEDIR)/makefiles/Makefile.one
 include $(BASEDIR)/makefiles/Makefile.common
-
-NATIVECODE_ONLY=true

--- a/testsuite/tests/locale/stubs.c
+++ b/testsuite/tests/locale/stubs.c
@@ -1,0 +1,8 @@
+#include <caml/mlvalues.h>
+#include <locale.h>
+
+value ml_setlocale(value v_locale)
+{
+  setlocale(LC_ALL,String_val(v_locale));
+  return Val_unit;
+}

--- a/testsuite/tests/locale/test.ml
+++ b/testsuite/tests/locale/test.ml
@@ -1,0 +1,24 @@
+
+external setlocale : string -> unit = "ml_setlocale"
+
+let show f = try string_of_float @@ f () with exn -> Printf.sprintf "exn %s" (Printexc.to_string exn)
+let pr fmt = Printf.ksprintf print_endline fmt
+
+let () =
+  let s = "12345.6789" in
+  let f = 1.23 in
+  let test () =
+    pr "  print 1.23 : %s" (show @@ fun () -> f);
+    pr "  parse %S : %s" s (show @@ fun () -> float_of_string s);
+    pr "  roundtrip 1.23 : %s" (show @@ fun () -> float_of_string @@ string_of_float f);
+  in
+  pr "locale from environment";
+  setlocale "";
+  test ();
+  pr "locale nl_NL";
+  setlocale "nl_NL";
+  test ();
+  pr "locale POSIX";
+  setlocale "C";
+  test ();
+  ()

--- a/testsuite/tests/locale/test.reference
+++ b/testsuite/tests/locale/test.reference
@@ -1,0 +1,12 @@
+locale from environment
+  print 1.23 : 1.23
+  parse "12345.6789" : 12345.6789
+  roundtrip 1.23 : 1.23
+locale nl_NL
+  print 1.23 : 1.23
+  parse "12345.6789" : 12345.6789
+  roundtrip 1.23 : 1.23
+locale POSIX
+  print 1.23 : 1.23
+  parse "12345.6789" : 12345.6789
+  roundtrip 1.23 : 1.23


### PR DESCRIPTION
(previously known as #1185 and #1682)

@damiendoligez I implemented your suggestion as in 
https://github.com/ocaml/ocaml/pull/1682#issuecomment-377524854
except it includes both xlocale.h and locale.h if they are available (should be more robust this way)

Tested only on linux, counting on CI to test on other platforms