### PR TITLE
Windows: Use common path for standard library

### DIFF
--- a/Changes
+++ b/Changes
@@ -94,6 +94,10 @@ Working version
   is no longer needed and Stdlib should be used instead.
   (Jérémie Dimino, review by Nicolás Ojeda Bär)
 
+- GPR#2004: Use common standard library path `lib/ocaml` for Windows,
+  for consistency with OSX & Linux. Previously was located at `lib`.
+  (Bryan Phelps, Jordan Walke, review by David Allsopp)
+
 ### Other libraries:
 
 - GPR#1061: Add ?follow parameter to Unix.link. This allows hardlinking

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -32,7 +32,7 @@ BINDIR=$(PREFIX)/bin
 BYTERUN=ocamlrun
 
 ### Where to install the standard library
-LIBDIR=$(PREFIX)/lib
+LIBDIR=$(PREFIX)/lib/ocaml
 
 ### Where to install the stub DLLs
 STUBLIBDIR=$(LIBDIR)/stublibs

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -32,7 +32,7 @@ BINDIR=$(PREFIX)/bin
 BYTERUN=ocamlrun
 
 ### Where to install the standard library
-LIBDIR=$(PREFIX)/lib
+LIBDIR=$(PREFIX)/lib/ocaml
 
 ### Where to install the stub DLLs
 STUBLIBDIR=$(LIBDIR)/stublibs

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -26,7 +26,7 @@ BINDIR=$(PREFIX)/bin
 BYTERUN=ocamlrun
 
 ### Where to install the standard library
-LIBDIR=$(PREFIX)/lib
+LIBDIR=$(PREFIX)/lib/ocaml
 
 ### Where to install the stub DLLs
 STUBLIBDIR=$(LIBDIR)/stublibs

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -26,7 +26,7 @@ BINDIR=$(PREFIX)/bin
 BYTERUN=ocamlrun
 
 ### Where to install the standard library
-LIBDIR=$(PREFIX)/lib
+LIBDIR=$(PREFIX)/lib/ocaml
 
 ### Where to install the stub DLLs
 STUBLIBDIR=$(LIBDIR)/stublibs


### PR DESCRIPTION
First off, thank you for all the incredible work you've done with the OCaml compiler!

I've been experimenting with the OCaml compiler as part of the https://github.com/esy/esy project, in particular, facilitating a smooth Windows experience. 

I noticed that the standard library path was different on Windows vs OSX / Linux:
- Windows: `<ocaml>/lib`
- OSX / Linux: `<ocaml>/lib/ocaml`

It seems like it would make sense for these to be consistent cross-platform. Looking at the history of the `Makefiles`, it looks like the `LIBDIR` was set a while ago - so I'm curious if perhaps it was changed in OSX / Linux, but not on Windows. For most tools and applications, it may not be important, as the `OCAMLLIB` variable can be used - but `esy` is a somewhat special case as it implements a sandbox isolation model, and needs strict control over the environment. Having a common path from the `ocaml` root means less special casing per-platform.

In addition, I wonder if there are any compatibility issues making this change. Please let me know if you'd like any information or have any feedback on this change. Thank you!