### PR TITLE
A type for unification traces

### DIFF
--- a/.depend
+++ b/.depend
@@ -323,7 +323,7 @@ typing/printtyp.cmx : utils/warnings.cmx typing/types.cmx \
     typing/printtyp.cmi
 typing/printtyp.cmi : typing/types.cmi typing/path.cmi \
     typing/outcometree.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi typing/env.cmi parsing/asttypes.cmi
+    typing/ident.cmi typing/env.cmi typing/ctype.cmi parsing/asttypes.cmi
 typing/printtyped.cmo : typing/types.cmi typing/typedtree.cmi \
     parsing/printast.cmi typing/path.cmi parsing/parsetree.cmi utils/misc.cmi \
     parsing/longident.cmi parsing/location.cmi typing/ident.cmi \
@@ -405,7 +405,8 @@ typing/typecore.cmx : utils/warnings.cmx typing/typetexp.cmx \
     parsing/ast_helper.cmx typing/annot.cmi typing/typecore.cmi
 typing/typecore.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
     parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/ident.cmi typing/env.cmi parsing/asttypes.cmi typing/annot.cmi
+    typing/ident.cmi typing/env.cmi typing/ctype.cmi parsing/asttypes.cmi \
+    typing/annot.cmi
 typing/typedecl.cmo : utils/warnings.cmi typing/typetexp.cmi \
     typing/types.cmi typing/typedtree.cmi typing/subst.cmi \
     typing/printtyp.cmi typing/primitive.cmi typing/predef.cmi \
@@ -426,7 +427,7 @@ typing/typedecl.cmx : utils/warnings.cmx typing/typetexp.cmx \
     parsing/ast_iterator.cmx parsing/ast_helper.cmx typing/typedecl.cmi
 typing/typedecl.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
     parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/includecore.cmi typing/ident.cmi typing/env.cmi \
+    typing/includecore.cmi typing/ident.cmi typing/env.cmi typing/ctype.cmi \
     parsing/asttypes.cmi
 typing/typedtree.cmo : typing/types.cmi typing/primitive.cmi typing/path.cmi \
     parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
@@ -511,7 +512,8 @@ typing/typetexp.cmx : typing/types.cmx typing/typedtree.cmx \
     parsing/ast_helper.cmx typing/typetexp.cmi
 typing/typetexp.cmi : typing/types.cmi typing/typedtree.cmi typing/path.cmi \
     parsing/parsetree.cmi parsing/longident.cmi parsing/location.cmi \
-    typing/includemod.cmi typing/env.cmi parsing/asttypes.cmi
+    typing/includemod.cmi typing/env.cmi typing/ctype.cmi \
+    parsing/asttypes.cmi
 typing/untypeast.cmo : typing/typedtree.cmi typing/path.cmi \
     parsing/parsetree.cmi utils/misc.cmi parsing/longident.cmi \
     parsing/location.cmi typing/ident.cmi typing/env.cmi parsing/asttypes.cmi \

--- a/Changes
+++ b/Changes
@@ -424,6 +424,9 @@ Working version
   for parser testing. See parsing/HACKING.adoc.
   (Gabriel Scherer, review by Nicolás Ojeda Bär)
 
+- GPR#2047: a new type for unification traces
+  (Florian Angeletti, review by Thomas Refis and Gabriel Scherer)
+
 - GPR#2055: Add [Linearize.Lprologue].
   (Mark Shinwell, review by Pierre Chambart)
 

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -116,8 +116,7 @@ let f (type a b) (x : (a, b) eq) =
 Line 3, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type (a, b) eq * b list
-       but a pattern was expected which matches values of type 'a
+Error:
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -131,8 +130,7 @@ let g1 (type a b) (x : (a, b) eq) =
 Line 3, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type (a, b) eq * b list
