### PR TITLE
Update cross-reference-checker

### DIFF
--- a/Changes
+++ b/Changes
@@ -252,6 +252,7 @@ Working version
 ### Internal/compiler-libs changes:
 
 * GPR#1952: refactor the code responsible for displaying errors and warnings
+  `Location.report_error` is removed, use `Location.print_report` instead
   (Armaël Guéneau, review by Thomas Refis)
 
 - GPR#1894: generalize highlight_dumb in location.ml to handle highlighting

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -10,6 +10,7 @@ tests: manual
 tools:
 	$(MAKE) -C tools clean
 	$(MAKE) -C tools all
+	$(MAKE) -C tests tools
 
 manual: tools
 	$(MAKE) -C manual all

--- a/manual/tests/Makefile
+++ b/manual/tests/Makefile
@@ -2,8 +2,11 @@ TOPDIR=$(abspath ../..)
 include $(TOPDIR)/Makefile.tools
 MANUAL=$(TOPDIR)/manual/manual
 
+.PHONY: all
 all: check-cross-references check-stdlib
 
+.PHONY: tools
+tools: cross-reference-checker
 
 cross-reference-checker: cross_reference_checker.ml
 	$(OCAMLC) $(TOPDIR)/compilerlibs/ocamlcommon.cma \

--- a/manual/tests/cross_reference_checker.ml
+++ b/manual/tests/cross_reference_checker.ml
@@ -28,7 +28,7 @@ let pp_ref ppf = Format.pp_print_list ~pp_sep:( fun ppf () ->
     Format.pp_print_string ppf ".") Format.pp_print_int ppf
 
 let print_error error =
-  Location.report_error Format.std_formatter @@ match error with
+  Location.print_report Format.std_formatter @@ match error with
   | Tuple_expected loc ->
       Location.errorf ~loc
         "Integer tuple expected after manual reference annotation@."

--- a/manual/tests/cross_reference_checker.ml
+++ b/manual/tests/cross_reference_checker.ml
@@ -135,17 +135,17 @@ module OCaml_refs = struct
       sourcefile
 
   (** search for an attribute [[@manual.ref "tex_label_name"]] *)
-  let manual_reference_attribute (s, payload) =
-    if s.Location.txt = "manual.ref" then
-      match payload with
-      | Parsetree.(
-          PStr [{pstr_desc= Pstr_eval
-                     ({ pexp_desc = Pexp_constant Pconst_string (s,_) },_) } ] ) ->
+  let manual_reference_attribute attr =
+    let open Parsetree in
+    if attr.attr_name.Location.txt <> "manual.ref"
+    then None
+    else begin match attr.attr_payload with
+      | PStr [{pstr_desc= Pstr_eval
+                 ({ pexp_desc = Pexp_constant Pconst_string (s,_) },_) } ] ->
           Some s
-      | _ -> print_error (Wrong_attribute_payload s.Location.loc);
+      | _ -> print_error (Wrong_attribute_payload attr.attr_loc);
           Some "" (* triggers an error *)
-    else
-      None
+    end
 
   let rec label_from_attributes = function
     | [] -> None


### PR DESCRIPTION
This useful piece of code was not built during our testing, and has gone unbuildable due to two separate changes to the parsetree in #1952 and #1953. (When it doesn't build, building the manual fails.)

The present PR fixes the two build errors, and adds building cross-reference-checker to the `manual-pregen` step of the CI, so that we notice future breakages earlier.

@Armael: I added a code-migration remark to the Changes entry for #1952.