### PR TITLE
Full explanation for unsafe cycles in recursive modules

### DIFF
--- a/Changes
+++ b/Changes
@@ -210,7 +210,7 @@ Working version
   (Hugo Heuzard, review by Jérémie Dimino)
 
 - GPR#2058: full explanation for unsafe cycles in recursive module definitions
-  (Florian Angeletti, suggested by Ivan Gotovchits)
+  (Florian Angeletti, review by Gabriel Scherer, suggested by Ivan Gotovchits)
 
 ### Code generation and optimizations:
 

--- a/Changes
+++ b/Changes
@@ -209,6 +209,9 @@ Working version
 - GPR#1960: The parser keeps previous location when relocating ast node.
   (Hugo Heuzard, review by Jérémie Dimino)
 
+- GPR#2058: full explanation for unsafe cycles in recursive module definitions
+  (Florian Angeletti, suggested by Ivan Gotovchits)
+
 ### Code generation and optimizations:
 
 - MPR#7725, GPR#1754: improve AFL instrumentation for objects and lazy values.

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -27,8 +27,15 @@ open Translobj
 open Translcore
 open Translclass
 
+type unsafe_component =
+  | Unsafe_module_binding
+  | Unsafe_functor
+  | Unsafe_non_function
+  | Unsafe_typext
+
+type unsafe_info = { reason:unsafe_component; loc:Location.t; subid:Ident.t }
 type error =
-  Circular_dependency of Ident.t list
+  Circular_dependency of (Ident.t * unsafe_info) list
 | Conflicting_inline_attributes
 
 exception Error of Location.t * error
@@ -197,29 +204,38 @@ let undefined_location loc =
                       Const_base(Const_int line);
                       Const_base(Const_int char)]))
 
-let init_shape modl =
-  let rec init_shape_mod env mty =
+exception Initialization_failure of unsafe_info
+type init_result =
+  | Ok of lambda * lambda
+  | Fail of unsafe_info
+(* The Error constructor has been stolen earlier, we cannot use result *)
+
+let init_shape id modl =
+  let rec init_shape_mod subid loc env mty =
     match Mtype.scrape env mty with
       Mty_ident _
     | Mty_alias (Mta_present, _) ->
-        raise Not_found
+        raise (Initialization_failure {reason=Unsafe_module_binding;loc;subid})
     | Mty_alias (Mta_absent, _) ->
         Const_block (1, [Const_pointer 0])
     | Mty_signature sg ->
         Const_block(0, [Const_block(0, init_shape_struct env sg)])
     | Mty_functor _ ->
-        raise Not_found (* can we do better? *)
+        (* can we do better? *)
+        raise (Initialization_failure {reason=Unsafe_functor;loc;subid})
   and init_shape_struct env sg =
     match sg with
       [] -> []
-    | Sig_value(_id, {val_kind=Val_reg; val_type=ty}) :: rem ->
+    | Sig_value(subid, {val_kind=Val_reg; val_type=ty; val_loc=loc}) :: rem ->
         let init_v =
           match Ctype.expand_head env ty with
             {desc = Tarrow(_,_,_,_)} ->
               Const_pointer 0 (* camlinternalMod.Function *)
           | {desc = Tconstr(p, _, _)} when Path.same p Predef.path_lazy_t ->
               Const_pointer 1 (* camlinternalMod.Lazy *)
-          | _ -> raise Not_found in
+          | _ ->
+              let not_a_function = {reason=Unsafe_non_function; loc; subid } in
+              raise (Initialization_failure not_a_function) in
         init_v :: init_shape_struct env rem
     | Sig_value(_, {val_kind=Val_prim _}) :: rem ->
         init_shape_struct env rem
@@ -227,10 +243,10 @@ let init_shape modl =
         assert false
     | Sig_type(id, tdecl, _) :: rem ->
         init_shape_struct (Env.add_type ~check:false id tdecl env) rem
-    | Sig_typext _ :: _ ->
-        raise Not_found
+    | Sig_typext (subid, {ext_loc=loc},_) :: _ ->
+        raise (Initialization_failure {reason=Unsafe_typext; loc; subid})
     | Sig_module(id, md, _) :: rem ->
