### PR TITLE
MPR7825: html manual, split compilerlibs from stdlib

### DIFF
--- a/Changes
+++ b/Changes
@@ -242,6 +242,10 @@ Working version
 
 ### Manual and documentation:
 
+- MPR#7825: html manual split compilerlibs from stdlib in the html
+  index of modules
+  (Florian Angeletti, review by Perry E. Metzger and Gabriel Scherer)
+
 - GPR#1209: use the automated caml_example environment in the Extension section,
   which uses the OCaml compiler to check the manual examples.
   This change was made possible by a lot of tooling work from Florian Angeletti:

--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -39,9 +39,9 @@ index:
 	  && makeindex manual.kwd.idx
 
 
-# libref/style.css is used as witness for the generation of the html stdlib
-# reference.
-html: htmlman/libref/style.css etex-files
+# libref/style.css and comilerlibref/style.css are used as witness
+# for the generation of the html stdlib and compilerlibs reference.
+html: htmlman/libref/style.css htmlman/compilerlibref/style.css etex-files
 	cd htmlman \
 	  && $(HEVEA) $(HTML_FLAGS) \
 	    -I .. -I ../cmds -I ../library -I ../refman -I ../tutorials \
@@ -49,12 +49,22 @@ html: htmlman/libref/style.css etex-files
 	    manual.hva -e macros.tex ../manual.tex \
 	  && $(HACHA) -tocter manual.html
 
-htmlman/libref/style.css: style.css $(STDLIB_DEPS)
+htmlman/libref/style.css: style.css $(STDLIB_MLIS)
 	mkdir -p htmlman/libref
 	$(OCAMLDOC) -colorize-code -sort -html \
 	  -d htmlman/libref \
-	  $(DOC_INCLUDES) \
+	  $(DOC_STDLIB_INCLUDES) \
 	  $(STDLIB_MLIS)
+	cp style.css $@
+
+
+htmlman/compilerlibref/style.css: style.css $(COMPILERLIBS_MLIS)
+	mkdir -p htmlman/compilerlibref
+	$(OCAMLDOC) -colorize-code -sort -html \
+	  -d htmlman/compilerlibref \
+	  -I $(SRC)/stdlib \
+	  $(DOC_COMPILERLIBS_INCLUDES) \
+	  $(COMPILERLIBS_MLIS)
 	cp style.css $@
 
 

--- a/manual/manual/htmlman/.gitignore
+++ b/manual/manual/htmlman/.gitignore
@@ -1,6 +1,7 @@
 *.html
 *.haux
 *.hind
+compilerlibref
 libref
 manual.hmanual
 manual.hmanual.kwd

--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -52,10 +52,10 @@ libs: $(FILES)
 # ocamldoc.out is used as witness for the generation of the stdlib tex files to
 # avoid issues with parallel make invocations.
 $(INTF): ocamldoc.out
-ocamldoc.out: $(STDLIB_DEPS)
+ocamldoc.out: $(DOC_ALL_MLIS)
 	$(OCAMLDOC) -latex \
-	  $(DOC_INCLUDES) \
-	  $(STDLIB_MLIS) \
+	  $(DOC_ALL_INCLUDES) \
+	  $(DOC_ALL_MLIS) \
 	  -sepfiles \
 	  -latextitle "1,subsection*" \
 	  -latextitle "2,subsubsection*" \

--- a/manual/manual/library/compilerlibs.etex
+++ b/manual/manual/library/compilerlibs.etex
@@ -28,16 +28,16 @@ type\\*"#load \"compiler-libs/ocamlcommon.cma\";;".
 
 \ifouthtml
 \begin{links}
