### PR TITLE
Parsetree, typedtree: add locations to all nodes carrying attributes

### DIFF
--- a/Changes
+++ b/Changes
@@ -288,6 +288,9 @@ Working version
   (Gabriel Radanne, help from Gabriel Scherer and Valentin Gatien-Baron,
    review by Mark Shinwell and Gabriel Radanne)
 
+- GPR#1903: parsetree, add locations to all nodes with attributes
+  (Gabriel Scherer, review by Thomas Refis)
+
 - GPR#1938: always check ast invariants after preprocessing
   (Florian Angeletti, review by Alain Frisch and Gabriel Scherer)
 

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -291,15 +291,15 @@ module Analyser =
             let fields = List.map (fun {pof_desc; _} -> pof_desc) fields in
             let rec f = function
               | [] -> []
-              | Otag ({txt=""},_,_) :: _ ->
+              | Otag ({txt=""},_) :: _ ->
                 (* Fields with no name have been eliminated previously. *)
                 assert false
-              | Otag ({txt=name}, _atts, ct) :: [] ->
+              | Otag ({txt=name}, ct) :: [] ->
                 let pos = Loc.ptyp_end ct in
                 let (_,comment_opt) = just_after_special pos pos_end in
                 [name, comment_opt]
-              | Otag ({txt=name}, _, ct) ::
-                  ((Oinherit ct2 | Otag (_, _, ct2)) as ele2) :: q ->
+              | Otag ({txt=name}, ct) ::
+                  ((Oinherit ct2 | Otag (_, ct2)) as ele2) :: q ->
                 let pos = Loc.ptyp_end ct in
                 let pos2 = Loc.ptyp_start ct2 in
                 let (_,comment_opt) = just_after_special pos pos2 in
@@ -308,7 +308,7 @@ module Analyser =
             in
             let is_named_field field =
               match field with
-              | Otag ({txt=""},_,_) -> false
+              | Otag ({txt=""},_) -> false
               | _ -> true
             in
             (0, f @@ List.filter is_named_field fields)

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -288,6 +288,7 @@ module Analyser =
         | Some core_ty ->
           begin match core_ty.ptyp_desc with
           | Ptyp_object (fields, _) ->
+            let fields = List.map (fun {pof_desc; _} -> pof_desc) fields in
             let rec f = function
               | [] -> []
               | Otag ({txt=""},_,_) :: _ ->

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -19,9 +19,11 @@ open Asttypes
 open Parsetree
 open Docstrings
 
-type lid = Longident.t loc
-type str = string loc
+type 'a with_loc = 'a Location.loc
 type loc = Location.t
+
+type lid = Longident.t with_loc
+type str = string with_loc
 type attrs = attribute list
 
 let default_loc = ref Location.none
@@ -110,18 +112,22 @@ module Typ = struct
             Ptyp_extension (s, arg)
       in
       {t with ptyp_desc = desc}
-    and loop_row_field  =
-      function
+    and loop_row_field field =
+      let prf_desc = match field.prf_desc with
         | Rtag(label,attrs,flag,lst) ->
             Rtag(label,attrs,flag,List.map loop lst)
         | Rinherit t ->
             Rinherit (loop t)
-    and loop_object_field =
-      function
+      in
+      { field with prf_desc; }
+    and loop_object_field field =
+      let pof_desc = match field.pof_desc with
         | Otag(label, attrs, t) ->
             Otag(label, attrs, loop t)
         | Oinherit t ->
             Oinherit (loop t)
+      in
+      { field with pof_desc; }
     in
     loop t
 
@@ -509,19 +515,22 @@ end
 
 (** Type extensions *)
 module Te = struct
-  let mk ?(attrs = []) ?(docs = empty_docs)
+  let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs)
         ?(params = []) ?(priv = Public) path constructors =
     {
      ptyext_path = path;
      ptyext_params = params;
      ptyext_constructors = constructors;
      ptyext_private = priv;
+     ptyext_loc = loc;
      ptyext_attributes = add_docs_attrs docs attrs;
     }
 
-  let mk_exception ?(attrs = []) ?(docs = empty_docs) constructor =
+  let mk_exception ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs)
+      constructor =
     {
      ptyexn_constructor = constructor;
+     ptyexn_loc = loc;
      ptyexn_attributes = add_docs_attrs docs attrs;
     }
 
@@ -568,4 +577,28 @@ module Cstr = struct
      pcstr_self = self;
      pcstr_fields = fields;
     }
+end
+
+(** Row fields *)
+module Rf = struct
+  let mk ?(loc = !default_loc) desc = {
+    prf_desc = desc;
+    prf_loc = loc;
+  }
+  let tag ?(loc = !default_loc) ?(attrs = []) label const tys =
+    mk ~loc (Rtag (label, attrs, const, tys))
+  let inherit_ ?(loc = !default_loc) ty =
+    mk ~loc (Rinherit ty)
+end
+
+(** Object fields *)
+module Of = struct
+  let mk ?(loc = !default_loc) desc = {
+    pof_desc = desc;
+    pof_loc = loc;
+  }
+  let tag ?(loc = !default_loc) ?(attrs = []) label ty =
+    mk ~loc (Otag (label, attrs, ty))
+  let inherit_ ?(loc = !default_loc) ty =
+    mk ~loc (Oinherit ty)
 end

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -114,16 +114,16 @@ module Typ = struct
       {t with ptyp_desc = desc}
     and loop_row_field field =
       let prf_desc = match field.prf_desc with
-        | Rtag(label,attrs,flag,lst) ->
-            Rtag(label,attrs,flag,List.map loop lst)
+        | Rtag(label,flag,lst) ->
+            Rtag(label,flag,List.map loop lst)
         | Rinherit t ->
             Rinherit (loop t)
       in
       { field with prf_desc; }
     and loop_object_field field =
       let pof_desc = match field.pof_desc with
-        | Otag(label, attrs, t) ->
-            Otag(label, attrs, loop t)
+        | Otag(label, t) ->
+            Otag(label, loop t)
         | Oinherit t ->
             Oinherit (loop t)
       in
@@ -581,24 +581,26 @@ end
 
 (** Row fields *)
 module Rf = struct
