### PR TITLE
Add paths for built-in types

### DIFF
--- a/Changes
+++ b/Changes
@@ -54,6 +54,11 @@ Working version
   (Francois Berenger, Nicolás Ojeda Bär, review by Daniel Bünzli, David Allsopp
   and ygrek)
 
+- MPR#5072, MPR#6655, GPR#1876: add aliases in Stdlib for built-in types
+  and exceptions.
+  (Jeremy Yallop, reports by Pierre Letouzey and David Sheets,
+   review by Valentin Gatien-Baron, Gabriel Scherer and Alain Frisch)
+
 - MPR#6701, GPR#1185, GPR#1803: make float_of_string and string_of_float
   locale-independent.
   (ygrek, review by Xavier Leroy and Damien Doligez)

--- a/manual/manual/library/stdlib.etex
+++ b/manual/manual/library/stdlib.etex
@@ -40,6 +40,7 @@ Here is a short listing, by theme, of the standard library modules.
 "List" & p.~\pageref{List} & list operations \\
 "StdLabels" & p.~\pageref{StdLabels} & labelized versions of
 the above 4 modules \\
+"Unit" & p.~\pageref{Unit} & unit values \\
 "Bool" & p.~\pageref{Bool} & boolean values \\
 "Char" & p.~\pageref{Char} & character operations \\
 "Uchar" & p.~\pageref{Uchar} & Unicode characters \\
@@ -157,6 +158,7 @@ be called from C \\
 \item \ahref{libref/StringLabels.html}{Module \texttt{StringLabels}: string operations (with labels)}
 \item \ahref{libref/Sys.html}{Module \texttt{Sys}: system interface}
 \item \ahref{libref/Uchar.html}{Module \texttt{Uchar}: Unicode characters}
+\item \ahref{libref/Unit.html}{Module \texttt{Unit}: unit values}
 \item \ahref{libref/Weak.html}{Module \texttt{Weak}: arrays of weak pointers}
 \end{links}
 \else
@@ -210,5 +212,6 @@ be called from C \\
 \input{StringLabels.tex}
 \input{Sys.tex}
 \input{Uchar.tex}
+\input{Unit.tex}
 \input{Weak.tex}
 \fi

--- a/otherlibs/threads/Makefile
+++ b/otherlibs/threads/Makefile
@@ -40,7 +40,8 @@ P=stdlib__
 
 LIB_OBJS=$(LIB)/camlinternalFormatBasics.cmo stdlib.cmo $(LIB)/$(P)bool.cmo \
   $(LIB)/$(P)seq.cmo $(LIB)/$(P)option.cmo $(LIB)/$(P)result.cmo \
-  $(LIB)/$(P)fun.cmo $(LIB)/$(P)array.cmo $(LIB)/$(P)list.cmo \
+  $(LIB)/$(P)fun.cmo $(LIB)/$(P)unit.cmo \
+  $(LIB)/$(P)array.cmo $(LIB)/$(P)list.cmo \
   $(LIB)/$(P)char.cmo $(LIB)/$(P)bytes.cmo $(LIB)/$(P)string.cmo \
   $(LIB)/$(P)sys.cmo marshal.cmo $(LIB)/$(P)obj.cmo \
   $(LIB)/$(P)int.cmo $(LIB)/$(P)int32.cmo $(LIB)/$(P)int64.cmo \

--- a/otherlibs/threads/stdlib.ml
+++ b/otherlibs/threads/stdlib.ml
@@ -35,6 +35,18 @@ let failwith s = raise(Failure s)
 let invalid_arg s = raise(Invalid_argument s)
 
 exception Exit
+exception Match_failure = Match_failure
+exception Assert_failure = Assert_failure
+exception Invalid_argument = Invalid_argument
+exception Failure = Failure
+exception Not_found = Not_found
+exception Out_of_memory = Out_of_memory
+exception Stack_overflow = Stack_overflow
+exception Sys_error = Sys_error
+exception End_of_file = End_of_file
+exception Division_by_zero = Division_by_zero
+exception Sys_blocked_io = Sys_blocked_io
+exception Undefined_recursive_module = Undefined_recursive_module
 
 type raw_backtrace
 external get_raw_backtrace:

