### PR TITLE
Eliminate warning in pre-commit hook when editing a commit message

### DIFF
--- a/tools/pre-commit-githook
+++ b/tools/pre-commit-githook
@@ -13,6 +13,10 @@
 #*                                                                        *
 #**************************************************************************
 
+# Bump this on any changes. It's vital that HOOK_VERSION followed by equals
+# appears nowhere else in these sources!
+HOOK_VERSION=2
+
 # For what it's worth, allow for empty trees!
 if git rev-parse --verify HEAD >/dev/null 2>&1
 then
@@ -27,10 +31,11 @@ exec 1>&2
 
 # Check to see if the script's been updated
 if git ls-files --error-unmatch tools/pre-commit-githook >/dev/null 2>&1 ; then
-  if ! diff -q <(git cat-file --textconv HEAD:tools/pre-commit-githook) "$0" \
-       >/dev/null 2>&1 ; then
-    echo "Note: tools/pre-commit-githook differs from .git/hooks/pre-commit"
-    echo "You may wish to upgrade your local githook"
+  THEIR_VERSION=$(git cat-file --textconv HEAD:tools/pre-commit-githook \
+                    | sed -ne 's/^HOOK_VERSION=//p')
+  if [[ -n $THEIR_VERSION && $THEIR_VERSION -gt $HOOK_VERSION ]] ; then
+    echo "Note: tools/pre-commit-githook is newer than .git/hooks/pre-commit"
+    echo "      You may wish to update your local githook"
   fi
 fi
 

--- a/tools/pre-commit-githook
+++ b/tools/pre-commit-githook
@@ -43,11 +43,15 @@ fi
 # The strange construction below creates a list of files which have either
 # white-at-eol or white-at-eof included in ocaml-typo in .gitattributes and by
 # prefixing the names with :! causes git diff-index to skip over them.
-FILES=$(git diff-index --cached --name-only $against \
+if [[ -n $(git diff-index --cached --name-only $against) ]] ; then
+  FILES=$(git diff-index --cached --name-only $against \
           | xargs git check-attr --cached ocaml-typo \
           | sed -ne 's/\(.*\): ocaml-typo:.*[ ,]white-at-eo[fl]\(,\|$\)/:!\1/p')
-if ! git diff-index --check --cached $against -- $FILES ; then
-  exit 1
+  if ! git diff-index --check --cached $against -- $FILES ; then
+    exit 1
+  fi
+else
+  exit 0
 fi
 
 # Test to see if any part of the directory name has been marked prune


### PR DESCRIPTION
So it turns out you can have been using a script for a year and not have noticed a glitch...

The glitch in this case is a (harmless) error message displayed if the index contains no files when running `git commit` - the usual reason for this is `git commit --amend` to update a commit message (the other scenario would be `git commit --allow-empty`, but that'd be a weird thing to do here...).

I've also taken the opportunity to add a version number to the hook. It previously just detected if the script was different but it occurs to me that that would get annoying if you upgrade the hook to a new version and then work on branches where `tools/pre-commit-githook` is an older version).