### PR TITLE
Add Format.dprintf, the delayed printing function

### DIFF
--- a/Changes
+++ b/Changes
@@ -67,6 +67,14 @@ Working version
 - GPR#1957: Add Stack.{top_opt,pop_opt} and Queue.{peek_opt,take_opt}.
   (Vladimir Keleshev, review by Nicolás Ojeda Bär and Gabriel Scherer)
 
+- GPR#1959: Add Format.dprintf, a printing function which ouputs a closure
+  usable with %t.
+  (Gabriel Radanne, request by Armaël Guéneau,
+   review by Florian Angeletti and Gabriel Scherer)
+
+- GPR#1959: Small simplification and optimization to Format.ifprintf
+  (Gabriel Radanne, review by Gabriel Scherer)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/stdlib/camlinternalFormat.ml
+++ b/stdlib/camlinternalFormat.ml
@@ -1781,8 +1781,8 @@ and make_custom : type x y a b c d e f .
 
 let const x _ = x
 
-let rec make_iprintf : type a b c d e f.
-  (b -> f) -> b -> (a, b, c, d, e, f) fmt -> a =
+let rec make_iprintf : type a b c d e f state.
+  (state -> f) -> state -> (a, b, c, d, e, f) fmt -> a =
   fun k o fmt -> match fmt with
     | Char rest ->
         const (make_iprintf k o rest)
@@ -1855,8 +1855,8 @@ let rec make_iprintf : type a b c d e f.
     | End_of_format ->
         k o
 and fn_of_padding_precision :
-  type x y z a b c d e f.
-  (b -> f) -> b -> (a, b, c, d, e, f) fmt ->
+  type x y z a b c d e f state.
+  (state -> f) -> state -> (a, b, c, d, e, f) fmt ->
   (x, y) padding -> (y, z -> a) precision -> x =
   fun k o fmt pad prec -> match pad, prec with
     | No_padding   , No_precision    ->
@@ -1877,8 +1877,9 @@ and fn_of_padding_precision :
         const (const (make_iprintf k o fmt))
     | Arg_padding _, Arg_precision   ->
         const (const (const (make_iprintf k o fmt)))
-and fn_of_custom_arity : type x y a b c d e f .
-  (b -> f) -> b -> (a, b, c, d, e, f) fmt -> (a, x, y) custom_arity -> y =
+and fn_of_custom_arity : type x y a b c d e f state.
+  (state -> f) ->
+  state -> (a, b, c, d, e, f) fmt -> (a, x, y) custom_arity -> y =
   fun k o fmt -> function
     | Custom_zero ->
         make_iprintf k o fmt

--- a/stdlib/camlinternalFormat.mli
+++ b/stdlib/camlinternalFormat.mli
@@ -58,7 +58,7 @@ type ('b, 'c, 'e, 'f) fmt_ebb = Fmt_EBB :
      ('b, 'c, 'e, 'f) fmt_ebb
 
 val make_printf :
