### PR TITLE
Longident.to string

### DIFF
--- a/Changes
+++ b/Changes
@@ -196,6 +196,9 @@ Working version
 - GPR#1886: move the Location.absname reference to Clflags.absname
   (Armaël Guéneau, review by Jérémie Dimino)
 
+- GPR#1918: Longident.to_string
+  (Gabriel Scherer, review by Florian Angeletti and Gabriel Radanne)
+
 ### Bug fixes:
 
 - MPR#7726, GPR#1676: Recursive modules, equi-recursive types and stack overflow

--- a/parsing/longident.ml
+++ b/parsing/longident.ml
@@ -47,3 +47,10 @@ let parse s =
   | None -> Lident ""  (* should not happen, but don't put assert false
                           so as not to crash the toplevel (see Genprintval) *)
   | Some v -> v
+
+let to_string lid =
+  let rec print lid acc = match lid with
+    | Lident s -> s::acc
+    | Ldot (lid, id) -> print lid ("." :: id :: acc)
+    | Lapply (la, lb) -> print la ("(" :: print lb (")" :: acc))
+  in String.concat "" (print lid [])

--- a/parsing/longident.ml
+++ b/parsing/longident.ml
@@ -54,3 +54,8 @@ let to_string lid =
     | Ldot (lid, id) -> print lid ("." :: id :: acc)
     | Lapply (la, lb) -> print la ("(" :: print lb (")" :: acc))
   in String.concat "" (print lid [])
+
+let rec pp ppf = function
+  | Lident s -> Format.pp_print_string ppf s
+  | Ldot(p, s) -> Format.fprintf ppf "%a.%s" pp p s
+  | Lapply(p1, p2) -> Format.fprintf ppf "%a(%a)" pp p1 pp p2

--- a/parsing/longident.mli
+++ b/parsing/longident.mli
@@ -24,3 +24,4 @@ val flatten: t -> string list
 val unflatten: string list -> t option
 val last: t -> string
 val parse: string -> t
+val to_string: t -> string

--- a/parsing/longident.mli
+++ b/parsing/longident.mli
@@ -24,4 +24,6 @@ val flatten: t -> string list
 val unflatten: string list -> t option
 val last: t -> string
 val parse: string -> t
+
+val pp: Format.formatter -> t -> unit
 val to_string: t -> string

--- a/testsuite/tests/compiler-libs/ocamltests
+++ b/testsuite/tests/compiler-libs/ocamltests
@@ -1,0 +1,1 @@
+test_longident.ml

--- a/testsuite/tests/compiler-libs/test_longident.ml
+++ b/testsuite/tests/compiler-libs/test_longident.ml
@@ -64,3 +64,15 @@ let to_string_dot_apply =
 let parse_to_string =
   Examples.all_noapp |> List.map (roundtrip L.parse L.to_string)
 ;;
+
+section "Longident.pp";;
+let test lid = Format.flush_str_formatter (L.pp Format.str_formatter lid)
+let pp_ident = test (L.Lident "foo");;
+let pp_dot = test (L.Ldot (L.Lident "M", "foo"));;
+let pp_apply = test (L.Lapply (L.Lident "F", L.Lident "X"));;
+let pp_dot_apply =
+  test (L.Ldot (L.Lapply (L.Lident "F", L.Lident "X"), "foo"));;
+
+let parse_pp =
+  Examples.all_noapp |> List.map (roundtrip L.parse test)
+;;

