### PR TITLE
Float.Array interface: turn external declarations into val ones.

### DIFF
--- a/Changes
+++ b/Changes
@@ -26,6 +26,9 @@ Working version
 
 ### Standard library:
 
+- GPR#2005: Float.Array interface: turn external declarations into val ones.
+  (Daniel C. Bünzli)
+
 - GPR#1940: Add Option module and Format.pp_print_option
   (Many fine eyes)
 

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -258,10 +258,10 @@ val hash: t -> int
 
 module Array : sig
   type t = floatarray
-  external create : int -> t = "caml_floatarray_create"
-  external length : t -> int = "%floatarray_length"
-  external get : t -> int -> float = "%floatarray_safe_get"
-  external set : t -> int -> float -> unit = "%floatarray_safe_set"
-  external unsafe_get : t -> int -> float = "%floatarray_unsafe_get"
-  external unsafe_set : t -> int -> float -> unit = "%floatarray_unsafe_set"
+  val create : int -> t
+  val length : t -> int
+  val get : t -> int -> float
+  val set : t -> int -> float -> unit
+  val unsafe_get : t -> int -> float
+  val unsafe_set : t -> int -> float -> unit
 end


### PR DESCRIPTION
This makes `Float.Array` satisfy an obvious `ARRAY` signature. Also it makes the signature compatible with the  `Float.Array` signature that gets into `stdlib-shims`, see https://github.com/ocaml/stdlib-shims/pull/3.

I was tempted to remove all the externals from the `Float` module aswell but did not. If there is desire to do so I can add that to this PR. 