### PR TITLE
Calculation of available ranges for registers

### DIFF
--- a/.depend
+++ b/.depend
@@ -1114,8 +1114,8 @@ asmcomp/linearize.cmx : asmcomp/debug/reg_with_debug_info.cmx \
     utils/config.cmx asmcomp/cmm.cmx asmcomp/backend_var.cmx \
     asmcomp/linearize.cmi
 asmcomp/linearize.cmi : asmcomp/debug/reg_availability_set.cmi \
-    asmcomp/reg.cmi asmcomp/mach.cmi middle_end/debuginfo.cmi asmcomp/cmm.cmi \
-    asmcomp/backend_var.cmi
+    asmcomp/reg.cmi asmcomp/mach.cmi typing/ident.cmi \
+    middle_end/debuginfo.cmi asmcomp/cmm.cmi asmcomp/backend_var.cmi
 asmcomp/linscan.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/interval.cmi \
     asmcomp/linscan.cmi
 asmcomp/linscan.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/interval.cmx \
@@ -2311,6 +2311,18 @@ middle_end/base_types/variable.cmx : utils/misc.cmx \
 middle_end/base_types/variable.cmi : middle_end/internal_variable_names.cmi \
     utils/identifiable.cmi typing/ident.cmi \
     middle_end/base_types/compilation_unit.cmi
+asmcomp/debug/available_ranges.cmo : asmcomp/debug/reg_with_debug_info.cmi \
+    asmcomp/reg.cmi asmcomp/proc.cmi utils/numbers.cmi utils/misc.cmi \
+    asmcomp/mach.cmi asmcomp/linearize.cmi typing/ident.cmi \
+    middle_end/debuginfo.cmi asmcomp/cmm.cmi utils/clflags.cmi \
+    asmcomp/backend_var.cmi asmcomp/debug/available_ranges.cmi
+asmcomp/debug/available_ranges.cmx : asmcomp/debug/reg_with_debug_info.cmx \
+    asmcomp/reg.cmx asmcomp/proc.cmx utils/numbers.cmx utils/misc.cmx \
+    asmcomp/mach.cmx asmcomp/linearize.cmx typing/ident.cmx \
+    middle_end/debuginfo.cmx asmcomp/cmm.cmx utils/clflags.cmx \
+    asmcomp/backend_var.cmx asmcomp/debug/available_ranges.cmi
+asmcomp/debug/available_ranges.cmi : asmcomp/reg.cmi utils/numbers.cmi \
+    asmcomp/mach.cmi asmcomp/linearize.cmi asmcomp/backend_var.cmi
 asmcomp/debug/available_regs.cmo : asmcomp/debug/reg_with_debug_info.cmi \
     asmcomp/debug/reg_availability_set.cmi asmcomp/reg.cmi asmcomp/proc.cmi \
     asmcomp/printmach.cmi utils/misc.cmi asmcomp/mach.cmi utils/clflags.cmi \

--- a/.depend
+++ b/.depend
@@ -987,11 +987,14 @@ asmcomp/emit.cmx : asmcomp/x86_proc.cmx asmcomp/x86_masm.cmx \
     utils/config.cmx asmcomp/compilenv.cmx asmcomp/cmm.cmx utils/clflags.cmx \
     asmcomp/branch_relaxation.cmx asmcomp/arch.cmx asmcomp/emit.cmi
 asmcomp/emit.cmi : asmcomp/linearize.cmi asmcomp/cmm.cmi
-asmcomp/emitaux.cmo : middle_end/debuginfo.cmi utils/config.cmi \
-    asmcomp/cmm.cmi utils/clflags.cmi asmcomp/arch.cmo asmcomp/emitaux.cmi
-asmcomp/emitaux.cmx : middle_end/debuginfo.cmx utils/config.cmx \
-    asmcomp/cmm.cmx utils/clflags.cmx asmcomp/arch.cmx asmcomp/emitaux.cmi
-asmcomp/emitaux.cmi : middle_end/debuginfo.cmi
+asmcomp/emitaux.cmo : asmcomp/reg.cmi utils/misc.cmi asmcomp/linearize.cmi \
+    middle_end/debuginfo.cmi utils/config.cmi asmcomp/cmm.cmi \
+    utils/clflags.cmi asmcomp/arch.cmo asmcomp/emitaux.cmi
+asmcomp/emitaux.cmx : asmcomp/reg.cmx utils/misc.cmx asmcomp/linearize.cmx \
+    middle_end/debuginfo.cmx utils/config.cmx asmcomp/cmm.cmx \
+    utils/clflags.cmx asmcomp/arch.cmx asmcomp/emitaux.cmi
+asmcomp/emitaux.cmi : asmcomp/reg.cmi asmcomp/linearize.cmi \
+    middle_end/debuginfo.cmi
 asmcomp/export_info.cmo : middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
     middle_end/base_types/tag.cmi middle_end/base_types/symbol.cmi \

--- a/.depend
+++ b/.depend
@@ -213,8 +213,10 @@ typing/envaux.cmo : typing/subst.cmi typing/printtyp.cmi typing/path.cmi \
 typing/envaux.cmx : typing/subst.cmx typing/printtyp.cmx typing/path.cmx \
     typing/ident.cmx typing/env.cmx typing/envaux.cmi
 typing/envaux.cmi : typing/subst.cmi typing/path.cmi typing/env.cmi
-typing/ident.cmo : utils/identifiable.cmi utils/clflags.cmi typing/ident.cmi
-typing/ident.cmx : utils/identifiable.cmx utils/clflags.cmx typing/ident.cmi
+typing/ident.cmo : utils/misc.cmi utils/identifiable.cmi utils/clflags.cmi \
+    typing/ident.cmi
+typing/ident.cmx : utils/misc.cmx utils/identifiable.cmx utils/clflags.cmx \
+    typing/ident.cmi
 typing/ident.cmi : utils/identifiable.cmi
 typing/includeclass.cmo : typing/types.cmi typing/printtyp.cmi \
     typing/path.cmi typing/ctype.cmi parsing/builtin_attributes.cmi \
@@ -308,17 +310,17 @@ typing/printpat.cmi : typing/typedtree.cmi parsing/asttypes.cmi
 typing/printtyp.cmo : utils/warnings.cmi typing/types.cmi \
     typing/primitive.cmi typing/predef.cmi typing/path.cmi \
     parsing/parsetree.cmi typing/outcometree.cmi typing/oprint.cmi \
-    utils/numbers.cmi utils/misc.cmi parsing/longident.cmi \
-    parsing/location.cmi typing/ident.cmi typing/env.cmi typing/ctype.cmi \
-    utils/clflags.cmi parsing/builtin_attributes.cmi typing/btype.cmi \
-    parsing/asttypes.cmi typing/printtyp.cmi
+    utils/misc.cmi parsing/longident.cmi parsing/location.cmi \
+    typing/ident.cmi typing/env.cmi typing/ctype.cmi utils/clflags.cmi \
+    parsing/builtin_attributes.cmi typing/btype.cmi parsing/asttypes.cmi \
+    typing/printtyp.cmi
 typing/printtyp.cmx : utils/warnings.cmx typing/types.cmx \
     typing/primitive.cmx typing/predef.cmx typing/path.cmx \
     parsing/parsetree.cmi typing/outcometree.cmi typing/oprint.cmx \
-    utils/numbers.cmx utils/misc.cmx parsing/longident.cmx \
-    parsing/location.cmx typing/ident.cmx typing/env.cmx typing/ctype.cmx \
-    utils/clflags.cmx parsing/builtin_attributes.cmx typing/btype.cmx \
-    parsing/asttypes.cmi typing/printtyp.cmi
+    utils/misc.cmx parsing/longident.cmx parsing/location.cmx \
+    typing/ident.cmx typing/env.cmx typing/ctype.cmx utils/clflags.cmx \
+    parsing/builtin_attributes.cmx typing/btype.cmx parsing/asttypes.cmi \
+    typing/printtyp.cmi
 typing/printtyp.cmi : typing/types.cmi typing/path.cmi \
     typing/outcometree.cmi parsing/longident.cmi parsing/location.cmi \
     typing/ident.cmi typing/env.cmi parsing/asttypes.cmi
@@ -836,10 +838,10 @@ asmcomp/asmpackager.cmx : typing/typemod.cmx bytecomp/translmod.cmx \
     utils/clflags.cmx utils/ccomp.cmx asmcomp/asmlink.cmx asmcomp/asmgen.cmx \
     asmcomp/asmpackager.cmi
 asmcomp/asmpackager.cmi : typing/env.cmi middle_end/backend_intf.cmi
-asmcomp/backend_var.cmo : typing/printtyp.cmi typing/path.cmi \
-    typing/ident.cmi middle_end/debuginfo.cmi asmcomp/backend_var.cmi
-asmcomp/backend_var.cmx : typing/printtyp.cmx typing/path.cmx \
-    typing/ident.cmx middle_end/debuginfo.cmx asmcomp/backend_var.cmi
+asmcomp/backend_var.cmo : typing/path.cmi typing/ident.cmi \
+    middle_end/debuginfo.cmi asmcomp/backend_var.cmi
+asmcomp/backend_var.cmx : typing/path.cmx typing/ident.cmx \
+    middle_end/debuginfo.cmx asmcomp/backend_var.cmi
 asmcomp/backend_var.cmi : typing/path.cmi typing/ident.cmi \
     middle_end/debuginfo.cmi
 asmcomp/branch_relaxation.cmo : utils/misc.cmi asmcomp/mach.cmi \
@@ -891,14 +893,14 @@ asmcomp/clambda.cmi : bytecomp/lambda.cmi middle_end/debuginfo.cmi \
 asmcomp/closure.cmo : utils/warnings.cmi bytecomp/switch.cmi \
     bytecomp/simplif.cmi bytecomp/semantics_of_primitives.cmi \
     typing/primitive.cmi utils/numbers.cmi utils/misc.cmi \
-    parsing/location.cmi bytecomp/lambda.cmi typing/env.cmi \
+    parsing/location.cmi bytecomp/lambda.cmi typing/ident.cmi typing/env.cmi \
     middle_end/debuginfo.cmi utils/config.cmi asmcomp/compilenv.cmi \
     utils/clflags.cmi asmcomp/clambda.cmi asmcomp/backend_var.cmi \
     parsing/asttypes.cmi asmcomp/arch.cmo asmcomp/closure.cmi
 asmcomp/closure.cmx : utils/warnings.cmx bytecomp/switch.cmx \
     bytecomp/simplif.cmx bytecomp/semantics_of_primitives.cmx \
     typing/primitive.cmx utils/numbers.cmx utils/misc.cmx \
-    parsing/location.cmx bytecomp/lambda.cmx typing/env.cmx \
+    parsing/location.cmx bytecomp/lambda.cmx typing/ident.cmx typing/env.cmx \
     middle_end/debuginfo.cmx utils/config.cmx asmcomp/compilenv.cmx \
     utils/clflags.cmx asmcomp/clambda.cmx asmcomp/backend_var.cmx \
     parsing/asttypes.cmi asmcomp/arch.cmx asmcomp/closure.cmi
