### PR TITLE
ocamldoc: expand support for "include module type of"

### DIFF
--- a/Changes
+++ b/Changes
@@ -214,6 +214,9 @@ Working version
   deprecated Emacs APIs
   (Wilfred Hughes, review by Clément Pit-Claudel)
 
+- GPR#2000: ocamdoc, extended support for "include module type of ..."
+  (Florian Angeletti, review by Jérémie Dimino)
+
 ### Manual and documentation:
 
 - GPR#1788: move the quoted string description to the main chapters.

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -1222,8 +1222,14 @@ module Analyser =
               | Parsetree.Pmty_with (mt, _) ->
                   f mt.Parsetree.pmty_desc
               | Parsetree.Pmty_typeof mexpr ->
-                  begin match mexpr.Parsetree.pmod_desc with
-                    Parsetree.Pmod_ident longident -> Name.from_longident longident.txt
+                  let open Parsetree in
+                  begin match mexpr.pmod_desc with
+                    Pmod_ident longident -> Name.from_longident longident.txt
+                  | Pmod_structure [
+                      {pstr_desc=Pstr_include
+                           {pincl_mod={pmod_desc=Pmod_ident longident}}
+                      }] -> (* include module type of struct include M end*)
+                      Name.from_longident longident.txt
                   | _ -> "??"
                   end
               | Parsetree.Pmty_extension _ -> assert false

--- a/testsuite/tests/tool-ocamldoc/Include_module_type_of.html.reference
+++ b/testsuite/tests/tool-ocamldoc/Include_module_type_of.html.reference
@@ -1,0 +1,29 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<link rel="stylesheet" href="style.css" type="text/css">
+<meta content="text/html; charset=iso-8859-1" http-equiv="Content-Type">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="Start" href="index.html">
+<link rel="Up" href="index.html">
+<link title="Index of types" rel=Appendix href="index_types.html">
+<link title="Index of modules" rel=Appendix href="index_modules.html">
+<link title="Include_module_type_of" rel="Chapter" href="Include_module_type_of.html"><title>Include_module_type_of</title>
+</head>
+<body>
+<div class="navbar">&nbsp;<a class="up" href="index.html" title="Index">Up</a>
+&nbsp;</div>
+<h1>Module <a href="type_Include_module_type_of.html">Include_module_type_of</a></h1>
+
+<pre><span id="MODULEInclude_module_type_of"><span class="keyword">module</span> Include_module_type_of</span>: <code class="code"><span class="keyword">sig</span></code> <a href="Include_module_type_of.html">..</a> <code class="code"><span class="keyword">end</span></code></pre><div class="info module top">
+<div class="info-desc">
+<p>Test <code class="code"><span class="keyword">include</span>&nbsp;<span class="keyword">module</span>&nbsp;<span class="keyword">type</span>&nbsp;<span class="keyword">of</span>...</code> variants</p>
+</div>
+</div>
+<hr width="100%">
+
+<pre><span id="MODULEA"><span class="keyword">module</span> <a href="Include_module_type_of.A.html">A</a></span>: <code class="code"><span class="keyword">sig</span></code> <a href="Include_module_type_of.A.html">..</a> <code class="code"><span class="keyword">end</span></code></pre>
+<pre><span id="MODULEM"><span class="keyword">module</span> <a href="Include_module_type_of.M.html">M</a></span>: <code class="code"><span class="keyword">sig</span></code> <a href="Include_module_type_of.M.html">..</a> <code class="code"><span class="keyword">end</span></code></pre>
+<pre><span id="MODULEB"><span class="keyword">module</span> <a href="Include_module_type_of.B.html">B</a></span>: <code class="code"><span class="keyword">sig</span></code> <a href="Include_module_type_of.B.html">..</a> <code class="code"><span class="keyword">end</span></code></pre>
+<pre><span class="keyword">include</span> <a href="Include_module_type_of.M.html">Include_module_type_of.M</a></pre>
+</body></html>

