### PR TITLE
Format.pp_print_custom_break, a more general break hint

### DIFF
--- a/Changes
+++ b/Changes
@@ -180,6 +180,10 @@ Working version
 - GPR#1936: Add module Float.Array
   (Damien Doligez, review by Xavier Clerc and Alain Frisch)
 
+- GPR#2002: Add Format.pp_print_custom_break, a new more general kind of break
+  hint that can emit non-whitespace characters.
+  (Vladimir Keleshev and Pierre Weis, review by Josh Berdine, Gabriel Radanne)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -288,6 +288,48 @@ val print_break : int -> int -> unit
   the current indentation.
 *)
 
+val pp_print_custom_break :
+  formatter ->
+  fits:(string * int * string) ->
+  breaks:(string * int * string) ->
+  unit
+(** [pp_print_custom_break ppf ~fits:(s1, n, s2) ~breaks:(s3, m, s4)] emits a
+   custom break hint: the pretty-printer may split the line at this point.
+
+   If it does not split the line, then the [s1] is emitted, then [n] spaces,
+   then [s2].
+
+   If it splits the line, then it emits the [s3] string, then an indent
+   (according to the box rules), then an offset of [m] spaces, then the [s4]
+   string.
+
+   While [n] and [m] are handled by [formatter_out_functions.out_indent], the
+   strings will be handled by [formatter_out_functions.out_string]. This allows
+   for a custom formatter that handles indentation distinctly, for example,
+   outputs [<br/>] tags or [&nbsp;] entities.
+
+   The custom break is useful if you want to change which visible
+   (non-whitespace) characters are printed in case of break or no break. For
+   example, when printing a list {[ [a; b; c] ]}, you might want to add a
+   trailing semicolon when it is printed vertically:
+
+   {[
+[
+  a;
+  b;
+  c;
+]
+   ]}
+
+   You can do this as follows:
+   {[
+printf "@[<v 0>[@;<0 2>@[<v 0>a;@,b;@,c@]%t]@]@\n"
+  (pp_print_custom_break ~fits:("", 0, "") ~breaks:(";", 0, ""))
+   ]}
+
+  @since 4.08.0
+*)
+
 val pp_force_newline : formatter -> unit -> unit
 val force_newline : unit -> unit
 (** Force a new line in the current pretty-printing box.

--- a/testsuite/tests/lib-format/ocamltests
+++ b/testsuite/tests/lib-format/ocamltests
@@ -1,3 +1,4 @@
 pr6824.ml
 tformat.ml
 print_if_newline.ml
+pp_print_custom_break.ml

--- a/testsuite/tests/lib-format/pp_print_custom_break.ml
+++ b/testsuite/tests/lib-format/pp_print_custom_break.ml
@@ -1,0 +1,64 @@
+(* TEST *)
+
+(*
+
+A test file for Format.pp_print_custom_break.
+
+*)
+let fprintf, printf, list = Format.(fprintf, printf, pp_print_list)
+let string, custom_break = Format.(pp_print_string, pp_print_custom_break)
+
+let () = Format.set_margin 30
+
+let example = [
+  "Foo"; "Baz"; "Bar"; "Qux"; "Quux"; "Quuz"; "Corge"; "Grault"; "Garply";
+]
+
+let boxes = ["v"; "b"; "h"; "hv"; "hov"]
+
+let test format data =
+  boxes |> List.iter (fun box ->
+    printf "## The %S box@\n```@\n@[<%s 0>%a@]@\n```@\n@\n" box box
+      (format box) data);
+
+module Format_list = struct
+  let pp_sep ppf () = fprintf ppf ";@ "
+
+  let format box_type ppf items =
+    fprintf ppf "[@;<0 2>@[<%s>%a@]%t]" box_type
+      (list ~pp_sep string) items
+      (custom_break ~fits:("", 0, "") ~breaks:(";", 0, ""))
+
+  let () =
+    printf "# Printing arrays: last trailing semicolon is optional@\n@\n";
+    test format example
+end
+
+
+module Format_statements = struct
+  let pp_sep ppf () =
+    custom_break ppf ~fits:(";", 1, "") ~breaks:("", 0, "")
+
+  let rec format box_type ppf items =
+    fprintf ppf "{@;<0 2>@[<%s>%a@]@,}" box_type
+      (list ~pp_sep string) items
+
+  let () =
+    printf "# Printing statements: terminator is optional after newline@\n@\n";
+    test format example
+end
+
+
+module Format_function = struct
+  let pp_sep ppf () = fprintf ppf "@ | "
+  let format_case ppf = fprintf ppf "%s -> ()"
+
+  let rec format box_type ppf items =
+    fprintf ppf "@[<%s>function%t%a@]" box_type
+      (custom_break ~fits:("", 1, "") ~breaks:("", 0, "| "))
+      (list ~pp_sep format_case) items
+
+  let () =
+    printf "# Printing function: first pipe character is optional@\n@\n";
+    test format example
+end

--- a/testsuite/tests/lib-format/pp_print_custom_break.reference
+++ b/testsuite/tests/lib-format/pp_print_custom_break.reference
@@ -1,0 +1,159 @@
+# Printing arrays: last trailing semicolon is optional
+
+## The "v" box
+```
+[
+  Foo;
+  Baz;
+  Bar;
+  Qux;
+  Quux;
+  Quuz;
+  Corge;
+  Grault;
+  Garply;
+]
+```
+
+## The "b" box
+```
+[
+  Foo; Baz; Bar; Qux; Quux;
+  Quuz; Corge; Grault; Garply;
+]
+```
+
+## The "h" box
+```
+[Foo; Baz; Bar; Qux; Quux; Quuz; Corge; Grault; Garply]
+```
+
+## The "hv" box
+```
+[
+  Foo;
+  Baz;
+  Bar;
+  Qux;
+  Quux;
+  Quuz;
+  Corge;
+  Grault;
+  Garply;
+]
+```
+
+## The "hov" box
+```
+[
+  Foo; Baz; Bar; Qux; Quux;
+  Quuz; Corge; Grault; Garply;
+]
+```
+
+# Printing statements: terminator is optional after newline
+
+## The "v" box
+```
+{
+  Foo
+  Baz
+  Bar
+  Qux
+  Quux
+  Quuz
+  Corge
+  Grault
+  Garply
+}
+```
+
+## The "b" box
+```
+{
+  Foo; Baz; Bar; Qux; Quux
+  Quuz; Corge; Grault; Garply
+}
+```
+
+## The "h" box
+```
+{Foo; Baz; Bar; Qux; Quux; Quuz; Corge; Grault; Garply}
+```
+
+## The "hv" box
+```
+{
+  Foo
+  Baz
+  Bar
+  Qux
+  Quux
+  Quuz
+  Corge
+  Grault
+  Garply
+}
+```
+
+## The "hov" box
+```
+{
+  Foo; Baz; Bar; Qux; Quux
+  Quuz; Corge; Grault; Garply
+}
+```
+
+# Printing function: first pipe character is optional
+
+## The "v" box
+```
+function
+| Foo -> ()
+| Baz -> ()
+| Bar -> ()
+| Qux -> ()
+| Quux -> ()
+| Quuz -> ()
+| Corge -> ()
+| Grault -> ()
+| Garply -> ()
+```
+
+## The "b" box
+```
+function Foo -> ()
+| Baz -> () | Bar -> ()
+| Qux -> () | Quux -> ()
+| Quuz -> () | Corge -> ()
+| Grault -> () | Garply -> ()
+```
+
+## The "h" box
+```
+function Foo -> () | Baz -> () | Bar -> () | Qux -> () | Quux -> () | Quuz -> () | Corge -> () | Grault -> () | Garply -> ()
+```
+
+## The "hv" box
+```
+function
+| Foo -> ()
+| Baz -> ()
+| Bar -> ()
+| Qux -> ()
+| Quux -> ()
+| Quuz -> ()
+| Corge -> ()
+| Grault -> ()
+| Garply -> ()
+```
+
+## The "hov" box
+```
+function Foo -> ()
+| Baz -> () | Bar -> ()
+| Qux -> () | Quux -> ()
+| Quuz -> () | Corge -> ()
+| Grault -> () | Garply -> ()
+```
+


### PR DESCRIPTION
`Format.pp_print_custom_break` is a more general break hint that can emit non-whitespace characters, for example, an additional trailing semicolon when a list of items is printed vertically.

# Motivation

Sometimes when formatting code or data structures you might want to print different non-whitespace characters depending on the layout being horizontal or vertical. For example, you might want to add a trailing semicolon when printing an OCaml list vertically:

```ocaml
(* Horizontal *)
[foo; baz; bar]

(* Vertical *)
[
  foo;
  bar;
  baz; (* Note the additional semicolon *)
]
```

Another example use-case is when a separator in a language is optional. For example, in many languages semicolons are optional for separating statements if each statement is located on a separate line. So you might want to remove semicolons when printing a bunch of statements vertically:

```
# Horizontal
{foo; baz; bar}

# Vertical
{
  foo
  baz
  bar
}
```

Both examples can be implemented using the new `Format.pp_print_custom_break`. See the added test file for the implementations.

# Implementation notes

The new break hint is implemented by introducing a new pretty-printing token `Pp_custom_break`. It is handled similarly to the existing `Pp_break`, with some modifications. If desirable, the `Pp_break` can be removed and `pp_print_break` can be re-implemented in terms of `Pp_custom_break`.