### PR TITLE
Ctype.unroll_abbrev bug

### DIFF
--- a/Changes
+++ b/Changes
@@ -192,6 +192,9 @@ Working version
 - GPR#1843: ocamloptp was doing the wrong thing with option -inline-max-unroll.
   (Github user @poechsel, review by Nicolás Ojeda Bär).
 
+- GPR#1890: remove last use of Ctype.unroll_abbrev
+  (Thomas Refis, report by Leo White, review by Jacques Garrigue)
+
 
 OCaml 4.07
 ----------

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -70,7 +70,7 @@ module I : functor (X : sig  end) -> sig type t = Priv(X).t end
 
 module IndirectPub = H(struct end);;
 [%%expect{|
-module IndirectPub : sig type t = [ `Foo of t ] end
+module IndirectPub : sig type t = [ `Foo of 'a ] as 'a end
 |}]
 
 (* The result would be

--- a/testsuite/tests/typing-modules/ocamltests
+++ b/testsuite/tests/typing-modules/ocamltests
@@ -11,3 +11,4 @@ pr7787.ml
 printing.ml
 recursive.ml
 Test.ml
+unroll_private_abbrev.ml

--- a/testsuite/tests/typing-modules/unroll_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/unroll_private_abbrev.ml
@@ -1,0 +1,75 @@
+(* TEST
+   * expect
+*)
+
+module M : sig
+  type t = private [ `Bar of 'a | `Foo ] as 'a
+  val bar : t
+end = struct
+  type t = [ `Bar of 'a | `Foo ] as 'a
+  let bar = `Bar `Foo
+end;;
+[%%expect{|
+module M : sig type t = private [ `Bar of 'a | `Foo ] as 'a val bar : t end
+|}]
+
+let y =
+  match (M.bar :> [ `Bar of 'a | `Foo ] as 'a) with
+  | `Bar x -> x
+  | `Foo -> assert false
+;;
+[%%expect{|
+val y : [ `Bar of 'a | `Foo ] as 'a = `Foo
+|}]
+
+let y =
+  match (M.bar :> [ `Bar of M.t | `Foo ]) with
+  | `Bar x -> x
+  | `Foo -> assert false
+;;
+[%%expect{|
+Line _, characters 8-41:
+    match (M.bar :> [ `Bar of M.t | `Foo ]) with
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type M.t is not a subtype of [ `Bar of M.t | `Foo ]
+       Type M.t = [ `Bar of M.t | `Foo ] is not a subtype of M.t
+|}]
+
+module F(X : sig end) : sig
+  type s = private [ `Bar of 'a | `Foo ] as 'a
+
+  val from : M.t -> s
+  val to_  : s -> M.t
+end = struct
+  type s = M.t
+
+  let from x = x
+  let to_ x = x
+end;;
+[%%expect{|
+module F :
+  functor (X : sig  end) ->
+    sig
+      type s = private [ `Bar of 'a | `Foo ] as 'a
+      val from : M.t -> s
+      val to_ : s -> M.t
+    end
+|}]
+
+module N = F(struct end);;
+[%%expect{|
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+let y =
+  match (N.from M.bar :> [ `Bar of N.s | `Foo ]) with
+  | `Bar x -> N.to_ x
+  | `Foo -> assert false
+;;
+[%%expect{|
+Line _, characters 35-38:
+    match (N.from M.bar :> [ `Bar of N.s | `Foo ]) with
+                                     ^^^
+Error: Unbound module N
+|}]

--- a/testsuite/tests/typing-modules/unroll_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/unroll_private_abbrev.ml
@@ -58,8 +58,12 @@ module F :
 
 module N = F(struct end);;
 [%%expect{|
-Uncaught exception: Misc.Fatal_error
-
+module N :
+  sig
+    type s = private [ `Bar of 'a | `Foo ] as 'a
+    val from : M.t -> s
+    val to_ : s -> M.t
+  end
 |}]
 
 let y =
@@ -68,8 +72,9 @@ let y =
   | `Foo -> assert false
 ;;
 [%%expect{|
-Line _, characters 35-38:
+Line _, characters 8-48:
     match (N.from M.bar :> [ `Bar of N.s | `Foo ]) with
-                                     ^^^
-Error: Unbound module N
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type N.s is not a subtype of [ `Bar of N.s | `Foo ]
+       Type N.s = [ `Bar of N.s | `Foo ] is not a subtype of N.s
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4438,18 +4438,8 @@ let nondep_type env id ty =
 
 let () = nondep_type' := nondep_type
 
-let unroll_abbrev id tl ty =
-  let ty = repr ty and path = Path.Pident id in
-  if is_Tvar ty || (List.exists (deep_occur ty) tl)
-  || is_object_type path then
-    ty
-  else
-    let ty' = newty2 ty.level ty.desc in
-    link_type ty (newty2 ty.level (Tconstr (path, tl, ref Mnil)));
-    ty'
-
 (* Preserve sharing inside type declarations. *)
-let nondep_type_decl env mid id is_covariant decl =
+let nondep_type_decl env mid is_covariant decl =
   try
     let params = List.map (nondep_type_rec env mid) decl.type_params in
     let tk =
@@ -4459,9 +4449,7 @@ let nondep_type_decl env mid id is_covariant decl =
       match decl.type_manifest with
       | None -> None, decl.type_private
       | Some ty ->
-          try Some (unroll_abbrev id params
-                      (nondep_type_rec env mid ty)),
-              decl.type_private
+          try Some (nondep_type_rec env mid ty), decl.type_private
           with Not_found when is_covariant ->
             clear_hash ();
             try Some (nondep_type_rec ~expand_private:true env mid ty),

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -244,7 +244,7 @@ val nondep_type: Env.t -> Ident.t -> type_expr -> type_expr
            references to the given module identifier. Raise [Not_found]
            if no such type exists. *)
 val nondep_type_decl:
-        Env.t -> Ident.t -> Ident.t -> bool -> type_declaration ->
+        Env.t -> Ident.t -> bool -> type_declaration ->
         type_declaration
         (* Same for type declarations. *)
 val nondep_extension_constructor:

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -182,7 +182,7 @@ let nondep_supertype env mid mty =
                     {d with val_type = Ctype.nondep_type env mid d.val_type})
           :: rem'
       | Sig_type(id, d, rs) ->
-          Sig_type(id, Ctype.nondep_type_decl env mid id (va = Co) d, rs)
+          Sig_type(id, Ctype.nondep_type_decl env mid (va = Co) d, rs)
           :: rem'
       | Sig_typext(id, ext, es) ->
           Sig_typext(id, Ctype.nondep_extension_constructor env mid ext, es)


### PR DESCRIPTION
The call to `unroll_abbrev` inside `Ctype.nondep_type_decl` allows one to break privateness, as shown by the following example (reported by @lpw25):

```
        OCaml version 4.07.0+rc1

# module M : sig
    type t = private [ `Bar of 'a | `Foo ] as 'a
    val bar : t
  end = struct
    type t = [ `Bar of 'a | `Foo ] as 'a
    let bar = `Bar `Foo
  end;;
module M : sig type t = private [ `Bar of 'a | `Foo ] as 'a val bar : t end

# let y =
    match (M.bar :> [ `Bar of 'a | `Foo ] as 'a) with
    | `Bar x -> x
    | `Foo -> assert false
  ;;
val y : [ `Bar of 'a | `Foo ] as 'a = `Foo

# let y =
    match (M.bar :> [ `Bar of M.t | `Foo ]) with
    | `Bar x -> x
    | `Foo -> assert false
  ;;
Characters 16-49:
    match (M.bar :> [ `Bar of M.t | `Foo ]) with
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Type M.t is not a subtype of [ `Bar of M.t | `Foo ] 
       Type M.t = [ `Bar of M.t | `Foo ] is not a subtype of M.t 

# module F(X : sig end) : sig
    type s = private [ `Bar of 'a | `Foo ] as 'a
    
    val from : M.t -> s
    val to_  : s -> M.t
  end = struct
    type s = M.t
    
    let from x = x
    let to_ x = x
  end;;
module F :
  functor (X : sig  end) ->
    sig
      type s = private [ `Bar of 'a | `Foo ] as 'a
      val from : M.t -> s
      val to_ : s -> M.t
    end

# module N = F(struct end);;
module N :
  sig
    type s = private [ `Bar of s | `Foo ]
    val from : M.t -> s
    val to_ : s -> M.t
  end

# let y =
    match (N.from M.bar :> [ `Bar of N.s | `Foo ]) with
    | `Bar x -> N.to_ x
    | `Foo -> assert false
  ;;
val y : M.t = `Foo
```

On trunk, thanks to the check added in #1826, this issue is caught and one gets the following error when defining `N`:
```
>> Fatal error: nondep_supertype not included in original module type
Fatal error: exception Misc.Fatal_error
```

This GPR proposes to remove the call to `unroll_abbrev`: it's a somewhat obscure piece of code, that can cause bugs when misused, and which is used only to get nicer printing of types, as far as I can tell.

For the curious reader: `unroll_abbrev` was first introduced by Jérôme in 7974a9d8b1c8195130b2df216d6a102ca00cdf5b , and was used every time one created a manifest that could be an object type, all the way up to 87b17301f4a408109a0f00f7a297b02c79724bc1 when it was removed everywhere except in `nondep_type_decl`.