### PR TITLE
Fix the bootstrap procedure and its documentation

### DIFF
--- a/BOOTSTRAP.adoc
+++ b/BOOTSTRAP.adoc
@@ -1,0 +1,58 @@
+= Bootstrapping the compiler
+
+This file explains how to bootstrap the OCaml compiler, i.e. how to
+update the binaries in the link:boot/[] directory.
+
+A bootstrap is required for example when something changes in the
+runtime system (the magic number of bytecode executables, the format of
+bytecode instructions, the set of available primitives) or when the
+format of .cmi files is modified. In particular, given that the .cmi
+files contain information related to types, modifying the way a type is
+represented will modify the format of .cmi files and thus require a
+bootstrap.
+
+Here is how to perform a change that requires a bootstrap:
+
+1. Make sure you start with a clean source tree (e.g. check with
+   `git status`)
+
+2. Configure your source tree by running:
+
+        ./configure
+
+3. Bring your system to a stable state. Concretely, this means that the
+   boot/ directory should contain a version of ocamlrun and all the
+   \*.cm* files of the standard library. This stable state can be reached
+   by running
+
+        make world
++
+(Actually, running `make coldstart` should be enough but `make world` is
+safer. Similarly, `make world.opt` will also bring you to such a stable
+state but builds more things than actually required.)
+
+4. Now, and only now, edit the sources. Changes here may include adding,
+   removing or renaming a primitive in the runtime, changing the magic
+   number of bytecode executable files, changing the way types are
+   represented or anything else in the format of .cmi files, etc.
+
+5. Run:
+
+        make coreall
++
+This will rebuild byterun/ocamlrun, ocamlc, etc.
+
+6. (optional) The new system can now be tested:
+
+        echo 'let _ = print_string "Hello world!\n"' > foo.ml
+        ./boot/ocamlrun ./ocamlc -I ./stdlib foo.ml
+        ./byterun/ocamlrun a.out
+
+7. We now know the system works and can thus build the new boot/
+   binaries:
+
+        make bootstrap
+
+If you notice that this procedure fails for a given change you are
+trying to implement, please report it so that the procedure can be
+updated to also cope with your change.

--- a/Changes
+++ b/Changes
@@ -92,6 +92,10 @@ Working version
 - GPR#1797: remove the deprecated Makefile.nt files
   (Sébastien Hinderer, review by Nicolas Ojeda Bar)  
 
+- GPR#1805: fix the bootstrap procedure and its documentation
+  (Sébastien Hinderer, Xavier Leroy and Damien Doligez; review by
+  Gabriel Scherer)
+
 ### Internal/compiler-libs changes:
 
 - GPR#1745: do not generalize the type of every sub-pattern, only of variables

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -157,13 +157,14 @@ has excellent documentation.
 
 === Complete file listing
 
+  BOOTSTRAP.adoc::        instructions for bootstrapping
   Changes::               what's new with each release
-  configure::             configure script
   CONTRIBUTING.md::       how to contribute to OCaml
   HACKING.adoc::          this file
   INSTALL.adoc::          instructions for installation
   LICENSE::               license and copyright notice
   Makefile::              main Makefile
+  Makefile.common::       common Makefile definitions
   Makefile.tools::        used by manual/ and testsuite/ Makefiles
   README.adoc::           general information on the compiler distribution
   README.win32.adoc::     general information on the Windows ports of OCaml
@@ -175,6 +176,7 @@ has excellent documentation.
   byterun/::              bytecode interpreter and runtime system
   compilerlibs/::         the OCaml compiler as a library
   config/::               configuration files
+  configure::             configure script
   debugger/::             source-level replay debugger
   driver/::               driver code for the compilers
   emacs/::                editing mode and debugger interface for GNU Emacs
@@ -185,6 +187,7 @@ has excellent documentation.
   manual/::               system to generate the manual
   middle_end/::           the flambda optimisation phase
   ocamldoc/::             documentation generator
+  ocamltest/::            test driver
   otherlibs/::            several additional libraries
   parsing/::              syntax analysis -- see link:parsing/HACKING.adoc[]
   stdlib/::               standard library
@@ -223,12 +226,12 @@ installation, the following targets may be of use:
 === Bootstrapping
 
 The OCaml compiler is bootstrapped. This means that
-previously-compiled bytecode versions of the compiler, dependency
-generator and lexer are included in the repository under the
+previously-compiled bytecode versions of the compiler and lexer are
+included in the repository under the
 link:boot/[] directory. These bytecode images are used once the
 bytecode runtime (which is written in C) has been built to compile the
 standard library and then to build a fresh compiler. Details can be
-found in link:INSTALL.adoc#bootstrap[INSTALL.adoc].
+found in link:BOOTSTRAP.adoc[].
 
 === Continuous integration
 

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -213,25 +213,10 @@ fairly verbose; consider redirecting the output to a file:
         make world > log.world 2>&1     # in sh
         make world >& log.world         # in csh
 
-[[bootstrap]]
-3. (Optional) To be sure everything works well, you can try to bootstrap the
-   system -- that is, to recompile all OCaml sources with the newly created
-   compiler. From the top directory, do:
+3. (Optional) To be sure everything works well, you can run the test suite
+   that comes with the compiler. To do so, do:
 
