### PR TITLE
Refactor [Location.print_loc] to print error locations more consistently

### DIFF
--- a/Changes
+++ b/Changes
@@ -110,6 +110,10 @@ Working version
   -rectypes, -principal, -alias-deps, -unboxed-types, -unsafe-string
   (Gabriel Scherer, review by Gabriel Radanne, Xavier Clerc and Frédéric Bour)
 
+- GPR#1925: Print error locations more consistently between batch mode, toplevel
+  and expect tests
+  (Armaël Guéneau, review by Thomas Refis, Gabriel Scherer and François Bobot)
+
 ### Code generation and optimizations:
 
 - MPR#7725, GPR#1754: improve AFL instrumentation for objects and lazy values.

--- a/stdlib/lexing.ml
+++ b/stdlib/lexing.ml
@@ -232,5 +232,6 @@ let flush_input lb =
   lb.lex_curr_pos <- 0;
   lb.lex_abs_pos <- 0;
   let lcp = lb.lex_curr_p in
-  if lcp != dummy_pos then lb.lex_curr_p <- {lcp with pos_cnum = 0};
+  if lcp != dummy_pos then
+    lb.lex_curr_p <- {zero_pos with pos_fname = lcp.pos_fname};
   lb.lex_buffer_len <- 0;

--- a/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
+++ b/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
@@ -8,7 +8,7 @@ and C:sig val x: int end = struct let x = B.x end
 and D:sig val x: int end = struct let x = C.x end
 and E:sig val x: int val y:int end = struct let x = D.x let y = 0 end
 [%%expect {|
-Line _, characters 27-49:
+Line 2, characters 27-49:
   and B:sig val x: int end = struct let x = E.y end
                              ^^^^^^^^^^^^^^^^^^^^^^
 Error: Cannot safely evaluate the definition of the following cycle

--- a/testsuite/tests/basic/patmatch_incoherence.ml
+++ b/testsuite/tests/basic/patmatch_incoherence.ml
@@ -35,7 +35,7 @@ match { x = assert false } with
 | { x = None } -> ()
 ;;
 [%%expect{|
-Line _, characters 0-70:
+Line 1, characters 0-70:
   match { x = assert false } with
   | { x = 3 } -> ()
   | { x = None } -> ()
@@ -50,7 +50,7 @@ match { x = assert false } with
 | { x = "" } -> ()
 ;;
 [%%expect{|
-Line _, characters 0-71:
+Line 1, characters 0-71:
   match { x = assert false } with
   | { x = None } -> ()
   | { x = "" } -> ()
@@ -65,7 +65,7 @@ match { x = assert false } with
 | { x = `X } -> ()
 ;;
 [%%expect{|
-Line _, characters 0-71:
+Line 1, characters 0-71:
   match { x = assert false } with
   | { x = None } -> ()
   | { x = `X } -> ()
@@ -80,7 +80,7 @@ match { x = assert false } with
 | { x = 3 } -> ()
 ;;
 [%%expect{|
-Line _, characters 0-70:
+Line 1, characters 0-70:
   match { x = assert false } with
   | { x = [||] } -> ()
   | { x = 3 } -> ()
@@ -95,7 +95,7 @@ match { x = assert false } with
 | { x = 3 } -> ()
 ;;
 [%%expect{|
-Line _, characters 0-68:
+Line 1, characters 0-68:
   match { x = assert false } with
   | { x = `X } -> ()
   | { x = 3 } -> ()
@@ -110,7 +110,7 @@ match { x = assert false } with
 | { x = 3 } -> ()
 ;;
 [%%expect{|
-Line _, characters 0-74:
+Line 1, characters 0-74:
   match { x = assert false } with
   | { x = `X "lol" } -> ()
   | { x = 3 } -> ()
@@ -126,7 +126,7 @@ match { x = assert false } with
 | { x = 3 } -> ()
 ;;
 [%%expect{|
-Line _, characters 0-95:
+Line 1, characters 0-95:
   match { x = assert false } with
   | { x = (2., "") } -> ()
   | { x = None } -> ()

--- a/testsuite/tests/formatting/margins.ocaml.reference
+++ b/testsuite/tests/formatting/margins.ocaml.reference
@@ -1,11 +1,11 @@
-Characters 5-10:
+Line 2, characters 4-9:
   1 + "foo";;
       ^^^^^
 Error: This expression has type
          string
        but an expression was expected of type
          int
-Characters 5-10:
+Line 2, characters 4-9:
   1 + "foo";;
       ^^^^^
 Error: This expression has type string but an expression was expected of type

--- a/testsuite/tests/letrec-disallowed/disallowed.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/disallowed.ocaml.reference
@@ -1,123 +1,123 @@
-Characters 38-53:
+Line 5, characters 12-27:
   let rec x = let y = () in x;;
               ^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-77:
+Line 2, characters 12-76:
   let rec x = let module M = struct let f = x let g = x () end in fun () -> ();;
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-77:
+Line 2, characters 12-76:
   let rec x = let module M = struct let f = x () let g = x end in fun () -> ();;
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-79:
+Line 2, characters 12-78:
   let rec x = (let module M = struct let f = y 0 let g = () end in fun () -> ())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-79:
+Line 2, characters 12-78:
   let rec x = let module M = struct module N = struct let y = x end end in M.N.y;;
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-77:
+Line 2, characters 12-76:
   let rec x = let module M = struct let f = x () and g = x end in fun () -> ();;
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 class c : 'a -> object  end
-Characters 12-19:
+Line 1, characters 12-19:
   let rec x = new c x;;
               ^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-21:
+Line 2, characters 12-20:
   let rec x = ignore x;;
               ^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-16:
+Line 2, characters 12-15:
   let rec x = y 0 and y _ = ();;
               ^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-40:
+Line 2, characters 12-39:
   let rec c = { c with Complex.re = 1.0 };;
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-38:
+Line 2, characters 12-37:
   let rec b = if b then true else false;;
               ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 28-34:
+Line 3, characters 12-18:
   let rec x = r := x;;
               ^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 15-65:
+Line 3, characters 2-52:
   ..for i = 0 to 1 do
       let z = y in ignore z
     done
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 15-46:
+Line 3, characters 2-33:
   ..for i = 0 to y do
       ()
     done
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 15-47:
+Line 3, characters 2-34:
   ..for i = y to 10 do
       ()
     done
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 15-62:
+Line 3, characters 2-49:
   ..while false do
       let y = x in ignore y
     done
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 15-39:
+Line 3, characters 2-26:
   ..while y do
       ()
     done
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 15-58:
+Line 3, characters 2-45:
   ..while y do
       let y = x in ignore y
     done
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-16:
+Line 2, characters 12-15:
   let rec x = y#m and y = object method m = () end;;
               ^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-45:
+Line 2, characters 12-44:
   let rec x = (object method m _ = () end)#m x;;
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-23:
+Line 2, characters 12-22:
   let rec x = y.contents and y = { contents = 3 };;
               ^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-59:
+Line 2, characters 12-58:
   let rec x = object val mutable v = 0 method m = v <- y end and y = 1;;
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-21:
+Line 2, characters 12-20:
   let rec x = assert y and y = true;;
               ^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-36:
+Line 2, characters 12-35:
   let rec x = object method m = x end;;
               ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 13-43:
+Line 2, characters 12-42:
   let rec x = object method m = ignore x end;;
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 230-246:
+Line 9, characters 14-30:
     let rec x = Pervasives.ref y
                 ^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 127-175:
+Line 6, characters 4-52:
       if p then (fun y -> x + g y) else (fun y -> g y)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 37-61:
+Line 3, characters 12-36:
   let rec x = (module (val y : T) : T)
               ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 15-98:
+Line 3, characters 2-85:
   ..match let _ = y in raise Not_found with
       _ -> "x"
     | exception Not_found -> "z"

--- a/testsuite/tests/letrec-disallowed/extension_constructor.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/extension_constructor.ocaml.reference
@@ -1,5 +1,5 @@
 module type T = sig exception A of int end
-Characters 15-49:
+Line 3, characters 2-36:
   ..let module M = (val m) in
     M.A 42
 Error: This kind of expression is not allowed as right-hand side of `let rec'

--- a/testsuite/tests/letrec-disallowed/float_block_disallowed.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/float_block_disallowed.ocaml.reference
@@ -1,4 +1,4 @@
-Characters 470-480:
+Line 14, characters 14-24:
     let rec x = [| y; y |] and y = 1. in
                 ^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'

--- a/testsuite/tests/letrec-disallowed/generic_arrays.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/generic_arrays.ocaml.reference
@@ -1,4 +1,4 @@
-Characters 188-198:
+Line 7, characters 22-32:
   let f z = let rec x = [| y; z |] and y = z in x;;
                         ^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'

--- a/testsuite/tests/letrec-disallowed/labels.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/labels.ocaml.reference
@@ -1,5 +1,5 @@
 val f : x:(unit -> 'a) -> unit -> 'a = <fun>
-Characters 12-16:
+Line 1, characters 12-16:
   let rec x = f ~x;;
               ^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'

--- a/testsuite/tests/letrec-disallowed/lazy_.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/lazy_.ocaml.reference
@@ -1,4 +1,4 @@
-Characters 38-44:
+Line 5, characters 12-18:
   let rec a = lazy b and b = 3;;
               ^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'

--- a/testsuite/tests/letrec-disallowed/module_constraints.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/module_constraints.ocaml.reference
@@ -1,7 +1,7 @@
 module type S = sig val y : float end
 module type T = sig val x : float val y : float end
 type t = T : (module S) -> t
-Characters 13-51:
+Line 2, characters 12-50:
   let rec x = let module M = (val m) in T (module M)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'

--- a/testsuite/tests/letrec-disallowed/pr7215.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/pr7215.ocaml.reference
@@ -1,6 +1,6 @@
 type (_, _) eq = Refl : ('a, 'a) eq
 val cast : ('a, 'b) eq -> 'a -> 'b = <fun>
-Characters 53-78:
+Line 3, characters 30-55:
     let rec (p : (int, a) eq) = match p with Refl -> Refl in
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'

--- a/testsuite/tests/letrec-disallowed/pr7231.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/pr7231.ocaml.reference
@@ -1,8 +1,8 @@
-Characters 84-90:
+Line 5, characters 58-64:
   let rec r = let rec x () = r and y () = x () in y () in r "oops";;
                                                             ^^^^^^
 Warning 20: this argument will not be used by the function.
-Characters 38-78:
+Line 5, characters 12-52:
   let rec r = let rec x () = r and y () = x () in y () in r "oops";;
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'

--- a/testsuite/tests/letrec-disallowed/pr7706.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/pr7706.ocaml.reference
@@ -1,8 +1,8 @@
-Characters 39-104:
+Line 5, characters 2-67:
   ..let y = if false then (fun z -> 1) else (fun z -> x 4 + 1) in
     y..
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 18-19:
+Line 2, characters 17-18:
   let () = ignore (x 42);;
                    ^
 Error: Unbound value x

--- a/testsuite/tests/letrec-disallowed/unboxed.ocaml.reference
+++ b/testsuite/tests/letrec-disallowed/unboxed.ocaml.reference
@@ -1,14 +1,14 @@
 type t = { x : int64; } [@@unboxed]
-Characters 12-19:
+Line 1, characters 12-19:
   let rec x = {x = y} and y = 3L;;
               ^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 type r = A of r [@@unboxed]
-Characters 12-15:
+Line 1, characters 12-15:
   let rec y = A y;;
               ^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 63-136:
+Line 6, characters 2-75:
   ..{a=
       (if Sys.opaque_identity true then
          X a
@@ -17,7 +17,7 @@ Characters 63-136:
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 type d = D of e [@@unboxed]
 and e = V of d | W
-Characters 15-85:
+Line 3, characters 2-72:
   ..D
       (if Sys.opaque_identity true then
          V d

--- a/testsuite/tests/lexing/uchar_esc.ocaml.reference
+++ b/testsuite/tests/lexing/uchar_esc.ocaml.reference
@@ -1,33 +1,33 @@
-Characters 34-43:
+Line 5, characters 18-27:
   let invalid_sv = "\u{0D800}" ;;
                     ^^^^^^^^^
 Error: Illegal backslash escape in string or character (\u{0D800}, D800 is not a Unicode scalar value)
-Characters 18-26:
+Line 1, characters 18-26:
   let invalid_sv = "\u{D800}" ;;
                     ^^^^^^^^
 Error: Illegal backslash escape in string or character (\u{D800}, D800 is not a Unicode scalar value)
-Characters 18-26:
+Line 1, characters 18-26:
   let invalid_sv = "\u{D900}" ;;
                     ^^^^^^^^
 Error: Illegal backslash escape in string or character (\u{D900}, D900 is not a Unicode scalar value)
-Characters 18-26:
+Line 1, characters 18-26:
   let invalid_sv = "\u{DFFF}" ;;
                     ^^^^^^^^
 Error: Illegal backslash escape in string or character (\u{DFFF}, DFFF is not a Unicode scalar value)
-Characters 18-28:
+Line 1, characters 18-28:
   let invalid_sv = "\u{110000} ;;
                     ^^^^^^^^^^
 Error: Illegal backslash escape in string or character (\u{110000}, 110000 is not a Unicode scalar value)
-Characters 24-36:
+Line 2, characters 23-35:
   let too_many_digits = "\u{01234567}" ;;
                          ^^^^^^^^^^^^
 Error: Illegal backslash escape in string or character (\u{01234567}, too many digits, expected 1 to 6 hexadecimal digits)
-Characters 21-23:
+Line 1, characters 21-23:
   let no_hex_digits = "\u{}" ;;
                        ^^
 Warning 14: illegal backslash escape in string.
 val no_hex_digits : string = "\\u{}"
-Characters 25-27:
+Line 1, characters 25-27:
   let illegal_hex_digit = "\u{u}" ;;
                            ^^
 Warning 14: illegal backslash escape in string.

--- a/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
+++ b/testsuite/tests/match-exception-warnings/exhaustiveness_warnings.ml
@@ -16,7 +16,7 @@ let test_match_exhaustiveness () =
 ;;
 
 [%%expect{|
-Line _, characters 4-83:
+Line 8, characters 4-83:
   ....match None with
       | exception e -> ()
       | Some false -> ()
@@ -35,7 +35,7 @@ let test_match_exhaustiveness_nest1 () =
 ;;
 
 [%%expect{|
-Line _, characters 4-73:
+Line 2, characters 4-73:
   ....match None with
       | Some false -> ()
       | None | exception _ -> ()
@@ -53,7 +53,7 @@ let test_match_exhaustiveness_nest2 () =
 ;;
 
 [%%expect{|
-Line _, characters 4-73:
+Line 2, characters 4-73:
   ....match None with
       | Some false | exception _ -> ()
       | None -> ()
@@ -72,7 +72,7 @@ let test_match_exhaustiveness_full () =
 ;;
 
 [%%expect{|
-Line _, characters 4-111:
+Line 2, characters 4-111:
   ....match None with
       | exception e -> ()
       | Some false | exception _ -> ()
@@ -80,11 +80,11 @@ Line _, characters 4-111:
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some true
-Line _, characters 29-30:
+Line 4, characters 29-30:
       | Some false | exception _ -> ()
                                ^
 Warning 11: this match case is unused.
-Line _, characters 23-24:
+Line 5, characters 23-24:
       | None | exception _ -> ()
                          ^
 Warning 11: this match case is unused.

--- a/testsuite/tests/messages/precise_locations.ml
+++ b/testsuite/tests/messages/precise_locations.ml
@@ -6,7 +6,7 @@ type t = (unit, unit, unit, unit) bar
 ;;
 (* PR#7315: we expect the error location on "bar" instead of "(...) bar" *)
 [%%expect{|
-Line _, characters 34-37:
+Line 1, characters 34-37:
   type t = (unit, unit, unit, unit) bar
                                     ^^^
 Error: Unbound type constructor bar
@@ -16,7 +16,7 @@ function (x :
 #bar) -> ();;
 (* we expect the location on "bar" instead of "#bar" *)
 [%%expect{|
-Line _, characters 1-4:
+Line 2, characters 1-4:
   #bar) -> ();;
    ^^^
 Error: Unbound class bar
@@ -27,7 +27,7 @@ function
 ;;
 (* we expect the location on "bar" instead of "#bar" *)
 [%%expect{|
-Line _, characters 1-4:
+Line 2, characters 1-4:
   #bar -> ()
    ^^^
 Error: Unbound type constructor bar
@@ -36,7 +36,7 @@ Error: Unbound type constructor bar
 new bar;;
 (* we expect the location on "bar" instead of "new bar" *)
 [%%expect{|
-Line _, characters 4-7:
+Line 1, characters 4-7:
   new bar;;
       ^^^
 Error: Unbound class bar
@@ -51,7 +51,7 @@ Foo ();;
 (* "Foo ()": the whole construct, with arguments, is deprecated *)
 [%%expect{|
 type t = Foo of unit | Bar
-Line _, characters 0-6:
+Line 6, characters 0-6:
   Foo ();;
   ^^^^^^
 Error (warning 3): deprecated: Foo
@@ -60,7 +60,7 @@ function
 Foo _ -> () | Bar -> ();;
 (* "Foo _", the whole construct is deprecated *)
 [%%expect{|
-Line _, characters 0-5:
+Line 2, characters 0-5:
   Foo _ -> () | Bar -> ();;
   ^^^^^
 Error (warning 3): deprecated: Foo
@@ -70,7 +70,7 @@ Error (warning 3): deprecated: Foo
 open Foo;;
 (* the error location should be on "Foo" *)
 [%%expect{|
-Line _, characters 5-8:
+Line 1, characters 5-8:
   open Foo;;
        ^^^
 Error: Unbound module Foo
@@ -83,7 +83,7 @@ end);;
 (* here we expect the error location to be
    on "open List" as whole rather than "List" *)
 [%%expect{|
-Line _, characters 0-9:
+Line 2, characters 0-9:
   open List
   ^^^^^^^^^
 Error (warning 33): unused open Stdlib.List.
@@ -92,7 +92,7 @@ Error (warning 33): unused open Stdlib.List.
 type unknown += Foo;;
 (* unknown, not the whole line *)
 [%%expect{|
-Line _, characters 5-12:
+Line 1, characters 5-12:
   type unknown += Foo;;
        ^^^^^^^
 Error: Unbound type constructor unknown
@@ -104,7 +104,7 @@ Foo = Foobar;;
 (* Foobar, not the whole line *)
 [%%expect{|
 type t = ..
-Line _, characters 6-12:
+Line 3, characters 6-12:
   Foo = Foobar;;
         ^^^^^^
 Error: Unbound constructor Foobar

--- a/testsuite/tests/parsing/docstrings.ml
+++ b/testsuite/tests/parsing/docstrings.ml
@@ -282,7 +282,7 @@ module Manual :
     module type my_module_type  = sig val x : int end[@@ocaml.doc
                                                        " The comment for module type my_module_type. "]
   end ;;
-Line _, characters 12-14:
+Line 128, characters 12-14:
       inherit cl
               ^^
 Error: Unbound class cl

--- a/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
+++ b/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
@@ -1,27 +1,30 @@
-Characters 197-204:
+Line 9, characters 8-15:
   let x = (1 + 2) +. 3. in ();;
           ^^^^^^^
 Error: This expression has type int but an expression was expected of type
          float
-Characters 9-18:
+Line 2, characters 8-9,
+Line 2, characters 15-17:
   let x = (1 + 2 in ();;
           ^      ^^
 Syntax error: ')' expected, the highlighted '(' might be unmatched
-Characters 9-17:
+Line 2, characters 8-9,
+Line 2, characters 14-16:
   let x = (1 + 2;;
           ^     ^^
 Syntax error: ')' expected, the highlighted '(' might be unmatched
-Characters 22-23:
+Line 3, characters 8-9:
   let y = 1 +. 2. in
           ^
 Error: This expression has type int but an expression was expected of type
          float
-Characters 9-20:
+Line 2, characters 8-9,
+Line 4, characters 2-4:
   ........(.
   ...
   ..in
 Syntax error: ')' expected, the highlighted '(' might be unmatched
-Characters 9-18:
+Line 2, characters 8-17:
   ........(1
     +
   2)...

--- a/testsuite/tests/tool-toplevel/pr6468.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr6468.compilers.reference
@@ -1,12 +1,12 @@
 - : unit = ()
 val f : unit -> 'a = <fun>
-Characters 11-15:
+Line 1, characters 11-15:
   let g () = f (); 1;;
              ^^^^
 Warning 21: this statement never returns (or has an unsound type.)
 val g : unit -> int = <fun>
 Exception: Not_found.
-Raised at file "//toplevel//", line 7, characters 17-26
-Called from file "//toplevel//", line 7, characters 10-14
+Raised at file "//toplevel//", line 2, characters 17-26
+Called from file "//toplevel//", line 1, characters 11-15
 Called from file "toplevel/toploop.ml", line 179, characters 17-27
 

--- a/testsuite/tests/tool-toplevel/pr7060.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr7060.compilers.reference
@@ -1,6 +1,6 @@
 type t = A | B
 type u = C of t
-Characters 18-54:
+Line 1, characters 18-54:
   let print_t out = function A -> Format.fprintf out "A";;
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -8,8 +8,8 @@ Here is an example of a case that is not matched:
 B
 val print_t : Format.formatter -> t -> unit = <fun>
 - : t =
-<printer print_t raised an exception: File "//toplevel//", line 5, characters -8--3: Pattern matching failed>
+<printer print_t raised an exception: File "//toplevel//", line 1, characters 18-23: Pattern matching failed>
 - : u =
 C
- <printer print_t raised an exception: File "//toplevel//", line 5, characters -8--3: Pattern matching failed>
+ <printer print_t raised an exception: File "//toplevel//", line 1, characters 18-23: Pattern matching failed>
 

--- a/testsuite/tests/typing-core-bugs/missing_rec_hint.ml
+++ b/testsuite/tests/typing-core-bugs/missing_rec_hint.ml
@@ -6,7 +6,7 @@ let facto n =   (* missing [rec] *)
    if n = 0 then 1 else n * facto (n-1)
 
 [%%expect{|
-Line _, characters 28-33:
+Line 2, characters 28-33:
      if n = 0 then 1 else n * facto (n-1)
                               ^^^^^
 Error: Unbound value facto
@@ -19,7 +19,7 @@ let f x = f x in
 ()
 
 [%%expect{|
-Line _, characters 10-11:
+Line 2, characters 10-11:
   let f x = f x in
             ^
 Error: Unbound value f
@@ -32,7 +32,7 @@ and g x = if x < 0 then x else f (x-1)
 and h x = if x < 0 then x else g (x-1)
 
 [%%expect{|
-Line _, characters 31-32:
+Line 1, characters 31-32:
   let f x = if x < 0 then x else h (x-1)
                                  ^
 Error: Unbound value h
@@ -45,7 +45,7 @@ let value2 = value2 (* typo: should be value1 *) + 1 in
 ()
 
 [%%expect{|
-Line _, characters 13-19:
+Line 2, characters 13-19:
   let value2 = value2 (* typo: should be value1 *) + 1 in
                ^^^^^^
 Error: Unbound value value2
@@ -57,7 +57,7 @@ let foobar2 () = foobar2 () (* typo? or missing "rec"? *) in
 ()
 
 [%%expect{|
-Line _, characters 17-24:
+Line 2, characters 17-24:
   let foobar2 () = foobar2 () (* typo? or missing "rec"? *) in
                    ^^^^^^^
 Error: Unbound value foobar2

--- a/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
+++ b/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
@@ -6,7 +6,7 @@
 if 3 then ();;
 
 [%%expect{|
-Line _, characters 3-4:
+Line 1, characters 3-4:
   if 3 then ();;
      ^
 Error: This expression has type int but an expression was expected of type
@@ -17,7 +17,7 @@ Error: This expression has type int but an expression was expected of type
 fun b -> if true then (print_int b) else (if b then ());;
 
 [%%expect{|
-Line _, characters 45-46:
+Line 1, characters 45-46:
   fun b -> if true then (print_int b) else (if b then ());;
                                                ^
 Error: This expression has type int but an expression was expected of type
@@ -30,7 +30,7 @@ Error: This expression has type int but an expression was expected of type
 fun b -> if true then (if b then ()) else (print_int b);;
 
 [%%expect{|
-Line _, characters 53-54:
+Line 1, characters 53-54:
   fun b -> if true then (if b then ()) else (print_int b);;
                                                        ^
 Error: This expression has type bool but an expression was expected of type
@@ -40,7 +40,7 @@ Error: This expression has type bool but an expression was expected of type
 if (let x = 3 in x) then ();;
 
 [%%expect{|
-Line _, characters 17-18:
+Line 1, characters 17-18:
   if (let x = 3 in x) then ();;
                    ^
 Error: This expression has type int but an expression was expected of type
@@ -51,7 +51,7 @@ Error: This expression has type int but an expression was expected of type
 if (if true then 3 else 4) then ();;
 
 [%%expect{|
-Line _, characters 17-18:
+Line 1, characters 17-18:
   if (if true then 3 else 4) then ();;
                    ^
 Error: This expression has type int but an expression was expected of type
@@ -62,7 +62,7 @@ Error: This expression has type int but an expression was expected of type
 if true then 3;;
 
 [%%expect{|
-Line _, characters 13-14:
+Line 1, characters 13-14:
   if true then 3;;
                ^
 Error: This expression has type int but an expression was expected of type
@@ -73,7 +73,7 @@ Error: This expression has type int but an expression was expected of type
 if (fun x -> x) then ();;
 
 [%%expect{|
-Line _, characters 3-15:
+Line 1, characters 3-15:
   if (fun x -> x) then ();;
      ^^^^^^^^^^^^
 Error: This expression should not be a function, the expected type is
@@ -84,7 +84,7 @@ because it is in the condition of an if-statement
 while 42 do () done;;
 
 [%%expect{|
-Line _, characters 6-8:
+Line 1, characters 6-8:
   while 42 do () done;;
         ^^
 Error: This expression has type int but an expression was expected of type
@@ -97,7 +97,7 @@ Error: This expression has type int but an expression was expected of type
 while true do (if true then 3 else 4) done;;
 
 [%%expect{|
-Line _, characters 14-37:
+Line 1, characters 14-37:
   while true do (if true then 3 else 4) done;;
                 ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type int but an expression was expected of type
@@ -108,7 +108,7 @@ Error: This expression has type int but an expression was expected of type
 for i = 3. to 4 do () done;;
 
 [%%expect{|
-Line _, characters 8-10:
+Line 1, characters 8-10:
   for i = 3. to 4 do () done;;
           ^^
 Error: This expression has type float but an expression was expected of type
@@ -119,7 +119,7 @@ Error: This expression has type float but an expression was expected of type
 for i = 3 to 4. do () done;;
 
 [%%expect{|
-Line _, characters 13-15:
+Line 1, characters 13-15:
   for i = 3 to 4. do () done;;
                ^^
 Error: This expression has type float but an expression was expected of type
@@ -132,7 +132,7 @@ Error: This expression has type float but an expression was expected of type
 for i = 0 to 0 do (if true then 3 else 4) done;;
 
 [%%expect{|
-Line _, characters 18-41:
+Line 1, characters 18-41:
   for i = 0 to 0 do (if true then 3 else 4) done;;
                     ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type int but an expression was expected of type
@@ -143,7 +143,7 @@ Error: This expression has type int but an expression was expected of type
 assert 12;;
 
 [%%expect{|
-Line _, characters 7-9:
+Line 1, characters 7-9:
   assert 12;;
          ^^
 Error: This expression has type int but an expression was expected of type
@@ -155,7 +155,7 @@ Error: This expression has type int but an expression was expected of type
 (let x = 3 in x+1); ();;
 
 [%%expect{|
-Line _, characters 0-18:
+Line 1, characters 0-18:
   (let x = 3 in x+1); ();;
   ^^^^^^^^^^^^^^^^^^
 Error: This expression has type int but an expression was expected of type
@@ -168,7 +168,7 @@ let ordered_list_with x y =
   else if x > y then [y;x]
 
 [%%expect{|
-Line _, characters 22-26:
+Line 3, characters 22-26:
     else if x > y then [y;x]
                         ^^^^
 Error: This variant expression is expected to have type unit
@@ -181,7 +181,7 @@ Error: This variant expression is expected to have type unit
   | _ -> ());;
 
 [%%expect{|
-Line _, characters 11-16:
+Line 2, characters 11-16:
     | y when y + 1 -> ()
              ^^^^^
 Error: This expression has type int but an expression was expected of type

--- a/testsuite/tests/typing-core-bugs/unit_fun_hints.ml
+++ b/testsuite/tests/typing-core-bugs/unit_fun_hints.ml
@@ -8,7 +8,7 @@ let _ = g 3;;       (* missing `fun () ->' *)
 
 [%%expect{|
 val g : (unit -> 'a) -> 'a = <fun>
-Line _, characters 10-11:
+Line 2, characters 10-11:
   let _ = g 3;;       (* missing `fun () ->' *)
             ^
 Error: This expression has type int but an expression was expected of type
@@ -25,7 +25,7 @@ let _ =
 (* We use -strict-sequence for this test: otherwise only a warning is produced
    about print_newline not being of type unit *)
 [%%expect{|
-Line _, characters 3-16:
+Line 3, characters 3-16:
      print_newline;    (* missing unit argument *)
      ^^^^^^^^^^^^^
 Error: This expression has type unit -> unit
@@ -38,7 +38,7 @@ let x = read_int in   (* missing unit argument *)
 print_int x;;
 
 [%%expect{|
-Line _, characters 10-11:
+Line 2, characters 10-11:
   print_int x;;
             ^
 Error: This expression has type unit -> int
@@ -51,7 +51,7 @@ let g f =
   f = 3;;
 
 [%%expect{|
-Line _, characters 6-7:
+Line 3, characters 6-7:
     f = 3;;
         ^
 Error: This expression has type int but an expression was expected of type
@@ -64,7 +64,7 @@ let g f =
   3 = f;;
 
 [%%expect{|
-Line _, characters 6-7:
+Line 3, characters 6-7:
     3 = f;;
         ^
 Error: This expression has type unit -> 'a

--- a/testsuite/tests/typing-deprecated/deprecated.ml
+++ b/testsuite/tests/typing-deprecated/deprecated.ml
@@ -16,7 +16,7 @@ end = struct
   let x = 0
 end;;
 [%%expect{|
-Line _, characters 9-10:
+Line 7, characters 9-10:
     val x: t [@@ocaml.deprecated]
            ^
 Warning 3: deprecated: t
@@ -26,7 +26,7 @@ module X : sig type t type s type u val x : t end
 type t = X.t
 ;;
 [%%expect{|
-Line _, characters 9-12:
+Line 1, characters 9-12:
   type t = X.t
            ^^^
 Warning 3: deprecated: X.t
@@ -36,7 +36,7 @@ type t = X.t
 let x = X.x
 ;;
 [%%expect{|
-Line _, characters 8-11:
+Line 1, characters 8-11:
   let x = X.x
           ^^^
 Warning 3: deprecated: X.x
@@ -50,7 +50,7 @@ let (_, foo [@deprecated], _) = 1, (), 3
 foo;;
 [%%expect{|
 val foo : unit = ()
-Line _, characters 0-3:
+Line 3, characters 0-3:
   foo;;
   ^^^
 Warning 3: deprecated: foo
@@ -70,7 +70,7 @@ let f = function
   | bar, cho [@deprecated], _ -> cho + 1
 ;;
 [%%expect{|
-Line _, characters 33-36:
+Line 2, characters 33-36:
     | bar, cho [@deprecated], _ -> cho + 1
                                    ^^^
 Warning 3: deprecated: cho
@@ -83,7 +83,7 @@ class c (_, (foo [@deprecated] : int)) =
   end
 ;;
 [%%expect{|
-Line _, characters 12-15:
+Line 3, characters 12-15:
       val h = foo
               ^^^
 Warning 3: deprecated: foo
@@ -95,11 +95,11 @@ class c : 'a * int -> object val h : int end
 type t = X.t * X.s
 ;;
 [%%expect{|
-Line _, characters 9-12:
+Line 1, characters 9-12:
   type t = X.t * X.s
            ^^^
 Warning 3: deprecated: X.t
-Line _, characters 15-18:
+Line 1, characters 15-18:
   type t = X.t * X.s
                  ^^^
 Warning 3: deprecated: X.s
@@ -116,7 +116,7 @@ type t1 = X.t [@@ocaml.warning "-3"]
 and t2 = X.s
 ;;
 [%%expect{|
-Line _, characters 9-12:
+Line 2, characters 9-12:
   and t2 = X.s
            ^^^
 Warning 3: deprecated: X.s
@@ -127,7 +127,7 @@ and t2 = X.s
 type t = A of t [@@ocaml.deprecated]
 ;;
 [%%expect{|
-Line _, characters 14-15:
+Line 1, characters 14-15:
   type t = A of t [@@ocaml.deprecated]
                 ^
 Warning 3: deprecated: t
@@ -153,7 +153,7 @@ type t = X.t * X.s
 type t = (X.t [@ocaml.warning "-3"]) * X.s
 ;;
 [%%expect{|
-Line _, characters 39-42:
+Line 1, characters 39-42:
   type t = (X.t [@ocaml.warning "-3"]) * X.s
                                          ^^^
 Warning 3: deprecated: X.s
@@ -173,7 +173,7 @@ type t = A of t
 let _ = function (_ : X.t) -> ()
 ;;
 [%%expect{|
-Line _, characters 22-25:
+Line 1, characters 22-25:
   let _ = function (_ : X.t) -> ()
                         ^^^
 Warning 3: deprecated: X.t
@@ -192,7 +192,7 @@ let _ = function (_ : X.t)[@ocaml.warning "-3"] -> ()
 module M = struct let x = X.x end
 ;;
 [%%expect{|
-Line _, characters 26-29:
+Line 1, characters 26-29:
   module M = struct let x = X.x end
                             ^^^
 Warning 3: deprecated: X.x
@@ -214,11 +214,11 @@ module M : sig val x : X.t end
 
 module rec M : sig val x: X.t end = struct let x = X.x end
 [%%expect{|
-Line _, characters 26-29:
+Line 1, characters 26-29:
   module rec M : sig val x: X.t end = struct let x = X.x end
                             ^^^
 Warning 3: deprecated: X.t
-Line _, characters 51-54:
+Line 1, characters 51-54:
   module rec M : sig val x: X.t end = struct let x = X.x end
                                                      ^^^
 Warning 3: deprecated: X.x
@@ -244,7 +244,7 @@ module rec M :
   (sig val x: X.t end)[@ocaml.warning "-3"] =
   struct let x = X.x end
 [%%expect{|
-Line _, characters 17-20:
+Line 3, characters 17-20:
     struct let x = X.x end
                    ^^^
 Warning 3: deprecated: X.x
@@ -256,7 +256,7 @@ module rec M : sig val x : X.t end
 module type S = sig type t = X.t end
 ;;
 [%%expect{|
-Line _, characters 29-32:
+Line 1, characters 29-32:
   module type S = sig type t = X.t end
                                ^^^
 Warning 3: deprecated: X.t
@@ -281,7 +281,7 @@ module type S = sig type t = X.t end
 class c = object method x = X.x end
 ;;
 [%%expect{|
-Line _, characters 28-31:
+Line 1, characters 28-31:
   class c = object method x = X.x end
                               ^^^
 Warning 3: deprecated: X.x
@@ -312,7 +312,7 @@ class c : object method x : X.t end
 class type c = object method x : X.t end
 ;;
 [%%expect{|
-Line _, characters 33-36:
+Line 1, characters 33-36:
   class type c = object method x : X.t end
                                    ^^^
 Warning 3: deprecated: X.t
@@ -344,7 +344,7 @@ class type c = object method x : X.t end
 external foo: unit -> X.t = "foo"
 ;;
 [%%expect{|
-Line _, characters 22-25:
+Line 1, characters 22-25:
   external foo: unit -> X.t = "foo"
                         ^^^
 Warning 3: deprecated: X.t
@@ -363,7 +363,7 @@ external foo : unit -> X.t = "foo"
 X.x
 ;;
 [%%expect{|
-Line _, characters 0-3:
+Line 1, characters 0-3:
   X.x
   ^^^
 Warning 3: deprecated: X.x
@@ -385,7 +385,7 @@ open D
 ;;
 [%%expect{|
 module D : sig  end
-Line _, characters 5-6:
+Line 3, characters 5-6:
   open D
        ^
 Warning 3: deprecated: module D
@@ -399,7 +399,7 @@ open D [@@ocaml.warning "-3"]
 include D
 ;;
 [%%expect{|
-Line _, characters 8-9:
+Line 1, characters 8-9:
   include D
           ^
 Warning 3: deprecated: module D
@@ -425,7 +425,7 @@ type ext +=
   | C of X.u [@ocaml.warning "-3"]
 ;;
 [%%expect{|
-Line _, characters 9-12:
+Line 2, characters 9-12:
     | A of X.t
            ^^^
 Warning 3: deprecated: X.t
@@ -444,7 +444,7 @@ type ext += C of X.t
 exception Foo of X.t
 ;;
 [%%expect{|
-Line _, characters 17-20:
+Line 1, characters 17-20:
   exception Foo of X.t
                    ^^^
 Warning 3: deprecated: X.t
@@ -466,7 +466,7 @@ type t =
   | C of (X.u [@ocaml.warning "-3"])
 ;;
 [%%expect{|
-Line _, characters 9-12:
+Line 2, characters 9-12:
     | A of X.t
            ^^^
 Warning 3: deprecated: X.t
@@ -481,7 +481,7 @@ type t =
   }
 ;;
 [%%expect{|
-Line _, characters 7-10:
+Line 3, characters 7-10:
       a: X.t;
          ^^^
 Warning 3: deprecated: X.t
@@ -497,7 +497,7 @@ type t =
   >
 ;;
 [%%expect{|
-Line _, characters 7-10:
+Line 3, characters 7-10:
       a: X.t;
          ^^^
 Warning 3: deprecated: X.t
@@ -513,7 +513,7 @@ type t =
   ]
 ;;
 [%%expect{|
-Line _, characters 10-13:
+Line 3, characters 10-13:
     | `A of X.t
             ^^^
 Warning 3: deprecated: X.t
@@ -527,7 +527,7 @@ type t = [ `A of X.t | `B of X.s | `C of X.u ]
 [@@@ocaml.ppwarning "Pp warning!"]
 ;;
 [%%expect{|
-Line _, characters 20-33:
+Line 1, characters 20-33:
   [@@@ocaml.ppwarning "Pp warning!"]
                       ^^^^^^^^^^^^^
 Warning 22: Pp warning!
@@ -538,11 +538,11 @@ let x = () [@ocaml.ppwarning "Pp warning 1!"]
     [@@ocaml.ppwarning  "Pp warning 2!"]
 ;;
 [%%expect{|
-Line _, characters 24-39:
+Line 2, characters 24-39:
       [@@ocaml.ppwarning  "Pp warning 2!"]
                           ^^^^^^^^^^^^^^^
 Warning 22: Pp warning 2!
-Line _, characters 29-44:
+Line 1, characters 29-44:
   let x = () [@ocaml.ppwarning "Pp warning 1!"]
                                ^^^^^^^^^^^^^^^
 Warning 22: Pp warning 1!
@@ -553,7 +553,7 @@ type t = unit
     [@ocaml.ppwarning "Pp warning!"]
 ;;
 [%%expect{|
-Line _, characters 22-35:
+Line 2, characters 22-35:
       [@ocaml.ppwarning "Pp warning!"]
                         ^^^^^^^^^^^^^
 Warning 22: Pp warning!
@@ -571,7 +571,7 @@ module X = struct
 end
 ;;
 [%%expect{|
-Line _, characters 22-36:
+Line 8, characters 22-36:
     [@@@ocaml.ppwarning "Pp warning2!"]
                         ^^^^^^^^^^^^^^
 Warning 22: Pp warning2!
@@ -583,7 +583,7 @@ let x =
     [@ocaml.ppwarning  "Pp warning 2!"]
 ;;
 [%%expect{|
-Line _, characters 23-38:
+Line 3, characters 23-38:
       [@ocaml.ppwarning  "Pp warning 2!"]
                          ^^^^^^^^^^^^^^^
 Warning 22: Pp warning 2!
@@ -596,11 +596,11 @@ type t =
   [@@ocaml.ppwarning "Pp warning 3!"]
 ;;
 [%%expect{|
-Line _, characters 21-36:
+Line 4, characters 21-36:
     [@@ocaml.ppwarning "Pp warning 3!"]
                        ^^^^^^^^^^^^^^^
 Warning 22: Pp warning 3!
-Line _, characters 21-36:
+Line 3, characters 21-36:
     [@ocaml.ppwarning  "Pp warning 2!"]
                        ^^^^^^^^^^^^^^^
 Warning 22: Pp warning 2!
@@ -610,11 +610,11 @@ type t = unit
 let ([][@ocaml.ppwarning "XX"]) = []
 ;;
 [%%expect{|
-Line _, characters 25-29:
+Line 1, characters 25-29:
   let ([][@ocaml.ppwarning "XX"]) = []
                            ^^^^
 Warning 22: XX
-Line _, characters 4-31:
+Line 1, characters 4-31:
   let ([][@ocaml.ppwarning "XX"]) = []
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-extension-constructor/test.ocaml.reference
+++ b/testsuite/tests/typing-extension-constructor/test.ocaml.reference
@@ -3,7 +3,7 @@ type t += A
 - : extension_constructor = <abstr>
 - : extension_constructor = <abstr>
 module M : sig type extension_constructor = int end
-Characters 2-28:
+Line 2, characters 1-27:
   ([%extension_constructor A] : extension_constructor);;
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type extension_constructor

--- a/testsuite/tests/typing-extensions/extensions.ocaml.reference
+++ b/testsuite/tests/typing-extensions/extensions.ocaml.reference
@@ -3,23 +3,23 @@ type foo = ..
 type foo += A | B of int
 val is_a : foo -> bool = <fun>
 type foo
-Characters 1-21:
+Line 2, characters 0-20:
   type foo += A of int (* Error type is not open *)
   ^^^^^^^^^^^^^^^^^^^^
 Error: Type definition foo is not extensible
 type foo = private ..
-Characters 13-21:
+Line 2, characters 12-20:
   type foo += A of int (* Error type is private *)
               ^^^^^^^^
 Error: Cannot extend private type definition foo
 type 'a foo = ..
-Characters 1-30:
+Line 2, characters 0-29:
   type ('a, 'b) foo += A of int (* Error: type parameter mismatch *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This extension does not match the definition of type foo
        They have different arities.
 module type S = sig type foo = private .. type foo += A of float end
-Characters 73-95:
+Line 7, characters 2-24:
     type foo += B of float (* Error: foo does not have an extensible type *)
     ^^^^^^^^^^^^^^^^^^^^^^
 Error: Type definition foo is not extensible
@@ -42,12 +42,12 @@ type _ foo += A : int -> int foo | B : int foo
 val get_num : 'a foo -> 'a -> 'a option = <fun>
 type 'a foo = .. constraint 'a = [> `Var ]
 type 'a foo += A of 'a
-Characters 11-12:
+Line 2, characters 10-11:
   let a = A 9 (* ERROR: Constraints not met *)
             ^
 Error: This expression has type int but an expression was expected of type
          [> `Var ]
-Characters 20-23:
+Line 2, characters 19-22:
   type 'a foo += B : int foo (* ERROR: Constraints not met *)
                      ^^^
 Error: This type int should be an instance of type [> `Var ]
@@ -57,7 +57,7 @@ val a1 : foo = M.A 10
 module type S = sig type foo += private A of int end
 module M_S : S
 val is_s : foo -> bool = <fun>
-Characters 10-18:
+Line 2, characters 9-17:
   let a2 = M_S.A 20 (* ERROR: Cannot create a value using a private constructor *)
            ^^^^^^^^
 Error: Cannot create values of the private type foo
@@ -65,17 +65,17 @@ type foo = ..
 module M : sig type foo += A1 of int end
 type foo += A2 of int
 type bar = ..
-Characters 18-22:
+Line 2, characters 17-21:
   type bar += A3 = M.A1    (* Error: rebind wrong type *)
                    ^^^^
 Error: The constructor M.A1 has type foo but was expected to be of type bar
 module M : sig type foo += private B1 of int end
 type foo += private B2 of int
-Characters 18-22:
+Line 2, characters 17-21:
   type foo += B3 = M.B1  (* Error: rebind private extension *)
                    ^^^^
 Error: The constructor M.B1 is private
-Characters 17-24:
+Line 2, characters 16-23:
   type foo += C = Unknown  (* Error: unbound extension *)
                   ^^^^^^^
 Error: Unbound constructor Unknown
@@ -88,20 +88,20 @@ type 'a foo1 += A of int | B of 'a | C : int foo1
 type 'a foo2 += D of int | E of 'a | F : int foo2
 type +'a foo = ..
 type 'a foo += A of (int -> 'a)
-Characters 1-32:
+Line 2, characters 0-31:
   type 'a foo += B of ('a -> int)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this definition, expected parameter variances are not satisfied.
        The 1st type parameter was expected to be covariant,
        but it is injective contravariant.
-Characters 1-40:
+Line 2, characters 0-39:
   type _ foo += C : ('a -> int) -> 'a foo
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this definition, expected parameter variances are not satisfied.
        The 1st type parameter was expected to be covariant,
        but it is injective contravariant.
 type 'a bar = ..
-Characters 1-33:
+Line 2, characters 0-32:
   type +'a bar += D of (int -> 'a) (* ERROR: type variances do not match *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This extension does not match the definition of type bar

--- a/testsuite/tests/typing-extensions/open_types.ocaml.reference
+++ b/testsuite/tests/typing-extensions/open_types.ocaml.reference
@@ -8,23 +8,23 @@ module type S = sig type baz += Foo of float end
 module M_S : S
 type foo = ..
 type bar = foo
-Characters 1-23:
+Line 2, characters 0-22:
   type bar += Bar of int (* Error: type is not open *)
   ^^^^^^^^^^^^^^^^^^^^^^
 Error: Type definition bar is not extensible
-Characters 1-20:
+Line 2, characters 0-19:
   type baz = bar = .. (* Error: type kinds don't match *)
   ^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type bar
        Their kinds differ.
 type 'a foo = ..
-Characters 1-32:
+Line 2, characters 0-31:
   type ('a, 'b) bar = 'a foo = .. (* Error: arrities do not match *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type 'a foo
        They have different arities.
 type ('a, 'b) foo = ..
-Characters 1-38:
+Line 2, characters 0-37:
   type ('a, 'b) bar = ('a, 'a) foo = .. (* Error: constraints do not match *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type
@@ -33,13 +33,13 @@ Error: This variant or record definition does not match that of type
 module M : sig type foo = .. end
 module type S = sig type foo end
 module M_S : S
-Characters 1-20:
+Line 2, characters 0-19:
   type M_S.foo += Foo (* ERROR: Cannot extend a type that isn't "open" *)
   ^^^^^^^^^^^^^^^^^^^
 Error: Type definition M_S.foo is not extensible
 module M : sig type foo end
 module type S = sig type foo = .. end
-Characters 15-16:
+Line 2, characters 14-15:
   module M_S = (M : S) (* ERROR: Signatures are not compatible *)
                 ^
 Error: Signature mismatch:
@@ -52,13 +52,13 @@ Error: Signature mismatch:
 module M : sig type foo = .. end
 module type S = sig type foo = private .. end
 module M_S : S
-Characters 17-20:
+Line 2, characters 16-19:
   type M_S.foo += Foo (* ERROR: Cannot extend a private extensible type *)
                   ^^^
 Error: Cannot extend private type definition M_S.foo
 module M : sig type foo = private .. end
 module type S = sig type foo = .. end
-Characters 15-16:
+Line 2, characters 14-15:
   module M_S = (M : S) (* ERROR: Signatures are not compatible *)
                 ^
 Error: Signature mismatch:
@@ -73,7 +73,7 @@ Error: Signature mismatch:
        A private type would be revealed.
 module M : sig type +'a foo = .. type 'a bar = 'a foo = .. end
 module type S = sig type 'a foo = .. type 'a bar = 'a foo = .. end
-Characters 15-16:
+Line 2, characters 14-15:
   module M_S = (M : S) (* ERROR: Signatures are not compatible *)
                 ^
 Error: Signature mismatch:
@@ -87,7 +87,7 @@ Error: Signature mismatch:
          type 'a foo = ..
        Their variances do not agree.
 type exn2 = exn = ..
-Characters 61-79:
+Line 6, characters 8-26:
   let f = function Foo -> ()
           ^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -98,7 +98,7 @@ must include a wild card pattern in order to be exhaustive.
 type foo = ..
 type foo += Foo
 val f : foo -> unit = <fun>
-Characters 44-96:
+Line 4, characters 8-60:
   ........function
     | [Foo] -> 1
     | _::_::_ -> 3
@@ -111,7 +111,7 @@ must include a wild card pattern in order to be exhaustive.
 val f : foo list -> int = <fun>
 type t = ..
 type t += IPair : (int * int) -> t
-Characters 9-63:
+Line 2, characters 8-62:
   let f = function IPair (i, j) -> Format.sprintf "(%d, %d)" i j ;; (* warn *)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -15,7 +15,7 @@ let ret_e1 (type a b) (b : bool) (wit : (a, b) eq) (x : a) (y : b) =
   | _ -> x
 ;;
 [%%expect{|
-Line _, characters 29-30:
+Line 3, characters 29-30:
     | Refl -> if b then x else y
                                ^
 Error: This expression has type b = a but an expression was expected of type
@@ -30,7 +30,7 @@ let ret_e2 (type a b) (b : bool) (wit : (a, b) eq) (x : a) (y : b) =
   | _ -> y
 ;;
 [%%expect{|
-Line _, characters 29-30:
+Line 3, characters 29-30:
     | Refl -> if b then x else y
                                ^
 Error: This expression has type b = a but an expression was expected of type
@@ -45,7 +45,7 @@ let ret_ei1 (type a) (b : bool) (wit : (a, int) eq) (x : a) =
   | _ -> x
 ;;
 [%%expect{|
-Line _, characters 29-30:
+Line 3, characters 29-30:
     | Refl -> if b then x else 0
                                ^
 Error: This expression has type int but an expression was expected of type
@@ -60,7 +60,7 @@ let ret_ei2 (type a) (b : bool) (wit : (a, int) eq) (x : a) =
   | _ -> x
 ;;
 [%%expect{|
-Line _, characters 29-30:
+Line 3, characters 29-30:
     | Refl -> if b then x else 0
                                ^
 Error: This expression has type int but an expression was expected of type
@@ -76,7 +76,7 @@ let ret_f (type a b) (wit : (a, b) eq) (x : a) (y : b) =
   | _ -> [x]
 ;;
 [%%expect{|
-Line _, characters 16-17:
+Line 3, characters 16-17:
     | Refl -> [x; y]
                   ^
 Error: This expression has type b = a but an expression was expected of type
@@ -91,7 +91,7 @@ let ret_g1 (type a b) (wit : (a, b) eq) (x : a) (y : b) =
   | _ -> [y]
 ;;
 [%%expect{|
-Line _, characters 16-17:
+Line 3, characters 16-17:
     | Refl -> [x; y]
                   ^
 Error: This expression has type b = a but an expression was expected of type
@@ -113,7 +113,7 @@ let f (type a b) (x : (a, b) eq) =
   | _, [(_ : a)] -> []
 ;;
 [%%expect{|
-Line _, characters 4-29:
+Line 3, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type (a, b) eq * b list
@@ -128,7 +128,7 @@ let g1 (type a b) (x : (a, b) eq) =
   | _, [(_ : b)] -> []
 ;;
 [%%expect{|
-Line _, characters 4-29:
+Line 3, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type (a, b) eq * b list
@@ -143,7 +143,7 @@ let g2 (type a b) (x : (a, b) eq) =
   | _, [(_ : a)] -> []
 ;;
 [%%expect{|
-Line _, characters 4-29:
+Line 3, characters 4-29:
     | Refl, [(_ : b) | (_ : a)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type (a, b) eq * b list
@@ -158,7 +158,7 @@ let h1 (type a b) (x : (a, b) eq) =
   | Refl, [(_ : a) | (_ : b)] -> []
 ;;
 [%%expect{|
-Line _, characters 4-29:
+Line 4, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type (a, b) eq * b list
@@ -173,7 +173,7 @@ let h2 (type a b) (x : (a, b) eq) =
   | Refl, [(_ : a) | (_ : b)] -> []
 ;;
 [%%expect{|
-Line _, characters 4-29:
+Line 4, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type (a, b) eq * b list
@@ -188,7 +188,7 @@ let h3 (type a b) (x : (a, b) eq) =
   | Refl, [(_ : b) | (_ : a)] -> []
 ;;
 [%%expect{|
-Line _, characters 4-29:
+Line 4, characters 4-29:
     | Refl, [(_ : b) | (_ : a)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type (a, b) eq * b list

--- a/testsuite/tests/typing-gadts/didier.ml
+++ b/testsuite/tests/typing-gadts/didier.ml
@@ -12,7 +12,7 @@ let fbool (type t) (x : t) (tag : t ty) =
 ;;
 [%%expect{|
 type 'a ty = Int : int ty | Bool : bool ty
-Line _, characters 2-30:
+Line 6, characters 2-30:
   ..match tag with
     | Bool -> x
 Warning 8: this pattern-matching is not exhaustive.
@@ -28,7 +28,7 @@ let fint (type t) (x : t) (tag : t ty) =
   | Int -> x > 0
 ;;
 [%%expect{|
-Line _, characters 2-33:
+Line 2, characters 2-33:
   ..match tag with
     | Int -> x > 0
 Warning 8: this pattern-matching is not exhaustive.
@@ -49,7 +49,7 @@ let f (type t) (x : t) (tag : t ty) =
 [%%expect{|
 val f : 'a -> 'a ty -> bool = <fun>
 |}, Principal{|
-Line _, characters 12-13:
+Line 4, characters 12-13:
     | Bool -> x
               ^
 Error: This expression has type t but an expression was expected of type bool
@@ -63,13 +63,13 @@ let g (type t) (x : t) (tag : t ty) =
   | Int -> x > 0
 ;;
 [%%expect{|
-Line _, characters 11-16:
+Line 4, characters 11-16:
     | Int -> x > 0
              ^^^^^
 Error: This expression has type bool but an expression was expected of type
          t = int
 |}, Principal{|
-Line _, characters 11-16:
+Line 4, characters 11-16:
     | Int -> x > 0
              ^^^^^
 Error: This expression has type bool but an expression was expected of type t

--- a/testsuite/tests/typing-gadts/dynamic_frisch.ml
+++ b/testsuite/tests/typing-gadts/dynamic_frisch.ml
@@ -601,7 +601,7 @@ let ty_list : type a e. (a,e) ty -> (a vlist,e) ty = fun t ->
     | "Cons", Some (Tdyn (Pair (_, Var), (p : a * a vlist))) -> `Cons p)))
 ;;
 [%%expect{|
-Line _, characters 41-58:
+Line 7, characters 41-58:
       | "Cons", Some (Tdyn (Pair (_, Var), (p : a * a vlist))) -> `Cons p)))
                                            ^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type a * a vlist

--- a/testsuite/tests/typing-gadts/nested_equations.ml
+++ b/testsuite/tests/typing-gadts/nested_equations.ml
@@ -16,7 +16,7 @@ let w_bool : bool t = Obj.magic 0;;
 let f_bool (x : bool) : int = let Int = w_bool in x;; (* fail *)
 [%%expect{|
 val w_bool : bool t = Int
-Line _, characters 34-37:
+Line 2, characters 34-37:
   let f_bool (x : bool) : int = let Int = w_bool in x;; (* fail *)
                                     ^^^
 Error: This pattern matches values of type int t
@@ -35,7 +35,7 @@ let w_spec : Arg.spec t = Obj.magic 0;;
 let f_spec (x : Arg.spec) : int = let Int = w_spec in x;; (* fail *)
 [%%expect{|
 val w_spec : Arg.spec t = Int
-Line _, characters 38-41:
+Line 2, characters 38-41:
   let f_spec (x : Arg.spec) : int = let Int = w_spec in x;; (* fail *)
                                         ^^^
 Error: This pattern matches values of type int t

--- a/testsuite/tests/typing-gadts/pr5332.ml
+++ b/testsuite/tests/typing-gadts/pr5332.ml
@@ -26,7 +26,7 @@ type ('env, 'a) typ =
     Tint : ('env, int) typ
   | Tbool : ('env, bool) typ
   | Tvar : ('env, 'a) var -> ('env, 'a) typ
-Line _, characters 5-6:
+Line 15, characters 5-6:
      | _ -> .   (* error *)
        ^
 Error: This match case could not be refuted.

--- a/testsuite/tests/typing-gadts/pr5689.ml
+++ b/testsuite/tests/typing-gadts/pr5689.ml
@@ -100,7 +100,7 @@ let rec process : type a. a linkp2 -> ast_t -> a inline_t =
 ;;
 [%%expect{|
 type _ linkp2 = Kind : 'a linkp -> ([< inkind ] as 'a) linkp2
-Line _, characters 35-43:
+Line 7, characters 35-43:
       | (Kind _, Ast_Text txt)    -> Text txt
                                      ^^^^^^^^
 Error: This expression has type ([< inkind > `Nonlink ] as 'a) inline_t

--- a/testsuite/tests/typing-gadts/pr5785.ml
+++ b/testsuite/tests/typing-gadts/pr5785.ml
@@ -13,7 +13,7 @@ struct
     | Two, Two -> "four"
 end;;
 [%%expect{|
-Line _, characters 43-100:
+Line 7, characters 43-100:
   ...........................................function
       | One, One -> "two"
       | Two, Two -> "four"

--- a/testsuite/tests/typing-gadts/pr5906.ml
+++ b/testsuite/tests/typing-gadts/pr5906.ml
@@ -27,7 +27,7 @@ type (_, _, _) binop =
     Eq : ('a, 'a, bool) binop
   | Leq : ('a, 'a, bool) binop
   | Add : (int, int, int) binop
-Line _, characters 2-195:
+Line 12, characters 2-195:
   ..match bop, x, y with
     | Eq, Bool x, Bool y -> Bool (if x then y else not y)
     | Leq, Int x, Int y -> Bool (x <= y)

--- a/testsuite/tests/typing-gadts/pr5948.ml
+++ b/testsuite/tests/typing-gadts/pr5948.ml
@@ -39,7 +39,7 @@ val intB : [< `TagB ] -> int = <fun>
 val intAorB : [< `TagA of int | `TagB ] -> int = <fun>
 type _ wrapPoly =
     WrapPoly : 'a poly -> ([< `TagA of int | `TagB ] as 'a) wrapPoly
-Line _, characters 23-27:
+Line 25, characters 23-27:
       | WrapPoly ATag -> intA
                          ^^^^
 Error: This expression has type ([< `TagA of 'b ] as 'a) -> 'b
@@ -52,7 +52,7 @@ Error: This expression has type ([< `TagA of 'b ] as 'a) -> 'b
 let _ =  example6 (WrapPoly AandBTags) `TagB (* This causes a seg fault *)
 ;;
 [%%expect{|
-Line _, characters 9-17:
+Line 1, characters 9-17:
   let _ =  example6 (WrapPoly AandBTags) `TagB (* This causes a seg fault *)
            ^^^^^^^^
 Error: Unbound value example6

--- a/testsuite/tests/typing-gadts/pr5981.ml
+++ b/testsuite/tests/typing-gadts/pr5981.ml
@@ -12,7 +12,7 @@ module F(S : sig type 'a t end) = struct
     | A, B -> "f A B"
 end;;
 [%%expect{|
-Line _, characters 47-84:
+Line 7, characters 47-84:
   ...............................................match l, r with
       | A, B -> "f A B"
 Warning 8: this pattern-matching is not exhaustive.
@@ -39,7 +39,7 @@ module F(S : sig type 'a t end) = struct
     | A, B -> "f A B"
 end;;
 [%%expect{|
-Line _, characters 15-52:
+Line 10, characters 15-52:
   ...............match l, r with
       | A, B -> "f A B"
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/pr5985.ml
+++ b/testsuite/tests/typing-gadts/pr5985.ml
@@ -8,7 +8,7 @@ module F (S : sig type 'a s end) = struct
   type _ t = T : 'a -> 'a s t
 end;; (* fail *)
 [%%expect{|
-Line _, characters 2-29:
+Line 3, characters 2-29:
     type _ t = T : 'a -> 'a s t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this definition, a type variable cannot be deduced
@@ -37,7 +37,7 @@ module F(T:sig type 'a t end) = struct
     object constraint 'a = 'b T.t val x' : 'b = x method x = x' end
 end;; (* fail *)
 [%%expect{|
-Line _, characters 2-86:
+Line 2, characters 2-86:
   ..class ['a] c x =
       object constraint 'a = 'b T.t val x' : 'b = x method x = x' end
 Error: In this definition, a type variable cannot be deduced
@@ -51,7 +51,7 @@ let magic (x : int) : bool  =
   let A x = A x in
   x;; (* fail *)
 [%%expect{|
-Line _, characters 0-49:
+Line 1, characters 0-49:
   type 'x t = A of 'a constraint 'x = [< `X of 'a ] ;; (* fail *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this definition, a type variable cannot be deduced
@@ -60,7 +60,7 @@ Error: In this definition, a type variable cannot be deduced
 
 type 'a t = A : 'a -> [< `X of 'a ] t;; (* fail *)
 [%%expect{|
-Line _, characters 0-37:
+Line 1, characters 0-37:
   type 'a t = A : 'a -> [< `X of 'a ] t;; (* fail *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this definition, a type variable cannot be deduced
@@ -77,7 +77,7 @@ type _ t = T : 'a -> 'a Queue.t t;; (* fail *)
 type (_, _) eq = Eq : ('a, 'a) eq
 val eq : 'a = <poly>
 val eq : ('a Queue.t, 'b Queue.t) eq = Eq
-Line _, characters 0-33:
+Line 5, characters 0-33:
   type _ t = T : 'a -> 'a Queue.t t;; (* fail *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this definition, a type variable cannot be deduced
@@ -95,7 +95,7 @@ module type S = sig
   type _ t = T : 'a -> 'a s t
 end;; (* fail *)
 [%%expect{|
-Line _, characters 2-29:
+Line 3, characters 2-29:
     type _ t = T : 'a -> 'a s t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this definition, a type variable cannot be deduced
@@ -104,7 +104,7 @@ Error: In this definition, a type variable cannot be deduced
 (* Otherwise we can write the following *)
 module rec M : (S with type 'a s = unit) = M;;
 [%%expect{|
-Line _, characters 16-17:
+Line 1, characters 16-17:
   module rec M : (S with type 'a s = unit) = M;;
                   ^
 Error: Unbound module type S
@@ -129,7 +129,7 @@ type 'a q = Q;;
 type +'a t = 'b constraint 'a = 'b q;;
 [%%expect{|
 type 'a q = Q
-Line _, characters 0-36:
+Line 2, characters 0-36:
   type +'a t = 'b constraint 'a = 'b q;;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this definition, a type variable has a variance that
@@ -146,7 +146,7 @@ type +'a s = 'b constraint 'a = 'b t
 |}];;
 type -'a s = 'b constraint 'a = 'b t;; (* fail *)
 [%%expect{|
-Line _, characters 0-36:
+Line 1, characters 0-36:
   type -'a s = 'b constraint 'a = 'b t;; (* fail *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this definition, a type variable has a variance that
@@ -167,7 +167,7 @@ type +'a s = 'b constraint 'a = 'b q t
 |}];;
 type +'a s = 'b constraint 'a = 'b t q;; (* fail *)
 [%%expect{|
-Line _, characters 0-38:
+Line 1, characters 0-38:
   type +'a s = 'b constraint 'a = 'b t q;; (* fail *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this definition, a type variable has a variance that
@@ -195,7 +195,7 @@ type +'a t = unit constraint 'a = 'b list;;
 type _ g = G : 'a -> 'a t g;; (* fail *)
 [%%expect{|
 type +'a t = unit constraint 'a = 'b list
-Line _, characters 0-27:
+Line 2, characters 0-27:
   type _ g = G : 'a -> 'a t g;; (* fail *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this definition, a type variable cannot be deduced

--- a/testsuite/tests/typing-gadts/pr5989.ml
+++ b/testsuite/tests/typing-gadts/pr5989.ml
@@ -25,7 +25,7 @@ let () = print_endline (f M.eq) ;;
 [%%expect{|
 type (_, _) t = Any : ('a, 'b) t | Eq : ('a, 'a) t
 module M : sig type s = private [> `A ] val eq : (s, [ `A | `B ]) t end
-Line _, characters 39-64:
+Line 16, characters 39-64:
   .......................................function
     | Any -> "Any"
 Warning 8: this pattern-matching is not exhaustive.
@@ -55,7 +55,7 @@ module N :
     type s = private < a : int; .. >
     val eq : (s, < a : int; b : bool >) t
   end
-Line _, characters 49-74:
+Line 12, characters 49-74:
   .................................................function
     | Any -> "Any"
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/pr5997.ml
+++ b/testsuite/tests/typing-gadts/pr5997.ml
@@ -22,7 +22,7 @@ match M.comp with | Diff -> false;;
 type (_, _) comp = Eq : ('a, 'a) comp | Diff : ('a, 'b) comp
 module U : sig type t = T end
 module M : sig type t = T val comp : (U.t, t) comp end
-Line _, characters 0-33:
+Line 16, characters 0-33:
   match M.comp with | Diff -> false;;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -45,7 +45,7 @@ match M.comp with | Diff -> false;;
 [%%expect{|
 module U : sig type t = { x : int; } end
 module M : sig type t = { x : int; } val comp : (U.t, t) comp end
-Line _, characters 0-33:
+Line 11, characters 0-33:
   match M.comp with | Diff -> false;;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/pr6158.ml
+++ b/testsuite/tests/typing-gadts/pr6158.ml
@@ -15,7 +15,7 @@ struct let f : ('a S.s, 'a S.t) eq -> unit = function Refl -> () end;;
 type 'a t = T of 'a
 type 'a s = S of 'a
 type (_, _) eq = Refl : ('a, 'a) eq
-Line _, characters 45-49:
+Line 6, characters 45-49:
   let f : (int s, int t) eq -> unit = function Refl -> ();;
                                                ^^^^
 Error: This pattern matches values of type (int s, int s) eq

--- a/testsuite/tests/typing-gadts/pr6163.ml
+++ b/testsuite/tests/typing-gadts/pr6163.ml
@@ -24,7 +24,7 @@ type aux =
     Aux :
       [ `Succ of [< [< [< [ `Zero ] pre_nat ] pre_nat ] pre_nat ] ] nat ->
       aux
-Line _, characters 4-5:
+Line 14, characters 4-5:
     | _ -> .  (* error *)
       ^
 Error: This match case could not be refuted.

--- a/testsuite/tests/typing-gadts/pr6174.ml
+++ b/testsuite/tests/typing-gadts/pr6174.ml
@@ -7,7 +7,7 @@ let f : type a o. ((a -> o) -> o) t -> (a -> o) -> o =
  fun C k -> k (fun x -> x);;
 [%%expect{|
 type _ t = C : ((('a -> 'o) -> 'o) -> ('b -> 'o) -> 'o) t
-Line _, characters 24-25:
+Line 3, characters 24-25:
    fun C k -> k (fun x -> x);;
                           ^
 Error: This expression has type $0 but an expression was expected of type

--- a/testsuite/tests/typing-gadts/pr6241.ml
+++ b/testsuite/tests/typing-gadts/pr6241.ml
@@ -21,7 +21,7 @@ let x = N.f A;;
 
 [%%expect{|
 type (_, _) t = A : ('a, 'a) t | B : string -> ('a, 'b) t
-Line _, characters 52-74:
+Line 8, characters 52-74:
   ....................................................function
      | B s -> s
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/pr6690.ml
+++ b/testsuite/tests/typing-gadts/pr6690.ml
@@ -26,7 +26,7 @@ type 'a local_visit_action
 type ('a, 'result, 'visit_action) context =
     Local : ('a, 'a * insert, 'a local_visit_action) context
   | Global : ('a, 'a, 'a visit_action) context
-Line _, characters 4-9:
+Line 15, characters 4-9:
     | Local -> fun _ -> raise Exit
       ^^^^^
 Error: This pattern matches values of type
@@ -41,7 +41,7 @@ type 'a local_visit_action
 type ('a, 'result, 'visit_action) context =
     Local : ('a, 'a * insert, 'a local_visit_action) context
   | Global : ('a, 'a, 'a visit_action) context
-Line _, characters 4-10:
+Line 16, characters 4-10:
     | Global -> fun _ -> raise Exit
       ^^^^^^
 Error: This pattern matches values of type ($1, $1, visit_action) context
@@ -57,7 +57,7 @@ let vexpr (type visit_action)
   | Global -> fun _ -> raise Exit
 ;;
 [%%expect{|
-Line _, characters 4-9:
+Line 4, characters 4-9:
     | Local -> fun _ -> raise Exit
       ^^^^^
 Error: This pattern matches values of type
@@ -66,7 +66,7 @@ Error: This pattern matches values of type
          ($'a, $'a * insert, visit_action) context
        The type constructor $'a would escape its scope
 |}, Principal{|
-Line _, characters 4-10:
+Line 5, characters 4-10:
     | Global -> fun _ -> raise Exit
       ^^^^^^
 Error: This pattern matches values of type ($1, $1, visit_action) context

--- a/testsuite/tests/typing-gadts/pr6934.ml
+++ b/testsuite/tests/typing-gadts/pr6934.ml
@@ -4,7 +4,7 @@
 
 type nonrec t = A : t;;
 [%%expect{|
-Line _, characters 16-21:
+Line 1, characters 16-21:
   type nonrec t = A : t;;
                   ^^^^^
 Error: GADT case syntax cannot be used in a 'nonrec' block.

--- a/testsuite/tests/typing-gadts/pr6980.ml
+++ b/testsuite/tests/typing-gadts/pr6980.ml
@@ -21,7 +21,7 @@ type 'a first = First : 'b t second -> ([< `Bar | `Foo ] as 'b) t first
 and 'a second = Second : [< `Bar | `Baz | `Foo > `Bar ] s second
 type aux = Aux : ([< `Bar | `Foo ] as 'a) t second * ('a -> int) -> aux
 val it : [< `Bar | `Foo > `Bar ] = `Bar
-Line _, characters 27-29:
+Line 11, characters 27-29:
   let g (Aux(Second, f)) = f it;;
                              ^^
 Error: This expression has type [< `Bar | `Foo > `Bar ]

--- a/testsuite/tests/typing-gadts/pr6993_bad.ml
+++ b/testsuite/tests/typing-gadts/pr6993_bad.ml
@@ -17,7 +17,7 @@ f B.eq;;
 
 [%%expect{|
 type (_, _) eqp = Y : ('a, 'a) eqp | N : string -> ('a, 'b) eqp
-Line _, characters 36-66:
+Line 2, characters 36-66:
   let f : ('a list, 'a) eqp -> unit = function N s -> print_string s;;
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/pr7016.ml
+++ b/testsuite/tests/typing-gadts/pr7016.ml
@@ -11,7 +11,7 @@ let get1 (Cons (x, _) : (_ * 'a, 'a) t) = x ;; (* warn, cf PR#6993 *)
 type (_, _) t =
     Nil : ('tl, 'tl) t
   | Cons : 'a * ('b, 'tl) t -> ('a * 'b, 'tl) t
-Line _, characters 9-43:
+Line 5, characters 9-43:
   let get1 (Cons (x, _) : (_ * 'a, 'a) t) = x ;; (* warn, cf PR#6993 *)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -26,7 +26,7 @@ let get1' = function
 [%%expect{|
 val get1' : ('b * 'a as 'a, 'a) t -> 'b = <fun>
 |}, Principal{|
-Line _, characters 4-7:
+Line 3, characters 4-7:
     | Nil -> assert false ;; (* ok *)
       ^^^
 Error: This pattern matches values of type ('b * 'a, 'b * 'a) t

--- a/testsuite/tests/typing-gadts/pr7160.ml
+++ b/testsuite/tests/typing-gadts/pr7160.ml
@@ -14,7 +14,7 @@ type _ t =
   | String : string -> string t
   | Same : 'l t -> 'l t
 val f : int t -> int = <fun>
-Line _, characters 0-97:
+Line 4, characters 0-97:
   type 'a tt = 'a t =
     Int : int -> int tt | String : string -> string tt | Same : 'l1 t -> 'l2 tt..
 Error: This variant or record definition does not match that of type 'a t

--- a/testsuite/tests/typing-gadts/pr7214.ml
+++ b/testsuite/tests/typing-gadts/pr7214.ml
@@ -12,7 +12,7 @@ let f (type a) (x : a t) =
   () ;;
 [%%expect{|
 type _ t = I : int t
-Line _, characters 9-10:
+Line 5, characters 9-10:
       let (I : a t) = x     (* fail because of toplevel let *)
            ^
 Error: This pattern matches values of type int t
@@ -36,7 +36,7 @@ let bad (type a) =
 ;;
 [%%expect{|
 type (_, _) eq = Refl : ('a, 'a) eq
-Line _, characters 10-14:
+Line 8, characters 10-14:
        let (Refl : (int, a) eq) = M.e  (* must fail for soundness *)
             ^^^^
 Error: This pattern matches values of type (int, int) eq

--- a/testsuite/tests/typing-gadts/pr7222.ml
+++ b/testsuite/tests/typing-gadts/pr7222.ml
@@ -20,7 +20,7 @@ type (_, _) elt =
     Elt_fine : 'nat n -> ('l, 'nat * 'l) elt
   | Elt : 'nat n -> ('l, 'nat -> 'l) elt
 type _ t = Nil : nil t | Cons : ('x, 'fx) elt * 'x t -> 'fx t
-Line _, characters 11-18:
+Line 9, characters 11-18:
     let Cons(Elt dim, _) = sh in ()
              ^^^^^^^
 Error: This pattern matches values of type ($Cons_'x, 'a -> $Cons_'x) elt
@@ -34,7 +34,7 @@ type (_, _) elt =
     Elt_fine : 'nat n -> ('l, 'nat * 'l) elt
   | Elt : 'nat n -> ('l, 'nat -> 'l) elt
 type _ t = Nil : nil t | Cons : ('x, 'fx) elt * 'x t -> 'fx t
-Line _, characters 6-22:
+Line 9, characters 6-22:
     let Cons(Elt dim, _) = sh in ()
         ^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type ('a -> $0 -> nil) t

--- a/testsuite/tests/typing-gadts/pr7234.ml
+++ b/testsuite/tests/typing-gadts/pr7234.ml
@@ -8,7 +8,7 @@ let f (type a) (Neq n : (a, a t) eq) = n;;   (* warn! *)
 [%%expect{|
 type (_, _) eq = Eq : ('a, 'a) eq | Neq : int -> ('a, 'b) eq
 type 'a t
-Line _, characters 15-40:
+Line 3, characters 15-40:
   let f (type a) (Neq n : (a, a t) eq) = n;;   (* warn! *)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -21,7 +21,7 @@ module F (T : sig type _ t end) = struct
  let f (type a) (Neq n : (a, a T.t) eq) = n  (* warn! *)
 end;;
 [%%expect{|
-Line _, characters 16-43:
+Line 2, characters 16-43:
    let f (type a) (Neq n : (a, a T.t) eq) = n  (* warn! *)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/pr7260.ml
+++ b/testsuite/tests/typing-gadts/pr7260.ml
@@ -19,7 +19,7 @@ class foo =
 type bar = < bar : unit >
 type _ ty = Int : int ty
 type dyn = Dyn : 'a ty -> dyn
-Line _, characters 0-108:
+Line 7, characters 0-108:
   class foo =
     object (this)
       method foo (Dyn ty) =

--- a/testsuite/tests/typing-gadts/pr7269.ml
+++ b/testsuite/tests/typing-gadts/pr7269.ml
@@ -11,7 +11,7 @@ let _ = f (T (`Conj `B) :> s t);; (* warn *)
 type s = [ `A | `B ]
 and sub = [ `B ]
 type +'a t = T : [< `Conj of 'a & sub | `Other of string ] -> 'a t
-Line _, characters 6-47:
+Line 4, characters 6-47:
   let f (T (`Other msg) : s t) = print_string msg;;
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -39,7 +39,7 @@ module M :
     type t = T : [< `Conj of int & s | `Other of string ] -> t
     val x : t
   end
-Line _, characters 12-59:
+Line 11, characters 12-59:
   let () = M.(match x with T (`Other msg) -> print_string msg);; (* warn *)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -71,7 +71,7 @@ module M :
     }
     val e : elim -> unit
   end
-Line _, characters 21-57:
+Line 13, characters 21-57:
   let () = M.(e { ex = fun (`Other msg) -> print_string msg });; (* warn *)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/pr7374.ml
+++ b/testsuite/tests/typing-gadts/pr7374.ml
@@ -21,7 +21,7 @@ end = struct
     fun Refl -> Refl
 end;; (* should fail *)
 [%%expect{|
-Line _, characters 16-20:
+Line 7, characters 16-20:
       fun Refl -> Refl
                   ^^^^
 Error: This expression has type (a, a) eq
@@ -47,7 +47,7 @@ module F (X : sig type 'a t end) = struct
     fun Refl Refl -> Refl;;
 end;; (* should fail *)
 [%%expect{|
-Line _, characters 21-25:
+Line 4, characters 21-25:
       fun Refl Refl -> Refl;;
                        ^^^^
 Error: This expression has type (a, a) eq

--- a/testsuite/tests/typing-gadts/pr7378.ml
+++ b/testsuite/tests/typing-gadts/pr7378.ml
@@ -15,7 +15,7 @@ module Y = struct
     | A : 'a * 'b * ('b -> unit) -> t
 end;; (* should fail *)
 [%%expect{|
-Line _, characters 2-54:
+Line 2, characters 2-54:
   ..type t = X.t =
       | A : 'a * 'b * ('b -> unit) -> t
 Error: This variant or record definition does not match that of type X.t

--- a/testsuite/tests/typing-gadts/pr7390.ml
+++ b/testsuite/tests/typing-gadts/pr7390.ml
@@ -21,7 +21,7 @@ type 'fill either =
 let f (* : filled either -> string *) =
   fun (Either (Y a, N)) -> a;;
 [%%expect{|
-Line _, characters 2-28:
+Line 2, characters 2-28:
     fun (Either (Y a, N)) -> a;;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/pr7421.ml
+++ b/testsuite/tests/typing-gadts/pr7421.ml
@@ -13,7 +13,7 @@ let f (x : ('a, empty Lazy.t) result) =
   | Ok x -> x
   | Error (lazy _) -> .;;
 [%%expect{|
-Line _, characters 4-18:
+Line 4, characters 4-18:
     | Error (lazy _) -> .;;
       ^^^^^^^^^^^^^^
 Error: This match case could not be refuted.
@@ -24,7 +24,7 @@ let f (x : ('a, empty Lazy.t) result) =
   | Ok x -> x
   | Error (lazy Refl) -> .;;
 [%%expect{|
-Line _, characters 16-20:
+Line 4, characters 16-20:
     | Error (lazy Refl) -> .;;
                   ^^^^
 Error: This pattern matches values of type (int, int) eq

--- a/testsuite/tests/typing-gadts/pr7432.ml
+++ b/testsuite/tests/typing-gadts/pr7432.ml
@@ -21,7 +21,7 @@ let f : [`L of (s, t) eql | `R of silly] -> 'a =
   function `R {silly} -> silly
 ;;
 [%%expect{|
-Line _, characters 2-30:
+Line 2, characters 2-30:
     function `R {silly} -> silly
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-gadts/pr7618.ml
+++ b/testsuite/tests/typing-gadts/pr7618.ml
@@ -19,7 +19,7 @@ let ok (type a b) (x : (a, b) eq) =
 ;;
 [%%expect{|
 type ('a, 'b) eq = Refl : ('a, 'a) eq
-Line _, characters 4-29:
+Line 4, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type (a, b) eq * b list
@@ -33,7 +33,7 @@ let fails (type a b) (x : (a, b) eq) =
   | Refl, [(_ : b) | (_ : a)] -> []
 ;;
 [%%expect{|
-Line _, characters 4-29:
+Line 3, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type (a, b) eq * b list
@@ -45,7 +45,7 @@ Error: This pattern matches values of type (a, b) eq * b list
 (* branches must be unified! *)
 let x = match [] with ["1"] -> 1 | [1.0] -> 2 | [1] -> 3 | _ -> 4;;
 [%%expect{|
-Line _, characters 35-40:
+Line 1, characters 35-40:
   let x = match [] with ["1"] -> 1 | [1.0] -> 2 | [1] -> 3 | _ -> 4;;
                                      ^^^^^
 Error: This pattern matches values of type float list

--- a/testsuite/tests/typing-gadts/pr7747.ml
+++ b/testsuite/tests/typing-gadts/pr7747.ml
@@ -22,7 +22,7 @@ val f : N.t -> M.t = <fun>
 |}]
 let f x = match N.eq with Refl -> (x : M.t :> N.t);;
 [%%expect{|
-Line _, characters 34-50:
+Line 1, characters 34-50:
   let f x = match N.eq with Refl -> (x : M.t :> N.t);;
                                     ^^^^^^^^^^^^^^^^
 Error: Type M.t is not a subtype of N.t

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -103,13 +103,13 @@ module Nonexhaustive =
   end
 ;;
 [%%expect{|
-Line _, characters 6-34:
+Line 11, characters 6-34:
   ......function
           | C2 x -> x
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 C1 _
-Line _, characters 6-77:
+Line 24, characters 6-77:
   ......function
           | Foo _ , Foo _ -> true
           | Bar _, Bar _ -> true
@@ -157,13 +157,13 @@ module PR6862 = struct
   class d (Just x) = object method x : int = x end
 end;;
 [%%expect{|
-Line _, characters 10-18:
+Line 2, characters 10-18:
     class c (Some x) = object method x : int = x end
             ^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 None
-Line _, characters 10-18:
+Line 4, characters 10-18:
     class d (Just x) = object method x : int = x end
             ^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -192,7 +192,7 @@ module PR6220 = struct
   let g : int t -> int = function I -> 1 | _ -> 2 (* warn *)
 end;;
 [%%expect{|
-Line _, characters 43-44:
+Line 4, characters 43-44:
     let g : int t -> int = function I -> 1 | _ -> 2 (* warn *)
                                              ^
 Warning 56: this match case is unreachable.
@@ -260,7 +260,7 @@ module PR6801 = struct
     | String s -> print_endline s (* warn : Any *)
 end;;
 [%%expect{|
-Line _, characters 4-50:
+Line 8, characters 4-50:
   ....match x with
       | String s -> print_endline s.................
 Warning 8: this pattern-matching is not exhaustive.
@@ -284,7 +284,7 @@ module Existential_escape =
   end
 ;;
 [%%expect{|
-Line _, characters 21-22:
+Line 5, characters 21-22:
       let eval (D x) = x
                        ^
 Error: This expression has type $D_'a t
@@ -317,7 +317,7 @@ module Or_patterns =
 end
 ;;
 [%%expect{|
-Line _, characters 11-19:
+Line 9, characters 11-19:
           | (IntLit _ | BoolLit _) -> ()
              ^^^^^^^^
 Error: This pattern matches values of type int t
@@ -368,7 +368,7 @@ module Propagation :
     val check : 's t -> 's
   end
 |}, Principal{|
-Line _, characters 19-20:
+Line 13, characters 19-20:
       | BoolLit b -> b
                      ^
 Error: This expression has type bool but an expression was expected of type s
@@ -381,13 +381,13 @@ module Normal_constrs = struct
   let f = function A -> 1 | B -> 2
 end;;
 [%%expect{|
-Line _, characters 28-29:
+Line 5, characters 28-29:
     let f = function A -> 1 | B -> 2
                               ^
 Error: This variant pattern is expected to have type a
        The constructor B does not belong to type a
 |}, Principal{|
-Line _, characters 28-29:
+Line 5, characters 28-29:
     let f = function A -> 1 | B -> 2
                               ^
 Error: This pattern matches values of type b
@@ -401,7 +401,7 @@ module PR6849 = struct
       Foo -> 5
 end;;
 [%%expect{|
-Line _, characters 6-9:
+Line 5, characters 6-9:
         Foo -> 5
         ^^^
 Error: This pattern matches values of type 'a t
@@ -432,7 +432,7 @@ let test : type a. a t -> _ =
   function Int -> ky (1 : a) 1  (* fails *)
 ;;
 [%%expect{|
-Line _, characters 18-30:
+Line 2, characters 18-30:
     function Int -> ky (1 : a) 1  (* fails *)
                     ^^^^^^^^^^^^
 Error: This expression has type a = int
@@ -446,7 +446,7 @@ let test : type a. a t -> a = fun x ->
   in r
 ;;
 [%%expect{|
-Line _, characters 30-42:
+Line 2, characters 30-42:
     let r = match x with Int -> ky (1 : a) 1  (* fails *)
                                 ^^^^^^^^^^^^
 Error: This expression has type a = int
@@ -460,7 +460,7 @@ let test : type a. a t -> a = fun x ->
   in r
 ;;
 [%%expect{|
-Line _, characters 30-42:
+Line 2, characters 30-42:
     let r = match x with Int -> ky 1 (1 : a)  (* fails *)
                                 ^^^^^^^^^^^^
 Error: This expression has type a = int
@@ -536,7 +536,7 @@ let test2 : type a. a t -> a option = fun x ->
   !u
 ;; (* fails because u : (int | a) option ref *)
 [%%expect{|
-Line _, characters 46-48:
+Line 4, characters 46-48:
     begin match x with Int -> u := Some 1; r := !u end;
                                                 ^^
 Error: This expression has type int option
@@ -574,7 +574,7 @@ let we_y1x (type a) (x : a) (v : a t) =
 ;; (* fail *)
 [%%expect{|
 val either : 'a -> 'a -> 'a = <fun>
-Line _, characters 44-45:
+Line 3, characters 44-45:
     match v with Int -> let y = either 1 x in y
                                               ^
 Error: This expression has type a = int
@@ -635,7 +635,7 @@ let f (type a) (x : a t) y =
     in M.z
 ;; (* fails because of aliasing... *)
 [%%expect{|
-Line _, characters 46-47:
+Line 3, characters 46-47:
       let module M = struct type b = a let z = (y : b) end
                                                 ^
 Error: This expression has type a = int
@@ -688,7 +688,7 @@ let f : type a b. (a,b) eq -> (<m : a; ..> as 'c) -> (<m : b; ..> as 'c) =
 ;; (* fail *)
 [%%expect{|
 type (_, _) eq = Eq : ('a, 'a) eq
-Line _, characters 4-90:
+Line 3, characters 4-90:
   ....f : type a b. (a,b) eq -> (<m : a; ..> as 'c) -> (<m : b; ..> as 'c) =
     fun Eq o -> o
 Error: The universal type variable 'b cannot be generalized:
@@ -699,7 +699,7 @@ let f : type a b. (a,b) eq -> <m : a; ..> -> <m : b; ..> =
   fun Eq o -> o
 ;; (* fail *)
 [%%expect{|
-Line _, characters 14-15:
+Line 2, characters 14-15:
     fun Eq o -> o
                 ^
 Error: This expression has type < m : a; .. >
@@ -712,7 +712,7 @@ Error: This expression has type < m : a; .. >
 let f (type a) (type b) (eq : (a,b) eq) (o : <m : a; ..>) : <m : b; ..> =
   match eq with Eq -> o ;; (* should fail *)
 [%%expect{|
-Line _, characters 22-23:
+Line 2, characters 22-23:
     match eq with Eq -> o ;; (* should fail *)
                         ^
 Error: This expression has type < m : a; .. >
@@ -752,7 +752,7 @@ let f : type a b. (a,b) eq -> < m : a; .. > -> < m : b > =
 [%%expect{|
 val f : ('a, 'b) eq -> < m : 'a > -> < m : 'b > = <fun>
 |}, Principal{|
-Line _, characters 44-45:
+Line 4, characters 44-45:
       let r : < m : b > = match eq with Eq -> o in (* fail with principal *)
                                               ^
 Error: This expression has type < m : a >
@@ -768,7 +768,7 @@ let f : type a b. (a,b) eq -> < m : a; .. > -> < m : b > =
     ignore (o : < m : a >);
     r;;
 [%%expect{|
-Line _, characters 44-45:
+Line 3, characters 44-45:
       let r : < m : b > = match eq with Eq -> o in (* fail *)
                                               ^
 Error: This expression has type < m : a; .. >
@@ -781,7 +781,7 @@ Error: This expression has type < m : a; .. >
 let f : type a b. (a,b) eq -> [> `A of a] -> [> `A of b] =
   fun Eq o -> o ;; (* fail *)
 [%%expect{|
-Line _, characters 14-15:
+Line 2, characters 14-15:
     fun Eq o -> o ;; (* fail *)
                 ^
 Error: This expression has type [> `A of a ]
@@ -790,7 +790,7 @@ Error: This expression has type [> `A of a ]
        This instance of a is ambiguous:
        it would escape the scope of its equation
 |}, Principal{|
-Line _, characters 9-15:
+Line 2, characters 9-15:
     fun Eq o -> o ;; (* fail *)
            ^^^^^^
 Error: This expression has type ([> `A of b ] as 'a) -> 'a
@@ -801,7 +801,7 @@ Error: This expression has type ([> `A of b ] as 'a) -> 'a
 let f (type a b) (eq : (a,b) eq) (v : [> `A of a]) : [> `A of b] =
   match eq with Eq -> v ;; (* should fail *)
 [%%expect{|
-Line _, characters 22-23:
+Line 2, characters 22-23:
     match eq with Eq -> v ;; (* should fail *)
                         ^
 Error: This expression has type [> `A of a ]
@@ -814,7 +814,7 @@ Error: This expression has type [> `A of a ]
 let f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
   fun Eq o -> o ;; (* fail *)
 [%%expect{|
-Line _, characters 4-84:
+Line 1, characters 4-84:
   ....f : type a b. (a,b) eq -> [< `A of a | `B] -> [< `A of b | `B] =
     fun Eq o -> o..............
 Error: This definition has type
@@ -843,7 +843,7 @@ let f : type a b. (a,b) eq -> [> `A of a | `B] -> [`A of b | `B] =
 [%%expect{|
 val f : ('a, 'b) eq -> [ `A of 'a | `B ] -> [ `A of 'b | `B ] = <fun>
 |}, Principal{|
-Line _, characters 49-50:
+Line 4, characters 49-50:
       let r : [`A of b | `B] = match eq with Eq -> o in (* fail with principal *)
                                                    ^
 Error: This expression has type [ `A of a | `B ]
@@ -859,7 +859,7 @@ let f : type a b. (a,b) eq -> [> `A of a | `B] -> [`A of b | `B] =
     ignore (o : [< `A of a | `B]);
     r;;
 [%%expect{|
-Line _, characters 49-50:
+Line 3, characters 49-50:
       let r : [`A of b | `B] = match eq with Eq -> o in (* fail *)
                                                    ^
 Error: This expression has type [> `A of a | `B ]
@@ -916,7 +916,7 @@ let f : type a. a ty -> a t -> int = fun x y ->
   | TA, D z -> z
 ;; (* warn *)
 [%%expect{|
-Line _, characters 2-153:
+Line 2, characters 2-153:
   ..match x, y with
     | _, A z -> z
     | _, B z -> if z then 1 else 2
@@ -940,7 +940,7 @@ let f : type a. a ty -> a t -> int = fun x y ->
   | D z, TA -> z
 ;; (* fail *)
 [%%expect{|
-Line _, characters 6-13:
+Line 6, characters 6-13:
     | D [|1.0|], TE TC -> 14
         ^^^^^^^
 Error: This pattern matches values of type 'a array
@@ -960,7 +960,7 @@ let f : type a. a ty -> a t -> int = fun x y ->
 ;; (* fail *)
 [%%expect{|
 type ('a, 'b) pair = { right : 'a; left : 'b; }
-Line _, characters 25-32:
+Line 8, characters 25-32:
     | {left=TE TC; right=D [|1.0|]} -> 14
                            ^^^^^^^
 Error: This pattern matches values of type 'a array
@@ -980,7 +980,7 @@ let f : type a. a ty -> a t -> int = fun x y ->
 ;; (* ok *)
 [%%expect{|
 type ('a, 'b) pair = { left : 'a; right : 'b; }
-Line _, characters 2-244:
+Line 4, characters 2-244:
   ..match {left=x; right=y} with
     | {left=_; right=A z} -> z
     | {left=_; right=B z} -> if z then 1 else 2
@@ -1005,7 +1005,7 @@ let f : type a b. (a M.t, b M.t) eq -> (a, b) eq =
 ;;
 [%%expect{|
 module M : sig type 'a t val eq : ('a t, 'b t) eq end
-Line _, characters 17-19:
+Line 6, characters 17-19:
     function Eq -> Eq (* fail *)
                    ^^
 Error: This expression has type (a, a) eq
@@ -1061,7 +1061,7 @@ let g (type t) (x:t) (e : t int_foo) (e' : t int_bar) =
 [%%expect{|
 type _ int_foo = IF_constr : < foo : int; .. > int_foo
 type _ int_bar = IB_constr : < bar : int; .. > int_bar
-Line _, characters 3-4:
+Line 10, characters 3-4:
     (x:<foo:int>)
      ^
 Error: This expression has type t = < foo : int; .. >
@@ -1075,7 +1075,7 @@ let g (type t) (x:t) (e : t int_foo) (e' : t int_bar) =
   (x:<foo:int;bar:int>)
 ;;
 [%%expect{|
-Line _, characters 3-4:
+Line 3, characters 3-4:
     (x:<foo:int;bar:int>)
      ^
 Error: This expression has type t = < foo : int; .. >
@@ -1089,7 +1089,7 @@ let g (type t) (x:t) (e : t int_foo) (e' : t int_bar) =
   (x:<foo:int;bar:int;..>)
 ;;
 [%%expect{|
-Line _, characters 2-26:
+Line 3, characters 2-26:
     (x:<foo:int;bar:int;..>)
     ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type < bar : int; foo : int; .. >
@@ -1173,7 +1173,7 @@ let f : type a b. (a,b) eq -> (a,int) eq -> a -> b -> _ = fun ab aint a b ->
   in ignore x
 ;; (* ok *)
 [%%expect{|
-Line _, characters 24-25:
+Line 5, characters 24-25:
       if true then a else b
                           ^
 Error: This expression has type b = int
@@ -1191,7 +1191,7 @@ let f : type a b. (a,b) eq -> (b,int) eq -> a -> b -> _ = fun ab bint a b ->
   in ignore x
 ;; (* ok *)
 [%%expect{|
-Line _, characters 24-25:
+Line 5, characters 24-25:
       if true then a else b
                           ^
 Error: This expression has type b = int
@@ -1207,7 +1207,7 @@ let f (type a b c) (b : bool) (w1 : (a,b) eq) (w2 : (a,int) eq) (x : a) (y : b) 
   if b then x else y
 ;;
 [%%expect{|
-Line _, characters 19-20:
+Line 4, characters 19-20:
     if b then x else y
                      ^
 Error: This expression has type b = int
@@ -1222,7 +1222,7 @@ let f (type a b c) (b : bool) (w1 : (a,b) eq) (w2 : (a,int) eq) (x : a) (y : b) 
   let Eq = w2 in
   if b then y else x
 [%%expect{|
-Line _, characters 19-20:
+Line 4, characters 19-20:
     if b then y else x
                      ^
 Error: This expression has type a = int

--- a/testsuite/tests/typing-gadts/unexpected_existentials.ml
+++ b/testsuite/tests/typing-gadts/unexpected_existentials.ml
@@ -10,7 +10,7 @@ type any = Any : 'a -> any
 
 let Any x = Any ()
 [%%expect {|
-Line _, characters 4-9:
+Line 1, characters 4-9:
   let Any x = Any ()
       ^^^^^
 Error: Existential types are not allowed in toplevel bindings,
@@ -21,7 +21,7 @@ let () =
   let Any x = Any () and () = () in
   ()
 [%%expect {|
-Line _, characters 6-11:
+Line 2, characters 6-11:
     let Any x = Any () and () = () in
         ^^^^^
 Error: Existential types are not allowed in "let ... and ..." bindings,
@@ -33,7 +33,7 @@ let () =
   let rec Any x = Any () in
   ()
 [%%expect {|
-Line _, characters 10-15:
+Line 2, characters 10-15:
     let rec Any x = Any () in
             ^^^^^
 Error: Existential types are not allowed in recursive bindings,
@@ -45,7 +45,7 @@ let () =
   let[@attribute] Any x = Any () in
   ()
 [%%expect {|
-Line _, characters 18-23:
+Line 2, characters 18-23:
     let[@attribute] Any x = Any () in
                     ^^^^^
 Error: Existential types are not allowed in presence of attributes,
@@ -55,7 +55,7 @@ but this pattern introduces the existential type $Any_'a.
 
 class c (Any x) = object end
 [%%expect {|
-Line _, characters 8-15:
+Line 1, characters 8-15:
   class c (Any x) = object end
           ^^^^^^^
 Error: Existential types are not allowed in class arguments,
@@ -64,7 +64,7 @@ but this pattern introduces the existential type $Any_'a.
 
 class c = object(Any x)end
 [%%expect {|
-Line _, characters 16-23:
+Line 1, characters 16-23:
   class c = object(Any x)end
                   ^^^^^^^
 Error: Existential types are not allowed in self patterns,
@@ -78,7 +78,7 @@ type other = Any : 'a -> other
 
 let Any x = Any ()
 [%%expect {|
-Line _, characters 4-9:
+Line 1, characters 4-9:
   let Any x = Any ()
       ^^^^^
 Error: Existential types are not allowed in toplevel bindings,
@@ -88,7 +88,7 @@ but the constructor Any introduces existential types.
 
 class c = let Any _x = () in object end
 [%%expect {|
-Line _, characters 14-20:
+Line 1, characters 14-20:
   class c = let Any _x = () in object end
                 ^^^^^^
 Error: Existential types are not allowed in bindings inside class definition,
@@ -99,7 +99,7 @@ let () =
   let Any x = Any () and () = () in
   ()
 [%%expect {|
-Line _, characters 6-11:
+Line 2, characters 6-11:
     let Any x = Any () and () = () in
         ^^^^^
 Error: Existential types are not allowed in "let ... and ..." bindings,
@@ -111,7 +111,7 @@ let () =
   let rec Any x = Any () in
   ()
 [%%expect {|
-Line _, characters 10-15:
+Line 2, characters 10-15:
     let rec Any x = Any () in
             ^^^^^
 Error: Existential types are not allowed in recursive bindings,
@@ -123,7 +123,7 @@ let () =
   let[@attribute] Any x = Any () in
   ()
 [%%expect {|
-Line _, characters 18-23:
+Line 2, characters 18-23:
     let[@attribute] Any x = Any () in
                     ^^^^^
 Error: Existential types are not allowed in presence of attributes,
@@ -132,7 +132,7 @@ but the constructor Any introduces existential types.
 
 class c (Any x) = object end
 [%%expect {|
-Line _, characters 8-15:
+Line 1, characters 8-15:
   class c (Any x) = object end
           ^^^^^^^
 Error: Existential types are not allowed in class arguments,
@@ -141,7 +141,7 @@ but the constructor Any introduces existential types.
 
 class c = object(Any x) end
 [%%expect {|
-Line _, characters 16-23:
+Line 1, characters 16-23:
   class c = object(Any x) end
                   ^^^^^^^
 Error: Existential types are not allowed in self patterns,
@@ -150,7 +150,7 @@ but the constructor Any introduces existential types.
 
 class c = let Any _x = () in object end
 [%%expect {|
-Line _, characters 14-20:
+Line 1, characters 14-20:
   class c = let Any _x = () in object end
                 ^^^^^^
 Error: Existential types are not allowed in bindings inside class definition,

--- a/testsuite/tests/typing-gadts/yallop_bugs.ml
+++ b/testsuite/tests/typing-gadts/yallop_bugs.ml
@@ -18,7 +18,7 @@ let magic : 'a 'b. 'a -> 'b =
 ;;
 [%%expect{|
 type (_, _) eq = Refl : ('a, 'a) eq
-Line _, characters 44-52:
+Line 8, characters 44-52:
            let f (Refl : (a T.t, b T.t) eq) = (x :> b)
                                               ^^^^^^^^
 Error: Type a is not a subtype of b
@@ -37,7 +37,7 @@ let magic : 'a 'b. 'a -> 'b =
     (downcast bad_proof ((object method m = x end) :> < >)) # m
 ;;
 [%%expect{|
-Line _, characters 0-36:
+Line 1, characters 0-36:
   type (_, +_) eq = Refl : ('a, 'a) eq
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In this GADT definition, the variance of some parameter
@@ -56,7 +56,7 @@ let check : type s . s t * s -> bool = function
 ;;
 [%%expect{|
 type _ t = IntLit : int t | BoolLit : bool t
-Line _, characters 39-99:
+Line 5, characters 39-99:
   .......................................function
     | BoolLit, false -> false
     | IntLit , 6 -> false
@@ -74,7 +74,7 @@ let check : type s . (s t, s) pair -> bool = function
 ;;
 [%%expect{|
 type ('a, 'b) pair = { fst : 'a; snd : 'b; }
-Line _, characters 45-134:
+Line 3, characters 45-134:
   .............................................function
     | {fst = BoolLit; snd = false} -> false
     | {fst = IntLit ; snd =  6} -> false

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -106,7 +106,7 @@ module B = struct
   type t = string [@@immediate]
 end;;
 [%%expect{|
-Line _, characters 2-31:
+Line 2, characters 2-31:
     type t = string [@@immediate]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Types marked with the immediate attribute must be
@@ -119,7 +119,7 @@ module C = struct
   type s = t [@@immediate]
 end;;
 [%%expect{|
-Line _, characters 2-26:
+Line 3, characters 2-26:
     type s = t [@@immediate]
     ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Types marked with the immediate attribute must be
@@ -131,7 +131,7 @@ module D : sig type t [@@immediate] end = struct
   type t = string
 end;;
 [%%expect{|
-Line _, characters 42-70:
+Line 1, characters 42-70:
   ..........................................struct
     type t = string
   end..
@@ -151,7 +151,7 @@ Error: Signature mismatch:
 module M_invalid : S = struct type t = string end;;
 module FM_invalid = F (struct type t = string end);;
 [%%expect{|
-Line _, characters 23-49:
+Line 1, characters 23-49:
   module M_invalid : S = struct type t = string end;;
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
@@ -169,7 +169,7 @@ module E = struct
   and s = string
 end;;
 [%%expect{|
-Line _, characters 2-26:
+Line 2, characters 2-26:
     type t = s [@@immediate]
     ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Types marked with the immediate attribute must be

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ocaml.reference
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ocaml.reference
@@ -3,7 +3,7 @@ val make_set : ('a -> 'a -> int) -> (module Set.S with type elt = 'a) = <fun>
 val sort_cmp : ('a -> 'a -> int) -> 'a list -> 'a list = <fun>
 module type S = sig type t val x : t end
 val f : (module S with type t = int) -> int = <fun>
-Characters 6-37:
+Line 1, characters 6-37:
   let f (module M : S with type t = 'a) = M.x;; (* Error *)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type of this packed module contains variables:
@@ -12,7 +12,7 @@ val f : (module S with type t = 'a) -> 'a = <fun>
 - : int = 1
 type 'a s = { s : (module S with type t = 'a); }
 - : int s = {s = <module>}
-Characters 9-19:
+Line 1, characters 9-19:
   let f {s=(module M)} = M.x;; (* Error *)
            ^^^^^^^^^^
 Error: The type of this packed module contains variables:
@@ -23,7 +23,7 @@ val f : s -> int = <fun>
 val f : s -> s -> int = <fun>
 module type S = sig val x : int end
 val f : (module S) -> int -> (module S) -> int = <fun>
-Characters 8-37:
+Line 1, characters 8-37:
   let m = (module struct let x = 3 end);; (* Error *)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The signature for this packaged module couldn't be inferred.
@@ -31,11 +31,11 @@ val m : (module S) = <module>
 - : int = 7
 - : int = 6
 - : int = 3
-Characters 4-14:
+Line 1, characters 4-14:
   let (module M) = m;; (* Error: only allowed in [let .. in] *)
       ^^^^^^^^^^
 Error: Modules are not allowed in this pattern.
-Characters 14-24:
+Line 1, characters 14-24:
   class c = let (module M) = m in object end;; (* Error again *)
                 ^^^^^^^^^^
 Error: Modules are not allowed in this pattern.

--- a/testsuite/tests/typing-misc/constraints.ml
+++ b/testsuite/tests/typing-misc/constraints.ml
@@ -4,13 +4,13 @@
 
 type 'a t = [`A of 'a t t] as 'a;; (* fails *)
 [%%expect{|
-Line _, characters 0-32:
+Line 1, characters 0-32:
   type 'a t = [`A of 'a t t] as 'a;; (* fails *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of t contains a cycle:
        'a t t as 'a
 |}, Principal{|
-Line _, characters 0-32:
+Line 1, characters 0-32:
   type 'a t = [`A of 'a t t] as 'a;; (* fails *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of t contains a cycle:
@@ -18,21 +18,21 @@ Error: The definition of t contains a cycle:
 |}];;
 type 'a t = [`A of 'a t t];; (* fails *)
 [%%expect{|
-Line _, characters 0-26:
+Line 1, characters 0-26:
   type 'a t = [`A of 'a t t];; (* fails *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the definition of t, type 'a t t should be 'a t
 |}];;
 type 'a t = [`A of 'a t t] constraint 'a = 'a t;; (* fails since 4.04 *)
 [%%expect{|
-Line _, characters 0-47:
+Line 1, characters 0-47:
   type 'a t = [`A of 'a t t] constraint 'a = 'a t;; (* fails since 4.04 *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type abbreviation t is cyclic
 |}];;
 type 'a t = [`A of 'a t] constraint 'a = 'a t;; (* fails since 4.04 *)
 [%%expect{|
-Line _, characters 0-45:
+Line 1, characters 0-45:
   type 'a t = [`A of 'a t] constraint 'a = 'a t;; (* fails since 4.04 *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type abbreviation t is cyclic
@@ -45,7 +45,7 @@ type 'a t = [ `A of 'b ] as 'b constraint 'a = [ `A of 'a ]
 |}];;
 type 'a v = [`A of u v] constraint 'a = t and t = u and u = t;; (* fails *)
 [%%expect{|
-Line _, characters 0-41:
+Line 1, characters 0-41:
   type 'a v = [`A of u v] constraint 'a = t and t = u and u = t;; (* fails *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of v contains a cycle:
@@ -73,7 +73,7 @@ module type PR6505 = sig
 end
 ;; (* fails *)
 [%%expect{|
-Line _, characters 2-44:
+Line 3, characters 2-44:
     and 'o abs constraint 'o = 'o is_an_object
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of abs contains a cycle:
@@ -93,7 +93,7 @@ module PR6505a :
     and ('a, 'l) abs = 'l constraint 'a = 'l is_an_object
     val y : (<  > is_an_object, <  > is_an_object) abs
   end
-Line _, characters 8-17:
+Line 6, characters 8-17:
   let _ = PR6505a.y#bang;; (* fails *)
           ^^^^^^^^^
 Error: This expression has type
@@ -106,7 +106,7 @@ module PR6505a :
     and ('a, 'l) abs = 'l constraint 'a = 'l is_an_object
     val y : (<  >, <  >) abs
   end
-Line _, characters 8-17:
+Line 6, characters 8-17:
   let _ = PR6505a.y#bang;; (* fails *)
           ^^^^^^^^^
 Error: This expression has type (<  >, <  >) PR6505a.abs
@@ -126,7 +126,7 @@ module PR6505b :
     and ('a, 'l) abs = 'l constraint 'a = 'l is_an_object
     val x : (([> `Foo of int ] as 'a) is_an_object, 'a is_an_object) abs
   end
-Line _, characters 23-57:
+Line 6, characters 23-57:
   let () = print_endline (match PR6505b.x with `Bar s -> s);; (* fails *)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-misc/disambiguate_principality.ml
+++ b/testsuite/tests/typing-misc/disambiguate_principality.ml
@@ -34,7 +34,7 @@ let after_a =
   { x with lbl = 4 }
 ;;
 [%%expect{|
-Line _, characters 2-20:
+Line 3, characters 2-20:
     { x with lbl = 4 }
     ^^^^^^^^^^^^^^^^^^
 Warning 23: all the fields are explicitly listed in this record:
@@ -49,7 +49,7 @@ let b =
 [%%expect{|
 val b : unit = ()
 |}, Principal{|
-Line _, characters 7-18:
+Line 3, characters 7-18:
     x := { lbl = 4 }
          ^^^^^^^^^^^
 Warning 18: this type-based record disambiguation is not principal.
@@ -77,7 +77,7 @@ let e =
   { x with contents = { lbl = 4 } }
 ;;
 [%%expect{|
-Line _, characters 24-27:
+Line 3, characters 24-27:
     { x with contents = { lbl = 4 } }
                           ^^^
 Error: Unbound record field lbl
@@ -107,13 +107,13 @@ let h x =
   | { lbl = _ } -> ()
 ;;
 [%%expect{|
-Line _, characters 4-15:
+Line 4, characters 4-15:
     | { lbl = _ } -> ()
       ^^^^^^^^^^^
 Warning 11: this match case is unused.
 val h : M.r -> unit = <fun>
 |}, Principal{|
-Line _, characters 6-9:
+Line 4, characters 6-9:
     | { lbl = _ } -> ()
         ^^^
 Error: Unbound record field lbl
@@ -125,7 +125,7 @@ let i x =
   | (_ : M.r) -> ()
 ;;
 [%%expect{|
-Line _, characters 6-9:
+Line 3, characters 6-9:
     | { lbl = _ } -> ()
         ^^^
 Error: Unbound record field lbl
@@ -137,7 +137,7 @@ let j x =
   | { lbl = _ } -> ()
 ;;
 [%%expect{|
-Line _, characters 4-15:
+Line 4, characters 4-15:
     | { lbl = _ } -> ()
       ^^^^^^^^^^^
 Warning 12: this sub-pattern is unused.
@@ -150,7 +150,7 @@ let k x =
   | (_ : M.r) -> ()
 ;;
 [%%expect{|
-Line _, characters 6-9:
+Line 3, characters 6-9:
     | { lbl = _ }
         ^^^
 Error: Unbound record field lbl
@@ -169,7 +169,7 @@ let m x =
   | { contents = { lbl = _ } } -> ()
 ;;
 [%%expect{|
-Line _, characters 19-22:
+Line 3, characters 19-22:
     | { contents = { lbl = _ } } -> ()
                      ^^^
 Error: Unbound record field lbl
@@ -181,13 +181,13 @@ let n x =
   | { contents = { lbl = _ } } -> ()
 ;;
 [%%expect{|
-Line _, characters 4-30:
+Line 4, characters 4-30:
     | { contents = { lbl = _ } } -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 11: this match case is unused.
 val n : M.r ref -> unit = <fun>
 |}, Principal{|
-Line _, characters 19-22:
+Line 4, characters 19-22:
     | { contents = { lbl = _ } } -> ()
                      ^^^
 Error: Unbound record field lbl
@@ -199,7 +199,7 @@ let o x =
   | (_ : M.r ref) -> ()
 ;;
 [%%expect{|
-Line _, characters 19-22:
+Line 3, characters 19-22:
     | { contents = { lbl = _ } } -> ()
                      ^^^
 Error: Unbound record field lbl
@@ -211,7 +211,7 @@ let p x =
   | { contents = { lbl = _ } } -> ()
 ;;
 [%%expect{|
-Line _, characters 4-30:
+Line 4, characters 4-30:
     | { contents = { lbl = _ } } -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 12: this sub-pattern is unused.
@@ -224,7 +224,7 @@ let q x =
   | (_ : M.r ref) -> ()
 ;;
 [%%expect{|
-Line _, characters 19-22:
+Line 3, characters 19-22:
     | { contents = { lbl = _ } }
                      ^^^
 Error: Unbound record field lbl
@@ -247,7 +247,7 @@ let s arg =
 [%%expect{|
 val s : M.r ref -> unit = <fun>
 |}, Principal{|
-Line _, characters 9-20:
+Line 4, characters 9-20:
       x := { lbl = 4 }
            ^^^^^^^^^^^
 Warning 18: this type-based record disambiguation is not principal.
@@ -261,7 +261,7 @@ let t = function
 [%%expect{|
 val t : M.r ref -> unit = <fun>
 |}, Principal{|
-Line _, characters 9-20:
+Line 3, characters 9-20:
       x := { lbl = 4 }
            ^^^^^^^^^^^
 Warning 18: this type-based record disambiguation is not principal.
@@ -275,7 +275,7 @@ let u = function
 [%%expect{|
 val u : M.r ref -> int = <fun>
 |}, Principal{|
-Line _, characters 7-10:
+Line 3, characters 7-10:
       !x.lbl
          ^^^
 Warning 18: this type-based field disambiguation is not principal.

--- a/testsuite/tests/typing-misc/labels.ml
+++ b/testsuite/tests/typing-misc/labels.ml
@@ -7,7 +7,7 @@ let f ~x = x + 1;;
 f ?x:0;;
 [%%expect{|
 val f : x:int -> int = <fun>
-Line _, characters 5-6:
+Line 2, characters 5-6:
   f ?x:0;;
        ^
 Warning 43: the label x is not optional.
@@ -27,7 +27,7 @@ val g : ?x:'a -> unit -> unit = <fun>
 (* PR#5748 *)
 foo (fun ?opt () -> ()) ;; (* fails *)
 [%%expect{|
-Line _, characters 4-23:
+Line 1, characters 4-23:
   foo (fun ?opt () -> ()) ;; (* fails *)
       ^^^^^^^^^^^^^^^^^^^
 Error: This function should have type unit -> unit

--- a/testsuite/tests/typing-misc/occur_check.ml
+++ b/testsuite/tests/typing-misc/occur_check.ml
@@ -8,7 +8,7 @@ type 'a t = 'a;;
 let f (g : 'a list -> 'a t -> 'a) s = g s s;;
 [%%expect{|
 type 'a t = 'a
-Line _, characters 42-43:
+Line 2, characters 42-43:
   let f (g : 'a list -> 'a t -> 'a) s = g s s;;
                                             ^
 Error: This expression has type 'a list
@@ -17,7 +17,7 @@ Error: This expression has type 'a list
 |}];;
 let f (g : 'a * 'b -> 'a t -> 'a) s = g s s;;
 [%%expect{|
-Line _, characters 42-43:
+Line 1, characters 42-43:
   let f (g : 'a * 'b -> 'a t -> 'a) s = g s s;;
                                             ^
 Error: This expression has type 'a * 'b

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -6,7 +6,7 @@ type ab = [ `A | `B ];;
 let f (x : [`A]) = match x with #ab -> 1;;
 [%%expect{|
 type ab = [ `A | `B ]
-Line _, characters 32-35:
+Line 2, characters 32-35:
   let f (x : [`A]) = match x with #ab -> 1;;
                                   ^^^
 Error: This pattern matches values of type [? `A | `B ]
@@ -15,7 +15,7 @@ Error: This pattern matches values of type [? `A | `B ]
 |}];;
 let f x = ignore (match x with #ab -> 1); ignore (x : [`A]);;
 [%%expect{|
-Line _, characters 31-34:
+Line 1, characters 31-34:
   let f x = ignore (match x with #ab -> 1); ignore (x : [`A]);;
                                  ^^^
 Error: This pattern matches values of type [? `B ]
@@ -24,7 +24,7 @@ Error: This pattern matches values of type [? `B ]
 |}];;
 let f x = ignore (match x with `A|`B -> 1); ignore (x : [`A]);;
 [%%expect{|
-Line _, characters 34-36:
+Line 1, characters 34-36:
   let f x = ignore (match x with `A|`B -> 1); ignore (x : [`A]);;
                                     ^^
 Error: This pattern matches values of type [? `B ]
@@ -34,7 +34,7 @@ Error: This pattern matches values of type [? `B ]
 
 let f (x : [< `A | `B]) = match x with `A | `B | `C -> 0;; (* warn *)
 [%%expect{|
-Line _, characters 49-51:
+Line 1, characters 49-51:
   let f (x : [< `A | `B]) = match x with `A | `B | `C -> 0;; (* warn *)
                                                    ^^
 Warning 12: this sub-pattern is unused.
@@ -42,7 +42,7 @@ val f : [< `A | `B ] -> int = <fun>
 |}];;
 let f (x : [`A | `B]) = match x with `A | `B | `C -> 0;; (* fail *)
 [%%expect{|
-Line _, characters 47-49:
+Line 1, characters 47-49:
   let f (x : [`A | `B]) = match x with `A | `B | `C -> 0;; (* fail *)
                                                  ^^
 Error: This pattern matches values of type [? `C ]
@@ -70,31 +70,31 @@ type t = A | B
 - : [> `A ] option * t -> int = <fun>
 - : t * [< `A | `B ] -> int = <fun>
 - : [< `A | `B ] * t -> int = <fun>
-Line _, characters 0-41:
+Line 9, characters 0-41:
   function (`A|`B), _ -> 0 | _,(`A|`B) -> 1;;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (`AnyOtherTag, `AnyOtherTag)
 - : [> `A | `B ] * [> `A | `B ] -> int = <fun>
-Line _, characters 0-29:
+Line 10, characters 0-29:
   function `B,1 -> 1 | _,1 -> 2;;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (_, 0)
-Line _, characters 21-24:
+Line 10, characters 21-24:
   function `B,1 -> 1 | _,1 -> 2;;
                        ^^^
 Warning 11: this match case is unused.
 - : [< `B ] * int -> int = <fun>
-Line _, characters 0-29:
+Line 11, characters 0-29:
   function 1,`B -> 1 | 1,_ -> 2;;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (0, _)
-Line _, characters 21-24:
+Line 11, characters 21-24:
   function 1,`B -> 1 | 1,_ -> 2;;
                        ^^^
 Warning 11: this match case is unused.
@@ -117,7 +117,7 @@ val f : 'a -> [< `Foo ] -> 'a = <fun>
 let f : ([`A | `B ] as 'a) -> [> 'a] -> unit = fun x (y : [> 'a]) -> ();;
 let f (x : [`A | `B] as 'a) (y : [> 'a]) = ();;
 [%%expect{|
-Line _, characters 61-63:
+Line 1, characters 61-63:
   let f : ([`A | `B ] as 'a) -> [> 'a] -> unit = fun x (y : [> 'a]) -> ();;
                                                                ^^
 Error: The type 'a does not expand to a polymorphic variant type
@@ -135,7 +135,7 @@ type t = private [> `A of string ];;
 function (`A x : t) -> x;;
 [%%expect{|
 type t = private [> `A of string ]
-Line _, characters 0-24:
+Line 2, characters 0-24:
   function (`A x : t) -> x;;
   ^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -146,7 +146,7 @@ Here is an example of a case that is not matched:
 
 let f = function `AnyOtherTag, _ -> 1 | _, (`AnyOtherTag|`AnyOtherTag') -> 2;;
 [%%expect{|
-Line _, characters 8-76:
+Line 1, characters 8-76:
   let f = function `AnyOtherTag, _ -> 1 | _, (`AnyOtherTag|`AnyOtherTag') -> 2;;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -12,7 +12,7 @@ module M = struct
   end
 end;;
 [%%expect{|
-Line _, characters 8-52:
+Line 5, characters 8-52:
   ........struct
       type t = B
       let f B = ()
@@ -26,11 +26,11 @@ Error: Signature mismatch:
          val f : t/1 -> unit
        is not included in
          val f : t/2 -> unit
-       Line _, characters 4-14:
+       Line 6, characters 4-14:
       type t = B
       ^^^^^^^^^^
 Definition of type t/1
-Line _, characters 2-12:
+Line 2, characters 2-12:
     type t = A
     ^^^^^^^^^^
 Definition of type t/2
@@ -42,7 +42,7 @@ module N = struct
   struct type t = B type u = A of t end
 end;;
 [%%expect{|
-Line _, characters 2-39:
+Line 4, characters 2-39:
     struct type t = B type u = A of t end
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
@@ -55,11 +55,11 @@ Error: Signature mismatch:
        is not included in
          type u = A of t/2
        The types for field A are not equal.
-       Line _, characters 9-19:
+       Line 4, characters 9-19:
     struct type t = B type u = A of t end
            ^^^^^^^^^^
 Definition of type t/1
-Line _, characters 2-11:
+Line 2, characters 2-11:
     type t= A
     ^^^^^^^^^
 Definition of type t/2
@@ -75,7 +75,7 @@ module K = struct
 end;;
 
 [%%expect{|
-Line _, characters 4-70:
+Line 4, characters 4-70:
   ....struct
         module type s
         module A(X:s) =struct end
@@ -92,11 +92,11 @@ Error: Signature mismatch:
          functor (X : s/2) -> sig  end
        At position module A(X : <here>) : ...
        Modules do not match: s/2 is not included in s/1
-       Line _, characters 6-19:
+       Line 5, characters 6-19:
         module type s
         ^^^^^^^^^^^^^
 Definition of module type s/1
-Line _, characters 2-15:
+Line 2, characters 2-15:
     module type s
     ^^^^^^^^^^^^^
 Definition of module type s/2
@@ -111,7 +111,7 @@ module L = struct
     end
 end;;
       [%%expect {|
-Line _, characters 4-77:
+Line 4, characters 4-77:
   ....struct
         module T = struct type t end
         type t = A of T.t
@@ -126,11 +126,11 @@ Error: Signature mismatch:
        is not included in
          type t = A of T/2.t
        The types for field A are not equal.
-       Line _, characters 6-34:
+       Line 5, characters 6-34:
         module T = struct type t end
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Definition of module T/1
-Line _, characters 2-30:
+Line 2, characters 2-30:
     module T = struct type t end
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Definition of module T/2
@@ -144,7 +144,7 @@ module O = struct
 end;;
 
 [%%expect{|
-Line _, characters 2-62:
+Line 5, characters 2-62:
     struct module type s type t = B let f (module X:s) A = B end
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
@@ -156,19 +156,19 @@ Error: Signature mismatch:
          val f : (module s/1) -> t/2 -> t/1
        is not included in
          val f : (module s/2) -> t/2 -> t/2
-       Line _, characters 23-33:
+       Line 5, characters 23-33:
     struct module type s type t = B let f (module X:s) A = B end
                          ^^^^^^^^^^
 Definition of type t/1
-Line _, characters 2-12:
+Line 3, characters 2-12:
     type t = A
     ^^^^^^^^^^
 Definition of type t/2
-Line _, characters 9-22:
+Line 5, characters 9-22:
     struct module type s type t = B let f (module X:s) A = B end
            ^^^^^^^^^^^^^
 Definition of module type s/1
-Line _, characters 2-15:
+Line 2, characters 2-15:
     module type s
     ^^^^^^^^^^^^^
 Definition of module type s/2
@@ -182,7 +182,7 @@ module P = struct
 end;;
 
 [%%expect{|
-Line _, characters 5-41:
+Line 5, characters 5-41:
      = struct type a = B let f A _  = B end
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
@@ -194,11 +194,11 @@ Error: Signature mismatch:
          val f : a/2 -> 'a -> a/1
        is not included in
          val f : a/2 -> (module a) -> a/2
-       Line _, characters 12-22:
+       Line 5, characters 12-22:
      = struct type a = B let f A _  = B end
               ^^^^^^^^^^
 Definition of type a/1
-Line _, characters 2-12:
+Line 3, characters 2-12:
     type a = A
     ^^^^^^^^^^
 Definition of type a/2
@@ -215,7 +215,7 @@ end;;
 
 
 [%%expect{|
-Line _, characters 2-105:
+Line 4, characters 2-105:
   ..struct
       class a = object method c = let module X = struct type t end in () end
       class b = a
@@ -231,11 +231,11 @@ Error: Signature mismatch:
          class b : a/2
        The first class type has no method m
        The public method c cannot be hidden
-       Line _, characters 4-74:
+       Line 5, characters 4-74:
       class a = object method c = let module X = struct type t end in () end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Definition of class type a/1
-Line _, characters 2-36:
+Line 2, characters 2-36:
     class a = object method m = () end
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Definition of class type a/2
@@ -251,7 +251,7 @@ module R = struct
 end;;
 
 [%%expect{|
-Line _, characters 2-65:
+Line 4, characters 2-65:
   ..struct
       class type a = object end
       class type b = a
@@ -266,11 +266,11 @@ Error: Signature mismatch:
        does not match
          class type b = a/2
        The first class type has no method m
-       Line _, characters 4-29:
+       Line 5, characters 4-29:
       class type a = object end
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Definition of class type a/1
-Line _, characters 2-42:
+Line 2, characters 2-42:
     class type a = object method m: unit end
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Definition of class type a/2
@@ -302,7 +302,7 @@ end = struct
 end;;
 
 [%%expect{|
-Line _, characters 6-141:
+Line 8, characters 6-141:
   ......struct
     type t
     class type a = object method m:t end
@@ -336,11 +336,11 @@ Error: Signature mismatch:
          class type c = object method m : t/1 end
        The method m has type t/2 but is expected to have type t/1
        Type t/2 is not compatible with type t/1 = K.t
-       Line _, characters 4-10:
+       Line 12, characters 4-10:
       type t
       ^^^^^^
 Definition of type t/1
-Line _, characters 2-8:
+Line 9, characters 2-8:
     type t
     ^^^^^^
 Definition of type t/2
@@ -351,7 +351,7 @@ module rec M: sig type t type a = M.t end  =
 struct type t module M = struct type t end type a = M.t end;;
 
 [%%expect{|
-Line _, characters 0-59:
+Line 2, characters 0-59:
   struct type t module M = struct type t end type a = M.t end;;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
@@ -363,11 +363,11 @@ Error: Signature mismatch:
          type a = M/1.t
        is not included in
          type a = M/2.t
-       Line _, characters 14-42:
+       Line 2, characters 14-42:
   struct type t module M = struct type t end type a = M.t end;;
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Definition of module M/1
-Line _:
+File "_none_", line 1:
 Definition of module M/2
 |}]
 
@@ -385,7 +385,7 @@ type t = A
 type t = B
 type t = C
 type t = D
-Line _, characters 44-72:
+Line 5, characters 44-72:
   ............................................struct
     let f A B C = D
   end..
@@ -398,19 +398,19 @@ Error: Signature mismatch:
          val f : t/2 -> t/3 -> t/4 -> t/1
        is not included in
          val f : t/1 -> t/1 -> t/1 -> t/1
-       Line _, characters 0-10:
+       Line 4, characters 0-10:
   type t = D;;
   ^^^^^^^^^^
 Definition of type t/1
-Line _, characters 0-10:
+Line 1, characters 0-10:
   type t = A;;
   ^^^^^^^^^^
 Definition of type t/2
-Line _, characters 0-10:
+Line 2, characters 0-10:
   type t = B;;
   ^^^^^^^^^^
 Definition of type t/3
-Line _, characters 0-10:
+Line 3, characters 0-10:
   type t = C;;
   ^^^^^^^^^^
 Definition of type t/4
@@ -424,7 +424,7 @@ end
 let add_extra_info arg = arg.Foo.info.doc
 [%%expect {|
 module Foo : sig type info = { doc : unit; } type t = { info : info; } end
-Line _, characters 38-41:
+Line 5, characters 38-41:
   let add_extra_info arg = arg.Foo.info.doc
                                         ^^^
 Warning 40: doc was selected from type Foo.info.
@@ -446,7 +446,7 @@ let add_extra_info arg = arg.Foo.info.doc
 module Bar : sig type info = { doc : unit; } end
 module Foo : sig type t = { info : Bar.info; } end
 module Bar : sig  end
-Line _, characters 38-41:
+Line 8, characters 38-41:
   let add_extra_info arg = arg.Foo.info.doc
                                         ^^^
 Warning 40: doc was selected from type Bar/2.info.

--- a/testsuite/tests/typing-misc/pr6634.ml
+++ b/testsuite/tests/typing-misc/pr6634.ml
@@ -10,7 +10,7 @@ end;;
 
 [%%expect{|
 type t = int
-Line _, characters 0-31:
+Line 3, characters 0-31:
   struct
     type t = [`T of t]
   end..
@@ -23,11 +23,11 @@ Error: Signature mismatch:
          type t = [ `T of t/2 ]
        is not included in
          type t = [ `T of t/1 ]
-       Line _, characters 0-12:
+       Line 1, characters 0-12:
   type t = int
   ^^^^^^^^^^^^
 Definition of type t/1
-Line _, characters 2-20:
+Line 4, characters 2-20:
     type t = [`T of t]
     ^^^^^^^^^^^^^^^^^^
 Definition of type t/2

--- a/testsuite/tests/typing-misc/pr6939-flat-float-array.ml
+++ b/testsuite/tests/typing-misc/pr6939-flat-float-array.ml
@@ -5,11 +5,11 @@
 
 let rec x = [| x |]; 1.;;
 [%%expect{|
-Line _, characters 12-19:
+Line 1, characters 12-19:
   let rec x = [| x |]; 1.;;
               ^^^^^^^
 Warning 10: this expression should have type unit.
-Line _, characters 12-23:
+Line 1, characters 12-23:
   let rec x = [| x |]; 1.;;
               ^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
@@ -17,7 +17,7 @@ Error: This kind of expression is not allowed as right-hand side of `let rec'
 
 let rec x = let u = [|y|] in 10. and y = 1.;;
 [%%expect{|
-Line _, characters 12-32:
+Line 1, characters 12-32:
   let rec x = let u = [|y|] in 10. and y = 1.;;
               ^^^^^^^^^^^^^^^^^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'

--- a/testsuite/tests/typing-misc/pr7103.ml
+++ b/testsuite/tests/typing-misc/pr7103.ml
@@ -20,7 +20,7 @@ val h : [> `b ] t -> unit = <fun>
 
 let _ = fun (x : a t) -> f x;;
 [%%expect{|
-Line _, characters 27-28:
+Line 1, characters 27-28:
   let _ = fun (x : a t) -> f x;;
                              ^
 Error: This expression has type a t but an expression was expected of type
@@ -30,7 +30,7 @@ Error: This expression has type a t but an expression was expected of type
 
 let _ = fun (x : a t) -> g x;;
 [%%expect{|
-Line _, characters 27-28:
+Line 1, characters 27-28:
   let _ = fun (x : a t) -> g x;;
                              ^
 Error: This expression has type a t but an expression was expected of type
@@ -40,7 +40,7 @@ Error: This expression has type a t but an expression was expected of type
 
 let _ = fun (x : a t) -> h x;;
 [%%expect{|
-Line _, characters 27-28:
+Line 1, characters 27-28:
   let _ = fun (x : a t) -> h x;;
                              ^
 Error: This expression has type a t but an expression was expected of type

--- a/testsuite/tests/typing-misc/pr7228.ml
+++ b/testsuite/tests/typing-misc/pr7228.ml
@@ -14,7 +14,7 @@ type t = private A of {mutable x: int};;
 fun (A r) -> r.x <- 42;;
 [%%expect{|
 type t = private A of { mutable x : int; }
-Line _, characters 15-16:
+Line 2, characters 15-16:
   fun (A r) -> r.x <- 42;;
                  ^
 Error: Cannot assign field x of the private type t.A

--- a/testsuite/tests/typing-misc/pr7668_bad.ml
+++ b/testsuite/tests/typing-misc/pr7668_bad.ml
@@ -20,7 +20,7 @@ else `Right ()) xs
 val partition_map :
   ('a -> [< `Left of 'b | `Right of 'c ]) -> 'a list -> 'b list * 'c list =
   <fun>
-Line _, characters 35-96:
+Line 12, characters 35-96:
   ...................................partition_map (fun x -> if x then `Left ()
   else `Right ()) xs
 Error: This expression has type unit list * unit list

--- a/testsuite/tests/typing-misc/printing.ml
+++ b/testsuite/tests/typing-misc/printing.ml
@@ -6,7 +6,7 @@
 
 type t = [ 'A_name | `Hi ];;
 [%%expect{|
-Line _, characters 11-18:
+Line 1, characters 11-18:
   type t = [ 'A_name | `Hi ];;
              ^^^^^^^
 Error: The type 'A_name does not expand to a polymorphic variant type

--- a/testsuite/tests/typing-misc/records.ml
+++ b/testsuite/tests/typing-misc/records.ml
@@ -7,14 +7,14 @@ type t = {x:int;y:int};;
 {x=3;z=2};;
 [%%expect{|
 type t = { x : int; y : int; }
-Line _, characters 5-6:
+Line 2, characters 5-6:
   {x=3;z=2};;
        ^
 Error: Unbound record field z
 |}];;
 fun {x=3;z=2} -> ();;
 [%%expect{|
-Line _, characters 9-10:
+Line 1, characters 9-10:
   fun {x=3;z=2} -> ();;
            ^
 Error: Unbound record field z
@@ -23,7 +23,7 @@ Error: Unbound record field z
 (* mixed labels *)
 {x=3; contents=2};;
 [%%expect{|
-Line _, characters 6-14:
+Line 1, characters 6-14:
   {x=3; contents=2};;
         ^^^^^^^^
 Error: The record field contents belongs to the type 'a ref
@@ -35,14 +35,14 @@ type u = private {mutable u:int};;
 {u=3};;
 [%%expect{|
 type u = private { mutable u : int; }
-Line _, characters 0-5:
+Line 2, characters 0-5:
   {u=3};;
   ^^^^^
 Error: Cannot create values of the private type u
 |}];;
 fun x -> x.u <- 3;;
 [%%expect{|
-Line _, characters 11-12:
+Line 1, characters 11-12:
   fun x -> x.u <- 3;;
              ^
 Error: Cannot assign field u of the private type u
@@ -70,7 +70,7 @@ type foo = { mutable y:int };;
 let f (r: int) = r.y <- 3;;
 [%%expect{|
 type foo = { mutable y : int; }
-Line _, characters 17-18:
+Line 2, characters 17-18:
   let f (r: int) = r.y <- 3;;
                    ^
 Error: This expression has type int but an expression was expected of type
@@ -81,7 +81,7 @@ let f (r: int) =
   match r with
   | { contents = 3 } -> ()
 [%%expect{|
-Line _, characters 4-20:
+Line 3, characters 4-20:
     | { contents = 3 } -> ()
       ^^^^^^^^^^^^^^^^
 Error: This pattern matches values of type int ref
@@ -97,7 +97,7 @@ let f (r: bar) = ({ r with z = 3 } : foo)
 [%%expect{|
 type foo = { y : int; z : int; }
 type bar = { x : int; }
-Line _, characters 20-21:
+Line 3, characters 20-21:
   let f (r: bar) = ({ r with z = 3 } : foo)
                       ^
 Error: This expression has type bar but an expression was expected of type
@@ -108,7 +108,7 @@ type foo = { x: int };;
 let r : foo = { ZZZ.x = 2 };;
 [%%expect{|
 type foo = { x : int; }
-Line _, characters 16-21:
+Line 2, characters 16-21:
   let r : foo = { ZZZ.x = 2 };;
                   ^^^^^
 Error: Unbound module ZZZ
@@ -116,7 +116,7 @@ Error: Unbound module ZZZ
 
 (ZZZ.X : int option);;
 [%%expect{|
-Line _, characters 1-6:
+Line 1, characters 1-6:
   (ZZZ.X : int option);;
    ^^^^^
 Error: Unbound module ZZZ
@@ -125,7 +125,7 @@ Error: Unbound module ZZZ
 (* PR#5865 *)
 let f (x : Complex.t) = x.Complex.z;;
 [%%expect{|
-Line _, characters 26-35:
+Line 1, characters 26-35:
   let f (x : Complex.t) = x.Complex.z;;
                             ^^^^^^^^^
 Error: Unbound record field Complex.z
@@ -134,7 +134,7 @@ Error: Unbound record field Complex.z
 (* PR#6608 *)
 { true with contents = 0 };;
 [%%expect{|
-Line _, characters 2-6:
+Line 1, characters 2-6:
   { true with contents = 0 };;
     ^^^^
 Error: This expression has type bool but an expression was expected of type
@@ -157,7 +157,7 @@ let x = { f = 12; g = 43 };;
 [%%expect{|
 type 'a t = { f : 'a; g : 'a; }
 val x : int t = {f = 12; g = 43}
-Line _, characters 0-19:
+Line 3, characters 0-19:
   {x with f = "hola"};;
   ^^^^^^^^^^^^^^^^^^^
 Error: This expression has type string t

--- a/testsuite/tests/typing-misc/typecore_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_errors.ml
@@ -12,7 +12,7 @@
 
 let x = function 0. .. 1. -> ()
 [%%expect {|
-Line _, characters 17-25:
+Line 8, characters 17-25:
   let x = function 0. .. 1. -> ()
                    ^^^^^^^^
 Error: Only character intervals are supported in patterns.
@@ -22,7 +22,7 @@ Error: Only character intervals are supported in patterns.
 let f = function None None -> 0
 
 [%%expect{|
-Line _, characters 17-26:
+Line 1, characters 17-26:
   let f = function None None -> 0
                    ^^^^^^^^^
 Error: The constructor None expects 0 argument(s),
@@ -31,7 +31,7 @@ Error: The constructor None expects 0 argument(s),
 
 let x = None None
 [%%expect{|
-Line _, characters 8-17:
+Line 1, characters 8-17:
   let x = None None
           ^^^^^^^^^
 Error: The constructor None expects 0 argument(s),
@@ -44,7 +44,7 @@ let f = function (A (x:_)) -> 0
 
 [%%expect{|
 type t = A of { x : int; }
-Line _, characters 20-25:
+Line 2, characters 20-25:
   let f = function (A (x:_)) -> 0
                       ^^^^^
 Error: This form is not allowed as the type of the inlined record could escape.
@@ -54,7 +54,7 @@ Error: This form is not allowed as the type of the inlined record could escape.
 (** Exception below toplevel *)
 let f = function Some(exception Not_found) -> 0
 [%%expect{|
-Line _, characters 21-42:
+Line 1, characters 21-42:
   let f = function Some(exception Not_found) -> 0
                        ^^^^^^^^^^^^^^^^^^^^^
 Error: Exception patterns are not allowed in this position.
@@ -63,7 +63,7 @@ Error: Exception patterns are not allowed in this position.
 (** Extension *)
 let f = function [%ext] -> 0
 [%%expect{|
-Line _, characters 19-22:
+Line 1, characters 19-22:
   let f = function [%ext] -> 0
                      ^^^
 Error: Uninterpreted extension 'ext'.
@@ -74,7 +74,7 @@ Error: Uninterpreted extension 'ext'.
 
 let rec f x = ( (), () : _ -> _ -> _ )
 [%%expect{|
-Line _, characters 14-38:
+Line 3, characters 14-38:
   let rec f x = ( (), () : _ -> _ -> _ )
                 ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a * 'b
@@ -83,7 +83,7 @@ Error: This expression has type 'a * 'b
 
 let rec g x = ( ((), ()) : _ -> _ :> _ )
 [%%expect{|
-Line _, characters 14-40:
+Line 1, characters 14-40:
   let rec g x = ( ((), ()) : _ -> _ :> _ )
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type 'a * 'b
@@ -94,7 +94,7 @@ Error: This expression has type 'a * 'b
 (** Masked instance variable *)
 let c = object val x= 0 val y = x end
 [%%expect{|
-Line _, characters 32-33:
+Line 1, characters 32-33:
   let c = object val x= 0 val y = x end
                                   ^
 Error: The instance variable x
@@ -106,7 +106,7 @@ cannot be accessed from the definition of another instance variable
 
 let f x = match x with exception Not_found -> ();;
 [%%expect{|
-Line _, characters 10-48:
+Line 3, characters 10-48:
   let f x = match x with exception Not_found -> ();;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: None of the patterns in this 'match' expression match values.
@@ -118,7 +118,7 @@ let r = { x= 1; x= 1}
 
 [%%expect{|
 type r = { x : int; }
-Line _, characters 8-21:
+Line 2, characters 8-21:
   let r = { x= 1; x= 1}
           ^^^^^^^^^^^^^
 Error: The record field label x is defined several times
@@ -128,7 +128,7 @@ Error: The record field label x is defined several times
 let () = { x = 1 }.x <- 2
 
 [%%expect{|
-Line _, characters 9-25:
+Line 1, characters 9-25:
   let () = { x = 1 }.x <- 2
            ^^^^^^^^^^^^^^^^
 Error: The record field x is not mutable
@@ -139,7 +139,7 @@ Error: The record field x is not mutable
 
 let () = for Some i = 3 to 4 do () done;
 [%%expect{|
-Line _, characters 13-19:
+Line 3, characters 13-19:
   let () = for Some i = 3 to 4 do () done;
                ^^^^^^
 Error: Invalid for-loop index: only variables and _ are allowed.
@@ -157,7 +157,7 @@ end;;
 
 [%%expect{|
 class virtual v : object method virtual m : int end
-Line _, characters 18-23:
+Line 7, characters 18-23:
     method x: int = super#m
                     ^^^^^
 Error: This expression has no method m
@@ -168,7 +168,7 @@ Error: This expression has no method m
 let x = new v
 
 [%%expect{|
-Line _, characters 8-13:
+Line 3, characters 8-13:
   let x = new v
           ^^^^^
 Error: Cannot instantiate the virtual class v
@@ -179,7 +179,7 @@ Error: Cannot instantiate the virtual class v
 let x = object val x = 1 method m = x<-0 end
 
 [%%expect{|
-Line _, characters 36-40:
+Line 1, characters 36-40:
   let x = object val x = 1 method m = x<-0 end
                                       ^^^^
 Error: The instance variable x is not mutable
@@ -189,7 +189,7 @@ Error: The instance variable x is not mutable
 let x = object(self) method m = self <-0 end
 
 [%%expect{|
-Line _, characters 32-40:
+Line 1, characters 32-40:
   let x = object(self) method m = self <-0 end
                                   ^^^^^^^^
 Error: The value self is not an instance variable
@@ -200,7 +200,7 @@ Error: The value self is not an instance variable
 class c = object val x = 0 method m: c = {< x=0; x=1 >} end
 
 [%%expect{|
-Line _, characters 41-55:
+Line 3, characters 41-55:
   class c = object val x = 0 method m: c = {< x=0; x=1 >} end
                                            ^^^^^^^^^^^^^^
 Error: The instance variable x is overridden several times
@@ -211,7 +211,7 @@ Error: The instance variable x is overridden several times
 let f x = {< y = x >}
 
 [%%expect{|
-Line _, characters 10-21:
+Line 3, characters 10-21:
   let f x = {< y = x >}
             ^^^^^^^^^^^
 Error: This object duplication occurs outside a method definition
@@ -223,7 +223,7 @@ Error: This object duplication occurs outside a method definition
 class c = object val x = 0 method m: c = {< y=1 >} end
 
 [%%expect{|
-Line _, characters 41-50:
+Line 3, characters 41-50:
   class c = object val x = 0 method m: c = {< y=1 >} end
                                            ^^^^^^^^^
 Error: Unbound instance variable y
@@ -237,7 +237,7 @@ let x = f (module struct end)
 [%%expect {|
 module type empty = sig  end
 val f : int -> unit = <fun>
-Line _, characters 10-29:
+Line 3, characters 10-29:
   let x = f (module struct end)
             ^^^^^^^^^^^^^^^^^^^
 Error: This expression is packed module, but the expected type is
@@ -250,7 +250,7 @@ type t = A
 let x = [%extension_constructor A]
 [%%expect {|
 type t = A
-Line _, characters 32-33:
+Line 2, characters 32-33:
   let x = [%extension_constructor A]
                                   ^
 Error: This constructor is not an extension constructor.
@@ -258,7 +258,7 @@ Error: This constructor is not an extension constructor.
 
 let x = [%extension_constructor]
 [%%expect {|
-Line _, characters 8-32:
+Line 1, characters 8-32:
   let x = [%extension_constructor]
           ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Invalid [%extension_constructor] payload, a constructor is expected.
@@ -267,7 +267,7 @@ Error: Invalid [%extension_constructor] payload, a constructor is expected.
 (** Invalid format *)
 let x = format_of_string "%z"
 [%%expect {|
-Line _, characters 25-29:
+Line 1, characters 25-29:
   let x = format_of_string "%z"
                            ^^^^
 Error: invalid format "%z": at character number 1, invalid conversion "%z"
@@ -279,7 +279,7 @@ let f ~x = x + 2
 let y = f ~y:1
 [%%expect {|
 val f : x:int -> int = <fun>
-Line _, characters 13-14:
+Line 4, characters 13-14:
   let y = f ~y:1
                ^
 Error: The function applied to this argument has type x:int -> int
@@ -288,7 +288,7 @@ This argument cannot be applied with label ~y
 
 let g f = f ~x:0 ~y:0; f ~y:0 ~x:0
 [%%expect {|
-Line _, characters 23-24:
+Line 1, characters 23-24:
   let g f = f ~x:0 ~y:0; f ~y:0 ~x:0
                          ^
 Error: This function is applied to arguments
@@ -301,7 +301,7 @@ type t = A of { x: int }
 let x = A 1
 [%%expect {|
 type t = A of { x : int; }
-Line _, characters 8-11:
+Line 2, characters 8-11:
   let x = A 1
           ^^^
 Error: This constructor expects an inlined record argument.
@@ -313,7 +313,7 @@ let rec A x = A (A ())
 
 [%%expect {|
 type 'a t = A of 'a
-Line _, characters 8-11:
+Line 2, characters 8-11:
   let rec A x = A (A ())
           ^^^
 Error: Only variables are allowed as left-hand side of `let rec'
@@ -323,7 +323,7 @@ Error: Only variables are allowed as left-hand side of `let rec'
 
 let quadratic (x,x) = x * x
 [%%expect {|
-Line _, characters 17-18:
+Line 3, characters 17-18:
   let quadratic (x,x) = x * x
                    ^
 Error: Variable x is bound several times in this matching
@@ -334,7 +334,7 @@ type t = A of int | B of float|C
 let f (A x|B x) = 0
 [%%expect {|
 type t = A of int | B of float | C
-Line _, characters 6-15:
+Line 2, characters 6-15:
   let f (A x|B x) = 0
         ^^^^^^^^^
 Error: The variable x on the left-hand side of this or-pattern has type
@@ -345,7 +345,7 @@ Error: The variable x on the left-hand side of this or-pattern has type
 
 let f (A x|C) = 0
 [%%expect {|
-Line _, characters 6-13:
+Line 3, characters 6-13:
   let f (A x|C) = 0
         ^^^^^^^
 Error: Variable x must occur on both sides of this | pattern
@@ -354,7 +354,7 @@ Error: Variable x must occur on both sides of this | pattern
 
 let f (A x|B y) = 0
 [%%expect {|
-Line _, characters 6-15:
+Line 1, characters 6-15:
   let f (A x|B y) = 0
         ^^^^^^^^^
 Error: Variable x must occur on both sides of this | pattern
@@ -365,7 +365,7 @@ type t = []
 let f = function #t -> ()
 [%%expect {|
 type t = []
-Line _, characters 18-19:
+Line 2, characters 18-19:
   let f = function #t -> ()
                     ^
 Error: The type t
@@ -374,7 +374,7 @@ is not a variant type
 
 let f {x;x=y;x=z} = x
 [%%expect {|
-Line _, characters 6-17:
+Line 1, characters 6-17:
   let f {x;x=y;x=z} = x
         ^^^^^^^^^^^
 Error: The record field label x is defined several times
@@ -384,7 +384,7 @@ Error: The record field label x is defined several times
 
 let x = ([`B]:>[`A])
 [%%expect {|
-Line _, characters 9-13:
+Line 3, characters 9-13:
   let x = ([`B]:>[`A])
            ^^^^
 Error: This expression cannot be coerced to type [ `A ]; it has type
@@ -397,7 +397,7 @@ Error: This expression cannot be coerced to type [ `A ]; it has type
 let o = object method m = instance <- 0 end
 
 [%%expect{|
-Line _, characters 26-39:
+Line 3, characters 26-39:
   let o = object method m = instance <- 0 end
                             ^^^^^^^^^^^^^
 Error: Unbound instance variable instance
@@ -409,7 +409,7 @@ let x = function
   | `azdwbie -> ()
   | `c7diagq -> ()
 [%%expect{|
-Line _, characters 4-12:
+Line 3, characters 4-12:
     | `c7diagq -> ()
       ^^^^^^^^
 Error: Variant tags `azdwbie and `c7diagq have the same hash value.
@@ -419,7 +419,7 @@ Error: Variant tags `azdwbie and `c7diagq have the same hash value.
 
 let x =  `azdwbie = `c7diagq
 [%%expect{|
-Line _, characters 20-28:
+Line 1, characters 20-28:
   let x =  `azdwbie = `c7diagq
                       ^^^^^^^^
 Error: Variant tags `azdwbie and `c7diagq have the same hash value.
@@ -436,7 +436,7 @@ let x  = function
 
 [%%expect{|
 type 'a x = X : [> `azdwbie ] x | Y : [> `c7diagq ] x
-Line _, characters 4-5:
+Line 7, characters 4-5:
     | Y  -> ()
       ^
 Error: Variant tags `azdwbie and `c7diagq have the same hash value.
@@ -450,7 +450,7 @@ let f = function {x; y} -> x
 [%%expect {|
 type t = { x : unit; }
 type s = { y : unit; }
-Line _, characters 21-22:
+Line 3, characters 21-22:
   let f = function {x; y} -> x
                        ^
 Error: The record field y belongs to the type s
@@ -462,7 +462,7 @@ Error: The record field y belongs to the type s
 
 let x = [%ocaml.error "Expression error"]
 [%%expect {|
-Line _, characters 10-21:
+Line 3, characters 10-21:
   let x = [%ocaml.error "Expression error"]
             ^^^^^^^^^^^
 Error: Expression error
@@ -470,7 +470,7 @@ Error: Expression error
 
 let f [%ocaml.error "Pattern error"] = ()
 [%%expect {|
-Line _, characters 8-19:
+Line 1, characters 8-19:
   let f [%ocaml.error "Pattern error"] = ()
           ^^^^^^^^^^^
 Error: Pattern error

--- a/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
@@ -20,7 +20,7 @@ val f : x:'a -> unit = <fun>
 
 let () = f ~y:1
 [%%expect {|
-Line _, characters 14-15:
+Line 1, characters 14-15:
   let () = f ~y:1
                 ^
 Error: The function applied to this argument has type x:'a -> unit
@@ -31,7 +31,7 @@ let f ?x ~a ?y ~z = ()
 let g = f ?y:None ?x:None ~a:()
 [%%expect {|
 val f : ?x:'a -> a:'b -> ?y:'c -> z:'d -> unit = <fun>
-Line _, characters 13-17:
+Line 2, characters 13-17:
   let g = f ?y:None ?x:None ~a:()
                ^^^^
 Error: The function applied to this argument has type
@@ -42,7 +42,7 @@ This argument cannot be applied with label ?y
 let f (g: ?x:_ -> _) = g ~y:None ?x:None; g ?x:None ()
 
 [%%expect{|
-Line _, characters 28-32:
+Line 1, characters 28-32:
   let f (g: ?x:_ -> _) = g ~y:None ?x:None; g ?x:None ()
                               ^^^^
 Error: The function applied to this argument has type ?x:'a -> 'b

--- a/testsuite/tests/typing-misc/unique_names_in_unification.ml
+++ b/testsuite/tests/typing-misc/unique_names_in_unification.ml
@@ -11,16 +11,16 @@ end;;
 [%%expect{|
 type t = A
 val x : t = A
-Line _, characters 27-28:
+Line 5, characters 27-28:
     let f: t -> t = fun B -> x
                              ^
 Error: This expression has type t/2 but an expression was expected of type
          t/1
-Line _, characters 2-12:
+Line 4, characters 2-12:
     type t = B
     ^^^^^^^^^^
 Definition of type t/1
-Line _, characters 0-10:
+Line 1, characters 0-10:
   type t = A
   ^^^^^^^^^^
 Definition of type t/2
@@ -38,17 +38,17 @@ end;;
 [%%expect{|
 module M : sig type t = B end
 val y : M.t = M.B
-Line _, characters 34-35:
+Line 7, characters 34-35:
     let f : M.t -> M.t = fun M.C -> y
                                     ^
 Error: This expression has type M/2.t but an expression was expected of type
          M/1.t
-Line _, characters 2-41:
+Line 4, characters 2-41:
   ..module M = struct
        type t = C
     end
 Definition of module M/1
-Line _, characters 0-32:
+Line 1, characters 0-32:
   module M = struct type t = B end
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Definition of module M/2
@@ -60,16 +60,16 @@ let f: t -> t = fun D -> x;;
 
 [%%expect{|
 type t = D
-Line _, characters 25-26:
+Line 2, characters 25-26:
   let f: t -> t = fun D -> x;;
                            ^
 Error: This expression has type t/1 but an expression was expected of type
          t/2
-Line _, characters 0-10:
+Line 1, characters 0-10:
   type t = A
   ^^^^^^^^^^
 Definition of type t/1
-Line _, characters 0-10:
+Line 1, characters 0-10:
   type t = D
   ^^^^^^^^^^
 Definition of type t/2
@@ -88,16 +88,16 @@ type nonrec ttt = X of ttt
 let x: ttt = let rec y = A y in y;;
 [%%expect{|
 type nonrec ttt = X of ttt
-Line _, characters 32-33:
+Line 2, characters 32-33:
   let x: ttt = let rec y = A y in y;;
                                   ^
 Error: This expression has type ttt/2 but an expression was expected of type
          ttt/1
-Line _, characters 0-26:
+Line 1, characters 0-26:
   type nonrec ttt = X of ttt
   ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Definition of type ttt/1
-Line _, characters 0-30:
+Line 2, characters 0-30:
   type ttt = A of ttt | B of uuu
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Definition of type ttt/2

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -11,7 +11,7 @@ end = struct
  let f = function A | B -> 0
 end;;
 [%%expect{|
-Line _, characters 6-61:
+Line 3, characters 6-61:
   ......struct
    type t = A | B
    let f = function A | B -> 0

--- a/testsuite/tests/typing-misc/wellfounded.ml
+++ b/testsuite/tests/typing-misc/wellfounded.ml
@@ -15,7 +15,7 @@ let f : type t. t prod -> _ = function Prod ->
 ;;
 [%%expect{|
 type _ prod = Prod : ('a * 'y) prod
-Line _, characters 6-20:
+Line 6, characters 6-20:
         type d = d * d
         ^^^^^^^^^^^^^^
 Error: The type abbreviation d is cyclic

--- a/testsuite/tests/typing-modules/Test.ml
+++ b/testsuite/tests/typing-modules/Test.ml
@@ -68,7 +68,7 @@ module M : sig type -'a t = private int end =
   struct type +'a t = private int end
 ;;
 [%%expect{|
-Line _, characters 2-37:
+Line 2, characters 2-37:
     struct type +'a t = private int end
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
@@ -91,7 +91,7 @@ module type B = A with type t = u;; (* fail *)
 [%%expect{|
 module type A = sig type t = X of int end
 type u = X of bool
-Line _, characters 23-33:
+Line 3, characters 23-33:
   module type B = A with type t = u;; (* fail *)
                          ^^^^^^^^^^
 Error: This variant or record definition does not match that of type u
@@ -103,7 +103,7 @@ Error: This variant or record definition does not match that of type u
 
 module type S = sig exception Foo of int  exception Foo of bool end;;
 [%%expect{|
-Line _, characters 52-55:
+Line 1, characters 52-55:
   module type S = sig exception Foo of int  exception Foo of bool end;;
                                                       ^^^
 Error: Multiple definition of the extension constructor name Foo.
@@ -116,7 +116,7 @@ module F(X : sig end) = struct let x = 3 end;;
 F.x;; (* fail *)
 [%%expect{|
 module F : functor (X : sig  end) -> sig val x : int end
-Line _, characters 0-3:
+Line 2, characters 0-3:
   F.x;; (* fail *)
   ^^^
 Error: The module F is a functor, it cannot have any components

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -568,7 +568,7 @@ module type S =
     type wrap' = wrap = W of (Set.Make(Int).t, Set.Make(I).t) eq
   end
 module Int2 : sig type t = int val compare : 'a -> 'a -> int end
-Line _, characters 10-30:
+Line 15, characters 10-30:
     include S with module I := I
             ^^^^^^^^^^^^^^^^^^^^
 Error: In this `with' constraint, the new definition of I
@@ -661,7 +661,7 @@ module rec Bad : A = Bad;;
 [%%expect{|
 module type Alias = sig module N : sig  end module M = N end
 module F : functor (X : sig  end) -> sig type t end
-Line _:
+Line 1:
 Error: Module type declarations do not match:
          module type A = sig module M = F(List) end
        does not match

--- a/testsuite/tests/typing-modules/applicative_functor_type.ml
+++ b/testsuite/tests/typing-modules/applicative_functor_type.ml
@@ -16,7 +16,7 @@ module M : sig type t val equal : 'a -> 'a -> bool end
 
 type t = Set.Make(M).t
 [%%expect{|
-Line _, characters 9-22:
+Line 1, characters 9-22:
   type t = Set.Make(M).t
            ^^^^^^^^^^^^^
 Error: The type of M does not match Set.Make's parameter
@@ -40,7 +40,7 @@ module F :
 
 type t = F(M).t
 [%%expect{|
-Line _, characters 9-15:
+Line 1, characters 9-15:
   type t = F(M).t
            ^^^^^^
 Error: The type of M does not match F's parameter
@@ -63,7 +63,7 @@ module Generative : functor () -> sig type t end
 
 type t = Generative(M).t
 [%%expect{|
-Line _, characters 9-24:
+Line 1, characters 9-24:
   type t = Generative(M).t
            ^^^^^^^^^^^^^^^
 Error: The functor Generative is generative, it cannot be applied in type
@@ -76,7 +76,7 @@ module F(X : sig module type S module F : S end) = struct
   type t = X.F(Parsing).t
 end
 [%%expect{|
-Line _, characters 11-25:
+Line 2, characters 11-25:
     type t = X.F(Parsing).t
              ^^^^^^^^^^^^^^
 Error: The module X.F is abstract, it cannot be applied

--- a/testsuite/tests/typing-modules/firstclass.ml
+++ b/testsuite/tests/typing-modules/firstclass.ml
@@ -29,7 +29,7 @@ module type S2 = sig type u type t type w end
 val g2 : (module S2 with type t = int and type u = bool) -> (module S') =
   <fun>
 val h : (module S2 with type t = 'a) -> (module S with type t = 'a) = <fun>
-Line _, characters 3-4:
+Line 5, characters 3-4:
     (x : (module S'));; (* fail *)
      ^
 Error: This expression has type
@@ -43,7 +43,7 @@ let g3 x =
   (x : (module S3 with type t = 'a and type u = 'b) :> (module S'));; (* fail *)
 [%%expect{|
 module type S3 = sig type u type t val x : int end
-Line _, characters 2-67:
+Line 3, characters 2-67:
     (x : (module S3 with type t = 'a and type u = 'b) :> (module S'));; (* fail *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type (module S3 with type t = int and type u = bool)

--- a/testsuite/tests/typing-modules/generative.ml
+++ b/testsuite/tests/typing-modules/generative.ml
@@ -29,7 +29,7 @@ module F : functor () -> S
 |}];;
 module G (X : sig end) : S = F ();; (* fail *)
 [%%expect{|
-Line _, characters 29-33:
+Line 1, characters 29-33:
   module G (X : sig end) : S = F ();; (* fail *)
                                ^^^^
 Error: This expression creates fresh types.
@@ -49,7 +49,7 @@ module M : S
 |}];;
 module M = F(U);; (* fail *)
 [%%expect{|
-Line _, characters 11-12:
+Line 1, characters 11-12:
   module M = F(U);; (* fail *)
              ^
 Error: This is a generative functor. It can only be applied to ()
@@ -60,7 +60,7 @@ module F1 (X : sig end) = struct end;;
 module F2 : functor () -> sig end = F1;; (* fail *)
 [%%expect{|
 module F1 : functor (X : sig  end) -> sig  end
-Line _, characters 36-38:
+Line 2, characters 36-38:
   module F2 : functor () -> sig end = F1;; (* fail *)
                                       ^^
 Error: Signature mismatch:
@@ -73,7 +73,7 @@ module F3 () = struct end;;
 module F4 : functor (X : sig end) -> sig end = F3;; (* fail *)
 [%%expect{|
 module F3 : functor () -> sig  end
-Line _, characters 47-49:
+Line 2, characters 47-49:
   module F4 : functor (X : sig end) -> sig end = F3;; (* fail *)
                                                  ^^
 Error: Signature mismatch:

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -99,7 +99,7 @@ end = struct
   type s = t
 end;;
 [%%expect{|
-Line _, characters 6-29:
+Line 3, characters 6-29:
   ......struct
     type s = t
   end..

--- a/testsuite/tests/typing-modules/pr6394.ml
+++ b/testsuite/tests/typing-modules/pr6394.ml
@@ -10,7 +10,7 @@ end = struct
   let f = function A | B -> 0
 end;;
 [%%expect{|
-Line _, characters 6-63:
+Line 4, characters 6-63:
   ......struct
     type t = A | B
     let f = function A | B -> 0

--- a/testsuite/tests/typing-modules/pr7207.ml
+++ b/testsuite/tests/typing-modules/pr7207.ml
@@ -6,7 +6,7 @@ module F (X : sig end) = struct type t = int end;;
 type t = F(Does_not_exist).t;;
 [%%expect{|
 module F : functor (X : sig  end) -> sig type t = int end
-Line _, characters 9-28:
+Line 2, characters 9-28:
   type t = F(Does_not_exist).t;;
            ^^^^^^^^^^^^^^^^^^^
 Error: Unbound module Does_not_exist

--- a/testsuite/tests/typing-modules/pr7726.ml
+++ b/testsuite/tests/typing-modules/pr7726.ml
@@ -15,7 +15,7 @@ module Fix :
 
 module T1 = Fix(functor (X:sig type t end) -> struct type t = X.t option end);;
 [%%expect{|
-Line _, characters 12-77:
+Line 1, characters 12-77:
   module T1 = Fix(functor (X:sig type t end) -> struct type t = X.t option end);;
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the signature of this functor application:
@@ -23,7 +23,7 @@ Error: In the signature of this functor application:
 |}]
 module T2 = Fix(functor (X:sig type t end) -> struct type t = X.t end);;
 [%%expect{|
-Line _, characters 12-70:
+Line 1, characters 12-70:
   module T2 = Fix(functor (X:sig type t end) -> struct type t = X.t end);;
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the signature of this functor application:
@@ -64,7 +64,7 @@ module Id : functor (X : T) -> sig type t = X.t end
 
 module type Bad = S with module F = Id;;
 [%%expect{|
-Line _, characters 18-38:
+Line 1, characters 18-38:
   module type Bad = S with module F = Id;;
                     ^^^^^^^^^^^^^^^^^^^^
 Error: In this instantiated signature:
@@ -75,7 +75,7 @@ Error: In this instantiated signature:
 (* More examples by lpw25 *)
 module M = Fix(Id);;
 [%%expect{|
-Line _, characters 11-18:
+Line 1, characters 11-18:
   module M = Fix(Id);;
              ^^^^^^^
 Error: In the signature of this functor application:
@@ -84,7 +84,7 @@ Error: In the signature of this functor application:
 |}]
 type t = Fix(Id).Fixed.t;;
 [%%expect{|
-Line _, characters 9-24:
+Line 1, characters 9-24:
   type t = Fix(Id).Fixed.t;;
            ^^^^^^^^^^^^^^^
 Error: In the signature of Fix(Id):
@@ -93,7 +93,7 @@ Error: In the signature of Fix(Id):
 |}]
 let f (x : Fix(Id).Fixed.t) = x;;
 [%%expect{|
-Line _, characters 11-26:
+Line 1, characters 11-26:
   let f (x : Fix(Id).Fixed.t) = x;;
              ^^^^^^^^^^^^^^^
 Error: In the signature of Fix(Id):
@@ -110,7 +110,7 @@ M.f 5;;
 module Foo :
   functor (F : T -> T) -> sig val f : Fix(F).Fixed.t -> Fix(F).Fixed.t end
 module M : sig val f : Fix(Id).Fixed.t -> Fix(Id).Fixed.t end
-Line _:
+Line 1:
 Error: In the signature of Fix(Id):
        The definition of Fixed.t contains a cycle:
        Id(Fixed).t
@@ -123,7 +123,7 @@ type t = F(M).t;;
 [%%expect{|
 module F : functor () -> sig type t end
 module M : sig  end
-Line _, characters 9-15:
+Line 3, characters 9-15:
   type t = F(M).t;;
            ^^^^^^
 Error: The functor F is generative, it cannot be applied in type expressions
@@ -141,7 +141,7 @@ module Fix2 :
       module rec Fixed : sig type t = F(Fixed).t end
       module R : functor (X : sig  end) -> sig type t = Fixed.t end
     end
-Line _, characters 11-26:
+Line 5, characters 11-26:
   let f (x : Fix2(Id).R(M).t) = x;;
              ^^^^^^^^^^^^^^^
 Error: In the signature of Fix2(Id):

--- a/testsuite/tests/typing-modules/recursive.ml
+++ b/testsuite/tests/typing-modules/recursive.ml
@@ -6,7 +6,7 @@
 
 module rec T : sig type t = T.t end = T;;
 [%%expect{|
-Line _, characters 15-35:
+Line 1, characters 15-35:
   module rec T : sig type t = T.t end = T;;
                  ^^^^^^^^^^^^^^^^^^^^
 Error: The type abbreviation T.t is cyclic

--- a/testsuite/tests/typing-modules/unroll_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/unroll_private_abbrev.ml
@@ -28,7 +28,7 @@ let y =
   | `Foo -> assert false
 ;;
 [%%expect{|
-Line _, characters 8-41:
+Line 2, characters 8-41:
     match (M.bar :> [ `Bar of M.t | `Foo ]) with
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type M.t is not a subtype of [ `Bar of M.t | `Foo ]
@@ -72,7 +72,7 @@ let y =
   | `Foo -> assert false
 ;;
 [%%expect{|
-Line _, characters 8-48:
+Line 2, characters 8-48:
     match (N.from M.bar :> [ `Bar of N.s | `Foo ]) with
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type N.s is not a subtype of [ `Bar of N.s | `Foo ]

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -95,7 +95,7 @@ class ref x_init = object
   method set y = x <- y
 end;;
 [%%expect{|
-Line _, characters 0-95:
+Line 1, characters 0-95:
   class ref x_init = object
     val mutable x = x_init
     method get = x
@@ -204,7 +204,7 @@ class ['a] color_circle :
 
 let c'' = new color_circle p;;
 [%%expect{|
-Line _, characters 27-28:
+Line 1, characters 27-28:
   let c'' = new color_circle p;;
                              ^
 Error: This expression has type point but an expression was expected of type
@@ -222,7 +222,7 @@ val c'' : color_point color_circle = <obj>
 |}];;
 (c'' :> point circle);;
 [%%expect{|
-Line _, characters 0-21:
+Line 1, characters 0-21:
   (c'' :> point circle);;
   ^^^^^^^^^^^^^^^^^^^^^
 Error: Type
@@ -236,7 +236,7 @@ Error: Type
 |}];;                 (* Fail *)
 fun x -> (x : color_point color_circle :> point circle);;
 [%%expect{|
-Line _, characters 9-55:
+Line 1, characters 9-55:
   fun x -> (x : color_point color_circle :> point circle);;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type
@@ -284,7 +284,7 @@ class printable_color_point y c = object (self)
     Format.print_string ")"
 end;;
 [%%expect{|
-Line _, characters 10-27:
+Line 3, characters 10-27:
     inherit printable_point y as super
             ^^^^^^^^^^^^^^^^^
 Warning 13: the following instance variables are overridden by the class printable_point :
@@ -532,7 +532,7 @@ val c2 : int_comparable2 = <obj>
 |}];;
 l#add (c2 :> int_comparable);;
 [%%expect{|
-Line _, characters 6-28:
+Line 1, characters 6-28:
   l#add (c2 :> int_comparable);;
         ^^^^^^^^^^^^^^^^^^^^^^
 Error: Type
@@ -577,7 +577,7 @@ l#add (c3 :> int_comparable);;
 |}];;
 (new sorted_list ())#add c3;;
 [%%expect{|
-Line _, characters 25-27:
+Line 1, characters 25-27:
   (new sorted_list ())#add c3;;
                            ^^
 Error: This expression has type
@@ -591,7 +591,7 @@ Error: This expression has type
            < cmp : int_comparable -> int; setx : int -> unit; x : int >
        The first object type has no method setx
 |}, Principal{|
-Line _, characters 25-27:
+Line 1, characters 25-27:
   (new sorted_list ())#add c3;;
                            ^^
 Error: This expression has type
@@ -612,7 +612,7 @@ let pr l =
   List.map (fun c -> Format.print_int c#x; Format.print_string " ") l;
   Format.print_newline ();;
 [%%expect{|
-Line _, characters 2-69:
+Line 2, characters 2-69:
     List.map (fun c -> Format.print_int c#x; Format.print_string " ") l;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 10: this expression should have type unit.

--- a/testsuite/tests/typing-objects/Tests.ml
+++ b/testsuite/tests/typing-objects/Tests.ml
@@ -31,7 +31,7 @@ end and d () = object
   inherit ['a] c ()
 end;;
 [%%expect{|
-Line _, characters 4-45:
+Line 3, characters 4-45:
   ....and d () = object
     inherit ['a] c ()
   end..
@@ -88,7 +88,7 @@ class x () = object
   method virtual f : int
 end;;
 [%%expect{|
-Line _, characters 0-48:
+Line 1, characters 0-48:
   class x () = object
     method virtual f : int
   end..
@@ -103,7 +103,7 @@ and virtual d x = object (_ : 'a)
   method g = true
 end;;
 [%%expect{|
-Line _, characters 49-57:
+Line 1, characters 49-57:
   class virtual c ((x : 'a): < f : int >) = object (_ : 'a) end
                                                    ^^^^^^^^
 Error: This pattern cannot match self: it only matches values of type
@@ -116,7 +116,7 @@ class ['a] c () = object
   method f x = (x : bool c)
 end;;
 [%%expect{|
-Line _, characters 0-78:
+Line 1, characters 0-78:
   class ['a] c () = object
     constraint 'a = int
     method f x = (x : bool c)
@@ -162,7 +162,7 @@ class ['a] c () = object
   method f = (x : 'a)
 end;;
 [%%expect{|
-Line _, characters 0-50:
+Line 1, characters 0-50:
   class ['a] c () = object
     method f = (x : 'a)
   end..
@@ -176,7 +176,7 @@ Error: The type of this class,
 type 'a c = <f : 'a c; g : 'a d>
 and 'a d = <f : int c>;;
 [%%expect{|
-Line _, characters 0-32:
+Line 1, characters 0-32:
   type 'a c = <f : 'a c; g : 'a d>
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the definition of d, type int c should be 'a c
@@ -196,7 +196,7 @@ and 'a d = < f : int c >
 type 'a u = < x : 'a>
 and 'a t = 'a t u;;
 [%%expect{|
-Line _, characters 0-17:
+Line 2, characters 0-17:
   and 'a t = 'a t u;;
   ^^^^^^^^^^^^^^^^^
 Error: The definition of t contains a cycle:
@@ -205,7 +205,7 @@ Error: The definition of t contains a cycle:
 type 'a u = 'a
 and 'a t = 'a t u;;
 [%%expect{|
-Line _, characters 0-17:
+Line 2, characters 0-17:
   and 'a t = 'a t u;;
   ^^^^^^^^^^^^^^^^^
 Error: The type abbreviation t is cyclic
@@ -216,7 +216,7 @@ type 'a u = 'a
 |}];;
 type t = t u * t u;;
 [%%expect{|
-Line _, characters 0-18:
+Line 1, characters 0-18:
   type t = t u * t u;;
   ^^^^^^^^^^^^^^^^^^
 Error: The type abbreviation t is cyclic
@@ -380,7 +380,7 @@ class e : unit -> object method f : int end
 |}];;
 class c () = object val x = - true val y = -. () end;;
 [%%expect{|
-Line _, characters 30-34:
+Line 1, characters 30-34:
   class c () = object val x = - true val y = -. () end;;
                                 ^^^^
 Error: This expression has type bool but an expression was expected of type
@@ -447,24 +447,24 @@ class e () = object
   method b = b
 end;;
 [%%expect{|
-Line _, characters 10-13:
+Line 3, characters 10-13:
     inherit c 5
             ^^^
 Warning 13: the following instance variables are overridden by the class c :
   x
 The behaviour changed in ocaml 3.10 (previous behaviour was hiding.)
-Line _, characters 6-7:
+Line 4, characters 6-7:
     val y = 3
         ^
 Warning 13: the instance variable y is overridden.
 The behaviour changed in ocaml 3.10 (previous behaviour was hiding.)
-Line _, characters 10-13:
+Line 6, characters 10-13:
     inherit d 7
             ^^^
 Warning 13: the following instance variables are overridden by the class d :
   t z
 The behaviour changed in ocaml 3.10 (previous behaviour was hiding.)
-Line _, characters 6-7:
+Line 7, characters 6-7:
     val u = 3
         ^
 Warning 13: the instance variable u is overridden.
@@ -618,7 +618,7 @@ class virtual ['a] matrix (sz, init : int * 'a) = object
   method add (mtx : 'a matrix) = (mtx#m.(0).(0) : 'a)
 end;;
 [%%expect{|
-Line _, characters 0-153:
+Line 1, characters 0-153:
   class virtual ['a] matrix (sz, init : int * 'a) = object
     val m = Array.make_matrix sz sz init
     method add (mtx : 'a matrix) = (mtx#m.(0).(0) : 'a)
@@ -667,7 +667,7 @@ end : sig
   val f : #c -> #c
 end);;
 [%%expect{|
-Line _, characters 12-43:
+Line 1, characters 12-43:
   ............struct
     let f (x : #c) = x
   end......
@@ -684,7 +684,7 @@ Error: Signature mismatch:
 
 module M = struct type t = int class t () = object end end;;
 [%%expect{|
-Line _, characters 37-38:
+Line 1, characters 37-38:
   module M = struct type t = int class t () = object end end;;
                                        ^
 Error: Multiple definition of the type name t.
@@ -698,7 +698,7 @@ fun x -> (x :> < m : 'a -> 'a > as 'a);;
 
 fun x -> (x : int -> bool :> 'a -> 'a);;
 [%%expect{|
-Line _, characters 9-38:
+Line 1, characters 9-38:
   fun x -> (x : int -> bool :> 'a -> 'a);;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type int -> bool is not a subtype of int -> int
@@ -706,7 +706,7 @@ Error: Type int -> bool is not a subtype of int -> int
 |}];;
 fun x -> (x : int -> bool :> int -> int);;
 [%%expect{|
-Line _, characters 9-40:
+Line 1, characters 9-40:
   fun x -> (x : int -> bool :> int -> int);;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type int -> bool is not a subtype of int -> int
@@ -741,7 +741,7 @@ type 'a t
 |}];;
 fun (x : 'a t as 'a) -> ();;
 [%%expect{|
-Line _, characters 9-19:
+Line 1, characters 9-19:
   fun (x : 'a t as 'a) -> ();;
            ^^^^^^^^^^
 Error: This alias is bound to type 'a t but is used as an instance of type 'a
@@ -749,7 +749,7 @@ Error: This alias is bound to type 'a t but is used as an instance of type 'a
 |}];;
 fun (x : 'a t) -> (x : 'a); ();;
 [%%expect{|
-Line _, characters 19-20:
+Line 1, characters 19-20:
   fun (x : 'a t) -> (x : 'a); ();;
                      ^
 Error: This expression has type 'a t but an expression was expected of type
@@ -766,7 +766,7 @@ fun (x : 'a t as 'a) -> ();;
 |}];;
 fun (x : 'a t) -> (x : 'a); ();;
 [%%expect{|
-Line _, characters 18-26:
+Line 1, characters 18-26:
   fun (x : 'a t) -> (x : 'a); ();;
                     ^^^^^^^^
 Warning 10: this expression should have type unit.
@@ -873,7 +873,7 @@ let o = object val x = 33 val y = 44 method m = x end in
 class a = let _ = new b in object end
 and b = let _ = new a in object end;;
 [%%expect{|
-Line _, characters 10-37:
+Line 1, characters 10-37:
   class a = let _ = new b in object end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of recursive class expression is not allowed
@@ -881,7 +881,7 @@ Error: This kind of recursive class expression is not allowed
 
 class a = let _ = new a in object end;;
 [%%expect{|
-Line _, characters 10-37:
+Line 1, characters 10-37:
   class a = let _ = new a in object end;;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This kind of recursive class expression is not allowed

--- a/testsuite/tests/typing-objects/dummy.ml
+++ b/testsuite/tests/typing-objects/dummy.ml
@@ -42,7 +42,7 @@ and foo = object(self)
 end;;
 
 [%%expect{|
-Line _, characters 22-26:
+Line 16, characters 22-26:
         inherit child1' self
                         ^^^^
 Error: This expression has type < child : 'a; previous : 'b option; .. >
@@ -139,7 +139,7 @@ class leading_up_to = object(self : 'a)
     end
 end;;
 [%%expect{|
-Line _, characters 4-65:
+Line 4, characters 4-65:
   ....object
         inherit child1 self
         inherit child2
@@ -162,7 +162,7 @@ class assertion_failure = object(self : 'a)
     end
 end;;
 [%%expect{|
-Line _, characters 4-129:
+Line 4, characters 4-129:
   ....object
         inherit child1 self
         inherit child2

--- a/testsuite/tests/typing-objects/errors.ml
+++ b/testsuite/tests/typing-objects/errors.ml
@@ -4,7 +4,7 @@
 
 class type virtual ['a] c = object constraint 'a = [<`A of int & float] end
 [%%expect {|
-Line _, characters 0-75:
+Line 1, characters 0-75:
   class type virtual ['a] c = object constraint 'a = [<`A of int & float] end
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type of this class,

--- a/testsuite/tests/typing-objects/pr5619_bad.ml
+++ b/testsuite/tests/typing-objects/pr5619_bad.ml
@@ -40,7 +40,7 @@ class foo: foo_t =
   end
 ;;
 [%%expect{|
-Line _, characters 2-156:
+Line 2, characters 2-156:
   ..object(self)
       method foo = "foo"
       method cast: type a. a name -> a =

--- a/testsuite/tests/typing-objects/pr5858.ml
+++ b/testsuite/tests/typing-objects/pr5858.ml
@@ -9,7 +9,7 @@ class type c = object  end
 
 module type S = sig class c: c end;;
 [%%expect{|
-Line _, characters 29-30:
+Line 1, characters 29-30:
   module type S = sig class c: c end;;
                                ^
 Error: The class type c is not yet completely defined

--- a/testsuite/tests/typing-objects/pr6123_bad.ml
+++ b/testsuite/tests/typing-objects/pr6123_bad.ml
@@ -26,7 +26,7 @@ object
 end
 ;;
 [%%expect{|
-Line _, characters 50-54:
+Line 15, characters 50-54:
         let args = List.map (fun ty -> new argument(self, ty)) args_ty in
                                                     ^^^^
 Error: This expression has type < arguments : 'a; .. >

--- a/testsuite/tests/typing-objects/pr6383.ml
+++ b/testsuite/tests/typing-objects/pr6383.ml
@@ -4,7 +4,7 @@
 
 let f (x: #M.foo) = 0;;
 [%%expect{|
-Line _, characters 11-16:
+Line 1, characters 11-16:
   let f (x: #M.foo) = 0;;
              ^^^^^
 Error: Unbound module M

--- a/testsuite/tests/typing-objects/pr6907_bad.ml
+++ b/testsuite/tests/typing-objects/pr6907_bad.ml
@@ -13,7 +13,7 @@ module type S = sig
   class base : 'e -> ['e] t
 end;;
 [%%expect{|
-Line _, characters 2-27:
+Line 2, characters 2-27:
     class base : 'e -> ['e] t
     ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Some type variables are unbound in this type:

--- a/testsuite/tests/typing-pattern_open/pattern_open.ocaml.reference
+++ b/testsuite/tests/typing-pattern_open/pattern_open.ocaml.reference
@@ -52,15 +52,15 @@ module S :
     type ex = Ex : 'a * 'a -> ex
     val s : unit t
   end
-Characters 58-61:
+Line 2, characters 27-30:
     | S.(Sep), (S.(Sep,Sep), Sep) -> ()
                              ^^^
 Error: Unbound constructor Sep
-Characters 50-52:
+Line 2, characters 17-19:
     | S.(Ex(a,b)), Ex(c,d) -> ()
                    ^^
 Error: Unbound constructor Ex
-Characters 48-49:
+Line 2, characters 15-16:
     | S.(Sep) -> s
                  ^
 Error: Unbound value s

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -38,7 +38,7 @@ match px with
 | {pv=true::_} -> "bool"
 ;;
 [%%expect {|
-Line _, characters 0-77:
+Line 1, characters 0-77:
   match px with
   | {pv=[]} -> "OK"
   | {pv=5::_} -> "int"
@@ -55,7 +55,7 @@ match px with
 | {pv=5::_} -> "int"
 ;;
 [%%expect {|
-Line _, characters 0-77:
+Line 1, characters 0-77:
   match px with
   | {pv=[]} -> "OK"
   | {pv=true::_} -> "bool"
@@ -292,7 +292,7 @@ class ['a] ostream1 :
     method tl : 'b
   end
 |}, Principal{|
-Line _, characters 4-16:
+Line 8, characters 4-16:
       self#tl#fold ~f ~init:(f self#hd init)
       ^^^^^^^^^^^^
 Warning 18: this use of a polymorphic method is not principal.
@@ -451,7 +451,7 @@ val cp : color_point = <obj>
 val c : circle = <obj>
 val d : float = 11.
 val f : < m : 'a. 'a -> 'a > -> < m : 'b. 'b -> 'b > = <fun>
-Line _, characters 41-42:
+Line 9, characters 41-42:
   let f (x : < m : 'a. 'a -> 'a list >) = (x : < m : 'b. 'b -> 'c >)
                                            ^
 Error: This expression has type < m : 'b. 'b -> 'b list >
@@ -503,7 +503,7 @@ class ['a] id1 = object
 end
 ;;
 [%%expect {|
-Line _, characters 12-17:
+Line 3, characters 12-17:
     method id x = x
               ^^^^^
 Error: This method has type 'a -> 'a which is less general than 'b. 'b -> 'a
@@ -515,7 +515,7 @@ class id2 (x : 'a) = object
 end
 ;;
 [%%expect {|
-Line _, characters 12-17:
+Line 3, characters 12-17:
     method id x = x
               ^^^^^
 Error: This method has type 'a -> 'a which is less general than 'b. 'b -> 'a
@@ -528,7 +528,7 @@ class id3 x = object
 end
 ;;
 [%%expect {|
-Line _, characters 12-17:
+Line 4, characters 12-17:
     method id _ = x
               ^^^^^
 Error: This method has type 'b -> 'b which is less general than 'a. 'a -> 'a
@@ -544,7 +544,7 @@ class id4 () = object
 end
 ;;
 [%%expect {|
-Line _, characters 12-79:
+Line 4, characters 12-79:
   ............x =
       match r with
         None -> r <- Some x; x
@@ -573,7 +573,7 @@ let f4 f = ignore(f : id); f#id 1, f#id true
 [%%expect {|
 val f1 : id -> int * bool = <fun>
 val f2 : id -> int * bool = <fun>
-Line _, characters 24-28:
+Line 5, characters 24-28:
   let f3 f = f#id 1, f#id true
                           ^^^^
 Error: This expression has type bool but an expression was expected of type
@@ -603,7 +603,7 @@ type 'a foo = 'a foo list
 [%%expect {|
 class id2 : object method id : 'a -> 'a method mono : int -> int end
 val app : int * bool = (1, true)
-Line _, characters 0-25:
+Line 9, characters 0-25:
   type 'a foo = 'a foo list
   ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type abbreviation foo is cyclic
@@ -813,7 +813,7 @@ let bad2 = {bad2 = None};;
 bad2.bad2 <- Some (ref None);;
 [%%expect {|
 type bad = { bad : 'a. 'a option ref; }
-Line _, characters 17-25:
+Line 2, characters 17-25:
   let bad = {bad = ref None};;
                    ^^^^^^^^
 Error: This field value has type 'b option ref which is less general than
@@ -868,7 +868,7 @@ object method virtual caseNil : 'a end
 and virtual int_list =
 object method virtual visit : 'a.('a visitor -> 'a) end;;
 [%%expect {|
-Line _, characters 30-51:
+Line 4, characters 30-51:
   object method virtual visit : 'a.('a visitor -> 'a) end;;
                                 ^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a cannot be generalized:
@@ -895,7 +895,7 @@ type t = { f : 'a 'b. ('b -> (#ct as 'a) -> 'b) -> 'b; }
 (* PR#1663 *)
 type t = u and u = t;;
 [%%expect {|
-Line _, characters 0-10:
+Line 1, characters 0-10:
   type t = u and u = t;;
   ^^^^^^^^^^
 Error: The definition of t contains a cycle:
@@ -913,7 +913,7 @@ type t = [ `A of t a ]
 (* Wrong in 3.06 *)
 type ('a,'b) t constraint 'a = 'b and ('a,'b) u = ('a,'b) t;;
 [%%expect {|
-Line _, characters 50-59:
+Line 1, characters 50-59:
   type ('a,'b) t constraint 'a = 'b and ('a,'b) u = ('a,'b) t;;
                                                     ^^^^^^^^^
 Error: Constraints are not satisfied in this type.
@@ -933,7 +933,7 @@ type 'a u = 'a and 'a v = 'a u t;;
 type 'a u = 'a and 'a v = 'a u t constraint 'a = int;;
 [%%expect {|
 type 'a t constraint 'a = int
-Line _, characters 26-32:
+Line 2, characters 26-32:
   type 'a u = 'a and 'a v = 'a u t;;
                             ^^^^^^
 Error: Constraints are not satisfied in this type.
@@ -948,7 +948,7 @@ type 'a u = 'a and 'a v = 'a u t constraint 'a = int;;
 [%%expect {|
 type g = int
 type 'a t = unit constraint 'a = g
-Line _, characters 26-32:
+Line 3, characters 26-32:
   type 'a u = 'a and 'a v = 'a u t;;
                             ^^^^^^
 Error: Constraints are not satisfied in this type.
@@ -958,7 +958,7 @@ Error: Constraints are not satisfied in this type.
 (* Example of wrong expansion *)
 type 'a u = < m : 'a v > and 'a v = 'a list u;;
 [%%expect {|
-Line _, characters 0-24:
+Line 1, characters 0-24:
   type 'a u = < m : 'a v > and 'a v = 'a list u;;
   ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the definition of v, type 'a list u should be 'a u
@@ -990,7 +990,7 @@ type u = 'a t as 'a
 type ('a, 'b) a = 'a -> unit constraint 'a = [> `B of ('a, 'b) b as 'b]
 and  ('a, 'b) b = 'b -> unit constraint 'b = [> `A of ('a, 'b) a as 'a];;
 [%%expect {|
-Line _, characters 0-71:
+Line 1, characters 0-71:
   type ('a, 'b) a = 'a -> unit constraint 'a = [> `B of ('a, 'b) b as 'b]
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The definition of a contains a cycle:
@@ -1068,13 +1068,13 @@ end;;
 class c : object method m : int end
 val f : unit -> c = <fun>
 val f : unit -> c = <fun>
-Line _, characters 11-60:
+Line 4, characters 11-60:
   let f () = object method private n = 1 method m = {<>}#n end;;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 15: the following private methods were made public implicitly:
  n.
 val f : unit -> < m : int; n : int > = <fun>
-Line _, characters 11-56:
+Line 5, characters 11-56:
   let f () = object (self:c) method n = 1 method m = 2 end;;
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This object is expected to have type c but actually has type
@@ -1092,7 +1092,7 @@ type 'a bar = <m: 'b. 'a * <m: 'c. 'c * 'a bar> >
 type bar' =   <m: 'a. 'a * 'a bar >
 let f (x : foo') = (x : bar');;
 [%%expect {|
-Line _, characters 3-4:
+Line 2, characters 3-4:
     (x : <m : 'a. 'a * (<m:'b. 'a * <m:'c. 'c * 'bar> > as 'bar) >);;
      ^
 Error: This expression has type < m : 'a. 'a * < m : 'a * 'b > > as 'b
@@ -1111,7 +1111,7 @@ let f x =
     (x : <m : 'a. 'a -> ('a * <m:'c. 'c -> 'bar> as 'bar)>
        :> <m : 'a. 'a -> ('a * 'foo)> as 'foo);;
 [%%expect {|
-Line _, characters 3-4:
+Line 2, characters 3-4:
     (x : <m : 'b. 'b * ('b * <m : 'c. 'c * ('c * 'bar)>)> as 'bar);;
      ^
 Error: This expression has type
@@ -1128,7 +1128,7 @@ module M
 : sig type t = <m : 'b. 'b * ('b * <m:'c. 'c * 'bar> as 'bar)> end
 = struct type t = <m : 'a. 'a * ('a * 'foo)> as 'foo end;;
 [%%expect {|
-Line _, characters 2-64:
+Line 3, characters 2-64:
   = struct let f (x : <m : 'a. 'a * ('a * 'foo)> as 'foo) = () end;;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
@@ -1188,7 +1188,7 @@ type v = private [> t ]
 - : t -> v = <fun>
 type u = private [< t ]
 - : u -> v = <fun>
-Line _, characters 9-21:
+Line 6, characters 9-21:
   fun x -> (x : v :> u);;
            ^^^^^^^^^^^^
 Error: Type v = [> `A | `B ] is not a subtype of u = [< `A | `B ]
@@ -1209,7 +1209,7 @@ let f5 x =
 let f6 x =
   (x : <m:'a. [< `A of < > ] as 'a> :> <m:'a. [< `A of <p:int> ] as 'a>);;
 [%%expect {|
-Line _, characters 2-88:
+Line 2, characters 2-88:
   ..(x : <m:'a. (<p:int;..> as 'a) -> int>
       :> <m:'b. (<p:int;q:int;..> as 'b) -> int>)..
 Error: Type < m : 'a. (< p : int; .. > as 'a) -> int > is not a subtype of
@@ -1234,19 +1234,19 @@ val f : < m : 'a. 'a -> 'a > -> < m : 'a. 'a -> 'a > array = <fun>
 - : < m : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
 |}, Principal{|
 val f : < m : 'a. 'a -> 'a > -> < m : 'a. 'a -> 'a > = <fun>
-Line _, characters 9-16:
+Line 2, characters 9-16:
   fun x -> (f x)#m;; (* Warning 18 *)
            ^^^^^^^
 Warning 18: this use of a polymorphic method is not principal.
 - : < m : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
 val f : < m : 'a. 'a -> 'a > * 'b -> < m : 'a. 'a -> 'a > = <fun>
-Line _, characters 9-20:
+Line 4, characters 9-20:
   fun x -> (f (x,x))#m;; (* Warning 18 *)
            ^^^^^^^^^^^
 Warning 18: this use of a polymorphic method is not principal.
 - : < m : 'a. 'a -> 'a > -> 'b -> 'b = <fun>
 val f : < m : 'a. 'a -> 'a > -> < m : 'a. 'a -> 'a > array = <fun>
-Line _, characters 9-20:
+Line 6, characters 9-20:
   fun x -> (f x).(0)#m;; (* Warning 18 *)
            ^^^^^^^^^^^
 Warning 18: this use of a polymorphic method is not principal.
@@ -1275,12 +1275,12 @@ val h : < id : 'a; .. > -> 'a = <fun>
 class c : object method id : 'a -> 'a end
 type u = c option
 val just : 'a option -> 'a = <fun>
-Line _, characters 42-62:
+Line 4, characters 42-62:
   let f x = let l = [Some x; (None : u)] in (just(List.hd l))#id;;
                                             ^^^^^^^^^^^^^^^^^^^^
 Warning 18: this use of a polymorphic method is not principal.
 val f : c -> 'a -> 'a = <fun>
-Line _, characters 36-47:
+Line 7, characters 36-47:
     let x = List.hd [Some x; none] in (just x)#id;;
                                       ^^^^^^^^^^^
 Warning 18: this use of a polymorphic method is not principal.
@@ -1323,7 +1323,7 @@ val f : 'a -> int = <fun>
 val g : 'a -> int = <fun>
 type 'a t = Leaf of 'a | Node of ('a * 'a) t
 val depth : 'a t -> int = <fun>
-Line _, characters 2-42:
+Line 6, characters 2-42:
     function Leaf _ -> 1 | Node x -> 1 + d x
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This definition has type 'a t -> int which is less general than
@@ -1339,7 +1339,7 @@ let zero = {f = `Int 0} ;; (* fails *)
 type t = { f : 'a. [> `B of 'a | `Int of int ] as 'a; }
 val zero : t = {f = `Int 0}
 type t = { f : 'a. [< `Int of int ] as 'a; }
-Line _, characters 16-22:
+Line 4, characters 16-22:
   let zero = {f = `Int 0} ;; (* fails *)
                   ^^^^^^
 Error: This expression has type [> `Int of int ]
@@ -1391,7 +1391,7 @@ let f ?x y = y in {f};; (* fail *)
 [%%expect {|
 type t = { f : 'a. 'a -> unit; }
 - : t = {f = <fun>}
-Line _, characters 19-20:
+Line 3, characters 19-20:
   let f ?x y = y in {f};; (* fail *)
                      ^
 Error: This field value has type unit -> unit which is less general than
@@ -1430,7 +1430,7 @@ Exception: Stdlib.Pervasives.Exit.
 
 type 'x t = < f : 'y. 'y t >;;
 [%%expect {|
-Line _, characters 0-28:
+Line 1, characters 0-28:
   type 'x t = < f : 'y. 'y t >;;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: In the definition of t, type 'y t should be 'x t
@@ -1474,7 +1474,7 @@ val n : < m : 'x. [< `Foo of 'x ] -> 'x > = <obj>
 let (n : < m : 'a. [< `Foo of int] -> 'a >) =
   object method m : 'x. [< `Foo of 'x] -> 'x = fun x -> assert false end;;
 [%%expect {|
-Line _, characters 2-72:
+Line 2, characters 2-72:
     object method m : 'x. [< `Foo of 'x] -> 'x = fun x -> assert false end;;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type < m : 'x. [< `Foo of 'x ] -> 'x >
@@ -1486,7 +1486,7 @@ Error: This expression has type < m : 'x. [< `Foo of 'x ] -> 'x >
 let (n : 'b -> < m : 'a . ([< `Foo of int] as 'b) -> 'a >) = fun x ->
   object method m : 'x. [< `Foo of 'x] -> 'x = fun x -> assert false end;;
 [%%expect {|
-Line _, characters 2-72:
+Line 2, characters 2-72:
     object method m : 'x. [< `Foo of 'x] -> 'x = fun x -> assert false end;;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type < m : 'x. [< `Foo of 'x ] -> 'x >
@@ -1500,7 +1500,7 @@ let f b (x: 'x) =
   let module M = struct type t = A end in
   if b then x else M.A;;
 [%%expect {|
-Line _, characters 19-22:
+Line 3, characters 19-22:
     if b then x else M.A;;
                      ^^^
 Error: This expression has type M.t but an expression was expected of type 'x
@@ -1594,7 +1594,7 @@ type h = < m : int; n : string; x : string; y : int >
 type t = <g>
 and g = <a:t>
 [%%expect{|
-Line _, characters 10-11:
+Line 1, characters 10-11:
   type t = <g>
             ^
 Error: The type constructor g
@@ -1605,7 +1605,7 @@ type t = int
 type g = <t>
 [%%expect{|
 type t = int
-Line _, characters 10-11:
+Line 2, characters 10-11:
   type g = <t>
             ^
 Error: The type int is not an object type
@@ -1646,7 +1646,7 @@ type r2 = < a : int >
 
 type gg = <a:int->float; a:int>
 [%%expect{|
-Line _, characters 27-30:
+Line 1, characters 27-30:
   type gg = <a:int->float; a:int>
                              ^^^
 Error: Method 'a' has type int, which should be int -> float
@@ -1656,7 +1656,7 @@ type t = <a:int; b:string>
 type g = <b:float; t;>
 [%%expect{|
 type t = < a : int; b : string >
-Line _, characters 19-20:
+Line 2, characters 19-20:
   type g = <b:float; t;>
                      ^
 Error: Method 'b' has type string, which should be float
@@ -1673,7 +1673,7 @@ type t = < f : int >
 
 type t = < int #A.t1 >
 [%%expect{|
-Line _, characters 11-20:
+Line 1, characters 11-20:
   type t = < int #A.t1 >
              ^^^^^^^^^
 Error: Illegal open object type

--- a/testsuite/tests/typing-polyvariants-bugs/pr7824.ml
+++ b/testsuite/tests/typing-polyvariants-bugs/pr7824.ml
@@ -37,7 +37,7 @@ let f x =
   | _::_ -> (x :> [`A | `C] Element.t)
 ;;
 [%%expect{|
-Line _, characters 2-54:
+Line 4, characters 2-54:
   ..match [] with
     | _::_ -> (x :> [`A | `C] Element.t)
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-private/private.compilers.principal.reference
+++ b/testsuite/tests/typing-private/private.compilers.principal.reference
@@ -1,6 +1,6 @@
 module Foobar : sig type t = private int end
 module F0 : sig type t = private int end
-Characters 21-22:
+Line 2, characters 20-21:
   let f (x : F0.t) = (x : Foobar.t);; (* fails *)
                       ^
 Error: This expression has type F0.t but an expression was expected of type
@@ -10,7 +10,7 @@ val f : F.t -> Foobar.t = <fun>
 module M : sig type t = < m : int > end
 module M1 : sig type t = private < m : int; .. > end
 module M2 : sig type t = private < m : int; .. > end
-Characters 19-20:
+Line 1, characters 19-20:
   fun (x : M1.t) -> (x : M2.t);; (* fails *)
                      ^
 Error: This expression has type M1.t but an expression was expected of type
@@ -18,7 +18,7 @@ Error: This expression has type M1.t but an expression was expected of type
 module M3 : sig type t = private M1.t end
 - : M3.t -> M1.t = <fun>
 - : M3.t -> M.t = <fun>
-Characters 44-46:
+Line 1, characters 44-46:
   module M4 : sig type t = private M3.t end = M2;; (* fails *)
                                               ^^
 Error: Signature mismatch:
@@ -30,7 +30,7 @@ Error: Signature mismatch:
          type t = M2.t
        is not included in
          type t = private M3.t
-Characters 44-45:
+Line 1, characters 44-45:
   module M4 : sig type t = private M3.t end = M;; (* fails *)
                                               ^
 Error: Signature mismatch:
@@ -42,7 +42,7 @@ Error: Signature mismatch:
          type t = < m : int >
        is not included in
          type t = private M3.t
-Characters 44-46:
+Line 1, characters 44-46:
   module M4 : sig type t = private M3.t end = M1;; (* might be ok *)
                                               ^^
 Error: Signature mismatch:
@@ -55,7 +55,7 @@ Error: Signature mismatch:
        is not included in
          type t = private M3.t
 module M5 : sig type t = private M1.t end
-Characters 53-55:
+Line 1, characters 53-55:
   module M6 : sig type t = private < n:int; .. > end = M1;; (* fails *)
                                                        ^^
 Error: Signature mismatch:
@@ -67,7 +67,7 @@ Error: Signature mismatch:
          type t = M1.t
        is not included in
          type t = private < n : int; .. >
-Characters 69-118:
+Line 3, characters 2-51:
     struct type t = int let f (x : int) = (x : t) end;; (* must fail *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
@@ -83,7 +83,7 @@ module M : sig type t = private T of int val mk : int -> t end
 module M1 : sig type t = M.t val mk : int -> t end
 module M2 : sig type t = M.t val mk : int -> t end
 module M3 : sig type t = M.t val mk : int -> t end
-Characters 21-44:
+Line 3, characters 4-27:
       type t = M.t = T of int
       ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type M.t
@@ -99,11 +99,11 @@ module Test : sig type t = private A end
 module Test2 : sig type t = Test.t = private A end
 val f : Test.t -> Test2.t = <fun>
 val f : Test2.t -> unit = <fun>
-Characters 8-15:
+Line 1, characters 8-15:
   let a = Test2.A;; (* fail *)
           ^^^^^^^
 Error: Cannot create values of the private type Test2.t
-Characters 148-171:
+Line 3, characters 40-63:
   module Test2 : module type of Test with type t = private Test.t = Test;;
                                           ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 3: deprecated: spurious use of private

--- a/testsuite/tests/typing-private/private.compilers.reference
+++ b/testsuite/tests/typing-private/private.compilers.reference
@@ -1,6 +1,6 @@
 module Foobar : sig type t = private int end
 module F0 : sig type t = private int end
-Characters 21-22:
+Line 2, characters 20-21:
   let f (x : F0.t) = (x : Foobar.t);; (* fails *)
                       ^
 Error: This expression has type F0.t but an expression was expected of type
@@ -10,7 +10,7 @@ val f : F.t -> Foobar.t = <fun>
 module M : sig type t = < m : int > end
 module M1 : sig type t = private < m : int; .. > end
 module M2 : sig type t = private < m : int; .. > end
-Characters 19-20:
+Line 1, characters 19-20:
   fun (x : M1.t) -> (x : M2.t);; (* fails *)
                      ^
 Error: This expression has type M1.t but an expression was expected of type
@@ -18,7 +18,7 @@ Error: This expression has type M1.t but an expression was expected of type
 module M3 : sig type t = private M1.t end
 - : M3.t -> M1.t = <fun>
 - : M3.t -> M.t = <fun>
-Characters 44-46:
+Line 1, characters 44-46:
   module M4 : sig type t = private M3.t end = M2;; (* fails *)
                                               ^^
 Error: Signature mismatch:
@@ -30,7 +30,7 @@ Error: Signature mismatch:
          type t = M2.t
        is not included in
          type t = private M3.t
-Characters 44-45:
+Line 1, characters 44-45:
   module M4 : sig type t = private M3.t end = M;; (* fails *)
                                               ^
 Error: Signature mismatch:
@@ -42,7 +42,7 @@ Error: Signature mismatch:
          type t = < m : int >
        is not included in
          type t = private M3.t
-Characters 44-46:
+Line 1, characters 44-46:
   module M4 : sig type t = private M3.t end = M1;; (* might be ok *)
                                               ^^
 Error: Signature mismatch:
@@ -55,7 +55,7 @@ Error: Signature mismatch:
        is not included in
          type t = private M3.t
 module M5 : sig type t = private M1.t end
-Characters 53-55:
+Line 1, characters 53-55:
   module M6 : sig type t = private < n:int; .. > end = M1;; (* fails *)
                                                        ^^
 Error: Signature mismatch:
@@ -67,7 +67,7 @@ Error: Signature mismatch:
          type t = M1.t
        is not included in
          type t = private < n : int; .. >
-Characters 69-118:
+Line 3, characters 2-51:
     struct type t = int let f (x : int) = (x : t) end;; (* must fail *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
@@ -83,7 +83,7 @@ module M : sig type t = private T of int val mk : int -> t end
 module M1 : sig type t = M.t val mk : int -> t end
 module M2 : sig type t = M.t val mk : int -> t end
 module M3 : sig type t = M.t val mk : int -> t end
-Characters 21-44:
+Line 3, characters 4-27:
       type t = M.t = T of int
       ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This variant or record definition does not match that of type M.t
@@ -99,11 +99,11 @@ module Test : sig type t = private A end
 module Test2 : sig type t = Test.t = private A end
 val f : Test.t -> Test2.t = <fun>
 val f : Test2.t -> unit = <fun>
-Characters 8-15:
+Line 1, characters 8-15:
   let a = Test2.A;; (* fail *)
           ^^^^^^^
 Error: Cannot create values of the private type Test2.t
-Characters 148-171:
+Line 3, characters 40-63:
   module Test2 : module type of Test with type t = private Test.t = Test;;
                                           ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 3: deprecated: spurious use of private

--- a/testsuite/tests/typing-recordarg/recordarg.ocaml.reference
+++ b/testsuite/tests/typing-recordarg/recordarg.ocaml.reference
@@ -1,12 +1,12 @@
 type t = A of { x : int; mutable y : int; }
-Characters 14-15:
+Line 1, characters 14-15:
   let f (A r) = r;;  (* -> escape *)
                 ^
 Error: This form is not allowed as the type of the inlined record could escape.
 val f : t -> int = <fun>
 val f : int -> t = <fun>
 val f : t -> t = <fun>
-Characters 14-15:
+Line 1, characters 14-15:
   let f () = A {a = 1};; (* customized error message *)
                 ^
 Error: The field a is not part of the record argument for the t.A constructor
@@ -25,29 +25,29 @@ module N :
     exception Foo of { x : int; }
   end
 module type S = sig exception A of { x : int; } end
-Characters 65-74:
+Line 3, characters 13-22:
     module A = (val X.x)
                ^^^^^^^^^
 Error: This expression creates fresh types.
        It is not allowed inside applicative functors.
-Characters 61-62:
+Line 5, characters 12-13:
     exception A of {x : string}
               ^
 Error: Multiple definition of the extension constructor name A.
        Names must be unique in a given structure or signature.
-Characters 58-59:
+Line 4, characters 12-13:
     exception A of {x : string}
               ^
 Error: Multiple definition of the extension constructor name A.
        Names must be unique in a given structure or signature.
 module M1 : sig exception A of { x : int; } end
-Characters 34-44:
+Line 4, characters 2-12:
     include M1
     ^^^^^^^^^^
 Error: Multiple definition of the extension constructor name A.
        Names must be unique in a given structure or signature.
 module type S1 = sig exception A of { x : int; } end
-Characters 36-46:
+Line 4, characters 2-12:
     include S1
     ^^^^^^^^^^
 Error: Multiple definition of the extension constructor name A.
@@ -55,7 +55,7 @@ Error: Multiple definition of the extension constructor name A.
 module M : sig exception A of { x : int; } end
 module X1 : sig type t = .. end
 module X2 : sig type t = .. end
-Characters 62-63:
+Line 3, characters 15-16:
     type X2.t += A of {x: int}
                  ^
 Error: Multiple definition of the extension constructor name A.

--- a/testsuite/tests/typing-short-paths/pr5918.compilers.reference
+++ b/testsuite/tests/typing-short-paths/pr5918.compilers.reference
@@ -1,4 +1,4 @@
-Characters 136-146:
+Line 10, characters 9-19:
    let _ = { a = () }
            ^^^^^^^^^^
 Error: Some record fields are undefined: b

--- a/testsuite/tests/typing-short-paths/pr7543.compilers.reference
+++ b/testsuite/tests/typing-short-paths/pr7543.compilers.reference
@@ -1,7 +1,7 @@
 module type S = sig type t end
 module N : sig type 'a t = 'a end
 val f : (module S with type t = unit) -> unit = <fun>
-Characters 19-20:
+Line 1, characters 19-20:
   let () = f (module N);;
                      ^
 Error: Signature mismatch:

--- a/testsuite/tests/typing-short-paths/short-paths.compilers.reference
+++ b/testsuite/tests/typing-short-paths/short-paths.compilers.reference
@@ -61,7 +61,7 @@ module Core :
     module Std : sig module Int = Int end
   end
 val x : 'a Int.Map.t = <abstr>
-Characters 8-9:
+Line 1, characters 8-9:
   let y = x + x ;;
           ^
 Error: This expression has type 'a Int.Map.t
@@ -85,7 +85,7 @@ type t1 = B
 module N2 : sig type u = v and v = N1.v end
 module type PR6566 = sig type t = string end
 module PR6566 : sig type t = int end
-Characters 26-32:
+Line 1, characters 26-32:
   module PR6566' : PR6566 = PR6566;;
                             ^^^^^^
 Error: Signature mismatch:

--- a/testsuite/tests/typing-signatures/pr6672.ocaml.reference
+++ b/testsuite/tests/typing-signatures/pr6672.ocaml.reference
@@ -1,6 +1,6 @@
 module type S = sig type 'a t end
 module type T = sig type 'a t = 'a list end
-Characters 23-43:
+Line 1, characters 23-43:
   module type T = S with type -'a t = 'a list;;
                          ^^^^^^^^^^^^^^^^^^^^
 Error: In this definition, expected parameter variances are not satisfied.

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -22,7 +22,7 @@ module type PrintableComparable = sig
   include Comparable with type t = t
 end
 [%%expect {|
-Line _, characters 2-36:
+Line 3, characters 2-36:
     include Comparable with type t = t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Multiple definition of the type name t.
@@ -45,7 +45,7 @@ module type S0 = sig
   and M2 : sig type t = int end
 end with type M.t = int
 [%%expect {|
-Line _, characters 17-115:
+Line 1, characters 17-115:
   .................sig
     module rec M : sig type t = M2.t end
     and M2 : sig type t = int end
@@ -168,7 +168,7 @@ module type S = sig
 end with type 'a t2 := 'a t * bool
 [%%expect {|
 type 'a t constraint 'a = 'b list
-Line _, characters 16-142:
+Line 2, characters 16-142:
   ................sig
     type 'a t2 constraint 'a = 'b list
     type 'a mylist = 'a list
@@ -244,7 +244,7 @@ module type S = sig
   module A = M
 end with type M.t := float
 [%%expect {|
-Line _, characters 16-89:
+Line 1, characters 16-89:
   ................sig
     module M : sig type t end
     module A = M
@@ -272,7 +272,7 @@ module type S =
 (* This particular substitution cannot be made to work *)
 module type S2 = S with type M.t := float
 [%%expect {|
-Line _, characters 17-41:
+Line 1, characters 17-41:
   module type S2 = S with type M.t := float
                    ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This `with' constraint on M.t makes the applicative functor
@@ -306,7 +306,7 @@ module type S3 = sig
 end with type M2.t := int
 [%%expect {|
 module Id : functor (X : sig type t end) -> sig type t = X.t end
-Line _, characters 17-120:
+Line 2, characters 17-120:
   .................sig
     module rec M : sig type t = A of Id(M2).t end
     and M2 : sig type t end
@@ -349,7 +349,7 @@ module type S = sig
   module Alias = M
 end with module M.N := A
 [%%expect {|
-Line _, characters 16-159:
+Line 1, characters 16-159:
   ................sig
     module M : sig
       module N : sig

--- a/testsuite/tests/typing-typeparam/newtype.ocaml.reference
+++ b/testsuite/tests/typing-typeparam/newtype.ocaml.reference
@@ -5,12 +5,12 @@ true
 false
 val sort_uniq : ('a -> 'a -> int) -> 'a list -> 'a list = <fun>
 abc,xyz
-Characters 33-34:
+Line 2, characters 32-33:
   let f x (type a) (y : a) = (x = y);; (* Fails *)
                                   ^
 Error: This expression has type a but an expression was expected of type 'a
        The type constructor a would escape its scope
-Characters 117-118:
+Line 3, characters 53-54:
     method n : 'a -> 'a = fun (type g) (x:g) -> self#m x
                                                        ^
 Error: This expression has type g but an expression was expected of type 'a

--- a/testsuite/tests/typing-unboxed-types/test.ml.reference-flat
+++ b/testsuite/tests/typing-unboxed-types/test.ml.reference-flat
@@ -4,42 +4,42 @@ type t2 = { f : string; } [@@unboxed]
 - : bool = true
 type t3 = B of { g : string; } [@@unboxed]
 - : bool = true
-Characters 29-58:
+Line 3, characters 0-29:
   type t4 = C [@@ocaml.unboxed];;  (* no argument *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because its constructor has no argument.
-Characters 0-45:
+Line 1, characters 0-45:
   type t5 = D of int * string [@@ocaml.unboxed];; (* more than one argument *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because
        its constructor has more than one argument.
-Characters 0-33:
+Line 1, characters 0-33:
   type t5 = E | F [@@ocaml.unboxed];;          (* more than one constructor *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because it has more than one constructor.
-Characters 0-40:
+Line 1, characters 0-40:
   type t6 = G of int | H [@@ocaml.unboxed];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because it has more than one constructor.
-Characters 0-51:
+Line 1, characters 0-51:
   type t7 = I of string | J of bool [@@ocaml.unboxed];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because it has more than one constructor.
-Characters 1-50:
+Line 2, characters 0-49:
   type t8 = { h : bool; i : int } [@@ocaml.unboxed];;  (* more than one field *)
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because it has more than one field.
-Characters 0-56:
+Line 1, characters 0-56:
   type t9 = K of { j : string; l : int } [@@ocaml.unboxed];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because
        its constructor has more than one argument.
 type t10 = A of t10 [@@unboxed]
-Characters 12-15:
+Line 1, characters 12-15:
   let rec x = A x;;
               ^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
-Characters 121-172:
+Line 5, characters 6-57:
   ......struct
     type t = A of string [@@ocaml.unboxed]
   end..
@@ -54,7 +54,7 @@ Error: Signature mismatch:
          type t = A of string
        Their internal representations differ:
        the first declaration uses unboxed representation.
-Characters 63-96:
+Line 4, characters 6-39:
   ......struct
     type t = A of string
   end..
@@ -69,7 +69,7 @@ Error: Signature mismatch:
          type t = A of string [@@unboxed]
        Their internal representations differ:
        the second declaration uses unboxed representation.
-Characters 48-102:
+Line 4, characters 6-60:
   ......struct
     type t = { f : string } [@@ocaml.unboxed]
   end..
@@ -84,7 +84,7 @@ Error: Signature mismatch:
          type t = { f : string; }
        Their internal representations differ:
        the first declaration uses unboxed representation.
-Characters 66-102:
+Line 4, characters 6-42:
   ......struct
     type t = { f : string }
   end..
@@ -99,7 +99,7 @@ Error: Signature mismatch:
          type t = { f : string; } [@@unboxed]
        Their internal representations differ:
        the second declaration uses unboxed representation.
-Characters 53-112:
+Line 4, characters 6-65:
   ......struct
     type t = A of { f : string } [@@ocaml.unboxed]
   end..
@@ -114,7 +114,7 @@ Error: Signature mismatch:
          type t = A of { f : string; }
        Their internal representations differ:
        the first declaration uses unboxed representation.
-Characters 71-112:
+Line 4, characters 6-47:
   ......struct
     type t = A of { f : string }
   end..
@@ -137,19 +137,19 @@ type t13 = A : 'a t12 -> t13 [@@unboxed]
 type t14
 type t15 = A of t14 [@@unboxed]
 type 'a abs
-Characters 0-45:
+Line 1, characters 0-45:
   type t16 = A : _ abs -> t16 [@@ocaml.unboxed];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because
        it might contain both float and non-float values.
        You should annotate it with [@@ocaml.boxed].
-Characters 19-69:
+Line 3, characters 0-50:
   type t18 = A : _ list abs -> t18 [@@ocaml.unboxed];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because
        it might contain both float and non-float values.
        You should annotate it with [@@ocaml.boxed].
-Characters 176-256:
+Line 7, characters 6-86:
   ......struct
     type t = A of float [@@ocaml.unboxed]
     type u = { f1 : t; f2 : t }
@@ -164,14 +164,14 @@ Error: Signature mismatch:
        the first declaration uses unboxed float representation.
 module T : sig type t [@@immediate] end
 type 'a s = S : 'a -> 'a s [@@unboxed]
-Characters 0-33:
+Line 1, characters 0-33:
   type t = T : _ s -> t [@@unboxed];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because
        it might contain both float and non-float values.
        You should annotate it with [@@ocaml.boxed].
 type 'a s = S : 'a -> 'a option s [@@unboxed]
-Characters 0-33:
+Line 1, characters 0-33:
   type t = T : _ s -> t [@@unboxed];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because
@@ -179,21 +179,21 @@ Error: This type cannot be unboxed because
        You should annotate it with [@@ocaml.boxed].
 module M :
   sig type 'a r constraint 'a = unit -> 'b val inj : 'b -> (unit -> 'b) r end
-Characters 14-59:
+Line 3, characters 0-45:
   type t = T : (unit -> _) M.r -> t [@@unboxed];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because
        it might contain both float and non-float values.
        You should annotate it with [@@ocaml.boxed].
 type 'a s = S : (unit -> 'a) M.r -> 'a option s [@@unboxed]
-Characters 14-47:
+Line 3, characters 0-33:
   type t = T : _ s -> t [@@unboxed];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because
        it might contain both float and non-float values.
        You should annotate it with [@@ocaml.boxed].
 type 'a t = T : 'a s -> 'a t [@@unboxed]
-Characters 42-81:
+Line 4, characters 0-39:
   type _ s = S : 'a t -> _ s  [@@unboxed]
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because

--- a/testsuite/tests/typing-unboxed/test.ocaml.reference
+++ b/testsuite/tests/typing-unboxed/test.ocaml.reference
@@ -10,27 +10,27 @@ module M :
     external a : int -> (int [@untagged]) = "a" "a_nat"
     external b : (int [@untagged]) -> int = "b" "b_nat"
   end
-Characters 382-451:
+Line 12, characters 2-71:
     external f : (int32 [@unboxed]) -> (int32 [@unboxed]) = "f" "noalloc"
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The native code version of the primitive is mandatory when attributes [@untagged] or [@unboxed] are present
-Characters 63-122:
+Line 4, characters 2-61:
     external a : float -> float = "a" "noalloc" "a_nat" "float"
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 3: deprecated: [@@unboxed] + [@@noalloc] should be used instead of "float"
-Characters 125-176:
+Line 5, characters 2-53:
     external b : float -> float = "b" "noalloc" "b_nat"
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 3: deprecated: [@@noalloc] should be used instead of "noalloc"
-Characters 179-228:
+Line 6, characters 2-51:
     external c : float -> float = "c" "c_nat" "float"
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 3: deprecated: [@@unboxed] + [@@noalloc] should be used instead of "float"
-Characters 231-274:
+Line 7, characters 2-45:
     external d : float -> float = "d" "noalloc"
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 3: deprecated: [@@noalloc] should be used instead of "noalloc"
-Characters 441-505:
+Line 15, characters 6-70:
   ......struct
     external f : int -> (int [@untagged]) = "f" "f_nat"
   end..
@@ -43,7 +43,7 @@ Error: Signature mismatch:
          external f : int -> (int [@untagged]) = "f" "f_nat"
        is not included in
          external f : int -> int = "f" "f_nat"
-Characters 65-129:
+Line 4, characters 6-70:
   ......struct
     external f : (int [@untagged]) -> int = "f" "f_nat"
   end..
@@ -56,7 +56,7 @@ Error: Signature mismatch:
          external f : (int [@untagged]) -> int = "f" "f_nat"
        is not included in
          external f : int -> int = "a" "a_nat"
-Characters 69-136:
+Line 4, characters 6-73:
   ......struct
     external f : float -> (float [@unboxed]) = "f" "f_nat"
   end..
@@ -69,7 +69,7 @@ Error: Signature mismatch:
          external f : float -> (float [@unboxed]) = "f" "f_nat"
        is not included in
          external f : float -> float = "f" "f_nat"
-Characters 69-136:
+Line 4, characters 6-73:
   ......struct
     external f : (float [@unboxed]) -> float = "f" "f_nat"
   end..
@@ -82,7 +82,7 @@ Error: Signature mismatch:
          external f : (float [@unboxed]) -> float = "f" "f_nat"
        is not included in
          external f : float -> float = "a" "a_nat"
-Characters 149-199:
+Line 6, characters 6-56:
   ......struct
     external f : int -> int = "f" "f_nat"
   end..
@@ -95,7 +95,7 @@ Error: Signature mismatch:
          external f : int -> int = "f" "f_nat"
        is not included in
          external f : int -> (int [@untagged]) = "f" "f_nat"
-Characters 79-129:
+Line 4, characters 6-56:
   ......struct
     external f : int -> int = "a" "a_nat"
   end..
@@ -108,7 +108,7 @@ Error: Signature mismatch:
          external f : int -> int = "a" "a_nat"
        is not included in
          external f : (int [@untagged]) -> int = "f" "f_nat"
-Characters 82-136:
+Line 4, characters 6-60:
   ......struct
     external f : float -> float = "f" "f_nat"
   end..
@@ -121,7 +121,7 @@ Error: Signature mismatch:
          external f : float -> float = "f" "f_nat"
        is not included in
          external f : float -> (float [@unboxed]) = "f" "f_nat"
-Characters 82-136:
+Line 4, characters 6-60:
   ......struct
     external f : float -> float = "a" "a_nat"
   end..
@@ -134,56 +134,56 @@ Error: Signature mismatch:
          external f : float -> float = "a" "a_nat"
        is not included in
          external f : (float [@unboxed]) -> float = "f" "f_nat"
-Characters 67-72:
+Line 4, characters 14-19:
   external g : (float [@untagged]) -> float = "g" "g_nat";;
                 ^^^^^
 Error: Don't know how to untag this type. Only int can be untagged
-Characters 14-17:
+Line 1, characters 14-17:
   external h : (int [@unboxed]) -> float = "h" "h_nat";;
                 ^^^
 Error: Don't know how to unbox this type. Only float, int32, int64 and nativeint can be unboxed
-Characters 52-64:
+Line 3, characters 13-25:
   external i : int -> float [@unboxed] = "i" "i_nat";;
                ^^^^^^^^^^^^
 Error: Don't know how to unbox this type. Only float, int32, int64 and nativeint can be unboxed
-Characters 61-66:
+Line 3, characters 21-26:
   external j : int -> (float [@unboxed]) * float = "j" "j_nat";;
                        ^^^^^
 Error: The attribute '@unboxed' should be attached to a direct argument or result of the primitive, it should not occur deeply into its type
 external k : int -> float = "k" "k_nat"
-Characters 58-119:
+Line 4, characters 0-61:
   external l : float -> float = "l" "l_nat" "float" [@@unboxed];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Cannot use "float" in conjunction with [@unboxed]/[@untagged]
-Characters 0-62:
+Line 1, characters 0-62:
   external m : (float [@unboxed]) -> float = "m" "m_nat" "float";;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Cannot use "float" in conjunction with [@unboxed]/[@untagged]
-Characters 0-55:
+Line 1, characters 0-55:
   external n : float -> float = "n" "noalloc" [@@noalloc];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Cannot use "noalloc" in conjunction with [@@noalloc]
-Characters 70-115:
+Line 3, characters 0-45:
   external o : (float[@unboxed]) -> float = "o";;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The native code version of the primitive is mandatory when attributes [@untagged] or [@unboxed] are present
-Characters 0-45:
+Line 1, characters 0-45:
   external p : float -> (float[@unboxed]) = "p";;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The native code version of the primitive is mandatory when attributes [@untagged] or [@unboxed] are present
-Characters 0-44:
+Line 1, characters 0-44:
   external q : (int[@untagged]) -> float = "q";;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The native code version of the primitive is mandatory when attributes [@untagged] or [@unboxed] are present
-Characters 0-42:
+Line 1, characters 0-42:
   external r : int -> (int[@untagged]) = "r";;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The native code version of the primitive is mandatory when attributes [@untagged] or [@unboxed] are present
-Characters 0-42:
+Line 1, characters 0-42:
   external s : int -> int = "s" [@@untagged];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The native code version of the primitive is mandatory when attributes [@untagged] or [@unboxed] are present
-Characters 0-45:
+Line 1, characters 0-45:
   external t : float -> float = "t" [@@unboxed];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The native code version of the primitive is mandatory when attributes [@untagged] or [@unboxed] are present

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.compilers.reference
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.compilers.reference
@@ -15,14 +15,14 @@ then just above there should be *no* warning text.
 ---------------------------------------------------------------------->
 
 type expr = Val of int | Rest
-Characters 46-71:
+Line 3, characters 4-29:
     | ((Val x, _) | (_, Val x)) when x < 0 -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57: Ambiguous or-pattern variables under guard;
 variable x may match different arguments. (See manual section 9.5)
 val ambiguous_typical_example : expr * expr -> unit = <fun>
 Note that an Assert_failure is expected just below.
-Exception: Assert_failure ("//toplevel//", 30, 6).
+Exception: Assert_failure ("//toplevel//", 7, 6).
 val not_ambiguous__no_orpat : int option -> unit = <fun>
 val not_ambiguous__no_guard : [< `A | `B | `C ] -> unit = <fun>
 val not_ambiguous__no_patvar_in_guard :
@@ -31,7 +31,7 @@ val not_ambiguous__disjoint_cases : [> `B of bool | `C of bool ] -> unit =
   <fun>
 val not_ambiguous__prefix_variables :
   [> `B of bool * 'a option * 'a option ] -> unit = <fun>
-Characters 33-72:
+Line 3, characters 4-43:
     | (`B (x, _, Some y) | `B (x, Some y, _)) when y -> ignore x
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57: Ambiguous or-pattern variables under guard;
@@ -39,13 +39,13 @@ variable y may match different arguments. (See manual section 9.5)
 val ambiguous__y : [> `B of 'a * bool option * bool option ] -> unit = <fun>
 val not_ambiguous__rhs_not_protected :
   [> `B of 'a * bool option * bool option ] -> unit = <fun>
-Characters 35-74:
+Line 3, characters 4-43:
     | (`B (x, _, Some y) | `B (x, Some y, _)) when x < y -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57: Ambiguous or-pattern variables under guard;
 variable y may match different arguments. (See manual section 9.5)
 val ambiguous__x_y : [> `B of 'a * 'a option * 'a option ] -> unit = <fun>
-Characters 37-76:
+Line 3, characters 4-43:
     | (`B (x, z, Some y) | `B (x, Some y, z)) when x < y || Some x = z -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57: Ambiguous or-pattern variables under guard;
@@ -55,7 +55,7 @@ val not_ambiguous__disjoint_in_depth :
   [> `A of [> `B of bool | `C of bool ] ] -> unit = <fun>
 val not_ambiguous__prefix_variables_in_depth :
   [> `A of [> `B of bool * [> `C1 | `C2 ] ] ] -> unit = <fun>
-Characters 40-76:
+Line 3, characters 4-40:
     | `A (`B (Some x, _) | `B (_, Some x)) when x -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57: Ambiguous or-pattern variables under guard;
@@ -68,7 +68,7 @@ val not_ambiguous__several_orpats :
        [> `C of 'a * 'd option * 'e option ] *
        [> `D1 of 'f * 'a * 'g option * 'h | `D2 of 'i * 'a * 'j * 'k option ] ] ->
   unit = <fun>
-Characters 43-140:
+Line 3, characters 4-101:
   ....`A ((`B (Some x, _) | `B (_, Some x)),
           (`C (Some y, Some _, _) | `C (Some y, _, Some _))).................
 Warning 57: Ambiguous or-pattern variables under guard;
@@ -78,7 +78,7 @@ val ambiguous__first_orpat :
        [> `B of 'a option * 'a option ] *
        [> `C of 'a option * 'b option * 'c option ] ] ->
   unit = <fun>
-Characters 44-141:
+Line 3, characters 4-101:
   ....`A ((`B (Some x, Some _, _) | `B (Some x, _, Some _)),
           (`C (Some y, _) | `C (_, Some y))).................
 Warning 57: Ambiguous or-pattern variables under guard;
@@ -101,14 +101,14 @@ val not_ambiguous__lazy : ('a list * 'b list) * bool lazy_t -> unit = <fun>
 type t = A of int * int option * int option | B
 val not_ambiguous__constructor : t -> unit = <fun>
 type amoi = Z of int | Y of int * int | X of amoi * amoi
-Characters 40-73:
+Line 3, characters 2-35:
   ..X (Z x,Y (y,0))
   | X (Z y,Y (x,_))
 Warning 57: Ambiguous or-pattern variables under guard;
 variables x,y may match different arguments. (See manual section 9.5)
 val ambiguous__amoi : amoi -> int = <fun>
 module type S = sig val b : bool end
-Characters 56-101:
+Line 3, characters 4-49:
   ....(module M:S),_,(1,_)
     | _,(module M:S),(_,1)...................
 Warning 57: Ambiguous or-pattern variables under guard;
@@ -118,18 +118,18 @@ val ambiguous__module_variable :
 val not_ambiguous__module_variable :
   (module S) * (module S) * (int * int) -> bool -> int = <fun>
 type t2 = A of int * int | B of int * int
-Characters 55-56:
+Line 3, characters 4-5:
     | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
       ^
 Warning 41: A belongs to several types: t2 t
 The first one was selected. Please disambiguate if this is wrong.
-Characters 42-138:
+Line 2, characters 41-137:
   .........................................function
     | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
     | _ -> 2
 Warning 4: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type t2.
-Characters 55-107:
+Line 3, characters 4-56:
     | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57: Ambiguous or-pattern variables under guard;
@@ -141,7 +141,7 @@ val not_ambiguous__as_disjoint_on_second_column_split :
 no warning below
 val solved_ambiguity_typical_example : expr * expr -> unit = <fun>
 yet a warning below
-Characters 164-189:
+Line 5, characters 4-29:
     | ((Val y, _) | (_, Val y)) when y < 0 -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57: Ambiguous or-pattern variables under guard;
@@ -150,7 +150,7 @@ val guarded_ambiguity : expr * expr -> unit = <fun>
 type a = A1 | A2
 type 'a alg = Val of 'a | Binop of 'a alg * 'a alg
 warning below
-Characters 100-125:
+Line 4, characters 4-29:
     | ((Val x, _) | (_, Val x)) when pred x -> ()
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 57: Ambiguous or-pattern variables under guard;

--- a/testsuite/tests/typing-warnings/application.compilers.reference
+++ b/testsuite/tests/typing-warnings/application.compilers.reference
@@ -1,11 +1,11 @@
 - : unit = ()
-Characters 16-19:
+Line 2, characters 15-18:
   let _ = ignore (+);;
                  ^^^
 Warning 5: this function application is partial,
 maybe some arguments are missing.
 - : unit = ()
-Characters 19-20:
+Line 1, characters 19-20:
   let _ = raise Exit 3;;
                      ^
 Warning 20: this argument will not be used by the function.

--- a/testsuite/tests/typing-warnings/coercions.compilers.principal.reference
+++ b/testsuite/tests/typing-warnings/coercions.compilers.principal.reference
@@ -1,9 +1,9 @@
-Characters 168-171:
+Line 9, characters 45-48:
   fun b -> if b then format_of_string "x" else "y";;
                                                ^^^
 Warning 18: this coercion to format6 is not principal.
 - : bool -> ('a, 'b, 'c, 'd, 'd, 'a) format6 = <fun>
-Characters 28-48:
+Line 1, characters 28-48:
   fun b -> if b then "x" else format_of_string "y";;
                               ^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type
@@ -17,7 +17,7 @@ module PR7135 :
     type t = M.t
     val lift2 : (int -> int -> int) -> t -> t -> int
   end
-Characters 133-143:
+Line 6, characters 49-59:
     let f x = let y = if true then x else (x:t) in (y :> int)
                                                    ^^^^^^^^^^
 Warning 18: this ground coercion is not principal.

--- a/testsuite/tests/typing-warnings/coercions.compilers.reference
+++ b/testsuite/tests/typing-warnings/coercions.compilers.reference
@@ -1,5 +1,5 @@
 - : bool -> ('a, 'b, 'c, 'd, 'd, 'a) format6 = <fun>
-Characters 28-48:
+Line 1, characters 28-48:
   fun b -> if b then "x" else format_of_string "y";;
                               ^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type

--- a/testsuite/tests/typing-warnings/exhaustiveness.compilers.reference
+++ b/testsuite/tests/typing-warnings/exhaustiveness.compilers.reference
@@ -1,4 +1,4 @@
-Characters 121-173:
+Line 7, characters 8-60:
   ........function
       None, None -> 1
     | Some _, Some _ -> 2..
@@ -9,13 +9,13 @@ val f : 'a option * 'b option -> int = <fun>
 type _ t = A : int t | B : bool t | C : char t | D : float t
 type (_, _, _, _) u = U : (int, int, int, int) u
 type v = E | F | G
-Characters 124-205:
+Line 5, characters 1-82:
   .function A, A, A, A, A, A, A, _, U, U -> 1
      | _, _, _, _, _, _, _, G, _, _ -> 1
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (A, A, A, A, A, A, B, (E|F), _, _)
-Characters 172-200:
+Line 6, characters 5-33:
      | _, _, _, _, _, _, _, G, _, _ -> 1
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 56: this match case is unreachable.
@@ -23,31 +23,31 @@ Consider replacing it with a refutation case '<pat> -> .'
 val f :
   'a t * 'b t * 'c t * 'd t * 'e t * 'f t * 'g t * v * ('a, 'b, 'c, 'd) u *
   ('e, 'f, 'g, 'g) u -> int = <fun>
-Characters 40-68:
+Line 3, characters 20-48:
   let f (x : int t) = match x with A -> 1 | _ -> 2;; (* warn *)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 4: this pattern-matching is fragile.
 It will remain exhaustive when constructors are added to type t.
-Characters 62-63:
+Line 3, characters 42-43:
   let f (x : int t) = match x with A -> 1 | _ -> 2;; (* warn *)
                                             ^
 Warning 56: this match case is unreachable.
 Consider replacing it with a refutation case '<pat> -> .'
 val f : int t -> int = <fun>
-Characters 53-54:
+Line 1, characters 53-54:
   let f (x : unit t option) = match x with None -> 1 | _ -> 2 ;; (* warn? *)
                                                        ^
 Warning 56: this match case is unreachable.
 Consider replacing it with a refutation case '<pat> -> .'
 val f : unit t option -> int = <fun>
-Characters 53-59:
+Line 1, characters 53-59:
   let f (x : unit t option) = match x with None -> 1 | Some _ -> 2 ;; (* warn *)
                                                        ^^^^^^
 Warning 56: this match case is unreachable.
 Consider replacing it with a refutation case '<pat> -> .'
 val f : unit t option -> int = <fun>
 val f : int t option -> int = <fun>
-Characters 27-49:
+Line 1, characters 27-49:
   let f (x : int t option) = match x with None -> 1;; (* warn *)
                              ^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -56,7 +56,7 @@ Some A
 val f : int t option -> int = <fun>
 type 'a box = Box of 'a
 type 'a pair = { left : 'a; right : 'a; }
-Characters 50-69:
+Line 2, characters 49-68:
   let f : (int t box pair * bool) option -> unit = function None -> ();;
                                                    ^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -64,14 +64,14 @@ Here is an example of a case that is not matched:
 Some ({left=Box A; right=Box A}, _)
 val f : (int t box pair * bool) option -> unit = <fun>
 val f : (string t box pair * bool) option -> unit = <fun>
-Characters 8-39:
+Line 1, characters 8-39:
   let f = function {left=Box 0; _ } -> ();;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 {left=Box 1; _ }
 val f : int box pair -> unit = <fun>
-Characters 8-47:
+Line 1, characters 8-47:
   let f = function {left=Box 0;right=Box 1} -> ();;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -84,7 +84,7 @@ val g : int t -> int = <fun>
 val h : 'a t -> 'a t -> bool = <fun>
 type (_, _) cmp = Eq : ('a, 'a) cmp | Any : ('a, 'b) cmp
 module A : sig type a type b val eq : (a, b) cmp end
-Characters 33-51:
+Line 1, characters 33-51:
   let f : (A.a, A.b) cmp -> unit = function Any -> ()
                                    ^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -99,7 +99,7 @@ type (_, _, _) plus =
   | PlusS : ('a, 'b, 'c) plus -> ('a succ, 'b, 'c succ) plus
 val trivial : (zero succ, zero, zero) plus option -> bool = <fun>
 val easy : (zero, zero succ, zero) plus option -> bool = <fun>
-Characters 71-93:
+Line 2, characters 2-24:
     function None -> false
     ^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -110,36 +110,36 @@ val harder : (zero succ, zero succ, zero succ) plus option -> bool = <fun>
 val inv_zero : ('a, 'b, 'c) plus -> ('c, 'd, zero) plus -> bool = <fun>
 type _ t = Int : int t
 val f : bool t -> 'a = <fun>
-Characters 54-55:
+Line 5, characters 27-28:
   let f () = match None with _ -> .;; (* error *)
                              ^
 Error: This match case could not be refuted.
        Here is an example of a value that would reach it: _
-Characters 47-48:
+Line 1, characters 47-48:
   let g () = match None with _ -> () | exception _ -> .;; (* error *)
                                                  ^
 Error: This match case could not be refuted.
        Here is an example of a value that would reach it: _
-Characters 27-28:
+Line 1, characters 27-28:
   let h () = match None with _ -> .  | exception _ -> .;; (* error *)
                              ^
 Error: This match case could not be refuted.
        Here is an example of a value that would reach it: _
 val f : 'a option -> unit = <fun>
-Characters 47-77:
+Line 4, characters 12-42:
   let f x y = match 1 with 1 when x = y -> 1;;
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 All clauses in this pattern-matching are guarded.
 val f : 'a -> 'a -> int = <fun>
-Characters 62-91:
+Line 3, characters 8-37:
   let f = function {contents=_}, 0 -> 0;;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 (_, 1)
 val f : 'a ref * int -> int = <fun>
-Characters 68-148:
+Line 3, characters 8-88:
   ........function
     | None -> ()
     | Some x when x > 0 -> ()

--- a/testsuite/tests/typing-warnings/pr5892.compilers.reference
+++ b/testsuite/tests/typing-warnings/pr5892.compilers.reference
@@ -1,7 +1,7 @@
 type _ choice =
     Left : CamlinternalOO.label choice
   | Right : CamlinternalOO.tag choice
-Characters 31-52:
+Line 1, characters 31-52:
   let f : label choice -> bool = function Left -> true;; (* warn *)
                                  ^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.

--- a/testsuite/tests/typing-warnings/pr6587.compilers.reference
+++ b/testsuite/tests/typing-warnings/pr6587.compilers.reference
@@ -1,6 +1,6 @@
 module A : sig val f : fpclass -> fpclass end
 type fpclass = A
-Characters 49-85:
+Line 3, characters 2-38:
   ..struct
       let f A = FP_normal
     end

--- a/testsuite/tests/typing-warnings/pr6872.compilers.principal.reference
+++ b/testsuite/tests/typing-warnings/pr6872.compilers.principal.reference
@@ -1,35 +1,35 @@
 - : unit = ()
 exception A
 type a = A
-Characters 1-2:
+Line 2, characters 0-1:
   A;;
   ^
 Warning 41: A belongs to several types: a exn
 The first one was selected. Please disambiguate if this is wrong.
 - : a = A
-Characters 6-7:
+Line 1, characters 6-7:
   raise A;;
         ^
 Warning 42: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 Exception: A.
 - : a -> unit = <fun>
-Characters 26-27:
+Line 1, characters 26-27:
   function Not_found -> 1 | A -> 2 | _ -> 3;;
                             ^
 Warning 41: A belongs to several types: a exn
 The first one was selected. Please disambiguate if this is wrong.
-Characters 26-27:
+Line 1, characters 26-27:
   function Not_found -> 1 | A -> 2 | _ -> 3;;
                             ^
 Error: This pattern matches values of type a
        but a pattern was expected which matches values of type exn
-Characters 10-11:
+Line 1, characters 10-11:
   try raise A with A -> 2;;
             ^
 Warning 42: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 17-18:
+Line 1, characters 17-18:
   try raise A with A -> 2;;
                    ^
 Warning 42: this use of A relies on type-directed disambiguation,

--- a/testsuite/tests/typing-warnings/pr6872.compilers.reference
+++ b/testsuite/tests/typing-warnings/pr6872.compilers.reference
@@ -1,31 +1,31 @@
 - : unit = ()
 exception A
 type a = A
-Characters 1-2:
+Line 2, characters 0-1:
   A;;
   ^
 Warning 41: A belongs to several types: a exn
 The first one was selected. Please disambiguate if this is wrong.
 - : a = A
-Characters 6-7:
+Line 1, characters 6-7:
   raise A;;
         ^
 Warning 42: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 Exception: A.
 - : a -> unit = <fun>
-Characters 26-27:
+Line 1, characters 26-27:
   function Not_found -> 1 | A -> 2 | _ -> 3;;
                             ^
 Warning 42: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 - : exn -> int = <fun>
-Characters 10-11:
+Line 1, characters 10-11:
   try raise A with A -> 2;;
             ^
 Warning 42: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 17-18:
+Line 1, characters 17-18:
   try raise A with A -> 2;;
                    ^
 Warning 42: this use of A relies on type-directed disambiguation,

--- a/testsuite/tests/typing-warnings/pr7085.compilers.reference
+++ b/testsuite/tests/typing-warnings/pr7085.compilers.reference
@@ -1,4 +1,4 @@
-Characters 355-385:
+Line 22, characters 5-35:
        match M.is_t () with None -> 0
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8: this pattern-matching is not exhaustive.
@@ -11,7 +11,7 @@ module type T =
     val is_t : unit -> unit is_t option
   end
 module Make : functor (M : T) -> sig val f : unit -> int end
-Characters 89-90:
+Line 4, characters 30-31:
     let g : t -> int = function _ -> .
                                 ^
 Error: This match case could not be refuted.

--- a/testsuite/tests/typing-warnings/pr7115.compilers.reference
+++ b/testsuite/tests/typing-warnings/pr7115.compilers.reference
@@ -1,19 +1,19 @@
 type t = A : t
-Characters 40-41:
+Line 3, characters 10-11:
     let _f ~x (* x unused argument *) = function
             ^
 Warning 27: unused variable x.
 module X1 : sig  end
-Characters 36-37:
+Line 3, characters 6-7:
     let x = 42 (* unused value *)
         ^
 Warning 32: unused value x.
 module X2 : sig  end
-Characters 54-55:
+Line 3, characters 24-25:
     module O = struct let x = 42 (* unused *) end
                           ^
 Warning 32: unused value x.
-Characters 80-86:
+Line 4, characters 2-8:
     open O (* unused open *)
     ^^^^^^
 Warning 33: unused open O.

--- a/testsuite/tests/typing-warnings/pr7261.compilers.reference
+++ b/testsuite/tests/typing-warnings/pr7261.compilers.reference
@@ -1,8 +1,8 @@
-Characters 93-95:
+Line 7, characters 19-21:
       Foo: [> `Bla ] as 'b ) * 'b -> foo;;
                      ^^
 Error: Syntax error
-Characters 46-60:
+Line 2, characters 35-49:
       Foo: 'b * 'b -> foo constraint 'b = [> `Bla ];;
                                      ^^^^^^^^^^^^^^
 Warning 62: Type constraints do not apply to GADT cases of variant types.

--- a/testsuite/tests/typing-warnings/pr7297.compilers.reference
+++ b/testsuite/tests/typing-warnings/pr7297.compilers.reference
@@ -1,5 +1,5 @@
 - : unit = ()
-Characters 10-20:
+Line 2, characters 9-19:
   let () = raise Exit; () ;; (* warn *)
            ^^^^^^^^^^
 Warning 21: this statement never returns (or has an unsound type.)

--- a/testsuite/tests/typing-warnings/pr7553.compilers.reference
+++ b/testsuite/tests/typing-warnings/pr7553.compilers.reference
@@ -1,17 +1,17 @@
 module A : sig type foo end
 module rec B : sig type bar = Bar of A.foo end
-Characters 22-28:
+Line 3, characters 2-8:
     open A
     ^^^^^^
 Warning 33: unused open A.
 module rec C : sig  end
-Characters 110-114:
+Line 6, characters 10-14:
         let None = None
             ^^^^
 Warning 8: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 Some _
-Characters 93-99:
+Line 5, characters 6-12:
         open A
         ^^^^^^
 Warning 33: unused open A.

--- a/testsuite/tests/typing-warnings/records.compilers.principal.reference
+++ b/testsuite/tests/typing-warnings/records.compilers.principal.reference
@@ -1,80 +1,80 @@
 module M1 :
   sig type t = { x : int; y : int; } type u = { x : bool; y : bool; } end
-Characters 49-50:
+Line 4, characters 19-20:
     let f1 (r:t) = r.x (* ok *)
                      ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 89-90:
+Line 5, characters 29-30:
     let f2 r = ignore (r:t); r.x (* non principal *)
                                ^
 Warning 18: this type-based field disambiguation is not principal.
-Characters 89-90:
+Line 5, characters 29-30:
     let f2 r = ignore (r:t); r.x (* non principal *)
                                ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 148-149:
+Line 8, characters 18-19:
       match r with {x; y} -> y + y (* ok *)
                     ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 151-152:
+Line 8, characters 21-22:
       match r with {x; y} -> y + y (* ok *)
                        ^
 Warning 42: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 148-149:
+Line 8, characters 18-19:
       match r with {x; y} -> y + y (* ok *)
                     ^
 Warning 27: unused variable x.
 module OK :
   sig val f1 : M1.t -> int val f2 : M1.t -> int val f3 : M1.t -> int end
-Characters 55-61:
+Line 4, characters 25-31:
     let f r = match r with {x; y} -> y + y
                            ^^^^^^
 Warning 41: these field labels belong to several types: M1.u M1.t
 The first one was selected. Please disambiguate if this is wrong.
-Characters 65-66:
+Line 4, characters 35-36:
     let f r = match r with {x; y} -> y + y
                                      ^
 Error: This expression has type bool but an expression was expected of type
          int
-Characters 85-91:
+Line 7, characters 7-13:
          {x; y} -> y + y
          ^^^^^^
 Warning 41: these field labels belong to several types: M1.u M1.t
 The first one was selected. Please disambiguate if this is wrong.
-Characters 85-91:
+Line 7, characters 7-13:
          {x; y} -> y + y
          ^^^^^^
 Error: This pattern matches values of type M1.u
        but a pattern was expected which matches values of type M1.t
 module M : sig type t = { x : int; } type u = { x : bool; } end
-Characters 18-21:
+Line 1, characters 18-21:
   let f (r:M.t) = r.M.x;; (* ok *)
                     ^^^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 val f : M.t -> int = <fun>
-Characters 18-19:
+Line 1, characters 18-19:
   let f (r:M.t) = r.x;; (* warning *)
                     ^
 Warning 40: x was selected from type M.t.
 It is not visible in the current scope, and will not 
 be selected if the type becomes unknown.
-Characters 18-19:
+Line 1, characters 18-19:
   let f (r:M.t) = r.x;; (* warning *)
                     ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 val f : M.t -> int = <fun>
-Characters 8-9:
+Line 1, characters 8-9:
   let f ({x}:M.t) = x;; (* warning *)
           ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 7-10:
+Line 1, characters 7-10:
   let f ({x}:M.t) = x;; (* warning *)
          ^^^
 Warning 40: this record of type M.t contains fields that are 
@@ -83,12 +83,12 @@ They will not be selected if the type becomes unknown.
 val f : M.t -> int = <fun>
 module M : sig type t = { x : int; y : int; } end
 module N : sig type u = { x : bool; y : bool; } end
-Characters 57-58:
+Line 4, characters 20-21:
     let f (r:M.t) = r.x
                       ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 30-36:
+Line 3, characters 2-8:
     open N
     ^^^^^^
 Warning 33: unused open N.
@@ -105,28 +105,28 @@ module M :
     type u = { x : bool; y : int; z : char; }
     type t = { x : int; y : bool; }
   end
-Characters 37-38:
+Line 3, characters 9-10:
     let f {x;z} = x,z
            ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 36-41:
+Line 3, characters 8-13:
     let f {x;z} = x,z
           ^^^^^
 Warning 9: the following labels are not bound in this record pattern:
 y
 Either bind these labels explicitly or add '; _' to the pattern.
 module OK : sig val f : M.u -> bool * char end
-Characters 38-52:
+Line 3, characters 10-24:
     let r = {x=true;z='z'}
             ^^^^^^^^^^^^^^
 Error: Some record fields are undefined: y
-Characters 90-91:
+Line 5, characters 11-12:
     let r = {x=3; y=true}
              ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 95-96:
+Line 5, characters 16-17:
     let r = {x=3; y=true}
                   ^
 Warning 42: this use of y relies on type-directed disambiguation,
@@ -137,14 +137,14 @@ module OK :
     type t = { x : bool; y : int; z : char; }
     val r : u
   end
-Characters 111-112:
+Line 7, characters 22-23:
     let b : bar = {x=3; y=4}
                         ^
 Error: This record expression is expected to have type bar
        The field y does not belong to type bar
 module M : sig type foo = { x : int; y : int; } end
 module N : sig type bar = { x : int; y : int; } end
-Characters 19-22:
+Line 1, characters 19-22:
   let r = { M.x = 3; N.y = 4; };; (* error: different definitions *)
                      ^^^
 Error: The record field N.y belongs to the type N.bar
@@ -159,17 +159,17 @@ module NM :
     type bar = N.bar = { x : int; y : int; }
     type foo = M.foo = { x : int; y : int; }
   end
-Characters 8-28:
+Line 1, characters 8-28:
   let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
           ^^^^^^^^^^^^^^^^^^^^
 Warning 41: x belongs to several types: MN.bar MN.foo
 The first one was selected. Please disambiguate if this is wrong.
-Characters 8-28:
+Line 1, characters 8-28:
   let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
           ^^^^^^^^^^^^^^^^^^^^
 Warning 41: y belongs to several types: NM.foo NM.bar
 The first one was selected. Please disambiguate if this is wrong.
-Characters 19-23:
+Line 1, characters 19-23:
   let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
                      ^^^^
 Error: The record field NM.y belongs to the type NM.foo = M.foo
@@ -179,12 +179,12 @@ module M :
     type foo = { x : int; y : int; }
     type bar = { x : int; y : int; z : int; }
   end
-Characters 65-66:
+Line 3, characters 37-38:
     let f r = ignore (r: foo); {r with x = 2; z = 3}
                                        ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 72-73:
+Line 3, characters 44-45:
     let f r = ignore (r: foo); {r with x = 2; z = 3}
                                               ^
 Error: This record expression is expected to have type M.foo
@@ -195,39 +195,39 @@ module M :
     type bar = M.bar = { x : int; y : int; z : int; }
     type other = { a : int; b : int; }
   end
-Characters 66-67:
+Line 3, characters 38-39:
     let f r = ignore (r: foo); { r with x = 3; a = 4 }
                                         ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 73-74:
+Line 3, characters 45-46:
     let f r = ignore (r: foo); { r with x = 3; a = 4 }
                                                ^
 Error: This record expression is expected to have type M.foo
        The field a does not belong to type M.foo
-Characters 39-40:
+Line 3, characters 11-12:
     let r = {x=1; y=2}
              ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 44-45:
+Line 3, characters 16-17:
     let r = {x=1; y=2}
                   ^
 Warning 42: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 67-68:
+Line 4, characters 18-19:
     let r: other = {x=1; y=2}
                     ^
 Error: This record expression is expected to have type M.other
        The field x does not belong to type M.other
 module A : sig type t = { x : int; } end
 module B : sig type t = { x : int; } end
-Characters 20-23:
+Line 1, characters 20-23:
   let f (r : B.t) = r.A.x;; (* fail *)
                       ^^^
 Error: The field A.x belongs to the record type A.t
        but a field was expected belonging to the record type B.t
-Characters 88-91:
+Line 6, characters 19-22:
     let a : t = {x=1;yyz=2}
                      ^^^
 Error: This record expression is expected to have type t
@@ -236,34 +236,34 @@ Hint: Did you mean yyy?
 type t = A
 type s = A
 class f : t -> object  end
-Characters 12-13:
+Line 1, characters 12-13:
   class g = f A;; (* ok *)
               ^
 Warning 42: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 class g : f
 class f : 'a -> 'a -> object  end
-Characters 13-14:
+Line 1, characters 13-14:
   class g = f (A : t) A;; (* warn with -principal *)
                ^
 Warning 42: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 20-21:
+Line 1, characters 20-21:
   class g = f (A : t) A;; (* warn with -principal *)
                       ^
 Warning 18: this type-based constructor disambiguation is not principal.
-Characters 20-21:
+Line 1, characters 20-21:
   class g = f (A : t) A;; (* warn with -principal *)
                       ^
 Warning 42: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 class g : f
-Characters 199-200:
+Line 11, characters 15-16:
     let y : t = {x = 0}
                  ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 114-120:
+Line 10, characters 2-8:
     open M  (* this open is unused, it isn't reported as shadowing 'x' *)
     ^^^^^^
 Warning 33: unused open M.
@@ -273,11 +273,11 @@ module Shadow1 :
     module M : sig type s = { x : string; } end
     val y : t
   end
-Characters 97-103:
+Line 6, characters 2-8:
     open M  (* this open shadows label 'x' *)
     ^^^^^^
 Warning 45: this open statement shadows the label x (which is later used)
-Characters 149-157:
+Line 7, characters 10-18:
     let y = {x = ""}
             ^^^^^^^^
 Warning 41: these field labels belong to several types: M.s t
@@ -288,7 +288,7 @@ module Shadow2 :
     module M : sig type s = { x : string; } end
     val y : M.s
   end
-Characters 167-170:
+Line 8, characters 37-40:
     let f (u : u) = match u with `Key {loc} -> loc
                                        ^^^
 Warning 42: this use of loc relies on type-directed disambiguation,
@@ -300,18 +300,18 @@ module P6235 :
     type u = [ `Key of t ]
     val f : u -> string
   end
-Characters 219-224:
+Line 10, characters 10-15:
       |`Key {loc} -> loc
             ^^^^^
 Warning 41: these field labels belong to several types: v t
 The first one was selected. Please disambiguate if this is wrong.
-Characters 219-224:
+Line 10, characters 10-15:
       |`Key {loc} -> loc
             ^^^^^
 Warning 9: the following labels are not bound in this record pattern:
 x
 Either bind these labels explicitly or add '; _' to the pattern.
-Characters 214-224:
+Line 10, characters 5-15:
       |`Key {loc} -> loc
        ^^^^^^^^^^
 Error: This pattern matches values of type [? `Key of v ]

--- a/testsuite/tests/typing-warnings/records.compilers.reference
+++ b/testsuite/tests/typing-warnings/records.compilers.reference
@@ -1,81 +1,81 @@
 module M1 :
   sig type t = { x : int; y : int; } type u = { x : bool; y : bool; } end
-Characters 49-50:
+Line 4, characters 19-20:
     let f1 (r:t) = r.x (* ok *)
                      ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 89-90:
+Line 5, characters 29-30:
     let f2 r = ignore (r:t); r.x (* non principal *)
                                ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 148-149:
+Line 8, characters 18-19:
       match r with {x; y} -> y + y (* ok *)
                     ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 151-152:
+Line 8, characters 21-22:
       match r with {x; y} -> y + y (* ok *)
                        ^
 Warning 42: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 148-149:
+Line 8, characters 18-19:
       match r with {x; y} -> y + y (* ok *)
                     ^
 Warning 27: unused variable x.
 module OK :
   sig val f1 : M1.t -> int val f2 : M1.t -> int val f3 : M1.t -> int end
-Characters 55-61:
+Line 4, characters 25-31:
     let f r = match r with {x; y} -> y + y
                            ^^^^^^
 Warning 41: these field labels belong to several types: M1.u M1.t
 The first one was selected. Please disambiguate if this is wrong.
-Characters 65-66:
+Line 4, characters 35-36:
     let f r = match r with {x; y} -> y + y
                                      ^
 Error: This expression has type bool but an expression was expected of type
          int
-Characters 86-87:
+Line 7, characters 8-9:
          {x; y} -> y + y
           ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 89-90:
+Line 7, characters 11-12:
          {x; y} -> y + y
              ^
 Warning 42: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 86-87:
+Line 7, characters 8-9:
          {x; y} -> y + y
           ^
 Warning 27: unused variable x.
 module F2 : sig val f : M1.t -> int end
 module M : sig type t = { x : int; } type u = { x : bool; } end
-Characters 18-21:
+Line 1, characters 18-21:
   let f (r:M.t) = r.M.x;; (* ok *)
                     ^^^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 val f : M.t -> int = <fun>
-Characters 18-19:
+Line 1, characters 18-19:
   let f (r:M.t) = r.x;; (* warning *)
                     ^
 Warning 40: x was selected from type M.t.
 It is not visible in the current scope, and will not 
 be selected if the type becomes unknown.
-Characters 18-19:
+Line 1, characters 18-19:
   let f (r:M.t) = r.x;; (* warning *)
                     ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 val f : M.t -> int = <fun>
-Characters 8-9:
+Line 1, characters 8-9:
   let f ({x}:M.t) = x;; (* warning *)
           ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 7-10:
+Line 1, characters 7-10:
   let f ({x}:M.t) = x;; (* warning *)
          ^^^
 Warning 40: this record of type M.t contains fields that are 
@@ -84,12 +84,12 @@ They will not be selected if the type becomes unknown.
 val f : M.t -> int = <fun>
 module M : sig type t = { x : int; y : int; } end
 module N : sig type u = { x : bool; y : bool; } end
-Characters 57-58:
+Line 4, characters 20-21:
     let f (r:M.t) = r.x
                       ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 30-36:
+Line 3, characters 2-8:
     open N
     ^^^^^^
 Warning 33: unused open N.
@@ -106,28 +106,28 @@ module M :
     type u = { x : bool; y : int; z : char; }
     type t = { x : int; y : bool; }
   end
-Characters 37-38:
+Line 3, characters 9-10:
     let f {x;z} = x,z
            ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 36-41:
+Line 3, characters 8-13:
     let f {x;z} = x,z
           ^^^^^
 Warning 9: the following labels are not bound in this record pattern:
 y
 Either bind these labels explicitly or add '; _' to the pattern.
 module OK : sig val f : M.u -> bool * char end
-Characters 38-52:
+Line 3, characters 10-24:
     let r = {x=true;z='z'}
             ^^^^^^^^^^^^^^
 Error: Some record fields are undefined: y
-Characters 90-91:
+Line 5, characters 11-12:
     let r = {x=3; y=true}
              ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 95-96:
+Line 5, characters 16-17:
     let r = {x=3; y=true}
                   ^
 Warning 42: this use of y relies on type-directed disambiguation,
@@ -138,14 +138,14 @@ module OK :
     type t = { x : bool; y : int; z : char; }
     val r : u
   end
-Characters 111-112:
+Line 7, characters 22-23:
     let b : bar = {x=3; y=4}
                         ^
 Error: This record expression is expected to have type bar
        The field y does not belong to type bar
 module M : sig type foo = { x : int; y : int; } end
 module N : sig type bar = { x : int; y : int; } end
-Characters 19-22:
+Line 1, characters 19-22:
   let r = { M.x = 3; N.y = 4; };; (* error: different definitions *)
                      ^^^
 Error: The record field N.y belongs to the type N.bar
@@ -160,17 +160,17 @@ module NM :
     type bar = N.bar = { x : int; y : int; }
     type foo = M.foo = { x : int; y : int; }
   end
-Characters 8-28:
+Line 1, characters 8-28:
   let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
           ^^^^^^^^^^^^^^^^^^^^
 Warning 41: x belongs to several types: MN.bar MN.foo
 The first one was selected. Please disambiguate if this is wrong.
-Characters 8-28:
+Line 1, characters 8-28:
   let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
           ^^^^^^^^^^^^^^^^^^^^
 Warning 41: y belongs to several types: NM.foo NM.bar
 The first one was selected. Please disambiguate if this is wrong.
-Characters 19-23:
+Line 1, characters 19-23:
   let r = {MN.x = 3; NM.y = 4};; (* error: type would change with order *)
                      ^^^^
 Error: The record field NM.y belongs to the type NM.foo = M.foo
@@ -180,12 +180,12 @@ module M :
     type foo = { x : int; y : int; }
     type bar = { x : int; y : int; z : int; }
   end
-Characters 65-66:
+Line 3, characters 37-38:
     let f r = ignore (r: foo); {r with x = 2; z = 3}
                                        ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 72-73:
+Line 3, characters 44-45:
     let f r = ignore (r: foo); {r with x = 2; z = 3}
                                               ^
 Error: This record expression is expected to have type M.foo
@@ -196,39 +196,39 @@ module M :
     type bar = M.bar = { x : int; y : int; z : int; }
     type other = { a : int; b : int; }
   end
-Characters 66-67:
+Line 3, characters 38-39:
     let f r = ignore (r: foo); { r with x = 3; a = 4 }
                                         ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 73-74:
+Line 3, characters 45-46:
     let f r = ignore (r: foo); { r with x = 3; a = 4 }
                                                ^
 Error: This record expression is expected to have type M.foo
        The field a does not belong to type M.foo
-Characters 39-40:
+Line 3, characters 11-12:
     let r = {x=1; y=2}
              ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 44-45:
+Line 3, characters 16-17:
     let r = {x=1; y=2}
                   ^
 Warning 42: this use of y relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 67-68:
+Line 4, characters 18-19:
     let r: other = {x=1; y=2}
                     ^
 Error: This record expression is expected to have type M.other
        The field x does not belong to type M.other
 module A : sig type t = { x : int; } end
 module B : sig type t = { x : int; } end
-Characters 20-23:
+Line 1, characters 20-23:
   let f (r : B.t) = r.A.x;; (* fail *)
                       ^^^
 Error: The field A.x belongs to the record type A.t
        but a field was expected belonging to the record type B.t
-Characters 88-91:
+Line 6, characters 19-22:
     let a : t = {x=1;yyz=2}
                      ^^^
 Error: This record expression is expected to have type t
@@ -237,30 +237,30 @@ Hint: Did you mean yyy?
 type t = A
 type s = A
 class f : t -> object  end
-Characters 12-13:
+Line 1, characters 12-13:
   class g = f A;; (* ok *)
               ^
 Warning 42: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 class g : f
 class f : 'a -> 'a -> object  end
-Characters 13-14:
+Line 1, characters 13-14:
   class g = f (A : t) A;; (* warn with -principal *)
                ^
 Warning 42: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 20-21:
+Line 1, characters 20-21:
   class g = f (A : t) A;; (* warn with -principal *)
                       ^
 Warning 42: this use of A relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
 class g : f
-Characters 199-200:
+Line 11, characters 15-16:
     let y : t = {x = 0}
                  ^
 Warning 42: this use of x relies on type-directed disambiguation,
 it will not compile with OCaml 4.00 or earlier.
-Characters 114-120:
+Line 10, characters 2-8:
     open M  (* this open is unused, it isn't reported as shadowing 'x' *)
     ^^^^^^
 Warning 33: unused open M.
@@ -270,11 +270,11 @@ module Shadow1 :
     module M : sig type s = { x : string; } end
     val y : t
   end
-Characters 97-103:
+Line 6, characters 2-8:
     open M  (* this open shadows label 'x' *)
     ^^^^^^
 Warning 45: this open statement shadows the label x (which is later used)
-Characters 149-157:
+Line 7, characters 10-18:
     let y = {x = ""}
             ^^^^^^^^
 Warning 41: these field labels belong to several types: M.s t
@@ -285,7 +285,7 @@ module Shadow2 :
     module M : sig type s = { x : string; } end
     val y : M.s
   end
-Characters 167-170:
+Line 8, characters 37-40:
     let f (u : u) = match u with `Key {loc} -> loc
                                        ^^^
 Warning 42: this use of loc relies on type-directed disambiguation,
@@ -297,7 +297,7 @@ module P6235 :
     type u = [ `Key of t ]
     val f : u -> string
   end
-Characters 220-223:
+Line 10, characters 11-14:
       |`Key {loc} -> loc
              ^^^
 Warning 42: this use of loc relies on type-directed disambiguation,

--- a/testsuite/tests/typing-warnings/unused_types.compilers.reference
+++ b/testsuite/tests/typing-warnings/unused_types.compilers.reference
@@ -1,52 +1,52 @@
-Characters 98-115:
+Line 8, characters 2-19:
     type unused = int
     ^^^^^^^^^^^^^^^^^
 Warning 34: unused type unused.
 module Unused : sig  end
-Characters 68-93:
+Line 5, characters 2-27:
     type nonrec unused = used
     ^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 34: unused type unused.
 module Unused_nonrec : sig  end
-Characters 40-65:
+Line 4, characters 2-27:
     type unused = A of unused
     ^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 34: unused type unused.
-Characters 40-65:
+Line 4, characters 2-27:
     type unused = A of unused
     ^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 37: unused constructor A.
 module Unused_rec : sig  end
-Characters 46-70:
+Line 4, characters 2-26:
     exception Nobody_uses_me
     ^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 38: unused exception Nobody_uses_me
 module Unused_exception : sig  end
-Characters 96-110:
+Line 6, characters 12-26:
     type t += Nobody_uses_me
               ^^^^^^^^^^^^^^
 Warning 38: unused extension constructor Nobody_uses_me
 module Unused_extension_constructor : sig type t = .. end
-Characters 91-121:
+Line 5, characters 2-32:
     exception Nobody_constructs_me
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 38: exception Nobody_constructs_me is never used to build values.
 (However, this constructor appears in patterns.)
 module Unused_exception_outside_patterns : sig val falsity : exn -> bool end
-Characters 127-147:
+Line 7, characters 12-32:
     type t += Nobody_constructs_me
               ^^^^^^^^^^^^^^^^^^^^
 Warning 38: extension constructor Nobody_constructs_me is never used to build values.
 (However, this constructor appears in patterns.)
 module Unused_extension_outside_patterns :
   sig type t = .. val falsity : t -> bool end
-Characters 88-109:
+Line 5, characters 2-23:
     exception Private_exn
     ^^^^^^^^^^^^^^^^^^^^^
 Warning 38: exception Private_exn is never used to build values.
 It is exported or rebound as a private extension.
 module Unused_private_exception : sig type exn += private Private_exn end
-Characters 124-135:
+Line 7, characters 12-23:
     type t += Private_ext
               ^^^^^^^^^^^
 Warning 38: extension constructor Private_ext is never used to build values.

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -131,19 +131,10 @@ let split_chunks phrases =
 
 module Compiler_messages = struct
   let print_loc ppf (loc : Location.t) =
-    let startchar = loc.loc_start.pos_cnum - loc.loc_start.pos_bol in
-    let endchar = loc.loc_end.pos_cnum - loc.loc_start.pos_bol in
-    Format.fprintf ppf "Line _";
-    if startchar >= 0 then
-      Format.fprintf ppf ", characters %d-%d" startchar endchar;
-    Format.fprintf ppf ":@.";
-    if startchar >= 0 then
-      begin match !Location.input_lexbuf with
-      | None -> ()
-      | Some lexbuf ->
-         Location.show_code_at_location ppf lexbuf [loc]
-      end;
-    ()
+    Format.fprintf ppf "%a:@." Location.print_loc loc;
+    match !Location.input_lexbuf with
+    | None -> ()
+    | Some lexbuf -> Location.show_code_at_location ppf lexbuf [loc]
 
   let capture ppf ~f =
     Misc.protect_refs


### PR DESCRIPTION
This PR refactors `Locations.print_loc`, which is used to print the location of an error (e.g. `File "foo.ml", line 5, characters 10-12`). Its functionality was being re-implemented in ad-hoc ways in a couple places: in `highlight_dumb` (responsible for highlighting the error in the toplevel with a "dumb" terminal), and in expect tests (`testsuite/tools/expect_test.ml`).

With this PR, a single one-size-fits-all implementation is provided and used in these two places as well. As a side effect:
- Locations printed in the toplevel now use line numbers (no more `Characters 789-866`)
- Locations printed in expect tests now display line numbers instead of `Line _`
- When `File "_none_", line 15` was printed, now only `Line 15` is printed (this could be changed but I assumed there was no point of printing the dummy file name)
- A few incorrect locations present in the testsuite are now correct (thanks to the change in `lexing.ml` I think)
- A bunch of tests needed to be updated, hence the somewhat big diff