--- a/otherlibs/threads/stdlib.ml
+++ b/otherlibs/threads/stdlib.ml
@@ -17,8 +17,6 @@
    been redefined to not block the whole process, but only the calling
    thread. *)
 
-(* type 'a option = None | Some of 'a *)
-
 (* Exceptions *)
 
 external register_named_value : string -> 'a -> unit

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -15,6 +15,9 @@ stdlib__bigarray.cmi : stdlib__complex.cmi
 stdlib__bool.cmo : stdlib.cmi stdlib__bool.cmi
 stdlib__bool.cmx : stdlib.cmx stdlib__bool.cmi
 stdlib__bool.cmi :
+stdlib__unit.cmo : stdlib.cmi stdlib__unit.cmi
+stdlib__unit.cmx : stdlib.cmx stdlib__unit.cmi
+stdlib__unit.cmi :
 stdlib__buffer.cmo : stdlib__uchar.cmi stdlib__sys.cmi stdlib__string.cmi stdlib__seq.cmi stdlib__char.cmi stdlib__bytes.cmi \
     stdlib__buffer.cmi
 stdlib__buffer.cmx : stdlib__uchar.cmx stdlib__sys.cmx stdlib__string.cmx stdlib__seq.cmx stdlib__char.cmx stdlib__bytes.cmx \

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -43,7 +43,7 @@ P=stdlib__
 OBJS=camlinternalFormatBasics.cmo stdlib.cmo $(OTHERS)
 OTHERS= $(P)pervasives.cmo $(P)seq.cmo $(P)option.cmo $(P)result.cmo \
   $(P)bool.cmo $(P)char.cmo $(P)uchar.cmo $(P)sys.cmo $(P)list.cmo \
-  $(P)bytes.cmo $(P)string.cmo $(P)fun.cmo \
+  $(P)bytes.cmo $(P)string.cmo $(P)fun.cmo $(P)unit.cmo \
   $(P)marshal.cmo $(P)obj.cmo $(P)float.cmo $(P)array.cmo \
   $(P)int.cmo $(P)int32.cmo $(P)int64.cmo $(P)nativeint.cmo \
   $(P)lexing.cmo $(P)parsing.cmo \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -79,4 +79,5 @@ STDLIB_MODULES=\
   $(P)stringLabels \
   $(P)sys \
   $(P)uchar \
+  $(P)unit \
   $(P)weak

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -13,6 +13,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(* An alias for the type of arrays. *)
+type 'a t = 'a array
+
 (* Array operations *)
 
 external length : 'a array -> int = "%array_length"

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -13,6 +13,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
+type 'a t = 'a array
+(** An alias for the type of arrays. *)
+
 (** Array operations. *)
 
 external length : 'a array -> int = "%array_length"

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -13,6 +13,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
+type 'a t = 'a array
+(** An alias for the type of arrays. *)
+
 (** Array operations. *)
 
 external length : 'a array -> int = "%array_length"

--- a/stdlib/bool.ml
+++ b/stdlib/bool.ml
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type t = bool
+type t = bool = false | true
 
 external not : bool -> bool = "%boolnot"
 external ( && ) : bool -> bool -> bool = "%sequand"

--- a/stdlib/bool.mli
+++ b/stdlib/bool.mli
@@ -19,8 +19,12 @@
 
 (** {1:bools Booleans} *)
 
-type t = bool
-(** The type for boolean values. *)
+type t = bool = false | true
+(** The type of booleans (truth values).
+
+    The constructors [false] and [true] are included here so that they have
+    paths, but they are not intended to be used in user-defined data types.
+ *)
 
 val not : bool -> bool
 (** [not b] is the boolean negation of [b]. *)

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -13,6 +13,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(* An alias for the type of lists. *)
+type 'a t = 'a list = [] | (::) of 'a * 'a list
+
 (* List operations *)
 
 let rec length_aux len = function

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -26,6 +26,9 @@
    longer than about 10000 elements.
 *)
 
