### PR TITLE
Pass the elements from `BUILD_PATH_PREFIX_MAP` to the assembler

### DIFF
--- a/.depend
+++ b/.depend
@@ -109,7 +109,7 @@ parsing/location.cmo : utils/warnings.cmi utils/terminfo.cmi utils/misc.cmi \
     utils/clflags.cmi utils/build_path_prefix_map.cmi parsing/location.cmi
 parsing/location.cmx : utils/warnings.cmx utils/terminfo.cmx utils/misc.cmx \
     utils/clflags.cmx utils/build_path_prefix_map.cmx parsing/location.cmi
-parsing/location.cmi : utils/warnings.cmi
+parsing/location.cmi : utils/warnings.cmi utils/build_path_prefix_map.cmi
 parsing/longident.cmo : utils/misc.cmi parsing/longident.cmi
 parsing/longident.cmx : utils/misc.cmx parsing/longident.cmi
 parsing/longident.cmi :
@@ -1277,10 +1277,12 @@ asmcomp/x86_masm.cmo : asmcomp/x86_proc.cmi asmcomp/x86_ast.cmi \
 asmcomp/x86_masm.cmx : asmcomp/x86_proc.cmx asmcomp/x86_ast.cmi \
     asmcomp/x86_masm.cmi
 asmcomp/x86_masm.cmi : asmcomp/x86_ast.cmi
-asmcomp/x86_proc.cmo : asmcomp/x86_ast.cmi utils/config.cmi \
-    utils/clflags.cmi utils/ccomp.cmi asmcomp/x86_proc.cmi
-asmcomp/x86_proc.cmx : asmcomp/x86_ast.cmi utils/config.cmx \
-    utils/clflags.cmx utils/ccomp.cmx asmcomp/x86_proc.cmi
+asmcomp/x86_proc.cmo : asmcomp/x86_ast.cmi parsing/location.cmi \
+    utils/config.cmi utils/clflags.cmi utils/ccomp.cmi \
+    utils/build_path_prefix_map.cmi asmcomp/x86_proc.cmi
+asmcomp/x86_proc.cmx : asmcomp/x86_ast.cmi parsing/location.cmx \
+    utils/config.cmx utils/clflags.cmx utils/ccomp.cmx \
+    utils/build_path_prefix_map.cmx asmcomp/x86_proc.cmi
 asmcomp/x86_proc.cmi : asmcomp/x86_ast.cmi
 middle_end/alias_analysis.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \

--- a/.depend
+++ b/.depend
@@ -23,9 +23,11 @@ utils/consistbl.cmi :
 utils/identifiable.cmo : utils/misc.cmi utils/identifiable.cmi
 utils/identifiable.cmx : utils/misc.cmx utils/identifiable.cmi
 utils/identifiable.cmi :
-utils/misc.cmo : utils/config.cmi utils/misc.cmi
-utils/misc.cmx : utils/config.cmx utils/misc.cmi
-utils/misc.cmi :
+utils/misc.cmo : utils/config.cmi utils/build_path_prefix_map.cmi \
+    utils/misc.cmi
+utils/misc.cmx : utils/config.cmx utils/build_path_prefix_map.cmx \
+    utils/misc.cmi
+utils/misc.cmi : utils/build_path_prefix_map.cmi
 utils/numbers.cmo : utils/misc.cmi utils/identifiable.cmi utils/numbers.cmi
 utils/numbers.cmx : utils/misc.cmx utils/identifiable.cmx utils/numbers.cmi
 utils/numbers.cmi : utils/identifiable.cmi
@@ -109,7 +111,7 @@ parsing/location.cmo : utils/warnings.cmi utils/terminfo.cmi utils/misc.cmi \
     utils/clflags.cmi utils/build_path_prefix_map.cmi parsing/location.cmi
 parsing/location.cmx : utils/warnings.cmx utils/terminfo.cmx utils/misc.cmx \
     utils/clflags.cmx utils/build_path_prefix_map.cmx parsing/location.cmi
-parsing/location.cmi : utils/warnings.cmi utils/build_path_prefix_map.cmi
+parsing/location.cmi : utils/warnings.cmi
 parsing/longident.cmo : utils/misc.cmi parsing/longident.cmi
 parsing/longident.cmx : utils/misc.cmx parsing/longident.cmi
 parsing/longident.cmi :
@@ -1277,12 +1279,12 @@ asmcomp/x86_masm.cmo : asmcomp/x86_proc.cmi asmcomp/x86_ast.cmi \
 asmcomp/x86_masm.cmx : asmcomp/x86_proc.cmx asmcomp/x86_ast.cmi \
     asmcomp/x86_masm.cmi
 asmcomp/x86_masm.cmi : asmcomp/x86_ast.cmi
-asmcomp/x86_proc.cmo : asmcomp/x86_ast.cmi parsing/location.cmi \
-    utils/config.cmi utils/clflags.cmi utils/ccomp.cmi \
-    utils/build_path_prefix_map.cmi asmcomp/x86_proc.cmi
-asmcomp/x86_proc.cmx : asmcomp/x86_ast.cmi parsing/location.cmx \
-    utils/config.cmx utils/clflags.cmx utils/ccomp.cmx \
-    utils/build_path_prefix_map.cmx asmcomp/x86_proc.cmi
+asmcomp/x86_proc.cmo : asmcomp/x86_ast.cmi utils/misc.cmi utils/config.cmi \
+    utils/clflags.cmi utils/ccomp.cmi utils/build_path_prefix_map.cmi \
+    asmcomp/x86_proc.cmi
+asmcomp/x86_proc.cmx : asmcomp/x86_ast.cmi utils/misc.cmx utils/config.cmx \
+    utils/clflags.cmx utils/ccomp.cmx utils/build_path_prefix_map.cmx \
+    asmcomp/x86_proc.cmi
 asmcomp/x86_proc.cmi : asmcomp/x86_ast.cmi
 middle_end/alias_analysis.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \

--- a/.depend
+++ b/.depend
@@ -1280,11 +1280,9 @@ asmcomp/x86_masm.cmx : asmcomp/x86_proc.cmx asmcomp/x86_ast.cmi \
     asmcomp/x86_masm.cmi
 asmcomp/x86_masm.cmi : asmcomp/x86_ast.cmi
 asmcomp/x86_proc.cmo : asmcomp/x86_ast.cmi utils/misc.cmi utils/config.cmi \
