### PR TITLE
New implementations of the static check for recursive definitions

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,7 +25,8 @@ Working version
   (Thomas Refis, with help from Leo White, review by Jacques Garrigue)
 
 - GPR#1942: simplification of the static check for recursive definitions
-  (Alban Reynaud and Gabriel Scherer, review by ??? and Armaël Guéneau)
+  (Alban Reynaud and Gabriel Scherer,
+   review by Jeremy Yallop and Armaël Guéneau)
 
 ### Standard library:
 

--- a/Changes
+++ b/Changes
@@ -24,6 +24,9 @@ Working version
 - GPR#1909: unsharing pattern types
   (Thomas Refis, with help from Leo White, review by Jacques Garrigue)
 
+- GPR#1942: simplification of the static check for recursive definitions
+  (Alban Reynaud and Gabriel Scherer, review by ??? and Armaël Guéneau)
+
 ### Standard library:
 
 - GPR#1940: Add Option module and Format.pp_print_option

--- a/testsuite/tests/letrec-check/basic.ml
+++ b/testsuite/tests/letrec-check/basic.ml
@@ -112,11 +112,14 @@ val x : 'a option -> unit = <fun>
 val y : 'a list -> unit = <fun>
 |}];;
 
+(* this is accepted as all fields are overriden *)
 let rec x = { x with contents = 3 }  [@ocaml.warning "-23"];;
 [%%expect{|
 val x : int ref = {contents = 3}
 |}];;
 
+(* this is rejected as `c` will be dereferenced during the copy,
+   and is not yet fully defined *)
 let rec c = { c with Complex.re = 1.0 };;
 [%%expect{|
 Line 1, characters 12-39:

--- a/testsuite/tests/letrec-check/float_unboxing.ml
+++ b/testsuite/tests/letrec-check/float_unboxing.ml
@@ -1,0 +1,37 @@
+(* TEST
+   * expect
+*)
+
+(* This program is a minimal example which segfault if
+   (e1.x <- e2) considers that (e2) is in Return mode,
+   rather than Dereference -- here a write to a
+   field in a statically-known all-float record is
+   unboxed on the flight, so accepting this example
+   would dereference (when running `g.f <- y` with y
+   uninitialized) an arbitrary address. *)
+type t = { mutable f: float }
+let g = { f = 0.0 }
+let rec x = (g.f <- y; ()) and y = 2.0;;
+[%%expect{|
+type t = { mutable f : float; }
+val g : t = {f = 0.}
+Line 3, characters 12-26:
+  let rec x = (g.f <- y; ()) and y = 2.0;;
+              ^^^^^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of `let rec'
+|}];;
+
+(* same example, with object instance variables
+   instead of record fields *)
+class c = object
+  val mutable f = 0.0
+  method m =
+    let rec x = (f <- y; ()) and y = 2.0 in f
+end;;
+let _ = print_float (new c)#m;;
+[%%expect{|
+Line 4, characters 16-28:
+      let rec x = (f <- y; ()) and y = 2.0 in f
+                  ^^^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of `let rec'
+|}];;

--- a/testsuite/tests/letrec-check/labels.ml
+++ b/testsuite/tests/letrec-check/labels.ml
@@ -14,3 +14,20 @@ Line 1, characters 12-16:
               ^^^^
 Error: This kind of expression is not allowed as right-hand side of `let rec'
 |}];;
+
+let f x ~y = x + y
+(* this function creates "abstracted arguments" in the sense of
+   Rec_check.is_abstracted_arg. Those should be treated as
+   returned/unguarded, and not delayed, otherwise the code below
+   segfaults. *)
+let rec g = f ~y:(print_endline !y; 0)
+and y =
+  let _ = g in (* ignore g to have a real dependency *)
+  ref "foo";;
+[%%expect {|
+val f : int -> y:int -> int = <fun>
+Line 6, characters 12-38:
+  let rec g = f ~y:(print_endline !y; 0)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of `let rec'
+|}]

--- a/testsuite/tests/letrec-check/ocamltests
+++ b/testsuite/tests/letrec-check/ocamltests
@@ -2,6 +2,7 @@ basic.ml
 extension_constructor.ml
 flat_float_array.ml
 no_flat_float_array.ml
+float_unboxing.ml
 records.ml
 labels.ml
 lazy_.ml

--- a/testsuite/tests/letrec-check/ocamltests
+++ b/testsuite/tests/letrec-check/ocamltests
@@ -2,6 +2,7 @@ basic.ml
 extension_constructor.ml
 flat_float_array.ml
 no_flat_float_array.ml
+records.ml
 labels.ml
 lazy_.ml
 modules.ml

