### PR TITLE
Manual, language extensions: cut one page per section

### DIFF
--- a/manual/manual/refman/exten.etex
+++ b/manual/manual/refman/exten.etex
@@ -6,6 +6,7 @@ that are implemented in OCaml, but not described in the
 OCaml reference manual.
 
 
+%HEVEA\cutdef{section}
 \section{Recursive definitions of values} \label{s:letrecvalues}
 
 (Introduced in Objective Caml 1.00)
@@ -2320,3 +2321,4 @@ Empty variant type can be eliminated by refutation case of pattern matching.
 type t = |
 let f (x: t) = match x with _ -> .
 \end{caml_example*}
+%HEVEA\cutend


### PR DESCRIPTION
I was recently shocked to how packed the [language extensions](http://caml.inria.fr/pub/docs/manual-ocaml/extn.html) chapter 8 feels in comparison to the [language reference](http://caml.inria.fr/pub/docs/manual-ocaml/language.html) chapter 7. In the language reference, each notion has its own webpage, but all language extensions are collated together.

(I wanted to suggest to @Octachron that maybe the "attributes and extensions" part could move to its own chapter in the context of #2033, and then I realized that it was only because of that all-content-together mashup that I felt uncomfortable about adding more content to some sections of the chapter.)

It's literally a two-line change to move to the language-reference style of one section per page:
- [Before](http://gallium.inria.fr/~scherer/tmp/htmlman-before/extn.html)
- [After](http://gallium.inria.fr/~scherer/tmp/htmlman-after/extn.html)

What do you think? Personally I think that it is an improvement; while it is slightly harder to idly scroll to get an overview of each extension, jumping to the content of one extension in particular gives a better, calmer experience.

(cc @Octachron @pmetzger)
