### PR TITLE
Pparse: check ast invariants after preprocessing

### DIFF
--- a/Changes
+++ b/Changes
@@ -255,6 +255,9 @@ Working version
   (Gabriel Radanne, help from Gabriel Scherer and Valentin Gatien-Baron,
    review by Mark Shinwell and Gabriel Radanne)
 
+- GPR#1938: always check ast invariants after preprocessing
+  (Florian Angeletti, review by Alain Frisch and Gabriel Scherer)
+
 ### Bug fixes:
 
 - GPR#1626: Do not allow recursive modules in `with module`

--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -112,19 +112,25 @@ let apply_rewriters_str ?(restore = true) ~tool_name ast =
   match !Clflags.all_ppx with
   | [] -> ast
   | ppxs ->
-      ast
-      |> Ast_mapper.add_ppx_context_str ~tool_name
-      |> rewrite Structure ppxs
-      |> Ast_mapper.drop_ppx_context_str ~restore
+      let ast =
+        ast
+        |> Ast_mapper.add_ppx_context_str ~tool_name
+        |> rewrite Structure ppxs
+        |> Ast_mapper.drop_ppx_context_str ~restore
+      in
+      Ast_invariants.structure ast; ast
 
 let apply_rewriters_sig ?(restore = true) ~tool_name ast =
   match !Clflags.all_ppx with
   | [] -> ast
   | ppxs ->
-      ast
-      |> Ast_mapper.add_ppx_context_sig ~tool_name
-      |> rewrite Signature ppxs
-      |> Ast_mapper.drop_ppx_context_sig ~restore
+      let ast =
+        ast
+        |> Ast_mapper.add_ppx_context_sig ~tool_name
+        |> rewrite Signature ppxs
+        |> Ast_mapper.drop_ppx_context_sig ~restore
+      in
+      Ast_invariants.signature ast; ast
 
 let apply_rewriters ?restore ~tool_name
     (type a) (kind : a ast_kind) (ast : a) : a =
@@ -170,7 +176,10 @@ let file_aux ~tool_name inputfile (type a) parse_fun invariant_fun
         if !Clflags.unsafe then
           Location.prerr_warning (Location.in_file !Location.input_name)
             Warnings.Unsafe_without_parsing;
-        (input_value ic : a)
+        let ast = (input_value ic : a) in
+        if !Clflags.all_ppx = [] then invariant_fun ast;
+        (* if all_ppx <> [], invariant_fun will be called by apply_rewriters *)
+        ast
       end else begin
         seek_in ic 0;
         let lexbuf = Lexing.from_channel ic in
@@ -180,11 +189,9 @@ let file_aux ~tool_name inputfile (type a) parse_fun invariant_fun
     with x -> close_in ic; raise x
   in
   close_in ic;
-  let ast =
-    Profile.record_call "-ppx" (fun () ->
-      apply_rewriters ~restore:false ~tool_name kind ast) in
-  if is_ast_file || !Clflags.all_ppx <> [] then invariant_fun ast;
-  ast
+  Profile.record_call "-ppx" (fun () ->
+      apply_rewriters ~restore:false ~tool_name kind ast
+    )
 
 let file ~tool_name inputfile parse_fun ast_kind =
   file_aux ~tool_name inputfile parse_fun ignore ast_kind

--- a/testsuite/tests/parsing/broken_invariants.compilers.reference
+++ b/testsuite/tests/parsing/broken_invariants.compilers.reference
@@ -1,0 +1,25 @@
+Line 12, characters 20-25:
+  let empty_tuple = [%tuple];;
+                      ^^^^^
+Error: broken invariant in parsetree: Tuples must have at least 2 components.
+Line 1, characters 21-27:
+  let empty_record = [%record];;
+                       ^^^^^^
+Error: broken invariant in parsetree: Records cannot be empty.
+Line 1, characters 20-27:
+  let empty_apply = [%no_args f];;
+                      ^^^^^^^
+Error: broken invariant in parsetree: Function application with no argument.
+Line 1, characters 19-45:
+  let f = function [%record_with_functor_fields] -> ();;
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: broken invariant in parsetree: Functor application not allowed here.
+Line 1, characters 3-12:
+  [%%empty_let];;
+     ^^^^^^^^^
+Error: broken invariant in parsetree: Let with no bindings.
+Line 1, characters 3-13:
+  [%%empty_type];;
+     ^^^^^^^^^^
+Error: broken invariant in parsetree: Type declarations cannot be empty.
+

