### PR TITLE
manual: Small style+grammar fixes to front matter and foreword

### DIFF
--- a/manual/manual/allfiles.etex
+++ b/manual/manual/allfiles.etex
@@ -8,9 +8,9 @@
 \thispagestyle{empty}
 \begin{maintitle}
 ~\vfill
-\Huge           The OCaml system \\
-                release \ocamlversion \\[1cm]
-\Large          Documentation and user's manual \\[1cm]
+\Huge           The OCaml System \\
+                Documentation and User's Manual \\[1cm]
+\Large          Release \ocamlversion \\[1cm]
 \large          Xavier Leroy, \\
                 Damien Doligez, Alain Frisch, Jacques Garrigue, Didier Rémy and Jérôme Vouillon \\[1cm]
                 \today \\
@@ -41,7 +41,7 @@ and as a
 
 \input{foreword.tex}
 
-\part{An introduction to OCaml}
+\part{An Introduction to OCaml}
 \label{p:tutorials}
 \input{coreexamples.tex}
 \input{moduleexamples.tex}
@@ -50,12 +50,12 @@ and as a
 \input{polymorphism.tex}
 \input{advexamples.tex}
 
-\part{The OCaml language}
+\part{The OCaml Language}
 \label{p:refman}
 \input{refman.tex}
 \input{exten.tex}
 
-\part{The OCaml tools}
+\part{The OCaml Tools}
 \label{p:commands}
 
 \input{comp.tex}
@@ -76,7 +76,7 @@ and as a
 \input{afl-fuzz.tex}
 \input{plugins}
 
-\part{The OCaml library}
+\part{The OCaml Library}
 \label{p:library}
 \input{core.tex}
 \input{stdlib.tex}
@@ -94,15 +94,15 @@ and as a
 
 \ifouthtml
 \begin{links}
-\item \ahref{libref/index_modules.html}{Index of modules}
-\item \ahref{libref/index_module_types.html}{Index of module types}
-\item \ahref{libref/index_types.html}{Index of types}
-\item \ahref{libref/index_exceptions.html}{Index of exceptions}
-\item \ahref{libref/index_values.html}{Index of values}
+\item \ahref{libref/index_modules.html}{Index of Modules}
+\item \ahref{libref/index_module_types.html}{Index of Module Types}
+\item \ahref{libref/index_types.html}{Index of Types}
+\item \ahref{libref/index_exceptions.html}{Index of Exceptions}
+\item \ahref{libref/index_values.html}{Index of Values}
 \end{links}
 \else
-\printindex{\jobname}{Index to the library}
+\printindex{\jobname}{Index to the Library}
 \fi
-\printindex{\jobname.kwd}{Index of keywords}
+\printindex{\jobname.kwd}{Index of Keywords}
 
 \end{document}

--- a/manual/manual/foreword.etex
+++ b/manual/manual/foreword.etex
@@ -2,16 +2,16 @@
 \markboth{Foreword}{}
 %HEVEA\cutname{foreword.html}
 
-This manual documents the release \ocamlversion\ of the OCaml
-system. It is organized as follows.
+This manual documents release \ocamlversion\ of the OCaml
+system. It is organized as follows:
 \begin{itemize}
-\item Part~\ref{p:tutorials}, ``An introduction to OCaml'',
+\item Part~\ref{p:tutorials}, ``An Introduction to OCaml'',
 gives an overview of the language.
-\item Part~\ref{p:refman}, ``The OCaml language'', is the
+\item Part~\ref{p:refman}, ``The OCaml Language'', is the
 reference description of the language.
-\item Part~\ref{p:commands}, ``The OCaml tools'', documents
+\item Part~\ref{p:commands}, ``The OCaml Tools'', documents
 the compilers, toplevel system, and programming utilities.
-\item Part~\ref{p:library}, ``The OCaml library'', describes the
+\item Part~\ref{p:library}, ``The OCaml Library'', describes the
 modules provided in the standard library.
 \begin{latexonly}
 \item Part~\ref{p:appendix}, ``Appendix'', contains an
@@ -45,7 +45,7 @@ The OCaml system is open source and can be freely
 redistributed.  See the file "LICENSE" in the distribution for
 licensing information.
 
-The present documentation is copyright \copyright\ \number\year\
+This documentation is copyright \copyright\ \number\year\
 Institut National de Recherche en Informatique et en
 Automatique (INRIA).  The OCaml documentation and user's
 manual may be reproduced and distributed in whole or
@@ -75,8 +75,8 @@ The former Web site contains a lot of additional information on OCaml.
 
 \begin{htmlonly}
 The complete OCaml distribution can be accessed via the
-\href{http://www.ocaml.org/}{community Caml Web site} and the
+\href{http://www.ocaml.org/}{community OCaml Web site} and the
 \href{http://caml.inria.fr/}{older Caml Web site}.
-The \href{http://www.ocaml.org/}{community Caml Web site}
+The \href{http://www.ocaml.org/}{community OCaml Web site}
 contains a lot of additional information on OCaml.
 \end{htmlonly}


### PR DESCRIPTION
I'm going through the OCaml manual, making small fixes to the style and grammar.
Mostly I'm following the rules of the Chicago Manual of Style, with some reference to other style manuals.
I'll be doing roughly one PR per chapter.

manual/manual/allfiles.etex:
    Change to put the fact that this is the manual in the main title,
    with the version in the subtitle.
    Capitalize title and chapter names per common editorial style
    guides like CMS, APA, MLA, etc.

manual/manual/foreword.etex:
    Capitalize title and chapter names per common editorial style
    guides like CMS, APA, MLA, etc.
    Small grammar fixes.
    The ocaml.org web site is for OCaml, not Caml, adjust accordingly.