### PR TITLE
ocamltest: support for ppx

### DIFF
--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -39,8 +39,8 @@ let modules env =
 let plugins env =
   Actions_helpers.words_of_variable env Ocaml_variables.plugins
 
-let ppxs env =
-  Actions_helpers.words_of_variable env Ocaml_variables.ppxs
+let ppx env =
+  Actions_helpers.words_of_variable env Ocaml_variables.ppx
 
 let directories env =
   Actions_helpers.words_of_variable env Ocaml_variables.directories
@@ -224,7 +224,7 @@ let compile_ppx ocamlsrcdir ppx log env =
   end
 
 
-let compile_ppxs =
+let compile_ppx =
   let single ocamlsrcdir log status ppx  =
     match status with
     | Error _ as e -> e
@@ -236,9 +236,9 @@ let compile_ppxs =
         Ok (Environments.append Ocaml_variables.flags (" -ppx " ^ ppx) env)
       else Error r in
 
-  Actions.make "compile-ppxs" (fun log env ->
+  Actions.make "compile-ppx" (fun log env ->
     let ocamlsrcdir = Ocaml_directories.srcdir () in
-    let ppxs = ppxs env in
+    let ppxs = ppx env in
     match List.fold_left (single ocamlsrcdir log) (Ok env) ppxs with
     | Error r -> r, env
     | Ok env -> Result.pass, env
@@ -394,7 +394,7 @@ let setup_tool_build_env tool log env =
   in
   let source_modules =
     Actions_helpers.words_of_variable env Ocaml_variables.all_modules in
-  let ppxs = ppxs env in
+  let ppx = ppx env in
   let tool_directory_suffix =
     Environments.safe_lookup Ocaml_variables.compiler_directory_suffix env in
   let tool_directory_name =
@@ -417,12 +417,12 @@ let setup_tool_build_env tool log env =
   Sys.force_remove tool_output_file;
   let env =
     Environments.add Builtin_variables.test_build_directory build_dir env in
-  Actions_helpers.setup_build_env false (ppxs @ source_modules) log env
+  Actions_helpers.setup_build_env false (ppx @ source_modules) log env
 
-let setup_simple_build_env_with_ppxs =
-  Actions.make "setup-simple-build-env-with-ppxs" (fun log env ->
-      let ppxs = ppxs env in
-      Actions_helpers.setup_simple_build_env true ppxs log env
+let setup_simple_build_env_with_ppx =
+  Actions.make "setup-simple-build-env-with-ppx" (fun log env ->
+      let ppx = ppx env in
+      Actions_helpers.setup_simple_build_env true ppx log env
     )
 
 let setup_compiler_build_env (compiler : Ocaml_compilers.compiler) log env =
@@ -1387,9 +1387,9 @@ let _ =
     setup_ocamlopt_opt_build_env;
     ocamlopt_opt;
     check_ocamlopt_opt_output;
-    compile_ppxs;
+    compile_ppx;
     run_expect;
-    setup_simple_build_env_with_ppxs;
+    setup_simple_build_env_with_ppx;
     compare_bytecode_programs;
     compare_native_programs;
     setup_ocaml_build_env;

--- a/ocamltest/ocaml_actions.mli
+++ b/ocamltest/ocaml_actions.mli
@@ -28,6 +28,7 @@ val setup_ocamlopt_opt_build_env : Actions.t
 val ocamlopt_opt : Actions.t
 val check_ocamlopt_opt_output : Actions.t
 val run_expect : Actions.t
+val setup_simple_build_env_with_ppxs: Actions.t
 val compare_bytecode_programs : Actions.t
 val compare_native_programs : Actions.t
 val setup_ocaml_build_env : Actions.t
@@ -54,3 +55,4 @@ val no_afl_instrument : Actions.t
 val codegen : Actions.t
 
 val cc : Actions.t
+val compile_ppxs: Actions.t

--- a/ocamltest/ocaml_actions.mli
+++ b/ocamltest/ocaml_actions.mli
@@ -28,7 +28,7 @@ val setup_ocamlopt_opt_build_env : Actions.t
 val ocamlopt_opt : Actions.t
 val check_ocamlopt_opt_output : Actions.t
 val run_expect : Actions.t
-val setup_simple_build_env_with_ppxs: Actions.t
+val setup_simple_build_env_with_ppx: Actions.t
 val compare_bytecode_programs : Actions.t
 val compare_native_programs : Actions.t
 val setup_ocaml_build_env : Actions.t
@@ -55,4 +55,4 @@ val no_afl_instrument : Actions.t
 val codegen : Actions.t
 
 val cc : Actions.t
-val compile_ppxs: Actions.t
+val compile_ppx: Actions.t

--- a/ocamltest/ocaml_tests.ml
+++ b/ocamltest/ocaml_tests.ml
@@ -33,7 +33,7 @@ let bytecode =
   test_actions =
   [
     setup_ocamlc_byte_build_env;
-    compile_ppxs;
+    compile_ppx;
     ocamlc_byte;
     check_ocamlc_byte_output;
     run;
@@ -45,7 +45,7 @@ let native =
   let opt_actions =
   [
     setup_ocamlopt_byte_build_env;
-    compile_ppxs;
+    compile_ppx;
     ocamlopt_byte;
     check_ocamlopt_byte_output;
     run;
@@ -68,7 +68,7 @@ let toplevel = {
   test_actions =
   [
     setup_ocaml_build_env;
-    compile_ppxs;
+    compile_ppx;
     ocaml;
     check_ocaml_output;
 (*
@@ -85,8 +85,8 @@ let expect =
   test_run_by_default = false;
   test_actions =
   [
-    setup_simple_build_env_with_ppxs;
-    compile_ppxs;
+    setup_simple_build_env_with_ppx;
+    compile_ppx;
     run_expect;
     check_program_output
   ]

--- a/ocamltest/ocaml_tests.ml
+++ b/ocamltest/ocaml_tests.ml
@@ -33,6 +33,7 @@ let bytecode =
   test_actions =
   [
     setup_ocamlc_byte_build_env;
+    compile_ppxs;
     ocamlc_byte;
     check_ocamlc_byte_output;
     run;
@@ -44,6 +45,7 @@ let native =
   let opt_actions =
   [
     setup_ocamlopt_byte_build_env;
+    compile_ppxs;
     ocamlopt_byte;
     check_ocamlopt_byte_output;
     run;
@@ -66,6 +68,7 @@ let toplevel = {
   test_actions =
   [
     setup_ocaml_build_env;
+    compile_ppxs;
     ocaml;
     check_ocaml_output;
 (*
@@ -82,7 +85,8 @@ let expect =
   test_run_by_default = false;
   test_actions =
   [
-    setup_simple_build_env;
+    setup_simple_build_env_with_ppxs;
+    compile_ppxs;
     run_expect;
     check_program_output
   ]

--- a/ocamltest/ocaml_variables.ml
+++ b/ocamltest/ocaml_variables.ml
@@ -111,6 +111,8 @@ let module_ = make ("module",
 let modules = make ("modules",
   "Other modules of the test")
 
+let ppxs = make("ppxs", "ppx for the test")
+
 let nativecc_libs = make ("nativecc_libs",
   "Libraries to link with for native code")
 
@@ -245,6 +247,7 @@ let _ = List.iter register_variable
     mkdll;
     module_;
     modules;
+    ppxs;
     nativecc_libs;
     objext;
     ocamlc_byte;

--- a/ocamltest/ocaml_variables.ml
+++ b/ocamltest/ocaml_variables.ml
@@ -111,7 +111,7 @@ let module_ = make ("module",
 let modules = make ("modules",
   "Other modules of the test")
 
-let ppxs = make("ppxs", "ppx for the test")
+let ppx = make("ppx", "ppx for the test")
 
 let nativecc_libs = make ("nativecc_libs",
   "Libraries to link with for native code")
@@ -247,7 +247,7 @@ let _ = List.iter register_variable
     mkdll;
     module_;
     modules;
-    ppxs;
+    ppx;
     nativecc_libs;
     objext;
     ocamlc_byte;

--- a/ocamltest/ocaml_variables.mli
+++ b/ocamltest/ocaml_variables.mli
@@ -68,6 +68,8 @@ val module_ : Variables.t
 
 val modules : Variables.t
 
+val ppxs : Variables.t
+
 val nativecc_libs : Variables.t
 (** Libraries to link with for native code *)
 

--- a/ocamltest/ocaml_variables.mli
+++ b/ocamltest/ocaml_variables.mli
@@ -68,7 +68,7 @@ val module_ : Variables.t
 
 val modules : Variables.t
 
-val ppxs : Variables.t
+val ppx : Variables.t
 
 val nativecc_libs : Variables.t
 (** Libraries to link with for native code *)

--- a/testsuite/tests/parsing/broken_invariants.ml
+++ b/testsuite/tests/parsing/broken_invariants.ml
@@ -1,0 +1,52 @@
+(* TEST
+  ppxs="illegal_ppx.ml"
+  * expect
+*)
+
+let empty_tuple = [%tuple];;
+
+[%%expect{|
+Line _:
+Error: File "", line 6, characters 20-25:
+Error: broken invariant in parsetree: Tuples must have at least 2 components.
+|}]
+
+
+let empty_record = [%record];;
+
+[%%expect{|
+Line _:
+Error: File "", line 15, characters 21-27:
+Error: broken invariant in parsetree: Records cannot be empty.
+|}]
+
+let empty_apply = [%no_args f];;
+
+[%%expect{|
+Line _:
+Error: File "", line 23, characters 20-27:
+Error: broken invariant in parsetree: Function application with no argument.
+|}]
+
+let f = function [%record_with_functor_fields] -> ();;
+[%%expect_test {||}];;
+
+[%%expect{|
+Line _:
+Error: File "", line 31, characters 19-45:
+Error: broken invariant in parsetree: Functor application not allowed here.
+|}]
+
+[%%empty_let];;
+[%%expect {|
+Line _:
+Error: File "", line 40, characters 3-12:
+Error: broken invariant in parsetree: Let with no bindings.
+|}]
+
+[%%empty_type];;
+[%%expect {|
+Line _:
+Error: File "", line 47, characters 3-13:
+Error: broken invariant in parsetree: Type declarations cannot be empty.
+|}]

--- a/testsuite/tests/parsing/broken_invariants.ml
+++ b/testsuite/tests/parsing/broken_invariants.ml
@@ -1,5 +1,5 @@
 (* TEST
-  ppxs="illegal_ppx.ml"
+  ppx="illegal_ppx.ml"
   * expect
 *)
 

--- a/testsuite/tests/parsing/illegal_ppx.ml
+++ b/testsuite/tests/parsing/illegal_ppx.ml
@@ -1,0 +1,38 @@
+module H = Ast_helper
+module M = Ast_mapper
+open Parsetree
+let empty_tuple loc = H.Exp.tuple ~loc []
+let empty_record loc = H.Exp.record ~loc [] None
+let empty_apply loc f =
+  H.Exp.apply ~loc f []
+
+let empty_let loc = H.Str.value ~loc Asttypes.Nonrecursive []
+let empty_type loc = H.Str.type_ ~loc Asttypes.Nonrecursive []
+let functor_id loc = Location.mkloc
+    (Longident.( Lapply (Lident "F", Lident "X"))) loc
+let complex_record loc =
+  H.Pat.record ~loc [functor_id loc, H.Pat.any ~loc () ] Asttypes.Closed
+
+let super = M.default_mapper
+let expr mapper e =
+  match e.pexp_desc with
+  | Pexp_extension ({txt="tuple";loc},_) -> empty_tuple loc
+  | Pexp_extension({txt="record";loc},_) -> empty_record loc
+  | Pexp_extension({txt="no_args";loc},PStr[{pstr_desc= Pstr_eval (e,_);_}])
+    -> empty_apply loc e
+  | _ -> super.M.expr mapper e
+
+let pat mapper p =
+  match p.ppat_desc with
+  | Ppat_extension ({txt="record_with_functor_fields";loc},_) ->
+      complex_record loc
+  | _ -> super.M.pat mapper p
+
+let structure_item mapper stri = match stri.pstr_desc with
+  | Pstr_extension (({Location.txt="empty_let";loc},_),_) -> empty_let loc
+  | Pstr_extension (({Location.txt="empty_type";loc},_),_) -> empty_type loc
+  | _ -> super.structure_item mapper stri
+
+let () = M.register "illegal ppx" (fun _ ->
+    { super with expr; pat; structure_item }
+  )

--- a/testsuite/tests/parsing/ocamltests
+++ b/testsuite/tests/parsing/ocamltests
@@ -1,4 +1,5 @@
 attributes.ml
+broken_invariants.ml
 docstrings.ml
 extended_indexoperators.ml
 extensions.ml

--- a/testsuite/tests/typing-misc/empty_ppx.ml
+++ b/testsuite/tests/typing-misc/empty_ppx.ml
@@ -1,0 +1,14 @@
+module H = Ast_helper
+module M = Ast_mapper
+open Parsetree
+let empty_polyvar loc = H.Typ.variant ~loc [] Asttypes.Closed None
+
+let super = M.default_mapper
+let typ mapper e =
+  match e.ptyp_desc with
+  | Ptyp_extension ({txt="empty_polyvar";loc},_) -> empty_polyvar loc
+  | _ -> super.M.typ mapper e
+
+let () = M.register "empty ppx" (fun _ ->
+    { super with typ }
+  )

--- a/testsuite/tests/typing-misc/ocamltests
+++ b/testsuite/tests/typing-misc/ocamltests
@@ -17,5 +17,6 @@ unique_names_in_unification.ml
 variant.ml
 wellfounded.ml
 empty_variant.ml
+typecore_empty_polyvariant_error.ml
 typecore_errors.ml
 typecore_nolabel_errors.ml

--- a/testsuite/tests/typing-misc/typecore_empty_polyvariant_error.ml
+++ b/testsuite/tests/typing-misc/typecore_empty_polyvariant_error.ml
@@ -1,0 +1,16 @@
+(* TEST
+  ppxs="empty_ppx.ml"
+  * expect
+*)
+
+type t = [%empty_polyvar];;
+
+let f: 'a. t -> 'a = function #t -> . ;;
+[%%expect{|
+type t = [  ]
+Line _, characters 31-32:
+  let f: 'a. t -> 'a = function #t -> . ;;
+                                 ^
+Error: The type t
+is not a variant type
+|}]

--- a/testsuite/tests/typing-misc/typecore_empty_polyvariant_error.ml
+++ b/testsuite/tests/typing-misc/typecore_empty_polyvariant_error.ml
@@ -1,5 +1,5 @@
 (* TEST
-  ppxs="empty_ppx.ml"
+  ppx="empty_ppx.ml"
   * expect
 *)
 


### PR DESCRIPTION
This PR adds some support for ppx to ocamltest.

This is implemented through an new variable `ppxs` and a new ocaml  specific action `compile_ppxs`  which compiles the ppx specificied in `ppxs` and the relevant `-ppx` option to the `flags` variable.
This new action has been added to ocaml, ocamlc, ocamlopt and expect tests. The code of `expect_test` itself has been updated to capture syntax errors during the ppx rewriting phase.

The last two commits adds two new tests:

* a broken invariant test that explore the various invariant enforced by  `Ast_invariant`  and the corresponding error messages
* a typecore_empty_polyvariant_errror test devoted to a rare error message that can only appear when pattern matching upon an empty polymorphic variant type.

cc @shindere  .