### PR TITLE
Fix erasable optional argument warning

### DIFF
--- a/Changes
+++ b/Changes
@@ -345,6 +345,11 @@ Working version
   no longer ignored.
   (Nicolás Ojeda Bär, review by Gabriel Scherer)
 
+- GPR#1983, MPR#7837: Warning 16 ("optional argument cannot be erased") is now
+  correctly triggered if the optional argument is followed solely by labelled
+  arguments.
+  (Nicolás Ojeda Bär)
+
 OCaml 4.07 maintenance branch
 -----------------------------
 

--- a/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
+++ b/testsuite/tests/typing-misc/typecore_nolabel_errors.ml
@@ -30,6 +30,10 @@ This argument cannot be applied with label ~y
 let f ?x ~a ?y ~z = ()
 let g = f ?y:None ?x:None ~a:()
 [%%expect {|
+Line 1, characters 13-14:
+  let f ?x ~a ?y ~z = ()
+               ^
+Warning 16: this optional argument cannot be erased.
 val f : ?x:'a -> a:'b -> ?y:'c -> z:'d -> unit = <fun>
 Line 2, characters 13-17:
   let g = f ?y:None ?x:None ~a:()

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3272,7 +3272,11 @@ and type_function ?in_function loc attrs env ty_expected_explained l caselist =
       true loc caselist in
   let not_function ty =
     let ls, tvar = list_labels env ty in
-    ls = [] && not tvar
+    not tvar &&
+    List.for_all (function
+        | Nolabel | Optional _ -> false
+        | Labelled _ -> true
+      ) ls
   in
   if is_optional l && not_function ty_res then
     Location.prerr_warning (List.hd cases).c_lhs.pat_loc


### PR DESCRIPTION
See [MPR#7836](https://caml.inria.fr/mantis/view.php?id=7836). There it is reported that if one defines
```ocaml
let f ?a ~b = ()
```
then `?a` is not erasable, but warning 16 is **not** triggered. For reference, this is what the [manual](https://caml.inria.fr/pub/docs/manual-ocaml/lablexamples.html#sec44) says:

> The criterion for deciding whether an optional argument has been omitted is the non-labeled application of an argument appearing after this optional argument in the function type. 

The condition to trigger warning 16, `ls = []` in the diff below, means that the optional argument is in fact the last one. That is, the warning is not triggered if the optional argument is followed by another argument, **even if it is labelled**.

Doing a little archeology we find that this code has been unchanged since 1279ab4b76cad7001b3b47902d4813947f427031 when the condition to trigger the warning was different:
```ocaml
not (List.exists (fun l -> l = "" || l.[0] = '?') ls)
```
which in fact coincides with what the manual says (set up so that the warning is triggered on the right-most optional argument).

This PR just goes back to the original condition as it was before 1279ab4b76cad7001b3b47902d4813947f427031.

/cc @garrigue