### PR TITLE
Fix ordering of floatting doc comments in classes

### DIFF
--- a/Changes
+++ b/Changes
@@ -298,6 +298,9 @@ Working version
   Unboxable_type_in_prim_decl
   (Stefan Muenzel)
 
+- GPR#1970: fix order of floatting documentation comments in classes
+  (Hugo Heuzard, review by Nicolás Ojeda Bär)
+
 OCaml 4.07 maintenance branch
 -----------------------------
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1083,7 +1083,7 @@ class_fields:
     /* empty */
       { [] }
   | class_fields class_field
-      { $2 :: (text_cstr 2) @ $1 }
+      { $2 :: (List.rev (text_cstr 2)) @ $1 }
 ;
 class_field:
   | INHERIT override_flag attributes class_expr parent_binder
@@ -1192,8 +1192,8 @@ class_self_type:
       { mktyp(Ptyp_any) }
 ;
 class_sig_fields:
-    /* empty */                                 { [] }
-| class_sig_fields class_sig_field     { $2 :: (text_csig 2) @ $1 }
+    /* empty */                     { [] }
+| class_sig_fields class_sig_field  { $2 :: (List.rev (text_csig 2)) @ $1 }
 ;
 class_sig_field:
     INHERIT attributes class_signature post_item_attributes

--- a/testsuite/tests/parsing/docstrings.ml
+++ b/testsuite/tests/parsing/docstrings.ml
@@ -146,6 +146,10 @@ end = struct
     (** Ambiguous comment on both titi and toto *)
     method toto = tutu ^ "!"
 
+    (** floating 1 *)
+
+    (** floating 2 *)
+
     (** The comment for method m *)
     method m (f : float) = 1
   end
@@ -154,6 +158,10 @@ end = struct
   class type my_class_type = object
     (** The comment for the instance variable x. *)
     val mutable x : int
+
+    (** floating 1 *)
+
+    (** floating 2 *)
 
     (** The comment for method m. *)
     method m : int -> int
@@ -266,12 +274,16 @@ module Manual :
                            " Ambiguous comment on both titi and toto "]
         method toto = tutu ^ "!"[@@ocaml.doc
                                   " Ambiguous comment on both titi and toto "]
+        [@@@ocaml.text " floating 1 "]
+        [@@@ocaml.text " floating 2 "]
         method m (f : float) = 1[@@ocaml.doc " The comment for method m "]
       end[@@ocaml.doc " The comment for class my_class "]
     class type my_class_type =
       object
         val  mutable x : int[@@ocaml.doc
                               " The comment for the instance variable x. "]
+        [@@@ocaml.text " floating 1 "]
+        [@@@ocaml.text " floating 2 "]
         method  m : int -> int[@@ocaml.doc " The comment for method m. "]
       end[@@ocaml.doc " The comment for class type my_class_type "]
     module Foo =


### PR DESCRIPTION
\cc @lpw25 
`class_fields` and  `class_sig_fields` are built in reverse order.
So should be doc-comments in those constructs.
