### PR TITLE
Tidy flexlink bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@
 
 # The main Makefile
 
+ROOTDIR=.
+
 include config/Makefile
 include Makefile.common
 
@@ -285,16 +287,12 @@ FLEXDLL_SUBMODULE_PRESENT := $(wildcard flexdll/Makefile)
 ifeq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
   BOOT_FLEXLINK_CMD =
   FLEXDLL_DIR =
-  FLEXLINK_ENV =
 else
   BOOT_FLEXLINK_CMD = FLEXLINK_CMD="../boot/ocamlrun ../flexdll/flexlink.exe"
-  # FLEXLINK_ENV must have a space at the end
-  FLEXLINK_ENV = OCAML_FLEXLINK="boot/ocamlrun flexdll/flexlink.exe" #
   FLEXDLL_DIR=$(if $(wildcard flexdll/flexdll_*.$(O)),+flexdll)
 endif
 else
   FLEXDLL_DIR =
-  FLEXLINK_ENV =
 endif
 
 # The configuration file

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 # The main Makefile
 
-ROOTDIR=.
+ROOTDIR = .
 
 include config/Makefile
 include Makefile.common
@@ -289,7 +289,7 @@ ifeq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
   FLEXDLL_DIR =
 else
   BOOT_FLEXLINK_CMD = FLEXLINK_CMD="../boot/ocamlrun ../flexdll/flexlink.exe"
-  FLEXDLL_DIR=$(if $(wildcard flexdll/flexdll_*.$(O)),+flexdll)
+  FLEXDLL_DIR = $(if $(wildcard flexdll/flexdll_*.$(O)),+flexdll)
 endif
 else
   FLEXDLL_DIR =

--- a/Makefile
+++ b/Makefile
@@ -545,9 +545,10 @@ flexlink: flexdll/Makefile
 flexlink.opt:
 	cd flexdll && \
 	mv flexlink.exe flexlink && \
-	$(MAKE) OCAML_FLEXLINK="../boot/ocamlrun ./flexlink" MSVC_DETECT=0 \
+	($(MAKE) OCAML_FLEXLINK="../boot/ocamlrun ./flexlink" MSVC_DETECT=0 \
 	           OCAML_CONFIG_FILE=../config/Makefile \
-	           OCAMLOPT="../ocamlopt.opt -I ../stdlib" flexlink.exe && \
+	           OCAMLOPT="../ocamlopt.opt -I ../stdlib" flexlink.exe || \
+	 (mv flexlink flexlink.exe && false)) && \
 	mv flexlink.exe flexlink.opt && \
 	mv flexlink flexlink.exe
 

--- a/Makefile
+++ b/Makefile
@@ -881,7 +881,7 @@ partialclean::
 
 ocamlc.opt: compilerlibs/ocamlcommon.cmxa compilerlibs/ocamlbytecomp.cmxa \
             $(BYTESTART:.cmo=.cmx)
-	$(FLEXLINK_ENV)$(CAMLOPT) $(LINKFLAGS) -o $@ $^ -cclib "$(BYTECCLIBS)"
+	$(CAMLOPT_CMD) $(LINKFLAGS) -o $@ $^ -cclib "$(BYTECCLIBS)"
 
 partialclean::
 	rm -f ocamlc.opt
@@ -895,7 +895,7 @@ partialclean::
 
 ocamlopt.opt: compilerlibs/ocamlcommon.cmxa compilerlibs/ocamloptcomp.cmxa \
               $(OPTSTART:.cmo=.cmx)
-	$(FLEXLINK_ENV)$(CAMLOPT) $(LINKFLAGS) -o $@ $^
+	$(CAMLOPT_CMD) $(LINKFLAGS) -o $@ $^
 
 partialclean::
 	rm -f ocamlopt.opt
@@ -1288,7 +1288,7 @@ ocamlnat$(EXE): compilerlibs/ocamlcommon.cmxa compilerlibs/ocamloptcomp.cmxa \
     compilerlibs/ocamlbytecomp.cmxa \
     compilerlibs/ocamlopttoplevel.cmxa \
     $(OPTTOPLEVELSTART:.cmo=.cmx)
-	$(FLEXLINK_ENV)$(CAMLOPT) $(LINKFLAGS) -linkall -o $@ $^
+	$(CAMLOPT_CMD) $(LINKFLAGS) -linkall -o $@ $^
 
 partialclean::
 	rm -f ocamlnat$(EXE)

--- a/Makefile
+++ b/Makefile
@@ -283,15 +283,18 @@ BOOT_FLEXLINK_CMD=
 ifeq "$(UNIX_OR_WIN32)" "win32"
 FLEXDLL_SUBMODULE_PRESENT := $(wildcard flexdll/Makefile)
 ifeq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
-  BOOT_FLEXLINK_CMD=
-  FLEXDLL_DIR=
+  BOOT_FLEXLINK_CMD =
+  FLEXDLL_DIR =
+  FLEXLINK_ENV =
 else
   BOOT_FLEXLINK_CMD = FLEXLINK_CMD="../boot/ocamlrun ../flexdll/flexlink.exe"
-  CAMLOPT := OCAML_FLEXLINK="boot/ocamlrun flexdll/flexlink.exe" $(CAMLOPT)
+  # FLEXLINK_ENV must have a space at the end
+  FLEXLINK_ENV = OCAML_FLEXLINK="boot/ocamlrun flexdll/flexlink.exe" #
   FLEXDLL_DIR=$(if $(wildcard flexdll/flexdll_*.$(O)),+flexdll)
 endif
 else
-  FLEXDLL_DIR=
+  FLEXDLL_DIR =
+  FLEXLINK_ENV =
 endif
 
 # The configuration file
@@ -879,7 +882,7 @@ partialclean::
 
 ocamlc.opt: compilerlibs/ocamlcommon.cmxa compilerlibs/ocamlbytecomp.cmxa \
             $(BYTESTART:.cmo=.cmx)
-	$(CAMLOPT) $(LINKFLAGS) -o $@ $^ -cclib "$(BYTECCLIBS)"
+	$(FLEXLINK_ENV)$(CAMLOPT) $(LINKFLAGS) -o $@ $^ -cclib "$(BYTECCLIBS)"
 
 partialclean::
 	rm -f ocamlc.opt
@@ -893,7 +896,7 @@ partialclean::
 
 ocamlopt.opt: compilerlibs/ocamlcommon.cmxa compilerlibs/ocamloptcomp.cmxa \
               $(OPTSTART:.cmo=.cmx)
-	$(CAMLOPT) $(LINKFLAGS) -o $@ $^
+	$(FLEXLINK_ENV)$(CAMLOPT) $(LINKFLAGS) -o $@ $^
 
 partialclean::
 	rm -f ocamlopt.opt
@@ -1286,7 +1289,7 @@ ocamlnat$(EXE): compilerlibs/ocamlcommon.cmxa compilerlibs/ocamloptcomp.cmxa \
     compilerlibs/ocamlbytecomp.cmxa \
     compilerlibs/ocamlopttoplevel.cmxa \
     $(OPTTOPLEVELSTART:.cmo=.cmx)
-	$(CAMLOPT) $(LINKFLAGS) -linkall -o $@ $^
+	$(FLEXLINK_ENV)$(CAMLOPT) $(LINKFLAGS) -linkall -o $@ $^
 
 partialclean::
 	rm -f ocamlnat$(EXE)

--- a/Makefile.common
+++ b/Makefile.common
@@ -28,3 +28,16 @@ INSTALL_BINDIR = $(DESTDIR)$(BINDIR)
 INSTALL_LIBDIR = $(DESTDIR)$(LIBDIR)
 INSTALL_STUBLIBDIR = $(DESTDIR)$(STUBLIBDIR)
 INSTALL_MANDIR = $(DESTDIR)$(MANDIR)
+
+ifeq "$(UNIX_OR_WIN32)" "win32"
+FLEXDLL_SUBMODULE_PRESENT := $(wildcard $(ROOTDIR)/flexdll/Makefile)
+ifeq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
+  FLEXLINK_ENV =
+else
+  # FLEXLINK_ENV must have a space at the end
+  FLEXLINK_ENV = \
+    OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
+endif
+else
+FLEXLINK_ENV =
+endif

--- a/Makefile.common
+++ b/Makefile.common
@@ -31,13 +31,23 @@ INSTALL_MANDIR = $(DESTDIR)$(MANDIR)
 
 ifeq "$(UNIX_OR_WIN32)" "win32"
 FLEXDLL_SUBMODULE_PRESENT := $(wildcard $(ROOTDIR)/flexdll/Makefile)
