### PR TITLE
Printtyp: minor refactoring of Path.t printing functions

### DIFF
--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -34,6 +34,8 @@ let rec print_ident ppf =
   | Oide_apply (id1, id2) ->
       fprintf ppf "%a(%a)" print_ident id1 print_ident id2
 
+let out_ident = ref print_ident
+
 let parenthesized_ident name =
   (List.mem name ["or"; "mod"; "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr"])
   ||

--- a/typing/oprint.mli
+++ b/typing/oprint.mli
@@ -16,6 +16,7 @@
 open Format
 open Outcometree
 
+val out_ident : (formatter -> out_ident -> unit) ref
 val out_value : (formatter -> out_value -> unit) ref
 val out_type : (formatter -> out_type -> unit) ref
 val out_class_type : (formatter -> out_class_type -> unit) ref

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -371,23 +371,8 @@ let rec tree_of_path namespace = function
   | Papply(p1, p2) ->
       Oide_apply (tree_of_path Module p1, tree_of_path Module p2)
 
-let rec path ppf = function
-  | Pident id ->
-      ident ppf id
-  | Pdot(_, s, _pos) as path
-    when non_shadowed_pervasive path ->
-      pp_print_string ppf s
-  | Pdot(p, s, _pos) ->
-      path ppf p;
-      pp_print_char ppf '.';
-      pp_print_string ppf s
-  | Papply(p1, p2) ->
-      fprintf ppf "%a(%a)" path p1 path p2
-
 let tree_of_path namespace p =
   tree_of_path namespace (rewrite_double_underscore_paths !printing_env p)
-let path ppf p =
-  path ppf (rewrite_double_underscore_paths !printing_env p)
 
 let rec string_of_out_ident = function
   | Oide_ident s -> Out_name.print s
@@ -396,7 +381,13 @@ let rec string_of_out_ident = function
       String.concat ""
         [string_of_out_ident id1; "("; string_of_out_ident id2; ")"]
 
+let out_ident ppf id =
+  Format.pp_print_string ppf (string_of_out_ident id)
+
 let string_of_path p = string_of_out_ident (tree_of_path Other p)
+
+let path ppf p =
+  Format.pp_print_string ppf (string_of_path p)
 
 let strings_of_paths namespace p =
   reset_naming_context ();

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -374,25 +374,16 @@ let rec tree_of_path namespace = function
 let tree_of_path namespace p =
   tree_of_path namespace (rewrite_double_underscore_paths !printing_env p)
 
-let rec string_of_out_ident = function
-  | Oide_ident s -> Out_name.print s
-  | Oide_dot (id, s) -> String.concat "." [string_of_out_ident id; s]
-  | Oide_apply (id1, id2) ->
-      String.concat ""
-        [string_of_out_ident id1; "("; string_of_out_ident id2; ")"]
-
-let out_ident ppf id =
-  Format.pp_print_string ppf (string_of_out_ident id)
-
-let string_of_path p = string_of_out_ident (tree_of_path Other p)
-
 let path ppf p =
-  Format.pp_print_string ppf (string_of_path p)
+  !Oprint.out_ident ppf (tree_of_path Other p)
+
+let string_of_path p =
+  Format.asprintf "%a" path p
 
 let strings_of_paths namespace p =
   reset_naming_context ();
   let trees = List.map (tree_of_path namespace) p in
-  List.map string_of_out_ident trees
+  List.map (Format.asprintf "%a" !Oprint.out_ident) trees
 
 (* Print a recursive annotation *)
 
@@ -1730,10 +1721,11 @@ let trees_of_type_path_expansion (tp,tp') =
     Diff(tree_of_path Type tp, tree_of_path Type tp')
 
 let type_path_expansion ppf = function
-  | Same p -> fprintf ppf "%s" (string_of_out_ident p)
+  | Same p -> !Oprint.out_ident ppf p
   | Diff(p,p') ->
-      fprintf ppf "@[<2>%s@ =@ %s@]" (string_of_out_ident p)
-        (string_of_out_ident p')
+      fprintf ppf "@[<2>%a@ =@ %a@]"
+        !Oprint.out_ident p
+        !Oprint.out_ident p'
 
 let rec trace fst txt ppf = function
   | te :: te2 :: rem ->

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -22,8 +22,6 @@ open Outcometree
 val longident: formatter -> Longident.t -> unit
 val ident: formatter -> Ident.t -> unit
 val tree_of_path: Path.t -> out_ident
-val out_ident: formatter -> out_ident -> unit
-val string_of_out_ident: out_ident -> string
 val path: formatter -> Path.t -> unit
 val string_of_path: Path.t -> string
 

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -22,6 +22,8 @@ open Outcometree
 val longident: formatter -> Longident.t -> unit
 val ident: formatter -> Ident.t -> unit
 val tree_of_path: Path.t -> out_ident
+val out_ident: formatter -> out_ident -> unit
+val string_of_out_ident: out_ident -> string
 val path: formatter -> Path.t -> unit
 val string_of_path: Path.t -> string
 


### PR DESCRIPTION
Implement more cleanly and expose the separation of printing in two phases for
Path.t: first, build an outcome tree component (possibly reading printing_env
and updating global state), second, print the outcome tree (without side-effect
apart for printing).

cc @Octachron 