### PR TITLE
Enable force-safe-string by default

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,14 @@ Working version
 - #7557, #1726: multi-indices for extended indexing operators
   (Florian Angeletti, review by Gabriel Radanne)
 
+* #1859: --enable-force-safe-string is now the default. This can be
+  overridden at configure time only (introduced by 4.04 in 2016).
+  Unless --disable-force-safe-string is used at configure time, this
+  breaks code that use the '-unsafe-string' argument and C stubs that
+  use String_val as a char* instead of const char*
+  (Kate Deplaix)
+
+
 ### Internal/compiler-libs changes:
 
 - #7927, #8527: Replace long tuples into records in typeclass.ml

--- a/configure
+++ b/configure
@@ -1517,8 +1517,8 @@ Optional Features:
   --enable-reserved-header-bits=BITS
                           reserve BITS (between 0 and 31) bits in block
                           headers for profiling info
-  --enable-force-safe-string
-                          force strings to be safe
+  --disable-force-safe-string
+                          do not force strings to be safe
   --disable-flat-float-array
                           do not use flat float arrays
   --disable-function-sections
@@ -3151,9 +3151,11 @@ fi
 # explicitly passed.
 #
 # The configure-time behavior of OCaml 4.05 and older was equivalent
-# to --disable-force-safe-string DEFAULT_STRING=unsafe. OCaml 4.06
-# and later use --disable-force-safe-string DEFAULT_STRING=safe. We
-# expect --enable-force-safe-string to become the default in the future.
+# to --disable-force-safe-string DEFAULT_STRING=unsafe. With OCaml 4.06
+# and older was equivalent to --disable-force-safe-string DEFAULT_STRING=safe.
+# With OCaml 4.10 and later use --enable-force-safe-string DEFAULT_STRING=safe.
+# We expect the --disable-force-safe-string and DEFAULT_STRING=unsafe options
+# to be removed in the future.
 
 # Check whether --enable-force-safe-string was given.
 if test "${enable_force_safe_string+set}" = set; then :
@@ -16590,12 +16592,12 @@ else
   afl=false
 fi
 
-if test x"$enable_force_safe_string" = "xyes"; then :
+if test x"$enable_force_safe_string" = "xno"; then :
   $as_echo "#define CAML_SAFE_STRING 1" >>confdefs.h
 
-  force_safe_string=true
-else
   force_safe_string=false
+else
+  force_safe_string=true
 fi
 
 if test x"$DEFAULT_STRING" = "xunsafe"; then :

--- a/configure.ac
+++ b/configure.ac
@@ -338,13 +338,15 @@ AC_ARG_VAR([WINDOWS_UNICODE_MODE],
 # explicitly passed.
 #
 # The configure-time behavior of OCaml 4.05 and older was equivalent
-# to --disable-force-safe-string DEFAULT_STRING=unsafe. OCaml 4.06
-# and later use --disable-force-safe-string DEFAULT_STRING=safe. We
-# expect --enable-force-safe-string to become the default in the future.
+# to --disable-force-safe-string DEFAULT_STRING=unsafe. With OCaml 4.06
+# and older was equivalent to --disable-force-safe-string DEFAULT_STRING=safe.
+# With OCaml 4.10 and later use --enable-force-safe-string DEFAULT_STRING=safe.
+# We expect the --disable-force-safe-string and DEFAULT_STRING=unsafe options
+# to be removed in the future.
 
 AC_ARG_ENABLE([force-safe-string],
-  [AS_HELP_STRING([--enable-force-safe-string],
-    [force strings to be safe])])
+  [AS_HELP_STRING([--disable-force-safe-string],
+    [do not force strings to be safe])])
 
 AC_ARG_VAR([DEFAULT_STRING],
   [whether strings should be safe (default) or unsafe])
@@ -1657,10 +1659,10 @@ AS_IF([test x"$with_afl" = "xyes"],
   [afl=true],
   [afl=false])
 