-    utils/clflags.cmi utils/ccomp.cmi utils/build_path_prefix_map.cmi \
-    asmcomp/x86_proc.cmi
+    utils/clflags.cmi utils/ccomp.cmi asmcomp/x86_proc.cmi
 asmcomp/x86_proc.cmx : asmcomp/x86_ast.cmi utils/misc.cmx utils/config.cmx \
-    utils/clflags.cmx utils/ccomp.cmx utils/build_path_prefix_map.cmx \
-    asmcomp/x86_proc.cmi
+    utils/clflags.cmx utils/ccomp.cmx asmcomp/x86_proc.cmi
 asmcomp/x86_proc.cmi : asmcomp/x86_ast.cmi
 middle_end/alias_analysis.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \

--- a/Changes
+++ b/Changes
@@ -115,7 +115,8 @@ Working version
   (Armaël Guéneau, review by Thomas Refis, Gabriel Scherer and François Bobot)
 
 - GPR#1930: pass the elements from `BUILD_PATH_PREFIX_MAP` to the assembler
-  (Xavier Clerc, review by Gabriel Scherer and Sébastien Hinderer)
+  (Xavier Clerc, review by Gabriel Scherer, Sébastien Hinderer, and
+   Xavier Leroy)
 
 ### Code generation and optimizations:
 

--- a/Changes
+++ b/Changes
@@ -114,8 +114,8 @@ Working version
   and expect tests
   (Armaël Guéneau, review by Thomas Refis, Gabriel Scherer and François Bobot)
 
-- GPR#????: pass the elements from `BUILD_PATH_PREFIX_MAP` to the assembler
-  (Xavier Clerc, review by ???)
+- GPR#1930: pass the elements from `BUILD_PATH_PREFIX_MAP` to the assembler
+  (Xavier Clerc, review by Gabriel Scherer and Sébastien Hinderer)
 
 ### Code generation and optimizations:
 

--- a/Changes
+++ b/Changes
@@ -114,6 +114,9 @@ Working version
   and expect tests
   (Armaël Guéneau, review by Thomas Refis, Gabriel Scherer and François Bobot)
 
+- GPR#????: pass the elements from `BUILD_PATH_PREFIX_MAP` to the assembler
+  (Xavier Clerc, review by ???)
+
 ### Code generation and optimizations:
 
 - MPR#7725, GPR#1754: improve AFL instrumentation for objects and lazy values.

--- a/Makefile
+++ b/Makefile
@@ -356,6 +356,7 @@ utils/config.ml: utils/config.mlp config/Makefile Makefile
 	    $(call SUBST,ENABLE_CALL_COUNTS) \
 	    $(call SUBST,FLAT_FLOAT_ARRAY) \
 	    $(call SUBST,CC_HAS_DEBUG_PREFIX_MAP) \
+	    $(call SUBST,AS_HAS_DEBUG_PREFIX_MAP) \
 	    $< > $@
 
 ifeq "$(UNIX_OR_WIN32)" "unix"

--- a/Makefile
+++ b/Makefile
@@ -68,13 +68,12 @@ DEPFLAGS=$(INCLUDES)
 
 OCAMLDOC_OPT=$(WITH_OCAMLDOC:=.opt)
 
-UTILS=utils/config.cmo utils/misc.cmo \
+UTILS=utils/config.cmo utils/build_path_prefix_map.cmo utils/misc.cmo \
   utils/identifiable.cmo utils/numbers.cmo utils/arg_helper.cmo \
   utils/clflags.cmo utils/profile.cmo \
   utils/terminfo.cmo utils/ccomp.cmo utils/warnings.cmo \
   utils/consistbl.cmo \
   utils/strongly_connected_components.cmo \
-  utils/build_path_prefix_map.cmo \
   utils/targetint.cmo
 
 PARSING=parsing/location.cmo parsing/longident.cmo \

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -310,7 +310,7 @@ let contains_calls = ref false
 (* Calling the assembler *)
 
 let assemble_file infile outfile =