--- a/testsuite/tests/tool-ocamldoc/Include_module_type_of.latex.reference
+++ b/testsuite/tests/tool-ocamldoc/Include_module_type_of.latex.reference
@@ -1,0 +1,96 @@
+\documentclass[11pt]{article} 
+\usepackage[latin1]{inputenc} 
+\usepackage[T1]{fontenc} 
+\usepackage{textcomp}
+\usepackage{fullpage} 
+\usepackage{url} 
+\usepackage{ocamldoc}
+\begin{document}
+\tableofcontents
+\section{Module {\tt{Include\_module\_type\_of}} : Test {\tt{include module type of...}} variants}
+\label{Include-underscoremodule-underscoretype-underscoreof}\index{Include-underscoremodule-underscoretype-underscoreof@\verb`Include_module_type_of`}
+
+
+
+
+\ocamldocvspace{0.5cm}
+
+
+
+\begin{ocamldoccode}
+{\tt{module }}{\tt{A}}{\tt{ : }}\end{ocamldoccode}
+\label{Include-underscoremodule-underscoretype-underscoreof.A}\index{A@\verb`A`}
+
+\begin{ocamldocsigend}
+
+
+\label{TYPInclude-underscoremodule-underscoretype-underscoreof.A.t}\begin{ocamldoccode}
+type t 
+\end{ocamldoccode}
+\index{t@\verb`t`}
+\end{ocamldocsigend}
+
+
+
+
+
+
+\begin{ocamldoccode}
+{\tt{module }}{\tt{M}}{\tt{ : }}\end{ocamldoccode}
+\label{Include-underscoremodule-underscoretype-underscoreof.M}\index{M@\verb`M`}
+
+\begin{ocamldocsigend}
+
+
+A module M
+
+\begin{ocamldoccode}
+{\tt{module }}{\tt{Inner}}{\tt{ : }}\end{ocamldoccode}
+\label{Include-underscoremodule-underscoretype-underscoreof.M.Inner}\index{Inner@\verb`Inner`}
+\begin{ocamldocsigend}
+
+
+\label{TYPInclude-underscoremodule-underscoretype-underscoreof.M.Inner.t}\begin{ocamldoccode}
+type t 
+\end{ocamldoccode}
+\index{t@\verb`t`}
+\end{ocamldocsigend}
+
+
+
+
+\begin{ocamldoccode}
+{\tt{module }}{\tt{Alias}}{\tt{ : }}\end{ocamldoccode}
+\label{Include-underscoremodule-underscoretype-underscoreof.M.Alias}\index{Alias@\verb`Alias`}
+{\tt{Include\_module\_type\_of.A}}
+
+
+
+\label{TYPInclude-underscoremodule-underscoretype-underscoreof.M.t}\begin{ocamldoccode}
+type t 
+\end{ocamldoccode}
+\index{t@\verb`t`}
+\end{ocamldocsigend}
+
+
+
+
+
+
+\begin{ocamldoccode}
+{\tt{module }}{\tt{B}}{\tt{ : }}\end{ocamldoccode}
+\label{Include-underscoremodule-underscoretype-underscoreof.B}\index{B@\verb`B`}
+
+\begin{ocamldocsigend}
+
+
+{\tt{include }}{\tt{Include\_module\_type\_of.M}}\end{ocamldocsigend}
+
+
+
+
+
+
+{\tt{include }}{\tt{Include\_module\_type\_of.M}}
+
+\end{document}

--- a/testsuite/tests/tool-ocamldoc/Include_module_type_of.mli
+++ b/testsuite/tests/tool-ocamldoc/Include_module_type_of.mli
@@ -1,0 +1,21 @@
+(* TEST
+   * ocamldoc with html
+   * ocamldoc with latex
+*)
+
+(** Test [include module type of...] variants *)
+
+module A: sig type t end
+module M: sig
+  (** A module M *)
+
+  module Inner: sig type t end
+  module Alias = A
+  type t
+end
+
+module B: sig
+  include module type of M
+end
+
+include module type of struct include M end

--- a/testsuite/tests/tool-ocamldoc/ocamltests
+++ b/testsuite/tests/tool-ocamldoc/ocamltests
@@ -1,5 +1,6 @@
 Documentation_tags.mli
 Extensible_variant.ml
+Include_module_type_of.mli
 Inline_records.mli
 Inline_records_bis.ml
 Item_ids.mli


### PR DESCRIPTION
This PR extends the adhoc support in ocamldoc for
```OCaml
include module type of M
```
to also include the expanded version
```OCaml
include module type of struct include M end
```
See #1605 for an use case.