### PR TITLE
ocamltest tweaks

### DIFF
--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -196,7 +196,7 @@ ocamltest.opt$(EXE): $(native_modules)
 %.$(O): %.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(BYTECCCOMPOPTS) -c $<
 
-ocamltest_config.ml: ocamltest_config.ml.in
+ocamltest_config.ml: ocamltest_config.ml.in Makefile
 	sed \
 	  -e 's|@@AFL_INSTRUMENT@@|$(AFL_INSTRUMENT)|' \
 	  -e 's|@@ARCH@@|$(ARCH)|' \

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -1045,7 +1045,8 @@ let config_variables _log env =
     Ocaml_variables.ocamlopt_byte, Ocaml_files.ocamlopt ocamlsrcdir;
     Ocaml_variables.bytecc_libs, Ocamltest_config.bytecc_libs;
     Ocaml_variables.nativecc_libs, Ocamltest_config.nativecc_libs;
-    Ocaml_variables.mkdll, Ocamltest_config.mkdll;
+    Ocaml_variables.mkdll,
+      Sys.getenv_with_default_value "MKDLL" Ocamltest_config.mkdll;
     Ocaml_variables.mkexe, Ocamltest_config.mkexe;
     Ocaml_variables.c_preprocessor, Ocamltest_config.c_preprocessor;
     Ocaml_variables.csc, Ocamltest_config.csc;

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -52,7 +52,12 @@ ocamltest_program := $(or \
   $(wildcard $(ocamltest_directory)/ocamltest.opt$(EXE)),\
   $(wildcard $(ocamltest_directory)/ocamltest$(EXE)))
 
-ocamltest := $(FLEXLINK_PREFIX) SORT=$(SORT) MAKE=$(MAKE) $(ocamltest_program)
+ifneq "$(FLEXLINK_PREFIX)" ""
+  MKDLL=$(WINTOPDIR)/boot/ocamlrun $(WINTOPDIR)/flexdll/flexlink.exe \
+                                   $(FLEXLINK_FLAGS)
+endif
+ocamltest := $(FLEXLINK_PREFIX) MKDLL="$(MKDLL)" SORT=$(SORT) MAKE=$(MAKE) \
+                                $(ocamltest_program)
 
 .PHONY: default
 default:

--- a/testsuite/tests/lib-dynlink-csharp/main.ml
+++ b/testsuite/tests/lib-dynlink-csharp/main.ml
@@ -33,7 +33,8 @@ flags = "-output-obj"
 program = "main_obj.${objext}"
 all_modules = "dynlink.cma entry.c main.ml"
 ****** script
-script = "${mkdll} -maindll -o main.dll main_obj.${objext} entry.${objext} ${ocamlsrcdir}/byterun/libcamlrun.lib ${bytecc_libs}"
+script = "${mkdll} -maindll -o main.dll main_obj.${objext} entry.${objext} \
+                   ${ocamlsrcdir}/byterun/libcamlrun.lib ${bytecc_libs}"
 ******* script
 script = "${csharp_cmd}"
 ******** run
@@ -68,7 +69,8 @@ flags = "-output-obj"
 program = "main_obj.${objext}"
 all_modules = "dynlink.cmxa entry.c main.ml"
 ****** script
-script = "${mkdll} -maindll -o main.dll main_obj.${objext} entry.${objext} ${ocamlsrcdir}/asmrun/libasmrun.lib ${nativecc_libs}"
+script = "${mkdll} -maindll -o main.dll main_obj.${objext} entry.${objext} \
+                   ${ocamlsrcdir}/asmrun/libasmrun.lib ${nativecc_libs}"
 ******* script
 script = "${csharp_cmd}"
 ******** run

