### PR TITLE
Emacs: Use built-in detection of comments

### DIFF
--- a/Changes
+++ b/Changes
@@ -232,6 +232,10 @@ Working version
   backend.
   (Florian Angeletti, review by Nicolás Ojeda Bär and Gabriel Scherer)
 
+- MPR#7844, GPR#2040: Emacs, use built-in detection of comments,
+  fixes an imenu crash.
+  (Wilfred Hughes, review by Christophe Troestler)
+
 - GPR#1711: the new 'open' flag in OCAMLRUNPARAM takes a comma-separated list of
   modules to open as if they had been passed via the command line -open flag.
   (Nicolás Ojeda Bär, review by Mark Shinwell)


### PR DESCRIPTION
This fixes https://caml.inria.fr/mantis/view.php?id=7844 where we crashed if we found text that looked like a definition inside a comment.

This is also faster and simpler. Emacs does handle nested comments correctly, but the comments  worrying about this were written in 1996 when that may have been true.