### PR TITLE
Add a runtime flag to call abort(3) instead of raising Out_of_memory

### DIFF
--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -495,10 +495,8 @@ static inline value caml_alloc_shr_aux (mlsize_t wosize, tag_t tag,
     if (new_block == NULL) {
       if (!raise_oom)
         return 0;
-      else if (caml_in_minor_collection)
-        caml_fatal_error ("out of memory");
       else
-        caml_raise_out_of_memory ();
+        caml_fatal_error ("out of memory");
     }
     caml_fl_add_blocks ((value) new_block);
     hp = caml_fl_allocate (wosize);


### PR DESCRIPTION
Currently, if allocation fails, runtime raises `Out_of_memory` exception. This exception is almost impossible to handle properly as it can be raised from virtually any allocation point, and will be caught by any catch all clauses.
This pr adds an OCAMLRUNPARAM option to turn this exception into an abort call.

###  Alternatives: 

 - most malloc implementation support a similar flags, but this makes it harder to get a consistent ocaml behavior accross malloc implementations/huge_page support, systems...
 - If a flag will be added, i wonder if it should be more generic and extend the behavior to other hard failures exceptions like Assert_failure or Match_failure which exhibit the same problem.

### Concerns

Some library features are well contained and it might be worth keeping the out_of_memory behavior for them, for instance bigarray creation or marshal. 

### Status

 this PR is wip but i'd like to know if this approach looks right before adding tests etc.