-        init_shape_mod env md.md_type ::
+        init_shape_mod id md.md_loc env md.md_type ::
         init_shape_struct (Env.add_module_declaration ~check:false
                              id md env) rem
     | Sig_modtype(id, minfo) :: rem ->
@@ -242,10 +258,9 @@ let init_shape modl =
         init_shape_struct env rem
   in
   try
-    Some(undefined_location modl.mod_loc,
-         Lconst(init_shape_mod modl.mod_env modl.mod_type))
-  with Not_found ->
-    None
+    Ok(undefined_location modl.mod_loc,
+       Lconst(init_shape_mod id modl.mod_loc modl.mod_env modl.mod_type))
+  with Initialization_failure reason -> Fail(reason)
 
 (* Reorder bindings to honor dependencies.  *)
 
@@ -254,15 +269,15 @@ type binding_status =
   | Inprogress of int option (** parent node *)
   | Defined
 
-let extract_unsafe_cycle id status cycle_start =
+let extract_unsafe_cycle id status init cycle_start =
+  let info i = match init.(i) with
+    | Fail r -> id.(i), r
+    | Ok _ -> assert false in
   let rec collect stop l i = match status.(i) with
     | Inprogress None | Undefined | Defined -> assert false
-    | Inprogress Some i when i = stop -> id.(i) :: l
-    | Inprogress Some i -> collect stop (id.(i)::l) i in
-  collect cycle_start [id.(cycle_start)] cycle_start
-(* This yields [cycle_start; ...; cycle_start]. The start of the cycle
-   is duplicated to make the cycle more visible in the corresponding error
-   message. *)
+    | Inprogress Some i when i = stop -> info i :: l
+    | Inprogress Some i -> collect stop (info i::l) i in
+  collect cycle_start [] cycle_start
 
 let reorder_rec_bindings bindings =
   let id = Array.of_list (List.map (fun (id,_,_,_) -> id) bindings)
@@ -273,21 +288,25 @@ let reorder_rec_bindings bindings =
   let num_bindings = Array.length id in
   let status = Array.make num_bindings Undefined in
   let res = ref [] in
+  let is_unsafe i = match init.(i) with Ok _ -> false | Fail _ -> true in
+  let init_res i = match init.(i) with
+    | Fail _ -> None
+    | Ok(a,b) -> Some(a,b) in
   let rec emit_binding parent i =
     match status.(i) with
       Defined -> ()
     | Inprogress _ ->
         status.(i) <- Inprogress parent;
-        let cycle = extract_unsafe_cycle id status i in
+        let cycle = extract_unsafe_cycle id status init i in
         raise(Error(loc.(i), Circular_dependency cycle))
     | Undefined ->
-        if init.(i) = None then begin
+        if is_unsafe i then begin
           status.(i) <- Inprogress parent;
           for j = 0 to num_bindings - 1 do
             if Ident.Set.mem id.(j) fv.(i) then emit_binding (Some i) j
           done
         end;
-        res := (id.(i), init.(i), rhs.(i)) :: !res;
+        res := (id.(i), init_res i, rhs.(i)) :: !res;
         status.(i) <- Defined in
   for i = 0 to num_bindings - 1 do
     match status.(i) with
@@ -342,7 +361,7 @@ let compile_recmodule compile_rhs bindings cont =
     (reorder_rec_bindings
        (List.map
           (fun {mb_id=id; mb_expr=modl; mb_loc=loc; _} ->
-            (id, modl.mod_loc, init_shape modl, compile_rhs id modl loc))
+            (id, modl.mod_loc, init_shape id modl, compile_rhs id modl loc))
           bindings))
     cont
 
@@ -1358,27 +1377,41 @@ let transl_store_package component_names target_name coercion =
 
 open Format
 
