### PR TITLE
Fix reloading of Icomp operands after spill.

### DIFF
--- a/Changes
+++ b/Changes
@@ -335,6 +335,10 @@ Working version
   Unboxable_type_in_prim_decl
   (Stefan Muenzel)
 
+- GPR#1943: Fix reloading of Icomp operands after register spill
+  (Simon Fowler with help from Stephen Dolan and Mark Shinwell,
+   review by Nicolás Ojeda Bär)
+
 - GPR#1958: allow [module M(_:S) = struct end] syntax
   (Hugo Heuzard, review by Gabriel Scherer)
 

--- a/asmcomp/amd64/reload.ml
+++ b/asmcomp/amd64/reload.ml
@@ -32,9 +32,8 @@ open Mach
      Itailcall_ind                      R
      Iload                      R       R       R
      Istore                             R       R
-     Iintop(Icomp)              R       R       S
-                            or  S       S       R
-     Iintop(Imul|Idiv|Imod)     R       R       S
+     Iintop(Icomp
+            |Imul|Idiv|Imod)    R       R       S
      Iintop(Imulh)              R       R       S
      Iintop(shift)              S       S       R
      Iintop(others)             R       R       S
@@ -65,7 +64,7 @@ inherit Reloadgen.reload_generic as super
 
 method! reload_operation op arg res =
   match op with
-  | Iintop(Iadd|Isub|Iand|Ior|Ixor|Icomp _|Icheckbound _) ->
+  | Iintop(Iadd|Isub|Iand|Ior|Ixor|Icheckbound _) ->
       (* One of the two arguments can reside in the stack, but not both *)
       if stackp arg.(0) && stackp arg.(1)
       then ([|arg.(0); self#makereg arg.(1)|], res)
@@ -80,7 +79,7 @@ method! reload_operation op arg res =
       (* Note: Imulh, Idiv, Imod: arg(0) and res(0) already forced in regs
                Ilsl, Ilsr, Iasr: arg(1) already forced in regs *)
       (arg, res)
-  | Iintop(Imul) | Iaddf | Isubf | Imulf | Idivf ->
+  | Iintop(Icomp _ | Imul) | Iaddf | Isubf | Imulf | Idivf ->
       (* First argument (= result) must be in register, second arg
          can reside in the stack *)
       if stackp arg.(0)

--- a/asmcomp/i386/reload.ml
+++ b/asmcomp/i386/reload.ml
@@ -40,12 +40,12 @@ method! makereg r =
 
 method! reload_operation op arg res =
   match op with
-    Iintop(Iadd|Isub|Iand|Ior|Ixor|Icomp _|Icheckbound _) ->
+    Iintop(Iadd|Isub|Iand|Ior|Ixor|Icheckbound _) ->
       (* One of the two arguments can reside in the stack *)
       if stackp arg.(0) && stackp arg.(1)
       then ([|arg.(0); self#makereg arg.(1)|], res)
       else (arg, res)
-  | Iintop(Imul) ->
+  | Iintop(Icomp _ | Imul) ->
       (* First argument (and destination) must be in register,
          second arg can reside in stack *)
       if stackp arg.(0)


### PR DESCRIPTION
The `Icomp` instruction is compiled using `movzx` on x86 and AMD64:

```
  | Lop(Iintop(Icomp cmp)) ->
      I.cmp (arg i 1) (arg i 0);
      I.set (cond cmp) al;
      I.movzx al (res i 0)
  | Lop(Iintop_imm(Icomp cmp, n)) ->
      I.cmp (int n) (arg i 0);
      I.set (cond cmp) al;
      I.movzx al (res i 0)
```
That is, performing a comparison, then zero-extending `al` using `movzx`.

Currently, reloading for Icomp is done in the same way as `Iadd`, `Isub`, `Iand`, `Ior`, `Ixor`, and `Icheckbound _`. However, `movzx` does not allow its destination operand to be on the stack -- see https://www.felixcloutier.com/x86/MOVZX.html. Thus, it should use the same conventions as `Imul`.

Coming across this case is very unusual indeed -- it only happened in my case as I had to treat loads as impure, which increases register pressure, and I also used the linear scan allocator. But, as it stands, the compiler was generating invalid instructions like

```
movzbq %al, 448(%rsp)
```
which in turn caused assembler "invalid operand size" errors.

Unfortunately, despite trying rather hard, I've not been able to distil this down to a succinct test case. However, you should be able to observe the behaviour yourself by doing the following:
  
1. Adding `| Iload _ ` before `-> false` in the `op_is_pure` function in `asmcomp/amd64/proc.ml`
2. Trying to run the codegen on the following file: https://gist.github.com/SimonJF/1e36c2c2c1a648c09ed862d960f55494 

Thanks to @mshinwell and @stedolan for their help debugging.