### PR TITLE
Allow non-val payload types in CMM Ccatch

### DIFF
--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -166,7 +166,7 @@ type expression =
   | Cifthenelse of expression * expression * expression
   | Cswitch of expression * int array * expression array * Debuginfo.t
   | Cloop of expression
-  | Ccatch of rec_flag * (int * Ident.t list * expression) list * expression
+  | Ccatch of rec_flag * (int * (Ident.t * machtype) list * expression) list * expression
   | Cexit of int * expression list
   | Ctrywith of expression * Ident.t * expression
 

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -146,7 +146,7 @@ and expression =
   | Cifthenelse of expression * expression * expression
   | Cswitch of expression * int array * expression array * Debuginfo.t
   | Cloop of expression
-  | Ccatch of rec_flag * (int * Ident.t list * expression) list * expression
+  | Ccatch of rec_flag * (int * (Ident.t * machtype) list * expression) list * expression
   | Cexit of int * expression list
   | Ctrywith of expression * Ident.t * expression
 
@@ -180,6 +180,6 @@ type phrase =
     Cfunction of fundecl
   | Cdata of data_item list
 
-val ccatch : int * Ident.t list * expression * expression -> expression
+val ccatch : int * (Ident.t * machtype) list * expression * expression -> expression
 
 val reset : unit -> unit

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -1891,7 +1891,9 @@ let rec transl env e =
   | Ucatch(nfail, [], body, handler) ->
       make_catch nfail (transl env body) (transl env handler)
   | Ucatch(nfail, ids, body, handler) ->
-      ccatch(nfail, ids, transl env body, transl env handler)
+      let ids_with_types =
+        List.map (fun i -> (i, Cmm.typ_val)) ids in
+      ccatch(nfail, ids_with_types, transl env body, transl env handler)
   | Utrywith(body, exn, handler) ->
       Ctrywith(transl env body, exn, transl env handler)
   | Uifthenelse(cond, ifso, ifnot) ->

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -185,7 +185,8 @@ let rec expr ppf = function
           i
           (fun ppf ids ->
              List.iter
-               (fun id -> fprintf ppf " %a" Ident.print id)
+               (fun (id, ty) ->
+                 fprintf ppf " %a: %a" Ident.print id machtype ty)
                ids) ids
           sequence e2
       in

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -793,9 +793,7 @@ method emit_expr (env:environment) exp =
         List.map (fun (nfail, ids, e2) ->
             let rs =
               List.map
-                (* CR-someday mshinwell: consider how we can do better than
-                   [typ_val] when appropriate. *)
-                (fun id -> let r = self#regs_for typ_val in name_regs id r; r)
+                (fun (id, typ) -> let r = self#regs_for typ in name_regs id r; r)
                 ids in
             (nfail, ids, rs, e2))
           handlers
@@ -812,7 +810,7 @@ method emit_expr (env:environment) exp =
       let translate_one_handler (nfail, ids, rs, e2) =
         assert(List.length ids = List.length rs);
         let new_env =
-          List.fold_left (fun env (id, r) -> env_add id r env)
+          List.fold_left (fun env ((id, _typ), r) -> env_add id r env)
             env (List.combine ids rs)
         in
         let (r, s) = self#emit_sequence new_env e2 in
@@ -832,14 +830,13 @@ method emit_expr (env:environment) exp =
           let dest_args =
             try env_find_static_exception nfail env
             with Not_found ->
-              fatal_error ("Selection.emit_expr: unboun label "^
+              fatal_error ("Selection.emit_expr: unbound label "^
                            string_of_int nfail)
           in
           (* Intermediate registers to handle cases where some
              registers from src are present in dest *)
           let tmp_regs = Reg.createv_like src in
-          (* Ccatch registers are created with type Val. They must not
-             contain out of heap pointers *)
+          (* Ccatch registers must not contain out of heap pointers *)
           Array.iter (fun reg -> assert(reg.typ <> Addr)) src;
           self#insert_moves src tmp_regs ;
           self#insert_moves tmp_regs (Array.concat dest_args) ;
@@ -1127,7 +1124,7 @@ method emit_tail (env:environment) exp =
         List.map (fun (nfail, ids, e2) ->
             let rs =
               List.map
-                (fun id -> let r = self#regs_for typ_val in name_regs id r; r)
+                (fun (id, typ) -> let r = self#regs_for typ in name_regs id r; r)
                 ids in
             (nfail, ids, rs, e2))
           handlers in
@@ -1140,7 +1137,7 @@ method emit_tail (env:environment) exp =
         assert(List.length ids = List.length rs);
         let new_env =
           List.fold_left
-            (fun env (id,r) -> env_add id r env)
+            (fun env ((id, _typ),r) -> env_add id r env)
             env (List.combine ids rs) in
         nfail, self#emit_tail_sequence new_env e2
       in

--- a/testsuite/tests/asmgen/catch-float.cmm
+++ b/testsuite/tests/asmgen/catch-float.cmm
@@ -1,0 +1,11 @@
+(* TEST
+files = "main.c"
+arguments = "-DFLOAT_CATCH -DFUN=catch_float main.c"
+* asmgen
+*)
+
+(function "catch_float" (b:int)
+  (+f 10.0
+  (catch
+    (exit lbl 100.0)
+   with (lbl x:float) (+f x 1000.0))))

--- a/testsuite/tests/asmgen/catch-rec.cmm
+++ b/testsuite/tests/asmgen/catch-rec.cmm
@@ -6,6 +6,6 @@ arguments = "-DINT_INT -DFUN=catch_fact main.c"
 
 (function "catch_fact" (b:int)
   (catch (exit fact b 1)
-   with (fact c acc)
+   with (fact c:val acc:val)
      (if (== c 0) acc
          (exit fact (- c 1) ( * c acc)))))

--- a/testsuite/tests/asmgen/catch-try-float.cmm
+++ b/testsuite/tests/asmgen/catch-try-float.cmm
@@ -1,0 +1,12 @@
+(* TEST
+files = "main.c"
+arguments = "-DFLOAT_CATCH -DFUN=catch_try_float main.c"
+* asmgen
+*)
+
+(function "catch_try_float" (b:float)
+  (+f 10.0
+  (catch
+    (try (exit lbl 100.0)
+     with var 456.0)
+   with (lbl x:float) (+f x 1000.0))))

--- a/testsuite/tests/asmgen/catch-try.cmm
+++ b/testsuite/tests/asmgen/catch-try.cmm
@@ -9,4 +9,4 @@ arguments = "-DINT_INT -DFUN=catch_exit main.c"
   (catch
     (try (exit lbl 12)
      with var 456)
-   with (lbl x) (+ x 789))))
+   with (lbl x:val) (+ x 789))))

