### PR TITLE
Fix PR#1856

### DIFF
--- a/Changes
+++ b/Changes
@@ -81,9 +81,10 @@ Working version
   when supported, for reproducible builds
   (Xavier Clerc, review by Jérémie Dimino)
 
-- GPR#1856: use `BUILD_PATH_PREFIX_MAP` when compiling primitives in order to
-  make builds reproducible if code contains uses of `__FILE__` or `__LOC__`
-  (Xavier Clerc, review by Gabriel Scherer)
+- GPR#1856, GPR#1869: use `BUILD_PATH_PREFIX_MAP` when compiling primitives
+  in order to make builds reproducible if code contains uses of
+  `__FILE__` or `__LOC__`
+  (Xavier Clerc, review by Gabriel Scherer and Sébastien Hinderer)
 
 ### Code generation and optimizations:
 

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -79,8 +79,9 @@ let compile_file ?output ?(opt="") ?stable_name name =
       ("", "") in
   let debug_prefix_map =
     match stable_name with
-    | None -> ""
-    | Some stable -> Printf.sprintf " -fdebug-prefix-map=%s=%s" name stable in
+    | Some stable when Config.c_has_debug_prefix_map ->
+      Printf.sprintf " -fdebug-prefix-map=%s=%s" name stable
+    | Some _ | None -> "" in
   let exit =
     command
       (Printf.sprintf


### PR DESCRIPTION
This PR fixes an embarrassing mistake in [PR#1856](https://github.com/ocaml/ocaml/pull/1856):
the `-fdebug-prefix-map` command-line switch should
be passed to the C compiler iff it supports it.

In the previous version, only one of the two uses was
guarded by a condition over `Config.c_has_debug_prefix_map`.