### PR TITLE
Testsuite reports: move failed tests and Summary to the end

### DIFF
--- a/testsuite/makefiles/summarize.awk
+++ b/testsuite/makefiles/summarize.awk
@@ -199,11 +199,10 @@ END {
                    ignored);
             printf("  %3d unexpected errors\n", unexped);
             printf("  %3d tests considered", nresults);
-            if (nresults == passed + skipped + ignored + failed + unexped){
-                printf ("\n");
-            }else{
-                printf (" (totals don't add up??)\n");
+            if (nresults != passed + skipped + ignored + failed + unexped){
+                printf (" (totals don't add up??)");
             }
+            printf ("\n");
             if (reran != 0){
                 printf("  %3d test dir re-runs\n", reran);
             }

--- a/testsuite/makefiles/summarize.awk
+++ b/testsuite/makefiles/summarize.awk
@@ -174,14 +174,6 @@ END {
                 }
             }
             printf("\n");
-            if (failed != 0){
-                printf("\nList of failed tests:\n");
-                for (i=0; i < failed; i++) printf("    %s\n", fail[i]);
-            }
-            if (unexped != 0){
-                printf("\nList of unexpected errors:\n");
-                for (i=0; i < unexped; i++) printf("    %s\n", unexp[i]);
-            }
             if (skipped != 0){
                 printf("\nList of skipped tests:\n");
                 for (i=0; i < skipidx; i++) printf("    %s\n", skips[i]);
@@ -189,6 +181,14 @@ END {
             if (empty != 0){
                 printf("\nList of directories returning no results:\n");
                 for (i=0; i < empty; i++) printf("    %s\n", blanks[i]);
+            }
+            if (failed != 0){
+                printf("\nList of failed tests:\n");
+                for (i=0; i < failed; i++) printf("    %s\n", fail[i]);
+            }
+            if (unexped != 0){
+                printf("\nList of unexpected errors:\n");
+                for (i=0; i < unexped; i++) printf("    %s\n", unexp[i]);
             }
             printf("\n");
             printf("Summary:\n");

--- a/testsuite/makefiles/summarize.awk
+++ b/testsuite/makefiles/summarize.awk
@@ -174,22 +174,6 @@ END {
                 }
             }
             printf("\n");
-            printf("Summary:\n");
-            printf("  %3d tests passed\n", passed);
-            printf("  %3d tests skipped\n", skipped);
-            printf("  %3d tests failed\n", failed);
-            printf("  %3d tests not started (parent test skipped or failed)\n",
-                   ignored);
-            printf("  %3d unexpected errors\n", unexped);
-            printf("  %3d tests considered", nresults);
-            if (nresults == passed + skipped + ignored + failed + unexped){
-                printf ("\n");
-            }else{
-                printf (" (totals don't add up??)\n");
-            }
-            if (reran != 0){
-                printf("  %3d test dir re-runs\n", reran);
-            }
             if (failed != 0){
                 printf("\nList of failed tests:\n");
                 for (i=0; i < failed; i++) printf("    %s\n", fail[i]);
@@ -207,6 +191,22 @@ END {
                 for (i=0; i < empty; i++) printf("    %s\n", blanks[i]);
             }
             printf("\n");
+            printf("Summary:\n");
+            printf("  %3d tests passed\n", passed);
+            printf("  %3d tests skipped\n", skipped);
+            printf("  %3d tests failed\n", failed);
+            printf("  %3d tests not started (parent test skipped or failed)\n",
+                   ignored);
+            printf("  %3d unexpected errors\n", unexped);
+            printf("  %3d tests considered", nresults);
+            if (nresults == passed + skipped + ignored + failed + unexped){
+                printf ("\n");
+            }else{
+                printf (" (totals don't add up??)\n");
+            }
+            if (reran != 0){
+                printf("  %3d test dir re-runs\n", reran);
+            }
             if (failed || unexped){
                 printf("#### Something failed. Exiting with error status.\n\n");
                 exit 4;


### PR DESCRIPTION
Today when I run the testsuite, my terminal looks like this by the time it is finished:

```
    tests/warnings/'w55.ml' with 3.1.1 (ocamlopt.byte) 
    tests/warnings/'w55.ml' with 3.1.1.1 (check-ocamlopt.byte-output) 
    tests/asmcomp/'unrolling_flambda.ml' with 1 (flambda) 
    tests/flambda/'specialise.ml' with 1 (flambda) 
    tests/warnings/'w55.ml' with 3 (flambda) 
    tests/translprim/'array_spec.ml' with 1.1.2 (no-flat-float-array) 
    tests/asmcomp/'is_static_flambda.ml' with 1 (flambda) 
    tests/typing-misc/'pr6939-no-flat-float-array.ml' with 1.1 (expect) 
    tests/runtime-errors/'syserror.ml' with 1.1.1.2.1 (check-program-output) 
    tests/win-unicode
    tests/asmcomp/'static_float_array_flambda_opaque.ml' with 1 (flambda) 
    tests/runtime-errors/'stackoverflow.ml' with 2 (libwin32unix) 
    tests/asmcomp/'static_float_array_flambda.ml' with 1.1.1 (native) 
    tests/warnings/'w59.ml' with 3.1 (setup-ocamlopt.byte-build-env) 
    tests/flambda/'specialise.ml' with 1.1 (native) 
    tests/asmcomp/'unrolling_flambda2.ml' with 1.1 (native) 
    tests/typing-misc/'pr6939-no-flat-float-array.ml' with 1 (no-flat-float-array) 
    tests/asmgen/'integr.cmm' with 1 (skip) 
    tests/letrec-disallowed/'float_block_allowed.ml' with 1 (no-flat-float-array) 
    tests/runtime-errors/'stackoverflow.ml' with 2.1.1 (ocamlopt.byte) 
    tests/asmcomp/'unrolling_flambda2.ml' with 1 (flambda) 
    tests/asmgen/'integr.cmm' with 1.1 (asmgen) 
    tests/flambda/'approx_meet.ml' with 1 (flambda) 

make[1]: Leaving directory '/home/gasche/Prog/ocaml/github-trunk/testsuite'
[gasche@zigomar testsuite (trunk)]$
```

I can't tell from this whether which test may have failed, and I need to scroll back.

After the proposed PR, it looks like this:

```
    tests/asmcomp/'is_static_flambda.ml' with 1 (flambda) 
    tests/typing-misc/'pr6939-no-flat-float-array.ml' with 1.1 (expect) 
    tests/runtime-errors/'syserror.ml' with 1.1.1.2.1 (check-program-output) 
    tests/win-unicode
    tests/asmcomp/'static_float_array_flambda_opaque.ml' with 1 (flambda) 
    tests/runtime-errors/'stackoverflow.ml' with 2 (libwin32unix) 
    tests/asmcomp/'static_float_array_flambda.ml' with 1.1.1 (native) 
    tests/warnings/'w59.ml' with 3.1 (setup-ocamlopt.byte-build-env) 
    tests/flambda/'specialise.ml' with 1.1 (native) 
    tests/asmcomp/'unrolling_flambda2.ml' with 1.1 (native) 
    tests/typing-misc/'pr6939-no-flat-float-array.ml' with 1 (no-flat-float-array) 
    tests/asmgen/'integr.cmm' with 1 (skip) 
    tests/letrec-disallowed/'float_block_allowed.ml' with 1 (no-flat-float-array) 
    tests/runtime-errors/'stackoverflow.ml' with 2.1.1 (ocamlopt.byte) 
    tests/asmcomp/'unrolling_flambda2.ml' with 1 (flambda) 
    tests/asmgen/'integr.cmm' with 1.1 (asmgen) 
    tests/flambda/'approx_meet.ml' with 1 (flambda) 

Summary:
  1777 tests passed
   93 tests skipped
    0 tests failed
    0 unexpected errors
  1870 tests considered
[gasche@zigomar testsuite (testsuite-status-order)]$ 
```