+else
+FLEXDLL_SUBMODULE_PRESENT =
+endif
+
 ifeq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
   FLEXLINK_ENV =
+  CAMLOPT_CMD = $(CAMLOPT)
+  OCAMLOPT_CMD = $(OCAMLOPT)
+  MKLIB_CMD = $(MKLIB)
+  ocamlc_cmd = $(ocamlc)
+  ocamlopt_cmd = $(ocamlopt)
 else
-  # FLEXLINK_ENV must have a space at the end
   FLEXLINK_ENV = \
-    OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
-endif
-else
-FLEXLINK_ENV =
+    OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe"
+  CAMLOPT_CMD = $(FLEXLINK_ENV) $(CAMLOPT)
+  OCAMLOPT_CMD = $(FLEXLINK_ENV) $(OCAMLOPT)
+  MKLIB_CMD = $(FLEXLINK_ENV) $(MKLIB)
+  ocamlc_cmd = $(FLEXLINK_ENV) $(ocamlc)
+  ocamlopt_cmd = $(FLEXLINK_ENV) $(ocamlopt)
 endif

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -15,7 +15,7 @@
 
 # The lexer generator
 
-ROOTDIR=..
+ROOTDIR = ..
 
 include $(ROOTDIR)/config/Makefile
 include $(ROOTDIR)/Makefile.common
@@ -23,15 +23,15 @@ include $(ROOTDIR)/Makefile.common
 CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 CAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc
 
