### PR TITLE
Location: refactor the code responsible for displaying errors and warnings

### DIFF
--- a/Changes
+++ b/Changes
@@ -242,8 +242,12 @@ Working version
 
 ### Internal/compiler-libs changes:
 
+* GPR#1952: refactor the code responsible for displaying errors and warnings
+  (Armaël Guéneau, review by Thomas Refis)
+
 - GPR#1894: generalize highlight_dumb in location.ml to handle highlighting
-  several locations (Armaël Guéneau, review by Gabriel Scherer)
+  several locations
+  (Armaël Guéneau, review by Gabriel Scherer)
 
 - GPR#1745: do not generalize the type of every sub-pattern, only of variables.
   (Thomas Refis, review by Leo White)

--- a/bytecomp/translclass.ml
+++ b/bytecomp/translclass.ml
@@ -926,7 +926,7 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, err) ->
-        Some (Location.error_of_printer loc report_error err)
+        Some (Location.error_of_printer ~loc report_error err)
       | _ ->
         None
     )

--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -909,7 +909,7 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, err) ->
-          Some (Location.error_of_printer loc report_error err)
+          Some (Location.error_of_printer ~loc report_error err)
       | _ ->
         None
     )

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -1375,7 +1375,7 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, err) ->
-        Some (Location.error_of_printer loc report_error err)
+        Some (Location.error_of_printer ~loc report_error err)
       | _ ->
         None
     )

--- a/bytecomp/translprim.ml
+++ b/bytecomp/translprim.ml
@@ -756,7 +756,7 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, err) ->
-          Some (Location.error_of_printer loc report_error err)
+          Some (Location.error_of_printer ~loc report_error err)
       | _ ->
         None
     )

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -476,8 +476,9 @@ let scan_line ic =
 let load_config ppf filename =
   match open_in_bin filename with
   | exception e ->
-      Location.print_error ppf (Location.in_file filename);
-      Format.fprintf ppf "Cannot open file %s@." (Printexc.to_string e);
+      Location.errorf ~loc:(Location.in_file filename)
+        "Cannot open file %s" (Printexc.to_string e)
+      |> Location.print_report ppf;
       raise Exit
   | ic ->
       let sic = Scanf.Scanning.from_channel ic in
@@ -500,8 +501,8 @@ let load_config ppf filename =
                 loc_ghost = false;
               }
             in
-            Location.print_error ppf loc;
-            Format.fprintf ppf "Configuration file error %s@." error;
+            Location.errorf ~loc "Configuration file error %s" error
+            |> Location.print_report ppf;
             close_in ic;
             raise Exit
         | line ->

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -460,9 +460,8 @@ let sort_files_by_dependencies files =
   done;
 
   if !worklist <> [] then begin
-    Format.fprintf Format.err_formatter
-      "@[%t: cycle in dependencies. End of list is not sorted.@]@."
-      Location.print_error_prefix;
+    Location.error "cycle in dependencies. End of list is not sorted."
+    |> Location.print_report Format.err_formatter;
     let sorted_deps =
       let li = ref [] in
       Hashtbl.iter (fun _ file_deps -> li := file_deps :: !li) h;

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -17,7 +17,6 @@ open! Int_replace_polymorphic_compare
 
 type t = string
 
-let anon_fn = "anon_fn"
 let apply_arg = "apply_arg"
 let apply_funct = "apply_funct"
 let block_symbol = "block_symbol"
@@ -291,12 +290,15 @@ let toplevel_substitution_named = "toplevel_substitution_named"
 let unbox_free_vars_of_closures = "unbox_free_vars_of_closures"
 let zero = "zero"
 
-let anon_fn_with_loc_fmt = format_of_string "anon_fn[%a]"
-let anon_fn_with_loc loc =
-  if loc.Location.loc_ghost then anon_fn
-  else begin
-    Format.asprintf anon_fn_with_loc_fmt Location.print_compact loc
-  end
+let anon_fn_with_loc (loc: Location.t) =
+  let (file, line, startchar) = Location.get_pos_info loc.loc_start in
+  let endchar = loc.loc_end.pos_cnum - loc.loc_start.pos_bol in
+  let pp_chars ppf =
+    if startchar >= 0 then Format.fprintf ppf ",%i--%i" startchar endchar in
+  if loc.Location.loc_ghost then "anon_fn"
+  else
+    Format.asprintf "anon_fn[%a:%i%t]"
+      Location.print_filename file line pp_chars
 
 let of_primitive : Lambda.primitive -> string = function
   | Pidentity -> pidentity

--- a/middle_end/middle_end.ml
+++ b/middle_end/middle_end.ml
@@ -37,7 +37,7 @@ let middle_end ~ppf_dump ~prefixname ~backend
     ~module_ident
     ~module_initializer =
   Profile.record_call "flambda" (fun () ->
-    let previous_warning_printer = !Location.warning_printer in
+    let previous_warning_reporter = !Location.warning_reporter in
     let module WarningSet =
       Set.Make (struct
         type t = Location.t * Warnings.t
@@ -45,15 +45,15 @@ let middle_end ~ppf_dump ~prefixname ~backend
       end)
     in
     let warning_set = ref WarningSet.empty in
-    let flambda_warning_printer loc ppf w =
+    let flambda_warning_reporter loc w =
       let elt = loc, w in
       if not (WarningSet.mem elt !warning_set) then begin
         warning_set := WarningSet.add elt !warning_set;
-        previous_warning_printer loc ppf w
-      end;
+        previous_warning_reporter loc w
+      end else None
     in
     Misc.protect_refs
-      [Misc.R (Location.warning_printer, flambda_warning_printer)]
+      [Misc.R (Location.warning_reporter, flambda_warning_reporter)]
       (fun () ->
          let pass_number = ref 0 in
          let round_number = ref 0 in

--- a/parsing/attr_helper.ml
+++ b/parsing/attr_helper.ml
@@ -48,7 +48,7 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, err) ->
-        Some (Location.error_of_printer loc report_error err)
+        Some (Location.error_of_printer ~loc report_error err)
       | _ ->
         None
     )

--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -32,11 +32,6 @@ type error =
 
 exception Error of error * Location.t
 
-open Format
-
-val report_error: formatter -> error -> unit
- (* Deprecated.  Use Location.{error_of_exn, report_error}. *)
-
 val in_comment : unit -> bool;;
 val in_string : unit -> bool;;
 

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -101,13 +101,12 @@ val highlight_terminfo:
   Lexing.lexbuf -> formatter -> t list -> unit
 
 val highlight_dumb:
-  print_chars:bool -> Lexing.lexbuf -> formatter -> t list -> unit
-
-val highlight_locations:
-  formatter -> t list -> unit
+  Lexing.lexbuf -> formatter -> t list -> unit
 
 
 (** {1 Reporting errors and warnings} *)
+
+(** {2 The type of reports and report printers} *)
 
 type msg = (Format.formatter -> unit) loc
 
@@ -149,16 +148,27 @@ type report_printer = {
     existing ones.
 *)
 
+(** {2 Report printers used in the compiler} *)
+
 val batch_mode_printer: report_printer
-val toplevel_printer:
-  highlight:(formatter -> t list -> unit) ->
-  report_printer
+
+val terminfo_toplevel_printer: Lexing.lexbuf -> report_printer
+val dumb_toplevel_printer: Lexing.lexbuf -> report_printer
+
+val best_toplevel_printer: unit -> report_printer
+(** Detects the terminal capabilities and selects an adequate printer *)
+
+(** {2 Printing a [report]} *)
 
 val print_report: formatter -> report -> unit
 (** Display an error or warning report. *)
 
 val report_printer: (unit -> report_printer) ref
-(** Hook for redefining the printer of reports. *)
+(** Hook for redefining the printer of reports.
+
+    The hook is a [unit -> report_printer] and not simply a [report_printer]:
+    this is useful so that it can detect the type of the output (a file, a
+    terminal, ...) and select a printer accordingly. *)
 
 val default_report_printer: unit -> report_printer
 (** Original report printer for use in hooks. *)

--- a/parsing/syntaxerr.ml
+++ b/parsing/syntaxerr.ml
@@ -28,17 +28,15 @@ type error =
 exception Error of error
 exception Escape_error
 
-let prepare_error = function
+let prepare_error err =
+  match err with
   | Unclosed(opening_loc, opening, closing_loc, closing) ->
-      Location.errorf ~loc:closing_loc
+      Location.errorf
+        ~loc:closing_loc
         ~sub:[
-          Location.errorf ~loc:opening_loc
+          Location.msg ~loc:opening_loc
             "This '%s' might be unmatched" opening
         ]
-        ~if_highlight:
-          (Printf.sprintf "Syntax error: '%s' expected, \
-                           the highlighted '%s' might be unmatched"
-             closing opening)
         "Syntax error: '%s' expected" closing
 
   | Expecting (loc, nonterm) ->
@@ -53,11 +51,12 @@ let prepare_error = function
       Location.errorf ~loc
         "In this scoped type, variable '%s \
          is reserved for the local type %s."
