### PR TITLE
documentation: move 32/64/native literals out of the extension chapter

### DIFF
--- a/Changes
+++ b/Changes
@@ -225,6 +225,10 @@ Working version
 - GPR#1863: caml-tex2, move to compiler-libs
   (Florian Angeletti, review by Sébastien Hinderer and Gabriel Scherer)
 
+- GPR#2007: move the documentation for 32-bit, 64-bit and native integer
+  literals to the main part of the manual.
+  (Florian Angeletti, review by Gabriel Scherer)
+
 ### Compiler distribution build system:
 
 - GPR#1776: add -no-install-bytecode-programs and related configure options to

--- a/manual/manual/library/builtin.etex
+++ b/manual/manual/library/builtin.etex
@@ -103,6 +103,7 @@ type int32
 \index{int32@\verb`int32`}
 \begin{ocamldocdescription}
  The type of signed 32-bit integers.
+ Literals for 32-bit integers are suffixed by l.
  See the "Int32"[\moduleref{Int32}] module.
 \end{ocamldocdescription}
 
@@ -112,6 +113,7 @@ type int64
 \index{int64@\verb`int64`}
 \begin{ocamldocdescription}
  The type of signed 64-bit integers.
+ Literals for 64-bit integers are suffixed by L.
  See the "Int64"[\moduleref{Int64}] module.
 \end{ocamldocdescription}
 
@@ -122,6 +124,7 @@ type nativeint
 \begin{ocamldocdescription}
  The type of signed, platform-native integers (32 bits on 32-bit
  processors, 64 bits on 64-bit processors).
+ Literals for native integers are suffixed by n.
  See the "Nativeint"[\moduleref{Nativeint}] module.
 \end{ocamldocdescription}
 

--- a/manual/manual/refman/const.etex
+++ b/manual/manual/refman/const.etex
@@ -9,6 +9,9 @@
 \begin{syntax}
 constant:
     integer-literal
+  | int32-literal
+  | int64-literal
+  | nativeint-literal
   | float-literal
   | char-literal
   | string-literal
@@ -21,14 +24,13 @@ constant:
   | "[|""|]"
   | "`"tag-name
 \end{syntax}
-See also the following language extensions:
-\hyperref[s:ext-integer]{integer literals for types \texttt{int32}, \texttt{int64}
-and \texttt{nativeint}},
-and \hyperref[s:extension-literals]{extension literals}.
+See also the following language extension:
+\hyperref[s:extension-literals]{extension literals}.
 
 The syntactic class of constants comprises literals from the four
 base types (integers, floating-point numbers, characters, character
-strings), and constant constructors from both normal and polymorphic
-variants, as well as the special constants @"false"@, @"true"@, @"("")"@,
+strings), the integer variants, and constant constructors
+from both normal and polymorphic variants, as well as the special
+constants @"false"@, @"true"@, @"("")"@,
 @"[""]"@, and @"[|""|]"@, which behave like constant constructors, and
 @"begin" "end"@, which is equivalent to @'('')'@.

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -5,33 +5,6 @@ This chapter describes language extensions and convenience features
 that are implemented in OCaml, but not described in the
 OCaml reference manual.
 
-\section{Integer literals for types \texttt{int32}, \texttt{int64}
-         and \texttt{nativeint}} \label{s:ext-integer}
-
-(Introduced in Objective Caml 3.07)
-
-\begin{syntax}
-constant: ...
-          | int32-literal
-          | int64-literal
-          | nativeint-literal
-;
-int32-literal: integer-literal 'l'
-;
-int64-literal: integer-literal 'L'
-;
-nativeint-literal: integer-literal 'n'
-\end{syntax}
-
-An integer literal can be followed by one of the letters "l", "L" or "n"
-to indicate that this integer has type "int32", "int64" or "nativeint"
-respectively, instead of the default type "int" for integer literals.
-\index{int32\@\verb`int32`}
-\index{int64\@\verb`int64`}
-\index{nativeint\@\verb`nativeint`}
-The library modules "Int32"[\moduleref{Int32}],
-"Int64"[\moduleref{Int64}] and "Nativeint"[\moduleref{Nativeint}]
-provide operations on these integer types.
 
 \section{Recursive definitions of values} \label{s:letrecvalues}
 

--- a/manual/manual/refman/lex.etex
+++ b/manual/manual/refman/lex.etex
@@ -54,6 +54,11 @@ integer-literal:
                             { "0"\ldots"9"||"A"\ldots"F"||"a"\ldots"f"||"_" }
         | ["-"] ("0o"||"0O") ("0"\ldots"7") { "0"\ldots"7"||"_" }
         | ["-"] ("0b"||"0B") ("0"\ldots"1") { "0"\ldots"1"||"_" }
+int32-literal: integer-literal 'l'
+;
+int64-literal: integer-literal 'L'
+;
+nativeint-literal: integer-literal 'n'
 \end{syntax}
 
 An integer literal is a sequence of one or more digits, optionally
@@ -65,6 +70,9 @@ preceded by a minus sign. By default, integer literals are in decimal
 \entree{"0b", "0B"}{binary (radix 2)}
 \end{tableau}
 (The initial @"0"@ is the digit zero; the @"O"@ for octal is the letter O.)
+An integer literal can be followed by one of the letters "l", "L" or "n"
+to indicate that this integer has type "int32", "int64" or "nativeint"
+respectively, instead of the default type "int" for integer literals.
 The interpretation of integer literals that fall outside the range of
 representable integer values is undefined.
 

--- a/stdlib/int32.mli
+++ b/stdlib/int32.mli
@@ -24,7 +24,15 @@
    Performance notice: values of type [int32] occupy more memory
    space than values of type [int], and arithmetic operations on
    [int32] are generally slower than those on [int].  Use [int32]
-   only when the application requires exact 32-bit arithmetic. *)
+   only when the application requires exact 32-bit arithmetic.
+
+    Literals for 32-bit integers are suffixed by l:
+    {[
+      let zero: int32 = 0l
+      let one: int32 = 1l
+      let m_one: int32 = -1l
+    ]}
+*)
 
 val zero : int32
 (** The 32-bit integer 0. *)

--- a/stdlib/int64.mli
+++ b/stdlib/int64.mli
@@ -25,6 +25,13 @@
    space than values of type [int], and arithmetic operations on
    [int64] are generally slower than those on [int].  Use [int64]
    only when the application requires exact 64-bit arithmetic.
+
+    Literals for 64-bit integers are suffixed by L:
+    {[
+      let zero: int64 = 0L
+      let one: int64 = 1L
+      let m_one: int64 = -1L
+    ]}
 *)
 
 val zero : int64

--- a/stdlib/nativeint.mli
+++ b/stdlib/nativeint.mli
@@ -28,6 +28,13 @@
    [nativeint] are generally slower than those on [int].  Use [nativeint]
    only when the application requires the extra bit of precision
    over the [int] type.
+
+    Literals for native integers are suffixed by n:
+    {[
+      let zero: nativeint = 0n
+      let one: nativeint = 1n
+      let m_one: nativeint = -1n
+    ]}
 *)
 
 val zero : nativeint


### PR DESCRIPTION
This PR proposes to move the documentation for 32-bit, 64-bit and native integer literals to the main part of the manual. More precisely,  the description of these literals in `refman/exten.etex` is moved to `refman/const.etex` and `refman/lex.etex`. Moreover, the description of  `int32`, `int64` and `nativeint` now mentions the existence of those literals in both the standard library documentation and the small section on built-in types.