### PR TITLE
Add Set.disjoint

### DIFF
--- a/Changes
+++ b/Changes
@@ -87,6 +87,9 @@ Working version
   (Marcello Seri, review by Daniel Bünzli, Gabriel Scherer, François Bobot,
   Nicolás Ojeda Bär, Xavier Clerc and Boris Yakobowski)
 
+- GPR#1986, MPR#6450: Add Set.disjoint
+  (Nicolás Ojeda Bär, review by Gabriel Scherer)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -194,6 +194,7 @@ module Set : sig
       val remove : elt -> t -> t
       val union : t -> t -> t
       val inter : t -> t -> t
+      val disjoint : t -> t -> bool
       val diff : t -> t -> t
       val compare : t -> t -> int
       val equal : t -> t -> bool

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -98,6 +98,9 @@ module type S =
     val inter: t -> t -> t
     (** Set intersection. *)
 
+    val disjoint: t -> t -> bool
+    (** Test if two sets are disjoint. *)
+
     val diff: t -> t -> t
     (** Set difference. *)
 

--- a/testsuite/tests/lib-set/testset.ml
+++ b/testsuite/tests/lib-set/testset.ml
@@ -41,6 +41,9 @@ let test x s1 s2 =
     (let s = S.inter s1 s2 in
      fun i -> S.mem i s = (S.mem i s1 && S.mem i s2));
 
+  checkbool "disjoint"
+    (S.is_empty (S.inter s1 s2) = S.disjoint s1 s2);
+
   check "diff"
     (let s = S.diff s1 s2 in
      fun i -> S.mem i s = (S.mem i s1 && not (S.mem i s2)));

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -287,6 +287,7 @@ module StringSet :
     val remove : elt -> t -> t
     val union : t -> t -> t
     val inter : t -> t -> t
+    val disjoint : t -> t -> bool
     val diff : t -> t -> t
     val compare : t -> t -> int
     val equal : t -> t -> bool
@@ -331,6 +332,7 @@ module SSet :
     val remove : elt -> t -> t
     val union : t -> t -> t
     val inter : t -> t -> t
+    val disjoint : t -> t -> bool
     val diff : t -> t -> t
     val compare : t -> t -> int
     val equal : t -> t -> bool
@@ -407,6 +409,7 @@ module A :
         val remove : elt -> t -> t
         val union : t -> t -> t
         val inter : t -> t -> t
+        val disjoint : t -> t -> bool
         val diff : t -> t -> t
         val compare : t -> t -> int
         val equal : t -> t -> bool
@@ -523,6 +526,7 @@ module SInt :
     val remove : elt -> t -> t
     val union : t -> t -> t
     val inter : t -> t -> t
+    val disjoint : t -> t -> bool
     val diff : t -> t -> t
     val compare : t -> t -> int
     val equal : t -> t -> bool


### PR DESCRIPTION
This adds a function to decide if two sets are disjoint. This can be done more efficiently from inside the `Set` module. See [MPR#6450](https://caml.inria.fr/mantis/view.php?id=6450).

This version has been used at LexiFi for a long time without problems.