### PR TITLE
Create an explicit "approval right" for reviewers to participate in PR decisions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -33,6 +33,22 @@ Jeremy Yallop <yallop@gmail.com> yallop <yallop@gmail.com>
 Nicolás Ojeda Bär <n.oje.bar@gmail.com>
 
 
+### Approved Approvers
+
+# The current policy to handle pull requests for the compiler
+# distribution is to merge a PR only it has been "approved" by someone
+# who is not an author of the PR and has the "approver" status, by
+# either
+# (1) having been given commit rights, or
+# (2) being part of the list of "approvers" below.
+#
+# Format:
+#
+#   Preferred Name <nickname>
+
+Gabriel Radanne <Drup>
+
+
 ### Remembering naming preferences for contributors
 
 # The aliases below correspond to preference expressed by

--- a/.mailmap
+++ b/.mailmap
@@ -11,6 +11,9 @@
 # of commits erroneously made under an obscure alias or email adress.
 # (Some Name <some@name.com>, pour ne pas le citer)
 
+
+### Normalizing information for frequent git commit authors
+
 Alain Frisch <alain@frisch.fr> alainfrisch <alain@frisch.fr>
 <damien.doligez@inria.fr> <damien.doligez-inria.fr>
 <damien.doligez@inria.fr> <damien.doligez@gmail.com>
@@ -28,6 +31,9 @@ Mohamed Iguernelala <mohamed.iguernelala@gmail.com>
 Jérémie Dimino <jdimino@janestreet.com>
 Jeremy Yallop <yallop@gmail.com> yallop <yallop@gmail.com>
 Nicolás Ojeda Bär <n.oje.bar@gmail.com>
+
+
+### Remembering naming preferences for contributors
 
 # The aliases below correspond to preference expressed by
 # contributors on the name under which they credited, for example


### PR DESCRIPTION
Before this PR, the general development policy for compiler-distribution PR was that, to be merged, a PR had to be "approved" by someone with commit rights (as a proxy for: trusted judgment on evaluating codebase changes).

Approving a PR means that one is confident that a change is good; approvers are publicizing their trust in the fact that the proposed change will improve the codebase rather than worsen it, and taking a part of responsibility. Typically, one approves only after having had given the proposed change a thorough review, and ensuring that appropriate quality-checking processes have been followed. Finally, the same sort of people also has the shared responsibility to sometimes say "no, I don't like the current proposal", and sometime suggest changes that would be necessary for them to approve.

This PR introduces an official "approver" status, so that non-maintainers whose main contribution to the compiler distribution is to review pull requests, instead of creating such pull requests themselves, can keep helping decisions on pull requests in some more official capacity.

Finally, Gabriel @Drup Radanne is inserted in this list of people.

(Github doesn't support this particular notion so, instead of using github metadata, I will be using the `.mailmap` file which already contains contributors-related information to store this information.)