### PR TITLE
Warn about partial application on let _ = (arrow type)

### DIFF
--- a/Changes
+++ b/Changes
@@ -292,6 +292,10 @@ Working version
   unused "open!" statements
   (Alain Frisch, report by dwang, review by and design from Leo White)
 
+- GPR#1974: Trigger warning 5 in "let _ = e" and "ignore e" if e is of function
+  type and syntactically an application. (For the case of "ignore e" the warning
+  already existed, but used to be triggered even when e was not an application.)
+  (Nicolás Ojeda Bär, review by Alain Frisch and Jacques Garrigue)
 
 ### Code generation and optimizations:
 

--- a/testsuite/tests/typing-warnings/application.ml
+++ b/testsuite/tests/typing-warnings/application.ml
@@ -9,14 +9,71 @@ Printexc.record_backtrace false;;
 - : unit = ()
 |}]
 
-let _ = ignore (+);;
+let _ = Array.get;;
 [%%expect {|
-Line 1, characters 15-18:
-1 | let _ = ignore (+);;
-                   ^^^
+- : 'a array -> int -> 'a = <fun>
+|}]
+
+let _ = Array.get [||];;
+[%%expect {|
+Line 1, characters 8-22:
+1 | let _ = Array.get [||];;
+            ^^^^^^^^^^^^^^
 Warning 5: this function application is partial,
 maybe some arguments are missing.
-- : unit = ()
+- : int -> 'a = <fun>
+|}]
+
+let () = ignore Array.get;;
+[%%expect {|
+|}]
+
+let () = ignore (Array.get [||]);;
+[%%expect {|
+Line 1, characters 16-32:
+1 | let () = ignore (Array.get [||]);;
+                    ^^^^^^^^^^^^^^^^
+Warning 5: this function application is partial,
+maybe some arguments are missing.
+|}]
+
+
+let _ = if true then Array.get else (fun _ _ -> 12);;
+[%%expect {|
+- : int array -> int -> int = <fun>
+|}]
+
+let _ = if true then Array.get [||] else (fun _ -> 12);;
+[%%expect {|
+Line 1, characters 21-35:
+1 | let _ = if true then Array.get [||] else (fun _ -> 12);;
+                         ^^^^^^^^^^^^^^
+Warning 5: this function application is partial,
+maybe some arguments are missing.
+- : int -> int = <fun>
+|}]
+
+let _ = (if true then Array.get [||] else (fun _ -> 12) : _ -> _);;
+[%%expect {|
+- : int -> int = <fun>
+|}]
+
+type t = {r: int -> int -> int}
+
+let f x = let _ = x.r in ();;
+[%%expect {|
+type t = { r : int -> int -> int; }
+val f : t -> unit = <fun>
+|}]
+
+let f x = let _ = x.r 1 in ();;
+[%%expect {|
+Line 1, characters 18-23:
+1 | let f x = let _ = x.r 1 in ();;
+                      ^^^^^
+Warning 5: this function application is partial,
+maybe some arguments are missing.
+val f : t -> unit = <fun>
 |}]
 
 let _ = raise Exit 3;;


### PR DESCRIPTION
In my experience (and others, judging by the discussion in #1971), `let _ = e` is a source of hard-to-track bugs.

This PR proposes to warn about partial application if `e` is of arrow type.

```ocaml
# let _ = Array.get;;
Warning 5: this function application is partial,
maybe some arguments are missing.
- : 'a array -> int -> 'a = <fun>
```

This is just a proof-of-concept; improvements may be possible with input from those more familiar with the type-checker.