### PR TITLE
fix_index.sh: fix a bug, and convert from using "ed" to "sed"

### DIFF
--- a/manual/README.md
+++ b/manual/README.md
@@ -6,8 +6,6 @@ Prerequisites
 
 - Any prerequisites required to build OCaml from sources.
 
-- The Unix editor 'ed', no longer installed by default on some systems.
-
 - A LaTeX installation.
 
 - The HeVeA LaTeX-to-HTML convertor (available in OPAM):

--- a/manual/tools/fix_index.sh
+++ b/manual/tools/fix_index.sh
@@ -39,14 +39,13 @@ case $# in
   *) usage;;
 esac
 
-ed "$1" <<'EOF'
-/-pipe-pipe/s/verb`("|hyperindexformat{\\"}/verb`("|"|)`|hyperpage/
-/-pipe-gt/s/verb`("|hyperindexformat{\\>)`}/verb`("|>)`|hyperpage/
-w
-q
-EOF
+sed < "$1" > "$1.new" \
+    -e 's/verb`("|hyperindexformat{\\"}/verb`("|"|)`|hyperpage/' \
+    -e 's/verb`("|hyperindexformat{\\>)`}/verb`("|>)`|hyperpage/'
 
 case $? in
   0) echo "fix_index.sh: fixed $1 successfully.";;
-  *) echo "fix_index.sh: some error occurred."; exit 0;;
+  *) echo "fix_index.sh: some error occurred."; exit 1;;
 esac
+
+mv "$1.new" "$1"


### PR DESCRIPTION
The manual build was broken for me. This fixes it. I can't explain why
the CI system wasn't complaining. [Edited to note: I'm told that the
CI system doesn't actually check the manual build, which seems like
a problem to me.]

Before, the ed script was only fixing the first instance of the
target lines it encountered, leaving second instances that were not
fixed. Rather than fixing the ed script, I've converted this to sed,
which means one less dependency for the build.

Sadly, although almost every modern sed has the -i flag for in-place
fixes, it isn't in POSIX, so I did a kludgy "sed into a .new file,
move back" hack.