### PR TITLE
Emacs: Dark theme fixes and modernisation

### DIFF
--- a/Changes
+++ b/Changes
@@ -108,6 +108,10 @@ Working version
   modules to open as if they had been passed via the command line -open flag.
   (Nicolás Ojeda Bär, review by Mark Shinwell)
 
+- GPR#1865: support dark themes in Emacs, and clean up usage of
+  deprecated Emacs APIs
+  (Wilfred Hughes, review by Clément Pit-Claudel)
+
 ### Manual and documentation:
 
 - GPR#1788: move the quoted string description to the main chapters.

--- a/emacs/caml-font-old.el
+++ b/emacs/caml-font-old.el
@@ -17,32 +17,7 @@
 (cond
  ((x-display-color-p)
   (require 'font-lock)
-  (cond
-   ((not (boundp 'font-lock-type-face))
-    ; make the necessary faces
-    (make-face 'Firebrick)
-    (set-face-foreground 'Firebrick "Firebrick")
-    (make-face 'RosyBrown)
-    (set-face-foreground 'RosyBrown "RosyBrown")
-    (make-face 'Purple)
-    (set-face-foreground 'Purple "Purple")
-    (make-face 'MidnightBlue)
-    (set-face-foreground 'MidnightBlue "MidnightBlue")
-    (make-face 'DarkGoldenRod)
-    (set-face-foreground 'DarkGoldenRod "DarkGoldenRod")
-    (make-face 'DarkOliveGreen)
-    (set-face-foreground 'DarkOliveGreen "DarkOliveGreen4")
-    (make-face 'CadetBlue)
-    (set-face-foreground 'CadetBlue "CadetBlue")
-    ; assign them as standard faces
-    (setq font-lock-comment-face 'Firebrick)
-    (setq font-lock-string-face 'RosyBrown)
-    (setq font-lock-keyword-face 'Purple)
-    (setq font-lock-function-name-face 'MidnightBlue)
-    (setq font-lock-variable-name-face 'DarkGoldenRod)
-    (setq font-lock-type-face 'DarkOliveGreen)
-    (setq font-lock-reference-face 'CadetBlue)))
-  ; extra faces for documentation
+  ;; extra faces for documentation
   (make-face 'Stop)
   (set-face-foreground 'Stop "White")
   (set-face-background 'Stop "Red")

--- a/emacs/caml-font.el
+++ b/emacs/caml-font.el
@@ -30,11 +30,6 @@
     (set-face-foreground 'caml-font-doccomment-face "Red")
     'caml-font-doccomment-face))
 
-(unless (facep 'font-lock-preprocessor-face)
-  (defvar font-lock-preprocessor-face
-    (copy-face 'font-lock-builtin-face
-               'font-lock-preprocessor-face)))
-
 (defconst caml-font-lock-keywords
   `(
 ;modules and constructors

--- a/emacs/caml-types.el
+++ b/emacs/caml-types.el
@@ -85,7 +85,9 @@ type call ident")
   (setq caml-types-location-re
         (concat "^" caml-types-position-re " " caml-types-position-re)))
 
-(defface caml-types-expr-face '((t :background "#88FF44"))
+(defface caml-types-expr-face
+  '((((class color) (background light)) :background "#88FF44")
+    (((class color) (background  dark)) :background "dark green"))
   "Face for highlighting expressions and types")
 
 (defvar caml-types-expr-ovl (make-overlay 1 1))
@@ -97,7 +99,9 @@ type call ident")
 (defvar caml-types-typed-ovl (make-overlay 1 1))
 (overlay-put caml-types-typed-ovl 'face 'caml-types-typed-face)
 
-(defface caml-types-scope-face '((t :background "#BBFFFF"))
+(defface caml-types-scope-face
+  '((((class color) (background light)) :background "#BBFFFF")
+    (((class color) (background  dark)) :background "dark blue"))
   "Face for highlighting variable scopes.")
 
 (defvar caml-types-scope-ovl (make-overlay 1 1))
@@ -109,7 +113,9 @@ type call ident")
 (defvar caml-types-def-ovl (make-overlay 1 1))
 (overlay-put caml-types-def-ovl 'face 'caml-types-def-face)
 
-(defface caml-types-occ-face '((t :background "#44FF44"))
+(defface caml-types-occ-face
+  '((((class color) (background light)) :background "#44FF44")
+    (((class color) (background  dark)) :background "dark green"))
   "Face for highlighting variable occurrences.")
 
 (defvar caml-types-occ-ovl (make-overlay 1 1))

--- a/emacs/caml-types.el
+++ b/emacs/caml-types.el
@@ -85,44 +85,34 @@ type call ident")
   (setq caml-types-location-re
         (concat "^" caml-types-position-re " " caml-types-position-re)))
 
+(defface caml-types-expr-face '((t :background "#88FF44"))
+  "Face for highlighting expressions and types")
+
 (defvar caml-types-expr-ovl (make-overlay 1 1))
-(make-face 'caml-types-expr-face)
-(set-face-doc-string 'caml-types-expr-face
-                     "face for hilighting expressions and types")
-(if (not (face-differs-from-default-p 'caml-types-expr-face))
-    (set-face-background 'caml-types-expr-face "#88FF44"))
 (overlay-put caml-types-expr-ovl 'face 'caml-types-expr-face)
 
+(defface caml-types-typed-face '((t :background "#FF8844"))
+  "Face for highlighting typed expressions.")
+
 (defvar caml-types-typed-ovl (make-overlay 1 1))
-(make-face 'caml-types-typed-face)
-(set-face-doc-string 'caml-types-typed-face
-                     "face for hilighting typed expressions")
-(if (not (face-differs-from-default-p 'caml-types-typed-face))
-    (set-face-background 'caml-types-typed-face "#FF8844"))
 (overlay-put caml-types-typed-ovl 'face 'caml-types-typed-face)
 
+(defface caml-types-scope-face '((t :background "#BBFFFF"))
+  "Face for highlighting variable scopes.")
+
 (defvar caml-types-scope-ovl (make-overlay 1 1))
-(make-face 'caml-types-scope-face)
-(set-face-doc-string 'caml-types-scope-face
-                     "face for hilighting variable scopes")
-(if (not (face-differs-from-default-p 'caml-types-scope-face))
-    (set-face-background 'caml-types-scope-face "#BBFFFF"))
 (overlay-put caml-types-scope-ovl 'face 'caml-types-scope-face)
 
+(defface caml-types-def-face '((t :background "#FF4444"))
+  "Face for highlighting binding occurrences.")
+
 (defvar caml-types-def-ovl (make-overlay 1 1))
-(make-face 'caml-types-def-face)
-(set-face-doc-string 'caml-types-def-face
-                     "face for hilighting binding occurrences")
-(if (not (face-differs-from-default-p 'caml-types-def-face))
-    (set-face-background 'caml-types-def-face "#FF4444"))
 (overlay-put caml-types-def-ovl 'face 'caml-types-def-face)
 
+(defface caml-types-occ-face '((t :background "#44FF44"))
+  "Face for highlighting variable occurrences.")
+
 (defvar caml-types-occ-ovl (make-overlay 1 1))
-(make-face 'caml-types-occ-face)
-(set-face-doc-string 'caml-types-occ-face
-                     "face for hilighting variable occurrences")
-(if (not (face-differs-from-default-p 'caml-types-occ-face))
-    (set-face-background 'caml-types-occ-face "#44FF44"))
 (overlay-put caml-types-occ-ovl 'face 'caml-types-occ-face)
 
 


### PR DESCRIPTION
The Emacs mode in this repository has colors defined that don't work well in dark themes.

Before:

![caml_before](https://user-images.githubusercontent.com/70800/41988481-2c859656-7a34-11e8-81c8-22e831b31506.png)

After:

![caml_after](https://user-images.githubusercontent.com/70800/41988488-30e3f29c-7a34-11e8-8cf3-b21f3e037c1a.png)

This also affects packages like merlin, which use the styles from the caml-types.el file. In the screenshot above, I'm running the `merlin-type-enclosing` command.

I've also updated the face definitions to correspond to Emacs best practices. See the individual commit messages for more details.

(This is my first PR to ocaml itself, so please let me know if I've done anything silly!)