### PR TITLE
manual/README.md: stop mentionning the DVI manual

### DIFF
--- a/manual/README.md
+++ b/manual/README.md
@@ -39,8 +39,6 @@ In the manual:
 
 - The Info manual is in directory `infoman`.
 
-- The DVI manual is in directory `texstuff` as file `manual.dvi`.
-
 - The PDF manual is in directory `texstuff` as file `pdfmanual.pdf`.
 
 Source files


### PR DESCRIPTION
This is a follow-up to commit 2f0d65c7ee522f77765338b5889dc4bbc0979607
in GPR #1842.

@xavierleroy may want to review this.