### PR TITLE
Fix MPR#7838

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,6 +23,9 @@ OCaml 4.07 maintenance branch
 - MPR#7833, GPR#1946: typecore: only 1k existential per match, not 100k
   (Thomas Refis, report by Jerome Simeon, review by Jacques Garrigue)
 
+- MPR#7838: -principal causes assertion failure in type checker
+  (Jacques Garrigue, report by Markus Mottl, review by Thomas Refis)
+
 OCaml 4.07.0 (10 July 2018)
 ---------------------------
 

--- a/testsuite/tests/typing-misc/variant.ml
+++ b/testsuite/tests/typing-misc/variant.ml
@@ -26,3 +26,19 @@ Error: Signature mismatch:
        is not included in
          type t = int * bool
 |}];;
+
+
+(* PR#7838 *)
+
+module Make (X : sig val f : [ `A ] -> unit end) = struct
+ let make f1 f2 arg = match arg with `A -> f1 arg; f2 arg
+ let f = make X.f (fun _ -> ())
+end;;
+[%%expect{|
+module Make :
+  functor (X : sig val f : [ `A ] -> unit end) ->
+    sig
+      val make : (([< `A ] as 'a) -> 'b) -> ('a -> 'c) -> 'a -> 'c
+      val f : [ `A ] -> unit
+    end
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1027,8 +1027,7 @@ let rec copy ?partial ?keep_names ty =
                 match more.desc with
                   Tsubst ty -> ty
                 | Tconstr _ | Tnil ->
-                    if more.level <> generic_level then
-                      save_desc more more.desc;
+                    save_desc more more.desc;
                     copy more
                 | Tvar _ | Tunivar _ ->
                     save_desc more more.desc;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1027,7 +1027,8 @@ let rec copy ?partial ?keep_names ty =
                 match more.desc with
                   Tsubst ty -> ty
                 | Tconstr _ | Tnil ->
-                    if keep then save_desc more more.desc;
+                    if more.level <> generic_level then
+                      save_desc more more.desc;
                     copy more
                 | Tvar _ | Tunivar _ ->
                     save_desc more more.desc;


### PR DESCRIPTION
This fixes [MPR#7838](https://caml.inria.fr/mantis/view.php?id=7838) by ensuring that `save_desc` is called in  the `Tvariant` case of `Ctype.copy` even when `partial <> None`.

@trefis provided the correct analysis.