-         var var
+        var var
   | Other loc ->
       Location.errorf ~loc "Syntax error"
   | Ill_formed_ast (loc, s) ->
-      Location.errorf ~loc "broken invariant in parsetree: %s" s
+      Location.errorf ~loc
+        "broken invariant in parsetree: %s" s
   | Invalid_package_type (loc, s) ->
       Location.errorf ~loc "invalid package type: %s" s
 
@@ -70,7 +69,7 @@ let () =
 
 
 let report_error ppf err =
-  Location.report_error ppf (prepare_error err)
+  Location.print_report ppf (prepare_error err)
 
 let location_of_error = function
   | Unclosed(l,_,_,_)

--- a/testsuite/tests/formatting/errors_batch.ml
+++ b/testsuite/tests/formatting/errors_batch.ml
@@ -1,0 +1,35 @@
+(* TEST
+   include ocamlcommon
+*)
+
+let () =
+  let open Location in
+  (* Some dummy locations for demo purposes *)
+  let pos = Lexing.{
+    pos_fname = "hello.ml";
+    pos_lnum = 18;
+    pos_bol = 15;
+    pos_cnum = 35;
+  } in
+  let loc1 = {
+    loc_start = pos; loc_end = { pos with pos_cnum = 42 };
+    loc_ghost = false
+  } in
+  let loc2 = {
+    loc_start = { pos with pos_lnum = 20; pos_bol = 0; pos_cnum = 4 };
+    loc_end = { pos with pos_lnum = 20; pos_bol = 0; pos_cnum = 8 };
+    loc_ghost = false
+  } in
+  let report = {
+    kind = Report_error;
+    main = msg ~loc:loc1 "%a" Format.pp_print_text
+        "These are the contents of the main error message. \
+         It is very long and should wrap across several lines.";
+    sub = [
+      msg ~loc:loc2 "A located first sub-message.";
+      msg "@[<v>This second sub-message does not have \
+           a location;@,ghost locations of submessages are \
+           not printed.@]";
+    ]
+  } in
+  print_report Format.std_formatter report

--- a/testsuite/tests/formatting/errors_batch.reference
+++ b/testsuite/tests/formatting/errors_batch.reference
@@ -1,0 +1,7 @@
+File "hello.ml", line 18, characters 20-27:
+Error: These are the contents of the main error message. It is very long and
+       should wrap across several lines.
+       File "hello.ml", line 20, characters 4-8:
+       A located first sub-message.
+       This second sub-message does not have a location;
+       ghost locations of submessages are not printed.

--- a/testsuite/tests/formatting/margins.ml
+++ b/testsuite/tests/formatting/margins.ml
@@ -7,5 +7,6 @@ let () = Format.pp_set_margin Format.std_formatter 20;;
 1 + "foo";;
 
 let () = Format.pp_set_margin Format.std_formatter 80;;
+let () = Format.pp_set_max_indent Format.std_formatter 70;;
 
 1 + "foo";;

--- a/testsuite/tests/formatting/ocamltests
+++ b/testsuite/tests/formatting/ocamltests
@@ -1,1 +1,2 @@
 margins.ml
+errors_batch.ml

--- a/testsuite/tests/parse-errors/unclosed_class_simpl_expr2.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_class_simpl_expr2.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_class_simpl_expr2.ml", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-File "unclosed_class_simpl_expr2.ml", line 8, characters 10-11:
-Error: This '(' might be unmatched
+       File "unclosed_class_simpl_expr2.ml", line 8, characters 10-11:
+       This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_class_simpl_expr3.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_class_simpl_expr3.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_class_simpl_expr3.ml", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-File "unclosed_class_simpl_expr3.ml", line 8, characters 10-11:
-Error: This '(' might be unmatched
+       File "unclosed_class_simpl_expr3.ml", line 8, characters 10-11:
+       This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr1.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr1.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_paren_module_expr1.ml", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-File "unclosed_paren_module_expr1.ml", line 8, characters 11-12:
-Error: This '(' might be unmatched
+       File "unclosed_paren_module_expr1.ml", line 8, characters 11-12:
+       This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr2.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr2.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_paren_module_expr2.ml", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-File "unclosed_paren_module_expr2.ml", line 8, characters 11-12:
-Error: This '(' might be unmatched
+       File "unclosed_paren_module_expr2.ml", line 8, characters 11-12:
+       This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr3.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr3.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_paren_module_expr3.ml", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-File "unclosed_paren_module_expr3.ml", line 8, characters 11-12:
-Error: This '(' might be unmatched
+       File "unclosed_paren_module_expr3.ml", line 8, characters 11-12:
+       This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr4.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr4.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_paren_module_expr4.ml", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-File "unclosed_paren_module_expr4.ml", line 8, characters 11-12:
-Error: This '(' might be unmatched
+       File "unclosed_paren_module_expr4.ml", line 8, characters 11-12:
+       This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr5.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr5.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_paren_module_expr5.ml", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-File "unclosed_paren_module_expr5.ml", line 8, characters 11-12:
-Error: This '(' might be unmatched
+       File "unclosed_paren_module_expr5.ml", line 8, characters 11-12:
+       This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_type.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_type.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_paren_module_type.mli", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-File "unclosed_paren_module_type.mli", line 8, characters 11-12:
-Error: This '(' might be unmatched
+       File "unclosed_paren_module_type.mli", line 8, characters 11-12:
+       This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_sig.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_sig.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_sig.mli", line 10, characters 0-0:
 Error: Syntax error: 'end' expected
