### PR TITLE
Envaux.env_from_summary: guard against failure to find module

### DIFF
--- a/Changes
+++ b/Changes
@@ -355,6 +355,10 @@ Working version
   no longer ignored.
   (Nicolás Ojeda Bär, review by Gabriel Scherer)
 
+- MPR#7830, GPR#1987: fix ocamldebug crash when printing a value in the scope of
+  an `open` statement for which the `.cmi` is not available.
+  (Nicolás Ojeda Bär, report Jocelyn Sérot, review by Gabriel Scherer)
+
 OCaml 4.07 maintenance branch
 -----------------------------
 

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -67,6 +67,7 @@ let rec env_from_summary sum subst =
                         ~hidden_submodules with
           | Some env -> env
           | None -> assert false
+          | exception Not_found -> raise (Error (Module_not_found path'))
           end
       | Env_functor_arg(Env_module(s, id, desc), id') when Ident.same id id' ->
           Env.add_module_declaration ~check:false


### PR DESCRIPTION
See [MPR#7830.](https://caml.inria.fr/mantis/view.php?id=7830) There it is reported that `ocamldebug` will crash when trying to print any value if the `.cmi` of **any** opened module is not found.

To reproduce, make an empty file `empty.ml`, and put the following in `main.ml`:
```ocaml
open Empty
let f () = ()
let () = ()
```
Then compile with
```
ocamlc -g empty.ml main.ml
rm empty.cmi
```
and run the resulting program under `ocamldebug` with
```
ocamldebug a.out
(ocd) break @ Main 1
(ocd) r
(ocd) print foo
Uncaught exception: Not_found
```

I traced the error to the function `Envaux.env_from_summary` (this function is only used in the debugger). There the case `Env_open` will raise `Not_found` if the `.cmi` file in question is not found (the exception is raised in  `Env.find_pers_struct`).

This part of the code was last touched in 3d037367a28a590876c8361a620e3402c108a36b (cc: @alainfrisch), where an exception handler for `Not_found` was removed. Based on that change, this PR restores a handler for `Not_found`, but I am not sure it is the right fix (it gives a sensible error message in the case above though).

Some questions/remarks:

- I couldn't quite figure out how the `Not_found` exception raised by `find_pers_struct` is handled in the rest of the compiler.
- Even if this fix is correct, the debugger should not error out if a `.cmi` file is not found, especially if it is not required for anything. Even if it is, at most it should make some types abstract, like in the toplevel.