### PR TITLE
fix an unintended change of library installation directory for ocamldoc

### DIFF
--- a/Changes
+++ b/Changes
@@ -366,8 +366,9 @@ OCaml 4.07
 
 ### Compiler distribution build system
 
-- MPR#5219, GPR#1680: use 'install' instead of 'cp' in install scripts
-  (Gabriel Scherer, review by Sébastien Hinderer)
+- MPR#5219, GPR#1680, GPR#1877: use 'install' instead of 'cp'
+  in install scripts.
+  (Gabriel Scherer, review by Sébastien Hinderer and Valentin Gatien-Baron)
 
 - MPR#7679: make sure .a files are erased before calling ar rc, otherwise
   leftover .a files from an earlier compilation may contain unwanted modules

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -289,15 +289,15 @@ INSTALL_MANODIR=$(INSTALL_MANDIR)/man3
 .PHONY: install
 install:
 	$(MKDIR) "$(INSTALL_BINDIR)"
-	$(MKDIR) "$(INSTALL_LIBDIR)"
+	$(MKDIR) "$(INSTALL_LIBDIR)/ocamldoc"
 	$(MKDIR) "$(INSTALL_MANODIR)"
 	$(INSTALL_PROG) $(OCAMLDOC) "$(INSTALL_BINDIR)/$(OCAMLDOC)$(EXE)"
 	$(INSTALL_DATA) \
 	  ocamldoc.hva *.cmi $(OCAMLDOC_LIBCMA) \
-	  "$(INSTALL_LIBDIR)"
+	  "$(INSTALL_LIBDIR)/ocamldoc"
 	$(INSTALL_DATA) \
 	  $(OCAMLDOC_LIBMLIS) $(OCAMLDOC_LIBCMIS) $(OCAMLDOC_LIBCMTS) \
-	  "$(INSTALL_LIBDIR)"
+	  "$(INSTALL_LIBDIR)/ocamldoc"
 	if test -d stdlib_man; then \
 	  $(INSTALL_DATA) stdlib_man/* "$(INSTALL_MANODIR)"; \
 	else : ; fi
@@ -312,15 +312,15 @@ installopt:
 .PHONY: installopt_really
 installopt_really:
 	$(MKDIR) "$(INSTALL_BINDIR)"
-	$(MKDIR) "$(INSTALL_LIBDIR)"
+	$(MKDIR) "$(INSTALL_LIBDIR)/ocamldoc"
 	$(INSTALL_PROG) \
 	   $(OCAMLDOC_OPT) "$(INSTALL_BINDIR)/$(OCAMLDOC_OPT)$(EXE)"
 	$(INSTALL_DATA) \
 	  $(OCAMLDOC_LIBMLIS) $(OCAMLDOC_LIBCMIS) $(OCAMLDOC_LIBCMTS) \
-	  "$(INSTALL_LIBDIR)"
+	  "$(INSTALL_LIBDIR)/ocamldoc"
 	$(INSTALL_DATA) \
 	  ocamldoc.hva *.cmx $(OCAMLDOC_LIBA) $(OCAMLDOC_LIBCMXA) \
-	  "$(INSTALL_LIBDIR)"
+	  "$(INSTALL_LIBDIR)/ocamldoc"
 
 # TODO: also split into several rules
 


### PR DESCRIPTION
The error comes from #1680, which changed the install scripts for
ocamldoc, and was caught and reported by Valentin "sliquister"
Gatien-Baron, presumably as part of his own work on #1569.