-AS_IF([test x"$enable_force_safe_string" = "xyes"],
+AS_IF([test x"$enable_force_safe_string" = "xno"],
   [AC_DEFINE([CAML_SAFE_STRING])
-  force_safe_string=true],
-  [force_safe_string=false])
+  force_safe_string=false],
+  [force_safe_string=true])
 
 AS_IF([test x"$DEFAULT_STRING" = "xunsafe"],
   [default_safe_string=false],

--- a/testsuite/tests/lib-arg/testarg.ml
+++ b/testsuite/tests/lib-arg/testarg.ml
@@ -1,5 +1,5 @@
 (* TEST
-   compare_programs = "false"
+   compare_programs = "false" (* See https://github.com/ocaml/ocaml/pull/8853 *)
 *)
 
 let current = ref 0;;

--- a/testsuite/tests/lib-arg/testarg.ml
+++ b/testsuite/tests/lib-arg/testarg.ml
@@ -1,4 +1,5 @@
 (* TEST
+   compare_programs = "false"
 *)
 
 let current = ref 0;;

--- a/testsuite/tests/lib-bigarray/change_layout.ml
+++ b/testsuite/tests/lib-bigarray/change_layout.ml
@@ -1,4 +1,5 @@
 (* TEST
+   compare_programs = "false"
 *)
 
 (** Test the various change_layout for Genarray and the various Array[n] *)

--- a/testsuite/tests/lib-bigarray/change_layout.ml
+++ b/testsuite/tests/lib-bigarray/change_layout.ml
@@ -1,5 +1,5 @@
 (* TEST
-   compare_programs = "false"
+   compare_programs = "false" (* See https://github.com/ocaml/ocaml/pull/8853 *)
 *)
 
 (** Test the various change_layout for Genarray and the various Array[n] *)

--- a/testsuite/tests/lib-scanf/tscanf.ml
+++ b/testsuite/tests/lib-scanf/tscanf.ml
@@ -1,6 +1,6 @@
 (* TEST
    include testing
-   compare_programs = "false"
+   compare_programs = "false" (* See https://github.com/ocaml/ocaml/pull/8853 *)
 *)
 
 (*

--- a/testsuite/tests/lib-scanf/tscanf.ml
+++ b/testsuite/tests/lib-scanf/tscanf.ml
@@ -1,5 +1,6 @@
 (* TEST
    include testing
+   compare_programs = "false"
 *)
 
 (*

--- a/testsuite/tests/ppx-contexts/myppx.ml
+++ b/testsuite/tests/ppx-contexts/myppx.ml
@@ -36,8 +36,6 @@ let () =
         !Clflags.transparent_modules;
       Printf.eprintf "unboxed_types: %B\n"
         !Clflags.unboxed_types;
-      Printf.eprintf "unsafe_string: %B\n"
-        !Clflags.unsafe_string;
       Printf.eprintf "</ppx-context>\n";
       flush stderr;
       default_mapper);

--- a/testsuite/tests/ppx-contexts/test.compilers.reference
+++ b/testsuite/tests/ppx-contexts/test.compilers.reference
@@ -8,7 +8,6 @@ recursive_types: true
 principal: true
 transparent_modules: false
 unboxed_types: true
-unsafe_string: false
 </ppx-context>
 <ppx-context>
 tool_name: "ocamlc"
@@ -20,5 +19,4 @@ recursive_types: false
 principal: false
 transparent_modules: true
 unboxed_types: false
-unsafe_string: true
 </ppx-context>

--- a/testsuite/tests/ppx-contexts/test.ml
+++ b/testsuite/tests/ppx-contexts/test.ml
@@ -14,14 +14,12 @@ flags = "-thread \
          -principal \
          -alias-deps \
          -unboxed-types \
-         -safe-string \
          -ppx ${program}"
 **** ocamlc.byte
 module = "test.ml"
 flags = "-g \
          -no-alias-deps \
          -no-unboxed-types \
-         -unsafe-string \
          -ppx ${program}"
 ***** check-ocamlc.byte-output
 *)


### PR DESCRIPTION
This PR forces safe strings globally, effectively ending the possibility for projects or modules to use unsafe strings (previously enabled by `-unsafe-string` or setting `OCAMLPARAM=safe-string=0,_`).

Rationales are:
* Safe strings have been available since 4.02 (4 years ago)
* Safe strings have been the default since 4.06 (7 months ago, see #1252)
* Very few opam packages still use unsafe strings: I'm only aware of `haxe.3.4.7` and `camlpdf.2.2.1`, maybe some others still use it under the table but very few of them remain.
* Deleting code is always good, it simplifies maintenance.

I think it would be good to have it in 4.08 but if not, at least this PR will remain open to be merged for a later release.