### PR TITLE
ctype: remove instance_def which is redundant

### DIFF
--- a/toplevel/opttopdirs.ml
+++ b/toplevel/opttopdirs.ml
@@ -122,7 +122,7 @@ let match_printer_type ppf desc typename =
   let ty_arg = Ctype.newvar() in
   Ctype.unify !toplevel_env
     (Ctype.newconstr printer_type [ty_arg])
-    (Ctype.instance_def desc.val_type);
+    (Ctype.instance desc.val_type);
   Ctype.end_def();
   Ctype.generalize ty_arg;
   ty_arg

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -294,7 +294,7 @@ let match_simple_printer_type desc printer_type =
   let ty_arg = Ctype.newvar() in
   Ctype.unify !toplevel_env
     (Ctype.newconstr printer_type [ty_arg])
-    (Ctype.instance_def desc.val_type);
+    (Ctype.instance desc.val_type);
   Ctype.end_def();
   Ctype.generalize ty_arg;
   (ty_arg, None)
@@ -312,7 +312,7 @@ let match_generic_printer_type desc path args printer_type =
       ty_args (Ctype.newconstr printer_type [ty_target]) in
   Ctype.unify !toplevel_env
     ty_expected
-    (Ctype.instance_def desc.val_type);
+    (Ctype.instance desc.val_type);
   Ctype.end_def();
   Ctype.generalize ty_expected;
   if not (Ctype.all_distinct_vars !toplevel_env args) then

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1089,11 +1089,6 @@ let instance ?partial sch =
   cleanup_types ();
   ty
 
-let instance_def sch =
-  let ty = copy sch in
-  cleanup_types ();
-  ty
-
 let generic_instance sch =
   let old = !current_level in
   current_level := generic_level;

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -117,8 +117,6 @@ val instance: ?partial:bool -> type_expr -> type_expr
         (* partial=None  -> normal
            partial=false -> newvar() for non generic subterms
            partial=true  -> newty2 ty.level Tvar for non generic subterms *)
-val instance_def: type_expr -> type_expr
-        (* use defaults *)
 val generic_instance: type_expr -> type_expr
         (* Same as instance, but new nodes at generic_level *)
 val instance_list: type_expr list -> type_expr list

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -762,7 +762,7 @@ and class_field_aux self_loc cl_num self_type meths vars
           let meth_type = mk_expected (
             Ctype.newty
               (Tarrow (Nolabel, self_type,
-                       Ctype.instance_def Predef.type_unit, Cok))
+                       Ctype.instance Predef.type_unit, Cok))
           ) in
           vars := vars_local;
           let texp = type_expect met_env expr meth_type in
@@ -1040,7 +1040,7 @@ and class_expr_aux cl_num val_env met_env scl =
       rc {cl_desc = Tcl_fun (l, pat, pv, cl, partial);
           cl_loc = scl.pcl_loc;
           cl_type = Cty_arrow
-            (l, Ctype.instance_def pat.pat_type, cl.cl_type);
+            (l, Ctype.instance pat.pat_type, cl.cl_type);
           cl_env = val_env;
           cl_attributes = scl.pcl_attributes;
          }
@@ -1253,7 +1253,7 @@ let rec approx_declaration cl =
   match cl.pcl_desc with
     Pcl_fun (l, _, _, cl) ->
       let arg =
-        if Btype.is_optional l then Ctype.instance_def var_option
+        if Btype.is_optional l then Ctype.instance var_option
         else Ctype.newvar () in
       Ctype.newty (Tarrow (l, arg, approx_declaration cl, Cok))
   | Pcl_let (_, _, cl) ->
@@ -1266,7 +1266,7 @@ let rec approx_description ct =
   match ct.pcty_desc with
     Pcty_arrow (l, _, ct) ->
       let arg =
-        if Btype.is_optional l then Ctype.instance_def var_option
+        if Btype.is_optional l then Ctype.instance var_option
         else Ctype.newvar () in
       Ctype.newty (Tarrow (l, arg, approx_description ct, Cok))
   | _ -> Ctype.newvar ()


### PR DESCRIPTION
Since #1609, calling `instance_def` is the same as calling `instance`.
This PR removes the former.