### PR TITLE
Format semantic tags as extensible sum types.

### DIFF
--- a/Changes
+++ b/Changes
@@ -102,6 +102,9 @@ Working version
   for consistency with OSX & Linux. Previously was located at `lib`.
   (Bryan Phelps, Jordan Walke, review by David Allsopp)
 
+- GPR#1966: Add Format semantic tags using extensible sum types.
+  (Gabriel Radanne, review by Nicolás Ojeda Bär)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -621,9 +621,9 @@ module Color = struct
   (* map a tag to a style, if the tag is known.
      @raise Not_found otherwise *)
   let style_of_tag s = match s with
-    | "error" -> (!cur_styles).error
-    | "warning" -> (!cur_styles).warning
-    | "loc" -> (!cur_styles).loc
+    | Format.String_tag "error" -> (!cur_styles).error
+    | Format.String_tag "warning" -> (!cur_styles).warning
+    | Format.String_tag "loc" -> (!cur_styles).loc
     | _ -> raise Not_found
 
   let color_enabled = ref true
@@ -644,13 +644,13 @@ module Color = struct
   (* add color handling to formatter [ppf] *)
   let set_color_tag_handling ppf =
     let open Format in
-    let functions = pp_get_formatter_tag_functions ppf () in
+    let functions = pp_get_formatter_stag_functions ppf () in
     let functions' = {functions with
-      mark_open_tag=(mark_open_tag ~or_else:functions.mark_open_tag);
-      mark_close_tag=(mark_close_tag ~or_else:functions.mark_close_tag);
+      mark_open_stag=(mark_open_tag ~or_else:functions.mark_open_stag);
+      mark_close_stag=(mark_close_tag ~or_else:functions.mark_close_stag);
     } in
     pp_set_mark_tags ppf true; (* enable tags *)
-    pp_set_formatter_tag_functions ppf functions';
+    pp_set_formatter_stag_functions ppf functions';
     (* also setup margins *)
     pp_set_margin ppf (pp_get_margin std_formatter());
     ()


### PR DESCRIPTION
This PR redefines Format "semantic tags" as an extensible sum types.

[Semantics tags](http://caml.inria.fr/pub/docs/manual-ocaml/libref/Format.html#tags) are annotations that are inserted into the formatting queue (either through combinators or trough the syntax `"@{<foo>..@}"`) and allow to mark some part of the text. Formatters can then act on these tags to do arbitrary things either before or after computation of the layout. 

A very common usage, including in the compiler itself, is to insert terminal sequences for colors. There are however more original use cases ([Interactive UIs](https://github.com/let-def/inuit), [S-exprs](https://binaryanalysisplatform.github.io/bap/api/master/Text_tags.html), [richer terminal informations](https://github.com/diml/lambda-term), [structured HTML](https://github.com/ocsigen/tyxml/blob/fmt/fmt/tyxml_fmt.mli), ... tune in for the upcoming OCaml workshop presentation by @let-def and myself for many crazy format use cases </self promotion>).

While semantic tags allows fairly original hacks, one big issue is that they are strings. Whichever information is passed down through the tags must be encoded into strings, passed through the formatting mechanisms and recovered at the other end. This has three major problems:
- Lack of encapsulation. semantic tags are open for anyone to interpret. If I remember @dbuenzli's remarks correctly, this is one of the major reason that led [Fmt](http://erratique.ch/software/fmt) to avoid them.
- Even without considering encapsulation, recognizing that a tag belongs to a library requires careful care.
- Everything must be serialized to strings or use IDs coupled with additional tables.

Hence this PR! Extensible sum types offer a very nice solution to all these problems. Libraries can declare new constructors that will contain arbitrary data. By keeping the constructor hidden, they can prevent users to mess with them. Constructors also allows to easily differentiate the various family of tags.

Given all that, the implementation is rather straightforward. On top of the new extensible sum type `stag`, I introduce the `String_tag` constructor which represent string tags. The format syntax still output string tags, and cannot be used to create arbitrary tags. I do not believe this is a problem in practice (especially given the various use cases presented above).

# Compatibility

Currently, all the Format "user facing" functions such as `{close,open}_tag` are kept, but marked as deprecated and to be replaced with the new ones. The `tag` type is kept unchanged. Functions expected to interpret formats (`formatter_tag_functions`) are all changed to use the new type `stag`.

There are many ways we could go about this, so I'll wait for comments.

# Going further

Currently, I have not changed the internal tags used by the compiler to use the new semantic tags. I will be happy to if people deem it worthwhile.