### PR TITLE
Add support for OCAMLTOP_INCLUDE_PATH environment variable

### DIFF
--- a/Changes
+++ b/Changes
@@ -213,6 +213,10 @@ Working version
 - GPR#2058: full explanation for unsafe cycles in recursive module definitions
   (Florian Angeletti, review by Gabriel Scherer, suggested by Ivan Gotovchits)
 
+- GPR#1841, MPR#7808: the environment variable OCAMLTOP_INCLUDE_PATH can now
+  specify a list of additional include directories for the ocaml toplevel.
+  (Nicolás Ojeda Bär, request by Daniel Bünzli, review by Damien Doligez)
+
 ### Code generation and optimizations:
 
 - MPR#7725, GPR#1754: improve AFL instrumentation for objects and lazy values.

--- a/Changes
+++ b/Changes
@@ -215,7 +215,8 @@ Working version
 
 - GPR#1841, MPR#7808: the environment variable OCAMLTOP_INCLUDE_PATH can now
   specify a list of additional include directories for the ocaml toplevel.
-  (Nicolás Ojeda Bär, request by Daniel Bünzli, review by Damien Doligez)
+  (Nicolás Ojeda Bär, request by Daniel Bünzli, review by Daniel Bünzli and
+  Damien Doligez)
 
 ### Code generation and optimizations:
 

--- a/bytecomp/dll.ml
+++ b/bytecomp/dll.ml
@@ -132,32 +132,20 @@ let ld_conf_contents () =
 
 (* Split the CAML_LD_LIBRARY_PATH environment variable and return
    the corresponding list of directories.  *)
-
-let split str sep =
-  let rec split_rec pos =
-    if pos >= String.length str then [] else begin
-      try
-        let newpos = String.index_from str pos sep in
-        String.sub str pos (newpos - pos) ::
-        split_rec (newpos + 1)
-      with Not_found ->
-        [String.sub str pos (String.length str - pos)]
-    end in
-  split_rec 0
-
 let ld_library_path_contents () =
   let path_separator =
     match Sys.os_type with
     | "Unix" | "Cygwin" -> ':'
     | "Win32" -> ';'
     | _ -> assert false in
-  try
-    split (Sys.getenv "CAML_LD_LIBRARY_PATH") path_separator
-  with Not_found ->
-    []
+  match Sys.getenv "CAML_LD_LIBRARY_PATH" with
+  | exception Not_found ->
+      []
+  | s ->
+      String.split_on_char path_separator s
 
 let split_dll_path path =
-  split path '\000'
+  String.split_on_char '\000' path
 
 (* Initialization for separate compilation *)
 

--- a/bytecomp/dll.ml
+++ b/bytecomp/dll.ml
@@ -133,16 +133,11 @@ let ld_conf_contents () =
 (* Split the CAML_LD_LIBRARY_PATH environment variable and return
    the corresponding list of directories.  *)
 let ld_library_path_contents () =
-  let path_separator =
-    match Sys.os_type with
-    | "Unix" | "Cygwin" -> ':'
-    | "Win32" -> ';'
-    | _ -> assert false in
   match Sys.getenv "CAML_LD_LIBRARY_PATH" with
   | exception Not_found ->
       []
   | s ->
-      String.split_on_char path_separator s
+      Misc.split_path_contents s
 
 let split_dll_path path =
   String.split_on_char '\000' path

--- a/bytecomp/dll.ml
+++ b/bytecomp/dll.ml
@@ -140,7 +140,7 @@ let ld_library_path_contents () =
       Misc.split_path_contents s
 
 let split_dll_path path =
-  String.split_on_char '\000' path
+  Misc.split_path_contents ~sep:'\000' path
 
 (* Initialization for separate compilation *)
 

--- a/manual/manual/cmds/top.etex
+++ b/manual/manual/cmds/top.etex
@@ -125,6 +125,10 @@ The following command-line options are recognized by the "ocaml" command.
 \begin{unix}
 The following environment variables are also consulted:
 \begin{options}