-  Ccomp.command (Config.asm ^ " -o " ^
+  Ccomp.command (Config.asm ^ Misc.debug_prefix_map_flags () ^ " -o " ^
                  Filename.quote outfile ^ " " ^ Filename.quote infile)
 
 

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -310,8 +310,9 @@ let contains_calls = ref false
 (* Calling the assembler *)
 
 let assemble_file infile outfile =
-  Ccomp.command (Config.asm ^ Misc.debug_prefix_map_flags () ^ " -o " ^
-                 Filename.quote outfile ^ " " ^ Filename.quote infile)
+  Ccomp.command (Config.asm ^ " " ^
+                 (String.concat " " (Misc.debug_prefix_map_flags ())) ^
+                 " -o " ^ Filename.quote outfile ^ " " ^ Filename.quote infile)
 
 
 let init () = ()

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -230,7 +230,7 @@ let contains_calls = ref false
 (* Calling the assembler *)
 
 let assemble_file infile outfile =
-  Ccomp.command (Config.asm ^ " -o " ^
+  Ccomp.command (Config.asm ^ Misc.debug_prefix_map_flags () ^ " -o " ^
                  Filename.quote outfile ^ " " ^ Filename.quote infile)
 
 

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -230,8 +230,9 @@ let contains_calls = ref false
 (* Calling the assembler *)
 
 let assemble_file infile outfile =
-  Ccomp.command (Config.asm ^ Misc.debug_prefix_map_flags () ^ " -o " ^
-                 Filename.quote outfile ^ " " ^ Filename.quote infile)
+  Ccomp.command (Config.asm ^ " " ^
+                 (String.concat " " (Misc.debug_prefix_map_flags ())) ^
+                 " -o " ^ Filename.quote outfile ^ " " ^ Filename.quote infile)
 
 
 let init () = ()

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -305,7 +305,7 @@ let contains_calls = ref false
 (* Calling the assembler *)
 
 let assemble_file infile outfile =
-  Ccomp.command (Config.asm ^ " -o " ^
+  Ccomp.command (Config.asm ^ Misc.debug_prefix_map_flags () ^ " -o " ^
                  Filename.quote outfile ^ " " ^ Filename.quote infile)
 
 let init () = ()

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -305,7 +305,8 @@ let contains_calls = ref false
 (* Calling the assembler *)
 
 let assemble_file infile outfile =
-  Ccomp.command (Config.asm ^ Misc.debug_prefix_map_flags () ^ " -o " ^
-                 Filename.quote outfile ^ " " ^ Filename.quote infile)
+  Ccomp.command (Config.asm ^ " " ^
+                 (String.concat " " (Misc.debug_prefix_map_flags ())) ^
+                 " -o " ^ Filename.quote outfile ^ " " ^ Filename.quote infile)
 
 let init () = ()

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -208,7 +208,7 @@ let contains_calls = ref false
 (* Calling the assembler *)
 
 let assemble_file infile outfile =
-  Ccomp.command (Config.asm ^ " -o " ^
+  Ccomp.command (Config.asm ^ Misc.debug_prefix_map_flags () ^ " -o " ^
                  Filename.quote outfile ^ " " ^ Filename.quote infile)
 
 let init () = ()

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -208,7 +208,8 @@ let contains_calls = ref false
 (* Calling the assembler *)
 
 let assemble_file infile outfile =
-  Ccomp.command (Config.asm ^ Misc.debug_prefix_map_flags () ^ " -o " ^
-                 Filename.quote outfile ^ " " ^ Filename.quote infile)
+  Ccomp.command (Config.asm ^ " " ^
+                 (String.concat " " (Misc.debug_prefix_map_flags ())) ^
+                 " -o " ^ Filename.quote outfile ^ " " ^ Filename.quote infile)
 
 let init () = ()

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -249,8 +249,10 @@ let compile infile outfile =
                    Filename.quote outfile ^ " " ^ Filename.quote infile ^
                    (if !Clflags.verbose then "" else ">NUL"))
   else
-    Ccomp.command (Config.asm ^ Misc.debug_prefix_map_flags () ^ " -o " ^
-                   Filename.quote outfile ^ " " ^ Filename.quote infile)
+    Ccomp.command (Config.asm ^ " " ^
+                   (String.concat " " (Misc.debug_prefix_map_flags ())) ^
+                   " -o " ^ Filename.quote outfile ^ " " ^
+                   Filename.quote infile)
 
 let assemble_file infile outfile =
   match !binary_content with

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -253,7 +253,7 @@ let compile infile outfile =
       if not Config.as_has_debug_prefix_map then
         ""
       else begin
-        match Location.get_build_path_prefix_map () with
+        match Misc.get_build_path_prefix_map () with
         | None -> ""
         | Some map ->
           let buff = Buffer.create 64 in

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -249,7 +249,26 @@ let compile infile outfile =
                    Filename.quote outfile ^ " " ^ Filename.quote infile ^
                    (if !Clflags.verbose then "" else ">NUL"))
   else
-    Ccomp.command (Config.asm ^ " -o " ^
+    let debug_prefix_map_switches =
+      if Config.as_has_debug_prefix_map then begin
+        match Location.get_build_path_prefix_map () with
+        | None -> ""
+        | Some map ->
+          let buff = Buffer.create 64 in
+          List.iter
+            (function
+              | None -> ()
+              | Some { Build_path_prefix_map.target; source; } ->
+                Buffer.add_string buff " --debug-prefix-map ";
+                Buffer.add_string buff source;
+                Buffer.add_char buff '=';
+                Buffer.add_string buff target)
+            map;
+          Buffer.contents buff
+      end else
+        ""
+    in
+    Ccomp.command (Config.asm ^ debug_prefix_map_switches ^ " -o " ^
                    Filename.quote outfile ^ " " ^ Filename.quote infile)
 
 let assemble_file infile outfile =

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -250,7 +250,9 @@ let compile infile outfile =
                    (if !Clflags.verbose then "" else ">NUL"))
   else
     let debug_prefix_map_switches =
-      if Config.as_has_debug_prefix_map then begin
+      if not Config.as_has_debug_prefix_map then
+        ""
+      else begin
         match Location.get_build_path_prefix_map () with
         | None -> ""
         | Some map ->
@@ -265,8 +267,7 @@ let compile infile outfile =
                 Buffer.add_string buff target)
             map;
           Buffer.contents buff
-      end else
-        ""
+      end
     in
     Ccomp.command (Config.asm ^ debug_prefix_map_switches ^ " -o " ^
                    Filename.quote outfile ^ " " ^ Filename.quote infile)

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -243,33 +243,13 @@ let use_plt =
 *)
 let binary_content = ref None
 
-let debug_prefix_map_flags () =
-  if not Config.as_has_debug_prefix_map then
-    ""
-  else begin
-    match Misc.get_build_path_prefix_map () with
-    | None -> ""
-    | Some map ->
-      let buff = Buffer.create 64 in
-      List.iter
-        (function
-          | None -> ()
-          | Some { Build_path_prefix_map.target; source; } ->
-            Buffer.add_string buff " --debug-prefix-map ";
-            Buffer.add_string buff source;
-            Buffer.add_char buff '=';
-            Buffer.add_string buff target)
-        map;
-      Buffer.contents buff
-  end
-
 let compile infile outfile =
   if masm then
     Ccomp.command (Config.asm ^
                    Filename.quote outfile ^ " " ^ Filename.quote infile ^
                    (if !Clflags.verbose then "" else ">NUL"))
   else
-    Ccomp.command (Config.asm ^ debug_prefix_map_flags () ^ " -o " ^
+    Ccomp.command (Config.asm ^ Misc.debug_prefix_map_flags () ^ " -o " ^
                    Filename.quote outfile ^ " " ^ Filename.quote infile)
 
 let assemble_file infile outfile =

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -243,33 +243,33 @@ let use_plt =
 *)
 let binary_content = ref None
 
+let debug_prefix_map_flags () =
+  if not Config.as_has_debug_prefix_map then
+    ""
+  else begin
+    match Misc.get_build_path_prefix_map () with
+    | None -> ""
+    | Some map ->
+      let buff = Buffer.create 64 in
+      List.iter
+        (function
+          | None -> ()
+          | Some { Build_path_prefix_map.target; source; } ->
+            Buffer.add_string buff " --debug-prefix-map ";
+            Buffer.add_string buff source;
+            Buffer.add_char buff '=';
+            Buffer.add_string buff target)
+        map;
+      Buffer.contents buff
+  end
+
 let compile infile outfile =
   if masm then
     Ccomp.command (Config.asm ^
                    Filename.quote outfile ^ " " ^ Filename.quote infile ^
                    (if !Clflags.verbose then "" else ">NUL"))
   else