+type 'a t = 'a list = [] | (::) of 'a * 'a list
+(** An alias for the type of lists. *)
+
 val length : 'a list -> int
 (** Return the length (number of elements) of the given list. *)
 

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -13,6 +13,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
+type 'a t = 'a list = [] | (::) of 'a * 'a list
+(** An alias for the type of lists. *)
+
 (** List operations.
 
    Some functions are flagged as not tail-recursive.  A tail-recursive

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -67,24 +67,32 @@ let int_tag = 1000
 let out_of_heap_tag = 1001
 let unaligned_tag = 1002
 
-let extension_constructor x =
-  let x = repr x in
-  let slot =
-    if (is_block x) && (tag x) <> object_tag && (size x) >= 1 then field x 0
-    else x
-  in
-  let name =
-    if (is_block slot) && (tag slot) = object_tag then field slot 0
-    else invalid_arg "Obj.extension_constructor"
-  in
-    if (tag name) = string_tag then (obj slot : extension_constructor)
-    else invalid_arg "Obj.extension_constructor"
+module Extension_constructor =
+struct
+  type t = extension_constructor
+  let of_val x =
+    let x = repr x in
+    let slot =
+      if (is_block x) && (tag x) <> object_tag && (size x) >= 1 then field x 0
+      else x
+    in
+    let name =
+      if (is_block slot) && (tag slot) = object_tag then field slot 0
+      else invalid_arg "Obj.extension_constructor"
+    in
+      if (tag name) = string_tag then (obj slot : t)
+      else invalid_arg "Obj.extension_constructor"
 
-let [@inline always] extension_name (slot : extension_constructor) =
-  (obj (field (repr slot) 0) : string)
+  let [@inline always] name (slot : t) =
+    (obj (field (repr slot) 0) : string)
 
-let [@inline always] extension_id (slot : extension_constructor) =
-  (obj (field (repr slot) 1) : int)
+  let [@inline always] id (slot : t) =
+    (obj (field (repr slot) 1) : int)
+end
+
+let extension_constructor = Extension_constructor.of_val
+let extension_name = Extension_constructor.name
+let extension_id = Extension_constructor.id
 
 module Ephemeron = struct
   type obj_t = t

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -86,9 +86,19 @@ val int_tag : int
 val out_of_heap_tag : int
 val unaligned_tag : int   (* should never happen @since 3.11.0 *)
 
+module Extension_constructor :
+sig
+  type t = extension_constructor
+  val of_val : 'a -> t
+  val [@inline always] name : t -> string
+  val [@inline always] id : t -> int
+end
 val extension_constructor : 'a -> extension_constructor
+  [@@ocaml.deprecated "use Obj.Extension_constructor.of_val"]
 val [@inline always] extension_name : extension_constructor -> string
+  [@@ocaml.deprecated "use Obj.Extension_constructor.name"]
 val [@inline always] extension_id : extension_constructor -> int
+  [@@ocaml.deprecated "use Obj.Extension_constructor.id"]
 
 (** The following two functions are deprecated.  Use module {!Marshal}
     instead. *)

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -15,6 +15,8 @@
 
 open Printf
 
+type t = exn = ..
+
 let printers = ref []
 
 let locfmt = format_of_string "File \"%s\", line %d, characters %d-%d: %s"

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -15,6 +15,9 @@
 
 (** Facilities for printing exceptions and inspecting current call stack. *)
 
+type t = exn = ..
+(** The type of exception values. *)
+
 val to_string: exn -> string
 (** [Printexc.to_string e] returns a string representation of
    the exception [e]. *)

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -23,7 +23,6 @@ let () =
   register_named_value "Pervasives.array_bound_error"
     (Invalid_argument "index out of bounds")
 
-
 external raise : exn -> 'a = "%raise"
 external raise_notrace : exn -> 'a = "%raise_notrace"
 
@@ -31,6 +30,18 @@ let failwith s = raise(Failure s)
 let invalid_arg s = raise(Invalid_argument s)
 
 exception Exit
+exception Match_failure = Match_failure
+exception Assert_failure = Assert_failure
+exception Invalid_argument = Invalid_argument
+exception Failure = Failure
+exception Not_found = Not_found
+exception Out_of_memory = Out_of_memory
+exception Stack_overflow = Stack_overflow
+exception Sys_error = Sys_error
+exception End_of_file = End_of_file
+exception Division_by_zero = Division_by_zero
+exception Sys_blocked_io = Sys_blocked_io
+exception Undefined_recursive_module = Undefined_recursive_module
 
 type raw_backtrace
 external get_raw_backtrace:

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -13,8 +13,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* type 'a option = None | Some of 'a *)
-
 (* Exceptions *)
 
 external register_named_value : string -> 'a -> unit

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -53,6 +53,74 @@ val protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a
 
     @since 4.08.0 *)
 
