### PR TITLE
Do not discard attributes attached to pattern variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -61,6 +61,9 @@ Working version
   to control the degree of optimization in the pattern matching compiler
   (Dwight Guth, review by Gabriel Scherer and Luc Maranget)
 
+- GPR#????: attributes attached to pattern variables are not ignored anymore.
+  (Nicolás Ojeda Bär, review by ...)
+
 ### Code generation and optimizations:
 
 - MPR#7725, GPR#1754: improve AFL instrumentation for objects and lazy values

--- a/Changes
+++ b/Changes
@@ -61,8 +61,8 @@ Working version
   to control the degree of optimization in the pattern matching compiler
   (Dwight Guth, review by Gabriel Scherer and Luc Maranget)
 
-- GPR#????: attributes attached to pattern variables are not ignored anymore.
-  (Nicolás Ojeda Bär, review by ...)
+- GPR#1822: keep attributes attached to pattern variables from being discarded.
+  (Nicolás Ojeda Bär, review by Thomas Refis)
 
 ### Code generation and optimizations:
 

--- a/bytecomp/translclass.ml
+++ b/bytecomp/translclass.ml
@@ -167,7 +167,6 @@ let rec build_object_init cl_table obj params inh_init obj_init cl =
            params obj_init,
          has_init))
   | Tcl_fun (_, pat, vals, cl, partial) ->
-      let vals = List.map (fun (id, _, e) -> id,e) vals in
       let (inh_init, obj_init) =
         build_object_init cl_table obj (vals @ params) inh_init obj_init cl
       in
@@ -190,7 +189,6 @@ let rec build_object_init cl_table obj params inh_init obj_init cl =
       in
       (inh_init, transl_apply obj_init oexprs Location.none)
   | Tcl_let (rec_flag, defs, vals, cl) ->
-      let vals = List.map (fun (id, _, e) -> id,e) vals in
       let (inh_init, obj_init) =
         build_object_init cl_table obj (vals @ params) inh_init obj_init cl
       in
@@ -202,7 +200,6 @@ let rec build_object_init cl_table obj params inh_init obj_init cl =
 let rec build_object_init_0 cl_table params cl copy_env subst_env top ids =
   match cl.cl_desc with
     Tcl_let (_rec_flag, _defs, vals, cl) ->
-      let vals = List.map (fun (id, _, e) -> id,e) vals in
       build_object_init_0 cl_table (vals@params) cl copy_env subst_env top ids
   | _ ->
       let self = Ident.create "self" in
@@ -262,7 +259,7 @@ let rec index a = function
   | b :: l ->
       if b = a then 0 else 1 + index a l
 
-let bind_id_as_val (id, _, _) = ("", id)
+let bind_id_as_val (id, _) = ("", id)
 
 let rec build_class_init cla cstr super inh_init cl_init msubst top cl =
   match cl.cl_desc with

--- a/testsuite/tests/typing-deprecated/deprecated.ml
+++ b/testsuite/tests/typing-deprecated/deprecated.ml
@@ -43,6 +43,53 @@ Warning 3: deprecated: X.x
 val x : X.t = <abstr>
 |}]
 
+(* Patterns *)
+
+let (_, foo [@deprecated], _) = 1, (), 3
+;;
+foo;;
+[%%expect{|
+val foo : unit = ()
+Line _, characters 0-3:
+  foo;;
+  ^^^
+Warning 3: deprecated: foo
+- : unit = ()
+|}]
+
+let (_, foo, bar) [@deprecated] = 1, (), 3
+;;
+foo;;
+[%%expect{|
+val foo : unit = ()
+val bar : int = 3
+- : unit = ()
+|}]
+
+let f = function
+  | bar, cho [@deprecated], _ -> cho + 1
+;;
+[%%expect{|
+Line _, characters 33-36:
+    | bar, cho [@deprecated], _ -> cho + 1
+                                   ^^^
+Warning 3: deprecated: cho
+val f : 'a * int * 'b -> int = <fun>
+|}]
+
+class c (_, (foo [@deprecated] : int)) =
+  object
+    val h = foo
+  end
+;;
+[%%expect{|
+Line _, characters 12-15:
+      val h = foo
+              ^^^
+Warning 3: deprecated: foo
+class c : 'a * int -> object val h : int end
+|}]
+
 (* Type declarations *)
 
 type t = X.t * X.s

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -578,7 +578,7 @@ and class_expr i ppf x =
   | Tcl_let (rf, l1, l2, ce) ->
       line i ppf "Tcl_let %a\n" fmt_rec_flag rf;
       list i value_binding ppf l1;
