### PR TITLE
Misc.fatal_error: use Format.eprintf instead of prerr_string

### DIFF
--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -17,10 +17,13 @@
 
 exception Fatal_error
 
-let fatal_error msg =
-  prerr_string ">> Fatal error: "; prerr_endline msg; raise Fatal_error
+let fatal_errorf fmt =
+  Format.kfprintf
+    (fun _ -> raise Fatal_error)
+    Format.err_formatter
+    ("@?>> Fatal error: " ^^ fmt ^^ "@.")
 
-let fatal_errorf fmt = Format.kasprintf fatal_error fmt
+let fatal_error msg = fatal_errorf "%s" msg
 
 (* Exceptions *)
 


### PR DESCRIPTION
The use of a non-Format output caused troubles when called from the
toplevel. In comparison, Misc.fatal_errorf was already using Format,
and many files freely mix those two functions.

The suggestion comes from Florian Angeletti in #1918.

With this change, I can confirm that the expect-style tests in d26aaf9785ad2ff332dcd3a501aa596a48072673 ( which include a test of a function using `Misc.fatal_error` work correctly, while they were previously broken. See [MPR#7827](https://caml.inria.fr/mantis/view.php?id=7827).