### PR TITLE
Test syntax error messages

### DIFF
--- a/testsuite/tests/parse-errors/escape_error.compilers.reference
+++ b/testsuite/tests/parse-errors/escape_error.compilers.reference
@@ -1,0 +1,13 @@
+Line 8, characters 16-18:
+  try foo () with ;;
+                  ^^
+Error: Syntax error
+Line 2, characters 5-6:
+  (3 : );;
+       ^
+Error: Syntax error
+Line 2, characters 6-7:
+  (3 :> );;
+        ^
+Error: Syntax error
+

--- a/testsuite/tests/parse-errors/escape_error.ml
+++ b/testsuite/tests/parse-errors/escape_error.ml
@@ -1,0 +1,12 @@
+(* TEST
+   * toplevel
+*)
+
+(* Nothing to see here, parse.ml dictates that these be printed as regular
+   "Syntax error". *)
+
+try foo () with ;;
+
+(3 : );;
+
+(3 :> );;

--- a/testsuite/tests/parse-errors/expecting.compilers.reference
+++ b/testsuite/tests/parse-errors/expecting.compilers.reference
@@ -1,0 +1,33 @@
+Line 6, characters 9-10:
+    | 3 as 3 -> ()
+           ^
+Error: Syntax error: identifier expected.
+Line 3, characters 9-11:
+    | 3 :: -> ()
+           ^^
+Error: Syntax error: pattern expected.
+Line 3, characters 8-10:
+    | 3 | -> ()
+          ^^
+Error: Syntax error: pattern expected.
+Line 3, characters 11-13:
+    | List.( -> ()
+             ^^
+Error: Syntax error: pattern expected.
+Line 3, characters 9-10:
+    | (3 : 3) -> ()
+           ^
+Error: Syntax error: type expected.
+Line 3, characters 7-8:
+    | (3,) -> ()
+         ^
+Error: Syntax error: pattern expected.
+Line 3, characters 6-8:
+    | ( -> ()
+        ^^
+Error: Syntax error: operator expected.
+Line 3, characters 12-14:
+    | (module -> ()
+              ^^
+Error: Syntax error: module-expr expected.
+

--- a/testsuite/tests/parse-errors/expecting.ml
+++ b/testsuite/tests/parse-errors/expecting.ml
@@ -1,0 +1,35 @@
+(* TEST
+   * toplevel
+*)
+
+let f = function
+  | 3 as 3 -> ()
+;;
+
+let f = function
+  | 3 :: -> ()
+;;
+
+let f = function
+  | 3 | -> ()
+;;
+
+let f = function
+  | List.( -> ()
+;;
+
+let f = function
+  | (3 : 3) -> ()
+;;
+
+let f = function
+  | (3,) -> ()
+;;
+
+let f = function
+  | ( -> ()
+;;
+
+let f = function
+  | (module -> ()
+;;

--- a/testsuite/tests/parse-errors/ocamltests
+++ b/testsuite/tests/parse-errors/ocamltests
@@ -1,0 +1,15 @@
+unclosed_class_signature.mli
+unclosed_class_simpl_expr1.ml
+unclosed_class_simpl_expr2.ml
+unclosed_class_simpl_expr3.ml
+unclosed_object.ml
+unclosed_paren_module_expr1.ml
+unclosed_paren_module_expr2.ml
+unclosed_paren_module_expr3.ml
+unclosed_paren_module_expr4.ml
+unclosed_paren_module_expr5.ml
+unclosed_paren_module_type.mli
+unclosed_sig.mli
+unclosed_simple_expr.ml
+unclosed_simple_pattern.ml
+unclosed_struct.ml

--- a/testsuite/tests/parse-errors/ocamltests
+++ b/testsuite/tests/parse-errors/ocamltests
@@ -1,3 +1,4 @@
+escape_error.ml
 unclosed_class_signature.mli
 unclosed_class_simpl_expr1.ml
 unclosed_class_simpl_expr2.ml

--- a/testsuite/tests/parse-errors/ocamltests
+++ b/testsuite/tests/parse-errors/ocamltests
@@ -1,4 +1,5 @@
 escape_error.ml
+expecting.ml
 unclosed_class_signature.mli
 unclosed_class_simpl_expr1.ml
 unclosed_class_simpl_expr2.ml

--- a/testsuite/tests/parse-errors/unclosed_class_signature.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_class_signature.compilers.reference
@@ -1,0 +1,2 @@
+File "unclosed_class_signature.mli", line 11, characters 0-0:
+Error: Syntax error

--- a/testsuite/tests/parse-errors/unclosed_class_signature.mli
+++ b/testsuite/tests/parse-errors/unclosed_class_signature.mli
@@ -1,0 +1,10 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*** check-ocamlc.byte-output
+*)
+
+(* It is apparently impossible to get the "unclosed object" message. *)
+
+class c : object

--- a/testsuite/tests/parse-errors/unclosed_class_simpl_expr1.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_class_simpl_expr1.compilers.reference
@@ -1,0 +1,2 @@
+File "unclosed_class_simpl_expr1.ml", line 10, characters 0-0:
+Error: Syntax error

--- a/testsuite/tests/parse-errors/unclosed_class_simpl_expr1.ml
+++ b/testsuite/tests/parse-errors/unclosed_class_simpl_expr1.ml
@@ -1,0 +1,9 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*** check-ocamlc.byte-output
+*)
+
+class c = object
+  method x = 1

--- a/testsuite/tests/parse-errors/unclosed_class_simpl_expr2.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_class_simpl_expr2.compilers.reference
@@ -1,0 +1,4 @@
+File "unclosed_class_simpl_expr2.ml", line 9, characters 0-0:
+Error: Syntax error: ')' expected
+File "unclosed_class_simpl_expr2.ml", line 8, characters 10-11:
+Error: This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_class_simpl_expr2.ml
+++ b/testsuite/tests/parse-errors/unclosed_class_simpl_expr2.ml
@@ -1,0 +1,8 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*** check-ocamlc.byte-output
+*)
+
+class c = (object end : object end

--- a/testsuite/tests/parse-errors/unclosed_class_simpl_expr3.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_class_simpl_expr3.compilers.reference
@@ -1,0 +1,4 @@
+File "unclosed_class_simpl_expr3.ml", line 9, characters 0-0:
+Error: Syntax error: ')' expected
+File "unclosed_class_simpl_expr3.ml", line 8, characters 10-11:
+Error: This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_class_simpl_expr3.ml
+++ b/testsuite/tests/parse-errors/unclosed_class_simpl_expr3.ml
@@ -1,0 +1,8 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*** check-ocamlc.byte-output
+*)
+
+class c = (object end

--- a/testsuite/tests/parse-errors/unclosed_object.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_object.compilers.reference
@@ -1,0 +1,2 @@
+File "unclosed_object.ml", line 11, characters 0-0:
+Error: Syntax error

--- a/testsuite/tests/parse-errors/unclosed_object.ml
+++ b/testsuite/tests/parse-errors/unclosed_object.ml
@@ -1,0 +1,10 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*** check-ocamlc.byte-output
+*)
+
+(* Failed to get the unclosed object error message. *)
+
+let o = object

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr1.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr1.compilers.reference
@@ -1,0 +1,4 @@
+File "unclosed_paren_module_expr1.ml", line 9, characters 0-0:
+Error: Syntax error: ')' expected
+File "unclosed_paren_module_expr1.ml", line 8, characters 11-12:
+Error: This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr1.ml
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr1.ml
@@ -1,0 +1,8 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*** check-ocamlc.byte-output
+*)
+
+module M = (struct end : sig end

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr2.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr2.compilers.reference
@@ -1,0 +1,4 @@
+File "unclosed_paren_module_expr2.ml", line 9, characters 0-0:
+Error: Syntax error: ')' expected
+File "unclosed_paren_module_expr2.ml", line 8, characters 11-12:
+Error: This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr2.ml
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr2.ml
@@ -1,0 +1,8 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*** check-ocamlc.byte-output
+*)
+
+module M = (struct end

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr3.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr3.compilers.reference
@@ -1,0 +1,4 @@
+File "unclosed_paren_module_expr3.ml", line 9, characters 0-0:
+Error: Syntax error: ')' expected
+File "unclosed_paren_module_expr3.ml", line 8, characters 11-12:
+Error: This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr3.ml
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr3.ml
@@ -1,0 +1,8 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*** check-ocamlc.byte-output
+*)
+
+module M = (val 3 :

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr4.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr4.compilers.reference
@@ -1,0 +1,4 @@
+File "unclosed_paren_module_expr4.ml", line 9, characters 0-0:
+Error: Syntax error: ')' expected
+File "unclosed_paren_module_expr4.ml", line 8, characters 11-12:
+Error: This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr4.ml
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr4.ml
@@ -1,0 +1,8 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*** check-ocamlc.byte-output
+*)
+
+module M = (val 3 :>

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr5.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr5.compilers.reference
@@ -1,0 +1,4 @@
+File "unclosed_paren_module_expr5.ml", line 9, characters 0-0:
+Error: Syntax error: ')' expected
+File "unclosed_paren_module_expr5.ml", line 8, characters 11-12:
+Error: This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr5.ml
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr5.ml
@@ -1,0 +1,8 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*** check-ocamlc.byte-output
+*)
+
+module M = (val 3

--- a/testsuite/tests/parse-errors/unclosed_paren_module_type.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_type.compilers.reference
@@ -1,0 +1,4 @@
+File "unclosed_paren_module_type.mli", line 9, characters 0-0:
+Error: Syntax error: ')' expected
+File "unclosed_paren_module_type.mli", line 8, characters 11-12:
+Error: This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_type.mli
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_type.mli
@@ -1,0 +1,8 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*** check-ocamlc.byte-output
+*)
+
+module M : (sig end

--- a/testsuite/tests/parse-errors/unclosed_sig.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_sig.compilers.reference
@@ -1,0 +1,4 @@
+File "unclosed_sig.mli", line 10, characters 0-0:
+Error: Syntax error: 'end' expected
+File "unclosed_sig.mli", line 8, characters 11-14:
+Error: This 'sig' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_sig.mli
+++ b/testsuite/tests/parse-errors/unclosed_sig.mli
@@ -1,0 +1,9 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*** check-ocamlc.byte-output
+*)
+
+module M : sig
+  type t = T

--- a/testsuite/tests/parse-errors/unclosed_simple_expr.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_simple_expr.compilers.reference
@@ -1,0 +1,107 @@
+Line 5, characters 0-1, Line 5, characters 5-7:  (3; 2;;
+                                                 ^    ^^
+Syntax error: ')' expected, the highlighted '(' might be unmatched
+Line 2, characters 0-5,
+Line 2, characters 10-12:
+  begin 3; 2;;
+  ^^^^^     ^^
+Syntax error: 'end' expected, the highlighted 'begin' might be unmatched
+Line 2, characters 5-6,
+Line 2, characters 10-12:
+  List.(3; 2;;
+       ^    ^^
+Syntax error: ')' expected, the highlighted '(' might be unmatched
+Line 2, characters 12-13,
+Line 2, characters 17-19:
+  simple_expr.(3; 2;;
+              ^    ^^
+Syntax error: ')' expected, the highlighted '(' might be unmatched
+Line 2, characters 12-13,
+Line 2, characters 17-19:
+  simple_expr.[3; 2;;
+              ^    ^^
+Syntax error: ']' expected, the highlighted '[' might be unmatched
+Line 2, characters 13-14,
+Line 2, characters 15-17:
+  simple_expr.%[3;;
+               ^ ^^
+Syntax error: ']' expected, the highlighted '[' might be unmatched
+Line 2, characters 13-14,
+Line 2, characters 15-17:
+  simple_expr.%(3;;
+               ^ ^^
+Syntax error: ')' expected, the highlighted '(' might be unmatched
+Line 2, characters 13-14,
+Line 2, characters 15-17:
+  simple_expr.%{3;;
+               ^ ^^
+Syntax error: '}' expected, the highlighted '{' might be unmatched
+Line 2, characters 9-10,
+Line 2, characters 11-13:
+  foo.Bar.%[3;;
+           ^ ^^
+Syntax error: ']' expected, the highlighted '[' might be unmatched
+Line 2, characters 9-10,
+Line 2, characters 11-13:
+  foo.Bar.%(3;;
+           ^ ^^
+Syntax error: ')' expected, the highlighted '(' might be unmatched
+Line 2, characters 9-10,
+Line 2, characters 11-13:
+  foo.Bar.%{3;;
+           ^ ^^
+Syntax error: '}' expected, the highlighted '{' might be unmatched
+Line 2, characters 12-13,
+Line 2, characters 17-19:
+  simple_expr.{3, 2;;
+              ^    ^^
+Syntax error: '}' expected, the highlighted '{' might be unmatched
+Line 2, characters 10-12:
+  { x = 3; y;;
+            ^^
+Error: Syntax error
+Line 2, characters 16-18:
+  List.{ x = 3; y ;;
+                  ^^
+Error: Syntax error
+Line 2, characters 7-9:
+  [| 3; 2;;
+         ^^
+Error: Syntax error
+Line 2, characters 11-13:
+  List.[|3; 2;;
+             ^^
+Error: Syntax error
+Line 2, characters 5-7:
+  [3; 2;;
+       ^^
+Error: Syntax error
+Line 2, characters 10-12:
+  List.[3; 2;;
+            ^^
+Error: Syntax error
+Line 2, characters 13-15:
+  {< x = 3; y; ;;
+               ^^
+Error: Syntax error
+Line 2, characters 17-19:
+  List.{< x = 3; y ;;
+                   ^^
+Error: Syntax error
+Line 2, characters 0-1,
+Line 2, characters 20-22:
+  (module struct end :;;
+  ^                   ^^
+Syntax error: ')' expected, the highlighted '(' might be unmatched
+Line 2, characters 5-6,
+Line 2, characters 25-27:
+  List.(module struct end :;;
+       ^                   ^^
+Syntax error: ')' expected, the highlighted '(' might be unmatched
+
+Line 2, characters 0-1,
+Line 2, characters 2-3:
+  (=;
+  ^ ^
+Syntax error: ')' expected, the highlighted '(' might be unmatched
+

--- a/testsuite/tests/parse-errors/unclosed_simple_expr.ml
+++ b/testsuite/tests/parse-errors/unclosed_simple_expr.ml
@@ -1,0 +1,49 @@
+(* TEST
+   * toplevel
+*)
+
+(3; 2;;
+
+begin 3; 2;;
+
+List.(3; 2;;
+
+simple_expr.(3; 2;;
+
+simple_expr.[3; 2;;
+
+simple_expr.%[3;;
+
+simple_expr.%(3;;
+
+simple_expr.%{3;;
+
+foo.Bar.%[3;;
+
+foo.Bar.%(3;;
+
+foo.Bar.%{3;;
+
+simple_expr.{3, 2;;
+
+{ x = 3; y;;
+
+List.{ x = 3; y ;;
+
+[| 3; 2;;
+
+List.[|3; 2;;
+
+[3; 2;;
+
+List.[3; 2;;
+
+{< x = 3; y; ;;
+
+List.{< x = 3; y ;;
+
+(module struct end :;;
+
+List.(module struct end :;;
+
+(=;

--- a/testsuite/tests/parse-errors/unclosed_simple_pattern.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_simple_pattern.compilers.reference
@@ -1,0 +1,30 @@
+Line 6, characters 9-10, Line 7, characters 0-2:  .........(.
+                                                  ;;
+Syntax error: ')' expected, the highlighted '(' might be unmatched
+Line 3, characters 4-5,
+Line 4, characters 0-2:
+  ....(.
+  ;;
+Syntax error: ')' expected, the highlighted '(' might be unmatched
+Line 3, characters 4-5,
+Line 4, characters 0-2:
+  ....(.......
+  ;;
+Syntax error: ')' expected, the highlighted '(' might be unmatched
+Line 7, characters 0-2:
+  ;;
+  ^^
+Error: Syntax error: module-expr expected.
+Line 7, characters 0-2:
+  ;;
+  ^^
+Error: Syntax error
+Line 4, characters 0-2:
+  ;;
+  ^^
+Error: Syntax error
+Line 4, characters 0-2:
+  ;;
+  ^^
+Error: Syntax error
+

--- a/testsuite/tests/parse-errors/unclosed_simple_pattern.ml
+++ b/testsuite/tests/parse-errors/unclosed_simple_pattern.ml
@@ -1,0 +1,37 @@
+(* TEST
+   * toplevel
+*)
+
+let f = function
+  | List.(_
+;;
+
+let f = function
+  | (_
+;;
+
+let f = function
+  | (_ : int
+;;
+
+(* Impossible to get the "unclosed (" message here. This case gets absorbed by
+   val_ident... *)
+
+let f = function
+  | (module Foo : sig end
+;;
+
+(* As with expressions, impossible to get the unclosed message for the following
+   cases. *)
+
+let f = function
+  | { foo; bar;
+;;
+
+let f = function
+  | [ 1; 2;
+;;
+
+let f = function
+  | [| 3; 4;
+;;

--- a/testsuite/tests/parse-errors/unclosed_struct.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_struct.compilers.reference
@@ -1,0 +1,4 @@
+File "unclosed_struct.ml", line 10, characters 0-0:
+Error: Syntax error: 'end' expected
+File "unclosed_struct.ml", line 8, characters 11-17:
+Error: This 'struct' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_struct.ml
+++ b/testsuite/tests/parse-errors/unclosed_struct.ml
@@ -1,0 +1,9 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+ocamlc_byte_exit_status = "2"
+*** check-ocamlc.byte-output
+*)
+
+module M = struct
+  type t = T


### PR DESCRIPTION
In preparation for a potential switch to menhir (but simply good to have regardless), this PR adds a test case for (almost[1]) every production in the grammar ending in an error token.

Some notes:
- it is not enough to write `module M = struct` to get:
  ```
  File "unclosed_struct.ml", line 10, characters 0-0:
  Error: Syntax error: 'end' expected
  File "unclosed_struct.ml", line 8, characters 11-17:
  Error: This 'struct' might be unmatched
  ```
  One has to go the extra distance and write `module M = struct type t = T`. I'm guessing that's because otherwise some other error rule gets in the way.
- I failed to produce the expected error message in a few cases.
- to properly test errors at the structure / signature level, I created a test file per grammar production which is compiled with `ocamlc`. For expressions and patterns it's fine to put several in one file and call the toplevel, so that's what I did.

[1]: I believe the only missing rules are the redundant ones between `pattern` and `pattern_no_exn`. Everything else should be covered.