### PR TITLE
in native code, make Printexc.get_callstack work in new threads

### DIFF
--- a/Changes
+++ b/Changes
@@ -109,6 +109,10 @@ Working version
 - GPR#1867: Remove the C plugins mechanism.
   (Xavier Leroy, review by David Allsopp, Damien Doligez, Sébastien Hinderer)
 
+- GPR#1895: Printexc.get_callstack would return only one frame in native
+  code in threads other then the initial one
+  (Valentin Gatien-Baron, review by Xavier Leroy)
+
 ### Tools
 
 - GPR#1711: the new 'open' flag in OCAMLRUNPARAM takes a comma-separated list of

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -550,6 +550,8 @@ static ST_THREAD_FUNCTION caml_thread_start(void * arg)
 #ifdef NATIVE_CODE
   struct longjmp_buffer termination_buf;
   char tos;
+  /* Record top of stack (approximative) */
+  th->top_of_stack = &tos;
 #endif
 
   /* Associate the thread descriptor with the thread */
@@ -557,8 +559,6 @@ static ST_THREAD_FUNCTION caml_thread_start(void * arg)
   /* Acquire the global mutex */
   caml_leave_blocking_section();
 #ifdef NATIVE_CODE
-  /* Record top of stack (approximative) */
-  th->top_of_stack = &tos;
   /* Setup termination handler (for caml_thread_exit) */
   if (sigsetjmp(termination_buf.buf, 0) == 0) {
     th->exit_buf = &termination_buf;

--- a/testsuite/tests/backtrace/callstack.ml
+++ b/testsuite/tests/backtrace/callstack.ml
@@ -1,0 +1,18 @@
+(* TEST
+   flags = "-g"
+   include systhreads
+   compare_programs = "false"
+   * no-flambda
+   reference = "${test_source_directory}/callstack.reference"
+   ** native
+   ** bytecode
+*)
+let[@inline never] f0 () =
+  Printexc.print_raw_backtrace stdout (Printexc.get_callstack 100); ()
+let[@inline never] f1 () = f0 (); ()
+let[@inline never] f2 () = f1 (); ()
+let[@inline never] f3 () = f2 (); ()
+let () = Printf.printf "main thread:\n"
+let () = f3 ()
+let () = Printf.printf "new thread:\n"
+let () = Thread.join (Thread.create f3 ())

--- a/testsuite/tests/backtrace/callstack.reference
+++ b/testsuite/tests/backtrace/callstack.reference
@@ -1,0 +1,12 @@
+main thread:
+Raised by primitive operation at file "callstack.ml", line 11, characters 38-66
+Called from file "callstack.ml", line 12, characters 27-32
+Called from file "callstack.ml", line 13, characters 27-32
+Called from file "callstack.ml", line 14, characters 27-32
+Called from file "callstack.ml", line 16, characters 9-14
+new thread:
+Raised by primitive operation at file "callstack.ml", line 11, characters 38-66
+Called from file "callstack.ml", line 12, characters 27-32
+Called from file "callstack.ml", line 13, characters 27-32
+Called from file "callstack.ml", line 14, characters 27-32
+Called from file "thread.ml", line 39, characters 8-14

--- a/testsuite/tests/backtrace/ocamltests
+++ b/testsuite/tests/backtrace/ocamltests
@@ -4,6 +4,7 @@ backtrace3.ml
 backtrace_deprecated.ml
 backtrace_slots.ml
 backtraces_and_finalizers.ml
+callstack.ml
 inline_test.ml
 inline_traversal_test.ml
 pr6920_why_at.ml


### PR DESCRIPTION
One would expect this code to behave the same regardless of whether THREAD is set:

```
(* ocamlopt -I +threads unix.cmxa threads.cmxa -g a.ml *)
let f0 () = Printexc.print_raw_backtrace stdout (Printexc.get_callstack 100); ()
let f1 () = f0 (); ()
let f2 () = f1 (); ()
let f3 () = f2 (); ()
let () =
  match Sys.getenv "THREAD" with
  | exception Not_found -> f3 ()
  | (_ : string) -> Thread.join (Thread.create f3 ())
```

But the observed behavior is:

```
   + OCAMLRUNPARAM=b=1 ./a.out
   Raised by primitive operation at file "a.ml", line 1, characters 48-76
   Called from file "a.ml" (inlined), line 2, characters 12-17
   Called from file "a.ml" (inlined), line 3, characters 12-17
   Called from file "a.ml" (inlined), line 4, characters 12-17
   Called from file "a.ml", line 7, characters 27-32
   + OCAMLRUNPARAM=b=1 THREAD= ./a.out
   Raised by primitive operation at file "a.ml", line 1, characters 48-76
```
ie in the new thread, the callstack is one frame.

This is because caml_top_of_stack is NULL in new threads, presumably resulting Printexc.get_callstack stopping after the first (unconditional) frame. caml_top_of_stack is NULL because the th->top_of_stack for new thread starts as NULL and is initialized to a proper value too late (after caml_leave_blocking_section, which does caml_top_of_stack = th->top_of_stack). So the fix is to initialize to a proper value before the call to caml_leave_blocking_section.

With this pull request, the observed behavior is:

```
+ OCAMLRUNPARAM=b=1 ./a.out
Raised by primitive operation at file "a.ml", line 1, characters 48-76
Called from file "a.ml" (inlined), line 2, characters 12-17
Called from file "a.ml" (inlined), line 3, characters 12-17
Called from file "a.ml" (inlined), line 4, characters 12-17
Called from file "a.ml", line 7, characters 27-32
+ OCAMLRUNPARAM=b=1 THREAD= ./a.out
Raised by primitive operation at file "a.ml", line 1, characters 48-76
Called from file "a.ml" (inlined), line 2, characters 12-17
Called from file "a.ml" (inlined), line 3, characters 12-17
Called from file "a.ml", line 4, characters 12-17
Called from file "thread.ml", line 39, characters 8-14
```