-CAMLC=$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -strict-sequence -nostdlib \
-      -I $(ROOTDIR)/boot -use-prims $(ROOTDIR)/runtime/primitives
-CAMLOPT=$(CAMLRUN) $(ROOTDIR)/ocamlopt -nostdlib -I $(ROOTDIR)/stdlib
-COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
-          -safe-string -strict-sequence -strict-formats -bin-annot
-LINKFLAGS=
-YACCFLAGS=-v
-CAMLLEX=$(CAMLRUN) $(ROOTDIR)/boot/ocamllex
-CAMLDEP=$(CAMLRUN) $(ROOTDIR)/tools/ocamldep
+CAMLC = $(CAMLRUN) $(ROOTDIR)/boot/ocamlc -strict-sequence -nostdlib \
+        -I $(ROOTDIR)/boot -use-prims $(ROOTDIR)/runtime/primitives
+CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt -nostdlib -I $(ROOTDIR)/stdlib
+COMPFLAGS = $(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
+            -safe-string -strict-sequence -strict-formats -bin-annot
+LINKFLAGS =
+YACCFLAGS = -v
+CAMLLEX = $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
+CAMLDEP = $(CAMLRUN) $(ROOTDIR)/tools/ocamldep
 
 
 OBJS=cset.cmo syntax.cmo parser.cmo lexer.cmo table.cmo lexgen.cmo \

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -20,14 +20,6 @@ ROOTDIR=..
 include $(ROOTDIR)/config/Makefile
 include $(ROOTDIR)/Makefile.common
 
-ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
-FLEXLINK_ENV =
-else
-# FLEXLINK_ENV must have a space at the end
-FLEXLINK_ENV = \
-  OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
-endif
-
 CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 CAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc
 

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -21,9 +21,11 @@ CAMLYACC ?= ../yacc/ocamlyacc
 ROOTDIR=..
 
 ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
-export OCAML_FLEXLINK:=
+FLEXLINK_ENV =
 else
-export OCAML_FLEXLINK:=$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe
+# FLEXLINK_ENV must have a space at the end
+FLEXLINK_ENV = \
+  OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
 endif
 
 CAMLC=$(CAMLRUN) ../boot/ocamlc -strict-sequence -nostdlib -I ../boot \
@@ -49,7 +51,7 @@ ocamllex: $(OBJS)
 	$(CAMLC) $(LINKFLAGS) -compat-32 -o ocamllex $(OBJS)
 
 ocamllex.opt: $(OBJS:.cmo=.cmx)
-	$(CAMLOPT) -o ocamllex.opt $(OBJS:.cmo=.cmx)
+	$(FLEXLINK_ENV)$(CAMLOPT) -o ocamllex.opt $(OBJS:.cmo=.cmx)
 
 clean::
 	rm -f ocamllex ocamllex.opt

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -14,11 +14,11 @@
 #**************************************************************************
 
 # The lexer generator
-include ../config/Makefile
-CAMLRUN ?= ../boot/ocamlrun
-CAMLYACC ?= ../yacc/ocamlyacc
 
 ROOTDIR=..
+
+include $(ROOTDIR)/config/Makefile
+include $(ROOTDIR)/Makefile.common
 
 ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
 FLEXLINK_ENV =
@@ -28,15 +28,18 @@ FLEXLINK_ENV = \
   OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
 endif
 
-CAMLC=$(CAMLRUN) ../boot/ocamlc -strict-sequence -nostdlib -I ../boot \
-      -use-prims ../runtime/primitives
-CAMLOPT=$(CAMLRUN) ../ocamlopt -nostdlib -I ../stdlib
+CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
+CAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc
+
+CAMLC=$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -strict-sequence -nostdlib \
+      -I $(ROOTDIR)/boot -use-prims $(ROOTDIR)/runtime/primitives
+CAMLOPT=$(CAMLRUN) $(ROOTDIR)/ocamlopt -nostdlib -I $(ROOTDIR)/stdlib
 COMPFLAGS=$(INCLUDES) -absname -w +a-4-9-41-42-44-45-48 -warn-error A \
           -safe-string -strict-sequence -strict-formats -bin-annot
 LINKFLAGS=
 YACCFLAGS=-v
-CAMLLEX=$(CAMLRUN) ../boot/ocamllex
-CAMLDEP=$(CAMLRUN) ../tools/ocamldep
+CAMLLEX=$(CAMLRUN) $(ROOTDIR)/boot/ocamllex
+CAMLDEP=$(CAMLRUN) $(ROOTDIR)/tools/ocamldep
 
 
 OBJS=cset.cmo syntax.cmo parser.cmo lexer.cmo table.cmo lexgen.cmo \

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -46,7 +46,7 @@ ocamllex: $(OBJS)
 	$(CAMLC) $(LINKFLAGS) -compat-32 -o ocamllex $(OBJS)
 
 ocamllex.opt: $(OBJS:.cmo=.cmx)
-	$(FLEXLINK_ENV)$(CAMLOPT) -o ocamllex.opt $(OBJS:.cmo=.cmx)
+	$(CAMLOPT_CMD) -o ocamllex.opt $(OBJS:.cmo=.cmx)
 
 clean::
 	rm -f ocamllex ocamllex.opt

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -67,7 +67,8 @@ ifeq "$(UNIX_OR_WIN32)" "unix"
     OCAMLDOC_RUN=$(OCAMLRUN) ./$(OCAMLDOC)
   endif
 else # Windows
-  OCAMLDOC_RUN = CAML_LD_LIBRARY_PATH="../otherlibs/win32unix;../otherlibs/str" $(OCAMLRUN) ./$(OCAMLDOC)
+  OCAMLDOC_RUN = \
+    CAML_LD_LIBRARY_PATH="$(ROOTDIR)/otherlibs/win32unix;$(ROOTDIR)/otherlibs/str" $(OCAMLRUN) ./$(OCAMLDOC)
 endif
 
 OCAMLDOC_OPT=$(OCAMLDOC).opt
@@ -353,17 +354,17 @@ test:
 test_stdlib:
 	$(MKDIR) $@
 	$(OCAMLDOC_RUN) -html -colorize-code -sort -d $@ $(INCLUDES) -dump $@/stdlib.odoc -keep-code \
-	../stdlib/*.mli \
-	../otherlibs/$(UNIXLIB)/unix.mli \
-	../otherlibs/str/str.mli
+	$(ROOTDIR)/stdlib/*.mli \
+	$(ROOTDIR)/otherlibs/$(UNIXLIB)/unix.mli \
+	$(ROOTDIR)/otherlibs/str/str.mli
 
 .PHONY: test_stdlib_code
 test_stdlib_code:
 	$(MKDIR) $@
 	$(OCAMLDOC_RUN) -html -colorize-code -sort -d $@ $(INCLUDES) -dump $@/stdlib.odoc -keep-code \
-	`ls ../stdlib/*.ml | grep -v Labels` \
-	../otherlibs/$(UNIXLIB)/unix.ml \
-	../otherlibs/str/str.ml
+	`ls $(ROOTDIR)/stdlib/*.ml | grep -v Labels` \
+	$(ROOTDIR)/otherlibs/$(UNIXLIB)/unix.ml \
+	$(ROOTDIR)/otherlibs/str/str.ml
 
 .PHONY: test_framed
 test_framed:
@@ -374,17 +375,17 @@ test_framed:
 test_latex:
 	$(MKDIR) $@
 	$(OCAMLDOC_RUN) -latex -sort -o $@/test.tex -d $@ $(INCLUDES) odoc*.ml \
-	        odoc*.mli test2.txt ../stdlib/*.mli ../otherlibs/unix/unix.mli
+	        odoc*.mli test2.txt $(ROOTDIR)/stdlib/*.mli $(ROOTDIR)/otherlibs/unix/unix.mli
 
 .PHONY: test_latex_simple
 test_latex_simple:
 	$(MKDIR) $@
 	$(OCAMLDOC_RUN) -latex -sort -o $@/test.tex -d $@ $(INCLUDES) \
 	-latextitle 6,subsection -latextitle 7,subsubection \
-	../stdlib/hashtbl.mli \
-	../stdlib/arg.mli \
-	../otherlibs/$(UNIXLIB)/unix.mli \
-	../stdlib/map.mli
+	$(ROOTDIR)/stdlib/hashtbl.mli \
+	$(ROOTDIR)/stdlib/arg.mli \
+	$(ROOTDIR)/otherlibs/$(UNIXLIB)/unix.mli \
+	$(ROOTDIR)/stdlib/map.mli
 
 .PHONY: test_man
 test_man:
@@ -423,9 +424,9 @@ autotest_stdlib:
 	$(MKDIR) $@
 	$(OCAMLDOC_RUN) -g autotest/odoc_test.cmo\
 	$(INCLUDES) -keep-code \
-	../stdlib/*.mli \
-	../otherlibs/$(UNIXLIB)/unix.mli \
-	../otherlibs/str/str.mli
+	$(ROOTDIR)/stdlib/*.mli \
+	$(ROOTDIR)/otherlibs/$(UNIXLIB)/unix.mli \
+	$(ROOTDIR)/otherlibs/str/str.mli
 
 
 # odoc rules :
@@ -436,22 +437,22 @@ odoc:
 	rm -rf odoc
 	$(MKDIR) odoc
 	# .cmti --> .odoc
-	for fn in ../stdlib/stdlib*.cmti; do \
-	  odoc compile $(INCLUDES) --package stdlib ../stdlib/$$fn; \
+	for fn in $(ROOTDIR)/stdlib/stdlib*.cmti; do \
+	  odoc compile $(INCLUDES) --package stdlib $(ROOTDIR)/stdlib/$$fn; \
 	done
 	for lib in str bigarray; do \
-	  odoc compile $(INCLUDES) --package $$lib ../otherlibs/$$lib/$$lib.cmti; \
+	  odoc compile $(INCLUDES) --package $$lib $(ROOTDIR)/otherlibs/$$lib/$$lib.cmti; \
 	done
-	odoc compile $(INCLUDES) --package unix ../otherlibs/$(UNIXLIB)/unix.cmti
-	for fn in ../parsing/*.cmti; do \
-	  odoc compile $(INCLUDES) --package parsing ../parsing/$$fn; \
+	odoc compile $(INCLUDES) --package unix $(ROOTDIR)/otherlibs/$(UNIXLIB)/unix.cmti
+	for fn in $(ROOTDIR)/parsing/*.cmti; do \
+	  odoc compile $(INCLUDES) --package parsing $(ROOTDIR)/parsing/$$fn; \
 	done
 	# .odoc --> .html
-	odoc html $(INCLUDES) --output-dir odoc ../stdlib/stdlib.odoc
+	odoc html $(INCLUDES) --output-dir odoc $(ROOTDIR)/stdlib/stdlib.odoc
 	for lib in str bigarray $(UNIXLIB); do \
-	  odoc html $(INCLUDES) --output-dir odoc ../otherlibs/$$lib/$$lib.odoc; \
+	  odoc html $(INCLUDES) --output-dir odoc $(ROOTDIR)/otherlibs/$$lib/$$lib.odoc; \
 	done
-	for fn in ../parsing/*.odoc; do \
+	for fn in $(ROOTDIR)/parsing/*.odoc; do \
 	  odoc html $(INCLUDES) --output-dir odoc $$fn; \
 	done
 	for d in odoc/*; do \

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -208,7 +208,7 @@ $(OCAMLDOC): $(EXECMOFILES)
 	$(OCAMLC) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_BCLIBRARIES) $^
 
 $(OCAMLDOC_OPT): $(EXECMXFILES)
-	$(FLEXLINK_ENV)$(OCAMLOPT) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_NCLIBRARIES) $^
+	$(OCAMLOPT_CMD) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_NCLIBRARIES) $^
 
 $(OCAMLDOC_LIBCMA): $(LIBCMOFILES)
 	$(OCAMLC) -a -o $@ $(LINKFLAGS) $^
@@ -260,7 +260,7 @@ odoc_see_lexer.ml: odoc_see_lexer.mll
 	$(OCAMLOPT) $(OCAMLPP) $(COMPFLAGS) -c $<
 
 .ml.cmxs:
-	$(FLEXLINK_ENV)$(OCAMLOPT) -shared -o $@ $(OCAMLPP) $(COMPFLAGS) $<
+	$(OCAMLOPT_CMD) -shared -o $@ $(OCAMLPP) $(COMPFLAGS) $<
 
 .mll.ml:
 	$(OCAMLLEX) $<

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -23,15 +23,17 @@ OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc
 
 STDLIBFLAGS = -nostdlib -I $(ROOTDIR)/stdlib
 OCAMLC    = $(OCAMLRUN) $(ROOTDIR)/ocamlc $(STDLIBFLAGS)
-ifeq "$(UNIX_OR_WIN32)" "unix"
 OCAMLOPT  = $(OCAMLRUN) $(ROOTDIR)/ocamlopt $(STDLIBFLAGS)
+ifeq "$(UNIX_OR_WIN32)" "unix"
+FLEXLINK_ENV =
 else # Windows
   ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
-    FLEXLINK_ENV=
+  FLEXLINK_ENV =
   else
-    FLEXLINK_ENV=OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe"
+  # FLEXLINK_ENV must have a space at the end
+  FLEXLINK_ENV = \
+    OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
   endif
-  OCAMLOPT = $(FLEXLINK_ENV) $(OCAMLRUN) $(ROOTDIR)/ocamlopt $(STDLIBFLAGS)
 endif
 OCAMLDEP  = $(OCAMLRUN) $(ROOTDIR)/tools/ocamldep -slash
 OCAMLLEX  = $(OCAMLRUN) $(ROOTDIR)/boot/ocamllex
@@ -216,7 +218,7 @@ $(OCAMLDOC): $(EXECMOFILES)
 	$(OCAMLC) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_BCLIBRARIES) $^
 
 $(OCAMLDOC_OPT): $(EXECMXFILES)
-	$(OCAMLOPT) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_NCLIBRARIES) $^
+	$(FLEXLINK_ENV)$(OCAMLOPT) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_NCLIBRARIES) $^
 
 $(OCAMLDOC_LIBCMA): $(LIBCMOFILES)
 	$(OCAMLC) -a -o $@ $(LINKFLAGS) $^
@@ -268,7 +270,7 @@ odoc_see_lexer.ml: odoc_see_lexer.mll
 	$(OCAMLOPT) $(OCAMLPP) $(COMPFLAGS) -c $<
 
 .ml.cmxs:
-	$(OCAMLOPT) -shared -o $@ $(OCAMLPP) $(COMPFLAGS) $<
+	$(FLEXLINK_ENV)$(OCAMLOPT) -shared -o $@ $(OCAMLPP) $(COMPFLAGS) $<
 
 .mll.ml:
 	$(OCAMLLEX) $<

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -24,17 +24,6 @@ OCAMLYACC ?= $(ROOTDIR)/yacc/ocamlyacc
 STDLIBFLAGS = -nostdlib -I $(ROOTDIR)/stdlib
 OCAMLC    = $(OCAMLRUN) $(ROOTDIR)/ocamlc $(STDLIBFLAGS)
 OCAMLOPT  = $(OCAMLRUN) $(ROOTDIR)/ocamlopt $(STDLIBFLAGS)
-ifeq "$(UNIX_OR_WIN32)" "unix"
-FLEXLINK_ENV =
-else # Windows
-  ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
-  FLEXLINK_ENV =
-  else
-  # FLEXLINK_ENV must have a space at the end
-  FLEXLINK_ENV = \
-    OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
-  endif
-endif
 OCAMLDEP  = $(OCAMLRUN) $(ROOTDIR)/tools/ocamldep -slash
 OCAMLLEX  = $(OCAMLRUN) $(ROOTDIR)/boot/ocamllex
 # TODO: figure out whether the DEBUG lines the following preprocessor removes

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -18,23 +18,16 @@
 ROOTDIR=..
 
 include $(ROOTDIR)/config/Makefile
+include $(ROOTDIR)/Makefile.common
 
 ifeq "$(UNIX_OR_WIN32)" "win32"
   unix := false
   ocamlsrcdir := $(shell echo "$(abspath $(shell pwd)/..)"|cygpath -w -f - \
     | sed 's/\\/\\\\\\\\/g')
-  ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
-    FLEXLINK_ENV =
-  else
-    # FLEXLINK_ENV must have a space at the end
-    FLEXLINK_ENV = \
-      OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
-  endif
   mkexe := $(MKEXE_ANSI) -link $(OC_LDFLAGS)
 else
   unix := true
   ocamlsrcdir := $(abspath $(shell pwd)/..)
-  FLEXLINK_ENV =
   mkexe := $(MKEXE)
 endif
 

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -22,15 +22,16 @@ ifeq "$(UNIX_OR_WIN32)" "win32"
   ocamlsrcdir := $(shell echo "$(abspath $(shell pwd)/..)"|cygpath -w -f - \
     | sed 's/\\/\\\\\\\\/g')
   ifeq "$(wildcard ../flexdll/Makefile)" ""
-    FLEXLINK_ENV=
+    FLEXLINK_ENV =
   else
-    FLEXLINK_ENV=OCAML_FLEXLINK="../boot/ocamlrun ../flexdll/flexlink.exe"
+    # FLEXLINK_ENV must have a space at the end
+    FLEXLINK_ENV = OCAML_FLEXLINK="../boot/ocamlrun ../flexdll/flexlink.exe" #
   endif
   mkexe := $(MKEXE_ANSI) -link $(OC_LDFLAGS)
 else
   unix := true
   ocamlsrcdir := $(abspath $(shell pwd)/..)
-  FLEXLINK_ENV=
+  FLEXLINK_ENV =
   mkexe := $(MKEXE)
 endif
 
@@ -158,9 +159,9 @@ flags := -g -nostdlib $(include_directories) \
   -strict-sequence -safe-string -strict-formats \
   -w +a-4-9-41-42-44-45-48 -warn-error A
 
-ocamlc := $(FLEXLINK_ENV) ../runtime/ocamlrun ../ocamlc $(flags)
+ocamlc := ../runtime/ocamlrun ../ocamlc $(flags)
 
-ocamlopt := $(FLEXLINK_ENV) ../runtime/ocamlrun ../ocamlopt $(flags)
+ocamlopt := ../runtime/ocamlrun ../ocamlopt $(flags)
 
 ocamldep := ../runtime/ocamlrun ../tools/ocamldep -slash
 
@@ -178,13 +179,13 @@ allopt: ocamltest.opt$(EXE)
 opt.opt: allopt
 
 ocamltest$(EXE): $(bytecode_modules)
-	$(ocamlc) -custom ocamlcommon.cma -o $@ $^
+	$(FLEXLINK_ENV)$(ocamlc) -custom ocamlcommon.cma -o $@ $^
 
 %.cmo: %.ml
 	$(ocamlc) -c $<
 
 ocamltest.opt$(EXE): $(native_modules)
-	$(ocamlopt) ocamlcommon.cmxa -o $@ $^
+	$(FLEXLINK_ENV)$(ocamlopt) ocamlcommon.cmxa -o $@ $^
 
 %.cmx: %.ml
 	$(ocamlopt) -c $<

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -15,17 +15,20 @@
 
 # The Makefile for ocamltest
 
-include ../config/Makefile
+ROOTDIR=..
+
+include $(ROOTDIR)/config/Makefile
 
 ifeq "$(UNIX_OR_WIN32)" "win32"
   unix := false
   ocamlsrcdir := $(shell echo "$(abspath $(shell pwd)/..)"|cygpath -w -f - \
     | sed 's/\\/\\\\\\\\/g')
-  ifeq "$(wildcard ../flexdll/Makefile)" ""
+  ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
     FLEXLINK_ENV =
   else
     # FLEXLINK_ENV must have a space at the end
-    FLEXLINK_ENV = OCAML_FLEXLINK="../boot/ocamlrun ../flexdll/flexlink.exe" #
+    FLEXLINK_ENV = \
+      OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
   endif
   mkexe := $(MKEXE_ANSI) -link $(OC_LDFLAGS)
 else
@@ -61,7 +64,7 @@ else
 WITH_OCAMLDEBUG := false
 endif
 
-OC_CPPFLAGS += -I../runtime -DCAML_INTERNALS
+OC_CPPFLAGS += -I$(ROOTDIR)/runtime -DCAML_INTERNALS
 
 run := run_$(UNIX_OR_WIN32)
 
@@ -151,7 +154,8 @@ bytecode_modules := $(o_files) $(cmo_files)
 
 native_modules := $(o_files) $(cmx_files)
 
-directories := ../utils ../parsing ../stdlib ../compilerlibs
+directories := $(ROOTDIR)/utils $(ROOTDIR)/parsing $(ROOTDIR)/stdlib \
+               $(ROOTDIR)/compilerlibs
 
 include_directories := $(addprefix -I , $(directories))
 
@@ -159,15 +163,15 @@ flags := -g -nostdlib $(include_directories) \
   -strict-sequence -safe-string -strict-formats \
   -w +a-4-9-41-42-44-45-48 -warn-error A
 
-ocamlc := ../runtime/ocamlrun ../ocamlc $(flags)
+ocamlc := $(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/ocamlc $(flags)
 
-ocamlopt := ../runtime/ocamlrun ../ocamlopt $(flags)
+ocamlopt := $(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/ocamlopt $(flags)
 
-ocamldep := ../runtime/ocamlrun ../tools/ocamldep -slash
+ocamldep := $(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/tools/ocamldep -slash
 
-ocamllex := ../runtime/ocamlrun ../lex/ocamllex
+ocamllex := $(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/lex/ocamllex
 
-ocamlyacc := ../yacc/ocamlyacc
+ocamlyacc := $(ROOTDIR)/yacc/ocamlyacc
 
 ocamlcdefaultflags :=
 

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -175,13 +175,13 @@ allopt: ocamltest.opt$(EXE)
 opt.opt: allopt
 
 ocamltest$(EXE): $(bytecode_modules)
-	$(FLEXLINK_ENV)$(ocamlc) -custom ocamlcommon.cma -o $@ $^
+	$(ocamlc_cmd) -custom ocamlcommon.cma -o $@ $^
 
 %.cmo: %.ml
 	$(ocamlc) -c $<
 
 ocamltest.opt$(EXE): $(native_modules)
-	$(FLEXLINK_ENV)$(ocamlopt) ocamlcommon.cmxa -o $@ $^
+	$(ocamlopt_cmd) ocamlcommon.cmxa -o $@ $^
 
 %.cmx: %.ml
 	$(ocamlopt) -c $<

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -15,7 +15,7 @@
 
 # The Makefile for ocamltest
 
-ROOTDIR=..
+ROOTDIR = ..
 
 include $(ROOTDIR)/config/Makefile
 include $(ROOTDIR)/Makefile.common
@@ -147,8 +147,7 @@ bytecode_modules := $(o_files) $(cmo_files)
 
 native_modules := $(o_files) $(cmx_files)
 
-directories := $(ROOTDIR)/utils $(ROOTDIR)/parsing $(ROOTDIR)/stdlib \
-               $(ROOTDIR)/compilerlibs
+directories := $(addprefix $(ROOTDIR)/,utils parsing stdlib compilerlibs)
 
 include_directories := $(addprefix -I , $(directories))
 

--- a/otherlibs/Makefile
+++ b/otherlibs/Makefile
@@ -21,14 +21,6 @@ include $(ROOTDIR)/Makefile.common
 
 CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 
-ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
-FLEXLINK_ENV =
-else
-# FLEXLINK_ENV must have a space at the end
-FLEXLINK_ENV = \
-  OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
-endif
-
 CAMLC=$(CAMLRUN) $(ROOTDIR)/ocamlc -nostdlib -I $(ROOTDIR)/stdlib
 CAMLOPT=$(CAMLRUN) $(ROOTDIR)/ocamlopt -nostdlib \
         -I $(ROOTDIR)/stdlib

--- a/otherlibs/Makefile
+++ b/otherlibs/Makefile
@@ -68,11 +68,10 @@ $(LIBNAME).cmxa: $(CAMLOBJS_NAT)
 	         $(CAMLOBJS_NAT) $(LINKOPTS)
 
 $(LIBNAME).cmxs: $(LIBNAME).cmxa lib$(CLIBNAME).$(A)
-	$(FLEXLINK_ENV)$(CAMLOPT) -shared -o $(LIBNAME).cmxs -I . \
-	                                     $(LIBNAME).cmxa
+	$(CAMLOPT_CMD) -shared -o $(LIBNAME).cmxs -I . $(LIBNAME).cmxa
 
 lib$(CLIBNAME).$(A): $(COBJS)
-	$(FLEXLINK_ENV)$(MKLIB) -oc $(CLIBNAME) $(COBJS) $(LDOPTS)
+	$(MKLIB_CMD) -oc $(CLIBNAME) $(COBJS) $(LDOPTS)
 
 install::
 	if test -f dll$(CLIBNAME)$(EXT_DLL); then \

--- a/otherlibs/Makefile
+++ b/otherlibs/Makefile
@@ -22,9 +22,11 @@ include $(ROOTDIR)/Makefile.common
 CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 
 ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
-export OCAML_FLEXLINK:=
+FLEXLINK_ENV =
 else
-export OCAML_FLEXLINK:=$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe
+# FLEXLINK_ENV must have a space at the end
+FLEXLINK_ENV = \
+  OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
 endif
 
 CAMLC=$(CAMLRUN) $(ROOTDIR)/ocamlc -nostdlib -I $(ROOTDIR)/stdlib
@@ -74,10 +76,11 @@ $(LIBNAME).cmxa: $(CAMLOBJS_NAT)
 	         $(CAMLOBJS_NAT) $(LINKOPTS)
 
 $(LIBNAME).cmxs: $(LIBNAME).cmxa lib$(CLIBNAME).$(A)
-	$(CAMLOPT) -shared -o $(LIBNAME).cmxs -I . $(LIBNAME).cmxa
+	$(FLEXLINK_ENV)$(CAMLOPT) -shared -o $(LIBNAME).cmxs -I . \
+	                                     $(LIBNAME).cmxa
 
 lib$(CLIBNAME).$(A): $(COBJS)
-	$(MKLIB) -oc $(CLIBNAME) $(COBJS) $(LDOPTS)
+	$(FLEXLINK_ENV)$(MKLIB) -oc $(CLIBNAME) $(COBJS) $(LDOPTS)
 
 install::
 	if test -f dll$(CLIBNAME)$(EXT_DLL); then \

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -20,14 +20,6 @@ include $(ROOTDIR)/Makefile.common
 
 CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 
-ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
-FLEXLINK_ENV =
-else
-# FLEXLINK_ENV must have a space at the end
-FLEXLINK_ENV = \
-  OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
-endif
-
 LIBS = -nostdlib -I $(ROOTDIR)/stdlib -I $(ROOTDIR)/otherlibs/$(UNIXLIB)
 
 CAMLC=$(CAMLRUN) $(ROOTDIR)/ocamlc $(LIBS)

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -21,9 +21,11 @@ include $(ROOTDIR)/Makefile.common
 CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 
 ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
-export OCAML_FLEXLINK:=
+FLEXLINK_ENV =
 else
-export OCAML_FLEXLINK:=$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe
+# FLEXLINK_ENV must have a space at the end
+FLEXLINK_ENV = \
+  OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
 endif
 
 LIBS = -nostdlib -I $(ROOTDIR)/stdlib -I $(ROOTDIR)/otherlibs/$(UNIXLIB)
@@ -67,10 +69,10 @@ all: lib$(LIBNAME).$(A) $(LIBNAME).cma $(CMIFILES)
 allopt: lib$(LIBNAME)nat.$(A) $(LIBNAME).cmxa $(CMIFILES)
 
 lib$(LIBNAME).$(A): $(BYTECODE_C_OBJS)
-	$(MKLIB) -o $(LIBNAME) $(BYTECODE_C_OBJS) $(PTHREAD_LINK)
+	$(FLEXLINK_ENV)$(MKLIB) -o $(LIBNAME) $(BYTECODE_C_OBJS) $(PTHREAD_LINK)
 
 lib$(LIBNAME)nat.$(A): $(NATIVECODE_C_OBJS)
-	$(MKLIB) -o $(LIBNAME)nat $^
+	$(FLEXLINK_ENV)$(MKLIB) -o $(LIBNAME)nat $^
 
 $(LIBNAME).cma: $(THREADS_BCOBJS)
 ifeq "$(UNIX_OR_WIN32)" "unix"

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -61,10 +61,10 @@ all: lib$(LIBNAME).$(A) $(LIBNAME).cma $(CMIFILES)
 allopt: lib$(LIBNAME)nat.$(A) $(LIBNAME).cmxa $(CMIFILES)
 
 lib$(LIBNAME).$(A): $(BYTECODE_C_OBJS)
-	$(FLEXLINK_ENV)$(MKLIB) -o $(LIBNAME) $(BYTECODE_C_OBJS) $(PTHREAD_LINK)
+	$(MKLIB_CMD) -o $(LIBNAME) $(BYTECODE_C_OBJS) $(PTHREAD_LINK)
 
 lib$(LIBNAME)nat.$(A): $(NATIVECODE_C_OBJS)
-	$(FLEXLINK_ENV)$(MKLIB) -o $(LIBNAME)nat $^
+	$(MKLIB_CMD) -o $(LIBNAME)nat $^
 
 $(LIBNAME).cma: $(THREADS_BCOBJS)
 ifeq "$(UNIX_OR_WIN32)" "unix"

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -33,12 +33,12 @@ else # Windows
   find := /usr/bin/find
   FLEXDLL_SUBMODULE_PRESENT := $(wildcard ../flexdll/Makefile)
   ifeq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
-    FLEXLINK_PREFIX=
+    FLEXLINK_ENV =
   else
     ROOT:=$(shell cd .. && pwd| cygpath -m -f -)
-    EMPTY=
-    FLEXLINK_PREFIX:=OCAML_FLEXLINK="$(ROOT)/boot/ocamlrun \
-                                     $(ROOT)/flexdll/flexlink.exe" $(EMPTY)
+    # FLEXLINK_ENV must have a space at the end
+    FLEXLINK_ENV = \
+      OCAML_FLEXLINK="$(ROOT)/boot/ocamlrun $(ROOT)/flexdll/flexlink.exe" #
   endif
 endif
 
@@ -52,12 +52,12 @@ ocamltest_program := $(or \
   $(wildcard $(ocamltest_directory)/ocamltest.opt$(EXE)),\
   $(wildcard $(ocamltest_directory)/ocamltest$(EXE)))
 
-ifneq "$(FLEXLINK_PREFIX)" ""
+ifneq "$(FLEXLINK_ENV)" ""
   MKDLL=$(WINTOPDIR)/boot/ocamlrun $(WINTOPDIR)/flexdll/flexlink.exe \
                                    $(FLEXLINK_FLAGS)
 endif
-ocamltest := $(FLEXLINK_PREFIX) MKDLL="$(MKDLL)" SORT=$(SORT) MAKE=$(MAKE) \
-                                $(ocamltest_program)
+ocamltest := $(FLEXLINK_ENV)MKDLL="$(MKDLL)" SORT=$(SORT) MAKE=$(MAKE) \
+                            $(ocamltest_program)
 
 .PHONY: default
 default:

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -35,7 +35,7 @@ else # Windows
   ifeq "$(FLEXDLL_SUBMODULE_PRESENT)" ""
     FLEXLINK_ENV =
   else
-    ROOT:=$(shell cd .. && pwd| cygpath -m -f -)
+    ROOT := $(shell cd .. && pwd| cygpath -m -f -)
     # FLEXLINK_ENV must have a space at the end
     FLEXLINK_ENV = \
       OCAML_FLEXLINK="$(ROOT)/boot/ocamlrun $(ROOT)/flexdll/flexlink.exe" #

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -23,6 +23,16 @@ include $(TOPDIR)/Makefile.tools
 
 OCAMLTESTDIR_CYGPATH=$(shell $(CYGPATH) $(BASEDIR)/$(DIR)/_ocamltest)
 
+failstamp := failure.stamp
+
+TESTLOG ?= _log
+
+ocamltest_directory := ../ocamltest
+
+ocamltest_program := $(or \
+  $(wildcard $(ocamltest_directory)/ocamltest.opt$(EXE)),\
+  $(wildcard $(ocamltest_directory)/ocamltest$(EXE)))
+
 ifeq "$(UNIX_OR_WIN32)" "unix"
   ifeq "$(SYSTEM)" "cygwin"
     find := /usr/bin/find
@@ -36,28 +46,20 @@ else # Windows
     FLEXLINK_ENV =
   else
     ROOT := $(shell cd .. && pwd| cygpath -m -f -)
-    # FLEXLINK_ENV must have a space at the end
     FLEXLINK_ENV = \
-      OCAML_FLEXLINK="$(ROOT)/boot/ocamlrun $(ROOT)/flexdll/flexlink.exe" #
+      OCAML_FLEXLINK="$(ROOT)/boot/ocamlrun $(ROOT)/flexdll/flexlink.exe"
   endif
 endif
 
-failstamp := failure.stamp
-
-TESTLOG ?= _log
-
-ocamltest_directory := ../ocamltest
-
-ocamltest_program := $(or \
-  $(wildcard $(ocamltest_directory)/ocamltest.opt$(EXE)),\
-  $(wildcard $(ocamltest_directory)/ocamltest$(EXE)))
-
-ifneq "$(FLEXLINK_ENV)" ""
+ifeq "$(FLEXLINK_ENV)" ""
+  ocamltest := MKDLL="$(MKDLL)" SORT=$(SORT) MAKE=$(MAKE) $(ocamltest_program)
+else
   MKDLL=$(WINTOPDIR)/boot/ocamlrun $(WINTOPDIR)/flexdll/flexlink.exe \
                                    $(FLEXLINK_FLAGS)
+
+  ocamltest := $(FLEXLINK_ENV) MKDLL="$(MKDLL)" SORT=$(SORT) MAKE=$(MAKE) \
+                               $(ocamltest_program)
 endif
-ocamltest := $(FLEXLINK_ENV)MKDLL="$(MKDLL)" SORT=$(SORT) MAKE=$(MAKE) \
-                            $(ocamltest_program)
 
 .PHONY: default
 default:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -14,8 +14,10 @@
 #**************************************************************************
 
 MAKEFLAGS := -r -R
-include ../config/Makefile
-include ../Makefile.common
+ROOTDIR=..
+
+include $(ROOTDIR)/config/Makefile
+include $(ROOTDIR)/Makefile.common
 
 ifeq ($(SYSTEM),unix)
 override define shellquote
@@ -24,7 +26,7 @@ endef
 $(foreach i,BINDIR LIBDIR STUBLIBDIR MANDIR,$(eval $(shellquote)))
 endif
 
-CAMLRUN ?= ../boot/ocamlrun
+CAMLRUN ?= $(ROOTDIR)/boot/ocamlrun
 DESTDIR ?=
 # Setup GNU make variables storing per-target source and target,
 # a list of installed tools, and a function to quote a filename for
@@ -47,10 +49,10 @@ define byte_and_opt_
 $(and $(filter-out 1,$(words $1)),$(error \
    cannot build file with whitespace in name))
 $1: $3 $2
-	$$(CAMLC) $$(LINKFLAGS) -I .. -o $$@ $2
+	$$(CAMLC) $$(LINKFLAGS) -I $$(ROOTDIR) -o $$@ $2
 
 $1.opt: $3 $$(call byte2native,$2)
-	$$(FLEXLINK_ENV)$$(CAMLOPT) $$(LINKFLAGS) -I .. -o $$@ \
+	$$(FLEXLINK_ENV)$$(CAMLOPT) $$(LINKFLAGS) -I $$(ROOTDIR) -o $$@ \
 	                            $$(call byte2native,$2)
 
 all: $1
@@ -71,8 +73,6 @@ $(eval $(call \
  byte_and_opt_,$(subst $$,$$$$,$1),$(subst $$,$$$$,$2),$(subst $$,$$$$,$3)))
 endef
 
-ROOTDIR=..
-
 ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
 FLEXLINK_ENV =
 else
@@ -81,13 +81,14 @@ FLEXLINK_ENV = \
   OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
 endif
 
-CAMLC=$(CAMLRUN) ../boot/ocamlc -g -nostdlib -I ../boot \
-      -use-prims ../runtime/primitives -I ..
-CAMLOPT=$(CAMLRUN) ../ocamlopt -g -nostdlib -I ../stdlib
-CAMLLEX=$(CAMLRUN) ../boot/ocamllex
-INCLUDES=-I ../utils -I ../parsing -I ../typing -I ../bytecomp -I ../asmcomp \
-         -I ../middle_end -I ../middle_end/base_types -I ../driver \
-         -I ../toplevel
+CAMLC=$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -g -nostdlib -I $(ROOTDIR)/boot \
+      -use-prims $(ROOTDIR)/runtime/primitives -I $(ROOTDIR)
+CAMLOPT=$(CAMLRUN) $(ROOTDIR)/ocamlopt -g -nostdlib -I $(ROOTDIR)/stdlib
+CAMLLEX=$(CAMLRUN) $(ROOTDIR)/boot/ocamllex
+INCLUDES=-I $(ROOTDIR)/utils -I $(ROOTDIR)/parsing -I $(ROOTDIR)/typing \
+         -I $(ROOTDIR)/bytecomp -I $(ROOTDIR)/asmcomp -I $(ROOTDIR)/middle_end \
+         -I $(ROOTDIR)/middle_end/base_types -I $(ROOTDIR)/driver \
+         -I $(ROOTDIR)/toplevel
 COMPFLAGS= -absname -w +a-4-9-41-42-44-45-48 -strict-sequence -warn-error A \
  -safe-string -strict-formats -bin-annot $(INCLUDES)
 LINKFLAGS=$(INCLUDES)
@@ -102,8 +103,8 @@ allopt: opt.opt
 
 CAMLDEP_OBJ=ocamldep.cmo
 CAMLDEP_IMPORTS= \
-  ../compilerlibs/ocamlcommon.cma \
-  ../compilerlibs/ocamlbytecomp.cma
+  $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
+  $(ROOTDIR)/compilerlibs/ocamlbytecomp.cma
 ocamldep: LINKFLAGS += -compat-32
 $(call byte_and_opt,ocamldep,$(CAMLDEP_IMPORTS) $(CAMLDEP_OBJ),)
 ocamldep: depend.cmi
@@ -158,13 +159,13 @@ $(call byte_and_opt,ocamlmklib,ocamlmklibconfig.cmo config.cmo \
 	         build_path_prefix_map.cmo misc.cmo ocamlmklib.cmo,)
 
 
-ocamlmklibconfig.ml: ../config/Makefile Makefile
+ocamlmklibconfig.ml: $(ROOTDIR)/config/Makefile Makefile
 	(echo 'let bindir = "$(BINDIR)"'; \
          echo 'let supports_shared_libraries = $(SUPPORTS_SHARED_LIBRARIES)';\
          echo 'let default_rpath = "$(RPATH)"'; \
          echo 'let mksharedlibrpath = "$(MKSHAREDLIBRPATH)"'; \
          echo 'let toolpref = "$(TOOLPREF)"'; \
-         sed -n -e 's/^#ml //p' ../config/Makefile) \
+         sed -n -e 's/^#ml //p' $(ROOTDIR)/config/Makefile) \
         > ocamlmklibconfig.ml
 
 beforedepend:: ocamlmklibconfig.ml
@@ -281,8 +282,8 @@ beforedepend:: cvt_emit.ml
 # Reading cmt files
 
 READ_CMT= \
-          ../compilerlibs/ocamlcommon.cma \
-          ../compilerlibs/ocamlbytecomp.cma \
+          $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
+          $(ROOTDIR)/compilerlibs/ocamlbytecomp.cma \
           \
           cmt2annot.cmo read_cmt.cmo
 
@@ -300,8 +301,8 @@ install::
 # The bytecode disassembler
 
 DUMPOBJ= \
-          ../compilerlibs/ocamlcommon.cma \
-          ../compilerlibs/ocamlbytecomp.cma \
+          $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
+          $(ROOTDIR)/compilerlibs/ocamlbytecomp.cma \
           \
           opnames.cmo dumpobj.cmo
 
@@ -313,8 +314,8 @@ make_opcodes.ml: make_opcodes.mll
 make_opcodes: make_opcodes.ml
 	$(CAMLC) make_opcodes.ml -o $@
 
-opnames.ml: ../runtime/caml/instruct.h make_opcodes
-	../runtime/ocamlrun make_opcodes -opnames < $< > $@
+opnames.ml: $(ROOTDIR)/runtime/caml/instruct.h make_opcodes
+	$(ROOTDIR)/runtime/ocamlrun make_opcodes -opnames < $< > $@
 
 clean::
 	rm -f opnames.ml make_opcodes make_opcodes.ml
@@ -329,15 +330,15 @@ else
 DEF_SYMBOL_PREFIX = '-Dsymbol_prefix=""'
 endif
 
-objinfo_helper$(EXE): objinfo_helper.c ../runtime/caml/s.h
-	$(CC) $(OC_CFLAGS) $(OC_CPPFLAGS) -I../runtime $(OUTPUTEXE)$@ \
+objinfo_helper$(EXE): objinfo_helper.c $(ROOTDIR)/runtime/caml/s.h
+	$(CC) $(OC_CFLAGS) $(OC_CPPFLAGS) -I$(ROOTDIR)/runtime $(OUTPUTEXE)$@ \
           $(DEF_SYMBOL_PREFIX) $(LIBBFD_INCLUDE) $< $(LIBBFD_LINK)
 
-OBJINFO=../compilerlibs/ocamlcommon.cma \
-        ../compilerlibs/ocamlbytecomp.cma \
-        ../compilerlibs/ocamlmiddleend.cma \
-        ../asmcomp/printclambda.cmo \
-        ../asmcomp/export_info.cmo \
+OBJINFO=$(ROOTDIR)/compilerlibs/ocamlcommon.cma \
+        $(ROOTDIR)/compilerlibs/ocamlbytecomp.cma \
+        $(ROOTDIR)/compilerlibs/ocamlmiddleend.cma \
+        $(ROOTDIR)/asmcomp/printclambda.cmo \
+        $(ROOTDIR)/asmcomp/export_info.cmo \
         objinfo.cmo
 
 $(call byte_and_opt,ocamlobjinfo,$(OBJINFO),objinfo_helper$(EXE))
@@ -346,24 +347,25 @@ install::
 	$(INSTALL_PROG) \
 	  objinfo_helper$(EXE) "$(INSTALL_LIBDIR)/objinfo_helper$(EXE)"
 
-primreq=../compilerlibs/ocamlcommon.cma \
-        ../compilerlibs/ocamlbytecomp.cma \
+primreq=$(ROOTDIR)/compilerlibs/ocamlcommon.cma \
+        $(ROOTDIR)/compilerlibs/ocamlbytecomp.cma \
         primreq.cmo
 
 # Scan object files for required primitives
 $(call byte_and_opt,primreq,$(primreq),)
 
-LINTAPIDIFF=../compilerlibs/ocamlcommon.cmxa \
-        ../compilerlibs/ocamlbytecomp.cmxa \
-        ../compilerlibs/ocamlmiddleend.cmxa \
-        ../asmcomp/printclambda.cmx \
-        ../asmcomp/export_info.cmx \
-	../otherlibs/str/str.cmxa \
+LINTAPIDIFF=$(ROOTDIR)/compilerlibs/ocamlcommon.cmxa \
+        $(ROOTDIR)/compilerlibs/ocamlbytecomp.cmxa \
+        $(ROOTDIR)/compilerlibs/ocamlmiddleend.cmxa \
+        $(ROOTDIR)/asmcomp/printclambda.cmx \
+        $(ROOTDIR)/asmcomp/export_info.cmx \
+	$(ROOTDIR)/otherlibs/str/str.cmxa \
 	lintapidiff.cmx
 
-lintapidiff.opt: INCLUDES+= -I ../otherlibs/str
+lintapidiff.opt: INCLUDES+= -I $(ROOTDIR)/otherlibs/str
 lintapidiff.opt: $(LINTAPIDIFF)
-	$(FLEXLINK_ENV)$(CAMLOPT) $(LINKFLAGS) -I .. -o $@ $(LINTAPIDIFF)
+	$(FLEXLINK_ENV)$(CAMLOPT) $(LINKFLAGS) -I $(ROOTDIR) -o $@ \
+	                          $(LINTAPIDIFF)
 clean::
 	rm -f -- lintapidiff.opt lintapidiff.cm? lintapidiff.o
 
@@ -374,16 +376,16 @@ clean::
 
 # Copy a bytecode executable, stripping debug info
 
-stripdebug=../compilerlibs/ocamlcommon.cma \
-           ../compilerlibs/ocamlbytecomp.cma \
+stripdebug=$(ROOTDIR)/compilerlibs/ocamlcommon.cma \
+           $(ROOTDIR)/compilerlibs/ocamlbytecomp.cma \
            stripdebug.cmo
 
 $(call byte_and_opt,stripdebug,$(stripdebug),)
 
 # Compare two bytecode executables
 
-CMPBYT=../compilerlibs/ocamlcommon.cma \
-       ../compilerlibs/ocamlbytecomp.cma \
+CMPBYT=$(ROOTDIR)/compilerlibs/ocamlcommon.cma \
+       $(ROOTDIR)/compilerlibs/ocamlbytecomp.cma \
        cmpbyt.cmo
 
 $(call byte_and_opt,cmpbyt,$(CMPBYT),)
@@ -395,19 +397,21 @@ install::
 	  "$(INSTALL_BINDIR)/"
 endif
 
-CAMLTEX= ../compilerlibs/ocamlcommon.cma \
-	../compilerlibs/ocamlbytecomp.cma \
-	../compilerlibs/ocamltoplevel.cma \
-	../otherlibs/str/str.cma \
-	../otherlibs/$(UNIXLIB)/unix.cma \
+CAMLTEX= $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
+	$(ROOTDIR)/compilerlibs/ocamlbytecomp.cma \
+	$(ROOTDIR)/compilerlibs/ocamltoplevel.cma \
+	$(ROOTDIR)/otherlibs/str/str.cma \
+	$(ROOTDIR)/otherlibs/$(UNIXLIB)/unix.cma \
 	caml_tex.ml
 
 #Scan latex files, and run ocaml code examples
 
-caml-tex: INCLUDES+= -I ../otherlibs/str -I ../otherlibs/$(UNIXLIB)
+caml-tex: INCLUDES+= -I $(ROOTDIR)/otherlibs/str \
+                     -I $(ROOTDIR)/otherlibs/$(UNIXLIB)
 caml-tex: $(CAMLTEX)
-	../runtime/ocamlrun ../ocamlc -nostdlib -I ../stdlib $(LINKFLAGS) \
-	-linkall -o $@ -no-alias-deps $(CAMLTEX)
+	$(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/ocamlc -nostdlib \
+	                            -I $(ROOTDIR)/stdlib $(LINKFLAGS) -linkall \
+	                            -o $@ -no-alias-deps $(CAMLTEX)
 
 # we need str and unix which depend on the bytecode version of other tools
 # thus we delay building caml-tex to the opt.opt stage

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -73,14 +73,6 @@ $(eval $(call \
  byte_and_opt_,$(subst $$,$$$$,$1),$(subst $$,$$$$,$2),$(subst $$,$$$$,$3)))
 endef
 
-ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
-FLEXLINK_ENV =
-else
-# FLEXLINK_ENV must have a space at the end
-FLEXLINK_ENV = \
-  OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
-endif
-
 CAMLC=$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -g -nostdlib -I $(ROOTDIR)/boot \
       -use-prims $(ROOTDIR)/runtime/primitives -I $(ROOTDIR)
 CAMLOPT=$(CAMLRUN) $(ROOTDIR)/ocamlopt -g -nostdlib -I $(ROOTDIR)/stdlib

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -50,7 +50,8 @@ $1: $3 $2
 	$$(CAMLC) $$(LINKFLAGS) -I .. -o $$@ $2
 
 $1.opt: $3 $$(call byte2native,$2)
-	$$(CAMLOPT) $$(LINKFLAGS) -I .. -o $$@ $$(call byte2native,$2)
+	$$(FLEXLINK_ENV)$$(CAMLOPT) $$(LINKFLAGS) -I .. -o $$@ \
+	                            $$(call byte2native,$2)
 
 all: $1
 
@@ -73,20 +74,16 @@ endef
 ROOTDIR=..
 
 ifeq "$(wildcard $(ROOTDIR)/flexdll/Makefile)" ""
-export OCAML_FLEXLINK:=
+FLEXLINK_ENV =
 else
-export OCAML_FLEXLINK:=$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe
+# FLEXLINK_ENV must have a space at the end
+FLEXLINK_ENV = \
+  OCAML_FLEXLINK="$(ROOTDIR)/boot/ocamlrun $(ROOTDIR)/flexdll/flexlink.exe" #
 endif
 
 CAMLC=$(CAMLRUN) ../boot/ocamlc -g -nostdlib -I ../boot \
       -use-prims ../runtime/primitives -I ..
 CAMLOPT=$(CAMLRUN) ../ocamlopt -g -nostdlib -I ../stdlib
-ifeq "$(UNIX_OR_WIN32)" "win32"
-  ifneq "$(wildcard ../flexdll/Makefile)" ""
-    CAMLOPT := OCAML_FLEXLINK="../boot/ocamlrun ../flexdll/flexlink.exe" \
-      $(CAMLOPT)
-  endif
-endif
 CAMLLEX=$(CAMLRUN) ../boot/ocamllex
 INCLUDES=-I ../utils -I ../parsing -I ../typing -I ../bytecomp -I ../asmcomp \
          -I ../middle_end -I ../middle_end/base_types -I ../driver \
@@ -366,7 +363,7 @@ LINTAPIDIFF=../compilerlibs/ocamlcommon.cmxa \
 
 lintapidiff.opt: INCLUDES+= -I ../otherlibs/str
 lintapidiff.opt: $(LINTAPIDIFF)
-	$(CAMLOPT) $(LINKFLAGS) -I .. -o $@ $(LINTAPIDIFF)
+	$(FLEXLINK_ENV)$(CAMLOPT) $(LINKFLAGS) -I .. -o $@ $(LINTAPIDIFF)
 clean::
 	rm -f -- lintapidiff.opt lintapidiff.cm? lintapidiff.o
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -52,8 +52,8 @@ $1: $3 $2
 	$$(CAMLC) $$(LINKFLAGS) -I $$(ROOTDIR) -o $$@ $2
 
 $1.opt: $3 $$(call byte2native,$2)
-	$$(FLEXLINK_ENV)$$(CAMLOPT) $$(LINKFLAGS) -I $$(ROOTDIR) -o $$@ \
-	                            $$(call byte2native,$2)
+	$$(CAMLOPT_CMD) $$(LINKFLAGS) -I $$(ROOTDIR) -o $$@ \
+	                $$(call byte2native,$2)
 
 all: $1
 
@@ -354,8 +354,7 @@ LINTAPIDIFF=$(ROOTDIR)/compilerlibs/ocamlcommon.cmxa \
 
 lintapidiff.opt: INCLUDES+= -I $(ROOTDIR)/otherlibs/str
 lintapidiff.opt: $(LINTAPIDIFF)
-	$(FLEXLINK_ENV)$(CAMLOPT) $(LINKFLAGS) -I $(ROOTDIR) -o $@ \
-	                          $(LINTAPIDIFF)
+	$(CAMLOPT_CMD) $(LINKFLAGS) -I $(ROOTDIR) -o $@ $(LINTAPIDIFF)
 clean::
 	rm -f -- lintapidiff.opt lintapidiff.cm? lintapidiff.o
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -14,7 +14,7 @@
 #**************************************************************************
 
 MAKEFLAGS := -r -R
-ROOTDIR=..
+ROOTDIR = ..
 
 include $(ROOTDIR)/config/Makefile
 include $(ROOTDIR)/Makefile.common
@@ -73,17 +73,15 @@ $(eval $(call \
  byte_and_opt_,$(subst $$,$$$$,$1),$(subst $$,$$$$,$2),$(subst $$,$$$$,$3)))
 endef
 
-CAMLC=$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -g -nostdlib -I $(ROOTDIR)/boot \
-      -use-prims $(ROOTDIR)/runtime/primitives -I $(ROOTDIR)
-CAMLOPT=$(CAMLRUN) $(ROOTDIR)/ocamlopt -g -nostdlib -I $(ROOTDIR)/stdlib
-CAMLLEX=$(CAMLRUN) $(ROOTDIR)/boot/ocamllex
-INCLUDES=-I $(ROOTDIR)/utils -I $(ROOTDIR)/parsing -I $(ROOTDIR)/typing \
-         -I $(ROOTDIR)/bytecomp -I $(ROOTDIR)/asmcomp -I $(ROOTDIR)/middle_end \
-         -I $(ROOTDIR)/middle_end/base_types -I $(ROOTDIR)/driver \
-         -I $(ROOTDIR)/toplevel
-COMPFLAGS= -absname -w +a-4-9-41-42-44-45-48 -strict-sequence -warn-error A \
+CAMLC = $(CAMLRUN) $(ROOTDIR)/boot/ocamlc -g -nostdlib -I $(ROOTDIR)/boot \
+        -use-prims $(ROOTDIR)/runtime/primitives -I $(ROOTDIR)
+CAMLOPT = $(CAMLRUN) $(ROOTDIR)/ocamlopt -g -nostdlib -I $(ROOTDIR)/stdlib
+CAMLLEX = $(CAMLRUN) $(ROOTDIR)/boot/ocamllex
+INCLUDES = $(addprefix -I $(ROOTDIR)/,utils parsing typing bytecomp asmcomp \
+                       middle_end middle_end/base_types driver toplevel)
+COMPFLAGS = -absname -w +a-4-9-41-42-44-45-48 -strict-sequence -warn-error A \
  -safe-string -strict-formats -bin-annot $(INCLUDES)
-LINKFLAGS=$(INCLUDES)
+LINKFLAGS = $(INCLUDES)
 VPATH := $(filter-out -I,$(INCLUDES))
 
 # scrapelabels addlabels
@@ -398,8 +396,7 @@ CAMLTEX= $(ROOTDIR)/compilerlibs/ocamlcommon.cma \
 
 #Scan latex files, and run ocaml code examples
 
-caml-tex: INCLUDES+= -I $(ROOTDIR)/otherlibs/str \
-                     -I $(ROOTDIR)/otherlibs/$(UNIXLIB)
+caml-tex: INCLUDES += $(addprefix -I $(ROOTDIR)/otherlibs/,str $(UNIXLIB))
 caml-tex: $(CAMLTEX)
 	$(ROOTDIR)/runtime/ocamlrun $(ROOTDIR)/ocamlc -nostdlib \
 	                            -I $(ROOTDIR)/stdlib $(LINKFLAGS) -linkall \


### PR DESCRIPTION
When bootstrapping flexlink, the usual invocation of `flexlink` (`FLEXLINK_CMD` in `config/Makefile`) has to be overridden as, like everything else during the compiler's build process, the command must be prefixed with an explicit call to `ocamlrun`. This is done in two places:
 1. `FLEXLINK_CMD` is threaded from the toplevel `Makefile`, which means that any `Makefile` commands which directly invoke `$(FLEXLINK)` automagically work.
 2. `OCAML_FLEXLINK` has to be exported to the environment when running `ocamlc -custom`, linking an executable with `ocamlopt -o`, and running `ocamlopt -shared` to instruct the compiler itself not to invoke `flexlink` directly.

Some `Makefile`s achieved the second by having an `export OCAML_FLEXLINK := ...` line and other more recent ones had a more elegant `FLEXLINK_ENV = OCAML_FLEXLINK=...` which is then explicitly used in commands when required. The latter has the benefit of appearing less magical, because you can see the `OCAML_FLEXLINK="../boot/ocamlrun ../flexdll/flexlink.exe"` instruction on the individual command lines and so be certain that the correct flexlink is being called.

This GPR, in preparation for full support of the Windows Linux Subsystem for building OCaml, tidies up three things:
 1. `FLEXLINK_ENV` is now used everywhere, instead of an exported variable
 2. The definition of `FLEXLINK_ENV` is moved to `Makefile.common` and consequentially several `Makefile`s now define and consistently use `ROOTDIR`
 3. `FLEXLINK_ENV` is used exactly where it is needed - previously it was used on all `CAMLOPT` invocations, which is unnecessary.