### PR TITLE
MPR7546, manual: preambles and warnings for compiler-libs modules

### DIFF
--- a/Changes
+++ b/Changes
@@ -245,6 +245,9 @@ Working version
 
 ### Manual and documentation:
 
+- MPR#7546: preambles for compiler-libs
+  (Florian Angeletti)
+
 - MPR#7825: html manual split compilerlibs from stdlib in the html
   index of modules
   (Florian Angeletti, review by Perry E. Metzger and Gabriel Scherer)

--- a/Changes
+++ b/Changes
@@ -245,8 +245,9 @@ Working version
 
 ### Manual and documentation:
 
-- MPR#7546: preambles for compiler-libs
-  (Florian Angeletti)
+- MPR#7546, GPR#2020: preambles and introduction for compiler-libs.
+  (Florian Angeletti, review by Daniel Bünzli, Perry E. Metzger
+  and Gabriel Scherer)
 
 - MPR#7825: html manual split compilerlibs from stdlib in the html
   index of modules

--- a/bytecomp/simplif.mli
+++ b/bytecomp/simplif.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Lambda simplification and lambda plugin hooks *)
+(** Lambda simplification and lambda plugin hooks
+
+    Plugins: beware this module makes no compatibility guarantees.
+
+*)
 
 (* Elimination of useless Llet(Alias) bindings.
    Transformation of let-bound references into variables.

--- a/bytecomp/simplif.mli
+++ b/bytecomp/simplif.mli
@@ -15,7 +15,8 @@
 
 (** Lambda simplification and lambda plugin hooks
 
-    Plugins: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/driver/pparse.mli
+++ b/driver/pparse.mli
@@ -15,7 +15,8 @@
 
 (** Driver for the parser, external preprocessors and ast plugin hooks
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/driver/pparse.mli
+++ b/driver/pparse.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Driver for the parser, external preprocessors and ast plugin hooks *)
+(** Driver for the parser, external preprocessors and ast plugin hooks
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 open Format
 

--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -57,13 +57,22 @@ htmlman/libref/style.css: style.css $(STDLIB_MLIS)
 	  $(STDLIB_MLIS)
 	cp style.css $@
 
+COMPILERLIBS_MODULES=$(shell echo $(basename $(notdir $(COMPILERLIBS_MLIS))) \
+| sed "s/\<./\U&/g")
 
-htmlman/compilerlibref/style.css: style.css $(COMPILERLIBS_MLIS)
+library/compiler-libs.txt: library/compiler-libs.mld
+	cp $< $@ && echo "{!modules:$(COMPILERLIBS_MODULES)}" >> $@
+
+
+htmlman/compilerlibref/style.css: library/compiler-libs.txt style.css \
+  $(COMPILERLIBS_MLIS)
 	mkdir -p htmlman/compilerlibref
 	$(OCAMLDOC) -colorize-code -sort -html \
 	  -d htmlman/compilerlibref \
 	  -I $(SRC)/stdlib \
 	  $(DOC_COMPILERLIBS_INCLUDES) \
+          -intro library/compiler-libs.txt \
+          library/compiler-libs.txt \
 	  $(COMPILERLIBS_MLIS)
 	cp style.css $@
 
@@ -153,6 +162,7 @@ clean:
 	$(MAKE) -C refman    clean
 	$(MAKE) -C tutorials clean
 	-rm -f texstuff/*
-	cd htmlman; rm -rf libref index.html manual*.html *.haux *.hind *.svg
+	cd htmlman; rm -rf libref compilerlibref index.html \
+	manual*.html *.haux *.hind *.svg
 	cd textman; rm -f manual.txt *.haux *.hind
 	cd infoman; rm -f ocaml.info ocaml.info-*  *.haux *.hind

--- a/manual/manual/library/.gitignore
+++ b/manual/manual/library/.gitignore
@@ -3,3 +3,5 @@
 arithstatus.mli
 ocamldoc.out
 ocamldoc.sty
+compiler-libs.txt
+

--- a/manual/manual/library/Makefile
+++ b/manual/manual/library/Makefile
@@ -74,3 +74,4 @@ ocamldoc.out: $(DOC_ALL_MLIS)
 .PHONY: clean
 clean:
 	rm -f *.tex ocamldoc.out ocamldoc.sty
+	rm -f compiler-libs.txt

--- a/manual/manual/library/compiler-libs.mld
+++ b/manual/manual/library/compiler-libs.mld
@@ -1,0 +1,9 @@
+{!indexlist}
+
+{1 Warning}
+  This library is part of the internal OCaml compiler API, and is
+not the language standard library.
+  There are no compatibility guarantees between releases, so code written
+against these modules must be willing to depend on specific OCaml compiler
+versions.
+

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -407,14 +407,18 @@ stdlib_man/Stdlib.3o: $(OCAMLDOC) $(DOC_ALL_MLIS)
 	$(OCAMLDOC_RUN) -man -d stdlib_man -nostdlib \
 	-hide Stdlib -lib Stdlib $(DOC_ALL_INCLUDES) \
 	-pp "$(AWK) -v ocamldoc=true -f $(SRC)/stdlib/expand_module_aliases.awk" \
-	-t "OCaml library" -man-mini $(DOC_ALL_MLIS)
+	-t "OCaml library" -man-mini \
+	-text $(SRC)/manual/manual/library/compiler-libs.mld \
+	$(DOC_ALL_MLIS)
 
 stdlib_html/Stdlib.html: $(OCAMLDOC) $(DOC_ALL_MLIS)
 	$(MKDIR) stdlib_html
 	$(OCAMLDOC_RUN) -html -d stdlib_html -nostdlib \
 	-hide Stdlib -lib Stdlib $(DOC_ALL_INCLUDES) \
 	-pp "$(AWK) -v ocamldoc=true -f $(SRC)/stdlib/expand_module_aliases.awk" \
-	-t "OCaml library" $(DOC_ALL_MLIS)
+	-t "OCaml library" \
+	-text $(SRC)/manual/manual/library/compiler-libs.mld \
+	$(DOC_ALL_MLIS)
 
 .PHONY: autotest_stdlib
 autotest_stdlib:

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Helpers to produce Parsetree fragments *)
+(** Helpers to produce Parsetree fragments
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 open Asttypes
 open Docstrings

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -15,7 +15,8 @@
 
 (** Helpers to produce Parsetree fragments
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning} This module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/parsing/ast_invariants.mli
+++ b/parsing/ast_invariants.mli
@@ -12,7 +12,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Check AST invariants *)
+(** Check AST invariants
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 val structure : Parsetree.structure -> unit
 val signature : Parsetree.signature -> unit

--- a/parsing/ast_invariants.mli
+++ b/parsing/ast_invariants.mli
@@ -14,7 +14,8 @@
 
 (** Check AST invariants
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/parsing/ast_iterator.mli
+++ b/parsing/ast_iterator.mli
@@ -15,7 +15,11 @@
 
 (** {!iterator} allows to implement AST inspection using open recursion.  A
     typical mapper would be based on {!default_iterator}, a trivial iterator,
-    and will fall back on it for handling the syntax it does not modify. *)
+    and will fall back on it for handling the syntax it does not modify.
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 open Parsetree
 

--- a/parsing/ast_iterator.mli
+++ b/parsing/ast_iterator.mli
@@ -17,7 +17,8 @@
     typical mapper would be based on {!default_iterator}, a trivial iterator,
     and will fall back on it for handling the syntax it does not modify.
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/parsing/ast_mapper.mli
+++ b/parsing/ast_mapper.mli
@@ -46,6 +46,9 @@ let () =
   the constant [42], can be compiled using
   [ocamlc -o ppx_test -I +compiler-libs ocamlcommon.cma ppx_test.ml].
 
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
+
   *)
 
 open Parsetree

--- a/parsing/asttypes.mli
+++ b/parsing/asttypes.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Auxiliary AST types used by parsetree and typedtree. *)
+(** Auxiliary AST types used by parsetree and typedtree.
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 type constant =
     Const_int of int

--- a/parsing/asttypes.mli
+++ b/parsing/asttypes.mli
@@ -15,7 +15,8 @@
 
 (** Auxiliary AST types used by parsetree and typedtree.
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/parsing/attr_helper.mli
+++ b/parsing/attr_helper.mli
@@ -15,7 +15,8 @@
 
 (** Helpers for attributes
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/parsing/attr_helper.mli
+++ b/parsing/attr_helper.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Helpers for attributes *)
+(** Helpers for attributes
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 open Asttypes
 open Parsetree

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -13,18 +13,21 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Support for some of the builtin attributes:
+(** Support for some of the builtin attributes
 
-   ocaml.deprecated
-   ocaml.error
-   ocaml.ppwarning
-   ocaml.warning
-   ocaml.warnerror
-   ocaml.explicit_arity (for camlp4/camlp5)
-   ocaml.warn_on_literal_pattern
-   ocaml.deprecated_mutable
-   ocaml.immediate
-   ocaml.boxed / ocaml.unboxed
+    - ocaml.deprecated
+    - ocaml.error
+    - ocaml.ppwarning
+    - ocaml.warning
+    - ocaml.warnerror
+    - ocaml.explicit_arity (for camlp4/camlp5)
+    - ocaml.warn_on_literal_pattern
+    - ocaml.deprecated_mutable
+    - ocaml.immediate
+    - ocaml.boxed / ocaml.unboxed
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
 *)
 
 

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -26,7 +26,8 @@
     - ocaml.immediate
     - ocaml.boxed / ocaml.unboxed
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+    {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/parsing/depend.mli
+++ b/parsing/depend.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Module dependencies. *)
+(** Module dependencies.
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+*)
+
 module String = Misc.Stdlib.String
 
 type map_tree = Node of String.Set.t * bound_map
@@ -24,7 +28,7 @@ val weaken_map : String.Set.t -> map_tree -> map_tree
 
 val free_structure_names : String.Set.t ref
 
-(* dependencies found by preprocessing tools (plugins) *)
+(** dependencies found by preprocessing tools (plugins) *)
 val pp_deps : string list ref
 
 val open_module : bound_map -> Longident.t -> bound_map

--- a/parsing/depend.mli
+++ b/parsing/depend.mli
@@ -15,7 +15,9 @@
 
 (** Module dependencies.
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
+
 *)
 
 module String = Misc.Stdlib.String

--- a/parsing/docstrings.mli
+++ b/parsing/docstrings.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Documentation comments *)
+(** Documentation comments
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 (** (Re)Initialise all docstring state *)
 val init : unit -> unit

--- a/parsing/docstrings.mli
+++ b/parsing/docstrings.mli
@@ -15,7 +15,8 @@
 
 (** Documentation comments
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* The lexical analyzer *)
+(** The lexical analyzer
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 val init : unit -> unit
 val token: Lexing.lexbuf -> Parser.token

--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -15,7 +15,8 @@
 
 (** The lexical analyzer
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -15,7 +15,8 @@
 
 (** {1 Source code locations (ranges of positions), used in parsetree}
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** {1 Source code locations (ranges of positions), used in parsetree} *)
+(** {1 Source code locations (ranges of positions), used in parsetree}
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 open Format
 

--- a/parsing/longident.mli
+++ b/parsing/longident.mli
@@ -15,7 +15,8 @@
 
 (** Long identifiers, used in parsetree.
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/parsing/longident.mli
+++ b/parsing/longident.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Long identifiers, used in parsetree. *)
+(** Long identifiers, used in parsetree.
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 type t =
     Lident of string

--- a/parsing/parse.mli
+++ b/parsing/parse.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Entry points in the parser *)
+(** Entry points in the parser
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 val implementation : Lexing.lexbuf -> Parsetree.structure
 val interface : Lexing.lexbuf -> Parsetree.signature

--- a/parsing/parse.mli
+++ b/parsing/parse.mli
@@ -15,7 +15,8 @@
 
 (** Entry points in the parser
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Abstract syntax tree produced by parsing *)
+(** Abstract syntax tree produced by parsing
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 open Asttypes
 

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -15,7 +15,8 @@
 
 (** Abstract syntax tree produced by parsing
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/parsing/pprintast.mli
+++ b/parsing/pprintast.mli
@@ -16,7 +16,8 @@
 
 (** Pretty-printers for {!Parsetree}
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/parsing/pprintast.mli
+++ b/parsing/pprintast.mli
@@ -13,6 +13,13 @@
 (*                                                                        *)
 (**************************************************************************)
 
+
+(** Pretty-printers for {!Parsetree}
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
+
 type space_formatter = (unit, Format.formatter, unit) format
 
 val longident : Format.formatter -> Longident.t -> unit

--- a/parsing/printast.mli
+++ b/parsing/printast.mli
@@ -15,7 +15,8 @@
 
 (** Raw printer for {!Parsetree}
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/parsing/printast.mli
+++ b/parsing/printast.mli
@@ -13,6 +13,12 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Raw printer for {!Parsetree}
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
+
 open Parsetree;;
 open Format;;
 

--- a/parsing/syntaxerr.mli
+++ b/parsing/syntaxerr.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Auxiliary type for reporting syntax errors *)
+(** Auxiliary type for reporting syntax errors
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 open Format
 

--- a/parsing/syntaxerr.mli
+++ b/parsing/syntaxerr.mli
@@ -15,7 +15,8 @@
 
 (** Auxiliary type for reporting syntax errors
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Type-checking of the module language and typed ast plugin hooks *)
+(** Type-checking of the module language and typed ast plugin hooks
+
+    Plugins: beware this module makes no compatibility guarantees.
+
+*)
 
 open Types
 open Format

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -15,7 +15,8 @@
 
 (** Type-checking of the module language and typed ast plugin hooks
 
-    Plugins: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/utils/arg_helper.mli
+++ b/utils/arg_helper.mli
@@ -20,7 +20,8 @@
     (as used for example for the specification of inlining parameters
     varying by simplification round).
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/utils/arg_helper.mli
+++ b/utils/arg_helper.mli
@@ -16,8 +16,12 @@
 
 (** Decipher command line arguments of the form
         <value> | <key>=<value>[,...]
+
     (as used for example for the specification of inlining parameters
     varying by simplification round).
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
 *)
 
 module Make (S : sig

--- a/utils/build_path_prefix_map.mli
+++ b/utils/build_path_prefix_map.mli
@@ -13,6 +13,13 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Rewrite paths for reproducible builds
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
+
+
 type path = string
 type path_prefix = string
 type error_message = string

--- a/utils/build_path_prefix_map.mli
+++ b/utils/build_path_prefix_map.mli
@@ -15,7 +15,8 @@
 
 (** Rewrite paths for reproducible builds
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/utils/ccomp.mli
+++ b/utils/ccomp.mli
@@ -15,7 +15,8 @@
 
 (** Compiling C files and building C libraries
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/utils/ccomp.mli
+++ b/utils/ccomp.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Compiling C files and building C libraries *)
+(** Compiling C files and building C libraries
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 val command: string -> int
 val run_command: string -> unit

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -13,184 +13,235 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* System configuration *)
+(** System configuration
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+*)
 
 val version: string
-        (* The current version number of the system *)
+(** The current version number of the system *)
 
 val standard_library: string
-        (* The directory containing the standard libraries *)
+(** The directory containing the standard libraries *)
+
 val standard_runtime: string
-        (* The full path to the standard bytecode interpreter ocamlrun *)
+(** The full path to the standard bytecode interpreter ocamlrun *)
+
 val ccomp_type: string
-        (* The "kind" of the C compiler, assembler and linker used: one of
-               "cc" (for Unix-style C compilers)
-               "msvc" (for Microsoft Visual C++ and MASM) *)
+(** The "kind" of the C compiler, assembler and linker used: one of
+    "cc" (for Unix-style C compilers)
+    "msvc" (for Microsoft Visual C++ and MASM) *)
+
 val c_compiler: string
-        (* The compiler to use for compiling C files *)
+(** The compiler to use for compiling C files *)
+
 val c_output_obj: string
-        (* Name of the option of the C compiler for specifying the output
-           file *)
+(** Name of the option of the C compiler for specifying the output
+    file *)
+
 val c_has_debug_prefix_map : bool
-        (* Whether the C compiler supports -fdebug-prefix-map *)
+(** Whether the C compiler supports -fdebug-prefix-map *)
+
 val as_has_debug_prefix_map : bool
-        (* Whether the assembler supports --debug-prefix-map *)
+(** Whether the assembler supports --debug-prefix-map *)
+
 val ocamlc_cflags : string
-        (* The flags ocamlc should pass to the C compiler *)
+(** The flags ocamlc should pass to the C compiler *)
+
 val ocamlc_cppflags : string
-        (* The flags ocamlc should pass to the C preprocessor *)
+(** The flags ocamlc should pass to the C preprocessor *)
+
 val ocamlopt_cflags : string
-        (* The flags ocamlopt should pass to the C compiler *)
+(** The flags ocamlopt should pass to the C compiler *)
+
 val ocamlopt_cppflags : string
-        (* The flags ocamlopt should pass to the C preprocessor *)
+(** The flags ocamlopt should pass to the C preprocessor *)
+
 val bytecomp_c_libraries: string
-        (* The C libraries to link with custom runtimes *)
+(** The C libraries to link with custom runtimes *)
+
 val native_c_libraries: string
-        (* The C libraries to link with native-code programs *)
+(** The C libraries to link with native-code programs *)
+
 val native_pack_linker: string
-        (* The linker to use for packaging (ocamlopt -pack) and for partial
-           links (ocamlopt -output-obj). *)
+(** The linker to use for packaging (ocamlopt -pack) and for partial
+    links (ocamlopt -output-obj). *)
+
 val mkdll: string
-        (* The linker command line to build dynamic libraries. *)
+(** The linker command line to build dynamic libraries. *)
+
 val mkexe: string
-        (* The linker command line to build executables. *)
+(** The linker command line to build executables. *)
+
 val mkmaindll: string
-        (* The linker command line to build main programs as dlls. *)
+(** The linker command line to build main programs as dlls. *)
+
 val ranlib: string
-        (* Command to randomize a library, or "" if not needed *)
+(** Command to randomize a library, or "" if not needed *)
+
 val ar: string
-        (* Name of the ar command, or "" if not needed  (MSVC) *)
+(** Name of the ar command, or "" if not needed  (MSVC) *)
+
 val cc_profile : string
-        (* The command line option to the C compiler to enable profiling. *)
+(** The command line option to the C compiler to enable profiling. *)
 
 val load_path: string list ref
-        (* Directories in the search path for .cmi and .cmo files *)
+(** Directories in the search path for .cmi and .cmo files *)
 
 val interface_suffix: string ref
-        (* Suffix for interface file names *)
+(** Suffix for interface file names *)
 
 val exec_magic_number: string
-        (* Magic number for bytecode executable files *)
+(** Magic number for bytecode executable files *)
+
 val cmi_magic_number: string
-        (* Magic number for compiled interface files *)
+(** Magic number for compiled interface files *)
+
 val cmo_magic_number: string
-        (* Magic number for object bytecode files *)
+(** Magic number for object bytecode files *)
+
 val cma_magic_number: string
-        (* Magic number for archive files *)
+(** Magic number for archive files *)
+
 val cmx_magic_number: string
-        (* Magic number for compilation unit descriptions *)
+(** Magic number for compilation unit descriptions *)
+
 val cmxa_magic_number: string
-        (* Magic number for libraries of compilation unit descriptions *)
+(** Magic number for libraries of compilation unit descriptions *)
+
 val ast_intf_magic_number: string
-        (* Magic number for file holding an interface syntax tree *)
+(** Magic number for file holding an interface syntax tree *)
+
 val ast_impl_magic_number: string
-        (* Magic number for file holding an implementation syntax tree *)
+(** Magic number for file holding an implementation syntax tree *)
+
 val cmxs_magic_number: string
-        (* Magic number for dynamically-loadable plugins *)
+(** Magic number for dynamically-loadable plugins *)
+
 val cmt_magic_number: string
-        (* Magic number for compiled interface files *)
+(** Magic number for compiled interface files *)
 
 val max_tag: int
-        (* Biggest tag that can be stored in the header of a regular block. *)
+(** Biggest tag that can be stored in the header of a regular block. *)
+
 val lazy_tag : int
-        (* Normally the same as Obj.lazy_tag.  Separate definition because
-           of technical reasons for bootstrapping. *)
+(** Normally the same as Obj.lazy_tag.  Separate definition because
+    of technical reasons for bootstrapping. *)
+
 val max_young_wosize: int
-        (* Maximal size of arrays that are directly allocated in the
-           minor heap *)
+(** Maximal size of arrays that are directly allocated in the
+    minor heap *)
+
 val stack_threshold: int
-        (* Size in words of safe area at bottom of VM stack,
-           see runtime/caml/config.h *)
+(** Size in words of safe area at bottom of VM stack,
+    see runtime/caml/config.h *)
+
 val stack_safety_margin: int
-        (* Size in words of the safety margin between the bottom of
-           the stack and the stack pointer. This margin can be used by
-           intermediate computations of some instructions, or the event
-           handler. *)
+(** Size in words of the safety margin between the bottom of
+    the stack and the stack pointer. This margin can be used by
+    intermediate computations of some instructions, or the event
+    handler. *)
 
 val architecture: string
-        (* Name of processor type for the native-code compiler *)
+(** Name of processor type for the native-code compiler *)
+
 val model: string
-        (* Name of processor submodel for the native-code compiler *)
+(** Name of processor submodel for the native-code compiler *)
+
 val system: string
-        (* Name of operating system for the native-code compiler *)
+(** Name of operating system for the native-code compiler *)
 
 val asm: string
-        (* The assembler (and flags) to use for assembling
-           ocamlopt-generated code. *)
+(** The assembler (and flags) to use for assembling
+    ocamlopt-generated code. *)
 
 val asm_cfi_supported: bool
-        (* Whether assembler understands CFI directives *)
+(** Whether assembler understands CFI directives *)
+
 val with_frame_pointers : bool
-        (* Whether assembler should maintain frame pointers *)
+(** Whether assembler should maintain frame pointers *)
 
 val ext_obj: string
-        (* Extension for object files, e.g. [.o] under Unix. *)
+(** Extension for object files, e.g. [.o] under Unix. *)
+
 val ext_asm: string
-        (* Extension for assembler files, e.g. [.s] under Unix. *)
+(** Extension for assembler files, e.g. [.s] under Unix. *)
+
 val ext_lib: string
-        (* Extension for library files, e.g. [.a] under Unix. *)
+(** Extension for library files, e.g. [.a] under Unix. *)
+
 val ext_dll: string
-        (* Extension for dynamically-loaded libraries, e.g. [.so] under Unix.*)
+(** Extension for dynamically-loaded libraries, e.g. [.so] under Unix.*)
 
 val default_executable_name: string
-        (* Name of executable produced by linking if none is given with -o,
-           e.g. [a.out] under Unix. *)
+(** Name of executable produced by linking if none is given with -o,
+    e.g. [a.out] under Unix. *)
 
 val systhread_supported : bool
-        (* Whether the system thread library is implemented *)
+(** Whether the system thread library is implemented *)
 
 val flexdll_dirs : string list
-        (* Directories needed for the FlexDLL objects *)
+(** Directories needed for the FlexDLL objects *)
 
 val host : string
-        (* Whether the compiler is a cross-compiler *)
+(** Whether the compiler is a cross-compiler *)
 
 val target : string
-        (* Whether the compiler is a cross-compiler *)
+(** Whether the compiler is a cross-compiler *)
 
 val profiling : bool
-        (* Whether profiling with gprof is supported on this platform *)
+(** Whether profiling with gprof is supported on this platform *)
 
 val flambda : bool
-        (* Whether the compiler was configured for flambda *)
+(** Whether the compiler was configured for flambda *)
+
 val with_flambda_invariants : bool
-        (* Whether the invariants checks for flambda are enabled *)
+(** Whether the invariants checks for flambda are enabled *)
 
 val spacetime : bool
-        (* Whether the compiler was configured for Spacetime profiling *)
+(** Whether the compiler was configured for Spacetime profiling *)
+
 val enable_call_counts : bool
-        (* Whether call counts are to be available when Spacetime profiling *)
+(** Whether call counts are to be available when Spacetime profiling *)
+
 val profinfo : bool
-        (* Whether the compiler was configured for profiling *)
+(** Whether the compiler was configured for profiling *)
+
 val profinfo_width : int
-        (* How many bits are to be used in values' headers for profiling
-           information *)
+(** How many bits are to be used in values' headers for profiling
+    information *)
+
 val libunwind_available : bool
-        (* Whether the libunwind library is available on the target *)
+(** Whether the libunwind library is available on the target *)
+
 val libunwind_link_flags : string
-        (* Linker flags to use libunwind *)
+(** Linker flags to use libunwind *)
 
 val safe_string: bool
-        (* Whether the compiler was configured with -force-safe-string;
-           in that case, the -unsafe-string compile-time option is unavailable
+(** Whether the compiler was configured with -force-safe-string;
+    in that case, the -unsafe-string compile-time option is unavailable
 
-           @since 4.05.0 *)
+    @since 4.05.0 *)
+
 val default_safe_string: bool
-        (* Whether the compiler was configured to use the -safe-string
-           or -unsafe-string compile-time option by default.
+(** Whether the compiler was configured to use the -safe-string
+    or -unsafe-string compile-time option by default.
 
-           @since 4.06.0 *)
+    @since 4.06.0 *)
+
 val flat_float_array : bool
-        (* Whether the compiler and runtime automagically flatten float
-           arrays *)
+(** Whether the compiler and runtime automagically flatten float
+    arrays *)
+
 val windows_unicode: bool
-        (* Whether Windows Unicode runtime is enabled *)
+(** Whether Windows Unicode runtime is enabled *)
+
 val afl_instrument : bool
-        (* Whether afl-fuzz instrumentation is generated by default *)
+(** Whether afl-fuzz instrumentation is generated by default *)
 
 
-(* Access to configuration values *)
-val print_config : out_channel -> unit;;
+(** Access to configuration values *)
+val print_config : out_channel -> unit
 
-val config_var : string -> string option;;
-        (* the configuration value of a variable, if it exists *)
+val config_var : string -> string option
+(** the configuration value of a variable, if it exists *)

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -15,7 +15,9 @@
 
 (** System configuration
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
+
 *)
 
 val version: string

--- a/utils/consistbl.mli
+++ b/utils/consistbl.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Consistency tables: for checking consistency of module CRCs *)
+(** Consistency tables: for checking consistency of module CRCs
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 type t
 

--- a/utils/consistbl.mli
+++ b/utils/consistbl.mli
@@ -15,7 +15,8 @@
 
 (** Consistency tables: for checking consistency of module CRCs
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/utils/identifiable.mli
+++ b/utils/identifiable.mli
@@ -16,7 +16,8 @@
 
 (** Uniform interface for common data structures over various things.
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/utils/identifiable.mli
+++ b/utils/identifiable.mli
@@ -14,7 +14,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Uniform interface for common data structures over various things. *)
+(** Uniform interface for common data structures over various things.
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 module type Thing = sig
   type t

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Miscellaneous useful types and functions *)
+(** Miscellaneous useful types and functions
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 val fatal_error: string -> 'a
 val fatal_errorf: ('a, Format.formatter, unit, 'b) format4 -> 'a

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -15,7 +15,8 @@
 
 (** Miscellaneous useful types and functions
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/utils/numbers.mli
+++ b/utils/numbers.mli
@@ -14,7 +14,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Modules about numbers, some of which satisfy {!Identifiable.S}. *)
+(** Modules about numbers, some of which satisfy {!Identifiable.S}.
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 module Int : sig
   include Identifiable.S with type t = int

--- a/utils/numbers.mli
+++ b/utils/numbers.mli
@@ -16,7 +16,8 @@
 
 (** Modules about numbers, some of which satisfy {!Identifiable.S}.
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/utils/profile.mli
+++ b/utils/profile.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Compiler performance recording *)
+(** Compiler performance recording
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 type file = string
 

--- a/utils/profile.mli
+++ b/utils/profile.mli
@@ -15,7 +15,8 @@
 
 (** Compiler performance recording
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/utils/strongly_connected_components.mli
+++ b/utils/strongly_connected_components.mli
@@ -16,7 +16,8 @@
 
 (** Kosaraju's algorithm for strongly connected components.
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/utils/strongly_connected_components.mli
+++ b/utils/strongly_connected_components.mli
@@ -14,7 +14,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Kosaraju's algorithm for strongly connected components. *)
+(** Kosaraju's algorithm for strongly connected components.
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 module type S = sig
   module Id : Identifiable.S

--- a/utils/targetint.mli
+++ b/utils/targetint.mli
@@ -23,6 +23,9 @@
    pointer type in the C compiler.  All arithmetic operations over
    are taken modulo 2{^32} or 2{^64} depending
    on the word size of the target architecture.
+
+   Compiler-libs: beware this module makes no compatibility guarantees.
+
 *)
 
 type t

--- a/utils/targetint.mli
+++ b/utils/targetint.mli
@@ -24,7 +24,8 @@
    are taken modulo 2{^32} or 2{^64} depending
    on the word size of the target architecture.
 
-   Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/utils/terminfo.mli
+++ b/utils/terminfo.mli
@@ -13,7 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Basic interface to the terminfo database *)
+(** Basic interface to the terminfo database
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
 
 type status =
   | Uninitialised

--- a/utils/terminfo.mli
+++ b/utils/terminfo.mli
@@ -15,7 +15,8 @@
 
 (** Basic interface to the terminfo database
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -15,7 +15,8 @@
 
 (** Warning definitions
 
-    Compiler-libs: beware this module makes no compatibility guarantees.
+  {b Warning:} this module is unstable and part of
+  {{!Compiler-libs}compiler-libs}.
 
 *)
 

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -13,6 +13,12 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Warning definitions
+
+    Compiler-libs: beware this module makes no compatibility guarantees.
+
+*)
+
 type loc = {
   loc_start: Lexing.position;
   loc_end: Lexing.position;


### PR DESCRIPTION
This PR ensures that all non-generated and non-internal compiler-libs modules available in the manual
are introduced by a short preamble. It also adds some words of caution on the instability of those module interfaces  as suggested by @gasche  in #2017  .  Finally, it exposes some preexisting documentation comments, notably in `Config` .