### PR TITLE
Fix MPR#7235

### DIFF
--- a/Changes
+++ b/Changes
@@ -39,6 +39,9 @@ Working version
   alternative integer formatting.
   (ygrek, review by Gabriel Scherer)
 
+- MPR#7235: Format, flush err_formatter at exit.
+  (Pierre Weis, request by Jun Furuse)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1367,9 +1367,13 @@ let kasprintf k (Format (fmt, _)) =
 
 let asprintf fmt = kasprintf (fun s -> s) fmt
 
-(* Output everything left in the pretty printer queue at end of execution. *)
-let () = at_exit print_flush
+(* Flushing standard formatters at end of execution. *)
 
+let flush_standard_formatters () =
+  pp_print_flush std_formatter ();
+  pp_print_flush err_formatter ()
+
+let () = at_exit flush_standard_formatters
 
 (*
 


### PR DESCRIPTION
This GPR fixes [MPR#7235](https://caml.inria.fr/mantis/view.php?id=7235) by flushing both std_formatter and err_formatter at
program exit.