### PR TITLE
nondep_type_decl: expand to private abbrev instead of abstracting

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,6 +10,10 @@ Working version
 
 ### Type system:
 
+- GPR#1826: allow expanding a type to a private abbreviation instead of
+  abstracting when removing references to an identifier
+  (Thomas Refis and Leo White, review by Jacques Garrigue)
+
 ### Standard library:
 
 - MPR#6701, GPR#1185, GPR#1803: make float_of_string and string_of_float

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -25,5 +25,5 @@ module G : functor (X : sig  end) -> sig type t = F(X).t end
 
 module Indirect = G(struct end);;
 [%%expect{|
-module Indirect : sig type t end
+module Indirect : sig type t = private int end
 |}]

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -80,7 +80,7 @@ module IndirectPub : sig type t = [ `Foo of t ] end
    if we were unrolling the abbrev.  *)
 module IndirectPriv = I(struct end);;
 [%%expect{|
-module IndirectPriv : sig type t = private [ `Foo of 'a ] as 'a end
+module IndirectPriv : sig type t end
 |}]
 
 (*** Test proposed by Jacques in
@@ -133,6 +133,5 @@ module I : functor (X : sig  end) -> sig type t = Priv(X).t end
 
 module IndirectPriv = I(struct end);;
 [%%expect{|
-module IndirectPriv :
-  sig type t = private [ `Bar of int | `Foo of 'a -> int ] as 'a end
+module IndirectPriv : sig type t end
 |}]

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -27,3 +27,59 @@ module Indirect = G(struct end);;
 [%%expect{|
 module Indirect : sig type t = private int end
 |}]
+
+(* unroll_abbrev *)
+
+module Pub(_ : sig end) = struct
+  type t = [ `Foo of t ]
+end;;
+[%%expect{|
+module Pub : sig  end -> sig type t = [ `Foo of t ] end
+|}]
+
+module Priv(_ : sig end) = struct
+  type t = private [ `Foo of t ]
+end;;
+[%%expect{|
+module Priv : sig  end -> sig type t = private [ `Foo of t ] end
+|}]
+
+module DirectPub = Pub(struct end);;
+[%%expect{|
+module DirectPub : sig type t = [ `Foo of t ] end
+|}]
+
+module DirectPriv = Priv(struct end);;
+[%%expect{|
+module DirectPriv : sig type t = private [ `Foo of t ] end
+|}]
+
+module H(X : sig end) : sig
+  type t = Pub(X).t
+end = Pub(X);;
+[%%expect{|
+module H : functor (X : sig  end) -> sig type t = Pub(X).t end
+|}]
+
+module I(X : sig end) : sig
+  type t = Priv(X).t
+end = Priv(X);;
+[%%expect{|
+module I : functor (X : sig  end) -> sig type t = Priv(X).t end
+|}]
+
+module IndirectPub = H(struct end);;
+[%%expect{|
+module IndirectPub : sig type t = [ `Foo of t ] end
+|}]
+
+(* The result would be
+   {[
+     type t = private [ `Foo of t ]
+   ]}
+   if we were unrolling the abbrev.  *)
+module IndirectPriv = I(struct end);;
+[%%expect{|
+module IndirectPriv : sig type t = private [ `Foo of 'a ] as 'a end
+|}]
+

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -1,0 +1,29 @@
+(* TEST
+   * expect
+*)
+
+module F(_ : sig end) : sig
+  type t = private int
+end = struct
+  type t = int
+end;;
+[%%expect{|
+module F : sig  end -> sig type t = private int end
+|}]
+
+module Direct = F(struct end);;
+[%%expect{|
+module Direct : sig type t = private int end
+|}]
+
+module G(X : sig end) : sig
+  type t = F(X).t
+end = F(X);;
+[%%expect{|
+module G : functor (X : sig  end) -> sig type t = F(X).t end
+|}]
+
+module Indirect = G(struct end);;
+[%%expect{|
+module Indirect : sig type t end
+|}]

--- a/testsuite/tests/typing-modules/ocamltests
+++ b/testsuite/tests/typing-modules/ocamltests
@@ -2,6 +2,7 @@ aliases.ml
 applicative_functor_type.ml
 firstclass.ml
 generative.ml
+nondep_private_abbrev.ml
 pr5911.ml
 pr6394.ml
 pr7207.ml

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4370,7 +4370,6 @@ let clear_hash ()   =
   TypeHash.clear nondep_hash; TypeHash.clear nondep_variants
 
 let rec nondep_type_rec ?(expand_private=false) env id ty =
-  let nondep_type_rec env id t = nondep_type_rec ~expand_private env id t in
   let expand_abbrev env t =
     if expand_private then expand_abbrev_opt env t else expand_abbrev env t
   in
@@ -4386,7 +4385,7 @@ let rec nondep_type_rec ?(expand_private=false) env id ty =
       | Tconstr(p, tl, _abbrev) ->
           if Path.isfree id p then
             begin try
-              Tlink (nondep_type_rec env id
+              Tlink (nondep_type_rec ~expand_private env id
                        (expand_abbrev env (newty2 ty.level ty.desc)))
               (*
                  The [Tlink] is important. The expanded type may be a


### PR DESCRIPTION
Given:
```ocaml
# module F(_ : sig end) = struct type t = private int end
  module G(X : sig end) : sig type t = F(X).t end = F(X);;
module F : sig  end -> sig type t = private int end
module G : functor (X : sig  end) -> sig type t = F(X).t end
```
Before this PR:
```ocaml
# module M = G(struct end);;
module M : sig type t end
```

After:
```ocaml
# module M = G(struct end);;
module M : sig type t = private int end
```