-let print_cycle ppf =
-  Format.pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf "@ -> ")
-    Printtyp.ident ppf
+let print_cycle ppf cycle =
+  let print_ident ppf (x,_) = Format.pp_print_string ppf (Ident.name x) in
+  let pp_sep ppf () = fprintf ppf "@ -> " in
+  Format.fprintf ppf "%a%a%s"
+    (Format.pp_print_list ~pp_sep print_ident) cycle
+    pp_sep ()
+    (Ident.name @@ fst @@ List.hd cycle)
+(* we repeat the first element to make the cycle more apparent *)
 
-let report_error ppf = function
-    Circular_dependency cycle ->
+let explanation_submsg (id, {reason;loc;subid}) =
+  let print fmt =
+    let printer = Format.dprintf fmt (Ident.name id) (Ident.name subid) in
+    Location.mkloc printer loc in
+  match reason with
+  | Unsafe_module_binding -> print "Module %s defines an unsafe module, %s ."
+  | Unsafe_functor -> print "Module %s defines an unsafe functor, %s ."
+  | Unsafe_typext ->
+      print "Module %s defines an unsafe extension constructor, %s ."
+  | Unsafe_non_function -> print "Module %s defines an unsafe value, %s ."
+
+let report_error loc = function
+  | Circular_dependency cycle ->
       let[@manual.ref "s-recursive-modules"] chapter, section = 8, 3 in
-      fprintf ppf
-        "@[Cannot safely evaluate the definition of the following cycle@ \
+      Location.errorf ~loc ~sub:(List.map explanation_submsg cycle)
+        "Cannot safely evaluate the definition of the following cycle@ \
          of recursively-defined modules:@ %a.@ \
-         There are no safe modules in this cycle@ (see manual section %d.%d)@]"
+         There are no safe modules in this cycle@ (see manual section %d.%d)."
         print_cycle cycle chapter section
   | Conflicting_inline_attributes ->
-      fprintf ppf
-        "@[Conflicting ``inline'' attributes@]"
+      Location.errorf "@[Conflicting ``inline'' attributes@]"
 
 let () =
   Location.register_error_of_exn
     (function
-      | Error (loc, err) ->
-        Some (Location.error_of_printer ~loc report_error err)
+      | Error (loc, err) -> Some (report_error loc err)
       | _ ->
         None
     )

--- a/bytecomp/translmod.mli
+++ b/bytecomp/translmod.mli
@@ -42,12 +42,20 @@ val nat_toplevel_name: Ident.t -> Ident.t * int
 
 val primitive_declarations: Primitive.description list ref
 
+type unsafe_component =
+  | Unsafe_module_binding
+  | Unsafe_functor
+  | Unsafe_non_function
+  | Unsafe_typext
+
+type unsafe_info = { reason:unsafe_component; loc:Location.t; subid:Ident.t }
+
 type error =
-  Circular_dependency of Ident.t list
+  Circular_dependency of (Ident.t * unsafe_info) list
 | Conflicting_inline_attributes
 
 exception Error of Location.t * error
 
-val report_error: Format.formatter -> error -> unit
+val report_error: Location.t -> error -> Location.error
 
 val reset: unit -> unit

--- a/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
+++ b/testsuite/tests/basic-modules/recursive_module_evaluation_errors.ml
@@ -13,8 +13,104 @@ Line 2, characters 27-49:
                              ^^^^^^^^^^^^^^^^^^^^^^
 Error: Cannot safely evaluate the definition of the following cycle
        of recursively-defined modules: B -> E -> D -> C -> B.
-       There are no safe modules in this cycle (see manual section 8.3)
+       There are no safe modules in this cycle (see manual section 8.3).
+Line 2, characters 10-20:
+  and B:sig val x: int end = struct let x = E.y end
+            ^^^^^^^^^^
+Module B defines an unsafe value, x .
+Line 5, characters 10-20:
+  and E:sig val x: int val y:int end = struct let x = D.x let y = 0 end
+            ^^^^^^^^^^
+Module E defines an unsafe value, x .
+Line 4, characters 10-20:
+  and D:sig val x: int end = struct let x = C.x end
+            ^^^^^^^^^^
+Module D defines an unsafe value, x .
+Line 3, characters 10-20:
+  and C:sig val x: int end = struct let x = B.x end
+            ^^^^^^^^^^
+Module C defines an unsafe value, x .
 |}]
