### PR TITLE
optionally write the output of -dlambda etc into a file

### DIFF
--- a/Changes
+++ b/Changes
@@ -111,6 +111,10 @@ Working version
   returns a syntax tree, to replace the print that was there already
   (Valentin Gatien-Baron)
 
+- GPR#1913: new flag -dump-into-file to print debug output like -dlambda into
+  a file named after the file being built, instead of on stderr.
+  (Valentin Gatien-Baron, review by Thomas Refis)
+
 - GPR#1921: in the compilation context passed to ppx extensions,
   add more configuration options related to type-checking:
   -rectypes, -principal, -alias-deps, -unboxed-types, -unsafe-string

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -74,73 +74,73 @@ let raw_clambda_dump_if ppf
     end;
   if !dump_cmm then Format.fprintf ppf "@.cmm:@."
 
-let rec regalloc ppf round fd =
+let rec regalloc ~ppf_dump round fd =
   if round > 50 then
     fatal_error(fd.Mach.fun_name ^
                 ": function too complex, cannot complete register allocation");
-  dump_if ppf dump_live "Liveness analysis" fd;
+  dump_if ppf_dump dump_live "Liveness analysis" fd;
   if !use_linscan then begin
     (* Linear Scan *)
     Interval.build_intervals fd;
-    if !dump_interval then Printmach.intervals ppf ();
+    if !dump_interval then Printmach.intervals ppf_dump ();
     Linscan.allocate_registers()
   end else begin
     (* Graph Coloring *)
     Interf.build_graph fd;
-    if !dump_interf then Printmach.interferences ppf ();
-    if !dump_prefer then Printmach.preferences ppf ();
+    if !dump_interf then Printmach.interferences ppf_dump ();
+    if !dump_prefer then Printmach.preferences ppf_dump ();
     Coloring.allocate_registers()
   end;
-  dump_if ppf dump_regalloc "After register allocation" fd;
+  dump_if ppf_dump dump_regalloc "After register allocation" fd;
   let (newfd, redo_regalloc) = Reload.fundecl fd in
-  dump_if ppf dump_reload "After insertion of reloading code" newfd;
+  dump_if ppf_dump dump_reload "After insertion of reloading code" newfd;
   if redo_regalloc then begin
-    Reg.reinit(); Liveness.fundecl newfd; regalloc ppf (round + 1) newfd
+    Reg.reinit(); Liveness.fundecl newfd; regalloc ~ppf_dump (round + 1) newfd
   end else newfd
 
 let (++) x f = f x
 
-let compile_fundecl (ppf : formatter) fd_cmm =
+let compile_fundecl ~ppf_dump fd_cmm =
   Proc.init ();
   Reg.reset();
   fd_cmm
   ++ Profile.record ~accumulate:true "selection" Selection.fundecl
-  ++ pass_dump_if ppf dump_selection "After instruction selection"
+  ++ pass_dump_if ppf_dump dump_selection "After instruction selection"
   ++ Profile.record ~accumulate:true "comballoc" Comballoc.fundecl
-  ++ pass_dump_if ppf dump_combine "After allocation combining"
+  ++ pass_dump_if ppf_dump dump_combine "After allocation combining"
   ++ Profile.record ~accumulate:true "cse" CSE.fundecl
-  ++ pass_dump_if ppf dump_cse "After CSE"
+  ++ pass_dump_if ppf_dump dump_cse "After CSE"
   ++ Profile.record ~accumulate:true "liveness" liveness
   ++ Profile.record ~accumulate:true "deadcode" Deadcode.fundecl
-  ++ pass_dump_if ppf dump_live "Liveness analysis"
+  ++ pass_dump_if ppf_dump dump_live "Liveness analysis"
   ++ Profile.record ~accumulate:true "spill" Spill.fundecl
   ++ Profile.record ~accumulate:true "liveness" liveness
-  ++ pass_dump_if ppf dump_spill "After spilling"
+  ++ pass_dump_if ppf_dump dump_spill "After spilling"
   ++ Profile.record ~accumulate:true "split" Split.fundecl
-  ++ pass_dump_if ppf dump_split "After live range splitting"
+  ++ pass_dump_if ppf_dump dump_split "After live range splitting"
   ++ Profile.record ~accumulate:true "liveness" liveness
-  ++ Profile.record ~accumulate:true "regalloc" (regalloc ppf 1)
+  ++ Profile.record ~accumulate:true "regalloc" (regalloc ~ppf_dump 1)
   ++ Profile.record ~accumulate:true "available_regs" Available_regs.fundecl
   ++ Profile.record ~accumulate:true "linearize" Linearize.fundecl
