### PR TITLE
Doc clarification

### DIFF
--- a/manual/manual/tutorials/lablexamples.etex
+++ b/manual/manual/tutorials/lablexamples.etex
@@ -116,9 +116,10 @@ A function taking some optional arguments must also take at least one
 non-optional argument. The criterion for deciding whether an optional
 argument has been omitted is the non-labeled application of an
 argument appearing after this optional argument in the function type.
+
 Note that if that argument is labeled, you will only be able to
-eliminate optional arguments through the special case for total
-applications.
+eliminate optional arguments by totally applying the function,
+omitting all optional arguments and omitting all labels.
 
 \begin{caml_example}{toplevel}
 let test ?(x = 0) ?(y = 0) () ?(z = 0) () = (x, y, z);;

--- a/manual/manual/tutorials/lablexamples.etex
+++ b/manual/manual/tutorials/lablexamples.etex
@@ -116,11 +116,10 @@ A function taking some optional arguments must also take at least one
 non-optional argument. The criterion for deciding whether an optional
 argument has been omitted is the non-labeled application of an
 argument appearing after this optional argument in the function type.
-
 Note that if that argument is labeled, you will only be able to
 eliminate optional arguments by totally applying the function,
 omitting all optional arguments and omitting all labels for all
-arguments.
+remaining arguments.
 
 \begin{caml_example}{toplevel}
 let test ?(x = 0) ?(y = 0) () ?(z = 0) () = (x, y, z);;

--- a/manual/manual/tutorials/lablexamples.etex
+++ b/manual/manual/tutorials/lablexamples.etex
@@ -119,7 +119,8 @@ argument appearing after this optional argument in the function type.
 
 Note that if that argument is labeled, you will only be able to
 eliminate optional arguments by totally applying the function,
-omitting all optional arguments and omitting all labels.
+omitting all optional arguments and omitting all labels for all
+arguments.
 
 \begin{caml_example}{toplevel}
 let test ?(x = 0) ?(y = 0) () ?(z = 0) () = (x, y, z);;


### PR DESCRIPTION
See [MPR#7836](https://caml.inria.fr/mantis/view.php?id=7836). Clarifies the documentation on erasability of optional arguments.