### PR TITLE
Distribute fonts with manual

### DIFF
--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -85,8 +85,10 @@ all:
 release: all
 	cp htmlman/manual.html $(RELEASE)refman.html
 	rm -f htmlman/manual.{html,haux,hmanual*,htoc}
-	tar zcf $(RELEASE)refman-html.tar.gz htmlman/*.* htmlman/libref
-	zip -8 $(RELEASE)refman-html.zip htmlman/*.* htmlman/libref/*.*
+	tar zcf $(RELEASE)refman-html.tar.gz \
+	  htmlman/*.* htmlman/libref htmlman/fonts
+	zip -8 $(RELEASE)refman-html.zip \
+	  htmlman/*.* htmlman/libref/*.* htmlman/fonts/*.*
 	cp texstuff/manual.pdf $(RELEASE)refman.pdf
 	cp textman/manual.txt $(RELEASE)refman.txt
 	tar cf - infoman/ocaml.info* | gzip > $(RELEASE)refman.info.tar.gz

--- a/manual/manual/macros.hva
+++ b/manual/manual/macros.hva
@@ -12,13 +12,13 @@
   font-family: 'Fira Sans';
   font-style: normal;
   font-weight: 400;
-  src: url('/pub/docs/manual-ocaml/fonts/fira-sans-v8-latin-regular.eot'); /* IE9 Compat Modes */
+  src: url('fonts/fira-sans-v8-latin-regular.eot'); /* IE9 Compat Modes */
   src: local('Fira Sans Regular'), local('FiraSans-Regular'),
-       url('/pub/docs/manual-ocaml/fonts/fira-sans-v8-latin-regular.eot?\#iefix') format('embedded-opentype'), /* IE6-IE8 */
-       url('/pub/docs/manual-ocaml/fonts/fira-sans-v8-latin-regular.woff2') format('woff2'), /* Super Modern Browsers */
-       url('/pub/docs/manual-ocaml/fonts/fira-sans-v8-latin-regular.woff') format('woff'), /* Modern Browsers */
-       url('/pub/docs/manual-ocaml/fonts/fira-sans-v8-latin-regular.ttf') format('truetype'), /* Safari, Android, iOS */
-       url('/pub/docs/manual-ocaml/fonts/fira-sans-v8-latin-regular.svg\#FiraSans') format('svg'); /* Legacy iOS */
+       url('fonts/fira-sans-v8-latin-regular.eot?\#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('fonts/fira-sans-v8-latin-regular.woff2') format('woff2'), /* Super Modern Browsers */
+       url('fonts/fira-sans-v8-latin-regular.woff') format('woff'), /* Modern Browsers */
+       url('fonts/fira-sans-v8-latin-regular.ttf') format('truetype'), /* Safari, Android, iOS */
+       url('fonts/fira-sans-v8-latin-regular.svg\#FiraSans') format('svg'); /* Legacy iOS */
 \}}
 
 % Compact layout

--- a/manual/manual/style.css
+++ b/manual/manual/style.css
@@ -3,13 +3,13 @@
   font-family: 'Fira Sans';
   font-style: normal;
   font-weight: 400;
-  src: url('/pub/docs/manual-ocaml/fonts/fira-sans-v8-latin-regular.eot'); /* IE9 Compat Modes */
+  src: url('../fonts/fira-sans-v8-latin-regular.eot'); /* IE9 Compat Modes */
   src: local('Fira Sans Regular'), local('FiraSans-Regular'),
-       url('/pub/docs/manual-ocaml/fonts/fira-sans-v8-latin-regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-       url('/pub/docs/manual-ocaml/fonts/fira-sans-v8-latin-regular.woff2') format('woff2'), /* Super Modern Browsers */
-       url('/pub/docs/manual-ocaml/fonts/fira-sans-v8-latin-regular.woff') format('woff'), /* Modern Browsers */
-       url('/pub/docs/manual-ocaml/fonts/fira-sans-v8-latin-regular.ttf') format('truetype'), /* Safari, Android, iOS */
-       url('/pub/docs/manual-ocaml/fonts/fira-sans-v8-latin-regular.svg#FiraSans') format('svg'); /* Legacy iOS */
+       url('../fonts/fira-sans-v8-latin-regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('../fonts/fira-sans-v8-latin-regular.woff2') format('woff2'), /* Super Modern Browsers */
+       url('../fonts/fira-sans-v8-latin-regular.woff') format('woff'), /* Modern Browsers */
+       url('../fonts/fira-sans-v8-latin-regular.ttf') format('truetype'), /* Safari, Android, iOS */
+       url('../fonts/fira-sans-v8-latin-regular.svg#FiraSans') format('svg'); /* Legacy iOS */
 }
 
 


### PR DESCRIPTION
This PR is a follow-up to the discussion in #1757; it does two things:

- change the manual style files to use relative paths for the font files, and
- copy the font files into the `.tar.gz` and `.zip` archives containing the html manual.

Following advice by @dbuenzli we only copy `.woff` and `.woff2` font file formats.