### PR TITLE
Expanded error message for universal quantification failure

### DIFF
--- a/Changes
+++ b/Changes
@@ -170,6 +170,9 @@ Working version
 * GPR#1979: Remove support for TERM=norepeat when displaying errors
   (Armaël Guéneau, review by Gabriel Scherer and Florian Angeletti)
 
+- GPR#1993: Expanded error messages for universal quantification failure
+  (Florian Angeletti, review by Jacques Garrigue)
+
 ### Code generation and optimizations:
 
 - MPR#7725, GPR#1754: improve AFL instrumentation for objects and lazy values.

--- a/testsuite/tests/typing-poly/error_messages.ml
+++ b/testsuite/tests/typing-poly/error_messages.ml
@@ -1,0 +1,28 @@
+(* TEST
+   * expect
+*)
+
+type t = < x : 'a. int as 'a >
+[%%expect {|
+Line 1, characters 15-28:
+  type t = < x : 'a. int as 'a >
+                 ^^^^^^^^^^^^^
+Error: The universal type variable 'a cannot be generalized: it is bound to
+       int.
+|}]
+type u = < x : 'a 'b. 'a as 'b >
+[%%expect {|
+Line 1, characters 15-30:
+  type u = < x : 'a 'b. 'a as 'b >
+                 ^^^^^^^^^^^^^^^
+Error: The universal type variable 'b cannot be generalized:
+       it is already bound to another variable.
+|}]
+type v = 'b -> < x : 'a. 'b as 'a >
+[%%expect {|
+Line 1, characters 21-33:
+  type v = 'b -> < x : 'a. 'b as 'a >
+                       ^^^^^^^^^^^^
+Error: The universal type variable 'a cannot be generalized:
+       it escapes its scope.
+|}]

--- a/testsuite/tests/typing-poly/ocamltests
+++ b/testsuite/tests/typing-poly/ocamltests
@@ -1,1 +1,2 @@
+error_messages.ml
 poly.ml

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -953,11 +953,15 @@ let report_error env ppf = function
       fprintf ppf "The type variable name %s is not allowed in programs" name
   | Cannot_quantify (name, v) ->
       fprintf ppf
-        "@[<hov>The universal type variable '%s cannot be generalized:@ %s.@]"
-        name
-        (if Btype.is_Tvar v then "it escapes its scope" else
-         if Btype.is_Tunivar v then "it is already bound to another variable"
-         else "it is not a variable")
+        "@[<hov>The universal type variable '%s cannot be generalized:@ "
+        name;
+      if Btype.is_Tvar v then
+        fprintf ppf "it escapes its scope"
+      else if Btype.is_Tunivar v then
+        fprintf ppf "it is already bound to another variable"
+      else
+        fprintf ppf "it is bound to@ %a" Printtyp.type_expr v;
+      fprintf ppf ".@]";
   | Multiple_constraints_on_type s ->
       fprintf ppf "Multiple constraints for type %a" longident s
   | Method_mismatch (l, ty, ty') ->


### PR DESCRIPTION
Currently, type expressions with an incorrect universal quantification, for instance
```OCaml
type a = <m: 'a. int as 'a >
```
fail with

> Error: The universal type variable 'a cannot be generalized:
       it is not a variable.

which seems to imply that the universal variable is somehow not a variable.

This PR proposes to remove the ambiguity on the `it` by expanding this error message to

> Error: The universal type variable 'a cannot be generalized:
       it is bound to int.

which is quite similar to the related error message

```OCaml
type b = <m: 'a 'b. 'a as 'b >
```
> Error: The universal type variable 'b cannot be generalized:
       it is already bound to another variable.