--- a/testsuite/tests/letrec-check/records.ml
+++ b/testsuite/tests/letrec-check/records.ml
@@ -1,0 +1,31 @@
+(* TEST
+   * expect
+*)
+type t = { x : int; self : t };;
+[%%expect {|
+type t = { x : int; self : t; }
+|}];;
+
+let rec x = 1
+and u = Some { t with x = 2 }
+and t = { x; self = t }
+(* We have carefully placed `u` before `t` here,
+   so that the copy { t with .. }, if accepted,
+   is evaluated before 't' is initialized -- making
+   the assertion below fail, typically aborting
+   with a segmentation fault.
+
+   If you exchange the declaration orders of `u` and `t`,
+   and the static check accepts this example, then `t`
+   is initialized first and the assertion succeeds. *)
+
+
+let () = match u with
+  | None -> assert false
+  | Some {x = _; self} -> assert (self.x = t.x)
+[%%expect {|
+Line 2, characters 8-29:
+  and u = Some { t with x = 2 }
+          ^^^^^^^^^^^^^^^^^^^^^
+Error: This kind of expression is not allowed as right-hand side of `let rec'
+|}];;

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -552,9 +552,13 @@ let rec expression : Typedtree.expression -> term_judg =
     | Texp_setfield (e1, _, _, e2) ->
       (*
         G1 |- e1: m[Dereference]
-        G2 |- e2: m[Dereference] (*TODO: why is this a dereference?*)
+        G2 |- e2: m[Dereference]
         ---
         G1 + G2 |- e1.x <- e2: m
+
+        Note: e2 is dereferenced in the case of a field assignment to
+        a record of unboxed floats in that case, e2 evaluates to
+        a boxed float and it is unboxed on assignment.
       *)
       join [
         expression e1 << Dereference;
@@ -603,8 +607,8 @@ let rec expression : Typedtree.expression -> term_judg =
       expression e << Dereference
     | Texp_setinstvar (pth,_,_,e) ->
       (*
-        G |- e: m[Dereference]  (*TODO: why is this a dereference?*)
-        -----------------------
+        G |- e: m[Dereference]
+        ----------------------
         G |- x <- e: m
       *)
       join [

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -7,6 +7,8 @@
 (*               Alban Reynaud, ENS Lyon                                  *)
 (*                                                                        *)
 (*   Copyright 2017 Jeremy Yallop                                         *)
+(*   Copyright 2018 Alban Reynaud                                         *)
+(*   Copyright 2018 INRIA                                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)

--- a/typing/rec_check.ml
+++ b/typing/rec_check.ml
@@ -441,7 +441,7 @@ let rec expression : mode -> Typedtree.expression -> Env.t =
           | _, Overridden (_, e) -> expression m e
         in
         Env.join (array field m' es)
-                 (option expression mode eo)
+                 (option expression (compos mode Dereference) eo)
     | Texp_ifthenelse (cond, ifso, ifnot) ->
       (*
         Gc |- c: m[Dereference]


### PR DESCRIPTION
This GPR is on top of #1937.

This work was conducted by Alban Reynaud @Cemoixerestre during an internship at INRIA
Saclay, with the help and under the supervision of Gabriel Scherer in
the Parsifal team.

A summary is included below. For more details, see

  https://github.com/Cemoixerestre/Internship-2018-ocaml-recursive-value

or the comments in the code itself, which has evolved a bit from
Alban's internship report above.

Summary:
--------

Rec_check is based on the idea of assigning "access modes" to variables

    m ::= Dereference (* full access and inspection of the value *)
        | Unguarded (* the value result is directly returned *)
        | Guard (* the value is stored under a data constructor *)
        | Delayed (* the value is not needed at definition time *)
        | Unused (* the value is not used at all *)

Before this patchset, the implementation (contributed by Jeremy Yallop)
was formulated as a type-checker manipulating "uses", which are mappings
from free variables to modes

    u ::= (x : m)*

and contexts Γ mapping variables to uses

    Γ ::= (x : u)*

The check relied on a judgment of the form

    Γ ⊢ e : u

where, in the typing algorithm, `Γ` and `e` are the inputs, and `u` is
the output — this could be written `-Γ ⊢ e : +u`.

After this patchset, the implementation uses a simpler notion of context
mapping variables to mods

    Γ ::= (x : m)*

and the judgment has the simpler structure

     Γ ⊢ e : m

but now `m` is an input to the judgment, indicating in which usage
context `e` is checked, and `Γ` is the output: `+Γ ⊢ e : -m`.

Other fixes:
------------

This patchset also fixes a soundness bug around `{ foo with ... }`
which is already present in 4.06 and 4.07.

Another soundness bug found during this work was submitted and fixed
independently as GPR #1915.

This work also led to the refactoring of GPR #1922, and the refactoring
of the testsuite in GPR #1937.
