### PR TITLE
Allow otherlibs not to be built

### DIFF
--- a/Changes
+++ b/Changes
@@ -492,6 +492,9 @@ Working version
   (Sébastien Hinderer, review by Xavier Leroy, Damien Doligez, Gabriel
   Scherer and Armaël Guéneau)
 
+- GPR#2053: allow unix, vmthreads and str not to be built.
+  (David Allsopp, review by Sébastien Hinderer)
+
 * GPR#2059: stop defining OCAML_STDLIB_DIR in s.h.
   (Sébastien Hinderer, review by David Allsopp and Damien Doligez)
 

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -227,6 +227,7 @@ MKEXEDEBUGFLAG=@mkexedebugflag@
 RUNTIMED=@debug_runtime@
 RUNTIMEI=@instrumented_runtime@
 WITH_DEBUGGER=@with_debugger@
+WITH_CAMLTEX=@with_camltex@
 WITH_OCAMLDOC=@ocamldoc@
 ASM_CFI_SUPPORTED=@asm_cfi_supported@
 WITH_FRAME_POINTERS=@frame_pointers@

--- a/configure
+++ b/configure
@@ -724,6 +724,7 @@ x_libraries
 x_includes
 pthread_link
 ocamldoc
+with_camltex
 with_debugger
 as_has_debug_prefix_map
 cc_has_debug_prefix_map
@@ -824,10 +825,13 @@ enable_debug_runtime
 enable_debugger
 with_dllibs
 enable_instrumented_runtime
+enable_vmthreads
 enable_systhreads
 with_libunwind
 with_libunwind_include_dir
 enable_graph_lib
+enable_str_lib
+enable_unix_lib
 enable_ocamldoc
 enable_frame_pointers
 enable_naked_pointers
@@ -1502,8 +1506,11 @@ Optional Features:
   --enable-debugger       build the debugger [default=yes]
   --enable-instrumented-runtime
                           build the instrumented runtime [default=auto]
+  --disable-vmthreads     disable the bytecode threads library
   --disable-systhreads    disable the Win32/POSIX threads library
   --disable-graph-lib     do not build the graphics library
+  --disable-str-lib       do not build the str library
+  --disable-unix-lib      do not build the unix library
   --disable-ocamldoc      do not build the ocamldoc documentation system
   --enable-frame-pointers use frame pointers in runtime and generated code
   --disable-naked-pointers
@@ -2823,6 +2830,7 @@ VERSION=4.08.0+dev0-2018-04-09
 
 
 
+
 ## Generated files
 
 ac_config_files="$ac_config_files Makefile.common"
@@ -2982,7 +2990,7 @@ fi
 if test "${enable_debugger+set}" = set; then :
   enableval=$enable_debugger;
 else
-  enable_debugger=yes
+  enable_debugger=auto
 fi
 
 
@@ -3000,6 +3008,12 @@ if test "${enable_instrumented_runtime+set}" = set; then :
   enableval=$enable_instrumented_runtime;
 else
   enable_instrumented_runtime=auto
+fi
+
+
+# Check whether --enable-vmthreads was given.
+if test "${enable_vmthreads+set}" = set; then :
+  enableval=$enable_vmthreads;
 fi
 
 
@@ -3029,9 +3043,23 @@ if test "${enable_graph_lib+set}" = set; then :
 fi
 
 
+# Check whether --enable-str-lib was given.
+if test "${enable_str_lib+set}" = set; then :
+  enableval=$enable_str_lib;
+fi
+
+
+# Check whether --enable-unix-lib was given.
+if test "${enable_unix_lib+set}" = set; then :
+  enableval=$enable_unix_lib;
+fi
+
+
 # Check whether --enable-ocamldoc was given.
 if test "${enable_ocamldoc+set}" = set; then :
   enableval=$enable_ocamldoc;
+else
+  ocamldoc=auto
 fi
 
 
@@ -3156,6 +3184,25 @@ if test "${with_afl+set}" = set; then :
   withval=$with_afl;
 fi
 
+
+if test x"$enable_unix_lib" = "xno"; then :
+  if test x"$enable_debugger" = "xyes"; then :
+  as_fn_error $? "replay debugger requires the unix library" "$LINENO" 5
+else
+  enable_debugger="no"
+fi
+fi
+
+if test x"$enable_unix_lib" = "xno" -o x"$enable_str_lib" = "xno"; then :
+  if test x"$enable_ocamldoc" = "xyes"; then :
+  as_fn_error $? "ocamldoc requires the unix and str libraries" "$LINENO" 5
+else
+  enable_ocamldoc="no"
+     with_camltex=""
+fi
+else
+  with_camltex="true"
+fi
 
 # Initialization of libtool
 # Allow the MSVC linker to be found even if ld isn't installed.
@@ -12257,7 +12304,13 @@ case $host in #(
   cc_profile='-pg' ;;
 esac
 
-otherlibraries="$unixlib str dynlink bigarray"
+otherlibraries="dynlink"
+if test x"$enable_unix_lib" != "xno"; then :
+  otherlibraries="$otherlibraries $unixlib bigarray"
+fi
+if test x"$enable_str_lib" != "xno"; then :
+  otherlibraries="$otherlibraries str"
+fi
 
 # Checks for system services
 
@@ -15971,13 +16024,23 @@ fi
 
 ## Determine if the bytecode thread library is supported
 
-if $select && $setitimer && $gettimeofday && $wait; then :
+if test x"$enable_vmthreads" = "xno"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: the bytecode threads library is disabled" >&5
+$as_echo "$as_me: the bytecode threads library is disabled" >&6;}
+else
+  if $select && $setitimer && $gettimeofday && $wait; then :
   otherlibraries="$otherlibraries threads"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: the bytecode threads library is supported" >&5
+    { $as_echo "$as_me:${as_lineno-$LINENO}: the bytecode threads library is supported" >&5
 $as_echo "$as_me: the bytecode threads library is supported" >&6;}
+else
+  if test x"$enable_vmthreads" = "xyes"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: the bytecode threads library is not available" >&5
+$as_echo "$as_me: the bytecode threads library is not available" >&6;}
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: the bytecode threads library is not supported" >&5
 $as_echo "$as_me: the bytecode threads library is not supported" >&6;}
+fi
+fi
 fi
 
 ## XWindow
@@ -16798,7 +16861,7 @@ else
   install_source_artifacts=true
 fi
 
-if test x"$enable_ocamldoc" == "xno"; then :
+if test x"$enable_ocamldoc" = "xno"; then :
   ocamldoc=""
 else
   ocamldoc=ocamldoc

--- a/configure
+++ b/configure
@@ -832,6 +832,7 @@ with_libunwind_include_dir
 enable_graph_lib
 enable_str_lib
 enable_unix_lib
+enable_bigarray_lib
 enable_ocamldoc
 enable_frame_pointers
 enable_naked_pointers
@@ -1511,6 +1512,7 @@ Optional Features:
   --disable-graph-lib     do not build the graphics library
   --disable-str-lib       do not build the str library
   --disable-unix-lib      do not build the unix library
+  --disable-bigarray-lib  do not build the legacy separate bigarray library
   --disable-ocamldoc      do not build the ocamldoc documentation system
   --enable-frame-pointers use frame pointers in runtime and generated code
   --disable-naked-pointers
@@ -3055,6 +3057,12 @@ if test "${enable_unix_lib+set}" = set; then :
 fi
 
 
+# Check whether --enable-bigarray-lib was given.
+if test "${enable_bigarray_lib+set}" = set; then :
+  enableval=$enable_bigarray_lib;
+fi
+
+
 # Check whether --enable-ocamldoc was given.
 if test "${enable_ocamldoc+set}" = set; then :
   enableval=$enable_ocamldoc;
