### PR TITLE
API to retrieve high level process's PIDs

### DIFF
--- a/Changes
+++ b/Changes
@@ -55,6 +55,10 @@ Working version
   Unix.open_process{,_in,_out,_full}, but passing an explicit argv array.
   (Nicolás Ojeda Bär, review by Jérémie Dimino, request by Volker Diels-Grabsch)
 
+- GPR#1999: Add Unix.process{,_in,_out,_full}_pid to retrieve opened process's
+  pid.
+  (Romain Beauxis, review by Nicolás Ojeda Bär)
+
 - GPR#1182: Add new Printf formats %#d %#Ld %#ld %#nd (idem for %i and %u) for
   alternative integer formatting.
   (ygrek, review by Gabriel Scherer)

--- a/otherlibs/threads/unix.ml
+++ b/otherlibs/threads/unix.ml
@@ -1124,6 +1124,16 @@ let find_proc_id fun_name proc =
   with Not_found ->
     raise(Unix_error(EBADF, fun_name, ""))
 
+let process_in_pid inchan =
+  find_proc_id "process_in_pid" (Process_in inchan)
+let process_out_pid outchan =
+  find_proc_id "process_out_pid" (Process_out outchan)
+let process_pid (inchan, outchan) =
+  find_proc_id "process_pid" (Process(inchan, outchan))
+let process_full_pid (inchan, outchan, errchan) =
+  find_proc_id "process_full_pid"
+    (Process_full(inchan, outchan, errchan))
+
 let close_process_in inchan =
   let pid = find_proc_id "close_process_in" (Process_in inchan) in
   close_in inchan;

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -1114,6 +1114,16 @@ let find_proc_id fun_name proc =
   with Not_found ->
     raise(Unix_error(EBADF, fun_name, ""))
 
+let process_in_pid inchan =
+  find_proc_id "process_in_pid" (Process_in inchan)
+let process_out_pid outchan =
+  find_proc_id "process_out_pid" (Process_out outchan)
+let process_pid (inchan, outchan) =
+  find_proc_id "process_pid" (Process(inchan, outchan))
+let process_full_pid (inchan, outchan, errchan) =
+  find_proc_id "process_full_pid"
+    (Process_full(inchan, outchan, errchan))
+
 let close_process_in inchan =
   let pid = find_proc_id "close_process_in" (Process_in inchan) in
   close_in inchan;

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -843,6 +843,30 @@ val open_process_args_full :
 
     @since 4.08.0 *)
 
+val process_in_pid : in_channel -> int
+(** Return the pid of a process opened via {!Unix.open_process_in} or
+   {!Unix.open_process_args_in}.
+
+    @since 4.08.0 *)
+
+val process_out_pid : out_channel -> int
+(** Return the pid of a process opened via {!Unix.open_process_out} or
+   {!Unix.open_process_args_out}.
+
+    @since 4.08.0 *)
+
+val process_pid : in_channel * out_channel -> int
+(** Return the pid of a process opened via {!Unix.open_process} or
+   {!Unix.open_process_args}.
+
+    @since 4.08.0 *)
+
+val process_full_pid : in_channel * out_channel * in_channel -> int
+(** Return the pid of a process opened via {!Unix.open_process_full} or
+   {!Unix.open_process_args_full}.
+
+    @since 4.08.0 *)
+
 val close_process_in : in_channel -> process_status
 (** Close channels opened by {!Unix.open_process_in},
    wait for the associated command to terminate,

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -1006,6 +1006,16 @@ let find_proc_id fun_name proc =
   with Not_found ->
     raise(Unix_error(EBADF, fun_name, ""))
 
+let process_in_pid inchan =
+  find_proc_id "process_in_pid" (Process_in inchan)
+let process_out_pid outchan =
+  find_proc_id "process_out_pid" (Process_out outchan)
+let process_pid (inchan, outchan) =
+  find_proc_id "process_pid" (Process(inchan, outchan))
+let process_full_pid (inchan, outchan, errchan) =
+  find_proc_id "process_full_pid"
+    (Process_full(inchan, outchan, errchan))
+
 let close_process_in inchan =
   let pid = find_proc_id "close_process_in" (Process_in inchan) in
   close_in inchan;


### PR DESCRIPTION
This PR adds an API to retrieve the PID of processes opened with the high-level `open_process*` functions.

It is particularly useful in situations where a call to `close_process*` is stuck waiting for a faulty process. Typical use would be to spawn an asynchronous task and send `SIGTERM`/`SIGKILL` to that `pid` if the process is still running.

Additionally, it could be used to communicate with the child process with signals such as `SIGHUP` and etc.