@@ -1101,14 +1103,19 @@ asmcomp/interval.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/mach.cmi \
 asmcomp/interval.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/mach.cmx \
     asmcomp/interval.cmi
 asmcomp/interval.cmi : asmcomp/reg.cmi asmcomp/mach.cmi
-asmcomp/linearize.cmo : asmcomp/reg.cmi asmcomp/proc.cmi utils/misc.cmi \
-    asmcomp/mach.cmi middle_end/debuginfo.cmi utils/config.cmi \
-    asmcomp/cmm.cmi asmcomp/linearize.cmi
-asmcomp/linearize.cmx : asmcomp/reg.cmx asmcomp/proc.cmx utils/misc.cmx \
-    asmcomp/mach.cmx middle_end/debuginfo.cmx utils/config.cmx \
-    asmcomp/cmm.cmx asmcomp/linearize.cmi
-asmcomp/linearize.cmi : asmcomp/reg.cmi asmcomp/mach.cmi \
-    middle_end/debuginfo.cmi asmcomp/cmm.cmi
+asmcomp/linearize.cmo : asmcomp/debug/reg_with_debug_info.cmi \
+    asmcomp/debug/reg_availability_set.cmi asmcomp/reg.cmi asmcomp/proc.cmi \
+    utils/misc.cmi asmcomp/mach.cmi typing/ident.cmi middle_end/debuginfo.cmi \
+    utils/config.cmi asmcomp/cmm.cmi asmcomp/backend_var.cmi \
+    asmcomp/linearize.cmi
+asmcomp/linearize.cmx : asmcomp/debug/reg_with_debug_info.cmx \
+    asmcomp/debug/reg_availability_set.cmx asmcomp/reg.cmx asmcomp/proc.cmx \
+    utils/misc.cmx asmcomp/mach.cmx typing/ident.cmx middle_end/debuginfo.cmx \
+    utils/config.cmx asmcomp/cmm.cmx asmcomp/backend_var.cmx \
+    asmcomp/linearize.cmi
+asmcomp/linearize.cmi : asmcomp/debug/reg_availability_set.cmi \
+    asmcomp/reg.cmi asmcomp/mach.cmi middle_end/debuginfo.cmi asmcomp/cmm.cmi \
+    asmcomp/backend_var.cmi
 asmcomp/linscan.cmo : asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/interval.cmi \
     asmcomp/linscan.cmi
 asmcomp/linscan.cmx : asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/interval.cmx \
@@ -1121,15 +1128,18 @@ asmcomp/liveness.cmx : asmcomp/reg.cmx asmcomp/proc.cmx \
     asmcomp/printmach.cmx utils/misc.cmx asmcomp/mach.cmx utils/config.cmx \
     asmcomp/cmm.cmx asmcomp/liveness.cmi
 asmcomp/liveness.cmi : asmcomp/mach.cmi
-asmcomp/mach.cmo : asmcomp/debug/reg_with_debug_info.cmi \
+asmcomp/mach.cmo : middle_end/base_types/symbol.cmi \
+    asmcomp/debug/reg_with_debug_info.cmi \
     asmcomp/debug/reg_availability_set.cmi asmcomp/reg.cmi \
     middle_end/debuginfo.cmi asmcomp/cmm.cmi asmcomp/backend_var.cmi \
     asmcomp/arch.cmo asmcomp/mach.cmi
-asmcomp/mach.cmx : asmcomp/debug/reg_with_debug_info.cmx \
+asmcomp/mach.cmx : middle_end/base_types/symbol.cmx \
+    asmcomp/debug/reg_with_debug_info.cmx \
     asmcomp/debug/reg_availability_set.cmx asmcomp/reg.cmx \
     middle_end/debuginfo.cmx asmcomp/cmm.cmx asmcomp/backend_var.cmx \
     asmcomp/arch.cmx asmcomp/mach.cmi
-asmcomp/mach.cmi : asmcomp/debug/reg_availability_set.cmi asmcomp/reg.cmi \
+asmcomp/mach.cmi : middle_end/base_types/symbol.cmi \
+    asmcomp/debug/reg_availability_set.cmi asmcomp/reg.cmi \
     middle_end/debuginfo.cmi asmcomp/cmm.cmi asmcomp/backend_var.cmi \
     asmcomp/arch.cmo
 asmcomp/printclambda.cmo : bytecomp/printlambda.cmi bytecomp/lambda.cmi \
@@ -1153,16 +1163,18 @@ asmcomp/printlinear.cmx : asmcomp/printmach.cmx asmcomp/printcmm.cmx \
     asmcomp/mach.cmx asmcomp/linearize.cmx middle_end/debuginfo.cmx \
     asmcomp/printlinear.cmi
 asmcomp/printlinear.cmi : asmcomp/linearize.cmi
-asmcomp/printmach.cmo : asmcomp/debug/reg_availability_set.cmi \
-    asmcomp/reg.cmi asmcomp/proc.cmi asmcomp/printcmm.cmi asmcomp/mach.cmi \
-    asmcomp/interval.cmi middle_end/debuginfo.cmi utils/config.cmi \
-    asmcomp/cmm.cmi utils/clflags.cmi asmcomp/backend_var.cmi \
-    asmcomp/arch.cmo asmcomp/printmach.cmi
-asmcomp/printmach.cmx : asmcomp/debug/reg_availability_set.cmx \
-    asmcomp/reg.cmx asmcomp/proc.cmx asmcomp/printcmm.cmx asmcomp/mach.cmx \
-    asmcomp/interval.cmx middle_end/debuginfo.cmx utils/config.cmx \
-    asmcomp/cmm.cmx utils/clflags.cmx asmcomp/backend_var.cmx \
-    asmcomp/arch.cmx asmcomp/printmach.cmi
+asmcomp/printmach.cmo : middle_end/base_types/symbol.cmi \
+    asmcomp/debug/reg_availability_set.cmi asmcomp/reg.cmi asmcomp/proc.cmi \
+    asmcomp/printcmm.cmi utils/misc.cmi asmcomp/mach.cmi asmcomp/interval.cmi \
+    middle_end/debuginfo.cmi utils/config.cmi asmcomp/cmm.cmi \
+    utils/clflags.cmi asmcomp/backend_var.cmi asmcomp/arch.cmo \
+    asmcomp/printmach.cmi
+asmcomp/printmach.cmx : middle_end/base_types/symbol.cmx \
+    asmcomp/debug/reg_availability_set.cmx asmcomp/reg.cmx asmcomp/proc.cmx \
+    asmcomp/printcmm.cmx utils/misc.cmx asmcomp/mach.cmx asmcomp/interval.cmx \
+    middle_end/debuginfo.cmx utils/config.cmx asmcomp/cmm.cmx \
+    utils/clflags.cmx asmcomp/backend_var.cmx asmcomp/arch.cmx \
+    asmcomp/printmach.cmi
 asmcomp/printmach.cmi : asmcomp/reg.cmi asmcomp/mach.cmi
 asmcomp/proc.cmo : asmcomp/x86_proc.cmi asmcomp/reg.cmi utils/misc.cmi \
     asmcomp/mach.cmi utils/config.cmi asmcomp/cmm.cmi asmcomp/arch.cmo \
@@ -2463,14 +2475,14 @@ toplevel/genprintval.cmi : typing/types.cmi typing/path.cmi \
     typing/outcometree.cmi typing/env.cmi
 toplevel/opttopdirs.cmo : utils/warnings.cmi typing/types.cmi \
     typing/printtyp.cmi toplevel/opttoploop.cmi utils/misc.cmi \
-    parsing/longident.cmi typing/ident.cmi typing/env.cmi typing/ctype.cmi \
-    utils/config.cmi driver/compdynlink.cmi utils/clflags.cmi \
-    asmcomp/asmlink.cmi toplevel/opttopdirs.cmi
+    parsing/longident.cmi typing/env.cmi typing/ctype.cmi utils/config.cmi \
+    driver/compdynlink.cmi utils/clflags.cmi asmcomp/asmlink.cmi \
+    toplevel/opttopdirs.cmi
 toplevel/opttopdirs.cmx : utils/warnings.cmx typing/types.cmx \
     typing/printtyp.cmx toplevel/opttoploop.cmx utils/misc.cmx \
-    parsing/longident.cmx typing/ident.cmx typing/env.cmx typing/ctype.cmx \
-    utils/config.cmx driver/compdynlink.cmi utils/clflags.cmx \
-    asmcomp/asmlink.cmx toplevel/opttopdirs.cmi
+    parsing/longident.cmx typing/env.cmx typing/ctype.cmx utils/config.cmx \
+    driver/compdynlink.cmi utils/clflags.cmx asmcomp/asmlink.cmx \
+    toplevel/opttopdirs.cmi
 toplevel/opttopdirs.cmi : parsing/longident.cmi
 toplevel/opttoploop.cmo : utils/warnings.cmi typing/types.cmi \
     typing/typemod.cmi typing/typedtree.cmi typing/typecore.cmi \

--- a/Changes
+++ b/Changes
@@ -407,6 +407,25 @@ Working version
   use [Backend_var.With_provenance] for variables in binding position.
   (Mark Shinwell, review by Pierre Chambart)
 
+- GPR#2061: Add [Linearize.Lcapture_stack_offset].
+  (Mark Shinwell, review by Xavier Leroy)
+
+- GPR#2063: Generate [Iname_for_debugger] in [Selectgen].  Skip over certain
+  naming operations in [Spill].
+  (Mark Shinwell)
+
+- GPR#2065: Add [Proc.destroyed_at_reloadretaddr].
+  (Mark Shinwell)
+
+- GPR#2067: Add remaining types and record fields in [Mach] and [Linearize]
+  to communicate register availability information to the debugging
+  information emitter.
+  (Mark Shinwell)
+
+- GPR#2068: Propagate availability information in [Linearize] and adjust
+  position of prologue.
+  (Mark Shinwell)
+
 - GPR#2076: Add [Targetint.print].
   (Mark Shinwell)
 

--- a/Changes
+++ b/Changes
@@ -426,6 +426,9 @@ Working version
   position of prologue.
   (Mark Shinwell)
 
+- GPR#2069: Add [Available_ranges] pass.
+  (Mark Shinwell)
+
 - GPR#2076: Add [Targetint.print].
   (Mark Shinwell)
 

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ ASMCOMP=\
   asmcomp/deadcode.cmo \
   asmcomp/printlinear.cmo asmcomp/linearize.cmo \
   asmcomp/debug/available_regs.cmo \
+  asmcomp/debug/available_ranges.cmo \
   asmcomp/schedgen.cmo asmcomp/scheduling.cmo \
   asmcomp/branch_relaxation_intf.cmo \
   asmcomp/branch_relaxation.cmo \

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -892,6 +892,9 @@ let emit_instr fallthrough i =
           I.pop r14;
           I.ret ()
       end