-      list i ident_x_loc_x_expression_def ppf l2;
+      list i ident_x_expression_def ppf l2;
       class_expr i ppf ce;
   | Tcl_constraint (ce, Some ct, _, _, _) ->
       line i ppf "Tcl_constraint\n";
@@ -877,7 +877,7 @@ and label_x_expression i ppf (l, e) =
   arg_label (i+1) ppf l;
   (match e with None -> () | Some e -> expression (i+1) ppf e)
 
-and ident_x_loc_x_expression_def i ppf (l,_, e) =
+and ident_x_expression_def i ppf (l, e) =
   line i ppf "<def> \"%a\"\n" fmt_ident l;
   expression (i+1) ppf e;
 

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -606,7 +606,7 @@ and class_expr : Env.env -> Typedtree.class_expr -> Use.t =
     | Tcl_structure cs ->
         class_structure env cs
     | Tcl_fun (_, _, args, ce, _) ->
-        let arg env (_, _, e) = expression env e in
+        let arg env (_, e) = expression env e in
         Use.inspect (Use.join (list arg env args)
                         (class_expr env ce))
     | Tcl_apply (ce, args) ->

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -508,7 +508,7 @@ let class_expr sub x =
         Tcl_fun (
           label,
           sub.pat sub pat,
-          List.map (tuple3 id id (sub.expr sub)) priv,
+          List.map (tuple2 id (sub.expr sub)) priv,
           sub.class_expr sub cl,
           partial
         )
@@ -524,7 +524,7 @@ let class_expr sub x =
         Tcl_let (
           rec_flag,
           value_bindings,
-          List.map (tuple3 id id (sub.expr sub)) ivars,
+          List.map (tuple2 id (sub.expr sub)) ivars,
           sub.class_expr sub cl
         )
     | Tcl_ident (path, lid, tyl) ->

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1008,11 +1008,11 @@ and class_expr_aux cl_num val_env met_env scl =
       end;
       let pv =
         List.map
