### PR TITLE
Fix Array.of_seq

### DIFF
--- a/Changes
+++ b/Changes
@@ -42,6 +42,10 @@ Working version
 - MPR#7235: Format, flush err_formatter at exit.
   (Pierre Weis, request by Jun Furuse)
 
+- MPR#7820, GPR#1897: Fix Array.of_seq. This function used to apply a circular
+  permutation of one cell to the right on the sequence.
+  (Thierry Martinez, review by Nicolás Ojeda Bär)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -334,7 +334,7 @@ let of_rev_list = function
           [] -> a
         | hd::tl -> unsafe_set a i hd; fill (i-1) tl
       in
-      fill (len-1) tl
+      fill (len-2) tl
 
 let of_seq i =
   let l = Seq.fold_left (fun acc x -> x::acc) [] i in

--- a/testsuite/tests/lib-seq/test.ml
+++ b/testsuite/tests/lib-seq/test.ml
@@ -13,4 +13,13 @@ let () =
   ()
 ;;
 
+(* MPR 7820 *)
+let () =
+  assert
+    ([| 1;2;3 |] =
+      (Array.to_seq [| 1;2;3 |]
+      |> Array.of_seq));
+  ()
+;;
+
 let () = print_endline "OK";;


### PR DESCRIPTION
Reported at https://caml.inria.fr/mantis/view.php?id=7820

Array.of_seq applies a circular permutation of one cell to the right
on the sequence.

With OCaml 4.07.0 and trunk, we have

```
# Array.of_seq (Array.to_seq [| 1; 2; 3 |]);;
- : int array = [|3; 1; 2|]
```

In stdlib/array.ml, line 337 (last line of of_rev_list), we have
```
fill (len-1) tl
```
whereas it should be
```
fill (len-2) tl
```
since `hd`, which should be assigned to the cell `len - 1`, is skipped.