### PR TITLE
Syntax: allow [module M(_:S) = struct end] syntax

### DIFF
--- a/Changes
+++ b/Changes
@@ -308,6 +308,9 @@ Working version
   Unboxable_type_in_prim_decl
   (Stefan Muenzel)
 
+- GPR#1958: allow [module M(_:S) = struct end] syntax
+  (Hugo Heuzard, review by Gabriel Scherer)
+
 - GPR#1970: fix order of floatting documentation comments in classes
   (Hugo Heuzard, review by Nicolás Ojeda Bär)
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -951,10 +951,9 @@ sig_include_statement:
 module_declaration_body:
     COLON module_type
       { $2 }
-  | LPAREN UIDENT COLON module_type RPAREN module_declaration_body
-      { mkmty(Pmty_functor(mkrhs $2 2, Some $4, $6)) }
-  | LPAREN RPAREN module_declaration_body
-      { mkmty(Pmty_functor(mkrhs2 "*" 1 2, None, $3)) }
+  | functor_arg module_declaration_body
+      { let (name,typ) = $1 in
+        mkmty(Pmty_functor(name, typ, $2)) }
 ;
 module_declaration:
     MODULE ext_attributes UIDENT module_declaration_body post_item_attributes

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -4820,6 +4820,7 @@ module Z = functor (_: sig end) (_:sig end) (_: sig end) -> struct end;;
 module GZ : functor (X: sig end) () (Z: sig end) -> sig end
           = functor (X: sig end) () (Z: sig end) -> struct end;;
 module F (X : sig end) = struct type t = int end;;
+module F (_ : sig end) = struct type t = int end;;
 type t = F(Does_not_exist).t;;
 type expr =
   [ `Abs of string * expr


### PR DESCRIPTION
While working on ocamlformat, I noticed the following syntax was not allowed.
```
module M(_:S) = struct end
```
`_` is not accepted, only `UIDENT` is.

Note that the following is currently accepted
```
module M = functor (_:S) -> struct end
```