### PR TITLE
Octal character literals and apostrophes in ocamlyacc actions

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,6 +25,10 @@ Working version
 - #1901: Fix lexing of character literals in comments
   (Pieter Goetschalckx, review by Damien Doligez)
 
+- #1932: Allow octal escape sequences and identifiers containing apostrophes
+  in ocamlyacc actions and comments.
+  (Pieter Goetschalckx, review by Damien Doligez)
+
 - #2288: Move middle end code from [Asmgen] to [Clambda_middle_end] and
   [Flambda_middle_end].  Run [Un_anf] from the middle end, not [Cmmgen].
   (Mark Shinwell, review by Pierre Chambart)

--- a/testsuite/tests/tool-lexyacc/grammar.mly
+++ b/testsuite/tests/tool-lexyacc/grammar.mly
@@ -3,6 +3,11 @@
 %{
 open Syntax
 open Gram_aux
+
+(* test f' '"' *)
+let () =
+  let f' = ignore in
+  f' '"'
 %}
 
 %token <string> Tident

--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -234,6 +234,14 @@ int process_apostrophe(FILE *const f)
             && cptr[4] == '\'') {
         fwrite(cptr, 1, 5, f);
         cptr += 5;
+    } else if (cptr[0] == '\\'
+            && cptr[1] == 'o'
+            && cptr[2] >= '0' && cptr[2] <= '3'
+            && cptr[3] >= '0' && cptr[3] <= '7'
+            && cptr[4] >= '0' && cptr[4] <= '7'
+            && cptr[5] == '\'') {
+        fwrite(cptr, 1, 6, f);
+        cptr += 6;
     } else if (cptr[0] == '\\' && cptr[2] == '\'') {
         fwrite(cptr, 1, 3, f);
         cptr += 3;

--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -370,6 +370,9 @@ static void process_comment(FILE *const f) {
                 process_open_curly_bracket(f);
                 continue;
             default:
+                if (In_bitmap(caml_ident_start, c)) {
+                  while (In_bitmap(caml_ident_body, *cptr)) cptr++;
+                }
                 continue;
             }
         }
@@ -608,6 +611,12 @@ loop:
         goto loop;
     default:
         putc(c, f);
+        if (In_bitmap(caml_ident_start, c)) {
+          while (In_bitmap(caml_ident_body, *cptr)) {
+            putc(*cptr, f);
+            cptr++;
+          }
+        }
         need_newline = 1;
         goto loop;
     }


### PR DESCRIPTION
The same fix as #1901 and #1912 for ocamlyacc.