-  ++ pass_dump_linear_if ppf dump_linear "Linearized code"
+  ++ pass_dump_linear_if ppf_dump dump_linear "Linearized code"
   ++ Profile.record ~accumulate:true "scheduling" Scheduling.fundecl
-  ++ pass_dump_linear_if ppf dump_scheduling "After instruction scheduling"
+  ++ pass_dump_linear_if ppf_dump dump_scheduling "After instruction scheduling"
   ++ Profile.record ~accumulate:true "emit" Emit.fundecl
 
-let compile_phrase ppf p =
-  if !dump_cmm then fprintf ppf "%a@." Printcmm.phrase p;
+let compile_phrase ~ppf_dump p =
+  if !dump_cmm then fprintf ppf_dump "%a@." Printcmm.phrase p;
   match p with
-  | Cfunction fd -> compile_fundecl ppf fd
+  | Cfunction fd -> compile_fundecl ~ppf_dump fd
   | Cdata dl -> Emit.data dl
 
 
 (* For the native toplevel: generates generic functions unless
    they are already available in the process *)
-let compile_genfuns ppf f =
+let compile_genfuns ~ppf_dump f =
   List.iter
     (function
        | (Cfunction {fun_name = name}) as ph when f name ->
-           compile_phrase ppf ph
+           compile_phrase ~ppf_dump ph
        | _ -> ())
     (Cmmgen.generic_functions true [Compilenv.current_unit_infos ()])
 
@@ -170,14 +170,14 @@ let set_export_info (ulambda, prealloc, structured_constants, export) =
   Compilenv.set_export_info export;
   (ulambda, prealloc, structured_constants)
 
-let end_gen_implementation ?toplevel ppf
+let end_gen_implementation ?toplevel ~ppf_dump
     (clambda:clambda_and_constants) =
   Emit.begin_assembly ();
   clambda
-  ++ Profile.record "cmm" Cmmgen.compunit
-  ++ Profile.record "compile_phrases" (List.iter (compile_phrase ppf))
+  ++ Profile.record "cmm" (Cmmgen.compunit ~ppf_dump)
+  ++ Profile.record "compile_phrases" (List.iter (compile_phrase ~ppf_dump))
   ++ (fun () -> ());
-  (match toplevel with None -> () | Some f -> compile_genfuns ppf f);
+  (match toplevel with None -> () | Some f -> compile_genfuns ~ppf_dump f);
 
   (* We add explicit references to external primitive symbols.  This
      is to ensure that the object files that define these symbols,
@@ -185,26 +185,26 @@ let end_gen_implementation ?toplevel ppf
      This is important if a module that uses such a symbol is later
      dynlinked. *)
 
-  compile_phrase ppf
+  compile_phrase ~ppf_dump
     (Cmmgen.reference_symbols
        (List.filter (fun s -> s <> "" && s.[0] <> '%')
           (List.map Primitive.native_name !Translmod.primitive_declarations))
     );
   Emit.end_assembly ()
 
-let flambda_gen_implementation ?toplevel ~backend ppf
+let flambda_gen_implementation ?toplevel ~backend ~ppf_dump
     (program:Flambda.program) =
   let export = Build_export_info.build_transient ~backend program in
   let (clambda, preallocated, constants) =
     Profile.record_call "backend" (fun () ->
       (program, export)
       ++ Flambda_to_clambda.convert
-      ++ flambda_raw_clambda_dump_if ppf
+      ++ flambda_raw_clambda_dump_if ppf_dump
       ++ (fun { Flambda_to_clambda. expr; preallocated_blocks;
                 structured_constants; exported; } ->
              (* "init_code" following the name used in
                 [Cmmgen.compunit_and_constants]. *)
-           Un_anf.apply expr ~what:"init_code", preallocated_blocks,
+           Un_anf.apply ~ppf_dump expr ~what:"init_code", preallocated_blocks,
            structured_constants, exported)
       ++ set_export_info)
   in
@@ -215,10 +215,10 @@ let flambda_gen_implementation ?toplevel ~backend ppf
           definition })
       (Symbol.Map.bindings constants)
   in
-  end_gen_implementation ?toplevel ppf
+  end_gen_implementation ?toplevel ~ppf_dump
     (clambda, preallocated, constants)
 
-let lambda_gen_implementation ?toplevel ppf
+let lambda_gen_implementation ?toplevel ~ppf_dump
     (lambda:Lambda.program) =
   let clambda = Closure.intro lambda.main_module_block_size lambda.code in
   let preallocated_block =
@@ -232,11 +232,11 @@ let lambda_gen_implementation ?toplevel ppf
   let clambda_and_constants =
     clambda, [preallocated_block], []
   in
