### PR TITLE
Add "finally" function to Pervasives

### DIFF
--- a/Changes
+++ b/Changes
@@ -75,8 +75,8 @@ Working version
 - GPR#1959: Small simplification and optimization to Format.ifprintf
   (Gabriel Radanne, review by Gabriel Scherer)
 
-- GPR#1855: Add `Pervasives.try_finally`, similar to `Misc.try_finally` from
-  the compiler library but using `Printexc.raise_with_backtrace` for
+- GPR#1855: Add `Pervasives.protect ~finally`, similar to `Misc.try_finally`
+  from the compiler library but using `Printexc.raise_with_backtrace` for
   preserving backtraces.
   (Marcello Seri, review by Daniel Bünzli, Gabriel Scherer, François Bobot,
   Nicolás Ojeda Bär, Xavier Clerc and Boris Yakobowski)

--- a/Changes
+++ b/Changes
@@ -75,6 +75,12 @@ Working version
 - GPR#1959: Small simplification and optimization to Format.ifprintf
   (Gabriel Radanne, review by Gabriel Scherer)
 
+- GPR#1855: Add `Pervasives.try_finally`, similar to `Misc.try_finally` from
+  the compiler library but using `Printexc.raise_with_backtrace` for
+  preserving backtraces.
+  (Marcello Seri, review by Daniel Bünzli, Gabriel Scherer, François Bobot,
+  Nicolás Ojeda Bär, Xavier Clerc and Boris Yakobowski)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/otherlibs/threads/stdlib.ml
+++ b/otherlibs/threads/stdlib.ml
@@ -39,6 +39,11 @@ let invalid_arg s = raise(Invalid_argument s)
 
 exception Exit
 
