### PR TITLE
UTF-8 Fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -44,7 +44,7 @@ README*                  ocaml-typo=missing-header
 
 /.mailmap                ocaml-typo=long-line,missing-header,non-ascii
 /.merlin                 ocaml-typo=missing-header
-/Changes                 ocaml-typo=non-ascii,missing-header
+/Changes                 ocaml-typo=utf8,missing-header
 /INSTALL                 ocaml-typo=missing-header
 /LICENSE                 ocaml-typo=long-line,very-long-line,missing-header
 # tools/ci/appveyor/appveyor_build.cmd only has missing-header because
@@ -87,8 +87,8 @@ testsuite/tests/**                            ocaml-typo=missing-header
 testsuite/tests/lib-bigarray-2/bigarrf.f      ocaml-typo=missing-header,tab
 testsuite/tests/lib-unix/win-stat/fakeclock.c ocaml-typo=
 testsuite/tests/misc-unsafe/almabench.ml      ocaml-typo=missing-header,long-line
-testsuite/tests/tool-toplevel/strings.ml      ocaml-typo=non-ascii,missing-header
-testsuite/tests/win-unicode/*.ml              ocaml-typo=non-ascii,missing-header
+testsuite/tests/tool-toplevel/strings.ml      ocaml-typo=utf8,missing-header
+testsuite/tests/win-unicode/*.ml              ocaml-typo=utf8,missing-header
 testsuite/typing                              ocaml-typo=missing-header
 
 tools/magic         ocaml-typo=missing-header

--- a/.gitattributes
+++ b/.gitattributes
@@ -83,11 +83,13 @@ otherlibs/win32unix/symlink.c     ocaml-typo=long-line
 
 stdlib/hashbang     ocaml-typo=white-at-eol,missing-lf
 
-testsuite/tests/**                        ocaml-typo=missing-header
+testsuite/tests/**                            ocaml-typo=missing-header
+testsuite/tests/lib-bigarray-2/bigarrf.f      ocaml-typo=missing-header,tab
 testsuite/tests/lib-unix/win-stat/fakeclock.c ocaml-typo=
-testsuite/tests/lib-bigarray-2/bigarrf.f  ocaml-typo=missing-header,tab
-testsuite/tests/misc-unsafe/almabench.ml  ocaml-typo=missing-header,long-line
-testsuite/typing                          ocaml-typo=missing-header
+testsuite/tests/misc-unsafe/almabench.ml      ocaml-typo=missing-header,long-line
+testsuite/tests/tool-toplevel/strings.ml      ocaml-typo=non-ascii,missing-header
+testsuite/tests/win-unicode/*.ml              ocaml-typo=non-ascii,missing-header
+testsuite/typing                              ocaml-typo=missing-header
 
 tools/magic         ocaml-typo=missing-header
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -49,7 +49,7 @@ README*                  ocaml-typo=missing-header
 /LICENSE                 ocaml-typo=long-line,very-long-line,missing-header
 # tools/ci/appveyor/appveyor_build.cmd only has missing-header because
 # dra27 too lazy to update check-typo to interpret Cmd-style comments!
-/tools/ci/appveyor/appveyor_build.cmd      ocaml-typo=long-line,very-long-line,missing-header text eol=crlf
+/tools/ci/appveyor/appveyor_build.cmd      ocaml-typo=long-line,very-long-line,missing-header,non-ascii text eol=crlf
 /tools/ci/appveyor/appveyor_build.sh       ocaml-typo=non-ascii
 
 

--- a/byterun/floats.c
+++ b/byterun/floats.c
@@ -304,10 +304,10 @@ static int caml_float_of_hex(const char * s, double * res)
       if (*s == 0) return -1;   /* nothing after exponent mark */
       e = strtol(s, &p, 10);
       if (*p != 0) return -1;   /* ill-formed exponent */