+  | Lcapture_stack_offset byte_offset_from_cfa ->
+      Emitaux.handle_lcapture_stack_offset i ~frame_size ~slot_offset
+        ~register_class ~byte_offset_from_cfa
 
 let rec emit_all fallthrough i =
   match i.desc with

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -352,6 +352,7 @@ let op_is_pure = function
   | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _) -> false
   | Ispecific(Ilea _|Isextend32) -> true
   | Ispecific _ -> false
+  | Iname_for_debugger _ -> false
   | _ -> true
 
 (* Layout of the stack frame *)

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -319,6 +319,8 @@ let destroyed_at_oper = function
 
 let destroyed_at_raise = all_phys_regs
 
+let destroyed_at_reloadretaddr = [| |]
+
 (* Maximal register pressure *)
 
 

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -858,6 +858,10 @@ let emit_instr i =
           `	mov	sp, trap_ptr\n`;
           `	pop	\{trap_ptr, pc}\n`; 2
         end
+    | Lcapture_stack_offset byte_offset_from_cfa ->
+        Emitaux.handle_lcapture_stack_offset i ~frame_size ~slot_offset
+          ~register_class ~byte_offset_from_cfa;
+        0
 
 (* Upper bound on the size of the code sequence for a Linear instruction,
    in 32-bit words. *)

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -274,6 +274,10 @@ let destroyed_at_oper = function
 
 let destroyed_at_raise = all_phys_regs
 
+(* lr is destroyed at [Lreloadretaddr], but lr is not used for register
+   allocation, and thus does not need to (and indeed cannot) occur here. *)
+let destroyed_at_reloadretaddr = [| |]
+
 (* Maximal register pressure *)
 
 let safe_register_pressure = function

--- a/asmcomp/arm/proc.ml
+++ b/asmcomp/arm/proc.ml
@@ -300,6 +300,7 @@ let op_is_pure = function
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
   | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _)
   | Ispecific(Ishiftcheckbound _) -> false
+  | Iname_for_debugger _ -> false
   | _ -> true
 
 (* Layout of the stack *)

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -502,6 +502,7 @@ module BR = Branch_relaxation.Make (struct
       | Cmm.Raise_withtrace -> 1
       | Cmm.Raise_notrace -> 4
       end
+    | Lcapture_stack_offset _ -> 0
 
   let relax_allocation ~num_words ~label_after_call_gc =
     Lop (Ispecific (Ifar_alloc { words = num_words; label_after_call_gc; }))
@@ -899,6 +900,9 @@ let emit_instr i =
           `	ldr	{emit_reg reg_trap_ptr}, [sp], 16\n`;
           `	br	{emit_reg reg_tmp1}\n`
         end
+  | Lcapture_stack_offset byte_offset_from_cfa ->
+      Emitaux.handle_lcapture_stack_offset i ~frame_size ~slot_offset
+        ~register_class ~byte_offset_from_cfa
 
 (* Emission of an instruction sequence *)
 

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -198,6 +198,8 @@ let destroyed_at_oper = function
 
 let destroyed_at_raise = all_phys_regs
 
+let destroyed_at_reloadretaddr = [| |]
+
 (* Maximal register pressure *)
 
 let safe_register_pressure = function

--- a/asmcomp/arm64/proc.ml
+++ b/asmcomp/arm64/proc.ml
@@ -220,6 +220,7 @@ let op_is_pure = function
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
   | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _)
   | Ispecific(Ishiftcheckbound _) -> false
+  | Iname_for_debugger _ -> false
   | _ -> true
 
 (* Layout of the stack *)

--- a/asmcomp/branch_relaxation.ml
+++ b/asmcomp/branch_relaxation.ml
@@ -72,7 +72,8 @@ module Make (T : Branch_relaxation_intf.S) = struct
       match lbl with
       | None -> next
       | Some l ->
-        instr_cons (Lcondbranch (Iinttest_imm (Isigned Cmm.Ceq, n), l))
+        instr_cons_same_avail
+          (Lcondbranch (Iinttest_imm (Isigned Cmm.Ceq, n), l))
           arg [||] next
     in
     let rec fixup did_fix pc instr =
@@ -102,8 +103,8 @@ module Make (T : Branch_relaxation_intf.S) = struct
           | Lcondbranch (test, lbl) ->
             let lbl2 = Cmm.new_label() in
             let cont =
-              instr_cons (Lbranch lbl) [||] [||]
-                (instr_cons (Llabel lbl2) [||] [||] instr.next)
+              instr_cons_same_avail (Lbranch lbl) [||] [||]
+                (instr_cons_same_avail (Llabel lbl2) [||] [||] instr.next)
             in
             instr.desc <- Lcondbranch (invert_test test, lbl2);
             instr.next <- cont;