-       but a pattern was expected which matches values of type 'a
+Error:
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -146,8 +144,7 @@ let g2 (type a b) (x : (a, b) eq) =
 Line 3, characters 4-29:
     | Refl, [(_ : b) | (_ : a)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type (a, b) eq * b list
-       but a pattern was expected which matches values of type 'a
+Error:
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -161,8 +158,7 @@ let h1 (type a b) (x : (a, b) eq) =
 Line 4, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type (a, b) eq * b list
-       but a pattern was expected which matches values of type 'a
+Error:
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -176,8 +172,7 @@ let h2 (type a b) (x : (a, b) eq) =
 Line 4, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type (a, b) eq * b list
-       but a pattern was expected which matches values of type 'a
+Error:
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -191,8 +186,7 @@ let h3 (type a b) (x : (a, b) eq) =
 Line 4, characters 4-29:
     | Refl, [(_ : b) | (_ : a)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type (a, b) eq * b list
-       but a pattern was expected which matches values of type 'a
+Error:
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/ambiguity.ml
+++ b/testsuite/tests/typing-gadts/ambiguity.ml
@@ -116,7 +116,7 @@ let f (type a b) (x : (a, b) eq) =
 Line 3, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error:
+Error: This pattern matches values of type (a, b) eq * b list
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -130,7 +130,7 @@ let g1 (type a b) (x : (a, b) eq) =
 Line 3, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error:
+Error: This pattern matches values of type (a, b) eq * b list
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -144,7 +144,7 @@ let g2 (type a b) (x : (a, b) eq) =
 Line 3, characters 4-29:
     | Refl, [(_ : b) | (_ : a)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error:
+Error: This pattern matches values of type (a, b) eq * b list
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -158,7 +158,7 @@ let h1 (type a b) (x : (a, b) eq) =
 Line 4, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error:
+Error: This pattern matches values of type (a, b) eq * b list
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -172,7 +172,7 @@ let h2 (type a b) (x : (a, b) eq) =
 Line 4, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error:
+Error: This pattern matches values of type (a, b) eq * b list
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -186,7 +186,7 @@ let h3 (type a b) (x : (a, b) eq) =
 Line 4, characters 4-29:
     | Refl, [(_ : b) | (_ : a)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error:
+Error: This pattern matches values of type (a, b) eq * b list
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/pr7618.ml
+++ b/testsuite/tests/typing-gadts/pr7618.ml
@@ -22,8 +22,7 @@ type ('a, 'b) eq = Refl : ('a, 'a) eq
 Line 4, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type (a, b) eq * b list
-       but a pattern was expected which matches values of type 'a
+Error:
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -36,8 +35,7 @@ let fails (type a b) (x : (a, b) eq) =
 Line 3, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This pattern matches values of type (a, b) eq * b list
-       but a pattern was expected which matches values of type 'a
+Error:
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/pr7618.ml
+++ b/testsuite/tests/typing-gadts/pr7618.ml
@@ -22,7 +22,7 @@ type ('a, 'b) eq = Refl : ('a, 'a) eq
 Line 4, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error:
+Error: This pattern matches values of type (a, b) eq * b list
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]
@@ -35,7 +35,7 @@ let fails (type a b) (x : (a, b) eq) =
 Line 3, characters 4-29:
     | Refl, [(_ : a) | (_ : b)] -> []
       ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error:
+Error: This pattern matches values of type (a, b) eq * b list
        This instance of b is ambiguous:
        it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-misc/exotic_unifications.ml
+++ b/testsuite/tests/typing-misc/exotic_unifications.ml
@@ -1,0 +1,29 @@
+(* TEST
+   * expect
+*)
+
+class virtual t = object method virtual x: float end
+
+class x = object(self: <x:int; ..>)
+        inherit t
+end
+[%%expect {|
+class virtual t : object method virtual x : float end
+Line 4, characters 16-17:
+          inherit t
+                  ^
+Error: The method x has type int but is expected to have type float
+       Type int is not compatible with type float
+|}]
+
+let x =
+  let module M = struct module type t = sig end end in
+  (module struct end: M.t)
+[%%expect {|
+Line 3, characters 2-26:
+    (module struct end: M.t)
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type (module M.t)
+       but an expression was expected of type 'a
+       The module type M.t would escape its scope
+|}]

--- a/testsuite/tests/typing-misc/ocamltests
+++ b/testsuite/tests/typing-misc/ocamltests
@@ -1,5 +1,6 @@
 constraints.ml
 disambiguate_principality.ml
+exotic_unifications.ml
 inside_out.ml
 labels.ml
 occur_check.ml

--- a/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr4018_bad.compilers.reference
@@ -16,26 +16,23 @@ Error: This type entity = < destroy_subject : id subject; entity_id : id >
          'a entity_container =
            < add_entity : (< destroy_subject : < add_observer : 'a
                                                                 entity_container ->
-                                                                'e;
-                                                 .. >;
+                                                                'f;
+                                                 .. >
+                                               as 'e;
                              .. >
                            as 'd) ->
-                          'e;
+                          'f;
              notify : 'd -> id -> unit > 
-       Type < destroy_subject : id subject; entity_id : id >
-       is not compatible with type
-         entity = < destroy_subject : id subject; entity_id : id > 
+       Type entity = < destroy_subject : id subject; entity_id : id >
+       is not compatible with type < destroy_subject : 'e; .. > as 'd 
        Type
-         < add_observer : (id subject, id) observer -> unit;
-           notify_observers : id -> unit >
-       is not compatible with type
          id subject =
            < add_observer : (id subject, id) observer -> unit;
-             notify_observers : id -> unit > 
-       Type < add_entity : 'd -> 'e; notify : 'd -> id -> unit >
+             notify_observers : id -> unit >
+       is not compatible with type
+         < add_observer : 'a entity_container -> 'f; .. > as 'e 
+       Type (id subject, id) observer = < notify : id subject -> id -> unit >
        is not compatible with type
          'a entity_container =
-           < add_entity : 'd -> 'e; notify : 'd -> id -> unit > 
-       Type < notify : id subject -> id -> unit > is not compatible with type
-         (id subject, id) observer = < notify : id subject -> id -> unit > 
-       Types for method add_entity are incompatible
+           < add_entity : 'd -> 'f; notify : 'd -> id -> unit > 
+       The first object type has no method add_entity

--- a/testsuite/tests/typing-objects-bugs/pr4824a_bad.compilers.reference
+++ b/testsuite/tests/typing-objects-bugs/pr4824a_bad.compilers.reference
@@ -6,5 +6,3 @@ Error: Signature mismatch:
        does not match
          class c : 'a -> object val x : 'b end
        The instance variable x has type 'a but is expected to have type 'b
-       This instance of 'b is ambiguous:
-       it would escape the scope of its equation

--- a/testsuite/tests/typing-objects/Exemples.ml
+++ b/testsuite/tests/typing-objects/Exemples.ml
@@ -233,6 +233,7 @@ Error: Type
          point circle =
            < center : point; move : int -> unit; set_center : point -> unit >
        Type point is not a subtype of color_point
+       The first object type has no method color
 |}];;                 (* Fail *)
 fun x -> (x : color_point color_circle :> point circle);;
 [%%expect{|
@@ -247,6 +248,7 @@ Error: Type
          point circle =
            < center : point; move : int -> unit; set_center : point -> unit >
        Type point is not a subtype of color_point
+       The first object type has no method color
 |}];;
 
 class printable_point y = object (s)
@@ -544,6 +546,7 @@ Error: Type
        is not a subtype of
          int_comparable2 =
            < cmp : int_comparable2 -> int; set_x : int -> unit; x : int >
+       The first object type has no method set_x
 |}];;      (* Fail : 'a comp2 is not a subtype *)
 (new sorted_list ())#add c2;;
 [%%expect{|

--- a/testsuite/tests/typing-objects/abstract_rows.ml
+++ b/testsuite/tests/typing-objects/abstract_rows.ml
@@ -1,0 +1,26 @@
+(* TEST
+   * expect
+*)
+type u = <x:int>
+type t = private <u; ..>
+
+let f (x:t) (y:u) = x = y;;
+[%%expect{|
+type u = < x : int >
+type t = private < x : int; .. >
+Line 4, characters 24-25:
+  let f (x:t) (y:u) = x = y;;
+                          ^
+Error: This expression has type u but an expression was expected of type t
+       The second object type has an abstract row, it cannot be closed
+|}]
+
+
+let g (x:u) (y:t) = x = y;;
+[%%expect{|
+Line 1, characters 24-25:
+  let g (x:u) (y:t) = x = y;;
+                          ^
+Error: This expression has type t but an expression was expected of type u
+       The first object type has an abstract row, it cannot be closed
+|}]

--- a/testsuite/tests/typing-objects/ocamltests
+++ b/testsuite/tests/typing-objects/ocamltests
@@ -1,3 +1,4 @@
+abstract_rows.ml
 dummy.ml
 errors.ml
 Exemples.ml

--- a/testsuite/tests/typing-poly-bugs/pr5673_bad.compilers.reference
+++ b/testsuite/tests/typing-poly-bugs/pr5673_bad.compilers.reference
@@ -3,9 +3,10 @@ Error: This expression has type
          refer1 = < poly : 'a 'b 'c. ('b, 'c) #Classdef.cl2 as 'a >
        but an expression was expected of type
          refer2 = < poly : 'd 'b 'c. ('b, 'c) #Classdef.cl2 as 'd >
-       Type
-         ('b, 'c) Classdef.cl1 =
-           < m : 'b -> 'c -> int; raise_trouble : int -> 'b >
+       Type ('b, 'c, ('b, 'c) Classdef.cl1) Classdef.cl0 = <  >
        is not compatible with type
-         < m : 'b -> 'c -> int; raise_trouble : int -> 'b > 
-       The type variable 'e occurs inside 'e
+         ('b0, 'c0, ('b0, 'c0) Classdef.cl1) Classdef.cl0 
+       Type < m : 'b -> 'c -> int; .. > is not compatible with type
+         ('b, 'c) Classdef.cl1 =
+           < m : 'b -> 'c -> int; raise_trouble : int -> 'b > 
+       The universal variable 'b would escape its scope

--- a/testsuite/tests/typing-poly/poly.ml
+++ b/testsuite/tests/typing-poly/poly.ml
@@ -1098,7 +1098,7 @@ Line 2, characters 3-4:
 Error: This expression has type < m : 'a. 'a * < m : 'a * 'b > > as 'b
        but an expression was expected of type
          < m : 'a. 'a * (< m : 'a * < m : 'c. 'c * 'd > > as 'd) >
-       Types for method m are incompatible
+       The universal variable 'a would escape its scope
 |}];;
 
 fun (x : <m : 'a. 'a * ('a * <m : 'a. 'a * 'foo> as 'foo)>) ->

--- a/testsuite/tests/typing-polyvariants-bugs-2/pr3918c.compilers.reference
+++ b/testsuite/tests/typing-polyvariants-bugs-2/pr3918c.compilers.reference
@@ -1,4 +1,4 @@
 File "pr3918c.ml", line 24, characters 11-12:
 Error: This expression has type 'b Pr3918b.vlist = 'a
        but an expression was expected of type 'b Pr3918b.vlist
-       The type variable 'a occurs inside 'a
+       The type variable 'a occurs inside ('d * 'c) Pr3918a.voption as 'c

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -18,10 +18,55 @@
 open Asttypes
 open Types
 
-exception Unify of (type_expr * type_expr) list
+module Unification_trace: sig
+  (** Unification traces are used to explain unification errrors
+      when printing error messages *)
+
+  type position = First | Second
+  type desc = { t: type_expr; expanded: type_expr option }
+  type 'a diff = { got: 'a; expected: 'a}
+
+   (** Scope escape related errors *)
+    type 'a escape =
+    | Constructor of Path.t
+    | Univ of string option
+    | Self
+    | Module_type of Path.t
+    | Equation of 'a
+
+   (** Errors for polymorphic variants *)
+  type variant =
+    | No_intersection
+    | No_tags of position * (Asttypes.label * row_field) list
+    | Incompatible_types_for of string
+
+  type 'a elt =
+    | Diff of 'a diff
+    | Variant of variant
+    | Escape of 'a escape
+    | Incompatible_fields of {name:string; diff: type_expr diff }
+    | Rec_occur of type_expr * type_expr
+
+  type t = desc elt list
+
+  val diff: type_expr -> type_expr -> desc elt
+
+  (** [map_diff f {expected;got}] is [{expected=f expected; got=f got}] *)
+  val map_diff: ('a -> 'b) -> 'a diff -> 'b diff
+
+  (** [flatten f trace] flattens all elements of type {!desc} in
+      [trace] to either [f x.t expanded] if [x.expanded=Some expanded]
+      or [f x.t x.t] otherwise *)
+  val flatten: (type_expr -> type_expr -> 'a) -> t -> 'a elt list
+
+  (** Switch [expected] and [got] *)
+  val swap: t -> t
+
+end
+
+exception Unify of Unification_trace.t
 exception Tags of label * label
-exception Subtype of
-        (type_expr * type_expr) list * (type_expr * type_expr) list
+exception Subtype of Unification_trace.t * Unification_trace.t
 exception Cannot_expand
 exception Cannot_apply
 
@@ -73,7 +118,7 @@ val associate_fields:
         (string * field_kind * type_expr) list *
         (string * field_kind * type_expr) list
 val opened_object: type_expr -> bool
-val close_object: type_expr -> unit
+val close_object: type_expr -> bool
 val row_variable: type_expr -> type_expr
         (* Return the row variable of an open object type *)
 val set_object_name:
@@ -204,11 +249,11 @@ val reify_univars : Types.type_expr -> Types.type_expr
 type class_match_failure =
     CM_Virtual_class
   | CM_Parameter_arity_mismatch of int * int
-  | CM_Type_parameter_mismatch of Env.t * (type_expr * type_expr) list
+  | CM_Type_parameter_mismatch of Env.t * Unification_trace.t
   | CM_Class_type_mismatch of Env.t * class_type * class_type
-  | CM_Parameter_mismatch of Env.t * (type_expr * type_expr) list
-  | CM_Val_type_mismatch of string * Env.t * (type_expr * type_expr) list
-  | CM_Meth_type_mismatch of string * Env.t * (type_expr * type_expr) list
+  | CM_Parameter_mismatch of Env.t * Unification_trace.t
+  | CM_Val_type_mismatch of string * Env.t * Unification_trace.t
+  | CM_Meth_type_mismatch of string * Env.t * Unification_trace.t
   | CM_Non_mutable_value of string
   | CM_Non_concrete_value of string
   | CM_Missing_value of string

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -43,7 +43,7 @@ module Unification_trace: sig
   type 'a elt =
     | Diff of 'a diff
     | Variant of variant
-    | Escape of 'a escape
+    | Escape of {context: type_expr option; kind:'a escape}
     | Incompatible_fields of {name:string; diff: type_expr diff }
     | Rec_occur of type_expr * type_expr
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -40,9 +40,14 @@ module Unification_trace: sig
     | No_tags of position * (Asttypes.label * row_field) list
     | Incompatible_types_for of string
 
+  type obj =
+    | Missing_field of position * string
+    | Abstract_row of position
+
   type 'a elt =
     | Diff of 'a diff
     | Variant of variant
+    | Obj of obj
     | Escape of {context: type_expr option; kind:'a escape}
     | Incompatible_fields of {name:string; diff: type_expr diff }
     | Rec_occur of type_expr * type_expr

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -57,7 +57,7 @@ let include_err ppf =
       fprintf ppf
         "The classes do not have the same number of type parameters"
   | CM_Type_parameter_mismatch (env, trace) ->
-      Printtyp.report_unification_error ppf env ~unif:false trace
+      Printtyp.report_unification_error ppf env trace
         (function ppf ->
           fprintf ppf "A type parameter has type")
         (function ppf ->
@@ -70,19 +70,19 @@ let include_err ppf =
           "is not matched by the class type"
           Printtyp.class_type cty2)
   | CM_Parameter_mismatch (env, trace) ->
-      Printtyp.report_unification_error ppf env ~unif:false trace
+      Printtyp.report_unification_error ppf env trace
         (function ppf ->
           fprintf ppf "A parameter has type")
         (function ppf ->
           fprintf ppf "but is expected to have type")
   | CM_Val_type_mismatch (lab, env, trace) ->
-      Printtyp.report_unification_error ppf env ~unif:false trace
+      Printtyp.report_unification_error ppf env trace
         (function ppf ->
           fprintf ppf "The instance variable %s@ has type" lab)
         (function ppf ->
           fprintf ppf "but is expected to have type")
   | CM_Meth_type_mismatch (lab, env, trace) ->
-      Printtyp.report_unification_error ppf env ~unif:false trace
+      Printtyp.report_unification_error ppf env trace
         (function ppf ->
           fprintf ppf "The method %s@ has type" lab)
         (function ppf ->

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1698,7 +1698,9 @@ let type_expansion ppf = function
   | Diff(t,t') ->
       fprintf ppf "@[<2>%a@ =@ %a@]"  !Oprint.out_type t  !Oprint.out_type t'
 
-let trees_of_trace = List.map trees_of_type_expansion
+module Trace = Ctype.Unification_trace
+
+let trees_of_trace = List.map (Trace.map_diff trees_of_type_expansion)
 
 let trees_of_type_path_expansion (tp,tp') =
   if Path.same tp tp' then Same(tree_of_path Type tp) else
@@ -1712,23 +1714,22 @@ let type_path_expansion ppf = function
         !Oprint.out_ident p'
 
 let rec trace fst txt ppf = function
-  | te :: te2 :: rem ->
+  | {Trace.got; expected} :: rem ->
       if not fst then fprintf ppf "@,";
       fprintf ppf "@[Type@;<1 2>%a@ %s@;<1 2>%a@] %a"
-       type_expansion te txt type_expansion te2
+       type_expansion got txt type_expansion expected
        (trace false txt) rem
   | _ -> ()
 
 let rec filter_trace keep_last = function
-  | (_, t1') :: (_, t2') :: [] when is_Tvar t1' || is_Tvar t2' ->
-      []
-  | (t1, t1') :: (t2, t2') :: rem ->
+  | Trace.(Diff ({ got=t1, t1'; expected=t2, t2'} as elt)) :: rem ->
       let rem' = filter_trace keep_last rem in
       if is_constr_row ~allow_ident:true t1'
       || is_constr_row ~allow_ident:true t2'
       || same_path t1 t1' && same_path t2 t2' && not (keep_last && rem' = [])
       then rem'
-      else (t1, t1') :: (t2, t2') :: rem'
+      else elt :: rem'
+  | _elt :: rem -> filter_trace keep_last rem
   | _ -> []
 
 let type_path_list =
@@ -1776,7 +1777,7 @@ let unifiable env ty1 ty2 =
   Btype.backtrack snap;
   res
 
-let explanation env unif t3 t4 : (Format.formatter -> unit) option =
+let explanation_diff env t3 t4 : (Format.formatter -> unit) option =
   match t3.desc, t4.desc with
   | Tarrow (_, ty1, ty2, _), _
     when is_unit env ty1 && unifiable env ty2 t4 ->
@@ -1789,46 +1790,6 @@ let explanation env unif t3 t4 : (Format.formatter -> unit) option =
         fprintf ppf
           "@,@[Hint: Did you forget to wrap the expression using \
            `fun () ->'?@]")
-  | Ttuple [], Tvar _ | Tvar _, Ttuple [] ->
-      Some (fun ppf ->
-        fprintf ppf "@,Self type cannot escape its class")
-  | Tconstr (p, _, _), Tvar _
-    when unif && t4.level < Path.scope p ->
-      Some (fun ppf ->
-        fprintf ppf
-          "@,@[The type constructor@;<1 2>%a@ would escape its scope@]"
-          path p)
-  | Tvar _, Tconstr (p, _, _)
-    when unif && t3.level < Path.scope p ->
-      Some (fun ppf ->
-        fprintf ppf
-          "@,@[The type constructor@;<1 2>%a@ would escape its scope@]"
-          path p)
-  | Tvar _, Tunivar _ | Tunivar _, Tvar _ ->
-      Some (fun ppf ->
-        fprintf ppf "@,The universal variable %a would escape its scope"
-          type_expr (if is_Tunivar t3 then t3 else t4))
-  | Tvar _, _ | _, Tvar _ ->
-      Some (fun ppf ->
-        let t, t' = if is_Tvar t3 then (t3, t4) else (t4, t3) in
-        if occur_in Env.empty t t' then
-          fprintf ppf "@,@[<hov>The type variable %a occurs inside@ %a@]"
-            type_expr t type_expr t'
-        else
-          fprintf ppf "@,@[<hov>This instance of %a is ambiguous:@ %s@]"
-            type_expr t'
-            "it would escape the scope of its equation")
-  | Tfield (lab, _, _, _), _ when lab = dummy_method ->
-      Some (fun ppf ->
-        fprintf ppf
-          "@,Self type cannot be unified with a closed object type")
-  | _, Tfield (lab, _, _, _) when lab = dummy_method ->
-      Some (fun ppf ->
-        fprintf ppf
-          "@,Self type cannot be unified with a closed object type")
-  | Tfield (l,_,_,{desc=Tnil}), Tfield (l',_,_,{desc=Tnil}) when l = l' ->
-      Some (fun ppf ->
-        fprintf ppf "@,Types for method %s are incompatible" l)
   | (Tnil|Tconstr _), Tfield (l, _, _, _) ->
       Some (fun ppf ->
         fprintf ppf
@@ -1842,37 +1803,68 @@ let explanation env unif t3 t4 : (Format.formatter -> unit) option =
         fprintf ppf
           "@,@[The %s object type has an abstract row, it cannot be closed@]"
           (if t4.desc = Tnil then "first" else "second"))
-  | Tvariant row1, Tvariant row2 ->
-      Some (fun ppf ->
-        let row1 = row_repr row1 and row2 = row_repr row2 in
-        begin match
-          row1.row_fields, row1.row_closed,
-          row2.row_fields, row2.row_closed with
-        | [], true, [], true ->
-            fprintf ppf "@,These two variant types have no intersection"
-        | [], true, (_::_ as fields), _ ->
-            fprintf ppf
-              "@,@[The first variant type does not allow tag(s)@ @[<hov>%a@]@]"
-              print_tags fields
-        | (_::_ as fields), _, [], true ->
-            fprintf ppf
-              "@,@[The second variant type does not allow tag(s)@ @[<hov>%a@]@]"
-              print_tags fields
-        | [l1,_], true, [l2,_], true when l1 = l2 ->
-            fprintf ppf "@,Types for tag `%s are incompatible" l1
-        | _ -> ()
-        end)
   | _ ->
       None
 
-let rec mismatch env unif = function
-    (_, t) :: (_, t') :: rem ->
-      begin match mismatch env unif rem with
+let print_pos ppf = function
+  | Trace.First -> fprintf ppf "first"
+  | Trace.Second -> fprintf ppf "second"
+
+let explain_variant = function
+  | Trace.No_intersection ->
+      Some(dprintf "@,These two variant types have no intersection")
+  | Trace.No_tags(pos,fields) -> Some(
+      dprintf
+        "@,@[The %a variant type does not allow tag(s)@ @[<hov>%a@]@]"
+        print_pos pos
+        print_tags fields
+    )
+  | Trace.Incompatible_types_for s ->
+      Some(dprintf "@,Types for tag `%s are incompatible" s)
+
+let explain_escape = function
+  | Trace.Univ Some u ->  Some(
+      dprintf "@,The universal variable '%s would escape its scope"
+        u)
+  | Trace.Univ None ->
+      Some(dprintf "@,An universal variable would escape its scope")
+  | Trace.Constructor p -> Some(
+      dprintf
+        "@,@[The type constructor@;<1 2>%a@ would escape its scope@]"
+        path p
+    )
+  | Trace.Module_type p -> Some(
+      dprintf
+        "@,@[The module type@;<1 2>%a@ would escape its scope@]"
+        path p
+    )
+  | Trace.Equation (_,t) -> Some(
+      dprintf "@,@[<hov>This instance of %a is ambiguous:@ %s@]"
+        type_expr t
+        "it would escape the scope of its equation"
+    )
+  | Trace.Self ->
+      Some (dprintf "@,Self type cannot escape its class")
+
+
+let explanation env = function
+  | Trace.Diff { Trace.got = _, s; expected = _,t } -> explanation_diff env s t
+  | Trace.Escape e -> explain_escape e
+  | Trace.Incompatible_fields { name; _ } ->
+        Some(dprintf "@,Types for method %s are incompatible" name)
+  | Trace.Variant v -> explain_variant v
+  | Trace.Rec_occur(x,y) ->
+      mark_loops y;
+      Some(dprintf "@,@[<hov>The type variable %a occurs inside@ %a@]"
+            type_expr x type_expr y)
+
+let rec mismatch env = function
+    h :: rem ->
+      begin match mismatch env rem with
         Some _ as m -> m
-      | None -> explanation env unif t t'
+      | None -> explanation env h
       end
   | [] -> None
-  | _ -> assert false
 
 let explain mis ppf =
   match mis with
@@ -1892,49 +1884,60 @@ let warn_on_missing_def env ppf t =
     end
   | _ -> ()
 
-let unification_error env unif tr txt1 ppf txt2 ty_expect_explanation =
+
+let prepare_expansion_head empty_tr = function
+  | Trace.Diff d ->
+      Some(Trace.map_diff (may_prepare_expansion empty_tr) d)
+  | _ -> None
+
+let head_error_printer txt_got txt_but = function
+  | None -> ignore
+  | Some d ->
+      let d = Trace.map_diff trees_of_type_expansion d in
+      dprintf "%t@;<1 2>%a@ %t@;<1 2>%a"
+        txt_got type_expansion d.Trace.got
+        txt_but type_expansion d.Trace.expected
+
+let warn_on_missing_defs env ppf = function
+  | None -> ()
+  | Some {Trace.got=te1,_; expected=te2,_ } ->
+      warn_on_missing_def env ppf te1;
+      warn_on_missing_def env ppf te2
+
+let unification_error env tr txt1 ppf txt2 ty_expect_explanation =
   reset ();
-  let tr = List.map (fun (t, t') -> (t, hide_variant_name t')) tr in
-  let mis = mismatch env unif tr in
+  let tr = Trace.flatten (fun t t' -> t, hide_variant_name t') tr in
+  let mis = mismatch env tr in
   match tr with
-  | [] | _ :: [] -> assert false
-  | t1 :: t2 :: tr ->
+  | [] -> assert false
+  | elt :: tr ->
     try
-      let tr = filter_trace (mis = None) tr in
-      let t1, t1' = may_prepare_expansion (tr = []) t1
-      and t2, t2' = may_prepare_expansion (tr = []) t2 in
       print_labels := not !Clflags.classic;
-      let tr = List.map prepare_expansion tr in
-      let te1 = trees_of_type_expansion (t1,t1')
-      and te2 = trees_of_type_expansion (t2,t2')
-      and tr = trees_of_trace tr in
+      let tr = filter_trace (mis = None) tr in
+      let head = prepare_expansion_head (tr=[]) elt in
+      let tr = List.map (Trace.map_diff prepare_expansion) tr in
+      let head_error = head_error_printer txt1 txt2 head in
+      let tr = trees_of_trace tr in
       fprintf ppf
         "@[<v>\
-          @[%t@;<1 2>%a@ \
-            %t@;<1 2>%a\
-            %t\
-          @]%a%t\
+          @[%t%t@]%a%t\
          @]"
-        txt1 type_expansion te1
-        txt2 type_expansion te2
+        head_error
         ty_expect_explanation
         (trace false "is not compatible with type") tr
         (explain mis);
       if env <> Env.empty
-      then begin
-        warn_on_missing_def env ppf t1;
-        warn_on_missing_def env ppf t2
-      end;
+      then warn_on_missing_defs env ppf head;
       Conflicts.print ppf;
       print_labels := true
     with exn ->
       print_labels := true;
       raise exn
 
-let report_unification_error ppf env ?(unif=true) tr
+let report_unification_error ppf env tr
     ?(type_expected_explanation = fun _ -> ())
     txt1 txt2 =
-  wrap_printing_env env (fun () -> unification_error env unif tr txt1 ppf txt2
+  wrap_printing_env env (fun () -> unification_error env tr txt1 ppf txt2
                             type_expected_explanation)
     ~error:true
 ;;
@@ -1942,11 +1945,15 @@ let report_unification_error ppf env ?(unif=true) tr
 let trace fst keep_last txt ppf tr =
   print_labels := not !Clflags.classic;
   try match tr with
-    t1 :: t2 :: tr' ->
-      let t1 = trees_of_type_expansion t1 in
-      let t2 = trees_of_type_expansion t2 in
-      let tr = trees_of_trace (filter_trace keep_last tr') in
-      if fst then trace fst txt ppf (t1 :: t2 :: tr)
+    | elt :: tr' ->
+        let elt = match elt with
+          | Trace.Diff diff -> [Trace.map_diff trees_of_type_expansion diff]
+          | _ -> [] in
+        let tr =
+          trees_of_trace
+          @@ List.map (Trace.map_diff prepare_expansion)
+          @@ filter_trace keep_last tr' in
+      if fst then trace fst txt ppf (elt @ tr)
       else trace fst txt ppf tr;
       print_labels := true
   | _ -> ()
@@ -1957,11 +1964,11 @@ let trace fst keep_last txt ppf tr =
 let report_subtyping_error ppf env tr1 txt1 tr2 =
   wrap_printing_env ~error:true env (fun () ->
     reset ();
-    let tr1 = List.map prepare_expansion tr1
-    and tr2 = List.map prepare_expansion tr2 in
+    let tr1 = Trace.flatten (fun t t' -> prepare_expansion (t, t')) tr1 in
+    let tr2 = Trace.flatten (fun t t' -> prepare_expansion (t, t')) tr2 in
     fprintf ppf "@[<v>%a" (trace true (tr2 = []) txt1) tr1;
     if tr2 = [] then fprintf ppf "@]" else
-    let mis = mismatch env true tr2 in
+    let mis = mismatch env tr2 in
     fprintf ppf "%a%t%t@]"
       (trace false (mis = None) "is not compatible with type") tr2
       (explain mis)

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -121,16 +121,17 @@ val cltype_declaration: Ident.t -> formatter -> class_type_declaration -> unit
 val type_expansion: type_expr -> Format.formatter -> type_expr -> unit
 val prepare_expansion: type_expr * type_expr -> type_expr * type_expr
 val trace:
-    bool -> bool-> string -> formatter -> (type_expr * type_expr) list -> unit
+  bool -> bool-> string -> formatter
+  -> (type_expr * type_expr) Ctype.Unification_trace.elt list -> unit
 val report_unification_error:
-    formatter -> Env.t -> ?unif:bool ->
-    (type_expr * type_expr) list ->
+    formatter -> Env.t ->
+    Ctype.Unification_trace.t ->
     ?type_expected_explanation:(formatter -> unit) ->
     (formatter -> unit) -> (formatter -> unit) ->
     unit
 val report_subtyping_error:
-    formatter -> Env.t -> (type_expr * type_expr) list ->
-    string -> (type_expr * type_expr) list -> unit
+    formatter -> Env.t -> Ctype.Unification_trace.t -> string
+    -> Ctype.Unification_trace.t -> unit
 val report_ambiguous_type_error:
     formatter -> Env.t -> (Path.t * Path.t) -> (Path.t * Path.t) list ->
     (formatter -> unit) -> (formatter -> unit) -> (formatter -> unit) -> unit

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -48,8 +48,8 @@ type class_type_info = {
 }
 
 type error =
-    Unconsistent_constraint of (type_expr * type_expr) list
-  | Field_type_mismatch of string * string * (type_expr * type_expr) list
+    Unconsistent_constraint of Ctype.Unification_trace.t
+  | Field_type_mismatch of string * string * Ctype.Unification_trace.t
   | Structure_expected of class_type
   | Cannot_apply of class_type
   | Apply_wrong_label of arg_label
@@ -58,10 +58,10 @@ type error =
   | Unbound_class_2 of Longident.t
   | Unbound_class_type_2 of Longident.t
   | Abbrev_type_clash of type_expr * type_expr * type_expr
-  | Constructor_type_mismatch of string * (type_expr * type_expr) list
+  | Constructor_type_mismatch of string * Ctype.Unification_trace.t
   | Virtual_class of bool * bool * string list * string list
   | Parameter_arity_mismatch of Longident.t * int * int
-  | Parameter_mismatch of (type_expr * type_expr) list
+  | Parameter_mismatch of Ctype.Unification_trace.t
   | Bad_parameters of Ident.t * type_expr * type_expr
   | Class_match_failure of Ctype.class_match_failure list
   | Unbound_val of string
@@ -69,8 +69,8 @@ type error =
   | Non_generalizable_class of Ident.t * Types.class_declaration
   | Cannot_coerce_self of type_expr
   | Non_collapsable_conjunction of
-      Ident.t * Types.class_declaration * (type_expr * type_expr) list
-  | Final_self_clash of (type_expr * type_expr) list
+      Ident.t * Types.class_declaration * Ctype.Unification_trace.t
+  | Final_self_clash of Ctype.Unification_trace.t
   | Mutability_mismatch of string * mutable_flag
   | No_overriding of string * string
   | Duplicate of string * string
@@ -290,11 +290,11 @@ let inheritance self_type env ovf concr_meths warn_vals loc parent =
       begin try
         Ctype.unify env self_type cl_sig.csig_self
       with Ctype.Unify trace ->
+        let open Ctype.Unification_trace in
         match trace with
-          _::_::_::({desc = Tfield(n, _, _, _)}, _)::rem ->
+        | Diff _ :: Incompatible_fields {name = n; _ } :: rem ->
             raise(Error(loc, env, Field_type_mismatch ("method", n, rem)))
-        | _ ->
-            assert false
+        | _ -> assert false
       end;
 
       (* Overriding *)
@@ -863,10 +863,8 @@ and class_structure cl_num final val_env met_env loc
   if final then begin
     (* Unify private_self and a copy of self_type. self_type will not
        be modified after this point *)
-    begin try Ctype.close_object self_type
-    with Ctype.Unify [] ->
-      raise(Error(loc, val_env, Closing_self_type self_type))
-    end;
+    if not (Ctype.close_object self_type) then
+      raise(Error(loc, val_env, Closing_self_type self_type));
     let mets = virtual_methods {sign with csig_self = self_type} in
     let vals =
       Vars.fold
@@ -1409,9 +1407,8 @@ let class_infos define_class kind
   begin
     let ty = Ctype.self_type obj_type in
     Ctype.hide_private_methods ty;
-    begin try Ctype.close_object ty
-    with Ctype.Unify [] -> raise(Error(cl.pci_loc, env, Closing_self_type ty))
-    end;
+    if not (Ctype.close_object ty) then
+      raise(Error(cl.pci_loc, env, Closing_self_type ty));
     begin try
       List.iter2 (Ctype.unify env) obj_params obj_params'
     with Ctype.Unify _ ->

--- a/typing/typeclass.mli
+++ b/typing/typeclass.mli
@@ -90,8 +90,8 @@ val type_classes :
 *)
 
 type error =
-    Unconsistent_constraint of (type_expr * type_expr) list
-  | Field_type_mismatch of string * string * (type_expr * type_expr) list
+    Unconsistent_constraint of Ctype.Unification_trace.t
+  | Field_type_mismatch of string * string * Ctype.Unification_trace.t
   | Structure_expected of class_type
   | Cannot_apply of class_type
   | Apply_wrong_label of arg_label
@@ -100,10 +100,10 @@ type error =
   | Unbound_class_2 of Longident.t
   | Unbound_class_type_2 of Longident.t
   | Abbrev_type_clash of type_expr * type_expr * type_expr
-  | Constructor_type_mismatch of string * (type_expr * type_expr) list
+  | Constructor_type_mismatch of string * Ctype.Unification_trace.t
   | Virtual_class of bool * bool * string list * string list
   | Parameter_arity_mismatch of Longident.t * int * int
-  | Parameter_mismatch of (type_expr * type_expr) list
+  | Parameter_mismatch of Ctype.Unification_trace.t
   | Bad_parameters of Ident.t * type_expr * type_expr
   | Class_match_failure of Ctype.class_match_failure list
   | Unbound_val of string
@@ -111,8 +111,8 @@ type error =
   | Non_generalizable_class of Ident.t * Types.class_declaration
   | Cannot_coerce_self of type_expr
   | Non_collapsable_conjunction of
-      Ident.t * Types.class_declaration * (type_expr * type_expr) list
-  | Final_self_clash of (type_expr * type_expr) list
+      Ident.t * Types.class_declaration * Ctype.Unification_trace.t
+  | Final_self_clash of Ctype.Unification_trace.t
   | Mutability_mismatch of string * mutable_flag
   | No_overriding of string * string
   | Duplicate of string * string

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -51,13 +51,13 @@ type existential_restriction =
 
 type error =
   | Constructor_arity_mismatch of Longident.t * int * int
-  | Label_mismatch of Longident.t * (type_expr * type_expr) list
-  | Pattern_type_clash of (type_expr * type_expr) list
-  | Or_pattern_type_clash of Ident.t * (type_expr * type_expr) list
+  | Label_mismatch of Longident.t * Ctype.Unification_trace.t
+  | Pattern_type_clash of Ctype.Unification_trace.t
+  | Or_pattern_type_clash of Ident.t * Ctype.Unification_trace.t
   | Multiply_bound_variable of string
   | Orpat_vars of Ident.t * Ident.t list
   | Expr_type_clash of
-      (type_expr * type_expr) list * type_forcing_context option
+      Ctype.Unification_trace.t * type_forcing_context option
   | Apply_non_function of type_expr
   | Apply_wrong_label of arg_label * type_expr
   | Label_multiply_defined of string
@@ -75,18 +75,18 @@ type error =
   | Private_label of Longident.t * type_expr
   | Unbound_instance_variable of string * string list
   | Instance_variable_not_mutable of bool * string
-  | Not_subtype of (type_expr * type_expr) list * (type_expr * type_expr) list
+  | Not_subtype of Ctype.Unification_trace.t * Ctype.Unification_trace.t
   | Outside_class
   | Value_multiply_overridden of string
   | Coercion_failure of
-      type_expr * type_expr * (type_expr * type_expr) list * bool
+      type_expr * type_expr * Ctype.Unification_trace.t * bool
   | Too_many_arguments of bool * type_expr * type_forcing_context option
   | Abstract_wrong_label of arg_label * type_expr * type_forcing_context option
   | Scoping_let_module of string * type_expr
   | Masked_instance_variable of Longident.t
   | Not_a_variant_type of Longident.t
   | Incoherent_label_order
-  | Less_general of string * (type_expr * type_expr) list
+  | Less_general of string * Ctype.Unification_trace.t
   | Modules_not_allowed
   | Cannot_infer_signature
   | Not_a_packed_module of type_expr
@@ -1939,7 +1939,7 @@ let check_univars env expans kind exp ty_expected vars =
   let ty = newgenty (Tpoly(repr exp.exp_type, vars'))
   and ty_expected = repr ty_expected in
   raise (Error (exp.exp_loc, env,
-                Less_general(kind, [ty, ty; ty_expected, ty_expected])))
+                Less_general(kind, [Unification_trace.diff ty ty_expected])))
 
 (* Check that a type is not a function *)
 let check_application_result env statement exp =

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -118,13 +118,13 @@ val self_coercion : (Path.t * Location.t list ref) list ref
 
 type error =
   | Constructor_arity_mismatch of Longident.t * int * int
-  | Label_mismatch of Longident.t * (type_expr * type_expr) list
-  | Pattern_type_clash of (type_expr * type_expr) list
-  | Or_pattern_type_clash of Ident.t * (type_expr * type_expr) list
+  | Label_mismatch of Longident.t * Ctype.Unification_trace.t
+  | Pattern_type_clash of Ctype.Unification_trace.t
+  | Or_pattern_type_clash of Ident.t * Ctype.Unification_trace.t
   | Multiply_bound_variable of string
   | Orpat_vars of Ident.t * Ident.t list
   | Expr_type_clash of
-      (type_expr * type_expr) list * type_forcing_context option
+      Ctype.Unification_trace.t * type_forcing_context option
   | Apply_non_function of type_expr
   | Apply_wrong_label of arg_label * type_expr
   | Label_multiply_defined of string
@@ -142,18 +142,18 @@ type error =
   | Private_label of Longident.t * type_expr
   | Unbound_instance_variable of string * string list
   | Instance_variable_not_mutable of bool * string
-  | Not_subtype of (type_expr * type_expr) list * (type_expr * type_expr) list
+  | Not_subtype of Ctype.Unification_trace.t * Ctype.Unification_trace.t
   | Outside_class
   | Value_multiply_overridden of string
   | Coercion_failure of
-      type_expr * type_expr * (type_expr * type_expr) list * bool
+      type_expr * type_expr * Ctype.Unification_trace.t * bool
   | Too_many_arguments of bool * type_expr * type_forcing_context option
   | Abstract_wrong_label of arg_label * type_expr * type_forcing_context option
   | Scoping_let_module of string * type_expr
   | Masked_instance_variable of Longident.t
   | Not_a_variant_type of Longident.t
   | Incoherent_label_order
-  | Less_general of string * (type_expr * type_expr) list
+  | Less_general of string * Ctype.Unification_trace.t
   | Modules_not_allowed
   | Cannot_infer_signature
   | Not_a_packed_module of type_expr

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -35,8 +35,8 @@ type error =
   | Cycle_in_def of string * type_expr
   | Definition_mismatch of type_expr * Includecore.type_mismatch option
   | Constraint_failed of type_expr * type_expr
-  | Inconsistent_constraint of Env.t * (type_expr * type_expr) list
-  | Type_clash of Env.t * (type_expr * type_expr) list
+  | Inconsistent_constraint of Env.t * Ctype.Unification_trace.t
+  | Type_clash of Env.t * Ctype.Unification_trace.t
   | Parameters_differ of Path.t * type_expr * type_expr
   | Null_arity_external
   | Missing_native_external
@@ -44,7 +44,7 @@ type error =
   | Cannot_extend_private_type of Path.t
   | Not_extensible_type of Path.t
   | Extension_mismatch of Path.t * Includecore.type_mismatch
-  | Rebind_wrong_type of Longident.t * Env.t * (type_expr * type_expr) list
+  | Rebind_wrong_type of Longident.t * Env.t * Ctype.Unification_trace.t
   | Rebind_mismatch of Longident.t * Path.t * Path.t
   | Rebind_private of Longident.t
   | Bad_variance of int * (bool * bool * bool) * (bool * bool * bool)

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -78,8 +78,8 @@ type error =
   | Cycle_in_def of string * type_expr
   | Definition_mismatch of type_expr * Includecore.type_mismatch option
   | Constraint_failed of type_expr * type_expr
-  | Inconsistent_constraint of Env.t * (type_expr * type_expr) list
-  | Type_clash of Env.t * (type_expr * type_expr) list
+  | Inconsistent_constraint of Env.t * Ctype.Unification_trace.t
+  | Type_clash of Env.t * Ctype.Unification_trace.t
   | Parameters_differ of Path.t * type_expr * type_expr
   | Null_arity_external
   | Missing_native_external
@@ -87,7 +87,7 @@ type error =
   | Cannot_extend_private_type of Path.t
   | Not_extensible_type of Path.t
   | Extension_mismatch of Path.t * Includecore.type_mismatch
-  | Rebind_wrong_type of Longident.t * Env.t * (type_expr * type_expr) list
+  | Rebind_wrong_type of Longident.t * Env.t * Ctype.Unification_trace.t
   | Rebind_mismatch of Longident.t * Path.t * Path.t
   | Rebind_private of Longident.t
   | Bad_variance of int * (bool*bool*bool) * (bool*bool*bool)

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -34,8 +34,8 @@ type error =
   | Bound_type_variable of string
   | Recursive_type
   | Unbound_row_variable of Longident.t
-  | Type_mismatch of (type_expr * type_expr) list
-  | Alias_type_mismatch of (type_expr * type_expr) list
+  | Type_mismatch of Ctype.Unification_trace.t
+  | Alias_type_mismatch of Ctype.Unification_trace.t
   | Present_has_conjunction of string
   | Present_has_no_type of string
   | Constructor_mismatch of type_expr * type_expr
@@ -318,10 +318,6 @@ let transl_type_param env styp =
 let new_pre_univar ?name () =
   let v = newvar ?name () in pre_univars := v :: !pre_univars; v
 
-let rec swap_list = function
-    x :: y :: l -> y :: x :: swap_list l
-  | l -> l
-
 type policy = Fixed | Extensible | Univars
 
 let rec transl_type env policy styp =
@@ -398,7 +394,9 @@ and transl_type_aux env policy styp =
       List.iter2
         (fun (sty, cty) ty' ->
            try unify_param env ty' cty.ctyp_type with Unify trace ->
-             raise (Error(sty.ptyp_loc, env, Type_mismatch (swap_list trace))))
+             let trace = Unification_trace.swap trace in
+             raise (Error(sty.ptyp_loc, env, Type_mismatch trace))
+        )
         (List.combine stl args) params;
       let constr =
         newconstr path (List.map (fun ctyp -> ctyp.ctyp_type) args) in
@@ -451,7 +449,9 @@ and transl_type_aux env policy styp =
       List.iter2
         (fun (sty, cty) ty' ->
            try unify_var env ty' cty.ctyp_type with Unify trace ->
-             raise (Error(sty.ptyp_loc, env, Type_mismatch (swap_list trace))))
+             let trace = Unification_trace.swap trace in
+             raise (Error(sty.ptyp_loc, env, Type_mismatch trace))
+        )
         (List.combine stl args) params;
         let ty_args = List.map (fun ctyp -> ctyp.ctyp_type) args in
       let ty =
@@ -501,7 +501,7 @@ and transl_type_aux env policy styp =
           in
           let ty = transl_type env policy st in
           begin try unify_var env t ty.ctyp_type with Unify trace ->
-            let trace = swap_list trace in
+            let trace = Unification_trace.swap trace in
             raise(Error(styp.ptyp_loc, env, Alias_type_mismatch trace))
           end;
           ty
@@ -512,7 +512,7 @@ and transl_type_aux env policy styp =
             TyVarMap.add alias (t, styp.ptyp_loc) !used_variables;
           let ty = transl_type env policy st in
           begin try unify_var env t ty.ctyp_type with Unify trace ->
-            let trace = swap_list trace in
+            let trace = Unification_trace.swap trace in
             raise(Error(styp.ptyp_loc, env, Alias_type_mismatch trace))
           end;
           if !Clflags.principal then begin

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -46,8 +46,8 @@ type error =
   | Bound_type_variable of string
   | Recursive_type
   | Unbound_row_variable of Longident.t
-  | Type_mismatch of (type_expr * type_expr) list
-  | Alias_type_mismatch of (type_expr * type_expr) list
+  | Type_mismatch of Ctype.Unification_trace.t
+  | Alias_type_mismatch of Ctype.Unification_trace.t
   | Present_has_conjunction of string
   | Present_has_no_type of string
   | Constructor_mismatch of type_expr * type_expr


### PR DESCRIPTION
This PR proposes to create an explicit type for the unification trace.
Currently, this trace is encoded as a `(type_expr * type_expr) list` which
can exist in three modes:

- a simple mode where an element is represented as a pair of type_expr `(actual, expected)`
- an expanded mode where an element of the list represents a pair `(short_representation, expanded_representation)` for one type, and the whole type difference is encoded as two elements of the list:
`(short_actual, expanded_actual) :: (short_expected, expanded_expected) :: _ `
- a degenerate mode where some elements have been expanded twice, thus both the expected and actual type are represented by a quadruplet:
 `(short, expanded) :: (expanded, expanded_expanded) :: _` .
The trace filtering in `Printtyp` removes most of those degenerate elements, but it sometimes fails on [complex object types](https://github.com/ocaml/ocaml/blob/trunk/testsuite/tests//typing-objects-bugs/pr4018_bad.compilers.reference#L25).

Moreover, some unification errors, like scope escapes, are not naturally representable as a difference of two types. In this case, unification functions resort to some artificial encodings into a difference of type expressions. Then the function `Printtyp.mismatch` try to recover the root cause behind a given unification trace, and may [fail](https://github.com/ocaml/ocaml/blob/trunk/testsuite/tests/typing-objects-bugs/pr4824a_bad.compilers.reference#L9).

This PR proposes to define an explicit type for the unification trace.
With this type, the expanded or not status of type differences are tracked elements by elements, removing the possibility of double expansions.
Similarly, some specific errors are given their own variants and are directly tracked in the trace:
- scope escape errors,
- recursive occurrences of type variables,
- tag mismatches for polymorphic variants
- incompatible fields in object types

Simplifying the encoding for those errors may also help to give better contextual information in error messages (for instance for [MPR#7565](https://caml.inria.fr/mantis/view.php?id=7565)).