--- a/testsuite/tests/compiler-libs/test_longident.ml
+++ b/testsuite/tests/compiler-libs/test_longident.ml
@@ -1,0 +1,66 @@
+(* TEST
+   include ocamlcommon
+   * toplevel
+*)
+
+module L = Longident
+
+module Examples = struct
+  let foo, _M = L.Lident "foo", L.Lident "M"
+  let _M_foo = L.Ldot (_M, "foo")
+  let _M_N = L.Ldot (_M, "N")
+  let _M_N_foo = L.Ldot (_M_N, "foo")
+  let _F, _X = L.Lident "F", L.Lident "X"
+  let _F_X = L.Lapply (_F, _X)
+  let complex = (* M.F(M.N).N.foo *)
+    L.Ldot (L.Ldot (L.Lapply(_F, _M_N), "N"), "foo")
+
+  let all = [foo; _M_foo; _M_N; _M_N_foo; _F_X; complex]
+  let all_noapp = [foo; _M_foo; _M_N; _M_N_foo]
+end
+
+let roundtrip f g x =
+  let y = f (g x) in (x = y, x, y)
+
+let roundtrip_opt f g x =
+  let y = f (g x) in (Some x = y, x, y)
+
+let section s = print_newline (); print_endline s;;
+
+section "Longident.flatten";;
+let flatten_ident = L.flatten (L.Lident "foo");;
+let flatten_dot = L.flatten (L.Ldot (L.Lident "M", "foo"));;
+let flatten_apply = L.flatten (L.Lapply (L.Lident "F", L.Lident "X"));;
+
+section "Longident.unflatten";;
+let unflatten_empty = L.unflatten [];;
+let unflatten_sing = L.unflatten ["foo"];;
+let unflatten_dot = L.unflatten ["M"; "N"; "foo"];;
+
+let unflatten_flatten =
+  Examples.all_noapp |> List.map (roundtrip_opt L.unflatten L.flatten)
+;;
+
+section "Longident.last";;
+let last_ident = L.last (L.Lident "foo");;
+let last_dot = L.last (L.Ldot (L.Lident "M", "foo"));;
+let last_apply = L.last (L.Lapply (L.Lident "F", L.Lident "X"));;
+let last_dot_apply = L.Ldot (L.Lapply (L.Lident "F", L.Lident "X"), "foo");;
+
+section "Longident.parse";;
+let parse_empty = L.parse "";;
+let parse_ident = L.parse "foo";;
+let parse_dot = L.parse "M.foo";;
+let parse_path = L.parse "M.N.foo";;
+let parse_complex = L.parse "F(M.N).N.foo";;
+
+section "Longident.to_string";;
+let to_string_ident = L.to_string (L.Lident "foo");;
+let to_string_dot = L.to_string (L.Ldot (L.Lident "M", "foo"));;
+let to_string_apply = L.to_string (L.Lapply (L.Lident "F", L.Lident "X"));;
+let to_string_dot_apply =
+  L.to_string (L.Ldot (L.Lapply (L.Lident "F", L.Lident "X"), "foo"));;
+
+let parse_to_string =
+  Examples.all_noapp |> List.map (roundtrip L.parse L.to_string)
+;;

