### PR TITLE
Fix typo in generic_final_minor_update leading to SEGV or missing finalyser calls.

### DIFF
--- a/byterun/finalise.c
+++ b/byterun/finalise.c
@@ -314,7 +314,7 @@ static void generic_final_minor_update (struct finalisable * final)
       CAMLassert (Is_block (final->table[i].val));
       CAMLassert (Is_in_heap_or_young (final->table[i].val));
       CAMLassert (Tag_val (final->table[i].val) != Forward_tag);
-      if(Is_young(final->table[j].val) && Hd_val(final->table[i].val) != 0){
+      if(Is_young(final->table[i].val) && Hd_val(final->table[i].val) != 0){
         /** dead */
         to_do_tl->item[k] = final->table[i];
         /* The finalisation function is called with unit not with the value */


### PR DESCRIPTION
Simple test case: SEGV on 4.06.1 and trunk

```
let alloc_a () =
  let v = Bytes.create 4096 in
  Gc.finalise_last (fun _ -> ()) v;
  v

let alloc_b () =
  let v = Bytes.create 16 in
  Gc.finalise_last (fun _ -> ()) v;
  v

let main () =
  let q = Queue.create () in
  while true do
    let b = alloc_b () in
    Queue.push b q;
    let a = alloc_a () in
    Queue.push a q;

    while (Queue.length q > 0) do
      ignore(Queue.pop q);
    done;
    Thread.yield ()
  done

let _ = main ()
```