### PR TITLE
typedtree: export pat_bound_idents_with_loc

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1736,8 +1736,7 @@ and is_nonexpansive_opt = function
   | Some e -> is_nonexpansive e
 
 let check_recursive_bindings env valbinds =
-  let ids = List.concat
-      (List.map (fun b -> pat_bound_idents b.vb_pat) valbinds) in
+  let ids = let_bound_idents valbinds in
   List.iter
     (fun {vb_expr} ->
        if not (Rec_check.is_valid_recursive_expression ids vb_expr) then

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -586,12 +586,15 @@ let rec bound_idents pat =
       bound_idents p1
   | d -> iter_pattern_desc bound_idents d
 
-let pat_bound_idents pat =
+let pat_bound_idents_with_loc pat =
   idents := [];
   bound_idents pat;
   let res = !idents in
   idents := [];
-  List.map fst res
+  res
+
+let pat_bound_idents pat =
+  List.map fst (pat_bound_idents_with_loc pat)
 
 let rev_let_bound_idents_with_loc bindings =
   idents := [];

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -674,3 +674,4 @@ val mknoloc: 'a -> 'a Asttypes.loc
 val mkloc: 'a -> Location.t -> 'a Asttypes.loc
 
 val pat_bound_idents: pattern -> Ident.t list
+val pat_bound_idents_with_loc: pattern -> (Ident.t * string loc) list


### PR DESCRIPTION
In #1768 I included a commit which deduplicated a function computing the idents bound by a pattern.
I just stumbled on yet another implementation of such a function in merlin (to make matters worse, the one in merlin wasn't even complete!) with a slight twist: we didn't just want the ids, but also the locations.
As it turns out, this function already exists in the compiler, but isn't exported.

The main purpose of this GPR is to export that function: I could simply do the export in merlin and not bother to change the compiler, we already do this for a few functions in a couple of places. But this export has to be redone with every new version of the compiler merlin wants to support, and I don't see any harm in doing the export in the compiler and never having to think about it again in merlin.

Additionally, I noticed that some call to `pat_bound_idents` in `Typecore` was to reimplement another function which was already defined in `Typedtree`, so I removed that duplication too.