### PR TITLE
Fix compilation of catches with multiple handlers

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,9 @@ Working version
 - GPR#1579: Add a separate types for clambda primitives
   (Pierre Chambart, review by Vincent Laviron and Mark Shinwell)
 
+- GPR#1973: fix compilation of catches with multiple handlers
+  (Vincent Laviron)
+
 - GPR#2228: refactoring the handling of .cmi files by moving it from
   Env to a new module Persistent_env
   (Gabriel Scherer, review by Jérémie Dimino and Thomas Refis)

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -272,7 +272,8 @@ let rec linear i n =
       let n2 = List.fold_left2 (fun n (_nfail, handler) lbl_handler ->
           match handler.Mach.desc with
           | Iend -> n
-          | _ -> cons_instr (Llabel lbl_handler) (linear handler n))
+          | _ -> cons_instr (Llabel lbl_handler)
+                   (linear handler (add_branch lbl_end n)))
           n1 handlers labels_at_entry_to_handlers
       in
       let n3 = linear body (add_branch lbl_end n2) in

--- a/testsuite/tests/asmgen/catch-multiple.cmm
+++ b/testsuite/tests/asmgen/catch-multiple.cmm
@@ -1,0 +1,20 @@
+(* TEST
+files = "main.c"
+arguments = "-DINT_INT -DFUN=catch_multiple main.c"
+* asmgen
+*)
+
+(*
+Expected output:
+catch_multiple(0) == -1
+catch_multiple(1) == 1
+*)
+
+(function "catch_multiple" (b:int)
+  (let x
+    (catch
+      (if (== b 0) (exit zero)
+          (exit other))
+     with (zero) -1
+     and (other) ( * b b))
+    x))

--- a/testsuite/tests/asmgen/ocamltests
+++ b/testsuite/tests/asmgen/ocamltests
@@ -2,6 +2,7 @@ arith.cmm
 catch-rec.cmm
 catch-try.cmm
 catch-float.cmm
+catch-multiple.cmm
 catch-try-float.cmm
 checkbound.cmm
 even-odd-spill.cmm


### PR DESCRIPTION
The Cmm and Mach representations have recently been updated to allow static catch constructions to contain more than one handler. There is currently no code that takes advantage of this feature, and as a result it is not well tested.

This pull request fixes a bug in the transformation of these multiple handlers to linear code.

The bug cannot be triggered from OCaml code currently, but the Cmm parser included in the testsuite already supported the feature, so I added a test program that would produce wrong code without this patch.
Unfortunately, I don't know how to ask `ocamltest` to run the actual produced code, let alone check its output, so the test would pass even without the fix.
If someone knows how to check the produced code's output, directions or patches are welcome.