-File "unclosed_sig.mli", line 8, characters 11-14:
-Error: This 'sig' might be unmatched
+       File "unclosed_sig.mli", line 8, characters 11-14:
+       This 'sig' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_simple_expr.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_simple_expr.compilers.reference
@@ -1,61 +1,87 @@
-Line 5, characters 0-1, Line 5, characters 5-7:  (3; 2;;
-                                                 ^    ^^
-Syntax error: ')' expected, the highlighted '(' might be unmatched
-Line 2, characters 0-5,
-Line 2, characters 10-12:
+Line 5, characters 5-7,
+Line 5, characters 0-1:
+  (3; 2;;
+  ^    ^^
+Error: Syntax error: ')' expected
+       Line 5, characters 0-1:
+       This '(' might be unmatched
+Line 2, characters 10-12,
+Line 2, characters 0-5:
   begin 3; 2;;
   ^^^^^     ^^
-Syntax error: 'end' expected, the highlighted 'begin' might be unmatched
-Line 2, characters 5-6,
-Line 2, characters 10-12:
+Error: Syntax error: 'end' expected
+       Line 2, characters 0-5:
+       This 'begin' might be unmatched
+Line 2, characters 10-12,
+Line 2, characters 5-6:
   List.(3; 2;;
        ^    ^^
-Syntax error: ')' expected, the highlighted '(' might be unmatched
-Line 2, characters 12-13,
-Line 2, characters 17-19:
+Error: Syntax error: ')' expected
+       Line 2, characters 5-6:
+       This '(' might be unmatched
+Line 2, characters 17-19,
+Line 2, characters 12-13:
   simple_expr.(3; 2;;
               ^    ^^
-Syntax error: ')' expected, the highlighted '(' might be unmatched
-Line 2, characters 12-13,
-Line 2, characters 17-19:
+Error: Syntax error: ')' expected
+       Line 2, characters 12-13:
+       This '(' might be unmatched
+Line 2, characters 17-19,
+Line 2, characters 12-13:
   simple_expr.[3; 2;;
               ^    ^^
-Syntax error: ']' expected, the highlighted '[' might be unmatched
-Line 2, characters 13-14,
-Line 2, characters 15-17:
+Error: Syntax error: ']' expected
+       Line 2, characters 12-13:
+       This '[' might be unmatched
+Line 2, characters 15-17,
+Line 2, characters 13-14:
   simple_expr.%[3;;
                ^ ^^
-Syntax error: ']' expected, the highlighted '[' might be unmatched
-Line 2, characters 13-14,
-Line 2, characters 15-17:
+Error: Syntax error: ']' expected
+       Line 2, characters 13-14:
+       This '[' might be unmatched
+Line 2, characters 15-17,
+Line 2, characters 13-14:
   simple_expr.%(3;;
                ^ ^^
-Syntax error: ')' expected, the highlighted '(' might be unmatched
-Line 2, characters 13-14,
-Line 2, characters 15-17:
+Error: Syntax error: ')' expected
+       Line 2, characters 13-14:
+       This '(' might be unmatched
+Line 2, characters 15-17,
+Line 2, characters 13-14:
   simple_expr.%{3;;
                ^ ^^
-Syntax error: '}' expected, the highlighted '{' might be unmatched
-Line 2, characters 9-10,
-Line 2, characters 11-13:
+Error: Syntax error: '}' expected
+       Line 2, characters 13-14:
+       This '{' might be unmatched
+Line 2, characters 11-13,
+Line 2, characters 9-10:
   foo.Bar.%[3;;
            ^ ^^
-Syntax error: ']' expected, the highlighted '[' might be unmatched
-Line 2, characters 9-10,
-Line 2, characters 11-13:
+Error: Syntax error: ']' expected
+       Line 2, characters 9-10:
+       This '[' might be unmatched
+Line 2, characters 11-13,
+Line 2, characters 9-10:
   foo.Bar.%(3;;
            ^ ^^
-Syntax error: ')' expected, the highlighted '(' might be unmatched
-Line 2, characters 9-10,
-Line 2, characters 11-13:
+Error: Syntax error: ')' expected
+       Line 2, characters 9-10:
+       This '(' might be unmatched
+Line 2, characters 11-13,
+Line 2, characters 9-10:
   foo.Bar.%{3;;
            ^ ^^
-Syntax error: '}' expected, the highlighted '{' might be unmatched
-Line 2, characters 12-13,
-Line 2, characters 17-19:
+Error: Syntax error: '}' expected
+       Line 2, characters 9-10:
+       This '{' might be unmatched
+Line 2, characters 17-19,
+Line 2, characters 12-13:
   simple_expr.{3, 2;;
               ^    ^^
-Syntax error: '}' expected, the highlighted '{' might be unmatched
+Error: Syntax error: '}' expected
+       Line 2, characters 12-13:
+       This '{' might be unmatched
 Line 2, characters 10-12:
   { x = 3; y;;
             ^^
@@ -88,20 +114,26 @@ Line 2, characters 17-19:
   List.{< x = 3; y ;;
                    ^^
 Error: Syntax error
-Line 2, characters 0-1,
-Line 2, characters 20-22:
+Line 2, characters 20-22,
+Line 2, characters 0-1:
   (module struct end :;;
   ^                   ^^
-Syntax error: ')' expected, the highlighted '(' might be unmatched
-Line 2, characters 5-6,
-Line 2, characters 25-27:
+Error: Syntax error: ')' expected
+       Line 2, characters 0-1:
+       This '(' might be unmatched
+Line 2, characters 25-27,
+Line 2, characters 5-6:
   List.(module struct end :;;
        ^                   ^^
-Syntax error: ')' expected, the highlighted '(' might be unmatched
+Error: Syntax error: ')' expected
+       Line 2, characters 5-6:
+       This '(' might be unmatched
 
-Line 2, characters 0-1,
-Line 2, characters 2-3:
+Line 2, characters 2-3,
+Line 2, characters 0-1:
   (=;
   ^ ^
-Syntax error: ')' expected, the highlighted '(' might be unmatched
+Error: Syntax error: ')' expected
+       Line 2, characters 0-1:
+       This '(' might be unmatched
 

--- a/testsuite/tests/parse-errors/unclosed_simple_expr.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_simple_expr.compilers.reference
@@ -1,86 +1,98 @@
-Line 5, characters 5-7,
-Line 5, characters 0-1:
+Line 5, characters 5-7:
   (3; 2;;
-  ^    ^^
+       ^^
 Error: Syntax error: ')' expected
        Line 5, characters 0-1:
+         (3; 2;;
+         ^
        This '(' might be unmatched
-Line 2, characters 10-12,
-Line 2, characters 0-5:
+Line 2, characters 10-12:
   begin 3; 2;;
-  ^^^^^     ^^
+            ^^
 Error: Syntax error: 'end' expected
        Line 2, characters 0-5:
+         begin 3; 2;;
+         ^^^^^
        This 'begin' might be unmatched
-Line 2, characters 10-12,
-Line 2, characters 5-6:
+Line 2, characters 10-12:
   List.(3; 2;;
-       ^    ^^
+            ^^
 Error: Syntax error: ')' expected
        Line 2, characters 5-6:
+         List.(3; 2;;
+              ^
        This '(' might be unmatched
-Line 2, characters 17-19,
-Line 2, characters 12-13:
+Line 2, characters 17-19:
   simple_expr.(3; 2;;
-              ^    ^^
+                   ^^
 Error: Syntax error: ')' expected
        Line 2, characters 12-13:
+         simple_expr.(3; 2;;
+                     ^
        This '(' might be unmatched
-Line 2, characters 17-19,
-Line 2, characters 12-13:
+Line 2, characters 17-19:
   simple_expr.[3; 2;;
-              ^    ^^
+                   ^^
 Error: Syntax error: ']' expected
        Line 2, characters 12-13:
+         simple_expr.[3; 2;;
+                     ^
        This '[' might be unmatched
-Line 2, characters 15-17,
-Line 2, characters 13-14:
+Line 2, characters 15-17:
   simple_expr.%[3;;
-               ^ ^^
+                 ^^
 Error: Syntax error: ']' expected
        Line 2, characters 13-14:
+         simple_expr.%[3;;
+                      ^
        This '[' might be unmatched
-Line 2, characters 15-17,
-Line 2, characters 13-14:
+Line 2, characters 15-17:
   simple_expr.%(3;;
-               ^ ^^
+                 ^^
 Error: Syntax error: ')' expected
        Line 2, characters 13-14:
+         simple_expr.%(3;;
+                      ^
        This '(' might be unmatched
-Line 2, characters 15-17,
-Line 2, characters 13-14:
+Line 2, characters 15-17:
   simple_expr.%{3;;
-               ^ ^^
+                 ^^
 Error: Syntax error: '}' expected
        Line 2, characters 13-14:
+         simple_expr.%{3;;
+                      ^
        This '{' might be unmatched
-Line 2, characters 11-13,
-Line 2, characters 9-10:
+Line 2, characters 11-13:
   foo.Bar.%[3;;
-           ^ ^^
+             ^^
 Error: Syntax error: ']' expected
        Line 2, characters 9-10:
+         foo.Bar.%[3;;
+                  ^
        This '[' might be unmatched
-Line 2, characters 11-13,
-Line 2, characters 9-10:
+Line 2, characters 11-13:
   foo.Bar.%(3;;
-           ^ ^^
+             ^^
 Error: Syntax error: ')' expected
        Line 2, characters 9-10:
+         foo.Bar.%(3;;
+                  ^
        This '(' might be unmatched
-Line 2, characters 11-13,
-Line 2, characters 9-10:
+Line 2, characters 11-13:
   foo.Bar.%{3;;
-           ^ ^^
+             ^^
 Error: Syntax error: '}' expected
        Line 2, characters 9-10:
+         foo.Bar.%{3;;
+                  ^
        This '{' might be unmatched
-Line 2, characters 17-19,
-Line 2, characters 12-13:
+Line 2, characters 17-19:
   simple_expr.{3, 2;;
-              ^    ^^
+                   ^^
 Error: Syntax error: '}' expected
        Line 2, characters 12-13:
+         simple_expr.{3, 2;;
+                     ^
        This '{' might be unmatched
 Line 2, characters 10-12:
   { x = 3; y;;
@@ -114,26 +126,29 @@ Line 2, characters 17-19:
   List.{< x = 3; y ;;
                    ^^
 Error: Syntax error
-Line 2, characters 20-22,
-Line 2, characters 0-1:
+Line 2, characters 20-22:
   (module struct end :;;
-  ^                   ^^
+                      ^^
 Error: Syntax error: ')' expected
        Line 2, characters 0-1:
+         (module struct end :;;
+         ^
        This '(' might be unmatched
-Line 2, characters 25-27,
-Line 2, characters 5-6:
+Line 2, characters 25-27:
   List.(module struct end :;;
-       ^                   ^^
+                           ^^
 Error: Syntax error: ')' expected
        Line 2, characters 5-6:
+         List.(module struct end :;;
+              ^
        This '(' might be unmatched
 
-Line 2, characters 2-3,
-Line 2, characters 0-1:
+Line 2, characters 2-3:
   (=;
-  ^ ^
+    ^
 Error: Syntax error: ')' expected
        Line 2, characters 0-1:
+         (=;
+         ^
        This '(' might be unmatched
 

--- a/testsuite/tests/parse-errors/unclosed_simple_pattern.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_simple_pattern.compilers.reference
@@ -1,23 +1,26 @@
-Line 7, characters 0-2,
-Line 6, characters 9-10:
-  .........(.
+Line 7, characters 0-2:
   ;;
+  ^^
 Error: Syntax error: ')' expected
        Line 6, characters 9-10:
+           | List.(_
+                  ^
        This '(' might be unmatched
-Line 4, characters 0-2,
-Line 3, characters 4-5:
-  ....(.
+Line 4, characters 0-2:
   ;;
+  ^^
 Error: Syntax error: ')' expected
        Line 3, characters 4-5:
+           | (_
+             ^
        This '(' might be unmatched
-Line 4, characters 0-2,
-Line 3, characters 4-5:
-  ....(.......
+Line 4, characters 0-2:
   ;;
+  ^^
 Error: Syntax error: ')' expected
        Line 3, characters 4-5:
+           | (_ : int
+             ^
        This '(' might be unmatched
 Line 7, characters 0-2:
   ;;

--- a/testsuite/tests/parse-errors/unclosed_simple_pattern.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_simple_pattern.compilers.reference
@@ -1,16 +1,24 @@
-Line 6, characters 9-10, Line 7, characters 0-2:  .........(.
-                                                  ;;
-Syntax error: ')' expected, the highlighted '(' might be unmatched
-Line 3, characters 4-5,
-Line 4, characters 0-2:
+Line 7, characters 0-2,
+Line 6, characters 9-10:
+  .........(.
+  ;;
+Error: Syntax error: ')' expected
+       Line 6, characters 9-10:
+       This '(' might be unmatched
+Line 4, characters 0-2,
+Line 3, characters 4-5:
   ....(.
   ;;
-Syntax error: ')' expected, the highlighted '(' might be unmatched
-Line 3, characters 4-5,
-Line 4, characters 0-2:
+Error: Syntax error: ')' expected
+       Line 3, characters 4-5:
+       This '(' might be unmatched
+Line 4, characters 0-2,
+Line 3, characters 4-5:
   ....(.......
   ;;
-Syntax error: ')' expected, the highlighted '(' might be unmatched
+Error: Syntax error: ')' expected
+       Line 3, characters 4-5:
+       This '(' might be unmatched
 Line 7, characters 0-2:
   ;;
   ^^

--- a/testsuite/tests/parse-errors/unclosed_struct.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_struct.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_struct.ml", line 10, characters 0-0:
 Error: Syntax error: 'end' expected
-File "unclosed_struct.ml", line 8, characters 11-17:
-Error: This 'struct' might be unmatched
+       File "unclosed_struct.ml", line 8, characters 11-17:
+       This 'struct' might be unmatched

--- a/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
+++ b/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
@@ -3,27 +3,33 @@ Line 9, characters 8-15:
           ^^^^^^^
 Error: This expression has type int but an expression was expected of type
          float
-Line 2, characters 8-9,
-Line 2, characters 15-17:
+Line 2, characters 15-17,
+Line 2, characters 8-9:
   let x = (1 + 2 in ();;
           ^      ^^
-Syntax error: ')' expected, the highlighted '(' might be unmatched
-Line 2, characters 8-9,
-Line 2, characters 14-16:
+Error: Syntax error: ')' expected
+       Line 2, characters 8-9:
+       This '(' might be unmatched
+Line 2, characters 14-16,
+Line 2, characters 8-9:
   let x = (1 + 2;;
           ^     ^^
-Syntax error: ')' expected, the highlighted '(' might be unmatched
+Error: Syntax error: ')' expected
+       Line 2, characters 8-9:
+       This '(' might be unmatched
 Line 3, characters 8-9:
   let y = 1 +. 2. in
           ^
 Error: This expression has type int but an expression was expected of type
          float
-Line 2, characters 8-9,
-Line 4, characters 2-4:
+Line 4, characters 2-4,
+Line 2, characters 8-9:
   ........(.
   ...
   ..in
-Syntax error: ')' expected, the highlighted '(' might be unmatched
+Error: Syntax error: ')' expected
+       Line 2, characters 8-9:
+       This '(' might be unmatched
 Line 2, characters 8-17:
   ........(1
     +
@@ -35,12 +41,12 @@ Error: This expression has type int but an expression was expected of type
          float
 File "error_highlighting_use2.ml", line 1, characters 15-17:
 Error: Syntax error: ')' expected
-File "error_highlighting_use2.ml", line 1, characters 8-9:
-Error: This '(' might be unmatched
+       File "error_highlighting_use2.ml", line 1, characters 8-9:
+       This '(' might be unmatched
 File "error_highlighting_use3.ml", line 3, characters 2-4:
 Error: Syntax error: ')' expected
-File "error_highlighting_use3.ml", line 1, characters 8-9:
-Error: This '(' might be unmatched
+       File "error_highlighting_use3.ml", line 1, characters 8-9:
+       This '(' might be unmatched
 File "error_highlighting_use4.ml", line 1, characters 8-17:
 Error: This expression has type int but an expression was expected of type
          float

--- a/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
+++ b/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
@@ -3,32 +3,34 @@ Line 9, characters 8-15:
           ^^^^^^^
 Error: This expression has type int but an expression was expected of type
          float
-Line 2, characters 15-17,
-Line 2, characters 8-9:
+Line 2, characters 15-17:
   let x = (1 + 2 in ();;
-          ^      ^^
+                 ^^
 Error: Syntax error: ')' expected
        Line 2, characters 8-9:
+         let x = (1 + 2 in ();;
+                 ^
        This '(' might be unmatched
-Line 2, characters 14-16,
-Line 2, characters 8-9:
+Line 2, characters 14-16:
   let x = (1 + 2;;
-          ^     ^^
+                ^^
 Error: Syntax error: ')' expected
        Line 2, characters 8-9:
+         let x = (1 + 2;;
+                 ^
        This '(' might be unmatched
 Line 3, characters 8-9:
   let y = 1 +. 2. in
           ^
 Error: This expression has type int but an expression was expected of type
          float
-Line 4, characters 2-4,
-Line 2, characters 8-9:
-  ........(.
-  ...
-  ..in
+Line 4, characters 2-4:
+  2 in
+    ^^
 Error: Syntax error: ')' expected
        Line 2, characters 8-9:
+         let x = (1
+                 ^
        This '(' might be unmatched
 Line 2, characters 8-17:
   ........(1

--- a/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
+++ b/testsuite/tests/typing-core-bugs/type_expected_explanation.ml
@@ -77,8 +77,7 @@ Line 1, characters 3-15:
   if (fun x -> x) then ();;
      ^^^^^^^^^^^^
 Error: This expression should not be a function, the expected type is
-bool
-because it is in the condition of an if-statement
+       bool because it is in the condition of an if-statement
 |}];;
 
 while 42 do () done;;

--- a/testsuite/tests/typing-gadts/unexpected_existentials.ml
+++ b/testsuite/tests/typing-gadts/unexpected_existentials.ml
@@ -14,7 +14,7 @@ Line 1, characters 4-9:
   let Any x = Any ()
       ^^^^^
 Error: Existential types are not allowed in toplevel bindings,
-but this pattern introduces the existential type $Any_'a.
+       but this pattern introduces the existential type $Any_'a.
 |}]
 
 let () =
@@ -25,7 +25,7 @@ Line 2, characters 6-11:
     let Any x = Any () and () = () in
         ^^^^^
 Error: Existential types are not allowed in "let ... and ..." bindings,
-but this pattern introduces the existential type $Any_'a.
+       but this pattern introduces the existential type $Any_'a.
 |}]
 
 
@@ -37,7 +37,7 @@ Line 2, characters 10-15:
     let rec Any x = Any () in
             ^^^^^
 Error: Existential types are not allowed in recursive bindings,
-but this pattern introduces the existential type $Any_'a.
+       but this pattern introduces the existential type $Any_'a.
 |}]
 
 
@@ -49,7 +49,7 @@ Line 2, characters 18-23:
     let[@attribute] Any x = Any () in
                     ^^^^^
 Error: Existential types are not allowed in presence of attributes,
-but this pattern introduces the existential type $Any_'a.
+       but this pattern introduces the existential type $Any_'a.
 |}]
 
 
@@ -59,7 +59,7 @@ Line 1, characters 8-15:
   class c (Any x) = object end
           ^^^^^^^
 Error: Existential types are not allowed in class arguments,
-but this pattern introduces the existential type $Any_'a.
+       but this pattern introduces the existential type $Any_'a.
 |}]
 
 class c = object(Any x)end
@@ -68,7 +68,7 @@ Line 1, characters 16-23:
   class c = object(Any x)end
                   ^^^^^^^
 Error: Existential types are not allowed in self patterns,
-but this pattern introduces the existential type $Any_'a.
+       but this pattern introduces the existential type $Any_'a.
 |}]
 
 type other = Any: _ -> other
@@ -82,7 +82,7 @@ Line 1, characters 4-9:
   let Any x = Any ()
       ^^^^^
 Error: Existential types are not allowed in toplevel bindings,
-but the constructor Any introduces existential types.
+       but the constructor Any introduces existential types.
 |}]
 
 
@@ -92,7 +92,7 @@ Line 1, characters 14-20:
   class c = let Any _x = () in object end
                 ^^^^^^
 Error: Existential types are not allowed in bindings inside class definition,
-but the constructor Any introduces existential types.
+       but the constructor Any introduces existential types.
 |}]
 
 let () =
@@ -103,7 +103,7 @@ Line 2, characters 6-11:
     let Any x = Any () and () = () in
         ^^^^^
 Error: Existential types are not allowed in "let ... and ..." bindings,
-but the constructor Any introduces existential types.
+       but the constructor Any introduces existential types.
 |}]
 
 
@@ -115,7 +115,7 @@ Line 2, characters 10-15:
     let rec Any x = Any () in
             ^^^^^
 Error: Existential types are not allowed in recursive bindings,
-but the constructor Any introduces existential types.
+       but the constructor Any introduces existential types.
 |}]
 
 
@@ -127,7 +127,7 @@ Line 2, characters 18-23:
     let[@attribute] Any x = Any () in
                     ^^^^^
 Error: Existential types are not allowed in presence of attributes,
-but the constructor Any introduces existential types.
+       but the constructor Any introduces existential types.
 |}]
 
 class c (Any x) = object end
@@ -136,7 +136,7 @@ Line 1, characters 8-15:
   class c (Any x) = object end
           ^^^^^^^
 Error: Existential types are not allowed in class arguments,
-but the constructor Any introduces existential types.
+       but the constructor Any introduces existential types.
 |}]
 
 class c = object(Any x) end
@@ -145,7 +145,7 @@ Line 1, characters 16-23:
   class c = object(Any x) end
                   ^^^^^^^
 Error: Existential types are not allowed in self patterns,
-but the constructor Any introduces existential types.
+       but the constructor Any introduces existential types.
 |}]
 
 class c = let Any _x = () in object end
@@ -154,5 +154,5 @@ Line 1, characters 14-20:
   class c = let Any _x = () in object end
                 ^^^^^^
 Error: Existential types are not allowed in bindings inside class definition,
-but the constructor Any introduces existential types.
+       but the constructor Any introduces existential types.
 |}]

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ocaml.reference
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ocaml.reference
@@ -7,7 +7,7 @@ Line 1, characters 6-37:
   let f (module M : S with type t = 'a) = M.x;; (* Error *)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type of this packed module contains variables:
-(module S with type t = 'a)
+       (module S with type t = 'a)
 val f : (module S with type t = 'a) -> 'a = <fun>
 - : int = 1
 type 'a s = { s : (module S with type t = 'a); }
@@ -16,7 +16,7 @@ Line 1, characters 9-19:
   let f {s=(module M)} = M.x;; (* Error *)
            ^^^^^^^^^^
 Error: The type of this packed module contains variables:
-(module S with type t = 'a)
+       (module S with type t = 'a)
 val f : 'a s -> 'a = <fun>
 type s = { s : (module S with type t = int); }
 val f : s -> int = <fun>

--- a/testsuite/tests/typing-misc/pr6416.ml
+++ b/testsuite/tests/typing-misc/pr6416.ml
@@ -27,13 +27,9 @@ Error: Signature mismatch:
        is not included in
          val f : t/2 -> unit
        Line 6, characters 4-14:
-      type t = B
-      ^^^^^^^^^^
-Definition of type t/1
-Line 2, characters 2-12:
-    type t = A
-    ^^^^^^^^^^
-Definition of type t/2
+         Definition of type t/1
+       Line 2, characters 2-12:
+         Definition of type t/2
 |}]
 
 module N = struct
@@ -56,13 +52,9 @@ Error: Signature mismatch:
          type u = A of t/2
        The types for field A are not equal.
        Line 4, characters 9-19:
-    struct type t = B type u = A of t end
-           ^^^^^^^^^^
-Definition of type t/1
-Line 2, characters 2-11:
-    type t= A
-    ^^^^^^^^^
-Definition of type t/2
+         Definition of type t/1
+       Line 2, characters 2-11:
+         Definition of type t/2
 |}]
 
 module K = struct
@@ -93,13 +85,9 @@ Error: Signature mismatch:
        At position module A(X : <here>) : ...
        Modules do not match: s/2 is not included in s/1
        Line 5, characters 6-19:
-        module type s
-        ^^^^^^^^^^^^^
-Definition of module type s/1
-Line 2, characters 2-15:
-    module type s
-    ^^^^^^^^^^^^^
-Definition of module type s/2
+         Definition of module type s/1
+       Line 2, characters 2-15:
+         Definition of module type s/2
 |}]
 
 module L = struct
@@ -127,13 +115,9 @@ Error: Signature mismatch:
          type t = A of T/2.t
        The types for field A are not equal.
        Line 5, characters 6-34:
-        module T = struct type t end
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Definition of module T/1
-Line 2, characters 2-30:
-    module T = struct type t end
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Definition of module T/2
+         Definition of module T/1
+       Line 2, characters 2-30:
+         Definition of module T/2
 |}]
 
 module O = struct
@@ -157,21 +141,13 @@ Error: Signature mismatch:
        is not included in
          val f : (module s/2) -> t/2 -> t/2
        Line 5, characters 23-33:
-    struct module type s type t = B let f (module X:s) A = B end
-                         ^^^^^^^^^^
-Definition of type t/1
-Line 3, characters 2-12:
-    type t = A
-    ^^^^^^^^^^
-Definition of type t/2
-Line 5, characters 9-22:
-    struct module type s type t = B let f (module X:s) A = B end
-           ^^^^^^^^^^^^^
-Definition of module type s/1
-Line 2, characters 2-15:
-    module type s
-    ^^^^^^^^^^^^^
-Definition of module type s/2
+         Definition of type t/1
+       Line 3, characters 2-12:
+         Definition of type t/2
+       Line 5, characters 9-22:
+         Definition of module type s/1
+       Line 2, characters 2-15:
+         Definition of module type s/2
 |}]
 
 module P = struct
@@ -195,13 +171,9 @@ Error: Signature mismatch:
        is not included in
          val f : a/2 -> (module a) -> a/2
        Line 5, characters 12-22:
-     = struct type a = B let f A _  = B end
-              ^^^^^^^^^^
-Definition of type a/1
-Line 3, characters 2-12:
-    type a = A
-    ^^^^^^^^^^
-Definition of type a/2
+         Definition of type a/1
+       Line 3, characters 2-12:
+         Definition of type a/2
 |}]
 
 module Q = struct
@@ -232,13 +204,9 @@ Error: Signature mismatch:
        The first class type has no method m
        The public method c cannot be hidden
        Line 5, characters 4-74:
-      class a = object method c = let module X = struct type t end in () end
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Definition of class type a/1
-Line 2, characters 2-36:
-    class a = object method m = () end
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Definition of class type a/2
+         Definition of class type a/1
+       Line 2, characters 2-36:
+         Definition of class type a/2
 |}]
 
 module R = struct
@@ -267,13 +235,9 @@ Error: Signature mismatch:
          class type b = a/2
        The first class type has no method m
        Line 5, characters 4-29:
-      class type a = object end
-      ^^^^^^^^^^^^^^^^^^^^^^^^^
-Definition of class type a/1
-Line 2, characters 2-42:
-    class type a = object method m: unit end
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Definition of class type a/2
+         Definition of class type a/1
+       Line 2, characters 2-42:
+         Definition of class type a/2
 |}]
 
 module S = struct
@@ -337,13 +301,9 @@ Error: Signature mismatch:
        The method m has type t/2 but is expected to have type t/1
        Type t/2 is not compatible with type t/1 = K.t
        Line 12, characters 4-10:
-      type t
-      ^^^^^^
-Definition of type t/1
-Line 9, characters 2-8:
-    type t
-    ^^^^^^
-Definition of type t/2
+         Definition of type t/1
+       Line 9, characters 2-8:
+         Definition of type t/2
 |}]
 ;;
 
@@ -364,11 +324,9 @@ Error: Signature mismatch:
        is not included in
          type a = M/2.t
        Line 2, characters 14-42:
-  struct type t module M = struct type t end type a = M.t end;;
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Definition of module M/1
-File "_none_", line 1:
-Definition of module M/2
+         Definition of module M/1
+       File "_none_", line 1:
+         Definition of module M/2
 |}]
 
 
@@ -399,21 +357,13 @@ Error: Signature mismatch:
        is not included in
          val f : t/1 -> t/1 -> t/1 -> t/1
        Line 4, characters 0-10:
-  type t = D;;
-  ^^^^^^^^^^
-Definition of type t/1
-Line 1, characters 0-10:
-  type t = A;;
-  ^^^^^^^^^^
-Definition of type t/2
-Line 2, characters 0-10:
-  type t = B;;
-  ^^^^^^^^^^
-Definition of type t/3
-Line 3, characters 0-10:
-  type t = C;;
-  ^^^^^^^^^^
-Definition of type t/4
+         Definition of type t/1
+       Line 1, characters 0-10:
+         Definition of type t/2
+       Line 2, characters 0-10:
+         Definition of type t/3
+       Line 3, characters 0-10:
+         Definition of type t/4
 |}]
 
 (** Check interaction with no-alias-deps *)

--- a/testsuite/tests/typing-misc/pr6634.ml
+++ b/testsuite/tests/typing-misc/pr6634.ml
@@ -24,11 +24,7 @@ Error: Signature mismatch:
        is not included in
          type t = [ `T of t/1 ]
        Line 1, characters 0-12:
-  type t = int
-  ^^^^^^^^^^^^
-Definition of type t/1
-Line 4, characters 2-20:
-    type t = [`T of t]
-    ^^^^^^^^^^^^^^^^^^
-Definition of type t/2
+         Definition of type t/1
+       Line 4, characters 2-20:
+         Definition of type t/2
 |}]

--- a/testsuite/tests/typing-misc/typecore_empty_polyvariant_error.compilers.reference
+++ b/testsuite/tests/typing-misc/typecore_empty_polyvariant_error.compilers.reference
@@ -2,6 +2,5 @@ type t = [  ]
 Line 1, characters 31-32:
   let f: 'a. t -> 'a = function #t -> . ;;
                                  ^
-Error: The type t
-is not a variant type
+Error: The type t is not a variant type
 

--- a/testsuite/tests/typing-misc/typecore_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_errors.ml
@@ -98,7 +98,7 @@ Line 1, characters 32-33:
   let c = object val x= 0 val y = x end
                                   ^
 Error: The instance variable x
-cannot be accessed from the definition of another instance variable
+       cannot be accessed from the definition of another instance variable
 |}]
 
 
@@ -240,8 +240,7 @@ val f : int -> unit = <fun>
 Line 3, characters 10-29:
   let x = f (module struct end)
             ^^^^^^^^^^^^^^^^^^^
-Error: This expression is packed module, but the expected type is
-int
+Error: This expression is packed module, but the expected type is int
 |}]
 
 
@@ -292,8 +291,8 @@ Line 1, characters 23-24:
   let g f = f ~x:0 ~y:0; f ~y:0 ~x:0
                          ^
 Error: This function is applied to arguments
-in an order different from other calls.
-This is only allowed when the real type is known.
+       in an order different from other calls.
+       This is only allowed when the real type is known.
 |}]
 
 (** Inlined record *)
@@ -368,8 +367,7 @@ type t = []
 Line 2, characters 18-19:
   let f = function #t -> ()
                     ^
-Error: The type t
-is not a variant type
+Error: The type t is not a variant type
 |}]
 
 let f {x;x=y;x=z} = x

--- a/testsuite/tests/typing-misc/unique_names_in_unification.ml
+++ b/testsuite/tests/typing-misc/unique_names_in_unification.ml
@@ -16,14 +16,10 @@ Line 5, characters 27-28:
                              ^
 Error: This expression has type t/2 but an expression was expected of type
          t/1
-Line 4, characters 2-12:
-    type t = B
-    ^^^^^^^^^^
-Definition of type t/1
-Line 1, characters 0-10:
-  type t = A
-  ^^^^^^^^^^
-Definition of type t/2
+       Line 4, characters 2-12:
+         Definition of type t/1
+       Line 1, characters 0-10:
+         Definition of type t/2
 |}]
 
 module M = struct type t = B end
@@ -43,15 +39,10 @@ Line 7, characters 34-35:
                                     ^
 Error: This expression has type M/2.t but an expression was expected of type
          M/1.t
-Line 4, characters 2-41:
-  ..module M = struct
-       type t = C
-    end
-Definition of module M/1
-Line 1, characters 0-32:
-  module M = struct type t = B end
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Definition of module M/2
+       Line 4, characters 2-41:
+         Definition of module M/1
+       Line 1, characters 0-32:
+         Definition of module M/2
 |}]
 
 type t = D
@@ -65,14 +56,10 @@ Line 2, characters 25-26:
                            ^
 Error: This expression has type t/1 but an expression was expected of type
          t/2
-Line 1, characters 0-10:
-  type t = A
-  ^^^^^^^^^^
-Definition of type t/1
-Line 1, characters 0-10:
-  type t = D
-  ^^^^^^^^^^
-Definition of type t/2
+       Line 1, characters 0-10:
+         Definition of type t/1
+       Line 1, characters 0-10:
+         Definition of type t/2
 |}]
 
 type ttt
@@ -93,12 +80,8 @@ Line 2, characters 32-33:
                                   ^
 Error: This expression has type ttt/2 but an expression was expected of type
          ttt/1
-Line 1, characters 0-26:
-  type nonrec ttt = X of ttt
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Definition of type ttt/1
-Line 2, characters 0-30:
-  type ttt = A of ttt | B of uuu
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Definition of type ttt/2
+       Line 1, characters 0-26:
+         Definition of type ttt/1
+       Line 2, characters 0-30:
+         Definition of type ttt/2
 |}]

--- a/testsuite/tests/typing-missing-cmi/test.compilers.reference
+++ b/testsuite/tests/typing-missing-cmi/test.compilers.reference
@@ -1,5 +1,5 @@
 File "main.ml", line 1, characters 14-17:
 Error: This expression has type M.b but an expression was expected of type
          M.a
-M.b is abstract because no corresponding cmi file was found in path.
-M.a is abstract because no corresponding cmi file was found in path.
+       M.b is abstract because no corresponding cmi file was found in path.
+       M.a is abstract because no corresponding cmi file was found in path.

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -661,7 +661,6 @@ module rec Bad : A = Bad;;
 [%%expect{|
 module type Alias = sig module N : sig  end module M = N end
 module F : functor (X : sig  end) -> sig type t end
-Line 1:
 Error: Module type declarations do not match:
          module type A = sig module M = F(List) end
        does not match

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -661,6 +661,7 @@ module rec Bad : A = Bad;;
 [%%expect{|
 module type Alias = sig module N : sig  end module M = N end
 module F : functor (X : sig  end) -> sig type t end
+Line 1:
 Error: Module type declarations do not match:
          module type A = sig module M = F(List) end
        does not match

--- a/testsuite/tests/typing-modules/pr7726.ml
+++ b/testsuite/tests/typing-modules/pr7726.ml
@@ -110,6 +110,7 @@ M.f 5;;
 module Foo :
   functor (F : T -> T) -> sig val f : Fix(F).Fixed.t -> Fix(F).Fixed.t end
 module M : sig val f : Fix(Id).Fixed.t -> Fix(Id).Fixed.t end
+Line 1:
 Error: In the signature of Fix(Id):
        The definition of Fixed.t contains a cycle:
        Id(Fixed).t

--- a/testsuite/tests/typing-modules/pr7726.ml
+++ b/testsuite/tests/typing-modules/pr7726.ml
@@ -110,7 +110,6 @@ M.f 5;;
 module Foo :
   functor (F : T -> T) -> sig val f : Fix(F).Fixed.t -> Fix(F).Fixed.t end
 module M : sig val f : Fix(Id).Fixed.t -> Fix(Id).Fixed.t end
-Line 1:
 Error: In the signature of Fix(Id):
        The definition of Fixed.t contains a cycle:
        Id(Fixed).t

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1597,8 +1597,7 @@ and g = <a:t>
 Line 1, characters 10-11:
   type t = <g>
             ^
-Error: The type constructor g
-is not yet completely defined
+Error: The type constructor g is not yet completely defined
 |}]
 
 type t = int

--- a/testsuite/tests/typing-private/private.compilers.principal.reference
+++ b/testsuite/tests/typing-private/private.compilers.principal.reference
@@ -112,6 +112,7 @@ type t = private < x : int; .. >
 type t = private < x : int; .. >
 type t = private < x : int >
 type t = private < x : int >
+Line 1:
 Error: Type declarations do not match:
          type 'a t = private 'a constraint 'a = < x : int; .. >
        is not included in

--- a/testsuite/tests/typing-private/private.compilers.reference
+++ b/testsuite/tests/typing-private/private.compilers.reference
@@ -112,6 +112,7 @@ type t = private < x : int; .. >
 type t = private < x : int; .. >
 type t = private < x : int >
 type t = private < x : int >
+Line 1:
 Error: Type declarations do not match:
          type 'a t = private < x : int; .. > constraint 'a = 'a t
        is not included in

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -57,7 +57,7 @@ Line 11, characters 2-71:
     external f : (int32 [@unboxed]) -> (int32 [@unboxed]) = "f" "noalloc"
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: [@The native code version of the primitive is mandatory
-when attributes [@untagged] or [@unboxed] are present.
+       when attributes [@untagged] or [@unboxed] are present.
 |}]
 
 module Old_style_warning = struct
@@ -355,7 +355,7 @@ Line 1, characters 0-45:
   external o : (float[@unboxed]) -> float = "o";;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: [@The native code version of the primitive is mandatory
-when attributes [@untagged] or [@unboxed] are present.
+       when attributes [@untagged] or [@unboxed] are present.
 |}]
 external p : float -> (float[@unboxed]) = "p";;
 [%%expect{|
@@ -363,7 +363,7 @@ Line 1, characters 0-45:
   external p : float -> (float[@unboxed]) = "p";;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: [@The native code version of the primitive is mandatory
-when attributes [@untagged] or [@unboxed] are present.
+       when attributes [@untagged] or [@unboxed] are present.
 |}]
 external q : (int[@untagged]) -> float = "q";;
 [%%expect{|
@@ -371,7 +371,7 @@ Line 1, characters 0-44:
   external q : (int[@untagged]) -> float = "q";;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: [@The native code version of the primitive is mandatory
-when attributes [@untagged] or [@unboxed] are present.
+       when attributes [@untagged] or [@unboxed] are present.
 |}]
 external r : int -> (int[@untagged]) = "r";;
 [%%expect{|
@@ -379,7 +379,7 @@ Line 1, characters 0-42:
   external r : int -> (int[@untagged]) = "r";;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: [@The native code version of the primitive is mandatory
-when attributes [@untagged] or [@unboxed] are present.
+       when attributes [@untagged] or [@unboxed] are present.
 |}]
 external s : int -> int = "s" [@@untagged];;
 [%%expect{|
@@ -387,7 +387,7 @@ Line 1, characters 0-42:
   external s : int -> int = "s" [@@untagged];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: [@The native code version of the primitive is mandatory
-when attributes [@untagged] or [@unboxed] are present.
+       when attributes [@untagged] or [@unboxed] are present.
 |}]
 external t : float -> float = "t" [@@unboxed];;
 [%%expect{|
@@ -395,7 +395,7 @@ Line 1, characters 0-45:
   external t : float -> float = "t" [@@unboxed];;
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: [@The native code version of the primitive is mandatory
-when attributes [@untagged] or [@unboxed] are present.
+       when attributes [@untagged] or [@unboxed] are present.
 |}]
 
 (* PR#7424 *)

--- a/testsuite/tests/warnings/deprecated_module_assigment.compilers.reference
+++ b/testsuite/tests/warnings/deprecated_module_assigment.compilers.reference
@@ -1,72 +1,72 @@
 File "deprecated_module_assigment.ml", line 17, characters 33-34:
 Warning 3: deprecated: x
 DEPRECATED
-  File "deprecated_module_assigment.ml", line 12, characters 2-41:
-  Definition
-  File "deprecated_module_assigment.ml", line 17, characters 15-26:
-  Expected signature
+           File "deprecated_module_assigment.ml", line 12, characters 2-41:
+           Definition
+           File "deprecated_module_assigment.ml", line 17, characters 15-26:
+           Expected signature
 File "deprecated_module_assigment.ml", line 23, characters 13-14:
 Warning 3: deprecated: x
 DEPRECATED
-  File "deprecated_module_assigment.ml", line 12, characters 2-41:
-  Definition
-  File "deprecated_module_assigment.ml", line 21, characters 17-28:
-  Expected signature
+           File "deprecated_module_assigment.ml", line 12, characters 2-41:
+           Definition
+           File "deprecated_module_assigment.ml", line 21, characters 17-28:
+           Expected signature
 File "deprecated_module_assigment.ml", line 33, characters 39-78:
 Warning 3: deprecated: A
-  File "deprecated_module_assigment.ml", line 33, characters 55-70:
-  Definition
-  File "deprecated_module_assigment.ml", line 33, characters 27-28:
-  Expected signature
+           File "deprecated_module_assigment.ml", line 33, characters 55-70:
+           Definition
+           File "deprecated_module_assigment.ml", line 33, characters 27-28:
+           Expected signature
 File "deprecated_module_assigment.ml", line 37, characters 2-20:
 Warning 3: deprecated: A
-  File "deprecated_module_assigment.ml", line 36, characters 11-26:
-  Definition
-  File "deprecated_module_assigment.ml", line 37, characters 15-16:
-  Expected signature
+           File "deprecated_module_assigment.ml", line 36, characters 11-26:
+           Definition
+           File "deprecated_module_assigment.ml", line 37, characters 15-16:
+           Expected signature
 File "deprecated_module_assigment.ml", line 45, characters 0-58:
 Warning 3: deprecated: mutating field x
-  File "deprecated_module_assigment.ml", line 45, characters 17-53:
-  Definition
-  File "deprecated_module_assigment.ml", line 44, characters 14-28:
-  Expected signature
+           File "deprecated_module_assigment.ml", line 45, characters 17-53:
+           Definition
+           File "deprecated_module_assigment.ml", line 44, characters 14-28:
+           Expected signature
 File "deprecated_module_assigment.ml", line 49, characters 2-31:
 Warning 3: deprecated: mutating field x
-  File "deprecated_module_assigment.ml", line 48, characters 12-48:
-  Definition
-  File "deprecated_module_assigment.ml", line 49, characters 16-30:
-  Expected signature
+           File "deprecated_module_assigment.ml", line 48, characters 12-48:
+           Definition
+           File "deprecated_module_assigment.ml", line 49, characters 16-30:
+           Expected signature
 File "deprecated_module_assigment.ml", line 54, characters 37-75:
 Warning 3: deprecated: t
-  File "deprecated_module_assigment.ml", line 54, characters 44-71:
-  Definition
-  File "deprecated_module_assigment.ml", line 54, characters 18-30:
-  Expected signature
+           File "deprecated_module_assigment.ml", line 54, characters 44-71:
+           Definition
+           File "deprecated_module_assigment.ml", line 54, characters 18-30:
+           Expected signature
 File "deprecated_module_assigment.ml", line 60, characters 0-52:
 Warning 3: deprecated: c
 FOO
-  File "deprecated_module_assigment.ml", line 60, characters 7-48:
-  Definition
-  File "deprecated_module_assigment.ml", line 59, characters 4-24:
-  Expected signature
+           File "deprecated_module_assigment.ml", line 60, characters 7-48:
+           Definition
+           File "deprecated_module_assigment.ml", line 59, characters 4-24:
+           Expected signature
 File "deprecated_module_assigment.ml", line 64, characters 0-57:
 Warning 3: deprecated: c
 FOO
-  File "deprecated_module_assigment.ml", line 64, characters 7-53:
-  Definition
-  File "deprecated_module_assigment.ml", line 63, characters 4-29:
-  Expected signature
+           File "deprecated_module_assigment.ml", line 64, characters 7-53:
+           Definition
+           File "deprecated_module_assigment.ml", line 63, characters 4-29:
+           Expected signature
 File "deprecated_module_assigment.ml", line 71, characters 0-55:
 Warning 3: deprecated: S
 FOO
-  File "deprecated_module_assigment.ml", line 71, characters 7-51:
-  Definition
-  File "deprecated_module_assigment.ml", line 70, characters 4-27:
-  Expected signature
+           File "deprecated_module_assigment.ml", line 71, characters 7-51:
+           Definition
+           File "deprecated_module_assigment.ml", line 70, characters 4-27:
+           Expected signature
 File "deprecated_module_assigment.ml", line 82, characters 0-53:
 Warning 3: deprecated: M
 FOO
-  File "deprecated_module_assigment.ml", line 82, characters 7-49:
-  Definition
-  File "deprecated_module_assigment.ml", line 81, characters 4-22:
-  Expected signature
+           File "deprecated_module_assigment.ml", line 82, characters 7-49:
+           Definition
+           File "deprecated_module_assigment.ml", line 81, characters 4-22:
+           Expected signature

--- a/tools/caml_tex.ml
+++ b/tools/caml_tex.ml
@@ -132,13 +132,25 @@ module Toplevel = struct
     if startchar >= 0 then
       locs := (startchar, endchar) :: !locs
 
+  (** Record the main location instead of printing it *)
+  let printer_register_locs =
+    { Location.batch_mode_printer with
+      pp_main_loc = (fun _ _ _ loc -> register_loc loc) }
+
   (** Capture warnings and keep them in a list *)
   let warnings = ref []
-  let print_warning loc _ppf w =
-    if Warnings.report w <> `Inactive then register_loc loc;
-    Location.default_warning_printer loc (snd warning_fmt) w;
-    let w = flush_fmt warning_fmt in
-    warnings := w :: !warnings
+  let report_printer =
+    (* Extend [printer_register_locs] *)
+    let pp self ppf report =
+      match report.Location.kind with
+      | Location.Report_warning _ | Location.Report_warning_as_error _ ->
+          printer_register_locs.pp self (snd warning_fmt) report;
+          let w = flush_fmt warning_fmt in
+          warnings := w :: !warnings
+      | _ ->
+          printer_register_locs.pp self ppf report
+    in
+    { printer_register_locs with pp }
 
   let fatal ic oc fmt =
     Format.kfprintf
@@ -146,14 +158,10 @@ module Toplevel = struct
       self_error_fmt ("@[<hov 2>  Error " ^^ fmt)
 
   let init () =
-    Location.printer := (fun _ _ -> ());
-    Location.warning_printer := print_warning;
+    Location.report_printer := (fun () -> report_printer);
     Clflags.color := Some Misc.Color.Never;
     Clflags.no_std_include := true;
     Compenv.last_include_dirs := [Filename.concat !repo_root "stdlib"];
-    Location.error_reporter :=
-      (fun _ e -> register_loc e.loc;
-        Location.default_error_reporter (snd error_fmt) e);
     Compmisc.init_path false;
     try
       Toploop.initialize_toplevel_env ();

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -155,8 +155,8 @@ let remove_printer = Printer.remove_printer
 
 let parse_toplevel_phrase = ref Parse.toplevel_phrase
 let parse_use_file = ref Parse.use_file
-let print_location = Location.print_error (* FIXME change back to print *)
-let print_error = Location.print_error
+let print_location = Location.print_loc
+let print_error = Location.print_report
 let print_warning = Location.print_warning
 let input_name = Location.input_name
 

--- a/toplevel/opttoploop.mli
+++ b/toplevel/opttoploop.mli
@@ -92,7 +92,7 @@ val max_printer_steps: int ref
 val parse_toplevel_phrase : (Lexing.lexbuf -> Parsetree.toplevel_phrase) ref
 val parse_use_file : (Lexing.lexbuf -> Parsetree.toplevel_phrase list) ref
 val print_location : formatter -> Location.t -> unit
-val print_error : formatter -> Location.t -> unit
+val print_error : formatter -> Location.error -> unit
 val print_warning : Location.t -> formatter -> Warnings.t -> unit
 val input_name : string ref
 

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -116,8 +116,8 @@ let remove_printer = Printer.remove_printer
 
 let parse_toplevel_phrase = ref Parse.toplevel_phrase
 let parse_use_file = ref Parse.use_file
-let print_location = Location.print_error (* FIXME change back to print *)
-let print_error = Location.print_error
+let print_location = Location.print_loc
+let print_error = Location.print_report
 let print_warning = Location.print_warning
 let input_name = Location.input_name
 

--- a/toplevel/toploop.mli
+++ b/toplevel/toploop.mli
@@ -113,7 +113,7 @@ val max_printer_steps: int ref
 val parse_toplevel_phrase : (Lexing.lexbuf -> Parsetree.toplevel_phrase) ref
 val parse_use_file : (Lexing.lexbuf -> Parsetree.toplevel_phrase list) ref
 val print_location : formatter -> Location.t -> unit
-val print_error : formatter -> Location.t -> unit
+val print_error : formatter -> Location.error -> unit
 val print_warning : Location.t -> formatter -> Warnings.t -> unit
 val input_name : string ref
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2389,7 +2389,7 @@ let () =
       | Error (Missing_module (loc, _, _)
               | Illegal_value_name (loc, _)
                as err) when loc <> Location.none ->
-          Some (Location.error_of_printer loc report_error err)
+          Some (Location.error_of_printer ~loc report_error err)
       | Error err -> Some (Location.error_of_printer_file report_error err)
       | _ -> None
     )

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -217,7 +217,7 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, err) ->
-        Some (Location.error_of_printer loc report_error err)
+        Some (Location.error_of_printer ~loc report_error err)
       | _ ->
         None
     )

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -131,8 +131,8 @@ module Conflicts = struct
             M.add name { kind = namespace; location; name } !explanations
 
   let pp_explanation ppf r=
-    Format.fprintf ppf "@[<v 2>%aDefinition of %s %s@]"
-      Location.print r.location (Namespace.show r.kind) r.name
+    Format.fprintf ppf "@[<v 2>%a:@,Definition of %s %s@]"
+      Location.print_loc r.location (Namespace.show r.kind) r.name
 
   let pp ppf l =
     Format.fprintf ppf "@[<v>%a@]" (Format.pp_print_list pp_explanation) l

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -2014,7 +2014,7 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, env, err) ->
-        Some (Location.error_of_printer loc (report_error env) err)
+        Some (Location.error_of_printer ~loc (report_error env) err)
       | Error_forward err ->
         Some err
       | _ ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4840,7 +4840,7 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, env, err) ->
-        Some (Location.error_of_printer loc (report_error env) err)
+        Some (Location.error_of_printer ~loc (report_error env) err)
       | Error_forward err ->
         Some err
       | _ ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2187,7 +2187,7 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, err) ->
-        Some (Location.error_of_printer loc report_error err)
+        Some (Location.error_of_printer ~loc report_error err)
       | _ ->
         None
     )

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2353,7 +2353,7 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, env, err) ->
-        Some (Location.error_of_printer loc (report_error env) err)
+        Some (Location.error_of_printer ~loc (report_error env) err)
       | Error_forward err ->
         Some err
       | _ ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1042,7 +1042,7 @@ let () =
   Location.register_error_of_exn
     (function
       | Error (loc, env, err) ->
-        Some (Location.error_of_printer loc (report_error env) err)
+        Some (Location.error_of_printer ~loc (report_error env) err)
       | Error_forward err ->
         Some err
       | _ ->

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -540,10 +540,11 @@ let message = function
 
 let sub_locs = function
   | Deprecated (_, def, use) ->
-      [
+      if not def.loc_ghost && not use.loc_ghost then [
         def, "Definition";
         use, "Expected signature";
       ]
+      else []
   | _ -> []
 
 let nerrors = ref 0;;


### PR DESCRIPTION
This PR is an attempt at refactoring the part of `Location` responsible for printing errors and warnings, to have a clearer separation between the structure of errors(/warnings), and backend-specific display of that structure.

There are indeed several "backends" on which an error can get printed, all with slightly different capabilities, in particular with respect to the highlighting of locations. I can distinguish:
- "batch mode", i.e. the standard compiler output when called from the command-line
- the toplevel, which e.g. can have the extra capability of going up and highlighting parts of the input to point at locations
- merlin, which has different support from the editor to highlight code directly in the source code (currently merlin maintains a patched `location.ml`)
- `expect_test` and the manual script `caml_tex.ml` also both display errors/collect locations in a custom way using the compiler-libs api.

I would say that the current implementation has the following issues:
- The current `Location` module exposes many functions related to the printing of errors/warnings/locations; with some of them being re-definable, and indeed re-defined in some places to allow for different printing backends. This makes the printing code entangled with the rest of the implementation, and hard to keep track of.
- On the printing code side, a few quirks make it hard to print errors nicely ([example 1](https://github.com/ocaml/ocaml/blob/9ed695dfe0fb0a5c77b425f743dde436f8282d6b/parsing/location.ml#L478): there's a hack to feed a custom formatter to `errorf` which adds fake indentation to anticipate the fact that the message will be printed in front of `Error: `) ([example 2](https://github.com/ocaml/ocaml/blob/9ed695dfe0fb0a5c77b425f743dde436f8282d6b/testsuite/tests/typing-misc/pr6416.ml#L29): poor indentation in the printing of sub-locations for name conflicts)
- On the error-message-writer side, it is hard to write errors that look good on all the backends, the result being that often, information that could be propagated to the backend for backend-specific display (e.g. sub-locations of an error) are instead baked in the error message.
- As a corollary, trying to improve the printing of errors is hard (this was the initial motivation for this PR)

## In this PR

This PR proposes to rework the current implementation, with minimal changes to its observational behavior, and pave the way for further improvements, in particular to the display of errors with several locations (typically, a main location and several sub-locations).

More specifically:
- Rework the `Location.error` type. 
  - messages as `string`s do not compose well as soon as they are multiline (e.g. with regard to Format boxes). In this PR error messages become of the type `formatter -> unit`. This required some refactoring in some places (e.g. `printtyp.ml`) to make sure the side effects performed when crafting an error message are still triggered at the right time. We discussed a bit with @Drup and @Octachron of an alternative solution (where messages would instead be formats where all `%a`, `%t`, `%d`... have been expanded) but I leave this as a potential future improvement.
  - remove the `if_highlight` field as it is intrinsically backend-dependent (it provided an alternative error message *when in the toplevel if parts of the input had been highlighted*) and is used in only one error message ("syntax error: missing closing )" )
  - there is already a notion of sub-errors, which is used only once across the codebase (also for "syntax error: missing closing )"). Sub-errors were recursively error themselves; this PR changes it to a list of sub-*messages* (and *not* recursively). The rationale is that it is simpler, but hopefully expressive enough to describe somewhat faithfully the structure of errors with sub-locations. The plan in future PRs is to rework existing errors to actually use this feature, instead of baking sub-locations in the text of the error itself as it is currently done almost everywhere.
- Generalize `Location.error` to a `Location.report` type, which can then be used to display warnings as well. The idea is that is gives us a more uniform printing of errors and warnings. The intent is that `Location.report` is a backend-agnostic description of an error or warning.
- Define "report printers", which define backend-specific ways of printing a report. Also make it possible to easily reuse code between report printers (e.g. the toplevel printer is defined after the batch mode printer; expect_test and the manual backend are also defined by reusing the toplevel/batch mode backend and modifying some bits)
- Limit the number of printing-related functions exposed by `Location`; the point is that everyone printing errors should emit a `Location.report`

Unfortunately, because of the way the current implementation is entangled, I not manage to make these changes independently -- so they come in a big one commit, sorry for that!

## Changes to the compiler output

The objective is to minimize the changes in the output; actual improvements to the way reports are printed should come in future PRs. There are nevertheless some changes:
  - indentation-related, and arguably always an improvement
  - there is a regression when displaying name conflicts in the terminal (there is no highlighting anymore). I plan to fix that in an upcoming PR which will turn such conflicts into proper sub-messages (I could do that here but it involves a whole bunch of uninteresting plumbing)
  - changes to the "missing closing)" message; maybe not for the best but at least it is consistent with the rest now
  - ~~one weird change that Format experts (@Drup @Octachron maybe?) may want to look at -- I point to it in a comment below.~~

## Comments on the code

- A `report_printer` is currently defined as a class type. The goal is to use inheritance to be able to re-use code between printers (the toplevel, expect_test and manual printers are defined that way). The currently used report printer can be changed when using the compiler-libs API. This way I that merlin can define its own report_printer (inheriting from the batch mode printer for example) and simply switch to it, instead of having to patch `location.ml`.

  ~~If people are reluctant to have objects in this part of the compiler, I could rewrite the printers as a record of functions -- given the way inheritance between printers is used currently, it should not be *too* painful.~~ EDIT: printers have been rewritten as a record of functions

- I expect this to cause some breakage at least in `utop`; I can send patches to fix it if needed.

- The PR is best reviewed commit by commit. The two first commits move some code around and add docstrings in `location.{ml,mli}`, but do not change anything else. The third commit does the refactoring, and should probably be read starting from `location.mli`.
