### PR TITLE
Add check-typo compatibility to recent GPRs

### DIFF
--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -166,7 +166,9 @@ type expression =
   | Cifthenelse of expression * expression * expression
   | Cswitch of expression * int array * expression array * Debuginfo.t
   | Cloop of expression
-  | Ccatch of rec_flag * (int * (Ident.t * machtype) list * expression) list * expression
+  | Ccatch of
+      rec_flag * (int * (Ident.t * machtype) list * expression) list
+      * expression
   | Cexit of int * expression list
   | Ctrywith of expression * Ident.t * expression
 

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -146,7 +146,9 @@ and expression =
   | Cifthenelse of expression * expression * expression
   | Cswitch of expression * int array * expression array * Debuginfo.t
   | Cloop of expression
-  | Ccatch of rec_flag * (int * (Ident.t * machtype) list * expression) list * expression
+  | Ccatch of
+      rec_flag * (int * (Ident.t * machtype) list * expression) list
+      * expression
   | Cexit of int * expression list
   | Ctrywith of expression * Ident.t * expression
 
@@ -180,6 +182,7 @@ type phrase =
     Cfunction of fundecl
   | Cdata of data_item list
 
-val ccatch : int * (Ident.t * machtype) list * expression * expression -> expression
+val ccatch :
+  int * (Ident.t * machtype) list * expression * expression -> expression
 
 val reset : unit -> unit

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -793,7 +793,8 @@ method emit_expr (env:environment) exp =
         List.map (fun (nfail, ids, e2) ->
             let rs =
               List.map
-                (fun (id, typ) -> let r = self#regs_for typ in name_regs id r; r)
+                (fun (id, typ) ->
+                  let r = self#regs_for typ in name_regs id r; r)
                 ids in
             (nfail, ids, rs, e2))
           handlers
@@ -1124,7 +1125,8 @@ method emit_tail (env:environment) exp =
         List.map (fun (nfail, ids, e2) ->
             let rs =
               List.map
-                (fun (id, typ) -> let r = self#regs_for typ in name_regs id r; r)
+                (fun (id, typ) ->
+                  let r = self#regs_for typ in name_regs id r; r)
                 ids in
             (nfail, ids, rs, e2))
           handlers in

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -574,7 +574,8 @@ val link :  ?follow:bool -> string -> string -> unit
    [link(2)] function is used whose behaviour is OS-dependent, but more widely
    available.
 
-   @raise ENOSYS On {e Unix} if [~follow:_] is requested, but linkat is unavailable.
+   @raise ENOSYS On {e Unix} if [~follow:_] is requested, but linkat is
+                 unavailable.
    @raise ENOSYS On {e Windows} if [~follow:false] is requested. *)
 
 

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -502,7 +502,8 @@ val link : ?follow:bool -> src:string -> dst:string -> unit
    [link(2)] function is used whose behaviour is OS-dependent, but more widely
    available.
 
-   @raise ENOSYS On {e Unix} if [~follow:_] is requested, but linkat is unavailable.
+   @raise ENOSYS On {e Unix} if [~follow:_] is requested, but linkat is
+                 unavailable.
    @raise ENOSYS On {e Windows} if [~follow:false] is requested. *)
 
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1481,7 +1481,8 @@ simple_expr:
       { mkexp(Pexp_open(Fresh, mkrhs $1 1, $4)) }
   | mod_longident DOT LPAREN RPAREN
       { mkexp(Pexp_open(Fresh, mkrhs $1 1,
-                        mkexp(Pexp_construct(mkrhs2 (Lident "()") 3 4, None)))) }
+                        mkexp(Pexp_construct(mkrhs2 (Lident "()") 3 4,
+                                                     None)))) }
   | mod_longident DOT LPAREN seq_expr error
       { unclosed "(" 3 ")" 5 }
   | simple_expr DOT LPAREN seq_expr RPAREN
@@ -1559,7 +1560,8 @@ simple_expr:
         mkexp(Pexp_open(Fresh, mkrhs $1 1, list_exp)) }
   | mod_longident DOT LBRACKET RBRACKET
       { mkexp(Pexp_open(Fresh, mkrhs $1 1,
-                        mkexp(Pexp_construct(mkrhs2 (Lident "[]") 3 4, None)))) }
+                        mkexp(Pexp_construct(mkrhs2 (Lident "[]") 3 4,
+                                             None)))) }
   | mod_longident DOT LBRACKET expr_semi_list opt_semi error
       { unclosed "[" 3 "]" 6 }
   | PREFIXOP simple_expr

--- a/utils/ccomp.mli
+++ b/utils/ccomp.mli
@@ -17,7 +17,8 @@
 
 val command: string -> int
 val run_command: string -> unit
-val compile_file: ?output:string -> ?opt:string -> ?stable_name:string -> string -> int
+val compile_file:
+  ?output:string -> ?opt:string -> ?stable_name:string -> string -> int
 val create_archive: string -> string list -> int
 val expand_libname: string -> string
 val quote_files: string list -> string


### PR DESCRIPTION
Since #1288 was merged #1061, #1833, #1844 and #1845 have been merged to trunk without check-typo being run on them.

I intentionally merged #1148 in order to test the trunk checking on Inria's CI which was lucky because it [didn't work](https://ci.inria.fr/ocaml/job/extra-checks/82/console) and required https://github.com/ocaml/ocaml/commit/bc3deddbb2f5edb3377ddb90eccd69b458c0c55a to ensure that the job failed [as it's supposed to](https://ci.inria.fr/ocaml/job/extra-checks/83/console)!

This GPR should restore the CI to blue/green.