### PR TITLE
compile_common: remove wrap_compilation

### DIFF
--- a/Changes
+++ b/Changes
@@ -244,12 +244,13 @@ Working version
 - GPR#374: use Misc.try_finally for resource cleanup in the compiler
   codebase. This should fix the problem of catch-and-reraise `try .. with`
   blocks destroying backtrace information.
-  (François Bobot, Gabriel Scherer, and Nicolás Ojeda Bär, review by Gabriel
-  Scherer)
+  (François Bobot, help from Gabriel Scherer and Nicolás Ojeda Bär,
+   review by Gabriel Scherer)
 
-- GPR#1703 : Add the module Compile_common, which factorizes the common
+- GPR#1703, GPR#1944: Add the module Compile_common, which factorizes the common
   part in Compile and Optcompile. This also makes the pipeline more modular.
-  (Gabriel Radanne, review by Mark Shinwell)
+  (Gabriel Radanne, help from Gabriel Scherer and Valentin Gatien-Baron,
+   review by Mark Shinwell and Gabriel Radanne)
 
 ### Bug fixes:
 

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -49,16 +49,9 @@ let emit_bytecode i (bytecode, required_globals) =
          (Emitcode.to_file oc i.modulename cmofile ~required_globals);
     )
 
-let implementation ~sourcefile ~outputprefix =
-  Compmisc.with_ppf_dump ~fileprefix:(outputprefix ^ ".cmo") @@ fun ppf_dump ->
-  let info =
-    init ppf_dump ~init_path:false ~tool_name ~sourcefile ~outputprefix
-  in
-  Profile.record_call info.sourcefile @@ fun () ->
-  let parsed = parse_impl info in
-  let typed = typecheck_impl info parsed in
-  if not !Clflags.print_types then begin
-    let bytecode = to_bytecode info typed in
-    emit_bytecode info bytecode
-  end;
-  Warnings.check_fatal ();
+let implementation =
+  Compile_common.implementation
+    ~native:false ~tool_name ~backend:(fun info typed ->
+      let bytecode = to_bytecode info typed in
+      emit_bytecode info bytecode
+    )

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -67,13 +67,6 @@ val typecheck_impl :
     its public interface.
 *)
 
-val wrap_compilation :
-  frontend:(info -> 'a) ->
-  backend:(info -> 'a -> unit) -> info -> unit
-(** [wrap_compilation ~frontend ~backend info] calls [frontend] and [backend]
-    in succession while handling options and errors.
-*)
-
 (** {2 Build artifacts} *)
 
 val cmo : info -> string

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -67,6 +67,15 @@ val typecheck_impl :
     its public interface.
 *)
 
+val implementation :
+  tool_name:string ->
+  native:bool ->
+  backend:(info -> Typedtree.structure * Typedtree.module_coercion -> unit) ->
+  sourcefile:string ->
+  outputprefix:string ->
+  unit
+(** The complete compilation pipeline for implementations. *)
+
 (** {2 Build artifacts} *)
 
 val cmo : info -> string


### PR DESCRIPTION
wrap_compilation makes the compilation pipeline non-modular by
exposing a split between two fixed passes, a frontend and a backend,
in a .mli interface. I need a finer-grained interface for a feature
I've been using in my Menhir-parser branch, and it is likely that
other users also will need to be finer-grained than that.

This PR pushes the error/ressource handling contained with
wrap_compilation into its producers (note: this change assume that
only typecheck_impl needs Stypes.dump, and that only the optcompile
backend may generate `obj` and `cmx` files), so that the logic in
"wrap" becomes very simple, and then inlines it in the two users in
{opt,}compile.ml.

(no change entry needed)