--- a/testsuite/tests/compiler-libs/test_longident.ocaml.reference
+++ b/testsuite/tests/compiler-libs/test_longident.ocaml.reference
@@ -1,0 +1,71 @@
+module L = Longident
+module Examples :
+  sig
+    val foo : L.t
+    val _M : L.t
+    val _M_foo : L.t
+    val _M_N : L.t
+    val _M_N_foo : L.t
+    val _F : L.t
+    val _X : L.t
+    val _F_X : L.t
+    val complex : L.t
+    val all : L.t list
+    val all_noapp : L.t list
+  end
+val roundtrip : ('a -> 'b) -> ('b -> 'a) -> 'b -> bool * 'b * 'b = <fun>
+val roundtrip_opt :
+  ('a -> 'b option) -> ('b -> 'a) -> 'b -> bool * 'b * 'b option = <fun>
+val section : string -> unit = <fun>
+
+Longident.flatten
+- : unit = ()
+val flatten_ident : string list = ["foo"]
+val flatten_dot : string list = ["M"; "foo"]
+>> Fatal error: Longident.flat
+Exception: Misc.Fatal_error.
+
+Longident.unflatten
+- : unit = ()
+val unflatten_empty : L.t option = None
+val unflatten_sing : L.t option = Some (L.Lident "foo")
+val unflatten_dot : L.t option =
+  Some (L.Ldot (L.Ldot (L.Lident "M", "N"), "foo"))
+val unflatten_flatten : (bool * L.t * L.t option) list =
+  [(true, L.Lident "foo", Some (L.Lident "foo"));
+   (true, L.Ldot (L.Lident "M", "foo"), Some (L.Ldot (L.Lident "M", "foo")));
+   (true, L.Ldot (L.Lident "M", "N"), Some (L.Ldot (L.Lident "M", "N")));
+   (true, L.Ldot (L.Ldot (L.Lident "M", "N"), "foo"),
+    Some (L.Ldot (L.Ldot (L.Lident "M", "N"), "foo")))]
+
+Longident.last
+- : unit = ()
+val last_ident : string = "foo"
+val last_dot : string = "foo"
+>> Fatal error: Longident.last
+Exception: Misc.Fatal_error.
+val last_dot_apply : L.t =
+  L.Ldot (L.Lapply (L.Lident "F", L.Lident "X"), "foo")
+
+Longident.parse
+- : unit = ()
+val parse_empty : L.t = L.Lident ""
+val parse_ident : L.t = L.Lident "foo"
+val parse_dot : L.t = L.Ldot (L.Lident "M", "foo")
+val parse_path : L.t = L.Ldot (L.Ldot (L.Lident "M", "N"), "foo")
+val parse_complex : L.t =
+  L.Ldot (L.Ldot (L.Ldot (L.Lident "F(M", "N)"), "N"), "foo")
+
+Longident.to_string
+- : unit = ()
+val to_string_ident : string = "foo"
+val to_string_dot : string = "M.foo"
+val to_string_apply : string = "F(X)"
+val to_string_dot_apply : string = "F(X).foo"
+val parse_to_string : (bool * L.t * L.t) list =
+  [(true, L.Lident "foo", L.Lident "foo");
+   (true, L.Ldot (L.Lident "M", "foo"), L.Ldot (L.Lident "M", "foo"));
+   (true, L.Ldot (L.Lident "M", "N"), L.Ldot (L.Lident "M", "N"));
+   (true, L.Ldot (L.Ldot (L.Lident "M", "N"), "foo"),
+    L.Ldot (L.Ldot (L.Lident "M", "N"), "foo"))]
+

--- a/testsuite/tests/compiler-libs/test_longident.ocaml.reference
+++ b/testsuite/tests/compiler-libs/test_longident.ocaml.reference
@@ -69,3 +69,17 @@ val parse_to_string : (bool * L.t * L.t) list =
    (true, L.Ldot (L.Ldot (L.Lident "M", "N"), "foo"),
     L.Ldot (L.Ldot (L.Lident "M", "N"), "foo"))]
 
+Longident.pp
+- : unit = ()
+val test : L.t -> string = <fun>
+val pp_ident : string = "foo"
+val pp_dot : string = "M.foo"
+val pp_apply : string = "F(X)"
+val pp_dot_apply : string = "F(X).foo"
+val parse_pp : (bool * L.t * L.t) list =
+  [(true, L.Lident "foo", L.Lident "foo");
+   (true, L.Ldot (L.Lident "M", "foo"), L.Ldot (L.Lident "M", "foo"));
+   (true, L.Ldot (L.Lident "M", "N"), L.Ldot (L.Lident "M", "N"));
+   (true, L.Ldot (L.Ldot (L.Lident "M", "N"), "foo"),
+    L.Ldot (L.Ldot (L.Lident "M", "N"), "foo"))]
+

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -26,11 +26,7 @@ open Btype
 open Outcometree
 
 (* Print a long identifier *)
-
-let rec longident ppf = function
-  | Lident s -> pp_print_string ppf s
-  | Ldot(p, s) -> fprintf ppf "%a.%s" longident p s
-  | Lapply(p1, p2) -> fprintf ppf "%a(%a)" longident p1 longident p2
+let longident = Longident.pp
 
 (* Print an identifier avoiding name collisions *)
 


### PR DESCRIPTION
`Longident.to_string : t -> string` is something which I would have needed while implementing https://github.com/ocaml-ppx/ppx_import/pull/25

I thought that I was writing the tests out of principle, but in fact my first version was buggy, it would print `(F)X` instead of `F(X)`. (One of the worst notations for applications.)