### PR TITLE
MPR#7814: fix non-prefixed symbol names in debug and instrumented runtimes

### DIFF
--- a/Changes
+++ b/Changes
@@ -113,6 +113,10 @@ Working version
   code in threads other then the initial one
   (Valentin Gatien-Baron, review by Xavier Leroy)
 
+- GPR#1900, MPR#7814: avoid exporting non-prefixed identifiers in the debug
+  and instrumented runtimes.
+  (Damien Doligez, report by Gabriel Scherer)
+
 ### Tools
 
 - GPR#1711: the new 'open' flag in OCAMLRUNPARAM takes a comma-separated list of

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -267,7 +267,7 @@ caml/opnames.h : caml/instruct.h
 	cat $^ | tr -d '\r' | \
 	sed -e '/\/\*/d' \
 	    -e '/^#/d' \
-	    -e 's/enum /char * names_of_/' \
+	    -e 's/enum /static char * names_of_/' \
 	    -e 's/{$$/[] = {/' \
 	    -e 's/\([[:upper:]][[:upper:]_0-9]*\)/"\1"/g' > $@
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -337,31 +337,31 @@ extern int caml_snprintf(char * buf, size_t size, const char * format, ...);
 #include <stdio.h>
 
 extern intnat caml_stat_minor_collections;
-extern intnat CAML_INSTR_STARTTIME, CAML_INSTR_STOPTIME;
+extern intnat caml_instr_starttime, caml_instr_stoptime;
 
