### PR TITLE
Add [Proc.destroyed_at_reloadretaddr]

### DIFF
--- a/Changes
+++ b/Changes
@@ -428,14 +428,17 @@ Working version
   use [Backend_var.With_provenance] for variables in binding position.
   (Mark Shinwell, review by Pierre Chambart)
 
+- GPR#2060: "Phantom let" support for the Clambda language.
+  (Mark Shinwell, review by Vincent Laviron)
+
+- GPR#2065: Add [Proc.destroyed_at_reloadretaddr].
+  (Mark Shinwell, review by Damien Doligez)
+
 - GPR#2072: Always associate a scope to a type
   (Thomas Refis, review by Jacques Garrigue and Leo White)
 
 - GPR#2074: Correct naming of record field inside [Ialloc] terms.
   (Mark Shinwell, review by Jérémie Dimino)
-
-- GPR#2060: "Phantom let" support for the Clambda language.
-  (Mark Shinwell, review by Vincent Laviron)
 
 - GPR#2076: Add [Targetint.print].
   (Mark Shinwell)

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -335,6 +335,8 @@ let destroyed_at_oper = function
 
 let destroyed_at_raise = all_phys_regs
 
+let destroyed_at_reloadretaddr = [| |]
+
 (* Maximal register pressure *)
 
 

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -308,6 +308,10 @@ let destroyed_at_oper = function
 
 let destroyed_at_raise = all_phys_regs
 
+(* lr is destroyed at [Lreloadretaddr], but lr is not used for register
+   allocation, and thus does not need to (and indeed cannot) occur here. *)
+let destroyed_at_reloadretaddr = [| |]
+
 (* Maximal register pressure *)
 
 let safe_register_pressure = function

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -223,6 +223,8 @@ let destroyed_at_oper = function
 
 let destroyed_at_raise = all_phys_regs
 
+let destroyed_at_reloadretaddr = [| |]
+
 (* Maximal register pressure *)
 
 let safe_register_pressure = function

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -212,6 +212,8 @@ let destroyed_at_oper = function
 
 let destroyed_at_raise = all_phys_regs
 
+let destroyed_at_reloadretaddr = [| |]
+
 (* Maximal register pressure *)
 
 let safe_register_pressure _op = 4

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -313,6 +313,8 @@ let destroyed_at_oper = function
 
 let destroyed_at_raise = all_phys_regs
 
+let destroyed_at_reloadretaddr = [| phys_reg 11 |]
+
 (* Maximal register pressure *)
 
 let safe_register_pressure = function

--- a/asmcomp/proc.mli
+++ b/asmcomp/proc.mli
@@ -56,6 +56,7 @@ val max_register_pressure: Mach.operation -> int array
 (* Registers destroyed by operations *)
 val destroyed_at_oper: Mach.instruction_desc -> Reg.t array
 val destroyed_at_raise: Reg.t array
+val destroyed_at_reloadretaddr : Reg.t array
 
 (* Volatile registers: those that change value when read *)
 val regs_are_volatile: Reg.t array -> bool

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -199,6 +199,10 @@ let destroyed_at_oper = function
 
 let destroyed_at_raise = all_phys_regs
 
+(* %r14 is destroyed at [Lreloadretaddr], but %r14 is not used for register
+   allocation, and thus does not need to (and indeed cannot) occur here. *)
+let destroyed_at_reloadretaddr = [| |]
+
 (* Maximal register pressure *)
 
 let safe_register_pressure = function


### PR DESCRIPTION
The `Linearize` pass needs to be enhanced to preserve the register availability information computed by `Available_regs`; this code will be presented in a subsequent pull request.  In order to do this accurately it is necessary to know whether any registers are destroyed by the "reload return address" (`Lreloadretaddr`) construct.  This patch provides that information.