### PR TITLE
Add documentation for contributing to the stdlib

### DIFF
--- a/stdlib/HACKING.adoc
+++ b/stdlib/HACKING.adoc
@@ -3,10 +3,10 @@
 For guidelines about standard library content, see
 link:../CONTRIBUTING.md#contributing-to-the-standard-library[].
 
+Note: All paths are given relative to the root of the repository.
+
 First, build the compiler. Run `./configure`, then `make world.opt`. See
 link:../HACKING.adoc[].
-
-Note: All paths are given relative to the root of the repository.
 
 To add a new module, you must:
 
@@ -19,8 +19,10 @@ To add a new module, you must:
   aliases. Note that `otherlibs/threads/stdlib.mli` is a symbolic link to
   `stdlib/stdlib.mli`.
 
-* Add `$(P)module_name.cmo` to the definition of `OTHERS` in `stdlib/Makefile`
-  and `otherlibs/threads/Makefile`.
+* Add `$(P)module_name.cmo` to the definition of `OTHERS` in `stdlib/Makefile`.
+
+* Add `$(LIB)/$(P)module_name.cmo` to the definition of `LIB_OBJS` in
+  `otherlibs/threads/Makefile`.
 
 * Add `$(P)module_name` to the definition of `STDLIB_MODULES` in
   `stdlib/StdlibModules`. Please maintain the alphabetical order.
@@ -28,7 +30,7 @@ To add a new module, you must:
 * Run `make alldepend` to update all the `.depend` files. These files are not
   edited by hand.
 
-* Run `make clean`, then `make world.opt`.
+* Run `make clean` or `make partialclean`, then `make world.opt`.
 
 If you are adding multiple modules, follow the steps above and rebuild the
 compiler after adding each module. If you add multiple modules before

--- a/stdlib/HACKING.adoc
+++ b/stdlib/HACKING.adoc
@@ -1,28 +1,34 @@
-# Contributing to the standard library
+= Contributing to the standard library
 
 For guidelines about standard library content, see
-[CONTRIBUTING.md](../CONTRIBUTING.md#contributing-to-the-standard-library).
+link:../CONTRIBUTING.md#contributing-to-the-standard-library[CONTRIBUTING.md].
 
 First, build the compiler. Run `./configure`, then `make world.opt`. See
-[HACKING.adoc](../HACKING.adoc).
+link:../HACKING.adoc[HACKING.adoc].
 
 Note: All paths are given relative to the root of the repository.
 
 To add a new module, you must:
-- Create new `.mli` and `.ml` files for the modules, obviously.
-- Define the module in `stdlib/stdlib.mli`, `stdlib/stdlib.ml`, and
+
+* Create new `.mli` and `.ml` files for the modules, obviously.
+
+* Define the module in `stdlib/stdlib.mli`, `stdlib/stdlib.ml`, and
   `otherlibs/threads/stdlib.ml` in the section of the code commented,
   "MODULE ALIASES". Please maintain the same style as the rest of the code, in
   particular the alphabetical ordering and whitespace alignment of module
   aliases. Note that `otherlibs/threads/stdlib.mli` is a symbolic link to
   `stdlib/stdlib.mli`.
-- Add `$(P)module_name.cmo` to the definition of `OTHERS` in `stdlib/Makefile`
+
+* Add `$(P)module_name.cmo` to the definition of `OTHERS` in `stdlib/Makefile`
   and `otherlibs/threads/Makefile`.
-- Add `$(P)module_name` to the definition of `STDLIB_MODULES` in
+
+* Add `$(P)module_name` to the definition of `STDLIB_MODULES` in
   `stdlib/StdlibModules`. Please maintain the alphabetical order.
-- Run `make alldepend` to update all the `.depend` files. These files are not
+
+* Run `make alldepend` to update all the `.depend` files. These files are not
   edited by hand.
-- Run `make clean`, then `make world.opt`.
+
+* Run `make clean`, then `make world.opt`.
 
 If you are adding multiple modules, follow the steps above and rebuild the
 compiler after adding each module. If you add multiple modules before

--- a/stdlib/HACKING.adoc
+++ b/stdlib/HACKING.adoc
@@ -1,10 +1,10 @@
 = Contributing to the standard library
 
 For guidelines about standard library content, see
-link:../CONTRIBUTING.md#contributing-to-the-standard-library[CONTRIBUTING.md].
+link:../CONTRIBUTING.md#contributing-to-the-standard-library[].
 
 First, build the compiler. Run `./configure`, then `make world.opt`. See
-link:../HACKING.adoc[HACKING.adoc].
+link:../HACKING.adoc[].
 
 Note: All paths are given relative to the root of the repository.
 

--- a/stdlib/README.md
+++ b/stdlib/README.md
@@ -1,0 +1,29 @@
+# Contributing to the standard library
+
+For guidelines about standard library content, see
+[CONTRIBUTING.md](../CONTRIBUTING.md#contributing-to-the-standard-library).
+
+First, build the compiler. Run `./configure`, then `make world.opt`. See
+[HACKING.adoc](../HACKING.adoc).
+
+Note: All paths are given relative to the root of the repository.
+
+To add a new module, you must:
+- Create new `.mli` and `.ml` files for the modules, obviously.
+- Define the module in `stdlib/stdlib.mli`, `stdlib/stdlib.ml`, and
+  `otherlibs/threads/stdlib.ml` in the section of the code commented,
+  "MODULE ALIASES". Please maintain the same style as the rest of the code, in
+  particular the alphabetical ordering and whitespace alignment of module
+  aliases. Note that `otherlibs/threads/stdlib.mli` is a symbolic link to
+  `stdlib/stdlib.mli`.
+- Add `$(P)module_name.cmo` to the definition of `OTHERS` in `stdlib/Makefile`
+  and `otherlibs/threads/Makefile`.
+- Add `$(P)module_name` to the definition of `STDLIB_MODULES` in
+  `stdlib/StdlibModules`. Please maintain the alphabetical order.
+- Run `make alldepend` to update all the `.depend` files. These files are not
+  edited by hand.
+- Run `make clean`, then `make world.opt`.
+
+If you are adding multiple modules, follow the steps above and rebuild the
+compiler after adding each module. If you add multiple modules before
+rebuilding, the build may fail.


### PR DESCRIPTION
I would like to document the technical standard library contribution process so that future potential contributors don't need to read commits to figure out how to build the compiler with changes. These notes are based on my experience making the (rejected) pull request to add a monad interface to the standard library.

I tested out these instructions with a dummy module. I am aware that there is a `partialclean` target, but I used `clean` to be safe; perhaps I should see if the instructions also work with `partialclean`? Also note that the compiler built even though I had forgotten to update `otherlibs/threads/Makefile`, but I assume that the file *should* be updated since `otherlibs/threads` contains `stdlib.mli` and `stdlib.ml`.

Special thanks to @gasche and @Octachron for helping me build the compiler on discuss.ocaml.org.