### PR TITLE
Simplify error messages for illegal includes

### DIFF
--- a/testsuite/tests/shadow_include/cannot_shadow_error.compilers.reference
+++ b/testsuite/tests/shadow_include/cannot_shadow_error.compilers.reference
@@ -1,6 +1,6 @@
 File "cannot_shadow_error.ml", line 23, characters 2-36:
-Error: Illegal shadowing of included type t/1143 by t/1147
+Error: Illegal shadowing of included type t/1 by t/2
        File "cannot_shadow_error.ml", line 22, characters 2-19:
-         Type t/1143 came from this include
+         Type t/1 came from this include
        File "cannot_shadow_error.ml", line 13, characters 2-43:
-         The value print has no valid type if t/1143 is shadowed
+         The value print has no valid type if t/1 is shadowed

--- a/testsuite/tests/shadow_include/shadow_all.ml
+++ b/testsuite/tests/shadow_include/shadow_all.ml
@@ -99,11 +99,11 @@ end
 Line 4, characters 2-11:
     include S
     ^^^^^^^^^
-Error: Illegal shadowing of included type t/1155 by t/1172
+Error: Illegal shadowing of included type t/1 by t/2
        Line 2, characters 2-11:
-         Type t/1155 came from this include
+         Type t/1 came from this include
        Line 3, characters 2-24:
-         The value ignore has no valid type if t/1155 is shadowed
+         The value ignore has no valid type if t/1 is shadowed
 |}]
 
 module type Module = sig
@@ -139,11 +139,11 @@ end
 Line 4, characters 2-11:
     include S
     ^^^^^^^^^
-Error: Illegal shadowing of included module M/1247 by M/1264
+Error: Illegal shadowing of included module M/1 by M/2
        Line 2, characters 2-11:
-         Module M/1247 came from this include
+         Module M/1 came from this include
        Line 3, characters 2-26:
-         The value ignore has no valid type if M/1247 is shadowed
+         The value ignore has no valid type if M/1 is shadowed
 |}]
 
 
@@ -180,11 +180,11 @@ end
 Line 4, characters 2-11:
     include S
     ^^^^^^^^^
-Error: Illegal shadowing of included module type T/1336 by T/1354
+Error: Illegal shadowing of included module type T/1 by T/2
        Line 2, characters 2-11:
-         Module type T/1336 came from this include
+         Module type T/1 came from this include
        Line 3, characters 2-39:
-         The module F has no valid type if T/1336 is shadowed
+         The module F has no valid type if T/1 is shadowed
 |}]
 
 module type Extension = sig
@@ -197,11 +197,11 @@ end
 Line 4, characters 2-11:
     include S
     ^^^^^^^^^
-Error: Illegal shadowing of included type ext/1372 by ext/1389
+Error: Illegal shadowing of included type ext/1 by ext/2
        Line 2, characters 2-11:
-         Type ext/1372 came from this include
+         Type ext/1 came from this include
        Line 3, characters 14-16:
-         The extension constructor C2 has no valid type if ext/1372 is shadowed
+         The extension constructor C2 has no valid type if ext/1 is shadowed
 |}]
 
 module type Class = sig

--- a/testsuite/tests/typing-sigsubst/sigsubst.ml
+++ b/testsuite/tests/typing-sigsubst/sigsubst.ml
@@ -25,11 +25,11 @@ end
 Line 3, characters 2-36:
     include Comparable with type t = t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Illegal shadowing of included type t/1154 by t/1158
+Error: Illegal shadowing of included type t/1 by t/2
        Line 2, characters 2-19:
-         Type t/1154 came from this include
+         Type t/1 came from this include
        Line 3, characters 2-43:
-         The value print has no valid type if t/1154 is shadowed
+         The value print has no valid type if t/1 is shadowed
 |}]
 
 module type Sunderscore = sig

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2324,17 +2324,19 @@ let report_error ppf = function
   | Cannot_hide_id { shadowed_item_kind; shadowed_item_id; shadowed_item_loc;
                      shadower_id; user_id; user_kind; user_loc } ->
       let shadowed_item_kind= Sig_component_kind.to_string shadowed_item_kind in
+      let shadowed = Ident.name shadowed_item_id ^ "/1" in
+      let shadower = Ident.name shadower_id ^ "/2" in
       fprintf ppf
-        "@[<v>Illegal shadowing of included %s %a by %a@ \
-         %a:@;<1 2>%s %a came from this include@ \
-         %a:@;<1 2>The %s %s has no valid type if %a is shadowed@]"
-        shadowed_item_kind Ident.print shadowed_item_id Ident.print shadower_id
+        "@[<v>Illegal shadowing of included %s %s by %s@ \
+         %a:@;<1 2>%s %s came from this include@ \
+         %a:@;<1 2>The %s %s has no valid type if %s is shadowed@]"
+        shadowed_item_kind shadowed shadower
         Location.print_loc shadowed_item_loc
         (String.capitalize_ascii shadowed_item_kind)
-        Ident.print shadowed_item_id
+        shadowed
         Location.print_loc user_loc
         (Sig_component_kind.to_string user_kind) (Ident.name user_id)
-        Ident.print shadowed_item_id
+        shadowed
 
 let report_error env ppf err =
   Printtyp.wrap_printing_env ~error:true env (fun () -> report_error ppf err)


### PR DESCRIPTION
This small PR proposes to replace

> Error: Illegal shadowing of included type t/1143 by t/1147
       File "cannot_shadow_error.ml", line 22, characters 2-19:
         Type t/1143 came from this include
       File "cannot_shadow_error.ml", line 13, characters 2-43:
         The value print has no valid type if t/1143 is shadowed

with

> Error: Illegal shadowing of included type t/1 by t/2
       File "cannot_shadow_error.ml", line 22, characters 2-19:
         Type t/1 came from this include
       File "cannot_shadow_error.ml", line 13, characters 2-43:
         The value print has no valid type if t/1 is shadowed

In this simplified error message, the ident stamps (1143/1147) have been replaced by 1/2 since they bring little information for ordinary users and they make it very easy to break the testsuite (cf #1956, #1959 ) . 

Note that another option in term of implementation would be to use the name collision mechanism of `Printtyp`.