+
+type t = ..
+module rec A: sig type t += A end = struct type t += A = B.A end
+and B:sig type t += A end = struct type t += A = A.A end
+[%%expect {|
+type t = ..
+Line 2, characters 36-64:
+  module rec A: sig type t += A end = struct type t += A = B.A end
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Cannot safely evaluate the definition of the following cycle
+       of recursively-defined modules: A -> B -> A.
+       There are no safe modules in this cycle (see manual section 8.3).
+Line 2, characters 28-29:
+  module rec A: sig type t += A end = struct type t += A = B.A end
+                              ^
+Module A defines an unsafe extension constructor, A .
+Line 3, characters 20-21:
+  and B:sig type t += A end = struct type t += A = A.A end
+                      ^
+Module B defines an unsafe extension constructor, A .
+|}]
+
+
+module rec A: sig
+  module F: functor(X:sig end) -> sig end
+  val f: unit -> unit
+end = struct
+  module F(X:sig end) = struct end
+  let f () = B.value
+end
+and B: sig val value: unit end = struct let value = A.f () end
+[%%expect {|
+Line 4, characters 6-72:
+  ......struct
+    module F(X:sig end) = struct end
+    let f () = B.value
+  end
+Error: Cannot safely evaluate the definition of the following cycle
+       of recursively-defined modules: A -> B -> A.
+       There are no safe modules in this cycle (see manual section 8.3).
+Line 2, characters 2-41:
+    module F: functor(X:sig end) -> sig end
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Module A defines an unsafe functor, F .
+Line 8, characters 11-26:
+  and B: sig val value: unit end = struct let value = A.f () end
+             ^^^^^^^^^^^^^^^
+Module B defines an unsafe value, value .
+|}]
+
+
+module F(X: sig module type t module M: t end) = struct
+  module rec A: sig
+    module M: X.t
+    val f: unit -> unit
+  end = struct
+    module M = X.M
+    let f () = B.value
+  end
+  and B: sig val value: unit end = struct let value  = A.f () end
+end
+[%%expect {|
+Line 5, characters 8-62:
+  ........struct
+      module M = X.M
+      let f () = B.value
+    end
+Error: Cannot safely evaluate the definition of the following cycle
+       of recursively-defined modules: A -> B -> A.
+       There are no safe modules in this cycle (see manual section 8.3).
+Line 3, characters 4-17:
+      module M: X.t
+      ^^^^^^^^^^^^^
+Module A defines an unsafe module, M .
+Line 9, characters 13-28:
+    and B: sig val value: unit end = struct let value  = A.f () end
+               ^^^^^^^^^^^^^^^
+Module B defines an unsafe value, value .
+|}]
+
 
 module rec M: sig val f: unit -> int end = struct let f () = N.x end
 and N:sig val x: int end = struct let x = M.f () end;;


### PR DESCRIPTION
This PR proposes to expand the error message for unsafe cycles in recursive module definition by providing an example of unsafe components for each unsafe module in the cycle.

For instance, the error message for

```OCaml
module rec A: sig
   module F: functor(X:sig end) -> sig end
   val f: unit -> unit
end = struct
  module F(X:sig end) = struct end
  let f () = B.value
end
and B: sig val value: unit end = struct let value = A.f () end
```
> Error: Cannot safely evaluate the definition of the following cycle
       of recursively-defined modules: A -> B -> A.
       There are no safe modules in this cycle (see manual section 8.3)

is expanded with two new lines:

>Line 2, characters 3-42: Module A defines an unsafe functor, F .
Line 8, characters 11-26: Module B defines an unsafe value, value .

In term of implementation, this PR merely keep track of the unsafe components detected during the
recursive module analysis and expose them to users.

Hopefully, pointing the unsafe components would make it easier for users to fix the problematic cycle, (particularly when the cycle contains exotic unsafe components).

This improvement over #1694 was suggested by @ivg . 
