### PR TITLE
Remove support for TERM=norepeat when displaying errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -164,6 +164,9 @@ Working version
 - GPR#1976: Better error messages for extension constructor type mismatches
   (Thomas Refis, review by Gabriel Scherer)
 
+* GPR#1979: Remove support for TERM=norepeat when displaying errors
+  (Armaël Guéneau, review by Gabriel Scherer and Florian Angeletti)
+
 ### Code generation and optimizations:
 
 - MPR#7725, GPR#1754: improve AFL instrumentation for objects and lazy values.

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -515,15 +515,12 @@ let terminfo_toplevel_printer (lb: lexbuf): report_printer =
 
 let best_toplevel_printer () =
   setup_terminal ();
-  let norepeat =
-    try Sys.getenv "TERM" = "norepeat" with Not_found -> false
-  in
-  match !status, !input_lexbuf, norepeat with
-  | Terminfo.Good_term, Some lb, _ ->
+  match !status, !input_lexbuf with
+  | Terminfo.Good_term, Some lb ->
       terminfo_toplevel_printer lb
-  | Terminfo.Bad_term, Some lb, false ->
+  | Terminfo.Bad_term, Some lb ->
       dumb_toplevel_printer lb
-  | _, _, _ ->
+  | _, _ ->
       batch_mode_printer
 
 (* Creates a printer for the current input *)


### PR DESCRIPTION
Another follow-up of #1952 that was discussed during the review. `TERM=norepeat` was used by the manual build setup, but is not needed anymore since #1863 switched to compiler-libs instead of parsing the compiler output. 
Removing it simplifies the error printing code, getting rid of one seemingly unused code path we have to think about when refactoring this part of the code.

I added a Changes entry and marked the change as potentially breaking, since people might in theory use the feature in the wild, even though it's unlikely, I would say.