-\item \ahref{libref/Ast\_helper.html}{Module \texttt{Ast_helper}: helper functions for AST construction}
-\item \ahref{libref/Ast\_mapper.html}{Module \texttt{Ast_mapper}: -ppx rewriter interface}
-\item \ahref{libref/Asttypes.html}{Module \texttt{Asttypes}: auxiliary types used by Parsetree}
-% \item \ahref{libref/Lexer.html}{Module \texttt{Lexer}: OCaml syntax lexing}
-\item \ahref{libref/Location.html}{Module \texttt{Location}: source code locations}
-\item \ahref{libref/Longident.html}{Module \texttt{Longident}: long identifiers}
-\item \ahref{libref/Parse.html}{Module \texttt{Parse}: OCaml syntax parsing}
-\item \ahref{libref/Parsetree.html}{Module \texttt{Parsetree}: OCaml syntax tree}
-\item \ahref{libref/Pprintast.html}{Module \texttt{Pprintast}: OCaml syntax printing}
-% \item \ahref{libref/Printast.html}{Module \texttt{Printast}: AST printing}
+\item \ahref{compilerlibref/Ast\_helper.html}{Module \texttt{Ast_helper}: helper functions for AST construction}
+\item \ahref{compilerlibref/Ast\_mapper.html}{Module \texttt{Ast_mapper}: -ppx rewriter interface}
+\item \ahref{compilerlibref/Asttypes.html}{Module \texttt{Asttypes}: auxiliary types used by Parsetree}
+% \item \ahref{compilerlibref/Lexer.html}{Module \texttt{Lexer}: OCaml syntax lexing}
+\item \ahref{compilerlibref/Location.html}{Module \texttt{Location}: source code locations}
+\item \ahref{compilerlibref/Longident.html}{Module \texttt{Longident}: long identifiers}
+\item \ahref{compilerlibref/Parse.html}{Module \texttt{Parse}: OCaml syntax parsing}
+\item \ahref{compilerlibref/Parsetree.html}{Module \texttt{Parsetree}: OCaml syntax tree}
+\item \ahref{compilerlibref/Pprintast.html}{Module \texttt{Pprintast}: OCaml syntax printing}
+% \item \ahref{compilerlibref/Printast.html}{Module \texttt{Printast}: AST printing}
 \end{links}
 
 \else
@@ -59,11 +59,11 @@ type\\*"#load \"compiler-libs/ocamlcommon.cma\";;".
 \ifouthtml
 The following modules provides hooks for compiler plugins:
 \begin{links}
