### PR TITLE
Get rid of the standard_runtime configuration variable

### DIFF
--- a/Changes
+++ b/Changes
@@ -328,6 +328,10 @@ Working version
   (Sébastien Hinderer, review by Xavier Leroy, Damien Doligez, Gabriel
   Scherer and Armaël Guéneau)
 
+* GPR#2066: remove the standard_runtime configuration variable.
+  (Sébastien Hinderer, review by Xavier Leroy, Stephen Dolan and
+  Damien Doligez)
+
 ### Internal/compiler-libs changes:
 
 - GPR#292: use Menhir as the parser generator for the OCaml parser.

--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,6 @@ utils/config.ml: utils/config.mlp Makefile.config Makefile
 	    $(call SUBST,ASM) \
 	    $(call SUBST,ASM_CFI_SUPPORTED) \
 	    $(call SUBST,BYTECCLIBS) \
-	    $(call SUBST,BYTERUN) \
 	    $(call SUBST,CC) \
 	    $(call SUBST,CCOMPTYPE) \
 	    $(call SUBST,CC_PROFILE) \

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -28,9 +28,6 @@ WITH_OCAMLDOC=ocamldoc
 ### Where to install the binaries
 BINDIR=$(PREFIX)/bin
 
-### Standard runtime system
-BYTERUN=ocamlrun
-
 ### Where to install the standard library
 LIBDIR=$(PREFIX)/lib/ocaml
 

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -28,9 +28,6 @@ WITH_OCAMLDOC=ocamldoc
 ### Where to install the binaries
 BINDIR=$(PREFIX)/bin
 
-### Standard runtime system
-BYTERUN=ocamlrun
-
 ### Where to install the standard library
 LIBDIR=$(PREFIX)/lib/ocaml
 

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -22,9 +22,6 @@ PREFIX=C:/ocamlms
 ### Where to install the binaries.
 BINDIR=$(PREFIX)/bin
 
-### Standard runtime system
-BYTERUN=ocamlrun
-
 ### Where to install the standard library
 LIBDIR=$(PREFIX)/lib/ocaml
 

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -22,9 +22,6 @@ PREFIX=C:/ocamlms64
 ### Where to install the binaries.
 BINDIR=$(PREFIX)/bin
 
-### Standard runtime system
-BYTERUN=ocamlrun
-
 ### Where to install the standard library
 LIBDIR=$(PREFIX)/lib/ocaml
 

--- a/configure
+++ b/configure
@@ -341,8 +341,6 @@ case "$bindir" in
    *) config BINDIR "$bindir";;
 esac
 
-config BYTERUN '$(BINDIR)/ocamlrun'
-
 case "$libdir" in
   "") config LIBDIR '$(PREFIX)/lib/ocaml'
       libdir="$prefix/lib/ocaml";;

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -26,9 +26,6 @@ val version: string
 val standard_library: string
 (** The directory containing the standard libraries *)
 
-val standard_runtime: string
-(** The full path to the standard bytecode interpreter ocamlrun *)
-
 val ccomp_type: string
 (** The "kind" of the C compiler, assembler and linker used: one of
     "cc" (for Unix-style C compilers)

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -28,7 +28,6 @@ let standard_library =
   with Not_found ->
     standard_library_default
 
-let standard_runtime = "%%BYTERUN%%"
 let ccomp_type = "%%CCOMPTYPE%%"
 let c_compiler = "%%CC%%"
 let c_output_obj = "%%OUTPUTOBJ%%"
@@ -166,7 +165,6 @@ let configuration_variables =
   p "version" version;
   p "standard_library_default" standard_library_default;
   p "standard_library" standard_library;
-  p "standard_runtime" standard_runtime;
   p "ccomp_type" ccomp_type;
   p "c_compiler" c_compiler;
   p "ocamlc_cflags" ocamlc_cflags;


### PR DESCRIPTION
This is a clone of #1992 because apparently GitHub does not let one
reopen a closed PR.