### PR TITLE
Split the AppVeyor build into two jobs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,12 @@ environment:
     CYG_CACHE: C:/cygwin64/var/cache/setup
     FLEXDLL_VERSION: 0.37
     OCAMLRUNPARAM: v=0,b
+  matrix:
+    - PORT: mingw32
+    - PORT: msvc64
+
+matrix:
+  fast_finish: true
 
 cache:
   - C:\cygwin64\var\cache\setup


### PR DESCRIPTION
Just for those who are wondering, AppVeyor performs the following:
 - msvc64 build on VS2015 (with binary FlexDLL distribution)
 - mingw32 build (with bootstrapped FlexDLL from submodule)
 - msvc32 runtime + C stubs build on Windows SDK 7.1 (VS2010, with binary FlexDLL distribution)
 - testsuite on msvc64
 - testsuite on mingw32
 - check_all_arches on msvc64

In #1388, I attempted to improve the build by running the mingw32 and msvc64 builds in parallel. It's never been entirely stable and, for reasons unknown, building and testing is now frequently hitting the 1hr limit if AppVeyor is under load.

This GPR moves the mingw32 parts to one job and the msvc64/msvc32 parts to another. The two jobs run in sequence, but the failure of one will instantly cancel/deschedule the next.

This will hopefully reduce the number of timeouts we've been seeing.