### PR TITLE
Add an explanation for the expected type of when-clauses

### DIFF
--- a/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
+++ b/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
@@ -175,3 +175,16 @@ Error: This variant expression is expected to have type unit
          because it is in the result of a conditional with no else branch
        The constructor :: does not belong to type unit
 |}];;
+
+(function
+  | y when y + 1 -> ()
+  | _ -> ());;
+
+[%%expect{|
+Line _, characters 11-16:
+    | y when y + 1 -> ()
+             ^^^^^
+Error: This expression has type int but an expression was expected of type
+         bool
+       because it is in a when-guard
+|}];;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -33,6 +33,7 @@ type type_forcing_context =
   | For_loop_body
   | Assert_condition
   | Sequence_left_hand_side
+  | When_guard
 
 type type_expected = {
   ty: type_expr;
@@ -4132,7 +4133,7 @@ and type_cases ?in_function env ty_arg ty_res partial_flag loc caselist =
           | Some scond ->
               Some
                 (type_expect ext_env (wrap_unpacks scond unpacks)
-                   (mk_expected Predef.type_bool))
+                   (mk_expected ~explanation:When_guard Predef.type_bool))
         in
         let exp =
           type_expect ?in_function ext_env sexp (mk_expected ty_res') in
@@ -4496,6 +4497,8 @@ let report_type_expected_explanation expl ppf =
       fprintf ppf "the condition of an assertion"
   | Sequence_left_hand_side ->
       fprintf ppf "the left-hand side of a sequence"
+  | When_guard ->
+      fprintf ppf "a when-guard"
 
 let report_type_expected_explanation_opt expl ppf =
   match expl with

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -37,6 +37,7 @@ type type_forcing_context =
   | For_loop_body
   | Assert_condition
   | Sequence_left_hand_side
+  | When_guard
 
 (* The combination of a type and a "type forcing context". The intent is that it
    describes a type that is "expected" (required) by the context. If unifying


### PR DESCRIPTION
This is a very small bit of #102 that I forgot to include in #1510 where it should have been implemented.

This patch adds an "explanation" for the type expected for when-clauses (that is, `bool`).