### PR TITLE
Remove leftover from GPR#1627

### DIFF
--- a/middle_end/ref_to_variables.ml
+++ b/middle_end/ref_to_variables.ml
@@ -16,9 +16,6 @@
 
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
-  (* Variable.rename var *)
-  (*   ~current_compilation_unit:(Compilation_unit.get_current_exn ()) *)
-
 let variables_not_used_as_local_reference (tree:Flambda.t) =
   let set = ref Variable.Set.empty in
   let rec loop_named (flam : Flambda.named) =


### PR DESCRIPTION
This PR just removes a comment that was related to a piece
of code deleted by [this PR](https://github.com/ocaml/ocaml/pull/1627).