-    let debug_prefix_map_flags =
-      if not Config.as_has_debug_prefix_map then
-        ""
-      else begin
-        match Misc.get_build_path_prefix_map () with
-        | None -> ""
-        | Some map ->
-          let buff = Buffer.create 64 in
-          List.iter
-            (function
-              | None -> ()
-              | Some { Build_path_prefix_map.target; source; } ->
-                Buffer.add_string buff " --debug-prefix-map ";
-                Buffer.add_string buff source;
-                Buffer.add_char buff '=';
-                Buffer.add_string buff target)
-            map;
-          Buffer.contents buff
-      end
-    in
-    Ccomp.command (Config.asm ^ debug_prefix_map_flags ^ " -o " ^
+    Ccomp.command (Config.asm ^ debug_prefix_map_flags () ^ " -o " ^
                    Filename.quote outfile ^ " " ^ Filename.quote infile)
 
 let assemble_file infile outfile =

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -249,7 +249,7 @@ let compile infile outfile =
                    Filename.quote outfile ^ " " ^ Filename.quote infile ^
                    (if !Clflags.verbose then "" else ">NUL"))
   else
-    let debug_prefix_map_switches =
+    let debug_prefix_map_flags =
       if not Config.as_has_debug_prefix_map then
         ""
       else begin
@@ -269,7 +269,7 @@ let compile infile outfile =
           Buffer.contents buff
       end
     in
