### PR TITLE
s/string_of_int/Int.to_string/g

### DIFF
--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -160,8 +160,8 @@ let load_symbol_addr s arg =
 
 let emit_label lbl =
   match system with
-  | S_macosx | S_win64 -> "L" ^ string_of_int lbl
-  | _ -> ".L" ^ string_of_int lbl
+  | S_macosx | S_win64 -> "L" ^ Int.to_string lbl
+  | _ -> ".L" ^ Int.to_string lbl
 
 let label s = sym (emit_label s)
 

--- a/asmcomp/compilenv.ml
+++ b/asmcomp/compilenv.ml
@@ -357,7 +357,7 @@ let const_label = ref 0
 
 let new_const_symbol () =
   incr const_label;
-  make_symbol (Some (string_of_int !const_label))
+  make_symbol (Some (Int.to_string !const_label))
 
 let snapshot () = !structured_constants
 let backtrack s = structured_constants := s

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -19,7 +19,7 @@ let output_channel = ref stdout
 
 let emit_string s = output_string !output_channel s
 
-let emit_int n = output_string !output_channel (string_of_int n)
+let emit_int n = output_string !output_channel (Int.to_string n)
 
 let emit_char c = output_char !output_channel c
 

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -97,7 +97,7 @@ let intop = function
         begin
           match label_after_error with
           | None -> ""
-          | Some lbl -> string_of_int lbl
+          | Some lbl -> Int.to_string lbl
         end
         spacetime_index
 

--- a/asmcomp/reg.ml
+++ b/asmcomp/reg.ml
@@ -117,7 +117,7 @@ let name t =
     in
     match t.part with
     | None -> with_spilled
-    | Some part -> with_spilled ^ "#" ^ string_of_int part
+    | Some part -> with_spilled ^ "#" ^ Int.to_string part
 
 let first_virtual_reg_stamp = ref (-1)
 

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -16,7 +16,6 @@
 (* Selection of pseudo-instructions, assignment of pseudo-registers,
    sequentialization. *)
 
-open Misc
 open Cmm
 open Reg
 open Mach
@@ -94,8 +93,8 @@ let size_expr (env:environment) exp =
           let regs = env_find id env in
           size_machtype (Array.map (fun r -> r.typ) regs)
         with Not_found ->
-          fatal_error("Selection.size_expr: unbound var " ^
-                      V.unique_name id)
+          Misc.fatal_error("Selection.size_expr: unbound var " ^
+                           V.unique_name id)
         end
     | Ctuple el ->
         List.fold_right (fun e sz -> size localenv e + sz) el 0
@@ -106,7 +105,7 @@ let size_expr (env:environment) exp =
     | Csequence(_e1, e2) ->
         size localenv e2
     | _ ->
-        fatal_error "Selection.size_expr"
+        Misc.fatal_error "Selection.size_expr"
   in size V.Map.empty exp
 
 (* Swap the two arguments of an integer comparison *)
@@ -475,7 +474,7 @@ method select_operation op args _dbg =
     let extra_args = self#select_checkbound_extra_args () in
     let op = self#select_checkbound () in
     self#select_arith op (args @ extra_args)
-  | _ -> fatal_error "Selection.select_oper"
+  | _ -> Misc.fatal_error "Selection.select_oper"
 
 method private select_arith_comm op = function
     [arg; Cconst_int n] when self#is_immediate n ->
@@ -593,8 +592,8 @@ method adjust_type src dst =
     match ts, td with
     | Val, Int -> dst.typ <- Val
     | Int, Val -> ()
-    | _, _ -> fatal_error("Selection.adjust_type: bad assignment to "
-                                                           ^ Reg.name dst)
+    | _, _ -> Misc.fatal_error("Selection.adjust_type: bad assignment to "
+                               ^ Reg.name dst)
 
 method adjust_types src dst =
   for i = 0 to min (Array.length src) (Array.length dst) - 1 do
@@ -665,7 +664,7 @@ method emit_expr (env:environment) exp =
       begin try
         Some(env_find v env)
       with Not_found ->
-        fatal_error("Selection.emit_expr: unbound var " ^ V.unique_name v)
+        Misc.fatal_error("Selection.emit_expr: unbound var " ^ V.unique_name v)
       end
   | Clet(v, e1, e2) ->
       begin match self#emit_expr env e1 with
@@ -679,7 +678,7 @@ method emit_expr (env:environment) exp =
         try
           env_find v env
         with Not_found ->
-          fatal_error ("Selection.emit_expr: unbound var " ^ V.name v) in
+          Misc.fatal_error ("Selection.emit_expr: unbound var " ^ V.name v) in
       begin match self#emit_expr env e1 with
         None -> None
       | Some r1 -> self#adjust_types r1 rv; self#insert_moves r1 rv; Some [||]
@@ -842,8 +841,8 @@ method emit_expr (env:environment) exp =
           let dest_args =
             try env_find_static_exception nfail env
             with Not_found ->
-              fatal_error ("Selection.emit_expr: unbound label "^
-                           string_of_int nfail)
+              Misc.fatal_error ("Selection.emit_expr: unbound label "^
+                                string_of_int nfail)
           in
           (* Intermediate registers to handle cases where some
              registers from src are present in dest *)
@@ -1107,7 +1106,7 @@ method emit_tail (env:environment) exp =
                 self#insert(Iop(Istackoffset(-stack_ofs))) [||] [||];
                 self#insert Ireturn loc_res [||]
               end
-          | _ -> fatal_error "Selection.emit_tail"
+          | _ -> Misc.fatal_error "Selection.emit_tail"
       end
   | Csequence(e1, e2) ->
       begin match self#emit_expr env e1 with

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -842,7 +842,7 @@ method emit_expr (env:environment) exp =
             try env_find_static_exception nfail env
             with Not_found ->
               Misc.fatal_error ("Selection.emit_expr: unbound label "^
-                                string_of_int nfail)
+                                Stdlib.Int.to_string nfail)
           in
           (* Intermediate registers to handle cases where some
              registers from src are present in dest *)

--- a/asmcomp/strmatch.ml
+++ b/asmcomp/strmatch.ml
@@ -65,7 +65,7 @@ module Make(I:I) = struct
   let pp_match chan tag idxs cases =
     Printf.eprintf
       "%s: idx=[%s]\n" tag
-      (String.concat "; " (List.map string_of_int idxs)) ;
+      (String.concat "; " (List.map Int.to_string idxs)) ;
     do_pp_cases chan cases
 
 (* Utilities *)

--- a/asmcomp/x86_gas.ml
+++ b/asmcomp/x86_gas.ml
@@ -36,7 +36,7 @@ let arg_mem b {arch; typ=_; idx; scale; base; sym; displ} =
   begin match sym with
   | None ->
       if displ <> 0 || scale = 0 then
-        Buffer.add_string b (string_of_int displ)
+        Buffer.add_string b (Int.to_string displ)
   | Some s ->
       Buffer.add_string b s;
       opt_displ b displ
@@ -49,7 +49,7 @@ let arg_mem b {arch; typ=_; idx; scale; base; sym; displ} =
     end;
     if base != None || scale <> 1 then Buffer.add_char b ',';
     print_reg b string_of_register idx;
-    if scale <> 1 then bprintf b ",%s" (string_of_int scale);
+    if scale <> 1 then bprintf b ",%s" (Int.to_string scale);
     Buffer.add_char b ')'
   end
 

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -272,7 +272,7 @@ let find_raise_label i =
   with
   | Not_found ->
       Misc.fatal_error
-        ("exit("^string_of_int i^") outside appropriated catch")
+        ("exit("^Int.to_string i^") outside appropriated catch")
 
 (* Will the translation of l lead to a jump to label ? *)
 let code_as_jump l sz = match l with
@@ -424,9 +424,9 @@ let comp_primitive p args =
   | Pbintcomp(_, Cgt) -> Kccall("caml_greaterthan", 2)
   | Pbintcomp(_, Cle) -> Kccall("caml_lessequal", 2)
   | Pbintcomp(_, Cge) -> Kccall("caml_greaterequal", 2)