--- a/asmcomp/debug/available_ranges.ml
+++ b/asmcomp/debug/available_ranges.ml
@@ -1,0 +1,698 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module L = Linearize
+
+let rewrite_label env label =
+  match Numbers.Int.Map.find label env with
+  | exception Not_found -> label
+  | label -> label
+
+(* CR-soon mshinwell: pull this type forward so other passes can use it *)
+type is_parameter =
+  | Local
+  | Parameter of { index : int; }
+
+module Available_subrange : sig
+  type t
+
+  type 'a location =
+    | Reg of Reg.t * 'a
+    | Phantom
+
+  val create
+     : reg:Reg.t
+    -> start_insn:L.instruction
+    -> start_pos:L.label
+    -> end_pos:L.label
+    -> end_pos_offset:int option
+    -> t
+
+  val create_phantom
+     : start_pos:Linearize.label
+    -> end_pos:Linearize.label
+    -> t
+
+  val start_pos : t -> L.label
+  val end_pos : t -> L.label
+  val end_pos_offset : t -> int option
+  val location : t -> unit location
+  val offset_from_stack_ptr_in_bytes : t -> int option
+
+  val rewrite_labels : t -> env:int Numbers.Int.Map.t -> t
+end = struct
+  type 'a location =
+    | Reg of Reg.t * 'a
+    | Phantom
+
+  type start_insn_or_phantom = L.instruction location
+
+  type t = {
+    (* CR-soon mshinwell: find a better name for [start_insn] *)
+    start_insn : start_insn_or_phantom;
+    start_pos : L.label;
+    (* CR mshinwell: we need to check exactly what happens with function
+       epilogues, including returns in the middle of functions. *)
+    end_pos : L.label;
+    end_pos_offset : int option;
+  }
+
+  let create ~(reg : Reg.t) ~(start_insn : Linearize.instruction)
+        ~start_pos ~end_pos ~end_pos_offset =
+    match start_insn.desc with
+    | L.Lcapture_stack_offset _ | L.Llabel _ ->
+      begin match start_insn.desc with
+      | L.Lcapture_stack_offset _ ->
+        assert (Array.length start_insn.arg = 1);
+        (* CR mshinwell: review assertions, maybe less useful now *)
+        (*assert (reg.name = start_insn.arg.(0).Reg.name);*)
+        (* CR mshinwell: Why bother storing the start instruction when it's
+           a label? *)
+        assert (reg.loc = start_insn.arg.(0).Reg.loc)
+      | _ -> ()
+      end;
+      { start_insn = Reg (reg, start_insn);
+        start_pos;
+        end_pos;
+        end_pos_offset;
+      }
+    | _ -> failwith "Available_subrange.create"
+
+  let create_phantom ~start_pos ~end_pos =
+    { start_insn = Phantom;
+      start_pos;
+      end_pos;
+      end_pos_offset = None;
+    }
+
+  let start_pos t = t.start_pos
+  let end_pos t = t.end_pos
+  let end_pos_offset t = t.end_pos_offset
+
+  let location t : unit location =
+    let convert_location (start_insn : start_insn_or_phantom) : unit location =
+      match start_insn with
+      | Reg (reg, _insn) -> Reg (reg, ())
+      | Phantom -> Phantom
+    in
+    convert_location t.start_insn
+
+  let offset_from_stack_ptr_in_bytes t =
+    let offset (start_insn : start_insn_or_phantom) =
+      match start_insn with
+      | Reg (_reg, insn) ->
+        begin match insn.L.desc with
+        | L.Lcapture_stack_offset offset -> Some !offset
+        | L.Llabel _ ->
+(* CR mshinwell: resurrect assertion *)
+(*          assert (not (Reg.assigned_to_stack reg)); *)
+          None
+        | _ -> assert false
+        end
+      | Phantom -> None
+    in
+    offset t.start_insn
+
+  let rewrite_labels t ~env =
+    { t with
+      start_pos = rewrite_label env t.start_pos;
+      end_pos = rewrite_label env t.end_pos;
+    }
+end
+
+type type_info =
+  | From_cmt_file of Backend_var.Provenance.t option
+  | Phantom of
+      Backend_var.Provenance.t option * Mach.phantom_defining_expr option
+
+let type_info_has_provenance = function
+  | From_cmt_file None -> false
+  | From_cmt_file (Some _) -> true
+  | Phantom (None, _) -> false
+  | Phantom (Some _, _) -> true
+
+module Available_range : sig
+  type t
+
+  val create
+     : type_info:type_info
+    -> is_parameter:is_parameter
+    -> t
+
+  val type_info : t -> type_info
+  val is_parameter : t -> is_parameter
+  val add_subrange : t -> subrange:Available_subrange.t -> unit
+  val extremities : t -> L.label * L.label
+
+  val iter
+     : t
+    -> f:(available_subrange:Available_subrange.t -> unit)
+    -> unit
+
+  val fold
+     : t
+    -> init:'a
+    -> f:('a -> available_subrange:Available_subrange.t -> 'a)
+    -> 'a
+
+  val rewrite_labels : t -> env:int Numbers.Int.Map.t -> t
+end = struct
+  type t = {
+    mutable subranges : Available_subrange.t list;
+    mutable min_pos : L.label option;
+    mutable max_pos : L.label option;
+    type_info : type_info;
+    is_parameter : is_parameter;
+  }
+
+  let create ~type_info ~is_parameter =
+    { subranges = []; min_pos = None; max_pos = None;
+      type_info; is_parameter;
+    }
+
+  let type_info t = t.type_info
+  let is_parameter t = t.is_parameter
+
+  let add_subrange t ~subrange =
+    let start_pos = Available_subrange.start_pos subrange in
+    let end_pos = Available_subrange.end_pos subrange in
+    (* This is dubious, but should be correct by virtue of the way label
+       counters are allocated (see linearize.ml) and the fact that, below,
+       we go through the code from lowest (code) address to highest.  As
+       such the label with the highest integer value should be the one with
+       the highest address, and vice-versa.  (Note that we also exploit the
+       ordering when constructing location lists, to ensure that they are
+       sorted in increasing program counter order by start address.
+       However by that stage [Coalesce_labels] has run.) *)
+    assert (compare start_pos end_pos <= 0);
+    begin
+      match t.min_pos with
+      | None -> t.min_pos <- Some start_pos
+      | Some min_pos ->
+        if compare start_pos min_pos < 0 then t.min_pos <- Some start_pos
+    end;
+    begin
+      match t.max_pos with
+      | None -> t.max_pos <- Some end_pos
+      | Some max_pos ->
+        if compare (`At_label end_pos) (`At_label max_pos) > 0 then
+          t.max_pos <- Some end_pos
+    end;
+    t.subranges <- subrange::t.subranges
+
+  let extremities t =
+    (* We ignore any [end_pos_offsets] here; should be ok. *)
+    match t.min_pos, t.max_pos with
+    | Some min, Some max -> min, max
+    | Some _, None | None, Some _ -> assert false
+    | None, None -> failwith "Available_ranges.extremities on empty range"
+
+  let iter t ~f =
+    List.iter (fun available_subrange -> f ~available_subrange)
+      t.subranges
+
+  let fold t ~init ~f =
+    List.fold_left (fun acc available_subrange -> f acc ~available_subrange)
+      init
+      t.subranges
+
+  let rewrite_labels t ~env =
+    let subranges =
+      List.map (fun subrange ->
+          Available_subrange.rewrite_labels subrange ~env)
+        t.subranges
+    in
+    let min_pos = Misc.Stdlib.Option.map (rewrite_label env) t.min_pos in
+    let max_pos = Misc.Stdlib.Option.map (rewrite_label env) t.max_pos in
+    { subranges; min_pos; max_pos;
+      type_info = t.type_info;
+      is_parameter = t.is_parameter;
+    }
+end
+
+type t = {
+  ranges : Available_range.t Backend_var.Tbl.t;
+}
+
+let find t ~var =
+  match Backend_var.Tbl.find t.ranges var with
+  | exception Not_found -> None
+  | range -> Some range
+
+let fold t ~init ~f =
+  Backend_var.Tbl.fold (fun var range acc ->
+      (* CR-soon mshinwell: improve efficiency *)
+      let with_same_name =
+        List.filter (fun (var', range') ->
+            let has_provenance =
+              type_info_has_provenance (Available_range.type_info range')
+            in
+            has_provenance
+              && Backend_var.name var = Backend_var.name var')
+          (Backend_var.Tbl.to_list t.ranges)
+      in
+      let is_unique = List.length with_same_name <= 1 in
+      f acc ~var ~is_unique ~range)
+    t.ranges
+    init
+
+module Make (S : sig
+  module Key : sig
+    type t
+
+    module Map : Map.S with type key := t
+    module Set : Set.S with type elt := t
+
+    val assert_valid : t -> unit
+    val needs_stack_offset_capture : t -> Reg.t option
+  end
+
+  val available_before : L.instruction -> Key.Set.t
+
+  val range_info
+     : fundecl:L.fundecl
+    -> key:Key.t
+    -> start_insn:L.instruction
+    -> (Backend_var.t * type_info * is_parameter) option
+
+  val create_subrange
+     : fundecl:L.fundecl
+    -> key:Key.t
+    -> start_pos:L.label
+    -> start_insn:L.instruction
+    -> end_pos:L.label
+    -> end_pos_offset:int option
+    -> Available_subrange.t
+
+  val end_pos_offset
+     : prev_insn:L.instruction option
+    -> key:Key.t
+    -> int option
+end) = struct
+  module KM = S.Key.Map
+  module KS = S.Key.Set
+
+  (* Imagine that the program counter is exactly at the start of [insn]; it has
+     not yet been executed.  This function calculates which available subranges
+     are to start at that point, and which are to stop.  [prev_insn] is the
+     instruction immediately prior to [insn], if such exists. *)
+  let births_and_deaths ~(insn : L.instruction)
+        ~(prev_insn : L.instruction option) =
+    (* Available subranges are allowed to cross points at which the stack
+       pointer changes, since we reference the stack slots as an offset from
+       the CFA, not from the stack pointer.
+
+       We avoid generating ranges that overlap, since this confuses lldb.
+       This pass may generate ranges that are the same as other ranges,
+       but those are deduped in [Dwarf].
+    *)
+    let proto_births =
+      match prev_insn with
+      | None -> S.available_before insn
+      | Some prev_insn ->
+        KS.diff (S.available_before insn) (S.available_before prev_insn)
+    in
+    let proto_deaths =
+      match prev_insn with
+      | None -> KS.empty
+      | Some prev_insn ->
+        KS.diff (S.available_before prev_insn) (S.available_before insn)
+    in
+    (* CR mshinwell: add command line flag to restart ranges *)
+    let restart_ranges = false (*
+      KS.cardinal proto_births <> 0 || KS.cardinal proto_deaths <> 0
+*)
+    in
+    let births =
+      match prev_insn with
+      | None -> S.available_before insn
+      | Some _prev_insn ->
+        if not restart_ranges then
+          proto_births
+        else
+          S.available_before insn
+    in
+    let deaths =
+      match prev_insn with
+      | None -> KS.empty
+      | Some prev_insn ->
+        if not restart_ranges then
+          proto_deaths
+        else
+          S.available_before prev_insn
+    in
+    births, deaths
+
+  let rec process_instruction t ~fundecl ~first_insn ~(insn : L.instruction)
+        ~prev_insn ~open_subrange_start_insns =
+    let births, deaths = births_and_deaths ~insn ~prev_insn in
+    let first_insn = ref first_insn in
+    let prev_insn = ref prev_insn in
+    let insert_insn ~new_insn =
+      assert (new_insn.L.next == insn);
+      (* (Note that by virtue of [Lprologue], we can insert labels prior
+         to the first assembly instruction of the function.) *)
+      begin match !prev_insn with
+      | None -> first_insn := new_insn
+      | Some prev_insn ->
+        assert (prev_insn.L.next == insn);
+        prev_insn.L.next <- new_insn
+      end;
+      prev_insn := Some new_insn
+    in
+    (* Note that we can't reuse an existing label in the code since we rely
+       on the ordering of range-related labels. *)
+    let label = Cmm.new_label () in
+    let used_label = ref false in
+    (* As a result of the code above to restart subranges, we may have
+       a register occurring in both [births] and [deaths]; and we would
+       like the register to have an open subrange from this point.  It
+       follows that we should process deaths before births. *)
+    KS.fold (fun (key : S.Key.t) () ->
+        S.Key.assert_valid key;
+        let start_pos, start_insn =
+          try KM.find key open_subrange_start_insns
+          with Not_found -> assert false
+        in
+        let end_pos = label in
+        used_label := true;
+        let end_pos_offset = S.end_pos_offset ~prev_insn:!prev_insn ~key in
+        match S.range_info ~fundecl ~key ~start_insn with
+        | None -> ()
+        | Some (var, type_info, is_parameter) ->
+          let range =
+            match Backend_var.Tbl.find t.ranges var with
+            | range -> range
+            | exception Not_found ->
+              let range = Available_range.create ~type_info ~is_parameter in
+              Backend_var.Tbl.add t.ranges var range;
+              range
+          in
+          let subrange =
+            S.create_subrange ~fundecl ~key ~start_pos ~start_insn ~end_pos
+              ~end_pos_offset
+          in
+          Available_range.add_subrange range ~subrange)
+      deaths
+      ();
+    let label_insn =
+      { L.
+        desc = L.Llabel label;
+        next = insn;
+        arg = [| |];
+        res = [| |];
+        dbg = Debuginfo.none;
+        live = Reg.Set.empty;
+        available_before = insn.available_before;
+        phantom_available_before = insn.phantom_available_before;
+        available_across = None;
+      }
+    in
+    let open_subrange_start_insns =
+      let open_subrange_start_insns =
+        (KM.filter (fun reg _start_insn -> not (KS.mem reg deaths))
+          open_subrange_start_insns)
+      in
+      KS.fold (fun key open_subrange_start_insns ->
+          (* We only need [Lcapture_stack_offset] in the case where the
+             register is assigned to the stack.  (It enables us to determine
+             what the stack offset will be at that point.) *)
+          let new_insn =
+            match S.Key.needs_stack_offset_capture key with
+            | None -> label_insn
+            | Some reg ->
+              let new_insn =
+                { L.
+                  (* CR-someday mshinwell: Instead of [int] it would be better
+                     if the ref held something like [int Set_once.t]. *)
+                  desc = L.Lcapture_stack_offset (ref 0);
+                  next = insn;
+                  arg = [| reg |];
+                  res = [| |];
+                  dbg = Debuginfo.none;
+                  live = Reg.Set.empty;
+                  available_before = insn.available_before;
+                  phantom_available_before = insn.phantom_available_before;
+                  available_across = None;
+                }
+              in
+              insert_insn ~new_insn;
+              new_insn
+          in
+          used_label := true;
+          KM.add key (label, new_insn) open_subrange_start_insns)
+        births
+        open_subrange_start_insns
+    in
+    begin if !used_label then
+      insert_insn ~new_insn:label_insn
+    end;
+    let first_insn = !first_insn in
+    match insn.L.desc with
+    | L.Lend -> first_insn
+    | L.Lprologue | L.Lop _ | L.Lreloadretaddr | L.Lreturn | L.Llabel _
+    | L.Lbranch _ | L.Lcondbranch _ | L.Lcondbranch3 _ | L.Lswitch _
+    | L.Lsetuptrap _ | L.Lpushtrap | L.Lpoptrap | L.Lraise _
+    | L.Lcapture_stack_offset _ ->
+      process_instruction t ~fundecl ~first_insn ~insn:insn.L.next
+        ~prev_insn:(Some insn) ~open_subrange_start_insns
+
+  let process_instructions t ~fundecl ~first_insn =
+    process_instruction t ~fundecl ~first_insn ~insn:first_insn
+      ~prev_insn:None ~open_subrange_start_insns:KM.empty
+end
+
+module Make_ranges = Make (struct
+  module RD = Reg_with_debug_info
+
+  (* By the time this pass has run, register stamps are irrelevant; indeed,
+     there may be multiple registers with different stamps assigned to the
+     same location.  As such, we quotient register sets by the equivalence
+     relation that varifies two registers iff they have the same name and
+     location. *)
+  module Key = struct
+    type t = RD.t
+
+    (* CR mshinwell: check this *)
+    let assert_valid (_t : t) = ()
+     (*  assert (t.name <> None);  (* cf. [Available_filtering] *) *)
+
+    module Map = RD.Map_distinguishing_names_and_locations
+    module Set = RD.Set_distinguishing_names_and_locations
+
+    let needs_stack_offset_capture t =
+      if RD.assigned_to_stack t then Some (RD.reg t) else None
+  end
+
+  (* CR mshinwell: improve efficiency *)
+  let available_before (insn : L.instruction) =
+    match insn.available_before with
+    | Unreachable -> Key.Set.empty
+    | Ok available_before -> Key.Set.of_list (RD.Set.elements available_before)
+
+  let end_pos_offset ~prev_insn ~key:reg =
+    (* If the range is for a register destroyed by a call and which
+       ends immediately after a call instruction, move the end of the
+       range back very slightly.  The effect is that the register is seen
+       in the debugger as available when standing on the call instruction
+       but unavailable when we are in the callee (and move to the previous
+       frame). *)
+    (* CR-someday mshinwell: I wonder if this should be more
+       conservative for Iextcall.  If the C callee is compiled with
+       debug info then it should describe where any callee-save
+       registers have been saved, so when we step back to the OCaml frame
+       in the debugger, the unwinding procedure should get register
+       values correct.  (I think.)  However if it weren't compiled with
+       debug info, this wouldn't happen, and when looking back up into
+       the OCaml frame I suspect registers would be wrong.  This may
+       not be a great problem once libmonda is hardened, although it
+       is possible for this to be subtle and misleading (e.g. an integer
+       value being 1 instead of 2 or something.) *)
+    match prev_insn with
+    | None -> None
+    | Some prev_insn ->
+      match prev_insn.L.desc with
+      | Lop ((Icall_ind _ | Icall_imm _ | Iextcall _) as op) ->
+        let destroyed_locations =
+          Array.map (fun (reg : Reg.t) -> reg.loc)
+            (Proc.destroyed_at_oper (Mach.Iop op))
+        in
+        let holds_immediate = RD.holds_non_pointer reg in
+        let on_stack = RD.assigned_to_stack reg in
+        let live_across = Reg.Set.mem (RD.reg reg) prev_insn.L.live in
+        let remains_available =
+          live_across
+            || (holds_immediate && on_stack)
+        in
+        if Array.mem (RD.location reg) destroyed_locations
+            || not remains_available
+        then
+          Some (-1)
+        else
+          None
+      | _ -> None
+
+  let range_info ~fundecl:_ ~key:reg ~start_insn:_ =
+    match RD.debug_info reg with
+    | None -> None
+    | Some debug_info ->
+      let is_parameter =
+        match RD.Debug_info.which_parameter debug_info with
+        | None -> Local
+        | Some index -> Parameter { index; }
+      in
+      let var = RD.Debug_info.holds_value_of debug_info in
+      Some (var, From_cmt_file (RD.Debug_info.provenance debug_info),
+        is_parameter)
+
+  let create_subrange ~fundecl:_ ~key:reg ~start_pos ~start_insn ~end_pos
+        ~end_pos_offset =
+    Available_subrange.create ~reg:(RD.reg reg)
+      ~start_pos ~start_insn
+      ~end_pos ~end_pos_offset
+end)
+
+module Make_phantom_ranges = Make (struct
+  module Key = struct
+    include Ident
+
+    let assert_valid _t = ()
+    let needs_stack_offset_capture _ = None
+  end
+
+  let available_before (insn : L.instruction) = insn.phantom_available_before
+
+  let end_pos_offset ~prev_insn:_ ~key:_ = None
+
+  let range_info ~fundecl ~key ~start_insn:_ =
+    match Backend_var.Map.find key fundecl.L.fun_phantom_lets with
+    | exception Not_found ->
+      Misc.fatal_errorf "Available_ranges.Make_phantom_ranges.create_range: \
+          phantom variable occurs in [phantom_available_before] but not in \
+          [fun_phantom_lets]: %a"
+        Key.print key
+    | provenance, defining_expr ->
+      (* CR-someday mshinwell: Presumably the "Local" only changes to indicate
+         a parameter when we can represent the inlined frames properly in
+         DWARF.  (Otherwise the function into which an inlining occurs ends up
+         having more parameters than it should in the debugger.)
+      *)
+      Some (key, Phantom (provenance, Some defining_expr), Local)
+
+  let create_subrange ~fundecl:_ ~key:_ ~start_pos ~start_insn:_ ~end_pos
+        ~end_pos_offset:_ =
+    (* Ranges for phantom variables are emitted as contiguous blocks
+       which are designed to approximately indicate their scope.
+       Some such phantom variables' values may ultimately be derived
+       from the values of normal variables (e.g. "Read_var_field") and
+       thus will be unavailable when those normal variables are
+       unavailable.  This effective intersecting of available ranges
+       is handled automatically in the debugger since we emit DWARF that
+       explains properly how the phantom variables relate to other
+       (normal or phantom) ones. *)
+    Available_subrange.create_phantom ~start_pos ~end_pos
+end)
+
+let create ~fundecl =
+  let t = { ranges = Backend_var.Tbl.create 42; } in
+  let first_insn =
+    let first_insn = fundecl.L.fun_body in
+    Make_ranges.process_instructions t ~fundecl ~first_insn
+  in
+  let first_insn =
+    Make_phantom_ranges.process_instructions t ~fundecl ~first_insn
+  in
+  (* It is unfortunately the case that variables can be named in the defining
+     expressions of phantom ranges without actually having any available range
+     themselves.  This might be caused by, for example, a "name for debugger"
+     operation on a register assigned to %rax immediately before an allocation
+     on x86-64 (which clobbers %rax).  The register is explicitly removed from
+     the availability sets by [Available_regs], and the name never appears on
+     any available range.
+     To prevent this situation from causing problems later on, we add empty
+     ranges for any such variables.  We assume such variables are local
+     variables. *)
+  let variables_without_ranges =
+    fold t ~init:[] ~f:(fun acc ~var:_ ~is_unique:_ ~range ->
+      match Available_range.type_info range with
+      | From_cmt_file _ -> acc
+      | Phantom (_, defining_expr) ->
+        let vars =
+          match defining_expr with
+          | None -> []
+          | Some defining_expr ->
+            match defining_expr with
+            | Iphantom_const_int _
+            | Iphantom_const_symbol _
+            | Iphantom_read_symbol_field _ -> []
+            | Iphantom_var var
+            | Iphantom_read_field (var, _)
+            | Iphantom_offset_var { var; _ } -> [var]
+            | Iphantom_block { fields; _ } ->
+              Misc.Stdlib.List.filter_map (fun field -> field) fields
+        in
+        let without_ranges =
+          List.filter (fun var -> not (Backend_var.Tbl.mem t.ranges var)) vars
+        in
+        acc @ without_ranges)
+  in
+  List.iter (fun var ->
+      let range =
+        Available_range.create ~type_info:(Phantom (None, None))
+          ~is_parameter:Local
+      in
+      Backend_var.Tbl.add t.ranges var range)
+    variables_without_ranges;
+  t, { fundecl with L.fun_body = first_insn; }
+
+let create ~fundecl =
+  if not !Clflags.debug then
+    let t =
+      { ranges = Backend_var.Tbl.create 1;
+      }
+    in
+    t, fundecl
+  else
+    create ~fundecl
+
+type label_classification =
+  | Start of {
+      end_pos : Linearize.label;
+      location : unit Available_subrange.location;
+    }
+  | End
+
+let classify_label t label =
+  Backend_var.Tbl.fold (fun var range result ->
+      Available_range.fold range ~init:result
+        ~f:(fun result ~available_subrange:subrange ->
+          if Available_subrange.start_pos subrange = label then
+            let location = Available_subrange.location subrange in
+            let end_pos = Available_subrange.end_pos subrange in
+            (Start { end_pos; location; }, var, subrange) :: result
+          else if Available_subrange.end_pos subrange = label then
+            (End, var, subrange) :: result
+          else
+            result))
+    t.ranges
+    []
+
+let rewrite_labels t ~env =
+  let ranges =
+    Backend_var.Tbl.map t.ranges (fun range ->
+      Available_range.rewrite_labels range ~env)
+  in
+  { ranges; }

--- a/asmcomp/debug/available_ranges.ml
+++ b/asmcomp/debug/available_ranges.ml
@@ -639,7 +639,7 @@ let create ~fundecl =
             | Iphantom_const_symbol _
             | Iphantom_read_symbol_field _ -> []
             | Iphantom_var var
-            | Iphantom_read_field (var, _)
+            | Iphantom_read_field { var; _ }
             | Iphantom_offset_var { var; _ } -> [var]
             | Iphantom_block { fields; _ } ->
               Misc.Stdlib.List.filter_map (fun field -> field) fields

--- a/asmcomp/debug/available_ranges.mli
+++ b/asmcomp/debug/available_ranges.mli
@@ -1,0 +1,122 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Given a variable [x] and a function, an "available subrange" is in the
+    normal case a contiguous subset of that function's code paired with a
+    register [r], such that at all times during the block's execution the value
+    of [x] is available in [r]. ([r] may end up being a hard register or a
+    location on the stack.)
+ 
+    An available subrange may instead be associated with a phantom variable.
+    Phantom variables correspond to variables that once bound computations that
+    have now been optimised out.
+ 
+    Available subranges associated with normal variables are computed by this
+    pass based on the information from the dataflow analysis in
+    [Available_regs]. (The linearized code is updated so that it contains the
+    necessary labels for delimiting such ranges.) Those associated with phantom
+    variables, however, are tracked explicitly from the [Uphantom_let] Clambda
+    expression onwards.
+ 
+    An "available range" is then a set of available subranges that do not
+    overlap in code space, again for a single variable (normal or phantom) and
+    function.
+*)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module Available_subrange : sig
+  type t
+
+  type 'a location = private
+    | Reg of Reg.t * 'a
+    | Phantom
+
+  val start_pos : t -> Linearize.label
+  val end_pos : t -> Linearize.label
+  val end_pos_offset : t -> int option
+
+  val location : t -> unit location
+
+  (** [offset_from_stack_ptr_in_bytes] returns [Some] only when [location]
+      is [Reg] and the contained register is assigned to the stack. *)
+  val offset_from_stack_ptr_in_bytes : t -> int option
+end
+
+type type_info = private
+  | From_cmt_file of Backend_var.Provenance.t option
+  | Phantom of
+      Backend_var.Provenance.t option * Mach.phantom_defining_expr option
+
+type is_parameter = private
+  | Local
+  | Parameter of { index : int; }
+
+module Available_range : sig
+  type t
+
+  val type_info : t -> type_info
+  val is_parameter : t -> is_parameter
+  val extremities : t -> Linearize.label * Linearize.label
+
+  val iter
+     : t
+    -> f:(available_subrange:Available_subrange.t -> unit)
+    -> unit
+
+  val fold
+     : t
+    -> init:'a
+    -> f:('a -> available_subrange:Available_subrange.t -> 'a)
+    -> 'a
+end
+
+type t
+
+(** [create ~fundecl] may change [fundecl].  It may change the first
+    instruction, even, which is why a new declaration is returned. *)
+val create
+   : fundecl:Linearize.fundecl
+  -> t * Linearize.fundecl
+
+val find : t -> var:Backend_var.t -> Available_range.t option
+
+type label_classification =
+  | Start of {
+      end_pos : Linearize.label;
+      location : unit Available_subrange.location;
+    }
+  | End
+
+val classify_label
+   : t
+  -> Linearize.label
+  -> (label_classification * Backend_var.t * Available_subrange.t) list
+
+val fold
+   : t
+  -> init:'a
+  (* CR mshinwell: fix [is_unique] stuff *)
+  -> f:('a
+    -> var:Backend_var.t
+    -> is_unique:bool
+    -> range:Available_range.t
+    -> 'a)
+    (** [is_unique] is [true] if there is no other variable with the
+        same (unstamped) name as [var] in [t].  (It follows that using the
+        unstamped name is sufficient to uniquely varify the variable amongst
+        a list of, say, local variables in a debugger.) *)
+  -> 'a
+
+val rewrite_labels : t -> env:int Numbers.Int.Map.t -> t

--- a/asmcomp/debug/reg_availability_set.ml
+++ b/asmcomp/debug/reg_availability_set.ml
@@ -21,6 +21,11 @@ type t =
   | Ok of RD.Set.t
   | Unreachable
 
+let map t ~f =
+  match t with
+  | Ok t -> Ok (f t)
+  | Unreachable -> Unreachable
+
 let inter regs1 regs2 =
   match regs1, regs2 with
   | Unreachable, _ -> regs2

--- a/asmcomp/debug/reg_availability_set.mli
+++ b/asmcomp/debug/reg_availability_set.mli
@@ -18,6 +18,8 @@ type t =
   | Ok of Reg_with_debug_info.Set.t
   | Unreachable
 
+val map : t -> f:(Reg_with_debug_info.Set.t -> Reg_with_debug_info.Set.t) -> t
+
 val inter : t -> t -> t
 (** Intersection of availabilities. *)
 

--- a/asmcomp/debug/reg_with_debug_info.ml
+++ b/asmcomp/debug/reg_with_debug_info.ml
@@ -22,7 +22,7 @@ module Debug_info = struct
     part_of_value : int;
     num_parts_of_value : int;
     which_parameter : int option;
-    provenance : unit option;
+    provenance : Backend_var.Provenance.t option;
   }
 
   let compare t1 t2 =

--- a/asmcomp/debug/reg_with_debug_info.mli
+++ b/asmcomp/debug/reg_with_debug_info.mli
@@ -30,7 +30,7 @@ module Debug_info : sig
   (** If the register corresponds to a function parameter, the value returned
       is the zero-based index of said parameter; otherwise it is [None]. *)
 
-  val provenance : t -> unit option
+  val provenance : t -> Backend_var.Provenance.t option
 end
 
 type t
@@ -43,7 +43,7 @@ val create
   -> part_of_value:int
   -> num_parts_of_value:int
   -> which_parameter:int option
-  -> provenance:unit option
+  -> provenance:Backend_var.Provenance.t option
   -> t
 
 val create_with_debug_info : reg:Reg.t -> debug_info:Debug_info.t option -> t

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -307,6 +307,19 @@ let emit_debug_info dbg =
        emit_int file_num; emit_char '\t';
        emit_int line; emit_char '\n')
 
