### PR TITLE
Ensure that comballoc.ml does not reverse the order of allocations

### DIFF
--- a/Changes
+++ b/Changes
@@ -299,6 +299,9 @@ Working version
   stubs on 32bits
   (Jérémie Dimino)
 
+- GPR#1917: comballoc: ensure object allocation order is preserved
+  (Stephen Dolan)
+
 ### Runtime system:
 
 - MPR#7198, MPR#7750, GPR#1738: add a function (caml_custom_alloc_mem)

--- a/asmcomp/comballoc.ml
+++ b/asmcomp/comballoc.ml
@@ -18,15 +18,14 @@
 open Mach
 
 type allocation_state =
-    No_alloc                            (* no allocation is pending *)
-  | Pending_alloc of Reg.t * int        (* an allocation is pending *)
-(* The arguments of Pending_alloc(reg, totalsz) are:
-     reg      the register holding the result of the last allocation
-     totalsz  the amount to be allocated in this block *)
+    No_alloc
+  | Pending_alloc of
+    { reg: Reg.t;    (* register holding the result of the last allocation *)
+      totalsz: int } (* amount to be allocated in this block *)
 
 let allocated_size = function
     No_alloc -> 0
-  | Pending_alloc(_, ofs) -> ofs
+  | Pending_alloc {totalsz; _} -> totalsz
 
 let rec combine i allocstate =
   match i.desc with
@@ -34,23 +33,27 @@ let rec combine i allocstate =
       (i, allocated_size allocstate)
   | Iop(Ialloc { bytes = sz; _ }) ->
       begin match allocstate with
-      | Pending_alloc(reg, totalsz)
+      | Pending_alloc {reg; totalsz}
           when totalsz + sz < Config.max_young_wosize * Arch.size_addr ->
-         let (newnext, newsz) =
-              combine i.next (Pending_alloc(i.res.(0), totalsz + sz)) in
-            (instr_cons_debug (Iop(Iintop_imm(Iadd, -sz)))
-               [| reg |] i.res i.dbg newnext,
-             newsz)
-      | _ ->
-         let (newnext, newsz) = combine i.next (Pending_alloc(i.res.(0), sz)) in
-         let newnext =
-           if newsz = sz then newnext
-           else instr_cons_debug (Iop(Iintop_imm(Iadd, newsz - sz))) i.res
-                i.res i.dbg newnext
+         let (next, totalsz) =
+           combine i.next
+             (Pending_alloc { reg = i.res.(0); totalsz = totalsz + sz }) in
+         (instr_cons_debug (Iop(Iintop_imm(Iadd, -sz)))
+            [| reg |] i.res i.dbg next,
+          totalsz)
+      | No_alloc | Pending_alloc _ ->
+         let (next, totalsz) =
+           combine i.next
+             (Pending_alloc { reg = i.res.(0); totalsz = sz }) in
+         let next =
+           let offset = totalsz - sz in
+           if offset = 0 then next
+           else instr_cons_debug (Iop(Iintop_imm(Iadd, offset))) i.res
+                i.res i.dbg next
          in