-    Ccomp.command (Config.asm ^ debug_prefix_map_switches ^ " -o " ^
+    Ccomp.command (Config.asm ^ debug_prefix_map_flags ^ " -o " ^
                    Filename.quote outfile ^ " " ^ Filename.quote infile)
 
 let assemble_file infile outfile =

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -108,6 +108,7 @@ WINDOWS_UNICODE=1
 AFL_INSTRUMENT=false
 AWK=gawk
 CC_HAS_DEBUG_PREFIX_MAP=false
+AS_HAS_DEBUG_PREFIX_MAP=false
 
 ########## Configuration for the bytecode compiler
 

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -108,6 +108,7 @@ WINDOWS_UNICODE=1
 AFL_INSTRUMENT=false
 AWK=gawk
 CC_HAS_DEBUG_PREFIX_MAP=false
+AS_HAS_DEBUG_PREFIX_MAP=false
 
 ########## Configuration for the bytecode compiler
 

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -101,6 +101,7 @@ WINDOWS_UNICODE=1
 AFL_INSTRUMENT=false
 AWK=gawk
 CC_HAS_DEBUG_PREFIX_MAP=false
+AS_HAS_DEBUG_PREFIX_MAP=false
 
 ########## Configuration for the bytecode compiler
 

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -100,6 +100,7 @@ WINDOWS_UNICODE=1
 AFL_INSTRUMENT=false
 AWK=gawk
 CC_HAS_DEBUG_PREFIX_MAP=false
+AS_HAS_DEBUG_PREFIX_MAP=false
 
 ########## Configuration for the bytecode compiler
 

--- a/config/auto-aux/simple.S
+++ b/config/auto-aux/simple.S
@@ -1,3 +1,3 @@
-	camlPervasives__loop_1128:
-	        .file   1       "pervasives.ml"
-	        .loc    1       193
+camlPervasives__loop_1128:
+        .file   1       "pervasives.ml"
+        .loc    1       193

--- a/config/auto-aux/simple.S
+++ b/config/auto-aux/simple.S
@@ -1,0 +1,3 @@
+	camlPervasives__loop_1128:
+	        .file   1       "pervasives.ml"
+	        .loc    1       193

--- a/configure
+++ b/configure
@@ -1909,6 +1909,12 @@ asm_cfi_supported=false
 
 export as aspp
 
+if $as --debug-prefix-map old=new simple.S; then
+    as_has_debug_prefix_map=true
+else
+    as_has_debug_prefix_map=false
+fi
+
 if ! $with_cfi; then
   echo "CFI support: disabled by command-line option -no-cfi"
 elif sh ./tryassemble cfi.S; then
@@ -2158,6 +2164,7 @@ config MAX_TESTSUITE_DIR_RETRIES "$max_testsuite_dir_retries"
 config FLAT_FLOAT_ARRAY "$flat_float_array"
 config AWK "awk"
 config CC_HAS_DEBUG_PREFIX_MAP "$cc_has_debug_prefix_map"
+config AS_HAS_DEBUG_PREFIX_MAP "$as_has_debug_prefix_map"
 
 
 rm -f tst hasgot.c

--- a/configure
+++ b/configure
@@ -1909,7 +1909,7 @@ asm_cfi_supported=false
 
 export as aspp
 
-if $as --debug-prefix-map old=new simple.S; then
+if $as --debug-prefix-map old=new simple.S 2> /dev/null; then
     as_has_debug_prefix_map=true
 else
     as_has_debug_prefix_map=false

--- a/debugger/Makefile
+++ b/debugger/Makefile
@@ -35,11 +35,10 @@ INCLUDES=\
 
 OTHEROBJS=\
   $(UNIXDIR)/unix.cma \
-  ../utils/config.cmo ../utils/misc.cmo \
+  ../utils/config.cmo ../utils/build_path_prefix_map.cmo ../utils/misc.cmo \
   ../utils/identifiable.cmo ../utils/numbers.cmo \
   ../utils/arg_helper.cmo ../utils/clflags.cmo \
   ../utils/consistbl.cmo ../utils/warnings.cmo \
-  ../utils/build_path_prefix_map.cmo \
   ../utils/terminfo.cmo \
   ../parsing/location.cmo ../parsing/longident.cmo ../parsing/docstrings.cmo \
   ../parsing/syntaxerr.cmo \

--- a/ocamldoc/.depend
+++ b/ocamldoc/.depend
@@ -9,7 +9,7 @@ odoc_analyse.cmo : ../utils/warnings.cmi ../typing/types.cmi \
     odoc_merge.cmi odoc_global.cmi odoc_dep.cmo odoc_cross.cmi \
     odoc_comments.cmi odoc_class.cmo odoc_ast.cmi ../parsing/location.cmi \
     ../parsing/lexer.cmi ../typing/env.cmi ../utils/config.cmi \
-    ../utils/clflags.cmi odoc_analyse.cmi
+    ../driver/compmisc.cmi ../utils/clflags.cmi odoc_analyse.cmi
 odoc_analyse.cmx : ../utils/warnings.cmx ../typing/types.cmx \
     ../typing/typemod.cmx ../typing/typedtree.cmx ../parsing/syntaxerr.cmx \
     ../driver/pparse.cmx ../parsing/parse.cmx odoc_types.cmx odoc_text.cmx \
@@ -17,20 +17,18 @@ odoc_analyse.cmx : ../utils/warnings.cmx ../typing/types.cmx \
     odoc_merge.cmx odoc_global.cmx odoc_dep.cmx odoc_cross.cmx \
     odoc_comments.cmx odoc_class.cmx odoc_ast.cmx ../parsing/location.cmx \
     ../parsing/lexer.cmx ../typing/env.cmx ../utils/config.cmx \
-    ../utils/clflags.cmx odoc_analyse.cmi
+    ../driver/compmisc.cmx ../utils/clflags.cmx odoc_analyse.cmi
 odoc_analyse.cmi : odoc_module.cmo odoc_global.cmi
 odoc_args.cmo : ../utils/warnings.cmi odoc_types.cmi odoc_texi.cmo \
     odoc_messages.cmo odoc_man.cmo odoc_latex.cmo odoc_html.cmo \
     odoc_global.cmi odoc_gen.cmi odoc_dot.cmo odoc_config.cmi \
-    ../utils/misc.cmi ../driver/main_args.cmi ../parsing/location.cmi \
-    ../utils/config.cmi ../driver/compenv.cmi ../utils/clflags.cmi \
-    odoc_args.cmi
+    ../driver/main_args.cmi ../utils/config.cmi ../driver/compenv.cmi \
+    ../utils/clflags.cmi odoc_args.cmi
 odoc_args.cmx : ../utils/warnings.cmx odoc_types.cmx odoc_texi.cmx \
     odoc_messages.cmx odoc_man.cmx odoc_latex.cmx odoc_html.cmx \
     odoc_global.cmx odoc_gen.cmx odoc_dot.cmx odoc_config.cmx \
-    ../utils/misc.cmx ../driver/main_args.cmx ../parsing/location.cmx \
-    ../utils/config.cmx ../driver/compenv.cmx ../utils/clflags.cmx \
-    odoc_args.cmi
+    ../driver/main_args.cmx ../utils/config.cmx ../driver/compenv.cmx \
+    ../utils/clflags.cmx odoc_args.cmi
 odoc_args.cmi : odoc_gen.cmi
 odoc_ast.cmo : ../typing/types.cmi ../typing/typedtree.cmi \
     ../typing/predef.cmi ../typing/path.cmi ../parsing/parsetree.cmi \

--- a/ocamldoc/Makefile.unprefix
+++ b/ocamldoc/Makefile.unprefix
@@ -42,7 +42,8 @@ STDLIB_MLIS=\
 STDLIB_MLIS:=$(addprefix $(STDLIB_UNPREFIXED)/, $(STDLIB_MLIS))
 
 # Dependencies for the documented modules
-STDLIB_DEPS:=$(STDLIB_MLIS) \
+STDLIB_DEPS:=$(UTILS_MLIS:$(SRC)/utils/%.mli=$(STDLIB_UNPREFIXED)/%.mli) \
+  $(STDLIB_MLIS) \
   $(TYPING_MLIS:$(SRC)/typing/%.mli=$(STDLIB_UNPREFIXED)/%.mli) \
   $(BYTECOMP_MLIS:$(SRC)/bytecomp/%.mli=$(STDLIB_UNPREFIXED)/%.mli)
 

--- a/ocamldoc/Makefile.unprefix
+++ b/ocamldoc/Makefile.unprefix
@@ -42,8 +42,7 @@ STDLIB_MLIS=\
 STDLIB_MLIS:=$(addprefix $(STDLIB_UNPREFIXED)/, $(STDLIB_MLIS))
 
 # Dependencies for the documented modules
-STDLIB_DEPS:=$(UTILS_MLIS:$(SRC)/utils/%.mli=$(STDLIB_UNPREFIXED)/%.mli) \
-  $(STDLIB_MLIS) \
+STDLIB_DEPS:=$(STDLIB_MLIS) \
   $(TYPING_MLIS:$(SRC)/typing/%.mli=$(STDLIB_UNPREFIXED)/%.mli) \
   $(BYTECOMP_MLIS:$(SRC)/bytecomp/%.mli=$(STDLIB_UNPREFIXED)/%.mli)
 

--- a/ocamldoc/stdlib_non_prefixed/.depend
+++ b/ocamldoc/stdlib_non_prefixed/.depend
@@ -85,7 +85,8 @@ map.cmi : seq.cmi
 marshal.cmi :
 matching.cmi : typedtree.cmi location.cmi lambda.cmi ident.cmi
 meta.cmi : obj.cmi instruct.cmi
-misc.cmi : string.cmi set.cmi map.cmi hashtbl.cmi format.cmi
+misc.cmi : string.cmi set.cmi map.cmi hashtbl.cmi format.cmi \
+    build_path_prefix_map.cmi
 moreLabels.cmi : set.cmi seq.cmi map.cmi hashtbl.cmi
 mtype.cmi : types.cmi path.cmi ident.cmi env.cmi
 mutex.cmi :

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -40,7 +40,8 @@ endif
 OBJS=dynlinkaux.cmo dynlink.cmo
 
 COMPILEROBJS=\
-  ../../utils/config.cmo ../../utils/build_path_prefix_map.cmo ../../utils/misc.cmo \
+  ../../utils/config.cmo ../../utils/build_path_prefix_map.cmo \
+  ../../utils/misc.cmo \
   ../../utils/identifiable.cmo ../../utils/numbers.cmo \
   ../../utils/arg_helper.cmo ../../utils/clflags.cmo \
   ../../utils/consistbl.cmo \

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -40,12 +40,11 @@ endif
 OBJS=dynlinkaux.cmo dynlink.cmo
 
 COMPILEROBJS=\
-  ../../utils/config.cmo ../../utils/misc.cmo \
+  ../../utils/config.cmo ../../utils/build_path_prefix_map.cmo ../../utils/misc.cmo \
   ../../utils/identifiable.cmo ../../utils/numbers.cmo \
   ../../utils/arg_helper.cmo ../../utils/clflags.cmo \
   ../../utils/consistbl.cmo \
   ../../utils/terminfo.cmo ../../utils/warnings.cmo \
-  ../../utils/build_path_prefix_map.cmo \
   ../../parsing/asttypes.cmi \
   ../../parsing/location.cmo ../../parsing/longident.cmo \
   ../../parsing/docstrings.cmo ../../parsing/syntaxerr.cmo \

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -100,30 +100,10 @@ let setup_colors () =
 (******************************************************************************)
 (* Printing locations, e.g. 'File "foo.ml", line 3, characters 10-12' *)
 
-let get_build_path_prefix_map, rewrite_absolute_path =
-  let init = ref false in
-  let map_cache = ref None in
-  let init_map () =
-    if not !init then begin
-      init := true;
-      match Sys.getenv "BUILD_PATH_PREFIX_MAP" with
-      | exception Not_found -> ()
-      | encoded_map ->
-        match Build_path_prefix_map.decode_map encoded_map with
-          | Error err ->
-              Misc.fatal_errorf
-                "Invalid value for the environment variable \
-                 BUILD_PATH_PREFIX_MAP: %s" err
-          | Ok map -> map_cache := Some map
-    end in
-  (fun () ->
-     init_map ();
-     !map_cache),
-  (fun path ->
-     init_map ();
-     match !map_cache with
-     | None -> path
-     | Some map -> Build_path_prefix_map.rewrite map path)
+let rewrite_absolute_path path =
+  match Misc.get_build_path_prefix_map () with
+  | None -> path
+  | Some map -> Build_path_prefix_map.rewrite map path
 
 let absolute_path s = (* This function could go into Filename *)
   let open Filename in

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -100,10 +100,10 @@ let setup_colors () =
 (******************************************************************************)
 (* Printing locations, e.g. 'File "foo.ml", line 3, characters 10-12' *)
 
-let rewrite_absolute_path =
+let get_build_path_prefix_map, rewrite_absolute_path =
   let init = ref false in
   let map_cache = ref None in
-  fun path ->
+  let init_map () =
     if not !init then begin
       init := true;
       match Sys.getenv "BUILD_PATH_PREFIX_MAP" with
@@ -115,10 +115,15 @@ let rewrite_absolute_path =
                 "Invalid value for the environment variable \
                  BUILD_PATH_PREFIX_MAP: %s" err
           | Ok map -> map_cache := Some map
-    end;
-    match !map_cache with
-    | None -> path
-    | Some map -> Build_path_prefix_map.rewrite map path
+    end in
+  (fun () ->
+     init_map ();
+     !map_cache),
+  (fun path ->
+     init_map ();
+     match !map_cache with
+     | None -> path
+     | Some map -> Build_path_prefix_map.rewrite map path)
 
 let absolute_path s = (* This function could go into Filename *)
   let open Filename in

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -96,6 +96,9 @@ val rewrite_absolute_path: string -> string
         variable (https://reproducible-builds.org/specs/build-path-prefix-map/)
         if it is set. *)
 
+val get_build_path_prefix_map: unit -> Build_path_prefix_map.map option
+    (** Returns the map used by [rewrite_absolute_path]. *)
+
 val absolute_path: string -> string
 
 val show_filename: string -> string

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -96,9 +96,6 @@ val rewrite_absolute_path: string -> string
         variable (https://reproducible-builds.org/specs/build-path-prefix-map/)
         if it is set. *)
 
-val get_build_path_prefix_map: unit -> Build_path_prefix_map.map option
-    (** Returns the map used by [rewrite_absolute_path]. *)
-
 val absolute_path: string -> string
 
 val show_filename: string -> string

--- a/testsuite/tests/utils/edit_distance.ml
+++ b/testsuite/tests/utils/edit_distance.ml
@@ -1,7 +1,7 @@
 (* TEST
 include config
 include testing
-binary_modules = "config misc identifiable numbers"
+binary_modules = "config build_path_prefix_map misc identifiable numbers"
 * bytecode
 *)
 

--- a/testsuite/tests/utils/overflow_detection.ml
+++ b/testsuite/tests/utils/overflow_detection.ml
@@ -1,7 +1,7 @@
 (* TEST
 include config
 include testing
-binary_modules = "config misc identifiable numbers"
+binary_modules = "config build_path_prefix_map misc identifiable numbers"
 * bytecode
 *)
 

--- a/testsuite/tests/utils/test_strongly_connected_components.ml
+++ b/testsuite/tests/utils/test_strongly_connected_components.ml
@@ -2,7 +2,7 @@
 include config
 include testing
 binary_modules =
-  "config misc identifiable numbers strongly_connected_components"
+  "config build_path_prefix_map misc identifiable numbers strongly_connected_components"
 * bytecode
 *)
 

