### PR TITLE
Location: refactor and get rid of [default_printer]

### DIFF
--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -290,25 +290,17 @@ let print_loc ppf loc =
   let endchar = loc.loc_end.pos_cnum - loc.loc_start.pos_cnum + startchar in
   if file = "//toplevel//" then begin
     if highlight_locations ppf [loc] then () else
-      Format.fprintf ppf "Characters %i-%i"
+      Format.fprintf ppf "@{<loc>Characters %i-%i@}:@,"
         loc.loc_start.pos_cnum loc.loc_end.pos_cnum
   end else begin
-    Format.fprintf ppf "File \"@{<loc>%a\", line %i"
+    Format.fprintf ppf "@{<loc>File \"%a\", line %i"
       print_filename file line;
     if startchar >= 0 then
       Format.fprintf ppf ", characters %i-%i" startchar endchar;
-    Format.fprintf ppf "@}"
+    Format.fprintf ppf "@}:@,"
   end
-;;
 
-let default_printer ppf loc =
-  setup_colors ();
-  if loc.loc_start.pos_fname = "//toplevel//"
-  && highlight_locations ppf [loc] then ()
-  else Format.fprintf ppf "@{<loc>%a@}:@," print_loc loc
-;;
-
-let printer = ref default_printer
+let printer = ref print_loc
 let print ppf loc = !printer ppf loc
 
 let error_prefix = "Error"

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -66,8 +66,8 @@ val prerr_warning: t -> Warnings.t -> unit
 val echo_eof: unit -> unit
 val reset: unit -> unit
 
-val default_printer : formatter -> t -> unit
 val printer : (formatter -> t -> unit) ref
+(** By default, [!printer] is equal to [print_loc]. *)
 
 val warning_printer : (t -> formatter -> Warnings.t -> unit) ref
 (** Hook for intercepting warnings. *)

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -561,7 +561,7 @@ open Format
 let show_loc msg ppf loc =
   let pos = loc.Location.loc_start in
   if List.mem pos.Lexing.pos_fname [""; "_none_"; "//toplevel//"] then ()
-  else fprintf ppf "@\n@[<2>%a:@ %s@]" Location.print_loc loc msg
+  else fprintf ppf "@\n@[<2>%a@ %s@]" Location.print_loc loc msg
 
 let show_locs ppf (loc1, loc2) =
   show_loc "Expected declaration" ppf loc2;


### PR DESCRIPTION
This PR does minor refactoring in location.ml. `default_printer` was duplicating code from `print_loc` only to call it and add a single `:` after. This PR refactors `print_loc` to match what `default_printer` was doing, and removes `default_printer` (it was not called anywhere).