-  raw_clambda_dump_if ppf clambda_and_constants;
-  end_gen_implementation ?toplevel ppf clambda_and_constants
+  raw_clambda_dump_if ppf_dump clambda_and_constants;
+  end_gen_implementation ?toplevel ~ppf_dump clambda_and_constants
 
 let compile_implementation_gen ?toplevel prefixname
-    ~required_globals ppf gen_implementation program =
+    ~required_globals ~ppf_dump gen_implementation program =
   let asmfile =
     if !keep_asm_file || !Emitaux.binary_backend_available
     then prefixname ^ ext_asm
@@ -245,18 +245,18 @@ let compile_implementation_gen ?toplevel prefixname
   compile_unit prefixname asmfile !keep_asm_file
       (prefixname ^ ext_obj) (fun () ->
         Ident.Set.iter Compilenv.require_global required_globals;
-        gen_implementation ?toplevel ppf program)
+        gen_implementation ?toplevel ~ppf_dump program)
 
 let compile_implementation_clambda ?toplevel prefixname
-    ppf (program:Lambda.program) =
+    ~ppf_dump (program:Lambda.program) =
   compile_implementation_gen ?toplevel prefixname
     ~required_globals:program.Lambda.required_globals
-    ppf lambda_gen_implementation program
+    ~ppf_dump lambda_gen_implementation program
 
 let compile_implementation_flambda ?toplevel prefixname
-    ~required_globals ~backend ppf (program:Flambda.program) =
+    ~required_globals ~backend ~ppf_dump (program:Flambda.program) =
   compile_implementation_gen ?toplevel prefixname
-    ~required_globals ppf (flambda_gen_implementation ~backend) program
+    ~required_globals ~ppf_dump (flambda_gen_implementation ~backend) program
 
 (* Error report *)
 

--- a/asmcomp/asmgen.mli
+++ b/asmcomp/asmgen.mli
@@ -20,15 +20,15 @@ val compile_implementation_flambda :
     string ->
     required_globals:Ident.Set.t ->
     backend:(module Backend_intf.S) ->
-    Format.formatter -> Flambda.program -> unit
+    ppf_dump:Format.formatter -> Flambda.program -> unit
 
 val compile_implementation_clambda :
     ?toplevel:(string -> bool) ->
     string ->
-    Format.formatter -> Lambda.program -> unit
+    ppf_dump:Format.formatter -> Lambda.program -> unit
 
 val compile_phrase :
-    Format.formatter -> Cmm.phrase -> unit
+    ppf_dump:Format.formatter -> Cmm.phrase -> unit
 
 type error = Assembler_error of string
 exception Error of error

--- a/asmcomp/asmlink.mli
+++ b/asmcomp/asmlink.mli
@@ -17,9 +17,9 @@
 
 open Format
 
-val link: formatter -> string list -> string -> unit
+val link: ppf_dump:formatter -> string list -> string -> unit
 
-val link_shared: formatter -> string list -> string -> unit
+val link_shared: ppf_dump:formatter -> string list -> string -> unit
 
 val call_linker_shared: string list -> string -> unit
 

--- a/asmcomp/asmpackager.mli
+++ b/asmcomp/asmpackager.mli
@@ -17,7 +17,7 @@
    original compilation units as sub-modules. *)
 
 val package_files
-   : Format.formatter
+   : ppf_dump:Format.formatter
   -> Env.t
   -> string list
   -> string

--- a/asmcomp/cmmgen.mli
+++ b/asmcomp/cmmgen.mli
@@ -16,7 +16,8 @@
 (* Translation from closed lambda to C-- *)
 
 val compunit:
-    Clambda.ulambda
+  ppf_dump:Format.formatter
+  -> Clambda.ulambda
     * Clambda.preallocated_block list
     * Clambda.preallocated_constant list
   -> Cmm.phrase list

--- a/asmcomp/un_anf.ml
+++ b/asmcomp/un_anf.ml
@@ -734,7 +734,7 @@ and un_anf_list ident_info env clams : Clambda.ulambda list =
 and un_anf_array ident_info env clams : Clambda.ulambda array =
   Array.map (un_anf ident_info env) clams
 
-let apply clam ~what =
+let apply ~ppf_dump clam ~what =
   let ident_info = make_ident_info clam in
   let let_bound_vars_that_can_be_moved =
     let_bound_vars_that_can_be_moved ident_info clam
@@ -746,6 +746,7 @@ let apply clam ~what =
   let ident_info = make_ident_info clam in
   let clam = un_anf ident_info Ident.Map.empty clam in
   if !Clflags.dump_clambda then begin