--- a/testsuite/tests/utils/test_strongly_connected_components.ml
+++ b/testsuite/tests/utils/test_strongly_connected_components.ml
@@ -2,7 +2,8 @@
 include config
 include testing
 binary_modules =
-  "config build_path_prefix_map misc identifiable numbers strongly_connected_components"
+  "config build_path_prefix_map misc identifiable numbers \
+   strongly_connected_components"
 * bytecode
 *)
 

--- a/tools/.depend
+++ b/tools/.depend
@@ -2,6 +2,16 @@ addlabels.cmo : ../parsing/parsetree.cmi ../parsing/parse.cmi \
     ../parsing/longident.cmi ../parsing/location.cmi ../parsing/asttypes.cmi
 addlabels.cmx : ../parsing/parsetree.cmi ../parsing/parse.cmx \
     ../parsing/longident.cmx ../parsing/location.cmx ../parsing/asttypes.cmi
+caml_tex.cmo : ../utils/warnings.cmi ../toplevel/toploop.cmi \
+    ../parsing/syntaxerr.cmi ../parsing/parsetree.cmi ../parsing/parse.cmi \
+    ../utils/misc.cmi ../parsing/location.cmi ../driver/compmisc.cmi \
+    ../driver/compenv.cmi ../utils/clflags.cmi ../parsing/ast_iterator.cmi \
+    ../parsing/ast_helper.cmi
+caml_tex.cmx : ../utils/warnings.cmx ../toplevel/toploop.cmx \
+    ../parsing/syntaxerr.cmx ../parsing/parsetree.cmi ../parsing/parse.cmx \
+    ../utils/misc.cmx ../parsing/location.cmx ../driver/compmisc.cmx \
+    ../driver/compenv.cmx ../utils/clflags.cmx ../parsing/ast_iterator.cmx \
+    ../parsing/ast_helper.cmx
 cmpbyt.cmo : ../bytecomp/bytesections.cmi
 cmpbyt.cmx : ../bytecomp/bytesections.cmx
 cmt2annot.cmo : ../typing/untypeast.cmi ../typing/types.cmi \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -123,16 +123,16 @@ clean::
 # The profiler
 
 CSLPROF=ocamlprof.cmo