+let handle_lcapture_stack_offset i ~frame_size ~slot_offset ~register_class
+      ~byte_offset_from_cfa =
+  assert (Array.length i.Linearize.arg = 1);
+  let reg = i.Linearize.arg.(0) in
+  let open Reg in
+  begin match reg.loc with
+  | Stack loc ->
+    byte_offset_from_cfa :=
+      frame_size () - (slot_offset loc (register_class reg))
+  | Unknown | Reg _ ->
+    Misc.fatal_error "[Lcapture_stack_offset] only valid for [Stack] regs"
+  end
+
 let reset () =
   reset_debug_info ();
   frame_descriptors := []

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -66,6 +66,13 @@ val cfi_endproc : unit -> unit
 val cfi_adjust_cfa_offset : int -> unit
 val cfi_offset : reg:int -> offset:int -> unit
 
+val handle_lcapture_stack_offset
+   : Linearize.instruction
+  -> frame_size:(unit -> int)
+  -> slot_offset:(Reg.stack_location -> int -> int)
+  -> register_class:(Reg.t -> int)
+  -> byte_offset_from_cfa:int ref
+  -> unit
 
 val binary_backend_available: bool ref
     (** Is a binary backend available.  If yes, we don't need

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -906,6 +906,9 @@ let emit_instr fallthrough i =
             I.add (int (trap_frame_size - 8)) esp;
           I.ret ()
       end
+  | Lcapture_stack_offset byte_offset_from_cfa ->
+      Emitaux.handle_lcapture_stack_offset i ~frame_size ~slot_offset
+        ~register_class ~byte_offset_from_cfa
 
 let rec emit_all fallthrough i =
   match i.desc with

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -196,6 +196,8 @@ let destroyed_at_oper = function
 
 let destroyed_at_raise = all_phys_regs
 
+let destroyed_at_reloadretaddr = [| |]
+
 (* Maximal register pressure *)
 
 let safe_register_pressure _op = 4

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -216,6 +216,7 @@ let op_is_pure = function
   | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _) -> false
   | Ispecific(Ilea _) -> true
   | Ispecific _ -> false
