### PR TITLE
manual: a subsection for the precedence and associativity table

### DIFF
--- a/manual/manual/refman/expr.etex
+++ b/manual/manual/refman/expr.etex
@@ -122,6 +122,7 @@ See also the following language extensions:
 \hyperref[s:local-exceptions]{local exceptions}
 \hyperref[s:index-operators]{extended indexing operators}.
 
+\subsection{Precedence and associativity}
 The table below shows the relative precedences and associativity of
 operators and non-closed constructions. The constructions with higher
 precedence come first. For infix and prefix symbols, we write


### PR DESCRIPTION
This micro PR adds a subsection for the precedence and associativity table in the language reference chapter. This change should make the table  much more visible and easier to find:  currently, some people find the Caml Light version of the table before the one in the manual version.

This PR also make it possible to directly link to the table section whereas the current nearest anchor is
 http://caml.inria.fr/pub/docs/manual-ocaml/expr.html#s:value-expr .