+exception Match_failure of (string * int * int)
+  [@ocaml.warn_on_literal_pattern]
+(** Exception raised when none of the cases of a pattern-matching
+   apply. The arguments are the location of the match keyword in the
+   source code (file name, line number, column number). *)
+
+exception Assert_failure of (string * int * int)
+  [@ocaml.warn_on_literal_pattern]
+(** Exception raised when an assertion fails. The arguments are the
+   location of the assert keyword in the source code (file name, line
+   number, column number). *)
+
+exception Invalid_argument of string
+  [@ocaml.warn_on_literal_pattern]
+(** Exception raised by library functions to signal that the given
+   arguments do not make sense. The string gives some information to
+   the programmer. As a general rule, this exception should not be
+   caught, it denotes a programming error and the code should be
+   modified not to trigger it. *)
+
+exception Failure of string
+  [@ocaml.warn_on_literal_pattern]
+(** Exception raised by library functions to signal that they are
+   undefined on the given arguments. The string is meant to give some
+   information to the programmer; you must not pattern match on the
+   string literal because it may change in future versions (use
+   Failure _ instead). *)
+
+exception Not_found
+(** Exception raised by search functions when the desired object could
+   not be found. *)
+
+exception Out_of_memory
+(** Exception raised by the garbage collector when there is
+   insufficient memory to complete the computation. *)
+
+exception Stack_overflow
+(** Exception raised by the bytecode interpreter when the evaluation
+   stack reaches its maximal size. This often indicates infinite or
+   excessively deep recursion in the user's program. (Not fully
+   implemented by the native-code compiler.) *)
+
+exception Sys_error of string
+  [@ocaml.warn_on_literal_pattern]
+(** Exception raised by the input/output functions to report an
+   operating system error. The string is meant to give some
+   information to the programmer; you must not pattern match on the
+   string literal because it may change in future versions (use
+   Sys_error _ instead). *)
+
+exception End_of_file
+(** Exception raised by input functions to signal that the end of file
+   has been reached. *)
+
+exception Division_by_zero
+(** Exception raised by integer division and remainder operations when
+   their second argument is zero. *)
+
+exception Sys_blocked_io
+(** A special case of Sys_error raised when no I/O is possible on a
+   non-blocking I/O channel. *)
+
+exception Undefined_recursive_module of (string * int * int)
+  [@ocaml.warn_on_literal_pattern]
+(** Exception raised when an ill-founded recursive module definition
+   is evaluated. The arguments are the location of the definition in
+   the source code (file name, line number, column number). *)
+
 (** {1 Comparisons} *)
 
 external ( = ) : 'a -> 'a -> bool = "%equal"
@@ -1065,7 +1133,6 @@ module LargeFile :
   positions and sizes by 64-bit integers (type [int64]) instead of
   regular integers (type [int]), these alternate functions allow
   operating on files whose sizes are greater than [max_int]. *)
-
 
 (** {1 References} *)
 