-  | Pbigarrayref(_, n, _, _) -> Kccall("caml_ba_get_" ^ string_of_int n, n + 1)
-  | Pbigarrayset(_, n, _, _) -> Kccall("caml_ba_set_" ^ string_of_int n, n + 2)
-  | Pbigarraydim(n) -> Kccall("caml_ba_dim_" ^ string_of_int n, 1)
+  | Pbigarrayref(_, n, _, _) -> Kccall("caml_ba_get_" ^ Int.to_string n, n + 1)
+  | Pbigarrayset(_, n, _, _) -> Kccall("caml_ba_set_" ^ Int.to_string n, n + 2)
+  | Pbigarraydim(n) -> Kccall("caml_ba_dim_" ^ Int.to_string n, 1)
   | Pbigstring_load_16(_) -> Kccall("caml_ba_uint8_get16", 2)
   | Pbigstring_load_32(_) -> Kccall("caml_ba_uint8_get32", 2)
   | Pbigstring_load_64(_) -> Kccall("caml_ba_uint8_get64", 2)

--- a/debugger/breakpoints.ml
+++ b/debugger/breakpoints.ml
@@ -193,7 +193,7 @@ let remove_breakpoint number =
         )
   with
     Not_found ->
-      prerr_endline ("No breakpoint number " ^ (string_of_int number) ^ ".");
+      prerr_endline ("No breakpoint number " ^ (Int.to_string number) ^ ".");
       raise Not_found
 
 let remove_all_breakpoints () =

--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -695,7 +695,7 @@ let instr_frame ppf lexbuf =
       show_current_frame ppf true
     with
     | Not_found ->
-        error ("No frame number " ^ string_of_int frame_number ^ ".")
+        error ("No frame number " ^ Int.to_string frame_number ^ ".")
 
 let instr_backtrace ppf lexbuf =
   let number =
@@ -983,7 +983,7 @@ let info_events _ppf lexbuf =
            (match ev.ev_repr with
               Event_none        -> ""
             | Event_parent _    -> "(repr)"
-            | Event_child repr  -> string_of_int !repr))
+            | Event_child repr  -> Int.to_string !repr))
       (events_in_module mdle)
 
 (** User-defined printers **)

--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -207,9 +207,9 @@ let main () =
         "Win32" ->
           (Unix.string_of_inet_addr Unix.inet_addr_loopback)^
           ":"^
-          (string_of_int (10000 + ((Unix.getpid ()) mod 10000)))
+          (Int.to_string (10000 + ((Unix.getpid ()) mod 10000)))
       | _ -> Filename.concat (Filename.get_temp_dir_name ())
-                                ("camldebug" ^ (string_of_int (Unix.getpid ())))
+                                ("camldebug" ^ (Int.to_string (Unix.getpid ())))
       );
     begin try
       Arg.parse speclist anonymous "";

--- a/debugger/printval.ml
+++ b/debugger/printval.ml
@@ -43,7 +43,7 @@ let find_named_value name =
 let check_depth depth obj ty =
   if depth <= 0 then begin
     let n = name_value obj ty in
-    Some (Outcometree.Oval_stuff ("$" ^ string_of_int n))
+    Some (Outcometree.Oval_stuff ("$" ^ Int.to_string n))
   end else None
 
 module EvalPath =

--- a/debugger/time_travel.ml
+++ b/debugger/time_travel.ml
@@ -95,7 +95,7 @@ let wait_for_connection checkpoint =
 (* Select a checkpoint as current. *)
 let set_current_checkpoint checkpoint =
   if !debug_time_travel then
-    prerr_endline ("Select: " ^ (string_of_int checkpoint.c_pid));
+    prerr_endline ("Select: " ^ (Int.to_string checkpoint.c_pid));
   if not checkpoint.c_valid then
     wait_for_connection checkpoint;
   current_checkpoint := checkpoint;