-    Format.eprintf "@.un-anf (%s):@ %a@." what Printclambda.clambda clam
+    Format.fprintf ppf_dump
+      "@.un-anf (%s):@ %a@." what Printclambda.clambda clam
   end;
   clam

--- a/asmcomp/un_anf.mli
+++ b/asmcomp/un_anf.mli
@@ -17,6 +17,7 @@
 (** Expand ANF-like constructs so that pattern matches in [Cmmgen] will
     work correctly. *)
 val apply
-   : Clambda.ulambda
+  : ppf_dump:Format.formatter
+  -> Clambda.ulambda
   -> what:string
   -> Clambda.ulambda

--- a/bytecomp/bytepackager.mli
+++ b/bytecomp/bytepackager.mli
@@ -16,7 +16,8 @@
 (* "Package" a set of .cmo files into one .cmo file having the
    original compilation units as sub-modules. *)
 
-val package_files: Env.t -> string list -> string -> unit
+val package_files:
+  ppf_dump:Format.formatter -> Env.t -> string list -> string -> unit
 
 type error =
     Forward_reference of string * Ident.t

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -76,13 +76,13 @@ let is_unit_name name =
   with Exit -> false
 ;;
 
-let check_unit_name ppf filename name =
+let check_unit_name filename name =
   if not (is_unit_name name) then
-    Location.print_warning (Location.in_file filename) ppf
+    Location.prerr_warning (Location.in_file filename)
       (Warnings.Bad_module_name name);;
 
 (* Compute name of module from output file name *)
-let module_of_filename ppf inputfile outputprefix =
+let module_of_filename inputfile outputprefix =
   let basename = Filename.basename outputprefix in
   let name =
     try
@@ -91,7 +91,7 @@ let module_of_filename ppf inputfile outputprefix =
     with Not_found -> basename
   in
   let name = String.capitalize_ascii name in
-  check_unit_name ppf inputfile name;
+  check_unit_name inputfile name;
   name
 ;;
 
@@ -576,12 +576,12 @@ let process_action
   | ProcessImplementation name ->
       readenv ppf (Before_compile name);
       let opref = output_prefix name in
-      implementation ppf name opref;
+      implementation name opref;
       objfiles := (opref ^ ocaml_mod_ext) :: !objfiles
   | ProcessInterface name ->
       readenv ppf (Before_compile name);
       let opref = output_prefix name in
-      interface ppf name opref;
+      interface name opref;
       if !make_package then objfiles := (opref ^ ".cmi") :: !objfiles
   | ProcessCFile name ->
       readenv ppf (Before_compile name);

--- a/driver/compenv.mli
+++ b/driver/compenv.mli
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val module_of_filename : Format.formatter -> string -> string -> string
+val module_of_filename : string -> string -> string
 
 val output_prefix : string -> string
 val extract_output : string option -> string
@@ -49,7 +49,7 @@ val readenv : Format.formatter -> readenv_position -> unit
 val is_unit_name : string -> bool
 (* [check_unit_name ppf filename name] prints a warning in [filename]
    on [ppf] if [name] should not be used as a module name. *)
-val check_unit_name : Format.formatter -> string -> string -> unit
+val check_unit_name : string -> string -> unit
 
 (* Deferred actions of the compiler, while parsing arguments *)
 
@@ -70,8 +70,8 @@ val intf : string -> unit
 
 val process_deferred_actions :
   Format.formatter *
-  (Format.formatter -> string -> string -> unit) * (* compile implementation *)
-  (Format.formatter -> string -> string -> unit) * (* compile interface *)
+  (string -> string -> unit) * (* compile implementation *)
+  (string -> string -> unit) * (* compile interface *)
   string * (* ocaml module extension *)
   string -> (* ocaml library extension *)
   unit

--- a/driver/compile.mli
+++ b/driver/compile.mli
@@ -15,7 +15,5 @@
 
 (* Compile a .ml or .mli file *)
 
-open Format
-
-val interface: formatter -> string -> string -> unit
-val implementation: formatter -> string -> string -> unit
+val interface: string -> string -> unit
+val implementation: string -> string -> unit

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -70,3 +70,17 @@ let read_color_env () =
       | Some _ -> ()
   with
     Not_found -> ()
+
+let with_ppf_dump ~fileprefix f =
+  let ppf_dump, finally =
+    if not !Clflags.dump_into_file
+    then Format.err_formatter, ignore
+    else
+       let ch = open_out (fileprefix ^ ".dump") in
+       let ppf = Format.formatter_of_out_channel ch in
+       ppf,
+       (fun () ->
+         Format.pp_print_flush ppf ();
+         close_out ch)
+  in
+  Misc.try_finally (fun () -> f ppf_dump) ~always:finally

