### PR TITLE
Simplify calls to `caml_int_compare` (and similar functions)

### DIFF
--- a/Changes
+++ b/Changes
@@ -80,6 +80,9 @@ Working version
 
 ### Code generation and optimizations:
 
+- #1809: rewrite `compare x y op 0` to `x op y` when values are integers
+  (Xavier Clerc, review by Gabriel Scherer and Vincent Laviron)
+
 - #9876: do not cache the young_limit GC variable in a processor register.
   This affects the ARM64, PowerPC and RISC-V ports, making signal handling
   and minor GC triggers more reliable, at the cost of a small slowdown.

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -524,6 +524,64 @@ let rec transl env e =
           tag_int (Cop(Cload (Word_int, Mutable),
             [field_address (transl env b) dim_ofs dbg],
             dbg)) dbg
+      | (Pintcomp _ as comp,
+         [Uprim(Pccall { prim_name = "caml_int_compare"; _ },
+                [arg1; arg2],
+                _);
+          Uconst(Uconst_int 0)]) ->
+          transl env (Uprim (comp, [arg1; arg2], dbg))
+      | (Pintcomp comp,
+         [Uprim(Pccall { prim_name = ("caml_int32_compare"
+                                     | "caml_int32_compare_unboxed"); _ },
+                [arg1; arg2],
+                _);
+          Uconst(Uconst_int 0)]) ->
+          transl env (Uprim (Pbintcomp (Pint32, comp), [arg1; arg2], dbg))
+      | (Pintcomp comp,
+         [Uprim(Pccall { prim_name = ("caml_int64_compare"
+                                     | "caml_int64_compare_unboxed"); _ },
+                [arg1; arg2],
+                _);
+          Uconst(Uconst_int 0)]) ->
+          transl env (Uprim (Pbintcomp (Pint64, comp), [arg1; arg2], dbg))
+      | (Pintcomp comp,
+         [Uprim(Pccall { prim_name = ("caml_nativeint_compare"
+                                     | "caml_nativeint_compare_unboxed"); _ },
+                [arg1; arg2],
+                _);
+          Uconst(Uconst_int 0)]) ->
+          transl env (Uprim (Pbintcomp (Pnativeint, comp), [arg1; arg2], dbg))
+      | (Pintcomp comp,
+         [Uconst(Uconst_int 0);
+          Uprim(Pccall { prim_name = "caml_int_compare"; _ },
+                [arg1; arg2],
+                _)]) ->
+          let comp = Lambda.swap_integer_comparison comp in
+          transl env (Uprim (Pintcomp comp, [arg1; arg2], dbg))
+      | (Pintcomp comp,
+         [Uconst(Uconst_int 0);
+          Uprim(Pccall { prim_name = ("caml_int32_compare"
+                                     | "caml_int32_compare_unboxed"); _ },
+                [arg1; arg2],
+                _)]) ->
+          let comp = Lambda.swap_integer_comparison comp in
+          transl env (Uprim (Pbintcomp (Pint32, comp), [arg1; arg2], dbg))
+      | (Pintcomp comp,
+         [Uconst(Uconst_int 0);
+          Uprim(Pccall { prim_name = ("caml_int64_compare"
+                                     | "caml_int64_compare_unboxed"); _ },
+                [arg1; arg2],
+                _)]) ->
+          let comp = Lambda.swap_integer_comparison comp in
+          transl env (Uprim (Pbintcomp (Pint64, comp), [arg1; arg2], dbg))
+      | (Pintcomp comp,
+         [Uconst(Uconst_int 0);
+          Uprim(Pccall { prim_name = ("caml_nativeint_compare"
+                                     | "caml_nativeint_compare_unboxed"); _ },
+                [arg1; arg2],
+                _)]) ->
+          let comp = Lambda.swap_integer_comparison comp in
+          transl env (Uprim (Pbintcomp (Pnativeint, comp), [arg1; arg2], dbg))
       | (p, [arg]) ->
           transl_prim_1 env p arg dbg
       | (p, [arg1; arg2]) ->

