### PR TITLE
restore the specialized error path for record patterns

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1326,7 +1326,7 @@ and type_pat_aux ~constrs ~labels ~no_existentials ~mode ~explode ~env
         let (_, ty_arg, ty_res) = instance_label false label in
         begin try
           unify_pat_types loc !env ty_res record_ty
-        with Unify trace ->
+        with Error(_loc, _env, Pattern_type_clash(trace)) ->
           raise(Error(label_lid.loc, !env,
                       Label_mismatch(label_lid.txt, trace)))
         end;


### PR DESCRIPTION
This PR restores a specialized error path for mixed record labels in record patterns:
on the expression side, mixing record labels (from different record types) inside a record expression
```OCaml
type t = {x:unit}
type s = {y:unit}
let r = {x=();y=()};;
```
yields a specialized error message:

> Error: The record field y belongs to the type s
       but is mixed here with fields of type t

Contrarily, the error message for erroneous record patterns 
```OCaml
let f = function {x;y} -> x
```
is the generic one

> Error: This pattern matches values of type s
     but a pattern was expected which matches values of type t

This difference is due to a small exception imbroglio: the label typing code was expecting an `Unify` exception after a call to `unify_pat_types` but  `unify_pat_types` catches `Unify` exception by itself and transform them into `Pattern_type_clash` errors.
