### PR TITLE
manual: fixes for the .svg arrow files hevea now generates

### DIFF
--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -139,6 +139,6 @@ clean:
 	$(MAKE) -C refman    clean
 	$(MAKE) -C tutorials clean
 	-rm -f texstuff/*
-	cd htmlman; rm -rf libref index.html manual*.html *.haux *.hind
+	cd htmlman; rm -rf libref index.html manual*.html *.haux *.hind *.svg
 	cd textman; rm -f manual.txt *.haux *.hind
 	cd infoman; rm -f ocaml.info ocaml.info-*  *.haux *.hind

--- a/manual/manual/htmlman/.gitignore
+++ b/manual/manual/htmlman/.gitignore
@@ -6,3 +6,4 @@ manual.hmanual
 manual.hmanual.kwd
 manual.css
 *.htoc
+*.svg


### PR DESCRIPTION
Hevea 2.32 now generates nice svg arrows in place of the old gifs. This change fixes the resulting minor infrastructure issues.

manual/Makefile: add *.svg to the clean target for htmlman directory
manual/htmlman/.gitignore: add *.svg