--- a/testsuite/tests/translprim/comparison_optim.ml
+++ b/testsuite/tests/translprim/comparison_optim.ml
@@ -1,0 +1,95 @@
+(* TEST *)
+
+let check_list name list =
+  Printf.printf "testing %S...\n" name;
+    List.iteri
+    (fun i (x, y) ->
+       Printf.printf "  #%d: %s\n"
+         i
+         (if x = y then "OK" else "KO"))
+    list;
+  Printf.printf "\n%!"
+
+let () = check_list "int" [
+  compare 1       2       <= 0, true;
+  compare 3       3       <= 0, true;
+  compare 1       min_int <= 0, false;
+  compare 1       2       <  0, true;
+  compare 3       3       <  0, false;
+  compare 1       min_int <  0, false;
+  compare max_int (-1)    >= 0, true;
+  compare 3       3       >= 0, true;
+  compare 2       min_int >= 0, true;
+  compare max_int (-1)    >  0, true;
+  compare 3       3       >  0, false;
+  compare 2       min_int >  0, true;
+  compare min_int min_int =  0, true;
+  compare max_int max_int =  0, true;
+  compare 1       2       =  0, false;
+  compare min_int min_int <> 0, false;
+  compare max_int max_int <> 0, false;
+  compare 1       2       <> 0, true;
+]
+
+let () = check_list "int32" [
+  compare 1l            2l            <= 0, true;
+  compare 3l            3l            <= 0, true;
+  compare 1l            Int32.min_int <= 0, false;
+  compare 1l            2l            <  0, true;
+  compare 3l            3l            <  0, false;
+  compare 1l            Int32.min_int <  0, false;
+  compare Int32.max_int (-1l)         >= 0, true;
+  compare 3l            3l            >= 0, true;
+  compare 2l            Int32.min_int >= 0, true;
+  compare Int32.max_int (-1l)         >  0, true;
+  compare 3l            3l            >  0, false;
+  compare 2l            Int32.min_int >  0, true;
+  compare Int32.min_int Int32.min_int =  0, true;
+  compare Int32.max_int Int32.max_int =  0, true;
+  compare 1l            2l            =  0, false;
+  compare Int32.min_int Int32.min_int <> 0, false;
+  compare Int32.max_int Int32.max_int <> 0, false;
+  compare 1l            2l            <> 0, true;
+]
+
+let () = check_list "int64" [
+  compare 1L            2L            <= 0, true;
+  compare 3L            3L            <= 0, true;
+  compare 1L            Int64.min_int <= 0, false;
+  compare 1L            2L            <  0, true;
+  compare 3L            3L            <  0, false;
+  compare 1L            Int64.min_int <  0, false;
+  compare Int64.max_int (-1L)         >= 0, true;
+  compare 3L            3L            >= 0, true;
+  compare 2L            Int64.min_int >= 0, true;
+  compare Int64.max_int (-1L)         >  0, true;
+  compare 3L            3L            >  0, false;
+  compare 2L            Int64.min_int >  0, true;
+  compare Int64.min_int Int64.min_int =  0, true;
+  compare Int64.max_int Int64.max_int =  0, true;
+  compare 1L            2L            =  0, false;
+  compare Int64.min_int Int64.min_int <> 0, false;
+  compare Int64.max_int Int64.max_int <> 0, false;
+  compare 1L            2L            <> 0, true;
+]
+
+let () = check_list "nativeint" [
+  compare 1n                2n                <= 0, true;
+  compare 3n                3n                <= 0, true;
+  compare 1n                Nativeint.min_int <= 0, false;
+  compare 1n                2n                <  0, true;
+  compare 3n                3n                <  0, false;
+  compare 1n                Nativeint.min_int <  0, false;
+  compare Nativeint.max_int (-1n)             >= 0, true;
+  compare 3n                3n                >= 0, true;
+  compare 2n                Nativeint.min_int >= 0, true;
+  compare Nativeint.max_int (-1n)             >  0, true;
+  compare 3n                3n                >  0, false;
+  compare 2n                Nativeint.min_int >  0, true;
+  compare Nativeint.min_int Nativeint.min_int =  0, true;
+  compare Nativeint.max_int Nativeint.max_int =  0, true;
+  compare 1n                2n                =  0, false;
+  compare Nativeint.min_int Nativeint.min_int <> 0, false;
+  compare Nativeint.max_int Nativeint.max_int <> 0, false;
+  compare 1n                2n                <> 0, true;
+]

--- a/testsuite/tests/translprim/comparison_optim.reference
+++ b/testsuite/tests/translprim/comparison_optim.reference
@@ -1,0 +1,80 @@
+testing "int"...
+  #0: OK
+  #1: OK
+  #2: OK
+  #3: OK
+  #4: OK
+  #5: OK
+  #6: OK
+  #7: OK
+  #8: OK
+  #9: OK
+  #10: OK
+  #11: OK
+  #12: OK
+  #13: OK
+  #14: OK
+  #15: OK
+  #16: OK
+  #17: OK
+
+testing "int32"...
+  #0: OK
+  #1: OK
+  #2: OK
+  #3: OK
+  #4: OK
+  #5: OK
+  #6: OK
+  #7: OK
+  #8: OK
+  #9: OK
+  #10: OK
+  #11: OK
+  #12: OK
+  #13: OK
+  #14: OK
+  #15: OK
+  #16: OK
+  #17: OK
+
+testing "int64"...
+  #0: OK
+  #1: OK
+  #2: OK
+  #3: OK
+  #4: OK
+  #5: OK
+  #6: OK
+  #7: OK
+  #8: OK
+  #9: OK
+  #10: OK
+  #11: OK
+  #12: OK
+  #13: OK
+  #14: OK
+  #15: OK
+  #16: OK
+  #17: OK
+
+testing "nativeint"...
+  #0: OK
+  #1: OK
+  #2: OK
+  #3: OK
+  #4: OK
+  #5: OK
+  #6: OK
+  #7: OK
+  #8: OK
+  #9: OK
+  #10: OK
+  #11: OK
+  #12: OK
+  #13: OK
+  #14: OK
+  #15: OK
+  #16: OK
+  #17: OK
+


### PR DESCRIPTION
This PR rewrites expressions such as `caml_int_compare x y op 0`
(where op is a comparison operator) to `x op y`. It is useful to support
the following idiom with no performance penalty:

```
let compare x y = ...
let equal x y = compare x y = 0
```

The rewrite happens for `int`, `int32`, `int64` and `nativeint` values,
but not for `float` values as `compare` and the operators disagree
for `float` values.

