### PR TITLE
Remove vestigial support for stacks that grow upward

### DIFF
--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -47,11 +47,7 @@ frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp)
     /* Skip to next frame */
     if (d->frame_size != 0xFFFF) {
       /* Regular frame, update sp/pc and return the frame descriptor */
-#ifndef Stack_grows_upwards
       *sp += (d->frame_size & 0xFFFC);
-#else
-      *sp -= (d->frame_size & 0xFFFC);
-#endif
       *pc = Saved_return_address(*sp);
 #ifdef Mask_already_scanned
       *pc = Mask_already_scanned(*pc);
@@ -102,11 +98,7 @@ void caml_stash_backtrace(value exn, uintnat pc, char * sp, char * trapsp)
     caml_backtrace_buffer[caml_backtrace_pos++] = (backtrace_slot) descr;
 
     /* Stop when we reach the current exception handler */
-#ifndef Stack_grows_upwards
     if (sp > trapsp) return;
-#else
-    if (sp < trapsp) return;
-#endif
   }
 }
 
@@ -129,8 +121,6 @@ CAMLprim value caml_get_current_callstack(value max_frames_value)
   /* first compute the size of the trace */
   {
     uintnat pc = caml_last_return_address;
-    /* note that [caml_bottom_of_stack] always points to the most recent
-     * frame, independently of the [Stack_grows_upwards] setting */
     char * sp = caml_bottom_of_stack;
     char * limitsp = caml_top_of_stack;
 
@@ -141,11 +131,7 @@ CAMLprim value caml_get_current_callstack(value max_frames_value)
       if (trace_size >= max_frames) break;
       ++trace_size;
 
-#ifndef Stack_grows_upwards
       if (sp > limitsp) break;
-#else
-      if (sp < limitsp) break;
-#endif
     }
   }
 

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -62,11 +62,7 @@ void caml_raise(value v)
   Unlock_exn();
   if (caml_exception_pointer == NULL) caml_fatal_uncaught_exception(v);
 
-#ifndef Stack_grows_upwards
 #define PUSHED_AFTER <
-#else
-#define PUSHED_AFTER >
-#endif
   while (caml_local_roots != NULL &&
          (char *) caml_local_roots PUSHED_AFTER caml_exception_pointer) {
     caml_local_roots = caml_local_roots->next;

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -62,12 +62,10 @@ void caml_raise(value v)
   Unlock_exn();
   if (caml_exception_pointer == NULL) caml_fatal_uncaught_exception(v);
 
-#define PUSHED_AFTER <
   while (caml_local_roots != NULL &&
-         (char *) caml_local_roots PUSHED_AFTER caml_exception_pointer) {
+         (char *) caml_local_roots < caml_exception_pointer) {
     caml_local_roots = caml_local_roots->next;
   }
-#undef PUSHED_AFTER
 
   caml_raise_exception(v);
 }

--- a/runtime/roots_nat.c
+++ b/runtime/roots_nat.c
@@ -243,11 +243,7 @@ void caml_oldify_local_roots (void)
   uintnat h;
   intnat i, j;
   int n, ofs;
-#ifdef Stack_grows_upwards
-  short * p;  /* PR#4339: stack offsets are negative in this case */
-#else
   unsigned short * p;
-#endif
   value * glob;
   value * root;
   struct caml__roots_block *lr;
@@ -299,11 +295,7 @@ void caml_oldify_local_roots (void)
           Oldify (root);
         }
         /* Move to next frame */
-#ifndef Stack_grows_upwards
         sp += (d->frame_size & 0xFFFC);
-#else
-        sp -= (d->frame_size & 0xFFFC);
-#endif
         retaddr = Saved_return_address(sp);
 #ifdef Already_scanned
         /* Stop here if the frame has been scanned during earlier GCs  */
@@ -446,11 +438,7 @@ void caml_do_local_roots(scanning_action f, char * bottom_of_stack,
   frame_descr * d;
   uintnat h;
   int i, j, n, ofs;
-#ifdef Stack_grows_upwards
-  short * p;  /* PR#4339: stack offsets are negative in this case */
-#else
   unsigned short * p;
-#endif
   value * root;
   struct caml__roots_block *lr;
 
@@ -478,11 +466,7 @@ void caml_do_local_roots(scanning_action f, char * bottom_of_stack,
           f (*root, root);
         }
         /* Move to next frame */
-#ifndef Stack_grows_upwards
         sp += (d->frame_size & 0xFFFC);
-#else
-        sp -= (d->frame_size & 0xFFFC);
-#endif
         retaddr = Saved_return_address(sp);
 #ifdef Mask_already_scanned
         retaddr = Mask_already_scanned(retaddr);


### PR DESCRIPTION
Stacks grow downward on all platforms that OCaml supports or is ever likely to, so this PR removes some `#ifdef`s about the direction of stack growth.

These `#ifdef`s were added to support HP's PA-RISC, the last major architecture that had stacks growing upward. The last PA-RISC processor was released in 2005, and HP customers looking for an upgrade path were told to move to Intel's Itanium (!). OCaml dropped PA-RISC support [in 2011](3e422142958ae6b902c56900a3ea4a52da97f762), but these `#ifdef`s hung around.

There aren't many other machines like this. Some grepping in the Linux sources returns only one other architecture that Linux has ever supported with stacks that grow up, an [embedded DSP called Meta](https://en.wikipedia.org/wiki/Imagination_META). Support has [recently been dropped](https://lwn.net/Articles/747759/). Apparently the [DECSYSTEM-20](https://en.wikipedia.org/wiki/DECSYSTEM-20) (running on the PDP-10) also had [stacks growing up](http://ftp.vim.org/pub/pub/networking/kermit/dec20/assembler-guide.txt), but I doubt OCaml is likely to support that soon either.