--- a/testsuite/tests/lib-dynlink-native/main.ml
+++ b/testsuite/tests/lib-dynlink-native/main.ml
@@ -1,6 +1,9 @@
 (* TEST
 
-files = "a.ml api.ml b.ml bug.ml c.ml factorial.c pack_client.ml packed1_client.ml packed1.ml plugin2.ml plugin4.ml plugin_ext.ml plugin_high_arity.ml plugin.ml plugin.mli plugin_ref.ml plugin_simple.ml plugin_thread.ml"
+files = "a.ml api.ml b.ml bug.ml c.ml factorial.c pack_client.ml \
+         packed1_client.ml packed1.ml plugin2.ml plugin4.ml plugin_ext.ml \
+         plugin_high_arity.ml plugin.ml plugin.mli plugin_ref.ml \
+         plugin_simple.ml plugin_thread.ml"
 
 include systhreads
 include dynlink
@@ -14,7 +17,8 @@ ocamlopt_default_flags = "" (* Removes the -ccopt -no-pie on ised on OpenBSD *)
 *** script
 script = "mkdir sub"
 **** script
-script = "cp ${subdir}/api.mli ${subdir}/api.ml ${subdir}/plugin3.ml ${subdir}/plugin.ml sub"
+script = "cp ${subdir}/api.mli ${subdir}/api.ml ${subdir}/plugin3.ml \
+             ${subdir}/plugin.ml sub"
 ***** ocamlopt.byte
 module = "api.ml"
 ****** ocamlopt.byte

--- a/testsuite/tests/link-test/test.ml
+++ b/testsuite/tests/link-test/test.ml
@@ -1,6 +1,7 @@
 (* TEST
 
-modules = "aliases.ml external_for_pack.ml external.ml submodule.ml test.ml use_in_pack.ml"
+modules = "aliases.ml external_for_pack.ml external.ml submodule.ml test.ml \
+           use_in_pack.ml"
 
 * setup-ocamlc.byte-build-env
 program = "${test_build_directory}/test.byte"

--- a/testsuite/tests/opaque/test.ml
+++ b/testsuite/tests/opaque/test.ml
@@ -4,7 +4,8 @@ compile_only = "true"
 
 * setup-ocamlopt.byte-build-env
 ** script
-script = "cp -r ${test_source_directory}/fst ${test_source_directory}/intf ${test_source_directory}/snd ${test_build_directory}"
+script = "cp -r ${test_source_directory}/fst ${test_source_directory}/intf \
+                ${test_source_directory}/snd ${test_build_directory}"
 *** ocamlopt.byte
 flags = "-I intf -opaque"
 all_modules = "intf/opaque_intf.mli"
@@ -12,9 +13,11 @@ all_modules = "intf/opaque_intf.mli"
 flags = "-I intf"
 all_modules = "intf/opaque_impl.mli intf/regular.mli"
 ***** script
-script = "cp intf/opaque_intf.cmi intf/opaque_impl.cmi intf/regular.cmi intf/opaque_intf.mli intf/opaque_impl.mli intf/regular.mli fst"
+script = "cp intf/opaque_intf.cmi intf/opaque_impl.cmi intf/regular.cmi \
+             intf/opaque_intf.mli intf/opaque_impl.mli intf/regular.mli fst"
 ****** script
-script = "cp intf/opaque_intf.cmi intf/opaque_impl.cmi intf/regular.cmi intf/opaque_intf.mli intf/opaque_impl.mli intf/regular.mli snd"
+script = "cp intf/opaque_intf.cmi intf/opaque_impl.cmi intf/regular.cmi \
+             intf/opaque_intf.mli intf/opaque_impl.mli intf/regular.mli snd"
 ******* ocamlopt.byte
 flags = "-I fst -opaque"
 all_modules = "fst/opaque_impl.ml"

--- a/testsuite/tests/output-complete-obj/test.ml
+++ b/testsuite/tests/output-complete-obj/test.ml
@@ -8,7 +8,8 @@ files = "test.ml_stub.c"
 flags = "-w a -output-complete-obj"
 program = "test.ml.bc.${objext}"
 **** script
-script = "${mkexe} -I${ocamlsrcdir}/byterun -o test.ml_bc_stub.exe test.ml.bc.${objext} ${nativecc_libs} test.ml_stub.c"
+script = "${mkexe} -I${ocamlsrcdir}/byterun -o test.ml_bc_stub.exe \
+                   test.ml.bc.${objext} ${nativecc_libs} test.ml_stub.c"
 output = "${compiler_output}"
 ***** run
 program = "./test.ml_bc_stub.exe"
@@ -19,7 +20,8 @@ stderr = "program-output"
 flags = "-w a -output-complete-obj"
 program = "test.ml.exe.${objext}"
 **** script
-script = "${mkexe} -I${ocamlsrcdir}/byterun -o test.ml_stub.exe test.ml.exe.${objext} ${bytecc_libs} test.ml_stub.c"
+script = "${mkexe} -I${ocamlsrcdir}/byterun -o test.ml_stub.exe \
+                   test.ml.exe.${objext} ${bytecc_libs} test.ml_stub.c"
 output = "${compiler_output}"
 ***** run
 program = "./test.ml_stub.exe"

--- a/testsuite/tests/tool-lexyacc/main.ml
+++ b/testsuite/tests/tool-lexyacc/main.ml
@@ -1,5 +1,6 @@
 (* TEST
-   modules = "syntax.ml gram_aux.ml grammar.mly scan_aux.ml scanner.mll lexgen.ml output.ml"
+   modules = "syntax.ml gram_aux.ml grammar.mly scan_aux.ml scanner.mll \
+              lexgen.ml output.ml"
    files = "input"
    arguments = "input"
    ocamllex_flags = " -q "

--- a/testsuite/tests/typing-sigsubst/test_locations.ml
+++ b/testsuite/tests/typing-sigsubst/test_locations.ml
@@ -1,5 +1,7 @@
 (* TEST
-files = "test_functor.ml test_loc_modtype_type_eq.ml test_loc_modtype_type_subst.ml test_loc_type_eq.ml test_loc_type_subst.ml"
+files = "test_functor.ml test_loc_modtype_type_eq.ml \
+         test_loc_modtype_type_subst.ml test_loc_type_eq.ml \
+         test_loc_type_subst.ml"
 * setup-ocamlc.byte-build-env
 ** ocamlc.byte
 module = "test_functor.ml"


### PR DESCRIPTION
Two unrelated changes to ocamltest:

 - When running the testsuite with a bootstrapped flexlink, it's necessary to override the value of `MKDLL` (this is what `Makefile` did in `testsuite/tests/lib-dynlink-csharp` and `testsuite/tests/lib-dynlink-native` previously), as flexlink won't be in `PATH`. In this patch, I simply allow the `MKDLL` environment variable to override the value taken from `config/Makefile`.
 - Many tests now fail the `long-line` test in `tools/check-typo`. I've introduced a continuation character for escaping newlines in strings and then applied it where required. I've done it in a maximally backwards-compatible manner meaning that backslash is only interpreted in two specific places (just before a newline and after an escaped newline before a blank character). It could go "all-in" and treat every backslash as escaping the following character, it's up to you.