### PR TITLE
rec_check.ml: fix a bug in recursive class declarations check.

### DIFF
--- a/Changes
+++ b/Changes
@@ -287,6 +287,9 @@ OCaml 4.07 maintenance branch
 - MPR#7824, GPR#1914: subtype_row: filter out absent fields when row is closed
   (Leo White and Thomas Refis, report by talex, review by Jacques Garrigue)
 
+- GPR#1915: rec_check.ml is too permissive for certain class declarations.
+  (Alban Reynaud with Gabriel Scherer, review by Jeremy Yallop)
+
 OCaml 4.07.0 (10 July 2018)
 ---------------------------
 

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -886,3 +886,33 @@ Line 1, characters 10-37:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of recursive class expression is not allowed
 |}];;
+
+(* More tests about recursion in class declarations *)
+class a = let _x() = new a in object end;;
+[%%expect{|
+class a : object  end
+|}];;
+
+class a = object end
+and b = let _x() = new a in object end;;
+[%%expect{|
+class a : object  end
+and b : object  end
+|}];;
+
+class a = let x() = new a in let y = x() in object end;;
+[%%expect{|
+Line 1, characters 10-54:
+  class a = let x() = new a in let y = x() in object end;;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This kind of recursive class expression is not allowed
+|}];;
+
+class a = object end
+and b = let x() = new a in let y = x() in object end;;
+[%%expect{|
+Line 2, characters 8-52:
+  and b = let x() = new a in let y = x() in object end;;
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This kind of recursive class expression is not allowed
+|}];;

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -716,8 +716,14 @@ let is_valid_class_expr idlist ce =
       | Tcl_fun (_, _, _, _, _) -> Use.empty
       | Tcl_apply (_, _) -> Use.empty
       | Tcl_let (rec_flag, valbinds, _, ce) ->
-          let _, ty = value_bindings rec_flag env valbinds in
-          Use.join ty (class_expr env ce)
+          (* This rule looks like the `Texp_let` rule in the `expression`
+             function. There is no `Use.discard` here because the
+             occurrences of the variables in [idlist] are only of the form
+             [new id], so they are either absent, Dereferenced, or Guarded
+             (under a delay), never Unguarded, and `discard` would be a no-op.
+          *)
+          let env', ty = value_bindings rec_flag env valbinds in
+          Use.join ty (class_expr env' ce)
       | Tcl_constraint (ce, _, _, _, _) ->
           class_expr env ce
       | Tcl_open (_, _, _, _, ce) ->


### PR DESCRIPTION
    # class a = let x() = new a in let y = x() in object end;;
    Warning 26: unused variable y.
    Segmentation fault (core dumped)