### PR TITLE
parser.mly: consistently use $sloc over $loc

### DIFF
--- a/boot/menhir/parser.ml
+++ b/boot/menhir/parser.ml
@@ -1229,7 +1229,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2911 "parsing/parser.mly"
+# 2901 "parsing/parser.mly"
                                                 ( "+" )
 # 1235 "parsing/parser.ml"
          in
@@ -1254,7 +1254,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2912 "parsing/parser.mly"
+# 2902 "parsing/parser.mly"
                                                 ( "+." )
 # 1260 "parsing/parser.ml"
          in
@@ -1279,7 +1279,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.core_type list) = 
-# 2646 "parsing/parser.mly"
+# 2636 "parsing/parser.mly"
                                                 ( [_1] )
 # 1285 "parsing/parser.ml"
          in
@@ -1316,7 +1316,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.core_type list) = 
-# 2647 "parsing/parser.mly"
+# 2637 "parsing/parser.mly"
                                                 ( _3 :: _1 )
 # 1322 "parsing/parser.ml"
          in
@@ -1385,32 +1385,24 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 1402 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 1394 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__7_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1207 "parsing/parser.mly"
+# 1197 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         let text = symbol_text _symbolstartpos in
         Ci.mk _5 _6 ~virt:_3 ~params:_4
                     ~attrs:(_2@_7) ~loc:(make_loc _sloc) ~text ~docs )
-# 1414 "parsing/parser.ml"
+# 1406 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -1469,7 +1461,7 @@ module Tables = struct
         let _10 : (
 # 578 "parsing/parser.mly"
        (string)
-# 1473 "parsing/parser.ml"
+# 1465 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _4 : ((Parsetree.core_type * Asttypes.variance) list) = Obj.magic _4 in
         let _3 : (Asttypes.virtual_flag) = Obj.magic _3 in
@@ -1483,32 +1475,24 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 1500 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 1484 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__8_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1478 "parsing/parser.mly"
+# 1468 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         let text = symbol_text _symbolstartpos in
         Ci.mk _5 _7 ~virt:_3 ~params:_4
                     ~attrs:(_2@_8) ~loc:(make_loc _sloc) ~text ~docs )
-# 1512 "parsing/parser.ml"
+# 1496 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -1567,7 +1551,7 @@ module Tables = struct
         let _10 : (
 # 578 "parsing/parser.mly"
        (string)
-# 1571 "parsing/parser.ml"
+# 1555 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _4 : ((Parsetree.core_type * Asttypes.variance) list) = Obj.magic _4 in
         let _3 : (Asttypes.virtual_flag) = Obj.magic _3 in
@@ -1581,32 +1565,24 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 1598 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 1574 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__8_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1501 "parsing/parser.mly"
+# 1491 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         let text = symbol_text _symbolstartpos in
         Ci.mk _5 _7 ~virt:_3 ~params:_4
                     ~attrs:(_2@_8) ~loc:(make_loc _sloc) ~text ~docs )
-# 1610 "parsing/parser.ml"
+# 1586 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -1650,9 +1626,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1944 "parsing/parser.mly"
+# 1934 "parsing/parser.mly"
       ( mklb ~loc:_sloc false _3 (_2@_4) )
-# 1656 "parsing/parser.ml"
+# 1632 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -1695,7 +1671,7 @@ module Tables = struct
         let _10 : (
 # 624 "parsing/parser.mly"
        (string)
-# 1699 "parsing/parser.ml"
+# 1675 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _2 : (Parsetree.attributes) = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
@@ -1707,31 +1683,23 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 1724 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 1692 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__5_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1031 "parsing/parser.mly"
+# 1021 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         let text = symbol_text _symbolstartpos in
         Mb.mk _3 _4 ~attrs:(_2@_5) ~loc:(make_loc _sloc) ~text ~docs )
-# 1735 "parsing/parser.ml"
+# 1703 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -1780,7 +1748,7 @@ module Tables = struct
         let _10 : (
 # 624 "parsing/parser.mly"
        (string)
-# 1784 "parsing/parser.ml"
+# 1752 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _2 : (Parsetree.attributes) = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
@@ -1792,31 +1760,23 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 1809 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 1769 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__6_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1172 "parsing/parser.mly"
+# 1162 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         let text = symbol_text _symbolstartpos in
         Md.mk _3 _5 ~attrs:(_2@_6) ~loc:(make_loc _sloc) ~text ~docs )
-# 1820 "parsing/parser.ml"
+# 1780 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -1870,7 +1830,7 @@ module Tables = struct
         let _10 : (
 # 578 "parsing/parser.mly"
        (string)
-# 1874 "parsing/parser.ml"
+# 1834 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _3 : ((Parsetree.core_type * Asttypes.variance) list) = Obj.magic _3 in
         let _2 : (Parsetree.attributes) = Obj.magic _2 in
@@ -1883,34 +1843,26 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 1900 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 1852 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__7_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2262 "parsing/parser.mly"
+# 2252 "parsing/parser.mly"
       ( let (kind, priv, manifest) = _5 in
         let docs = symbol_docs _sloc in
         let text = symbol_text _symbolstartpos in
         Type.mk _4 ~params:_3 ~cstrs:(List.rev _6)
           ~kind ~priv ?manifest
           ~attrs:(_2@_7) ~loc:(make_loc _sloc) ~docs ~text )
-# 1914 "parsing/parser.ml"
+# 1866 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -1939,9 +1891,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 2974 "parsing/parser.mly"
+# 2964 "parsing/parser.mly"
                      ( _1 )
-# 1945 "parsing/parser.ml"
+# 1897 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -1950,15 +1902,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 745 "parsing/parser.mly"
+# 735 "parsing/parser.mly"
     ( mkloc _1 (make_loc _sloc) )
-# 1956 "parsing/parser.ml"
+# 1908 "parsing/parser.ml"
           
         in
         
-# 2976 "parsing/parser.mly"
+# 2966 "parsing/parser.mly"
     ( _1 )
-# 1962 "parsing/parser.ml"
+# 1914 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2003,9 +1955,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 2975 "parsing/parser.mly"
+# 2965 "parsing/parser.mly"
                                  ( _1 ^ "." ^ _3.txt )
-# 2009 "parsing/parser.ml"
+# 1961 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -2014,15 +1966,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 745 "parsing/parser.mly"
+# 735 "parsing/parser.mly"
     ( mkloc _1 (make_loc _sloc) )
-# 2020 "parsing/parser.ml"
+# 1972 "parsing/parser.ml"
           
         in
         
-# 2976 "parsing/parser.mly"
+# 2966 "parsing/parser.mly"
     ( _1 )
-# 2026 "parsing/parser.ml"
+# 1978 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2066,9 +2018,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2980 "parsing/parser.mly"
+# 2970 "parsing/parser.mly"
     ( Attr.mk ~loc:(make_loc _sloc) _2 _3 )
-# 2072 "parsing/parser.ml"
+# 2024 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2084,9 +2036,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Parsetree.attributes) = 
-# 2996 "parsing/parser.mly"
+# 2986 "parsing/parser.mly"
                ( [] )
-# 2090 "parsing/parser.ml"
+# 2042 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2115,9 +2067,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.attributes) = 
-# 2997 "parsing/parser.mly"
+# 2987 "parsing/parser.mly"
                          ( _1 :: _2 )
-# 2121 "parsing/parser.ml"
+# 2073 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2162,31 +2114,23 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 2179 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 2123 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__4_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2345 "parsing/parser.mly"
+# 2335 "parsing/parser.mly"
     ( let args,res = _3 in
       let info = symbol_info _endpos in
       Type.constructor _2 ~args ?res ~attrs:_4 ~loc:(make_loc _sloc) ~info )
-# 2190 "parsing/parser.ml"
+# 2134 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2231,31 +2175,23 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 2248 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 2184 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__4_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2454 "parsing/parser.mly"
+# 2444 "parsing/parser.mly"
       ( let args, res = _3 in
         let info = symbol_info _endpos in
         Te.decl _2 ~args ?res ~attrs:_4 ~loc:(make_loc _sloc) ~info )
-# 2259 "parsing/parser.ml"
+# 2195 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2306,20 +2242,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__11_ in
           let _1 = _11 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 2323 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 2251 "parsing/parser.ml"
           
         in
         let _2 =
@@ -2327,30 +2255,22 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 2344 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 2264 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__5_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2465 "parsing/parser.mly"
+# 2455 "parsing/parser.mly"
       ( let info = symbol_info _endpos in
         Te.rebind _2 _4 ~attrs:_5 ~loc:(make_loc _sloc) ~info )
-# 2354 "parsing/parser.ml"
+# 2274 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2403,7 +2323,7 @@ module Tables = struct
         let _10 : (
 # 578 "parsing/parser.mly"
        (string)
-# 2407 "parsing/parser.ml"
+# 2327 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _4 : ((Parsetree.core_type * Asttypes.variance) list) = Obj.magic _4 in
         let _3 : (Asttypes.virtual_flag) = Obj.magic _3 in
@@ -2417,33 +2337,25 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 2434 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 2346 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__7_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1198 "parsing/parser.mly"
+# 1188 "parsing/parser.mly"
       ( let (ext, attrs) = _2 in
         let docs = symbol_docs _sloc in
         Ci.mk _5 _6 ~virt:_3 ~params:_4
                     ~attrs:(attrs@_7) ~loc:(make_loc _sloc) ~docs
         , ext )
-# 2447 "parsing/parser.ml"
+# 2359 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2466,9 +2378,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.class_declaration list * string Asttypes.loc option) = 
-# 1191 "parsing/parser.mly"
+# 1181 "parsing/parser.mly"
       ( let (body, ext) = _1 in ([body], ext) )
-# 2472 "parsing/parser.ml"
+# 2384 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2497,9 +2409,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.class_declaration list * string Asttypes.loc option) = 
-# 1193 "parsing/parser.mly"
+# 1183 "parsing/parser.mly"
       ( let (l, ext) = _1 in (_2 :: l, ext) )
-# 2503 "parsing/parser.ml"
+# 2415 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2558,7 +2470,7 @@ module Tables = struct
         let _10 : (
 # 578 "parsing/parser.mly"
        (string)
-# 2562 "parsing/parser.ml"
+# 2474 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _4 : ((Parsetree.core_type * Asttypes.variance) list) = Obj.magic _4 in
         let _3 : (Asttypes.virtual_flag) = Obj.magic _3 in
@@ -2572,33 +2484,25 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 2589 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 2493 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__8_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1469 "parsing/parser.mly"
+# 1459 "parsing/parser.mly"
       ( let (ext, attrs) = _2 in
         let docs = symbol_docs _sloc in
         Ci.mk _5 _7 ~virt:_3 ~params:_4
                     ~attrs:(attrs @ _8) ~loc:(make_loc _sloc) ~docs
         , ext )
-# 2602 "parsing/parser.ml"
+# 2506 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2621,9 +2525,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.class_description list * string Asttypes.loc option) = 
-# 1462 "parsing/parser.mly"
+# 1452 "parsing/parser.mly"
       ( let (body, ext) = _1 in ([body],ext) )
-# 2627 "parsing/parser.ml"
+# 2531 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2652,9 +2556,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.class_description list * string Asttypes.loc option) = 
-# 1464 "parsing/parser.mly"
+# 1454 "parsing/parser.mly"
       ( let (l, ext) = _1 in (_2 :: l, ext) )
-# 2658 "parsing/parser.ml"
+# 2562 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2677,9 +2581,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.class_expr) = 
-# 1236 "parsing/parser.mly"
+# 1226 "parsing/parser.mly"
       ( _1 )
-# 2683 "parsing/parser.ml"
+# 2587 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2717,9 +2621,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1238 "parsing/parser.mly"
+# 1228 "parsing/parser.mly"
       ( wrap_class_attrs ~loc:_sloc _3 _2 )
-# 2723 "parsing/parser.ml"
+# 2627 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2757,9 +2661,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1240 "parsing/parser.mly"
+# 1230 "parsing/parser.mly"
       ( class_of_let_bindings ~loc:_sloc _1 _3 )
-# 2763 "parsing/parser.ml"
+# 2667 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2822,29 +2726,21 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 2839 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 2735 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__7_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1242 "parsing/parser.mly"
+# 1232 "parsing/parser.mly"
       ( mkclass ~loc:_sloc ~attrs:_4 (Pcl_open(_3, _5, _7)) )
-# 2848 "parsing/parser.ml"
+# 2744 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2873,9 +2769,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.class_expr) = 
-# 1244 "parsing/parser.mly"
+# 1234 "parsing/parser.mly"
       ( Cl.attr _1 _2 )
-# 2879 "parsing/parser.ml"
+# 2775 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2912,9 +2808,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1247 "parsing/parser.mly"
+# 1237 "parsing/parser.mly"
         ( Pcl_apply(_1, List.rev _2) )
-# 2918 "parsing/parser.ml"
+# 2814 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -2923,15 +2819,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 766 "parsing/parser.mly"
+# 756 "parsing/parser.mly"
     ( mkclass ~loc:_sloc _1 )
-# 2929 "parsing/parser.ml"
+# 2825 "parsing/parser.ml"
           
         in
         
-# 1250 "parsing/parser.mly"
+# 1240 "parsing/parser.mly"
       ( _1 )
-# 2935 "parsing/parser.ml"
+# 2831 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -2960,9 +2856,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 1249 "parsing/parser.mly"
+# 1239 "parsing/parser.mly"
         ( Pcl_extension _1 )
-# 2966 "parsing/parser.ml"
+# 2862 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -2971,15 +2867,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 766 "parsing/parser.mly"
+# 756 "parsing/parser.mly"
     ( mkclass ~loc:_sloc _1 )
-# 2977 "parsing/parser.ml"
+# 2873 "parsing/parser.ml"
           
         in
         
-# 1250 "parsing/parser.mly"
+# 1240 "parsing/parser.mly"
       ( _1 )
-# 2983 "parsing/parser.ml"
+# 2879 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3035,10 +2931,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1294 "parsing/parser.mly"
+# 1284 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         mkcf ~loc:_sloc (Pcf_inherit (_2, _4, _5)) ~attrs:(_3@_6) ~docs )
-# 3042 "parsing/parser.ml"
+# 2938 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3078,11 +2974,11 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1297 "parsing/parser.mly"
+# 1287 "parsing/parser.mly"
       ( let v, attrs = _2 in
         let docs = symbol_docs _sloc in
         mkcf ~loc:_sloc (Pcf_val v) ~attrs:(attrs@_3) ~docs )
-# 3086 "parsing/parser.ml"
+# 2982 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3122,11 +3018,11 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1301 "parsing/parser.mly"
+# 1291 "parsing/parser.mly"
       ( let meth, attrs = _2 in
         let docs = symbol_docs _sloc in
         mkcf ~loc:_sloc (Pcf_method meth) ~attrs:(attrs@_3) ~docs )
-# 3130 "parsing/parser.ml"
+# 3026 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3170,10 +3066,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1305 "parsing/parser.mly"
+# 1295 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         mkcf ~loc:_sloc (Pcf_constraint _3) ~attrs:(_2@_4) ~docs )
-# 3177 "parsing/parser.ml"
+# 3073 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3217,10 +3113,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1308 "parsing/parser.mly"
+# 1298 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         mkcf ~loc:_sloc (Pcf_initializer _3) ~attrs:(_2@_4) ~docs )
-# 3224 "parsing/parser.ml"
+# 3120 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3252,10 +3148,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1311 "parsing/parser.mly"
+# 1301 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         mkcf ~loc:_sloc (Pcf_extension _1) ~attrs:_2 ~docs )
-# 3259 "parsing/parser.ml"
+# 3155 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3284,9 +3180,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 1314 "parsing/parser.mly"
+# 1304 "parsing/parser.mly"
       ( Pcf_attribute _1 )
-# 3290 "parsing/parser.ml"
+# 3186 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -3295,15 +3191,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 764 "parsing/parser.mly"
+# 754 "parsing/parser.mly"
     ( mkcf ~loc:_sloc _1 )
-# 3301 "parsing/parser.ml"
+# 3197 "parsing/parser.ml"
           
         in
         
-# 1315 "parsing/parser.mly"
+# 1305 "parsing/parser.mly"
       ( _1 )
-# 3307 "parsing/parser.ml"
+# 3203 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3319,9 +3215,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Parsetree.class_field list) = 
-# 1287 "parsing/parser.mly"
+# 1277 "parsing/parser.mly"
       ( [] )
-# 3325 "parsing/parser.ml"
+# 3221 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3350,9 +3246,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.class_field list) = 
-# 1289 "parsing/parser.mly"
+# 1279 "parsing/parser.mly"
       ( _2 :: List.rev (text_cstr _startpos__2_) @ _1 )
-# 3356 "parsing/parser.ml"
+# 3252 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3381,9 +3277,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.class_expr) = 
-# 1214 "parsing/parser.mly"
+# 1204 "parsing/parser.mly"
       ( _2 )
-# 3387 "parsing/parser.ml"
+# 3283 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3436,9 +3332,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1217 "parsing/parser.mly"
+# 1207 "parsing/parser.mly"
         ( Pcl_constraint(_4, _2) )
-# 3442 "parsing/parser.ml"
+# 3338 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -3447,15 +3343,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 766 "parsing/parser.mly"
+# 756 "parsing/parser.mly"
     ( mkclass ~loc:_sloc _1 )
-# 3453 "parsing/parser.ml"
+# 3349 "parsing/parser.ml"
           
         in
         
-# 1220 "parsing/parser.mly"
+# 1210 "parsing/parser.mly"
       ( _1 )
-# 3459 "parsing/parser.ml"
+# 3355 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3492,9 +3388,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1219 "parsing/parser.mly"
+# 1209 "parsing/parser.mly"
       ( let (l,o,p) = _1 in Pcl_fun(l, o, p, _2) )
-# 3498 "parsing/parser.ml"
+# 3394 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -3503,15 +3399,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 766 "parsing/parser.mly"
+# 756 "parsing/parser.mly"
     ( mkclass ~loc:_sloc _1 )
-# 3509 "parsing/parser.ml"
+# 3405 "parsing/parser.ml"
           
         in
         
-# 1220 "parsing/parser.mly"
+# 1210 "parsing/parser.mly"
       ( _1 )
-# 3515 "parsing/parser.ml"
+# 3411 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3541,15 +3437,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 766 "parsing/parser.mly"
+# 756 "parsing/parser.mly"
     ( mkclass ~loc:_sloc _1 )
-# 3547 "parsing/parser.ml"
+# 3443 "parsing/parser.ml"
           
         in
         
-# 1227 "parsing/parser.mly"
+# 1217 "parsing/parser.mly"
                                            ( _1 )
-# 3553 "parsing/parser.ml"
+# 3449 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3584,9 +3480,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.class_expr_desc) = 
-# 1230 "parsing/parser.mly"
+# 1220 "parsing/parser.mly"
       ( let (l,o,p) = _1 in Pcl_fun(l, o, p, _3) )
-# 3590 "parsing/parser.ml"
+# 3486 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3615,9 +3511,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.class_expr_desc) = 
-# 1232 "parsing/parser.mly"
+# 1222 "parsing/parser.mly"
       ( let (l,o,p) = _1 in Pcl_fun(l, o, p, _2) )
-# 3621 "parsing/parser.ml"
+# 3517 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3638,15 +3534,15 @@ module Tables = struct
         let _1 : (
 # 578 "parsing/parser.mly"
        (string)
-# 3642 "parsing/parser.ml"
+# 3538 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Longident.t) = 
-# 2827 "parsing/parser.mly"
+# 2817 "parsing/parser.mly"
                                                 ( Lident _1 )
-# 3650 "parsing/parser.ml"
+# 3546 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3677,7 +3573,7 @@ module Tables = struct
         let _3 : (
 # 578 "parsing/parser.mly"
        (string)
-# 3681 "parsing/parser.ml"
+# 3577 "parsing/parser.ml"
         ) = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
         let _1 : (Longident.t) = Obj.magic _1 in
@@ -3685,9 +3581,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Longident.t) = 
-# 2828 "parsing/parser.mly"
+# 2818 "parsing/parser.mly"
                                                 ( Ldot(_1, _3) )
-# 3691 "parsing/parser.ml"
+# 3587 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3725,9 +3621,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1278 "parsing/parser.mly"
+# 1268 "parsing/parser.mly"
       ( reloc_pat ~loc:_sloc _2 )
-# 3731 "parsing/parser.ml"
+# 3627 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3788,9 +3684,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1280 "parsing/parser.mly"
+# 1270 "parsing/parser.mly"
       ( Ppat_constraint(_2, _4) )
-# 3794 "parsing/parser.ml"
+# 3690 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -3799,15 +3695,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 3805 "parsing/parser.ml"
+# 3701 "parsing/parser.ml"
           
         in
         
-# 1281 "parsing/parser.mly"
+# 1271 "parsing/parser.mly"
       ( _1 )
-# 3811 "parsing/parser.ml"
+# 3707 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3826,9 +3722,9 @@ module Tables = struct
         let _symbolstartpos = _endpos in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1283 "parsing/parser.mly"
+# 1273 "parsing/parser.mly"
       ( ghpat ~loc:_sloc Ppat_any )
-# 3832 "parsing/parser.ml"
+# 3728 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3863,9 +3759,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.core_type) = 
-# 1412 "parsing/parser.mly"
+# 1402 "parsing/parser.mly"
       ( _2 )
-# 3869 "parsing/parser.ml"
+# 3765 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3883,9 +3779,9 @@ module Tables = struct
         let _v : (Parsetree.core_type) = let _1 =
           let _1 =
             
-# 1413 "parsing/parser.mly"
+# 1403 "parsing/parser.mly"
                       ( Ptyp_any )
-# 3889 "parsing/parser.ml"
+# 3785 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__0_ in
@@ -3893,15 +3789,15 @@ module Tables = struct
           let _symbolstartpos = _endpos in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 752 "parsing/parser.mly"
+# 742 "parsing/parser.mly"
     ( mktyp ~loc:_sloc _1 )
-# 3899 "parsing/parser.ml"
+# 3795 "parsing/parser.ml"
           
         in
         
-# 1414 "parsing/parser.mly"
+# 1404 "parsing/parser.mly"
       ( _1 )
-# 3905 "parsing/parser.ml"
+# 3801 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3938,13 +3834,13 @@ module Tables = struct
           
 # 723 "parsing/parser.mly"
                                ( extra_csig _startpos _endpos _1 )
-# 3942 "parsing/parser.ml"
+# 3838 "parsing/parser.ml"
           
         in
         
-# 1408 "parsing/parser.mly"
+# 1398 "parsing/parser.mly"
       ( Csig.mk _1 (List.rev _2) )
-# 3948 "parsing/parser.ml"
+# 3844 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -3988,10 +3884,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1424 "parsing/parser.mly"
+# 1414 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         mkctf ~loc:_sloc (Pctf_inherit _3) ~attrs:(_2@_4) ~docs )
-# 3995 "parsing/parser.ml"
+# 3891 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4036,10 +3932,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1427 "parsing/parser.mly"
+# 1417 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         mkctf ~loc:_sloc (Pctf_val _3) ~attrs:(_2@_4) ~docs )
-# 4043 "parsing/parser.ml"
+# 3939 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4102,31 +3998,23 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 4119 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 4007 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__7_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1431 "parsing/parser.mly"
+# 1421 "parsing/parser.mly"
       ( let (p, v) = _3 in
         let docs = symbol_docs _sloc in
         mkctf ~loc:_sloc (Pctf_method (_4, p, v, _6)) ~attrs:(_2@_7) ~docs )
-# 4130 "parsing/parser.ml"
+# 4018 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4170,10 +4058,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1435 "parsing/parser.mly"
+# 1425 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         mkctf ~loc:_sloc (Pctf_constraint _3) ~attrs:(_2@_4) ~docs )
-# 4177 "parsing/parser.ml"
+# 4065 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4205,10 +4093,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1438 "parsing/parser.mly"
+# 1428 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         mkctf ~loc:_sloc (Pctf_extension _1) ~attrs:_2 ~docs )
-# 4212 "parsing/parser.ml"
+# 4100 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4237,9 +4125,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 1441 "parsing/parser.mly"
+# 1431 "parsing/parser.mly"
       ( Pctf_attribute _1 )
-# 4243 "parsing/parser.ml"
+# 4131 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -4248,15 +4136,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 762 "parsing/parser.mly"
+# 752 "parsing/parser.mly"
     ( mkctf ~loc:_sloc _1 )
-# 4254 "parsing/parser.ml"
+# 4142 "parsing/parser.ml"
           
         in
         
-# 1442 "parsing/parser.mly"
+# 1432 "parsing/parser.mly"
       ( _1 )
-# 4260 "parsing/parser.ml"
+# 4148 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4272,9 +4160,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Parsetree.class_type_field list) = 
-# 1418 "parsing/parser.mly"
+# 1408 "parsing/parser.mly"
     ( [] )
-# 4278 "parsing/parser.ml"
+# 4166 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4303,9 +4191,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.class_type_field list) = 
-# 1420 "parsing/parser.mly"
+# 1410 "parsing/parser.mly"
     ( _2 :: List.rev (text_csig _startpos__2_) @ _1 )
-# 4309 "parsing/parser.ml"
+# 4197 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4365,34 +4253,26 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 4382 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 4262 "parsing/parser.ml"
               
             in
             let _2 =
               let tys = tys0 in
               
-# 2662 "parsing/parser.mly"
+# 2652 "parsing/parser.mly"
     ( tys )
-# 4390 "parsing/parser.ml"
+# 4270 "parsing/parser.ml"
               
             in
             
-# 1391 "parsing/parser.mly"
+# 1381 "parsing/parser.mly"
         ( Pcty_constr (_4, List.rev _2) )
-# 4396 "parsing/parser.ml"
+# 4276 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -4401,15 +4281,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 760 "parsing/parser.mly"
+# 750 "parsing/parser.mly"
     ( mkcty ~loc:_sloc _1 )
-# 4407 "parsing/parser.ml"
+# 4287 "parsing/parser.ml"
           
         in
         
-# 1396 "parsing/parser.mly"
+# 1386 "parsing/parser.mly"
       ( _1 )
-# 4413 "parsing/parser.ml"
+# 4293 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4444,26 +4324,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 4461 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 4333 "parsing/parser.ml"
               
             in
             
-# 1393 "parsing/parser.mly"
+# 1383 "parsing/parser.mly"
         ( Pcty_constr (_1, []) )
-# 4467 "parsing/parser.ml"
+# 4339 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -4472,15 +4344,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 760 "parsing/parser.mly"
+# 750 "parsing/parser.mly"
     ( mkcty ~loc:_sloc _1 )
-# 4478 "parsing/parser.ml"
+# 4350 "parsing/parser.ml"
           
         in
         
-# 1396 "parsing/parser.mly"
+# 1386 "parsing/parser.mly"
       ( _1 )
-# 4484 "parsing/parser.ml"
+# 4356 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4509,9 +4381,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 1395 "parsing/parser.mly"
+# 1385 "parsing/parser.mly"
         ( Pcty_extension _1 )
-# 4515 "parsing/parser.ml"
+# 4387 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -4520,15 +4392,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 760 "parsing/parser.mly"
+# 750 "parsing/parser.mly"
     ( mkcty ~loc:_sloc _1 )
-# 4526 "parsing/parser.ml"
+# 4398 "parsing/parser.ml"
           
         in
         
-# 1396 "parsing/parser.mly"
+# 1386 "parsing/parser.mly"
       ( _1 )
-# 4532 "parsing/parser.ml"
+# 4404 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4572,9 +4444,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1398 "parsing/parser.mly"
+# 1388 "parsing/parser.mly"
       ( mkcty ~loc:_sloc ~attrs:_2 (Pcty_signature _3) )
-# 4578 "parsing/parser.ml"
+# 4450 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4617,9 +4489,9 @@ module Tables = struct
         let _v : (Parsetree.class_type) = let _loc__4_ = (_startpos__4_, _endpos__4_) in
         let _loc__1_ = (_startpos__1_, _endpos__1_) in
         
-# 1400 "parsing/parser.mly"
+# 1390 "parsing/parser.mly"
       ( unclosed "object" _loc__1_ "end" _loc__4_ )
-# 4623 "parsing/parser.ml"
+# 4495 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4648,9 +4520,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.class_type) = 
-# 1402 "parsing/parser.mly"
+# 1392 "parsing/parser.mly"
       ( Cty.attr _1 _2 )
-# 4654 "parsing/parser.ml"
+# 4526 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4713,29 +4585,21 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 4730 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 4594 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__7_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1404 "parsing/parser.mly"
+# 1394 "parsing/parser.mly"
       ( mkcty ~loc:_sloc ~attrs:_4 (Pcty_open(_3, _5, _7)) )
-# 4739 "parsing/parser.ml"
+# 4603 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4770,9 +4634,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.class_expr) = 
-# 1254 "parsing/parser.mly"
+# 1244 "parsing/parser.mly"
       ( _2 )
-# 4776 "parsing/parser.ml"
+# 4640 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4809,9 +4673,9 @@ module Tables = struct
         let _v : (Parsetree.class_expr) = let _loc__3_ = (_startpos__3_, _endpos__3_) in
         let _loc__1_ = (_startpos__1_, _endpos__1_) in
         
-# 1256 "parsing/parser.mly"
+# 1246 "parsing/parser.mly"
       ( unclosed "(" _loc__1_ ")" _loc__3_ )
-# 4815 "parsing/parser.ml"
+# 4679 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4871,34 +4735,26 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 4888 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 4744 "parsing/parser.ml"
               
             in
             let _2 =
               let tys = tys0 in
               
-# 2662 "parsing/parser.mly"
+# 2652 "parsing/parser.mly"
     ( tys )
-# 4896 "parsing/parser.ml"
+# 4752 "parsing/parser.ml"
               
             in
             
-# 1259 "parsing/parser.mly"
+# 1249 "parsing/parser.mly"
         ( Pcl_constr(_4, List.rev _2) )
-# 4902 "parsing/parser.ml"
+# 4758 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -4907,15 +4763,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 766 "parsing/parser.mly"
+# 756 "parsing/parser.mly"
     ( mkclass ~loc:_sloc _1 )
-# 4913 "parsing/parser.ml"
+# 4769 "parsing/parser.ml"
           
         in
         
-# 1268 "parsing/parser.mly"
+# 1258 "parsing/parser.mly"
       ( _1 )
-# 4919 "parsing/parser.ml"
+# 4775 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -4950,26 +4806,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 4967 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 4815 "parsing/parser.ml"
               
             in
             
-# 1261 "parsing/parser.mly"
+# 1251 "parsing/parser.mly"
         ( Pcl_constr(_1, []) )
-# 4973 "parsing/parser.ml"
+# 4821 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -4978,15 +4826,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 766 "parsing/parser.mly"
+# 756 "parsing/parser.mly"
     ( mkclass ~loc:_sloc _1 )
-# 4984 "parsing/parser.ml"
+# 4832 "parsing/parser.ml"
           
         in
         
-# 1268 "parsing/parser.mly"
+# 1258 "parsing/parser.mly"
       ( _1 )
-# 4990 "parsing/parser.ml"
+# 4838 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5047,9 +4895,9 @@ module Tables = struct
             let _loc__4_ = (_startpos__4_, _endpos__4_) in
             let _loc__1_ = (_startpos__1_, _endpos__1_) in
             
-# 1263 "parsing/parser.mly"
+# 1253 "parsing/parser.mly"
         ( unclosed "object" _loc__1_ "end" _loc__4_ )
-# 5053 "parsing/parser.ml"
+# 4901 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -5058,15 +4906,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 766 "parsing/parser.mly"
+# 756 "parsing/parser.mly"
     ( mkclass ~loc:_sloc _1 )
-# 5064 "parsing/parser.ml"
+# 4912 "parsing/parser.ml"
           
         in
         
-# 1268 "parsing/parser.mly"
+# 1258 "parsing/parser.mly"
       ( _1 )
-# 5070 "parsing/parser.ml"
+# 4918 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5127,9 +4975,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1265 "parsing/parser.mly"
+# 1255 "parsing/parser.mly"
         ( Pcl_constraint(_2, _4) )
-# 5133 "parsing/parser.ml"
+# 4981 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -5138,15 +4986,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 766 "parsing/parser.mly"
+# 756 "parsing/parser.mly"
     ( mkclass ~loc:_sloc _1 )
-# 5144 "parsing/parser.ml"
+# 4992 "parsing/parser.ml"
           
         in
         
-# 1268 "parsing/parser.mly"
+# 1258 "parsing/parser.mly"
       ( _1 )
-# 5150 "parsing/parser.ml"
+# 4998 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5215,9 +5063,9 @@ module Tables = struct
             let _loc__5_ = (_startpos__5_, _endpos__5_) in
             let _loc__1_ = (_startpos__1_, _endpos__1_) in
             
-# 1267 "parsing/parser.mly"
+# 1257 "parsing/parser.mly"
         ( unclosed "(" _loc__1_ ")" _loc__5_ )
-# 5221 "parsing/parser.ml"
+# 5069 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -5226,15 +5074,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 766 "parsing/parser.mly"
+# 756 "parsing/parser.mly"
     ( mkclass ~loc:_sloc _1 )
-# 5232 "parsing/parser.ml"
+# 5080 "parsing/parser.ml"
           
         in
         
-# 1268 "parsing/parser.mly"
+# 1258 "parsing/parser.mly"
       ( _1 )
-# 5238 "parsing/parser.ml"
+# 5086 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5278,9 +5126,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1270 "parsing/parser.mly"
+# 1260 "parsing/parser.mly"
     ( mkclass ~loc:_sloc ~attrs:_2 (Pcl_structure _3) )
-# 5284 "parsing/parser.ml"
+# 5132 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5317,13 +5165,13 @@ module Tables = struct
           
 # 722 "parsing/parser.mly"
                                ( extra_cstr _startpos _endpos _1 )
-# 5321 "parsing/parser.ml"
+# 5169 "parsing/parser.ml"
           
         in
         
-# 1274 "parsing/parser.mly"
+# 1264 "parsing/parser.mly"
        ( Cstr.mk _1 (List.rev _2) )
-# 5327 "parsing/parser.ml"
+# 5175 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5346,9 +5194,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.class_type) = 
-# 1376 "parsing/parser.mly"
+# 1366 "parsing/parser.mly"
       ( _1 )
-# 5352 "parsing/parser.ml"
+# 5200 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5398,7 +5246,7 @@ module Tables = struct
         let _200 : (
 # 578 "parsing/parser.mly"
        (string)
-# 5402 "parsing/parser.ml"
+# 5250 "parsing/parser.ml"
         ) = Obj.magic _200 in
         let _100 : unit = Obj.magic _100 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
@@ -5421,9 +5269,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1379 "parsing/parser.mly"
+# 1369 "parsing/parser.mly"
         ( Pcty_arrow(Optional _2 , _4, _6) )
-# 5427 "parsing/parser.ml"
+# 5275 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__60_ in
@@ -5432,15 +5280,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 760 "parsing/parser.mly"
+# 750 "parsing/parser.mly"
     ( mkcty ~loc:_sloc _1 )
-# 5438 "parsing/parser.ml"
+# 5286 "parsing/parser.ml"
           
         in
         
-# 1386 "parsing/parser.mly"
+# 1376 "parsing/parser.mly"
       ( _1 )
-# 5444 "parsing/parser.ml"
+# 5292 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5479,7 +5327,7 @@ module Tables = struct
         let _100 : (
 # 595 "parsing/parser.mly"
        (string)
-# 5483 "parsing/parser.ml"
+# 5331 "parsing/parser.ml"
         ) = Obj.magic _100 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__100_ in
@@ -5497,9 +5345,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1381 "parsing/parser.mly"
+# 1371 "parsing/parser.mly"
         ( Pcty_arrow(Optional _1, _2, _4) )
-# 5503 "parsing/parser.ml"
+# 5351 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -5508,15 +5356,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 760 "parsing/parser.mly"
+# 750 "parsing/parser.mly"
     ( mkcty ~loc:_sloc _1 )
-# 5514 "parsing/parser.ml"
+# 5362 "parsing/parser.ml"
           
         in
         
-# 1386 "parsing/parser.mly"
+# 1376 "parsing/parser.mly"
       ( _1 )
-# 5520 "parsing/parser.ml"
+# 5368 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5561,7 +5409,7 @@ module Tables = struct
         let _100 : (
 # 578 "parsing/parser.mly"
        (string)
-# 5565 "parsing/parser.ml"
+# 5413 "parsing/parser.ml"
         ) = Obj.magic _100 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__100_ in
@@ -5581,9 +5429,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1383 "parsing/parser.mly"
+# 1373 "parsing/parser.mly"
         ( Pcty_arrow(Labelled _1, _3, _5) )
-# 5587 "parsing/parser.ml"
+# 5435 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -5592,15 +5440,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 760 "parsing/parser.mly"
+# 750 "parsing/parser.mly"
     ( mkcty ~loc:_sloc _1 )
-# 5598 "parsing/parser.ml"
+# 5446 "parsing/parser.ml"
           
         in
         
-# 1386 "parsing/parser.mly"
+# 1376 "parsing/parser.mly"
       ( _1 )
-# 5604 "parsing/parser.ml"
+# 5452 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5645,9 +5493,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1385 "parsing/parser.mly"
+# 1375 "parsing/parser.mly"
         ( Pcty_arrow(Nolabel, _1, _3) )
-# 5651 "parsing/parser.ml"
+# 5499 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -5656,15 +5504,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 760 "parsing/parser.mly"
+# 750 "parsing/parser.mly"
     ( mkcty ~loc:_sloc _1 )
-# 5662 "parsing/parser.ml"
+# 5510 "parsing/parser.ml"
           
         in
         
-# 1386 "parsing/parser.mly"
+# 1376 "parsing/parser.mly"
       ( _1 )
-# 5668 "parsing/parser.ml"
+# 5516 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5728,7 +5576,7 @@ module Tables = struct
         let _10 : (
 # 578 "parsing/parser.mly"
        (string)
-# 5732 "parsing/parser.ml"
+# 5580 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _5 : ((Parsetree.core_type * Asttypes.variance) list) = Obj.magic _5 in
         let _4 : (Asttypes.virtual_flag) = Obj.magic _4 in
@@ -5743,33 +5591,25 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 5760 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 5600 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__9_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1492 "parsing/parser.mly"
+# 1482 "parsing/parser.mly"
       ( let (ext, attrs) = _3 in
         let docs = symbol_docs _sloc in
         Ci.mk _6 _8 ~virt:_4 ~params:_5
                     ~attrs:(attrs@_9) ~loc:(make_loc _sloc) ~docs
         , ext )
-# 5773 "parsing/parser.ml"
+# 5613 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5792,9 +5632,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.class_type_declaration list * string Asttypes.loc option) = 
-# 1485 "parsing/parser.mly"
+# 1475 "parsing/parser.mly"
       ( let (body, ext) = _1 in ([body],ext) )
-# 5798 "parsing/parser.ml"
+# 5638 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5823,9 +5663,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.class_type_declaration list * string Asttypes.loc option) = 
-# 1487 "parsing/parser.mly"
+# 1477 "parsing/parser.mly"
       ( let (l, ext) = _1 in (_2 :: l, ext) )
-# 5829 "parsing/parser.ml"
+# 5669 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5841,9 +5681,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : ((Parsetree.core_type * Asttypes.variance) list) = 
-# 1223 "parsing/parser.mly"
+# 1213 "parsing/parser.mly"
                                                 ( [] )
-# 5847 "parsing/parser.ml"
+# 5687 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5878,9 +5718,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : ((Parsetree.core_type * Asttypes.variance) list) = 
-# 1224 "parsing/parser.mly"
+# 1214 "parsing/parser.mly"
                                                 ( List.rev _2 )
-# 5884 "parsing/parser.ml"
+# 5724 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5901,15 +5741,15 @@ module Tables = struct
         let _1 : (
 # 578 "parsing/parser.mly"
        (string)
-# 5905 "parsing/parser.ml"
+# 5745 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Longident.t) = 
-# 2823 "parsing/parser.mly"
+# 2813 "parsing/parser.mly"
                                                 ( Lident _1 )
-# 5913 "parsing/parser.ml"
+# 5753 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5940,7 +5780,7 @@ module Tables = struct
         let _3 : (
 # 578 "parsing/parser.mly"
        (string)
-# 5944 "parsing/parser.ml"
+# 5784 "parsing/parser.ml"
         ) = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
         let _1 : (Longident.t) = Obj.magic _1 in
@@ -5948,9 +5788,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Longident.t) = 
-# 2824 "parsing/parser.mly"
+# 2814 "parsing/parser.mly"
                                                 ( Ldot(_1, _3) )
-# 5954 "parsing/parser.ml"
+# 5794 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -5971,15 +5811,15 @@ module Tables = struct
         let _1 : (
 # 564 "parsing/parser.mly"
        (string * char option)
-# 5975 "parsing/parser.ml"
+# 5815 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.constant) = 
-# 2721 "parsing/parser.mly"
+# 2711 "parsing/parser.mly"
                  ( let (n, m) = _1 in Pconst_integer (n, m) )
-# 5983 "parsing/parser.ml"
+# 5823 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6000,15 +5840,15 @@ module Tables = struct
         let _1 : (
 # 525 "parsing/parser.mly"
        (char)
-# 6004 "parsing/parser.ml"
+# 5844 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.constant) = 
-# 2722 "parsing/parser.mly"
+# 2712 "parsing/parser.mly"
                  ( Pconst_char _1 )
-# 6012 "parsing/parser.ml"
+# 5852 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6029,15 +5869,15 @@ module Tables = struct
         let _1 : (
 # 616 "parsing/parser.mly"
        (string * string option)
-# 6033 "parsing/parser.ml"
+# 5873 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.constant) = 
-# 2723 "parsing/parser.mly"
+# 2713 "parsing/parser.mly"
                  ( let (s, d) = _1 in Pconst_string (s, d) )
-# 6041 "parsing/parser.ml"
+# 5881 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6058,15 +5898,15 @@ module Tables = struct
         let _1 : (
 # 545 "parsing/parser.mly"
        (string * char option)
-# 6062 "parsing/parser.ml"
+# 5902 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.constant) = 
-# 2724 "parsing/parser.mly"
+# 2714 "parsing/parser.mly"
                  ( let (f, m) = _1 in Pconst_float (f, m) )
-# 6070 "parsing/parser.ml"
+# 5910 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6087,15 +5927,15 @@ module Tables = struct
         let _1 : (
 # 624 "parsing/parser.mly"
        (string)
-# 6091 "parsing/parser.ml"
+# 5931 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2779 "parsing/parser.mly"
+# 2769 "parsing/parser.mly"
                                                 ( _1 )
-# 6099 "parsing/parser.ml"
+# 5939 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6124,9 +5964,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (string) = 
-# 2780 "parsing/parser.mly"
+# 2770 "parsing/parser.mly"
                                                 ( "[]" )
-# 6130 "parsing/parser.ml"
+# 5970 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6155,9 +5995,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (string) = 
-# 2781 "parsing/parser.mly"
+# 2771 "parsing/parser.mly"
                                                 ( "()" )
-# 6161 "parsing/parser.ml"
+# 6001 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6192,9 +6032,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (string) = 
-# 2782 "parsing/parser.mly"
+# 2772 "parsing/parser.mly"
                                                 ( "::" )
-# 6198 "parsing/parser.ml"
+# 6038 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6217,9 +6057,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2783 "parsing/parser.mly"
+# 2773 "parsing/parser.mly"
                                                 ( "false" )
-# 6223 "parsing/parser.ml"
+# 6063 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6242,9 +6082,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2784 "parsing/parser.mly"
+# 2774 "parsing/parser.mly"
                                                 ( "true" )
-# 6248 "parsing/parser.ml"
+# 6088 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6267,9 +6107,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Longident.t) = 
-# 2792 "parsing/parser.mly"
+# 2782 "parsing/parser.mly"
                                                 ( _1 )
-# 6273 "parsing/parser.ml"
+# 6113 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6316,9 +6156,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
         let _v : (Longident.t) = 
-# 2793 "parsing/parser.mly"
+# 2783 "parsing/parser.mly"
                                                 ( Ldot(_1,"::") )
-# 6322 "parsing/parser.ml"
+# 6162 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6347,9 +6187,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Longident.t) = 
-# 2794 "parsing/parser.mly"
+# 2784 "parsing/parser.mly"
                                                 ( Lident "[]" )
-# 6353 "parsing/parser.ml"
+# 6193 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6378,9 +6218,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Longident.t) = 
-# 2795 "parsing/parser.mly"
+# 2785 "parsing/parser.mly"
                                                 ( Lident "()" )
-# 6384 "parsing/parser.ml"
+# 6224 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6415,9 +6255,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Longident.t) = 
-# 2796 "parsing/parser.mly"
+# 2786 "parsing/parser.mly"
                                                 ( Lident "::" )
-# 6421 "parsing/parser.ml"
+# 6261 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6440,9 +6280,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Longident.t) = 
-# 2797 "parsing/parser.mly"
+# 2787 "parsing/parser.mly"
                                                 ( Lident "false" )
-# 6446 "parsing/parser.ml"
+# 6286 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6465,9 +6305,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Longident.t) = 
-# 2798 "parsing/parser.mly"
+# 2788 "parsing/parser.mly"
                                                 ( Lident "true" )
-# 6471 "parsing/parser.ml"
+# 6311 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6505,9 +6345,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1454 "parsing/parser.mly"
+# 1444 "parsing/parser.mly"
     ( _1, _3, make_loc _sloc )
-# 6511 "parsing/parser.ml"
+# 6351 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6542,9 +6382,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.core_type * Parsetree.core_type) = 
-# 1458 "parsing/parser.mly"
+# 1448 "parsing/parser.mly"
     ( _1, _3 )
-# 6548 "parsing/parser.ml"
+# 6388 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6579,9 +6419,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : ((Parsetree.core_type * Parsetree.core_type * Ast_helper.loc) list) = 
-# 2270 "parsing/parser.mly"
+# 2260 "parsing/parser.mly"
                                                 ( _3 :: _1 )
-# 6585 "parsing/parser.ml"
+# 6425 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6597,9 +6437,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : ((Parsetree.core_type * Parsetree.core_type * Ast_helper.loc) list) = 
-# 2271 "parsing/parser.mly"
+# 2261 "parsing/parser.mly"
                                                 ( [] )
-# 6603 "parsing/parser.ml"
+# 6443 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6622,9 +6462,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.constructor_arguments) = 
-# 2385 "parsing/parser.mly"
+# 2375 "parsing/parser.mly"
                                      ( Pcstr_tuple (List.rev _1) )
-# 6628 "parsing/parser.ml"
+# 6468 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6659,9 +6499,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.constructor_arguments) = 
-# 2386 "parsing/parser.mly"
+# 2376 "parsing/parser.mly"
                                      ( Pcstr_record _2 )
-# 6665 "parsing/parser.ml"
+# 6505 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6700,20 +6540,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 6717 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 6549 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -6721,11 +6553,11 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2339 "parsing/parser.mly"
+# 2329 "parsing/parser.mly"
     ( let args,res = _2 in
       let info = symbol_info _endpos in
       Type.constructor _1 ~args ?res ~attrs:_3 ~loc:(make_loc _sloc) ~info )
-# 6729 "parsing/parser.ml"
+# 6561 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6748,9 +6580,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.constructor_declaration list) = 
-# 2332 "parsing/parser.mly"
+# 2322 "parsing/parser.mly"
                                                          ( [  ] )
-# 6754 "parsing/parser.ml"
+# 6586 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6773,9 +6605,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.constructor_declaration list) = 
-# 2333 "parsing/parser.mly"
+# 2323 "parsing/parser.mly"
                                                          ( [_1] )
-# 6779 "parsing/parser.ml"
+# 6611 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6798,9 +6630,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.constructor_declaration list) = 
-# 2334 "parsing/parser.mly"
+# 2324 "parsing/parser.mly"
                                                          ( [_1] )
-# 6804 "parsing/parser.ml"
+# 6636 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6829,9 +6661,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.constructor_declaration list) = 
-# 2335 "parsing/parser.mly"
+# 2325 "parsing/parser.mly"
                                                          ( _2 :: _1 )
-# 6835 "parsing/parser.ml"
+# 6667 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6854,9 +6686,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.core_type) = 
-# 2533 "parsing/parser.mly"
+# 2523 "parsing/parser.mly"
       ( _1 )
-# 6860 "parsing/parser.ml"
+# 6692 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6885,9 +6717,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.core_type) = 
-# 2535 "parsing/parser.mly"
+# 2525 "parsing/parser.mly"
       ( Typ.attr _1 _2 )
-# 6891 "parsing/parser.ml"
+# 6723 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6910,9 +6742,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.core_type) = 
-# 2546 "parsing/parser.mly"
+# 2536 "parsing/parser.mly"
       ( _1 )
-# 6916 "parsing/parser.ml"
+# 6748 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -6942,15 +6774,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 752 "parsing/parser.mly"
+# 742 "parsing/parser.mly"
     ( mktyp ~loc:_sloc _1 )
-# 6948 "parsing/parser.ml"
+# 6780 "parsing/parser.ml"
           
         in
         
-# 2548 "parsing/parser.mly"
+# 2538 "parsing/parser.mly"
       ( _1 )
-# 6954 "parsing/parser.ml"
+# 6786 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7000,7 +6832,7 @@ module Tables = struct
         let _2 : (
 # 578 "parsing/parser.mly"
        (string)
-# 7004 "parsing/parser.ml"
+# 6836 "parsing/parser.ml"
         ) = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
@@ -7010,15 +6842,15 @@ module Tables = struct
           let _endpos__1_ = _endpos__10_ in
           let _1 = _10 in
           
-# 2561 "parsing/parser.mly"
+# 2551 "parsing/parser.mly"
   ( extra_rhs_core_type _1 ~pos:_endpos__1_ )
-# 7016 "parsing/parser.ml"
+# 6848 "parsing/parser.ml"
           
         in
         
-# 2552 "parsing/parser.mly"
+# 2542 "parsing/parser.mly"
       ( Ptyp_arrow(Optional _2, _4, _6) )
-# 7022 "parsing/parser.ml"
+# 6854 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7057,7 +6889,7 @@ module Tables = struct
         let _1 : (
 # 595 "parsing/parser.mly"
        (string)
-# 7061 "parsing/parser.ml"
+# 6893 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
@@ -7066,15 +6898,15 @@ module Tables = struct
           let _endpos__1_ = _endpos__10_ in
           let _1 = _10 in
           
-# 2561 "parsing/parser.mly"
+# 2551 "parsing/parser.mly"
   ( extra_rhs_core_type _1 ~pos:_endpos__1_ )
-# 7072 "parsing/parser.ml"
+# 6904 "parsing/parser.ml"
           
         in
         
-# 2554 "parsing/parser.mly"
+# 2544 "parsing/parser.mly"
       ( Ptyp_arrow(Optional _1 , _2, _4) )
-# 7078 "parsing/parser.ml"
+# 6910 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7119,7 +6951,7 @@ module Tables = struct
         let _1 : (
 # 578 "parsing/parser.mly"
        (string)
-# 7123 "parsing/parser.ml"
+# 6955 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
@@ -7128,15 +6960,15 @@ module Tables = struct
           let _endpos__1_ = _endpos__10_ in
           let _1 = _10 in
           
-# 2561 "parsing/parser.mly"
+# 2551 "parsing/parser.mly"
   ( extra_rhs_core_type _1 ~pos:_endpos__1_ )
-# 7134 "parsing/parser.ml"
+# 6966 "parsing/parser.ml"
           
         in
         
-# 2556 "parsing/parser.mly"
+# 2546 "parsing/parser.mly"
       ( Ptyp_arrow(Labelled _1, _3, _5) )
-# 7140 "parsing/parser.ml"
+# 6972 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7174,15 +7006,15 @@ module Tables = struct
           let _endpos__1_ = _endpos__10_ in
           let _1 = _10 in
           
-# 2561 "parsing/parser.mly"
+# 2551 "parsing/parser.mly"
   ( extra_rhs_core_type _1 ~pos:_endpos__1_ )
-# 7180 "parsing/parser.ml"
+# 7012 "parsing/parser.ml"
           
         in
         
-# 2558 "parsing/parser.mly"
+# 2548 "parsing/parser.mly"
       ( Ptyp_arrow(Nolabel, _1, _3) )
-# 7186 "parsing/parser.ml"
+# 7018 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7205,9 +7037,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.core_type list) = 
-# 2678 "parsing/parser.mly"
+# 2668 "parsing/parser.mly"
                                            ( [_1] )
-# 7211 "parsing/parser.ml"
+# 7043 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7242,9 +7074,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.core_type list) = 
-# 2679 "parsing/parser.mly"
+# 2669 "parsing/parser.mly"
                                            ( _3 :: _1 )
-# 7248 "parsing/parser.ml"
+# 7080 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7267,9 +7099,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.core_type) = 
-# 2539 "parsing/parser.mly"
+# 2529 "parsing/parser.mly"
       ( _1 )
-# 7273 "parsing/parser.ml"
+# 7105 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7322,9 +7154,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 2541 "parsing/parser.mly"
+# 2531 "parsing/parser.mly"
       ( Ptyp_alias(_1, _4) )
-# 7328 "parsing/parser.ml"
+# 7160 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -7333,15 +7165,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 752 "parsing/parser.mly"
+# 742 "parsing/parser.mly"
     ( mktyp ~loc:_sloc _1 )
-# 7339 "parsing/parser.ml"
+# 7171 "parsing/parser.ml"
           
         in
         
-# 2542 "parsing/parser.mly"
+# 2532 "parsing/parser.mly"
       ( _1 )
-# 7345 "parsing/parser.ml"
+# 7177 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7364,9 +7196,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.direction_flag) = 
-# 2872 "parsing/parser.mly"
+# 2862 "parsing/parser.mly"
                                                 ( Upto )
-# 7370 "parsing/parser.ml"
+# 7202 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7389,9 +7221,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.direction_flag) = 
-# 2873 "parsing/parser.mly"
+# 2863 "parsing/parser.mly"
                                                 ( Downto )
-# 7395 "parsing/parser.ml"
+# 7227 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7414,9 +7246,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.expression) = 
-# 1573 "parsing/parser.mly"
+# 1563 "parsing/parser.mly"
       ( _1 )
-# 7420 "parsing/parser.ml"
+# 7252 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7470,7 +7302,7 @@ module Tables = struct
         let _100 : (
 # 624 "parsing/parser.mly"
        (string)
-# 7474 "parsing/parser.ml"
+# 7306 "parsing/parser.ml"
         ) = Obj.magic _100 in
         let _30 : (string Asttypes.loc option * Parsetree.attributes) = Obj.magic _30 in
         let _20 : unit = Obj.magic _20 in
@@ -7493,26 +7325,18 @@ module Tables = struct
             let _startpos__1_ = _startpos__10_ in
             let _1 = _10 in
             let _endpos = _endpos__1_ in
-            let _startpos = _startpos__1_ in
-            let _loc = (_startpos, _endpos) in
+            let _symbolstartpos = _startpos__1_ in
+            let _sloc = (_symbolstartpos, _endpos) in
             
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 7510 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 7334 "parsing/parser.ml"
             
           in
           
-# 1612 "parsing/parser.mly"
+# 1602 "parsing/parser.mly"
       ( Pexp_letmodule(_4, _5, _7), _3 )
-# 7516 "parsing/parser.ml"
+# 7340 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__70_ in
@@ -7521,10 +7345,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 7528 "parsing/parser.ml"
+# 7352 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7584,9 +7408,9 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _10 in
           
-# 1614 "parsing/parser.mly"
+# 1604 "parsing/parser.mly"
       ( Pexp_letexception(_4, _6), _3 )
-# 7590 "parsing/parser.ml"
+# 7414 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__60_ in
@@ -7595,10 +7419,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 7602 "parsing/parser.ml"
+# 7426 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7671,26 +7495,18 @@ module Tables = struct
             let _startpos__1_ = _startpos__10_ in
             let _1 = _10 in
             let _endpos = _endpos__1_ in
-            let _startpos = _startpos__1_ in
-            let _loc = (_startpos, _endpos) in
+            let _symbolstartpos = _startpos__1_ in
+            let _sloc = (_symbolstartpos, _endpos) in
             
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 7688 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 7504 "parsing/parser.ml"
             
           in
           
-# 1616 "parsing/parser.mly"
+# 1606 "parsing/parser.mly"
       ( Pexp_open(_3, _5, _7), _4 )
-# 7694 "parsing/parser.ml"
+# 7510 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__70_ in
@@ -7699,10 +7515,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 7706 "parsing/parser.ml"
+# 7522 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7748,9 +7564,9 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _10 in
           
-# 1618 "parsing/parser.mly"
+# 1608 "parsing/parser.mly"
       ( Pexp_function(List.rev _4), _2 )
-# 7754 "parsing/parser.ml"
+# 7570 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__40_ in
@@ -7759,10 +7575,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 7766 "parsing/parser.ml"
+# 7582 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7808,10 +7624,10 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _10 in
           
-# 1620 "parsing/parser.mly"
+# 1610 "parsing/parser.mly"
       ( let (l,o,p) = _3 in
         Pexp_fun(l, o, p, _4), _2 )
-# 7815 "parsing/parser.ml"
+# 7631 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__40_ in
@@ -7820,10 +7636,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 7827 "parsing/parser.ml"
+# 7643 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7895,9 +7711,9 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 1623 "parsing/parser.mly"
+# 1613 "parsing/parser.mly"
       ( (mk_newtypes ~loc:_sloc _5 _7).pexp_desc, _2 )
-# 7901 "parsing/parser.ml"
+# 7717 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__70_ in
@@ -7906,10 +7722,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 7913 "parsing/parser.ml"
+# 7729 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -7969,9 +7785,9 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _10 in
           
-# 1625 "parsing/parser.mly"
+# 1615 "parsing/parser.mly"
       ( Pexp_match(_3, List.rev _6), _2 )
-# 7975 "parsing/parser.ml"
+# 7791 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__60_ in
@@ -7980,10 +7796,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 7987 "parsing/parser.ml"
+# 7803 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -8043,9 +7859,9 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _10 in
           
-# 1627 "parsing/parser.mly"
+# 1617 "parsing/parser.mly"
       ( Pexp_try(_3, List.rev _6), _2 )
-# 8049 "parsing/parser.ml"
+# 7865 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__60_ in
@@ -8054,10 +7870,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 8061 "parsing/parser.ml"
+# 7877 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -8110,9 +7926,9 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _10 in
           
-# 1629 "parsing/parser.mly"
+# 1619 "parsing/parser.mly"
       ( syntax_error() )
-# 8116 "parsing/parser.ml"
+# 7932 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__50_ in
@@ -8121,10 +7937,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 8128 "parsing/parser.ml"
+# 7944 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -8191,9 +8007,9 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _10 in
           
-# 1631 "parsing/parser.mly"
+# 1621 "parsing/parser.mly"
       ( Pexp_ifthenelse(_3, _5, Some _7), _2 )
-# 8197 "parsing/parser.ml"
+# 8013 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__70_ in
@@ -8202,10 +8018,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 8209 "parsing/parser.ml"
+# 8025 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -8258,9 +8074,9 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _10 in
           
-# 1633 "parsing/parser.mly"
+# 1623 "parsing/parser.mly"
       ( Pexp_ifthenelse(_3, _5, None), _2 )
-# 8264 "parsing/parser.ml"
+# 8080 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__50_ in
@@ -8269,10 +8085,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 8276 "parsing/parser.ml"
+# 8092 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -8332,9 +8148,9 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _10 in
           
-# 1635 "parsing/parser.mly"
+# 1625 "parsing/parser.mly"
       ( Pexp_while(_3, _5), _2 )
-# 8338 "parsing/parser.ml"
+# 8154 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__60_ in
@@ -8343,10 +8159,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 8350 "parsing/parser.ml"
+# 8166 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -8434,9 +8250,9 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _11 in
           
-# 1638 "parsing/parser.mly"
+# 1628 "parsing/parser.mly"
       ( Pexp_for(_3, _5, _7, _6, _9), _2 )
-# 8440 "parsing/parser.ml"
+# 8256 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__100_ in
@@ -8445,10 +8261,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 8452 "parsing/parser.ml"
+# 8268 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -8487,9 +8303,9 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _10 in
           
-# 1640 "parsing/parser.mly"
+# 1630 "parsing/parser.mly"
       ( Pexp_assert _3, _2 )
-# 8493 "parsing/parser.ml"
+# 8309 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__30_ in
@@ -8498,10 +8314,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 8505 "parsing/parser.ml"
+# 8321 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -8540,9 +8356,9 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _10 in
           
-# 1642 "parsing/parser.mly"
+# 1632 "parsing/parser.mly"
       ( Pexp_lazy _3, _2 )
-# 8546 "parsing/parser.ml"
+# 8362 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__30_ in
@@ -8551,10 +8367,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 8558 "parsing/parser.ml"
+# 8374 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -8600,9 +8416,9 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _10 in
           
-# 1644 "parsing/parser.mly"
+# 1634 "parsing/parser.mly"
       ( Pexp_object _3, _2 )
-# 8606 "parsing/parser.ml"
+# 8422 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__40_ in
@@ -8611,10 +8427,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 8618 "parsing/parser.ml"
+# 8434 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -8666,9 +8482,9 @@ module Tables = struct
           let _loc__4_ = (_startpos__4_, _endpos__4_) in
           let _loc__1_ = (_startpos__1_, _endpos__1_) in
           
-# 1646 "parsing/parser.mly"
+# 1636 "parsing/parser.mly"
       ( unclosed "object" _loc__1_ "end" _loc__4_ )
-# 8672 "parsing/parser.ml"
+# 8488 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__40_ in
@@ -8677,10 +8493,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1575 "parsing/parser.mly"
+# 1565 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 8684 "parsing/parser.ml"
+# 8500 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -8712,7 +8528,7 @@ module Tables = struct
         let _10000 : (
 # 556 "parsing/parser.mly"
        (string)
-# 8716 "parsing/parser.ml"
+# 8532 "parsing/parser.ml"
         ) = Obj.magic _10000 in
         let _1100 : (Parsetree.expression) = Obj.magic _1100 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
@@ -8743,26 +8559,24 @@ module Tables = struct
                 let _startpos__1_ = _startpos__10_ in
                 let _1 = _10 in
                 let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
                 
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 8754 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 8568 "parsing/parser.ml"
                 
               in
               
-# 1661 "parsing/parser.mly"
+# 1651 "parsing/parser.mly"
       ( mkinfix _1 _2 _3 )
-# 8760 "parsing/parser.ml"
+# 8574 "parsing/parser.ml"
               
             in
             
-# 1649 "parsing/parser.mly"
+# 1639 "parsing/parser.mly"
             ( _1 )
-# 8766 "parsing/parser.ml"
+# 8580 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__300_ in
@@ -8771,15 +8585,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 8777 "parsing/parser.ml"
+# 8591 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 8783 "parsing/parser.ml"
+# 8597 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -8811,7 +8625,7 @@ module Tables = struct
         let _10000 : (
 # 557 "parsing/parser.mly"
        (string)
-# 8815 "parsing/parser.ml"
+# 8629 "parsing/parser.ml"
         ) = Obj.magic _10000 in
         let _1100 : (Parsetree.expression) = Obj.magic _1100 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
@@ -8842,26 +8656,24 @@ module Tables = struct
                 let _startpos__1_ = _startpos__10_ in
                 let _1 = _10 in
                 let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
                 
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 8853 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 8665 "parsing/parser.ml"
                 
               in
               
-# 1663 "parsing/parser.mly"
+# 1653 "parsing/parser.mly"
       ( mkinfix _1 _2 _3 )
-# 8859 "parsing/parser.ml"
+# 8671 "parsing/parser.ml"
               
             in
             
-# 1649 "parsing/parser.mly"
+# 1639 "parsing/parser.mly"
             ( _1 )
-# 8865 "parsing/parser.ml"
+# 8677 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__300_ in
@@ -8870,15 +8682,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 8876 "parsing/parser.ml"
+# 8688 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 8882 "parsing/parser.ml"
+# 8694 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -8910,7 +8722,7 @@ module Tables = struct
         let _10000 : (
 # 558 "parsing/parser.mly"
        (string)
-# 8914 "parsing/parser.ml"
+# 8726 "parsing/parser.ml"
         ) = Obj.magic _10000 in
         let _1100 : (Parsetree.expression) = Obj.magic _1100 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
@@ -8941,26 +8753,24 @@ module Tables = struct
                 let _startpos__1_ = _startpos__10_ in
                 let _1 = _10 in
                 let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
                 
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 8952 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 8762 "parsing/parser.ml"
                 
               in
               
-# 1665 "parsing/parser.mly"
+# 1655 "parsing/parser.mly"
       ( mkinfix _1 _2 _3 )
-# 8958 "parsing/parser.ml"
+# 8768 "parsing/parser.ml"
               
             in
             
-# 1649 "parsing/parser.mly"
+# 1639 "parsing/parser.mly"
             ( _1 )
-# 8964 "parsing/parser.ml"
+# 8774 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__300_ in
@@ -8969,15 +8779,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 8975 "parsing/parser.ml"
+# 8785 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 8981 "parsing/parser.ml"
+# 8791 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -9009,7 +8819,7 @@ module Tables = struct
         let _10000 : (
 # 559 "parsing/parser.mly"
        (string)
-# 9013 "parsing/parser.ml"
+# 8823 "parsing/parser.ml"
         ) = Obj.magic _10000 in
         let _1100 : (Parsetree.expression) = Obj.magic _1100 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
@@ -9040,26 +8850,24 @@ module Tables = struct
                 let _startpos__1_ = _startpos__10_ in
                 let _1 = _10 in
                 let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
                 
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 9051 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 8859 "parsing/parser.ml"
                 
               in
               
-# 1667 "parsing/parser.mly"
+# 1657 "parsing/parser.mly"
       ( mkinfix _1 _2 _3 )
-# 9057 "parsing/parser.ml"
+# 8865 "parsing/parser.ml"
               
             in
             
-# 1649 "parsing/parser.mly"
+# 1639 "parsing/parser.mly"
             ( _1 )
-# 9063 "parsing/parser.ml"
+# 8871 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__300_ in
@@ -9068,15 +8876,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 9074 "parsing/parser.ml"
+# 8882 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 9080 "parsing/parser.ml"
+# 8888 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -9108,7 +8916,7 @@ module Tables = struct
         let _10000 : (
 # 560 "parsing/parser.mly"
        (string)
-# 9112 "parsing/parser.ml"
+# 8920 "parsing/parser.ml"
         ) = Obj.magic _10000 in
         let _1100 : (Parsetree.expression) = Obj.magic _1100 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
@@ -9139,26 +8947,24 @@ module Tables = struct
                 let _startpos__1_ = _startpos__10_ in
                 let _1 = _10 in
                 let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
                 
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 9150 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 8956 "parsing/parser.ml"
                 
               in
               
-# 1669 "parsing/parser.mly"
+# 1659 "parsing/parser.mly"
       ( mkinfix _1 _2 _3 )
-# 9156 "parsing/parser.ml"
+# 8962 "parsing/parser.ml"
               
             in
             
-# 1649 "parsing/parser.mly"
+# 1639 "parsing/parser.mly"
             ( _1 )
-# 9162 "parsing/parser.ml"
+# 8968 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__300_ in
@@ -9167,15 +8973,530 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 9173 "parsing/parser.ml"
+# 8979 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 9179 "parsing/parser.ml"
+# 8985 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _3000;
+          MenhirLib.EngineTypes.startp = _startpos__3000_;
+          MenhirLib.EngineTypes.endp = _endpos__3000_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _100000;
+            MenhirLib.EngineTypes.startp = _startpos__100000_;
+            MenhirLib.EngineTypes.endp = _endpos__100000_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.state = _menhir_s;
+              MenhirLib.EngineTypes.semv = _1000;
+              MenhirLib.EngineTypes.startp = _startpos__1000_;
+              MenhirLib.EngineTypes.endp = _endpos__1000_;
+              MenhirLib.EngineTypes.next = _menhir_stack;
+            };
+          };
+        } = _menhir_stack in
+        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
+        let _100000 : unit = Obj.magic _100000 in
+        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1000_ in
+        let _endpos = _endpos__3000_ in
+        let _v : (Parsetree.expression) = let _1 =
+          let _endpos__300_ = _endpos__3000_ in
+          let _endpos__10000_ = _endpos__100000_ in
+          let _startpos__10000_ = _startpos__100000_ in
+          let _startpos__100_ = _startpos__1000_ in
+          let _300 = _3000 in
+          let _10000 = _100000 in
+          let _100 = _1000 in
+          let _1 =
+            let _endpos__1000_ = _endpos__10000_ in
+            let _startpos__1000_ = _startpos__10000_ in
+            let _30 = _300 in
+            let _1000 = _10000 in
+            let _10 = _100 in
+            let _1 =
+              let _endpos__100_ = _endpos__1000_ in
+              let _startpos__100_ = _startpos__1000_ in
+              let _3 = _30 in
+              let _100 = _1000 in
+              let _1 = _10 in
+              let _2 =
+                let _endpos__10_ = _endpos__100_ in
+                let _startpos__10_ = _startpos__100_ in
+                let _10 = _100 in
+                let _1 =
+                  let _1 = _10 in
+                  
+# 1660 "parsing/parser.mly"
+                 ("+")
+# 9048 "parsing/parser.ml"
+                  
+                in
+                let _endpos__1_ = _endpos__10_ in
+                let _startpos__1_ = _startpos__10_ in
+                let _endpos = _endpos__1_ in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
+                
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 9059 "parsing/parser.ml"
+                
+              in
+              
+# 1661 "parsing/parser.mly"
+      ( mkinfix _1 _2 _3 )
+# 9065 "parsing/parser.ml"
+              
+            in
+            
+# 1639 "parsing/parser.mly"
+            ( _1 )
+# 9071 "parsing/parser.ml"
+            
+          in
+          let _endpos__1_ = _endpos__300_ in
+          let _startpos__1_ = _startpos__100_ in
+          let _endpos = _endpos__1_ in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
+          
+# 738 "parsing/parser.mly"
+    ( mkexp ~loc:_sloc _1 )
+# 9082 "parsing/parser.ml"
+          
+        in
+        
+# 1568 "parsing/parser.mly"
+    ( _1 )
+# 9088 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _3000;
+          MenhirLib.EngineTypes.startp = _startpos__3000_;
+          MenhirLib.EngineTypes.endp = _endpos__3000_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _100000;
+            MenhirLib.EngineTypes.startp = _startpos__100000_;
+            MenhirLib.EngineTypes.endp = _endpos__100000_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.state = _menhir_s;
+              MenhirLib.EngineTypes.semv = _1000;
+              MenhirLib.EngineTypes.startp = _startpos__1000_;
+              MenhirLib.EngineTypes.endp = _endpos__1000_;
+              MenhirLib.EngineTypes.next = _menhir_stack;
+            };
+          };
+        } = _menhir_stack in
+        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
+        let _100000 : unit = Obj.magic _100000 in
+        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1000_ in
+        let _endpos = _endpos__3000_ in
+        let _v : (Parsetree.expression) = let _1 =
+          let _endpos__300_ = _endpos__3000_ in
+          let _endpos__10000_ = _endpos__100000_ in
+          let _startpos__10000_ = _startpos__100000_ in
+          let _startpos__100_ = _startpos__1000_ in
+          let _300 = _3000 in
+          let _10000 = _100000 in
+          let _100 = _1000 in
+          let _1 =
+            let _endpos__1000_ = _endpos__10000_ in
+            let _startpos__1000_ = _startpos__10000_ in
+            let _30 = _300 in
+            let _1000 = _10000 in
+            let _10 = _100 in
+            let _1 =
+              let _endpos__100_ = _endpos__1000_ in
+              let _startpos__100_ = _startpos__1000_ in
+              let _3 = _30 in
+              let _100 = _1000 in
+              let _1 = _10 in
+              let _2 =
+                let _endpos__10_ = _endpos__100_ in
+                let _startpos__10_ = _startpos__100_ in
+                let _10 = _100 in
+                let _1 =
+                  let _1 = _10 in
+                  
+# 1662 "parsing/parser.mly"
+                    ("+.")
+# 9151 "parsing/parser.ml"
+                  
+                in
+                let _endpos__1_ = _endpos__10_ in
+                let _startpos__1_ = _startpos__10_ in
+                let _endpos = _endpos__1_ in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
+                
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 9162 "parsing/parser.ml"
+                
+              in
+              
+# 1663 "parsing/parser.mly"
+      ( mkinfix _1 _2 _3 )
+# 9168 "parsing/parser.ml"
+              
+            in
+            
+# 1639 "parsing/parser.mly"
+            ( _1 )
+# 9174 "parsing/parser.ml"
+            
+          in
+          let _endpos__1_ = _endpos__300_ in
+          let _startpos__1_ = _startpos__100_ in
+          let _endpos = _endpos__1_ in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
+          
+# 738 "parsing/parser.mly"
+    ( mkexp ~loc:_sloc _1 )
+# 9185 "parsing/parser.ml"
+          
+        in
+        
+# 1568 "parsing/parser.mly"
+    ( _1 )
+# 9191 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _3000;
+          MenhirLib.EngineTypes.startp = _startpos__3000_;
+          MenhirLib.EngineTypes.endp = _endpos__3000_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _100000;
+            MenhirLib.EngineTypes.startp = _startpos__100000_;
+            MenhirLib.EngineTypes.endp = _endpos__100000_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.state = _menhir_s;
+              MenhirLib.EngineTypes.semv = _1000;
+              MenhirLib.EngineTypes.startp = _startpos__1000_;
+              MenhirLib.EngineTypes.endp = _endpos__1000_;
+              MenhirLib.EngineTypes.next = _menhir_stack;
+            };
+          };
+        } = _menhir_stack in
+        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
+        let _100000 : unit = Obj.magic _100000 in
+        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1000_ in
+        let _endpos = _endpos__3000_ in
+        let _v : (Parsetree.expression) = let _1 =
+          let _endpos__300_ = _endpos__3000_ in
+          let _endpos__10000_ = _endpos__100000_ in
+          let _startpos__10000_ = _startpos__100000_ in
+          let _startpos__100_ = _startpos__1000_ in
+          let _300 = _3000 in
+          let _10000 = _100000 in
+          let _100 = _1000 in
+          let _1 =
+            let _endpos__1000_ = _endpos__10000_ in
+            let _startpos__1000_ = _startpos__10000_ in
+            let _30 = _300 in
+            let _1000 = _10000 in
+            let _10 = _100 in
+            let _1 =
+              let _endpos__100_ = _endpos__1000_ in
+              let _startpos__100_ = _startpos__1000_ in
+              let _3 = _30 in
+              let _100 = _1000 in
+              let _1 = _10 in
+              let _2 =
+                let _endpos__10_ = _endpos__100_ in
+                let _startpos__10_ = _startpos__100_ in
+                let _10 = _100 in
+                let _1 =
+                  let _1 = _10 in
+                  
+# 1664 "parsing/parser.mly"
+                   ("+=")
+# 9254 "parsing/parser.ml"
+                  
+                in
+                let _endpos__1_ = _endpos__10_ in
+                let _startpos__1_ = _startpos__10_ in
+                let _endpos = _endpos__1_ in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
+                
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 9265 "parsing/parser.ml"
+                
+              in
+              
+# 1665 "parsing/parser.mly"
+      ( mkinfix _1 _2 _3 )
+# 9271 "parsing/parser.ml"
+              
+            in
+            
+# 1639 "parsing/parser.mly"
+            ( _1 )
+# 9277 "parsing/parser.ml"
+            
+          in
+          let _endpos__1_ = _endpos__300_ in
+          let _startpos__1_ = _startpos__100_ in
+          let _endpos = _endpos__1_ in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
+          
+# 738 "parsing/parser.mly"
+    ( mkexp ~loc:_sloc _1 )
+# 9288 "parsing/parser.ml"
+          
+        in
+        
+# 1568 "parsing/parser.mly"
+    ( _1 )
+# 9294 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _3000;
+          MenhirLib.EngineTypes.startp = _startpos__3000_;
+          MenhirLib.EngineTypes.endp = _endpos__3000_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _100000;
+            MenhirLib.EngineTypes.startp = _startpos__100000_;
+            MenhirLib.EngineTypes.endp = _endpos__100000_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.state = _menhir_s;
+              MenhirLib.EngineTypes.semv = _1000;
+              MenhirLib.EngineTypes.startp = _startpos__1000_;
+              MenhirLib.EngineTypes.endp = _endpos__1000_;
+              MenhirLib.EngineTypes.next = _menhir_stack;
+            };
+          };
+        } = _menhir_stack in
+        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
+        let _100000 : unit = Obj.magic _100000 in
+        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1000_ in
+        let _endpos = _endpos__3000_ in
+        let _v : (Parsetree.expression) = let _1 =
+          let _endpos__300_ = _endpos__3000_ in
+          let _endpos__10000_ = _endpos__100000_ in
+          let _startpos__10000_ = _startpos__100000_ in
+          let _startpos__100_ = _startpos__1000_ in
+          let _300 = _3000 in
+          let _10000 = _100000 in
+          let _100 = _1000 in
+          let _1 =
+            let _endpos__1000_ = _endpos__10000_ in
+            let _startpos__1000_ = _startpos__10000_ in
+            let _30 = _300 in
+            let _1000 = _10000 in
+            let _10 = _100 in
+            let _1 =
+              let _endpos__100_ = _endpos__1000_ in
+              let _startpos__100_ = _startpos__1000_ in
+              let _3 = _30 in
+              let _100 = _1000 in
+              let _1 = _10 in
+              let _2 =
+                let _endpos__10_ = _endpos__100_ in
+                let _startpos__10_ = _startpos__100_ in
+                let _10 = _100 in
+                let _1 =
+                  let _1 = _10 in
+                  
+# 1666 "parsing/parser.mly"
+                  ("-")
+# 9357 "parsing/parser.ml"
+                  
+                in
+                let _endpos__1_ = _endpos__10_ in
+                let _startpos__1_ = _startpos__10_ in
+                let _endpos = _endpos__1_ in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
+                
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 9368 "parsing/parser.ml"
+                
+              in
+              
+# 1667 "parsing/parser.mly"
+      ( mkinfix _1 _2 _3 )
+# 9374 "parsing/parser.ml"
+              
+            in
+            
+# 1639 "parsing/parser.mly"
+            ( _1 )
+# 9380 "parsing/parser.ml"
+            
+          in
+          let _endpos__1_ = _endpos__300_ in
+          let _startpos__1_ = _startpos__100_ in
+          let _endpos = _endpos__1_ in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
+          
+# 738 "parsing/parser.mly"
+    ( mkexp ~loc:_sloc _1 )
+# 9391 "parsing/parser.ml"
+          
+        in
+        
+# 1568 "parsing/parser.mly"
+    ( _1 )
+# 9397 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _3000;
+          MenhirLib.EngineTypes.startp = _startpos__3000_;
+          MenhirLib.EngineTypes.endp = _endpos__3000_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _100000;
+            MenhirLib.EngineTypes.startp = _startpos__100000_;
+            MenhirLib.EngineTypes.endp = _endpos__100000_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.state = _menhir_s;
+              MenhirLib.EngineTypes.semv = _1000;
+              MenhirLib.EngineTypes.startp = _startpos__1000_;
+              MenhirLib.EngineTypes.endp = _endpos__1000_;
+              MenhirLib.EngineTypes.next = _menhir_stack;
+            };
+          };
+        } = _menhir_stack in
+        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
+        let _100000 : unit = Obj.magic _100000 in
+        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1000_ in
+        let _endpos = _endpos__3000_ in
+        let _v : (Parsetree.expression) = let _1 =
+          let _endpos__300_ = _endpos__3000_ in
+          let _endpos__10000_ = _endpos__100000_ in
+          let _startpos__10000_ = _startpos__100000_ in
+          let _startpos__100_ = _startpos__1000_ in
+          let _300 = _3000 in
+          let _10000 = _100000 in
+          let _100 = _1000 in
+          let _1 =
+            let _endpos__1000_ = _endpos__10000_ in
+            let _startpos__1000_ = _startpos__10000_ in
+            let _30 = _300 in
+            let _1000 = _10000 in
+            let _10 = _100 in
+            let _1 =
+              let _endpos__100_ = _endpos__1000_ in
+              let _startpos__100_ = _startpos__1000_ in
+              let _3 = _30 in
+              let _100 = _1000 in
+              let _1 = _10 in
+              let _2 =
+                let _endpos__10_ = _endpos__100_ in
+                let _startpos__10_ = _startpos__100_ in
+                let _10 = _100 in
+                let _1 =
+                  let _1 = _10 in
+                  
+# 1668 "parsing/parser.mly"
+                     ("-.")
+# 9460 "parsing/parser.ml"
+                  
+                in
+                let _endpos__1_ = _endpos__10_ in
+                let _startpos__1_ = _startpos__10_ in
+                let _endpos = _endpos__1_ in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
+                
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 9471 "parsing/parser.ml"
+                
+              in
+              
+# 1669 "parsing/parser.mly"
+      ( mkinfix _1 _2 _3 )
+# 9477 "parsing/parser.ml"
+              
+            in
+            
+# 1639 "parsing/parser.mly"
+            ( _1 )
+# 9483 "parsing/parser.ml"
+            
+          in
+          let _endpos__1_ = _endpos__300_ in
+          let _startpos__1_ = _startpos__100_ in
+          let _endpos = _endpos__1_ in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
+          
+# 738 "parsing/parser.mly"
+    ( mkexp ~loc:_sloc _1 )
+# 9494 "parsing/parser.ml"
+          
+        in
+        
+# 1568 "parsing/parser.mly"
+    ( _1 )
+# 9500 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -9237,33 +9558,31 @@ module Tables = struct
                   let _1 = _10 in
                   
 # 1670 "parsing/parser.mly"
-                 ("+")
-# 9242 "parsing/parser.ml"
+                 ("*")
+# 9563 "parsing/parser.ml"
                   
                 in
                 let _endpos__1_ = _endpos__10_ in
                 let _startpos__1_ = _startpos__10_ in
                 let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
                 
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 9255 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 9574 "parsing/parser.ml"
                 
               in
               
 # 1671 "parsing/parser.mly"
       ( mkinfix _1 _2 _3 )
-# 9261 "parsing/parser.ml"
+# 9580 "parsing/parser.ml"
               
             in
             
-# 1649 "parsing/parser.mly"
+# 1639 "parsing/parser.mly"
             ( _1 )
-# 9267 "parsing/parser.ml"
+# 9586 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__300_ in
@@ -9272,15 +9591,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 9278 "parsing/parser.ml"
+# 9597 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 9284 "parsing/parser.ml"
+# 9603 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -9342,33 +9661,31 @@ module Tables = struct
                   let _1 = _10 in
                   
 # 1672 "parsing/parser.mly"
-                    ("+.")
-# 9347 "parsing/parser.ml"
+                    ("%")
+# 9666 "parsing/parser.ml"
                   
                 in
                 let _endpos__1_ = _endpos__10_ in
                 let _startpos__1_ = _startpos__10_ in
                 let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
                 
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 9360 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 9677 "parsing/parser.ml"
                 
               in
               
 # 1673 "parsing/parser.mly"
       ( mkinfix _1 _2 _3 )
-# 9366 "parsing/parser.ml"
+# 9683 "parsing/parser.ml"
               
             in
             
-# 1649 "parsing/parser.mly"
+# 1639 "parsing/parser.mly"
             ( _1 )
-# 9372 "parsing/parser.ml"
+# 9689 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__300_ in
@@ -9377,15 +9694,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 9383 "parsing/parser.ml"
+# 9700 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 9389 "parsing/parser.ml"
+# 9706 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -9447,346 +9764,29 @@ module Tables = struct
                   let _1 = _10 in
                   
 # 1674 "parsing/parser.mly"
-                   ("+=")
-# 9452 "parsing/parser.ml"
+                  ("=")
+# 9769 "parsing/parser.ml"
                   
                 in
                 let _endpos__1_ = _endpos__10_ in
                 let _startpos__1_ = _startpos__10_ in
                 let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
                 
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 9465 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 9780 "parsing/parser.ml"
                 
               in
               
 # 1675 "parsing/parser.mly"
       ( mkinfix _1 _2 _3 )
-# 9471 "parsing/parser.ml"
-              
-            in
-            
-# 1649 "parsing/parser.mly"
-            ( _1 )
-# 9477 "parsing/parser.ml"
-            
-          in
-          let _endpos__1_ = _endpos__300_ in
-          let _startpos__1_ = _startpos__100_ in
-          let _endpos = _endpos__1_ in
-          let _symbolstartpos = _startpos__1_ in
-          let _sloc = (_symbolstartpos, _endpos) in
-          
-# 748 "parsing/parser.mly"
-    ( mkexp ~loc:_sloc _1 )
-# 9488 "parsing/parser.ml"
-          
-        in
-        
-# 1578 "parsing/parser.mly"
-    ( _1 )
-# 9494 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _3000;
-          MenhirLib.EngineTypes.startp = _startpos__3000_;
-          MenhirLib.EngineTypes.endp = _endpos__3000_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _100000;
-            MenhirLib.EngineTypes.startp = _startpos__100000_;
-            MenhirLib.EngineTypes.endp = _endpos__100000_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.state = _menhir_s;
-              MenhirLib.EngineTypes.semv = _1000;
-              MenhirLib.EngineTypes.startp = _startpos__1000_;
-              MenhirLib.EngineTypes.endp = _endpos__1000_;
-              MenhirLib.EngineTypes.next = _menhir_stack;
-            };
-          };
-        } = _menhir_stack in
-        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
-        let _100000 : unit = Obj.magic _100000 in
-        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1000_ in
-        let _endpos = _endpos__3000_ in
-        let _v : (Parsetree.expression) = let _1 =
-          let _endpos__300_ = _endpos__3000_ in
-          let _endpos__10000_ = _endpos__100000_ in
-          let _startpos__10000_ = _startpos__100000_ in
-          let _startpos__100_ = _startpos__1000_ in
-          let _300 = _3000 in
-          let _10000 = _100000 in
-          let _100 = _1000 in
-          let _1 =
-            let _endpos__1000_ = _endpos__10000_ in
-            let _startpos__1000_ = _startpos__10000_ in
-            let _30 = _300 in
-            let _1000 = _10000 in
-            let _10 = _100 in
-            let _1 =
-              let _endpos__100_ = _endpos__1000_ in
-              let _startpos__100_ = _startpos__1000_ in
-              let _3 = _30 in
-              let _100 = _1000 in
-              let _1 = _10 in
-              let _2 =
-                let _endpos__10_ = _endpos__100_ in
-                let _startpos__10_ = _startpos__100_ in
-                let _10 = _100 in
-                let _1 =
-                  let _1 = _10 in
-                  
-# 1676 "parsing/parser.mly"
-                  ("-")
-# 9557 "parsing/parser.ml"
-                  
-                in
-                let _endpos__1_ = _endpos__10_ in
-                let _startpos__1_ = _startpos__10_ in
-                let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
-                
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 9570 "parsing/parser.ml"
-                
-              in
-              
-# 1677 "parsing/parser.mly"
-      ( mkinfix _1 _2 _3 )
-# 9576 "parsing/parser.ml"
-              
-            in
-            
-# 1649 "parsing/parser.mly"
-            ( _1 )
-# 9582 "parsing/parser.ml"
-            
-          in
-          let _endpos__1_ = _endpos__300_ in
-          let _startpos__1_ = _startpos__100_ in
-          let _endpos = _endpos__1_ in
-          let _symbolstartpos = _startpos__1_ in
-          let _sloc = (_symbolstartpos, _endpos) in
-          
-# 748 "parsing/parser.mly"
-    ( mkexp ~loc:_sloc _1 )
-# 9593 "parsing/parser.ml"
-          
-        in
-        
-# 1578 "parsing/parser.mly"
-    ( _1 )
-# 9599 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _3000;
-          MenhirLib.EngineTypes.startp = _startpos__3000_;
-          MenhirLib.EngineTypes.endp = _endpos__3000_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _100000;
-            MenhirLib.EngineTypes.startp = _startpos__100000_;
-            MenhirLib.EngineTypes.endp = _endpos__100000_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.state = _menhir_s;
-              MenhirLib.EngineTypes.semv = _1000;
-              MenhirLib.EngineTypes.startp = _startpos__1000_;
-              MenhirLib.EngineTypes.endp = _endpos__1000_;
-              MenhirLib.EngineTypes.next = _menhir_stack;
-            };
-          };
-        } = _menhir_stack in
-        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
-        let _100000 : unit = Obj.magic _100000 in
-        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1000_ in
-        let _endpos = _endpos__3000_ in
-        let _v : (Parsetree.expression) = let _1 =
-          let _endpos__300_ = _endpos__3000_ in
-          let _endpos__10000_ = _endpos__100000_ in
-          let _startpos__10000_ = _startpos__100000_ in
-          let _startpos__100_ = _startpos__1000_ in
-          let _300 = _3000 in
-          let _10000 = _100000 in
-          let _100 = _1000 in
-          let _1 =
-            let _endpos__1000_ = _endpos__10000_ in
-            let _startpos__1000_ = _startpos__10000_ in
-            let _30 = _300 in
-            let _1000 = _10000 in
-            let _10 = _100 in
-            let _1 =
-              let _endpos__100_ = _endpos__1000_ in
-              let _startpos__100_ = _startpos__1000_ in
-              let _3 = _30 in
-              let _100 = _1000 in
-              let _1 = _10 in
-              let _2 =
-                let _endpos__10_ = _endpos__100_ in
-                let _startpos__10_ = _startpos__100_ in
-                let _10 = _100 in
-                let _1 =
-                  let _1 = _10 in
-                  
-# 1678 "parsing/parser.mly"
-                     ("-.")
-# 9662 "parsing/parser.ml"
-                  
-                in
-                let _endpos__1_ = _endpos__10_ in
-                let _startpos__1_ = _startpos__10_ in
-                let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
-                
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 9675 "parsing/parser.ml"
-                
-              in
-              
-# 1679 "parsing/parser.mly"
-      ( mkinfix _1 _2 _3 )
-# 9681 "parsing/parser.ml"
-              
-            in
-            
-# 1649 "parsing/parser.mly"
-            ( _1 )
-# 9687 "parsing/parser.ml"
-            
-          in
-          let _endpos__1_ = _endpos__300_ in
-          let _startpos__1_ = _startpos__100_ in
-          let _endpos = _endpos__1_ in
-          let _symbolstartpos = _startpos__1_ in
-          let _sloc = (_symbolstartpos, _endpos) in
-          
-# 748 "parsing/parser.mly"
-    ( mkexp ~loc:_sloc _1 )
-# 9698 "parsing/parser.ml"
-          
-        in
-        
-# 1578 "parsing/parser.mly"
-    ( _1 )
-# 9704 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _3000;
-          MenhirLib.EngineTypes.startp = _startpos__3000_;
-          MenhirLib.EngineTypes.endp = _endpos__3000_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _100000;
-            MenhirLib.EngineTypes.startp = _startpos__100000_;
-            MenhirLib.EngineTypes.endp = _endpos__100000_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.state = _menhir_s;
-              MenhirLib.EngineTypes.semv = _1000;
-              MenhirLib.EngineTypes.startp = _startpos__1000_;
-              MenhirLib.EngineTypes.endp = _endpos__1000_;
-              MenhirLib.EngineTypes.next = _menhir_stack;
-            };
-          };
-        } = _menhir_stack in
-        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
-        let _100000 : unit = Obj.magic _100000 in
-        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1000_ in
-        let _endpos = _endpos__3000_ in
-        let _v : (Parsetree.expression) = let _1 =
-          let _endpos__300_ = _endpos__3000_ in
-          let _endpos__10000_ = _endpos__100000_ in
-          let _startpos__10000_ = _startpos__100000_ in
-          let _startpos__100_ = _startpos__1000_ in
-          let _300 = _3000 in
-          let _10000 = _100000 in
-          let _100 = _1000 in
-          let _1 =
-            let _endpos__1000_ = _endpos__10000_ in
-            let _startpos__1000_ = _startpos__10000_ in
-            let _30 = _300 in
-            let _1000 = _10000 in
-            let _10 = _100 in
-            let _1 =
-              let _endpos__100_ = _endpos__1000_ in
-              let _startpos__100_ = _startpos__1000_ in
-              let _3 = _30 in
-              let _100 = _1000 in
-              let _1 = _10 in
-              let _2 =
-                let _endpos__10_ = _endpos__100_ in
-                let _startpos__10_ = _startpos__100_ in
-                let _10 = _100 in
-                let _1 =
-                  let _1 = _10 in
-                  
-# 1680 "parsing/parser.mly"
-                 ("*")
-# 9767 "parsing/parser.ml"
-                  
-                in
-                let _endpos__1_ = _endpos__10_ in
-                let _startpos__1_ = _startpos__10_ in
-                let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
-                
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 9780 "parsing/parser.ml"
-                
-              in
-              
-# 1681 "parsing/parser.mly"
-      ( mkinfix _1 _2 _3 )
 # 9786 "parsing/parser.ml"
               
             in
             
-# 1649 "parsing/parser.mly"
+# 1639 "parsing/parser.mly"
             ( _1 )
 # 9792 "parsing/parser.ml"
             
@@ -9797,13 +9797,13 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
 # 9803 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
 # 9809 "parsing/parser.ml"
          in
@@ -9866,34 +9866,32 @@ module Tables = struct
                 let _1 =
                   let _1 = _10 in
                   
-# 1682 "parsing/parser.mly"
-                    ("%")
+# 1676 "parsing/parser.mly"
+                 ("<")
 # 9872 "parsing/parser.ml"
                   
                 in
                 let _endpos__1_ = _endpos__10_ in
                 let _startpos__1_ = _startpos__10_ in
                 let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
                 
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 9885 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 9883 "parsing/parser.ml"
                 
               in
               
-# 1683 "parsing/parser.mly"
-      ( mkinfix _1 _2 _3 )
-# 9891 "parsing/parser.ml"
+# 1677 "parsing/parser.mly"
+    ( mkinfix _1 _2 _3 )
+# 9889 "parsing/parser.ml"
               
             in
             
-# 1649 "parsing/parser.mly"
+# 1639 "parsing/parser.mly"
             ( _1 )
-# 9897 "parsing/parser.ml"
+# 9895 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__300_ in
@@ -9902,15 +9900,324 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 9908 "parsing/parser.ml"
+# 9906 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 9914 "parsing/parser.ml"
+# 9912 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _3000;
+          MenhirLib.EngineTypes.startp = _startpos__3000_;
+          MenhirLib.EngineTypes.endp = _endpos__3000_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _100000;
+            MenhirLib.EngineTypes.startp = _startpos__100000_;
+            MenhirLib.EngineTypes.endp = _endpos__100000_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.state = _menhir_s;
+              MenhirLib.EngineTypes.semv = _1000;
+              MenhirLib.EngineTypes.startp = _startpos__1000_;
+              MenhirLib.EngineTypes.endp = _endpos__1000_;
+              MenhirLib.EngineTypes.next = _menhir_stack;
+            };
+          };
+        } = _menhir_stack in
+        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
+        let _100000 : unit = Obj.magic _100000 in
+        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1000_ in
+        let _endpos = _endpos__3000_ in
+        let _v : (Parsetree.expression) = let _1 =
+          let _endpos__300_ = _endpos__3000_ in
+          let _endpos__10000_ = _endpos__100000_ in
+          let _startpos__10000_ = _startpos__100000_ in
+          let _startpos__100_ = _startpos__1000_ in
+          let _300 = _3000 in
+          let _10000 = _100000 in
+          let _100 = _1000 in
+          let _1 =
+            let _endpos__1000_ = _endpos__10000_ in
+            let _startpos__1000_ = _startpos__10000_ in
+            let _30 = _300 in
+            let _1000 = _10000 in
+            let _10 = _100 in
+            let _1 =
+              let _endpos__100_ = _endpos__1000_ in
+              let _startpos__100_ = _startpos__1000_ in
+              let _3 = _30 in
+              let _100 = _1000 in
+              let _1 = _10 in
+              let _2 =
+                let _endpos__10_ = _endpos__100_ in
+                let _startpos__10_ = _startpos__100_ in
+                let _10 = _100 in
+                let _1 =
+                  let _1 = _10 in
+                  
+# 1678 "parsing/parser.mly"
+                    (">")
+# 9975 "parsing/parser.ml"
+                  
+                in
+                let _endpos__1_ = _endpos__10_ in
+                let _startpos__1_ = _startpos__10_ in
+                let _endpos = _endpos__1_ in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
+                
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 9986 "parsing/parser.ml"
+                
+              in
+              
+# 1679 "parsing/parser.mly"
+      ( mkinfix _1 _2 _3 )
+# 9992 "parsing/parser.ml"
+              
+            in
+            
+# 1639 "parsing/parser.mly"
+            ( _1 )
+# 9998 "parsing/parser.ml"
+            
+          in
+          let _endpos__1_ = _endpos__300_ in
+          let _startpos__1_ = _startpos__100_ in
+          let _endpos = _endpos__1_ in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
+          
+# 738 "parsing/parser.mly"
+    ( mkexp ~loc:_sloc _1 )
+# 10009 "parsing/parser.ml"
+          
+        in
+        
+# 1568 "parsing/parser.mly"
+    ( _1 )
+# 10015 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _3000;
+          MenhirLib.EngineTypes.startp = _startpos__3000_;
+          MenhirLib.EngineTypes.endp = _endpos__3000_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _100000;
+            MenhirLib.EngineTypes.startp = _startpos__100000_;
+            MenhirLib.EngineTypes.endp = _endpos__100000_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.state = _menhir_s;
+              MenhirLib.EngineTypes.semv = _1000;
+              MenhirLib.EngineTypes.startp = _startpos__1000_;
+              MenhirLib.EngineTypes.endp = _endpos__1000_;
+              MenhirLib.EngineTypes.next = _menhir_stack;
+            };
+          };
+        } = _menhir_stack in
+        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
+        let _100000 : unit = Obj.magic _100000 in
+        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1000_ in
+        let _endpos = _endpos__3000_ in
+        let _v : (Parsetree.expression) = let _1 =
+          let _endpos__300_ = _endpos__3000_ in
+          let _endpos__10000_ = _endpos__100000_ in
+          let _startpos__10000_ = _startpos__100000_ in
+          let _startpos__100_ = _startpos__1000_ in
+          let _300 = _3000 in
+          let _10000 = _100000 in
+          let _100 = _1000 in
+          let _1 =
+            let _endpos__1000_ = _endpos__10000_ in
+            let _startpos__1000_ = _startpos__10000_ in
+            let _30 = _300 in
+            let _1000 = _10000 in
+            let _10 = _100 in
+            let _1 =
+              let _endpos__100_ = _endpos__1000_ in
+              let _startpos__100_ = _startpos__1000_ in
+              let _3 = _30 in
+              let _100 = _1000 in
+              let _1 = _10 in
+              let _2 =
+                let _endpos__10_ = _endpos__100_ in
+                let _startpos__10_ = _startpos__100_ in
+                let _10 = _100 in
+                let _1 =
+                  let _1 = _10 in
+                  
+# 1680 "parsing/parser.mly"
+               ("or")
+# 10078 "parsing/parser.ml"
+                  
+                in
+                let _endpos__1_ = _endpos__10_ in
+                let _startpos__1_ = _startpos__10_ in
+                let _endpos = _endpos__1_ in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
+                
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 10089 "parsing/parser.ml"
+                
+              in
+              
+# 1681 "parsing/parser.mly"
+      ( mkinfix _1 _2 _3 )
+# 10095 "parsing/parser.ml"
+              
+            in
+            
+# 1639 "parsing/parser.mly"
+            ( _1 )
+# 10101 "parsing/parser.ml"
+            
+          in
+          let _endpos__1_ = _endpos__300_ in
+          let _startpos__1_ = _startpos__100_ in
+          let _endpos = _endpos__1_ in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
+          
+# 738 "parsing/parser.mly"
+    ( mkexp ~loc:_sloc _1 )
+# 10112 "parsing/parser.ml"
+          
+        in
+        
+# 1568 "parsing/parser.mly"
+    ( _1 )
+# 10118 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _3000;
+          MenhirLib.EngineTypes.startp = _startpos__3000_;
+          MenhirLib.EngineTypes.endp = _endpos__3000_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _100000;
+            MenhirLib.EngineTypes.startp = _startpos__100000_;
+            MenhirLib.EngineTypes.endp = _endpos__100000_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.state = _menhir_s;
+              MenhirLib.EngineTypes.semv = _1000;
+              MenhirLib.EngineTypes.startp = _startpos__1000_;
+              MenhirLib.EngineTypes.endp = _endpos__1000_;
+              MenhirLib.EngineTypes.next = _menhir_stack;
+            };
+          };
+        } = _menhir_stack in
+        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
+        let _100000 : unit = Obj.magic _100000 in
+        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1000_ in
+        let _endpos = _endpos__3000_ in
+        let _v : (Parsetree.expression) = let _1 =
+          let _endpos__300_ = _endpos__3000_ in
+          let _endpos__10000_ = _endpos__100000_ in
+          let _startpos__10000_ = _startpos__100000_ in
+          let _startpos__100_ = _startpos__1000_ in
+          let _300 = _3000 in
+          let _10000 = _100000 in
+          let _100 = _1000 in
+          let _1 =
+            let _endpos__1000_ = _endpos__10000_ in
+            let _startpos__1000_ = _startpos__10000_ in
+            let _30 = _300 in
+            let _1000 = _10000 in
+            let _10 = _100 in
+            let _1 =
+              let _endpos__100_ = _endpos__1000_ in
+              let _startpos__100_ = _startpos__1000_ in
+              let _3 = _30 in
+              let _100 = _1000 in
+              let _1 = _10 in
+              let _2 =
+                let _endpos__10_ = _endpos__100_ in
+                let _startpos__10_ = _startpos__100_ in
+                let _10 = _100 in
+                let _1 =
+                  let _1 = _10 in
+                  
+# 1682 "parsing/parser.mly"
+                   ("||")
+# 10181 "parsing/parser.ml"
+                  
+                in
+                let _endpos__1_ = _endpos__10_ in
+                let _startpos__1_ = _startpos__10_ in
+                let _endpos = _endpos__1_ in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
+                
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 10192 "parsing/parser.ml"
+                
+              in
+              
+# 1683 "parsing/parser.mly"
+      ( mkinfix _1 _2 _3 )
+# 10198 "parsing/parser.ml"
+              
+            in
+            
+# 1639 "parsing/parser.mly"
+            ( _1 )
+# 10204 "parsing/parser.ml"
+            
+          in
+          let _endpos__1_ = _endpos__300_ in
+          let _startpos__1_ = _startpos__100_ in
+          let _endpos = _endpos__1_ in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
+          
+# 738 "parsing/parser.mly"
+    ( mkexp ~loc:_sloc _1 )
+# 10215 "parsing/parser.ml"
+          
+        in
+        
+# 1568 "parsing/parser.mly"
+    ( _1 )
+# 10221 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -9972,33 +10279,31 @@ module Tables = struct
                   let _1 = _10 in
                   
 # 1684 "parsing/parser.mly"
-                  ("=")
-# 9977 "parsing/parser.ml"
+                      ("&")
+# 10284 "parsing/parser.ml"
                   
                 in
                 let _endpos__1_ = _endpos__10_ in
                 let _startpos__1_ = _startpos__10_ in
                 let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
                 
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 9990 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 10295 "parsing/parser.ml"
                 
               in
               
 # 1685 "parsing/parser.mly"
       ( mkinfix _1 _2 _3 )
-# 9996 "parsing/parser.ml"
+# 10301 "parsing/parser.ml"
               
             in
             
-# 1649 "parsing/parser.mly"
+# 1639 "parsing/parser.mly"
             ( _1 )
-# 10002 "parsing/parser.ml"
+# 10307 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__300_ in
@@ -10007,15 +10312,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 10013 "parsing/parser.ml"
+# 10318 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 10019 "parsing/parser.ml"
+# 10324 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -10077,33 +10382,31 @@ module Tables = struct
                   let _1 = _10 in
                   
 # 1686 "parsing/parser.mly"
-                 ("<")
-# 10082 "parsing/parser.ml"
+                       ("&&")
+# 10387 "parsing/parser.ml"
                   
                 in
                 let _endpos__1_ = _endpos__10_ in
                 let _startpos__1_ = _startpos__10_ in
                 let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
                 
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 10095 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 10398 "parsing/parser.ml"
                 
               in
               
 # 1687 "parsing/parser.mly"
-    ( mkinfix _1 _2 _3 )
-# 10101 "parsing/parser.ml"
+      ( mkinfix _1 _2 _3 )
+# 10404 "parsing/parser.ml"
               
             in
             
-# 1649 "parsing/parser.mly"
+# 1639 "parsing/parser.mly"
             ( _1 )
-# 10107 "parsing/parser.ml"
+# 10410 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__300_ in
@@ -10112,15 +10415,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 10118 "parsing/parser.ml"
+# 10421 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 10124 "parsing/parser.ml"
+# 10427 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -10182,33 +10485,31 @@ module Tables = struct
                   let _1 = _10 in
                   
 # 1688 "parsing/parser.mly"
-                    (">")
-# 10187 "parsing/parser.ml"
+                       (":=")
+# 10490 "parsing/parser.ml"
                   
                 in
                 let _endpos__1_ = _endpos__10_ in
                 let _startpos__1_ = _startpos__10_ in
                 let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
+                let _symbolstartpos = _startpos__1_ in
+                let _sloc = (_symbolstartpos, _endpos) in
                 
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 10200 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 10501 "parsing/parser.ml"
                 
               in
               
 # 1689 "parsing/parser.mly"
       ( mkinfix _1 _2 _3 )
-# 10206 "parsing/parser.ml"
+# 10507 "parsing/parser.ml"
               
             in
             
-# 1649 "parsing/parser.mly"
+# 1639 "parsing/parser.mly"
             ( _1 )
-# 10212 "parsing/parser.ml"
+# 10513 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__300_ in
@@ -10217,15 +10518,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 10223 "parsing/parser.ml"
+# 10524 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 10229 "parsing/parser.ml"
+# 10530 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -10237,100 +10538,66 @@ module Tables = struct
       (fun _menhir_env ->
         let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
         let {
-          MenhirLib.EngineTypes.semv = _3000;
-          MenhirLib.EngineTypes.startp = _startpos__3000_;
-          MenhirLib.EngineTypes.endp = _endpos__3000_;
+          MenhirLib.EngineTypes.semv = _2000;
+          MenhirLib.EngineTypes.startp = _startpos__2000_;
+          MenhirLib.EngineTypes.endp = _endpos__2000_;
           MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _100000;
-            MenhirLib.EngineTypes.startp = _startpos__100000_;
-            MenhirLib.EngineTypes.endp = _endpos__100000_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.state = _menhir_s;
-              MenhirLib.EngineTypes.semv = _1000;
-              MenhirLib.EngineTypes.startp = _startpos__1000_;
-              MenhirLib.EngineTypes.endp = _endpos__1000_;
-              MenhirLib.EngineTypes.next = _menhir_stack;
-            };
+            MenhirLib.EngineTypes.state = _menhir_s;
+            MenhirLib.EngineTypes.semv = _1000;
+            MenhirLib.EngineTypes.startp = _startpos__1000_;
+            MenhirLib.EngineTypes.endp = _endpos__1000_;
+            MenhirLib.EngineTypes.next = _menhir_stack;
           };
         } = _menhir_stack in
-        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
-        let _100000 : unit = Obj.magic _100000 in
-        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
+        let _2000 : (Parsetree.expression) = Obj.magic _2000 in
+        let _1000 : (string) = Obj.magic _1000 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1000_ in
-        let _endpos = _endpos__3000_ in
+        let _endpos = _endpos__2000_ in
         let _v : (Parsetree.expression) = let _1 =
-          let _endpos__300_ = _endpos__3000_ in
-          let _endpos__10000_ = _endpos__100000_ in
-          let _startpos__10000_ = _startpos__100000_ in
+          let _endpos__200_ = _endpos__2000_ in
+          let _endpos__100_ = _endpos__1000_ in
           let _startpos__100_ = _startpos__1000_ in
-          let _300 = _3000 in
-          let _10000 = _100000 in
+          let _200 = _2000 in
           let _100 = _1000 in
           let _1 =
-            let _endpos__1000_ = _endpos__10000_ in
-            let _startpos__1000_ = _startpos__10000_ in
-            let _30 = _300 in
-            let _1000 = _10000 in
+            let _endpos__10_ = _endpos__100_ in
+            let _startpos__10_ = _startpos__100_ in
+            let _20 = _200 in
             let _10 = _100 in
             let _1 =
-              let _endpos__100_ = _endpos__1000_ in
-              let _startpos__100_ = _startpos__1000_ in
-              let _3 = _30 in
-              let _100 = _1000 in
+              let _endpos__1_ = _endpos__10_ in
+              let _startpos__1_ = _startpos__10_ in
+              let _2 = _20 in
               let _1 = _10 in
-              let _2 =
-                let _endpos__10_ = _endpos__100_ in
-                let _startpos__10_ = _startpos__100_ in
-                let _10 = _100 in
-                let _1 =
-                  let _1 = _10 in
-                  
-# 1690 "parsing/parser.mly"
-               ("or")
-# 10292 "parsing/parser.ml"
-                  
-                in
-                let _endpos__1_ = _endpos__10_ in
-                let _startpos__1_ = _startpos__10_ in
-                let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
-                
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 10305 "parsing/parser.ml"
-                
-              in
+              let _loc__1_ = (_startpos__1_, _endpos__1_) in
               
 # 1691 "parsing/parser.mly"
-      ( mkinfix _1 _2 _3 )
-# 10311 "parsing/parser.ml"
+      ( mkuminus ~oploc:_loc__1_ _1 _2 )
+# 10578 "parsing/parser.ml"
               
             in
             
-# 1649 "parsing/parser.mly"
+# 1639 "parsing/parser.mly"
             ( _1 )
-# 10317 "parsing/parser.ml"
+# 10584 "parsing/parser.ml"
             
           in
-          let _endpos__1_ = _endpos__300_ in
+          let _endpos__1_ = _endpos__200_ in
           let _startpos__1_ = _startpos__100_ in
           let _endpos = _endpos__1_ in
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 10328 "parsing/parser.ml"
+# 10595 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 10334 "parsing/parser.ml"
+# 10601 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -10342,540 +10609,49 @@ module Tables = struct
       (fun _menhir_env ->
         let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
         let {
-          MenhirLib.EngineTypes.semv = _3000;
-          MenhirLib.EngineTypes.startp = _startpos__3000_;
-          MenhirLib.EngineTypes.endp = _endpos__3000_;
+          MenhirLib.EngineTypes.semv = _2000;
+          MenhirLib.EngineTypes.startp = _startpos__2000_;
+          MenhirLib.EngineTypes.endp = _endpos__2000_;
           MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _100000;
-            MenhirLib.EngineTypes.startp = _startpos__100000_;
-            MenhirLib.EngineTypes.endp = _endpos__100000_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.state = _menhir_s;
-              MenhirLib.EngineTypes.semv = _1000;
-              MenhirLib.EngineTypes.startp = _startpos__1000_;
-              MenhirLib.EngineTypes.endp = _endpos__1000_;
-              MenhirLib.EngineTypes.next = _menhir_stack;
-            };
+            MenhirLib.EngineTypes.state = _menhir_s;
+            MenhirLib.EngineTypes.semv = _1000;
+            MenhirLib.EngineTypes.startp = _startpos__1000_;
+            MenhirLib.EngineTypes.endp = _endpos__1000_;
+            MenhirLib.EngineTypes.next = _menhir_stack;
           };
         } = _menhir_stack in
-        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
-        let _100000 : unit = Obj.magic _100000 in
-        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
+        let _2000 : (Parsetree.expression) = Obj.magic _2000 in
+        let _1000 : (string) = Obj.magic _1000 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1000_ in
-        let _endpos = _endpos__3000_ in
+        let _endpos = _endpos__2000_ in
         let _v : (Parsetree.expression) = let _1 =
-          let _endpos__300_ = _endpos__3000_ in
-          let _endpos__10000_ = _endpos__100000_ in
-          let _startpos__10000_ = _startpos__100000_ in
+          let _endpos__200_ = _endpos__2000_ in
+          let _endpos__100_ = _endpos__1000_ in
           let _startpos__100_ = _startpos__1000_ in
-          let _300 = _3000 in
-          let _10000 = _100000 in
+          let _200 = _2000 in
           let _100 = _1000 in
           let _1 =
-            let _endpos__1000_ = _endpos__10000_ in
-            let _startpos__1000_ = _startpos__10000_ in
-            let _30 = _300 in
-            let _1000 = _10000 in
+            let _endpos__10_ = _endpos__100_ in
+            let _startpos__10_ = _startpos__100_ in
+            let _20 = _200 in
             let _10 = _100 in
             let _1 =
-              let _endpos__100_ = _endpos__1000_ in
-              let _startpos__100_ = _startpos__1000_ in
-              let _3 = _30 in
-              let _100 = _1000 in
+              let _endpos__1_ = _endpos__10_ in
+              let _startpos__1_ = _startpos__10_ in
+              let _2 = _20 in
               let _1 = _10 in
-              let _2 =
-                let _endpos__10_ = _endpos__100_ in
-                let _startpos__10_ = _startpos__100_ in
-                let _10 = _100 in
-                let _1 =
-                  let _1 = _10 in
-                  
-# 1692 "parsing/parser.mly"
-                   ("||")
-# 10397 "parsing/parser.ml"
-                  
-                in
-                let _endpos__1_ = _endpos__10_ in
-                let _startpos__1_ = _startpos__10_ in
-                let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
-                
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 10410 "parsing/parser.ml"
-                
-              in
+              let _loc__1_ = (_startpos__1_, _endpos__1_) in
               
 # 1693 "parsing/parser.mly"
-      ( mkinfix _1 _2 _3 )
-# 10416 "parsing/parser.ml"
-              
-            in
-            
-# 1649 "parsing/parser.mly"
-            ( _1 )
-# 10422 "parsing/parser.ml"
-            
-          in
-          let _endpos__1_ = _endpos__300_ in
-          let _startpos__1_ = _startpos__100_ in
-          let _endpos = _endpos__1_ in
-          let _symbolstartpos = _startpos__1_ in
-          let _sloc = (_symbolstartpos, _endpos) in
-          
-# 748 "parsing/parser.mly"
-    ( mkexp ~loc:_sloc _1 )
-# 10433 "parsing/parser.ml"
-          
-        in
-        
-# 1578 "parsing/parser.mly"
-    ( _1 )
-# 10439 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _3000;
-          MenhirLib.EngineTypes.startp = _startpos__3000_;
-          MenhirLib.EngineTypes.endp = _endpos__3000_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _100000;
-            MenhirLib.EngineTypes.startp = _startpos__100000_;
-            MenhirLib.EngineTypes.endp = _endpos__100000_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.state = _menhir_s;
-              MenhirLib.EngineTypes.semv = _1000;
-              MenhirLib.EngineTypes.startp = _startpos__1000_;
-              MenhirLib.EngineTypes.endp = _endpos__1000_;
-              MenhirLib.EngineTypes.next = _menhir_stack;
-            };
-          };
-        } = _menhir_stack in
-        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
-        let _100000 : unit = Obj.magic _100000 in
-        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1000_ in
-        let _endpos = _endpos__3000_ in
-        let _v : (Parsetree.expression) = let _1 =
-          let _endpos__300_ = _endpos__3000_ in
-          let _endpos__10000_ = _endpos__100000_ in
-          let _startpos__10000_ = _startpos__100000_ in
-          let _startpos__100_ = _startpos__1000_ in
-          let _300 = _3000 in
-          let _10000 = _100000 in
-          let _100 = _1000 in
-          let _1 =
-            let _endpos__1000_ = _endpos__10000_ in
-            let _startpos__1000_ = _startpos__10000_ in
-            let _30 = _300 in
-            let _1000 = _10000 in
-            let _10 = _100 in
-            let _1 =
-              let _endpos__100_ = _endpos__1000_ in
-              let _startpos__100_ = _startpos__1000_ in
-              let _3 = _30 in
-              let _100 = _1000 in
-              let _1 = _10 in
-              let _2 =
-                let _endpos__10_ = _endpos__100_ in
-                let _startpos__10_ = _startpos__100_ in
-                let _10 = _100 in
-                let _1 =
-                  let _1 = _10 in
-                  
-# 1694 "parsing/parser.mly"
-                      ("&")
-# 10502 "parsing/parser.ml"
-                  
-                in
-                let _endpos__1_ = _endpos__10_ in
-                let _startpos__1_ = _startpos__10_ in
-                let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
-                
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 10515 "parsing/parser.ml"
-                
-              in
-              
-# 1695 "parsing/parser.mly"
-      ( mkinfix _1 _2 _3 )
-# 10521 "parsing/parser.ml"
-              
-            in
-            
-# 1649 "parsing/parser.mly"
-            ( _1 )
-# 10527 "parsing/parser.ml"
-            
-          in
-          let _endpos__1_ = _endpos__300_ in
-          let _startpos__1_ = _startpos__100_ in
-          let _endpos = _endpos__1_ in
-          let _symbolstartpos = _startpos__1_ in
-          let _sloc = (_symbolstartpos, _endpos) in
-          
-# 748 "parsing/parser.mly"
-    ( mkexp ~loc:_sloc _1 )
-# 10538 "parsing/parser.ml"
-          
-        in
-        
-# 1578 "parsing/parser.mly"
-    ( _1 )
-# 10544 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _3000;
-          MenhirLib.EngineTypes.startp = _startpos__3000_;
-          MenhirLib.EngineTypes.endp = _endpos__3000_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _100000;
-            MenhirLib.EngineTypes.startp = _startpos__100000_;
-            MenhirLib.EngineTypes.endp = _endpos__100000_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.state = _menhir_s;
-              MenhirLib.EngineTypes.semv = _1000;
-              MenhirLib.EngineTypes.startp = _startpos__1000_;
-              MenhirLib.EngineTypes.endp = _endpos__1000_;
-              MenhirLib.EngineTypes.next = _menhir_stack;
-            };
-          };
-        } = _menhir_stack in
-        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
-        let _100000 : unit = Obj.magic _100000 in
-        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1000_ in
-        let _endpos = _endpos__3000_ in
-        let _v : (Parsetree.expression) = let _1 =
-          let _endpos__300_ = _endpos__3000_ in
-          let _endpos__10000_ = _endpos__100000_ in
-          let _startpos__10000_ = _startpos__100000_ in
-          let _startpos__100_ = _startpos__1000_ in
-          let _300 = _3000 in
-          let _10000 = _100000 in
-          let _100 = _1000 in
-          let _1 =
-            let _endpos__1000_ = _endpos__10000_ in
-            let _startpos__1000_ = _startpos__10000_ in
-            let _30 = _300 in
-            let _1000 = _10000 in
-            let _10 = _100 in
-            let _1 =
-              let _endpos__100_ = _endpos__1000_ in
-              let _startpos__100_ = _startpos__1000_ in
-              let _3 = _30 in
-              let _100 = _1000 in
-              let _1 = _10 in
-              let _2 =
-                let _endpos__10_ = _endpos__100_ in
-                let _startpos__10_ = _startpos__100_ in
-                let _10 = _100 in
-                let _1 =
-                  let _1 = _10 in
-                  
-# 1696 "parsing/parser.mly"
-                       ("&&")
-# 10607 "parsing/parser.ml"
-                  
-                in
-                let _endpos__1_ = _endpos__10_ in
-                let _startpos__1_ = _startpos__10_ in
-                let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
-                
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 10620 "parsing/parser.ml"
-                
-              in
-              
-# 1697 "parsing/parser.mly"
-      ( mkinfix _1 _2 _3 )
-# 10626 "parsing/parser.ml"
-              
-            in
-            
-# 1649 "parsing/parser.mly"
-            ( _1 )
-# 10632 "parsing/parser.ml"
-            
-          in
-          let _endpos__1_ = _endpos__300_ in
-          let _startpos__1_ = _startpos__100_ in
-          let _endpos = _endpos__1_ in
-          let _symbolstartpos = _startpos__1_ in
-          let _sloc = (_symbolstartpos, _endpos) in
-          
-# 748 "parsing/parser.mly"
-    ( mkexp ~loc:_sloc _1 )
-# 10643 "parsing/parser.ml"
-          
-        in
-        
-# 1578 "parsing/parser.mly"
-    ( _1 )
-# 10649 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _3000;
-          MenhirLib.EngineTypes.startp = _startpos__3000_;
-          MenhirLib.EngineTypes.endp = _endpos__3000_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _100000;
-            MenhirLib.EngineTypes.startp = _startpos__100000_;
-            MenhirLib.EngineTypes.endp = _endpos__100000_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.state = _menhir_s;
-              MenhirLib.EngineTypes.semv = _1000;
-              MenhirLib.EngineTypes.startp = _startpos__1000_;
-              MenhirLib.EngineTypes.endp = _endpos__1000_;
-              MenhirLib.EngineTypes.next = _menhir_stack;
-            };
-          };
-        } = _menhir_stack in
-        let _3000 : (Parsetree.expression) = Obj.magic _3000 in
-        let _100000 : unit = Obj.magic _100000 in
-        let _1000 : (Parsetree.expression) = Obj.magic _1000 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1000_ in
-        let _endpos = _endpos__3000_ in
-        let _v : (Parsetree.expression) = let _1 =
-          let _endpos__300_ = _endpos__3000_ in
-          let _endpos__10000_ = _endpos__100000_ in
-          let _startpos__10000_ = _startpos__100000_ in
-          let _startpos__100_ = _startpos__1000_ in
-          let _300 = _3000 in
-          let _10000 = _100000 in
-          let _100 = _1000 in
-          let _1 =
-            let _endpos__1000_ = _endpos__10000_ in
-            let _startpos__1000_ = _startpos__10000_ in
-            let _30 = _300 in
-            let _1000 = _10000 in
-            let _10 = _100 in
-            let _1 =
-              let _endpos__100_ = _endpos__1000_ in
-              let _startpos__100_ = _startpos__1000_ in
-              let _3 = _30 in
-              let _100 = _1000 in
-              let _1 = _10 in
-              let _2 =
-                let _endpos__10_ = _endpos__100_ in
-                let _startpos__10_ = _startpos__100_ in
-                let _10 = _100 in
-                let _1 =
-                  let _1 = _10 in
-                  
-# 1698 "parsing/parser.mly"
-                       (":=")
-# 10712 "parsing/parser.ml"
-                  
-                in
-                let _endpos__1_ = _endpos__10_ in
-                let _startpos__1_ = _startpos__10_ in
-                let _endpos = _endpos__1_ in
-                let _startpos = _startpos__1_ in
-                let _loc = (_startpos, _endpos) in
-                
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 10725 "parsing/parser.ml"
-                
-              in
-              
-# 1699 "parsing/parser.mly"
-      ( mkinfix _1 _2 _3 )
-# 10731 "parsing/parser.ml"
-              
-            in
-            
-# 1649 "parsing/parser.mly"
-            ( _1 )
-# 10737 "parsing/parser.ml"
-            
-          in
-          let _endpos__1_ = _endpos__300_ in
-          let _startpos__1_ = _startpos__100_ in
-          let _endpos = _endpos__1_ in
-          let _symbolstartpos = _startpos__1_ in
-          let _sloc = (_symbolstartpos, _endpos) in
-          
-# 748 "parsing/parser.mly"
-    ( mkexp ~loc:_sloc _1 )
-# 10748 "parsing/parser.ml"
-          
-        in
-        
-# 1578 "parsing/parser.mly"
-    ( _1 )
-# 10754 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _2000;
-          MenhirLib.EngineTypes.startp = _startpos__2000_;
-          MenhirLib.EngineTypes.endp = _endpos__2000_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.state = _menhir_s;
-            MenhirLib.EngineTypes.semv = _1000;
-            MenhirLib.EngineTypes.startp = _startpos__1000_;
-            MenhirLib.EngineTypes.endp = _endpos__1000_;
-            MenhirLib.EngineTypes.next = _menhir_stack;
-          };
-        } = _menhir_stack in
-        let _2000 : (Parsetree.expression) = Obj.magic _2000 in
-        let _1000 : (string) = Obj.magic _1000 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1000_ in
-        let _endpos = _endpos__2000_ in
-        let _v : (Parsetree.expression) = let _1 =
-          let _endpos__200_ = _endpos__2000_ in
-          let _endpos__100_ = _endpos__1000_ in
-          let _startpos__100_ = _startpos__1000_ in
-          let _200 = _2000 in
-          let _100 = _1000 in
-          let _1 =
-            let _endpos__10_ = _endpos__100_ in
-            let _startpos__10_ = _startpos__100_ in
-            let _20 = _200 in
-            let _10 = _100 in
-            let _1 =
-              let _endpos__1_ = _endpos__10_ in
-              let _startpos__1_ = _startpos__10_ in
-              let _2 = _20 in
-              let _1 = _10 in
-              let _loc__1_ = (_startpos__1_, _endpos__1_) in
-              
-# 1701 "parsing/parser.mly"
-      ( mkuminus ~oploc:_loc__1_ _1 _2 )
-# 10802 "parsing/parser.ml"
-              
-            in
-            
-# 1649 "parsing/parser.mly"
-            ( _1 )
-# 10808 "parsing/parser.ml"
-            
-          in
-          let _endpos__1_ = _endpos__200_ in
-          let _startpos__1_ = _startpos__100_ in
-          let _endpos = _endpos__1_ in
-          let _symbolstartpos = _startpos__1_ in
-          let _sloc = (_symbolstartpos, _endpos) in
-          
-# 748 "parsing/parser.mly"
-    ( mkexp ~loc:_sloc _1 )
-# 10819 "parsing/parser.ml"
-          
-        in
-        
-# 1578 "parsing/parser.mly"
-    ( _1 )
-# 10825 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _2000;
-          MenhirLib.EngineTypes.startp = _startpos__2000_;
-          MenhirLib.EngineTypes.endp = _endpos__2000_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.state = _menhir_s;
-            MenhirLib.EngineTypes.semv = _1000;
-            MenhirLib.EngineTypes.startp = _startpos__1000_;
-            MenhirLib.EngineTypes.endp = _endpos__1000_;
-            MenhirLib.EngineTypes.next = _menhir_stack;
-          };
-        } = _menhir_stack in
-        let _2000 : (Parsetree.expression) = Obj.magic _2000 in
-        let _1000 : (string) = Obj.magic _1000 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1000_ in
-        let _endpos = _endpos__2000_ in
-        let _v : (Parsetree.expression) = let _1 =
-          let _endpos__200_ = _endpos__2000_ in
-          let _endpos__100_ = _endpos__1000_ in
-          let _startpos__100_ = _startpos__1000_ in
-          let _200 = _2000 in
-          let _100 = _1000 in
-          let _1 =
-            let _endpos__10_ = _endpos__100_ in
-            let _startpos__10_ = _startpos__100_ in
-            let _20 = _200 in
-            let _10 = _100 in
-            let _1 =
-              let _endpos__1_ = _endpos__10_ in
-              let _startpos__1_ = _startpos__10_ in
-              let _2 = _20 in
-              let _1 = _10 in
-              let _loc__1_ = (_startpos__1_, _endpos__1_) in
-              
-# 1703 "parsing/parser.mly"
       ( mkuplus ~oploc:_loc__1_ _1 _2 )
-# 10873 "parsing/parser.ml"
+# 10649 "parsing/parser.ml"
               
             in
             
-# 1649 "parsing/parser.mly"
+# 1639 "parsing/parser.mly"
             ( _1 )
-# 10879 "parsing/parser.ml"
+# 10655 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__200_ in
@@ -10884,15 +10660,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 10890 "parsing/parser.ml"
+# 10666 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 10896 "parsing/parser.ml"
+# 10672 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -10929,9 +10705,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1651 "parsing/parser.mly"
+# 1641 "parsing/parser.mly"
     ( Pexp_apply(_1, List.rev _2) )
-# 10935 "parsing/parser.ml"
+# 10711 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -10940,15 +10716,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 10946 "parsing/parser.ml"
+# 10722 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 10952 "parsing/parser.ml"
+# 10728 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -10977,9 +10753,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 1653 "parsing/parser.mly"
+# 1643 "parsing/parser.mly"
     ( Pexp_tuple(List.rev _1) )
-# 10983 "parsing/parser.ml"
+# 10759 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -10988,15 +10764,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 10994 "parsing/parser.ml"
+# 10770 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 11000 "parsing/parser.ml"
+# 10776 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -11040,26 +10816,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 11057 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 10825 "parsing/parser.ml"
               
             in
             
-# 1655 "parsing/parser.mly"
+# 1645 "parsing/parser.mly"
     ( Pexp_construct(_1, Some _2) )
-# 11063 "parsing/parser.ml"
+# 10831 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -11068,15 +10836,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 11074 "parsing/parser.ml"
+# 10842 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 11080 "parsing/parser.ml"
+# 10848 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -11113,9 +10881,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1657 "parsing/parser.mly"
+# 1647 "parsing/parser.mly"
     ( Pexp_variant(_1, Some _2) )
-# 11119 "parsing/parser.ml"
+# 10887 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -11124,15 +10892,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 11130 "parsing/parser.ml"
+# 10898 "parsing/parser.ml"
           
         in
         
-# 1578 "parsing/parser.mly"
+# 1568 "parsing/parser.mly"
     ( _1 )
-# 11136 "parsing/parser.ml"
+# 10904 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -11170,9 +10938,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1580 "parsing/parser.mly"
+# 1570 "parsing/parser.mly"
     ( expr_of_let_bindings ~loc:_sloc _1 _3 )
-# 11176 "parsing/parser.ml"
+# 10944 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -11211,9 +10979,9 @@ module Tables = struct
         let _loc__2_ = (_startpos__2_, _endpos__2_) in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1582 "parsing/parser.mly"
+# 1572 "parsing/parser.mly"
       ( mkexp_cons ~loc:_sloc _loc__2_ (ghexp ~loc:_sloc (Pexp_tuple[_1;_3])) )
-# 11217 "parsing/parser.ml"
+# 10985 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -11252,20 +11020,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 11269 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 11029 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -11273,9 +11033,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1584 "parsing/parser.mly"
+# 1574 "parsing/parser.mly"
       ( mkexp ~loc:_sloc (Pexp_setinstvar(_1, _3)) )
-# 11279 "parsing/parser.ml"
+# 11039 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -11326,29 +11086,21 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 11343 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 11095 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__5_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1586 "parsing/parser.mly"
+# 1576 "parsing/parser.mly"
       ( mkexp ~loc:_sloc (Pexp_setfield(_1, _3, _5)) )
-# 11352 "parsing/parser.ml"
+# 11104 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -11402,6 +11154,338 @@ module Tables = struct
         let _4 : (Parsetree.expression) = Obj.magic _4 in
         let _3 : unit = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
+        let _1 : (Parsetree.expression) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__7_ in
+        let _v : (Parsetree.expression) = let _endpos = _endpos__7_ in
+        let _symbolstartpos = _startpos__1_ in
+        let _sloc = (_symbolstartpos, _endpos) in
+        
+# 1578 "parsing/parser.mly"
+      ( array_set ~loc:_sloc _1 _4 _7 )
+# 11168 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _7;
+          MenhirLib.EngineTypes.startp = _startpos__7_;
+          MenhirLib.EngineTypes.endp = _endpos__7_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _6;
+            MenhirLib.EngineTypes.startp = _startpos__6_;
+            MenhirLib.EngineTypes.endp = _endpos__6_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.semv = _5;
+              MenhirLib.EngineTypes.startp = _startpos__5_;
+              MenhirLib.EngineTypes.endp = _endpos__5_;
+              MenhirLib.EngineTypes.next = {
+                MenhirLib.EngineTypes.semv = _4;
+                MenhirLib.EngineTypes.startp = _startpos__4_;
+                MenhirLib.EngineTypes.endp = _endpos__4_;
+                MenhirLib.EngineTypes.next = {
+                  MenhirLib.EngineTypes.semv = _3;
+                  MenhirLib.EngineTypes.startp = _startpos__3_;
+                  MenhirLib.EngineTypes.endp = _endpos__3_;
+                  MenhirLib.EngineTypes.next = {
+                    MenhirLib.EngineTypes.semv = _2;
+                    MenhirLib.EngineTypes.startp = _startpos__2_;
+                    MenhirLib.EngineTypes.endp = _endpos__2_;
+                    MenhirLib.EngineTypes.next = {
+                      MenhirLib.EngineTypes.state = _menhir_s;
+                      MenhirLib.EngineTypes.semv = _1;
+                      MenhirLib.EngineTypes.startp = _startpos__1_;
+                      MenhirLib.EngineTypes.endp = _endpos__1_;
+                      MenhirLib.EngineTypes.next = _menhir_stack;
+                    };
+                  };
+                };
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _7 : (Parsetree.expression) = Obj.magic _7 in
+        let _6 : unit = Obj.magic _6 in
+        let _5 : unit = Obj.magic _5 in
+        let _4 : (Parsetree.expression) = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : (Parsetree.expression) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__7_ in
+        let _v : (Parsetree.expression) = let _endpos = _endpos__7_ in
+        let _symbolstartpos = _startpos__1_ in
+        let _sloc = (_symbolstartpos, _endpos) in
+        
+# 1580 "parsing/parser.mly"
+      ( string_set ~loc:_sloc _1 _4 _7 )
+# 11232 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _7;
+          MenhirLib.EngineTypes.startp = _startpos__7_;
+          MenhirLib.EngineTypes.endp = _endpos__7_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _6;
+            MenhirLib.EngineTypes.startp = _startpos__6_;
+            MenhirLib.EngineTypes.endp = _endpos__6_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.semv = _5;
+              MenhirLib.EngineTypes.startp = _startpos__5_;
+              MenhirLib.EngineTypes.endp = _endpos__5_;
+              MenhirLib.EngineTypes.next = {
+                MenhirLib.EngineTypes.semv = _4;
+                MenhirLib.EngineTypes.startp = _startpos__4_;
+                MenhirLib.EngineTypes.endp = _endpos__4_;
+                MenhirLib.EngineTypes.next = {
+                  MenhirLib.EngineTypes.semv = _3;
+                  MenhirLib.EngineTypes.startp = _startpos__3_;
+                  MenhirLib.EngineTypes.endp = _endpos__3_;
+                  MenhirLib.EngineTypes.next = {
+                    MenhirLib.EngineTypes.semv = _2;
+                    MenhirLib.EngineTypes.startp = _startpos__2_;
+                    MenhirLib.EngineTypes.endp = _endpos__2_;
+                    MenhirLib.EngineTypes.next = {
+                      MenhirLib.EngineTypes.state = _menhir_s;
+                      MenhirLib.EngineTypes.semv = _1;
+                      MenhirLib.EngineTypes.startp = _startpos__1_;
+                      MenhirLib.EngineTypes.endp = _endpos__1_;
+                      MenhirLib.EngineTypes.next = _menhir_stack;
+                    };
+                  };
+                };
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _7 : (Parsetree.expression) = Obj.magic _7 in
+        let _6 : unit = Obj.magic _6 in
+        let _5 : unit = Obj.magic _5 in
+        let _4 : (Parsetree.expression) = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : (Parsetree.expression) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__7_ in
+        let _v : (Parsetree.expression) = let _endpos = _endpos__7_ in
+        let _symbolstartpos = _startpos__1_ in
+        let _sloc = (_symbolstartpos, _endpos) in
+        
+# 1582 "parsing/parser.mly"
+      ( bigarray_set ~loc:_sloc _1 _4 _7 )
+# 11296 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _7;
+          MenhirLib.EngineTypes.startp = _startpos__7_;
+          MenhirLib.EngineTypes.endp = _endpos__7_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _6;
+            MenhirLib.EngineTypes.startp = _startpos__6_;
+            MenhirLib.EngineTypes.endp = _endpos__6_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.semv = _5;
+              MenhirLib.EngineTypes.startp = _startpos__5_;
+              MenhirLib.EngineTypes.endp = _endpos__5_;
+              MenhirLib.EngineTypes.next = {
+                MenhirLib.EngineTypes.semv = _4;
+                MenhirLib.EngineTypes.startp = _startpos__4_;
+                MenhirLib.EngineTypes.endp = _endpos__4_;
+                MenhirLib.EngineTypes.next = {
+                  MenhirLib.EngineTypes.semv = _3;
+                  MenhirLib.EngineTypes.startp = _startpos__3_;
+                  MenhirLib.EngineTypes.endp = _endpos__3_;
+                  MenhirLib.EngineTypes.next = {
+                    MenhirLib.EngineTypes.semv = _2;
+                    MenhirLib.EngineTypes.startp = _startpos__2_;
+                    MenhirLib.EngineTypes.endp = _endpos__2_;
+                    MenhirLib.EngineTypes.next = {
+                      MenhirLib.EngineTypes.state = _menhir_s;
+                      MenhirLib.EngineTypes.semv = _1;
+                      MenhirLib.EngineTypes.startp = _startpos__1_;
+                      MenhirLib.EngineTypes.endp = _endpos__1_;
+                      MenhirLib.EngineTypes.next = _menhir_stack;
+                    };
+                  };
+                };
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _7 : (Parsetree.expression) = Obj.magic _7 in
+        let _6 : unit = Obj.magic _6 in
+        let _5 : unit = Obj.magic _5 in
+        let _4 : (Parsetree.expression) = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : (
+# 561 "parsing/parser.mly"
+       (string)
+# 11352 "parsing/parser.ml"
+        ) = Obj.magic _2 in
+        let _1 : (Parsetree.expression) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__7_ in
+        let _v : (Parsetree.expression) = let _endpos = _endpos__7_ in
+        let _symbolstartpos = _startpos__1_ in
+        let _sloc = (_symbolstartpos, _endpos) in
+        
+# 1584 "parsing/parser.mly"
+      ( dotop_set ~loc:_sloc (Lident ("." ^ _2 ^ "[]<-")) _1 _4 _7 )
+# 11364 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _7;
+          MenhirLib.EngineTypes.startp = _startpos__7_;
+          MenhirLib.EngineTypes.endp = _endpos__7_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _6;
+            MenhirLib.EngineTypes.startp = _startpos__6_;
+            MenhirLib.EngineTypes.endp = _endpos__6_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.semv = _5;
+              MenhirLib.EngineTypes.startp = _startpos__5_;
+              MenhirLib.EngineTypes.endp = _endpos__5_;
+              MenhirLib.EngineTypes.next = {
+                MenhirLib.EngineTypes.semv = _4;
+                MenhirLib.EngineTypes.startp = _startpos__4_;
+                MenhirLib.EngineTypes.endp = _endpos__4_;
+                MenhirLib.EngineTypes.next = {
+                  MenhirLib.EngineTypes.semv = _3;
+                  MenhirLib.EngineTypes.startp = _startpos__3_;
+                  MenhirLib.EngineTypes.endp = _endpos__3_;
+                  MenhirLib.EngineTypes.next = {
+                    MenhirLib.EngineTypes.semv = _2;
+                    MenhirLib.EngineTypes.startp = _startpos__2_;
+                    MenhirLib.EngineTypes.endp = _endpos__2_;
+                    MenhirLib.EngineTypes.next = {
+                      MenhirLib.EngineTypes.state = _menhir_s;
+                      MenhirLib.EngineTypes.semv = _1;
+                      MenhirLib.EngineTypes.startp = _startpos__1_;
+                      MenhirLib.EngineTypes.endp = _endpos__1_;
+                      MenhirLib.EngineTypes.next = _menhir_stack;
+                    };
+                  };
+                };
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _7 : (Parsetree.expression) = Obj.magic _7 in
+        let _6 : unit = Obj.magic _6 in
+        let _5 : unit = Obj.magic _5 in
+        let _4 : (Parsetree.expression) = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : (
+# 561 "parsing/parser.mly"
+       (string)
+# 11420 "parsing/parser.ml"
+        ) = Obj.magic _2 in
+        let _1 : (Parsetree.expression) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__7_ in
+        let _v : (Parsetree.expression) = let _endpos = _endpos__7_ in
+        let _symbolstartpos = _startpos__1_ in
+        let _sloc = (_symbolstartpos, _endpos) in
+        
+# 1586 "parsing/parser.mly"
+      ( dotop_set ~loc:_sloc (Lident ("." ^ _2 ^ "()<-")) _1 _4 _7 )
+# 11432 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _7;
+          MenhirLib.EngineTypes.startp = _startpos__7_;
+          MenhirLib.EngineTypes.endp = _endpos__7_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _6;
+            MenhirLib.EngineTypes.startp = _startpos__6_;
+            MenhirLib.EngineTypes.endp = _endpos__6_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.semv = _5;
+              MenhirLib.EngineTypes.startp = _startpos__5_;
+              MenhirLib.EngineTypes.endp = _endpos__5_;
+              MenhirLib.EngineTypes.next = {
+                MenhirLib.EngineTypes.semv = _4;
+                MenhirLib.EngineTypes.startp = _startpos__4_;
+                MenhirLib.EngineTypes.endp = _endpos__4_;
+                MenhirLib.EngineTypes.next = {
+                  MenhirLib.EngineTypes.semv = _3;
+                  MenhirLib.EngineTypes.startp = _startpos__3_;
+                  MenhirLib.EngineTypes.endp = _endpos__3_;
+                  MenhirLib.EngineTypes.next = {
+                    MenhirLib.EngineTypes.semv = _2;
+                    MenhirLib.EngineTypes.startp = _startpos__2_;
+                    MenhirLib.EngineTypes.endp = _endpos__2_;
+                    MenhirLib.EngineTypes.next = {
+                      MenhirLib.EngineTypes.state = _menhir_s;
+                      MenhirLib.EngineTypes.semv = _1;
+                      MenhirLib.EngineTypes.startp = _startpos__1_;
+                      MenhirLib.EngineTypes.endp = _endpos__1_;
+                      MenhirLib.EngineTypes.next = _menhir_stack;
+                    };
+                  };
+                };
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _7 : (Parsetree.expression) = Obj.magic _7 in
+        let _6 : unit = Obj.magic _6 in
+        let _5 : unit = Obj.magic _5 in
+        let _4 : (Parsetree.expression) = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : (
+# 561 "parsing/parser.mly"
+       (string)
+# 11488 "parsing/parser.ml"
+        ) = Obj.magic _2 in
         let _1 : (Parsetree.expression) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
@@ -11411,8 +11495,8 @@ module Tables = struct
         let _sloc = (_symbolstartpos, _endpos) in
         
 # 1588 "parsing/parser.mly"
-      ( array_set ~loc:_sloc _1 _4 _7 )
-# 11416 "parsing/parser.ml"
+      ( dotop_set ~loc:_sloc (Lident ("." ^ _2 ^ "{}<-")) _1 _4 _7 )
+# 11500 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -11424,35 +11508,45 @@ module Tables = struct
       (fun _menhir_env ->
         let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
         let {
-          MenhirLib.EngineTypes.semv = _7;
-          MenhirLib.EngineTypes.startp = _startpos__7_;
-          MenhirLib.EngineTypes.endp = _endpos__7_;
+          MenhirLib.EngineTypes.semv = _9;
+          MenhirLib.EngineTypes.startp = _startpos__9_;
+          MenhirLib.EngineTypes.endp = _endpos__9_;
           MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _6;
-            MenhirLib.EngineTypes.startp = _startpos__6_;
-            MenhirLib.EngineTypes.endp = _endpos__6_;
+            MenhirLib.EngineTypes.semv = _8;
+            MenhirLib.EngineTypes.startp = _startpos__8_;
+            MenhirLib.EngineTypes.endp = _endpos__8_;
             MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _5;
-              MenhirLib.EngineTypes.startp = _startpos__5_;
-              MenhirLib.EngineTypes.endp = _endpos__5_;
+              MenhirLib.EngineTypes.semv = _7;
+              MenhirLib.EngineTypes.startp = _startpos__7_;
+              MenhirLib.EngineTypes.endp = _endpos__7_;
               MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _4;
-                MenhirLib.EngineTypes.startp = _startpos__4_;
-                MenhirLib.EngineTypes.endp = _endpos__4_;
+                MenhirLib.EngineTypes.semv = _6;
+                MenhirLib.EngineTypes.startp = _startpos__6_;
+                MenhirLib.EngineTypes.endp = _endpos__6_;
                 MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.semv = _3;
-                  MenhirLib.EngineTypes.startp = _startpos__3_;
-                  MenhirLib.EngineTypes.endp = _endpos__3_;
+                  MenhirLib.EngineTypes.semv = _5;
+                  MenhirLib.EngineTypes.startp = _startpos__5_;
+                  MenhirLib.EngineTypes.endp = _endpos__5_;
                   MenhirLib.EngineTypes.next = {
-                    MenhirLib.EngineTypes.semv = _2;
-                    MenhirLib.EngineTypes.startp = _startpos__2_;
-                    MenhirLib.EngineTypes.endp = _endpos__2_;
+                    MenhirLib.EngineTypes.semv = _4;
+                    MenhirLib.EngineTypes.startp = _startpos__4_;
+                    MenhirLib.EngineTypes.endp = _endpos__4_;
                     MenhirLib.EngineTypes.next = {
-                      MenhirLib.EngineTypes.state = _menhir_s;
-                      MenhirLib.EngineTypes.semv = _1;
-                      MenhirLib.EngineTypes.startp = _startpos__1_;
-                      MenhirLib.EngineTypes.endp = _endpos__1_;
-                      MenhirLib.EngineTypes.next = _menhir_stack;
+                      MenhirLib.EngineTypes.semv = _3;
+                      MenhirLib.EngineTypes.startp = _startpos__3_;
+                      MenhirLib.EngineTypes.endp = _endpos__3_;
+                      MenhirLib.EngineTypes.next = {
+                        MenhirLib.EngineTypes.semv = _2;
+                        MenhirLib.EngineTypes.startp = _startpos__2_;
+                        MenhirLib.EngineTypes.endp = _endpos__2_;
+                        MenhirLib.EngineTypes.next = {
+                          MenhirLib.EngineTypes.state = _menhir_s;
+                          MenhirLib.EngineTypes.semv = _1;
+                          MenhirLib.EngineTypes.startp = _startpos__1_;
+                          MenhirLib.EngineTypes.endp = _endpos__1_;
+                          MenhirLib.EngineTypes.next = _menhir_stack;
+                        };
+                      };
                     };
                   };
                 };
@@ -11460,23 +11554,29 @@ module Tables = struct
             };
           };
         } = _menhir_stack in
-        let _7 : (Parsetree.expression) = Obj.magic _7 in
-        let _6 : unit = Obj.magic _6 in
+        let _9 : (Parsetree.expression) = Obj.magic _9 in
+        let _8 : unit = Obj.magic _8 in
+        let _7 : unit = Obj.magic _7 in
+        let _6 : (Parsetree.expression) = Obj.magic _6 in
         let _5 : unit = Obj.magic _5 in
-        let _4 : (Parsetree.expression) = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
+        let _4 : (
+# 561 "parsing/parser.mly"
+       (string)
+# 11566 "parsing/parser.ml"
+        ) = Obj.magic _4 in
+        let _3 : (Longident.t) = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
         let _1 : (Parsetree.expression) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
-        let _endpos = _endpos__7_ in
-        let _v : (Parsetree.expression) = let _endpos = _endpos__7_ in
+        let _endpos = _endpos__9_ in
+        let _v : (Parsetree.expression) = let _endpos = _endpos__9_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
 # 1590 "parsing/parser.mly"
-      ( string_set ~loc:_sloc _1 _4 _7 )
-# 11480 "parsing/parser.ml"
+      ( dotop_set ~loc:_sloc (Ldot(_3,"." ^ _4 ^ "[]<-")) _1 _6 _9 )
+# 11580 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -11488,35 +11588,45 @@ module Tables = struct
       (fun _menhir_env ->
         let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
         let {
-          MenhirLib.EngineTypes.semv = _7;
-          MenhirLib.EngineTypes.startp = _startpos__7_;
-          MenhirLib.EngineTypes.endp = _endpos__7_;
+          MenhirLib.EngineTypes.semv = _9;
+          MenhirLib.EngineTypes.startp = _startpos__9_;
+          MenhirLib.EngineTypes.endp = _endpos__9_;
           MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _6;
-            MenhirLib.EngineTypes.startp = _startpos__6_;
-            MenhirLib.EngineTypes.endp = _endpos__6_;
+            MenhirLib.EngineTypes.semv = _8;
+            MenhirLib.EngineTypes.startp = _startpos__8_;
+            MenhirLib.EngineTypes.endp = _endpos__8_;
             MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _5;
-              MenhirLib.EngineTypes.startp = _startpos__5_;
-              MenhirLib.EngineTypes.endp = _endpos__5_;
+              MenhirLib.EngineTypes.semv = _7;
+              MenhirLib.EngineTypes.startp = _startpos__7_;
+              MenhirLib.EngineTypes.endp = _endpos__7_;
               MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _4;
-                MenhirLib.EngineTypes.startp = _startpos__4_;
-                MenhirLib.EngineTypes.endp = _endpos__4_;
+                MenhirLib.EngineTypes.semv = _6;
+                MenhirLib.EngineTypes.startp = _startpos__6_;
+                MenhirLib.EngineTypes.endp = _endpos__6_;
                 MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.semv = _3;
-                  MenhirLib.EngineTypes.startp = _startpos__3_;
-                  MenhirLib.EngineTypes.endp = _endpos__3_;
+                  MenhirLib.EngineTypes.semv = _5;
+                  MenhirLib.EngineTypes.startp = _startpos__5_;
+                  MenhirLib.EngineTypes.endp = _endpos__5_;
                   MenhirLib.EngineTypes.next = {
-                    MenhirLib.EngineTypes.semv = _2;
-                    MenhirLib.EngineTypes.startp = _startpos__2_;
-                    MenhirLib.EngineTypes.endp = _endpos__2_;
+                    MenhirLib.EngineTypes.semv = _4;
+                    MenhirLib.EngineTypes.startp = _startpos__4_;
+                    MenhirLib.EngineTypes.endp = _endpos__4_;
                     MenhirLib.EngineTypes.next = {
-                      MenhirLib.EngineTypes.state = _menhir_s;
-                      MenhirLib.EngineTypes.semv = _1;
-                      MenhirLib.EngineTypes.startp = _startpos__1_;
-                      MenhirLib.EngineTypes.endp = _endpos__1_;
-                      MenhirLib.EngineTypes.next = _menhir_stack;
+                      MenhirLib.EngineTypes.semv = _3;
+                      MenhirLib.EngineTypes.startp = _startpos__3_;
+                      MenhirLib.EngineTypes.endp = _endpos__3_;
+                      MenhirLib.EngineTypes.next = {
+                        MenhirLib.EngineTypes.semv = _2;
+                        MenhirLib.EngineTypes.startp = _startpos__2_;
+                        MenhirLib.EngineTypes.endp = _endpos__2_;
+                        MenhirLib.EngineTypes.next = {
+                          MenhirLib.EngineTypes.state = _menhir_s;
+                          MenhirLib.EngineTypes.semv = _1;
+                          MenhirLib.EngineTypes.startp = _startpos__1_;
+                          MenhirLib.EngineTypes.endp = _endpos__1_;
+                          MenhirLib.EngineTypes.next = _menhir_stack;
+                        };
+                      };
                     };
                   };
                 };
@@ -11524,23 +11634,29 @@ module Tables = struct
             };
           };
         } = _menhir_stack in
-        let _7 : (Parsetree.expression) = Obj.magic _7 in
-        let _6 : unit = Obj.magic _6 in
+        let _9 : (Parsetree.expression) = Obj.magic _9 in
+        let _8 : unit = Obj.magic _8 in
+        let _7 : unit = Obj.magic _7 in
+        let _6 : (Parsetree.expression) = Obj.magic _6 in
         let _5 : unit = Obj.magic _5 in
-        let _4 : (Parsetree.expression) = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
+        let _4 : (
+# 561 "parsing/parser.mly"
+       (string)
+# 11646 "parsing/parser.ml"
+        ) = Obj.magic _4 in
+        let _3 : (Longident.t) = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
         let _1 : (Parsetree.expression) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
-        let _endpos = _endpos__7_ in
-        let _v : (Parsetree.expression) = let _endpos = _endpos__7_ in
+        let _endpos = _endpos__9_ in
+        let _v : (Parsetree.expression) = let _endpos = _endpos__9_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
 # 1592 "parsing/parser.mly"
-      ( bigarray_set ~loc:_sloc _1 _4 _7 )
-# 11544 "parsing/parser.ml"
+      ( dotop_set ~loc:_sloc (Ldot(_3, "." ^ _4 ^ "()<-")) _1 _6 _9 )
+# 11660 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -11552,35 +11668,45 @@ module Tables = struct
       (fun _menhir_env ->
         let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
         let {
-          MenhirLib.EngineTypes.semv = _7;
-          MenhirLib.EngineTypes.startp = _startpos__7_;
-          MenhirLib.EngineTypes.endp = _endpos__7_;
+          MenhirLib.EngineTypes.semv = _9;
+          MenhirLib.EngineTypes.startp = _startpos__9_;
+          MenhirLib.EngineTypes.endp = _endpos__9_;
           MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _6;
-            MenhirLib.EngineTypes.startp = _startpos__6_;
-            MenhirLib.EngineTypes.endp = _endpos__6_;
+            MenhirLib.EngineTypes.semv = _8;
+            MenhirLib.EngineTypes.startp = _startpos__8_;
+            MenhirLib.EngineTypes.endp = _endpos__8_;
             MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _5;
-              MenhirLib.EngineTypes.startp = _startpos__5_;
-              MenhirLib.EngineTypes.endp = _endpos__5_;
+              MenhirLib.EngineTypes.semv = _7;
+              MenhirLib.EngineTypes.startp = _startpos__7_;
+              MenhirLib.EngineTypes.endp = _endpos__7_;
               MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _4;
-                MenhirLib.EngineTypes.startp = _startpos__4_;
-                MenhirLib.EngineTypes.endp = _endpos__4_;
+                MenhirLib.EngineTypes.semv = _6;
+                MenhirLib.EngineTypes.startp = _startpos__6_;
+                MenhirLib.EngineTypes.endp = _endpos__6_;
                 MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.semv = _3;
-                  MenhirLib.EngineTypes.startp = _startpos__3_;
-                  MenhirLib.EngineTypes.endp = _endpos__3_;
+                  MenhirLib.EngineTypes.semv = _5;
+                  MenhirLib.EngineTypes.startp = _startpos__5_;
+                  MenhirLib.EngineTypes.endp = _endpos__5_;
                   MenhirLib.EngineTypes.next = {
-                    MenhirLib.EngineTypes.semv = _2;
-                    MenhirLib.EngineTypes.startp = _startpos__2_;
-                    MenhirLib.EngineTypes.endp = _endpos__2_;
+                    MenhirLib.EngineTypes.semv = _4;
+                    MenhirLib.EngineTypes.startp = _startpos__4_;
+                    MenhirLib.EngineTypes.endp = _endpos__4_;
                     MenhirLib.EngineTypes.next = {
-                      MenhirLib.EngineTypes.state = _menhir_s;
-                      MenhirLib.EngineTypes.semv = _1;
-                      MenhirLib.EngineTypes.startp = _startpos__1_;
-                      MenhirLib.EngineTypes.endp = _endpos__1_;
-                      MenhirLib.EngineTypes.next = _menhir_stack;
+                      MenhirLib.EngineTypes.semv = _3;
+                      MenhirLib.EngineTypes.startp = _startpos__3_;
+                      MenhirLib.EngineTypes.endp = _endpos__3_;
+                      MenhirLib.EngineTypes.next = {
+                        MenhirLib.EngineTypes.semv = _2;
+                        MenhirLib.EngineTypes.startp = _startpos__2_;
+                        MenhirLib.EngineTypes.endp = _endpos__2_;
+                        MenhirLib.EngineTypes.next = {
+                          MenhirLib.EngineTypes.state = _menhir_s;
+                          MenhirLib.EngineTypes.semv = _1;
+                          MenhirLib.EngineTypes.startp = _startpos__1_;
+                          MenhirLib.EngineTypes.endp = _endpos__1_;
+                          MenhirLib.EngineTypes.next = _menhir_stack;
+                        };
+                      };
                     };
                   };
                 };
@@ -11588,403 +11714,29 @@ module Tables = struct
             };
           };
         } = _menhir_stack in
-        let _7 : (Parsetree.expression) = Obj.magic _7 in
-        let _6 : unit = Obj.magic _6 in
+        let _9 : (Parsetree.expression) = Obj.magic _9 in
+        let _8 : unit = Obj.magic _8 in
+        let _7 : unit = Obj.magic _7 in
+        let _6 : (Parsetree.expression) = Obj.magic _6 in
         let _5 : unit = Obj.magic _5 in
-        let _4 : (Parsetree.expression) = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
-        let _2 : (
+        let _4 : (
 # 561 "parsing/parser.mly"
        (string)
-# 11600 "parsing/parser.ml"
-        ) = Obj.magic _2 in
+# 11726 "parsing/parser.ml"
+        ) = Obj.magic _4 in
+        let _3 : (Longident.t) = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
         let _1 : (Parsetree.expression) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
-        let _endpos = _endpos__7_ in
-        let _v : (Parsetree.expression) = let _endpos = _endpos__7_ in
+        let _endpos = _endpos__9_ in
+        let _v : (Parsetree.expression) = let _endpos = _endpos__9_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
 # 1594 "parsing/parser.mly"
-      ( dotop_set ~loc:_sloc (Lident ("." ^ _2 ^ "[]<-")) _1 _4 _7 )
-# 11612 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _7;
-          MenhirLib.EngineTypes.startp = _startpos__7_;
-          MenhirLib.EngineTypes.endp = _endpos__7_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _6;
-            MenhirLib.EngineTypes.startp = _startpos__6_;
-            MenhirLib.EngineTypes.endp = _endpos__6_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _5;
-              MenhirLib.EngineTypes.startp = _startpos__5_;
-              MenhirLib.EngineTypes.endp = _endpos__5_;
-              MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _4;
-                MenhirLib.EngineTypes.startp = _startpos__4_;
-                MenhirLib.EngineTypes.endp = _endpos__4_;
-                MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.semv = _3;
-                  MenhirLib.EngineTypes.startp = _startpos__3_;
-                  MenhirLib.EngineTypes.endp = _endpos__3_;
-                  MenhirLib.EngineTypes.next = {
-                    MenhirLib.EngineTypes.semv = _2;
-                    MenhirLib.EngineTypes.startp = _startpos__2_;
-                    MenhirLib.EngineTypes.endp = _endpos__2_;
-                    MenhirLib.EngineTypes.next = {
-                      MenhirLib.EngineTypes.state = _menhir_s;
-                      MenhirLib.EngineTypes.semv = _1;
-                      MenhirLib.EngineTypes.startp = _startpos__1_;
-                      MenhirLib.EngineTypes.endp = _endpos__1_;
-                      MenhirLib.EngineTypes.next = _menhir_stack;
-                    };
-                  };
-                };
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _7 : (Parsetree.expression) = Obj.magic _7 in
-        let _6 : unit = Obj.magic _6 in
-        let _5 : unit = Obj.magic _5 in
-        let _4 : (Parsetree.expression) = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
-        let _2 : (
-# 561 "parsing/parser.mly"
-       (string)
-# 11668 "parsing/parser.ml"
-        ) = Obj.magic _2 in
-        let _1 : (Parsetree.expression) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__7_ in
-        let _v : (Parsetree.expression) = let _endpos = _endpos__7_ in
-        let _symbolstartpos = _startpos__1_ in
-        let _sloc = (_symbolstartpos, _endpos) in
-        
-# 1596 "parsing/parser.mly"
-      ( dotop_set ~loc:_sloc (Lident ("." ^ _2 ^ "()<-")) _1 _4 _7 )
-# 11680 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _7;
-          MenhirLib.EngineTypes.startp = _startpos__7_;
-          MenhirLib.EngineTypes.endp = _endpos__7_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _6;
-            MenhirLib.EngineTypes.startp = _startpos__6_;
-            MenhirLib.EngineTypes.endp = _endpos__6_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _5;
-              MenhirLib.EngineTypes.startp = _startpos__5_;
-              MenhirLib.EngineTypes.endp = _endpos__5_;
-              MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _4;
-                MenhirLib.EngineTypes.startp = _startpos__4_;
-                MenhirLib.EngineTypes.endp = _endpos__4_;
-                MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.semv = _3;
-                  MenhirLib.EngineTypes.startp = _startpos__3_;
-                  MenhirLib.EngineTypes.endp = _endpos__3_;
-                  MenhirLib.EngineTypes.next = {
-                    MenhirLib.EngineTypes.semv = _2;
-                    MenhirLib.EngineTypes.startp = _startpos__2_;
-                    MenhirLib.EngineTypes.endp = _endpos__2_;
-                    MenhirLib.EngineTypes.next = {
-                      MenhirLib.EngineTypes.state = _menhir_s;
-                      MenhirLib.EngineTypes.semv = _1;
-                      MenhirLib.EngineTypes.startp = _startpos__1_;
-                      MenhirLib.EngineTypes.endp = _endpos__1_;
-                      MenhirLib.EngineTypes.next = _menhir_stack;
-                    };
-                  };
-                };
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _7 : (Parsetree.expression) = Obj.magic _7 in
-        let _6 : unit = Obj.magic _6 in
-        let _5 : unit = Obj.magic _5 in
-        let _4 : (Parsetree.expression) = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
-        let _2 : (
-# 561 "parsing/parser.mly"
-       (string)
-# 11736 "parsing/parser.ml"
-        ) = Obj.magic _2 in
-        let _1 : (Parsetree.expression) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__7_ in
-        let _v : (Parsetree.expression) = let _endpos = _endpos__7_ in
-        let _symbolstartpos = _startpos__1_ in
-        let _sloc = (_symbolstartpos, _endpos) in
-        
-# 1598 "parsing/parser.mly"
-      ( dotop_set ~loc:_sloc (Lident ("." ^ _2 ^ "{}<-")) _1 _4 _7 )
-# 11748 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _9;
-          MenhirLib.EngineTypes.startp = _startpos__9_;
-          MenhirLib.EngineTypes.endp = _endpos__9_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _8;
-            MenhirLib.EngineTypes.startp = _startpos__8_;
-            MenhirLib.EngineTypes.endp = _endpos__8_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _7;
-              MenhirLib.EngineTypes.startp = _startpos__7_;
-              MenhirLib.EngineTypes.endp = _endpos__7_;
-              MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _6;
-                MenhirLib.EngineTypes.startp = _startpos__6_;
-                MenhirLib.EngineTypes.endp = _endpos__6_;
-                MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.semv = _5;
-                  MenhirLib.EngineTypes.startp = _startpos__5_;
-                  MenhirLib.EngineTypes.endp = _endpos__5_;
-                  MenhirLib.EngineTypes.next = {
-                    MenhirLib.EngineTypes.semv = _4;
-                    MenhirLib.EngineTypes.startp = _startpos__4_;
-                    MenhirLib.EngineTypes.endp = _endpos__4_;
-                    MenhirLib.EngineTypes.next = {
-                      MenhirLib.EngineTypes.semv = _3;
-                      MenhirLib.EngineTypes.startp = _startpos__3_;
-                      MenhirLib.EngineTypes.endp = _endpos__3_;
-                      MenhirLib.EngineTypes.next = {
-                        MenhirLib.EngineTypes.semv = _2;
-                        MenhirLib.EngineTypes.startp = _startpos__2_;
-                        MenhirLib.EngineTypes.endp = _endpos__2_;
-                        MenhirLib.EngineTypes.next = {
-                          MenhirLib.EngineTypes.state = _menhir_s;
-                          MenhirLib.EngineTypes.semv = _1;
-                          MenhirLib.EngineTypes.startp = _startpos__1_;
-                          MenhirLib.EngineTypes.endp = _endpos__1_;
-                          MenhirLib.EngineTypes.next = _menhir_stack;
-                        };
-                      };
-                    };
-                  };
-                };
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _9 : (Parsetree.expression) = Obj.magic _9 in
-        let _8 : unit = Obj.magic _8 in
-        let _7 : unit = Obj.magic _7 in
-        let _6 : (Parsetree.expression) = Obj.magic _6 in
-        let _5 : unit = Obj.magic _5 in
-        let _4 : (
-# 561 "parsing/parser.mly"
-       (string)
-# 11814 "parsing/parser.ml"
-        ) = Obj.magic _4 in
-        let _3 : (Longident.t) = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : (Parsetree.expression) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__9_ in
-        let _v : (Parsetree.expression) = let _endpos = _endpos__9_ in
-        let _symbolstartpos = _startpos__1_ in
-        let _sloc = (_symbolstartpos, _endpos) in
-        
-# 1600 "parsing/parser.mly"
-      ( dotop_set ~loc:_sloc (Ldot(_3,"." ^ _4 ^ "[]<-")) _1 _6 _9 )
-# 11828 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _9;
-          MenhirLib.EngineTypes.startp = _startpos__9_;
-          MenhirLib.EngineTypes.endp = _endpos__9_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _8;
-            MenhirLib.EngineTypes.startp = _startpos__8_;
-            MenhirLib.EngineTypes.endp = _endpos__8_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _7;
-              MenhirLib.EngineTypes.startp = _startpos__7_;
-              MenhirLib.EngineTypes.endp = _endpos__7_;
-              MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _6;
-                MenhirLib.EngineTypes.startp = _startpos__6_;
-                MenhirLib.EngineTypes.endp = _endpos__6_;
-                MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.semv = _5;
-                  MenhirLib.EngineTypes.startp = _startpos__5_;
-                  MenhirLib.EngineTypes.endp = _endpos__5_;
-                  MenhirLib.EngineTypes.next = {
-                    MenhirLib.EngineTypes.semv = _4;
-                    MenhirLib.EngineTypes.startp = _startpos__4_;
-                    MenhirLib.EngineTypes.endp = _endpos__4_;
-                    MenhirLib.EngineTypes.next = {
-                      MenhirLib.EngineTypes.semv = _3;
-                      MenhirLib.EngineTypes.startp = _startpos__3_;
-                      MenhirLib.EngineTypes.endp = _endpos__3_;
-                      MenhirLib.EngineTypes.next = {
-                        MenhirLib.EngineTypes.semv = _2;
-                        MenhirLib.EngineTypes.startp = _startpos__2_;
-                        MenhirLib.EngineTypes.endp = _endpos__2_;
-                        MenhirLib.EngineTypes.next = {
-                          MenhirLib.EngineTypes.state = _menhir_s;
-                          MenhirLib.EngineTypes.semv = _1;
-                          MenhirLib.EngineTypes.startp = _startpos__1_;
-                          MenhirLib.EngineTypes.endp = _endpos__1_;
-                          MenhirLib.EngineTypes.next = _menhir_stack;
-                        };
-                      };
-                    };
-                  };
-                };
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _9 : (Parsetree.expression) = Obj.magic _9 in
-        let _8 : unit = Obj.magic _8 in
-        let _7 : unit = Obj.magic _7 in
-        let _6 : (Parsetree.expression) = Obj.magic _6 in
-        let _5 : unit = Obj.magic _5 in
-        let _4 : (
-# 561 "parsing/parser.mly"
-       (string)
-# 11894 "parsing/parser.ml"
-        ) = Obj.magic _4 in
-        let _3 : (Longident.t) = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : (Parsetree.expression) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__9_ in
-        let _v : (Parsetree.expression) = let _endpos = _endpos__9_ in
-        let _symbolstartpos = _startpos__1_ in
-        let _sloc = (_symbolstartpos, _endpos) in
-        
-# 1602 "parsing/parser.mly"
-      ( dotop_set ~loc:_sloc (Ldot(_3, "." ^ _4 ^ "()<-")) _1 _6 _9 )
-# 11908 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _9;
-          MenhirLib.EngineTypes.startp = _startpos__9_;
-          MenhirLib.EngineTypes.endp = _endpos__9_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _8;
-            MenhirLib.EngineTypes.startp = _startpos__8_;
-            MenhirLib.EngineTypes.endp = _endpos__8_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _7;
-              MenhirLib.EngineTypes.startp = _startpos__7_;
-              MenhirLib.EngineTypes.endp = _endpos__7_;
-              MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _6;
-                MenhirLib.EngineTypes.startp = _startpos__6_;
-                MenhirLib.EngineTypes.endp = _endpos__6_;
-                MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.semv = _5;
-                  MenhirLib.EngineTypes.startp = _startpos__5_;
-                  MenhirLib.EngineTypes.endp = _endpos__5_;
-                  MenhirLib.EngineTypes.next = {
-                    MenhirLib.EngineTypes.semv = _4;
-                    MenhirLib.EngineTypes.startp = _startpos__4_;
-                    MenhirLib.EngineTypes.endp = _endpos__4_;
-                    MenhirLib.EngineTypes.next = {
-                      MenhirLib.EngineTypes.semv = _3;
-                      MenhirLib.EngineTypes.startp = _startpos__3_;
-                      MenhirLib.EngineTypes.endp = _endpos__3_;
-                      MenhirLib.EngineTypes.next = {
-                        MenhirLib.EngineTypes.semv = _2;
-                        MenhirLib.EngineTypes.startp = _startpos__2_;
-                        MenhirLib.EngineTypes.endp = _endpos__2_;
-                        MenhirLib.EngineTypes.next = {
-                          MenhirLib.EngineTypes.state = _menhir_s;
-                          MenhirLib.EngineTypes.semv = _1;
-                          MenhirLib.EngineTypes.startp = _startpos__1_;
-                          MenhirLib.EngineTypes.endp = _endpos__1_;
-                          MenhirLib.EngineTypes.next = _menhir_stack;
-                        };
-                      };
-                    };
-                  };
-                };
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _9 : (Parsetree.expression) = Obj.magic _9 in
-        let _8 : unit = Obj.magic _8 in
-        let _7 : unit = Obj.magic _7 in
-        let _6 : (Parsetree.expression) = Obj.magic _6 in
-        let _5 : unit = Obj.magic _5 in
-        let _4 : (
-# 561 "parsing/parser.mly"
-       (string)
-# 11974 "parsing/parser.ml"
-        ) = Obj.magic _4 in
-        let _3 : (Longident.t) = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : (Parsetree.expression) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__9_ in
-        let _v : (Parsetree.expression) = let _endpos = _endpos__9_ in
-        let _symbolstartpos = _startpos__1_ in
-        let _sloc = (_symbolstartpos, _endpos) in
-        
-# 1604 "parsing/parser.mly"
       ( dotop_set ~loc:_sloc (Ldot(_3, "." ^ _4 ^ "{}<-")) _1 _6 _9 )
-# 11988 "parsing/parser.ml"
+# 11740 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12013,9 +11765,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.expression) = 
-# 1606 "parsing/parser.mly"
+# 1596 "parsing/parser.mly"
       ( Exp.attr _1 _2 )
-# 12019 "parsing/parser.ml"
+# 11771 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12039,9 +11791,9 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.expression) = let _loc__1_ = (_startpos__1_, _endpos__1_) in
         
-# 1608 "parsing/parser.mly"
+# 1598 "parsing/parser.mly"
      ( not_expecting _loc__1_ "wildcard \"_\"" )
-# 12045 "parsing/parser.ml"
+# 11797 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12076,9 +11828,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.expression list) = 
-# 1988 "parsing/parser.mly"
+# 1978 "parsing/parser.mly"
                                                 ( _3 :: _1 )
-# 12082 "parsing/parser.ml"
+# 11834 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12113,9 +11865,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.expression list) = 
-# 1989 "parsing/parser.mly"
+# 1979 "parsing/parser.mly"
                                                 ( [_3; _1] )
-# 12119 "parsing/parser.ml"
+# 11871 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12138,9 +11890,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.expression list) = 
-# 2019 "parsing/parser.mly"
+# 2009 "parsing/parser.mly"
                                                 ( [_1] )
-# 12144 "parsing/parser.ml"
+# 11896 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12175,9 +11927,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.expression list) = 
-# 2020 "parsing/parser.mly"
+# 2010 "parsing/parser.mly"
                                                 ( _3 :: _1 )
-# 12181 "parsing/parser.ml"
+# 11933 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12193,9 +11945,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (string Asttypes.loc option * Parsetree.attributes) = 
-# 3000 "parsing/parser.mly"
+# 2990 "parsing/parser.mly"
                  ( None, [] )
-# 12199 "parsing/parser.ml"
+# 11951 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12224,9 +11976,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (string Asttypes.loc option * Parsetree.attributes) = 
-# 3001 "parsing/parser.mly"
+# 2991 "parsing/parser.mly"
                          ( None, _1 :: _2 )
-# 12230 "parsing/parser.ml"
+# 11982 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12261,9 +12013,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (string Asttypes.loc option * Parsetree.attributes) = 
-# 3002 "parsing/parser.mly"
+# 2992 "parsing/parser.mly"
                                ( Some _2, _3 )
-# 12267 "parsing/parser.ml"
+# 12019 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12304,9 +12056,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : (Parsetree.extension) = 
-# 3005 "parsing/parser.mly"
+# 2995 "parsing/parser.mly"
                                            ( (_2, _3) )
-# 12310 "parsing/parser.ml"
+# 12062 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12345,20 +12097,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 12362 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 12106 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -12366,11 +12110,11 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2448 "parsing/parser.mly"
+# 2438 "parsing/parser.mly"
       ( let args, res = _2 in
         let info = symbol_info _endpos in
         Te.decl _1 ~args ?res ~attrs:_3 ~loc:(make_loc _sloc) ~info )
-# 12374 "parsing/parser.ml"
+# 12118 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12415,20 +12159,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__11_ in
           let _1 = _11 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 12432 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 12168 "parsing/parser.ml"
           
         in
         let _1 =
@@ -12436,20 +12172,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 12453 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 12181 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -12457,10 +12185,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2460 "parsing/parser.mly"
+# 2450 "parsing/parser.mly"
       ( let info = symbol_info _endpos in
         Te.rebind _1 _3 ~attrs:_4 ~loc:(make_loc _sloc) ~info )
-# 12464 "parsing/parser.ml"
+# 12192 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12505,20 +12233,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 12522 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 12242 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -12526,11 +12246,11 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2694 "parsing/parser.mly"
+# 2684 "parsing/parser.mly"
     ( let info = symbol_info _endpos in
       let attrs = add_info_attrs info _4 in
       Of.tag ~loc:(make_loc _sloc) ~attrs _1 _3 )
-# 12534 "parsing/parser.ml"
+# 12254 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12569,26 +12289,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 12586 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 12298 "parsing/parser.ml"
           
         in
         
-# 2014 "parsing/parser.mly"
+# 2004 "parsing/parser.mly"
       ( (_1, _3) )
-# 12592 "parsing/parser.ml"
+# 12304 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12615,20 +12327,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 12632 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 12336 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__10_ in
@@ -12637,9 +12341,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2016 "parsing/parser.mly"
+# 2006 "parsing/parser.mly"
       ( (_1, exp_of_label ~loc:_sloc {_1 with txt = Lident _1.txt}) )
-# 12643 "parsing/parser.ml"
+# 12347 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12668,9 +12372,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : ((Asttypes.label Asttypes.loc * Parsetree.expression) list) = 
-# 2009 "parsing/parser.mly"
+# 1999 "parsing/parser.mly"
                         ( [_1] )
-# 12674 "parsing/parser.ml"
+# 12378 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12705,9 +12409,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : ((Asttypes.label Asttypes.loc * Parsetree.expression) list) = 
-# 2010 "parsing/parser.mly"
+# 2000 "parsing/parser.mly"
                                     ( _1 :: _3 )
-# 12711 "parsing/parser.ml"
+# 12415 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12764,20 +12468,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 12781 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 12477 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -12785,7 +12481,7 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2701 "parsing/parser.mly"
+# 2691 "parsing/parser.mly"
     ( let info =
         match rhs_info _endpos__4_ with
         | Some _ as info_before_semi -> info_before_semi
@@ -12793,7 +12489,7 @@ module Tables = struct
       in
       let attrs = add_info_attrs info (_4 @ _6) in
       Of.tag ~loc:(make_loc _sloc) ~attrs _1 _3 )
-# 12797 "parsing/parser.ml"
+# 12493 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12837,10 +12533,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2988 "parsing/parser.mly"
+# 2978 "parsing/parser.mly"
     ( mark_symbol_docs _sloc;
       Attr.mk ~loc:(make_loc _sloc) _2 _3 )
-# 12844 "parsing/parser.ml"
+# 12540 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12863,9 +12559,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.expression) = 
-# 1948 "parsing/parser.mly"
+# 1938 "parsing/parser.mly"
       ( _1 )
-# 12869 "parsing/parser.ml"
+# 12565 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12903,9 +12599,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1950 "parsing/parser.mly"
+# 1940 "parsing/parser.mly"
       ( mkexp_constraint ~loc:_sloc _3 _1 )
-# 12909 "parsing/parser.ml"
+# 12605 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12934,9 +12630,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.expression) = 
-# 1974 "parsing/parser.mly"
+# 1964 "parsing/parser.mly"
       ( _2 )
-# 12940 "parsing/parser.ml"
+# 12636 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -12989,9 +12685,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1976 "parsing/parser.mly"
+# 1966 "parsing/parser.mly"
       ( Pexp_constraint (_4, _2) )
-# 12995 "parsing/parser.ml"
+# 12691 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -13000,15 +12696,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 13006 "parsing/parser.ml"
+# 12702 "parsing/parser.ml"
           
         in
         
-# 1977 "parsing/parser.mly"
+# 1967 "parsing/parser.mly"
       ( _1 )
-# 13012 "parsing/parser.ml"
+# 12708 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13040,12 +12736,12 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1980 "parsing/parser.mly"
+# 1970 "parsing/parser.mly"
       (
        let (l,o,p) = _1 in
        ghexp ~loc:_sloc (Pexp_fun(l, o, p, _2))
       )
-# 13049 "parsing/parser.ml"
+# 12745 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13095,9 +12791,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1985 "parsing/parser.mly"
+# 1975 "parsing/parser.mly"
       ( mk_newtypes ~loc:_sloc _3 _5 )
-# 13101 "parsing/parser.ml"
+# 12797 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13134,34 +12830,26 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 858 "parsing/parser.mly"
+# 848 "parsing/parser.mly"
                         ("*")
-# 13140 "parsing/parser.ml"
+# 12836 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
           let _startpos__1_ = _startpos__10_ in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 13159 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 12847 "parsing/parser.ml"
           
         in
         
-# 859 "parsing/parser.mly"
+# 849 "parsing/parser.mly"
       ( _1, None )
-# 13165 "parsing/parser.ml"
+# 12853 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13212,26 +12900,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 13229 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 12909 "parsing/parser.ml"
           
         in
         
-# 861 "parsing/parser.mly"
+# 851 "parsing/parser.mly"
       ( _2, Some _4 )
-# 13235 "parsing/parser.ml"
+# 12915 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13252,15 +12932,15 @@ module Tables = struct
         let _1 : (
 # 624 "parsing/parser.mly"
        (string)
-# 13256 "parsing/parser.ml"
+# 12936 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 865 "parsing/parser.mly"
+# 855 "parsing/parser.mly"
                ( _1 )
-# 13264 "parsing/parser.ml"
+# 12944 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13283,9 +12963,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 866 "parsing/parser.mly"
+# 856 "parsing/parser.mly"
                ( "_" )
-# 13289 "parsing/parser.ml"
+# 12969 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13314,9 +12994,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : ((string Asttypes.loc * Parsetree.module_type option) list) = 
-# 871 "parsing/parser.mly"
+# 861 "parsing/parser.mly"
       ( _2 :: _1 )
-# 13320 "parsing/parser.ml"
+# 13000 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13339,9 +13019,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : ((string Asttypes.loc * Parsetree.module_type option) list) = 
-# 873 "parsing/parser.mly"
+# 863 "parsing/parser.mly"
       ( [ _1 ] )
-# 13345 "parsing/parser.ml"
+# 13025 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13357,9 +13037,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Parsetree.constructor_arguments * Parsetree.core_type option) = 
-# 2376 "parsing/parser.mly"
+# 2366 "parsing/parser.mly"
                                   ( (Pcstr_tuple [],None) )
-# 13363 "parsing/parser.ml"
+# 13043 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13388,9 +13068,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.constructor_arguments * Parsetree.core_type option) = 
-# 2377 "parsing/parser.mly"
+# 2367 "parsing/parser.mly"
                                   ( (_2,None) )
-# 13394 "parsing/parser.ml"
+# 13074 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13431,9 +13111,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : (Parsetree.constructor_arguments * Parsetree.core_type option) = 
-# 2379 "parsing/parser.mly"
+# 2369 "parsing/parser.mly"
                                   ( (_2,Some _4) )
-# 13437 "parsing/parser.ml"
+# 13117 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13462,9 +13142,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.constructor_arguments * Parsetree.core_type option) = 
-# 2381 "parsing/parser.mly"
+# 2371 "parsing/parser.mly"
                                   ( (Pcstr_tuple [],Some _2) )
-# 13468 "parsing/parser.ml"
+# 13148 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13485,15 +13165,15 @@ module Tables = struct
         let _1 : (
 # 624 "parsing/parser.mly"
        (string)
-# 13489 "parsing/parser.ml"
+# 13169 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.label) = 
-# 2737 "parsing/parser.mly"
+# 2727 "parsing/parser.mly"
                               ( _1 )
-# 13497 "parsing/parser.ml"
+# 13177 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13514,15 +13194,15 @@ module Tables = struct
         let _1 : (
 # 578 "parsing/parser.mly"
        (string)
-# 13518 "parsing/parser.ml"
+# 13198 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.label) = 
-# 2738 "parsing/parser.mly"
+# 2728 "parsing/parser.mly"
                               ( _1 )
-# 13526 "parsing/parser.ml"
+# 13206 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13553,11 +13233,11 @@ module Tables = struct
         let _v : (
 # 704 "parsing/parser.mly"
       (Parsetree.structure)
-# 13557 "parsing/parser.ml"
+# 13237 "parsing/parser.ml"
         ) = 
-# 797 "parsing/parser.mly"
+# 787 "parsing/parser.mly"
                                          ( _1 )
-# 13561 "parsing/parser.ml"
+# 13241 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13589,9 +13269,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2712 "parsing/parser.mly"
+# 2702 "parsing/parser.mly"
     ( Of.inherit_ ~loc:(make_loc _sloc) _1 )
-# 13595 "parsing/parser.ml"
+# 13275 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13622,11 +13302,11 @@ module Tables = struct
         let _v : (
 # 706 "parsing/parser.mly"
       (Parsetree.signature)
-# 13626 "parsing/parser.ml"
+# 13306 "parsing/parser.ml"
         ) = 
-# 801 "parsing/parser.mly"
+# 791 "parsing/parser.mly"
                                          ( _1 )
-# 13630 "parsing/parser.ml"
+# 13310 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13667,9 +13347,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : (Parsetree.extension) = 
-# 3008 "parsing/parser.mly"
+# 2998 "parsing/parser.mly"
                                                   ( (_2, _3) )
-# 13673 "parsing/parser.ml"
+# 13353 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13690,15 +13370,15 @@ module Tables = struct
         let _1 : (
 # 578 "parsing/parser.mly"
        (string)
-# 13694 "parsing/parser.ml"
+# 13374 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.label) = 
-# 2715 "parsing/parser.mly"
+# 2705 "parsing/parser.mly"
                                                 ( _1 )
-# 13702 "parsing/parser.ml"
+# 13382 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13749,20 +13429,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 13766 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 13438 "parsing/parser.ml"
           
         in
         let _startpos__2_ = _startpos__10_ in
@@ -13773,10 +13445,10 @@ module Tables = struct
           _startpos__2_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2395 "parsing/parser.mly"
+# 2385 "parsing/parser.mly"
       ( let info = symbol_info _endpos in
         Type.field _2 _4 ~mut:_1 ~attrs:_5 ~loc:(make_loc _sloc) ~info )
-# 13780 "parsing/parser.ml"
+# 13452 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13839,20 +13511,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 13856 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 13520 "parsing/parser.ml"
           
         in
         let _startpos__2_ = _startpos__10_ in
@@ -13863,14 +13527,14 @@ module Tables = struct
           _startpos__2_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2400 "parsing/parser.mly"
+# 2390 "parsing/parser.mly"
       ( let info =
           match rhs_info _endpos__5_ with
           | Some _ as info_before_semi -> info_before_semi
           | None -> symbol_info _endpos
        in
        Type.field _2 _4 ~mut:_1 ~attrs:(_5 @ _7) ~loc:(make_loc _sloc) ~info )
-# 13874 "parsing/parser.ml"
+# 13538 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13893,9 +13557,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.label_declaration list) = 
-# 2389 "parsing/parser.mly"
+# 2379 "parsing/parser.mly"
                                                 ( [_1] )
-# 13899 "parsing/parser.ml"
+# 13563 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13918,9 +13582,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.label_declaration list) = 
-# 2390 "parsing/parser.mly"
+# 2380 "parsing/parser.mly"
                                                 ( [_1] )
-# 13924 "parsing/parser.ml"
+# 13588 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13949,9 +13613,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.label_declaration list) = 
-# 2391 "parsing/parser.mly"
+# 2381 "parsing/parser.mly"
                                                 ( _1 :: _2 )
-# 13955 "parsing/parser.ml"
+# 13619 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -13978,15 +13642,15 @@ module Tables = struct
         let _1 : (
 # 565 "parsing/parser.mly"
        (string)
-# 13982 "parsing/parser.ml"
+# 13646 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Asttypes.arg_label * Parsetree.expression) = 
-# 1882 "parsing/parser.mly"
+# 1872 "parsing/parser.mly"
       ( (Labelled _1, _2) )
-# 13990 "parsing/parser.ml"
+# 13654 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14015,9 +13679,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Asttypes.arg_label * Parsetree.expression) = 
-# 1884 "parsing/parser.mly"
+# 1874 "parsing/parser.mly"
       ( (Labelled (fst _2), snd _2) )
-# 14021 "parsing/parser.ml"
+# 13685 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14046,9 +13710,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Asttypes.arg_label * Parsetree.expression) = 
-# 1886 "parsing/parser.mly"
+# 1876 "parsing/parser.mly"
       ( (Optional (fst _2), snd _2) )
-# 14052 "parsing/parser.ml"
+# 13716 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14075,15 +13739,15 @@ module Tables = struct
         let _1 : (
 # 595 "parsing/parser.mly"
        (string)
-# 14079 "parsing/parser.ml"
+# 13743 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Asttypes.arg_label * Parsetree.expression) = 
-# 1888 "parsing/parser.mly"
+# 1878 "parsing/parser.mly"
       ( (Optional _1, _2) )
-# 14087 "parsing/parser.ml"
+# 13751 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14104,7 +13768,7 @@ module Tables = struct
         let _1 : (
 # 578 "parsing/parser.mly"
        (string)
-# 14108 "parsing/parser.ml"
+# 13772 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
@@ -14113,9 +13777,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1892 "parsing/parser.mly"
+# 1882 "parsing/parser.mly"
       ( (_1, mkexp ~loc:_sloc (Pexp_ident(mkrhs (Lident _1) _sloc))) )
-# 14119 "parsing/parser.ml"
+# 13783 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14138,9 +13802,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string * Parsetree.pattern) = 
-# 1554 "parsing/parser.mly"
+# 1544 "parsing/parser.mly"
       ( _1 )
-# 14144 "parsing/parser.ml"
+# 13808 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14178,10 +13842,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1556 "parsing/parser.mly"
+# 1546 "parsing/parser.mly"
       ( let (lab, pat) = _1 in
         (lab, mkpat ~loc:_sloc (Ppat_constraint(pat, _3))) )
-# 14185 "parsing/parser.ml"
+# 13849 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14202,15 +13866,15 @@ module Tables = struct
         let _1 : (
 # 578 "parsing/parser.mly"
        (string)
-# 14206 "parsing/parser.ml"
+# 13870 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Longident.t) = 
-# 2801 "parsing/parser.mly"
+# 2791 "parsing/parser.mly"
                                                 ( Lident _1 )
-# 14214 "parsing/parser.ml"
+# 13878 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14241,7 +13905,7 @@ module Tables = struct
         let _3 : (
 # 578 "parsing/parser.mly"
        (string)
-# 14245 "parsing/parser.ml"
+# 13909 "parsing/parser.ml"
         ) = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
         let _1 : (Longident.t) = Obj.magic _1 in
@@ -14249,9 +13913,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Longident.t) = 
-# 2802 "parsing/parser.mly"
+# 2792 "parsing/parser.mly"
                                                 ( Ldot(_1, _3) )
-# 14255 "parsing/parser.ml"
+# 13919 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14272,7 +13936,7 @@ module Tables = struct
         let _10 : (
 # 578 "parsing/parser.mly"
        (string)
-# 14276 "parsing/parser.ml"
+# 13940 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__10_ in
@@ -14282,20 +13946,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 14299 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 13955 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__10_ in
@@ -14304,9 +13960,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1561 "parsing/parser.mly"
+# 1551 "parsing/parser.mly"
       ( (_1.Location.txt, mkpat ~loc:_sloc (Ppat_var _1)) )
-# 14310 "parsing/parser.ml"
+# 13966 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14329,9 +13985,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.arg_label * Parsetree.expression) = 
-# 1876 "parsing/parser.mly"
+# 1866 "parsing/parser.mly"
       ( (Nolabel, _1) )
-# 14335 "parsing/parser.ml"
+# 13991 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14354,9 +14010,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.arg_label * Parsetree.expression) = 
-# 1878 "parsing/parser.mly"
+# 1868 "parsing/parser.mly"
       ( _1 )
-# 14360 "parsing/parser.ml"
+# 14016 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14403,9 +14059,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
         let _v : (Asttypes.arg_label * Parsetree.expression option * Parsetree.pattern) = 
-# 1522 "parsing/parser.mly"
+# 1512 "parsing/parser.mly"
       ( (Optional (fst _3), _4, snd _3) )
-# 14409 "parsing/parser.ml"
+# 14065 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14434,9 +14090,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Asttypes.arg_label * Parsetree.expression option * Parsetree.pattern) = 
-# 1524 "parsing/parser.mly"
+# 1514 "parsing/parser.mly"
       ( (Optional (fst _2), None, snd _2) )
-# 14440 "parsing/parser.ml"
+# 14096 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14481,15 +14137,15 @@ module Tables = struct
         let _1 : (
 # 595 "parsing/parser.mly"
        (string)
-# 14485 "parsing/parser.ml"
+# 14141 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
         let _v : (Asttypes.arg_label * Parsetree.expression option * Parsetree.pattern) = 
-# 1526 "parsing/parser.mly"
+# 1516 "parsing/parser.mly"
       ( (Optional _1, _4, _3) )
-# 14493 "parsing/parser.ml"
+# 14149 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14516,15 +14172,15 @@ module Tables = struct
         let _1 : (
 # 595 "parsing/parser.mly"
        (string)
-# 14520 "parsing/parser.ml"
+# 14176 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Asttypes.arg_label * Parsetree.expression option * Parsetree.pattern) = 
-# 1528 "parsing/parser.mly"
+# 1518 "parsing/parser.mly"
       ( (Optional _1, None, _2) )
-# 14528 "parsing/parser.ml"
+# 14184 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14565,9 +14221,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : (Asttypes.arg_label * Parsetree.expression option * Parsetree.pattern) = 
-# 1530 "parsing/parser.mly"
+# 1520 "parsing/parser.mly"
       ( (Labelled (fst _3), None, snd _3) )
-# 14571 "parsing/parser.ml"
+# 14227 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14596,9 +14252,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Asttypes.arg_label * Parsetree.expression option * Parsetree.pattern) = 
-# 1532 "parsing/parser.mly"
+# 1522 "parsing/parser.mly"
       ( (Labelled (fst _2), None, snd _2) )
-# 14602 "parsing/parser.ml"
+# 14258 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14625,15 +14281,15 @@ module Tables = struct
         let _1 : (
 # 565 "parsing/parser.mly"
        (string)
-# 14629 "parsing/parser.ml"
+# 14285 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Asttypes.arg_label * Parsetree.expression option * Parsetree.pattern) = 
-# 1534 "parsing/parser.mly"
+# 1524 "parsing/parser.mly"
       ( (Labelled _1, None, _2) )
-# 14637 "parsing/parser.ml"
+# 14293 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14656,9 +14312,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.arg_label * Parsetree.expression option * Parsetree.pattern) = 
-# 1536 "parsing/parser.mly"
+# 1526 "parsing/parser.mly"
       ( (Nolabel, None, _1) )
-# 14662 "parsing/parser.ml"
+# 14318 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14703,20 +14359,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 14720 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 14368 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -14724,9 +14372,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2002 "parsing/parser.mly"
+# 1992 "parsing/parser.mly"
       ( (_1, mkexp_opt_constraint ~loc:_sloc _4 _2) )
-# 14730 "parsing/parser.ml"
+# 14378 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14759,20 +14407,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 14776 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 14416 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -14780,11 +14420,11 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2004 "parsing/parser.mly"
+# 1994 "parsing/parser.mly"
       ( (_1,
          mkexp_opt_constraint ~loc:_sloc
            (exp_of_longident ~loc:_sloc _1) _2) )
-# 14788 "parsing/parser.ml"
+# 14428 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14807,9 +14447,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : ((Longident.t Asttypes.loc * Parsetree.expression) list) = 
-# 1996 "parsing/parser.mly"
+# 1986 "parsing/parser.mly"
               ( [_1] )
-# 14813 "parsing/parser.ml"
+# 14453 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14844,9 +14484,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : ((Longident.t Asttypes.loc * Parsetree.expression) list) = 
-# 1997 "parsing/parser.mly"
+# 1987 "parsing/parser.mly"
                                  ( _1 :: _3 )
-# 14850 "parsing/parser.ml"
+# 14490 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14875,9 +14515,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : ((Longident.t Asttypes.loc * Parsetree.expression) list) = 
-# 1998 "parsing/parser.mly"
+# 1988 "parsing/parser.mly"
                    ( [_1] )
-# 14881 "parsing/parser.ml"
+# 14521 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14922,20 +14562,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 14939 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 14571 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -14943,9 +14575,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2203 "parsing/parser.mly"
+# 2193 "parsing/parser.mly"
      ( (_1, mkpat_opt_constraint ~loc:_sloc _4 _2) )
-# 14949 "parsing/parser.ml"
+# 14581 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -14978,20 +14610,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 14995 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 14619 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -14999,11 +14623,11 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2205 "parsing/parser.mly"
+# 2195 "parsing/parser.mly"
      ( let label = {_1 with txt = Longident.last _1.txt} in
        (_1, mkpat_opt_constraint ~loc:_sloc
               (pat_of_label ~loc:_sloc label) _2) )
-# 15007 "parsing/parser.ml"
+# 14631 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15026,9 +14650,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : ((Longident.t Asttypes.loc * Parsetree.pattern) list * Asttypes.closed_flag) = 
-# 2195 "parsing/parser.mly"
+# 2185 "parsing/parser.mly"
                 ( [_1], Closed )
-# 15032 "parsing/parser.ml"
+# 14656 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15057,9 +14681,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : ((Longident.t Asttypes.loc * Parsetree.pattern) list * Asttypes.closed_flag) = 
-# 2196 "parsing/parser.mly"
+# 2186 "parsing/parser.mly"
                      ( [_1], Closed )
-# 15063 "parsing/parser.ml"
+# 14687 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15100,9 +14724,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : ((Longident.t Asttypes.loc * Parsetree.pattern) list * Asttypes.closed_flag) = 
-# 2197 "parsing/parser.mly"
+# 2187 "parsing/parser.mly"
                                          ( [_1], Open )
-# 15106 "parsing/parser.ml"
+# 14730 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15137,9 +14761,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : ((Longident.t Asttypes.loc * Parsetree.pattern) list * Asttypes.closed_flag) = 
-# 2199 "parsing/parser.mly"
+# 2189 "parsing/parser.mly"
       ( let (fields, closed) = _3 in _1 :: fields, closed )
-# 15143 "parsing/parser.ml"
+# 14767 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15189,10 +14813,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1939 "parsing/parser.mly"
+# 1929 "parsing/parser.mly"
       ( let (ext, attr) = _2 in
         mklbs ~loc:_sloc ext _3 (mklb ~loc:_sloc true _4 (attr@_5)) )
-# 15196 "parsing/parser.ml"
+# 14820 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15225,18 +14849,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
-# 1899 "parsing/parser.mly"
-              ( mkpatvar ~loc:_loc _1 )
-# 15234 "parsing/parser.ml"
+# 1889 "parsing/parser.mly"
+              ( mkpatvar ~loc:_sloc _1 )
+# 14858 "parsing/parser.ml"
           
         in
         
-# 1902 "parsing/parser.mly"
+# 1892 "parsing/parser.mly"
       ( (_1, _2) )
-# 15240 "parsing/parser.ml"
+# 14864 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15281,12 +14905,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
-# 1899 "parsing/parser.mly"
-              ( mkpatvar ~loc:_loc _1 )
-# 15290 "parsing/parser.ml"
+# 1889 "parsing/parser.mly"
+              ( mkpatvar ~loc:_sloc _1 )
+# 14914 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -15294,7 +14918,7 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1904 "parsing/parser.mly"
+# 1894 "parsing/parser.mly"
       ( let v = _1 in (* PR#7344 *)
         let t =
           match _2 with
@@ -15307,7 +14931,7 @@ module Tables = struct
         let patloc = (_startpos__1_, _endpos__2_) in
         (ghpat ~loc:patloc (Ppat_constraint(v, typ)),
          mkexp_constraint ~loc:_sloc _4 _2) )
-# 15311 "parsing/parser.ml"
+# 14935 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15370,23 +14994,23 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
-# 1899 "parsing/parser.mly"
-              ( mkpatvar ~loc:_loc _1 )
-# 15379 "parsing/parser.ml"
+# 1889 "parsing/parser.mly"
+              ( mkpatvar ~loc:_sloc _1 )
+# 15003 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
         
-# 1917 "parsing/parser.mly"
+# 1907 "parsing/parser.mly"
       ( let typloc = (_startpos__3_, _endpos__5_) in
         let patloc = (_startpos__1_, _endpos__5_) in
         (ghpat ~loc:patloc
            (Ppat_constraint(_1, ghtyp ~loc:typloc (Ptyp_poly(List.rev _3,_5)))),
          _7) )
-# 15390 "parsing/parser.ml"
+# 15014 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15455,12 +15079,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
-# 1899 "parsing/parser.mly"
-              ( mkpatvar ~loc:_loc _1 )
-# 15464 "parsing/parser.ml"
+# 1889 "parsing/parser.mly"
+              ( mkpatvar ~loc:_sloc _1 )
+# 15088 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -15468,12 +15092,12 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1923 "parsing/parser.mly"
+# 1913 "parsing/parser.mly"
       ( let exp, poly =
           wrap_type_annotation ~loc:_sloc _4 _6 _8 in
         let loc = (_startpos__1_, _endpos__6_) in
         (ghpat ~loc (Ppat_constraint(_1, poly)), exp) )
-# 15477 "parsing/parser.ml"
+# 15101 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15508,9 +15132,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.pattern * Parsetree.expression) = 
-# 1928 "parsing/parser.mly"
+# 1918 "parsing/parser.mly"
       ( (_1, _3) )
-# 15514 "parsing/parser.ml"
+# 15138 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15557,10 +15181,10 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
         let _v : (Parsetree.pattern * Parsetree.expression) = 
-# 1930 "parsing/parser.mly"
+# 1920 "parsing/parser.mly"
       ( let loc = (_startpos__1_, _endpos__3_) in
         (ghpat ~loc (Ppat_constraint(_1, _3)), _5) )
-# 15564 "parsing/parser.ml"
+# 15188 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15583,9 +15207,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (let_bindings) = 
-# 1934 "parsing/parser.mly"
+# 1924 "parsing/parser.mly"
                                                 ( _1 )
-# 15589 "parsing/parser.ml"
+# 15213 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15614,9 +15238,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (let_bindings) = 
-# 1935 "parsing/parser.mly"
+# 1925 "parsing/parser.mly"
                                                 ( addlb _1 _2 )
-# 15620 "parsing/parser.ml"
+# 15244 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15655,20 +15279,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 15672 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 15288 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -15676,10 +15292,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2372 "parsing/parser.mly"
+# 2362 "parsing/parser.mly"
       ( let args, res = _2 in
         Te.decl _1 ~args ?res ~attrs:_3 ~loc:(make_loc _sloc) )
-# 15683 "parsing/parser.ml"
+# 15299 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15702,9 +15318,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.pattern) = 
-# 1565 "parsing/parser.mly"
+# 1555 "parsing/parser.mly"
       ( _1 )
-# 15708 "parsing/parser.ml"
+# 15324 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15749,9 +15365,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1567 "parsing/parser.mly"
+# 1557 "parsing/parser.mly"
       ( Ppat_constraint(_1, _3) )
-# 15755 "parsing/parser.ml"
+# 15371 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -15760,15 +15376,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 15766 "parsing/parser.ml"
+# 15382 "parsing/parser.ml"
           
         in
         
-# 1568 "parsing/parser.mly"
+# 1558 "parsing/parser.mly"
       ( _1 )
-# 15772 "parsing/parser.ml"
+# 15388 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15789,7 +15405,7 @@ module Tables = struct
         let _10 : (
 # 578 "parsing/parser.mly"
        (string)
-# 15793 "parsing/parser.ml"
+# 15409 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__10_ in
@@ -15799,26 +15415,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 15816 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 15424 "parsing/parser.ml"
           
         in
         
-# 1895 "parsing/parser.mly"
+# 1885 "parsing/parser.mly"
                                       ( [_1] )
-# 15822 "parsing/parser.ml"
+# 15430 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15845,7 +15453,7 @@ module Tables = struct
         let _10 : (
 # 578 "parsing/parser.mly"
        (string)
-# 15849 "parsing/parser.ml"
+# 15457 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__10_ in
@@ -15855,26 +15463,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 15872 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 15472 "parsing/parser.ml"
           
         in
         
-# 1896 "parsing/parser.mly"
+# 1886 "parsing/parser.mly"
                                       ( _1 :: _2 )
-# 15878 "parsing/parser.ml"
+# 15478 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15909,9 +15509,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.case) = 
-# 1966 "parsing/parser.mly"
+# 1956 "parsing/parser.mly"
       ( Exp.case _1 _3 )
-# 15915 "parsing/parser.ml"
+# 15515 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15958,9 +15558,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
         let _v : (Parsetree.case) = 
-# 1968 "parsing/parser.mly"
+# 1958 "parsing/parser.mly"
       ( Exp.case _1 ~guard:_3 _5 )
-# 15964 "parsing/parser.ml"
+# 15564 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -15996,9 +15596,9 @@ module Tables = struct
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.case) = let _loc__3_ = (_startpos__3_, _endpos__3_) in
         
-# 1970 "parsing/parser.mly"
+# 1960 "parsing/parser.mly"
       ( Exp.case _1 (Exp.unreachable ~loc:(make_loc _loc__3_) ()) )
-# 16002 "parsing/parser.ml"
+# 15602 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16021,9 +15621,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.case list) = 
-# 1961 "parsing/parser.mly"
+# 1951 "parsing/parser.mly"
                ( [_1] )
-# 16027 "parsing/parser.ml"
+# 15627 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16058,9 +15658,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.case list) = 
-# 1962 "parsing/parser.mly"
+# 1952 "parsing/parser.mly"
                                ( _3 :: _1 )
-# 16064 "parsing/parser.ml"
+# 15664 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16089,9 +15689,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.object_field list * Asttypes.closed_flag) = 
-# 2683 "parsing/parser.mly"
+# 2673 "parsing/parser.mly"
       ( let (f, c) = _2 in (_1 :: f, c) )
-# 16095 "parsing/parser.ml"
+# 15695 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16120,9 +15720,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.object_field list * Asttypes.closed_flag) = 
-# 2685 "parsing/parser.mly"
+# 2675 "parsing/parser.mly"
       ( let (f, c) = _2 in (_1 :: f, c) )
-# 16126 "parsing/parser.ml"
+# 15726 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16145,9 +15745,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.object_field list * Asttypes.closed_flag) = 
-# 2686 "parsing/parser.mly"
+# 2676 "parsing/parser.mly"
                          ( [_1], Closed )
-# 16151 "parsing/parser.ml"
+# 15751 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16170,9 +15770,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.object_field list * Asttypes.closed_flag) = 
-# 2687 "parsing/parser.mly"
+# 2677 "parsing/parser.mly"
                          ( [_1], Closed )
-# 16176 "parsing/parser.ml"
+# 15776 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16195,9 +15795,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.object_field list * Asttypes.closed_flag) = 
-# 2688 "parsing/parser.mly"
+# 2678 "parsing/parser.mly"
                          ( [_1], Closed )
-# 16201 "parsing/parser.ml"
+# 15801 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16223,9 +15823,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2689 "parsing/parser.mly"
+# 2679 "parsing/parser.mly"
                          ( [Of.inherit_ ~loc:(make_loc _sloc) _1], Closed )
-# 16229 "parsing/parser.ml"
+# 15829 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16248,9 +15848,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.object_field list * Asttypes.closed_flag) = 
-# 2690 "parsing/parser.mly"
+# 2680 "parsing/parser.mly"
                          ( [], Open )
-# 16254 "parsing/parser.ml"
+# 15854 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16315,27 +15915,19 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 16332 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 15924 "parsing/parser.ml"
           
         in
         
-# 1342 "parsing/parser.mly"
+# 1332 "parsing/parser.mly"
       ( if _1 = Override then syntax_error ();
         (_5, Private, Cfk_virtual _7), _2 )
-# 16339 "parsing/parser.ml"
+# 15931 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16400,27 +15992,19 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 16417 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 16001 "parsing/parser.ml"
           
         in
         
-# 1345 "parsing/parser.mly"
+# 1335 "parsing/parser.mly"
       ( if _1 = Override then syntax_error ();
         (_5, _4, Cfk_virtual _7), _2 )
-# 16424 "parsing/parser.ml"
+# 16008 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16473,29 +16057,21 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 16490 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 16066 "parsing/parser.ml"
           
         in
         
-# 1348 "parsing/parser.mly"
+# 1338 "parsing/parser.mly"
       ( let e = _5 in
         let loc = Location.(e.pexp_loc.loc_start, e.pexp_loc.loc_end) in
         (_4, _3,
         Cfk_concrete (_1, ghexp ~loc (Pexp_poly (e, None)))), _2 )
-# 16499 "parsing/parser.ml"
+# 16075 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16566,29 +16142,21 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 16583 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 16151 "parsing/parser.ml"
           
         in
         
-# 1354 "parsing/parser.mly"
+# 1344 "parsing/parser.mly"
       ( let poly_exp =
           let loc = (_startpos__6_, _endpos__8_) in
           ghexp ~loc (Pexp_poly(_8, Some _6)) in
         (_4, _3, Cfk_concrete (_1, poly_exp)), _2 )
-# 16592 "parsing/parser.ml"
+# 16160 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16677,20 +16245,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__12_ in
           let _1 = _12 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 16694 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 16254 "parsing/parser.ml"
           
         in
         let _startpos__4_ = _startpos__12_ in
@@ -16707,7 +16267,7 @@ module Tables = struct
               _startpos__4_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1360 "parsing/parser.mly"
+# 1350 "parsing/parser.mly"
       ( let poly_exp_loc = (_startpos__7_, _endpos__11_) in
         let poly_exp =
           let exp, poly =
@@ -16718,7 +16278,7 @@ module Tables = struct
           ghexp ~loc:poly_exp_loc (Pexp_poly(exp, Some poly)) in
         (_4, _3,
         Cfk_concrete (_1, poly_exp)), _2 )
-# 16722 "parsing/parser.ml"
+# 16282 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16739,15 +16299,15 @@ module Tables = struct
         let _1 : (
 # 624 "parsing/parser.mly"
        (string)
-# 16743 "parsing/parser.ml"
+# 16303 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Longident.t) = 
-# 2813 "parsing/parser.mly"
+# 2803 "parsing/parser.mly"
                                                 ( Lident _1 )
-# 16751 "parsing/parser.ml"
+# 16311 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16778,7 +16338,7 @@ module Tables = struct
         let _3 : (
 # 624 "parsing/parser.mly"
        (string)
-# 16782 "parsing/parser.ml"
+# 16342 "parsing/parser.ml"
         ) = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
         let _1 : (Longident.t) = Obj.magic _1 in
@@ -16786,9 +16346,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Longident.t) = 
-# 2814 "parsing/parser.mly"
+# 2804 "parsing/parser.mly"
                                                 ( Ldot(_1, _3) )
-# 16792 "parsing/parser.ml"
+# 16352 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16832,9 +16392,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2816 "parsing/parser.mly"
+# 2806 "parsing/parser.mly"
       ( lapply ~loc:_sloc _1 _3 )
-# 16838 "parsing/parser.ml"
+# 16398 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16855,15 +16415,15 @@ module Tables = struct
         let _1 : (
 # 624 "parsing/parser.mly"
        (string)
-# 16859 "parsing/parser.ml"
+# 16419 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Longident.t) = 
-# 2809 "parsing/parser.mly"
+# 2799 "parsing/parser.mly"
                                                 ( Lident _1 )
-# 16867 "parsing/parser.ml"
+# 16427 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16894,7 +16454,7 @@ module Tables = struct
         let _3 : (
 # 624 "parsing/parser.mly"
        (string)
-# 16898 "parsing/parser.ml"
+# 16458 "parsing/parser.ml"
         ) = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
         let _1 : (Longident.t) = Obj.magic _1 in
@@ -16902,9 +16462,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Longident.t) = 
-# 2810 "parsing/parser.mly"
+# 2800 "parsing/parser.mly"
                                                 ( Ldot(_1, _3) )
-# 16908 "parsing/parser.ml"
+# 16468 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -16953,7 +16513,7 @@ module Tables = struct
         let _10 : (
 # 624 "parsing/parser.mly"
        (string)
-# 16957 "parsing/parser.ml"
+# 16517 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _2 : (string Asttypes.loc option * Parsetree.attributes) = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
@@ -16969,20 +16529,12 @@ module Tables = struct
             let _startpos__1_ = _startpos__10_ in
             let _1 = _10 in
             let _endpos = _endpos__1_ in
-            let _startpos = _startpos__1_ in
-            let _loc = (_startpos, _endpos) in
+            let _symbolstartpos = _startpos__1_ in
+            let _sloc = (_symbolstartpos, _endpos) in
             
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 16986 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 16538 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -16991,9 +16543,9 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 1149 "parsing/parser.mly"
+# 1139 "parsing/parser.mly"
   ( Mty.alias ~loc:(make_loc _sloc) _1 )
-# 16997 "parsing/parser.ml"
+# 16549 "parsing/parser.ml"
           
         in
         let _3 =
@@ -17001,31 +16553,23 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 17018 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 16562 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__6_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1153 "parsing/parser.mly"
+# 1143 "parsing/parser.mly"
       ( let (ext, attrs) = _2 in
         let docs = symbol_docs _sloc in
         Md.mk _3 _5 ~attrs:(attrs@_6) ~loc:(make_loc _sloc) ~docs, ext )
-# 17029 "parsing/parser.ml"
+# 16573 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17068,7 +16612,7 @@ module Tables = struct
         let _10 : (
 # 624 "parsing/parser.mly"
        (string)
-# 17072 "parsing/parser.ml"
+# 16616 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _2 : (string Asttypes.loc option * Parsetree.attributes) = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
@@ -17080,31 +16624,23 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 17097 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 16633 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__5_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1012 "parsing/parser.mly"
+# 1002 "parsing/parser.mly"
       ( let (ext, attrs) = _2 in
         let docs = symbol_docs _sloc in
         Mb.mk _3 _4 ~attrs:(attrs@_5) ~loc:(make_loc _sloc) ~docs, ext )
-# 17108 "parsing/parser.ml"
+# 16644 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17133,9 +16669,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.module_expr) = 
-# 1002 "parsing/parser.mly"
+# 992 "parsing/parser.mly"
       ( _2 )
-# 17139 "parsing/parser.ml"
+# 16675 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17188,9 +16724,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1005 "parsing/parser.mly"
+# 995 "parsing/parser.mly"
         ( Pmod_constraint(_4, _2) )
-# 17194 "parsing/parser.ml"
+# 16730 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -17199,15 +16735,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 756 "parsing/parser.mly"
+# 746 "parsing/parser.mly"
     ( mkmod ~loc:_sloc _1 )
-# 17205 "parsing/parser.ml"
+# 16741 "parsing/parser.ml"
           
         in
         
-# 1008 "parsing/parser.mly"
+# 998 "parsing/parser.mly"
     ( _1 )
-# 17211 "parsing/parser.ml"
+# 16747 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17244,9 +16780,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1007 "parsing/parser.mly"
+# 997 "parsing/parser.mly"
         ( Pmod_functor(fst _1, snd _1, _2) )
-# 17250 "parsing/parser.ml"
+# 16786 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -17255,15 +16791,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 756 "parsing/parser.mly"
+# 746 "parsing/parser.mly"
     ( mkmod ~loc:_sloc _1 )
-# 17261 "parsing/parser.ml"
+# 16797 "parsing/parser.ml"
           
         in
         
-# 1008 "parsing/parser.mly"
+# 998 "parsing/parser.mly"
     ( _1 )
-# 17267 "parsing/parser.ml"
+# 16803 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17306,7 +16842,7 @@ module Tables = struct
         let _10 : (
 # 624 "parsing/parser.mly"
        (string)
-# 17310 "parsing/parser.ml"
+# 16846 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _2 : (string Asttypes.loc option * Parsetree.attributes) = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
@@ -17318,31 +16854,23 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 17335 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 16863 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__5_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1144 "parsing/parser.mly"
+# 1134 "parsing/parser.mly"
       ( let (ext, attrs) = _2 in
         let docs = symbol_docs _sloc in
         Md.mk _3 _4 ~attrs:(attrs@_5) ~loc:(make_loc _sloc) ~docs, ext )
-# 17346 "parsing/parser.ml"
+# 16874 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17371,9 +16899,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.module_type) = 
-# 1135 "parsing/parser.mly"
+# 1125 "parsing/parser.mly"
       ( _2 )
-# 17377 "parsing/parser.ml"
+# 16905 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17410,10 +16938,10 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1137 "parsing/parser.mly"
+# 1127 "parsing/parser.mly"
       ( let (name,typ) = _1 in
         Pmty_functor(name, typ, _2) )
-# 17417 "parsing/parser.ml"
+# 16945 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -17422,15 +16950,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 758 "parsing/parser.mly"
+# 748 "parsing/parser.mly"
     ( mkmty ~loc:_sloc _1 )
-# 17428 "parsing/parser.ml"
+# 16956 "parsing/parser.ml"
           
         in
         
-# 1139 "parsing/parser.mly"
+# 1129 "parsing/parser.mly"
       ( _1 )
-# 17434 "parsing/parser.ml"
+# 16962 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17474,9 +17002,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 878 "parsing/parser.mly"
+# 868 "parsing/parser.mly"
       ( mkmod ~loc:_sloc ~attrs:_2 (Pmod_structure(_3)) )
-# 17480 "parsing/parser.ml"
+# 17008 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17519,9 +17047,9 @@ module Tables = struct
         let _v : (Parsetree.module_expr) = let _loc__4_ = (_startpos__4_, _endpos__4_) in
         let _loc__1_ = (_startpos__1_, _endpos__1_) in
         
-# 880 "parsing/parser.mly"
+# 870 "parsing/parser.mly"
       ( unclosed "struct" _loc__1_ "end" _loc__4_ )
-# 17525 "parsing/parser.ml"
+# 17053 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17571,13 +17099,13 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 882 "parsing/parser.mly"
+# 872 "parsing/parser.mly"
       ( let modexp =
           List.fold_left
             (fun acc (n, t) -> mkmod ~loc:_sloc (Pmod_functor(n, t, acc)))
             _5 _3
         in wrap_mod_attrs ~loc:_sloc modexp _2 )
-# 17581 "parsing/parser.ml"
+# 17109 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17600,9 +17128,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.module_expr) = 
-# 888 "parsing/parser.mly"
+# 878 "parsing/parser.mly"
       ( _1 )
-# 17606 "parsing/parser.ml"
+# 17134 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17631,9 +17159,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.module_expr) = 
-# 890 "parsing/parser.mly"
+# 880 "parsing/parser.mly"
       ( Mod.attr _1 _2 )
-# 17637 "parsing/parser.ml"
+# 17165 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17668,26 +17196,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 17685 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 17205 "parsing/parser.ml"
               
             in
             
-# 896 "parsing/parser.mly"
+# 886 "parsing/parser.mly"
     ( Pmod_ident _1 )
-# 17691 "parsing/parser.ml"
+# 17211 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -17696,15 +17216,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 756 "parsing/parser.mly"
+# 746 "parsing/parser.mly"
     ( mkmod ~loc:_sloc _1 )
-# 17702 "parsing/parser.ml"
+# 17222 "parsing/parser.ml"
           
         in
         
-# 892 "parsing/parser.mly"
+# 882 "parsing/parser.mly"
       ( _1 )
-# 17708 "parsing/parser.ml"
+# 17228 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17741,9 +17261,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 898 "parsing/parser.mly"
+# 888 "parsing/parser.mly"
     ( Pmod_apply(_1, _2) )
-# 17747 "parsing/parser.ml"
+# 17267 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -17752,15 +17272,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 756 "parsing/parser.mly"
+# 746 "parsing/parser.mly"
     ( mkmod ~loc:_sloc _1 )
-# 17758 "parsing/parser.ml"
+# 17278 "parsing/parser.ml"
           
         in
         
-# 892 "parsing/parser.mly"
+# 882 "parsing/parser.mly"
       ( _1 )
-# 17764 "parsing/parser.ml"
+# 17284 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17810,10 +17330,10 @@ module Tables = struct
             let _symbolstartpos = _startpos__1_ in
             let _sloc = (_symbolstartpos, _endpos) in
             
-# 900 "parsing/parser.mly"
+# 890 "parsing/parser.mly"
     ( (* TODO review mkmod location *)
       Pmod_apply(_1, mkmod ~loc:_sloc (Pmod_structure [])) )
-# 17817 "parsing/parser.ml"
+# 17337 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -17822,15 +17342,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 756 "parsing/parser.mly"
+# 746 "parsing/parser.mly"
     ( mkmod ~loc:_sloc _1 )
-# 17828 "parsing/parser.ml"
+# 17348 "parsing/parser.ml"
           
         in
         
-# 892 "parsing/parser.mly"
+# 882 "parsing/parser.mly"
       ( _1 )
-# 17834 "parsing/parser.ml"
+# 17354 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17859,9 +17379,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 903 "parsing/parser.mly"
+# 893 "parsing/parser.mly"
     ( Pmod_extension _1 )
-# 17865 "parsing/parser.ml"
+# 17385 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -17870,15 +17390,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 756 "parsing/parser.mly"
+# 746 "parsing/parser.mly"
     ( mkmod ~loc:_sloc _1 )
-# 17876 "parsing/parser.ml"
+# 17396 "parsing/parser.ml"
           
         in
         
-# 892 "parsing/parser.mly"
+# 882 "parsing/parser.mly"
       ( _1 )
-# 17882 "parsing/parser.ml"
+# 17402 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17922,9 +17442,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1040 "parsing/parser.mly"
+# 1030 "parsing/parser.mly"
       ( mkmty ~loc:_sloc ~attrs:_2 (Pmty_signature (_3)) )
-# 17928 "parsing/parser.ml"
+# 17448 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -17967,9 +17487,9 @@ module Tables = struct
         let _v : (Parsetree.module_type) = let _loc__4_ = (_startpos__4_, _endpos__4_) in
         let _loc__1_ = (_startpos__1_, _endpos__1_) in
         
-# 1042 "parsing/parser.mly"
+# 1032 "parsing/parser.mly"
       ( unclosed "sig" _loc__1_ "end" _loc__4_ )
-# 17973 "parsing/parser.ml"
+# 17493 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18019,13 +17539,13 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1045 "parsing/parser.mly"
+# 1035 "parsing/parser.mly"
       ( let mty =
           List.fold_left
             (fun acc (n, t) -> mkmty ~loc:_sloc (Pmty_functor(n, t, acc)))
             _5 _3
         in wrap_mty_attrs ~loc:_sloc mty _2 )
-# 18029 "parsing/parser.ml"
+# 17549 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18075,9 +17595,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1051 "parsing/parser.mly"
+# 1041 "parsing/parser.mly"
       ( mkmty ~loc:_sloc ~attrs:_4 (Pmty_typeof _5) )
-# 18081 "parsing/parser.ml"
+# 17601 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18112,9 +17632,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.module_type) = 
-# 1053 "parsing/parser.mly"
+# 1043 "parsing/parser.mly"
       ( _2 )
-# 18118 "parsing/parser.ml"
+# 17638 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18151,9 +17671,9 @@ module Tables = struct
         let _v : (Parsetree.module_type) = let _loc__3_ = (_startpos__3_, _endpos__3_) in
         let _loc__1_ = (_startpos__1_, _endpos__1_) in
         
-# 1055 "parsing/parser.mly"
+# 1045 "parsing/parser.mly"
       ( unclosed "(" _loc__1_ ")" _loc__3_ )
-# 18157 "parsing/parser.ml"
+# 17677 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18182,9 +17702,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.module_type) = 
-# 1057 "parsing/parser.mly"
+# 1047 "parsing/parser.mly"
       ( Mty.attr _1 _2 )
-# 18188 "parsing/parser.ml"
+# 17708 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18219,26 +17739,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 18236 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 17748 "parsing/parser.ml"
               
             in
             
-# 1063 "parsing/parser.mly"
+# 1053 "parsing/parser.mly"
       ( Pmty_ident _1 )
-# 18242 "parsing/parser.ml"
+# 17754 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -18247,15 +17759,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 758 "parsing/parser.mly"
+# 748 "parsing/parser.mly"
     ( mkmty ~loc:_sloc _1 )
-# 18253 "parsing/parser.ml"
+# 17765 "parsing/parser.ml"
           
         in
         
-# 1059 "parsing/parser.mly"
+# 1049 "parsing/parser.mly"
       ( _1 )
-# 18259 "parsing/parser.ml"
+# 17771 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18300,9 +17812,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1066 "parsing/parser.mly"
+# 1056 "parsing/parser.mly"
       ( Pmty_functor(mknoloc "_", Some _1, _3) )
-# 18306 "parsing/parser.ml"
+# 17818 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -18311,15 +17823,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 758 "parsing/parser.mly"
+# 748 "parsing/parser.mly"
     ( mkmty ~loc:_sloc _1 )
-# 18317 "parsing/parser.ml"
+# 17829 "parsing/parser.ml"
           
         in
         
-# 1059 "parsing/parser.mly"
+# 1049 "parsing/parser.mly"
       ( _1 )
-# 18323 "parsing/parser.ml"
+# 17835 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18364,9 +17876,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1068 "parsing/parser.mly"
+# 1058 "parsing/parser.mly"
       ( Pmty_with(_1, List.rev _3) )
-# 18370 "parsing/parser.ml"
+# 17882 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -18375,15 +17887,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 758 "parsing/parser.mly"
+# 748 "parsing/parser.mly"
     ( mkmty ~loc:_sloc _1 )
-# 18381 "parsing/parser.ml"
+# 17893 "parsing/parser.ml"
           
         in
         
-# 1059 "parsing/parser.mly"
+# 1049 "parsing/parser.mly"
       ( _1 )
-# 18387 "parsing/parser.ml"
+# 17899 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18412,9 +17924,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 1072 "parsing/parser.mly"
+# 1062 "parsing/parser.mly"
       ( Pmty_extension _1 )
-# 18418 "parsing/parser.ml"
+# 17930 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -18423,15 +17935,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 758 "parsing/parser.mly"
+# 748 "parsing/parser.mly"
     ( mkmty ~loc:_sloc _1 )
-# 18429 "parsing/parser.ml"
+# 17941 "parsing/parser.ml"
           
         in
         
-# 1059 "parsing/parser.mly"
+# 1049 "parsing/parser.mly"
       ( _1 )
-# 18435 "parsing/parser.ml"
+# 17947 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18488,31 +18000,23 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 18505 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 18009 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__6_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1183 "parsing/parser.mly"
+# 1173 "parsing/parser.mly"
       ( let (ext, attrs) = _3 in
         let docs = symbol_docs _sloc in
         Mtd.mk _4 ?typ:_5 ~attrs:(attrs@_6) ~loc:(make_loc _sloc) ~docs, ext )
-# 18516 "parsing/parser.ml"
+# 18020 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18528,9 +18032,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Parsetree.module_type option) = 
-# 1177 "parsing/parser.mly"
+# 1167 "parsing/parser.mly"
                               ( None )
-# 18534 "parsing/parser.ml"
+# 18038 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18559,9 +18063,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.module_type option) = 
-# 1178 "parsing/parser.mly"
+# 1168 "parsing/parser.mly"
                               ( Some _2 )
-# 18565 "parsing/parser.ml"
+# 18069 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18584,9 +18088,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Longident.t) = 
-# 2819 "parsing/parser.mly"
+# 2809 "parsing/parser.mly"
                                                 ( Lident _1 )
-# 18590 "parsing/parser.ml"
+# 18094 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18621,9 +18125,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Longident.t) = 
-# 2820 "parsing/parser.mly"
+# 2810 "parsing/parser.mly"
                                                 ( Ldot(_1, _3) )
-# 18627 "parsing/parser.ml"
+# 18131 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18639,9 +18143,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Asttypes.mutable_flag) = 
-# 2880 "parsing/parser.mly"
+# 2870 "parsing/parser.mly"
                                                 ( Immutable )
-# 18645 "parsing/parser.ml"
+# 18149 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18664,9 +18168,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.mutable_flag) = 
-# 2881 "parsing/parser.mly"
+# 2871 "parsing/parser.mly"
                                                 ( Mutable )
-# 18670 "parsing/parser.ml"
+# 18174 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18695,9 +18199,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Asttypes.label) = 
-# 2861 "parsing/parser.mly"
+# 2851 "parsing/parser.mly"
                                                 ( _2 )
-# 18701 "parsing/parser.ml"
+# 18205 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18720,9 +18224,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.label list) = 
-# 2650 "parsing/parser.mly"
+# 2640 "parsing/parser.mly"
                                                 ( [_1] )
-# 18726 "parsing/parser.ml"
+# 18230 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18751,9 +18255,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Asttypes.label list) = 
-# 2651 "parsing/parser.mly"
+# 2641 "parsing/parser.mly"
                                                 ( _2 :: _1 )
-# 18757 "parsing/parser.ml"
+# 18261 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18769,9 +18273,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Asttypes.rec_flag) = 
-# 2868 "parsing/parser.mly"
+# 2858 "parsing/parser.mly"
                                                 ( Recursive )
-# 18775 "parsing/parser.ml"
+# 18279 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18794,9 +18298,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.rec_flag) = 
-# 2869 "parsing/parser.mly"
+# 2859 "parsing/parser.mly"
                                                 ( Nonrecursive )
-# 18800 "parsing/parser.ml"
+# 18304 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18847,32 +18351,24 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 18864 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 18360 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__5_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1122 "parsing/parser.mly"
+# 1112 "parsing/parser.mly"
       ( let (ext, attrs) = _3 in
         let docs = symbol_docs _sloc in
         Opn.mk _4 ~override:_2 ~attrs:(attrs@_5) ~loc:(make_loc _sloc) ~docs
         , ext )
-# 18876 "parsing/parser.ml"
+# 18372 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18893,15 +18389,15 @@ module Tables = struct
         let _1 : (
 # 602 "parsing/parser.mly"
        (string)
-# 18897 "parsing/parser.ml"
+# 18393 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2748 "parsing/parser.mly"
+# 2738 "parsing/parser.mly"
                                                 ( _1 )
-# 18905 "parsing/parser.ml"
+# 18401 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18922,15 +18418,15 @@ module Tables = struct
         let _1 : (
 # 556 "parsing/parser.mly"
        (string)
-# 18926 "parsing/parser.ml"
+# 18422 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2749 "parsing/parser.mly"
+# 2739 "parsing/parser.mly"
                                                 ( _1 )
-# 18934 "parsing/parser.ml"
+# 18430 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18951,15 +18447,15 @@ module Tables = struct
         let _1 : (
 # 557 "parsing/parser.mly"
        (string)
-# 18955 "parsing/parser.ml"
+# 18451 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2750 "parsing/parser.mly"
+# 2740 "parsing/parser.mly"
                                                 ( _1 )
-# 18963 "parsing/parser.ml"
+# 18459 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -18980,15 +18476,15 @@ module Tables = struct
         let _1 : (
 # 558 "parsing/parser.mly"
        (string)
-# 18984 "parsing/parser.ml"
+# 18480 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2751 "parsing/parser.mly"
+# 2741 "parsing/parser.mly"
                                                 ( _1 )
-# 18992 "parsing/parser.ml"
+# 18488 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19009,15 +18505,15 @@ module Tables = struct
         let _1 : (
 # 559 "parsing/parser.mly"
        (string)
-# 19013 "parsing/parser.ml"
+# 18509 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2752 "parsing/parser.mly"
+# 2742 "parsing/parser.mly"
                                                 ( _1 )
-# 19021 "parsing/parser.ml"
+# 18517 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19038,15 +18534,15 @@ module Tables = struct
         let _1 : (
 # 560 "parsing/parser.mly"
        (string)
-# 19042 "parsing/parser.ml"
+# 18538 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2753 "parsing/parser.mly"
+# 2743 "parsing/parser.mly"
                                                 ( _1 )
-# 19050 "parsing/parser.ml"
+# 18546 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19079,15 +18575,15 @@ module Tables = struct
         let _1 : (
 # 561 "parsing/parser.mly"
        (string)
-# 19083 "parsing/parser.ml"
+# 18579 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (string) = 
-# 2754 "parsing/parser.mly"
+# 2744 "parsing/parser.mly"
                                                 ( "."^ _1 ^"()" )
-# 19091 "parsing/parser.ml"
+# 18587 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19126,15 +18622,15 @@ module Tables = struct
         let _1 : (
 # 561 "parsing/parser.mly"
        (string)
-# 19130 "parsing/parser.ml"
+# 18626 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : (string) = 
-# 2755 "parsing/parser.mly"
+# 2745 "parsing/parser.mly"
                                                 ( "."^ _1 ^ "()<-" )
-# 19138 "parsing/parser.ml"
+# 18634 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19167,15 +18663,15 @@ module Tables = struct
         let _1 : (
 # 561 "parsing/parser.mly"
        (string)
-# 19171 "parsing/parser.ml"
+# 18667 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (string) = 
-# 2756 "parsing/parser.mly"
+# 2746 "parsing/parser.mly"
                                                 ( "."^ _1 ^"[]" )
-# 19179 "parsing/parser.ml"
+# 18675 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19214,15 +18710,15 @@ module Tables = struct
         let _1 : (
 # 561 "parsing/parser.mly"
        (string)
-# 19218 "parsing/parser.ml"
+# 18714 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : (string) = 
-# 2757 "parsing/parser.mly"
+# 2747 "parsing/parser.mly"
                                                 ( "."^ _1 ^ "[]<-" )
-# 19226 "parsing/parser.ml"
+# 18722 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19255,15 +18751,15 @@ module Tables = struct
         let _1 : (
 # 561 "parsing/parser.mly"
        (string)
-# 19259 "parsing/parser.ml"
+# 18755 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (string) = 
-# 2758 "parsing/parser.mly"
+# 2748 "parsing/parser.mly"
                                                 ( "."^ _1 ^"{}" )
-# 19267 "parsing/parser.ml"
+# 18763 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19302,15 +18798,15 @@ module Tables = struct
         let _1 : (
 # 561 "parsing/parser.mly"
        (string)
-# 19306 "parsing/parser.ml"
+# 18802 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : (string) = 
-# 2759 "parsing/parser.mly"
+# 2749 "parsing/parser.mly"
                                                 ( "."^ _1 ^ "{}<-" )
-# 19314 "parsing/parser.ml"
+# 18810 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19331,15 +18827,265 @@ module Tables = struct
         let _1 : (
 # 613 "parsing/parser.mly"
        (string)
-# 19335 "parsing/parser.ml"
+# 18831 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2760 "parsing/parser.mly"
+# 2750 "parsing/parser.mly"
                                                 ( _1 )
-# 19343 "parsing/parser.ml"
+# 18839 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2751 "parsing/parser.mly"
+                                                ( "!" )
+# 18864 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2752 "parsing/parser.mly"
+                                                ( "+" )
+# 18889 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2753 "parsing/parser.mly"
+                                                ( "+." )
+# 18914 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2754 "parsing/parser.mly"
+                                                ( "-" )
+# 18939 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2755 "parsing/parser.mly"
+                                                ( "-." )
+# 18964 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2756 "parsing/parser.mly"
+                                                ( "*" )
+# 18989 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2757 "parsing/parser.mly"
+                                                ( "=" )
+# 19014 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2758 "parsing/parser.mly"
+                                                ( "<" )
+# 19039 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2759 "parsing/parser.mly"
+                                                ( ">" )
+# 19064 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2760 "parsing/parser.mly"
+                                                ( "or" )
+# 19089 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19363,8 +19109,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2761 "parsing/parser.mly"
-                                                ( "!" )
-# 19368 "parsing/parser.ml"
+                                                ( "||" )
+# 19114 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19388,8 +19134,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2762 "parsing/parser.mly"
-                                                ( "+" )
-# 19393 "parsing/parser.ml"
+                                                ( "&" )
+# 19139 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19413,8 +19159,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2763 "parsing/parser.mly"
-                                                ( "+." )
-# 19418 "parsing/parser.ml"
+                                                ( "&&" )
+# 19164 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19438,8 +19184,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2764 "parsing/parser.mly"
-                                                ( "-" )
-# 19443 "parsing/parser.ml"
+                                                ( ":=" )
+# 19189 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19463,8 +19209,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2765 "parsing/parser.mly"
-                                                ( "-." )
-# 19468 "parsing/parser.ml"
+                                                ( "+=" )
+# 19214 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19488,258 +19234,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2766 "parsing/parser.mly"
-                                                ( "*" )
-# 19493 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2767 "parsing/parser.mly"
-                                                ( "=" )
-# 19518 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2768 "parsing/parser.mly"
-                                                ( "<" )
-# 19543 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2769 "parsing/parser.mly"
-                                                ( ">" )
-# 19568 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2770 "parsing/parser.mly"
-                                                ( "or" )
-# 19593 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2771 "parsing/parser.mly"
-                                                ( "||" )
-# 19618 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2772 "parsing/parser.mly"
-                                                ( "&" )
-# 19643 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2773 "parsing/parser.mly"
-                                                ( "&&" )
-# 19668 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2774 "parsing/parser.mly"
-                                                ( ":=" )
-# 19693 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2775 "parsing/parser.mly"
-                                                ( "+=" )
-# 19718 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2776 "parsing/parser.mly"
                                                 ( "%" )
-# 19743 "parsing/parser.ml"
+# 19239 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19762,9 +19258,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (bool) = 
-# 2642 "parsing/parser.mly"
+# 2632 "parsing/parser.mly"
                                                 ( true )
-# 19768 "parsing/parser.ml"
+# 19264 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19780,9 +19276,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (bool) = 
-# 2643 "parsing/parser.mly"
+# 2633 "parsing/parser.mly"
                                                 ( false )
-# 19786 "parsing/parser.ml"
+# 19282 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19798,9 +19294,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (unit) = 
-# 2899 "parsing/parser.mly"
+# 2889 "parsing/parser.mly"
                                                 ( () )
-# 19804 "parsing/parser.ml"
+# 19300 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19823,9 +19319,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (unit) = 
-# 2900 "parsing/parser.mly"
+# 2890 "parsing/parser.mly"
                                                 ( () )
-# 19829 "parsing/parser.ml"
+# 19325 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19841,9 +19337,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Parsetree.expression option) = 
-# 1549 "parsing/parser.mly"
+# 1539 "parsing/parser.mly"
                                         ( None )
-# 19847 "parsing/parser.ml"
+# 19343 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19872,9 +19368,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.expression option) = 
-# 1550 "parsing/parser.mly"
+# 1540 "parsing/parser.mly"
                                         ( Some _2 )
-# 19878 "parsing/parser.ml"
+# 19374 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19903,9 +19399,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.core_type option) = 
-# 2210 "parsing/parser.mly"
+# 2200 "parsing/parser.mly"
                     ( Some _2 )
-# 19909 "parsing/parser.ml"
+# 19405 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19921,9 +19417,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Parsetree.core_type option) = 
-# 2211 "parsing/parser.mly"
+# 2201 "parsing/parser.mly"
                 ( None )
-# 19927 "parsing/parser.ml"
+# 19423 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19939,9 +19435,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (unit) = 
-# 2903 "parsing/parser.mly"
+# 2893 "parsing/parser.mly"
                                                 ( () )
-# 19945 "parsing/parser.ml"
+# 19441 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19964,9 +19460,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (unit) = 
-# 2904 "parsing/parser.mly"
+# 2894 "parsing/parser.mly"
                                                 ( () )
-# 19970 "parsing/parser.ml"
+# 19466 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -19989,9 +19485,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : ((Parsetree.core_type option * Parsetree.core_type option) option) = 
-# 2030 "parsing/parser.mly"
+# 2020 "parsing/parser.mly"
                     ( Some _1 )
-# 19995 "parsing/parser.ml"
+# 19491 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20007,9 +19503,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : ((Parsetree.core_type option * Parsetree.core_type option) option) = 
-# 2031 "parsing/parser.mly"
+# 2021 "parsing/parser.mly"
                 ( None )
-# 20013 "parsing/parser.ml"
+# 19509 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20038,9 +19534,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.core_type * Asttypes.variance) = 
-# 2303 "parsing/parser.mly"
+# 2293 "parsing/parser.mly"
                                                 ( _2, _1 )
-# 20044 "parsing/parser.ml"
+# 19540 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20063,9 +19559,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : ((Parsetree.core_type * Asttypes.variance) list) = 
-# 2306 "parsing/parser.mly"
+# 2296 "parsing/parser.mly"
                                                          ( [_1] )
-# 20069 "parsing/parser.ml"
+# 19565 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20100,9 +19596,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : ((Parsetree.core_type * Asttypes.variance) list) = 
-# 2307 "parsing/parser.mly"
+# 2297 "parsing/parser.mly"
                                                                   ( _3 :: _1 )
-# 20106 "parsing/parser.ml"
+# 19602 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20118,9 +19614,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : ((Parsetree.core_type * Asttypes.variance) list) = 
-# 2298 "parsing/parser.mly"
+# 2288 "parsing/parser.mly"
                                                 ( [] )
-# 20124 "parsing/parser.ml"
+# 19620 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20143,9 +19639,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : ((Parsetree.core_type * Asttypes.variance) list) = 
-# 2299 "parsing/parser.mly"
+# 2289 "parsing/parser.mly"
                                                 ( [_1] )
-# 20149 "parsing/parser.ml"
+# 19645 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20180,9 +19676,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : ((Parsetree.core_type * Asttypes.variance) list) = 
-# 2300 "parsing/parser.mly"
+# 2290 "parsing/parser.mly"
                                                 ( List.rev _2 )
-# 20186 "parsing/parser.ml"
+# 19682 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20219,9 +19715,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 2311 "parsing/parser.mly"
+# 2301 "parsing/parser.mly"
                     ( Ptyp_var _2 )
-# 20225 "parsing/parser.ml"
+# 19721 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -20230,15 +19726,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 752 "parsing/parser.mly"
+# 742 "parsing/parser.mly"
     ( mktyp ~loc:_sloc _1 )
-# 20236 "parsing/parser.ml"
+# 19732 "parsing/parser.ml"
           
         in
         
-# 2313 "parsing/parser.mly"
+# 2303 "parsing/parser.mly"
       ( _1 )
-# 20242 "parsing/parser.ml"
+# 19738 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20267,9 +19763,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 2312 "parsing/parser.mly"
+# 2302 "parsing/parser.mly"
                     ( Ptyp_any )
-# 20273 "parsing/parser.ml"
+# 19769 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -20278,15 +19774,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 752 "parsing/parser.mly"
+# 742 "parsing/parser.mly"
     ( mktyp ~loc:_sloc _1 )
-# 20284 "parsing/parser.ml"
+# 19780 "parsing/parser.ml"
           
         in
         
-# 2313 "parsing/parser.mly"
+# 2303 "parsing/parser.mly"
       ( _1 )
-# 20290 "parsing/parser.ml"
+# 19786 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20302,9 +19798,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Asttypes.override_flag) = 
-# 2895 "parsing/parser.mly"
+# 2885 "parsing/parser.mly"
                                                 ( Fresh )
-# 20308 "parsing/parser.ml"
+# 19804 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20327,9 +19823,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.override_flag) = 
-# 2896 "parsing/parser.mly"
+# 2886 "parsing/parser.mly"
                                                 ( Override )
-# 20333 "parsing/parser.ml"
+# 19829 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20358,9 +19854,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 2620 "parsing/parser.mly"
+# 2610 "parsing/parser.mly"
       ( Ptyp_package (package_type_of_module_type _1) )
-# 20364 "parsing/parser.ml"
+# 19860 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -20369,15 +19865,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 752 "parsing/parser.mly"
+# 742 "parsing/parser.mly"
     ( mktyp ~loc:_sloc _1 )
-# 20375 "parsing/parser.ml"
+# 19871 "parsing/parser.ml"
           
         in
         
-# 2621 "parsing/parser.mly"
+# 2611 "parsing/parser.mly"
       ( _1 )
-# 20381 "parsing/parser.ml"
+# 19877 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20438,9 +19934,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 908 "parsing/parser.mly"
+# 898 "parsing/parser.mly"
       ( Pmod_constraint(_2, _4) )
-# 20444 "parsing/parser.ml"
+# 19940 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -20449,15 +19945,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 756 "parsing/parser.mly"
+# 746 "parsing/parser.mly"
     ( mkmod ~loc:_sloc _1 )
-# 20455 "parsing/parser.ml"
+# 19951 "parsing/parser.ml"
           
         in
         
-# 909 "parsing/parser.mly"
+# 899 "parsing/parser.mly"
       ( _1 )
-# 20461 "parsing/parser.ml"
+# 19957 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20506,9 +20002,9 @@ module Tables = struct
         let _v : (Parsetree.module_expr) = let _loc__5_ = (_startpos__5_, _endpos__5_) in
         let _loc__1_ = (_startpos__1_, _endpos__1_) in
         
-# 911 "parsing/parser.mly"
+# 901 "parsing/parser.mly"
       ( unclosed "(" _loc__1_ ")" _loc__5_ )
-# 20512 "parsing/parser.ml"
+# 20008 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20543,9 +20039,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.module_expr) = 
-# 913 "parsing/parser.mly"
+# 903 "parsing/parser.mly"
       ( _2 (* TODO consider reloc *) )
-# 20549 "parsing/parser.ml"
+# 20045 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20582,9 +20078,9 @@ module Tables = struct
         let _v : (Parsetree.module_expr) = let _loc__3_ = (_startpos__3_, _endpos__3_) in
         let _loc__1_ = (_startpos__1_, _endpos__1_) in
         
-# 915 "parsing/parser.mly"
+# 905 "parsing/parser.mly"
       ( unclosed "(" _loc__1_ ")" _loc__3_ )
-# 20588 "parsing/parser.ml"
+# 20084 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20634,9 +20130,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 917 "parsing/parser.mly"
+# 907 "parsing/parser.mly"
       ( mkmod ~loc:_sloc ~attrs:_3 (Pmod_unpack _4))
-# 20640 "parsing/parser.ml"
+# 20136 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20698,12 +20194,12 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 919 "parsing/parser.mly"
+# 909 "parsing/parser.mly"
       ( let constr_loc = (_startpos__4_, _endpos__6_) in
         mkmod ~loc:_sloc ~attrs:_3
           (Pmod_unpack(
                ghexp ~loc:constr_loc (Pexp_constraint(_4, _6)))) )
-# 20707 "parsing/parser.ml"
+# 20203 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20777,12 +20273,12 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 925 "parsing/parser.mly"
+# 915 "parsing/parser.mly"
       ( let constr_loc = (_startpos__4_, _endpos__8_) in
         mkmod ~loc:_sloc ~attrs:_3
           (Pmod_unpack(
                ghexp ~loc:constr_loc (Pexp_coerce(_4, Some _6, _8)))) )
-# 20786 "parsing/parser.ml"
+# 20282 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20844,12 +20340,12 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 930 "parsing/parser.mly"
+# 920 "parsing/parser.mly"
       ( let constr_loc = (_startpos__4_, _endpos__6_) in
         mkmod ~loc:_sloc ~attrs:_3
           (Pmod_unpack(
                ghexp ~loc:constr_loc (Pexp_coerce(_4, None, _6)))) )
-# 20853 "parsing/parser.ml"
+# 20349 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20904,9 +20400,9 @@ module Tables = struct
         let _v : (Parsetree.module_expr) = let _loc__6_ = (_startpos__6_, _endpos__6_) in
         let _loc__1_ = (_startpos__1_, _endpos__1_) in
         
-# 935 "parsing/parser.mly"
+# 925 "parsing/parser.mly"
       ( unclosed "(" _loc__1_ ")" _loc__6_ )
-# 20910 "parsing/parser.ml"
+# 20406 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -20961,9 +20457,9 @@ module Tables = struct
         let _v : (Parsetree.module_expr) = let _loc__6_ = (_startpos__6_, _endpos__6_) in
         let _loc__1_ = (_startpos__1_, _endpos__1_) in
         
-# 937 "parsing/parser.mly"
+# 927 "parsing/parser.mly"
       ( unclosed "(" _loc__1_ ")" _loc__6_ )
-# 20967 "parsing/parser.ml"
+# 20463 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21012,9 +20508,9 @@ module Tables = struct
         let _v : (Parsetree.module_expr) = let _loc__5_ = (_startpos__5_, _endpos__5_) in
         let _loc__1_ = (_startpos__1_, _endpos__1_) in
         
-# 939 "parsing/parser.mly"
+# 929 "parsing/parser.mly"
       ( unclosed "(" _loc__1_ ")" _loc__5_ )
-# 21018 "parsing/parser.ml"
+# 20514 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21040,7 +20536,7 @@ module Tables = struct
         let _10 : (
 # 578 "parsing/parser.mly"
        (string)
-# 21044 "parsing/parser.ml"
+# 20540 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
@@ -21051,26 +20547,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 21068 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 20556 "parsing/parser.ml"
           
         in
         
-# 1319 "parsing/parser.mly"
+# 1309 "parsing/parser.mly"
           ( Some _2 )
-# 21074 "parsing/parser.ml"
+# 20562 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21086,9 +20574,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (string Asttypes.loc option) = 
-# 1321 "parsing/parser.mly"
+# 1311 "parsing/parser.mly"
           ( None )
-# 21092 "parsing/parser.ml"
+# 20580 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21119,11 +20607,11 @@ module Tables = struct
         let _v : (
 # 712 "parsing/parser.mly"
       (Parsetree.core_type)
-# 21123 "parsing/parser.ml"
+# 20611 "parsing/parser.ml"
         ) = 
-# 844 "parsing/parser.mly"
+# 834 "parsing/parser.mly"
                   ( _1 )
-# 21127 "parsing/parser.ml"
+# 20615 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21154,11 +20642,11 @@ module Tables = struct
         let _v : (
 # 714 "parsing/parser.mly"
       (Parsetree.expression)
-# 21158 "parsing/parser.ml"
+# 20646 "parsing/parser.ml"
         ) = 
-# 848 "parsing/parser.mly"
+# 838 "parsing/parser.mly"
                  ( _1 )
-# 21162 "parsing/parser.ml"
+# 20650 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21189,11 +20677,11 @@ module Tables = struct
         let _v : (
 # 716 "parsing/parser.mly"
       (Parsetree.pattern)
-# 21193 "parsing/parser.ml"
+# 20681 "parsing/parser.ml"
         ) = 
-# 852 "parsing/parser.mly"
+# 842 "parsing/parser.mly"
                 ( _1 )
-# 21197 "parsing/parser.ml"
+# 20685 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21232,9 +20720,9 @@ module Tables = struct
         let _loc__2_ = (_startpos__2_, _endpos__2_) in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2038 "parsing/parser.mly"
+# 2028 "parsing/parser.mly"
       ( mkpat_cons ~loc:_sloc _loc__2_ (ghpat ~loc:_sloc (Ppat_tuple[_1;_3])) )
-# 21238 "parsing/parser.ml"
+# 20726 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21272,9 +20760,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2040 "parsing/parser.mly"
+# 2030 "parsing/parser.mly"
       ( mkpat_attrs ~loc:_sloc (Ppat_exception _3) _2)
-# 21278 "parsing/parser.ml"
+# 20766 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21303,9 +20791,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.pattern) = 
-# 2042 "parsing/parser.mly"
+# 2032 "parsing/parser.mly"
       ( Pat.attr _1 _2 )
-# 21309 "parsing/parser.ml"
+# 20797 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21328,9 +20816,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.pattern) = 
-# 2044 "parsing/parser.mly"
+# 2034 "parsing/parser.mly"
       ( _1 )
-# 21334 "parsing/parser.ml"
+# 20822 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21382,26 +20870,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 21399 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 20879 "parsing/parser.ml"
               
             in
             
-# 2050 "parsing/parser.mly"
+# 2040 "parsing/parser.mly"
       ( Ppat_alias(_1, _3) )
-# 21405 "parsing/parser.ml"
+# 20885 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -21410,15 +20890,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 21416 "parsing/parser.ml"
+# 20896 "parsing/parser.ml"
           
         in
         
-# 2046 "parsing/parser.mly"
+# 2036 "parsing/parser.mly"
       ( _1 )
-# 21422 "parsing/parser.ml"
+# 20902 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21467,9 +20947,9 @@ module Tables = struct
             let _1 = _10 in
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             
-# 2052 "parsing/parser.mly"
+# 2042 "parsing/parser.mly"
       ( expecting _loc__3_ "identifier" )
-# 21473 "parsing/parser.ml"
+# 20953 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -21478,15 +20958,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 21484 "parsing/parser.ml"
+# 20964 "parsing/parser.ml"
           
         in
         
-# 2046 "parsing/parser.mly"
+# 2036 "parsing/parser.mly"
       ( _1 )
-# 21490 "parsing/parser.ml"
+# 20970 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21515,9 +20995,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 2054 "parsing/parser.mly"
+# 2044 "parsing/parser.mly"
       ( Ppat_tuple(List.rev _1) )
-# 21521 "parsing/parser.ml"
+# 21001 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -21526,15 +21006,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 21532 "parsing/parser.ml"
+# 21012 "parsing/parser.ml"
           
         in
         
-# 2046 "parsing/parser.mly"
+# 2036 "parsing/parser.mly"
       ( _1 )
-# 21538 "parsing/parser.ml"
+# 21018 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21583,9 +21063,9 @@ module Tables = struct
             let _1 = _10 in
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             
-# 2056 "parsing/parser.mly"
+# 2046 "parsing/parser.mly"
       ( expecting _loc__3_ "pattern" )
-# 21589 "parsing/parser.ml"
+# 21069 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -21594,15 +21074,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 21600 "parsing/parser.ml"
+# 21080 "parsing/parser.ml"
           
         in
         
-# 2046 "parsing/parser.mly"
+# 2036 "parsing/parser.mly"
       ( _1 )
-# 21606 "parsing/parser.ml"
+# 21086 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21647,9 +21127,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 2058 "parsing/parser.mly"
+# 2048 "parsing/parser.mly"
       ( Ppat_or(_1, _3) )
-# 21653 "parsing/parser.ml"
+# 21133 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -21658,15 +21138,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 21664 "parsing/parser.ml"
+# 21144 "parsing/parser.ml"
           
         in
         
-# 2046 "parsing/parser.mly"
+# 2036 "parsing/parser.mly"
       ( _1 )
-# 21670 "parsing/parser.ml"
+# 21150 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21715,9 +21195,9 @@ module Tables = struct
             let _1 = _10 in
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             
-# 2060 "parsing/parser.mly"
+# 2050 "parsing/parser.mly"
       ( expecting _loc__3_ "pattern" )
-# 21721 "parsing/parser.ml"
+# 21201 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -21726,15 +21206,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 21732 "parsing/parser.ml"
+# 21212 "parsing/parser.ml"
           
         in
         
-# 2046 "parsing/parser.mly"
+# 2036 "parsing/parser.mly"
       ( _1 )
-# 21738 "parsing/parser.ml"
+# 21218 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21769,9 +21249,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.pattern list) = 
-# 2181 "parsing/parser.mly"
+# 2171 "parsing/parser.mly"
                                                 ( _3 :: _1 )
-# 21775 "parsing/parser.ml"
+# 21255 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21806,9 +21286,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.pattern list) = 
-# 2182 "parsing/parser.mly"
+# 2172 "parsing/parser.mly"
                                                 ( [_3; _1] )
-# 21812 "parsing/parser.ml"
+# 21292 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21844,9 +21324,9 @@ module Tables = struct
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.pattern list) = let _loc__3_ = (_startpos__3_, _endpos__3_) in
         
-# 2183 "parsing/parser.mly"
+# 2173 "parsing/parser.mly"
                                                 ( expecting _loc__3_ "pattern" )
-# 21850 "parsing/parser.ml"
+# 21330 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21869,9 +21349,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.pattern) = 
-# 2090 "parsing/parser.mly"
+# 2080 "parsing/parser.mly"
       ( _1 )
-# 21875 "parsing/parser.ml"
+# 21355 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21915,26 +21395,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 21932 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 21404 "parsing/parser.ml"
               
             in
             
-# 2093 "parsing/parser.mly"
+# 2083 "parsing/parser.mly"
         ( Ppat_construct(_1, Some _2) )
-# 21938 "parsing/parser.ml"
+# 21410 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -21943,15 +21415,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 21949 "parsing/parser.ml"
+# 21421 "parsing/parser.ml"
           
         in
         
-# 2096 "parsing/parser.mly"
+# 2086 "parsing/parser.mly"
       ( _1 )
-# 21955 "parsing/parser.ml"
+# 21427 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -21988,9 +21460,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 2095 "parsing/parser.mly"
+# 2085 "parsing/parser.mly"
         ( Ppat_variant(_1, Some _2) )
-# 21994 "parsing/parser.ml"
+# 21466 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -21999,15 +21471,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 22005 "parsing/parser.ml"
+# 21477 "parsing/parser.ml"
           
         in
         
-# 2096 "parsing/parser.mly"
+# 2086 "parsing/parser.mly"
       ( _1 )
-# 22011 "parsing/parser.ml"
+# 21483 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22045,9 +21517,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2098 "parsing/parser.mly"
+# 2088 "parsing/parser.mly"
       ( mkpat_attrs ~loc:_sloc (Ppat_lazy _3) _2)
-# 22051 "parsing/parser.ml"
+# 21523 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22086,9 +21558,9 @@ module Tables = struct
         let _loc__2_ = (_startpos__2_, _endpos__2_) in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2065 "parsing/parser.mly"
+# 2055 "parsing/parser.mly"
       ( mkpat_cons ~loc:_sloc _loc__2_ (ghpat ~loc:_sloc (Ppat_tuple[_1;_3])) )
-# 22092 "parsing/parser.ml"
+# 21564 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22117,9 +21589,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.pattern) = 
-# 2067 "parsing/parser.mly"
+# 2057 "parsing/parser.mly"
       ( Pat.attr _1 _2 )
-# 22123 "parsing/parser.ml"
+# 21595 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22142,9 +21614,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.pattern) = 
-# 2069 "parsing/parser.mly"
+# 2059 "parsing/parser.mly"
       ( _1 )
-# 22148 "parsing/parser.ml"
+# 21620 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22196,26 +21668,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 22213 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 21677 "parsing/parser.ml"
               
             in
             
-# 2075 "parsing/parser.mly"
+# 2065 "parsing/parser.mly"
       ( Ppat_alias(_1, _3) )
-# 22219 "parsing/parser.ml"
+# 21683 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -22224,15 +21688,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 22230 "parsing/parser.ml"
+# 21694 "parsing/parser.ml"
           
         in
         
-# 2071 "parsing/parser.mly"
+# 2061 "parsing/parser.mly"
       ( _1 )
-# 22236 "parsing/parser.ml"
+# 21700 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22281,9 +21745,9 @@ module Tables = struct
             let _1 = _10 in
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             
-# 2077 "parsing/parser.mly"
+# 2067 "parsing/parser.mly"
       ( expecting _loc__3_ "identifier" )
-# 22287 "parsing/parser.ml"
+# 21751 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -22292,15 +21756,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 22298 "parsing/parser.ml"
+# 21762 "parsing/parser.ml"
           
         in
         
-# 2071 "parsing/parser.mly"
+# 2061 "parsing/parser.mly"
       ( _1 )
-# 22304 "parsing/parser.ml"
+# 21768 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22329,9 +21793,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 2079 "parsing/parser.mly"
+# 2069 "parsing/parser.mly"
       ( Ppat_tuple(List.rev _1) )
-# 22335 "parsing/parser.ml"
+# 21799 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -22340,15 +21804,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 22346 "parsing/parser.ml"
+# 21810 "parsing/parser.ml"
           
         in
         
-# 2071 "parsing/parser.mly"
+# 2061 "parsing/parser.mly"
       ( _1 )
-# 22352 "parsing/parser.ml"
+# 21816 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22397,9 +21861,9 @@ module Tables = struct
             let _1 = _10 in
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             
-# 2081 "parsing/parser.mly"
+# 2071 "parsing/parser.mly"
       ( expecting _loc__3_ "pattern" )
-# 22403 "parsing/parser.ml"
+# 21867 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -22408,15 +21872,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 22414 "parsing/parser.ml"
+# 21878 "parsing/parser.ml"
           
         in
         
-# 2071 "parsing/parser.mly"
+# 2061 "parsing/parser.mly"
       ( _1 )
-# 22420 "parsing/parser.ml"
+# 21884 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22461,9 +21925,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 2083 "parsing/parser.mly"
+# 2073 "parsing/parser.mly"
       ( Ppat_or(_1, _3) )
-# 22467 "parsing/parser.ml"
+# 21931 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -22472,15 +21936,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 22478 "parsing/parser.ml"
+# 21942 "parsing/parser.ml"
           
         in
         
-# 2071 "parsing/parser.mly"
+# 2061 "parsing/parser.mly"
       ( _1 )
-# 22484 "parsing/parser.ml"
+# 21948 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22529,9 +21993,9 @@ module Tables = struct
             let _1 = _10 in
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             
-# 2085 "parsing/parser.mly"
+# 2075 "parsing/parser.mly"
       ( expecting _loc__3_ "pattern" )
-# 22535 "parsing/parser.ml"
+# 21999 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -22540,15 +22004,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 22546 "parsing/parser.ml"
+# 22010 "parsing/parser.ml"
           
         in
         
-# 2071 "parsing/parser.mly"
+# 2061 "parsing/parser.mly"
       ( _1 )
-# 22552 "parsing/parser.ml"
+# 22016 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22583,9 +22047,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.pattern list) = 
-# 2186 "parsing/parser.mly"
+# 2176 "parsing/parser.mly"
                                                 ( _3 :: _1 )
-# 22589 "parsing/parser.ml"
+# 22053 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22620,9 +22084,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.pattern list) = 
-# 2187 "parsing/parser.mly"
+# 2177 "parsing/parser.mly"
                                                 ( [_3; _1] )
-# 22626 "parsing/parser.ml"
+# 22090 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22658,9 +22122,9 @@ module Tables = struct
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.pattern list) = let _loc__3_ = (_startpos__3_, _endpos__3_) in
         
-# 2188 "parsing/parser.mly"
+# 2178 "parsing/parser.mly"
                                                 ( expecting _loc__3_ "pattern" )
-# 22664 "parsing/parser.ml"
+# 22128 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22683,9 +22147,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.pattern list) = 
-# 2191 "parsing/parser.mly"
+# 2181 "parsing/parser.mly"
                                                 ( [_1] )
-# 22689 "parsing/parser.ml"
+# 22153 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22720,9 +22184,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.pattern list) = 
-# 2192 "parsing/parser.mly"
+# 2182 "parsing/parser.mly"
                                                 ( _3 :: _1 )
-# 22726 "parsing/parser.ml"
+# 22190 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22752,15 +22216,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 22758 "parsing/parser.ml"
+# 22222 "parsing/parser.ml"
           
         in
         
-# 1541 "parsing/parser.mly"
+# 1531 "parsing/parser.mly"
       ( _1 )
-# 22764 "parsing/parser.ml"
+# 22228 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22781,7 +22245,7 @@ module Tables = struct
         let _10 : (
 # 578 "parsing/parser.mly"
        (string)
-# 22785 "parsing/parser.ml"
+# 22249 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__10_ in
@@ -22791,26 +22255,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 22808 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 22264 "parsing/parser.ml"
           
         in
         
-# 1544 "parsing/parser.mly"
+# 1534 "parsing/parser.mly"
                       ( Ppat_var _1 )
-# 22814 "parsing/parser.ml"
+# 22270 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22833,9 +22289,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.pattern_desc) = 
-# 1545 "parsing/parser.mly"
+# 1535 "parsing/parser.mly"
                       ( Ppat_any )
-# 22839 "parsing/parser.ml"
+# 22295 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22858,9 +22314,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.payload) = 
-# 3011 "parsing/parser.mly"
+# 3001 "parsing/parser.mly"
               ( PStr _1 )
-# 22864 "parsing/parser.ml"
+# 22320 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22889,9 +22345,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.payload) = 
-# 3012 "parsing/parser.mly"
+# 3002 "parsing/parser.mly"
                     ( PSig _2 )
-# 22895 "parsing/parser.ml"
+# 22351 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22920,9 +22376,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.payload) = 
-# 3013 "parsing/parser.mly"
+# 3003 "parsing/parser.mly"
                     ( PTyp _2 )
-# 22926 "parsing/parser.ml"
+# 22382 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22951,9 +22407,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.payload) = 
-# 3014 "parsing/parser.mly"
+# 3004 "parsing/parser.mly"
                      ( PPat (_2, None) )
-# 22957 "parsing/parser.ml"
+# 22413 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -22994,9 +22450,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : (Parsetree.payload) = 
-# 3015 "parsing/parser.mly"
+# 3005 "parsing/parser.mly"
                                    ( PPat (_2, Some _4) )
-# 23000 "parsing/parser.ml"
+# 22456 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23019,162 +22475,162 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.core_type) = 
+# 2506 "parsing/parser.mly"
+          ( _1 )
+# 22481 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _300;
+          MenhirLib.EngineTypes.startp = _startpos__300_;
+          MenhirLib.EngineTypes.endp = _endpos__300_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _200;
+            MenhirLib.EngineTypes.startp = _startpos__200_;
+            MenhirLib.EngineTypes.endp = _endpos__200_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.state = _menhir_s;
+              MenhirLib.EngineTypes.semv = _100;
+              MenhirLib.EngineTypes.startp = _startpos__100_;
+              MenhirLib.EngineTypes.endp = _endpos__100_;
+              MenhirLib.EngineTypes.next = _menhir_stack;
+            };
+          };
+        } = _menhir_stack in
+        let _300 : (Parsetree.core_type) = Obj.magic _300 in
+        let _200 : unit = Obj.magic _200 in
+        let _100 : (Asttypes.label Asttypes.loc list) = Obj.magic _100 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__100_ in
+        let _endpos = _endpos__300_ in
+        let _v : (Parsetree.core_type) = let _1 =
+          let _endpos__30_ = _endpos__300_ in
+          let _startpos__10_ = _startpos__100_ in
+          let _30 = _300 in
+          let _20 = _200 in
+          let _10 = _100 in
+          let _1 =
+            let _3 = _30 in
+            let _2 = _20 in
+            let _1 = _10 in
+            
+# 2508 "parsing/parser.mly"
+          ( Ptyp_poly(List.rev _1, _3) )
+# 22528 "parsing/parser.ml"
+            
+          in
+          let _endpos__1_ = _endpos__30_ in
+          let _startpos__1_ = _startpos__10_ in
+          let _endpos = _endpos__1_ in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
+          
+# 742 "parsing/parser.mly"
+    ( mktyp ~loc:_sloc _1 )
+# 22539 "parsing/parser.ml"
+          
+        in
+        
+# 2509 "parsing/parser.mly"
+          ( _1 )
+# 22545 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : (Parsetree.core_type) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (Parsetree.core_type) = 
+# 2513 "parsing/parser.mly"
+          ( _1 )
+# 22570 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _300;
+          MenhirLib.EngineTypes.startp = _startpos__300_;
+          MenhirLib.EngineTypes.endp = _endpos__300_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _200;
+            MenhirLib.EngineTypes.startp = _startpos__200_;
+            MenhirLib.EngineTypes.endp = _endpos__200_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.state = _menhir_s;
+              MenhirLib.EngineTypes.semv = _100;
+              MenhirLib.EngineTypes.startp = _startpos__100_;
+              MenhirLib.EngineTypes.endp = _endpos__100_;
+              MenhirLib.EngineTypes.next = _menhir_stack;
+            };
+          };
+        } = _menhir_stack in
+        let _300 : (Parsetree.core_type) = Obj.magic _300 in
+        let _200 : unit = Obj.magic _200 in
+        let _100 : (Asttypes.label Asttypes.loc list) = Obj.magic _100 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__100_ in
+        let _endpos = _endpos__300_ in
+        let _v : (Parsetree.core_type) = let _1 =
+          let _endpos__30_ = _endpos__300_ in
+          let _startpos__10_ = _startpos__100_ in
+          let _30 = _300 in
+          let _20 = _200 in
+          let _10 = _100 in
+          let _1 =
+            let _3 = _30 in
+            let _2 = _20 in
+            let _1 = _10 in
+            
+# 2515 "parsing/parser.mly"
+          ( Ptyp_poly(List.rev _1, _3) )
+# 22617 "parsing/parser.ml"
+            
+          in
+          let _endpos__1_ = _endpos__30_ in
+          let _startpos__1_ = _startpos__10_ in
+          let _endpos = _endpos__1_ in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
+          
+# 742 "parsing/parser.mly"
+    ( mktyp ~loc:_sloc _1 )
+# 22628 "parsing/parser.ml"
+          
+        in
+        
 # 2516 "parsing/parser.mly"
           ( _1 )
-# 23025 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _300;
-          MenhirLib.EngineTypes.startp = _startpos__300_;
-          MenhirLib.EngineTypes.endp = _endpos__300_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _200;
-            MenhirLib.EngineTypes.startp = _startpos__200_;
-            MenhirLib.EngineTypes.endp = _endpos__200_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.state = _menhir_s;
-              MenhirLib.EngineTypes.semv = _100;
-              MenhirLib.EngineTypes.startp = _startpos__100_;
-              MenhirLib.EngineTypes.endp = _endpos__100_;
-              MenhirLib.EngineTypes.next = _menhir_stack;
-            };
-          };
-        } = _menhir_stack in
-        let _300 : (Parsetree.core_type) = Obj.magic _300 in
-        let _200 : unit = Obj.magic _200 in
-        let _100 : (Asttypes.label Asttypes.loc list) = Obj.magic _100 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__100_ in
-        let _endpos = _endpos__300_ in
-        let _v : (Parsetree.core_type) = let _1 =
-          let _endpos__30_ = _endpos__300_ in
-          let _startpos__10_ = _startpos__100_ in
-          let _30 = _300 in
-          let _20 = _200 in
-          let _10 = _100 in
-          let _1 =
-            let _3 = _30 in
-            let _2 = _20 in
-            let _1 = _10 in
-            
-# 2518 "parsing/parser.mly"
-          ( Ptyp_poly(List.rev _1, _3) )
-# 23072 "parsing/parser.ml"
-            
-          in
-          let _endpos__1_ = _endpos__30_ in
-          let _startpos__1_ = _startpos__10_ in
-          let _endpos = _endpos__1_ in
-          let _symbolstartpos = _startpos__1_ in
-          let _sloc = (_symbolstartpos, _endpos) in
-          
-# 752 "parsing/parser.mly"
-    ( mktyp ~loc:_sloc _1 )
-# 23083 "parsing/parser.ml"
-          
-        in
-        
-# 2519 "parsing/parser.mly"
-          ( _1 )
-# 23089 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : (Parsetree.core_type) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (Parsetree.core_type) = 
-# 2523 "parsing/parser.mly"
-          ( _1 )
-# 23114 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _300;
-          MenhirLib.EngineTypes.startp = _startpos__300_;
-          MenhirLib.EngineTypes.endp = _endpos__300_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _200;
-            MenhirLib.EngineTypes.startp = _startpos__200_;
-            MenhirLib.EngineTypes.endp = _endpos__200_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.state = _menhir_s;
-              MenhirLib.EngineTypes.semv = _100;
-              MenhirLib.EngineTypes.startp = _startpos__100_;
-              MenhirLib.EngineTypes.endp = _endpos__100_;
-              MenhirLib.EngineTypes.next = _menhir_stack;
-            };
-          };
-        } = _menhir_stack in
-        let _300 : (Parsetree.core_type) = Obj.magic _300 in
-        let _200 : unit = Obj.magic _200 in
-        let _100 : (Asttypes.label Asttypes.loc list) = Obj.magic _100 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__100_ in
-        let _endpos = _endpos__300_ in
-        let _v : (Parsetree.core_type) = let _1 =
-          let _endpos__30_ = _endpos__300_ in
-          let _startpos__10_ = _startpos__100_ in
-          let _30 = _300 in
-          let _20 = _200 in
-          let _10 = _100 in
-          let _1 =
-            let _3 = _30 in
-            let _2 = _20 in
-            let _1 = _10 in
-            
-# 2525 "parsing/parser.mly"
-          ( Ptyp_poly(List.rev _1, _3) )
-# 23161 "parsing/parser.ml"
-            
-          in
-          let _endpos__1_ = _endpos__30_ in
-          let _startpos__1_ = _startpos__10_ in
-          let _endpos = _endpos__1_ in
-          let _symbolstartpos = _startpos__1_ in
-          let _sloc = (_symbolstartpos, _endpos) in
-          
-# 752 "parsing/parser.mly"
-    ( mktyp ~loc:_sloc _1 )
-# 23172 "parsing/parser.ml"
-          
-        in
-        
-# 2526 "parsing/parser.mly"
-          ( _1 )
-# 23178 "parsing/parser.ml"
+# 22634 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23218,9 +22674,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2984 "parsing/parser.mly"
+# 2974 "parsing/parser.mly"
     ( Attr.mk ~loc:(make_loc _sloc) _2 _3 )
-# 23224 "parsing/parser.ml"
+# 22680 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23236,9 +22692,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Parsetree.attributes) = 
-# 2992 "parsing/parser.mly"
+# 2982 "parsing/parser.mly"
                  ( [] )
-# 23242 "parsing/parser.ml"
+# 22698 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23267,9 +22723,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.attributes) = 
-# 2993 "parsing/parser.mly"
+# 2983 "parsing/parser.mly"
                                              ( _1 :: _2 )
-# 23273 "parsing/parser.ml"
+# 22729 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23338,32 +22794,24 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 23355 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 22803 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__8_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2232 "parsing/parser.mly"
+# 2222 "parsing/parser.mly"
       ( let (ext, attrs) = _2 in
         let docs = symbol_docs _sloc in
         Val.mk _3 _5 ~prim:_7 ~attrs:(attrs@_8) ~loc:(make_loc _sloc) ~docs
         , ext )
-# 23367 "parsing/parser.ml"
+# 22815 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23384,15 +22832,15 @@ module Tables = struct
         let _1 : (
 # 616 "parsing/parser.mly"
        (string * string option)
-# 23388 "parsing/parser.ml"
+# 22836 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string list) = 
-# 2226 "parsing/parser.mly"
+# 2216 "parsing/parser.mly"
                                                 ( [fst _1] )
-# 23396 "parsing/parser.ml"
+# 22844 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23419,15 +22867,15 @@ module Tables = struct
         let _1 : (
 # 616 "parsing/parser.mly"
        (string * string option)
-# 23423 "parsing/parser.ml"
+# 22871 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (string list) = 
-# 2227 "parsing/parser.mly"
+# 2217 "parsing/parser.mly"
                                                 ( fst _1 :: _2 )
-# 23431 "parsing/parser.ml"
+# 22879 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23443,9 +22891,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Asttypes.private_flag) = 
-# 2876 "parsing/parser.mly"
+# 2866 "parsing/parser.mly"
                                                 ( Public )
-# 23449 "parsing/parser.ml"
+# 22897 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23468,9 +22916,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.private_flag) = 
-# 2877 "parsing/parser.mly"
+# 2867 "parsing/parser.mly"
                                                 ( Private )
-# 23474 "parsing/parser.ml"
+# 22922 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23486,9 +22934,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Asttypes.private_flag * Asttypes.virtual_flag) = 
-# 2888 "parsing/parser.mly"
+# 2878 "parsing/parser.mly"
                  ( Public, Concrete )
-# 23492 "parsing/parser.ml"
+# 22940 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23511,9 +22959,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.private_flag * Asttypes.virtual_flag) = 
-# 2889 "parsing/parser.mly"
+# 2879 "parsing/parser.mly"
             ( Private, Concrete )
-# 23517 "parsing/parser.ml"
+# 22965 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23536,9 +22984,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.private_flag * Asttypes.virtual_flag) = 
-# 2890 "parsing/parser.mly"
+# 2880 "parsing/parser.mly"
             ( Public, Virtual )
-# 23542 "parsing/parser.ml"
+# 22990 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23567,9 +23015,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Asttypes.private_flag * Asttypes.virtual_flag) = 
-# 2891 "parsing/parser.mly"
+# 2881 "parsing/parser.mly"
                     ( Private, Virtual )
-# 23573 "parsing/parser.ml"
+# 23021 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23598,9 +23046,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Asttypes.private_flag * Asttypes.virtual_flag) = 
-# 2892 "parsing/parser.mly"
+# 2882 "parsing/parser.mly"
                     ( Private, Virtual )
-# 23604 "parsing/parser.ml"
+# 23052 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23616,9 +23064,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Asttypes.rec_flag) = 
-# 2864 "parsing/parser.mly"
+# 2854 "parsing/parser.mly"
                                                 ( Nonrecursive )
-# 23622 "parsing/parser.ml"
+# 23070 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23641,9 +23089,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.rec_flag) = 
-# 2865 "parsing/parser.mly"
+# 2855 "parsing/parser.mly"
                                                 ( Recursive )
-# 23647 "parsing/parser.ml"
+# 23095 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23691,7 +23139,7 @@ module Tables = struct
         let _10 : (
 # 624 "parsing/parser.mly"
        (string)
-# 23695 "parsing/parser.ml"
+# 23143 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _3 : unit = Obj.magic _3 in
         let _2 : (string Asttypes.loc option * Parsetree.attributes) = Obj.magic _2 in
@@ -23704,31 +23152,23 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 23721 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 23161 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__6_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1025 "parsing/parser.mly"
+# 1015 "parsing/parser.mly"
       ( let (ext, attrs) = _2 in
         let docs = symbol_docs _sloc in
         Mb.mk _4 _5 ~attrs:(attrs@_6) ~loc:(make_loc _sloc) ~docs, ext )
-# 23732 "parsing/parser.ml"
+# 23172 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23751,9 +23191,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.module_binding list * string Asttypes.loc option) = 
-# 1018 "parsing/parser.mly"
+# 1008 "parsing/parser.mly"
       ( let (b, ext) = _1 in ([b], ext) )
-# 23757 "parsing/parser.ml"
+# 23197 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23782,9 +23222,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.module_binding list * string Asttypes.loc option) = 
-# 1020 "parsing/parser.mly"
+# 1010 "parsing/parser.mly"
       ( let (l, ext) = _1 in (_2 :: l, ext) )
-# 23788 "parsing/parser.ml"
+# 23228 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23838,7 +23278,7 @@ module Tables = struct
         let _10 : (
 # 624 "parsing/parser.mly"
        (string)
-# 23842 "parsing/parser.ml"
+# 23282 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _3 : unit = Obj.magic _3 in
         let _2 : (string Asttypes.loc option * Parsetree.attributes) = Obj.magic _2 in
@@ -23851,31 +23291,23 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 23868 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 23300 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__7_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1166 "parsing/parser.mly"
+# 1156 "parsing/parser.mly"
       ( let (ext, attrs) = _2 in
         let docs = symbol_docs _sloc in
         Md.mk _4 _6 ~attrs:(attrs@_7) ~loc:(make_loc _sloc) ~docs, ext )
-# 23879 "parsing/parser.ml"
+# 23311 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23898,9 +23330,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.module_declaration list * string Asttypes.loc option) = 
-# 1159 "parsing/parser.mly"
+# 1149 "parsing/parser.mly"
       ( let (body, ext) = _1 in ([body], ext) )
-# 23904 "parsing/parser.ml"
+# 23336 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23929,9 +23361,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.module_declaration list * string Asttypes.loc option) = 
-# 1161 "parsing/parser.mly"
+# 1151 "parsing/parser.mly"
       ( let (l, ext) = _1 in (_2 :: l, ext) )
-# 23935 "parsing/parser.ml"
+# 23367 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23967,9 +23399,9 @@ module Tables = struct
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.expression option *
   (Longident.t Asttypes.loc * Parsetree.expression) list) = 
-# 1992 "parsing/parser.mly"
+# 1982 "parsing/parser.mly"
                                                 ( (Some _1, _3) )
-# 23973 "parsing/parser.ml"
+# 23405 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -23993,9 +23425,9 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.expression option *
   (Longident.t Asttypes.loc * Parsetree.expression) list) = 
-# 1993 "parsing/parser.mly"
+# 1983 "parsing/parser.mly"
                                                 ( (None, _1) )
-# 23999 "parsing/parser.ml"
+# 23431 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24020,15 +23452,15 @@ module Tables = struct
         let _v : (Parsetree.core_type list) = let xs =
           let x = x0 in
           
-# 784 "parsing/parser.mly"
+# 774 "parsing/parser.mly"
     ( [ x ] )
-# 24026 "parsing/parser.ml"
+# 23458 "parsing/parser.ml"
           
         in
         
-# 792 "parsing/parser.mly"
+# 782 "parsing/parser.mly"
     ( xs )
-# 24032 "parsing/parser.ml"
+# 23464 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24067,15 +23499,15 @@ module Tables = struct
           let _2 = _20 in
           let xs = xs0 in
           
-# 788 "parsing/parser.mly"
+# 778 "parsing/parser.mly"
     ( x :: xs )
-# 24073 "parsing/parser.ml"
+# 23505 "parsing/parser.ml"
           
         in
         
-# 792 "parsing/parser.mly"
+# 782 "parsing/parser.mly"
     ( xs )
-# 24079 "parsing/parser.ml"
+# 23511 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24098,9 +23530,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.row_field) = 
-# 2628 "parsing/parser.mly"
+# 2618 "parsing/parser.mly"
                        ( _1 )
-# 24104 "parsing/parser.ml"
+# 23536 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24126,9 +23558,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2629 "parsing/parser.mly"
+# 2619 "parsing/parser.mly"
                        ( Rf.inherit_ ~loc:(make_loc _sloc) _1 )
-# 24132 "parsing/parser.ml"
+# 23564 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24151,9 +23583,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.row_field list) = 
-# 2624 "parsing/parser.mly"
+# 2614 "parsing/parser.mly"
                                                 ( [_1] )
-# 24157 "parsing/parser.ml"
+# 23589 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24188,9 +23620,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.row_field list) = 
-# 2625 "parsing/parser.mly"
+# 2615 "parsing/parser.mly"
                                                 ( _3 :: _1 )
-# 24194 "parsing/parser.ml"
+# 23626 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24213,9 +23645,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.expression) = 
-# 1510 "parsing/parser.mly"
+# 1500 "parsing/parser.mly"
                                   ( _1 )
-# 24219 "parsing/parser.ml"
+# 23651 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24244,9 +23676,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.expression) = 
-# 1511 "parsing/parser.mly"
+# 1501 "parsing/parser.mly"
                                   ( _1 )
-# 24250 "parsing/parser.ml"
+# 23682 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24291,9 +23723,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1513 "parsing/parser.mly"
+# 1503 "parsing/parser.mly"
     ( Pexp_sequence(_1, _3) )
-# 24297 "parsing/parser.ml"
+# 23729 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -24302,15 +23734,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 24308 "parsing/parser.ml"
+# 23740 "parsing/parser.ml"
           
         in
         
-# 1514 "parsing/parser.mly"
+# 1504 "parsing/parser.mly"
     ( _1 )
-# 24314 "parsing/parser.ml"
+# 23746 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24360,11 +23792,11 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1516 "parsing/parser.mly"
+# 1506 "parsing/parser.mly"
     ( let seq = mkexp ~loc:_sloc (Pexp_sequence (_1, _5)) in
       let payload = PStr [mkstrexp seq []] in
       mkexp ~loc:_sloc (Pexp_extension (_4, payload)) )
-# 24368 "parsing/parser.ml"
+# 23800 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24421,27 +23853,19 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 24438 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 23862 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__6_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2362 "parsing/parser.mly"
+# 2352 "parsing/parser.mly"
       ( let args, res = _4 in
         let (ext,attrs) = _2 in
         let docs = symbol_docs _sloc in
@@ -24449,7 +23873,7 @@ module Tables = struct
           (Te.decl _3 ~args ?res
                       ~attrs:(attrs @ _5) ~loc:(make_loc _sloc) ~docs)
         , ext )
-# 24453 "parsing/parser.ml"
+# 23877 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24472,9 +23896,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.extension_constructor list) = 
-# 2441 "parsing/parser.mly"
+# 2431 "parsing/parser.mly"
                                                           ( [_1] )
-# 24478 "parsing/parser.ml"
+# 23902 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24497,9 +23921,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.extension_constructor list) = 
-# 2442 "parsing/parser.mly"
+# 2432 "parsing/parser.mly"
                                                           ( [_1] )
-# 24503 "parsing/parser.ml"
+# 23927 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24528,9 +23952,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.extension_constructor list) = 
-# 2444 "parsing/parser.mly"
+# 2434 "parsing/parser.mly"
       ( _2 :: _1 )
-# 24534 "parsing/parser.ml"
+# 23958 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24574,11 +23998,11 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1129 "parsing/parser.mly"
+# 1119 "parsing/parser.mly"
       ( let (ext, attrs) = _2 in
         let docs = symbol_docs _sloc in
         Incl.mk _3 ~attrs:(attrs@_4) ~loc:(make_loc _sloc) ~docs, ext )
-# 24582 "parsing/parser.ml"
+# 24006 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24653,20 +24077,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 24670 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 24086 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__9_ in
@@ -24674,13 +24090,13 @@ module Tables = struct
         let _loc__3_ = (_startpos__3_, _endpos__3_) in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2424 "parsing/parser.mly"
+# 2414 "parsing/parser.mly"
       ( let (ext, attrs) = _2 in
         if _3 <> Recursive then not_expecting _loc__3_ "nonrec flag";
         let docs = symbol_docs _sloc in
         Te.mk _5 (List.rev _8) ~params:_4 ~priv:_7 ~attrs:(attrs@_9) ~docs
         , ext )
-# 24684 "parsing/parser.ml"
+# 24100 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24711,13 +24127,13 @@ module Tables = struct
           
 # 721 "parsing/parser.mly"
                               ( extra_sig _startpos _endpos _1 )
-# 24715 "parsing/parser.ml"
+# 24131 "parsing/parser.ml"
           
         in
         
-# 1075 "parsing/parser.mly"
+# 1065 "parsing/parser.mly"
                                       ( _1 )
-# 24721 "parsing/parser.ml"
+# 24137 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24740,15 +24156,13 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.signature_item) = let _endpos = _endpos__1_ in
-        let _startpos = _startpos__1_ in
         let _symbolstartpos = _startpos__1_ in
-        let _loc = (_startpos, _endpos) in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1083 "parsing/parser.mly"
+# 1073 "parsing/parser.mly"
       ( let item, ext = _1 in
-        wrap_sig_ext ~loc:_loc (mksig ~loc:_sloc item) ext )
-# 24752 "parsing/parser.ml"
+        wrap_sig_ext ~loc:_sloc (mksig ~loc:_sloc item) ext )
+# 24166 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24780,10 +24194,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1086 "parsing/parser.mly"
+# 1076 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         mksig ~loc:_sloc (Psig_extension (_1, (add_docs_attrs docs _2))) )
-# 24787 "parsing/parser.ml"
+# 24201 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24812,9 +24226,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 1089 "parsing/parser.mly"
+# 1079 "parsing/parser.mly"
       ( Psig_attribute _1 )
-# 24818 "parsing/parser.ml"
+# 24232 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -24823,15 +24237,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 754 "parsing/parser.mly"
+# 744 "parsing/parser.mly"
     ( mksig ~loc:_sloc _1 )
-# 24829 "parsing/parser.ml"
+# 24243 "parsing/parser.ml"
           
         in
         
-# 1090 "parsing/parser.mly"
+# 1080 "parsing/parser.mly"
       ( _1 )
-# 24835 "parsing/parser.ml"
+# 24249 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24854,9 +24268,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.signature_item_desc * string Asttypes.loc option) = 
-# 1094 "parsing/parser.mly"
+# 1084 "parsing/parser.mly"
       ( let (body, ext) = _1 in (Psig_value body, ext) )
-# 24860 "parsing/parser.ml"
+# 24274 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24879,9 +24293,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.signature_item_desc * string Asttypes.loc option) = 
-# 1096 "parsing/parser.mly"
+# 1086 "parsing/parser.mly"
       ( let (body, ext) = _1 in (Psig_value body, ext) )
-# 24885 "parsing/parser.ml"
+# 24299 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24905,9 +24319,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.signature_item_desc * string Asttypes.loc option) = 
-# 1098 "parsing/parser.mly"
+# 1088 "parsing/parser.mly"
       ( let (nr, l, ext) = _1 in (Psig_type (nr, List.rev l), ext) )
-# 24911 "parsing/parser.ml"
+# 24325 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24930,9 +24344,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.signature_item_desc * string Asttypes.loc option) = 
-# 1100 "parsing/parser.mly"
+# 1090 "parsing/parser.mly"
       ( let (l, ext) = _1 in (Psig_typext l, ext) )
-# 24936 "parsing/parser.ml"
+# 24350 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24955,9 +24369,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.signature_item_desc * string Asttypes.loc option) = 
-# 1102 "parsing/parser.mly"
+# 1092 "parsing/parser.mly"
       ( let (l, ext) = _1 in (Psig_exception l, ext) )
-# 24961 "parsing/parser.ml"
+# 24375 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -24980,9 +24394,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.signature_item_desc * string Asttypes.loc option) = 
-# 1104 "parsing/parser.mly"
+# 1094 "parsing/parser.mly"
       ( let (body, ext) = _1 in (Psig_module body, ext) )
-# 24986 "parsing/parser.ml"
+# 24400 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25005,9 +24419,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.signature_item_desc * string Asttypes.loc option) = 
-# 1106 "parsing/parser.mly"
+# 1096 "parsing/parser.mly"
       ( let (body, ext) = _1 in (Psig_module body, ext) )
-# 25011 "parsing/parser.ml"
+# 24425 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25030,9 +24444,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.signature_item_desc * string Asttypes.loc option) = 
-# 1108 "parsing/parser.mly"
+# 1098 "parsing/parser.mly"
       ( let (l, ext) = _1 in (Psig_recmodule (List.rev l), ext) )
-# 25036 "parsing/parser.ml"
+# 24450 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25055,9 +24469,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.signature_item_desc * string Asttypes.loc option) = 
-# 1110 "parsing/parser.mly"
+# 1100 "parsing/parser.mly"
       ( let (body, ext) = _1 in (Psig_modtype body, ext) )
-# 25061 "parsing/parser.ml"
+# 24475 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25080,9 +24494,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.signature_item_desc * string Asttypes.loc option) = 
-# 1112 "parsing/parser.mly"
+# 1102 "parsing/parser.mly"
       ( let (body, ext) = _1 in (Psig_open body, ext) )
-# 25086 "parsing/parser.ml"
+# 24500 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25105,9 +24519,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.signature_item_desc * string Asttypes.loc option) = 
-# 1114 "parsing/parser.mly"
+# 1104 "parsing/parser.mly"
       ( let (body, ext) = _1 in (Psig_include body, ext) )
-# 25111 "parsing/parser.ml"
+# 24525 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25130,9 +24544,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.signature_item_desc * string Asttypes.loc option) = 
-# 1116 "parsing/parser.mly"
+# 1106 "parsing/parser.mly"
       ( let (l, ext) = _1 in (Psig_class (List.rev l), ext) )
-# 25136 "parsing/parser.ml"
+# 24550 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25155,9 +24569,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.signature_item_desc * string Asttypes.loc option) = 
-# 1118 "parsing/parser.mly"
+# 1108 "parsing/parser.mly"
       ( let (l, ext) = _1 in (Psig_class_type (List.rev l), ext) )
-# 25161 "parsing/parser.ml"
+# 24575 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25173,9 +24587,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Parsetree.signature_item list) = 
-# 1077 "parsing/parser.mly"
+# 1067 "parsing/parser.mly"
                                    ( [] )
-# 25179 "parsing/parser.ml"
+# 24593 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25204,9 +24618,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.signature_item list) = 
-# 1078 "parsing/parser.mly"
+# 1068 "parsing/parser.mly"
                                    ( text_sig _startpos__1_ @ _2 )
-# 25210 "parsing/parser.ml"
+# 24624 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25235,9 +24649,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.signature_item list) = 
-# 1079 "parsing/parser.mly"
+# 1069 "parsing/parser.mly"
                                    ( text_sig _startpos__1_ @ _1 :: _2 )
-# 25241 "parsing/parser.ml"
+# 24655 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25260,9 +24674,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.constant) = 
-# 2727 "parsing/parser.mly"
+# 2717 "parsing/parser.mly"
                  ( _1 )
-# 25266 "parsing/parser.ml"
+# 24680 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25288,16 +24702,16 @@ module Tables = struct
         let _2 : (
 # 564 "parsing/parser.mly"
        (string * char option)
-# 25292 "parsing/parser.ml"
+# 24706 "parsing/parser.ml"
         ) = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.constant) = 
-# 2728 "parsing/parser.mly"
+# 2718 "parsing/parser.mly"
                  ( let (n, m) = _2 in Pconst_integer("-" ^ n, m) )
-# 25301 "parsing/parser.ml"
+# 24715 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25323,16 +24737,16 @@ module Tables = struct
         let _2 : (
 # 545 "parsing/parser.mly"
        (string * char option)
-# 25327 "parsing/parser.ml"
+# 24741 "parsing/parser.ml"
         ) = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.constant) = 
-# 2729 "parsing/parser.mly"
+# 2719 "parsing/parser.mly"
                  ( let (f, m) = _2 in Pconst_float("-" ^ f, m) )
-# 25336 "parsing/parser.ml"
+# 24750 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25358,16 +24772,16 @@ module Tables = struct
         let _2 : (
 # 564 "parsing/parser.mly"
        (string * char option)
-# 25362 "parsing/parser.ml"
+# 24776 "parsing/parser.ml"
         ) = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.constant) = 
-# 2730 "parsing/parser.mly"
+# 2720 "parsing/parser.mly"
                  ( let (n, m) = _2 in Pconst_integer (n, m) )
-# 25371 "parsing/parser.ml"
+# 24785 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25393,16 +24807,16 @@ module Tables = struct
         let _2 : (
 # 545 "parsing/parser.mly"
        (string * char option)
-# 25397 "parsing/parser.ml"
+# 24811 "parsing/parser.ml"
         ) = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.constant) = 
-# 2731 "parsing/parser.mly"
+# 2721 "parsing/parser.mly"
                  ( let (f, m) = _2 in Pconst_float(f, m) )
-# 25406 "parsing/parser.ml"
+# 24820 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25425,9 +24839,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.core_type) = 
-# 2565 "parsing/parser.mly"
+# 2555 "parsing/parser.mly"
       ( _1 )
-# 25431 "parsing/parser.ml"
+# 24845 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25462,9 +24876,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.core_type) = 
-# 2567 "parsing/parser.mly"
+# 2557 "parsing/parser.mly"
       ( _2 )
-# 25468 "parsing/parser.ml"
+# 24882 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25514,9 +24928,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2571 "parsing/parser.mly"
+# 2561 "parsing/parser.mly"
       ( wrap_typ_attrs ~loc:_sloc (reloc_typ ~loc:_sloc _4) _3 )
-# 25520 "parsing/parser.ml"
+# 24934 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25546,15 +24960,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 752 "parsing/parser.mly"
+# 742 "parsing/parser.mly"
     ( mktyp ~loc:_sloc _1 )
-# 25552 "parsing/parser.ml"
+# 24966 "parsing/parser.ml"
           
         in
         
-# 2573 "parsing/parser.mly"
+# 2563 "parsing/parser.mly"
       ( _1 )
-# 25558 "parsing/parser.ml"
+# 24972 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25583,9 +24997,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.core_type_desc) = 
-# 2577 "parsing/parser.mly"
+# 2567 "parsing/parser.mly"
       ( Ptyp_var _2 )
-# 25589 "parsing/parser.ml"
+# 25003 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25608,9 +25022,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.core_type_desc) = 
-# 2579 "parsing/parser.mly"
+# 2569 "parsing/parser.mly"
       ( Ptyp_any )
-# 25614 "parsing/parser.ml"
+# 25028 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25637,26 +25051,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 25654 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 25060 "parsing/parser.ml"
           
         in
         
-# 2581 "parsing/parser.mly"
+# 2571 "parsing/parser.mly"
       ( Ptyp_constr(_1, []) )
-# 25660 "parsing/parser.ml"
+# 25066 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25689,26 +25095,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 25706 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 25104 "parsing/parser.ml"
           
         in
         
-# 2583 "parsing/parser.mly"
+# 2573 "parsing/parser.mly"
       ( Ptyp_constr(_2, [_1]) )
-# 25712 "parsing/parser.ml"
+# 25110 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25753,20 +25151,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 25770 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 25160 "parsing/parser.ml"
           
         in
         let _2 =
@@ -25774,21 +25164,21 @@ module Tables = struct
           let tys =
             let x = x0 in
             
-# 784 "parsing/parser.mly"
+# 774 "parsing/parser.mly"
     ( [ x ] )
-# 25780 "parsing/parser.ml"
+# 25170 "parsing/parser.ml"
             
           in
           
-# 2675 "parsing/parser.mly"
+# 2665 "parsing/parser.mly"
     ( tys )
-# 25786 "parsing/parser.ml"
+# 25176 "parsing/parser.ml"
           
         in
         
-# 2585 "parsing/parser.mly"
+# 2575 "parsing/parser.mly"
       ( Ptyp_constr(_4, List.rev _2) )
-# 25792 "parsing/parser.ml"
+# 25182 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25845,20 +25235,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 25862 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 25244 "parsing/parser.ml"
           
         in
         let _2 =
@@ -25870,21 +25252,21 @@ module Tables = struct
             let _2 = _20 in
             let xs = xs0 in
             
-# 788 "parsing/parser.mly"
+# 778 "parsing/parser.mly"
     ( x :: xs )
-# 25876 "parsing/parser.ml"
+# 25258 "parsing/parser.ml"
             
           in
           
-# 2675 "parsing/parser.mly"
+# 2665 "parsing/parser.mly"
     ( tys )
-# 25882 "parsing/parser.ml"
+# 25264 "parsing/parser.ml"
           
         in
         
-# 2585 "parsing/parser.mly"
+# 2575 "parsing/parser.mly"
       ( Ptyp_constr(_4, List.rev _2) )
-# 25888 "parsing/parser.ml"
+# 25270 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25919,9 +25301,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.core_type_desc) = 
-# 2587 "parsing/parser.mly"
+# 2577 "parsing/parser.mly"
       ( let (f, c) = _2 in Ptyp_object (f, c) )
-# 25925 "parsing/parser.ml"
+# 25307 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25950,9 +25332,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.core_type_desc) = 
-# 2589 "parsing/parser.mly"
+# 2579 "parsing/parser.mly"
       ( Ptyp_object ([], Closed) )
-# 25956 "parsing/parser.ml"
+# 25338 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -25985,26 +25367,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 26002 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 25376 "parsing/parser.ml"
           
         in
         
-# 2591 "parsing/parser.mly"
+# 2581 "parsing/parser.mly"
       ( Ptyp_class(_2, []) )
-# 26008 "parsing/parser.ml"
+# 25382 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26043,26 +25417,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 26060 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 25426 "parsing/parser.ml"
           
         in
         
-# 2593 "parsing/parser.mly"
+# 2583 "parsing/parser.mly"
       ( Ptyp_class(_3, [_1]) )
-# 26066 "parsing/parser.ml"
+# 25432 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26113,20 +25479,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 26130 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 25488 "parsing/parser.ml"
           
         in
         let _2 =
@@ -26134,21 +25492,21 @@ module Tables = struct
           let tys =
             let x = x0 in
             
-# 784 "parsing/parser.mly"
+# 774 "parsing/parser.mly"
     ( [ x ] )
-# 26140 "parsing/parser.ml"
+# 25498 "parsing/parser.ml"
             
           in
           
-# 2675 "parsing/parser.mly"
+# 2665 "parsing/parser.mly"
     ( tys )
-# 26146 "parsing/parser.ml"
+# 25504 "parsing/parser.ml"
           
         in
         
-# 2595 "parsing/parser.mly"
+# 2585 "parsing/parser.mly"
       ( Ptyp_class(_5, List.rev _2) )
-# 26152 "parsing/parser.ml"
+# 25510 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26211,20 +25569,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 26228 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 25578 "parsing/parser.ml"
           
         in
         let _2 =
@@ -26236,21 +25586,21 @@ module Tables = struct
             let _2 = _20 in
             let xs = xs0 in
             
-# 788 "parsing/parser.mly"
+# 778 "parsing/parser.mly"
     ( x :: xs )
-# 26242 "parsing/parser.ml"
+# 25592 "parsing/parser.ml"
             
           in
           
-# 2675 "parsing/parser.mly"
+# 2665 "parsing/parser.mly"
     ( tys )
-# 26248 "parsing/parser.ml"
+# 25598 "parsing/parser.ml"
           
         in
         
-# 2595 "parsing/parser.mly"
+# 2585 "parsing/parser.mly"
       ( Ptyp_class(_5, List.rev _2) )
-# 26254 "parsing/parser.ml"
+# 25604 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26285,9 +25635,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.core_type_desc) = 
-# 2597 "parsing/parser.mly"
+# 2587 "parsing/parser.mly"
       ( Ptyp_variant([_2], Closed, None) )
-# 26291 "parsing/parser.ml"
+# 25641 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26328,9 +25678,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : (Parsetree.core_type_desc) = 
-# 2603 "parsing/parser.mly"
+# 2593 "parsing/parser.mly"
       ( Ptyp_variant(List.rev _3, Closed, None) )
-# 26334 "parsing/parser.ml"
+# 25684 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26377,9 +25727,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
         let _v : (Parsetree.core_type_desc) = 
-# 2605 "parsing/parser.mly"
+# 2595 "parsing/parser.mly"
       ( Ptyp_variant(_2 :: List.rev _4, Closed, None) )
-# 26383 "parsing/parser.ml"
+# 25733 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26420,9 +25770,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : (Parsetree.core_type_desc) = 
-# 2607 "parsing/parser.mly"
+# 2597 "parsing/parser.mly"
       ( Ptyp_variant(List.rev _3, Open, None) )
-# 26426 "parsing/parser.ml"
+# 25776 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26451,9 +25801,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.core_type_desc) = 
-# 2609 "parsing/parser.mly"
+# 2599 "parsing/parser.mly"
       ( Ptyp_variant([], Open, None) )
-# 26457 "parsing/parser.ml"
+# 25807 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26494,9 +25844,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : (Parsetree.core_type_desc) = 
-# 2611 "parsing/parser.mly"
+# 2601 "parsing/parser.mly"
       ( Ptyp_variant(List.rev _3, Closed, Some []) )
-# 26500 "parsing/parser.ml"
+# 25850 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26549,9 +25899,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__6_ in
         let _v : (Parsetree.core_type_desc) = 
-# 2613 "parsing/parser.mly"
+# 2603 "parsing/parser.mly"
       ( Ptyp_variant(List.rev _3, Closed, Some (List.rev _5)) )
-# 26555 "parsing/parser.ml"
+# 25905 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26574,9 +25924,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.core_type_desc) = 
-# 2615 "parsing/parser.mly"
+# 2605 "parsing/parser.mly"
       ( Ptyp_extension _1 )
-# 26580 "parsing/parser.ml"
+# 25930 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26599,9 +25949,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.core_type) = 
-# 2654 "parsing/parser.mly"
+# 2644 "parsing/parser.mly"
                      ( _1 )
-# 26605 "parsing/parser.ml"
+# 25955 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26646,9 +25996,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 2656 "parsing/parser.mly"
+# 2646 "parsing/parser.mly"
       ( Ptyp_tuple(_1 :: List.rev _3) )
-# 26652 "parsing/parser.ml"
+# 26002 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -26657,15 +26007,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 752 "parsing/parser.mly"
+# 742 "parsing/parser.mly"
     ( mktyp ~loc:_sloc _1 )
-# 26663 "parsing/parser.ml"
+# 26013 "parsing/parser.ml"
           
         in
         
-# 2657 "parsing/parser.mly"
+# 2647 "parsing/parser.mly"
       ( _1 )
-# 26669 "parsing/parser.ml"
+# 26019 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26710,10 +26060,10 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 2164 "parsing/parser.mly"
+# 2154 "parsing/parser.mly"
       ( let (fields, closed) = _2 in
         Ppat_record(fields, closed) )
-# 26717 "parsing/parser.ml"
+# 26067 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -26722,15 +26072,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 26728 "parsing/parser.ml"
+# 26078 "parsing/parser.ml"
           
         in
         
-# 2178 "parsing/parser.mly"
+# 2168 "parsing/parser.mly"
     ( _1 )
-# 26734 "parsing/parser.ml"
+# 26084 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26783,9 +26133,9 @@ module Tables = struct
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             let _loc__1_ = (_startpos__1_, _endpos__1_) in
             
-# 2167 "parsing/parser.mly"
+# 2157 "parsing/parser.mly"
       ( unclosed "{" _loc__1_ "}" _loc__3_ )
-# 26789 "parsing/parser.ml"
+# 26139 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -26794,15 +26144,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 26800 "parsing/parser.ml"
+# 26150 "parsing/parser.ml"
           
         in
         
-# 2178 "parsing/parser.mly"
+# 2168 "parsing/parser.mly"
     ( _1 )
-# 26806 "parsing/parser.ml"
+# 26156 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26859,9 +26209,9 @@ module Tables = struct
             let _1 = _10 in
             let _loc__4_ = (_startpos__4_, _endpos__4_) in
             
-# 2169 "parsing/parser.mly"
+# 2159 "parsing/parser.mly"
       ( fst (mktailpat _loc__4_ (List.rev _2)) )
-# 26865 "parsing/parser.ml"
+# 26215 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -26870,15 +26220,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 26876 "parsing/parser.ml"
+# 26226 "parsing/parser.ml"
           
         in
         
-# 2178 "parsing/parser.mly"
+# 2168 "parsing/parser.mly"
     ( _1 )
-# 26882 "parsing/parser.ml"
+# 26232 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -26939,9 +26289,9 @@ module Tables = struct
             let _loc__4_ = (_startpos__4_, _endpos__4_) in
             let _loc__1_ = (_startpos__1_, _endpos__1_) in
             
-# 2171 "parsing/parser.mly"
+# 2161 "parsing/parser.mly"
       ( unclosed "[" _loc__1_ "]" _loc__4_ )
-# 26945 "parsing/parser.ml"
+# 26295 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -26950,15 +26300,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 26956 "parsing/parser.ml"
+# 26306 "parsing/parser.ml"
           
         in
         
-# 2178 "parsing/parser.mly"
+# 2168 "parsing/parser.mly"
     ( _1 )
-# 26962 "parsing/parser.ml"
+# 26312 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -27011,9 +26361,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 2173 "parsing/parser.mly"
+# 2163 "parsing/parser.mly"
       ( Ppat_array(List.rev _2) )
-# 27017 "parsing/parser.ml"
+# 26367 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -27022,15 +26372,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 27028 "parsing/parser.ml"
+# 26378 "parsing/parser.ml"
           
         in
         
-# 2178 "parsing/parser.mly"
+# 2168 "parsing/parser.mly"
     ( _1 )
-# 27034 "parsing/parser.ml"
+# 26384 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -27067,9 +26417,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 2175 "parsing/parser.mly"
+# 2165 "parsing/parser.mly"
       ( Ppat_array [] )
-# 27073 "parsing/parser.ml"
+# 26423 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -27078,15 +26428,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 27084 "parsing/parser.ml"
+# 26434 "parsing/parser.ml"
           
         in
         
-# 2178 "parsing/parser.mly"
+# 2168 "parsing/parser.mly"
     ( _1 )
-# 27090 "parsing/parser.ml"
+# 26440 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -27147,9 +26497,9 @@ module Tables = struct
             let _loc__4_ = (_startpos__4_, _endpos__4_) in
             let _loc__1_ = (_startpos__1_, _endpos__1_) in
             
-# 2177 "parsing/parser.mly"
+# 2167 "parsing/parser.mly"
       ( unclosed "[|" _loc__1_ "|]" _loc__4_ )
-# 27153 "parsing/parser.ml"
+# 26503 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -27158,15 +26508,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 27164 "parsing/parser.ml"
+# 26514 "parsing/parser.ml"
           
         in
         
-# 2178 "parsing/parser.mly"
+# 2168 "parsing/parser.mly"
     ( _1 )
-# 27170 "parsing/parser.ml"
+# 26520 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -27204,9 +26554,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1708 "parsing/parser.mly"
+# 1698 "parsing/parser.mly"
       ( reloc_exp ~loc:_sloc _2 )
-# 27210 "parsing/parser.ml"
+# 26560 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -27243,9 +26593,9 @@ module Tables = struct
         let _v : (Parsetree.expression) = let _loc__3_ = (_startpos__3_, _endpos__3_) in
         let _loc__1_ = (_startpos__1_, _endpos__1_) in
         
-# 1710 "parsing/parser.mly"
+# 1700 "parsing/parser.mly"
       ( unclosed "(" _loc__1_ ")" _loc__3_ )
-# 27249 "parsing/parser.ml"
+# 26599 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -27289,9 +26639,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1712 "parsing/parser.mly"
+# 1702 "parsing/parser.mly"
       ( mkexp_constraint ~loc:_sloc _2 _3 )
-# 27295 "parsing/parser.ml"
+# 26645 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -27340,10 +26690,275 @@ module Tables = struct
         let _v : (Parsetree.expression) = let _endpos = _endpos__5_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
+        
+# 1704 "parsing/parser.mly"
+      ( array_get ~loc:_sloc _1 _4 )
+# 26697 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _5;
+          MenhirLib.EngineTypes.startp = _startpos__5_;
+          MenhirLib.EngineTypes.endp = _endpos__5_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _4;
+            MenhirLib.EngineTypes.startp = _startpos__4_;
+            MenhirLib.EngineTypes.endp = _endpos__4_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.semv = _3;
+              MenhirLib.EngineTypes.startp = _startpos__3_;
+              MenhirLib.EngineTypes.endp = _endpos__3_;
+              MenhirLib.EngineTypes.next = {
+                MenhirLib.EngineTypes.semv = _2;
+                MenhirLib.EngineTypes.startp = _startpos__2_;
+                MenhirLib.EngineTypes.endp = _endpos__2_;
+                MenhirLib.EngineTypes.next = {
+                  MenhirLib.EngineTypes.state = _menhir_s;
+                  MenhirLib.EngineTypes.semv = _1;
+                  MenhirLib.EngineTypes.startp = _startpos__1_;
+                  MenhirLib.EngineTypes.endp = _endpos__1_;
+                  MenhirLib.EngineTypes.next = _menhir_stack;
+                };
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _5 : unit = Obj.magic _5 in
+        let _4 : (Parsetree.expression) = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : (Parsetree.expression) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__5_ in
+        let _v : (Parsetree.expression) = let _loc__5_ = (_startpos__5_, _endpos__5_) in
+        let _loc__3_ = (_startpos__3_, _endpos__3_) in
+        
+# 1706 "parsing/parser.mly"
+      ( unclosed "(" _loc__3_ ")" _loc__5_ )
+# 26748 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _5;
+          MenhirLib.EngineTypes.startp = _startpos__5_;
+          MenhirLib.EngineTypes.endp = _endpos__5_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _4;
+            MenhirLib.EngineTypes.startp = _startpos__4_;
+            MenhirLib.EngineTypes.endp = _endpos__4_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.semv = _3;
+              MenhirLib.EngineTypes.startp = _startpos__3_;
+              MenhirLib.EngineTypes.endp = _endpos__3_;
+              MenhirLib.EngineTypes.next = {
+                MenhirLib.EngineTypes.semv = _2;
+                MenhirLib.EngineTypes.startp = _startpos__2_;
+                MenhirLib.EngineTypes.endp = _endpos__2_;
+                MenhirLib.EngineTypes.next = {
+                  MenhirLib.EngineTypes.state = _menhir_s;
+                  MenhirLib.EngineTypes.semv = _1;
+                  MenhirLib.EngineTypes.startp = _startpos__1_;
+                  MenhirLib.EngineTypes.endp = _endpos__1_;
+                  MenhirLib.EngineTypes.next = _menhir_stack;
+                };
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _5 : unit = Obj.magic _5 in
+        let _4 : (Parsetree.expression) = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : (Parsetree.expression) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__5_ in
+        let _v : (Parsetree.expression) = let _endpos = _endpos__5_ in
+        let _symbolstartpos = _startpos__1_ in
+        let _sloc = (_symbolstartpos, _endpos) in
+        
+# 1708 "parsing/parser.mly"
+      ( string_get ~loc:_sloc _1 _4 )
+# 26800 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _5;
+          MenhirLib.EngineTypes.startp = _startpos__5_;
+          MenhirLib.EngineTypes.endp = _endpos__5_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _4;
+            MenhirLib.EngineTypes.startp = _startpos__4_;
+            MenhirLib.EngineTypes.endp = _endpos__4_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.semv = _3;
+              MenhirLib.EngineTypes.startp = _startpos__3_;
+              MenhirLib.EngineTypes.endp = _endpos__3_;
+              MenhirLib.EngineTypes.next = {
+                MenhirLib.EngineTypes.semv = _2;
+                MenhirLib.EngineTypes.startp = _startpos__2_;
+                MenhirLib.EngineTypes.endp = _endpos__2_;
+                MenhirLib.EngineTypes.next = {
+                  MenhirLib.EngineTypes.state = _menhir_s;
+                  MenhirLib.EngineTypes.semv = _1;
+                  MenhirLib.EngineTypes.startp = _startpos__1_;
+                  MenhirLib.EngineTypes.endp = _endpos__1_;
+                  MenhirLib.EngineTypes.next = _menhir_stack;
+                };
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _5 : unit = Obj.magic _5 in
+        let _4 : (Parsetree.expression) = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : (Parsetree.expression) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__5_ in
+        let _v : (Parsetree.expression) = let _loc__5_ = (_startpos__5_, _endpos__5_) in
+        let _loc__3_ = (_startpos__3_, _endpos__3_) in
+        
+# 1710 "parsing/parser.mly"
+      ( unclosed "[" _loc__3_ "]" _loc__5_ )
+# 26851 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _5;
+          MenhirLib.EngineTypes.startp = _startpos__5_;
+          MenhirLib.EngineTypes.endp = _endpos__5_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _4;
+            MenhirLib.EngineTypes.startp = _startpos__4_;
+            MenhirLib.EngineTypes.endp = _endpos__4_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.semv = _3;
+              MenhirLib.EngineTypes.startp = _startpos__3_;
+              MenhirLib.EngineTypes.endp = _endpos__3_;
+              MenhirLib.EngineTypes.next = {
+                MenhirLib.EngineTypes.semv = _2;
+                MenhirLib.EngineTypes.startp = _startpos__2_;
+                MenhirLib.EngineTypes.endp = _endpos__2_;
+                MenhirLib.EngineTypes.next = {
+                  MenhirLib.EngineTypes.state = _menhir_s;
+                  MenhirLib.EngineTypes.semv = _1;
+                  MenhirLib.EngineTypes.startp = _startpos__1_;
+                  MenhirLib.EngineTypes.endp = _endpos__1_;
+                  MenhirLib.EngineTypes.next = _menhir_stack;
+                };
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _5 : unit = Obj.magic _5 in
+        let _4 : (Parsetree.expression) = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : (
+# 561 "parsing/parser.mly"
+       (string)
+# 26895 "parsing/parser.ml"
+        ) = Obj.magic _2 in
+        let _1 : (Parsetree.expression) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__5_ in
+        let _v : (Parsetree.expression) = let _endpos = _endpos__5_ in
+        let _symbolstartpos = _startpos__1_ in
+        let _sloc = (_symbolstartpos, _endpos) in
+        
+# 1712 "parsing/parser.mly"
+      ( dotop_get ~loc:_sloc (Lident ("." ^ _2 ^ "[]")) _1 _4 )
+# 26907 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _5;
+          MenhirLib.EngineTypes.startp = _startpos__5_;
+          MenhirLib.EngineTypes.endp = _endpos__5_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _4;
+            MenhirLib.EngineTypes.startp = _startpos__4_;
+            MenhirLib.EngineTypes.endp = _endpos__4_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.semv = _3;
+              MenhirLib.EngineTypes.startp = _startpos__3_;
+              MenhirLib.EngineTypes.endp = _endpos__3_;
+              MenhirLib.EngineTypes.next = {
+                MenhirLib.EngineTypes.semv = _2;
+                MenhirLib.EngineTypes.startp = _startpos__2_;
+                MenhirLib.EngineTypes.endp = _endpos__2_;
+                MenhirLib.EngineTypes.next = {
+                  MenhirLib.EngineTypes.state = _menhir_s;
+                  MenhirLib.EngineTypes.semv = _1;
+                  MenhirLib.EngineTypes.startp = _startpos__1_;
+                  MenhirLib.EngineTypes.endp = _endpos__1_;
+                  MenhirLib.EngineTypes.next = _menhir_stack;
+                };
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _5 : unit = Obj.magic _5 in
+        let _4 : (Parsetree.expression) = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : (
+# 561 "parsing/parser.mly"
+       (string)
+# 26951 "parsing/parser.ml"
+        ) = Obj.magic _2 in
+        let _1 : (Parsetree.expression) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__5_ in
+        let _v : (Parsetree.expression) = let _loc__5_ = (_startpos__5_, _endpos__5_) in
+        let _loc__3_ = (_startpos__3_, _endpos__3_) in
         
 # 1714 "parsing/parser.mly"
-      ( array_get ~loc:_sloc _1 _4 )
-# 27347 "parsing/parser.ml"
+      ( unclosed "[" _loc__3_ "]" _loc__5_ )
+# 26962 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -27384,17 +26999,22 @@ module Tables = struct
         let _5 : unit = Obj.magic _5 in
         let _4 : (Parsetree.expression) = Obj.magic _4 in
         let _3 : unit = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
+        let _2 : (
+# 561 "parsing/parser.mly"
+       (string)
+# 27006 "parsing/parser.ml"
+        ) = Obj.magic _2 in
         let _1 : (Parsetree.expression) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
-        let _v : (Parsetree.expression) = let _loc__5_ = (_startpos__5_, _endpos__5_) in
-        let _loc__3_ = (_startpos__3_, _endpos__3_) in
+        let _v : (Parsetree.expression) = let _endpos = _endpos__5_ in
+        let _symbolstartpos = _startpos__1_ in
+        let _sloc = (_symbolstartpos, _endpos) in
         
 # 1716 "parsing/parser.mly"
-      ( unclosed "(" _loc__3_ ")" _loc__5_ )
-# 27398 "parsing/parser.ml"
+      ( dotop_get ~loc:_sloc (Lident ("." ^ _2 ^ "()")) _1 _4  )
+# 27018 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -27435,18 +27055,21 @@ module Tables = struct
         let _5 : unit = Obj.magic _5 in
         let _4 : (Parsetree.expression) = Obj.magic _4 in
         let _3 : unit = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
+        let _2 : (
+# 561 "parsing/parser.mly"
+       (string)
+# 27062 "parsing/parser.ml"
+        ) = Obj.magic _2 in
         let _1 : (Parsetree.expression) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
-        let _v : (Parsetree.expression) = let _endpos = _endpos__5_ in
-        let _symbolstartpos = _startpos__1_ in
-        let _sloc = (_symbolstartpos, _endpos) in
+        let _v : (Parsetree.expression) = let _loc__5_ = (_startpos__5_, _endpos__5_) in
+        let _loc__3_ = (_startpos__3_, _endpos__3_) in
         
 # 1718 "parsing/parser.mly"
-      ( string_get ~loc:_sloc _1 _4 )
-# 27450 "parsing/parser.ml"
+      ( unclosed "(" _loc__3_ ")" _loc__5_ )
+# 27073 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -27487,17 +27110,22 @@ module Tables = struct
         let _5 : unit = Obj.magic _5 in
         let _4 : (Parsetree.expression) = Obj.magic _4 in
         let _3 : unit = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
+        let _2 : (
+# 561 "parsing/parser.mly"
+       (string)
+# 27117 "parsing/parser.ml"
+        ) = Obj.magic _2 in
         let _1 : (Parsetree.expression) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
-        let _v : (Parsetree.expression) = let _loc__5_ = (_startpos__5_, _endpos__5_) in
-        let _loc__3_ = (_startpos__3_, _endpos__3_) in
+        let _v : (Parsetree.expression) = let _endpos = _endpos__5_ in
+        let _symbolstartpos = _startpos__1_ in
+        let _sloc = (_symbolstartpos, _endpos) in
         
 # 1720 "parsing/parser.mly"
-      ( unclosed "[" _loc__3_ "]" _loc__5_ )
-# 27501 "parsing/parser.ml"
+      ( dotop_get ~loc:_sloc (Lident ("." ^ _2 ^ "{}")) _1 _4 )
+# 27129 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -27541,296 +27169,18 @@ module Tables = struct
         let _2 : (
 # 561 "parsing/parser.mly"
        (string)
-# 27545 "parsing/parser.ml"
+# 27173 "parsing/parser.ml"
         ) = Obj.magic _2 in
         let _1 : (Parsetree.expression) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
-        let _v : (Parsetree.expression) = let _endpos = _endpos__5_ in
-        let _symbolstartpos = _startpos__1_ in
-        let _sloc = (_symbolstartpos, _endpos) in
+        let _v : (Parsetree.expression) = let _loc__5_ = (_startpos__5_, _endpos__5_) in
+        let _loc__3_ = (_startpos__3_, _endpos__3_) in
         
 # 1722 "parsing/parser.mly"
-      ( dotop_get ~loc:_sloc (Lident ("." ^ _2 ^ "[]")) _1 _4 )
-# 27557 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _5;
-          MenhirLib.EngineTypes.startp = _startpos__5_;
-          MenhirLib.EngineTypes.endp = _endpos__5_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _4;
-            MenhirLib.EngineTypes.startp = _startpos__4_;
-            MenhirLib.EngineTypes.endp = _endpos__4_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _3;
-              MenhirLib.EngineTypes.startp = _startpos__3_;
-              MenhirLib.EngineTypes.endp = _endpos__3_;
-              MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _2;
-                MenhirLib.EngineTypes.startp = _startpos__2_;
-                MenhirLib.EngineTypes.endp = _endpos__2_;
-                MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.state = _menhir_s;
-                  MenhirLib.EngineTypes.semv = _1;
-                  MenhirLib.EngineTypes.startp = _startpos__1_;
-                  MenhirLib.EngineTypes.endp = _endpos__1_;
-                  MenhirLib.EngineTypes.next = _menhir_stack;
-                };
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _5 : unit = Obj.magic _5 in
-        let _4 : (Parsetree.expression) = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
-        let _2 : (
-# 561 "parsing/parser.mly"
-       (string)
-# 27601 "parsing/parser.ml"
-        ) = Obj.magic _2 in
-        let _1 : (Parsetree.expression) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__5_ in
-        let _v : (Parsetree.expression) = let _loc__5_ = (_startpos__5_, _endpos__5_) in
-        let _loc__3_ = (_startpos__3_, _endpos__3_) in
-        
-# 1724 "parsing/parser.mly"
-      ( unclosed "[" _loc__3_ "]" _loc__5_ )
-# 27612 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _5;
-          MenhirLib.EngineTypes.startp = _startpos__5_;
-          MenhirLib.EngineTypes.endp = _endpos__5_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _4;
-            MenhirLib.EngineTypes.startp = _startpos__4_;
-            MenhirLib.EngineTypes.endp = _endpos__4_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _3;
-              MenhirLib.EngineTypes.startp = _startpos__3_;
-              MenhirLib.EngineTypes.endp = _endpos__3_;
-              MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _2;
-                MenhirLib.EngineTypes.startp = _startpos__2_;
-                MenhirLib.EngineTypes.endp = _endpos__2_;
-                MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.state = _menhir_s;
-                  MenhirLib.EngineTypes.semv = _1;
-                  MenhirLib.EngineTypes.startp = _startpos__1_;
-                  MenhirLib.EngineTypes.endp = _endpos__1_;
-                  MenhirLib.EngineTypes.next = _menhir_stack;
-                };
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _5 : unit = Obj.magic _5 in
-        let _4 : (Parsetree.expression) = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
-        let _2 : (
-# 561 "parsing/parser.mly"
-       (string)
-# 27656 "parsing/parser.ml"
-        ) = Obj.magic _2 in
-        let _1 : (Parsetree.expression) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__5_ in
-        let _v : (Parsetree.expression) = let _endpos = _endpos__5_ in
-        let _symbolstartpos = _startpos__1_ in
-        let _sloc = (_symbolstartpos, _endpos) in
-        
-# 1726 "parsing/parser.mly"
-      ( dotop_get ~loc:_sloc (Lident ("." ^ _2 ^ "()")) _1 _4  )
-# 27668 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _5;
-          MenhirLib.EngineTypes.startp = _startpos__5_;
-          MenhirLib.EngineTypes.endp = _endpos__5_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _4;
-            MenhirLib.EngineTypes.startp = _startpos__4_;
-            MenhirLib.EngineTypes.endp = _endpos__4_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _3;
-              MenhirLib.EngineTypes.startp = _startpos__3_;
-              MenhirLib.EngineTypes.endp = _endpos__3_;
-              MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _2;
-                MenhirLib.EngineTypes.startp = _startpos__2_;
-                MenhirLib.EngineTypes.endp = _endpos__2_;
-                MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.state = _menhir_s;
-                  MenhirLib.EngineTypes.semv = _1;
-                  MenhirLib.EngineTypes.startp = _startpos__1_;
-                  MenhirLib.EngineTypes.endp = _endpos__1_;
-                  MenhirLib.EngineTypes.next = _menhir_stack;
-                };
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _5 : unit = Obj.magic _5 in
-        let _4 : (Parsetree.expression) = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
-        let _2 : (
-# 561 "parsing/parser.mly"
-       (string)
-# 27712 "parsing/parser.ml"
-        ) = Obj.magic _2 in
-        let _1 : (Parsetree.expression) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__5_ in
-        let _v : (Parsetree.expression) = let _loc__5_ = (_startpos__5_, _endpos__5_) in
-        let _loc__3_ = (_startpos__3_, _endpos__3_) in
-        
-# 1728 "parsing/parser.mly"
-      ( unclosed "(" _loc__3_ ")" _loc__5_ )
-# 27723 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _5;
-          MenhirLib.EngineTypes.startp = _startpos__5_;
-          MenhirLib.EngineTypes.endp = _endpos__5_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _4;
-            MenhirLib.EngineTypes.startp = _startpos__4_;
-            MenhirLib.EngineTypes.endp = _endpos__4_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _3;
-              MenhirLib.EngineTypes.startp = _startpos__3_;
-              MenhirLib.EngineTypes.endp = _endpos__3_;
-              MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _2;
-                MenhirLib.EngineTypes.startp = _startpos__2_;
-                MenhirLib.EngineTypes.endp = _endpos__2_;
-                MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.state = _menhir_s;
-                  MenhirLib.EngineTypes.semv = _1;
-                  MenhirLib.EngineTypes.startp = _startpos__1_;
-                  MenhirLib.EngineTypes.endp = _endpos__1_;
-                  MenhirLib.EngineTypes.next = _menhir_stack;
-                };
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _5 : unit = Obj.magic _5 in
-        let _4 : (Parsetree.expression) = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
-        let _2 : (
-# 561 "parsing/parser.mly"
-       (string)
-# 27767 "parsing/parser.ml"
-        ) = Obj.magic _2 in
-        let _1 : (Parsetree.expression) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__5_ in
-        let _v : (Parsetree.expression) = let _endpos = _endpos__5_ in
-        let _symbolstartpos = _startpos__1_ in
-        let _sloc = (_symbolstartpos, _endpos) in
-        
-# 1730 "parsing/parser.mly"
-      ( dotop_get ~loc:_sloc (Lident ("." ^ _2 ^ "{}")) _1 _4 )
-# 27779 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _5;
-          MenhirLib.EngineTypes.startp = _startpos__5_;
-          MenhirLib.EngineTypes.endp = _endpos__5_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _4;
-            MenhirLib.EngineTypes.startp = _startpos__4_;
-            MenhirLib.EngineTypes.endp = _endpos__4_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _3;
-              MenhirLib.EngineTypes.startp = _startpos__3_;
-              MenhirLib.EngineTypes.endp = _endpos__3_;
-              MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _2;
-                MenhirLib.EngineTypes.startp = _startpos__2_;
-                MenhirLib.EngineTypes.endp = _endpos__2_;
-                MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.state = _menhir_s;
-                  MenhirLib.EngineTypes.semv = _1;
-                  MenhirLib.EngineTypes.startp = _startpos__1_;
-                  MenhirLib.EngineTypes.endp = _endpos__1_;
-                  MenhirLib.EngineTypes.next = _menhir_stack;
-                };
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _5 : unit = Obj.magic _5 in
-        let _4 : (Parsetree.expression) = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
-        let _2 : (
-# 561 "parsing/parser.mly"
-       (string)
-# 27823 "parsing/parser.ml"
-        ) = Obj.magic _2 in
-        let _1 : (Parsetree.expression) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__5_ in
-        let _v : (Parsetree.expression) = let _loc__5_ = (_startpos__5_, _endpos__5_) in
-        let _loc__3_ = (_startpos__3_, _endpos__3_) in
-        
-# 1732 "parsing/parser.mly"
       ( unclosed "{" _loc__3_ "}" _loc__5_ )
-# 27834 "parsing/parser.ml"
+# 27184 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -27884,7 +27234,277 @@ module Tables = struct
         let _4 : (
 # 561 "parsing/parser.mly"
        (string)
-# 27888 "parsing/parser.ml"
+# 27238 "parsing/parser.ml"
+        ) = Obj.magic _4 in
+        let _3 : (Longident.t) = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : (Parsetree.expression) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__7_ in
+        let _v : (Parsetree.expression) = let _endpos = _endpos__7_ in
+        let _symbolstartpos = _startpos__1_ in
+        let _sloc = (_symbolstartpos, _endpos) in
+        
+# 1724 "parsing/parser.mly"
+      ( dotop_get ~loc:_sloc (Ldot(_3, "." ^ _4 ^ "[]")) _1 _6  )
+# 27252 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _7;
+          MenhirLib.EngineTypes.startp = _startpos__7_;
+          MenhirLib.EngineTypes.endp = _endpos__7_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _6;
+            MenhirLib.EngineTypes.startp = _startpos__6_;
+            MenhirLib.EngineTypes.endp = _endpos__6_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.semv = _5;
+              MenhirLib.EngineTypes.startp = _startpos__5_;
+              MenhirLib.EngineTypes.endp = _endpos__5_;
+              MenhirLib.EngineTypes.next = {
+                MenhirLib.EngineTypes.semv = _4;
+                MenhirLib.EngineTypes.startp = _startpos__4_;
+                MenhirLib.EngineTypes.endp = _endpos__4_;
+                MenhirLib.EngineTypes.next = {
+                  MenhirLib.EngineTypes.semv = _3;
+                  MenhirLib.EngineTypes.startp = _startpos__3_;
+                  MenhirLib.EngineTypes.endp = _endpos__3_;
+                  MenhirLib.EngineTypes.next = {
+                    MenhirLib.EngineTypes.semv = _2;
+                    MenhirLib.EngineTypes.startp = _startpos__2_;
+                    MenhirLib.EngineTypes.endp = _endpos__2_;
+                    MenhirLib.EngineTypes.next = {
+                      MenhirLib.EngineTypes.state = _menhir_s;
+                      MenhirLib.EngineTypes.semv = _1;
+                      MenhirLib.EngineTypes.startp = _startpos__1_;
+                      MenhirLib.EngineTypes.endp = _endpos__1_;
+                      MenhirLib.EngineTypes.next = _menhir_stack;
+                    };
+                  };
+                };
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _7 : unit = Obj.magic _7 in
+        let _6 : (Parsetree.expression) = Obj.magic _6 in
+        let _5 : unit = Obj.magic _5 in
+        let _4 : (
+# 561 "parsing/parser.mly"
+       (string)
+# 27306 "parsing/parser.ml"
+        ) = Obj.magic _4 in
+        let _3 : (Longident.t) = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : (Parsetree.expression) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__7_ in
+        let _v : (Parsetree.expression) = let _loc__7_ = (_startpos__7_, _endpos__7_) in
+        let _loc__5_ = (_startpos__5_, _endpos__5_) in
+        
+# 1727 "parsing/parser.mly"
+      ( unclosed "[" _loc__5_ "]" _loc__7_ )
+# 27319 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _7;
+          MenhirLib.EngineTypes.startp = _startpos__7_;
+          MenhirLib.EngineTypes.endp = _endpos__7_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _6;
+            MenhirLib.EngineTypes.startp = _startpos__6_;
+            MenhirLib.EngineTypes.endp = _endpos__6_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.semv = _5;
+              MenhirLib.EngineTypes.startp = _startpos__5_;
+              MenhirLib.EngineTypes.endp = _endpos__5_;
+              MenhirLib.EngineTypes.next = {
+                MenhirLib.EngineTypes.semv = _4;
+                MenhirLib.EngineTypes.startp = _startpos__4_;
+                MenhirLib.EngineTypes.endp = _endpos__4_;
+                MenhirLib.EngineTypes.next = {
+                  MenhirLib.EngineTypes.semv = _3;
+                  MenhirLib.EngineTypes.startp = _startpos__3_;
+                  MenhirLib.EngineTypes.endp = _endpos__3_;
+                  MenhirLib.EngineTypes.next = {
+                    MenhirLib.EngineTypes.semv = _2;
+                    MenhirLib.EngineTypes.startp = _startpos__2_;
+                    MenhirLib.EngineTypes.endp = _endpos__2_;
+                    MenhirLib.EngineTypes.next = {
+                      MenhirLib.EngineTypes.state = _menhir_s;
+                      MenhirLib.EngineTypes.semv = _1;
+                      MenhirLib.EngineTypes.startp = _startpos__1_;
+                      MenhirLib.EngineTypes.endp = _endpos__1_;
+                      MenhirLib.EngineTypes.next = _menhir_stack;
+                    };
+                  };
+                };
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _7 : unit = Obj.magic _7 in
+        let _6 : (Parsetree.expression) = Obj.magic _6 in
+        let _5 : unit = Obj.magic _5 in
+        let _4 : (
+# 561 "parsing/parser.mly"
+       (string)
+# 27373 "parsing/parser.ml"
+        ) = Obj.magic _4 in
+        let _3 : (Longident.t) = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : (Parsetree.expression) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__7_ in
+        let _v : (Parsetree.expression) = let _endpos = _endpos__7_ in
+        let _symbolstartpos = _startpos__1_ in
+        let _sloc = (_symbolstartpos, _endpos) in
+        
+# 1729 "parsing/parser.mly"
+      ( dotop_get ~loc:_sloc (Ldot(_3, "." ^ _4 ^ "()")) _1 _6 )
+# 27387 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _7;
+          MenhirLib.EngineTypes.startp = _startpos__7_;
+          MenhirLib.EngineTypes.endp = _endpos__7_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _6;
+            MenhirLib.EngineTypes.startp = _startpos__6_;
+            MenhirLib.EngineTypes.endp = _endpos__6_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.semv = _5;
+              MenhirLib.EngineTypes.startp = _startpos__5_;
+              MenhirLib.EngineTypes.endp = _endpos__5_;
+              MenhirLib.EngineTypes.next = {
+                MenhirLib.EngineTypes.semv = _4;
+                MenhirLib.EngineTypes.startp = _startpos__4_;
+                MenhirLib.EngineTypes.endp = _endpos__4_;
+                MenhirLib.EngineTypes.next = {
+                  MenhirLib.EngineTypes.semv = _3;
+                  MenhirLib.EngineTypes.startp = _startpos__3_;
+                  MenhirLib.EngineTypes.endp = _endpos__3_;
+                  MenhirLib.EngineTypes.next = {
+                    MenhirLib.EngineTypes.semv = _2;
+                    MenhirLib.EngineTypes.startp = _startpos__2_;
+                    MenhirLib.EngineTypes.endp = _endpos__2_;
+                    MenhirLib.EngineTypes.next = {
+                      MenhirLib.EngineTypes.state = _menhir_s;
+                      MenhirLib.EngineTypes.semv = _1;
+                      MenhirLib.EngineTypes.startp = _startpos__1_;
+                      MenhirLib.EngineTypes.endp = _endpos__1_;
+                      MenhirLib.EngineTypes.next = _menhir_stack;
+                    };
+                  };
+                };
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _7 : unit = Obj.magic _7 in
+        let _6 : (Parsetree.expression) = Obj.magic _6 in
+        let _5 : unit = Obj.magic _5 in
+        let _4 : (
+# 561 "parsing/parser.mly"
+       (string)
+# 27441 "parsing/parser.ml"
+        ) = Obj.magic _4 in
+        let _3 : (Longident.t) = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : (Parsetree.expression) = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__7_ in
+        let _v : (Parsetree.expression) = let _loc__7_ = (_startpos__7_, _endpos__7_) in
+        let _loc__5_ = (_startpos__5_, _endpos__5_) in
+        
+# 1732 "parsing/parser.mly"
+      ( unclosed "(" _loc__5_ ")" _loc__7_ )
+# 27454 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.semv = _7;
+          MenhirLib.EngineTypes.startp = _startpos__7_;
+          MenhirLib.EngineTypes.endp = _endpos__7_;
+          MenhirLib.EngineTypes.next = {
+            MenhirLib.EngineTypes.semv = _6;
+            MenhirLib.EngineTypes.startp = _startpos__6_;
+            MenhirLib.EngineTypes.endp = _endpos__6_;
+            MenhirLib.EngineTypes.next = {
+              MenhirLib.EngineTypes.semv = _5;
+              MenhirLib.EngineTypes.startp = _startpos__5_;
+              MenhirLib.EngineTypes.endp = _endpos__5_;
+              MenhirLib.EngineTypes.next = {
+                MenhirLib.EngineTypes.semv = _4;
+                MenhirLib.EngineTypes.startp = _startpos__4_;
+                MenhirLib.EngineTypes.endp = _endpos__4_;
+                MenhirLib.EngineTypes.next = {
+                  MenhirLib.EngineTypes.semv = _3;
+                  MenhirLib.EngineTypes.startp = _startpos__3_;
+                  MenhirLib.EngineTypes.endp = _endpos__3_;
+                  MenhirLib.EngineTypes.next = {
+                    MenhirLib.EngineTypes.semv = _2;
+                    MenhirLib.EngineTypes.startp = _startpos__2_;
+                    MenhirLib.EngineTypes.endp = _endpos__2_;
+                    MenhirLib.EngineTypes.next = {
+                      MenhirLib.EngineTypes.state = _menhir_s;
+                      MenhirLib.EngineTypes.semv = _1;
+                      MenhirLib.EngineTypes.startp = _startpos__1_;
+                      MenhirLib.EngineTypes.endp = _endpos__1_;
+                      MenhirLib.EngineTypes.next = _menhir_stack;
+                    };
+                  };
+                };
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _7 : unit = Obj.magic _7 in
+        let _6 : (Parsetree.expression) = Obj.magic _6 in
+        let _5 : unit = Obj.magic _5 in
+        let _4 : (
+# 561 "parsing/parser.mly"
+       (string)
+# 27508 "parsing/parser.ml"
         ) = Obj.magic _4 in
         let _3 : (Longident.t) = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
@@ -27897,8 +27517,8 @@ module Tables = struct
         let _sloc = (_symbolstartpos, _endpos) in
         
 # 1734 "parsing/parser.mly"
-      ( dotop_get ~loc:_sloc (Ldot(_3, "." ^ _4 ^ "[]")) _1 _6  )
-# 27902 "parsing/parser.ml"
+      ( dotop_get ~loc:_sloc (Ldot(_3, "." ^ _4 ^ "{}")) _1 _6  )
+# 27522 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -27952,7 +27572,7 @@ module Tables = struct
         let _4 : (
 # 561 "parsing/parser.mly"
        (string)
-# 27956 "parsing/parser.ml"
+# 27576 "parsing/parser.ml"
         ) = Obj.magic _4 in
         let _3 : (Longident.t) = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
@@ -27964,278 +27584,8 @@ module Tables = struct
         let _loc__5_ = (_startpos__5_, _endpos__5_) in
         
 # 1737 "parsing/parser.mly"
-      ( unclosed "[" _loc__5_ "]" _loc__7_ )
-# 27969 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _7;
-          MenhirLib.EngineTypes.startp = _startpos__7_;
-          MenhirLib.EngineTypes.endp = _endpos__7_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _6;
-            MenhirLib.EngineTypes.startp = _startpos__6_;
-            MenhirLib.EngineTypes.endp = _endpos__6_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _5;
-              MenhirLib.EngineTypes.startp = _startpos__5_;
-              MenhirLib.EngineTypes.endp = _endpos__5_;
-              MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _4;
-                MenhirLib.EngineTypes.startp = _startpos__4_;
-                MenhirLib.EngineTypes.endp = _endpos__4_;
-                MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.semv = _3;
-                  MenhirLib.EngineTypes.startp = _startpos__3_;
-                  MenhirLib.EngineTypes.endp = _endpos__3_;
-                  MenhirLib.EngineTypes.next = {
-                    MenhirLib.EngineTypes.semv = _2;
-                    MenhirLib.EngineTypes.startp = _startpos__2_;
-                    MenhirLib.EngineTypes.endp = _endpos__2_;
-                    MenhirLib.EngineTypes.next = {
-                      MenhirLib.EngineTypes.state = _menhir_s;
-                      MenhirLib.EngineTypes.semv = _1;
-                      MenhirLib.EngineTypes.startp = _startpos__1_;
-                      MenhirLib.EngineTypes.endp = _endpos__1_;
-                      MenhirLib.EngineTypes.next = _menhir_stack;
-                    };
-                  };
-                };
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _7 : unit = Obj.magic _7 in
-        let _6 : (Parsetree.expression) = Obj.magic _6 in
-        let _5 : unit = Obj.magic _5 in
-        let _4 : (
-# 561 "parsing/parser.mly"
-       (string)
-# 28023 "parsing/parser.ml"
-        ) = Obj.magic _4 in
-        let _3 : (Longident.t) = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : (Parsetree.expression) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__7_ in
-        let _v : (Parsetree.expression) = let _endpos = _endpos__7_ in
-        let _symbolstartpos = _startpos__1_ in
-        let _sloc = (_symbolstartpos, _endpos) in
-        
-# 1739 "parsing/parser.mly"
-      ( dotop_get ~loc:_sloc (Ldot(_3, "." ^ _4 ^ "()")) _1 _6 )
-# 28037 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _7;
-          MenhirLib.EngineTypes.startp = _startpos__7_;
-          MenhirLib.EngineTypes.endp = _endpos__7_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _6;
-            MenhirLib.EngineTypes.startp = _startpos__6_;
-            MenhirLib.EngineTypes.endp = _endpos__6_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _5;
-              MenhirLib.EngineTypes.startp = _startpos__5_;
-              MenhirLib.EngineTypes.endp = _endpos__5_;
-              MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _4;
-                MenhirLib.EngineTypes.startp = _startpos__4_;
-                MenhirLib.EngineTypes.endp = _endpos__4_;
-                MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.semv = _3;
-                  MenhirLib.EngineTypes.startp = _startpos__3_;
-                  MenhirLib.EngineTypes.endp = _endpos__3_;
-                  MenhirLib.EngineTypes.next = {
-                    MenhirLib.EngineTypes.semv = _2;
-                    MenhirLib.EngineTypes.startp = _startpos__2_;
-                    MenhirLib.EngineTypes.endp = _endpos__2_;
-                    MenhirLib.EngineTypes.next = {
-                      MenhirLib.EngineTypes.state = _menhir_s;
-                      MenhirLib.EngineTypes.semv = _1;
-                      MenhirLib.EngineTypes.startp = _startpos__1_;
-                      MenhirLib.EngineTypes.endp = _endpos__1_;
-                      MenhirLib.EngineTypes.next = _menhir_stack;
-                    };
-                  };
-                };
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _7 : unit = Obj.magic _7 in
-        let _6 : (Parsetree.expression) = Obj.magic _6 in
-        let _5 : unit = Obj.magic _5 in
-        let _4 : (
-# 561 "parsing/parser.mly"
-       (string)
-# 28091 "parsing/parser.ml"
-        ) = Obj.magic _4 in
-        let _3 : (Longident.t) = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : (Parsetree.expression) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__7_ in
-        let _v : (Parsetree.expression) = let _loc__7_ = (_startpos__7_, _endpos__7_) in
-        let _loc__5_ = (_startpos__5_, _endpos__5_) in
-        
-# 1742 "parsing/parser.mly"
-      ( unclosed "(" _loc__5_ ")" _loc__7_ )
-# 28104 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _7;
-          MenhirLib.EngineTypes.startp = _startpos__7_;
-          MenhirLib.EngineTypes.endp = _endpos__7_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _6;
-            MenhirLib.EngineTypes.startp = _startpos__6_;
-            MenhirLib.EngineTypes.endp = _endpos__6_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _5;
-              MenhirLib.EngineTypes.startp = _startpos__5_;
-              MenhirLib.EngineTypes.endp = _endpos__5_;
-              MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _4;
-                MenhirLib.EngineTypes.startp = _startpos__4_;
-                MenhirLib.EngineTypes.endp = _endpos__4_;
-                MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.semv = _3;
-                  MenhirLib.EngineTypes.startp = _startpos__3_;
-                  MenhirLib.EngineTypes.endp = _endpos__3_;
-                  MenhirLib.EngineTypes.next = {
-                    MenhirLib.EngineTypes.semv = _2;
-                    MenhirLib.EngineTypes.startp = _startpos__2_;
-                    MenhirLib.EngineTypes.endp = _endpos__2_;
-                    MenhirLib.EngineTypes.next = {
-                      MenhirLib.EngineTypes.state = _menhir_s;
-                      MenhirLib.EngineTypes.semv = _1;
-                      MenhirLib.EngineTypes.startp = _startpos__1_;
-                      MenhirLib.EngineTypes.endp = _endpos__1_;
-                      MenhirLib.EngineTypes.next = _menhir_stack;
-                    };
-                  };
-                };
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _7 : unit = Obj.magic _7 in
-        let _6 : (Parsetree.expression) = Obj.magic _6 in
-        let _5 : unit = Obj.magic _5 in
-        let _4 : (
-# 561 "parsing/parser.mly"
-       (string)
-# 28158 "parsing/parser.ml"
-        ) = Obj.magic _4 in
-        let _3 : (Longident.t) = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : (Parsetree.expression) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__7_ in
-        let _v : (Parsetree.expression) = let _endpos = _endpos__7_ in
-        let _symbolstartpos = _startpos__1_ in
-        let _sloc = (_symbolstartpos, _endpos) in
-        
-# 1744 "parsing/parser.mly"
-      ( dotop_get ~loc:_sloc (Ldot(_3, "." ^ _4 ^ "{}")) _1 _6  )
-# 28172 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.semv = _7;
-          MenhirLib.EngineTypes.startp = _startpos__7_;
-          MenhirLib.EngineTypes.endp = _endpos__7_;
-          MenhirLib.EngineTypes.next = {
-            MenhirLib.EngineTypes.semv = _6;
-            MenhirLib.EngineTypes.startp = _startpos__6_;
-            MenhirLib.EngineTypes.endp = _endpos__6_;
-            MenhirLib.EngineTypes.next = {
-              MenhirLib.EngineTypes.semv = _5;
-              MenhirLib.EngineTypes.startp = _startpos__5_;
-              MenhirLib.EngineTypes.endp = _endpos__5_;
-              MenhirLib.EngineTypes.next = {
-                MenhirLib.EngineTypes.semv = _4;
-                MenhirLib.EngineTypes.startp = _startpos__4_;
-                MenhirLib.EngineTypes.endp = _endpos__4_;
-                MenhirLib.EngineTypes.next = {
-                  MenhirLib.EngineTypes.semv = _3;
-                  MenhirLib.EngineTypes.startp = _startpos__3_;
-                  MenhirLib.EngineTypes.endp = _endpos__3_;
-                  MenhirLib.EngineTypes.next = {
-                    MenhirLib.EngineTypes.semv = _2;
-                    MenhirLib.EngineTypes.startp = _startpos__2_;
-                    MenhirLib.EngineTypes.endp = _endpos__2_;
-                    MenhirLib.EngineTypes.next = {
-                      MenhirLib.EngineTypes.state = _menhir_s;
-                      MenhirLib.EngineTypes.semv = _1;
-                      MenhirLib.EngineTypes.startp = _startpos__1_;
-                      MenhirLib.EngineTypes.endp = _endpos__1_;
-                      MenhirLib.EngineTypes.next = _menhir_stack;
-                    };
-                  };
-                };
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _7 : unit = Obj.magic _7 in
-        let _6 : (Parsetree.expression) = Obj.magic _6 in
-        let _5 : unit = Obj.magic _5 in
-        let _4 : (
-# 561 "parsing/parser.mly"
-       (string)
-# 28226 "parsing/parser.ml"
-        ) = Obj.magic _4 in
-        let _3 : (Longident.t) = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : (Parsetree.expression) = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__7_ in
-        let _v : (Parsetree.expression) = let _loc__7_ = (_startpos__7_, _endpos__7_) in
-        let _loc__5_ = (_startpos__5_, _endpos__5_) in
-        
-# 1747 "parsing/parser.mly"
       ( unclosed "{" _loc__5_ "}" _loc__7_ )
-# 28239 "parsing/parser.ml"
+# 27589 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -28285,9 +27635,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1749 "parsing/parser.mly"
+# 1739 "parsing/parser.mly"
       ( bigarray_get ~loc:_sloc _1 _4 )
-# 28291 "parsing/parser.ml"
+# 27641 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -28336,9 +27686,9 @@ module Tables = struct
         let _v : (Parsetree.expression) = let _loc__5_ = (_startpos__5_, _endpos__5_) in
         let _loc__3_ = (_startpos__3_, _endpos__3_) in
         
-# 1751 "parsing/parser.mly"
+# 1741 "parsing/parser.mly"
       ( unclosed "{" _loc__3_ "}" _loc__5_ )
-# 28342 "parsing/parser.ml"
+# 27692 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -28384,10 +27734,10 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _10 in
           
-# 1760 "parsing/parser.mly"
+# 1750 "parsing/parser.mly"
       ( let (ext, attrs) = _2 in
         _3.pexp_desc, (ext, attrs @ _3.pexp_attributes) )
-# 28391 "parsing/parser.ml"
+# 27741 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__40_ in
@@ -28396,10 +27746,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1753 "parsing/parser.mly"
+# 1743 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 28403 "parsing/parser.ml"
+# 27753 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -28443,9 +27793,9 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 1763 "parsing/parser.mly"
+# 1753 "parsing/parser.mly"
       ( Pexp_construct (mkloc (Lident "()") (make_loc _sloc), None), _2 )
-# 28449 "parsing/parser.ml"
+# 27799 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__30_ in
@@ -28454,10 +27804,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1753 "parsing/parser.mly"
+# 1743 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 28461 "parsing/parser.ml"
+# 27811 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -28509,9 +27859,9 @@ module Tables = struct
           let _loc__4_ = (_startpos__4_, _endpos__4_) in
           let _loc__1_ = (_startpos__1_, _endpos__1_) in
           
-# 1765 "parsing/parser.mly"
+# 1755 "parsing/parser.mly"
       ( unclosed "begin" _loc__1_ "end" _loc__4_ )
-# 28515 "parsing/parser.ml"
+# 27865 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__40_ in
@@ -28520,10 +27870,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1753 "parsing/parser.mly"
+# 1743 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 28527 "parsing/parser.ml"
+# 27877 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -28568,26 +27918,18 @@ module Tables = struct
             let _startpos__1_ = _startpos__10_ in
             let _1 = _10 in
             let _endpos = _endpos__1_ in
-            let _startpos = _startpos__1_ in
-            let _loc = (_startpos, _endpos) in
+            let _symbolstartpos = _startpos__1_ in
+            let _sloc = (_symbolstartpos, _endpos) in
             
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 28585 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 27927 "parsing/parser.ml"
             
           in
           
-# 1767 "parsing/parser.mly"
+# 1757 "parsing/parser.mly"
       ( Pexp_new(_3), _2 )
-# 28591 "parsing/parser.ml"
+# 27933 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__100_ in
@@ -28596,10 +27938,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1753 "parsing/parser.mly"
+# 1743 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 28603 "parsing/parser.ml"
+# 27945 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -28652,9 +27994,9 @@ module Tables = struct
           let _2 = _20 in
           let _1 = _10 in
           
-# 1769 "parsing/parser.mly"
+# 1759 "parsing/parser.mly"
       ( Pexp_pack _4, _3 )
-# 28658 "parsing/parser.ml"
+# 28000 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__50_ in
@@ -28663,10 +28005,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1753 "parsing/parser.mly"
+# 1743 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 28670 "parsing/parser.ml"
+# 28012 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -28738,9 +28080,9 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 1771 "parsing/parser.mly"
+# 1761 "parsing/parser.mly"
       ( Pexp_constraint (ghexp ~loc:_sloc (Pexp_pack _4), _6), _3 )
-# 28744 "parsing/parser.ml"
+# 28086 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__70_ in
@@ -28749,10 +28091,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1753 "parsing/parser.mly"
+# 1743 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 28756 "parsing/parser.ml"
+# 28098 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -28818,9 +28160,9 @@ module Tables = struct
           let _loc__6_ = (_startpos__6_, _endpos__6_) in
           let _loc__1_ = (_startpos__1_, _endpos__1_) in
           
-# 1773 "parsing/parser.mly"
+# 1763 "parsing/parser.mly"
       ( unclosed "(" _loc__1_ ")" _loc__6_ )
-# 28824 "parsing/parser.ml"
+# 28166 "parsing/parser.ml"
           
         in
         let _endpos__1_ = _endpos__60_ in
@@ -28829,10 +28171,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1753 "parsing/parser.mly"
+# 1743 "parsing/parser.mly"
     ( let desc, attrs = _1 in
       mkexp_attrs ~loc:_sloc desc attrs )
-# 28836 "parsing/parser.ml"
+# 28178 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -28867,26 +28209,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 28884 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 28218 "parsing/parser.ml"
               
             in
             
-# 1777 "parsing/parser.mly"
+# 1767 "parsing/parser.mly"
       ( Pexp_ident (_1) )
-# 28890 "parsing/parser.ml"
+# 28224 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -28895,15 +28229,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 28901 "parsing/parser.ml"
+# 28235 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 28907 "parsing/parser.ml"
+# 28241 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -28932,9 +28266,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 1779 "parsing/parser.mly"
+# 1769 "parsing/parser.mly"
       ( Pexp_constant _1 )
-# 28938 "parsing/parser.ml"
+# 28272 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -28943,15 +28277,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 28949 "parsing/parser.ml"
+# 28283 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 28955 "parsing/parser.ml"
+# 28289 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -28986,26 +28320,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 29003 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 28329 "parsing/parser.ml"
               
             in
             
-# 1781 "parsing/parser.mly"
+# 1771 "parsing/parser.mly"
       ( Pexp_construct(_1, None) )
-# 29009 "parsing/parser.ml"
+# 28335 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -29014,15 +28340,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 29020 "parsing/parser.ml"
+# 28346 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 29026 "parsing/parser.ml"
+# 28352 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -29051,9 +28377,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 1783 "parsing/parser.mly"
+# 1773 "parsing/parser.mly"
       ( Pexp_variant(_1, None) )
-# 29057 "parsing/parser.ml"
+# 28383 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -29062,15 +28388,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 29068 "parsing/parser.ml"
+# 28394 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 29074 "parsing/parser.ml"
+# 28400 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -29097,7 +28423,7 @@ module Tables = struct
         let _1000 : (
 # 602 "parsing/parser.mly"
        (string)
-# 29101 "parsing/parser.ml"
+# 28427 "parsing/parser.ml"
         ) = Obj.magic _1000 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1000_ in
@@ -29118,20 +28444,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 29129 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 28453 "parsing/parser.ml"
               
             in
             
-# 1785 "parsing/parser.mly"
+# 1775 "parsing/parser.mly"
       ( Pexp_apply(_1, [Nolabel,_2]) )
-# 29135 "parsing/parser.ml"
+# 28459 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -29140,15 +28464,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 29146 "parsing/parser.ml"
+# 28470 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 29152 "parsing/parser.ml"
+# 28476 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -29194,28 +28518,26 @@ module Tables = struct
               let _1 =
                 let _1 = _10 in
                 
-# 1786 "parsing/parser.mly"
+# 1776 "parsing/parser.mly"
             ("!")
-# 29200 "parsing/parser.ml"
+# 28524 "parsing/parser.ml"
                 
               in
               let _endpos__1_ = _endpos__10_ in
               let _startpos__1_ = _startpos__10_ in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 29213 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 28535 "parsing/parser.ml"
               
             in
             
-# 1787 "parsing/parser.mly"
+# 1777 "parsing/parser.mly"
       ( Pexp_apply(_1, [Nolabel,_2]) )
-# 29219 "parsing/parser.ml"
+# 28541 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -29224,15 +28546,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 29230 "parsing/parser.ml"
+# 28552 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 29236 "parsing/parser.ml"
+# 28558 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -29277,9 +28599,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1789 "parsing/parser.mly"
+# 1779 "parsing/parser.mly"
       ( Pexp_override _2 )
-# 29283 "parsing/parser.ml"
+# 28605 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -29288,15 +28610,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 29294 "parsing/parser.ml"
+# 28616 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 29300 "parsing/parser.ml"
+# 28622 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -29349,9 +28671,9 @@ module Tables = struct
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             let _loc__1_ = (_startpos__1_, _endpos__1_) in
             
-# 1791 "parsing/parser.mly"
+# 1781 "parsing/parser.mly"
       ( unclosed "{<" _loc__1_ ">}" _loc__3_ )
-# 29355 "parsing/parser.ml"
+# 28677 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -29360,15 +28682,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 29366 "parsing/parser.ml"
+# 28688 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 29372 "parsing/parser.ml"
+# 28694 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -29405,9 +28727,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1793 "parsing/parser.mly"
+# 1783 "parsing/parser.mly"
       ( Pexp_override [] )
-# 29411 "parsing/parser.ml"
+# 28733 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -29416,15 +28738,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 29422 "parsing/parser.ml"
+# 28744 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 29428 "parsing/parser.ml"
+# 28750 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -29476,26 +28798,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 29493 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 28807 "parsing/parser.ml"
               
             in
             
-# 1795 "parsing/parser.mly"
+# 1785 "parsing/parser.mly"
       ( Pexp_field(_1, _3) )
-# 29499 "parsing/parser.ml"
+# 28813 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -29504,15 +28818,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 29510 "parsing/parser.ml"
+# 28824 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 29516 "parsing/parser.ml"
+# 28830 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -29580,26 +28894,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 29597 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 28903 "parsing/parser.ml"
               
             in
             
-# 1797 "parsing/parser.mly"
+# 1787 "parsing/parser.mly"
       ( Pexp_open(Fresh, _1, _4) )
-# 29603 "parsing/parser.ml"
+# 28909 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -29608,15 +28914,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 29614 "parsing/parser.ml"
+# 28920 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 29620 "parsing/parser.ml"
+# 28926 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -29685,20 +28991,12 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 29702 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 29000 "parsing/parser.ml"
               
             in
             let _startpos__1_ = _startpos__10_ in
@@ -29706,10 +29004,10 @@ module Tables = struct
             let _symbolstartpos = _startpos__1_ in
             let _sloc = (_symbolstartpos, _endpos) in
             
-# 1799 "parsing/parser.mly"
+# 1789 "parsing/parser.mly"
       ( (* TODO: review the location of Pexp_override *)
         Pexp_open(Fresh, _1, mkexp ~loc:_sloc (Pexp_override _4)) )
-# 29713 "parsing/parser.ml"
+# 29011 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -29718,15 +29016,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 29724 "parsing/parser.ml"
+# 29022 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 29730 "parsing/parser.ml"
+# 29028 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -29796,9 +29094,9 @@ module Tables = struct
             let _loc__5_ = (_startpos__5_, _endpos__5_) in
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             
-# 1802 "parsing/parser.mly"
+# 1792 "parsing/parser.mly"
       ( unclosed "{<" _loc__3_ ">}" _loc__5_ )
-# 29802 "parsing/parser.ml"
+# 29100 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -29807,15 +29105,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 29813 "parsing/parser.ml"
+# 29111 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 29819 "parsing/parser.ml"
+# 29117 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -29867,26 +29165,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 29884 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 29174 "parsing/parser.ml"
               
             in
             
-# 1804 "parsing/parser.mly"
+# 1794 "parsing/parser.mly"
       ( Pexp_send(_1, _3) )
-# 29890 "parsing/parser.ml"
+# 29180 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -29895,15 +29185,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 29901 "parsing/parser.ml"
+# 29191 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 29907 "parsing/parser.ml"
+# 29197 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -29935,7 +29225,7 @@ module Tables = struct
         let _1000 : (
 # 613 "parsing/parser.mly"
        (string)
-# 29939 "parsing/parser.ml"
+# 29229 "parsing/parser.ml"
         ) = Obj.magic _1000 in
         let _110 : (Parsetree.expression) = Obj.magic _110 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
@@ -29960,20 +29250,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
-# 740 "parsing/parser.mly"
-   ( (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:_loc _1 )
-# 29971 "parsing/parser.ml"
+# 732 "parsing/parser.mly"
+   ( mkoperator ~loc:_sloc _1 )
+# 29259 "parsing/parser.ml"
               
             in
             
-# 1806 "parsing/parser.mly"
+# 1796 "parsing/parser.mly"
       ( mkinfix _1 _2 _3 )
-# 29977 "parsing/parser.ml"
+# 29265 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -29982,15 +29270,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 29988 "parsing/parser.ml"
+# 29276 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 29994 "parsing/parser.ml"
+# 29282 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -30019,9 +29307,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 1808 "parsing/parser.mly"
+# 1798 "parsing/parser.mly"
       ( Pexp_extension _1 )
-# 30025 "parsing/parser.ml"
+# 29313 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -30030,15 +29318,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 30036 "parsing/parser.ml"
+# 29324 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 30042 "parsing/parser.ml"
+# 29330 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -30105,28 +29393,20 @@ module Tables = struct
                 let _2 = _20 in
                 let _1 = _10 in
                 
-# 1809 "parsing/parser.mly"
+# 1799 "parsing/parser.mly"
                                                  (Lident "()")
-# 30111 "parsing/parser.ml"
+# 29399 "parsing/parser.ml"
                 
               in
               let _endpos__1_ = _endpos__20_ in
               let _startpos__1_ = _startpos__10_ in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 30130 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 29410 "parsing/parser.ml"
               
             in
             let _endpos__3_ = _endpos__200_ in
@@ -30135,20 +29415,12 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 30152 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 29424 "parsing/parser.ml"
               
             in
             let _startpos__1_ = _startpos__10_ in
@@ -30156,10 +29428,10 @@ module Tables = struct
             let _symbolstartpos = _startpos__1_ in
             let _sloc = (_symbolstartpos, _endpos) in
             
-# 1810 "parsing/parser.mly"
+# 1800 "parsing/parser.mly"
       ( (* TODO: review the location of Pexp_construct *)
         Pexp_open(Fresh, _1, mkexp ~loc:_sloc (Pexp_construct(_3, None))) )
-# 30163 "parsing/parser.ml"
+# 29435 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__2000_ in
@@ -30168,15 +29440,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 30174 "parsing/parser.ml"
+# 29446 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 30180 "parsing/parser.ml"
+# 29452 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -30246,9 +29518,9 @@ module Tables = struct
             let _loc__5_ = (_startpos__5_, _endpos__5_) in
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             
-# 1813 "parsing/parser.mly"
+# 1803 "parsing/parser.mly"
       ( unclosed "(" _loc__3_ ")" _loc__5_ )
-# 30252 "parsing/parser.ml"
+# 29524 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -30257,15 +29529,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 30263 "parsing/parser.ml"
+# 29535 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 30269 "parsing/parser.ml"
+# 29541 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -30311,10 +29583,10 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1815 "parsing/parser.mly"
+# 1805 "parsing/parser.mly"
       ( let (exten, fields) = _2 in
         Pexp_record(fields, exten) )
-# 30318 "parsing/parser.ml"
+# 29590 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -30323,15 +29595,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 30329 "parsing/parser.ml"
+# 29601 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 30335 "parsing/parser.ml"
+# 29607 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -30385,9 +29657,9 @@ module Tables = struct
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             let _loc__1_ = (_startpos__1_, _endpos__1_) in
             
-# 1818 "parsing/parser.mly"
+# 1808 "parsing/parser.mly"
       ( unclosed "{" _loc__1_ "}" _loc__3_ )
-# 30391 "parsing/parser.ml"
+# 29663 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -30396,15 +29668,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 30402 "parsing/parser.ml"
+# 29674 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 30408 "parsing/parser.ml"
+# 29680 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -30474,20 +29746,12 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 30491 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 29755 "parsing/parser.ml"
               
             in
             let _startpos__1_ = _startpos__10_ in
@@ -30495,11 +29759,11 @@ module Tables = struct
             let _symbolstartpos = _startpos__1_ in
             let _sloc = (_symbolstartpos, _endpos) in
             
-# 1820 "parsing/parser.mly"
+# 1810 "parsing/parser.mly"
       ( let (exten, fields) = _4 in
         (* TODO: review the location of Pexp_construct *)
         Pexp_open(Fresh, _1, mkexp ~loc:_sloc (Pexp_record(fields, exten))) )
-# 30503 "parsing/parser.ml"
+# 29767 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -30508,15 +29772,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 30514 "parsing/parser.ml"
+# 29778 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 30520 "parsing/parser.ml"
+# 29784 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -30587,9 +29851,9 @@ module Tables = struct
             let _loc__5_ = (_startpos__5_, _endpos__5_) in
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             
-# 1824 "parsing/parser.mly"
+# 1814 "parsing/parser.mly"
       ( unclosed "{" _loc__3_ "}" _loc__5_ )
-# 30593 "parsing/parser.ml"
+# 29857 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -30598,15 +29862,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 30604 "parsing/parser.ml"
+# 29868 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 30610 "parsing/parser.ml"
+# 29874 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -30659,9 +29923,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1826 "parsing/parser.mly"
+# 1816 "parsing/parser.mly"
       ( Pexp_array(List.rev _2) )
-# 30665 "parsing/parser.ml"
+# 29929 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -30670,15 +29934,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 30676 "parsing/parser.ml"
+# 29940 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 30682 "parsing/parser.ml"
+# 29946 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -30739,9 +30003,9 @@ module Tables = struct
             let _loc__4_ = (_startpos__4_, _endpos__4_) in
             let _loc__1_ = (_startpos__1_, _endpos__1_) in
             
-# 1828 "parsing/parser.mly"
+# 1818 "parsing/parser.mly"
       ( unclosed "[|" _loc__1_ "|]" _loc__4_ )
-# 30745 "parsing/parser.ml"
+# 30009 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -30750,15 +30014,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 30756 "parsing/parser.ml"
+# 30020 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 30762 "parsing/parser.ml"
+# 30026 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -30795,9 +30059,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 1830 "parsing/parser.mly"
+# 1820 "parsing/parser.mly"
       ( Pexp_array [] )
-# 30801 "parsing/parser.ml"
+# 30065 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -30806,15 +30070,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 30812 "parsing/parser.ml"
+# 30076 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 30818 "parsing/parser.ml"
+# 30082 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -30891,20 +30155,12 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 30908 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 30164 "parsing/parser.ml"
               
             in
             let _startpos__1_ = _startpos__10_ in
@@ -30912,10 +30168,10 @@ module Tables = struct
             let _symbolstartpos = _startpos__1_ in
             let _sloc = (_symbolstartpos, _endpos) in
             
-# 1832 "parsing/parser.mly"
+# 1822 "parsing/parser.mly"
       ( (* TODO: review the location of Pexp_array *)
         Pexp_open(Fresh, _1, mkexp ~loc:_sloc (Pexp_array(List.rev _4))) )
-# 30919 "parsing/parser.ml"
+# 30175 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__60_ in
@@ -30924,15 +30180,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 30930 "parsing/parser.ml"
+# 30186 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 30936 "parsing/parser.ml"
+# 30192 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -30993,20 +30249,12 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 31010 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 30258 "parsing/parser.ml"
               
             in
             let _startpos__1_ = _startpos__10_ in
@@ -31014,10 +30262,10 @@ module Tables = struct
             let _symbolstartpos = _startpos__1_ in
             let _sloc = (_symbolstartpos, _endpos) in
             
-# 1835 "parsing/parser.mly"
+# 1825 "parsing/parser.mly"
       ( (* TODO: review the location of Pexp_array *)
         Pexp_open(Fresh, _1, mkexp ~loc:_sloc (Pexp_array [])) )
-# 31021 "parsing/parser.ml"
+# 30269 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -31026,15 +30274,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 31032 "parsing/parser.ml"
+# 30280 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 31038 "parsing/parser.ml"
+# 30286 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -31112,9 +30360,9 @@ module Tables = struct
             let _loc__6_ = (_startpos__6_, _endpos__6_) in
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             
-# 1839 "parsing/parser.mly"
+# 1829 "parsing/parser.mly"
       ( unclosed "[|" _loc__3_ "|]" _loc__6_ )
-# 31118 "parsing/parser.ml"
+# 30366 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__60_ in
@@ -31123,15 +30371,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 31129 "parsing/parser.ml"
+# 30377 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 31135 "parsing/parser.ml"
+# 30383 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -31188,9 +30436,9 @@ module Tables = struct
             let _1 = _10 in
             let _loc__4_ = (_startpos__4_, _endpos__4_) in
             
-# 1841 "parsing/parser.mly"
+# 1831 "parsing/parser.mly"
       ( fst (mktailexp _loc__4_ (List.rev _2)) )
-# 31194 "parsing/parser.ml"
+# 30442 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -31199,15 +30447,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 31205 "parsing/parser.ml"
+# 30453 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 31211 "parsing/parser.ml"
+# 30459 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -31268,9 +30516,9 @@ module Tables = struct
             let _loc__4_ = (_startpos__4_, _endpos__4_) in
             let _loc__1_ = (_startpos__1_, _endpos__1_) in
             
-# 1843 "parsing/parser.mly"
+# 1833 "parsing/parser.mly"
       ( unclosed "[" _loc__1_ "]" _loc__4_ )
-# 31274 "parsing/parser.ml"
+# 30522 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -31279,15 +30527,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 31285 "parsing/parser.ml"
+# 30533 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 31291 "parsing/parser.ml"
+# 30539 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -31366,20 +30614,12 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 31383 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 30623 "parsing/parser.ml"
               
             in
             let _startpos__1_ = _startpos__10_ in
@@ -31388,13 +30628,13 @@ module Tables = struct
             let _loc__6_ = (_startpos__6_, _endpos__6_) in
             let _sloc = (_symbolstartpos, _endpos) in
             
-# 1845 "parsing/parser.mly"
+# 1835 "parsing/parser.mly"
       ( let list_exp =
           (* TODO: review the location of list_exp *)
           let tail_exp, _tail_loc = mktailexp _loc__6_ (List.rev _4) in
           mkexp ~loc:_sloc tail_exp in
         Pexp_open(Fresh, _1, list_exp) )
-# 31398 "parsing/parser.ml"
+# 30638 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__60_ in
@@ -31403,15 +30643,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 31409 "parsing/parser.ml"
+# 30649 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 31415 "parsing/parser.ml"
+# 30655 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -31478,28 +30718,20 @@ module Tables = struct
                 let _2 = _20 in
                 let _1 = _10 in
                 
-# 1850 "parsing/parser.mly"
+# 1840 "parsing/parser.mly"
                                                      (Lident "[]")
-# 31484 "parsing/parser.ml"
+# 30724 "parsing/parser.ml"
                 
               in
               let _endpos__1_ = _endpos__20_ in
               let _startpos__1_ = _startpos__10_ in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 31503 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 30735 "parsing/parser.ml"
               
             in
             let _endpos__3_ = _endpos__200_ in
@@ -31508,20 +30740,12 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 31525 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 30749 "parsing/parser.ml"
               
             in
             let _startpos__1_ = _startpos__10_ in
@@ -31529,10 +30753,10 @@ module Tables = struct
             let _symbolstartpos = _startpos__1_ in
             let _sloc = (_symbolstartpos, _endpos) in
             
-# 1851 "parsing/parser.mly"
+# 1841 "parsing/parser.mly"
       ( (* TODO: review the location of Pexp_construct *)
         Pexp_open(Fresh, _1, mkexp ~loc:_sloc (Pexp_construct(_3, None))) )
-# 31536 "parsing/parser.ml"
+# 30760 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__2000_ in
@@ -31541,15 +30765,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 31547 "parsing/parser.ml"
+# 30771 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 31553 "parsing/parser.ml"
+# 30777 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -31627,9 +30851,9 @@ module Tables = struct
             let _loc__6_ = (_startpos__6_, _endpos__6_) in
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             
-# 1855 "parsing/parser.mly"
+# 1845 "parsing/parser.mly"
       ( unclosed "[" _loc__3_ "]" _loc__6_ )
-# 31633 "parsing/parser.ml"
+# 30857 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__60_ in
@@ -31638,15 +30862,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 31644 "parsing/parser.ml"
+# 30868 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 31650 "parsing/parser.ml"
+# 30874 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -31747,20 +30971,12 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 31764 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 30980 "parsing/parser.ml"
               
             in
             let _startpos__1_ = _startpos__10_ in
@@ -31768,13 +30984,13 @@ module Tables = struct
             let _symbolstartpos = _startpos__1_ in
             let _sloc = (_symbolstartpos, _endpos) in
             
-# 1858 "parsing/parser.mly"
+# 1848 "parsing/parser.mly"
       ( (* TODO: review the location of Pexp_constraint *)
         let modexp =
           mkexp_attrs ~loc:_sloc
             (Pexp_constraint (ghexp ~loc:_sloc (Pexp_pack _6), _8)) _5 in
         Pexp_open(Fresh, _1, modexp) )
-# 31778 "parsing/parser.ml"
+# 30994 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__90_ in
@@ -31783,15 +30999,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 31789 "parsing/parser.ml"
+# 31005 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 31795 "parsing/parser.ml"
+# 31011 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -31885,9 +31101,9 @@ module Tables = struct
             let _loc__8_ = (_startpos__8_, _endpos__8_) in
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             
-# 1865 "parsing/parser.mly"
+# 1855 "parsing/parser.mly"
       ( unclosed "(" _loc__3_ ")" _loc__8_ )
-# 31891 "parsing/parser.ml"
+# 31107 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__80_ in
@@ -31896,15 +31112,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 748 "parsing/parser.mly"
+# 738 "parsing/parser.mly"
     ( mkexp ~loc:_sloc _1 )
-# 31902 "parsing/parser.ml"
+# 31118 "parsing/parser.ml"
           
         in
         
-# 1756 "parsing/parser.mly"
+# 1746 "parsing/parser.mly"
       ( _1 )
-# 31908 "parsing/parser.ml"
+# 31124 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -31927,9 +31143,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : ((Asttypes.arg_label * Parsetree.expression) list) = 
-# 1870 "parsing/parser.mly"
+# 1860 "parsing/parser.mly"
       ( [_1] )
-# 31933 "parsing/parser.ml"
+# 31149 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -31958,9 +31174,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : ((Asttypes.arg_label * Parsetree.expression) list) = 
-# 1872 "parsing/parser.mly"
+# 1862 "parsing/parser.mly"
       ( _2 :: _1 )
-# 31964 "parsing/parser.ml"
+# 31180 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -31995,26 +31211,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 32012 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 31220 "parsing/parser.ml"
               
             in
             
-# 2102 "parsing/parser.mly"
+# 2092 "parsing/parser.mly"
       ( Ppat_var (_1) )
-# 32018 "parsing/parser.ml"
+# 31226 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -32023,15 +31231,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 32029 "parsing/parser.ml"
+# 31237 "parsing/parser.ml"
           
         in
         
-# 2103 "parsing/parser.mly"
+# 2093 "parsing/parser.mly"
       ( _1 )
-# 32035 "parsing/parser.ml"
+# 31243 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -32054,9 +31262,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.pattern) = 
-# 2104 "parsing/parser.mly"
+# 2094 "parsing/parser.mly"
                              ( _1 )
-# 32060 "parsing/parser.ml"
+# 31268 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -32094,9 +31302,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2109 "parsing/parser.mly"
+# 2099 "parsing/parser.mly"
       ( reloc_pat ~loc:_sloc _2 )
-# 32100 "parsing/parser.ml"
+# 31308 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -32119,9 +31327,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.pattern) = 
-# 2111 "parsing/parser.mly"
+# 2101 "parsing/parser.mly"
       ( _1 )
-# 32125 "parsing/parser.ml"
+# 31333 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -32163,7 +31371,7 @@ module Tables = struct
         let _10 : (
 # 624 "parsing/parser.mly"
        (string)
-# 32167 "parsing/parser.ml"
+# 31375 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _3 : (string Asttypes.loc option * Parsetree.attributes) = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
@@ -32176,29 +31384,21 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 32193 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 31393 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__5_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2113 "parsing/parser.mly"
+# 2103 "parsing/parser.mly"
       ( mkpat_attrs ~loc:_sloc (Ppat_unpack _4) _3 )
-# 32202 "parsing/parser.ml"
+# 31402 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -32252,7 +31452,7 @@ module Tables = struct
         let _10 : (
 # 624 "parsing/parser.mly"
        (string)
-# 32256 "parsing/parser.ml"
+# 31456 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _3 : (string Asttypes.loc option * Parsetree.attributes) = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
@@ -32265,31 +31465,23 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 32282 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 31474 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__7_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2115 "parsing/parser.mly"
+# 2105 "parsing/parser.mly"
       ( mkpat_attrs ~loc:_sloc
           (Ppat_constraint(mkpat ~loc:_sloc (Ppat_unpack _4), _6))
           _3 )
-# 32293 "parsing/parser.ml"
+# 31485 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -32318,9 +31510,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 2123 "parsing/parser.mly"
+# 2113 "parsing/parser.mly"
       ( Ppat_any )
-# 32324 "parsing/parser.ml"
+# 31516 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -32329,15 +31521,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 32335 "parsing/parser.ml"
+# 31527 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 32341 "parsing/parser.ml"
+# 31533 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -32366,9 +31558,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 2125 "parsing/parser.mly"
+# 2115 "parsing/parser.mly"
       ( Ppat_constant _1 )
-# 32372 "parsing/parser.ml"
+# 31564 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -32377,15 +31569,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 32383 "parsing/parser.ml"
+# 31575 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 32389 "parsing/parser.ml"
+# 31581 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -32430,9 +31622,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 2127 "parsing/parser.mly"
+# 2117 "parsing/parser.mly"
       ( Ppat_interval (_1, _3) )
-# 32436 "parsing/parser.ml"
+# 31628 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -32441,15 +31633,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 32447 "parsing/parser.ml"
+# 31639 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 32453 "parsing/parser.ml"
+# 31645 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -32484,26 +31676,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 32501 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 31685 "parsing/parser.ml"
               
             in
             
-# 2129 "parsing/parser.mly"
+# 2119 "parsing/parser.mly"
       ( Ppat_construct(_1, None) )
-# 32507 "parsing/parser.ml"
+# 31691 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -32512,15 +31696,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 32518 "parsing/parser.ml"
+# 31702 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 32524 "parsing/parser.ml"
+# 31708 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -32549,9 +31733,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 2131 "parsing/parser.mly"
+# 2121 "parsing/parser.mly"
       ( Ppat_variant(_1, None) )
-# 32555 "parsing/parser.ml"
+# 31739 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -32560,15 +31744,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 32566 "parsing/parser.ml"
+# 31750 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 32572 "parsing/parser.ml"
+# 31756 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -32612,26 +31796,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 32629 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 31805 "parsing/parser.ml"
               
             in
             
-# 2133 "parsing/parser.mly"
+# 2123 "parsing/parser.mly"
       ( Ppat_type (_2) )
-# 32635 "parsing/parser.ml"
+# 31811 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__100_ in
@@ -32640,15 +31816,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 32646 "parsing/parser.ml"
+# 31822 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 32652 "parsing/parser.ml"
+# 31828 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -32700,26 +31876,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 32717 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 31885 "parsing/parser.ml"
               
             in
             
-# 2135 "parsing/parser.mly"
+# 2125 "parsing/parser.mly"
       ( Ppat_open(_1, _3) )
-# 32723 "parsing/parser.ml"
+# 31891 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -32728,15 +31896,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 32734 "parsing/parser.ml"
+# 31902 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 32740 "parsing/parser.ml"
+# 31908 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -32803,28 +31971,20 @@ module Tables = struct
                 let _2 = _20 in
                 let _1 = _10 in
                 
-# 2136 "parsing/parser.mly"
+# 2126 "parsing/parser.mly"
                                                      (Lident "[]")
-# 32809 "parsing/parser.ml"
+# 31977 "parsing/parser.ml"
                 
               in
               let _endpos__1_ = _endpos__20_ in
               let _startpos__1_ = _startpos__10_ in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 32828 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 31988 "parsing/parser.ml"
               
             in
             let _endpos__3_ = _endpos__200_ in
@@ -32833,20 +31993,12 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 32850 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 32002 "parsing/parser.ml"
               
             in
             let _startpos__1_ = _startpos__10_ in
@@ -32854,9 +32006,9 @@ module Tables = struct
             let _symbolstartpos = _startpos__1_ in
             let _sloc = (_symbolstartpos, _endpos) in
             
-# 2137 "parsing/parser.mly"
+# 2127 "parsing/parser.mly"
     ( Ppat_open(_1, mkpat ~loc:_sloc (Ppat_construct(_3, None))) )
-# 32860 "parsing/parser.ml"
+# 32012 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__2000_ in
@@ -32865,15 +32017,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 32871 "parsing/parser.ml"
+# 32023 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 32877 "parsing/parser.ml"
+# 32029 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -32940,28 +32092,20 @@ module Tables = struct
                 let _2 = _20 in
                 let _1 = _10 in
                 
-# 2138 "parsing/parser.mly"
+# 2128 "parsing/parser.mly"
                                                  (Lident "()")
-# 32946 "parsing/parser.ml"
+# 32098 "parsing/parser.ml"
                 
               in
               let _endpos__1_ = _endpos__20_ in
               let _startpos__1_ = _startpos__10_ in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 32965 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 32109 "parsing/parser.ml"
               
             in
             let _endpos__3_ = _endpos__200_ in
@@ -32970,20 +32114,12 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 32987 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 32123 "parsing/parser.ml"
               
             in
             let _startpos__1_ = _startpos__10_ in
@@ -32991,9 +32127,9 @@ module Tables = struct
             let _symbolstartpos = _startpos__1_ in
             let _sloc = (_symbolstartpos, _endpos) in
             
-# 2139 "parsing/parser.mly"
+# 2129 "parsing/parser.mly"
     ( Ppat_open(_1, mkpat ~loc:_sloc (Ppat_construct(_3, None))) )
-# 32997 "parsing/parser.ml"
+# 32133 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__2000_ in
@@ -33002,15 +32138,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 33008 "parsing/parser.ml"
+# 32144 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 33014 "parsing/parser.ml"
+# 32150 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33078,26 +32214,18 @@ module Tables = struct
               let _startpos__1_ = _startpos__10_ in
               let _1 = _10 in
               let _endpos = _endpos__1_ in
-              let _startpos = _startpos__1_ in
-              let _loc = (_startpos, _endpos) in
+              let _symbolstartpos = _startpos__1_ in
+              let _sloc = (_symbolstartpos, _endpos) in
               
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 33095 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 32223 "parsing/parser.ml"
               
             in
             
-# 2141 "parsing/parser.mly"
+# 2131 "parsing/parser.mly"
       ( Ppat_open (_1, _4) )
-# 33101 "parsing/parser.ml"
+# 32229 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -33106,15 +32234,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 33112 "parsing/parser.ml"
+# 32240 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 33118 "parsing/parser.ml"
+# 32246 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33184,9 +32312,9 @@ module Tables = struct
             let _loc__5_ = (_startpos__5_, _endpos__5_) in
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             
-# 2143 "parsing/parser.mly"
+# 2133 "parsing/parser.mly"
       ( unclosed "(" _loc__3_ ")" _loc__5_  )
-# 33190 "parsing/parser.ml"
+# 32318 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -33195,15 +32323,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 33201 "parsing/parser.ml"
+# 32329 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 33207 "parsing/parser.ml"
+# 32335 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33260,9 +32388,9 @@ module Tables = struct
             let _1 = _10 in
             let _loc__4_ = (_startpos__4_, _endpos__4_) in
             
-# 2145 "parsing/parser.mly"
+# 2135 "parsing/parser.mly"
       ( expecting _loc__4_ "pattern" )
-# 33266 "parsing/parser.ml"
+# 32394 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -33271,15 +32399,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 33277 "parsing/parser.ml"
+# 32405 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 33283 "parsing/parser.ml"
+# 32411 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33332,9 +32460,9 @@ module Tables = struct
             let _loc__3_ = (_startpos__3_, _endpos__3_) in
             let _loc__1_ = (_startpos__1_, _endpos__1_) in
             
-# 2147 "parsing/parser.mly"
+# 2137 "parsing/parser.mly"
       ( unclosed "(" _loc__1_ ")" _loc__3_ )
-# 33338 "parsing/parser.ml"
+# 32466 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__30_ in
@@ -33343,15 +32471,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 33349 "parsing/parser.ml"
+# 32477 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 33355 "parsing/parser.ml"
+# 32483 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33412,9 +32540,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 2149 "parsing/parser.mly"
+# 2139 "parsing/parser.mly"
       ( Ppat_constraint(_2, _4) )
-# 33418 "parsing/parser.ml"
+# 32546 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -33423,15 +32551,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 33429 "parsing/parser.ml"
+# 32557 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 33435 "parsing/parser.ml"
+# 32563 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33500,9 +32628,9 @@ module Tables = struct
             let _loc__5_ = (_startpos__5_, _endpos__5_) in
             let _loc__1_ = (_startpos__1_, _endpos__1_) in
             
-# 2151 "parsing/parser.mly"
+# 2141 "parsing/parser.mly"
       ( unclosed "(" _loc__1_ ")" _loc__5_ )
-# 33506 "parsing/parser.ml"
+# 32634 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__50_ in
@@ -33511,15 +32639,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 33517 "parsing/parser.ml"
+# 32645 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 33523 "parsing/parser.ml"
+# 32651 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33576,9 +32704,9 @@ module Tables = struct
             let _1 = _10 in
             let _loc__4_ = (_startpos__4_, _endpos__4_) in
             
-# 2153 "parsing/parser.mly"
+# 2143 "parsing/parser.mly"
       ( expecting _loc__4_ "type" )
-# 33582 "parsing/parser.ml"
+# 32710 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__40_ in
@@ -33587,15 +32715,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 33593 "parsing/parser.ml"
+# 32721 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 33599 "parsing/parser.ml"
+# 32727 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33649,7 +32777,7 @@ module Tables = struct
         let _400 : (
 # 624 "parsing/parser.mly"
        (string)
-# 33653 "parsing/parser.ml"
+# 32781 "parsing/parser.ml"
         ) = Obj.magic _400 in
         let _300 : (string Asttypes.loc option * Parsetree.attributes) = Obj.magic _300 in
         let _200 : unit = Obj.magic _200 in
@@ -33684,9 +32812,9 @@ module Tables = struct
             let _loc__7_ = (_startpos__7_, _endpos__7_) in
             let _loc__1_ = (_startpos__1_, _endpos__1_) in
             
-# 2156 "parsing/parser.mly"
+# 2146 "parsing/parser.mly"
       ( unclosed "(" _loc__1_ ")" _loc__7_ )
-# 33690 "parsing/parser.ml"
+# 32818 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__70_ in
@@ -33695,15 +32823,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 33701 "parsing/parser.ml"
+# 32829 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 33707 "parsing/parser.ml"
+# 32835 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33732,9 +32860,9 @@ module Tables = struct
           let _1 =
             let _1 = _10 in
             
-# 2158 "parsing/parser.mly"
+# 2148 "parsing/parser.mly"
       ( Ppat_extension _1 )
-# 33738 "parsing/parser.ml"
+# 32866 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__10_ in
@@ -33743,15 +32871,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 750 "parsing/parser.mly"
+# 740 "parsing/parser.mly"
     ( mkpat ~loc:_sloc _1 )
-# 33749 "parsing/parser.ml"
+# 32877 "parsing/parser.ml"
           
         in
         
-# 2119 "parsing/parser.mly"
+# 2109 "parsing/parser.mly"
       ( _1 )
-# 33755 "parsing/parser.ml"
+# 32883 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33772,15 +32900,15 @@ module Tables = struct
         let _1 : (
 # 578 "parsing/parser.mly"
        (string)
-# 33776 "parsing/parser.ml"
+# 32904 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2918 "parsing/parser.mly"
+# 2908 "parsing/parser.mly"
            ( _1 )
-# 33784 "parsing/parser.ml"
+# 32912 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33801,15 +32929,265 @@ module Tables = struct
         let _1 : (
 # 624 "parsing/parser.mly"
        (string)
-# 33805 "parsing/parser.ml"
+# 32933 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2919 "parsing/parser.mly"
+# 2909 "parsing/parser.mly"
            ( _1 )
-# 33813 "parsing/parser.ml"
+# 32941 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2910 "parsing/parser.mly"
+        ( "and" )
+# 32966 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2911 "parsing/parser.mly"
+       ( "as" )
+# 32991 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2912 "parsing/parser.mly"
+           ( "assert" )
+# 33016 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2913 "parsing/parser.mly"
+          ( "begin" )
+# 33041 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2914 "parsing/parser.mly"
+          ( "class" )
+# 33066 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2915 "parsing/parser.mly"
+               ( "constraint" )
+# 33091 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2916 "parsing/parser.mly"
+       ( "do" )
+# 33116 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2917 "parsing/parser.mly"
+         ( "done" )
+# 33141 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2918 "parsing/parser.mly"
+           ( "downto" )
+# 33166 "parsing/parser.ml"
+         in
+        {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = Obj.repr _v;
+          MenhirLib.EngineTypes.startp = _startpos;
+          MenhirLib.EngineTypes.endp = _endpos;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
+        let {
+          MenhirLib.EngineTypes.state = _menhir_s;
+          MenhirLib.EngineTypes.semv = _1;
+          MenhirLib.EngineTypes.startp = _startpos__1_;
+          MenhirLib.EngineTypes.endp = _endpos__1_;
+          MenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (string) = 
+# 2919 "parsing/parser.mly"
+         ( "else" )
+# 33191 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33833,8 +33211,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2920 "parsing/parser.mly"
-        ( "and" )
-# 33838 "parsing/parser.ml"
+        ( "end" )
+# 33216 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33858,8 +33236,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2921 "parsing/parser.mly"
-       ( "as" )
-# 33863 "parsing/parser.ml"
+              ( "exception" )
+# 33241 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33883,8 +33261,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2922 "parsing/parser.mly"
-           ( "assert" )
-# 33888 "parsing/parser.ml"
+             ( "external" )
+# 33266 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33908,8 +33286,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2923 "parsing/parser.mly"
-          ( "begin" )
-# 33913 "parsing/parser.ml"
+          ( "false" )
+# 33291 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33933,8 +33311,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2924 "parsing/parser.mly"
-          ( "class" )
-# 33938 "parsing/parser.ml"
+        ( "for" )
+# 33316 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33958,8 +33336,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2925 "parsing/parser.mly"
-               ( "constraint" )
-# 33963 "parsing/parser.ml"
+        ( "fun" )
+# 33341 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -33983,8 +33361,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2926 "parsing/parser.mly"
-       ( "do" )
-# 33988 "parsing/parser.ml"
+             ( "function" )
+# 33366 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34008,8 +33386,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2927 "parsing/parser.mly"
-         ( "done" )
-# 34013 "parsing/parser.ml"
+            ( "functor" )
+# 33391 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34033,8 +33411,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2928 "parsing/parser.mly"
-           ( "downto" )
-# 34038 "parsing/parser.ml"
+       ( "if" )
+# 33416 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34058,8 +33436,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2929 "parsing/parser.mly"
-         ( "else" )
-# 34063 "parsing/parser.ml"
+       ( "in" )
+# 33441 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34083,8 +33461,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2930 "parsing/parser.mly"
-        ( "end" )
-# 34088 "parsing/parser.ml"
+            ( "include" )
+# 33466 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34108,8 +33486,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2931 "parsing/parser.mly"
-              ( "exception" )
-# 34113 "parsing/parser.ml"
+            ( "inherit" )
+# 33491 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34133,8 +33511,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2932 "parsing/parser.mly"
-             ( "external" )
-# 34138 "parsing/parser.ml"
+                ( "initializer" )
+# 33516 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34158,8 +33536,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2933 "parsing/parser.mly"
-          ( "false" )
-# 34163 "parsing/parser.ml"
+         ( "lazy" )
+# 33541 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34183,8 +33561,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2934 "parsing/parser.mly"
-        ( "for" )
-# 34188 "parsing/parser.ml"
+        ( "let" )
+# 33566 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34208,8 +33586,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2935 "parsing/parser.mly"
-        ( "fun" )
-# 34213 "parsing/parser.ml"
+          ( "match" )
+# 33591 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34233,8 +33611,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2936 "parsing/parser.mly"
-             ( "function" )
-# 34238 "parsing/parser.ml"
+           ( "method" )
+# 33616 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34258,8 +33636,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2937 "parsing/parser.mly"
-            ( "functor" )
-# 34263 "parsing/parser.ml"
+           ( "module" )
+# 33641 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34283,8 +33661,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2938 "parsing/parser.mly"
-       ( "if" )
-# 34288 "parsing/parser.ml"
+            ( "mutable" )
+# 33666 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34308,8 +33686,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2939 "parsing/parser.mly"
-       ( "in" )
-# 34313 "parsing/parser.ml"
+        ( "new" )
+# 33691 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34333,8 +33711,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2940 "parsing/parser.mly"
-            ( "include" )
-# 34338 "parsing/parser.ml"
+           ( "nonrec" )
+# 33716 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34358,8 +33736,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2941 "parsing/parser.mly"
-            ( "inherit" )
-# 34363 "parsing/parser.ml"
+           ( "object" )
+# 33741 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34383,8 +33761,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2942 "parsing/parser.mly"
-                ( "initializer" )
-# 34388 "parsing/parser.ml"
+       ( "of" )
+# 33766 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34408,8 +33786,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2943 "parsing/parser.mly"
-         ( "lazy" )
-# 34413 "parsing/parser.ml"
+         ( "open" )
+# 33791 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34433,8 +33811,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2944 "parsing/parser.mly"
-        ( "let" )
-# 34438 "parsing/parser.ml"
+       ( "or" )
+# 33816 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34458,8 +33836,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2945 "parsing/parser.mly"
-          ( "match" )
-# 34463 "parsing/parser.ml"
+            ( "private" )
+# 33841 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34483,8 +33861,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2946 "parsing/parser.mly"
-           ( "method" )
-# 34488 "parsing/parser.ml"
+        ( "rec" )
+# 33866 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34508,8 +33886,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2947 "parsing/parser.mly"
-           ( "module" )
-# 34513 "parsing/parser.ml"
+        ( "sig" )
+# 33891 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34533,8 +33911,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2948 "parsing/parser.mly"
-            ( "mutable" )
-# 34538 "parsing/parser.ml"
+           ( "struct" )
+# 33916 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34558,8 +33936,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2949 "parsing/parser.mly"
-        ( "new" )
-# 34563 "parsing/parser.ml"
+         ( "then" )
+# 33941 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34583,8 +33961,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2950 "parsing/parser.mly"
-           ( "nonrec" )
-# 34588 "parsing/parser.ml"
+       ( "to" )
+# 33966 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34608,8 +33986,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2951 "parsing/parser.mly"
-           ( "object" )
-# 34613 "parsing/parser.ml"
+         ( "true" )
+# 33991 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34633,8 +34011,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2952 "parsing/parser.mly"
-       ( "of" )
-# 34638 "parsing/parser.ml"
+        ( "try" )
+# 34016 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34658,8 +34036,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2953 "parsing/parser.mly"
-         ( "open" )
-# 34663 "parsing/parser.ml"
+         ( "type" )
+# 34041 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34683,8 +34061,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2954 "parsing/parser.mly"
-       ( "or" )
-# 34688 "parsing/parser.ml"
+        ( "val" )
+# 34066 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34708,8 +34086,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2955 "parsing/parser.mly"
-            ( "private" )
-# 34713 "parsing/parser.ml"
+            ( "virtual" )
+# 34091 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34733,8 +34111,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2956 "parsing/parser.mly"
-        ( "rec" )
-# 34738 "parsing/parser.ml"
+         ( "when" )
+# 34116 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34758,8 +34136,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2957 "parsing/parser.mly"
-        ( "sig" )
-# 34763 "parsing/parser.ml"
+          ( "while" )
+# 34141 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -34783,258 +34161,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (string) = 
 # 2958 "parsing/parser.mly"
-           ( "struct" )
-# 34788 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2959 "parsing/parser.mly"
-         ( "then" )
-# 34813 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2960 "parsing/parser.mly"
-       ( "to" )
-# 34838 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2961 "parsing/parser.mly"
-         ( "true" )
-# 34863 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2962 "parsing/parser.mly"
-        ( "try" )
-# 34888 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2963 "parsing/parser.mly"
-         ( "type" )
-# 34913 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2964 "parsing/parser.mly"
-        ( "val" )
-# 34938 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2965 "parsing/parser.mly"
-            ( "virtual" )
-# 34963 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2966 "parsing/parser.mly"
-         ( "when" )
-# 34988 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2967 "parsing/parser.mly"
-          ( "while" )
-# 35013 "parsing/parser.ml"
-         in
-        {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = Obj.repr _v;
-          MenhirLib.EngineTypes.startp = _startpos;
-          MenhirLib.EngineTypes.endp = _endpos;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.MenhirLib.EngineTypes.stack in
-        let {
-          MenhirLib.EngineTypes.state = _menhir_s;
-          MenhirLib.EngineTypes.semv = _1;
-          MenhirLib.EngineTypes.startp = _startpos__1_;
-          MenhirLib.EngineTypes.endp = _endpos__1_;
-          MenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (string) = 
-# 2968 "parsing/parser.mly"
          ( "with" )
-# 35038 "parsing/parser.ml"
+# 34166 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35057,9 +34185,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.type_exception * string Asttypes.loc option) = 
-# 2350 "parsing/parser.mly"
+# 2340 "parsing/parser.mly"
                                                  ( _1 )
-# 35063 "parsing/parser.ml"
+# 34191 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35122,20 +34250,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__11_ in
           let _1 = _11 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 35139 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 34259 "parsing/parser.ml"
           
         in
         let _3 =
@@ -35143,33 +34263,25 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 35160 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 34272 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__7_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2353 "parsing/parser.mly"
+# 2343 "parsing/parser.mly"
     ( let (ext,attrs) = _2 in
       let docs = symbol_docs _sloc in
       Te.mk_exception ~attrs:_7
         (Te.rebind _3 _5 ~attrs:(attrs @ _6) ~loc:(make_loc _sloc) ~docs)
       , ext )
-# 35173 "parsing/parser.ml"
+# 34285 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35192,9 +34304,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.extension_constructor list) = 
-# 2431 "parsing/parser.mly"
+# 2421 "parsing/parser.mly"
                                                           ( [_1] )
-# 35198 "parsing/parser.ml"
+# 34310 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35217,9 +34329,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.extension_constructor list) = 
-# 2432 "parsing/parser.mly"
+# 2422 "parsing/parser.mly"
                                                           ( [_1] )
-# 35223 "parsing/parser.ml"
+# 34335 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35242,9 +34354,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.extension_constructor list) = 
-# 2433 "parsing/parser.mly"
+# 2423 "parsing/parser.mly"
                                                           ( [_1] )
-# 35248 "parsing/parser.ml"
+# 34360 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35267,9 +34379,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.extension_constructor list) = 
-# 2434 "parsing/parser.mly"
+# 2424 "parsing/parser.mly"
                                                           ( [_1] )
-# 35273 "parsing/parser.ml"
+# 34385 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35298,9 +34410,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.extension_constructor list) = 
-# 2436 "parsing/parser.mly"
+# 2426 "parsing/parser.mly"
       ( _2 :: _1 )
-# 35304 "parsing/parser.ml"
+# 34416 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35329,9 +34441,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.extension_constructor list) = 
-# 2438 "parsing/parser.mly"
+# 2428 "parsing/parser.mly"
       ( _2 :: _1 )
-# 35335 "parsing/parser.ml"
+# 34447 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35375,11 +34487,11 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 996 "parsing/parser.mly"
+# 986 "parsing/parser.mly"
       ( let (ext, attrs) = _2 in
         let docs = symbol_docs _sloc in
         Incl.mk _3 ~attrs:(attrs@_4) ~loc:(make_loc _sloc) ~docs, ext )
-# 35383 "parsing/parser.ml"
+# 34495 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35454,20 +34566,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 35471 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 34575 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__9_ in
@@ -35475,13 +34579,13 @@ module Tables = struct
         let _loc__3_ = (_startpos__3_, _endpos__3_) in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2414 "parsing/parser.mly"
+# 2404 "parsing/parser.mly"
       ( let (ext, attrs) = _2 in
         if _3 <> Recursive then not_expecting _loc__3_ "nonrec flag";
         let docs = symbol_docs _sloc in
         Te.mk _5 (List.rev _8) ~params:_4 ~priv:_7 ~attrs:(attrs@_9) ~docs
         , ext )
-# 35485 "parsing/parser.ml"
+# 34589 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35510,9 +34614,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.expression) = 
-# 1954 "parsing/parser.mly"
+# 1944 "parsing/parser.mly"
       ( _2 )
-# 35516 "parsing/parser.ml"
+# 34620 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35544,9 +34648,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1956 "parsing/parser.mly"
+# 1946 "parsing/parser.mly"
       ( let (l, o, p) = _1 in ghexp ~loc:_sloc (Pexp_fun(l, o, p, _2)) )
-# 35550 "parsing/parser.ml"
+# 34654 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35596,9 +34700,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1958 "parsing/parser.mly"
+# 1948 "parsing/parser.mly"
       ( mk_newtypes ~loc:_sloc _3 _5 )
-# 35602 "parsing/parser.ml"
+# 34706 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35629,13 +34733,13 @@ module Tables = struct
           
 # 720 "parsing/parser.mly"
                               ( extra_str _startpos _endpos _1 )
-# 35633 "parsing/parser.ml"
+# 34737 "parsing/parser.ml"
           
         in
         
-# 942 "parsing/parser.mly"
+# 932 "parsing/parser.mly"
                                       ( _1 )
-# 35639 "parsing/parser.ml"
+# 34743 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35661,9 +34765,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 957 "parsing/parser.mly"
+# 947 "parsing/parser.mly"
       ( val_of_let_bindings ~loc:_sloc _1 )
-# 35667 "parsing/parser.ml"
+# 34771 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35686,13 +34790,13 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item) = let _endpos = _endpos__1_ in
-        let _startpos = _startpos__1_ in
-        let _loc = (_startpos, _endpos) in
+        let _symbolstartpos = _startpos__1_ in
+        let _sloc = (_symbolstartpos, _endpos) in
         
-# 959 "parsing/parser.mly"
+# 949 "parsing/parser.mly"
       ( let item, ext = _1 in
-        wrap_str_ext ~loc:_loc (mkstr ~loc:_loc item) ext )
-# 35696 "parsing/parser.ml"
+        wrap_str_ext ~loc:_sloc (mkstr ~loc:_sloc item) ext )
+# 34800 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35724,10 +34828,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 962 "parsing/parser.mly"
+# 952 "parsing/parser.mly"
       ( let docs = symbol_docs _sloc in
         mkstr ~loc:_sloc (Pstr_extension (_1, (add_docs_attrs docs _2))) )
-# 35731 "parsing/parser.ml"
+# 34835 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35753,9 +34857,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 965 "parsing/parser.mly"
+# 955 "parsing/parser.mly"
       ( mkstr ~loc:_sloc (Pstr_attribute _1) )
-# 35759 "parsing/parser.ml"
+# 34863 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35778,9 +34882,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item_desc * string Asttypes.loc option) = 
-# 969 "parsing/parser.mly"
+# 959 "parsing/parser.mly"
       ( let (body, ext) = _1 in (Pstr_primitive body, ext) )
-# 35784 "parsing/parser.ml"
+# 34888 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35803,9 +34907,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item_desc * string Asttypes.loc option) = 
-# 971 "parsing/parser.mly"
+# 961 "parsing/parser.mly"
       ( let (body, ext) = _1 in (Pstr_primitive body, ext) )
-# 35809 "parsing/parser.ml"
+# 34913 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35829,9 +34933,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item_desc * string Asttypes.loc option) = 
-# 973 "parsing/parser.mly"
+# 963 "parsing/parser.mly"
       ( let (nr, l, ext ) = _1 in (Pstr_type (nr, List.rev l), ext) )
-# 35835 "parsing/parser.ml"
+# 34939 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35854,9 +34958,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item_desc * string Asttypes.loc option) = 
-# 975 "parsing/parser.mly"
+# 965 "parsing/parser.mly"
       ( let (l, ext) = _1 in (Pstr_typext l, ext) )
-# 35860 "parsing/parser.ml"
+# 34964 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35879,9 +34983,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item_desc * string Asttypes.loc option) = 
-# 977 "parsing/parser.mly"
+# 967 "parsing/parser.mly"
       ( let (l, ext) = _1 in (Pstr_exception l, ext) )
-# 35885 "parsing/parser.ml"
+# 34989 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35904,9 +35008,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item_desc * string Asttypes.loc option) = 
-# 979 "parsing/parser.mly"
+# 969 "parsing/parser.mly"
       ( let (body, ext) = _1 in (Pstr_module body, ext) )
-# 35910 "parsing/parser.ml"
+# 35014 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35929,9 +35033,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item_desc * string Asttypes.loc option) = 
-# 981 "parsing/parser.mly"
+# 971 "parsing/parser.mly"
       ( let (l, ext) = _1 in (Pstr_recmodule (List.rev l), ext) )
-# 35935 "parsing/parser.ml"
+# 35039 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35954,9 +35058,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item_desc * string Asttypes.loc option) = 
-# 983 "parsing/parser.mly"
+# 973 "parsing/parser.mly"
       ( let (body, ext) = _1 in (Pstr_modtype body, ext) )
-# 35960 "parsing/parser.ml"
+# 35064 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -35979,9 +35083,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item_desc * string Asttypes.loc option) = 
-# 985 "parsing/parser.mly"
+# 975 "parsing/parser.mly"
       ( let (body, ext) = _1 in (Pstr_open body, ext) )
-# 35985 "parsing/parser.ml"
+# 35089 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36004,9 +35108,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item_desc * string Asttypes.loc option) = 
-# 987 "parsing/parser.mly"
+# 977 "parsing/parser.mly"
       ( let (l, ext) = _1 in (Pstr_class (List.rev l), ext) )
-# 36010 "parsing/parser.ml"
+# 35114 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36029,9 +35133,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item_desc * string Asttypes.loc option) = 
-# 989 "parsing/parser.mly"
+# 979 "parsing/parser.mly"
       ( let (l, ext) = _1 in (Pstr_class_type (List.rev l), ext) )
-# 36035 "parsing/parser.ml"
+# 35139 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36054,9 +35158,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item_desc * string Asttypes.loc option) = 
-# 991 "parsing/parser.mly"
+# 981 "parsing/parser.mly"
       ( let (body, ext) = _1 in (Pstr_include body, ext) )
-# 36060 "parsing/parser.ml"
+# 35164 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36091,10 +35195,10 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.structure_item list) = 
-# 945 "parsing/parser.mly"
+# 935 "parsing/parser.mly"
       ( mark_rhs_docs _startpos__1_ _endpos__2_;
         text_str _startpos__1_ @ mkstrexp _1 _2 :: _3 )
-# 36098 "parsing/parser.ml"
+# 35202 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36117,9 +35221,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item list) = 
-# 947 "parsing/parser.mly"
+# 937 "parsing/parser.mly"
                          ( _1 )
-# 36123 "parsing/parser.ml"
+# 35227 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36135,9 +35239,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Parsetree.structure_item list) = 
-# 950 "parsing/parser.mly"
+# 940 "parsing/parser.mly"
                                         ( [] )
-# 36141 "parsing/parser.ml"
+# 35245 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36166,9 +35270,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.structure_item list) = 
-# 951 "parsing/parser.mly"
+# 941 "parsing/parser.mly"
                                         ( text_str _startpos__1_ @ _2 )
-# 36172 "parsing/parser.ml"
+# 35276 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36197,9 +35301,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.structure_item list) = 
-# 952 "parsing/parser.mly"
+# 942 "parsing/parser.mly"
                                         ( text_str _startpos__1_ @ _1 :: _2 )
-# 36203 "parsing/parser.ml"
+# 35307 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36222,9 +35326,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2907 "parsing/parser.mly"
+# 2897 "parsing/parser.mly"
                                                 ( "-" )
-# 36228 "parsing/parser.ml"
+# 35332 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36247,9 +35351,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2908 "parsing/parser.mly"
+# 2898 "parsing/parser.mly"
                                                 ( "-." )
-# 36253 "parsing/parser.ml"
+# 35357 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36300,20 +35404,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 36317 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 35413 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -36321,11 +35417,11 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2633 "parsing/parser.mly"
+# 2623 "parsing/parser.mly"
       ( let info = symbol_info _endpos in
         let attrs = add_info_attrs info _5 in
         Rf.tag ~loc:(make_loc _sloc) ~attrs _1 _3 (List.rev _4) )
-# 36329 "parsing/parser.ml"
+# 35425 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36358,20 +35454,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 36375 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 35463 "parsing/parser.ml"
           
         in
         let _startpos__1_ = _startpos__10_ in
@@ -36379,11 +35467,11 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2637 "parsing/parser.mly"
+# 2627 "parsing/parser.mly"
       ( let info = symbol_info _endpos in
         let attrs = add_info_attrs info _2 in
         Rf.tag ~loc:(make_loc _sloc) ~attrs _1 true [] )
-# 36387 "parsing/parser.ml"
+# 35475 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36414,13 +35502,13 @@ module Tables = struct
           
 # 720 "parsing/parser.mly"
                               ( extra_str _startpos _endpos _1 )
-# 36418 "parsing/parser.ml"
+# 35506 "parsing/parser.ml"
           
         in
         
-# 809 "parsing/parser.mly"
+# 799 "parsing/parser.mly"
                                               ( _1 )
-# 36424 "parsing/parser.ml"
+# 35512 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36449,9 +35537,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.structure_item list) = 
-# 812 "parsing/parser.mly"
+# 802 "parsing/parser.mly"
       ( text_str _startpos__1_ @ [mkstrexp _1 _2] )
-# 36455 "parsing/parser.ml"
+# 35543 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36474,9 +35562,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.structure_item list) = 
-# 814 "parsing/parser.mly"
+# 804 "parsing/parser.mly"
       ( _1 )
-# 36480 "parsing/parser.ml"
+# 35568 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36492,9 +35580,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Parsetree.structure_item list) = 
-# 818 "parsing/parser.mly"
+# 808 "parsing/parser.mly"
       ( [] )
-# 36498 "parsing/parser.ml"
+# 35586 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36523,9 +35611,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.structure_item list) = 
-# 820 "parsing/parser.mly"
+# 810 "parsing/parser.mly"
       ( text_str _startpos__1_ @ _1 :: _2 )
-# 36529 "parsing/parser.ml"
+# 35617 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36551,10 +35639,10 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2835 "parsing/parser.mly"
+# 2825 "parsing/parser.mly"
     ( let (dir, arg) = _1 in
       mk_directive ~loc:_sloc dir arg )
-# 36558 "parsing/parser.ml"
+# 35646 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36587,26 +35675,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 36604 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 35684 "parsing/parser.ml"
           
         in
         
-# 2840 "parsing/parser.mly"
+# 2830 "parsing/parser.mly"
     ( _2, None )
-# 36610 "parsing/parser.ml"
+# 35690 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36645,26 +35725,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 36662 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 35734 "parsing/parser.ml"
           
         in
         
-# 2842 "parsing/parser.mly"
+# 2832 "parsing/parser.mly"
     ( _2, Some _3 )
-# 36668 "parsing/parser.ml"
+# 35740 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36690,9 +35762,9 @@ module Tables = struct
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2847 "parsing/parser.mly"
+# 2837 "parsing/parser.mly"
     ( mk_directive_arg ~loc:_sloc _1 )
-# 36696 "parsing/parser.ml"
+# 35768 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36713,15 +35785,15 @@ module Tables = struct
         let _1 : (
 # 616 "parsing/parser.mly"
        (string * string option)
-# 36717 "parsing/parser.ml"
+# 35789 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.directive_argument_desc) = 
-# 2850 "parsing/parser.mly"
+# 2840 "parsing/parser.mly"
                   ( let (s, _) = _1 in Pdir_string s )
-# 36725 "parsing/parser.ml"
+# 35797 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36742,15 +35814,15 @@ module Tables = struct
         let _1 : (
 # 564 "parsing/parser.mly"
        (string * char option)
-# 36746 "parsing/parser.ml"
+# 35818 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.directive_argument_desc) = 
-# 2851 "parsing/parser.mly"
+# 2841 "parsing/parser.mly"
                   ( let (n, m) = _1 in Pdir_int (n ,m) )
-# 36754 "parsing/parser.ml"
+# 35826 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36773,9 +35845,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.directive_argument_desc) = 
-# 2852 "parsing/parser.mly"
+# 2842 "parsing/parser.mly"
                   ( Pdir_ident _1 )
-# 36779 "parsing/parser.ml"
+# 35851 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36798,9 +35870,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.directive_argument_desc) = 
-# 2853 "parsing/parser.mly"
+# 2843 "parsing/parser.mly"
                   ( Pdir_ident _1 )
-# 36804 "parsing/parser.ml"
+# 35876 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36823,9 +35895,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.directive_argument_desc) = 
-# 2854 "parsing/parser.mly"
+# 2844 "parsing/parser.mly"
                   ( Pdir_bool false )
-# 36829 "parsing/parser.ml"
+# 35901 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36848,9 +35920,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.directive_argument_desc) = 
-# 2855 "parsing/parser.mly"
+# 2845 "parsing/parser.mly"
                   ( Pdir_bool true )
-# 36854 "parsing/parser.ml"
+# 35926 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36881,11 +35953,11 @@ module Tables = struct
         let _v : (
 # 708 "parsing/parser.mly"
       (Parsetree.toplevel_phrase)
-# 36885 "parsing/parser.ml"
+# 35957 "parsing/parser.ml"
         ) = 
-# 805 "parsing/parser.mly"
+# 795 "parsing/parser.mly"
                                          ( Ptop_def (_1) )
-# 36889 "parsing/parser.ml"
+# 35961 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36916,11 +35988,11 @@ module Tables = struct
         let _v : (
 # 708 "parsing/parser.mly"
       (Parsetree.toplevel_phrase)
-# 36920 "parsing/parser.ml"
+# 35992 "parsing/parser.ml"
         ) = 
-# 806 "parsing/parser.mly"
+# 796 "parsing/parser.mly"
                                          ( _1 )
-# 36924 "parsing/parser.ml"
+# 35996 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36945,11 +36017,11 @@ module Tables = struct
         let _v : (
 # 708 "parsing/parser.mly"
       (Parsetree.toplevel_phrase)
-# 36949 "parsing/parser.ml"
+# 36021 "parsing/parser.ml"
         ) = 
-# 807 "parsing/parser.mly"
+# 797 "parsing/parser.mly"
                                          ( raise End_of_file )
-# 36953 "parsing/parser.ml"
+# 36025 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -36978,9 +36050,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.core_type option * Parsetree.core_type option) = 
-# 2023 "parsing/parser.mly"
+# 2013 "parsing/parser.mly"
                                                 ( (Some _2, None) )
-# 36984 "parsing/parser.ml"
+# 36056 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37021,9 +36093,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : (Parsetree.core_type option * Parsetree.core_type option) = 
-# 2024 "parsing/parser.mly"
+# 2014 "parsing/parser.mly"
                                                 ( (Some _2, Some _4) )
-# 37027 "parsing/parser.ml"
+# 36099 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37052,9 +36124,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.core_type option * Parsetree.core_type option) = 
-# 2025 "parsing/parser.mly"
+# 2015 "parsing/parser.mly"
                                                 ( (None, Some _2) )
-# 37058 "parsing/parser.ml"
+# 36130 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37083,9 +36155,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.core_type option * Parsetree.core_type option) = 
-# 2026 "parsing/parser.mly"
+# 2016 "parsing/parser.mly"
                                                 ( syntax_error() )
-# 37089 "parsing/parser.ml"
+# 36161 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37114,9 +36186,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.core_type option * Parsetree.core_type option) = 
-# 2027 "parsing/parser.mly"
+# 2017 "parsing/parser.mly"
                                                 ( syntax_error() )
-# 37120 "parsing/parser.ml"
+# 36192 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37175,7 +36247,7 @@ module Tables = struct
         let _10 : (
 # 578 "parsing/parser.mly"
        (string)
-# 37179 "parsing/parser.ml"
+# 36251 "parsing/parser.ml"
         ) = Obj.magic _10 in
         let _4 : ((Parsetree.core_type * Asttypes.variance) list) = Obj.magic _4 in
         let _3 : (Asttypes.rec_flag) = Obj.magic _3 in
@@ -37189,27 +36261,19 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 37206 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 36270 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__8_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2250 "parsing/parser.mly"
+# 2240 "parsing/parser.mly"
       ( let (kind, priv, manifest) = _6 in
         let (ext, attrs) = _2 in
         let docs = symbol_docs _sloc in
@@ -37218,7 +36282,7 @@ module Tables = struct
             ~priv ?manifest ~attrs:(attrs@_8) ~loc:(make_loc _sloc) ~docs
         in
         (_3, ty, ext) )
-# 37222 "parsing/parser.ml"
+# 36286 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37242,9 +36306,9 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.rec_flag * Parsetree.type_declaration list *
   string Asttypes.loc option) = 
-# 2242 "parsing/parser.mly"
+# 2232 "parsing/parser.mly"
       ( let (nonrec_flag, ty, ext) = _1 in (nonrec_flag, [ty], ext) )
-# 37248 "parsing/parser.ml"
+# 36312 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37275,9 +36339,9 @@ module Tables = struct
         let _endpos = _endpos__2_ in
         let _v : (Asttypes.rec_flag * Parsetree.type_declaration list *
   string Asttypes.loc option) = 
-# 2244 "parsing/parser.mly"
+# 2234 "parsing/parser.mly"
       ( let (nonrec_flag, tys, ext) = _1 in (nonrec_flag, _2 :: tys, ext) )
-# 37281 "parsing/parser.ml"
+# 36345 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37293,9 +36357,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Parsetree.type_kind * Asttypes.private_flag * Parsetree.core_type option) = 
-# 2275 "parsing/parser.mly"
+# 2265 "parsing/parser.mly"
       ( (Ptype_abstract, Public, None) )
-# 37299 "parsing/parser.ml"
+# 36363 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37324,9 +36388,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.type_kind * Asttypes.private_flag * Parsetree.core_type option) = 
-# 2277 "parsing/parser.mly"
+# 2267 "parsing/parser.mly"
       ( (Ptype_abstract, Public, Some _2) )
-# 37330 "parsing/parser.ml"
+# 36394 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37361,9 +36425,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.type_kind * Asttypes.private_flag * Parsetree.core_type option) = 
-# 2279 "parsing/parser.mly"
+# 2269 "parsing/parser.mly"
       ( (Ptype_abstract, Private, Some _3) )
-# 37367 "parsing/parser.ml"
+# 36431 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37392,9 +36456,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.type_kind * Asttypes.private_flag * Parsetree.core_type option) = 
-# 2281 "parsing/parser.mly"
+# 2271 "parsing/parser.mly"
       ( (Ptype_variant(List.rev _2), Public, None) )
-# 37398 "parsing/parser.ml"
+# 36462 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37429,9 +36493,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.type_kind * Asttypes.private_flag * Parsetree.core_type option) = 
-# 2283 "parsing/parser.mly"
+# 2273 "parsing/parser.mly"
       ( (Ptype_variant(List.rev _3), Private, None) )
-# 37435 "parsing/parser.ml"
+# 36499 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37460,9 +36524,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.type_kind * Asttypes.private_flag * Parsetree.core_type option) = 
-# 2285 "parsing/parser.mly"
+# 2275 "parsing/parser.mly"
       ( (Ptype_open, Public, None) )
-# 37466 "parsing/parser.ml"
+# 36530 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37497,9 +36561,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.type_kind * Asttypes.private_flag * Parsetree.core_type option) = 
-# 2287 "parsing/parser.mly"
+# 2277 "parsing/parser.mly"
       ( (Ptype_open, Private, None) )
-# 37503 "parsing/parser.ml"
+# 36567 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37546,9 +36610,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
         let _v : (Parsetree.type_kind * Asttypes.private_flag * Parsetree.core_type option) = 
-# 2289 "parsing/parser.mly"
+# 2279 "parsing/parser.mly"
       ( (Ptype_record _4, _2, None) )
-# 37552 "parsing/parser.ml"
+# 36616 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37595,9 +36659,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
         let _v : (Parsetree.type_kind * Asttypes.private_flag * Parsetree.core_type option) = 
-# 2291 "parsing/parser.mly"
+# 2281 "parsing/parser.mly"
       ( (Ptype_variant(List.rev _5), _4, Some _2) )
-# 37601 "parsing/parser.ml"
+# 36665 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37644,9 +36708,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
         let _v : (Parsetree.type_kind * Asttypes.private_flag * Parsetree.core_type option) = 
-# 2293 "parsing/parser.mly"
+# 2283 "parsing/parser.mly"
       ( (Ptype_open, _4, Some _2) )
-# 37650 "parsing/parser.ml"
+# 36714 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37705,9 +36769,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__7_ in
         let _v : (Parsetree.type_kind * Asttypes.private_flag * Parsetree.core_type option) = 
-# 2295 "parsing/parser.mly"
+# 2285 "parsing/parser.mly"
       ( (Ptype_record _6, _4, Some _2) )
-# 37711 "parsing/parser.ml"
+# 36775 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37728,15 +36792,15 @@ module Tables = struct
         let _1 : (
 # 578 "parsing/parser.mly"
        (string)
-# 37732 "parsing/parser.ml"
+# 36796 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Longident.t) = 
-# 2805 "parsing/parser.mly"
+# 2795 "parsing/parser.mly"
                                                 ( Lident _1 )
-# 37740 "parsing/parser.ml"
+# 36804 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37767,7 +36831,7 @@ module Tables = struct
         let _3 : (
 # 578 "parsing/parser.mly"
        (string)
-# 37771 "parsing/parser.ml"
+# 36835 "parsing/parser.ml"
         ) = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
         let _1 : (Longident.t) = Obj.magic _1 in
@@ -37775,9 +36839,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Longident.t) = 
-# 2806 "parsing/parser.mly"
+# 2796 "parsing/parser.mly"
                                                 ( Ldot(_1, _3) )
-# 37781 "parsing/parser.ml"
+# 36845 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37806,9 +36870,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.core_type * Asttypes.variance) = 
-# 2317 "parsing/parser.mly"
+# 2307 "parsing/parser.mly"
                                                   ( _2, _1 )
-# 37812 "parsing/parser.ml"
+# 36876 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37831,9 +36895,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : ((Parsetree.core_type * Asttypes.variance) list) = 
-# 2328 "parsing/parser.mly"
+# 2318 "parsing/parser.mly"
                                                 ( [_1] )
-# 37837 "parsing/parser.ml"
+# 36901 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37868,9 +36932,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : ((Parsetree.core_type * Asttypes.variance) list) = 
-# 2329 "parsing/parser.mly"
+# 2319 "parsing/parser.mly"
                                                 ( _3 :: _1 )
-# 37874 "parsing/parser.ml"
+# 36938 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37907,9 +36971,9 @@ module Tables = struct
             let _2 = _20 in
             let _1 = _10 in
             
-# 2325 "parsing/parser.mly"
+# 2315 "parsing/parser.mly"
                       ( Ptyp_var _2 )
-# 37913 "parsing/parser.ml"
+# 36977 "parsing/parser.ml"
             
           in
           let _endpos__1_ = _endpos__20_ in
@@ -37918,15 +36982,15 @@ module Tables = struct
           let _symbolstartpos = _startpos__1_ in
           let _sloc = (_symbolstartpos, _endpos) in
           
-# 752 "parsing/parser.mly"
+# 742 "parsing/parser.mly"
     ( mktyp ~loc:_sloc _1 )
-# 37924 "parsing/parser.ml"
+# 36988 "parsing/parser.ml"
           
         in
         
-# 2325 "parsing/parser.mly"
+# 2315 "parsing/parser.mly"
                                        ( _1 )
-# 37930 "parsing/parser.ml"
+# 36994 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37942,9 +37006,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Asttypes.variance) = 
-# 2320 "parsing/parser.mly"
+# 2310 "parsing/parser.mly"
                                                 ( Invariant )
-# 37948 "parsing/parser.ml"
+# 37012 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37967,9 +37031,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.variance) = 
-# 2321 "parsing/parser.mly"
+# 2311 "parsing/parser.mly"
                                                 ( Covariant )
-# 37973 "parsing/parser.ml"
+# 37037 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -37992,9 +37056,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.variance) = 
-# 2322 "parsing/parser.mly"
+# 2312 "parsing/parser.mly"
                                                 ( Contravariant )
-# 37998 "parsing/parser.ml"
+# 37062 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38027,26 +37091,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 38044 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 37100 "parsing/parser.ml"
           
         in
         
-# 2511 "parsing/parser.mly"
+# 2501 "parsing/parser.mly"
                                                 ( [_2] )
-# 38050 "parsing/parser.ml"
+# 37106 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38085,26 +37141,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 38102 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 37150 "parsing/parser.ml"
           
         in
         
-# 2512 "parsing/parser.mly"
+# 2502 "parsing/parser.mly"
                                                 ( _3 :: _1 )
-# 38108 "parsing/parser.ml"
+# 37156 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38135,7 +37183,7 @@ module Tables = struct
         let _v : (
 # 710 "parsing/parser.mly"
       (Parsetree.toplevel_phrase list)
-# 38139 "parsing/parser.ml"
+# 37187 "parsing/parser.ml"
         ) = let _1 =
           let _endpos__1_ = _endpos__10_ in
           let _startpos__1_ = _startpos__10_ in
@@ -38145,13 +37193,13 @@ module Tables = struct
           
 # 724 "parsing/parser.mly"
                               ( extra_def _startpos _endpos _1 )
-# 38149 "parsing/parser.ml"
+# 37197 "parsing/parser.ml"
           
         in
         
-# 824 "parsing/parser.mly"
+# 814 "parsing/parser.mly"
                                          ( _1 )
-# 38155 "parsing/parser.ml"
+# 37203 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38174,9 +37222,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.toplevel_phrase list) = 
-# 827 "parsing/parser.mly"
+# 817 "parsing/parser.mly"
                                          ( _1 )
-# 38180 "parsing/parser.ml"
+# 37228 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38211,9 +37259,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.toplevel_phrase list) = 
-# 829 "parsing/parser.mly"
+# 819 "parsing/parser.mly"
       ( text_def _startpos__1_ @ Ptop_def[mkstrexp _1 _2] :: _3 )
-# 38217 "parsing/parser.ml"
+# 37265 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38229,9 +37277,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Parsetree.toplevel_phrase list) = 
-# 833 "parsing/parser.mly"
+# 823 "parsing/parser.mly"
       ( [] )
-# 38235 "parsing/parser.ml"
+# 37283 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38260,9 +37308,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.toplevel_phrase list) = 
-# 835 "parsing/parser.mly"
+# 825 "parsing/parser.mly"
       ( _2 )
-# 38266 "parsing/parser.ml"
+# 37314 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38291,9 +37339,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.toplevel_phrase list) = 
-# 837 "parsing/parser.mly"
+# 827 "parsing/parser.mly"
       ( text_def _startpos__1_ @ Ptop_def[_1] :: _2 )
-# 38297 "parsing/parser.ml"
+# 37345 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38322,10 +37370,10 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Parsetree.toplevel_phrase list) = 
-# 839 "parsing/parser.mly"
+# 829 "parsing/parser.mly"
       ( mark_rhs_docs _startpos__1_ _endpos__1_;
         text_def _startpos__1_ @ _1 :: _2 )
-# 38329 "parsing/parser.ml"
+# 37377 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38346,15 +37394,15 @@ module Tables = struct
         let _1 : (
 # 578 "parsing/parser.mly"
        (string)
-# 38350 "parsing/parser.ml"
+# 37398 "parsing/parser.ml"
         ) = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (string) = 
-# 2741 "parsing/parser.mly"
+# 2731 "parsing/parser.mly"
                               ( _1 )
-# 38358 "parsing/parser.ml"
+# 37406 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38389,9 +37437,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (string) = 
-# 2742 "parsing/parser.mly"
+# 2732 "parsing/parser.mly"
                               ( _2 )
-# 38395 "parsing/parser.ml"
+# 37443 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38428,9 +37476,9 @@ module Tables = struct
         let _v : (string) = let _loc__3_ = (_startpos__3_, _endpos__3_) in
         let _loc__1_ = (_startpos__1_, _endpos__1_) in
         
-# 2743 "parsing/parser.mly"
+# 2733 "parsing/parser.mly"
                               ( unclosed "(" _loc__1_ ")" _loc__3_ )
-# 38434 "parsing/parser.ml"
+# 37482 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38460,9 +37508,9 @@ module Tables = struct
         let _endpos = _endpos__2_ in
         let _v : (string) = let _loc__2_ = (_startpos__2_, _endpos__2_) in
         
-# 2744 "parsing/parser.mly"
+# 2734 "parsing/parser.mly"
                               ( expecting _loc__2_ "operator" )
-# 38466 "parsing/parser.ml"
+# 37514 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38498,9 +37546,9 @@ module Tables = struct
         let _endpos = _endpos__3_ in
         let _v : (string) = let _loc__3_ = (_startpos__3_, _endpos__3_) in
         
-# 2745 "parsing/parser.mly"
+# 2735 "parsing/parser.mly"
                               ( expecting _loc__3_ "module-expr" )
-# 38504 "parsing/parser.ml"
+# 37552 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38523,9 +37571,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Longident.t) = 
-# 2788 "parsing/parser.mly"
+# 2778 "parsing/parser.mly"
                                                 ( Lident _1 )
-# 38529 "parsing/parser.ml"
+# 37577 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38560,9 +37608,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Longident.t) = 
-# 2789 "parsing/parser.mly"
+# 2779 "parsing/parser.mly"
                                                 ( Ldot(_1, _3) )
-# 38566 "parsing/parser.ml"
+# 37614 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38627,27 +37675,19 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 38644 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 37684 "parsing/parser.ml"
           
         in
         
-# 1326 "parsing/parser.mly"
+# 1316 "parsing/parser.mly"
       ( if _1 = Override then syntax_error ();
         (_5, Mutable, Cfk_virtual _7), _2 )
-# 38651 "parsing/parser.ml"
+# 37691 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38712,27 +37752,19 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 38729 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 37761 "parsing/parser.ml"
           
         in
         
-# 1329 "parsing/parser.mly"
+# 1319 "parsing/parser.mly"
       ( if _1 = Override then syntax_error ();
         (_5, _4, Cfk_virtual _7), _2 )
-# 38736 "parsing/parser.ml"
+# 37768 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38791,26 +37823,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 38808 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 37832 "parsing/parser.ml"
           
         in
         
-# 1332 "parsing/parser.mly"
+# 1322 "parsing/parser.mly"
       ( (_4, _3, Cfk_concrete (_1, _6)), _2 )
-# 38814 "parsing/parser.ml"
+# 37838 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38875,20 +37899,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 38892 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 37908 "parsing/parser.ml"
           
         in
         let _startpos__4_ = _startpos__10_ in
@@ -38905,11 +37921,11 @@ module Tables = struct
               _startpos__4_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 1335 "parsing/parser.mly"
+# 1325 "parsing/parser.mly"
       ( let e = mkexp_constraint ~loc:_sloc _7 _5 in
         (_4, _3, Cfk_concrete (_1, e)), _2
       )
-# 38913 "parsing/parser.ml"
+# 37929 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -38966,31 +37982,23 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 38983 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 37991 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__6_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2218 "parsing/parser.mly"
+# 2208 "parsing/parser.mly"
       ( let (ext, attrs) = _2 in
         let docs = symbol_docs _sloc in
         Val.mk _3 _5 ~attrs:(attrs@_6) ~loc:(make_loc _sloc) ~docs, ext )
-# 38994 "parsing/parser.ml"
+# 38002 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -39042,26 +38050,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 39059 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 38059 "parsing/parser.ml"
           
         in
         
-# 1446 "parsing/parser.mly"
+# 1436 "parsing/parser.mly"
       ( _3, _2, Virtual, _5 )
-# 39065 "parsing/parser.ml"
+# 38065 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -39113,26 +38113,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 39130 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 38122 "parsing/parser.ml"
           
         in
         
-# 1448 "parsing/parser.mly"
+# 1438 "parsing/parser.mly"
       ( _3, Mutable, _2, _5 )
-# 39136 "parsing/parser.ml"
+# 38128 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -39172,26 +38164,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 39189 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 38173 "parsing/parser.ml"
           
         in
         
-# 1450 "parsing/parser.mly"
+# 1440 "parsing/parser.mly"
       ( _1, Immutable, Concrete, _3 )
-# 39195 "parsing/parser.ml"
+# 38179 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -39207,9 +38191,9 @@ module Tables = struct
         let _startpos = _menhir_stack.MenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : (Asttypes.virtual_flag) = 
-# 2884 "parsing/parser.mly"
+# 2874 "parsing/parser.mly"
                                                 ( Concrete )
-# 39213 "parsing/parser.ml"
+# 38197 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -39232,9 +38216,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.virtual_flag) = 
-# 2885 "parsing/parser.mly"
+# 2875 "parsing/parser.mly"
                                                 ( Virtual )
-# 39238 "parsing/parser.ml"
+# 38222 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -39291,27 +38275,19 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 39308 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 38284 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__6_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2478 "parsing/parser.mly"
+# 2468 "parsing/parser.mly"
       ( let lident = Location.{ _3 with txt = Longident.last _3.txt } in
         Pwith_type
           (_3,
@@ -39321,7 +38297,7 @@ module Tables = struct
               ~manifest:_5
               ~priv:_4
               ~loc:(make_loc _sloc))) )
-# 39325 "parsing/parser.ml"
+# 38301 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -39372,27 +38348,19 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 39389 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 38357 "parsing/parser.ml"
           
         in
         let _endpos = _endpos__5_ in
         let _symbolstartpos = _startpos__1_ in
         let _sloc = (_symbolstartpos, _endpos) in
         
-# 2491 "parsing/parser.mly"
+# 2481 "parsing/parser.mly"
       ( let lident = Location.{ _3 with txt = Longident.last _3.txt } in
         Pwith_typesubst
          (_3,
@@ -39400,7 +38368,7 @@ module Tables = struct
               ~params:_2
               ~manifest:_5
               ~loc:(make_loc _sloc))) )
-# 39404 "parsing/parser.ml"
+# 38372 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -39445,20 +38413,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__11_ in
           let _1 = _11 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 39462 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 38422 "parsing/parser.ml"
           
         in
         let _2 =
@@ -39466,26 +38426,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 39483 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 38435 "parsing/parser.ml"
           
         in
         
-# 2499 "parsing/parser.mly"
+# 2489 "parsing/parser.mly"
       ( Pwith_module (_2, _4) )
-# 39489 "parsing/parser.ml"
+# 38441 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -39530,20 +38482,12 @@ module Tables = struct
           let _startpos__1_ = _startpos__11_ in
           let _1 = _11 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 39547 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 38491 "parsing/parser.ml"
           
         in
         let _2 =
@@ -39551,26 +38495,18 @@ module Tables = struct
           let _startpos__1_ = _startpos__10_ in
           let _1 = _10 in
           let _endpos = _endpos__1_ in
-          let _startpos = _startpos__1_ in
-          let _loc = (_startpos, _endpos) in
+          let _symbolstartpos = _startpos__1_ in
+          let _sloc = (_symbolstartpos, _endpos) in
           
 # 728 "parsing/parser.mly"
-    (
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs _1 _loc )
-# 39568 "parsing/parser.ml"
+    ( mkrhs _1 _sloc )
+# 38504 "parsing/parser.ml"
           
         in
         
-# 2501 "parsing/parser.mly"
+# 2491 "parsing/parser.mly"
       ( Pwith_modsubst (_2, _4) )
-# 39574 "parsing/parser.ml"
+# 38510 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -39593,9 +38529,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Parsetree.with_constraint list) = 
-# 2472 "parsing/parser.mly"
+# 2462 "parsing/parser.mly"
                                                 ( [_1] )
-# 39599 "parsing/parser.ml"
+# 38535 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -39630,9 +38566,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : (Parsetree.with_constraint list) = 
-# 2473 "parsing/parser.mly"
+# 2463 "parsing/parser.mly"
                                                 ( _3 :: _1 )
-# 39636 "parsing/parser.ml"
+# 38572 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -39655,9 +38591,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : (Asttypes.private_flag) = 
-# 2504 "parsing/parser.mly"
+# 2494 "parsing/parser.mly"
                    ( Public )
-# 39661 "parsing/parser.ml"
+# 38597 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -39686,9 +38622,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : (Asttypes.private_flag) = 
-# 2505 "parsing/parser.mly"
+# 2495 "parsing/parser.mly"
                    ( Private )
-# 39692 "parsing/parser.ml"
+# 38628 "parsing/parser.ml"
          in
         {
           MenhirLib.EngineTypes.state = _menhir_s;
@@ -39719,7 +38655,7 @@ let use_file =
     (Obj.magic (MenhirInterpreter.entry 1662 lexer lexbuf) : (
 # 710 "parsing/parser.mly"
       (Parsetree.toplevel_phrase list)
-# 39723 "parsing/parser.ml"
+# 38659 "parsing/parser.ml"
     ))
 
 and toplevel_phrase =
@@ -39727,7 +38663,7 @@ and toplevel_phrase =
     (Obj.magic (MenhirInterpreter.entry 1637 lexer lexbuf) : (
 # 708 "parsing/parser.mly"
       (Parsetree.toplevel_phrase)
-# 39731 "parsing/parser.ml"
+# 38667 "parsing/parser.ml"
     ))
 
 and parse_pattern =
@@ -39735,7 +38671,7 @@ and parse_pattern =
     (Obj.magic (MenhirInterpreter.entry 1633 lexer lexbuf) : (
 # 716 "parsing/parser.mly"
       (Parsetree.pattern)
-# 39739 "parsing/parser.ml"
+# 38675 "parsing/parser.ml"
     ))
 
 and parse_expression =
@@ -39743,7 +38679,7 @@ and parse_expression =
     (Obj.magic (MenhirInterpreter.entry 1629 lexer lexbuf) : (
 # 714 "parsing/parser.mly"
       (Parsetree.expression)
-# 39747 "parsing/parser.ml"
+# 38683 "parsing/parser.ml"
     ))
 
 and parse_core_type =
@@ -39751,7 +38687,7 @@ and parse_core_type =
     (Obj.magic (MenhirInterpreter.entry 1625 lexer lexbuf) : (
 # 712 "parsing/parser.mly"
       (Parsetree.core_type)
-# 39755 "parsing/parser.ml"
+# 38691 "parsing/parser.ml"
     ))
 
 and interface =
@@ -39759,7 +38695,7 @@ and interface =
     (Obj.magic (MenhirInterpreter.entry 1621 lexer lexbuf) : (
 # 706 "parsing/parser.mly"
       (Parsetree.signature)
-# 39763 "parsing/parser.ml"
+# 38699 "parsing/parser.ml"
     ))
 
 and implementation =
@@ -39767,7 +38703,7 @@ and implementation =
     (Obj.magic (MenhirInterpreter.entry 0 lexer lexbuf) : (
 # 704 "parsing/parser.mly"
       (Parsetree.structure)
-# 39771 "parsing/parser.ml"
+# 38707 "parsing/parser.ml"
     ))
 
 module Incremental = struct
@@ -39777,7 +38713,7 @@ module Incremental = struct
       (Obj.magic (MenhirInterpreter.start 1662 initial_position) : (
 # 710 "parsing/parser.mly"
       (Parsetree.toplevel_phrase list)
-# 39781 "parsing/parser.ml"
+# 38717 "parsing/parser.ml"
       ) MenhirInterpreter.checkpoint)
   
   and toplevel_phrase =
@@ -39785,7 +38721,7 @@ module Incremental = struct
       (Obj.magic (MenhirInterpreter.start 1637 initial_position) : (
 # 708 "parsing/parser.mly"
       (Parsetree.toplevel_phrase)
-# 39789 "parsing/parser.ml"
+# 38725 "parsing/parser.ml"
       ) MenhirInterpreter.checkpoint)
   
   and parse_pattern =
@@ -39793,7 +38729,7 @@ module Incremental = struct
       (Obj.magic (MenhirInterpreter.start 1633 initial_position) : (
 # 716 "parsing/parser.mly"
       (Parsetree.pattern)
-# 39797 "parsing/parser.ml"
+# 38733 "parsing/parser.ml"
       ) MenhirInterpreter.checkpoint)
   
   and parse_expression =
@@ -39801,7 +38737,7 @@ module Incremental = struct
       (Obj.magic (MenhirInterpreter.start 1629 initial_position) : (
 # 714 "parsing/parser.mly"
       (Parsetree.expression)
-# 39805 "parsing/parser.ml"
+# 38741 "parsing/parser.ml"
       ) MenhirInterpreter.checkpoint)
   
   and parse_core_type =
@@ -39809,7 +38745,7 @@ module Incremental = struct
       (Obj.magic (MenhirInterpreter.start 1625 initial_position) : (
 # 712 "parsing/parser.mly"
       (Parsetree.core_type)
-# 39813 "parsing/parser.ml"
+# 38749 "parsing/parser.ml"
       ) MenhirInterpreter.checkpoint)
   
   and interface =
@@ -39817,7 +38753,7 @@ module Incremental = struct
       (Obj.magic (MenhirInterpreter.start 1621 initial_position) : (
 # 706 "parsing/parser.mly"
       (Parsetree.signature)
-# 39821 "parsing/parser.ml"
+# 38757 "parsing/parser.ml"
       ) MenhirInterpreter.checkpoint)
   
   and implementation =
@@ -39825,17 +38761,17 @@ module Incremental = struct
       (Obj.magic (MenhirInterpreter.start 0 initial_position) : (
 # 704 "parsing/parser.mly"
       (Parsetree.structure)
-# 39829 "parsing/parser.ml"
+# 38765 "parsing/parser.ml"
       ) MenhirInterpreter.checkpoint)
   
 end
 
-# 3017 "parsing/parser.mly"
+# 3007 "parsing/parser.mly"
   
 
-# 39837 "parsing/parser.ml"
+# 38773 "parsing/parser.ml"
 
 # 233 "menhir/standard.mly"
   
 
-# 39842 "parsing/parser.ml"
+# 38778 "parsing/parser.ml"

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -725,21 +725,11 @@ The precedences must be listed from low to high.
 %inline extra_text(symb): symb { extra_text $startpos $endpos $1 };
 
 %inline mkrhs(symb): symb
-    {
-      (* Semantically we could use $symbolstartpos instead of $startpos
-         here, but the code comes from calls to (Parsing.rhs_loc p) for
-         some position p, which rather corresponds to
-         $startpos, so we kept it for compatibility.
-
-         I do not know if mkrhs is ever used in a situation where $startpos
-         and $symbolpos do not coincide.  *)
-      mkrhs $1 $loc }
+    { mkrhs $1 $sloc }
 ;
 
 %inline op(symb): symb
-   { (* see the mkrhs comment above
-        for the choice of $startpos over $symbolstartpos *)
-     mkoperator ~loc:$loc $1 }
+   { mkoperator ~loc:$sloc $1 }
 
 %inline mkloc(symb): symb
     { mkloc $1 (make_loc $sloc) }
@@ -957,7 +947,7 @@ structure_item:
       { val_of_let_bindings ~loc:$sloc $1 }
   | structure_item_with_ext
       { let item, ext = $1 in
-        wrap_str_ext ~loc:$loc (mkstr ~loc:$loc item) ext }
+        wrap_str_ext ~loc:$sloc (mkstr ~loc:$sloc item) ext }
   | item_extension post_item_attributes
       { let docs = symbol_docs $sloc in
         mkstr ~loc:$sloc (Pstr_extension ($1, (add_docs_attrs docs $2))) }
@@ -1081,7 +1071,7 @@ signature_nodoc:
 signature_item:
   | signature_item_with_ext
       { let item, ext = $1 in
-        wrap_sig_ext ~loc:$loc (mksig ~loc:$sloc item) ext }
+        wrap_sig_ext ~loc:$sloc (mksig ~loc:$sloc item) ext }
   | item_extension post_item_attributes
       { let docs = symbol_docs $sloc in
         mksig ~loc:$sloc (Psig_extension ($1, (add_docs_attrs docs $2))) }
@@ -1896,7 +1886,7 @@ lident_list:
   | mkrhs(LIDENT) lident_list         { $1 :: $2 }
 ;
 %inline let_ident:
-    val_ident { mkpatvar ~loc:$loc $1 };
+    val_ident { mkpatvar ~loc:$sloc $1 };
 let_binding_body:
     let_ident strict_binding
       { ($1, $2) }


### PR DESCRIPTION
Menhir has two keywords to describe "the current source position",
$loc and $sloc. $sloc is more precise (it is included within $loc),
and the two differ only when the production starts with empty symbols,
and the difference only spans over whitespace.

We originally used $loc by default to emulate ocamlyacc behavior,
but $sloc is generally preferable, so this PR converts all locations
to use $sloc.

(Note: the location-of-a-symbol keyword remains $loc(...), for example
$loc($1) or $loc(foo), there is no $sloc version of those.)

I have tested this PR using #2030, and it does not, in fact, change any parse location in the compiler distribution. On the contrary, the converse change (turning all $sloc into $loc) produces a lot of location changes, as expected.

This proposed change was mentioned/discussed in #2029 and, more importantly, in https://github.com/ocaml/ocaml/pull/2016#issuecomment-418367879.