+  | Iname_for_debugger _ -> false
   | _ -> true
 
 (* Layout of the stack frame *)

--- a/asmcomp/i386/selection.ml
+++ b/asmcomp/i386/selection.ml
@@ -316,7 +316,7 @@ method! emit_extcall_args env args =
   | e :: el ->
       emit_pushes el;
       let (op, arg) = self#select_push e in
-      match self#emit_expr env arg with
+      match self#emit_expr env arg ~bound_name:None with
       | None -> ()
       | Some r -> self#insert (Iop op) r [||] in
   emit_pushes args;

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -43,6 +43,7 @@ and instruction_desc =
   | Lpushtrap
   | Lpoptrap
   | Lraise of Cmm.raise_kind
+  | Lcapture_stack_offset of int ref
 
 let has_fallthrough = function
   | Lreturn | Lbranch _ | Lswitch _ | Lraise _

--- a/asmcomp/linearize.mli
+++ b/asmcomp/linearize.mli
@@ -23,7 +23,11 @@ type instruction =
     arg: Reg.t array;
     res: Reg.t array;
     dbg: Debuginfo.t;
-    live: Reg.Set.t }
+    live: Reg.Set.t;
+    phantom_available_before: Backend_var.Set.t;
+    available_before: Reg_availability_set.t;
+    available_across: Reg_availability_set.t option;
+  }
 
 and instruction_desc =
   | Lprologue
@@ -60,6 +64,9 @@ type fundecl =
     fun_fast: bool;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : Mach.spacetime_shape option;
+    fun_phantom_lets :
+      (Backend_var.Provenance.t option * Mach.phantom_defining_expr)
+        Backend_var.Map.t;
   }
 
 val fundecl: Mach.fundecl -> fundecl

--- a/asmcomp/linearize.mli
+++ b/asmcomp/linearize.mli
@@ -54,8 +54,24 @@ and instruction_desc =
 
 val has_fallthrough :  instruction_desc -> bool
 val end_instr: instruction
-val instr_cons:
-  instruction_desc -> Reg.t array -> Reg.t array -> instruction -> instruction
+
+val instr_cons
+   : instruction_desc
+  -> Reg.t array
+  -> Reg.t array
+  -> instruction
+  -> available_before:Reg_availability_set.t
+  -> phantom_available_before:Ident.Set.t
+  -> available_across:Reg_availability_set.t option
+  -> instruction
+
+val instr_cons_same_avail
+   : instruction_desc
+  -> Reg.t array
+  -> Reg.t array
+  -> instruction
+  -> instruction
+
 val invert_test: Mach.test -> Mach.test
 
 type fundecl =

--- a/asmcomp/linearize.mli
+++ b/asmcomp/linearize.mli
@@ -40,6 +40,13 @@ and instruction_desc =
   | Lpushtrap
   | Lpoptrap
   | Lraise of Cmm.raise_kind
+  | Lcapture_stack_offset of int ref
+  (** [Lcapture_stack_offset] takes a single element in the [arg] array.
+      That element must be a register assigned to the stack.  The assembly
+      emitter must fill in the [int ref] with the offset in bytes from the
+      current frame address to the stack slot of such register.
+      This information is used for emission of debugging information for
+      spilled values. *)
 
 val has_fallthrough :  instruction_desc -> bool
 val end_instr: instruction

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -43,9 +43,9 @@ type phantom_defining_expr =
   | Iphantom_const_int of int
   | Iphantom_const_symbol of string
   | Iphantom_var of Backend_var.t
-  | Iphantom_read_field of Backend_var.t * int
-  | Iphantom_read_symbol_field of { symbol : string; field : int; }
-  | Iphantom_offset_var of { var : Backend_var.t; offset_in_bytes : int; }
+  | Iphantom_offset_var of { var : Backend_var.t; offset_in_words : int; }
+  | Iphantom_read_field of { var : Backend_var.t; field : int; }
+  | Iphantom_read_symbol_field of { sym : string; field : int; }
   | Iphantom_block of { tag : int; fields : Backend_var.t option list; }
 
 type operation =

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -39,6 +39,15 @@ type test =
   | Ioddtest
   | Ieventest
 
+type phantom_defining_expr =
+  | Iphantom_const_int of int
+  | Iphantom_const_symbol of Symbol.t
+  | Iphantom_var of Backend_var.t
+  | Iphantom_read_field of Backend_var.t * int
+  | Iphantom_read_symbol_field of { symbol : Symbol.t; field : int; }
+  | Iphantom_offset_var of { var : Backend_var.t; offset_in_bytes : int; }
+  | Iphantom_block of { tag : int; fields : Backend_var.t option list; }
+
 type operation =
     Imove
   | Ispill
@@ -70,6 +79,7 @@ type instruction =
     arg: Reg.t array;
     res: Reg.t array;
     dbg: Debuginfo.t;
+    phantom_available_before: Backend_var.Set.t;
     mutable live: Reg.Set.t;
     mutable available_before: Reg_availability_set.t;
     mutable available_across: Reg_availability_set.t option;
@@ -101,6 +111,9 @@ type fundecl =
     fun_codegen_options : Cmm.codegen_option list;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : spacetime_shape option;
+    fun_phantom_lets :
+      (Backend_var.Provenance.t option * phantom_defining_expr)
+        Backend_var.Map.t;
   }
 
 let rec dummy_instr =
@@ -109,6 +122,7 @@ let rec dummy_instr =
     arg = [||];
     res = [||];
     dbg = Debuginfo.none;
+    phantom_available_before = Backend_var.Set.empty;
     live = Reg.Set.empty;
     available_before = Reg_availability_set.Ok Reg_with_debug_info.Set.empty;
     available_across = None;
@@ -120,6 +134,7 @@ let end_instr () =
     arg = [||];
     res = [||];
     dbg = Debuginfo.none;
