### PR TITLE
 Improve the formatting of sub-errors in error/warning reports 

### DIFF
--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -426,11 +426,11 @@ type report_printer = {
 }
 
 let batch_mode_printer : report_printer =
-  let pp_loc ppf loc = Format.fprintf ppf "%a:@," print_loc loc in
+  let pp_loc ppf loc = Format.fprintf ppf "%a:@ " print_loc loc in
   let pp_txt ppf txt = Format.fprintf ppf "@[%t@]" txt in
   let pp self ppf report =
     setup_colors ();
-    Format.fprintf ppf "@[<v>%a%a: @[<v>%a%a@]@]@."
+    Format.fprintf ppf "@[<v>%a%a: %a%a@]@."
       (self.pp_main_loc self report) report.main.loc
       (self.pp_report_kind self report) report.kind
       (self.pp_main_txt self report) report.main.txt
@@ -454,7 +454,7 @@ let batch_mode_printer : report_printer =
     ) msgs
   in
   let pp_submsg self report ppf { loc; txt } =
-    Format.fprintf ppf "%a%a"
+    Format.fprintf ppf "@[<hv 2>%a%a@]"
       (self.pp_submsg_loc self report) loc
       (self.pp_submsg_txt self report) txt
   in
@@ -493,7 +493,7 @@ let dumb_toplevel_printer (lb: lexbuf): report_printer =
   let pp_loc _ _ ppf loc =
     let highlight ppf loc =
       if is_toplevel_loc loc then highlight_dumb lb ppf [loc] in
-    Format.fprintf ppf "%a:@,%a" print_loc loc highlight loc
+    Format.fprintf ppf "@[<v>%a:@,%a@]" print_loc loc highlight loc
   in
   { batch_mode_printer with pp; pp_main_loc = pp_loc; pp_submsg_loc = pp_loc }
 

--- a/testsuite/tests/formatting/errors_batch.ml
+++ b/testsuite/tests/formatting/errors_batch.ml
@@ -20,6 +20,11 @@ let () =
     loc_end = { pos with pos_lnum = 20; pos_bol = 0; pos_cnum = 8 };
     loc_ghost = false
   } in