-\item \ahref{libref/Pparse.html}{Module \texttt{Pparse}: OCaml parser driver}
-\item \ahref{libref/Typemod.html}{Module \texttt{Typemod}:
+\item \ahref{compilerlibref/Pparse.html}{Module \texttt{Pparse}: OCaml parser driver}
+\item \ahref{compilerlibref/Typemod.html}{Module \texttt{Typemod}:
 OCaml module type checking}
-\item \ahref{libref/Simplif.html}{Module \texttt{Simplif}: Lambda simplification}
-\item \ahref{libref/Clflags.html}{Module \texttt{Clflags}: command line flags}
+\item \ahref{compilerlibref/Simplif.html}{Module \texttt{Simplif}: Lambda simplification}
+\item \ahref{compilerlibref/Clflags.html}{Module \texttt{Clflags}: command line flags}
 \end{links}
 \else
 \input{Pparse.tex}

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -402,20 +402,19 @@ SRC=$(ROOTDIR)
 
 include Makefile.docfiles
 
-stdlib_man/Stdlib.3o: $(OCAMLDOC) $(STDLIB_DEPS)
+stdlib_man/Stdlib.3o: $(OCAMLDOC) $(DOC_ALL_MLIS)
 	$(MKDIR) stdlib_man
-	$(OCAMLDOC_RUN) -man -d stdlib_man -nostdlib $(DOC_INCLUDES) \
-	-hide Stdlib  -lib Stdlib \
+	$(OCAMLDOC_RUN) -man -d stdlib_man -nostdlib \
+	-hide Stdlib -lib Stdlib $(DOC_ALL_INCLUDES) \
 	-pp "$(AWK) -v ocamldoc=true -f $(SRC)/stdlib/expand_module_aliases.awk" \
-	-t "OCaml library" -man-mini $(STDLIB_MLIS)
+	-t "OCaml library" -man-mini $(DOC_ALL_MLIS)
 
-stdlib_html/Stdlib.html: $(OCAMLDOC) $(STDLIB_DEPS)
+stdlib_html/Stdlib.html: $(OCAMLDOC) $(DOC_ALL_MLIS)
 	$(MKDIR) stdlib_html
-	$(OCAMLDOC_RUN) \
-	-hide Stdlib -lib Stdlib \
+	$(OCAMLDOC_RUN) -html -d stdlib_html -nostdlib \
+	-hide Stdlib -lib Stdlib $(DOC_ALL_INCLUDES) \
 	-pp "$(AWK) -v ocamldoc=true -f $(SRC)/stdlib/expand_module_aliases.awk" \
-	-d stdlib_html -html -nostdlib $(DOC_INCLUDES) \
-	-t "OCaml library" $(STDLIB_MLIS)
+	-t "OCaml library" $(DOC_ALL_MLIS)
 
 .PHONY: autotest_stdlib
 autotest_stdlib:

--- a/ocamldoc/Makefile.docfiles
+++ b/ocamldoc/Makefile.docfiles
@@ -29,12 +29,21 @@ THREAD_MLIS = $(addprefix $(SRC)/otherlibs/systhreads/, \
   thread.mli condition.mli mutex.mli event.mli threadUnix.mli)
 DRIVER_MLIS = $(SRC)/driver/pparse.mli
 
-DOC_ALL_DIRS = stdlib parsing utils typing bytecomp driver \
+
+DOC_STDLIB_DIRS = stdlib \
 	otherlibs/str \
 	otherlibs/$(UNIXLIB) otherlibs/graphics otherlibs/dynlink \
 	otherlibs/systhreads
 
-DOC_INCLUDES = $(addprefix -I $(SRC)/, $(DOC_ALL_DIRS))
+DOC_COMPILERLIBS_DIRS= parsing utils typing bytecomp driver
+
+DOC_ALL_DIRS = $(DOC_COMPILERLIBS) $(DOC_STDLIB_DIRS)
+
+DOC_STDLIB_INCLUDES = $(addprefix -I $(SRC)/, $(DOC_STDLIB_DIRS))
+DOC_COMPILERLIBS_INCLUDES = $(addprefix -I $(SRC)/, $(DOC_COMPILERLIBS_DIRS))
+
+DOC_ALL_INCLUDES = $(DOC_STDLIB_INCLUDES) $(DOC_COMPILERLIBS_INCLUDES)
+
 
 STDLIB_MODS = $(STDLIB_MODULES:stdlib__%=%)
 
@@ -42,13 +51,17 @@ STDLIB_MOD_WP = $(filter-out stdlib__pervasives, $(STDLIB_MODULES))
 STDLIB_MLI0 = $(SRC)/stdlib/pervasives.ml $(STDLIB_MOD_WP:%=$(SRC)/stdlib/%.mli)
 STDLIB_MLIS=\
   $(STDLIB_MLI0:$(SRC)/stdlib/stdlib__%=$(SRC)/stdlib/%) \
-  $(PARSING_MLIS) \
-  $(UTILS_MLIS) \
-  $(TYPING_MLIS) \
-  $(BYTECOMP_MLIS) \
-  $(DRIVER_MLIS) \
   $(STR_MLIS) \
   $(UNIX_MLIS) \
   $(THREAD_MLIS) \
   $(GRAPHICS_MLIS) \
   $(DYNLINK_MLIS)
+
+COMPILERLIBS_MLIS=\
+  $(PARSING_MLIS) \
+  $(UTILS_MLIS) \
+  $(TYPING_MLIS) \
+  $(BYTECOMP_MLIS) \
+  $(DRIVER_MLIS)
+
+DOC_ALL_MLIS= $(STDLIB_MLIS) $(COMPILERLIBS_MLIS)


### PR DESCRIPTION
[MPR#7825](https://caml.inria.fr/mantis/view.php?id=7825): 
Currently, the global [index](http://caml.inria.fr/pub/docs/manual-ocaml-4.07/libref/index.html) for modules distributed with the compiler is sometimes confusing and frustrating for beginners due the presence of the compiler-libs modules in the index.

This PR proposes to split the html documentation for the `stdlib` + `otherlibs` from the documentation for `compiler-libs`. This results in smaller and more homogeneous indexes: [stdlib index](https://www.polychoron.fr/ocaml-nonmanual/split_index/libref/index.html) and [compiler-libs index](https://www.polychoron.fr/ocaml-nonmanual/split_index/compilerlibref/index.html).

This split comes at the cost of an handful of cross-references from the compiler-libs to the stdlib but I thought the cost reasonable.

In term of implementation, this PR merely splits more explicitly the compiler-libs and stdlib files in `Makefile.docfiles` and generate the compiler-libs documentation in `compilerlibref` rather than `libref`. 