### PR TITLE
printtyp: enforce calls to wrap_printing_env

### DIFF
--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -48,7 +48,7 @@ let prim_fresh_oo_id =
 
 let transl_extension_constructor env path ext =
   let path =
-    Printtyp.wrap_printing_env env ~error:true (fun () ->
+    Printtyp.wrap_printing_env env ~error:true (fun (module Printtyp) ->
       Stdlib.Option.map (Printtyp.rewrite_double_underscore_paths env) path)
   in
   let name =

--- a/debugger/eval.ml
+++ b/debugger/eval.ml
@@ -165,7 +165,7 @@ and find_label lbl env ty path tydesc pos = function
 
 open Format
 
-let report_error ppf = function
+let report_error (module Printtyp:Printtyp.S) ppf = function
   | Unbound_identifier id ->
       fprintf ppf "@[Unbound identifier %s@]@." (Ident.name id)
   | Not_initialized_yet path ->
@@ -209,3 +209,7 @@ let report_error ppf = function
         "@[The type@ %a@ is not a record type@]@." Printtyp.type_expr ty
   | No_result ->
       fprintf ppf "@[No result available at current program event@]@."
+
+let report_error ppf x =
+  Printtyp.wrap_printing_env ~error:true Env.empty
+  @@ fun p -> report_error p ppf x

--- a/debugger/printval.ml
+++ b/debugger/printval.ml
@@ -102,6 +102,8 @@ let print_named_value max_depth exp env obj ppf ty =
   | _ ->
       let n = name_value obj ty in
       fprintf ppf "$%i" n in
+  Printtyp.wrap_printing_env ~error:false env @@
+  fun (module Printtyp) ->
   Printtyp.reset_and_mark_loops ty;
   fprintf ppf "@[<2>%a:@ %a@ =@ %a@]@."
   print_value_name exp

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -55,7 +55,8 @@ let typecheck_intf info ast =
   in
   let sg = tsg.Typedtree.sig_type in
   if !Clflags.print_types then
-    Printtyp.wrap_printing_env ~error:false info.env (fun () ->
+    Printtyp.wrap_printing_env ~error:false info.env
+      (fun (module Printtyp:Printtyp.S) ->
         Format.(fprintf std_formatter) "%a@."
           (Printtyp.printed_signature info.sourcefile)
           sg);

--- a/ocamldoc/odoc_print.ml
+++ b/ocamldoc/odoc_print.ml
@@ -39,6 +39,8 @@ let (modtype_fmt, flush_modtype_fmt) = new_fmt ()
 
 
 let string_of_type_expr t =
+  Printtyp.wrap_printing_env Env.empty ~error:false
+  @@ fun (module Printtyp) ->
   Printtyp.mark_loops t;
   Printtyp.type_scheme_max ~b_reset_names: false type_fmt t;
   flush_type_fmt ()
@@ -69,6 +71,8 @@ let simpl_module_type ?code t =
 
 let string_of_module_type ?code ?(complete=false) t =
   try
+    Printtyp.wrap_printing_env Env.empty ~error:false
+    @@ fun (module Printtyp) ->
     let t2 = if complete then t else simpl_module_type ?code t in
     Printtyp.modtype modtype_fmt t2;
     flush_modtype_fmt ()
@@ -101,6 +105,8 @@ let simpl_class_type t =
   iter t
 
 let string_of_class_type ?(complete=false) t =
+  Printtyp.wrap_printing_env Env.empty ~error:false
+  @@ fun (module Printtyp) ->
   let t2 = if complete then t else simpl_class_type t in
   (* FIXME : my own Printtyp.class_type variant to avoid reset_names *)
   Printtyp.class_type modtype_fmt t2;

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -51,6 +51,8 @@ let raw_string_of_type_list sep type_list =
     | Types.Tfield _ | Types.Tnil | Types.Tvariant _ | Types.Tpackage _ -> false
   in
   let print_one_type variance t =
+      Printtyp.wrap_printing_env Env.empty ~error:false
+      @@ fun (module Printtyp) ->
     Printtyp.mark_loops t;
     if need_parent t then
       (

--- a/toplevel/opttoploop.ml
+++ b/toplevel/opttoploop.ml
@@ -329,18 +329,19 @@ let execute_phrase print_outcome ppf phr =
               else
                 Compilenv.record_global_approx_toplevel ();
               if print_outcome then
-                Printtyp.wrap_printing_env ~error:false oldenv (fun () ->
+                Printtyp.wrap_printing_env ~error:false oldenv
+                  (fun  (module Printtyp:Printtyp.S) ->
                 match str.str_items with
                 | [] -> Ophr_signature []
                 | _ ->
                     if rewritten then
                       match sg' with
                       | [ Sig_value (id, vd) ] ->
+                          let ty = Printtyp.tree_of_type_scheme vd.val_type in
                           let outv =
                             outval_of_value newenv (toplevel_value id)
                               vd.val_type
                           in
-                          let ty = Printtyp.tree_of_type_scheme vd.val_type in
                           Ophr_eval (outv, ty)
                       | _ -> assert false
                     else

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -407,6 +407,8 @@ let tracing_function_ptr =
 
 let dir_trace ppf lid =
   try
+    Printtyp.wrap_printing_env !toplevel_env ~error:true @@
+    fun (module Printtyp:Printtyp.S) ->
     let (path, desc) = Env.lookup_value lid !toplevel_env in
     (* Check if this is a primitive *)
     match desc.val_kind with
@@ -461,6 +463,8 @@ let dir_untrace ppf lid =
   | Not_found -> fprintf ppf "Unbound value %a.@." Printtyp.longident lid
 
 let dir_untrace_all ppf () =
+  Printtyp.wrap_printing_env !toplevel_env ~error:true @@
+  fun (module Printtyp:Printtyp.S) ->
   List.iter
     (fun f ->
       set_code_pointer f.closure f.actual_code;
@@ -509,7 +513,7 @@ let show_prim to_sig ppf lid =
     let id = Ident.create_persistent s in
     let sg = to_sig env loc id lid in
     Printtyp.wrap_printing_env ~error:false env
-      (fun () -> fprintf ppf "@[%a@]@." Printtyp.signature sg)
+      (fun (module Printtyp) -> fprintf ppf "@[%a@]@." Printtyp.signature sg)
   with
   | Not_found ->
       fprintf ppf "@[Unknown element.@]@."

--- a/toplevel/toploop.ml
+++ b/toplevel/toploop.ml
@@ -255,7 +255,8 @@ let execute_phrase print_outcome ppf phr =
           match res with
           | Result v ->
               if print_outcome then
-                Printtyp.wrap_printing_env ~error:false oldenv (fun () ->
+                Printtyp.wrap_printing_env ~error:false oldenv
+                  (fun (module Printtyp) ->
                   match str.str_items with
                   | [ { str_desc =
                           (Tstr_eval (exp, _)
@@ -268,8 +269,8 @@ let execute_phrase print_outcome ppf phr =
                           )
                       }
                     ] ->
-                      let outv = outval_of_value newenv v exp.exp_type in
                       let ty = Printtyp.tree_of_type_scheme exp.exp_type in
+                      let outv = outval_of_value newenv v exp.exp_type in
                       Ophr_eval (outv, ty)
 
                   | [] -> Ophr_signature []

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -95,4 +95,7 @@ open Format
 
 let report_error ppf = function
   | Module_not_found p ->
-      fprintf ppf "@[Cannot find module %a@].@." Printtyp.path p
+      Printtyp.wrap_printing_env Env.empty ~error:true @@
+      fun (module Printtyp:Printtyp.S) ->
+      fprintf ppf "@[Cannot find module %a@].@."
+        Printtyp.path p

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -63,7 +63,8 @@ let include_err ppf =
         (function ppf ->
           fprintf ppf "but is expected to have type")
   | CM_Class_type_mismatch (env, cty1, cty2) ->
-      Printtyp.wrap_printing_env ~error:true env (fun () ->
+      Printtyp.wrap_printing_env ~error:true env
+        (fun (module Printtyp) ->
         fprintf ppf
           "@[The class type@;<1 2>%a@ %s@;<1 2>%a@]"
           Printtyp.class_type cty1

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -202,30 +202,30 @@ let rec print_list pr ppf = function
 let print_list pr ppf l =
   Format.fprintf ppf "[@[%a@]]" (print_list pr) l
 
-let rec print_coercion ppf c =
+let rec print_coercion ((module Printtyp:Printtyp.S) as m) ppf c =
   let pr fmt = Format.fprintf ppf fmt in
   match c with
     Tcoerce_none -> pr "id"
   | Tcoerce_structure (fl, nl) ->
       pr "@[<2>struct@ %a@ %a@]"
-        (print_list print_coercion2) fl
-        (print_list print_coercion3) nl
+        (print_list @@ print_coercion2 m) fl
+        (print_list @@ print_coercion3 m) nl
   | Tcoerce_functor (inp, out) ->
       pr "@[<2>functor@ (%a)@ (%a)@]"
-        print_coercion inp
-        print_coercion out
+        (print_coercion m) inp
+        (print_coercion m) out
   | Tcoerce_primitive {pc_desc; pc_env = _; pc_type}  ->
       pr "prim %s@ (%a)" pc_desc.Primitive.prim_name
         Printtyp.raw_type_expr pc_type
   | Tcoerce_alias (p, c) ->
       pr "@[<2>alias %a@ (%a)@]"
         Printtyp.path p
-        print_coercion c
-and print_coercion2 ppf (n, c) =
-  Format.fprintf ppf "@[%d,@ %a@]" n print_coercion c
-and print_coercion3 ppf (i, n, c) =
+        (print_coercion m) c
+and print_coercion2 m ppf (n, c) =
+  Format.fprintf ppf "@[%d,@ %a@]" n (print_coercion m) c
+and print_coercion3 m ppf (i, n, c) =
   Format.fprintf ppf "@[%s, %d,@ %a@]"
-    (Ident.unique_name i) n print_coercion c
+    (Ident.unique_name i) n (print_coercion m) c
 
 (* Simplify a structure coercion *)
 
@@ -515,6 +515,10 @@ and check_modtype_equiv ~loc env ~mark cxt mty1 mty2 =
         print_coercion _c1 print_coercion _c2; *)
       raise(Error [cxt, env, Modtype_permutation])
 
+let print_coercion ppf x =
+  Printtyp.wrap_printing_env Env.empty ~error:false
+    (fun p -> print_coercion p ppf x)
+
 (* Simplified inclusion check between module types (for Env) *)
 
 let can_alias env path =
@@ -577,7 +581,7 @@ let show_locs ppf (loc1, loc2) =
   show_loc "Expected declaration" ppf loc2;
   show_loc "Actual declaration" ppf loc1
 
-let include_err ppf = function
+let include_err (module Printtyp:Printtyp.S) ppf = function
   | Missing_field (id, loc, kind) ->
       fprintf ppf "The %s `%a' is required but not provided"
         kind Printtyp.ident id;
@@ -686,7 +690,7 @@ let path_of_context = function
       in subm (Path.Pident id) rem
   | _ -> assert false
 
-let context ppf cxt =
+let context (module Printtyp:Printtyp.S) ppf cxt =
   if cxt = [] then () else
   if List.for_all (function Module _ -> true | _ -> false) cxt then
     fprintf ppf "In module %a:@ " Printtyp.path (path_of_context cxt)
@@ -694,8 +698,9 @@ let context ppf cxt =
     fprintf ppf "@[<hv 2>At position@ %a@]@ " context cxt
 
 let include_err ppf (cxt, env, err) =
-  Printtyp.wrap_printing_env ~error:true env (fun () ->
-    fprintf ppf "@[<v>%a%a@]" context (List.rev cxt) include_err err)
+  Printtyp.wrap_printing_env ~error:true env (fun pr ->
+      fprintf ppf "@[<v>%a%a@]" (context pr) (List.rev cxt)
+        (include_err pr) err)
 
 let buffer = ref Bytes.empty
 let is_big obj =

--- a/typing/stypes.ml
+++ b/typing/stypes.ml
@@ -157,10 +157,11 @@ let print_info pp prev_loc ti =
       end;
       output_string pp "type(\n";
       printtyp_reset_maybe loc;
-      Printtyp.mark_loops typ;
       Format.pp_print_string Format.str_formatter "  ";
       Printtyp.wrap_printing_env ~error:false env
-                       (fun () -> Printtyp.type_sch Format.str_formatter typ);
+        (fun (module Printtyp) ->
+           Printtyp.mark_loops typ;
+           Printtyp.type_sch Format.str_formatter typ);
       Format.pp_print_newline Format.str_formatter ();
       let s = Format.flush_str_formatter () in
       output_string pp s;

--- a/typing/typeclass.mli
+++ b/typing/typeclass.mli
@@ -89,6 +89,10 @@ val type_classes :
            list * Env.t
 *)
 
+type unbound =
+  | Unbound_class of Ident.t * class_declaration
+  | Unbound_cltype of Ident.t * class_type_declaration
+
 type error =
     Unconsistent_constraint of (type_expr * type_expr) list
   | Field_type_mismatch of string * string * (type_expr * type_expr) list
@@ -107,7 +111,7 @@ type error =
   | Bad_parameters of Ident.t * type_expr * type_expr
   | Class_match_failure of Ctype.class_match_failure list
   | Unbound_val of string
-  | Unbound_type_var of (formatter -> unit) * Ctype.closed_class_failure
+  | Unbound_type_var of unbound * Ctype.closed_class_failure
   | Non_generalizable_class of Ident.t * Types.class_declaration
   | Cannot_coerce_self of type_expr
   | Non_collapsable_conjunction of

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -734,8 +734,8 @@ end) = struct
     match tpaths with
       [_] -> []
     | _ -> let open Printtyp in
-        wrap_printing_env ~error:true env (fun () ->
-            reset(); strings_of_paths Type tpaths)
+        wrap_printing_env ~error:true env ( fun (module P) ->
+            reset(); P.strings_of_paths Type tpaths)
 
   let disambiguate_by_type env tpath lbls =
     let check_type (lbl, _) =
@@ -795,7 +795,7 @@ end) = struct
           begin
           let s =
             Printtyp.wrap_printing_env ~error:true env
-              (fun () -> Printtyp.string_of_path tpath) in
+              (fun (module Printtyp) -> Printtyp.string_of_path tpath) in
           warn lid.loc
             (Warnings.Name_out_of_scope (s, [Longident.last lid.txt], false));
           end;
@@ -4548,7 +4548,9 @@ let report_type_expected_explanation_opt expl ppf =
       fprintf ppf "@ because it is in %t"
         (report_type_expected_explanation expl)
 
-let report_error env ppf = function
+let report_error (module P: Printtyp.S) env ppf =
+  let open P in
+  function
   | Constructor_arity_mismatch(lid, expected, provided) ->
       fprintf ppf
        "@[The constructor %a@ expects %i argument(s),@ \
@@ -4834,7 +4836,7 @@ let report_error env ppf = function
   | Empty_pattern -> assert false
 
 let report_error env ppf err =
-  wrap_printing_env ~error:true env (fun () -> report_error env ppf err)
+  wrap_printing_env ~error:true env (fun p -> report_error p env ppf err)
 
 let () =
   Location.register_error_of_exn

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2092,7 +2092,7 @@ let type_implementation sourcefile outputprefix modulename initial_env ast =
       if !Clflags.print_types then begin
         Typecore.force_delayed_checks ();
         Printtyp.wrap_printing_env ~error:false initial_env
-          (fun () -> fprintf std_formatter "%a@."
+          (fun (module Printtyp) -> fprintf std_formatter "%a@."
               (Printtyp.printed_signature sourcefile) simple_sg
           );
         (str, Tcoerce_none)   (* result is ignored by Compile.implementation *)
@@ -2229,9 +2229,9 @@ let package_units initial_env objfiles cmifile modulename =
 
 (* Error report *)
 
-open Printtyp
-
-let report_error ppf = function
+let report_error (module Printtyp: Printtyp.S) ppf =
+  let open Printtyp in
+  function
     Cannot_apply mty ->
       fprintf ppf
         "@[This module is not a functor; it has type@ %a@]" modtype mty
@@ -2347,7 +2347,7 @@ let report_error ppf = function
         Ident.print shadowed_item_id
 
 let report_error env ppf err =
-  Printtyp.wrap_printing_env ~error:true env (fun () -> report_error ppf err)
+  Printtyp.wrap_printing_env ~error:true env (fun p -> report_error p ppf err)
 
 let () =
   Location.register_error_of_exn


### PR DESCRIPTION
This PR is the heavy-handed sibling of #1975: it enforces the use of `Printtyp.wrap_printing_env` before any call to `Printtyp` functions that rely on the printing environment by hiding those functions in the interface file and only giving them back after a call to `Printtyp.wrap_printing_env`.

If the first-class module approach is too heavy, I can see two alternatives. I could either
use an abstract token to unlock function by function rather than a first-class module (the initial version of this PR was made to quickly check that #1975 covered all paths ) . Or, I could alter the `printtyp` functions to handle more gracefully failures to set the printing env. In particular, we could make sure to avoid any environment lookups in this case; and still integrate the missing calls to `Printtyp.wrap_printing_env` unearthed in #1975 and this PR.