### PR TITLE
Location: generalize [highlight_dumb] to handle several locations

### DIFF
--- a/Changes
+++ b/Changes
@@ -155,6 +155,9 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+- GPR#1894: generalize highlight_dumb in location.ml to handle highlighting
+  several locations (Armaël Guéneau, review by Gabriel Scherer)
+
 - GPR#1745: do not generalize the type of every sub-pattern, only of variables.
   (Thomas Refis, review by Leo White)
 

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -77,7 +77,7 @@ val default_warning_printer : t -> formatter -> Warnings.t -> unit
 
 val highlight_locations: formatter -> t list -> bool
 
-val show_code_at_location: formatter -> Lexing.lexbuf -> t -> unit
+val show_code_at_location: formatter -> Lexing.lexbuf -> t list -> unit
 
 type 'a loc = {
   txt : 'a;

--- a/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
+++ b/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
@@ -1,0 +1,30 @@
+Characters 34-41:
+  let x = (1 + 2) +. 3. in ();;
+          ^^^^^^^
+Error: This expression has type int but an expression was expected of type
+         float
+Characters 9-18:
+  let x = (1 + 2 in ();;
+          ^      ^^
+Syntax error: ')' expected, the highlighted '(' might be unmatched
+Characters 9-17:
+  let x = (1 + 2;;
+          ^     ^^
+Syntax error: ')' expected, the highlighted '(' might be unmatched
+Characters 22-23:
+  let y = 1 +. 2. in
+          ^
+Error: This expression has type int but an expression was expected of type
+         float
+Characters 9-20:
+  ........(.
+  ...
+  ..in
+Syntax error: ')' expected, the highlighted '(' might be unmatched
+Characters 9-18:
+  ........(1
+    +
+  2)...
+Error: This expression has type int but an expression was expected of type
+         float
+

--- a/testsuite/tests/tool-toplevel/error_highlighting.ml
+++ b/testsuite/tests/tool-toplevel/error_highlighting.ml
@@ -1,0 +1,23 @@
+(* TEST
+   * toplevel
+*)
+
+let x = (1 + 2) +. 3. in ();;
+
+let x = (1 + 2 in ();;
+
+let x = (1 + 2;;
+
+let x = 1 in
+let y = 1 +. 2. in
+();;
+
+let x = (1
+  +
+2 in
+();;
+
+let x = (1
+  +
+2) +.
+3. in ();;

--- a/testsuite/tests/tool-toplevel/ocamltests
+++ b/testsuite/tests/tool-toplevel/ocamltests
@@ -4,3 +4,4 @@ pr7060.ml
 pr7751.ml
 strings.ml
 tracing.ml
+error_highlighting.ml

--- a/testsuite/tests/typing-private/private.compilers.principal.reference
+++ b/testsuite/tests/typing-private/private.compilers.principal.reference
@@ -112,9 +112,6 @@ type t = private < x : int; .. >
 type t = private < x : int; .. >
 type t = private < x : int >
 type t = private < x : int >
-Characters -1--1:
-  type 'a t = private < x : int; .. > as 'a;;
-  
 Error: Type declarations do not match:
          type 'a t = private 'a constraint 'a = < x : int; .. >
        is not included in

--- a/testsuite/tests/typing-private/private.compilers.reference
+++ b/testsuite/tests/typing-private/private.compilers.reference
@@ -112,9 +112,6 @@ type t = private < x : int; .. >
 type t = private < x : int; .. >
 type t = private < x : int >
 type t = private < x : int >
-Characters -1--1:
-  type 'a t = private < x : int; .. > as 'a;;
-  
 Error: Type declarations do not match:
          type 'a t = private < x : int; .. > constraint 'a = 'a t
        is not included in

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -141,7 +141,7 @@ module Compiler_messages = struct
       begin match !Location.input_lexbuf with
       | None -> ()
       | Some lexbuf ->
-         Location.show_code_at_location ppf lexbuf loc
+         Location.show_code_at_location ppf lexbuf [loc]
       end;
     ()
 


### PR DESCRIPTION
The purpose of this PR is to generalize `highlight_dumb` to make it consistent with `highlight_terminfo`, that is, able to highlight several location at the same time.

`highlight_terminfo` (which highlights the error by underlining it using ANSI terminal features) supports highlighting several locations simultaneously. Note that this feature is at the moment only used in one error -- "unmatched parenthesis", which highlights both the erroneous token and the unmatched parenthesis. 

Since this feature might be useful more generally in the future (for the future parsing error messages maybe?), it seems useful to clean-up the current situation. 

### Before this patch

`highlight_dumb` only supports highlighting a single location, and is passed `List.hd` of the locations (in `highlight_locations`):

with an ANSI terminal (where `__` denotes underlined text):
```
# let x = __(__1 + 2 __in__ ();;
Syntax error: ')' expected, the highlighted '(' might be unmatched
```

with `TERM=dumb`, only the open parenthesis gets highlighted:
```
# let x = (1 + 2 in ();;                                                                                  
Characters 8-9:
  let x = (1 + 2 in ();;
          ^
Syntax error: ')' expected, the highlighted '(' might be unmatched
```

### After this patch

`highlight_dumb` highlights all locations:

```
# let x = (1 + 2 in ();;
Characters 8-17:
  let x = (1 + 2 in ();;
          ^      ^^
  Syntax error: ')' expected, the highlighted '(' might be unmatched
```

If the locations occur or span across several lines, the "multi-line" style for displaying errors is used:

```
# let x = (1
  +
    2 in ();;
Characters 8-19:
  ........(.
  .
  ....in.....
  Syntax error: ')' expected, the highlighted '(' might be unmatched
```