-  let mk ?(loc = !default_loc) desc = {
+  let mk ?(loc = !default_loc) ?(attrs = []) desc = {
     prf_desc = desc;
     prf_loc = loc;
+    prf_attributes = attrs;
   }
-  let tag ?(loc = !default_loc) ?(attrs = []) label const tys =
-    mk ~loc (Rtag (label, attrs, const, tys))
-  let inherit_ ?(loc = !default_loc) ty =
-    mk ~loc (Rinherit ty)
+  let tag ?loc ?attrs label const tys =
+    mk ?loc ?attrs (Rtag (label, const, tys))
+  let inherit_?loc ty =
+    mk ?loc (Rinherit ty)
 end
 
 (** Object fields *)
 module Of = struct
-  let mk ?(loc = !default_loc) desc = {
+  let mk ?(loc = !default_loc) ?(attrs=[]) desc = {
     pof_desc = desc;
     pof_loc = loc;
+    pof_attributes = attrs;
   }
-  let tag ?(loc = !default_loc) ?(attrs = []) label ty =
-    mk ~loc (Otag (label, attrs, ty))
-  let inherit_ ?(loc = !default_loc) ty =
-    mk ~loc (Oinherit ty)
+  let tag ?loc ?attrs label ty =
+    mk ?loc ?attrs (Otag (label, ty))
+  let inherit_ ?loc ty =
+    mk ?loc (Oinherit ty)
 end

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -454,7 +454,7 @@ module Cstr:
 (** Row fields *)
 module Rf:
   sig
-    val mk: ?loc:loc -> row_field_desc -> row_field
+    val mk: ?loc:loc -> ?attrs:attrs -> row_field_desc -> row_field
     val tag: ?loc:loc -> ?attrs:attrs ->
       label with_loc -> bool -> core_type list -> row_field
     val inherit_: ?loc:loc -> core_type -> row_field
@@ -463,7 +463,8 @@ module Rf:
 (** Object fields *)
 module Of:
   sig
-    val mk: ?loc:loc -> object_field_desc -> object_field
+    val mk: ?loc:loc -> ?attrs:attrs ->
+      object_field_desc -> object_field
     val tag: ?loc:loc -> ?attrs:attrs ->
       label with_loc -> core_type -> object_field
     val inherit_: ?loc:loc -> core_type -> object_field

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -19,9 +19,11 @@ open Asttypes
 open Docstrings
 open Parsetree
 
-type lid = Longident.t loc
-type str = string loc
+type 'a with_loc = 'a Location.loc
 type loc = Location.t
+
+type lid = Longident.t with_loc
+type str = string with_loc
 type attrs = attribute list
 
 (** {1 Default locations} *)
@@ -207,11 +209,11 @@ module Type:
 (** Type extensions *)
 module Te:
   sig
-    val mk: ?attrs:attrs -> ?docs:docs ->
+    val mk: ?loc:loc -> ?attrs:attrs -> ?docs:docs ->
       ?params:(core_type * variance) list -> ?priv:private_flag ->
       lid -> extension_constructor list -> type_extension
 
-    val mk_exception: ?attrs:attrs -> ?docs:docs ->
+    val mk_exception: ?loc:loc -> ?attrs:attrs -> ?docs:docs ->
       extension_constructor -> type_exception
 
     val constructor: ?loc:loc -> ?attrs:attrs -> ?docs:docs -> ?info:info ->
@@ -447,4 +449,22 @@ module Csig:
 module Cstr:
   sig
     val mk: pattern -> class_field list -> class_structure
+  end
+
+(** Row fields *)
+module Rf:
+  sig
+    val mk: ?loc:loc -> row_field_desc -> row_field
+    val tag: ?loc:loc -> ?attrs:attrs ->
+      label with_loc -> bool -> core_type list -> row_field
+    val inherit_: ?loc:loc -> core_type -> row_field
+  end
+
+(** Object fields *)
+module Of:
+  sig
+    val mk: ?loc:loc -> object_field_desc -> object_field
+    val tag: ?loc:loc -> ?attrs:attrs ->
+      label with_loc -> core_type -> object_field
+    val inherit_: ?loc:loc -> core_type -> object_field
   end

--- a/parsing/ast_invariants.ml
+++ b/parsing/ast_invariants.ml
@@ -145,6 +145,30 @@ let iterator =
     | Psig_type (_, []) -> empty_type loc
     | _ -> ()
   in
+  let row_field self field =
+    super.row_field self field;
+    let loc = field.prf_loc in
+    match field.prf_desc with
+    | Rtag _ -> ()
+    | Rinherit _ ->
+      if field.prf_attributes = []
+      then ()
+      else err loc
+          "In variant types, attaching attributes to inherited \
+           subtypes is not allowed."
+  in
+  let object_field self field =
+    super.object_field self field;
+    let loc = field.pof_loc in
+    match field.pof_desc with
+    | Otag _ -> ()
+    | Oinherit _ ->
+      if field.pof_attributes = []
+      then ()
+      else err loc
+          "In object types, attaching attributes to inherited \
+           subtypes is not allowed."
+  in
   { super with
     type_declaration
   ; typ
@@ -158,6 +182,8 @@ let iterator =
   ; with_constraint
   ; structure_item
   ; signature_item
+  ; row_field
+  ; object_field
   }
 
 let structure st = iterator.structure iterator st

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -59,6 +59,8 @@ type iterator = {
   structure: iterator -> structure -> unit;
   structure_item: iterator -> structure_item -> unit;
   typ: iterator -> core_type -> unit;
+  row_field: iterator -> row_field -> unit;
+  object_field: iterator -> object_field -> unit;
   type_declaration: iterator -> type_declaration -> unit;
   type_extension: iterator -> type_extension -> unit;
   type_exception: iterator -> type_exception -> unit;
@@ -83,12 +85,22 @@ let iter_loc sub {loc; txt = _} = sub.location sub loc
 module T = struct
   (* Type expressions for the core language *)
 
-  let row_field sub = function
+  let row_field sub {
+      prf_desc;
+      prf_loc;
+    } =
+    sub.location sub prf_loc;
+    match prf_desc with
     | Rtag (_, attrs, _, tl) ->
         sub.attributes sub attrs; List.iter (sub.typ sub) tl
     | Rinherit t -> sub.typ sub t
 
-  let object_field sub = function
+  let object_field sub {
+      pof_desc;
+      pof_loc;
+    } =
+    sub.location sub pof_loc;
+    match pof_desc with
     | Otag (_, attrs, t) ->
         sub.attributes sub attrs; sub.typ sub t
     | Oinherit t -> sub.typ sub t
@@ -501,6 +513,8 @@ let default_iterator =
     type_declaration = T.iter_type_declaration;
     type_kind = T.iter_type_kind;
     typ = T.iter;
+    row_field = T.row_field;
+    object_field = T.object_field;
     type_extension = T.iter_type_extension;
     type_exception = T.iter_type_exception;
     extension_constructor = T.iter_extension_constructor;

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -162,14 +162,18 @@ module T = struct
       {ptyext_path; ptyext_params;
        ptyext_constructors;
        ptyext_private = _;
+       ptyext_loc;
        ptyext_attributes} =
     iter_loc sub ptyext_path;
     List.iter (sub.extension_constructor sub) ptyext_constructors;
     List.iter (iter_fst (sub.typ sub)) ptyext_params;
+    sub.location sub ptyext_loc;
     sub.attributes sub ptyext_attributes
 
-  let iter_type_exception sub {ptyexn_constructor; ptyexn_attributes} =
+  let iter_type_exception sub
+      {ptyexn_constructor; ptyexn_loc; ptyexn_attributes} =
     sub.extension_constructor sub ptyexn_constructor;
+    sub.location sub ptyexn_loc;
     sub.attributes sub ptyexn_attributes
 
   let iter_extension_constructor_kind sub = function
@@ -271,7 +275,8 @@ module MT = struct
     | Psig_class_type l ->
         List.iter (sub.class_type_declaration sub) l
     | Psig_extension (x, attrs) ->
-        sub.extension sub x; sub.attributes sub attrs
+        sub.attributes sub attrs;
+        sub.extension sub x
     | Psig_attribute x -> sub.attribute sub x
 end
 
@@ -300,7 +305,7 @@ module M = struct
     sub.location sub loc;
     match desc with
     | Pstr_eval (x, attrs) ->
-        sub.expr sub x; sub.attributes sub attrs
+        sub.attributes sub attrs; sub.expr sub x
     | Pstr_value (_r, vbs) -> List.iter (sub.value_binding sub) vbs
     | Pstr_primitive vd -> sub.value_description sub vd
     | Pstr_type (_rf, l) -> List.iter (sub.type_declaration sub) l
@@ -315,7 +320,7 @@ module M = struct
         List.iter (sub.class_type_declaration sub) l
     | Pstr_include x -> sub.include_declaration sub x
     | Pstr_extension (x, attrs) ->
-        sub.extension sub x; sub.attributes sub attrs
+        sub.attributes sub attrs; sub.extension sub x
     | Pstr_attribute x -> sub.attribute sub x
 end
 
@@ -523,8 +528,8 @@ let default_iterator =
                  pval_attributes} ->
         iter_loc this pval_name;
         this.typ this pval_type;
+        this.location this pval_loc;
         this.attributes this pval_attributes;
-        this.location this pval_loc
       );
 
     pat = P.iter;
@@ -534,23 +539,23 @@ let default_iterator =
       (fun this {pmd_name; pmd_type; pmd_attributes; pmd_loc} ->
          iter_loc this pmd_name;
          this.module_type this pmd_type;
+         this.location this pmd_loc;
          this.attributes this pmd_attributes;
-         this.location this pmd_loc
       );
 
     module_type_declaration =
       (fun this {pmtd_name; pmtd_type; pmtd_attributes; pmtd_loc} ->
          iter_loc this pmtd_name;
          iter_opt (this.module_type this) pmtd_type;
+         this.location this pmtd_loc;
          this.attributes this pmtd_attributes;
-         this.location this pmtd_loc
       );
 
     module_binding =
       (fun this {pmb_name; pmb_expr; pmb_attributes; pmb_loc} ->
          iter_loc this pmb_name; this.module_expr this pmb_expr;
+         this.location this pmb_loc;
          this.attributes this pmb_attributes;
-         this.location this pmb_loc
       );
 
 

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -88,21 +88,23 @@ module T = struct
   let row_field sub {
       prf_desc;
       prf_loc;
+      prf_attributes;
     } =
     sub.location sub prf_loc;
+    sub.attributes sub prf_attributes;
     match prf_desc with
-    | Rtag (_, attrs, _, tl) ->
-        sub.attributes sub attrs; List.iter (sub.typ sub) tl
+    | Rtag (_, _, tl) -> List.iter (sub.typ sub) tl
     | Rinherit t -> sub.typ sub t
 
   let object_field sub {
       pof_desc;
       pof_loc;
+      pof_attributes;
     } =
     sub.location sub pof_loc;
+    sub.attributes sub pof_attributes;
     match pof_desc with
-    | Otag (_, attrs, t) ->
-        sub.attributes sub attrs; sub.typ sub t
+    | Otag (_, t) -> sub.typ sub t
     | Oinherit t -> sub.typ sub t
 
   let iter sub {ptyp_desc = desc; ptyp_loc = loc; ptyp_attributes = attrs} =

--- a/parsing/ast_iterator.mli
+++ b/parsing/ast_iterator.mli
@@ -56,6 +56,8 @@ type iterator = {
   structure: iterator -> structure -> unit;
   structure_item: iterator -> structure_item -> unit;
   typ: iterator -> core_type -> unit;
+  row_field: iterator -> row_field -> unit;
+  object_field: iterator -> object_field -> unit;
   type_declaration: iterator -> type_declaration -> unit;
   type_extension: iterator -> type_extension -> unit;
   type_exception: iterator -> type_exception -> unit;

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -92,8 +92,8 @@ module T = struct
     let loc = sub.location sub prf_loc in
     let desc = match prf_desc with
       | Rtag (l, attrs, b, tl) ->
-          Rtag (map_loc sub l, sub.attributes sub attrs, b,
-                List.map (sub.typ sub) tl)
+          let attrs = sub.attributes sub attrs in
+          Rtag (map_loc sub l, attrs, b, List.map (sub.typ sub) tl)
       | Rinherit t -> Rinherit (sub.typ sub t)
     in
     Rf.mk ~loc desc
@@ -105,7 +105,8 @@ module T = struct
     let loc = sub.location sub pof_loc in
     let desc = match pof_desc with
       | Otag (l, attrs, t) ->
-          Otag (map_loc sub l, sub.attributes sub attrs, sub.typ sub t)
+          let attrs = sub.attributes sub attrs in
+          Otag (map_loc sub l, attrs, sub.typ sub t)
       | Oinherit t -> Oinherit (sub.typ sub t)
     in
     Of.mk ~loc desc
@@ -143,7 +144,9 @@ module T = struct
        ptype_manifest;
        ptype_attributes;
        ptype_loc} =
-    Type.mk (map_loc sub ptype_name)
+    let loc = sub.location sub ptype_loc in
+    let attrs = sub.attributes sub ptype_attributes in
+    Type.mk ~loc ~attrs (map_loc sub ptype_name)
       ~params:(List.map (map_fst (sub.typ sub)) ptype_params)
       ~priv:ptype_private
       ~cstrs:(List.map
@@ -151,8 +154,6 @@ module T = struct
                 ptype_cstrs)
       ~kind:(sub.type_kind sub ptype_kind)
       ?manifest:(map_opt (sub.typ sub) ptype_manifest)
-      ~loc:(sub.location sub ptype_loc)
-      ~attrs:(sub.attributes sub ptype_attributes)
 
   let map_type_kind sub = function
     | Ptype_abstract -> Ptype_abstract
@@ -170,18 +171,22 @@ module T = struct
       {ptyext_path; ptyext_params;
        ptyext_constructors;
        ptyext_private;
+       ptyext_loc;
        ptyext_attributes} =
-    Te.mk
+    let loc = sub.location sub ptyext_loc in
+    let attrs = sub.attributes sub ptyext_attributes in
+    Te.mk ~loc ~attrs
       (map_loc sub ptyext_path)
       (List.map (sub.extension_constructor sub) ptyext_constructors)
       ~params:(List.map (map_fst (sub.typ sub)) ptyext_params)
       ~priv:ptyext_private
-      ~attrs:(sub.attributes sub ptyext_attributes)
 
-  let map_type_exception sub {ptyexn_constructor; ptyexn_attributes} =
-    Te.mk_exception
+  let map_type_exception sub
+      {ptyexn_constructor; ptyexn_loc; ptyexn_attributes} =
+    let loc = sub.location sub ptyexn_loc in
+    let attrs = sub.attributes sub ptyexn_attributes in
+    Te.mk_exception ~loc ~attrs
       (sub.extension_constructor sub ptyexn_constructor)
-      ~attrs:(sub.attributes sub ptyexn_attributes)
 
   let map_extension_constructor_kind sub = function
       Pext_decl(ctl, cto) ->
@@ -194,11 +199,11 @@ module T = struct
        pext_kind;
        pext_loc;
        pext_attributes} =