+    phantom_available_before = Backend_var.Set.empty;
     live = Reg.Set.empty;
     available_before = Reg_availability_set.Ok Reg_with_debug_info.Set.empty;
     available_across = None;
@@ -128,12 +143,14 @@ let end_instr () =
 let instr_cons d a r n =
   { desc = d; next = n; arg = a; res = r;
     dbg = Debuginfo.none; live = Reg.Set.empty;
+    phantom_available_before = Backend_var.Set.empty;
     available_before = Reg_availability_set.Ok Reg_with_debug_info.Set.empty;
     available_across = None;
   }
 
 let instr_cons_debug d a r dbg n =
   { desc = d; next = n; arg = a; res = r; dbg = dbg; live = Reg.Set.empty;
+    phantom_available_before = Backend_var.Set.empty;
     available_before = Reg_availability_set.Ok Reg_with_debug_info.Set.empty;
     available_across = None;
   }

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -140,17 +140,18 @@ let end_instr () =
     available_across = None;
   }
 
-let instr_cons d a r n =
+let instr_cons ?(phantom_available_before = Backend_var.Set.empty) d a r n =
   { desc = d; next = n; arg = a; res = r;
     dbg = Debuginfo.none; live = Reg.Set.empty;
-    phantom_available_before = Backend_var.Set.empty;
+    phantom_available_before;
     available_before = Reg_availability_set.Ok Reg_with_debug_info.Set.empty;
     available_across = None;
   }
 
-let instr_cons_debug d a r dbg n =
+let instr_cons_debug ?(phantom_available_before = Backend_var.Set.empty)
+      d a r dbg n =
   { desc = d; next = n; arg = a; res = r; dbg = dbg; live = Reg.Set.empty;
-    phantom_available_before = Backend_var.Set.empty;
+    phantom_available_before;
     available_before = Reg_availability_set.Ok Reg_with_debug_info.Set.empty;
     available_across = None;
   }

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -62,7 +62,7 @@ type operation =
   | Ifloatofint | Iintoffloat
   | Ispecific of Arch.specific_operation
   | Iname_for_debugger of { ident : Backend_var.t; which_parameter : int option;
-      provenance : unit option; is_assignment : bool; }
+      provenance : Backend_var.Provenance.t option; is_assignment : bool; }
 
 type instruction =
   { desc: instruction_desc;

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -41,10 +41,10 @@ type test =
 
 type phantom_defining_expr =
   | Iphantom_const_int of int
-  | Iphantom_const_symbol of Symbol.t
+  | Iphantom_const_symbol of string
   | Iphantom_var of Backend_var.t
   | Iphantom_read_field of Backend_var.t * int
-  | Iphantom_read_symbol_field of { symbol : Symbol.t; field : int; }
+  | Iphantom_read_symbol_field of { symbol : string; field : int; }
   | Iphantom_offset_var of { var : Backend_var.t; offset_in_bytes : int; }
   | Iphantom_block of { tag : int; fields : Backend_var.t option list; }
 

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -140,11 +140,11 @@ type fundecl =
 
 val dummy_instr: instruction
 val end_instr: unit -> instruction
-val instr_cons:
-      instruction_desc -> Reg.t array -> Reg.t array -> instruction ->
+val instr_cons: ?phantom_available_before:Backend_var.Set.t
+      -> instruction_desc -> Reg.t array -> Reg.t array -> instruction ->
         instruction
-val instr_cons_debug:
-      instruction_desc -> Reg.t array -> Reg.t array -> Debuginfo.t ->
+val instr_cons_debug: ?phantom_available_before:Backend_var.Set.t
+      -> instruction_desc -> Reg.t array -> Reg.t array -> Debuginfo.t ->
         instruction -> instruction
 val instr_iter: (instruction -> unit) -> instruction -> unit
 

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -48,10 +48,10 @@ type test =
 
 type phantom_defining_expr =
   | Iphantom_const_int of int
-  | Iphantom_const_symbol of Symbol.t
+  | Iphantom_const_symbol of string
   | Iphantom_var of Backend_var.t  (** Must not be a phantom identifier. *)
   | Iphantom_read_field of Backend_var.t * int
-  | Iphantom_read_symbol_field of { symbol : Symbol.t; field : int; }
+  | Iphantom_read_symbol_field of { symbol : string; field : int; }
   | Iphantom_offset_var of { var : Backend_var.t; offset_in_bytes : int; }
   | Iphantom_block of { tag : int; fields : Backend_var.t option list; }
 

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -72,7 +72,7 @@ type operation =
   | Ifloatofint | Iintoffloat
   | Ispecific of Arch.specific_operation
   | Iname_for_debugger of { ident : Backend_var.t; which_parameter : int option;
-      provenance : unit option; is_assignment : bool; }
+      provenance : Backend_var.Provenance.t option; is_assignment : bool; }
     (** [Iname_for_debugger] has the following semantics:
         (a) The argument register(s) is/are deemed to contain the value of the
             given identifier.

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -46,6 +46,15 @@ type test =
   | Ioddtest
   | Ieventest
 
+type phantom_defining_expr =
+  | Iphantom_const_int of int
+  | Iphantom_const_symbol of Symbol.t
+  | Iphantom_var of Backend_var.t  (** Must not be a phantom identifier. *)
+  | Iphantom_read_field of Backend_var.t * int
+  | Iphantom_read_symbol_field of { symbol : Symbol.t; field : int; }
+  | Iphantom_offset_var of { var : Backend_var.t; offset_in_bytes : int; }
+  | Iphantom_block of { tag : int; fields : Backend_var.t option list; }
+
 type operation =
     Imove
   | Ispill
@@ -86,6 +95,7 @@ type instruction =
     arg: Reg.t array;
     res: Reg.t array;
     dbg: Debuginfo.t;
+    phantom_available_before: Backend_var.Set.t;
     mutable live: Reg.Set.t;
     mutable available_before: Reg_availability_set.t;
     mutable available_across: Reg_availability_set.t option;
@@ -123,6 +133,9 @@ type fundecl =
     fun_codegen_options : Cmm.codegen_option list;
     fun_dbg : Debuginfo.t;
     fun_spacetime_shape : spacetime_shape option;
+    fun_phantom_lets :
+      (Backend_var.Provenance.t option * phantom_defining_expr)
+        Backend_var.Map.t;
   }
 
 val dummy_instr: instruction

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -50,9 +50,9 @@ type phantom_defining_expr =
   | Iphantom_const_int of int
   | Iphantom_const_symbol of string
   | Iphantom_var of Backend_var.t  (** Must not be a phantom identifier. *)
-  | Iphantom_read_field of Backend_var.t * int
-  | Iphantom_read_symbol_field of { symbol : string; field : int; }
-  | Iphantom_offset_var of { var : Backend_var.t; offset_in_bytes : int; }
+  | Iphantom_offset_var of { var : Backend_var.t; offset_in_words : int; }
+  | Iphantom_read_field of { var : Backend_var.t; field : int; }
+  | Iphantom_read_symbol_field of { sym : string; field : int; }
   | Iphantom_block of { tag : int; fields : Backend_var.t option list; }
 
 type operation =

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -506,6 +506,7 @@ module BR = Branch_relaxation.Make (struct
     | Lpushtrap -> size 4 5 5
     | Lpoptrap -> 2
     | Lraise _ -> 6
+    | Lcapture_stack_offset _ -> 0
 
   let relax_allocation ~num_words:words ~label_after_call_gc =
     Lop (Ispecific (Ialloc_far { words; label_after_call_gc; }))
@@ -1015,6 +1016,9 @@ let emit_instr i =
             `	addi	1, 1, {emit_int trap_size}\n`;
             `	bctr\n`
         end
+  | Lcapture_stack_offset byte_offset_from_cfa ->
+      Emitaux.handle_lcapture_stack_offset i ~frame_size ~slot_offset
+        ~register_class ~byte_offset_from_cfa
 
 (* Emit a sequence of instructions *)
 

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -276,6 +276,8 @@ let destroyed_at_oper = function
 
 let destroyed_at_raise = all_phys_regs
 
+let destroyed_at_reloadretaddr = [| phys_reg 11 |]
+
 (* Maximal register pressure *)
 
 let safe_register_pressure = function

--- a/asmcomp/power/proc.ml
+++ b/asmcomp/power/proc.ml
@@ -295,6 +295,7 @@ let op_is_pure = function
   | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _) -> false
   | Ispecific(Imultaddf | Imultsubf) -> true
   | Ispecific _ -> false
+  | Iname_for_debugger _ -> false
   | _ -> true
 
 (* Layout of the stack *)

--- a/asmcomp/printlinear.ml
+++ b/asmcomp/printlinear.ml
@@ -67,6 +67,8 @@ let instr ppf i =
       fprintf ppf "pop trap"
   | Lraise k ->
       fprintf ppf "%a %a" Printcmm.raise_kind k reg i.arg.(0)
+  | Lcapture_stack_offset _ ->
+      fprintf ppf "capture stack offset"
   end;
   if not (Debuginfo.is_none i.dbg) then
     fprintf ppf " %s" (Debuginfo.to_string i.dbg)

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -245,7 +245,7 @@ let phantom_defining_expr ppf defining_expr =
   | Iphantom_const_int i ->
     fprintf ppf "@[(const_int@ %d)@]" i
   | Iphantom_const_symbol sym ->
-    fprintf ppf "@[(const_symbol@ %a)@]" Symbol.print sym
+    fprintf ppf "@[(const_symbol@ %s)@]" sym
   | Iphantom_var var ->
     fprintf ppf "@[(var@ %a)@]" Backend_var.print var
   | Iphantom_read_field (var, field) ->
@@ -253,8 +253,8 @@ let phantom_defining_expr ppf defining_expr =
       Backend_var.print var
       field
   | Iphantom_read_symbol_field { symbol; field; } ->
-    fprintf ppf "@[((symbol@ %a)@ (field@ %d))@]"
-      Symbol.print symbol
+    fprintf ppf "@[((symbol@ %s)@ (field@ %d))@]"
+      sym
       field
   | Iphantom_offset_var { var; offset_in_bytes; } ->
     fprintf ppf "@[((var@ %a)@ (offset_in_bytes@ %d))@]"

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -248,18 +248,18 @@ let phantom_defining_expr ppf defining_expr =
     fprintf ppf "@[(const_symbol@ %s)@]" sym
   | Iphantom_var var ->
     fprintf ppf "@[(var@ %a)@]" Backend_var.print var
-  | Iphantom_read_field (var, field) ->
+  | Iphantom_offset_var { var; offset_in_words; } ->
+    fprintf ppf "@[((var@ %a)@ (offset_in_words@ %d))@]"
+      Backend_var.print var
+      offset_in_words
+  | Iphantom_read_field { var; field; } ->
     fprintf ppf "@[((var@ %a)@ (field@ %d))@]"
       Backend_var.print var
       field
