### PR TITLE
Unused rec: take local warning scope into account

### DIFF
--- a/testsuite/tests/typing-warnings/ocamltests
+++ b/testsuite/tests/typing-warnings/ocamltests
@@ -11,4 +11,5 @@ pr7261.ml
 pr7297.ml
 pr7553.ml
 records.ml
+unused_rec.ml
 unused_types.ml

--- a/testsuite/tests/typing-warnings/unused_rec.ml
+++ b/testsuite/tests/typing-warnings/unused_rec.ml
@@ -1,0 +1,45 @@
+(* TEST
+   * expect
+*)
+
+[@@@ocaml.warning "+39"]
+
+let rec f () = 3;;
+[%%expect{|
+Line 3, characters 8-9:
+  let rec f () = 3;;
+          ^
+Warning 39: unused rec flag.
+val f : unit -> int = <fun>
+|}];;
+
+let[@warning "-39"] rec g () = 3;;
+[%%expect{|
+val g : unit -> int = <fun>
+|}];;
+
+let[@warning "+39"] rec h () = 3;;
+[%%expect{|
+Line 1, characters 24-25:
+  let[@warning "+39"] rec h () = 3;;
+                          ^
+Warning 39: unused rec flag.
+val h : unit -> int = <fun>
+|}];;
+
+[@@@ocaml.warning "-39"]
+
+let rec f () = 3;;
+[%%expect{|
+val f : unit -> int = <fun>
+|}];;
+
+let[@warning "-39"] rec g () = 3;;
+[%%expect{|
+val g : unit -> int = <fun>
+|}];;
+
+let[@warning "+39"] rec h () = 3;;
+[%%expect{|
+val h : unit -> int = <fun>
+|}];;

--- a/testsuite/tests/typing-warnings/unused_rec.ml
+++ b/testsuite/tests/typing-warnings/unused_rec.ml
@@ -41,5 +41,9 @@ val g : unit -> int = <fun>
 
 let[@warning "+39"] rec h () = 3;;
 [%%expect{|
+Line 1, characters 24-25:
+  let[@warning "+39"] rec h () = 3;;
+                          ^
+Warning 39: unused rec flag.
 val h : unit -> int = <fun>
 |}];;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4426,8 +4426,7 @@ and type_let
               type_expect exp_env sexp (mk_expected pat.pat_type)))
       spat_sexp_list pat_slot_list in
   current_slot := None;
-  if is_recursive && not !rec_needed
-  && Warnings.is_active Warnings.Unused_rec_flag then begin
+  if is_recursive && not !rec_needed then begin
     let {pvb_pat; pvb_attributes} = List.hd spat_sexp_list in
     (* See PR#6677 *)
     Builtin_attributes.warning_scope ~ppwarning:false pvb_attributes


### PR DESCRIPTION
Slight improvement over ddb2826 (cf [MPR#6677](https://caml.inria.fr/mantis/view.php?id=6677)): one can also turn on the warning locally.