### PR TITLE
test suite: empty polymorphic variants in pattern

### DIFF
--- a/testsuite/tests/typing-misc/empty_ppx.ml
+++ b/testsuite/tests/typing-misc/empty_ppx.ml
@@ -1,0 +1,14 @@
+module H = Ast_helper
+module M = Ast_mapper
+open Parsetree
+let empty_polyvar loc = H.Typ.variant ~loc [] Asttypes.Closed None
+
+let super = M.default_mapper
+let typ mapper e =
+  match e.ptyp_desc with
+  | Ptyp_extension ({txt="empty_polyvar";loc},_) -> empty_polyvar loc
+  | _ -> super.M.typ mapper e
+
+let () = M.register "empty ppx" (fun _ ->
+    { super with typ }
+  )

--- a/testsuite/tests/typing-misc/ocamltests
+++ b/testsuite/tests/typing-misc/ocamltests
@@ -20,3 +20,4 @@ wellfounded.ml
 empty_variant.ml
 typecore_errors.ml
 typecore_nolabel_errors.ml
+typecore_empty_polyvariant_error.ml

--- a/testsuite/tests/typing-misc/typecore_empty_polyvariant_error.compilers.reference
+++ b/testsuite/tests/typing-misc/typecore_empty_polyvariant_error.compilers.reference
@@ -1,0 +1,7 @@
+type t = [  ]
+Line 1, characters 31-32:
+  let f: 'a. t -> 'a = function #t -> . ;;
+                                 ^
+Error: The type t
+is not a variant type
+

--- a/testsuite/tests/typing-misc/typecore_empty_polyvariant_error.ml
+++ b/testsuite/tests/typing-misc/typecore_empty_polyvariant_error.ml
@@ -1,0 +1,13 @@
+(* TEST
+  files="empty_ppx.ml"
+  * setup-ocamlc.byte-build-env
+  ** ocamlc.byte with ocamlcommon
+  all_modules="empty_ppx.ml"
+  program="ppx.exe"
+  *** toplevel
+  all_modules="${test_file}"
+  flags="-ppx '${ocamlrun} ${test_build_directory_prefix}/ocamlc.byte/ppx.exe'"
+*)
+
+type t = [%empty_polyvar];;
+let f: 'a. t -> 'a = function #t -> . ;;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -640,7 +640,10 @@ let build_or_pat env loc lid =
       pats
   in
   match pats with
-    [] -> raise(Error(lid.loc, env, Not_a_variant_type lid.txt))
+    [] ->
+      (* empty polymorphic variants: not possible with the concrete language
+         but valid at the ast level *)
+      raise(Error(lid.loc, env, Not_a_variant_type lid.txt))
   | pat :: pats ->
       let r =
         List.fold_left


### PR DESCRIPTION
This small PR adds a test and a comment for ppx-only typechecking error for empty polymorphic variant abbreviation in pattern:

```OCaml
type t = [%empty_list_of_tags]
let f #t = ()
```
> Error: The type t
is not a variant type
