### PR TITLE
handle `-stop-after parsing` when processing `.mli` files

### DIFF
--- a/Changes
+++ b/Changes
@@ -173,8 +173,8 @@ Working version
   (Xavier Clerc, review by Gabriel Scherer, Sébastien Hinderer, and
    Xavier Leroy)
 
-- GPR#1945: new "-stop-after parse" option to stop compilation
-  after the parsing pass
+- GPR#1945, GPR#2032: new "-stop-after [parsing|typing]" option
+  to stop compilation after the parsing or typing pass
   (Gabriel Scherer, review by Jérémie Dimino)
 
 - GRP#1953: Add locations to attributes in the parsetree.

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -80,9 +80,11 @@ let interface ~tool_name ~sourcefile ~outputprefix =
     init ppf_dump ~init_path:false ~tool_name ~sourcefile ~outputprefix
   in
   let ast = parse_intf info in
-  let tsg = typecheck_intf info ast in
-  if not !Clflags.print_types then begin
-    emit_signature info ast tsg
+  if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
+    let tsg = typecheck_intf info ast in
+    if not !Clflags.print_types then begin
+      emit_signature info ast tsg
+    end
   end
 
 

--- a/testsuite/tests/tool-ocamlc-stop-after/ocamltests
+++ b/testsuite/tests/tool-ocamlc-stop-after/ocamltests
@@ -1,0 +1,3 @@
+stop_after_parsing_impl.ml
+stop_after_parsing_intf.mli
+stop_after_typing_impl.ml

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_impl.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_impl.compilers.reference
@@ -1,0 +1,36 @@
+[
+  structure_item (stop_after_parsing_impl.ml[12,306+0]..[12,306+24])
+    Pstr_value Nonrec
+    [
+      <def>
+        pattern (stop_after_parsing_impl.ml[12,306+4]..[12,306+5])
+          Ppat_any
+        expression (stop_after_parsing_impl.ml[12,306+8]..[12,306+24])
+          Pexp_apply
+          expression (stop_after_parsing_impl.ml[12,306+21]..[12,306+22])
+            Pexp_ident "+" (stop_after_parsing_impl.ml[12,306+21]..[12,306+22])
+          [
+            <arg>
+            Nolabel
+              expression (stop_after_parsing_impl.ml[12,306+8]..[12,306+20])
+                Pexp_apply
+                expression (stop_after_parsing_impl.ml[12,306+11]..[12,306+12])
+                  Pexp_ident "+" (stop_after_parsing_impl.ml[12,306+11]..[12,306+12])
+                [
+                  <arg>
+                  Nolabel
+                    expression (stop_after_parsing_impl.ml[12,306+9]..[12,306+10])
+                      Pexp_constant PConst_int (1,None)
+                  <arg>
+                  Nolabel
+                    expression (stop_after_parsing_impl.ml[12,306+13]..[12,306+19])
+                      Pexp_constant PConst_string("true",None)
+                ]
+            <arg>
+            Nolabel
+              expression (stop_after_parsing_impl.ml[12,306+23]..[12,306+24])
+                Pexp_ident "x" (stop_after_parsing_impl.ml[12,306+23]..[12,306+24])
+          ]
+    ]
+]
+

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_impl.ml
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_impl.ml
@@ -1,0 +1,12 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+    flags = "-stop-after parsing -dparsetree"
+    ocamlc_byte_exit_status = "0"
+*** check-ocamlc.byte-output
+*)
+
+(* we intentionally write ill-typed output;
+   if `-stop-after parsing` was not supported properly,
+   the test would fail with an error *)
+let _ = (1 + "true") + x

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_intf.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_intf.compilers.reference
@@ -1,0 +1,10 @@
+[
+  signature_item (stop_after_parsing_intf.mli[12,306+0]..[12,306+61])
+    Psig_value
+    value_description "x" (stop_after_parsing_intf.mli[12,306+4]..[12,306+5]) (stop_after_parsing_intf.mli[12,306+0]..[12,306+61])
+      core_type (stop_after_parsing_intf.mli[12,306+8]..[12,306+61])
+        Ptyp_constr "Module_that_does_not_exists.type_that_does_not_exists" (stop_after_parsing_intf.mli[12,306+8]..[12,306+61])
+        []
+      []
+]
+

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_intf.mli
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_parsing_intf.mli
@@ -1,0 +1,12 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+    flags = "-stop-after parsing -dparsetree"
+    ocamlc_byte_exit_status = "0"
+*** check-ocamlc.byte-output
+*)
+
+(* we intentionally write ill-typed output;
+   if `-stop-after parsing` was not supported properly,
+   the test would fail with an error *)
+val x : Module_that_does_not_exists.type_that_does_not_exists

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.compilers.reference
@@ -1,0 +1,18 @@
+[
+  structure_item (stop_after_typing_impl.ml[13,349+0]..stop_after_typing_impl.ml[13,349+37])
+    Tstr_primitive
+    value_description apply/1002 (stop_after_typing_impl.ml[13,349+0]..stop_after_typing_impl.ml[13,349+37])
+      core_type (stop_after_typing_impl.ml[13,349+16]..stop_after_typing_impl.ml[13,349+26])
+        Ttyp_arrow
+        Nolabel
+        core_type (stop_after_typing_impl.ml[13,349+16]..stop_after_typing_impl.ml[13,349+19])
+          Ttyp_constr "int/1"
+          []
+        core_type (stop_after_typing_impl.ml[13,349+23]..stop_after_typing_impl.ml[13,349+26])
+          Ttyp_constr "int/1"
+          []
+      [
+        "%apply"
+      ]
+]
+

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.ml
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.ml
@@ -1,0 +1,13 @@
+(* TEST
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+    flags = "-stop-after typing -dtypedtree"
+    ocamlc_byte_exit_status = "0"
+*** check-ocamlc.byte-output
+*)
+
+(* we intentionally write an output that is type-correct
+   but will be rejected before bytecode compilation
+   due to the incorrect type given to the %apply
+   compiler primitive. *)
+external apply: int -> int = "%apply"


### PR DESCRIPTION
This is arguably a bug in the original implementation: only `Compiler_common.implementation` was made to support `-stop-after parsing`, not `Compiler_common.interface`.

This PR also adds a testsuite for `stop-after` options in `testsuite/tests/tool-ocamlc-stop-after`.