### PR TITLE
type_cases: rely on levels to enforce principality

### DIFF
--- a/Changes
+++ b/Changes
@@ -155,6 +155,9 @@ Working version
 
 ### Compiler user-interface and warnings:
 
+- #1931: rely on levels to enforce principality in patterns
+  (Thomas Refis and Leo White, review by Jacques Garrigue)
+
 * #9011: Do not create .a/.lib files when creating a .cmxa with no modules.
   macOS ar doesn't support creating empty .a files (#1094) and MSVC doesn't
   permit .lib files to contain no objects. When linking with a .cmxa containing

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -715,6 +715,10 @@ let bad_location =
 [%%expect{|
 val bad_location : 'a GADT_ordering.is_point -> 'a -> int = <fun>
 |}, Principal{|
+Line 4, characters 11-19:
+4 |       let+ Is_point = is_point
+               ^^^^^^^^
+Warning 18: This introduction of a GADT equation is not principal.
 Line 5, characters 13-14:
 5 |       and+ { x; y } = a in
                  ^

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -718,7 +718,8 @@ val bad_location : 'a GADT_ordering.is_point -> 'a -> int = <fun>
 Line 4, characters 11-19:
 4 |       let+ Is_point = is_point
                ^^^^^^^^
-Warning 18: This introduction of a GADT equation is not principal.
+Warning 18: typing this pattern requires considering GADT_ordering.point and a as equal.
+But the knowledge of these types is not principal.
 Line 5, characters 13-14:
 5 |       and+ { x; y } = a in
                  ^

--- a/testsuite/tests/let-syntax/let_syntax.ml
+++ b/testsuite/tests/let-syntax/let_syntax.ml
@@ -587,7 +587,8 @@ val let_not_principal : unit = ()
 Line 3, characters 9-10:
 3 |     let+ A = A.A in
              ^
-Error: Unbound constructor A
+Warning 18: this type-based constructor disambiguation is not principal.
+val let_not_principal : unit = ()
 |}];;
 
 module And_not_principal = struct
@@ -615,7 +616,8 @@ val and_not_principal : A.t -> A.t -> unit = <fun>
 Line 5, characters 11-12:
 5 |       and+ A = y in
                ^
-Error: Unbound constructor A
+Warning 18: this type-based constructor disambiguation is not principal.
+val and_not_principal : A.t -> A.t -> unit = <fun>
 |}];;
 
 module Let_not_propagated = struct
@@ -713,12 +715,11 @@ let bad_location =
 [%%expect{|
 val bad_location : 'a GADT_ordering.is_point -> 'a -> int = <fun>
 |}, Principal{|
-Line 4, characters 6-10:
-4 |       let+ Is_point = is_point
-          ^^^^
-Error: This pattern matches values of type
-         GADT_ordering.point GADT_ordering.is_point * GADT_ordering.point
-       but a pattern was expected which matches values of type
-         a GADT_ordering.is_point * a
-       Type GADT_ordering.point is not compatible with type a
+Line 5, characters 13-14:
+5 |       and+ { x; y } = a in
+                 ^
+Error: The record field x belongs to the type GADT_ordering.point
+       but is mixed here with fields of type a = GADT_ordering.point
+       This instance of GADT_ordering.point is ambiguous:
+       it would escape the scope of its equation
 |}];;