--- a/driver/compmisc.mli
+++ b/driver/compmisc.mli
@@ -17,3 +17,5 @@ val init_path : ?dir:string -> bool -> unit
 val initial_env : unit -> Env.t
 
 val read_color_env : unit -> unit
+
+val with_ppf_dump : fileprefix:string -> (Format.formatter -> unit) -> unit

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -614,6 +614,10 @@ let mk_use_prims f =
   "-use-prims", Arg.String f, "<file>  (undocumented)"
 ;;
 
+let mk_dump_into_file f =
+  "-dump-into-file", Arg.Unit f, " dump output like -dlambda into <target>.dump"
+;;
+
 let mk_dparsetree f =
   "-dparsetree", Arg.Unit f, " (undocumented)"
 ;;
@@ -895,6 +899,7 @@ module type Compiler_options = sig
   val _match_context_rows : int -> unit
   val _dtimings : unit -> unit
   val _dprofile : unit -> unit
+  val _dump_into_file : unit -> unit
 
   val _args: string -> string array
   val _args0: string -> string array
@@ -1131,6 +1136,7 @@ struct
     mk_dcamlprimc F._dcamlprimc;
     mk_dtimings F._dtimings;
     mk_dprofile F._dprofile;
+    mk_dump_into_file F._dump_into_file;
 
     mk_args F._args;
     mk_args0 F._args0;
@@ -1333,6 +1339,7 @@ struct
     mk_dstartup F._dstartup;
     mk_dtimings F._dtimings;
     mk_dprofile F._dprofile;
+    mk_dump_into_file F._dump_into_file;
     mk_dump_pass F._dump_pass;
 
     mk_args F._args;

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -105,6 +105,7 @@ module type Compiler_options = sig
   val _match_context_rows : int -> unit
   val _dtimings : unit -> unit
   val _dprofile : unit -> unit
+  val _dump_into_file : unit -> unit
 
   val _args: string -> string array
   val _args0: string -> string array

--- a/driver/optcompile.mli
+++ b/driver/optcompile.mli
@@ -15,13 +15,10 @@
 
 (* Compile a .ml or .mli file *)
 
-open Format
-
-val interface: formatter -> string -> string -> unit
+val interface: string -> string -> unit
 
 val implementation:
    backend:(module Backend_intf.S)
-   -> formatter
   -> string
   -> string
   -> unit

--- a/driver/optmain.ml
+++ b/driver/optmain.ml
@@ -192,6 +192,7 @@ module Options = Main_args.Make_optcomp_options (struct
 
   let _nopervasives = set nopervasives
   let _match_context_rows n = match_context_rows := n
+  let _dump_into_file = set dump_into_file
   let _dno_unique_ids = clear unique_ids
   let _dunique_ids = set unique_ids
   let _dsource = set dump_source
@@ -270,24 +271,29 @@ let main () =
                      [make_package; make_archive; shared;
                       compile_only; output_c_object]) > 1
     then
-      fatal "Please specify at most one of -pack, -a, -shared, -c, -output-obj";
+      fatal "Please specify at most one of -pack, -a, -shared, -c, \
+             -output-obj";
     if !make_archive then begin
       Compmisc.init_path true;
       let target = extract_output !output_name in
-      Asmlibrarian.create_archive (get_objfiles ~with_ocamlparam:false) target;
+      Asmlibrarian.create_archive
+        (get_objfiles ~with_ocamlparam:false) target;
       Warnings.check_fatal ();
     end
     else if !make_package then begin
       Compmisc.init_path true;
       let target = extract_output !output_name in
-      Asmpackager.package_files ppf (Compmisc.initial_env ())
-        (get_objfiles ~with_ocamlparam:false) target ~backend;
+      Compmisc.with_ppf_dump ~fileprefix:target (fun ppf_dump ->
+        Asmpackager.package_files ~ppf_dump (Compmisc.initial_env ())
+          (get_objfiles ~with_ocamlparam:false) target ~backend);
       Warnings.check_fatal ();
     end
     else if !shared then begin
       Compmisc.init_path true;
       let target = extract_output !output_name in
-      Asmlink.link_shared ppf (get_objfiles ~with_ocamlparam:false) target;
+      Compmisc.with_ppf_dump ~fileprefix:target (fun ppf_dump ->
+        Asmlink.link_shared ~ppf_dump
+          (get_objfiles ~with_ocamlparam:false) target);
       Warnings.check_fatal ();
     end
     else if not !compile_only && !objfiles <> [] then begin