--- a/testsuite/tests/asmgen/even-odd-spill-float.cmm
+++ b/testsuite/tests/asmgen/even-odd-spill-float.cmm
@@ -1,6 +1,6 @@
 (* TEST
 files = "main.c"
-arguments = "-DINT_INT -DFUN=is_even main.c"
+arguments = "-DINT_FLOAT -DFUN=is_even main.c"
 * asmgen
 *)
 
@@ -8,18 +8,20 @@ arguments = "-DINT_INT -DFUN=is_even main.c"
 ("format_even": string "even %d\n\000")
 
 (function "force_spill" (a:int) 0)
+(function "force_spill_float" (f:float) 0.0)
 
 (function "is_even" (b:int)
-  (catch (exit even b)
-   with (odd v:val)
-     (if (== v 0) 0
+  (catch (exit even b 0.0)
+   with (odd v:val f:float)
+     (if (== v 0) f
          (seq
            (extcall "printf_int" "format_odd" v unit)
            (let v2 (- v 1)
              (app "force_spill" 0 int)
-             (exit even v2))))
-   and (even v:val)
-     (if (== v 0) 1
+             (app "force_spill_float" 0.0 float)
+             (exit even v2 (+f 1.0 f)))))
+   and (even v:val f:float)
+     (if (== v 0) f
          (seq
            (extcall "printf_int" "format_even" v unit)
-           (exit odd (- v 1))))))
+           (exit odd (- v 1) (+f 1.0 f))))))

--- a/testsuite/tests/asmgen/even-odd.cmm
+++ b/testsuite/tests/asmgen/even-odd.cmm
@@ -6,9 +6,9 @@ arguments = "-DINT_INT -DFUN=is_even main.c"
 
 (function "is_even" (b:int)
   (catch (exit even b)
-   with (odd v)
+   with (odd v:val)
      (if (== v 0) 0
          (exit even (- v 1)))
-   and (even v)
+   and (even v:val)
      (if (== v 0) 1
          (exit odd (- v 1)))))

--- a/testsuite/tests/asmgen/main.c
+++ b/testsuite/tests/asmgen/main.c
@@ -34,6 +34,16 @@ void printf_int(char * fmt, int arg)
   printf(fmt, arg);
 }
 