--- a/testsuite/tests/typing-core-bugs/const_int_hint.ml
+++ b/testsuite/tests/typing-core-bugs/const_int_hint.ml
@@ -75,12 +75,6 @@ Line 2, characters 4-5:
 Error: This pattern matches values of type int
        but a pattern was expected which matches values of type int32
   Hint: Did you mean `0l'?
-|}, Principal{|
-Line 2, characters 4-5:
-2 |   | 0 -> 0l
-        ^
-Error: This pattern matches values of type int
-       but a pattern was expected which matches values of type int32
 |}]
 
 let _ : int64 -> int64 = function

--- a/testsuite/tests/typing-gadts/or_patterns.ml
+++ b/testsuite/tests/typing-gadts/or_patterns.ml
@@ -124,13 +124,6 @@ Line 4, characters 4-11:
 Error: This pattern matches values of type bool t
        but a pattern was expected which matches values of type int t
        Type bool is not compatible with type int
-|}, Principal{|
-Line 4, characters 4-17:
-4 |   | BoolLit, true -> ()
-        ^^^^^^^^^^^^^
-Error: This pattern matches values of type bool t * bool
-       but a pattern was expected which matches values of type int t * int
-       Type bool is not compatible with type int
 |}]
 
 let simple_annotated (type a) (t : a t) (a : a) =
@@ -391,13 +384,6 @@ Line 4, characters 4-11:
         ^^^^^^^
 Error: This pattern matches values of type bool t
        but a pattern was expected which matches values of type int t
-       Type bool is not compatible with type int
-|}, Principal{|
-Line 4, characters 4-14:
-4 |   | BoolLit, x -> x
-        ^^^^^^^^^^
-Error: This pattern matches values of type bool t * 'a
-       but a pattern was expected which matches values of type int t * 'b
        Type bool is not compatible with type int
 |}]
 

--- a/testsuite/tests/typing-gadts/pr6690.ml
+++ b/testsuite/tests/typing-gadts/pr6690.ml
@@ -34,19 +34,6 @@ Error: This pattern matches values of type
        but a pattern was expected which matches values of type
          ($0, $0 * insert, visit_action) context
        The type constructor $0 would escape its scope
-|}, Principal{|
-type 'a visit_action
-type insert
-type 'a local_visit_action
-type ('a, 'result, 'visit_action) context =
-    Local : ('a, 'a * insert, 'a local_visit_action) context
-  | Global : ('a, 'a, 'a visit_action) context
-Line 15, characters 4-9:
-15 |   | Local -> fun _ -> raise Exit
-         ^^^^^
-Error: This pattern matches values of type
-         ($0, $0 * insert, visit_action) context
-       The type constructor $0 would escape its scope
 |}];;
 
 let vexpr (type visit_action)
@@ -64,13 +51,6 @@ Error: This pattern matches values of type
        but a pattern was expected which matches values of type
          ($'a, $'a * insert, visit_action) context
        The type constructor $'a would escape its scope
-|}, Principal{|
-Line 4, characters 4-9:
-4 |   | Local -> fun _ -> raise Exit
-        ^^^^^
-Error: This pattern matches values of type
-         ($0, $0 * insert, visit_action) context
-       The type constructor $0 would escape its scope
 |}];;
 
 let vexpr (type result) (type visit_action)

--- a/testsuite/tests/typing-gadts/pr7222.ml
+++ b/testsuite/tests/typing-gadts/pr7222.ml
@@ -27,16 +27,4 @@ Error: This pattern matches values of type ($Cons_'x, 'a -> $Cons_'x) elt
        but a pattern was expected which matches values of type
          ($Cons_'x, 'a -> $'b -> nil) elt
        The type constructor $'b would escape its scope
-|}, Principal{|
-type +'a n = private int
-type nil = private Nil_type
-type (_, _) elt =
-    Elt_fine : 'nat n -> ('l, 'nat * 'l) elt
-  | Elt : 'nat n -> ('l, 'nat -> 'l) elt
-type _ t = Nil : nil t | Cons : ('x, 'fx) elt * 'x t -> 'fx t
-Line 9, characters 6-22:
-9 |   let Cons(Elt dim, _) = sh in ()
-          ^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type ('a -> $0 -> nil) t
-       The type constructor $0 would escape its scope
 |}];;

--- a/testsuite/tests/typing-gadts/pr7902.ml
+++ b/testsuite/tests/typing-gadts/pr7902.ml
@@ -30,12 +30,4 @@ Error: This pattern matches values of type ('a * 'a, 'a * 'a) segment
        but a pattern was expected which matches values of type
          ('a * 'a, 'a) segment
        The type variable 'a occurs inside 'a * 'a
-|}, Principal{|
-Line 3, characters 4-18:
-3 |   | SegCons SegNil -> 0
-        ^^^^^^^^^^^^^^
-Error: This pattern matches values of type ('a, 'a * 'a) segment
-       but a pattern was expected which matches values of type
-         ('a, 'a) segment
-       The type variable 'a occurs inside 'a * 'a
 |}]

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -197,6 +197,13 @@ let g2 (type x) (e : (x, _ option) eq) (x : x) : int option =
    let Refl = e in x;;
 [%%expect{|
 val g2 : ('x, int option) eq -> 'x -> int option = <fun>
+|}, Principal{|
+Line 3, characters 7-11:
+3 |    let Refl = e in x;;
+           ^^^^
+Warning 18: typing this pattern requires considering x and int option as equal.
+But the knowledge of these types is not principal.
+val g2 : ('x, int option) eq -> 'x -> int option = <fun>
 |}]
 
 (* Issues with "principal level" *)

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -212,6 +212,10 @@ let () =
   | [ { a = 3; _ } ; { b = F; _ }] -> ()
   | _ -> ();;
 [%%expect{|
+Line 3, characters 27-28:
+3 |   | [ { a = 3; _ } ; { b = F; _ }] -> ()
+                               ^
+Warning 18: This introduction of a GADT equation is not principal.
 |}]
 
 let () =
@@ -264,6 +268,10 @@ let () =
   | [ { a = 3; _ }; { b = Refl3 ; _ }] -> ()
   | _ -> ()
 [%%expect{|
+Line 3, characters 26-31:
+3 |   | [ { a = 3; _ }; { b = Refl3 ; _ }] -> ()
+                              ^^^^^
+Warning 18: This introduction of a GADT equation is not principal.
 |}]
 
 let () =
@@ -271,6 +279,10 @@ let () =
   | [ { b = Refl3 ; _ }; { a = 3; _ } ] -> ()
   | _ -> ()
 [%%expect{|
+Line 3, characters 12-17:
+3 |   | [ { b = Refl3 ; _ }; { a = 3; _ } ] -> ()
+                ^^^^^
+Warning 18: This introduction of a GADT equation is not principal.
 |}]
 
 
@@ -304,6 +316,10 @@ let foo x =
   | { x = (x : int); eq = Refl3 } -> x
 ;;
 [%%expect{|
+Line 3, characters 26-31:
+3 |   | { x = (x : int); eq = Refl3 } -> x
+                              ^^^^^
+Warning 18: This introduction of a GADT equation is not principal.
 val foo : int foo -> int = <fun>
 |}]
 
@@ -326,6 +342,10 @@ let foo x =
   | { x = (x : string); eq = Refl3 } -> x
 ;;
 [%%expect{|
+Line 3, characters 29-34:
+3 |   | { x = (x : string); eq = Refl3 } -> x
+                                 ^^^^^
+Warning 18: This introduction of a GADT equation is not principal.
 val foo : string foo -> string = <fun>
 |}]
 

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -46,11 +46,13 @@ val f : 'a t -> 'a -> int = <fun>
 Line 4, characters 4-10:
 4 |   | IntLit, n -> n+1
         ^^^^^^
-Warning 18: This introduction of a GADT equation is not principal.
+Warning 18: typing this pattern requires considering int and a as equal.
+But the knowledge of these types is not principal.
 Line 5, characters 4-11:
 5 |   | BoolLit, b -> 1
         ^^^^^^^
-Warning 18: This introduction of a GADT equation is not principal.
+Warning 18: typing this pattern requires considering bool and a as equal.
+But the knowledge of these types is not principal.
 val f : 'a t -> 'a -> int = <fun>
 |}]
 
@@ -66,7 +68,8 @@ val f : 'a t -> 'a -> int = <fun>
 Line 4, characters 4-10:
 4 |   | IntLit, n -> n+1
         ^^^^^^
-Warning 18: This introduction of a GADT equation is not principal.
+Warning 18: typing this pattern requires considering int and a as equal.
+But the knowledge of these types is not principal.
 val f : 'a t -> 'a -> int = <fun>
 |}]
 
@@ -128,10 +131,13 @@ let f1 t1 =
   | AB -> true
   | MAB -> false;;
 [%%expect{|
+val f1 : unit ab M.t -> bool = <fun>
+|}, Principal{|
 Line 4, characters 4-7:
 4 |   | MAB -> false;;
         ^^^
-Warning 18: 'some error message here' is not principal.
+Warning 18: typing this pattern requires considering unit M.mab and unit ab as equal.
+But the knowledge of these types is not principal.
 val f1 : unit ab M.t -> bool = <fun>
 |}]
 
@@ -146,11 +152,13 @@ val f2 : 'x M.t -> bool = <fun>
 Line 4, characters 4-6:
 4 |   | AB -> true
         ^^
-Warning 18: This introduction of a GADT equation is not principal.
+Warning 18: typing this pattern requires considering unit ab and x as equal.
+But the knowledge of these types is not principal.
 Line 5, characters 4-7:
 5 |   | MAB -> false;;
         ^^^
-Warning 18: This introduction of a GADT equation is not principal.
+Warning 18: typing this pattern requires considering unit M.mab and x as equal.
+But the knowledge of these types is not principal.
 val f2 : 'x M.t -> bool = <fun>
 |}]
 
@@ -166,7 +174,8 @@ val f3 : unit ab M.t -> bool = <fun>
 Line 5, characters 4-7:
 5 |   | MAB -> false;;
         ^^^
-Warning 18: 'some error message here' is not principal.
+Warning 18: typing this pattern requires considering unit M.mab and unit ab as equal.
+But the knowledge of these types is not principal.
 val f3 : unit ab M.t -> bool = <fun>
 |}]
 
@@ -212,10 +221,12 @@ let () =
   | [ { a = 3; _ } ; { b = F; _ }] -> ()
   | _ -> ();;
 [%%expect{|
+|}, Principal{|
 Line 3, characters 27-28:
 3 |   | [ { a = 3; _ } ; { b = F; _ }] -> ()
                                ^
-Warning 18: This introduction of a GADT equation is not principal.
+Warning 18: typing this pattern requires considering Foo.t and int as equal.
+But the knowledge of these types is not principal.
 |}]
 
 let () =
@@ -245,6 +256,12 @@ let () =
   | _ -> ()
 ;;
 [%%expect{|
+|}, Principal{|
+Line 3, characters 26-31:
+3 |   | [ { a = 3; _ }; { b = Refl3 ; _ }] -> ()
+                              ^^^^^
+Warning 18: typing this pattern requires considering int and Foo.t as equal.
+But the knowledge of these types is not principal.
 |}]
 
 let () =
@@ -253,6 +270,12 @@ let () =
   | _ -> ()
 ;;
 [%%expect{|
+|}, Principal{|
+Line 3, characters 12-17:
+3 |   | [ { b = Refl3 ; _ }; { a = 3; _ } ] -> ()
+                ^^^^^
+Warning 18: typing this pattern requires considering int and Foo.t as equal.
+But the knowledge of these types is not principal.
 |}]
 
 (* Unify with 'a first *)
@@ -268,10 +291,12 @@ let () =
   | [ { a = 3; _ }; { b = Refl3 ; _ }] -> ()
   | _ -> ()
 [%%expect{|
+|}, Principal{|
 Line 3, characters 26-31:
 3 |   | [ { a = 3; _ }; { b = Refl3 ; _ }] -> ()
                               ^^^^^
-Warning 18: This introduction of a GADT equation is not principal.
+Warning 18: typing this pattern requires considering int and Foo.t as equal.
+But the knowledge of these types is not principal.
 |}]
 
 let () =
@@ -279,10 +304,12 @@ let () =
   | [ { b = Refl3 ; _ }; { a = 3; _ } ] -> ()
   | _ -> ()
 [%%expect{|
+|}, Principal{|
 Line 3, characters 12-17:
 3 |   | [ { b = Refl3 ; _ }; { a = 3; _ } ] -> ()
                 ^^^^^
-Warning 18: This introduction of a GADT equation is not principal.
+Warning 18: typing this pattern requires considering int and Foo.t as equal.
+But the knowledge of these types is not principal.
 |}]
 
 
@@ -309,6 +336,13 @@ let foo x =
 ;;
 [%%expect{|
 val foo : M.t foo -> M.t = <fun>
+|}, Principal{|
+Line 3, characters 18-23:
+3 |   | { x = x; eq = Refl3 } -> x
+                      ^^^^^
+Warning 18: typing this pattern requires considering M.t and N.t as equal.
+But the knowledge of these types is not principal.
+val foo : M.t foo -> M.t = <fun>
 |}]
 
 let foo x =
@@ -316,10 +350,13 @@ let foo x =
   | { x = (x : int); eq = Refl3 } -> x
 ;;
 [%%expect{|
+val foo : int foo -> int = <fun>
+|}, Principal{|
 Line 3, characters 26-31:
 3 |   | { x = (x : int); eq = Refl3 } -> x
                               ^^^^^
-Warning 18: This introduction of a GADT equation is not principal.
+Warning 18: typing this pattern requires considering M.t and N.t as equal.
+But the knowledge of these types is not principal.
 val foo : int foo -> int = <fun>
 |}]
 
@@ -335,6 +372,19 @@ Error: This pattern matches values of type N.t foo
        but a pattern was expected which matches values of type 'a
        This instance of M.t is ambiguous:
        it would escape the scope of its equation
+|}, Principal{|
+Line 3, characters 26-31:
+3 |   | { x = (x : N.t); eq = Refl3 } -> x
+                              ^^^^^
+Warning 18: typing this pattern requires considering M.t and N.t as equal.
+But the knowledge of these types is not principal.
+Line 3, characters 4-33:
+3 |   | { x = (x : N.t); eq = Refl3 } -> x
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This pattern matches values of type N.t foo
+       but a pattern was expected which matches values of type 'a
+       This instance of M.t is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 let foo x =
@@ -342,10 +392,13 @@ let foo x =
   | { x = (x : string); eq = Refl3 } -> x
 ;;
 [%%expect{|
+val foo : string foo -> string = <fun>
+|}, Principal{|
 Line 3, characters 29-34:
 3 |   | { x = (x : string); eq = Refl3 } -> x
                                  ^^^^^
-Warning 18: This introduction of a GADT equation is not principal.
+Warning 18: typing this pattern requires considering M.t and string as equal.
+But the knowledge of these types is not principal.
 val foo : string foo -> string = <fun>
 |}]
 

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -42,13 +42,6 @@ let f (type a) t (x : a) =
 ;;
 [%%expect{|
 val f : 'a t -> 'a -> int = <fun>
-|}, Principal{|
-Line 5, characters 4-14:
-5 |   | BoolLit, b -> 1
-        ^^^^^^^^^^
-Error: This pattern matches values of type bool t * a
-       but a pattern was expected which matches values of type int t * a
-       Type bool is not compatible with type int
 |}]
 
 let f (type a) t (x : a) =
@@ -59,13 +52,6 @@ let f (type a) t (x : a) =
 ;;
 [%%expect{|
 val f : 'a t -> 'a -> int = <fun>
-|}, Principal{|
-Line 4, characters 4-13:
-4 |   | IntLit, n -> n+1
-        ^^^^^^^^^
-Error: This pattern matches values of type int t * a
-       but a pattern was expected which matches values of type a t * a
-       Type int is not compatible with type a
 |}]
 
 
@@ -82,13 +68,6 @@ Line 4, characters 4-11:
         ^^^^^^^
 Error: This pattern matches values of type bool t
        but a pattern was expected which matches values of type int t
-       Type bool is not compatible with type int
-|}, Principal{|
-Line 4, characters 4-14:
-4 |   | BoolLit, b -> 1
-        ^^^^^^^^^^
-Error: This pattern matches values of type bool t * a
-       but a pattern was expected which matches values of type int t * a
        Type bool is not compatible with type int
 |}]
 
@@ -134,13 +113,6 @@ let f1 t1 =
   | MAB -> false;;
 [%%expect{|
 val f1 : unit ab M.t -> bool = <fun>
-|}, Principal{|
-Line 4, characters 4-7:
-4 |   | MAB -> false;;
-        ^^^
-Error: This pattern matches values of type unit M.mab M.t
-       but a pattern was expected which matches values of type unit ab M.t
-       Type unit M.mab is not compatible with type unit ab
 |}]
 
 let f2 (type x) t1 =
@@ -150,13 +122,6 @@ let f2 (type x) t1 =
   | MAB -> false;;
 [%%expect{|
 val f2 : 'x M.t -> bool = <fun>
-|}, Principal{|
-Line 5, characters 4-7:
-5 |   | MAB -> false;;
-        ^^^
-Error: This pattern matches values of type unit M.mab M.t
-       but a pattern was expected which matches values of type unit ab M.t
-       Type unit M.mab is not compatible with type unit ab
 |}]
 
 (* This should warn *)
@@ -167,13 +132,6 @@ let f3 t1 =
   | MAB -> false;;
 [%%expect{|
 val f3 : unit ab M.t -> bool = <fun>
-|}, Principal{|
-Line 5, characters 4-7:
-5 |   | MAB -> false;;
-        ^^^
-Error: This pattern matches values of type unit M.mab M.t
-       but a pattern was expected which matches values of type unit ab M.t
-       Type unit M.mab is not compatible with type unit ab
 |}]
 
 (* Example showing we need to warn when any part of the type is non generic. *)
@@ -194,12 +152,6 @@ let g2 (type x) (e : (x, _ option) eq) (x : x) : int option =
    let Refl = e in x;;
 [%%expect{|
 val g2 : ('x, int option) eq -> 'x -> int option = <fun>
-|}, Principal{|
-Line 3, characters 7-11:
-3 |    let Refl = e in x;;
-           ^^^^
-Error: This pattern matches values of type (x, $0 option) eq
-       The type constructor $0 would escape its scope
 |}]
 
 (* Issues with "principal level" *)
@@ -330,13 +282,6 @@ Line 3, characters 4-33:
 Error: This pattern matches values of type N.t foo
        but a pattern was expected which matches values of type 'a
        This instance of M.t is ambiguous:
-       it would escape the scope of its equation
-|}, Principal{|
-Line 3, characters 4-33:
-3 |   | { x = (x : N.t); eq = Refl3 } -> x
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type N.t foo
-       This instance of N.t is ambiguous:
        it would escape the scope of its equation
 |}]
 

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -128,6 +128,10 @@ let f1 t1 =
   | AB -> true
   | MAB -> false;;
 [%%expect{|
+Line 4, characters 4-7:
+4 |   | MAB -> false;;
+        ^^^
+Warning 18: 'some error message here' is not principal.
 val f1 : unit ab M.t -> bool = <fun>
 |}]
 
@@ -157,6 +161,12 @@ let f3 t1 =
   | AB -> true
   | MAB -> false;;
 [%%expect{|
+val f3 : unit ab M.t -> bool = <fun>
+|}, Principal{|
+Line 5, characters 4-7:
+5 |   | MAB -> false;;
+        ^^^
+Warning 18: 'some error message here' is not principal.
 val f3 : unit ab M.t -> bool = <fun>
 |}]
 

--- a/testsuite/tests/typing-gadts/principality-and-gadts.ml
+++ b/testsuite/tests/typing-gadts/principality-and-gadts.ml
@@ -42,6 +42,16 @@ let f (type a) t (x : a) =
 ;;
 [%%expect{|
 val f : 'a t -> 'a -> int = <fun>
+|}, Principal{|
+Line 4, characters 4-10:
+4 |   | IntLit, n -> n+1
+        ^^^^^^
+Warning 18: This introduction of a GADT equation is not principal.
+Line 5, characters 4-11:
+5 |   | BoolLit, b -> 1
+        ^^^^^^^
+Warning 18: This introduction of a GADT equation is not principal.
+val f : 'a t -> 'a -> int = <fun>
 |}]
 
 let f (type a) t (x : a) =
@@ -51,6 +61,12 @@ let f (type a) t (x : a) =
   | _, _ -> 1
 ;;
 [%%expect{|
+val f : 'a t -> 'a -> int = <fun>
+|}, Principal{|
+Line 4, characters 4-10:
+4 |   | IntLit, n -> n+1
+        ^^^^^^
+Warning 18: This introduction of a GADT equation is not principal.
 val f : 'a t -> 'a -> int = <fun>
 |}]
 
@@ -121,6 +137,16 @@ let f2 (type x) t1 =
   | AB -> true
   | MAB -> false;;
 [%%expect{|
+val f2 : 'x M.t -> bool = <fun>
+|}, Principal{|
+Line 4, characters 4-6:
+4 |   | AB -> true
+        ^^
+Warning 18: This introduction of a GADT equation is not principal.
+Line 5, characters 4-7:
+5 |   | MAB -> false;;
+        ^^^
+Warning 18: This introduction of a GADT equation is not principal.
 val f2 : 'x M.t -> bool = <fun>
 |}]
 

--- a/testsuite/tests/typing-gadts/test.ml
+++ b/testsuite/tests/typing-gadts/test.ml
@@ -385,12 +385,6 @@ Line 5, characters 28-29:
                                 ^
 Error: This variant pattern is expected to have type a
        The constructor B does not belong to type a
-|}, Principal{|
-Line 5, characters 28-29:
-5 |   let f = function A -> 1 | B -> 2
-                                ^
-Error: This pattern matches values of type b
-       but a pattern was expected which matches values of type a
 |}];;
 
 module PR6849 = struct

--- a/testsuite/tests/typing-misc/disambiguate_principality.ml
+++ b/testsuite/tests/typing-misc/disambiguate_principality.ml
@@ -113,10 +113,15 @@ Line 4, characters 4-15:
 Warning 11: this match case is unused.
 val h : M.r -> unit = <fun>
 |}, Principal{|
-Line 4, characters 6-9:
+Line 4, characters 4-15:
 4 |   | { lbl = _ } -> ()
-          ^^^
-Error: Unbound record field lbl
+        ^^^^^^^^^^^
+Warning 18: this type-based record disambiguation is not principal.
+Line 4, characters 4-15:
+4 |   | { lbl = _ } -> ()
+        ^^^^^^^^^^^
+Warning 11: this match case is unused.
+val h : M.r -> unit = <fun>
 |}]
 
 let i x =
@@ -137,6 +142,16 @@ let j x =
   | { lbl = _ } -> ()
 ;;
 [%%expect{|
+Line 4, characters 4-15:
+4 |   | { lbl = _ } -> ()
+        ^^^^^^^^^^^
+Warning 12: this sub-pattern is unused.
+val j : M.r -> unit = <fun>
+|}, Principal{|
+Line 4, characters 4-15:
+4 |   | { lbl = _ } -> ()
+        ^^^^^^^^^^^
+Warning 18: this type-based record disambiguation is not principal.
 Line 4, characters 4-15:
 4 |   | { lbl = _ } -> ()
         ^^^^^^^^^^^
@@ -187,10 +202,15 @@ Line 4, characters 4-30:
 Warning 11: this match case is unused.
 val n : M.r ref -> unit = <fun>
 |}, Principal{|
-Line 4, characters 19-22:
+Line 4, characters 17-28:
 4 |   | { contents = { lbl = _ } } -> ()
-                       ^^^
-Error: Unbound record field lbl
+                     ^^^^^^^^^^^
+Warning 18: this type-based record disambiguation is not principal.
+Line 4, characters 4-30:
+4 |   | { contents = { lbl = _ } } -> ()
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 11: this match case is unused.
+val n : M.r ref -> unit = <fun>
 |}]
 
 let o x =
@@ -211,6 +231,16 @@ let p x =
   | { contents = { lbl = _ } } -> ()
 ;;
 [%%expect{|
+Line 4, characters 4-30:
+4 |   | { contents = { lbl = _ } } -> ()
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 12: this sub-pattern is unused.
+val p : M.r ref -> unit = <fun>
+|}, Principal{|
+Line 4, characters 17-28:
+4 |   | { contents = { lbl = _ } } -> ()
+                     ^^^^^^^^^^^
+Warning 18: this type-based record disambiguation is not principal.
 Line 4, characters 4-30:
 4 |   | { contents = { lbl = _ } } -> ()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -364,7 +394,8 @@ val h : M.t -> unit = <fun>
 Line 4, characters 4-5:
 4 |   | B -> ()
         ^
-Error: Unbound constructor B
+Warning 18: this type-based constructor disambiguation is not principal.
+val h : M.t -> unit = <fun>
 |}]
 
 let i x =
@@ -385,6 +416,12 @@ let j x =
   | B -> ()
 ;;
 [%%expect{|
+val j : M.t -> unit = <fun>
+|}, Principal{|
+Line 4, characters 4-5:
+4 |   | B -> ()
+        ^
+Warning 18: this type-based constructor disambiguation is not principal.
 val j : M.t -> unit = <fun>
 |}]
 
@@ -434,7 +471,12 @@ val n : M.t ref -> unit = <fun>
 Line 4, characters 17-18:
 4 |   | { contents = A } -> ()
                      ^
-Error: Unbound constructor A
+Warning 18: this type-based constructor disambiguation is not principal.
+Line 4, characters 4-20:
+4 |   | { contents = A } -> ()
+        ^^^^^^^^^^^^^^^^
+Warning 11: this match case is unused.
+val n : M.t ref -> unit = <fun>
 |}]
 
 let o x =
@@ -455,6 +497,16 @@ let p x =
   | { contents = A } -> ()
 ;;
 [%%expect{|
+Line 4, characters 4-20:
+4 |   | { contents = A } -> ()
+        ^^^^^^^^^^^^^^^^
+Warning 12: this sub-pattern is unused.
+val p : M.t ref -> unit = <fun>
+|}, Principal{|
+Line 4, characters 17-18:
+4 |   | { contents = A } -> ()
+                     ^
+Warning 18: this type-based constructor disambiguation is not principal.
 Line 4, characters 4-20:
 4 |   | { contents = A } -> ()
         ^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-misc/pr7937.ml
+++ b/testsuite/tests/typing-misc/pr7937.ml
@@ -15,13 +15,11 @@ Error: This expression has type bool but an expression was expected of type
        Types for tag `X are incompatible
 |}, Principal{|
 type 'a r = 'a constraint 'a = [< `X of int & 'a ]