+let try_finally (work: unit -> 'a) (cleanup: unit -> unit) : 'a =
+  let result = (try work () with e -> cleanup (); raise e) in
+  cleanup ();
+  result
+
 (* Composition operators *)
 
 external ( |> ) : 'a -> ('a -> 'b) -> 'b = "%revapply"

--- a/otherlibs/threads/stdlib.ml
+++ b/otherlibs/threads/stdlib.ml
@@ -40,9 +40,9 @@ let invalid_arg s = raise(Invalid_argument s)
 exception Exit
 
 let try_finally (work: unit -> 'a) (cleanup: unit -> unit) : 'a =
-  let result = (try work () with e -> cleanup (); raise e) in
-  cleanup ();
-  result
+  match work () with
+  | result -> cleanup (); result
+  | exception e -> cleanup (); raise e
 
 (* Composition operators *)
 

--- a/otherlibs/threads/stdlib.ml
+++ b/otherlibs/threads/stdlib.ml
@@ -45,12 +45,12 @@ external _get_raw_backtrace:
 external _raise_with_backtrace: exn -> _raw_backtrace -> 'a
   = "%raise_with_backtrace"
 
-let try_finally ~(always: unit -> unit) work =
+let protect ~(finally: unit -> unit) work =
   match work () with
-  | result -> always (); result
+  | result -> finally (); result
   | exception work_exn ->
     let work_bt = _get_raw_backtrace () in
-    always ();
+    finally ();
     _raise_with_backtrace work_exn work_bt
 
 (* Composition operators *)

--- a/otherlibs/threads/stdlib.ml
+++ b/otherlibs/threads/stdlib.ml
@@ -45,27 +45,13 @@ external _get_raw_backtrace:
 external _raise_with_backtrace: exn -> _raw_backtrace -> 'a
   = "%raise_with_backtrace"
 
-let try_finally ?(always=fun () -> ()) ?(exceptionally=fun () -> ()) work =
+let try_finally ~(always: unit -> unit) work =
   match work () with
-  | result ->
-      begin match always () with
-      | () -> result
-      | exception always_exn ->
-          let always_bt = _get_raw_backtrace () in
-          exceptionally ();
-          _raise_with_backtrace always_exn always_bt
-      end
+  | result -> always (); result
   | exception work_exn ->
-      let work_bt = _get_raw_backtrace () in
-      begin match always () with
-      | () ->
-          exceptionally ();
-          _raise_with_backtrace work_exn work_bt
-      | exception always_exn ->
-          let always_bt = _get_raw_backtrace () in
-          exceptionally ();
-          _raise_with_backtrace always_exn always_bt
-      end
+    let work_bt = _get_raw_backtrace () in
+    always ();
+    _raise_with_backtrace work_exn work_bt
 
 (* Composition operators *)
 

--- a/otherlibs/threads/stdlib.ml
+++ b/otherlibs/threads/stdlib.ml
@@ -39,10 +39,33 @@ let invalid_arg s = raise(Invalid_argument s)
 
 exception Exit
 
-let try_finally (work: unit -> 'a) (cleanup: unit -> unit) : 'a =
+type _raw_backtrace
+external _get_raw_backtrace:
+  unit -> _raw_backtrace = "caml_get_exception_raw_backtrace"
+external _raise_with_backtrace: exn -> _raw_backtrace -> 'a
+  = "%raise_with_backtrace"
+
+let try_finally ?(always=fun () -> ()) ?(exceptionally=fun () -> ()) work =
   match work () with
-  | result -> cleanup (); result
-  | exception e -> cleanup (); raise e
+  | result ->
+      begin match always () with
+      | () -> result
+      | exception always_exn ->
+          let always_bt = _get_raw_backtrace () in
+          exceptionally ();
+          _raise_with_backtrace always_exn always_bt
+      end
+  | exception work_exn ->
+      let work_bt = _get_raw_backtrace () in
+      begin match always () with
+      | () ->
+          exceptionally ();
+          _raise_with_backtrace work_exn work_bt
+      | exception always_exn ->
+          let always_bt = _get_raw_backtrace () in
+          exceptionally ();
+          _raise_with_backtrace always_exn always_bt
+      end
 
 (* Composition operators *)
 

--- a/otherlibs/threads/stdlib.ml
+++ b/otherlibs/threads/stdlib.ml
@@ -39,19 +39,19 @@ let invalid_arg s = raise(Invalid_argument s)
 
 exception Exit
 
-type _raw_backtrace
-external _get_raw_backtrace:
-  unit -> _raw_backtrace = "caml_get_exception_raw_backtrace"
-external _raise_with_backtrace: exn -> _raw_backtrace -> 'a
+type raw_backtrace
+external get_raw_backtrace:
+  unit -> raw_backtrace = "caml_get_exception_raw_backtrace"
+external raise_with_backtrace: exn -> raw_backtrace -> 'a
   = "%raise_with_backtrace"
 
 let protect ~(finally: unit -> unit) work =
   match work () with
   | result -> finally (); result
   | exception work_exn ->
-    let work_bt = _get_raw_backtrace () in
+    let work_bt = get_raw_backtrace () in
     finally ();
-    _raise_with_backtrace work_exn work_bt
+    raise_with_backtrace work_exn work_bt
 
 (* Composition operators *)
 

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -35,6 +35,11 @@ let invalid_arg s = raise(Invalid_argument s)
 
 exception Exit
 
+let try_finally (work: unit -> 'a) (cleanup: unit -> unit) : 'a =
+  let result = (try work () with e -> cleanup (); raise e) in
+  cleanup ();
+  result
+
 (* Composition operators *)
 
 external ( |> ) : 'a -> ('a -> 'b) -> 'b = "%revapply"

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -36,9 +36,9 @@ let invalid_arg s = raise(Invalid_argument s)
 exception Exit
 
 let try_finally (work: unit -> 'a) (cleanup: unit -> unit) : 'a =
-  let result = (try work () with e -> cleanup (); raise e) in
-  cleanup ();
-  result
+  match work () with
+  | result -> cleanup (); result
+  | exception e -> cleanup (); raise e
 
 (* Composition operators *)
 

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -35,19 +35,19 @@ let invalid_arg s = raise(Invalid_argument s)
 
 exception Exit
 
-type _raw_backtrace
-external _get_raw_backtrace:
-  unit -> _raw_backtrace = "caml_get_exception_raw_backtrace"
-external _raise_with_backtrace: exn -> _raw_backtrace -> 'a
+type raw_backtrace
+external get_raw_backtrace:
+  unit -> raw_backtrace = "caml_get_exception_raw_backtrace"
+external raise_with_backtrace: exn -> raw_backtrace -> 'a
   = "%raise_with_backtrace"
 
 let protect ~(finally: unit -> unit) work =
   match work () with
   | result -> finally (); result
   | exception work_exn ->
-    let work_bt = _get_raw_backtrace () in
+    let work_bt = get_raw_backtrace () in
     finally ();
-    _raise_with_backtrace work_exn work_bt
+    raise_with_backtrace work_exn work_bt
 
 (* Composition operators *)
 

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -41,27 +41,13 @@ external _get_raw_backtrace:
 external _raise_with_backtrace: exn -> _raw_backtrace -> 'a
   = "%raise_with_backtrace"
 
-let try_finally ?(always=fun () -> ()) ?(exceptionally=fun () -> ()) work =
+let try_finally ~(always: unit -> unit) work =
   match work () with
-  | result ->
-      begin match always () with
-      | () -> result
-      | exception always_exn ->
-          let always_bt = _get_raw_backtrace () in
-          exceptionally ();
-          _raise_with_backtrace always_exn always_bt
-      end
+  | result -> always (); result
   | exception work_exn ->
-      let work_bt = _get_raw_backtrace () in
-      begin match always () with
-      | () ->
-          exceptionally ();
-          _raise_with_backtrace work_exn work_bt
-      | exception always_exn ->
-          let always_bt = _get_raw_backtrace () in
-          exceptionally ();
-          _raise_with_backtrace always_exn always_bt
-      end
+    let work_bt = _get_raw_backtrace () in
+    always ();
+    _raise_with_backtrace work_exn work_bt
 
 (* Composition operators *)
 

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -41,12 +41,12 @@ external _get_raw_backtrace:
 external _raise_with_backtrace: exn -> _raw_backtrace -> 'a
   = "%raise_with_backtrace"
 
-let try_finally ~(always: unit -> unit) work =
+let protect ~(finally: unit -> unit) work =
   match work () with
-  | result -> always (); result
+  | result -> finally (); result
   | exception work_exn ->
     let work_bt = _get_raw_backtrace () in
-    always ();
+    finally ();
     _raise_with_backtrace work_exn work_bt
 
 (* Composition operators *)

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -53,8 +53,8 @@ exception Exit
 
 val try_finally : (unit -> 'a) -> (unit -> unit) -> 'a
 (** [try_finally f g] calls [f ()] and returns its result.  If it raises,
-    the same exception is raised; in {b: any} case, [g ()] is called after
-    [f ()] terminates.
+    the same exception is raised unless [g ()] itself raises;
+    in {b: any} case, [g ()] is called after [f ()] terminates.
 
     @since NEXT_RELEASE *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -51,6 +51,12 @@ exception Exit
 (** The [Exit] exception is not raised by any library function.  It is
     provided for use in your programs. *)
 
+val try_finally : (unit -> 'a) -> (unit -> unit) -> 'a
+(** [try_finally f g] calls [f ()] and returns its result.  If it raises,
+    the same exception is raised; in {b: any} case, [g ()] is called after
+    [f ()] terminates.
+
+    @since NEXT_RELEASE *)
 
 (** {1 Comparisons} *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -51,40 +51,15 @@ exception Exit
 (** The [Exit] exception is not raised by any library function.  It is
     provided for use in your programs. *)
 
-val try_finally :
-  ?always:(unit -> unit) ->
-  ?exceptionally:(unit -> unit) ->
-  (unit -> 'a) -> 'a
-(** [try_finally work ~always ~exceptionally] is designed to run code
-    in [work] that may fail with an exception, and has two kind of
-    cleanup routines:
-    {ul
-    {- [always], that must be run after {b any} execution
-       of the function (typically, freeing system resources), and}
-    {- [exceptionally], that should be run {b only} if [work] or [always]
-       failed with an exception (typically, undoing user-visible state
-       changes that would only make sense if the function completes
-       correctly).}
-    }
-    For example:
-    {[
-      let outfile = outputprefix ^ ".cmo" in
-      let oc = open_out_bin objfile in
-      try_finally
-        (fun () ->
-           bytecode
-           ++ Timings.(accumulate_time (Generate sourcefile))
-               (Emitcode.to_file oc modulename objfile);
-           Warnings.check_fatal ())
-        ~always:(fun () -> close_out oc)
-        ~exceptionally:(fun _exn -> remove_file objfile);
-    ]}
-    If [exceptionally] fail with an exception, it is propagated as
-    usual.
-    If [always] or [exceptionally] use exceptions internally for
-    control-flow but do not raise, then [try_finally] is careful to
-    preserve any exception backtrace coming from [work] or [always]
-    for easier debugging.
+val try_finally : always:(unit -> unit) -> (unit -> 'a) -> 'a
+(** [try_finally ~always work] is designed to run code in [work] that
+    may fail with an exception.
+    The function [always], is guaranteed to run after {b any} execution
+    of the [work] function. Exceptions raised by [always] are not
+    caught, they will be propagated to the caller as usual.
+    In any other case [try_finally] will return the result of the
+    [work] funciton or re-raise its exception, preserving the
+    backtrace (For more details, see {!Printexc.raise_with_backtrace}).
 
     @since NEXT_RELEASE *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -52,14 +52,11 @@ exception Exit
     provided for use in your programs. *)
 
 val try_finally : always:(unit -> unit) -> (unit -> 'a) -> 'a
-(** [try_finally ~always work] is designed to run code in [work] that
-    may fail with an exception.
-    The function [always], is guaranteed to run after {b any} execution
-    of the [work] function. Exceptions raised by [always] are not
-    caught, they will be propagated to the caller as usual.
-    In any other case [try_finally] will return the result of the
-    [work] funciton or re-raise its exception, preserving the
-    backtrace (For more details, see {!Printexc.raise_with_backtrace}).
+(** [try_finally ~always work] invokes [work ()] and then [always ()]
+    before [work] returns with its value or an exception. In the latter
+    case the exception is re-raised after [always ()].
+    If [always ()] raises, this exception is not caught and may shadow
+    one [work ()] may have raised.
 
     @since NEXT_RELEASE *)
 

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -51,11 +51,11 @@ exception Exit
 (** The [Exit] exception is not raised by any library function.  It is
     provided for use in your programs. *)
 
-val try_finally : always:(unit -> unit) -> (unit -> 'a) -> 'a
-(** [try_finally ~always work] invokes [work ()] and then [always ()]
+val protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a
+(** [protect ~finally work] invokes [work ()] and then [finally ()]
     before [work] returns with its value or an exception. In the latter
-    case the exception is re-raised after [always ()].
-    If [always ()] raises, this exception is not caught and may shadow
+    case the exception is re-raised after [finally ()].
+    If [finally ()] raises, this exception is not caught and may shadow
     one [work ()] may have raised.
 
     @since NEXT_RELEASE *)

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -58,7 +58,7 @@ val protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a
     If [finally ()] raises, this exception is not caught and may shadow
     one [work ()] may have raised.
 
-    @since NEXT_RELEASE *)
+    @since 4.08.0 *)
 
 (** {1 Comparisons} *)
 


### PR DESCRIPTION
This exposes `Pervasives.try_finally` function, already implemented in the `Misc` module and used in the compiler.

This function is very often used to make sure that resources are clened up on failure, and practically reimplemented over and over in many modules and standard librarires.
The following are from different sources in the ocaml ecosystem:

1. From [containers (CCFun)](https://c-cube.github.io/ocaml-containers/last/containers/CCFun/index.html)
	```ocaml
	val finally : h:(unit ‑> _) ‑> f:(unit ‑> 'a) ‑> 'a
	(* finally h f calls f () and returns its result. If it raises, the same exception is raised;
	   in any case, h () is called after f () terminates. *)

	val finally1 : h:(unit ‑> _) ‑> ('a ‑> 'b) ‑> 'a ‑> 'b
	(* finally1 ~h f x is the same as f x, but after the computation, h () is called whether
	   f x rose an exception or not.
	    Since: 0.16 *)

	val finally2 : h:(unit ‑> _) ‑> ('a ‑> 'b ‑> 'c) ‑> 'a ‑> 'b ‑> 'c
	(* finally2 ~h f x y is the same as f x y, but after the computation, h () is called whether
	   f x y rose an exception or not.
	    Since: 0.16 *)
	```

2. From [base (Base.Exn)](https://ocaml.janestreet.com/ocaml-core/latest/doc/base/Base/Exn/)
	```ocaml
	val protectx : f:('a ‑> 'b) ‑> 'a ‑> finally:('a ‑> unit) ‑> 'b
	(* Executes f and afterwards executes finally, whether f throws an exception or not. *)

	val protect : f:(unit ‑> 'a) ‑> finally:(unit ‑> unit) ‑> 'a
	```

3. From [batteries (BatPervasives)](http://ocaml-batteries-team.github.io/batteries-included/hdoc2/BatPervasives.html)
	```ocaml
	val finally : (unit -> unit) -> ('a -> 'b) -> 'a -> 'b
	(* finally fend f x calls f x and then fend() even if f x raised an exception. *)

	val with_dispose : dispose:('a -> unit) -> ('a -> 'b) -> 'a -> 'b
	(* with_dispose dispose f x invokes f on x, calling dispose x when f
	   terminates (either with a return value or an exception). *)
	```

4. From [xapi-stdext-pervasives (Pervasiveext)](https://github.com/xapi-project/stdext/blob/master/lib/xapi-stdext-pervasives/pervasiveext.mli) (the same module is also in xen-oxenstored)
	```ocaml
	val finally : (unit -> 'a) -> (unit -> unit) -> 'a
	(* finally f g returns f () guaranteeing to run clean-up actions g ()
	   even if f () throws an exception. *)
	```

5. From [Unix System Programming in Ocaml](https://ocaml.github.io/ocamlunix/generalities.html#sec8):
	```ocaml
	let try_finalize f x finally y =
	   let res = try f x with exn -> finally y; raise exn in
	   finally y;
           res
	```

As you also see from the implementations, there is a tendency to already use `finally` to mention this function.
In other languages this idea seems to vary: haskell has a [`bracket` function](https://wiki.haskell.org/Bracket_pattern), python, javascript, C# and F# have `finally` as a keyword in the exception matching constructs, ruby uses `ensure`.
I think that even if it is not an optimal name, it would ease adoption. But I am happy to get any feedback on what could be the right name and implementation. See also the discussion in https://github.com/ocaml/ocaml/pull/640

An alternative implementation could be the one from @c-cube here: https://github.com/ocaml/ocaml/pull/640/commits/6bfb79518f23908f9699448b7c903e8e506d208a