-    Te.constructor
+    let loc = sub.location sub pext_loc in
+    let attrs = sub.attributes sub pext_attributes in
+    Te.constructor ~loc ~attrs
       (map_loc sub pext_name)
       (map_extension_constructor_kind sub pext_kind)
-      ~loc:(sub.location sub pext_loc)
-      ~attrs:(sub.attributes sub pext_attributes)
 
 end
 
@@ -290,7 +295,8 @@ module MT = struct
     | Psig_class_type l ->
         class_type ~loc (List.map (sub.class_type_declaration sub) l)
     | Psig_extension (x, attrs) ->
-        extension ~loc (sub.extension sub x) ~attrs:(sub.attributes sub attrs)
+        let attrs = sub.attributes sub attrs in
+        extension ~loc ~attrs (sub.extension sub x)
     | Psig_attribute x -> attribute ~loc (sub.attribute sub x)
 end
 
@@ -322,7 +328,8 @@ module M = struct
     let loc = sub.location sub loc in
     match desc with
     | Pstr_eval (x, attrs) ->
-        eval ~loc ~attrs:(sub.attributes sub attrs) (sub.expr sub x)
+        let attrs = sub.attributes sub attrs in
+        eval ~loc ~attrs (sub.expr sub x)
     | Pstr_value (r, vbs) -> value ~loc r (List.map (sub.value_binding sub) vbs)
     | Pstr_primitive vd -> primitive ~loc (sub.value_description sub vd)
     | Pstr_type (rf, l) -> type_ ~loc rf (List.map (sub.type_declaration sub) l)
