### PR TITLE
Fix windows ANSI locale: use CP_ACP instead of CP_THREAD_ACP

### DIFF
--- a/Changes
+++ b/Changes
@@ -470,6 +470,9 @@ Working version
 - MPR#7408, MPR#7846, GPR#2015: Check arity of primitives.
   (Hugo Heuzard, review by Nicolás Ojeda Bär)
 
+- MPR#7854, GPR#2062: fix an issue where the wrong locale may be used when using
+  the legacy ANSI encoding under Windows.
+  (Nicolás Ojeda Bär, report by Tiphaine Turpin)
 
 OCaml 4.07 maintenance branch
 -----------------------------

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -846,9 +846,9 @@ CAMLexport int win_multi_byte_to_wide_char(const char *s, int slen,
                           windows_unicode_strict ? MB_ERR_INVALID_CHARS : 0,
                           s, slen, out, outlen);
     if (retcode == 0 && windows_unicode_fallback != 0)
-      retcode = MultiByteToWideChar(CP_THREAD_ACP, 0, s, slen, out, outlen);
+      retcode = MultiByteToWideChar(CP_ACP, 0, s, slen, out, outlen);
   } else {
-    retcode = MultiByteToWideChar(CP_THREAD_ACP, 0, s, slen, out, outlen);
+    retcode = MultiByteToWideChar(CP_ACP, 0, s, slen, out, outlen);
   }
 
   if (retcode == 0)
@@ -879,7 +879,7 @@ CAMLexport int win_wide_char_to_multi_byte(const wchar_t *s, int slen,
                           s, slen, out, outlen, NULL, NULL);
   else
     retcode =
-      WideCharToMultiByte(CP_THREAD_ACP, 0, s, slen, out, outlen, NULL, NULL);
+      WideCharToMultiByte(CP_ACP, 0, s, slen, out, outlen, NULL, NULL);
 
   if (retcode == 0)
     caml_win32_sys_error(GetLastError());

--- a/stdlib/headernt.c
+++ b/stdlib/headernt.c
@@ -90,7 +90,7 @@ static BOOL WINAPI ctrl_handler(DWORD event)
 #if WINDOWS_UNICODE
 #define CP CP_UTF8
 #else
-#define CP CP_THREAD_ACP
+#define CP CP_ACP
 #endif
 
 static void write_console(HANDLE hOut, WCHAR *wstr)


### PR DESCRIPTION
See [MPR#7854](https://caml.inria.fr/mantis/view.php?id=7854).

It would be nice to include this in 4.07.1; @damiendoligez ?