### PR TITLE
Ast_mapper.PpxContext: store type-checking related flags

### DIFF
--- a/Changes
+++ b/Changes
@@ -101,6 +101,11 @@ Working version
   returns a syntax tree, to replace the print that was there already
   (Valentin Gatien-Baron)
 
+- GPR#1921: in the compilation context passed to ppx extensions,
+  add more configuration options related to type-checking:
+  -rectypes, -principal, -alias-deps, -unboxed-types, -unsafe-string
+  (Gabriel Scherer, review by Gabriel Radanne, Xavier Clerc and Frédéric Bour)
+
 ### Code generation and optimizations:
 
 - MPR#7725, GPR#1754: improve AFL instrumentation for objects and lazy values.

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -734,6 +734,11 @@ module PpxContext = struct
         lid "debug",        make_bool !Clflags.debug;
         lid "use_threads",  make_bool !Clflags.use_threads;
         lid "use_vmthreads", make_bool !Clflags.use_vmthreads;
+        lid "recursive_types", make_bool !Clflags.recursive_types;
+        lid "principal", make_bool !Clflags.principal;
+        lid "transparent_modules", make_bool !Clflags.transparent_modules;
+        lid "unboxed_types", make_bool !Clflags.unboxed_types;
+        lid "unsafe_string", make_bool !Clflags.unsafe_string;
         get_cookies ()
       ]
     in
@@ -804,6 +809,16 @@ module PpxContext = struct
           Clflags.use_threads := get_bool payload
       | "use_vmthreads" ->
           Clflags.use_vmthreads := get_bool payload
+      | "recursive_types" ->
+          Clflags.recursive_types := get_bool payload
+      | "principal" ->
+          Clflags.principal := get_bool payload
+      | "transparent_modules" ->
+          Clflags.transparent_modules := get_bool payload
+      | "unboxed_types" ->
+          Clflags.unboxed_types := get_bool payload
+      | "unsafe_string" ->
+          Clflags.unsafe_string := get_bool payload
       | "cookies" ->
           let l = get_list (get_pair get_string (fun x -> x)) payload in
           cookies :=

--- a/testsuite/tests/ppx-contexts/myppx.ml
+++ b/testsuite/tests/ppx-contexts/myppx.ml
@@ -3,7 +3,43 @@
 open Ast_mapper
 
 let () =
+  let quote_strings li =
+    List.map (Printf.sprintf "%S") li |> String.concat " " in
+  let quote_option = function
+    | None -> "None"
+    | Some s -> Printf.sprintf "Some(%S)" s in
   register "test" (fun _ ->
-      Printf.eprintf "use_threads=%b\n" !Clflags.use_threads;
-      Printf.eprintf "use_vmthreads=%b\n" !Clflags.use_vmthreads;
+      Printf.eprintf "<ppx-context>\n";
+      Printf.eprintf "tool_name: %S\n"
+        (tool_name ());
+      (*
+         (* Note: we do not test include_dirs, load_path
+            as they produce non-portable paths *)
+      Printf.eprintf "include_dirs: [%s]\n"
+        (quote_strings !Clflags.include_dirs);
+      Printf.eprintf "load_path: [%s]\n"
+        (quote_strings !Config.load_path);
+      *)
+      Printf.eprintf "open_modules: [%s]\n"
+        (quote_strings !Clflags.open_modules);
+      Printf.eprintf "for_package: %S\n"
+        (quote_option !Clflags.for_package);
+      Printf.eprintf "use_debug: %B\n"
+        !Clflags.debug;
+      Printf.eprintf "use_threads: %B\n"
+        !Clflags.use_threads;
+      Printf.eprintf "use_vmthreads: %B\n"
+        !Clflags.use_vmthreads;
+      Printf.eprintf "recursive_types: %B\n"
+        !Clflags.recursive_types;
+      Printf.eprintf "principal: %B\n"
+        !Clflags.principal;
+      Printf.eprintf "transparent_modules: %B\n"
+        !Clflags.transparent_modules;
+      Printf.eprintf "unboxed_types: %B\n"
+        !Clflags.unboxed_types;
+      Printf.eprintf "unsafe_string: %B\n"
+        !Clflags.unsafe_string;
+      Printf.eprintf "</ppx-context>\n";
+      flush stderr;
       default_mapper);

--- a/testsuite/tests/ppx-contexts/test.compilers.reference
+++ b/testsuite/tests/ppx-contexts/test.compilers.reference
@@ -1,4 +1,26 @@
-use_threads=true
-use_vmthreads=false
-use_threads=false
-use_vmthreads=true
+<ppx-context>
+tool_name: "ocamlc"
+open_modules: ["List"]
+for_package: "None"
+use_debug: false
+use_threads: true
+use_vmthreads: false
+recursive_types: true
+principal: true
+transparent_modules: false
+unboxed_types: true
+unsafe_string: false
+</ppx-context>
+<ppx-context>
+tool_name: "ocamlc"
+open_modules: []
+for_package: "None"
+use_debug: true
+use_threads: false
+use_vmthreads: true
+recursive_types: false
+principal: false
+transparent_modules: true
+unboxed_types: false
+unsafe_string: true
+</ppx-context>

--- a/testsuite/tests/ppx-contexts/test.ml
+++ b/testsuite/tests/ppx-contexts/test.ml
@@ -7,10 +7,23 @@ program = "${test_build_directory}/myppx.exe"
 all_modules = "myppx.ml"
 *** ocamlc.byte
 module = "test.ml"
-flags = "-thread -ppx ${program}"
+flags = "-thread \
+         -I ${test_build_directory} \
+         -open List \
+         -rectypes \
+         -principal \
+         -alias-deps \
+         -unboxed-types \
+         -safe-string \
+         -ppx ${program}"
 **** ocamlc.byte
 module = "test.ml"
-flags = "-vmthread -ppx ${program}"
+flags = "-vmthread \
+         -g \
+         -no-alias-deps \
+         -no-unboxed-types \
+         -unsafe-string \
+         -ppx ${program}"
 ***** check-ocamlc.byte-output
 *)
 


### PR DESCRIPTION
It is a bug of the current PpxContext that -rectypes is not passed as
part of the context: any ppx extension that would like to be able to
load .cmi files in the same initial environment as the user code would
break because loading -rectypes-using .cmi is disallowed if
Clflags.recursive_types is not set.

(I found this issue while debugging a ppx_import user that compiles
with -rectypes -- https://github.com/ocaml-ppx/ppx_import/pull/25 )

I tried to add all the other Clflags that seem related to
type-checking and might cause a program to not-type-check if they
are not correctly passed:

- recursive_types
- principal
- transparent_modules
- unboxed_types
- unsafe_string