@@ -337,7 +344,8 @@ module M = struct
         class_type ~loc (List.map (sub.class_type_declaration sub) l)
     | Pstr_include x -> include_ ~loc (sub.include_declaration sub x)
     | Pstr_extension (x, attrs) ->
-        extension ~loc (sub.extension sub x) ~attrs:(sub.attributes sub attrs)
+        let attrs = sub.attributes sub attrs in
+        extension ~loc ~attrs (sub.extension sub x)
     | Pstr_attribute x -> attribute ~loc (sub.attribute sub x)
 end
 
@@ -511,13 +519,13 @@ module CE = struct
 
   let class_infos sub f {pci_virt; pci_params = pl; pci_name; pci_expr;
                          pci_loc; pci_attributes} =
-    Ci.mk
+    let loc = sub.location sub pci_loc in
+    let attrs = sub.attributes sub pci_attributes in
+    Ci.mk ~loc ~attrs
      ~virt:pci_virt
      ~params:(List.map (map_fst (sub.typ sub)) pl)
       (map_loc sub pci_name)
       (f pci_expr)
-      ~loc:(sub.location sub pci_loc)
-      ~attrs:(sub.attributes sub pci_attributes)
 end
 
 (* Now, a generic AST mapper, to be extended to cover all kinds and

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -85,16 +85,30 @@ let map_loc sub {loc; txt} = {loc = sub.location sub loc; txt}
 module T = struct
   (* Type expressions for the core language *)
 
-  let row_field sub = function
-    | Rtag (l, attrs, b, tl) ->
-        Rtag (map_loc sub l, sub.attributes sub attrs,
-              b, List.map (sub.typ sub) tl)
-    | Rinherit t -> Rinherit (sub.typ sub t)
+  let row_field sub {
+      prf_desc;
+      prf_loc;
+    } =
+    let loc = sub.location sub prf_loc in
+    let desc = match prf_desc with
+      | Rtag (l, attrs, b, tl) ->
+          Rtag (map_loc sub l, sub.attributes sub attrs, b,
+                List.map (sub.typ sub) tl)
+      | Rinherit t -> Rinherit (sub.typ sub t)
+    in
+    Rf.mk ~loc desc
 
-  let object_field sub = function
-    | Otag (l, attrs, t) ->
-        Otag (map_loc sub l, sub.attributes sub attrs, sub.typ sub t)
-    | Oinherit t -> Oinherit (sub.typ sub t)
+  let object_field sub {
+      pof_desc;
+      pof_loc;
+    } =
+    let loc = sub.location sub pof_loc in
+    let desc = match pof_desc with
+      | Otag (l, attrs, t) ->
+          Otag (map_loc sub l, sub.attributes sub attrs, sub.typ sub t)
+      | Oinherit t -> Oinherit (sub.typ sub t)
+    in
+    Of.mk ~loc desc
 
   let map sub {ptyp_desc = desc; ptyp_loc = loc; ptyp_attributes = attrs} =
     let open Typ in

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -88,28 +88,28 @@ module T = struct
   let row_field sub {
       prf_desc;
       prf_loc;
+      prf_attributes;
     } =
     let loc = sub.location sub prf_loc in
+    let attrs = sub.attributes sub prf_attributes in
     let desc = match prf_desc with
-      | Rtag (l, attrs, b, tl) ->
-          let attrs = sub.attributes sub attrs in
-          Rtag (map_loc sub l, attrs, b, List.map (sub.typ sub) tl)
+      | Rtag (l, b, tl) -> Rtag (map_loc sub l, b, List.map (sub.typ sub) tl)
       | Rinherit t -> Rinherit (sub.typ sub t)
     in
-    Rf.mk ~loc desc
+    Rf.mk ~loc ~attrs desc
 
   let object_field sub {
       pof_desc;
       pof_loc;
+      pof_attributes;
     } =
     let loc = sub.location sub pof_loc in
+    let attrs = sub.attributes sub pof_attributes in
     let desc = match pof_desc with
-      | Otag (l, attrs, t) ->
-          let attrs = sub.attributes sub attrs in
-          Otag (map_loc sub l, attrs, sub.typ sub t)
+      | Otag (l, t) -> Otag (map_loc sub l, sub.typ sub t)
       | Oinherit t -> Oinherit (sub.typ sub t)
     in
-    Of.mk ~loc desc
+    Of.mk ~loc ~attrs desc
 
   let map sub {ptyp_desc = desc; ptyp_loc = loc; ptyp_attributes = attrs} =
     let open Typ in

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -105,14 +105,14 @@ let rec add_type bv ty =
   | Ptyp_object (fl, _) ->
       List.iter
        (fun {pof_desc; _} -> match pof_desc with
-         | Otag (_, _, t) -> add_type bv t
+         | Otag (_, t) -> add_type bv t
          | Oinherit t -> add_type bv t) fl
   | Ptyp_class(c, tl) -> add bv c; List.iter (add_type bv) tl
   | Ptyp_alias(t, _) -> add_type bv t
   | Ptyp_variant(fl, _, _) ->
       List.iter
         (fun {prf_desc; _} -> match prf_desc with
-          | Rtag(_,_,_,stl) -> List.iter (add_type bv) stl
+          | Rtag(_, _, stl) -> List.iter (add_type bv) stl
           | Rinherit sty -> add_type bv sty)
         fl
   | Ptyp_poly(_, t) -> add_type bv t

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -104,13 +104,15 @@ let rec add_type bv ty =
   | Ptyp_constr(c, tl) -> add bv c; List.iter (add_type bv) tl
   | Ptyp_object (fl, _) ->
       List.iter
-       (function Otag (_, _, t) -> add_type bv t
+       (fun {pof_desc; _} -> match pof_desc with
+         | Otag (_, _, t) -> add_type bv t
          | Oinherit t -> add_type bv t) fl
   | Ptyp_class(c, tl) -> add bv c; List.iter (add_type bv) tl
   | Ptyp_alias(t, _) -> add_type bv t
   | Ptyp_variant(fl, _, _) ->
       List.iter
-        (function Rtag(_,_,_,stl) -> List.iter (add_type bv) stl
+        (fun {prf_desc; _} -> match prf_desc with
+          | Rtag(_,_,_,stl) -> List.iter (add_type bv) stl
           | Rinherit sty -> add_type bv sty)
         fl
   | Ptyp_poly(_, t) -> add_type bv t

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -148,16 +148,17 @@ and package_type = Longident.t loc * (Longident.t loc * core_type) list
 and row_field = {
   prf_desc : row_field_desc;
   prf_loc : Location.t;
+  prf_attributes : attributes;
 }
 
 and row_field_desc =
-  | Rtag of label loc * attributes * bool * core_type list
+  | Rtag of label loc * bool * core_type list
         (* [`A]                   ( true,  [] )
            [`A of T]              ( false, [T] )
            [`A of T1 & .. & Tn]   ( false, [T1;...Tn] )
            [`A of & T1 & .. & Tn] ( true,  [T1;...Tn] )
 
-          - The 3rd field is true if the tag contains a
+          - The 'bool' field is true if the tag contains a
             constant (empty) constructor.
           - '&' occurs when several types are used for the same constructor
             (see 4.2 in the manual)
@@ -168,10 +169,11 @@ and row_field_desc =
 and object_field = {
   pof_desc : object_field_desc;
   pof_loc : Location.t;
+  pof_attributes : attributes;
 }
 
 and object_field_desc =
-  | Otag of label loc * attributes * core_type
+  | Otag of label loc * core_type
   | Oinherit of core_type
 
 (* Patterns *)

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -145,24 +145,32 @@ and package_type = Longident.t loc * (Longident.t loc * core_type) list
         (module S with type t1 = T1 and ... and tn = Tn)
        *)
 
-and row_field =
+and row_field = {
+  prf_desc : row_field_desc;
+  prf_loc : Location.t;
+}
+
+and row_field_desc =
   | Rtag of label loc * attributes * bool * core_type list
         (* [`A]                   ( true,  [] )
            [`A of T]              ( false, [T] )
            [`A of T1 & .. & Tn]   ( false, [T1;...Tn] )
            [`A of & T1 & .. & Tn] ( true,  [T1;...Tn] )
 
-          - The 2nd field is true if the tag contains a
+          - The 3rd field is true if the tag contains a
             constant (empty) constructor.
           - '&' occurs when several types are used for the same constructor
             (see 4.2 in the manual)
-
-          - TODO: switch to a record representation, and keep location
         *)
   | Rinherit of core_type
         (* [ T ] *)
 
-and object_field =
+and object_field = {
+  pof_desc : object_field_desc;
+  pof_loc : Location.t;
+}
+
+and object_field_desc =
   | Otag of label loc * attributes * core_type
   | Oinherit of core_type
 
@@ -458,6 +466,7 @@ and type_extension =
      ptyext_params: (core_type * variance) list;
      ptyext_constructors: extension_constructor list;
      ptyext_private: private_flag;
+     ptyext_loc: Location.t;
      ptyext_attributes: attributes;   (* ... [@@id1] [@@id2] *)
     }
 (*
@@ -476,6 +485,7 @@ and extension_constructor =
 and type_exception =
   {
     ptyexn_constructor: extension_constructor;
+    ptyexn_loc: Location.t;
     ptyexn_attributes: attributes; (* ... [@@id1] [@@id2] *)
   }
 

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -288,13 +288,13 @@ and core_type1 ctxt f x =
     | Ptyp_variant (l, closed, low) ->
         let type_variant_helper f x =
           match x.prf_desc with
-          | Rtag (l, attrs, _, ctl) ->
+          | Rtag (l, _, ctl) ->
               pp f "@[<2>%a%a@;%a@]" (iter_loc string_quot) l
                 (fun f l -> match l with
                    |[] -> ()
                    | _ -> pp f "@;of@;%a"
                             (list (core_type ctxt) ~sep:"&")  ctl) ctl
-                (attributes ctxt) attrs
+                (attributes ctxt) x.prf_attributes
           | Rinherit ct -> core_type ctxt f ct in
         pp f "@[<2>[%a%a]@]"
           (fun f l ->
@@ -315,9 +315,10 @@ and core_type1 ctxt f x =
                    (list string_quot) xs) low
     | Ptyp_object (l, o) ->
         let core_field_type f x = match x.pof_desc with
-          | Otag (l, attrs, ct) ->
+          | Otag (l, ct) ->
+            (* Cf #7200 *)
             pp f "@[<hov2>%s: %a@ %a@ @]" l.txt
-              (core_type ctxt) ct (attributes ctxt) attrs (* Cf #7200 *)
+              (core_type ctxt) ct (attributes ctxt) x.pof_attributes
           | Oinherit ct ->
             pp f "@[<hov2>%a@ @]" (core_type ctxt) ct
         in

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -165,9 +165,9 @@ let rec core_type i ppf x =
       let i = i + 1 in
       List.iter (fun field ->
         match field.pof_desc with
-          | Otag (l, attrs, t) ->
+          | Otag (l, t) ->
             line i ppf "method %s\n" l.txt;
-            attributes i ppf attrs;
+            attributes i ppf field.pof_attributes;
             core_type (i + 1) ppf t
           | Oinherit ct ->
               line i ppf "Oinherit\n";
@@ -894,9 +894,9 @@ and label_x_expression i ppf (l,e) =
 
 and label_x_bool_x_core_type_list i ppf x =
   match x.prf_desc with
-    Rtag (l, attrs, b, ctl) ->
+    Rtag (l, b, ctl) ->
       line i ppf "Rtag \"%s\" %s\n" l.txt (string_of_bool b);
-      attributes (i+1) ppf attrs;
+      attributes (i+1) ppf x.prf_attributes;
       list (i+1) core_type ppf ctl
   | Rinherit (ct) ->
       line i ppf "Rinherit\n";

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -163,8 +163,8 @@ let rec core_type i ppf x =
   | Ptyp_object (l, c) ->
       line i ppf "Ptyp_object %a\n" fmt_closed_flag c;
       let i = i + 1 in
-      List.iter (
-        function
+      List.iter (fun field ->
+        match field.pof_desc with
           | Otag (l, attrs, t) ->
             line i ppf "method %s\n" l.txt;
             attributes i ppf attrs;
@@ -893,7 +893,7 @@ and label_x_expression i ppf (l,e) =
   expression (i+1) ppf e;
 
 and label_x_bool_x_core_type_list i ppf x =
-  match x with
+  match x.prf_desc with
     Rtag (l, attrs, b, ctl) ->
       line i ppf "Rtag \"%s\" %s\n" l.txt (string_of_bool b);
       attributes (i+1) ppf attrs;

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -190,10 +190,11 @@ let rec core_type i ppf x =
   | Ttyp_object (l, c) ->
       line i ppf "Ttyp_object %a\n" fmt_closed_flag c;
       let i = i + 1 in
-      List.iter (fun {of_desc; _} -> match of_desc with
-        | OTtag (s, attrs, t) ->
+      List.iter (fun {of_desc; of_attributes; _} ->
+        match of_desc with
+        | OTtag (s, t) ->
             line i ppf "method %s\n" s.txt;
-            attributes i ppf attrs;
+            attributes i ppf of_attributes;
             core_type (i + 1) ppf t
         | OTinherit ct ->
             line i ppf "OTinherit\n";
@@ -883,9 +884,9 @@ and ident_x_expression_def i ppf (l, e) =
 
 and label_x_bool_x_core_type_list i ppf x =
   match x.rf_desc with
-  | Ttag (l, attrs, b, ctl) ->
+  | Ttag (l, b, ctl) ->
       line i ppf "Ttag \"%s\" %s\n" l.txt (string_of_bool b);
-      attributes (i+1) ppf attrs;
+      attributes (i+1) ppf x.rf_attributes;
       list (i+1) core_type ppf ctl
   | Tinherit (ct) ->
       line i ppf "Tinherit\n";

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -190,7 +190,7 @@ let rec core_type i ppf x =
   | Ttyp_object (l, c) ->
       line i ppf "Ttyp_object %a\n" fmt_closed_flag c;
       let i = i + 1 in
-      List.iter (function
+      List.iter (fun {of_desc; _} -> match of_desc with
         | OTtag (s, attrs, t) ->
             line i ppf "method %s\n" s.txt;
             attributes i ppf attrs;
@@ -882,8 +882,8 @@ and ident_x_expression_def i ppf (l, e) =
   expression (i+1) ppf e;
 
 and label_x_bool_x_core_type_list i ppf x =
-  match x with
-    Ttag (l, attrs, b, ctl) ->
+  match x.rf_desc with
+  | Ttag (l, attrs, b, ctl) ->
       line i ppf "Ttag \"%s\" %s\n" l.txt (string_of_bool b);
       attributes (i+1) ppf attrs;
       list (i+1) core_type ppf ctl

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -614,16 +614,16 @@ let class_structure sub x =
 
 let row_field sub x =
   let rf_desc = match x.rf_desc with
-    | Ttag (label, attrs, b, list) ->
-        Ttag (label, attrs, b, List.map (sub.typ sub) list)
+    | Ttag (label, b, list) ->
+        Ttag (label, b, List.map (sub.typ sub) list)
     | Tinherit ct -> Tinherit (sub.typ sub ct)
   in
   { x with rf_desc; }
 
 let object_field sub x =
   let of_desc = match x.of_desc with
-    | OTtag (label, attrs, ct) ->
-        OTtag (label, attrs, (sub.typ sub ct))
+    | OTtag (label, ct) ->
+        OTtag (label, (sub.typ sub ct))
     | OTinherit ct -> OTinherit (sub.typ sub ct)
   in
   { x with of_desc; }

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -71,6 +71,7 @@ let tuple2 f1 f2 (x, y) = (f1 x, f2 y)
 let tuple3 f1 f2 f3 (x, y, z) = (f1 x, f2 y, f3 z)
 let opt f = function None -> None | Some x -> Some (f x)
 
+
 let structure sub {str_items; str_type; str_final_env} =
   {
     str_items = List.map (sub.structure_item sub) str_items;
@@ -611,15 +612,21 @@ let class_structure sub x =
   let cstr_fields = List.map (sub.class_field sub) x.cstr_fields in
   {x with cstr_self; cstr_fields}
 
-let row_field sub = function
-  | Ttag (label, attrs, b, list) ->
-      Ttag (label, attrs, b, List.map (sub.typ sub) list)
-  | Tinherit ct -> Tinherit (sub.typ sub ct)
+let row_field sub x =
+  let rf_desc = match x.rf_desc with
+    | Ttag (label, attrs, b, list) ->
+        Ttag (label, attrs, b, List.map (sub.typ sub) list)
+    | Tinherit ct -> Tinherit (sub.typ sub ct)
+  in
+  { x with rf_desc; }
 
-let object_field sub = function
-  | OTtag (label, attrs, ct) ->
-      OTtag (label, attrs, (sub.typ sub ct))
-  | OTinherit ct -> OTinherit (sub.typ sub ct)
+let object_field sub x =
+  let of_desc = match x.of_desc with
+    | OTtag (label, attrs, ct) ->
+        OTtag (label, attrs, (sub.typ sub ct))
+    | OTinherit ct -> OTinherit (sub.typ sub ct)
+  in
+  { x with of_desc; }
 
 let class_field_kind sub = function
   | Tcfk_virtual ct -> Tcfk_virtual (sub.typ sub ct)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1620,6 +1620,7 @@ let transl_type_extension extend env loc styext =
       tyext_params = ttype_params;
       tyext_constructors = constructors;
       tyext_private = styext.ptyext_private;
+      tyext_loc = styext.ptyext_loc;
       tyext_attributes = styext.ptyext_attributes; }
   in
     (tyext, newenv)
@@ -1657,6 +1658,7 @@ let transl_type_exception env t =
       )
   in
   {tyexn_constructor = contructor;
+   tyexn_loc = t.ptyexn_loc;
    tyexn_attributes = t.ptyexn_attributes}, newenv
 
 

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -386,11 +386,21 @@ and package_type = {
   pack_txt : Longident.t loc;
 }
 
-and row_field =
+and row_field = {
+  rf_desc : row_field_desc;
+  rf_loc : Location.t;
+}
+
+and row_field_desc =
     Ttag of string loc * attributes * bool * core_type list
   | Tinherit of core_type
 
-and object_field =
+and object_field = {
+  of_desc : object_field_desc;
+  of_loc : Location.t;
+}
+
+and object_field_desc =
   | OTtag of string loc * attributes * core_type
   | OTinherit of core_type
 
@@ -454,12 +464,14 @@ and type_extension =
     tyext_params: (core_type * variance) list;
     tyext_constructors: extension_constructor list;
     tyext_private: private_flag;
+    tyext_loc: Location.t;
     tyext_attributes: attribute list;
   }
 
 and type_exception =
   {
     tyexn_constructor: extension_constructor;
+    tyexn_loc: Location.t;
     tyexn_attributes: attribute list;
   }
 

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -389,19 +389,21 @@ and package_type = {
 and row_field = {
   rf_desc : row_field_desc;
   rf_loc : Location.t;
+  rf_attributes : attributes;
 }
 
 and row_field_desc =
-    Ttag of string loc * attributes * bool * core_type list
+    Ttag of string loc * bool * core_type list
   | Tinherit of core_type
 
 and object_field = {
   of_desc : object_field_desc;
   of_loc : Location.t;
+  of_attributes : attributes;
 }
 
 and object_field_desc =
-  | OTtag of string loc * attributes * core_type
+  | OTtag of string loc * core_type
   | OTinherit of core_type
 
 and value_description =

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -509,11 +509,21 @@ and package_type = {
   pack_txt : Longident.t loc;
 }
 
-and row_field =
+and row_field = {
+  rf_desc : row_field_desc;
+  rf_loc : Location.t;
+}
+
+and row_field_desc =
     Ttag of string loc * attributes * bool * core_type list
   | Tinherit of core_type
 
-and object_field =
+and object_field = {
+  of_desc : object_field_desc;
+  of_loc : Location.t;
+}
+
+and object_field_desc =
   | OTtag of string loc * attributes * core_type
   | OTinherit of core_type
 
@@ -578,12 +588,14 @@ and type_extension =
     tyext_params: (core_type * variance) list;
     tyext_constructors: extension_constructor list;
     tyext_private: private_flag;
+    tyext_loc: Location.t;
     tyext_attributes: attributes;
   }
 
 and type_exception =
   {
     tyexn_constructor: extension_constructor;
+    tyexn_loc: Location.t;
     tyexn_attributes: attribute list;
   }
 

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -512,19 +512,21 @@ and package_type = {
 and row_field = {
   rf_desc : row_field_desc;
   rf_loc : Location.t;
+  rf_attributes : attributes;
 }
 
 and row_field_desc =
-    Ttag of string loc * attributes * bool * core_type list
+    Ttag of string loc * bool * core_type list
   | Tinherit of core_type
 
 and object_field = {
   of_desc : object_field_desc;
   of_loc : Location.t;
+  of_attributes : attributes;
 }
 
 and object_field_desc =
-  | OTtag of string loc * attributes * core_type
+  | OTtag of string loc * core_type
   | OTinherit of core_type
 
 and value_description =

--- a/typing/typedtreeIter.ml
+++ b/typing/typedtreeIter.ml
@@ -596,13 +596,13 @@ module MakeIterator(Iter : IteratorArgument) : sig
 
     and iter_row_field rf =
       match rf.rf_desc with
-      | Ttag (_label, _attrs, _bool, list) ->
+      | Ttag (_label, _bool, list) ->
           List.iter iter_core_type list
       | Tinherit ct -> iter_core_type ct
 
     and iter_object_field ofield =
       match ofield.of_desc with
-      | OTtag (_, _, ct) | OTinherit ct -> iter_core_type ct
+      | OTtag (_, ct) | OTinherit ct -> iter_core_type ct
 
     and iter_class_field cf =
       Iter.enter_class_field cf;

--- a/typing/typedtreeIter.ml
+++ b/typing/typedtreeIter.ml
@@ -595,14 +595,14 @@ module MakeIterator(Iter : IteratorArgument) : sig
 
 
     and iter_row_field rf =
-      match rf with
-        Ttag (_label, _attrs, _bool, list) ->
+      match rf.rf_desc with
+      | Ttag (_label, _attrs, _bool, list) ->
           List.iter iter_core_type list
       | Tinherit ct -> iter_core_type ct
 
     and iter_object_field ofield =
-      match ofield with
-        OTtag (_, _, ct) | OTinherit ct -> iter_core_type ct
+      match ofield.of_desc with
+      | OTtag (_, _, ct) | OTinherit ct -> iter_core_type ct
 
     and iter_class_field cf =
       Iter.enter_class_field cf;

--- a/typing/typedtreeMap.ml
+++ b/typing/typedtreeMap.ml
@@ -654,22 +654,22 @@ module MakeMap(Map : MapArgument) = struct
     Map.leave_class_structure { cs with cstr_self; cstr_fields }
 
   and map_row_field field =
-    let { rf_desc; rf_loc; } = Map.enter_row_field field in
+    let { rf_desc; rf_loc; rf_attributes; } = Map.enter_row_field field in
     let rf_desc = match rf_desc with
-      | Ttag (label, attrs, bool, list) ->
-          Ttag (label, attrs, bool, List.map map_core_type list)
+      | Ttag (label, bool, list) ->
+          Ttag (label, bool, List.map map_core_type list)
       | Tinherit ct -> Tinherit (map_core_type ct)
     in
-    Map.leave_row_field { rf_desc; rf_loc; }
+    Map.leave_row_field { rf_desc; rf_loc; rf_attributes; }
 
   and map_object_field field =
-    let { of_desc; of_loc; } = Map.enter_object_field field in
+    let { of_desc; of_loc; of_attributes; } = Map.enter_object_field field in
     let of_desc = match of_desc with
-      | OTtag (label, attrs, ct) ->
-          OTtag (label, attrs, map_core_type ct)
+      | OTtag (label, ct) ->
+          OTtag (label, map_core_type ct)
       | OTinherit ct -> OTinherit (map_core_type ct)
     in
-    Map.leave_object_field { of_desc; of_loc; }
+    Map.leave_object_field { of_desc; of_loc; of_attributes; }
 
   and map_class_field cf =
     let cf = Map.enter_class_field cf in

--- a/typing/typedtreeMap.ml
+++ b/typing/typedtreeMap.ml
@@ -45,6 +45,8 @@ module type MapArgument = sig
   val enter_class_structure : class_structure -> class_structure
   val enter_class_field : class_field -> class_field
   val enter_structure_item : structure_item -> structure_item
+  val enter_row_field : row_field -> row_field
+  val enter_object_field : object_field -> object_field
 
   val leave_structure : structure -> structure
   val leave_value_description : value_description -> value_description
@@ -75,6 +77,8 @@ module type MapArgument = sig
   val leave_class_structure : class_structure -> class_structure
   val leave_class_field : class_field -> class_field
   val leave_structure_item : structure_item -> structure_item
+  val leave_row_field : row_field -> row_field
+  val leave_object_field : object_field -> object_field
 
 end
 
@@ -649,17 +653,23 @@ module MakeMap(Map : MapArgument) = struct
     let cstr_fields = List.map map_class_field cs.cstr_fields in
     Map.leave_class_structure { cs with cstr_self; cstr_fields }
 
-  and map_row_field rf =
-    match rf with
-        Ttag (label, attrs, bool, list) ->
+  and map_row_field field =
+    let { rf_desc; rf_loc; } = Map.enter_row_field field in
+    let rf_desc = match rf_desc with
+      | Ttag (label, attrs, bool, list) ->
           Ttag (label, attrs, bool, List.map map_core_type list)
       | Tinherit ct -> Tinherit (map_core_type ct)
+    in
+    Map.leave_row_field { rf_desc; rf_loc; }
 
-  and map_object_field ofield =
-    match ofield with
-        OTtag (label, attrs, ct) ->
+  and map_object_field field =
+    let { of_desc; of_loc; } = Map.enter_object_field field in
+    let of_desc = match of_desc with
+      | OTtag (label, attrs, ct) ->
           OTtag (label, attrs, map_core_type ct)
       | OTinherit ct -> OTinherit (map_core_type ct)
+    in
+    Map.leave_object_field { of_desc; of_loc; }
 
   and map_class_field cf =
     let cf = Map.enter_class_field cf in
@@ -712,6 +722,8 @@ module DefaultMapArgument = struct
   let enter_class_structure t = t
   let enter_class_field t = t
   let enter_structure_item t = t
+  let enter_row_field t = t
+  let enter_object_field t = t
 
 
   let leave_structure t = t
@@ -740,5 +752,7 @@ module DefaultMapArgument = struct
   let leave_class_structure t = t
   let leave_class_field t = t
   let leave_structure_item t = t
+  let leave_row_field t = t
+  let leave_object_field t = t
 
 end

--- a/typing/typedtreeMap.mli
+++ b/typing/typedtreeMap.mli
@@ -45,6 +45,8 @@ module type MapArgument = sig
   val enter_class_structure : class_structure -> class_structure
   val enter_class_field : class_field -> class_field
   val enter_structure_item : structure_item -> structure_item
+  val enter_row_field : row_field -> row_field
+  val enter_object_field : object_field -> object_field
 
   val leave_structure : structure -> structure
   val leave_value_description : value_description -> value_description
@@ -75,6 +77,8 @@ module type MapArgument = sig
   val leave_class_structure : class_structure -> class_structure
   val leave_class_field : class_field -> class_field
   val leave_structure_item : structure_item -> structure_item
+  val leave_row_field : row_field -> row_field
+  val leave_object_field : object_field -> object_field
 
 end
 

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -550,8 +550,10 @@ and transl_type_aux env policy styp =
         with Not_found ->
           Hashtbl.add hfields h (l,f)
       in
-      let add_field = function
-          Rtag (l, attrs, c, stl) ->
+      let add_field field =
+        let rf_loc = field.prf_loc in
+        let rf_desc = match field.prf_desc with
+        | Rtag (l, attrs, c, stl) ->
             name := None;
             let tl =
               Builtin_attributes.warning_scope attrs
@@ -613,6 +615,8 @@ and transl_type_aux env policy styp =
                 add_typed_field sty.ptyp_loc l f)
               fl;
               Tinherit cty
+        in
+        { rf_desc; rf_loc }
       in
       let tfields = List.map add_field fields in
       let fields = Hashtbl.fold (fun _ p l -> p :: l) hfields [] in
@@ -699,7 +703,9 @@ and transl_fields env policy o fields =
           raise(Error(loc, env, Method_mismatch (l, ty, ty')))
     with Not_found ->
       Hashtbl.add hfields l ty in
-  let add_field = function
+  let add_field {pof_desc; pof_loc;} =
+    let of_loc = pof_loc in
+    let of_desc = match pof_desc with
     | Otag (s, a, ty1) -> begin
         let ty1 =
           Builtin_attributes.warning_scope a
@@ -734,6 +740,8 @@ and transl_fields env policy o fields =
             raise (Error (sty.ptyp_loc, env, Unbound_type_constructor_2 p))
         | _ -> raise (Error (sty.ptyp_loc, env, Not_an_object t))
       end in
+    { of_desc; of_loc; }
+  in
   let object_fields = List.map add_field fields in
   let fields = Hashtbl.fold (fun s ty l -> (s, ty) :: l) hfields [] in
   let ty_init =

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -552,11 +552,12 @@ and transl_type_aux env policy styp =
       in
       let add_field field =
         let rf_loc = field.prf_loc in
+        let rf_attributes = field.prf_attributes in
         let rf_desc = match field.prf_desc with
-        | Rtag (l, attrs, c, stl) ->
+        | Rtag (l, c, stl) ->
             name := None;
             let tl =
-              Builtin_attributes.warning_scope attrs
+              Builtin_attributes.warning_scope rf_attributes
                 (fun () -> List.map (transl_type env policy) stl)
             in
             let f = match present with
@@ -572,7 +573,7 @@ and transl_type_aux env policy styp =
                       Rpresent (Some st.ctyp_type)
             in
             add_typed_field styp.ptyp_loc l.txt f;
-              Ttag (l,attrs,c,tl)
+              Ttag (l,c,tl)
         | Rinherit sty ->
             let cty = transl_type env policy sty in
             let ty = cty.ctyp_type in
@@ -616,7 +617,7 @@ and transl_type_aux env policy styp =
               fl;
               Tinherit cty
         in
-        { rf_desc; rf_loc }
+        { rf_desc; rf_loc; rf_attributes; }
       in
       let tfields = List.map add_field fields in
       let fields = Hashtbl.fold (fun _ p l -> p :: l) hfields [] in
@@ -703,15 +704,16 @@ and transl_fields env policy o fields =
           raise(Error(loc, env, Method_mismatch (l, ty, ty')))
     with Not_found ->
       Hashtbl.add hfields l ty in
-  let add_field {pof_desc; pof_loc;} =
+  let add_field {pof_desc; pof_loc; pof_attributes;} =
     let of_loc = pof_loc in
+    let of_attributes = pof_attributes in
     let of_desc = match pof_desc with
-    | Otag (s, a, ty1) -> begin
+    | Otag (s, ty1) -> begin
         let ty1 =
-          Builtin_attributes.warning_scope a
+          Builtin_attributes.warning_scope of_attributes
             (fun () -> transl_poly_type env policy ty1)
         in
-        let field = OTtag (s, a, ty1) in
+        let field = OTtag (s, ty1) in
         add_typed_field ty1.ctyp_loc s.txt ty1.ctyp_type;
         field
       end
@@ -740,7 +742,7 @@ and transl_fields env policy o fields =
             raise (Error (sty.ptyp_loc, env, Unbound_type_constructor_2 p))
         | _ -> raise (Error (sty.ptyp_loc, env, Not_an_object t))
       end in
-    { of_desc; of_loc; }
+    { of_desc; of_loc; of_attributes; }
   in
   let object_fields = List.map add_field fields in
   let fields = Hashtbl.fold (fun s ty l -> (s, ty) :: l) hfields [] in

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -718,23 +718,25 @@ let class_structure sub cs =
     pcstr_fields = List.map (sub.class_field sub) cs.cstr_fields;
   }
 
-let row_field sub {rf_loc; rf_desc} =
+let row_field sub {rf_loc; rf_desc; rf_attributes;} =
   let loc = sub.location sub rf_loc in
+  let attrs = sub.attributes sub rf_attributes in
   let desc = match rf_desc with
-    | Ttag (label, attrs, bool, list) ->
-        Rtag (label, sub.attributes sub attrs, bool, List.map (sub.typ sub) list)
+    | Ttag (label, bool, list) ->
+        Rtag (label, bool, List.map (sub.typ sub) list)
     | Tinherit ct -> Rinherit (sub.typ sub ct)
   in
-  Rf.mk ~loc desc
+  Rf.mk ~loc ~attrs desc
 
-let object_field sub {of_loc; of_desc} =
+let object_field sub {of_loc; of_desc; of_attributes;} =
   let loc = sub.location sub of_loc in
+  let attrs = sub.attributes sub of_attributes in
   let desc = match of_desc with
-    | OTtag (label, attrs, ct) ->
-        Otag (label, sub.attributes sub attrs, sub.typ sub ct)
+    | OTtag (label, ct) ->
+        Otag (label, sub.typ sub ct)
     | OTinherit ct -> Oinherit (sub.typ sub ct)
   in
-  Of.mk ~loc desc
+  Of.mk ~loc ~attrs desc
 
 and is_self_pat = function
   | { pat_desc = Tpat_alias(_pat, id, _) } ->

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -718,17 +718,23 @@ let class_structure sub cs =
     pcstr_fields = List.map (sub.class_field sub) cs.cstr_fields;
   }
 
-let row_field sub rf =
-  match rf with
-    Ttag (label, attrs, bool, list) ->
-      Rtag (label, sub.attributes sub attrs, bool, List.map (sub.typ sub) list)
-  | Tinherit ct -> Rinherit (sub.typ sub ct)
+let row_field sub {rf_loc; rf_desc} =
+  let loc = sub.location sub rf_loc in
+  let desc = match rf_desc with
+    | Ttag (label, attrs, bool, list) ->
+        Rtag (label, sub.attributes sub attrs, bool, List.map (sub.typ sub) list)
+    | Tinherit ct -> Rinherit (sub.typ sub ct)
+  in
+  Rf.mk ~loc desc
 
-let object_field sub ofield =
-  match ofield with
-    OTtag (label, attrs, ct) ->
-      Otag (label, sub.attributes sub attrs, sub.typ sub ct)
-  | OTinherit ct -> Oinherit (sub.typ sub ct)
+let object_field sub {of_loc; of_desc} =
+  let loc = sub.location sub of_loc in
+  let desc = match of_desc with
+    | OTtag (label, attrs, ct) ->
+        Otag (label, sub.attributes sub attrs, sub.typ sub ct)
+    | OTinherit ct -> Oinherit (sub.typ sub ct)
+  in
+  Of.mk ~loc desc
 
 and is_self_pat = function
   | { pat_desc = Tpat_alias(_pat, id, _) } ->


### PR DESCRIPTION
Currently, there are nodes in the AST that carry attributes, but don't store their own location. This is a problem for various kind of preprocessing where one would want to have access to the locations of the nodes concerned by a particular attribute.

We ran into this issue with @Octachron when trying to add an `[@ellipsis]` attribute to elide parts of a program for the manual examples (#1765).

This PR changes the parsetree and typedtree definitions, so it will break third-party consumers of those. I tried to keep the changes relatively minimal. (In particular, I started with a version that put `Rtag` and `Otag` payloads into records, but that proved too invasive and I went for a simpler approach here.)