### PR TITLE
WIP: Add match operators

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -295,6 +295,8 @@ let symbolchar =
   ['!' '$' '%' '&' '*' '+' '-' '.' '/' ':' '<' '=' '>' '?' '@' '^' '|' '~']
 let dotsymbolchar =
   ['!' '$' '%' '&' '*' '+' '-' '/' ':' '=' '>' '?' '@' '^' '|' '~']
+let infixchar =
+  ['=' '<' '>' '|' '&' '$' '@' '^' '+' '-' '*' '/']
 let decimal_literal =
   ['0'-'9'] ['0'-'9' '_']*
 let hex_digit =
@@ -511,6 +513,8 @@ rule token = parse
             { INFIXOP3(Lexing.lexeme lexbuf) }
   | '#' (symbolchar | '#') +
             { HASHOP(Lexing.lexeme lexbuf) }
+  | "match" infixchar symbolchar *
+            { MATCHOP(Lexing.lexeme lexbuf) }
   | eof { EOF }
   | _
       { raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -87,6 +87,10 @@ let ghsig d = Sig.mk ~loc:(symbol_gloc()) d
 let mkinfix arg1 name arg2 =
   mkexp(Pexp_apply(mkoperator name 2, [Nolabel, arg1; Nolabel, arg2]))
 
+let mkmatchfix matchop expr cases =
+  let func = mkexp (Pexp_function cases) in
+  mkexp(Pexp_apply(matchop, [Nolabel, func; Nolabel, expr]))
+
 let neg_string f =
   if String.length f > 0 && f.[0] = '-'
   then String.sub f 1 (String.length f - 1)
@@ -480,6 +484,7 @@ let package_type_of_module_type pmty =
 %token <string> INFIXOP3
 %token <string> INFIXOP4
 %token <string> DOTOP
+%token <string> MATCHOP
 %token INHERIT
 %token INITIALIZER
 %token <string * char option> INT
@@ -1345,6 +1350,8 @@ expr:
       { mkexp_attrs (mk_newtypes $5 $7).pexp_desc $2 }
   | MATCH ext_attributes seq_expr WITH opt_bar match_cases
       { mkexp_attrs (Pexp_match($3, List.rev $6)) $2 }
+  | MATCHOP seq_expr WITH opt_bar match_cases
+      { mkmatchfix (mkoperator $1 1) $2 (List.rev $5) }
   | TRY ext_attributes seq_expr WITH opt_bar match_cases
       { mkexp_attrs (Pexp_try($3, List.rev $6)) $2 }
   | TRY ext_attributes seq_expr WITH error
@@ -2427,6 +2434,7 @@ operator:
   | INFIXOP2                                    { $1 }
   | INFIXOP3                                    { $1 }
   | INFIXOP4                                    { $1 }
+  | MATCHOP                                     { $1 }
   | DOTOP LPAREN RPAREN                         { "."^ $1 ^"()" }
   | DOTOP LPAREN RPAREN LESSMINUS               { "."^ $1 ^ "()<-" }
   | DOTOP LBRACKET RBRACKET                     { "."^ $1 ^"[]" }

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -36,6 +36,15 @@ let infix_symbols = [ '='; '<'; '>'; '@'; '^'; '|'; '&'; '+'; '-'; '*'; '/';
 let special_infix_strings =
   ["asr"; "land"; "lor"; "lsl"; "lsr"; "lxor"; "mod"; "or"; ":="; "!="; "::" ]
 
+let matchop s =
+  String.length s > 5
+  && s.[0] = 'm'
+  && s.[1] = 'a'
+  && s.[2] = 't'
+  && s.[3] = 'c'
+  && s.[4] = 'h'
+  && List.mem s.[5] infix_symbols
+
 (* determines if the string is an infix string.
    checks backwards, first allowing a renaming postfix ("_102") which
    may have resulted from Pexp -> Texp -> Pexp translation, then checking
@@ -46,6 +55,7 @@ let fixity_of_string  = function
   | s when List.mem s.[0] infix_symbols -> `Infix s
   | s when List.mem s.[0] prefix_symbols -> `Prefix s
   | s when s.[0] = '.' -> `Mixfix s
+  | s when matchop s -> `Matchop s
   | _ -> `Normal
 
 let view_fixity_of_exp = function
@@ -55,12 +65,14 @@ let view_fixity_of_exp = function
 
 let is_infix  = function  | `Infix _ -> true | _  -> false
 let is_mixfix = function `Mixfix _ -> true | _ -> false
+let is_kwdop = function `Matchop _ -> true | _ -> false
 
 (* which identifiers are in fact operators needing parentheses *)
 let needs_parens txt =
   let fix = fixity_of_string txt in
   is_infix fix
   || is_mixfix fix
+  || is_kwdop fix
   || List.mem txt.[0] prefix_symbols
 
 (* some infixes need spaces around parens to avoid clashes with comment

--- a/testsuite/tests/let-syntax/match_syntax.ml
+++ b/testsuite/tests/let-syntax/match_syntax.ml
@@ -1,0 +1,115 @@
+(* TEST
+   * expect
+*)
+
+module List = struct
+
+  let concat_map f l =
+    let l = List.map f l in
+    List.concat l
+
+  let product xs ys =
+    List.fold_right
+      (fun x acc -> (List.map (fun y -> (x, y)) ys) @ acc)
+      xs []
+
+  let (match+) = List.map
+
+  let ( match* ) = concat_map
+
+end;;
+[%%expect{|
+module List :
+  sig
+    val concat_map : ('a -> 'b list) -> 'a list -> 'b list
+    val product : 'a list -> 'b list -> ('a * 'b) list
+    val ( match+ ) : ('a -> 'b) -> 'a list -> 'b list
+    val ( match* ) : ('a -> 'b list) -> 'a list -> 'b list
+  end
+|}];;
+
+let match_map =
+  List.(
+    match+ [1; 2; 3] with
+    | 2 -> true
+    | _ -> false
+  );;
+[%%expect{|
+val match_map : bool list = [false; true; false]
+|}];;
+
+let match_bind =
+  List.(
+    match* [1; 2; 3] with
+    | 2 -> [true; true; true]
+    | _ -> [false]
+  );;
+[%%expect{|
+val match_bind : bool list = [false; true; true; true; false]
+|}];;
+
+module Ill_typed_1 = struct
+
+  let (match+) = fun f x -> not x
+
+end;;
+[%%expect{|
+module Ill_typed_1 : sig val ( match+ ) : 'a -> bool -> bool end
+|}];;
+
+let ill_typed_1 =
+  Ill_typed_1.(
+    match+ 1 with
+    | _ -> ()
+  );;
+[%%expect{|
+Line 3, characters 11-12:
+      match+ 1 with
+             ^
+Error: This expression has type int but an expression was expected of type
+         bool
+|}];;
+
+module Ill_typed_2 = struct
+
+  let (match+) = 5
+
+end;;
+[%%expect{|
+module Ill_typed_2 : sig val ( match+ ) : int end
+|}];;
+
+let ill_typed_2 =
+  Ill_typed_2.(
+    match+ 2 with
+    | _ -> ()
+  );;
+[%%expect{|
+Line 3, characters 4-10:
+      match+ 2 with
+      ^^^^^^
+Error: This expression has type int
+       This is not a function; it cannot be applied.
+|}];;
+
+module Ill_typed_3 = struct
+
+  let (match+) = fun f x -> not f
+
+end;;
+[%%expect{|
+module Ill_typed_3 : sig val ( match+ ) : bool -> 'a -> bool end
+|}];;
+
+let ill_typed_3 =
+  Ill_typed_3.(
+    match+ 2 with
+    | _ -> ()
+  );;
+[%%expect{|
+Line 3, characters 4-31:
+  ....match+ 2 with
+      | _ -> ()
+Error: This expression should not be a function, the expected type is
+bool
+|}];;

--- a/testsuite/tests/let-syntax/ocamltests
+++ b/testsuite/tests/let-syntax/ocamltests
@@ -1,0 +1,1 @@
+match_syntax.ml

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -34,13 +34,28 @@ let rec print_ident ppf =
   | Oide_apply (id1, id2) ->
       fprintf ppf "%a(%a)" print_ident id1 print_ident id2
 
+(* Check a character matches the [identchar_latin1] class from the lexer *)
+let is_ident_char c =
+  match c with
+  | 'A'..'Z' | 'a'..'z' | '_' | '\192'..'\214' | '\216'..'\246'
+  | '\248'..'\255' | '\'' | '0'..'9' -> true
+  | _ -> false
+
+let all_ident_chars s =
+  let rec loop s len i =
+    if i < len then begin
+      if is_ident_char s.[i] then loop s len (i+1)
+      else false
+    end else begin
+      true
+    end
+  in
+  let len = String.length s in
+  loop s len 0
+
 let parenthesized_ident name =
   (List.mem name ["or"; "mod"; "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr"])
-  ||
-  (match name.[0] with
-      'a'..'z' | 'A'..'Z' | '\223'..'\246' | '\248'..'\255' | '_' ->
-        false
-    | _ -> true)
+  || not (all_ident_chars name)
 
 let value_ident ppf name =
   if parenthesized_ident name then


### PR DESCRIPTION
This PR is the "match operators" part of #1947. I've extracted it to allow this part to be discussed independently of the rest of that PR. I've copied the description of this aspect below.

-----------------

This PR also adds support for match operators. These are simpler than let operators because there is no match ... and ... construct. The translation for these is simply:

match+ expr with
| pat1 -> case1
| pat2 -> case2
to:

(match+) (function | pat1 -> case1 | pat2 -> case2) expr
As with let I would recommend that a monad bind match+ to map and match* to bind.