--- a/stdlib/unit.ml
+++ b/stdlib/unit.ml
@@ -1,0 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                         The OCaml programmers                          *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type t = unit = ()
+
+let equal () () = true
+let compare () () = 0
+let to_string () = "()"

--- a/stdlib/unit.mli
+++ b/stdlib/unit.mli
@@ -1,0 +1,36 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                         The OCaml programmers                          *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Unit values.
+
+    @since 4.08 *)
+
+(** {1:unit The unit type} *)
+
+type t = unit = ()
+(** The unit type.
+
+    The constructor [()] is included here so that it has a path,
+    but it is not intended to be used in user-defined data types.
+ *)
+
+val equal : t -> t -> bool
+(** [equal u1 u2] is [true]. *)
+
+val compare : t -> t -> int
+(** [compare u1 u2] is [0]. *)
+
+val to_string : t -> string
+(** [to_string b] is ["()"]. *)

--- a/testsuite/tests/extension-constructor/test.ml
+++ b/testsuite/tests/extension-constructor/test.ml
@@ -12,13 +12,13 @@ type t += C
 type t += D of int * string
 
 let () =
-  assert (Obj.extension_constructor  M.A
+  assert (Obj.Extension_constructor.of_val  M.A
           == [%extension_constructor M.A]);
-  assert (Obj.extension_constructor (M.B 42)
+  assert (Obj.Extension_constructor.of_val (M.B 42)
           == [%extension_constructor M.B]);
-  assert (Obj.extension_constructor  C
+  assert (Obj.Extension_constructor.of_val  C
           == [%extension_constructor C]);
-  assert (Obj.extension_constructor (D (42, ""))
+  assert (Obj.Extension_constructor.of_val (D (42, ""))
           == [%extension_constructor D])
 
 let () = print_endline "OK"

--- a/testsuite/tests/typing-extensions/extensions.ml
+++ b/testsuite/tests/typing-extensions/extensions.ml
@@ -310,8 +310,10 @@ type foo +=
   | Bar of int
 ;;
 
-let extension_name e = Obj.extension_name (Obj.extension_constructor e);;
-let extension_id e = Obj.extension_id (Obj.extension_constructor e);;
+let extension_name e = Obj.Extension_constructor.name
+                         (Obj.Extension_constructor.of_val e);;
+let extension_id e = Obj.Extension_constructor.id
+                       (Obj.Extension_constructor.of_val e);;
 
 let n1 = extension_name Foo
 ;;
@@ -333,8 +335,8 @@ type foo += Foo
 let f = is_foo Foo
 ;;
 
-let _ = Obj.extension_constructor 7 (* Invald_arg *)
+let _ = Obj.Extension_constructor.of_val 7 (* Invalid_arg *)
 ;;
 
-let _ = Obj.extension_constructor (object method m = 3 end) (* Invald_arg *)
+let _ = Obj.Extension_constructor.of_val (object method m = 3 end) (* Invalid_arg *)
 ;;


### PR DESCRIPTION
It's often useful to write or generate code that refers to built-in types such as `int` or `option`, but it's currently inconvenient to do so in a way that avoids shadowing.

This PR adds aliases in `Stdlib` for the built-in types `option`, `int`, `bool`, `unit`, and `exn`, and aliases in `List` and `Array` for the built-in types `list` and `array`.  Other built-in types (`floatarray`, `bytes`, `string`, `float`, `nativeint`, `int32`, `int64`, `lazy_t` and `char`) are already aliased elsewhere in the standard library.

At some point in the future there may be standard library modules for some of these types (e.g. `Option` or `Bool`); if that happens before the next release then the corresponding aliases in `Stdlib` could be removed.

(Fixes [Mantis 5072: Absolute name for built-in types such as int, bool, ... ?](https://caml.inria.fr/mantis/view.php?id=5072) and [Mantis 6655: Alias built-in types and pre-defined exceptions in Pervasives](https://caml.inria.fr/mantis/view.php?id=6655).)