### PR TITLE
Fix Unix.fsync on Windows: retrieve fd outside blocking section

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,9 +26,9 @@ Working version
 
 ### Standard library:
 
-- MPR#2533, GPR#1839: added Unix.fsync
-  (Nicolas Ojeda Bar, Francois Berenger, review by Daniel Bunzli and
-  David Allsopp)
+- MPR#2533, GPR#1839, GPR#1949: added Unix.fsync
+  (Francois Berenger, Nicolás Ojeda Bär, review by Daniel Bünzli, David Allsopp
+  and ygrek)
 
 - MPR#6701, GPR#1185, GPR#1803: make float_of_string and string_of_float
   locale-independent.

--- a/otherlibs/unix/fsync.c
+++ b/otherlibs/unix/fsync.c
@@ -19,14 +19,19 @@
 
 #ifdef _WIN32
 #include <io.h>
-#define fsync(fd) _commit(win_CRT_fd_of_filedescr(fd))
+#define fsync(fd) _commit(fd)
 #else
-#define fsync(fd) fsync(Int_val(fd))
+#define fsync(fd) fsync(fd)
 #endif
 
-CAMLprim value unix_fsync(value fd)
+CAMLprim value unix_fsync(value v)
 {
   int ret;
+#ifdef _WIN32
+  int fd = win_CRT_fd_of_filedescr(v);
+#else
+  int fd = Int_val(v);
+#endif
   caml_enter_blocking_section();
   ret = fsync(fd);
   caml_leave_blocking_section();


### PR DESCRIPTION
Fixes a bug spotted by @ygrek: `win_CRT_fd_of_filedescr` needs to be called outside blocking section because the argument is a heap block.