### PR TITLE
Alternative formatting for polymorphic variant types

### DIFF
--- a/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.compilers.reference
+++ b/testsuite/tests/typing-warnings/ambiguous_guarded_disjunction.compilers.reference
@@ -66,8 +66,8 @@ val not_ambiguous__several_orpats :
   [> `A of
        [> `B of 'a * 'b option * 'c option ] *
        [> `C of 'a * 'd option * 'e option ] *
-       [> `D1 of 'f * 'a * 'g option * 'h | `D2 of 'i * 'a * 'j * 'k option ] ] ->
-  unit = <fun>
+       [> `D1 of 'f * 'a * 'g option * 'h | `D2 of 'i * 'a * 'j * 'k option ]
+  ] -> unit = <fun>
 Line 3, characters 4-101:
   ....`A ((`B (Some x, _) | `B (_, Some x)),
           (`C (Some y, Some _, _) | `C (Some y, _, Some _))).................

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -296,7 +296,8 @@ and print_simple_out_type ppf =
         | Ovar_typ typ ->
            print_simple_out_type ppf typ
       in
-      fprintf ppf "%s[%s@[<hv>@[<hv>%a@]%a ]@]" (if non_gen then "_" else "")
+      fprintf ppf "%s@[<hov>[%s@[<hv>@[<hv>%a@]%a@]@ ]@]"
+        (if non_gen then "_" else "")
         (if closed then if tags = None then " " else "< "
          else if tags = None then "> " else "? ")
         print_fields row_fields


### PR DESCRIPTION
This PR proposes to tweak the formatting of polymorphic variant types from
```OCaml
type t =
    [ `Abc
    | `Def
    | `Ghi
    | `Jkl
    | `Mno ]
```
to 
```OCaml
type t =
    [ `Abc
    | `Def
    | `Ghi
    | `Jkl
    | `Mno
    ]
```
by replacing a non-breaking space `~]` with a break hint (with the right indentation to keep the alignment between `[` and `]`).

This is particularly useful with nested polymorphic variant types: it avoids starving the layout engine for break hints. For instance this PR replaces the overfull
```OCaml
  [> `A of
       [> `B of 'a * 'b option * 'c option ] *
       [> `C of 'a * 'd option * 'e option ] *
       [> `D1 of 'f * 'a * 'g option * 'h | `D2 of 'i * 'a * 'j * 'k option ] ] ->
(* this line is 82 characters long, due to the lack of any break hints in " ] ] ->" *)
```
with
```OCaml
  [> `A of
       [> `B of 'a * 'b option * 'c option ] *
       [> `C of 'a * 'd option * 'e option ] *
       [> `D1 of 'f * 'a * 'g option * 'h | `D2 of 'i * 'a * 'j * 'k option ]
  ] ->
``` 
cc @nojb 