+  let loc3 = {
+    loc_start = { pos with pos_lnum = 20; pos_bol = 0; pos_cnum = 6 };
+    loc_end = { pos with pos_lnum = 20; pos_bol = 0; pos_cnum = 8 };
+    loc_ghost = false
+  } in
   let report = {
     kind = Report_error;
     main = msg ~loc:loc1 "%a" Format.pp_print_text
@@ -27,6 +32,9 @@ let () =
          It is very long and should wrap across several lines.";
     sub = [
       msg ~loc:loc2 "A located first sub-message.";
+      msg ~loc:loc3 "%a" Format.pp_print_text
+        "Longer sub-messages that do not fit on the \
+         same line as the location get indented.";
       msg "@[<v>This second sub-message does not have \
            a location;@,ghost locations of submessages are \
            not printed.@]";

--- a/testsuite/tests/formatting/errors_batch.reference
+++ b/testsuite/tests/formatting/errors_batch.reference
@@ -1,7 +1,6 @@
 File "hello.ml", line 18, characters 20-27:
 Error: These are the contents of the main error message. It is very long and
        should wrap across several lines.
-       File "hello.ml", line 20, characters 4-8:
-       A located first sub-message.
-       This second sub-message does not have a location;
-       ghost locations of submessages are not printed.
+File "hello.ml", line 20, characters 4-8: A located first sub-message.
+This second sub-message does not have a location;
+ghost locations of submessages are not printed.

--- a/testsuite/tests/formatting/errors_batch.reference
+++ b/testsuite/tests/formatting/errors_batch.reference
@@ -2,5 +2,8 @@ File "hello.ml", line 18, characters 20-27:
 Error: These are the contents of the main error message. It is very long and
        should wrap across several lines.
 File "hello.ml", line 20, characters 4-8: A located first sub-message.
+File "hello.ml", line 20, characters 6-8:
+  Longer sub-messages that do not fit on the same line as the location get
+  indented.
 This second sub-message does not have a location;
 ghost locations of submessages are not printed.

--- a/testsuite/tests/parse-errors/unclosed_class_signature.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_class_signature.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_class_signature.mli", line 11, characters 0-0:
 Error: Syntax error: 'end' expected
-       File "unclosed_class_signature.mli", line 10, characters 10-16:
-       This 'object' might be unmatched
+File "unclosed_class_signature.mli", line 10, characters 10-16:
+  This 'object' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_class_simpl_expr1.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_class_simpl_expr1.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_class_simpl_expr1.ml", line 10, characters 0-0:
 Error: Syntax error: 'end' expected
-       File "unclosed_class_simpl_expr1.ml", line 8, characters 10-16:
-       This 'object' might be unmatched
+File "unclosed_class_simpl_expr1.ml", line 8, characters 10-16:
+  This 'object' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_class_simpl_expr2.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_class_simpl_expr2.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_class_simpl_expr2.ml", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-       File "unclosed_class_simpl_expr2.ml", line 8, characters 10-11:
-       This '(' might be unmatched
+File "unclosed_class_simpl_expr2.ml", line 8, characters 10-11:
+  This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_class_simpl_expr3.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_class_simpl_expr3.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_class_simpl_expr3.ml", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-       File "unclosed_class_simpl_expr3.ml", line 8, characters 10-11:
-       This '(' might be unmatched
+File "unclosed_class_simpl_expr3.ml", line 8, characters 10-11:
+  This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_object.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_object.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_object.ml", line 11, characters 0-0:
 Error: Syntax error: 'end' expected
-       File "unclosed_object.ml", line 10, characters 8-14:
-       This 'object' might be unmatched
+File "unclosed_object.ml", line 10, characters 8-14:
+  This 'object' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr1.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr1.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_paren_module_expr1.ml", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-       File "unclosed_paren_module_expr1.ml", line 8, characters 11-12:
-       This '(' might be unmatched
+File "unclosed_paren_module_expr1.ml", line 8, characters 11-12:
+  This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr2.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr2.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_paren_module_expr2.ml", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-       File "unclosed_paren_module_expr2.ml", line 8, characters 11-12:
-       This '(' might be unmatched
+File "unclosed_paren_module_expr2.ml", line 8, characters 11-12:
+  This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr3.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr3.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_paren_module_expr3.ml", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-       File "unclosed_paren_module_expr3.ml", line 8, characters 11-12:
-       This '(' might be unmatched
+File "unclosed_paren_module_expr3.ml", line 8, characters 11-12:
+  This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr4.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr4.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_paren_module_expr4.ml", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-       File "unclosed_paren_module_expr4.ml", line 8, characters 11-12:
-       This '(' might be unmatched
+File "unclosed_paren_module_expr4.ml", line 8, characters 11-12:
+  This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_expr5.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_expr5.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_paren_module_expr5.ml", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-       File "unclosed_paren_module_expr5.ml", line 8, characters 11-12:
-       This '(' might be unmatched
+File "unclosed_paren_module_expr5.ml", line 8, characters 11-12:
+  This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_paren_module_type.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_paren_module_type.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_paren_module_type.mli", line 9, characters 0-0:
 Error: Syntax error: ')' expected
-       File "unclosed_paren_module_type.mli", line 8, characters 11-12:
-       This '(' might be unmatched
+File "unclosed_paren_module_type.mli", line 8, characters 11-12:
+  This '(' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_sig.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_sig.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_sig.mli", line 10, characters 0-0:
 Error: Syntax error: 'end' expected
-       File "unclosed_sig.mli", line 8, characters 11-14:
-       This 'sig' might be unmatched
+File "unclosed_sig.mli", line 8, characters 11-14:
+  This 'sig' might be unmatched

--- a/testsuite/tests/parse-errors/unclosed_simple_expr.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_simple_expr.compilers.reference
@@ -2,185 +2,185 @@ Line 5, characters 5-7:
   (3; 2;;
        ^^
 Error: Syntax error: ')' expected
-       Line 5, characters 0-1:
-         (3; 2;;
-         ^
-       This '(' might be unmatched
+Line 5, characters 0-1:
+  (3; 2;;
+  ^
+This '(' might be unmatched
 Line 2, characters 10-12:
   begin 3; 2;;
             ^^
 Error: Syntax error: 'end' expected
-       Line 2, characters 0-5:
-         begin 3; 2;;
-         ^^^^^
-       This 'begin' might be unmatched
+Line 2, characters 0-5:
+  begin 3; 2;;
+  ^^^^^
+This 'begin' might be unmatched
 Line 2, characters 10-12:
   List.(3; 2;;
             ^^
 Error: Syntax error: ')' expected
-       Line 2, characters 5-6:
-         List.(3; 2;;
-              ^
-       This '(' might be unmatched
+Line 2, characters 5-6:
+  List.(3; 2;;
+       ^
+This '(' might be unmatched
 Line 2, characters 17-19:
   simple_expr.(3; 2;;
                    ^^
 Error: Syntax error: ')' expected
-       Line 2, characters 12-13:
-         simple_expr.(3; 2;;
-                     ^
-       This '(' might be unmatched
+Line 2, characters 12-13:
+  simple_expr.(3; 2;;
+              ^
+This '(' might be unmatched
 Line 2, characters 17-19:
   simple_expr.[3; 2;;
                    ^^
 Error: Syntax error: ']' expected
-       Line 2, characters 12-13:
-         simple_expr.[3; 2;;
-                     ^
-       This '[' might be unmatched
+Line 2, characters 12-13:
+  simple_expr.[3; 2;;
+              ^
+This '[' might be unmatched
 Line 2, characters 15-17:
   simple_expr.%[3;;
                  ^^
 Error: Syntax error: ']' expected
-       Line 2, characters 13-14:
-         simple_expr.%[3;;
-                      ^
-       This '[' might be unmatched
+Line 2, characters 13-14:
+  simple_expr.%[3;;
+               ^
+This '[' might be unmatched
 Line 2, characters 15-17:
   simple_expr.%(3;;
                  ^^
 Error: Syntax error: ')' expected
-       Line 2, characters 13-14:
-         simple_expr.%(3;;
-                      ^
-       This '(' might be unmatched
+Line 2, characters 13-14:
+  simple_expr.%(3;;
+               ^
+This '(' might be unmatched
 Line 2, characters 15-17:
   simple_expr.%{3;;
                  ^^
 Error: Syntax error: '}' expected
-       Line 2, characters 13-14:
-         simple_expr.%{3;;
-                      ^
-       This '{' might be unmatched
+Line 2, characters 13-14:
+  simple_expr.%{3;;
+               ^
+This '{' might be unmatched
 Line 2, characters 11-13:
   foo.Bar.%[3;;
              ^^
 Error: Syntax error: ']' expected
-       Line 2, characters 9-10:
-         foo.Bar.%[3;;
-                  ^
-       This '[' might be unmatched
+Line 2, characters 9-10:
+  foo.Bar.%[3;;
+           ^
+This '[' might be unmatched
 Line 2, characters 11-13:
   foo.Bar.%(3;;
              ^^
 Error: Syntax error: ')' expected
-       Line 2, characters 9-10:
-         foo.Bar.%(3;;
-                  ^
-       This '(' might be unmatched
+Line 2, characters 9-10:
+  foo.Bar.%(3;;
+           ^
+This '(' might be unmatched
 Line 2, characters 11-13:
   foo.Bar.%{3;;
              ^^
 Error: Syntax error: '}' expected
-       Line 2, characters 9-10:
-         foo.Bar.%{3;;
-                  ^
-       This '{' might be unmatched
+Line 2, characters 9-10:
+  foo.Bar.%{3;;
+           ^
+This '{' might be unmatched
 Line 2, characters 17-19:
   simple_expr.{3, 2;;
                    ^^
 Error: Syntax error: '}' expected
-       Line 2, characters 12-13:
-         simple_expr.{3, 2;;
-                     ^
-       This '{' might be unmatched
+Line 2, characters 12-13:
+  simple_expr.{3, 2;;
+              ^
+This '{' might be unmatched
 Line 2, characters 10-12:
   { x = 3; y;;
             ^^
 Error: Syntax error: '}' expected
-       Line 2, characters 0-1:
-         { x = 3; y;;
-         ^
-       This '{' might be unmatched
+Line 2, characters 0-1:
+  { x = 3; y;;
+  ^
+This '{' might be unmatched
 Line 2, characters 16-18:
   List.{ x = 3; y ;;
                   ^^
 Error: Syntax error: '}' expected
-       Line 2, characters 5-6:
-         List.{ x = 3; y ;;
-              ^
-       This '{' might be unmatched
+Line 2, characters 5-6:
+  List.{ x = 3; y ;;
+       ^
+This '{' might be unmatched
 Line 2, characters 7-9:
   [| 3; 2;;
          ^^
 Error: Syntax error: '|]' expected
-       Line 2, characters 0-2:
-         [| 3; 2;;
-         ^^
-       This '[|' might be unmatched
+Line 2, characters 0-2:
+  [| 3; 2;;
+  ^^
+This '[|' might be unmatched
 Line 2, characters 11-13:
   List.[|3; 2;;
              ^^
 Error: Syntax error: '|]' expected
-       Line 2, characters 5-7:
-         List.[|3; 2;;
-              ^^
-       This '[|' might be unmatched
+Line 2, characters 5-7:
+  List.[|3; 2;;
+       ^^
+This '[|' might be unmatched
 Line 2, characters 5-7:
   [3; 2;;
        ^^
 Error: Syntax error: ']' expected
-       Line 2, characters 0-1:
-         [3; 2;;
-         ^
-       This '[' might be unmatched
+Line 2, characters 0-1:
+  [3; 2;;
+  ^
+This '[' might be unmatched
 Line 2, characters 10-12:
   List.[3; 2;;
             ^^
 Error: Syntax error: ']' expected
-       Line 2, characters 5-6:
-         List.[3; 2;;
-              ^
-       This '[' might be unmatched
+Line 2, characters 5-6:
+  List.[3; 2;;
+       ^
+This '[' might be unmatched
 Line 2, characters 13-15:
   {< x = 3; y; ;;
                ^^
 Error: Syntax error: '>}' expected
-       Line 2, characters 0-2:
-         {< x = 3; y; ;;
-         ^^
-       This '{<' might be unmatched
+Line 2, characters 0-2:
+  {< x = 3; y; ;;
+  ^^
+This '{<' might be unmatched
 Line 2, characters 17-19:
   List.{< x = 3; y ;;
                    ^^
 Error: Syntax error: '>}' expected
-       Line 2, characters 5-7:
-         List.{< x = 3; y ;;
-              ^^
-       This '{<' might be unmatched
+Line 2, characters 5-7:
+  List.{< x = 3; y ;;
+       ^^
+This '{<' might be unmatched
 Line 2, characters 20-22:
   (module struct end :;;
                       ^^
 Error: Syntax error: ')' expected
-       Line 2, characters 0-1:
-         (module struct end :;;
-         ^
-       This '(' might be unmatched
+Line 2, characters 0-1:
+  (module struct end :;;
+  ^
+This '(' might be unmatched
 Line 2, characters 25-27:
   List.(module struct end :;;
                            ^^
 Error: Syntax error: ')' expected
-       Line 2, characters 5-6:
-         List.(module struct end :;;
-              ^
-       This '(' might be unmatched
+Line 2, characters 5-6:
+  List.(module struct end :;;
+       ^
+This '(' might be unmatched
 
 Line 2, characters 2-3:
   (=;
     ^
 Error: Syntax error: ')' expected
-       Line 2, characters 0-1:
-         (=;
-         ^
-       This '(' might be unmatched
+Line 2, characters 0-1:
+  (=;
+  ^
+This '(' might be unmatched
 

--- a/testsuite/tests/parse-errors/unclosed_simple_pattern.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_simple_pattern.compilers.reference
@@ -2,26 +2,26 @@ Line 7, characters 0-2:
   ;;
   ^^
 Error: Syntax error: ')' expected
-       Line 6, characters 9-10:
-           | List.(_
-                  ^
-       This '(' might be unmatched
+Line 6, characters 9-10:
+    | List.(_
+           ^
+This '(' might be unmatched
 Line 4, characters 0-2:
   ;;
   ^^
 Error: Syntax error: ')' expected
-       Line 3, characters 4-5:
-           | (_
-             ^
-       This '(' might be unmatched
+Line 3, characters 4-5:
+    | (_
+      ^
+This '(' might be unmatched
 Line 4, characters 0-2:
   ;;
   ^^
 Error: Syntax error: ')' expected
-       Line 3, characters 4-5:
-           | (_ : int
-             ^
-       This '(' might be unmatched
+Line 3, characters 4-5:
+    | (_ : int
+      ^
+This '(' might be unmatched
 Line 6, characters 18-25:
     | (module Foo : sig end
                     ^^^^^^^
@@ -30,24 +30,24 @@ Line 7, characters 0-2:
   ;;
   ^^
 Error: Syntax error: '}' expected
-       Line 6, characters 4-5:
-           | { foo; bar;
-             ^
-       This '{' might be unmatched
+Line 6, characters 4-5:
+    | { foo; bar;
+      ^
+This '{' might be unmatched
 Line 4, characters 0-2:
   ;;
   ^^
 Error: Syntax error: ']' expected
-       Line 3, characters 4-5:
-           | [ 1; 2;
-             ^
-       This '[' might be unmatched
+Line 3, characters 4-5:
+    | [ 1; 2;
+      ^
+This '[' might be unmatched
 Line 4, characters 0-2:
   ;;
   ^^
 Error: Syntax error: '|]' expected
-       Line 3, characters 4-6:
-           | [| 3; 4;
-             ^^
-       This '[|' might be unmatched
+Line 3, characters 4-6:
+    | [| 3; 4;
+      ^^
+This '[|' might be unmatched
 

--- a/testsuite/tests/parse-errors/unclosed_struct.compilers.reference
+++ b/testsuite/tests/parse-errors/unclosed_struct.compilers.reference
@@ -1,4 +1,4 @@
 File "unclosed_struct.ml", line 10, characters 0-0:
 Error: Syntax error: 'end' expected
-       File "unclosed_struct.ml", line 8, characters 11-17:
-       This 'struct' might be unmatched
+File "unclosed_struct.ml", line 8, characters 11-17:
+  This 'struct' might be unmatched

--- a/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
+++ b/testsuite/tests/tool-toplevel/error_highlighting.compilers.reference
@@ -7,18 +7,18 @@ Line 2, characters 15-17:
   let x = (1 + 2 in ();;
                  ^^
 Error: Syntax error: ')' expected
-       Line 2, characters 8-9:
-         let x = (1 + 2 in ();;
-                 ^
-       This '(' might be unmatched
+Line 2, characters 8-9:
+  let x = (1 + 2 in ();;
+          ^
+This '(' might be unmatched
 Line 2, characters 14-16:
   let x = (1 + 2;;
                 ^^
 Error: Syntax error: ')' expected
-       Line 2, characters 8-9:
-         let x = (1 + 2;;
-                 ^
-       This '(' might be unmatched
+Line 2, characters 8-9:
+  let x = (1 + 2;;
+          ^
+This '(' might be unmatched
 Line 3, characters 8-9:
   let y = 1 +. 2. in
           ^
@@ -28,10 +28,10 @@ Line 4, characters 2-4:
   2 in
     ^^
 Error: Syntax error: ')' expected
-       Line 2, characters 8-9:
-         let x = (1
-                 ^
-       This '(' might be unmatched
+Line 2, characters 8-9:
+  let x = (1
+          ^
+This '(' might be unmatched
 Line 2, characters 8-17:
   ........(1
     +
@@ -43,12 +43,12 @@ Error: This expression has type int but an expression was expected of type
          float
 File "error_highlighting_use2.ml", line 1, characters 15-17:
 Error: Syntax error: ')' expected
-       File "error_highlighting_use2.ml", line 1, characters 8-9:
-       This '(' might be unmatched
+File "error_highlighting_use2.ml", line 1, characters 8-9:
+  This '(' might be unmatched
 File "error_highlighting_use3.ml", line 3, characters 2-4:
 Error: Syntax error: ')' expected
-       File "error_highlighting_use3.ml", line 1, characters 8-9:
-       This '(' might be unmatched
+File "error_highlighting_use3.ml", line 1, characters 8-9:
+  This '(' might be unmatched
 File "error_highlighting_use4.ml", line 1, characters 8-17:
 Error: This expression has type int but an expression was expected of type
          float

--- a/testsuite/tests/warnings/deprecated_module_assigment.compilers.reference
+++ b/testsuite/tests/warnings/deprecated_module_assigment.compilers.reference
@@ -1,72 +1,61 @@
 File "deprecated_module_assigment.ml", line 17, characters 33-34:
 Warning 3: deprecated: x
 DEPRECATED
-           File "deprecated_module_assigment.ml", line 12, characters 2-41:
-           Definition
-           File "deprecated_module_assigment.ml", line 17, characters 15-26:
-           Expected signature
+File "deprecated_module_assigment.ml", line 12, characters 2-41: Definition
+File "deprecated_module_assigment.ml", line 17, characters 15-26:
+  Expected signature
 File "deprecated_module_assigment.ml", line 23, characters 13-14:
 Warning 3: deprecated: x
 DEPRECATED
-           File "deprecated_module_assigment.ml", line 12, characters 2-41:
-           Definition
-           File "deprecated_module_assigment.ml", line 21, characters 17-28:
-           Expected signature
+File "deprecated_module_assigment.ml", line 12, characters 2-41: Definition
+File "deprecated_module_assigment.ml", line 21, characters 17-28:
+  Expected signature
 File "deprecated_module_assigment.ml", line 33, characters 39-78:
 Warning 3: deprecated: A
-           File "deprecated_module_assigment.ml", line 33, characters 55-70:
-           Definition
-           File "deprecated_module_assigment.ml", line 33, characters 27-28:
-           Expected signature
+File "deprecated_module_assigment.ml", line 33, characters 55-70: Definition
+File "deprecated_module_assigment.ml", line 33, characters 27-28:
+  Expected signature
 File "deprecated_module_assigment.ml", line 37, characters 2-20:
 Warning 3: deprecated: A
-           File "deprecated_module_assigment.ml", line 36, characters 11-26:
-           Definition
-           File "deprecated_module_assigment.ml", line 37, characters 15-16:
-           Expected signature
+File "deprecated_module_assigment.ml", line 36, characters 11-26: Definition
+File "deprecated_module_assigment.ml", line 37, characters 15-16:
+  Expected signature
 File "deprecated_module_assigment.ml", line 45, characters 0-58:
 Warning 3: deprecated: mutating field x
-           File "deprecated_module_assigment.ml", line 45, characters 17-53:
-           Definition
-           File "deprecated_module_assigment.ml", line 44, characters 14-28:
-           Expected signature
+File "deprecated_module_assigment.ml", line 45, characters 17-53: Definition
+File "deprecated_module_assigment.ml", line 44, characters 14-28:
+  Expected signature
 File "deprecated_module_assigment.ml", line 49, characters 2-31:
 Warning 3: deprecated: mutating field x
-           File "deprecated_module_assigment.ml", line 48, characters 12-48:
-           Definition
-           File "deprecated_module_assigment.ml", line 49, characters 16-30:
-           Expected signature
+File "deprecated_module_assigment.ml", line 48, characters 12-48: Definition
+File "deprecated_module_assigment.ml", line 49, characters 16-30:
+  Expected signature
 File "deprecated_module_assigment.ml", line 54, characters 37-75:
 Warning 3: deprecated: t
-           File "deprecated_module_assigment.ml", line 54, characters 44-71:
-           Definition
-           File "deprecated_module_assigment.ml", line 54, characters 18-30:
-           Expected signature
+File "deprecated_module_assigment.ml", line 54, characters 44-71: Definition
+File "deprecated_module_assigment.ml", line 54, characters 18-30:
+  Expected signature
 File "deprecated_module_assigment.ml", line 60, characters 0-52:
 Warning 3: deprecated: c
 FOO
-           File "deprecated_module_assigment.ml", line 60, characters 7-48:
-           Definition
-           File "deprecated_module_assigment.ml", line 59, characters 4-24:
-           Expected signature
+File "deprecated_module_assigment.ml", line 60, characters 7-48: Definition
+File "deprecated_module_assigment.ml", line 59, characters 4-24:
+  Expected signature
 File "deprecated_module_assigment.ml", line 64, characters 0-57:
 Warning 3: deprecated: c
 FOO
-           File "deprecated_module_assigment.ml", line 64, characters 7-53:
-           Definition
-           File "deprecated_module_assigment.ml", line 63, characters 4-29:
-           Expected signature
+File "deprecated_module_assigment.ml", line 64, characters 7-53: Definition
+File "deprecated_module_assigment.ml", line 63, characters 4-29:
+  Expected signature
 File "deprecated_module_assigment.ml", line 71, characters 0-55:
 Warning 3: deprecated: S
 FOO
-           File "deprecated_module_assigment.ml", line 71, characters 7-51:
-           Definition
-           File "deprecated_module_assigment.ml", line 70, characters 4-27:
-           Expected signature
+File "deprecated_module_assigment.ml", line 71, characters 7-51: Definition
+File "deprecated_module_assigment.ml", line 70, characters 4-27:
+  Expected signature
 File "deprecated_module_assigment.ml", line 82, characters 0-53:
 Warning 3: deprecated: M
 FOO
-           File "deprecated_module_assigment.ml", line 82, characters 7-49:
-           Definition
-           File "deprecated_module_assigment.ml", line 81, characters 4-22:
-           Expected signature
+File "deprecated_module_assigment.ml", line 82, characters 7-49: Definition
+File "deprecated_module_assigment.ml", line 81, characters 4-22:
+  Expected signature

--- a/testsuite/tools/expect_test.ml
+++ b/testsuite/tools/expect_test.ml
@@ -133,7 +133,7 @@ module Compiler_messages = struct
     let pp_loc _ _ ppf loc =
       (* We want to highlight locations even coming from a file, but the
          toplevel printer will only highlight locations from the toplevel. *)
-      Format.fprintf ppf "%a:@,%a"
+      Format.fprintf ppf "@[<v>%a:@,%a@]"
         Location.print_loc loc
         (Location.highlight_dumb lb) [loc]
     in


### PR DESCRIPTION
As has been found out by @alainfrisch [here](https://github.com/ocaml/ocaml/pull/1804/files#r213308026), the current way sub-errors are indented (that are in particular used by deprecation warnings/alerts) is not great.

In this PR, we avoid indenting sub-errors on the right of "Error:" (or "Warning x:"), and
implement more compact printing (the sub-location message is printed on the same
line of the location if it can fit).

FTR, this PR is "fixing" bad formatting that I introduced last month when refactoring parsing/location.ml; so it never appeared in a released version.

Note that the diff in the testsuite is quite small because sub-errors are under-used currently. Similar indentation tweaks can be done to the main message of the error (for the same reasons, to avoid wasting space and having a big block of text aligned on the right of `Error: ` or `Warning x: `) -- but I want to keep that for an other PR.

Not sure a Changes entry is necessary (this is mostly fixing my own code from earlier anyway).