--- a/testsuite/tests/parsing/broken_invariants.ml
+++ b/testsuite/tests/parsing/broken_invariants.ml
@@ -1,0 +1,17 @@
+(* TEST
+   files="illegal_ppx.ml"
+  * setup-ocamlc.byte-build-env
+  ** ocamlc.byte with ocamlcommon
+  all_modules="illegal_ppx.ml"
+  program="ppx.exe"
+  *** toplevel
+  all_modules="broken_invariants.ml"
+  flags="-ppx '${ocamlrun} ${test_build_directory_prefix}/ocamlc.byte/ppx.exe'"
+*)
+
+let empty_tuple = [%tuple];;
+let empty_record = [%record];;
+let empty_apply = [%no_args f];;
+let f = function [%record_with_functor_fields] -> ();;
+[%%empty_let];;
+[%%empty_type];;

--- a/testsuite/tests/parsing/illegal_ppx.ml
+++ b/testsuite/tests/parsing/illegal_ppx.ml
@@ -1,0 +1,38 @@
+module H = Ast_helper
+module M = Ast_mapper
+open Parsetree
+let empty_tuple loc = H.Exp.tuple ~loc []
+let empty_record loc = H.Exp.record ~loc [] None
+let empty_apply loc f =
+  H.Exp.apply ~loc f []
+
+let empty_let loc = H.Str.value ~loc Asttypes.Nonrecursive []
+let empty_type loc = H.Str.type_ ~loc Asttypes.Nonrecursive []
+let functor_id loc = Location.mkloc
+    (Longident.( Lapply (Lident "F", Lident "X"))) loc
+let complex_record loc =
+  H.Pat.record ~loc [functor_id loc, H.Pat.any ~loc () ] Asttypes.Closed
+
+let super = M.default_mapper
+let expr mapper e =
+  match e.pexp_desc with
+  | Pexp_extension ({txt="tuple";loc},_) -> empty_tuple loc
+  | Pexp_extension({txt="record";loc},_) -> empty_record loc
+  | Pexp_extension({txt="no_args";loc},PStr[{pstr_desc= Pstr_eval (e,_);_}])
+    -> empty_apply loc e
+  | _ -> super.M.expr mapper e
+
+let pat mapper p =
+  match p.ppat_desc with
+  | Ppat_extension ({txt="record_with_functor_fields";loc},_) ->
+      complex_record loc
+  | _ -> super.M.pat mapper p
+
+let structure_item mapper stri = match stri.pstr_desc with
+  | Pstr_extension (({Location.txt="empty_let";loc},_),_) -> empty_let loc
+  | Pstr_extension (({Location.txt="empty_type";loc},_),_) -> empty_type loc
+  | _ -> super.structure_item mapper stri
+
+let () = M.register "illegal ppx" (fun _ ->
+    { super with expr; pat; structure_item }
+  )

--- a/testsuite/tests/parsing/ocamltests
+++ b/testsuite/tests/parsing/ocamltests
@@ -1,4 +1,5 @@
 attributes.ml
+broken_invariants.ml
 docstrings.ml
 extended_indexoperators.ml
 extensions.ml


### PR DESCRIPTION
This small PR proposes to check AST invariants after the preprocessing phase of the toplevel.

For instance, running a faulty ppx that generates an empty tuple with
```OCaml
let t = [%tuple];;
```
raises with this PR an error in the toplevel itself:
> Error: broken invariant in parsetree: Tuples must have at least 2 components.

rather than an internal fatal error:
> Fatal error: exception File "typing/typecore.ml", line 2999, characters 6-12: Assertion failed

