### PR TITLE
fix 'depend' target in otherlibs/bigarray

### DIFF
--- a/otherlibs/bigarray/Makefile
+++ b/otherlibs/bigarray/Makefile
@@ -33,11 +33,6 @@ mmap_ba.$(O): ../unix/mmap_ba.c
 .PHONY: depend
 
 depend:
-ifeq "$(TOOLCHAIN)" "msvc"
-	$(error Dependencies cannot be regenerated using the MSVC ports)
-else
-	$(CC) -MM $(CFLAGS) $(CPPFLAGS) *.c | sed -e 's/\.o/.$$(O)/g' > .depend
-	$(CAMLRUN) $(ROOTDIR)/tools/ocamldep -slash *.mli *.ml >> .depend
-endif
+	$(CAMLRUN) $(ROOTDIR)/tools/ocamldep -slash *.mli *.ml > .depend
 
 include .depend


### PR DESCRIPTION
This target has been broken by the move of bigarray C files to the runtime.
Before the current PR:

```
$ make depend
gcc -MM -O2 -fno-strict-aliasing -fwrapv -Wall -Werror -fno-tree-vrp -fPIC -I../unix -DIN_OCAML_BIGARRAY -D_FILE_OFFSET_BITS=64 -D_REENTRANT -DCAML_NAME_SPACE  -I../../byterun *.c | sed -e 's/\.o/.$(O)/g' > .depend
gcc: error: *.c: No such file or directory
gcc: fatal error: no input files
```