-          begin fun (id, id_loc, id', _ty) ->
+          begin fun (id, id', _ty) ->
             let path = Pident id' in
             (* do not mark the value as being used *)
             let vd = Env.find_value path val_env' in
-            (id, id_loc,
+            (id,
              {exp_desc =
               Texp_ident(path, mknoloc (Longident.Lident (Ident.name id)), vd);
               exp_loc = Location.none; exp_extra = [];
@@ -1158,7 +1158,7 @@ and class_expr_aux cl_num val_env met_env scl =
         Typecore.type_let In_class_def val_env rec_flag sdefs None in
       let (vals, met_env) =
         List.fold_right
-          (fun (id, id_loc) (vals, met_env) ->
+          (fun (id, _id_loc) (vals, met_env) ->
              let path = Pident id in
              (* do not mark the value as used *)
              let vd = Env.find_value path val_env in
@@ -1182,7 +1182,7 @@ and class_expr_aux cl_num val_env met_env scl =
                }
              in
              let id' = Ident.create (Ident.name id) in
-             ((id', id_loc, expr)
+             ((id', expr)
               :: vals,
               Env.add_value id' desc met_env))
           (let_bound_idents_with_loc defs)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -162,21 +162,6 @@ let mk_expected ?explanation ty = { ty; explanation; }
 let case lhs rhs =
   {c_lhs = lhs; c_guard = None; c_rhs = rhs}
 
-let maybe_add_pattern_variables_ghost loc_let env pv =
-  List.fold_right
-    (fun (id, ty, _name, _loc, _as_var) env ->
-       let lid = Longident.Lident (Ident.name id) in
-       match Env.lookup_value ~mark:false lid env with
-       | _ -> env
-       | exception Not_found ->
-         Env.add_value id
-           { val_type = ty;
-             val_kind = Val_unbound Val_unbound_ghost_recursive;
-             val_loc = loc_let;
-             val_attributes = [];
-           } env
-    ) pv env
-
 (* Upper approximation of free identifiers on the parse tree *)
 
 let iter_expression f e =
@@ -462,7 +447,14 @@ let has_variants p =
 
 (* pattern environment *)
 type pattern_variable =
-  Ident.t * type_expr * string loc * Location.t * bool (* as-variable *)
+  {
+    pv_id: Ident.t;
+    pv_type: type_expr;
+    pv_name: string loc;
+    pv_loc: Location.t;
+    pv_as_var: bool;
+  }
+
 type module_variable =
   string loc * Location.t
 
@@ -479,13 +471,32 @@ let reset_pattern scope allow =
   module_variables := [];
 ;;
 
+let maybe_add_pattern_variables_ghost loc_let env pv =
+  List.fold_right
+    (fun {pv_id; pv_type; _} env ->
+       let lid = Longident.Lident (Ident.name pv_id) in
+       match Env.lookup_value ~mark:false lid env with
+       | _ -> env
+       | exception Not_found ->
+         Env.add_value pv_id
+           { val_type = pv_type;
+             val_kind = Val_unbound Val_unbound_ghost_recursive;
+             val_loc = loc_let;
+             val_attributes = [];
+           } env
+    ) pv env
+
 let enter_variable ?(is_module=false) ?(is_as_variable=false) loc name ty =
-  if List.exists (fun (id, _, _, _, _) -> Ident.name id = name.txt)
+  if List.exists (fun {pv_id; _} -> Ident.name pv_id = name.txt)
       !pattern_variables
   then raise(Error(loc, Env.empty, Multiply_bound_variable name.txt));
   let id = Ident.create name.txt in
   pattern_variables :=
-    (id, ty, name, loc, is_as_variable) :: !pattern_variables;
+    {pv_id = id;
+     pv_type = ty;
+     pv_name = name;
+     pv_loc = loc;
+     pv_as_var = is_as_variable} :: !pattern_variables;
   if is_module then begin
     (* Note: unpack patterns enter a variable of the same name *)
     if not !allow_modules then
@@ -499,7 +510,7 @@ let enter_variable ?(is_module=false) ?(is_as_variable=false) loc name ty =
 
 let sort_pattern_variables vs =
   List.sort
-    (fun (x,_,_,_,_) (y,_,_,_,_) ->
+    (fun {pv_id = x; _} {pv_id = y; _} ->
       Pervasives.compare (Ident.name x) (Ident.name y))
     vs
 
@@ -510,9 +521,9 @@ let enter_orpat_variables loc env  p1_vs p2_vs =
   and p2_vs = sort_pattern_variables p2_vs in
 
   let rec unify_vars p1_vs p2_vs =
-    let vars vs = List.map (fun (x,_t,_,_l,_a) -> x) vs in
+    let vars vs = List.map (fun {pv_id; _} -> pv_id) vs in
     match p1_vs, p2_vs with
-      | (x1,t1,_,_l1,_a1)::rem1, (x2,t2,_,_l2,_a2)::rem2
+      | {pv_id = x1; pv_type = t1; _}::rem1, {pv_id = x2; pv_type = t2; _}::rem2
         when Ident.equal x1 x2 ->
           if x1==x2 then
             unify_vars rem1 rem2
@@ -526,9 +537,9 @@ let enter_orpat_variables loc env  p1_vs p2_vs =
           (x2,x1)::unify_vars rem1 rem2
           end
       | [],[] -> []
-      | (x,_,_,_,_)::_, [] -> raise (Error (loc, env, Orpat_vars (x, [])))
-      | [],(y,_,_,_,_)::_  -> raise (Error (loc, env, Orpat_vars (y, [])))
-      | (x,_,_,_,_)::_, (y,_,_,_,_)::_ ->
+      | {pv_id = x; _}::_, [] -> raise (Error (loc, env, Orpat_vars (x, [])))
+      | [],{pv_id = y; _}::_  -> raise (Error (loc, env, Orpat_vars (y, [])))
+      | {pv_id = x; _}::_, {pv_id = y; _}::_ ->
           let err =
             if Ident.name x < Ident.name y
             then Orpat_vars (x, vars p2_vs)
@@ -1492,14 +1503,14 @@ let check_unused ?(lev=get_current_level ()) env expected_ty cases =
     cases
 
 let iter_pattern_variables_type f : pattern_variable list -> unit =
-  List.iter (fun (_, t, _, _, _) -> f t)
+  List.iter (fun {pv_type; _} -> f pv_type)
 
 let add_pattern_variables ?check ?check_as env pv =
   List.fold_right
-    (fun (id, ty, _name, loc, as_var) env ->
-       let check = if as_var then check_as else check in
-       Env.add_value ?check id
-         {val_type = ty; val_kind = Val_reg; Types.val_loc = loc;
+    (fun {pv_id; pv_type; pv_name = _; pv_loc; pv_as_var} env ->
+       let check = if pv_as_var then check_as else check in
+       Env.add_value ?check pv_id
+         {val_type = pv_type; val_kind = Val_reg; Types.val_loc = pv_loc;
           val_attributes = [];
          } env
     )
@@ -1540,16 +1551,16 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
   if is_optional l then unify_pat val_env pat (type_option (newvar ()));
   let (pv, met_env) =
     List.fold_right
-      (fun (id, ty, name, loc, as_var) (pv, env) ->
+      (fun {pv_id; pv_type; pv_name; pv_loc; pv_as_var} (pv, env) ->
          let check s =
-           if as_var then Warnings.Unused_var s
+           if pv_as_var then Warnings.Unused_var s
            else Warnings.Unused_var_strict s in
-         let id' = Ident.create (Ident.name id) in
-         ((id', name, id, ty)::pv,
-          Env.add_value id' {val_type = ty;
+         let id' = Ident.create (Ident.name pv_id) in
+         ((id', pv_name, pv_id, pv_type)::pv,
+          Env.add_value id' {val_type = pv_type;
                              val_kind = Val_ivar (Immutable, cl_num);
                              val_attributes = [];
-                             Types.val_loc = loc;
+                             Types.val_loc = pv_loc;
                             } ~check
             env))
       !pattern_variables ([], met_env)
@@ -1573,27 +1584,27 @@ let type_self_pattern cl_num privty val_env met_env par_env spat =
   pattern_variables := [];
   let (val_env, met_env, par_env) =
     List.fold_right
-      (fun (id, ty, _name, loc, as_var) (val_env, met_env, par_env) ->
-         (Env.add_value id {val_type = ty;
-                            val_kind =
-                              Val_unbound Val_unbound_instance_variable;
-                            val_attributes = [];
-                            Types.val_loc = loc;
-                           } val_env,
-          Env.add_value id {val_type = ty;
-                            val_kind = Val_self (meths, vars, cl_num, privty);
-                            val_attributes = [];
-                            Types.val_loc = loc;
-                           }
-            ~check:(fun s -> if as_var then Warnings.Unused_var s
+      (fun {pv_id; pv_type; pv_name = _; pv_loc; pv_as_var} (val_env, met_env, par_env) ->
+         (Env.add_value pv_id {val_type = pv_type;
+                               val_kind =
+                                 Val_unbound Val_unbound_instance_variable;
+                               val_attributes = [];
+                               Types.val_loc = pv_loc;
+                              } val_env,
+          Env.add_value pv_id {val_type = pv_type;
+                               val_kind = Val_self (meths, vars, cl_num, privty);
+                               val_attributes = [];
+                               Types.val_loc = pv_loc;
+                              }
+            ~check:(fun s -> if pv_as_var then Warnings.Unused_var s
                              else Warnings.Unused_var_strict s)
             met_env,
-          Env.add_value id {val_type = ty;
-                            val_kind =
-                              Val_unbound Val_unbound_instance_variable;
-                            val_attributes = [];
-                            Types.val_loc = loc;
-                           } par_env))
+          Env.add_value pv_id {val_type = pv_type;
+                               val_kind =
+                                 Val_unbound Val_unbound_instance_variable;
+                               val_attributes = [];
+                               Types.val_loc = pv_loc;
+                              } par_env))
       pv (val_env, met_env, par_env)
   in
   (pat, meths, vars, val_env, met_env, par_env)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -450,7 +450,6 @@ type pattern_variable =
   {
     pv_id: Ident.t;
     pv_type: type_expr;
-    pv_name: string loc;
     pv_loc: Location.t;
     pv_as_var: bool;
     pv_attributes: attributes;
@@ -495,7 +494,6 @@ let enter_variable ?(is_module=false) ?(is_as_variable=false) loc name ty attrs 
   pattern_variables :=
     {pv_id = id;
      pv_type = ty;
-     pv_name = name;
      pv_loc = loc;
      pv_as_var = is_as_variable;
      pv_attributes = attrs} :: !pattern_variables;
@@ -1509,7 +1507,7 @@ let iter_pattern_variables_type f : pattern_variable list -> unit =
 
 let add_pattern_variables ?check ?check_as env pv =
   List.fold_right
-    (fun {pv_id; pv_type; pv_name = _; pv_loc; pv_as_var; pv_attributes} env ->
+    (fun {pv_id; pv_type; pv_loc; pv_as_var; pv_attributes} env ->
        let check = if pv_as_var then check_as else check in
        Env.add_value ?check pv_id
          {val_type = pv_type; val_kind = Val_reg; Types.val_loc = pv_loc;
@@ -1553,12 +1551,12 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
   if is_optional l then unify_pat val_env pat (type_option (newvar ()));
   let (pv, met_env) =
     List.fold_right
-      (fun {pv_id; pv_type; pv_name; pv_loc; pv_as_var; pv_attributes} (pv, env) ->
+      (fun {pv_id; pv_type; pv_loc; pv_as_var; pv_attributes} (pv, env) ->
          let check s =
            if pv_as_var then Warnings.Unused_var s
            else Warnings.Unused_var_strict s in
          let id' = Ident.create (Ident.name pv_id) in
-         ((id', pv_name, pv_id, pv_type)::pv,
+         ((id', pv_id, pv_type)::pv,
           Env.add_value id' {val_type = pv_type;
                              val_kind = Val_ivar (Immutable, cl_num);
                              val_attributes = pv_attributes;
@@ -1586,7 +1584,7 @@ let type_self_pattern cl_num privty val_env met_env par_env spat =
   pattern_variables := [];
   let (val_env, met_env, par_env) =
     List.fold_right
-      (fun {pv_id; pv_type; pv_name = _; pv_loc; pv_as_var; pv_attributes} (val_env, met_env, par_env) ->
+      (fun {pv_id; pv_type; pv_loc; pv_as_var; pv_attributes} (val_env, met_env, par_env) ->
          (Env.add_value pv_id {val_type = pv_type;
                                val_kind =
                                  Val_unbound Val_unbound_instance_variable;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -537,8 +537,7 @@ let enter_orpat_variables loc env  p1_vs p2_vs =
           (x2,x1)::unify_vars rem1 rem2
           end
       | [],[] -> []
-      | {pv_id = x; _}::_, [] -> raise (Error (loc, env, Orpat_vars (x, [])))
-      | [],{pv_id = y; _}::_  -> raise (Error (loc, env, Orpat_vars (y, [])))
+      | {pv_id; _}::_, [] | [],{pv_id; _}::_ -> raise (Error (loc, env, Orpat_vars (pv_id, [])))
       | {pv_id = x; _}::_, {pv_id = y; _}::_ ->
           let err =
             if Ident.name x < Ident.name y

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -78,7 +78,7 @@ val type_expression:
         Env.t -> Parsetree.expression -> Typedtree.expression
 val type_class_arg_pattern:
         string -> Env.t -> Env.t -> arg_label -> Parsetree.pattern ->
-        Typedtree.pattern * (Ident.t * string loc * Ident.t * type_expr) list *
+        Typedtree.pattern * (Ident.t * Ident.t * type_expr) list *
         Env.t * Env.t
 val type_self_pattern:
         string -> type_expr -> Env.t -> Env.t -> Env.t -> Parsetree.pattern ->

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -145,11 +145,11 @@ and class_expr_desc =
     Tcl_ident of Path.t * Longident.t loc * core_type list
   | Tcl_structure of class_structure
   | Tcl_fun of
-      arg_label * pattern * (Ident.t * string loc * expression) list
+      arg_label * pattern * (Ident.t * expression) list
       * class_expr * partial
   | Tcl_apply of class_expr * (arg_label * expression option) list
   | Tcl_let of rec_flag * value_binding list *
-                  (Ident.t * string loc * expression) list * class_expr
+                  (Ident.t * expression) list * class_expr
   | Tcl_constraint of
       class_expr * class_type option * string list * string list * Concr.t
     (* Visible instance variables, methods and concrete methods *)

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -260,11 +260,11 @@ and class_expr_desc =
     Tcl_ident of Path.t * Longident.t loc * core_type list
   | Tcl_structure of class_structure
   | Tcl_fun of
-      arg_label * pattern * (Ident.t * string loc * expression) list
+      arg_label * pattern * (Ident.t * expression) list
       * class_expr * partial
   | Tcl_apply of class_expr * (arg_label * expression option) list
   | Tcl_let of rec_flag * value_binding list *
-                  (Ident.t * string loc * expression) list * class_expr
+                  (Ident.t * expression) list * class_expr
   | Tcl_constraint of
       class_expr * class_type option * string list * string list * Concr.t
   (* Visible instance variables, methods and concrete methods *)

--- a/typing/typedtreeIter.ml
+++ b/typing/typedtreeIter.ml
@@ -496,7 +496,7 @@ module MakeIterator(Iter : IteratorArgument) : sig
         | Tcl_structure clstr -> iter_class_structure clstr
         | Tcl_fun (_label, pat, priv, cl, _partial) ->
           iter_pattern pat;
-          List.iter (fun (_id, _, exp) -> iter_expression exp) priv;
+          List.iter (fun (_id, exp) -> iter_expression exp) priv;
           iter_class_expr cl
 
         | Tcl_apply (cl, args) ->
@@ -509,7 +509,7 @@ module MakeIterator(Iter : IteratorArgument) : sig
 
         | Tcl_let (rec_flat, bindings, ivars, cl) ->
           iter_bindings rec_flat bindings;
-          List.iter (fun (_id, _, exp) -> iter_expression exp) ivars;
+          List.iter (fun (_id, exp) -> iter_expression exp) ivars;
             iter_class_expr cl
 
         | Tcl_constraint (cl, Some clty, _vals, _meths, _concrs) ->

--- a/typing/typedtreeMap.ml
+++ b/typing/typedtreeMap.ml
@@ -555,8 +555,8 @@ module MakeMap(Map : MapArgument) = struct
         | Tcl_structure clstr -> Tcl_structure (map_class_structure clstr)
         | Tcl_fun (label, pat, priv, cl, partial) ->
           Tcl_fun (label, map_pattern pat,
-                   List.map (fun (id, name, exp) ->
-                     (id, name, map_expression exp)) priv,
+                   List.map (fun (id, exp) ->
+                     (id, map_expression exp)) priv,
                    map_class_expr cl, partial)
 
         | Tcl_apply (cl, args) ->
@@ -566,8 +566,8 @@ module MakeMap(Map : MapArgument) = struct
                      ) args)
         | Tcl_let (rec_flag, bindings, ivars, cl) ->
           Tcl_let (rec_flag, map_bindings bindings,
-                   List.map (fun (id, name, exp) ->
-                     (id, name, map_expression exp)) ivars,
+                   List.map (fun (id, exp) ->
+                     (id, map_expression exp)) ivars,
                    map_class_expr cl)
 
         | Tcl_constraint (cl, Some clty, vals, meths, concrs) ->


### PR DESCRIPTION
This PR adds the necessary plumbing so that attributes attached to variables bound in patterns are not discarded. It is motivated by [MPR#7719](https://caml.inria.fr/mantis/view.php?id=7719), where it is observed that `[@@deprecated]` attributes attached to top-level `let`s are ignored.

For example, this PR makes it so that
```
let (_, foo[@deprecated], _) = .... in foo
```
will trigger the deprecation warning.

The PR is better reviewed commit-by-commit:
- the first commit replaces the type `Typecore.pattern_variable` by a record type to aid readability;
- the second commit keeps track of attributes attached to pattern variables in the `pattern_variable` type; and
-  the third commit records that information when the pattern variables are entered into the environment.

In order to fix [MPR#7719](https://caml.inria.fr/mantis/view.php?id=7719) some kind of cascading logic is needed so that `[@@deprecated]` attributes attached to a `let` are inherited by the individual variables bounds in the pattern. But it wasn't clear to me that it was a good idea for this to be the case for arbitrary attributes. Maybe special casing some attributes (such as `[@@deprecated]`) would be a better idea.