@@ -3190,6 +3198,9 @@ if test x"$enable_unix_lib" = "xno"; then :
   as_fn_error $? "replay debugger requires the unix library" "$LINENO" 5
 else
   enable_debugger="no"
+fi
+   if test x"$enable_bigarray_lib" = "xyes"; then :
+  as_fn_error $? "legacy bigarray library requires the unix library" "$LINENO" 5
 fi
 fi
 
@@ -12306,7 +12317,11 @@ esac
 
 otherlibraries="dynlink"
 if test x"$enable_unix_lib" != "xno"; then :
+  if test x"$enable_bigarray_lib" != "xno"; then :
   otherlibraries="$otherlibraries $unixlib bigarray"
+else
+  otherlibraries="$otherlibraries $unixlib"
+fi
 fi
 if test x"$enable_str_lib" != "xno"; then :
   otherlibraries="$otherlibraries str"

--- a/configure
+++ b/configure
@@ -15286,6 +15286,7 @@ esac
 ## Determine if the POSIX threads library is supported
 
 if test x"$enable_pthread" = "xno"; then :
+  systhread_support=false
   { $as_echo "$as_me:${as_lineno-$LINENO}: the POSIX threads library is disabled" >&5
 $as_echo "$as_me: the POSIX threads library is disabled" >&6;}
 else

--- a/configure
+++ b/configure
@@ -824,7 +824,7 @@ enable_debug_runtime
 enable_debugger
 with_dllibs
 enable_instrumented_runtime
-enable_pthread
+enable_systhreads
 with_libunwind
 with_libunwind_include_dir
 enable_graph_lib
@@ -1502,7 +1502,7 @@ Optional Features:
   --enable-debugger       build the debugger [default=yes]
   --enable-instrumented-runtime
                           build the instrumented runtime [default=auto]
-  --disable-pthread       disable the POSIX thread library
+  --disable-systhreads    disable the Win32/POSIX threads library
   --disable-graph-lib     do not build the graphics library
   --disable-ocamldoc      do not build the ocamldoc documentation system
   --enable-frame-pointers use frame pointers in runtime and generated code
@@ -3003,9 +3003,9 @@ else
 fi
 
 
-# Check whether --enable-pthread was given.
-if test "${enable_pthread+set}" = set; then :
-  enableval=$enable_pthread;
+# Check whether --enable-systhreads was given.
+if test "${enable_systhreads+set}" = set; then :
+  enableval=$enable_systhreads;
 fi
 
 
@@ -15285,17 +15285,17 @@ esac
 
 ## Determine if the POSIX threads library is supported
 
-if test x"$enable_pthread" = "xno"; then :
+if test x"$enable_systhreads" = "xno"; then :
   systhread_support=false
-  { $as_echo "$as_me:${as_lineno-$LINENO}: the POSIX threads library is disabled" >&5
-$as_echo "$as_me: the POSIX threads library is disabled" >&6;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: the Win32/POSIX threads library is disabled" >&5
+$as_echo "$as_me: the Win32/POSIX threads library is disabled" >&6;}
 else
   case $host in #(
   *-*-mingw32|*-pc-windows) :
     systhread_support=true
       otherlibraries="$otherlibraries systhreads"
-      { $as_echo "$as_me:${as_lineno-$LINENO}: the POSIX threads library is supported" >&5
-$as_echo "$as_me: the POSIX threads library is supported" >&6;} ;; #(
+      { $as_echo "$as_me:${as_lineno-$LINENO}: the Win32 threads library is supported" >&5
+$as_echo "$as_me: the Win32 threads library is supported" >&6;} ;; #(
   *) :
 
 
@@ -15951,7 +15951,7 @@ fi
         :
 else
         ax_pthread_ok=no
-        if test x"$enable_pthread" = "xyes"; then :
+        if test x"$enable_systhreads" = "xyes"; then :
   as_fn_error $? "the POSIX thread library is not available" "$LINENO" 5
 else
   systhread_support=false

--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,7 @@ AC_SUBST([otherlibraries])
 AC_SUBST([cc_has_debug_prefix_map])
 AC_SUBST([as_has_debug_prefix_map])
 AC_SUBST([with_debugger]) # TODO: rename this variable
+AC_SUBST([with_camltex])
 AC_SUBST([ocamldoc])
 AC_SUBST([pthread_link])
 AC_SUBST([x_includes])
