### PR TITLE
Fix MPR#7818 by prohibiting inner aliases inside functor argument types

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+### Bug fixes:
+
+* MPR#7818: Unaliasable module can be aliased
+  (Jacques Garrigue, report by mandrykin)
+
 OCaml 4.07.0 (10 July 2018)
 ---------------------------
 

--- a/testsuite/tests/typing-modules/ocamltests
+++ b/testsuite/tests/typing-modules/ocamltests
@@ -7,6 +7,7 @@ pr6394.ml
 pr7207.ml
 pr7348.ml
 pr7787.ml
+pr7818.ml
 printing.ml
 recursive.ml
 Test.ml

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -1,0 +1,131 @@
+(* TEST
+   * expect
+*)
+
+(* cannot_alias.ml *)
+module Termsig = struct
+  module Term0 = struct
+    module type S = sig
+      module Id : sig end
+    end
+  end
+  module Term = struct
+    module type S = sig
+      module Term0 : Term0.S
+      module T = Term0
+    end
+  end
+end;;
+[%%expect{|
+module Termsig :
+  sig
+    module Term0 : sig module type S = sig module Id : sig  end end end
+    module Term :
+      sig module type S = sig module Term0 : Term0.S module T = Term0 end end
+  end
+|}]
+
+module Make1 (T' : Termsig.Term.S) = struct
+  module T = struct
+    include T'.T
+    let u = 1
+  end
+end;;
+[%%expect{|
+Line _, characters 19-33:
+  module Make1 (T' : Termsig.Term.S) = struct
+                     ^^^^^^^^^^^^^^
+Error: This module type contains an alias for Term0.
+       Internal aliases are not allowed in functor argument types.
+|}]
+
+module Make2 (T' : Termsig.Term.S) = struct
+  module T = struct
+    include T'.T
+    module Id2 = Id
+    let u = 1
+  end
+end;;
+[%%expect{|
+Line _, characters 19-33:
+  module Make2 (T' : Termsig.Term.S) = struct
+                     ^^^^^^^^^^^^^^
+Error: This module type contains an alias for Term0.
+       Internal aliases are not allowed in functor argument types.
+|}]
+
+module Make3 (T' : Termsig.Term.S) = struct
+  module T = struct
+    include T'.T
+    module Id2 = Id
+    let u = 1
+    let u = 1
+  end
+end;;
+[%%expect{|
+Line _, characters 19-33:
+  module Make3 (T' : Termsig.Term.S) = struct
+                     ^^^^^^^^^^^^^^
+Error: This module type contains an alias for Term0.
+       Internal aliases are not allowed in functor argument types.
+|}]
+
+(* cannot_alias2.ml *)
+module type S = sig
+  module Term0 : sig module Id : sig end end
+  module T = Term0
+end;;
+
+module Make1 (T' : S)  = struct
+  module Id = T'.T.Id
+  module Id2 = Id
+end;;
+[%%expect{|
+module type S =
+  sig module Term0 : sig module Id : sig  end end module T = Term0 end
+Line _, characters 19-20:
+  module Make1 (T' : S)  = struct
+                     ^
+Error: This module type contains an alias for Term0.
+       Internal aliases are not allowed in functor argument types.
+|}]
+
+module Make2 (T' : S) : sig module Id : sig end module Id2 = Id end
+                        with module Id := T'.Term0.Id  = struct
+  module Id = T'.T.Id
+  module Id2 = Id
+end;;
+[%%expect{|
+Line _, characters 19-20:
+  module Make2 (T' : S) : sig module Id : sig end module Id2 = Id end
+                     ^
+Error: This module type contains an alias for Term0.
+       Internal aliases are not allowed in functor argument types.
+|}]
+
+module Make3 (T' : S) = struct
+  module T = struct
+    module Id = T'.T.Id
+    module Id2 = Id
+    let u = 1
+    let u = 1
+  end
+end;;
+[%%expect{|
+Line _, characters 19-20:
+  module Make3 (T' : S) = struct
+                     ^
+Error: This module type contains an alias for Term0.
+       Internal aliases are not allowed in functor argument types.
+|}]
+
+(* unsoundness if Make1 were accepted *)
+module M = Make1 (struct module Term0 =
+  struct module Id = struct let x = "a" end end module T = Term0 end);;
+M.Id.x;;
+[%%expect{|
+Line _, characters 11-16:
+  module M = Make1 (struct module Term0 =
+             ^^^^^
+Error: Unbound module Make1
+|}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1949,20 +1949,20 @@ let enter_module ?arg s mty env =
 
 (* Insertion of all components of a signature *)
 
-let add_item comp env =
+let add_item ?arg comp env =
   match comp with
     Sig_value(id, decl)     -> add_value id decl env
   | Sig_type(id, decl, _)   -> add_type ~check:false id decl env
   | Sig_typext(id, ext, _)  -> add_extension ~check:false id ext env
-  | Sig_module(id, md, _)   -> add_module_declaration ~check:false id md env
+  | Sig_module(id, md, _) -> add_module_declaration ?arg ~check:false id md env
   | Sig_modtype(id, decl)   -> add_modtype id decl env
   | Sig_class(id, decl, _)  -> add_class id decl env
   | Sig_class_type(id, decl, _) -> add_cltype id decl env
 
-let rec add_signature sg env =
+let rec add_signature ?arg sg env =
   match sg with
     [] -> env
-  | comp :: rem -> add_signature rem (add_item comp env)
+  | comp :: rem -> add_signature ?arg rem (add_item ?arg comp env)
 
 (* Open a signature path *)
 

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -151,8 +151,8 @@ val add_local_type: Path.t -> type_declaration -> t -> t
 
 (* Insertion of all fields of a signature. *)
 
-val add_item: signature_item -> t -> t
-val add_signature: signature -> t -> t
+val add_item: ?arg:bool -> signature_item -> t -> t
+val add_signature: ?arg:bool -> signature -> t -> t
 
 (* Insertion of all fields of a signature, relative to the given path.
    Used to implement open. Returns None if the path refers to a functor,

--- a/typing/mtype.mli
+++ b/typing/mtype.mli
@@ -24,6 +24,9 @@ val scrape: Env.t -> module_type -> module_type
 val scrape_for_type_of:
   remove_aliases:bool -> Env.t -> module_type -> module_type
         (* Expand module aliases *)
+val check_aliases: Env.t -> module_type -> Path.t option
+        (* Look for internal aliases in a module type.
+           This is not allowed for functor arguments. *)
 val freshen: module_type -> module_type
         (* Return an alpha-equivalent copy of the given module type
            where bound identifiers are fresh. *)

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -84,6 +84,7 @@ type error =
   | Recursive_module_require_explicit_type
   | Apply_generative
   | Cannot_scrape_alias of Path.t
+  | Invalid_alias of Path.t
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error


### PR DESCRIPTION
[MPR#7818](https://caml.inria.fr/mantis/view.php?id=7818) uncovered some situations where a non-aliasable module (coming from a functor argument) can be aliased in the return type of a functor.

This is a soundness bug, as it allows to access components that have been discarded by subtyping.

This PR fixes this by checking that functor argument types do not contain inner module aliases, which are the key to breaking `Env.is_functor_arg` logic.