-CSLPROF_IMPORTS=config.cmo misc.cmo identifiable.cmo numbers.cmo \
-  arg_helper.cmo clflags.cmo terminfo.cmo \
-  build_path_prefix_map.cmo \
+CSLPROF_IMPORTS=config.cmo build_path_prefix_map.cmo misc.cmo identifiable.cmo \
+  numbers.cmo arg_helper.cmo clflags.cmo terminfo.cmo \
   warnings.cmo location.cmo longident.cmo docstrings.cmo \
   syntaxerr.cmo ast_helper.cmo parser.cmo lexer.cmo parse.cmo
 
 $(call byte_and_opt,ocamlprof,$(CSLPROF_IMPORTS) profiling.cmo $(CSLPROF),)
 
-ocamlcp_cmos = config.cmo misc.cmo profile.cmo warnings.cmo identifiable.cmo \
-               numbers.cmo arg_helper.cmo clflags.cmo main_args.cmo
+ocamlcp_cmos = config.cmo build_path_prefix_map.cmo misc.cmo profile.cmo \
+               warnings.cmo identifiable.cmo numbers.cmo arg_helper.cmo \
+               clflags.cmo main_args.cmo
 
 $(call byte_and_opt,ocamlcp,$(ocamlcp_cmos) ocamlcp.cmo,)
 $(call byte_and_opt,ocamloptp,$(ocamlcp_cmos) ocamloptp.cmo,)
@@ -156,7 +156,7 @@ installopt::
 
 # To help building mixed-mode libraries (OCaml + C)
 
-$(call byte_and_opt,ocamlmklib,ocamlmklibconfig.cmo config.cmo misc.cmo \
+$(call byte_and_opt,ocamlmklib,ocamlmklibconfig.cmo config.cmo build_path_prefix_map.cmo misc.cmo \
 	         ocamlmklib.cmo,)
 
 
@@ -177,15 +177,15 @@ clean::
 # To make custom toplevels
 
 OCAMLMKTOP=ocamlmktop.cmo
-OCAMLMKTOP_IMPORTS=config.cmo misc.cmo identifiable.cmo numbers.cmo \
-		   arg_helper.cmo clflags.cmo ccomp.cmo
+OCAMLMKTOP_IMPORTS=config.cmo build_path_prefix_map.cmo misc.cmo identifiable.cmo \
+       numbers.cmo arg_helper.cmo clflags.cmo ccomp.cmo
 
 $(call byte_and_opt,ocamlmktop,$(OCAMLMKTOP_IMPORTS) $(OCAMLMKTOP),)
 
 # Converter olabl/ocaml 2.99 to ocaml 3
 
 OCAML299TO3=lexer299.cmo ocaml299to3.cmo
-LIBRARY3=config.cmo misc.cmo warnings.cmo build_path_prefix_map.cmo location.cmo
+LIBRARY3=config.cmo build_path_prefix_map.cmo misc.cmo warnings.cmo location.cmo
 
 ocaml299to3: $(OCAML299TO3)
 	$(CAMLC) $(LINKFLAGS) -o ocaml299to3 $(LIBRARY3) $(OCAML299TO3)
@@ -217,9 +217,8 @@ clean::
 
 # Insert labels following an interface file (upgrade 3.02 to 3.03)
 
-ADDLABELS_IMPORTS=config.cmo misc.cmo arg_helper.cmo clflags.cmo \
+ADDLABELS_IMPORTS=config.cmo build_path_prefix_map.cmo misc.cmo arg_helper.cmo clflags.cmo \
   identifiable.cmo numbers.cmo terminfo.cmo \
-  build_path_prefix_map.cmo \
   warnings.cmo location.cmo longident.cmo docstrings.cmo \
   syntaxerr.cmo ast_helper.cmo parser.cmo lexer.cmo parse.cmo
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -156,8 +156,8 @@ installopt::
 
 # To help building mixed-mode libraries (OCaml + C)
 
-$(call byte_and_opt,ocamlmklib,ocamlmklibconfig.cmo config.cmo build_path_prefix_map.cmo misc.cmo \
-	         ocamlmklib.cmo,)
+$(call byte_and_opt,ocamlmklib,ocamlmklibconfig.cmo config.cmo \
+	         build_path_prefix_map.cmo misc.cmo ocamlmklib.cmo,)
 
 
 ocamlmklibconfig.ml: ../config/Makefile Makefile
@@ -177,8 +177,8 @@ clean::
 # To make custom toplevels
 
 OCAMLMKTOP=ocamlmktop.cmo
-OCAMLMKTOP_IMPORTS=config.cmo build_path_prefix_map.cmo misc.cmo identifiable.cmo \
-       numbers.cmo arg_helper.cmo clflags.cmo ccomp.cmo
+OCAMLMKTOP_IMPORTS=config.cmo build_path_prefix_map.cmo misc.cmo \
+       identifiable.cmo numbers.cmo arg_helper.cmo clflags.cmo ccomp.cmo
 
 $(call byte_and_opt,ocamlmktop,$(OCAMLMKTOP_IMPORTS) $(OCAMLMKTOP),)
 
@@ -217,8 +217,8 @@ clean::
 
 # Insert labels following an interface file (upgrade 3.02 to 3.03)
 
-ADDLABELS_IMPORTS=config.cmo build_path_prefix_map.cmo misc.cmo arg_helper.cmo clflags.cmo \
-  identifiable.cmo numbers.cmo terminfo.cmo \
+ADDLABELS_IMPORTS=config.cmo build_path_prefix_map.cmo misc.cmo arg_helper.cmo \
+  clflags.cmo identifiable.cmo numbers.cmo terminfo.cmo \
   warnings.cmo location.cmo longident.cmo docstrings.cmo \
   syntaxerr.cmo ast_helper.cmo parser.cmo lexer.cmo parse.cmo
 

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -33,6 +33,8 @@ val c_output_obj: string
            file *)
 val c_has_debug_prefix_map : bool
         (* Whether the C compiler supports -fdebug-prefix-map *)
