### PR TITLE
test suite: examples for error paths in typecore.ml

### DIFF
--- a/testsuite/tests/typing-misc/ocamltests
+++ b/testsuite/tests/typing-misc/ocamltests
@@ -17,3 +17,5 @@ unique_names_in_unification.ml
 variant.ml
 wellfounded.ml
 empty_variant.ml
+typecore_errors.ml
+typecore_nolabel_errors.ml

--- a/testsuite/tests/typing-misc/typecore_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_errors.ml
@@ -10,11 +10,11 @@
 
 (** Illegal interval *)
 
-let x = function 'a'..10 -> ()
+let x = function 0. .. 1. -> ()
 [%%expect {|
-Line _, characters 17-24:
-  let x = function 'a'..10 -> ()
-                   ^^^^^^^
+Line _, characters 17-25:
+  let x = function 0. .. 1. -> ()
+                   ^^^^^^^^
 Error: Only character intervals are supported in patterns.
 |}]
 

--- a/testsuite/tests/typing-misc/typecore_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_errors.ml
@@ -1,0 +1,477 @@
+(* TEST
+   * expect
+*)
+
+
+(** Gives an example for every [raise(Error(_,_,_)] in typing/typecore.ml
+    that is no covered by another test in the testsuite and does not
+    require special flags or ppx.
+*)
+
+(** Illegal interval *)
+
+let x = function 'a'..10 -> ()
+[%%expect {|
+Line _, characters 17-24:
+  let x = function 'a'..10 -> ()
+                   ^^^^^^^
+Error: Only character intervals are supported in patterns.
+|}]
+
+(** Constructor arity mismatch *)
+let f = function None None -> 0
+
+[%%expect{|
+Line _, characters 17-26:
+  let f = function None None -> 0
+                   ^^^^^^^^^
+Error: The constructor None expects 0 argument(s),
+       but is applied here to 1 argument(s)
+|}]
+
+let x = None None
+[%%expect{|
+Line _, characters 8-17:
+  let x = None None
+          ^^^^^^^^^
+Error: The constructor None expects 0 argument(s),
+       but is applied here to 1 argument(s)
+|}]
+
+(** Inline record escape *)
+type t = A of {x:int}
+let f = function (A (x:_)) -> 0
+
+[%%expect{|
+type t = A of { x : int; }
+Line _, characters 20-25:
+  let f = function (A (x:_)) -> 0
+                      ^^^^^
+Error: This form is not allowed as the type of the inlined record could escape.
+|}]
+
+
+(** Exception below toplevel *)
+let f = function Some(exception Not_found) -> 0
+[%%expect{|
+Line _, characters 21-42:
+  let f = function Some(exception Not_found) -> 0
+                       ^^^^^^^^^^^^^^^^^^^^^
+Error: Exception patterns must be at the top level of a match case.
+|}]
+
+(** Extension *)
+let f = function [%ext] -> 0
+[%%expect{|
+Line _, characters 19-22:
+  let f = function [%ext] -> 0
+                     ^^^
+Error: Uninterpreted extension 'ext'.
+|}]
+
+
+(** Unification error in type approx *)
+
+let rec f x = ( (), () : _ -> _ -> _ )
+[%%expect{|
+Line _, characters 14-38:
+  let rec f x = ( (), () : _ -> _ -> _ )
+                ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type 'a * 'b
+       but an expression was expected of type 'c -> 'd -> 'e
+|}]
+
+let rec g x = ( ((), ()) : _ -> _ :> _ )
+[%%expect{|
+Line _, characters 14-40:
+  let rec g x = ( ((), ()) : _ -> _ :> _ )
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type 'a * 'b
+       but an expression was expected of type 'c -> 'd
+|}]
+
+
+(** Masked instance variable *)
+let c = object val x= 0 val y = x end
+[%%expect{|
+Line _, characters 32-33:
+  let c = object val x= 0 val y = x end
+                                  ^
+Error: The instance variable x
+cannot be accessed from the definition of another instance variable
+|}]
+
+
+(** No value clause *)
+
+let f x = match x with exception Not_found -> ();;
+[%%expect{|
+Line _, characters 10-48:
+  let f x = match x with exception Not_found -> ();;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: None of the patterns in this 'match' expression match values.
+|}]
+
+(** Check duplicate *)
+type r = { x : int }
+let r = { x= 1; x= 1}
+
+[%%expect{|
+type r = { x : int; }
+Line _, characters 8-21:
+  let r = { x= 1; x= 1}
+          ^^^^^^^^^^^^^
+Error: The record field label x is defined several times
+|}]
+
+(** Non-mutable is non mutable *)
+let () = { x = 1 }.x <- 2
+
+[%%expect{|
+Line _, characters 9-25:
+  let () = { x = 1 }.x <- 2
+           ^^^^^^^^^^^^^^^^
+Error: The record field x is not mutable
+|}]
+
+
+(** Invalid for loop *)
+
+let () = for Some i = 3 to 4 do () done;
+[%%expect{|
+Line _, characters 13-19:
+  let () = for Some i = 3 to 4 do () done;
+               ^^^^^^
+Error: Invalid for-loop index: only variables and _ are allowed.
+|}]
+
+
+(** Inherited methods not defined *)
+
+class virtual v = object method virtual m: int end;;
+class c = object(self)
+  inherit v as super
+  method m = 0
+  method x: int = super#m
+end;;
+
+[%%expect{|
+class virtual v : object method virtual m : int end
+Line _, characters 18-23:
+    method x: int = super#m
+                    ^^^^^
+Error: This expression has no method m
+|}]
+
+(** New virtual class *)
+
+let x = new v
+
+[%%expect{|
+Line _, characters 8-13:
+  let x = new v
+          ^^^^^
+Error: Cannot instantiate the virtual class v
+|}]
+
+
+(* Immutable instance variable cannot be mutated *)
+let x = object val x = 1 method m = x<-0 end
+
+[%%expect{|
+Line _, characters 36-40:
+  let x = object val x = 1 method m = x<-0 end
+                                      ^^^^
+Error: The instance variable x is not mutable
+|}]
+
+(** Self variables cannot be mutated *)
+let x = object(self) method m = self <-0 end
+
+[%%expect{|
+Line _, characters 32-40:
+  let x = object(self) method m = self <-0 end
+                                  ^^^^^^^^
+Error: The value self is not an instance variable
+|}]
+
+(** Multiply override *)
+
+class c = object val x = 0 method m: c = {< x=0; x=1 >} end
+
+[%%expect{|
+Line _, characters 41-55:
+  class c = object val x = 0 method m: c = {< x=0; x=1 >} end
+                                           ^^^^^^^^^^^^^^
+Error: The instance variable x is overridden several times
+|}]
+
+(** Override outside of classes *)
+
+let f x = {< y = x >}
+
+[%%expect{|
+Line _, characters 10-21:
+  let f x = {< y = x >}
+            ^^^^^^^^^^^
+Error: This object duplication occurs outside a method definition
+|}]
+
+
+(** Unbound instance variable in object duplication *)
+
+class c = object val x = 0 method m: c = {< y=1 >} end
+
+[%%expect{|
+Line _, characters 41-50:
+  class c = object val x = 0 method m: c = {< y=1 >} end
+                                           ^^^^^^^^^
+Error: Unbound instance variable y
+|}]
+
+
+(** Not a packed type *)
+module type empty = sig  end
+let f (x:int) = ()
+let x = f (module struct end)
+[%%expect {|
+module type empty = sig  end
+val f : int -> unit = <fun>
+Line _, characters 10-29:
+  let x = f (module struct end)
+            ^^^^^^^^^^^^^^^^^^^
+Error: This expression is packed module, but the expected type is
+int
+|}]
+
+
+(** Bultin [%extension_constructor *)
+type t = A
+let x = [%extension_constructor A]
+[%%expect {|
+type t = A
+Line _, characters 32-33:
+  let x = [%extension_constructor A]
+                                  ^
+Error: This constructor is not an extension constructor.
+|}]
+
+let x = [%extension_constructor]
+[%%expect {|
+Line _, characters 8-32:
+  let x = [%extension_constructor]
+          ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Invalid [%extension_constructor] payload, a constructor is expected.
+|}]
+
+(** Invalid format *)
+let x = format_of_string "%z"
+[%%expect {|
+Line _, characters 25-29:
+  let x = format_of_string "%z"
+                           ^^^^
+Error: invalid format "%z": at character number 1, invalid conversion "%z"
+|}]
+
+(** Apply wrong label *)
+
+let f ~x = x + 2
+let y = f ~y:1
+[%%expect {|
+val f : x:int -> int = <fun>
+Line _, characters 13-14:
+  let y = f ~y:1
+               ^
+Error: The function applied to this argument has type x:int -> int
+This argument cannot be applied with label ~y
+|}]
+
+let g f = f ~x:0 ~y:0; f ~y:0 ~x:0
+[%%expect {|
+Line _, characters 23-24:
+  let g f = f ~x:0 ~y:0; f ~y:0 ~x:0
+                         ^
+Error: This function is applied to arguments
+in an order different from other calls.
+This is only allowed when the real type is known.
+|}]
+
+(** Inlined record *)
+type t = A of { x: int }
+let x = A 1
+[%%expect {|
+type t = A of { x : int; }
+Line _, characters 8-11:
+  let x = A 1
+          ^^^
+Error: This constructor expects an inlined record argument.
+|}]
+
+(** Illegal let rec *)
+type 'a t = A of 'a
+let rec A x = A (A ())
+
+[%%expect {|
+type 'a t = A of 'a
+Line _, characters 8-11:
+  let rec A x = A (A ())
+          ^^^
+Error: Only variables are allowed as left-hand side of `let rec'
+|}]
+
+(** Non-linear pattern *)
+
+let quadratic (x,x) = x * x
+[%%expect {|
+Line _, characters 17-18:
+  let quadratic (x,x) = x * x
+                   ^
+Error: Variable x is bound several times in this matching
+|}]
+
+(** Or-patter clash *)
+type t = A of int | B of float|C
+let f (A x|B x) = 0
+[%%expect {|
+type t = A of int | B of float | C
+Line _, characters 6-15:
+  let f (A x|B x) = 0
+        ^^^^^^^^^
+Error: The variable x on the left-hand side of this or-pattern has type
+       int but on the right-hand side it has type float
+|}]
+
+(** Orphan pattern variable *)
+
+let f (A x|C) = 0
+[%%expect {|
+Line _, characters 6-13:
+  let f (A x|C) = 0
+        ^^^^^^^
+Error: Variable x must occur on both sides of this | pattern
+|}]
+
+
+let f (A x|B y) = 0
+[%%expect {|
+Line _, characters 6-15:
+  let f (A x|B y) = 0
+        ^^^^^^^^^
+Error: Variable x must occur on both sides of this | pattern
+|}]
+
+(** #t *)
+type t = []
+let f = function #t -> ()
+[%%expect {|
+type t = []
+Line _, characters 18-19:
+  let f = function #t -> ()
+                    ^
+Error: The type t
+is not a variant type
+|}]
+
+let f {x;x=y;x=z} = x
+[%%expect {|
+Line _, characters 6-17:
+  let f {x;x=y;x=z} = x
+        ^^^^^^^^^^^
+Error: The record field label x is defined several times
+|}]
+
+(** Coercion failure *)
+
+let x = ([`B]:>[`A])
+[%%expect {|
+Line _, characters 9-13:
+  let x = ([`B]:>[`A])
+           ^^^^
+Error: This expression cannot be coerced to type [ `A ]; it has type
+         [> `B ] list
+       but is here used with type [< `A ]
+|}]
+
+(** Unbound instance variable *)
+
+let o = object method m = instance <- 0 end
+
+[%%expect{|
+Line _, characters 26-39:
+  let o = object method m = instance <- 0 end
+                            ^^^^^^^^^^^^^
+Error: Unbound instance variable instance
+|}]
+
+
+(** Hash collision *)
+let x = function
+  | `azdwbie -> ()
+  | `c7diagq -> ()
+[%%expect{|
+Line _, characters 4-12:
+    | `c7diagq -> ()
+      ^^^^^^^^
+Error: Variant tags `azdwbie and `c7diagq have the same hash value.
+       Change one of them.
+|}]
+
+
+let x =  `azdwbie = `c7diagq
+[%%expect{|
+Line _, characters 20-28:
+  let x =  `azdwbie = `c7diagq
+                      ^^^^^^^^
+Error: Variant tags `azdwbie and `c7diagq have the same hash value.
+       Change one of them.
+|}]
+
+type 'a x =
+  | X: [>`azdwbie] x
+  | Y: [>`c7diagq] x
+
+let x  = function
+  | X -> ()
+  | Y  -> ()
+
+[%%expect{|
+type 'a x = X : [> `azdwbie ] x | Y : [> `c7diagq ] x
+Line _, characters 4-5:
+    | Y  -> ()
+      ^
+Error: Variant tags `azdwbie and `c7diagq have the same hash value.
+       Change one of them.
+|}]
+
+
+type t = {x:unit}
+type s = {y:unit}
+let f = function {x; y} -> x
+[%%expect {|
+type t = { x : unit; }
+type s = { y : unit; }
+Line _, characters 21-22:
+  let f = function {x; y} -> x
+                       ^
+Error: The record field y belongs to the type s
+       but is mixed here with fields of type t
+|}]
+
+
+(** Error extension node *)
+
+let x = [%ocaml.error "Expression error"]
+[%%expect {|
+Line _, characters 10-21:
+  let x = [%ocaml.error "Expression error"]
+            ^^^^^^^^^^^
+Error: Expression error
+|}]
+
+let f [%ocaml.error "Pattern error"] = ()
+[%%expect {|
+Line _, characters 8-19:
+  let f [%ocaml.error "Pattern error"] = ()
+          ^^^^^^^^^^^
+Error: Pattern error
+|}]

--- a/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
@@ -1,0 +1,50 @@
+(* TEST
+   flags="-nolabels"
+   * expect
+*)
+
+
+(** Gives an example for every [raise(Error(_,_,_)] in typing/typecore.ml
+    which both requires the "-nolabel" flags and is no covered by another test
+    in the testsuite.
+*)
+
+let check f = f ()
+
+let f ~x = ()
+let () = check f;;
+[%%expect {|
+val check : (unit -> 'a) -> 'a = <fun>
+val f : x:'a -> unit = <fun>
+|}]
+
+let () = f ~y:1
+[%%expect {|
+Line _, characters 14-15:
+  let () = f ~y:1
+                ^
+Error: The function applied to this argument has type x:'a -> unit
+This argument cannot be applied with label ~y
+|}]
+
+let f ?x ~a ?y ~z = ()
+let g = f ?y:None ?x:None ~a:()
+[%%expect {|
+val f : ?x:'a -> a:'b -> ?y:'c -> z:'d -> unit = <fun>
+Line _, characters 13-17:
+  let g = f ?y:None ?x:None ~a:()
+               ^^^^
+Error: The function applied to this argument has type
+         ?x:'a -> a:'b -> ?y:'c -> z:'d -> unit
+This argument cannot be applied with label ?y
+|}]
+
+let f (g: ?x:_ -> _) = g ~y:None ?x:None; g ?x:None ()
+
+[%%expect{|
+Line _, characters 28-32:
+  let f (g: ?x:_ -> _) = g ~y:None ?x:None; g ?x:None ()
+                              ^^^^
+Error: The function applied to this argument has type ?x:'a -> 'b
+This argument cannot be applied with label ~y
+|}]


### PR DESCRIPTION
This PR is the negative counterpart to #1868, #1872 and #1881: it adds a small example for every error path of the form `raise(Error(…))` in `typecore.ml` that was not covered anywhere else in the test suite.
Most of the examples tested in this PR are trivial, but they helped me to identify the issues raised in the above PRs.

There is one small exception, due to an error that is only reachable with a ppx that would create an empty polymorphic variant type abbreviation:
```OCaml
type t = [%empty_polymorphic_variant]
let f = function #t -> ()
```
I am currently planning to add support for ppx in ocamltest to also cover this error.