### PR TITLE
Add Lcapture_stack_offset

### DIFF
--- a/.depend
+++ b/.depend
@@ -213,8 +213,10 @@ typing/envaux.cmo : typing/subst.cmi typing/printtyp.cmi typing/path.cmi \
 typing/envaux.cmx : typing/subst.cmx typing/printtyp.cmx typing/path.cmx \
     typing/ident.cmx typing/env.cmx typing/envaux.cmi
 typing/envaux.cmi : typing/subst.cmi typing/path.cmi typing/env.cmi
-typing/ident.cmo : utils/identifiable.cmi utils/clflags.cmi typing/ident.cmi
-typing/ident.cmx : utils/identifiable.cmx utils/clflags.cmx typing/ident.cmi
+typing/ident.cmo : utils/misc.cmi utils/identifiable.cmi utils/clflags.cmi \
+    typing/ident.cmi
+typing/ident.cmx : utils/misc.cmx utils/identifiable.cmx utils/clflags.cmx \
+    typing/ident.cmi
 typing/ident.cmi : utils/identifiable.cmi
 typing/includeclass.cmo : typing/types.cmi typing/printtyp.cmi \
     typing/path.cmi typing/ctype.cmi parsing/builtin_attributes.cmi \
@@ -308,17 +310,17 @@ typing/printpat.cmi : typing/typedtree.cmi parsing/asttypes.cmi
 typing/printtyp.cmo : utils/warnings.cmi typing/types.cmi \
     typing/primitive.cmi typing/predef.cmi typing/path.cmi \
     parsing/parsetree.cmi typing/outcometree.cmi typing/oprint.cmi \
-    utils/numbers.cmi utils/misc.cmi parsing/longident.cmi \
-    parsing/location.cmi typing/ident.cmi typing/env.cmi typing/ctype.cmi \
-    utils/clflags.cmi parsing/builtin_attributes.cmi typing/btype.cmi \
-    parsing/asttypes.cmi typing/printtyp.cmi
+    utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
+    typing/ident.cmi typing/env.cmi typing/ctype.cmi utils/clflags.cmi \
+    parsing/builtin_attributes.cmi typing/btype.cmi parsing/asttypes.cmi \
+    typing/printtyp.cmi
 typing/printtyp.cmx : utils/warnings.cmx typing/types.cmx \
     typing/primitive.cmx typing/predef.cmx typing/path.cmx \
     parsing/parsetree.cmi typing/outcometree.cmi typing/oprint.cmx \
-    utils/numbers.cmx utils/misc.cmx parsing/longident.cmx \
-    parsing/location.cmx typing/ident.cmx typing/env.cmx typing/ctype.cmx \
-    utils/clflags.cmx parsing/builtin_attributes.cmx typing/btype.cmx \
-    parsing/asttypes.cmi typing/printtyp.cmi
+    utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
+    typing/ident.cmx typing/env.cmx typing/ctype.cmx utils/clflags.cmx \
+    parsing/builtin_attributes.cmx typing/btype.cmx parsing/asttypes.cmi \
+    typing/printtyp.cmi
 typing/printtyp.cmi : typing/types.cmi typing/path.cmi \
     typing/outcometree.cmi parsing/longident.cmi parsing/location.cmi \
     typing/ident.cmi typing/env.cmi parsing/asttypes.cmi
@@ -332,11 +334,11 @@ typing/printtyped.cmx : typing/types.cmx typing/typedtree.cmx \
     parsing/asttypes.cmi typing/printtyped.cmi
 typing/printtyped.cmi : typing/typedtree.cmi
 typing/rec_check.cmo : typing/types.cmi typing/typeopt.cmi \
-    typing/typedtree.cmi typing/primitive.cmi typing/path.cmi utils/misc.cmi \
+    typing/typedtree.cmi typing/primitive.cmi typing/path.cmi \
     bytecomp/lambda.cmi typing/ident.cmi parsing/asttypes.cmi \
     typing/rec_check.cmi
 typing/rec_check.cmx : typing/types.cmx typing/typeopt.cmx \
-    typing/typedtree.cmx typing/primitive.cmx typing/path.cmx utils/misc.cmx \
+    typing/typedtree.cmx typing/primitive.cmx typing/path.cmx \
     bytecomp/lambda.cmx typing/ident.cmx parsing/asttypes.cmi \
     typing/rec_check.cmi
 typing/rec_check.cmi : typing/typedtree.cmi typing/ident.cmi
@@ -981,11 +983,14 @@ asmcomp/emit.cmx : asmcomp/x86_proc.cmx asmcomp/x86_masm.cmx \
     utils/config.cmx asmcomp/compilenv.cmx asmcomp/cmm.cmx utils/clflags.cmx \
     asmcomp/branch_relaxation.cmx asmcomp/arch.cmx asmcomp/emit.cmi
 asmcomp/emit.cmi : asmcomp/linearize.cmi asmcomp/cmm.cmi