+val as_has_debug_prefix_map : bool
+        (* Whether the assembler supports --debug-prefix-map *)
 val ocamlc_cflags : string
         (* The flags ocamlc should pass to the C compiler *)
 val ocamlc_cppflags : string

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -33,6 +33,7 @@ let ccomp_type = "%%CCOMPTYPE%%"
 let c_compiler = "%%CC%%"
 let c_output_obj = "%%OUTPUTOBJ%%"
 let c_has_debug_prefix_map = %%CC_HAS_DEBUG_PREFIX_MAP%%
+let as_has_debug_prefix_map = %%AS_HAS_DEBUG_PREFIX_MAP%%
 let ocamlc_cflags = "%%OCAMLC_CFLAGS%%"
 let ocamlc_cppflags = "%%OCAMLC_CPPFLAGS%%"
 let ocamlopt_cflags = "%%OCAMLOPT_CFLAGS%%"

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -800,7 +800,9 @@ let debug_prefix_map_flags () =
         (function
           | None -> ()
           | Some { Build_path_prefix_map.target; source; } ->
-            Printf.bprintf buff " --debug-prefix-map %S=%S" source target)
+            Printf.bprintf buff " --debug-prefix-map %s=%s"
+              (Filename.quote source)
+              (Filename.quote target))
         map;
       Buffer.contents buff
   end

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -800,10 +800,7 @@ let debug_prefix_map_flags () =
         (function
           | None -> ()
           | Some { Build_path_prefix_map.target; source; } ->
-            Buffer.add_string buff " --debug-prefix-map ";
-            Buffer.add_string buff source;
-            Buffer.add_char buff '=';
-            Buffer.add_string buff target)
+            Printf.bprintf buff " --debug-prefix-map %S=%S" source target)
         map;
       Buffer.contents buff
   end

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -790,19 +790,19 @@ let get_build_path_prefix_map =
 
 let debug_prefix_map_flags () =
   if not Config.as_has_debug_prefix_map then
-    ""
+    []
   else begin
     match get_build_path_prefix_map () with
-    | None -> ""
+    | None -> []
     | Some map ->
-      let buff = Buffer.create 64 in
-      List.iter
-        (function
-          | None -> ()
-          | Some { Build_path_prefix_map.target; source; } ->
-            Printf.bprintf buff " --debug-prefix-map %s=%s"
-              (Filename.quote source)
-              (Filename.quote target))
-        map;
-      Buffer.contents buff
+      List.fold_right
+        (fun map_elem acc ->
+           match map_elem with
+           | None -> acc
+           | Some { Build_path_prefix_map.target; source; } ->
+             (Printf.sprintf "--debug-prefix-map %s=%s"
+                (Filename.quote source)
+                (Filename.quote target)) :: acc)
+        map
+        []
   end

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -769,3 +769,21 @@ let show_config_variable_and_exit x =
       exit 0
   | None ->
       exit 2
+
+let get_build_path_prefix_map =
+  let init = ref false in
+  let map_cache = ref None in
+  fun () ->
+    if not !init then begin
+      init := true;
+      match Sys.getenv "BUILD_PATH_PREFIX_MAP" with
+      | exception Not_found -> ()
+      | encoded_map ->
+        match Build_path_prefix_map.decode_map encoded_map with
+          | Error err ->
+              fatal_errorf
+                "Invalid value for the environment variable \
+                 BUILD_PATH_PREFIX_MAP: %s" err
+          | Ok map -> map_cache := Some map
+    end;
+    !map_cache

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -787,3 +787,23 @@ let get_build_path_prefix_map =
           | Ok map -> map_cache := Some map
     end;
     !map_cache
+
+let debug_prefix_map_flags () =
+  if not Config.as_has_debug_prefix_map then
+    ""
+  else begin
+    match get_build_path_prefix_map () with
+    | None -> ""
+    | Some map ->
+      let buff = Buffer.create 64 in
+      List.iter
+        (function
+          | None -> ()
+          | Some { Build_path_prefix_map.target; source; } ->
+            Buffer.add_string buff " --debug-prefix-map ";
+            Buffer.add_string buff source;
+            Buffer.add_char buff '=';
+            Buffer.add_string buff target)
+        map;
+      Buffer.contents buff
+  end

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -358,5 +358,10 @@ val show_config_and_exit : unit -> unit
 val show_config_variable_and_exit : string -> unit
 
 val get_build_path_prefix_map: unit -> Build_path_prefix_map.map option
-(** Returns the map encoded in [BUILD_PATH_PREFIX_MAP] environment
+(** Returns the map encoded in the [BUILD_PATH_PREFIX_MAP] environment
     variable. *)
+
+val debug_prefix_map_flags: unit -> string
+(** Returns the list of [--debug-prefix-map] flags to be passed to the
+    assembler, built from the [BUILD_PATH_PREFIX_MAP] environment variable.
+    The returned string is either empty or contains a leading space. *)

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -356,3 +356,7 @@ module MakeHooks : functor (M : sig type t end) -> HookSig with type t = M.t
 (** configuration variables *)
 val show_config_and_exit : unit -> unit
 val show_config_variable_and_exit : string -> unit
+
+val get_build_path_prefix_map: unit -> Build_path_prefix_map.map option
+(** Returns the map encoded in [BUILD_PATH_PREFIX_MAP] environment
+    variable. *)

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -361,7 +361,6 @@ val get_build_path_prefix_map: unit -> Build_path_prefix_map.map option
 (** Returns the map encoded in the [BUILD_PATH_PREFIX_MAP] environment
     variable. *)
 
-val debug_prefix_map_flags: unit -> string
+val debug_prefix_map_flags: unit -> string list
 (** Returns the list of [--debug-prefix-map] flags to be passed to the
-    assembler, built from the [BUILD_PATH_PREFIX_MAP] environment variable.
-    The returned string is either empty or contains a leading space. *)
+    assembler, built from the [BUILD_PATH_PREFIX_MAP] environment variable. *)


### PR DESCRIPTION
Given that `as` does not inspect the `BUILD_PATH_PREFIX_MAP`
environment variable, it is necessary to pass its elements explicitly.
Otherwise, the produced object files contain the the absolute paths
of their sources, leading to non-reproducible builds.