### PR TITLE
Towards autoconf #2: OCAML_STDLIB_DIR

### DIFF
--- a/Changes
+++ b/Changes
@@ -328,6 +328,9 @@ Working version
   (Sébastien Hinderer, review by Xavier Leroy, Damien Doligez, Gabriel
   Scherer and Armaël Guéneau)
 
+* GPR#2059: stop defining OCAML_STDLIB_DIR in s.h.
+  (Sébastien Hinderer, review by David Allsopp and Damien Doligez)
+
 * GPR#2066: remove the standard_runtime configuration variable.
   (Sébastien Hinderer, review by Xavier Leroy, Stephen Dolan and
   Damien Doligez)

--- a/configure
+++ b/configure
@@ -1013,7 +1013,6 @@ config ARCMD "${TOOLPREF}ar"
 # Write the OS type (Unix or Cygwin)
 
 echo "#define OCAML_OS_TYPE \"$ostype\"" >> s.h
-echo "#define OCAML_STDLIB_DIR \"$libdir\"" >> s.h
 
 # Do #! scripts work?
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -138,6 +138,9 @@ ifeq "$(UNIX_OR_WIN32)" "win32"
 # pre-Visual Studio 2013 compilers where \x is a non-standard alias for \u.
 OCAML_STDLIB_DIR = $(shell echo $(LIBDIR)| iconv -t JAVA | sed -e 's/\\u/\\x/g')
 OC_CPPFLAGS += -DOCAML_STDLIB_DIR='L"$(OCAML_STDLIB_DIR)"'
+else # Unix
+OCAML_STDLIB_DIR = $(LIBDIR)
+OC_CPPFLAGS += -DOCAML_STDLIB_DIR='"$(OCAML_STDLIB_DIR)"'
 endif
 
 OC_CPPFLAGS += $(IFLEXDIR)


### PR DESCRIPTION
(Cc @dra27, @damiendoligez and @xavierleroy)

So far, `OCAML_STDLIB_DIR` has been computed at configure time and written
to `s.h`. However, in the autoconf world, it is recommended that
directories can be changed by running just `make` without having to
reconfigure. So defining a directory at configure time to a value
that can then not be overwritten by running `make` is not suitable.
And, in the autoconf world, it's not only not suitable, it is also hard
(if not impossible) to achieve.

So this PR takes `OCAML_STDLIB_DIR` out of `s.h` and defines it in
`runtime/Makefile`. This seems also reasonable in the sense that `s.h`
is for OS-related settings, to which `OCAML_STDLIB_DIR` does not really
belong.