### PR TITLE
typecore: remove redundant `try … with`

### DIFF
--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2686,9 +2686,7 @@ and type_expect_
                 end_def ();
                 let tv = newvar () in
                 let gen = generalizable tv.level arg.exp_type in
-                (try unify_var env tv arg.exp_type with Unify trace ->
-                  raise(Error(arg.exp_loc, env,
-                              Expr_type_clash (trace, None))));
+                unify_var env tv arg.exp_type;
                 gen
               end else true
             in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2968,22 +2968,14 @@ and type_expect_
       let (id, new_env) = Env.enter_module name.txt modl.mod_type env in
       Ctype.init_def(Ident.current_time());
       Typetexp.widen context;
+      (* ideally, we should catch Expr_type_clash errors
+         in type_expect triggered by escaping identifiers from the local module
+         and refine them into Scoping_let_module errors
+      *)
       let body = type_expect new_env sbody ty_expected_explained in
       (* go back to original level *)
       end_def ();
-      (* Unification of body.exp_type with the fresh variable ty
-         fails if and only if the prefix condition is violated,
-         i.e. if generative types rooted at id show up in the
-         type body.exp_type.  Thus, this unification enforces the
-         scoping condition on "let module". *)
-      (* Note that this code will only be reached if ty_expected
-         is a generic type variable, otherwise the error will occur
-         above in type_expect *)
-      begin try
-        Ctype.unify_var new_env ty body.exp_type
-      with Unify _ ->
-        raise(Error(loc, env, Scoping_let_module(name.txt, body.exp_type)))
-      end;
+      Ctype.unify_var new_env ty body.exp_type;
       re {
         exp_desc = Texp_letmodule(id, name, modl, body);
         exp_loc = loc; exp_extra = [];


### PR DESCRIPTION
This PR proposes to remove two possibly redundant `try … with` clauses in `typing/typecore.ml`.

The first commit removes a `try … with` clause in the typechecking of coercion that was added while fixing [MPR#7260](https://caml.inria.fr/mantis/view.php?id=7260). However, the example added with this fix does not raise such an exception.

The second commit removes the `try … with` clause used when typechecking local
module bindings. This clause wrap around a call to `unify_var env newvar`
that is called subsequently to a call to `type_expect`. As far as I can tell (and after a discussion with @trefis and @Drup ), this call to `type_expect` would have raised an exception earlier if
`unify_var` were to raise an exception itself, thus the `try ... with` statement is redundant.

This removal makes clear that the error message for locally bound module (`Scoping_let_module`) has been unheard of since 4.00, i.e. the prime example of this error

```OCaml
let module M = struct type t = A end in M.A
```
raises a generic scope escape message since 4.00:

> Error: This expression has type M.t but an expression was expected of type 'a
       The type constructor M.t would escape its scope

I have therefore updated the comment about this error message to reflect that it is currently dead code but it might be nice to restore it.

@lpw25 , @garrigue : would you have the time to comment on those minor issues?