-         (instr_cons_debug (Iop(Ialloc {bytes = newsz; spacetime_index = 0;
+         (instr_cons_debug (Iop(Ialloc {bytes = totalsz; spacetime_index = 0;
                                         label_after_call_gc = None; }))
-          i.arg i.res i.dbg newnext, allocated_size allocstate)
+          i.arg i.res i.dbg next, allocated_size allocstate)
       end
   | Iop(Icall_ind _ | Icall_imm _ | Iextcall _ |
         Itailcall_ind _ | Itailcall_imm _) ->

--- a/asmcomp/comballoc.ml
+++ b/asmcomp/comballoc.ml
@@ -20,9 +20,9 @@ open Mach
 type allocation_state =
     No_alloc                            (* no allocation is pending *)
   | Pending_alloc of Reg.t * int        (* an allocation is pending *)
-(* The arguments of Pending_alloc(reg, ofs) are:
-     reg  the register holding the result of the last allocation
-     ofs  the alloc position in the allocated block *)
+(* The arguments of Pending_alloc(reg, totalsz) are:
+     reg      the register holding the result of the last allocation
+     totalsz  the amount to be allocated in this block *)
 
 let allocated_size = function
     No_alloc -> 0
@@ -34,25 +34,23 @@ let rec combine i allocstate =
       (i, allocated_size allocstate)
   | Iop(Ialloc { bytes = sz; _ }) ->
       begin match allocstate with
-        No_alloc ->
-          let (newnext, newsz) =
-            combine i.next (Pending_alloc(i.res.(0), sz)) in
-          (instr_cons_debug (Iop(Ialloc {bytes = newsz; spacetime_index = 0;
-              label_after_call_gc = None; }))
-            i.arg i.res i.dbg newnext, 0)
-      | Pending_alloc(reg, ofs) ->
-          if ofs + sz < Config.max_young_wosize * Arch.size_addr then begin
-            let (newnext, newsz) =
-              combine i.next (Pending_alloc(reg, ofs + sz)) in
-            (instr_cons (Iop(Iintop_imm(Iadd, ofs))) [| reg |] i.res newnext,
+      | Pending_alloc(reg, totalsz)
+          when totalsz + sz < Config.max_young_wosize * Arch.size_addr ->
+         let (newnext, newsz) =
+              combine i.next (Pending_alloc(i.res.(0), totalsz + sz)) in
+            (instr_cons_debug (Iop(Iintop_imm(Iadd, -sz)))
+               [| reg |] i.res i.dbg newnext,
              newsz)
-          end else begin
-            let (newnext, newsz) =
-              combine i.next (Pending_alloc(i.res.(0), sz)) in
-            (instr_cons_debug (Iop(Ialloc { bytes = newsz; spacetime_index = 0;
-                label_after_call_gc = None; }))
-              i.arg i.res i.dbg newnext, ofs)
-          end
+      | _ ->
+         let (newnext, newsz) = combine i.next (Pending_alloc(i.res.(0), sz)) in
+         let newnext =
+           if newsz = sz then newnext
+           else instr_cons_debug (Iop(Iintop_imm(Iadd, newsz - sz))) i.res
+                i.res i.dbg newnext
+         in
+         (instr_cons_debug (Iop(Ialloc {bytes = newsz; spacetime_index = 0;
+                                        label_after_call_gc = None; }))
+          i.arg i.res i.dbg newnext, allocated_size allocstate)
       end
   | Iop(Icall_ind _ | Icall_imm _ | Iextcall _ |
         Itailcall_ind _ | Itailcall_imm _) ->


### PR DESCRIPTION
Since their fields are provided at creation time, immutable blocks point only to older blocks. The current GC does not rely on this invariant, but multicore does.

Since the minor heap is filled from higher addresses to lower (allocation is subtraction from the heap pointer), this means that immutable blocks will point to higher addresses. Specifically, multicore relies on the invariant that all fields in the minor heap containing pointers:

  - point to the major heap, or
  - point to a higher address in the minor heap, or
  - were created by `caml_modify`

This invariant is broken by `comballoc`, which combines multiple allocations into one, since the current implementation of `comballoc` actually reverses the allocation order, which caused a nasty bug in multicore (ocamllabs/ocaml-multicore#131).

This patch makes comballoc preserve the order of allocation. Here's the diff in the `-dlinear` output of `fun x -> 1 :: 2 :: 3 :: x`:

```diff
 camlComb__f_1199: {comb.ml:1,6-26}
   x/29[%rbx] := R/0[%rax]
   {x/29[%rbx]*}
   V/30[%rax] := alloc 72 {comb.ml:1,20-26}
+  V/30[%rax] := V/30[%rax] + 48 {comb.ml:1,20-26}
   [V/30[%rax] + -8] := 2048 (init)
   [V/30[%rax]] := 7 (init)
   val[V/30[%rax] + 8] := x/29[%rbx] (init)
-  V/31[%rbx] := V/30[%rax] + 24
+  V/31[%rbx] := V/30[%rax] + -24 {comb.ml:1,15-26}
   [V/31[%rbx] + -8] := 2048 (init)
   [V/31[%rbx]] := 5 (init)
   val[V/31[%rbx] + 8] := V/30[%rax] (init)
-  V/32[%rax] := V/30[%rax] + 48
+  V/32[%rax] := V/31[%rbx] + -24 {comb.ml:1,10-26}
   [V/32[%rax] + -8] := 2048 (init)
   [V/32[%rax]] := 3 (init)
   val[V/32[%rax] + 8] := V/31[%rbx] (init)
```

The other difference visible above is that the new version uses `instr_cons_debug` instead of `instr_cons`, so preserves more location information.