-asmcomp/emitaux.cmo : middle_end/debuginfo.cmi utils/config.cmi \
-    asmcomp/cmm.cmi utils/clflags.cmi asmcomp/arch.cmo asmcomp/emitaux.cmi
-asmcomp/emitaux.cmx : middle_end/debuginfo.cmx utils/config.cmx \
-    asmcomp/cmm.cmx utils/clflags.cmx asmcomp/arch.cmx asmcomp/emitaux.cmi
-asmcomp/emitaux.cmi : middle_end/debuginfo.cmi
+asmcomp/emitaux.cmo : asmcomp/reg.cmi utils/misc.cmi asmcomp/linearize.cmi \
+    middle_end/debuginfo.cmi utils/config.cmi asmcomp/cmm.cmi \
+    utils/clflags.cmi asmcomp/arch.cmo asmcomp/emitaux.cmi
+asmcomp/emitaux.cmx : asmcomp/reg.cmx utils/misc.cmx asmcomp/linearize.cmx \
+    middle_end/debuginfo.cmx utils/config.cmx asmcomp/cmm.cmx \
+    utils/clflags.cmx asmcomp/arch.cmx asmcomp/emitaux.cmi
+asmcomp/emitaux.cmi : asmcomp/reg.cmi asmcomp/linearize.cmi \
+    middle_end/debuginfo.cmi
 asmcomp/export_info.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \
@@ -2450,14 +2455,14 @@ toplevel/genprintval.cmi : typing/types.cmi typing/path.cmi \
     typing/outcometree.cmi typing/env.cmi
 toplevel/opttopdirs.cmo : utils/warnings.cmi typing/types.cmi \
     typing/printtyp.cmi toplevel/opttoploop.cmi utils/misc.cmi \
-    parsing/longident.cmi typing/ident.cmi typing/env.cmi typing/ctype.cmi \
-    utils/config.cmi driver/compdynlink.cmi utils/clflags.cmi \
-    asmcomp/asmlink.cmi toplevel/opttopdirs.cmi
+    parsing/longident.cmi typing/env.cmi typing/ctype.cmi utils/config.cmi \
+    driver/compdynlink.cmi utils/clflags.cmi asmcomp/asmlink.cmi \
+    toplevel/opttopdirs.cmi
 toplevel/opttopdirs.cmx : utils/warnings.cmx typing/types.cmx \
     typing/printtyp.cmx toplevel/opttoploop.cmx utils/misc.cmx \
-    parsing/longident.cmx typing/ident.cmx typing/env.cmx typing/ctype.cmx \
-    utils/config.cmx driver/compdynlink.cmi utils/clflags.cmx \
-    asmcomp/asmlink.cmx toplevel/opttopdirs.cmi
+    parsing/longident.cmx typing/env.cmx typing/ctype.cmx utils/config.cmx \
+    driver/compdynlink.cmi utils/clflags.cmx asmcomp/asmlink.cmx \
+    toplevel/opttopdirs.cmi
 toplevel/opttopdirs.cmi : parsing/longident.cmi
 toplevel/opttoploop.cmo : utils/warnings.cmi typing/types.cmi \
     typing/typemod.cmi typing/typedtree.cmi typing/typecore.cmi \

--- a/Changes
+++ b/Changes
@@ -403,6 +403,9 @@ Working version
 - GPR#2055: Add [Linearize.Lprologue].
   (Mark Shinwell, review by Pierre Chambart)
 
+- GPR#2061: Add [Linearize.Lcapture_stack_offset].
+  (Mark Shinwell, review by Xavier Leroy)
+
 ### Bug fixes:
 
 - MPR#7847, GPR#2019: Fix an infinite loop that could occur when the

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -892,6 +892,9 @@ let emit_instr fallthrough i =
           I.pop r14;
           I.ret ()
       end
+  | Lcapture_stack_offset byte_offset_from_cfa ->
+      Emitaux.handle_lcapture_stack_offset i ~frame_size ~slot_offset
+        ~register_class ~byte_offset_from_cfa
 
 let rec emit_all fallthrough i =
   match i.desc with

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -858,6 +858,10 @@ let emit_instr i =
           `	mov	sp, trap_ptr\n`;
           `	pop	\{trap_ptr, pc}\n`; 2
         end
+    | Lcapture_stack_offset byte_offset_from_cfa ->
+        Emitaux.handle_lcapture_stack_offset i ~frame_size ~slot_offset
+          ~register_class ~byte_offset_from_cfa;
+        0
 
 (* Upper bound on the size of the code sequence for a Linear instruction,
    in 32-bit words. *)

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -502,6 +502,7 @@ module BR = Branch_relaxation.Make (struct
       | Cmm.Raise_withtrace -> 1
       | Cmm.Raise_notrace -> 4
       end
+    | Lcapture_stack_offset _ -> 0
 
   let relax_allocation ~num_words ~label_after_call_gc =
     Lop (Ispecific (Ifar_alloc { words = num_words; label_after_call_gc; }))
@@ -899,6 +900,9 @@ let emit_instr i =
           `	ldr	{emit_reg reg_trap_ptr}, [sp], 16\n`;
           `	br	{emit_reg reg_tmp1}\n`
         end
+  | Lcapture_stack_offset byte_offset_from_cfa ->
+      Emitaux.handle_lcapture_stack_offset i ~frame_size ~slot_offset
+        ~register_class ~byte_offset_from_cfa
 
 (* Emission of an instruction sequence *)
 

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -307,6 +307,19 @@ let emit_debug_info dbg =
        emit_int file_num; emit_char '\t';
        emit_int line; emit_char '\n')
 
