### PR TITLE
Allow shadowing of items coming from an include

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,9 @@ Working version
 - GPR#1705: Allow @@attributes on exceptions.
   (Hugo Heuzard, review by Gabriel Radanne and Thomas Refis)
 
+- GPR#1892: Allow shadowing of items coming from an include
+  (Thomas Refis, review by Gabriel Radanne)
+
 ### Type system:
 
 - GPR#1826: allow expanding a type to a private abbreviation instead of

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -45,7 +45,7 @@ let interface ppf sourcefile outputprefix =
         Printtyp.wrap_printing_env ~error:false initial_env (fun () ->
             fprintf std_formatter "%a@."
               (Printtyp.printed_signature sourcefile)
-              (Typemod.simplify_signature sg));
+              sg);
       ignore (Includemod.signatures initial_env sg sg);
       Typecore.force_delayed_checks ();
       Warnings.check_fatal ();

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -45,7 +45,7 @@ let interface ppf sourcefile outputprefix =
         Printtyp.wrap_printing_env ~error:false initial_env (fun () ->
             fprintf std_formatter "%a@."
               (Printtyp.printed_signature sourcefile)
-              (Typemod.simplify_signature sg));
+              sg);
       ignore (Includemod.signatures initial_env sg sg);
       Typecore.force_delayed_checks ();
       Warnings.check_fatal ();

--- a/testsuite/tests/shadow_include/artificial.ml
+++ b/testsuite/tests/shadow_include/artificial.ml
@@ -1,0 +1,69 @@
+(* TEST
+   * expect
+*)
+
+module Foo : sig
+  type t
+
+  module Bar : sig
+    type t
+  end
+
+  val to_ : t -> Bar.t
+  val from: Bar.t -> t
+end = struct
+  type t
+
+  module Bar = struct
+    type nonrec t = t
+  end
+
+  let to_ x = x
+  let from x = x
+end
+;;
+[%%expect{|
+module Foo :
+  sig
+    type t
+    module Bar : sig type t end
+    val to_ : t -> Bar.t
+    val from : Bar.t -> t
+  end
+|}]
+
+module Extended = struct
+  include Foo
+  module Bar = struct
+    include Bar
+    let int = 42
+  end
+end
+;;
+[%%expect{|
+module Extended :
+  sig
+    type t = Foo.t
+    val to_ : t -> Foo.Bar.t
+    val from : Foo.Bar.t -> t
+    module Bar : sig type t = Foo.Bar.t val int : int end
+  end
+|}]
+
+module type Extended = sig
+  include module type of struct include Foo end
+  module Bar : sig
+    include module type of struct include Bar end
+    val int : int
+  end
+end
+;;
+[%%expect{|
+module type Extended =
+  sig
+    type t = Foo.t
+    val to_ : t -> Foo.Bar.t
+    val from : Foo.Bar.t -> t
+    module Bar : sig type t = Foo.Bar.t val int : int end
+  end
+|}]

--- a/testsuite/tests/shadow_include/cannot_shadow_error.compilers.reference
+++ b/testsuite/tests/shadow_include/cannot_shadow_error.compilers.reference
@@ -1,0 +1,6 @@
+File "cannot_shadow_error.ml", line 23, characters 2-36:
+Error: Illegal shadowing of included type t/1141 by t/1145
+       File "cannot_shadow_error.ml", line 22, characters 2-19:
+         Type t/1141 came from this include
+       File "cannot_shadow_error.ml", line 13, characters 2-43:
+         The value print has no valid type if t/1141 is shadowed

--- a/testsuite/tests/shadow_include/cannot_shadow_error.ml
+++ b/testsuite/tests/shadow_include/cannot_shadow_error.ml
@@ -1,0 +1,24 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*** check-ocamlc.byte-output
+*)
+
+(* Same example as in tests/typing-sigsubst/sigsubst.ml, but not as an
+   expect_test so we get the full error.  *)
+
+module type Printable = sig
+  type t
+  val print : Format.formatter -> t -> unit
+end
+
+module type Comparable = sig
+  type t
+  val compare : t -> t -> int
+end
+
+module type PrintableComparable = sig
+  include Printable
+  include Comparable with type t = t
+end