+\item["OCAMLTOP_INCLUDE_PATH"]  Additional directories to search for
+  compiled object code files (".cmi", ".cmo" and ".cma"). The directory list
+  is searched in left-to-right order.
+
 \item["OCAMLTOP_UTF_8"] When printing string values, non-ascii bytes
 ($ {} > "\0x7E" $) are printed as decimal escape sequence if "OCAMLTOP_UTF_8" is
 set to false. Otherwise, they are printed unescaped.
@@ -424,16 +428,6 @@ compiled object code files (".cmo" and ".cma").
 \item["-o" \var{exec-file}]
 Specify the name of the toplevel file produced by the linker.
 The default is "a.out".
-
-\end{options}
-
-\noindent
-The following environment variables are also consulted:
-
-\begin{options}
-
-\item["OCAMLTOP_INCLUDE_PATH"]  Additional directories to search for
-  compiled object code files (".cmo" and ".cma").
 
 \end{options}
 

--- a/manual/manual/cmds/top.etex
+++ b/manual/manual/cmds/top.etex
@@ -128,7 +128,7 @@ The following environment variables are also consulted:
 \item["OCAMLTOP_INCLUDE_PATH"] Additional directories to search for compiled
   object code files (".cmi", ".cmo" and ".cma"). The specified directories are
   considered from left to right, after the include directories specified on the
-  command line via "-I" have been searched.
+  command line via "-I" have been searched. Available since OCaml 4.08.
 
 \item["OCAMLTOP_UTF_8"] When printing string values, non-ascii bytes
 ($ {} > "\0x7E" $) are printed as decimal escape sequence if "OCAMLTOP_UTF_8" is

--- a/manual/manual/cmds/top.etex
+++ b/manual/manual/cmds/top.etex
@@ -125,9 +125,10 @@ The following command-line options are recognized by the "ocaml" command.
 \begin{unix}
 The following environment variables are also consulted:
 \begin{options}
-\item["OCAMLTOP_INCLUDE_PATH"]  Additional directories to search for
-  compiled object code files (".cmi", ".cmo" and ".cma"). The directory list
-  is searched in left-to-right order.
+\item["OCAMLTOP_INCLUDE_PATH"] Additional directories to search for compiled
+  object code files (".cmi", ".cmo" and ".cma"). The specified directories are
+  considered from left to right, after the include directories specified on the
+  command line via "-I" have been searched.
 
 \item["OCAMLTOP_UTF_8"] When printing string values, non-ascii bytes
 ($ {} > "\0x7E" $) are printed as decimal escape sequence if "OCAMLTOP_UTF_8" is

--- a/manual/manual/cmds/top.etex
+++ b/manual/manual/cmds/top.etex
@@ -212,7 +212,7 @@ directories:
   \item Directories added with the "#directory" directive.
   \item Directories given on the command line with "-I" options.
   \item The standard library directory.
-\end{enumerate}    
+\end{enumerate}
 
 \item[Environment queries]
   \begin{options}
@@ -424,6 +424,16 @@ compiled object code files (".cmo" and ".cma").
 \item["-o" \var{exec-file}]
 Specify the name of the toplevel file produced by the linker.
 The default is "a.out".
+
+\end{options}
+
+\noindent
+The following environment variables are also consulted:
+
+\begin{options}
+
+\item["OCAMLTOP_INCLUDE_PATH"]  Additional directories to search for
+  compiled object code files (".cmo" and ".cma").
 
 \end{options}
 

--- a/toplevel/opttopmain.ml
+++ b/toplevel/opttopmain.ml
@@ -248,6 +248,14 @@ module Options = Main_args.Make_opttop_options (struct
   let anonymous = file_argument
 end);;
 
+let () =
+  let extra_paths =
+    match Sys.getenv "OCAMLTOP_INCLUDE_PATH" with
+    | exception Not_found -> []
+    | s -> Misc.split_path_contents s
+  in
+  Clflags.include_dirs := List.rev_append extra_paths !Clflags.include_dirs
+
 let main () =
   native_code := true;
   let list = ref Options.list in

--- a/toplevel/topmain.ml
+++ b/toplevel/topmain.ml
@@ -156,6 +156,13 @@ module Options = Main_args.Make_bytetop_options (struct
   let anonymous s = file_argument s
 end);;
 
