### PR TITLE
rec_check: remove the duplicate array_type_kind classifier, use Typeopt

### DIFF
--- a/testsuite/tests/letrec-disallowed/float_block_allowed.ml
+++ b/testsuite/tests/letrec-disallowed/float_block_allowed.ml
@@ -1,14 +1,32 @@
 (* TEST
    * no-flat-float-array
-   ** toplevel
+   ** expect
 *)
 
-(* these recursive float arrays are allowed when -no-flat-float-array
-   is set -- the first array element is not forced on array creation
-   anymore *)
-let test =
-  let rec x = [| y; y |] and y = 1. in
-  assert (x = [| 1.; 1. |]);
-  assert (y = 1.);
-  ()
-;;
+(* See float_block_disallowed.ml for explanations.
+
+   When the -flat-float-array optimization is *not* set, float arrays
+   are not unboxed, and no dynamic check is performed on generc array
+   creation, so array literals behave just like other constructors
+   and can be defined mutually recursively with their elements.
+*)
+
+(* Case of elements known not to be float. *)
+let f (z: int) = let rec x = [| y; z |] and y = z in x;;
+let f (z: bytes) = let rec x = [| y; z |] and y = z in x;;
+[%%expect {|
+val f : int -> int array = <fun>
+val f : bytes -> bytes array = <fun>
+|}];;
+
+(* Generic case (element may or may not be float), no dynamic test. *)
+let f z = let rec x = [| y; z |] and y = z in x;;
+[%%expect {|
+val f : 'a -> 'a array = <fun>
+|}]
+
+(* Float case, no unboxing. *)
+let f (z: float) = let rec x = [| y; z |] and y = z in x;;
+[%%expect {|
+val f : float -> float array = <fun>
+|}]

--- a/testsuite/tests/letrec-disallowed/float_block_allowed.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/float_block_allowed.ocaml.reference
@@ -1,2 +1,0 @@
-val test : unit = ()
-

--- a/testsuite/tests/letrec-disallowed/float_block_disallowed.ml
+++ b/testsuite/tests/letrec-disallowed/float_block_disallowed.ml
@@ -1,18 +1,52 @@
 (* TEST
    * flat-float-array
-   ** toplevel
+   ** expect
 *)
 
-(* when the -flat-float-array optimization is active (standard in
-   OCaml versions up to at least 4.07), creating an array inspects its
-   first element to decide whether it is a float or not; it would thus
-   be unsound to allow to recursively define a float value and an
-   array starting with that element (in general we disallow using a
-   recursively-defined value in an array literal).
+(* When the -flat-float-array optimization is active (standard in
+   OCaml versions up to at least 4.07), creating an array may perform
+   a dynamic check, inspecing its first element to decide whether it
+   is a float or not. The check is elided when the type-checker can
+   determine statically that the type of the elements is float, or
+   that it will never be float.
+
+   In the dynamic check case, it is unsound to define in
+   a mutually-recursive way a value and an array containing that
+   value.
+
+   In the case where an array is statically known to be an array of float,
+   this dynamic check does not happen, but the elements are unboxed to
+   be put in the flat float array, so they are dereferenced anyway.
 *)
-let test =
-  let rec x = [| y; y |] and y = 1. in
-  assert (x = [| 1.; 1. |]);
-  assert (y = 1.);
-  ()
-;;
+
+(* In these tests, `z` is known to be a non-float,
+   so no unboxing or dynamic check happens, the definition is valid. *)
+let f (z: int) = let rec x = [| y; z |] and y = z in x;;
+let f (z: bytes) = let rec x = [| y; z |] and y = z in x;;
+[%%expect {|
+val f : int -> int array = <fun>
+val f : bytes -> bytes array = <fun>
+|}];;
+
+(* In this test, `z` has a generic/polymorphic type,
+   so it could be instantiated with either float or non-float.
+   A dynamic check will occur, so the definition must be rejected. *)
+let f z = let rec x = [| y; z |] and y = z in x;;
+[%%expect {|
+Line 1, characters 22-32:
+  let f z = let rec x = [| y; z |] and y = z in x;;
+                        ^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of `let rec'
+|}]
+
+(* In this test, `z` is known to be a float, so a float array will be
+   created. When the flat-float-array optimization is active, the
+   array elements will be unboxed, thus evaluated. This definition
+   must be rejected. *)
+let f (z: float) = let rec x = [| y; z |] and y = z in x;;
+[%%expect {|
+Line 1, characters 31-41:
+  let f (z: float) = let rec x = [| y; z |] and y = z in x;;
+                                 ^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of `let rec'
+|}]

--- a/testsuite/tests/letrec-disallowed/float_block_disallowed.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/float_block_disallowed.ocaml.reference
@@ -1,5 +1,0 @@
-Line 14, characters 14-24:
-    let rec x = [| y; y |] and y = 1. in
-                ^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of `let rec'
-

--- a/testsuite/tests/letrec-disallowed/generic_arrays.ml
+++ b/testsuite/tests/letrec-disallowed/generic_arrays.ml
@@ -1,7 +1,0 @@
-(* TEST
-   * toplevel
-*)
-
-(* This is not allowed because constructing the generic array 'x' involves
-   inspecting 'y', which is bound in the same recursive group *)
-let f z = let rec x = [| y; z |] and y = z in x;;

--- a/testsuite/tests/letrec-disallowed/ocamltests
+++ b/testsuite/tests/letrec-disallowed/ocamltests
@@ -2,7 +2,6 @@ disallowed.ml
 extension_constructor.ml
 float_block_allowed.ml
 float_block_disallowed.ml
-generic_arrays.ml
 labels.ml
 lazy_.ml
 module_constraints.ml


### PR DESCRIPTION
This PR supersedes the more timid change that I proposed in #1911: that other change is less invasive, but when I tried to justify why it is correct (thanks to the hard looks from @trefis), I found that my only strong argument was "if it isn't, then `Typeopt.array_type_kind` also isn't". This is not reasoning-by-contradiction but a simple contraposition, and the present PR is a constructive proof.

A side-result of this change is that, because Typeopt classifies
parametric arrays in a more flexible way that the Rec_check code did
(when -no-flat-float-array is set, they are marked Paddrarray rather
than Pgenarray, to reflect the fact that not dynamic test for unboxing
is performed), the -no-flat-float-array compiler starts accepting
*more* recursive definition than before: basically, arrays at all
types act just like constructors.

Our testsuite had a case (letrec-disallowed/generic_arrays.ml) that
specifically check that this case of generic array is disallowed,
even under -no-flat-float-array. I changed the tests to reflect
the finer-grained criterion -- and converted them to expect-style
tests along the way.