@@ -104,7 +104,7 @@ let set_current_checkpoint checkpoint =
 (* Kill `checkpoint'. *)
 let kill_checkpoint checkpoint =
   if !debug_time_travel then
-    prerr_endline ("Kill: " ^ (string_of_int checkpoint.c_pid));
+    prerr_endline ("Kill: " ^ (Int.to_string checkpoint.c_pid));
   if checkpoint.c_pid > 0 then          (* Ghosts don't have to be killed ! *)
     (if not checkpoint.c_valid then
        wait_for_connection checkpoint;
@@ -241,7 +241,7 @@ let duplicate_current_checkpoint () =
            Checkpoint_done pid ->
              (new_checkpoint.c_pid <- pid;
               if !debug_time_travel then
-                prerr_endline ("Waiting for connection: " ^ string_of_int pid))
+                prerr_endline ("Waiting for connection: " ^ Int.to_string pid))
          | Checkpoint_failed ->
              prerr_endline
                "A fork failed. Reducing maximum number of checkpoints.";
@@ -373,7 +373,7 @@ let set_file_descriptor pid fd =
            true)
   in
     if !debug_time_travel then
-      prerr_endline ("New connection: " ^(string_of_int pid));
+      prerr_endline ("New connection: " ^(Int.to_string pid));
     find (!current_checkpoint::!checkpoints)
 
 (* Kill all the checkpoints. *)

--- a/manual/manual/cmds/flambda.etex
+++ b/manual/manual/cmds/flambda.etex
@@ -552,7 +552,7 @@ let rec iter f l =
 and used like this:
 \begin{verbatim}
 let print_int x =
-  print_endline (string_of_int x)
+  print_endline (Int.to_string x)
 
 let run xs =
   iter print_int (List.rev xs)
@@ -594,7 +594,7 @@ let run xs =
     match l with
     | [] -> ()
     | h :: t ->
-      print_endline (string_of_int h);
+      print_endline (Int.to_string h);
       iter' f t
   in
   iter' print_int (List.rev xs)
@@ -606,7 +606,7 @@ let run xs =
     match l with
     | [] -> ()
     | h :: t ->
-      print_endline (string_of_int h);
+      print_endline (Int.to_string h);
       iter' t
   in
   iter' (List.rev xs)

--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -724,7 +724,7 @@ open Typ
 let rec to_string: 'a. 'a Typ.typ -> 'a -> string =
   fun (type s) t x ->
     match t with
-    | Int eq -> string_of_int (TypEq.apply eq x)
+    | Int eq -> Int.to_string (TypEq.apply eq x)
     | String eq -> Printf.sprintf "%S" (TypEq.apply eq x)
     | Pair p ->
         let module P = (val p : PAIR with type t = s) in
@@ -1201,7 +1201,7 @@ type _ typ =
 let rec to_string: type t. t typ -> t -> string =
   fun t x ->
   match t with
-  | Int -> string_of_int x
+  | Int -> Int.to_string x
   | String -> Printf.sprintf "%S" x
   | Pair(t1,t2) ->
       let (x1, x2) = x in
@@ -1872,7 +1872,7 @@ to handle unknown variant constructors:
 \begin{caml_example*}{verbatim}
 let to_string = function
   | Expr.Str s -> s
-  | Expr.Int i -> string_of_int i
+  | Expr.Int i -> Int.to_string i
   | Expr.Float f -> string_of_float f
   | _ -> "?"
 \end{caml_example*}

--- a/manual/manual/tutorials/objectexamples.etex
+++ b/manual/manual/tutorials/objectexamples.etex
@@ -652,7 +652,7 @@ does not work in practice.
 let l = new intlist [1; 2; 3];;
 l#fold (fun x y -> x+y) 0;;
 l;;
-l#fold (fun s x -> s ^ string_of_int x ^ " ") "" [@@expect error];;
+l#fold (fun s x -> s ^ Int.to_string x ^ " ") "" [@@expect error];;
 \end{caml_example}
 Our iterator works, as shows its first use for summation. However,
 since objects themselves are not polymorphic (only their constructors
@@ -672,7 +672,7 @@ class intlist (l : int list) =
   end;;
 let l = new intlist [1; 2; 3];;
 l#fold (fun x y -> x+y) 0;;
-l#fold (fun s x -> s ^ string_of_int x ^ " ") "";;
+l#fold (fun s x -> s ^ Int.to_string x ^ " ") "";;
 \end{caml_example}
 As you can see in the class type shown by the compiler, while
 polymorphic method types must be fully explicit in class definitions

--- a/middle_end/base_types/id_types.ml
+++ b/middle_end/base_types/id_types.ml
@@ -54,7 +54,7 @@ module Id(E:sig end) : Id = struct
     else Some name
   let to_string (t,name) =
     if name == empty_string
-    then string_of_int t
+    then Int.to_string t
     else Printf.sprintf "%s_%i" name t
   let output fd t = output_string fd (to_string t)
   let print ppf v = Format.pp_print_string ppf (to_string v)

--- a/middle_end/base_types/variable.ml
+++ b/middle_end/base_types/variable.ml
@@ -43,7 +43,7 @@ include Identifiable.Make (struct
   let output chan t =
     output_string chan t.name;
     output_string chan "_";
-    output_string chan (string_of_int t.name_stamp)
+    output_string chan (Int.to_string t.name_stamp)
 
   let hash t = t.name_stamp lxor (Compilation_unit.hash t.compilation_unit)
 
@@ -95,7 +95,7 @@ let get_compilation_unit t = t.compilation_unit
 let name t = t.name
 
 let unique_name t =
-  t.name ^ "_" ^ (string_of_int t.name_stamp)
+  t.name ^ "_" ^ (Int.to_string t.name_stamp)
 
 let print_list ppf ts =
   List.iter (fun t -> Format.fprintf ppf "@ %a" print t) ts

--- a/middle_end/closure_conversion_aux.ml
+++ b/middle_end/closure_conversion_aux.ml
@@ -65,7 +65,7 @@ module Env = struct
     try Numbers.Int.Map.find st_exn t.static_exceptions
     with Not_found ->
       Misc.fatal_error ("Closure_conversion.Env.find_static_exception: exn "
-        ^ string_of_int st_exn)
+        ^ Int.to_string st_exn)
 
   let add_global t pos symbol =
     { t with globals = Numbers.Int.Map.add pos symbol t.globals }
@@ -74,7 +74,7 @@ module Env = struct
     try Numbers.Int.Map.find pos t.globals
     with Not_found ->
       Misc.fatal_error ("Closure_conversion.Env.find_global: global "
-        ^ string_of_int pos)
+        ^ Int.to_string pos)
 
   let at_toplevel t = t.at_toplevel
 

--- a/ocamldoc/odoc_comments.ml
+++ b/ocamldoc/odoc_comments.ml
@@ -151,8 +151,8 @@ module Info_retriever =
             (n, acc)
         | (n2, Some i) ->
             print_DEBUG ("all_special: avant String.sub new_s="^s2);
-            print_DEBUG ("n2="^(string_of_int n2)) ;
-            print_DEBUG ("len(s2)="^(string_of_int (String.length s2))) ;
+            print_DEBUG ("n2="^(Int.to_string n2)) ;
+            print_DEBUG ("len(s2)="^(Int.to_string (String.length s2))) ;
             let new_s = String.sub s2 n2 ((String.length s2) - n2) in
             print_DEBUG ("all_special: apres String.sub new_s="^new_s);
             iter (acc @ [i]) (n + n2) new_s

--- a/ocamldoc/odoc_messages.ml
+++ b/ocamldoc/odoc_messages.ml
@@ -262,7 +262,7 @@ let bad_magic_number =
 let not_a_module_name s = s^" is not a valid module name"
 let load_file_error f e = "Error while loading file "^f^":\n"^e
 let wrong_format s = "Wrong format for \""^s^"\""
-let errors_occured n = (string_of_int n)^" error(s) encountered"
+let errors_occured n = (Int.to_string n)^" error(s) encountered"
 let parse_error = "Parse error"
 let text_parse_error l c s =
   let lines = Str.split (Str.regexp_string "\n") s in
@@ -316,7 +316,7 @@ let module_not_found_in_typedtree m = "Module "^m^" was not found in typed tree.
 let class_not_found_in_typedtree c = "Class "^c^" was not found in typed tree."
 let class_type_not_found_in_typedtree ct = "Class type "^ct^" was not found in typed tree."
 let inherit_classexp_not_found_in_typedtree n =
-  "Inheritance class expression number "^(string_of_int n)^" was not found in typed tree."
+  "Inheritance class expression number "^(Int.to_string n)^" was not found in typed tree."
 let attribute_not_found_in_typedtree att = "Class attribute "^att^" was not found in typed tree."
 let method_not_found_in_typedtree met = "Class method "^met^" was not found in typed tree."
 let misplaced_comment file pos =

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -116,7 +116,7 @@ let rec string_of_text t =
           let rec f n = function
               [] -> "\n"
             | t :: q ->
-                "\n"^(string_of_int n)^". "^(string_of_text t)^
+                "\n"^(Int.to_string n)^". "^(string_of_text t)^
                 (f (n + 1) q)
           in
           f 1 l
@@ -229,14 +229,14 @@ let apply_opt f v_opt =
 let string_of_date ?(absolute=false) ?(hour=true) d =
   let add_0 s = if String.length s < 2 then "0"^s else s in
   let t = (if absolute then Unix.gmtime else Unix.localtime) d in
-  (string_of_int (t.Unix.tm_year + 1900))^"-"^
-  (add_0 (string_of_int (t.Unix.tm_mon + 1)))^"-"^
-  (add_0 (string_of_int t.Unix.tm_mday))^
+  (Int.to_string (t.Unix.tm_year + 1900))^"-"^
+  (add_0 (Int.to_string (t.Unix.tm_mon + 1)))^"-"^
+  (add_0 (Int.to_string t.Unix.tm_mday))^
   (
    if hour then
      " "^
-     (add_0 (string_of_int t.Unix.tm_hour))^":"^
-     (add_0 (string_of_int t.Unix.tm_min))
+     (add_0 (Int.to_string t.Unix.tm_hour))^":"^
+     (add_0 (Int.to_string t.Unix.tm_min))
    else
      ""
   )

--- a/otherlibs/threads/unix.ml
+++ b/otherlibs/threads/unix.ml
@@ -887,7 +887,7 @@ let getnameinfo_emulation addr opts =
           let kind = if List.mem NI_DGRAM opts then "udp" else "tcp" in
           (getservbyport p kind).s_name
         with Not_found ->
-          string_of_int p in
+          Int.to_string p in
       { ni_hostname = hostname; ni_service = service }
 
 let getnameinfo addr opts =

--- a/otherlibs/unix/unix.ml
+++ b/otherlibs/unix/unix.ml
@@ -863,7 +863,7 @@ let getnameinfo_emulation addr opts =
           let kind = if List.mem NI_DGRAM opts then "udp" else "tcp" in
           (getservbyport p kind).s_name
         with Not_found ->
-          string_of_int p in
+          Int.to_string p in
       { ni_hostname = hostname; ni_service = service }
 
 let getnameinfo addr opts =

--- a/otherlibs/win32unix/unix.ml
+++ b/otherlibs/win32unix/unix.ml
@@ -844,7 +844,7 @@ let getnameinfo_emulation addr opts =
           let kind = if List.mem NI_DGRAM opts then "udp" else "tcp" in
           (getservbyport p kind).s_name
         with Not_found ->
-          string_of_int p in
+          Int.to_string p in
       { ni_hostname = hostname; ni_service = service }
 
 let getnameinfo addr opts =

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -33,7 +33,7 @@ let with_default_loc l f =
 
 module Const = struct
   let integer ?suffix i = Pconst_integer (i, suffix)
-  let int ?suffix i = integer ?suffix (string_of_int i)
+  let int ?suffix i = integer ?suffix (Int.to_string i)
   let int32 ?(suffix='l') i = integer ~suffix (Int32.to_string i)
   let int64 ?(suffix='L') i = integer ~suffix (Int64.to_string i)
   let nativeint ?(suffix='n') i = integer ~suffix (Nativeint.to_string i)

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -446,7 +446,7 @@ let highlight_quote ppf
         |> infer_line_numbers
         |> List.map (fun (lnum, { text; start_pos }) ->
           (text,
-           Misc.Stdlib.Option.value_default string_of_int ~default:"" lnum,
+           Misc.Stdlib.Option.value_default Int.to_string ~default:"" lnum,
            start_pos))
       in
     Format.fprintf ppf "@[<v>";

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -29,9 +29,9 @@ stdlib__bytesLabels.cmi : stdlib__seq.cmi
 stdlib__callback.cmo : stdlib__obj.cmi stdlib__callback.cmi
 stdlib__callback.cmx : stdlib__obj.cmx stdlib__callback.cmi
 stdlib__callback.cmi :
-camlinternalFormat.cmo : stdlib__sys.cmi stdlib__string.cmi stdlib__char.cmi \
+camlinternalFormat.cmo : stdlib__sys.cmi stdlib__string.cmi stdlib__int.cmi stdlib__char.cmi \
     camlinternalFormatBasics.cmi stdlib__bytes.cmi stdlib__buffer.cmi camlinternalFormat.cmi
-camlinternalFormat.cmx : stdlib__sys.cmx stdlib__string.cmx stdlib__char.cmx \
+camlinternalFormat.cmx : stdlib__sys.cmx stdlib__string.cmx stdlib__int.cmx stdlib__char.cmx \
     camlinternalFormatBasics.cmx stdlib__bytes.cmx stdlib__buffer.cmx camlinternalFormat.cmi
 camlinternalFormat.cmi : camlinternalFormatBasics.cmi stdlib__buffer.cmi
 camlinternalFormatBasics.cmo : camlinternalFormatBasics.cmi
@@ -72,9 +72,9 @@ stdlib__filename.cmi :
 stdlib__float.cmo : stdlib.cmi stdlib__float.cmi
 stdlib__float.cmx : stdlib.cmx stdlib__float.cmi
 stdlib__float.cmi : stdlib.cmi
-stdlib__format.cmo : stdlib__string.cmi stdlib.cmi stdlib__stack.cmi stdlib__queue.cmi stdlib__list.cmi \
+stdlib__format.cmo : stdlib__string.cmi stdlib.cmi stdlib__stack.cmi stdlib__queue.cmi stdlib__list.cmi stdlib__int.cmi \
     camlinternalFormatBasics.cmi camlinternalFormat.cmi stdlib__buffer.cmi stdlib__format.cmi
-stdlib__format.cmx : stdlib__string.cmx stdlib.cmx stdlib__stack.cmx stdlib__queue.cmx stdlib__list.cmx \
+stdlib__format.cmx : stdlib__string.cmx stdlib.cmx stdlib__stack.cmx stdlib__queue.cmx stdlib__list.cmx stdlib__int.cmx \
     camlinternalFormatBasics.cmx camlinternalFormat.cmx stdlib__buffer.cmx stdlib__format.cmi
 stdlib__format.cmi : stdlib.cmi stdlib__buffer.cmi
 stdlib__fun.cmo : stdlib__fun.cmi
@@ -153,9 +153,9 @@ stdlib__printf.cmi : stdlib__buffer.cmi
 stdlib__queue.cmo : stdlib__seq.cmi stdlib__queue.cmi
 stdlib__queue.cmx : stdlib__seq.cmx stdlib__queue.cmi
 stdlib__queue.cmi : stdlib__seq.cmi
-stdlib__random.cmo : stdlib__string.cmi stdlib.cmi stdlib__nativeint.cmi stdlib__int64.cmi stdlib__int32.cmi \
+stdlib__random.cmo : stdlib__string.cmi stdlib.cmi stdlib__nativeint.cmi stdlib__int64.cmi stdlib__int32.cmi stdlib__int.cmi \
     stdlib__digest.cmi stdlib__char.cmi stdlib__array.cmi stdlib__random.cmi
-stdlib__random.cmx : stdlib__string.cmx stdlib.cmx stdlib__nativeint.cmx stdlib__int64.cmx stdlib__int32.cmx \
+stdlib__random.cmx : stdlib__string.cmx stdlib.cmx stdlib__nativeint.cmx stdlib__int64.cmx stdlib__int32.cmx stdlib__int.cmx \
     stdlib__digest.cmx stdlib__char.cmx stdlib__array.cmx stdlib__random.cmi
 stdlib__random.cmi : stdlib__nativeint.cmi stdlib__int64.cmi stdlib__int32.cmi
 stdlib__result.cmo : stdlib__seq.cmi stdlib__result.cmi
@@ -231,9 +231,9 @@ stdlib__bytesLabels.cmo : stdlib__bytes.cmi stdlib__bytesLabels.cmi
 stdlib__bytesLabels.p.cmx : stdlib__bytes.cmx stdlib__bytesLabels.cmi
 stdlib__callback.cmo : stdlib__obj.cmi stdlib__callback.cmi
 stdlib__callback.p.cmx : stdlib__obj.cmx stdlib__callback.cmi
-camlinternalFormat.cmo : stdlib__sys.cmi stdlib__string.cmi stdlib__char.cmi \
+camlinternalFormat.cmo : stdlib__sys.cmi stdlib__string.cmi stdlib__int.cmi stdlib__char.cmi \
     camlinternalFormatBasics.cmi stdlib__bytes.cmi stdlib__buffer.cmi camlinternalFormat.cmi
-camlinternalFormat.p.cmx : stdlib__sys.cmx stdlib__string.cmx stdlib__char.cmx \
+camlinternalFormat.p.cmx : stdlib__sys.cmx stdlib__string.cmx stdlib__int.cmx stdlib__char.cmx \
     camlinternalFormatBasics.cmx stdlib__bytes.cmx stdlib__buffer.cmx camlinternalFormat.cmi
 camlinternalFormatBasics.cmo : camlinternalFormatBasics.cmi
 camlinternalFormatBasics.p.cmx : camlinternalFormatBasics.cmi
@@ -263,9 +263,9 @@ stdlib__filename.p.cmx : stdlib__sys.cmx stdlib__string.cmx stdlib__random.cmx s
     stdlib__filename.cmi
 stdlib__float.cmo : stdlib.cmi stdlib__float.cmi
 stdlib__float.p.cmx : stdlib.cmx stdlib__float.cmi
-stdlib__format.cmo : stdlib__string.cmi stdlib.cmi stdlib__stack.cmi stdlib__queue.cmi stdlib__list.cmi \
+stdlib__format.cmo : stdlib__string.cmi stdlib.cmi stdlib__stack.cmi stdlib__queue.cmi stdlib__list.cmi stdlib__int.cmi \
     camlinternalFormatBasics.cmi camlinternalFormat.cmi stdlib__buffer.cmi stdlib__format.cmi
-stdlib__format.p.cmx : stdlib__string.cmx stdlib.cmx stdlib__stack.cmx stdlib__queue.cmx stdlib__list.cmx \
+stdlib__format.p.cmx : stdlib__string.cmx stdlib.cmx stdlib__stack.cmx stdlib__queue.cmx stdlib__list.cmx stdlib__int.cmx \
     camlinternalFormatBasics.cmx camlinternalFormat.cmx stdlib__buffer.cmx stdlib__format.cmi
 stdlib__fun.cmo : stdlib__fun.cmi
 stdlib__fun.p.cmx : stdlib__fun.cmi
@@ -321,9 +321,9 @@ stdlib__printf.p.cmx : camlinternalFormatBasics.cmx camlinternalFormat.cmx stdli
     stdlib__printf.cmi
 stdlib__queue.cmo : stdlib__seq.cmi stdlib__queue.cmi
 stdlib__queue.p.cmx : stdlib__seq.cmx stdlib__queue.cmi
-stdlib__random.cmo : stdlib__string.cmi stdlib.cmi stdlib__nativeint.cmi stdlib__int64.cmi stdlib__int32.cmi \
+stdlib__random.cmo : stdlib__string.cmi stdlib.cmi stdlib__nativeint.cmi stdlib__int64.cmi stdlib__int32.cmi stdlib__int.cmi \
     stdlib__digest.cmi stdlib__char.cmi stdlib__array.cmi stdlib__random.cmi
-stdlib__random.p.cmx : stdlib__string.cmx stdlib.cmx stdlib__nativeint.cmx stdlib__int64.cmx stdlib__int32.cmx \
+stdlib__random.p.cmx : stdlib__string.cmx stdlib.cmx stdlib__nativeint.cmx stdlib__int64.cmx stdlib__int32.cmx stdlib__int.cmx \
     stdlib__digest.cmx stdlib__char.cmx stdlib__array.cmx stdlib__random.cmi
 stdlib__result.cmo : stdlib__seq.cmi stdlib__result.cmi
 stdlib__result.p.cmx : stdlib__seq.cmx stdlib__result.cmi

--- a/stdlib/camlinternalFormat.ml
+++ b/stdlib/camlinternalFormat.ml
@@ -376,7 +376,7 @@ let bprint_ignored_flag buf ign_flag =
 
 let bprint_pad_opt buf pad_opt = match pad_opt with
   | None -> ()
-  | Some width -> buffer_add_string buf (string_of_int width)
+  | Some width -> buffer_add_string buf (Int.to_string width)
 
 (***)
 
@@ -386,7 +386,7 @@ fun buf pad -> match pad with
   | No_padding -> ()
   | Lit_padding (padty, n) ->
     bprint_padty buf padty;
-    buffer_add_string buf (string_of_int n);
+    buffer_add_string buf (Int.to_string n);
   | Arg_padding padty ->
     bprint_padty buf padty;
     buffer_add_char buf '*'
@@ -397,7 +397,7 @@ let bprint_precision : type a b . buffer -> (a, b) precision -> unit =
   | No_precision -> ()
   | Lit_precision n ->
     buffer_add_char buf '.';
-    buffer_add_string buf (string_of_int n);
+    buffer_add_string buf (Int.to_string n);
   | Arg_precision ->
     buffer_add_string buf ".*"
 
@@ -1415,7 +1415,7 @@ let format_of_fconv fconv prec =
     buffer_add_char buf '%';
     bprint_fconv_flag buf fconv;
     buffer_add_char buf '.';
-    buffer_add_string buf (string_of_int prec);
+    buffer_add_string buf (Int.to_string prec);
     buffer_add_char buf symb;
     buffer_contents buf
 

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -622,7 +622,7 @@ let pp_print_string state s =
 
 
 (* To format an integer. *)
-let pp_print_int state i = pp_print_string state (string_of_int i)
+let pp_print_int state i = pp_print_string state (Int.to_string i)
 
 (* To format a float. *)
 let pp_print_float state f = pp_print_string state (string_of_float f)

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -38,7 +38,7 @@ module State = struct
 
 
   let full_init s seed =
-    let combine accu x = Digest.string (accu ^ string_of_int x) in
+    let combine accu x = Digest.string (accu ^ Int.to_string x) in
     let extract d =
       Char.code d.[0] + (Char.code d.[1] lsl 8) + (Char.code d.[2] lsl 16)
       + (Char.code d.[3] lsl 24)

--- a/testsuite/tests/asmcomp/register_typing.ml
+++ b/testsuite/tests/asmcomp/register_typing.ml
@@ -19,6 +19,6 @@ let g (t : int list typ) x =
   let x = f t ([x; x; x; x; x]) in
   Gc.minor ();
   allocate_garbage ();
-  ignore (String.length (String.concat " " (List.map string_of_int x)))
+  ignore (String.length (String.concat " " (List.map Int.to_string x)))
 
 let () = g Ptr 5

--- a/testsuite/tests/asmcomp/register_typing_switch.ml
+++ b/testsuite/tests/asmcomp/register_typing_switch.ml
@@ -20,6 +20,6 @@ let g (t : int list typ) x =
   let x = f t ([x; x; x; x; x]) in
   Gc.minor ();
   allocate_garbage ();
-  ignore (String.length (String.concat " " (List.map string_of_int x)))
+  ignore (String.length (String.concat " " (List.map Int.to_string x)))
 
 let () = g Ptr 5

--- a/testsuite/tests/backtrace/inline_traversal_test.ml
+++ b/testsuite/tests/backtrace/inline_traversal_test.ml
@@ -40,7 +40,7 @@ let () =
       let location = match Slot.location x with
         | None -> "<unknown>"
         | Some {filename; line_number; _} ->
-            filename ^ ":" ^ string_of_int line_number
+            filename ^ ":" ^ Int.to_string line_number
       in
       Printf.printf "- %s%s%s\n"
         location

--- a/testsuite/tests/basic-more/morematch.ml
+++ b/testsuite/tests/basic-more/morematch.ml
@@ -1132,7 +1132,7 @@ exception Error of string
 let lucexn  e =
   try
     try  raise e  with Error msg -> msg
-  with Found (s,r) -> s^string_of_int r
+  with Found (s,r) -> s^Int.to_string r
 
 let () =
   test "lucexn1" lucexn  (Error "coucou") "coucou" ;

--- a/testsuite/tests/basic/eval_order_6.ml
+++ b/testsuite/tests/basic/eval_order_6.ml
@@ -11,8 +11,8 @@ let r = { x = 10; y = 20 };;
 
 let h = f r;;
 
-print_endline (string_of_int (h ()));;
+print_endline (Int.to_string (h ()));;
 
 r.x <- 20;;
 
-print_endline (string_of_int (h ()));;
+print_endline (Int.to_string (h ()));;

--- a/testsuite/tests/basic/min_int.ml
+++ b/testsuite/tests/basic/min_int.ml
@@ -7,6 +7,6 @@
 let min_int = -1073741824
 let () = match min_int with
 | -1073741824 as i ->
-  assert (string_of_int i = "-1073741824");
+  assert (Int.to_string i = "-1073741824");
   print_endline "OK"
 | _ -> assert false

--- a/testsuite/tests/embedded/cmcaml.ml
+++ b/testsuite/tests/embedded/cmcaml.ml
@@ -8,7 +8,7 @@ let rec fib n =
   if n < 2 then 1 else fib(n-1) + fib(n-2)
 
 let format_result n =
-  let r = "Result = " ^ string_of_int n in
+  let r = "Result = " ^ Int.to_string n in
   (* Allocate gratuitously to test GC *)
   for i = 1 to 1500 do ignore (Bytes.create 256) done;
   r

--- a/testsuite/tests/gc-roots/globroots.ml
+++ b/testsuite/tests/gc-roots/globroots.ml
@@ -31,9 +31,9 @@ module Test(G: GLOBREF) = struct
 
   let size = 1024
 
-  let vals = Array.init size string_of_int
+  let vals = Array.init size Int.to_string
 
-  let a = Array.init size (fun i -> G.register (string_of_int i))
+  let a = Array.init size (fun i -> G.register (Int.to_string i))
 
   let check () =
     for i = 0 to size - 1 do
@@ -51,14 +51,14 @@ module Test(G: GLOBREF) = struct
         Gc.minor()
     | 5|6|7|8|9|10|11|12 ->             (* update with young value *)
         let i = Random.int size in
-        G.set a.(i) (string_of_int i)
+        G.set a.(i) (Int.to_string i)
     | 13|14|15|16|17|18|19|20 ->        (* update with old value *)
         let i = Random.int size in
         G.set a.(i) vals.(i)
     | 21|22|23|24|25|26|27|28 ->        (* re-register young value *)
         let i = Random.int size in
         G.remove a.(i);
-        a.(i) <- G.register (string_of_int i)
+        a.(i) <- G.register (Int.to_string i)
     | (*29|30|31|32|33|34|35|36*) _ ->  (* re-register old value *)
         let i = Random.int size in
         G.remove a.(i);

--- a/testsuite/tests/lib-hashtbl/htbl.ml
+++ b/testsuite/tests/lib-hashtbl/htbl.ml
@@ -234,7 +234,7 @@ let list_data data =
       hd :: tl
     end in
   for i = 0 to Array.length d - 1 do
-    d.(i) <- (mklist (Random.int 16), string_of_int i)
+    d.(i) <- (mklist (Random.int 16), Int.to_string i)
   done;
   d
 

--- a/testsuite/tests/lib-scanf/tscanf.ml
+++ b/testsuite/tests/lib-scanf/tscanf.ml
@@ -1235,7 +1235,7 @@ let next_char ob () =
 
 let send_string ob s =
   Buffer.add_string ob s; Buffer.add_char ob '\n';;
-let send_int ob i = send_string ob (string_of_int i);;
+let send_int ob i = send_string ob (Int.to_string i);;
 
 let rec reader =
   let count = ref 0 in

--- a/testsuite/tests/lib-unix/common/cloexec.ml
+++ b/testsuite/tests/lib-unix/common/cloexec.ml
@@ -54,7 +54,7 @@ all_modules= "cloexec.ml"
 
 let string_of_fd (fd: Unix.file_descr) : string =
   match Sys.os_type with
-  | "Unix" | "Cygwin" ->  string_of_int (Obj.magic fd : int)
+  | "Unix" | "Cygwin" ->  Int.to_string (Obj.magic fd : int)
   | "Win32" ->
       if Sys.word_size = 32 then
         Int32.to_string (Obj.magic fd : int32)

--- a/testsuite/tests/misc/ephetest2.ml
+++ b/testsuite/tests/misc/ephetest2.ml
@@ -149,5 +149,5 @@ let run test init =
 
 let () =
   for i = 0 to nb_test do
-    ignore (run ("test"^(string_of_int i)) i);
+    ignore (run ("test"^(Int.to_string i)) i);
   done

--- a/testsuite/tests/parsetree/source.ml
+++ b/testsuite/tests/parsetree/source.ml
@@ -720,7 +720,7 @@ end = struct
   let ik =
     { tag = Int;
       label = "int";
-      write = string_of_int;
+      write = Int.to_string;
       read = int_of_string }
 
   let () = Hashtbl.add readTbl "int" (K ik)
@@ -838,7 +838,7 @@ let apply x =
   (module N : S)
 
 let () =
-  let int = forget (create string_of_int succ 0) in
+  let int = forget (create Int.to_string succ 0) in
   let str = forget (create (fun s -> s) (fun s -> s ^ s) "X") in
   List.iter print (List.map apply [int; apply int; apply (apply str)])
 
@@ -911,7 +911,7 @@ module rec Print : sig
 end = struct
   let to_string (type s) t x =
     match t with
-    | Int eq -> string_of_int (TypEq.apply eq x)
+    | Int eq -> Int.to_string (TypEq.apply eq x)
     | String eq -> Printf.sprintf "%S" (TypEq.apply eq x)
     | Pair p ->
         let module P = (val p : PAIR with type t = s) in
@@ -946,7 +946,7 @@ let f = function
   | Some _ [@foooo]-> 2
   | None -> 3
 ;;
-print_endline (string_of_int (f (Some (module struct let x = false end))));;
+print_endline (Int.to_string (f (Some (module struct let x = false end))));;
 type 'a ty =
   | Int : int ty
   | Bool : bool ty
@@ -3182,7 +3182,7 @@ open Typ
 let rec to_string: 'a. 'a Typ.typ -> 'a -> string =
   fun (type s) t x ->
     match (t : s typ) with
-    | Int eq -> string_of_int (TypEq.apply eq x)
+    | Int eq -> Int.to_string (TypEq.apply eq x)
     | String eq -> Printf.sprintf "%S" (TypEq.apply eq x)
     | Pair (module P) ->
         let (x1, x2) = TypEq.apply P.eq x in
@@ -3288,7 +3288,7 @@ let subst_lambda ~subst_rec ~free ~subst : _ lambda -> _ = function
           ~f:(fun ~key ~data acc ->
                 if Names.mem s used then data::acc else acc) in
       if List.exists used_expr ~f:(fun t -> Names.mem s (free t)) then
-        let name = s ^ string_of_int (next_id ()) in
+        let name = s ^ Int.to_string (next_id ()) in
         `Abs(name,
              subst_rec ~subst:(Subst.add ~key:s ~data:(`Var name) subst) t)
       else
@@ -3469,7 +3469,7 @@ class ['a] lambda_ops (ops : ('a,'a) #ops Lazy.t) =
               ~f:(fun ~key ~data acc ->
                 if Names.mem s used then data::acc else acc) in
           if List.exists used_expr ~f:(fun t -> Names.mem s (!!free t)) then
-            let name = s ^ string_of_int (next_id ()) in
+            let name = s ^ Int.to_string (next_id ()) in
             `Abs(name,
                  !!subst ~sub:(Subst.add ~key:s ~data:(`Var name) sub) t)
           else
@@ -3656,7 +3656,7 @@ let lambda_ops (ops : ('a,'a) #ops Lazy.t) =
               ~f:(fun ~key ~data acc ->
                 if Names.mem s used then data::acc else acc) in
           if List.exists used_expr ~f:(fun t -> Names.mem s (!!free t)) then
-            let name = s ^ string_of_int (next_id ()) in
+            let name = s ^ Int.to_string (next_id ()) in
             `Abs(name,
                  !!subst ~sub:(Subst.add ~key:s ~data:(`Var name) sub) t)
           else
@@ -4746,7 +4746,7 @@ module C : sig module L : module type of List end = A
 include D'
 (*
 let () =
-  print_endline (string_of_int D'.M.y)
+  print_endline (Int.to_string D'.M.y)
 *)
 open A
 let f =

--- a/testsuite/tests/tool-lexyacc/output.ml
+++ b/testsuite/tests/tool-lexyacc/output.ml
@@ -21,7 +21,7 @@ let copy_chunk (Location(start,stop)) =
 
 
 let output_action (i,act) =
-  output_string !oc ("action_" ^ string_of_int i ^ " lexbuf = (\n");
+  output_string !oc ("action_" ^ Int.to_string i ^ " lexbuf = (\n");
   copy_chunk act;
   output_string !oc ")\nand "
 
@@ -53,9 +53,9 @@ let output_move = function
   | Goto dest ->
       match !states.(dest) with
         Perform act_num ->
-          output_string !oc ("action_" ^ string_of_int act_num ^ " lexbuf")
+          output_string !oc ("action_" ^ Int.to_string act_num ^ " lexbuf")
       | _ ->
-          output_string !oc ("state_" ^ string_of_int dest ^ " lexbuf")
+          output_string !oc ("state_" ^ Int.to_string dest ^ " lexbuf")
 
 
 (* Cannot use standard char_for_read because the characters to escape
@@ -111,13 +111,13 @@ let output_state state_num = function
       ()
   | Shift(what_to_do, moves) ->
       output_string !oc
-        ("state_"  ^ string_of_int state_num ^ " lexbuf =\n");
+        ("state_"  ^ Int.to_string state_num ^ " lexbuf =\n");
       begin match what_to_do with
         No_remember -> ()
       | Remember i ->
           output_string !oc
             ("  Lexing.set_backtrack lexbuf action_" ^
-             string_of_int i ^ ";\n")
+             Int.to_string i ^ ";\n")
       end;
       output_all_trans moves
 
@@ -129,7 +129,7 @@ let rec output_entries = function
   | (name,state_num) :: rest ->
       output_string !oc (name ^ " lexbuf =\n");
       output_string !oc "  Lexing.init lexbuf;\n";
-      output_string !oc ("  state_" ^ string_of_int state_num ^
+      output_string !oc ("  state_" ^ Int.to_string state_num ^
                         " lexbuf\n");
       match rest with
         [] -> ()

--- a/testsuite/tests/translprim/locs.ml
+++ b/testsuite/tests/translprim/locs.ml
@@ -7,7 +7,7 @@ let print_file file =
   print_endline file
 
 let print_line line =
-  print_endline (string_of_int line)
+  print_endline (Int.to_string line)
 
 let print_module md =
   print_endline md

--- a/testsuite/tests/typing-extensions/msg.ml
+++ b/testsuite/tests/typing-extensions/msg.ml
@@ -73,7 +73,7 @@ end = struct
   let ik =
     { tag = Int;
       label = "int";
-      write = string_of_int;
+      write = Int.to_string;
       read = int_of_string }
 
   let () = Hashtbl.add readTbl "int" (K ik)

--- a/testsuite/tests/typing-fstclassmod/fstclassmod.ml
+++ b/testsuite/tests/typing-fstclassmod/fstclassmod.ml
@@ -60,7 +60,7 @@ let apply x =
   (module N : S)
 
 let () =
-  let int = forget (create string_of_int succ 0) in
+  let int = forget (create Int.to_string succ 0) in
   let str = forget (create (fun s -> s) (fun s -> s ^ s) "X") in
   List.iter print (List.map apply [int; apply int; apply (apply str)])
 
@@ -133,7 +133,7 @@ module rec Print : sig
 end = struct
   let to_string (type s) t x =
     match t with
-    | Int eq -> string_of_int (TypEq.apply eq x)
+    | Int eq -> Int.to_string (TypEq.apply eq x)
     | String eq -> Printf.sprintf "%S" (TypEq.apply eq x)
     | Pair p ->
         let module P = (val p : PAIR with type t = s) in
@@ -168,4 +168,4 @@ let f = function
   | Some _ -> 2
   | None -> 3
 ;;
-print_endline (string_of_int (f (Some (module struct let x = false end))));;
+print_endline (Int.to_string (f (Some (module struct let x = false end))));;

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
@@ -113,7 +113,7 @@ open Typ
 let rec to_string: 'a. 'a Typ.typ -> 'a -> string =
   fun (type s) t x ->
     match (t : s typ) with
-    | Int eq -> string_of_int (TypEq.apply eq x)
+    | Int eq -> Int.to_string (TypEq.apply eq x)
     | String eq -> Printf.sprintf "%S" (TypEq.apply eq x)
     | Pair (module P) ->
         let (x1, x2) = TypEq.apply P.eq x in

--- a/testsuite/tests/typing-labels/mixin.ml
+++ b/testsuite/tests/typing-labels/mixin.ml
@@ -52,7 +52,7 @@ let subst_lambda ~subst_rec ~free ~subst : _ lambda -> _ = function
           ~f:(fun ~key ~data acc ->
                 if Names.mem s used then data::acc else acc) in
       if List.exists used_expr ~f:(fun t -> Names.mem s (free t)) then
-        let name = s ^ string_of_int (next_id ()) in
+        let name = s ^ Int.to_string (next_id ()) in
         `Abs(name,
              subst_rec ~subst:(Subst.add ~key:s ~data:(`Var name) subst) t)
       else

--- a/testsuite/tests/typing-labels/mixin2.ml
+++ b/testsuite/tests/typing-labels/mixin2.ml
@@ -78,7 +78,7 @@ class ['a] lambda_ops (ops : ('a,'a) #ops Lazy.t) =
               ~f:(fun ~key ~data acc ->
                 if Names.mem s used then data::acc else acc) in
           if List.exists used_expr ~f:(fun t -> Names.mem s (!!free t)) then
-            let name = s ^ string_of_int (next_id ()) in
+            let name = s ^ Int.to_string (next_id ()) in
             `Abs(name,
                  !!subst ~sub:(Subst.add ~key:s ~data:(`Var name) sub) t)
           else

--- a/testsuite/tests/typing-labels/mixin3.ml
+++ b/testsuite/tests/typing-labels/mixin3.ml
@@ -75,7 +75,7 @@ let lambda_ops (ops : ('a,'a) #ops Lazy.t) =
               ~f:(fun ~key ~data acc ->
                 if Names.mem s used then data::acc else acc) in
           if List.exists used_expr ~f:(fun t -> Names.mem s (!!free t)) then
-            let name = s ^ string_of_int (next_id ()) in
+            let name = s ^ Int.to_string (next_id ()) in
             `Abs(name,
                  !!subst ~sub:(Subst.add ~key:s ~data:(`Var name) sub) t)
           else

--- a/testsuite/tests/typing-modules-bugs/pr7414_2_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7414_2_bad.ml
@@ -15,7 +15,7 @@ end
 module Int = struct
   type t = int
   let x = 0
-  let show x = string_of_int x
+  let show x = Int.to_string x
 end
 
 module String = struct

--- a/testsuite/tests/typing-modules-bugs/pr7414_bad.ml
+++ b/testsuite/tests/typing-modules-bugs/pr7414_bad.ml
@@ -15,7 +15,7 @@ end
 module Int = struct
   type t = int
   let x = 0
-  let show x = string_of_int x
+  let show x = Int.to_string x
 end
 
 module String = struct

--- a/testsuite/tests/unboxed-primitive-args/common.ml
+++ b/testsuite/tests/unboxed-primitive-args/common.ml
@@ -45,7 +45,7 @@ let expand_test = function
   | T (s, fn, p) -> Test (s, fn, p)
 
 let string_of : type a. a typ -> a -> string = function
-  | Int       -> string_of_int
+  | Int       -> Int.to_string
   | Int32     -> Printf.sprintf "%ldl"
   | Int64     -> Printf.sprintf "%LdL"
   | Nativeint -> Printf.sprintf "%ndn"

--- a/testsuite/tests/utils/edit_distance.ml
+++ b/testsuite/tests/utils/edit_distance.ml
@@ -16,7 +16,7 @@ let test =
   fun a b cutoff expected ->
     let show_result = function
       | None -> "None"
-      | Some d -> "Some " ^ string_of_int d in
+      | Some d -> "Some " ^ Int.to_string d in
     incr counter;
     Printf.printf "[%02d] (edit_distance %S %S %s), expected %s\n"
       !counter a b (show_cutoff cutoff) (show_result expected);

--- a/testsuite/tests/utils/overflow_detection.ml
+++ b/testsuite/tests/utils/overflow_detection.ml
@@ -11,7 +11,7 @@ let print_int i =
   else if i = min_int then
     "min_int"
   else
-    string_of_int i
+    Int.to_string i
 
 let test_no_overflow_add a b =
   Printf.printf "Misc.no_overflow_add %s %s = %b\n"

--- a/testsuite/tests/utils/test_strongly_connected_components.ml
+++ b/testsuite/tests/utils/test_strongly_connected_components.ml
@@ -25,7 +25,7 @@ let print_scc scc =
       | SCC.No_loop e -> Printf.printf "%i\n" e
       | SCC.Has_loop l ->
           Printf.printf "[%s]\n"
-            (String.concat "; " (List.map string_of_int l))) scc;
+            (String.concat "; " (List.map Stdlib.Int.to_string l))) scc;
   Printf.printf "end\n"
 
 let scc graph =

--- a/tools/ocamlcp.ml
+++ b/tools/ocamlcp.ml
@@ -24,7 +24,7 @@ let option_with_arg opt arg =
   compargs := (Filename.quote arg) :: opt :: !compargs
 ;;
 let option_with_int opt arg =
-  compargs := (string_of_int arg) :: opt :: !compargs
+  compargs := (Int.to_string arg) :: opt :: !compargs
 ;;
 
 let make_archive = ref false;;

--- a/tools/ocamloptp.ml
+++ b/tools/ocamloptp.ml
@@ -24,7 +24,7 @@ let option_with_arg opt arg =
   compargs := (Filename.quote arg) :: opt :: !compargs
 ;;
 let option_with_int opt arg =
-  compargs := (string_of_int arg) :: opt :: !compargs
+  compargs := (Int.to_string arg) :: opt :: !compargs
 ;;
 let option_with_float opt arg =
   compargs := (string_of_float arg) :: opt :: !compargs

--- a/tools/ocamlprof.ml
+++ b/tools/ocamlprof.ml
@@ -139,7 +139,7 @@ let final_rewrite add_function =
   List.iter add_function !to_insert;
   copy (in_channel_length !inchan);
   if !instr_mode then begin
-    let len = string_of_int !prof_counter in
+    let len = Int.to_string !prof_counter in
     if String.length len > 9 then raise (Profiler "too many counters");
     seek_out !outchan (!pos_len - String.length len);
     output_string !outchan len

--- a/tools/scrapelabels.ml
+++ b/tools/scrapelabels.ml
@@ -85,7 +85,7 @@ let convert_impl buffer =
         | UIDENT _ | LIDENT _ ->
             dropext (next_token ())
         | _ ->
-            prerr_endline ("bad index at position " ^ string_of_int s);
+            prerr_endline ("bad index at position " ^ Int.to_string s);
             (token, s, e)
         end
     | _ ->
@@ -186,7 +186,7 @@ let convert_impl buffer =
     end
   | Closing _ ->
       prerr_endline ("bad closing token at position " ^
-                     string_of_int (Lexing.lexeme_start buffer));
+                     Int.to_string (Lexing.lexeme_start buffer));
       modified := false
 
 type state = Out | Enter | In | Escape

--- a/typing/ident.ml
+++ b/typing/ident.ml
@@ -60,7 +60,7 @@ let rename = function
 
 let unique_name = function
   | Local { name; stamp }
-  | Scoped { name; stamp } -> name ^ "_" ^ string_of_int stamp
+  | Scoped { name; stamp } -> name ^ "_" ^ Int.to_string stamp
   | Global name ->
       (* we're adding a fake stamp, because someone could have named his unit
          [Foo_123] and since we're using unique_name to produce symbol names,
@@ -73,7 +73,7 @@ let unique_name = function
 
 let unique_toplevel_name = function
   | Local { name; stamp }
-  | Scoped { name; stamp } -> name ^ "/" ^ string_of_int stamp
+  | Scoped { name; stamp } -> name ^ "/" ^ Int.to_string stamp
   | Global name
   | Predef { name; _ } -> name
 

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1871,7 +1871,7 @@ module Conv = struct
   let fresh name =
     let current = !name_counter in
     name_counter := !name_counter + 1;
-    "#$" ^ name ^ string_of_int current
+    "#$" ^ name ^ Int.to_string current
 
   let conv typed =
     let constrs = Hashtbl.create 7 in

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -704,12 +704,12 @@ let rec new_name () =
     if !name_counter < 26
     then String.make 1 (Char.chr(97 + !name_counter))
     else String.make 1 (Char.chr(97 + !name_counter mod 26)) ^
-           string_of_int(!name_counter / 26) in
+           Int.to_string(!name_counter / 26) in
   incr name_counter;
   if name_is_already_used name then new_name () else name
 
 let rec new_weak_name ty () =
-  let name = "weak" ^ string_of_int !weak_counter in
+  let name = "weak" ^ Int.to_string !weak_counter in
   incr weak_counter;
   if name_is_already_used name then new_weak_name ty ()
   else begin
@@ -732,7 +732,7 @@ let name_of_type name_generator t =
           let current_name = ref name in
           let i = ref 0 in
           while List.exists (fun (_, name') -> !current_name = name') !names do
-            current_name := name ^ (string_of_int !i);
+            current_name := name ^ (Int.to_string !i);
             i := !i + 1;
           done;
           !current_name
@@ -873,7 +873,7 @@ let rec tree_of_typexp sch ty =
     match ty.desc with
     | Tvar _ ->
         (*let lev =
-          if is_non_gen sch ty then "/" ^ string_of_int ty.level else "" in*)
+          if is_non_gen sch ty then "/" ^ Int.to_string ty.level else "" in*)
         let non_gen = is_non_gen sch ty in
         let name_gen = if non_gen then new_weak_name ty else new_name in
         Otyp_var (non_gen, name_of_type name_gen ty)

--- a/typing/stypes.ml
+++ b/typing/stypes.ml
@@ -27,7 +27,7 @@ open Lexing;;
 open Location;;
 open Typedtree;;
 
-let output_int oc i = output_string oc (string_of_int i)
+let output_int oc i = output_string oc (Int.to_string i)
 
 type annotation =
   | Ti_pat   of pattern

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1747,7 +1747,7 @@ let type_classes define_class approx kind env cls =
 let class_num = ref 0
 let class_declaration env sexpr =
   incr class_num;
-  let expr = class_expr (string_of_int !class_num) env env sexpr in
+  let expr = class_expr (Int.to_string !class_num) env env sexpr in
   (expr, expr.cl_type)
 
 let class_description env sexpr =
@@ -1815,7 +1815,7 @@ and unify_parents_struct env ty st =
 let type_object env loc s =
   incr class_num;
   let (desc, sign) =
-    class_structure (string_of_int !class_num) true env env loc s in
+    class_structure (Int.to_string !class_num) true env env loc s in
   let sty = Ctype.expand_head env sign.csig_self in
   Ctype.hide_private_methods sty;
   let (fields, _) = Ctype.flatten_fields (Ctype.object_fields sty) in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3358,7 +3358,7 @@ and type_format loc str env =
           | _ :: _ :: _ -> Some (mk_exp_loc (Pexp_tuple args)) in
         mk_exp_loc (Pexp_construct (mk_lid_loc lid, arg)) in
       let mk_cst cst = mk_exp_loc (Pexp_constant cst) in
-      let mk_int n = mk_cst (Pconst_integer (string_of_int n, None))
+      let mk_int n = mk_cst (Pconst_integer (Int.to_string n, None))
       and mk_string str = mk_cst (Pconst_string (str, None))
       and mk_char chr = mk_cst (Pconst_char chr) in
       let rec mk_formatting_lit fmting = match fmting with

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -106,7 +106,7 @@ let map_loc sub {loc; txt} = {loc = sub.location sub loc; txt}
 (** Try a name [$name$0], check if it's free, if not, increment and repeat. *)
 let fresh_name s env =
   let rec aux i =
-    let name = s ^ string_of_int i in
+    let name = s ^ Int.to_string i in
     try
       let _ = Env.lookup_value (Lident name) env in
       name
@@ -120,7 +120,7 @@ let fresh_name s env =
 let constant = function
   | Const_char c -> Pconst_char c
   | Const_string (s,d) -> Pconst_string (s,d)
-  | Const_int i -> Pconst_integer (string_of_int i, None)
+  | Const_int i -> Pconst_integer (Int.to_string i, None)
   | Const_int32 i -> Pconst_integer (Int32.to_string i, Some 'l')
   | Const_int64 i -> Pconst_integer (Int64.to_string i, Some 'L')
   | Const_nativeint i -> Pconst_integer (Nativeint.to_string i, Some 'n')

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -239,7 +239,7 @@ let config_var x =
   | Some v ->
       let s = match v with
         | String s -> s
-        | Int n -> string_of_int n
+        | Int n -> Int.to_string n
         | Bool b -> string_of_bool b
       in
       Some s

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -676,7 +676,7 @@ let help_warnings () =
     | l ->
         Printf.printf "  %c warnings %s.\n"
           (Char.uppercase_ascii c)
-          (String.concat ", " (List.map string_of_int l))
+          (String.concat ", " (List.map Int.to_string l))
   done;
   exit 0
 ;;


### PR DESCRIPTION
Following up on #2011 this ~~deprecate~~ substitutes `string_of_int` in favor of `Int.to_string`. Note that this basically consists in substituing the latter by the former which has, conveniently, exactly the same number of characters.

~~There is however one tricky in `asmcomp/selectgen.ml` since that module defines an `Int` module internally. For some reason trying to use `Stdlib.Int` didn't work at that point (the module is unbound, even though the  `boot` interface seems to have `stdlib.cmi` ?!). Either the `Int` module can be "saved" to another name before `selectgen.ml` defines it own `Int` module or `Stdlib__int` can be used. I chose the later.  If anyones knows a better way please tell.~~ This has been [solved](https://github.com/ocaml/ocaml/pull/2012#issuecomment-417659370).

 