@@ -307,7 +313,8 @@ let main () =
           default_output !output_name
       in
       Compmisc.init_path true;
-      Asmlink.link ppf (get_objfiles ~with_ocamlparam:true) target;
+      Compmisc.with_ppf_dump ~fileprefix:target (fun ppf_dump ->
+        Asmlink.link ~ppf_dump (get_objfiles ~with_ocamlparam:true) target);
       Warnings.check_fatal ();
     end;
   with x ->

--- a/middle_end/augment_specialised_args.ml
+++ b/middle_end/augment_specialised_args.ml
@@ -752,7 +752,8 @@ module Make (T : S) = struct
       Some (expr, benefit)
 
   let rewrite_set_of_closures ~env ~duplicate_function ~set_of_closures =
-    Pass_wrapper.with_dump ~pass_name:T.pass_name ~input:set_of_closures
+    Pass_wrapper.with_dump ~ppf_dump:(Inline_and_simplify_aux.Env.ppf_dump env)
+      ~pass_name:T.pass_name ~input:set_of_closures
       ~print_input:Flambda.print_set_of_closures
       ~print_output:(fun ppf (expr, _) -> Flambda.print ppf expr)
       ~f:(fun () ->

--- a/middle_end/inline_and_simplify.ml
+++ b/middle_end/inline_and_simplify.ml
@@ -937,7 +937,8 @@ and simplify_named env r (tree : Flambda.named) : Flambda.named * R.t =
        the [Unbox_closures] output, this also prevents applying
        [Unbox_closures] over and over.) *)
     let set_of_closures =
-      match Remove_free_vars_equal_to_args.run set_of_closures with
+      let ppf_dump = Inline_and_simplify_aux.Env.ppf_dump env in
+      match Remove_free_vars_equal_to_args.run ~ppf_dump set_of_closures with
       | None -> set_of_closures
       | Some set_of_closures -> set_of_closures
     in
@@ -1678,13 +1679,13 @@ let add_predef_exns_to_environment ~env ~backend =
     env
     Predef.all_predef_exns
 
-let run ~never_inline ~backend ~prefixname ~round program =
+let run ~never_inline ~backend ~prefixname ~round ~ppf_dump program =
   let r = R.create () in
   let report = !Clflags.inlining_report in
   if never_inline then Clflags.inlining_report := false;
   let initial_env =
     add_predef_exns_to_environment
-      ~env:(E.create ~never_inline ~backend ~round)
+      ~env:(E.create ~never_inline ~backend ~round ~ppf_dump)
       ~backend
   in
   let result, r = simplify_program initial_env r program in

--- a/middle_end/inline_and_simplify.mli
+++ b/middle_end/inline_and_simplify.mli
@@ -27,6 +27,7 @@ val run
   -> backend:(module Backend_intf.S)
   -> prefixname:string
   -> round:int
+  -> ppf_dump:Format.formatter
   -> Flambda.program
   -> Flambda.program
 

--- a/middle_end/inline_and_simplify_aux.ml
+++ b/middle_end/inline_and_simplify_aux.ml
@@ -23,6 +23,7 @@ module Env = struct
   type t = {
     backend : (module Backend_intf.S);
     round : int;
+    ppf_dump : Format.formatter;
     approx : (scope * Simple_value_approx.t) Variable.Map.t;
     approx_mutable : Simple_value_approx.t Mutable_variable.Map.t;
     approx_sym : Simple_value_approx.t Symbol.Map.t;
@@ -45,9 +46,10 @@ module Env = struct
     inlined_debuginfo : Debuginfo.t;
   }
 
