### PR TITLE
manual, code example preprocessor : full conversion to compiler-libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,6 +245,7 @@ _ocamltestd
 /tools/stripdebug.opt
 /tools/make_opcodes
 /tools/make_opcodes.ml
+/tools/caml-tex
 
 /utils/config.ml
 

--- a/Changes
+++ b/Changes
@@ -143,6 +143,9 @@ Working version
 - GPR#1831: move the local exceptions and exception cases to the main chapters.
   (Florian Angeletti, review by Perry E. Metzger and Jeremy Yallop)
 
+- GPR#1863: caml-tex2, move to compiler-libs
+  (Florian Angeletti, review by Sébastien Hinderer and Gabriel Scherer)
+
 ### Compiler distribution build system:
 
 - GPR#1776: add -no-install-bytecode-programs and related configure options to

--- a/manual/README.md
+++ b/manual/README.md
@@ -117,7 +117,7 @@ Latex extensions
 
 ### Caml environments
 
-The tool `tools/caml-tex2` is used to generate the latex code for the examples
+The tool `tools/caml-tex` is used to generate the latex code for the examples
 in the introduction and language extension parts of the manual. It implements
 two pseudo-environments: `caml_example` and `caml_eval`.
 
@@ -145,10 +145,10 @@ otherwise an error would be raised.
 The `verbatim` does not require a final `;;` and is intended to be
 a lighter mode for code examples.
 
-By default, `caml_tex2` raises an error and stops if the output of one
+By default, `caml-tex` raises an error and stops if the output of one
 the `caml_example` environment contains an unexpected error or warning.
 If such an error or warning is, in fact, expected, it is necessary to