+let () =
+  let extra_paths =
+    match Sys.getenv "OCAMLTOP_INCLUDE_PATH" with
+    | exception Not_found -> []
+    | s -> Misc.split_path_contents s
+  in
+  Clflags.include_dirs := List.rev_append extra_paths !Clflags.include_dirs
 
 let main () =
   let ppf = Format.err_formatter in

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -272,6 +272,17 @@ let expand_directory alt s =
                        (String.sub s 1 (String.length s - 1))
   else s
 
+(* Split contents of "PATH"-like variable and return
+   the corresponding list of directories.  *)
+let split_path_contents s =
+  let path_separator =
+    match Sys.os_type with
+    | "Unix" | "Cygwin" -> ':'
+    | "Win32" -> ';'
+    | _ -> assert false
+  in
+  String.split_on_char path_separator s
+
 (* Hashtable functions *)
 
 let create_hashtable size init =

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -272,16 +272,17 @@ let expand_directory alt s =
                        (String.sub s 1 (String.length s - 1))
   else s
 
-(* Split contents of "PATH"-like variable and return
-   the corresponding list of directories.  *)
-let split_path_contents s =
-  let path_separator =
-    match Sys.os_type with
-    | "Unix" | "Cygwin" -> ':'
-    | "Win32" -> ';'
-    | _ -> assert false
-  in
-  String.split_on_char path_separator s
+let split_path_contents ?sep = function
+  | "" -> []
+  | s ->
+      let path_separator =
+        match sep, Sys.os_type with
+        | Some c, _ -> c
+        | None, ("Unix" | "Cygwin") -> ':'
+        | None, "Win32" -> ';'
+        | None, _ -> assert false
+      in
+      String.split_on_char path_separator s
 
 (* Hashtable functions *)
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -272,17 +272,14 @@ let expand_directory alt s =
                        (String.sub s 1 (String.length s - 1))
   else s
 
-let split_path_contents ?sep = function
+let path_separator =
+  match Sys.os_type with
+  | "Win32" -> ';'
+  | _ -> ':'
+
+let split_path_contents ?(sep = path_separator) = function
   | "" -> []
-  | s ->
-      let path_separator =
-        match sep, Sys.os_type with
-        | Some c, _ -> c
-        | None, ("Unix" | "Cygwin") -> ':'
-        | None, "Win32" -> ';'
-        | None, _ -> assert false
-      in
-      String.split_on_char path_separator s
+  | s -> String.split_on_char sep s
 
 (* Hashtable functions *)
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -163,6 +163,10 @@ val expand_directory: string -> string -> string
         (* [expand_directory alt file] eventually expands a [+] at the
            beginning of file into [alt] (an alternate root directory) *)
 
+val split_path_contents: string -> string list
+(* Split contents of "PATH"-like variable and return
+   the corresponding list of directories.  *)
+
 val create_hashtable: int -> ('a * 'b) list -> ('a, 'b) Hashtbl.t
         (* Create a hashtable of the given size and fills it with the
            given bindings. *)

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -163,9 +163,12 @@ val expand_directory: string -> string -> string
         (* [expand_directory alt file] eventually expands a [+] at the
            beginning of file into [alt] (an alternate root directory) *)
 
-val split_path_contents: string -> string list
-(* Split contents of "PATH"-like variable and return
-   the corresponding list of directories.  *)
+val split_path_contents: ?sep:char -> string -> string list
+(* [split_path_contents ?sep s] interprets [s] as the value of a "PATH"-like
+   variable and returns the corresponding list of directories. [s] is split
+   using the platform-specific delimiter, or [~sep] if it is passed.
+
+   Returns the empty list if [s] is empty. *)
 
 val create_hashtable: int -> ('a * 'b) list -> ('a, 'b) Hashtbl.t
         (* Create a hashtable of the given size and fills it with the


### PR DESCRIPTION
See [MPR#7808](https://caml.inria.fr/mantis/view.php?id=7808).

We add the possibility of passing extra include directories to the `ocaml` toplevel by using a specific environment variable `OCAMLTOP_INCLUDE_PATH`. The effect is the same as if they had been passed using  `-I` options.
