### PR TITLE
MPR7843: ocamldoc, latex: keep text in {{!lbl} text}

### DIFF
--- a/Changes
+++ b/Changes
@@ -206,6 +206,10 @@ Working version
 
 ### Tools
 
+- MPR#7843, GPR#2013: ocamldoc, better handling of {{!label}text} in the latex
+  backend.
+  (Florian Angeletti, review by Nicolás Ojeda Bär and Gabriel Scherer)
+
 - GPR#1711: the new 'open' flag in OCAMLRUNPARAM takes a comma-separated list of
   modules to open as if they had been passed via the command line -open flag.
   (Nicolás Ojeda Bär, review by Mark Shinwell)

--- a/ocamldoc/odoc_latex.ml
+++ b/ocamldoc/odoc_latex.ml
@@ -403,8 +403,12 @@ class text =
            | Some t -> t
            )
       | Some (RK_section _) ->
-          self#latex_of_text_element fmt
-            (Latex ("["^(self#make_ref (self#label ~no_:false (Name.simple name)))^"]"))
+          let text = match text_opt with
+            | None -> []
+            | Some x -> x in
+          let label= self#make_ref (self#label ~no_:false (Name.simple name)) in
+          self#latex_of_text fmt
+            (text @ [Latex ("["^label^"]")] )
       | Some kind ->
           let f_label =
             match kind with

--- a/testsuite/tests/tool-ocamldoc/latex_ref.latex.reference
+++ b/testsuite/tests/tool-ocamldoc/latex_ref.latex.reference
@@ -1,0 +1,27 @@
+\documentclass[11pt]{article} 
+\usepackage[latin1]{inputenc} 
+\usepackage[T1]{fontenc} 
+\usepackage{textcomp}
+\usepackage{fullpage} 
+\usepackage{url} 
+\usepackage{ocamldoc}
+\begin{document}
+\tableofcontents
+\section{Module {\tt{Latex\_ref}} : Latex-only test}
+\label{Latex-underscoreref}\index{Latex-underscoreref@\verb`Latex_ref`}
+
+
+
+
+\ocamldocvspace{0.5cm}
+
+
+
+\subsection*{Title }
+\label{lbl}
+
+
+    Check that this text[\ref{lbl}] is present in the generated latex
+    with a reference to [\ref{lbl}].
+
+\end{document}

--- a/testsuite/tests/tool-ocamldoc/latex_ref.mli
+++ b/testsuite/tests/tool-ocamldoc/latex_ref.mli
@@ -1,0 +1,11 @@
+(* TEST
+   * ocamldoc with latex
+*)
+
+(** Latex-only test *)
+
+(** {1:lbl Title }
+
+    Check that {{!lbl}this text} is present in the generated latex
+    with a reference to {!lbl}.
+*)

--- a/testsuite/tests/tool-ocamldoc/ocamltests
+++ b/testsuite/tests/tool-ocamldoc/ocamltests
@@ -7,6 +7,7 @@ Item_ids.mli
 Paragraph.mli
 Module_whitespace.ml
 No_preamble.mli
+latex_ref.mli
 Level_0.mli
 Linebreaks.mli
 Loop.ml


### PR DESCRIPTION
[MPR7843](https://caml.inria.fr/mantis/view.php?id=7843): Currently ocamldoc latex backend translates `{{!label}text}` to [\ref{label}], discarding the text, if the label points to a (sub)section. Contrarily, the html backend keep the text by translating the ocamldoc markup to `<a href=label> text </a>`. This PR proposes to keep the text associated to the label in the latex mode too:
`{{!label}text}` → `text[\ref{label}]`. 