### PR TITLE
fix non removal of empty let_rec_symbol constructors

### DIFF
--- a/middle_end/remove_unused_program_constructs.ml
+++ b/middle_end/remove_unused_program_constructs.ml
@@ -69,8 +69,10 @@ let rec loop (program : Flambda.program_body)
     let dep = let_rec_dep defs dep in
     let defs =
       List.filter (fun (sym, _) -> Symbol.Set.mem sym dep) defs
-    in
-    Let_rec_symbol (defs, program), dep
+    in begin match defs with
+      | [] -> program, dep
+      | _ -> Let_rec_symbol (defs, program), dep
+    end
   | Initialize_symbol (sym, tag, fields, program) ->
     let program, dep = loop program in
     if Symbol.Set.mem sym dep then


### PR DESCRIPTION
At the end of its optimisation process flambda removes unused program constructors. Unfortunately, no check was implemented to avoid having `Let_rec_symbols` with an empty list of `defs`, this in some cases (as in the exemple below) leading to the introduction of a useless `Let_rec_symbols` in the program. This fix it.

Exemple of program causing an empty `let_rec_symbol` to appear:
```ocaml
let x = 4;;
let f y =
  let rec foo = (fun z -> bar x + foo x)[@inline]
  and bar = fun z -> foo y
in
let rec list_map f l  a b c d e  w g h i =
  match l with
  | [] -> []
  | x :: tl -> (f x,  a, b, c, d, e, f, g, h, i) :: list_map f tl (a+1) (b+2) (c+3) (4+d) (5+e) (6+w) (7+g) (8+h) (9+i)
in
(list_map[@specialised]) foo [1;2;3] 0 0 0 0 0 0 0 0 0;;
f 7
```