-        make bootstrap
-+
-or, better:
-
-        make bootstrap > log.bootstrap 2>&1     # in sh
-        make bootstrap >& log.bootstrap         # in csh
-+
-The `make bootstrap` checks that the bytecode programs compiled with the new
-compiler are identical to the bytecode programs compiled with the old compiler.
-If this is the case, you can be pretty sure the system has been correctly
-compiled. Otherwise, this does not necessarily mean something went wrong.  The
-best thing to do is to try a second bootstrapping phase: just do
-`make bootstrap` again.  It will either crash almost immediately, or
-re-re-compile everything correctly and reach the fix-point.
+        make tests
 
 4. You can now install the OCaml system. This will create the following commands
    (in the binary directory selected during autoconfiguration):

--- a/Makefile
+++ b/Makefile
@@ -1308,7 +1308,7 @@ toplevel/opttoploop.cmx: otherlibs/dynlink/dynlink.cmxa
 # The numeric opcodes
 
 bytecomp/opcodes.ml: byterun/caml/instruct.h tools/make_opcodes
-	$(CAMLRUN) tools/make_opcodes -opcodes < $< > $@
+	byterun/ocamlrun tools/make_opcodes -opcodes < $< > $@
 
 tools/make_opcodes: tools/make_opcodes.mll
 	$(MAKE) -C tools make_opcodes

--- a/Makefile
+++ b/Makefile
@@ -15,21 +15,6 @@
 
 # The main Makefile
 
-# Hard bootstrap how-to:
-# (only necessary if you remove or rename some primitive)
-#
-# make core     [old system -- you were in a stable state]
-# make coreboot [optional -- check state stability]
-# <add new primitives and remove uses of old primitives>
-# make clean && make core
-# if the above fails:
-#     <debug your changes>
-#     make clean && make core
-# make coreboot [intermediate state with both old and new primitives]
-# <remove old primitives>
-# make clean && make runtime && make coreall
-# make coreboot [new system -- now in a stable state]
-
 include config/Makefile
 include Makefile.common
 

--- a/Makefile
+++ b/Makefile
@@ -434,19 +434,27 @@ compare:
 	else echo "Fixpoint not reached, try one more bootstrapping cycle."; \
 	fi
 
+# Promote a compiler
+
+PROMOTE ?= cp
+
+.PHONY: promote-common
+promote-common:
+	$(PROMOTE) ocamlc boot/ocamlc
+	$(PROMOTE) lex/ocamllex boot/ocamllex
+	cp yacc/ocamlyacc$(EXE) boot/ocamlyacc$(EXE)
+	cd stdlib; cp $(LIBFILES) ../boot
+
 # Promote the newly compiled system to the rank of cross compiler
 # (Runs on the old runtime, produces code for the new runtime)
 .PHONY: promote-cross
-promote-cross:
-	$(CAMLRUN) tools/stripdebug ocamlc boot/ocamlc
-	$(CAMLRUN) tools/stripdebug lex/ocamllex boot/ocamllex
-	cp yacc/ocamlyacc$(EXE) boot/ocamlyacc$(EXE)
-	cd stdlib; cp $(LIBFILES) ../boot
+promote-cross: promote-common
 
 # Promote the newly compiled system to the rank of bootstrap compiler
 # (Runs on the new runtime, produces code for the new runtime)
 .PHONY: promote
-promote: promote-cross
+promote: PROMOTE = $(CAMLRUN) tools/stripdebug
+promote: promote-common
 	cp byterun/ocamlrun$(EXE) boot/ocamlrun$(EXE)
 
 # Remove old bootstrap compilers

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -314,7 +314,7 @@ make_opcodes: make_opcodes.ml
 	$(CAMLC) make_opcodes.ml -o $@
 
 opnames.ml: ../byterun/caml/instruct.h make_opcodes
-	$(CAMLRUN) make_opcodes -opnames < $< > $@
+	../byterun/ocamlrun make_opcodes -opnames < $< > $@
 
 clean::
 	rm -f opnames.ml make_opcodes make_opcodes.ml


### PR DESCRIPTION
As mentionned in the Changes entry, this is joint work with @xavierleroy
and @damiendoligez.

TL+DR: the bootstrap procedure was broken and this PR fixes it

Therer were two main issues:

 1. stripdebug can actually not be used by the promote-cross target
    so this PR uses cp instead. Since stripdebug can be used by the
    promote target, which is called later than promote-cross during
    the bootstrap, the final executables will still be stripped of
    their debugging symbols.

 2. The make_opcodes tool was run on the wrong runtime during
    the bootstrap, which this PR also fixes.

In addition, the PR also contains a bit of makefile cleanup and
simplification and updates the documentation to make it reflect the current
state of affairs. This documentation update includes removing the
"Hard bootstrap how-to" that appeared at the beginning of the root
Makefile and moving the bootstrap-related explanations from INSTALL.adoc to
HACKING.adoc. Finally, INSTALL.adoc has been updated to suggest
running the testsuite rather than bootstrapping.