-Line 3, characters 30-31:
+Line 3, characters 35-39:
 3 | let f: 'a. 'a r -> 'a r = fun x -> true;;
-                                  ^
-Error: This pattern matches values of type
+                                       ^^^^
+Error: This expression has type bool but an expression was expected of type
          ([< `X of 'b & 'a & 'c & 'd & 'e ] as 'a) r
-       but a pattern was expected which matches values of type
-         ([< `X of int & 'f ] as 'f) r
        Types for tag `X are incompatible
 |}]
 
@@ -34,13 +32,12 @@ Error: This expression has type int ref
        but an expression was expected of type ([< `X of int & 'a ] as 'a) r
        Types for tag `X are incompatible
 |}, Principal{|
-Line 1, characters 30-31:
+Line 1, characters 35-51:
 1 | let g: 'a. 'a r -> 'a r = fun x -> { contents = 0 };;
-                                  ^
-Error: This pattern matches values of type
+                                       ^^^^^^^^^^^^^^^^
+Error: This expression has type int ref
+       but an expression was expected of type
          ([< `X of 'b & 'a & 'c & 'd & 'e ] as 'a) r
-       but a pattern was expected which matches values of type
-         ([< `X of int & 'f ] as 'f) r
        Types for tag `X are incompatible
 |}]
 