-  ('b -> ('b, 'c) acc -> 'd) -> 'b -> ('b, 'c) acc ->
+  (('b, 'c) acc -> 'd) -> ('b, 'c) acc ->
   ('a, 'b, 'c, 'c, 'c, 'd) CamlinternalFormatBasics.fmt -> 'a
 
 val make_iprintf : ('b -> 'f) -> 'b -> ('a, 'b, 'c, 'd, 'e, 'f) fmt -> 'a

--- a/stdlib/camlinternalFormat.mli
+++ b/stdlib/camlinternalFormat.mli
@@ -61,7 +61,7 @@ val make_printf :
   (('b, 'c) acc -> 'd) -> ('b, 'c) acc ->
   ('a, 'b, 'c, 'c, 'c, 'd) CamlinternalFormatBasics.fmt -> 'a
 
-val make_iprintf : ('b -> 'f) -> 'b -> ('a, 'b, 'c, 'd, 'e, 'f) fmt -> 'a
+val make_iprintf : ('s -> 'f) -> 's -> ('a, 'b, 'c, 'd, 'e, 'f) fmt -> 'a
 
 val output_acc : out_channel -> (out_channel, unit) acc -> unit
 val bufput_acc : Buffer.t -> (Buffer.t, unit) acc -> unit

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1334,8 +1334,8 @@ let rec strput_acc ppf acc = match acc with
 
 let kfprintf k ppf (Format (fmt, _)) =
   make_printf
-    (fun ppf acc -> output_acc ppf acc; k ppf)
-    ppf End_of_acc fmt
+    (fun acc -> output_acc ppf acc; k ppf)
+    End_of_acc fmt
 
 and ikfprintf k ppf (Format (fmt, _)) =
   make_iprintf k ppf fmt
@@ -1348,10 +1348,10 @@ let eprintf fmt = fprintf err_formatter fmt
 let ksprintf k (Format (fmt, _)) =
   let b = pp_make_buffer () in
   let ppf = formatter_of_buffer b in
-  let k () acc =
+  let k acc =
     strput_acc ppf acc;
     k (flush_buffer_formatter b ppf) in
-  make_printf k () End_of_acc fmt
+  make_printf k End_of_acc fmt
 
 
 let sprintf fmt = ksprintf (fun s -> s) fmt
@@ -1359,10 +1359,10 @@ let sprintf fmt = ksprintf (fun s -> s) fmt
 let kasprintf k (Format (fmt, _)) =
   let b = pp_make_buffer () in
   let ppf = formatter_of_buffer b in
-  let k ppf acc =
+  let k acc =
     output_acc ppf acc;
     k (flush_buffer_formatter b ppf) in
-  make_printf k ppf End_of_acc fmt
+  make_printf k End_of_acc fmt
 
 
 let asprintf fmt = kasprintf (fun s -> s) fmt
@@ -1412,8 +1412,9 @@ let get_all_formatter_output_functions =
    let ppf = formatter_of_buffer b
    then use {!fprintf ppf} as usual. *)
 let bprintf b (Format (fmt, _) : ('a, formatter, unit) format) =
-  let k ppf acc = output_acc ppf acc; pp_flush_queue ppf false in
-  make_printf k (formatter_of_buffer b) End_of_acc fmt
+  let ppf = formatter_of_buffer b in
+  let k acc = output_acc ppf acc; pp_flush_queue ppf false in
+  make_printf k End_of_acc fmt
 
 
 (* Deprecated : alias for ksprintf. *)

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1345,6 +1345,13 @@ let ifprintf ppf = ikfprintf ignore ppf
 let printf fmt = fprintf std_formatter fmt
 let eprintf fmt = fprintf err_formatter fmt
 
+let kdprintf k (Format (fmt, _)) =
+  make_printf
+    (fun acc -> k (fun ppf -> output_acc ppf acc))
+    End_of_acc fmt
+
+let dprintf fmt = kdprintf (fun i -> i) fmt
+
 let ksprintf k (Format (fmt, _)) =
   let b = pp_make_buffer () in
   let ppf = formatter_of_buffer b in

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1340,8 +1340,10 @@ let kfprintf k ppf (Format (fmt, _)) =
 and ikfprintf k ppf (Format (fmt, _)) =
   make_iprintf k ppf fmt
 
+let ifprintf _ppf (Format (fmt, _)) =
+  make_iprintf ignore () fmt
+
 let fprintf ppf = kfprintf ignore ppf
-let ifprintf ppf = ikfprintf ignore ppf
 let printf fmt = fprintf std_formatter fmt
 let eprintf fmt = fprintf err_formatter fmt
 

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -1068,6 +1068,18 @@ val asprintf : ('a, formatter, unit, string) format4 -> 'a
   @since 4.01.0
 *)
 
+val dprintf :
+  ('a, formatter, unit, formatter -> unit) format4 -> 'a
+(** Same as {!fprintf}, except the formatter is the last argument.
+  All printing actions are delayed until the formatter is provided.
+  In particular, [printff "..." a b c] is a
+  function of type [formatter -> unit] which can be given to
+  a format specifier [%t].
+
+  @since NEXT_VERSION
+*)
+
+
 val ifprintf : formatter -> ('a, formatter, unit) format -> 'a
 (** Same as [fprintf] above, but does not print anything.
   Useful to ignore some material when conditionally printing.
@@ -1082,6 +1094,15 @@ val kfprintf :
   ('b, formatter, unit, 'a) format4 -> 'b
 (** Same as [fprintf] above, but instead of returning immediately,
   passes the formatter to its first argument at the end of printing. *)
+
+val kdprintf :
+  ((formatter -> unit) -> 'a) ->
+  ('b, formatter, unit, 'a) format4 -> 'b
+(** Same as {!dprintf} above, but instead of returning immediately,
+  passes the suspended printer to its first argument at the end of printing.
+
+  @since NEXT_VERSION
+*)
 
 val ikfprintf :
   (formatter -> 'a) -> formatter ->

--- a/stdlib/printf.ml
+++ b/stdlib/printf.ml
@@ -17,9 +17,9 @@ open CamlinternalFormatBasics
 open CamlinternalFormat
 
 let kfprintf k o (Format (fmt, _)) =
-  make_printf (fun o acc -> output_acc o acc; k o) o End_of_acc fmt
+  make_printf (fun acc -> output_acc o acc; k o) End_of_acc fmt
 let kbprintf k b (Format (fmt, _)) =
-  make_printf (fun b acc -> bufput_acc b acc; k b) b End_of_acc fmt
+  make_printf (fun acc -> bufput_acc b acc; k b) End_of_acc fmt
 let ikfprintf k oc (Format (fmt, _)) =
   make_iprintf k oc fmt
 
@@ -30,11 +30,11 @@ let printf fmt = fprintf stdout fmt
 let eprintf fmt = fprintf stderr fmt
 
 let ksprintf k (Format (fmt, _)) =
-  let k' () acc =
+  let k' acc =
     let buf = Buffer.create 64 in
     strput_acc buf acc;
     k (Buffer.contents buf) in
-  make_printf k' () End_of_acc fmt
+  make_printf k' End_of_acc fmt
 
 let sprintf fmt = ksprintf (fun s -> s) fmt
 

--- a/testsuite/tests/lib-format/tformat.ml
+++ b/testsuite/tests/lib-format/tformat.ml
@@ -525,6 +525,14 @@ try
   test (sprintf "@@" = "@");
   test (sprintf "@@@@" = "@@");
   test (sprintf "@@%%" = "@%");
+
+  say "\nDelayed printf\n%!";
+  let t1 = dprintf "%i - %s" 1 "bar" in
+  test (asprintf "foo %t" t1 = "foo 1 - bar");
+  let t2 = dprintf "%a@]" (pp_print_list pp_print_int) [1 ; 2 ; 3] in
+  test (asprintf "foo @[<v>%t@,%s" t2 "bar" = "foo 1\n    2\n    3\nbar");
+  test (asprintf "%t @[<h>%t" t1 t2 = "1 - bar 123");
+
   say "\nend of tests\n%!";
 
 with e ->

--- a/testsuite/tests/lib-format/tformat.reference
+++ b/testsuite/tests/lib-format/tformat.reference
@@ -90,6 +90,8 @@ t
  309
 ! % @ , and constants
  310 311 312 313 314 315 316
+Delayed printf
+ 317 318 319
 end of tests
 
 All tests succeeded.

--- a/testsuite/tests/shadow_include/cannot_shadow_error.compilers.reference
+++ b/testsuite/tests/shadow_include/cannot_shadow_error.compilers.reference
@@ -1,6 +1,6 @@
 File "cannot_shadow_error.ml", line 23, characters 2-36:
-Error: Illegal shadowing of included type t/1141 by t/1145
+Error: Illegal shadowing of included type t/1143 by t/1147
        File "cannot_shadow_error.ml", line 22, characters 2-19:
-         Type t/1141 came from this include
+         Type t/1143 came from this include
        File "cannot_shadow_error.ml", line 13, characters 2-43:
-         The value print has no valid type if t/1141 is shadowed
+         The value print has no valid type if t/1143 is shadowed

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -25,11 +25,11 @@ end
 Line 3, characters 2-36:
     include Comparable with type t = t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/1152 by t/1156
+Error: Illegal shadowing of included type t/1154 by t/1158
        Line 2, characters 2-19:
-         Type t/1152 came from this include
+         Type t/1154 came from this include
        Line 3, characters 2-43:
-         The value print has no valid type if t/1152 is shadowed
+         The value print has no valid type if t/1154 is shadowed
 |}]
 
 module type Sunderscore = sig


### PR DESCRIPTION
In https://github.com/ocaml/ocaml/pull/1952, @Armael uses the type `Format.formatter -> unit` as the vehicle for "messages with delayed formatting decisions". Delaying the formatting decisions mean they can be taken when all the information regarding the final error message, the context and the output are known, instead of being translated into string now, resulting in bad formatting. `Format.formatter -> unit` also corresponds to the "%t" modifier in format strings.

Unfortunately, it means introducing a function
```ocaml
val errorf: ?loc:t -> ?sub:msg list -> (formatter -> unit) -> error
```

with usages that look like
```ocaml
Location.errorf ~loc:(Location.in_file filename) (fun ppf ->
        Format.fprintf ppf "Cannot open file %s@." (Printexc.to_string e))
```

This is not very nice. This PR introduces `dprintf` which works like a usual printf function, except it returns a closure of type `formatter -> unit` containing the printing actions.

Using `kdprintf` (the version that takes a continuation), `Location.errorf` can be redefined to be of type `?loc:t -> ?sub:msg list -> ('a, formatter, unit, error) format4 -> 'a`, which is more in line with the usual formatting functions and nicer to use.

I'm not particularly convinced neither by the current name nor the documentation, so feel free to propose improvements.

# Implementation

The first two commits are somewhat independent, but necessary for being able to express `dprintf`. All printf-like functions are defined in term of `CamlinternalFormat.make_printf` which used to be of type:
```ocaml
val make_printf :
  ('b -> ('b, 'c) acc -> 'd) -> 'b -> ('b, 'c) acc ->
  ('a, 'b, 'c, 'c, 'c, 'd) CamlinternalFormatBasics.fmt -> 'a
```

The `'b` parameter corresponds (in our case) to `Format.formatter`. This means that you must have a formatter at hand to do anything with a format string. However, this formatter is not actually used, it's only passed around everywhere until the continuation is called. The two first commits simply remove that argument everywhere and modify the continuations in `Format` and `Printf` to be closure that capture the required formatter.

As a side note, adding functions to `Format`'s api shift the ids, which makes two test fails for no real reason.