### PR TITLE
Document performance properties of `ocamllex -ml` vs `ocamllex`

### DIFF
--- a/manual/manual/cmds/lexyacc.etex
+++ b/manual/manual/cmds/lexyacc.etex
@@ -52,8 +52,8 @@ The following command-line options are recognized by "ocamllex".
 \item["-ml"]
 Output code that does not use OCaml's built-in automata
 interpreter. Instead, the automaton is encoded by OCaml functions.
-This option mainly is useful for debugging "ocamllex", using it for
-production lexers is not recommended.
+This option improves performance when using the native compiler, but
+decreases it when using the bytecode compiler.
 
 \item["-o" \var{output-file}]
 Specify the name of the output file produced by "ocamllex".


### PR DESCRIPTION
This PR cherry-picks some useful info from [bench_ocamllex_optims.md](https://github.com/ocaml/ocaml/blob/4.07/experimental/frisch/bench_ocamllex_optims.md) -- which will be removed as part of #2033 -- and puts it in the manual.

Also removing the idea that `ocamllex -ml` is not suitable for production use (my experience suggests otherwise).