@@ -53,14 +50,6 @@ Error: This pattern matches values of type bool
        but a pattern was expected which matches values of type
          ([< `X of int & 'a ] as 'a) r
        Types for tag `X are incompatible
-|}, Principal{|
-Line 1, characters 32-36:
-1 | let h: 'a. 'a r -> _ = function true | false -> ();;
-                                    ^^^^
-Error: This pattern matches values of type bool
-       but a pattern was expected which matches values of type
-         ([< `X of 'b & 'a & 'c ] as 'a) r
-       Types for tag `X are incompatible
 |}]
 
 
@@ -72,13 +61,5 @@ Line 1, characters 32-48:
 Error: This pattern matches values of type int ref
        but a pattern was expected which matches values of type
          ([< `X of int & 'a ] as 'a) r
-       Types for tag `X are incompatible
-|}, Principal{|
-Line 1, characters 32-48:
-1 | let i: 'a. 'a r -> _ = function { contents = 0 } -> ();;
-                                    ^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type int ref
-       but a pattern was expected which matches values of type
-         ([< `X of 'b & 'a & 'c ] as 'a) r
        Types for tag `X are incompatible
 |}]

--- a/testsuite/tests/typing-poly/pr9603.ml
+++ b/testsuite/tests/typing-poly/pr9603.ml
@@ -33,16 +33,4 @@ Error: This expression has type
        is not compatible with type < left : 'left0; right : 'right0 > pair
        The method left has type 'a, but the expected method type was 'left
        The universal variable 'left would escape its scope
-|}, Principal{|
-Line 4, characters 6-7:
-4 | = fun x -> x
-          ^
-Error: This pattern matches values of type
-         < m : 'left 'right. < left : 'left; right : 'right > pair >
-       but a pattern was expected which matches values of type
-         < m : 'left 'right. < left : 'left; right : 'right > pair >
-       Type < left : 'left; right : 'right > pair = 'a * 'b
-       is not compatible with type < left : 'left0; right : 'right0 > pair
-       The method left has type 'a, but the expected method type was 'left
-       The universal variable 'left would escape its scope
 |}]

--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.ml
@@ -382,6 +382,35 @@ Warning 57: Ambiguous or-pattern variables under guard;
 variables x,y may match different arguments. (See manual section 9.5)
 val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t2 -> int =
   <fun>
+|}, Principal{|
+Line 2, characters 4-5:
+2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
+        ^
+Warning 41: A belongs to several types: t2 t
+The first one was selected. Please disambiguate if this is wrong.
+Line 2, characters 24-25:
+2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
+                            ^
+Warning 41: A belongs to several types: t2 t
+The first one was selected. Please disambiguate if this is wrong.
+Line 2, characters 42-43:
+2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
+                                              ^
+Warning 41: B belongs to several types: t2 t
+The first one was selected. Please disambiguate if this is wrong.
+Lines 1-3, characters 41-10:
+1 | .........................................function
+2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
+3 |   | _ -> 2
+Warning 4: this pattern-matching is fragile.
+It will remain exhaustive when constructors are added to type t2.
+Line 2, characters 4-56:
+2 |   | A (x as z,(0 as y))|A (0 as y as z,x)|B (x,(y as z)) when g x (y+z) -> 1
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 57: Ambiguous or-pattern variables under guard;
+variables x,y may match different arguments. (See manual section 9.5)
+val ambiguous_xy_but_not_ambiguous_z : (int -> int -> bool) -> t2 -> int =
+  <fun>
 |}]
 
 (* Regression test against an erroneous simplification of the algorithm

--- a/testsuite/tests/typing-warnings/pr6872.ml
+++ b/testsuite/tests/typing-warnings/pr6872.ml
@@ -62,13 +62,13 @@ it will not compile with OCaml 4.00 or earlier.
 Line 1, characters 26-27:
 1 | function Not_found -> 1 | A -> 2 | _ -> 3
                               ^
-Warning 41: A belongs to several types: a exn
-The first one was selected. Please disambiguate if this is wrong.
+Warning 18: this type-based constructor disambiguation is not principal.
 Line 1, characters 26-27:
 1 | function Not_found -> 1 | A -> 2 | _ -> 3
                               ^
-Error: This pattern matches values of type a
-       but a pattern was expected which matches values of type exn
+Warning 42: this use of A relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
+- : exn -> int = <fun>
 |}]
 ;;
 

