### PR TITLE
warning 40: fix missing wrap_printing_env

### DIFF
--- a/Changes
+++ b/Changes
@@ -198,6 +198,10 @@ Working version
 - GPR#1890: remove last use of Ctype.unroll_abbrev
   (Thomas Refis, report by Leo White, review by Jacques Garrigue)
 
+- GPR#1893: dev-branch only, warning 40(name not in scope) triggered spurious
+  warnings 49(missing cmi) with -no-alias-deps.
+  (Florian Angeletti, report by Valentin Gatien-Baron,
+  review by Gabriel Scherer)
 
 OCaml 4.07
 ----------

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -77,9 +77,11 @@ module Namespace = struct
     let to_lookup f lid =
       fst @@ f ?loc:None ?mark:(Some false) (Lident lid) !printing_env in
     function
-    | Type -> fun id -> Env.lookup_type ?loc:None (Lident id) !printing_env
+    | Type -> fun id ->
+      Env.lookup_type ?loc:None ~mark:false (Lident id) !printing_env
     | Module -> fun id ->
-      Env.lookup_module ~load:false ?loc:None (Lident id) !printing_env
+      Env.lookup_module ~load:true ~mark:false ?loc:None
+        (Lident id) !printing_env
     | Module_type -> to_lookup Env.lookup_modtype
     | Class -> to_lookup Env.lookup_class
     | Class_type -> to_lookup Env.lookup_cltype

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -776,7 +776,9 @@ end) = struct
           let lbl = lookup_from_type env tpath lid in
           if in_env lbl then
           begin
-          let s = Printtyp.string_of_path tpath in
+          let s =
+            Printtyp.wrap_printing_env ~error:true env
+              (fun () -> Printtyp.string_of_path tpath) in
           warn lid.loc
             (Warnings.Name_out_of_scope (s, [Longident.last lid.txt], false));
           end;


### PR DESCRIPTION
This PR fixes a missing call to `wrap_printing_env` in #1120 that was causing spurious warnings 49 (missing cmi)  when a warning 40 (name not in scope) was triggered  and the compiler was called with `-no-alias-deps`.

More precisely, the bug path in 
```OCaml
module Foo = struct
  type info = { doc : unit }
  type t = { info : info }
end
let add_extra_info arg = arg.Foo.info.doc
```
> Warning 40: doc was selected from type Foo.info.
> ...
> Warning 49: no cmi file was found in path for module Foo

was:

0. When printing `Foo.info`, `Printtyp.string_of_path` checks that the module `Foo` is the one in scope in the printing environment. 
1. But due to the missing call to `wrap_print_env`,   `Foo` is not defined in the printing env
2.  Thus, `Env.lookup_module` looks for `foo.cmi`
3. When `-no-alias-deps` is defined and `Env.lookup_module` is called with `~load:false`
      `Env.check_pers_struct` is called
4. `Env.check_pers_struct` raises warning 49 if no cmi exists for module Foo.

The change in `typecore.ml` fixes the first and second point: `Printtyp.wrap_module_env ~error:true` both sets the printing env and disables cmi lookup. (The second new test example illustrate why it is useful to update the printing env rather than simply disable cmi lookup with `Env.without_cmi`). Similarly, the change in `printtyp.ml` adjust the lookup options to avoid the third and fourth point altogether.

This fix addresses the first and third point reported by @sliquister . However, the warning message is still computed even if the warning is not active since I think that avoiding computation for disabled  warnings sounds PR worthy by itself.