### PR TITLE
Fix handling of warning attribute attached to type declarations

### DIFF
--- a/Changes
+++ b/Changes
@@ -334,6 +334,10 @@ Working version
 - GPR#1970: fix order of floatting documentation comments in classes
   (Hugo Heuzard, review by Nicolás Ojeda Bär)
 
+- GPR#1977: [@@ocaml.warning "..."] attributes attached to type declarations are
+  no longer ignored.
+  (Nicolás Ojeda Bär, review by Gabriel Scherer)
+
 OCaml 4.07 maintenance branch
 -----------------------------
 

--- a/testsuite/tests/typing-warnings/unused_types.compilers.reference
+++ b/testsuite/tests/typing-warnings/unused_types.compilers.reference
@@ -54,4 +54,14 @@ It is exported or rebound as a private extension.
 module Unused_private_extension :
   sig type t = .. type t += private Private_ext end
 module Pr7438 : sig  end
+Line 4, characters 2-30:
+    type t = A [@@warning "-34"]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 37: unused constructor A.
+module Unused_type_disable_warning : sig  end
+Line 4, characters 2-30:
+    type t = A [@@warning "-37"]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 34: unused type t.
+module Unused_constructor_disable_warning : sig  end
 

--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -80,3 +80,13 @@ end = struct
   module type X =
     sig type t = private [> `Foo | `Bar] include S with type t := t end
 end;;
+
+module Unused_type_disable_warning : sig
+end = struct
+  type t = A [@@warning "-34"]
+end;;
+
+module Unused_constructor_disable_warning : sig
+end = struct
+  type t = A [@@warning "-37"]
+end;;

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1341,7 +1341,7 @@ let set_type_used_callback name td callback =
   else let key = (name, loc) in
   let old =
     try Hashtbl.find type_declarations key
-    with Not_found -> assert false
+    with Not_found -> ignore
   in
   Hashtbl.replace type_declarations key (fun () -> callback old)
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1140,7 +1140,9 @@ let rec compute_properties_fixpoint env decls required variances immediacies =
   in
   let new_env =
     List.fold_right
-      (fun (id, decl) env -> Env.add_type ~check:true id decl env)
+      (fun (id, decl) env ->
+         Builtin_attributes.warning_scope decl.type_attributes
+           (fun () -> Env.add_type ~check:true id decl env))
       new_decls env
   in
   let new_variances =
@@ -1329,7 +1331,9 @@ let transl_type_decl env rec_flag sdecl_list =
   (* Build the final env. *)
   let newenv =
     List.fold_right
-      (fun (id, decl) env -> Env.add_type ~check:true id decl env)
+      (fun (id, decl) env ->
+         Builtin_attributes.warning_scope decl.type_attributes
+           (fun () -> Env.add_type ~check:true id decl env))
       decls env
   in
   (* Update stubs *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -82,7 +82,7 @@ let get_unboxed_from_attributes sdecl =
 (* Enter all declared types in the environment as abstract types *)
 
 let add_type ~check id decl env =
-  Builtin_attributes.warning_scope decl.type_attributes
+  Builtin_attributes.warning_scope ~ppwarning:false decl.type_attributes
     (fun () -> Env.add_type ~check id decl env)
 
 let enter_type rec_flag env sdecl id =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -114,7 +114,8 @@ let enter_type rec_flag env sdecl id =
       type_unboxed = unboxed_false_default_false;
     }
   in
-  Env.add_type ~check:true id decl env
+  Builtin_attributes.warning_scope decl.type_attributes
+    (fun () -> Env.add_type ~check:true id decl env)
 
 let update_type temp_env env id loc =
   let path = Path.Pident id in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -81,6 +81,10 @@ let get_unboxed_from_attributes sdecl =
 
 (* Enter all declared types in the environment as abstract types *)
 
+let add_type ~check id decl env =
+  Builtin_attributes.warning_scope decl.type_attributes
+    (fun () -> Env.add_type ~check id decl env)
+
 let enter_type rec_flag env sdecl id =
   let needed =
     match rec_flag with
@@ -114,8 +118,7 @@ let enter_type rec_flag env sdecl id =
       type_unboxed = unboxed_false_default_false;
     }
   in
-  Builtin_attributes.warning_scope decl.type_attributes
-    (fun () -> Env.add_type ~check:true id decl env)
+  add_type ~check:true id decl env
 
 let update_type temp_env env id loc =
   let path = Path.Pident id in
@@ -1141,9 +1144,7 @@ let rec compute_properties_fixpoint env decls required variances immediacies =
   in
   let new_env =
     List.fold_right
-      (fun (id, decl) env ->
-         Builtin_attributes.warning_scope decl.type_attributes
-           (fun () -> Env.add_type ~check:true id decl env))
+      (fun (id, decl) env -> add_type ~check:true id decl env)
       new_decls env
   in
   let new_variances =
@@ -1332,9 +1333,7 @@ let transl_type_decl env rec_flag sdecl_list =
   (* Build the final env. *)
   let newenv =
     List.fold_right
-      (fun (id, decl) env ->
-         Builtin_attributes.warning_scope decl.type_attributes
-           (fun () -> Env.add_type ~check:true id decl env))
+      (fun (id, decl) env -> add_type ~check:true id decl env)
       decls env
   in
   (* Update stubs *)


### PR DESCRIPTION
Currently warning attributes attached to type declaration are not always respected. For example,
```ocaml
module M : sig end = struct type t = A [@@warning "-37"] end
```
will still trigger warning 37 if enabled.