-  | Iphantom_read_symbol_field { symbol; field; } ->
+  | Iphantom_read_symbol_field { sym; field; } ->
     fprintf ppf "@[((symbol@ %s)@ (field@ %d))@]"
       sym
       field
-  | Iphantom_offset_var { var; offset_in_bytes; } ->
-    fprintf ppf "@[((var@ %a)@ (offset_in_bytes@ %d))@]"
-      Backend_var.print var
-      offset_in_bytes
   | Iphantom_block { tag; fields; } ->
     fprintf ppf "@[((tag@ %d)@ (fields@ @[(%a)@]))@]"
       tag

--- a/asmcomp/proc.mli
+++ b/asmcomp/proc.mli
@@ -56,6 +56,7 @@ val max_register_pressure: Mach.operation -> int array
 (* Registers destroyed by operations *)
 val destroyed_at_oper: Mach.instruction_desc -> Reg.t array
 val destroyed_at_raise: Reg.t array
+val destroyed_at_reloadretaddr : Reg.t array
 
 (* Volatile registers: those that change value when read *)
 val regs_are_volatile: Reg.t array -> bool

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -130,6 +130,7 @@ method fundecl f =
   let new_body = self#reload f.fun_body in
   ({fun_name = f.fun_name; fun_args = f.fun_args;
     fun_body = new_body; fun_codegen_options = f.fun_codegen_options;
-    fun_dbg  = f.fun_dbg; fun_spacetime_shape = f.fun_spacetime_shape},
+    fun_dbg  = f.fun_dbg; fun_spacetime_shape = f.fun_spacetime_shape;
+    fun_phantom_lets = f.fun_phantom_lets},
    redo_regalloc)
 end

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -632,6 +632,9 @@ let emit_instr i =
           emit_stack_adjust (-16);
           `	br	%r1\n`
         end
+  | Lcapture_stack_offset byte_offset_from_cfa ->
+      Emitaux.handle_lcapture_stack_offset i ~frame_size ~slot_offset
+        ~register_class ~byte_offset_from_cfa
 
 
 (* Emit a sequence of instructions *)

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -198,6 +198,7 @@ let op_is_pure = function
   | Iextcall _ | Istackoffset _ | Istore _ | Ialloc _
   | Iintop(Icheckbound _) | Iintop_imm(Icheckbound _, _) -> false
   | Ispecific(Imultaddf | Imultsubf) -> true
+  | Iname_for_debugger _ -> false
   | _ -> true
 
 (* Layout of the stack *)

--- a/asmcomp/s390x/proc.ml
+++ b/asmcomp/s390x/proc.ml
@@ -180,6 +180,10 @@ let destroyed_at_oper = function
 
 let destroyed_at_raise = all_phys_regs
 
+(* %r14 is destroyed at [Lreloadretaddr], but %r14 is not used for register
+   allocation, and thus does not need to (and indeed cannot) occur here. *)
+let destroyed_at_reloadretaddr = [| |]
+
 (* Maximal register pressure *)
 
 let safe_register_pressure = function

--- a/asmcomp/schedgen.ml
+++ b/asmcomp/schedgen.ml
@@ -391,6 +391,7 @@ method schedule_fundecl f =
       fun_fast = f.fun_fast;
       fun_dbg  = f.fun_dbg;
       fun_spacetime_shape = f.fun_spacetime_shape;
+      fun_phantom_lets = f.fun_phantom_lets;
     }
   end else
     f

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -1413,6 +1413,7 @@ method emit_fundecl f =
     fun_codegen_options = f.Cmm.fun_codegen_options;
     fun_dbg  = f.Cmm.fun_dbg;
     fun_spacetime_shape;
+    fun_phantom_lets = Backend_var.Map.empty;
   }
 
 end

--- a/asmcomp/selectgen.mli
+++ b/asmcomp/selectgen.mli
@@ -145,8 +145,11 @@ class virtual selector_generic : object
   method insert_moves : Reg.t array -> Reg.t array -> unit
   method adjust_type : Reg.t -> Reg.t -> unit
   method adjust_types : Reg.t array -> Reg.t array -> unit
-  method emit_expr :
-    environment -> Cmm.expression -> Reg.t array option
+  method emit_expr
+     : environment
+    -> Cmm.expression
+    -> bound_name:Backend_var.With_provenance.t option
+    -> Reg.t array option
   method emit_tail : environment -> Cmm.expression -> unit
 
   (* Only for the use of [Spacetime_profiling]. *)
@@ -169,6 +172,7 @@ class virtual selector_generic : object
      : Cmm.fundecl
     -> loc_arg:Reg.t array
     -> rarg:Reg.t array
+    -> num_regs_per_arg:int array
     -> spacetime_node_hole:(Backend_var.t * Reg.t array) option
     -> env:environment
     -> Mach.spacetime_shape option

--- a/asmcomp/spacetime_profiling.ml
+++ b/asmcomp/spacetime_profiling.ml
@@ -272,7 +272,7 @@ class virtual instruction_selection = object (self)
         ~is_tail
         ~label:label_after
     in
-    match self#emit_expr env instrumentation with
+    match self#emit_expr env instrumentation ~bound_name:None with
     | None -> assert false
     | Some reg -> Some reg
 
@@ -289,7 +289,7 @@ class virtual instruction_selection = object (self)
         ~is_tail
         ~label:label_after
     in
-    match self#emit_expr env instrumentation with
+    match self#emit_expr env instrumentation ~bound_name:None with
     | None -> assert false
     | Some reg -> Some reg
 
@@ -327,7 +327,7 @@ class virtual instruction_selection = object (self)
         ~node:(Lazy.force !spacetime_node_ident)
         ~value's_header ~dbg
     in
-    self#emit_expr env instrumentation
+    self#emit_expr env instrumentation ~bound_name:None
 
   method private emit_prologue f ~node_hole ~env =
     (* We don't need the prologue unless we inserted some instrumentation.
@@ -339,7 +339,7 @@ class virtual instruction_selection = object (self)
       in
       disable_instrumentation <- true;
       let node_temp_reg =
-        match self#emit_expr env prologue_cmm with
+        match self#emit_expr env prologue_cmm ~bound_name:None with
         | None ->
           Misc.fatal_error "Spacetime prologue instruction \
               selection did not yield a destination register"
@@ -433,9 +433,11 @@ class virtual instruction_selection = object (self)
     end;
     super#emit_fundecl f
 
-  method! insert_prologue f ~loc_arg ~rarg ~spacetime_node_hole ~env =
+  method! insert_prologue f ~loc_arg ~rarg ~num_regs_per_arg
+        ~spacetime_node_hole ~env =
     let fun_spacetime_shape =
-      super#insert_prologue f ~loc_arg ~rarg ~spacetime_node_hole ~env
+      super#insert_prologue f ~loc_arg ~rarg ~num_regs_per_arg
+        ~spacetime_node_hole ~env
     in
     (* CR-soon mshinwell: add check to make sure the node size doesn't exceed
        the chunk size of the allocator *)

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -487,4 +487,5 @@ let fundecl f =
     fun_codegen_options = f.fun_codegen_options;
     fun_dbg  = f.fun_dbg;
     fun_spacetime_shape = f.fun_spacetime_shape;
+    fun_phantom_lets = f.fun_phantom_lets;
   }

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -308,9 +308,22 @@ and inside_arm = ref false
 and inside_catch = ref false
 
 let add_spills regset i =
-  Reg.Set.fold
-    (fun r i -> instr_cons (Iop Ispill) [|r|] [|spill_reg r|] i)
-    regset i
+  let regset = Reg.Set.elements regset in
+  (* Skip over any [Iname_for_debugger] operations so that we don't put a
+     spill between a move into a register and the operation naming that
+     register.  (Such a situation would cause the spilled register to be
+     unnamed). *)
+  let rec add_spills i =
+    match i.desc with
+    | Iop (Iname_for_debugger _) ->
+      let next = add_spills i.next in
+      { i with next; }
+    | _ ->
+      List.fold_left (fun i r ->
+          instr_cons (Iop Ispill) [|r|] [|spill_reg r|] i)
+        i regset
+  in
+  add_spills i
 
 let rec spill i finally =
   match i.desc with

--- a/asmcomp/split.ml
+++ b/asmcomp/split.ml
@@ -225,4 +225,5 @@ let fundecl f =
     fun_codegen_options = f.fun_codegen_options;
     fun_dbg  = f.fun_dbg;
     fun_spacetime_shape = f.fun_spacetime_shape;
+    fun_phantom_lets = f.fun_phantom_lets;
   }

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -189,6 +189,11 @@ module Stdlib = struct
       match a with
       | None -> default
       | Some a -> f a
+
+    let print print_contents ppf = function
+      | None -> Format.pp_print_string ppf "()"
+      | Some contents ->
+        Format.fprintf ppf "(%a)" print_contents contents
   end
 
   module Array = struct

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -131,6 +131,12 @@ module Stdlib : sig
     val map : ('a -> 'b) -> 'a t -> 'b t
     val fold : ('a -> 'b -> 'b) -> 'a t -> 'b -> 'b
     val value_default : ('a -> 'b) -> default:'b -> 'a t -> 'b
+
+    val print
+       : (Format.formatter -> 'a -> unit)
+      -> Format.formatter
+      -> 'a t
+      -> unit
   end
 
   module Array : sig


### PR DESCRIPTION
This patch is based on several previous ones.  It takes the register availability information tagged on each `Linearize` instruction (together with information provided by the emitter via `Lcapture_stack_offset`) and finds consecutive sequences of instructions where some given value is in the same register.  This significantly cuts down on the size of the DWARF information required to describe the locations of all the named variables in the program.  There is a more detailed explanation given at the top of the new file `asmcomp/debug/available_ranges.ml`.

I think for this file and the others in the debug/ directory, which do not affect code generation and indeed will only be enabled when the user so requests, that a lower standard of review scrutiny is appropriate in the first instance.  I plan to mark the full DWARF support as experimental for 4.08 and possibly future releases too, depending on how things go.  There is still a substantial amount of general coding, mostly outside the compiler in the debugger support library and gdb itself, and also detailed testing work required to make things "just so" in the debugger.  The exact semantics of how all of this work should behave are rather vague and I am sure a good amount of tuning will be required in future.  However there is real value in having this support in the compiler to avoid the maintenance of nearly twenty patches and to gather experience from users in the real world.

The situation is further complicated by the fact that the non-responsiveness of the FSF may mean that we have to contemplate more seriously retargetting this work to lldb, which we already know to have different semantics as regards interpretation of DWARF information (there is a comment in this patch about that, in fact).

@chambart @lthls Perhaps you could have an initial look at this (I think @chambart is familiar with some of this already) and then we can go through it in person to make sure there are no obvious oversights.  I still need to fix a couple of things---you'll see there are some code review comments I need to deal with, and I also need to think about how the provision of "available across" information at operations which we now have (and did not have previously) needs to be incorporated into this pass.  However I believe this to basically be in a working state.