### PR TITLE
parser: better location on type constraints (on expressions)

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -748,18 +748,21 @@ paren_module_expr:
   | LPAREN VAL attributes expr RPAREN
       { mkmod ~attrs:$3 (Pmod_unpack $4)}
   | LPAREN VAL attributes expr COLON package_type RPAREN
-      { mkmod ~attrs:$3
+      { let constr_loc = rhs_interval 4 6 in
+        mkmod ~attrs:$3
           (Pmod_unpack(
-               ghexp(Pexp_constraint($4, $6)))) }
+               ghexp ~loc:constr_loc (Pexp_constraint($4, $6)))) }
   | LPAREN VAL attributes expr COLON package_type COLONGREATER package_type
     RPAREN
-      { mkmod ~attrs:$3
+      { let constr_loc = rhs_interval 4 8 in
+        mkmod ~attrs:$3
           (Pmod_unpack(
-               ghexp(Pexp_coerce($4, Some $6, $8)))) }
+               ghexp ~loc:constr_loc (Pexp_coerce($4, Some $6, $8)))) }
   | LPAREN VAL attributes expr COLONGREATER package_type RPAREN
-      { mkmod ~attrs:$3
+      { let constr_loc = rhs_interval 4 6 in
+        mkmod ~attrs:$3
           (Pmod_unpack(
-               ghexp(Pexp_coerce($4, None, $6)))) }
+               ghexp ~loc:constr_loc (Pexp_coerce($4, None, $6)))) }
   | LPAREN VAL attributes expr COLON error
       { unclosed "(" 1 ")" 6 }
   | LPAREN VAL attributes expr COLONGREATER error
@@ -1132,16 +1135,19 @@ method_:
       { if $1 = Override then syntax_error ();
         (mkrhs $5 5, $4, Cfk_virtual $7), $2 }
   | override_flag attributes private_flag label strict_binding
-      { (mkrhs $4 4, $3,
-        Cfk_concrete ($1, ghexp(Pexp_poly ($5, None)))), $2 }
+      { let e = $5 in
+        (mkrhs $4 4, $3,
+        Cfk_concrete ($1, ghexp ~loc:e.pexp_loc (Pexp_poly (e, None)))), $2 }
   | override_flag attributes private_flag label COLON poly_type EQUAL seq_expr
-      { (mkrhs $4 4, $3,
-        Cfk_concrete ($1, ghexp(Pexp_poly($8, Some $6)))), $2 }
+      { let loc = rhs_interval 6 8 in
+        (mkrhs $4 4, $3,
+        Cfk_concrete ($1, ghexp ~loc (Pexp_poly($8, Some $6)))), $2 }
   | override_flag attributes private_flag label COLON TYPE lident_list
     DOT core_type EQUAL seq_expr
       { let exp, poly = wrap_type_annotation $7 $9 $11 in
+        let loc = rhs_interval 7 11 in
         (mkrhs $4 4, $3,
-        Cfk_concrete ($1, ghexp(Pexp_poly(exp, Some poly)))), $2 }
+        Cfk_concrete ($1, ghexp ~loc (Pexp_poly(exp, Some poly)))), $2 }
 ;
 
 /* Class types */

--- a/testsuite/tests/parsing/shortcut_ext_attr.compilers.reference
+++ b/testsuite/tests/parsing/shortcut_ext_attr.compilers.reference
@@ -387,7 +387,7 @@
                       Pcf_method Public
                         "x" (shortcut_ext_attr.ml[42,939+17]..[42,939+18])
                         Concrete Fresh
-                        expression (shortcut_ext_attr.ml[42,939+10]..[42,939+22]) ghost
+                        expression (shortcut_ext_attr.ml[42,939+21]..[42,939+22]) ghost
                           Pexp_poly
                           expression (shortcut_ext_attr.ml[42,939+21]..[42,939+22])
                             Pexp_constant PConst_int (3,None)
@@ -407,7 +407,7 @@
                       Pcf_method Private
                         "x" (shortcut_ext_attr.ml[44,993+26]..[44,993+27])
                         Concrete Override
-                        expression (shortcut_ext_attr.ml[44,993+10]..[44,993+31]) ghost
+                        expression (shortcut_ext_attr.ml[44,993+30]..[44,993+31]) ghost
                           Pexp_poly
                           expression (shortcut_ext_attr.ml[44,993+30]..[44,993+31])
                             Pexp_constant PConst_int (3,None)


### PR DESCRIPTION
Round 2: the previous PR looked only at constraints on patterns, while this one looks at expressions.