### PR TITLE
Test check_all_arches on AppVeyor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1203,7 +1203,7 @@ check_arch:
 
 .PHONY: check_all_arches
 check_all_arches:
-ifneq ($(shell grep -E '^\#define ARCH_SIXTYFOUR$$' byterun/caml/m.h 2> /dev/null),)
+ifeq ($(ARCH64),true)
 	@STATUS=0; \
 	 for i in $(ARCHES); do \
 	   $(MAKE) --no-print-directory check_arch ARCH=$$i || STATUS=1; \

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -178,6 +178,7 @@ ARCMD=$(TOOLPREF)ar
 
 ### Name of architecture for the native-code compiler
 ARCH=i386
+ARCH64=false
 
 ### Name of architecture model for the native-code compiler.
 MODEL=default

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -178,6 +178,7 @@ ARCMD=$(TOOLPREF)ar
 
 ### Name of architecture for the native-code compiler
 ARCH=amd64
+ARCH64=true
 
 ### Name of architecture model for the native-code compiler.
 MODEL=default

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -173,6 +173,7 @@ ARCMD=
 
 ### Name of architecture for the native-code compiler
 ARCH=i386
+ARCH64=false
 
 ### Name of architecture model for the native-code compiler.
 MODEL=default

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -176,6 +176,7 @@ ARCMD=
 
 ### Name of architecture for the native-code compiler
 ARCH=amd64
+ARCH64=true
 
 ### Name of architecture model for the native-code compiler.
 MODEL=default

--- a/configure
+++ b/configure
@@ -670,9 +670,11 @@ if test "$?" -eq 0; then
   case "$3" in
     4) inf "OK, this is a regular 32 bit architecture."
        echo "#undef ARCH_SIXTYFOUR" >> m.h
+       config ARCH64 "false"
        arch64=false;;
     8) inf "Wow! A 64 bit architecture!"
        echo "#define ARCH_SIXTYFOUR" >> m.h
+       config ARCH64 "true"
        arch64=true;;
     *) err "This architecture seems to be neither 32 bits nor 64 bits.\n" \
            "OCaml won't run on this architecture.";;

--- a/tools/ci/appveyor/appveyor_build.sh
+++ b/tools/ci/appveyor/appveyor_build.sh
@@ -85,6 +85,7 @@ case "$1" in
     run "test mingw32" make -C $FULL_BUILD_PREFIX-mingw32 tests
     run "install msvc64" make -C $FULL_BUILD_PREFIX-msvc64 install
     run "install mingw32" make -C $FULL_BUILD_PREFIX-mingw32 install
+    run "check_all_arches" make -C $FULL_BUILD_PREFIX-msvc64 check_all_arches
     ;;
   *)
     cd $APPVEYOR_BUILD_FOLDER/../$BUILD_PREFIX-msvc64


### PR DESCRIPTION
This change was originally inspired by a desire to eliminate an overly long line in `Makefile`. The change here is to write `ARCH64` as a Boolean to `config/makefile` in addition to its presence in `byterun/caml/m.h`. The `grep` test used previously would not have worked on Windows.

Armed with this change, AppVeyor now runs `check_all_arches` too.