### PR TITLE
./tools/check-typo-since trunk

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -66,14 +66,15 @@ Makefile*                typo.tab=may
 asmcomp/*/emit.mlp       typo.tab=may typo.long-line=may
 
 /config/gnu              typo.prune
+/config/gnu/**           typo.prune
+
+/manual                  typo.prune
+/manual/**               typo.prune
 
 emacs/*.el               typo.long-line=may
 emacs/caml.el            typo.long-line=may typo.missing-header
 emacs/COPYING            typo.prune
 emacs/ocamltags.in       typo.non-printing
-
-/manual                  typo.prune
-/manual/**               typo.prune
 
 ocamldoc/**              typo.long-line=may
 ocamldoc/Changes.txt     typo.missing-header

--- a/Changes
+++ b/Changes
@@ -444,6 +444,10 @@ Working version
 - GPR#1903: parsetree, add locations to all nodes with attributes
   (Gabriel Scherer, review by Thomas Refis)
 
+- GPR#1905: add check-typo-since to check the files changed
+  since a given git reference
+  (Gabriel Scherer, review by David Allsopp)
+
 - GPR#1910: improve the check-typo use of .gitattributes
   (Gabriel Scherer, review by David Allsopp and Damien Doligez)
 

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -98,15 +98,25 @@ get_attrs() {
   | sed "s/: set//g" | sed "s/: true//g" | sed "s/: may/?/g"
 }
 
+# empty if the path is *not* pruned
+check_prune() {
+  env $OCAML_CT_GIT_INDEX git check-attr typo.prune $OCAML_CT_CA_FLAG "$1" \
+  | grep -v ': unspecified$' | grep -v ': false$'
+}
+
 # Special case for recursive call from the find command (see IGNORE_DIRS).
 case "$1" in
   --check-prune)
-    case $2,"$(get_attrs "$2" | grep -xF prune)" in
-      *,prune|.git,*|.git/*,*)
-          echo "INFO: pruned directory $2 (typo.prune)" >&2
+    case $2 in
+      .git|.git/*)
+          echo "INFO: pruned path $2 (.git)" >&2
           exit 0;;
-      *,*) exit 3;;
-    esac;;
+    esac
+    if test -n "$(check_prune "$2")"; then
+        echo "INFO: pruned path $2 (typo.prune)" >&2
+        exit 0
+    fi
+    exit 3;;
 esac
 
 case "$1" in
@@ -136,7 +146,7 @@ IGNORE_DIRS="
   -type d -exec $0 --check-prune {} ; -prune -o
 "
 # `-type d`: simple files (not directories) are not pruned during the
-# "find" invocation but below (look for " prune ") for performance
+# "find" invocation but below (look for "check_prune") for performance
 # reasons: most files outside pruned directories are not pruned, so it
 # is faster to optimistically run check-typo on them (and maybe get
 # out in the middle) than to first check then run.
@@ -148,6 +158,7 @@ EXIT_CODE=0
   esac
 ) | (
   while read f; do
+    if test -n "$(check_prune "$f")"; then continue; fi
     case `$OCAML_CT_LS_FILES "$f" 2>&1` in
       "") path_in_index=false;;
       *) path_in_index=true;;
@@ -181,10 +192,6 @@ EXIT_CODE=0
     rules=" $(echo $rules) "
     attr_rules=" $(echo $attr_rules) "
 
-    if test -n "$(echo "$rules $attr_rules" | grep " prune ")"
-    then
-        continue
-    fi
     if test -n "$(echo "$rules $attr_rules" | grep " utf8 ")"
     then
         # grep -a is used to force the file to be considered as text and -x

--- a/tools/check-typo
+++ b/tools/check-typo
@@ -102,7 +102,7 @@ get_attrs() {
 case "$1" in
   --check-prune)
     case $2,"$(get_attrs "$2" | grep -xF prune)" in
-      *,prune|.git,*)
+      *,prune|.git,*|.git/*,*)
           echo "INFO: pruned directory $2 (typo.prune)" >&2
           exit 0;;
       *,*) exit 3;;

--- a/tools/check-typo-since
+++ b/tools/check-typo-since
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*            Gabriel Scherer, projet Parsifal, INRIA Saclay              *
+#*                                                                        *
+#*   Copyright 2018 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+# Run check-typo, comparing only files that have changed since a particular
+# git state
+
+check_typo_since() {
+  CHECK_TYPO=$(dirname $0)/check-typo
+  git diff --name-only $1 \
+  | (while IFS= read -r path
+  do
+    if test -e "$path"; then :; else continue; fi
+    $CHECK_TYPO --check-prune "$path" 2>/dev/null
+    if test $? -eq 0; then continue; fi
+    $CHECK_TYPO "$path"
+  done)
+}
+
+case $# in
+    0) echo "usage: check-typo-since <git reference>"; exit 2;;
+    1) check_typo_since $1; break;;
+    *) echo "too many arguments"; exit 2;;
+esac


### PR DESCRIPTION
I have not learned to use the check-typo pre-commit-hook yet (and I think there are various situations where I want to run check-typo at other times than at pre-commits), but I already find just running `./tools/check-typo` (to check the whole repository) very slow, it takes slightly above one minute on my machine.

This PR proposes an auxiliary tool, `check-typo-since`, which takes a git reference as argument, and runs `check-typo` on all the files that have changed since this reference -- due to further commit, or not-yet-committed changes. The following could be useful

```
./tools/check-typo-since trunk  # check my whole feature branch
./tools/check-typo-since HEAD~1 # check last commit
./tools/check-typo-since HEAD # check uncommitted changes
```

I first considered adding this feature to `check-typo` directly (`--since trunk`), but the control flow of `check-typo` is horrible spaghetti and I don't want to touch it.

To make `check-typo-since` work well, I had to make some tweaks to `.gitattributes`. In particular, instead of having `/manual ocaml-typo=prune`, which tells that the `manual` directory is to be pruned, I changed it into `/manual** ocaml-typo=prune`, which tells that `manual` and any file underneath is to be pruned. This makes the implementation of `check-typo-since` simple and easy, but one has to remember to always use the child-closure operator `**` when pruning in gitattributes.

(I realize now that some of the logic is very close to the code of the pre-commit-hook, but that I made different choices which could also be used to simplify the pre-commit-hook's logic, if @dra27 agrees that they are sensible choices.)