### PR TITLE
Remove the unreachable `Typecore.Recursive_local_constraint`  error

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -78,11 +78,6 @@ exception Cannot_expand
 
 exception Cannot_apply
 
-exception Recursive_abbrev
-
-(* GADT: recursive abbrevs can appear as a result of local constraints *)
-exception Unification_recursive_abbrev of (type_expr * type_expr) list
-
 (**** Type level management ****)
 
 let current_level = ref 0
@@ -2853,9 +2848,6 @@ let unify env ty1 ty2 =
     Unify trace ->
       undo_compress snap;
       raise (Unify (expand_trace !env trace))
-  | Recursive_abbrev ->
-      undo_compress snap;
-      raise (Unification_recursive_abbrev (expand_trace !env [(ty1,ty2)]))
 
 let unify_gadt ~equations_level:lev (env:Env.t ref) ty1 ty2 =
   try

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -24,8 +24,6 @@ exception Subtype of
         (type_expr * type_expr) list * (type_expr * type_expr) list
 exception Cannot_expand
 exception Cannot_apply
-exception Recursive_abbrev
-exception Unification_recursive_abbrev of (type_expr * type_expr) list
 
 val init_def: int -> unit
         (* Set the initial variable level *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -89,7 +89,6 @@ type error =
   | Modules_not_allowed
   | Cannot_infer_signature
   | Not_a_packed_module of type_expr
-  | Recursive_local_constraint of (type_expr * type_expr) list
   | Unexpected_existential of existential_restriction * string * string list
   | Invalid_interval
   | Invalid_for_loop_index
@@ -397,9 +396,6 @@ let unify_pat_types_gadt loc env ty ty' =
       raise(Error(loc, !env, Pattern_type_clash(trace)))
   | Tags(l1,l2) ->
       raise(Typetexp.Error(loc, !env, Typetexp.Variant_tags (l1, l2)))
-  | Unification_recursive_abbrev trace ->
-      raise(Error(loc, !env, Recursive_local_constraint trace))
-
 
 (* Creating new conjunctive types is not allowed when typing patterns *)
 
@@ -4713,12 +4709,6 @@ let report_error env ppf = function
       fprintf ppf
         "This expression is packed module, but the expected type is@ %a"
         type_expr ty
-  | Recursive_local_constraint trace ->
-      report_unification_error ppf env trace
-        (function ppf ->
-           fprintf ppf "Recursive local constraint when unifying")
-        (function ppf ->
-           fprintf ppf "with")
   | Unexpected_existential (reason, name, types) -> (
       begin match reason with
       | In_class_args ->

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -154,7 +154,6 @@ type error =
   | Modules_not_allowed
   | Cannot_infer_signature
   | Not_a_packed_module of type_expr
-  | Recursive_local_constraint of (type_expr * type_expr) list
   | Unexpected_existential of existential_restriction * string * string list
   | Invalid_interval
   | Invalid_for_loop_index


### PR DESCRIPTION
The `Ctype.Recursive_abbrev` exception is no longer raised in the compiler. This PR removes it along with the `Typecore.Recursive_local_constraints` error which was no longer reachable.