-  let create ~never_inline ~backend ~round =
+  let create ~never_inline ~backend ~round ~ppf_dump =
     { backend;
       round;
+      ppf_dump;
       approx = Variable.Map.empty;
       approx_mutable = Mutable_variable.Map.empty;
       approx_sym = Symbol.Map.empty;
@@ -70,6 +72,7 @@ module Env = struct
 
   let backend t = t.backend
   let round t = t.round
+  let ppf_dump t = t.ppf_dump
 
   let local env =
     { env with

--- a/middle_end/inline_and_simplify_aux.mli
+++ b/middle_end/inline_and_simplify_aux.mli
@@ -33,6 +33,7 @@ module Env : sig
      : never_inline:bool
     -> backend:(module Backend_intf.S)
     -> round:int
+    -> ppf_dump:Format.formatter
     -> t
 
   (** Obtain the first-class module that gives information about the
@@ -46,6 +47,9 @@ module Env : sig
 
   (** Which simplification round we are currently in. *)
   val round : t -> int
+
+  (** Where to print intermediate asts and similar debug information *)
+  val ppf_dump : t -> Format.formatter
 
   (** Add the approximation of a variable---that is to say, some knowledge
       about the value(s) the variable may take on at runtime---to the

--- a/middle_end/middle_end.mli
+++ b/middle_end/middle_end.mli
@@ -19,7 +19,7 @@
 (* Translate Lambda code to Flambda code and then optimize it. *)
 
 val middle_end
-   : Format.formatter
+   : ppf_dump:Format.formatter
   -> prefixname:string
   -> backend:(module Backend_intf.S)
   -> size:int

--- a/middle_end/pass_wrapper.ml
+++ b/middle_end/pass_wrapper.ml
@@ -20,16 +20,16 @@ open! Int_replace_polymorphic_compare
 let register ~pass_name =
   Clflags.all_passes := pass_name :: !Clflags.all_passes
 
-let with_dump ~pass_name ~f ~input ~print_input ~print_output =
+let with_dump ~ppf_dump ~pass_name ~f ~input ~print_input ~print_output =
   let dump = Clflags.dumped_pass pass_name in
   let result = f () in
   match result with
   | None ->
-    if dump then Format.eprintf "%s: no-op.\n\n%!" pass_name;
+    if dump then Format.fprintf ppf_dump "%s: no-op.\n\n%!" pass_name;
     None
   | Some result ->
     if dump then begin
-      Format.eprintf "Before %s:@ %a@.@." pass_name print_input input;
-      Format.eprintf "After %s:@ %a@.@." pass_name print_output result
+      Format.fprintf ppf_dump "Before %s:@ %a@.@." pass_name print_input input;
+      Format.fprintf ppf_dump "After %s:@ %a@.@." pass_name print_output result;
     end;
     Some result

--- a/middle_end/pass_wrapper.mli
+++ b/middle_end/pass_wrapper.mli
@@ -17,7 +17,8 @@
 val register : pass_name:string -> unit
 
 val with_dump
-   : pass_name:string
+   : ppf_dump:Format.formatter
+  -> pass_name:string
   -> f:(unit -> 'b option)
   -> input:'a
   -> print_input:(Format.formatter -> 'a -> unit)

--- a/middle_end/remove_free_vars_equal_to_args.ml
+++ b/middle_end/remove_free_vars_equal_to_args.ml
@@ -92,8 +92,8 @@ let rewrite_one_set_of_closures (set_of_closures : Flambda.set_of_closures) =
     in
     Some set_of_closures
 
-let run set_of_closures =
-  Pass_wrapper.with_dump ~pass_name ~input:set_of_closures
+let run ~ppf_dump set_of_closures =
+  Pass_wrapper.with_dump ~ppf_dump ~pass_name ~input:set_of_closures
     ~print_input:Flambda.print_set_of_closures
     ~print_output:Flambda.print_set_of_closures
     ~f:(fun () -> rewrite_one_set_of_closures set_of_closures)

--- a/middle_end/remove_free_vars_equal_to_args.mli
+++ b/middle_end/remove_free_vars_equal_to_args.mli
@@ -17,4 +17,7 @@
 (** Replace free variables in closures known to be equal to specialised
     arguments of such closures with those specialised arguments. *)
 
-val run : Flambda.set_of_closures -> Flambda.set_of_closures option
+val run
+  : ppf_dump:Format.formatter
+  -> Flambda.set_of_closures
+  -> Flambda.set_of_closures option

--- a/middle_end/unbox_free_vars_of_closures.ml
+++ b/middle_end/unbox_free_vars_of_closures.ml
@@ -163,7 +163,8 @@ let run ~env ~(set_of_closures : Flambda.set_of_closures) =
         Some (expr, benefit)
 
 let run ~env ~set_of_closures =
-  Pass_wrapper.with_dump ~pass_name ~input:set_of_closures
+  Pass_wrapper.with_dump ~ppf_dump:(Inline_and_simplify_aux.Env.ppf_dump env)
+    ~pass_name ~input:set_of_closures
     ~print_input:Flambda.print_set_of_closures
     ~print_output:(fun ppf (expr, _) -> Flambda.print ppf expr)
     ~f:(fun () -> run ~env ~set_of_closures)

--- a/testsuite/tools/codegen_main.ml
+++ b/testsuite/tools/codegen_main.ml
@@ -28,8 +28,8 @@ let compile_file filename =
   lb.Lexing.lex_curr_p <- { lb.Lexing.lex_curr_p with pos_fname = filename };
   try
     while true do
-      Asmgen.compile_phrase Format.std_formatter
-                            (Parsecmm.phrase Lexcmm.token lb)
+      Asmgen.compile_phrase ~ppf_dump:Format.std_formatter
+        (Parsecmm.phrase Lexcmm.token lb)
     done
   with
       End_of_file ->

--- a/tools/ocamlcp.ml
+++ b/tools/ocamlcp.ml
@@ -123,6 +123,7 @@ module Options = Main_args.Make_bytecomp_options (struct
   let _where = option "-where"
   let _nopervasives = option "-nopervasives"
   let _match_context_rows n = option_with_int "-match-context-rows" n
+  let _dump_into_file = option "-dump-into-file"
   let _dno_unique_ids = option "-dno-unique-ids"
   let _dunique_ids = option "-dunique-ids"
   let _dsource = option "-dsource"

--- a/tools/ocamloptp.ml
+++ b/tools/ocamloptp.ml
@@ -148,6 +148,7 @@ module Options = Main_args.Make_optcomp_options (struct
   let _linscan = option "-linscan"
   let _nopervasives = option "-nopervasives"
   let _match_context_rows n = option_with_int "-match-context-rows" n
+  let _dump_into_file = option "-dump-into-file"
   let _dno_unique_ids = option "-dno-unique_ids"
   let _dunique_ids = option "-dunique_ids"
   let _dsource = option "-dsource"

--- a/toplevel/opttopdirs.ml
+++ b/toplevel/opttopdirs.ml
@@ -72,7 +72,7 @@ let load_file ppf name0 =
       if Filename.check_suffix name ".cmx" || Filename.check_suffix name ".cmxa"
       then
         let cmxs = Filename.temp_file "caml" ".cmxs" in
-        Asmlink.link_shared ppf [name] cmxs;
+        Asmlink.link_shared ~ppf_dump:ppf [name] cmxs;
         cmxs,true
       else
         name,false

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -221,13 +221,13 @@ let load_lambda ppf ~module_ident ~required_globals lam size =
   let fn = Filename.chop_extension dll in
   if not Config.flambda then
     Asmgen.compile_implementation_clambda
-      ~toplevel:need_symbol fn ppf
+      ~toplevel:need_symbol fn ~ppf_dump:ppf
       { Lambda.code=slam ; main_module_block_size=size;
         module_ident; required_globals }
   else
     Asmgen.compile_implementation_flambda
-      ~required_globals ~backend ~toplevel:need_symbol fn ppf
-      (Middle_end.middle_end ppf ~prefixname:"" ~backend ~size
+      ~required_globals ~backend ~toplevel:need_symbol fn ~ppf_dump:ppf
+      (Middle_end.middle_end ~ppf_dump:ppf ~prefixname:"" ~backend ~size
          ~module_ident ~module_initializer:slam ~filename:"toplevel");
   Asmlink.call_linker_shared [fn ^ ext_obj] dll;
   Sys.remove (fn ^ ext_obj);

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -365,6 +365,8 @@ let set_dumped_pass s enabled =
     dumped_passes_list := dumped_passes
   end
 
+let dump_into_file = ref false (* -dump-into-file *)
+
 let parse_color_setting = function
   | "auto" -> Some Misc.Color.Auto
   | "always" -> Some Misc.Color.Always

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -210,6 +210,8 @@ val all_passes : string list ref
 val dumped_pass : string -> bool
 val set_dumped_pass : string -> bool -> unit
 
+val dump_into_file : bool ref
+
 val parse_color_setting : string -> Misc.Color.setting option
 val color : Misc.Color.setting option ref
 


### PR DESCRIPTION
Right now, -dlambda, -dcmm, -dlive and all such debug flags cause the compiler to write to stderr. This works fine when running the compiler by hand, but when using a build system, it's usually easier or more convenient to change flags for a bunch of files at once, at which point the printing to stderr isn't so nice. 

So I propose the addition of a flag -dintofile that makes the compiler write all such output into a file `<compilation-unit>.mldump`, or `<exe>.mldump` depending on what is being built.

I initially had the command line take the filename to write into, but I think it's preferable to have the compiler choose it, similar to `ocamlopt -S`. It's simpler for the build system, simpler to setup editor modes if needed.

Implementation-wise, many files are touched, but the changes are simple: the debug output already goes into this `ppf` argument being passed around, so I rename it to `~ppf_dump`to clarify the intended use of the formatter (and avoid people starting using it to print errors).
Then I grepped for Clflags.dump to see if I was missing some flags, and found some prints directly on stderr, which I made use this `ppf_dump`.
I had a previous version where the formatter was in a global variable (as is traditional), but I think passing the formatter around is better because it's clear when we do and don't need to provide such a formatter.