### PR TITLE
Fix references to Location.report_error in docstrings

### DIFF
--- a/parsing/syntaxerr.mli
+++ b/parsing/syntaxerr.mli
@@ -31,7 +31,7 @@ exception Error of error
 exception Escape_error
 
 val report_error: formatter -> error -> unit
- (** @deprecated Use {!Location.error_of_exn}, {!Location.report_error}. *)
+ (** @deprecated Use {!Location.error_of_exn}, {!Location.print_report}. *)
 
 val location_of_error: error -> Location.t
 val ill_formed_ast: Location.t -> string -> 'a

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -179,7 +179,7 @@ exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
 val report_error: Env.t -> formatter -> error -> unit
- (* Deprecated.  Use Location.{error_of_exn, report_error}. *)
+ (** @deprecated.  Use {!Location.error_of_exn}, {!Location.print_report}. *)
 
 (* Forward declaration, to be filled in by Typemod.type_module *)
 val type_module: (Env.t -> Parsetree.module_expr -> Typedtree.module_expr) ref


### PR DESCRIPTION
This is a follow-up of #1952 which removed `Location.report_error`