-struct CAML_INSTR_BLOCK {
+struct caml_instr_block {
   struct timespec ts[10];
   char *tag[10];
   int index;
-  struct CAML_INSTR_BLOCK *next;
+  struct caml_instr_block *next;
 };
 
-extern struct CAML_INSTR_BLOCK *CAML_INSTR_LOG;
+extern struct caml_instr_block *caml_instr_log;
 
 /* Declare a timer/counter name. [t] must be a new variable name. */
 #define CAML_INSTR_DECLARE(t)                                       \
-  struct CAML_INSTR_BLOCK *t = NULL
+  struct caml_instr_block *t = NULL
 
 /* Allocate the data block for a given name.
    [t] must have been declared with [CAML_INSTR_DECLARE]. */
 #define CAML_INSTR_ALLOC(t) do{                                     \
-    if (caml_stat_minor_collections >= CAML_INSTR_STARTTIME         \
-        && caml_stat_minor_collections < CAML_INSTR_STOPTIME){      \
-      t = caml_stat_alloc_noexc (sizeof (struct CAML_INSTR_BLOCK)); \
+    if (caml_stat_minor_collections >= caml_instr_starttime         \
+        && caml_stat_minor_collections < caml_instr_stoptime){      \
+      t = caml_stat_alloc_noexc (sizeof (struct caml_instr_block)); \
       t->index = 0;                                                 \
       t->tag[0] = "";                                               \
-      t->next = CAML_INSTR_LOG;                                     \
-      CAML_INSTR_LOG = t;                                           \
+      t->next = caml_instr_log;                                     \
+      caml_instr_log = t;                                           \
     }                                                               \
   }while(0)
 
@@ -409,11 +409,11 @@ extern struct CAML_INSTR_BLOCK *CAML_INSTR_LOG;
 /* This function is called at the start of the program to set up
    the data for the above macros.
 */
-extern void CAML_INSTR_INIT (void);
+extern void caml_instr_init (void);
 
 /* This function is automatically called by the runtime to output
    the collected data to the dump file. */
-extern void CAML_INSTR_ATEXIT (void);
+extern void caml_instr_atexit (void);
 
 #else /* CAML_INSTR */
 
@@ -423,8 +423,8 @@ extern void CAML_INSTR_ATEXIT (void);
 #define CAML_INSTR_SETUP(t, name) /**/
 #define CAML_INSTR_TIME(t, msg) /**/
 #define CAML_INSTR_INT(msg, c) /**/
-#define CAML_INSTR_INIT() /**/
-#define CAML_INSTR_ATEXIT() /**/
+#define caml_instr_init() /**/
+#define caml_instr_atexit() /**/
 
 #endif /* CAML_INSTR */
 

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -589,7 +589,7 @@ void caml_init_gc (uintnat minor_size, uintnat major_size,
   uintnat major_heap_size =
     Bsize_wsize (caml_normalize_heap_increment (major_size));
 
-  CAML_INSTR_INIT ();
+  caml_instr_init ();
   if (caml_init_alloc_for_heap () != 0){
     caml_fatal_error ("cannot initialize heap: mmap failed");
   }

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -207,27 +207,27 @@ int caml_runtime_warnings_active(void)
 #include <sys/types.h>
 #include <unistd.h>
 
-struct CAML_INSTR_BLOCK *CAML_INSTR_LOG = NULL;
-intnat CAML_INSTR_STARTTIME, CAML_INSTR_STOPTIME;
+struct caml_instr_block *caml_instr_log = NULL;
+intnat caml_instr_starttime, caml_instr_stoptime;
 
 #define Get_time(p,i) ((p)->ts[(i)].tv_nsec + 1000000000 * (p)->ts[(i)].tv_sec)
 
-void CAML_INSTR_INIT (void)
+void caml_instr_init (void)
 {
   char *s;
 
-  CAML_INSTR_STARTTIME = 0;
+  caml_instr_starttime = 0;
   s = caml_secure_getenv ("OCAML_INSTR_START");
-  if (s != NULL) CAML_INSTR_STARTTIME = atol (s);
-  CAML_INSTR_STOPTIME = LONG_MAX;
+  if (s != NULL) caml_instr_starttime = atol (s);
+  caml_instr_stoptime = LONG_MAX;
   s = caml_secure_getenv ("OCAML_INSTR_STOP");
-  if (s != NULL) CAML_INSTR_STOPTIME = atol (s);
+  if (s != NULL) caml_instr_stoptime = atol (s);
 }
 
-void CAML_INSTR_ATEXIT (void)
+void caml_instr_atexit (void)
 {
   int i;
-  struct CAML_INSTR_BLOCK *p, *prev, *next;
+  struct caml_instr_block *p, *prev, *next;
   FILE *f = NULL;
   char *fname;
 
@@ -254,16 +254,16 @@ void CAML_INSTR_ATEXIT (void)
   if (f != NULL){
     /* reverse the list */
     prev = NULL;
-    p = CAML_INSTR_LOG;
+    p = caml_instr_log;
     while (p != NULL){
       next = p->next;
       p->next = prev;
       prev = p;
       p = next;
     }
-    CAML_INSTR_LOG = prev;
+    caml_instr_log = prev;
     fprintf (f, "==== OCAML INSTRUMENTATION DATA %s\n", OCAML_VERSION_STRING);
-    for (p = CAML_INSTR_LOG; p != NULL; p = p->next){
+    for (p = caml_instr_log; p != NULL; p = p->next){
       for (i = 0; i < p->index; i++){
         fprintf (f, "@@ %19ld %19ld %s\n",
                  (long) Get_time (p, i),

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -150,7 +150,7 @@ CAMLprim value caml_sys_exit(value retcode_v)
 #ifndef NATIVE_CODE
   caml_debugger(PROGRAM_EXIT);
 #endif
-  CAML_INSTR_ATEXIT ();
+  caml_instr_atexit ();
   if (caml_cleanup_on_exit)
     caml_shutdown();
 #ifdef _WIN32


### PR DESCRIPTION
Follow Xavier's advice and make names_of_instructions `static`.
Rename auxiliary functions of the instrumented runtime to lowercase names.
Also rename the `struct` declaration to lowercase for consistency.

See also: https://caml.inria.fr/mantis/view.php?id=7814