-      /* Handle exponents larger than int by returning 0/∞ directly.
-	 Mind that INT_MIN/INT_MAX are included in the test so as to capture
-	 the overflow case of strtol on Win64 — long and int have the same
-	 size there. */
+      /* Handle exponents larger than int by returning 0/infinity directly.
+         Mind that INT_MIN/INT_MAX are included in the test so as to capture
+         the overflow case of strtol on Win64 -- long and int have the same
+         size there. */
       if (e <= INT_MIN) {
         *res = 0.;
         return 0;

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -81,9 +81,9 @@
 # You can ignore a rule by giving the option -<rule> on the command
 # line (before any file names).
 
-# Files which include the utf8 rule will have line-length computations take
-# UTF-8 sequences into account. As a special case, UTF-8 sequences are always
-# allowed in the copyright headers.
+# Files which include the utf8 rule will be validated using grep and line-length
+# computations will take UTF-8 sequences into account. As a special case, UTF-8
+# sequences are always allowed in the copyright headers.
 
 # First prevent i18n from messing up everything.
 export LC_ALL=C
@@ -161,6 +161,19 @@ IGNORE_DIRS="
     esac
     case "$f" in
       ocamldoc/*|*/ocamldoc/*) rules="long-line,$rules";;
+    esac
+
+    case ,$svnrules, in
+      *,utf8,*)
+        # grep -a is used to force the file to be considered as text and -x
+        # requires the entire line to match. This specifically detects the
+        # presence of lines containing malformed UTF-8. It may be tested using
+        # https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
+        if LC_ALL=en_US.UTF8 grep -qaxv '.*' "$f" ; then
+          echo File "$f" is not correctly encoded in UTF-8
+          exit 2
+        fi
+        ;;
     esac
 
     (cat "$f" | tr -d '\r'; echo) \

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -81,6 +81,10 @@
 # You can ignore a rule by giving the option -<rule> on the command
 # line (before any file names).
 
+# Files which include the utf8 rule will have line-length computations take
+# UTF-8 sequences into account. As a special case, UTF-8 sequences are always
+# allowed in the copyright headers.
+
 # First prevent i18n from messing up everything.
 export LC_ALL=C
 
@@ -191,16 +195,31 @@ IGNORE_DIRS="
           return c > limit;
         }
 
+        function utf8_decode(str) {
+          if (is_err("utf8")) {
+            return str;
+          } else {
+            # This script assumes that the UTF-8 has been externally validated
+            t = str;
+            gsub(/[\300-\367][\200-\277]+/, "?", t);
+            if (t != str) {
+              ++ counts["utf8"];
+            }
+            return t;
+          }
+        }
+
         BEGIN { state = "(first line)"; }
 
         match($0, /\t/) {
           err("tab", "TAB character(s)");
-          if (more_columns($0, 80)){
+          t = utf8_decode($0);
+          if (more_columns(t, 80)){
             RSTART=81;
             RLENGTH = 0;
             err("long-line", "line is over 80 columns");
           }
-          if (more_columns($0, 132)){
+          if (more_columns(t, 132)){
             RSTART=133;
             RLENGTH = 0;
             err("very-long-line", "line is over 132 columns");
@@ -209,10 +228,14 @@ IGNORE_DIRS="
 
         match($0, /[\200-\377]/) \
         && state != "authors" && state != "copyright" {
-          err("non-ascii", "non-ASCII character(s)");
-          if (header_utf8 && !is_err("non-ascii")) {
-            err("non-ascii-utf8", \
-                "non-ASCII character(s) AND UTF-8 encountered");
+          if (is_err("utf8")) {
+            err("non-ascii", "non-ASCII character(s)");
+            if (header_utf8 && !is_err("non-ascii")) {
+              err("non-ascii-utf8", \
+                  "non-ASCII character(s) AND UTF-8 encountered");
+            }
+          } else {
+            ++ counts["utf8"];
           }
         }
 
@@ -229,7 +252,7 @@ IGNORE_DIRS="
         }
 
         $0 !~ /\t/ && length($0) > 80 {
-          t = $0;
+          t = utf8_decode($0);
           sub(/https?:[A-Za-z0-9._~:/?#\[\]@!$&\047()*+,;=%-]{73,}$/, "", t);
           if (length(t) > 80) {
             RSTART = 81;
@@ -241,7 +264,10 @@ IGNORE_DIRS="
         $0 !~ /\t/ && length($0) > 132 {
           RSTART = 133;
           RLENGTH = 0;
-          err("very-long-line", "line is over 132 columns");
+          t = utf8_decode($0);
+          if (length(t) > 132) {
+            err("very-long-line", "line is over 132 columns");
+          }
         }
 
         # Record that the header contained UTF-8 sequences

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -72,11 +72,11 @@ let zero = make_pat (Tpat_constant (Const_int 0)) Ctype.none Env.empty
                                                    S
                                                 -------> | "" |
                              U     | S, "" | __/         | () |
-                         --------> | _, () |   \  ¬ S
+                         --------> | _, () |   \ not S
         | U, _, () | __/                        -------> | () |
         | _, S, "" |   \
                         ---------> | S, "" | ----------> | "" |
-                           ¬ U                    S
+                          not U                    S
    v}
 
    where following an edge labelled by a pattern P means "assuming the value I


### PR DESCRIPTION
4 parts to this GPR, all related to UTF-8 in the repo:

 - There were some missing `ocaml-typo` attributes relating to files containing UTF-8 characters
 - Removing UTF-8 characters from comments in two source files. At present `tools/check-typo` permits UTF-8 characters in comment headers - it seems better to avoid using it elsewhere in our own tree at the moment, although I'm not cemented to this opinion.
 - The use of UTF-8 in some files causes them to "fail" the `long-line` test. I've added a `utf8` rule in `ocaml-typo` which declares that UTF-8 is allowed anywhere in the file and in this case takes the simplest route of interpreting a UTF-8 sequence as a single character. This is obviously not perfect, though it's rather better than what was there before, particular for validating the `Changes` file. Note that this could be used for the previously mentioned two files.
 - Files which are marked as `utf8` in `.gitattributes` will be UTF-8 validated by `tools/check-typo` and this introduces a hard error (i.e. the tool aborts completely) if an invalid file is tested.