+#define FLOATTEST(arg,res) \
+  { double result = (res); \
+    if (arg < result || arg > result) { \
+      printf("Failed test \"%s == %s\": " \
+             "result %.15g, expected %.15g\n", \
+             #arg, #res, arg, result); \
+      return(2); \
+    } \
+  }
+
 #ifdef SORT
 
 int cmpint(const void * i, const void * j)
@@ -69,6 +79,14 @@ int main(int argc, char **argv)
   { extern double FUN(long);
     extern double call_gen_code(double (*)(long), long);
     printf("%f\n", call_gen_code(FUN, atoi(argv[1])));
+  }
+#endif
+#ifdef FLOAT_CATCH
+  { extern double FUN(long);
+    extern double call_gen_code(double (*)(long), long);
+    double result = call_gen_code(FUN, 1);
+    FLOATTEST(result, 1110.0)
+    printf("%f\n", result);
   }
 #endif
 #ifdef SORT

--- a/testsuite/tests/asmgen/ocamltests
+++ b/testsuite/tests/asmgen/ocamltests
@@ -1,8 +1,11 @@
 arith.cmm
 catch-rec.cmm
 catch-try.cmm
+catch-float.cmm
+catch-try-float.cmm
 checkbound.cmm
 even-odd-spill.cmm
+even-odd-spill-float.cmm
 even-odd.cmm
 fib.cmm
 integr.cmm

--- a/testsuite/tests/asmgen/pgcd.cmm
+++ b/testsuite/tests/asmgen/pgcd.cmm
@@ -6,7 +6,7 @@ arguments = "-DINT_INT -DFUN=pgcd_30030 main.c"
 
 (function "pgcd_30030" (a:int)
   (catch (exit pgcd a 30030)
-   with (pgcd n m)
+   with (pgcd n:val m:val)
      (if (> n m)
          (exit pgcd m n)
          (if (== n 0)

--- a/testsuite/tools/asmgen_i386.S
+++ b/testsuite/tools/asmgen_i386.S
@@ -53,6 +53,17 @@ G(caml_c_call):
         .comm   G(young_ptr), 4
         .comm   G(young_start), 4
 
+        .data
+        .globl  G(caml_extra_params)
+G(caml_extra_params):
+#ifndef SYS_solaris
+        .space  64
+#else
+        .zero   64
+#endif
+
+
+
 #if defined(SYS_linux_elf)
     /* Mark stack as non-executable */
         .section .note.GNU-stack,"",%progbits

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -210,7 +210,8 @@ expr:
     { Cexit(find_label $3, List.rev $4) }
   | LPAREN CATCH sequence WITH catch_handlers RPAREN
     { let handlers = $5 in
-      List.iter (fun (_, l, _) -> List.iter unbind_ident l) handlers;
+      List.iter (fun (_, l, _) ->
+        List.iter (fun (x, _) -> unbind_ident x) l) handlers;
       Ccatch(Recursive, handlers, $3) }
   | EXIT        { Cexit(0,[]) }
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
@@ -361,12 +362,8 @@ catch_handlers:
 catch_handler:
   | sequence
     { 0, [], $1 }
-  | LPAREN IDENT bind_identlist RPAREN sequence
+  | LPAREN IDENT params RPAREN sequence
     { find_label $2, $3, $5 }
-
-bind_identlist:
-    /**/                        { [] }
-  | bind_ident bind_identlist   { $1 :: $2 }
 
 location:
     /**/                        { None }


### PR DESCRIPTION
Summary
-------
This patch adds explicit type annotations for Ccatch payloads in the CMM
IR, thus supporting payloads which are not of type `val`.

(Note: I opened a PR a week or so ago which failed one test on x86. This was due to a missing symbol in `asmgen_i386.S`, which is added now).

Rationale
---------
While CMM generated from OCaml source will always generate payloads of type
`val`, this is not the case when targeting CMM to compile from a different
language. As a concrete example, I am currently targeting the CMM backend for
compilation of WebAssembly, and require `float` payloads. Additionally, @mshinwell
has noted that such an extension will be useful for flambda2. As a result, this
patch will increase the applicability of the CMM IR as a compilation target.

Design
------
The design of the patch is as follows:

  1. Add explicit type annotations to Ccatch handlers. Specifically,
        ```Ccatch (int * (Ident.t list) * expression)```
     becomes
        ```Ccatch (int * (Ident.t * machtype) list * expression)```

  2. By default, in `cmmgen`, select `typ_val` as the `machtype`

  3. Select an appropriate register using the type annotation in `selectgen`,
     instead of defaulting to `typ_val`

  4. Test updates:
     - Update the CMM parser and pretty-printer to require annotations on Ccatch
       handlers
     - Update the existing CMM tests to add the required annotations
     - Add new tests which require the use of floating-point registers, for
       which the compiler would generate invalid ASM prior to this patch

Since all OCaml code will use `typ_val` as before in `cmmgen` and therefore
`selectgen`, compilation for OCaml programs will be identical.