--- a/testsuite/tests/typing-warnings/records.ml
+++ b/testsuite/tests/typing-warnings/records.ml
@@ -122,16 +122,25 @@ Line 6, characters 8-9:
 Warning 27: unused variable x.
 module F2 : sig val f : M1.t -> int end
 |}, Principal{|
+Line 6, characters 8-9:
+6 |        {x; y} -> y + y
+            ^
+Warning 42: this use of x relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
+Line 6, characters 11-12:
+6 |        {x; y} -> y + y
+               ^
+Warning 42: this use of y relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Line 6, characters 7-13:
 6 |        {x; y} -> y + y
            ^^^^^^
-Warning 41: these field labels belong to several types: M1.u M1.t
-The first one was selected. Please disambiguate if this is wrong.
-Line 6, characters 7-13:
+Warning 18: this type-based record disambiguation is not principal.
+Line 6, characters 8-9:
 6 |        {x; y} -> y + y
-           ^^^^^^
-Error: This pattern matches values of type M1.u
-       but a pattern was expected which matches values of type M1.t
+            ^
+Warning 27: unused variable x.
+module F2 : sig val f : M1.t -> int end
 |}]
 
 (* Use type information with modules*)
@@ -633,23 +642,22 @@ module P6235' :
     val f : u -> string
   end
 |}, Principal{|
+Line 7, characters 11-14:
+7 |     |`Key {loc} -> loc
+               ^^^
+Warning 42: this use of loc relies on type-directed disambiguation,
+it will not compile with OCaml 4.00 or earlier.
 Line 7, characters 10-15:
 7 |     |`Key {loc} -> loc
               ^^^^^
-Warning 41: these field labels belong to several types: v t
-The first one was selected. Please disambiguate if this is wrong.
-Line 7, characters 10-15:
-7 |     |`Key {loc} -> loc
-              ^^^^^
-Warning 9: the following labels are not bound in this record pattern:
-x
-Either bind these labels explicitly or add '; _' to the pattern.
-Line 7, characters 5-15:
-7 |     |`Key {loc} -> loc
-         ^^^^^^^^^^
-Error: This pattern matches values of type [? `Key of v ]
-       but a pattern was expected which matches values of type u
-       Types for tag `Key are incompatible
+Warning 18: this type-based record disambiguation is not principal.
+module P6235' :
+  sig
+    type t = { loc : string; }
+    type v = { loc : string; x : int; }
+    type u = [ `Key of t ]
+    val f : u -> string
+  end
 |}]
 
 (** no candidates after filtering;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1074,6 +1074,22 @@ let compute_univars ty =
     try !(TypeHash.find node_univars ty) with Not_found -> TypeSet.empty
 
 
+let fully_generic ty =
+  let rec aux acc ty =
+    acc &&
+    let ty = repr ty in
+    ty.level < lowest_level || (
+      ty.level = generic_level && (
+        mark_type_node ty;
+        fold_type_expr aux true ty
+      )
+    )
+  in
+  let res = aux true ty in
+  unmark_type ty;
+  res
+
+
                               (*******************)
                               (*  Instantiation  *)
                               (*******************)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2742,7 +2742,14 @@ and unify3 env t1 t1' t2 t2' =
       | (Tconstr (_,_,_), _) | (_, Tconstr (_,_,_)) when !umode = Pattern ->
           reify env t1';
           reify env t2';
-          if can_generate_equations () then mcomp !env t1' t2'
+          if can_generate_equations () then (
+            mcomp !env t1' t2';
+            match using_only_principal_information t1' t2' with
+            | Ok () -> ()
+            | Error loc ->
+              Location.prerr_warning loc
+                (Warnings.Not_principal "'some error message here'")
+          )
       | (Tobject (fi1, nm1), Tobject (fi2, _)) ->
           unify_fields env fi1 fi2;
           (* Type [t2'] may have been instantiated by [unify_fields] *)
@@ -2764,7 +2771,14 @@ and unify3 env t1 t1' t2 t2' =
               backtrack snap;
               reify env t1';
               reify env t2';
-              if can_generate_equations () then mcomp !env t1' t2'
+              if can_generate_equations () then (
+                mcomp !env t1' t2';
+                match using_only_principal_information t1' t2' with
+                | Ok () -> ()
+                | Error loc ->
+                  Location.prerr_warning loc
+                    (Warnings.Not_principal "'some error message here'")
+              )
           end
       | (Tfield(f,kind,_,rem), Tnil) | (Tnil, Tfield(f,kind,_,rem)) ->
           begin match field_kind_repr kind with

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -191,6 +191,8 @@ val limited_generalize: type_expr -> type_expr -> unit
         (* Only generalize some part of the type
            Make the remaining of the type non-generalizable *)
 
+val fully_generic: type_expr -> bool
+
 val check_scope_escape : Env.t -> int -> type_expr -> unit
         (* [check_scope_escape env lvl ty] ensures that [ty] could be raised
            to the level [lvl] without any scope escape.

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -252,8 +252,8 @@ val enforce_constraints: Env.t -> type_expr -> unit
 val unify: Env.t -> type_expr -> type_expr -> unit
         (* Unify the two types given. Raise [Unify] if not possible. *)
 val unify_gadt:
-        equations_level:int -> allow_recursive:bool ->
-        Env.t ref -> type_expr -> type_expr -> unit
+        loc:Location.t -> equations_level:int -> principal_level:int ->
+        allow_recursive:bool -> Env.t ref -> type_expr -> type_expr -> unit
         (* Unify the two types given and update the environment with the
            local constraints. Raise [Unify] if not possible. *)
 val unify_var: Env.t -> type_expr -> type_expr -> unit

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -18,6 +18,8 @@
 open Asttypes
 open Types
 
+module TypePairs : Hashtbl.S with type key = type_expr * type_expr
+
 module Unification_trace: sig
   (** Unification traces are used to explain unification errors
       when printing error messages *)
@@ -252,10 +254,11 @@ val enforce_constraints: Env.t -> type_expr -> unit
 val unify: Env.t -> type_expr -> type_expr -> unit
         (* Unify the two types given. Raise [Unify] if not possible. *)
 val unify_gadt:
-        loc:Location.t -> equations_level:int -> principal_level:int ->
-        allow_recursive:bool -> Env.t ref -> type_expr -> type_expr -> unit
+        equations_level:int -> allow_recursive:bool ->
+        Env.t ref -> type_expr -> type_expr -> unit TypePairs.t
         (* Unify the two types given and update the environment with the
-           local constraints. Raise [Unify] if not possible. *)
+           local constraints. Raise [Unify] if not possible.
+           Returns the pairs of types that have been equated.  *)
 val unify_var: Env.t -> type_expr -> type_expr -> unit
         (* Same as [unify], but allow free univars when first type
            is a variable. *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1495,7 +1495,10 @@ and type_pat_aux
       let expected_type =
         try
           let (p0, p, _) = extract_concrete_variant !env expected_ty in
-            Some (p0, p, true)
+          let principal =
+            (repr expected_ty).level = generic_level || not !Clflags.principal
+          in
+            Some (p0, p, principal)
         with Not_found -> None
       in
       let constr =
@@ -1627,7 +1630,10 @@ and type_pat_aux
           let ty = instance expected_ty in
           end_def ();
           generalize_structure ty;
-          Some (p0, p, true), ty
+          let principal =
+            (repr expected_ty).level = generic_level || not !Clflags.principal
+          in
+          Some (p0, p, principal), ty
         with Not_found -> None, newvar ()
       in
       let type_label_pat (label_lid, label, sarg) k =
@@ -4568,7 +4574,7 @@ and type_cases
     get_current_level ()
   in
   let take_partial_instance =
-    if !Clflags.principal || erase_either
+    if erase_either
     then Some false else None
   in
   begin_def (); (* propagation of the argument *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -309,7 +309,7 @@ let unify_pat_types ?(refine = None) loc env ty ty' =
     | Some allow_recursive ->
         unify_gadt ~loc
           ~equations_level:(get_gadt_equations_level ())
-          ~principal_level:(get_gadt_equations_level ())
+          ~principal_level:(get_current_level ())
           ~allow_recursive env ty ty'
     | None ->
         unify !env ty ty'

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1581,7 +1581,7 @@ and type_pat_aux
           TypePairs.iter (fun (t1, t2) () ->
             generalize_structure t1;
             generalize_structure t2;
-            if t1.level <> generic_level || t2.level <> generic_level then
+            if not (fully_generic t1 && fully_generic t2) then
               let msg =
                 Format.asprintf
                   "typing this pattern requires considering@ %a@ and@ %a@ as \

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -307,7 +307,9 @@ let unify_pat_types ?(refine = None) loc env ty ty' =
   try
     match refine with
     | Some allow_recursive ->
-        unify_gadt ~equations_level:(get_gadt_equations_level ())
+        unify_gadt ~loc
+          ~equations_level:(get_gadt_equations_level ())
+          ~principal_level:(get_gadt_equations_level ())
           ~allow_recursive env ty ty'
     | None ->
         unify !env ty ty'


### PR DESCRIPTION
This is extracted from #1675.

Note: as said before, the erasure still happens when polymorphic variants appear in the patterns, and the type of the scrutinee contains a `Reither`. It is left as future work to see whether this approach could be extended to polymorphic variants as well.

See the first part of https://github.com/ocaml/ocaml/pull/1675#issuecomment-402725995 for a discussion  of the changes in the testsuite.