### PR TITLE
Makefiles: consistently offer `allopt` and `opt.opt` targets

### DIFF
--- a/lex/Makefile
+++ b/lex/Makefile
@@ -40,8 +40,10 @@ CAMLDEP=$(CAMLRUN) ../tools/ocamldep
 OBJS=cset.cmo syntax.cmo parser.cmo lexer.cmo table.cmo lexgen.cmo \
      compact.cmo common.cmo output.cmo outputbis.cmo main.cmo
 
+.PHONY: all allopt opt.opt # allopt and opt.opt are synonyms
 all: ocamllex
 allopt: ocamllex.opt
+opt.opt: allopt
 
 ocamllex: $(OBJS)
 	$(CAMLC) $(LINKFLAGS) -compat-32 -o ocamllex $(OBJS)

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -189,8 +189,9 @@ lib: $(OCAMLDOC_LIBCMA) $(OCAMLDOC_LIBCMI) $(ODOC_TEST)
 .PHONY: generators
 generators: $(GENERATORS_CMOS)
 
-.PHONY: opt.opt
+.PHONY: opt.opt allopt # allopt and opt.opt are synonyms
 opt.opt: exeopt libopt generatorsopt
+allopt: opt.opt
 
 .PHONY: exeopt
 exeopt: $(OCAMLDOC_OPT)

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -172,6 +172,11 @@ ocamlcdefaultflags :=
 
 ocamloptdefaultflags := $(shell ./getocamloptdefaultflags $(TARGET))
 
+.PHONY: all allopt opt.opt # allopt and opt.opt are synonyms
+all: ocamltest$(EXE)
+allopt: ocamltest.opt$(EXE)
+opt.opt: allopt
+
 ocamltest$(EXE): $(bytecode_modules)
 	$(ocamlc) -custom ocamlcommon.cma -o $@ $^
 

--- a/otherlibs/Makefile
+++ b/otherlibs/Makefile
@@ -60,9 +60,11 @@ CMIFILES ?= $(CAMLOBJS:.cmo=.cmi)
 CAMLOBJS_NAT ?= $(CAMLOBJS:.cmo=.cmx)
 CLIBNAME ?= $(LIBNAME)
 
+.PHONY: all allopt opt.opt # allopt and opt.opt are synonyms
 all: lib$(CLIBNAME).$(A) $(LIBNAME).cma $(CMIFILES)
 
 allopt: lib$(CLIBNAME).$(A) $(LIBNAME).cmxa $(LIBNAME).$(CMXS) $(CMIFILES)
+opt.opt: allopt
 
 $(LIBNAME).cma: $(CAMLOBJS)
 	$(MKLIB) -o $(LIBNAME) -oc $(CLIBNAME) -ocamlc '$(CAMLC)' -linkall \

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -75,8 +75,9 @@ else
 PROFILINGTARGET = noprof
 endif
 
-.PHONY: allopt
+.PHONY: allopt opt.opt # allopt and opt.opt are synonyms
 allopt: stdlib.cmxa std_exit.cmx allopt-$(PROFILINGTARGET)
+opt.opt: allopt
 
 .PHONY: allopt-noprof
 allopt-noprof:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -99,7 +99,8 @@ VPATH := $(filter-out -I,$(INCLUDES))
 
 # scrapelabels addlabels
 
-.PHONY: all opt.opt
+.PHONY: all allopt opt.opt # allopt and opt.opt are synonyms
+allopt: opt.opt
 
 # The dependency generator
 


### PR DESCRIPTION
When there is a build failure in one of the distribution subdirectories (on my system this is often caused by races in parallel builds), I go to the subdirectory, run `make clean` and then rebuild. But I never remember the name of the rule to build the "opt" stuff in this subdirectory. Some directories offer `allopt` (lex, stdlib, otherlibs), some directories offer `opt.opt` (ocamldoc, tools), and others use a different name (ocamltest uses `ocamltest.opt$(EXE)`).

The present PR fixes this inconsistency by making sure that all sub-Makefiles define both an `allopt` and an `opt.opt` target, which are aliases of each other and of the other "build all the native stuff" target if it exists.