--- a/testsuite/tests/shadow_include/ocamltests
+++ b/testsuite/tests/shadow_include/ocamltests
@@ -1,0 +1,3 @@
+artificial.ml
+cannot_shadow_error.ml
+shadow_all.ml

--- a/testsuite/tests/shadow_include/shadow_all.ml
+++ b/testsuite/tests/shadow_include/shadow_all.ml
@@ -1,0 +1,476 @@
+(* TEST
+   * expect
+*)
+
+(* Signatures *)
+
+(* Tests that everything can be shadowed. *)
+
+module type S = sig
+  type t
+
+  val unit : unit
+
+  external e : unit -> unit = "%identity"
+
+  module M : sig type t end
+
+  module type T
+
+  exception E
+
+  type ext = ..
+  type ext += C
+
+  class c : object end
+
+  class type ct = object end
+end
+;;
+[%%expect{|
+module type S =
+  sig
+    type t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M : sig type t end
+    module type T
+    exception E
+    type ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+module type SS = sig
+  include S
+  include S
+end
+;;
+[%%expect{|
+module type SS =
+  sig
+    type t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M : sig type t end
+    module type T
+    exception E
+    type ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+(* Test that the call to nondep works properly. *)
+
+module type Type = sig
+  include S
+  type u = t
+  include S
+end
+;;
+[%%expect{|
+module type Type =
+  sig
+    type u
+    type t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M : sig type t end
+    module type T
+    exception E
+    type ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+module type Type_fail = sig
+  include S
+  val ignore : t -> unit
+  include S
+end
+;;
+[%%expect{|
+Line 4, characters 2-11:
+    include S
+    ^^^^^^^^^
+Error: Illegal shadowing of included type t/1155 by t/1172
+       Line 2, characters 2-11:
+         Type t/1155 came from this include
+       Line 3, characters 2-24:
+         The value ignore has no valid type if t/1155 is shadowed
+|}]
+
+module type Module = sig
+  include S
+  module N = M
+  include S
+end
+;;
+[%%expect{|
+module type Module =
+  sig
+    module N : sig type t end
+    type t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M : sig type t end
+    module type T
+    exception E
+    type ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+module type Module_fail = sig
+  include S
+  val ignore : M.t -> unit
+  include S
+end
+;;
+[%%expect{|
+Line 4, characters 2-11:
+    include S
+    ^^^^^^^^^
+Error: Illegal shadowing of included module M/1247 by M/1264
+       Line 2, characters 2-11:
+         Module M/1247 came from this include
+       Line 3, characters 2-26:
+         The value ignore has no valid type if M/1247 is shadowed
+|}]
+
+
+module type Module_type = sig
+  include S
+  module type U = T
+  include S
+end
+;;
+[%%expect{|
+module type Module_type =
+  sig
+    module type U
+    type t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M : sig type t end
+    module type T
+    exception E
+    type ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+module type Module_type_fail = sig
+  include S
+  module F : functor (_ : T) -> sig end
+  include S
+end
+;;
+[%%expect{|
+Line 4, characters 2-11:
+    include S
+    ^^^^^^^^^
+Error: Illegal shadowing of included module type T/1336 by T/1354
+       Line 2, characters 2-11:
+         Module type T/1336 came from this include
+       Line 3, characters 2-39:
+         The module F has no valid type if T/1336 is shadowed
+|}]
+
+module type Extension = sig
+  include S
+  type ext += C2
+  include S
+end
+;;
+[%%expect{|
+Line 4, characters 2-11:
+    include S
+    ^^^^^^^^^
+Error: Illegal shadowing of included type ext/1372 by ext/1389
+       Line 2, characters 2-11:
+         Type ext/1372 came from this include
+       Line 3, characters 14-16:
+         The extension constructor C2 has no valid type if ext/1372 is shadowed
+|}]
+
+module type Class = sig
+  include S
+  class parametrized : int -> c
+  include S
+end
+;;
+[%%expect{|
+module type Class =
+  sig
+    class parametrized : int -> object  end
+    type t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M : sig type t end
+    module type T
+    exception E
+    type ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+module type Class_type = sig
+  include S
+  class type parametrized = ct
+  include S
+end
+;;
+[%%expect{|
+module type Class_type =
+  sig
+    class type parametrized = object  end
+    type t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M : sig type t end
+    module type T
+    exception E
+    type ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+(* Structures *)
+
+(* Tests that everything can be shadowed. *)
+
+module N = struct
+  type t
+
+  let unit = ()
+
+  external e : unit -> unit = "%identity"
+
+  module M = struct end
+
+  module type T = sig end
+
+  exception E
+
+  type ext = ..
+  type ext += C
+
+  class c = object end
+
+  class type ct = object end
+end
+;;
+[%%expect{|
+module N :
+  sig
+    type t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M : sig  end
+    module type T = sig  end
+    exception E
+    type ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+module NN = struct
+  include N
+  include N
+end
+;;
+[%%expect{|
+module NN :
+  sig
+    type t = N.t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M = N.M
+    module type T = sig  end
+    exception E
+    type ext = N.ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+(* Test that the call to nondep works properly *)
+
+module Type = struct
+  include N
+  type u = t
+  include N
+end
+;;
+[%%expect{|
+module Type :
+  sig
+    type u = N.t
+    type t = N.t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M = N.M
+    module type T = sig  end
+    exception E
+    type ext = N.ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+module Module = struct
+  include N
+  module O = M
+  include N
+end
+;;
+[%%expect{|
+module Module :
+  sig
+    module O = N.M
+    type t = N.t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M = N.M
+    module type T = sig  end
+    exception E
+    type ext = N.ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+module Module_type = struct
+  include N
+  module type U = T
+  include N
+end
+;;
+[%%expect{|
+module Module_type :
+  sig
+    module type U = sig  end
+    type t = N.t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M = N.M
+    module type T = sig  end
+    exception E
+    type ext = N.ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+module Exception = struct
+  include N
+  exception Exn = E
+  include N
+end
+;;
+[%%expect{|
+module Exception :
+  sig
+    exception Exn
+    type t = N.t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M = N.M
+    module type T = sig  end
+    exception E
+    type ext = N.ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+module Extension = struct
+  include N
+  type ext += C2
+  include N
+end
+;;
+[%%expect{|
+module Extension :
+  sig
+    type N.ext += C2
+    type t = N.t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M = N.M
+    module type T = sig  end
+    exception E
+    type ext = N.ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+module Class = struct
+  include N
+  class parametrized _ = c
+  include N
+end
+;;
+[%%expect{|
+module Class :
+  sig
+    class parametrized : 'a -> object  end
+    type t = N.t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M = N.M
+    module type T = sig  end
+    exception E
+    type ext = N.ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]
+
+module Class_type = struct
+  include N
+  class type parametrized = ct
+  include N
+end
+;;
+[%%expect{|
+module Class_type :
+  sig
+    class type parametrized = object  end
+    type t = N.t
+    val unit : unit
+    external e : unit -> unit = "%identity"
+    module M = N.M
+    module type T = sig  end
+    exception E
+    type ext = N.ext = ..
+    type ext += C
+    class c : object  end
+    class type ct = object  end
+  end
+|}]

--- a/testsuite/tests/typing-modules/Test.ml
+++ b/testsuite/tests/typing-modules/Test.ml
@@ -103,9 +103,9 @@ Error: This variant or record definition does not match that of type u
 
 module type S = sig exception Foo of int  exception Foo of bool end;;
 [%%expect{|
-Line 1, characters 52-55:
+Line 1, characters 42-63:
   module type S = sig exception Foo of int  exception Foo of bool end;;
-                                                      ^^^
+                                            ^^^^^^^^^^^^^^^^^^^^^
 Error: Multiple definition of the extension constructor name Foo.
        Names must be unique in a given structure or signature.
 |}];;

--- a/testsuite/tests/typing-objects-bugs/pr4435_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr4435_bad.compilers.reference
@@ -1,3 +1,3 @@
 File "pr4435_bad.ml", line 14, characters 6-7:
-Error: Multiple definition of the type name c.
+Error: Multiple definition of the class name c.
        Names must be unique in a given structure or signature.

--- a/testsuite/tests/typing-recordarg/recordarg.ocaml.reference
+++ b/testsuite/tests/typing-recordarg/recordarg.ocaml.reference
@@ -30,34 +30,26 @@ Line 3, characters 13-22:
                ^^^^^^^^^
 Error: This expression creates fresh types.
        It is not allowed inside applicative functors.
-Line 5, characters 12-13:
+Line 5, characters 2-29:
     exception A of {x : string}
-              ^
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Multiple definition of the extension constructor name A.
        Names must be unique in a given structure or signature.
-Line 4, characters 12-13:
+Line 4, characters 2-29:
     exception A of {x : string}
-              ^
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Multiple definition of the extension constructor name A.
        Names must be unique in a given structure or signature.
 module M1 : sig exception A of { x : int; } end
-Line 4, characters 2-12:
-    include M1
-    ^^^^^^^^^^
-Error: Multiple definition of the extension constructor name A.
-       Names must be unique in a given structure or signature.
+module M : sig exception A of { x : int; } end
 module type S1 = sig exception A of { x : int; } end
-Line 4, characters 2-12:
-    include S1
-    ^^^^^^^^^^
-Error: Multiple definition of the extension constructor name A.
-       Names must be unique in a given structure or signature.
+module type S = sig exception A of { x : int; } end
 module M : sig exception A of { x : int; } end
 module X1 : sig type t = .. end
 module X2 : sig type t = .. end
-Line 3, characters 15-16:
+Line 3, characters 15-28:
     type X2.t += A of {x: int}
-                 ^
+                 ^^^^^^^^^^^^^
 Error: Multiple definition of the extension constructor name A.
        Names must be unique in a given structure or signature.
 type _ c = C : [ `A ] c

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -25,8 +25,11 @@ end
 Line 3, characters 2-36:
     include Comparable with type t = t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Multiple definition of the type name t.
-       Names must be unique in a given structure or signature.
+Error: Illegal shadowing of included type t/1152 by t/1156
+       Line 2, characters 2-19:
+         Type t/1152 came from this include
+       Line 3, characters 2-43:
+         The value print has no valid type if t/1152 is shadowed
 |}]
 
 module type Sunderscore = sig

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -297,9 +297,9 @@ let execute_phrase print_outcome ppf phr =
             [ Ast_helper.Str.value ~loc Asttypes.Nonrecursive [vb] ], true
         | _ -> sstr, false
       in
-      let (str, sg, newenv) = Typemod.type_toplevel_phrase oldenv sstr in
+      let (str, sg, info, newenv) = Typemod.type_toplevel_phrase oldenv sstr in
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
-      let sg' = Typemod.simplify_signature sg in
+      let sg' = Typemod.simplify_signature newenv info sg in
       (* Why is this done? *)
       ignore (Includemod.signatures oldenv sg sg');
       Typecore.force_delayed_checks ();

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -239,9 +239,11 @@ let execute_phrase print_outcome ppf phr =
   | Ptop_def sstr ->
       let oldenv = !toplevel_env in
       Typecore.reset_delayed_checks ();
-      let (str, sg, newenv) = Typemod.type_toplevel_phrase oldenv sstr in
+      let (str, sg, to_remove_from_sg, newenv) =
+        Typemod.type_toplevel_phrase oldenv sstr
+      in
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
-      let sg' = Typemod.simplify_signature sg in
+      let sg' = Typemod.simplify_signature newenv to_remove_from_sg sg in
       ignore (Includemod.signatures oldenv sg sg');
       Typecore.force_delayed_checks ();
       let lam = Translmod.transl_toplevel_definition str in

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -237,23 +237,22 @@ val subtype: Env.t -> type_expr -> type_expr -> unit -> unit
            enforce and returns a function that enforces this
            constraints. *)
 
-val nondep_type: Env.t -> Ident.t -> type_expr -> type_expr
+val nondep_type: Env.t -> Ident.t list -> type_expr -> type_expr
         (* Return a type equivalent to the given type but without
-           references to the given module identifier. Raise [Not_found]
+           references to the given identifiers. Raise [Not_found]
            if no such type exists. *)
 val nondep_type_decl:
-        Env.t -> Ident.t -> bool -> type_declaration ->
-        type_declaration
+        Env.t -> Ident.t list -> bool -> type_declaration -> type_declaration
         (* Same for type declarations. *)
 val nondep_extension_constructor:
-        Env.t -> Ident.t -> extension_constructor ->
+        Env.t -> Ident.t list -> extension_constructor ->
         extension_constructor
           (* Same for extension constructor *)
 val nondep_class_declaration:
-        Env.t -> Ident.t -> class_declaration -> class_declaration
+        Env.t -> Ident.t list -> class_declaration -> class_declaration
         (* Same for class declarations. *)
 val nondep_cltype_declaration:
-        Env.t -> Ident.t -> class_type_declaration -> class_type_declaration
+        Env.t -> Ident.t list -> class_type_declaration -> class_type_declaration
         (* Same for class type declarations. *)
 (*val correct_abbrev: Env.t -> Path.t -> type_expr list -> type_expr -> unit*)
 val cyclic_abbrev: Env.t -> Ident.t -> type_expr -> bool

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -237,10 +237,13 @@ val subtype: Env.t -> type_expr -> type_expr -> unit -> unit
            enforce and returns a function that enforces this
            constraints. *)
 
+exception Nondep_cannot_erase of Ident.t
+
 val nondep_type: Env.t -> Ident.t list -> type_expr -> type_expr
         (* Return a type equivalent to the given type but without
-           references to the given identifiers. Raise [Not_found]
-           if no such type exists. *)
+           references to any of the given identifiers.
+           Raise [Nondep_cannot_erase id] if no such type exists because [id],
+           in particular, could not be erased. *)
 val nondep_type_decl:
         Env.t -> Ident.t list -> bool -> type_declaration -> type_declaration
         (* Same for type declarations. *)
@@ -252,7 +255,7 @@ val nondep_class_declaration:
         Env.t -> Ident.t list -> class_declaration -> class_declaration
         (* Same for class declarations. *)
 val nondep_cltype_declaration:
-        Env.t -> Ident.t list -> class_type_declaration -> class_type_declaration
+  Env.t -> Ident.t list -> class_type_declaration -> class_type_declaration
         (* Same for class type declarations. *)
 (*val correct_abbrev: Env.t -> Path.t -> type_expr list -> type_expr -> unit*)
 val cyclic_abbrev: Env.t -> Ident.t -> type_expr -> bool

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -150,67 +150,72 @@ let scrape_for_type_of env mty =
 
 type variance = Co | Contra | Strict
 
-let nondep_supertype env ids mty =
+let rec nondep_mty env va ids mty =
+  match mty with
+    Mty_ident p ->
+      begin match Path.find_free_opt ids p with
+      | Some id ->
+          let expansion =
+            try Env.find_modtype_expansion p env
+            with Not_found ->
+              raise (Ctype.Nondep_cannot_erase id)
+          in
+          nondep_mty env va ids expansion
+      | None -> mty
+      end
+  | Mty_alias(_, p) ->
+      begin match Path.find_free_opt ids p with
+      | Some id ->
+          let expansion =
+            try Env.find_module p env
+            with Not_found ->
+              raise (Ctype.Nondep_cannot_erase id)
+          in
+          nondep_mty env va ids expansion.md_type
+      | None -> mty
+      end
+  | Mty_signature sg ->
+      Mty_signature(nondep_sig env va ids sg)
+  | Mty_functor(param, arg, res) ->
+      let var_inv =
+        match va with Co -> Contra | Contra -> Co | Strict -> Strict in
+      Mty_functor(param, Misc.may_map (nondep_mty env var_inv ids) arg,
+                  nondep_mty
+                    (Env.add_module ~arg:true param
+                        (Btype.default_mty arg) env) va ids res)
 
-  let rec nondep_mty env va mty =
-    match mty with
-      Mty_ident p ->
-        if Path.exists_free ids p then
-          nondep_mty env va (Env.find_modtype_expansion p env)
-        else mty
-    | Mty_alias(_, p) ->
-        if Path.exists_free ids p then
-          nondep_mty env va (Env.find_module p env).md_type
-        else mty
-    | Mty_signature sg ->
-        Mty_signature(nondep_sig env va sg)
-    | Mty_functor(param, arg, res) ->
-        let var_inv =
-          match va with Co -> Contra | Contra -> Co | Strict -> Strict in
-        Mty_functor(param, Misc.may_map (nondep_mty env var_inv) arg,
-                    nondep_mty
-                      (Env.add_module ~arg:true param
-                         (Btype.default_mty arg) env) va res)
+and nondep_sig_item env va ids = function
+  | Sig_value(id, d) ->
+      Sig_value(id,
+                {d with val_type = Ctype.nondep_type env ids d.val_type})
+  | Sig_type(id, d, rs) ->
+      Sig_type(id, Ctype.nondep_type_decl env ids (va = Co) d, rs)
+  | Sig_typext(id, ext, es) ->
+      Sig_typext(id, Ctype.nondep_extension_constructor env ids ext, es)
+  | Sig_module(id, md, rs) ->
+      Sig_module(id, {md with md_type=nondep_mty env va ids md.md_type}, rs)
+  | Sig_modtype(id, d) ->
+      begin try
+        Sig_modtype(id, nondep_modtype_decl env ids d)
+      with Ctype.Nondep_cannot_erase _ as exn ->
+        match va with
+          Co -> Sig_modtype(id, {mtd_type=None; mtd_loc=Location.none;
+                                 mtd_attributes=[]})
+        | _  -> raise exn
+      end
+  | Sig_class(id, d, rs) ->
+      Sig_class(id, Ctype.nondep_class_declaration env ids d, rs)
+  | Sig_class_type(id, d, rs) ->
+      Sig_class_type(id, Ctype.nondep_cltype_declaration env ids d, rs)
 
-  and nondep_sig env va = function
-    [] -> []
-  | item :: rem ->
-      let rem' = nondep_sig env va rem in
-      match item with
-        Sig_value(id, d) ->
-          Sig_value(id,
-                    {d with val_type = Ctype.nondep_type env ids d.val_type})
-          :: rem'
-      | Sig_type(id, d, rs) ->
-          Sig_type(id, Ctype.nondep_type_decl env ids (va = Co) d, rs)
-          :: rem'
-      | Sig_typext(id, ext, es) ->
-          Sig_typext(id, Ctype.nondep_extension_constructor env ids ext, es)
-          :: rem'
-      | Sig_module(id, md, rs) ->
-          Sig_module(id, {md with md_type=nondep_mty env va md.md_type}, rs)
-          :: rem'
-      | Sig_modtype(id, d) ->
-          begin try
-            Sig_modtype(id, nondep_modtype_decl env d) :: rem'
-          with Not_found ->
-            match va with
-              Co -> Sig_modtype(id, {mtd_type=None; mtd_loc=Location.none;
-                                     mtd_attributes=[]}) :: rem'
-            | _  -> raise Not_found
-          end
-      | Sig_class(id, d, rs) ->
-          Sig_class(id, Ctype.nondep_class_declaration env ids d, rs)
-          :: rem'
-      | Sig_class_type(id, d, rs) ->
-          Sig_class_type(id, Ctype.nondep_cltype_declaration env ids d, rs)
-          :: rem'
+and nondep_sig env va ids sg =
+  List.map (nondep_sig_item env va ids) sg
 
-  and nondep_modtype_decl env mtd =
-    {mtd with mtd_type = Misc.may_map (nondep_mty env Strict) mtd.mtd_type}
+and nondep_modtype_decl env ids mtd =
+  {mtd with mtd_type = Misc.may_map (nondep_mty env Strict ids) mtd.mtd_type}
 
-  in
-    nondep_mty env Co mty
+let nondep_supertype env ids = nondep_mty env Co ids
+let nondep_sig_item env ids = nondep_sig_item env Co ids
 
 let enrich_typedecl env p id decl =
   match decl.type_manifest with

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -150,16 +150,16 @@ let scrape_for_type_of env mty =
 
 type variance = Co | Contra | Strict
 
-let nondep_supertype env mid mty =
+let nondep_supertype env ids mty =
 
   let rec nondep_mty env va mty =
     match mty with
       Mty_ident p ->
-        if Path.isfree mid p then
+        if Path.exists_free ids p then
           nondep_mty env va (Env.find_modtype_expansion p env)
         else mty
     | Mty_alias(_, p) ->
-        if Path.isfree mid p then
+        if Path.exists_free ids p then
           nondep_mty env va (Env.find_module p env).md_type
         else mty
     | Mty_signature sg ->
@@ -179,13 +179,13 @@ let nondep_supertype env mid mty =
       match item with
         Sig_value(id, d) ->
           Sig_value(id,
-                    {d with val_type = Ctype.nondep_type env mid d.val_type})
+                    {d with val_type = Ctype.nondep_type env ids d.val_type})
           :: rem'
       | Sig_type(id, d, rs) ->
-          Sig_type(id, Ctype.nondep_type_decl env mid (va = Co) d, rs)
+          Sig_type(id, Ctype.nondep_type_decl env ids (va = Co) d, rs)
           :: rem'
       | Sig_typext(id, ext, es) ->
-          Sig_typext(id, Ctype.nondep_extension_constructor env mid ext, es)
+          Sig_typext(id, Ctype.nondep_extension_constructor env ids ext, es)
           :: rem'
       | Sig_module(id, md, rs) ->
           Sig_module(id, {md with md_type=nondep_mty env va md.md_type}, rs)
@@ -200,10 +200,10 @@ let nondep_supertype env mid mty =
             | _  -> raise Not_found
           end
       | Sig_class(id, d, rs) ->
-          Sig_class(id, Ctype.nondep_class_declaration env mid d, rs)
+          Sig_class(id, Ctype.nondep_class_declaration env ids d, rs)
           :: rem'
       | Sig_class_type(id, d, rs) ->
-          Sig_class_type(id, Ctype.nondep_cltype_declaration env mid d, rs)
+          Sig_class_type(id, Ctype.nondep_cltype_declaration env ids d, rs)
           :: rem'
 
   and nondep_modtype_decl env mtd =

--- a/typing/mtype.mli
+++ b/typing/mtype.mli
@@ -35,7 +35,12 @@ val strengthen_decl:
 val nondep_supertype: Env.t -> Ident.t list -> module_type -> module_type
         (* Return the smallest supertype of the given type
            in which none of the given idents appears.
-           Raise [Not_found] if no such type exists. *)
+           @raise [Ctype.Nondep_cannot_erase] if no such type exists. *)
+val nondep_sig_item: Env.t -> Ident.t list -> signature_item -> signature_item
+        (* Returns the signature item with its type updated
+           to be the smallest supertype of its initial type
+           in which none of the given idents appears.
+           @raise [Ctype.Nondep_cannot_erase] if no such type exists. *)
 val no_code_needed: Env.t -> module_type -> bool
 val no_code_needed_sig: Env.t -> signature -> bool
         (* Determine whether a module needs no implementation code,

--- a/typing/mtype.mli
+++ b/typing/mtype.mli
@@ -32,9 +32,9 @@ val strengthen: aliasable:bool -> Env.t -> module_type -> Path.t -> module_type
            given path. *)
 val strengthen_decl:
   aliasable:bool -> Env.t -> module_declaration -> Path.t -> module_declaration
-val nondep_supertype: Env.t -> Ident.t -> module_type -> module_type
+val nondep_supertype: Env.t -> Ident.t list -> module_type -> module_type
         (* Return the smallest supertype of the given type
-           in which the given ident does not appear.
+           in which none of the given idents appears.
            Raise [Not_found] if no such type exists. *)
 val no_code_needed: Env.t -> module_type -> bool
 val no_code_needed_sig: Env.t -> signature -> bool

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -40,10 +40,10 @@ let rec compare p1 p2 =
   | ((Pident _ | Pdot _), (Pdot _ | Papply _)) -> -1
   | ((Pdot _ | Papply _), (Pident _ | Pdot _)) -> 1
 
-let rec isfree id = function
-    Pident id' -> Ident.same id id'
-  | Pdot(p, _s, _pos) -> isfree id p
-  | Papply(p1, p2) -> isfree id p1 || isfree id p2
+let rec exists_free ids = function
+    Pident id -> List.exists (Ident.same id) ids
+  | Pdot(p, _s, _pos) -> exists_free ids p
+  | Papply(p1, p2) -> exists_free ids p1 || exists_free ids p2
 
 let rec binding_time = function
     Pident id -> Ident.binding_time id

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -40,10 +40,18 @@ let rec compare p1 p2 =
   | ((Pident _ | Pdot _), (Pdot _ | Papply _)) -> -1
   | ((Pdot _ | Papply _), (Pident _ | Pdot _)) -> 1
 
-let rec exists_free ids = function
-    Pident id -> List.exists (Ident.same id) ids
-  | Pdot(p, _s, _pos) -> exists_free ids p
-  | Papply(p1, p2) -> exists_free ids p1 || exists_free ids p2
+let rec find_free_opt ids = function
+    Pident id -> List.find_opt (Ident.same id) ids
+  | Pdot(p, _s, _pos) -> find_free_opt ids p
+  | Papply(p1, p2) ->
+      match find_free_opt ids p1 with
+      | None -> find_free_opt ids p2
+      | Some _ as res -> res
+
+let exists_free ids p =
+  match find_free_opt ids p with
+  | None -> false
+  | _ -> true
 
 let rec binding_time = function
     Pident id -> Ident.binding_time id

--- a/typing/path.mli
+++ b/typing/path.mli
@@ -22,7 +22,7 @@ type t =
 
 val same: t -> t -> bool
 val compare: t -> t -> int
-val isfree: Ident.t -> t -> bool
+val exists_free: Ident.t list -> t -> bool
 val binding_time: t -> int
 val flatten : t -> [ `Contains_apply | `Ok of Ident.t * string list ]
 

--- a/typing/path.mli
+++ b/typing/path.mli
@@ -22,6 +22,7 @@ type t =
 
 val same: t -> t -> bool
 val compare: t -> t -> int
+val find_free_opt: Ident.t list -> t -> Ident.t option
 val exists_free: Ident.t list -> t -> bool
 val binding_time: t -> int
 val flatten : t -> [ `Contains_apply | `Ok of Ident.t * string list ]

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1929,8 +1929,7 @@ let approx_type_decl sdecl_list =
 let check_recmod_typedecl env loc recmod_ids path decl =
   (* recmod_ids is the list of recursively-defined module idents.
      (path, decl) is the type declaration to be checked. *)
-  let to_check path =
-    List.exists (fun id -> Path.isfree id path) recmod_ids in
+  let to_check path = Path.exists_free recmod_ids path in
   check_well_founded_decl env loc path decl to_check;
   check_recursion env loc path decl to_check
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1444,7 +1444,7 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
                 check_well_formed_module env smod.pmod_loc
                   "the signature of this functor application" mty_res;
                 let nondep_mty =
-                  try Mtype.nondep_supertype env param mty_res
+                  try Mtype.nondep_supertype env [param] mty_res
                   with Not_found ->
                     raise(Error(smod.pmod_loc, env,
                                 Cannot_eliminate_dependency mty_functor))


### PR DESCRIPTION
This GPR implements the change described in https://blog.janestreet.com/plans-for-ocaml-408/#shadowing-of-items-from-include.

Most of the actual work happens in `typemod.ml` and revolves around `check_name` and `simplify_signature`.

Previously:
- `check_name` was checking that all names in a signature were unique (excluding value names for which the check wasn't called)
- `simplify_signature` was dropping shadowed value names from a signature.

Now:
- `check_name` keeps track of what can (or not) be shadowed, and errors when one tries to shadow something that's not allowed to be
- `simplify_signature` drops shadowed items from a signature, and calls `nondep_*` to remove reference to the shadowed items from the ones that remain. That last step is not guaranteed to succeed, and a error message is printed when it fails.

All the other changes qualify as plumbing (to get vaguely decent error messages, to not call `nondep_*` in a loop, etc.).

I'm not all that fond of the error message that is emitted when something cannot be shadowed, (see `testsuite/tests/shadow_include/cannot_shadow_error.{ml,compilers.reference}` for an example), so if someone has a better formulation, I'd be happy to integrate it.

The last commit ("check for repeated name after having typed the item") is not strictly necessary for this PR, but it makes the implementation a bit more regular.

A note on performances: for the moment we always call `nondep_`, even though there might be no ident to hide (more clearly: we should call nondep only when an ident which can appear in a type gets shadowed). I plan to add one last commit to that, but I think one can already start to look at this PR even without that.
