### PR TITLE
Refactor Format module to use Queue and Stack

### DIFF
--- a/Changes
+++ b/Changes
@@ -261,6 +261,10 @@ Working version
 - GPR#1938: always check ast invariants after preprocessing
   (Florian Angeletti, review by Alain Frisch and Gabriel Scherer)
 
+- GPR#1948: Refactor Stdlib.Format. Notably, use Stdlib.Stack and Stdlib.Queue,
+  and avoid exceptions for control flow.
+  (Vladimir Keleshev, review by Nicolás Ojeda Bär and Gabriel Scherer)
+
 ### Bug fixes:
 
 - GPR#1626: Do not allow recursive modules in `with module`

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -98,7 +98,7 @@ and tbox = Pp_tbox of int list ref  (* Tabulation box *)
      (size is set when the size of the box is known, so that size of break
       hints are definitive). *)
 type pp_queue_elem = {
-  mutable elem_size : Size.t;
+  mutable size : Size.t;
   token : pp_token;
   length : int;
 }
@@ -283,9 +283,9 @@ let pp_force_break_line state =
 (* To skip a token, if the previous line has been broken. *)
 let pp_skip_token state =
   (* When calling pp_skip_token the queue cannot be empty. *)
-  let { elem_size; length; _ } = Queue.take state.pp_queue in
+  let { size; length; _ } = Queue.take state.pp_queue in
   state.pp_left_total <- state.pp_left_total - length;
-  state.pp_space_left <- state.pp_space_left + Size.to_int elem_size
+  state.pp_space_left <- state.pp_space_left + Size.to_int size
 
 
 (*
@@ -425,7 +425,7 @@ let enqueue_advance state tok = pp_enqueue state tok; advance_left state
 
 (* Building pretty-printer queue elements. *)
 let make_queue_elem size tok len =
-  { elem_size = size; token = tok; length = len; }
+  { size; token = tok; length = len; }
 
 
 (* To enqueue strings. *)
@@ -459,8 +459,8 @@ let initialize_scan_stack stack =
 let set_size state ty =
   match Stack.top_opt state.pp_scan_stack with
   | None -> () (* scan_stack is never empty. *)
-  | Some (Scan_elem (left_total, ({ elem_size; token; _ } as queue_elem))) ->
-    let size = Size.to_int elem_size in
+  | Some (Scan_elem (left_total, ({ size; token; _ } as queue_elem))) ->
+    let size = Size.to_int size in
     (* test if scan stack contains any data that is not obsolete. *)
     if left_total < state.pp_left_total then
       initialize_scan_stack state.pp_scan_stack
@@ -468,12 +468,12 @@ let set_size state ty =
       match token with
       | Pp_break (_, _) | Pp_tbreak (_, _) ->
         if ty then begin
-          queue_elem.elem_size <- Size.of_int (state.pp_right_total + size);
+          queue_elem.size <- Size.of_int (state.pp_right_total + size);
           Stack.pop_opt state.pp_scan_stack |> ignore
         end
       | Pp_begin (_, _) ->
         if not ty then begin
-          queue_elem.elem_size <- Size.of_int (state.pp_right_total + size);
+          queue_elem.size <- Size.of_int (state.pp_right_total + size);
           Stack.pop_opt state.pp_scan_stack |> ignore
         end
       | Pp_text _ | Pp_stab | Pp_tbegin _ | Pp_tend | Pp_end
@@ -515,7 +515,7 @@ let pp_close_box state () =
     if state.pp_curr_depth < state.pp_max_boxes then
     begin
       pp_enqueue state
-        { elem_size = Size.zero; token = Pp_end; length = 0; };
+        { size = Size.zero; token = Pp_end; length = 0; };
       set_size state true; set_size state false
     end;
     state.pp_curr_depth <- state.pp_curr_depth - 1;
@@ -531,7 +531,7 @@ let pp_open_tag state tag_name =
   end;
   if state.pp_mark_tags then
     pp_enqueue state {
-      elem_size = Size.zero;
+      size = Size.zero;
       token = Pp_open_tag tag_name;
       length = 0;
     }
@@ -541,7 +541,7 @@ let pp_open_tag state tag_name =
 let pp_close_tag state () =
   if state.pp_mark_tags then
     pp_enqueue state {
-      elem_size = Size.zero;
+      size = Size.zero;
       token = Pp_close_tag;
       length = 0;
     };

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -31,7 +31,7 @@ module Size : sig
   val of_int : int -> t
   val zero : t
   val unknown : t
-  val is_unknown : t -> bool
+  val is_known : t -> bool
 end  = struct
   type t = int
 
@@ -39,7 +39,7 @@ end  = struct
   let of_int = id
   let zero = 0
   let unknown = -1
-  let is_unknown n = n < 0
+  let is_known n = n >= 0
 end
 
 
@@ -283,10 +283,11 @@ let pp_force_break_line state =
 
 (* To skip a token, if the previous line has been broken. *)
 let pp_skip_token state =
-  (* When calling pp_skip_token the queue cannot be empty. *)
-  let { size; length; _ } = Queue.take state.pp_queue in
-  state.pp_left_total <- state.pp_left_total - length;
-  state.pp_space_left <- state.pp_space_left + Size.to_int size
+  match Queue.take_opt state.pp_queue with
+  | None -> () (* print_if_newline must have been the last printing command *)
+  | Some { size; length; _ } ->
+    state.pp_left_total <- state.pp_left_total - length;
+    state.pp_space_left <- state.pp_space_left + Size.to_int size
 
 
 (*

--- a/testsuite/tests/lib-format/ocamltests
+++ b/testsuite/tests/lib-format/ocamltests
@@ -1,2 +1,3 @@
 pr6824.ml
 tformat.ml
+print_if_newline.ml

--- a/testsuite/tests/lib-format/print_if_newline.ml
+++ b/testsuite/tests/lib-format/print_if_newline.ml
@@ -1,0 +1,26 @@
+(* TEST *)
+
+(*
+
+A test file for Format.print_if_newline.
+
+*)
+
+open Format;;
+
+printf "\ntest print_if_newline\n%!";
+printf "  newline here\n%!";
+print_if_newline ();
+printf "  this gets printed";
+print_if_newline ();
+printf "  this doesn't get printed";
+
+printf "\nprint_if_newline doesn't crash when last statement\n%!";
+printf "  newline here\n";
+(* Important that the following is the last statement in the file.
+
+   [print_if_newline] sets up the Format module to skip printing
+   the next printing command. However, it should not crash if there
+   is no next printing statement. *)
+print_if_newline ();
+;;

--- a/testsuite/tests/lib-format/print_if_newline.reference
+++ b/testsuite/tests/lib-format/print_if_newline.reference
@@ -1,0 +1,6 @@
+
+test print_if_newline
+  newline here
+  this gets printed
+print_if_newline doesn't crash when last statement
+  newline here


### PR DESCRIPTION
I wanted to contribute a feature to the Format module, but first I decided to refactor it a bit to understand the code better.

Using Stack and Queue modules instead of ad-hoc implementations of stacks and queues improves clarity and reduces the volume of code. I think it makes it easier to contribute to the module.

It looks like Format re-implements queues and stacks on purpose, to avoid dependencies. Perhaps the idea was that someday Stack and Queue would acquire pretty-printing functions that depend on Format. If that is necessary, additional internal modules could be extracted, for example, Stack0 and Queue0, or CamlInternalStack and CamlInternalQueue. 

I am interested to hear what you think.