+let handle_lcapture_stack_offset i ~frame_size ~slot_offset ~register_class
+      ~byte_offset_from_cfa =
+  assert (Array.length i.Linearize.arg = 1);
+  let reg = i.Linearize.arg.(0) in
+  let open Reg in
+  begin match reg.loc with
+  | Stack loc ->
+    byte_offset_from_cfa :=
+      frame_size () - (slot_offset loc (register_class reg))
+  | Unknown | Reg _ ->
+    Misc.fatal_error "[Lcapture_stack_offset] only valid for [Stack] regs"
+  end
+
 let reset () =
   reset_debug_info ();
   frame_descriptors := []

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -66,6 +66,13 @@ val cfi_endproc : unit -> unit
 val cfi_adjust_cfa_offset : int -> unit
 val cfi_offset : reg:int -> offset:int -> unit
 
+val handle_lcapture_stack_offset
+   : Linearize.instruction
+  -> frame_size:(unit -> int)
+  -> slot_offset:(Reg.stack_location -> int -> int)
+  -> register_class:(Reg.t -> int)
+  -> byte_offset_from_cfa:int ref
+  -> unit
 
 val binary_backend_available: bool ref
     (** Is a binary backend available.  If yes, we don't need

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -906,6 +906,9 @@ let emit_instr fallthrough i =
             I.add (int (trap_frame_size - 8)) esp;
           I.ret ()
       end
+  | Lcapture_stack_offset byte_offset_from_cfa ->
+      Emitaux.handle_lcapture_stack_offset i ~frame_size ~slot_offset
+        ~register_class ~byte_offset_from_cfa
 
 let rec emit_all fallthrough i =
   match i.desc with

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -43,6 +43,7 @@ and instruction_desc =
   | Lpushtrap
   | Lpoptrap
   | Lraise of Cmm.raise_kind
+  | Lcapture_stack_offset of int ref
 
 let has_fallthrough = function
   | Lreturn | Lbranch _ | Lswitch _ | Lraise _

--- a/asmcomp/linearize.mli
+++ b/asmcomp/linearize.mli
@@ -40,6 +40,13 @@ and instruction_desc =
   | Lpushtrap
   | Lpoptrap
   | Lraise of Cmm.raise_kind
+  | Lcapture_stack_offset of int ref
+  (** [Lcapture_stack_offset] takes a single element in the [arg] array.
+      That element must be a register assigned to the stack.  The assembly
+      emitter must fill in the [int ref] with the offset in bytes from the
+      current frame address to the stack slot of such register.
+      This information is used for emission of debugging information for
+      spilled values. *)
 
 val has_fallthrough :  instruction_desc -> bool
 val end_instr: instruction

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -506,6 +506,7 @@ module BR = Branch_relaxation.Make (struct
     | Lpushtrap -> size 4 5 5
     | Lpoptrap -> 2
     | Lraise _ -> 6
+    | Lcapture_stack_offset _ -> 0
 
   let relax_allocation ~num_words:words ~label_after_call_gc =
     Lop (Ispecific (Ialloc_far { words; label_after_call_gc; }))
@@ -1015,6 +1016,9 @@ let emit_instr i =
             `	addi	1, 1, {emit_int trap_size}\n`;
             `	bctr\n`
         end
+  | Lcapture_stack_offset byte_offset_from_cfa ->
+      Emitaux.handle_lcapture_stack_offset i ~frame_size ~slot_offset
+        ~register_class ~byte_offset_from_cfa
 
 (* Emit a sequence of instructions *)
 

--- a/asmcomp/printlinear.ml
+++ b/asmcomp/printlinear.ml
@@ -67,6 +67,8 @@ let instr ppf i =
       fprintf ppf "pop trap"
   | Lraise k ->
       fprintf ppf "%a %a" Printcmm.raise_kind k reg i.arg.(0)
+  | Lcapture_stack_offset _ ->
+      fprintf ppf "capture stack offset"
   end;
   if not (Debuginfo.is_none i.dbg) then
     fprintf ppf " %s" (Debuginfo.to_string i.dbg)

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -632,6 +632,9 @@ let emit_instr i =
           emit_stack_adjust (-16);
           `	br	%r1\n`
         end
+  | Lcapture_stack_offset byte_offset_from_cfa ->
+      Emitaux.handle_lcapture_stack_offset i ~frame_size ~slot_offset
+        ~register_class ~byte_offset_from_cfa
 
 
 (* Emit a sequence of instructions *)


### PR DESCRIPTION
This patch adds a means of determining, _post hoc_, the number of bytes between the assigned stack slot of a register and the current frame address.  This is required for debugging information emission in the context of spilled values.

The _modus operandi_ of this patch is slightly distasteful, but it is a straightforward way of extracting this information, which depends on the operation of target-specific functions in the emitter.  We could potentially improve upon it later, but I think it should be ok for now.