@@ -207,7 +208,7 @@ AC_ARG_ENABLE([debugger],
   [AS_HELP_STRING([--enable-debugger],
     [build the debugger @<:@default=yes@:>@])],
   [],
-  [enable_debugger=yes])
+  [enable_debugger=auto])
 
 AC_ARG_WITH([dllibs],
   [AS_HELP_STRING([--with-dllibs=LIBS],
@@ -220,6 +221,10 @@ AC_ARG_ENABLE([instrumented-runtime],
     [build the instrumented runtime @<:@default=auto@:>@])],
   [],
   [enable_instrumented_runtime=auto])
+
+AC_ARG_ENABLE([vmthreads],
+  [AS_HELP_STRING([--disable-vmthreads],
+    [disable the bytecode threads library])])
 
 AC_ARG_ENABLE([systhreads],
   [AS_HELP_STRING([--disable-systhreads],
@@ -237,9 +242,19 @@ AC_ARG_ENABLE([graph-lib],
   [AS_HELP_STRING([--disable-graph-lib],
     [do not build the graphics library])])
 
+AC_ARG_ENABLE([str-lib],
+  [AS_HELP_STRING([--disable-str-lib],
+    [do not build the str library])])
+
+AC_ARG_ENABLE([unix-lib],
+  [AS_HELP_STRING([--disable-unix-lib],
+    [do not build the unix library])])
+
 AC_ARG_ENABLE([ocamldoc],
   [AS_HELP_STRING([--disable-ocamldoc],
-    [do not build the ocamldoc documentation system])])
+    [do not build the ocamldoc documentation system])],
+  [],
+  [ocamldoc=auto])
 
 AC_ARG_ENABLE([frame-pointers],
   [AS_HELP_STRING([--enable-frame-pointers],
@@ -328,6 +343,18 @@ AC_ARG_WITH([afl],
   [AS_HELP_STRING([--with-afl],
     [use the AFL fuzzer])])
 
+AS_IF([test x"$enable_unix_lib" = "xno"],
+  [AS_IF([test x"$enable_debugger" = "xyes"],
+    [AC_MSG_ERROR([replay debugger requires the unix library])],
+    [enable_debugger="no"])])
+
+AS_IF([test x"$enable_unix_lib" = "xno" -o x"$enable_str_lib" = "xno"],
+  [AS_IF([test x"$enable_ocamldoc" = "xyes"],
+    [AC_MSG_ERROR([ocamldoc requires the unix and str libraries])],
+    [enable_ocamldoc="no"
+     with_camltex=""])],
+  [with_camltex="true"])
+
 # Initialization of libtool
 # Allow the MSVC linker to be found even if ld isn't installed.
 # User-specified LD still takes precedence.
@@ -383,7 +410,11 @@ AS_CASE([$host],
   graphlib="graph"
   cc_profile='-pg'])
 
-otherlibraries="$unixlib str dynlink bigarray"
+otherlibraries="dynlink"
+AS_IF([test x"$enable_unix_lib" != "xno"],
+  [otherlibraries="$otherlibraries $unixlib bigarray"])
+AS_IF([test x"$enable_str_lib" != "xno"],
+  [otherlibraries="$otherlibraries str"])
 
 # Checks for system services
 
@@ -1435,10 +1466,14 @@ AS_IF([test x"$enable_systhreads" = "xno"],
 
 ## Determine if the bytecode thread library is supported
 
-AS_IF([$select && $setitimer && $gettimeofday && $wait],
-  [otherlibraries="$otherlibraries threads"
-  AC_MSG_NOTICE([the bytecode threads library is supported])],
-  [AC_MSG_NOTICE([the bytecode threads library is not supported])])
+AS_IF([test x"$enable_vmthreads" = "xno"],
+  [AC_MSG_NOTICE([the bytecode threads library is disabled])],
+  [AS_IF([$select && $setitimer && $gettimeofday && $wait],
+    [otherlibraries="$otherlibraries threads"
+    AC_MSG_NOTICE([the bytecode threads library is supported])],
+    [AS_IF([test x"$enable_vmthreads" = "xyes"],
+      [AC_MSG_NOTICE([the bytecode threads library is not available])],
+      [AC_MSG_NOTICE([the bytecode threads library is not supported])])])])
 
 ## XWindow
 
@@ -1580,7 +1615,7 @@ AS_IF([test x"$enable_installing_source_artifacts" = "xno"],
   [install_source_artifacts=false],
   [install_source_artifacts=true])
 
-AS_IF([test x"$enable_ocamldoc" == "xno"],
+AS_IF([test x"$enable_ocamldoc" = "xno"],
   [ocamldoc=""],
   [ocamldoc=ocamldoc])
 

--- a/configure.ac
+++ b/configure.ac
@@ -221,9 +221,9 @@ AC_ARG_ENABLE([instrumented-runtime],
   [],
   [enable_instrumented_runtime=auto])
 
-AC_ARG_ENABLE([pthread],
-  [AS_HELP_STRING([--disable-pthread],
-    [disable the POSIX thread library])])
+AC_ARG_ENABLE([systhreads],
+  [AS_HELP_STRING([--disable-systhreads],
+    [disable the Win32/POSIX threads library])])
 
 AC_ARG_WITH([libunwind],
   [AS_HELP_STRING([--with-libunwind],
@@ -1404,14 +1404,14 @@ AS_CASE([$arch,$system],
 
 ## Determine if the POSIX threads library is supported
 
-AS_IF([test x"$enable_pthread" = "xno"],
+AS_IF([test x"$enable_systhreads" = "xno"],
   [systhread_support=false
-  AC_MSG_NOTICE([the POSIX threads library is disabled])],
+  AC_MSG_NOTICE([the Win32/POSIX threads library is disabled])],
   [AS_CASE([$host],
     [*-*-mingw32|*-pc-windows],
       [systhread_support=true
       otherlibraries="$otherlibraries systhreads"
-      AC_MSG_NOTICE([the POSIX threads library is supported])],
+      AC_MSG_NOTICE([the Win32 threads library is supported])],
     [AX_PTHREAD(
       [systhread_support=true
       otherlibraries="$otherlibraries systhreads"
@@ -1428,7 +1428,7 @@ AS_IF([test x"$enable_pthread" = "xno"],
       AC_CHECK_FUNC([sigwait], [AC_DEFINE([HAS_SIGWAIT])])
       LIBS="$saved_LIBS"
       CFLAGS="$saved_CFLAGS"],
-      [AS_IF([test x"$enable_pthread" = "xyes"],
+      [AS_IF([test x"$enable_systhreads" = "xyes"],
         [AC_MSG_ERROR([the POSIX thread library is not available])],
         [systhread_support=false
         AC_MSG_NOTICE([the POSIX threads library is not supported])])])])])

--- a/configure.ac
+++ b/configure.ac
@@ -1405,7 +1405,8 @@ AS_CASE([$arch,$system],
 ## Determine if the POSIX threads library is supported
 
 AS_IF([test x"$enable_pthread" = "xno"],
-  [AC_MSG_NOTICE([the POSIX threads library is disabled])],
+  [systhread_support=false
+  AC_MSG_NOTICE([the POSIX threads library is disabled])],
   [AS_CASE([$host],
     [*-*-mingw32|*-pc-windows],
       [systhread_support=true

--- a/configure.ac
+++ b/configure.ac
@@ -250,6 +250,10 @@ AC_ARG_ENABLE([unix-lib],
   [AS_HELP_STRING([--disable-unix-lib],
     [do not build the unix library])])
 
+AC_ARG_ENABLE([bigarray-lib],
+  [AS_HELP_STRING([--disable-bigarray-lib],
+    [do not build the legacy separate bigarray library])])
+
 AC_ARG_ENABLE([ocamldoc],
   [AS_HELP_STRING([--disable-ocamldoc],
     [do not build the ocamldoc documentation system])],
@@ -346,7 +350,9 @@ AC_ARG_WITH([afl],
 AS_IF([test x"$enable_unix_lib" = "xno"],
   [AS_IF([test x"$enable_debugger" = "xyes"],
     [AC_MSG_ERROR([replay debugger requires the unix library])],
-    [enable_debugger="no"])])
+    [enable_debugger="no"])
+   AS_IF([test x"$enable_bigarray_lib" = "xyes"],
+    [AC_MSG_ERROR([legacy bigarray library requires the unix library])])])
 
 AS_IF([test x"$enable_unix_lib" = "xno" -o x"$enable_str_lib" = "xno"],
   [AS_IF([test x"$enable_ocamldoc" = "xyes"],
@@ -412,7 +418,9 @@ AS_CASE([$host],
 
 otherlibraries="dynlink"
 AS_IF([test x"$enable_unix_lib" != "xno"],
-  [otherlibraries="$otherlibraries $unixlib bigarray"])
+  [AS_IF([test x"$enable_bigarray_lib" != "xno"],
+    [otherlibraries="$otherlibraries $unixlib bigarray"],
+    [otherlibraries="$otherlibraries $unixlib"])])
 AS_IF([test x"$enable_str_lib" != "xno"],
   [otherlibraries="$otherlibraries str"])
 

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -20,6 +20,18 @@ ROOTDIR = ..
 include $(ROOTDIR)/Makefile.config
 include $(ROOTDIR)/Makefile.common
 
+ifeq "$(filter str,$(OTHERLIBRARIES))" ""
+  str := false
+else
+  str := true
+endif
+
+ifeq "$(filter systhreads,$(OTHERLIBRARIES))" ""
+  systhreads := false
+else
+  systhreads := true
+endif
+
 ifeq "$(filter $(UNIXLIB),$(OTHERLIBRARIES))" ""
   unix := None
 else
@@ -214,6 +226,8 @@ ocamltest_config.ml: ocamltest_config.ml.in Makefile
 	  -e 's|@@ARCH@@|$(ARCH)|' \
 	  -e 's|@@SHARED_LIBRARIES@@|$(SUPPORTS_SHARED_LIBRARIES)|' \
 	  -e 's|@@UNIX@@|$(unix)|' \
+	  -e 's|@@SYSTHREADS@@|$(systhreads)|' \
+	  -e 's|@@STR@@|$(str)|' \
 	  -e 's|@@SYSTEM@@|$(SYSTEM)|' \
 	  -e 's|@@CPP@@|$(CPP)|' \
 	  -e 's|@@OCAMLCDEFAULTFLAGS@@|$(ocamlcdefaultflags)|' \

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -20,13 +20,21 @@ ROOTDIR = ..
 include $(ROOTDIR)/Makefile.config
 include $(ROOTDIR)/Makefile.common
 
+ifeq "$(filter $(UNIXLIB),$(OTHERLIBRARIES))" ""
+  unix := None
+else
+  ifeq "$(UNIX_OR_WIN32)" "win32"
+    unix := Some false
+  else
+    unix := Some true
+  endif
+endif
+
 ifeq "$(UNIX_OR_WIN32)" "win32"
-  unix := false
   ocamlsrcdir := $(shell echo "$(abspath $(shell pwd)/..)"|cygpath -w -f - \
     | sed 's/\\/\\\\\\\\/g')
   mkexe := $(MKEXE_ANSI) -link $(OC_LDFLAGS)
 else
-  unix := true
   ocamlsrcdir := $(abspath $(shell pwd)/..)
   mkexe := $(MKEXE)
 endif

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -62,15 +62,21 @@ let dumpenv = make
   (fun log env ->
     Environments.dump log env; (Result.pass, env))
 
+let hasunix = make
+  "hasunix"
+  (Actions_helpers.pass_or_skip (Ocamltest_config.libunix <> None)
+    "unix library available"
+    "unix library not available")
+
 let libunix = make
   "libunix"
-  (Actions_helpers.pass_or_skip Ocamltest_config.libunix
+  (Actions_helpers.pass_or_skip (Ocamltest_config.libunix = Some true)
     "libunix available"
     "libunix not available")
 
 let libwin32unix = make
   "libwin32unix"
-  (Actions_helpers.pass_or_skip (not Ocamltest_config.libunix)
+  (Actions_helpers.pass_or_skip (Ocamltest_config.libunix = Some false)
     "libwin32unix available"
     "libwin32unix not available")
 
@@ -170,6 +176,7 @@ let _ =
     fail;
     cd;
     dumpenv;
+    hasunix;
     libunix;
     libwin32unix;
     windows;

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -80,6 +80,18 @@ let libwin32unix = make
     "libwin32unix available"
     "libwin32unix not available")
 
+let hassysthreads = make
+  "hassysthreads"
+  (Actions_helpers.pass_or_skip Ocamltest_config.systhreads
+    "systhreads library available"
+    "systhreads library not available")
+
+let hasstr = make
+  "hasstr"
+  (Actions_helpers.pass_or_skip Ocamltest_config.str
+    "str library available"
+    "str library not available")
+
 let windows_OS = "Windows_NT"
 
 let get_OS () = Sys.safe_getenv "OS"
@@ -177,6 +189,8 @@ let _ =
     cd;
     dumpenv;
     hasunix;
+    hassysthreads;
+    hasstr;
     libunix;
     libwin32unix;
     windows;

--- a/ocamltest/builtin_actions.mli
+++ b/ocamltest/builtin_actions.mli
@@ -21,6 +21,7 @@ val fail : Actions.t
 
 val dumpenv : Actions.t
 
+val hasunix : Actions.t
 val libunix : Actions.t
 val libwin32unix : Actions.t
 

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -1118,6 +1118,12 @@ let native_dynlink = Actions.make
     "native dynlink support available"
     "native dynlink support not available")
 
+let debugger = Actions.make
+  "debugger"
+  (Actions_helpers.pass_or_skip Ocamltest_config.ocamldebug
+     "debugger available"
+     "debugger not available")
+
 let csharp_compiler = Actions.make
   "csharp-compiler"
   (Actions_helpers.pass_or_skip (Ocamltest_config.csc<>"")
@@ -1331,6 +1337,7 @@ let _ =
     shared_libraries;
     native_compiler;
     native_dynlink;
+    debugger;
     csharp_compiler;
     windows_unicode;
     afl_instrument;

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -31,6 +31,10 @@ let shared_libraries = @@SHARED_LIBRARIES@@
 
 let libunix = @@UNIX@@
 
+let systhreads = @@SYSTHREADS@@
+
+let str = @@STR@@
+
 let objext = "@@OBJEXT@@"
 
 let system = "@@SYSTEM@@"

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -40,6 +40,12 @@ val libunix : bool option
 (** [Some true] for unix, [Some false] for win32unix, or [None] if neither is
     built. *)
 
+val systhreads : bool
+(** Indicates whether systhreads is available. *)
+
+val str : bool
+(** Indicates whether str is available. *)
+
 val objext : string
 (** Extension of object files *)
 

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -36,8 +36,9 @@ val ccomptype : string
 val shared_libraries : bool
 (** [true] if shared libraries are supported, [false] otherwise *)
 
-val libunix : bool
-(** [true] for unix, [false] for win32unix *)
+val libunix : bool option
+(** [Some true] for unix, [Some false] for win32unix, or [None] if neither is
+    built. *)
 
 val objext : string
 (** Extension of object files *)

--- a/testsuite/tests/ast-invariants/test.ml
+++ b/testsuite/tests/ast-invariants/test.ml
@@ -1,8 +1,9 @@
 (* TEST
    include ocamlcommon
+   * hasunix
    include unix
    arguments = "${ocamlsrcdir}"
-   * native
+   ** native
 *)
 
 (* This test checks all ml files in the ocaml repository that are accepted

--- a/testsuite/tests/backtrace/callstack.ml
+++ b/testsuite/tests/backtrace/callstack.ml
@@ -1,11 +1,12 @@
 (* TEST
    flags = "-g"
+   * hassysthreads
    include systhreads
    compare_programs = "false"
-   * no-flambda
+   ** no-flambda
    reference = "${test_source_directory}/callstack.reference"
-   ** native
-   ** bytecode
+   *** native
+   *** bytecode
 *)
 let[@inline never] f0 () =
   Printexc.print_raw_backtrace stdout (Printexc.get_callstack 100); ()

--- a/testsuite/tests/backtrace/callstack.reference
+++ b/testsuite/tests/backtrace/callstack.reference
@@ -1,12 +1,12 @@
 main thread:
-Raised by primitive operation at file "callstack.ml", line 11, characters 38-66
-Called from file "callstack.ml", line 12, characters 27-32
+Raised by primitive operation at file "callstack.ml", line 12, characters 38-66
 Called from file "callstack.ml", line 13, characters 27-32
 Called from file "callstack.ml", line 14, characters 27-32
-Called from file "callstack.ml", line 16, characters 9-14
+Called from file "callstack.ml", line 15, characters 27-32
+Called from file "callstack.ml", line 17, characters 9-14
 new thread:
-Raised by primitive operation at file "callstack.ml", line 11, characters 38-66
-Called from file "callstack.ml", line 12, characters 27-32
+Raised by primitive operation at file "callstack.ml", line 12, characters 38-66
 Called from file "callstack.ml", line 13, characters 27-32
 Called from file "callstack.ml", line 14, characters 27-32
+Called from file "callstack.ml", line 15, characters 27-32
 Called from file "thread.ml", line 39, characters 8-14

--- a/testsuite/tests/lib-bigarray-file/mapfile.ml
+++ b/testsuite/tests/lib-bigarray-file/mapfile.ml
@@ -1,4 +1,5 @@
 (* TEST
+   * hasunix
    include unix
 *)
 

--- a/testsuite/tests/lib-dynlink-native/main.ml
+++ b/testsuite/tests/lib-dynlink-native/main.ml
@@ -5,193 +5,194 @@ files = "a.ml api.ml b.ml bug.ml c.ml factorial.c pack_client.ml \
          plugin_high_arity.ml plugin.ml plugin.mli plugin_ref.ml \
          plugin_simple.ml plugin_thread.ml"
 
+* hassysthreads
 include systhreads
 include dynlink
 
 set subdir = "${test_source_directory}/sub"
 
-* native-dynlink
+** native-dynlink
 libraries = "" (* We will add them manually where appropriated *)
-** setup-ocamlopt.byte-build-env
+*** setup-ocamlopt.byte-build-env
 ocamlopt_default_flags = "" (* Removes the -ccopt -no-pie on ised on OpenBSD *)
-*** script
-script = "mkdir sub"
 **** script
+script = "mkdir sub"
+***** script
 script = "cp ${subdir}/api.mli ${subdir}/api.ml ${subdir}/plugin3.ml \
              ${subdir}/plugin.ml sub"
-***** ocamlopt.byte
-module = "api.ml"
 ****** ocamlopt.byte
+module = "api.ml"
+******* ocamlopt.byte
 flags = "-opaque"
 module = "plugin.mli"
-******* ocamlopt.byte
+******** ocamlopt.byte
 flags = ""
 module = "plugin.ml"
-******** ocamlopt.byte
+********* ocamlopt.byte
 module= ""
 flags = "-shared"
 program = "plugin.so"
 all_modules = "plugin.cmx"
-********* script
+********** script
 script = "mv plugin.cmx plugin.cmx.bak"
-********** ocamlopt.byte
+*********** ocamlopt.byte
 flags = ""
 module = "plugin2.ml"
-*********** script
+************ script
 script = "mv plugin.cmx.bak plugin.cmx"
-************ ocamlopt.byte
+************* ocamlopt.byte
 module= ""
 flags = "-shared"
 program = "plugin2.so"
 all_modules = "plugin2.cmx"
-************* ocamlopt.byte
+************** ocamlopt.byte
 flags = ""
 module = "sub/plugin.ml"
-************** ocamlopt.byte
+*************** ocamlopt.byte
 module = ""
 flags = "-shared"
 program = "sub/plugin.so"
 all_modules = "sub/plugin.cmx"
-*************** cd
+**************** cd
 cwd = "sub"
-**************** ocamlopt.byte
+***************** ocamlopt.byte
 module = "api.mli"
 flags = "-opaque"
-***************** ocamlopt.byte
+****************** ocamlopt.byte
 flags = ""
 module = "api.ml"
-****************** script
+******************* script
 script = "mv api.cmx api.cmx.bak"
-******************* ocamlopt.byte
+******************** ocamlopt.byte
 module = "plugin3.ml"
-******************** script
+********************* script
 script = "mv api.cmx.bak api.cmx"
-********************* cd
+********************** cd
 cwd = ".."
-********************** ocamlopt.byte
+*********************** ocamlopt.byte
 module = ""
 flags = "-shared"
 program = "sub/plugin3.so"
 all_modules = "sub/plugin3.cmx"
-*********************** ocamlopt.byte
+************************ ocamlopt.byte
 flags = ""
 module = "plugin4.ml"
-************************ ocamlopt.byte
+************************* ocamlopt.byte
 module = ""
 flags = "-shared"
 program = "plugin4.so"
 all_modules = "plugin4.cmx"
-************************* ocamlopt.byte
+************************** ocamlopt.byte
 module = "packed1.ml"
 flags = "-for-pack Mypack"
-************************** ocamlopt.byte
+*************************** ocamlopt.byte
 flags = "-S -pack"
 module = ""
 program = "mypack.cmx"
 all_modules = "packed1.cmx"
-*************************** ocamlopt.byte
+**************************** ocamlopt.byte
 program = "mypack.so"
 flags = "-shared"
 all_modules = "mypack.cmx"
-**************************** ocamlopt.byte
+***************************** ocamlopt.byte
 program = "packed1.so"
 flags = "-shared"
 all_modules = "packed1.cmx"
-***************************** ocamlopt.byte
+****************************** ocamlopt.byte
 flags = ""
 module = "packed1_client.ml"
-****************************** ocamlopt.byte
+******************************* ocamlopt.byte
 module = ""
 program = "packed1_client.so"
 flags = "-shared"
 all_modules = "packed1_client.cmx"
-******************************* ocamlopt.byte
+******************************** ocamlopt.byte
 flags = ""
 module = "pack_client.ml"
-******************************** ocamlopt.byte
+********************************* ocamlopt.byte
 module = ""
 program = "pack_client.so"
 flags = "-shared"
 all_modules = "pack_client.cmx"
-********************************* ocamlopt.byte
+********************************** ocamlopt.byte
 flags = ""
 module = "plugin_ref.ml"
-********************************** ocamlopt.byte
+*********************************** ocamlopt.byte
 module = ""
 program = "plugin_ref.so"
 flags = "-shared"
 all_modules = "plugin_ref.cmx"
-*********************************** ocamlopt.byte
+************************************ ocamlopt.byte
 flags = ""
 module = "plugin_high_arity.ml"
-************************************ ocamlopt.byte
+************************************* ocamlopt.byte
 module = ""
 program = "plugin_high_arity.so"
 flags = "-shared"
 all_modules = "plugin_high_arity.cmx"
-************************************* ocamlopt.byte
+************************************** ocamlopt.byte
 flags = "-ccopt ${shared_library_cflags}"
 module = "factorial.c"
-************************************** ocamlopt.byte
+*************************************** ocamlopt.byte
 flags = ""
 module = "plugin_ext.ml"
-*************************************** ocamlopt.byte
+**************************************** ocamlopt.byte
 module = ""
 program = "plugin_ext.so"
 flags = "-shared"
 all_modules = "factorial.${objext} plugin_ext.cmx"
-**************************************** ocamlopt.byte
+***************************************** ocamlopt.byte
 module = "plugin_simple.ml"
 flags = ""
-***************************************** ocamlopt.byte
+****************************************** ocamlopt.byte
 module = ""
 program = "plugin_simple.so"
 flags = "-shared"
 all_modules = "plugin_simple.cmx"
-***************************************** ocamlopt.byte
+****************************************** ocamlopt.byte
 module = "bug.ml"
 flags = ""
-****************************************** ocamlopt.byte
+******************************************* ocamlopt.byte
 module = ""
 program = "bug.so"
 flags = "-shared"
 all_modules = "bug.cmx"
-****************************************** ocamlopt.byte
+******************************************* ocamlopt.byte
 module = "plugin_thread.ml"
 flags = ""
-******************************************* ocamlopt.byte
+******************************************** ocamlopt.byte
 module = ""
 program = "plugin_thread.so"
 flags = "-shared"
 all_modules = "plugin_thread.cmx"
-******************************************** ocamlopt.byte
+********************************************* ocamlopt.byte
 program = "plugin4_unix.so"
 all_modules = "unix.cmxa plugin4.cmx"
-********************************************* ocamlopt.byte
+********************************************** ocamlopt.byte
 flags = ""
 compile_only = "true"
 all_modules = "a.ml b.ml c.ml main.ml"
-********************************************** ocamlopt.byte
+*********************************************** ocamlopt.byte
 module = ""
 compile_only = "false"
 flags = "-shared"
 program = "a.so"
 all_modules = "a.cmx"
-*********************************************** ocamlopt.byte
+************************************************ ocamlopt.byte
 program = "b.so"
 all_modules = "b.cmx"
-************************************************ ocamlopt.byte
+************************************************* ocamlopt.byte
 program = "c.so"
 all_modules = "c.cmx"
-************************************************* ocamlopt.byte
+************************************************** ocamlopt.byte
 program = "mylib.cmxa"
 flags = "-a"
 all_modules = "plugin.cmx plugin2.cmx"
-************************************************** ocamlopt.byte
+*************************************************** ocamlopt.byte
 program = "mylib.so"
 flags = "-shared -linkall"
 all_modules = "mylib.cmxa"
-*************************************************** ocamlopt.byte
+**************************************************** ocamlopt.byte
 program = "${test_build_directory}/main.exe"
 libraries = "unix threads dynlink"
 flags = "-linkall"
@@ -206,9 +207,9 @@ We thus do not check compiler output. This was not done either before the
 test was ported to ocamltest.
 *)
 
-**************************************************** run
+***************************************************** run
 arguments = "plugin.so plugin2.so plugin_thread.so"
-***************************************************** check-program-output
+****************************************************** check-program-output
 *)
 
 let () =

--- a/testsuite/tests/lib-scanf-2/tscanf2_master.ml
+++ b/testsuite/tests/lib-scanf-2/tscanf2_master.ml
@@ -1,57 +1,58 @@
 (* TEST
 
-include unix
 modules = "tscanf2_io.ml"
+* hasunix
+include unix
 files = "tscanf2_worker.ml"
 reference = "${test_source_directory}/tscanf2.reference"
 
 (* The bytcode test *)
 
-* setup-ocamlc.byte-build-env
+** setup-ocamlc.byte-build-env
 
 program = "${test_build_directory}/master.byte"
 
-** ocamlc.byte (* Compiles the master *)
+*** ocamlc.byte (* Compiles the master *)
 
-*** ocamlc.byte (* Compiles the worker *)
+**** ocamlc.byte (* Compiles the worker *)
 
 all_modules = "tscanf2_io.cmo tscanf2_worker.ml"
 
 program = "${test_build_directory}/worker.byte"
 
-**** check-ocamlc.byte-output
+***** check-ocamlc.byte-output
 
-***** run
+****** run
 
 program = "${test_build_directory}/master.byte"
 
 arguments = "${test_build_directory}/worker.byte"
 
-****** check-program-output
+******* check-program-output
 
 (* The native test *)
 
-* setup-ocamlopt.byte-build-env
+** setup-ocamlopt.byte-build-env
 
 program = "${test_build_directory}/master.opt"
 
-** ocamlopt.byte (* Compiles the master *)
+*** ocamlopt.byte (* Compiles the master *)
 
-*** ocamlopt.byte (* Compiles the worker *)
+**** ocamlopt.byte (* Compiles the worker *)
 
 all_modules = "tscanf2_io.cmx tscanf2_worker.ml"
 
 program = "${test_build_directory}/worker.opt"
 
-**** check-ocamlopt.byte-output
+***** check-ocamlopt.byte-output
 
-***** run
+****** run
 
 program = "${test_build_directory}/master.opt"
 
 arguments = "${test_build_directory}/worker.opt"
 
-****** check-program-output
+******* check-program-output
 
 *)
 

--- a/testsuite/tests/lib-str/t01.ml
+++ b/testsuite/tests/lib-str/t01.ml
@@ -1,4 +1,5 @@
 (* TEST
+   * hasstr
    include str
 *)
 

--- a/testsuite/tests/lib-systhreads/testfork.ml
+++ b/testsuite/tests/lib-systhreads/testfork.ml
@@ -1,9 +1,10 @@
 (* TEST
+   * hassysthreads
    include systhreads
-   * not-bsd
-   ** libunix
-   *** bytecode
-   *** native
+   ** not-bsd
+   *** libunix
+   **** bytecode
+   **** native
 *)
 
 (* POSIX threads and fork() *)

--- a/testsuite/tests/lib-systhreads/testpreempt.ml
+++ b/testsuite/tests/lib-systhreads/testpreempt.ml
@@ -1,13 +1,14 @@
 (* TEST
+   * hassysthreads
    (*
      On Windows, we use Sleep(0) for triggering preemption of threads.
      However, this does not seem very reliable, so that this test fails
      on some Windows configurations. See GPR #1533.
    *)
    include systhreads
-   * not-windows
-   ** bytecode
-   ** native
+   ** not-windows
+   *** bytecode
+   *** native
 *)
 
 let rec generate_list n =

--- a/testsuite/tests/lib-threads/backtrace_threads.ml
+++ b/testsuite/tests/lib-threads/backtrace_threads.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-threads/bank.ml
+++ b/testsuite/tests/lib-threads/bank.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-threads/beat.ml
+++ b/testsuite/tests/lib-threads/beat.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-threads/bufchan.ml
+++ b/testsuite/tests/lib-threads/bufchan.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-threads/close.ml
+++ b/testsuite/tests/lib-threads/close.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-threads/fileio.ml
+++ b/testsuite/tests/lib-threads/fileio.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-threads/pr4466.ml
+++ b/testsuite/tests/lib-threads/pr4466.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-threads/pr5325.ml
+++ b/testsuite/tests/lib-threads/pr5325.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-threads/pr7638.ml
+++ b/testsuite/tests/lib-threads/pr7638.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-threads/prodcons.ml
+++ b/testsuite/tests/lib-threads/prodcons.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-threads/prodcons2.ml
+++ b/testsuite/tests/lib-threads/prodcons2.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-threads/sieve.ml
+++ b/testsuite/tests/lib-threads/sieve.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-threads/signal.ml
+++ b/testsuite/tests/lib-threads/signal.ml
@@ -1,46 +1,47 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 files = "sigint.c"
 
-* libunix (* excludes mingw32/64 and msvc32/64 *)
+** libunix (* excludes mingw32/64 and msvc32/64 *)
 
-** setup-ocamlc.byte-build-env
+*** setup-ocamlc.byte-build-env
 
 program = "${test_build_directory}/signal.byte"
 
-*** ocamlc.byte
+**** ocamlc.byte
 
 program = "sigint"
 all_modules = "sigint.c"
 
-**** ocamlc.byte
+***** ocamlc.byte
 
 program = "${test_build_directory}/signal.byte"
 all_modules = "signal.ml"
 
-***** check-ocamlc.byte-output
-****** run
-******* check-program-output
+****** check-ocamlc.byte-output
+******* run
+******** check-program-output
 
-** setup-ocamlopt.byte-build-env
+*** setup-ocamlopt.byte-build-env
 
 program = "${test_build_directory}/signal.opt"
 
-*** ocamlopt.byte
+**** ocamlopt.byte
 
 program = "sigint"
 all_modules = "sigint.c"
 
-**** ocamlc.byte
+***** ocamlc.byte
 
 program = "${test_build_directory}/signal.opt"
 all_modules = "signal.ml"
 
-***** check-ocamlopt.byte-output
-****** run
-******* check-program-output
+****** check-ocamlopt.byte-output
+******* run
+******** check-program-output
 
 *)
 

--- a/testsuite/tests/lib-threads/sockets.ml
+++ b/testsuite/tests/lib-threads/sockets.ml
@@ -1,10 +1,11 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
-* libunix (* Broken on Windows (missing join?), needs to be fixed *)
-** bytecode
-** native
+** libunix (* Broken on Windows (missing join?), needs to be fixed *)
+*** bytecode
+*** native
 
 *)
 

--- a/testsuite/tests/lib-threads/swapchan.ml
+++ b/testsuite/tests/lib-threads/swapchan.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-threads/tls.ml
+++ b/testsuite/tests/lib-threads/tls.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-threads/torture.ml
+++ b/testsuite/tests/lib-threads/torture.ml
@@ -1,5 +1,6 @@
 (* TEST
 
+* hassysthreads
 include systhreads
 
 *)

--- a/testsuite/tests/lib-unix/common/channel_of.ml
+++ b/testsuite/tests/lib-unix/common/channel_of.ml
@@ -1,4 +1,5 @@
 (* TEST
+* hasunix
 include unix
 *)
 

--- a/testsuite/tests/lib-unix/common/cloexec.ml
+++ b/testsuite/tests/lib-unix/common/cloexec.ml
@@ -14,33 +14,34 @@
   already does.
 *)
 
+* hasunix
 include unix
 files = "fdstatus_aux.c fdstatus_main.ml"
 
-*libunix
-** setup-ocamlc.byte-build-env
+**libunix
+*** setup-ocamlc.byte-build-env
 program = "${test_build_directory}/cloexec.byte"
-*** ocamlc.byte
-program = "${test_build_directory}/fdstatus.exe"
-all_modules = "fdstatus_aux.c fdstatus_main.ml"
 **** ocamlc.byte
-program = "${test_build_directory}/cloexec.byte"
-all_modules= "cloexec.ml"
-***** check-ocamlc.byte-output
-****** run
-******* check-program-output
-
-** setup-ocamlopt.byte-build-env
-program = "${test_build_directory}/cloexec.opt"
-*** ocamlopt.byte
 program = "${test_build_directory}/fdstatus.exe"
 all_modules = "fdstatus_aux.c fdstatus_main.ml"
+***** ocamlc.byte
+program = "${test_build_directory}/cloexec.byte"
+all_modules= "cloexec.ml"
+****** check-ocamlc.byte-output
+******* run
+******** check-program-output
+
+*** setup-ocamlopt.byte-build-env
+program = "${test_build_directory}/cloexec.opt"
 **** ocamlopt.byte
+program = "${test_build_directory}/fdstatus.exe"
+all_modules = "fdstatus_aux.c fdstatus_main.ml"
+***** ocamlopt.byte
 program = "${test_build_directory}/cloexec.opt"
 all_modules= "cloexec.ml"
-***** check-ocamlopt.byte-output
-****** run
-******* check-program-output
+****** check-ocamlopt.byte-output
+******* run
+******** check-program-output
 
 *)
 

--- a/testsuite/tests/lib-unix/common/dup.ml
+++ b/testsuite/tests/lib-unix/common/dup.ml
@@ -1,4 +1,5 @@
 (* TEST
+* hasunix
 include unix
 *)
 

--- a/testsuite/tests/lib-unix/common/dup2.ml
+++ b/testsuite/tests/lib-unix/common/dup2.ml
@@ -1,4 +1,5 @@
 (* TEST
+* hasunix
 include unix
 stderr = "/dev/null"
 *)

--- a/testsuite/tests/lib-unix/common/getaddrinfo.ml
+++ b/testsuite/tests/lib-unix/common/getaddrinfo.ml
@@ -1,4 +1,5 @@
 (* TEST
+* hasunix
 include unix
 *)
 

--- a/testsuite/tests/lib-unix/common/pipe_eof.ml
+++ b/testsuite/tests/lib-unix/common/pipe_eof.ml
@@ -1,4 +1,5 @@
 (* TEST
+* hasunix
 include unix
 *)
 

--- a/testsuite/tests/lib-unix/common/redirections.ml
+++ b/testsuite/tests/lib-unix/common/redirections.ml
@@ -2,31 +2,32 @@
 
 files = "reflector.ml"
 
-* setup-ocamlc.byte-build-env
+* hasunix
+** setup-ocamlc.byte-build-env
 program = "${test_build_directory}/redirections.byte"
-** ocamlc.byte
-program = "${test_build_directory}/reflector.exe"
-all_modules = "reflector.ml"
 *** ocamlc.byte
+program = "${test_build_directory}/reflector.exe"
+all_modules = "reflector.ml"
+**** ocamlc.byte
 include unix
 program = "${test_build_directory}/redirections.byte"
 all_modules= "redirections.ml"
-**** check-ocamlc.byte-output
-***** run
-****** check-program-output
+***** check-ocamlc.byte-output
+****** run
+******* check-program-output
 
-* setup-ocamlopt.byte-build-env
+** setup-ocamlopt.byte-build-env
 program = "${test_build_directory}/redirections.opt"
-** ocamlopt.byte
+*** ocamlopt.byte
 program = "${test_build_directory}/reflector.exe"
 all_modules = "reflector.ml"
-*** ocamlopt.byte
+**** ocamlopt.byte
 include unix
 program = "${test_build_directory}/redirections.opt"
 all_modules= "redirections.ml"
-**** check-ocamlopt.byte-output
-***** run
-****** check-program-output
+***** check-ocamlopt.byte-output
+****** run
+******* check-program-output
 
 *)
 

--- a/testsuite/tests/lib-unix/common/rename.ml
+++ b/testsuite/tests/lib-unix/common/rename.ml
@@ -1,4 +1,5 @@
 (* TEST
+* hasunix
 include unix
 *)
 

--- a/testsuite/tests/lib-unix/common/test_unix_cmdline.ml
+++ b/testsuite/tests/lib-unix/common/test_unix_cmdline.ml
@@ -2,31 +2,32 @@
 
 files = "cmdline_prog.ml"
 
-* setup-ocamlc.byte-build-env
+* hasunix
+** setup-ocamlc.byte-build-env
 program = "${test_build_directory}/test_unix_cmdline.byte"
-** ocamlc.byte
-program = "${test_build_directory}/cmdline_prog.exe"
-all_modules = "cmdline_prog.ml"
 *** ocamlc.byte
+program = "${test_build_directory}/cmdline_prog.exe"
+all_modules = "cmdline_prog.ml"
+**** ocamlc.byte
 include unix
 program = "${test_build_directory}/test_unix_cmdline.byte"
 all_modules= "test_unix_cmdline.ml"
-**** check-ocamlc.byte-output
-***** run
-****** check-program-output
+***** check-ocamlc.byte-output
+****** run
+******* check-program-output
 
-* setup-ocamlopt.byte-build-env
+** setup-ocamlopt.byte-build-env
 program = "${test_build_directory}/test_unix_cmdline.opt"
-** ocamlc.byte
+*** ocamlc.byte
 program = "${test_build_directory}/cmdline_prog.exe"
 all_modules = "cmdline_prog.ml"
-*** ocamlopt.byte
+**** ocamlopt.byte
 include unix
 program = "${test_build_directory}/test_unix_cmdline.opt"
 all_modules= "test_unix_cmdline.ml"
-**** check-ocamlopt.byte-output
-***** run
-****** check-program-output
+***** check-ocamlopt.byte-output
+****** run
+******* check-program-output
 
 *)
 

--- a/testsuite/tests/lib-unix/common/utimes.ml
+++ b/testsuite/tests/lib-unix/common/utimes.ml
@@ -1,4 +1,5 @@
 (* TEST
+* hasunix
 include unix
 files = "utimes.txt"
 *)

--- a/testsuite/tests/lib-unix/common/wait_nohang.ml
+++ b/testsuite/tests/lib-unix/common/wait_nohang.ml
@@ -1,4 +1,5 @@
 (* TEST
+* hasunix
 include unix
 *)
 

--- a/testsuite/tests/lib-unix/isatty/isatty_std.ml
+++ b/testsuite/tests/lib-unix/isatty/isatty_std.ml
@@ -1,4 +1,5 @@
 (* TEST
+* hasunix
 include unix
 stdin = "/dev/null"
 stderr = "/dev/null"

--- a/testsuite/tests/lib-unix/unix-execvpe/exec.ml
+++ b/testsuite/tests/lib-unix/unix-execvpe/exec.ml
@@ -1,9 +1,10 @@
 (* TEST
+   * hasunix
    include unix
    script = "sh ${test_source_directory}/has-execvpe.sh"
-   * script
-   ** bytecode
-   ** native
+   ** script
+   *** bytecode
+   *** native
 *)
 
 open Printf

--- a/testsuite/tests/lib-unix/win-stat/test.ml
+++ b/testsuite/tests/lib-unix/win-stat/test.ml
@@ -1,7 +1,7 @@
 (* TEST
-include unix
 modules = "fakeclock.c"
-* windows
+* libwin32unix
+include unix
 ** bytecode
 ** native
 *)

--- a/testsuite/tests/lib-unix/win-symlink/test.ml
+++ b/testsuite/tests/lib-unix/win-symlink/test.ml
@@ -1,7 +1,7 @@
 (* TEST
 
+* libwin32unix
    include unix
-* windows
 ** has_symlink
 *** bytecode
 *** native

--- a/testsuite/tests/tool-caml-tex/ellipses.ml
+++ b/testsuite/tests/tool-caml-tex/ellipses.ml
@@ -3,9 +3,10 @@
    output="ellipses.output"
    script = "${ocamlrun} ${ocamlsrcdir}/tools/caml-tex \
    -repo-root ${ocamlsrcdir} ${test_source_directory}/${test_file} -o ${output}"
-  * native-compiler
-  ** script with unix,str
-  *** check-program-output
+  * hasstr
+  ** native-compiler
+  *** script with unix,str
+  **** check-program-output
 *)
 
 \begin{caml_example*}{verbatim}

--- a/testsuite/tests/tool-caml-tex/ellipses.reference
+++ b/testsuite/tests/tool-caml-tex/ellipses.reference
@@ -3,9 +3,10 @@
    output="ellipses.output"
    script = "${ocamlrun} ${ocamlsrcdir}/tools/caml-tex \
    -repo-root ${ocamlsrcdir} ${test_source_directory}/${test_file} -o ${output}"
-  * native-compiler
-  ** script with unix,str
-  *** check-program-output
+  * hasstr
+  ** native-compiler
+  *** script with unix,str
+  **** check-program-output
 *)
 
 \camlexample{verbatim}

--- a/testsuite/tests/tool-caml-tex/redirections.ml
+++ b/testsuite/tests/tool-caml-tex/redirections.ml
@@ -3,9 +3,10 @@
    output="redirections.output"
    script = "${ocamlrun} ${ocamlsrcdir}/tools/caml-tex \
    -repo-root ${ocamlsrcdir} ${test_source_directory}/${test_file} -o ${output}"
-  * native-compiler
-  ** script with unix,str
-  *** check-program-output
+  * hasstr
+  ** native-compiler
+  *** script with unix,str
+  **** check-program-output
 *)
 
 \begin{caml_example}{toplevel}

--- a/testsuite/tests/tool-caml-tex/redirections.reference
+++ b/testsuite/tests/tool-caml-tex/redirections.reference
@@ -3,9 +3,10 @@
    output="redirections.output"
    script = "${ocamlrun} ${ocamlsrcdir}/tools/caml-tex \
    -repo-root ${ocamlsrcdir} ${test_source_directory}/${test_file} -o ${output}"
-  * native-compiler
-  ** script with unix,str
-  *** check-program-output
+  * hasstr
+  ** native-compiler
+  *** script with unix,str
+  **** check-program-output
 *)
 
 \camlexample{toplevel}

--- a/testsuite/tests/tool-debugger/basic/debuggee.ml
+++ b/testsuite/tests/tool-debugger/basic/debuggee.ml
@@ -2,12 +2,13 @@
 set foo = "bar"
 flags += " -g "
 ocamldebug_script = "${test_source_directory}/input_script"
-* shared-libraries
-** setup-ocamlc.byte-build-env
-*** ocamlc.byte
-**** check-ocamlc.byte-output
-***** ocamldebug
-****** check-program-output
+* debugger
+** shared-libraries
+*** setup-ocamlc.byte-build-env
+**** ocamlc.byte
+***** check-ocamlc.byte-output
+****** ocamldebug
+******* check-program-output
 *)
 
 print_endline Sys.argv.(1);;

--- a/testsuite/tests/tool-debugger/find-artifacts/debuggee.ml
+++ b/testsuite/tests/tool-debugger/find-artifacts/debuggee.ml
@@ -1,24 +1,25 @@
 (* TEST
 ocamldebug_script = "${test_source_directory}/input_script"
-* shared-libraries
-** setup-ocamlc.byte-build-env
-*** script
+* debugger
+** shared-libraries
+*** setup-ocamlc.byte-build-env
+**** script
 script = "mkdir out"
-**** ocamlc.byte
+***** ocamlc.byte
 flags = "-g -c"
 all_modules = "${test_source_directory}/in/blah.ml"
 program = "out/blah.cmo"
-***** ocamlc.byte
+****** ocamlc.byte
 program = "out/foo.cmo"
 flags = "-I out -g -c"
 all_modules = "${test_source_directory}/in/foo.ml"
-****** ocamlc.byte
+******* ocamlc.byte
 all_modules = "out/blah.cmo out/foo.cmo"
 flags = " -g "
 program = "debuggee.exe"
-******* check-ocamlc.byte-output
-******** ocamldebug
-********* check-program-output
+******** check-ocamlc.byte-output
+********* ocamldebug
+********** check-program-output
 *)
 
 (* This file only contains the specification of how to run the test *)

--- a/testsuite/tests/tool-debugger/no_debug_event/noev.ml
+++ b/testsuite/tests/tool-debugger/no_debug_event/noev.ml
@@ -1,27 +1,28 @@
 (* TEST
 files = "a.ml b.ml"
 ocamldebug_script = "${test_source_directory}/input_script"
-* shared-libraries
-** setup-ocamlc.byte-build-env
-*** ocamlc.byte
+* debugger
+** shared-libraries
+*** setup-ocamlc.byte-build-env
+**** ocamlc.byte
 module = "a.ml"
 flags = "-g -for-pack foo"
-**** ocamlc.byte
+***** ocamlc.byte
 module = ""
 all_modules = "a.cmo"
 program = "foo.cmo"
 flags = "-g -pack"
-***** ocamlc.byte
+****** ocamlc.byte
 module = "b.ml"
 flags = " -g "
-****** ocamlc.byte
+******* ocamlc.byte
 module = ""
 flags = " -g "
 all_modules = "foo.cmo b.cmo"
 program = "${test_build_directory}/noev.exe"
-******* check-ocamlc.byte-output
-******** ocamldebug
-********* check-program-output
+******** check-ocamlc.byte-output
+********* ocamldebug
+********** check-program-output
 *)
 
 (* This file only contains the specification of how to run the test *)

--- a/testsuite/tests/unboxed-primitive-args/test.ml
+++ b/testsuite/tests/unboxed-primitive-args/test.ml
@@ -1,21 +1,22 @@
 (* TEST
 
+* hasunix
 include unix
 
 files = "common.mli common.ml test_common.c test_common.h"
 
-* setup-ocamlopt.byte-build-env
-** ocaml
+** setup-ocamlopt.byte-build-env
+*** ocaml
 test_file = "${test_source_directory}/gen_test.ml"
 ocaml_script_as_argument = "true"
 arguments = "c"
 compiler_output = "stubs.c"
-*** ocaml
+**** ocaml
 arguments = "ml"
 compiler_output = "main.ml"
-**** ocamlopt.byte
+***** ocamlopt.byte
 all_modules = "test_common.c stubs.c common.mli common.ml main.ml"
-***** run
-****** check-program-output
+****** run
+******* check-program-output
 
 *)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -405,7 +405,9 @@ caml-tex: $(CAMLTEX)
 
 # we need str and unix which depend on the bytecode version of other tools
 # thus we delay building caml-tex to the opt.opt stage
+ifneq "$(WITH_CAMLTEX)" ""
 opt.opt:caml-tex
+endif
 clean::
 	rm -f -- caml-tex caml_tex.cm?
 


### PR DESCRIPTION
This is a precursor to allowing compilation of certain parts of the source tree without building the compiler.

The main addition is `--no-unix`, `--no-vmthreads` and `--no-str` options. Rather pleasingly, this is largely a configure script change - the other changes are a minor tweak in the build system to skip building caml-tex and changes to allow the testsuite to adapt to these libraries not being available.

One point which may want addressing further: we always build caml-tex, but we don't install it, which seems daft. Perhaps an option should be added so that it's tested on CI but not built by default?