-indicate the expected output status to `caml_tex2` by adding either
+indicate the expected output status to `caml-tex` by adding either
 an option to the `caml_example` environment:
 ```latex
 \begin{caml_example}{toplevel}[error]

--- a/manual/manual/cmds/Makefile
+++ b/manual/manual/cmds/Makefile
@@ -5,7 +5,7 @@ LD_PATH = "$(TOPDIR)/otherlibs/str:$(TOPDIR)/otherlibs/unix"
 
 TOOLS = ../../tools
 CAMLLATEX = $(SET_LD_PATH) \
-  $(OCAMLRUN) $(TOOLS)/caml-tex2 \
+  $(OCAMLRUN) $(TOPDIR)/tools/caml-tex \
   -repo-root $(TOPDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
 TRANSF = $(SET_LD_PATH) $(OCAMLRUN) $(TOOLS)/transf

--- a/manual/manual/cmds/Makefile
+++ b/manual/manual/cmds/Makefile
@@ -6,10 +6,9 @@ LD_PATH = "$(TOPDIR)/otherlibs/str:$(TOPDIR)/otherlibs/unix"
 TOOLS = ../../tools
 CAMLLATEX = $(SET_LD_PATH) \
   $(OCAMLRUN) $(TOOLS)/caml-tex2 \
-  -caml "TERM=norepeat $(OCAML)" -n 80 -v false
+  -repo-root $(TOPDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
 TRANSF = $(SET_LD_PATH) $(OCAMLRUN) $(TOOLS)/transf
-
 
 FILES = comp.tex top.tex runtime.tex native.tex lexyacc.tex intf-c.tex \
   depend.tex profil.tex debugger.tex browser.tex ocamldoc.tex \

--- a/manual/manual/refman/Makefile
+++ b/manual/manual/refman/Makefile
@@ -5,7 +5,7 @@ LD_PATH = "$(TOPDIR)/otherlibs/str:$(TOPDIR)/otherlibs/unix"
 
 TOOLS = ../../tools
 CAMLLATEX = $(SET_LD_PATH) \
-  $(OCAMLRUN) $(TOOLS)/caml-tex2 \
+  $(OCAMLRUN) $(TOPDIR)/tools/caml-tex \
   -repo-root $(TOPDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
 TRANSF = $(SET_LD_PATH) $(OCAMLRUN) $(TOOLS)/transf

--- a/manual/manual/refman/Makefile
+++ b/manual/manual/refman/Makefile
@@ -6,7 +6,7 @@ LD_PATH = "$(TOPDIR)/otherlibs/str:$(TOPDIR)/otherlibs/unix"
 TOOLS = ../../tools
 CAMLLATEX = $(SET_LD_PATH) \
   $(OCAMLRUN) $(TOOLS)/caml-tex2 \
-  -caml "TERM=norepeat $(OCAML)" -n 80 -v false
+  -repo-root $(TOPDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
 TRANSF = $(SET_LD_PATH) $(OCAMLRUN) $(TOOLS)/transf
 

--- a/manual/manual/tutorials/Makefile
+++ b/manual/manual/tutorials/Makefile
@@ -5,7 +5,7 @@ LD_PATH = "$(TOPDIR)/otherlibs/str:$(TOPDIR)/otherlibs/unix"
 
 TOOLS = ../../tools
 CAMLLATEX = $(SET_LD_PATH) \
-  $(OCAMLRUN) $(TOOLS)/caml-tex2 \
+  $(OCAMLRUN) $(TOPDIR)/tools/caml-tex \
   -repo-root $(TOPDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
 TRANSF = $(SET_LD_PATH) $(OCAMLRUN) $(TOOLS)/transf

--- a/manual/manual/tutorials/Makefile
+++ b/manual/manual/tutorials/Makefile
@@ -6,7 +6,7 @@ LD_PATH = "$(TOPDIR)/otherlibs/str:$(TOPDIR)/otherlibs/unix"
 TOOLS = ../../tools
 CAMLLATEX = $(SET_LD_PATH) \
   $(OCAMLRUN) $(TOOLS)/caml-tex2 \
-  -caml "TERM=norepeat $(OCAML)" -n 80 -v false
+  -repo-root $(TOPDIR) -n 80 -v false
 TEXQUOTE = $(OCAMLRUN) $(TOOLS)/texquote2
 TRANSF = $(SET_LD_PATH) $(OCAMLRUN) $(TOOLS)/transf
 

--- a/manual/manual/tutorials/objectexamples.etex
+++ b/manual/manual/tutorials/objectexamples.etex
@@ -699,7 +699,7 @@ The following idiom separates description and definition.
 \begin{caml_example*}{toplevel}
 class type ['a] iterator =
   object method fold : ('b -> 'a -> 'b) -> 'b -> 'b end;;
-class intlist l =
+class intlist' l =
   object (self : int #iterator)
     method empty = (l = [])
     method fold f accu = List.fold_left f accu l

--- a/manual/tools/.gitignore
+++ b/manual/tools/.gitignore
@@ -6,7 +6,6 @@ htmlgen
 htmlquote
 latexscan.ml
 dvi2txt
-caml-tex2
 *.dSYM
 *.cm[io]
 *.o

--- a/manual/tools/Makefile
+++ b/manual/tools/Makefile
@@ -1,5 +1,13 @@
 TOPDIR=../..
 COMPFLAGS=-I $(OTOPDIR)/otherlibs/str -I $(OTOPDIR)/otherlibs/unix
+CAMLTEX2_FLAGS= -I $(OTOPDIR)/parsing -I $(OTOPDIR)/utils \
+          -I $(OTOPDIR)/driver -I $(OTOPDIR)/toplevel
+
+CAMLTEX2_LIBS = $(TOPDIR)/compilerlibs/ocamlcommon.cma \
+ $(TOPDIR)/compilerlibs/ocamlbytecomp.cma \
+ $(TOPDIR)/compilerlibs/ocamltoplevel.cma
+
+
 include $(TOPDIR)/Makefile.tools
 
 all: texquote2 transf caml-tex2
@@ -10,14 +18,16 @@ transf: transf.cmo htmltransf.cmo transfmain.cmo
 
 transfmain.cmo: transf.cmo htmltransf.cmo
 
+COMPILER_CMAS=common bytecomp toplevel
+COMPILER_LIBS=$(addprefix $(TOPDIR)/compilerlibs/ocaml, $(COMPILER_CMAS) )
+COMPILER_CMIS = $(addprefix  -I $(TOPDIR)/, utils parsing driver toplevel)
 
 caml-tex2: caml_tex2.ml
-	$(OCAMLC) $(TOPDIR)/compilerlibs/ocamlcommon.cma -I $(TOPDIR)/parsing \
-	  -o $@ str.cma unix.cma $<
+	$(OCAMLC) $(addsuffix .cma, $(COMPILER_LIBS)) $(COMPILER_CMIS) \
+	  -o $@ str.cma unix.cma -linkall $<
 
 texquote2: texquote2.ml
 	$(OCAMLC) -o $@ $<
-
 
 %.cmo: %.ml
 	$(OCAMLC) -c $<

--- a/manual/tools/Makefile
+++ b/manual/tools/Makefile
@@ -1,30 +1,14 @@
 TOPDIR=../..
 COMPFLAGS=-I $(OTOPDIR)/otherlibs/str -I $(OTOPDIR)/otherlibs/unix
-CAMLTEX2_FLAGS= -I $(OTOPDIR)/parsing -I $(OTOPDIR)/utils \
-          -I $(OTOPDIR)/driver -I $(OTOPDIR)/toplevel
-
-CAMLTEX2_LIBS = $(TOPDIR)/compilerlibs/ocamlcommon.cma \
- $(TOPDIR)/compilerlibs/ocamlbytecomp.cma \
- $(TOPDIR)/compilerlibs/ocamltoplevel.cma
-
-
 include $(TOPDIR)/Makefile.tools
 
-all: texquote2 transf caml-tex2
+all: texquote2 transf
 
 
 transf: transf.cmo htmltransf.cmo transfmain.cmo
 	$(OCAMLC) -o $@ -g $^
 
 transfmain.cmo: transf.cmo htmltransf.cmo
-
-COMPILER_CMAS=common bytecomp toplevel
-COMPILER_LIBS=$(addprefix $(TOPDIR)/compilerlibs/ocaml, $(COMPILER_CMAS) )
-COMPILER_CMIS = $(addprefix  -I $(TOPDIR)/, utils parsing driver toplevel)
-
-caml-tex2: caml_tex2.ml
-	$(OCAMLC) $(addsuffix .cma, $(COMPILER_LIBS)) $(COMPILER_CMIS) \
-	  -o $@ str.cma unix.cma -linkall $<
 
 texquote2: texquote2.ml
 	$(OCAMLC) -o $@ $<
@@ -43,4 +27,4 @@ texquote2: texquote2.ml
 clean:
 	rm -f *.o *.cm? *.cmx?
 	rm -f transf.ml htmltransf.ml
-	rm -f texquote2 transf caml-tex2
+	rm -f texquote2 transf

--- a/manual/tools/caml_tex2.ml
+++ b/manual/tools/caml_tex2.ml
@@ -99,10 +99,8 @@ module Toplevel = struct
     let rec loop retry =
       try
         let n = Unix.read stdout_out b 0 size in
-        if n = size then
-          (Buffer.add_bytes buffer b; loop max_retry)
-        else
-          Buffer.add_bytes buffer (Bytes.sub b 0 n)
+        Buffer.add_subbytes buffer b 0 n;
+        if n = size then loop max_retry
       with Unix.(Unix_error (EAGAIN,_,_) ) ->
         if retry = 0 then () else loop (retry - 1)
     in

--- a/manual/tools/caml_tex2.ml
+++ b/manual/tools/caml_tex2.ml
@@ -61,11 +61,11 @@ module Toplevel = struct
 
   type output =
     {
-      error:string; (** error message text *)
-      warnings:string list; (** warning messages text *)
-      values:string; (** toplevel output *)
-      stdout:string; (** output printed on the toplevel stdout *)
-      underlined: (int * int) list
+      error : string; (** error message text *)
+      warnings : string list; (** warning messages text *)
+      values : string; (** toplevel output *)
+      stdout : string; (** output printed on the toplevel stdout *)
+      underlined : (int * int) list
       (** locations to underline in input phrases *)
     }
 
@@ -250,8 +250,14 @@ module Output = struct
   (** {1 Exceptions } *)
   exception Parsing_error of kind * string
 
-  type source = { file:string; lines:int * int; phrase:string; output:string }
-  type unexpected_report = {source:source; expected:status; got:status}
+  type source =
+    {
+      file : string;
+      lines : int * int;
+      phrase : string;
+      output : string
+    }
+  type unexpected_report = {source : source; expected : status; got : status}
   exception Unexpected_status of unexpected_report
 
   let print_source ppf {file; lines = (start, stop); phrase; output} =
@@ -357,12 +363,13 @@ module Text_transform = struct
     | Underline
     | Ellipsis
 
-  type t = { kind:kind; start:int; stop:int}
+  type t = { kind : kind; start : int; stop : int}
   exception Intersection of
-      {line:int;
-       file:string;
-       left: t;
-       right: t;
+      {
+        line : int;
+        file : string;
+        left : t;
+        right : t;
       }
 
   let pp ppf = function
@@ -464,11 +471,11 @@ module Ellipsis = struct
       An ellipsis is either an [[@ellipsis]] attribute, or a pair
       of [[@@@ellipsis.start]...[@@@ellipsis.stop]] attributes. *)
 
-  exception Unmatched_ellipsis of {kind:string; start:int; stop:int}
+  exception Unmatched_ellipsis of {kind : string; start : int; stop : int}
   (** raised when an [[@@@ellipsis.start]] or [[@@@ellipsis.stop]] is
       not paired with another ellipsis attribute *)
 
-  exception Nested_ellipses of {first:int ; second:int }
+  exception Nested_ellipses of {first : int ; second : int}
   (** raised by [[@@@ellipsis.start][@@@ellipsis.start]] *)
 
   let extract f x =

--- a/manual/tools/caml_tex2.ml
+++ b/manual/tools/caml_tex2.ml
@@ -641,10 +641,15 @@ let process_file file =
         let output = Text_transform.escape_specials output in
         let phrase = global_replace ~!{|^\(.\)|} camlin phrase
         and output = global_replace ~!{|^\(.\)|} camlout output in
+        let final_output =
+          if omit_answer && String.length error_msgs > 0 then
+            global_replace ~!{|^\(.\)|} camlout error_msgs
+          else if omit_answer then ""
+          else output in
         start false tex_fmt phrase_env [];
         code_env ~newline:omit_answer input_env tex_fmt phrase;
-        if not omit_answer then
-          code_env ~newline:false (Output.env status) tex_fmt output;
+        if String.length final_output > 0 then
+          code_env ~newline:false (Output.env status) tex_fmt final_output;
         stop true tex_fmt phrase_env;
         flush oc;
         first := false;

--- a/testsuite/tests/tool-caml-tex/ocamltests
+++ b/testsuite/tests/tool-caml-tex/ocamltests
@@ -1,0 +1,1 @@
+redirections.ml

--- a/testsuite/tests/tool-caml-tex/redirections.ml
+++ b/testsuite/tests/tool-caml-tex/redirections.ml
@@ -1,10 +1,10 @@
 (* TEST
    reference="${test_source_directory}/redirections.reference"
    output="redirections.output"
-   script = "${ocamlrun} ${ocamlsrcdir}/tools/caml-tex -repo-root ${ocamlsrcdir} ${test_source_directory}/${test_file} -o ${output}"
+   script = "${ocamlrun} ${ocamlsrcdir}/tools/caml-tex \
+   -repo-root ${ocamlsrcdir} ${test_source_directory}/${test_file} -o ${output}"
   * script with unix,str
   ** check-program-output
-
 *)
 
 \begin{caml_example}{toplevel}

--- a/testsuite/tests/tool-caml-tex/redirections.ml
+++ b/testsuite/tests/tool-caml-tex/redirections.ml
@@ -1,0 +1,19 @@
+(* TEST
+   reference="${test_source_directory}/redirections.reference"
+   output="redirections.output"
+   script = "${ocamlrun} ${ocamlsrcdir}/tools/caml-tex -repo-root ${ocamlsrcdir} ${test_source_directory}/${test_file} -o ${output}"
+  * script with unix,str
+  ** check-program-output
+
+*)
+
+\begin{caml_example}{toplevel}
+[@@@warning "+A"];;
+1 + 2. [@@expect error];;
+let f x = () [@@expect warning 27];;
+\end{caml_example}
+
+\begin{caml_example}{toplevel}
+Format.printf "Hello@.";
+print_endline "world";;
+\end{caml_example}

--- a/testsuite/tests/tool-caml-tex/redirections.reference
+++ b/testsuite/tests/tool-caml-tex/redirections.reference
@@ -1,0 +1,30 @@
+(* TEST
+   reference="${test_source_directory}/redirections.reference"
+   output="redirections.output"
+   script = "${ocamlrun} ${ocamlsrcdir}/tools/caml-tex -repo-root ${ocamlsrcdir} ${test_source_directory}/${test_file} -o ${output}"
+  * script with unix,str
+  ** check-program-output
+
+*)
+
+\camlexample{toplevel}
+\caml\camlinput\?[@@@warning "+A"];;
+\endcamlinput\endcaml
+\caml\camlinput\?1 + \<2.\> ;;
+\endcamlinput\camlerror\:Error: This expression has type float but an expression was expected of type
+\:         int
+\endcamlerror\endcaml
+\caml\camlinput\?let f \<x\> = () ;;
+\endcamlinput\camlwarn\:Warning 27: unused variable x.
+\:val f : \textquotesingle\-a -> unit = <fun>
+\endcamlwarn\endcaml
+\endcamlexample
+
+\camlexample{toplevel}
+\caml\camlinput\?Format.printf "Hello@.";
+\?print_endline "world";;
+\endcamlinput\camloutput\:Hello
+\:world
+\:- : unit = ()
+\endcamloutput\endcaml
+\endcamlexample

--- a/testsuite/tests/tool-caml-tex/redirections.reference
+++ b/testsuite/tests/tool-caml-tex/redirections.reference
@@ -1,10 +1,10 @@
 (* TEST
    reference="${test_source_directory}/redirections.reference"
    output="redirections.output"
-   script = "${ocamlrun} ${ocamlsrcdir}/tools/caml-tex -repo-root ${ocamlsrcdir} ${test_source_directory}/${test_file} -o ${output}"
+   script = "${ocamlrun} ${ocamlsrcdir}/tools/caml-tex \
+   -repo-root ${ocamlsrcdir} ${test_source_directory}/${test_file} -o ${output}"
   * script with unix,str
   ** check-program-output
-
 *)
 
 \camlexample{toplevel}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -392,6 +392,23 @@ install::
 	  "$(INSTALL_BINDIR)/"
 endif
 
+CAMLTEX= ../compilerlibs/ocamlcommon.cma \
+	../compilerlibs/ocamlbytecomp.cma \
+	../compilerlibs/ocamltoplevel.cma \
+	../otherlibs/str/str.cma \
+	../otherlibs/unix/unix.cma \
+	caml_tex.ml
+
+#Scan latex files, and run ocaml code examples
+
+caml-tex: INCLUDES+= -I ../otherlibs/str -I ../otherlibs/unix
+caml-tex: $(CAMLTEX)
+	$(CAMLC) $(LINKFLAGS) -I .. -linkall -o $@ $(CAMLTEX)
+
+opt.opt:caml-tex
+clean::
+	rm -f -- caml-tex caml_tex.cm?
+
 # Common stuff
 
 .SUFFIXES:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -396,15 +396,18 @@ CAMLTEX= ../compilerlibs/ocamlcommon.cma \
 	../compilerlibs/ocamlbytecomp.cma \
 	../compilerlibs/ocamltoplevel.cma \
 	../otherlibs/str/str.cma \
-	../otherlibs/unix/unix.cma \
+	../otherlibs/$(UNIXLIB)/unix.cma \
 	caml_tex.ml
 
 #Scan latex files, and run ocaml code examples
 
-caml-tex: INCLUDES+= -I ../otherlibs/str -I ../otherlibs/unix
+caml-tex: INCLUDES+= -I ../otherlibs/str -I ../otherlibs/$(UNIXLIB)
 caml-tex: $(CAMLTEX)
-	$(CAMLC) $(LINKFLAGS) -I .. -linkall -o $@ $(CAMLTEX)
+	../runtime/ocamlrun ../ocamlc -nostdlib -I ../stdlib $(LINKFLAGS) \
+	-linkall -o $@ $(CAMLTEX)
 
+# we need str and unix which depend on the bytecode version of other tools
+# thus we delay building caml-tex to the opt.opt stage
 opt.opt:caml-tex
 clean::
 	rm -f -- caml-tex caml_tex.cm?

--- a/tools/caml_tex.ml
+++ b/tools/caml_tex.ml
@@ -1,5 +1,4 @@
-(* $Id$ *)
-
+[@@@warning "a-40-6"]
 open StdLabels
 open Str
 
@@ -205,7 +204,7 @@ let () =
              "-v", Arg.Bool (fun b -> verbose := b ), "output result on stderr"
             ]
     (fun s -> files := s :: !files)
-    "caml-tex2: ";
+    "caml-tex: ";
   Toplevel.init ()
 
 
@@ -527,7 +526,6 @@ module Ellipsis = struct
 end
 
 let process_file file =
-  prerr_endline ("Processing " ^ file);
   let ic = try open_in file with _ -> failwith "Cannot read input file" in
   let phrase_start = ref 1 and phrase_stop = ref 1 in
   let incr_phrase_start () =

--- a/tools/caml_tex.ml
+++ b/tools/caml_tex.ml
@@ -1,3 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Gallium, INRIA Paris                  *)
+(*             Jacques Garrigue, Nagoya University                        *)
+(*             Florian Angeletti                                          *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
 [@@@warning "a-40-6"]
 open StdLabels
 open Str


### PR DESCRIPTION
This is PR is essentially  #1785 without the ellipses as extension nodes change: it replaces the uses of a separated toplevel process inside `manual/tools/caml_tex2.ml` by a direct use of `Toploop` 's api from the compiler-libs. 

The main benefits of this change is that it enables a more precise control of the data flux from the toplevel: compiler error, compiler warnings, locations to underline, and the example stdout and stderr are now collected separately.

As a direct consequence of this change, all error and warnings related locations are now underlined, not only the first one.

Similarly, code examples now always print warnings and errors message even when the toplevel output is omitted, as wished by @gasche  .