### PR TITLE
[WIP] Deprecated optional arguments

### DIFF
--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -35,6 +35,12 @@ val check_deprecated_inclusion:
 val deprecated_of_attrs: Parsetree.attributes -> string option
 val deprecated_of_sig: Parsetree.signature -> string option
 val deprecated_of_str: Parsetree.structure -> string option
+val deprecated_arguments_of_attrs:
+  Parsetree.attributes -> (bool * string * string) list
+    (* (b, label, message)
+       b = true -> warn if argument is passed
+       b = false -> warn if argument is missing
+    *)
 
 val check_deprecated_mutable:
     Location.t -> Parsetree.attributes -> string -> unit


### PR DESCRIPTION
Following a discussion on the caml-list, this is a POC for marking optional arguments as deprecated.  This is intended to help library evolves their API when adding/removing optional arguments, or turning optional arguments into mandatory ones.  For now, the annotation must be on the function declaration:

````ocaml
  val foo: ?x: int -> ?y: int -> unit -> unit
  [@@deprecated_argument x "Please do not use x anymore..."]
  [@@deprecated_missing_argument y "Please pass y explicitly!"]
````

cc @garrigue 